### PR TITLE
Relaxes boleta_url validation

### DIFF
--- a/apps/crm/apps/server/src/routers/accounting.ts
+++ b/apps/crm/apps/server/src/routers/accounting.ts
@@ -12,7 +12,7 @@ export const accountingRouter = {
 		.input(
 			z.object({
 				inversionista_id: z.number().int().positive(),
-				boleta_url: z.string().url(),
+				boleta_url: z.string(),
 				monto_boleta: z.string().optional(),
 				notas: z.string().optional(),
 			}),


### PR DESCRIPTION
Allows boleta_url to accept any string instead of just URLs. This provides greater flexibility and avoids unnecessary restrictions.