### PR TITLE
fix(crm): corregir edición de leads y creación de oportunidades

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -228,7 +228,9 @@ export const crmRouter = {
 				.select({
 					id: leads.id,
 					firstName: leads.firstName,
+					middleName: leads.middleName,
 					lastName: leads.lastName,
+					secondLastName: leads.secondLastName,
 					email: leads.email,
 					phone: leads.phone,
 					age: leads.age,

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -798,6 +798,10 @@ function RouteComponent() {
 				leadId:
 					value.leadId && value.leadId !== "none" ? value.leadId : undefined,
 				vehicleId: value.vehicleId || undefined,
+				vendorId:
+					value.vendorId && value.vendorId !== "none"
+						? value.vendorId
+						: undefined,
 				value: value.value || undefined,
 				expectedCloseDate: value.expectedCloseDate || undefined,
 				notes: value.notes || undefined,


### PR DESCRIPTION
## Summary
- Agregar `middleName` y `secondLastName` al select de `getLeads` para que se puedan editar
- Transformar `vendorId: "none"` a `undefined` en `createOpportunity` para evitar error de validación UUID

## Test plan
- [ ] Verificar que al editar un lead se muestran y guardan segundo nombre y segundo apellido
- [ ] Verificar que se puede crear una oportunidad sin seleccionar vendedor

🤖 Generated with [Claude Code](https://claude.com/claude-code)