### PR TITLE
Terminal Updates legal contract PDF handling and status

### DIFF
--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -113,7 +113,8 @@ export const legalContractsRouter = {
 					`legal-contracts/${input.opportunityId || input.leadId}`,
 				);
 
-				pdfLink = await getFileUrl(key);
+				// Guardar solo la key, no la URL firmada temporal
+				pdfLink = key;
 			}
 
 			// Crear el contrato (sin incluir pdfFile en los valores)
@@ -193,10 +194,11 @@ export const legalContractsRouter = {
 				const { key } = await uploadFileToR2(
 					fileBlob,
 					uniqueFilename,
-					`legal-contracts/${existingContract.leadId}`,
+					`legal-contracts/${existingContract.opportunityId || existingContract.leadId}`,
 				);
 
-				pdfLink = await getFileUrl(key);
+				// Guardar solo la key, no la URL firmada temporal
+				pdfLink = key;
 			}
 
 			// Actualizar el contrato
@@ -327,11 +329,13 @@ export const legalContractsRouter = {
 				.where(eq(generatedLegalContracts.opportunityId, input.opportunityId))
 				.orderBy(generatedLegalContracts.generatedAt);
 
-			// Verificar estado de firma en Documenso para contratos pendientes
+			// Verificar estado de firma en Documenso y generar URLs firmadas para PDFs
 			const contractsWithUpdatedStatus = await Promise.all(
 				contracts.map(async (contractData) => {
+					let updatedContract = contractData.contract;
+					// TODO: Aun nadie usa Documenso, deshabilitado por ahora
 					// Solo verificar si el contrato está pendiente y tiene link de firma del cliente
-					if (
+					/*if (
 						contractData.contract.status === "pending" &&
 						contractData.contract.clientSigningLink
 					) {
@@ -341,7 +345,7 @@ export const legalContractsRouter = {
 
 						// Si está firmado, actualizar en la base de datos
 						if (signingStatus.isSigned) {
-							const [updatedContract] = await db
+							const [dbUpdatedContract] = await db
 								.update(generatedLegalContracts)
 								.set({
 									status: "signed",
@@ -350,14 +354,37 @@ export const legalContractsRouter = {
 								.where(eq(generatedLegalContracts.id, contractData.contract.id))
 								.returning();
 
-							return {
-								...contractData,
-								contract: updatedContract,
-							};
+							updatedContract = dbUpdatedContract;
+						}
+					}*/
+
+					// Generar URL firmada fresca si pdfLink es una key (no es URL de documenso)
+					let pdfLinkUrl = updatedContract.pdfLink;
+					if (
+						updatedContract.pdfLink &&
+						!updatedContract.pdfLink.includes("documenso")
+					) {
+						// Si es una key (no empieza con http), generar URL firmada
+						if (!updatedContract.pdfLink.startsWith("http")) {
+							try {
+								pdfLinkUrl = await getFileUrl(updatedContract.pdfLink);
+							} catch (error) {
+								console.error(
+									`Error generando URL para contrato ${updatedContract.id}:`,
+									error,
+								);
+								// Mantener el valor original si hay error
+							}
 						}
 					}
 
-					return contractData;
+					return {
+						...contractData,
+						contract: {
+							...updatedContract,
+							pdfLink: pdfLinkUrl,
+						},
+					};
 				}),
 			);
 


### PR DESCRIPTION
This pull request updates the handling of legal contract PDFs in the `legalContractsRouter`. The main goal is to store only the storage key for contract PDFs in the database instead of a temporary signed URL, and to generate fresh signed URLs on demand when contracts are queried. This improves security and ensures that links to PDFs do not expire prematurely.

Key changes:

**PDF Storage and Retrieval Logic:**
* When uploading or updating a contract PDF, only the storage key is saved in the `pdfLink` field, not a signed URL. This prevents storing temporary links that could expire or be misused. [[1]](diffhunk://#diff-18e745f4714cb36710d37a654910ec85bbbdd99b1075e095c7ac09e02b5840faL116-R117) [[2]](diffhunk://#diff-18e745f4714cb36710d37a654910ec85bbbdd99b1075e095c7ac09e02b5840faL196-R201)
* When fetching contracts, if the `pdfLink` is a storage key (not a URL), a fresh signed URL is generated dynamically for each contract. This ensures that users always receive a valid, non-expired link to the PDF.

**Documenso Integration (Signature Status):**
* The code for checking signature status in Documenso is now commented out with a note indicating that Documenso is not currently in use. This prevents unnecessary API calls and simplifies contract retrieval for now.

**Code Quality and Maintainability:**
* Variable names have been clarified (e.g., `updatedContract` and `dbUpdatedContract`) to improve code readability and prevent confusion when updating contract status.