### PR TITLE
Enhance investor lookup and API integrations for flexibility

### DIFF
--- a/apps/auth-google/src/routes/cartera.routes.ts
+++ b/apps/auth-google/src/routes/cartera.routes.ts
@@ -97,12 +97,13 @@ carteraRoutes.post("/investor", async (c) => {
 carteraRoutes.get("/investor", async (c) => {
   try {
     const dpi = c.req.query("dpi");
+    const email = c.req.query("email");
 
-    if (!dpi) {
-      throw new HTTPException(400, { message: "El parámetro dpi es requerido" });
+    if (!dpi && !email) {
+      throw new HTTPException(400, { message: "Se requiere dpi o email" });
     }
 
-    const profile = await getInvestorProfile(dpi);
+    const profile = await getInvestorProfile(dpi || "", email || "");
 
     return c.json({
       success: true,
@@ -151,14 +152,15 @@ carteraRoutes.get("/bancos", async (c) => {
 carteraRoutes.get("/liquidaciones", async (c) => {
   try {
     const dpi = c.req.query("dpi");
+    const email = c.req.query("email");
     const page = parseInt(c.req.query("page") || "1", 10);
     const perPage = parseInt(c.req.query("perPage") || "10", 10);
 
-    if (!dpi) {
-      throw new HTTPException(400, { message: "El parámetro dpi es requerido" });
+    if (!dpi && !email) {
+      throw new HTTPException(400, { message: "Se requiere dpi o email" });
     }
 
-    const liquidaciones = await getLiquidaciones(dpi, page, perPage);
+    const liquidaciones = await getLiquidaciones(dpi || "", email || "", page, perPage);
 
     return c.json({
       success: true,
@@ -181,12 +183,13 @@ carteraRoutes.get("/liquidaciones", async (c) => {
 carteraRoutes.get("/investments/stats", async (c) => {
   try {
     const dpi = c.req.query("dpi");
+    const email = c.req.query("email");
 
-    if (!dpi) {
-      throw new HTTPException(400, { message: "El parámetro dpi es requerido" });
+    if (!dpi && !email) {
+      throw new HTTPException(400, { message: "Se requiere dpi o email" });
     }
 
-    const stats = await getInvestmentsStats(dpi);
+    const stats = await getInvestmentsStats(dpi || "", email || "");
 
     return c.json({
       success: true,

--- a/apps/auth-google/src/services/cartera/investments.service.ts
+++ b/apps/auth-google/src/services/cartera/investments.service.ts
@@ -122,6 +122,7 @@ export interface AsesorResponse {
  */
 export const getLiquidaciones = async (
   dpi: string,
+  email: string,
   page: number = 1,
   perPage: number = 10
 ): Promise<LiquidacionesResponse> => {
@@ -130,7 +131,7 @@ export const getLiquidaciones = async (
     const token = await ensureCarteraAuth();
 
     const response = await fetch(
-      `${env.CARTERA_API_URL}/liquidaciones?dpi=${dpi}&page=${page}&perPage=${perPage}`,
+      `${env.CARTERA_API_URL}/liquidaciones?dpi=${dpi}&email=${email}&page=${page}&perPage=${perPage}`,
       {
         headers: {
          // Authorization: `Bearer ${token}`,
@@ -153,13 +154,13 @@ export const getLiquidaciones = async (
 /**
  * Obtener estadísticas de inversiones desde la API de Cartera
  */
-export const getInvestmentsStats = async (dpi: string): Promise<InvestmentsStats> => {
+export const getInvestmentsStats = async (dpi: string, email: string): Promise<InvestmentsStats> => {
   try {
     // Asegurar autenticación
     const token = await ensureCarteraAuth();
 
     const response = await fetch(
-      `${env.CARTERA_API_URL}/inversionistas/rendimiento?dpi=${dpi}`,
+      `${env.CARTERA_API_URL}/inversionistas/rendimiento?dpi=${dpi}&email=${email}`,
       {
         headers: {
           // Authorization: `Bearer ${token}`,

--- a/apps/auth-google/src/services/cartera/investor.service.ts
+++ b/apps/auth-google/src/services/cartera/investor.service.ts
@@ -85,12 +85,12 @@ export const createInvestor = async (
 /**
  * Obtener perfil de inversionista por DPI
  */
-export const getInvestorProfile = async (dpi: string): Promise<InvestorProfile> => {
+export const getInvestorProfile = async (dpi: string, email: string): Promise<InvestorProfile> => {
   try {
     // Asegurar autenticación
     const token = await ensureCarteraAuth();
 
-    const response = await fetch(`${env.CARTERA_API_URL}/investor?dpi=${dpi}`, {
+    const response = await fetch(`${env.CARTERA_API_URL}/investor?dpi=${dpi}&email=${email}`, {
       headers: {
         // Authorization: `Bearer ${token}`,
       },

--- a/apps/crm/apps/server/src/controllers/portal-lead.ts
+++ b/apps/crm/apps/server/src/controllers/portal-lead.ts
@@ -7,7 +7,7 @@ import { opportunityDocuments } from "../db/schema/documents";
 import { generatedLegalContracts } from "../db/schema/legal-contracts";
 import { vehiclePhotos, vehicles } from "../db/schema/vehicles";
 import { getFileUrl, getFileUrlWithBucketInKey } from "../lib/storage";
-import { getRenapInfoController } from "./bot";
+import { getOnlyRenapInfoController } from "./bot";
 import {
 	createOpportunityForLead,
 	getSalesUserWithLeastLeads,
@@ -264,8 +264,7 @@ export async function updateLeadByEmail(c: Context) {
 		// If DPI was updated, call RENAP to get information
 		let renapInfo = null;
 		if (dpi !== undefined && dpi.trim() !== "" && updatedLead) {
-			const phoneToUse = phone ?? existingLead.phone ?? "";
-			renapInfo = await getRenapInfoController(dpi, phoneToUse);
+			renapInfo = await getOnlyRenapInfoController(dpi);
 		}
 
 		return c.json({
@@ -694,8 +693,8 @@ export async function createPortalRegisterLead(c: Context) {
 			.returning();
 
 		let renapInfo = null;
-		if (phone) {
-			renapInfo = await getRenapInfoController(dpi, phone);
+		if (dpi) {
+			renapInfo = await getOnlyRenapInfoController(dpi);
 		}
 
 		const newOpportunity = await createOpportunityForLead(

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { leads, opportunities, salesStages } from "../db/schema/crm";
-import { getRenapInfoController } from "./bot";
+import { getOnlyRenapInfoController } from "./bot";
 
 /**
  * Encuentra al usuario de ventas con menos oportunidades asignadas.
@@ -351,9 +351,7 @@ export async function createPublicLead(c: Context) {
 
 		// RENAP solo si tiene DPI y teléfono
 		const renapInfo =
-			hasDpi && body.phone
-				? await getRenapInfoController(body.dpi, body.phone)
-				: null;
+			hasDpi ? await getOnlyRenapInfoController(body.dpi) : null;
 
 		const opportunity = await createOpportunityForLead(
 			newLead.id,

--- a/apps/portal-web/src/features/Profile/MyInvestments/MyInvestments.tsx
+++ b/apps/portal-web/src/features/Profile/MyInvestments/MyInvestments.tsx
@@ -30,7 +30,7 @@ export const MyInvestments = () => {
   // Obtener estadísticas usando DPI del perfil
   const { data: stats, isLoading: loadingStats } = useQuery({
     queryKey: ["investments-stats", user?.dpi],
-    queryFn: () => getInvestmentsStats(user?.dpi || ""),
+    queryFn: () => getInvestmentsStats(user?.dpi || "", user?.email || ""),
     enabled: !!user?.dpi,
   });
 
@@ -42,7 +42,7 @@ export const MyInvestments = () => {
   } = useQuery({
     queryKey: ["liquidaciones", user?.dpi, currentPage, perPage],
     queryFn: () =>
-      getLiquidaciones(user?.dpi || "", currentPage, perPage),
+      getLiquidaciones(user?.dpi || "", user?.email || "", currentPage, perPage),
     enabled: !!user?.dpi,
   });
 

--- a/apps/portal-web/src/features/Profile/MyProfile/InfoPerson.tsx
+++ b/apps/portal-web/src/features/Profile/MyProfile/InfoPerson.tsx
@@ -52,7 +52,7 @@ export const InfoPerson = () => {
     refetch: refetchInvestor,
   } = useQuery({
     queryKey: ["investor-profile", user?.dpi],
-    queryFn: () => getInvestorProfile(user?.dpi || ""),
+    queryFn: () => getInvestorProfile(user?.dpi || "", user?.email || ""),
     enabled: !!user?.dpi && isInvestor,
   });
 

--- a/apps/portal-web/src/features/Profile/services/investmentsService.ts
+++ b/apps/portal-web/src/features/Profile/services/investmentsService.ts
@@ -78,6 +78,7 @@ export interface LiquidacionesResponse {
  */
 export const getLiquidaciones = async (
   dpi: string,
+  email: string,
   page: number = 1,
   perPage: number = 10
 ): Promise<LiquidacionesResponse> => {
@@ -90,7 +91,7 @@ export const getLiquidaciones = async (
       totalItems: number;
       totalPages: number;
     }>(
-      `/api/cartera/liquidaciones?dpi=${encodeURIComponent(dpi)}&page=${page}&perPage=${perPage}`
+      `/api/cartera/liquidaciones?dpi=${encodeURIComponent(dpi)}&email=${encodeURIComponent(email)}&page=${page}&perPage=${perPage}`
     );
 
     const result = response.data;
@@ -155,10 +156,10 @@ export interface InvestmentsStatsResponse {
 /**
  * Obtener estadísticas de inversiones desde la API de Cartera
  */
-export const getInvestmentsStats = async (dpi: string): Promise<InvestmentsStats> => {
+export const getInvestmentsStats = async (dpi: string, email: string): Promise<InvestmentsStats> => {
   try {
     const response = await apiAuth.get<InvestmentsStatsResponse>(
-      `/api/cartera/investments/stats?dpi=${encodeURIComponent(dpi)}`
+      `/api/cartera/investments/stats?dpi=${encodeURIComponent(dpi)}&email=${encodeURIComponent(email)}`
     );
     return response.data.data;
   } catch (error) {

--- a/apps/portal-web/src/features/Profile/services/investorService.ts
+++ b/apps/portal-web/src/features/Profile/services/investorService.ts
@@ -62,11 +62,12 @@ export const createInvestor = async (
  * Obtener perfil de inversionista por DPI
  */
 export const getInvestorProfile = async (
-  dpi: string
+  dpi: string,
+  email: string
 ): Promise<InvestorProfile> => {
   try {
     const response = await apiAuth.get<{ data: InvestorProfile }>(
-      `/api/cartera/investor?dpi=${encodeURIComponent(dpi)}`
+      `/api/cartera/investor?dpi=${encodeURIComponent(dpi)}&email=${encodeURIComponent(email)}`
     );
     return response.data.data;
   } catch (error) {


### PR DESCRIPTION
This pull request introduces support for querying investor information, liquidations, and investment statistics using either a user's DPI or email across both backend and frontend. The main goal is to make endpoints and services more flexible and robust by allowing queries with either identifier, and to propagate these changes through all layers of the application.

**API and Service Enhancements:**

* Updated backend route handlers in `cartera.routes.ts` to accept both `dpi` and `email` as query parameters for investor profile, liquidations, and investment stats endpoints, including validation and service calls. [[1]](diffhunk://#diff-ad0d8ee5f2787e2cff86e1d375f8d1ff73e73db1af7ea9fbf9886c6e4fae4679R100-R106) [[2]](diffhunk://#diff-ad0d8ee5f2787e2cff86e1d375f8d1ff73e73db1af7ea9fbf9886c6e4fae4679R155-R163) [[3]](diffhunk://#diff-ad0d8ee5f2787e2cff86e1d375f8d1ff73e73db1af7ea9fbf9886c6e4fae4679R186-R192)
* Modified backend service functions (`getInvestorProfile`, `getLiquidaciones`, `getInvestmentsStats`) to accept and use both `dpi` and `email` parameters in API requests to the Cartera service. [[1]](diffhunk://#diff-28dea5c6ce4c3ec6a52b25cedf61bdcdb5dc6fa6bbe9c7897c56c14fc6692a7bL88-R93) [[2]](diffhunk://#diff-a49ccec9bb5fbcfe66efe8d8b79d8ce566f1d5ce1a5e2c5b3dd81a6248212974R125) [[3]](diffhunk://#diff-a49ccec9bb5fbcfe66efe8d8b79d8ce566f1d5ce1a5e2c5b3dd81a6248212974L156-R163) [[4]](diffhunk://#diff-a49ccec9bb5fbcfe66efe8d8b79d8ce566f1d5ce1a5e2c5b3dd81a6248212974L133-R134)

**Frontend Integration:**

* Updated frontend service functions and React hooks to pass both `dpi` and `email` when fetching investor profile, liquidations, and investment stats, ensuring compatibility with the new backend API. [[1]](diffhunk://#diff-dce3a02066a659d3ceaba5e008d1315439c9b289da1024cbdba5a595ef5a7474L65-R70) [[2]](diffhunk://#diff-423ac9d6f09117d84d6eabd2b14f5794354eb524ddab0f71749c091dceeb628bR81) [[3]](diffhunk://#diff-423ac9d6f09117d84d6eabd2b14f5794354eb524ddab0f71749c091dceeb628bL158-R162) [[4]](diffhunk://#diff-423ac9d6f09117d84d6eabd2b14f5794354eb524ddab0f71749c091dceeb628bL93-R94) [[5]](diffhunk://#diff-b33ecc2650e416e39c44e535878708b11e4432d44aafda2b1db16f97d453a35eL33-R33) [[6]](diffhunk://#diff-b33ecc2650e416e39c44e535878708b11e4432d44aafda2b1db16f97d453a35eL45-R45) [[7]](diffhunk://#diff-b8a29753959b229b6410456c1b141f716a13a65d7231dc2a54e3ed873fe0a9baL55-R55)

**CRM Lead Controller Refactoring:**

* Replaced usage of `getRenapInfoController` with the new `getOnlyRenapInfoController` in CRM lead controllers, simplifying RENAP info retrieval to only require DPI. [[1]](diffhunk://#diff-980eca6ad5e4151e94b39896019b552d367e012fc718eeef75929d99ef14e438L10-R10) [[2]](diffhunk://#diff-980eca6ad5e4151e94b39896019b552d367e012fc718eeef75929d99ef14e438L267-R267) [[3]](diffhunk://#diff-980eca6ad5e4151e94b39896019b552d367e012fc718eeef75929d99ef14e438L697-R697) [[4]](diffhunk://#diff-52ca4a8c810d1c4e7997b0a12b7ef12c246a51ab12fca183d47b05da8646f5eeL6-R6) [[5]](diffhunk://#diff-52ca4a8c810d1c4e7997b0a12b7ef12c246a51ab12fca183d47b05da8646f5eeL354-R354)