### PR TITLE
Uses r2Key for documentLink in ContractResults

### DIFF
--- a/apps/crm/apps/server/src/routers/contract-generation.ts
+++ b/apps/crm/apps/server/src/routers/contract-generation.ts
@@ -421,6 +421,7 @@ export const contractGenerationRouter = {
 					signingLinks?: string[];
 					templateId?: number;
 					apiResponse?: unknown;
+					r2Key?: string;
 					error?: string;
 				}> = [];
 
@@ -444,6 +445,7 @@ export const contractGenerationRouter = {
 								documentLink: contractResult.r2Key
 									? await getFileUrlWithBucketInKey(contractResult.r2Key)
 									: contractResult.linkDocument,
+								r2Key: contractResult.r2Key ?? undefined,
 								signingLinks: contractResult.signing_links,
 								templateId: contractResult.templateId,
 								apiResponse: contractResult,

--- a/apps/crm/apps/web/src/components/contracts/ContractResults.tsx
+++ b/apps/crm/apps/web/src/components/contracts/ContractResults.tsx
@@ -15,6 +15,7 @@ export interface ContractResult {
 	success: boolean;
 	contractId?: string;
 	documentLink?: string;
+	r2Key?: string;
 	signingLinks?: string[];
 	templateId?: number;
 	apiResponse?: unknown;

--- a/apps/crm/apps/web/src/components/contracts/DynamicContractWizard.tsx
+++ b/apps/crm/apps/web/src/components/contracts/DynamicContractWizard.tsx
@@ -1569,7 +1569,7 @@ export function DynamicContractWizard({
 				contracts: successfulContracts.map((c) => ({
 					contractType: c.contractType,
 					contractName: c.contractName,
-					documentLink: c.documentLink,
+					documentLink: c.r2Key ?? c.documentLink,
 					signingLinks: c.signingLinks,
 					templateId: c.templateId,
 					apiResponse: c.apiResponse,


### PR DESCRIPTION
Prioritizes the `r2Key` value as the `documentLink` in `ContractResults` when available, providing a more reliable link to the contract document. This change ensures the application utilizes the most up-to-date and accurate document link, especially when using R2 storage.