### PR TITLE
feat: agregar términos del crédito en vista de aprobación

### DIFF
--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -811,6 +811,63 @@ export function CreditDetailView({
 
 				{/* TAB 1: Detalle Vehículo (Interno) */}
 				<TabsContent value="interno" className="mt-4 space-y-4">
+					{/* Términos del Crédito - Resumen de cotización */}
+					{quotation && (
+						<Card>
+							<CardHeader className="pb-3">
+								<div className="flex items-center gap-2">
+									<Calculator className="h-5 w-5 text-muted-foreground" />
+									<CardTitle className="text-lg">Términos del Crédito</CardTitle>
+									{quotation.status === "accepted" && (
+										<Badge
+											variant="outline"
+											className="ml-2 border-green-500 bg-green-50 text-green-700"
+										>
+											Cotización Aceptada
+										</Badge>
+									)}
+								</div>
+							</CardHeader>
+							<CardContent>
+								<div className="grid grid-cols-4 gap-6">
+									<div>
+										<p className="text-muted-foreground text-sm">
+											Valor del Vehículo
+										</p>
+										<p className="mt-1 font-semibold text-lg">
+											{formatCurrency(quotation.vehicleValue)}
+										</p>
+									</div>
+									<div>
+										<p className="text-muted-foreground text-sm">
+											Monto Asegurado
+										</p>
+										<p className="mt-1 font-semibold text-lg">
+											{formatCurrency(quotation.insuredAmount)}
+										</p>
+									</div>
+									<div>
+										<p className="text-muted-foreground text-sm">Enganche</p>
+										<p className="mt-1 font-semibold text-lg">
+											{formatCurrency(quotation.downPayment)}{" "}
+											<span className="font-normal text-muted-foreground text-sm">
+												({formatPercent(quotation.downPaymentPercentage)})
+											</span>
+										</p>
+									</div>
+									<div>
+										<p className="text-muted-foreground text-sm">
+											Total Financiado
+										</p>
+										<p className="mt-1 font-semibold text-lg">
+											{formatCurrency(quotation.totalFinanced)}
+										</p>
+									</div>
+								</div>
+							</CardContent>
+						</Card>
+					)}
+
 					<Card>
 						<CardHeader className="pb-3">
 							<div className="flex items-center justify-between">

--- a/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
@@ -4,11 +4,8 @@ import {
 	AlertCircle,
 	ArrowLeft,
 	CheckCircle,
-	ChevronLeft,
-	ChevronRight,
 	FileText,
 	Loader2,
-	Receipt,
 	XCircle,
 } from "lucide-react";
 import { useState } from "react";
@@ -216,19 +213,6 @@ function OpportunityDocumentsPage() {
 		},
 		enabled: !!opportunityId,
 	});
-
-	// Obtener cotizaciones de la oportunidad
-	const quotationsQuery = useQuery({
-		...orpc.listQuotationsByOpportunity.queryOptions({
-			input: { opportunityId },
-		}),
-		enabled: !!opportunityId,
-	});
-
-	// Obtener la cotización aceptada o la más reciente
-	const activeQuotation =
-		quotationsQuery.data?.find((q) => q.status === "accepted") ??
-		quotationsQuery.data?.[0];
 
 	const canApprove =
 		(validation.data?.canApprove ?? false) &&
@@ -509,107 +493,6 @@ function OpportunityDocumentsPage() {
 					</div>
 				</CardContent>
 			</Card>
-
-			{/* Términos del Crédito - Cotización */}
-			{activeQuotation && (
-				<Card>
-					<CardHeader className="pb-3">
-						<div className="flex items-center gap-2">
-							<Receipt className="h-5 w-5 text-muted-foreground" />
-							<CardTitle className="text-lg">Términos del Crédito</CardTitle>
-							{activeQuotation.status === "accepted" && (
-								<Badge variant="default" className="ml-2">
-									Aceptada
-								</Badge>
-							)}
-						</div>
-					</CardHeader>
-					<CardContent>
-						<div className="flex items-center gap-2">
-							<Button
-								variant="ghost"
-								size="icon"
-								className="h-8 w-8 shrink-0"
-								disabled
-							>
-								<ChevronLeft className="h-4 w-4" />
-							</Button>
-							<div className="grid flex-1 grid-cols-4 gap-6">
-								<div>
-									<p className="text-muted-foreground text-sm">
-										Valor del Vehículo
-									</p>
-									<p className="mt-1 font-semibold text-lg">
-										Q{" "}
-										{Number(activeQuotation.vehicleValue).toLocaleString(
-											"es-GT",
-											{
-												minimumFractionDigits: 2,
-												maximumFractionDigits: 2,
-											},
-										)}
-									</p>
-								</div>
-								<div>
-									<p className="text-muted-foreground text-sm">
-										Monto Asegurado
-									</p>
-									<p className="mt-1 font-semibold text-lg">
-										Q{" "}
-										{Number(activeQuotation.insuredAmount).toLocaleString(
-											"es-GT",
-											{
-												minimumFractionDigits: 2,
-												maximumFractionDigits: 2,
-											},
-										)}
-									</p>
-								</div>
-								<div>
-									<p className="text-muted-foreground text-sm">Enganche</p>
-									<p className="mt-1 font-semibold text-lg">
-										Q{" "}
-										{Number(activeQuotation.downPayment).toLocaleString(
-											"es-GT",
-											{
-												minimumFractionDigits: 2,
-												maximumFractionDigits: 2,
-											},
-										)}{" "}
-										<span className="font-normal text-muted-foreground text-sm">
-											({Number(activeQuotation.downPaymentPercentage).toFixed(2)}
-											%)
-										</span>
-									</p>
-								</div>
-								<div>
-									<p className="text-muted-foreground text-sm">
-										Total Financiado
-									</p>
-									<p className="mt-1 font-semibold text-lg">
-										Q{" "}
-										{Number(activeQuotation.totalFinanced).toLocaleString(
-											"es-GT",
-											{
-												minimumFractionDigits: 2,
-												maximumFractionDigits: 2,
-											},
-										)}
-									</p>
-								</div>
-							</div>
-							<Button
-								variant="ghost"
-								size="icon"
-								className="h-8 w-8 shrink-0"
-								disabled
-							>
-								<ChevronRight className="h-4 w-4" />
-							</Button>
-						</div>
-					</CardContent>
-				</Card>
-			)}
 
 			{/* Checklist */}
 			<AnalysisChecklistView

--- a/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
@@ -4,8 +4,11 @@ import {
 	AlertCircle,
 	ArrowLeft,
 	CheckCircle,
+	ChevronLeft,
+	ChevronRight,
 	FileText,
 	Loader2,
+	Receipt,
 	XCircle,
 } from "lucide-react";
 import { useState } from "react";
@@ -213,6 +216,19 @@ function OpportunityDocumentsPage() {
 		},
 		enabled: !!opportunityId,
 	});
+
+	// Obtener cotizaciones de la oportunidad
+	const quotationsQuery = useQuery({
+		...orpc.listQuotationsByOpportunity.queryOptions({
+			input: { opportunityId },
+		}),
+		enabled: !!opportunityId,
+	});
+
+	// Obtener la cotización aceptada o la más reciente
+	const activeQuotation =
+		quotationsQuery.data?.find((q) => q.status === "accepted") ??
+		quotationsQuery.data?.[0];
 
 	const canApprove =
 		(validation.data?.canApprove ?? false) &&
@@ -493,6 +509,107 @@ function OpportunityDocumentsPage() {
 					</div>
 				</CardContent>
 			</Card>
+
+			{/* Términos del Crédito - Cotización */}
+			{activeQuotation && (
+				<Card>
+					<CardHeader className="pb-3">
+						<div className="flex items-center gap-2">
+							<Receipt className="h-5 w-5 text-muted-foreground" />
+							<CardTitle className="text-lg">Términos del Crédito</CardTitle>
+							{activeQuotation.status === "accepted" && (
+								<Badge variant="default" className="ml-2">
+									Aceptada
+								</Badge>
+							)}
+						</div>
+					</CardHeader>
+					<CardContent>
+						<div className="flex items-center gap-2">
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-8 w-8 shrink-0"
+								disabled
+							>
+								<ChevronLeft className="h-4 w-4" />
+							</Button>
+							<div className="grid flex-1 grid-cols-4 gap-6">
+								<div>
+									<p className="text-muted-foreground text-sm">
+										Valor del Vehículo
+									</p>
+									<p className="mt-1 font-semibold text-lg">
+										Q{" "}
+										{Number(activeQuotation.vehicleValue).toLocaleString(
+											"es-GT",
+											{
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											},
+										)}
+									</p>
+								</div>
+								<div>
+									<p className="text-muted-foreground text-sm">
+										Monto Asegurado
+									</p>
+									<p className="mt-1 font-semibold text-lg">
+										Q{" "}
+										{Number(activeQuotation.insuredAmount).toLocaleString(
+											"es-GT",
+											{
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											},
+										)}
+									</p>
+								</div>
+								<div>
+									<p className="text-muted-foreground text-sm">Enganche</p>
+									<p className="mt-1 font-semibold text-lg">
+										Q{" "}
+										{Number(activeQuotation.downPayment).toLocaleString(
+											"es-GT",
+											{
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											},
+										)}{" "}
+										<span className="font-normal text-muted-foreground text-sm">
+											({Number(activeQuotation.downPaymentPercentage).toFixed(2)}
+											%)
+										</span>
+									</p>
+								</div>
+								<div>
+									<p className="text-muted-foreground text-sm">
+										Total Financiado
+									</p>
+									<p className="mt-1 font-semibold text-lg">
+										Q{" "}
+										{Number(activeQuotation.totalFinanced).toLocaleString(
+											"es-GT",
+											{
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											},
+										)}
+									</p>
+								</div>
+							</div>
+							<Button
+								variant="ghost"
+								size="icon"
+								className="h-8 w-8 shrink-0"
+								disabled
+							>
+								<ChevronRight className="h-4 w-4" />
+							</Button>
+						</div>
+					</CardContent>
+				</Card>
+			)}
 
 			{/* Checklist */}
 			<AnalysisChecklistView


### PR DESCRIPTION
## Resumen
Agrega card de 'Términos del Crédito' en CreditDetailView (donde la supervisora de ventas aprueba el detalle del crédito 40%→50%).

Muestra datos de la cotización:
- Valor del Vehículo
- Monto Asegurado
- Enganche (con porcentaje)
- Total Financiado

## Test plan
- [ ] Verificar que aparece el card en el tab 'Detalle Vehículo (Interno)'
- [ ] Verificar que muestra los datos correctos de la cotización