### PR TITLE
fix(crm): placed credits, lead combobox & stage cards redesign

### DIFF
--- a/apps/crm/apps/web/src/components/ui/combobox.tsx
+++ b/apps/crm/apps/web/src/components/ui/combobox.tsx
@@ -138,7 +138,6 @@ export function Combobox({
 											onSelect={() => {
 												onChange?.(option.value === value ? "" : option.value);
 												setSearchValue("");
-												onSearchChange?.("");
 												setOpen(false);
 											}}
 										>

--- a/apps/crm/apps/web/src/components/ui/combobox.tsx
+++ b/apps/crm/apps/web/src/components/ui/combobox.tsx
@@ -135,16 +135,10 @@ export function Combobox({
 										<CommandItem
 											key={option.value}
 											value={option.label}
-											onSelect={(selectedLabel) => {
-												const selectedOption = options.find(
-													(opt) =>
-													opt.label.toLowerCase() ===
-													selectedLabel.toLowerCase(),
-												);
-												const actualValue = selectedOption
-													? selectedOption.value
-													: "";
-												onChange?.(actualValue === value ? "" : actualValue);
+											onSelect={() => {
+												onChange?.(option.value === value ? "" : option.value);
+												setSearchValue("");
+												onSearchChange?.("");
 												setOpen(false);
 											}}
 										>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -1299,52 +1299,37 @@ function RouteComponent() {
 
 			{/* Oportunidades por Etapa */}
 			{salesStagesQuery.data && salesStagesQuery.data.length > 0 && (
-				<Card>
-					<CardHeader className="pb-3">
-						<CardTitle className="flex items-center gap-2 text-base">
-							<TrendingUp className="h-4 w-4" />
-							Oportunidades por Etapa
-						</CardTitle>
-					</CardHeader>
-					<CardContent>
-						<div className="flex flex-wrap gap-3">
-							{salesStagesQuery.data.map((stage) => {
-								const stageCount =
-									opportunitiesQuery.data?.filter(
-										(opp) => opp.stage?.id === stage.id,
-									).length || 0;
-								const stageValue =
-									opportunitiesQuery.data
-										?.filter((opp) => opp.stage?.id === stage.id)
-										.reduce(
-											(sum, opp) =>
-												sum + (Number.parseFloat(opp.value || "0") || 0),
-											0,
-										) || 0;
-								return (
-									<div
-										key={stage.id}
-										className="flex items-center gap-3 rounded-lg border p-3"
-									>
-										<Badge
-											style={{ backgroundColor: stage.color, color: "white" }}
-											className="min-w-[50px] justify-center text-xs"
-										>
-											{stage.closurePercentage}%
-										</Badge>
-										<div>
-											<p className="font-medium text-sm">{stage.name}</p>
-											<p className="text-muted-foreground text-xs">
-												{stageCount} oportunidades &middot; Q
-												{stageValue.toLocaleString()}
-											</p>
-										</div>
-									</div>
-								);
-							})}
-						</div>
-					</CardContent>
-				</Card>
+				<div className="grid gap-3 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+					{salesStagesQuery.data.map((stage) => {
+						const stageOpps = opportunitiesQuery.data?.filter(
+							(opp) => opp.stage?.id === stage.id,
+						) || [];
+						const stageValue = stageOpps.reduce(
+							(sum, opp) =>
+								sum + (Number.parseFloat(opp.value || "0") || 0),
+							0,
+						);
+						return (
+							<Card key={stage.id} className="relative overflow-hidden">
+								<div
+									className="absolute inset-x-0 top-0 h-1"
+									style={{ backgroundColor: stage.color }}
+								/>
+								<CardContent className="pt-4 pb-3">
+									<p className="truncate font-medium text-muted-foreground text-xs">
+										{stage.name}
+									</p>
+									<p className="mt-1 font-bold text-2xl" style={{ fontVariantNumeric: "tabular-nums" }}>
+										{stageOpps.length}
+									</p>
+									<p className="mt-0.5 text-muted-foreground text-sm" style={{ fontVariantNumeric: "tabular-nums" }}>
+										Q{stageValue.toLocaleString()}
+									</p>
+								</CardContent>
+							</Card>
+						);
+					})}
+				</div>
 			)}
 
 			{/* Actions Bar */}


### PR DESCRIPTION
## Summary
- Adds placed credits cards (count + amount) to dashboard and opportunities views, replacing weighted values
- Fixes lead Combobox selection: case-insensitive matching, current lead always visible in edit form, search state reset on dialog open/close
- Adds 3-month bank statement upload checkbox to DocumentsManager (was only in modal)
- Fixes duplicate search bar in table view mode
- Redesigns stage cards with uniform responsive grid and prominent data display
- Addresses PR #206 review: extracts magic number to constant, uses Promise.allSettled for uploads, fixes double parseFloat fallback

## Changes
- **Backend**: Added PLACED_STAGE_THRESHOLD constant, getPlacedCreditsStats helper, Promise.allSettled for bank statement uploads
- **Frontend**: New placed credits cards, stage cards grid redesign, Combobox fix (closure-based onSelect), lead search state management, hideSearch prop on DataTable
- **UI**: Removed weighted values from kanban/detail, replaced conversion analysis with stage overview cards

## Test plan
- [ ] Verify placed credits cards show correct count and amount on dashboard (admin/supervisor/sales)
- [ ] Verify placed credits cards on opportunities page
- [ ] Edit an opportunity and confirm the current lead shows in the combobox
- [ ] Search and select a different lead, confirm it persists after selection
- [ ] Close and reopen dialog, confirm search resets and lead still shows
- [ ] Upload a bank statement with the 3-month checkbox from the inline documents section
- [ ] Switch to table view and confirm no duplicate search bar
- [ ] Verify stage cards display correctly across screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)