### PR TITLE
Clean up unused imports and remove investor summary filter

### DIFF
--- a/apps/crm/apps/server/src/routers/accounting.ts
+++ b/apps/crm/apps/server/src/routers/accounting.ts
@@ -4,11 +4,7 @@ import { carteraBackClient } from "../services/cartera-back-client";
 
 export const accountingRouter = {
 	getResumenGlobalInversionistas: crmProcedure.handler(async () => {
-		const data = await carteraBackClient.getResumenGlobalInversionistas();
-		return data.filter(
-			(item: { total_a_recibir_con_reinversion: string }) =>
-				Number(item.total_a_recibir_con_reinversion) > 0,
-		);
+		return await carteraBackClient.getResumenGlobalInversionistas()
 	}),
 
 	createBoleta: crmProcedure

--- a/apps/portal-web/src/features/HomePage/HomePage.tsx
+++ b/apps/portal-web/src/features/HomePage/HomePage.tsx
@@ -1,5 +1,5 @@
 import { NavBar } from "@components/ui";
-import { CarrouselStart, HowItWorks, Testimonies, GraphLine } from "./sections";
+import { CarrouselStart, HowItWorks, GraphLine } from "./sections";
 import { WhoWeAre } from "./sections/whoWeAre/WhoWeAre";
 import { HowSellOrBuy } from "./sections/howSellOrBuy/HowSellOrBuy";
 

--- a/apps/portal-web/src/features/footer/Footer.tsx
+++ b/apps/portal-web/src/features/footer/Footer.tsx
@@ -1,8 +1,5 @@
 import Map from "./assets/Map.png";
 import {
-  InvestorsLogo as Investors,
-  Tranki,
-  Listo,
   Facebook,
   Instagram,
   Linkedin,


### PR DESCRIPTION
This pull request includes minor updates to both backend and frontend code, focusing on simplifying data handling and cleaning up unused imports.

Backend data handling:

* Simplified the `getResumenGlobalInversionistas` method in the `accountingRouter` by removing client-side filtering and returning the raw data from `carteraBackClient`.

Frontend code cleanup:

* Removed the unused `Testimonies` section import from `HomePage.tsx` to streamline the homepage code.
* Removed unused logo imports from `Footer.tsx` to reduce clutter and improve maintainability.