### PR TITLE
fix(legal-docs): mejorar R2 upload - estructura y robustez

### DIFF
--- a/apps/legal-docs-blueprints/services/ContractGeneratorService.ts
+++ b/apps/legal-docs-blueprints/services/ContractGeneratorService.ts
@@ -567,16 +567,14 @@ export class ContractGeneratorService {
         }
       }
 
-      // 11.5. Subir PDF a R2 solo si NO hay flujo de firma (evitar uploads redundantes)
+      // 11.5. Subir PDF a R2 siempre (garantiza r2Key independiente de firma)
       let r2KeyDirect: string | undefined;
-      const hasSigningFlow = options.emails && options.emails.length > 0;
-      if (pdfBuffer && !hasSigningFlow) {
+      if (pdfBuffer) {
         try {
           const result = await uploadPdfToR2(pdfBuffer, baseFilename);
           r2KeyDirect = result.r2Key;
         } catch (error) {
-          console.error('Error al subir PDF a R2:', error);
-          // No fallar - continuamos con el flujo normal
+          console.error('⚠️ ALERTA: No se pudo subir PDF a R2. El contrato NO tendrá r2Key:', error);
         }
       }
 
@@ -642,7 +640,7 @@ export class ContractGeneratorService {
       }
 
       // 13. Limpiar archivos locales si se subieron exitosamente a R2
-      if (shouldCleanupFiles) {
+      if (shouldCleanupFiles || r2KeyDirect) {
         try {
           await this.cleanupLocalFiles(docxPath, pdfPath);
           console.log(`🗑️  Archivos locales eliminados (ya están en R2)`);
@@ -728,7 +726,7 @@ export class ContractGeneratorService {
         signing_links: signingLinks,
         linkDocument: signing?.linkDocument || '',
         signingProvider,
-        r2Key: signing?.r2Key || r2KeyDirect,
+        r2Key: r2KeyDirect || signing?.r2Key,
         // Campos adicionales para backward compatibility
         contractType,
         docx_path: docxPath,

--- a/apps/legal-docs-blueprints/services/R2Service.ts
+++ b/apps/legal-docs-blueprints/services/R2Service.ts
@@ -5,33 +5,43 @@ const R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID;
 const R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY;
 const R2_BUCKET_LEGAL_DOCS = process.env.R2_BUCKET_LEGAL_DOCS || 'legal-documents';
 
-if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY) {
-  console.warn('⚠️  R2 storage credentials not configured. Direct PDF uploads to R2 will fail.');
-}
+let r2Client: S3Client | null = null;
 
-const r2Client = new S3Client({
-  region: 'auto',
-  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-  credentials: {
-    accessKeyId: R2_ACCESS_KEY_ID || '',
-    secretAccessKey: R2_SECRET_ACCESS_KEY || '',
-  },
-});
+function getR2Client(): S3Client {
+  if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY) {
+    throw new Error('R2 credentials not configured (R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY)');
+  }
+  if (!r2Client) {
+    r2Client = new S3Client({
+      region: 'auto',
+      endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+      credentials: {
+        accessKeyId: R2_ACCESS_KEY_ID,
+        secretAccessKey: R2_SECRET_ACCESS_KEY,
+      },
+    });
+  }
+  return r2Client;
+}
 
 /**
  * Sube un PDF directamente a R2 (independiente de firma electrónica).
  * Retorna un r2Key con formato "bucket/path" compatible con getFileUrlWithBucketInKey del CRM.
+ *
+ * Key format: contracts/{YYYY-MM-DD}/{nombre_tipo_timestamp_random}.pdf
+ * Ejemplo: contracts/2026-02-27/Christian_Ruiz_uso_carro_usado_2026-02-27T15-30-45_a3b2c1.pdf
  */
 export async function uploadPdfToR2(
   pdfBuffer: Buffer,
   filename: string
 ): Promise<{ r2Key: string }> {
-  if (!R2_ACCOUNT_ID || !R2_ACCESS_KEY_ID || !R2_SECRET_ACCESS_KEY) {
-    throw new Error('R2 credentials not configured. Skipping direct PDF upload.');
-  }
+  const client = getR2Client();
 
-  const sanitizedFilename = filename.replace(/[^a-zA-Z0-9-_]/g, '_');
-  const key = sanitizedFilename.endsWith('.pdf') ? sanitizedFilename : `${sanitizedFilename}.pdf`;
+  const sanitized = filename.replace(/[^a-zA-Z0-9-_]/g, '_');
+  const randomSuffix = Math.random().toString(36).substring(2, 8);
+  const datePrefix = new Date().toISOString().slice(0, 10);
+  const finalName = `${sanitized}_${randomSuffix}.pdf`;
+  const key = `contracts/${datePrefix}/${finalName}`;
 
   const command = new PutObjectCommand({
     Bucket: R2_BUCKET_LEGAL_DOCS,
@@ -40,11 +50,10 @@ export async function uploadPdfToR2(
     ContentType: 'application/pdf',
   });
 
-  await r2Client.send(command);
+  await client.send(command);
 
-  // r2Key con formato "bucket/key" para que el CRM lo resuelva con getFileUrlWithBucketInKey
   const r2Key = `${R2_BUCKET_LEGAL_DOCS}/${key}`;
-  console.log(`✓ PDF subido directamente a R2: ${r2Key}`);
+  console.log(`✓ PDF subido a R2: ${r2Key}`);
 
   return { r2Key };
 }


### PR DESCRIPTION
## Summary
Mejoras al PR #316 (ya mergeado) para el upload directo de PDFs a R2.

- **r2Key consistente**: prioriza `r2KeyDirect` sobre `signing.r2Key` (evita formato inconsistente de Documenso)
- **Sin colisiones**: sufijo random en filename (`_a3b2c1`)
- **Organizado**: `contracts/{YYYY-MM-DD}/nombre_tipo_timestamp_random.pdf`
- **Cliente S3 lazy**: solo se instancia si hay credenciales
- **Log prominente**: alerta clara cuando falla upload a R2
- **Cleanup mejorado**: limpia archivos locales también sin flujo de firma

## Ejemplo de r2Key
```
legal-documents/contracts/2026-02-27/Christian_Ruiz_uso_carro_usado_2026-02-27T15-30-45_a3b2c1.pdf
```

## Test plan
- [ ] Generar contrato y verificar estructura de key en R2
- [ ] Verificar que el CRM resuelve el r2Key correctamente
- [ ] Verificar log de alerta sin credenciales R2

🤖 Generated with [Claude Code](https://claude.com/claude-code)