### PR TITLE
fix(portal-web): UI fixes and branding cleanup

### DIFF
--- a/apps/portal-web/src/components/ui/NavBar.tsx
+++ b/apps/portal-web/src/components/ui/NavBar.tsx
@@ -198,11 +198,15 @@ export const NavBar = () => {
             `}
           >
             {isInvestorPage ? (
-              <InvestorsLogo />
+              <Link href="/invest">
+                <InvestorsLogo />
+              </Link>
             ) : (
-              <div className="w-full h-full">
-                <IconCCI />
-              </div>
+              <Link href="/">
+                <div className="w-full h-full">
+                  <IconCCI />
+                </div>
+              </Link>
             )}
           </div>
         </div>

--- a/apps/portal-web/src/features/Credit/Sections/GetMoney.tsx
+++ b/apps/portal-web/src/features/Credit/Sections/GetMoney.tsx
@@ -99,7 +99,7 @@ export const GetMoney = () => {
           {items.map((item, index) => (
             <div
               key={index}
-              className="flex flex-col   p-6 rounded-xl border border-secondary/20 bg-secondary/5"
+              className="flex flex-col items-center p-6 rounded-xl border border-secondary/20 bg-secondary/5"
             >
               {/* Icono */}
               <div className="mb-4 w-8 text-secondary">{item.icon}</div>

--- a/apps/portal-web/src/features/FormLeads/FormLeads.tsx
+++ b/apps/portal-web/src/features/FormLeads/FormLeads.tsx
@@ -2,18 +2,18 @@ import { Button } from "@/components";
 import { Formulario, InfoLead, Thanks } from "./components";
 import { useIsMobile } from "@/hooks";
 import { useLead } from "./store/useLead";
+import { Link } from "@/components/ui";
+import { IconCCI } from "@/components/IconCCI";
 
 const urlImage = import.meta.env.VITE_IMAGE_URL;
 
 export const IconCashIn = () => (
-  <div className="flex items-center gap-2 lg:gap-6 lg:px-12 z-50">
-    <h1 className="text-4xl font-bold lg:text-header-3">Cash In</h1>
-    <img
-      src="/logo1.png"
-      alt="CashIn company logo"
-      className="w-8 h-8 object-contain"
-    />
-  </div>
+  <Link href="/" className="flex items-center gap-2 lg:gap-6 lg:px-12 z-50">
+    <h1 className="text-4xl font-bold lg:text-header-3">CashIn</h1>
+    <div className="w-8 h-8">
+      <IconCCI />
+    </div>
+  </Link>
 );
 
 export const FormLeads = () => {

--- a/apps/portal-web/src/features/HomePage/HomePage.tsx
+++ b/apps/portal-web/src/features/HomePage/HomePage.tsx
@@ -23,7 +23,7 @@ export const HomePage = () => {
         <HowItWorks />
         <GraphLine />
         <HowSellOrBuy />
-        <Testimonies />
+        {/* <Testimonies /> TODO: Reemplazar con reseñas reales */}
       </div>
     </div>
   );

--- a/apps/portal-web/src/features/HomePage/sections/whoWeAre/WhoWeAre.tsx
+++ b/apps/portal-web/src/features/HomePage/sections/whoWeAre/WhoWeAre.tsx
@@ -79,8 +79,8 @@ const FeatureCard = ({
       </div>
     ) : (
       <>
-        <div className="flex items-center gap-2">
-          <span className="w-2.5 h-2.5 rounded-full bg-blue-500 shrink-0" />
+        <div className={`flex items-center gap-2 ${isMobile ? "" : "min-h-[52px] items-start"}`}>
+          <span className={`w-2.5 h-2.5 rounded-full bg-blue-500 shrink-0 ${isMobile ? "" : "mt-[7px]"}`} />
           <motion.span
             animate={{ color: isActive ? "#3A86FF" : "#FFFFFF" }}
             transition={{ duration: 0.15 }}

--- a/apps/portal-web/src/features/footer/Footer.tsx
+++ b/apps/portal-web/src/features/footer/Footer.tsx
@@ -129,7 +129,7 @@ export const Footer: React.FC<FooterProps> = ({ notShowRedirects = false }) => {
 
           {/* Social media and contact */}
           <div
-            className={`order-1 lg:order-2 w-full col-span-2 lg:col-span-3 flex  ${notShowRedirects ? "" : "lg:justify-end lg:pr-14"} gap-4 lg:gap-8 `}
+            className={`order-1 lg:order-2 w-full col-span-2 lg:col-span-3 flex ${notShowRedirects ? "" : "lg:justify-end lg:pr-14"} gap-4 lg:gap-8 `}
           >
             {SOCIAL_CONTACTS.filter(contact => notShowRedirects ? contact.lead !== false : true).map((contact) => {
               const IconComponent = contact.icon;
@@ -142,7 +142,7 @@ export const Footer: React.FC<FooterProps> = ({ notShowRedirects = false }) => {
                   className={`flex flex-col items-center gap-1 text-[14px] font-normal transition-all hover:scale-110 hover:text-gray-300 cursor-pointer ${contact.className || ""}`}
                 >
                   <IconComponent />
-                  <div className="hidden lg:block">{contact.label}</div>
+                  <div className={`hidden lg:block text-[14px] ${contact.className ? "" : "whitespace-nowrap"}`}>{contact.label}</div>
                 </a>
               );
             })}

--- a/apps/portal-web/src/features/footer/Footer.tsx
+++ b/apps/portal-web/src/features/footer/Footer.tsx
@@ -95,12 +95,7 @@ export const Footer: React.FC<FooterProps> = ({ notShowRedirects = false }) => {
       <div className="flex justify-end flex-col gap-6 h-full p-8 lg:px-40 lg:py-20 z-10 relative">
         {/* Logo section */}
         <div className="flex flex-col lg:flex-row gap-6 lg:gap-10 lg:items-center">
-          <h1 className="text-3xl lg:text-header-3">Cashin</h1>
-          <div className="flex gap-6 lg:gap-10">
-            <Investors />
-            <Tranki />
-            <Listo />
-          </div>
+          <Link href="/"><h1 className="text-3xl lg:text-header-3">Cashin</h1></Link>
         </div>
 
         <div className="border-t border-white border-2"></div>


### PR DESCRIPTION
## Summary
- Align WhoWeAre section bullets (Tecnología, Asesoría humana, Procesos claros) to same vertical level
- Fix footer contact labels wrapping to two lines on smaller screens
- Link all logos to home page (navbar CCI icon, footer Cashin, lead pages)
- Investors logo in navbar links to /invest
- Unify lead pages branding to use CashIn + IconCCI instead of old logo
- Center icons in GetMoney section cards
- Remove extra brand logos (Investors, Tranki, Listo) from footer
- Hide fake hardcoded testimonials section until real reviews available

## Test plan
- [ ] Verify WhoWeAre bullets are vertically aligned on desktop
- [ ] Verify footer labels don't wrap on MacBook-sized screens
- [ ] Verify all logos navigate to correct pages (home, /invest)
- [ ] Verify /leads and /leadinvestor show correct CashIn branding
- [ ] Verify testimonials section is hidden on homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)