### PR TITLE
feat: mejoras cotizador y soporte crédito interno

### DIFF
--- a/apps/crm/apps/server/src/db/schema/quotations.ts
+++ b/apps/crm/apps/server/src/db/schema/quotations.ts
@@ -1,4 +1,5 @@
 import {
+	boolean,
 	decimal,
 	integer,
 	pgEnum,
@@ -171,6 +172,9 @@ export const quotations = pgTable("quotations", {
 		precision: 12,
 		scale: 2,
 	}).default("0"), // Traspaso de vehículo (diferente de transferCost)
+
+	// Crédito interno (empleados)
+	isInterno: boolean("is_interno").notNull().default(false),
 
 	// Valores calculados
 	amountToFinance: decimal("amount_to_finance", {

--- a/apps/crm/apps/server/src/routers/quotations.ts
+++ b/apps/crm/apps/server/src/routers/quotations.ts
@@ -154,6 +154,7 @@ export const quotationsRouter = {
 				extraAdminCost: z.number().default(600),
 				interestCost: z.number().default(0),
 				vehicleTransferCost: z.number().default(0),
+				isInterno: z.boolean().default(false),
 				notes: z.string().optional(),
 			}),
 		)
@@ -268,6 +269,7 @@ export const quotationsRouter = {
 					extraAdminCost: input.extraAdminCost.toString(),
 					interestCost: input.interestCost.toString(),
 					vehicleTransferCost: input.vehicleTransferCost.toString(),
+					isInterno: input.isInterno,
 					amountToFinance: amountToFinance.toString(),
 					totalFinanced: totalFinanced.toString(),
 					monthlyPayment: monthlyPayment.toFixed(2),

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -151,6 +151,7 @@ interface CreditDetailViewProps {
 		extraAdminCost?: string | null;
 		interestCost?: string | null;
 		vehicleTransferCost?: string | null;
+		isInterno?: boolean;
 		amountToFinance: string;
 		totalFinanced: string;
 		monthlyPayment: string;
@@ -812,6 +813,14 @@ export function CreditDetailView({
 											className="ml-2 border-green-500 bg-green-50 text-green-700"
 										>
 											Cotización Aceptada
+										</Badge>
+									)}
+									{quotation.isInterno && (
+										<Badge
+											variant="outline"
+											className="ml-2 border-purple-500 bg-purple-50 text-purple-700"
+										>
+											Crédito Interno
 										</Badge>
 									)}
 								</div>
@@ -1761,9 +1770,7 @@ export function CreditDetailView({
 												<TableCell className="text-center">
 													<Badge
 														variant={
-															verificacionDireccion > 0
-																? "default"
-																: "outline"
+															verificacionDireccion > 0 ? "default" : "outline"
 														}
 														className="text-xs"
 													>

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -80,7 +80,11 @@ export const Route = createFileRoute("/crm/quoter")({
 	component: QuoterPage,
 });
 
-import { calculateQuotation, GPS_COST } from "@/utils/quoter-calculations";
+import {
+	calculateQuotation,
+	GARANTIA_MOBILIARIA_INTERNO,
+	GPS_COST,
+} from "@/utils/quoter-calculations";
 
 // Tipo para los valores del formulario de cotización
 interface QuotationFormValues {
@@ -751,6 +755,8 @@ function QuoterPage() {
 		monthlyPayment: 0,
 	});
 
+	const [isInterno, setIsInterno] = useState(false);
+
 	const [amortizationTable, setAmortizationTable] = useState<AmortizationRow[]>(
 		[],
 	);
@@ -764,6 +770,7 @@ function QuoterPage() {
 			toast.success("Cotización creada exitosamente");
 			queryClient.invalidateQueries(orpc.getQuotations.queryOptions());
 			quoterForm.reset();
+			setIsInterno(false);
 			setOpportunityVehicle(null);
 			setCalculatedValues({
 				amountToFinance: 0,
@@ -881,6 +888,7 @@ function QuoterPage() {
 				extraAdminCost: Number(value.extraAdminCost),
 				interestCost: Number(value.interestCost),
 				vehicleTransferCost: Number(value.vehicleTransferCost),
+				isInterno,
 			});
 		},
 	});
@@ -917,6 +925,7 @@ function QuoterPage() {
 		quoterForm.state.values.insuredAmount,
 		quoterForm.state.values.vehicleType,
 		quoterForm.state.values.creditType,
+		isInterno,
 	]);
 
 	// Tipos de bus RCDP (membresía ya incluida en la tarifa)
@@ -973,6 +982,7 @@ function QuoterPage() {
 			transferCost: Number(values.transferCost),
 			royaltyPercentage: Number(values.royaltyPercentage),
 			rcdpCost: Number(values.rcdpCost),
+			isInterno,
 		});
 
 		quoterForm.setFieldValue("royalty", result.calculatedRoyalty);
@@ -1207,6 +1217,9 @@ function QuoterPage() {
 					Number(q.vehicleTransferCost) || 0,
 				);
 
+				// Restaurar estado de crédito interno
+				setIsInterno(q.isInterno ?? false);
+
 				// Recalcular después de cargar
 				setTimeout(() => recalculate(), 100);
 
@@ -1387,6 +1400,10 @@ function QuoterPage() {
 														field.handleChange(
 															value as "autocompra" | "sobre_vehiculo",
 														);
+														// Resetear crédito interno al cambiar tipo
+														if (value === "sobre_vehiculo") {
+															setIsInterno(false);
+														}
 														// Actualizar campos específicos según tipo de crédito
 														if (value === "autocompra") {
 															quoterForm.setFieldValue(
@@ -1427,6 +1444,54 @@ function QuoterPage() {
 										);
 									}}
 								</quoterForm.Field>
+
+								{/* Toggle Crédito Interno - solo visible para autocompra */}
+								{quoterForm.state.values.creditType === "autocompra" && (
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											id="isInterno"
+											checked={isInterno}
+											onCheckedChange={(checked) => {
+												const value = checked === true;
+												setIsInterno(value);
+												if (value) {
+													// Crédito interno: sin membresía, sin GPS, sin admin fijo, sin leasing, garantía 300
+													quoterForm.setFieldValue("membershipCost", 0);
+													quoterForm.setFieldValue("extraMembershipCost", 0);
+													quoterForm.setFieldValue("gpsCost", 0);
+													quoterForm.setFieldValue(
+														"mobileGuaranteeCost",
+														GARANTIA_MOBILIARIA_INTERNO,
+													);
+													quoterForm.setFieldValue("leasingContractCost", 0);
+													quoterForm.setFieldValue("extraAdminCost", 0);
+												} else {
+													// Restaurar defaults de autocompra
+													quoterForm.setFieldValue("gpsCost", GPS_COST);
+													quoterForm.setFieldValue("mobileGuaranteeCost", 400);
+													quoterForm.setFieldValue("leasingContractCost", 400);
+													quoterForm.setFieldValue("extraAdminCost", 600);
+													// Recalcular seguro/membresía
+													const insuredAmount =
+														quoterForm.getFieldValue("insuredAmount") ?? 0;
+													if (insuredAmount > 0) {
+														updateInsuranceCost(
+															insuredAmount,
+															quoterForm.state.values.vehicleType,
+														);
+													}
+												}
+												setTimeout(() => recalculate(), 100);
+											}}
+										/>
+										<Label
+											htmlFor="isInterno"
+											className="cursor-pointer font-medium text-sm"
+										>
+											Crédito Interno (Empleados)
+										</Label>
+									</div>
+								)}
 							</CardContent>
 						</Card>
 

--- a/apps/crm/apps/web/src/utils/quoter-calculations.ts
+++ b/apps/crm/apps/web/src/utils/quoter-calculations.ts
@@ -10,6 +10,9 @@ export const FIXED_ADMIN_COST = 600;
 /** Garantía mobiliaria */
 export const GARANTIA_MOBILIARIA = 400;
 
+/** Garantía mobiliaria para crédito interno (empleados) */
+export const GARANTIA_MOBILIARIA_INTERNO = 300;
+
 /** Contrato leasing */
 export const CONTRATO_LEASING = 400;
 
@@ -27,6 +30,7 @@ interface QuotationInput {
 	transferCost: number;
 	royaltyPercentage: number;
 	rcdpCost: number;
+	isInterno?: boolean;
 }
 
 export interface QuotationResult {
@@ -101,15 +105,24 @@ export function calculateQuotation(input: QuotationInput): QuotationResult {
 		// Total financiado = monto solicitado (los gastos se descuentan del desembolso)
 		totalFinanced = amountToFinance;
 	} else {
+		// Constantes según tipo de crédito (interno vs normal)
+		const garantia = input.isInterno
+			? GARANTIA_MOBILIARIA_INTERNO
+			: GARANTIA_MOBILIARIA;
+		const leasing = input.isInterno ? 0 : CONTRATO_LEASING;
+		const adminFijo = input.isInterno ? 0 : FIXED_ADMIN_COST;
+		const gps = input.isInterno ? 0 : input.gpsCost;
+		const seguro = input.insuranceCost;
+
 		// B22 = Monto a financiar + Traspaso + Garantía + Leasing + Admin fijo + GPS + Seguro
 		const b22 =
 			amountToFinance +
 			input.transferCost +
-			GARANTIA_MOBILIARIA +
-			CONTRATO_LEASING +
-			FIXED_ADMIN_COST +
-			input.gpsCost +
-			input.insuranceCost;
+			garantia +
+			leasing +
+			adminFijo +
+			gps +
+			seguro;
 
 		// Royalty = % de B22 redondeado hacia arriba
 		calculatedRoyalty = Math.ceil(b22 * (royaltyPercentage / 100));
@@ -119,25 +132,23 @@ export function calculateQuotation(input: QuotationInput): QuotationResult {
 			Math.ceil(b22 * AUTOCOMPRA_INTEREST_RATE) + input.rcdpCost;
 
 		// Gastos Admin = Garantía + Royalty + Leasing + Admin fijo + Intereses + GPS + Seguro
-		const extraCost = calculatedInterest + input.gpsCost + input.insuranceCost;
-		adminCost =
-			GARANTIA_MOBILIARIA +
-			calculatedRoyalty +
-			CONTRATO_LEASING +
-			FIXED_ADMIN_COST +
-			extraCost;
+		const extraCost = calculatedInterest + gps + seguro;
+		adminCost = garantia + calculatedRoyalty + leasing + adminFijo + extraCost;
 
 		// Total financiado = monto a financiar + costos financiados
 		const financedCosts = input.transferCost + adminCost;
 		totalFinanced = amountToFinance + financedCosts;
 	}
 
+	const effectiveGpsCost =
+		!isSobreVehiculo && input.isInterno ? 0 : input.gpsCost;
+
 	const monthlyPayment = calculateMonthlyPayment(
 		totalFinanced,
 		input.interestRate,
 		input.termMonths,
 		input.insuranceCost,
-		input.gpsCost,
+		effectiveGpsCost,
 	);
 
 	return {


### PR DESCRIPTION
## Summary
- Agregar soporte para crédito interno (empleados) en cotizador
- Extraer lógica de cálculo del cotizador a utility separada
- Extraer magic numbers a constantes con nombre descriptivo
- Corregir fórmulas del cotizador para sobre vehículo
- Mostrar campo verificación de dirección en cotizador para sobre vehículo

## Test plan
- [ ] Verificar cotizador con crédito interno (empleados)
- [ ] Verificar cálculos sobre vehículo
- [ ] Verificar campo verificación de dirección visible para sobre vehículo

🤖 Generated with [Claude Code](https://claude.com/claude-code)