### PR TITLE
Removes validation for credit detail approval

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1673,56 +1673,6 @@ export const crmRouter = {
 				throw new Error("El detalle de crédito ya fue aprobado");
 			}
 
-			// Validar que los campos requeridos estén llenos
-			const camposFaltantes: string[] = [];
-
-			if (!opportunity.categoria) {
-				camposFaltantes.push("Categoría");
-			}
-			if (!opportunity.nit) {
-				camposFaltantes.push("NIT");
-			}
-			if (!opportunity.diaPagoMensual) {
-				camposFaltantes.push("Día de pago mensual");
-			}
-
-			// Validar dirección desde el lead
-			if (opportunity.leadId) {
-				const [leadData] = await db
-					.select({ direccion: leads.direccion })
-					.from(leads)
-					.where(eq(leads.id, opportunity.leadId))
-					.limit(1);
-				if (!leadData?.direccion) {
-					camposFaltantes.push("Dirección");
-				}
-			} else {
-				camposFaltantes.push("Lead/Dirección");
-			}
-
-			// Validar inversionistas
-			if (!opportunity.inversionistas) {
-				camposFaltantes.push("Inversionistas");
-			} else {
-				try {
-					const inversionistasParsed = JSON.parse(opportunity.inversionistas);
-					if (
-						!Array.isArray(inversionistasParsed) ||
-						inversionistasParsed.length === 0
-					) {
-						camposFaltantes.push("Inversionistas");
-					}
-				} catch {
-					camposFaltantes.push("Inversionistas (formato inválido)");
-				}
-			}
-
-			if (camposFaltantes.length > 0) {
-				throw new Error(
-					`Faltan campos requeridos para aprobar: ${camposFaltantes.join(", ")}. Guarde los cambios primero.`,
-				);
-			}
-
 			// Update opportunity with approval
 			await db
 				.update(opportunities)

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1673,10 +1673,21 @@ export const crmRouter = {
 				throw new Error("El detalle de crédito ya fue aprobado");
 			}
 
+			const nextStage = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.order, 6)) // "Formalización" 50%
+				.limit(1);
+			
+			if (!nextStage[0]) {
+				throw new Error("Next stage not found");
+			}
+
 			// Update opportunity with approval
 			await db
 				.update(opportunities)
 				.set({
+					stageId: nextStage[0].id,
 					creditDetailApproved: true,
 					creditDetailApprovedBy: context.userId,
 					creditDetailApprovedAt: new Date(),

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -559,12 +559,12 @@ export function CreditDetailView({
 	// Mutation para aprobar detalle de crédito
 	const approveCreditDetailMutation = useMutation({
 		mutationFn: async () => {
-			const camposFaltantes = validateRequiredFields();
+		    /*const camposFaltantes = validateRequiredFields();
 			if (camposFaltantes.length > 0) {
 				throw new Error(
 					`Faltan campos requeridos: ${camposFaltantes.join(", ")}. Guarde los cambios primero.`,
 				);
-			}
+			}*/
 
 			// Actualizar el value de la oportunidad con el totalFinanced de la cotización
 			if (


### PR DESCRIPTION
This pull request simplifies the credit detail approval process by removing client-side and server-side validation of required fields before approval. Instead, the process now only checks for the existence of the next sales stage before proceeding with approval. This change streamlines the workflow but reduces validation on both the backend and frontend.

**Backend validation removal:**
- Removed all required field checks (such as `Categoría`, `NIT`, `Día de pago mensual`, `Dirección`, and `Inversionistas`) before approving a credit detail in `crm.ts`. The approval now only verifies the existence of the next sales stage and updates the opportunity accordingly.

**Frontend validation removal:**
- Commented out the call to `validateRequiredFields()` in the credit detail approval mutation in `CreditDetailView.tsx`, so required fields are no longer checked on the client side before attempting approval.