### PR TITLE
feat(crm): add score calculation button to lead views

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -62,6 +62,7 @@ import {
 	getMissingFieldsForCompletion,
 	getMissingFieldsForContracts,
 } from "../lib/vehicle-helpers";
+import { scoreLead } from "../services/lead-scoring";
 
 /**
  * Helper function to check vehicle inspection status.
@@ -571,7 +572,10 @@ export const crmRouter = {
 
 			// Admin and juridico can update any lead, others only their own
 			const canUpdateAnyLead =
-				context.userRole === "admin" || context.userRole === "juridico" || context.userRole === "sales_supervisor" || context.userRole === "analyst";
+				context.userRole === "admin" ||
+				context.userRole === "juridico" ||
+				context.userRole === "sales_supervisor" ||
+				context.userRole === "analyst";
 			const whereClause = canUpdateAnyLead
 				? eq(leads.id, id)
 				: and(eq(leads.id, id), eq(leads.assignedTo, context.userId));
@@ -3413,7 +3417,9 @@ export const crmRouter = {
 				// Recalculate vehicle section completion
 				checklistData.sections.vehiculo.completed =
 					vehicleInspected &&
-					(checklistData.sections.vehiculo.documentos?.items?.length > 0 ? (checklistData.sections.vehiculo.documentos?.completed ?? true) : true) &&
+					(checklistData.sections.vehiculo.documentos?.items?.length > 0
+						? (checklistData.sections.vehiculo.documentos?.completed ?? true)
+						: true) &&
 					(checklistData.sections.vehiculo.verificaciones?.completed ?? false);
 			}
 
@@ -3545,7 +3551,9 @@ export const crmRouter = {
 			// Recalculate vehicle section completion
 			checklistData.sections.vehiculo.completed =
 				vehicleInspected &&
-				(checklistData.sections.vehiculo.documentos?.items?.length > 0 ? (checklistData.sections.vehiculo.documentos?.completed ?? true) : true) &&
+				(checklistData.sections.vehiculo.documentos?.items?.length > 0
+					? (checklistData.sections.vehiculo.documentos?.completed ?? true)
+					: true) &&
 				checklistData.sections.vehiculo.verificaciones.completed;
 
 			// Recalculate client verificaciones completion
@@ -4290,7 +4298,7 @@ export const crmRouter = {
 					hasCreditData: !!(
 						opp.numeroCuotas &&
 						opp.tasaInteres &&
-						opp.cuotaMensual 
+						opp.cuotaMensual
 					),
 					// Campos adicionales para edición
 					categoria: opp.categoria,
@@ -4577,5 +4585,17 @@ export const crmRouter = {
 				success: true,
 				message: "Inversionista asignado y oportunidad avanzada a 80%",
 			};
+		}),
+
+	// ── Credit Scoring ──────────────────────────────────────────────────
+	scoreLead: crmProcedure
+		.input(
+			z.object({
+				leadId: z.string().uuid(),
+				opportunityId: z.string().uuid().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			return await scoreLead(input.leadId, input.opportunityId);
 		}),
 };

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -86,6 +86,7 @@ export const appRouter = {
 	createClient: crmRouter.createClient,
 	updateClient: crmRouter.updateClient,
 	getDashboardStats: crmRouter.getDashboardStats,
+	scoreLead: crmRouter.scoreLead,
 
 	// Vehicles routes
 	getVehicles: vehiclesRouter.getAll,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -670,7 +670,9 @@ export class CarteraBackClient {
 	 * @param input - Datos de la factura a generar
 	 * @returns Resultado de la operación
 	 */
-	async facturarGenerico(input: FacturarGenericoInput): Promise<FacturarGenericoResponse> {
+	async facturarGenerico(
+		input: FacturarGenericoInput,
+	): Promise<FacturarGenericoResponse> {
 		const response = await this.request<FacturarGenericoResponse>(
 			"/api/dte/facturar-generico",
 			{

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -19,14 +19,14 @@ import {
 } from "../db/schema";
 import { contratosFinanciamiento } from "../db/schema/cobros";
 import { clients, leads, opportunities } from "../db/schema/crm";
-import type { FacturaItem } from "../types/cartera-back";
 import { formatMissingFields, getMissingFields } from "../lib/vehicle-helpers";
+import type { FacturaItem } from "../types/cartera-back";
+import { carteraBackClient } from "./cartera-back-client";
 import {
 	type CreateCreditoResult,
 	createCreditoInCarteraBack,
 	isCarteraBackEnabled,
 } from "./cartera-back-integration";
-import { carteraBackClient } from "./cartera-back-client";
 
 // ============================================================================
 // CONSTANTS
@@ -336,7 +336,9 @@ function validateOpportunityForClose(opp: OpportunityData): string[] {
 /**
  * Registra un log de sincronización de facturación
  */
-async function logInvoiceSyncOperation(log: NewCarteraBackSyncLog): Promise<void> {
+async function logInvoiceSyncOperation(
+	log: NewCarteraBackSyncLog,
+): Promise<void> {
 	try {
 		await db.insert(carteraBackSyncLog).values(log);
 	} catch (error) {
@@ -370,10 +372,7 @@ async function getLatestApprovedQuotation(
 
 		return quotation || null;
 	} catch (error) {
-		console.error(
-			"[CloseOpportunity] Error fetching latest quotation:",
-			error,
-		);
+		console.error("[CloseOpportunity] Error fetching latest quotation:", error);
 		return null;
 	}
 }
@@ -410,7 +409,9 @@ function buildInvoices(
 	}
 
 	if (!quotation) {
-		console.log("[CloseOpportunity] No quotation found, only royalty invoice will be generated");
+		console.log(
+			"[CloseOpportunity] No quotation found, only royalty invoice will be generated",
+		);
 		return invoices;
 	}
 
@@ -606,7 +607,8 @@ function generateInvoicesInBackground(params: GenerateInvoicesParams): void {
 					};
 
 					// Llamar al endpoint de facturación genérica
-					const response = await carteraBackClient.facturarGenerico(requestBody);
+					const response =
+						await carteraBackClient.facturarGenerico(requestBody);
 
 					// Registrar éxito en el log con el payload exacto enviado
 					await logInvoiceSyncOperation({
@@ -1106,9 +1108,7 @@ export async function closeOpportunity(
 				quotation,
 				userId,
 			});
-			console.log(
-				"[CloseOpportunity] Invoice generation queued in background",
-			);
+			console.log("[CloseOpportunity] Invoice generation queued in background");
 		}
 
 		// 4. Complete local operations in a transaction for atomicity

--- a/apps/crm/apps/server/src/services/contract-data-mapper.ts
+++ b/apps/crm/apps/server/src/services/contract-data-mapper.ts
@@ -403,8 +403,8 @@ export async function mapOpportunityToContractData(
 				placasMayusculas: toUpperCase(vehicle.licensePlate || ""),
 				vin: vehicle.vinNumber || "",
 				vinMayusculas: toUpperCase(vehicle.vinNumber || ""),
-				motor: vehicle.motorNumber || "-",
-				motorMayusculas: toUpperCase(vehicle.motorNumber || "-"),
+				motor: vehicle.motorNumber || "",
+				motorMayusculas: toUpperCase(vehicle.motorNumber || ""),
 				serie: vehicle.series || undefined,
 				serieMayusculas: vehicle.series
 					? toUpperCase(vehicle.series)

--- a/apps/crm/apps/server/src/services/lead-scoring.ts
+++ b/apps/crm/apps/server/src/services/lead-scoring.ts
@@ -1,0 +1,229 @@
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { leads, opportunities } from "../db/schema/crm";
+
+// ── Interfaces ──────────────────────────────────────────────────────────
+
+export interface ClientData {
+	age: number;
+	income: number;
+	loan_amount: number;
+	credit_card: number;
+	own_home: number;
+	own_vehicle: number;
+	work_time: number;
+	occupation: number;
+	marital_status: number;
+	dependents: number;
+	loan_purpose: number;
+	num_credits: number;
+}
+
+export interface CreditScoreResponse {
+	fit: boolean;
+	probability: number;
+}
+
+interface MappingResult {
+	data: ClientData | null;
+	missingFields: string[];
+}
+
+// ── Encoding helpers ────────────────────────────────────────────────────
+
+function encodeWorkTime(value: string | null | undefined): number | null {
+	const map: Record<string, number> = {
+		less_than_1: 0,
+		"1_to_5": 0,
+		"5_to_10": 1,
+		"10_plus": 2,
+	};
+	return value ? (map[value] ?? null) : null;
+}
+
+function encodeOccupation(value: string | null | undefined): number | null {
+	const map: Record<string, number> = {
+		employee: 0,
+		owner: 1,
+	};
+	return value ? (map[value] ?? null) : null;
+}
+
+function encodeMaritalStatus(value: string | null | undefined): number | null {
+	if (!value) return null;
+	return value === "single" ? 0 : 1;
+}
+
+function encodeLoanPurpose(value: string | null | undefined): number {
+	if (!value || value === "personal") return 0;
+	return 1; // business
+}
+
+function encodeAge(age: number | null | undefined): number | null {
+	if (age == null) return null;
+	if (age < 30) return 0;
+	if (age < 40) return 1;
+	if (age < 50) return 2;
+	return 3;
+}
+
+function encodeBool(value: boolean | null | undefined): number {
+	return value ? 1 : 0;
+}
+
+// ── Map lead → ML input ─────────────────────────────────────────────────
+
+export function mapLeadToScoringInput(
+	lead: {
+		age: number | null;
+		monthlyIncome: string | null;
+		loanAmount: string | null;
+		hasCreditCard: boolean | null;
+		ownsHome: boolean | null;
+		ownsVehicle: boolean | null;
+		workTime: string | null;
+		occupation: string | null;
+		maritalStatus: string | null;
+		dependents: number | null;
+	},
+	loanPurpose?: string | null,
+): MappingResult {
+	const missing: string[] = [];
+
+	if (lead.age == null) missing.push("age");
+	if (!lead.monthlyIncome) missing.push("monthlyIncome");
+	if (!lead.loanAmount) missing.push("loanAmount");
+	if (lead.workTime == null) missing.push("workTime");
+	if (lead.occupation == null) missing.push("occupation");
+	if (lead.maritalStatus == null) missing.push("maritalStatus");
+
+	if (missing.length > 0) {
+		return { data: null, missingFields: missing };
+	}
+
+	const encodedAge = encodeAge(lead.age);
+	const encodedWorkTime = encodeWorkTime(lead.workTime);
+	const encodedOccupation = encodeOccupation(lead.occupation);
+	const encodedMaritalStatus = encodeMaritalStatus(lead.maritalStatus);
+
+	if (
+		encodedAge == null ||
+		encodedWorkTime == null ||
+		encodedOccupation == null ||
+		encodedMaritalStatus == null
+	) {
+		return { data: null, missingFields: ["encoding_error"] };
+	}
+
+	return {
+		data: {
+			age: encodedAge,
+			income: Number.parseFloat(lead.monthlyIncome!),
+			loan_amount: Number.parseFloat(lead.loanAmount!),
+			credit_card: encodeBool(lead.hasCreditCard),
+			own_home: encodeBool(lead.ownsHome),
+			own_vehicle: encodeBool(lead.ownsVehicle),
+			work_time: encodedWorkTime,
+			occupation: encodedOccupation,
+			marital_status: encodedMaritalStatus,
+			dependents: lead.dependents ?? 0,
+			loan_purpose: encodeLoanPurpose(loanPurpose),
+			num_credits: 0,
+		},
+		missingFields: [],
+	};
+}
+
+// ── ML API call ─────────────────────────────────────────────────────────
+
+const SCORING_API_URL =
+	process.env.SCORING_API_URL || "https://scoring.devteamatcci.site/predict";
+
+export async function predictCreditScore(
+	data: ClientData,
+): Promise<CreditScoreResponse> {
+	const response = await fetch(SCORING_API_URL, {
+		method: "POST",
+		headers: { "Content-Type": "application/json" },
+		body: JSON.stringify(data),
+	});
+
+	if (!response.ok) {
+		throw new Error(
+			`Scoring API error: ${response.status} ${response.statusText}`,
+		);
+	}
+
+	return response.json() as Promise<CreditScoreResponse>;
+}
+
+// ── Orchestrator ────────────────────────────────────────────────────────
+
+export async function scoreLead(leadId: string, opportunityId?: string) {
+	// 1. Fetch lead
+	const [lead] = await db
+		.select({
+			age: leads.age,
+			monthlyIncome: leads.monthlyIncome,
+			loanAmount: leads.loanAmount,
+			hasCreditCard: leads.hasCreditCard,
+			ownsHome: leads.ownsHome,
+			ownsVehicle: leads.ownsVehicle,
+			workTime: leads.workTime,
+			occupation: leads.occupation,
+			maritalStatus: leads.maritalStatus,
+			dependents: leads.dependents,
+		})
+		.from(leads)
+		.where(eq(leads.id, leadId))
+		.limit(1);
+
+	if (!lead) {
+		throw new Error(`Lead ${leadId} not found`);
+	}
+
+	// 2. Get loanPurpose from opportunity if provided
+	let loanPurpose: string | null = null;
+	if (opportunityId) {
+		const [opp] = await db
+			.select({ loanPurpose: opportunities.loanPurpose })
+			.from(opportunities)
+			.where(eq(opportunities.id, opportunityId))
+			.limit(1);
+		loanPurpose = opp?.loanPurpose ?? null;
+	}
+
+	// 3. Map to ML input
+	const { data, missingFields } = mapLeadToScoringInput(lead, loanPurpose);
+
+	if (!data) {
+		return {
+			score: null,
+			fit: null,
+			scoredAt: null,
+			missingFields,
+		};
+	}
+
+	// 4. Call ML model
+	const result = await predictCreditScore(data);
+
+	// 5. Update lead in DB
+	const scoredAt = new Date();
+	await db
+		.update(leads)
+		.set({
+			score: String(result.probability),
+			fit: result.fit,
+			scoredAt,
+			updatedAt: scoredAt,
+		})
+		.where(eq(leads.id, leadId));
+
+	return {
+		score: result.probability,
+		fit: result.fit,
+		scoredAt,
+		missingFields: [] as string[],
+	};
+}

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -450,7 +450,7 @@ export function InvestmentAssignmentSection() {
 					{/* Buscador */}
 					<div className="mb-4 flex items-center gap-4">
 						<div className="relative flex-1">
-							<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
+							<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 							<Input
 								placeholder="Buscar por nombre, placa..."
 								value={searchTerm}

--- a/apps/crm/apps/web/src/components/contracts/DynamicContractWizard.tsx
+++ b/apps/crm/apps/web/src/components/contracts/DynamicContractWizard.tsx
@@ -1673,13 +1673,11 @@ export function DynamicContractWizard({
 										<Link2 className="h-5 w-5 text-blue-600" />
 									</div>
 									<div>
-										<h4 className="font-semibold text-blue-800">
-											¿Qué sigue?
-										</h4>
+										<h4 className="font-semibold text-blue-800">¿Qué sigue?</h4>
 										<ul className="mt-1 list-inside list-disc space-y-1 text-blue-700 text-sm">
 											<li>
-												<strong>Revisa los documentos generados</strong> haciendo
-												clic en el botón morado "Ver PDF"
+												<strong>Revisa los documentos generados</strong>{" "}
+												haciendo clic en el botón morado "Ver PDF"
 											</li>
 											<li>
 												Si algún documento tiene errores, haz clic en "Corregir

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -526,7 +526,7 @@ export function CreditDetailView({
 			const totalFinanced = quotation?.totalFinanced || "0";
 
 			// Actualizar el value de la oportunidad con el totalFinanced de la cotización
-			
+
 			await client.updateOpportunity({
 				id: opportunityId,
 				numeroCuotas: numeroCuotasValue,
@@ -534,7 +534,6 @@ export function CreditDetailView({
 				cuotaMensual: cuotaMensual,
 				value: totalFinanced,
 			});
-			
 
 			return client.approveCreditDetail({ opportunityId });
 		},

--- a/apps/crm/apps/web/src/components/juridico/ContractCard.tsx
+++ b/apps/crm/apps/web/src/components/juridico/ContractCard.tsx
@@ -1,6 +1,13 @@
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
-import { Copy, Edit, ExternalLink, FileText, Loader2, Trash2 } from "lucide-react";
+import {
+	Copy,
+	Edit,
+	ExternalLink,
+	FileText,
+	Loader2,
+	Trash2,
+} from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import {
@@ -335,7 +342,9 @@ export function ContractCard({
 						</AlertDialogDescription>
 					</AlertDialogHeader>
 					<AlertDialogFooter>
-						<AlertDialogCancel disabled={isDeleting}>Cancelar</AlertDialogCancel>
+						<AlertDialogCancel disabled={isDeleting}>
+							Cancelar
+						</AlertDialogCancel>
 						<AlertDialogAction
 							onClick={handleDelete}
 							disabled={isDeleting}

--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -1,6 +1,7 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
-import { Building, Mail, Phone, Users } from "lucide-react";
+import { Building, Loader2, Mail, Phone, Users } from "lucide-react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -23,7 +24,7 @@ import {
 	getStatusLabel,
 	getWorkTimeLabel,
 } from "@/lib/crm-formatters";
-import { orpc } from "@/utils/orpc";
+import { client, orpc } from "@/utils/orpc";
 
 // Type for the lead data
 export type LeadForModal = {
@@ -116,6 +117,39 @@ export function LeadDetailModal({
 			input: { leadId: lead?.id ?? "" },
 		}),
 		enabled: open && !!lead?.id,
+	});
+
+	const queryClient = useQueryClient();
+
+	const scoringFieldLabels: Record<string, string> = {
+		age: "Edad",
+		monthlyIncome: "Ingreso Mensual",
+		loanAmount: "Monto del Préstamo",
+		workTime: "Tiempo Laboral",
+		occupation: "Ocupación",
+		maritalStatus: "Estado Civil",
+	};
+
+	const scoreLeadMutation = useMutation({
+		mutationFn: (leadId: string) => client.scoreLead({ leadId }),
+		onSuccess: (data) => {
+			if (data.missingFields && data.missingFields.length > 0) {
+				const fieldNames = data.missingFields
+					.map((f: string) => scoringFieldLabels[f] || f)
+					.join(", ");
+				toast.warning(
+					`No se puede calcular el score. Faltan campos: ${fieldNames}`,
+				);
+				return;
+			}
+			toast.success("Score crediticio calculado exitosamente");
+			queryClient.invalidateQueries({
+				predicate: (query) => query.queryKey[0] === "getLeads",
+			});
+		},
+		onError: () => {
+			toast.error("Error al calcular el score");
+		},
 	});
 
 	if (!lead) return null;
@@ -550,9 +584,22 @@ export function LeadDetailModal({
 					</div>
 
 					{/* Scoring Section */}
-					{displayLead.score && (
-						<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+					<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+						<div className="flex items-center justify-between">
 							<h3 className="font-semibold text-base">Análisis de Riesgo</h3>
+							<Button
+								size="sm"
+								variant="outline"
+								disabled={scoreLeadMutation.isPending}
+								onClick={() => scoreLeadMutation.mutate(displayLead.id)}
+							>
+								{scoreLeadMutation.isPending && (
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								)}
+								{displayLead.score ? "Recalcular Score" : "Calcular Score"}
+							</Button>
+						</div>
+						{displayLead.score ? (
 							<div className="grid grid-cols-3 gap-4">
 								<div className="space-y-2">
 									<Label className="font-medium text-muted-foreground text-sm">
@@ -604,8 +651,12 @@ export function LeadDetailModal({
 									</p>
 								</div>
 							</div>
-						</div>
-					)}
+						) : (
+							<p className="text-muted-foreground text-sm">
+								Sin análisis de riesgo aún
+							</p>
+						)}
+					</div>
 
 					{/* Credit Analysis Section (Read-only view) */}
 					{creditAnalysisQuery.data && (

--- a/apps/crm/apps/web/src/components/mode-toggle.tsx
+++ b/apps/crm/apps/web/src/components/mode-toggle.tsx
@@ -15,7 +15,7 @@ export function ModeToggle() {
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
 				<Button variant="outline" size="icon">
-					<Sun className="dark:-rotate-90 h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:scale-0" />
+					<Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
 					<Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
 					<span className="sr-only">Cambiar tema</span>
 				</Button>

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -281,10 +281,10 @@ export function OpportunityDetailModal({
 												onClick={() => onOpenChange(false)}
 											>
 												<span className="font-medium">
-													{opportunity.lead.firstName} {opportunity.lead.lastName}
+													{opportunity.lead.firstName}{" "}
+													{opportunity.lead.lastName}
 												</span>
 											</Link>
-											
 										)}
 									</div>
 									{opportunity.lead.dpi && (

--- a/apps/crm/apps/web/src/components/ui/select.tsx
+++ b/apps/crm/apps/web/src/components/ui/select.tsx
@@ -66,7 +66,7 @@ function SelectContent({
 				className={cn(
 					"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
 					position === "popper" &&
-						"data-[side=left]:-translate-x-1 data-[side=top]:-translate-y-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1",
+						"data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
 					size === "full" && "right-0 left-0 w-full",
 					className,
 				)}
@@ -135,7 +135,7 @@ function SelectSeparator({
 	return (
 		<SelectPrimitive.Separator
 			data-slot="select-separator"
-			className={cn("-mx-1 pointer-events-none my-1 h-px bg-border", className)}
+			className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
 			{...props}
 		/>
 	);

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -401,7 +401,7 @@ function AnalysisPage() {
 							{/* Buscador */}
 							<div className="mb-4 flex items-center gap-4">
 								<div className="relative max-w-sm flex-1">
-									<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
+									<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 									<Input
 										placeholder="Buscar por nombre, placa..."
 										value={searchTerm}
@@ -834,7 +834,7 @@ function DisbursementSection() {
 					{/* Buscador */}
 					<div className="mb-4 flex items-center gap-4">
 						<div className="relative flex-1">
-							<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
+							<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 							<Input
 								placeholder="Buscar por nombre, placa..."
 								value={searchTerm}

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -9,6 +9,7 @@ import {
 	ChevronsLeft,
 	ChevronsRight,
 	Filter,
+	Loader2,
 	Mail,
 	MoreHorizontal,
 	Pencil,
@@ -510,6 +511,39 @@ function RouteComponent() {
 		},
 		onError: (error: any) => {
 			toast.error(error.message || "Error al crear la oportunidad");
+		},
+	});
+
+	// Mapa de campos a español para scoring
+	const scoringFieldLabels: Record<string, string> = {
+		age: "Edad",
+		monthlyIncome: "Ingreso Mensual",
+		loanAmount: "Monto del Préstamo",
+		workTime: "Tiempo Laboral",
+		occupation: "Ocupación",
+		maritalStatus: "Estado Civil",
+	};
+
+	// Mutación para calcular score crediticio
+	const scoreLeadMutation = useMutation({
+		mutationFn: (leadId: string) => client.scoreLead({ leadId }),
+		onSuccess: (data) => {
+			if (data.missingFields && data.missingFields.length > 0) {
+				const fieldNames = data.missingFields
+					.map((f: string) => scoringFieldLabels[f] || f)
+					.join(", ");
+				toast.warning(
+					`No se puede calcular el score. Faltan campos: ${fieldNames}`,
+				);
+				return;
+			}
+			toast.success("Score crediticio calculado exitosamente");
+			queryClient.invalidateQueries({
+				predicate: (query) => query.queryKey[0] === "getLeads",
+			});
+		},
+		onError: () => {
+			toast.error("Error al calcular el score");
 		},
 	});
 
@@ -2416,11 +2450,24 @@ function RouteComponent() {
 							</div>
 
 							{/* Scoring Section */}
-							{selectedLead.score && (
-								<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+							<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+								<div className="flex items-center justify-between">
 									<h3 className="font-semibold text-base">
 										Análisis de Riesgo
 									</h3>
+									<Button
+										size="sm"
+										variant="outline"
+										disabled={scoreLeadMutation.isPending}
+										onClick={() => scoreLeadMutation.mutate(selectedLead.id)}
+									>
+										{scoreLeadMutation.isPending && (
+											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										)}
+										{selectedLead.score ? "Recalcular Score" : "Calcular Score"}
+									</Button>
+								</div>
+								{selectedLead.score ? (
 									<div className="grid grid-cols-3 gap-4">
 										<div className="space-y-2">
 											<Label className="font-medium text-muted-foreground text-sm">
@@ -2472,8 +2519,12 @@ function RouteComponent() {
 											</p>
 										</div>
 									</div>
-								</div>
-							)}
+								) : (
+									<p className="text-muted-foreground text-sm">
+										Sin análisis de riesgo aún
+									</p>
+								)}
+							</div>
 
 							{/* Credit Analysis Section - Análisis de Capacidad de Pago */}
 							<div className="space-y-3 rounded-lg border bg-muted/30 p-4">

--- a/apps/crm/apps/web/src/routes/juridico/index.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/index.tsx
@@ -358,7 +358,7 @@ function RouteComponent() {
 
 							{/* Barra de búsqueda */}
 							<div className="relative">
-								<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
+								<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 								<Input
 									placeholder="Buscar por título, nombre o DPI..."
 									value={opportunitiesSearchQuery}
@@ -550,7 +550,7 @@ function RouteComponent() {
 
 							{/* Barra de búsqueda */}
 							<div className="relative">
-								<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
+								<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
 								<Input
 									placeholder="Buscar por nombre, DPI o email..."
 									value={searchQuery}


### PR DESCRIPTION
## Summary
- Agrega botón "Calcular Score" / "Recalcular Score" en la vista de leads y en el modal de detalle de lead
- La sección de Análisis de Riesgo ahora es siempre visible (antes solo aparecía si ya tenía score)
- Si faltan campos obligatorios, muestra advertencia con los nombres en español
- Agrega servicio lead-scoring con mapeo de datos del lead al modelo ML y endpoint scoreLead

## Test plan
- [ ] Abrir un lead sin score → verificar que aparece la sección con mensaje "Sin análisis de riesgo aún" y botón "Calcular Score"
- [ ] Click en "Calcular Score" con campos faltantes → verificar toast de advertencia con nombres de campos en español
- [ ] Click en "Calcular Score" con todos los campos → verificar toast de éxito y score visible
- [ ] Abrir lead con score existente → verificar botón dice "Recalcular Score"
- [ ] Verificar lo mismo desde el modal de detalle de lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)