### PR TITLE
Updates key copy cost calculation in invoice

### DIFF
--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -160,7 +160,7 @@ interface QuotationDataForBilling {
 	interestCost: string | null; // Intereses anticipados (cuota 0)
 	extraMembershipCost: string | null; // Membresía extra (cuota 0)
 	appointmentCost: string | null; // Nombramiento
-	keyCopyCost: string | null; // Copia de llave
+	keyCopyDiffCost: string | null; // Diferencia de copia de llave
 	extraInsuranceCost: string | null; // Seguro extra
 	extraAdminCost: string | null; // Gastos administrativos
 }
@@ -359,7 +359,7 @@ async function getLatestApprovedQuotation(
 				interestCost: quotations.interestCost,
 				extraMembershipCost: quotations.extraMembershipCost,
 				appointmentCost: quotations.appointmentCost,
-				keyCopyCost: quotations.keyCopyCost,
+				keyCopyDiffCost: quotations.keyCopyDiffCost,
 				extraInsuranceCost: quotations.extraInsuranceCost,
 				extraAdminCost: quotations.extraAdminCost,
 			})
@@ -387,8 +387,8 @@ async function getLatestApprovedQuotation(
  * 4. GARANTÍA MOBILIARIA: 1 factura con 1 rubro (Q100 fijo si mobile_guarantee_cost > 0)
  * 5. CUOTA 0: 1 factura con 2 rubros (interest_cost + extra_membership_cost)
  * 6. NOMBRAMIENTO: 1 factura con 1 rubro (Q150 fijo si appointment_cost > 0)
- * 7. COPIA DE LLAVE: 1 factura con 1 rubro (Q950 fijo si key_copy_cost > 0)
- * 8. SEGURO Y GASTOS ADMIN: 1 factura con 2 rubros (extra_insurance_cost + extra_membership_cost)
+ * 7. COPIA DE LLAVE: 1 factura con 1 rubro (valor de key_copy_diff_cost)
+ * 8. SEGURO Y GASTOS ADMIN: 1 factura con 2 rubros (extra_insurance_cost + extra_admin_cost)
  */
 function buildInvoices(
 	royalti: number | null,
@@ -508,16 +508,16 @@ function buildInvoices(
 		});
 	}
 
-	// 7. COPIA DE LLAVE - Q950 fijo si tiene costo (1 factura, 1 rubro)
-	const keyCopyCost = quotation.keyCopyCost
-		? Number(quotation.keyCopyCost)
+	// 7. COPIA DE LLAVE - Facturar el valor real de key_copy_diff_cost (1 factura, 1 rubro)
+	const keyCopyDiffCost = quotation.keyCopyDiffCost
+		? Number(quotation.keyCopyDiffCost)
 		: 0;
-	if (keyCopyCost > 0) {
+	if (keyCopyDiffCost > 0) {
 		invoices.push({
 			name: "Copia de Llave",
 			items: [
 				{
-					monto: FACTURACION_COPIA_LLAVE_COSTO,
+					monto: keyCopyDiffCost,
 					rubro: "Copia de llave - Duplicado de llave del vehículo",
 				},
 			],


### PR DESCRIPTION
This pull request updates the billing logic for the "Copia de Llave" (key copy) charge in the CRM's opportunity closing process. Instead of billing a fixed amount, the system now uses the actual "key copy difference cost" provided in the quotation data. The relevant property and all references have been renamed to reflect this change, and a minor correction was made to the insurance and admin cost calculation.

Key changes:

### Key Copy Cost Calculation

* Replaced the `keyCopyCost` property with `keyCopyDiffCost` in the `QuotationDataForBilling` interface and all related usages, ensuring the system now tracks and bills the actual key copy difference cost instead of a fixed value. [[1]](diffhunk://#diff-5377e9349347e79ce6ad4130a9d5c6bb1ff65ceb0bddebc3957577757275813fL163-R163) [[2]](diffhunk://#diff-5377e9349347e79ce6ad4130a9d5c6bb1ff65ceb0bddebc3957577757275813fL362-R362)
* Updated the invoice generation logic in `buildInvoices` to use the real value from `keyCopyDiffCost` for the "Copia de Llave" invoice item, rather than the previous hardcoded amount.
* Updated documentation and comments to clarify that the billed amount for "Copia de Llave" is now the value of `key_copy_diff_cost`, not a fixed Q950.

### Insurance and Admin Cost Calculation

* Corrected the comment for the "Seguro y Gastos Admin" (insurance and admin costs) invoice to reference `extra_admin_cost` instead of incorrectly repeating `extra_membership_cost`.