### PR TITLE
fix: actualiza campos de scoring API a español

### DIFF
--- a/apps/crm/apps/server/package.json
+++ b/apps/crm/apps/server/package.json
@@ -19,6 +19,7 @@
 	},
 	"dependencies": {
 		"@ai-sdk/deepseek": "^1.0.18",
+		"@ai-sdk/google": "^2.0.0",
 		"@ai-sdk/openai": "^2.0.32",
 		"@aws-sdk/client-rekognition": "^3.888.0",
 		"@aws-sdk/client-s3": "^3.850.0",
@@ -26,6 +27,8 @@
 		"@modelcontextprotocol/sdk": "^1.0.0",
 		"@orpc/client": "^1.5.0",
 		"@orpc/server": "^1.5.0",
+		"@repo/infornet": "file:../../../../packages/infornet",
+		"@repo/sms": "file:../../../../packages/sms",
 		"@types/bcryptjs": "^3.0.0",
 		"ai": "^5.0.48",
 		"bcryptjs": "^3.0.2",
@@ -35,9 +38,7 @@
 		"drizzle-orm": "^0.44.2",
 		"hono": "^4.8.2",
 		"pg": "^8.14.1",
-		"zod": "^3.23.8",
-		"@repo/infornet": "file:../../../../packages/infornet",
-		"@repo/sms": "file:../../../../packages/sms"
+		"zod": "^3.23.8"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.2.6",

--- a/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
+++ b/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+export const bankStatementAnalysisSchema = z.object({
+	datos_generales: z.object({
+		nombre_cuentahabiente: z.string(),
+		numero_cuenta: z.string(),
+		tipo_cuenta: z.string(),
+	}),
+	resumen_mensual: z.array(
+		z.object({
+			mes: z.string(),
+			saldo_inicial: z.number(),
+			total_debitos: z.number(),
+			total_creditos: z.number(),
+			saldo_final: z.number(),
+			ingresos: z.object({
+				fijos: z.number(),
+				variables: z.number(),
+			}),
+			gastos: z.object({
+				fijos: z.number(),
+				variables: z.number(),
+			}),
+		}),
+	),
+	promedio_mensual: z.object({
+		promedio_ingresos_fijos: z.number(),
+		promedio_ingresos_variables: z.number(),
+		promedio_gastos_fijos: z.number(),
+		promedio_gastos_variables: z.number(),
+		disponibilidad_economica: z.number(),
+	}),
+});
+
+export type BankStatementAnalysis = z.infer<typeof bankStatementAnalysisSchema>;
+
+export const BANK_ANALYSIS_PROMPT = `
+Eres un analista de capacidad de pago para una financiera que otorga créditos para la compra de vehículos. Tu tarea es analizar los estados de cuenta bancarios de un solicitante y extraer la información relevante para evaluar su capacidad de pago. Debes responder en formato JSON con los siguientes campos:
+
+1. **datos_generales**: Un objeto que contenga:
+   - nombre_cuentahabiente: Nombre completo del cuentahabiente.
+   - numero_cuenta: Número de cuenta bancaria.
+   - tipo_cuenta: Tipo de cuenta (monetaria, ahorros, etc.).
+
+2. **resumen_mensual**: Un arreglo de objetos, donde cada objeto representa un mes y contiene:
+   - mes: Nombre del mes (ej. "Febrero 2024").
+   - saldo_inicial: Saldo al inicio del mes.
+   - total_debitos: Total de débitos durante el mes.
+   - total_creditos: Total de créditos durante el mes.
+   - saldo_final: Saldo al final del mes.
+   - ingresos: Un objeto que contenga:
+     - fijos: Total de ingresos fijos durante el mes (ej. sueldos, rentas).
+     - variables: Total de ingresos variables durante el mes (ej. bonos, comisiones).
+     **Nota**: La suma de 'ingresos.fijos' y 'ingresos.variables' debe ser igual a 'total_creditos'.
+   - gastos: Un objeto que contenga:
+     - fijos: Total de gastos fijos durante el mes (ej. renta, membresías).
+     - variables: Total de gastos variables durante el mes (ej. compras, pagos móviles).
+     **Nota**: La suma de 'gastos.fijos' y 'gastos.variables' debe ser igual a 'total_debitos'.
+
+3. **promedio_mensual**: Un objeto que contenga:
+   - promedio_ingresos_fijos: Promedio mensual de ingresos fijos.
+   - promedio_ingresos_variables: Promedio mensual de ingresos variables.
+   - promedio_gastos_fijos: Promedio mensual de gastos fijos.
+   - promedio_gastos_variables: Promedio mensual de gastos variables.
+   - disponibilidad_economica: Promedio de la diferencia entre créditos y débitos totales. Se calcula como: (promedio_creditos - promedio_debitos).
+   **Nota**: El promedio de créditos es la suma de 'total_creditos' a lo largo de los meses analizados dividido por la cantidad de meses. El promedio de débitos es la suma de 'total_debitos' a lo largo de los meses analizados dividido por la cantidad de meses.
+
+Analiza los siguientes estados de cuenta bancarios y responde en formato JSON. Asegúrate de que los datos cuadren correctamente.
+`.trim();

--- a/apps/crm/apps/server/src/lib/financial-math.ts
+++ b/apps/crm/apps/server/src/lib/financial-math.ts
@@ -1,0 +1,136 @@
+/**
+ * Calculates the present value of a series of future payments
+ */
+export function PV(
+	rate: number,
+	nper: number,
+	pmt: number,
+	fv = 0,
+	type: 0 | 1 = 0,
+): number {
+	if (rate === -1) throw new Error("Rate cannot be -100%");
+	if (nper <= 0) throw new Error("Number of periods must be positive");
+
+	if (rate === 0) {
+		return -pmt * nper - fv;
+	}
+
+	const pvif = (1 + rate) ** -nper;
+
+	if (type === 1) {
+		return (-pmt * (1 + rate) * (1 - pvif)) / rate - fv * pvif;
+	}
+	return (-pmt * (1 - pvif)) / rate - fv * pvif;
+}
+
+/**
+ * Calculates the payment for a loan based on constant payments and a constant interest rate
+ */
+export function PMT(
+	rate: number,
+	nper: number,
+	pv: number,
+	fv = 0,
+	type: 0 | 1 = 0,
+): number {
+	if (rate === -1) throw new Error("Rate cannot be -100%");
+	if (nper <= 0) throw new Error("Number of periods must be positive");
+
+	if (rate === 0) {
+		return -(pv + fv) / nper;
+	}
+
+	const pvif = (1 + rate) ** -nper;
+
+	if (type === 1) {
+		return (
+			(-rate * pv) / ((1 + rate) * (1 - pvif)) -
+			(fv * rate) / ((1 + rate) * (pvif - 1))
+		);
+	}
+	return (-rate * pv) / (1 - pvif) - (fv * rate) / (pvif - 1);
+}
+
+export interface CreditCalculationParams {
+	annualRate: number;
+	termMonths: number;
+	maxDebtRatio: number;
+	maxVariableDebtRatio: number;
+}
+
+export interface AnalysisResult {
+	resumen_mensual: Array<{
+		mes: string;
+		saldo_inicial: number;
+		total_debitos: number;
+		total_creditos: number;
+		saldo_final: number;
+		ingresos: { fijos: number; variables: number };
+		gastos: { fijos: number; variables: number };
+	}>;
+	promedio_mensual: {
+		promedio_ingresos_fijos: number;
+		promedio_ingresos_variables: number;
+		promedio_gastos_fijos: number;
+		promedio_gastos_variables: number;
+		disponibilidad_economica: number;
+	};
+}
+
+export function calculateCreditCapacity(
+	analysis: AnalysisResult,
+	params: CreditCalculationParams = {
+		annualRate: 0.18,
+		termMonths: 60,
+		maxDebtRatio: 0.2,
+		maxVariableDebtRatio: 0.3,
+	},
+) {
+	const months = analysis.resumen_mensual;
+	const monthCount = months.length || 1;
+
+	let guaranteedIncome = 0;
+	let fixedExpenses = 0;
+	for (const month of months) {
+		guaranteedIncome += month.total_creditos;
+		fixedExpenses += month.total_debitos;
+	}
+	guaranteedIncome = guaranteedIncome / monthCount;
+	fixedExpenses = fixedExpenses / monthCount;
+
+	// Método 1: Flujo libre
+	const freeFlux = guaranteedIncome - fixedExpenses;
+
+	// Método 2: Basado en ingresos
+	const method2MaxAmount = params.maxDebtRatio * (guaranteedIncome * 0.5);
+
+	// Método 3: Basado en gastos variables
+	const method3MaxAmount = params.maxVariableDebtRatio * fixedExpenses;
+
+	// Estimación de capacidad
+	const minPayment = Math.min(method2MaxAmount, method3MaxAmount);
+	const maxPayment = Math.max(method2MaxAmount, method3MaxAmount);
+	const adjustedPayment = (freeFlux + method2MaxAmount + method3MaxAmount) / 3;
+
+	const maxCreditAmount = Math.abs(
+		PV(
+			params.annualRate / 12,
+			params.termMonths,
+			method2MaxAmount,
+			undefined,
+			0,
+		),
+	);
+
+	return {
+		guaranteedIncome,
+		fixedExpenses,
+		freeFlux,
+		method2MaxAmount,
+		method3MaxAmount,
+		minPayment,
+		maxPayment,
+		adjustedPayment,
+		maxCreditAmount,
+	};
+}

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -1,0 +1,145 @@
+import { google } from "@ai-sdk/google";
+import { ORPCError } from "@orpc/server";
+import { generateObject } from "ai";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db";
+import { creditAnalysis, leads } from "../db/schema/crm";
+import {
+	BANK_ANALYSIS_PROMPT,
+	bankStatementAnalysisSchema,
+} from "../lib/bank-analysis-schema";
+import { calculateCreditCapacity } from "../lib/financial-math";
+import { crmProcedure } from "../lib/orpc";
+
+export const bankAnalysisRouter = {
+	analyzeBankStatements: crmProcedure
+		.input(
+			z.object({
+				leadId: z.string().uuid(),
+				files: z
+					.array(
+						z.object({
+							name: z.string(),
+							data: z.string(), // base64
+							mimeType: z.string().default("application/pdf"),
+						}),
+					)
+					.min(1)
+					.max(3),
+				annualRate: z.number().default(0.18),
+				termMonths: z.number().int().min(12).max(120).default(60),
+				maxDebtRatio: z.number().min(0).max(1).default(0.2),
+				maxVariableDebtRatio: z.number().min(0).max(1).default(0.3),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			// 1. Verificar que el lead existe y el usuario tiene acceso
+			const lead = await db
+				.select()
+				.from(leads)
+				.where(eq(leads.id, input.leadId))
+				.limit(1);
+
+			if (lead.length === 0) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Lead no encontrado",
+				});
+			}
+
+			if (
+				context.userRole === "sales" &&
+				lead[0].assignedTo !== context.userId
+			) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permiso para analizar este lead",
+				});
+			}
+
+			// 2. Construir content parts con los PDFs
+			const fileParts = input.files.map((file) => ({
+				type: "file" as const,
+				data: Buffer.from(file.data, "base64"),
+				mediaType: file.mimeType as "application/pdf",
+				filename: file.name,
+			}));
+
+			// 3. Llamar a Gemini con generateObject
+			const { object: analysis } = await generateObject({
+				model: google("gemini-3-flash-preview"),
+				schema: bankStatementAnalysisSchema,
+				messages: [
+					{
+						role: "system",
+						content: BANK_ANALYSIS_PROMPT,
+					},
+					{
+						role: "user",
+						content: [
+							{
+								type: "text",
+								text: "Analiza los siguientes estados de cuenta bancarios:",
+							},
+							...fileParts,
+						],
+					},
+				],
+			});
+
+			// 4. Calcular capacidad crediticia
+			const creditCapacity = calculateCreditCapacity(analysis, {
+				annualRate: input.annualRate,
+				termMonths: input.termMonths,
+				maxDebtRatio: input.maxDebtRatio,
+				maxVariableDebtRatio: input.maxVariableDebtRatio,
+			});
+
+			// 5. Upsert en tabla creditAnalysis
+			const dataForDb = {
+				fullAnalysis: JSON.stringify(analysis),
+				monthlyFixedIncome:
+					analysis.promedio_mensual.promedio_ingresos_fijos.toString(),
+				monthlyVariableIncome:
+					analysis.promedio_mensual.promedio_ingresos_variables.toString(),
+				monthlyFixedExpenses:
+					analysis.promedio_mensual.promedio_gastos_fijos.toString(),
+				monthlyVariableExpenses:
+					analysis.promedio_mensual.promedio_gastos_variables.toString(),
+				economicAvailability:
+					analysis.promedio_mensual.disponibilidad_economica.toString(),
+				minPayment: creditCapacity.minPayment.toString(),
+				maxPayment: creditCapacity.maxPayment.toString(),
+				adjustedPayment: creditCapacity.adjustedPayment.toString(),
+				maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
+				analyzedAt: new Date(),
+			};
+
+			const existing = await db
+				.select()
+				.from(creditAnalysis)
+				.where(eq(creditAnalysis.leadId, input.leadId))
+				.limit(1);
+
+			if (existing.length > 0) {
+				await db
+					.update(creditAnalysis)
+					.set({
+						...dataForDb,
+						updatedAt: new Date(),
+					})
+					.where(eq(creditAnalysis.leadId, input.leadId));
+			} else {
+				await db.insert(creditAnalysis).values({
+					leadId: input.leadId,
+					...dataForDb,
+					createdBy: context.userId,
+				});
+			}
+
+			// 6. Retornar resultados
+			return {
+				analysis,
+				creditCapacity,
+			};
+		}),
+};

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -4,6 +4,7 @@ import { adminImportRouter } from "./admin-import";
 import { adminMiniagentRouter } from "./admin-miniagent";
 import { auctionRouter } from "./auctionVehicles"; // Import the auction router
 import { authRouter } from "./auth";
+import { bankAnalysisRouter } from "./bank-analysis";
 import { checksRouter } from "./checks";
 import { cobrosRouter } from "./cobros";
 import { contractGenerationRouter } from "./contract-generation";
@@ -88,6 +89,9 @@ export const appRouter = {
 	updateClient: crmRouter.updateClient,
 	getDashboardStats: crmRouter.getDashboardStats,
 	scoreLead: crmRouter.scoreLead,
+
+	// Bank Analysis routes (Análisis de estados de cuenta)
+	analyzeBankStatements: bankAnalysisRouter.analyzeBankStatements,
 
 	// Vehicles routes
 	getVehicles: vehiclesRouter.getAll,

--- a/apps/crm/apps/server/src/services/lead-scoring.ts
+++ b/apps/crm/apps/server/src/services/lead-scoring.ts
@@ -5,18 +5,18 @@ import { leads, opportunities } from "../db/schema/crm";
 // ── Interfaces ──────────────────────────────────────────────────────────
 
 export interface ClientData {
-	age: number;
-	income: number;
-	loan_amount: number;
-	credit_card: number;
-	own_home: number;
-	own_vehicle: number;
-	work_time: number;
-	occupation: number;
-	marital_status: number;
-	dependents: number;
-	loan_purpose: number;
-	num_credits: number;
+	EDAD: number;
+	SUELDO: number;
+	PRECIO_PRODUCTO: number;
+	TARJETA_DE_CREDITO: number;
+	VIVIENDA_PROPIA: number;
+	VEHICULO_PROPIO: number;
+	ANTIGUEDAD: number;
+	OCUPACION: number;
+	ESTADO_CIVIL: number;
+	DEPENDIENTES_ECONOMICOS: number;
+	UTILIZACION_DINERO: number;
+	TIPO_DE_COMPRAS: number;
 }
 
 export interface CreditScoreResponse {
@@ -59,6 +59,11 @@ function encodeLoanPurpose(value: string | null | undefined): number {
 	return 1; // business
 }
 
+function encodeCreditType(value: string | null | undefined): number {
+	if (!value || value === "autocompra") return 0;
+	return 1; // sobre_vehiculo
+}
+
 function encodeAge(age: number | null | undefined): number | null {
 	if (age == null) return null;
 	if (age < 30) return 0;
@@ -87,6 +92,7 @@ export function mapLeadToScoringInput(
 		dependents: number | null;
 	},
 	loanPurpose?: string | null,
+	creditType?: string | null,
 ): MappingResult {
 	const missing: string[] = [];
 
@@ -117,18 +123,18 @@ export function mapLeadToScoringInput(
 
 	return {
 		data: {
-			age: encodedAge,
-			income: Number.parseFloat(lead.monthlyIncome!),
-			loan_amount: Number.parseFloat(lead.loanAmount!),
-			credit_card: encodeBool(lead.hasCreditCard),
-			own_home: encodeBool(lead.ownsHome),
-			own_vehicle: encodeBool(lead.ownsVehicle),
-			work_time: encodedWorkTime,
-			occupation: encodedOccupation,
-			marital_status: encodedMaritalStatus,
-			dependents: lead.dependents ?? 0,
-			loan_purpose: encodeLoanPurpose(loanPurpose),
-			num_credits: 0,
+			EDAD: encodedAge,
+			SUELDO: Number.parseFloat(lead.monthlyIncome!),
+			PRECIO_PRODUCTO: Number.parseFloat(lead.loanAmount!),
+			TARJETA_DE_CREDITO: encodeBool(lead.hasCreditCard),
+			VIVIENDA_PROPIA: encodeBool(lead.ownsHome),
+			VEHICULO_PROPIO: encodeBool(lead.ownsVehicle),
+			ANTIGUEDAD: encodedWorkTime,
+			OCUPACION: encodedOccupation,
+			ESTADO_CIVIL: encodedMaritalStatus,
+			DEPENDIENTES_ECONOMICOS: lead.dependents ?? 0,
+			UTILIZACION_DINERO: encodeLoanPurpose(loanPurpose),
+			TIPO_DE_COMPRAS: encodeCreditType(creditType),
 		},
 		missingFields: [],
 	};
@@ -189,22 +195,27 @@ export async function scoreLead(leadId: string, opportunityId?: string) {
 			throw new Error(`Lead ${leadId} not found`);
 		}
 
-		// 2. Get loanPurpose from opportunity if provided
+		// 2. Get loanPurpose and creditType from opportunity if provided
 		let loanPurpose: string | null = null;
+		let creditType: string | null = null;
 		if (opportunityId) {
 			console.log("[scoreLead] Step 2: Fetching opportunity...");
 			const [opp] = await db
-				.select({ loanPurpose: opportunities.loanPurpose })
+				.select({
+					loanPurpose: opportunities.loanPurpose,
+					creditType: opportunities.creditType,
+				})
 				.from(opportunities)
 				.where(eq(opportunities.id, opportunityId))
 				.limit(1);
 			loanPurpose = opp?.loanPurpose ?? null;
-			console.log("[scoreLead] loanPurpose:", loanPurpose);
+			creditType = opp?.creditType ?? null;
+			console.log("[scoreLead] loanPurpose:", loanPurpose, "creditType:", creditType);
 		}
 
 		// 3. Map to ML input
 		console.log("[scoreLead] Step 3: Mapping to ML input...");
-		const { data, missingFields } = mapLeadToScoringInput(lead, loanPurpose);
+		const { data, missingFields } = mapLeadToScoringInput(lead, loanPurpose, creditType);
 		console.log("[scoreLead] Mapped data:", { hasData: !!data, missingFields });
 
 		if (!data) {

--- a/apps/crm/apps/server/src/services/lead-scoring.ts
+++ b/apps/crm/apps/server/src/services/lead-scoring.ts
@@ -142,6 +142,7 @@ const SCORING_API_URL =
 export async function predictCreditScore(
 	data: ClientData,
 ): Promise<CreditScoreResponse> {
+	console.log(JSON.stringify(data, null, 2));
 	const response = await fetch(SCORING_API_URL, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
@@ -160,70 +161,89 @@ export async function predictCreditScore(
 // ── Orchestrator ────────────────────────────────────────────────────────
 
 export async function scoreLead(leadId: string, opportunityId?: string) {
-	// 1. Fetch lead
-	const [lead] = await db
-		.select({
-			age: leads.age,
-			monthlyIncome: leads.monthlyIncome,
-			loanAmount: leads.loanAmount,
-			hasCreditCard: leads.hasCreditCard,
-			ownsHome: leads.ownsHome,
-			ownsVehicle: leads.ownsVehicle,
-			workTime: leads.workTime,
-			occupation: leads.occupation,
-			maritalStatus: leads.maritalStatus,
-			dependents: leads.dependents,
-		})
-		.from(leads)
-		.where(eq(leads.id, leadId))
-		.limit(1);
+	console.log("[scoreLead] Starting", { leadId, opportunityId });
 
-	if (!lead) {
-		throw new Error(`Lead ${leadId} not found`);
-	}
-
-	// 2. Get loanPurpose from opportunity if provided
-	let loanPurpose: string | null = null;
-	if (opportunityId) {
-		const [opp] = await db
-			.select({ loanPurpose: opportunities.loanPurpose })
-			.from(opportunities)
-			.where(eq(opportunities.id, opportunityId))
+	try {
+		// 1. Fetch lead
+		console.log("[scoreLead] Step 1: Fetching lead...");
+		const [lead] = await db
+			.select({
+				age: leads.age,
+				monthlyIncome: leads.monthlyIncome,
+				loanAmount: leads.loanAmount,
+				hasCreditCard: leads.hasCreditCard,
+				ownsHome: leads.ownsHome,
+				ownsVehicle: leads.ownsVehicle,
+				workTime: leads.workTime,
+				occupation: leads.occupation,
+				maritalStatus: leads.maritalStatus,
+				dependents: leads.dependents,
+			})
+			.from(leads)
+			.where(eq(leads.id, leadId))
 			.limit(1);
-		loanPurpose = opp?.loanPurpose ?? null;
-	}
 
-	// 3. Map to ML input
-	const { data, missingFields } = mapLeadToScoringInput(lead, loanPurpose);
+		console.log("[scoreLead] Lead fetched:", lead ? "found" : "not found");
 
-	if (!data) {
+		if (!lead) {
+			throw new Error(`Lead ${leadId} not found`);
+		}
+
+		// 2. Get loanPurpose from opportunity if provided
+		let loanPurpose: string | null = null;
+		if (opportunityId) {
+			console.log("[scoreLead] Step 2: Fetching opportunity...");
+			const [opp] = await db
+				.select({ loanPurpose: opportunities.loanPurpose })
+				.from(opportunities)
+				.where(eq(opportunities.id, opportunityId))
+				.limit(1);
+			loanPurpose = opp?.loanPurpose ?? null;
+			console.log("[scoreLead] loanPurpose:", loanPurpose);
+		}
+
+		// 3. Map to ML input
+		console.log("[scoreLead] Step 3: Mapping to ML input...");
+		const { data, missingFields } = mapLeadToScoringInput(lead, loanPurpose);
+		console.log("[scoreLead] Mapped data:", { hasData: !!data, missingFields });
+
+		if (!data) {
+			console.log("[scoreLead] No data, returning early with missingFields");
+			return {
+				score: null,
+				fit: null,
+				scoredAt: null,
+				missingFields,
+			};
+		}
+
+		// 4. Call ML model
+		console.log("[scoreLead] Step 4: Calling ML model with data:", data);
+		const result = await predictCreditScore(data);
+		console.log("[scoreLead] ML result:", result);
+
+		// 5. Update lead in DB
+		console.log("[scoreLead] Step 5: Updating lead in DB...");
+		const scoredAt = new Date();
+		await db
+			.update(leads)
+			.set({
+				score: String(result.probability),
+				fit: result.fit,
+				scoredAt,
+				updatedAt: scoredAt,
+			})
+			.where(eq(leads.id, leadId));
+
+		console.log("[scoreLead] Success!");
 		return {
-			score: null,
-			fit: null,
-			scoredAt: null,
-			missingFields,
-		};
-	}
-
-	// 4. Call ML model
-	const result = await predictCreditScore(data);
-
-	// 5. Update lead in DB
-	const scoredAt = new Date();
-	await db
-		.update(leads)
-		.set({
-			score: String(result.probability),
+			score: result.probability,
 			fit: result.fit,
 			scoredAt,
-			updatedAt: scoredAt,
-		})
-		.where(eq(leads.id, leadId));
-
-	return {
-		score: result.probability,
-		fit: result.fit,
-		scoredAt,
-		missingFields: [] as string[],
-	};
+			missingFields: [] as string[],
+		};
+	} catch (error) {
+		console.error("[scoreLead] ERROR:", error);
+		throw error;
+	}
 }

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -473,7 +473,7 @@ export function InvestmentAssignmentSection() {
 					{/* Buscador */}
 					<div className="mb-4 flex items-center gap-4">
 						<div className="relative flex-1">
-							<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+							<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
 							<Input
 								placeholder="Buscar por nombre, placa..."
 								value={searchTerm}

--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -36,6 +36,8 @@ export function BankStatementAnalysis({
 	const [termMonths, setTermMonths] = useState("60");
 	const [maxDebtRatio, setMaxDebtRatio] = useState("0.2");
 	const [maxVariableDebtRatio, setMaxVariableDebtRatio] = useState("0.3");
+	const [attemptCount, setAttemptCount] = useState(0);
+	const [analysisSucceeded, setAnalysisSucceeded] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 
 	const analyzeMutation = useMutation({
@@ -72,6 +74,7 @@ export function BankStatementAnalysis({
 		},
 		onSuccess: () => {
 			toast.success("Análisis completado exitosamente");
+			setAnalysisSucceeded(true);
 			setFiles([]);
 			onAnalysisComplete?.();
 		},
@@ -243,18 +246,38 @@ export function BankStatementAnalysis({
 					type="button"
 					size="sm"
 					className="w-full"
-					onClick={() => analyzeMutation.mutate()}
-					disabled={files.length === 0 || analyzeMutation.isPending}
+					onClick={() => {
+						setAttemptCount((prev) => prev + 1);
+						analyzeMutation.mutate();
+					}}
+					disabled={
+						files.length === 0 ||
+						analyzeMutation.isPending ||
+						analysisSucceeded ||
+						attemptCount >= 2
+					}
 				>
 					{analyzeMutation.isPending ? (
 						<>
 							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
 							Analizando con IA...
 						</>
+					) : attemptCount > 0 && !analysisSucceeded ? (
+						"Reintentar Análisis"
 					) : (
 						"Analizar"
 					)}
 				</Button>
+				{analysisSucceeded && (
+					<p className="text-center text-xs text-green-600">
+						Análisis completado exitosamente.
+					</p>
+				)}
+				{attemptCount >= 2 && !analysisSucceeded && (
+					<p className="text-center text-xs text-muted-foreground">
+						Se alcanzó el límite de intentos. Contacte al administrador.
+					</p>
+				)}
 			</CardContent>
 		</Card>
 	);

--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -1,0 +1,261 @@
+import { useMutation } from "@tanstack/react-query";
+import {
+	ChevronDown,
+	ChevronUp,
+	FileText,
+	Loader2,
+	Trash2,
+	Upload,
+} from "lucide-react";
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { client } from "@/utils/orpc";
+
+interface BankStatementAnalysisProps {
+	leadId: string;
+	onAnalysisComplete?: () => void;
+}
+
+export function BankStatementAnalysis({
+	leadId,
+	onAnalysisComplete,
+}: BankStatementAnalysisProps) {
+	const [files, setFiles] = useState<File[]>([]);
+	const [showAdvanced, setShowAdvanced] = useState(false);
+	const [annualRate, setAnnualRate] = useState("0.18");
+	const [termMonths, setTermMonths] = useState("60");
+	const [maxDebtRatio, setMaxDebtRatio] = useState("0.2");
+	const [maxVariableDebtRatio, setMaxVariableDebtRatio] = useState("0.3");
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const analyzeMutation = useMutation({
+		mutationFn: async () => {
+			const filePayloads = await Promise.all(
+				files.map(
+					(file) =>
+						new Promise<{ name: string; data: string; mimeType: string }>(
+							(resolve, reject) => {
+								const reader = new FileReader();
+								reader.onload = () => {
+									const base64 = (reader.result as string).split(",")[1];
+									resolve({
+										name: file.name,
+										data: base64,
+										mimeType: file.type || "application/pdf",
+									});
+								};
+								reader.onerror = reject;
+								reader.readAsDataURL(file);
+							},
+						),
+				),
+			);
+
+			return client.analyzeBankStatements({
+				leadId,
+				files: filePayloads,
+				annualRate: Number.parseFloat(annualRate),
+				termMonths: Number.parseInt(termMonths),
+				maxDebtRatio: Number.parseFloat(maxDebtRatio),
+				maxVariableDebtRatio: Number.parseFloat(maxVariableDebtRatio),
+			});
+		},
+		onSuccess: () => {
+			toast.success("Análisis completado exitosamente");
+			setFiles([]);
+			onAnalysisComplete?.();
+		},
+		onError: (error) => {
+			toast.error(`Error al analizar: ${error.message}`);
+		},
+	});
+
+	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const selectedFiles = Array.from(e.target.files || []);
+		const pdfFiles = selectedFiles.filter((f) => f.type === "application/pdf");
+
+		if (pdfFiles.length !== selectedFiles.length) {
+			toast.warning("Solo se permiten archivos PDF");
+		}
+
+		const totalFiles = files.length + pdfFiles.length;
+		if (totalFiles > 3) {
+			toast.warning("Máximo 3 archivos permitidos");
+			const allowed = pdfFiles.slice(0, 3 - files.length);
+			setFiles((prev) => [...prev, ...allowed]);
+		} else {
+			setFiles((prev) => [...prev, ...pdfFiles]);
+		}
+
+		if (fileInputRef.current) {
+			fileInputRef.current.value = "";
+		}
+	};
+
+	const removeFile = (index: number) => {
+		setFiles((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	return (
+		<Card className="border-dashed">
+			<CardHeader className="pb-3">
+				<CardTitle className="font-medium text-sm">
+					Análisis de Estados de Cuenta
+				</CardTitle>
+				<CardDescription className="text-xs">
+					Suba 1 a 3 estados de cuenta bancarios en PDF para análisis automático
+					con IA
+				</CardDescription>
+			</CardHeader>
+			<CardContent className="space-y-3">
+				{/* File input */}
+				<div>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept=".pdf,application/pdf"
+						multiple
+						className="hidden"
+						onChange={handleFileChange}
+						disabled={files.length >= 3 || analyzeMutation.isPending}
+					/>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						className="w-full"
+						onClick={() => fileInputRef.current?.click()}
+						disabled={files.length >= 3 || analyzeMutation.isPending}
+					>
+						<Upload className="mr-2 h-4 w-4" />
+						Seleccionar PDFs ({files.length}/3)
+					</Button>
+				</div>
+
+				{/* File list */}
+				{files.length > 0 && (
+					<div className="space-y-1.5">
+						{files.map((file, index) => (
+							<div
+								key={`${file.name}-${index}`}
+								className="flex items-center justify-between rounded-md border bg-muted/50 px-3 py-1.5 text-sm"
+							>
+								<div className="flex items-center gap-2 truncate">
+									<FileText className="h-4 w-4 shrink-0 text-red-500" />
+									<span className="truncate">{file.name}</span>
+									<span className="shrink-0 text-muted-foreground text-xs">
+										({(file.size / 1024).toFixed(0)} KB)
+									</span>
+								</div>
+								<Button
+									type="button"
+									variant="ghost"
+									size="sm"
+									className="h-6 w-6 p-0"
+									onClick={() => removeFile(index)}
+									disabled={analyzeMutation.isPending}
+								>
+									<Trash2 className="h-3.5 w-3.5 text-destructive" />
+								</Button>
+							</div>
+						))}
+					</div>
+				)}
+
+				{/* Advanced options */}
+				<button
+					type="button"
+					className="flex items-center gap-1 text-muted-foreground text-xs hover:text-foreground"
+					onClick={() => setShowAdvanced(!showAdvanced)}
+				>
+					{showAdvanced ? (
+						<ChevronUp className="h-3 w-3" />
+					) : (
+						<ChevronDown className="h-3 w-3" />
+					)}
+					Opciones avanzadas
+				</button>
+
+				{showAdvanced && (
+					<div className="grid grid-cols-2 gap-3 rounded-md border bg-muted/30 p-3">
+						<div className="space-y-1">
+							<Label className="text-xs">Plazo (meses)</Label>
+							<Input
+								type="number"
+								min="12"
+								max="120"
+								value={termMonths}
+								onChange={(e) => setTermMonths(e.target.value)}
+								className="h-8 text-sm"
+							/>
+						</div>
+						<div className="space-y-1">
+							<Label className="text-xs">Tasa anual</Label>
+							<Input
+								type="number"
+								step="0.01"
+								min="0"
+								max="1"
+								value={annualRate}
+								onChange={(e) => setAnnualRate(e.target.value)}
+								className="h-8 text-sm"
+							/>
+						</div>
+						<div className="space-y-1">
+							<Label className="text-xs">Ratio deuda máx.</Label>
+							<Input
+								type="number"
+								step="0.01"
+								min="0"
+								max="1"
+								value={maxDebtRatio}
+								onChange={(e) => setMaxDebtRatio(e.target.value)}
+								className="h-8 text-sm"
+							/>
+						</div>
+						<div className="space-y-1">
+							<Label className="text-xs">Ratio deuda var. máx.</Label>
+							<Input
+								type="number"
+								step="0.01"
+								min="0"
+								max="1"
+								value={maxVariableDebtRatio}
+								onChange={(e) => setMaxVariableDebtRatio(e.target.value)}
+								className="h-8 text-sm"
+							/>
+						</div>
+					</div>
+				)}
+
+				{/* Analyze button */}
+				<Button
+					type="button"
+					size="sm"
+					className="w-full"
+					onClick={() => analyzeMutation.mutate()}
+					disabled={files.length === 0 || analyzeMutation.isPending}
+				>
+					{analyzeMutation.isPending ? (
+						<>
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							Analizando con IA...
+						</>
+					) : (
+						"Analizar"
+					)}
+				</Button>
+			</CardContent>
+		</Card>
+	);
+}

--- a/apps/crm/apps/web/src/components/mode-toggle.tsx
+++ b/apps/crm/apps/web/src/components/mode-toggle.tsx
@@ -15,7 +15,7 @@ export function ModeToggle() {
 		<DropdownMenu>
 			<DropdownMenuTrigger asChild>
 				<Button variant="outline" size="icon">
-					<Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+					<Sun className="dark:-rotate-90 h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:scale-0" />
 					<Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
 					<span className="sr-only">Cambiar tema</span>
 				</Button>

--- a/apps/crm/apps/web/src/components/ui/select.tsx
+++ b/apps/crm/apps/web/src/components/ui/select.tsx
@@ -66,7 +66,7 @@ function SelectContent({
 				className={cn(
 					"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-[8rem] origin-(--radix-select-content-transform-origin) overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=closed]:animate-out data-[state=open]:animate-in",
 					position === "popper" &&
-						"data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
+						"data-[side=left]:-translate-x-1 data-[side=top]:-translate-y-1 data-[side=right]:translate-x-1 data-[side=bottom]:translate-y-1",
 					size === "full" && "right-0 left-0 w-full",
 					className,
 				)}
@@ -135,7 +135,7 @@ function SelectSeparator({
 	return (
 		<SelectPrimitive.Separator
 			data-slot="select-separator"
-			className={cn("pointer-events-none -mx-1 my-1 h-px bg-border", className)}
+			className={cn("-mx-1 pointer-events-none my-1 h-px bg-border", className)}
 			{...props}
 		/>
 	);

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -401,7 +401,7 @@ function AnalysisPage() {
 							{/* Buscador */}
 							<div className="mb-4 flex items-center gap-4">
 								<div className="relative max-w-sm flex-1">
-									<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+									<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
 									<Input
 										placeholder="Buscar por nombre, placa..."
 										value={searchTerm}
@@ -834,7 +834,7 @@ function DisbursementSection() {
 					{/* Buscador */}
 					<div className="mb-4 flex items-center gap-4">
 						<div className="relative flex-1">
-							<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+							<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
 							<Input
 								placeholder="Buscar por nombre, placa..."
 								value={searchTerm}

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -22,6 +22,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { z } from "zod";
+import { BankStatementAnalysis } from "@/components/credit/BankStatementAnalysis";
 import { NotesTimeline } from "@/components/notes-timeline";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -2597,6 +2598,14 @@ function RouteComponent() {
 										</Button>
 									)}
 								</div>
+
+								{/* Análisis automático con IA */}
+								{selectedLead?.id && (
+									<BankStatementAnalysis
+										leadId={selectedLead.id}
+										onAnalysisComplete={() => creditAnalysisQuery.refetch()}
+									/>
+								)}
 
 								{isEditingCreditAnalysis ? (
 									<form

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -1471,12 +1471,12 @@ function RouteComponent() {
 			<div className="flex items-center justify-between">
 				<div className="flex gap-4">
 					<div className="relative">
-						<Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+						<Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
 						<Input
 							placeholder="Buscar por nombre, título..."
 							value={boardSearch}
 							onChange={(e) => setBoardSearch(e.target.value)}
-							className="w-[280px] pl-9 h-9"
+							className="h-9 w-[280px] pl-9"
 						/>
 					</div>
 					<Select value={stageFilter} onValueChange={setStageFilter}>

--- a/apps/crm/apps/web/src/routes/juridico/index.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/index.tsx
@@ -358,7 +358,7 @@ function RouteComponent() {
 
 							{/* Barra de búsqueda */}
 							<div className="relative">
-								<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+								<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
 								<Input
 									placeholder="Buscar por título, nombre o DPI..."
 									value={opportunitiesSearchQuery}
@@ -550,7 +550,7 @@ function RouteComponent() {
 
 							{/* Barra de búsqueda */}
 							<div className="relative">
-								<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+								<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
 								<Input
 									placeholder="Buscar por nombre, DPI o email..."
 									value={searchQuery}

--- a/apps/crm/bun.lock
+++ b/apps/crm/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "crm",
       "dependencies": {
+        "@ai-sdk/google": "^3.0.20",
         "@hookform/resolvers": "^5.2.1",
         "@modelcontextprotocol/sdk": "^1.15.1",
         "@orpc/client": "^1.6.6",
@@ -35,6 +36,7 @@
       "name": "server",
       "dependencies": {
         "@ai-sdk/deepseek": "^1.0.18",
+        "@ai-sdk/google": "^2.0.0",
         "@ai-sdk/openai": "^2.0.32",
         "@aws-sdk/client-rekognition": "^3.888.0",
         "@aws-sdk/client-s3": "^3.850.0",
@@ -132,15 +134,17 @@
   "packages": {
     "@ai-sdk/deepseek": ["@ai-sdk/deepseek@1.0.18", "", { "dependencies": { "@ai-sdk/openai-compatible": "1.0.18", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-FHSwu8POrN47pemQMwO7xbJ8KSVWmevD9B1jSmbnotIxEgDwgtPLWPGiPAJLlEkuMlLdrdPRLm9rYtpLXN/0hw=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@1.0.25", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-eI/6LLmn1tWFzuhjxgcPEqUFXwLjyRuGFrwkCoqLaTKe/qMYBEAV3iddnGUM0AV+Hp4NEykzP4ly5tibOLDMXw=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@2.0.31", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HcglYbIFqKhUYqK5qSNc2RwYxVyuhADy2R/8HMSTaUqHVFfUIFyCyDHeuNBxJcSDtHVMebPdn6Bxa0YogeiwcA=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bVGsulEr6JiipAFlclo9bjL5WaUV0iCSiiekLt+PY6pwmtJeuU2GaD9DoE3OqR8LN2W779mU13IhVEzlTupf8g=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@2.0.32", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-p7giSkCs66Q1qYO/NPYI41CrSg65mcm8R2uAdF86+Y1D1/q4mUrWMyf5UTOJ0bx/z4jIPiNgGDCg2Kabi5zrKQ=="],
 
     "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@1.0.18", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-WSxF83ZVvTpj2vKhgSNe95qr46TaTBRitF7LlX817r1vKAHw3MDFjjrxZTHbR58jcQWX6N9B3D2aX2Ro9fPBNA=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.9", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
 
@@ -734,7 +738,7 @@
 
     "@smithy/util-waiter": ["@smithy/util-waiter@4.1.1", "", { "dependencies": { "@smithy/abort-controller": "^4.1.1", "@smithy/types": "^4.5.0", "tslib": "^2.6.2" } }, "sha512-PJBmyayrlfxM7nbqjomF4YcT1sApQwZio0NHSsT0EzhJqljRmvhzqZua43TyEs80nJk2Cn2FGPg/N8phH6KeCQ=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -868,6 +872,8 @@
 
     "@types/uuid": ["@types/uuid@9.0.8", "", {}, "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.6.0", "", { "dependencies": { "@babel/core": "^7.27.4", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.19", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" } }, "sha512-5Kgff+m8e2PB+9j51eGHEpn5kUzRKH2Ry0qGoe8ItJg7pqnkPrYPkDQZGgGmTa0EGarHrkjLvOdU3b1fzI8otQ=="],
 
     "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
@@ -890,7 +896,7 @@
 
     "adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
 
-    "ai": ["ai@5.0.48", "", { "dependencies": { "@ai-sdk/gateway": "1.0.25", "@ai-sdk/provider": "2.0.0", "@ai-sdk/provider-utils": "3.0.9", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-+oYhbN3NGRXayGfTFI8k1Fu4rhiJcQ0mbgiAOJGFkzvCxunRRQu5cyDl7y6cHNTj1QvHmIBROK5u655Ss2oI0g=="],
+    "ai": ["ai@5.0.125", "", { "dependencies": { "@ai-sdk/gateway": "2.0.31", "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-M4gVfuxOP7eywi9zKbonVKGYMYV2IMuj9jki5/7FpogzNq+P9u7/ZvBivt4iu5A3z/V5BJojZ8vdBsEqbGnsHA=="],
 
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
 
@@ -1586,6 +1592,22 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
 
+    "@ai-sdk/deepseek/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
+
+    "@ai-sdk/deepseek/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.9", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.9", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider": ["@ai-sdk/provider@2.0.0", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.9", "", { "dependencies": { "@ai-sdk/provider": "2.0.0", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.5" }, "peerDependencies": { "zod": "^3.25.76 || ^4" } }, "sha512-Pm571x5efqaI4hf9yW4KsVlDBDme8++UepZRnq+kqVBWWjgvGhQlzU8glaFq0YJEB9kkxZHbRRyVeHoV2sRYaQ=="],
+
     "@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "@atlaskit/feature-gate-js-client/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
@@ -1784,6 +1806,8 @@
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.4", "", {}, "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw=="],
 
+    "@orpc/contract/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
     "@radix-ui/react-accordion/@radix-ui/react-collapsible": ["@radix-ui/react-collapsible@1.1.11", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-dialog": ["@radix-ui/react-dialog@1.1.14", "", { "dependencies": { "@radix-ui/primitive": "1.1.2", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.10", "@radix-ui/react-focus-guards": "1.1.2", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-id": "1.1.1", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.4", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-use-controllable-state": "1.2.2", "aria-hidden": "^1.2.4", "react-remove-scroll": "^2.6.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw=="],
@@ -1833,6 +1857,8 @@
     "@radix-ui/react-toast/@radix-ui/react-presence": ["@radix-ui/react-presence@1.1.4", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA=="],
 
     "@radix-ui/react-tooltip/@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
+
+    "@reduxjs/toolkit/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
 
     "@smithy/chunked-blob-reader-native/@smithy/util-base64": ["@smithy/util-base64@4.0.0", "", { "dependencies": { "@smithy/util-buffer-from": "^4.0.0", "@smithy/util-utf8": "^4.0.0", "tslib": "^2.6.2" } }, "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg=="],
 
@@ -1898,6 +1924,10 @@
 
     "@tokenizer/inflate/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "ai/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
+
+    "ai/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "elysia/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
@@ -1928,11 +1958,13 @@
 
     "recast/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
+    "server/@ai-sdk/google": ["@ai-sdk/google@2.0.52", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@ai-sdk/provider-utils": "3.0.20" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-2XUnGi3f7TV4ujoAhA+Fg3idUoG/+Y2xjCRg70a1/m0DH1KSQqYaCboJ1C19y6ZHGdf5KNT20eJdswP6TvrY2g=="],
+
     "server/@repo/infornet": ["@repo/infornet@file:../../packages/infornet", { "dependencies": { "elysia": "^1.1.29", "fast-xml-parser": "^4.5.0" }, "devDependencies": { "@types/bun": "latest", "vitest": "^2.0.0" }, "peerDependencies": { "typescript": "^5.0.0" } }],
 
     "server/@repo/sms": ["@repo/sms@file:../../packages/sms", { "devDependencies": { "@types/bun": "latest", "vitest": "^2.0.0" }, "peerDependencies": { "typescript": "^5.0.0" } }],
 
-    "server/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
+    "server/@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
 
     "source-map-support/source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -1947,6 +1979,20 @@
     "web/react-day-picker": ["react-day-picker@9.11.1", "", { "dependencies": { "@date-fns/tz": "^1.4.1", "date-fns": "^4.1.0", "date-fns-jalali": "^4.1.0-0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-l3ub6o8NlchqIjPKrRFUCkTUEq6KwemQlfv3XZzzwpUeGwmDJ+0u0Upmt38hJyd7D/vn2dQoOoLV/qAp0o3uUw=="],
 
     "web/react-hook-form": ["react-hook-form@7.65.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-xtOzDz063WcXvGWaHgLNrNzlsdFgtUWcb32E6WFaGTd7kPZG3EeDusjdZfUsPwKCKVXy1ZlntifaHZ4l8pAsmw=="],
+
+    "@ai-sdk/deepseek/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@ai-sdk/deepseek/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "@ai-sdk/gateway/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils/@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@ai-sdk/openai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.3.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA=="],
 
@@ -2206,11 +2252,13 @@
 
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
 
-    "server/@repo/infornet/@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+    "ai/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
-    "server/@repo/sms/@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
+    "server/@ai-sdk/google/@ai-sdk/provider": ["@ai-sdk/provider@2.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-KCUwswvsC5VsW2PWFqF8eJgSCu5Ysj7m1TxiHTVA6g7k360bk0RNQENT8KTMAYEs+8fWPD3Uu4dEmzGHc+jGng=="],
 
-    "server/@types/bun/bun-types": ["bun-types@1.3.5", "", { "dependencies": { "@types/node": "*" } }, "sha512-inmAYe2PFLs0SUbFOWSVD24sg1jFlMPxOjOSSCYqUgn4Hsc3rDc7dFvfVYjFPNHtov6kgUeulV4SxbuIV/stPw=="],
+    "server/@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "2.0.1", "@standard-schema/spec": "^1.0.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-iXHVe0apM2zUEzauqJwqmpC37A5rihrStAih5Ks+JE32iTe4LZ58y17UGBjpQQTCRw9YxMeo2UFLxLpBluyvLQ=="],
+
+    "server/@types/bun/bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
 
     "vite-node/vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -2296,9 +2344,7 @@
 
     "@smithy/util-stream/@smithy/node-http-handler/@smithy/querystring-builder/@smithy/util-uri-escape": ["@smithy/util-uri-escape@4.0.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg=="],
 
-    "server/@repo/infornet/@types/bun/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
-
-    "server/@repo/sms/@types/bun/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
+    "server/@ai-sdk/google/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
     "vite-node/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 

--- a/apps/crm/package.json
+++ b/apps/crm/package.json
@@ -24,6 +24,7 @@
 		"pr": "bash ./create-pr.sh"
 	},
 	"dependencies": {
+		"@ai-sdk/google": "^3.0.20",
 		"@hookform/resolvers": "^5.2.1",
 		"@modelcontextprotocol/sdk": "^1.15.1",
 		"@orpc/client": "^1.6.6",

--- a/bun.lock
+++ b/bun.lock
@@ -207,6 +207,7 @@
     "apps/crm": {
       "name": "crm",
       "dependencies": {
+        "@ai-sdk/google": "^3.0.20",
         "@hookform/resolvers": "^5.2.1",
         "@modelcontextprotocol/sdk": "^1.15.1",
         "@orpc/client": "^1.6.6",
@@ -723,6 +724,12 @@
     "@0no-co/graphql.web": ["@0no-co/graphql.web@1.2.0", "", { "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0" }, "optionalPeers": ["graphql"] }, "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw=="],
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@3.0.20", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@ai-sdk/provider-utils": "4.0.13" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bVGsulEr6JiipAFlclo9bjL5WaUV0iCSiiekLt+PY6pwmtJeuU2GaD9DoE3OqR8LN2W779mU13IhVEzlTupf8g=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.7", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-VkPLrutM6VdA924/mG8OS+5frbVTcu6e046D2bgDo00tehBANR1QBJ/mPcZ9tXMFOsVcm6SQArOregxePzTFPw=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "3.0.7", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-HHG72BN4d+OWTcq2NwTxOm/2qvk1duYsnhCDtsbYwn/h/4zeqURu1S0+Cn0nY2Ysq9a9HGKvrYuMn9bgFhR2Og=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 


### PR DESCRIPTION
Actualiza el servicio de lead-scoring para usar los nuevos nombres de campos en español que espera el API de scoring.

## Cambios
- Renombra campos de ClientData a español (EDAD, SUELDO, PRECIO_PRODUCTO, etc.)
- Agrega función encodeCreditType para mapear TIPO_DE_COMPRAS
- Obtiene creditType desde la oportunidad para el scoring

## Contexto
El API de scoring en https://scoring.devteamatcci.site/predict cambió su contrato y ahora espera campos en español en mayúsculas.