### PR TITLE
feat(legal-docs): add WeeTrust webhook endpoints

### DIFF
--- a/apps/legal-docs-blueprints/index.ts
+++ b/apps/legal-docs-blueprints/index.ts
@@ -2,6 +2,10 @@ import { Elysia } from 'elysia';
 import { cors } from '@elysiajs/cors';
 import { contractGenerator } from './services/ContractGeneratorService';
 import { ContractType, GenerateContractRequest } from './types/contract';
+import { WeeTrustService } from './services/WeeTrustService';
+
+// Inicializar WeeTrust
+const weeTrustService = new WeeTrustService();
 
 const PORT = Number(process.env.PORT) || 4000;
 
@@ -327,7 +331,12 @@ const app = new Elysia()
       listContracts: 'GET /contracts/types',
       generateContract: 'POST /generatecontrato',
       generateBatch: 'POST /contracts/batch',
-      generateByType: 'POST /contracts/:type'
+      generateByType: 'POST /contracts/:type',
+      webhooks: {
+        receive: 'POST /webhooks/weetrust',
+        status: 'GET /webhooks/weetrust/status',
+        register: 'POST /webhooks/weetrust/register'
+      }
     },
     examples: {
       generateContract: {
@@ -358,6 +367,139 @@ const app = new Elysia()
     }
   };
 })
+
+  // ===== WEBHOOKS =====
+
+  /**
+   * POST /webhooks/weetrust - Recibe notificaciones de WeeTrust
+   *
+   * Tipos de eventos:
+   * - sendDocument: Documento enviado a firma
+   * - signDocument: Un firmante firmó
+   * - completedDocument: Todos los firmantes completaron
+   */
+  .post('/webhooks/weetrust', async ({ body, set }) => {
+    try {
+      const payload = body as {
+        event?: string;
+        type?: string;
+        documentID?: string;
+        document?: {
+          documentID: string;
+          status: string;
+        };
+        signatory?: {
+          emailID: string;
+          name: string;
+          isSigned: number;
+        };
+        timestamp?: string;
+      };
+
+      console.log('\n📥 [WeeTrust Webhook] Evento recibido:', JSON.stringify(payload, null, 2));
+
+      // Determinar tipo de evento
+      const eventType = payload.event || payload.type || 'unknown';
+      const documentId = payload.documentID || payload.document?.documentID;
+
+      if (!documentId) {
+        console.warn('[WeeTrust Webhook] Payload sin documentID');
+        set.status = 400;
+        return { success: false, error: 'Missing documentID' };
+      }
+
+      // Procesar según tipo de evento
+      switch (eventType) {
+        case 'sendDocument':
+          console.log(`[WeeTrust Webhook] Documento ${documentId} enviado a firma`);
+          break;
+
+        case 'signDocument':
+          console.log(`[WeeTrust Webhook] Documento ${documentId} - Firmante firmó:`, payload.signatory?.emailID);
+          // TODO: Notificar a CRM que un firmante firmó
+          break;
+
+        case 'completedDocument':
+          console.log(`[WeeTrust Webhook] Documento ${documentId} - COMPLETADO (todos firmaron)`);
+          // TODO: Notificar a CRM que el documento está completo
+          // await notifyCrmDocumentCompleted(documentId);
+          break;
+
+        default:
+          console.log(`[WeeTrust Webhook] Evento desconocido: ${eventType}`);
+      }
+
+      // Responder éxito a WeeTrust
+      set.status = 200;
+      return {
+        success: true,
+        message: 'Webhook received',
+        event: eventType,
+        documentId
+      };
+
+    } catch (error: any) {
+      console.error('[WeeTrust Webhook] Error:', error);
+      set.status = 500;
+      return { success: false, error: error.message };
+    }
+  })
+
+  /**
+   * GET /webhooks/weetrust/status - Ver webhooks registrados
+   */
+  .get('/webhooks/weetrust/status', async ({ set }) => {
+    try {
+      const webhooks = await weeTrustService.listWebhooks();
+      return {
+        success: true,
+        count: webhooks.length,
+        webhooks
+      };
+    } catch (error: any) {
+      set.status = 500;
+      return { success: false, error: error.message };
+    }
+  })
+
+  /**
+   * POST /webhooks/weetrust/register - Registrar webhook en WeeTrust
+   * Body: { url: string, type: 'sendDocument' | 'signDocument' | 'completedDocument' }
+   */
+  .post('/webhooks/weetrust/register', async ({ body, set }) => {
+    try {
+      const { url, type } = body as { url: string; type: string };
+
+      if (!url || !type) {
+        set.status = 400;
+        return { success: false, error: 'Missing url or type' };
+      }
+
+      const validTypes = ['sendDocument', 'signDocument', 'completedDocument'];
+      if (!validTypes.includes(type)) {
+        set.status = 400;
+        return {
+          success: false,
+          error: `Invalid type. Valid types: ${validTypes.join(', ')}`
+        };
+      }
+
+      const result = await weeTrustService.addWebhook(
+        url,
+        type as 'sendDocument' | 'signDocument' | 'completedDocument'
+      );
+
+      return {
+        success: true,
+        message: 'Webhook registered',
+        webhook: result
+      };
+    } catch (error: any) {
+      set.status = 500;
+      return { success: false, error: error.message };
+    }
+  })
+
   .listen({
     port: PORT,
     hostname: '0.0.0.0'
@@ -374,6 +516,11 @@ console.log(`
 ║  • POST /generatecontrato      - Genera contrato          ║
 ║  • POST /contracts/batch       - Genera múltiples         ║
 ║  • POST /contracts/:type       - Genera por tipo          ║
+║                                                           ║
+║  Webhooks:                                                ║
+║  • POST /webhooks/weetrust          - Recibe eventos      ║
+║  • GET  /webhooks/weetrust/status   - Ver registrados     ║
+║  • POST /webhooks/weetrust/register - Registrar webhook   ║
 ╚═══════════════════════════════════════════════════════════╝
 `);
 


### PR DESCRIPTION
## Summary
- Add webhook endpoints for WeeTrust integration
- POST /webhooks/weetrust - receive events from WeeTrust
- GET /webhooks/weetrust/status - list registered webhooks
- POST /webhooks/weetrust/register - register new webhooks

Supports: sendDocument, signDocument, completedDocument

## Pending
- Deploy to production
- Register webhook with WeeTrust
- Connect to CRM on completedDocument

🤖 Generated with [Claude Code](https://claude.ai/claude-code)