### PR TITLE
fix(crm): getOpportunities date filter + TS fixes

### DIFF
--- a/apps/crm/apps/server/src/controllers/otp.ts
+++ b/apps/crm/apps/server/src/controllers/otp.ts
@@ -50,7 +50,7 @@ export class OTPController {
 			// 5. Enviar SMS
 			const smsClient = new SMSClient({
 				token: process.env.SMS_TOKEN!,
-				apiKey: parseInt(process.env.SMS_API_KEY!),
+				apiKey: Number.parseInt(process.env.SMS_API_KEY!),
 			});
 
 			const message = `Tu código de verificación es: ${code}. Válido por 5 minutos.`;

--- a/apps/crm/apps/server/src/lib/vehicle-helpers.ts
+++ b/apps/crm/apps/server/src/lib/vehicle-helpers.ts
@@ -97,11 +97,7 @@ export function isNewVehicleDataComplete(
 export function getMissingFields(
 	vehicle: Pick<
 		Vehicle,
-		| "isNew"
-		| "vinNumber"
-		| "origin"
-		| "fuelType"
-		| "transmission"
+		"isNew" | "vinNumber" | "origin" | "fuelType" | "transmission"
 	>,
 ): string[] {
 	// Vehículos usados no tienen campos faltantes

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -737,8 +737,12 @@ export const cobrosRouter = {
 								numeroCredito: numeroSifco || null,
 								etiquetas: null as string[] | null,
 								isPool:
-									credito.creditos.formato_credito?.toUpperCase().includes("POOL") ||
-									credito.creditos.tipoCredito?.toUpperCase().includes("POOL") ||
+									credito.creditos.formato_credito
+										?.toUpperCase()
+										.includes("POOL") ||
+									credito.creditos.tipoCredito
+										?.toUpperCase()
+										.includes("POOL") ||
 									(Array.isArray(credito.inversionistas) &&
 										credito.inversionistas.length > 1),
 							};

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -989,64 +989,63 @@ export const crmRouter = {
 				);
 			}
 
-			// Determinar rango de mes para filtros basados en historial de stages
+			// Filtros de stage/fecha solo aplican cuando se pasan month/year explícitamente
 			const filterMonth = input?.month;
 			const filterYear = input?.year;
-			const now = new Date();
-			const startOfMonth =
-				filterMonth && filterYear
-					? new Date(filterYear, filterMonth - 1, 1)
-					: new Date(now.getFullYear(), now.getMonth(), 1);
-			const endOfMonth =
-				filterMonth && filterYear
-					? new Date(filterYear, filterMonth, 1)
-					: undefined;
 
-			// Solo mostrar oportunidades al 100% que llegaron ahí en el mes seleccionado
-			const fullStages = await db
-				.select({ id: salesStages.id })
-				.from(salesStages)
-				.where(eq(salesStages.closurePercentage, 100));
-			const fullStageIds = fullStages.map((s) => s.id);
+			if (filterMonth && filterYear) {
+				const startOfMonth = new Date(filterYear, filterMonth - 1, 1);
+				const endOfMonth = new Date(filterYear, filterMonth, 1);
 
-			if (fullStageIds.length > 0) {
-				const historyConditions = [
-					inArray(opportunityStageHistory.toStageId, fullStageIds),
-					gte(opportunityStageHistory.changedAt, startOfMonth),
-				];
-				if (endOfMonth) {
-					historyConditions.push(
-						lt(opportunityStageHistory.changedAt, endOfMonth),
+				// Solo mostrar oportunidades al 100% que llegaron ahí en el mes seleccionado
+				const fullStages = await db
+					.select({ id: salesStages.id })
+					.from(salesStages)
+					.where(eq(salesStages.closurePercentage, 100));
+				const fullStageIds = fullStages.map((s) => s.id);
+
+				if (fullStageIds.length > 0) {
+					const thisMonthFullOpps = await db
+						.select({
+							opportunityId: opportunityStageHistory.opportunityId,
+						})
+						.from(opportunityStageHistory)
+						.where(
+							and(
+								inArray(
+									opportunityStageHistory.toStageId,
+									fullStageIds,
+								),
+								gte(opportunityStageHistory.changedAt, startOfMonth),
+								lt(opportunityStageHistory.changedAt, endOfMonth),
+							),
+						);
+
+					const thisMonthOppIds = thisMonthFullOpps.map(
+						(o) => o.opportunityId,
+					);
+
+					conditions.push(
+						or(
+							not(inArray(opportunities.stageId, fullStageIds)),
+							...(thisMonthOppIds.length > 0
+								? [inArray(opportunities.id, thisMonthOppIds)]
+								: []),
+						),
 					);
 				}
 
-				const thisMonthFullOpps = await db
-					.select({ opportunityId: opportunityStageHistory.opportunityId })
-					.from(opportunityStageHistory)
-					.where(and(...historyConditions));
-
-				const thisMonthOppIds = thisMonthFullOpps.map((o) => o.opportunityId);
-
-				conditions.push(
-					or(
-						not(inArray(opportunities.stageId, fullStageIds)),
-						...(thisMonthOppIds.length > 0
-							? [inArray(opportunities.id, thisMonthOppIds)]
-							: []),
-					),
-				);
-			}
-
-			// Cuando se filtra por mes/año, también filtrar oportunidades colocadas (>= 90%)
-			// que llegaron a ese stage en el mes seleccionado
-			if (filterMonth && filterYear && endOfMonth) {
+				// Filtrar oportunidades colocadas (>= 90%) que llegaron a ese stage en el mes
 				const PLACED_STAGE_THRESHOLD = 90;
 				const placedStages = await db
 					.select({ id: salesStages.id })
 					.from(salesStages)
 					.where(
 						and(
-							gte(salesStages.closurePercentage, PLACED_STAGE_THRESHOLD),
+							gte(
+								salesStages.closurePercentage,
+								PLACED_STAGE_THRESHOLD,
+							),
 							lt(salesStages.closurePercentage, 100),
 						),
 					);
@@ -1054,19 +1053,25 @@ export const crmRouter = {
 
 				if (placedStageIds.length > 0) {
 					const placedThisMonth = await db
-						.select({ opportunityId: opportunityStageHistory.opportunityId })
+						.select({
+							opportunityId: opportunityStageHistory.opportunityId,
+						})
 						.from(opportunityStageHistory)
 						.where(
 							and(
-								inArray(opportunityStageHistory.toStageId, placedStageIds),
+								inArray(
+									opportunityStageHistory.toStageId,
+									placedStageIds,
+								),
 								gte(opportunityStageHistory.changedAt, startOfMonth),
 								lt(opportunityStageHistory.changedAt, endOfMonth),
 							),
 						);
 
-					const placedOppIds = placedThisMonth.map((o) => o.opportunityId);
+					const placedOppIds = placedThisMonth.map(
+						(o) => o.opportunityId,
+					);
 
-					// Filtrar: oportunidades en stages colocados (90-99%) solo si llegaron ahí en el mes
 					conditions.push(
 						or(
 							not(inArray(opportunities.stageId, placedStageIds)),

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -185,7 +185,7 @@ export default function Header() {
 									<DropdownMenuItem asChild>
 										<Link
 											to="/vehicles"
-											search={{ vehicleId: undefined, inspectionId: undefined }}
+											search={{ vehicleId: undefined, inspectionId: undefined, tab: undefined }}
 											className="cursor-pointer"
 										>
 											<Car className="mr-2 h-4 w-4" />

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -401,6 +401,7 @@ export function OpportunityDetailModal({
 												search={{
 													vehicleId: opportunity.vehicle.id,
 													inspectionId: undefined,
+													tab: undefined,
 												}}
 												className="font-medium text-primary hover:underline"
 												onClick={() => onOpenChange(false)}
@@ -539,6 +540,7 @@ export function OpportunityDetailModal({
 															search={{
 																vehicleId: quotation.vehicleId,
 																inspectionId: undefined,
+																tab: undefined,
 															}}
 															className="flex items-center gap-1 font-medium text-primary text-sm hover:underline"
 														>

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -182,7 +182,10 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 				>
 					{numero || "-"}
 					{isPool && (
-						<Badge variant="secondary" className="ml-2 bg-indigo-100 text-indigo-800">
+						<Badge
+							variant="secondary"
+							className="ml-2 bg-indigo-100 text-indigo-800"
+						>
 							Pool
 						</Badge>
 					)}

--- a/apps/crm/apps/web/src/lib/investment-labels.ts
+++ b/apps/crm/apps/web/src/lib/investment-labels.ts
@@ -1,0 +1,31 @@
+/**
+ * Labels en español para los enums del módulo de inversiones.
+ */
+
+const LEAD_SOURCE_LABELS: Record<string, string> = {
+	website: "Sitio web",
+	referral: "Referido",
+	cold_call: "Llamada en frío",
+	email: "Correo electrónico",
+	social_media: "Redes sociales",
+	event: "Evento",
+	whatsapp: "WhatsApp",
+};
+
+const OPPORTUNITY_STATUS_LABELS: Record<string, string> = {
+	open: "Abierta",
+	won: "Ganada",
+	lost: "Perdida",
+};
+
+export function formatLeadSource(source: string | null | undefined): string {
+	if (!source) return "—";
+	return LEAD_SOURCE_LABELS[source] ?? source;
+}
+
+export function formatOpportunityStatus(
+	status: string | null | undefined,
+): string {
+	if (!status) return "—";
+	return OPPORTUNITY_STATUS_LABELS[status] ?? status;
+}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -320,9 +320,7 @@ function RouteComponent() {
 								<YAxis yAxisId="right" orientation="right" />
 								<Tooltip
 									formatter={(value, name) =>
-										name === "monto"
-											? formatCurrency(Number(value))
-											: value
+										name === "monto" ? formatCurrency(Number(value)) : value
 									}
 								/>
 								<Legend />

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -2165,6 +2165,7 @@ function RouteComponent() {
 																	search: {
 																		vehicleId: selectedOpportunity.vehicle?.id,
 																		inspectionId: undefined,
+																		tab: undefined,
 																	},
 																});
 															}}
@@ -2178,6 +2179,7 @@ function RouteComponent() {
 																			vehicleId:
 																				selectedOpportunity.vehicle?.id,
 																			inspectionId: undefined,
+																			tab: undefined,
 																		},
 																	});
 																}

--- a/apps/crm/apps/web/src/routes/juridico/generate.$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/generate.$opportunityId.tsx
@@ -403,6 +403,7 @@ function RouteComponent() {
 												search: {
 													vehicleId: opportunity?.vehicle?.id,
 													inspectionId: undefined,
+													tab: undefined,
 												},
 											})
 										}

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -260,9 +260,11 @@ function VehiclesDashboard() {
 				processedVehicleIdRef.current = null;
 				processedInspectionIdRef.current = null;
 				navigate({
-					search: (prev) => {
-						const { vehicleId, inspectionId, tab, ...rest } = prev;
-						return rest;
+					to: "/vehicles",
+					search: {
+						vehicleId: undefined,
+						inspectionId: undefined,
+						tab: undefined,
 					},
 					replace: true,
 				});
@@ -714,11 +716,12 @@ function VehiclesDashboard() {
 																	<DropdownMenuItem
 																		onClick={() => {
 																			navigate({
-																				search: (prev) => ({
-																					...prev,
+																				to: "/vehicles",
+																				search: {
 																					vehicleId: vehicle.id,
+																					inspectionId: undefined,
 																					tab: "general",
-																				}),
+																				},
 																			});
 																		}}
 																	>
@@ -765,11 +768,12 @@ function VehiclesDashboard() {
 																	<DropdownMenuItem
 																		onClick={() => {
 																			navigate({
-																				search: (prev) => ({
-																					...prev,
+																				to: "/vehicles",
+																				search: {
 																					vehicleId: vehicle.id,
+																					inspectionId: undefined,
 																					tab: "photos",
-																				}),
+																				},
 																			});
 																		}}
 																	>
@@ -779,11 +783,12 @@ function VehiclesDashboard() {
 																	<DropdownMenuItem
 																		onClick={() => {
 																			navigate({
-																				search: (prev) => ({
-																					...prev,
+																				to: "/vehicles",
+																				search: {
 																					vehicleId: vehicle.id,
+																					inspectionId: undefined,
 																					tab: "documents",
-																				}),
+																				},
 																			});
 																		}}
 																	>

--- a/apps/crm/apps/web/src/routes/vehicles/inspection.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/inspection.tsx
@@ -205,7 +205,7 @@ function VehicleInspectionForm() {
 			setTimeout(() => {
 				navigate({
 					to: "/vehicles",
-					search: { vehicleId: undefined, inspectionId: undefined },
+					search: { vehicleId: undefined, inspectionId: undefined, tab: undefined },
 				});
 			}, 2000);
 		} catch (error) {

--- a/apps/portal-web/index.html
+++ b/apps/portal-web/index.html
@@ -20,12 +20,12 @@
       fbq('init', '884085006070709');
       fbq('track', 'PageView');
     </script>
-    <noscript><img height="1" width="1" style="display:none"
-      src="https://www.facebook.com/tr?id=884085006070709&ev=PageView&noscript=1"
-    /></noscript>
     <!-- End Meta Pixel Code -->
   </head>
   <body>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://www.facebook.com/tr?id=884085006070709&ev=PageView&noscript=1"
+    /></noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/apps/portal-web/src/features/Investors/Sections/HeaderInvestor.tsx
+++ b/apps/portal-web/src/features/Investors/Sections/HeaderInvestor.tsx
@@ -44,7 +44,7 @@ export const HeaderInvestor = () => {
               whileHover={{ scale: 1.02 }}
               whileTap={{ scale: 0.98 }}
               transition={{ type: "spring", stiffness: 400, damping: 17 }}
-              onClick={() => navigate({ to: "/leadInvestor" })}
+              onClick={() => navigate({ to: "/leadInvestor", search: { amount: undefined } })}
             >
               <div>
                 <IconArrow width={isMobile ? 16 : 24} height={isMobile ? 16 : 24} />

--- a/apps/portal-web/src/features/Investors/Sections/Now.tsx
+++ b/apps/portal-web/src/features/Investors/Sections/Now.tsx
@@ -60,7 +60,7 @@ export const Now = () => {
 
             {/* Botón Invierte Ahora con motion */}
             <motion.button
-              onClick={() => navigate({ to: "/leadInvestor" })}
+              onClick={() => navigate({ to: "/leadInvestor", search: { amount: undefined } })}
               className="mt-4 lg:mt-0 px-12 lg:px-16 py-4 lg:py-6 rounded-xl font-semibold text-primary border border-primary text-2xl mb-8 lg:mb-12"
               initial={{ opacity: 0, scale: 0.9 }}
               whileInView={{ opacity: 1, scale: 1 }}


### PR DESCRIPTION
## Summary
- **Fix getOpportunities:** Los filtros de stage/fecha (100% y colocadas 90-99%) ahora solo aplican cuando se pasan `month`/`year` explícitamente. Antes usaba el mes actual como fallback, ocultando oportunidades cerradas en meses anteriores para búsquedas por ID, por SIFCO, y listados genéricos.
- **Fix TS errors:** Agrega `tab` faltante en search params de `/vehicles` en header, opportunity-detail-modal, opportunities, jurídico y vehicles routes.
- **Misc:** Labels en español para enums de inversiones, formatting pendiente en cobros/reports/otp/vehicle-helpers.

## Test plan
- [ ] Llamar `getOpportunities` con `opportunityId` de una oportunidad al 100% de un mes anterior → debe retornar datos
- [ ] Verificar que el pipeline view con `month`/`year` sigue filtrando correctamente
- [ ] Verificar navegación a `/vehicles` desde header, modal de oportunidad y jurídico

🤖 Generated with [Claude Code](https://claude.com/claude-code)