### PR TITLE
Jalvarez

### DIFF
--- a/apps/cartera-back/src/controllers/createCredit.ts
+++ b/apps/cartera-back/src/controllers/createCredit.ts
@@ -4,7 +4,8 @@ import { db } from "../database";
 import { 
   creditos, 
   creditos_rubros_otros, 
-  creditos_inversionistas, 
+  creditos_inversionistas,
+  creditos_inversionistas_espejo, 
   cuotas_credito, 
   pagos_credito 
 } from "../database/db";
@@ -521,6 +522,7 @@ creditosInversionistasData.forEach(({ monto_cash_in, iva_cash_in }: Inversionist
 
 if (creditosInversionistasData.length > 0) {
   await db.insert(creditos_inversionistas).values(creditosInversionistasData);
+  await db.insert(creditos_inversionistas_espejo).values(creditosInversionistasData);
 }
   return {
     newCredit,

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -9,6 +9,7 @@ import {
   credit_cancelations,
   creditos,
   creditos_inversionistas,
+  creditos_inversionistas_espejo,
   creditos_rubros_otros,
   cuotas_credito,
   inversionistas,
@@ -525,6 +526,18 @@ export interface CreditoConInfo {
   mora?: any; // 👈 Este también faltaba si no lo tenías
   deuda_total_con_mora?: string; // 👈 Este también
   proxima_cuota?: ProximaCuota | null; // 🆕 NUEVO CAMPO
+  creditos_inversionistas_espejo?: {
+    credito_id: number;
+    inversionista_id: number;
+    nombre: string;
+    monto_aportado: string;
+    porcentaje_participacion: string;
+    porcentaje_cash_in: string;
+    porcentaje_inversion: string;
+    monto_cash_in: string;
+    monto_inversionista: string;
+    cuota_inversionista: string;
+  }[];
 }
 
 // 🔥 Función auxiliar para calcular proximidad (con zona horaria de Guatemala)
@@ -772,8 +785,11 @@ export async function getCreditosWithUserByMesAnio(
 
   // 3️⃣ 🔥 INVERSIONISTAS - Optimizado
   let inversionistasMap: Record<number, any> = {};
+  let inversionistasEspejoMap: Record<number, any[]> = {}; // 🆕 Mapa para Espejos
+
   if (creditosIds.length > 0) {
     try {
+      // 3.1 Inversionistas Normales (Ordenados por ID para consistencia)
       const inversionistasPorCredito = await db
         .select({
           credito_id: creditos_inversionistas.credito_id,
@@ -798,39 +814,81 @@ export async function getCreditosWithUserByMesAnio(
             inversionistas.inversionista_id
           )
         )
-        .where(inArray(creditos_inversionistas.credito_id, creditosIds));
+        .where(inArray(creditos_inversionistas.credito_id, creditosIds))
+        .orderBy(asc(creditos_inversionistas.id)); // 👈 Orden garantizado
 
-      console.log(`👥 Inversionistas encontrados: ${inversionistasPorCredito.length}`);
+      // 3.2 Inversionistas Espejo (Ordenados por ID para consistencia)
+      const inversionistasEspejoPorCredito = await db
+        .select({
+          credito_id: creditos_inversionistas_espejo.credito_id,
+          inversionista_id: inversionistas.inversionista_id,
+          nombre: inversionistas.nombre,
+          monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+          porcentaje_participacion: sql<string>`'0'`, // Calculado en frontend
+          porcentaje_cash_in: creditos_inversionistas_espejo.porcentaje_cash_in,
+          porcentaje_inversion:
+            creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+          monto_cash_in: creditos_inversionistas_espejo.monto_cash_in,
+          monto_inversionista:
+            creditos_inversionistas_espejo.monto_inversionista,
+          cuota_inversionista:
+            creditos_inversionistas_espejo.cuota_inversionista,
+        })
+        .from(creditos_inversionistas_espejo)
+        .innerJoin(
+          inversionistas,
+          eq(
+            creditos_inversionistas_espejo.inversionista_id,
+            inversionistas.inversionista_id
+          )
+        )
+        .where(inArray(creditos_inversionistas_espejo.credito_id, creditosIds))
+        .orderBy(asc(creditos_inversionistas_espejo.id)); // 👈 Orden garantizado
 
-      // 🔥 Agrupar por credito_id correctamente
-      inversionistasMap = creditosIds.reduce((acc, creditoId) => {
-        const aportes = inversionistasPorCredito.filter(
-          (inv) => inv.credito_id === creditoId
-        );
-        
-        acc[creditoId] = {
-          aportes,
-          resumen: {
-            total_cash_in_monto: aportes.reduce(
-              (sum, cur) => sum + Number(cur.monto_cash_in ?? 0),
-              0
-            ),
-            total_cash_in_iva: aportes.reduce(
-              (sum, cur) => sum + Number(cur.iva_cash_in ?? 0),
-              0
-            ),
-            total_inversion_monto: aportes.reduce(
-              (sum, cur) => sum + Number(cur.monto_inversionista ?? 0),
-              0
-            ),
-            total_inversion_iva: aportes.reduce(
-              (sum, cur) => sum + Number(cur.iva_inversionista ?? 0),
-              0
-            ),
-          },
-        };
-        return acc;
-      }, {} as Record<number, any>);
+      // 3.3 Mapeo Normales
+      inversionistasMap = creditosIds.reduce(
+        (acc, creditoId) => {
+          const aportes = inversionistasPorCredito.filter(
+            (inv) => inv.credito_id === creditoId
+          );
+
+          acc[creditoId] = {
+            aportes,
+            resumen: {
+              total_cash_in_monto: aportes.reduce(
+                (sum, cur) => sum + Number(cur.monto_cash_in ?? 0),
+                0
+              ),
+              total_cash_in_iva: aportes.reduce(
+                (sum, cur) => sum + Number(cur.iva_cash_in ?? 0),
+                0
+              ),
+              total_inversion_monto: aportes.reduce(
+                (sum, cur) => sum + Number(cur.monto_inversionista ?? 0),
+                0
+              ),
+              total_inversion_iva: aportes.reduce(
+                (sum, cur) => sum + Number(cur.iva_inversionista ?? 0),
+                0
+              ),
+            },
+          };
+          return acc;
+        },
+        {} as Record<number, any>
+      );
+
+      // 3.4 Mapeo Espejos
+      inversionistasEspejoMap = creditosIds.reduce(
+        (acc, creditoId) => {
+          const aportesEspejo = inversionistasEspejoPorCredito.filter(
+            (inv) => inv.credito_id === creditoId
+          );
+          acc[creditoId] = aportesEspejo;
+          return acc;
+        },
+        {} as Record<number, any[]>
+      );
     } catch (err) {
       console.error("❌ Error consultando inversionistas:", err);
     }
@@ -999,6 +1057,7 @@ export async function getCreditosWithUserByMesAnio(
           usuarios: row.usuarios,
           asesores: row.asesores,
           inversionistas: info.aportes,
+          creditos_inversionistas_espejo: inversionistasEspejoMap[creditoId] || [], // 👈 Agregado aquí
           resumen: info.resumen,
           cancelacion,
           rubros,

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -509,13 +509,15 @@ const updateInitialQuotaOtros = async (
  */
 const updateInvestors = async (
   credito_id: number,
-  inversionistas: any[], // Generic array to support both fields
+  inversionistas:
+    | CreditUpdateData["inversionistas"]
+    | CreditUpdateData["inversionistas_espejo"],
   updateFields: any,
   current: any,
   numero_credito_sifco: string,
   seguro: number,
   membresias: number,
-  targetTable: any = creditos_inversionistas
+  targetTable: any = creditos_inversionistas,
 ): Promise<void> => {
   if (!inversionistas || inversionistas.length === 0) return;
 

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -4,6 +4,7 @@ import { db } from "../database";
 import {
   creditos,
   creditos_inversionistas,
+  creditos_inversionistas_espejo,
   cuotas_credito,
   pagos_credito,
   usuarios,
@@ -275,7 +276,19 @@ const creditUpdateSchema = z.object({
         porcentaje_inversion: z.number().min(0).max(100),
       }),
     )
-    .min(0),
+    .min(0)
+    .optional(),
+  inversionistas_espejo: z
+    .array(
+      z.object({
+        inversionista_id: z.number().int().positive(),
+        monto_aportado: z.number().positive(),
+        porcentaje_cash_in: z.number().min(0).max(100),
+        porcentaje_inversion: z.number().min(0).max(100),
+      }),
+    )
+    .min(0)
+    .optional(),
   capital: z.number().nonnegative(),
   porcentaje_interes: z.number().min(0).max(100),
   seguro_10_cuotas: z.number().min(0),
@@ -315,6 +328,7 @@ const validateInvestorsPercentages = (
   inversionistas: CreditUpdateData["inversionistas"],
   set: SetContext,
 ): ValidationResult => {
+  if (!inversionistas) return { success: true };
   for (const inv of inversionistas) {
     const total =
       Number(inv.porcentaje_cash_in) + Number(inv.porcentaje_inversion);
@@ -340,6 +354,7 @@ const validateInvestorsCapital = (
   capital: number,
   set: SetContext,
 ): ValidationResult => {
+  if (!inversionistas) return { success: true };
   const totalMontoAportado = inversionistas.reduce(
     (acc: Big, inv) => acc.plus(inv.monto_aportado ?? 0),
     new Big(0),
@@ -494,19 +509,20 @@ const updateInitialQuotaOtros = async (
  */
 const updateInvestors = async (
   credito_id: number,
-  inversionistas: CreditUpdateData["inversionistas"],
+  inversionistas: any[], // Generic array to support both fields
   updateFields: any,
   current: any,
   numero_credito_sifco: string,
   seguro: number,
   membresias: number,
+  targetTable: any = creditos_inversionistas
 ): Promise<void> => {
-  if (inversionistas.length === 0) return;
+  if (!inversionistas || inversionistas.length === 0) return;
 
   // Eliminar inversionistas existentes
   await db
-    .delete(creditos_inversionistas)
-    .where(eq(creditos_inversionistas.credito_id, credito_id));
+    .delete(targetTable)
+    .where(eq(targetTable.credito_id, credito_id));
   console.log(current.capital, "current values ");
 
   // 🔥 OBTENER CAPITAL Y CUOTA TOTAL DEL CRÉDITO
@@ -705,7 +721,7 @@ const updateInvestors = async (
 
   // Insertar nuevos inversionistas
   if (creditosInversionistasData.length > 0) {
-    await db.insert(creditos_inversionistas).values(creditosInversionistasData);
+    await db.insert(targetTable).values(creditosInversionistasData);
   }
 };
 
@@ -788,13 +804,28 @@ export const updateCredit = async ({ body, set }: any) => {
       return { message: "Credit not found" };
     }
 
+
     // 3. Validar inversionistas
-    const percentagesValidation = validateInvestorsPercentages(
-      inversionistas,
-      set,
-    );
-    if (!percentagesValidation.success) {
-      return percentagesValidation.error;
+    if (inversionistas && inversionistas.length > 0) {
+      const percentagesValidation = validateInvestorsPercentages(
+        inversionistas as any,
+        set,
+      );
+      if (!percentagesValidation.success) {
+        return percentagesValidation.error;
+      }
+    }
+
+    // 3.1. Validar inversionistas espejo si existen
+    const { inversionistas_espejo } = parseResult.data;
+    if (inversionistas_espejo && inversionistas_espejo.length > 0) {
+      const mirrorValidation = validateInvestorsPercentages(
+        inversionistas_espejo as any,
+        set
+      );
+      if (!mirrorValidation.success) {
+        return mirrorValidation.error;
+      }
     }
 
     // 3.5 Actualizar datos del usuario si se enviaron
@@ -914,16 +945,33 @@ export const updateCredit = async ({ body, set }: any) => {
         nueva_cuota: cuota,
       });
 
-    // 9. Actualizar inversionistas
-    await updateInvestors(
-      credito_id,
-      inversionistas,
-      updateFields,
-      current,
-      numero_credito_sifco ?? current.numero_credito_sifco,
-      Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
-      Number(updateFields.membresias_pago ?? current.membresias_pago),
-    );
+    // 9. Actualizar inversionistas (Principal)
+    if (inversionistas && inversionistas.length > 0) {
+      await updateInvestors(
+        credito_id,
+        inversionistas,
+        updateFields,
+        current,
+        numero_credito_sifco ?? current.numero_credito_sifco,
+        Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
+        Number(updateFields.membresias_pago ?? current.membresias_pago),
+        creditos_inversionistas // Explicit target
+      );
+    }
+
+    // 10. Actualizar inversionistas (Espejo)
+    if (inversionistas_espejo && inversionistas_espejo.length > 0) {
+      await updateInvestors(
+        credito_id,
+        inversionistas_espejo,
+        updateFields,
+        current,
+        numero_credito_sifco ?? current.numero_credito_sifco,
+        Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
+        Number(updateFields.membresias_pago ?? current.membresias_pago),
+        creditos_inversionistas_espejo // Mirror target
+      );
+    }
 
     set.status = 200;
     return updatedCredit;

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -6,15 +6,12 @@ import {
   FileSpreadsheet,
   Loader2,
   Search,
-  SearchIcon,
   User,
-  UserIcon,
   X,
-  XIcon,
 } from "lucide-react";
 import { useCreditosPaginadosWithFilters } from "../hooks/credits";
 import { Button } from "@/components/ui/button";
-import { Eye, Pencil, XCircle, MoreVertical, FileCheck } from "lucide-react";
+import { Eye, Pencil, XCircle, FileCheck } from "lucide-react";
 
 import {
   Table,
@@ -165,6 +162,8 @@ export function ListaCreditosPagos() {
     reportCancelationIntern.status === "pending" ||
     reportCostDetail.status === "pending";
 
+
+
   const handleOpenEdit = (credit: any, inversionistas: any, usuario?: any) => {
     console.log(credit);
     setCreditToEdit({
@@ -188,29 +187,31 @@ export function ListaCreditosPagos() {
       saldo_a_favor: usuario?.saldo_a_favor ?? 0,
     });
 
-    setInvestorsToEdit(
-      inversionistas.map((inv: any) => ({
-        inversionista_id: inv.inversionista_id,
-        porcentaje_participacion: inv.porcentaje_participacion,
-        monto_aportado: inv.monto_aportado,
-        porcentaje_cash_in: inv.porcentaje_cash_in,
-        porcentaje_inversion: inv.porcentaje_participacion_inversionista,
-        cuota_inversionista: inv.cuota_inversionista ?? 0,
-      }))
-    );
+    const mappedInvestors = inversionistas.map((inv: any) => ({
+      inversionista_id: inv.inversionista_id,
+      porcentaje_participacion: inv.porcentaje_participacion,
+      monto_aportado: inv.monto_aportado,
+      porcentaje_cash_in: inv.porcentaje_cash_in,
+      porcentaje_inversion: inv.porcentaje_participacion_inversionista,
+      cuota_inversionista: inv.cuota_inversionista ?? 0,
+    }));
+
+    setInvestorsToEdit(mappedInvestors);
 
     // Mapeo seguro de espejo
     const mirrorData = credit.creditos_inversionistas_espejo || [];
-    setInvestorsMirrorToEdit(
-      mirrorData.map((inv: any) => ({
-        inversionista_id: inv.inversionista_id,
-        porcentaje_participacion: inv.porcentaje_participacion,
-        monto_aportado: inv.monto_aportado,
-        porcentaje_cash_in: inv.porcentaje_cash_in,
-        porcentaje_inversion: inv.porcentaje_participacion_inversionista,
-        cuota_inversionista: inv.cuota_inversionista ?? 0,
-      }))
-    );
+    const mappedMirror = mirrorData.map((inv: any) => ({
+      inversionista_id: inv.inversionista_id,
+      porcentaje_participacion: inv.porcentaje_participacion,
+      monto_aportado: inv.monto_aportado,
+      porcentaje_cash_in: inv.porcentaje_cash_in,
+      porcentaje_inversion: inv.porcentaje_inversion,
+      cuota_inversionista: inv.cuota_inversionista ?? 0,
+    }));
+
+    setInvestorsMirrorToEdit(mappedMirror);
+
+
 
     setEditModalOpen(true);
   };
@@ -246,17 +247,47 @@ export function ListaCreditosPagos() {
   console.log("👥 Advisors:", advisors);
   console.log("🎯 Asesor ID actual:", asesorId);
 
+  // 🆕 Handler para activar convenio (por ahora vacío, lo conectarás después)
+  const handleActivarConvenio = (creditId: number) => {
+    console.log("🎯 Activar convenio para crédito:", creditId);
+    // TODO: Aquí llamarás al hook/servicio cuando esté listo
+  };
+
   // Cuando cierras el modal, resetea ambos states (opcional)
   const handleCloseModal = () => {
     setModalOpen(false);
     setSelectedCreditId(null);
   };
 
-  // 🆕 Handler para activar convenio (por ahora vacío, lo conectarás después)
-  const handleActivarConvenio = (creditId: number) => {
-    console.log("🎯 Activar convenio para crédito:", creditId);
-    // TODO: Aquí llamarás al hook/servicio cuando esté listo
-  };
+  // 🔍 DEBUG: Log credits with mirror investors
+  React.useEffect(() => {
+    if (data?.data) {
+      console.log("🔍 Datos recibidos del backend:", data.data);
+      const creditsWithMirror = data.data.filter(
+        (c: any) =>
+          c.creditos_inversionistas_espejo &&
+          c.creditos_inversionistas_espejo.length > 0
+      );
+
+      if (creditsWithMirror.length > 0) {
+        console.group("🔍 Créditos CON datos espejo detectados:");
+        creditsWithMirror.forEach((c: any) => {
+          console.group(
+            `📄 Crédito: ${c.creditos.numero_credito_sifco} (ID: ${c.creditos.credito_id})`
+          );
+          console.log("🟢 Inversionistas Normales:", c.inversionistas);
+          console.table(c.inversionistas);
+          console.log("🟣 Inversionistas Espejo:", c.creditos_inversionistas_espejo);
+          console.table(c.creditos_inversionistas_espejo);
+          console.groupEnd();
+        });
+        console.groupEnd();
+      } else {
+        console.log("ℹ️ No se detectaron créditos con datos espejo en esta página.");
+      }
+    }
+  }, [data]);
+
 
   if (isLoading) {
     return (
@@ -1150,7 +1181,15 @@ function MobileView({
                   variant="outline"
                   className="text-yellow-700 border-yellow-300 hover:bg-yellow-50"
                   onClick={() =>
-                    handleOpenEdit(item.creditos, item.inversionistas, item.usuarios)
+                    handleOpenEdit(
+                      {
+                        ...item.creditos,
+                        creditos_inversionistas_espejo:
+                          item.creditos_inversionistas_espejo,
+                      },
+                      item.inversionistas,
+                      item.usuarios
+                    )
                   }
                 >
                   <Pencil className="w-4 h-4 mr-1" /> Editar
@@ -1359,7 +1398,11 @@ function DesktopView({
                               className="flex items-center gap-1 text-yellow-700 border-yellow-300 hover:bg-yellow-50"
                               onClick={() =>
                                 handleOpenEdit(
-                                  item.creditos,
+                                  {
+                                    ...item.creditos,
+                                    creditos_inversionistas_espejo:
+                                      item.creditos_inversionistas_espejo,
+                                  },
                                   item.inversionistas,
                                   item.usuarios
                                 )

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -88,6 +88,7 @@ export function ListaCreditosPagos() {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [creditToEdit, setCreditToEdit] = useState<any | null>(null);
   const [investorsToEdit, setInvestorsToEdit] = useState<any[]>([]);
+  const [investorsMirrorToEdit, setInvestorsMirrorToEdit] = useState<any[]>([]);
   const queryClient = useQueryClient();
   const isMobile = useIsMobile();
 
@@ -189,6 +190,19 @@ export function ListaCreditosPagos() {
 
     setInvestorsToEdit(
       inversionistas.map((inv: any) => ({
+        inversionista_id: inv.inversionista_id,
+        porcentaje_participacion: inv.porcentaje_participacion,
+        monto_aportado: inv.monto_aportado,
+        porcentaje_cash_in: inv.porcentaje_cash_in,
+        porcentaje_inversion: inv.porcentaje_participacion_inversionista,
+        cuota_inversionista: inv.cuota_inversionista ?? 0,
+      }))
+    );
+
+    // Mapeo seguro de espejo
+    const mirrorData = credit.creditos_inversionistas_espejo || [];
+    setInvestorsMirrorToEdit(
+      mirrorData.map((inv: any) => ({
         inversionista_id: inv.inversionista_id,
         porcentaje_participacion: inv.porcentaje_participacion,
         monto_aportado: inv.monto_aportado,
@@ -630,6 +644,7 @@ export function ListaCreditosPagos() {
         onClose={() => setEditModalOpen(false)}
         initialValues={creditToEdit}
         investorsInitial={investorsToEdit}
+        investorsMirrorInitial={investorsMirrorToEdit}
         onSuccess={() => {
           setEditModalOpen(false);
           queryClient.invalidateQueries({

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -1,0 +1,288 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Plus, Trash2, BookCopy, ArrowDown, ArrowUp } from "lucide-react";
+import type { InversionistaPayload } from "../services/services";
+import { useState } from "react";
+
+interface InvestorOption {
+  inversionista_id: number;
+  nombre: string;
+}
+
+interface InvestorsListProps {
+  investors: InversionistaPayload[];
+  investorsMirror: InversionistaPayload[]; // 🆕 Lista espejo
+  investorsOptions: InvestorOption[];
+  formik: any;
+  fieldName: string; // "investors"
+  labelTitle: string;
+  errorMessage?: string | string[];
+  errorMessageMirror?: string | string[];
+}
+
+export function InvestorsList({
+  investors,
+  investorsMirror,
+  investorsOptions,
+  formik,
+  fieldName,
+  labelTitle,
+  errorMessage,
+  errorMessageMirror,
+}: InvestorsListProps) {
+  // Estado local para saber qué items tienen el espejo expandido
+  const [expandedMirrors, setExpandedMirrors] = useState<Set<number>>(new Set());
+
+  const toggleMirror = (index: number) => {
+    const newSet = new Set(expandedMirrors);
+    if (newSet.has(index)) {
+      newSet.delete(index);
+    } else {
+      newSet.add(index);
+    }
+    setExpandedMirrors(newSet);
+  };
+
+  const addInvestor = () => {
+    // Agregamos a ambas listas para mantener sincronía
+    const newInvestor = {
+      inversionista_id: 0,
+      monto_aportado: 0,
+      porcentaje_cash_in: 0,
+      porcentaje_inversion: 0,
+    };
+
+    formik.setFieldValue("investors", [...investors, { ...newInvestor }]);
+    formik.setFieldValue("investorsMirror", [
+      ...investorsMirror,
+      { ...newInvestor },
+    ]);
+  };
+
+  const removeInvestor = (index: number) => {
+    const updated = [...investors];
+    updated.splice(index, 1);
+    formik.setFieldValue("investors", updated);
+
+    const updatedMirror = [...investorsMirror];
+    updatedMirror.splice(index, 1);
+    formik.setFieldValue("investorsMirror", updatedMirror);
+    
+    // Limpiar estado de expansión si se borra
+    if (expandedMirrors.has(index)) {
+        const newSet = new Set(expandedMirrors);
+        newSet.delete(index);
+        setExpandedMirrors(newSet);
+    }
+  };
+
+  // Safe checks
+  const listToRender = investors || [];
+  const listMirror = investorsMirror || [];
+
+  return (
+    <div className="space-y-4 mt-4">
+      <h3 className="text-lg font-bold text-blue-800 mb-2">{labelTitle}</h3>
+      {listToRender.length === 0 && (
+        <div className="text-sm text-gray-500 mb-2">
+          No hay inversionistas agregados.
+        </div>
+      )}
+      {listToRender.map((inv, index) => {
+        const isMirrorExpanded = expandedMirrors.has(index);
+        const invMirror = listMirror[index] || {}; // Fallback safe
+
+        return (
+          <div
+            key={index}
+            className="border rounded-xl p-4 bg-blue-50 flex flex-col gap-3 transition-all duration-300"
+          >
+            {/* 🟦 SECCIÓN PRINCIPAL (FISCAL/OFICIAL) */}
+            <div className="flex flex-wrap gap-4 items-end">
+              <div className="flex-1 min-w-[200px]">
+                <Label className="text-blue-900 font-semibold">Inversionista (Fiscal)</Label>
+                <select
+                  name={`${fieldName}.${index}.inversionista_id`}
+                  value={inv.inversionista_id}
+                  onChange={formik.handleChange}
+                  className="w-full border rounded px-3 py-2 bg-white h-10 mt-1"
+                >
+                  <option value={0}>Seleccione un inversionista</option>
+                  {investorsOptions.map((opt) => (
+                    <option key={opt.inversionista_id} value={opt.inversionista_id}>
+                      {opt.nombre}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="w-32">
+                <Label className="text-blue-900">Monto</Label>
+                <Input
+                  className="mt-1"
+                  type="number"
+                  name={`${fieldName}.${index}.monto_aportado`}
+                  value={inv.monto_aportado}
+                  onChange={formik.handleChange}
+                />
+              </div>
+              <div className="w-24">
+                <Label className="text-blue-900">Cash In %</Label>
+                <Input
+                  className="mt-1"
+                  type="number"
+                  name={`${fieldName}.${index}.porcentaje_cash_in`}
+                  value={inv.porcentaje_cash_in}
+                  onChange={(e) => {
+                    const val = Number(e.target.value);
+                    formik.setFieldValue(
+                      `${fieldName}.${index}.porcentaje_cash_in`,
+                      val
+                    );
+                    formik.setFieldValue(
+                      `${fieldName}.${index}.porcentaje_inversion`,
+                      parseFloat((100 - val).toFixed(10))
+                    );
+                  }}
+                />
+              </div>
+              <div className="w-24">
+                <Label className="text-blue-900">Inv %</Label>
+                <Input
+                  className="mt-1"
+                  type="number"
+                  name={`${fieldName}.${index}.porcentaje_inversion`}
+                  value={inv.porcentaje_inversion}
+                  onChange={(e) => {
+                    const val = Number(e.target.value);
+                    formik.setFieldValue(
+                      `${fieldName}.${index}.porcentaje_inversion`,
+                      val
+                    );
+                    formik.setFieldValue(
+                      `${fieldName}.${index}.porcentaje_cash_in`,
+                      parseFloat((100 - val).toFixed(10))
+                    );
+                  }}
+                />
+              </div>
+
+               {/* Botones de Acción */}
+               <div className="flex gap-2 mb-0.5">
+                <Button
+                    type="button"
+                    variant={isMirrorExpanded ? "secondary" : "ghost"}
+                    size="icon"
+                    className={`h-10 w-10 border ${isMirrorExpanded ? "bg-purple-100 border-purple-300 text-purple-700" : "border-gray-300 text-gray-500 hover:text-purple-600 hover:bg-purple-50"}`}
+                    onClick={() => toggleMirror(index)}
+                    title={isMirrorExpanded ? "Ocultar Espejo" : "Mostrar Espejo"}
+                >
+                    <BookCopy className="w-4 h-4" />
+                </Button>
+                <Button
+                    type="button"
+                    variant="outline"
+                    className="h-10 w-10 border-red-200 text-red-500 hover:bg-red-50 hover:text-red-700 hover:border-red-300 p-0"
+                    onClick={() => removeInvestor(index)}
+                >
+                    <Trash2 className="w-4 h-4" />
+                </Button>
+              </div>
+            </div>
+
+            {/* 🟪 SECCIÓN ESPEJO (EXPANDIBLE) */}
+            {isMirrorExpanded && (
+              <div className="mt-2 pl-4 pr-4 py-4 bg-purple-50/50 rounded-lg border border-purple-200 border-l-4 border-l-purple-400 animate-in fade-in slide-in-from-top-2 duration-200">
+                <div className="flex items-center gap-2 mb-3">
+                    <BookCopy className="w-4 h-4 text-purple-600" />
+                    <h4 className="font-bold text-sm text-purple-800">Datos Espejo (Interno)</h4>
+                </div>
+                
+                <div className="flex flex-wrap gap-4 items-end">
+                    <div className="flex-1 min-w-[200px]">
+                        <Label className="text-purple-900 font-semibold text-xs">Inversionista Espejo</Label>
+                        <select
+                        name={`investorsMirror.${index}.inversionista_id`}
+                        value={invMirror.inversionista_id}
+                        onChange={formik.handleChange}
+                        className="w-full border rounded px-3 py-2 bg-white h-9 mt-1 text-sm border-purple-200 focus:ring-purple-500"
+                        >
+                        <option value={0}>Seleccione (Opcional)</option>
+                        {investorsOptions.map((opt) => (
+                            <option key={opt.inversionista_id} value={opt.inversionista_id}>
+                            {opt.nombre}
+                            </option>
+                        ))}
+                        </select>
+                    </div>
+                    <div className="w-32">
+                        <Label className="text-purple-900 text-xs">Monto Espejo</Label>
+                        <Input
+                        className="mt-1 h-9 text-sm border-purple-200"
+                        type="number"
+                        name={`investorsMirror.${index}.monto_aportado`}
+                        value={invMirror.monto_aportado}
+                        onChange={formik.handleChange}
+                        />
+                    </div>
+                    <div className="w-24">
+                        <Label className="text-purple-900 text-xs">Cash In %</Label>
+                        <Input
+                        className="mt-1 h-9 text-sm border-purple-200"
+                        type="number"
+                        name={`investorsMirror.${index}.porcentaje_cash_in`}
+                        value={invMirror.porcentaje_cash_in}
+                        onChange={(e) => {
+                            const val = Number(e.target.value);
+                            formik.setFieldValue(`investorsMirror.${index}.porcentaje_cash_in`, val);
+                            formik.setFieldValue(`investorsMirror.${index}.porcentaje_inversion`, parseFloat((100 - val).toFixed(10)));
+                        }}
+                        />
+                    </div>
+                    <div className="w-24">
+                        <Label className="text-purple-900 text-xs">Inv %</Label>
+                        <Input
+                        className="mt-1 h-9 text-sm border-purple-200"
+                        type="number"
+                        name={`investorsMirror.${index}.porcentaje_inversion`}
+                        value={invMirror.porcentaje_inversion}
+                        onChange={(e) => {
+                            const val = Number(e.target.value);
+                            formik.setFieldValue(`investorsMirror.${index}.porcentaje_inversion`, val);
+                            formik.setFieldValue(`investorsMirror.${index}.porcentaje_cash_in`, parseFloat((100 - val).toFixed(10)));
+                        }}
+                        />
+                    </div>
+                    <div className="w-10"></div> {/* Spacer para alinear con botones de arriba */}
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <Button
+        type="button"
+        onClick={addInvestor}
+        variant="outline"
+        className="w-full border-blue-500 text-blue-700 hover:bg-blue-50 flex items-center gap-2"
+      >
+        <Plus className="w-4 h-4" />
+        Agregar Inversionista
+      </Button>
+
+      {/* 🔥 MOSTRAR ERRORES */}
+      {errorMessage && typeof errorMessage === "string" && (
+        <div className="text-red-600 text-sm font-medium bg-red-50 border border-red-200 rounded-lg p-3">
+          ⚠️ {errorMessage}
+        </div>
+      )}
+      {errorMessageMirror && typeof errorMessageMirror === "string" && (
+        <div className="text-red-600 text-sm font-medium bg-red-50 border border-red-200 rounded-lg p-3">
+          ⚠️ {errorMessageMirror}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -2,7 +2,7 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Plus, Trash2, BookCopy, ArrowDown, ArrowUp } from "lucide-react";
+import { Plus, Trash2, BookCopy } from "lucide-react";
 import type { InversionistaPayload } from "../services/services";
 import { useState } from "react";
 
@@ -61,20 +61,29 @@ export function InvestorsList({
     ]);
   };
 
-  const removeInvestor = (index: number) => {
+  const removeInvestor = (indexToRemove: number) => {
+    // 1. Actualizar estado de expansión (Shift Logic)
+    const newExpandedSet = new Set<number>();
+    expandedMirrors.forEach((expandedIndex) => {
+      if (expandedIndex < indexToRemove) {
+        newExpandedSet.add(expandedIndex);
+      } else if (expandedIndex > indexToRemove) {
+        newExpandedSet.add(expandedIndex - 1);
+      }
+      // Si es igual, se ignora (se borra)
+    });
+    setExpandedMirrors(newExpandedSet);
+
+    // 2. Borrar del array principal
     const updated = [...investors];
-    updated.splice(index, 1);
+    updated.splice(indexToRemove, 1);
     formik.setFieldValue("investors", updated);
 
-    const updatedMirror = [...investorsMirror];
-    updatedMirror.splice(index, 1);
-    formik.setFieldValue("investorsMirror", updatedMirror);
-    
-    // Limpiar estado de expansión si se borra
-    if (expandedMirrors.has(index)) {
-        const newSet = new Set(expandedMirrors);
-        newSet.delete(index);
-        setExpandedMirrors(newSet);
+    // 3. Borrar del array espejo (si existe)
+    if (investorsMirror && investorsMirror.length > indexToRemove) {
+      const updatedMirror = [...investorsMirror];
+      updatedMirror.splice(indexToRemove, 1);
+      formik.setFieldValue("investorsMirror", updatedMirror);
     }
   };
 

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -12,13 +12,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useFormik } from "formik";
 import { toast } from "sonner";
-import { Plus, Trash2 } from "lucide-react";
 import { useUpdateCredit } from "../hooks/updateCredit";
 import { useRecalculateQuota } from "../hooks/recalculateQuota";
 import type {
   InversionistaPayload,
   UpdateCreditBody,
 } from "../services/services";
+import { InvestorsList } from "./InvestorsList";
 
 // Tipos locales
 interface InvestorItem extends InversionistaPayload {}
@@ -32,6 +32,7 @@ interface ModalEditCreditProps {
   onClose: () => void;
   initialValues: Omit<UpdateCreditBody, "inversionistas">;
   investorsInitial?: InvestorItem[];
+  investorsMirrorInitial?: InvestorItem[]; // 🆕 Nueva prop para datos iniciales espejo
   onSuccess: () => void;
   investorsOptions: InvestorOption[];
   advisorsOptions: { asesor_id: number; nombre: string }[];
@@ -88,42 +89,79 @@ export function ModalEditCredit({
   onClose,
   initialValues,
   investorsInitial,
+  investorsMirrorInitial,
   onSuccess,
   investorsOptions,
   advisorsOptions,
 }: ModalEditCreditProps) {
   const { mutate: updateCredit, isPending } = useUpdateCredit();
-  const { mutate: recalculateQuota, isPending: isRecalculating } = useRecalculateQuota();
+  const { mutate: recalculateQuota, isPending: isRecalculating } =
+    useRecalculateQuota();
 
-  // Preparamos los valores iniciales de inversionistas asegurando que siempre tienen todos los campos necesarios
-  const parsedInvestors =
-    investorsInitial?.map((inv) => ({
+  // Preparamos los valores iniciales
+  const parseInvestors = (list?: InvestorItem[]) =>
+    list?.map((inv) => ({
       inversionista_id: Number(inv.inversionista_id),
       monto_aportado: Number(inv.monto_aportado),
       porcentaje_cash_in: Number(inv.porcentaje_cash_in),
       porcentaje_inversion: Number(inv.porcentaje_inversion),
     })) || [];
 
+  const parsedInvestors = parseInvestors(investorsInitial);
+  // Si no hay espejo inicial, usamos una lista vacía.
+  // Pero ojo: la UI necesita que estén sincronizados.
+  // Si investors tiene 3 items, investorsMirror debería tener 3 items (aunque vacíos)
+  // para que coincidan los índices.
+  // Sin embargo, para simplificar, dejaremos que InvestorsList maneje la creación
+  // dinámica del espejo si no existe.
+  const parsedInvestorsMirror = parseInvestors(investorsMirrorInitial);
+
+  // Sincronización inicial de longitudes
+  while (parsedInvestorsMirror.length < parsedInvestors.length) {
+    parsedInvestorsMirror.push({
+      inversionista_id: 0,
+      monto_aportado: 0,
+      porcentaje_cash_in: 0,
+      porcentaje_inversion: 0,
+    });
+  }
+
   const formik = useFormik({
     initialValues: {
       ...initialValues,
       investors: parsedInvestors,
+      investorsMirror: parsedInvestorsMirror, // 🆕 Campo para espejo
     },
     enableReinitialize: true,
     validate: (values) => {
       const errors: any = {};
+      const capital = Number(values.capital || 0);
 
-      // 🔥 VALIDAR QUE LA SUMA DE MONTOS APORTADOS = CAPITAL
+      // 🔥 VALIDACIÓN 1: Inversionistas Principales
       if (values.investors.length > 0) {
         const sumaMontos = values.investors.reduce(
           (sum, inv) => sum + Number(inv.monto_aportado || 0),
           0
         );
-        const capital = Number(values.capital || 0);
 
         if (Math.abs(sumaMontos - capital) > 0.01) {
-          errors.investors = `La suma de montos aportados (Q${sumaMontos.toFixed(2)}) debe ser igual al capital (Q${capital.toFixed(2)})`;
+          errors.investors = `La suma de montos aportados (Q${sumaMontos.toFixed(
+            2
+          )}) debe ser igual al capital (Q${capital.toFixed(2)})`;
         }
+      }
+
+      // 🔥 VALIDACIÓN 2: Inversionistas Espejo (solo validamos si HAY datos reales)
+      // Si la suma es 0, asumimos que no se está usando el espejo (o está vacío)
+      const sumaMontosMirror = values.investorsMirror.reduce(
+        (sum, inv) => sum + Number(inv.monto_aportado || 0),
+        0
+      );
+
+      if (sumaMontosMirror > 0 && Math.abs(sumaMontosMirror - capital) > 0.01) {
+        errors.investorsMirror = `(Espejo) Suma: Q${sumaMontosMirror.toFixed(
+          2
+        )} ≠ Capital: Q${capital.toFixed(2)}`;
       }
 
       return errors;
@@ -139,6 +177,12 @@ export function ModalEditCredit({
         });
         return;
       }
+
+      // Filtrar espejo vacíos antes de enviar
+      const espejoFinal = values.investorsMirror.filter(
+        (inv) => Number(inv.monto_aportado) > 0 || Number(inv.inversionista_id) > 0
+      );
+
       const payload: UpdateCreditBody = {
         // Asegúrate que cada campo numérico va como Number:
         capital: Number(values.capital),
@@ -162,14 +206,24 @@ export function ModalEditCredit({
         nombre: values.nombre ?? undefined,
         nit: values.nit ?? undefined,
         direccion: values.direccion ?? undefined,
-        saldo_a_favor: values.saldo_a_favor !== undefined && values.saldo_a_favor !== null
-          ? Number(values.saldo_a_favor)
-          : undefined,
+        saldo_a_favor:
+          values.saldo_a_favor !== undefined && values.saldo_a_favor !== null
+            ? Number(values.saldo_a_favor)
+            : undefined,
 
         // Formato de crédito
         formato_credito: values.formato_credito ?? undefined,
 
+        // Lista Principal
         inversionistas: values.investors.map((i: InvestorItem) => ({
+          inversionista_id: Number(i.inversionista_id),
+          monto_aportado: Number(i.monto_aportado),
+          porcentaje_cash_in: Number(i.porcentaje_cash_in),
+          porcentaje_inversion: Number(i.porcentaje_inversion),
+        })),
+
+        // Lista Espejo
+        inversionistas_espejo: espejoFinal.map((i: InvestorItem) => ({
           inversionista_id: Number(i.inversionista_id),
           monto_aportado: Number(i.monto_aportado),
           porcentaje_cash_in: Number(i.porcentaje_cash_in),
@@ -191,24 +245,6 @@ export function ModalEditCredit({
     },
   });
 
-  const addInvestor = () => {
-    formik.setFieldValue("investors", [
-      ...formik.values.investors,
-      {
-        inversionista_id: 0,
-        monto_aportado: 0,
-        porcentaje_cash_in: 0,
-        porcentaje_inversion: 0,
-      },
-    ]);
-  };
-
-  const removeInvestor = (index: number) => {
-    const updated = [...formik.values.investors];
-    updated.splice(index, 1);
-    formik.setFieldValue("investors", updated);
-  };
-
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent
@@ -220,23 +256,27 @@ export function ModalEditCredit({
         }}
       >
         {/* Cabecera */}
-        <DialogHeader className="sticky top-0 bg-white z-10 px-6 pt-6 pb-2 border-b border-blue-100">
+        <DialogHeader className="sticky top-0 bg-white z-10 px-6 pt-6 pb-2 border-b border-blue-100 flex flex-row items-center justify-between">
           <DialogTitle className="text-blue-700 font-bold text-xl">
             Editar Crédito e Inversionistas
           </DialogTitle>
         </DialogHeader>
 
-        {/* Scrollable content */}
+        {/* Scrollable content container */}
         <div
           className="flex-1 overflow-y-auto px-6 pb-4"
-          style={{ maxHeight: "66vh", minHeight: 0 }}
+          style={{ maxHeight: "75vh" }}
         >
           <Button
             type="button"
-            disabled={isRecalculating || !initialValues?.numero_credito_sifco}
-            className="w-full mb-4 bg-green-600 text-white font-bold hover:bg-green-700"
+            disabled={
+              isRecalculating || !initialValues?.numero_credito_sifco
+            }
+            className="w-full my-4 bg-green-600 text-white font-bold hover:bg-green-700"
             onClick={() => {
-              const sifco = String(initialValues?.numero_credito_sifco ?? "");
+              const sifco = String(
+                initialValues?.numero_credito_sifco ?? ""
+              );
               if (!sifco) return;
               recalculateQuota(
                 { numero_credito_sifco: sifco },
@@ -250,6 +290,7 @@ export function ModalEditCredit({
           >
             {isRecalculating ? "Recalculando..." : "Recalcular Cuota"}
           </Button>
+
           <form
             onSubmit={formik.handleSubmit}
             className="flex flex-col"
@@ -262,7 +303,6 @@ export function ModalEditCredit({
               </h3>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 {creditFields.map((name) => {
-                  // ✅ Renderizado especial para asesor_id como select
                   if (name === "asesor_id") {
                     return (
                       <div key={name} className="flex flex-col gap-1">
@@ -277,7 +317,10 @@ export function ModalEditCredit({
                         >
                           <option value="">Seleccione un asesor</option>
                           {advisorsOptions.map((adv) => (
-                            <option key={adv.asesor_id} value={adv.asesor_id}>
+                            <option
+                              key={adv.asesor_id}
+                              value={adv.asesor_id}
+                            >
                               {adv.nombre}
                             </option>
                           ))}
@@ -286,7 +329,6 @@ export function ModalEditCredit({
                     );
                   }
 
-                  // ✅ Renderizado especial para formato_credito como select
                   if (name === "formato_credito") {
                     return (
                       <div key={name} className="flex flex-col gap-1">
@@ -307,7 +349,6 @@ export function ModalEditCredit({
                     );
                   }
 
-                  // ✅ Renderizado normal para los demás campos
                   return (
                     <div key={name} className="flex flex-col gap-1">
                       <Label className="text-gray-700 font-medium">
@@ -371,125 +412,22 @@ export function ModalEditCredit({
               </div>
             </div>
 
-            {/* Inversionistas con scroll interno */}
-            <div className="space-y-4 mt-4">
-              <h3 className="text-lg font-bold text-blue-800 mb-2">
-                Inversionistas Asociados
-              </h3>
-              {formik.values.investors.length === 0 && (
-                <div className="text-sm text-gray-500 mb-2">
-                  No hay inversionistas agregados.
-                </div>
-              )}
-              {formik.values.investors.map((inv, index) => (
-                <div
-                  key={index}
-                  className="border rounded-xl p-4 bg-blue-50 flex flex-col gap-2"
-                >
-                  <div className="flex flex-wrap gap-4 items-center">
-                    <div className="flex-1 min-w-[160px]">
-                      <Label>Inversionista</Label>
-                      <select
-                        name={`investors.${index}.inversionista_id`}
-                        value={inv.inversionista_id}
-                        onChange={formik.handleChange}
-                        className="w-full border rounded px-3 py-2 bg-white"
-                      >
-                        <option value={0}>Seleccione un inversionista</option>
-                        {investorsOptions.map((opt) => (
-                          <option
-                            key={opt.inversionista_id}
-                            value={opt.inversionista_id}
-                          >
-                            {opt.nombre}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <div className="w-36 min-w-[120px]">
-                      <Label>Monto Aportado</Label>
-                      <Input
-                        type="number"
-                        name={`investors.${index}.monto_aportado`}
-                        value={inv.monto_aportado}
-                        onChange={formik.handleChange}
-                      />
-                    </div>
-                    <div className="w-36 min-w-[120px]">
-                      <Label>Cash In (%)</Label>
-                      <Input
-                        type="number"
-                        name={`investors.${index}.porcentaje_cash_in`}
-                        value={inv.porcentaje_cash_in}
-                        onChange={(e) => {
-                          const val = Number(e.target.value);
-                          formik.setFieldValue(
-                            `investors.${index}.porcentaje_cash_in`,
-                            val
-                          );
-                          formik.setFieldValue(
-                            `investors.${index}.porcentaje_inversion`,
-                            parseFloat((100 - val).toFixed(10))
-                          );
-                        }}
-                        min={0}
-                        max={100}
-                      />
-                    </div>
-                    <div className="w-36 min-w-[120px]">
-                      <Label>Inversión (%)</Label>
-                      <Input
-                        type="number"
-                        name={`investors.${index}.porcentaje_inversion`}
-                        value={inv.porcentaje_inversion}
-                        onChange={(e) => {
-                          const val = Number(e.target.value);
-                          formik.setFieldValue(
-                            `investors.${index}.porcentaje_inversion`,
-                            val
-                          );
-                          formik.setFieldValue(
-                            `investors.${index}.porcentaje_cash_in`,
-                            parseFloat((100 - val).toFixed(10))
-                          );
-                        }}
-                        min={0}
-                        max={100}
-                      />
-                    </div>
-
-                    <Button
-                      type="button"
-                      variant="outline"
-                      className="h-10 mt-6 border-red-500 text-red-600 hover:bg-red-50"
-                      onClick={() => removeInvestor(index)}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
-                  </div>
-                </div>
-              ))}
-              <Button
-                type="button"
-                onClick={addInvestor}
-                variant="outline"
-                className="w-full border-blue-500 text-blue-700 hover:bg-blue-50 flex items-center gap-2"
-              >
-                <Plus className="w-4 h-4" />
-                Agregar Inversionista
-              </Button>
-
-              {/* 🔥 MOSTRAR ERROR DE VALIDACIÓN */}
-              {formik.errors.investors && typeof formik.errors.investors === 'string' && (
-                <div className="text-red-600 text-sm font-medium bg-red-50 border border-red-200 rounded-lg p-3">
-                  ⚠️ {formik.errors.investors}
-                </div>
-              )}
-            </div>
+            {/* 🔥 LISTA UNIFICADA DE INVERSIONISTAS (CON ESPEJO INTEGRADO) */}
+            <InvestorsList
+              investors={formik.values.investors}
+              investorsMirror={formik.values.investorsMirror} // Pasamos los espejos
+              investorsOptions={investorsOptions}
+              formik={formik}
+              fieldName="investors" // Base name, el componente manejará el espejo internamente
+              labelTitle="Inversionistas Asociados"
+              errorMessage={formik.errors.investors as string}
+              errorMessageMirror={formik.errors.investorsMirror as string}
+            />
           </form>
         </div>
+
         {/* FOOTER FIJO */}
-        <DialogFooter className="mt-auto px-6 pt-2 pb-4 flex gap-4 justify-between border-t border-blue-100">
+        <DialogFooter className="mt-auto px-6 pt-2 pb-4 flex gap-4 justify-between border-t border-blue-100 bg-white">
           <Button
             variant="outline"
             type="button"

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -158,18 +158,7 @@ export function ModalEditCredit({
         }
       }
 
-      // 🔥 VALIDACIÓN 2: Inversionistas Espejo (solo validamos si HAY datos reales)
-      // Si la suma es 0, asumimos que no se está usando el espejo (o está vacío)
-      const sumaMontosMirror = values.investorsMirror.reduce(
-        (sum, inv) => sum + Number(inv.monto_aportado || 0),
-        0
-      );
 
-      if (sumaMontosMirror > 0 && Math.abs(sumaMontosMirror - capital) > 0.01) {
-        errors.investorsMirror = `(Espejo) Suma: Q${sumaMontosMirror.toFixed(
-          2
-        )} ≠ Capital: Q${capital.toFixed(2)}`;
-      }
 
       return errors;
     },

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -7,6 +7,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -108,23 +109,29 @@ export function ModalEditCredit({
     })) || [];
 
   const parsedInvestors = parseInvestors(investorsInitial);
-  // Si no hay espejo inicial, usamos una lista vacía.
-  // Pero ojo: la UI necesita que estén sincronizados.
-  // Si investors tiene 3 items, investorsMirror debería tener 3 items (aunque vacíos)
-  // para que coincidan los índices.
-  // Sin embargo, para simplificar, dejaremos que InvestorsList maneje la creación
-  // dinámica del espejo si no existe.
-  const parsedInvestorsMirror = parseInvestors(investorsMirrorInitial);
+  // 🔥 Sincronización Real (Por ID de Inversionista)
+  // Buscamos explícitamente el espejo que corresponda al mismo ID de inversionista.
+  const parsedInvestorsMirror = parsedInvestors.map((inv) => {
+    const mirrorItem = investorsMirrorInitial?.find(
+      (m) => Number(m.inversionista_id) === Number(inv.inversionista_id)
+    );
 
-  // Sincronización inicial de longitudes
-  while (parsedInvestorsMirror.length < parsedInvestors.length) {
-    parsedInvestorsMirror.push({
+    if (mirrorItem) {
+      return {
+        inversionista_id: Number(mirrorItem.inversionista_id),
+        monto_aportado: Number(mirrorItem.monto_aportado),
+        porcentaje_cash_in: Number(mirrorItem.porcentaje_cash_in),
+        porcentaje_inversion: Number(mirrorItem.porcentaje_inversion),
+      };
+    }
+    // Si no hay espejo para ese inversionista, devolvemos objeto vacío
+    return {
       inversionista_id: 0,
       monto_aportado: 0,
       porcentaje_cash_in: 0,
       porcentaje_inversion: 0,
-    });
-  }
+    };
+  });
 
   const formik = useFormik({
     initialValues: {

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -637,6 +637,7 @@ export interface UpdateCreditBody {
 
   // Inversionistas nuevos
   inversionistas?: InversionistaPayload[];
+  inversionistas_espejo?: InversionistaPayload[];
 }
 export async function updateCreditService(body: UpdateCreditBody) {
   const response = await api.post(`${API_URL}/updateCredit`, body);

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -322,11 +322,24 @@ export interface BadDebt {
     incobrable?: BadDebt | null;
   cancelacion?: CreditCancelation | null;
 }
+export interface InversionistaEspejo {
+  credito_id: number;
+  inversionista_id: number;
+  nombre: string;
+  monto_aportado: string;
+  porcentaje_participacion: string;
+  porcentaje_cash_in: string;
+  porcentaje_inversion: string;
+  monto_cash_in: string;
+  monto_inversionista: string;
+  cuota_inversionista: string;
+}
 
 export interface CreditoUsuarioPago {
   creditos: Credito;
   usuarios: Usuario;
   inversionistas: AporteInversionista[];
+  creditos_inversionistas_espejo?: InversionistaEspejo[];
   resumen: ResumenCreditos;
   asesor: Asesor; // 👈 corregí el typo "aseor" -> "asesor"
   cancelacion?: CreditCancelation | null;


### PR DESCRIPTION
# Implementación de Edición de Inversionistas Espejo

## Resumen

Se implementó la funcionalidad para visualizar, agregar, editar y eliminar "Inversionistas Espejo" dentro del modal de edición de créditos (`ModalEditCredit`). La interfaz ahora permite gestionar estos datos de forma sincronizada con los inversionistas principales, manteniendo una experiencia de usuario limpia mediante un sistema de despliegue ("toggle") por ítem.

## Cambios Realizados

### 1. Servicios (`services.ts`)

- Se actualizó la interfaz `UpdateCreditBody` para incluir la propiedad opcional `inversionistas_espejo`, permitiendo enviar estos datos al backend.

### 2. Componente de Lista (`InvestorsList.tsx`)

- **Sincronización de Listas**: Se actualizó la lógica de `addInvestor` y `removeInvestor` para manipular simultáneamente los arrays `investors` (fiscal) e `investorsMirror` (interno). Esto asegura que siempre haya una correspondencia 1:1 entre los índices de ambas listas.
- **Interfaz de Usuario (UI)**:
  - Se agregó un botón con ícono de "copia" (`BookCopy`) en cada tarjeta de inversionista.
  - Se implementó un estado local para controlar la visibilidad de los campos espejo de manera individual por cada fila.
  - Los campos espejo se renderizan dentro de la misma tarjeta del inversionista principal, diferenciados por un estilo visual (color púrpura).
- **Props**: Se añadieron `investorsMirror` y `errorMessageMirror` para recibir los datos y errores correspondientes.

### 3. Modal de Edición (`ModalEditCredit.tsx`)

- **Gestión de Estado (Formik)**:
  - Se inicializa el formulario con los datos de `investorsMirror`.
  - Se agregó lógica de validación para asegurar que, si existen montos espejo, su suma coincida con el capital del crédito.
  - En el envío (`onSubmit`), se filtran los inversionistas espejo vacíos y se construye el payload correcto para el backend.
- **Limpieza**: Se eliminó la lógica anterior de visualización "side-by-side" (dos columnas) en favor del nuevo diseño integrado.

### 4. Vista Principal (`CreditsPaymentsData.tsx`)

- **Carga de Datos**:
  - Se implementó la extracción de `creditos_inversionistas_espejo` del objeto de crédito seleccionado.
  - Se pasan estos datos iniciales al modal a través de la prop `investorsMirrorInitial`, permitiendo editar datos existentes.

## Resultado Final

El usuario ahora puede:

1. Abrir la edición de un crédito.
2. Ver los inversionistas principales.
3. Hacer clic en el icono "Espejo" de cualquier inversionista para desplegar y editar sus datos internos asociados.
4. Agregar o eliminar inversionistas, afectando a ambas listas automáticamente.
5. Guardar los cambios, actualizando tanto la información fiscal como la interna en el servidor.


<img width="1868" height="1013" alt="image" src="https://github.com/user-attachments/assets/92f8c26a-98ec-45d0-b902-44790afa4094" />
