### PR TITLE
feat(crm): Add credit statistics endpoint and client methods for fetching

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -2173,3 +2173,142 @@ const updateInstallments = async ({
   console.log(`   💰 Nueva cuota: Q${nueva_cuota}`);
   // Aquí va tu implementación existente
 };
+
+// ========================================
+// ESTADÍSTICAS DE CRÉDITOS
+// ========================================
+
+interface CreditStats {
+  cantidad: number;
+  sumaCuotaMensual: string;
+  sumaMora: string;
+}
+
+interface CreditStatsResponse {
+  porCuotasAtrasadas: {
+    "0": CreditStats;
+    "1": CreditStats;
+    "2": CreditStats;
+    "3": CreditStats;
+    "4": CreditStats;
+  };
+  porEstado: {
+    cancelado: CreditStats;
+    incobrable: CreditStats;
+  };
+}
+
+export const getCreditStats = async (email?: string): Promise<CreditStatsResponse> => {
+  console.log(`📊 Obteniendo estadísticas de créditos...`);
+  if (email) {
+    console.log(`   🔍 Filtrando por asesor con email: ${email}`);
+  }
+
+  // Obtener el asesor_id si se proporciona email
+  let asesorId: number | null = null;
+  if (email) {
+    const platformUser = await db
+      .select({ asesor_id: platform_users.asesor_id })
+      .from(platform_users)
+      .where(eq(platform_users.email, email))
+      .limit(1);
+
+    if (platformUser.length > 0 && platformUser[0].asesor_id) {
+      asesorId = platformUser[0].asesor_id;
+      console.log(`   ✅ Asesor encontrado con ID: ${asesorId}`);
+    } else {
+      console.log(`   ⚠️ No se encontró asesor con email: ${email}`);
+    }
+  }
+
+  // Estadísticas por cuotas atrasadas (0, 1, 2, 3, 4) - Solo créditos ACTIVOS o MOROSOS
+  const statsPerCuotasAtrasadas: Record<string, CreditStats> = {
+    "0": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+    "1": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+    "2": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+    "3": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+    "4": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+  };
+
+  // Consulta para créditos activos/morosos con sus moras
+  const baseConditionsActive = [
+    inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
+  ];
+
+  if (asesorId) {
+    baseConditionsActive.push(eq(creditos.asesor_id, asesorId));
+  }
+
+  for (const cuotasNum of [0, 1, 2, 3, 4]) {
+    const result = await db
+      .select({
+        cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+        sumaCuotaMensual: sql<string>`COALESCE(SUM(${creditos.cuota}), 0)::text`,
+        sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
+      })
+      .from(creditos)
+      .leftJoin(
+        moras_credito,
+        and(
+          eq(creditos.credito_id, moras_credito.credito_id),
+          eq(moras_credito.activa, true)
+        )
+      )
+      .where(
+        and(
+          ...baseConditionsActive,
+          sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) = ${cuotasNum}`
+        )
+      );
+
+    statsPerCuotasAtrasadas[cuotasNum.toString()] = {
+      cantidad: result[0]?.cantidad || 0,
+      sumaCuotaMensual: result[0]?.sumaCuotaMensual || "0",
+      sumaMora: result[0]?.sumaMora || "0",
+    };
+  }
+
+  // Estadísticas por estado (CANCELADO, INCOBRABLE)
+  const statsPerEstado = {
+    cancelado: { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+    incobrable: { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+  };
+
+  for (const estado of ["CANCELADO", "INCOBRABLE"] as const) {
+    const baseConditionsStatus = [eq(creditos.statusCredit, estado)];
+
+    if (asesorId) {
+      baseConditionsStatus.push(eq(creditos.asesor_id, asesorId));
+    }
+
+    const result = await db
+      .select({
+        cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+        sumaCuotaMensual: sql<string>`COALESCE(SUM(${creditos.cuota}), 0)::text`,
+        sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
+      })
+      .from(creditos)
+      .leftJoin(
+        moras_credito,
+        and(
+          eq(creditos.credito_id, moras_credito.credito_id),
+          eq(moras_credito.activa, true)
+        )
+      )
+      .where(and(...baseConditionsStatus));
+
+    const key = estado.toLowerCase() as "cancelado" | "incobrable";
+    statsPerEstado[key] = {
+      cantidad: result[0]?.cantidad || 0,
+      sumaCuotaMensual: result[0]?.sumaCuotaMensual || "0",
+      sumaMora: result[0]?.sumaMora || "0",
+    };
+  }
+
+  console.log(`📊 Estadísticas obtenidas exitosamente`);
+
+  return {
+    porCuotasAtrasadas: statsPerCuotasAtrasadas as CreditStatsResponse["porCuotasAtrasadas"],
+    porEstado: statsPerEstado,
+  };
+};

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -2180,11 +2180,14 @@ const updateInstallments = async ({
 
 interface CreditStats {
   cantidad: number;
-  sumaCuotaMensual: string;
+  porcentaje: string;
+  sumaCapital: string;
   sumaMora: string;
 }
 
 interface CreditStatsResponse {
+  totalCreditos: number;
+  efectividad: string; // Porcentaje de créditos SIN cuotas atrasadas
   porCuotasAtrasadas: {
     "0": CreditStats;
     "1": CreditStats;
@@ -2221,13 +2224,30 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
     }
   }
 
+  // Primero obtener el total de créditos activos para calcular porcentajes
+  const baseConditionsTotal = [
+    inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
+  ];
+  if (asesorId) {
+    baseConditionsTotal.push(eq(creditos.asesor_id, asesorId));
+  }
+
+  const totalResult = await db
+    .select({
+      total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+    })
+    .from(creditos)
+    .where(and(...baseConditionsTotal));
+
+  const totalCreditosActivos = totalResult[0]?.total || 0;
+
   // Estadísticas por cuotas atrasadas (0, 1, 2, 3, 4) - Solo créditos ACTIVOS o MOROSOS
   const statsPerCuotasAtrasadas: Record<string, CreditStats> = {
-    "0": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
-    "1": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
-    "2": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
-    "3": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
-    "4": { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+    "0": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "1": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "2": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "3": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "4": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
   };
 
   // Consulta para créditos activos/morosos con sus moras
@@ -2239,11 +2259,13 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
     baseConditionsActive.push(eq(creditos.asesor_id, asesorId));
   }
 
+  let creditosSinAtraso = 0;
+
   for (const cuotasNum of [0, 1, 2, 3, 4]) {
     const result = await db
       .select({
         cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-        sumaCuotaMensual: sql<string>`COALESCE(SUM(${creditos.cuota}), 0)::text`,
+        sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
         sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
       })
       .from(creditos)
@@ -2261,18 +2283,50 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
         )
       );
 
+    const cantidad = result[0]?.cantidad || 0;
+    const porcentaje = totalCreditosActivos > 0 
+      ? ((cantidad / totalCreditosActivos) * 100).toFixed(2) 
+      : "0";
+
+    if (cuotasNum === 0) {
+      creditosSinAtraso = cantidad;
+    }
+
     statsPerCuotasAtrasadas[cuotasNum.toString()] = {
-      cantidad: result[0]?.cantidad || 0,
-      sumaCuotaMensual: result[0]?.sumaCuotaMensual || "0",
+      cantidad,
+      porcentaje,
+      sumaCapital: result[0]?.sumaCapital || "0",
       sumaMora: result[0]?.sumaMora || "0",
     };
   }
 
+  // Calcular efectividad: porcentaje de créditos SIN cuotas atrasadas
+  const efectividad = totalCreditosActivos > 0 
+    ? ((creditosSinAtraso / totalCreditosActivos) * 100).toFixed(2) 
+    : "0";
+
   // Estadísticas por estado (CANCELADO, INCOBRABLE)
   const statsPerEstado = {
-    cancelado: { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
-    incobrable: { cantidad: 0, sumaCuotaMensual: "0", sumaMora: "0" },
+    cancelado: { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    incobrable: { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
   };
+
+  // Obtener total de créditos cancelados + incobrables para sus porcentajes
+  const baseConditionsStatusTotal = [
+    inArray(creditos.statusCredit, ["CANCELADO", "INCOBRABLE"]),
+  ];
+  if (asesorId) {
+    baseConditionsStatusTotal.push(eq(creditos.asesor_id, asesorId));
+  }
+
+  const totalStatusResult = await db
+    .select({
+      total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+    })
+    .from(creditos)
+    .where(and(...baseConditionsStatusTotal));
+
+  const totalCreditosStatus = totalStatusResult[0]?.total || 0;
 
   for (const estado of ["CANCELADO", "INCOBRABLE"] as const) {
     const baseConditionsStatus = [eq(creditos.statusCredit, estado)];
@@ -2284,7 +2338,7 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
     const result = await db
       .select({
         cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-        sumaCuotaMensual: sql<string>`COALESCE(SUM(${creditos.cuota}), 0)::text`,
+        sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
         sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
       })
       .from(creditos)
@@ -2297,10 +2351,16 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
       )
       .where(and(...baseConditionsStatus));
 
+    const cantidad = result[0]?.cantidad || 0;
+    const porcentaje = totalCreditosStatus > 0 
+      ? ((cantidad / totalCreditosStatus) * 100).toFixed(2) 
+      : "0";
+
     const key = estado.toLowerCase() as "cancelado" | "incobrable";
     statsPerEstado[key] = {
-      cantidad: result[0]?.cantidad || 0,
-      sumaCuotaMensual: result[0]?.sumaCuotaMensual || "0",
+      cantidad,
+      porcentaje,
+      sumaCapital: result[0]?.sumaCapital || "0",
       sumaMora: result[0]?.sumaMora || "0",
     };
   }
@@ -2308,6 +2368,8 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
   console.log(`📊 Estadísticas obtenidas exitosamente`);
 
   return {
+    totalCreditos: totalCreditosActivos,
+    efectividad,
     porCuotasAtrasadas: statsPerCuotasAtrasadas as CreditStatsResponse["porCuotasAtrasadas"],
     porEstado: statsPerEstado,
   };

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -1069,14 +1069,20 @@ export const creditRouter = new Elysia()
       description: `
         Obtiene estadísticas agregadas de los créditos, incluyendo:
         
+        **Campos generales:**
+        - totalCreditos: Total de créditos activos/morosos/en convenio
+        - efectividad: Porcentaje de créditos SIN cuotas atrasadas
+        
         **Por cuotas atrasadas (0, 1, 2, 3, 4):**
         - Cantidad de créditos
-        - Suma de cuota mensual
+        - Porcentaje respecto al total
+        - Suma del capital
         - Suma de mora
         
         **Por estado (Cancelado, Incobrable):**
         - Cantidad de créditos
-        - Suma de cuota mensual
+        - Porcentaje respecto al total de cancelados+incobrables
+        - Suma del capital
         - Suma de mora (si aplica)
         
         **Filtro opcional:**
@@ -1087,42 +1093,51 @@ export const creditRouter = new Elysia()
     },
     response: {
       200: t.Object({
+        totalCreditos: t.Number(),
+        efectividad: t.String(),
         porCuotasAtrasadas: t.Object({
           "0": t.Object({
             cantidad: t.Number(),
-            sumaCuotaMensual: t.String(),
+            porcentaje: t.String(),
+            sumaCapital: t.String(),
             sumaMora: t.String(),
           }),
           "1": t.Object({
             cantidad: t.Number(),
-            sumaCuotaMensual: t.String(),
+            porcentaje: t.String(),
+            sumaCapital: t.String(),
             sumaMora: t.String(),
           }),
           "2": t.Object({
             cantidad: t.Number(),
-            sumaCuotaMensual: t.String(),
+            porcentaje: t.String(),
+            sumaCapital: t.String(),
             sumaMora: t.String(),
           }),
           "3": t.Object({
             cantidad: t.Number(),
-            sumaCuotaMensual: t.String(),
+            porcentaje: t.String(),
+            sumaCapital: t.String(),
             sumaMora: t.String(),
           }),
           "4": t.Object({
             cantidad: t.Number(),
-            sumaCuotaMensual: t.String(),
+            porcentaje: t.String(),
+            sumaCapital: t.String(),
             sumaMora: t.String(),
           }),
         }),
         porEstado: t.Object({
           cancelado: t.Object({
             cantidad: t.Number(),
-            sumaCuotaMensual: t.String(),
+            porcentaje: t.String(),
+            sumaCapital: t.String(),
             sumaMora: t.String(),
           }),
           incobrable: t.Object({
             cantidad: t.Number(),
-            sumaCuotaMensual: t.String(),
+            porcentaje: t.String(),
+            sumaCapital: t.String(),
             sumaMora: t.String(),
           }),
         }),

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -7,7 +7,8 @@ import {
   getCreditosIncobrables,
   getCreditosWithUserByMesAnio, 
   mergeCreditosAndUpdate, 
-  resetCredit, 
+  resetCredit,
+  getCreditStats, 
 } from "../controllers/credits";
 import { z } from "zod";
 import { getCreditWithCancellationDetails } from "../controllers/cancelCredit";
@@ -1051,5 +1052,80 @@ export const creditRouter = new Elysia()
         }),
       },
     }
-  );
-
+  )
+  // ========================================
+  // ENDPOINT: ESTADÍSTICAS DE CRÉDITOS
+  // ========================================
+  .get("/stats", async ({ query }) => {
+    const { email } = query;
+    const stats = await getCreditStats(email);
+    return stats;
+  }, {
+    query: t.Object({
+      email: t.Optional(t.String({ description: "Email del asesor para filtrar solo sus créditos" })),
+    }),
+    detail: {
+      summary: "Obtener estadísticas de créditos",
+      description: `
+        Obtiene estadísticas agregadas de los créditos, incluyendo:
+        
+        **Por cuotas atrasadas (0, 1, 2, 3, 4):**
+        - Cantidad de créditos
+        - Suma de cuota mensual
+        - Suma de mora
+        
+        **Por estado (Cancelado, Incobrable):**
+        - Cantidad de créditos
+        - Suma de cuota mensual
+        - Suma de mora (si aplica)
+        
+        **Filtro opcional:**
+        Si se proporciona el email del asesor, solo se muestran los créditos asignados a ese asesor.
+        Si no se proporciona, se muestran todos los créditos.
+      `,
+      tags: ["Créditos", "Estadísticas"],
+    },
+    response: {
+      200: t.Object({
+        porCuotasAtrasadas: t.Object({
+          "0": t.Object({
+            cantidad: t.Number(),
+            sumaCuotaMensual: t.String(),
+            sumaMora: t.String(),
+          }),
+          "1": t.Object({
+            cantidad: t.Number(),
+            sumaCuotaMensual: t.String(),
+            sumaMora: t.String(),
+          }),
+          "2": t.Object({
+            cantidad: t.Number(),
+            sumaCuotaMensual: t.String(),
+            sumaMora: t.String(),
+          }),
+          "3": t.Object({
+            cantidad: t.Number(),
+            sumaCuotaMensual: t.String(),
+            sumaMora: t.String(),
+          }),
+          "4": t.Object({
+            cantidad: t.Number(),
+            sumaCuotaMensual: t.String(),
+            sumaMora: t.String(),
+          }),
+        }),
+        porEstado: t.Object({
+          cancelado: t.Object({
+            cantidad: t.Number(),
+            sumaCuotaMensual: t.String(),
+            sumaMora: t.String(),
+          }),
+          incobrable: t.Object({
+            cantidad: t.Number(),
+            sumaCuotaMensual: t.String(),
+            sumaMora: t.String(),
+          }),
+        }),
+      }),
+    },
+  });

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -132,104 +132,121 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 
 export const cobrosRouter = {
 	// Dashboard de cobros - Vista general del embudo
-	getDashboardStats: cobrosProcedure.handler(async ({ context }) => {
-		// Si la integración con Cartera-Back está habilitada, calcular stats desde Cartera-Back
-		if (isCarteraBackEnabled()) {
-			try {
-				// Usar mes=0 para obtener TODOS los créditos sin filtrar por mes
-				// (el backend de cartera-back trata mes=0 como "sin filtro de fecha")
-				const mes = 0;
-				const anio = new Date().getFullYear();
+	getDashboardStats: cobrosProcedure
+		.input(
+			z.object({
+				emailCobrador: z.string().optional(),
+			}).optional(),
+		)
+		.handler(async ({ input, context }) => {
+			// Si la integración con Cartera-Back está habilitada, usar el endpoint de stats
+			if (isCarteraBackEnabled()) {
+        try {
+          console.log(
+            `[Cobros] Obteniendo stats desde Cartera-Back endpoint /stats${input?.emailCobrador ? `?email=${input.emailCobrador}` : ""}`
+          );
 
-				console.log(
-					`[Cobros] Calculando stats desde Cartera-Back: mes=${mes} (todos), anio=${anio}`,
-				);
+          // Usar el nuevo endpoint de stats de cartera-back
+          const statsResponse = await carteraBackClient.getStats({
+            email: input?.emailCobrador,
+          });
 
-				// Obtener todos los créditos de Cartera-Back de todos los estados
-				const creditosResponse = await obtenerTodosLosCreditosCarteraBack({
-					mes,
-					anio,
-					page: 1,
-					perPage: 10000, // Obtener todos para calcular stats
-				});
+          // Mapear la respuesta del nuevo formato al formato esperado por el frontend
+          const embudoStats = {
+            al_dia: { totalCases: 0, montoTotal: "0" },
+            mora_30: { totalCases: 0, montoTotal: "0" },
+            mora_60: { totalCases: 0, montoTotal: "0" },
+            mora_90: { totalCases: 0, montoTotal: "0" },
+            mora_120: { totalCases: 0, montoTotal: "0" },
+            pagado: { totalCases: 0, montoTotal: "0" },
+            incobrable: { totalCases: 0, montoTotal: "0" },
+            completado: { totalCases: 0, montoTotal: "0" },
+          };
 
-				if (!creditosResponse || !creditosResponse.data) {
-					throw new Error("Estructura de respuesta inválida");
-				}
+          // Mapear porCuotasAtrasadas a estados de mora
+          // 0 cuotas = al_dia, 1 = mora_30, 2 = mora_60, 3 = mora_90, 4+ = mora_120
+          if (statsResponse.porCuotasAtrasadas) {
+            for (const [cuotas, bucket] of Object.entries(
+              statsResponse.porCuotasAtrasadas
+            )) {
+              const numCuotas = Number.parseInt(cuotas, 10);
+              let estadoMora: keyof typeof embudoStats;
 
-				// Procesar estadísticas para el embudo
-				const embudoStats = {
-					al_dia: { totalCases: 0, montoTotal: "0" },
-					mora_30: { totalCases: 0, montoTotal: "0" },
-					mora_60: { totalCases: 0, montoTotal: "0" },
-					mora_90: { totalCases: 0, montoTotal: "0" },
-					mora_120: { totalCases: 0, montoTotal: "0" },
-					pagado: { totalCases: 0, montoTotal: "0" },
-					incobrable: { totalCases: 0, montoTotal: "0" },
-					completado: { totalCases: 0, montoTotal: "0" },
-				};
+              if (numCuotas === 0) {
+                estadoMora = "al_dia";
+              } else if (numCuotas === 1) {
+                estadoMora = "mora_30";
+              } else if (numCuotas === 2) {
+                estadoMora = "mora_60";
+              } else if (numCuotas === 3) {
+                estadoMora = "mora_90";
+              } else {
+                estadoMora = "mora_120";
+              }
 
-				// Contar créditos por estado de mora
-				for (const credito of creditosResponse.data) {
-					// Acceder a los datos anidados correctamente
-					const statusCredit = credito.creditos.statusCredit;
-					const cuotasAtrasadas = credito.mora?.cuotas_atrasadas ?? 0;
-					const montoMora = Number(credito.mora?.monto_mora ?? 0);
+              embudoStats[estadoMora].totalCases += bucket.cantidad;
+              const currentMonto = Number(embudoStats[estadoMora].montoTotal);
+              embudoStats[estadoMora].montoTotal = (
+                currentMonto + Number(bucket.sumaMora || 0)
+              ).toString();
+            }
+          }
 
-					// NOTA: Usamos aproximación (30 días por cuota) porque /getAllCredits
-					// NO retorna las fechas de vencimiento de las cuotas individuales.
-					// Solo /credito retorna el array completo con fechas para cálculo exacto.
-					const diasMora = cuotasAtrasadas * 30;
+          // Mapear porEstado (cancelado, incobrable)
+          if (statsResponse.porEstado) {
+            if (statsResponse.porEstado.cancelado) {
+              embudoStats.completado.totalCases =
+                statsResponse.porEstado.cancelado.cantidad;
+              embudoStats.completado.montoTotal =
+                statsResponse.porEstado.cancelado.sumaMora || "0";
+            }
+            if (statsResponse.porEstado.incobrable) {
+              embudoStats.incobrable.totalCases =
+                statsResponse.porEstado.incobrable.cantidad;
+              embudoStats.incobrable.montoTotal =
+                statsResponse.porEstado.incobrable.sumaMora || "0";
+            }
+          }
 
-					// Determinar estado de mora
-					let estadoMora: keyof typeof embudoStats;
-					if (statusCredit === "CANCELADO") {
-						estadoMora = "completado";
-					} else if (statusCredit === "INCOBRABLE") {
-						estadoMora = "incobrable";
-					} else if (diasMora === 0) {
-						estadoMora = "al_dia";
-					} else if (diasMora <= 30) {
-						estadoMora = "mora_30";
-					} else if (diasMora <= 60) {
-						estadoMora = "mora_60";
-					} else if (diasMora <= 90) {
-						estadoMora = "mora_90";
-					} else {
-						estadoMora = "mora_120";
-					}
+          // Calcular total de casos con mora (cuotas atrasadas > 0)
+          const totalCasosConMora = Object.entries(
+            statsResponse.porCuotasAtrasadas || {}
+          )
+            .filter(([cuotas]) => Number.parseInt(cuotas, 10) > 0)
+            .reduce((sum, [_, bucket]) => sum + bucket.cantidad, 0);
 
-					embudoStats[estadoMora].totalCases += 1;
-					const currentMonto = Number(embudoStats[estadoMora].montoTotal);
-					embudoStats[estadoMora].montoTotal = (
-						currentMonto + montoMora
-					).toString();
-				}
+          console.log(
+            "[Cobros] Stats obtenidas desde endpoint /stats:",
+            embudoStats
+          );
 
-				console.log(
-					"[Cobros] Stats calculadas desde Cartera-Back:",
-					embudoStats,
-				);
+          // Contactos realizados hoy
+          const contactosHoy = await db
+            .select({ count: count() })
+            .from(contactosCobros)
+            .where(
+              gte(
+                contactosCobros.fechaContacto,
+                new Date(new Date().setHours(0, 0, 0, 0))
+              )
+            );
 
-				return {
-					estatusStats: Object.entries(embudoStats).map(([estado, data]) => ({
-						estadoMora: estado,
-						...data,
-					})),
-					totalCasosAsignados: creditosResponse.data.filter((c) => {
-						const cuotasAtrasadas = c.mora?.cuotas_atrasadas ?? 0;
-						return cuotasAtrasadas > 0;
-					}).length,
-					contactosHoy: 0, // No disponible en Cartera-Back
-				};
-			} catch (error) {
-				console.error(
-					"[Cobros] Error calculando stats desde Cartera-Back:",
-					error,
-				);
-				// Fallback a datos locales
-			}
-		}
+          return {
+            estatusStats: Object.entries(embudoStats).map(([estado, data]) => ({
+              estadoMora: estado,
+              ...data,
+            })),
+            totalCasosAsignados: totalCasosConMora,
+            contactosHoy: contactosHoy[0]?.count || 0,
+          };
+        } catch (error) {
+          console.error(
+            "[Cobros] Error obteniendo stats desde Cartera-Back:",
+            error
+          );
+          // Fallback a datos locales
+        }
+      }
 
 		// Fallback: Calcular stats desde la base de datos local
 		const estatusStats = await db
@@ -452,7 +469,7 @@ export const cobrosRouter = {
 							let vehiculoMarca = "-";
 							let vehiculoModelo = "-";
 							let vehiculoYear: number | null = null;
-							let vehiculoPlaca = numeroSifco;
+							let vehiculoPlaca = "-";
 
 							if (numeroSifco) {
 								const [oportunidad] = await db
@@ -472,7 +489,7 @@ export const cobrosRouter = {
 									vehiculoMarca = oportunidad.marca || "-";
 									vehiculoModelo = oportunidad.modelo || "-";
 									vehiculoYear = oportunidad.year;
-									vehiculoPlaca = oportunidad.placa || numeroSifco;
+									vehiculoPlaca = oportunidad.placa || "";
 								}
 							}
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -151,73 +151,62 @@ export const cobrosRouter = {
             email: input?.emailCobrador,
           });
 
-          // Mapear la respuesta del nuevo formato al formato esperado por el frontend
-          const embudoStats = {
-            al_dia: { totalCases: 0, montoTotal: "0" },
-            mora_30: { totalCases: 0, montoTotal: "0" },
-            mora_60: { totalCases: 0, montoTotal: "0" },
-            mora_90: { totalCases: 0, montoTotal: "0" },
-            mora_120: { totalCases: 0, montoTotal: "0" },
-            pagado: { totalCases: 0, montoTotal: "0" },
-            incobrable: { totalCases: 0, montoTotal: "0" },
-            completado: { totalCases: 0, montoTotal: "0" },
-          };
-
-          // Mapear porCuotasAtrasadas a estados de mora
-          // 0 cuotas = al_dia, 1 = mora_30, 2 = mora_60, 3 = mora_90, 4+ = mora_120
-          if (statsResponse.porCuotasAtrasadas) {
-            for (const [cuotas, bucket] of Object.entries(
-              statsResponse.porCuotasAtrasadas
-            )) {
-              const numCuotas = Number.parseInt(cuotas, 10);
-              let estadoMora: keyof typeof embudoStats;
-
-              if (numCuotas === 0) {
-                estadoMora = "al_dia";
-              } else if (numCuotas === 1) {
-                estadoMora = "mora_30";
-              } else if (numCuotas === 2) {
-                estadoMora = "mora_60";
-              } else if (numCuotas === 3) {
-                estadoMora = "mora_90";
-              } else {
-                estadoMora = "mora_120";
-              }
-
-              embudoStats[estadoMora].totalCases += bucket.cantidad;
-              const currentMonto = Number(embudoStats[estadoMora].montoTotal);
-              embudoStats[estadoMora].montoTotal = (
-                currentMonto + Number(bucket.sumaMora || 0)
-              ).toString();
-            }
-          }
-
-          // Mapear porEstado (cancelado, incobrable)
-          if (statsResponse.porEstado) {
-            if (statsResponse.porEstado.cancelado) {
-              embudoStats.completado.totalCases =
-                statsResponse.porEstado.cancelado.cantidad;
-              embudoStats.completado.montoTotal =
-                statsResponse.porEstado.cancelado.sumaMora || "0";
-            }
-            if (statsResponse.porEstado.incobrable) {
-              embudoStats.incobrable.totalCases =
-                statsResponse.porEstado.incobrable.cantidad;
-              embudoStats.incobrable.montoTotal =
-                statsResponse.porEstado.incobrable.sumaMora || "0";
-            }
-          }
-
-          // Calcular total de casos con mora (cuotas atrasadas > 0)
-          const totalCasosConMora = Object.entries(
-            statsResponse.porCuotasAtrasadas || {}
-          )
-            .filter(([cuotas]) => Number.parseInt(cuotas, 10) > 0)
-            .reduce((sum, [_, bucket]) => sum + bucket.cantidad, 0);
+          // Mapear cuotas atrasadas a estados de mora - usar datos exactos de cartera
+          const estatusStats = [
+            {
+              estadoMora: "al_dia",
+              totalCases: statsResponse.porCuotasAtrasadas["0"]?.cantidad || 0,
+              montoTotal: statsResponse.porCuotasAtrasadas["0"]?.sumaMora || "0",
+              sumaCapital: statsResponse.porCuotasAtrasadas["0"]?.sumaCapital || "0",
+              porcentaje: statsResponse.porCuotasAtrasadas["0"]?.porcentaje || "0",
+            },
+            {
+              estadoMora: "mora_30",
+              totalCases: statsResponse.porCuotasAtrasadas["1"]?.cantidad || 0,
+              montoTotal: statsResponse.porCuotasAtrasadas["1"]?.sumaMora || "0",
+              sumaCapital: statsResponse.porCuotasAtrasadas["1"]?.sumaCapital || "0",
+              porcentaje: statsResponse.porCuotasAtrasadas["1"]?.porcentaje || "0",
+            },
+            {
+              estadoMora: "mora_60",
+              totalCases: statsResponse.porCuotasAtrasadas["2"]?.cantidad || 0,
+              montoTotal: statsResponse.porCuotasAtrasadas["2"]?.sumaMora || "0",
+              sumaCapital: statsResponse.porCuotasAtrasadas["2"]?.sumaCapital || "0",
+              porcentaje: statsResponse.porCuotasAtrasadas["2"]?.porcentaje || "0",
+            },
+            {
+              estadoMora: "mora_90",
+              totalCases: statsResponse.porCuotasAtrasadas["3"]?.cantidad || 0,
+              montoTotal: statsResponse.porCuotasAtrasadas["3"]?.sumaMora || "0",
+              sumaCapital: statsResponse.porCuotasAtrasadas["3"]?.sumaCapital || "0",
+              porcentaje: statsResponse.porCuotasAtrasadas["3"]?.porcentaje || "0",
+            },
+            {
+              estadoMora: "mora_120",
+              totalCases: statsResponse.porCuotasAtrasadas["4"]?.cantidad || 0,
+              montoTotal: statsResponse.porCuotasAtrasadas["4"]?.sumaMora || "0",
+              sumaCapital: statsResponse.porCuotasAtrasadas["4"]?.sumaCapital || "0",
+              porcentaje: statsResponse.porCuotasAtrasadas["4"]?.porcentaje || "0",
+            },
+            {
+              estadoMora: "completado",
+              totalCases: statsResponse.porEstado.cancelado?.cantidad || 0,
+              montoTotal: statsResponse.porEstado.cancelado?.sumaMora || "0",
+              sumaCapital: statsResponse.porEstado.cancelado?.sumaCapital || "0",
+              porcentaje: statsResponse.porEstado.cancelado?.porcentaje || "0",
+            },
+            {
+              estadoMora: "incobrable",
+              totalCases: statsResponse.porEstado.incobrable?.cantidad || 0,
+              montoTotal: statsResponse.porEstado.incobrable?.sumaMora || "0",
+              sumaCapital: statsResponse.porEstado.incobrable?.sumaCapital || "0",
+              porcentaje: statsResponse.porEstado.incobrable?.porcentaje || "0",
+            },
+          ];
 
           console.log(
             "[Cobros] Stats obtenidas desde endpoint /stats:",
-            embudoStats
+            estatusStats
           );
 
           // Contactos realizados hoy
@@ -232,11 +221,9 @@ export const cobrosRouter = {
             );
 
           return {
-            estatusStats: Object.entries(embudoStats).map(([estado, data]) => ({
-              estadoMora: estado,
-              ...data,
-            })),
-            totalCasosAsignados: totalCasosConMora,
+            estatusStats,
+            totalCasosAsignados: statsResponse.totalCreditos,
+            efectividad: statsResponse.efectividad,
             contactosHoy: contactosHoy[0]?.count || 0,
           };
         } catch (error) {
@@ -265,14 +252,14 @@ export const cobrosRouter = {
 
 		// Procesar estadísticas para el embudo
 		const embudoStats = {
-			al_dia: { totalCases: 0, montoTotal: "0" },
-			mora_30: { totalCases: 0, montoTotal: "0" },
-			mora_60: { totalCases: 0, montoTotal: "0" },
-			mora_90: { totalCases: 0, montoTotal: "0" },
-			mora_120: { totalCases: 0, montoTotal: "0" },
-			pagado: { totalCases: 0, montoTotal: "0" },
-			incobrable: { totalCases: 0, montoTotal: "0" },
-			completado: { totalCases: 0, montoTotal: "0" },
+			al_dia: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
+			mora_30: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
+			mora_60: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
+			mora_90: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
+			mora_120: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
+			pagado: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
+			incobrable: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
+			completado: { totalCases: 0, montoTotal: "0", sumaCapital: "0", porcentaje: "0" },
 		};
 
 		estatusStats.forEach((stat) => {
@@ -335,6 +322,7 @@ export const cobrosRouter = {
 				...data,
 			})),
 			totalCasosAsignados: casosAsignados[0]?.count || 0,
+			efectividad: "0",
 			contactosHoy: contactosHoy[0]?.count || 0,
 		};
 	}),

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -13,6 +13,7 @@ import type {
 	CarteraCredito,
 	CarteraInversionista,
 	CarteraPagoCredito,
+	CarteraStatsResponse,
 	CarteraUsuario,
 	CreateCreditoInput,
 	CreatePagoInput,
@@ -635,10 +636,7 @@ export class CarteraBackClient {
 	// STATS (ESTADÍSTICAS)
 	// ========================================================================
 
-	async getStats(params: { email?: string } = {}): Promise<{
-		porCuotasAtrasadas: { [key: string]: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
-		porEstado: { cancelado?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string }; incobrable?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
-	}> {
+	async getStats(params: { email?: string } = {}): Promise<CarteraStatsResponse> {
 		const queryParams = new URLSearchParams({
 			...(params.email && { email: params.email }),
 		});
@@ -646,10 +644,7 @@ export class CarteraBackClient {
 		const url = params.email ? `/stats?${queryParams}` : "/stats";
 
 		// Este endpoint retorna directamente el objeto de stats
-		const response = await this.request<{
-			porCuotasAtrasadas: { [key: string]: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
-			porEstado: { cancelado?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string }; incobrable?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
-		}>(url, { method: "GET" }, true);
+		const response = await this.request<CarteraStatsResponse>(url, { method: "GET" }, true);
 
 		return response;
 	}

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -632,6 +632,29 @@ export class CarteraBackClient {
 	}
 
 	// ========================================================================
+	// STATS (ESTADÍSTICAS)
+	// ========================================================================
+
+	async getStats(params: { email?: string } = {}): Promise<{
+		porCuotasAtrasadas: { [key: string]: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
+		porEstado: { cancelado?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string }; incobrable?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
+	}> {
+		const queryParams = new URLSearchParams({
+			...(params.email && { email: params.email }),
+		});
+
+		const url = params.email ? `/stats?${queryParams}` : "/stats";
+
+		// Este endpoint retorna directamente el objeto de stats
+		const response = await this.request<{
+			porCuotasAtrasadas: { [key: string]: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
+			porEstado: { cancelado?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string }; incobrable?: { cantidad: number; sumaCuotaMensual: string; sumaMora: string } };
+		}>(url, { method: "GET" }, true);
+
+		return response;
+	}
+
+	// ========================================================================
 	// CACHE MANAGEMENT
 	// ========================================================================
 

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -577,11 +577,14 @@ export interface PagoDetalle {
 
 export interface CarteraStatsBucket {
 	cantidad: number;
-	sumaCuotaMensual: string;
+	porcentaje: string;
+	sumaCapital: string;
 	sumaMora: string;
 }
 
 export interface CarteraStatsResponse {
+	totalCreditos: number;
+	efectividad: string;
 	porCuotasAtrasadas: {
 		[key: string]: CarteraStatsBucket; // "0", "1", "2", "3", "4"+
 	};

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -572,6 +572,30 @@ export interface PagoDetalle {
 }
 
 // ============================================================================
+// STATS (ESTADÍSTICAS)
+// ============================================================================
+
+export interface CarteraStatsBucket {
+	cantidad: number;
+	sumaCuotaMensual: string;
+	sumaMora: string;
+}
+
+export interface CarteraStatsResponse {
+	porCuotasAtrasadas: {
+		[key: string]: CarteraStatsBucket; // "0", "1", "2", "3", "4"+
+	};
+	porEstado: {
+		cancelado?: CarteraStatsBucket;
+		incobrable?: CarteraStatsBucket;
+	};
+}
+
+export interface GetStatsParams {
+	email?: string; // Email del asesor para filtrar
+}
+
+// ============================================================================
 // ERROR TYPES
 // ============================================================================
 

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -19,6 +19,7 @@ export type ContratoCobranza = {
 	fechaProximoPago: string | null;
 	diasHastaPago: number | null; // Calculado: días hasta el próximo pago (null si no hay fecha definida)
 	numeroCredito: string | null;
+	cuotaMensual: string | null;
 };
 
 function getEstadoBadge(estado: string) {
@@ -105,6 +106,25 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 					Cliente
 					<ArrowUpDown className="ml-2 h-4 w-4" />
 				</Button>
+			);
+		},
+		cell: ({ row }) => {
+			return (
+				<div className="w-[350px] whitespace-normal font-medium" style={{ wordBreak: 'break-word' }}>
+					{row.getValue("clienteNombre")}
+				</div>
+			);
+		},
+	},
+	{
+		accessorKey: "numeroCredito",
+		header: "No. Crédito",
+		cell: ({ row }) => {
+			const numero = row.getValue("numeroCredito") as string | null;
+			return (
+				<div className="w-[180px] whitespace-normal font-mono text-sm" style={{ wordBreak: 'break-all' }}>
+					{numero || "-"}
+				</div>
 			);
 		},
 	},

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -353,25 +353,12 @@ function RouteComponent() {
 					</CardHeader>
 					<CardContent>
 						<div className="font-bold text-2xl">
-							{(() => {
-								const totalCasos = stats.reduce(
-									(sum, s) => sum + s.totalCases,
-									0,
-								);
-								const casosRecuperados =
-									(stats.find((s) => s.estadoMora === "pagado")?.totalCases ||
-										0) +
-									(stats.find((s) => s.estadoMora === "completado")
-										?.totalCases || 0);
-								const efectividad =
-									totalCasos > 0
-										? Math.round((casosRecuperados / totalCasos) * 100)
-										: 0;
-								return `${efectividad}%`;
-							})()}
+							{dashboardStats.data?.efectividad
+								? `${Number.parseFloat(dashboardStats.data.efectividad).toFixed(2)}%`
+								: "0%"}
 						</div>
 						<p className="text-muted-foreground text-xs">
-							Tasa de recuperación mensual
+							Tasa de recuperación
 						</p>
 					</CardContent>
 				</Card>
@@ -432,6 +419,8 @@ function RouteComponent() {
 							) || {
 								totalCases: 0,
 								montoTotal: "0",
+								sumaCapital: "0",
+								porcentaje: "0",
 							};
 							const maxCasos = Math.max(...stats.map((s) => s.totalCases), 1);
 							const porcentaje = (estadoStats.totalCases / maxCasos) * 100;
@@ -465,7 +454,7 @@ function RouteComponent() {
 															color: porcentaje > 60 ? "white" : "#1f2937",
 														}}
 													>
-														{estadoStats.totalCases} casos
+														{estadoStats.totalCases} casos - {Number.parseFloat(estadoStats.porcentaje || "0").toFixed(2)}% del total
 													</span>
 												</div>
 											) : (
@@ -479,14 +468,29 @@ function RouteComponent() {
 														}}
 													/>
 													<span className="ml-2 whitespace-nowrap font-semibold text-muted-foreground text-sm">
-														{estadoStats.totalCases} casos
+														{estadoStats.totalCases} casos - {Number.parseFloat(estadoStats.porcentaje || "0").toFixed(2)}% del total
 													</span>
 												</div>
 											)}
 										</div>
 									</div>
-									<div className="w-32 shrink-0 text-right font-medium text-sm">
-										Q{Number(estadoStats.montoTotal || 0).toLocaleString()}
+									<div className="flex w-52 shrink-0 flex-col gap-1 text-right text-sm">
+										<div className="flex items-center justify-end gap-2">
+											<span className="text-muted-foreground text-xs">
+												Mora:
+											</span>
+											<span className="font-medium">
+												Q{Number(estadoStats.montoTotal || 0).toLocaleString()}
+											</span>
+										</div>
+										<div className="flex items-center justify-end gap-2">
+											<span className="text-muted-foreground text-xs">
+												Capital:
+											</span>
+											<span className="font-medium">
+												Q{Number(estadoStats.sumaCapital || 0).toLocaleString()}
+											</span>
+										</div>
 									</div>
 								</div>
 							);

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -71,8 +71,15 @@ function RouteComponent() {
 		return () => clearTimeout(timer);
 	}, [filterValue]);
 
+	const userRole = session?.user.role;
+
 	const dashboardStats = useQuery({
-		...orpc.getCobrosDashboardStats.queryOptions(),
+		...orpc.getCobrosDashboardStats.queryOptions({
+			input: {
+				emailCobrador:
+					userRole !== ROLES.ADMIN ? session?.user?.email : undefined,
+			},
+		}),
 		enabled: !!session,
 	});
 
@@ -98,8 +105,6 @@ function RouteComponent() {
 				return undefined;
 		}
 	}, [filtroTemporal]);
-
-	const userRole = session?.user.role;
 
 	const todosLosCreditos = useQuery({
 		...orpc.getTodosLosCreditos.queryOptions({

--- a/apps/portal-web/src/features/Terms/TermsAndConditions.tsx
+++ b/apps/portal-web/src/features/Terms/TermsAndConditions.tsx
@@ -2,53 +2,15 @@ import { Footer } from "@/features/footer";
 
 // Contenido de términos y condiciones (editable)
 const TERMS_CONTENT = `
-Bienvenido a CashIn. Al utilizar nuestros servicios, aceptas estar sujeto a los siguientes términos y condiciones.
-
-1. ACEPTACIÓN DE LOS TÉRMINOS
-Al acceder y utilizar esta plataforma, aceptas cumplir con estos términos y condiciones de uso. Si no estás de acuerdo con alguna parte de estos términos, no debes usar nuestros servicios.
-
-2. DESCRIPCIÓN DEL SERVICIO
-CashIn ofrece servicios de financiamiento vehicular y soluciones de inversión. Nos reservamos el derecho de modificar o descontinuar el servicio en cualquier momento sin previo aviso.
-
-3. REGISTRO Y CUENTA DE USUARIO
-Para acceder a ciertos servicios, debes registrarte y crear una cuenta. Eres responsable de mantener la confidencialidad de tu información de cuenta y contraseña.
-
-4. USO ACEPTABLE
-Te comprometes a utilizar nuestros servicios únicamente para fines legales y de acuerdo con estos términos. No debes:
-- Proporcionar información falsa o engañosa
-- Violar cualquier ley o regulación aplicable
-- Interferir con el funcionamiento de la plataforma
-- Intentar obtener acceso no autorizado a nuestros sistemas
-
-5. PRIVACIDAD Y PROTECCIÓN DE DATOS
-Nos comprometemos a proteger tu información personal de acuerdo con nuestra Política de Privacidad. Al usar nuestros servicios, aceptas la recopilación y uso de información según se describe en dicha política.
-
-6. FINANCIAMIENTO Y CRÉDITOS
-Los servicios de financiamiento están sujetos a aprobación crediticia. CashIn se reserva el derecho de aprobar o rechazar cualquier solicitud de crédito a su discreción.
-
-7. SERVICIOS DE INVERSIÓN
-Las inversiones conllevan riesgos. El rendimiento pasado no garantiza resultados futuros. Debes consultar con un asesor financiero antes de tomar decisiones de inversión.
-
-8. PROPIEDAD INTELECTUAL
-Todo el contenido de la plataforma, incluyendo textos, gráficos, logos, iconos, imágenes y software, es propiedad de CashIn y está protegido por las leyes de propiedad intelectual.
-
-9. LIMITACIÓN DE RESPONSABILIDAD
-CashIn no será responsable por daños indirectos, incidentales, especiales o consecuentes que resulten del uso o la imposibilidad de usar nuestros servicios.
-
-10. MODIFICACIONES
-Nos reservamos el derecho de modificar estos términos en cualquier momento. Los cambios entrarán en vigor inmediatamente después de su publicación en la plataforma.
-
-11. LEY APLICABLE
-Estos términos se rigen por las leyes de Guatemala. Cualquier disputa se resolverá en los tribunales competentes de Guatemala.
-
-12. CONTACTO
-Si tienes preguntas sobre estos términos, por favor contáctanos a través de nuestros canales de atención al cliente.
-
-Última actualización: Enero 2026
+Autorizo voluntariamente que la información recopilada y/o proporcionada por entidades públicas o 
+privadas y la generada de relaciones contractuales, crediticias o comerciales, sea reportada a entidades
+que prestan servicios de información, centrales de riesgo o burós de crédito para ser tratada, almacenada
+o transferida; y autorizo expresamente a las entidades que prestan servicios de información,
+centrales de riesgo y burós de crédito a recopilar, difundir o comercializar reportes
+ o estudios que contengan información sobre mi persona.
 `;
 
 export const TermsAndConditions = () => {
-
   return (
     <div className="min-h-screen flex flex-col relative">
       {/* Fondo con gradiente para toda la página */}
@@ -88,13 +50,12 @@ export const TermsAndConditions = () => {
       <section className="flex-1  mx-auto px-6 lg:px-8 pb-12 z-10 relative">
         <div className="bg-white/5 backdrop-blur-sm border border-white/10 rounded-2xl p-6 lg:p-8">
           <div className="prose prose-invert max-w-none">
-            <div className="whitespace-pre-wrap text-gray leading-relaxed">
+            <div className="whitespace-pre-wrap text-gray leading-relaxed text-2xl">
               {TERMS_CONTENT}
             </div>
           </div>
 
           {/* Botón Continuar */}
-          
         </div>
       </section>
 


### PR DESCRIPTION
This pull request introduces a new aggregated credit statistics endpoint to the cartera-back service and integrates it throughout the CRM backend and frontend. The main focus is to provide efficient, filtered statistics for credits, which simplifies and speeds up dashboard data retrieval and display. Additionally, there are minor improvements to vehicle plate handling and the columns shown in the collections dashboard.

**Credit statistics endpoint and integration:**

* Added a new `getCreditStats` function in `credits.ts` that computes aggregated statistics of credits by overdue installments and status, with optional filtering by advisor email. This includes counts and sums of monthly payments and overdue amounts for each group.
* Exposed a new `/stats` endpoint in the credits router (`credits.ts`) to serve these statistics, with OpenAPI documentation and response schema.
* Implemented a `getStats` method in the `CarteraBackClient` service to call the new `/stats` endpoint.
* Added corresponding TypeScript types for the stats response and parameters.

**CRM backend dashboard integration:**

* Refactored the cobros dashboard (`cobros.ts`) to use the new `/stats` endpoint for statistics, mapping its response to the frontend format and supporting filtering by collector email. This replaces the previous approach of fetching and processing all credits individually. [[1]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649L135-R154) [[2]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649L172-R245)
* Now calculates the number of assigned overdue cases and today's contacts more efficiently.

**Frontend and UI improvements:**

* The dashboard now requests stats filtered by the current user's email unless the user is an admin, improving data relevance and performance.
* Added the "No. Crédito" (credit number) column to the collections dashboard table for better identification.
* Minor: Added `cuotaMensual` to the `ContratoCobranza` type for potential future use.

**Minor fixes:**

* Improved vehicle plate assignment logic to avoid using the SIFCO number as a fallback, ensuring plates are either the opportunity's plate or empty. [[1]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649L455-R472) [[2]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649L475-R492)…hing stats

This pull request introduces a new aggregated statistics endpoint for credit data in the Cartera-Back service, refactors the CRM backend to use this new endpoint for dashboard statistics, and updates types and data flow to support richer statistics. The main themes are the addition of the `/stats` endpoint, integration of this endpoint into the CRM dashboard, and enhancements to type definitions for statistics data.

**Cartera-Back: Estadísticas de créditos**
- Added a new `getCreditStats` function in `credits.ts` that computes aggregated statistics on credits, such as total active credits, effectiveness (percentage without overdue payments), breakdowns by overdue installments (0–4), and by status (cancelled, uncollectible). Supports optional filtering by advisor email.
- Exposed a new `/stats` GET endpoint in `credits.ts` router, which returns the statistics computed by `getCreditStats`. The endpoint is documented and supports filtering by advisor email. [[1]](diffhunk://#diff-2110ab408da96d9bf103219f7592e3026590585e91af3ab742a79d141856b6cfL1054-R1146) [[2]](diffhunk://#diff-2110ab408da96d9bf103219f7592e3026590585e91af3ab742a79d141856b6cfR11)

**CRM Backend: Dashboard integration**
- Refactored the `getDashboardStats` handler in `cobros.ts` to fetch statistics directly from the new `/stats` endpoint of Cartera-Back, instead of aggregating from raw credit data. The handler now maps the stats response to the dashboard's funnel states and includes effectiveness and today's contacts.
- Updated the local fallback stats structure in `cobros.ts` to match the new stats shape, including new fields such as `sumaCapital` and `porcentaje`. [[1]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649L251-R262) [[2]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649R325)

**Type and Client updates**
- Added new TypeScript interfaces (`CarteraStatsBucket`, `CarteraStatsResponse`, `GetStatsParams`) for statistics data to `cartera-back.ts` and updated the client to support the new `/stats` endpoint. [[1]](diffhunk://#diff-9f078d3098a1c191b620d30aed397cb24ff653bedc64b3ea910471fd70b8c48fR574-R600) [[2]](diffhunk://#diff-58fe83033f4c68e6d222a6af1a0797e0ec39b9b93db8d634b7fb5c4196a51840R16) [[3]](diffhunk://#diff-58fe83033f4c68e6d222a6af1a0797e0ec39b9b93db8d634b7fb5c4196a51840R635-R651)

**Minor fixes**
- Adjusted vehicle plate assignment logic in CRM backend to avoid defaulting to `numeroSifco` when not available, ensuring cleaner data. [[1]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649L455-R460) [[2]](diffhunk://#diff-a17ade9aa319e01f8cb160b783615e26d28314e805887553888998c12b91d649L475-R480)
- Added `cuotaMensual` field to `ContratoCobranza` type in CRM web columns for future use.

<img width="1576" height="898" alt="image" src="https://github.com/user-attachments/assets/446c3278-d590-4ffb-9425-56a523c267ee" />
