### PR TITLE
feat(crm): revoke credit detail approval + misc fixes

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1308,8 +1308,21 @@ export const crmRouter = {
 		}),
 
 	// Analyst specific endpoints
-	getOpportunitiesForAnalysis: analystProcedure.handler(
-		async ({ context: _ }) => {
+	getOpportunitiesForAnalysis: analystProcedure
+		.input(
+			z
+				.object({
+					limit: z.number().min(1).max(100).default(20),
+					offset: z.number().min(0).default(0),
+					search: z.string().optional(),
+				})
+				.optional(),
+		)
+		.handler(async ({ input }) => {
+			const limit = input?.limit ?? 20;
+			const offset = input?.offset ?? 0;
+			const search = input?.search;
+
 			// Get the stage ID for "Recepción de documentación y traslado a análisis"
 			const analysisStage = await db
 				.select()
@@ -1326,8 +1339,37 @@ export const crmRouter = {
 				throw new Error("Analysis stage not found");
 			}
 
-			// Get all opportunities in the analysis stage
-			return await db
+			// Build conditions
+			const conditions = [eq(opportunities.stageId, analysisStage[0].id)];
+
+			// Search filter (name, license plate)
+			if (search && search.trim() !== "") {
+				const searchTerms = search.trim().split(/\s+/);
+				for (const term of searchTerms) {
+					const searchPattern = `%${term}%`;
+					conditions.push(
+						or(
+							ilike(leads.firstName, searchPattern),
+							ilike(leads.lastName, searchPattern),
+							ilike(vehicles.licensePlate, searchPattern),
+						)!,
+					);
+				}
+			}
+
+			// conditions always has at least one element (stageId condition)
+			const whereClause = and(...conditions)!;
+
+			// Get total count
+			const [{ total }] = await db
+				.select({ total: count() })
+				.from(opportunities)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+				.where(whereClause);
+
+			// Get paginated data
+			const data = await db
 				.select({
 					id: opportunities.id,
 					title: opportunities.title,
@@ -1372,10 +1414,18 @@ export const crmRouter = {
 				.leftJoin(companies, eq(opportunities.companyId, companies.id))
 				.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 				.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
-				.where(eq(opportunities.stageId, analysisStage[0].id))
-				.orderBy(opportunities.createdAt);
-		},
-	),
+				.where(whereClause)
+				.orderBy(opportunities.createdAt)
+				.limit(limit)
+				.offset(offset);
+
+			return {
+				data,
+				total,
+				limit,
+				offset,
+			};
+		}),
 
 	approveOpportunityAnalysis: analystProcedure
 		.input(
@@ -1682,7 +1732,7 @@ export const crmRouter = {
 				.from(salesStages)
 				.where(eq(salesStages.order, 6)) // "Formalización" 50%
 				.limit(1);
-			
+
 			if (!nextStage[0]) {
 				throw new Error("Next stage not found");
 			}
@@ -1698,6 +1748,106 @@ export const crmRouter = {
 					updatedAt: new Date(),
 				})
 				.where(eq(opportunities.id, input.opportunityId));
+
+			// Record stage history
+			await db.insert(opportunityStageHistory).values({
+				opportunityId: input.opportunityId,
+				fromStageId: opportunity.stageId,
+				toStageId: nextStage[0].id,
+				changedBy: context.userId,
+				reason: "Detalle de crédito aprobado - Movido a Formalización (50%)",
+				isOverride: false,
+			});
+
+			return { success: true };
+		}),
+
+	// Revoke credit detail approval (back to 40%)
+	revokeCreditDetailApproval: crmProcedure
+		.input(
+			z.object({
+				opportunityId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			// Only admin or sales_supervisor can revoke
+			if (!PERMISSIONS.canApproveCreditDetail(context.userRole)) {
+				throw new Error(
+					"Solo supervisores de ventas o administradores pueden cancelar la aprobación",
+				);
+			}
+
+			// Get current opportunity with stage info
+			const [opportunity] = await db
+				.select({
+					id: opportunities.id,
+					stageId: opportunities.stageId,
+					creditDetailApproved: opportunities.creditDetailApproved,
+				})
+				.from(opportunities)
+				.where(eq(opportunities.id, input.opportunityId))
+				.limit(1);
+
+			if (!opportunity) {
+				throw new Error("Oportunidad no encontrada");
+			}
+
+			// Validate that it's approved
+			if (!opportunity.creditDetailApproved) {
+				throw new Error("El detalle de crédito no está aprobado");
+			}
+
+			// Get current stage to check closure percentage
+			const [currentStage] = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.id, opportunity.stageId))
+				.limit(1);
+
+			if (!currentStage) {
+				throw new Error("Etapa actual no encontrada");
+			}
+
+			// Cannot revoke if at 90% or higher (already sent to cartera)
+			if (currentStage.closurePercentage >= 90) {
+				throw new Error(
+					"No se puede cancelar la aprobación de una oportunidad que ya fue enviada a cartera",
+				);
+			}
+
+			// Get stage 40% (Cierre de propuesta)
+			const [previousStage] = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.order, 5)) // Order 5 = 40% - Cierre de propuesta
+				.limit(1);
+
+			if (!previousStage) {
+				throw new Error("Etapa anterior no encontrada");
+			}
+
+			// Update opportunity - revoke approval
+			await db
+				.update(opportunities)
+				.set({
+					stageId: previousStage.id,
+					creditDetailApproved: false,
+					creditDetailApprovedBy: null,
+					creditDetailApprovedAt: null,
+					updatedAt: new Date(),
+				})
+				.where(eq(opportunities.id, input.opportunityId));
+
+			// Record stage history
+			await db.insert(opportunityStageHistory).values({
+				opportunityId: input.opportunityId,
+				fromStageId: opportunity.stageId,
+				toStageId: previousStage.id,
+				changedBy: context.userId,
+				reason:
+					"Aprobación de detalle cancelada - Regresado a Cierre de propuesta (40%)",
+				isOverride: false,
+			});
 
 			return { success: true };
 		}),
@@ -3750,88 +3900,145 @@ export const crmRouter = {
 		}),
 
 	// Get opportunities at 90% for disbursement review
-	getOpportunitiesForDisbursement: analystProcedure.handler(async () => {
-		// Get the 90% stage
-		const [stage90] = await db
-			.select()
-			.from(salesStages)
-			.where(eq(salesStages.closurePercentage, 90))
-			.limit(1);
+	getOpportunitiesForDisbursement: analystProcedure
+		.input(
+			z
+				.object({
+					limit: z.number().min(1).max(100).default(20),
+					offset: z.number().min(0).default(0),
+					search: z.string().optional(),
+				})
+				.optional(),
+		)
+		.handler(async ({ input }) => {
+			const limit = input?.limit ?? 20;
+			const offset = input?.offset ?? 0;
+			const search = input?.search;
 
-		if (!stage90) {
-			return [];
-		}
+			// Get the 90% stage
+			const [stage90] = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.closurePercentage, 90))
+				.limit(1);
 
-		// Get opportunities at 90%
-		const opps = await db
-			.select({
-				id: opportunities.id,
-				value: opportunities.value,
-				stageId: opportunities.stageId,
-				disbursementApproved: opportunities.disbursementApproved,
-				leadId: opportunities.leadId,
-				vehicleId: opportunities.vehicleId,
-				createdAt: opportunities.createdAt,
-				updatedAt: opportunities.updatedAt,
-			})
-			.from(opportunities)
-			.where(eq(opportunities.stageId, stage90.id))
-			.orderBy(desc(opportunities.updatedAt));
+			if (!stage90) {
+				return { data: [], total: 0, limit, offset };
+			}
 
-		// Get lead info for each opportunity
-		const result = await Promise.all(
-			opps.map(async (opp) => {
-				let lead:
-					| { firstName: string; lastName: string; phone: string | null }
-					| undefined;
-				if (opp.leadId) {
-					const [leadResult] = await db
-						.select({
-							firstName: leads.firstName,
-							lastName: leads.lastName,
-							phone: leads.phone,
-						})
-						.from(leads)
-						.where(eq(leads.id, opp.leadId))
-						.limit(1);
-					lead = leadResult;
+			// Build conditions
+			const conditions = [eq(opportunities.stageId, stage90.id)];
+
+			// Search filter (name, license plate)
+			if (search && search.trim() !== "") {
+				const searchTerms = search.trim().split(/\s+/);
+				for (const term of searchTerms) {
+					const searchPattern = `%${term}%`;
+					conditions.push(
+						or(
+							ilike(leads.firstName, searchPattern),
+							ilike(leads.lastName, searchPattern),
+							ilike(vehicles.licensePlate, searchPattern),
+						)!,
+					);
 				}
+			}
 
-				// Get vehicle info
-				let vehicle:
-					| {
-							id: string;
-							make: string;
-							model: string;
-							year: number;
-							licensePlate: string | null;
-							color: string;
-							isNew: boolean;
-					  }
-					| undefined;
-				if (opp.vehicleId) {
-					const [vehicleResult] = await db
-						.select({
-							id: vehicles.id,
-							make: vehicles.make,
-							model: vehicles.model,
-							year: vehicles.year,
-							licensePlate: vehicles.licensePlate,
-							color: vehicles.color,
-							isNew: vehicles.isNew,
-						})
-						.from(vehicles)
-						.where(eq(vehicles.id, opp.vehicleId))
-						.limit(1);
-					vehicle = vehicleResult;
-				}
+			// conditions always has at least one element (stageId condition)
+			const whereClause = and(...conditions)!;
 
-				// Get checklist status
-				const [checklist] = await db
-					.select()
-					.from(disbursementChecklists)
-					.where(eq(disbursementChecklists.opportunityId, opp.id))
-					.limit(1);
+			// Get total count
+			const [{ total }] = await db
+				.select({ total: count() })
+				.from(opportunities)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+				.where(whereClause);
+
+			// Get paginated opportunities at 90%
+			const opps = await db
+				.select({
+					id: opportunities.id,
+					value: opportunities.value,
+					stageId: opportunities.stageId,
+					disbursementApproved: opportunities.disbursementApproved,
+					leadId: opportunities.leadId,
+					vehicleId: opportunities.vehicleId,
+					createdAt: opportunities.createdAt,
+					updatedAt: opportunities.updatedAt,
+				})
+				.from(opportunities)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+				.where(whereClause)
+				.orderBy(desc(opportunities.updatedAt))
+				.limit(limit)
+				.offset(offset);
+
+			if (opps.length === 0) {
+				return { data: [], total, limit, offset };
+			}
+
+			// Batch fetch leads and vehicles to avoid N+1 queries
+			const leadIds = opps
+				.map((o) => o.leadId)
+				.filter((id): id is string => id !== null);
+			const vehicleIds = opps
+				.map((o) => o.vehicleId)
+				.filter((id): id is string => id !== null);
+			const oppIds = opps.map((o) => o.id);
+
+			// Fetch all leads in one query
+			const leadsData =
+				leadIds.length > 0
+					? await db
+							.select({
+								id: leads.id,
+								firstName: leads.firstName,
+								lastName: leads.lastName,
+								phone: leads.phone,
+							})
+							.from(leads)
+							.where(inArray(leads.id, leadIds))
+					: [];
+
+			// Fetch all vehicles in one query
+			const vehiclesData =
+				vehicleIds.length > 0
+					? await db
+							.select({
+								id: vehicles.id,
+								make: vehicles.make,
+								model: vehicles.model,
+								year: vehicles.year,
+								licensePlate: vehicles.licensePlate,
+								color: vehicles.color,
+								isNew: vehicles.isNew,
+							})
+							.from(vehicles)
+							.where(inArray(vehicles.id, vehicleIds))
+					: [];
+
+			// Fetch all checklists in one query
+			const checklistsData = await db
+				.select()
+				.from(disbursementChecklists)
+				.where(inArray(disbursementChecklists.opportunityId, oppIds));
+
+			// Create maps for quick lookup
+			const leadsMap = new Map(leadsData.map((l) => [l.id, l]));
+			const vehiclesMap = new Map(vehiclesData.map((v) => [v.id, v]));
+			const checklistsMap = new Map(
+				checklistsData.map((c) => [c.opportunityId, c]),
+			);
+
+			// Map results
+			const data = opps.map((opp) => {
+				const lead = opp.leadId ? leadsMap.get(opp.leadId) : undefined;
+				const vehicle = opp.vehicleId
+					? vehiclesMap.get(opp.vehicleId)
+					: undefined;
+				const checklist = checklistsMap.get(opp.id);
 
 				let progress = 0;
 				if (checklist) {
@@ -3848,7 +4055,14 @@ export const crmRouter = {
 				}
 
 				return {
-					...opp,
+					id: opp.id,
+					value: opp.value,
+					stageId: opp.stageId,
+					disbursementApproved: opp.disbursementApproved,
+					leadId: opp.leadId,
+					vehicleId: opp.vehicleId,
+					createdAt: opp.createdAt,
+					updatedAt: opp.updatedAt,
 					leadName: lead ? `${lead.firstName} ${lead.lastName}` : "N/A",
 					leadPhone: lead?.phone,
 					vehicle: vehicle || null,
@@ -3861,121 +4075,167 @@ export const crmRouter = {
 						color: stage90.color,
 					},
 				};
-			}),
-		);
+			});
 
-		return result;
-	}),
+			return { data, total, limit, offset };
+		}),
 
 	// Get opportunities at 50% for investment assignment
-	getOpportunitiesForInvestment: analystProcedure.handler(async () => {
-		// Get the 50% stage
-		const [stage50] = await db
-			.select()
-			.from(salesStages)
-			.where(eq(salesStages.closurePercentage, 50))
-			.limit(1);
+	getOpportunitiesForInvestment: analystProcedure
+		.input(
+			z
+				.object({
+					limit: z.number().min(1).max(100).default(20),
+					offset: z.number().min(0).default(0),
+					search: z.string().optional(),
+				})
+				.optional(),
+		)
+		.handler(async ({ input }) => {
+			const limit = input?.limit ?? 20;
+			const offset = input?.offset ?? 0;
+			const search = input?.search;
 
-		if (!stage50) {
-			return [];
-		}
+			// Get the 50% stage
+			const [stage50] = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.closurePercentage, 50))
+				.limit(1);
 
-		// Get opportunities at 50%
-		const opps = await db
-			.select({
-				id: opportunities.id,
-				title: opportunities.title,
-				value: opportunities.value,
-				stageId: opportunities.stageId,
-				inversionistas: opportunities.inversionistas,
-				leadId: opportunities.leadId,
-				vehicleId: opportunities.vehicleId,
-				numeroCuotas: opportunities.numeroCuotas,
-				tasaInteres: opportunities.tasaInteres,
-				cuotaMensual: opportunities.cuotaMensual,
-				createdAt: opportunities.createdAt,
-				updatedAt: opportunities.updatedAt,
-			})
-			.from(opportunities)
-			.where(eq(opportunities.stageId, stage50.id))
-			.orderBy(desc(opportunities.updatedAt));
+			if (!stage50) {
+				return { data: [], total: 0, limit, offset };
+			}
 
-		if (opps.length === 0) {
-			return [];
-		}
+			// Build conditions
+			const conditions = [eq(opportunities.stageId, stage50.id)];
 
-		// Batch fetch leads and vehicles to avoid N+1 queries
-		const leadIds = opps
-			.map((o) => o.leadId)
-			.filter((id): id is string => id !== null);
-		const vehicleIds = opps
-			.map((o) => o.vehicleId)
-			.filter((id): id is string => id !== null);
-
-		// Fetch all leads in one query
-		const leadsData =
-			leadIds.length > 0
-				? await db
-						.select({
-							id: leads.id,
-							firstName: leads.firstName,
-							lastName: leads.lastName,
-							phone: leads.phone,
-							dpi: leads.dpi,
-							direccion: leads.direccion,
-							maritalStatus: leads.maritalStatus,
-							gender: leads.gender,
-							birthDate: leads.birthDate,
-							nationality: leads.nationality,
-						})
-						.from(leads)
-						.where(inArray(leads.id, leadIds))
-				: [];
-
-		// Fetch all vehicles in one query
-		const vehiclesData =
-			vehicleIds.length > 0
-				? await db
-						.select({
-							id: vehicles.id,
-							make: vehicles.make,
-							model: vehicles.model,
-							year: vehicles.year,
-							licensePlate: vehicles.licensePlate,
-							color: vehicles.color,
-							isNew: vehicles.isNew,
-							vinNumber: vehicles.vinNumber,
-							motorNumber: vehicles.motorNumber,
-							seats: vehicles.seats,
-							vehicleUse: vehicles.vehicleUse,
-						})
-						.from(vehicles)
-						.where(inArray(vehicles.id, vehicleIds))
-				: [];
-
-		// Create maps for quick lookup
-		const leadsMap = new Map(leadsData.map((l) => [l.id, l]));
-		const vehiclesMap = new Map(vehiclesData.map((v) => [v.id, v]));
-
-		// Map results
-		const result = opps.map((opp) => {
-			const lead = opp.leadId ? leadsMap.get(opp.leadId) || null : null;
-			const vehicle = opp.vehicleId
-				? vehiclesMap.get(opp.vehicleId) || null
-				: null;
-
-			// Check if has investor assigned
-			let hasInvestor = false;
-			if (opp.inversionistas) {
-				try {
-					const parsed = JSON.parse(opp.inversionistas);
-					hasInvestor = Array.isArray(parsed) && parsed.length > 0;
-				} catch {
-					hasInvestor = false;
+			// Search filter (name, license plate)
+			if (search && search.trim() !== "") {
+				const searchTerms = search.trim().split(/\s+/);
+				for (const term of searchTerms) {
+					const searchPattern = `%${term}%`;
+					conditions.push(
+						or(
+							ilike(leads.firstName, searchPattern),
+							ilike(leads.lastName, searchPattern),
+							ilike(vehicles.licensePlate, searchPattern),
+						)!,
+					);
 				}
 			}
 
-			return {
+			// conditions always has at least one element (stageId condition)
+			const whereClause = and(...conditions)!;
+
+			// Get total count
+			const [{ total }] = await db
+				.select({ total: count() })
+				.from(opportunities)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+				.where(whereClause);
+
+			// Get paginated opportunities at 50%
+			const opps = await db
+				.select({
+					id: opportunities.id,
+					title: opportunities.title,
+					value: opportunities.value,
+					stageId: opportunities.stageId,
+					inversionistas: opportunities.inversionistas,
+					leadId: opportunities.leadId,
+					vehicleId: opportunities.vehicleId,
+					numeroCuotas: opportunities.numeroCuotas,
+					tasaInteres: opportunities.tasaInteres,
+					cuotaMensual: opportunities.cuotaMensual,
+					createdAt: opportunities.createdAt,
+					updatedAt: opportunities.updatedAt,
+				})
+				.from(opportunities)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+				.where(whereClause)
+				.orderBy(desc(opportunities.updatedAt))
+				.limit(limit)
+				.offset(offset);
+
+			if (opps.length === 0) {
+				return { data: [], total, limit, offset };
+			}
+
+			// Batch fetch leads and vehicles to avoid N+1 queries
+			const leadIds = opps
+				.map((o) => o.leadId)
+				.filter((id): id is string => id !== null);
+			const vehicleIds = opps
+				.map((o) => o.vehicleId)
+				.filter((id): id is string => id !== null);
+
+			// Fetch all leads in one query
+			const leadsData =
+				leadIds.length > 0
+					? await db
+							.select({
+								id: leads.id,
+								firstName: leads.firstName,
+								lastName: leads.lastName,
+								phone: leads.phone,
+								dpi: leads.dpi,
+								direccion: leads.direccion,
+								maritalStatus: leads.maritalStatus,
+								gender: leads.gender,
+								birthDate: leads.birthDate,
+								nationality: leads.nationality,
+							})
+							.from(leads)
+							.where(inArray(leads.id, leadIds))
+					: [];
+
+			// Fetch all vehicles in one query
+			const vehiclesData =
+				vehicleIds.length > 0
+					? await db
+							.select({
+								id: vehicles.id,
+								make: vehicles.make,
+								model: vehicles.model,
+								year: vehicles.year,
+								licensePlate: vehicles.licensePlate,
+								color: vehicles.color,
+								isNew: vehicles.isNew,
+								vinNumber: vehicles.vinNumber,
+								motorNumber: vehicles.motorNumber,
+								seats: vehicles.seats,
+								vehicleUse: vehicles.vehicleUse,
+							})
+							.from(vehicles)
+							.where(inArray(vehicles.id, vehicleIds))
+					: [];
+
+			// Create maps for quick lookup
+			const leadsMap = new Map(leadsData.map((l) => [l.id, l]));
+			const vehiclesMap = new Map(vehiclesData.map((v) => [v.id, v]));
+
+			// Map results
+			const data = opps.map((opp) => {
+				const lead = opp.leadId ? leadsMap.get(opp.leadId) || null : null;
+				const vehicle = opp.vehicleId
+					? vehiclesMap.get(opp.vehicleId) || null
+					: null;
+
+				// Check if has investor assigned
+				let hasInvestor = false;
+				if (opp.inversionistas) {
+					try {
+						const parsed = JSON.parse(opp.inversionistas);
+						hasInvestor = Array.isArray(parsed) && parsed.length > 0;
+					} catch {
+						hasInvestor = false;
+					}
+				}
+
+				return {
 					id: opp.id,
 					title: opp.title,
 					value: opp.value,
@@ -4030,17 +4290,17 @@ export const crmRouter = {
 								}),
 							}
 						: null,
-				stage: {
-					id: stage50.id,
-					name: stage50.name,
-					closurePercentage: stage50.closurePercentage,
-					color: stage50.color,
-				},
-			};
-		});
+					stage: {
+						id: stage50.id,
+						name: stage50.name,
+						closurePercentage: stage50.closurePercentage,
+						color: stage50.color,
+					},
+				};
+			});
 
-		return result;
-	}),
+			return { data, total, limit, offset };
+		}),
 
 	// Assign investor and advance to 80%
 	assignInvestorAndAdvance: analystProcedure

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -4106,29 +4106,6 @@ export const crmRouter = {
 			if (!stage50) {
 				return { data: [], total: 0, limit, offset };
 			}
-		// Get opportunities at 50%
-		const opps = await db
-			.select({
-				id: opportunities.id,
-				title: opportunities.title,
-				value: opportunities.value,
-				stageId: opportunities.stageId,
-				inversionistas: opportunities.inversionistas,
-				leadId: opportunities.leadId,
-				vehicleId: opportunities.vehicleId,
-				numeroCuotas: opportunities.numeroCuotas,
-				tasaInteres: opportunities.tasaInteres,
-				cuotaMensual: opportunities.cuotaMensual,
-				// Campos adicionales para edición
-				categoria: opportunities.categoria,
-				nit: opportunities.nit,
-				diaPagoMensual: opportunities.diaPagoMensual,
-				createdAt: opportunities.createdAt,
-				updatedAt: opportunities.updatedAt,
-			})
-			.from(opportunities)
-			.where(eq(opportunities.stageId, stage50.id))
-			.orderBy(desc(opportunities.updatedAt));
 
 			// Build conditions
 			const conditions = [eq(opportunities.stageId, stage50.id)];
@@ -4172,6 +4149,9 @@ export const crmRouter = {
 					numeroCuotas: opportunities.numeroCuotas,
 					tasaInteres: opportunities.tasaInteres,
 					cuotaMensual: opportunities.cuotaMensual,
+					categoria: opportunities.categoria,
+					nit: opportunities.nit,
+					diaPagoMensual: opportunities.diaPagoMensual,
 					createdAt: opportunities.createdAt,
 					updatedAt: opportunities.updatedAt,
 				})

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -57,6 +57,7 @@ export const appRouter = {
 	getOpportunitiesForAnalysis: crmRouter.getOpportunitiesForAnalysis,
 	approveOpportunityAnalysis: crmRouter.approveOpportunityAnalysis,
 	approveCreditDetail: crmRouter.approveCreditDetail,
+	revokeCreditDetailApproval: crmRouter.revokeCreditDetailApproval,
 	getCreditDetailApprovalStatus: crmRouter.getCreditDetailApprovalStatus,
 	getOpportunityHistory: crmRouter.getOpportunityHistory,
 	validateOpportunityDocuments: crmRouter.validateOpportunityDocuments,

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -4,14 +4,19 @@ import {
 	AlertTriangle,
 	Car,
 	CheckCircle2,
+	ChevronLeft,
+	ChevronRight,
+	ChevronsLeft,
+	ChevronsRight,
 	CreditCard,
 	Loader2,
 	Plus,
+	Search,
 	Trash2,
 	TrendingUp,
 	User,
 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -26,7 +31,7 @@ import {
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { client, orpc } from "@/utils/orpc";
+import { client } from "@/utils/orpc";
 
 // Type for selected investor
 interface SelectedInversionista {
@@ -37,11 +42,6 @@ interface SelectedInversionista {
 	porcentaje_cash_in: number;
 }
 
-// Type for opportunity from getOpportunitiesForInvestment
-type InvestmentOpportunity = Awaited<
-	ReturnType<typeof client.getOpportunitiesForInvestment>
->[0];
-
 export function InvestmentAssignmentSection() {
 	const queryClient = useQueryClient();
 	const [selectedOpportunityId, setSelectedOpportunityId] = useState<
@@ -51,15 +51,44 @@ export function InvestmentAssignmentSection() {
 		SelectedInversionista[]
 	>([]);
 
+	// Search and pagination states
+	const [searchTerm, setSearchTerm] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+	const [page, setPage] = useState(0);
+	const pageSize = 20;
+
+	// Debounce search input
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedSearch(searchTerm);
+			setPage(0); // Reset to first page on search
+		}, 300);
+		return () => clearTimeout(timer);
+	}, [searchTerm]);
+
 	// Query for opportunities at 50%
 	const {
-		data: opportunities,
+		data: opportunitiesData,
 		isLoading: isLoadingOpportunities,
 		refetch: refetchOpportunities,
 	} = useQuery({
-		queryKey: ["getOpportunitiesForInvestment"],
-		queryFn: () => client.getOpportunitiesForInvestment(),
+		queryKey: [
+			"getOpportunitiesForInvestment",
+			page,
+			pageSize,
+			debouncedSearch,
+		],
+		queryFn: () =>
+			client.getOpportunitiesForInvestment({
+				limit: pageSize,
+				offset: page * pageSize,
+				search: debouncedSearch || undefined,
+			}),
 	});
+
+	const opportunities = opportunitiesData?.data ?? [];
+	const total = opportunitiesData?.total ?? 0;
+	const totalPages = Math.ceil(total / pageSize);
 
 	// Query for available investors
 	const inversionistasQuery = useQuery({
@@ -239,18 +268,6 @@ export function InvestmentAssignmentSection() {
 		);
 	}
 
-	if (!opportunities || opportunities.length === 0) {
-		return (
-			<Alert>
-				<AlertCircle className="h-4 w-4" />
-				<AlertDescription>
-					No hay oportunidades pendientes de asignación de inversión en este
-					momento.
-				</AlertDescription>
-			</Alert>
-		);
-	}
-
 	return (
 		<div className="grid gap-6 lg:grid-cols-2">
 			{/* List of opportunities */}
@@ -258,96 +275,178 @@ export function InvestmentAssignmentSection() {
 				<CardHeader>
 					<CardTitle>Oportunidades en 50%</CardTitle>
 					<CardDescription>
-						{opportunities.length} oportunidad
-						{opportunities.length !== 1 ? "es" : ""} pendientes de asignación de
-						inversión
+						{total} oportunidad
+						{total !== 1 ? "es" : ""} pendientes de asignación de inversión
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
-					<div className="space-y-3">
-						{opportunities.map((opp) => (
-							<div
-								key={opp.id}
-								className={`cursor-pointer rounded-lg border p-4 transition-colors hover:bg-muted/50 ${
-									selectedOpportunityId === opp.id
-										? "border-primary bg-muted/50"
-										: ""
-								}`}
-								onClick={() => {
-									setSelectedOpportunityId(opp.id);
-									setSelectedInversionistas([]);
-								}}
-							>
-								<div className="flex items-center justify-between">
-									<div>
-										<p className="font-medium">
-											{opp.lead?.name || "Sin cliente"}
-										</p>
-										<p className="text-muted-foreground text-sm">
-											{opp.vehicle?.description || "Sin vehículo"}
-										</p>
-										<p className="font-mono text-[10px] text-muted-foreground/60">
-											ID: {opp.id.slice(0, 8)}
-										</p>
-									</div>
-									<div className="text-right">
-										<p className="font-medium">{formatCurrency(opp.value)}</p>
-										<div className="flex items-center gap-2">
-											{opp.hasInvestor ? (
-												<Badge variant="default">Con inversor</Badge>
-											) : (
-												<Badge variant="outline">Sin inversor</Badge>
-											)}
+					{/* Buscador */}
+					<div className="mb-4 flex items-center gap-4">
+						<div className="relative flex-1">
+							<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								placeholder="Buscar por nombre, placa..."
+								value={searchTerm}
+								onChange={(e) => setSearchTerm(e.target.value)}
+								className="pl-10"
+							/>
+						</div>
+					</div>
+
+					{opportunities.length === 0 ? (
+						<Alert>
+							<AlertCircle className="h-4 w-4" />
+							<AlertDescription>
+								{debouncedSearch
+									? "No se encontraron oportunidades con ese criterio de búsqueda."
+									: "No hay oportunidades pendientes de asignación de inversión en este momento."}
+							</AlertDescription>
+						</Alert>
+					) : (
+						<>
+							<div className="space-y-3">
+								{opportunities.map((opp) => (
+									<div
+										key={opp.id}
+										className={`cursor-pointer rounded-lg border p-4 transition-colors hover:bg-muted/50 ${
+											selectedOpportunityId === opp.id
+												? "border-primary bg-muted/50"
+												: ""
+										}`}
+										onClick={() => {
+											setSelectedOpportunityId(opp.id);
+											setSelectedInversionistas([]);
+										}}
+									>
+										<div className="flex items-center justify-between">
+											<div>
+												<p className="font-medium">
+													{opp.lead?.name || "Sin cliente"}
+												</p>
+												<p className="text-muted-foreground text-sm">
+													{opp.vehicle?.description || "Sin vehículo"}
+												</p>
+												<p className="font-mono text-[10px] text-muted-foreground/60">
+													ID: {opp.id.slice(0, 8)}
+												</p>
+											</div>
+											<div className="text-right">
+												<p className="font-medium">
+													{formatCurrency(opp.value)}
+												</p>
+												<div className="flex items-center gap-2">
+													{opp.hasInvestor ? (
+														<Badge variant="default">Con inversor</Badge>
+													) : (
+														<Badge variant="outline">Sin inversor</Badge>
+													)}
+												</div>
+											</div>
+										</div>
+
+										{/* Validation indicators */}
+										<div className="mt-2 flex flex-wrap gap-1">
+											<Badge
+												variant={
+													opp.lead?.hasRequiredData
+														? "secondary"
+														: "destructive"
+												}
+												className="text-xs"
+											>
+												<User className="mr-1 h-3 w-3" />
+												Cliente{" "}
+												{opp.lead?.hasRequiredData ? (
+													<CheckCircle2 className="ml-1 h-3 w-3" />
+												) : (
+													<AlertTriangle className="ml-1 h-3 w-3" />
+												)}
+											</Badge>
+											<Badge
+												variant={
+													opp.vehicle?.hasRequiredData
+														? "secondary"
+														: "destructive"
+												}
+												className="text-xs"
+											>
+												<Car className="mr-1 h-3 w-3" />
+												Vehículo{" "}
+												{opp.vehicle?.hasRequiredData ? (
+													<CheckCircle2 className="ml-1 h-3 w-3" />
+												) : (
+													<AlertTriangle className="ml-1 h-3 w-3" />
+												)}
+											</Badge>
+											<Badge
+												variant={
+													opp.hasCreditData ? "secondary" : "destructive"
+												}
+												className="text-xs"
+											>
+												<CreditCard className="mr-1 h-3 w-3" />
+												Crédito{" "}
+												{opp.hasCreditData ? (
+													<CheckCircle2 className="ml-1 h-3 w-3" />
+												) : (
+													<AlertTriangle className="ml-1 h-3 w-3" />
+												)}
+											</Badge>
 										</div>
 									</div>
-								</div>
-
-								{/* Validation indicators */}
-								<div className="mt-2 flex flex-wrap gap-1">
-									<Badge
-										variant={
-											opp.lead?.hasRequiredData ? "secondary" : "destructive"
-										}
-										className="text-xs"
-									>
-										<User className="mr-1 h-3 w-3" />
-										Cliente{" "}
-										{opp.lead?.hasRequiredData ? (
-											<CheckCircle2 className="ml-1 h-3 w-3" />
-										) : (
-											<AlertTriangle className="ml-1 h-3 w-3" />
-										)}
-									</Badge>
-									<Badge
-										variant={
-											opp.vehicle?.hasRequiredData ? "secondary" : "destructive"
-										}
-										className="text-xs"
-									>
-										<Car className="mr-1 h-3 w-3" />
-										Vehículo{" "}
-										{opp.vehicle?.hasRequiredData ? (
-											<CheckCircle2 className="ml-1 h-3 w-3" />
-										) : (
-											<AlertTriangle className="ml-1 h-3 w-3" />
-										)}
-									</Badge>
-									<Badge
-										variant={opp.hasCreditData ? "secondary" : "destructive"}
-										className="text-xs"
-									>
-										<CreditCard className="mr-1 h-3 w-3" />
-										Crédito{" "}
-										{opp.hasCreditData ? (
-											<CheckCircle2 className="ml-1 h-3 w-3" />
-										) : (
-											<AlertTriangle className="ml-1 h-3 w-3" />
-										)}
-									</Badge>
-								</div>
+								))}
 							</div>
-						))}
-					</div>
+
+							{/* Paginación */}
+							{totalPages > 1 && (
+								<div className="mt-4 flex items-center justify-between border-t pt-4">
+									<span className="text-muted-foreground text-sm">
+										Mostrando {page * pageSize + 1} -{" "}
+										{Math.min((page + 1) * pageSize, total)} de {total}
+									</span>
+									<div className="flex items-center gap-2">
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => setPage(0)}
+											disabled={page === 0}
+										>
+											<ChevronsLeft className="h-4 w-4" />
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => setPage((p) => Math.max(0, p - 1))}
+											disabled={page === 0}
+										>
+											<ChevronLeft className="h-4 w-4" />
+										</Button>
+										<span className="px-2 text-sm">
+											Página {page + 1} de {totalPages}
+										</span>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() =>
+												setPage((p) => Math.min(totalPages - 1, p + 1))
+											}
+											disabled={page >= totalPages - 1}
+										>
+											<ChevronRight className="h-4 w-4" />
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => setPage(totalPages - 1)}
+											disabled={page >= totalPages - 1}
+										>
+											<ChevronsRight className="h-4 w-4" />
+										</Button>
+									</div>
+								</div>
+							)}
+						</>
+					)}
 				</CardContent>
 			</Card>
 

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -37,6 +37,14 @@ import {
 import { Combobox } from "@/components/ui/combobox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
 import { client } from "@/utils/orpc";
 
 // Type for selected investor
@@ -61,7 +69,7 @@ type CreditCategory =
 // Type for opportunity from getOpportunitiesForInvestment
 type InvestmentOpportunity = Awaited<
 	ReturnType<typeof client.getOpportunitiesForInvestment>
->[0];
+>["data"][number];
 
 export function InvestmentAssignmentSection() {
 	const queryClient = useQueryClient();

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -13,6 +13,7 @@ import {
 	Save,
 	Trash2,
 	User,
+	X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -559,7 +560,7 @@ export function CreditDetailView({
 	// Mutation para aprobar detalle de crédito
 	const approveCreditDetailMutation = useMutation({
 		mutationFn: async () => {
-		    /*const camposFaltantes = validateRequiredFields();
+			/*const camposFaltantes = validateRequiredFields();
 			if (camposFaltantes.length > 0) {
 				throw new Error(
 					`Faltan campos requeridos: ${camposFaltantes.join(", ")}. Guarde los cambios primero.`,
@@ -580,14 +581,42 @@ export function CreditDetailView({
 			return client.approveCreditDetail({ opportunityId });
 		},
 		onSuccess: () => {
-			toast.success("Detalle de crédito aprobado correctamente");
+			toast.success(
+				"Detalle de crédito aprobado - Oportunidad movida a Formalización (50%)",
+			);
 			queryClient.invalidateQueries({ queryKey: ["getOpportunities"] });
 			queryClient.invalidateQueries({
 				queryKey: ["getCreditDetailApprovalStatus", opportunityId],
 			});
+			queryClient.invalidateQueries({
+				queryKey: ["getOpportunityHistory", opportunityId],
+			});
+			// Invalidar cualquier otra query relacionada con oportunidades
+			queryClient.invalidateQueries({ queryKey: ["opportunities"] });
 		},
 		onError: (error) => {
 			toast.error(`Error al aprobar: ${error.message}`);
+		},
+	});
+
+	// Mutation para cancelar aprobación del detalle de crédito
+	const revokeCreditDetailMutation = useMutation({
+		mutationFn: () => client.revokeCreditDetailApproval({ opportunityId }),
+		onSuccess: () => {
+			toast.success(
+				"Aprobación cancelada - Oportunidad regresada a Cierre de propuesta (40%)",
+			);
+			queryClient.invalidateQueries({ queryKey: ["getOpportunities"] });
+			queryClient.invalidateQueries({
+				queryKey: ["getCreditDetailApprovalStatus", opportunityId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["getOpportunityHistory", opportunityId],
+			});
+			queryClient.invalidateQueries({ queryKey: ["opportunities"] });
+		},
+		onError: (error) => {
+			toast.error(`Error al cancelar aprobación: ${error.message}`);
 		},
 	});
 
@@ -834,13 +863,29 @@ export function CreditDetailView({
 								</div>
 								<div className="flex items-center gap-3">
 									{creditDetailApprovalQuery.data?.approved ? (
-										<Badge
-											variant="outline"
-											className="border-green-500 bg-green-50 text-green-700"
-										>
-											<CheckCircle className="mr-1 h-3 w-3" />
-											Aprobado
-										</Badge>
+										<div className="flex items-center gap-2">
+											<Badge
+												variant="outline"
+												className="border-green-500 bg-green-50 text-green-700"
+											>
+												<CheckCircle className="mr-1 h-3 w-3" />
+												Aprobado
+											</Badge>
+											{canApprove && (
+												<Button
+													size="sm"
+													variant="ghost"
+													className="text-muted-foreground hover:text-destructive"
+													onClick={() => revokeCreditDetailMutation.mutate()}
+													disabled={revokeCreditDetailMutation.isPending}
+												>
+													<X className="mr-1 h-3 w-3" />
+													{revokeCreditDetailMutation.isPending
+														? "Cancelando..."
+														: "Cancelar"}
+												</Button>
+											)}
+										</div>
 									) : (
 										<>
 											{isEditing ? (
@@ -1006,17 +1051,23 @@ export function CreditDetailView({
 											Día de Pago Mensual
 										</Label>
 										{isEditing ? (
-											<Input
-												type="number"
-												min={1}
-												max={31}
-												value={editDiaPagoMensual}
-												onChange={(e) =>
-													setEditDiaPagoMensual(Number(e.target.value) || 15)
+											<Select
+												value={String(editDiaPagoMensual)}
+												onValueChange={(value) =>
+													setEditDiaPagoMensual(Number(value))
 												}
-												placeholder="15"
-												className="mt-1"
-											/>
+											>
+												<SelectTrigger className="mt-1">
+													<SelectValue placeholder="Seleccionar día" />
+												</SelectTrigger>
+												<SelectContent>
+													{[1, 5, 10, 15, 20, 25, 30].map((day) => (
+														<SelectItem key={day} value={String(day)}>
+															Día {day}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
 										) : (
 											<p className="font-medium">
 												Día{" "}
@@ -2647,6 +2698,93 @@ export function CreditDetailView({
 										</div>
 									</div>
 
+									{/* Resumen Principal - Datos Clave */}
+									<div className="rounded-lg border-2 border-primary bg-primary/5 p-4">
+										<h4 className="mb-4 flex items-center gap-2 font-bold text-primary">
+											<Banknote className="h-5 w-5" />
+											Resumen del Crédito
+										</h4>
+										<div className="grid grid-cols-2 gap-6 md:grid-cols-4">
+											<div className="rounded-md bg-background p-3 text-center shadow-sm">
+												<Label className="text-muted-foreground text-xs">
+													Monto a Financiar
+												</Label>
+												<p className="font-bold text-lg">
+													{formatCurrency(quotation.amountToFinance)}
+												</p>
+											</div>
+											<div className="rounded-md bg-background p-3 text-center shadow-sm">
+												<Label className="text-muted-foreground text-xs">
+													Plazo
+												</Label>
+												<p className="font-bold text-lg">
+													{quotation.termMonths} meses
+												</p>
+											</div>
+											<div className="rounded-md bg-background p-3 text-center shadow-sm">
+												<Label className="text-muted-foreground text-xs">
+													Tasa de Interés
+												</Label>
+												<p className="font-bold text-lg">
+													{formatPercent(quotation.interestRate)}
+												</p>
+											</div>
+											<div className="rounded-md bg-primary/10 p-3 text-center shadow-sm ring-2 ring-primary">
+												<Label className="font-medium text-primary text-xs">
+													Cuota Mensual
+												</Label>
+												<p className="font-bold text-primary text-xl">
+													{formatCurrency(quotation.monthlyPayment)}
+												</p>
+											</div>
+										</div>
+									</div>
+
+									<Separator />
+
+									{/* Términos del Crédito - Detalle */}
+									<div>
+										<h4 className="mb-3 flex items-center gap-2 font-semibold">
+											<Calculator className="h-4 w-4" />
+											Términos del Crédito
+										</h4>
+										<div className="grid grid-cols-2 gap-4 rounded-lg border bg-muted/30 p-4 md:grid-cols-4">
+											<div>
+												<Label className="text-muted-foreground text-xs">
+													Valor del Vehículo
+												</Label>
+												<p className="font-medium">
+													{formatCurrency(quotation.vehicleValue)}
+												</p>
+											</div>
+											<div>
+												<Label className="text-muted-foreground text-xs">
+													Monto Asegurado
+												</Label>
+												<p className="font-medium">
+													{formatCurrency(quotation.insuredAmount)}
+												</p>
+											</div>
+											<div>
+												<Label className="text-muted-foreground text-xs">
+													Enganche
+												</Label>
+												<p className="font-medium">
+													{formatCurrency(quotation.downPayment)} (
+													{formatPercent(quotation.downPaymentPercentage)})
+												</p>
+											</div>
+											<div>
+												<Label className="text-muted-foreground text-xs">
+													Total Financiado
+												</Label>
+												<p className="font-medium">
+													{formatCurrency(quotation.totalFinanced)}
+												</p>
+											</div>
+										</div>
+									</div>
+
 									<Separator />
 
 									{/* Información del Vehículo */}
@@ -2687,83 +2825,6 @@ export function CreditDetailView({
 												<p className="font-medium">
 													{vehicleTypeLabels[quotation.vehicleType] ||
 														quotation.vehicleType}
-												</p>
-											</div>
-										</div>
-									</div>
-
-									<Separator />
-
-									{/* Términos del Crédito */}
-									<div>
-										<h4 className="mb-3 flex items-center gap-2 font-semibold">
-											<Banknote className="h-4 w-4" />
-											Términos del Crédito
-										</h4>
-										<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Valor del Vehículo
-												</Label>
-												<p className="font-medium">
-													{formatCurrency(quotation.vehicleValue)}
-												</p>
-											</div>
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Monto Asegurado
-												</Label>
-												<p className="font-medium">
-													{formatCurrency(quotation.insuredAmount)}
-												</p>
-											</div>
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Enganche
-												</Label>
-												<p className="font-medium">
-													{formatCurrency(quotation.downPayment)} (
-													{formatPercent(quotation.downPaymentPercentage)})
-												</p>
-											</div>
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Plazo
-												</Label>
-												<p className="font-medium">
-													{quotation.termMonths} meses
-												</p>
-											</div>
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Tasa de Interés
-												</Label>
-												<p className="font-medium">
-													{formatPercent(quotation.interestRate)}
-												</p>
-											</div>
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Monto a Financiar
-												</Label>
-												<p className="font-medium">
-													{formatCurrency(quotation.amountToFinance)}
-												</p>
-											</div>
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Total Financiado
-												</Label>
-												<p className="font-medium">
-													{formatCurrency(quotation.totalFinanced)}
-												</p>
-											</div>
-											<div>
-												<Label className="text-muted-foreground text-xs">
-													Cuota Mensual
-												</Label>
-												<p className="font-bold text-primary">
-													{formatCurrency(quotation.monthlyPayment)}
 												</p>
 											</div>
 										</div>

--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -178,10 +178,12 @@ export function LeadDetailModal({
 					<div className="flex items-start justify-between">
 						<div>
 							<h3 className="font-semibold text-lg">
-								{displayLead.firstName} {displayLead.middleName || ""} {displayLead.lastName}{" "}
-								{displayLead.secondLastName || ""}
+								{displayLead.firstName} {displayLead.middleName || ""}{" "}
+								{displayLead.lastName} {displayLead.secondLastName || ""}
 							</h3>
-							<p className="text-muted-foreground text-sm">{displayLead.email}</p>
+							<p className="text-muted-foreground text-sm">
+								{displayLead.email}
+							</p>
 						</div>
 						<div className="flex flex-col gap-2">
 							<Badge
@@ -193,7 +195,9 @@ export function LeadDetailModal({
 							{displayLead.fit !== null && displayLead.fit !== undefined && (
 								<Badge
 									variant={displayLead.fit ? "default" : "secondary"}
-									className={displayLead.fit ? "bg-green-500 hover:bg-green-600" : ""}
+									className={
+										displayLead.fit ? "bg-green-500 hover:bg-green-600" : ""
+									}
 								>
 									{displayLead.fit ? "PREAPROBADO" : "NO PREAPROBADO"}
 								</Badge>
@@ -212,15 +216,17 @@ export function LeadDetailModal({
 										Nombre Completo
 									</Label>
 									<p className="font-medium text-sm">
-										{displayLead.firstName} {displayLead.middleName || ""} {displayLead.lastName}{" "}
-										{displayLead.secondLastName || ""}
+										{displayLead.firstName} {displayLead.middleName || ""}{" "}
+										{displayLead.lastName} {displayLead.secondLastName || ""}
 									</p>
 								</div>
 								<div>
 									<Label className="font-medium text-muted-foreground text-sm">
 										DPI
 									</Label>
-									<p className="text-sm">{displayLead.dpi || "No especificado"}</p>
+									<p className="text-sm">
+										{displayLead.dpi || "No especificado"}
+									</p>
 								</div>
 								<div>
 									<Label className="font-medium text-muted-foreground text-sm">
@@ -256,7 +262,9 @@ export function LeadDetailModal({
 									<Label className="font-medium text-muted-foreground text-sm">
 										Edad
 									</Label>
-									<p className="text-sm">{displayLead.age || "No especificado"}</p>
+									<p className="text-sm">
+										{displayLead.age || "No especificado"}
+									</p>
 								</div>
 								<div>
 									<Label className="font-medium text-muted-foreground text-sm">
@@ -305,7 +313,9 @@ export function LeadDetailModal({
 									</Label>
 									<div className="flex items-center gap-2">
 										<Mail className="h-4 w-4 text-muted-foreground" />
-										<p className="text-sm">{displayLead.email || "No especificado"}</p>
+										<p className="text-sm">
+											{displayLead.email || "No especificado"}
+										</p>
 									</div>
 								</div>
 								<div>
@@ -314,7 +324,9 @@ export function LeadDetailModal({
 									</Label>
 									<div className="flex items-center gap-2">
 										<Phone className="h-4 w-4 text-muted-foreground" />
-										<p className="text-sm">{displayLead.phone || "No especificado"}</p>
+										<p className="text-sm">
+											{displayLead.phone || "No especificado"}
+										</p>
 									</div>
 								</div>
 								<div>
@@ -427,7 +439,9 @@ export function LeadDetailModal({
 									<Label className="font-medium text-muted-foreground text-sm">
 										Zona
 									</Label>
-									<p className="text-sm">{displayLead.zona || "No especificado"}</p>
+									<p className="text-sm">
+										{displayLead.zona || "No especificado"}
+									</p>
 								</div>
 							</div>
 						</div>
@@ -444,11 +458,17 @@ export function LeadDetailModal({
 									<Label className="text-sm">Posee Casa Propia</Label>
 								</div>
 								<div className="flex items-center gap-2">
-									<Checkbox checked={displayLead.ownsVehicle ?? false} disabled />
+									<Checkbox
+										checked={displayLead.ownsVehicle ?? false}
+										disabled
+									/>
 									<Label className="text-sm">Posee Vehículo Propio</Label>
 								</div>
 								<div className="flex items-center gap-2">
-									<Checkbox checked={displayLead.hasCreditCard ?? false} disabled />
+									<Checkbox
+										checked={displayLead.hasCreditCard ?? false}
+										disabled
+									/>
 									<Label className="text-sm">Tiene Tarjeta de Crédito</Label>
 								</div>
 							</div>
@@ -483,7 +503,10 @@ export function LeadDetailModal({
 								{displayLead.livenessValidated !== null &&
 									displayLead.livenessValidated !== undefined && (
 										<div className="flex items-center gap-2">
-											<Checkbox checked={displayLead.livenessValidated} disabled />
+											<Checkbox
+												checked={displayLead.livenessValidated}
+												disabled
+											/>
 											<Label className="text-sm">Liveness Validado</Label>
 										</div>
 									)}

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -1,15 +1,20 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import {
 	AlertCircle,
 	CheckCircle,
+	ChevronLeft,
+	ChevronRight,
+	ChevronsLeft,
+	ChevronsRight,
 	FileText,
 	RefreshCw,
+	Search,
 	TrendingUp,
 	Wallet,
 	XCircle,
 } from "lucide-react";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { DisbursementChecklistView } from "@/components/analysis/DisbursementChecklistView";
 import { InvestmentAssignmentSection } from "@/components/analysis/InvestmentAssignmentSection";
@@ -39,6 +44,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import {
 	Table,
 	TableBody,
@@ -64,7 +70,7 @@ export const Route = createFileRoute("/crm/analysis/")({
 
 type OpportunityForAnalysis = Awaited<
 	ReturnType<typeof client.getOpportunitiesForAnalysis>
->[0];
+>["data"][0];
 
 // Helper component to render action buttons with validation
 function OpportunityActions({
@@ -168,10 +174,21 @@ function AnalysisPage() {
 	const navigate = Route.useNavigate();
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 
-	const [opportunities, setOpportunities] = useState<OpportunityForAnalysis[]>(
-		[],
-	);
-	const [isLoading, setIsLoading] = useState(true);
+	// Search and pagination states
+	const [searchTerm, setSearchTerm] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+	const [page, setPage] = useState(0);
+	const pageSize = 20;
+
+	// Debounce search input
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedSearch(searchTerm);
+			setPage(0); // Reset to first page on search
+		}, 300);
+		return () => clearTimeout(timer);
+	}, [searchTerm]);
+
 	const [selectedOpportunity, setSelectedOpportunity] =
 		useState<OpportunityForAnalysis | null>(null);
 	const [isApprovalDialogOpen, setIsApprovalDialogOpen] = useState(false);
@@ -197,23 +214,24 @@ function AnalysisPage() {
 		}
 	}, [userProfile.data, navigate]);
 
-	// Cargar oportunidades en análisis
-	const loadOpportunities = async () => {
-		try {
-			setIsLoading(true);
-			const data = await client.getOpportunitiesForAnalysis();
-			setOpportunities(data);
-		} catch (error) {
-			toast.error("No se pudieron cargar las oportunidades");
-		} finally {
-			setIsLoading(false);
-		}
-	};
+	// Query with pagination
+	const {
+		data: opportunitiesData,
+		isLoading,
+		refetch: loadOpportunities,
+	} = useQuery({
+		queryKey: ["getOpportunitiesForAnalysis", page, pageSize, debouncedSearch],
+		queryFn: () =>
+			client.getOpportunitiesForAnalysis({
+				limit: pageSize,
+				offset: page * pageSize,
+				search: debouncedSearch || undefined,
+			}),
+	});
 
-	// Cargar al montar el componente
-	React.useEffect(() => {
-		loadOpportunities();
-	}, []);
+	const opportunities = opportunitiesData?.data ?? [];
+	const total = opportunitiesData?.total ?? 0;
+	const totalPages = Math.ceil(total / pageSize);
 
 	const handleApprovalClick = (
 		opportunity: OpportunityForAnalysis,
@@ -346,9 +364,9 @@ function AnalysisPage() {
 					<TabsTrigger value="analysis" className="flex items-center gap-2">
 						<FileText className="h-4 w-4" />
 						Análisis (30% → 40%)
-						{opportunities.length > 0 && (
+						{total > 0 && (
 							<Badge variant="secondary" className="ml-1">
-								{opportunities.length}
+								{total}
 							</Badge>
 						)}
 					</TabsTrigger>
@@ -363,138 +381,206 @@ function AnalysisPage() {
 				</TabsList>
 
 				<TabsContent value="analysis">
-					{opportunities.length === 0 ? (
-						<Alert>
-							<AlertCircle className="h-4 w-4" />
-							<AlertDescription>
-								No hay oportunidades pendientes de análisis en este momento.
-							</AlertDescription>
-						</Alert>
-					) : (
-						<Card>
-							<CardHeader>
-								<CardTitle>Oportunidades Pendientes de Análisis</CardTitle>
-								<CardDescription>
-									{opportunities.length} oportunidad
-									{opportunities.length !== 1 ? "es" : ""} esperando revisión de
-									documentación
-								</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<Table>
-									<TableHeader>
-										<TableRow>
-											<TableHead>Título</TableHead>
-											<TableHead>Estado</TableHead>
-											<TableHead>Lead</TableHead>
-											<TableHead>Empresa</TableHead>
-											<TableHead>Valor</TableHead>
-											<TableHead>Fecha Esperada</TableHead>
-											<TableHead>Acciones</TableHead>
-										</TableRow>
-									</TableHeader>
-									<TableBody>
-										{opportunities.map((opportunity) => (
-											<TableRow key={opportunity.id}>
-												<TableCell className="font-medium">
-													<div className="space-y-1">
-														<button
-															type="button"
-															className="cursor-pointer text-left text-primary hover:underline"
-															onClick={() =>
-																handleOpenOpportunityModal(opportunity)
-															}
-														>
-															{opportunity.title}
-														</button>
-														<p className="font-mono text-[10px] text-muted-foreground/60">
-															ID: {opportunity.id.slice(0, 8)}
-														</p>
-													</div>
-												</TableCell>
-												<TableCell>
-													{opportunity.analysisStatus === "resubmitted" ? (
-														<Badge className="border-orange-300 bg-orange-100 text-orange-700">
-															<RefreshCw className="mr-1 h-3 w-3" />
-															Reenviado ({opportunity.analysisRejectionCount}x)
-														</Badge>
-													) : (
-														<Badge className="border-green-300 bg-green-100 text-green-700">
-															Nueva
-														</Badge>
-													)}
-												</TableCell>
-												<TableCell>
-													{opportunity.lead ? (
-														<div>
+					<Card>
+						<CardHeader>
+							<CardTitle>Oportunidades Pendientes de Análisis</CardTitle>
+							<CardDescription>
+								{total} oportunidad
+								{total !== 1 ? "es" : ""} esperando revisión de documentación
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							{/* Buscador */}
+							<div className="mb-4 flex items-center gap-4">
+								<div className="relative max-w-sm flex-1">
+									<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+									<Input
+										placeholder="Buscar por nombre, placa..."
+										value={searchTerm}
+										onChange={(e) => setSearchTerm(e.target.value)}
+										className="pl-10"
+									/>
+								</div>
+							</div>
+
+							{opportunities.length === 0 ? (
+								<Alert>
+									<AlertCircle className="h-4 w-4" />
+									<AlertDescription>
+										{debouncedSearch
+											? "No se encontraron oportunidades con ese criterio de búsqueda."
+											: "No hay oportunidades pendientes de análisis en este momento."}
+									</AlertDescription>
+								</Alert>
+							) : (
+								<>
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Título</TableHead>
+												<TableHead>Estado</TableHead>
+												<TableHead>Lead</TableHead>
+												<TableHead>Empresa</TableHead>
+												<TableHead>Valor</TableHead>
+												<TableHead>Fecha Esperada</TableHead>
+												<TableHead>Acciones</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{opportunities.map((opportunity) => (
+												<TableRow key={opportunity.id}>
+													<TableCell className="font-medium">
+														<div className="space-y-1">
 															<button
 																type="button"
-																className="cursor-pointer text-left font-medium text-primary hover:underline"
-																onClick={() => handleOpenLeadModal(opportunity)}
+																className="cursor-pointer text-left text-primary hover:underline"
+																onClick={() =>
+																	handleOpenOpportunityModal(opportunity)
+																}
 															>
-																{opportunity.lead.firstName}{" "}
-																{opportunity.lead.lastName}
+																{opportunity.title}
 															</button>
-															<p className="text-muted-foreground text-sm">
-																{opportunity.lead.email}
+															<p className="font-mono text-[10px] text-muted-foreground/60">
+																ID: {opportunity.id.slice(0, 8)}
 															</p>
 														</div>
-													) : (
-														<span className="text-muted-foreground">
-															Sin lead
-														</span>
-													)}
-												</TableCell>
-												<TableCell>
-													{opportunity.company?.name || (
-														<span className="text-muted-foreground">
-															Sin empresa
-														</span>
-													)}
-												</TableCell>
-												<TableCell>
-													{opportunity.value ? (
-														<span className="font-medium">
-															Q{Number(opportunity.value).toLocaleString()}
-														</span>
-													) : (
-														<span className="text-muted-foreground">
-															Sin valor
-														</span>
-													)}
-												</TableCell>
-												<TableCell>
-													{opportunity.expectedCloseDate ? (
-														new Date(
-															opportunity.expectedCloseDate,
-														).toLocaleDateString("es-GT")
-													) : (
-														<span className="text-muted-foreground">
-															Sin fecha
-														</span>
-													)}
-												</TableCell>
-												<TableCell>
-													<OpportunityActions
-														opportunity={opportunity}
-														onApprove={() =>
-															handleApprovalClick(opportunity, true)
-														}
-														onReject={() =>
-															handleApprovalClick(opportunity, false)
-														}
-														onViewDocuments={() =>
-															handleViewDocuments(opportunity)
-														}
-													/>
-												</TableCell>
-											</TableRow>
-										))}
-									</TableBody>
-								</Table>
-							</CardContent>
-						</Card>
-					)}
+													</TableCell>
+													<TableCell>
+														{opportunity.analysisStatus === "resubmitted" ? (
+															<Badge className="border-orange-300 bg-orange-100 text-orange-700">
+																<RefreshCw className="mr-1 h-3 w-3" />
+																Reenviado ({opportunity.analysisRejectionCount}
+																x)
+															</Badge>
+														) : (
+															<Badge className="border-green-300 bg-green-100 text-green-700">
+																Nueva
+															</Badge>
+														)}
+													</TableCell>
+													<TableCell>
+														{opportunity.lead ? (
+															<div>
+																<button
+																	type="button"
+																	className="cursor-pointer text-left font-medium text-primary hover:underline"
+																	onClick={() =>
+																		handleOpenLeadModal(opportunity)
+																	}
+																>
+																	{opportunity.lead.firstName}{" "}
+																	{opportunity.lead.lastName}
+																</button>
+																<p className="text-muted-foreground text-sm">
+																	{opportunity.lead.email}
+																</p>
+															</div>
+														) : (
+															<span className="text-muted-foreground">
+																Sin lead
+															</span>
+														)}
+													</TableCell>
+													<TableCell>
+														{opportunity.company?.name || (
+															<span className="text-muted-foreground">
+																Sin empresa
+															</span>
+														)}
+													</TableCell>
+													<TableCell>
+														{opportunity.value ? (
+															<span className="font-medium">
+																Q{Number(opportunity.value).toLocaleString()}
+															</span>
+														) : (
+															<span className="text-muted-foreground">
+																Sin valor
+															</span>
+														)}
+													</TableCell>
+													<TableCell>
+														{opportunity.expectedCloseDate ? (
+															new Date(
+																opportunity.expectedCloseDate,
+															).toLocaleDateString("es-GT")
+														) : (
+															<span className="text-muted-foreground">
+																Sin fecha
+															</span>
+														)}
+													</TableCell>
+													<TableCell>
+														<OpportunityActions
+															opportunity={opportunity}
+															onApprove={() =>
+																handleApprovalClick(opportunity, true)
+															}
+															onReject={() =>
+																handleApprovalClick(opportunity, false)
+															}
+															onViewDocuments={() =>
+																handleViewDocuments(opportunity)
+															}
+														/>
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+									</Table>
+
+									{/* Paginación */}
+									{totalPages > 1 && (
+										<div className="mt-4 flex items-center justify-between border-t pt-4">
+											<span className="text-muted-foreground text-sm">
+												Mostrando {page * pageSize + 1} -{" "}
+												{Math.min((page + 1) * pageSize, total)} de {total}
+											</span>
+											<div className="flex items-center gap-2">
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => setPage(0)}
+													disabled={page === 0}
+												>
+													<ChevronsLeft className="h-4 w-4" />
+												</Button>
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => setPage((p) => Math.max(0, p - 1))}
+													disabled={page === 0}
+												>
+													<ChevronLeft className="h-4 w-4" />
+												</Button>
+												<span className="px-2 text-sm">
+													Página {page + 1} de {totalPages}
+												</span>
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() =>
+														setPage((p) => Math.min(totalPages - 1, p + 1))
+													}
+													disabled={page >= totalPages - 1}
+												>
+													<ChevronRight className="h-4 w-4" />
+												</Button>
+												<Button
+													variant="outline"
+													size="sm"
+													onClick={() => setPage(totalPages - 1)}
+													disabled={page >= totalPages - 1}
+												>
+													<ChevronsRight className="h-4 w-4" />
+												</Button>
+											</div>
+										</div>
+									)}
+								</>
+							)}
+						</CardContent>
+					</Card>
 				</TabsContent>
 
 				<TabsContent value="investment">
@@ -603,16 +689,47 @@ function DisbursementSection() {
 	const [selectedLeadForModal, setSelectedLeadForModal] =
 		useState<LeadForModal | null>(null);
 
+	// Search and pagination states
+	const [searchTerm, setSearchTerm] = useState("");
+	const [debouncedSearch, setDebouncedSearch] = useState("");
+	const [pageD, setPageD] = useState(0);
+	const pageSizeD = 20;
+
+	// Debounce search input
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedSearch(searchTerm);
+			setPageD(0); // Reset to first page on search
+		}, 300);
+		return () => clearTimeout(timer);
+	}, [searchTerm]);
+
 	const {
-		data: opportunities,
+		data: opportunitiesData,
 		isLoading,
 		refetch,
 	} = useQuery({
-		queryKey: ["getOpportunitiesForDisbursement"],
-		queryFn: () => client.getOpportunitiesForDisbursement(),
+		queryKey: [
+			"getOpportunitiesForDisbursement",
+			pageD,
+			pageSizeD,
+			debouncedSearch,
+		],
+		queryFn: () =>
+			client.getOpportunitiesForDisbursement({
+				limit: pageSizeD,
+				offset: pageD * pageSizeD,
+				search: debouncedSearch || undefined,
+			}),
 	});
 
-	type DisbursementOpportunity = NonNullable<typeof opportunities>[0];
+	const opportunities = opportunitiesData?.data ?? [];
+	const totalD = opportunitiesData?.total ?? 0;
+	const totalPagesD = Math.ceil(totalD / pageSizeD);
+
+	type DisbursementOpportunity = NonNullable<
+		typeof opportunitiesData
+	>["data"][0];
 
 	const handleOpenOpportunityModal = (opp: DisbursementOpportunity) => {
 		setSelectedOpportunityForModal({
@@ -687,17 +804,6 @@ function DisbursementSection() {
 		);
 	}
 
-	if (!opportunities || opportunities.length === 0) {
-		return (
-			<Alert>
-				<AlertCircle className="h-4 w-4" />
-				<AlertDescription>
-					No hay oportunidades pendientes de desembolso en este momento.
-				</AlertDescription>
-			</Alert>
-		);
-	}
-
 	return (
 		<div className="grid gap-6 lg:grid-cols-2">
 			{/* Lista de oportunidades */}
@@ -705,65 +811,140 @@ function DisbursementSection() {
 				<CardHeader>
 					<CardTitle>Oportunidades en 90%</CardTitle>
 					<CardDescription>
-						{opportunities.length} oportunidad
-						{opportunities.length !== 1 ? "es" : ""} pendientes de desembolso
+						{totalD} oportunidad
+						{totalD !== 1 ? "es" : ""} pendientes de desembolso
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
-					<div className="space-y-3">
-						{opportunities.map((opp) => (
-							<div
-								key={opp.id}
-								className={`cursor-pointer rounded-lg border p-4 transition-colors hover:bg-muted/50 ${
-									selectedOpportunity === opp.id
-										? "border-primary bg-muted/50"
-										: ""
-								}`}
-								onClick={() => setSelectedOpportunity(opp.id)}
-							>
-								<div className="flex items-center justify-between">
-									<div>
-										<button
-											type="button"
-											className="cursor-pointer text-left font-medium text-primary hover:underline"
-											onClick={(e) => {
-												e.stopPropagation();
-												handleOpenOpportunityModal(opp);
-											}}
-										>
-											{opp.leadName}
-										</button>
-										<p className="text-muted-foreground text-sm">
-											{opp.leadPhone}
-										</p>
-										<p className="font-mono text-[10px] text-muted-foreground/60">
-											ID: {opp.id.slice(0, 8)}
-										</p>
-									</div>
-									<div className="text-right">
-										<p className="font-medium">
-											Q{Number(opp.value).toLocaleString()}
-										</p>
-										<div className="flex items-center gap-2">
-											{opp.hasChecklist ? (
-												<Badge
-													variant={
-														opp.checklistProgress === 100
-															? "default"
-															: "secondary"
-													}
+					{/* Buscador */}
+					<div className="mb-4 flex items-center gap-4">
+						<div className="relative flex-1">
+							<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+							<Input
+								placeholder="Buscar por nombre, placa..."
+								value={searchTerm}
+								onChange={(e) => setSearchTerm(e.target.value)}
+								className="pl-10"
+							/>
+						</div>
+					</div>
+
+					{opportunities.length === 0 ? (
+						<Alert>
+							<AlertCircle className="h-4 w-4" />
+							<AlertDescription>
+								{debouncedSearch
+									? "No se encontraron oportunidades con ese criterio de búsqueda."
+									: "No hay oportunidades pendientes de desembolso en este momento."}
+							</AlertDescription>
+						</Alert>
+					) : (
+						<>
+							<div className="space-y-3">
+								{opportunities.map((opp) => (
+									<div
+										key={opp.id}
+										className={`cursor-pointer rounded-lg border p-4 transition-colors hover:bg-muted/50 ${
+											selectedOpportunity === opp.id
+												? "border-primary bg-muted/50"
+												: ""
+										}`}
+										onClick={() => setSelectedOpportunity(opp.id)}
+									>
+										<div className="flex items-center justify-between">
+											<div>
+												<button
+													type="button"
+													className="cursor-pointer text-left font-medium text-primary hover:underline"
+													onClick={(e) => {
+														e.stopPropagation();
+														handleOpenOpportunityModal(opp);
+													}}
 												>
-													{opp.checklistProgress}%
-												</Badge>
-											) : (
-												<Badge variant="outline">Sin iniciar</Badge>
-											)}
+													{opp.leadName}
+												</button>
+												<p className="text-muted-foreground text-sm">
+													{opp.leadPhone}
+												</p>
+												<p className="font-mono text-[10px] text-muted-foreground/60">
+													ID: {opp.id.slice(0, 8)}
+												</p>
+											</div>
+											<div className="text-right">
+												<p className="font-medium">
+													Q{Number(opp.value).toLocaleString()}
+												</p>
+												<div className="flex items-center gap-2">
+													{opp.hasChecklist ? (
+														<Badge
+															variant={
+																opp.checklistProgress === 100
+																	? "default"
+																	: "secondary"
+															}
+														>
+															{opp.checklistProgress}%
+														</Badge>
+													) : (
+														<Badge variant="outline">Sin iniciar</Badge>
+													)}
+												</div>
+											</div>
 										</div>
 									</div>
-								</div>
+								))}
 							</div>
-						))}
-					</div>
+
+							{/* Paginación */}
+							{totalPagesD > 1 && (
+								<div className="mt-4 flex items-center justify-between border-t pt-4">
+									<span className="text-muted-foreground text-sm">
+										Mostrando {pageD * pageSizeD + 1} -{" "}
+										{Math.min((pageD + 1) * pageSizeD, totalD)} de {totalD}
+									</span>
+									<div className="flex items-center gap-2">
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => setPageD(0)}
+											disabled={pageD === 0}
+										>
+											<ChevronsLeft className="h-4 w-4" />
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => setPageD((p) => Math.max(0, p - 1))}
+											disabled={pageD === 0}
+										>
+											<ChevronLeft className="h-4 w-4" />
+										</Button>
+										<span className="px-2 text-sm">
+											Página {pageD + 1} de {totalPagesD}
+										</span>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() =>
+												setPageD((p) => Math.min(totalPagesD - 1, p + 1))
+											}
+											disabled={pageD >= totalPagesD - 1}
+										>
+											<ChevronRight className="h-4 w-4" />
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => setPageD(totalPagesD - 1)}
+											disabled={pageD >= totalPagesD - 1}
+										>
+											<ChevronsRight className="h-4 w-4" />
+										</Button>
+									</div>
+								</div>
+							)}
+						</>
+					)}
 				</CardContent>
 			</Card>
 

--- a/apps/crm/apps/web/src/routes/dashboard.tsx
+++ b/apps/crm/apps/web/src/routes/dashboard.tsx
@@ -320,7 +320,7 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-purple-600">
-									{analysisStats.data?.filter(
+									{analysisStats.data?.data?.filter(
 										(o) => o.stage?.closurePercentage === 30,
 									).length || 0}
 								</div>
@@ -338,7 +338,7 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-blue-600">
-									{analysisStats.data?.filter(
+									{analysisStats.data?.data?.filter(
 										(o) => o.stage?.closurePercentage === 40,
 									).length || 0}
 								</div>
@@ -356,7 +356,7 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl">
-									{analysisStats.data?.length || 0}
+									{analysisStats.data?.total || 0}
 								</div>
 								<p className="text-muted-foreground text-xs">
 									Oportunidades por procesar


### PR DESCRIPTION
## Summary
- Agregar funcionalidad para cancelar aprobación del detalle de crédito (antes del 90%)
- Permitir a analistas ver todos los leads
- Excluir documentos de propietario para vehículos nuevos
- Hacer patente_comercio opcional para comerciantes
- Hacer issuerBank opcional para cheques

## Test plan
- [ ] Aprobar detalle → pasa a 50%
- [ ] Cancelar en 50% → regresa a 40%
- [ ] En 90%+ → error al cancelar
- [ ] Solo admin/sales_supervisor ven botón Cancelar