### PR TITLE
Resets `amount` search param for investor lead

### DIFF
--- a/apps/portal-web/src/features/Investors/Sections/HeaderInvestor.tsx
+++ b/apps/portal-web/src/features/Investors/Sections/HeaderInvestor.tsx
@@ -44,7 +44,7 @@ export const HeaderInvestor = () => {
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
               transition={{ type: "spring", stiffness: 400, damping: 17 }}
-              onClick={() => navigate({ to: "/leadInvestor" })}
+              onClick={() => navigate({ to: "/leadInvestor", search: { amount: undefined } })}
             >
               <div>
                 <IconArrow width={isMobile ? 16 : 24} height={isMobile ? 16 : 24} />

--- a/apps/portal-web/src/features/Investors/Sections/Now.tsx
+++ b/apps/portal-web/src/features/Investors/Sections/Now.tsx
@@ -60,7 +60,7 @@ export const Now = () => {
 
             {/* Botón Invierte Ahora con motion */}
             <motion.button
-              onClick={() => navigate({ to: "/leadInvestor" })}
+              onClick={() => navigate({ to: "/leadInvestor", search: { amount: undefined } })}
               className="mt-4 lg:mt-0 px-12 lg:px-16 py-4 lg:py-6 rounded-xl font-semibold text-primary border border-primary text-2xl mb-8 lg:mb-12"
               initial={{ opacity: 0, scale: 0.9 }}
               whileInView={{ opacity: 1, scale: 1 }}


### PR DESCRIPTION
Clears any pre-existing `amount` query parameter when navigating to the lead investor page from the header or 'Invest Now' sections. Ensures a fresh state for the investment form, preventing unintended pre-population.