### PR TITLE
fix(crm): corregir error 500 al actualizar status de oportunidad

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -927,6 +927,8 @@ export const crmRouter = {
 				membresiaPago,
 				direccion,
 				gastosAdministrativos,
+				expectedCloseDate,
+				fechaInicio,
 				...updateData
 			} = input;
 
@@ -1075,12 +1077,12 @@ export const crmRouter = {
 				.set({
 					...updateData,
 					...(assignedTo && { assignedTo }),
-					expectedCloseDate: updateData.expectedCloseDate
-						? new Date(updateData.expectedCloseDate)
-						: undefined,
-					fechaInicio: updateData.fechaInicio
-						? new Date(updateData.fechaInicio)
-						: undefined,
+					...(expectedCloseDate && {
+						expectedCloseDate: new Date(expectedCloseDate),
+					}),
+					...(fechaInicio && {
+						fechaInicio: new Date(fechaInicio),
+					}),
 					// Convert numeric fields to strings for decimal columns
 					...(seguro !== undefined && { seguro: String(seguro) }),
 					...(gps !== undefined && { gps: String(gps) }),

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -930,7 +930,6 @@ function RouteComponent() {
 			expectedCloseDate?: string;
 			assignedTo?: string;
 			notes?: string;
-			vendorId?: string;
 		}) => client.createOpportunity(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({


### PR DESCRIPTION
## Summary
- Corregir error 500 al cambiar status de oportunidad (excluir campos de fecha del spread)
- Remover vendorId duplicado en frontend

## Test plan
- [ ] Cambiar status de una oportunidad a "En espera" o "Perdida"
- [ ] Verificar que no haya error 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)