### PR TITLE
Refactors loan purpose and adds opportunity source

### DIFF
--- a/apps/crm/apps/server/src/controllers/bot.ts
+++ b/apps/crm/apps/server/src/controllers/bot.ts
@@ -255,6 +255,7 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 			createdBy: createdByUserId,
 			title: `Oportunidad de crédito para ${renapData.firstName} ${renapData.firstLastName}`,
 			stageId: firstStage.id,
+			source: "other", // Bot source
 		})
 		.returning();
 
@@ -372,9 +373,6 @@ export const updateLeadAndCreateOpportunity = async (
 	const normalizedWorkTime = data.workTime
 		? (workTimeMap[data.workTime.toUpperCase()] ?? null)
 		: null;
-	const normalizedLoanPurpose = data.loanPurpose
-		? (loanPurposeMap[data.loanPurpose.toUpperCase()] ?? null)
-		: null;
 
 	// 2. Construir objeto de actualización dinámico
 	const leadUpdates: Partial<typeof leads.$inferInsert> = {};
@@ -385,8 +383,6 @@ export const updateLeadAndCreateOpportunity = async (
 	if (normalizedOccupation !== null)
 		leadUpdates.occupation = normalizedOccupation;
 	if (normalizedWorkTime !== null) leadUpdates.workTime = normalizedWorkTime;
-	if (normalizedLoanPurpose !== null)
-		leadUpdates.loanPurpose = normalizedLoanPurpose;
 	if (data.ownsHome !== undefined) leadUpdates.ownsHome = data.ownsHome;
 	if (data.ownsVehicle !== undefined)
 		leadUpdates.ownsVehicle = data.ownsVehicle;
@@ -530,7 +526,6 @@ export const getLeadProgress = async (phone: string) => {
 		if (!lead.loanAmount) steps.push("loanAmount");
 		if (!lead.occupation) steps.push("occupation");
 		if (!lead.workTime) steps.push("workTime");
-		if (!lead.loanPurpose) steps.push("loanPurpose");
 		if (!docs || !docs.electricityBill) steps.push("electricityBill");
 		if (!docs || !docs.bankStatements) steps.push("bankStatements");
 

--- a/apps/crm/apps/server/src/controllers/portal-lead.ts
+++ b/apps/crm/apps/server/src/controllers/portal-lead.ts
@@ -127,7 +127,6 @@ export async function getLeadByEmail(c: Context) {
 			loanAmount: result.lead.loanAmount,
 			occupation: result.lead.occupation,
 			workTime: result.lead.workTime,
-			loanPurpose: result.lead.loanPurpose,
 			ownsHome: result.lead.ownsHome,
 			ownsVehicle: result.lead.ownsVehicle,
 			hasCreditCard: result.lead.hasCreditCard,

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -14,6 +14,8 @@ async function createOpportunityForLead(
 	lastName: string,
 	systemUserId: string,
 	notes: string = "",
+	source?: "website" | "referral" | "cold_call" | "email" | "social_media" | "event" | "other",
+	loanPurpose?: "personal" | "business",
 ) {
 	const [firstStage] = await db
 		.select()
@@ -39,6 +41,8 @@ async function createOpportunityForLead(
 			createdAt: new Date(),
 			updatedAt: new Date(),
 			notes: notes,
+			source: source,
+			loanPurpose: loanPurpose,
 		})
 		.returning();
 
@@ -100,6 +104,8 @@ export async function createPublicLead(c: Context) {
 				lead.lastName,
 				systemUser.id,
 				body.notes ?? "",
+				body.source || lead.source || "website",
+				body.loanPurpose,
 			);
 
 			// Si encontró el lead por DPI y no tiene email (o tiene un email diferente al enviado)
@@ -170,7 +176,6 @@ export async function createPublicLead(c: Context) {
 				loanAmount: body.loanAmount?.toString(),
 				occupation: body.occupation,
 				workTime: body.workTime,
-				loanPurpose: body.loanPurpose,
 				ownsHome: body.ownsHome ?? false,
 				ownsVehicle: body.ownsVehicle ?? false,
 				hasCreditCard: body.hasCreditCard ?? false,
@@ -197,6 +202,8 @@ export async function createPublicLead(c: Context) {
 			newLead.lastName,
 			systemUser.id,
 			body.notes ?? "",
+			body.source || "website",
+			body.loanPurpose,
 		);
 
 		return c.json({

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -138,7 +138,6 @@ export const leads = pgTable("leads", {
 	loanAmount: decimal("loan_amount", { precision: 12, scale: 2 }),
 	occupation: occupationTypeEnum("occupation"),
 	workTime: workTimeEnum("work_time"),
-	loanPurpose: loanPurposeEnum("loan_purpose"),
 	ownsHome: boolean("owns_home").default(false),
 	ownsVehicle: boolean("owns_vehicle").default(false),
 	hasCreditCard: boolean("has_credit_card").default(false),
@@ -238,6 +237,8 @@ export const opportunities = pgTable("opportunities", {
 	companyId: uuid("company_id").references(() => companies.id),
 	vehicleId: uuid("vehicle_id").references(() => vehicles.id), // Relación con vehículo (opcional)
 	creditType: creditTypeEnum("credit_type").notNull().default("autocompra"),
+	source: leadSourceEnum("source"), // Source of the opportunity (from lead or input)
+	loanPurpose: loanPurposeEnum("loan_purpose"), // Purpose of the loan (migrated from leads)
 	value: decimal("value", { precision: 12, scale: 2 }),
 	stageId: uuid("stage_id")
 		.notNull()

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -223,7 +223,6 @@ export const crmRouter = {
 					loanAmount: leads.loanAmount,
 					occupation: leads.occupation,
 					workTime: leads.workTime,
-					loanPurpose: leads.loanPurpose,
 					ownsHome: leads.ownsHome,
 					ownsVehicle: leads.ownsVehicle,
 					hasCreditCard: leads.hasCreditCard,
@@ -377,7 +376,6 @@ export const crmRouter = {
 				workTime: z
 					.enum(["less_than_1", "1_to_5", "5_to_10", "10_plus"])
 					.optional(),
-				loanPurpose: z.enum(["personal", "business"]).optional(),
 				ownsHome: z.boolean().default(false),
 				ownsVehicle: z.boolean().default(false),
 				hasCreditCard: z.boolean().default(false),
@@ -444,7 +442,6 @@ export const crmRouter = {
 				workTime: z
 					.enum(["less_than_1", "1_to_5", "5_to_10", "10_plus"])
 					.optional(),
-				loanPurpose: z.enum(["personal", "business"]).optional(),
 				ownsHome: z.boolean().optional(),
 				ownsVehicle: z.boolean().optional(),
 				hasCreditCard: z.boolean().optional(),
@@ -768,6 +765,18 @@ export const crmRouter = {
 				companyId: z.string().uuid().optional(),
 				vehicleId: z.string().uuid().optional(),
 				creditType: z.enum(["autocompra", "sobre_vehiculo"]),
+				source: z
+					.enum([
+						"website",
+						"referral",
+						"cold_call",
+						"email",
+						"social_media",
+						"event",
+						"other",
+					])
+					.optional(),
+				loanPurpose: z.enum(["personal", "business"]).optional(),
 				value: z.string().optional(), // Will be converted to decimal
 				stageId: z.string().uuid(),
 				probability: z.number().min(0).max(100).optional(),
@@ -786,16 +795,23 @@ export const crmRouter = {
 				);
 			}
 
-			// If a lead is provided, get the company from the lead
+			// If a lead is provided, get the company and source from the lead
 			let companyId = input.companyId;
+			let source = input.source;
 			if (input.leadId) {
 				const lead = await db
 					.select()
 					.from(leads)
 					.where(eq(leads.id, input.leadId))
 					.limit(1);
-				if (lead.length > 0 && lead[0].companyId) {
-					companyId = lead[0].companyId;
+				if (lead.length > 0) {
+					if (lead[0].companyId) {
+						companyId = lead[0].companyId;
+					}
+					// If source not provided, take from lead
+					if (!source && lead[0].source) {
+						source = lead[0].source;
+					}
 				}
 			}
 
@@ -804,6 +820,7 @@ export const crmRouter = {
 				.values({
 					...input,
 					companyId,
+					source,
 					assignedTo,
 					expectedCloseDate: input.expectedCloseDate
 						? new Date(input.expectedCloseDate)
@@ -861,6 +878,7 @@ export const crmRouter = {
 				direccion: z.string().optional(),
 				rubros: z.string().optional(), // JSON string with expense items
 				gastosAdministrativos: z.number().optional(), // Administrative expenses for cartera "otros"
+				loanPurpose: z.enum(["personal", "business"]).optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -1741,7 +1759,6 @@ export const crmRouter = {
 					loanAmount: leads.loanAmount,
 					occupation: leads.occupation,
 					workTime: leads.workTime,
-					loanPurpose: leads.loanPurpose,
 					ownsHome: leads.ownsHome,
 					ownsVehicle: leads.ownsVehicle,
 					hasCreditCard: leads.hasCreditCard,

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -316,7 +316,7 @@ export function CreditDetailView({
 			const membresiaValue = Number.parseFloat(quotation?.membershipCost || "0");
 			const numeroCuotasValue = quotation?.termMonths || 0;
 			const gastosAdminValue = Number.parseFloat(quotation?.adminCost || "0");
-			const finalValue = quotation?.totalFinanced || opportunity.value || "0";
+			const finalValue = quotation?.amountToFinance || opportunity.value || "0";
 			// Reserva = 600 + seguro
 			const reservaValue = 600 + seguroValue;
 
@@ -431,13 +431,13 @@ export function CreditDetailView({
 			}
 		}
 		
-		// Validar que la suma de montos aportados = totalFinanced (capital)
-		if (inversionistasToValidate.length > 0 && quotation?.totalFinanced) {
+		// Validar que la suma de montos aportados = amountToFinance (capital)
+		if (inversionistasToValidate.length > 0 && quotation?.amountToFinance) {
 			const totalAportado = inversionistasToValidate.reduce(
 				(sum, inv) => sum + (inv.monto_aportado || 0),
 				0
 			);
-			const capitalCredito = Number.parseFloat(quotation.totalFinanced);
+			const capitalCredito = Number.parseFloat(quotation.amountToFinance);
 			
 			// Permitir una pequeña diferencia por redondeo (1 centavo)
 			if (Math.abs(totalAportado - capitalCredito) > 0.01) {
@@ -460,11 +460,11 @@ export function CreditDetailView({
 				);
 			}
 			
-			// Actualizar el value de la oportunidad con el totalFinanced de la cotización
-			if (quotation?.totalFinanced && (Number(quotation?.totalFinanced) !== Number(opportunity.value)))  {
+			// Actualizar el value de la oportunidad con el amountToFinance de la cotización
+			if (quotation?.amountToFinance && (Number(quotation?.amountToFinance) !== Number(opportunity.value)))  {
 				await client.updateOpportunity({
 					id: opportunityId,
-					value: quotation.totalFinanced,
+					value: quotation.amountToFinance,
 				});
 			}
 			
@@ -518,7 +518,8 @@ export function CreditDetailView({
 	});
 
 	// Calcular valores derivados
-	const montoSolicitado = Number.parseFloat(quotation?.totalFinanced || "0");
+	const montoTotalFinanciar = Number.parseFloat(quotation?.totalFinanced || "0");
+	const montoFinanciar = Number.parseFloat(quotation?.amountToFinance || "0");
 	const tasaMensual = Number.parseFloat(quotation?.interestRate || "0");
 	const tasaInteres = tasaMensual * 12;
 	const iva = tasaMensual * IVA_RATE;
@@ -527,16 +528,16 @@ export function CreditDetailView({
 	// División de cuota entre Inversionista y Empresa
 	const porcentajeEmpresa = 100 - porcentajeInversionista;
 	const cuotaInversionista =
-		montoSolicitado * (tasaMensual / 100) * (porcentajeInversionista / 100);
+		montoTotalFinanciar * (tasaMensual / 100) * (porcentajeInversionista / 100);
 	const cuotaEmpresa =
-		montoSolicitado * (tasaMensual / 100) * (porcentajeEmpresa / 100);
+		montoTotalFinanciar * (tasaMensual / 100) * (porcentajeEmpresa / 100);
 	const ivaInversionista = cuotaInversionista * IVA_RATE;
 	const ivaEmpresa = cuotaEmpresa * IVA_RATE;
 	const totalInversionista = cuotaInversionista + ivaInversionista;
 	const totalEmpresa = cuotaEmpresa + ivaEmpresa;
 
 	// Calcular mes de interés anticipado
-	const interesAnticipado = montoSolicitado * (tasaMensual / 100);
+	const interesAnticipado = montoTotalFinanciar * (tasaMensual / 100);
 
 	// Royalty - priorizar el de la cotización, si no existe usar el de la oportunidad
 	const royalty = Number.parseFloat(
@@ -613,7 +614,7 @@ export function CreditDetailView({
 		subtotalComisionGastos + subtotalOtrosDescuentos + subtotalGastosAbogado;
 
 	// Líquido a recibir
-	const liquidoARecibir = montoSolicitado - totalDescuentos;
+	const liquidoARecibir = montoTotalFinanciar - totalDescuentos;
 
 	// Información del vehículo
 	const vehiculo = opportunity.vehicle;
@@ -955,7 +956,7 @@ export function CreditDetailView({
 											Monto Solicitado
 										</Label>
 										<p className="font-bold text-green-600 text-lg">
-											{formatCurrency(montoSolicitado)}
+											{formatCurrency(montoFinanciar)}
 										</p>
 									</div>
 									<div>
@@ -1716,10 +1717,10 @@ export function CreditDetailView({
 								<div className="grid grid-cols-3 gap-4">
 									<div className="text-center">
 										<Label className="text-muted-foreground text-xs">
-											Monto Solicitado
+											Monto total a financiar
 										</Label>
 										<p className="font-bold text-xl">
-											{formatCurrency(montoSolicitado)}
+											{formatCurrency(montoTotalFinanciar)}
 										</p>
 									</div>
 									<div className="text-center">
@@ -1837,7 +1838,7 @@ export function CreditDetailView({
 							<div className="flex items-center justify-between border-t py-3">
 								<span className="font-semibold">Monto Solicitado</span>
 								<span className="font-bold text-xl">
-									{formatCurrency(montoSolicitado)}
+									{formatCurrency(montoTotalFinanciar)}
 								</span>
 							</div>
 
@@ -1920,7 +1921,7 @@ export function CreditDetailView({
 								<span className="font-semibold">Líquido a recibir</span>
 								<span className="font-bold text-2xl text-green-600">
 									{formatCurrency(
-										montoSolicitado -
+										montoTotalFinanciar -
 											(interesAnticipado +
 												royalty +
 												gastosCombinados +

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -120,18 +120,6 @@ const getWorkTimeLabel = (workTime: string | null) => {
 	}
 };
 
-const getLoanPurposeLabel = (purpose: string | null) => {
-	if (!purpose) return "No especificado";
-	switch (purpose) {
-		case "personal":
-			return "Personal";
-		case "business":
-			return "Negocio";
-		default:
-			return purpose;
-	}
-};
-
 const formatCurrency = (value: string | number | null) => {
 	if (!value) return "Q0.00";
 	const num = typeof value === "string" ? Number.parseFloat(value) : value;
@@ -169,7 +157,6 @@ type ClientData = {
 	loanAmount: string | null;
 	occupation: string | null;
 	workTime: string | null;
-	loanPurpose: string | null;
 	ownsHome: boolean | null;
 	ownsVehicle: boolean | null;
 	hasCreditCard: boolean | null;
@@ -708,14 +695,6 @@ function RouteComponent() {
 												{selectedClient.loanAmount
 													? formatCurrency(selectedClient.loanAmount)
 													: "No especificado"}
-											</p>
-										</div>
-										<div>
-											<Label className="font-medium text-muted-foreground text-sm">
-												Propósito del Préstamo
-											</Label>
-											<p className="text-sm">
-												{getLoanPurposeLabel(selectedClient.loanPurpose)}
 											</p>
 										</div>
 									</div>

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -70,7 +70,6 @@ import { authClient } from "@/lib/auth-client";
 import {
 	formatCurrency,
 	formatGuatemalaDate,
-	getLoanPurposeLabel,
 	getMaritalStatusLabel,
 	getOccupationLabel,
 	getSourceLabel,
@@ -267,7 +266,6 @@ function RouteComponent() {
 			loanAmount: "",
 			occupation: "employee" as "owner" | "employee",
 			workTime: "1_to_5" as "less_than_1" | "1_to_5" | "5_to_10" | "10_plus",
-			loanPurpose: "personal" as "personal" | "business",
 			ownsHome: false,
 			ownsVehicle: false,
 			hasCreditCard: false,
@@ -330,7 +328,6 @@ function RouteComponent() {
 				maritalStatus: value.maritalStatus || undefined,
 				occupation: value.occupation || undefined,
 				workTime: value.workTime || undefined,
-				loanPurpose: value.loanPurpose || undefined,
 				dpi: value.dpi || undefined,
 				middleName: value.middleName || undefined,
 				secondLastName: value.secondLastName || undefined,
@@ -545,10 +542,6 @@ function RouteComponent() {
 			createLeadForm.setFieldValue(
 				"workTime",
 				editingLead.workTime || "1_to_5",
-			);
-			createLeadForm.setFieldValue(
-				"loanPurpose",
-				editingLead.loanPurpose || "personal",
 			);
 			createLeadForm.setFieldValue("ownsHome", editingLead.ownsHome || false);
 			createLeadForm.setFieldValue(
@@ -1479,37 +1472,6 @@ function RouteComponent() {
 												</createLeadForm.Field>
 											</div>
 										</div>
-										<div>
-											<createLeadForm.Field name="loanPurpose">
-												{(field) => (
-													<div className="space-y-2">
-														<Label htmlFor={field.name}>
-															Propósito del Préstamo
-														</Label>
-														<Select
-															value={field.state.value}
-															onValueChange={(value) =>
-																field.handleChange(
-																	value as "personal" | "business",
-																)
-															}
-														>
-															<SelectTrigger>
-																<SelectValue placeholder="Seleccionar propósito" />
-															</SelectTrigger>
-															<SelectContent>
-																<SelectItem value="personal">
-																	Personal
-																</SelectItem>
-																<SelectItem value="business">
-																	Negocio
-																</SelectItem>
-															</SelectContent>
-														</Select>
-													</div>
-												)}
-											</createLeadForm.Field>
-										</div>
 									</div>
 
 									{/* Assets */}
@@ -2084,16 +2046,6 @@ function RouteComponent() {
 											<p className="font-medium text-sm">
 												{selectedLead.loanAmount
 													? formatCurrency(selectedLead.loanAmount)
-													: "No especificado"}
-											</p>
-										</div>
-										<div>
-											<Label className="font-medium text-muted-foreground text-sm">
-												Propósito del Préstamo
-											</Label>
-											<p className="text-sm">
-												{selectedLead.loanPurpose
-													? getLoanPurposeLabel(selectedLead.loanPurpose)
 													: "No especificado"}
 											</p>
 										</div>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -66,6 +66,8 @@ import { authClient } from "@/lib/auth-client";
 import {
 	formatDate,
 	formatGuatemalaDate,
+	getLoanPurposeLabel,
+	getSourceLabel,
 	getStatusLabel,
 } from "@/lib/crm-formatters";
 import { client, orpc } from "@/utils/orpc";
@@ -322,6 +324,8 @@ export interface IOpportunity  {
 		// direccion: string | null;
 		inversionistas: string | null;
 		status: string;
+		source?: "website" | "referral" | "cold_call" | "email" | "social_media" | "event" | "other" | null;
+		loanPurpose?: "personal" | "business" | null;
 		creditType?: "autocompra" | "sobre_vehiculo" | null;
 		creditDetailApproved?: boolean | null;
 		creditDetailApprovedBy?: string | null;
@@ -613,6 +617,11 @@ function RouteComponent() {
 				"asesorId",
 				selectedOpportunity.asesorId || 0,
 			);
+			// Loan Purpose
+			editOpportunityForm.setFieldValue(
+				"loanPurpose",
+				selectedOpportunity.loanPurpose || "",
+			);
 		}
 
 		if (openEditModal) {
@@ -745,6 +754,7 @@ function RouteComponent() {
 			leadId: "none",
 			vehicleId: "",
 			creditType: "autocompra" as "autocompra" | "sobre_vehiculo",
+			loanPurpose: "" as "" | "personal" | "business",
 			value: "",
 			stageId: "",
 			probability: undefined as number | undefined,
@@ -769,6 +779,7 @@ function RouteComponent() {
 				...value,
 				stageId: value.stageId || firstStage?.id || "",
 				creditType: value.creditType,
+				loanPurpose: value.loanPurpose || undefined,
 				leadId:
 					value.leadId && value.leadId !== "none" ? value.leadId : undefined,
 				vehicleId: value.vehicleId || undefined,
@@ -786,6 +797,7 @@ function RouteComponent() {
 			leadId: "none",
 			vehicleId: "",
 			creditType: "autocompra" as "autocompra" | "sobre_vehiculo",
+			loanPurpose: "" as "" | "personal" | "business",
 			value: "",
 			stageId: "",
 			probability: undefined as number | undefined,
@@ -877,6 +889,7 @@ function RouteComponent() {
 						value.rubros.length > 0 ? JSON.stringify(value.rubros) : undefined,
 					asesorId: value.asesorId > 0 ? value.asesorId : undefined,
 					direccion: value.direccion || undefined,
+					loanPurpose: value.loanPurpose || undefined,
 				});
 			}
 		},
@@ -886,6 +899,7 @@ function RouteComponent() {
 		mutationFn: (input: {
 			title: string;
 			creditType: "autocompra" | "sobre_vehiculo";
+			loanPurpose?: "personal" | "business";
 			leadId?: string;
 			companyId?: string;
 			vehicleId?: string;
@@ -949,6 +963,7 @@ function RouteComponent() {
 			rubros?: string;
 			asesorId?: number;
 			direccion?: string;
+			loanPurpose?: "personal" | "business";
 		}) => client.updateOpportunity(input),
 		onMutate: async (variables) => {
 			const opportunitiesQueryKey = [
@@ -1514,6 +1529,40 @@ function RouteComponent() {
 									</createOpportunityForm.Field>
 								</div>
 								<div>
+									<createOpportunityForm.Field name="loanPurpose">
+										{(field) => (
+											<div className="space-y-2">
+												<Label htmlFor={field.name}>
+													Propósito del Préstamo
+												</Label>
+												<Select
+													value={field.state.value}
+													onValueChange={(value) =>
+														field.handleChange(
+															value as "personal" | "business",
+														)
+													}
+												>
+													<SelectTrigger className="w-full">
+														<SelectValue placeholder="Seleccionar propósito" />
+													</SelectTrigger>
+													<SelectContent align="start">
+														<SelectItem value="personal">
+															Personal
+														</SelectItem>
+														<SelectItem value="business">
+															Negocio
+														</SelectItem>
+													</SelectContent>
+												</Select>
+											</div>
+										)}
+									</createOpportunityForm.Field>
+								</div>
+							</div>
+
+							<div className="grid grid-cols-2 gap-4">
+								<div className="col-span-2">
 									<createOpportunityForm.Field name="leadId">
 										{(field) => (
 											<div className="space-y-2">
@@ -1883,6 +1932,36 @@ function RouteComponent() {
 													<span className="font-medium">
 														{selectedOpportunity.assignedUser.name ||
 															"Usuario sin nombre"}
+													</span>
+												</div>
+											</div>
+										)}
+
+										{/* Source */}
+										{selectedOpportunity.source && (
+											<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+												<Label className="font-semibold text-muted-foreground text-sm">
+													Fuente
+												</Label>
+												<div className="flex items-center gap-3">
+													<Target className="h-5 w-5 text-muted-foreground" />
+													<span className="font-medium">
+														{getSourceLabel(selectedOpportunity.source)}
+													</span>
+												</div>
+											</div>
+										)}
+
+										{/* Loan Purpose */}
+										{selectedOpportunity.loanPurpose && (
+											<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+												<Label className="font-semibold text-muted-foreground text-sm">
+													Propósito del Préstamo
+												</Label>
+												<div className="flex items-center gap-3">
+													<Banknote className="h-5 w-5 text-muted-foreground" />
+													<span className="font-medium">
+														{getLoanPurposeLabel(selectedOpportunity.loanPurpose)}
 													</span>
 												</div>
 											</div>
@@ -2382,6 +2461,40 @@ function RouteComponent() {
 									</editOpportunityForm.Field>
 								</div>
 								<div>
+									<editOpportunityForm.Field name="loanPurpose">
+										{(field) => (
+											<div className="space-y-2">
+												<Label htmlFor={field.name}>
+													Propósito del Préstamo
+												</Label>
+												<Select
+													value={field.state.value}
+													onValueChange={(value) =>
+														field.handleChange(
+															value as "personal" | "business",
+														)
+													}
+												>
+													<SelectTrigger className="w-full">
+														<SelectValue placeholder="Seleccionar propósito" />
+													</SelectTrigger>
+													<SelectContent align="start">
+														<SelectItem value="personal">
+															Personal
+														</SelectItem>
+														<SelectItem value="business">
+															Negocio
+														</SelectItem>
+													</SelectContent>
+												</Select>
+											</div>
+										)}
+									</editOpportunityForm.Field>
+								</div>
+							</div>
+
+							<div className="grid grid-cols-2 gap-4">
+								<div>
 									<editOpportunityForm.Field name="vehicleId">
 										{(field) => (
 											<div className="space-y-2">
@@ -2411,9 +2524,8 @@ function RouteComponent() {
 										)}
 									</editOpportunityForm.Field>
 								</div>
-							</div>
 
-							<div>
+									<div>
 								<editOpportunityForm.Field name="stageId">
 									{(field) => (
 										<div className="space-y-2">
@@ -2437,7 +2549,7 @@ function RouteComponent() {
 									)}
 								</editOpportunityForm.Field>
 							</div>
-
+							</div>
 							<div className="grid grid-cols-2 gap-4">
 								<div>
 									<editOpportunityForm.Field name="probability">


### PR DESCRIPTION
Removes the `loanPurpose` field from the leads table and integrates it into the opportunities table. This change ensures that the loan purpose is associated with the specific opportunity rather than the initial lead.

Adds a `source` field to the opportunities table to track the origin of the opportunity. This field is populated when the opportunity is created, either from a lead or directly through user input.

Updates the UI to reflect these changes, removing the loan purpose field from the lead creation/editing forms and adding it to the opportunity creation/editing forms. Also shows the opportunity source.

Updates credit detail to use quotation amount to finance.