### PR TITLE
fix: mostrar verificación de dirección en cotizador sobre vehículo

### DIFF
--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -1756,28 +1756,26 @@ export function CreditDetailView({
 														: "Q -"}
 												</TableCell>
 											</TableRow>
-											{isAutocompra && (
-												<TableRow>
-													<TableCell>Verificación de dirección</TableCell>
-													<TableCell className="text-center">
-														<Badge
-															variant={
-																verificacionDireccion > 0
-																	? "default"
-																	: "outline"
-															}
-															className="text-xs"
-														>
-															{verificacionDireccion > 0 ? "SI" : "NO"}
-														</Badge>
-													</TableCell>
-													<TableCell className="text-right">
-														{verificacionDireccion > 0
-															? formatCurrency(verificacionDireccion)
-															: "Q -"}
-													</TableCell>
-												</TableRow>
-											)}
+											<TableRow>
+												<TableCell>Verificación de dirección</TableCell>
+												<TableCell className="text-center">
+													<Badge
+														variant={
+															verificacionDireccion > 0
+																? "default"
+																: "outline"
+														}
+														className="text-xs"
+													>
+														{verificacionDireccion > 0 ? "SI" : "NO"}
+													</Badge>
+												</TableCell>
+												<TableCell className="text-right">
+													{verificacionDireccion > 0
+														? formatCurrency(verificacionDireccion)
+														: "Q -"}
+												</TableCell>
+											</TableRow>
 											<TableRow>
 												<TableCell>Impuesto circulación</TableCell>
 												<TableCell className="text-center">

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -285,7 +285,7 @@ const EXTRA_COST_FIELDS: ExtraCostFieldConfig[] = [
 		label: "Verificación de dirección",
 		type: "fixed",
 		valueField: "addressVerificationCost",
-		creditType: "autocompra",
+		creditType: "all",
 		section: "otros",
 		defaultActive: true,
 		defaultValue: 395,
@@ -1454,10 +1454,6 @@ function QuoterPage() {
 															quoterForm.setFieldValue("appointmentCost", 150);
 															quoterForm.setFieldValue("interestRate", 1.5);
 														} else {
-															quoterForm.setFieldValue(
-																"addressVerificationCost",
-																0,
-															);
 															quoterForm.setFieldValue("appointmentCost", 0);
 															quoterForm.setFieldValue("interestRate", 3);
 															// En sobre vehículo no hay enganche, limpiar


### PR DESCRIPTION
## Summary
- Habilita el campo "Verificación de dirección" (Q395) en el cotizador para créditos de tipo **sobre vehículo**, que antes solo aparecía para autocompra
- Elimina el reset del valor a 0 al cambiar a sobre vehículo
- Muestra la fila en la tabla de Otros Descuentos del detalle de crédito para ambos tipos

## Test plan
- [ ] Crear cotización de tipo sobre vehículo y verificar que aparece el campo "Verificación de dirección" con valor Q395
- [ ] Crear cotización de tipo autocompra y verificar que sigue apareciendo el campo con Q395
- [ ] Verificar que en el detalle de crédito (CreditDetailView) se muestra la fila para ambos tipos
- [ ] Verificar que el cálculo de gastos administrativos incluye correctamente el costo de verificación

🤖 Generated with [Claude Code](https://claude.com/claude-code)