### PR TITLE
Adds mirror investor data population

### DIFF
--- a/apps/cartera-back/src/controllers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/controllers/mirrorInvestor.ts
@@ -173,9 +173,10 @@ async function calcularCuotaInversionista(
  * - cuota_inversionista se calcula con la misma lógica de createCredit
  * - Si no existe padre en creditos_inversionistas, igual se inserta el espejo
  */
-export const llenarTablaEspejo = async ({ body, set }: any) => {
+export const llenarTablaEspejo = async ({ body, query, set }: any) => {
   try {
     const { inversionista: nombreInversionista, creditos: creditosInput } = body;
+    const calcularCuota = query?.calcular_cuota === "true";
 
     // 1) Buscar inversionista por nombre
     const inversionistasEncontrados = await buscarInversionista(nombreInversionista);
@@ -202,6 +203,7 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
 
     const inversionistaId = inversionistasEncontrados[0].inversionista_id;
     const resultados: any[] = [];
+    const omitidos: any[] = [];
 
     // 2) Transacción para procesar todos los créditos
     await db.transaction(async (tx) => {
@@ -231,7 +233,11 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
           .where(ilike(usuarios.nombre, `%${cliente.trim()}%`));
 
         if (creditosEncontrados.length === 0) {
-          throw new Error(`No se encontró crédito para cliente: "${cliente}"`);
+          omitidos.push({
+            cliente,
+            razon: `No se encontró crédito para cliente: "${cliente}"`,
+          });
+          continue;
         }
 
         // 2b) Buscar cuál crédito tiene relación con este inversionista en creditos_inversionistas
@@ -257,22 +263,46 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
           }
         }
 
-        // Si no hay padre: solo agarrar el crédito si es el ÚNICO a nombre de esa persona
+        // Si no hay padre: si es único crédito lo tomamos, si hay varios omitimos
         if (!creditoId) {
-          if (creditosEncontrados.length > 1) {
-            throw new Error(
-              `No se encontró padre para inversionista "${nombreInversionista}" y cliente "${cliente}", y hay ${creditosEncontrados.length} créditos a nombre de ese cliente. No se puede determinar cuál usar.`
-            );
+          if (creditosEncontrados.length === 1) {
+            creditoId = creditosEncontrados[0].credito_id;
+            porcentajeInteres = creditosEncontrados[0].porcentaje_interes;
+            console.log(`[ESPEJO] Sin padre para inv=${inversionistaId} + cliente="${cliente}", usando único credito_id=${creditoId}`);
+          } else {
+            omitidos.push({
+              cliente,
+              razon: `No se encontró padre y hay ${creditosEncontrados.length} créditos a nombre de "${cliente}". No se puede determinar cuál usar.`,
+            });
+            continue;
           }
-          creditoId = creditosEncontrados[0].credito_id;
-          porcentajeInteres = creditosEncontrados[0].porcentaje_interes;
-          console.log(`[ESPEJO] No se encontró padre para inv=${inversionistaId} + credito cliente="${cliente}", usando único credito_id=${creditoId}`);
         }
 
-        // 3) Calcular cuota_inversionista (misma lógica de createCredit)
+        // 3) Calcular o no la cuota_inversionista según el query param
         const montoAportado = new Big(capital);
-        const { cuotaInversionista, porcentajeParticipacion } =
-          await calcularCuotaInversionista(tx, creditoId, inversionistaId, montoAportado);
+        let cuotaInversionista: Big;
+
+        if (calcularCuota) {
+          const resultado = await calcularCuotaInversionista(tx, creditoId, inversionistaId, montoAportado);
+          cuotaInversionista = resultado.cuotaInversionista;
+        } else {
+          // Sin cálculo: traer cuota del padre si existe, sino poner 0
+          const [padre] = await tx
+            .select({
+              cuota_inversionista: creditos_inversionistas.cuota_inversionista,
+              porcentaje_participacion_inversionista: creditos_inversionistas.porcentaje_participacion_inversionista,
+            })
+            .from(creditos_inversionistas)
+            .where(
+              and(
+                eq(creditos_inversionistas.credito_id, creditoId),
+                eq(creditos_inversionistas.inversionista_id, inversionistaId)
+              )
+            )
+            .limit(1);
+
+          cuotaInversionista = new Big(padre?.cuota_inversionista ?? 0);
+        }
 
         // 4) Cálculos de interés y distribución
         const interes = new Big(porcentajeInteres ?? 0);
@@ -288,7 +318,7 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
           ? montoCashIn.times(0.12).round(2)
           : new Big(0);
 
-        console.log(`[ESPEJO] Cliente: ${cliente}`);
+        console.log(`[ESPEJO] Cliente: ${cliente} | calcularCuota=${calcularCuota}`);
         console.log(`  capital=${montoAportado} | inversor=${inversor} → %cashIn=${porcCashIn}`);
         console.log(`  %interes=${interes} | cuotaInteres=${cuotaInteres}`);
         console.log(`  montoCashIn=${montoCashIn} | ivaCashIn=${ivaCashIn}`);
@@ -299,7 +329,7 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
           credito_id: creditoId,
           inversionista_id: inversionistaId,
           cuota_inversionista: cuotaInversionista.toString(),
-          porcentaje_participacion_inversionista: porcentajeParticipacion.toString(),
+          porcentaje_participacion_inversionista: inversorPct.toString(),
           monto_aportado: montoAportado.toString(),
           porcentaje_cash_in: porcCashIn.toString(),
           monto_inversionista: new Big(interes_inversor).toString(),
@@ -344,12 +374,13 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
     set.status = 200;
     return {
       success: true,
-      message: `Se procesaron ${resultados.length} créditos para inversionista "${inversionistasEncontrados[0].nombre}"`,
+      message: `Se procesaron ${resultados.length} créditos, ${omitidos.length} omitidos`,
       inversionista: {
         id: inversionistaId,
         nombre: inversionistasEncontrados[0].nombre,
       },
       resultados,
+      omitidos,
     };
   } catch (error) {
     console.error("[llenarTablaEspejo] Error:", error);

--- a/apps/cartera-back/src/controllers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/controllers/mirrorInvestor.ts
@@ -24,7 +24,6 @@ async function buscarInversionista(nombreCompleto: string) {
   const inputNorm = removeAccents(nombreCompleto.toLowerCase().trim());
   const partes = inputNorm.split(/\s+/);
 
-  // Traer candidatos que coincidan con la primera palabra (sin acentos)
   const candidatos = await db
     .select({
       inversionista_id: inversionistas.inversionista_id,
@@ -37,7 +36,6 @@ async function buscarInversionista(nombreCompleto: string) {
 
   if (candidatos.length <= 1) return candidatos;
 
-  // Puntuar: cuántas palabras del input aparecen en el nombre del candidato
   const scored = candidatos.map((c) => {
     const nombreNorm = removeAccents(c.nombre.toLowerCase());
     const score = partes.filter((p) => nombreNorm.includes(p)).length;
@@ -52,6 +50,108 @@ async function buscarInversionista(nombreCompleto: string) {
     .map(({ score, ...rest }) => rest);
 }
 
+// ─────────────────────────────────────────────────────────────
+// FUNCIÓN: calcularCuotaInversionista
+// Replica la lógica de createCredit.ts líneas 335-494
+// pero consultando datos reales de la BD en vez de recibirlos.
+//
+// Parámetros:
+//   - tx: transacción de Drizzle
+//   - creditoId: ID del crédito
+//   - inversionistaId: ID del inversionista para quien calculamos
+//   - montoAportadoEspejo: el capital del inversionista en el espejo (body.capital)
+//
+// Lógica:
+//   1. Trae el crédito (cuota, seguro, membresías, capital total)
+//   2. Trae TODOS los inversionistas reales de ese crédito (creditos_inversionistas)
+//   3. Calcula porcentajeParticipacion = montoAportadoEspejo / capitalTotal * 100
+//   4. cuotaSinCargos = cuota - membresías - seguro
+//   5. cuotaBase = cuotaSinCargos * (porcentajeParticipacion / 100)
+//   6. Determina quién es el inversionista mayor (por monto_aportado en la tabla REAL)
+//   7. Si ESTE inversionista es el mayor → cuotaBase + seguro + membresías
+//   8. Si no → cuotaBase
+// ─────────────────────────────────────────────────────────────
+async function calcularCuotaInversionista(
+  tx: any,
+  creditoId: number,
+  inversionistaId: number,
+  montoAportadoEspejo: Big
+) {
+  // 1) Traer datos del crédito
+  const [creditoData] = await tx
+    .select({
+      capital: creditos.capital,
+      cuota: creditos.cuota,
+      seguro_10_cuotas: creditos.seguro_10_cuotas,
+      membresias_pago: creditos.membresias_pago,
+    })
+    .from(creditos)
+    .where(eq(creditos.credito_id, creditoId))
+    .limit(1);
+
+  if (!creditoData) {
+    throw new Error(`No se encontró crédito con ID ${creditoId}`);
+  }
+
+  const capitalTotal = new Big(creditoData.capital);
+  const cuotaTotal = new Big(creditoData.cuota);
+  const seguro = new Big(creditoData.seguro_10_cuotas || 0);
+  const membresias = new Big(creditoData.membresias_pago || 0);
+
+  // 2) Traer TODOS los inversionistas reales de este crédito
+  const inversionistasReales = await tx
+    .select({
+      inversionista_id: creditos_inversionistas.inversionista_id,
+      monto_aportado: creditos_inversionistas.monto_aportado,
+    })
+    .from(creditos_inversionistas)
+    .where(eq(creditos_inversionistas.credito_id, creditoId));
+
+  // 3) Porcentaje de participación = montoAportadoEspejo / capitalTotal * 100
+  const porcentajeParticipacion = montoAportadoEspejo.div(capitalTotal).times(100);
+
+  // 4) Cuota sin cargos = cuota - membresías - seguro
+  const cuotaSinCargos = cuotaTotal.minus(membresias).minus(seguro);
+
+  // 5) Cuota base = cuotaSinCargos * (porcentajeParticipacion / 100)
+  const cuotaBase = cuotaSinCargos.times(porcentajeParticipacion.div(100)).round(2);
+
+  // 6) Encontrar al inversionista con mayor monto_aportado (en la tabla REAL)
+  let mayorId: number | null = null;
+  let mayorMonto = new Big(0);
+
+  for (const inv of inversionistasReales) {
+    const monto = new Big(inv.monto_aportado);
+    if (monto.gt(mayorMonto)) {
+      mayorMonto = monto;
+      mayorId = inv.inversionista_id;
+    }
+  }
+
+  const esMayor = inversionistaId === mayorId;
+
+  // 7/8) Si es el mayor → sumar seguro + membresías
+  let cuotaInversionista: Big;
+  if (esMayor) {
+    cuotaInversionista = cuotaBase.plus(seguro).plus(membresias).round(2);
+  } else {
+    cuotaInversionista = cuotaBase;
+  }
+
+  console.log(`[calcularCuotaInversionista] credito=${creditoId} inv=${inversionistaId}`);
+  console.log(`  capitalTotal=${capitalTotal} | cuotaTotal=${cuotaTotal}`);
+  console.log(`  seguro=${seguro} | membresias=${membresias}`);
+  console.log(`  montoAportadoEspejo=${montoAportadoEspejo} | %participacion=${porcentajeParticipacion.toFixed(4)}%`);
+  console.log(`  cuotaSinCargos=${cuotaSinCargos} | cuotaBase=${cuotaBase}`);
+  console.log(`  esMayor=${esMayor} (mayor=${mayorId}, monto=${mayorMonto})`);
+  console.log(`  cuotaInversionista=${cuotaInversionista}`);
+
+  return {
+    cuotaInversionista,
+    porcentajeParticipacion,
+  };
+}
+
 /**
  * Controller: llenarTablaEspejo
  *
@@ -61,15 +161,17 @@ async function buscarInversionista(nombreCompleto: string) {
  *   creditos: [{
  *     meses_en_credito: number,
  *     cliente: "nombre del cliente",
- *     capital: number,
- *     inversor: number,        // porcentaje_inversion
+ *     capital: number,          // monto_aportado del espejo
+ *     inversor: number,         // porcentaje_inversion (0 a 1, ej: 0.8 = 80%)
  *     interes_inversor: number, // monto_inversionista directo
- *     iva: number              // iva_inversionista
+ *     iva: number               // iva_inversionista
  *   }]
  * }
  *
- * Campos calculados: monto_cash_in, iva_cash_in
- * Campos del padre: cuota_inversionista, porcentaje_participacion, porcentaje_cash_in
+ * - inversor se usa directo como multiplicador (ya viene de 0 a 1)
+ * - porcentaje_cash_in = 100 - (inversor * 100)
+ * - cuota_inversionista se calcula con la misma lógica de createCredit
+ * - Si no existe padre en creditos_inversionistas, igual se inserta el espejo
  */
 export const llenarTablaEspejo = async ({ body, set }: any) => {
   try {
@@ -107,9 +209,15 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
         const {
           cliente,
           capital,
+          inversor,
           interes_inversor,
           iva,
         } = creditoInput;
+
+        // inversor viene de 0 a 1 (ej: 0.8 = 80%)
+        // porcentaje_cash_in = 100 - (inversor * 100)
+        const inversorPct = new Big(inversor).times(100);   // 0.8 → 80
+        const porcCashIn = new Big(100).minus(inversorPct);  // 100 - 80 = 20
 
         // 2a) Buscar crédito por nombre del cliente
         const creditosEncontrados = await tx
@@ -126,14 +234,13 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
           throw new Error(`No se encontró crédito para cliente: "${cliente}"`);
         }
 
-        // 2b) De los créditos encontrados, buscar cuál tiene padre con este inversionista
+        // 2b) Buscar cuál crédito tiene relación con este inversionista en creditos_inversionistas
         let creditoId: number | null = null;
-        let padre: any = null;
         let porcentajeInteres: string | null = null;
 
         for (const cred of creditosEncontrados) {
           const [padreTemp] = await tx
-            .select()
+            .select({ id: creditos_inversionistas.id })
             .from(creditos_inversionistas)
             .where(
               and(
@@ -145,28 +252,36 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
 
           if (padreTemp) {
             creditoId = cred.credito_id;
-            padre = padreTemp;
             porcentajeInteres = cred.porcentaje_interes;
             break;
           }
         }
 
-        if (!padre || !creditoId) {
-          throw new Error(
-            `No se encontró relación padre entre inversionista "${nombreInversionista}" y cliente "${cliente}"`
-          );
+        // Si no hay padre: solo agarrar el crédito si es el ÚNICO a nombre de esa persona
+        if (!creditoId) {
+          if (creditosEncontrados.length > 1) {
+            throw new Error(
+              `No se encontró padre para inversionista "${nombreInversionista}" y cliente "${cliente}", y hay ${creditosEncontrados.length} créditos a nombre de ese cliente. No se puede determinar cuál usar.`
+            );
+          }
+          creditoId = creditosEncontrados[0].credito_id;
+          porcentajeInteres = creditosEncontrados[0].porcentaje_interes;
+          console.log(`[ESPEJO] No se encontró padre para inv=${inversionistaId} + credito cliente="${cliente}", usando único credito_id=${creditoId}`);
         }
 
-        // 3) Cálculos
+        // 3) Calcular cuota_inversionista (misma lógica de createCredit)
         const montoAportado = new Big(capital);
-        const porcCashInPadre = new Big(padre.porcentaje_cash_in);
+        const { cuotaInversionista, porcentajeParticipacion } =
+          await calcularCuotaInversionista(tx, creditoId, inversionistaId, montoAportado);
+
+        // 4) Cálculos de interés y distribución
         const interes = new Big(porcentajeInteres ?? 0);
 
         // cuota_interes = capital * (porcentaje_interes / 100)
         const cuotaInteres = montoAportado.times(interes.div(100)).round(2);
 
-        // monto_cash_in = cuota_interes * (porcentaje_cash_in_padre / 100)
-        const montoCashIn = cuotaInteres.times(porcCashInPadre).div(100).round(2);
+        // monto_cash_in = cuota_interes * (porcentaje_cash_in / 100)
+        const montoCashIn = cuotaInteres.times(porcCashIn).div(100).round(2);
 
         // iva_cash_in = monto_cash_in * 0.12
         const ivaCashIn = Number(montoCashIn) > 0
@@ -174,18 +289,19 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
           : new Big(0);
 
         console.log(`[ESPEJO] Cliente: ${cliente}`);
-        console.log(`  capital=${montoAportado} | %interes=${interes} | cuotaInteres=${cuotaInteres}`);
-        console.log(`  %cashIn(padre)=${porcCashInPadre} | montoCashIn=${montoCashIn} | ivaCashIn=${ivaCashIn}`);
+        console.log(`  capital=${montoAportado} | inversor=${inversor} → %cashIn=${porcCashIn}`);
+        console.log(`  %interes=${interes} | cuotaInteres=${cuotaInteres}`);
+        console.log(`  montoCashIn=${montoCashIn} | ivaCashIn=${ivaCashIn}`);
         console.log(`  interes_inversor=${interes_inversor} | iva=${iva}`);
-        console.log(`  cuota_inversionista(padre)=${padre.cuota_inversionista}`);
+        console.log(`  cuotaInversionista=${cuotaInversionista}`);
 
         const dataEspejo = {
           credito_id: creditoId,
           inversionista_id: inversionistaId,
-          cuota_inversionista: padre.cuota_inversionista,
-          porcentaje_participacion_inversionista: padre.porcentaje_participacion_inversionista,
+          cuota_inversionista: cuotaInversionista.toString(),
+          porcentaje_participacion_inversionista: porcentajeParticipacion.toString(),
           monto_aportado: montoAportado.toString(),
-          porcentaje_cash_in: porcCashInPadre.toString(),
+          porcentaje_cash_in: porcCashIn.toString(),
           monto_inversionista: new Big(interes_inversor).toString(),
           monto_cash_in: montoCashIn.toString(),
           iva_inversionista: new Big(iva).toString(),
@@ -193,7 +309,7 @@ export const llenarTablaEspejo = async ({ body, set }: any) => {
           fecha_creacion: new Date(),
         };
 
-        // 4) Upsert: verificar si ya existe
+        // 5) Upsert en tabla espejo
         const [existente] = await tx
           .select()
           .from(creditos_inversionistas_espejo)

--- a/apps/cartera-back/src/routers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/routers/mirrorInvestor.ts
@@ -3,6 +3,9 @@ import { llenarTablaEspejo } from "../controllers/mirrorInvestor";
 
 export const mirrorInvestorRouter = new Elysia()
   .post("/llenar-tabla-espejo", llenarTablaEspejo, {
+    query: t.Object({
+      calcular_cuota: t.Optional(t.String()),
+    }),
     body: t.Object({
       inversionista: t.String({ minLength: 1 }),
       creditos: t.Array(
@@ -20,7 +23,7 @@ export const mirrorInvestorRouter = new Elysia()
     detail: {
       summary: "Llenar tabla espejo de inversionistas",
       description:
-        "Busca inversionista por nombre y para cada crédito (buscado por nombre de cliente) inserta/actualiza en la tabla espejo. Todo en transacción.",
+        "Busca inversionista por nombre y para cada crédito (buscado por nombre de cliente) inserta/actualiza en la tabla espejo. Si no encuentra padre, omite ese crédito y lo reporta. Query param calcular_cuota=true para calcular cuota_inversionista con lógica de createCredit.",
       tags: ["Inversionistas", "Espejo"],
     },
   });


### PR DESCRIPTION
Implements the functionality to populate the mirror investor table with data derived from existing credit and investor relationships.

This involves:
- Searching for investors by name with fuzzy matching.
- Calculating the investor's share of a credit based on their contribution and the credit's total capital.
- Determining the investor's quota using the same logic as credit creation.
- Calculating interest and cash-in amounts.
- Performing an upsert operation on the mirror table to update existing entries or create new ones.

The logic now correctly handles scenarios where a direct parent relationship between an investor and credit doesn't exist, falling back to using the sole credit associated with a client, and incorporates cash-in calculations, ensuring accurate data population for mirror investors.