### PR TITLE
fix actualizar permisos en cobros

### DIFF
--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -76,8 +76,8 @@ function RouteComponent() {
 	const dashboardStats = useQuery({
 		...orpc.getCobrosDashboardStats.queryOptions({
 			input: {
-				emailCobrador:
-					userRole !== ROLES.ADMIN ? session?.user?.email : undefined,
+				emailCobrador: !PERMISSIONS.canAssignCobros(userRole ?? "") ? session?.user?.email : undefined,
+
 			},
 		}),
 		enabled: !!session,
@@ -115,7 +115,7 @@ function RouteComponent() {
 				nombreUsuario: debouncedFilterValue || undefined,
 				time: timeParam,
 				emailCobrador:
-					userRole !== ROLES.ADMIN ? session?.user?.email : undefined,
+					!PERMISSIONS.canAssignCobros(userRole ?? "") ? session?.user?.email : undefined,
 			},
 		}),
 		enabled: !!session,


### PR DESCRIPTION
This pull request updates the logic for determining the `emailCobrador` parameter in two places within the `RouteComponent` in `apps/crm/apps/web/src/routes/cobros/index.tsx`. The change replaces a direct comparison to the `ADMIN` role with a more flexible permission check using the `PERMISSIONS.canAssignCobros` method.

Permission logic improvements:

* Updated the `emailCobrador` assignment in the `dashboardStats` query to use `PERMISSIONS.canAssignCobros(userRole ?? "")` instead of checking for `ROLES.ADMIN`, improving flexibility and future maintainability.
* Applied the same permission-based logic to the `getCobros` query, ensuring consistent access control for cobrador assignment.