### PR TITLE
feat(dashboard): gráficas BI de colocación

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -583,8 +583,7 @@ export const crmRouter = {
 
 						if (!firstStage) {
 							throw new ORPCError("INTERNAL_SERVER_ERROR", {
-								message:
-									"No se encontró el primer stage de ventas",
+								message: "No se encontró el primer stage de ventas",
 							});
 						}
 
@@ -3113,8 +3112,7 @@ export const crmRouter = {
 					candidateIds.length > 0
 						? await db
 								.select({
-									opportunityId:
-										opportunityStageHistory.opportunityId,
+									opportunityId: opportunityStageHistory.opportunityId,
 								})
 								.from(opportunityStageHistory)
 								.where(
@@ -3123,14 +3121,8 @@ export const crmRouter = {
 											opportunityStageHistory.opportunityId,
 											candidateIds,
 										),
-										inArray(
-											opportunityStageHistory.toStageId,
-											placedStageIds,
-										),
-										lt(
-											opportunityStageHistory.changedAt,
-											startOfMonth,
-										),
+										inArray(opportunityStageHistory.toStageId, placedStageIds),
+										lt(opportunityStageHistory.changedAt, startOfMonth),
 									),
 								)
 						: [];
@@ -5948,9 +5940,36 @@ export const crmRouter = {
 						),
 					);
 
-				const placedOppIds = [
+				const candidateIds = [
 					...new Set(placedThisMonth.map((o) => o.opportunityId)),
 				];
+
+				// Exclude opportunities that already reached placed before this month
+				const alreadyPlacedBefore =
+					candidateIds.length > 0
+						? await db
+								.select({
+									opportunityId: opportunityStageHistory.opportunityId,
+								})
+								.from(opportunityStageHistory)
+								.where(
+									and(
+										inArray(
+											opportunityStageHistory.opportunityId,
+											candidateIds,
+										),
+										inArray(opportunityStageHistory.toStageId, placedStageIds),
+										lt(opportunityStageHistory.changedAt, startOfMonth),
+									),
+								)
+						: [];
+
+				const alreadyPlacedIds = new Set(
+					alreadyPlacedBefore.map((o) => o.opportunityId),
+				);
+				const placedOppIds = candidateIds.filter(
+					(id) => !alreadyPlacedIds.has(id),
+				);
 
 				if (placedOppIds.length > 0) {
 					const rankingConditions = [
@@ -6015,20 +6034,19 @@ export const crmRouter = {
 						isNotNull(opportunities.vehicleId),
 					];
 					if (userFilter) {
-						marcaConditions.push(
-							eq(opportunities.assignedTo, userFilter),
-						);
+						marcaConditions.push(eq(opportunities.assignedTo, userFilter));
 					}
+					const marcaNorm = sql<string>`upper(trim(${vehicles.make}))`;
 					const marcaRows = await db
 						.select({
-							make: vehicles.make,
+							make: marcaNorm,
 							monto: sql<string>`coalesce(sum(${opportunities.value}), 0)`,
 							cantidad: count(),
 						})
 						.from(opportunities)
 						.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 						.where(and(...marcaConditions))
-						.groupBy(vehicles.make)
+						.groupBy(marcaNorm)
 						.orderBy(desc(sql`sum(${opportunities.value})`));
 
 					byMarca = marcaRows.map((r) => ({
@@ -6044,9 +6062,7 @@ export const crmRouter = {
 						not(eq(opportunities.status, "migrate")),
 					];
 					if (userFilter) {
-						medioConditions.push(
-							eq(opportunities.assignedTo, userFilter),
-						);
+						medioConditions.push(eq(opportunities.assignedTo, userFilter));
 					}
 					const medioRows = await db
 						.select({

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -5932,6 +5932,9 @@ export const crmRouter = {
 			const placedStageIds = placedStages.map((s) => s.id);
 
 			let ranking: { name: string; monto: number }[] = [];
+			let byTipoCredito: { name: string; monto: number }[] = [];
+			let byMarca: { name: string; monto: number; cantidad: number }[] = [];
+			let byMedio: { name: string; monto: number }[] = [];
 			if (placedStageIds.length > 0) {
 				// Find opportunities that moved to a placed stage within this month
 				const placedThisMonth = await db
@@ -5972,6 +5975,104 @@ export const crmRouter = {
 
 					ranking = rankingRows.map((r) => ({
 						name: r.userName || "Sin asignar",
+						monto: Number.parseFloat(r.monto) || 0,
+					}));
+
+					// 4) Monto colocado por tipo de crédito
+					const tipoCreditoConditions = [
+						inArray(opportunities.id, placedOppIds),
+						inArray(opportunities.stageId, placedStageIds),
+						not(eq(opportunities.status, "migrate")),
+					];
+					if (userFilter) {
+						tipoCreditoConditions.push(
+							eq(opportunities.assignedTo, userFilter),
+						);
+					}
+					const tipoCreditoRows = await db
+						.select({
+							creditType: opportunities.creditType,
+							monto: sql<string>`coalesce(sum(${opportunities.value}), 0)`,
+						})
+						.from(opportunities)
+						.where(and(...tipoCreditoConditions))
+						.groupBy(opportunities.creditType);
+
+					const CREDIT_TYPE_LABELS: Record<string, string> = {
+						autocompra: "Autocompra",
+						sobre_vehiculo: "Sobre Vehículo",
+					};
+					byTipoCredito = tipoCreditoRows.map((r) => ({
+						name: CREDIT_TYPE_LABELS[r.creditType] || r.creditType,
+						monto: Number.parseFloat(r.monto) || 0,
+					}));
+
+					// 5) Monto colocado y cantidad por marca de vehículo
+					const marcaConditions = [
+						inArray(opportunities.id, placedOppIds),
+						inArray(opportunities.stageId, placedStageIds),
+						not(eq(opportunities.status, "migrate")),
+						isNotNull(opportunities.vehicleId),
+					];
+					if (userFilter) {
+						marcaConditions.push(
+							eq(opportunities.assignedTo, userFilter),
+						);
+					}
+					const marcaRows = await db
+						.select({
+							make: vehicles.make,
+							monto: sql<string>`coalesce(sum(${opportunities.value}), 0)`,
+							cantidad: count(),
+						})
+						.from(opportunities)
+						.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+						.where(and(...marcaConditions))
+						.groupBy(vehicles.make)
+						.orderBy(desc(sql`sum(${opportunities.value})`));
+
+					byMarca = marcaRows.map((r) => ({
+						name: r.make || "Sin marca",
+						monto: Number.parseFloat(r.monto) || 0,
+						cantidad: r.cantidad,
+					}));
+
+					// 6) Monto colocado por medio/fuente
+					const medioConditions = [
+						inArray(opportunities.id, placedOppIds),
+						inArray(opportunities.stageId, placedStageIds),
+						not(eq(opportunities.status, "migrate")),
+					];
+					if (userFilter) {
+						medioConditions.push(
+							eq(opportunities.assignedTo, userFilter),
+						);
+					}
+					const medioRows = await db
+						.select({
+							source: opportunities.source,
+							monto: sql<string>`coalesce(sum(${opportunities.value}), 0)`,
+						})
+						.from(opportunities)
+						.where(and(...medioConditions))
+						.groupBy(opportunities.source)
+						.orderBy(desc(sql`sum(${opportunities.value})`));
+
+					const SOURCE_LABELS: Record<string, string> = {
+						website: "Sitio Web",
+						referral: "Referido",
+						cold_call: "Llamada en Frío",
+						email: "Email",
+						social_media: "Redes Sociales",
+						event: "Evento",
+						other: "Otro",
+						facebook: "Facebook",
+						instagram: "Instagram",
+						google: "Google",
+						Whatsapp: "WhatsApp",
+					};
+					byMedio = medioRows.map((r) => ({
+						name: SOURCE_LABELS[r.source || ""] || r.source || "Sin fuente",
 						monto: Number.parseFloat(r.monto) || 0,
 					}));
 				}
@@ -6015,6 +6116,6 @@ export const crmRouter = {
 				(a, b) => b.abiertas + b.cerradas - (a.abiertas + a.cerradas),
 			);
 
-			return { pipeline, ranking, activity };
+			return { pipeline, ranking, activity, byTipoCredito, byMarca, byMedio };
 		}),
 };

--- a/apps/crm/apps/web/src/routes/dashboard.tsx
+++ b/apps/crm/apps/web/src/routes/dashboard.tsx
@@ -25,6 +25,10 @@ import {
 	CartesianGrid,
 	Cell,
 	Legend,
+	Line,
+	LineChart,
+	Pie,
+	PieChart,
 	ResponsiveContainer,
 	Tooltip,
 	XAxis,
@@ -828,6 +832,159 @@ function RouteComponent() {
 					)}
 				</div>
 			)}
+
+			{/* BI Charts - Análisis de Colocación */}
+			{chartData.data &&
+				(chartData.data.byTipoCredito.length > 0 ||
+					chartData.data.byMarca.length > 0 ||
+					chartData.data.byMedio.length > 0) && (
+					<div className="space-y-4">
+						<h2 className="font-semibold text-2xl">
+							Análisis de Colocación
+						</h2>
+						<div className="grid gap-4 md:grid-cols-2">
+							{/* Pie: Monto por Tipo de Crédito */}
+							{chartData.data.byTipoCredito.length > 0 && (
+								<Card>
+									<CardHeader>
+										<CardTitle>Monto por Tipo de Crédito</CardTitle>
+										<CardDescription>
+											Distribución de monto colocado
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<ResponsiveContainer width="100%" height={300}>
+											<PieChart>
+												<Pie
+													data={chartData.data.byTipoCredito}
+													dataKey="monto"
+													nameKey="name"
+													cx="50%"
+													cy="50%"
+													outerRadius={100}
+													label={({ name, percent }) =>
+														`${name}: ${((percent ?? 0) * 100).toFixed(0)}%`
+													}
+												>
+													<Cell fill="#3b82f6" />
+													<Cell fill="#f59e0b" />
+												</Pie>
+												<Tooltip
+													formatter={(value) =>
+														`Q${Number(value).toLocaleString()}`
+													}
+												/>
+												<Legend />
+											</PieChart>
+										</ResponsiveContainer>
+									</CardContent>
+								</Card>
+							)}
+
+							{/* Bar: Monto por Medio/Fuente */}
+							{chartData.data.byMedio.length > 0 && (
+								<Card>
+									<CardHeader>
+										<CardTitle>Monto por Medio</CardTitle>
+										<CardDescription>
+											Monto colocado por canal de adquisición
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<ResponsiveContainer width="100%" height={300}>
+											<BarChart data={chartData.data.byMedio}>
+												<CartesianGrid strokeDasharray="3 3" />
+												<XAxis
+													dataKey="name"
+													angle={-45}
+													textAnchor="end"
+													height={100}
+													fontSize={11}
+													interval={0}
+												/>
+												<YAxis
+													tickFormatter={(v: number) =>
+														`Q${(v / 1000).toFixed(0)}k`
+													}
+												/>
+												<Tooltip
+													formatter={(value) =>
+														`Q${Number(value).toLocaleString()}`
+													}
+												/>
+												<Bar dataKey="monto" name="Monto" fill="#8b5cf6" />
+											</BarChart>
+										</ResponsiveContainer>
+									</CardContent>
+								</Card>
+							)}
+
+							{/* Line (dual axis): Monto y Cantidad por Marca */}
+							{chartData.data.byMarca.length > 0 && (
+								<Card className="md:col-span-2">
+									<CardHeader>
+										<CardTitle>
+											Colocación por Marca de Vehículo
+										</CardTitle>
+										<CardDescription>
+											Monto colocado y cantidad de créditos por marca
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<ResponsiveContainer width="100%" height={350}>
+											<LineChart data={chartData.data.byMarca}>
+												<CartesianGrid strokeDasharray="3 3" />
+												<XAxis
+													dataKey="name"
+													angle={-45}
+													textAnchor="end"
+													height={80}
+													fontSize={11}
+													interval={0}
+												/>
+												<YAxis
+													yAxisId="left"
+													tickFormatter={(v: number) =>
+														`Q${(v / 1000).toFixed(0)}k`
+													}
+												/>
+												<YAxis
+													yAxisId="right"
+													orientation="right"
+													allowDecimals={false}
+												/>
+												<Tooltip
+													formatter={(value, name) =>
+														name === "Monto"
+															? `Q${Number(value).toLocaleString()}`
+															: value
+													}
+												/>
+												<Legend />
+												<Line
+													yAxisId="left"
+													type="monotone"
+													dataKey="monto"
+													stroke="#10b981"
+													name="Monto"
+													strokeWidth={2}
+												/>
+												<Line
+													yAxisId="right"
+													type="monotone"
+													dataKey="cantidad"
+													stroke="#3b82f6"
+													name="Cantidad"
+													strokeWidth={2}
+												/>
+											</LineChart>
+										</ResponsiveContainer>
+									</CardContent>
+								</Card>
+							)}
+						</div>
+					</div>
+				)}
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/dashboard.tsx
+++ b/apps/crm/apps/web/src/routes/dashboard.tsx
@@ -728,19 +728,30 @@ function RouteComponent() {
 								</CardDescription>
 							</CardHeader>
 							<CardContent>
-								<ResponsiveContainer width="100%" height={300}>
+								<ResponsiveContainer width="100%" height={400}>
 									<BarChart data={chartData.data.pipeline}>
 										<CartesianGrid strokeDasharray="3 3" />
 										<XAxis
 											dataKey="name"
-											angle={-45}
-											textAnchor="end"
-											height={100}
-											fontSize={11}
 											interval={0}
-											tickFormatter={(name: string) =>
-												name.length > 20 ? `${name.slice(0, 18)}…` : name
-											}
+											height={120}
+											tick={({ x, y, payload }) => (
+												<g transform={`translate(${x},${y})`}>
+													<text
+														x={0}
+														y={0}
+														dy={16}
+														textAnchor="end"
+														fill="#666"
+														fontSize={11}
+														transform="rotate(-45)"
+													>
+														{payload.value.length > 20
+															? `${payload.value.slice(0, 18)}…`
+															: payload.value}
+													</text>
+												</g>
+											)}
 										/>
 										<YAxis
 											tickFormatter={(v: number) =>
@@ -839,9 +850,7 @@ function RouteComponent() {
 					chartData.data.byMarca.length > 0 ||
 					chartData.data.byMedio.length > 0) && (
 					<div className="space-y-4">
-						<h2 className="font-semibold text-2xl">
-							Análisis de Colocación
-						</h2>
+						<h2 className="font-semibold text-2xl">Análisis de Colocación</h2>
 						<div className="grid gap-4 md:grid-cols-2">
 							{/* Pie: Monto por Tipo de Crédito */}
 							{chartData.data.byTipoCredito.length > 0 && (
@@ -891,16 +900,28 @@ function RouteComponent() {
 										</CardDescription>
 									</CardHeader>
 									<CardContent>
-										<ResponsiveContainer width="100%" height={300}>
+										<ResponsiveContainer width="100%" height={400}>
 											<BarChart data={chartData.data.byMedio}>
 												<CartesianGrid strokeDasharray="3 3" />
 												<XAxis
 													dataKey="name"
-													angle={-45}
-													textAnchor="end"
-													height={100}
-													fontSize={11}
 													interval={0}
+													height={120}
+													tick={({ x, y, payload }) => (
+														<g transform={`translate(${x},${y})`}>
+															<text
+																x={0}
+																y={0}
+																dy={16}
+																textAnchor="end"
+																fill="#666"
+																fontSize={11}
+																transform="rotate(-45)"
+															>
+																{payload.value}
+															</text>
+														</g>
+													)}
 												/>
 												<YAxis
 													tickFormatter={(v: number) =>
@@ -923,24 +944,34 @@ function RouteComponent() {
 							{chartData.data.byMarca.length > 0 && (
 								<Card className="md:col-span-2">
 									<CardHeader>
-										<CardTitle>
-											Colocación por Marca de Vehículo
-										</CardTitle>
+										<CardTitle>Colocación por Marca de Vehículo</CardTitle>
 										<CardDescription>
 											Monto colocado y cantidad de créditos por marca
 										</CardDescription>
 									</CardHeader>
 									<CardContent>
-										<ResponsiveContainer width="100%" height={350}>
+										<ResponsiveContainer width="100%" height={400}>
 											<LineChart data={chartData.data.byMarca}>
 												<CartesianGrid strokeDasharray="3 3" />
 												<XAxis
 													dataKey="name"
-													angle={-45}
-													textAnchor="end"
-													height={80}
-													fontSize={11}
 													interval={0}
+													height={120}
+													tick={({ x, y, payload }) => (
+														<g transform={`translate(${x},${y})`}>
+															<text
+																x={0}
+																y={0}
+																dy={16}
+																textAnchor="end"
+																fill="#666"
+																fontSize={11}
+																transform="rotate(-45)"
+															>
+																{payload.value}
+															</text>
+														</g>
+													)}
 												/>
 												<YAxis
 													yAxisId="left"


### PR DESCRIPTION
## Summary
- Agrega 3 gráficas BI al dashboard: pie de monto por tipo de crédito, barras de monto por medio/fuente, y líneas dual-axis de monto/cantidad por marca de vehículo
- Corrige lógica de "colocados" en `getDashboardChartData` para alinear con las cards (`getDashboardStats`)
- Normaliza marcas de vehículo con `UPPER(TRIM())` para evitar duplicados por capitalización
- Usa tick custom en XAxis para que los labels rotados no se sobrepongan a las barras

## Test plan
- [ ] Verificar que las 3 gráficas nuevas aparecen en `/dashboard` cuando hay datos de colocación
- [ ] Verificar que los montos de las gráficas coinciden con las cards de arriba
- [ ] Verificar que marcas duplicadas (ej. "Mazda" vs "MAZDA") se unifican
- [ ] Verificar que los labels del eje X van debajo de las barras, no encima
- [ ] Navegar entre meses y verificar que las gráficas se actualizan

🤖 Generated with [Claude Code](https://claude.com/claude-code)