### PR TITLE
fix: Excluir membresía del seguro en créditos internos

### DIFF
--- a/apps/backend-2/src/controllers/docuseal.ts
+++ b/apps/backend-2/src/controllers/docuseal.ts
@@ -1,4 +1,4 @@
-import { asc, desc, inArray, sql } from "drizzle-orm";
+import { asc, inArray, sql } from "drizzle-orm";
 import { detail_document_field, docusealDocuments, field } from "../database/schemas/docuseal";
 import { db } from "../database";
 import { and, eq } from "drizzle-orm";

--- a/apps/backend-2/src/database/schemas/docuseal.ts
+++ b/apps/backend-2/src/database/schemas/docuseal.ts
@@ -1,4 +1,4 @@
-import { pgSchema, pgEnum, pgTable, varchar, text, uniqueIndex, serial, boolean, integer, primaryKey } from "drizzle-orm/pg-core";
+import { pgSchema, varchar, text, uniqueIndex, serial, boolean, integer, primaryKey } from "drizzle-orm/pg-core";
 
 // 🧱 Schema principal
 export const docusealSchema = pgSchema("docuseal");

--- a/apps/backend-2/src/lib/twenty-graphql.ts
+++ b/apps/backend-2/src/lib/twenty-graphql.ts
@@ -31,7 +31,7 @@ export async function uploadFileToTwenty(
   form.append("map", JSON.stringify({ "1": ["variables.file"] }));
 
   // Actual file content
-  form.append("1", new Blob([fileBuffer]), fileName);
+  form.append("1", new Blob([new Uint8Array(fileBuffer)]), fileName);
 
   const response = await fetch("https://crm.devteamatcci.site/graphql", {
     method: "POST",

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -948,16 +948,24 @@ function QuoterPage() {
 				Math.round(result.baseInsuranceCost * 100) / 100;
 			const rawMembershipCost = Math.round(result.membershipCost * 100) / 100;
 
-			// El seguro total para cálculos es: base + (membresía - GPS)
-			const netMembershipCost =
-				Math.round((rawMembershipCost - GPS_COST) * 100) / 100;
-			const insuranceCost =
-				Math.round((baseInsuranceCost + netMembershipCost) * 100) / 100;
+			if (isInterno) {
+				// Crédito interno: solo seguro base, sin membresía ni GPS
+				quoterForm.setFieldValue("insuranceCost", baseInsuranceCost);
+				quoterForm.setFieldValue("membershipCost", 0);
+				quoterForm.setFieldValue("extraInsuranceCost", baseInsuranceCost);
+				quoterForm.setFieldValue("extraMembershipCost", 0);
+			} else {
+				// El seguro total para cálculos es: base + (membresía - GPS)
+				const netMembershipCost =
+					Math.round((rawMembershipCost - GPS_COST) * 100) / 100;
+				const insuranceCost =
+					Math.round((baseInsuranceCost + netMembershipCost) * 100) / 100;
 
-			quoterForm.setFieldValue("insuranceCost", insuranceCost);
-			quoterForm.setFieldValue("membershipCost", netMembershipCost);
-			quoterForm.setFieldValue("extraInsuranceCost", baseInsuranceCost);
-			quoterForm.setFieldValue("extraMembershipCost", rawMembershipCost);
+				quoterForm.setFieldValue("insuranceCost", insuranceCost);
+				quoterForm.setFieldValue("membershipCost", netMembershipCost);
+				quoterForm.setFieldValue("extraInsuranceCost", baseInsuranceCost);
+				quoterForm.setFieldValue("extraMembershipCost", rawMembershipCost);
+			}
 			quoterForm.setFieldValue("rcdpCost", result.rcdpCost);
 
 			// Recalcular después de actualizar
@@ -1465,6 +1473,18 @@ function QuoterPage() {
 													);
 													quoterForm.setFieldValue("leasingContractCost", 0);
 													quoterForm.setFieldValue("extraAdminCost", 0);
+													// Recalcular seguro sin membresía
+													const insuredAmountInterno =
+														quoterForm.getFieldValue("insuredAmount") ?? 0;
+													if (insuredAmountInterno > 0) {
+														// Setear insuranceCost solo al base (extraInsuranceCost ya tiene el valor)
+														const baseOnly =
+															quoterForm.getFieldValue("extraInsuranceCost") ?? 0;
+														quoterForm.setFieldValue(
+															"insuranceCost",
+															Number(baseOnly),
+														);
+													}
 												} else {
 													// Restaurar defaults de autocompra
 													quoterForm.setFieldValue("gpsCost", GPS_COST);

--- a/apps/marketing-landing/package.json
+++ b/apps/marketing-landing/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@elysiajs/eden": "^1.4.8",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.2",
@@ -19,6 +20,7 @@
     "@tanstack/react-table": "^8.21.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "elysia": "^1.4.25",
     "lucide-react": "^0.482.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/apps/marketing-landing/src/components/ui/button.tsx
+++ b/apps/marketing-landing/src/components/ui/button.tsx
@@ -45,7 +45,7 @@ function Button({
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }) {
-  const Comp = asChild ? Slot : "button"
+  const Comp: React.ElementType = asChild ? Slot : "button"
 
   return (
     <Comp

--- a/bun.lock
+++ b/bun.lock
@@ -392,6 +392,7 @@
     "apps/marketing-landing": {
       "name": "marketing-landing",
       "dependencies": {
+        "@elysiajs/eden": "^1.4.8",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-radio-group": "^1.2.3",
         "@radix-ui/react-slot": "^1.1.2",
@@ -402,6 +403,7 @@
         "@tanstack/react-table": "^8.21.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "elysia": "^1.4.25",
         "lucide-react": "^0.482.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -1160,7 +1162,7 @@
 
     "@elysiajs/cron": ["@elysiajs/cron@1.4.1", "", { "dependencies": { "croner": "^6.0.3" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-Y+jqXtMJ+m17QzNWlWc09ugd1Fn1Wh7lqE+y9qSW8eiQZEqsRADXWmbLuXRSRaSC5dkfOyRSiwNCp6n8L/yuqA=="],
 
-    "@elysiajs/eden": ["@elysiajs/eden@1.4.6", "", { "peerDependencies": { "elysia": ">=1.4.19" } }, "sha512-Tsa4NwXEWg/u73vWiYZQ3L5/ecgZSxqiEjYwpS+4qBKXeTZqZKl2hcgHJSVBL+InEDMi35Xugct7qyAXE5oM4Q=="],
+    "@elysiajs/eden": ["@elysiajs/eden@1.4.8", "", { "peerDependencies": { "elysia": ">=1.4.19" } }, "sha512-a7oct2kFa49tH+GawZtSUCZR2rQgucNYgGLz8alXUqb4IrU3PASA0T4zXJw4MhdV1Xb6vyiR7p7kkqJcVjgbkA=="],
 
     "@elysiajs/jwt": ["@elysiajs/jwt@1.4.0", "", { "dependencies": { "jose": "^6.0.11" }, "peerDependencies": { "elysia": ">= 1.4.0" } }, "sha512-Z0PvZhQxdDeKZ8HslXzDoXXD83NKExNPmoiAPki3nI2Xvh5wtUrBH+zWOD17yP14IbRo8fxGj3L25MRCAPsgPA=="],
 
@@ -7106,6 +7108,8 @@
 
     "marketing-landing/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "marketing-landing/elysia": ["elysia@1.4.25", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-liKjavH99Gpzrv9cDil6uYWmPuqESfPFV1FIaFSd3iNqo3y7e29sN43VxFIK8tWWnyi6eDAmi2SZk8hNAMQMyg=="],
+
     "marketing-landing/jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
 
     "marketing-landing/lucide-react": ["lucide-react@0.482.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-XM8PzHzSrg8ATmmO+fzf+JyYlVVdQnJjuyLDj2p4V2zEtcKeBNAqAoJIGFv1x2HSBa7kT8gpYUxwdQ0g7nypfw=="],
@@ -7659,6 +7663,8 @@
     "tldts-icann/tldts-core": ["tldts-core@7.0.19", "", {}, "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A=="],
 
     "to-buffer/isarray": ["isarray@2.0.5", "", {}, "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="],
+
+    "tranki/@elysiajs/eden": ["@elysiajs/eden@1.4.6", "", { "peerDependencies": { "elysia": ">=1.4.19" } }, "sha512-Tsa4NwXEWg/u73vWiYZQ3L5/ecgZSxqiEjYwpS+4qBKXeTZqZKl2hcgHJSVBL+InEDMi35Xugct7qyAXE5oM4Q=="],
 
     "tranki/@hookform/resolvers": ["@hookform/resolvers@4.1.3", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-Jsv6UOWYTrEFJ/01ZrnwVXs7KDvP8XIo115i++5PWvNkNvkrsTfGiLS6w+eJ57CYtUtDQalUWovCZDHFJ8u1VQ=="],
 
@@ -8545,6 +8551,10 @@
     "legal-documents/vite/esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
     "load-yaml-file/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "marketing-landing/elysia/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "marketing-landing/elysia/exact-mirror": ["exact-mirror@0.2.7", "", { "peerDependencies": { "@sinclair/typebox": "^0.34.15" }, "optionalPeers": ["@sinclair/typebox"] }, "sha512-+MeEmDcLA4o/vjK2zujgk+1VTxPR4hdp23qLqkWfStbECtAq9gmsvQa3LW6z/0GXZyHJobrCnmy1cdeE7BjsYg=="],
 
     "marketing-landing/jsdom/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 


### PR DESCRIPTION
## Summary
- Corrige cálculo de seguro en créditos internos (empleados) que incluía membresía incorrectamente (Q 426.17 en vez de Q 245.00)
- `updateInsuranceCost()` ahora omite membresía y GPS cuando `isInterno` está activo
- Al marcar el checkbox de crédito interno, se recalcula `insuranceCost` al valor base inmediatamente
- Limpia imports no usados en backend-2 y corrige constructor de Blob para upload a Twenty
- Agrega dependencias elysia/eden en marketing-landing y corrige tipo de Button

## Test plan
- [ ] Crear cotización de autocompra, marcar "Crédito Interno", verificar que seguro sea solo el base (ej. Q 245.00 para pickup Q 36k)
- [ ] Desmarcar crédito interno y verificar que seguro vuelva a incluir membresía (ej. Q 426.17)
- [ ] Verificar que cotizaciones existentes no se vean afectadas al cargar

🤖 Generated with [Claude Code](https://claude.com/claude-code)