### PR TITLE
feat: buscador en tablero de oportunidades

### DIFF
--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -21,6 +21,7 @@ import {
 	Mail,
 	Plus,
 	RefreshCw,
+	Search,
 	Target,
 	Trash2,
 	TrendingUp,
@@ -437,6 +438,7 @@ function RouteComponent() {
 	const [vehiclesSearch, setVehiclesSearch] = useState("");
 	const [debouncedVehiclesSearch, setDebouncedVehiclesSearch] = useState("");
 	const [showLostOpportunities, setShowLostOpportunities] = useState(false);
+	const [boardSearch, setBoardSearch] = useState("");
 	const processedCompanyIdRef = useRef<string | null>(null);
 	const processedOpportunityIdRef = useRef<string | null>(null);
 	const prevOpenRef = useRef(isCreateDialogOpen);
@@ -1251,7 +1253,14 @@ function RouteComponent() {
 					(opp) =>
 						opp.stage?.id === stage.id &&
 						(stageFilter === "all" || opp.status === stageFilter) &&
-						(showLostOpportunities || opp.status !== "lost"),
+						(showLostOpportunities || opp.status !== "lost") &&
+						(!boardSearch.trim() ||
+							`${opp.lead?.firstName ?? ""} ${opp.lead?.lastName ?? ""}`
+								.toLowerCase()
+								.includes(boardSearch.trim().toLowerCase()) ||
+							(opp.title ?? "")
+								.toLowerCase()
+								.includes(boardSearch.trim().toLowerCase())),
 				) || [];
 
 			const totalValue = stageOpportunities.reduce(
@@ -1451,6 +1460,15 @@ function RouteComponent() {
 			{/* Actions Bar */}
 			<div className="flex items-center justify-between">
 				<div className="flex gap-4">
+					<div className="relative">
+						<Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
+						<Input
+							placeholder="Buscar por nombre, título..."
+							value={boardSearch}
+							onChange={(e) => setBoardSearch(e.target.value)}
+							className="h-9 w-[280px] pl-9"
+						/>
+					</div>
 					<Select value={stageFilter} onValueChange={setStageFilter}>
 						<SelectTrigger className="w-[180px]">
 							<Filter className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- Agrega un input de búsqueda en la barra de acciones del tablero de oportunidades
- Filtra las tarjetas en tiempo real por nombre del lead (firstName + lastName) y título de la oportunidad
- Funciona en conjunto con los filtros existentes de estado y oportunidades perdidas

## Test plan
- [ ] Escribir un nombre parcial de un lead y verificar que las columnas filtran en tiempo real
- [ ] Escribir un título parcial de oportunidad y verificar el filtrado
- [ ] Combinar búsqueda con filtro de estado y verificar que ambos filtros se aplican
- [ ] Limpiar el input y verificar que todas las oportunidades reaparecen

🤖 Generated with [Claude Code](https://claude.com/claude-code)