### PR TITLE
fix(legal-docs): fallar contrato si no se puede subir PDF a R2

### DIFF
--- a/apps/legal-docs-blueprints/services/ContractGeneratorService.ts
+++ b/apps/legal-docs-blueprints/services/ContractGeneratorService.ts
@@ -570,12 +570,8 @@ export class ContractGeneratorService {
       // 11.5. Subir PDF a R2 siempre (garantiza r2Key independiente de firma)
       let r2KeyDirect: string | undefined;
       if (pdfBuffer) {
-        try {
-          const result = await uploadPdfToR2(pdfBuffer, baseFilename);
-          r2KeyDirect = result.r2Key;
-        } catch (error) {
-          console.error('⚠️ ALERTA: No se pudo subir PDF a R2. El contrato NO tendrá r2Key:', error);
-        }
+        const result = await uploadPdfToR2(pdfBuffer, baseFilename);
+        r2KeyDirect = result.r2Key;
       }
 
       // 12. Integración con firma electrónica (WeeTrust principal, Documenso fallback)


### PR DESCRIPTION
## Summary
- Si el upload a R2 falla, el contrato ahora devuelve `success: false` en vez de continuar silenciosamente
- Sin PDF en R2 el contrato es inútil para el CRM, no tiene sentido guardarlo sin archivo

## Test plan
- [ ] Verificar que con R2 configurado el contrato se genera normalmente
- [ ] Verificar que sin credenciales R2 el contrato falla con error claro

🤖 Generated with [Claude Code](https://claude.com/claude-code)