### PR TITLE
feat: paginación y mejoras en notificaciones

### DIFF
--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -209,6 +209,7 @@ export const appRouter = {
 	addDocumentToNotification: notificationsRouter.addDocumentToNotification,
 	getAccountDocumentsByOpportunities:
 		notificationsRouter.getAccountDocumentsByOpportunities,
+	markAllNotificationsAsRead: notificationsRouter.markAllNotificationsAsRead,
 
 	// Quotations routes
 	createQuotation: quotationsRouter.createQuotation,

--- a/apps/crm/apps/server/src/routers/notifications.ts
+++ b/apps/crm/apps/server/src/routers/notifications.ts
@@ -102,7 +102,8 @@ export const notificationsRouter = {
 			.select(notificationWithCreator)
 			.from(notifications)
 			.leftJoin(user, eq(notifications.createdBy, user.id))
-			.orderBy(desc(notifications.createdAt));
+			.orderBy(desc(notifications.createdAt))
+			.limit(500);
 
 		return result;
 	}),
@@ -131,7 +132,8 @@ export const notificationsRouter = {
 					isNull(notifications.assignedTo),
 				),
 			)
-			.orderBy(desc(notifications.createdAt));
+			.orderBy(desc(notifications.createdAt))
+			.limit(500);
 
 		return result;
 	}),
@@ -145,7 +147,8 @@ export const notificationsRouter = {
 			.from(notifications)
 			.leftJoin(user, eq(notifications.createdBy, user.id))
 			.where(eq(notifications.assignedTo, userId))
-			.orderBy(desc(notifications.createdAt));
+			.orderBy(desc(notifications.createdAt))
+			.limit(500);
 
 		return result;
 	}),
@@ -170,13 +173,36 @@ export const notificationsRouter = {
 					.min(1),
 			}),
 		)
-		.handler(async ({ input }) => {
+		.handler(async ({ input, context }) => {
+			const userId = context.session.user.id;
+
+			const [userData] = await db
+				.select({ role: user.role })
+				.from(user)
+				.where(eq(user.id, userId))
+				.limit(1);
+
+			if (!userData) return [];
+
+			// Admin puede consultar cualquier rol; otros solo los que les corresponden
+			const isAdmin = userData.role === "admin";
+			let allowedRoles = input.roles;
+			if (!isAdmin) {
+				const visibleRoles: Record<string, string[]> = {
+					sales_supervisor: ["sales_supervisor", "analyst", "juridico"],
+				};
+				const allowed = visibleRoles[userData.role] ?? [userData.role];
+				allowedRoles = input.roles.filter((r) => allowed.includes(r));
+				if (allowedRoles.length === 0) return [];
+			}
+
 			const result = await db
 				.select(notificationWithCreator)
 				.from(notifications)
 				.leftJoin(user, eq(notifications.createdBy, user.id))
-				.where(inArray(notifications.assignedToRole, input.roles))
-				.orderBy(desc(notifications.createdAt));
+				.where(inArray(notifications.assignedToRole, allowedRoles))
+				.orderBy(desc(notifications.createdAt))
+				.limit(500);
 
 			return result;
 		}),
@@ -195,57 +221,107 @@ export const notificationsRouter = {
 				]),
 			}),
 		)
-		.handler(async ({ input }) => {
+		.handler(async ({ input, context }) => {
+			const userId = context.session.user.id;
+
+			// Obtener datos del usuario y la notificación
+			const [userData] = await db
+				.select({ role: user.role })
+				.from(user)
+				.where(eq(user.id, userId))
+				.limit(1);
+
+			const [notif] = await db
+				.select({
+					type: notifications.type,
+					assignedToRole: notifications.assignedToRole,
+					assignedTo: notifications.assignedTo,
+				})
+				.from(notifications)
+				.where(eq(notifications.id, input.notificationId))
+				.limit(1);
+
+			if (!notif) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Notificación no encontrada",
+				});
+			}
+
+			// Verificar autorización: admin, rol coincide, asignación directa, o supervisor con visibilidad expandida
+			const isAdmin = userData?.role === "admin";
+			const roleMatches = userData?.role === notif.assignedToRole;
+			const isDirectlyAssigned = notif.assignedTo === userId;
+			const isSupervisorWithAccess =
+				userData?.role === "sales_supervisor" &&
+				["sales_supervisor", "analyst"].includes(notif.assignedToRole);
+
+			if (
+				!isAdmin &&
+				!roleMatches &&
+				!isDirectlyAssigned &&
+				!isSupervisorWithAccess
+			) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permiso para modificar esta notificación",
+				});
+			}
+
 			// Si se intenta resolver, verificar que no sea action_upload_files sin documentos
-			if (input.status === "resolved") {
-				const [notif] = await db
-					.select({
-						type: notifications.type,
-					})
-					.from(notifications)
-					.where(eq(notifications.id, input.notificationId))
+			if (input.status === "resolved" && notif.type === "action_upload_files") {
+				const docs = await db
+					.select({ id: notificationDocuments.id })
+					.from(notificationDocuments)
+					.where(eq(notificationDocuments.notificationId, input.notificationId))
 					.limit(1);
 
-				if (notif?.type === "action_upload_files") {
-					const docs = await db
-						.select({ id: notificationDocuments.id })
-						.from(notificationDocuments)
-						.where(
-							eq(notificationDocuments.notificationId, input.notificationId),
-						)
-						.limit(1);
-
-					if (docs.length === 0) {
-						throw new ORPCError("BAD_REQUEST", {
-							message:
-								"No se puede resolver esta notificación sin haber subido al menos un documento.",
-						});
-					}
+				if (docs.length === 0) {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"No se puede resolver esta notificación sin haber subido al menos un documento.",
+					});
 				}
 			}
 
 			const now = new Date();
 
-			const setData: Record<string, unknown> = {
-				status: input.status,
-				updatedAt: now,
-			};
-
-			if (input.status === "read") {
-				setData.readAt = now;
-			}
-			if (input.status === "resolved") {
-				setData.resolvedAt = now;
-			}
-
 			const [updated] = await db
 				.update(notifications)
-				.set(setData)
+				.set({
+					status: input.status,
+					updatedAt: now,
+					...(input.status === "read" ? { readAt: now } : {}),
+					...(input.status === "resolved" ? { resolvedAt: now } : {}),
+				})
 				.where(eq(notifications.id, input.notificationId))
 				.returning();
 
 			return updated;
 		}),
+
+	// Marcar todas las notificaciones pendientes del admin como leídas
+	markAllNotificationsAsRead: adminProcedure.handler(async ({ context }) => {
+		const userId = context.session.user.id;
+		const now = new Date();
+		const updated = await db
+			.update(notifications)
+			.set({
+				status: "read",
+				readAt: now,
+				updatedAt: now,
+			})
+			.where(
+				and(
+					eq(notifications.status, "pending"),
+					or(
+						eq(notifications.assignedToRole, "admin"),
+						eq(notifications.assignedTo, userId),
+					),
+				),
+			)
+			.returning({ id: notifications.id });
+
+		return { count: updated.length };
+	}),
 
 	// Obtener documentos de una notificación
 	getNotificationDocuments: protectedProcedure

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -3,6 +3,8 @@ import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
 	Bell,
 	CheckCircle,
+	ChevronLeft,
+	ChevronRight,
 	Clock,
 	Download,
 	ExternalLink,
@@ -143,6 +145,70 @@ const REDIRECT_CONFIG: Record<
 	},
 };
 
+const PAGE_SIZE = 20;
+const SUPERVISOR_ROLES = ["sales_supervisor", "analyst", "juridico"] as const;
+
+function usePagination(totalItems: number) {
+	const [page, setPage] = useState(1);
+	const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
+	const safePage = Math.min(page, totalPages);
+
+	return {
+		page: safePage,
+		totalPages,
+		setPage,
+		startIndex: (safePage - 1) * PAGE_SIZE,
+		endIndex: safePage * PAGE_SIZE,
+	};
+}
+
+function PaginationControls({
+	page,
+	totalPages,
+	setPage,
+	totalItems,
+}: {
+	page: number;
+	totalPages: number;
+	setPage: (p: number) => void;
+	totalItems: number;
+}) {
+	if (totalPages <= 1) return null;
+
+	return (
+		<div className="flex items-center justify-between border-t pt-4">
+			<span className="text-muted-foreground text-sm">
+				{totalItems} notificación{totalItems !== 1 ? "es" : ""}
+			</span>
+			<div className="flex items-center gap-2">
+				<Button
+					size="sm"
+					variant="outline"
+					className="h-8"
+					onClick={() => setPage(page - 1)}
+					disabled={page <= 1}
+				>
+					<ChevronLeft className="h-4 w-4" />
+					Anterior
+				</Button>
+				<span className="text-sm">
+					Página {page} de {totalPages}
+				</span>
+				<Button
+					size="sm"
+					variant="outline"
+					className="h-8"
+					onClick={() => setPage(page + 1)}
+					disabled={page >= totalPages}
+				>
+					Siguiente
+					<ChevronRight className="h-4 w-4" />
+				</Button>
+			</div>
+		</div>
+	);
+}
+
 function NotificationsPage() {
 	const { data: session, isPending: isSessionPending } =
 		authClient.useSession();
@@ -152,6 +218,7 @@ function NotificationsPage() {
 	});
 
 	const userRole = userProfile.data?.role;
+	const userId = session?.user?.id;
 	const isAdmin = userRole === ROLES.ADMIN;
 	const isSalesSupervisor = userRole === ROLES.SALES_SUPERVISOR;
 
@@ -163,11 +230,11 @@ function NotificationsPage() {
 		enabled: !!session && isAdmin,
 	});
 
-	// Supervisor de ventas: notificaciones de su rol + analyst
+	// Supervisor de ventas: notificaciones de su rol + analyst + juridico
 	const supervisorNotifications = useQuery({
 		...orpc.getNotificationsByRoles.queryOptions({
 			input: {
-				roles: ["sales_supervisor", "analyst"],
+				roles: [...SUPERVISOR_ROLES],
 			},
 		}),
 		enabled: !!session && isSalesSupervisor,
@@ -185,7 +252,24 @@ function NotificationsPage() {
 		enabled: !!session && !isAdmin,
 	});
 
+	const invalidateAll = useCallback(() => {
+		queryClient.invalidateQueries(orpc.getAllNotifications.queryOptions());
+		queryClient.invalidateQueries(orpc.getNotificationsByRole.queryOptions());
+		queryClient.invalidateQueries(
+			orpc.getNotificationsByRoles.queryOptions({
+				input: { roles: [...SUPERVISOR_ROLES] },
+			}),
+		);
+		queryClient.invalidateQueries(orpc.getNotificationsByAssign.queryOptions());
+		queryClient.invalidateQueries(
+			orpc.getUnreadNotificationCount.queryOptions(),
+		);
+	}, []);
+
 	// Mutation para cambiar status
+	const [changingNotificationId, setChangingNotificationId] = useState<
+		string | null
+	>(null);
 	const changeStatus = useMutation({
 		mutationFn: async ({
 			notificationId,
@@ -194,23 +278,31 @@ function NotificationsPage() {
 			notificationId: string;
 			status: NotificationStatus;
 		}) => {
+			setChangingNotificationId(notificationId);
 			return await client.changeNotificationStatus({ notificationId, status });
 		},
 		onSuccess: () => {
 			toast.success("Estado actualizado");
-			queryClient.invalidateQueries(orpc.getAllNotifications.queryOptions());
-			queryClient.invalidateQueries(orpc.getNotificationsByRole.queryOptions());
-			queryClient.invalidateQueries(
-				orpc.getNotificationsByRoles.queryOptions({
-					input: { roles: ["sales_supervisor", "analyst", "juridico"] },
-				}),
+			invalidateAll();
+		},
+		onSettled: () => {
+			setChangingNotificationId(null);
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	// Mutation para marcar todas como leídas (admin)
+	const markAllAsRead = useMutation({
+		mutationFn: async () => {
+			return await client.markAllNotificationsAsRead({});
+		},
+		onSuccess: (data) => {
+			toast.success(
+				`${data.count} notificación${data.count !== 1 ? "es" : ""} marcada${data.count !== 1 ? "s" : ""} como leída${data.count !== 1 ? "s" : ""}`,
 			);
-			queryClient.invalidateQueries(
-				orpc.getNotificationsByAssign.queryOptions(),
-			);
-			queryClient.invalidateQueries(
-				orpc.getUnreadNotificationCount.queryOptions(),
-			);
+			invalidateAll();
 		},
 		onError: (error: Error) => {
 			toast.error(error.message);
@@ -243,12 +335,61 @@ function NotificationsPage() {
 		byAssignNotifications.data,
 	]);
 
-	// Filtro por status (descartadas ocultas por defecto)
-	const filtered = useMemo(() => {
-		if (statusFilter === "all")
-			return notifications.filter((n) => n.status !== "dismissed");
-		return notifications.filter((n) => n.status === statusFilter);
-	}, [notifications, statusFilter]);
+	// Admin: separar notificaciones propias vs sistema
+	const { myNotifications, systemNotifications } = useMemo(() => {
+		if (!isAdmin) {
+			return { myNotifications: notifications, systemNotifications: [] };
+		}
+		const my: typeof notifications = [];
+		const system: typeof notifications = [];
+		for (const n of notifications) {
+			if (n.assignedToRole === "admin" || n.assignedTo === userId) {
+				my.push(n);
+			} else {
+				system.push(n);
+			}
+		}
+		return { myNotifications: my, systemNotifications: system };
+	}, [isAdmin, notifications, userId]);
+
+	// Aplicar filtro de status
+	const filterByStatus = useCallback(
+		(items: typeof notifications) => {
+			if (statusFilter === "all")
+				return items.filter((n) => n.status !== "dismissed");
+			return items.filter((n) => n.status === statusFilter);
+		},
+		[statusFilter],
+	);
+
+	const filteredMy = useMemo(
+		() => filterByStatus(myNotifications),
+		[filterByStatus, myNotifications],
+	);
+	const filteredSystem = useMemo(
+		() => filterByStatus(systemNotifications),
+		[filterByStatus, systemNotifications],
+	);
+
+	// Paginación
+	const myPagination = usePagination(filteredMy.length);
+	const systemPagination = usePagination(filteredSystem.length);
+
+	const pagedMy = filteredMy.slice(
+		myPagination.startIndex,
+		myPagination.endIndex,
+	);
+	const pagedSystem = filteredSystem.slice(
+		systemPagination.startIndex,
+		systemPagination.endIndex,
+	);
+
+	// Reset página al cambiar filtro
+	const handleStatusFilter = (value: string) => {
+		setStatusFilter(value);
+		myPagination.setPage(1);
+		systemPagination.setPage(1);
+	};
 
 	const isLoading =
 		isSessionPending ||
@@ -271,20 +412,62 @@ function NotificationsPage() {
 		return null;
 	}
 
-	// Contadores
-	const pendingCount = notifications.filter(
-		(n) => n.status === "pending",
-	).length;
-	const inProgressCount = notifications.filter(
+	// Contadores (solo de "mis notificaciones" para admin)
+	const countSource = myNotifications;
+	const pendingCount = countSource.filter((n) => n.status === "pending").length;
+	const inProgressCount = countSource.filter(
 		(n) => n.status === "in_progress",
 	).length;
-	const resolvedCount = notifications.filter(
+	const resolvedCount = countSource.filter(
 		(n) => n.status === "resolved",
 	).length;
-	const readCount = notifications.filter((n) => n.status === "read").length;
-	const dismissedCount = notifications.filter(
+	const readCount = countSource.filter((n) => n.status === "read").length;
+	const dismissedCount = countSource.filter(
 		(n) => n.status === "dismissed",
 	).length;
+
+	const renderNotificationList = (
+		items: typeof notifications,
+		pagination: ReturnType<typeof usePagination>,
+		totalFiltered: number,
+	) => {
+		if (items.length === 0) {
+			return (
+				<Card>
+					<CardContent className="flex flex-col items-center justify-center py-12">
+						<Bell className="mb-4 h-12 w-12 text-muted-foreground/50" />
+						<p className="font-medium text-lg text-muted-foreground">
+							No hay notificaciones
+						</p>
+					</CardContent>
+				</Card>
+			);
+		}
+
+		return (
+			<div className="space-y-3">
+				{items.map((notification) => (
+					<NotificationCard
+						key={notification.id}
+						notification={notification}
+						onChangeStatus={(status) =>
+							changeStatus.mutate({
+								notificationId: notification.id,
+								status,
+							})
+						}
+						isChanging={changingNotificationId === notification.id}
+					/>
+				))}
+				<PaginationControls
+					page={pagination.page}
+					totalPages={pagination.totalPages}
+					setPage={pagination.setPage}
+					totalItems={totalFiltered}
+				/>
+			</div>
+		);
+	};
 
 	return (
 		<div className="container mx-auto space-y-6 p-6">
@@ -293,7 +476,7 @@ function NotificationsPage() {
 				<h1 className="font-bold text-3xl">Notificaciones</h1>
 				<p className="text-muted-foreground">
 					{isAdmin
-						? "Todas las notificaciones del sistema"
+						? "Tus notificaciones y vista general del sistema"
 						: "Tus notificaciones pendientes y asignadas"}
 				</p>
 			</div>
@@ -343,7 +526,7 @@ function NotificationsPage() {
 
 			{/* Filtro */}
 			<div className="flex items-center gap-4">
-				<Select value={statusFilter} onValueChange={setStatusFilter}>
+				<Select value={statusFilter} onValueChange={handleStatusFilter}>
 					<SelectTrigger className="w-[200px]">
 						<SelectValue placeholder="Filtrar por estado" />
 					</SelectTrigger>
@@ -356,37 +539,48 @@ function NotificationsPage() {
 						<SelectItem value="dismissed">Descartadas</SelectItem>
 					</SelectContent>
 				</Select>
-				<span className="text-muted-foreground text-sm">
-					{filtered.length} notificación{filtered.length !== 1 ? "es" : ""}
-				</span>
 			</div>
 
-			{/* Lista de notificaciones */}
-			{filtered.length === 0 ? (
-				<Card>
-					<CardContent className="flex flex-col items-center justify-center py-12">
-						<Bell className="mb-4 h-12 w-12 text-muted-foreground/50" />
-						<p className="font-medium text-lg text-muted-foreground">
-							No hay notificaciones
-						</p>
-					</CardContent>
-				</Card>
-			) : (
-				<div className="space-y-3">
-					{filtered.map((notification) => (
-						<NotificationCard
-							key={notification.id}
-							notification={notification}
-							onChangeStatus={(status) =>
-								changeStatus.mutate({
-									notificationId: notification.id,
-									status,
-								})
-							}
-							isChanging={changeStatus.isPending}
-						/>
-					))}
+			{/* Sección: Mis notificaciones (o única sección para no-admins) */}
+			{isAdmin && (
+				<div className="flex items-center justify-between">
+					<h2 className="font-semibold text-xl">Mis notificaciones</h2>
+					{pendingCount > 0 && (
+						<Button
+							size="sm"
+							variant="outline"
+							onClick={() => markAllAsRead.mutate()}
+							disabled={markAllAsRead.isPending}
+						>
+							{markAllAsRead.isPending ? (
+								<Loader2 className="mr-1 h-3 w-3 animate-spin" />
+							) : (
+								<CheckCircle className="mr-1 h-3 w-3" />
+							)}
+							Marcar {pendingCount} como leída{pendingCount !== 1 ? "s" : ""}
+						</Button>
+					)}
 				</div>
+			)}
+			{renderNotificationList(pagedMy, myPagination, filteredMy.length)}
+
+			{/* Sección: Sistema (solo admin) */}
+			{isAdmin && (
+				<>
+					<div className="border-t pt-6">
+						<h2 className="font-semibold text-xl">
+							Notificaciones del sistema
+						</h2>
+						<p className="text-muted-foreground text-sm">
+							Notificaciones de otros roles (solo lectura)
+						</p>
+					</div>
+					{renderNotificationList(
+						pagedSystem,
+						systemPagination,
+						filteredSystem.length,
+					)}
+				</>
 			)}
 		</div>
 	);
@@ -816,14 +1010,15 @@ function UploadDocumentsDialog({
 			if (!files?.length) return;
 
 			setUploading(true);
-			for (const file of Array.from(files)) {
-				await uploadMutation.mutateAsync(file);
-			}
-			setUploading(false);
-
-			// Reset input
-			if (fileInputRef.current) {
-				fileInputRef.current.value = "";
+			try {
+				for (const file of Array.from(files)) {
+					await uploadMutation.mutateAsync(file);
+				}
+			} finally {
+				setUploading(false);
+				if (fileInputRef.current) {
+					fileInputRef.current.value = "";
+				}
 			}
 		},
 		[uploadMutation],


### PR DESCRIPTION
## Summary
- Paginación client-side (20/página) en notificaciones para todos los roles
- Admin ve dos secciones: "Mis notificaciones" (rol admin + asignación directa) y "Notificaciones del sistema" (monitoreo de otros roles)
- Botón "Marcar todas como leídas" solo para admin, scoped a sus propias notificaciones
- Autorización server-side en `changeNotificationStatus` y `getNotificationsByRoles`
- `.limit(500)` en todas las queries de notificaciones
- Estado de carga per-card y try/finally en subida de archivos

## Test plan
- [ ] Verificar paginación con más de 20 notificaciones
- [ ] Verificar que admin ve dos secciones separadas
- [ ] Verificar botón "Marcar todas como leídas" solo aparece para admin con pendientes
- [ ] Verificar que supervisor de ventas puede cambiar status de analyst pero NO de jurídico
- [ ] Verificar que un usuario normal no puede cambiar status de notificaciones de otro rol

🤖 Generated with [Claude Code](https://claude.com/claude-code)