### PR TITLE
Decouples profile features from strict DPI dependency

### DIFF
--- a/apps/portal-web/src/features/Profile/MyInvestments/MyInvestments.tsx
+++ b/apps/portal-web/src/features/Profile/MyInvestments/MyInvestments.tsx
@@ -27,11 +27,11 @@ export const MyInvestments = () => {
   const { isModalOpen, modalOptionsInvestors, setIsModalOpen } =
     useModalOptionsCall();
 
-  // Obtener estadísticas usando DPI del perfil
+  // Obtener estadísticas usando email o DPI del perfil
   const { data: stats, isLoading: loadingStats } = useQuery({
-    queryKey: ["investments-stats", user?.dpi],
+    queryKey: ["investments-stats", user?.id],
     queryFn: () => getInvestmentsStats(user?.dpi || "", user?.email || ""),
-    enabled: !!user?.dpi,
+    enabled: !!user?.id,
   });
 
   // Obtener liquidaciones con paginación
@@ -40,10 +40,10 @@ export const MyInvestments = () => {
     isLoading: loadingLiquidaciones,
     isFetching: fetchingLiquidaciones,
   } = useQuery({
-    queryKey: ["liquidaciones", user?.dpi, currentPage, perPage],
+    queryKey: ["liquidaciones", user?.id, currentPage, perPage],
     queryFn: () =>
       getLiquidaciones(user?.dpi || "", user?.email || "", currentPage, perPage),
-    enabled: !!user?.dpi,
+    enabled: !!user?.id,
   });
 
   // Solo mostrar loading de página completa en la carga inicial

--- a/apps/portal-web/src/features/Profile/MyProfile/InfoPerson.tsx
+++ b/apps/portal-web/src/features/Profile/MyProfile/InfoPerson.tsx
@@ -318,6 +318,8 @@ export const InfoPerson = () => {
                   onChange={(value) => setTipoCuenta(value)}
                   options={[
                     { value: "MONETARIA", label: "Monetaria" },
+                    { value: "MONETARIA Q", label: "Monetaria Q" },
+                    { value: "MONETARIA $", label: "Monetaria $" },
                     { value: "AHORRO", label: "Ahorro" },
                   ]}
                   placeholder="Selecciona tipo de cuenta"

--- a/apps/portal-web/src/features/Profile/MyProfile/InfoPerson.tsx
+++ b/apps/portal-web/src/features/Profile/MyProfile/InfoPerson.tsx
@@ -51,9 +51,9 @@ export const InfoPerson = () => {
     isLoading: isLoadingInvestor,
     refetch: refetchInvestor,
   } = useQuery({
-    queryKey: ["investor-profile", user?.dpi],
+    queryKey: ["investor-profile", user?.id],
     queryFn: () => getInvestorProfile(user?.dpi || "", user?.email || ""),
-    enabled: !!user?.dpi && isInvestor,
+    enabled: !!user?.id && isInvestor,
   });
 
   // Obtener catálogo de bancos - solo si es INVESTOR

--- a/apps/portal-web/src/features/Profile/MyProfile/ModalConfirmChange.tsx
+++ b/apps/portal-web/src/features/Profile/MyProfile/ModalConfirmChange.tsx
@@ -51,11 +51,12 @@ export const ModalConfirmChange = ({
       const dpi = user?.dpi;
 
       // Si es campo de inversionista, actualizar en Cartera
-      if (isInvestorField) {
-        if (!dpi) throw new Error("DPI no disponible");
+      if (isInvestorField || user?.role === "INVESTOR") {
+       // if (!dpi) throw new Error("DPI no disponible");
 
         const payload: any = {
-          dpi: parseInt(dpi),
+          dpi: dpi ? parseInt(dpi) : undefined,
+          email,
         };
 
         // Solo enviar el campo que se está actualizando

--- a/apps/portal-web/src/features/Profile/MyProfile/Profile.tsx
+++ b/apps/portal-web/src/features/Profile/MyProfile/Profile.tsx
@@ -1,24 +1,23 @@
 import { NavBar } from "@components/ui";
 import { InfoPerson } from "./InfoPerson";
-import { CompleteProfileForm } from "./CompleteProfileForm";
 import { ContainerMenu } from "../components/ContainerMenu";
 import { useProfile } from "../hooks/useProfile";
-import { useState } from "react";
+//import { useState } from "react";
 
 export const Profile = () => {
   const { user, isLoading } = useProfile();
-  const [isCompletingProfile, setIsCompletingProfile] = useState(false);
+  //const [isCompletingProfile, setIsCompletingProfile] = useState(false);
 
-  const needsProfileCompletion = !user?.dpi && !isCompletingProfile;
+  /*const needsProfileCompletion = !user?.dpi && !isCompletingProfile;
 
   const handleProfileCompleted = () => {
     // Activar estado de carga antes de recargar
     setIsCompletingProfile(true);
     // Recargar la página para actualizar el contexto de autenticación
     window.location.reload();
-  };
+  };*/
 
-  if (isLoading || isCompletingProfile) {
+  if (isLoading) {
     return (
       <div>
         <div className="w-full mt-4 ">
@@ -41,11 +40,7 @@ export const Profile = () => {
         <NavBar />
         <ContainerMenu>
           {/* Si necesita completar perfil, mostrar formulario especial */}
-          {needsProfileCompletion ? (
-            <div className="py-12">
-              <CompleteProfileForm onSuccess={handleProfileCompleted} />
-            </div>
-          ) : (
+          
             <>
               {/* Header - Mi Perfil */}
               <div className="mb-12">
@@ -83,7 +78,7 @@ export const Profile = () => {
                 </div>
               )}
             </>
-          )}
+        
         </ContainerMenu>
       </div>
     </div>

--- a/apps/portal-web/src/features/Profile/components/Menu.tsx
+++ b/apps/portal-web/src/features/Profile/components/Menu.tsx
@@ -61,9 +61,7 @@ export const Menu = () => {
   );
 
   // Si no tiene DPI, solo mostrar "Mi Perfil"
-  const displayItems = !user?.dpi
-    ? menuItems.filter((item) => item.id === "/profile")
-    : menuItems;
+  const displayItems = menuItems;
 
   return (
     <div

--- a/apps/portal-web/src/features/Profile/services/documentsService.ts
+++ b/apps/portal-web/src/features/Profile/services/documentsService.ts
@@ -131,7 +131,7 @@ export interface ContractsResponse {
  */
 export const getPersonalDocuments = async (
   email: string,
-  dpi: string
+  dpi: string = ""
 ): Promise<Document[]> => {
   try {
     const response = await apiAuth.get<DocumentsResponse>(
@@ -151,7 +151,7 @@ export const getPersonalDocuments = async (
  */
 export const getContracts = async (
   email: string,
-  dpi: string
+  dpi: string = ""
 ): Promise<Contract[]> => {
   try {
     const response = await apiAuth.get<ContractsResponse>(

--- a/apps/portal-web/src/features/Profile/services/investmentsService.ts
+++ b/apps/portal-web/src/features/Profile/services/investmentsService.ts
@@ -77,8 +77,8 @@ export interface LiquidacionesResponse {
  * Obtener liquidaciones del inversionista por DPI con paginación
  */
 export const getLiquidaciones = async (
-  dpi: string,
-  email: string,
+  dpi: string = "",
+  email: string = "",
   page: number = 1,
   perPage: number = 10
 ): Promise<LiquidacionesResponse> => {
@@ -156,7 +156,7 @@ export interface InvestmentsStatsResponse {
 /**
  * Obtener estadísticas de inversiones desde la API de Cartera
  */
-export const getInvestmentsStats = async (dpi: string, email: string): Promise<InvestmentsStats> => {
+export const getInvestmentsStats = async (dpi: string = "", email: string = ""): Promise<InvestmentsStats> => {
   try {
     const response = await apiAuth.get<InvestmentsStatsResponse>(
       `/api/cartera/investments/stats?dpi=${encodeURIComponent(dpi)}&email=${encodeURIComponent(email)}`

--- a/apps/portal-web/src/features/Profile/services/investorService.ts
+++ b/apps/portal-web/src/features/Profile/services/investorService.ts
@@ -7,7 +7,7 @@ import apiAuth from "@/lib/api/apiAuth";
 // Interfaces
 export interface CreateInvestorPayload {
   nombre?: string;
-  dpi: number;
+  dpi?: number;
   email?: string;
   emite_factura?: boolean;
   tipo_reinversion: string;
@@ -62,8 +62,8 @@ export const createInvestor = async (
  * Obtener perfil de inversionista por DPI
  */
 export const getInvestorProfile = async (
-  dpi: string,
-  email: string
+  dpi: string = "",
+  email: string = ""
 ): Promise<InvestorProfile> => {
   try {
     const response = await apiAuth.get<{ data: InvestorProfile }>(

--- a/apps/portal-web/src/features/Profile/services/profileService.ts
+++ b/apps/portal-web/src/features/Profile/services/profileService.ts
@@ -70,7 +70,7 @@ export interface UpdateLeadPayload {
  */
 export const getProfile = async (
   email: string,
-  dpi: string
+  dpi: string = ""
 ): Promise<ProfileData> => {
   try {
     const response = await apiAuth.get<{ data: ProfileData }>(
@@ -112,7 +112,7 @@ export const updateLead = async (
 
 export const getNumbersSifco = async (
   email: string,
-  dpi: string
+  dpi: string = ""
 ): Promise<Opportunity[]> => {
   try {
     const response = await apiAuth.get<{ data: Opportunity[] }>(

--- a/apps/portal-web/src/features/Profile/services/unifiedService.ts
+++ b/apps/portal-web/src/features/Profile/services/unifiedService.ts
@@ -11,7 +11,7 @@ export interface RegisterExternalUserPayload {
   userType: UserType;
   fullName: string;
   email: string;
-  dpi: string;
+  dpi?: string;
   phone?: string;
 }
 


### PR DESCRIPTION
This pull request updates the profile and investments features to consistently use `user.id` (or email) instead of `user.dpi` as the primary identifier for API queries and UI logic. It also improves API service functions by making the `dpi` parameter optional, which enhances flexibility for users who may not have a DPI. Additionally, code related to enforcing profile completion based on DPI has been removed, simplifying the user experience for those without a DPI.

**Identifier and Query Logic Updates:**

- Updated all relevant queries in `MyInvestments.tsx` and `InfoPerson.tsx` to use `user.id` (or email) instead of `user.dpi` for query keys and enabled conditions, ensuring users without a DPI can still access their data. [[1]](diffhunk://#diff-b33ecc2650e416e39c44e535878708b11e4432d44aafda2b1db16f97d453a35eL30-R34) [[2]](diffhunk://#diff-b33ecc2650e416e39c44e535878708b11e4432d44aafda2b1db16f97d453a35eL43-R46) [[3]](diffhunk://#diff-b8a29753959b229b6410456c1b141f716a13a65d7231dc2a54e3ed873fe0a9baL54-R56)

**Profile Completion and Menu Display Simplification:**

- Removed the logic in `Profile.tsx` and `Menu.tsx` that enforced profile completion and limited menu items based on the presence of a DPI, allowing all users to access their profile and menu options regardless of DPI status. [[1]](diffhunk://#diff-684885738b38b60f2b9260a8e443c5b3c6ccc2d6071636293bd786d2ca3a5986L3-R20) [[2]](diffhunk://#diff-684885738b38b60f2b9260a8e443c5b3c6ccc2d6071636293bd786d2ca3a5986L44-R43) [[3]](diffhunk://#diff-684885738b38b60f2b9260a8e443c5b3c6ccc2d6071636293bd786d2ca3a5986L86-R81) [[4]](diffhunk://#diff-8617647b05f7a7dc869db5d37b08785ab13b259df65bdaef58865883cc6a602cL64-R64)

**API Service Improvements:**

- Made the `dpi` parameter optional (defaulting to an empty string) in all profile, investor, investments, and documents service functions, supporting API calls for users who may not have a DPI. [[1]](diffhunk://#diff-375c2dd8dfcb3c61c4c3583aed213c56e923c422971810907b45963f00307e62L134-R134) [[2]](diffhunk://#diff-375c2dd8dfcb3c61c4c3583aed213c56e923c422971810907b45963f00307e62L154-R154) [[3]](diffhunk://#diff-423ac9d6f09117d84d6eabd2b14f5794354eb524ddab0f71749c091dceeb628bL80-R81) [[4]](diffhunk://#diff-423ac9d6f09117d84d6eabd2b14f5794354eb524ddab0f71749c091dceeb628bL159-R159) [[5]](diffhunk://#diff-dce3a02066a659d3ceaba5e008d1315439c9b289da1024cbdba5a595ef5a7474L65-R66) [[6]](diffhunk://#diff-5acffde5a094cf4ded93578218d45d4d2746d8fd45c7852157afe05c3c1ebdb8L73-R73) [[7]](diffhunk://#diff-5acffde5a094cf4ded93578218d45d4d2746d8fd45c7852157afe05c3c1ebdb8L115-R115)

**Interface Adjustments:**

- Updated the `CreateInvestorPayload` and `RegisterExternalUserPayload` interfaces to make `dpi` optional, reflecting the new logic that does not require DPI for all users. [[1]](diffhunk://#diff-dce3a02066a659d3ceaba5e008d1315439c9b289da1024cbdba5a595ef5a7474L10-R10) [[2]](diffhunk://#diff-620e7638164e6f78eee4e7b2d7f2fa93d908a7478a4b14b6971d3c4f365757a6L14-R14)