### PR TITLE
feat(portal-web): add Google Tag Manager

### DIFF
--- a/apps/portal-web/index.html
+++ b/apps/portal-web/index.html
@@ -21,8 +21,19 @@
       fbq('track', 'PageView');
     </script>
     <!-- End Meta Pixel Code -->
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-TX9JRXHJ');</script>
+    <!-- End Google Tag Manager -->
   </head>
   <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TX9JRXHJ"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <noscript><img height="1" width="1" style="display:none"
       src="https://www.facebook.com/tr?id=884085006070709&ev=PageView&noscript=1"
     /></noscript>


### PR DESCRIPTION
## Summary
- Add Google Tag Manager (GTM-TX9JRXHJ) script to portal-web `index.html`
- Includes both the `<head>` script and the `<body>` noscript fallback

## Test plan
- [ ] Verify GTM loads correctly in browser dev tools (Network tab)
- [ ] Confirm GTM container fires on page load via Tag Assistant

🤖 Generated with [Claude Code](https://claude.com/claude-code)