### PR TITLE
Calculates proportional interest for new investors

### DIFF
--- a/apps/cartera-back/src/controllers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/controllers/mirrorInvestor.ts
@@ -214,8 +214,6 @@ export const llenarTablaEspejo = async ({ body, query, set }: any) => {
           numero_credito_sifco,
           capital,
           inversor,
-          interes_inversor,
-          iva,
         } = creditoInput;
 
         // inversor viene de 0 a 1 (ej: 0.8 = 80%)
@@ -349,7 +347,6 @@ export const llenarTablaEspejo = async ({ body, query, set }: any) => {
         console.log(`  capital=${montoAportado} | inversor=${inversor} → %cashIn=${porcCashIn}`);
         console.log(`  %interes=${interes} | cuotaInteres=${cuotaInteres}`);
         console.log(`  montoCashIn=${montoCashIn} | ivaCashIn=${ivaCashIn}`);
-        console.log(`  interes_inversor=${interes_inversor} | iva=${iva}`);
         console.log(`  cuotaInversionista=${cuotaInversionista}`);
 
         const dataEspejo = {

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -442,7 +442,10 @@ export async function insertPagosCreditoInversionistas(
     const fechaInicio = inv.fecha_inicio_participacion
       ? new Date(inv.fecha_inicio_participacion + "T00:00:00")
       : null;
-    const fechaPago =  new Date();
+    // Usar hora de Guatemala (UTC-6) en lugar de la hora del servidor
+    const fechaPago = new Date(
+      new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
+    );
 
     const mesAnterior = fechaPago.getMonth() === 0 ? 11 : fechaPago.getMonth() - 1;
     const anioMesAnterior = fechaPago.getMonth() === 0
@@ -1170,7 +1173,9 @@ export async function falsePayment(pago_id: number, credito_id: number) {
 }
 
 export async function getPagosDelMesActual(credito_id: number) {
-  const hoy = new Date();
+  const hoy = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
+  );
   const mes = hoy.getMonth() + 1; // getMonth() es 0-based
   const anio = hoy.getFullYear();
 
@@ -1576,7 +1581,9 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
 
 // 📅 Función helper para obtener el rango del mes actual
 function obtenerRangoMesActual() {
-  const hoy = new Date();
+  const hoy = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
+  );
   const primerDia = new Date(hoy.getFullYear(), hoy.getMonth(), 1);
   const ultimoDia = new Date(hoy.getFullYear(), hoy.getMonth() + 1, 0);
   

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -438,19 +438,65 @@ export async function insertPagosCreditoInversionistas(
 
     console.log(`   ¿Es Cube? ${isCube ? "SÍ ✅" : "NO ❌"}`);
 
-    const bigInteres = isCube
-      ? new Big(inv.monto_cash_in ?? 0)
-      : new Big(inv.monto_inversionista);
+    // --- Interés proporcional si fecha_inicio_participacion es del mes anterior ---
+    const fechaInicio = inv.fecha_inicio_participacion
+      ? new Date(inv.fecha_inicio_participacion + "T00:00:00")
+      : null;
+    const fechaPago =  new Date();
 
-    const bigIVA = isCube
-      ? new Big(inv.iva_cash_in ?? 0)
-      : new Big(inv.iva_inversionista);
+    const mesAnterior = fechaPago.getMonth() === 0 ? 11 : fechaPago.getMonth() - 1;
+    const anioMesAnterior = fechaPago.getMonth() === 0
+      ? fechaPago.getFullYear() - 1
+      : fechaPago.getFullYear();
+
+    const esMesAnterior =
+      !isCube &&
+      fechaInicio !== null &&
+      fechaInicio.getMonth() === mesAnterior &&
+      fechaInicio.getFullYear() === anioMesAnterior;
+
+    let bigInteres: Big;
+    let bigIVA: Big;
+
+    if (esMesAnterior) {
+      // Días totales del mes de la fecha de inicio (ej: enero = 31)
+      const diasDelMes = new Date(
+        fechaInicio!.getFullYear(),
+        fechaInicio!.getMonth() + 1,
+        0
+      ).getDate();
+      const diaInicio = fechaInicio!.getDate(); // ej: 18
+
+      // Interés proporcional = (monto_inversionista / diasDelMes) * diaInicio
+      bigInteres = new Big(inv.monto_inversionista)
+        .div(diasDelMes)
+        .times(diaInicio)
+        .round(2);
+
+      // IVA proporcional = interés proporcional * 12%
+      bigIVA = bigInteres.times(0.12).round(2);
+
+      console.log(`   📅 INTERÉS PROPORCIONAL:`);
+      console.log(`      fecha_inicio: ${inv.fecha_inicio_participacion}`);
+      console.log(`      días del mes: ${diasDelMes}`);
+      console.log(`      día inicio: ${diaInicio}`);
+      console.log(`      interés proporcional: ${bigInteres.toString()}`);
+      console.log(`      IVA proporcional: ${bigIVA.toString()}`);
+    } else {
+      bigInteres = isCube
+        ? new Big(inv.monto_cash_in ?? 0)
+        : new Big(inv.monto_inversionista);
+
+      bigIVA = isCube
+        ? new Big(inv.iva_cash_in ?? 0)
+        : new Big(inv.iva_inversionista);
+    }
 
     console.log(
-      `   💵 Interés a usar: ${bigInteres.toString()} (${isCube ? "monto_cash_in" : "monto_inversionista"})`
+      `   💵 Interés a usar: ${bigInteres.toString()} (${esMesAnterior ? "PROPORCIONAL" : isCube ? "monto_cash_in" : "monto_inversionista"})`
     );
     console.log(
-      `   🧾 IVA a usar: ${bigIVA.toString()} (${isCube ? "iva_cash_in" : "iva_inversionista"})`
+      `   🧾 IVA a usar: ${bigIVA.toString()} (${esMesAnterior ? "PROPORCIONAL" : isCube ? "iva_cash_in" : "iva_inversionista"})`
     );
 
     console.log(

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -91,12 +91,13 @@ export function InvestorsList({
 
   const addInvestor = () => {
     // Agregamos a ambas listas para mantener sincronía
+    const today = new Date().toISOString().split("T")[0]; // "YYYY-MM-DD"
     const newInvestor = {
       inversionista_id: 0,
       monto_aportado: 0,
       porcentaje_cash_in: 0,
       porcentaje_inversion: 0,
-      fecha_inicio_participacion: "2025-12-01",
+      fecha_inicio_participacion: today,
     };
 
     formik.setFieldValue("investors", [...investors, { ...newInvestor }]);


### PR DESCRIPTION
This pull request introduces a significant update to the payment calculation logic for investors, specifically addressing proportional interest and IVA calculations when an investor's participation starts in the previous month. It also removes unused variables and log statements related to interest and IVA in the mirror investor controller.

**Payment calculation improvements:**

* Added logic in `insertPagosCreditoInversionistas` to calculate proportional interest and IVA when `fecha_inicio_participacion` is from the previous month, including detailed logging for these calculations.
* Updated log statements to indicate whether the interest and IVA used are proportional, from `monto_cash_in`, or from `monto_inversionista`, improving clarity during debugging.

**Cleanup in mirror investor controller:**

* Removed unused `interes_inversor` and `iva` variables from destructuring in `llenarTablaEspejo`, as they are no longer needed.
* Deleted the log statement for `interes_inversor` and `iva` in `llenarTablaEspejo`, reducing unnecessary output.