### PR TITLE
Jalvarez

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -32,6 +32,7 @@ import {
 	opportunities,
 	opportunityStageHistory,
 	salesStages,
+	leadSourceEnum,
 } from "../db/schema/crm";
 import {
 	analysisChecklists,
@@ -506,15 +507,7 @@ export const crmRouter = {
 				hasCreditCard: z.boolean().default(false),
 				jobTitle: z.string().optional(),
 				companyId: z.string().uuid().optional(),
-				source: z.enum([
-					"website",
-					"referral",
-					"cold_call",
-					"email",
-					"social_media",
-					"event",
-					"other",
-				]),
+				source: z.enum(leadSourceEnum.enumValues),
 				assignedTo: z.string().optional(), // Better Auth user ID (text, not UUID)
 				notes: z.string().optional(),
 			}),
@@ -579,15 +572,7 @@ export const crmRouter = {
 				jobTitle: z.string().optional(),
 				companyId: z.string().uuid().optional(),
 				source: z
-					.enum([
-						"website",
-						"referral",
-						"cold_call",
-						"email",
-						"social_media",
-						"event",
-						"other",
-					])
+					.enum(leadSourceEnum.enumValues)
 					.optional(),
 				status: z
 					.enum(["new", "contacted", "qualified", "unqualified", "converted"])
@@ -1018,15 +1003,7 @@ export const crmRouter = {
 				vehicleId: z.string().uuid().optional(),
 				creditType: z.enum(["autocompra", "sobre_vehiculo"]),
 				source: z
-					.enum([
-						"website",
-						"referral",
-						"cold_call",
-						"email",
-						"social_media",
-						"event",
-						"other",
-					])
+					.enum(leadSourceEnum.enumValues)
 					.optional(),
 				loanPurpose: z.enum(["personal", "business"]).optional(),
 				value: z.string().optional(), // Will be converted to decimal

--- a/apps/crm/apps/web/src/lib/crm-formatters.ts
+++ b/apps/crm/apps/web/src/lib/crm-formatters.ts
@@ -16,6 +16,14 @@ export const getSourceLabel = (source: string) => {
 			return "Evento";
 		case "other":
 			return "Otro";
+		case "facebook":
+			return "Facebook";
+		case "instagram":
+			return "Instagram";
+		case "google":
+			return "Google";
+		case "tiktok":
+			return "TikTok";
 		default:
 			return source;
 	}

--- a/apps/crm/apps/web/src/lib/crm-formatters.ts
+++ b/apps/crm/apps/web/src/lib/crm-formatters.ts
@@ -22,8 +22,6 @@ export const getSourceLabel = (source: string) => {
 			return "Instagram";
 		case "google":
 			return "Google";
-		case "tiktok":
-			return "TikTok";
 		default:
 			return source;
 	}


### PR DESCRIPTION
## Fix: Sync Lead/Opportunity Source Validation with DB
### Description
This PR addresses type mismatch errors where the API validation schemas for leads and opportunities were using hardcoded enums that were out of sync with the database.
### Changes
- **Server**: Updated `createLead`, `updateLead`, and `createOpportunity` schemas to dynamically use `leadSourceEnum.enumValues` from the database definition instead of hardcoded string arrays.
- **Web**: Removed unused `tiktok` case from CRM formatters to match supported sources.