### PR TITLE
Enhances investor search and summary logic

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -343,7 +343,17 @@ export const insertInvestor = async ({ body, set }: any) => {
         existente = result[0] || null;
       }
 
-      // Si no lo encontro por DPI, buscar por nombre
+      // Si no lo encontro por DPI, buscar por email
+      if (!existente && inv.email?.trim()) {
+        const result = await db
+          .select()
+          .from(inversionistas)
+          .where(eq(inversionistas.email, inv.email.trim().toLowerCase()))
+          .limit(1);
+        existente = result[0] || null;
+      }
+
+      // Si no lo encontro por email, buscar por nombre
       if (!existente && inv.nombre?.trim()) {
         const result = await db
           .select()
@@ -3171,7 +3181,15 @@ export async function resumenGlobalInversionistas(
         WHEN 'reinversion_total' THEN COALESCE(SUM(${pe.abono_capital} + ${pe.abono_interes}), 0)
         WHEN 'reinversion_variable' THEN LEAST(
           COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
-          COALESCE(SUM(${pe.abono_capital} + ${pe.abono_interes}), 0)
+          COALESCE(SUM(
+            ${pe.abono_capital}
+            + ${pe.abono_interes}
+            + CASE
+                WHEN ${inversionistas.emite_factura}
+                  THEN ${pe.abono_iva_12}
+                ELSE -(${pe.abono_interes} * 0.07)
+              END
+          ), 0)
         )
         ELSE 0
       END`,
@@ -3194,7 +3212,15 @@ export async function resumenGlobalInversionistas(
             WHEN 'reinversion_total' THEN COALESCE(SUM(${pe.abono_capital} + ${pe.abono_interes}), 0)
             WHEN 'reinversion_variable' THEN LEAST(
               COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
-              COALESCE(SUM(${pe.abono_capital} + ${pe.abono_interes}), 0)
+              COALESCE(SUM(
+                ${pe.abono_capital}
+                + ${pe.abono_interes}
+                + CASE
+                    WHEN ${inversionistas.emite_factura}
+                      THEN ${pe.abono_iva_12}
+                    ELSE -(${pe.abono_interes} * 0.07)
+                  END
+              ), 0)
             )
             ELSE 0
           END`,

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -472,6 +472,16 @@ export const getInvestors = async ({ query, set }: any) => {
         ? result[0]
         : { message: "Inversionista no encontrado" };
     }
+    if(query.email){  
+      const result = await db
+        .select()
+        .from(inversionistas)
+        .where(eq(inversionistas.email, query.email));
+      set.status = result.length ? 200 : 404;
+      return result.length
+        ? result[0]
+        : { message: "Inversionista no encontrado con ese email" };
+    }
 
     // Buscar por DPI
     if (query.dpi) {
@@ -3110,32 +3120,38 @@ export async function resumenGlobalInversionistas(
 ): Promise<
   InversionistaResumen[] | { success: boolean; url: string; filename: string }
 > {
-  // 🔎 Condiciones dinámicas — ahora sobre tablas ESPEJO
-  const condiciones: any[] = [
-    eq(pagos_credito_inversionistas_espejo.estado_liquidacion, "NO_LIQUIDADO"),
+  // 🔎 Condiciones sobre inversionistas (van en WHERE)
+  const condicionesWhere: any[] = [
     eq(inversionistas.permite_distribucion, false) // Solo inversionistas que NO permiten distribución (es decir, que se les paga directamente)
   ];
 
   if (inversionistaId) {
-    condiciones.push(
-      eq(pagos_credito_inversionistas_espejo.inversionista_id, inversionistaId)
+    condicionesWhere.push(
+      eq(inversionistas.inversionista_id, inversionistaId)
     );
   }
 
+  // 🔎 Condiciones sobre pagos espejo (van en el ON del LEFT JOIN)
+  const pe = pagos_credito_inversionistas_espejo; // alias corto
+
+  const condicionesJoinPagos: any[] = [
+    eq(inversionistas.inversionista_id, pe.inversionista_id),
+    eq(pe.estado_liquidacion, "NO_LIQUIDADO"),
+  ];
+
   if (mes) {
-    condiciones.push(
-      sql`EXTRACT(MONTH FROM ${pagos_credito_inversionistas_espejo.fecha_pago}) = ${mes}`
+    condicionesJoinPagos.push(
+      sql`EXTRACT(MONTH FROM ${pe.fecha_pago}) = ${mes}`
     );
   }
 
   if (anio) {
-    condiciones.push(
-      sql`EXTRACT(YEAR FROM ${pagos_credito_inversionistas_espejo.fecha_pago}) = ${anio}`
+    condicionesJoinPagos.push(
+      sql`EXTRACT(YEAR FROM ${pe.fecha_pago}) = ${anio}`
     );
   }
 
   // 📊 Query agregada usando tablas ESPEJO (misma lógica que getInvestorMirrorSummary)
-  const pe = pagos_credito_inversionistas_espejo; // alias corto
 
   const result = await db
     .select({
@@ -3232,9 +3248,9 @@ export async function resumenGlobalInversionistas(
     )
     .leftJoin(
       pe,
-      eq(inversionistas.inversionista_id, pe.inversionista_id)
+      and(...condicionesJoinPagos)
     )
-    .where(and(...condiciones))
+    .where(and(...condicionesWhere))
     .groupBy(
       inversionistas.inversionista_id,
       inversionistas.nombre,
@@ -3252,6 +3268,9 @@ export async function resumenGlobalInversionistas(
         ? undefined
         : sql`COUNT(${pe.id}) > 0`
     );
+
+  console.log("resumen-global result IDs:", result.map(r => r.inversionista_id));
+  console.log("resumen-global total:", result.length, "inversionistas");
 
   // 📂 Si excel = true → generar archivo, subir a R2 y devolver URL
   if (excel) {
@@ -3436,12 +3455,14 @@ export async function getLiquidaciones({
   inversionista_id,
   liquidacion_id,
   dpi,
+  email,
   page = 1,
   perPage = 10,
 }: {
   inversionista_id?: number;
   liquidacion_id?: number;
   dpi?: string;
+  email?: string;
   page?: number;
   perPage?: number;
 }) {
@@ -3468,6 +3489,9 @@ export async function getLiquidaciones({
   if (dpi) {
     conditions.push(eq(inversionistas.dpi, parseInt(dpi)));
   }
+  if (email) {
+    conditions.push(eq(inversionistas.email, email));
+  }
 
   // 📊 Query principal con joins
   const query = db
@@ -3491,6 +3515,7 @@ export async function getLiquidaciones({
       nombre_inversionista: inversionistas.nombre,
       emite_factura: inversionistas.emite_factura,
       dpi: inversionistas.dpi,
+      email: inversionistas.email,
     })
     .from(liquidaciones)
     .leftJoin(

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -484,7 +484,7 @@ export const inversionistasRouter = new Elysia()
     "/liquidaciones",
     async ({ query, set }) => {
       try {
-        const { inversionista_id, liquidacion_id, dpi, page, perPage } = query;
+        const { inversionista_id, liquidacion_id, dpi,email, page, perPage } = query;
 
         const result = await getLiquidaciones({
           inversionista_id: inversionista_id
@@ -492,6 +492,7 @@ export const inversionistasRouter = new Elysia()
             : undefined,
           liquidacion_id: liquidacion_id ? Number(liquidacion_id) : undefined,
           dpi: dpi || undefined,
+          email: email || undefined,
           page: page ? Number(page) : 1,
           perPage: perPage ? Number(perPage) : 10,
         });
@@ -512,6 +513,7 @@ export const inversionistasRouter = new Elysia()
         inversionista_id: t.Optional(t.String()),
         liquidacion_id: t.Optional(t.String()),
         dpi: t.Optional(t.String()),
+        email: t.Optional(t.String()),
         page: t.Optional(t.String()),
         perPage: t.Optional(t.String()),
       }),


### PR DESCRIPTION
Adds the ability to search for investors by email:
- Implements email-based lookup in the `getInvestors` controller.
- Extends the `getLiquidaciones` function and its router endpoint to allow filtering liquidations by investor email.

Refactors the `resumenGlobalInversionistas` query:
- Improves the application of conditional logic for aggregated investor summaries.
- Moves conditions related to mirrored payment records from the main `WHERE` clause to the `ON` clause of the `LEFT JOIN` for better query accuracy.