### PR TITLE
feat(crm): revoke credit approval + performance fixes

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1815,38 +1815,41 @@ export const crmRouter = {
 				);
 			}
 
-			// Get stage 40% (Cierre de propuesta)
+			// Get stage 40% by closurePercentage (more reliable than order)
 			const [previousStage] = await db
 				.select()
 				.from(salesStages)
-				.where(eq(salesStages.order, 5)) // Order 5 = 40% - Cierre de propuesta
+				.where(eq(salesStages.closurePercentage, 40))
 				.limit(1);
 
 			if (!previousStage) {
-				throw new Error("Etapa anterior no encontrada");
+				throw new Error("Etapa 40% no encontrada");
 			}
 
-			// Update opportunity - revoke approval
-			await db
-				.update(opportunities)
-				.set({
-					stageId: previousStage.id,
-					creditDetailApproved: false,
-					creditDetailApprovedBy: null,
-					creditDetailApprovedAt: null,
-					updatedAt: new Date(),
-				})
-				.where(eq(opportunities.id, input.opportunityId));
+			// Update opportunity and record history in a transaction for atomicity
+			await db.transaction(async (tx) => {
+				// Update opportunity - revoke approval
+				await tx
+					.update(opportunities)
+					.set({
+						stageId: previousStage.id,
+						creditDetailApproved: false,
+						creditDetailApprovedBy: null,
+						creditDetailApprovedAt: null,
+						updatedAt: new Date(),
+					})
+					.where(eq(opportunities.id, input.opportunityId));
 
-			// Record stage history
-			await db.insert(opportunityStageHistory).values({
-				opportunityId: input.opportunityId,
-				fromStageId: opportunity.stageId,
-				toStageId: previousStage.id,
-				changedBy: context.userId,
-				reason:
-					"Aprobación de detalle cancelada - Regresado a Cierre de propuesta (40%)",
-				isOverride: false,
+				// Record stage history
+				await tx.insert(opportunityStageHistory).values({
+					opportunityId: input.opportunityId,
+					fromStageId: opportunity.stageId,
+					toStageId: previousStage.id,
+					changedBy: context.userId,
+					reason:
+						"Aprobación de detalle cancelada - Regresado a Cierre de propuesta (40%)",
+					isOverride: false,
+				});
 			});
 
 			return { success: true };

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -4152,6 +4152,7 @@ export const crmRouter = {
 					categoria: opportunities.categoria,
 					nit: opportunities.nit,
 					diaPagoMensual: opportunities.diaPagoMensual,
+					creditType: opportunities.creditType,
 					createdAt: opportunities.createdAt,
 					updatedAt: opportunities.updatedAt,
 				})

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -18,7 +18,7 @@ import {
 	User,
 	FileText,
 } from "lucide-react";
-import { useState, useEffect } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
 	OpportunityDetailModal,
@@ -426,7 +426,10 @@ export function InvestmentAssignmentSection() {
 							<Input
 								placeholder="Buscar por nombre, placa..."
 								value={searchTerm}
-								onChange={(e) => setSearchTerm(e.target.value)}
+								onChange={(e) => {
+									const value = e.target.value;
+									startTransition(() => setSearchTerm(value));
+								}}
 								className="pl-10"
 							/>
 						</div>

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -551,14 +551,19 @@ export function CreditDetailView({
 			toast.success(
 				"Aprobación cancelada - Oportunidad regresada a Cierre de propuesta (40%)",
 			);
-			queryClient.invalidateQueries({ queryKey: ["getOpportunities"] });
+			// Batch invalidate related queries
 			queryClient.invalidateQueries({
-				queryKey: ["getCreditDetailApprovalStatus", opportunityId],
+				predicate: (query) => {
+					const key = query.queryKey;
+					return (
+						key[0] === "getOpportunities" ||
+						key[0] === "opportunities" ||
+						(key[0] === "getCreditDetailApprovalStatus" &&
+							key[1] === opportunityId) ||
+						(key[0] === "getOpportunityHistory" && key[1] === opportunityId)
+					);
+				},
 			});
-			queryClient.invalidateQueries({
-				queryKey: ["getOpportunityHistory", opportunityId],
-			});
-			queryClient.invalidateQueries({ queryKey: ["opportunities"] });
 		},
 		onError: (error) => {
 			toast.error(`Error al cancelar aprobación: ${error.message}`);

--- a/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
@@ -596,6 +596,23 @@ function OpportunityDocumentsPage() {
 				opportunity={selectedOpportunityForModal}
 				userRole="analyst"
 				readOnly
+				onNavigateToLead={() => {
+					setIsOpportunityModalOpen(false);
+					if (opportunity?.lead) {
+						setSelectedLeadForModal({
+							id: opportunity.lead.id,
+							firstName: opportunity.lead.firstName,
+							lastName: opportunity.lead.lastName,
+							email: opportunity.lead.email,
+							phone: null,
+							dpi: null,
+							source: "",
+							status: "",
+							createdAt: new Date(),
+						});
+						setIsLeadModalOpen(true);
+					}
+				}}
 			/>
 
 			{/* Lead Detail Modal */}

--- a/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
@@ -599,7 +599,7 @@ function OpportunityDocumentsPage() {
 				onNavigateToLead={() => {
 					setIsOpportunityModalOpen(false);
 					if (opportunity?.lead) {
-						setSelectedLeadForModal({
+						const leadData = {
 							id: opportunity.lead.id,
 							firstName: opportunity.lead.firstName,
 							lastName: opportunity.lead.lastName,
@@ -609,8 +609,12 @@ function OpportunityDocumentsPage() {
 							source: "",
 							status: "",
 							createdAt: new Date(),
-						});
-						setIsLeadModalOpen(true);
+						};
+						// Delay opening second modal to allow first to fully close
+						setTimeout(() => {
+							setSelectedLeadForModal(leadData);
+							setIsLeadModalOpen(true);
+						}, 150);
 					}
 				}}
 			/>

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -782,7 +782,7 @@ function DisbursementSection() {
 		// Find the opportunity with this lead
 		const opp = opportunities?.find((o) => o.leadId === leadId);
 		if (opp) {
-			setSelectedLeadForModal({
+			const leadData = {
 				id: leadId,
 				firstName: opp.leadName?.split(" ")[0] || "",
 				lastName: opp.leadName?.split(" ").slice(1).join(" ") || "",
@@ -792,9 +792,13 @@ function DisbursementSection() {
 				source: "",
 				status: "qualified",
 				createdAt: opp.createdAt,
-			});
+			};
 			setIsOpportunityModalOpen(false);
-			setIsLeadModalOpen(true);
+			// Delay opening second modal to allow first to fully close
+			setTimeout(() => {
+				setSelectedLeadForModal(leadData);
+				setIsLeadModalOpen(true);
+			}, 150);
 		}
 	};
 

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -62,6 +62,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { authClient } from "@/lib/auth-client";
+import { PERMISSIONS } from "@/lib/roles";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/crm/analysis/")({
@@ -208,7 +209,7 @@ function AnalysisPage() {
 	useEffect(() => {
 		if (
 			userProfile.data &&
-			!["admin", "analyst"].includes(userProfile.data.role)
+			!PERMISSIONS.canAccessAnalysis(userProfile.data.role)
 		) {
 			navigate({ to: "/dashboard" });
 		}

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -14,7 +14,7 @@ import {
 	Wallet,
 	XCircle,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { startTransition, useEffect, useState } from "react";
 import { toast } from "sonner";
 import { DisbursementChecklistView } from "@/components/analysis/DisbursementChecklistView";
 import { InvestmentAssignmentSection } from "@/components/analysis/InvestmentAssignmentSection";
@@ -398,7 +398,10 @@ function AnalysisPage() {
 									<Input
 										placeholder="Buscar por nombre, placa..."
 										value={searchTerm}
-										onChange={(e) => setSearchTerm(e.target.value)}
+										onChange={(e) => {
+											const value = e.target.value;
+											startTransition(() => setSearchTerm(value));
+										}}
 										className="pl-10"
 									/>
 								</div>
@@ -824,7 +827,10 @@ function DisbursementSection() {
 							<Input
 								placeholder="Buscar por nombre, placa..."
 								value={searchTerm}
-								onChange={(e) => setSearchTerm(e.target.value)}
+								onChange={(e) => {
+									const value = e.target.value;
+									startTransition(() => setSearchTerm(value));
+								}}
 								className="pl-10"
 							/>
 						</div>

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -2949,7 +2949,10 @@ function RouteComponent() {
 										setEditingLead(selectedLead);
 										isTransitioningToEditRef.current = true;
 										setIsDetailsDialogOpen(false);
-										setIsCreateDialogOpen(true);
+										// Delay opening second modal to allow first to fully close
+										setTimeout(() => {
+											setIsCreateDialogOpen(true);
+										}, 150);
 									}}
 								>
 									Editar Lead


### PR DESCRIPTION
## Summary
- Agregar funcionalidad para cancelar aprobación del detalle de crédito (antes del 90%)
- Usar transacciones para atomicidad en operaciones críticas
- Optimizar performance con startTransition en inputs de búsqueda
- Corregir bloqueo de UI en transiciones modal-a-modal
- Usar sistema PERMISSIONS en lugar de checks directos de roles
- Agregar link al lead desde modal de oportunidad en análisis

## Changes
- `revokeCreditDetailApproval`: nuevo endpoint con validación de etapa y transacción
- `startTransition`: búsquedas en tablas de análisis no bloquean UI
- Modal transitions: delay de 150ms para permitir cleanup de Radix Dialog
- Query invalidations: usar predicate function para batch

## Test plan
- [ ] Aprobar detalle → pasa a 50%
- [ ] Cancelar en 50% → regresa a 40%
- [ ] En 90%+ → error al cancelar
- [ ] Escribir en buscadores de análisis → UI responsiva
- [ ] Abrir modal de oportunidad → click en lead → abre modal de lead sin bloqueo