### PR TITLE
Jalvarez

### DIFF
--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -82,7 +82,7 @@ app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
 // External contracts endpoint (requires service account authentication)
 app.route("/api/contracts/external", externalContractsRouter);
 
-const handler = new RPCHandler({ ...appRouter, ...investmentsRouter });
+const handler = new RPCHandler({ ...appRouter, ...investmentsRouter } as typeof appRouter & typeof investmentsRouter);
 app.use("/rpc/*", async (c, next) => {
 	const context = await createContext({ context: c });
 	const { matched, response } = await handler.handle(c.req.raw, {

--- a/apps/crm/apps/server/src/routers/accounting.ts
+++ b/apps/crm/apps/server/src/routers/accounting.ts
@@ -37,4 +37,17 @@ export const accountingRouter = {
 			});
 			return boleta;
 		}),
+
+	liquidateInversionista: crmProcedure
+		.input(
+			z.object({
+				inversionista_id: z.number().int().positive(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const result = await carteraBackClient.liquidateInversionista(
+				input.inversionista_id,
+			);
+			return result;
+		}),
 };


### PR DESCRIPTION
## Descripción del PR

Este PR soluciona los problemas de inferencia de TypeScript ocasionados por los límites de recursividad (TS7056) en la inicialización estática del servidor y termina de empalmar adecuadamente las llamadas de cartera subyacentes.

### Cambios realizados:
- **Resuelto problema de máxima profundidad en ORPC (Type Mismatch en index.ts):** Implementada una _Top-Level Intersection_ (`as typeof appRouter & typeof investmentsRouter`) directo en el despachador del `RPCHandler`. Esto corta el cuello de botella donde TS se bloqueaba al intentar validar recursivamente la profunda unión inferida en el objeto gigante y evita desmantelar limpiamente el estado de los middlewares del enrutador central.
- **Implementación faltante de inversión:** Agregado el método de liquidación [liquidateInversionista](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/server/src/services/cartera-back-client.ts:744:1-756:2) dentro de [src/routers/accounting.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/server/src/routers/accounting.ts:0:0-0:0) conectándolo al cliente de API `carteraBackClient`.

### Resultado:
- `bun run tsc --noEmit` regresa un *Exit code 0* impecablemente, confirmando sanidad de chequeos en toda la base.
- Se mantiene resguardada la verificación de validaciones de sesión preservando el tipado nativo que las aplicaciones frontend estaban esperando consumir.

