### PR TITLE
fix: filtros temporales de cobros y errores de tipos

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -668,36 +668,32 @@ export async function getCreditosWithUserByMesAnio(
     hoy.setHours(0, 0, 0, 0);
 
     if (proximidad_pago === "TODAY") {
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date = ${hoyStr}::date`);
+      // Vencidos + vence hoy
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${hoyStr}::date`);
     } else if (proximidad_pago === "WEEK") {
+      // Vencidos + vence esta semana
       const fin = new Date(hoy);
       fin.setDate(fin.getDate() + 7);
       const finStr = fin.toISOString().slice(0, 10);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date > ${hoyStr}::date`);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
     } else if (proximidad_pago === "TWO_WEEKS") {
-      const inicio = new Date(hoy);
-      inicio.setDate(inicio.getDate() + 8);
-      const inicioStr = inicio.toISOString().slice(0, 10);
+      // Vencidos + próximos 14 días
       const fin = new Date(hoy);
       fin.setDate(fin.getDate() + 14);
       const finStr = fin.toISOString().slice(0, 10);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
     } else if (proximidad_pago === "MONTH") {
-      const inicio = new Date(hoy);
-      inicio.setDate(inicio.getDate() + 15);
-      const inicioStr = inicio.toISOString().slice(0, 10);
+      // Vencidos + próximos 30 días
       const fin = new Date(hoy);
       fin.setDate(fin.getDate() + 30);
       const finStr = fin.toISOString().slice(0, 10);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
     } else if (proximidad_pago === "DUEMONTH") {
-      const inicio = new Date(hoy);
-      inicio.setDate(inicio.getDate() + 31);
-      const inicioStr = inicio.toISOString().slice(0, 10);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
+      // Vencidos + próximos 15 días (quincena)
+      const fin = new Date(hoy);
+      fin.setDate(fin.getDate() + 15);
+      const finStr = fin.toISOString().slice(0, 10);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
     }
 
     // Solo cuotas no pagadas y con numero > 0

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -161,13 +161,16 @@
     numero_cuota: integer("numero_cuota").notNull(), // Ej: 1, 2, 3...
     fecha_vencimiento: date("fecha_vencimiento").notNull(),
     pagado: boolean("pagado").default(false), // 👈 Si el cliente ya pagó esta cuota
-    
+
     // 👇 NUEVO - Para control de liquidación a inversionistas
     liquidado_inversionistas: boolean("liquidado_inversionistas").default(false).notNull(), // 👈 Si ya se liquidó a TODOS los inversionistas
     fecha_liquidacion_inversionistas: timestamp("fecha_liquidacion_inversionistas"), // 👈 Cuándo se liquidó
-    
+
     createdAt: timestamp("createdat").defaultNow(),
-  });
+  },
+  (table) => ({
+    fechaVencimientoIdx: index("idx_cuotas_fecha_vencimiento").on(table.fecha_vencimiento),
+  }));
   export const moras_credito = customSchema.table("moras_credito", {
     mora_id: serial("mora_id").primaryKey(),
     credito_id: integer("credito_id")

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -120,7 +120,10 @@ interface CreditDetailViewProps {
 			| "nuevo"
 			| "panel"
 			| "camion"
-			| "microbus";
+			| "microbus"
+			| "microbus_20"
+			| "microbus_35"
+			| "microbus_36plus";
 		vehicleValue: string;
 		insuredAmount: string;
 		downPayment: string;

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -188,14 +188,14 @@ export interface FileRoutesByFullPath {
   '/juridico/$leadId': typeof JuridicoLeadIdRoute
   '/vehicles/auction-vehicles': typeof VehiclesAuctionVehiclesRoute
   '/vehicles/inspection': typeof VehiclesInspectionRoute
-  '/cobros/': typeof CobrosIndexRoute
-  '/juridico/': typeof JuridicoIndexRoute
-  '/vehicles/': typeof VehiclesIndexRoute
+  '/cobros': typeof CobrosIndexRoute
+  '/juridico': typeof JuridicoIndexRoute
+  '/vehicles': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
-  '/admin/reports/': typeof AdminReportsIndexRoute
-  '/crm/analysis/': typeof CrmAnalysisIndexRoute
+  '/admin/reports': typeof AdminReportsIndexRoute
+  '/crm/analysis': typeof CrmAnalysisIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -275,14 +275,14 @@ export interface FileRouteTypes {
     | '/juridico/$leadId'
     | '/vehicles/auction-vehicles'
     | '/vehicles/inspection'
-    | '/cobros/'
-    | '/juridico/'
-    | '/vehicles/'
+    | '/cobros'
+    | '/juridico'
+    | '/vehicles'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
     | '/juridico/generate/$opportunityId'
-    | '/admin/reports/'
-    | '/crm/analysis/'
+    | '/admin/reports'
+    | '/crm/analysis'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -403,21 +403,21 @@ declare module '@tanstack/react-router' {
     '/vehicles/': {
       id: '/vehicles/'
       path: '/vehicles'
-      fullPath: '/vehicles/'
+      fullPath: '/vehicles'
       preLoaderRoute: typeof VehiclesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/juridico/': {
       id: '/juridico/'
       path: '/juridico'
-      fullPath: '/juridico/'
+      fullPath: '/juridico'
       preLoaderRoute: typeof JuridicoIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/cobros/': {
       id: '/cobros/'
       path: '/cobros'
-      fullPath: '/cobros/'
+      fullPath: '/cobros'
       preLoaderRoute: typeof CobrosIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
@@ -522,14 +522,14 @@ declare module '@tanstack/react-router' {
     '/crm/analysis/': {
       id: '/crm/analysis/'
       path: '/crm/analysis'
-      fullPath: '/crm/analysis/'
+      fullPath: '/crm/analysis'
       preLoaderRoute: typeof CrmAnalysisIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/admin/reports/': {
       id: '/admin/reports/'
       path: '/admin/reports'
-      fullPath: '/admin/reports/'
+      fullPath: '/admin/reports'
       preLoaderRoute: typeof AdminReportsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -163,12 +163,13 @@ function RouteComponent() {
 			});
 	}, [creditos]);
 
-	// Filtrar según el rango temporal seleccionado
+	// Filtrar completados/incobrables según estado del toggle
 	const creditosFiltrados = useMemo(() => {
 		let filtrados = creditosConDias;
 
 		// Excluir completados e incobrables si el filtro está desactivado
 		// NOTA: El filtro por etapa ahora se hace en el servidor mediante estadoMora
+		// NOTA: El filtro temporal se hace en el servidor mediante proximidad_pago
 		if (!mostrarCompletadosIncobrables && !filtroEtapa) {
 			filtrados = filtrados.filter(
 				(c) =>
@@ -177,24 +178,8 @@ function RouteComponent() {
 			);
 		}
 
-		// Filtrar por rango temporal
-		if (filtroTemporal === "todos") return filtrados;
-
-		const limitesDias: Record<FiltroTemporal, number> = {
-			hoy: 0,
-			semana: 7,
-			quincena: 15,
-			mes: 30,
-			todos: Number.POSITIVE_INFINITY,
-		};
-
-		const limite = limitesDias[filtroTemporal];
-
-		return filtrados.filter((c) => {
-			// Incluir casos en mora (días negativos) y casos próximos a vencer
-			return c?.diasHastaPago !== null && c?.diasHastaPago <= limite;
-		});
-	}, [creditosConDias, filtroTemporal, mostrarCompletadosIncobrables]);
+		return filtrados;
+	}, [creditosConDias, mostrarCompletadosIncobrables, filtroEtapa]);
 
 	// Check permissions after all hooks
 	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -317,7 +317,10 @@ function RouteComponent() {
 				| "email"
 				| "social_media"
 				| "event"
-				| "other",
+				| "other"
+				| "facebook"
+				| "instagram"
+				| "google",
 			assignedTo: "",
 			notes: "",
 			score: "",


### PR DESCRIPTION
## Summary
- Corregir filtros temporales (Hoy/Semana/Quincena/Mes) en cobros que mostraban vacío
- Los rangos de proximidad_pago en cartera-back ahora son acumulativos (incluyen vencidos)
- Eliminado doble filtrado client-side redundante en CRM
- Corregidos errores de tipos TS: vehicleType (microbus) y source (facebook/instagram/google)

## Test plan
- [ ] Verificar filtro Hoy en cobros muestra clientes con pago vencido y del día
- [ ] Verificar filtro Semana muestra vencidos + próximos 7 días
- [ ] Verificar filtro Quincena muestra vencidos + próximos 15 días
- [ ] Verificar filtro Mes muestra vencidos + próximos 30 días
- [ ] Verificar filtro Todos sigue funcionando igual
- [ ] Verificar que bun check-types pasa sin errores

Generated with Claude Code