### PR TITLE
fix(crm): align maxVariableDebtRatio default and add opportunity filters

### DIFF
--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -39,7 +39,7 @@ export function BankStatementAnalysis({
 	const [annualRate, setAnnualRate] = useState("0.18");
 	const [termMonths, setTermMonths] = useState("60");
 	const [maxDebtRatio, setMaxDebtRatio] = useState("0.2");
-	const [maxVariableDebtRatio, setMaxVariableDebtRatio] = useState("0.3");
+	const [maxVariableDebtRatio, setMaxVariableDebtRatio] = useState("0.2");
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const queryClient = useQueryClient();
 


### PR DESCRIPTION
## Summary
- Fix `maxVariableDebtRatio` frontend default from 0.3 to 0.2 to match backend, reducing inflated credit capacity calculations
- Add source and created date filters to opportunities page

## Test plan
- [ ] Verify bank analysis uses 0.2 as default variable debt ratio
- [ ] Verify opportunity filters work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)