### PR TITLE
Re-enables OTP SMS and refines payment due date calculation

### DIFF
--- a/apps/crm/apps/server/src/controllers/bot.ts
+++ b/apps/crm/apps/server/src/controllers/bot.ts
@@ -434,6 +434,7 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 				status: "new",
 				age: age ?? existingLead[0].age,
 				updatedAt: new Date(),
+				livenessValidated:false
 			})
 			.where(eq(leads.dpi, dpi));
 		leadId = existingLead[0].id;

--- a/apps/crm/apps/server/src/controllers/otp.ts
+++ b/apps/crm/apps/server/src/controllers/otp.ts
@@ -74,7 +74,6 @@ export class OTPController {
 					otpId: newOtp.id,
 					expiresAt: newOtp.expiresAt,
 					phoneNumber: phoneNumber,
-					code: code, // 🔥 Solo para desarrollo - remover en producción
 				},
 				status: 200 as const,
 			};


### PR DESCRIPTION
Re-enables sending of OTP verification codes via SMS, including a specific dial parameter in the SMS client configuration.

Updates payment migration logic to use the exact expected day for due dates, ensuring accuracy and handling month-end constraints.
