### PR TITLE
feat(cobros): plantillas de mensajes y mejora UX contacto

### DIFF
--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -27,15 +27,14 @@ import {
 import { createPublicLead } from "./controllers/public-lead";
 import type { db } from "./db";
 import { otps } from "./db/schema/otp";
-import { auth } from "./lib/auth";
-import { createContext } from "./lib/context";
-import { appRouter } from "./routers/index";
-import externalContractsRouter from "./routes/external-contracts";
-
 import {
 	checkCasosSinContacto,
 	checkSeguimientosVencidos,
 } from "./jobs/cobros-notifications";
+import { auth } from "./lib/auth";
+import { createContext } from "./lib/context";
+import { appRouter } from "./routers/index";
+import externalContractsRouter from "./routes/external-contracts";
 
 const app = new Hono();
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -15,14 +15,21 @@ import {
 	metodoContactoEnum,
 	recuperacionesVehiculo,
 } from "../db/schema/cobros";
-import { clients, leads, opportunities, PARENTESCO_VALUES, referenciasLead, salesStages } from "../db/schema/crm";
+import {
+	clients,
+	leads,
+	opportunities,
+	PARENTESCO_VALUES,
+	referenciasLead,
+	salesStages,
+} from "../db/schema/crm";
 import { vehicles } from "../db/schema/vehicles";
+import { calcularDiasMoraExactos } from "../lib/mora-utils";
 import {
 	cobrosProcedure,
 	cobrosSupervisorProcedure,
 	crmOrCobrosProcedure,
 } from "../lib/orpc";
-import { createNotification } from "./notifications";
 import { PERMISSIONS } from "../lib/roles";
 import { carteraBackClient } from "../services/cartera-back-client";
 import {
@@ -36,7 +43,7 @@ import {
 	sincronizarCasosCobros,
 } from "../services/sync-casos-cobros";
 import type { CreditoDirectoResponse } from "../types/cartera-back";
-import { calcularDiasMoraExactos } from "../lib/mora-utils";
+import { createNotification } from "./notifications";
 
 // Helper: Obtener todos los créditos de todos los estados
 async function obtenerTodosLosCreditosCarteraBack(params: {
@@ -1826,7 +1833,8 @@ export const cobrosRouter = {
 					cuotasVencidas: cuotasAtrasadas,
 
 					// Datos de contacto (del caso de cobros primero, fallback al lead)
-					telefonoPrincipal: casoCobro?.telefonoPrincipal || leadInfo?.telefono || null,
+					telefonoPrincipal:
+						casoCobro?.telefonoPrincipal || leadInfo?.telefono || null,
 					telefonoAlternativo: casoCobro?.telefonoAlternativo || null,
 					emailContacto: casoCobro?.emailContacto || leadInfo?.email || null,
 					direccionContacto: direccion || null,
@@ -2490,7 +2498,12 @@ export const cobrosRouter = {
 					notas: input.notas || null,
 					updatedAt: new Date(),
 				})
-				.where(and(eq(referenciasLead.id, input.id), eq(referenciasLead.leadId, input.leadId)))
+				.where(
+					and(
+						eq(referenciasLead.id, input.id),
+						eq(referenciasLead.leadId, input.leadId),
+					),
+				)
 				.returning();
 
 			if (!updated) {
@@ -2512,7 +2525,12 @@ export const cobrosRouter = {
 		.handler(async ({ input }) => {
 			const [deleted] = await db
 				.delete(referenciasLead)
-				.where(and(eq(referenciasLead.id, input.id), eq(referenciasLead.leadId, input.leadId)))
+				.where(
+					and(
+						eq(referenciasLead.id, input.id),
+						eq(referenciasLead.leadId, input.leadId),
+					),
+				)
 				.returning();
 
 			if (!deleted) {

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -9,10 +9,10 @@ import { z } from "zod";
 import { db } from "../db";
 import { carteraBackReferences } from "../db/schema/cartera-back";
 import { casosCobros } from "../db/schema/cobros";
+import { calcularDiasMoraExactos } from "../lib/mora-utils";
 import { adminProcedure } from "../lib/orpc";
 import { carteraBackClient } from "../services/cartera-back-client";
 import { isCarteraBackEnabled } from "../services/cartera-back-integration";
-import { calcularDiasMoraExactos } from "../lib/mora-utils";
 
 export const reportesCarteraRouter = {
 	// ========================================================================

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+	BoletaPagoInversionista,
 	CarteraAsesor,
 	CarteraBackApiResponse,
 	CarteraBackAuthError,
@@ -15,6 +16,7 @@ import type {
 	CarteraPagoCredito,
 	CarteraStatsResponse,
 	CarteraUsuario,
+	CreateBoletaInput,
 	CreateCreditoInput,
 	CreatePagoInput,
 	CreateUsuarioInput,
@@ -30,8 +32,6 @@ import type {
 	GetPaymentsParams,
 	InversionistaReporte,
 	LiquidatePagosInversionistasInput,
-	BoletaPagoInversionista,
-	CreateBoletaInput,
 	PaginatedResponse,
 	ResumenGlobalInversionista,
 	ReversePagoInput,
@@ -695,7 +695,9 @@ export class CarteraBackClient {
 	// RESUMEN GLOBAL INVERSIONISTAS
 	// ========================================================================
 
-	async getResumenGlobalInversionistas(): Promise<ResumenGlobalInversionista[]> {
+	async getResumenGlobalInversionistas(): Promise<
+		ResumenGlobalInversionista[]
+	> {
 		const response = await this.request<ResumenGlobalInversionista[]>(
 			"/resumen-global",
 			{ method: "GET" },
@@ -704,7 +706,10 @@ export class CarteraBackClient {
 		return response;
 	}
 
-	async uploadFile(file: File | Blob, filename: string): Promise<{ url: string; filename: string }> {
+	async uploadFile(
+		file: File | Blob,
+		filename: string,
+	): Promise<{ url: string; filename: string }> {
 		const url = `${this.config.baseUrl}/upload`;
 		const formData = new FormData();
 		formData.append("file", file, filename);
@@ -726,14 +731,13 @@ export class CarteraBackClient {
 		return response.json();
 	}
 
-	async createBoleta(input: CreateBoletaInput): Promise<BoletaPagoInversionista> {
-		const response = await this.request<BoletaPagoInversionista>(
-			"/boletas",
-			{
-				method: "POST",
-				body: JSON.stringify(input),
-			},
-		);
+	async createBoleta(
+		input: CreateBoletaInput,
+	): Promise<BoletaPagoInversionista> {
+		const response = await this.request<BoletaPagoInversionista>("/boletas", {
+			method: "POST",
+			body: JSON.stringify(input),
+		});
 		this.cache.invalidate("resumen-global");
 		return response;
 	}

--- a/apps/crm/apps/server/src/services/sync-casos-cobros.ts
+++ b/apps/crm/apps/server/src/services/sync-casos-cobros.ts
@@ -16,9 +16,9 @@ import {
 	type estadoMoraEnum,
 } from "../db/schema/cobros";
 import { leads } from "../db/schema/crm";
-import type { StatusCreditEnum } from "../types/cartera-back";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
 import { createNotification } from "../routers/notifications";
+import type { StatusCreditEnum } from "../types/cartera-back";
 import { carteraBackClient } from "./cartera-back-client";
 import { isCarteraBackEnabled } from "./cartera-back-integration";
 
@@ -62,10 +62,7 @@ const MORA_SEVERITY: Record<string, number> = {
 	incobrable: 6,
 };
 
-function moraEscalo(
-	estadoAnterior: string,
-	estadoNuevo: string,
-): boolean {
+function moraEscalo(estadoAnterior: string, estadoNuevo: string): boolean {
 	return (
 		(MORA_SEVERITY[estadoNuevo] ?? 0) > (MORA_SEVERITY[estadoAnterior] ?? 0)
 	);
@@ -420,21 +417,24 @@ export async function sincronizarCasosCobros(
 					const emailContacto = lead[0]?.email || "Sin email";
 					const direccionContacto = "Por confirmar";
 
-					const [nuevoCaso] = await db.insert(casosCobros).values({
-						contratoId,
-						numeroCreditoSifco: credito.creditos.numero_credito_sifco,
-						estadoMora,
-						montoEnMora: creditoCompleto.moraActual, // ya es string
-						diasMoraMaximo: diasMora,
-						cuotasVencidas: creditoCompleto.cuotasAtrasadas?.length || 0,
-						responsableCobros: responsable,
-						telefonoPrincipal,
-						telefonoAlternativo: null,
-						emailContacto,
-						direccionContacto,
-						activo: true,
-						notes: `Caso creado automáticamente desde cartera-back el ${now.toLocaleDateString()}`,
-					}).returning();
+					const [nuevoCaso] = await db
+						.insert(casosCobros)
+						.values({
+							contratoId,
+							numeroCreditoSifco: credito.creditos.numero_credito_sifco,
+							estadoMora,
+							montoEnMora: creditoCompleto.moraActual, // ya es string
+							diasMoraMaximo: diasMora,
+							cuotasVencidas: creditoCompleto.cuotasAtrasadas?.length || 0,
+							responsableCobros: responsable,
+							telefonoPrincipal,
+							telefonoAlternativo: null,
+							emailContacto,
+							direccionContacto,
+							activo: true,
+							notes: `Caso creado automáticamente desde cartera-back el ${now.toLocaleDateString()}`,
+						})
+						.returning();
 
 					result.casosCreados++;
 					console.log(

--- a/apps/crm/apps/web/src/components/cobros/ReferenciasView.tsx
+++ b/apps/crm/apps/web/src/components/cobros/ReferenciasView.tsx
@@ -338,16 +338,10 @@ export function ReferenciasView({ leadId }: ReferenciasViewProps) {
 					</DialogHeader>
 					{renderFormFields()}
 					<DialogFooter>
-						<Button
-							variant="outline"
-							onClick={() => setIsAddDialogOpen(false)}
-						>
+						<Button variant="outline" onClick={() => setIsAddDialogOpen(false)}>
 							Cancelar
 						</Button>
-						<Button
-							onClick={handleCreate}
-							disabled={createMutation.isPending}
-						>
+						<Button onClick={handleCreate} disabled={createMutation.isPending}>
 							{createMutation.isPending ? (
 								"Guardando..."
 							) : (
@@ -378,10 +372,7 @@ export function ReferenciasView({ leadId }: ReferenciasViewProps) {
 						>
 							Cancelar
 						</Button>
-						<Button
-							onClick={handleUpdate}
-							disabled={updateMutation.isPending}
-						>
+						<Button onClick={handleUpdate} disabled={updateMutation.isPending}>
 							{updateMutation.isPending ? (
 								"Guardando..."
 							) : (

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Dialog,
 	DialogClose,
@@ -580,17 +581,19 @@ export function ContactoModal({
 						<form.Field name="requiereSeguimiento">
 							{(field) => (
 								<div className="flex items-center space-x-2">
-									<input
-										type="checkbox"
+									<Checkbox
+										id="requiereSeguimiento"
 										checked={field.state.value}
-										onChange={(e) => {
-											field.handleChange(e.target.checked);
-											if (!e.target.checked) {
+										onCheckedChange={(checked) => {
+											field.handleChange(!!checked);
+											if (!checked) {
 												form.setFieldValue("fechaProximoContacto", undefined);
 											}
 										}}
 									/>
-									<Label>Requiere seguimiento programado</Label>
+									<Label htmlFor="requiereSeguimiento">
+										Requiere seguimiento programado
+									</Label>
 								</div>
 							)}
 						</form.Field>

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -443,17 +443,13 @@ export function ContactoModal({
 																: "Seleccionar fecha"}
 														</Button>
 													</PopoverTrigger>
-													<PopoverContent
-														className="w-auto p-0"
-														align="start"
-													>
+													<PopoverContent className="w-auto p-0" align="start">
 														<Calendar
 															mode="single"
 															selected={field.state.value}
 															onSelect={(date) => field.handleChange(date)}
 															disabled={(date) =>
-																date <
-																new Date(new Date().setHours(0, 0, 0, 0))
+																date < new Date(new Date().setHours(0, 0, 0, 0))
 															}
 															locale={es}
 														/>

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -59,6 +59,7 @@ interface ContactoModalProps {
 	montoAdeudado?: string;
 	cuotasAtraso?: number;
 	estadoMora?: string;
+	fechaInicio?: string | null;
 	nombreAsesor?: string;
 	telefonoAsesor?: string;
 }
@@ -78,6 +79,7 @@ export function ContactoModal({
 	montoAdeudado = "",
 	cuotasAtraso = 0,
 	estadoMora,
+	fechaInicio,
 	nombreAsesor = "",
 	telefonoAsesor = "",
 }: ContactoModalProps) {
@@ -136,16 +138,14 @@ export function ContactoModal({
 
 	// Pre-seleccionar plantilla sugerida al abrir
 	useEffect(() => {
-		const sugerida = sugerirPlantilla(estadoMora);
-		if (sugerida) {
-			setPlantillaId(sugerida);
-			const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === sugerida);
-			if (plantilla) {
-				setMensajeEditado(interpolar(plantilla.cuerpo, variables));
-				setAsuntoEditado(interpolar(plantilla.asunto, variables));
-			}
+		const sugerida = sugerirPlantilla(estadoMora, fechaInicio);
+		setPlantillaId(sugerida);
+		const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === sugerida);
+		if (plantilla) {
+			setMensajeEditado(interpolar(plantilla.cuerpo, variables));
+			setAsuntoEditado(interpolar(plantilla.asunto, variables));
 		}
-	}, [estadoMora, variables]);
+	}, [estadoMora, fechaInicio, variables]);
 
 	const handlePlantillaChange = (id: string) => {
 		setPlantillaId(id);

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import { CalendarIcon, Mail, MessageCircle, Phone } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -33,6 +33,12 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import {
+	PLANTILLAS_MENSAJES,
+	type VariablesPlantilla,
+	interpolar,
+	sugerirPlantilla,
+} from "@/lib/cobros/plantillas-mensajes";
 import { cn } from "@/lib/utils";
 import { client, orpc } from "@/utils/orpc";
 
@@ -40,20 +46,114 @@ interface ContactoModalProps {
 	casoCobroId: string;
 	clienteNombre: string;
 	telefonoPrincipal: string;
+	telefonoAlternativo?: string;
 	emailCliente?: string;
 	metodoInicial: "llamada" | "whatsapp" | "email";
 	children: React.ReactNode;
+	// Variables para plantillas de mensaje
+	fechaPago?: string;
+	cuotaMensual?: string;
+	placa?: string;
+	marcaLineaModelo?: string;
+	montoAdeudado?: string;
+	cuotasAtraso?: number;
+	estadoMora?: string;
+	nombreAsesor?: string;
+	telefonoAsesor?: string;
 }
 
 export function ContactoModal({
 	casoCobroId,
 	clienteNombre,
 	telefonoPrincipal,
+	telefonoAlternativo,
 	emailCliente,
 	metodoInicial,
 	children,
+	fechaPago = "",
+	cuotaMensual = "",
+	placa = "",
+	marcaLineaModelo = "",
+	montoAdeudado = "",
+	cuotasAtraso = 0,
+	estadoMora,
+	nombreAsesor = "",
+	telefonoAsesor = "",
 }: ContactoModalProps) {
 	const queryClient = useQueryClient();
+
+	const telefonos = useMemo(() => {
+		const lista: string[] = [];
+		// telefonoPrincipal puede traer varios números separados por coma
+		if (telefonoPrincipal) {
+			for (const t of telefonoPrincipal.split(",")) {
+				const limpio = t.trim();
+				if (limpio) lista.push(limpio);
+			}
+		}
+		if (telefonoAlternativo) {
+			for (const t of telefonoAlternativo.split(",")) {
+				const limpio = t.trim();
+				if (limpio && !lista.includes(limpio)) lista.push(limpio);
+			}
+		}
+		return lista;
+	}, [telefonoPrincipal, telefonoAlternativo]);
+
+	const [telefonoSeleccionado, setTelefonoSeleccionado] = useState(
+		() => telefonos[0] || telefonoPrincipal,
+	);
+
+	const [plantillaId, setPlantillaId] = useState<string>("");
+	const [mensajeEditado, setMensajeEditado] = useState("");
+	const [asuntoEditado, setAsuntoEditado] = useState("");
+
+	const variables: VariablesPlantilla = useMemo(
+		() => ({
+			clienteNombre,
+			fechaPago,
+			cuotaMensual,
+			placa,
+			marcaLineaModelo,
+			montoAdeudado,
+			cuotasAtraso,
+			telefonoAsesor,
+			nombreAsesor,
+		}),
+		[
+			clienteNombre,
+			fechaPago,
+			cuotaMensual,
+			placa,
+			marcaLineaModelo,
+			montoAdeudado,
+			cuotasAtraso,
+			telefonoAsesor,
+			nombreAsesor,
+		],
+	);
+
+	// Pre-seleccionar plantilla sugerida al abrir
+	useEffect(() => {
+		const sugerida = sugerirPlantilla(estadoMora);
+		if (sugerida) {
+			setPlantillaId(sugerida);
+			const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === sugerida);
+			if (plantilla) {
+				setMensajeEditado(interpolar(plantilla.cuerpo, variables));
+				setAsuntoEditado(interpolar(plantilla.asunto, variables));
+			}
+		}
+	}, [estadoMora, variables]);
+
+	const handlePlantillaChange = (id: string) => {
+		setPlantillaId(id);
+		const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === id);
+		if (plantilla) {
+			setMensajeEditado(interpolar(plantilla.cuerpo, variables));
+			setAsuntoEditado(interpolar(plantilla.asunto, variables));
+		}
+	};
 
 	const form = useForm({
 		defaultValues: {
@@ -79,11 +179,9 @@ export function ContactoModal({
 			}),
 		onSuccess: () => {
 			toast.success("Contacto registrado correctamente");
-			// Invalidar usando los queryOptions de orpc para obtener las query keys correctas
 			queryClient.invalidateQueries(
 				orpc.getHistorialContactos.queryOptions({ input: { casoCobroId } }),
 			);
-			// Invalidar también el detalle del caso para actualizar el sidebar de próximo contacto
 			queryClient.invalidateQueries({
 				predicate: (query) =>
 					query.queryKey.some(
@@ -93,7 +191,6 @@ export function ContactoModal({
 					),
 			});
 			form.reset();
-			// Cerrar el dialogo
 			document
 				.querySelector<HTMLButtonElement>("[data-radix-dialog-close]")
 				?.click();
@@ -117,25 +214,38 @@ export function ContactoModal({
 	};
 
 	const ejecutarAccion = (metodo: "llamada" | "whatsapp" | "email") => {
+		const tel = telefonoSeleccionado || telefonoPrincipal;
 		switch (metodo) {
 			case "llamada":
-				window.open(`tel:${telefonoPrincipal}`);
+				window.open(`tel:${tel}`);
 				break;
-			case "whatsapp":
+			case "whatsapp": {
+				const telLimpio = tel.replace(/[^0-9]/g, "");
+				const url = mensajeEditado
+					? `https://wa.me/${telLimpio}?text=${encodeURIComponent(mensajeEditado)}`
+					: `https://wa.me/${telLimpio}`;
+				window.open(url);
+				break;
+			}
+			case "email": {
+				const params = new URLSearchParams();
+				if (asuntoEditado) params.set("subject", asuntoEditado);
+				if (mensajeEditado) params.set("body", mensajeEditado);
+				const query = params.toString();
 				window.open(
-					`https://wa.me/${telefonoPrincipal.replace(/[^0-9]/g, "")}`,
+					`mailto:${emailCliente || ""}${query ? `?${query}` : ""}`,
 				);
 				break;
-			case "email":
-				window.open(`mailto:${emailCliente || ""}`);
-				break;
+			}
 		}
 	};
+
+	const mostrarPlantillas = metodoInicial === "whatsapp" || metodoInicial === "email";
 
 	return (
 		<Dialog>
 			<DialogTrigger asChild>{children}</DialogTrigger>
-			<DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+			<DialogContent className="max-h-[90vh] min-w-3xl max-w-4xl overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
 						{getIconoMetodo(metodoInicial)}
@@ -228,7 +338,74 @@ export function ContactoModal({
 							</form.Field>
 						</div>
 
-						{/* Botón para ejecutar acción */}
+						{/* Selector de plantilla para WhatsApp y Email */}
+						{mostrarPlantillas && (
+							<div className="space-y-3 rounded-md border p-3">
+								<div className="space-y-2">
+									<Label>Plantilla de mensaje</Label>
+									<Select
+										value={plantillaId}
+										onValueChange={handlePlantillaChange}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="Seleccionar plantilla..." />
+										</SelectTrigger>
+										<SelectContent>
+											{PLANTILLAS_MENSAJES.map((p) => (
+												<SelectItem key={p.id} value={p.id}>
+													{p.nombre}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+
+								{plantillaId && metodoInicial === "email" && (
+									<div className="space-y-2">
+										<Label>Asunto</Label>
+										<Input
+											value={asuntoEditado}
+											onChange={(e) => setAsuntoEditado(e.target.value)}
+										/>
+									</div>
+								)}
+
+								{plantillaId && (
+									<div className="space-y-2">
+										<Label>Mensaje (editable)</Label>
+										<Textarea
+											className="min-h-[150px] text-sm"
+											value={mensajeEditado}
+											onChange={(e) => setMensajeEditado(e.target.value)}
+										/>
+									</div>
+								)}
+							</div>
+						)}
+
+						{/* Selector de teléfono cuando hay múltiples */}
+						{telefonos.length > 1 && (
+							<div className="space-y-2">
+								<Label>Teléfono a contactar</Label>
+								<Select
+									value={telefonoSeleccionado}
+									onValueChange={setTelefonoSeleccionado}
+								>
+									<SelectTrigger>
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										{telefonos.map((t) => (
+											<SelectItem key={t} value={t}>
+												{t}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+						)}
+
+						{/* Botones para ejecutar acción */}
 						<div className="flex gap-2">
 							<Button
 								type="button"
@@ -238,7 +415,7 @@ export function ContactoModal({
 								className="flex items-center gap-2"
 							>
 								<Phone className="h-4 w-4" />
-								Llamar {telefonoPrincipal}
+								Llamar {telefonos.length <= 1 ? telefonos[0] || "" : ""}
 							</Button>
 							<Button
 								type="button"

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -272,9 +272,7 @@ export default function Header() {
 								<DropdownMenu>
 									<DropdownMenuTrigger asChild>
 										<Button
-											variant={
-												isActive("/accounting") ? "secondary" : "ghost"
-											}
+											variant={isActive("/accounting") ? "secondary" : "ghost"}
 											size="sm"
 											className="gap-1"
 										>

--- a/apps/crm/apps/web/src/components/user-menu.tsx
+++ b/apps/crm/apps/web/src/components/user-menu.tsx
@@ -88,8 +88,9 @@ export default function UserMenu() {
 					<Button
 						variant="outline"
 						className="w-full"
-						onClick={() => {
-							authClient.signOut();
+						onClick={async () => {
+							await authClient.signOut();
+							window.location.href = "/";
 						}}
 					>
 						Cerrar Sesión

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -2,6 +2,7 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { parseFechaLocal } from "@/lib/date-utils";
 
 export type ContratoCobranza = {
 	contratoId: string;
@@ -104,7 +105,7 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 				);
 			}
 
-			const fechaFormateada = new Date(fecha).toLocaleDateString("es-GT", {
+			const fechaFormateada = parseFechaLocal(fecha).toLocaleDateString("es-GT", {
 				day: "2-digit",
 				month: "short",
 				year: "numeric",

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -177,17 +177,34 @@ Tel: {telefonoAsesor}`,
 	},
 ];
 
-/** Sugiere una plantilla según el estado de mora del caso */
+/** Sugiere una plantilla según el estado de mora y antigüedad del caso */
 export function sugerirPlantilla(
 	estadoMora: string | undefined,
-): string | undefined {
-	const mapa: Record<string, string> = {
-		al_dia: "al_dia",
+	fechaInicio?: string | Date | null,
+): string {
+	const mapaMora: Record<string, string> = {
 		pre_mora: "pre_mora",
 		mora_30: "mora_30",
 		mora_60: "mora_60",
 		mora_90: "aviso_juridico",
 		incobrable: "aviso_juridico",
 	};
-	return estadoMora ? mapa[estadoMora] : undefined;
+
+	// Si tiene mora, usar plantilla correspondiente
+	if (estadoMora && mapaMora[estadoMora]) {
+		return mapaMora[estadoMora];
+	}
+
+	// Si es cliente reciente (menos de 30 días), bienvenida
+	if (fechaInicio) {
+		const inicio = new Date(fechaInicio);
+		const diasDesdeInicio =
+			(Date.now() - inicio.getTime()) / (1000 * 60 * 60 * 24);
+		if (diasDesdeInicio <= 30) {
+			return "bienvenida";
+		}
+	}
+
+	// Fallback: recordatorio de pago
+	return "al_dia";
 }

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -1,0 +1,167 @@
+/**
+ * Plantillas de mensajes predefinidos para cobros (WhatsApp y Email).
+ *
+ * RFC: Migrar a tabla `plantillas_mensaje` en DB para permitir edición
+ * en caliente desde UI admin sin necesidad de deploy.
+ * Esquema propuesto:
+ *   - id, nombre, etapa, asunto, cuerpo, activa, created_at, updated_at
+ *   - Seed inicial con estas 6 plantillas
+ *   - Endpoint ORPC: listPlantillasMensaje
+ */
+
+export interface VariablesPlantilla {
+	clienteNombre: string;
+	fechaPago: string;
+	cuotaMensual: string;
+	placa: string;
+	marcaLineaModelo: string;
+	montoAdeudado: string;
+	cuotasAtraso: number;
+	telefonoAsesor: string;
+	nombreAsesor: string;
+}
+
+export interface PlantillaMensaje {
+	id: string;
+	nombre: string;
+	etapa: string;
+	asunto: string;
+	cuerpo: string;
+}
+
+export function interpolar(
+	texto: string,
+	variables: VariablesPlantilla,
+): string {
+	return texto
+		.replace(/{clienteNombre}/g, variables.clienteNombre)
+		.replace(/{fechaPago}/g, variables.fechaPago)
+		.replace(/{cuotaMensual}/g, variables.cuotaMensual)
+		.replace(/{placa}/g, variables.placa)
+		.replace(/{marcaLineaModelo}/g, variables.marcaLineaModelo)
+		.replace(/{montoAdeudado}/g, variables.montoAdeudado)
+		.replace(/{cuotasAtraso}/g, String(variables.cuotasAtraso))
+		.replace(/{telefonoAsesor}/g, variables.telefonoAsesor)
+		.replace(/{nombreAsesor}/g, variables.nombreAsesor);
+}
+
+export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
+	{
+		id: "bienvenida",
+		nombre: "Bienvenida",
+		etapa: "al_dia",
+		asunto: "Bienvenido/a a su plan de financiamiento",
+		cuerpo: `Estimado/a {clienteNombre},
+
+Le damos la bienvenida a su plan de financiamiento para su vehículo {marcaLineaModelo} ({placa}).
+
+Su cuota mensual es de Q{cuotaMensual}, con fecha de pago el día {fechaPago} de cada mes.
+
+Cualquier consulta no dude en comunicarse con nosotros.
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
+		id: "al_dia",
+		nombre: "Recordatorio de pago",
+		etapa: "al_dia",
+		asunto: "Recordatorio de pago - Vehículo {placa}",
+		cuerpo: `Estimado/a {clienteNombre},
+
+Le recordamos que su próxima cuota de Q{cuotaMensual} vence el día {fechaPago}.
+
+Vehículo: {marcaLineaModelo} ({placa})
+
+Agradecemos su puntualidad. Si ya realizó el pago, por favor haga caso omiso de este mensaje.
+
+Saludos cordiales,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
+		id: "pre_mora",
+		nombre: "Aviso de atraso",
+		etapa: "pre_mora",
+		asunto: "Aviso de atraso en pago - Vehículo {placa}",
+		cuerpo: `Estimado/a {clienteNombre},
+
+Hemos notado que su pago correspondiente al día {fechaPago} aún no ha sido registrado.
+
+Vehículo: {marcaLineaModelo} ({placa})
+Monto pendiente: Q{montoAdeudado}
+
+Le solicitamos ponerse al día a la brevedad para evitar recargos adicionales. Si ya realizó el pago, por favor envíenos el comprobante.
+
+Quedo a sus órdenes,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
+		id: "mora_30",
+		nombre: "Mora 30 días",
+		etapa: "mora_30",
+		asunto: "URGENTE: Mora de 30 días - Vehículo {placa}",
+		cuerpo: `Estimado/a {clienteNombre},
+
+Su cuenta presenta un atraso de {cuotasAtraso} cuota(s) por un monto total de Q{montoAdeudado}.
+
+Vehículo: {marcaLineaModelo} ({placa})
+
+Es importante que regularice su situación a la brevedad posible para evitar acciones adicionales de cobro. Le invitamos a comunicarse con nosotros para buscar una solución.
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
+		id: "mora_60",
+		nombre: "Mora 60 días",
+		etapa: "mora_60",
+		asunto: "AVISO IMPORTANTE: Mora de 60 días - Vehículo {placa}",
+		cuerpo: `Estimado/a {clienteNombre},
+
+Su cuenta presenta un atraso significativo de {cuotasAtraso} cuota(s) con un saldo vencido de Q{montoAdeudado}.
+
+Vehículo: {marcaLineaModelo} ({placa})
+
+De no recibir respuesta o pago en los próximos días, nos veremos en la necesidad de escalar su caso a la siguiente fase de recuperación. Le urgimos comunicarse con nosotros para llegar a un acuerdo.
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
+		id: "aviso_juridico",
+		nombre: "Aviso jurídico",
+		etapa: "mora_90",
+		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
+		cuerpo: `Estimado/a {clienteNombre},
+
+Por medio de la presente le notificamos que debido al incumplimiento reiterado en sus pagos ({cuotasAtraso} cuotas vencidas por Q{montoAdeudado}), su caso será trasladado al departamento jurídico para iniciar las acciones legales correspondientes.
+
+Vehículo: {marcaLineaModelo} ({placa})
+
+Tiene un plazo de 48 horas para comunicarse con nosotros y regularizar su situación antes de que se proceda con las acciones legales.
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+];
+
+/** Sugiere una plantilla según el estado de mora del caso */
+export function sugerirPlantilla(
+	estadoMora: string | undefined,
+): string | undefined {
+	const mapa: Record<string, string> = {
+		al_dia: "al_dia",
+		pre_mora: "pre_mora",
+		mora_30: "mora_30",
+		mora_60: "mora_60",
+		mora_90: "aviso_juridico",
+		incobrable: "aviso_juridico",
+	};
+	return estadoMora ? mapa[estadoMora] : undefined;
+}

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -29,20 +29,46 @@ export interface PlantillaMensaje {
 	cuerpo: string;
 }
 
+function toCapitalCase(str: string): string {
+	return str
+		.toLowerCase()
+		.split(" ")
+		.map((word) => (word ? word[0].toUpperCase() + word.slice(1) : ""))
+		.join(" ");
+}
+
 export function interpolar(
 	texto: string,
 	variables: VariablesPlantilla,
 ): string {
+	const v = (val: string | number, placeholder: string) =>
+		val !== undefined && val !== null && val !== "" && val !== 0
+			? String(val)
+			: `[${placeholder}]`;
+
+	const nombre = variables.clienteNombre
+		? toCapitalCase(variables.clienteNombre)
+		: "";
+
 	return texto
-		.replace(/{clienteNombre}/g, variables.clienteNombre)
-		.replace(/{fechaPago}/g, variables.fechaPago)
-		.replace(/{cuotaMensual}/g, variables.cuotaMensual)
-		.replace(/{placa}/g, variables.placa)
-		.replace(/{marcaLineaModelo}/g, variables.marcaLineaModelo)
-		.replace(/{montoAdeudado}/g, variables.montoAdeudado)
-		.replace(/{cuotasAtraso}/g, String(variables.cuotasAtraso))
-		.replace(/{telefonoAsesor}/g, variables.telefonoAsesor)
-		.replace(/{nombreAsesor}/g, variables.nombreAsesor);
+		.replace(/{clienteNombre}/g, v(nombre, "nombre cliente"))
+		.replace(/{fechaPago}/g, v(variables.fechaPago, "fecha pago"))
+		.replace(/{cuotaMensual}/g, v(variables.cuotaMensual, "cuota mensual"))
+		.replace(/{placa}/g, v(variables.placa, "placa"))
+		.replace(
+			/{marcaLineaModelo}/g,
+			v(variables.marcaLineaModelo, "marca/modelo"),
+		)
+		.replace(/{montoAdeudado}/g, v(variables.montoAdeudado, "monto adeudado"))
+		.replace(
+			/{cuotasAtraso}/g,
+			v(variables.cuotasAtraso, "cuotas en atraso"),
+		)
+		.replace(
+			/{telefonoAsesor}/g,
+			v(variables.telefonoAsesor, "teléfono asesor"),
+		)
+		.replace(/{nombreAsesor}/g, v(variables.nombreAsesor, "nombre asesor"));
 }
 
 export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [

--- a/apps/crm/apps/web/src/lib/date-utils.ts
+++ b/apps/crm/apps/web/src/lib/date-utils.ts
@@ -1,0 +1,8 @@
+/**
+ * Parsea una fecha string "YYYY-MM-DD" como fecha local (sin UTC).
+ * Evita el desfase de timezone que ocurre con `new Date("2026-02-24")`.
+ */
+export function parseFechaLocal(fecha: string): Date {
+	const [year, month, day] = fecha.split("-").map(Number);
+	return new Date(year, month - 1, day);
+}

--- a/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
+++ b/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
@@ -82,9 +82,9 @@ function useUploadBoleta() {
 		onSuccess: () => {
 			queryClient.invalidateQueries({
 				queryKey: orpc.getResumenGlobalInversionistas.queryOptions().queryKey,
-			})
+			});
 		},
-	})
+	});
 
 	const upload = useCallback(
 		async (params: {
@@ -105,7 +105,7 @@ function useUploadBoleta() {
 					body: formData,
 					credentials: "include",
 				},
-			)
+			);
 
 			if (!uploadRes.ok) {
 				const err = await uploadRes.json();
@@ -122,10 +122,10 @@ function useUploadBoleta() {
 				boleta_url: url,
 				monto_boleta: params.monto_boleta,
 				notas: params.notas || undefined,
-			})
+			});
 		},
 		[createBoletaMutation],
-	)
+	);
 
 	return { upload, isPending: createBoletaMutation.isPending };
 }
@@ -150,7 +150,7 @@ function SubirBoletaDialog({
 	const handleSubmit = async () => {
 		if (!file) {
 			toast.error("Selecciona un archivo");
-			return
+			return;
 		}
 
 		setUploading(true);
@@ -160,7 +160,7 @@ function SubirBoletaDialog({
 				inversionista_id: inv.inversionista_id,
 				monto_boleta: inv.total_a_recibir_con_reinversion,
 				notas: notas.trim() || undefined,
-			})
+			});
 			toast.success("Boleta subida correctamente");
 			setFile(null);
 			setNotas("");
@@ -170,7 +170,7 @@ function SubirBoletaDialog({
 		} finally {
 			setUploading(false);
 		}
-	}
+	};
 
 	const handleClose = (value: boolean) => {
 		if (!uploading) {
@@ -178,7 +178,7 @@ function SubirBoletaDialog({
 			setNotas("");
 			onOpenChange(value);
 		}
-	}
+	};
 
 	return (
 		<Dialog open={open} onOpenChange={handleClose}>
@@ -254,7 +254,7 @@ function SubirBoletaDialog({
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>
-	)
+	);
 }
 
 // ─── Card del inversionista ───────────────────────────────────────────────────
@@ -264,7 +264,7 @@ function DetailItem({ label, value }: { label: string; value: string }) {
 		<span className="text-[10px] text-muted-foreground">
 			{label} <span className="font-medium text-foreground/70">{value}</span>
 		</span>
-	)
+	);
 }
 
 function InversionistaCard({ inv }: { inv: ResumenInversionista }) {
@@ -377,7 +377,7 @@ function InversionistaCard({ inv }: { inv: ResumenInversionista }) {
 				onOpenChange={setDialogOpen}
 			/>
 		</>
-	)
+	);
 }
 
 // ─── Página principal ─────────────────────────────────────────────────────────
@@ -387,7 +387,7 @@ function PagarInversionistas() {
 	const userProfile = useQuery({
 		...orpc.getUserProfile.queryOptions(),
 		enabled: !!session,
-	})
+	});
 	const userRole = userProfile.data?.role;
 
 	const [search, setSearch] = useState("");
@@ -397,7 +397,7 @@ function PagarInversionistas() {
 		...orpc.getResumenGlobalInversionistas.queryOptions(),
 		enabled:
 			!!session && !!userRole && PERMISSIONS.canAccessAccounting(userRole),
-	})
+	});
 
 	const inversionistas = (data ?? []) as ResumenInversionista[];
 
@@ -408,7 +408,7 @@ function PagarInversionistas() {
 			(inv) =>
 				inv.nombre.toLowerCase().includes(q) ||
 				String(inv.inversionista_id).includes(q),
-		)
+		);
 	}, [inversionistas, search]);
 
 	const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
@@ -416,12 +416,12 @@ function PagarInversionistas() {
 	const paginatedData = filtered.slice(
 		(safePage - 1) * PAGE_SIZE,
 		safePage * PAGE_SIZE,
-	)
+	);
 
 	const handleSearch = (value: string) => {
 		setSearch(value);
 		setPage(1);
-	}
+	};
 
 	if (!userRole || !PERMISSIONS.canAccessAccounting(userRole)) {
 		return (
@@ -433,7 +433,7 @@ function PagarInversionistas() {
 					</p>
 				</div>
 			</div>
-		)
+		);
 	}
 
 	if (isLoading) {
@@ -441,7 +441,7 @@ function PagarInversionistas() {
 			<div className="flex min-h-screen items-center justify-center">
 				<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
 			</div>
-		)
+		);
 	}
 
 	if (error) {
@@ -454,14 +454,14 @@ function PagarInversionistas() {
 					</p>
 				</div>
 			</div>
-		)
+		);
 	}
 
 	const totalARecibir = inversionistas.reduce(
 		(acc, inv) =>
 			acc + Number.parseFloat(inv.total_a_recibir_con_reinversion || "0"),
 		0,
-	)
+	);
 	const conBoleta = inversionistas.filter(
 		(inv) => inv.boleta_pendiente != null,
 	).length;
@@ -507,7 +507,7 @@ function PagarInversionistas() {
 			{/* Buscador + paginación */}
 			<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
 				<div className="relative max-w-xs flex-1">
-					<Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+					<Search className="-translate-y-1/2 absolute top-1/2 left-3 h-4 w-4 text-muted-foreground" />
 					<Input
 						placeholder="Buscar por nombre o ID..."
 						value={search}
@@ -550,7 +550,7 @@ function PagarInversionistas() {
 				</div>
 			)}
 		</div>
-	)
+	);
 }
 
 // ─── Componentes auxiliares ───────────────────────────────────────────────────
@@ -582,7 +582,7 @@ function StatCard({
 				</div>
 			</CardContent>
 		</Card>
-	)
+	);
 }
 
 function PaginationControls({
@@ -623,5 +623,5 @@ function PaginationControls({
 				<ChevronRight className="h-4 w-4" />
 			</Button>
 		</div>
-	)
+	);
 }

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -23,8 +23,8 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
-import { ContactoModal } from "@/components/contacto-modal";
 import { ReferenciasView } from "@/components/cobros/ReferenciasView";
+import { ContactoModal } from "@/components/contacto-modal";
 import {
 	OpportunityDetailModal,
 	type OpportunityForModal,
@@ -38,9 +38,9 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Popover,
 	PopoverContent,
@@ -530,17 +530,26 @@ function RouteComponent() {
 										<Banknote className="h-4 w-4 text-muted-foreground" />
 										<span className="font-medium">Cuota Mensual:</span>
 									</div>
-									<p className="font-bold text-lg text-blue-600 uppercase tracking-tight">
+									<p className="font-bold text-blue-600 text-lg uppercase tracking-tight">
 										Q{Number(caso.cuotaMensual || 0).toLocaleString()}
 									</p>
 								</div>
 								<div className="space-y-2">
 									<div className="flex items-center gap-2 text-sm">
 										<Banknote className="h-4 w-4 text-muted-foreground" />
-										<span className="font-medium">Total a Pagar <span className="text-xs text-muted-foreground">(Mora + Cuota)</span>:</span>
+										<span className="font-medium">
+											Total a Pagar{" "}
+											<span className="text-muted-foreground text-xs">
+												(Mora + Cuota)
+											</span>
+											:
+										</span>
 									</div>
 									<p className="font-bold text-lg text-orange-600">
-										Q{(Number(caso.montoEnMora) + Number(caso.cuotaMensual || 0)).toLocaleString()}
+										Q
+										{(
+											Number(caso.montoEnMora) + Number(caso.cuotaMensual || 0)
+										).toLocaleString()}
 									</p>
 								</div>
 							</div>
@@ -562,7 +571,9 @@ function RouteComponent() {
 											</PopoverTrigger>
 											<PopoverContent className="w-64">
 												<div className="space-y-2">
-													<h4 className="font-medium text-sm">Gestionar Etiquetas</h4>
+													<h4 className="font-medium text-sm">
+														Gestionar Etiquetas
+													</h4>
 													{ETIQUETAS_COBROS.map((etiqueta) => (
 														<div
 															key={etiqueta}
@@ -570,12 +581,17 @@ function RouteComponent() {
 														>
 															<Checkbox
 																id={`etiqueta-${etiqueta}`}
-																checked={(caso.etiquetas || []).includes(etiqueta)}
+																checked={(caso.etiquetas || []).includes(
+																	etiqueta,
+																)}
 																onCheckedChange={(checked) => {
-																	const currentEtiquetas = (caso.etiquetas || []) as (typeof ETIQUETAS_COBROS)[number][];
+																	const currentEtiquetas = (caso.etiquetas ||
+																		[]) as (typeof ETIQUETAS_COBROS)[number][];
 																	const newEtiquetas = checked
 																		? [...currentEtiquetas, etiqueta]
-																		: currentEtiquetas.filter((e) => e !== etiqueta);
+																		: currentEtiquetas.filter(
+																				(e) => e !== etiqueta,
+																			);
 																	updateEtiquetasMutation.mutate({
 																		casoCobroId: caso.id!,
 																		etiquetas: newEtiquetas,
@@ -599,7 +615,10 @@ function RouteComponent() {
 											(caso.etiquetas || []).map((etiqueta: string) => (
 												<Badge
 													key={etiqueta}
-													className={ETIQUETA_COLORS[etiqueta] || "bg-gray-100 text-gray-800"}
+													className={
+														ETIQUETA_COLORS[etiqueta] ||
+														"bg-gray-100 text-gray-800"
+													}
 												>
 													{ETIQUETA_LABELS[etiqueta] || etiqueta}
 												</Badge>
@@ -637,7 +656,11 @@ function RouteComponent() {
 											</div>
 										</div>
 										<p className="font-extrabold text-2xl text-orange-700">
-											Q{(Number(caso.montoEnMora) + Number(caso.cuotaMensual || 0)).toLocaleString()}
+											Q
+											{(
+												Number(caso.montoEnMora) +
+												Number(caso.cuotaMensual || 0)
+											).toLocaleString()}
 										</p>
 									</div>
 								</div>
@@ -688,7 +711,9 @@ function RouteComponent() {
 										/>
 									</div>
 									<div>
-										<Label htmlFor="contact-phone-alt">Teléfono Alternativo</Label>
+										<Label htmlFor="contact-phone-alt">
+											Teléfono Alternativo
+										</Label>
 										<Input
 											id="contact-phone-alt"
 											value={contactForm.telefonoAlternativo}
@@ -720,10 +745,16 @@ function RouteComponent() {
 										<Button
 											size="sm"
 											onClick={() => {
-												if (!window.confirm("¿Estás seguro de actualizar la información de contacto?")) return;
+												if (
+													!window.confirm(
+														"¿Estás seguro de actualizar la información de contacto?",
+													)
+												)
+													return;
 												updateContactMutation.mutate({
 													telefonoPrincipal: contactForm.telefonoPrincipal,
-													telefonoAlternativo: contactForm.telefonoAlternativo || undefined,
+													telefonoAlternativo:
+														contactForm.telefonoAlternativo || undefined,
 													emailContacto: contactForm.emailContacto || undefined,
 												});
 											}}
@@ -747,38 +778,53 @@ function RouteComponent() {
 									</div>
 								</div>
 							) : (
-							<div className="grid grid-cols-2 gap-4">
-								<div>
-									<p className="text-muted-foreground text-sm">
-										Teléfono Principal
-									</p>
-									{caso.telefonoPrincipal ? (
-										<a href={`tel:${caso.telefonoPrincipal.replace(/[^0-9+]/g, "")}`} className="font-medium text-primary hover:underline">{caso.telefonoPrincipal}</a>
-									) : (
-										<p className="font-medium">-</p>
-									)}
-								</div>
-								{caso.telefonoAlternativo && (
+								<div className="grid grid-cols-2 gap-4">
 									<div>
 										<p className="text-muted-foreground text-sm">
-											Teléfono Alternativo
+											Teléfono Principal
 										</p>
-										<a href={`tel:${String(caso.telefonoAlternativo).replace(/[^0-9+]/g, "")}`} className="font-medium text-primary hover:underline">{caso.telefonoAlternativo}</a>
+										{caso.telefonoPrincipal ? (
+											<a
+												href={`tel:${caso.telefonoPrincipal.replace(/[^0-9+]/g, "")}`}
+												className="font-medium text-primary hover:underline"
+											>
+												{caso.telefonoPrincipal}
+											</a>
+										) : (
+											<p className="font-medium">-</p>
+										)}
 									</div>
-								)}
-								<div>
-									<p className="text-muted-foreground text-sm">Email</p>
-									{caso.emailContacto ? (
-										<a href={`mailto:${caso.emailContacto}`} className="font-medium text-primary hover:underline">{caso.emailContacto}</a>
-									) : (
-										<p className="font-medium">-</p>
+									{caso.telefonoAlternativo && (
+										<div>
+											<p className="text-muted-foreground text-sm">
+												Teléfono Alternativo
+											</p>
+											<a
+												href={`tel:${String(caso.telefonoAlternativo).replace(/[^0-9+]/g, "")}`}
+												className="font-medium text-primary hover:underline"
+											>
+												{caso.telefonoAlternativo}
+											</a>
+										</div>
 									)}
+									<div>
+										<p className="text-muted-foreground text-sm">Email</p>
+										{caso.emailContacto ? (
+											<a
+												href={`mailto:${caso.emailContacto}`}
+												className="font-medium text-primary hover:underline"
+											>
+												{caso.emailContacto}
+											</a>
+										) : (
+											<p className="font-medium">-</p>
+										)}
+									</div>
+									<div>
+										<p className="text-muted-foreground text-sm">Dirección</p>
+										<p className="font-medium">{caso.direccionContacto}</p>
+									</div>
 								</div>
-								<div>
-									<p className="text-muted-foreground text-sm">Dirección</p>
-									<p className="font-medium">{caso.direccionContacto}</p>
-								</div>
-							</div>
 							)}
 							{/* Botones de Contacto - Solo si existe caso de cobros */}
 							{caso.id ? (

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -20,6 +20,7 @@ import {
 	Tag,
 	User,
 	Users,
+	X,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
@@ -178,8 +179,8 @@ function RouteComponent() {
 	// Estado de edición de contacto
 	const [isEditingContact, setIsEditingContact] = useState(false);
 	const [contactForm, setContactForm] = useState({
-		telefonoPrincipal: "",
-		telefonoAlternativo: "",
+		telefonoPrincipal: [] as string[],
+		telefonoAlternativo: [] as string[],
 		emailContacto: "",
 	});
 
@@ -680,9 +681,14 @@ function RouteComponent() {
 									variant="outline"
 									size="sm"
 									onClick={() => {
+										const parseTels = (val: string | number | null | undefined) =>
+											String(val || "")
+												.split(",")
+												.map((t) => t.trim())
+												.filter(Boolean);
 										setContactForm({
-											telefonoPrincipal: caso.telefonoPrincipal || "",
-											telefonoAlternativo: caso.telefonoAlternativo || "",
+											telefonoPrincipal: parseTels(caso.telefonoPrincipal),
+											telefonoAlternativo: parseTels(caso.telefonoAlternativo),
 											emailContacto: caso.emailContacto || "",
 										});
 										setIsEditingContact(true);
@@ -696,37 +702,99 @@ function RouteComponent() {
 						<CardContent className="space-y-4">
 							{isEditingContact ? (
 								<div className="space-y-3">
-									<div>
-										<Label htmlFor="contact-phone">Teléfono Principal *</Label>
+									<div className="space-y-1">
+										<Label>Teléfono Principal *</Label>
+										<div className="flex flex-wrap gap-1.5">
+											{contactForm.telefonoPrincipal.map((tel, i) => (
+												<Badge
+													key={`principal-${tel}-${i}`}
+													variant="secondary"
+													className="gap-1 pl-2 pr-1"
+												>
+													{tel}
+													<button
+														type="button"
+														onClick={() =>
+															setContactForm((f) => ({
+																...f,
+																telefonoPrincipal: f.telefonoPrincipal.filter(
+																	(_, idx) => idx !== i,
+																),
+															}))
+														}
+														className="rounded-full hover:bg-muted"
+													>
+														<X className="h-3 w-3" />
+													</button>
+												</Badge>
+											))}
+										</div>
 										<Input
-											id="contact-phone"
-											value={contactForm.telefonoPrincipal}
-											onChange={(e) =>
-												setContactForm((f) => ({
-													...f,
-													telefonoPrincipal: e.target.value,
-												}))
-											}
-											placeholder="Ej: 5555-5555"
+											placeholder="Agregar teléfono y presionar Enter"
+											onKeyDown={(e) => {
+												if (e.key === "Enter") {
+													e.preventDefault();
+													const val = e.currentTarget.value.trim();
+													if (val) {
+														setContactForm((f) => ({
+															...f,
+															telefonoPrincipal: [...f.telefonoPrincipal, val],
+														}));
+														e.currentTarget.value = "";
+													}
+												}
+											}}
 										/>
 									</div>
-									<div>
-										<Label htmlFor="contact-phone-alt">
-											Teléfono Alternativo
-										</Label>
+									<div className="space-y-1">
+										<Label>Teléfono Alternativo</Label>
+										<div className="flex flex-wrap gap-1.5">
+											{contactForm.telefonoAlternativo.map((tel, i) => (
+												<Badge
+													key={`alt-${tel}-${i}`}
+													variant="secondary"
+													className="gap-1 pl-2 pr-1"
+												>
+													{tel}
+													<button
+														type="button"
+														onClick={() =>
+															setContactForm((f) => ({
+																...f,
+																telefonoAlternativo:
+																	f.telefonoAlternativo.filter(
+																		(_, idx) => idx !== i,
+																	),
+															}))
+														}
+														className="rounded-full hover:bg-muted"
+													>
+														<X className="h-3 w-3" />
+													</button>
+												</Badge>
+											))}
+										</div>
 										<Input
-											id="contact-phone-alt"
-											value={contactForm.telefonoAlternativo}
-											onChange={(e) =>
-												setContactForm((f) => ({
-													...f,
-													telefonoAlternativo: e.target.value,
-												}))
-											}
-											placeholder="Ej: 4444-4444"
+											placeholder="Agregar teléfono y presionar Enter"
+											onKeyDown={(e) => {
+												if (e.key === "Enter") {
+													e.preventDefault();
+													const val = e.currentTarget.value.trim();
+													if (val) {
+														setContactForm((f) => ({
+															...f,
+															telefonoAlternativo: [
+																...f.telefonoAlternativo,
+																val,
+															],
+														}));
+														e.currentTarget.value = "";
+													}
+												}
+											}}
 										/>
 									</div>
-									<div>
+									<div className="space-y-1">
 										<Label htmlFor="contact-email">Email</Label>
 										<Input
 											id="contact-email"
@@ -752,15 +820,17 @@ function RouteComponent() {
 												)
 													return;
 												updateContactMutation.mutate({
-													telefonoPrincipal: contactForm.telefonoPrincipal,
+													telefonoPrincipal: contactForm.telefonoPrincipal.join(", "),
 													telefonoAlternativo:
-														contactForm.telefonoAlternativo || undefined,
+														contactForm.telefonoAlternativo.length > 0
+															? contactForm.telefonoAlternativo.join(", ")
+															: undefined,
 													emailContacto: contactForm.emailContacto || undefined,
 												});
 											}}
 											disabled={
 												updateContactMutation.isPending ||
-												!contactForm.telefonoPrincipal
+												contactForm.telefonoPrincipal.length === 0
 											}
 										>
 											{updateContactMutation.isPending
@@ -784,12 +854,21 @@ function RouteComponent() {
 											Teléfono Principal
 										</p>
 										{caso.telefonoPrincipal ? (
-											<a
-												href={`tel:${caso.telefonoPrincipal.replace(/[^0-9+]/g, "")}`}
-												className="font-medium text-primary hover:underline"
-											>
-												{caso.telefonoPrincipal}
-											</a>
+											<div className="flex flex-wrap gap-1.5">
+												{String(caso.telefonoPrincipal)
+													.split(",")
+													.map((t) => t.trim())
+													.filter(Boolean)
+													.map((tel) => (
+														<a
+															key={tel}
+															href={`tel:${tel.replace(/[^0-9+]/g, "")}`}
+															className="inline-flex items-center rounded-md border px-2 py-0.5 font-medium text-primary text-sm hover:underline"
+														>
+															{tel}
+														</a>
+													))}
+											</div>
 										) : (
 											<p className="font-medium">-</p>
 										)}
@@ -799,12 +878,21 @@ function RouteComponent() {
 											<p className="text-muted-foreground text-sm">
 												Teléfono Alternativo
 											</p>
-											<a
-												href={`tel:${String(caso.telefonoAlternativo).replace(/[^0-9+]/g, "")}`}
-												className="font-medium text-primary hover:underline"
-											>
-												{caso.telefonoAlternativo}
-											</a>
+											<div className="flex flex-wrap gap-1.5">
+												{String(caso.telefonoAlternativo)
+													.split(",")
+													.map((t) => t.trim())
+													.filter(Boolean)
+													.map((tel) => (
+														<a
+															key={tel}
+															href={`tel:${tel.replace(/[^0-9+]/g, "")}`}
+															className="inline-flex items-center rounded-md border px-2 py-0.5 font-medium text-primary text-sm hover:underline"
+														>
+															{tel}
+														</a>
+													))}
+											</div>
 										</div>
 									)}
 									<div>
@@ -835,8 +923,18 @@ function RouteComponent() {
 											casoCobroId={caso.id}
 											clienteNombre={caso.clienteNombre || ""}
 											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											telefonoAlternativo={caso.telefonoAlternativo ? String(caso.telefonoAlternativo) : undefined}
 											emailCliente={caso.emailContacto || ""}
 											metodoInicial="llamada"
+											fechaPago={String(caso.diaPagoMensual || 15)}
+											cuotaMensual={Number(caso.cuotaMensual || 0).toLocaleString()}
+											placa={caso.vehiculoPlaca || ""}
+											marcaLineaModelo={`${caso.vehiculoMarca || ""} ${caso.vehiculoModelo || ""} ${caso.vehiculoYear || ""}`.trim()}
+											montoAdeudado={Number(caso.montoEnMora || 0).toLocaleString()}
+											cuotasAtraso={caso.cuotasVencidas ?? 0}
+											estadoMora={caso.estadoMora || undefined}
+											nombreAsesor={session?.user?.name || ""}
+											telefonoAsesor=""
 										>
 											<Button className="flex items-center gap-2">
 												<Phone className="h-4 w-4" />
@@ -848,8 +946,18 @@ function RouteComponent() {
 											casoCobroId={caso.id}
 											clienteNombre={caso.clienteNombre || ""}
 											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											telefonoAlternativo={caso.telefonoAlternativo ? String(caso.telefonoAlternativo) : undefined}
 											emailCliente={caso.emailContacto || ""}
 											metodoInicial="whatsapp"
+											fechaPago={String(caso.diaPagoMensual || 15)}
+											cuotaMensual={Number(caso.cuotaMensual || 0).toLocaleString()}
+											placa={caso.vehiculoPlaca || ""}
+											marcaLineaModelo={`${caso.vehiculoMarca || ""} ${caso.vehiculoModelo || ""} ${caso.vehiculoYear || ""}`.trim()}
+											montoAdeudado={Number(caso.montoEnMora || 0).toLocaleString()}
+											cuotasAtraso={caso.cuotasVencidas ?? 0}
+											estadoMora={caso.estadoMora || undefined}
+											nombreAsesor={session?.user?.name || ""}
+											telefonoAsesor=""
 										>
 											<Button
 												variant="outline"
@@ -864,8 +972,18 @@ function RouteComponent() {
 											casoCobroId={caso.id}
 											clienteNombre={caso.clienteNombre || ""}
 											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											telefonoAlternativo={caso.telefonoAlternativo ? String(caso.telefonoAlternativo) : undefined}
 											emailCliente={caso.emailContacto || ""}
 											metodoInicial="email"
+											fechaPago={String(caso.diaPagoMensual || 15)}
+											cuotaMensual={Number(caso.cuotaMensual || 0).toLocaleString()}
+											placa={caso.vehiculoPlaca || ""}
+											marcaLineaModelo={`${caso.vehiculoMarca || ""} ${caso.vehiculoModelo || ""} ${caso.vehiculoYear || ""}`.trim()}
+											montoAdeudado={Number(caso.montoEnMora || 0).toLocaleString()}
+											cuotasAtraso={caso.cuotasVencidas ?? 0}
+											estadoMora={caso.estadoMora || undefined}
+											nombreAsesor={session?.user?.name || ""}
+											telefonoAsesor=""
 										>
 											<Button
 												variant="outline"

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -933,6 +933,7 @@ function RouteComponent() {
 											montoAdeudado={Number(caso.montoEnMora || 0).toLocaleString()}
 											cuotasAtraso={caso.cuotasVencidas ?? 0}
 											estadoMora={caso.estadoMora || undefined}
+											fechaInicio={caso.fechaInicio || null}
 											nombreAsesor={session?.user?.name || ""}
 											telefonoAsesor=""
 										>
@@ -956,6 +957,7 @@ function RouteComponent() {
 											montoAdeudado={Number(caso.montoEnMora || 0).toLocaleString()}
 											cuotasAtraso={caso.cuotasVencidas ?? 0}
 											estadoMora={caso.estadoMora || undefined}
+											fechaInicio={caso.fechaInicio || null}
 											nombreAsesor={session?.user?.name || ""}
 											telefonoAsesor=""
 										>
@@ -982,6 +984,7 @@ function RouteComponent() {
 											montoAdeudado={Number(caso.montoEnMora || 0).toLocaleString()}
 											cuotasAtraso={caso.cuotasVencidas ?? 0}
 											estadoMora={caso.estadoMora || undefined}
+											fechaInicio={caso.fechaInicio || null}
 											nombreAsesor={session?.user?.name || ""}
 											telefonoAsesor=""
 										>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -329,15 +329,17 @@ function RouteComponent() {
 			const en7Dias = new Date(hoy);
 			en7Dias.setDate(en7Dias.getDate() + 7);
 
-			return data.filter((caso) => {
-				if (!caso.proximoContacto) return false;
-				const fecha = new Date(caso.proximoContacto);
-				return fecha <= en7Dias;
-			}).sort((a, b) => {
-				const fechaA = new Date(a.proximoContacto!);
-				const fechaB = new Date(b.proximoContacto!);
-				return fechaA.getTime() - fechaB.getTime();
-			});
+			return data
+				.filter((caso) => {
+					if (!caso.proximoContacto) return false;
+					const fecha = new Date(caso.proximoContacto);
+					return fecha <= en7Dias;
+				})
+				.sort((a, b) => {
+					const fechaA = new Date(a.proximoContacto!);
+					const fechaB = new Date(b.proximoContacto!);
+					return fechaA.getTime() - fechaB.getTime();
+				});
 		},
 	});
 
@@ -482,7 +484,12 @@ function RouteComponent() {
 			// Incluir casos en mora (días negativos) y casos próximos a vencer
 			return c?.diasHastaPago !== null && c?.diasHastaPago <= limite;
 		});
-	}, [creditosConDias, filtroTemporal, mostrarCompletadosIncobrables, filtroEtiqueta]);
+	}, [
+		creditosConDias,
+		filtroTemporal,
+		mostrarCompletadosIncobrables,
+		filtroEtiqueta,
+	]);
 
 	// Check permissions after all hooks
 	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {
@@ -816,7 +823,7 @@ function RouteComponent() {
 										</div>
 										<div className="text-right">
 											<p
-												className={`text-sm font-medium ${esPasado ? "text-red-600" : esHoy ? "text-amber-600" : "text-muted-foreground"}`}
+												className={`font-medium text-sm ${esPasado ? "text-red-600" : esHoy ? "text-amber-600" : "text-muted-foreground"}`}
 											>
 												{esHoy
 													? "Hoy"
@@ -866,7 +873,9 @@ function RouteComponent() {
 										"mora_90",
 										"mora_120",
 									];
-									return orden.indexOf(a.categoria) - orden.indexOf(b.categoria);
+									return (
+										orden.indexOf(a.categoria) - orden.indexOf(b.categoria)
+									);
 								})
 								.map((meta) => {
 									const label: Record<string, string> = {
@@ -929,7 +938,7 @@ function RouteComponent() {
 											key={meta.id}
 											className={`rounded-lg border p-3 ${color[meta.categoria] || ""}`}
 										>
-											<p className="font-medium text-xs text-muted-foreground">
+											<p className="font-medium text-muted-foreground text-xs">
 												{label[meta.categoria] || meta.categoria}
 											</p>
 											<p
@@ -939,10 +948,9 @@ function RouteComponent() {
 											</p>
 											{actual !== undefined && (
 												<p
-													className={`text-xs font-medium ${cumplida ? "text-green-600" : "text-red-600"}`}
+													className={`font-medium text-xs ${cumplida ? "text-green-600" : "text-red-600"}`}
 												>
-													Real: {actual.toFixed(2)}%{" "}
-													{cumplida ? "✓" : "↑"}
+													Real: {actual.toFixed(2)}% {cumplida ? "✓" : "↑"}
 												</p>
 											)}
 										</div>
@@ -1055,9 +1063,7 @@ function RouteComponent() {
 										key={key}
 										className={`cursor-pointer ${filtroEtiqueta === key ? "bg-primary text-primary-foreground" : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
 										onClick={() => {
-											setFiltroEtiqueta(
-												filtroEtiqueta === key ? null : key,
-											);
+											setFiltroEtiqueta(filtroEtiqueta === key ? null : key);
 											setPage(1);
 										}}
 									>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -33,6 +33,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
 import { type ContratoCobranza, columns } from "@/lib/cobros/columns";
+import { parseFechaLocal } from "@/lib/date-utils";
 import { PERMISSIONS, ROLES } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
@@ -42,7 +43,7 @@ function calcularDiasHastaPago(fechaProximoPago: string | null) {
 
 	const ahora = new Date();
 	const hoy = new Date(ahora.getFullYear(), ahora.getMonth(), ahora.getDate());
-	const fechaPago = new Date(fechaProximoPago);
+	const fechaPago = parseFechaLocal(fechaProximoPago);
 
 	const diasRestantes = differenceInDays(fechaPago, hoy);
 
@@ -285,7 +286,7 @@ function RouteComponent() {
 	const [mostrarCompletadosIncobrables, setMostrarCompletadosIncobrables] =
 		useState(false);
 	const [filtroEtapa, setFiltroEtapa] = useState<string | null>(null);
-	const [filtroEtiqueta, setFiltroEtiqueta] = useState<string | null>(null);
+	const [filtroEtiquetas, setFiltroEtiquetas] = useState<string[]>([]);
 	const [page, setPage] = useState(1);
 	const [filterValue, setFilterValue] = useState("");
 	const [debouncedFilterValue, setDebouncedFilterValue] = useState("");
@@ -460,10 +461,12 @@ function RouteComponent() {
 			);
 		}
 
-		// Filtrar por etiqueta
-		if (filtroEtiqueta) {
+		// Filtrar por etiquetas (AND: el caso debe tener todas las seleccionadas)
+		if (filtroEtiquetas.length > 0) {
 			filtrados = filtrados.filter(
-				(c) => c.etiquetas && c.etiquetas.includes(filtroEtiqueta),
+				(c) =>
+					c.etiquetas &&
+					filtroEtiquetas.every((et) => c.etiquetas!.includes(et)),
 			);
 		}
 
@@ -488,7 +491,7 @@ function RouteComponent() {
 		creditosConDias,
 		filtroTemporal,
 		mostrarCompletadosIncobrables,
-		filtroEtiqueta,
+		filtroEtiquetas,
 	]);
 
 	// Check permissions after all hooks
@@ -942,17 +945,25 @@ function RouteComponent() {
 												{label[meta.categoria] || meta.categoria}
 											</p>
 											<p
-												className={`font-bold text-xl ${textColor[meta.categoria] || ""}`}
+												className={`font-bold text-2xl ${actual !== undefined ? (cumplida ? "text-green-600" : "text-red-600") : (textColor[meta.categoria] || "")}`}
 											>
-												{objetivo.toFixed(2)}%
+												{actual !== undefined
+													? `${actual.toFixed(2)}%`
+													: "—"}
 											</p>
-											{actual !== undefined && (
-												<p
-													className={`font-medium text-xs ${cumplida ? "text-green-600" : "text-red-600"}`}
-												>
-													Real: {actual.toFixed(2)}% {cumplida ? "✓" : "↑"}
-												</p>
-											)}
+											<p className="text-muted-foreground text-xs">
+												Meta: {objetivo.toFixed(2)}%
+												{actual !== undefined &&
+													(cumplida ? (
+														<span className="ml-1 font-semibold text-green-600">
+															✓
+														</span>
+													) : (
+														<span className="ml-1 font-semibold text-red-600">
+															↑ {(actual - objetivo).toFixed(2)}%
+														</span>
+													))}
+											</p>
 										</div>
 									);
 								})}
@@ -1016,61 +1027,70 @@ function RouteComponent() {
 							});
 						}}
 						filterContent={
-							<>
-								<span className="font-medium text-muted-foreground text-sm">
-									Filtrar por etapa:
-								</span>
-								<Button
-									variant={filtroEtapa === null ? "default" : "outline"}
-									size="sm"
-									onClick={() => {
-										setFiltroEtapa(null);
-										setPage(1);
-									}}
-								>
-									Todas
-								</Button>
-								{filtrosEtapa.map((filtro) => (
-									<Badge
-										key={filtro.key}
-										className={`cursor-pointer ${filtroEtapa === filtro.key ? filtro.color : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+							<div className="flex flex-col gap-3 w-full">
+								<div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
+									<span className="font-semibold text-foreground text-sm">
+										Filtrar por etapa:
+									</span>
+									<Button
+										variant={filtroEtapa === null ? "default" : "outline"}
+										size="sm"
 										onClick={() => {
-											setFiltroEtapa(
-												filtroEtapa === filtro.key ? null : filtro.key,
-											);
+											setFiltroEtapa(null);
 											setPage(1);
 										}}
 									>
-										{filtro.label}
-									</Badge>
-								))}
-								<Separator orientation="vertical" className="mx-2 h-6" />
-								<span className="font-medium text-muted-foreground text-sm">
-									Etiqueta:
-								</span>
-								<Button
-									variant={filtroEtiqueta === null ? "default" : "outline"}
-									size="sm"
-									onClick={() => {
-										setFiltroEtiqueta(null);
-										setPage(1);
-									}}
-								>
-									Todas
-								</Button>
-								{Object.entries(ETIQUETA_LABELS_FILTRO).map(([key, label]) => (
-									<Badge
-										key={key}
-										className={`cursor-pointer ${filtroEtiqueta === key ? "bg-primary text-primary-foreground" : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+										Todas
+									</Button>
+									{filtrosEtapa.map((filtro) => (
+										<Badge
+											key={filtro.key}
+											className={`cursor-pointer ${filtroEtapa === filtro.key ? filtro.color : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+											onClick={() => {
+												setFiltroEtapa(
+													filtroEtapa === filtro.key ? null : filtro.key,
+												);
+												setPage(1);
+											}}
+										>
+											{filtro.label}
+										</Badge>
+									))}
+								</div>
+								<div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
+									<span className="font-semibold text-foreground text-sm">
+										Etiquetas:
+									</span>
+									<Button
+										variant={filtroEtiquetas.length === 0 ? "default" : "outline"}
+										size="sm"
 										onClick={() => {
-											setFiltroEtiqueta(filtroEtiqueta === key ? null : key);
+											setFiltroEtiquetas([]);
 											setPage(1);
 										}}
 									>
-										{label}
-									</Badge>
-								))}
-							</>
+										Todas
+									</Button>
+									{Object.entries(ETIQUETA_LABELS_FILTRO).map(
+										([key, label]) => (
+											<Badge
+												key={key}
+												className={`cursor-pointer ${filtroEtiquetas.includes(key) ? "bg-primary text-primary-foreground" : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+												onClick={() => {
+													setFiltroEtiquetas((prev) =>
+														prev.includes(key)
+															? prev.filter((e) => e !== key)
+															: [...prev, key],
+													);
+													setPage(1);
+												}}
+											>
+												{label}
+											</Badge>
+										),
+									)}
+								</div>
+							</div>
 						}
 						serverPagination={{
 							page: page,

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -282,7 +282,7 @@ const ETIQUETA_LABELS_FILTRO: Record<string, string> = {
 function RouteComponent() {
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
-	const [filtroTemporal, setFiltroTemporal] = useState<FiltroTemporal>("todos");
+	const [filtroTemporal, setFiltroTemporal] = useState<FiltroTemporal>("hoy");
 	const [mostrarCompletadosIncobrables, setMostrarCompletadosIncobrables] =
 		useState(false);
 	const [filtroEtapa, setFiltroEtapa] = useState<string | null>(null);

--- a/apps/crm/apps/web/src/routes/cobros/metas.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/metas.tsx
@@ -98,16 +98,15 @@ function MetasMoraPage() {
 			const promises = [];
 			for (let mes = 1; mes <= 12; mes++) {
 				const metas = CATEGORIAS.filter(
-					(cat) => editValues[mes]?.[cat] !== undefined && editValues[mes][cat] !== "",
+					(cat) =>
+						editValues[mes]?.[cat] !== undefined && editValues[mes][cat] !== "",
 				).map((cat) => ({
 					categoria: cat,
 					valorObjetivo: editValues[mes][cat],
 				}));
 
 				if (metas.length > 0) {
-					promises.push(
-						client.upsertMetasMora({ mes, anio, metas }),
-					);
+					promises.push(client.upsertMetasMora({ mes, anio, metas }));
 				}
 			}
 			return Promise.all(promises);

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -633,7 +633,10 @@ function NotificationCard({
 		if (!config) return null;
 
 		// Algunas notificaciones (como pay_investors) no necesitan relatedEntityId
-		if (!notification.relatedEntityId && notification.redirectPage !== "pay_investors")
+		if (
+			!notification.relatedEntityId &&
+			notification.redirectPage !== "pay_investors"
+		)
 			return null;
 
 		const route = config.getRoute(notification.relatedEntityId ?? "");


### PR DESCRIPTION
## Summary
- Plantillas de mensaje predefinidas por etapa (bienvenida, recordatorio, pre-mora, mora 30/60, aviso jurídico) para WhatsApp y Email con interpolación de variables
- Pre-selección inteligente de plantilla según estado de mora y antigüedad del caso
- Mejora UX de teléfonos: parsing de números separados por coma, chips individuales clickeables, selector de número al contactar
- Checkbox de seguimiento con componente shadcn/ui consistente
- Filtro temporal de tabla de cobros por defecto en "hoy"
- Capital Case en nombre de cliente y placeholders `[sin dato]` para variables faltantes

## Test plan
- [ ] Abrir detalle de caso → WhatsApp → verificar plantilla pre-seleccionada según etapa
- [ ] Verificar que `wa.me` abre con texto pre-llenado
- [ ] Abrir Email → verificar `mailto:` con subject y body
- [ ] Editar mensaje en textarea antes de enviar
- [ ] Caso con múltiples teléfonos → verificar selector de número
- [ ] Caso con variables faltantes → verificar placeholders `[sin dato]`
- [ ] Editar teléfonos como chips (agregar con Enter, quitar con X)
- [ ] Tabla de cobros carga filtrada por "hoy" al entrar

🤖 Generated with [Claude Code](https://claude.com/claude-code)