### PR TITLE
Jalvarez

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1575,6 +1575,232 @@ export async function getInvestorTotalsGlobales(
   };
 }
 
+// ============================================
+// getInvestorMirrorSummary
+// ============================================
+
+/**
+ * Calcula los subtotales financieros globales de un inversionista usando
+ * EXCLUSIVAMENTE los registros de `pagos_credito_inversionistas_espejo`.
+ *
+ * Lógica:
+ *  1. Lee `monto_aportado` base de `creditos_inversionistas_espejo`.
+ *  2. Suma todos los `abono_capital` de los pagos espejo.
+ *  3. Saldo actual = monto_aportado_base - SUM(abono_capital de pagos).
+ *
+ * La respuesta incluye únicamente datos básicos del inversionista y
+ * subtotales globales (sin detalle de créditos ni de pagos individuales).
+ *
+ * @param investorId        - ID del inversionista (opcional si se provee dpi)
+ * @param dpi               - DPI del inversionista (opcional si se provee investorId)
+ * @param incluirLiquidados - Si true, incluye pagos ya liquidados en el cálculo
+ */
+export async function getInvestorMirrorSummary(
+  investorId?: number,
+  dpi?: string,
+  incluirLiquidados = false
+) {
+  console.log(
+    "[getInvestorMirrorSummary] investorId:", investorId,
+    "DPI:", dpi,
+    "incluirLiquidados:", incluirLiquidados
+  );
+
+  // ── PASO 1: Validar y obtener datos del inversionista ──────────────────────
+  const queryConditions: SQL[] = [];
+  if (investorId) queryConditions.push(eq(inversionistas.inversionista_id, investorId));
+  if (dpi)        queryConditions.push(eq(inversionistas.dpi, parseInt(dpi)));
+  if (queryConditions.length === 0) {
+    throw new Error("Debe proporcionar al menos 'id' o 'dpi' del inversionista.");
+  }
+
+  const [inv] = await db
+    .select({
+      inversionista_id: inversionistas.inversionista_id,
+      nombre:           inversionistas.nombre,
+      emite_factura:    inversionistas.emite_factura,
+      reinversion:      inversionistas.tipo_reinversion,
+      banco_id:         inversionistas.banco_id,
+      tipo_cuenta:      inversionistas.tipo_cuenta,
+      numero_cuenta:    inversionistas.numero_cuenta,
+      dpi:              inversionistas.dpi,
+    })
+    .from(inversionistas)
+    .where(and(...queryConditions))
+    .limit(1);
+
+  if (!inv) throw new Error("Inversionista no encontrado.");
+
+  console.log(`[getInvestorMirrorSummary] Inversionista: ${inv.nombre} (ID: ${inv.inversionista_id})`);
+
+  // ── PASO 2: Leer monto_aportado base de creditos_inversionistas_espejo ─────
+  const creditosEspejo = await db
+    .select({
+      credito_id:          creditos_inversionistas_espejo.credito_id,
+      monto_aportado_base: creditos_inversionistas_espejo.monto_aportado,
+    })
+    .from(creditos_inversionistas_espejo)
+    .where(eq(creditos_inversionistas_espejo.inversionista_id, inv.inversionista_id));
+
+  const totalMontoBase = creditosEspejo.reduce(
+    (acc, c) => acc.plus(new Big(c.monto_aportado_base ?? 0)),
+    new Big(0)
+  );
+
+  // Caso sin créditos espejo: devolver ceros con monto base
+  if (creditosEspejo.length === 0) {
+    return {
+      inversionista_id: inv.inversionista_id,
+      nombre:           inv.nombre,
+      emite_factura:    inv.emite_factura,
+      reinversion:      inv.reinversion,
+      banco_id:         inv.banco_id,
+      tipo_cuenta:      inv.tipo_cuenta,
+      numero_cuenta:    inv.numero_cuenta,
+      dpi:              inv.dpi,
+      subtotal: {
+        total_abono_capital:      0,
+        total_abono_interes:      0,
+        total_abono_iva:          0,
+        total_isr:                0,
+        total_cuota:              0,
+        total_monto_aportado:     Number(totalMontoBase.toString()),
+        totalAbonoGeneralInteres: 0,
+        total_capital_creditos:   Number(totalMontoBase.toString()),
+        total_capital_actual:     Number(totalMontoBase.toString()),
+      },
+    };
+  }
+
+  const creditosIds = creditosEspejo.map((c) => c.credito_id);
+  console.log(`[getInvestorMirrorSummary] Créditos espejo: ${creditosIds.length}`);
+
+  // ── PASO 3: Obtener todos los pagos espejo (fuente de verdad) ─────────────
+  const pagosConditions: SQL[] = [
+    eq(pagos_credito_inversionistas_espejo.inversionista_id, inv.inversionista_id),
+    inArray(pagos_credito_inversionistas_espejo.credito_id, creditosIds),
+  ];
+  if (!incluirLiquidados) {
+    pagosConditions.push(
+      eq(pagos_credito_inversionistas_espejo.estado_liquidacion, "NO_LIQUIDADO")
+    );
+  }
+
+  const pagosEspejo = await db
+    .select({
+      credito_id:    pagos_credito_inversionistas_espejo.credito_id,
+      abono_capital: pagos_credito_inversionistas_espejo.abono_capital,
+      abono_interes: pagos_credito_inversionistas_espejo.abono_interes,
+      abono_iva_12:  pagos_credito_inversionistas_espejo.abono_iva_12,
+    })
+    .from(pagos_credito_inversionistas_espejo)
+    .where(and(...pagosConditions));
+
+  console.log(`[getInvestorMirrorSummary] Pagos espejo: ${pagosEspejo.length}`);
+
+  // Agrupar pagos por credito_id
+  const pagosPorCredito = new Map<number, typeof pagosEspejo>();
+  for (const pago of pagosEspejo) {
+    const arr = pagosPorCredito.get(pago.credito_id) ?? [];
+    arr.push(pago);
+    pagosPorCredito.set(pago.credito_id, arr);
+  }
+
+  // ── PASO 4: Calcular subtotales globales ──────────────────────────────────
+  const sg = {
+    total_abono_capital:      new Big(0),
+    total_abono_interes:      new Big(0),
+    total_abono_iva:          new Big(0),
+    total_isr:                new Big(0),
+    total_cuota:              new Big(0),
+    total_monto_aportado:     new Big(0),
+    totalAbonoGeneralInteres: new Big(0),
+    total_capital_creditos:   new Big(0),
+    total_capital_actual:     new Big(0),
+  };
+
+  for (const credito of creditosEspejo) {
+    const pagos             = pagosPorCredito.get(credito.credito_id) ?? [];
+    const montoAportadoBase = new Big(credito.monto_aportado_base ?? 0);
+
+    sg.total_capital_creditos = sg.total_capital_creditos.plus(montoAportadoBase);
+
+    let abonoCapitalCredito = new Big(0);
+
+    for (const pago of pagos) {
+      const abono_capital = new Big(pago.abono_capital ?? 0);
+      const abono_interes = new Big(pago.abono_interes ?? 0);
+      const abono_iva     = new Big(pago.abono_iva_12  ?? 0);
+
+      // ISR: 7% sobre interés si NO emite factura
+      const isr = inv.emite_factura
+        ? new Big(0)
+        : abono_interes.times(0.07).round(2);
+
+      const abonoGeneralInteres = inv.emite_factura
+        ? abono_interes.plus(abono_iva)
+        : abono_interes.minus(isr);
+
+      let cuota_inversor: Big;
+      switch (inv.reinversion) {
+        case "sin_reinversion":
+          cuota_inversor = abono_capital.plus(abono_interes).plus(inv.emite_factura ? abono_iva : isr.neg());
+          break;
+        case "reinversion_capital":
+          cuota_inversor = abono_interes.plus(inv.emite_factura ? abono_iva : isr.neg());
+          break;
+        case "reinversion_interes":
+          cuota_inversor = abono_capital.plus(inv.emite_factura ? abono_iva : isr.neg());
+          break;
+        case "reinversion_total":
+          cuota_inversor = new Big(0);
+          break;
+        default:
+          cuota_inversor = abono_capital.plus(abono_interes).plus(inv.emite_factura ? abono_iva : isr.neg());
+      }
+
+      abonoCapitalCredito         = abonoCapitalCredito.plus(abono_capital);
+      sg.total_abono_capital      = sg.total_abono_capital.plus(abono_capital);
+      sg.total_abono_interes      = sg.total_abono_interes.plus(abono_interes);
+      sg.total_abono_iva          = sg.total_abono_iva.plus(abono_iva);
+      sg.total_isr                = sg.total_isr.plus(isr);
+      sg.total_cuota              = sg.total_cuota.plus(cuota_inversor);
+      sg.totalAbonoGeneralInteres = sg.totalAbonoGeneralInteres.plus(abonoGeneralInteres);
+    }
+
+    // 🔑 Saldo actual = monto_aportado_base - SUM(abono_capital de pagos espejo)
+    const capital_actual = montoAportadoBase.minus(abonoCapitalCredito);
+    sg.total_monto_aportado = sg.total_monto_aportado.plus(capital_actual);
+    sg.total_capital_actual = sg.total_capital_actual.plus(capital_actual);
+  }
+
+  // ── PASO 5: Retornar datos del inversionista + subtotales globales ─────────
+  return {
+    inversionista_id: inv.inversionista_id,
+    nombre:           inv.nombre,
+    emite_factura:    inv.emite_factura,
+    reinversion:      inv.reinversion,
+    banco_id:         inv.banco_id,
+    tipo_cuenta:      inv.tipo_cuenta,
+    numero_cuenta:    inv.numero_cuenta,
+    dpi:              inv.dpi,
+    subtotal: {
+      total_abono_capital:      Number(sg.total_abono_capital.toString()),
+      total_abono_interes:      Number(sg.total_abono_interes.toString()),
+      total_abono_iva:          Number(sg.total_abono_iva.toString()),
+      total_isr:                Number(sg.total_isr.toString()),
+      total_cuota:              Number(sg.total_cuota.toString()),
+      /** Saldo actual: monto_aportado_base - SUM(abono_capital de pagos espejo) */
+      total_monto_aportado:     Number(sg.total_monto_aportado.toString()),
+      totalAbonoGeneralInteres: Number(sg.totalAbonoGeneralInteres.toString()),
+      /** Suma de monto_aportado_base de todos los créditos espejo */
+      total_capital_creditos:   Number(sg.total_capital_creditos.toString()),
+      /** Igual a total_monto_aportado: saldo vivo calculado desde pagos */
+      total_capital_actual:     Number(sg.total_capital_actual.toString()),
+    },
+  };
+}
+
 export const liquidateByInvestorSchema = z.object({
   inversionista_id: z.number().optional(), // 🆕 Ahora es opcional
 });

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1609,7 +1609,11 @@ export async function getInvestorMirrorSummary(
   // ── PASO 1: Validar y obtener datos del inversionista ──────────────────────
   const queryConditions: SQL[] = [];
   if (investorId) queryConditions.push(eq(inversionistas.inversionista_id, investorId));
-  if (dpi)        queryConditions.push(eq(inversionistas.dpi, parseInt(dpi)));
+  if (dpi) {
+    const dpiNumber = parseInt(dpi, 10);
+    if (isNaN(dpiNumber)) throw new Error("DPI inválido: debe ser un número entero.");
+    queryConditions.push(eq(inversionistas.dpi, dpiNumber));
+  }
   if (queryConditions.length === 0) {
     throw new Error("Debe proporcionar al menos 'id' o 'dpi' del inversionista.");
   }

--- a/apps/cartera-back/src/controllers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/controllers/mirrorInvestor.ts
@@ -7,7 +7,7 @@ import {
   inversionistas,
   usuarios,
 } from "../database/db";
-import { and, eq, ilike, sql } from "drizzle-orm";
+import { and, eq, ilike, sql, or, inArray } from "drizzle-orm";
 
 /** Quita tildes/acentos de un string */
 function removeAccents(str: string): string {
@@ -404,6 +404,241 @@ export const llenarTablaEspejo = async ({ body, query, set }: any) => {
     return {
       success: false,
       message: "Error al llenar tabla espejo",
+      error: String(error),
+    };
+  }
+};
+
+/**
+ * Controller: getCreditsWithMirrors
+ * 
+ * Retorna todos los créditos separados por:
+ * - con_espejo: Tienen registro en creditos_inversionistas_espejo (excluyendo inversionista_id = 86)
+ * - sin_espejo: No tienen registro (o solo tienen el 86)
+ */
+export const getCreditsWithMirrors = async ({ set }: any) => {
+  try {
+    const allCredits = await db
+      .select({
+        credito_id: creditos.credito_id,
+        numero_credito_sifco: creditos.numero_credito_sifco,
+        cliente: usuarios.nombre,
+        espejo: {
+          id: creditos_inversionistas_espejo.id,
+          inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+          monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+          cuota_inversionista: creditos_inversionistas_espejo.cuota_inversionista,
+        },
+        nombre_inversionista: inversionistas.nombre,
+        real_inversionista_id: creditos_inversionistas.inversionista_id
+      })
+      .from(creditos)
+      .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+      .leftJoin(
+        creditos_inversionistas_espejo,
+        eq(creditos.credito_id, creditos_inversionistas_espejo.credito_id)
+      )
+      .leftJoin(
+        inversionistas,
+        eq(creditos_inversionistas_espejo.inversionista_id, inversionistas.inversionista_id)
+      )
+      .leftJoin(
+        creditos_inversionistas,
+        eq(creditos.credito_id, creditos_inversionistas.credito_id)
+      );
+
+    const creditMap = new Map<number, any>();
+
+    for (const row of allCredits) {
+      if (!creditMap.has(row.credito_id)) {
+        creditMap.set(row.credito_id, {
+          credito_id: row.credito_id,
+          numero_credito_sifco: row.numero_credito_sifco,
+          cliente: row.cliente,
+          mirrors: [],
+          hasBlockedInvestor: false
+        });
+      }
+      
+      const entry = creditMap.get(row.credito_id);
+      
+      // Chequear bloqueo en el inversionista REAL
+      if (row.real_inversionista_id === 86 || row.real_inversionista_id === 89) {
+          entry.hasBlockedInvestor = true;
+      }
+      
+      // Chequear bloqueo en el inversionista ESPEJO y agregar si válido
+      if (row.espejo && row.espejo.id) {
+          if (row.espejo.inversionista_id === 86 || row.espejo.inversionista_id === 89) {
+              entry.hasBlockedInvestor = true;
+          } else {
+             // Evitar duplicados (por el left join múltiple)
+             const exists = entry.mirrors.some((m: any) => m.id === row.espejo?.id);
+             if (!exists && row.espejo) {
+                entry.mirrors.push({
+                    ...row.espejo,
+                    nombre_inversionista: row.nombre_inversionista
+                });
+             }
+          }
+      }
+    }
+
+    const conEspejo: any[] = [];
+    const sinEspejo: any[] = [];
+
+    for (const credit of creditMap.values()) {
+        const hasBlocked = credit.hasBlockedInvestor;
+        delete credit.hasBlockedInvestor;
+
+        // Si tiene algún inversionista bloqueado (86 u 89) YA SEA REAL O ESPEJO, lo omitimos TOTALMENTE.
+        if (hasBlocked) {
+            continue;
+        }
+
+        if (credit.mirrors.length > 0) {
+            conEspejo.push(credit);
+        } else {
+            delete credit.mirrors;
+            sinEspejo.push(credit);
+        }
+    }
+
+    set.status = 200;
+    return {
+      success: true,
+      con_espejo: conEspejo,
+      sin_espejo: sinEspejo
+    };
+
+  } catch (error) {
+    console.error("[getCreditsWithMirrors] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al obtener creditos con espejo",
+      error: String(error),
+    };
+  }
+};
+
+
+/**
+ * Controller: getCreditsByInvestor
+ * 
+ * Recibe query param `id` (inversionista_id).
+ * Retorna lista de créditos donde ese inversionista participa (como real o como espejo).
+ * Para cada crédito, incluye:
+ * - Datos del crédito (numero_credito_sifco, cliente)
+ * - Lista de inversionistas REALES
+ * - Lista de inversionistas ESPEJOS
+ */
+export const getCreditsByInvestor = async ({ query, set }: any) => {
+  try {
+    const { id } = query;
+    if (!id) {
+      set.status = 400;
+      return { success: false, message: "Falta el parámetro 'id' (inversionista_id)" };
+    }
+    
+    // Convertir el id a entero (si es string)
+    const targetId = Number(id);
+    if (isNaN(targetId)) {
+        set.status = 400;
+        return { success: false, message: "El ID debe ser un número válido" };
+    }
+
+    // 1) Encontrar IDs de créditos donde participa este inversionista
+    //    En la tabla REAL
+    const realParticipations = await db
+      .select({ credito_id: creditos_inversionistas.credito_id })
+      .from(creditos_inversionistas)
+      .where(eq(creditos_inversionistas.inversionista_id, targetId));
+
+    //    En la tabla ESPEJO
+    const mirrorParticipations = await db
+      .select({ credito_id: creditos_inversionistas_espejo.credito_id })
+      .from(creditos_inversionistas_espejo)
+      .where(eq(creditos_inversionistas_espejo.inversionista_id, targetId));
+      
+    const uniqueCreditIds = new Set<number>();
+    realParticipations.forEach(r => uniqueCreditIds.add(r.credito_id));
+    mirrorParticipations.forEach(m => uniqueCreditIds.add(m.credito_id));
+    
+    const creditIds = Array.from(uniqueCreditIds);
+    
+    if (creditIds.length === 0) {
+        return {
+            success: true,
+            message: "El inversionista no tiene créditos asociados.",
+            data: []
+        };
+    }
+
+    // 2) Query principal: Detalles de créditos
+    const creditsDetails = await db
+        .select({
+            credito_id: creditos.credito_id,
+            numero_credito_sifco: creditos.numero_credito_sifco,
+            cliente: usuarios.nombre,
+        })
+        .from(creditos)
+        .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+        .where(inArray(creditos.credito_id, creditIds));
+        
+    // 3) Inversionistas Reales (para esos creditos)
+    const allRealInvestors = await db
+        .select({
+            credito_id: creditos_inversionistas.credito_id,
+            inversionista_id: creditos_inversionistas.inversionista_id,
+            nombre: inversionistas.nombre,
+            monto_aportado: creditos_inversionistas.monto_aportado,
+            porcentaje: creditos_inversionistas.porcentaje_participacion_inversionista
+        })
+        .from(creditos_inversionistas)
+        .innerJoin(inversionistas, eq(inversionistas.inversionista_id, creditos_inversionistas.inversionista_id))
+        .where(inArray(creditos_inversionistas.credito_id, creditIds));
+
+    // 4) Inversionistas Espejo (para esos creditos)
+    const allMirrorInvestors = await db
+        .select({
+            credito_id: creditos_inversionistas_espejo.credito_id,
+            inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+            nombre: inversionistas.nombre,
+            monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+            porcentaje: creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+            cuota_inversionista: creditos_inversionistas_espejo.cuota_inversionista
+        })
+        .from(creditos_inversionistas_espejo)
+        .innerJoin(inversionistas, eq(inversionistas.inversionista_id, creditos_inversionistas_espejo.inversionista_id))
+        .where(inArray(creditos_inversionistas_espejo.credito_id, creditIds));
+
+    // 5) Armar respuesta
+    const results = creditsDetails.map(c => {
+        // Filtrar arrays en memoria
+        const realForThisCredit = allRealInvestors.filter(r => r.credito_id === c.credito_id);
+        const mirrorForThisCredit = allMirrorInvestors.filter(m => m.credito_id === c.credito_id);
+        
+        return {
+            ...c,
+            inversionistas_originales: realForThisCredit,
+            inversionistas_espejos: mirrorForThisCredit
+        };
+    });
+
+    set.status = 200;
+    return {
+      success: true,
+      inversionista_consultado: targetId,
+      data: results
+    };
+
+  } catch (error) {
+    console.error("[getCreditsByInvestor] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al obtener créditos por inversionista",
       error: String(error),
     };
   }

--- a/apps/cartera-back/src/controllers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/controllers/mirrorInvestor.ts
@@ -7,7 +7,7 @@ import {
   inversionistas,
   usuarios,
 } from "../database/db";
-import { and, eq, ilike, sql } from "drizzle-orm";
+import { and, eq, ilike, sql, or, inArray } from "drizzle-orm";
 
 /** Quita tildes/acentos de un string */
 function removeAccents(str: string): string {
@@ -407,6 +407,241 @@ export const llenarTablaEspejo = async ({ body, query, set }: any) => {
     return {
       success: false,
       message: "Error al llenar tabla espejo",
+      error: String(error),
+    };
+  }
+};
+
+/**
+ * Controller: getCreditsWithMirrors
+ * 
+ * Retorna todos los créditos separados por:
+ * - con_espejo: Tienen registro en creditos_inversionistas_espejo (excluyendo inversionista_id = 86)
+ * - sin_espejo: No tienen registro (o solo tienen el 86)
+ */
+export const getCreditsWithMirrors = async ({ set }: any) => {
+  try {
+    const allCredits = await db
+      .select({
+        credito_id: creditos.credito_id,
+        numero_credito_sifco: creditos.numero_credito_sifco,
+        cliente: usuarios.nombre,
+        espejo: {
+          id: creditos_inversionistas_espejo.id,
+          inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+          monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+          cuota_inversionista: creditos_inversionistas_espejo.cuota_inversionista,
+        },
+        nombre_inversionista: inversionistas.nombre,
+        real_inversionista_id: creditos_inversionistas.inversionista_id
+      })
+      .from(creditos)
+      .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+      .leftJoin(
+        creditos_inversionistas_espejo,
+        eq(creditos.credito_id, creditos_inversionistas_espejo.credito_id)
+      )
+      .leftJoin(
+        inversionistas,
+        eq(creditos_inversionistas_espejo.inversionista_id, inversionistas.inversionista_id)
+      )
+      .leftJoin(
+        creditos_inversionistas,
+        eq(creditos.credito_id, creditos_inversionistas.credito_id)
+      );
+
+    const creditMap = new Map<number, any>();
+
+    for (const row of allCredits) {
+      if (!creditMap.has(row.credito_id)) {
+        creditMap.set(row.credito_id, {
+          credito_id: row.credito_id,
+          numero_credito_sifco: row.numero_credito_sifco,
+          cliente: row.cliente,
+          mirrors: [],
+          hasBlockedInvestor: false
+        });
+      }
+      
+      const entry = creditMap.get(row.credito_id);
+      
+      // Chequear bloqueo en el inversionista REAL
+      if (row.real_inversionista_id === 86 || row.real_inversionista_id === 89) {
+          entry.hasBlockedInvestor = true;
+      }
+      
+      // Chequear bloqueo en el inversionista ESPEJO y agregar si válido
+      if (row.espejo && row.espejo.id) {
+          if (row.espejo.inversionista_id === 86 || row.espejo.inversionista_id === 89) {
+              entry.hasBlockedInvestor = true;
+          } else {
+             // Evitar duplicados (por el left join múltiple)
+             const exists = entry.mirrors.some((m: any) => m.id === row.espejo?.id);
+             if (!exists && row.espejo) {
+                entry.mirrors.push({
+                    ...row.espejo,
+                    nombre_inversionista: row.nombre_inversionista
+                });
+             }
+          }
+      }
+    }
+
+    const conEspejo: any[] = [];
+    const sinEspejo: any[] = [];
+
+    for (const credit of creditMap.values()) {
+        const hasBlocked = credit.hasBlockedInvestor;
+        delete credit.hasBlockedInvestor;
+
+        // Si tiene algún inversionista bloqueado (86 u 89) YA SEA REAL O ESPEJO, lo omitimos TOTALMENTE.
+        if (hasBlocked) {
+            continue;
+        }
+
+        if (credit.mirrors.length > 0) {
+            conEspejo.push(credit);
+        } else {
+            delete credit.mirrors;
+            sinEspejo.push(credit);
+        }
+    }
+
+    set.status = 200;
+    return {
+      success: true,
+      con_espejo: conEspejo,
+      sin_espejo: sinEspejo
+    };
+
+  } catch (error) {
+    console.error("[getCreditsWithMirrors] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al obtener creditos con espejo",
+      error: String(error),
+    };
+  }
+};
+
+
+/**
+ * Controller: getCreditsByInvestor
+ * 
+ * Recibe query param `id` (inversionista_id).
+ * Retorna lista de créditos donde ese inversionista participa (como real o como espejo).
+ * Para cada crédito, incluye:
+ * - Datos del crédito (numero_credito_sifco, cliente)
+ * - Lista de inversionistas REALES
+ * - Lista de inversionistas ESPEJOS
+ */
+export const getCreditsByInvestor = async ({ query, set }: any) => {
+  try {
+    const { id } = query;
+    if (!id) {
+      set.status = 400;
+      return { success: false, message: "Falta el parámetro 'id' (inversionista_id)" };
+    }
+    
+    // Convertir el id a entero (si es string)
+    const targetId = Number(id);
+    if (isNaN(targetId)) {
+        set.status = 400;
+        return { success: false, message: "El ID debe ser un número válido" };
+    }
+
+    // 1) Encontrar IDs de créditos donde participa este inversionista
+    //    En la tabla REAL
+    const realParticipations = await db
+      .select({ credito_id: creditos_inversionistas.credito_id })
+      .from(creditos_inversionistas)
+      .where(eq(creditos_inversionistas.inversionista_id, targetId));
+
+    //    En la tabla ESPEJO
+    const mirrorParticipations = await db
+      .select({ credito_id: creditos_inversionistas_espejo.credito_id })
+      .from(creditos_inversionistas_espejo)
+      .where(eq(creditos_inversionistas_espejo.inversionista_id, targetId));
+      
+    const uniqueCreditIds = new Set<number>();
+    realParticipations.forEach(r => uniqueCreditIds.add(r.credito_id));
+    mirrorParticipations.forEach(m => uniqueCreditIds.add(m.credito_id));
+    
+    const creditIds = Array.from(uniqueCreditIds);
+    
+    if (creditIds.length === 0) {
+        return {
+            success: true,
+            message: "El inversionista no tiene créditos asociados.",
+            data: []
+        };
+    }
+
+    // 2) Query principal: Detalles de créditos
+    const creditsDetails = await db
+        .select({
+            credito_id: creditos.credito_id,
+            numero_credito_sifco: creditos.numero_credito_sifco,
+            cliente: usuarios.nombre,
+        })
+        .from(creditos)
+        .innerJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+        .where(inArray(creditos.credito_id, creditIds));
+        
+    // 3) Inversionistas Reales (para esos creditos)
+    const allRealInvestors = await db
+        .select({
+            credito_id: creditos_inversionistas.credito_id,
+            inversionista_id: creditos_inversionistas.inversionista_id,
+            nombre: inversionistas.nombre,
+            monto_aportado: creditos_inversionistas.monto_aportado,
+            porcentaje: creditos_inversionistas.porcentaje_participacion_inversionista
+        })
+        .from(creditos_inversionistas)
+        .innerJoin(inversionistas, eq(inversionistas.inversionista_id, creditos_inversionistas.inversionista_id))
+        .where(inArray(creditos_inversionistas.credito_id, creditIds));
+
+    // 4) Inversionistas Espejo (para esos creditos)
+    const allMirrorInvestors = await db
+        .select({
+            credito_id: creditos_inversionistas_espejo.credito_id,
+            inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+            nombre: inversionistas.nombre,
+            monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+            porcentaje: creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+            cuota_inversionista: creditos_inversionistas_espejo.cuota_inversionista
+        })
+        .from(creditos_inversionistas_espejo)
+        .innerJoin(inversionistas, eq(inversionistas.inversionista_id, creditos_inversionistas_espejo.inversionista_id))
+        .where(inArray(creditos_inversionistas_espejo.credito_id, creditIds));
+
+    // 5) Armar respuesta
+    const results = creditsDetails.map(c => {
+        // Filtrar arrays en memoria
+        const realForThisCredit = allRealInvestors.filter(r => r.credito_id === c.credito_id);
+        const mirrorForThisCredit = allMirrorInvestors.filter(m => m.credito_id === c.credito_id);
+        
+        return {
+            ...c,
+            inversionistas_originales: realForThisCredit,
+            inversionistas_espejos: mirrorForThisCredit
+        };
+    });
+
+    set.status = 200;
+    return {
+      success: true,
+      inversionista_consultado: targetId,
+      data: results
+    };
+
+  } catch (error) {
+    console.error("[getCreditsByInvestor] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al obtener créditos por inversionista",
       error: String(error),
     };
   }

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -14,6 +14,7 @@ import {
   getInvestorPerformance,
   reversePagosEspejoPorInversionista,
   getInvestorTotalsGlobales, // 🆕 NUEVO: Función para totales globales
+  getInvestorMirrorSummary,  // 🆕 NUEVO: Resumen calculado desde pagos espejo
 } from "../controllers/investor";
 import { InversionistaReporte, RespuestaReporte } from "../utils/interface";
 import puppeteer from "puppeteer";
@@ -163,6 +164,74 @@ export const inversionistasRouter = new Elysia()
         summary: "Obtiene los totales globales de un inversionista (sin paginación)",
         description: "Calcula las sumas de TODOS los créditos y pagos del inversionista, sin aplicar paginación. Útil para mostrar totales reales en el frontend.",
         tags: ["Inversionistas"],
+      },
+    }
+  )
+  .get(
+    "/getInvestorMirrorSummary",
+    /**
+     * Endpoint: GET /getInvestorMirrorSummary
+     *
+     * Devuelve los subtotales financieros de un inversionista calculados
+     * EXCLUSIVAMENTE desde la tabla `pagos_credito_inversionistas_espejo`.
+     *
+     * El campo `total_monto_aportado` se recalcula dinámicamente:
+     *   monto_aportado_base (de creditos_inversionistas_espejo)
+     *   - SUM(abono_capital de pagos_credito_inversionistas_espejo)
+     *
+     * Esto garantiza que el saldo sea consistente con el historial real de pagos.
+     *
+     * @param id              - ID del inversionista
+     * @param dpi             - DPI del inversionista (alternativa al id)
+     * @param incluirLiquidados - "true" para incluir pagos ya liquidados
+     */
+    async ({ query, set }) => {
+      const {
+        id,
+        dpi,
+        incluirLiquidados = "false",
+      } = query as Record<string, string | undefined>;
+
+      if (!id && !dpi) {
+        set.status = 400;
+        return {
+          message: "Debe proporcionar al menos 'id' o 'dpi' para buscar al inversionista.",
+        };
+      }
+
+      const incluirLiquidadosBool = incluirLiquidados === "true";
+
+      try {
+        const result = await getInvestorMirrorSummary(
+          id ? Number(id) : undefined,
+          dpi,
+          incluirLiquidadosBool
+        );
+
+        set.status = 200;
+        return result;
+      } catch (error: any) {
+        console.error("[GET /getInvestorMirrorSummary] Error:", error);
+        set.status = error.message?.includes("no encontrado") ? 404 : 500;
+        return {
+          message: error.message || "Error al calcular el resumen espejo del inversionista",
+        };
+      }
+    },
+    {
+      query: t.Object({
+        id: t.Optional(t.String()),
+        dpi: t.Optional(t.String()),
+        incluirLiquidados: t.Optional(t.String()),
+      }),
+      detail: {
+        summary: "Resumen financiero calculado desde pagos espejo",
+        description:
+          "Calcula los subtotales del inversionista (capital, interés, IVA, ISR, cuota) " +
+          "usando EXCLUSIVAMENTE los registros de `pagos_credito_inversionistas_espejo`. " +
+          "El campo `total_monto_aportado` se recalcula restando los abonos de capital " +
+          "al monto_aportado_base, sin depender del saldo guardado en `creditos_inversionistas_espejo`.",
+        tags: ["Inversionistas", "Espejos"],
       },
     }
   )

--- a/apps/cartera-back/src/routers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/routers/mirrorInvestor.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from "elysia";
-import { llenarTablaEspejo } from "../controllers/mirrorInvestor";
+import { llenarTablaEspejo, getCreditsWithMirrors, getCreditsByInvestor } from "../controllers/mirrorInvestor";
 
 export const mirrorInvestorRouter = new Elysia()
   .post("/llenar-tabla-espejo", llenarTablaEspejo, {
@@ -27,4 +27,22 @@ export const mirrorInvestorRouter = new Elysia()
         "Busca inversionista por nombre y para cada crédito (buscado por nombre de cliente) inserta/actualiza en la tabla espejo. Si no encuentra padre, omite ese crédito y lo reporta. Query param calcular_cuota=true para calcular cuota_inversionista con lógica de createCredit.",
       tags: ["Inversionistas", "Espejo"],
     },
+  })
+  .get("/creditos-espejo", getCreditsWithMirrors, {
+    detail: {
+      summary: "Obtener todos los créditos con y sin espejo",
+      description: "Devuelve dos listas: creditos con espejo (excluyendo inversionista 86) y creditos sin espejo.",
+      tags: ["Inversionistas", "Espejo"],
+    }
+  })
+  .get("/creditos-por-inversionista", getCreditsByInvestor, {
+      query: t.Object({
+          id: t.String()
+      }),
+      detail: {
+          summary: "Obtener créditos asociados a un inversionista (Real o Espejo)",
+          description: "Devuelve todos los créditos donde el ID proporcionado participa, junto con sus inversionistas originales y espejo.",
+          tags: ["Inversionistas", "Espejo"]
+      }
   });
+

--- a/apps/carteraFront/src/private/cartera/hooks/getInvestor.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/getInvestor.ts
@@ -183,7 +183,7 @@ export function useLiquidateByInvestor() {
       });
     },
     
-    onError: (error, t) => {
+    onError: (error) => {
       console.error("❌ Error al liquidar inversionista:", error);
       
       // 🔙 Rollback: restaura data anterior si falla


### PR DESCRIPTION
## feat(investor): add `getInvestorMirrorSummary` endpoint

Adds a new `GET /getInvestorMirrorSummary` endpoint that returns global financial subtotals for an investor, calculated exclusively from `pagos_credito_inversionistas_espejo`.

### Key differences vs `resumeInvestor`

- Does **not** read balances directly from `creditos_inversionistas_espejo`
- Instead, recalculates the current balance as:
  > `monto_aportado_base − SUM(abono_capital from payments)`
- This ensures the reported balance is always consistent with the actual payment history

### Response includes

- Basic investor info (`nombre`, `dpi`, `banco_id`, `tipo_cuenta`, etc.)
- Global subtotals only — no credit or payment detail arrays:
  - `total_monto_aportado` — current balance derived from payments
  - `total_capital_creditos` — sum of base investment amounts
  - `total_abono_capital` / `total_abono_interes` / `total_abono_iva`
  - `total_isr` — 7% on interest for non-billing investors
  - `total_cuota` — payout amount based on reinvestment type
  - `totalAbonoGeneralInteres`

### Query params

| Param               | Type    | Required   | Description                                            |
| ------------------- | ------- | ---------- | ------------------------------------------------------ |
| `id`                | number  | optional\* | Investor ID                                            |
| `dpi`               | string  | optional\* | Investor DPI                                           |
| `incluirLiquidados` | boolean | optional   | Include already-liquidated payments (default: `false`) |

> \* At least one of `id` or `dpi` must be provided.
