### PR TITLE
fix(crm): validación de datos vehículo nuevo solo al 100%

### DIFF
--- a/apps/crm/apps/server/src/lib/vehicle-helpers.ts
+++ b/apps/crm/apps/server/src/lib/vehicle-helpers.ts
@@ -99,7 +99,6 @@ export function getMissingFields(
 		Vehicle,
 		| "isNew"
 		| "vinNumber"
-		| "licensePlate"
 		| "origin"
 		| "fuelType"
 		| "transmission"

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1352,8 +1352,8 @@ export const crmRouter = {
 								});
 							}
 
-							// Para vehículos nuevos, validar campos adicionales para 100%
-							if (vehicleForValidation[0].isNew) {
+							// Para vehículos nuevos, validar campos adicionales solo al cerrar al 100%
+							if (vehicleForValidation[0].isNew && toPercentage === 100) {
 								const missingForCompletion = getMissingFieldsForCompletion(
 									vehicleForValidation[0],
 								);

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -2208,7 +2208,7 @@ function RouteComponent() {
 													).length > 0 && (
 														<div className="mt-2 text-amber-600 text-sm">
 															<span className="font-medium">
-																Campos pendientes:{" "}
+																Campos pendientes para cierre (100%):{" "}
 															</span>
 															{getMissingFieldsForNewVehicle(
 																selectedOpportunity.vehicle,


### PR DESCRIPTION
## Summary
- La validación de campos completos (Placa, Origen, Combustible, Transmisión) para vehículos nuevos se aplicaba desde la etapa 80%+, bloqueando el avance a 85%/90% cuando el vehículo aún no tenía placa
- Ahora la validación solo se aplica al intentar cerrar al 100%, permitiendo avanzar normalmente hasta el 90%
- Se clarifica el mensaje de "Campos pendientes" en la UI para indicar que son requeridos para el cierre (100%)

## Test plan
- [ ] Crear oportunidad con vehículo nuevo sin placa
- [ ] Verificar que se puede avanzar hasta 90% sin bloqueo
- [ ] Verificar que al intentar cerrar al 100% sin placa, se muestra el error
- [ ] Verificar que el badge dice "Campos pendientes para cierre (100%)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)