### PR TITLE
fix(crm): hacer número de motor opcional para avance a jurídico

### DIFF
--- a/apps/crm/apps/server/src/lib/vehicle-helpers.ts
+++ b/apps/crm/apps/server/src/lib/vehicle-helpers.ts
@@ -5,11 +5,10 @@ import type { Vehicle } from "../db/schema/vehicles";
  * Aplica a todos los vehículos (nuevos y usados).
  */
 export function getMissingFieldsForContracts(
-	vehicle: Pick<Vehicle, "vinNumber" | "motorNumber" | "seats" | "vehicleUse">,
+	vehicle: Pick<Vehicle, "vinNumber" | "seats" | "vehicleUse">,
 ): string[] {
 	const requiredForContracts = [
 		{ field: "vinNumber" as const, label: "VIN/Chasis" },
-		{ field: "motorNumber" as const, label: "Número de Motor" },
 		{ field: "seats" as const, label: "Asientos" },
 		{ field: "vehicleUse" as const, label: "Uso (Particular/Comercial)" },
 	];
@@ -28,7 +27,6 @@ export function getMissingFieldsForCompletion(
 		Vehicle,
 		| "isNew"
 		| "vinNumber"
-		| "motorNumber"
 		| "seats"
 		| "vehicleUse"
 		| "licensePlate"
@@ -42,7 +40,6 @@ export function getMissingFieldsForCompletion(
 
 	const requiredForCompletion = [
 		{ field: "vinNumber" as const, label: "VIN/Chasis" },
-		{ field: "motorNumber" as const, label: "Número de Motor" },
 		{ field: "seats" as const, label: "Asientos" },
 		{ field: "vehicleUse" as const, label: "Uso (Particular/Comercial)" },
 		{ field: "licensePlate" as const, label: "Placa" },
@@ -60,7 +57,7 @@ export function getMissingFieldsForCompletion(
  * Verifica si un vehículo tiene los datos mínimos para generar contratos.
  */
 export function hasMinimumDataForContracts(
-	vehicle: Pick<Vehicle, "vinNumber" | "motorNumber" | "seats" | "vehicleUse">,
+	vehicle: Pick<Vehicle, "vinNumber" | "seats" | "vehicleUse">,
 ): boolean {
 	return getMissingFieldsForContracts(vehicle).length === 0;
 }
@@ -76,7 +73,6 @@ export function isNewVehicleDataComplete(
 		Vehicle,
 		| "isNew"
 		| "vinNumber"
-		| "motorNumber"
 		| "seats"
 		| "vehicleUse"
 		| "licensePlate"

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -4331,13 +4331,11 @@ export const crmRouter = {
 								isNew: vehicle.isNew,
 								hasRequiredData: !!(
 									vehicle.vinNumber &&
-									vehicle.motorNumber &&
 									vehicle.seats &&
 									vehicle.vehicleUse
 								),
 								missingFields: getMissingFieldsForContracts({
 									vinNumber: vehicle.vinNumber,
-									motorNumber: vehicle.motorNumber,
 									seats: vehicle.seats,
 									vehicleUse: vehicle.vehicleUse,
 								}),
@@ -4496,7 +4494,6 @@ export const crmRouter = {
 				const [vehicle] = await db
 					.select({
 						vinNumber: vehicles.vinNumber,
-						motorNumber: vehicles.motorNumber,
 						seats: vehicles.seats,
 						vehicleUse: vehicles.vehicleUse,
 					})

--- a/apps/crm/apps/server/src/services/contract-data-mapper.ts
+++ b/apps/crm/apps/server/src/services/contract-data-mapper.ts
@@ -403,8 +403,8 @@ export async function mapOpportunityToContractData(
 				placasMayusculas: toUpperCase(vehicle.licensePlate || ""),
 				vin: vehicle.vinNumber || "",
 				vinMayusculas: toUpperCase(vehicle.vinNumber || ""),
-				motor: vehicle.motorNumber || "",
-				motorMayusculas: toUpperCase(vehicle.motorNumber || ""),
+				motor: vehicle.motorNumber || "-",
+				motorMayusculas: toUpperCase(vehicle.motorNumber || "-"),
 				serie: vehicle.series || undefined,
 				serieMayusculas: vehicle.series
 					? toUpperCase(vehicle.series)
@@ -582,7 +582,6 @@ export async function validateOpportunityForContracts(
 		missingVehicleFields.push("Vehículo no asociado");
 	} else {
 		if (!vehicle.vinNumber) missingVehicleFields.push("VIN/Chasis");
-		if (!vehicle.motorNumber) missingVehicleFields.push("Número de Motor");
 		if (!vehicle.seats) missingVehicleFields.push("Asientos");
 		if (!vehicle.vehicleUse)
 			missingVehicleFields.push("Uso (Particular/Comercial)");

--- a/apps/crm/apps/web/src/routes/juridico/generate.$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/generate.$opportunityId.tsx
@@ -66,7 +66,7 @@ function RouteComponent() {
 			dpi: string;
 			documentNames: string[];
 		}) => {
-			return await client.getDocumentsByDpi({ dpi, documentNames });
+			return await client.getDocumentsByDpi({ dpi: dpi.replace(/\s/g, ""), documentNames });
 		},
 	});
 


### PR DESCRIPTION
## Summary
- Número de motor ya no es obligatorio para avanzar a etapa 80% (jurídico) ni para cerrar al 100%
- Vehículos nuevos sin número de motor ahora pueden avanzar sin bloqueo
- En contratos legales, si no hay número de motor se envía "-" como valor por defecto
- Validación removida en vehicle-helpers, contract-data-mapper y crm router

## Test plan
- [ ] Verificar que un vehículo nuevo sin número de motor puede avanzar a 80%
- [ ] Verificar que los contratos generados muestran "-" cuando no hay motor
- [ ] Verificar que vehículos con número de motor siguen funcionando normal