### PR TITLE
feat(juridico): agregar etapa 85% Contratos en Firma

### DIFF
--- a/apps/crm/apps/server/src/db/seed.ts
+++ b/apps/crm/apps/server/src/db/seed.ts
@@ -82,15 +82,23 @@ const salesStagesData = [
 		description: "Cierre definitivo del negocio",
 	},
 	{
-		name: "Formalización Final",
+		name: "Contratos en Firma",
 		order: 8,
+		closurePercentage: 85,
+		color: "#22c55e", // green-500
+		description:
+			"Contratos generados por jurídico, pendientes de firma por el cliente",
+	},
+	{
+		name: "Formalización Final",
+		order: 9,
 		closurePercentage: 90,
 		color: "#22c55e", // green-500
 		description: "Formalización completa de todos los documentos",
 	},
 	{
 		name: "Post Venta",
-		order: 9,
+		order: 10,
 		closurePercentage: 100,
 		color: "#22c55e", // green-500
 		description: "Seguimiento post-venta y gestión de la relación cliente",

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -167,6 +167,13 @@ export const PERMISSIONS = {
 	canApproveLegalStage: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.JURIDICO,
 
+	// Confirm contracts have been signed (85% → 90%)
+	canConfirmContractsSigning: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN ||
+		role === ROLES.SALES ||
+		role === ROLES.SALES_SUPERVISOR ||
+		role === ROLES.JURIDICO,
+
 	// Clients Module Access
 	canAccessClients: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN ||

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1354,8 +1354,8 @@ export const crmRouter = {
 					}
 				}
 
-				// Note: The actual 100% closure logic (credit creation, client, contract)
-				// is now handled by approveDisbursement via closeOpportunity service
+				// Note: El cierre del crédito (creación en cartera-back, cliente, contrato)
+				// se ejecuta en confirmContractsSigned (85% → 90%) en legal-contracts.ts
 			}
 
 			// Calculate new analysisStatus based on stage transition

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1253,28 +1253,12 @@ export const crmRouter = {
 					}
 				}
 
-				// Validate legal approval when moving from 80% to 90%
-				if (fromPercentage === 80 && toPercentage === 90) {
-					// Only juridico and admin can approve this transition
-					if (!PERMISSIONS.canApproveLegalStage(context.userRole)) {
-						throw new ORPCError("BAD_REQUEST", {
-							message:
-								"Para avanzar de 80% a 90%, la oportunidad debe ser aprobada por el departamento jurídico.",
-						});
-					}
-
-					// Verify there's at least one contract associated
-					const [{ count: contractCount }] = await db
-						.select({ count: count() })
-						.from(generatedLegalContracts)
-						.where(eq(generatedLegalContracts.opportunityId, id));
-
-					if (Number(contractCount) === 0) {
-						throw new ORPCError("BAD_REQUEST", {
-							message:
-								"Debe haber al menos un contrato asociado a la oportunidad para avanzar a 90%.",
-						});
-					}
+				// Validate transitions from 80% - must go through jurídico approval to 85%
+				if (fromPercentage === 80 && toPercentage >= 85) {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"Para avanzar de 80% a la siguiente etapa, la oportunidad debe ser aprobada por el departamento jurídico desde el módulo de Jurídico.",
+					});
 				}
 
 				// Validaciones para avanzar a etapa 80% (jurídica)
@@ -1350,15 +1334,11 @@ export const crmRouter = {
 					}
 				}
 
-				//  en este apartado ya nadie puede mover de 80 a 90 sin aprobacion de analista
-				// Validate document approval when moving from 80% to 90%
-				if (fromPercentage === 80 && toPercentage >= 90) {
-					console.log(
-						"Validating document approval for 80% to 90% stage change",
-					);
+				// Validate: 85% → 90% must use confirmContractsSigned endpoint
+				if (fromPercentage === 85 && toPercentage >= 90) {
 					throw new ORPCError("BAD_REQUEST", {
 						message:
-							"Para avanzar de evaluación (80%) a la siguiente etapa (90%+), solo un analista puede realizar este cambio después de aprobar los documentos.",
+							"Para avanzar de 85% (Contratos en Firma) a 90%, debes confirmar que los contratos fueron firmados usando el botón de confirmación.",
 					});
 				}
 

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -5515,8 +5515,7 @@ export const crmRouter = {
 
 			// Only admin and sales_supervisor see global charts
 			const isGlobal =
-				context.userRole === "admin" ||
-				context.userRole === "sales_supervisor";
+				context.userRole === "admin" || context.userRole === "sales_supervisor";
 			const userFilter = isGlobal ? undefined : context.userId;
 
 			// 1) Pipeline por Etapa: count + sum(value) grouped by stage
@@ -5536,9 +5535,7 @@ export const crmRouter = {
 						eq(opportunities.status, "open"),
 						gte(opportunities.createdAt, startOfMonth),
 						lt(opportunities.createdAt, endOfMonth),
-						userFilter
-							? eq(opportunities.assignedTo, userFilter)
-							: undefined,
+						userFilter ? eq(opportunities.assignedTo, userFilter) : undefined,
 					),
 				)
 				.groupBy(
@@ -5577,9 +5574,7 @@ export const crmRouter = {
 							inArray(opportunities.stageId, placedStageIds),
 							gte(opportunities.createdAt, startOfMonth),
 							lt(opportunities.createdAt, endOfMonth),
-							userFilter
-								? eq(opportunities.assignedTo, userFilter)
-								: undefined,
+							userFilter ? eq(opportunities.assignedTo, userFilter) : undefined,
 						),
 					)
 					.groupBy(user.id, user.name)
@@ -5605,9 +5600,7 @@ export const crmRouter = {
 						inArray(opportunities.status, ["open", "won", "lost"]),
 						gte(opportunities.createdAt, startOfMonth),
 						lt(opportunities.createdAt, endOfMonth),
-						userFilter
-							? eq(opportunities.assignedTo, userFilter)
-							: undefined,
+						userFilter ? eq(opportunities.assignedTo, userFilter) : undefined,
 					),
 				)
 				.groupBy(user.id, user.name, opportunities.status);

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -166,7 +166,7 @@ export const appRouter = {
 	getOpportunitiesForContracts:
 		legalContractsRouter.getOpportunitiesForContracts,
 	approveOpportunityLegal: legalContractsRouter.approveOpportunityLegal,
-	markAllContractsSigned: legalContractsRouter.markAllContractsSigned,
+	confirmContractsSigned: legalContractsRouter.confirmContractsSigned,
 
 	// Contract Generation routes (Generación automática de contratos)
 	getContractTypes: contractGenerationRouter.getContractTypes,

--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -24,6 +24,7 @@ import {
 	uploadFileToR2,
 	validateFile,
 } from "../lib/storage";
+import { closeOpportunity } from "../services/close-opportunity";
 import { createNotification } from "./notifications";
 
 // Standardized env var naming: R2_BUCKET_* pattern
@@ -811,18 +812,6 @@ export const legalContractsRouter = {
 				});
 			}
 
-			// Close the opportunity (create credit, client, contract)
-			const closeResult = await closeOpportunity({
-				opportunityId: input.opportunityId,
-				userId: context.userId,
-			});
-
-			if (!closeResult.success) {
-				throw new ORPCError("BAD_REQUEST", {
-					message: closeResult.error || "Error al cerrar la oportunidad",
-				});
-			}
-
 			// Obtener la etapa del 85%
 			const [targetStage] = await db
 				.select()
@@ -1008,6 +997,18 @@ export const legalContractsRouter = {
 					reason: "Contratos firmados confirmados - Avanza a formalización",
 				});
 			});
+
+			// Cerrar la oportunidad (crear crédito, cliente, contrato en cartera)
+			const closeResult = await closeOpportunity({
+				opportunityId: input.opportunityId,
+				userId: context.userId,
+			});
+
+			if (!closeResult.success) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: closeResult.error || "Error al cerrar la oportunidad",
+				});
+			}
 
 			// Notificar a análisis que está lista para desembolso
 			await createNotification({

--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -24,8 +24,6 @@ import {
 	uploadFileToR2,
 	validateFile,
 } from "../lib/storage";
-import { closeOpportunity } from "../services/close-opportunity";
-import { checkDocumensoSigningStatus } from "../services/documenso-signing";
 import { createNotification } from "./notifications";
 
 // Standardized env var naming: R2_BUCKET_* pattern
@@ -547,57 +545,6 @@ export const legalContractsRouter = {
 			return updatedContract;
 		}),
 
-	// Marcar todos los contratos de una oportunidad como firmados
-	markAllContractsSigned: juridicoProcedure
-		.input(
-			z.object({
-				opportunityId: z.string().uuid(),
-			}),
-		)
-		.handler(async ({ input, context }) => {
-			if (!context.canCreateLegalContracts) {
-				throw new ORPCError("FORBIDDEN", {
-					message: "No tienes permisos para actualizar contratos",
-				});
-			}
-
-			// Verificar que la oportunidad existe
-			const [opportunity] = await db
-				.select({ id: opportunities.id })
-				.from(opportunities)
-				.where(eq(opportunities.id, input.opportunityId))
-				.limit(1);
-
-			if (!opportunity) {
-				throw new ORPCError("NOT_FOUND", {
-					message: "Oportunidad no encontrada",
-				});
-			}
-
-			const updated = await db
-				.update(generatedLegalContracts)
-				.set({
-					status: "signed",
-					updatedAt: new Date(),
-				})
-				.where(
-					and(
-						eq(generatedLegalContracts.opportunityId, input.opportunityId),
-						eq(generatedLegalContracts.status, "pending"),
-					),
-				)
-				.returning();
-
-			if (updated.length === 0) {
-				throw new ORPCError("NOT_FOUND", {
-					message:
-						"No se encontraron contratos pendientes para esta oportunidad",
-				});
-			}
-
-			return { success: true, updatedCount: updated.length };
-		}),
-
 	// Eliminar contrato (solo admin)
 	deleteContract: adminProcedure
 		.input(
@@ -864,24 +811,6 @@ export const legalContractsRouter = {
 				});
 			}
 
-			// Verificar que todos los contratos activos estén firmados
-			const [{ count: unsignedCount }] = await db
-				.select({ count: count() })
-				.from(generatedLegalContracts)
-				.where(
-					and(
-						eq(generatedLegalContracts.opportunityId, input.opportunityId),
-						eq(generatedLegalContracts.status, "pending"),
-					),
-				);
-
-			if (Number(unsignedCount) > 0) {
-				throw new ORPCError("BAD_REQUEST", {
-					message:
-						"Todos los contratos deben estar firmados antes de aprobar. Hay contratos pendientes de firma.",
-				});
-			}
-
 			// Close the opportunity (create credit, client, contract)
 			/*const closeResult = await closeOpportunity({
 				opportunityId: input.opportunityId,
@@ -894,22 +823,22 @@ export const legalContractsRouter = {
 				});
 			}*/
 
-			// Obtener la etapa del 90%
+			// Obtener la etapa del 85%
 			const [targetStage] = await db
 				.select()
 				.from(salesStages)
-				.where(eq(salesStages.closurePercentage, 90))
+				.where(eq(salesStages.closurePercentage, 85))
 				.limit(1);
 
 			if (!targetStage) {
 				throw new ORPCError("NOT_FOUND", {
-					message: "No se encontró la etapa del 90%",
+					message: "No se encontró la etapa del 85%",
 				});
 			}
 
 			// Actualizar la oportunidad y registrar historial en una transacción
 			await db.transaction(async (tx) => {
-				// Actualizar la oportunidad a 90%
+				// Actualizar la oportunidad a 85%
 				await tx
 					.update(opportunities)
 					.set({
@@ -924,14 +853,166 @@ export const legalContractsRouter = {
 					fromStageId: opportunity.stageId,
 					toStageId: targetStage.id,
 					changedBy: context.userId,
-					reason: "Aprobación legal - Contratos adjuntados",
+					reason: "Aprobación legal - Contratos generados, pendientes de firma",
 				});
 			});
 
-			// Notificar a análisis que los contratos fueron creados y está lista para desembolso
+			// Notificar al asesor de ventas que debe confirmar firma de contratos
+			if (opportunity.assignedTo) {
+				await createNotification({
+					titulo: `Contratos listos para firma - ${opportunity.title}`,
+					descripcion: `Los contratos de la oportunidad "${opportunity.title}" fueron generados por jurídico. Confirma cuando estén firmados para avanzar al 90%.`,
+					type: "aviso",
+					createdBy: context.userId,
+					createdByRole: context.userRole,
+					assignedToRole: "sales",
+					assignedTo: opportunity.assignedTo,
+					relatedEntityType: "opportunity",
+					relatedEntityId: input.opportunityId,
+					redirectPage: "opportunity_details",
+				});
+			}
+
+			return {
+				success: true,
+				message:
+					"Oportunidad aprobada y movida a la etapa del 85% (Contratos en Firma)",
+				newStageId: targetStage.id,
+				newStageName: targetStage.name,
+			};
+		}),
+
+	// Confirmar que los contratos fueron firmados (mover de 85% a 90%)
+	confirmContractsSigned: viewOpportunityContractsProcedure
+		.input(
+			z.object({
+				opportunityId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			// Verificar permisos
+			if (!PERMISSIONS.canConfirmContractsSigning(context.userRole)) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permisos para confirmar la firma de contratos",
+				});
+			}
+
+			// Obtener la oportunidad con su etapa actual
+			const [opportunity] = await db
+				.select({
+					id: opportunities.id,
+					stageId: opportunities.stageId,
+					leadId: opportunities.leadId,
+					title: opportunities.title,
+					assignedTo: opportunities.assignedTo,
+				})
+				.from(opportunities)
+				.where(eq(opportunities.id, input.opportunityId))
+				.limit(1);
+
+			if (!opportunity) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Oportunidad no encontrada",
+				});
+			}
+
+			// Verificar que la oportunidad está en 85%
+			const [currentStage] = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.id, opportunity.stageId))
+				.limit(1);
+
+			if (!currentStage || currentStage.closurePercentage !== 85) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: `La oportunidad debe estar en la etapa del 85% (Contratos en Firma) para confirmar. Actualmente está en ${currentStage?.closurePercentage || 0}%`,
+				});
+			}
+
+			// Verificar que hay contratos asociados a la oportunidad
+			const [{ count: contractCount }] = await db
+				.select({ count: count() })
+				.from(generatedLegalContracts)
+				.where(eq(generatedLegalContracts.opportunityId, input.opportunityId));
+
+			if (Number(contractCount) === 0) {
+				throw new ORPCError("BAD_REQUEST", {
+					message:
+						"No hay contratos asociados a esta oportunidad. No se puede confirmar la firma.",
+				});
+			}
+
+			// Obtener la etapa del 90%
+			const [targetStage] = await db
+				.select()
+				.from(salesStages)
+				.where(eq(salesStages.closurePercentage, 90))
+				.limit(1);
+
+			if (!targetStage) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "No se encontró la etapa del 90%",
+				});
+			}
+
+			// En transacción: re-verificar etapa + marcar contratos + mover a 90%
+			await db.transaction(async (tx) => {
+				// Re-verificar que la oportunidad sigue en 85% (previene race condition)
+				const [currentOpp] = await tx
+					.select({ stageId: opportunities.stageId })
+					.from(opportunities)
+					.where(eq(opportunities.id, input.opportunityId))
+					.limit(1);
+
+				const [currentStageInTx] = await tx
+					.select({ closurePercentage: salesStages.closurePercentage })
+					.from(salesStages)
+					.where(eq(salesStages.id, currentOpp.stageId))
+					.limit(1);
+
+				if (currentStageInTx.closurePercentage !== 85) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: "La oportunidad ya fue procesada por otro usuario.",
+					});
+				}
+
+				// Marcar todos los contratos pending como signed
+				await tx
+					.update(generatedLegalContracts)
+					.set({
+						status: "signed",
+						updatedAt: new Date(),
+					})
+					.where(
+						and(
+							eq(generatedLegalContracts.opportunityId, input.opportunityId),
+							eq(generatedLegalContracts.status, "pending"),
+						),
+					);
+
+				// Mover oportunidad a 90%
+				await tx
+					.update(opportunities)
+					.set({
+						stageId: targetStage.id,
+						updatedAt: new Date(),
+					})
+					.where(eq(opportunities.id, input.opportunityId));
+
+				// Registrar en historial
+				await tx.insert(opportunityStageHistory).values({
+					opportunityId: input.opportunityId,
+					fromStageId: opportunity.stageId,
+					toStageId: targetStage.id,
+					changedBy: context.userId,
+					reason: "Contratos firmados confirmados - Avanza a formalización",
+				});
+			});
+
+			// Notificar a análisis que está lista para desembolso
 			await createNotification({
-				titulo: `Contratos listos - ${opportunity.title}`,
-				descripcion: `Los contratos legales de la oportunidad "${opportunity.title}" fueron adjuntados. La oportunidad pasó a la etapa del 90% y está lista para revisión de desembolso.`,
+				titulo: `Contratos firmados - ${opportunity.title}`,
+				descripcion: `Los contratos de la oportunidad "${opportunity.title}" fueron firmados. La oportunidad pasó a la etapa del 90% y está lista para revisión de desembolso.`,
 				type: "aviso",
 				createdBy: context.userId,
 				createdByRole: context.userRole,
@@ -941,25 +1022,10 @@ export const legalContractsRouter = {
 				redirectPage: "analysis_90_details",
 			});
 
-			// Notificar al asesor de ventas asignado que el crédito está ganado
-			if (opportunity.assignedTo) {
-				await createNotification({
-					titulo: `Crédito ganado - ${opportunity.title}`,
-					descripcion: `Los contratos de la oportunidad "${opportunity.title}" fueron cargados y avanzó al 90%. El crédito está ganado.`,
-					type: "aviso",
-					createdBy: context.userId,
-					createdByRole: context.userRole,
-					assignedToRole: "sales",
-					assignedTo: opportunity.assignedTo,
-					relatedEntityType: "opportunity",
-					redirectPage: "client_details",
-					relatedEntityId: input.opportunityId,
-				});
-			}
-
 			return {
 				success: true,
-				message: "Oportunidad aprobada y movida a la etapa del 90%",
+				message:
+					"Contratos confirmados como firmados. Oportunidad movida a la etapa del 90%",
 				newStageId: targetStage.id,
 				newStageName: targetStage.name,
 			};

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -658,6 +658,11 @@ export class CarteraBackClient {
 			true,
 		);
 
+		console.log(
+			"[CarteraBackClient] getStats raw response:",
+			JSON.stringify(response, null, 2),
+		);
+
 		return response;
 	}
 

--- a/apps/crm/apps/web/src/components/crm/ConfirmContractsSignedModal.tsx
+++ b/apps/crm/apps/web/src/components/crm/ConfirmContractsSignedModal.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle } from "lucide-react";
+import { FileSignature } from "lucide-react";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -10,7 +10,7 @@ import {
 	AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 
-interface ApproveOpportunityModalProps {
+interface ConfirmContractsSignedModalProps {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	onConfirm: () => void;
@@ -18,44 +18,39 @@ interface ApproveOpportunityModalProps {
 	opportunityTitle?: string;
 }
 
-export function ApproveOpportunityModal({
+export function ConfirmContractsSignedModal({
 	open,
 	onOpenChange,
 	onConfirm,
 	isLoading = false,
 	opportunityTitle,
-}: ApproveOpportunityModalProps) {
+}: ConfirmContractsSignedModalProps) {
 	return (
 		<AlertDialog open={open} onOpenChange={onOpenChange}>
 			<AlertDialogContent>
 				<AlertDialogHeader>
 					<AlertDialogTitle className="flex items-center gap-2">
-						<CheckCircle className="h-5 w-5 text-green-600" />
-						¿Aprobar y enviar a firma?
+						<FileSignature className="h-5 w-5 text-green-600" />
+						¿Todos los contratos han sido firmados?
 					</AlertDialogTitle>
 					<AlertDialogDescription asChild>
 						<div className="space-y-3 pt-2">
-							<p>
-								Los contratos fueron generados
-								{opportunityTitle && (
-									<>
-										{" "}
-										para la oportunidad <strong>{opportunityTitle}</strong>
-									</>
-								)}
-								.
-							</p>
+							{opportunityTitle && (
+								<p>
+									Oportunidad: <strong>{opportunityTitle}</strong>
+								</p>
+							)}
 							<div className="rounded-lg bg-blue-50 p-3">
 								<p className="font-medium text-blue-900 text-sm">
-									<CheckCircle className="mr-1 inline h-4 w-4" />
-									Esta acción moverá la oportunidad al 85% (Contratos en Firma)
+									<FileSignature className="mr-1 inline h-4 w-4" />
+									Al confirmar, los contratos se marcarán como firmados y la
+									oportunidad avanzará al 90%
 								</p>
 								<p className="mt-1 text-blue-700 text-xs">
-									El asesor de ventas recibirá una notificación para confirmar
-									cuando los contratos estén firmados.
+									Asegúrate de que todos los contratos estén debidamente
+									firmados antes de confirmar.
 								</p>
 							</div>
-							<p className="font-medium text-sm">¿Estás seguro de continuar?</p>
 						</div>
 					</AlertDialogDescription>
 				</AlertDialogHeader>
@@ -69,7 +64,7 @@ export function ApproveOpportunityModal({
 						disabled={isLoading}
 						className="bg-green-600 hover:bg-green-700"
 					>
-						{isLoading ? "Procesando..." : "Sí, aprobar y enviar a firma"}
+						{isLoading ? "Procesando..." : "Sí, contratos firmados"}
 					</AlertDialogAction>
 				</AlertDialogFooter>
 			</AlertDialogContent>

--- a/apps/crm/apps/web/src/components/juridico/ApproveOpportunityModal.tsx
+++ b/apps/crm/apps/web/src/components/juridico/ApproveOpportunityModal.tsx
@@ -1,4 +1,9 @@
-import { AlertCircle, AlertTriangle, CheckCircle, FileText } from "lucide-react";
+import {
+	AlertCircle,
+	AlertTriangle,
+	CheckCircle,
+	FileText,
+} from "lucide-react";
 import {
 	AlertDialog,
 	AlertDialogAction,
@@ -55,9 +60,7 @@ export function ApproveOpportunityModal({
 						) : (
 							<CheckCircle className="h-5 w-5 text-green-600" />
 						)}
-						{hasUnsigned
-							? "Contratos sin firmar"
-							: "¿Completar contratos?"}
+						{hasUnsigned ? "Contratos sin firmar" : "¿Completar contratos?"}
 					</AlertDialogTitle>
 					<AlertDialogDescription asChild>
 						<div className="space-y-3 pt-2">
@@ -73,8 +76,7 @@ export function ApproveOpportunityModal({
 										{opportunityTitle && (
 											<>
 												{" "}
-												en la oportunidad{" "}
-												<strong>{opportunityTitle}</strong>
+												en la oportunidad <strong>{opportunityTitle}</strong>
 											</>
 										)}
 										:
@@ -91,9 +93,7 @@ export function ApproveOpportunityModal({
 												</span>
 												<Badge
 													variant={
-														contract.status === "signed"
-															? "default"
-															: "outline"
+														contract.status === "signed" ? "default" : "outline"
 													}
 													className={
 														contract.status === "signed"
@@ -111,8 +111,7 @@ export function ApproveOpportunityModal({
 									<div className="rounded-lg bg-amber-50 p-3">
 										<p className="font-medium text-amber-900 text-sm">
 											<AlertCircle className="mr-1 inline h-4 w-4" />
-											Debes marcar los contratos como firmados antes de
-											aprobar
+											Debes marcar los contratos como firmados antes de aprobar
 										</p>
 									</div>
 								</>
@@ -123,8 +122,7 @@ export function ApproveOpportunityModal({
 										{opportunityTitle && (
 											<>
 												{" "}
-												para la oportunidad{" "}
-												<strong>{opportunityTitle}</strong>
+												para la oportunidad <strong>{opportunityTitle}</strong>
 											</>
 										)}
 										.
@@ -135,8 +133,8 @@ export function ApproveOpportunityModal({
 											Esta acción moverá la oportunidad al 90% de cierre
 										</p>
 										<p className="mt-1 text-blue-700 text-xs">
-											La oportunidad avanzará a la siguiente etapa del
-											proceso de venta.
+											La oportunidad avanzará a la siguiente etapa del proceso
+											de venta.
 										</p>
 									</div>
 									<p className="font-medium text-sm">
@@ -160,9 +158,7 @@ export function ApproveOpportunityModal({
 							disabled={isMarkingAsSigned}
 							className="bg-amber-600 hover:bg-amber-700"
 						>
-							{isMarkingAsSigned
-								? "Marcando..."
-								: "Marcar todos como firmados"}
+							{isMarkingAsSigned ? "Marcando..." : "Marcar todos como firmados"}
 						</Button>
 					) : (
 						<AlertDialogAction

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -55,43 +55,62 @@ function getEstadoBadge(estado: string) {
 
 export const columns: ColumnDef<ContratoCobranza>[] = [
 	{
-		accessorKey: "diasHastaPago",
+		accessorKey: "fechaProximoPago",
 		header: ({ column }) => {
 			return (
 				<Button
 					variant="ghost"
 					onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
 				>
-					Días hasta Pago
+					Fecha de Pago
 					<ArrowUpDown className="ml-2 h-4 w-4" />
 				</Button>
 			);
 		},
 		cell: ({ row }) => {
-			const dias = row.getValue("diasHastaPago") as number | null;
-			let className = "font-medium";
+			const fecha = row.getValue("fechaProximoPago") as string | null;
+			const dias = row.original.diasHastaPago;
 
-			// Si no hay fecha de próximo pago definida
+			if (!fecha) {
+				return (
+					<div className="font-medium text-gray-500">Sin fecha definida</div>
+				);
+			}
+
+			const fechaFormateada = new Date(fecha).toLocaleDateString("es-GT", {
+				day: "2-digit",
+				month: "short",
+				year: "numeric",
+			});
+
+			let diasClassName = "text-xs mt-0.5";
+			let diasText = "";
+
 			if (dias === null) {
-				className += " text-gray-500";
-				return <div className={className}>Sin fecha definida</div>;
-			}
-
-			if (dias === 0) {
-				className += " text-red-600";
-				return <div className={className}>¡Hoy!</div>;
-			}
-			if (dias < 0) {
-				className += " text-red-700";
-				return <div className={className}>{Math.abs(dias)} días vencido</div>;
-			}
-			if (dias <= 3) {
-				className += " text-orange-600";
+				diasText = "";
+			} else if (dias === 0) {
+				diasClassName += " text-red-600 font-semibold";
+				diasText = "¡Hoy!";
+			} else if (dias < 0) {
+				diasClassName += " text-red-700 font-semibold";
+				diasText = `${Math.abs(dias)} días vencido`;
+			} else if (dias <= 3) {
+				diasClassName += " text-orange-600";
+				diasText = `en ${dias} días`;
 			} else if (dias <= 7) {
-				className += " text-yellow-600";
+				diasClassName += " text-yellow-600";
+				diasText = `en ${dias} días`;
+			} else {
+				diasClassName += " text-muted-foreground";
+				diasText = `en ${dias} días`;
 			}
 
-			return <div className={className}>{dias} días</div>;
+			return (
+				<div className="font-medium">
+					<div>{fechaFormateada}</div>
+					{diasText && <div className={diasClassName}>{diasText}</div>}
+				</div>
+			);
 		},
 	},
 	{

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -961,7 +961,7 @@ function RouteComponent() {
 						<CardContent className="space-y-3">
 							<div>
 								<p className="text-muted-foreground text-sm">
-									Monto Financiado
+									Capital Activo
 								</p>
 								<p className="font-medium">
 									Q{Number(caso.montoFinanciado || 0).toLocaleString()}

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -960,9 +960,7 @@ function RouteComponent() {
 						</CardHeader>
 						<CardContent className="space-y-3">
 							<div>
-								<p className="text-muted-foreground text-sm">
-									Capital Activo
-								</p>
+								<p className="text-muted-foreground text-sm">Capital Activo</p>
 								<p className="font-medium">
 									Q{Number(caso.montoFinanciado || 0).toLocaleString()}
 								</p>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -5,6 +5,7 @@ import {
 	Banknote,
 	CalendarDays,
 	CalendarRange,
+	ChevronDown,
 	Loader2,
 	Phone,
 	TrendingDown,
@@ -22,6 +23,11 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { authClient } from "@/lib/auth-client";
 import { type ContratoCobranza, columns } from "@/lib/cobros/columns";
 import { PERMISSIONS, ROLES } from "@/lib/roles";
@@ -44,6 +50,213 @@ function calcularDiasHastaPago(fechaProximoPago: string | null) {
 }
 
 type FiltroTemporal = "hoy" | "semana" | "quincena" | "mes" | "todos";
+
+interface EmbudoEstado {
+	key: string;
+	label: string;
+	color: string;
+	barColor: string;
+}
+
+interface EmbudoStats {
+	totalCases: number;
+	montoTotal: string;
+	sumaCapital: string;
+	porcentaje: string;
+}
+
+function EmbudoRow({
+	estado,
+	estadoStats,
+	maxCasos,
+	emailCobrador,
+	onNavigate,
+}: {
+	estado: EmbudoEstado;
+	estadoStats: EmbudoStats;
+	maxCasos: number;
+	emailCobrador: string | undefined;
+	onNavigate: (id: string, tipo: string) => void;
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+	const porcentaje = (estadoStats.totalCases / maxCasos) * 100;
+
+	const topCasos = useQuery({
+		...orpc.getTodosLosCreditos.queryOptions({
+			input: {
+				limit: 5,
+				offset: 0,
+				estadoMora: estado.key,
+				emailCobrador,
+			},
+		}),
+		enabled: isOpen && estadoStats.totalCases > 0,
+	});
+
+	const casosOrdenados = useMemo(() => {
+		if (!topCasos.data?.data) return [];
+		return [...topCasos.data.data].sort(
+			(a, b) => Number(b.montoFinanciado || 0) - Number(a.montoFinanciado || 0),
+		);
+	}, [topCasos.data]);
+
+	return (
+		<Collapsible
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			className="rounded-lg border border-border"
+		>
+			<CollapsibleTrigger asChild>
+				<button
+					type="button"
+					className="group flex w-full cursor-pointer items-center gap-3 p-3 text-left transition-all hover:bg-muted/50"
+				>
+					<div className="flex w-32 shrink-0 items-center gap-2">
+						<Badge className={`${estado.color} whitespace-nowrap text-xs`}>
+							{estado.label}
+						</Badge>
+					</div>
+					<div className="relative flex-1">
+						<div className="h-10 w-full overflow-hidden rounded-md bg-muted">
+							{porcentaje >= 15 ? (
+								<div
+									className="flex h-full items-center justify-between px-3 transition-all duration-300 group-hover:opacity-80"
+									style={{
+										width: `${porcentaje}%`,
+										backgroundColor: estado.barColor,
+									}}
+								>
+									<span
+										className="whitespace-nowrap font-semibold text-sm"
+										style={{
+											color: porcentaje > 60 ? "white" : "#1f2937",
+										}}
+									>
+										{estadoStats.totalCases} casos -{" "}
+										{Number.parseFloat(estadoStats.porcentaje || "0").toFixed(
+											1,
+										)}
+										%
+									</span>
+								</div>
+							) : (
+								<div className="flex h-full items-center">
+									<div
+										className="h-full transition-all duration-300 group-hover:opacity-80"
+										style={{
+											width: `${Math.max(porcentaje, 3)}%`,
+											backgroundColor: estado.barColor,
+										}}
+									/>
+									<span className="ml-2 whitespace-nowrap font-semibold text-muted-foreground text-sm">
+										{estadoStats.totalCases} casos -{" "}
+										{Number.parseFloat(estadoStats.porcentaje || "0").toFixed(
+											1,
+										)}
+										%
+									</span>
+								</div>
+							)}
+						</div>
+					</div>
+					<div className="flex w-52 shrink-0 flex-col gap-1 text-right text-sm">
+						<div className="flex items-center justify-end gap-2">
+							<span className="text-muted-foreground text-xs">Mora:</span>
+							<span className="font-medium">
+								Q{Number(estadoStats.montoTotal || 0).toLocaleString()}
+							</span>
+						</div>
+						<div className="flex items-center justify-end gap-2">
+							<span className="text-muted-foreground text-xs">Capital:</span>
+							<span className="font-medium">
+								Q{Number(estadoStats.sumaCapital || 0).toLocaleString()}
+							</span>
+						</div>
+					</div>
+					<ChevronDown
+						className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 ${isOpen ? "rotate-180" : ""}`}
+					/>
+				</button>
+			</CollapsibleTrigger>
+			<CollapsibleContent>
+				<div className="overflow-hidden border-t bg-card">
+					{topCasos.isLoading ? (
+						<div className="flex items-center justify-center gap-2 py-4">
+							<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+							<span className="text-muted-foreground text-sm">
+								Cargando casos...
+							</span>
+						</div>
+					) : casosOrdenados.length === 0 ? (
+						<div className="py-4 text-center text-muted-foreground text-sm">
+							Sin casos en esta etapa
+						</div>
+					) : (
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="border-b bg-muted/30">
+									<th className="py-2 pl-3 text-left font-medium text-muted-foreground">
+										Cliente
+									</th>
+									<th className="py-2 text-left font-medium text-muted-foreground">
+										No. Crédito
+									</th>
+									<th className="py-2 text-right font-medium text-muted-foreground">
+										Capital Activo
+									</th>
+									<th className="py-2 text-right font-medium text-muted-foreground">
+										Mora
+									</th>
+									<th className="py-2 pr-3 text-right font-medium text-muted-foreground">
+										Cuota
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{casosOrdenados.map((caso) => (
+									<tr
+										key={caso.numeroCredito || caso.contratoId}
+										className="cursor-pointer border-b transition-colors last:border-b-0 hover:bg-muted/40"
+										onClick={() => {
+											const linkId = caso.numeroCredito || caso.contratoId;
+											const tipoLink = caso.casoCobroId ? "caso" : "contrato";
+											onNavigate(linkId, tipoLink);
+										}}
+									>
+										<td className="py-2 pl-3 font-medium">
+											{caso.clienteNombre}
+										</td>
+										<td className="py-2 font-mono text-muted-foreground text-xs">
+											{caso.numeroCredito || "-"}
+										</td>
+										<td className="py-2 text-right tabular-nums">
+											Q{Number(caso.montoFinanciado || 0).toLocaleString()}
+										</td>
+										<td className="py-2 text-right text-red-600 tabular-nums">
+											{Number(caso.montoEnMora || 0) > 0
+												? `Q${Number(caso.montoEnMora).toLocaleString()}`
+												: "-"}
+										</td>
+										<td className="py-2 pr-3 text-right tabular-nums">
+											Q{Number(caso.cuotaMensual || 0).toLocaleString()}
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					)}
+					{estadoStats.totalCases > 5 && (
+						<div className="border-t px-3 py-2 text-center">
+							<span className="text-muted-foreground text-xs">
+								Mostrando top 5 de {estadoStats.totalCases} casos
+							</span>
+						</div>
+					)}
+				</div>
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}
 
 export const Route = createFileRoute("/cobros/")({
 	component: RouteComponent,
@@ -386,7 +599,7 @@ function RouteComponent() {
 				</Card>
 			</div>
 
-			{/* Embudo Visual de Estados */}
+			{/* Embudo Visual de Estados - Acordeón */}
 			<Card>
 				<CardHeader>
 					<CardTitle className="flex items-center gap-2">
@@ -394,49 +607,59 @@ function RouteComponent() {
 						Embudo de Cobranza
 					</CardTitle>
 					<CardDescription>
-						Distribución de casos por estado de mora
+						Distribución de casos por estado de mora — click en una etapa para
+						ver los casos de mayor capital
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
-					<div className="space-y-3">
-						{[
-							{
-								key: "al_dia",
-								label: "Al Día",
-								color: "bg-green-100 text-green-800",
-							},
-							{
-								key: "mora_30",
-								label: "Mora 30",
-								color: "bg-yellow-100 text-yellow-800",
-							},
-							{
-								key: "mora_60",
-								label: "Mora 60",
-								color: "bg-orange-100 text-orange-800",
-							},
-							{
-								key: "mora_90",
-								label: "Mora 90",
-								color: "bg-red-100 text-red-800",
-							},
-							{
-								key: "mora_120",
-								label: "Mora 120",
-								color: "bg-red-200 text-red-900",
-							},
-							{
-								key: "incobrable",
-								label: "Incobrable",
-								color: "bg-gray-100 text-gray-800",
-							},
-							{
-								key: "completado",
-								label: "Completado",
-								color: "bg-blue-100 text-blue-800",
-							},
-						].map((estado) => {
-							const estadoStats = stats.find(
+					<div className="space-y-1">
+						{(
+							[
+								{
+									key: "al_dia",
+									label: "Al Día",
+									color: "bg-green-100 text-green-800",
+									barColor: "#22c55e",
+								},
+								{
+									key: "mora_30",
+									label: "Mora 30",
+									color: "bg-yellow-100 text-yellow-800",
+									barColor: "#eab308",
+								},
+								{
+									key: "mora_60",
+									label: "Mora 60",
+									color: "bg-orange-100 text-orange-800",
+									barColor: "#f97316",
+								},
+								{
+									key: "mora_90",
+									label: "Mora 90",
+									color: "bg-red-100 text-red-800",
+									barColor: "#ef4444",
+								},
+								{
+									key: "mora_120",
+									label: "Mora 120+",
+									color: "bg-red-200 text-red-900",
+									barColor: "#b91c1c",
+								},
+								{
+									key: "incobrable",
+									label: "Incobrable",
+									color: "bg-gray-100 text-gray-800",
+									barColor: "#6b7280",
+								},
+								{
+									key: "completado",
+									label: "Completado",
+									color: "bg-blue-100 text-blue-800",
+									barColor: "#3b82f6",
+								},
+							] satisfies EmbudoEstado[]
+						).map((estado) => {
+							const estadoStat = stats.find(
 								(s) => s.estadoMora === estado.key,
 							) || {
 								totalCases: 0,
@@ -445,84 +668,28 @@ function RouteComponent() {
 								porcentaje: "0",
 							};
 							const maxCasos = Math.max(...stats.map((s) => s.totalCases), 1);
-							const porcentaje = (estadoStats.totalCases / maxCasos) * 100;
 
 							return (
-								<div
+								<EmbudoRow
 									key={estado.key}
-									className="group flex items-center gap-3 rounded-lg p-3 transition-all hover:bg-muted/50"
-								>
-									<div className="flex w-32 shrink-0 items-center gap-2">
-										<Badge
-											className={`${estado.color} whitespace-nowrap text-xs`}
-										>
-											{estado.label}
-										</Badge>
-									</div>
-									<div className="relative flex-1">
-										<div className="h-10 w-full overflow-hidden rounded-md bg-muted">
-											{porcentaje >= 15 ? (
-												// Barra suficientemente ancha - texto dentro
-												<div
-													className="flex h-full items-center justify-between px-3 transition-all duration-300 group-hover:opacity-80"
-													style={{
-														width: `${porcentaje}%`,
-														backgroundColor: `hsl(220, 15%, ${Math.max(30, 90 - porcentaje * 0.5)}%)`,
-													}}
-												>
-													<span
-														className="whitespace-nowrap font-semibold text-sm"
-														style={{
-															color: porcentaje > 60 ? "white" : "#1f2937",
-														}}
-													>
-														{estadoStats.totalCases} casos -{" "}
-														{Number.parseFloat(
-															estadoStats.porcentaje || "0",
-														).toFixed(2)}
-														% del total
-													</span>
-												</div>
-											) : (
-												// Barra estrecha - texto fuera
-												<div className="flex h-full items-center">
-													<div
-														className="h-full transition-all duration-300 group-hover:opacity-80"
-														style={{
-															width: `${Math.max(porcentaje, 3)}%`,
-															backgroundColor: `hsl(220, 15%, ${Math.max(30, 90 - porcentaje * 0.5)}%)`,
-														}}
-													/>
-													<span className="ml-2 whitespace-nowrap font-semibold text-muted-foreground text-sm">
-														{estadoStats.totalCases} casos -{" "}
-														{Number.parseFloat(
-															estadoStats.porcentaje || "0",
-														).toFixed(2)}
-														% del total
-													</span>
-												</div>
-											)}
-										</div>
-									</div>
-									<div className="flex w-52 shrink-0 flex-col gap-1 text-right text-sm">
-										<div className="flex items-center justify-end gap-2">
-											<span className="text-muted-foreground text-xs">
-												Mora:
-											</span>
-											<span className="font-medium">
-												Q{Number(estadoStats.montoTotal || 0).toLocaleString()}
-											</span>
-										</div>
-										<div className="flex items-center justify-end gap-2">
-											<span className="text-muted-foreground text-xs">
-												Capital:
-											</span>
-											<span className="font-medium">
-												Q{Number(estadoStats.sumaCapital || 0).toLocaleString()}
-											</span>
-										</div>
-									</div>
-								</div>
+									estado={estado}
+									estadoStats={estadoStat}
+									maxCasos={maxCasos}
+									emailCobrador={
+										!PERMISSIONS.canAssignCobros(userRole ?? "")
+											? (session?.user?.email ?? undefined)
+											: undefined
+									}
+									onNavigate={(id, tipo) => {
+										navigate({
+											to: "/cobros/$id",
+											params: { id },
+											search: {
+												tipo: tipo as "caso" | "contrato",
+											},
+										});
+									}}
+								/>
 							);
 						})}
 					</div>

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -635,7 +635,9 @@ function RouteComponent() {
 											</TableCell>
 											<TableCell>
 												<div className="space-y-1">
-													{clientData.email && <div className="text-sm">{clientData.email}</div>}
+													{clientData.email && (
+														<div className="text-sm">{clientData.email}</div>
+													)}
 													{clientData.phone && (
 														<div className="flex items-center gap-1 text-muted-foreground text-xs">
 															<Phone className="h-3 w-3" />

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -328,7 +328,10 @@ function RouteComponent() {
 					errors.lastName = "El apellido es requerido";
 				}
 
-				if (value.email.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.email)) {
+				if (
+					value.email.trim() &&
+					!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.email)
+				) {
 					errors.email = "El correo electrónico no es válido";
 				}
 
@@ -346,7 +349,9 @@ function RouteComponent() {
 		onSubmit: async ({ value }) => {
 			const leadData = {
 				...value,
-				...(value.email ? { email: value.email } : { email: undefined as string | undefined }),
+				...(value.email
+					? { email: value.email }
+					: { email: undefined as string | undefined }),
 				age: value.age ? Number.parseInt(value.age) : undefined,
 				dependents: Number.parseInt(value.dependents),
 				monthlyIncome: value.monthlyIncome
@@ -1057,13 +1062,19 @@ function RouteComponent() {
 												name="email"
 												validators={{
 													onChange: ({ value }) => {
-														if (value.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+														if (
+															value.trim() &&
+															!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+														) {
 															return "El correo electrónico no es válido";
 														}
 														return undefined;
 													},
 													onBlur: ({ value }) => {
-														if (value.trim() && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+														if (
+															value.trim() &&
+															!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
+														) {
 															return "El correo electrónico no es válido";
 														}
 														return undefined;
@@ -2310,7 +2321,9 @@ function RouteComponent() {
 											</Label>
 											<div className="flex items-center gap-2">
 												<Mail className="h-4 w-4 text-muted-foreground" />
-												<p className="text-sm">{selectedLead.email || "No especificado"}</p>
+												<p className="text-sm">
+													{selectedLead.email || "No especificado"}
+												</p>
 											</div>
 										</div>
 										<div>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -39,6 +39,7 @@ import { z } from "zod";
 import { CoDebtorsView } from "@/components/co-debtors/CoDebtorsView";
 import { ConsolidatedCreditSummary } from "@/components/credit/ConsolidatedCreditSummary";
 import { CreditDetailView } from "@/components/credit/CreditDetailView";
+import { ConfirmContractsSignedModal } from "@/components/crm/ConfirmContractsSignedModal";
 import { DataTable } from "@/components/data-table";
 import { NotesTimeline } from "@/components/notes-timeline";
 import { Badge } from "@/components/ui/badge";
@@ -378,6 +379,30 @@ function RouteComponent() {
 		localStorage.setItem("opportunities-view-mode", mode);
 	};
 
+	// State for confirm contracts signed modal
+	const [confirmSignedModalOpen, setConfirmSignedModalOpen] = useState(false);
+	const [opportunityToConfirmSigned, setOpportunityToConfirmSigned] = useState<{
+		id: string;
+		title: string;
+	} | null>(null);
+
+	const confirmContractsSignedMutation = useMutation({
+		mutationFn: async (opportunityId: string) => {
+			return await client.confirmContractsSigned({ opportunityId });
+		},
+		onSuccess: (data) => {
+			toast.success(data.message);
+			setConfirmSignedModalOpen(false);
+			setOpportunityToConfirmSigned(null);
+			queryClient.invalidateQueries({
+				queryKey: ["getOpportunities"],
+			});
+		},
+		onError: (error: Error) => {
+			toast.error(error.message || "Error al confirmar firma de contratos");
+		},
+	});
+
 	const handleDropOpportunity = (opportunityId: string, newStageId: string) => {
 		// Find the opportunity and the target stage
 		const opportunity = opportunitiesQuery.data?.find(
@@ -413,6 +438,22 @@ function RouteComponent() {
 			toast.error(
 				"No puedes mover manualmente una oportunidad de Recepción de documentación (30%) a etapas superiores. El equipo de análisis debe aprobar los documentos para que la oportunidad avance automáticamente al 40%.",
 			);
+			return;
+		}
+
+		// Intercept 85% → 90%+: open confirm contracts signed modal
+		if (
+			opportunity &&
+			targetStage &&
+			currentStage &&
+			currentStage.closurePercentage === 85 &&
+			targetStage.closurePercentage >= 90
+		) {
+			setOpportunityToConfirmSigned({
+				id: opportunity.id,
+				title: opportunity.title,
+			});
+			setConfirmSignedModalOpen(true);
 			return;
 		}
 
@@ -3057,6 +3098,21 @@ function RouteComponent() {
 					}
 				/>
 			)}
+
+			{/* Modal para confirmar firma de contratos (85% → 90%) */}
+			<ConfirmContractsSignedModal
+				open={confirmSignedModalOpen}
+				onOpenChange={setConfirmSignedModalOpen}
+				onConfirm={() => {
+					if (opportunityToConfirmSigned) {
+						confirmContractsSignedMutation.mutate(
+							opportunityToConfirmSigned.id,
+						);
+					}
+				}}
+				isLoading={confirmContractsSignedMutation.isPending}
+				opportunityTitle={opportunityToConfirmSigned?.title}
+			/>
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/juridico/$leadId.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/$leadId.tsx
@@ -76,7 +76,7 @@ function RouteComponent() {
 
 	const opportunityId = searchParams?.opportunityId;
 
-	// Mutación para aprobar oportunidad (mover a 90%)
+	// Mutación para aprobar oportunidad (mover a 85%)
 	const approveMutation = useMutation({
 		mutationFn: async (opportunityId: string) => {
 			return await client.approveOpportunityLegal({ opportunityId });
@@ -92,20 +92,6 @@ function RouteComponent() {
 		},
 		onError: (error: Error) => {
 			toast.error(error.message || "Error al aprobar la oportunidad");
-		},
-	});
-
-	// Mutación para marcar todos los contratos como firmados
-	const markAllSignedMutation = useMutation({
-		mutationFn: async (opportunityId: string) => {
-			return await client.markAllContractsSigned({ opportunityId });
-		},
-		onSuccess: () => {
-			toast.success("Todos los contratos marcados como firmados");
-			refetch();
-		},
-		onError: (error: Error) => {
-			toast.error(error.message || "Error al marcar contratos como firmados");
 		},
 	});
 
@@ -479,21 +465,8 @@ function RouteComponent() {
 						approveMutation.mutate(opportunityId);
 					}
 				}}
-				onMarkAllSigned={() => {
-					if (opportunityId) {
-						markAllSignedMutation.mutate(opportunityId);
-					}
-				}}
 				isLoading={approveMutation.isPending}
-				isMarkingAsSigned={markAllSignedMutation.isPending}
 				opportunityTitle={opportunityData?.title}
-				contracts={
-					contracts?.map((c) => ({
-						id: c.contract.id,
-						contractName: c.contract.contractName,
-						status: c.contract.status,
-					})) || []
-				}
 			/>
 
 			{/* Modal para regenerar contratos */}

--- a/apps/crm/apps/web/src/routes/juridico/$leadId.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/$leadId.tsx
@@ -105,9 +105,7 @@ function RouteComponent() {
 			refetch();
 		},
 		onError: (error: Error) => {
-			toast.error(
-				error.message || "Error al marcar contratos como firmados",
-			);
+			toast.error(error.message || "Error al marcar contratos como firmados");
 		},
 	});
 

--- a/apps/crm/apps/web/src/routes/juridico/index.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/index.tsx
@@ -75,7 +75,7 @@ function RouteComponent() {
 		title: string;
 	} | null>(null);
 
-	// Mutación para aprobar oportunidad (mover a 90%)
+	// Mutación para aprobar oportunidad (mover a 85%)
 	const approveMutation = useMutation({
 		mutationFn: async (opportunityId: string) => {
 			return await client.approveOpportunityLegal({ opportunityId });
@@ -510,7 +510,7 @@ function RouteComponent() {
 																		className="cursor-pointer"
 																	>
 																		<CheckCircle className="mr-2 h-4 w-4" />
-																		Aprobar (→ 90%)
+																		Aprobar (→ 85%)
 																	</DropdownMenuItem>
 																)}
 														</DropdownMenuContent>

--- a/apps/portal-web/src/features/Credit/Sections/GetMoney.tsx
+++ b/apps/portal-web/src/features/Credit/Sections/GetMoney.tsx
@@ -143,7 +143,7 @@ export const GetMoney = () => {
       <ModalChatBot
         open={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        options={[optionsCredit.sell]}
+        options={optionsCredit.sell}
       />
     </section>
   );

--- a/apps/portal-web/src/features/HomePage/sections/CarrouselStart/CarrouselStart.tsx
+++ b/apps/portal-web/src/features/HomePage/sections/CarrouselStart/CarrouselStart.tsx
@@ -32,8 +32,8 @@ const slides: CarouselSlide[] = [
     id: 2,
     imageUrl: url + "/familia-joven-disfrutando-de-su-viaje.jpg",
     title: "Tenemos el auto ideal para darte momentos inolvidables",
-    buttonText: "Ver marketplace",
-    buttonLink: "/marketplace",
+    buttonText: "Solicita tu crédito", // TODO: devolver a "Ver marketplace" y "/marketplace" cuando esté habilitado
+    buttonLink: "/credit",
   },
   {
     id: 3,

--- a/apps/portal-web/src/features/HomePage/sections/howSellOrBuy/HowSellOrBuy.tsx
+++ b/apps/portal-web/src/features/HomePage/sections/howSellOrBuy/HowSellOrBuy.tsx
@@ -123,7 +123,8 @@ export const HowSellOrBuy = () => {
           ))}
         </div>
         <div className="flex justify-center mt-12">
-          <Link to="/marketplace">
+          {/* TODO: devolver a "/marketplace" cuando esté habilitado */}
+          <Link to="/credit">
             <Button size={isMobile ? "sm" : "lg"}>Comprar un auto</Button>
           </Link>
         </div>

--- a/apps/portal-web/src/features/footer/Footer.tsx
+++ b/apps/portal-web/src/features/footer/Footer.tsx
@@ -17,7 +17,7 @@ const FOOTER_SECTIONS = [
   {
     title: "Autos",
     links: [
-      { label: "Encuentra tu auto", href: "/marketplace" },
+      { label: "Encuentra tu auto", href: "/credit" }, // TODO: devolver a "/marketplace" cuando esté habilitado
       { label: "Obtén tu financiamiento", href: "/credit" },
       { label: "Compramos tu auto", href: "/sell" },
     ],

--- a/apps/portal-web/src/hooks/useModalOptionsCall.tsx
+++ b/apps/portal-web/src/hooks/useModalOptionsCall.tsx
@@ -64,17 +64,30 @@ export const useModalOptionsCall = () => {
       ),
   };
 
-  const optionCreditSell: ModalOption = {
-    type: "whatsapp",
-    title:
-      "Puedes obtener más información y realizar el proceso para vender tu auto a través de nuestro WhatsApp.",
-    description: "",
-    buttonText: "WhatsApp",
-    buttonAction: () =>
-      openWhatsApp(
-        "Hola, estoy interesado en obtener más información sobre la venta de mi auto."
-      ),
-  };
+  const optionCreditSell: ModalOption[] = [
+    {
+      type: "whatsapp",
+      title:
+        "Puedes obtener más información y realizar el proceso para vender tu auto a través de nuestro WhatsApp.",
+      description: "",
+      buttonText: "WhatsApp",
+      buttonAction: () =>
+        openWhatsApp(
+          "Hola, estoy interesado en obtener más información sobre la venta de mi auto."
+        ),
+    },
+    {
+      type: "form",
+      title:
+        "También puedes completar nuestro formulario y un asesor se pondrá en contacto contigo.",
+      description: "",
+      buttonText: "Ir al formulario",
+      buttonAction: () => {
+        setIsModalOpen(false);
+        globalThis.location.href = "/leads";
+      },
+    },
+  ];
 
   const optionCrediQuestions: ModalOption = {
     type: "whatsapp",


### PR DESCRIPTION
## Summary

- Agrega etapa 85% "Contratos en Firma" entre Cierre Final (80%) y Formalización Final (90%)
- Jurídico aprueba sin necesitar firma (80%→85%), ventas confirma firma (85%→90%)
- Elimina cuello de botella donde jurídico debía preguntar a ventas si los contratos estaban firmados

## Cambios principales

- **Nuevo endpoint** `confirmContractsSigned` con protección contra race conditions (re-verificación dentro de transacción)
- **Validaciones de transición** actualizadas: 80%→85%+ bloqueado (debe ir por jurídico), 85%→90%+ requiere confirmación de firma
- **Modal de confirmación** integrado en drag del tablero CRM (intercepta 85%→90%+)
- **ApproveOpportunityModal** simplificado (ya no requiere verificar firmas)
- **Nuevo permiso** `canConfirmContractsSigning` para sales, sales_supervisor, juridico, admin
- **Limpieza**: removido `markAllContractsSigned` (reemplazado por nuevo flujo atómico)
- **Notificaciones**: jurídico→ventas al aprobar, ventas→analista al confirmar firma

## SQL para bases de datos existentes

El seed no migra DBs existentes. Ejecutar manualmente:

```sql
INSERT INTO sales_stages (name, "order", closure_percentage, color, description)
VALUES ('Contratos en Firma', 8, 85, '#22c55e', 'Contratos generados por jurídico, pendientes de firma por el cliente');

UPDATE sales_stages SET "order" = 9 WHERE closure_percentage = 90;
UPDATE sales_stages SET "order" = 10 WHERE closure_percentage = 100;
```

## Test plan

- [ ] Generar contratos en 80% → aprobar desde jurídico → debe moverse a 85%
- [ ] En 85% arrastrar a 90% → aparece modal → confirmar → mueve a 90% con contratos firmados
- [ ] Verificar que no se puede saltar de 80% a 90% directamente (drag bloqueado)
- [ ] Verificar que drag de 85% a 100% también abre el modal de confirmación
- [ ] Verificar notificaciones: ventas recibe aviso al pasar a 85%, analista al pasar a 90%
- [ ] `bun check-types` sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)