### PR TITLE
Makes lead name in opportunity modal clickable

### DIFF
--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -272,9 +272,19 @@ export function OpportunityDetailModal({
 												{opportunity.lead.firstName} {opportunity.lead.lastName}
 											</span>
 										) : (
-											<span className="font-medium">
-												{opportunity.lead.firstName} {opportunity.lead.lastName}
-											</span>
+											<Link
+												to="/crm/leads"
+												search={{
+													leadId: opportunity.lead.id,
+												}}
+												className="font-medium text-primary hover:underline"
+												onClick={() => onOpenChange(false)}
+											>
+												<span className="font-medium">
+													{opportunity.lead.firstName} {opportunity.lead.lastName}
+												</span>
+											</Link>
+											
 										)}
 									</div>
 									{opportunity.lead.dpi && (


### PR DESCRIPTION
Makes the lead's name in the opportunity detail modal clickable and redirects to the leads page with the corresponding lead selected. This improves navigation and allows users to quickly access the lead's details.