### PR TITLE
fix: cotizador sobre vehículo - verificación dirección y fórmulas

### DIFF
--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -80,40 +80,7 @@ export const Route = createFileRoute("/crm/quoter")({
 	component: QuoterPage,
 });
 
-/** IVA de Guatemala (12%) */
-const IVA_FACTOR = 1.12;
-
-/** Tasa de interés fija para autocompra usada en el cálculo de intereses del detalle */
-const AUTOCOMPRA_INTEREST_RATE = 0.0178;
-
-/** Gastos administrativos fijos para sobre vehículo */
-const FIXED_ADMIN_COST = 600;
-
-/** Garantía mobiliaria */
-const GARANTIA_MOBILIARIA = 400;
-
-/** Contrato leasing */
-const CONTRATO_LEASING = 400;
-
-// Función para calcular cuota mensual (según Excel)
-function calculateMonthlyPayment(
-	principal: number,
-	monthlyRate: number,
-	termMonths: number,
-	insuranceCost: number,
-	gpsCost: number,
-): number {
-	// La tasa incluye IVA (12%)
-	const r = (monthlyRate / 100) * IVA_FACTOR;
-
-	if (r === 0) return principal / termMonths;
-
-	const factor = (1 + r) ** termMonths;
-	const baseMonthlyPayment = (principal * (r * factor)) / (factor - 1);
-
-	// Agregar seguro y GPS a la cuota mensual
-	return Math.round((baseMonthlyPayment + insuranceCost + gpsCost) * 100) / 100;
-}
+import { calculateQuotation, GPS_COST } from "@/utils/quoter-calculations";
 
 // Tipo para los valores del formulario de cotización
 interface QuotationFormValues {
@@ -705,9 +672,6 @@ function ExtraCostsTable({
 	);
 }
 
-/** Costo fijo del GPS (se resta de la membresía cruda para obtener la neta) */
-const GPS_COST = 148.2;
-
 function QuoterPage() {
 	const { data: session } = authClient.useSession();
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
@@ -997,100 +961,37 @@ function QuoterPage() {
 	// Función para recalcular cuando cambian los valores (según Excel)
 	const recalculate = () => {
 		const values = quoterForm.state.values;
-		const isSobreVehiculo = values.creditType === "sobre_vehiculo";
 
-		// En sobre vehículo: el "downPayment" field se usa como "monto solicitado" directo
-		// En autocompra: monto a financiar = valor del vehículo - enganche
-		const amountToFinance = isSobreVehiculo
-			? Number(values.downPayment) // downPayment field = monto solicitado
-			: Number(values.vehicleValue) - Number(values.downPayment);
-		const insuranceCost = Number(values.insuranceCost);
-		const gpsCost = Number(values.gpsCost);
-		const transferCost = Number(values.transferCost);
-		const royaltyPercentage = Number(values.royaltyPercentage) || 4.0;
-		const rcdpCost = Number(values.rcdpCost);
+		const result = calculateQuotation({
+			creditType: values.creditType,
+			vehicleValue: Number(values.vehicleValue),
+			downPayment: Number(values.downPayment),
+			interestRate: Number(values.interestRate),
+			termMonths: Number(values.termMonths),
+			insuranceCost: Number(values.insuranceCost),
+			gpsCost: Number(values.gpsCost),
+			transferCost: Number(values.transferCost),
+			royaltyPercentage: Number(values.royaltyPercentage),
+			rcdpCost: Number(values.rcdpCost),
+		});
 
-		let calculatedRoyalty: number;
-		let calculatedInterest: number;
-		let adminCost: number;
-		let totalFinanced: number;
-
-		if (isSobreVehiculo) {
-			// Sobre vehículo: cálculos sobre el monto solicitado directamente
-			// Royalty = % del monto solicitado
-			calculatedRoyalty = Math.ceil(
-				amountToFinance * (royaltyPercentage / 100),
-			);
-
-			// Intereses = monto solicitado × tasa × IVA
-			const interestRate = Number(values.interestRate) / 100;
-			calculatedInterest =
-				Math.round(amountToFinance * interestRate * IVA_FACTOR * 100) / 100;
-
-			// Gastos administrativos fijos
-			adminCost = FIXED_ADMIN_COST;
-
-			// Total financiado = monto solicitado (los gastos se descuentan del desembolso)
-			totalFinanced = amountToFinance;
-		} else {
-			// Autocompra: cálculos sobre B22
-			// B22 = Monto a financiar + Traspaso + Garantía + Leasing + Admin fijo + GPS + Seguro
-			const b22 =
-				amountToFinance +
-				transferCost +
-				GARANTIA_MOBILIARIA +
-				CONTRATO_LEASING +
-				FIXED_ADMIN_COST +
-				gpsCost +
-				insuranceCost;
-
-			// Royalty = % de B22 redondeado hacia arriba
-			calculatedRoyalty = Math.ceil(b22 * (royaltyPercentage / 100));
-
-			// Interés = ROUNDUP(B22 * tasa autocompra) + RCDP (para microbuses)
-			calculatedInterest =
-				Math.ceil(b22 * AUTOCOMPRA_INTEREST_RATE) + rcdpCost;
-
-			// Gastos Admin = Garantía + Royalty + Leasing + Admin fijo + Intereses + GPS + Seguro
-			const extraCost = calculatedInterest + gpsCost + insuranceCost;
-			adminCost =
-				GARANTIA_MOBILIARIA +
-				calculatedRoyalty +
-				CONTRATO_LEASING +
-				FIXED_ADMIN_COST +
-				extraCost;
-
-			// Total financiado = monto a financiar + costos financiados
-			const financedCosts = transferCost + adminCost;
-			totalFinanced = amountToFinance + financedCosts;
-		}
-
-		quoterForm.setFieldValue("royalty", calculatedRoyalty);
-		quoterForm.setFieldValue("interestCost", calculatedInterest);
-		quoterForm.setFieldValue("adminCost", Math.round(adminCost * 100) / 100);
+		quoterForm.setFieldValue("royalty", result.calculatedRoyalty);
+		quoterForm.setFieldValue("interestCost", result.calculatedInterest);
+		quoterForm.setFieldValue("adminCost", result.adminCost);
 
 		// Nota: extraInsuranceCost y extraMembershipCost se calculan en updateInsuranceCost()
 		// para que sean editables y no se sobrescriban en cada recálculo
 
-		// La cuota mensual incluye seguro y GPS aparte
-		const monthlyPayment = calculateMonthlyPayment(
-			totalFinanced,
-			Number(values.interestRate),
-			Number(values.termMonths),
-			insuranceCost,
-			gpsCost,
-		);
-
 		setCalculatedValues({
-			amountToFinance,
-			totalFinanced,
-			monthlyPayment,
+			amountToFinance: result.amountToFinance,
+			totalFinanced: result.totalFinanced,
+			monthlyPayment: result.monthlyPayment,
 		});
 
 		// Generar tabla de amortización si hay valores
-		if (totalFinanced > 0 && monthlyPayment > 0) {
+		if (result.totalFinanced > 0 && result.monthlyPayment > 0) {
 			const table = generateAmortizationTable(
-				totalFinanced,
+				result.totalFinanced,
 				Number(values.interestRate),
 				Number(values.termMonths),
 			);

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -992,44 +992,64 @@ function QuoterPage() {
 		const insuranceCost = Number(values.insuranceCost);
 		const gpsCost = Number(values.gpsCost);
 		const transferCost = Number(values.transferCost);
-		const membershipCost = Number(values.membershipCost);
-
-		// Calcular B22 según Excel
-		// B22 = Monto a financiar + Traspaso + 400 + 400 + 600 + GPS + Seguro
-		const b22 =
-			amountToFinance +
-			transferCost +
-			400 +
-			400 +
-			600 +
-			gpsCost +
-			insuranceCost;
-
-		// Royalty = 4% de B22 redondeado hacia arriba
 		const royaltyPercentage = Number(values.royaltyPercentage) || 4.0;
-		const calculatedRoyalty = Math.ceil(b22 * (royaltyPercentage / 100));
-		quoterForm.setFieldValue("royalty", calculatedRoyalty);
-
-		// Interés = ROUNDUP(B22 * 1.78%) + RCDP (para microbuses)
 		const rcdpCost = Number(values.rcdpCost);
-		const calculatedInterest = Math.ceil(b22 * 0.0178) + rcdpCost;
+
+		let calculatedRoyalty: number;
+		let calculatedInterest: number;
+		let adminCost: number;
+		let totalFinanced: number;
+
+		if (isSobreVehiculo) {
+			// Sobre vehículo: cálculos sobre el monto solicitado directamente
+			// Royalty = % del monto solicitado
+			calculatedRoyalty = Math.ceil(
+				amountToFinance * (royaltyPercentage / 100),
+			);
+
+			// Intereses = monto solicitado × tasa × 1.12 (IVA)
+			const interestRate = Number(values.interestRate) / 100;
+			calculatedInterest =
+				Math.round(amountToFinance * interestRate * 1.12 * 100) / 100;
+
+			// Gastos administrativos = Q600 fijo
+			adminCost = 600;
+
+			// Total financiado = monto solicitado (los gastos se descuentan del desembolso)
+			totalFinanced = amountToFinance;
+		} else {
+			// Autocompra: cálculos sobre B22
+			// B22 = Monto a financiar + Traspaso + 400 + 400 + 600 + GPS + Seguro
+			const b22 =
+				amountToFinance +
+				transferCost +
+				400 +
+				400 +
+				600 +
+				gpsCost +
+				insuranceCost;
+
+			// Royalty = % de B22 redondeado hacia arriba
+			calculatedRoyalty = Math.ceil(b22 * (royaltyPercentage / 100));
+
+			// Interés = ROUNDUP(B22 * 1.78%) + RCDP (para microbuses)
+			calculatedInterest = Math.ceil(b22 * 0.0178) + rcdpCost;
+
+			// Gastos Admin = 400 + Royalty + 400 + 600 + Intereses(incluye RCDP) + GPS + Seguro
+			const extraCost = calculatedInterest + gpsCost + insuranceCost;
+			adminCost = 400 + calculatedRoyalty + 400 + 600 + extraCost;
+
+			// Total financiado = monto a financiar + costos financiados
+			const financedCosts = transferCost + adminCost;
+			totalFinanced = amountToFinance + financedCosts;
+		}
+
+		quoterForm.setFieldValue("royalty", calculatedRoyalty);
 		quoterForm.setFieldValue("interestCost", calculatedInterest);
+		quoterForm.setFieldValue("adminCost", Math.round(adminCost * 100) / 100);
 
 		// Nota: extraInsuranceCost y extraMembershipCost se calculan en updateInsuranceCost()
 		// para que sean editables y no se sobrescriban en cada recálculo
-
-		// Gastos Admin = 400 + Royalty + 400 + 600 + Intereses(incluye RCDP) + GPS + Seguro
-		const extraCost = calculatedInterest + gpsCost + insuranceCost;
-		const adminCost = 400 + calculatedRoyalty + 400 + 600 + extraCost;
-
-		// Actualizar el campo de gastos administrativos
-		quoterForm.setFieldValue("adminCost", Math.round(adminCost * 100) / 100);
-
-		// Costos que se financian (NO incluyen seguro ni GPS)
-		// La membresía ya está incluida en adminCost, no se debe agregar de nuevo
-		const financedCosts = transferCost + adminCost;
-
-		const totalFinanced = amountToFinance + financedCosts;
 
 		// La cuota mensual incluye seguro y GPS aparte
 		const monthlyPayment = calculateMonthlyPayment(

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -80,6 +80,21 @@ export const Route = createFileRoute("/crm/quoter")({
 	component: QuoterPage,
 });
 
+/** IVA de Guatemala (12%) */
+const IVA_FACTOR = 1.12;
+
+/** Tasa de interés fija para autocompra usada en el cálculo de intereses del detalle */
+const AUTOCOMPRA_INTEREST_RATE = 0.0178;
+
+/** Gastos administrativos fijos para sobre vehículo */
+const FIXED_ADMIN_COST = 600;
+
+/** Garantía mobiliaria */
+const GARANTIA_MOBILIARIA = 400;
+
+/** Contrato leasing */
+const CONTRATO_LEASING = 400;
+
 // Función para calcular cuota mensual (según Excel)
 function calculateMonthlyPayment(
 	principal: number,
@@ -89,7 +104,7 @@ function calculateMonthlyPayment(
 	gpsCost: number,
 ): number {
 	// La tasa incluye IVA (12%)
-	const r = (monthlyRate / 100) * 1.12;
+	const r = (monthlyRate / 100) * IVA_FACTOR;
 
 	if (r === 0) return principal / termMonths;
 
@@ -1007,37 +1022,43 @@ function QuoterPage() {
 				amountToFinance * (royaltyPercentage / 100),
 			);
 
-			// Intereses = monto solicitado × tasa × 1.12 (IVA)
+			// Intereses = monto solicitado × tasa × IVA
 			const interestRate = Number(values.interestRate) / 100;
 			calculatedInterest =
-				Math.round(amountToFinance * interestRate * 1.12 * 100) / 100;
+				Math.round(amountToFinance * interestRate * IVA_FACTOR * 100) / 100;
 
-			// Gastos administrativos = Q600 fijo
-			adminCost = 600;
+			// Gastos administrativos fijos
+			adminCost = FIXED_ADMIN_COST;
 
 			// Total financiado = monto solicitado (los gastos se descuentan del desembolso)
 			totalFinanced = amountToFinance;
 		} else {
 			// Autocompra: cálculos sobre B22
-			// B22 = Monto a financiar + Traspaso + 400 + 400 + 600 + GPS + Seguro
+			// B22 = Monto a financiar + Traspaso + Garantía + Leasing + Admin fijo + GPS + Seguro
 			const b22 =
 				amountToFinance +
 				transferCost +
-				400 +
-				400 +
-				600 +
+				GARANTIA_MOBILIARIA +
+				CONTRATO_LEASING +
+				FIXED_ADMIN_COST +
 				gpsCost +
 				insuranceCost;
 
 			// Royalty = % de B22 redondeado hacia arriba
 			calculatedRoyalty = Math.ceil(b22 * (royaltyPercentage / 100));
 
-			// Interés = ROUNDUP(B22 * 1.78%) + RCDP (para microbuses)
-			calculatedInterest = Math.ceil(b22 * 0.0178) + rcdpCost;
+			// Interés = ROUNDUP(B22 * tasa autocompra) + RCDP (para microbuses)
+			calculatedInterest =
+				Math.ceil(b22 * AUTOCOMPRA_INTEREST_RATE) + rcdpCost;
 
-			// Gastos Admin = 400 + Royalty + 400 + 600 + Intereses(incluye RCDP) + GPS + Seguro
+			// Gastos Admin = Garantía + Royalty + Leasing + Admin fijo + Intereses + GPS + Seguro
 			const extraCost = calculatedInterest + gpsCost + insuranceCost;
-			adminCost = 400 + calculatedRoyalty + 400 + 600 + extraCost;
+			adminCost =
+				GARANTIA_MOBILIARIA +
+				calculatedRoyalty +
+				CONTRATO_LEASING +
+				FIXED_ADMIN_COST +
+				extraCost;
 
 			// Total financiado = monto a financiar + costos financiados
 			const financedCosts = transferCost + adminCost;

--- a/apps/crm/apps/web/src/utils/quoter-calculations.ts
+++ b/apps/crm/apps/web/src/utils/quoter-calculations.ts
@@ -1,0 +1,151 @@
+/** IVA de Guatemala (12%) */
+export const IVA_FACTOR = 1.12;
+
+/** Tasa de interés fija para autocompra usada en el cálculo de intereses del detalle */
+export const AUTOCOMPRA_INTEREST_RATE = 0.0178;
+
+/** Gastos administrativos fijos para sobre vehículo */
+export const FIXED_ADMIN_COST = 600;
+
+/** Garantía mobiliaria */
+export const GARANTIA_MOBILIARIA = 400;
+
+/** Contrato leasing */
+export const CONTRATO_LEASING = 400;
+
+/** Costo fijo del GPS (se resta de la membresía cruda para obtener la neta) */
+export const GPS_COST = 148.2;
+
+interface QuotationInput {
+	creditType: "autocompra" | "sobre_vehiculo";
+	vehicleValue: number;
+	downPayment: number;
+	interestRate: number;
+	termMonths: number;
+	insuranceCost: number;
+	gpsCost: number;
+	transferCost: number;
+	royaltyPercentage: number;
+	rcdpCost: number;
+}
+
+export interface QuotationResult {
+	amountToFinance: number;
+	calculatedRoyalty: number;
+	calculatedInterest: number;
+	adminCost: number;
+	totalFinanced: number;
+	monthlyPayment: number;
+}
+
+/**
+ * Calcula la cuota mensual nivelada (según Excel).
+ * Incluye seguro y GPS como costos adicionales a la cuota base.
+ */
+export function calculateMonthlyPayment(
+	principal: number,
+	monthlyRate: number,
+	termMonths: number,
+	insuranceCost: number,
+	gpsCost: number,
+): number {
+	// La tasa incluye IVA (12%)
+	const r = (monthlyRate / 100) * IVA_FACTOR;
+
+	if (r === 0) return principal / termMonths;
+
+	const factor = (1 + r) ** termMonths;
+	const baseMonthlyPayment = (principal * (r * factor)) / (factor - 1);
+
+	// Agregar seguro y GPS a la cuota mensual
+	return Math.round((baseMonthlyPayment + insuranceCost + gpsCost) * 100) / 100;
+}
+
+/**
+ * Calcula todos los valores de una cotización según el tipo de crédito.
+ *
+ * - Sobre vehículo: los cálculos se hacen sobre el monto solicitado directamente.
+ *   Los gastos se descuentan del desembolso al cliente.
+ * - Autocompra: los cálculos se hacen sobre B22 (base intermedia que incluye
+ *   monto a financiar + traspaso + garantía + leasing + admin + GPS + seguro).
+ *   Los gastos se suman al monto a financiar.
+ */
+export function calculateQuotation(input: QuotationInput): QuotationResult {
+	const isSobreVehiculo = input.creditType === "sobre_vehiculo";
+
+	// En sobre vehículo: downPayment = monto solicitado directo
+	// En autocompra: monto a financiar = valor del vehículo - enganche
+	const amountToFinance = isSobreVehiculo
+		? input.downPayment
+		: input.vehicleValue - input.downPayment;
+
+	const royaltyPercentage = input.royaltyPercentage || 4.0;
+
+	let calculatedRoyalty: number;
+	let calculatedInterest: number;
+	let adminCost: number;
+	let totalFinanced: number;
+
+	if (isSobreVehiculo) {
+		// Royalty = % del monto solicitado
+		calculatedRoyalty = Math.ceil(amountToFinance * (royaltyPercentage / 100));
+
+		// Intereses = monto solicitado × tasa × IVA
+		const interestRate = input.interestRate / 100;
+		calculatedInterest =
+			Math.round(amountToFinance * interestRate * IVA_FACTOR * 100) / 100;
+
+		// Gastos administrativos fijos
+		adminCost = FIXED_ADMIN_COST;
+
+		// Total financiado = monto solicitado (los gastos se descuentan del desembolso)
+		totalFinanced = amountToFinance;
+	} else {
+		// B22 = Monto a financiar + Traspaso + Garantía + Leasing + Admin fijo + GPS + Seguro
+		const b22 =
+			amountToFinance +
+			input.transferCost +
+			GARANTIA_MOBILIARIA +
+			CONTRATO_LEASING +
+			FIXED_ADMIN_COST +
+			input.gpsCost +
+			input.insuranceCost;
+
+		// Royalty = % de B22 redondeado hacia arriba
+		calculatedRoyalty = Math.ceil(b22 * (royaltyPercentage / 100));
+
+		// Interés = ROUNDUP(B22 * tasa autocompra) + RCDP (para microbuses)
+		calculatedInterest =
+			Math.ceil(b22 * AUTOCOMPRA_INTEREST_RATE) + input.rcdpCost;
+
+		// Gastos Admin = Garantía + Royalty + Leasing + Admin fijo + Intereses + GPS + Seguro
+		const extraCost = calculatedInterest + input.gpsCost + input.insuranceCost;
+		adminCost =
+			GARANTIA_MOBILIARIA +
+			calculatedRoyalty +
+			CONTRATO_LEASING +
+			FIXED_ADMIN_COST +
+			extraCost;
+
+		// Total financiado = monto a financiar + costos financiados
+		const financedCosts = input.transferCost + adminCost;
+		totalFinanced = amountToFinance + financedCosts;
+	}
+
+	const monthlyPayment = calculateMonthlyPayment(
+		totalFinanced,
+		input.interestRate,
+		input.termMonths,
+		input.insuranceCost,
+		input.gpsCost,
+	);
+
+	return {
+		amountToFinance,
+		calculatedRoyalty,
+		calculatedInterest,
+		adminCost: Math.round(adminCost * 100) / 100,
+		totalFinanced,
+		monthlyPayment,
+	};
+}


### PR DESCRIPTION
## Summary
- Habilita el campo "Verificación de dirección" (Q395) en el cotizador para créditos sobre vehículo (antes solo autocompra)
- Corrige las fórmulas del cotizador para sobre vehículo que usaban la lógica de autocompra:
  - **Royalty**: ahora se calcula como % del monto solicitado (no de B22)
  - **Intereses**: ahora usa `monto × tasa × 1.12 (IVA)` en vez del 1.78% hardcodeado de autocompra
  - **Gastos Admin**: Q600 fijo (no la fórmula compleja de autocompra)
  - **Total financiado**: igual al monto solicitado (los gastos se restan del desembolso)
- La ruta de autocompra se mantiene sin cambios funcionales

## Verificación vs Excel
| Cálculo | Excel Sobre Vehículo | Código |
|---|---|---|
| Royalty (4%) | 1,720 | 1,720 |
| Intereses | 1,444.80 | 1,444.80 |
| Gastos Admin | 600 | 600 |
| Total Financiado | 43,000 | 43,000 |

| Cálculo | Excel Microbus FOTON | Código |
|---|---|---|
| Royalty (4%) | 6,835 | 6,835 |
| Intereses | 3,603.99 | 3,603.99 |
| Gastos Admin | 13,909.44 | 13,909.44 |
| Total Financiado | 181,304.44 | 181,304.44 |

## Test plan
- [ ] Crear cotización sobre vehículo con monto Q43,000 al 3% y verificar que royalty=1,720, intereses=1,444.80, admin=600
- [ ] Crear cotización autocompra microbus y verificar que los cálculos no cambiaron
- [ ] Verificar que "Verificación de dirección" aparece para ambos tipos de crédito

🤖 Generated with [Claude Code](https://claude.com/claude-code)