### PR TITLE
fix(crm): corregir cálculo de checklist para vehículos nuevos

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3503,6 +3503,19 @@ export const crmRouter = {
 					)
 					.limit(1);
 				vehicleInspected = !!inspection;
+
+				// New vehicles don't require inspection
+				if (!vehicleInspected) {
+					const [vehicle] = await db
+						.select({ isNew: vehicles.isNew })
+						.from(vehicles)
+						.where(eq(vehicles.id, opportunity.vehicleId))
+						.limit(1);
+
+					if (vehicle?.isNew) {
+						vehicleInspected = true;
+					}
+				}
 			}
 
 			// Recalculate vehicle section completion

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3159,7 +3159,7 @@ export const crmRouter = {
 						// Vehicle documents subsection
 						documentos: {
 							completed:
-								requiredVehicleDocs.length > 0 &&
+								requiredVehicleDocs.length === 0 ||
 								requiredVehicleDocs.every((doc) =>
 									uploadedVehicleTypes.has(doc.documentType),
 								),
@@ -3483,38 +3483,35 @@ export const crmRouter = {
 					.filter((i: any) => i.required)
 					.every((i: any) => i.completed);
 
-			// Get opportunity and vehicle inspection status
-			const [opportunity] = await db
-				.select({ vehicleId: opportunities.vehicleId })
+			// Get opportunity with vehicle data in a single query
+			const [opportunityWithVehicle] = await db
+				.select({
+					vehicleId: opportunities.vehicleId,
+					vehicleIsNew: vehicles.isNew,
+				})
 				.from(opportunities)
+				.leftJoin(vehicles, eq(vehicles.id, opportunities.vehicleId))
 				.where(eq(opportunities.id, input.opportunityId))
 				.limit(1);
 
+			const opportunity = opportunityWithVehicle;
 			let vehicleInspected = false;
 			if (opportunity?.vehicleId) {
-				const [inspection] = await db
-					.select()
-					.from(vehicleInspections)
-					.where(
-						and(
-							eq(vehicleInspections.vehicleId, opportunity.vehicleId),
-							eq(vehicleInspections.status, "approved"),
-						),
-					)
-					.limit(1);
-				vehicleInspected = !!inspection;
-
 				// New vehicles don't require inspection
-				if (!vehicleInspected) {
-					const [vehicle] = await db
-						.select({ isNew: vehicles.isNew })
-						.from(vehicles)
-						.where(eq(vehicles.id, opportunity.vehicleId))
+				if (opportunity.vehicleIsNew) {
+					vehicleInspected = true;
+				} else {
+					const [inspection] = await db
+						.select()
+						.from(vehicleInspections)
+						.where(
+							and(
+								eq(vehicleInspections.vehicleId, opportunity.vehicleId),
+								eq(vehicleInspections.status, "approved"),
+							),
+						)
 						.limit(1);
-
-					if (vehicle?.isNew) {
-						vehicleInspected = true;
-					}
+					vehicleInspected = !!inspection;
 				}
 			}
 


### PR DESCRIPTION
## Cambios

- Corregir bug donde vehículos nuevos (is_new=true) requerían inspección aprobada para marcar la sección de vehículo como completada
- Vehículos nuevos no requieren inspección, pero el código no lo verificaba al actualizar verificaciones del vehículo
- Esto causaba que vehiculo.completed=false y overallProgress quedara en 96% aunque todo estuviera completo

## Testing
- Verificar que oportunidades con vehículos nuevos muestren 100% cuando todo esté completo
- Verificar que vehiculo.completed sea true para vehículos nuevos sin inspección