### PR TITLE
Removes NIT validation on credit approval

### DIFF
--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -520,14 +520,6 @@ export function CreditDetailView({
 	// Mutation para aprobar detalle de crédito
 	const approveCreditDetailMutation = useMutation({
 		mutationFn: async () => {
-			// Validar que el NIT esté presente
-			const nitValue = editNit || opportunity.nit;
-			if (!nitValue || nitValue.trim() === "") {
-				throw new Error(
-					"El NIT es obligatorio para aprobar el detalle de crédito. Por favor ingrese el NIT del cliente.",
-				);
-			}
-
 			const cuotaMensual = quotation?.monthlyPayment || "0";
 			const tasaMensualValue = quotation?.interestRate || "0";
 			const numeroCuotasValue = quotation?.termMonths || 0;


### PR DESCRIPTION
Removes the explicit validation for the NIT field during credit detail approval.

The necessity of this validation is handled elsewhere, so its removal streamlines the approval process.