### PR TITLE
fix crm: remove validation checks for optional fields

### DIFF
--- a/apps/crm/apps/server/src/services/cartera-back-integration.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-integration.ts
@@ -184,7 +184,7 @@ export async function createCreditoInCarteraBack(
 			cuota: params.cuota,
 			// asesor: params.asesor_id,
 			seguro_10_cuotas: params.seguro_10_cuotas,
-			gps: params.gps,
+			gps: params.gps ?? 0,
 			observaciones: params.observaciones,
 			no_poliza: params.no_poliza || "",
 			direccion: params.direccion || "",

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -247,20 +247,11 @@ function validateOpportunityForClose(opp: OpportunityData): string[] {
 	if (!opp.numeroCuotas) missingFields.push("número de cuotas");
 	if (!opp.tasaInteres) missingFields.push("tasa de interés");
 	if (!opp.cuotaMensual) missingFields.push("cuota mensual");
-	if (!opp.diaPagoMensual) missingFields.push("día de pago mensual");
 
 	const seguro = opp.seguro ? Number.parseFloat(opp.seguro) : undefined;
-	const gps = opp.gps ? Number.parseFloat(opp.gps) : undefined;
-	const reserva = opp.reserva ? Number.parseFloat(opp.reserva) : undefined;
 
 	if (seguro === undefined || seguro === null || seguro <= 0) {
 		missingFields.push("seguro (debe ser mayor a 0)");
-	}
-	if (gps === undefined || gps === null || gps <= 0) {
-		missingFields.push("GPS (debe ser mayor a 0)");
-	}
-	if (reserva === undefined || reserva === null || reserva <= 0) {
-		missingFields.push("reserva (debe ser mayor a 0)");
 	}
 	if (!opp.categoria) missingFields.push("categoría del crédito");
 	if (!opp.nit) missingFields.push("NIT del cliente");

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -78,6 +78,7 @@ interface SelectedInversionista {
 // Constantes financieras
 const IVA_RATE = 0.12; // 12% IVA Guatemala
 const DEFAULT_INVESTOR_PERCENTAGE = 70; // Porcentaje default para inversionista
+const DEFAULT_RESERVA = 600; // Reserva default
 
 // Tipo para inversionistas parseados del JSON
 interface Inversionista {
@@ -316,16 +317,15 @@ export function CreditDetailView({
 			// Campos de la cotización que se guardan en la oportunidad
 			const cuotaMensual = quotation?.monthlyPayment || "0";
 			const tasaMensualValue = quotation?.interestRate || "0";
-			const seguroValue = Number.parseFloat(quotation?.insuranceCost || "0");
-			const gpsValue = Number.parseFloat(quotation?.gpsCost || "0");
+			const seguroValue = Number.parseFloat(quotation?.extraInsuranceCost || "0");
+			const gpsValue = Number.parseFloat(quotation?.extraGpsCost || "0");
 			const royaltyValue = Number.parseFloat(quotation?.royalty || "0");
 			const royaltyPercentageValue = quotation?.royaltyPercentage || "4.0";
-			const membresiaValue = Number.parseFloat(quotation?.membershipCost || "0");
+			const membresiaValue = Number.parseFloat(quotation?.extraMembershipCost || "0");
 			const numeroCuotasValue = quotation?.termMonths || 0;
-			const gastosAdminValue = Number.parseFloat(quotation?.adminCost || "0");
-			const finalValue = quotation?.amountToFinance || opportunity.value || "0";
-			// Reserva = 600 + seguro
-			const reservaValue = 600 + seguroValue;
+			const gastosAdminValue = Number.parseFloat(quotation?.extraAdminCost || "0");
+			const finalValue = quotation?.totalFinanced || opportunity.value || "0";
+			const reservaValue = DEFAULT_RESERVA + seguroValue;
 
 			// Construir rubros desde los "Otros Descuentos" de la cotización
 			const rubrosArray: { nombre_rubro: string; monto: number }[] = [];
@@ -369,6 +369,12 @@ export function CreditDetailView({
 			const inspeccionValue = Number.parseFloat(quotation?.inspectionCost || "0");
 			if (inspeccionValue > 0) rubrosArray.push({ nombre_rubro: "Inspección", monto: inspeccionValue });
 
+			const appointmentValue = Number.parseFloat(quotation?.appointmentCost || "0");
+			if (appointmentValue > 0) rubrosArray.push({ nombre_rubro: "Nombramiento", monto: appointmentValue });
+
+			const addressVerificationValue = Number.parseFloat(quotation?.addressVerificationCost || "0");
+			if (addressVerificationValue > 0) rubrosArray.push({ nombre_rubro: "Verificación de dirección", monto: addressVerificationValue });
+			
 			return client.updateOpportunity({
 				id: opportunityId,
 				// Campos editables directamente
@@ -439,12 +445,12 @@ export function CreditDetailView({
 		}
 		
 		// Validar que la suma de montos aportados = amountToFinance (capital)
-		if (inversionistasToValidate.length > 0 && quotation?.amountToFinance) {
+		if (inversionistasToValidate.length > 0 && quotation?.totalFinanced) {
 			const totalAportado = inversionistasToValidate.reduce(
 				(sum, inv) => sum + (inv.monto_aportado || 0),
 				0
 			);
-			const capitalCredito = Number.parseFloat(quotation.amountToFinance);
+			const capitalCredito = Number.parseFloat(quotation.totalFinanced);
 			
 			// Permitir una pequeña diferencia por redondeo (1 centavo)
 			if (Math.abs(totalAportado - capitalCredito) > 0.01) {
@@ -467,13 +473,14 @@ export function CreditDetailView({
 				);
 			}
 			
-			// Actualizar el value de la oportunidad con el amountToFinance de la cotización
-			if (quotation?.amountToFinance && (Number(quotation?.amountToFinance) !== Number(opportunity.value)))  {
+			// Actualizar el value de la oportunidad con el totalFinanced de la cotización
+			if (quotation?.totalFinanced && (Number(quotation?.totalFinanced) !== Number(opportunity.value)))  {
 				await client.updateOpportunity({
 					id: opportunityId,
-					value: quotation.amountToFinance,
+					value: quotation.totalFinanced,
 				});
 			}
+			
 			
 			return client.approveCreditDetail({ opportunityId });
 		},

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -1028,10 +1028,11 @@ export function CreditDetailView({
 											type="number"
 											min={0}
 											max={100}
-											value={porcentajeInversionista}
-											onChange={(e) =>
-												setPorcentajeInversionista(Number(e.target.value))
-											}
+											value={porcentajeInversionista === 0 ? "" : porcentajeInversionista}
+											onChange={(e) => {
+												const value = e.target.value === "" ? 0 : Number(e.target.value);
+												setPorcentajeInversionista(isNaN(value) ? 0 : value);
+											}}
 											className="h-8 w-20 text-sm"
 										/>
 										<span className="text-muted-foreground text-xs">
@@ -1161,6 +1162,7 @@ export function CreditDetailView({
 																					}
 																					placeholder="Seleccionar..."
 																					width="full"
+																					isInModal
 																				/>
 																				{/* Preview de porcentajes debajo del inversionista */}
 																				<div className="mt-2 flex items-center gap-4 text-muted-foreground text-xs">
@@ -1189,10 +1191,11 @@ export function CreditDetailView({
 																				<Input
 																					type="number"
 																					step="0.01"
-																					value={inv.monto_aportado}
+																					value={inv.monto_aportado === 0 ? "" : inv.monto_aportado}
 																					onChange={(e) => {
 																						const newInv = [...editInversionistas];
-																						newInv[index].monto_aportado = Number.parseFloat(e.target.value) || 0;
+																						const value = e.target.value === "" ? 0 : Number.parseFloat(e.target.value);
+																						newInv[index].monto_aportado = isNaN(value) ? 0 : value;
 																						setEditInversionistas(newInv);
 																					}}
 																					placeholder="0.00"
@@ -1204,13 +1207,15 @@ export function CreditDetailView({
 																				<Input
 																					type="number"
 																					step="0.01"
-																					value={inv.porcentaje_participacion}
+																					value={inv.porcentaje_participacion === 0 ? "" : inv.porcentaje_participacion}
 																					onChange={(e) => {
 																						const newInv = [...editInversionistas];
-																						newInv[index].porcentaje_participacion = Number.parseFloat(e.target.value) || 0;
+																						const value = e.target.value === "" ? 0 : Number.parseFloat(e.target.value);
+																						newInv[index].porcentaje_participacion = isNaN(value) ? 0 : value;
 																						setEditInversionistas(newInv);
 																					}}
-																					placeholder={porcentajeInversionista.toString()}
+																					placeholder="0"	
+
 																				/>
 																			</div>
 																			<div>
@@ -1218,13 +1223,14 @@ export function CreditDetailView({
 																				<Input
 																					type="number"
 																					step="0.01"
-																					value={inv.porcentaje_cash_in}
+																					value={inv.porcentaje_cash_in === 0 ? "" : inv.porcentaje_cash_in}
 																					onChange={(e) => {
 																						const newInv = [...editInversionistas];
-																						newInv[index].porcentaje_cash_in = Number.parseFloat(e.target.value) || 0;
+																						const value = e.target.value === "" ? 0 : Number.parseFloat(e.target.value);
+																						newInv[index].porcentaje_cash_in = isNaN(value) ? 0 : value;
 																						setEditInversionistas(newInv);
 																					}}
-																					placeholder={(100 - porcentajeInversionista).toString()}
+																					placeholder="0"
 																				/>
 																			</div>
 																		</div>

--- a/apps/crm/apps/web/src/components/ui/combobox.tsx
+++ b/apps/crm/apps/web/src/components/ui/combobox.tsx
@@ -32,6 +32,7 @@ interface ComboboxDemoProps {
 	onChange: (value: string) => void;
 	onSearchChange?: (search: string) => void;
 	isLoading?: boolean;
+	isInModal?: boolean;
 }
 
 export function Combobox({
@@ -43,14 +44,37 @@ export function Combobox({
 	onChange,
 	onSearchChange,
 	isLoading,
+	isInModal = false,
 }: ComboboxDemoProps) {
 	const [open, setOpen] = React.useState(false);
 	const [searchValue, setSearchValue] = React.useState("");
+	const triggerRef = React.useRef<HTMLButtonElement>(null);
+
+	// Mantener la posición del scroll cuando se abre el popover en un modal
+	const handleOpenChange = React.useCallback((newOpen: boolean) => {
+		if (isInModal && newOpen) {
+			// Guardar la posición del scroll del contenedor padre (DialogContent)
+			const scrollContainer = triggerRef.current?.closest('[data-radix-scroll-area-viewport], [class*="overflow-y-auto"], [class*="overflow-auto"]');
+			const scrollTop = scrollContainer?.scrollTop ?? 0;
+			
+			setOpen(newOpen);
+			
+			// Restaurar la posición después de que React actualice el DOM
+			requestAnimationFrame(() => {
+				if (scrollContainer) {
+					scrollContainer.scrollTop = scrollTop;
+				}
+			});
+		} else {
+			setOpen(newOpen);
+		}
+	}, [isInModal]);
 
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
+		<Popover open={open} onOpenChange={handleOpenChange}>
 			<PopoverTrigger asChild>
 				<Button
+					ref={triggerRef}
 					variant="outline"
 					role="combobox"
 					aria-expanded={open}
@@ -68,6 +92,10 @@ export function Combobox({
 			</PopoverTrigger>
 			<PopoverContent
 				align="start"
+				onOpenAutoFocus={isInModal ? (e) => e.preventDefault() : undefined}
+				onCloseAutoFocus={isInModal ? (e) => e.preventDefault() : undefined}
+				sideOffset={4}
+				avoidCollisions={isInModal}
 				className={cn(
 					"min-w-[300px] p-0",
 					popOverWidth === "full"

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -143,9 +143,6 @@ function DraggableOpportunityCard({
 							!opportunity.numeroCuotas ||
 							!opportunity.tasaInteres ||
 							!opportunity.cuotaMensual ||
-							!opportunity.diaPagoMensual ||
-							!opportunity.seguro ||
-							!opportunity.gps ||
 							!opportunity.nit ||
 							!opportunity.categoria);
 

--- a/apps/crm/bun.lock
+++ b/apps/crm/bun.lock
@@ -28,6 +28,7 @@
         "@tailwindcss/vite": "^4.1.14",
         "@types/bun": "^1.3.0",
         "typescript": "^5.9.3",
+        "xlsx": "^0.18.5",
       },
     },
     "apps/server": {
@@ -887,6 +888,8 @@
 
     "acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
+    "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
+
     "ai": ["ai@5.0.48", "", { "dependencies": { "@ai-sdk/gateway": "1.0.25", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-+oYhbN3NGRXayGfTFI8k1Fu4rhiJcQ0mbgiAOJGFkzvCxunRRQu5cyDl7y6cHNTj1QvHmIBROK5u655Ss2oI0g=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
@@ -943,6 +946,8 @@
 
     "canvg": ["canvg@3.0.11", "", { "dependencies": { "@babel/runtime": "^7.12.5", "@types/raf": "^3.4.0", "core-js": "^3.8.3", "raf": "^3.4.1", "regenerator-runtime": "^0.13.7", "rgbcolor": "^1.0.1", "stackblur-canvas": "^2.0.0", "svg-pathdata": "^6.0.3" } }, "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA=="],
 
+    "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
+
     "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
 
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
@@ -954,6 +959,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
+
+    "codepage": ["codepage@1.15.0", "", {}, "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA=="],
 
     "commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
@@ -972,6 +979,8 @@
     "core-js": ["core-js@3.46.0", "", {}, "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA=="],
 
     "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
+
+    "crc-32": ["crc-32@1.2.2", "", { "bin": { "crc32": "bin/crc32.njs" } }, "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1114,6 +1123,8 @@
     "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
@@ -1455,6 +1466,8 @@
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
+    "ssf": ["ssf@0.11.2", "", { "dependencies": { "frac": "~1.1.2" } }, "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g=="],
+
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
     "stackblur-canvas": ["stackblur-canvas@2.7.0", "", {}, "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ=="],
@@ -1557,7 +1570,13 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "wmf": ["wmf@1.0.2", "", {}, "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw=="],
+
+    "word": ["word@0.3.0", "", {}, "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xlsx": ["xlsx@0.18.5", "", { "dependencies": { "adler-32": "~1.3.0", "cfb": "~1.2.1", "codepage": "~1.15.0", "crc-32": "~1.2.1", "ssf": "~0.11.2", "wmf": "~1.0.1", "word": "~0.3.0" }, "bin": { "xlsx": "bin/xlsx.njs" } }, "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ=="],
 
     "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
 


### PR DESCRIPTION
This pull request updates how credit details and related costs are handled in both the backend and frontend of the CRM application. The main changes improve the consistency of field naming, calculation logic, and validation for credit opportunities, as well as introduce support for new cost types and default values.

**Frontend Consistency & Calculation Improvements:**

- Updated field names in `CreditDetailView.tsx` to use the new `extra*` and `totalFinanced` fields from the quotation object, ensuring alignment with backend expectations. Also, calculation of the reservation amount now uses a defined constant.
- Changed the validation logic to compare investor contributions with `totalFinanced` instead of `amountToFinance`, and updated opportunity value using the same field, improving accuracy in credit approval workflows. [[1]](diffhunk://#diff-a97d1c6a4d4a4f31956fee03c9e2fe4799667986a63348a05111f792d3c0f8a4L442-R453) [[2]](diffhunk://#diff-a97d1c6a4d4a4f31956fee03c9e2fe4799667986a63348a05111f792d3c0f8a4L470-R484)
- Added support for new cost types in the UI, such as "Nombramiento" (appointment) and "Verificación de dirección" (address verification), which are now included in the rubros array if present.
- Introduced a constant `DEFAULT_RESERVA` for the reservation value, improving maintainability and clarity.

**Backend Validation & Defaults:**

- Modified backend validation in `close-opportunity.ts` to remove strict checks for GPS and reservation fields, only requiring insurance to be greater than zero. This relaxes some constraints and prevents unnecessary validation failures.
- Updated the backend integration to default the `gps` parameter to `0` if not provided, ensuring smoother API calls.

**Validation Logic Simplification:**

- Simplified the opportunity card validation logic in the frontend by removing mandatory checks for `diaPagoMensual`, `seguro`, and `gps`, making it consistent with the backend changes.