### PR TITLE
feat(crm): add PDF upload functionality and link to legal contracts

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0012_add_pdf_link_to_legal_contracts.sql
+++ b/apps/crm/apps/server/src/db/migrations/0012_add_pdf_link_to_legal_contracts.sql
@@ -1,0 +1,2 @@
+-- Migration: Add pdfLink column to generated_legal_contracts table
+ALTER TABLE "generated_legal_contracts" ADD COLUMN "pdf_link" text;

--- a/apps/crm/apps/server/src/db/schema/legal-contracts.ts
+++ b/apps/crm/apps/server/src/db/schema/legal-contracts.ts
@@ -37,6 +37,7 @@ export const generatedLegalContracts = pgTable("generated_legal_contracts", {
 	clientSigningLink: text("client_signing_link"), // Link del cliente
 	representativeSigningLink: text("representative_signing_link"), // Link del representante
 	additionalSigningLinks: text("additional_signing_links").array(), // Links adicionales si aplica
+	pdfLink: text("pdf_link"), // Link del PDF subido a R2 (opcional)
 
 	// Metadata de generación
 	templateId: integer("template_id"),

--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -110,7 +110,7 @@ export const legalContractsRouter = {
 				const { key } = await uploadFileToR2(
 					fileBlob,
 					uniqueFilename,
-					`legal-contracts/${input.leadId}`,
+					`legal-contracts/${input.opportunityId || input.leadId}`,
 				);
 
 				pdfLink = await getFileUrl(key);

--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -2,6 +2,12 @@ import { ORPCError } from "@orpc/server";
 import { and, count, eq, inArray, ne } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
+import {
+	generateUniqueFilename,
+	getFileUrl,
+	uploadFileToR2,
+	validateFile,
+} from "../lib/storage";
 import { user } from "../db/schema/auth";
 import {
 	leads,
@@ -34,6 +40,14 @@ export const legalContractsRouter = {
 				templateId: z.number().optional(),
 				apiResponse: z.any().optional(),
 				opportunityId: z.string().uuid().optional(),
+				pdfFile: z
+					.object({
+						name: z.string(),
+						type: z.string(),
+						size: z.number(),
+						data: z.string(), // Base64
+					})
+					.optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -75,11 +89,40 @@ export const legalContractsRouter = {
 				}
 			}
 
-			// Crear el contrato
+			// Subir PDF si se proporciona
+			let pdfLink: string | undefined;
+			if (input.pdfFile) {
+				const validation = validateFile({
+					type: input.pdfFile.type,
+					size: input.pdfFile.size,
+				} as File);
+
+				if (!validation.valid) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: validation.error || "Archivo inválido",
+					});
+				}
+
+				const fileBuffer = Buffer.from(input.pdfFile.data, "base64");
+				const fileBlob = new Blob([fileBuffer], { type: input.pdfFile.type });
+				const uniqueFilename = generateUniqueFilename(input.pdfFile.name);
+
+				const { key } = await uploadFileToR2(
+					fileBlob,
+					uniqueFilename,
+					`legal-contracts/${input.leadId}`,
+				);
+
+				pdfLink = await getFileUrl(key);
+			}
+
+			// Crear el contrato (sin incluir pdfFile en los valores)
+			const { pdfFile: _, ...contractData } = input;
 			const [newContract] = await db
 				.insert(generatedLegalContracts)
 				.values({
-					...input,
+					...contractData,
+					pdfLink,
 					generatedBy: context.userId,
 					generatedAt: new Date(),
 				})
@@ -98,6 +141,14 @@ export const legalContractsRouter = {
 				clientSigningLink: z.string().url().optional().nullable(),
 				representativeSigningLink: z.string().url().optional().nullable(),
 				additionalSigningLinks: z.array(z.string().url()).optional().nullable(),
+				pdfFile: z
+					.object({
+						name: z.string(),
+						type: z.string(),
+						size: z.number(),
+						data: z.string(), // Base64
+					})
+					.optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -121,6 +172,33 @@ export const legalContractsRouter = {
 				});
 			}
 
+			// Subir PDF si se proporciona
+			let pdfLink: string | undefined;
+			if (input.pdfFile) {
+				const validation = validateFile({
+					type: input.pdfFile.type,
+					size: input.pdfFile.size,
+				} as File);
+
+				if (!validation.valid) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: validation.error || "Archivo inválido",
+					});
+				}
+
+				const fileBuffer = Buffer.from(input.pdfFile.data, "base64");
+				const fileBlob = new Blob([fileBuffer], { type: input.pdfFile.type });
+				const uniqueFilename = generateUniqueFilename(input.pdfFile.name);
+
+				const { key } = await uploadFileToR2(
+					fileBlob,
+					uniqueFilename,
+					`legal-contracts/${existingContract.leadId}`,
+				);
+
+				pdfLink = await getFileUrl(key);
+			}
+
 			// Actualizar el contrato
 			const [updatedContract] = await db
 				.update(generatedLegalContracts)
@@ -130,6 +208,7 @@ export const legalContractsRouter = {
 					clientSigningLink: input.clientSigningLink,
 					representativeSigningLink: input.representativeSigningLink,
 					additionalSigningLinks: input.additionalSigningLinks,
+					...(pdfLink && { pdfLink }),
 					updatedAt: new Date(),
 				})
 				.where(eq(generatedLegalContracts.id, input.id))

--- a/apps/crm/apps/web/src/components/juridico/ContractCard.tsx
+++ b/apps/crm/apps/web/src/components/juridico/ContractCard.tsx
@@ -40,6 +40,7 @@ interface ContractCardProps {
 		clientSigningLink: string | null;
 		representativeSigningLink: string | null;
 		additionalSigningLinks: string[] | null;
+		pdfLink?: string | null;
 		status: "pending" | "signed" | "cancelled";
 		generatedAt: Date | string;
 		opportunityId: string | null;
@@ -249,6 +250,38 @@ export function ContractCard({
 									</div>
 								</div>
 							))}
+					</div>
+				)}
+
+				{/* PDF del contrato */}
+				{contract.pdfLink && (
+					<div className="rounded-lg border border-border bg-amber-50/50 p-3">
+						<div className="flex items-center justify-between gap-2">
+							<p className="font-medium text-amber-900 text-sm">
+								📄 Documento PDF
+							</p>
+							<div className="flex gap-1">
+								<Button
+									size="sm"
+									variant="outline"
+									className="h-7"
+									onClick={() => openLink(contract.pdfLink!)}
+								>
+									<ExternalLink className="mr-1 h-3 w-3" />
+									Ver PDF
+								</Button>
+								<Button
+									size="sm"
+									variant="ghost"
+									className="h-7 px-2"
+									onClick={() =>
+										copyToClipboard(contract.pdfLink!, "Link del PDF")
+									}
+								>
+									<Copy className="h-3 w-3" />
+								</Button>
+							</div>
+						</div>
 					</div>
 				)}
 			</CardContent>

--- a/apps/crm/apps/web/src/components/juridico/ContractsList.tsx
+++ b/apps/crm/apps/web/src/components/juridico/ContractsList.tsx
@@ -8,6 +8,7 @@ interface Contract {
 	clientSigningLink: string | null;
 	representativeSigningLink: string | null;
 	additionalSigningLinks: string[] | null;
+	pdfLink?: string | null;
 	status: "pending" | "signed" | "cancelled";
 	generatedAt: Date | string;
 	opportunityId: string | null;

--- a/apps/crm/apps/web/src/components/juridico/CreateContractModal.tsx
+++ b/apps/crm/apps/web/src/components/juridico/CreateContractModal.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { Loader2, Plus, X } from "lucide-react";
+import { FileUp, Loader2, Plus, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -75,6 +75,10 @@ const CONTRACT_TYPES = [
 		enum: "contrato_privado_uso_carro_usado",
 		label: "Contrato Privado Uso Carro Usado",
 	},
+	{
+		enum: "otro",
+		label: "Otro (especificar en el nombre)",
+	},
 ] as const;
 
 interface CreateContractModalProps {
@@ -93,6 +97,7 @@ interface CreateContractModalProps {
 		representativeSigningLink: string | null;
 		additionalSigningLinks: string[] | null;
 		opportunityId: string | null;
+		pdfLink?: string | null;
 	};
 	/** Opportunity info (for display when editing) */
 	opportunityInfo?: {
@@ -125,6 +130,7 @@ export function CreateContractModal({
 	});
 
 	const [newAdditionalLink, setNewAdditionalLink] = useState("");
+	const [selectedPdfFile, setSelectedPdfFile] = useState<File | null>(null);
 
 	// Actualizar opportunityId cuando cambia preselectedOpportunityId
 	useEffect(() => {
@@ -167,6 +173,12 @@ export function CreateContractModal({
 			representativeSigningLink?: string;
 			additionalSigningLinks?: string[];
 			opportunityId?: string;
+			pdfFile?: {
+				name: string;
+				type: string;
+				size: number;
+				data: string;
+			};
 		}) => {
 			if (values.id) {
 				// Editar contrato existente
@@ -177,6 +189,7 @@ export function CreateContractModal({
 					clientSigningLink: values.clientSigningLink || null,
 					representativeSigningLink: values.representativeSigningLink || null,
 					additionalSigningLinks: values.additionalSigningLinks || null,
+					pdfFile: values.pdfFile,
 				});
 			}
 			// Crear nuevo contrato
@@ -209,6 +222,12 @@ export function CreateContractModal({
 			opportunityId: preselectedOpportunityId || "",
 		});
 		setNewAdditionalLink("");
+		setSelectedPdfFile(null);
+		// Reset file input
+		const fileInput = document.getElementById(
+			"pdf-file-input",
+		) as HTMLInputElement;
+		if (fileInput) fileInput.value = "";
 	};
 
 	const handleAddAdditionalLink = () => {
@@ -233,7 +252,22 @@ export function CreateContractModal({
 		}));
 	};
 
-	const handleSubmit = (e: React.FormEvent) => {
+	const handlePdfFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (file) {
+			if (file.size > 10 * 1024 * 1024) {
+				toast.error("El archivo debe ser menor a 10MB");
+				return;
+			}
+			if (file.type !== "application/pdf") {
+				toast.error("Solo se permiten archivos PDF");
+				return;
+			}
+			setSelectedPdfFile(file);
+		}
+	};
+
+	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
 
 		// Validaciones
@@ -250,6 +284,28 @@ export function CreateContractModal({
 			return;
 		}
 
+		// Preparar archivo PDF si existe
+		let pdfFileData: { name: string; type: string; size: number; data: string } | undefined;
+		if (selectedPdfFile) {
+			const base64 = await new Promise<string>((resolve, reject) => {
+				const reader = new FileReader();
+				reader.onloadend = () => {
+					const result = reader.result as string;
+					const base64Data = result.split(",")[1];
+					resolve(base64Data);
+				};
+				reader.onerror = reject;
+				reader.readAsDataURL(selectedPdfFile);
+			});
+
+			pdfFileData = {
+				name: selectedPdfFile.name,
+				type: selectedPdfFile.type,
+				size: selectedPdfFile.size,
+				data: base64,
+			};
+		}
+
 		createMutation.mutate({
 			...(isEditing && contractToEdit ? { id: contractToEdit.id } : {}),
 			leadId,
@@ -263,6 +319,7 @@ export function CreateContractModal({
 					? formData.additionalSigningLinks
 					: undefined,
 			opportunityId: formData.opportunityId || undefined,
+			pdfFile: pdfFileData,
 		});
 	};
 
@@ -464,6 +521,60 @@ export function CreateContractModal({
 										</div>
 									))}
 								</div>
+							)}
+						</div>
+
+						{/* Subir documento PDF */}
+						<div className="space-y-2 rounded-lg border bg-muted/30 p-4">
+							<div className="flex items-center gap-2">
+								<FileUp className="h-4 w-4 text-muted-foreground" />
+								<Label htmlFor="pdf-file-input">
+									Subir documento si no se ha generado link o es necesario
+								</Label>
+							</div>
+							<input
+								id="pdf-file-input"
+								type="file"
+								accept=".pdf"
+								onChange={handlePdfFileChange}
+								className="h-10 w-full rounded-md border bg-background px-3 py-2 text-sm file:border-0 file:bg-transparent file:font-medium file:text-sm"
+								disabled={createMutation.isPending}
+							/>
+							{selectedPdfFile && (
+								<div className="flex items-center justify-between rounded-md border border-border bg-muted/50 p-2">
+									<p className="text-muted-foreground text-xs">
+										Seleccionado: {selectedPdfFile.name} (
+										{(selectedPdfFile.size / 1024).toFixed(1)} KB)
+									</p>
+									<Button
+										type="button"
+										variant="ghost"
+										size="sm"
+										onClick={() => {
+											setSelectedPdfFile(null);
+											const fileInput = document.getElementById(
+												"pdf-file-input",
+											) as HTMLInputElement;
+											if (fileInput) fileInput.value = "";
+										}}
+										disabled={createMutation.isPending}
+									>
+										<X className="h-4 w-4" />
+									</Button>
+								</div>
+							)}
+							{isEditing && contractToEdit?.pdfLink && !selectedPdfFile && (
+								<p className="text-muted-foreground text-xs">
+									Ya tiene un PDF subido.{" "}
+									<a
+										href={contractToEdit.pdfLink}
+										target="_blank"
+										rel="noopener noreferrer"
+										className="text-primary underline"
+									>
+										Ver documento actual
+									</a>
+								</p>
 							)}
 						</div>
 					</div>

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -12,6 +12,7 @@ import {
 	ExternalLink,
 	FileSignature,
 	FileSpreadsheet,
+	FileText,
 	History,
 	Mail,
 	Target,
@@ -450,6 +451,19 @@ export function OpportunityDetailModal({
 												</div>
 
 												<div className="flex gap-2">
+													{contract.pdfLink && (
+														<Button variant="outline" size="sm" asChild>
+															<a
+																href={contract.pdfLink}
+																target="_blank"
+																rel="noopener noreferrer"
+																className="flex items-center gap-1"
+															>
+																<FileText className="h-3 w-3" />
+																PDF
+															</a>
+														</Button>
+													)}
 													{contract.clientSigningLink && (
 														<Button variant="outline" size="sm" asChild>
 															<a

--- a/apps/crm/apps/web/src/routes/crm/analysis.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis.tsx
@@ -564,7 +564,7 @@ function AnalysisPage() {
 				open={isDocumentsDialogOpen}
 				onOpenChange={setIsDocumentsDialogOpen}
 			>
-				<DialogContent className="max-h-[90vh] min-w-[80vw] max-w-6xl overflow-y-auto">
+				<DialogContent className="max-h-[90vh] min-w-[60vw] max-w-6xl overflow-y-auto">
 					<DialogHeader>
 						<DialogTitle>Documentos de la Oportunidad</DialogTitle>
 						{selectedOpportunityForDocs && (

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -2170,6 +2170,23 @@ function RouteComponent() {
 																		</span>
 																	</div>
 																	<div className="flex gap-2">
+																		{contract.pdfLink && (
+																			<Button
+																				variant="outline"
+																				size="sm"
+																				asChild
+																			>
+																				<a
+																					href={contract.pdfLink}
+																					target="_blank"
+																					rel="noopener noreferrer"
+																					className="flex items-center gap-1"
+																				>
+																					<FileText className="h-3 w-3" />
+																					PDF
+																				</a>
+																			</Button>
+																		)}
 																		{contract.clientSigningLink && (
 																			<Button
 																				variant="outline"

--- a/apps/crm/apps/web/src/routes/juridico/$leadId.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/$leadId.tsx
@@ -53,6 +53,7 @@ function RouteComponent() {
 		clientSigningLink: string | null;
 		representativeSigningLink: string | null;
 		additionalSigningLinks: string[] | null;
+		pdfLink?: string | null;
 		opportunityId: string | null;
 	} | null>(null);
 	const [opportunityInfo, setOpportunityInfo] = useState<{
@@ -123,6 +124,7 @@ function RouteComponent() {
 			clientSigningLink: string | null;
 			representativeSigningLink: string | null;
 			additionalSigningLinks: string[] | null;
+			pdfLink?: string | null;
 			opportunityId: string | null;
 		},
 		opportunity?: { id: string; title: string; value: string | null } | null,


### PR DESCRIPTION
This pull request adds support for uploading, storing, and displaying a PDF document associated with each legal contract in the CRM system. It introduces backend changes to handle PDF upload and storage, updates the database schema, and enhances the frontend to allow users to upload a PDF when creating or editing a contract, as well as view or download the PDF from various UI components.

**Backend: PDF Upload and Storage**

- Added a new `pdf_link` column to the `generated_legal_contracts` table to store the URL of the uploaded PDF.
- Updated backend logic in `legal-contracts.ts` to accept an optional `pdfFile` object, validate and upload the PDF to R2 storage, and save the resulting URL in the `pdf_link` column during contract creation and update. [[1]](diffhunk://#diff-18e745f4714cb36710d37a654910ec85bbbdd99b1075e095c7ac09e02b5840faR43-R50) [[2]](diffhunk://#diff-18e745f4714cb36710d37a654910ec85bbbdd99b1075e095c7ac09e02b5840faL78-R125) [[3]](diffhunk://#diff-18e745f4714cb36710d37a654910ec85bbbdd99b1075e095c7ac09e02b5840faR144-R151) [[4]](diffhunk://#diff-18e745f4714cb36710d37a654910ec85bbbdd99b1075e095c7ac09e02b5840faR175-R201) [[5]](diffhunk://#diff-18e745f4714cb36710d37a654910ec85bbbdd99b1075e095c7ac09e02b5840faR211)
- Updated the database schema definition in `legal-contracts.ts` to include the new `pdfLink` field.

**Frontend: Contract PDF Upload and Display**

- Enhanced the contract creation and editing modal (`CreateContractModal.tsx`) to allow users to upload a PDF file, with validation for file type and size, and reset logic for the file input. The selected file is encoded and sent to the backend. [[1]](diffhunk://#diff-f197b5e4b0529aeb804114448f195d2a1da552d57fbbe9b00bcef02406decd1dL2-R2) [[2]](diffhunk://#diff-f197b5e4b0529aeb804114448f195d2a1da552d57fbbe9b00bcef02406decd1dR133) [[3]](diffhunk://#diff-f197b5e4b0529aeb804114448f195d2a1da552d57fbbe9b00bcef02406decd1dL236-R270) [[4]](diffhunk://#diff-f197b5e4b0529aeb804114448f195d2a1da552d57fbbe9b00bcef02406decd1dR287-R308) [[5]](diffhunk://#diff-f197b5e4b0529aeb804114448f195d2a1da552d57fbbe9b00bcef02406decd1dR322) [[6]](diffhunk://#diff-f197b5e4b0529aeb804114448f195d2a1da552d57fbbe9b00bcef02406decd1dR526-R579)
- Updated contract-related TypeScript interfaces across multiple files to include the optional `pdfLink` property. [[1]](diffhunk://#diff-437c3b189369869febf0f1db869a6db5a2c06a055ca48f33dda71cbc720f7aa4R43) [[2]](diffhunk://#diff-8b38d106818dce28527fe7d2389354b403e3ec69882cf2a1f9520be7542e598bR11) [[3]](diffhunk://#diff-f197b5e4b0529aeb804114448f195d2a1da552d57fbbe9b00bcef02406decd1dR100) [[4]](diffhunk://#diff-6a60efdce277f57181418d8d3a75fa6c969e0df6571f86f88190228783b72fd4R56) [[5]](diffhunk://#diff-6a60efdce277f57181418d8d3a75fa6c969e0df6571f86f88190228783b72fd4R127)

**Frontend: PDF Viewing in UI**

- Added UI elements in `ContractCard.tsx` to show a button for viewing or copying the PDF link when available.
- Added a button to view/download the PDF in contract lists and opportunity detail modals (`opportunity-detail-modal.tsx`, `opportunities.tsx`). [[1]](diffhunk://#diff-861e1ed99559c57e22c9a45f02235c2b37b1160d5e7da5e43337c42594283afeR15) [[2]](diffhunk://#diff-861e1ed99559c57e22c9a45f02235c2b37b1160d5e7da5e43337c42594283afeR454-R466) [[3]](diffhunk://#diff-9fe13c3956eb5c7895ba04bbe346e1794560a4d38af5f8459edc9069d1686193R2173-R2189)

**Other UI/UX Improvements**

- Added a new contract type option "Otro (especificar en el nombre)" to the contract type selector.
- Adjusted the width of the documents dialog in the analysis page for better usability.

These changes collectively enable users to associate a PDF document with each contract, improving document management and accessibility throughout the CRM.