### PR TITLE
Filters investor summaries for positive totals

### DIFF
--- a/apps/crm/apps/server/src/routers/accounting.ts
+++ b/apps/crm/apps/server/src/routers/accounting.ts
@@ -5,7 +5,10 @@ import { carteraBackClient } from "../services/cartera-back-client";
 export const accountingRouter = {
 	getResumenGlobalInversionistas: crmProcedure.handler(async () => {
 		const data = await carteraBackClient.getResumenGlobalInversionistas();
-		return data;
+		return data.filter(
+			(item: { total_a_recibir_con_reinversion: string }) =>
+				Number(item.total_a_recibir_con_reinversion) > 0,
+		);
 	}),
 
 	createBoleta: crmProcedure


### PR DESCRIPTION
This pull request updates the `getResumenGlobalInversionistas` handler in the `accountingRouter` to filter out items where `total_a_recibir_con_reinversion` is not greater than zero. This ensures that only relevant data is returned to the client.

- Data filtering improvement:
  * Updated `getResumenGlobalInversionistas` to return only items with a `total_a_recibir_con_reinversion` value greater than zero in `accounting.ts`.