### PR TITLE
feat: enhance vehicle inspection UI, evidence capture and null data h…

### DIFF
--- a/apps/crm/apps/server/src/db/schema/vehicles.ts
+++ b/apps/crm/apps/server/src/db/schema/vehicles.ts
@@ -177,7 +177,7 @@ export const vehicleInspections = pgTable("vehicle_inspections", {
 	// Detailed Conditions (Resumen final de la inspección)
 	tiresCondition: integer("tires_condition"), // Vida útil neumáticos %
 	paintCondition: integer("paint_condition"), // Estado pintura %
-	hasAgencyHistory: boolean("has_agency_history").default(false), // Historial agencia
+	hasAgencyHistory: boolean("has_agency_history"), // Historial agencia
 
 	// Equipment and considerations
 	vehicleEquipment: text("vehicle_equipment").notNull(),

--- a/apps/taller/src/components/ImagePreviewDialog.tsx
+++ b/apps/taller/src/components/ImagePreviewDialog.tsx
@@ -1,0 +1,41 @@
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+
+interface ImagePreviewDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    imageUrl: string | null;
+    title?: string;
+}
+
+export function ImagePreviewDialog({
+    open,
+    onOpenChange,
+    imageUrl,
+    title = "Vista previa de imagen",
+}: ImagePreviewDialogProps) {
+    if (!imageUrl) return null;
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-4xl p-0 overflow-hidden bg-black/5 border-none shadow-none sm:rounded-lg">
+                <div className="relative w-full h-full flex flex-col bg-background rounded-lg shadow-lg overflow-hidden">
+                    <DialogHeader className="p-4 border-b shrink-0 flex flex-row items-center justify-between bg-white z-10">
+                        <DialogTitle>{title}</DialogTitle>
+                    </DialogHeader>
+                    <div className="flex-1 overflow-auto p-4 flex items-center justify-center bg-muted/20 min-h-[50vh] max-h-[80vh]">
+                        <img
+                            src={imageUrl}
+                            alt={title}
+                            className="max-w-full max-h-full object-contain rounded-md shadow-sm"
+                        />
+                    </div>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/taller/src/components/ImagePreviewDialog.tsx
+++ b/apps/taller/src/components/ImagePreviewDialog.tsx
@@ -4,35 +4,90 @@ import {
     DialogHeader,
     DialogTitle,
 } from "@/components/ui/dialog";
+import { X, Loader2, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useState, useEffect } from "react";
+import { cn } from "@/lib/utils";
 
 interface ImagePreviewDialogProps {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
+    isOpen: boolean;
+    onClose: () => void;
     imageUrl: string | null;
     title?: string;
 }
 
-export function ImagePreviewDialog({
-    open,
-    onOpenChange,
+export default function ImagePreviewDialog({
+    isOpen,
+    onClose,
     imageUrl,
-    title = "Vista previa de imagen",
+    title = "Evidencia de Rechazo",
 }: ImagePreviewDialogProps) {
+    const [isLoading, setIsLoading] = useState(true);
+    const [hasError, setHasError] = useState(false);
+
+    // Reset states when dialog opens or URL changes
+    useEffect(() => {
+        if (isOpen) {
+            setIsLoading(true);
+            setHasError(false);
+        }
+    }, [isOpen, imageUrl]);
+
     if (!imageUrl) return null;
 
     return (
-        <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="max-w-4xl p-0 overflow-hidden bg-black/5 border-none shadow-none sm:rounded-lg">
-                <div className="relative w-full h-full flex flex-col bg-background rounded-lg shadow-lg overflow-hidden">
-                    <DialogHeader className="p-4 border-b shrink-0 flex flex-row items-center justify-between bg-white z-10">
-                        <DialogTitle>{title}</DialogTitle>
-                    </DialogHeader>
-                    <div className="flex-1 overflow-auto p-4 flex items-center justify-center bg-muted/20 min-h-[50vh] max-h-[80vh]">
+        <Dialog open={isOpen} onOpenChange={onClose}>
+            <DialogContent className="max-w-4xl w-full h-[80vh] flex flex-col p-0 gap-0 bg-transparent border-none shadow-none z-50">
+                <DialogHeader className="absolute top-2 right-2 z-10 flex-row justify-end p-0 space-y-0">
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={onClose}
+                        className="rounded-full bg-black/50 hover:bg-black/70 text-white w-10 h-10 border border-white/20 transition-transform hover:scale-105"
+                    >
+                        <X className="h-6 w-6" />
+                    </Button>
+                </DialogHeader>
+
+                {/* Contenedor de Imagen con Loader */}
+                <div className="flex-1 flex items-center justify-center w-full h-full bg-black/90 rounded-lg overflow-hidden relative">
+
+                    {/* Loader */}
+                    {isLoading && !hasError && (
+                        <div className="absolute inset-0 flex flex-col items-center justify-center text-white/70 gap-3">
+                            <Loader2 className="h-10 w-10 animate-spin text-white" />
+                            <p className="text-sm font-medium">Cargando evidencia...</p>
+                        </div>
+                    )}
+
+                    {/* Error State */}
+                    {hasError && (
+                        <div className="flex flex-col items-center justify-center text-red-400 gap-3">
+                            <AlertCircle className="h-12 w-12" />
+                            <p className="font-medium">No se pudo cargar la imagen</p>
+                        </div>
+                    )}
+
+                    {/* Imagen */}
+                    {!hasError && (
                         <img
                             src={imageUrl}
                             alt={title}
-                            className="max-w-full max-h-full object-contain rounded-md shadow-sm"
+                            className={cn(
+                                "max-w-full max-h-full object-contain transition-opacity duration-300",
+                                isLoading ? "opacity-0" : "opacity-100"
+                            )}
+                            onLoad={() => setIsLoading(false)}
+                            onError={() => {
+                                setHasError(true);
+                                setIsLoading(false);
+                            }}
                         />
+                    )}
+
+                    {/* Título en la parte inferior */}
+                    <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white">
+                        <h3 className="text-lg font-semibold text-center">{title}</h3>
                     </div>
                 </div>
             </DialogContent>

--- a/apps/taller/src/components/ImagePreviewDialog.tsx
+++ b/apps/taller/src/components/ImagePreviewDialog.tsx
@@ -27,13 +27,11 @@ export default function ImagePreviewDialog({
 
     // Reset states when dialog opens or URL changes
     useEffect(() => {
-        if (isOpen) {
+        if (isOpen && imageUrl) {
             setIsLoading(true);
             setHasError(false);
         }
     }, [isOpen, imageUrl]);
-
-    if (!imageUrl) return null;
 
     return (
         <Dialog open={isOpen} onOpenChange={onClose}>
@@ -43,6 +41,7 @@ export default function ImagePreviewDialog({
                         variant="ghost"
                         size="icon"
                         onClick={onClose}
+                        aria-label="Cerrar vista previa"
                         className="rounded-full bg-black/50 hover:bg-black/70 text-white w-10 h-10 border border-white/20 transition-transform hover:scale-105"
                     >
                         <X className="h-6 w-6" />
@@ -51,44 +50,57 @@ export default function ImagePreviewDialog({
 
                 {/* Contenedor de Imagen con Loader */}
                 <div className="flex-1 flex items-center justify-center w-full h-full bg-black/90 rounded-lg overflow-hidden relative">
-
-                    {/* Loader */}
-                    {isLoading && !hasError && (
-                        <div className="absolute inset-0 flex flex-col items-center justify-center text-white/70 gap-3">
-                            <Loader2 className="h-10 w-10 animate-spin text-white" />
-                            <p className="text-sm font-medium">Cargando evidencia...</p>
-                        </div>
-                    )}
-
-                    {/* Error State */}
-                    {hasError && (
-                        <div className="flex flex-col items-center justify-center text-red-400 gap-3">
-                            <AlertCircle className="h-12 w-12" />
-                            <p className="font-medium">No se pudo cargar la imagen</p>
-                        </div>
-                    )}
-
-                    {/* Imagen */}
-                    {!hasError && (
-                        <img
-                            src={imageUrl}
-                            alt={title}
-                            className={cn(
-                                "max-w-full max-h-full object-contain transition-opacity duration-300",
-                                isLoading ? "opacity-0" : "opacity-100"
+                    {imageUrl ? (
+                        <>
+                            {/* Loader */}
+                            {isLoading && !hasError && (
+                                <div
+                                    className="absolute inset-0 flex flex-col items-center justify-center text-white/70 gap-3"
+                                    aria-live="polite"
+                                    aria-label="Cargando imagen"
+                                >
+                                    <Loader2 className="h-10 w-10 animate-spin text-white" />
+                                    <p className="text-sm font-medium">Cargando evidencia...</p>
+                                </div>
                             )}
-                            onLoad={() => setIsLoading(false)}
-                            onError={() => {
-                                setHasError(true);
-                                setIsLoading(false);
-                            }}
-                        />
-                    )}
 
-                    {/* Título en la parte inferior */}
-                    <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white">
-                        <h3 className="text-lg font-semibold text-center">{title}</h3>
-                    </div>
+                            {/* Error State */}
+                            {hasError && (
+                                <div className="flex flex-col items-center justify-center text-red-400 gap-3">
+                                    <AlertCircle className="h-12 w-12" />
+                                    <p className="font-medium">No se pudo cargar la imagen</p>
+                                </div>
+                            )}
+
+                            {/* Imagen */}
+                            {!hasError && (
+                                <img
+                                    key={imageUrl}
+                                    src={imageUrl}
+                                    alt={title}
+                                    className={cn(
+                                        "max-w-full max-h-full object-contain transition-opacity duration-300",
+                                        isLoading ? "opacity-0" : "opacity-100"
+                                    )}
+                                    onLoad={() => setIsLoading(false)}
+                                    onError={() => {
+                                        setHasError(true);
+                                        setIsLoading(false);
+                                    }}
+                                />
+                            )}
+
+                            {/* Título en la parte inferior */}
+                            <div className="absolute bottom-0 left-0 right-0 p-4 bg-gradient-to-t from-black/80 to-transparent text-white">
+                                <h3 className="text-lg font-semibold text-center">{title}</h3>
+                            </div>
+                        </>
+                    ) : (
+                        <div className="flex flex-col items-center justify-center text-white/50 gap-3">
+                            <AlertCircle className="h-12 w-12" />
+                            <p className="font-medium">No hay imagen disponible</p>
+                        </div>
+                    )}
                 </div>
             </DialogContent>
         </Dialog>

--- a/apps/taller/src/components/inspection-360-step.tsx
+++ b/apps/taller/src/components/inspection-360-step.tsx
@@ -205,7 +205,7 @@ export default function Inspection360Step({ onComplete }: Inspection360StepProps
 
                                 <div className="flex items-center gap-3">
                                     {areaFails > 0 && (
-                                        <Badge variant="destructive" className="gap-1 flex items-center">
+                                        <Badge variant="secondary" className="gap-1 flex items-center bg-slate-100 text-slate-600 hover:bg-slate-200 border-slate-200">
                                             <AlertCircle className="h-3 w-3" /> {areaFails}
                                         </Badge>
                                     )}
@@ -227,8 +227,7 @@ export default function Inspection360Step({ onComplete }: Inspection360StepProps
                                         return (
                                             <div key={point.id} className={cn(
                                                 "p-3 rounded-md border transition-all duration-200",
-                                                isFail ? "bg-red-50 border-red-200" :
-                                                    isOk ? "bg-green-50 border-green-200" : "bg-slate-50/50 border-slate-100"
+                                                "bg-white border-slate-200 hover:border-slate-300"
                                             )}>
                                                 <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-3">
                                                     <div className="flex-1">
@@ -239,39 +238,43 @@ export default function Inspection360Step({ onComplete }: Inspection360StepProps
 
                                                     <div className="flex items-center gap-2 shrink-0">
                                                         <Button
-                                                            variant={isOk ? "default" : "outline"}
+                                                            variant="outline"
                                                             size="sm"
                                                             onClick={() => handleStatusChange(area.id, point.label, 'ok')}
                                                             className={cn(
-                                                                "h-8 px-3 gap-1.5 min-w-[80px]",
-                                                                isOk ? "bg-green-600 hover:bg-green-700 text-white" : "text-green-700 border-green-200 hover:bg-green-50"
+                                                                "h-8 px-3 gap-1.5 min-w-[80px] transition-all",
+                                                                isOk
+                                                                    ? "bg-slate-200 text-slate-900 border-slate-400 font-medium hover:bg-slate-300"
+                                                                    : "text-slate-700 border-slate-400 hover:bg-slate-100 hover:text-slate-900"
                                                             )}
                                                         >
-                                                            <CheckCircle2 className="h-3.5 w-3.5" />
+                                                            <CheckCircle2 className={cn("h-3.5 w-3.5", isOk ? "text-green-600" : "text-slate-500")} />
                                                             OK
                                                         </Button>
                                                         <Button
-                                                            variant={isFail ? "destructive" : "outline"}
+                                                            variant="outline"
                                                             size="sm"
                                                             onClick={() => handleStatusChange(area.id, point.label, 'bad')}
                                                             className={cn(
-                                                                "h-8 px-3 gap-1.5 min-w-[80px]",
-                                                                isFail ? "" : "text-red-700 border-red-200 hover:bg-red-50"
+                                                                "h-8 px-3 gap-1.5 min-w-[80px] transition-all",
+                                                                isFail
+                                                                    ? "bg-slate-200 text-slate-900 border-slate-400 font-medium hover:bg-slate-300"
+                                                                    : "text-slate-700 border-slate-400 hover:bg-slate-100 hover:text-slate-900"
                                                             )}
                                                         >
-                                                            <XCircle className="h-3.5 w-3.5" />
+                                                            <XCircle className={cn("h-3.5 w-3.5", isFail ? "text-red-600" : "text-slate-500")} />
                                                             Fallo
                                                         </Button>
                                                     </div>
                                                 </div>
 
                                                 {isFail && (
-                                                    <div className="mt-3 pl-0 sm:pl-3 border-l-0 sm:border-l-2 border-red-200 animate-in slide-in-from-top-1 fade-in duration-200">
+                                                    <div className="mt-3 pl-0 sm:pl-3 border-l-0 sm:border-l-2 border-slate-200 animate-in slide-in-from-top-1 fade-in duration-200">
                                                         <Textarea
-                                                            placeholder="Describa el problema encontrado (ej. Fuga visible, pieza rota)..."
+                                                            placeholder="Describa el problema encontrado..."
                                                             value={state?.notes || ''}
                                                             onChange={(e) => handleObservationChange(area.id, point.label, e.target.value)}
-                                                            className="min-h-[60px] bg-white border-red-200 focus-visible:ring-red-500 text-sm resize-none"
+                                                            className="min-h-[60px] bg-slate-50 border-slate-200 focus-visible:ring-slate-400 text-sm resize-none"
                                                         />
                                                     </div>
                                                 )}
@@ -285,15 +288,15 @@ export default function Inspection360Step({ onComplete }: Inspection360StepProps
                 })}
             </div>
 
-            <div className="flex justify-end pt-6">
+            <div className="flex justify-center pt-8">
                 <Button
                     size="lg"
                     onClick={onComplete}
                     disabled={!isComplete}
-                    className="w-full sm:w-auto gap-2"
+                    className="w-full sm:w-auto gap-2 px-8 min-w-[200px]"
                 >
-                    Continuar a Checklist
-                    <ChevronDown className="h-4 w-4 rotate-270" style={{ transform: 'rotate(-90deg)' }} />
+                    <CheckCircle2 className="h-5 w-5" />
+                    Confirmar y Continuar
                 </Button>
             </div>
         </div>

--- a/apps/taller/src/components/inspection-checklist.tsx
+++ b/apps/taller/src/components/inspection-checklist.tsx
@@ -14,6 +14,7 @@ import {
   Sparkles,
   FileText,
   Camera,
+  Upload,
 } from "lucide-react";
 import { useInspection, type SectionTimes } from "../contexts/InspectionContext";
 import { cn } from "@/lib/utils";
@@ -405,6 +406,7 @@ export default function InspectionChecklist({
   // Local state for evidence upload
   const [isUploadingEvidence, setIsUploadingEvidence] = useState(false);
   const evidenceInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
 
   const [checkedItems, setCheckedItems] = useState<Record<string, boolean>>({});
   const [expandedCategories, setExpandedCategories] = useState<
@@ -930,26 +932,46 @@ export default function InspectionChecklist({
                           <input
                             type="file"
                             accept="image/*"
+                            capture="environment"
+                            className="hidden"
+                            ref={cameraInputRef}
+                            onChange={handleEvidenceUpload}
+                          />
+                          <input
+                            type="file"
+                            accept="image/*"
                             className="hidden"
                             ref={evidenceInputRef}
                             onChange={handleEvidenceUpload}
                           />
-                          <Button
-                            type="button"
-                            variant="outline"
-                            className="border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800 w-full max-w-xs"
-                            onClick={() => evidenceInputRef.current?.click()}
-                            disabled={isUploadingEvidence}
-                          >
-                            {isUploadingEvidence ? (
-                              <>Subiendo...</>
-                            ) : (
-                              <>
-                                <Camera className="mr-2 h-4 w-4" />
-                                Adjuntar Foto de Evidencia
-                              </>
-                            )}
-                          </Button>
+                          <div className="grid grid-cols-2 gap-3 w-full max-w-sm">
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="h-20 flex flex-col gap-2 border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
+                              onClick={() => cameraInputRef.current?.click()}
+                              disabled={isUploadingEvidence}
+                            >
+                              <Camera className="h-6 w-6" />
+                              <span>Tomar Foto</span>
+                            </Button>
+
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="h-20 flex flex-col gap-2 border-red-200 text-red-700 hover:bg-red-50 hover:text-red-800"
+                              onClick={() => evidenceInputRef.current?.click()}
+                              disabled={isUploadingEvidence}
+                            >
+                              <Upload className="h-6 w-6" />
+                              <span>Galería</span>
+                            </Button>
+                          </div>
+                          {isUploadingEvidence && (
+                            <p className="text-xs text-red-600 animate-pulse mt-1">
+                              Subiendo evidencia...
+                            </p>
+                          )}
                         </>
                       )}
                     </div>

--- a/apps/taller/src/components/inspection-checklist.tsx
+++ b/apps/taller/src/components/inspection-checklist.tsx
@@ -34,6 +34,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { toast } from "sonner";
 
 // ==========================================
 // CRITERIOS DE RECHAZO (Causales de rechazo)
@@ -500,6 +501,24 @@ export default function InspectionChecklist({
     const file = event.target.files?.[0];
     if (!file) return;
 
+    // Validación de seguridad
+    const maxSize = 10 * 1024 * 1024; // 10MB
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
+
+    if (file.size > maxSize) {
+      toast.error("Archivo demasiado grande. El máximo permitido es 10MB.");
+      if (evidenceInputRef.current) evidenceInputRef.current.value = '';
+      if (cameraInputRef.current) cameraInputRef.current.value = '';
+      return;
+    }
+
+    if (!allowedTypes.includes(file.type)) {
+      toast.error("Tipo de archivo no válido. Use JPG, PNG o WebP.");
+      if (evidenceInputRef.current) evidenceInputRef.current.value = '';
+      if (cameraInputRef.current) cameraInputRef.current.value = '';
+      return;
+    }
+
     setIsUploadingEvidence(true);
     const formData = new FormData();
     formData.append("file", file);
@@ -532,7 +551,15 @@ export default function InspectionChecklist({
       }
     } catch (error) {
       console.error("Error uploading evidence:", error);
-      toast.error("Error al subir la evidencia");
+      const errorMsg = error instanceof Error ? error.message : 'Error desconocido';
+
+      if (errorMsg.includes('size')) {
+        toast.error("El archivo excede el límite permitido por el servidor.");
+      } else if (errorMsg.includes('network') || errorMsg.includes('fetch')) {
+        toast.error("Error de conexión. Verifique su internet e intente de nuevo.");
+      } else {
+        toast.error("Error al subir la evidencia. Intente nuevamente.");
+      }
     } finally {
       setIsUploadingEvidence(false);
     }

--- a/apps/taller/src/components/vehicle-valuation.tsx
+++ b/apps/taller/src/components/vehicle-valuation.tsx
@@ -246,9 +246,8 @@ export default function VehicleValuation({
                       <SelectValue placeholder="¿Tiene récord?" />
                     </SelectTrigger>
                     <SelectContent>
-                      <SelectItem value="Sí">Sí, completo</SelectItem>
-                      <SelectItem value="Parcial">Sí, parcial</SelectItem>
-                      <SelectItem value="No">No tiene</SelectItem>
+                      <SelectItem value="Sí">Sí</SelectItem>
+                      <SelectItem value="No">No</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/apps/taller/src/pages/vehicle-inspection-wizard.tsx
+++ b/apps/taller/src/pages/vehicle-inspection-wizard.tsx
@@ -58,6 +58,7 @@ const STEPS = [
 export default function VehicleInspectionWizard() {
   const { formData, checklistItems, photos, sectionTimes, resetInspection, currentStep, setCurrentStep, items360, rejectionEvidenceUrl } = useInspection();
   const [basicInfoCompleted, setBasicInfoCompleted] = useState(false);
+  const [inspection360Completed, setInspection360Completed] = useState(false);
   const vehicleFormRef = useRef<VehicleInspectionFormRef>(null);
   const [checklistCompleted, setChecklistCompleted] = useState(false);
   const [photosCompleted, setPhotosCompleted] = useState(false);
@@ -82,7 +83,11 @@ export default function VehicleInspectionWizard() {
       }
     }
 
-    // Paso 1: 360 (La validación estricta la hace el botón interno del componente)
+    // Paso 1: 360 (Validación explícita)
+    if (currentStep === 1 && !inspection360Completed) {
+      toast.error("Por favor confirme la inspección 360 antes de continuar");
+      return;
+    }
 
     if (currentStep === 2 && !checklistCompleted) {
       toast.error("Por favor complete la evaluación de criterios antes de continuar");
@@ -186,7 +191,7 @@ export default function VehicleInspectionWizard() {
                 // Lógica de completado actualizada para 5 pasos
                 const isCompleted =
                   (index === 0 && basicInfoCompleted) ||
-                  (index === 1 && (items360.length > 0)) ||
+                  (index === 1 && inspection360Completed) ||
                   (index === 2 && checklistCompleted) ||
                   (index === 3 && photosCompleted) ||
                   (index === 4 && valuationCompleted);
@@ -281,6 +286,7 @@ export default function VehicleInspectionWizard() {
               <div className="animate-in fade-in slide-in-from-right-4 duration-300">
                 <Inspection360Step
                   onComplete={() => {
+                    setInspection360Completed(true);
                     setCurrentStep(2);
                     window.scrollTo({ top: 0, behavior: "smooth" });
                   }}

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -21,16 +21,20 @@ import {
   Fuel,
   Palette,
   Hash,
+  ExternalLink,
 } from "lucide-react";
 import { getVehicleStatistics, getVehicleById } from "../services/vehicles";
 import { vehiclesApi, client } from "../utils/orpc";
 import { toast } from "sonner";
-import type { Vehicle, VehicleInspection, VehiclePhoto, InspectionChecklistItem } from "../../../crm/apps/server/src/db/schema/vehicles";
+import { INSPECTION_AREAS } from "../lib/inspection-data";
+import { ImagePreviewDialog } from "@/components/ImagePreviewDialog";
+import type { Vehicle, VehicleInspection, VehiclePhoto, InspectionChecklistItem, VehicleInspection360Item } from "../../../crm/apps/server/src/db/schema/vehicles";
 
 // Type for what the getAll endpoint returns
 type VehicleWithRelations = Vehicle & {
   inspections: (VehicleInspection & {
     checklistItems: InspectionChecklistItem[];
+    inspection360Items?: VehicleInspection360Item[];
   })[];
   photos: VehiclePhoto[];
 };
@@ -61,6 +65,13 @@ interface DashboardVehicle {
   photos: number;
   hasScanner: boolean;
   alerts: string[];
+  trim: string;
+  traction: string;
+  tiresCondition: number | null;
+  paintCondition: number | null;
+  hasAgencyHistory: boolean | null;
+  failedChecks: { area: string; checkpoint: string; comment?: string | null }[];
+  rejectionEvidenceUrl?: string | null;
 }
 
 import { Button } from "@/components/ui/button";
@@ -112,6 +123,8 @@ const sampleVehicles = [
     vehicleYear: "2020",
     licensePlate: "P-789ABC",
     vinNumber: "1HGCM82633A123456",
+    trim: "LE",
+    traction: "FWD",
     kmMileage: "45000",
     origin: "Agencia",
     vehicleType: "Sedan",
@@ -139,6 +152,8 @@ const sampleVehicles = [
     vehicleYear: "2018",
     licensePlate: "P-456DEF",
     vinNumber: "2HKRW7H8XJH123456",
+    trim: "Touring",
+    traction: "FWD",
     kmMileage: "72000",
     origin: "Rodado",
     vehicleType: "SUV",
@@ -166,6 +181,8 @@ const sampleVehicles = [
     vehicleYear: "2017",
     licensePlate: "P-123GHI",
     vinNumber: "3N1AB7AP7HY123456",
+    trim: "Advance",
+    traction: "FWD",
     kmMileage: "95000",
     origin: "Rodado",
     vehicleType: "Sedan",
@@ -193,6 +210,8 @@ const sampleVehicles = [
     vehicleYear: "2019",
     licensePlate: "P-789JKL",
     vinNumber: "1FMCU0F73KUA12345",
+    trim: "Titanium",
+    traction: "AWD",
     kmMileage: "55000",
     origin: "Agencia",
     vehicleType: "SUV",
@@ -220,6 +239,8 @@ const sampleVehicles = [
     vehicleYear: "2020",
     licensePlate: "P-456MNO",
     vinNumber: "JM3KFBDL9L0123456",
+    trim: "Grand Touring",
+    traction: "AWD",
     kmMileage: "32000",
     origin: "Agencia",
     vehicleType: "SUV",
@@ -294,6 +315,7 @@ export default function VehiclesDashboard() {
   const [totalVehicles, setTotalVehicles] = useState(0);
   const [isModalLoading, setIsModalLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   // Edit form state
   const [editForm, setEditForm] = useState({
@@ -354,6 +376,21 @@ export default function VehiclesDashboard() {
       photos: vehicle.photos?.length || 0,
       hasScanner: latestInspection?.scannerUsed || false,
       alerts: (latestInspection?.alerts as string[]) || [],
+      trim: vehicle.trim || '',
+      traction: vehicle.traction || '',
+      tiresCondition: latestInspection?.tiresCondition ?? null,
+      paintCondition: latestInspection?.paintCondition ?? null,
+      hasAgencyHistory: latestInspection?.hasAgencyHistory ?? null,
+      failedChecks: latestInspection?.inspection360Items
+        ? latestInspection.inspection360Items
+          .filter(item => item.status === 'bad')
+          .map(item => ({
+            area: item.area,
+            checkpoint: item.checkpoint,
+            comment: item.comment
+          }))
+        : [],
+      rejectionEvidenceUrl: latestInspection?.rejectionEvidenceUrl,
     };
   };
 
@@ -546,6 +583,15 @@ export default function VehiclesDashboard() {
     commercial: statistics?.commercialVehicles || 0,
     nonCommercial: statistics?.nonCommercialVehicles || 0,
     withAlerts: statistics?.vehiclesWithAlerts || 0,
+  };
+
+  const getAreaLabel = (rawArea: string) => {
+    // Try to find by exact title match first (case insensitive)
+    const found = INSPECTION_AREAS.find(a =>
+      a.title.toLowerCase() === rawArea.toLowerCase() ||
+      a.id === rawArea
+    );
+    return found ? found.title : rawArea; // Fallback to raw if not found
   };
 
 
@@ -1240,6 +1286,21 @@ export default function VehiclesDashboard() {
                           {selectedVehicle.alerts.length} {selectedVehicle.alerts.length === 1 ? "alerta" : "alertas"}
                         </Badge>
                       )}
+
+                      {/* Botón de Evidencia (Si existe) */}
+                      {selectedVehicle.rejectionEvidenceUrl && (
+                        <div className="ml-auto">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="text-red-700 border-red-200 hover:bg-red-50 h-7 text-xs"
+                            onClick={() => setPreviewUrl(selectedVehicle.rejectionEvidenceUrl || null)}
+                          >
+                            <ExternalLink className="h-3 w-3 mr-1.5" />
+                            Ver Evidencia
+                          </Button>
+                        </div>
+                      )}
                     </div>
 
                     <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -1259,11 +1320,17 @@ export default function VehiclesDashboard() {
                             <div className="text-muted-foreground">Modelo</div>
                             <div className="font-medium">{selectedVehicle.vehicleModel}</div>
 
+                            <div className="text-muted-foreground">Versión/Trim</div>
+                            <div className="font-medium">{selectedVehicle.trim || "N/A"}</div>
+
                             <div className="text-muted-foreground">Año</div>
                             <div className="font-medium">{selectedVehicle.vehicleYear}</div>
 
                             <div className="text-muted-foreground">Tipo</div>
                             <div className="font-medium">{selectedVehicle.vehicleType}</div>
+
+                            <div className="text-muted-foreground">Tracción</div>
+                            <div className="font-medium">{selectedVehicle.traction || "N/A"}</div>
                           </div>
 
                           <div className="pt-2 border-t space-y-2">
@@ -1343,6 +1410,61 @@ export default function VehiclesDashboard() {
                             <div className="font-medium">{selectedVehicle.photos}</div>
                           </div>
 
+                          <div className="pt-3 border-t grid grid-cols-3 gap-3 text-center">
+                            <div className="flex flex-col gap-1.5">
+                              <div className="flex justify-between items-end px-1">
+                                <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">Llantas</span>
+                                <span className={cn("text-sm font-bold", selectedVehicle.tiresCondition === null && "text-muted-foreground font-normal")}>
+                                  {selectedVehicle.tiresCondition !== null ? `${selectedVehicle.tiresCondition}%` : "N/A"}
+                                </span>
+                              </div>
+                              <div className="w-full bg-secondary/50 h-2 rounded-full overflow-hidden">
+                                <div
+                                  className={cn("h-full rounded-full transition-all duration-500 ease-out",
+                                    selectedVehicle.tiresCondition === null ? "bg-muted" :
+                                      selectedVehicle.tiresCondition >= 70 ? "bg-green-500" :
+                                        selectedVehicle.tiresCondition >= 40 ? "bg-yellow-500" : "bg-red-500"
+                                  )}
+                                  style={{ width: selectedVehicle.tiresCondition !== null ? `${selectedVehicle.tiresCondition}%` : "100%" }}
+                                />
+                              </div>
+                            </div>
+
+                            <div className="flex flex-col gap-1.5">
+                              <div className="flex justify-between items-end px-1">
+                                <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold">Pintura</span>
+                                <span className={cn("text-sm font-bold", selectedVehicle.paintCondition === null && "text-muted-foreground font-normal")}>
+                                  {selectedVehicle.paintCondition !== null ? `${selectedVehicle.paintCondition}%` : "N/A"}
+                                </span>
+                              </div>
+                              <div className="w-full bg-secondary/50 h-2 rounded-full overflow-hidden">
+                                <div
+                                  className={cn("h-full rounded-full transition-all duration-500 ease-out",
+                                    selectedVehicle.paintCondition === null ? "bg-muted" :
+                                      selectedVehicle.paintCondition >= 70 ? "bg-green-500" :
+                                        selectedVehicle.paintCondition >= 40 ? "bg-yellow-500" : "bg-red-500"
+                                  )}
+                                  style={{ width: selectedVehicle.paintCondition !== null ? `${selectedVehicle.paintCondition}%` : "100%" }}
+                                />
+                              </div>
+                            </div>
+
+                            <div className="flex flex-col items-center justify-center gap-1">
+                              <span className="text-[10px] uppercase tracking-wider text-muted-foreground font-semibold mb-0.5">De Agencia</span>
+                              <Badge
+                                variant={selectedVehicle.hasAgencyHistory === true ? "default" : selectedVehicle.hasAgencyHistory === false ? "secondary" : "outline"}
+                                className={cn(
+                                  "text-xs px-2.5 py-0.5",
+                                  selectedVehicle.hasAgencyHistory === true ? "bg-green-600 hover:bg-green-700" :
+                                    selectedVehicle.hasAgencyHistory === false ? "text-muted-foreground bg-muted" :
+                                      "text-yellow-600 border-yellow-200 bg-yellow-50"
+                                )}
+                              >
+                                {selectedVehicle.hasAgencyHistory === true ? "Sí" : selectedVehicle.hasAgencyHistory === false ? "No" : "N/A"}
+                              </Badge>
+                            </div>
+                          </div>
+
                           {selectedVehicle.alerts && selectedVehicle.alerts.length > 0 && (
                             <div className="pt-3 border-t">
                               <p className="text-sm text-muted-foreground mb-2">Alertas detectadas:</p>
@@ -1409,6 +1531,46 @@ export default function VehiclesDashboard() {
                         </CardContent>
                       </Card>
                     </div>
+
+                    {/* Hallazgos Críticos (Check 360) */}
+                    {selectedVehicle.failedChecks && selectedVehicle.failedChecks.length > 0 && (
+                      <Card className="border-red-200 bg-red-50/30">
+                        <CardHeader className="pb-3">
+                          <CardTitle className="text-base flex items-center gap-2 text-red-700">
+                            <AlertTriangle className="h-4 w-4" />
+                            Hallazgos del Check 360
+                            <Badge variant="destructive" className="ml-2 h-5 text-[10px] px-1.5">
+                              {selectedVehicle.failedChecks.length}
+                            </Badge>
+                          </CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                          <div className="max-h-[300px] overflow-y-auto pr-2 space-y-2">
+                            {selectedVehicle.failedChecks.map((check, idx) => (
+                              <div
+                                key={idx}
+                                className="flex gap-3 p-3 rounded-md border border-red-100 bg-white shadow-sm"
+                              >
+                                <div className="mt-0.5">
+                                  <XCircle className="h-4 w-4 text-red-500" />
+                                </div>
+                                <div className="flex-1 space-y-1">
+                                  <div className="font-medium text-sm text-foreground">
+                                    <span className="text-muted-foreground mr-1">{getAreaLabel(check.area)}:</span>
+                                    {check.checkpoint}
+                                  </div>
+                                  {check.comment && (
+                                    <p className="text-sm text-muted-foreground">
+                                      {check.comment}
+                                    </p>
+                                  )}
+                                </div>
+                              </div>
+                            ))}
+                          </div>
+                        </CardContent>
+                      </Card>
+                    )}
 
                     {/* Resultado de Inspección */}
                     <Card>
@@ -1621,6 +1783,13 @@ export default function VehiclesDashboard() {
           )}
         </DialogContent>
       </Dialog>
+
+      <ImagePreviewDialog
+        open={!!previewUrl}
+        onOpenChange={(open) => !open && setPreviewUrl(null)}
+        imageUrl={previewUrl}
+        title="Evidencia de Rechazo / Daño"
+      />
     </div>
   );
 }

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -1249,13 +1249,13 @@ export default function VehiclesDashboard() {
           ) : (
 
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full pt-4">
-              <TabsList>
-                <TabsTrigger value="details">Detalles</TabsTrigger>
-                <TabsTrigger value="photos">Fotos ({selectedVehicle?.photos || 0})</TabsTrigger>
+              <TabsList className="w-full">
+                <TabsTrigger value="details" className="flex-1">Detalles</TabsTrigger>
+                <TabsTrigger value="photos" className="flex-1">Fotos ({selectedVehicle?.photos || 0})</TabsTrigger>
                 {selectedVehicle?.hasScanner && (
-                  <TabsTrigger value="scanner">Scanner</TabsTrigger>
+                  <TabsTrigger value="scanner" className="flex-1">Scanner</TabsTrigger>
                 )}
-                <TabsTrigger value="edit">Editar</TabsTrigger>
+                <TabsTrigger value="edit" className="flex-1">Editar</TabsTrigger>
               </TabsList>
 
               <TabsContent value="details" className="mt-4">
@@ -1288,19 +1288,7 @@ export default function VehiclesDashboard() {
                       )}
 
                       {/* Botón de Evidencia (Si existe) */}
-                      {selectedVehicle.rejectionEvidenceUrl && (
-                        <div className="ml-auto">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="text-red-700 border-red-200 hover:bg-red-50 h-7 text-xs"
-                            onClick={() => setPreviewUrl(selectedVehicle.rejectionEvidenceUrl || null)}
-                          >
-                            <ExternalLink className="h-3 w-3 mr-1.5" />
-                            Ver Evidencia
-                          </Button>
-                        </div>
-                      )}
+
                     </div>
 
                     <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -1366,9 +1354,22 @@ export default function VehiclesDashboard() {
                       {/* Datos de Inspección */}
                       <Card>
                         <CardHeader className="pb-3">
-                          <CardTitle className="text-base flex items-center gap-2">
-                            <ClipboardCheck className="h-4 w-4" />
-                            Datos de Inspección
+                          <CardTitle className="text-base flex justify-between items-center w-full">
+                            <div className="flex items-center gap-2">
+                              <ClipboardCheck className="h-4 w-4" />
+                              Datos de Inspección
+                            </div>
+                            {selectedVehicle.rejectionEvidenceUrl && (
+                              <Button
+                                variant="outline"
+                                size="sm"
+                                className="h-7 text-xs px-2 text-red-600 border-red-300 hover:bg-red-50 hover:text-red-700"
+                                onClick={() => setPreviewUrl(selectedVehicle.rejectionEvidenceUrl || null)}
+                              >
+                                <ExternalLink className="h-3 w-3 mr-1.5" />
+                                Ver evidencia
+                              </Button>
+                            )}
                           </CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3">
@@ -1408,6 +1409,8 @@ export default function VehiclesDashboard() {
 
                             <div className="text-muted-foreground">Fotos</div>
                             <div className="font-medium">{selectedVehicle.photos}</div>
+
+
                           </div>
 
                           <div className="pt-3 border-t grid grid-cols-3 gap-3 text-center">

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -27,7 +27,7 @@ import { getVehicleStatistics, getVehicleById } from "../services/vehicles";
 import { vehiclesApi, client } from "../utils/orpc";
 import { toast } from "sonner";
 import { INSPECTION_AREAS } from "../lib/inspection-data";
-import { ImagePreviewDialog } from "@/components/ImagePreviewDialog";
+import ImagePreviewDialog from "@/components/ImagePreviewDialog";
 import type { Vehicle, VehicleInspection, VehiclePhoto, InspectionChecklistItem, VehicleInspection360Item } from "../../../crm/apps/server/src/db/schema/vehicles";
 
 // Type for what the getAll endpoint returns
@@ -1785,8 +1785,8 @@ export default function VehiclesDashboard() {
       </Dialog>
 
       <ImagePreviewDialog
-        open={!!previewUrl}
-        onOpenChange={(open) => !open && setPreviewUrl(null)}
+        isOpen={!!previewUrl}
+        onClose={() => setPreviewUrl(null)}
         imageUrl={previewUrl}
         title="Evidencia de Rechazo / Daño"
       />

--- a/apps/taller/src/services/vehicles.ts
+++ b/apps/taller/src/services/vehicles.ts
@@ -140,9 +140,9 @@ export const prepareInspectionData = (formData: any, sectionTimes?: Record<strin
     noTestDriveReason: formData.noTestDriveReason,
     sectionTimes: sectionTimes || {},
     rejectionEvidenceUrl: rejectionEvidenceUrl,
-    tiresCondition: formData.tiresCondition ? parseInt(formData.tiresCondition) : 0,
-    paintCondition: formData.paintCondition ? parseInt(formData.paintCondition) : 0,
-    hasAgencyHistory: formData.agencyServices === 'Sí',
+    tiresCondition: formData.tiresCondition ? parseInt(formData.tiresCondition) : undefined,
+    paintCondition: formData.paintCondition ? parseInt(formData.paintCondition) : undefined,
+    hasAgencyHistory: formData.hasAgencyHistory === 'Sí' ? true : (formData.hasAgencyHistory === 'No' ? false : undefined),
   };
 
   return { vehicleData, inspectionData };


### PR DESCRIPTION
### Captura de Evidencia (Wizard)
- **Soporte Dual para Fotos:** Se rediseñó la sección de carga de evidencia de rechazo en [InspectionChecklist](cci:1://file:///d:/Work/CashIn/universe/apps/taller/src/components/inspection-checklist.tsx:399:0-997:1).
  - Botón **"Tomar Foto" **: Activa directamente la cámara del dispositivo (usando `capture="environment"`).
  - Botón **"Galería" **: Permite seleccionar archivos existentes.
- Esto agiliza significativamente el trabajo de los técnicos en dispositivos móviles.
###  Dashboard de Vehículos
- **Visualización de Evidencia:** Nuevo botón **"Ver Evidencia"** en el encabezado del detalle del vehículo, que abre un visor ([ImagePreviewDialog](cci:1://file:///d:/Work/CashIn/universe/apps/taller/src/components/ImagePreviewDialog.tsx:14:0-40:1)) sin salir de la pantalla.
- **Manejo de Datos Nulos (N/A):**
  - **Llantas y Pintura:** Ahora muestran **"N/A"** (gris) si no se capturó información, en lugar de mostrar erróneamente "0%" o barras rojas.
  - **Historial de Agencia:** Nueva lógica tri-estado para el badge:
    -  **Sí** (Verde)
    -  **No** (Gris)
    -  **N/A** (Amarillo/Outline) - *Nuevo estado para "Sin información"*
###  Backend & Lógica
- **Transformación de Datos:** Se corrigió [prepareInspectionData](cci:1://file:///d:/Work/CashIn/universe/apps/taller/src/services/vehicles.ts:104:0-148:2) para preservar los valores `null/undefined` en lugar de forzar valores por defecto (`false` o `0`) que falseaban la realidad del estado del vehículo.
- **Limpieza de Tipos:** Actualización de interfaces TypeScript para soportar explícitamente valores nulos en campos de condición.
- **Simplificación:** El selector de "Historial de Agencia" ahora es más claro (Sí/No) en la etapa de valoración.


### Capturas

<img width="1863" height="887" alt="image" src="https://github.com/user-attachments/assets/095b2b6d-8329-4899-a054-11357cca7a58" />

<img width="1867" height="879" alt="image" src="https://github.com/user-attachments/assets/00d184e0-ecaa-47e1-93eb-a30b60e4e75a" />
