### PR TITLE
Jalvarez

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -2095,31 +2095,35 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
             );
 
             if (sumaCapital > 0) {
-              // 1. Descontar capital en la tabla original
-              await db
-                .update(creditos_inversionistas)
-                .set({
-                  monto_aportado: sql`monto_aportado - ${sumaCapital}`,
-                })
-                .where(
-                  and(
-                    eq(creditos_inversionistas.inversionista_id, inv_id),
-                    eq(creditos_inversionistas.credito_id, credito.credito_id)
-                  )
-                );
+              const sumaSegura = Number(sumaCapital) || 0;
+              
+              await db.transaction(async (tx) => {
+                // 1. Descontar capital en la tabla original
+                await tx
+                  .update(creditos_inversionistas)
+                  .set({
+                    monto_aportado: sql`monto_aportado - ${sumaSegura}`,
+                  })
+                  .where(
+                    and(
+                      eq(creditos_inversionistas.inversionista_id, inv_id),
+                      eq(creditos_inversionistas.credito_id, credito.credito_id)
+                    )
+                  );
 
-              // 2. Descontar capital en la tabla espejo
-              await db
-                .update(creditos_inversionistas_espejo)
-                .set({
-                  monto_aportado: sql`monto_aportado - ${sumaCapital}`,
-                })
-                .where(
-                  and(
-                    eq(creditos_inversionistas_espejo.inversionista_id, inv_id),
-                    eq(creditos_inversionistas_espejo.credito_id, credito.credito_id)
-                  )
-                );
+                // 2. Descontar capital en la tabla espejo
+                await tx
+                  .update(creditos_inversionistas_espejo)
+                  .set({
+                    monto_aportado: sql`monto_aportado - ${sumaSegura}`,
+                  })
+                  .where(
+                    and(
+                      eq(creditos_inversionistas_espejo.inversionista_id, inv_id),
+                      eq(creditos_inversionistas_espejo.credito_id, credito.credito_id)
+                    )
+                  );
+              });
             }
           }
         }
@@ -2127,6 +2131,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
 
       let updateResult: any = { rowCount: 0 };
       if (pagosIds.length > 0) {
+        // NOTA: Por requerimiento del negocio, solo se liquida la tabla espejo, la original debe permanecer intacta en su estado.
         updateResult = await db
           .update(pagos_credito_inversionistas_espejo)
           .set({

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1607,7 +1607,6 @@ export async function upsertPagosEspejo(
     id: number;
     abono_capital: string;
     abono_interes: string;
-    abono_iva_12: string;
     porcentaje_participacion: string;
     cuota: string;
     estado_liquidacion?: "NO_LIQUIDADO" | "LIQUIDADO";
@@ -1636,19 +1635,23 @@ export async function upsertPagosEspejo(
 
   // ── PASO 2: UPDATE por id para cada pago ────────────────────────────────────
   await Promise.all(
-    pagos.map((p) =>
-      db
+    pagos.map((p) => {
+      // 🆕 Recalcular IVA basado en el interés (Siempre 12%)
+      const numericInteres = Number(p.abono_interes) || 0;
+      const calculadoIva = (numericInteres * 0.12).toFixed(2);
+
+      return db
         .update(pagos_credito_inversionistas_espejo)
         .set({
           abono_capital:            p.abono_capital,
           abono_interes:            p.abono_interes,
-          abono_iva_12:             p.abono_iva_12,
+          abono_iva_12:             calculadoIva,
           porcentaje_participacion: p.porcentaje_participacion,
           cuota:                    p.cuota,
           ...(p.estado_liquidacion && { estado_liquidacion: p.estado_liquidacion }),
         })
-        .where(eq(pagos_credito_inversionistas_espejo.id, p.id))
-    )
+        .where(eq(pagos_credito_inversionistas_espejo.id, p.id));
+    })
   );
 
   console.log(`[upsertPagosEspejo] ${pagos.length} registro(s) actualizados.`);

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1910,17 +1910,17 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
     inversionistasALiquidar = [inversionista_id];
   } else {
     const inversionistasConPagos = await db
-      .selectDistinct({
-        inversionista_id: pagos_credito_inversionistas.inversionista_id,
-      })
-      .from(pagos_credito_inversionistas)
-      .where(
-        eq(pagos_credito_inversionistas.estado_liquidacion, "NO_LIQUIDADO")
-      );
+        .selectDistinct({
+          inversionista_id: pagos_credito_inversionistas_espejo.inversionista_id,
+        })
+        .from(pagos_credito_inversionistas_espejo)
+        .where(
+          eq(pagos_credito_inversionistas_espejo.estado_liquidacion, "NO_LIQUIDADO")
+        );
 
-    inversionistasALiquidar = inversionistasConPagos.map(
-      (i) => i.inversionista_id
-    );
+      inversionistasALiquidar = inversionistasConPagos.map(
+        (i) => i.inversionista_id
+      );
   }
 
   if (inversionistasALiquidar.length === 0) {
@@ -1984,7 +1984,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
       console.log(`     Monto: Q${boletaPendiente.monto_boleta ?? "N/A"}`);
       console.log(`     Fecha subida: ${boletaPendiente.fecha_subida}`);
 
-      // 🆕 Obtener datos del inversionista
+      // 🆕 Obtener datos del inversionista desde las tablas espejo
       const resumen = await resumeInvestor(
         inv_id,
         1,
@@ -1993,7 +1993,8 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
         undefined,
         undefined,
         false,
-        undefined
+        undefined,
+        "espejos"
       );
 
       if (!resumen.inversionistas || resumen.inversionistas.length === 0) {
@@ -2059,36 +2060,80 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
 
       console.log(`  ✅ Boleta ${boletaPendiente.boleta_id} marcada como PROCESADO`);
 
-      // 🆕 PASO 4: Obtener IDs de pagos y actualizar
+      // 🆕 PASO 4: Obtener IDs de pagos y actualizar en base a ESPEJO
       const pagosIds: number[] = [];
       for (const credito of inversionista.creditos) {
         if (credito.pagos && credito.pagos.length > 0) {
           const pagosBD = await db
-            .select({ id: pagos_credito_inversionistas.id })
-            .from(pagos_credito_inversionistas)
+            .select({ 
+              id: pagos_credito_inversionistas_espejo.id,
+              abono_capital: pagos_credito_inversionistas_espejo.abono_capital,
+            })
+            .from(pagos_credito_inversionistas_espejo)
             .where(
               and(
-                eq(pagos_credito_inversionistas.inversionista_id, inv_id),
-                eq(pagos_credito_inversionistas.credito_id, credito.credito_id),
+                eq(pagos_credito_inversionistas_espejo.inversionista_id, inv_id),
+                eq(pagos_credito_inversionistas_espejo.credito_id, credito.credito_id),
                 eq(
-                  pagos_credito_inversionistas.estado_liquidacion,
+                  pagos_credito_inversionistas_espejo.estado_liquidacion,
                   "NO_LIQUIDADO"
                 )
               )
             );
-          pagosIds.push(...pagosBD.map((p) => p.id));
+          
+          const idsActuales = pagosBD.map((p) => p.id);
+          pagosIds.push(...idsActuales);
+
+          if (idsActuales.length > 0) {
+            // Calcular capital total a descontar
+            const sumaCapital = pagosBD.reduce(
+              (sum, p) => sum + Number(p.abono_capital || 0),
+              0
+            );
+
+            if (sumaCapital > 0) {
+              // 1. Descontar capital en la tabla original
+              await db
+                .update(creditos_inversionistas)
+                .set({
+                  monto_aportado: sql`monto_aportado - ${sumaCapital}`,
+                })
+                .where(
+                  and(
+                    eq(creditos_inversionistas.inversionista_id, inv_id),
+                    eq(creditos_inversionistas.credito_id, credito.credito_id)
+                  )
+                );
+
+              // 2. Descontar capital en la tabla espejo
+              await db
+                .update(creditos_inversionistas_espejo)
+                .set({
+                  monto_aportado: sql`monto_aportado - ${sumaCapital}`,
+                })
+                .where(
+                  and(
+                    eq(creditos_inversionistas_espejo.inversionista_id, inv_id),
+                    eq(creditos_inversionistas_espejo.credito_id, credito.credito_id)
+                  )
+                );
+            }
+          }
         }
       }
 
-      const updateResult = await db
-        .update(pagos_credito_inversionistas)
-        .set({
-          estado_liquidacion: "LIQUIDADO",
-          liquidacion_id: liquidacion.liquidacion_id,
-        })
-        .where(inArray(pagos_credito_inversionistas.id, pagosIds));
+      let updateResult: any = { rowCount: 0 };
+      if (pagosIds.length > 0) {
+        updateResult = await db
+          .update(pagos_credito_inversionistas_espejo)
+          .set({
+            estado_liquidacion: "LIQUIDADO",
+            liquidacion_id: liquidacion.liquidacion_id,
+          })
+          .where(inArray(pagos_credito_inversionistas_espejo.id, pagosIds));
+      }
 
-      console.log(`  ✅ ${updateResult.rowCount ?? 0} pagos actualizados`);
+      console.log(`  ✅ ${updateResult.rowCount ?? 0} pagos espero actualizados`);
 
       // 🆕 PASO 5: Generar PDF usando la data que YA TENEMOS
       console.log(`  📄 Generando PDF...`);

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -2097,33 +2097,18 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
             if (sumaCapital > 0) {
               const sumaSegura = Number(sumaCapital) || 0;
               
-              await db.transaction(async (tx) => {
-                // 1. Descontar capital en la tabla original
-                await tx
-                  .update(creditos_inversionistas)
-                  .set({
-                    monto_aportado: sql`monto_aportado - ${sumaSegura}`,
-                  })
-                  .where(
-                    and(
-                      eq(creditos_inversionistas.inversionista_id, inv_id),
-                      eq(creditos_inversionistas.credito_id, credito.credito_id)
-                    )
-                  );
-
-                // 2. Descontar capital en la tabla espejo
-                await tx
-                  .update(creditos_inversionistas_espejo)
-                  .set({
-                    monto_aportado: sql`monto_aportado - ${sumaSegura}`,
-                  })
-                  .where(
-                    and(
-                      eq(creditos_inversionistas_espejo.inversionista_id, inv_id),
-                      eq(creditos_inversionistas_espejo.credito_id, credito.credito_id)
-                    )
-                  );
-              });
+              // Descontar capital de la tabla espejo SOLAMENTE
+              await db
+                .update(creditos_inversionistas_espejo)
+                .set({
+                  monto_aportado: sql`monto_aportado - ${sumaSegura}`,
+                })
+                .where(
+                  and(
+                    eq(creditos_inversionistas_espejo.inversionista_id, inv_id),
+                    eq(creditos_inversionistas_espejo.credito_id, credito.credito_id)
+                  )
+                );
             }
           }
         }

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1,5 +1,6 @@
 // app.ts (o donde declares tus rutas Elysia)
 import { z } from "zod";
+import { formatToUSD } from "../utils/functions/currencyConverter";
 import { db } from "../database/index";
 import {
   bancos,
@@ -363,6 +364,7 @@ export const insertInvestor = async ({ body, set }: any) => {
         if (inv.numero_cuenta?.trim())
           updateData.numero_cuenta = inv.numero_cuenta.trim();
         if (inv.dpi) updateData.dpi = inv.dpi;
+        if (inv.moneda?.trim()) updateData.moneda = inv.moneda.trim();
 
         const [updated] = await db
           .update(inversionistas)
@@ -392,6 +394,7 @@ export const insertInvestor = async ({ body, set }: any) => {
           banco_id: inv._banco_id || null,
           tipo_cuenta: inv.tipo_cuenta?.trim() || null,
           numero_cuenta: inv.numero_cuenta?.trim() || null,
+          moneda: inv.moneda?.trim() || "quetzales",
         };
 
         const [inserted] = await db
@@ -978,6 +981,7 @@ export async function resumeInvestor(
       tipo_cuenta: inversionistas.tipo_cuenta,
       numero_cuenta: inversionistas.numero_cuenta,
       dpi: inversionistas.dpi,
+      moneda: inversionistas.moneda,
    tiene_boleta_pendiente: sql<boolean>`
       EXISTS (
         SELECT 1 
@@ -1079,6 +1083,9 @@ export async function resumeInvestor(
         total_capital_creditos: new Big(0),
         total_capital_actual: new Big(0),
       };
+
+      const formatValue = (val: string | number | null | undefined) =>
+        inv.moneda === "dolares" ? formatToUSD(val) : Number(val || 0);
 
       // Procesar créditos del inversionista
       const creditosData = await Promise.all(
@@ -1222,18 +1229,18 @@ const mes = fechaParaMes
               return {
                 id: (pago as any).id,
                 mes, // 🔥 AHORA USA LA FECHA DE LA CUOTA
-                abono_capital: Number(abono_capital.toString()),
-                abono_interes: Number(abono_interes.toString()),
-                abono_iva: Number(abono_iva.toString()),
-                isr: inv.emite_factura ? 0 : Number(isr.toString()),
+                abono_capital: formatValue(abono_capital.toString()),
+                abono_interes: formatValue(abono_interes.toString()),
+                abono_iva: formatValue(abono_iva.toString()),
+                isr: inv.emite_factura ? 0 : formatValue(isr.toString()),
                 porcentaje_inversor: pago.porcentaje_participacion,
-                cuota_inversor: Number(cuota_inversor.toString()),
-                cuota: cuota,
+                cuota_inversor: formatValue(cuota_inversor.toString()),
+                cuota: formatValue(cuota),
                 fecha_pago: pago.fecha_pago,
                 fecha_vencimiento_cuota: pago.fecha_vencimiento_cuota, // 🔥 NUEVA
                 fecha_pago_efectivo_cuota: pago.fecha_pago_efectivo_cuota, // 🔥 NUEVA
-                cuota_inversionista: c.cuota_inversionista,
-                abonoGeneralInteres: Number(abonoGeneralInteres.toString()),
+                cuota_inversionista: formatValue(c.cuota_inversionista),
+                abonoGeneralInteres: formatValue(abonoGeneralInteres.toString()),
                 tasaInteresInvesor: Number(
                   new Big(credito?.porcentaje_interes ?? 0).mul(
                     pago.porcentaje_participacion
@@ -1269,22 +1276,22 @@ const mes = fechaParaMes
             numero_credito_sifco: credito?.numero_credito_sifco,
             nombre_usuario: credito?.nombre_usuario,
             nit_usuario: credito?.nit_usuario,
-            capital: credito?.capital,
-            capital_actual: Number(capital_actual.toString()),
+            capital: formatValue(credito?.capital),
+            capital_actual: formatValue(capital_actual.toString()),
             porcentaje_interes: credito?.porcentaje_interes,
-            cuota_interes: credito?.cuota_interes,
-            iva12: credito?.iva12,
+            cuota_interes: formatValue(credito?.cuota_interes),
+            iva12: formatValue(credito?.iva12),
             fecha_creacion: credito?.fecha_creacion,
-            monto_aportado: c.monto_aportado,
+            monto_aportado: formatValue(c.monto_aportado),
             porcentaje_inversionista: c.porcentaje_inversionista,
-            cuota_inversionista: c.cuota_inversionista,
+            cuota_inversionista: formatValue(c.cuota_inversionista),
             plazo: credito.plazo,
             pagos: pagos_detalle,
-            total_abono_capital: Number(total_abono_capital.toString()),
-            total_abono_interes: Number(total_abono_interes.toString()),
-            total_abono_iva: Number(total_abono_iva.toString()),
-            total_isr: Number(total_isr.toString()),
-            total_cuota: Number(total_cuota.toString()),
+            total_abono_capital: formatValue(total_abono_capital.toString()),
+            total_abono_interes: formatValue(total_abono_interes.toString()),
+            total_abono_iva: formatValue(total_abono_iva.toString()),
+            total_isr: formatValue(total_isr.toString()),
+            total_cuota: formatValue(total_cuota.toString()),
             meses_en_credito,
             origen: c.origen, // 🆕 NUEVO: Indica si viene de tabla original o espejo
           };
@@ -1303,25 +1310,19 @@ const mes = fechaParaMes
         re_inversion: inv.reinversion,
         tieneBoletaPendiente: inv.tiene_boleta_pendiente,
         dpi: inv.dpi,
+        moneda: inv.moneda,
+        currencySymbol: inv.moneda === "dolares" ? "$" : "Q.",
         creditos: creditosData,
         subtotal: {
-          total_abono_capital: Number(subtotal.total_abono_capital.toString()),
-          total_abono_interes: Number(subtotal.total_abono_interes.toString()),
-          total_abono_iva: Number(subtotal.total_abono_iva.toString()),
-          total_isr: Number(subtotal.total_isr.toString()),
-          total_cuota: Number(subtotal.total_cuota.toString()),
-          total_monto_aportado: Number(
-            subtotal.total_monto_aportado.toString()
-          ),
-          totalAbonoGeneralInteres: Number(
-            subtotal.totalAbonoGeneralInteres.toString()
-          ),
-          total_capital_creditos: Number(
-            subtotal.total_capital_creditos.toString()
-          ),
-          total_capital_actual: Number(
-            subtotal.total_capital_actual.toString()
-          ),
+          total_abono_capital: formatValue(subtotal.total_abono_capital.toString()),
+          total_abono_interes: formatValue(subtotal.total_abono_interes.toString()),
+          total_abono_iva: formatValue(subtotal.total_abono_iva.toString()),
+          total_isr: formatValue(subtotal.total_isr.toString()),
+          total_cuota: formatValue(subtotal.total_cuota.toString()),
+          total_monto_aportado: formatValue(subtotal.total_monto_aportado.toString()),
+          totalAbonoGeneralInteres: formatValue(subtotal.totalAbonoGeneralInteres.toString()),
+          total_capital_creditos: formatValue(subtotal.total_capital_creditos.toString()),
+          total_capital_actual: formatValue(subtotal.total_capital_actual.toString()),
         },
       };
     })
@@ -1377,6 +1378,7 @@ export async function getInvestorTotalsGlobales(
       inversionista: inversionistas.nombre,
       emite_factura: inversionistas.emite_factura,
       reinversion: inversionistas.tipo_reinversion,
+      moneda: inversionistas.moneda,
     })
     .from(inversionistas)
     .where(and(...queryConditions))
@@ -1401,10 +1403,14 @@ export async function getInvestorTotalsGlobales(
 
   let creditosIds = creditosParticipa.map((c) => c.credito_id);
 
+  const formatValue = (val: string | number) => inv.moneda === "dolares" ? formatToUSD(val) : Number(val);
+
   if (creditosIds.length === 0) {
     return {
       inversionista_id: inv.inversionista_id,
       nombre_inversionista: inv.inversionista,
+      moneda: inv.moneda,
+      currencySymbol: inv.moneda === "dolares" ? "$" : "Q.",
       totales: {
         total_abono_capital: 0,
         total_abono_interes: 0,
@@ -1438,6 +1444,8 @@ export async function getInvestorTotalsGlobales(
     return {
       inversionista_id: inv.inversionista_id,
       nombre_inversionista: inv.inversionista,
+      moneda: inv.moneda,
+      currencySymbol: inv.moneda === "dolares" ? "$" : "Q.",
       totales: {
         total_abono_capital: 0,
         total_abono_interes: 0,
@@ -1563,16 +1571,18 @@ export async function getInvestorTotalsGlobales(
   return {
     inversionista_id: inv.inversionista_id,
     nombre_inversionista: inv.inversionista,
+    moneda: inv.moneda,
+    currencySymbol: inv.moneda === "dolares" ? "$" : "Q.",
     totales: {
-      total_abono_capital: Number(subtotal.total_abono_capital.toString()),
-      total_abono_interes: Number(subtotal.total_abono_interes.toString()),
-      total_abono_iva: Number(subtotal.total_abono_iva.toString()),
-      total_isr: Number(subtotal.total_isr.toString()),
-      total_cuota: Number(subtotal.total_cuota.toString()),
-      total_monto_aportado: Number(subtotal.total_monto_aportado.toString()),
-      totalAbonoGeneralInteres: Number(subtotal.totalAbonoGeneralInteres.toString()),
-      total_capital_creditos: Number(subtotal.total_capital_creditos.toString()),
-      total_capital_actual: Number(subtotal.total_capital_actual.toString()),
+      total_abono_capital: formatValue(subtotal.total_abono_capital.toString()),
+      total_abono_interes: formatValue(subtotal.total_abono_interes.toString()),
+      total_abono_iva: formatValue(subtotal.total_abono_iva.toString()),
+      total_isr: formatValue(subtotal.total_isr.toString()),
+      total_cuota: formatValue(subtotal.total_cuota.toString()),
+      total_monto_aportado: formatValue(subtotal.total_monto_aportado.toString()),
+      totalAbonoGeneralInteres: formatValue(subtotal.totalAbonoGeneralInteres.toString()),
+      total_capital_creditos: formatValue(subtotal.total_capital_creditos.toString()),
+      total_capital_actual: formatValue(subtotal.total_capital_actual.toString()),
     },
   };
 }
@@ -1698,6 +1708,7 @@ export async function getInvestorMirrorSummary(
       tipo_cuenta:      inversionistas.tipo_cuenta,
       numero_cuenta:    inversionistas.numero_cuenta,
       dpi:              inversionistas.dpi,
+      moneda:           inversionistas.moneda,
     })
     .from(inversionistas)
     .where(and(...queryConditions))
@@ -1721,6 +1732,8 @@ export async function getInvestorMirrorSummary(
     new Big(0)
   );
 
+  const formatValue = (val: string | number) => inv.moneda === "dolares" ? formatToUSD(val) : Number(val);
+
   // Caso sin créditos espejo: devolver ceros con monto base
   if (creditosEspejo.length === 0) {
     return {
@@ -1732,16 +1745,18 @@ export async function getInvestorMirrorSummary(
       tipo_cuenta:      inv.tipo_cuenta,
       numero_cuenta:    inv.numero_cuenta,
       dpi:              inv.dpi,
+      moneda:           inv.moneda,
+      currencySymbol:   inv.moneda === "dolares" ? "$" : "Q.",
       subtotal: {
         total_abono_capital:      0,
         total_abono_interes:      0,
         total_abono_iva:          0,
         total_isr:                0,
         total_cuota:              0,
-        total_monto_aportado:     Number(totalMontoBase.toString()),
+        total_monto_aportado:     formatValue(totalMontoBase.toString()),
         totalAbonoGeneralInteres: 0,
-        total_capital_creditos:   Number(totalMontoBase.toString()),
-        total_capital_actual:     Number(totalMontoBase.toString()),
+        total_capital_creditos:   formatValue(totalMontoBase.toString()),
+        total_capital_actual:     formatValue(totalMontoBase.toString()),
       },
     };
   }
@@ -1858,19 +1873,22 @@ export async function getInvestorMirrorSummary(
     tipo_cuenta:      inv.tipo_cuenta,
     numero_cuenta:    inv.numero_cuenta,
     dpi:              inv.dpi,
+    moneda:           inv.moneda,
+    currencySymbol:   inv.moneda === "dolares" ? "$" : "Q.",
     subtotal: {
-      total_abono_capital:      Number(sg.total_abono_capital.toString()),
-      total_abono_interes:      Number(sg.total_abono_interes.toString()),
-      total_abono_iva:          Number(sg.total_abono_iva.toString()),
-      total_isr:                Number(sg.total_isr.toString()),
-      total_cuota:              Number(sg.total_cuota.toString()),
+      total_abono_capital:      formatValue(sg.total_abono_capital.toString()),
+      total_abono_interes:      formatValue(sg.total_abono_interes.toString()),
+      total_abono_iva:          formatValue(sg.total_abono_iva.toString()),
+      total_isr:                formatValue(sg.total_isr.toString()),
+      total_cuota:              formatValue(sg.total_cuota.toString()),
       /** Saldo actual: monto_aportado_base - SUM(abono_capital de pagos espejo) */
-      total_monto_aportado:     Number(sg.total_monto_aportado.toString()),
-      totalAbonoGeneralInteres: Number(sg.totalAbonoGeneralInteres.toString()),
+      total_monto_aportado:     formatValue(sg.total_monto_aportado.toString()),
+      totalAbonoGeneralInteres: formatValue(sg.totalAbonoGeneralInteres.toString()),
       /** Suma de monto_aportado_base de todos los créditos espejo */
-      total_capital_creditos:   Number(sg.total_capital_creditos.toString()),
+
+      total_capital_creditos:   formatValue(sg.total_capital_creditos.toString()),
       /** Igual a total_monto_aportado: saldo vivo calculado desde pagos */
-      total_capital_actual:     Number(sg.total_capital_actual.toString()),
+      total_capital_actual:     formatValue(sg.total_capital_actual.toString()),
     },
   };
 }
@@ -2721,6 +2739,7 @@ export const updateInvestor = async ({ body, set }: any) => {
         tipo_cuenta,
         numero_cuenta,
         dpi,
+        moneda,
       } = inv;
 
       // Construir dinámicamente solo los campos enviados
@@ -2737,6 +2756,7 @@ export const updateInvestor = async ({ body, set }: any) => {
       if (typeof numero_cuenta !== "undefined")
         updateData.numero_cuenta = numero_cuenta;
       if (typeof dpi !== "undefined") updateData.dpi = dpi;
+      if (typeof moneda !== "undefined") updateData.moneda = moneda;
 
       // Si no hay nada que actualizar, saltar
       if (Object.keys(updateData).length === 0) continue;

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -544,6 +544,8 @@
       "reinversion_total"
     ]);
 
+  export const tipoMonedaEnum = customSchema.enum("tipo_moneda", ["quetzales", "dolares"]);
+
 
   export const inversionistas = customSchema.table("inversionistas", {
     inversionista_id: serial("inversionista_id").primaryKey(),
@@ -558,6 +560,7 @@
     banco_id: integer("banco_id").references(() => bancos.banco_id),
     tipo_cuenta: tipoCuentaEnum("tipo_cuenta"),
     numero_cuenta: varchar("numero_cuenta", { length: 100 }),
+    moneda: tipoMonedaEnum("moneda").notNull().default("quetzales"),
   });
   export const asesores = customSchema.table("asesores", {
     asesor_id: serial("asesor_id").primaryKey(),

--- a/apps/cartera-back/src/utils/functions/const.ts
+++ b/apps/cartera-back/src/utils/functions/const.ts
@@ -318,3 +318,5 @@ export function getInversionistaFacturadorConfig(nombreInversionista: string) {
 
   return null;
 }
+
+export const USD_EXCHANGE_RATE = process.env.USD_EXCHANGE_RATE ? Number(process.env.USD_EXCHANGE_RATE) : 8.9;

--- a/apps/cartera-back/src/utils/functions/currencyConverter.ts
+++ b/apps/cartera-back/src/utils/functions/currencyConverter.ts
@@ -3,6 +3,10 @@ import { USD_EXCHANGE_RATE } from "./const";
 export const formatToUSD = (montoEnQuetzales: number | string | null | undefined): number => {
   if (montoEnQuetzales === null || montoEnQuetzales === undefined) return 0;
   const val = Number(montoEnQuetzales);
-  if (isNaN(val)) return Number(montoEnQuetzales) || 0;
+  if (isNaN(val)) return 0;
+  
+  // Prevenir división por cero si la variable de entorno no está correctamente configurada
+  if (!USD_EXCHANGE_RATE || USD_EXCHANGE_RATE <= 0) return 0;
+  
   return Number((val / USD_EXCHANGE_RATE).toFixed(2));
 };

--- a/apps/cartera-back/src/utils/functions/currencyConverter.ts
+++ b/apps/cartera-back/src/utils/functions/currencyConverter.ts
@@ -1,0 +1,8 @@
+import { USD_EXCHANGE_RATE } from "./const";
+
+export const formatToUSD = (montoEnQuetzales: number | string | null | undefined): number => {
+  if (montoEnQuetzales === null || montoEnQuetzales === undefined) return 0;
+  const val = Number(montoEnQuetzales);
+  if (isNaN(val)) return Number(montoEnQuetzales) || 0;
+  return Number((val / USD_EXCHANGE_RATE).toFixed(2));
+};

--- a/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
@@ -23,10 +23,12 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
       nombre: "",
       dpi: undefined,
       emite_factura: false,
+      reinversion: false,
       banco: null,
       tipo_cuenta: "",
       numero_cuenta: "",
       re_inversion: "sin_reinversion",
+      moneda: "quetzales",
     },
   });
 
@@ -47,10 +49,12 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
         nombre: "",
         dpi: undefined,
         emite_factura: false,
+        reinversion: false,
         banco: null,
         tipo_cuenta: "",
         numero_cuenta: "",
         re_inversion: "sin_reinversion",
+        moneda: "quetzales",
       });
     }
   }, [initialData, mode, reset]);
@@ -72,6 +76,8 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
           : "✅ Inversionista actualizado correctamente.";
         alert(mensaje);
         queryClient.invalidateQueries({ queryKey: ["investors"] });
+        queryClient.invalidateQueries({ queryKey: ["investor-mirror-summary"] });
+        queryClient.invalidateQueries({ queryKey: ["investor-totals"] });
         reset();
         onClose();
       },
@@ -176,7 +182,18 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
               <option value="sin_reinversion">Sin Reinversión</option>
               <option value="reinversion_capital">Reinversión Capital</option>
               <option value="reinversion_interes">Reinversión Interés</option>
-              <option value="reinversion_total">Reinversión Total</option>
+            </select>
+          </div>
+
+          {/* Moneda */}
+          <div>
+            <label className="block text-sm text-blue-800 mb-1">Moneda Preferida</label>
+            <select
+              {...register("moneda")}
+              className="bg-white text-blue-900 border border-gray-300 rounded-lg px-4 py-2 w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+            >
+              <option value="quetzales">Quetzales (Q)</option>
+              <option value="dolares">Dólares ($)</option>
             </select>
           </div>
 

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -124,14 +124,14 @@ export function TableInvestors() {
       const changed = changes[id] || {}; 
 
       const currentInteres = Number(changed.abono_interes ?? original.abono_interes);
-      const calculatedIva = inversionista.emite_factura ? (currentInteres * 0.12).toFixed(2) : "0.00";
 
       return {
         id,
         // Convertir a STRING para el backend, y usar los nombres correctos 
         abono_capital:            String(changed.abono_capital            ?? original.abono_capital),
         abono_interes:            String(currentInteres),
-        abono_iva_12:             String(calculatedIva),
+        // Ya no calculamos IVA localmente, enviamos lo original, backend recalcula
+        abono_iva_12:             original.abono_iva_12 ?? "0.00",
         porcentaje_participacion: String(changed.porcentaje_participacion ?? original.porcentaje_inversor),
         cuota:                    String(changed.cuota                    ?? original.cuota),
       };

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -1213,7 +1213,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                               Capital Aportado
                             </div>
                             <div className="font-semibold text-green-700 text-sm">
-                              Q
+                              {inv.currencySymbol}
                               {Number(
                                 cred.monto_aportado
                               ).toLocaleString("es-GT", {
@@ -1234,7 +1234,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                               Total a Recibir
                             </div>
                             <div className="font-bold text-green-700 text-sm">
-                              Q
+                              {inv.currencySymbol}
                               {Number(
                                 cred.total_cuota
                               ).toLocaleString("es-GT", {
@@ -1297,12 +1297,15 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                   <div className="bg-white rounded-lg p-2 border border-blue-200">
                                     <div className="text-xs text-blue-700">💵 Abono Capital</div>
                                     {isDraft ? (
-                                      <input
-                                        type="number"
-                                        className="w-full text-right bg-white border border-blue-300 rounded px-1 text-sm font-bold text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 mt-1"
-                                        value={changes[pago.id]?.abono_capital ?? pago.abono_capital}
-                                        onChange={(e) => handleInputChange(pago.id, 'abono_capital', e.target.value)}
-                                      />
+                                      <div className="flex items-center mt-1">
+                                        <span className="text-blue-900 font-bold text-sm mr-1">{inv.currencySymbol}</span>
+                                        <input
+                                          type="number"
+                                          className="w-full text-right bg-white border border-blue-300 rounded px-1 text-sm font-bold text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                          value={changes[pago.id]?.abono_capital ?? pago.abono_capital}
+                                          onChange={(e) => handleInputChange(pago.id, 'abono_capital', e.target.value)}
+                                        />
+                                      </div>
                                     ) : (
                                       <div className="font-bold text-blue-900 text-sm">
                                         {inv.currencySymbol} {Number(pago.abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
@@ -1314,12 +1317,15 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                   <div className="bg-white rounded-lg p-2 border border-violet-200">
                                     <div className="text-xs text-violet-700">💰 Cuota Inversor</div>
                                     {isDraft ? (
-                                      <input
-                                        type="number"
-                                        className="w-full text-right bg-white border border-violet-300 rounded px-1 text-sm font-bold text-violet-900 focus:outline-none focus:ring-2 focus:ring-violet-500 mt-1"
-                                        value={changes[pago.id]?.abono_interes ?? pago.abono_interes}
-                                        onChange={(e) => handleInputChange(pago.id, 'abono_interes', e.target.value)}
-                                      />
+                                      <div className="flex items-center mt-1">
+                                        <span className="text-violet-900 font-bold text-sm mr-1">{inv.currencySymbol}</span>
+                                        <input
+                                          type="number"
+                                          className="w-full text-right bg-white border border-violet-300 rounded px-1 text-sm font-bold text-violet-900 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                                          value={changes[pago.id]?.abono_interes ?? pago.abono_interes}
+                                          onChange={(e) => handleInputChange(pago.id, 'abono_interes', e.target.value)}
+                                        />
+                                      </div>
                                     ) : (
                                       <div className="font-bold text-violet-900 text-sm">
                                         {inv.currencySymbol} {Number(pago.abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
@@ -1332,7 +1338,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                     <div className="text-xs text-green-700">📈 IVA</div>
                                     {isDraft ? (
                                       <div className="w-full text-right bg-green-50 rounded px-1 text-sm font-bold text-green-700 mt-1 h-7 flex items-center justify-end">
-                                        {inv.emite_factura
+                                        {inv.currencySymbol} {inv.emite_factura
                                           ? (Number(changes[pago.id]?.abono_interes ?? pago.abono_interes) * 0.12).toFixed(2)
                                           : "0.00"}
                                       </div>
@@ -1348,7 +1354,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                     <div className="text-xs text-yellow-700">📉 ISR</div>
                                     {isDraft ? (
                                       <div className="w-full text-right bg-yellow-50 rounded px-1 text-sm font-bold text-yellow-700 mt-1 h-7 flex items-center justify-end">
-                                        {!inv.emite_factura
+                                        {inv.currencySymbol} {!inv.emite_factura
                                           ? (Number(changes[pago.id]?.abono_interes ?? pago.abono_interes) * 0.07).toFixed(2)
                                           : "0.00"}
                                       </div>
@@ -1789,12 +1795,15 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                               <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-2 border border-blue-200">
                                 <div className="text-xs text-blue-700">💵 Abono Capital</div>
                                 {isDraft ? (
-                                  <input
-                                    type="number"
-                                    className="w-full text-right bg-white border border-blue-300 rounded px-1 text-sm font-bold text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500 mt-1"
-                                    value={changes[pago.id]?.abono_capital ?? pago.abono_capital}
-                                    onChange={(e) => handleInputChange(pago.id, 'abono_capital', e.target.value)}
-                                  />
+                                  <div className="flex items-center mt-1">
+                                    <span className="text-blue-900 font-bold text-sm mr-1">{inv.currencySymbol}</span>
+                                    <input
+                                      type="number"
+                                      className="w-full text-right bg-white border border-blue-300 rounded px-1 text-sm font-bold text-blue-900 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                                      value={changes[pago.id]?.abono_capital ?? pago.abono_capital}
+                                      onChange={(e) => handleInputChange(pago.id, 'abono_capital', e.target.value)}
+                                    />
+                                  </div>
                                 ) : (
                                   <div className="font-bold text-blue-900 text-sm">
                                     {inv.currencySymbol} {Number(pago.abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
@@ -1806,12 +1815,15 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                               <div className="bg-gradient-to-br from-violet-50 to-violet-100 rounded-lg p-2 border border-violet-200">
                                 <div className="text-xs text-violet-700">💰 Cuota Inversor</div>
                                 {isDraft ? (
-                                  <input
-                                    type="number"
-                                    className="w-full text-right bg-white border border-violet-300 rounded px-1 text-sm font-bold text-violet-900 focus:outline-none focus:ring-2 focus:ring-violet-500 mt-1"
-                                    value={changes[pago.id]?.abono_interes ?? pago.abono_interes}
-                                    onChange={(e) => handleInputChange(pago.id, 'abono_interes', e.target.value)}
-                                  />
+                                  <div className="flex items-center mt-1">
+                                    <span className="text-violet-900 font-bold text-sm mr-1">{inv.currencySymbol}</span>
+                                    <input
+                                      type="number"
+                                      className="w-full text-right bg-white border border-violet-300 rounded px-1 text-sm font-bold text-violet-900 focus:outline-none focus:ring-2 focus:ring-violet-500"
+                                      value={changes[pago.id]?.abono_interes ?? pago.abono_interes}
+                                      onChange={(e) => handleInputChange(pago.id, 'abono_interes', e.target.value)}
+                                    />
+                                  </div>
                                 ) : (
                                   <div className="font-bold text-violet-900 text-sm">
                                     {inv.currencySymbol} {Number(pago.abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
@@ -1823,12 +1835,15 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                               <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-2 border border-green-200">
                                 <div className="text-xs text-green-700">📈 IVA</div>
                                 {isDraft ? (
-                                  <input
-                                    type="number"
-                                    className="w-full text-right bg-white border border-green-300 rounded px-1 text-sm font-bold text-green-900 focus:outline-none focus:ring-2 focus:ring-green-500 mt-1"
-                                    value={changes[pago.id]?.abono_iva_12 ?? pago.abono_iva}
-                                    onChange={(e) => handleInputChange(pago.id, 'abono_iva_12', e.target.value)}
-                                  />
+                                  <div className="flex items-center mt-1">
+                                    <span className="text-green-900 font-bold text-sm mr-1">{inv.currencySymbol}</span>
+                                    <input
+                                      type="number"
+                                      className="w-full text-right bg-white border border-green-300 rounded px-1 text-sm font-bold text-green-900 focus:outline-none focus:ring-2 focus:ring-green-500"
+                                      value={changes[pago.id]?.abono_iva_12 ?? pago.abono_iva}
+                                      onChange={(e) => handleInputChange(pago.id, 'abono_iva_12', e.target.value)}
+                                    />
+                                  </div>
                                 ) : (
                                   <div className="font-bold text-green-900 text-sm">
                                     {inv.currencySymbol} {Number(pago.abono_iva).toLocaleString("es-GT", { minimumFractionDigits: 2 })}

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -123,12 +123,15 @@ export function TableInvestors() {
       const id = original.id; 
       const changed = changes[id] || {}; 
 
+      const currentInteres = Number(changed.abono_interes ?? original.abono_interes);
+      const calculatedIva = inversionista.emite_factura ? (currentInteres * 0.12).toFixed(2) : "0.00";
+
       return {
         id,
         // Convertir a STRING para el backend, y usar los nombres correctos 
         abono_capital:            String(changed.abono_capital            ?? original.abono_capital),
-        abono_interes:            String(changed.abono_interes            ?? original.abono_interes),
-        abono_iva_12:             String(changed.abono_iva_12             ?? original.abono_iva),
+        abono_interes:            String(currentInteres),
+        abono_iva_12:             String(calculatedIva),
         porcentaje_participacion: String(changed.porcentaje_participacion ?? original.porcentaje_inversor),
         cuota:                    String(changed.cuota                    ?? original.cuota),
       };
@@ -416,6 +419,7 @@ export function TableInvestors() {
       tipo_cuenta: inv.tipo_cuenta ?? "",
       numero_cuenta: inv.numero_cuenta ?? "",
       re_inversion: inv.re_inversion ?? "sin_reinversion",
+      moneda: inv.moneda ?? "quetzales",
       dpi: inv.dpi ?? "",
     });
     setModalOpen(true);
@@ -893,8 +897,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   Total Capital
                 </div>
                 <div className={`font-bold ${isDraft ? "text-yellow-700" : "text-blue-700"}`}>
-                  Q
-                  {Number(subtotales.total_abono_capital).toLocaleString("es-GT", {
+                  {inv.currencySymbol} {Number(subtotales.total_abono_capital).toLocaleString("es-GT", {
                     minimumFractionDigits: 2,
                   })}
                 </div>
@@ -905,8 +908,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   Total Interés
                 </div>
                 <div className={`font-bold ${isDraft ? "text-yellow-700" : "text-indigo-700"}`}>
-                  Q
-                  {Number(subtotales.total_abono_interes).toLocaleString("es-GT", {
+                  {inv.currencySymbol} {Number(subtotales.total_abono_interes).toLocaleString("es-GT", {
                     minimumFractionDigits: 2,
                   })}
                 </div>
@@ -917,9 +919,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   IVA + ISR
                 </div>
                 <div className={`font-bold ${isDraft ? "text-yellow-700" : "text-violet-700"}`}>
-                  Q
-                  {(
-                    Number(subtotales.total_abono_iva) +
+                  {inv.currencySymbol} {(Number(subtotales.total_abono_iva) +
                     Number(subtotales.total_isr)
                   ).toLocaleString("es-GT", {
                     minimumFractionDigits: 2,
@@ -932,8 +932,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   💰 Total Cuota
                 </div>
                 <div className={`font-bold text-lg ${isDraft ? "text-yellow-900" : "text-green-900"}`}>
-                  Q
-                  {Number(subtotales.total_cuota).toLocaleString("es-GT", {
+                  {inv.currencySymbol} {Number(subtotales.total_cuota).toLocaleString("es-GT", {
                     minimumFractionDigits: 2,
                   })}
                 </div>
@@ -944,8 +943,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   Total Monto Aportado
                 </div>
                 <div className={`font-bold text-lg ${isDraft ? "text-yellow-900" : "text-purple-900"}`}>
-                  Q
-                  {Number(subtotales.total_monto_aportado).toLocaleString("es-GT", {
+                  {inv.currencySymbol} {Number(subtotales.total_monto_aportado).toLocaleString("es-GT", {
                     minimumFractionDigits: 2,
                   })}
                 </div>
@@ -1307,7 +1305,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                       />
                                     ) : (
                                       <div className="font-bold text-blue-900 text-sm">
-                                        Q{Number(pago.abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                        {inv.currencySymbol} {Number(pago.abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                       </div>
                                     )}
                                   </div>
@@ -1324,7 +1322,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                       />
                                     ) : (
                                       <div className="font-bold text-violet-900 text-sm">
-                                        Q{Number(pago.abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                        {inv.currencySymbol} {Number(pago.abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                       </div>
                                     )}
                                   </div>
@@ -1333,15 +1331,14 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                   <div className="bg-white rounded-lg p-2 border border-green-200">
                                     <div className="text-xs text-green-700">📈 IVA</div>
                                     {isDraft ? (
-                                      <input
-                                        type="number"
-                                        className="w-full text-right bg-white border border-green-300 rounded px-1 text-sm font-bold text-green-900 focus:outline-none focus:ring-2 focus:ring-green-500 mt-1"
-                                        value={changes[pago.id]?.abono_iva_12 ?? pago.abono_iva}
-                                        onChange={(e) => handleInputChange(pago.id, 'abono_iva_12', e.target.value)}
-                                      />
+                                      <div className="w-full text-right bg-green-50 rounded px-1 text-sm font-bold text-green-700 mt-1 h-7 flex items-center justify-end">
+                                        {inv.emite_factura
+                                          ? (Number(changes[pago.id]?.abono_interes ?? pago.abono_interes) * 0.12).toFixed(2)
+                                          : "0.00"}
+                                      </div>
                                     ) : (
                                       <div className="font-bold text-green-900 text-sm">
-                                        Q{Number(pago.abono_iva).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                        {inv.currencySymbol} {Number(pago.abono_iva).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                       </div>
                                     )}
                                   </div>
@@ -1349,9 +1346,17 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                   {/* 📉 ISR */}
                                   <div className="bg-white rounded-lg p-2 border border-yellow-200">
                                     <div className="text-xs text-yellow-700">📉 ISR</div>
-                                    <div className="font-bold text-yellow-900 text-sm">
-                                      Q{Number(pago.isr).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
-                                    </div>
+                                    {isDraft ? (
+                                      <div className="w-full text-right bg-yellow-50 rounded px-1 text-sm font-bold text-yellow-700 mt-1 h-7 flex items-center justify-end">
+                                        {!inv.emite_factura
+                                          ? (Number(changes[pago.id]?.abono_interes ?? pago.abono_interes) * 0.07).toFixed(2)
+                                          : "0.00"}
+                                      </div>
+                                    ) : (
+                                      <div className="font-bold text-yellow-900 text-sm">
+                                        {inv.currencySymbol} {Number(pago.isr).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                      </div>
+                                    )}
                                   </div>
                                 </div>
 
@@ -1462,31 +1467,31 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
         <div>
           <span className="font-bold text-blue-900">Total Capital: </span>
           <span className="text-blue-800 font-bold">
-            Q{Number(totalesData?.totales.total_abono_capital ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+            {totalesData?.currencySymbol ?? 'Q.'} {Number(totalesData?.totales.total_abono_capital ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
           </span>
         </div>
         <div>
           <span className="font-bold text-blue-900">Total Interés: </span>
           <span className="text-indigo-700 font-bold">
-            Q{Number(totalesData?.totales.total_abono_interes ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+            {totalesData?.currencySymbol ?? 'Q.'} {Number(totalesData?.totales.total_abono_interes ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
           </span>
         </div>
         <div>
           <span className="font-bold text-blue-900">IVA + ISR: </span>
           <span className="text-violet-700 font-bold">
-            Q{(Number(totalesData?.totales.total_abono_iva ?? 0) + Number(totalesData?.totales.total_isr ?? 0)).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+            {totalesData?.currencySymbol ?? 'Q.'} {(Number(totalesData?.totales.total_abono_iva ?? 0) + Number(totalesData?.totales.total_isr ?? 0)).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
           </span>
         </div>
         <div>
           <span className="font-bold text-blue-900">Total Cuota: </span>
           <span className="text-green-700 font-bold">
-            Q{Number(totalesData?.totales.total_cuota ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+            {totalesData?.currencySymbol ?? 'Q.'} {Number(totalesData?.totales.total_cuota ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
           </span>
         </div>
         <div>
           <span className="font-bold text-blue-900">Total Monto Aportado: </span>
           <span className="text-purple-700 font-bold">
-            Q{Number(totalesData?.totales.total_monto_aportado ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+            {totalesData?.currencySymbol ?? 'Q.'} {Number(totalesData?.totales.total_monto_aportado ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
           </span>
         </div>
         <div>
@@ -1692,7 +1697,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   <div className="bg-gradient-to-br from-green-50 to-emerald-50 rounded-lg p-3 shadow-sm border border-green-200">
                     <div className="text-xs text-green-700 mb-1">💰 Capital Aportado</div>
                     <div className="font-bold text-green-900 text-sm">
-                      Q{Number(cred.monto_aportado).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                      {inv.currencySymbol} {Number(cred.monto_aportado).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                     </div>
                   </div>
                   <div className="bg-gradient-to-br from-purple-50 to-violet-50 rounded-lg p-3 shadow-sm border border-purple-200">
@@ -1704,13 +1709,13 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   <div className="bg-gradient-to-br from-blue-50 to-cyan-50 rounded-lg p-3 shadow-sm border border-blue-200">
                     <div className="text-xs text-blue-700 mb-1">🏦 Capital Crédito</div>
                     <div className="font-bold text-blue-900 text-sm">
-                      Q{Number(cred.capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                      {inv.currencySymbol} {Number(cred.capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                     </div>
                   </div>
                   <div className="bg-gradient-to-br from-yellow-50 to-amber-50 rounded-lg p-3 shadow-sm border border-yellow-300">
                     <div className="text-xs text-yellow-700 mb-1">✨ Total a Recibir</div>
                     <div className="font-bold text-yellow-900 text-sm">
-                      Q{Number(cred.total_cuota).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                      {inv.currencySymbol} {Number(cred.total_cuota).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                     </div>
                   </div>
                 </div>
@@ -1720,25 +1725,25 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   <div className="bg-white rounded-lg p-2 shadow-sm border border-gray-200">
                     <div className="text-xs text-gray-600">Abono Capital</div>
                     <div className="font-semibold text-blue-900 text-xs">
-                      Q{Number(cred.total_abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                      {inv.currencySymbol} {Number(cred.total_abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                     </div>
                   </div>
                   <div className="bg-white rounded-lg p-2 shadow-sm border border-gray-200">
                     <div className="text-xs text-gray-600">Abono Interés</div>
                     <div className="font-semibold text-blue-900 text-xs">
-                      Q{Number(cred.total_abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                      {inv.currencySymbol} {Number(cred.total_abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                     </div>
                   </div>
                   <div className="bg-white rounded-lg p-2 shadow-sm border border-gray-200">
                     <div className="text-xs text-gray-600">IVA</div>
                     <div className="font-semibold text-blue-900 text-xs">
-                      Q{Number(cred.total_abono_iva).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                      {inv.currencySymbol} {Number(cred.total_abono_iva).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                     </div>
                   </div>
                   <div className="bg-white rounded-lg p-2 shadow-sm border border-gray-200">
                     <div className="text-xs text-gray-600">ISR</div>
                     <div className="font-semibold text-blue-900 text-xs">
-                      Q{Number(cred.total_isr).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                      {inv.currencySymbol} {Number(cred.total_isr).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                     </div>
                   </div>
                 </div>
@@ -1792,7 +1797,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                   />
                                 ) : (
                                   <div className="font-bold text-blue-900 text-sm">
-                                    Q{Number(pago.abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                    {inv.currencySymbol} {Number(pago.abono_capital).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                   </div>
                                 )}
                               </div>
@@ -1809,7 +1814,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                   />
                                 ) : (
                                   <div className="font-bold text-violet-900 text-sm">
-                                    Q{Number(pago.abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                    {inv.currencySymbol} {Number(pago.abono_interes).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                   </div>
                                 )}
                               </div>
@@ -1826,7 +1831,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                   />
                                 ) : (
                                   <div className="font-bold text-green-900 text-sm">
-                                    Q{Number(pago.abono_iva).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                    {inv.currencySymbol} {Number(pago.abono_iva).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                   </div>
                                 )}
                               </div>
@@ -1835,14 +1840,14 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                               <div className="bg-gradient-to-br from-yellow-50 to-yellow-100 rounded-lg p-2 border border-yellow-200">
                                 <div className="text-xs text-yellow-700">📉 ISR (Calc)</div>
                                 <div className="font-bold text-yellow-900 text-sm">
-                                  Q{Number(pago.isr).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                  {inv.currencySymbol} {Number(pago.isr).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                 </div>
                               </div>
 
                               <div className="col-span-2 bg-gradient-to-br from-indigo-50 to-indigo-100 rounded-lg p-2 border border-indigo-300">
                                 <div className="text-xs text-indigo-700">💎 Total Inversor</div>
                                 <div className="font-bold text-indigo-900 text-base">
-                                  Q{Number(pago.abonoGeneralInteres).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                  {inv.currencySymbol} {Number(pago.abonoGeneralInteres).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                                 </div>
                               </div>
                             </div>

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -31,6 +31,7 @@ export interface InvestorPayload {
   tipo_cuenta: string | null;
   re_inversion: string | null;
   numero_cuenta: string | null;
+  moneda?: string;
 }
 export interface InvestorResponse {
   inversionista_id: number;
@@ -40,6 +41,8 @@ export interface InvestorResponse {
   banco: string | null;
   tipo_cuenta: string | null;
   numero_cuenta: string | null;
+  moneda?: string;
+  currencySymbol?: string;
 }
 
 // Crear inversionista(s)
@@ -742,7 +745,8 @@ export interface InversionistaConCreditos {
   re_inversion:string
   dpi:number | null
   tieneBoletaPendiente:boolean
-
+  moneda?: string;
+  currencySymbol?: string;
 }
 
 // La respuesta completa (paginada)
@@ -759,6 +763,8 @@ export interface InversionistasCreditosResponse {
 export interface InvestorTotalsResponse {
   inversionista_id: number;
   nombre_inversionista: string;
+  moneda?: string;
+  currencySymbol?: string;
   totales: SubtotalInversionista;
 }
 


### PR DESCRIPTION
## Descripción
Se actualizó la lógica del endpoint de liquidación de inversionistas ([liquidateByInvestorId](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/investor.ts:1898:0-2250:1)) para independizar el cálculo de los saldos de la tabla original de pagos y utilizar exclusivamente la tabla espejo como fuente de verdad. 

## Cambios Principales
* **Fuente de Verdad Actualizada:** La obtención de abonos a capital y la identificación de pagos pendientes ahora se realiza consultando únicamente la tabla `pagos_credito_inversionistas_espejo`.
* **Cálculo de Totales Unificado:** Se incluyó el parámetro `"espejos"` al invocar [resumeInvestor](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/investor.ts:924:0-1337:1) dentro de la función, asegurando que los subtotales globales y del PDF generado coincidan rigurosamente con los datos procesados en la tabla espejo.
* **Control de Saldos (Monto Aportado):** Se implementó una lógica donde, al liquidar pagos, el monto total del capital abonado se resta del `monto_aportado` actual. Esto se refleja de forma dual: tanto en la tabla `creditos_inversionistas` original como en `creditos_inversionistas_espejo`, manteniéndolas en sincronía.
* **Liquidación Aislada:** El paso final que actualiza el estado (`estado_liquidacion`) a `"LIQUIDADO"` y que asocia el `liquidacion_id` se aplica estrictamente a la tabla `pagos_credito_inversionistas_espejo`. La tabla original de pagos ya no se altera durante este proceso.

