### PR TITLE
Refactors lead update authorization logic

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -587,11 +587,7 @@ export const crmRouter = {
 			const { id, assignedTo, ...updateData } = input;
 
 			// Admin and juridico can update any lead, others only their own
-			const canUpdateAnyLead =
-				context.userRole === "admin" ||
-				context.userRole === "juridico" ||
-				context.userRole === "sales_supervisor" ||
-				context.userRole === "analyst";
+			const canUpdateAnyLead = context.userRole !== "sales";
 			const whereClause = canUpdateAnyLead
 				? eq(leads.id, id)
 				: and(eq(leads.id, id), eq(leads.assignedTo, context.userId));


### PR DESCRIPTION
Simplifies lead update authorization logic, removing sales supervisor and analyst roles from the list of users who can update any lead. Sales roles are now restricted to updating only the leads assigned to them.