### PR TITLE
feat: Implement credit participation start date and add associated cr…

### DIFF
--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -267,6 +267,7 @@ const creditUpdateSchema = z.object({
         monto_aportado: z.number().positive(),
         porcentaje_cash_in: z.number().min(0).max(100),
         porcentaje_inversion: z.number().min(0).max(100),
+        fecha_inicio_participacion: z.string().optional(),
       }),
     )
     .min(0)
@@ -278,6 +279,7 @@ const creditUpdateSchema = z.object({
         monto_aportado: z.number().positive(),
         porcentaje_cash_in: z.number().min(0).max(100),
         porcentaje_inversion: z.number().min(0).max(100),
+        fecha_inicio_participacion: z.string().optional(),
       }),
     )
     .min(0)
@@ -717,6 +719,9 @@ const updateInvestors = async (
       iva_inversionista: ivaInversionista.toString(),
       iva_cash_in: ivaCashIn.toString(),
       fecha_creacion: new Date(),
+      fecha_inicio_participacion: inv.fecha_inicio_participacion 
+        ? new Date(inv.fecha_inicio_participacion).toISOString().split('T')[0] 
+        : "2025-12-01",
       cuota_inversionista: cuotaInversionista.toString(), // 🔥 CON LÓGICA CORRECTA
       numero_credito_sifco: numero_credito_sifco ?? undefined,
     };

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -313,6 +313,7 @@
       iva_inversionista: numeric("iva_inversionista", { precision: 18, scale: 2 }).notNull().default("0"),
       iva_cash_in: numeric("iva_cash_in", { precision: 18 }).notNull().default("0"),
       fecha_creacion: timestamp("fecha_creacion", { withTimezone: true }).notNull().$default(() => new Date()),
+      fecha_inicio_participacion: date("fecha_inicio_participacion").notNull().default("2025-12-01"),
       monto_inversionista: numeric("monto_inversionista", { precision: 18, scale: 2 }).notNull().default("0"),
       monto_cash_in: numeric("monto_cash_in", { precision: 18, scale: 2 }).notNull(),
     },
@@ -335,6 +336,7 @@
       iva_inversionista: numeric("iva_inversionista", { precision: 18, scale: 2 }).notNull().default("0"),
       iva_cash_in: numeric("iva_cash_in", { precision: 18, scale: 2 }).notNull().default("0"),
       fecha_creacion: timestamp("fecha_creacion", { withTimezone: true }).notNull().$default(() => new Date()),
+      fecha_inicio_participacion: date("fecha_inicio_participacion").notNull().default("2025-12-01"),
     },
     (t) => ({
       uxCreditoInvEspejo: uniqueIndex("ux_credito_inversionista_espejo").on(t.credito_id, t.inversionista_id),

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -3,8 +3,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Plus, Trash2, BookCopy } from "lucide-react";
-import type { InversionistaPayload } from "../services/services";
 import { useState } from "react";
+import { DatePickerMUI } from "./calendar";
+import type { InversionistaPayload } from "../services/services";
 
 interface InvestorOption {
   inversionista_id: number;
@@ -52,6 +53,7 @@ export function InvestorsList({
       monto_aportado: 0,
       porcentaje_cash_in: 0,
       porcentaje_inversion: 0,
+      fecha_inicio_participacion: "2025-12-01",
     };
 
     formik.setFieldValue("investors", [...investors, { ...newInvestor }]);
@@ -176,6 +178,18 @@ export function InvestorsList({
                   }}
                 />
               </div>
+              <div className="w-40 flex flex-col justify-end">
+                <Label className="text-blue-900 mb-1">Inicio Participación</Label>
+                <div className="h-10 mt-1 [&_.MuiInputBase-root]:h-10 [&_.MuiInputBase-root]:text-sm [&_.MuiInputBase-root]:bg-white [&_.MuiOutlinedInput-notchedOutline]:border-gray-200 [&_.MuiOutlinedInput-notchedOutline]:rounded-md hover:[&_.MuiOutlinedInput-notchedOutline]:border-gray-300 [&_.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-blue-500 [&_.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2">
+                  <DatePickerMUI
+                    disableFuture={false}
+                    value={inv.fecha_inicio_participacion || ""}
+                    onChange={(val) => {
+                      formik.setFieldValue(`${fieldName}.${index}.fecha_inicio_participacion`, val);
+                    }}
+                  />
+                </div>
+              </div>
 
                {/* Botones de Acción */}
                <div className="flex gap-2 mb-0.5">
@@ -262,6 +276,18 @@ export function InvestorsList({
                             formik.setFieldValue(`investorsMirror.${index}.porcentaje_cash_in`, parseFloat((100 - val).toFixed(10)));
                         }}
                         />
+                    </div>
+                    <div className="w-40 flex flex-col justify-end">
+                        <Label className="text-purple-900 text-xs mb-1">Inicio Participación</Label>
+                        <div className="h-9 mt-1 [&_.MuiInputBase-root]:h-9 [&_.MuiInputBase-root]:text-sm [&_.MuiInputBase-root]:bg-white [&_.MuiOutlinedInput-notchedOutline]:border-purple-200 [&_.MuiOutlinedInput-notchedOutline]:rounded-md hover:[&_.MuiOutlinedInput-notchedOutline]:border-purple-300 [&_.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-purple-500 [&_.Mui-focused_.MuiOutlinedInput-notchedOutline]:border-2">
+                          <DatePickerMUI
+                            disableFuture={false}
+                            value={invMirror.fecha_inicio_participacion || ""}
+                            onChange={(val) => {
+                              formik.setFieldValue(`investorsMirror.${index}.fecha_inicio_participacion`, val);
+                            }}
+                          />
+                        </div>
                     </div>
                     <div className="w-10"></div> {/* Spacer para alinear con botones de arriba */}
                 </div>

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -106,6 +106,7 @@ export function ModalEditCredit({
       monto_aportado: Number(inv.monto_aportado),
       porcentaje_cash_in: Number(inv.porcentaje_cash_in),
       porcentaje_inversion: Number(inv.porcentaje_inversion),
+      fecha_inicio_participacion: inv.fecha_inicio_participacion ? new Date(inv.fecha_inicio_participacion).toISOString().split('T')[0] : "2025-12-01",
     })) || [];
 
   const parsedInvestors = parseInvestors(investorsInitial);
@@ -122,6 +123,7 @@ export function ModalEditCredit({
         monto_aportado: Number(mirrorItem.monto_aportado),
         porcentaje_cash_in: Number(mirrorItem.porcentaje_cash_in),
         porcentaje_inversion: Number(mirrorItem.porcentaje_inversion),
+        fecha_inicio_participacion: mirrorItem.fecha_inicio_participacion ? new Date(mirrorItem.fecha_inicio_participacion).toISOString().split('T')[0] : "2025-12-01",
       };
     }
     // Si no hay espejo para ese inversionista, devolvemos objeto vacío
@@ -130,6 +132,7 @@ export function ModalEditCredit({
       monto_aportado: 0,
       porcentaje_cash_in: 0,
       porcentaje_inversion: 0,
+      fecha_inicio_participacion: "2025-12-01",
     };
   });
 
@@ -216,6 +219,7 @@ export function ModalEditCredit({
           monto_aportado: Number(i.monto_aportado),
           porcentaje_cash_in: Number(i.porcentaje_cash_in),
           porcentaje_inversion: Number(i.porcentaje_inversion),
+          fecha_inicio_participacion: i.fecha_inicio_participacion,
         })),
 
         // Lista Espejo
@@ -224,6 +228,7 @@ export function ModalEditCredit({
           monto_aportado: Number(i.monto_aportado),
           porcentaje_cash_in: Number(i.porcentaje_cash_in),
           porcentaje_inversion: Number(i.porcentaje_inversion),
+          fecha_inicio_participacion: i.fecha_inicio_participacion,
         })),
       };
       updateCredit(payload, {

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -99,6 +99,10 @@ export function ModalEditCredit({
   const { mutate: recalculateQuota, isPending: isRecalculating } =
     useRecalculateQuota();
 
+  const parseParticipantDate = (dateString?: string | Date | null) => {
+    return dateString ? new Date(dateString).toISOString().split('T')[0] : "2025-12-01";
+  };
+
   // Preparamos los valores iniciales
   const parseInvestors = (list?: InvestorItem[]) =>
     list?.map((inv) => ({
@@ -106,7 +110,7 @@ export function ModalEditCredit({
       monto_aportado: Number(inv.monto_aportado),
       porcentaje_cash_in: Number(inv.porcentaje_cash_in),
       porcentaje_inversion: Number(inv.porcentaje_inversion),
-      fecha_inicio_participacion: inv.fecha_inicio_participacion ? new Date(inv.fecha_inicio_participacion).toISOString().split('T')[0] : "2025-12-01",
+      fecha_inicio_participacion: parseParticipantDate(inv.fecha_inicio_participacion),
     })) || [];
 
   const parsedInvestors = parseInvestors(investorsInitial);
@@ -123,7 +127,7 @@ export function ModalEditCredit({
         monto_aportado: Number(mirrorItem.monto_aportado),
         porcentaje_cash_in: Number(mirrorItem.porcentaje_cash_in),
         porcentaje_inversion: Number(mirrorItem.porcentaje_inversion),
-        fecha_inicio_participacion: mirrorItem.fecha_inicio_participacion ? new Date(mirrorItem.fecha_inicio_participacion).toISOString().split('T')[0] : "2025-12-01",
+        fecha_inicio_participacion: parseParticipantDate(mirrorItem.fecha_inicio_participacion),
       };
     }
     // Si no hay espejo para ese inversionista, devolvemos objeto vacío

--- a/apps/carteraFront/src/private/cartera/components/calendar.tsx
+++ b/apps/carteraFront/src/private/cartera/components/calendar.tsx
@@ -13,19 +13,20 @@ interface DatePickerMUIProps {
   value?: string
   onChange?: (value: string) => void
   label?: string
+  disableFuture?: boolean
 }
 
 export function DatePickerMUI({
   value,
   onChange,
- 
+  disableFuture = true,
 }: DatePickerMUIProps) {
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
       <DatePicker
      
         value={value ? dayjs(value) : null}
-        maxDate={dayjs()} // 🚫 sin fechas futuras
+        maxDate={disableFuture ? dayjs() : undefined} // 🚫 sin fechas futuras si disableFuture es true
         enableAccessibleFieldDOMStructure={false} // 🔥 FIX CLAVE
         onChange={(newValue: Dayjs | null) => {
           onChange?.(

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -12,6 +12,7 @@ import {
   Loader2,
   MoreVertical,
   RefreshCw,
+  Search,
   Trash2,
   Upload,
 
@@ -50,6 +51,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Combobox, Transition } from "@headlessui/react";
+import { Input } from "@/components/ui/input";
 import { Fragment, useState, useEffect, useMemo } from "react";
 import { ConfirmationModal } from "@/components/ui/confirmation-modal";
 import { CrearBoletaInversionista } from "./investorPayment";
@@ -69,6 +71,9 @@ export function TableInvestors() {
   // Estado Draft: cuando está activo, se muestran subtotales del mirror summary
   const [isDraft, setIsDraft] = useState(false);
   const [draftInvestorId, setDraftInvestorId] = useState<number | null>(null);
+
+  // 🆕 Estado para el buscador interno de créditos asociados
+  const [creditSearchQuery, setCreditSearchQuery] = useState<Record<number, string>>({});
 
   // 🆕 Modal Revertir Pagos
   const [showRevertirModal, setShowRevertirModal] = useState(false);
@@ -717,25 +722,6 @@ const handleAbrirModalBoleta = (inversionista?: { id: number; nombre: string; dp
               <div className="absolute top-full left-1/2 transform -translate-x-1/2 w-0 h-0 border-l-4 border-r-4 border-t-4 border-transparent border-t-gray-900"></div>
             </div>
           </div>
-          <button
-            onClick={() => setShowLiquidarTodosModal(true)}
-            disabled={liquidateMutation.isPending}
-            className="px-4 py-2 rounded-lg bg-red-600 text-white font-bold hover:bg-red-700 active:scale-95 transition-all flex items-center gap-2 justify-center shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {liquidateMutation.isPending ? (
-              <>
-                <Loader2 className="w-5 h-5 animate-spin" />
-                <span className="hidden sm:inline">Liquidando TODO...</span>
-                <span className="sm:hidden">Liquidando...</span>
-              </>
-            ) : (
-              <>
-                <CheckCircle className="w-5 h-5" />
-                <span className="hidden sm:inline">Liquidar TODOS</span>
-                <span className="sm:hidden">Liquidar</span>
-              </>
-            )}
-          </button>
         </div>
       </div>
       <div className="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
@@ -1136,22 +1122,42 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
       {/* COLLAPSE - Créditos */}
       {expandedRow === idx && (
         <div className="p-6 bg-white border-t-2 border-blue-100">
-          <div className="mb-4">
+          <div className="mb-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
             <h4 className="text-lg font-bold text-blue-900 flex items-center gap-2">
               <span className="text-2xl">💼</span>
               Créditos Asociados
             </h4>
+            
+            <div className="relative w-full sm:w-72">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+              <Input
+                placeholder="Buscar cliente o NIT..."
+                value={creditSearchQuery[inv.inversionista_id] || ""}
+                onChange={(e) => 
+                  setCreditSearchQuery(prev => ({ ...prev, [inv.inversionista_id]: e.target.value }))
+                }
+                className="pl-9 bg-gradient-to-r from-blue-50 to-white border-blue-200 focus-visible:ring-blue-400 rounded-full h-10 shadow-sm transition-all text-gray-900 placeholder:text-gray-400 font-medium"
+              />
+            </div>
           </div>
 
-          {(inv.creditos ?? []).length === 0 ? (
-            <div className="text-center py-12 text-gray-500">
-              <p className="text-lg">
-                Este inversionista no tiene créditos asociados.
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {inv.creditos.map((cred) => (
+          {(() => {
+            const query = (creditSearchQuery[inv.inversionista_id] || "").toLowerCase();
+            const filteredCreditos = (inv.creditos ?? []).filter(cred => 
+              cred.nombre_usuario?.toLowerCase().includes(query) ||
+              cred.nit_usuario?.toLowerCase().includes(query)
+            );
+
+            return filteredCreditos.length === 0 ? (
+              <div className="text-center py-12 text-gray-500 bg-blue-50/50 rounded-xl border border-dashed border-blue-200">
+                <p className="text-lg flex flex-col items-center justify-center gap-2">
+                  <span className="text-3xl">🔍</span>
+                  {query ? "No se encontraron créditos con esa búsqueda." : "Este inversionista no tiene créditos asociados."}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-4 max-h-[60vh] overflow-y-auto pl-1 pr-2 custom-scrollbar">
+                {filteredCreditos.map((cred) => (
                 <div
                   key={cred.credito_id}
                   className="border-2 border-blue-200 rounded-xl bg-gradient-to-br from-blue-50 to-white overflow-hidden"
@@ -1367,8 +1373,9 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   )}
                 </div>
               ))}
-            </div>
-          )}
+              </div>
+            );
+          })()}
         </div>
       )}
     </div>
@@ -1601,19 +1608,45 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
       {/* COLLAPSE: Créditos Asociados - SIN CAMBIOS */}
       {expandedRow === idx && (
         <div className="mt-2">
-          <div className="font-bold text-blue-900 mb-2">
-            Créditos asociados:
-          </div>
-          {(inv.creditos ?? []).length === 0 ? (
-            <div className="text-gray-500 text-center py-4">
-              Este inversionista no tiene créditos asociados.
+          <div className="flex flex-col gap-3 mb-3 mt-4">
+            <div className="font-bold text-blue-900 flex items-center gap-2">
+              <span className="text-xl">💼</span>
+              Créditos asociados:
             </div>
-          ) : (
-            inv.creditos.map((cred) => (
-              <div
-                key={cred.credito_id}
-                className="mb-4 border-2 border-blue-200 rounded-xl p-4 bg-gradient-to-br from-blue-50 to-indigo-50 shadow-sm"
-              >
+            <div className="relative w-full">
+              <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+              <Input
+                placeholder="Buscar cliente o NIT..."
+                value={creditSearchQuery[inv.inversionista_id] || ""}
+                onChange={(e) => 
+                  setCreditSearchQuery(prev => ({ ...prev, [inv.inversionista_id]: e.target.value }))
+                }
+                className="pl-9 bg-gradient-to-r from-blue-50 to-white border-blue-200 focus-visible:ring-blue-400 rounded-full h-10 shadow-sm transition-all text-sm w-full text-gray-900 placeholder:text-gray-400 font-medium"
+              />
+            </div>
+          </div>
+
+          {(() => {
+            const query = (creditSearchQuery[inv.inversionista_id] || "").toLowerCase();
+            const filteredCreditos = (inv.creditos ?? []).filter(cred => 
+              cred.nombre_usuario?.toLowerCase().includes(query) ||
+              cred.nit_usuario?.toLowerCase().includes(query)
+            );
+
+            return filteredCreditos.length === 0 ? (
+              <div className="text-gray-500 text-center py-8 bg-blue-50/50 rounded-xl border border-dashed border-blue-200">
+                <p className="flex flex-col items-center justify-center gap-2 text-sm">
+                  <span className="text-2xl">🔍</span>
+                  {query ? "No hay resultados." : "El inversionista no tiene créditos."}
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-4 max-h-[50vh] overflow-y-auto pl-1 pr-2 custom-scrollbar">
+                {filteredCreditos.map((cred) => (
+                <div
+                  key={cred.credito_id}
+                  className="mb-4 border-2 border-blue-200 rounded-xl p-4 bg-gradient-to-br from-blue-50 to-indigo-50 shadow-sm"
+                >
                 {/* ... resto del código de créditos sin cambios ... */}
                 <button
                   className="w-full flex justify-between items-center mb-3"
@@ -1835,8 +1868,10 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   </div>
                 )}
               </div>
-            ))
-          )}
+            ))}
+            </div>
+            );
+          })()}
         </div>
       )}
     </div>

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -58,6 +58,9 @@ import { CrearBoletaInversionista } from "./investorPayment";
 
 const PER_PAGE_OPTIONS = [5, 10, 20, 50, 100, 200, 500];
 
+const MOBILE_MAX_HEIGHT = "max-h-[50vh]";
+const DESKTOP_MAX_HEIGHT = "max-h-[60vh]";
+
 
 
 export function TableInvestors() {
@@ -1156,7 +1159,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 </p>
               </div>
             ) : (
-              <div className="space-y-4 max-h-[60vh] overflow-y-auto pl-1 pr-2 custom-scrollbar">
+              <div className={`space-y-4 ${DESKTOP_MAX_HEIGHT} overflow-y-auto pl-1 pr-2 custom-scrollbar`}>
                 {filteredCreditos.map((cred) => (
                 <div
                   key={cred.credito_id}
@@ -1641,7 +1644,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 </p>
               </div>
             ) : (
-              <div className="space-y-4 max-h-[50vh] overflow-y-auto pl-1 pr-2 custom-scrollbar">
+              <div className={`space-y-4 ${MOBILE_MAX_HEIGHT} overflow-y-auto pl-1 pr-2 custom-scrollbar`}>
                 {filteredCreditos.map((cred) => (
                 <div
                   key={cred.credito_id}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -333,6 +333,7 @@ export interface InversionistaEspejo {
   monto_cash_in: string;
   monto_inversionista: string;
   cuota_inversionista: string;
+  fecha_inicio_participacion?: string;
 }
 
 export interface CreditoUsuarioPago {
@@ -427,6 +428,7 @@ export interface AporteInversionista {
   iva_cash_in: string;
   monto_inversionista: string;
   monto_cash_in: string;
+  fecha_inicio_participacion?: string;
 }
 
 export interface ResumenCreditos {
@@ -614,6 +616,7 @@ export interface InversionistaPayload {
   monto_aportado: number;
   porcentaje_cash_in: number;
   porcentaje_inversion: number; 
+  fecha_inicio_participacion?: string;
 }
 
 export interface UpdateCreditBody {


### PR DESCRIPTION
# 🚀 Detalles del Pull Request

## 📝 Descripción
Este PR incluye actualizaciones importantes tanto en el Backend como en el Frontend para mejorar el flujo operativo de Cartera y la visualización/gestión de inversionistas. Principalmente se integra el nuevo campo `fecha_inicio_participacion`, se optimiza la interfaz de `Créditos Asociados` de cada inversionista y se elimina la funcionalidad riesgosa de liquidación masiva directa desde la tabla.

## ✨ Nuevas Funcionalidades y Cambios Extras
### 🛠️ Backend
- **Nueva Columna de Fecha:** Se agregó el campo `fecha_inicio_participacion` (tipo `DATE`) a los esquemas de base de datos (`creditos_inversionistas` y `creditos_inversionistas_espejo`), configurado con valor por defecto `2025-12-01`.
- **Actualización de Endpoints:** Se actualizó el controlador [updateCredit](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/services/services.ts:658:0-661:1) para validar, tipar, reformatear (`YYYY-MM-DD`) y guardar el nuevo campo `fecha_inicio_participacion` en la base de datos principal y espejo.

### 💻 Frontend
- **Integración de Fecha de Inicio de Participación:**
  - Se actualizaron las interfaces ([InversionistaPayload](cci:2://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/services/services.ts:613:0-619:1), [AporteInversionista](cci:2://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/services/services.ts:412:0-431:1), [InversionistaEspejo](cci:2://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/services/services.ts:324:0-336:1)) en los servicios del cliente.
  - Se modificó [ModalEditCredit.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx:0:0-0:0) para interceptar correctamente los valores iniciales y el parseo de fechas del lado del cliente.
  - Se mejoró el componente [calendar.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/components/calendar.tsx:0:0-0:0) (DatePicker global) para exponer propiedades de bloqueo de visualización, como `disableFuture={false}`.
  - Se reemplazaron por completo los horribles tags convencionales `<input type="date">` por un [DatePickerMUI](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/components/calendar.tsx:18:0-48:1) estilizado asertivamente de acuerdo al patrón de experiencia visual en [InvestorsList.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx:0:0-0:0).

- **Mejoras UX/UI sobre Tabla de Inversionistas ([tableInvestors.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx:0:0-0:0)):**
  - **Eliminación del Botón Peligroso:** Se quitó funcional y visualmente el botón global general de "Liquidar TODOS" para prevenir acciones humanas destructivas asíncronas por accidente.
  - **Rejilla con Scroll Funcional:** A los listados internos de "Créditos Asociados" se les fijó un tope de altura asimétrico (`max-h-[60vh]` en Desktop, `max-h-[50vh]` en Mobile) y una política de auto-scroll para evitar que los contenedores revienten la dimensión horizontal-vertical de la pantalla principal.
  - **Buscador Interno Incorporado:** Se incrustó exitosamente un mini-buscador interno a la par del título de "Créditos Asociados". Este busca **exclusivamente por Nombre del Cliente o NIT** ignorando valores no explícitos, protegiendo interacciones asíncronas cruzadas entre los estados temporales.
