### PR TITLE
Adds public lead creation endpoint

### DIFF
--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -1,0 +1,84 @@
+import type { Context } from "hono";
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { leads } from "../db/schema/crm";
+import { user } from "../db/schema/auth";
+
+export async function createPublicLead(c: Context) {
+  try {
+    const body = await c.req.json();
+
+    // Validate required fields
+    if (!body.firstName || !body.lastName || !body.email || !body.phone) {
+      return c.json(
+        {
+          success: false,
+          error: "Faltan campos requeridos: firstName, lastName, email, phone",
+        },
+        400
+      );
+    }
+
+    // Get first admin user to assign the lead
+    const [systemUser] = await db
+      .select()
+      .from(user)
+      .where(eq(user.role, "admin"))
+      .limit(1);
+
+    if (!systemUser) {
+      return c.json(
+        {
+          success: false,
+          error: "No hay usuario administrador disponible",
+        },
+        500
+      );
+    }
+
+    // Create the lead
+    const [newLead] = await db
+      .insert(leads)
+      .values({
+        firstName: body.firstName,
+        lastName: body.lastName,
+        email: body.email,
+        phone: body.phone,
+        age: body.age,
+        dpi: body.dpi,
+        clientType: body.clientType || "individual",
+        maritalStatus: body.maritalStatus,
+        dependents: body.dependents ?? 0,
+        monthlyIncome: body.monthlyIncome?.toString(),
+        loanAmount: body.loanAmount?.toString(),
+        occupation: body.occupation,
+        workTime: body.workTime,
+        loanPurpose: body.loanPurpose,
+        ownsHome: body.ownsHome ?? false,
+        ownsVehicle: body.ownsVehicle ?? false,
+        hasCreditCard: body.hasCreditCard ?? false,
+        jobTitle: body.jobTitle,
+        notes: body.notes,
+        source: body.source || "website",
+        status: "new",
+        assignedTo: systemUser.id,
+        createdBy: systemUser.id,
+        updatedAt: new Date(),
+      })
+      .returning();
+
+    return c.json({
+      success: true,
+      data: newLead,
+    });
+  } catch (error: any) {
+    console.error("[ERROR] createPublicLead:", error);
+    return c.json(
+      {
+        success: false,
+        error: error.message || "Error al crear el lead",
+      },
+      500
+    );
+  }
+}

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -12,6 +12,7 @@ import {
 } from "./controllers/bot";
 import { processCsvLeads } from "./controllers/csv";
 import { livenessController } from "./controllers/liveness";
+import { createPublicLead } from "./controllers/public-lead";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
 import { appRouter } from "./routers/index";
@@ -389,6 +390,10 @@ app.post("/info/liveness-validation", async (c) => {
 		);
 	}
 });
+
+// REST endpoint for public lead creation (for external web forms)
+app.post("/api/public/lead", createPublicLead);
+
 app.get("/webhook/facebook-lead", async (c) => {
 	const challenge = c.req.query("hub.challenge");
 


### PR DESCRIPTION
Implements a new REST endpoint to allow the creation of leads from public web forms.

This endpoint receives lead data, validates required fields, assigns the lead to the first available admin user, and stores it in the database with a default "new" status. Handles potential errors gracefully and returns appropriate responses.