### PR TITLE
Allows lead creation without DPI

### DIFF
--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -174,21 +174,87 @@ export async function createPublicLead(c: Context) {
 	try {
 		const body = await c.req.json();
 
-		// Validate required fields
-		if (
-			!body.firstName ||
-			!body.lastName ||
-			!body.email ||
-			!body.dpi ||
-			body.dpi.trim() === ""
-		) {
+		// Validate required fields (DPI es opcional)
+		if (!body.firstName || !body.lastName || !body.email) {
 			return c.json(
 				{
 					success: false,
-					error: "Faltan campos requeridos: Nombre, Apellido o Email o DPI",
+					error: "Faltan campos requeridos: Nombre, Apellido o Email",
 				},
 				400,
 			);
+		}
+
+		const hasDpi = body.dpi && body.dpi.trim() !== "";
+
+		// Si no tiene DPI, solo verificar por email y crear lead sin oportunidad
+		if (!hasDpi) {
+			// Verificar si ya existe un lead con el mismo email
+			const existingLeadByEmail = await db
+				.select()
+				.from(leads)
+				.where(eq(leads.email, body.email))
+				.limit(1);
+
+			if (existingLeadByEmail.length > 0) {
+				return c.json(
+					{
+						success: true,
+						data: existingLeadByEmail[0],
+						message: "Lead ya existe con el mismo email",
+					},
+					200,
+				);
+			}
+
+			// Obtener usuario de ventas con menos leads asignados
+			const salesUserForLead = await getSalesUserWithLeastLeads();
+
+			if (!salesUserForLead) {
+				return c.json(
+					{
+						success: false,
+						error: "No hay usuario de ventas disponible para asignar",
+					},
+					500,
+				);
+			}
+
+			// Crear el lead sin oportunidad (para importación masiva)
+			const [newLead] = await db
+				.insert(leads)
+				.values({
+					firstName: body.firstName,
+					lastName: body.lastName,
+					email: body.email,
+					phone: body.phone,
+					age: body.age,
+					dpi: null,
+					clientType: body.clientType || "individual",
+					maritalStatus: body.maritalStatus,
+					dependents: body.dependents ?? 0,
+					monthlyIncome: body.monthlyIncome?.toString(),
+					loanAmount: body.loanAmount?.toString(),
+					occupation: body.occupation,
+					workTime: body.workTime,
+					ownsHome: body.ownsHome ?? false,
+					ownsVehicle: body.ownsVehicle ?? false,
+					hasCreditCard: body.hasCreditCard ?? false,
+					jobTitle: body.jobTitle,
+					notes: body.notes,
+					source: body.source || "website",
+					status: "new",
+					assignedTo: salesUserForLead.id,
+					createdBy: salesUserForLead.id,
+					updatedAt: new Date(),
+				})
+				.returning();
+
+			return c.json({
+				success: true,
+				data: newLead,
+				message: "Lead creado sin DPI (importación)",
+			});
 		}
 
 		// Check if lead already exists with same email or DPI

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -3232,6 +3232,7 @@ function DocumentsManager({ opportunityId }: { opportunityId: string }) {
 			label: "Pago impuesto de circulación",
 		},
 		{ value: "consulta_sat", label: "Usuario de SAT (Propietario)" },
+		{ value: "usuario_sat_cliente", label: "Usuario de SAT (Cliente)" },
 		{
 			value: "consulta_garantias_mobiliarias",
 			label: "Consulta garantías mobiliarias",


### PR DESCRIPTION
Improves lead creation flow by allowing leads to be created without a DPI.

This enables the import of leads where DPI information is not available, creating a lead without an associated opportunity. If a lead with the provided email already exists, the existing lead will be returned. A sales user with the least amount of assigned leads will be selected and assigned to this new lead.