### PR TITLE
feat(crm/cobros): seguimientos, contacto y fix permisos analista 85→90

### DIFF
--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -419,3 +419,34 @@ export const activities = pgTable("activities", {
 		.notNull()
 		.references(() => user.id),
 });
+
+// Enum para parentesco de referencias
+export const parentescoReferenciaEnum = pgEnum("parentesco_referencia", [
+	"padre_madre",
+	"hermano_a",
+	"hijo_a",
+	"conyuge",
+	"tio_a",
+	"primo_a",
+	"amigo_a",
+	"vecino_a",
+	"companero_trabajo",
+	"otro",
+]);
+
+/** Valores canónicos del enum de parentesco. Úsalo en lugar de duplicar el array. */
+export const PARENTESCO_VALUES = parentescoReferenciaEnum.enumValues;
+
+// Referencias de un lead (personas de contacto: familiares, amigos, etc.)
+export const referenciasLead = pgTable("referencias_lead", {
+	id: uuid("id").primaryKey().defaultRandom(),
+	leadId: uuid("lead_id")
+		.notNull()
+		.references(() => leads.id, { onDelete: "cascade" }),
+	nombre: text("nombre").notNull(),
+	telefono: text("telefono").notNull(),
+	parentesco: parentescoReferenciaEnum("parentesco").notNull(),
+	notas: text("notas"),
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -172,6 +172,7 @@ export const PERMISSIONS = {
 		role === ROLES.ADMIN ||
 		role === ROLES.SALES ||
 		role === ROLES.SALES_SUPERVISOR ||
+		role === ROLES.ANALYST ||
 		role === ROLES.JURIDICO,
 
 	// Clients Module Access

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -14,7 +14,7 @@ import {
 	metodoContactoEnum,
 	recuperacionesVehiculo,
 } from "../db/schema/cobros";
-import { clients, leads, opportunities, salesStages } from "../db/schema/crm";
+import { clients, leads, opportunities, PARENTESCO_VALUES, referenciasLead, salesStages } from "../db/schema/crm";
 import { vehicles } from "../db/schema/vehicles";
 import {
 	cobrosProcedure,
@@ -1447,7 +1447,7 @@ export const cobrosRouter = {
 					cuotasVencidas: sql<number>`0`,
 					telefonoPrincipal: sql<string>`COALESCE(${casosCobros.telefonoPrincipal}, '')`,
 					telefonoAlternativo: sql<string>`COALESCE(${casosCobros.telefonoAlternativo}, '')`,
-					emailContacto: sql<string>`COALESCE(${casosCobros.emailContacto}, 'cliente@email.com')`,
+					emailContacto: sql<string>`COALESCE(${casosCobros.emailContacto}, '')`,
 					direccionContacto: sql<string>`COALESCE(${casosCobros.direccionContacto}, '')`,
 					proximoContacto: casosCobros.proximoContacto,
 					metodoContactoProximo: casosCobros.metodoContactoProximo,
@@ -1842,10 +1842,10 @@ export const cobrosRouter = {
 					diasMoraMaximo: diasMora,
 					cuotasVencidas: cuotasAtrasadas,
 
-					// Datos de contacto (del lead y oportunidad)
-					telefonoPrincipal: leadInfo?.telefono || null,
-					telefonoAlternativo: null,
-					emailContacto: leadInfo?.email || null,
+					// Datos de contacto (del caso de cobros primero, fallback al lead)
+					telefonoPrincipal: casoCobro?.telefonoPrincipal || leadInfo?.telefono || null,
+					telefonoAlternativo: casoCobro?.telefonoAlternativo || null,
+					emailContacto: casoCobro?.emailContacto || leadInfo?.email || null,
 					direccionContacto: direccion || null,
 					proximoContacto: casoCobro?.proximoContacto || null,
 					metodoContactoProximo: null,
@@ -2404,5 +2404,139 @@ export const cobrosRouter = {
 					message: `Error obteniendo asesores: ${error instanceof Error ? error.message : String(error)}`,
 				});
 			}
+		}),
+
+	// ============================================================================
+	// ACTUALIZAR INFO DE CONTACTO
+	// ============================================================================
+
+	updateContactInfoCobros: cobrosProcedure
+		.input(
+			z.object({
+				casoCobroId: z.string().uuid(),
+				telefonoPrincipal: z.string().min(1),
+				telefonoAlternativo: z.string().optional(),
+				emailContacto: z.string().email().optional().or(z.literal("")),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const [updated] = await db
+				.update(casosCobros)
+				.set({
+					telefonoPrincipal: input.telefonoPrincipal,
+					telefonoAlternativo: input.telefonoAlternativo || null,
+					emailContacto: input.emailContacto || "",
+					updatedAt: new Date(),
+				})
+				.where(eq(casosCobros.id, input.casoCobroId))
+				.returning();
+
+			if (!updated) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Caso de cobros no encontrado",
+				});
+			}
+
+			return updated;
+		}),
+
+	// ============================================================================
+	// CRUD DE REFERENCIAS
+	// ============================================================================
+
+	getReferencias: cobrosProcedure
+		.input(
+			z.object({
+				leadId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const result = await db
+				.select()
+				.from(referenciasLead)
+				.where(eq(referenciasLead.leadId, input.leadId))
+				.orderBy(desc(referenciasLead.createdAt));
+
+			return result;
+		}),
+
+	createReferencia: cobrosProcedure
+		.input(
+			z.object({
+				leadId: z.string().uuid(),
+				nombre: z.string().min(1),
+				telefono: z.string().min(1),
+				parentesco: z.enum(PARENTESCO_VALUES),
+				notas: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const [created] = await db
+				.insert(referenciasLead)
+				.values({
+					leadId: input.leadId,
+					nombre: input.nombre,
+					telefono: input.telefono,
+					parentesco: input.parentesco,
+					notas: input.notas || null,
+				})
+				.returning();
+
+			return created;
+		}),
+
+	updateReferencia: cobrosProcedure
+		.input(
+			z.object({
+				id: z.string().uuid(),
+				leadId: z.string().uuid(),
+				nombre: z.string().min(1),
+				telefono: z.string().min(1),
+				parentesco: z.enum(PARENTESCO_VALUES),
+				notas: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const [updated] = await db
+				.update(referenciasLead)
+				.set({
+					nombre: input.nombre,
+					telefono: input.telefono,
+					parentesco: input.parentesco,
+					notas: input.notas || null,
+					updatedAt: new Date(),
+				})
+				.where(and(eq(referenciasLead.id, input.id), eq(referenciasLead.leadId, input.leadId)))
+				.returning();
+
+			if (!updated) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Referencia no encontrada",
+				});
+			}
+
+			return updated;
+		}),
+
+	deleteReferencia: cobrosProcedure
+		.input(
+			z.object({
+				id: z.string().uuid(),
+				leadId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const [deleted] = await db
+				.delete(referenciasLead)
+				.where(and(eq(referenciasLead.id, input.id), eq(referenciasLead.leadId, input.leadId)))
+				.returning();
+
+			if (!deleted) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Referencia no encontrada",
+				});
+			}
+
+			return { success: true };
 		}),
 };

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -148,6 +148,11 @@ export const appRouter = {
 	getDetalleInversionista: cobrosRouter.getDetalleInversionista,
 	getInversionistasDelCredito: cobrosRouter.getInversionistasDelCredito,
 	getAsesores: cobrosRouter.getAsesores,
+	updateContactInfoCobros: cobrosRouter.updateContactInfoCobros,
+	getReferencias: cobrosRouter.getReferencias,
+	createReferencia: cobrosRouter.createReferencia,
+	updateReferencia: cobrosRouter.updateReferencia,
+	deleteReferencia: cobrosRouter.deleteReferencia,
 
 	// Legal Contracts routes (Jurídico)
 	createLegalContract: legalContractsRouter.createLegalContract,

--- a/apps/crm/apps/web/src/components/cobros/ReferenciasView.tsx
+++ b/apps/crm/apps/web/src/components/cobros/ReferenciasView.tsx
@@ -1,0 +1,430 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Edit2, Phone, Plus, Save, Trash2, User } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { client, orpc } from "@/utils/orpc";
+
+interface ReferenciasViewProps {
+	leadId: string;
+}
+
+type Referencia = Awaited<ReturnType<typeof client.getReferencias>>[number];
+
+const parentescoLabels: Record<string, string> = {
+	padre_madre: "Padre/Madre",
+	hermano_a: "Hermano/a",
+	hijo_a: "Hijo/a",
+	conyuge: "Cónyuge",
+	tio_a: "Tío/a",
+	primo_a: "Primo/a",
+	amigo_a: "Amigo/a",
+	vecino_a: "Vecino/a",
+	companero_trabajo: "Compañero de trabajo",
+	otro: "Otro",
+};
+
+const parentescoOptions = [
+	"padre_madre",
+	"hermano_a",
+	"hijo_a",
+	"conyuge",
+	"tio_a",
+	"primo_a",
+	"amigo_a",
+	"vecino_a",
+	"companero_trabajo",
+	"otro",
+] as const;
+
+interface ReferenciaFormData {
+	nombre: string;
+	telefono: string;
+	parentesco: string;
+	notas: string;
+}
+
+const emptyFormData: ReferenciaFormData = {
+	nombre: "",
+	telefono: "",
+	parentesco: "",
+	notas: "",
+};
+
+export function ReferenciasView({ leadId }: ReferenciasViewProps) {
+	const queryClient = useQueryClient();
+	const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
+	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
+	const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+	const [selectedRef, setSelectedRef] = useState<Referencia | null>(null);
+	const [formData, setFormData] = useState<ReferenciaFormData>(emptyFormData);
+
+	const { data: referencias = [], isLoading } = useQuery({
+		...orpc.getReferencias.queryOptions({
+			input: { leadId },
+		}),
+	});
+
+	const createMutation = useMutation({
+		mutationFn: (data: Parameters<typeof client.createReferencia>[0]) =>
+			client.createReferencia(data),
+		onSuccess: () => {
+			queryClient.invalidateQueries(
+				orpc.getReferencias.queryOptions({ input: { leadId } }),
+			);
+			toast.success("Referencia agregada correctamente");
+			setIsAddDialogOpen(false);
+			setFormData(emptyFormData);
+		},
+		onError: (error) => {
+			toast.error(`Error al agregar referencia: ${error.message}`);
+		},
+	});
+
+	const updateMutation = useMutation({
+		mutationFn: (data: Parameters<typeof client.updateReferencia>[0]) =>
+			client.updateReferencia(data),
+		onSuccess: () => {
+			queryClient.invalidateQueries(
+				orpc.getReferencias.queryOptions({ input: { leadId } }),
+			);
+			toast.success("Referencia actualizada correctamente");
+			setIsEditDialogOpen(false);
+			setSelectedRef(null);
+			setFormData(emptyFormData);
+		},
+		onError: (error) => {
+			toast.error(`Error al actualizar referencia: ${error.message}`);
+		},
+	});
+
+	const deleteMutation = useMutation({
+		mutationFn: (id: string) => client.deleteReferencia({ id, leadId }),
+		onSuccess: () => {
+			queryClient.invalidateQueries(
+				orpc.getReferencias.queryOptions({ input: { leadId } }),
+			);
+			toast.success("Referencia eliminada correctamente");
+			setIsDeleteDialogOpen(false);
+			setSelectedRef(null);
+		},
+		onError: (error) => {
+			toast.error(`Error al eliminar referencia: ${error.message}`);
+		},
+	});
+
+	const handleCreate = () => {
+		if (!formData.nombre || !formData.telefono || !formData.parentesco) {
+			toast.error("Nombre, teléfono y parentesco son requeridos");
+			return;
+		}
+		createMutation.mutate({
+			leadId,
+			nombre: formData.nombre,
+			telefono: formData.telefono,
+			parentesco: formData.parentesco as (typeof parentescoOptions)[number],
+			notas: formData.notas || undefined,
+		});
+	};
+
+	const handleUpdate = () => {
+		if (!selectedRef) return;
+		if (!formData.nombre || !formData.telefono || !formData.parentesco) {
+			toast.error("Nombre, teléfono y parentesco son requeridos");
+			return;
+		}
+		updateMutation.mutate({
+			id: selectedRef.id,
+			leadId,
+			nombre: formData.nombre,
+			telefono: formData.telefono,
+			parentesco: formData.parentesco as (typeof parentescoOptions)[number],
+			notas: formData.notas || undefined,
+		});
+	};
+
+	const handleOpenAdd = () => {
+		setFormData(emptyFormData);
+		setIsAddDialogOpen(true);
+	};
+
+	const handleEdit = (ref: Referencia) => {
+		setSelectedRef(ref);
+		setFormData({
+			nombre: ref.nombre,
+			telefono: ref.telefono,
+			parentesco: ref.parentesco,
+			notas: ref.notas || "",
+		});
+		setIsEditDialogOpen(true);
+	};
+
+	const handleDeleteClick = (ref: Referencia) => {
+		setSelectedRef(ref);
+		setIsDeleteDialogOpen(true);
+	};
+
+	const renderFormFields = () => (
+		<div className="grid gap-4 py-4">
+			<div className="grid grid-cols-2 gap-4">
+				<div className="space-y-2">
+					<Label htmlFor="ref-nombre">
+						Nombre <span className="text-red-500">*</span>
+					</Label>
+					<Input
+						id="ref-nombre"
+						value={formData.nombre}
+						onChange={(e) =>
+							setFormData((prev) => ({ ...prev, nombre: e.target.value }))
+						}
+						placeholder="Ej: María López"
+					/>
+				</div>
+				<div className="space-y-2">
+					<Label htmlFor="ref-telefono">
+						Teléfono <span className="text-red-500">*</span>
+					</Label>
+					<Input
+						id="ref-telefono"
+						value={formData.telefono}
+						onChange={(e) =>
+							setFormData((prev) => ({ ...prev, telefono: e.target.value }))
+						}
+						placeholder="Ej: 5555-5555"
+					/>
+				</div>
+			</div>
+			<div className="space-y-2">
+				<Label htmlFor="ref-parentesco">
+					Parentesco <span className="text-red-500">*</span>
+				</Label>
+				<Select
+					value={formData.parentesco}
+					onValueChange={(value) =>
+						setFormData((prev) => ({ ...prev, parentesco: value }))
+					}
+				>
+					<SelectTrigger>
+						<SelectValue placeholder="Seleccionar parentesco" />
+					</SelectTrigger>
+					<SelectContent>
+						{parentescoOptions.map((p) => (
+							<SelectItem key={p} value={p}>
+								{parentescoLabels[p]}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+			<div className="space-y-2">
+				<Label htmlFor="ref-notas">Notas</Label>
+				<Textarea
+					id="ref-notas"
+					value={formData.notas}
+					onChange={(e) =>
+						setFormData((prev) => ({ ...prev, notas: e.target.value }))
+					}
+					placeholder="Notas adicionales sobre la referencia..."
+					rows={2}
+				/>
+			</div>
+		</div>
+	);
+
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between">
+				<CardTitle className="flex items-center gap-2">
+					<User className="h-5 w-5" />
+					Referencias
+				</CardTitle>
+				<Button size="sm" onClick={handleOpenAdd}>
+					<Plus className="mr-2 h-4 w-4" />
+					Agregar
+				</Button>
+			</CardHeader>
+			<CardContent>
+				{isLoading ? (
+					<div className="flex items-center justify-center py-4">
+						<p className="text-muted-foreground text-sm">
+							Cargando referencias...
+						</p>
+					</div>
+				) : referencias.length === 0 ? (
+					<div className="flex flex-col items-center justify-center py-6">
+						<User className="mb-2 h-8 w-8 text-muted-foreground" />
+						<p className="text-muted-foreground text-sm">
+							No hay referencias registradas
+						</p>
+					</div>
+				) : (
+					<div className="space-y-3">
+						{referencias.map((ref) => (
+							<div
+								key={ref.id}
+								className="flex items-center justify-between rounded-lg border p-3"
+							>
+								<div className="space-y-1">
+									<div className="flex items-center gap-2">
+										<span className="font-medium">{ref.nombre}</span>
+										<Badge variant="secondary">
+											{parentescoLabels[ref.parentesco] || ref.parentesco}
+										</Badge>
+									</div>
+									<div className="flex items-center gap-2 text-sm">
+										<Phone className="h-3 w-3 text-muted-foreground" />
+										<a
+											href={`tel:${ref.telefono}`}
+											className="text-primary hover:underline"
+										>
+											{ref.telefono}
+										</a>
+									</div>
+									{ref.notas && (
+										<p className="text-muted-foreground text-xs">{ref.notas}</p>
+									)}
+								</div>
+								<div className="flex gap-1">
+									<Button
+										variant="ghost"
+										size="icon"
+										onClick={() => handleEdit(ref)}
+									>
+										<Edit2 className="h-4 w-4" />
+									</Button>
+									<Button
+										variant="ghost"
+										size="icon"
+										className="text-red-500 hover:text-red-600"
+										onClick={() => handleDeleteClick(ref)}
+									>
+										<Trash2 className="h-4 w-4" />
+									</Button>
+								</div>
+							</div>
+						))}
+					</div>
+				)}
+			</CardContent>
+
+			{/* Dialog para agregar */}
+			<Dialog open={isAddDialogOpen} onOpenChange={setIsAddDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Agregar Referencia</DialogTitle>
+						<DialogDescription>
+							Ingresa la información de la persona de referencia
+						</DialogDescription>
+					</DialogHeader>
+					{renderFormFields()}
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setIsAddDialogOpen(false)}
+						>
+							Cancelar
+						</Button>
+						<Button
+							onClick={handleCreate}
+							disabled={createMutation.isPending}
+						>
+							{createMutation.isPending ? (
+								"Guardando..."
+							) : (
+								<>
+									<Save className="mr-2 h-4 w-4" />
+									Guardar
+								</>
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Dialog para editar */}
+			<Dialog open={isEditDialogOpen} onOpenChange={setIsEditDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Editar Referencia</DialogTitle>
+						<DialogDescription>
+							Modifica la información de la referencia
+						</DialogDescription>
+					</DialogHeader>
+					{renderFormFields()}
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setIsEditDialogOpen(false)}
+						>
+							Cancelar
+						</Button>
+						<Button
+							onClick={handleUpdate}
+							disabled={updateMutation.isPending}
+						>
+							{updateMutation.isPending ? (
+								"Guardando..."
+							) : (
+								<>
+									<Save className="mr-2 h-4 w-4" />
+									Actualizar
+								</>
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Dialog para confirmar eliminación */}
+			<Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>Eliminar Referencia</DialogTitle>
+						<DialogDescription>
+							¿Estás seguro de que deseas eliminar a{" "}
+							<span className="font-medium">{selectedRef?.nombre}</span>? Esta
+							acción no se puede deshacer.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button
+							variant="outline"
+							onClick={() => setIsDeleteDialogOpen(false)}
+						>
+							Cancelar
+						</Button>
+						<Button
+							variant="destructive"
+							onClick={() =>
+								selectedRef && deleteMutation.mutate(selectedRef.id)
+							}
+							disabled={deleteMutation.isPending}
+						>
+							{deleteMutation.isPending ? "Eliminando..." : "Eliminar"}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</Card>
+	);
+}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -31,6 +31,7 @@ interface ContactoModalProps {
 	casoCobroId: string;
 	clienteNombre: string;
 	telefonoPrincipal: string;
+	emailCliente?: string;
 	metodoInicial: "llamada" | "whatsapp" | "email";
 	children: React.ReactNode;
 }
@@ -39,6 +40,7 @@ export function ContactoModal({
 	casoCobroId,
 	clienteNombre,
 	telefonoPrincipal,
+	emailCliente,
 	metodoInicial,
 	children,
 }: ContactoModalProps) {
@@ -106,8 +108,7 @@ export function ContactoModal({
 				);
 				break;
 			case "email":
-				// El email se obtendría del caso, por ahora placeholder
-				window.open("mailto:cliente@email.com");
+				window.open(`mailto:${emailCliente || ""}`);
 				break;
 		}
 	};

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -1,10 +1,13 @@
 import { useForm } from "@tanstack/react-form";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
 import { CalendarIcon, Mail, MessageCircle, Phone } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import {
 	Dialog,
 	DialogClose,
@@ -18,6 +21,11 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+import {
 	Select,
 	SelectContent,
 	SelectItem,
@@ -25,6 +33,7 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 import { client, orpc } from "@/utils/orpc";
 
 interface ContactoModalProps {
@@ -54,6 +63,7 @@ export function ContactoModal({
 			acuerdosAlcanzados: "",
 			compromisosPago: "",
 			requiereSeguimiento: false,
+			fechaProximoContacto: undefined as Date | undefined,
 			duracionLlamada: undefined as number | undefined,
 		},
 		onSubmit: async ({ value }) => {
@@ -73,6 +83,15 @@ export function ContactoModal({
 			queryClient.invalidateQueries(
 				orpc.getHistorialContactos.queryOptions({ input: { casoCobroId } }),
 			);
+			// Invalidar también el detalle del caso para actualizar el sidebar de próximo contacto
+			queryClient.invalidateQueries({
+				predicate: (query) =>
+					query.queryKey.some(
+						(k) =>
+							typeof k === "string" &&
+							k.includes("getDetallesCreditoCarteraBack"),
+					),
+			});
 			form.reset();
 			// Cerrar el dialogo
 			document
@@ -387,11 +406,64 @@ export function ContactoModal({
 									<input
 										type="checkbox"
 										checked={field.state.value}
-										onChange={(e) => field.handleChange(e.target.checked)}
+										onChange={(e) => {
+											field.handleChange(e.target.checked);
+											if (!e.target.checked) {
+												form.setFieldValue("fechaProximoContacto", undefined);
+											}
+										}}
 									/>
 									<Label>Requiere seguimiento programado</Label>
 								</div>
 							)}
+						</form.Field>
+
+						<form.Field name="requiereSeguimiento">
+							{(seguimientoField) =>
+								seguimientoField.state.value && (
+									<form.Field name="fechaProximoContacto">
+										{(field) => (
+											<div className="space-y-2">
+												<Label>Fecha de próximo contacto *</Label>
+												<Popover>
+													<PopoverTrigger asChild>
+														<Button
+															type="button"
+															variant="outline"
+															className={cn(
+																"w-full justify-start text-left font-normal",
+																!field.state.value && "text-muted-foreground",
+															)}
+														>
+															<CalendarIcon className="mr-2 h-4 w-4" />
+															{field.state.value
+																? format(field.state.value, "dd MMM, yyyy", {
+																		locale: es,
+																	})
+																: "Seleccionar fecha"}
+														</Button>
+													</PopoverTrigger>
+													<PopoverContent
+														className="w-auto p-0"
+														align="start"
+													>
+														<Calendar
+															mode="single"
+															selected={field.state.value}
+															onSelect={(date) => field.handleChange(date)}
+															disabled={(date) =>
+																date <
+																new Date(new Date().setHours(0, 0, 0, 0))
+															}
+															locale={es}
+														/>
+													</PopoverContent>
+												</Popover>
+											</div>
+										)}
+									</form.Field>
+								)
+							}
 						</form.Field>
 					</div>
 

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -336,7 +336,7 @@ function RouteComponent() {
 									type="monotone"
 									dataKey="monto"
 									stroke="#10b981"
-									name="Monto Financiado"
+									name="Capital Activo"
 								/>
 							</LineChart>
 						</ResponsiveContainer>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
 	AlertTriangle,
@@ -23,6 +23,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { ContactoModal } from "@/components/contacto-modal";
+import { ReferenciasView } from "@/components/cobros/ReferenciasView";
 import {
 	OpportunityDetailModal,
 	type OpportunityForModal,
@@ -127,6 +128,16 @@ function RouteComponent() {
 		year: 2000,
 		licensePlate: "",
 	});
+
+	// Estado de edición de contacto
+	const [isEditingContact, setIsEditingContact] = useState(false);
+	const [contactForm, setContactForm] = useState({
+		telefonoPrincipal: "",
+		telefonoAlternativo: "",
+		emailContacto: "",
+	});
+
+	const queryClient = useQueryClient();
 
 	// Obtener detalles del contrato/caso
 	// Si es ID numérico, usar endpoint de Cartera-Back, si es UUID usar el del CRM
@@ -245,6 +256,30 @@ function RouteComponent() {
 		},
 		onError: (err: any) => {
 			toast.error(err.message || "Error al actualizar el vehículo");
+		},
+	});
+
+	const updateContactMutation = useMutation({
+		mutationFn: (data: {
+			telefonoPrincipal: string;
+			telefonoAlternativo?: string;
+			emailContacto?: string;
+		}) =>
+			client.updateContactInfoCobros({
+				casoCobroId: casoDetails.data?.id ?? "",
+				...data,
+			}),
+		onSuccess: () => {
+			toast.success("Información de contacto actualizada");
+			queryClient.invalidateQueries(
+				orpc.getDetallesCreditoCarteraBack.queryOptions({
+					input: { creditoId: id },
+				}),
+			);
+			setIsEditingContact(false);
+		},
+		onError: (err: any) => {
+			toast.error(err.message || "Error al actualizar contacto");
 		},
 	});
 
@@ -437,47 +472,134 @@ function RouteComponent() {
 								<Phone className="h-5 w-5" />
 								Información de Contacto
 							</CardTitle>
-							{matchingOpportunity?.lead?.id &&
-								(caso.telefonoPrincipal ||
-									caso.emailContacto ||
-									caso.direccionContacto) && (
-									<Link
-										to="/crm/clients"
-										search={{ idLead: matchingOpportunity.lead.id, edit: true }}
-									>
-										<Button variant="outline" size="sm">
-											<Pencil className="mr-2 h-4 w-4" />
-											Editar
-										</Button>
-									</Link>
-								)}
+							{caso.id && !isEditingContact && (
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => {
+										setContactForm({
+											telefonoPrincipal: caso.telefonoPrincipal || "",
+											telefonoAlternativo: caso.telefonoAlternativo || "",
+											emailContacto: caso.emailContacto || "",
+										});
+										setIsEditingContact(true);
+									}}
+								>
+									<Pencil className="mr-2 h-4 w-4" />
+									Editar
+								</Button>
+							)}
 						</CardHeader>
 						<CardContent className="space-y-4">
+							{isEditingContact ? (
+								<div className="space-y-3">
+									<div>
+										<Label htmlFor="contact-phone">Teléfono Principal *</Label>
+										<Input
+											id="contact-phone"
+											value={contactForm.telefonoPrincipal}
+											onChange={(e) =>
+												setContactForm((f) => ({
+													...f,
+													telefonoPrincipal: e.target.value,
+												}))
+											}
+											placeholder="Ej: 5555-5555"
+										/>
+									</div>
+									<div>
+										<Label htmlFor="contact-phone-alt">Teléfono Alternativo</Label>
+										<Input
+											id="contact-phone-alt"
+											value={contactForm.telefonoAlternativo}
+											onChange={(e) =>
+												setContactForm((f) => ({
+													...f,
+													telefonoAlternativo: e.target.value,
+												}))
+											}
+											placeholder="Ej: 4444-4444"
+										/>
+									</div>
+									<div>
+										<Label htmlFor="contact-email">Email</Label>
+										<Input
+											id="contact-email"
+											type="email"
+											value={contactForm.emailContacto}
+											onChange={(e) =>
+												setContactForm((f) => ({
+													...f,
+													emailContacto: e.target.value,
+												}))
+											}
+											placeholder="Ej: correo@ejemplo.com"
+										/>
+									</div>
+									<div className="flex gap-2">
+										<Button
+											size="sm"
+											onClick={() => {
+												if (!window.confirm("¿Estás seguro de actualizar la información de contacto?")) return;
+												updateContactMutation.mutate({
+													telefonoPrincipal: contactForm.telefonoPrincipal,
+													telefonoAlternativo: contactForm.telefonoAlternativo || undefined,
+													emailContacto: contactForm.emailContacto || undefined,
+												});
+											}}
+											disabled={
+												updateContactMutation.isPending ||
+												!contactForm.telefonoPrincipal
+											}
+										>
+											{updateContactMutation.isPending
+												? "Guardando..."
+												: "Guardar"}
+										</Button>
+										<Button
+											size="sm"
+											variant="outline"
+											onClick={() => setIsEditingContact(false)}
+											disabled={updateContactMutation.isPending}
+										>
+											Cancelar
+										</Button>
+									</div>
+								</div>
+							) : (
 							<div className="grid grid-cols-2 gap-4">
 								<div>
 									<p className="text-muted-foreground text-sm">
 										Teléfono Principal
 									</p>
-									<p className="font-medium">{caso.telefonoPrincipal}</p>
+									{caso.telefonoPrincipal ? (
+										<a href={`tel:${caso.telefonoPrincipal.replace(/[^0-9+]/g, "")}`} className="font-medium text-primary hover:underline">{caso.telefonoPrincipal}</a>
+									) : (
+										<p className="font-medium">-</p>
+									)}
 								</div>
 								{caso.telefonoAlternativo && (
 									<div>
 										<p className="text-muted-foreground text-sm">
 											Teléfono Alternativo
 										</p>
-										<p className="font-medium">{caso.telefonoAlternativo}</p>
+										<a href={`tel:${String(caso.telefonoAlternativo).replace(/[^0-9+]/g, "")}`} className="font-medium text-primary hover:underline">{caso.telefonoAlternativo}</a>
 									</div>
 								)}
 								<div>
 									<p className="text-muted-foreground text-sm">Email</p>
-									<p className="font-medium">{caso.emailContacto}</p>
+									{caso.emailContacto ? (
+										<a href={`mailto:${caso.emailContacto}`} className="font-medium text-primary hover:underline">{caso.emailContacto}</a>
+									) : (
+										<p className="font-medium">-</p>
+									)}
 								</div>
 								<div>
 									<p className="text-muted-foreground text-sm">Dirección</p>
 									<p className="font-medium">{caso.direccionContacto}</p>
 								</div>
 							</div>
-
+							)}
 							{/* Botones de Contacto - Solo si existe caso de cobros */}
 							{caso.id ? (
 								<>
@@ -487,6 +609,7 @@ function RouteComponent() {
 											casoCobroId={caso.id}
 											clienteNombre={caso.clienteNombre || ""}
 											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											emailCliente={caso.emailContacto || ""}
 											metodoInicial="llamada"
 										>
 											<Button className="flex items-center gap-2">
@@ -499,6 +622,7 @@ function RouteComponent() {
 											casoCobroId={caso.id}
 											clienteNombre={caso.clienteNombre || ""}
 											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											emailCliente={caso.emailContacto || ""}
 											metodoInicial="whatsapp"
 										>
 											<Button
@@ -514,6 +638,7 @@ function RouteComponent() {
 											casoCobroId={caso.id}
 											clienteNombre={caso.clienteNombre || ""}
 											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											emailCliente={caso.emailContacto || ""}
 											metodoInicial="email"
 										>
 											<Button
@@ -537,6 +662,11 @@ function RouteComponent() {
 							)}
 						</CardContent>
 					</Card>
+
+					{/* Referencias */}
+					{matchingOpportunity?.lead?.id && (
+						<ReferenciasView leadId={matchingOpportunity.lead.id} />
+					)}
 
 					{/* Historial de Contactos */}
 					<Card>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -739,6 +739,16 @@ function RouteComponent() {
 																{contacto.compromisosPago}
 															</div>
 														)}
+														{contacto.fechaProximoContacto && (
+															<div className="mt-2 rounded bg-amber-50 p-2 text-sm">
+																<span className="font-medium">
+																	📅 Seguimiento programado:{" "}
+																</span>
+																{new Date(
+																	contacto.fechaProximoContacto,
+																).toLocaleDateString("es-GT")}
+															</div>
+														)}
 														<div className="mt-2 flex items-center justify-between text-muted-foreground text-xs">
 															<span>
 																Por: {contacto.realizadoPor || "Sin asignar"}

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -1,8 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { differenceInDays } from "date-fns";
 import {
 	Banknote,
+	CalendarClock,
 	CalendarDays,
 	CalendarRange,
 	ChevronDown,
@@ -295,6 +296,33 @@ function RouteComponent() {
 			},
 		}),
 		enabled: !!session,
+	});
+
+	// Query para seguimientos pendientes (casos con proximoContacto)
+	const seguimientosQuery = useQuery({
+		...orpc.getCasosCobros.queryOptions({
+			input: {
+				limit: 100,
+				offset: 0,
+			},
+		}),
+		enabled: !!session,
+		select: (data) => {
+			const hoy = new Date();
+			hoy.setHours(0, 0, 0, 0);
+			const en7Dias = new Date(hoy);
+			en7Dias.setDate(en7Dias.getDate() + 7);
+
+			return data.filter((caso) => {
+				if (!caso.proximoContacto) return false;
+				const fecha = new Date(caso.proximoContacto);
+				return fecha <= en7Dias;
+			}).sort((a, b) => {
+				const fechaA = new Date(a.proximoContacto!);
+				const fechaB = new Date(b.proximoContacto!);
+				return fechaA.getTime() - fechaB.getTime();
+			});
+		},
 	});
 
 	// Mapear filtroTemporal al enum time
@@ -695,6 +723,73 @@ function RouteComponent() {
 					</div>
 				</CardContent>
 			</Card>
+
+			{/* Seguimientos Pendientes */}
+			{seguimientosQuery.data && seguimientosQuery.data.length > 0 && (
+				<Card className="border-amber-200">
+					<CardHeader className="pb-3">
+						<CardTitle className="flex items-center gap-2">
+							<CalendarClock className="h-5 w-5 text-amber-600" />
+							Seguimientos Pendientes
+						</CardTitle>
+						<CardDescription>
+							Casos con seguimiento programado para hoy o los próximos 7 días
+						</CardDescription>
+					</CardHeader>
+					<CardContent>
+						<div className="space-y-2">
+							{seguimientosQuery.data.map((caso) => {
+								const fecha = new Date(caso.proximoContacto!);
+								const hoy = new Date();
+								hoy.setHours(0, 0, 0, 0);
+								const esHoy = fecha.toDateString() === hoy.toDateString();
+								const esPasado = fecha < hoy;
+
+								return (
+									<Link
+										key={caso.id}
+										to="/cobros/$id"
+										params={{ id: caso.contratoId || caso.id }}
+										search={{ tipo: "caso" as const }}
+										className="flex items-center justify-between rounded-lg border p-3 transition-colors hover:bg-muted/50"
+									>
+										<div className="flex items-center gap-3">
+											<div
+												className={`h-2 w-2 rounded-full ${esPasado ? "bg-red-500" : esHoy ? "bg-amber-500" : "bg-green-500"}`}
+											/>
+											<div>
+												<p className="font-medium text-sm">
+													{caso.clienteNombre || "Sin nombre"}
+												</p>
+												<p className="text-muted-foreground text-xs">
+													{caso.vehiculoMarca} {caso.vehiculoModelo}{" "}
+													{caso.vehiculoYear}
+												</p>
+											</div>
+										</div>
+										<div className="text-right">
+											<p
+												className={`text-sm font-medium ${esPasado ? "text-red-600" : esHoy ? "text-amber-600" : "text-muted-foreground"}`}
+											>
+												{esHoy
+													? "Hoy"
+													: esPasado
+														? "Vencido"
+														: fecha.toLocaleDateString("es-GT")}
+											</p>
+											{esPasado && (
+												<p className="text-red-500 text-xs">
+													{fecha.toLocaleDateString("es-GT")}
+												</p>
+											)}
+										</div>
+									</Link>
+								);
+							})}
+						</div>
+					</CardContent>
+				</Card>
+			)}
 
 			{/* Filtros Temporales y Tabla */}
 			<Card>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -2941,6 +2941,22 @@ function RouteComponent() {
 													);
 													return;
 												}
+												// Intercept 85% → 90%+: open confirm contracts signed modal
+												if (
+													targetStage &&
+													currentStage &&
+													currentStage.closurePercentage === 85 &&
+													targetStage.closurePercentage >= 90
+												) {
+													setOpportunityToConfirmSigned({
+														id: selectedOpportunity.id,
+														title: selectedOpportunity.title,
+													});
+													setConfirmSignedModalOpen(true);
+													setIsChangeStageDialogOpen(false);
+													return;
+												}
+
 												// Validate: moving from <=20% to >=30% requires a vehicle
 												if (
 													targetStage &&


### PR DESCRIPTION
## Summary
- **feat(cobros):** Gestión de teléfonos, referencias y contacto en casos de cobro
- **feat(cobros):** Fecha de próximo contacto en modal de gestión y panel de seguimientos pendientes en dashboard
- **fix(crm):** Permitir a analistas confirmar firma de contratos (85% → 90%) tanto en drag & drop como en diálogo "Cambiar Etapa"

## Test plan
- [ ] Verificar que analistas pueden mover oportunidades de 85% a 90% via drag & drop
- [ ] Verificar que analistas pueden mover oportunidades de 85% a 90% via diálogo "Cambiar Etapa"
- [ ] Verificar que el modal de confirmación de firma se abre correctamente en ambos flujos
- [ ] Verificar que el panel de seguimientos pendientes muestra casos con próximo contacto en los próximos 7 días
- [ ] Verificar que se puede seleccionar fecha de próximo contacto al registrar gestión con seguimiento

🤖 Generated with [Claude Code](https://claude.com/claude-code)