### PR TITLE
feat(crm): implementar analysisStatus para oportunidades

### DIFF
--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -86,6 +86,15 @@ export const clientTypeEnum = pgEnum("client_type", [
 	"empresa", // Empresa (S.A, Ltda, etc.)
 ]);
 
+// Analysis status enum for tracking opportunity analysis workflow
+export const analysisStatusEnum = pgEnum("analysis_status", [
+	"not_applicable", // Nunca ha llegado a análisis (etapa < 30%)
+	"pending", // Primera vez en 30%, esperando revisión
+	"rejected", // Rechazada, en etapa < 30% esperando corrección
+	"resubmitted", // Corregida y reenviada a 30%
+	"approved", // Aprobada, pasó a 40%+
+]);
+
 // Companies table
 export const companies = pgTable("companies", {
 	id: uuid("id").primaryKey().defaultRandom(),
@@ -292,6 +301,18 @@ export const opportunities = pgTable("opportunities", {
 		() => user.id,
 	),
 	disbursementApprovedAt: timestamp("disbursement_approved_at"),
+
+	// Analysis Status
+	analysisStatus: analysisStatusEnum("analysis_status")
+		.notNull()
+		.default("not_applicable"),
+	analysisRejectionCount: integer("analysis_rejection_count")
+		.notNull()
+		.default(0),
+	lastAnalysisRejectedAt: timestamp("last_analysis_rejected_at"),
+	lastAnalysisRejectedBy: text("last_analysis_rejected_by").references(
+		() => user.id,
+	),
 
 	notes: text("notes"),
 	createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -924,6 +924,8 @@ export const crmRouter = {
 				rubros: z.string().optional(), // JSON string with expense items
 				gastosAdministrativos: z.number().optional(), // Administrative expenses for cartera "otros"
 				loanPurpose: z.enum(["personal", "business"]).optional(),
+				// Optimistic locking - prevents race conditions on concurrent updates
+				expectedUpdatedAt: z.string().datetime().optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -941,6 +943,7 @@ export const crmRouter = {
 				gastosAdministrativos,
 				expectedCloseDate,
 				fechaInicio,
+				expectedUpdatedAt,
 				...updateData
 			} = input;
 
@@ -1105,13 +1108,22 @@ export const crmRouter = {
 
 			// Sales users can only update opportunities assigned to them
 			// Admin and sales_supervisor can update any opportunity
-			const whereClause =
+			// Include optimistic locking check if expectedUpdatedAt is provided
+			const baseWhereClause =
 				context.userRole === "admin" || context.userRole === "sales_supervisor"
 					? eq(opportunities.id, id)
 					: and(
 							eq(opportunities.id, id),
 							eq(opportunities.assignedTo, context.userId),
 						);
+
+			// Add optimistic locking condition if expectedUpdatedAt is provided
+			const whereClause = expectedUpdatedAt
+				? and(
+						baseWhereClause,
+						eq(opportunities.updatedAt, new Date(expectedUpdatedAt)),
+					)
+				: baseWhereClause;
 
 			// Sales users cannot reassign opportunities
 			if (
@@ -1184,6 +1196,13 @@ export const crmRouter = {
 				.returning();
 
 			if (updatedOpportunity.length === 0) {
+				// If expectedUpdatedAt was provided and no rows updated, it's likely a concurrent modification
+				if (expectedUpdatedAt) {
+					throw new ORPCError("CONFLICT", {
+						message:
+							"La oportunidad fue modificada por otro usuario. Por favor recarga la página e intenta de nuevo.",
+					});
+				}
 				throw new Error(
 					"Opportunity not found or you don't have permission to update it",
 				);
@@ -1296,6 +1315,8 @@ export const crmRouter = {
 				approved: z.boolean(),
 				reason: z.string().optional(),
 				bypassValidation: z.boolean().optional(), // Solo admin puede usar bypass
+				// Optimistic locking - prevents race conditions on concurrent updates
+				expectedUpdatedAt: z.string().datetime().optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -1303,6 +1324,7 @@ export const crmRouter = {
 			const opportunity = await db
 				.select({
 					id: opportunities.id,
+					updatedAt: opportunities.updatedAt,
 					vehicleId: opportunities.vehicleId,
 					creditType: opportunities.creditType,
 					stageId: opportunities.stageId,
@@ -1454,6 +1476,26 @@ export const crmRouter = {
 				throw new Error("Opportunity is not in analysis stage");
 			}
 
+			// Validate analysisStatus is in a valid state for approval/rejection
+			const validStatusesForReview = ["pending", "resubmitted"];
+			if (!validStatusesForReview.includes(opportunity[0].analysisStatus)) {
+				if (opportunity[0].analysisStatus === "approved") {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"Esta oportunidad ya fue aprobada. No se puede aprobar o rechazar nuevamente.",
+					});
+				}
+				if (opportunity[0].analysisStatus === "rejected") {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"Esta oportunidad ya fue rechazada y está pendiente de corrección por el vendedor.",
+					});
+				}
+				throw new ORPCError("BAD_REQUEST", {
+					message: `Estado de análisis inválido: ${opportunity[0].analysisStatus}. Solo se pueden revisar oportunidades con estado 'pending' o 'resubmitted'.`,
+				});
+			}
+
 			// Get the next stage (40% - Cierre de propuesta) for approval
 			const nextStage = await db
 				.select()
@@ -1482,8 +1524,16 @@ export const crmRouter = {
 				: previousStage[0].id; // 20% - Solución y propuesta (rejection)
 
 			if (input.approved || input.reason || !input.approved) {
+				// Build where clause with optional optimistic locking
+				const whereClause = input.expectedUpdatedAt
+					? and(
+							eq(opportunities.id, input.opportunityId),
+							eq(opportunities.updatedAt, new Date(input.expectedUpdatedAt)),
+						)
+					: eq(opportunities.id, input.opportunityId);
+
 				// Update opportunity with analysisStatus
-				await db
+				const updatedRows = await db
 					.update(opportunities)
 					.set({
 						stageId: newStageId,
@@ -1498,7 +1548,16 @@ export const crmRouter = {
 							: opportunity[0].notes,
 						updatedAt: new Date(),
 					})
-					.where(eq(opportunities.id, input.opportunityId));
+					.where(whereClause)
+					.returning();
+
+				// Check for concurrent modification
+				if (updatedRows.length === 0 && input.expectedUpdatedAt) {
+					throw new ORPCError("CONFLICT", {
+						message:
+							"La oportunidad fue modificada por otro usuario. Por favor recarga la página e intenta de nuevo.",
+					});
+				}
 
 				// Record stage history
 				await db.insert(opportunityStageHistory).values({

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -677,6 +677,9 @@ export const crmRouter = {
 				notes: opportunities.notes,
 				createdAt: opportunities.createdAt,
 				updatedAt: opportunities.updatedAt,
+				// Analysis status for tracking rejection/resubmission
+				analysisStatus: opportunities.analysisStatus,
+				analysisRejectionCount: opportunities.analysisRejectionCount,
 				// Credit terms fields
 				numeroCuotas: opportunities.numeroCuotas,
 				tasaInteres: opportunities.tasaInteres,
@@ -1068,6 +1071,38 @@ export const crmRouter = {
 				// is now handled by approveDisbursement via closeOpportunity service
 			}
 
+			// Calculate new analysisStatus based on stage transition
+			let newAnalysisStatus = currentOpportunity[0].analysisStatus;
+
+			if (input.stageId && input.stageId !== currentOpportunity[0].stageId) {
+				const targetStage = await db
+					.select()
+					.from(salesStages)
+					.where(eq(salesStages.id, input.stageId))
+					.limit(1);
+
+				const currentStage = await db
+					.select()
+					.from(salesStages)
+					.where(eq(salesStages.id, currentOpportunity[0].stageId))
+					.limit(1);
+
+				const fromPercentage = currentStage[0]?.closurePercentage ?? 0;
+				const toPercentage = targetStage[0]?.closurePercentage ?? 0;
+
+				// If moving TO stage 30% (analysis stage)
+				if (toPercentage === 30 && fromPercentage !== 30) {
+					if (currentOpportunity[0].analysisStatus === "not_applicable") {
+						newAnalysisStatus = "pending";
+					} else if (currentOpportunity[0].analysisStatus === "rejected") {
+						newAnalysisStatus = "resubmitted";
+					} else if (currentOpportunity[0].analysisStatus === "approved") {
+						// Re-analysis of previously approved opportunity
+						newAnalysisStatus = "pending";
+					}
+				}
+			}
+
 			// Sales users can only update opportunities assigned to them
 			// Admin and sales_supervisor can update any opportunity
 			const whereClause =
@@ -1137,6 +1172,10 @@ export const crmRouter = {
 					}),
 					...(gastosAdministrativos !== undefined && {
 						gastosAdministrativos: String(gastosAdministrativos),
+					}),
+					// Update analysisStatus if it changed during stage transition
+					...(newAnalysisStatus !== currentOpportunity[0].analysisStatus && {
+						analysisStatus: newAnalysisStatus,
 					}),
 					...(updateData.status === "won" && { actualCloseDate: new Date() }),
 					updatedAt: new Date(),
@@ -1211,6 +1250,8 @@ export const crmRouter = {
 					notes: opportunities.notes,
 					createdAt: opportunities.createdAt,
 					updatedAt: opportunities.updatedAt,
+					analysisStatus: opportunities.analysisStatus,
+					analysisRejectionCount: opportunities.analysisRejectionCount,
 					lead: {
 						id: leads.id,
 						firstName: leads.firstName,
@@ -1268,6 +1309,8 @@ export const crmRouter = {
 					notes: opportunities.notes,
 					leadId: opportunities.leadId,
 					clientType: leads.clientType,
+					analysisStatus: opportunities.analysisStatus,
+					analysisRejectionCount: opportunities.analysisRejectionCount,
 				})
 				.from(opportunities)
 				.leftJoin(leads, eq(opportunities.leadId, leads.id))
@@ -1411,7 +1454,7 @@ export const crmRouter = {
 				throw new Error("Opportunity is not in analysis stage");
 			}
 
-			// Get the next stage
+			// Get the next stage (40% - Cierre de propuesta) for approval
 			const nextStage = await db
 				.select()
 				.from(salesStages)
@@ -1422,17 +1465,34 @@ export const crmRouter = {
 				throw new Error("Next stage not found");
 			}
 
-			// Update opportunity stage if approved
-			const newStageId = input.approved
-				? nextStage[0].id
-				: opportunity[0].stageId;
+			// Get the previous stage (20% - Solución y propuesta) for rejection
+			const previousStage = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.name, "Solución y propuesta"))
+				.limit(1);
 
-			if (input.approved || input.reason) {
-				// Update opportunity
+			if (!previousStage[0]) {
+				throw new Error("Previous stage (Solución y propuesta) not found");
+			}
+
+			// Determine new stage based on approval/rejection
+			const newStageId = input.approved
+				? nextStage[0].id // 40% - Cierre de propuesta
+				: previousStage[0].id; // 20% - Solución y propuesta (rejection)
+
+			if (input.approved || input.reason || !input.approved) {
+				// Update opportunity with analysisStatus
 				await db
 					.update(opportunities)
 					.set({
 						stageId: newStageId,
+						analysisStatus: input.approved ? "approved" : "rejected",
+						analysisRejectionCount: input.approved
+							? opportunity[0].analysisRejectionCount
+							: opportunity[0].analysisRejectionCount + 1,
+						lastAnalysisRejectedAt: input.approved ? null : new Date(),
+						lastAnalysisRejectedBy: input.approved ? null : context.userId,
 						notes: input.reason
 							? `${opportunity[0].notes || ""}\n\n[Análisis ${input.approved ? "Aprobado" : "Rechazado"}]: ${input.reason}`
 							: opportunity[0].notes,
@@ -1450,7 +1510,7 @@ export const crmRouter = {
 						input.reason ||
 						(input.approved
 							? "Documentación aprobada"
-							: "Documentación rechazada"),
+							: "Documentación rechazada - movida a etapa 20%"),
 					isOverride: false,
 				});
 			}

--- a/apps/crm/apps/web/src/routes/crm/analysis.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis.tsx
@@ -4,6 +4,7 @@ import {
 	AlertCircle,
 	CheckCircle,
 	FileText,
+	RefreshCw,
 	Wallet,
 	XCircle,
 } from "lucide-react";
@@ -381,6 +382,7 @@ function AnalysisPage() {
 									<TableHeader>
 										<TableRow>
 											<TableHead>Título</TableHead>
+											<TableHead>Estado</TableHead>
 											<TableHead>Lead</TableHead>
 											<TableHead>Empresa</TableHead>
 											<TableHead>Valor</TableHead>
@@ -401,6 +403,18 @@ function AnalysisPage() {
 													>
 														{opportunity.title}
 													</button>
+												</TableCell>
+												<TableCell>
+													{opportunity.analysisStatus === "resubmitted" ? (
+														<Badge className="border-orange-300 bg-orange-100 text-orange-700">
+															<RefreshCw className="mr-1 h-3 w-3" />
+															Reenviado ({opportunity.analysisRejectionCount}x)
+														</Badge>
+													) : (
+														<Badge className="border-green-300 bg-green-100 text-green-700">
+															Nueva
+														</Badge>
+													)}
 												</TableCell>
 												<TableCell>
 													{opportunity.lead ? (

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -20,11 +20,13 @@ import {
 	History,
 	Mail,
 	Plus,
+	RefreshCw,
 	Target,
 	Trash2,
 	TrendingUp,
 	Upload,
 	Users,
+	XCircle,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -160,7 +162,23 @@ function DraggableOpportunityCard({
 						);
 					}
 					return null;
-				})()} {opportunity.expectedCloseDate && (
+				})()}
+				{opportunity.analysisStatus === "rejected" && (
+					<Badge variant="destructive" className="text-xs">
+						<XCircle className="mr-1 h-3 w-3" />
+						Análisis Rechazado
+					</Badge>
+				)}
+				{opportunity.analysisStatus === "resubmitted" && (
+					<Badge
+						variant="outline"
+						className="border-blue-300 bg-blue-50 text-blue-700 text-xs"
+					>
+						<RefreshCw className="mr-1 h-3 w-3" />
+						Reenviado a Análisis
+					</Badge>
+				)}
+				{opportunity.expectedCloseDate && (
 					<div className="flex items-center gap-1 text-muted-foreground text-xs">
 						<Calendar className="h-3 w-3" />
 						{formatDate(opportunity.expectedCloseDate)}


### PR DESCRIPTION
## Resumen
- Agregar enum analysisStatus con estados: not_applicable, pending, rejected, resubmitted, approved
- Agregar campos analysisRejectionCount, lastAnalysisRejectedAt, lastAnalysisRejectedBy a tabla opportunities
- Al rechazar análisis, mover oportunidad a etapa 20% (Solución y propuesta)
- Detectar transiciones a etapa 30% y actualizar analysisStatus automáticamente
- Mostrar badge rojo "Análisis Rechazado" para vendedor
- Mostrar badge "Reenviado (Nx)" para analista con contador de rechazos

## Test plan
- [ ] Crear oportunidad y moverla a 30%, verificar analysisStatus = pending
- [ ] Rechazar desde análisis, verificar que se mueve a 20% y analysisStatus = rejected
- [ ] Verificar que el vendedor ve el badge rojo
- [ ] Mover oportunidad rechazada de 20% a 30%, verificar analysisStatus = resubmitted
- [ ] Verificar que el analista ve "Reenviado (1x)"
- [ ] Aprobar oportunidad, verificar analysisStatus = approved