### PR TITLE
Re-enables closing opportunity functionality

### DIFF
--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -814,7 +814,7 @@ export const legalContractsRouter = {
 			}
 
 			// Close the opportunity (create credit, client, contract)
-			/*const closeResult = await closeOpportunity({
+			const closeResult = await closeOpportunity({
 				opportunityId: input.opportunityId,
 				userId: context.userId,
 			});
@@ -823,7 +823,7 @@ export const legalContractsRouter = {
 				throw new ORPCError("BAD_REQUEST", {
 					message: closeResult.error || "Error al cerrar la oportunidad",
 				});
-			}*/
+			}
 
 			// Obtener la etapa del 90%
 			const [targetStage] = await db


### PR DESCRIPTION
The close opportunity functionality was previously commented out, preventing the creation of the credit, client, and contract upon opportunity closure.

This commit re-enables this functionality by uncommenting the relevant code block.