### PR TITLE
feat: Implement management and registration of investor credit mirror…

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1576,6 +1576,74 @@ export async function getInvestorTotalsGlobales(
 }
 
 // ============================================
+// upsertPagosEspejo
+// ============================================
+
+/**
+ * Recibe un array de pagos con su `id` (PK de pagos_credito_inversionistas_espejo)
+ * y actualiza los campos financieros de cada uno.
+ *
+ * Validación previa: verifica que todos los ids existan en la BD antes de
+ * hacer cualquier UPDATE. Si alguno no existe, lanza un error descriptivo.
+ *
+ * No toca ninguna otra tabla.
+ *
+ * @param pagos - Array de pagos a actualizar (deben existir en la BD)
+ */
+export async function upsertPagosEspejo(
+  pagos: {
+    id: number;
+    abono_capital: string;
+    abono_interes: string;
+    abono_iva_12: string;
+    porcentaje_participacion: string;
+    cuota: string;
+    estado_liquidacion?: "NO_LIQUIDADO" | "LIQUIDADO";
+  }[]
+) {
+  if (pagos.length === 0) {
+    return { actualizados: 0 };
+  }
+
+  // ── PASO 1: Validar que todos los ids existen ────────────────────────────────
+  const ids = pagos.map((p) => p.id);
+
+  const encontrados = await db
+    .select({ id: pagos_credito_inversionistas_espejo.id })
+    .from(pagos_credito_inversionistas_espejo)
+    .where(inArray(pagos_credito_inversionistas_espejo.id, ids));
+
+  const idsEncontrados = new Set(encontrados.map((r) => r.id));
+  const idsNoEncontrados = ids.filter((id) => !idsEncontrados.has(id));
+
+  if (idsNoEncontrados.length > 0) {
+    throw new Error(
+      `Los siguientes ids no existen en pagos_credito_inversionistas_espejo: [${idsNoEncontrados.join(", ")}]`
+    );
+  }
+
+  // ── PASO 2: UPDATE por id para cada pago ────────────────────────────────────
+  await Promise.all(
+    pagos.map((p) =>
+      db
+        .update(pagos_credito_inversionistas_espejo)
+        .set({
+          abono_capital:            p.abono_capital,
+          abono_interes:            p.abono_interes,
+          abono_iva_12:             p.abono_iva_12,
+          porcentaje_participacion: p.porcentaje_participacion,
+          cuota:                    p.cuota,
+          ...(p.estado_liquidacion && { estado_liquidacion: p.estado_liquidacion }),
+        })
+        .where(eq(pagos_credito_inversionistas_espejo.id, p.id))
+    )
+  );
+
+  console.log(`[upsertPagosEspejo] ${pagos.length} registro(s) actualizados.`);
+  return { actualizados: pagos.length };
+}
+
+// ============================================
 // getInvestorMirrorSummary
 // ============================================
 

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -312,7 +312,8 @@ export async function insertPagosCreditoInversionistas(
   pago_id: number,
   credito_id: number,
   excludeCube: boolean = false,
-  cuotaPagada:boolean = false
+  cuotaPagada: boolean = false,
+  updateCredito: boolean = true  // si false, omite el UPDATE a creditos_inversionistas_espejo
 ) {
   console.log(
     "\n🔍 ========== INICIO insertPagosCreditoInversionistas =========="
@@ -504,19 +505,23 @@ export async function insertPagosCreditoInversionistas(
       );
     }
 
-    console.log(`\n   🔄 Llamando a processAndReplaceCreditInvestors:`);
-    console.log(`      credito_id: ${credito_id}`);
-    console.log(`      abono_capital: ${abono_capital.toNumber()}`);
-    console.log(`      addition: false (RESTA)`);
-    console.log(`      inversionista_id: ${inv.inversionista_id}`);
+    if (updateCredito) {
+      console.log(`\n   🔄 Llamando a processAndReplaceCreditInvestors:`);
+      console.log(`      credito_id: ${credito_id}`);
+      console.log(`      abono_capital: ${abono_capital.toNumber()}`);
+      console.log(`      addition: false (RESTA)`);
+      console.log(`      inversionista_id: ${inv.inversionista_id}`);
 
-   await processAndReplaceCreditInvestors(
-      credito_id,
-      abono_capital.toNumber(),
-      false,
-      inv.inversionista_id,
-      true
-    );
+      await processAndReplaceCreditInvestors(
+        credito_id,
+        abono_capital.toNumber(),
+        false,
+        inv.inversionista_id,
+        true
+      );
+    } else {
+      console.log(`\n   ⏭️  updateCredito=false → omitiendo UPDATE a creditos_inversionistas_espejo`);
+    }
 
     console.log(`   📊 Porcentajes:`);
     console.log(`      porcentaje_cash_in: ${inv.porcentaje_cash_in}`);
@@ -1779,4 +1784,201 @@ export async function obtenerCreditosConPagosPendientes(
     };
   }
 }
- 
+
+// ============================================================
+// calcularYRegistrarPagosEspejo
+// ============================================================
+
+/**
+ * Calcula y registra los pagos espejo de un inversionista SIN actualizar
+ * `creditos_inversionistas_espejo`.
+ *
+ * Diferencia clave vs `obtenerCreditosConPagosPendientes` con generateFalsePayment=true:
+ *  - Llama a `insertPagosCreditoInversionistas` con `updateCredito = false`
+ *    → Solo hace el upsert en `pagos_credito_inversionistas_espejo`
+ *    → NO toca `creditos_inversionistas_espejo`
+ *  - Sí marca la cuota como `liquidado_inversionistas = true` en `cuotas_credito`
+ *    para evitar reprocesar la misma cuota en ejecuciones futuras.
+ *
+ * @param inversionistaId - ID del inversionista a procesar
+ */
+export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
+  try {
+    const rangoMesActual = obtenerRangoMesActual();
+    console.log(
+      `\n🚀 [calcularYRegistrarPagosEspejo] Iniciando para inversionista ${inversionistaId}`
+    );
+    console.log(
+      `📆 Mes actual: ${rangoMesActual.inicio} - ${rangoMesActual.fin}`
+    );
+
+    // ── PASO 1: Obtener créditos espejo del inversionista (ACTIVO/MOROSO/etc.) ──
+    const creditosInversionista = await db
+      .select({
+        creditoId: creditos_inversionistas_espejo.credito_id,
+        inversionistaId: creditos_inversionistas_espejo.inversionista_id,
+        montoAportado: creditos_inversionistas_espejo.monto_aportado,
+        porcentajeParticipacion:
+          creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+        numeroCreditoSifco: creditos.numero_credito_sifco,
+        capital: creditos.capital,
+        deudaTotal: creditos.deudatotal,
+        statusCredit: creditos.statusCredit,
+        cuota: creditos.cuota,
+      })
+      .from(creditos_inversionistas_espejo)
+      .innerJoin(
+        creditos,
+        eq(creditos_inversionistas_espejo.credito_id, creditos.credito_id)
+      )
+      .where(
+        and(
+          eq(creditos_inversionistas_espejo.inversionista_id, inversionistaId),
+          inArray(creditos.statusCredit, [
+            "ACTIVO",
+            "MOROSO",
+            "PENDIENTE_CANCELACION",
+            "EN_CONVENIO",
+          ])
+        )
+      );
+
+    console.log(
+      `📊 Créditos encontrados: ${creditosInversionista.length}`
+    );
+
+    // ── PASO 2: Por cada crédito, buscar la primera cuota NO liquidada ──────────
+    const resultados = await Promise.all(
+      creditosInversionista.map(async (credito) => {
+        console.log(
+          `\n🔍 Verificando crédito ${credito.creditoId}...`
+        );
+
+        // Saltar si ya tiene pagos NO_LIQUIDADO en la tabla espejo
+        const pagosPendientes = await db
+          .select()
+          .from(pagos_credito_inversionistas_espejo)
+          .where(
+            and(
+              eq(
+                pagos_credito_inversionistas_espejo.credito_id,
+                credito.creditoId
+              ),
+              eq(
+                pagos_credito_inversionistas_espejo.inversionista_id,
+                inversionistaId
+              ),
+              eq(
+                pagos_credito_inversionistas_espejo.estado_liquidacion,
+                "NO_LIQUIDADO"
+              )
+            )
+          );
+
+        if (pagosPendientes.length > 0) {
+          console.log(
+            `⚠️  Crédito ${credito.creditoId} tiene ${pagosPendientes.length} pago(s) NO_LIQUIDADO → se omite`
+          );
+          return null;
+        }
+
+        // Buscar la primera cuota NO liquidada con sus pagos
+        const cuotaConPagos = await db
+          .select({
+            cuotaId: cuotas_credito.cuota_id,
+            numeroCuota: cuotas_credito.numero_cuota,
+            fechaVencimiento: cuotas_credito.fecha_vencimiento,
+            pagadoCuota: cuotas_credito.pagado,
+            liquidadoInversionistas: cuotas_credito.liquidado_inversionistas,
+            pagoId: pagos_credito.pago_id,
+            fechaPago: pagos_credito.fecha_pago,
+            montoBoleta: pagos_credito.monto_boleta,
+            abonoCapital: pagos_credito.abono_capital,
+            abonoInteres: pagos_credito.abono_interes,
+            abonoIva: pagos_credito.abono_iva_12,
+            validationStatus: pagos_credito.validationStatus,
+          })
+          .from(cuotas_credito)
+          .innerJoin(
+            pagos_credito,
+            eq(cuotas_credito.cuota_id, pagos_credito.cuota_id)
+          )
+          .where(
+            and(
+              eq(cuotas_credito.credito_id, credito.creditoId),
+              eq(cuotas_credito.liquidado_inversionistas, false)
+            )
+          )
+          .orderBy(cuotas_credito.numero_cuota, pagos_credito.fecha_pago);
+
+        if (cuotaConPagos.length === 0) {
+          console.log(
+            `⚠️  Crédito ${credito.creditoId}: sin cuotas pendientes con pagos`
+          );
+          return null;
+        }
+
+        const primeraFila = cuotaConPagos[0];
+        const { numeroCuota, cuotaId } = primeraFila;
+        const pagosDeLaCuota = cuotaConPagos.filter(
+          (r) => r.numeroCuota === numeroCuota
+        );
+
+        console.log(
+          `✅ Crédito ${credito.creditoId}, Cuota ${numeroCuota}: ${pagosDeLaCuota.length} pago(s) → procesando...`
+        );
+
+        // ── PASO 3: Upsert en pagos_credito_inversionistas_espejo ──────────────
+        // updateCredito = false → NO toca creditos_inversionistas_espejo
+        // NO se toca cuotas_credito → endpoint de solo escritura en pagos
+        try {
+          await insertPagosCreditoInversionistas(
+            pagosDeLaCuota[0].pagoId,
+            credito.creditoId,
+            false,  // excludeCube
+            false,  // cuotaPagada
+            false   // updateCredito ← omite el UPDATE a creditos_inversionistas_espejo
+          );
+
+          console.log(
+            `  ✅ Upsert completado para crédito ${credito.creditoId}, cuota ${numeroCuota}`
+          );
+
+          return {
+            creditoId: credito.creditoId,
+            numeroCreditoSifco: credito.numeroCreditoSifco,
+            cuotaProcesada: numeroCuota,
+            pagosRegistrados: pagosDeLaCuota.length,
+          };
+        } catch (err) {
+          console.error(
+            `  ❌ Error procesando crédito ${credito.creditoId}:`,
+            err
+          );
+          return null;
+        }
+      })
+    );
+
+    const procesados = resultados.filter((r) => r !== null);
+
+    console.log(
+      `\n✅ [calcularYRegistrarPagosEspejo] Completado. Créditos procesados: ${procesados.length}`
+    );
+
+    return {
+      success: true,
+      inversionistaId,
+      totalCreditosProcesados: procesados.length,
+      pagosGenerados: true,
+      data: procesados,
+    };
+  } catch (error: any) {
+    console.error("❌ Error en calcularYRegistrarPagosEspejo:", error);
+    return {
+      success: false,
+      error: error.message,
+      data: [],
+    };
+  }
+}

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -13,14 +13,15 @@ import {
   getLiquidaciones,
   getInvestorPerformance,
   reversePagosEspejoPorInversionista,
-  getInvestorTotalsGlobales, // 🆕 NUEVO: Función para totales globales
-  getInvestorMirrorSummary,  // 🆕 NUEVO: Resumen calculado desde pagos espejo
+  getInvestorTotalsGlobales,
+  getInvestorMirrorSummary,
+  upsertPagosEspejo,             // 🆕 Recalcular pagos espejo desde el front
 } from "../controllers/investor";
 import { InversionistaReporte, RespuestaReporte } from "../utils/interface";
 import puppeteer from "puppeteer";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { authMiddleware } from "./midleware";
-import { obtenerCreditosConPagosPendientes } from "../controllers/payments";
+import { obtenerCreditosConPagosPendientes, calcularYRegistrarPagosEspejo } from "../controllers/payments";
 import { createBoleta, getBoletaById, getAllBoletas, getBoletasPendientes, updateBoleta, marcarBoletaComoProcesada, marcarBoletaComoPendiente, deleteBoleta, getBoletasStats } from "../controllers/liquidateInvestor";
 // 🔥 IMPORTAR SERVICIO DE BOLETAS
  
@@ -914,6 +915,136 @@ export const inversionistasRouter = new Elysia()
       detail: {
         summary: "Obtener estadísticas de boletas",
         tags: ["Boletas"],
+      },
+    }
+  )
+  .post(
+    "/calcularPagosEspejo",
+    async ({ body, set }) => {
+      try {
+        const { inversionistaId } = body;
+
+        console.log(
+          `\n🚀 POST /calcularPagosEspejo → inversionistaId: ${inversionistaId}`
+        );
+
+        const resultado = await calcularYRegistrarPagosEspejo(inversionistaId);
+
+        if (!resultado.success) {
+          set.status = 500;
+          return {
+            success: false as const,
+            error: (resultado as any).error ?? "Error desconocido",
+          };
+        }
+
+        set.status = 200;
+        return {
+          success: true as const,
+          message: `✅ Pagos espejo calculados y registrados correctamente`,
+          inversionistaId: resultado.inversionistaId ?? inversionistaId,
+          totalCreditosProcesados: resultado.totalCreditosProcesados ?? 0,
+          data: resultado.data,
+        };
+      } catch (error: any) {
+        console.error("❌ Error en POST /calcularPagosEspejo:", error);
+        set.status = 500;
+        return {
+          success: false as const,
+          error: error.message || "Error al calcular pagos espejo",
+        };
+      }
+    },
+    {
+      detail: {
+        summary:
+          "Calcula y registra pagos espejo sin actualizar creditos_inversionistas_espejo",
+        description:
+          "Replica la lógica de /generateFalsePayments pero omite el UPDATE a creditos_inversionistas_espejo. Solo hace upsert en pagos_credito_inversionistas_espejo y marca las cuotas como liquidadas.",
+        tags: ["Pagos Espejo"],
+      },
+      body: t.Object({
+        inversionistaId: t.Number({
+          description: "ID del inversionista a procesar",
+          minimum: 1,
+        }),
+      }),
+      response: {
+        200: t.Object({
+          success: t.Literal(true),
+          message: t.String(),
+          inversionistaId: t.Number(),
+          totalCreditosProcesados: t.Number(),
+          data: t.Array(t.Any()),
+        }),
+        500: t.Object({
+          success: t.Literal(false),
+          error: t.String(),
+        }),
+      },
+    }
+  )
+  .post(
+    "/recalcularPagosEspejo",
+    async ({ body, set }) => {
+      try {
+        const { pagos } = body;
+
+        console.log(
+          `\n🔄 POST /recalcularPagosEspejo → ${pagos.length} pago(s) recibidos`
+        );
+
+        const resultado = await upsertPagosEspejo(pagos);
+
+        set.status = 200;
+        return {
+          success: true as const,
+          message: `✅ ${resultado.actualizados} pago(s) actualizados correctamente`,
+          actualizados: resultado.actualizados,
+        };
+      } catch (error: any) {
+        console.error("❌ Error en POST /recalcularPagosEspejo:", error);
+        set.status = 500;
+        return {
+          success: false as const,
+          error: error.message || "Error al recalcular pagos espejo",
+        };
+      }
+    },
+    {
+      detail: {
+        summary: "Recalcular pagos espejo desde el frontend",
+        description:
+          "Recibe un array de pagos (con su id PK) y actualiza los campos financieros en pagos_credito_inversionistas_espejo. " +
+          "Valida que todos los ids existan antes de hacer cualquier UPDATE. No toca ninguna otra tabla.",
+        tags: ["Pagos Espejo"],
+      },
+      body: t.Object({
+        pagos: t.Array(
+          t.Object({
+            id:                       t.Number({ description: "PK de pagos_credito_inversionistas_espejo" }),
+            abono_capital:            t.String(),
+            abono_interes:            t.String(),
+            abono_iva_12:             t.String(),
+            porcentaje_participacion: t.String(),
+            cuota:                    t.String(),
+            estado_liquidacion:       t.Optional(
+              t.Union([t.Literal("NO_LIQUIDADO"), t.Literal("LIQUIDADO")])
+            ),
+          }),
+          { minItems: 1, description: "Array de pagos espejo a actualizar (deben existir en la BD)" }
+        ),
+      }),
+      response: {
+        200: t.Object({
+          success: t.Literal(true),
+          message: t.String(),
+          actualizados: t.Number(),
+        }),
+        500: t.Object({
+          success: t.Literal(false),
+          error: t.String(),
+        }),
       },
     }
   );


### PR DESCRIPTION
## feat(investor): add `POST /calcularPagosEspejo` and `POST /recalcularPagosEspejo` endpoints

Adds two new POST endpoints for managing mirror payment records in `pagos_credito_inversionistas_espejo`.

---

### `POST /calcularPagosEspejo`

Calculates and registers mirror payments for a given investor, replicating the logic of `/generateFalsePayments` but with a key restriction: **it does not update `creditos_inversionistas_espejo`**.

**Body:**

```json
{
  "inversionistaId": 9
}
```

**Behavior:**

- Fetches all active mirror credits for the investor (`ACTIVO`, `MOROSO`, `PENDIENTE_CANCELACION`, `EN_CONVENIO`)
- For each credit, finds the first unpaid quota with payments
- Calls `insertPagosCreditoInversionistas` with `updateCredito = false` → only performs upsert in `pagos_credito_inversionistas_espejo`
- Does **not** touch `creditos_inversionistas_espejo` or `cuotas_credito`
- Fully **idempotent** — safe to run multiple times; upsert overwrites existing records

**Tables affected:** `pagos_credito_inversionistas_espejo` only

**Response (200):**

```json
{
  "success": true,
  "message": "✅ Pagos espejo calculados y registrados correctamente",
  "inversionistaId": 9,
  "totalCreditosProcesados": 3,
  "data": [
    {
      "creditoId": 101,
      "numeroCreditoSifco": "CR-2024-001",
      "cuotaProcesada": 5,
      "pagosRegistrados": 1
    }
  ]
}
```

---

### `POST /recalcularPagosEspejo`

Receives an array of existing payment records (identified by their `id` PK) and updates their financial fields directly.

**Body:**

```json
{
  "pagos": [
    {
      "id": 42,
      "abono_capital": "1500.00",
      "abono_interes": "200.00",
      "abono_iva_12": "24.00",
      "porcentaje_participacion": "50.00",
      "cuota": "1724.00",
      "estado_liquidacion": "NO_LIQUIDADO"
    }
  ]
}
```

**Behavior:**

- Validates that **all provided `id`s exist** in `pagos_credito_inversionistas_espejo` before making any changes
- If any `id` is not found → returns a descriptive error listing the missing ids, without touching anything
- If all ids exist → performs parallel `UPDATE` by `id` for each record
- Does **not** touch any other table

**Tables affected:** `pagos_credito_inversionistas_espejo` only

**Response (200):**

```json
{
  "success": true,
  "message": "✅ 1 pago(s) actualizados correctamente",
  "actualizados": 1
}
```

---

### Supporting changes

- **`insertPagosCreditoInversionistas`** (`payments.ts`): Added `updateCredito: boolean = true` parameter (5th arg). When `false`, skips the `UPDATE` to `creditos_inversionistas_espejo`. Fully backwards-compatible — all existing callers are unaffected.
- **`upsertPagosEspejo`** (`investor.ts`): New controller function backing `/recalcularPagosEspejo`.
- **`calcularYRegistrarPagosEspejo`** (`payments.ts`): New controller function backing `/calcularPagosEspejo`.
