### PR TITLE
feat: toggle vista tabla/kanban en oportunidades

### DIFF
--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -747,7 +747,7 @@ export function CreditDetailView({
 	// Información del lead (deudor)
 	const lead = opportunity.lead;
 	const nombreDeudor = lead
-		? `${lead.firstName} ${lead.middleName || ""} ${lead.lastName} ${lead.secondLastName || ""}`
+		? `${lead.firstName} ${(lead as { middleName?: string }).middleName || ""} ${lead.lastName} ${(lead as { secondLastName?: string }).secondLastName || ""}`
 				.trim()
 				.replace(/\s+/g, " ")
 		: "No asignado";
@@ -817,7 +817,9 @@ export function CreditDetailView({
 							<CardHeader className="pb-3">
 								<div className="flex items-center gap-2">
 									<Calculator className="h-5 w-5 text-muted-foreground" />
-									<CardTitle className="text-lg">Términos del Crédito</CardTitle>
+									<CardTitle className="text-lg">
+										Términos del Crédito
+									</CardTitle>
 									{quotation.status === "accepted" && (
 										<Badge
 											variant="outline"

--- a/apps/crm/apps/web/src/lib/opportunities/columns.tsx
+++ b/apps/crm/apps/web/src/lib/opportunities/columns.tsx
@@ -7,38 +7,12 @@ import {
 	formatGuatemalaDate,
 	getStatusLabel,
 } from "@/lib/crm-formatters";
+import type { client } from "@/utils/orpc";
 
-export interface OpportunityTableRow {
-	id: string;
-	title: string;
-	value: string | null;
-	status: string;
-	probability: number | null;
-	expectedCloseDate: Date | string | null;
-	createdAt: Date | string;
-	stage: {
-		id: string;
-		name: string;
-		closurePercentage: number;
-		color: string;
-	} | null;
-	lead: {
-		id: string;
-		firstName: string;
-		lastName: string;
-	} | null;
-	vehicle: {
-		id: string;
-		make: string;
-		model: string;
-		year: string;
-	} | null;
-	assignedUser: {
-		id: string;
-		name: string;
-	} | null;
-	analysisStatus?: string;
-}
+// Tipo inferido directamente del cliente ORPC - fuente única de verdad
+export type Opportunity = Awaited<
+	ReturnType<typeof client.getOpportunities>
+>[number];
 
 function getStatusBadgeColor(status: string): string {
 	switch (status) {
@@ -62,7 +36,7 @@ function getStageBadgeStyle(closurePercentage: number): string {
 	return "bg-gray-100 text-gray-800";
 }
 
-export const opportunitiesColumns: ColumnDef<OpportunityTableRow>[] = [
+export const opportunitiesColumns: ColumnDef<Opportunity>[] = [
 	{
 		accessorKey: "title",
 		header: ({ column }) => (

--- a/apps/crm/apps/web/src/lib/opportunities/columns.tsx
+++ b/apps/crm/apps/web/src/lib/opportunities/columns.tsx
@@ -1,0 +1,297 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { ArrowUpDown, Calendar, Car, User } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	formatDate,
+	formatGuatemalaDate,
+	getStatusLabel,
+} from "@/lib/crm-formatters";
+
+export interface OpportunityTableRow {
+	id: string;
+	title: string;
+	value: string | null;
+	status: string;
+	probability: number | null;
+	expectedCloseDate: Date | string | null;
+	createdAt: Date | string;
+	stage: {
+		id: string;
+		name: string;
+		closurePercentage: number;
+		color: string;
+	} | null;
+	lead: {
+		id: string;
+		firstName: string;
+		lastName: string;
+	} | null;
+	vehicle: {
+		id: string;
+		make: string;
+		model: string;
+		year: string;
+	} | null;
+	assignedUser: {
+		id: string;
+		name: string;
+	} | null;
+	analysisStatus?: string;
+}
+
+function getStatusBadgeColor(status: string): string {
+	switch (status) {
+		case "open":
+			return "bg-blue-100 text-blue-800";
+		case "won":
+			return "bg-green-100 text-green-800";
+		case "lost":
+			return "bg-red-100 text-red-800";
+		case "on_hold":
+			return "bg-yellow-100 text-yellow-800";
+		default:
+			return "bg-gray-100 text-gray-800";
+	}
+}
+
+function getStageBadgeStyle(closurePercentage: number): string {
+	if (closurePercentage >= 80) return "bg-green-100 text-green-800";
+	if (closurePercentage >= 50) return "bg-blue-100 text-blue-800";
+	if (closurePercentage >= 30) return "bg-yellow-100 text-yellow-800";
+	return "bg-gray-100 text-gray-800";
+}
+
+export const opportunitiesColumns: ColumnDef<OpportunityTableRow>[] = [
+	{
+		accessorKey: "title",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				aria-label="Ordenar por título"
+			>
+				Título
+				<ArrowUpDown className="ml-2 h-4 w-4" aria-hidden="true" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const title = row.getValue("title") as string;
+			const analysisStatus = row.original.analysisStatus;
+
+			return (
+				<div className="flex flex-col gap-1">
+					<span className="font-medium">{title}</span>
+					{analysisStatus === "rejected" && (
+						<Badge variant="destructive" className="w-fit text-xs">
+							Análisis Rechazado
+						</Badge>
+					)}
+					{analysisStatus === "resubmitted" && (
+						<Badge
+							variant="outline"
+							className="w-fit border-blue-300 bg-blue-50 text-blue-700 text-xs"
+						>
+							Reenviado a Análisis
+						</Badge>
+					)}
+				</div>
+			);
+		},
+	},
+	{
+		accessorKey: "lead",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				aria-label="Ordenar por cliente"
+			>
+				<User className="mr-2 h-4 w-4" aria-hidden="true" />
+				Cliente
+				<ArrowUpDown className="ml-2 h-4 w-4" aria-hidden="true" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const lead = row.original.lead;
+			return lead ? (
+				<span>
+					{lead.firstName} {lead.lastName}
+				</span>
+			) : (
+				<span className="text-muted-foreground">Sin cliente</span>
+			);
+		},
+		sortingFn: (rowA, rowB) => {
+			const a = rowA.original.lead;
+			const b = rowB.original.lead;
+			if (!a && !b) return 0;
+			if (!a) return 1;
+			if (!b) return -1;
+			return `${a.firstName} ${a.lastName}`.localeCompare(
+				`${b.firstName} ${b.lastName}`,
+			);
+		},
+	},
+	{
+		accessorKey: "stage",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				aria-label="Ordenar por etapa"
+			>
+				Etapa
+				<ArrowUpDown className="ml-2 h-4 w-4" aria-hidden="true" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const stage = row.original.stage;
+			return stage ? (
+				<Badge className={getStageBadgeStyle(stage.closurePercentage)}>
+					{stage.closurePercentage}% - {stage.name}
+				</Badge>
+			) : (
+				<span className="text-muted-foreground">Sin etapa</span>
+			);
+		},
+		sortingFn: (rowA, rowB) => {
+			const a = rowA.original.stage?.closurePercentage ?? 0;
+			const b = rowB.original.stage?.closurePercentage ?? 0;
+			return a - b;
+		},
+	},
+	{
+		accessorKey: "value",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				aria-label="Ordenar por valor"
+			>
+				Valor
+				<ArrowUpDown className="ml-2 h-4 w-4" aria-hidden="true" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const value = row.getValue("value") as string | null;
+			const numericValue = value ? Number.parseFloat(value) : null;
+			return numericValue !== null ? (
+				<span className="font-medium text-green-600 tabular-nums">
+					Q{numericValue.toLocaleString()}
+				</span>
+			) : (
+				<span className="text-muted-foreground">—</span>
+			);
+		},
+		sortingFn: (rowA, rowB) => {
+			const a = Number.parseFloat(rowA.getValue("value") ?? "0") || 0;
+			const b = Number.parseFloat(rowB.getValue("value") ?? "0") || 0;
+			return a - b;
+		},
+	},
+	{
+		accessorKey: "vehicle",
+		header: () => (
+			<span className="flex items-center gap-2">
+				<Car className="h-4 w-4" aria-hidden="true" />
+				Vehículo
+			</span>
+		),
+		cell: ({ row }) => {
+			const vehicle = row.original.vehicle;
+			return vehicle ? (
+				<span className="text-sm">
+					{vehicle.year} {vehicle.make} {vehicle.model}
+				</span>
+			) : (
+				<span className="text-muted-foreground">Sin vehículo</span>
+			);
+		},
+	},
+	{
+		accessorKey: "status",
+		header: "Estado",
+		cell: ({ row }) => {
+			const status = row.getValue("status") as string;
+			return (
+				<Badge className={getStatusBadgeColor(status)} variant="outline">
+					{getStatusLabel(status)}
+				</Badge>
+			);
+		},
+		filterFn: (row, id, value) => {
+			return value === "all" || row.getValue(id) === value;
+		},
+	},
+	{
+		accessorKey: "probability",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				aria-label="Ordenar por probabilidad"
+			>
+				Prob.
+				<ArrowUpDown className="ml-2 h-4 w-4" aria-hidden="true" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const probability = row.getValue("probability") as number | null;
+			const stage = row.original.stage;
+			const displayValue = probability ?? stage?.closurePercentage ?? 0;
+			return <span className="tabular-nums">{displayValue}%</span>;
+		},
+	},
+	{
+		accessorKey: "assignedUser",
+		header: "Asignado a",
+		cell: ({ row }) => {
+			const user = row.original.assignedUser;
+			return user ? (
+				<span className="text-sm">{user.name}</span>
+			) : (
+				<span className="text-muted-foreground">Sin asignar</span>
+			);
+		},
+	},
+	{
+		accessorKey: "expectedCloseDate",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				aria-label="Ordenar por fecha estimada de cierre"
+			>
+				<Calendar className="mr-2 h-4 w-4" aria-hidden="true" />
+				Cierre Est.
+				<ArrowUpDown className="ml-2 h-4 w-4" aria-hidden="true" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const date = row.getValue("expectedCloseDate") as Date | string | null;
+			return date ? (
+				<span className="text-sm">{formatDate(date)}</span>
+			) : (
+				<span className="text-muted-foreground">—</span>
+			);
+		},
+	},
+	{
+		accessorKey: "createdAt",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				aria-label="Ordenar por fecha de creación"
+			>
+				Creada
+				<ArrowUpDown className="ml-2 h-4 w-4" aria-hidden="true" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const date = row.getValue("createdAt") as Date | string;
+			return <span className="text-sm">{formatGuatemalaDate(date)}</span>;
+		},
+	},
+];

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -18,6 +18,8 @@ import {
 	FileText,
 	Filter,
 	History,
+	Kanban,
+	List,
 	Mail,
 	Plus,
 	RefreshCw,
@@ -34,6 +36,7 @@ import { toast } from "sonner";
 import invariant from "tiny-invariant";
 import { z } from "zod";
 import { CreditDetailView } from "@/components/credit/CreditDetailView";
+import { DataTable } from "@/components/data-table";
 import { NotesTimeline } from "@/components/notes-timeline";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -73,6 +76,7 @@ import {
 	getSourceLabel,
 	getStatusLabel,
 } from "@/lib/crm-formatters";
+import { opportunitiesColumns } from "@/lib/opportunities/columns";
 import { getRoleLabel, PERMISSIONS } from "@/lib/roles";
 import {
 	getMissingFieldsForNewVehicle,
@@ -440,6 +444,16 @@ function RouteComponent() {
 	const [showLostOpportunities, setShowLostOpportunities] = useState(false);
 	const [boardSearch, setBoardSearch] = useState("");
 	const debouncedBoardSearch = useDeferredValue(boardSearch);
+	// View toggle: "kanban" or "table" - persist in localStorage
+	const [viewMode, setViewMode] = useState<"kanban" | "table">(() => {
+		if (typeof window !== "undefined") {
+			const saved = localStorage.getItem("opportunities-view-mode");
+			return saved === "table" ? "table" : "kanban";
+		}
+		return "kanban";
+	});
+	// Filtro por etapa (stage ID) para vista tabla
+	const [stageIdFilter, setStageIdFilter] = useState<string>("all");
 	const processedCompanyIdRef = useRef<string | null>(null);
 	const processedOpportunityIdRef = useRef<string | null>(null);
 	const prevOpenRef = useRef(isCreateDialogOpen);
@@ -463,6 +477,12 @@ function RouteComponent() {
 		}, 300);
 		return () => clearTimeout(timer);
 	}, [vehiclesSearch]);
+
+	// Handler para cambiar vista y persistir en localStorage
+	const handleViewModeChange = (mode: "kanban" | "table") => {
+		setViewMode(mode);
+		localStorage.setItem("opportunities-view-mode", mode);
+	};
 
 	const handleDropOpportunity = (opportunityId: string, newStageId: string) => {
 		// Find the opportunity and the target stage
@@ -1498,9 +1518,39 @@ function RouteComponent() {
 						onClick={() => setShowLostOpportunities(!showLostOpportunities)}
 						className="gap-2"
 					>
-						<span className="h-2 w-2 rounded-full bg-red-500" />
+						<span
+							className="h-2 w-2 rounded-full bg-red-500"
+							aria-hidden="true"
+						/>
 						{showLostOpportunities ? "Ocultando perdidas" : "Mostrar perdidas"}
 					</Button>
+					{/* View Toggle */}
+					<div
+						className="flex rounded-md border"
+						role="group"
+						aria-label="Cambiar vista"
+					>
+						<Button
+							variant={viewMode === "kanban" ? "default" : "ghost"}
+							size="sm"
+							onClick={() => handleViewModeChange("kanban")}
+							className="rounded-r-none"
+							aria-label="Vista Kanban"
+							aria-pressed={viewMode === "kanban"}
+						>
+							<Kanban className="h-4 w-4" aria-hidden="true" />
+						</Button>
+						<Button
+							variant={viewMode === "table" ? "default" : "ghost"}
+							size="sm"
+							onClick={() => handleViewModeChange("table")}
+							className="rounded-l-none border-l"
+							aria-label="Vista Tabla"
+							aria-pressed={viewMode === "table"}
+						>
+							<List className="h-4 w-4" aria-hidden="true" />
+						</Button>
+					</div>
 				</div>
 
 				<Dialog
@@ -3030,23 +3080,92 @@ function RouteComponent() {
 				</Dialog>
 			</div>
 
-			{/* Enhanced Opportunities Kanban View */}
-			<div className="flex items-start gap-6 overflow-x-auto pb-4">
-				{opportunitiesByStage.map(
-					({ stage, opportunities, totalValue, count }) => (
-						<DroppableStageColumn
-							key={stage.id}
-							stage={stage}
-							opportunities={opportunities}
-							totalValue={totalValue}
-							count={count}
-							getStatusBadgeColor={getStatusBadgeColor}
-							onDropOpportunity={handleDropOpportunity}
-							onOpportunityClick={handleOpportunityClick}
-						/>
-					),
-				)}
-			</div>
+			{/* Conditional View: Kanban or Table */}
+			{viewMode === "kanban" ? (
+				<div className="flex items-start gap-6 overflow-x-auto pb-4">
+					{opportunitiesByStage.map(
+						({ stage, opportunities, totalValue, count }) => (
+							<DroppableStageColumn
+								key={stage.id}
+								stage={stage}
+								opportunities={opportunities}
+								totalValue={totalValue}
+								count={count}
+								getStatusBadgeColor={getStatusBadgeColor}
+								onDropOpportunity={handleDropOpportunity}
+								onOpportunityClick={handleOpportunityClick}
+							/>
+						),
+					)}
+				</div>
+			) : (
+				<DataTable
+					columns={opportunitiesColumns}
+					data={
+						opportunitiesQuery.data?.filter(
+							(opp) =>
+								// Filtro por estado (del Select del toolbar)
+								(stageFilter === "all" || opp.status === stageFilter) &&
+								// Filtro por etapa (de los badges)
+								(stageIdFilter === "all" || opp.stage?.id === stageIdFilter) &&
+								// Filtro de perdidas
+								(showLostOpportunities || opp.status !== "lost") &&
+								// Filtro de búsqueda
+								(!debouncedBoardSearch.trim() ||
+									`${opp.lead?.firstName ?? ""} ${opp.lead?.lastName ?? ""}`
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+									(opp.title ?? "")
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase())),
+						) ?? []
+					}
+					isLoading={opportunitiesQuery.isLoading}
+					searchPlaceholder="Buscar oportunidades..."
+					onRowClick={handleOpportunityClick}
+					filterContent={
+						<div className="flex flex-wrap items-center gap-2">
+							<span className="font-medium text-muted-foreground text-sm">
+								Filtrar por etapa:
+							</span>
+							<Badge
+								variant={stageIdFilter === "all" ? "default" : "outline"}
+								className="cursor-pointer"
+								onClick={() => setStageIdFilter("all")}
+							>
+								Todas
+							</Badge>
+							{salesStagesQuery.data?.map((stage) => {
+								const count =
+									opportunitiesQuery.data?.filter(
+										(opp) =>
+											opp.stage?.id === stage.id &&
+											(stageFilter === "all" || opp.status === stageFilter) &&
+											(showLostOpportunities || opp.status !== "lost"),
+									).length ?? 0;
+								const isActive = stageIdFilter === stage.id;
+								return (
+									<Badge
+										key={stage.id}
+										variant={isActive ? "default" : "outline"}
+										className="cursor-pointer tabular-nums transition-colors hover:bg-muted"
+										style={{
+											borderColor: isActive ? undefined : stage.color,
+											backgroundColor: isActive ? stage.color : undefined,
+											color: isActive ? "white" : undefined,
+										}}
+										onClick={() =>
+											setStageIdFilter(isActive ? "all" : stage.id)
+										}
+									>
+										{stage.closurePercentage}% ({count})
+									</Badge>
+								);
+							})}
+						</div>
+					}
+				/>
+			)}
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -76,7 +76,10 @@ import {
 	getSourceLabel,
 	getStatusLabel,
 } from "@/lib/crm-formatters";
-import { opportunitiesColumns } from "@/lib/opportunities/columns";
+import {
+	type Opportunity,
+	opportunitiesColumns,
+} from "@/lib/opportunities/columns";
 import { getRoleLabel, PERMISSIONS } from "@/lib/roles";
 import {
 	getMissingFieldsForNewVehicle,
@@ -338,88 +341,8 @@ export const Route = createFileRoute("/crm/opportunities")({
 	}).parse,
 });
 
-export interface IOpportunity {
-	id: string;
-	title: string;
-	value: string | null;
-	tasaInteres: string | null;
-	numeroCuotas: number | null;
-	cuotaMensual: string | null;
-	royalti: string | null;
-	porcentajeRoyalti: string | null;
-	gps: string | null;
-	seguro: string | null;
-	membresiaPago: string | null;
-	nit: string | null;
-	// direccion: string | null;
-	inversionistas: string | null;
-	status: string;
-	source?:
-		| "website"
-		| "referral"
-		| "cold_call"
-		| "email"
-		| "social_media"
-		| "event"
-		| "other"
-		| null;
-	loanPurpose?: "personal" | "business" | null;
-	creditType?: "autocompra" | "sobre_vehiculo" | null;
-	creditDetailApproved?: boolean | null;
-	creditDetailApprovedBy?: string | null;
-	creditDetailApprovedAt?: Date | string | null;
-	stage: any;
-	vehicleId: string | null;
-	expectedCloseDate: Date | string | null;
-	probability: number | null;
-	notes: string | null;
-	createdAt: Date | string;
-	updatedAt: Date | string;
-	asesorId: number | null;
-	fechaInicio: Date | string | null;
-	diaPagoMensual: number | null;
-	categoria: any;
-	reserva: string | null;
-	rubros: string | null;
-	leadId: string | null;
-	company: any;
-	assignedUser: any;
-	lead?: {
-		id: string;
-		firstName: string;
-		middleName?: string | null;
-		lastName: string;
-		email?: string | null;
-		secondLastName?: string | null;
-		age?: number | null;
-		departamento?: string | null;
-		municipio?: string | null;
-		direccion?: string | null;
-		zona?: string | null;
-	} | null;
-	vehicle?: {
-		id: string;
-		make: string;
-		model: string;
-		year: string;
-		licensePlate: string | null;
-		color: string | null;
-		plate: string | null;
-		origin: string | null;
-		isNew: boolean;
-		fuelType: string | null;
-		transmission: string | null;
-		vinNumber: string | null;
-		vendor?: {
-			id: string;
-			name: string;
-			phone: string;
-			dpi: string;
-			vendorType: string;
-			companyName: string | null;
-		} | null;
-	} | null;
-}
+// IOpportunity es un alias de Opportunity para compatibilidad con código existente
+export type IOpportunity = Opportunity;
 
 function RouteComponent() {
 	const { data: session, isPending } = authClient.useSession();
@@ -431,7 +354,7 @@ function RouteComponent() {
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 	const [isChangeStageDialogOpen, setIsChangeStageDialogOpen] = useState(false);
 	const [selectedOpportunity, setSelectedOpportunity] =
-		useState<IOpportunity | null>(null);
+		useState<Opportunity | null>(null);
 	const [selectedStage, setSelectedStage] = useState<string>("");
 	const [stageFilter, setStageFilter] = useState<string>("all");
 	const [opportunityHistory, setOpportunityHistory] = useState<any[]>([]);
@@ -543,7 +466,7 @@ function RouteComponent() {
 		});
 	};
 
-	const handleOpportunityClick = async (opportunity: any) => {
+	const handleOpportunityClick = async (opportunity: Opportunity) => {
 		setSelectedOpportunity(opportunity);
 		setIsDetailsDialogOpen(true);
 
@@ -1109,7 +1032,6 @@ function RouteComponent() {
 					(opp) => opp.id === variables.id,
 				);
 				if (updatedOpportunity) {
-					// @ts-expect-error
 					setSelectedOpportunity(updatedOpportunity);
 				}
 
@@ -1219,7 +1141,6 @@ function RouteComponent() {
 				(opp) => opp.id === search.opportunityId,
 			);
 			if (opportunity) {
-				// @ts-expect-error
 				setSelectedOpportunity(opportunity);
 				setIsDetailsDialogOpen(true);
 				processedOpportunityIdRef.current = search.opportunityId;
@@ -2101,21 +2022,6 @@ function RouteComponent() {
 													<span className="font-medium">
 														{selectedOpportunity.assignedUser.name ||
 															"Usuario sin nombre"}
-													</span>
-												</div>
-											</div>
-										)}
-
-										{/* Source */}
-										{selectedOpportunity.source && (
-											<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
-												<Label className="font-semibold text-muted-foreground text-sm">
-													Fuente
-												</Label>
-												<div className="flex items-center gap-3">
-													<Target className="h-5 w-5 text-muted-foreground" />
-													<span className="font-medium">
-														{getSourceLabel(selectedOpportunity.source)}
 													</span>
 												</div>
 											</div>
@@ -3032,7 +2938,7 @@ function RouteComponent() {
 
 													if (!selectedOpportunity.vehicleId)
 														missingFields.push("vehículo");
-													if (!selectedOpportunity.leadId)
+													if (!selectedOpportunity.lead)
 														missingFields.push("lead/contacto");
 													if (!selectedOpportunity.value)
 														missingFields.push("valor del crédito");


### PR DESCRIPTION
## Resumen
- Agregar toggle para alternar entre vista Kanban y DataTable en oportunidades
- Columnas con ordenamiento: Título, Cliente, Etapa, Valor, Vehículo, Estado, etc.
- Vista persistida en localStorage
- Filtros por etapa con badges interactivos en vista tabla

## Test plan
- [x] Verificar toggle cambia entre vistas
- [x] Verificar filtros funcionan en ambas vistas
- [x] Verificar ordenamiento de columnas en tabla
- [x] Verificar click en fila abre detalle de oportunidad
- [x] Verificar persistencia de vista en localStorage