### PR TITLE
feat(crm): filtros por fecha y fuente en oportunidades

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -861,6 +861,25 @@ export const crmRouter = {
 					// Filtro por mes/año para alinear con dashboard
 					month: z.number().min(1).max(12).optional(),
 					year: z.number().optional(),
+					// NEW: Filtro por fecha de creación
+					createdMonth: z.number().min(1).max(12).optional(),
+					createdYear: z.number().optional(),
+					// NEW: Filtro por fuente/medio
+					source: z
+						.enum([
+							"website",
+							"referral",
+							"cold_call",
+							"email",
+							"social_media",
+							"event",
+							"other",
+							"facebook",
+							"instagram",
+							"google",
+							"Whatsapp",
+						])
+						.optional(),
 				})
 				.optional(),
 		)
@@ -902,6 +921,7 @@ export const crmRouter = {
 				membresiaPago: opportunities.membresiaPago,
 				inversionistas: opportunities.inversionistas,
 				asesorId: opportunities.asesorId,
+				source: opportunities.source,
 				rubros: opportunities.rubros,
 				loanPurpose: opportunities.loanPurpose,
 				company: {
@@ -987,6 +1007,27 @@ export const crmRouter = {
 				conditions.push(
 					not(inArray(opportunities.status, input.excludeStatuses)),
 				);
+			}
+
+			// Filtro por fuente/medio de la oportunidad
+			if (input?.source) {
+				conditions.push(eq(opportunities.source, input.source));
+			}
+
+			// Filtro por mes/año de creación de la oportunidad
+			if (input?.createdMonth && input?.createdYear) {
+				const createdStart = new Date(
+					input.createdYear,
+					input.createdMonth - 1,
+					1,
+				);
+				const createdEnd = new Date(
+					input.createdYear,
+					input.createdMonth,
+					1,
+				);
+				conditions.push(gte(opportunities.createdAt, createdStart));
+				conditions.push(lt(opportunities.createdAt, createdEnd));
 			}
 
 			// Filtros de stage/fecha solo aplican cuando se pasan month/year explícitamente

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -356,6 +356,13 @@ function RouteComponent() {
 	const [showLostOpportunities, setShowLostOpportunities] = useState(false);
 	const [boardSearch, setBoardSearch] = useState("");
 	const [salespersonFilter, setSalespersonFilter] = useState<string>("all");
+	const [sourceFilter, setSourceFilter] = useState<string>("all");
+	const [createdMonth, setCreatedMonth] = useState(
+		() => new Date().getMonth() + 1,
+	);
+	const [createdYear, setCreatedYear] = useState(() =>
+		new Date().getFullYear(),
+	);
 	const debouncedBoardSearch = useDeferredValue(boardSearch);
 	// View toggle: "kanban" or "table" - persist in localStorage
 	const [viewMode, setViewMode] = useState<"kanban" | "table">(() => {
@@ -681,6 +688,9 @@ function RouteComponent() {
 				excludeStatuses: ["migrate"],
 				month,
 				year,
+				...(sourceFilter !== "all" ? { source: sourceFilter as any } : {}),
+				createdMonth,
+				createdYear,
 			},
 		}),
 		enabled:
@@ -693,6 +703,9 @@ function RouteComponent() {
 			userProfile.data?.role,
 			month,
 			year,
+			sourceFilter,
+			createdMonth,
+			createdYear,
 		],
 	});
 	const salesStagesQuery = useQuery({
@@ -1515,6 +1528,64 @@ function RouteComponent() {
 							))}
 						</SelectContent>
 					</Select>
+					<Select value={sourceFilter} onValueChange={setSourceFilter}>
+						<SelectTrigger className="w-52">
+							<Filter className="mr-2 h-4 w-4" />
+							<SelectValue placeholder="Filtrar por fuente" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">Todas las Fuentes</SelectItem>
+							<SelectItem value="facebook">Facebook</SelectItem>
+							<SelectItem value="instagram">Instagram</SelectItem>
+							<SelectItem value="google">Google</SelectItem>
+							<SelectItem value="Whatsapp">WhatsApp</SelectItem>
+							<SelectItem value="website">Sitio Web</SelectItem>
+							<SelectItem value="referral">Referencia</SelectItem>
+							<SelectItem value="cold_call">Llamada en Frío</SelectItem>
+							<SelectItem value="email">Correo Electrónico</SelectItem>
+							<SelectItem value="social_media">Redes Sociales</SelectItem>
+							<SelectItem value="event">Evento</SelectItem>
+							<SelectItem value="other">Otro</SelectItem>
+						</SelectContent>
+					</Select>
+					<div className="flex items-center gap-1">
+						<Select
+							value={String(createdMonth)}
+							onValueChange={(v) => setCreatedMonth(Number(v))}
+						>
+							<SelectTrigger className="w-36">
+								<Calendar className="mr-2 h-4 w-4" />
+								<SelectValue placeholder="Mes" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="1">Enero</SelectItem>
+								<SelectItem value="2">Febrero</SelectItem>
+								<SelectItem value="3">Marzo</SelectItem>
+								<SelectItem value="4">Abril</SelectItem>
+								<SelectItem value="5">Mayo</SelectItem>
+								<SelectItem value="6">Junio</SelectItem>
+								<SelectItem value="7">Julio</SelectItem>
+								<SelectItem value="8">Agosto</SelectItem>
+								<SelectItem value="9">Septiembre</SelectItem>
+								<SelectItem value="10">Octubre</SelectItem>
+								<SelectItem value="11">Noviembre</SelectItem>
+								<SelectItem value="12">Diciembre</SelectItem>
+							</SelectContent>
+						</Select>
+						<Select
+							value={String(createdYear)}
+							onValueChange={(v) => setCreatedYear(Number(v))}
+						>
+							<SelectTrigger className="w-24">
+								<SelectValue placeholder="Año" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="2025">2025</SelectItem>
+								<SelectItem value="2026">2026</SelectItem>
+								<SelectItem value="2027">2027</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
 					<Button
 						variant={showLostOpportunities ? "default" : "outline"}
 						size="sm"

--- a/apps/portal-web/src/features/HomePage/HomePage.tsx
+++ b/apps/portal-web/src/features/HomePage/HomePage.tsx
@@ -1,5 +1,5 @@
 import { NavBar } from "@components/ui";
-import { CarrouselStart, HowItWorks, Testimonies, GraphLine } from "./sections";
+import { CarrouselStart, HowItWorks, GraphLine } from "./sections";
 import { WhoWeAre } from "./sections/whoWeAre/WhoWeAre";
 import { HowSellOrBuy } from "./sections/howSellOrBuy/HowSellOrBuy";
 

--- a/apps/portal-web/src/features/footer/Footer.tsx
+++ b/apps/portal-web/src/features/footer/Footer.tsx
@@ -1,8 +1,5 @@
 import Map from "./assets/Map.png";
 import {
-  InvestorsLogo as Investors,
-  Tranki,
-  Listo,
   Facebook,
   Instagram,
   Linkedin,


### PR DESCRIPTION
## Summary
- Agrega filtro por mes/año de creación en la página de oportunidades (kanban y tabla)
- Agrega filtro por fuente/medio (Facebook, Instagram, Google, WhatsApp, etc.)
- Limpia imports no usados en portal-web (HomePage, Footer)
- Se eliminaron 3 oportunidades de prueba de MKT en la DB (Javier Mendizabal x2, Jhairo Nájera x1)

## Test plan
- [ ] Verificar que los dropdowns de fuente y mes/año aparecen en la barra de filtros
- [ ] Verificar que el filtro de mes default es el mes actual
- [ ] Cambiar fuente y verificar que filtra correctamente
- [ ] Cambiar mes y verificar que solo muestra oportunidades creadas en ese mes
- [ ] Verificar que los filtros aplican tanto en vista kanban como tabla
- [ ] Verificar que los filtros existentes (asesor, estado) siguen funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)