### PR TITLE
fix(crm): capacidad de pago consolidada para múltiples firmantes

### DIFF
--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -277,17 +277,17 @@ export function CreditDetailView({
 		enabled: !!opportunity.vehicle?.id,
 	});
 
-	// Query para obtener el análisis de crédito del lead
-	const creditAnalysisQuery = useQuery({
-		queryKey: ["getCreditAnalysisByLeadId", opportunity.lead?.id],
+	// Query para obtener el análisis de crédito consolidado (lead + co-firmantes)
+	const consolidatedCreditQuery = useQuery({
+		queryKey: ["getConsolidatedCreditAnalysis", opportunityId],
 		queryFn: () =>
-			client.getCreditAnalysisByLeadId({ leadId: opportunity.lead!.id }),
-		enabled: !!opportunity.lead?.id,
+			client.getConsolidatedCreditAnalysis({ opportunityId }),
+		enabled: !!opportunityId,
 	});
 
 	// Datos de inspección y análisis de crédito
 	const vehicleInspection = vehicleInspectionQuery.data;
-	const creditAnalysis = creditAnalysisQuery.data;
+	const creditAnalysis = consolidatedCreditQuery.data?.consolidated;
 
 	// Query para obtener el vendor del vehículo (solo para Autocompras)
 	const vendorQuery = useQuery({


### PR DESCRIPTION
## Summary
- `CreditDetailView` usaba `getCreditAnalysisByLeadId` que solo mostraba la capacidad de pago del lead principal
- Ahora usa `getConsolidatedCreditAnalysis` que suma la capacidad de pago del lead + todos los co-firmantes
- Corrige el caso donde 2 firmantes tienen capacidad de pago analizada pero el detalle solo muestra la de uno

## Test plan
- [ ] Abrir una oportunidad con 2 firmantes que tengan capacidad de pago analizada
- [ ] Verificar que el detalle de crédito muestre la suma de ambas capacidades
- [ ] Verificar que con un solo firmante sigue funcionando correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)