### PR TITLE
Updates production frontend URL and auth cookies

### DIFF
--- a/apps/auth-google/src/lib/auth.ts
+++ b/apps/auth-google/src/lib/auth.ts
@@ -91,7 +91,7 @@ export const auth = betterAuth({
     },
     useSecureCookies: env.NODE_ENV === "production",
     cookies: {
-      sameSite: env.NODE_ENV === "production" ? "strict" : "lax" as const,
+      sameSite: env.NODE_ENV === "production" ? "none" : "lax" as const,
     },
   },
   secret: env.BETTER_AUTH_SECRET,

--- a/apps/portal-web/Dockerfile
+++ b/apps/portal-web/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 
 # Build arguments for environment variables
 ARG VITE_IMAGE_URL=https://pub-6db6052b52cf40f7bb41443a6b24ef95.r2.dev
-ARG VITE_FRONTEND_URL=https://portal.servicioscashin.com
+ARG VITE_FRONTEND_URL=https://clubcashin.com
 ARG VITE_WHATSAPP_PHONE_NUMBER=+59899683075
 ARG VITE_PHONE_NUMBER=+50222341368
 ARG VITE_URL_INSPECTION=https://taller.s3.devteamatcci.site/vehicle-inspection


### PR DESCRIPTION
Adjusts the `VITE_FRONTEND_URL` in the `portal-web` Dockerfile to reflect the new production domain `clubcashin.com`. Updates the `sameSite` cookie policy for authentication in production to `none`. This change supports cross-site cookie usage, necessary for the authentication service to function correctly with the frontend's new domain.