### PR TITLE
feat: persistir contador de intentos de análisis IA en servidor

### DIFF
--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -236,8 +236,10 @@ export const creditAnalysis = pgTable("credit_analysis", {
 	maxPayment: decimal("max_payment", { precision: 12, scale: 2 }),
 	adjustedPayment: decimal("adjusted_payment", { precision: 12, scale: 2 }),
 	maxCreditAmount: decimal("max_credit_amount", { precision: 12, scale: 2 }),
+	// Control de intentos de análisis con IA (cada llamada a IA cuesta dinero)
+	attemptCount: integer("attempt_count").notNull().default(0), // Se incrementa al llamar a la IA
 	// Metadata
-	analyzedAt: timestamp("analyzed_at").notNull().defaultNow(),
+	analyzedAt: timestamp("analyzed_at"), // null hasta que haya un análisis exitoso
 	createdAt: timestamp("created_at").notNull().defaultNow(),
 	updatedAt: timestamp("updated_at").notNull().defaultNow(),
 	createdBy: text("created_by")

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -1,7 +1,7 @@
 import { google } from "@ai-sdk/google";
 import { ORPCError } from "@orpc/server";
 import { generateObject } from "ai";
-import { eq } from "drizzle-orm";
+import { and, eq, isNull, lt, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { creditAnalysis, leads } from "../db/schema/crm";
@@ -11,6 +11,29 @@ import {
 } from "../lib/bank-analysis-schema";
 import { calculateCreditCapacity } from "../lib/financial-math";
 import { crmProcedure } from "../lib/orpc";
+
+const MAX_AI_ATTEMPTS = 2;
+const MAX_FILE_SIZE_BYTES = 15 * 1024 * 1024; // 15MB por archivo
+const AI_TIMEOUT_MS = 120_000; // 2 minutos timeout para la IA
+
+// Validar que el archivo es un PDF verificando los magic bytes
+function isValidPdf(base64Data: string): boolean {
+	try {
+		const buffer = Buffer.from(base64Data, "base64");
+		// PDF magic bytes: %PDF (0x25 0x50 0x44 0x46)
+		return buffer.length >= 4 && buffer.subarray(0, 4).toString() === "%PDF";
+	} catch {
+		return false;
+	}
+}
+
+// Obtener tamaño del archivo en bytes desde base64
+function getBase64SizeInBytes(base64Data: string): number {
+	// Base64 encoding: cada 4 caracteres = 3 bytes
+	// Ajustar por padding (=)
+	const padding = (base64Data.match(/=/g) || []).length;
+	return Math.floor((base64Data.length * 3) / 4) - padding;
+}
 
 export const bankAnalysisRouter = {
 	analyzeBankStatements: crmProcedure
@@ -56,37 +79,169 @@ export const bankAnalysisRouter = {
 				});
 			}
 
-			// 2. Construir content parts con los PDFs
+			// 2. Validar archivos: tamaño máximo y formato PDF
+			for (const file of input.files) {
+				const fileSize = getBase64SizeInBytes(file.data);
+				if (fileSize > MAX_FILE_SIZE_BYTES) {
+					const maxSizeMB = MAX_FILE_SIZE_BYTES / (1024 * 1024);
+					const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(1);
+					throw new ORPCError("BAD_REQUEST", {
+						message: `El archivo "${file.name}" (${fileSizeMB}MB) excede el tamaño máximo permitido de ${maxSizeMB}MB.`,
+					});
+				}
+				if (!isValidPdf(file.data)) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: `El archivo "${file.name}" no es un PDF válido.`,
+					});
+				}
+			}
+
+			// 3. Incremento atómico del contador para evitar race conditions
+			// Intentar actualizar registro existente con condiciones atómicas
+			const updateResult = await db
+				.update(creditAnalysis)
+				.set({
+					attemptCount: sql`${creditAnalysis.attemptCount} + 1`,
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(creditAnalysis.leadId, input.leadId),
+						lt(creditAnalysis.attemptCount, MAX_AI_ATTEMPTS),
+						isNull(creditAnalysis.analyzedAt),
+					),
+				)
+				.returning({
+					id: creditAnalysis.id,
+					attemptCount: creditAnalysis.attemptCount,
+				});
+
+			let currentAttemptCount: number;
+
+			if (updateResult.length > 0) {
+				// Registro existente actualizado exitosamente
+				currentAttemptCount = updateResult[0].attemptCount;
+			} else {
+				// No se actualizó: o no existe, o ya tiene análisis, o alcanzó el límite
+				const existing = await db
+					.select()
+					.from(creditAnalysis)
+					.where(eq(creditAnalysis.leadId, input.leadId))
+					.limit(1);
+
+				if (existing.length === 0) {
+					// No existe, crear nuevo registro
+					const insertResult = await db
+						.insert(creditAnalysis)
+						.values({
+							leadId: input.leadId,
+							attemptCount: 1,
+							createdBy: context.userId,
+						})
+						.onConflictDoNothing() // En caso de race condition en insert
+						.returning({ attemptCount: creditAnalysis.attemptCount });
+
+					if (insertResult.length === 0) {
+						// Hubo conflict, reintentar el update
+						const retryUpdate = await db
+							.update(creditAnalysis)
+							.set({
+								attemptCount: sql`${creditAnalysis.attemptCount} + 1`,
+								updatedAt: new Date(),
+							})
+							.where(
+								and(
+									eq(creditAnalysis.leadId, input.leadId),
+									lt(creditAnalysis.attemptCount, MAX_AI_ATTEMPTS),
+									isNull(creditAnalysis.analyzedAt),
+								),
+							)
+							.returning({ attemptCount: creditAnalysis.attemptCount });
+
+						if (retryUpdate.length === 0) {
+							throw new ORPCError("PRECONDITION_FAILED", {
+								message: `Se alcanzó el límite de ${MAX_AI_ATTEMPTS} intentos o ya existe un análisis exitoso.`,
+							});
+						}
+						currentAttemptCount = retryUpdate[0].attemptCount;
+					} else {
+						currentAttemptCount = insertResult[0].attemptCount;
+					}
+				} else {
+					// Existe pero no se pudo actualizar
+					if (existing[0].analyzedAt !== null) {
+						throw new ORPCError("PRECONDITION_FAILED", {
+							message:
+								"Ya existe un análisis exitoso para este lead. No se permiten más intentos.",
+						});
+					}
+					throw new ORPCError("PRECONDITION_FAILED", {
+						message: `Se alcanzó el límite de ${MAX_AI_ATTEMPTS} intentos de análisis. Contacte al administrador.`,
+					});
+				}
+			}
+
+			// 4. Construir content parts con los PDFs
 			const fileParts = input.files.map((file) => ({
 				type: "file" as const,
 				data: Buffer.from(file.data, "base64"),
-				mediaType: file.mimeType as "application/pdf",
+				mediaType: "application/pdf" as const,
 				filename: file.name,
 			}));
 
-			// 3. Llamar a Gemini con generateObject
-			const { object: analysis } = await generateObject({
-				model: google("gemini-3-flash-preview"),
-				schema: bankStatementAnalysisSchema,
-				messages: [
-					{
-						role: "system",
-						content: BANK_ANALYSIS_PROMPT,
-					},
-					{
-						role: "user",
-						content: [
-							{
-								type: "text",
-								text: "Analiza los siguientes estados de cuenta bancarios:",
-							},
-							...fileParts,
-						],
-					},
-				],
-			});
+			// 5. Llamar a Gemini con generateObject (aquí es donde cuesta dinero)
+			let analysis: Awaited<
+				ReturnType<typeof generateObject<typeof bankStatementAnalysisSchema>>
+			>["object"];
 
-			// 4. Calcular capacidad crediticia
+			try {
+				const result = await generateObject({
+					model: google("gemini-3-flash-preview"),
+					schema: bankStatementAnalysisSchema,
+					abortSignal: AbortSignal.timeout(AI_TIMEOUT_MS),
+					messages: [
+						{
+							role: "system",
+							content: BANK_ANALYSIS_PROMPT,
+						},
+						{
+							role: "user",
+							content: [
+								{
+									type: "text",
+									text: "Analiza los siguientes estados de cuenta bancarios:",
+								},
+								...fileParts,
+							],
+						},
+					],
+				});
+				analysis = result.object;
+			} catch (error) {
+				// El intento ya se contó, informar al usuario del error
+				const isTimeout =
+					error instanceof Error && error.name === "TimeoutError";
+				console.error("Error en análisis de IA:", {
+					leadId: input.leadId,
+					attemptCount: currentAttemptCount,
+					isTimeout,
+					error: error instanceof Error ? error.message : String(error),
+				});
+
+				const remainingAttempts = MAX_AI_ATTEMPTS - currentAttemptCount;
+				const timeoutMsg = isTimeout
+					? "El análisis tardó demasiado tiempo. "
+					: "";
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: `${timeoutMsg}Error al analizar los documentos (intento ${currentAttemptCount}/${MAX_AI_ATTEMPTS}). ${
+						remainingAttempts > 0
+							? `Puede intentar ${remainingAttempts} vez más.`
+							: "Se agotaron los intentos disponibles. Contacte al administrador."
+					}`,
+				});
+			}
+
+			// 6. Calcular capacidad crediticia
 			const creditCapacity = calculateCreditCapacity(analysis, {
 				annualRate: input.annualRate,
 				termMonths: input.termMonths,
@@ -94,49 +249,31 @@ export const bankAnalysisRouter = {
 				maxVariableDebtRatio: input.maxVariableDebtRatio,
 			});
 
-			// 5. Upsert en tabla creditAnalysis
-			const dataForDb = {
-				fullAnalysis: JSON.stringify(analysis),
-				monthlyFixedIncome:
-					analysis.promedio_mensual.promedio_ingresos_fijos.toString(),
-				monthlyVariableIncome:
-					analysis.promedio_mensual.promedio_ingresos_variables.toString(),
-				monthlyFixedExpenses:
-					analysis.promedio_mensual.promedio_gastos_fijos.toString(),
-				monthlyVariableExpenses:
-					analysis.promedio_mensual.promedio_gastos_variables.toString(),
-				economicAvailability:
-					analysis.promedio_mensual.disponibilidad_economica.toString(),
-				minPayment: creditCapacity.minPayment.toString(),
-				maxPayment: creditCapacity.maxPayment.toString(),
-				adjustedPayment: creditCapacity.adjustedPayment.toString(),
-				maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
-				analyzedAt: new Date(),
-			};
+			// 7. Actualizar con los resultados del análisis exitoso
+			await db
+				.update(creditAnalysis)
+				.set({
+					fullAnalysis: JSON.stringify(analysis),
+					monthlyFixedIncome:
+						analysis.promedio_mensual.promedio_ingresos_fijos.toString(),
+					monthlyVariableIncome:
+						analysis.promedio_mensual.promedio_ingresos_variables.toString(),
+					monthlyFixedExpenses:
+						analysis.promedio_mensual.promedio_gastos_fijos.toString(),
+					monthlyVariableExpenses:
+						analysis.promedio_mensual.promedio_gastos_variables.toString(),
+					economicAvailability:
+						analysis.promedio_mensual.disponibilidad_economica.toString(),
+					minPayment: creditCapacity.minPayment.toString(),
+					maxPayment: creditCapacity.maxPayment.toString(),
+					adjustedPayment: creditCapacity.adjustedPayment.toString(),
+					maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
+					analyzedAt: new Date(),
+					updatedAt: new Date(),
+				})
+				.where(eq(creditAnalysis.leadId, input.leadId));
 
-			const existing = await db
-				.select()
-				.from(creditAnalysis)
-				.where(eq(creditAnalysis.leadId, input.leadId))
-				.limit(1);
-
-			if (existing.length > 0) {
-				await db
-					.update(creditAnalysis)
-					.set({
-						...dataForDb,
-						updatedAt: new Date(),
-					})
-					.where(eq(creditAnalysis.leadId, input.leadId));
-			} else {
-				await db.insert(creditAnalysis).values({
-					leadId: input.leadId,
-					...dataForDb,
-					createdBy: context.userId,
-				});
-			}
-
-			// 6. Retornar resultados
+			// 8. Retornar resultados
 			return {
 				analysis,
 				creditCapacity,

--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -47,7 +47,9 @@ export function BankStatementAnalysis({
 		queryFn: () => client.getCreditAnalysisByLeadId({ leadId }),
 	});
 
-	const hasSuccessfulAnalysis = existingAnalysis?.analyzedAt !== null;
+	// Verificar si hay un análisis exitoso (analyzedAt debe existir y no ser null)
+	const hasSuccessfulAnalysis =
+		existingAnalysis != null && existingAnalysis.analyzedAt != null;
 	const attemptCount = existingAnalysis?.attemptCount ?? 0;
 	const canAnalyze =
 		!hasSuccessfulAnalysis && attemptCount < MAX_AI_ATTEMPTS;

--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	ChevronDown,
 	ChevronUp,
@@ -21,6 +21,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { client } from "@/utils/orpc";
 
+const MAX_AI_ATTEMPTS = 2;
+
 interface BankStatementAnalysisProps {
 	leadId: string;
 	onAnalysisComplete?: () => void;
@@ -36,9 +38,19 @@ export function BankStatementAnalysis({
 	const [termMonths, setTermMonths] = useState("60");
 	const [maxDebtRatio, setMaxDebtRatio] = useState("0.2");
 	const [maxVariableDebtRatio, setMaxVariableDebtRatio] = useState("0.3");
-	const [attemptCount, setAttemptCount] = useState(0);
-	const [analysisSucceeded, setAnalysisSucceeded] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
+	const queryClient = useQueryClient();
+
+	// Obtener estado del análisis desde el servidor
+	const { data: existingAnalysis, isLoading: isLoadingAnalysis } = useQuery({
+		queryKey: ["creditAnalysis", leadId],
+		queryFn: () => client.getCreditAnalysisByLeadId({ leadId }),
+	});
+
+	const hasSuccessfulAnalysis = existingAnalysis?.analyzedAt !== null;
+	const attemptCount = existingAnalysis?.attemptCount ?? 0;
+	const canAnalyze =
+		!hasSuccessfulAnalysis && attemptCount < MAX_AI_ATTEMPTS;
 
 	const analyzeMutation = useMutation({
 		mutationFn: async () => {
@@ -74,12 +86,15 @@ export function BankStatementAnalysis({
 		},
 		onSuccess: () => {
 			toast.success("Análisis completado exitosamente");
-			setAnalysisSucceeded(true);
 			setFiles([]);
+			// Invalidar query para obtener estado actualizado del servidor
+			queryClient.invalidateQueries({ queryKey: ["creditAnalysis", leadId] });
 			onAnalysisComplete?.();
 		},
 		onError: (error) => {
 			toast.error(`Error al analizar: ${error.message}`);
+			// Invalidar query para obtener el contador actualizado
+			queryClient.invalidateQueries({ queryKey: ["creditAnalysis", leadId] });
 		},
 	});
 
@@ -246,36 +261,39 @@ export function BankStatementAnalysis({
 					type="button"
 					size="sm"
 					className="w-full"
-					onClick={() => {
-						setAttemptCount((prev) => prev + 1);
-						analyzeMutation.mutate();
-					}}
+					onClick={() => analyzeMutation.mutate()}
 					disabled={
+						isLoadingAnalysis ||
 						files.length === 0 ||
 						analyzeMutation.isPending ||
-						analysisSucceeded ||
-						attemptCount >= 2
+						!canAnalyze
 					}
 				>
-					{analyzeMutation.isPending ? (
+					{isLoadingAnalysis ? (
+						<>
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							Cargando...
+						</>
+					) : analyzeMutation.isPending ? (
 						<>
 							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
 							Analizando con IA...
 						</>
-					) : attemptCount > 0 && !analysisSucceeded ? (
-						"Reintentar Análisis"
+					) : attemptCount > 0 && !hasSuccessfulAnalysis ? (
+						`Reintentar Análisis (${attemptCount}/${MAX_AI_ATTEMPTS})`
 					) : (
 						"Analizar"
 					)}
 				</Button>
-				{analysisSucceeded && (
+				{hasSuccessfulAnalysis && (
 					<p className="text-center text-xs text-green-600">
 						Análisis completado exitosamente.
 					</p>
 				)}
-				{attemptCount >= 2 && !analysisSucceeded && (
+				{!hasSuccessfulAnalysis && attemptCount >= MAX_AI_ATTEMPTS && (
 					<p className="text-center text-xs text-muted-foreground">
-						Se alcanzó el límite de intentos. Contacte al administrador.
+						Se alcanzó el límite de {MAX_AI_ATTEMPTS} intentos. Contacte al
+						administrador.
 					</p>
 				)}
 			</CardContent>

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -2847,7 +2847,7 @@ function RouteComponent() {
 											</Button>
 										</div>
 									</form>
-								) : creditAnalysisQuery.data ? (
+								) : creditAnalysisQuery.data?.analyzedAt ? (
 									<>
 										{/* Income and Expenses Summary */}
 										<div className="grid grid-cols-2 gap-6">


### PR DESCRIPTION
## Resumen
- Persiste el contador de intentos de análisis con IA en el servidor (tabla creditAnalysis)
- Implementa incremento atómico para evitar race conditions (clics rápidos duplicados)
- Valida magic bytes de PDF en servidor (no confiar en mimeType del cliente)
- Agrega límite de 15MB por archivo
- Agrega timeout de 2 minutos para llamadas a IA
- Frontend ahora usa datos del servidor en lugar de estado local

## Cambios técnicos
- `apps/server/src/db/schema/crm.ts`: Campo attemptCount en creditAnalysis
- `apps/server/src/routers/bank-analysis.ts`: Lógica de validación y control de intentos
- `apps/web/src/components/credit/BankStatementAnalysis.tsx`: Query para estado remoto
- `apps/web/src/routes/crm/leads.tsx`: Condición para mostrar análisis exitoso

## Test plan
- [ ] Verificar que el análisis funciona correctamente
- [ ] Verificar que no se puede analizar más de 2 veces si falla
- [ ] Verificar que después de éxito no se puede re-analizar
- [ ] Verificar que archivos no-PDF son rechazados
- [ ] Verificar que archivos >15MB son rechazados