### PR TITLE
Add disbursement management workflow and tab for opportunities

### DIFF
--- a/apps/crm/apps/server/src/db/schema/notifications.ts
+++ b/apps/crm/apps/server/src/db/schema/notifications.ts
@@ -49,6 +49,7 @@ export const notificationRedirectPageEnum = pgEnum(
 		"analysis_90_details",
 		"pay_investors",
 		"cobros_detail",
+		"client_details_disbursement",
 	],
 );
 

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -86,7 +86,7 @@ export const PERMISSIONS = {
 		role === ROLES.SALES ||
 		role === ROLES.SALES_SUPERVISOR ||
 		role === ROLES.ANALYST ||
-		role === ROLES.JURIDICO || role === ROLES.ACCOUNTING,
+		role === ROLES.JURIDICO,
 
 	// Analysis Module Access
 	canAccessAnalysis: (role: UserRole | string): boolean =>

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -4768,7 +4768,7 @@ export const crmRouter = {
 				assignedToRole: "accounting",
 				relatedEntityType: "opportunity_client",
 				relatedEntityId: input.opportunityId,
-				redirectPage: "client_details",
+				redirectPage: "client_details_disbursement",
 			});
 
 			return {

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -233,6 +233,12 @@ export const appRouter = {
 	addDocumentToNotification: notificationsRouter.addDocumentToNotification,
 	getAccountDocumentsByOpportunities:
 		notificationsRouter.getAccountDocumentsByOpportunities,
+	getDisbursementForOpportunity:
+		notificationsRouter.getDisbursementForOpportunity,
+	deleteNotificationDocument:
+		notificationsRouter.deleteNotificationDocument,
+	notifyDisbursementCompleted:
+		notificationsRouter.notifyDisbursementCompleted,
 	markAllNotificationsAsRead: notificationsRouter.markAllNotificationsAsRead,
 
 	// Quotations routes

--- a/apps/crm/apps/server/src/routers/notifications.ts
+++ b/apps/crm/apps/server/src/routers/notifications.ts
@@ -3,6 +3,7 @@ import { and, count, desc, eq, inArray, isNull, or } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
+import { opportunities } from "../db/schema/crm";
 import type { NewNotification } from "../db/schema/notifications";
 import {
 	notificationDocuments,
@@ -10,6 +11,7 @@ import {
 } from "../db/schema/notifications";
 import { adminProcedure, protectedProcedure } from "../lib/orpc";
 import {
+	deleteFileFromR2,
 	generateUniqueFilename,
 	getFileUrl,
 	resolveMimeType,
@@ -370,6 +372,7 @@ export const notificationsRouter = {
 				.where(
 					and(
 						eq(notifications.assignedToRole, "accounting"),
+						eq(notifications.type, "action_upload_files"),
 						eq(notifications.relatedEntityType, "opportunity"),
 						inArray(notifications.relatedEntityId, input.opportunityIds),
 					),
@@ -406,6 +409,60 @@ export const notificationsRouter = {
 			);
 
 			return docsWithUrls;
+		}),
+
+	// Obtener info de desembolso para una oportunidad (notificación + documentos)
+	getDisbursementForOpportunity: protectedProcedure
+		.input(
+			z.object({
+				opportunityId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			// Buscar notificación de contabilidad para desembolso
+			const [notif] = await db
+				.select({
+					id: notifications.id,
+					titulo: notifications.titulo,
+					status: notifications.status,
+					createdAt: notifications.createdAt,
+				})
+				.from(notifications)
+				.where(
+					and(
+						eq(notifications.assignedToRole, "accounting"),
+						eq(notifications.type, "action_upload_files"),
+						inArray(notifications.relatedEntityType, [
+							"opportunity",
+							"opportunity_client",
+						]),
+						eq(notifications.relatedEntityId, input.opportunityId),
+					),
+				)
+				.limit(1);
+
+			if (!notif) {
+				return { notificationId: null, documents: [] };
+			}
+
+			// Obtener documentos de esa notificación
+			const docs = await db
+				.select()
+				.from(notificationDocuments)
+				.where(eq(notificationDocuments.notificationId, notif.id))
+				.orderBy(desc(notificationDocuments.uploadedAt));
+
+			const docsWithUrls = await Promise.all(
+				docs.map(async (doc) => ({
+					...doc,
+					url: await getFileUrl(doc.filePath),
+				})),
+			);
+
+			return {
+				notificationId: notif.id,
+				documents: docsWithUrls,
+			};
 		}),
 
 	// Agregar documento a una notificación (sube a R2)
@@ -491,5 +548,102 @@ export const notificationsRouter = {
 				.returning();
 
 			return document;
+		}),
+
+	// Eliminar documento de una notificación
+	deleteNotificationDocument: protectedProcedure
+		.input(
+			z.object({
+				documentId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			const [document] = await db
+				.select()
+				.from(notificationDocuments)
+				.where(eq(notificationDocuments.id, input.documentId))
+				.limit(1);
+
+			if (!document) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Documento no encontrado",
+				});
+			}
+
+			// Solo el que subió o admin puede borrar
+			const userRole = context.session.user.role;
+			if (
+				document.uploadedBy !== context.session.user.id &&
+				userRole !== "admin"
+			) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permisos para eliminar este documento",
+				});
+			}
+
+			// Eliminar de R2
+			await deleteFileFromR2(document.filePath);
+
+			// Eliminar de la base de datos
+			await db
+				.delete(notificationDocuments)
+				.where(eq(notificationDocuments.id, input.documentId));
+
+			return { success: true };
+		}),
+
+	// Notificar al asesor de ventas que el desembolso fue completado
+	notifyDisbursementCompleted: protectedProcedure
+		.input(
+			z.object({
+				opportunityId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			const userId = context.session.user.id;
+			const [userData] = await db
+				.select({ role: user.role })
+				.from(user)
+				.where(eq(user.id, userId))
+				.limit(1);
+
+			// Obtener la oportunidad para saber el asesor asignado y el título
+			const [opportunity] = await db
+				.select({
+					id: opportunities.id,
+					title: opportunities.title,
+					assignedTo: opportunities.assignedTo,
+				})
+				.from(opportunities)
+				.where(eq(opportunities.id, input.opportunityId))
+				.limit(1);
+
+			if (!opportunity) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Oportunidad no encontrada",
+				});
+			}
+
+			if (!opportunity.assignedTo) {
+				throw new ORPCError("BAD_REQUEST", {
+					message:
+						"La oportunidad no tiene un asesor de ventas asignado",
+				});
+			}
+
+			await createNotification({
+				titulo: `Desembolso completado - ${opportunity.title}`,
+				descripcion: `El desembolso de la oportunidad "${opportunity.title}" ha sido completado. Las boletas ya fueron subidas.`,
+				type: "aviso",
+				createdBy: userId,
+				createdByRole: userData?.role ?? "accounting",
+				assignedToRole: "sales",
+				assignedTo: opportunity.assignedTo,
+				redirectPage: "client_details_disbursement",
+				relatedEntityType: "opportunity_client",
+				relatedEntityId: input.opportunityId,
+			});
+
+			return { success: true };
 		}),
 };

--- a/apps/crm/apps/web/src/components/disbursement/DisbursementView.tsx
+++ b/apps/crm/apps/web/src/components/disbursement/DisbursementView.tsx
@@ -1,0 +1,441 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import {
+	Banknote,
+	CheckCircle,
+	Download,
+	FileText,
+	Loader2,
+	Send,
+	Trash2,
+	Upload,
+} from "lucide-react";
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { PERMISSIONS } from "@/lib/roles";
+import { client, orpc } from "@/utils/orpc";
+
+interface DisbursementViewProps {
+	opportunityId: string;
+	opportunityTitle: string;
+	assignedUserId?: string;
+	userRole?: string | null;
+	quotation?: {
+		amountToFinance: string;
+		totalFinanced: string;
+	} | null;
+}
+
+export function DisbursementView({
+	opportunityId,
+	opportunityTitle,
+	assignedUserId,
+	userRole,
+	quotation,
+}: DisbursementViewProps) {
+	const queryClient = useQueryClient();
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const [uploadingDisbursement, setUploadingDisbursement] = useState(false);
+
+	const isAccounting =
+		userRole != null && PERMISSIONS.canAccessAccounting(userRole);
+
+	const amountToFinance = quotation
+		? Number(quotation.amountToFinance)
+		: 0;
+	const totalFinanced = quotation
+		? Number(quotation.totalFinanced)
+		: 0;
+	const gastos = totalFinanced - amountToFinance;
+
+	// Query for disbursement info (accounting documents)
+	const disbursementQuery = useQuery({
+		...orpc.getDisbursementForOpportunity.queryOptions({
+			input: { opportunityId },
+		}),
+		queryKey: ["getDisbursementForOpportunity", opportunityId],
+	}) as any;
+
+	// Query for checks associated with the opportunity
+	const checksQuery = useQuery({
+		queryKey: ["getChecksByOpportunity", opportunityId],
+		queryFn: () =>
+			client.getChecksByOpportunity({ opportunityId }),
+	}) as any;
+
+	const uploadDisbursementMutation = useMutation({
+		mutationFn: async (file: File) => {
+			const notificationId = disbursementQuery.data?.notificationId;
+			if (!notificationId)
+				throw new Error("No hay notificación de desembolso");
+
+			const data = await new Promise<string>((resolve, reject) => {
+				const reader = new FileReader();
+				reader.onload = () => {
+					const base64 = (reader.result as string).split(",")[1];
+					resolve(base64);
+				};
+				reader.onerror = reject;
+				reader.readAsDataURL(file);
+			});
+
+			return await client.addDocumentToNotification({
+				notificationId,
+				file: {
+					name: file.name,
+					type: file.type,
+					size: file.size,
+					data,
+				},
+			});
+		},
+		onSuccess: () => {
+			toast.success("Documento de desembolso subido");
+			queryClient.invalidateQueries({
+				queryKey: ["getDisbursementForOpportunity", opportunityId],
+			});
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	const deleteDisbursementDocMutation = useMutation({
+		mutationFn: async (documentId: string) => {
+			return await client.deleteNotificationDocument({ documentId });
+		},
+		onSuccess: () => {
+			toast.success("Documento eliminado");
+			queryClient.invalidateQueries({
+				queryKey: ["getDisbursementForOpportunity", opportunityId],
+			});
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	const notifySalesMutation = useMutation({
+		mutationFn: async () => {
+			return await client.notifyDisbursementCompleted({
+				opportunityId,
+			});
+		},
+		onSuccess: () => {
+			toast.success("Notificación enviada al asesor de ventas");
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	const handleDisbursementFileSelect = useCallback(
+		async (e: React.ChangeEvent<HTMLInputElement>) => {
+			const files = e.target.files;
+			if (!files?.length) return;
+
+			setUploadingDisbursement(true);
+			try {
+				for (const file of Array.from(files)) {
+					await uploadDisbursementMutation.mutateAsync(file);
+				}
+			} finally {
+				setUploadingDisbursement(false);
+				if (fileInputRef.current) {
+					fileInputRef.current.value = "";
+				}
+			}
+		},
+		[uploadDisbursementMutation],
+	);
+
+	const hasDocuments =
+		disbursementQuery.data &&
+		disbursementQuery.data.documents.length > 0;
+
+	return (
+		<div className="space-y-6">
+			{/* Financial summary - only for admin/accounting */}
+			{isAccounting && quotation && (
+				<div className="grid grid-cols-2 gap-4">
+					<div className="rounded-lg border bg-muted/30 p-4">
+						<span className="text-muted-foreground text-xs">
+							Monto a desembolsar
+						</span>
+						<p className="font-bold text-2xl text-green-600">
+							Q{amountToFinance.toLocaleString()}
+						</p>
+					</div>
+					<div className="rounded-lg border bg-muted/30 p-4">
+						<span className="text-muted-foreground text-xs">
+							Gastos
+						</span>
+						<p className="font-bold text-2xl text-orange-600">
+							Q{gastos.toLocaleString()}
+						</p>
+					</div>
+				</div>
+			)}
+
+			{/* Disbursement documents */}
+			<div className="space-y-3">
+				<div className="flex items-center gap-2">
+					<FileText className="h-5 w-5 text-muted-foreground" />
+					<h3 className="font-semibold text-lg">
+						Boletas de desembolso
+					</h3>
+				</div>
+
+				{disbursementQuery.isLoading ? (
+					<p className="text-muted-foreground text-sm">
+						Cargando documentos...
+					</p>
+				) : hasDocuments ? (
+					<div className="space-y-2">
+						{disbursementQuery.data!.documents.map((doc: any) => (
+							<div
+								key={doc.id}
+								className="flex items-center justify-between rounded-md border bg-background px-4 py-3"
+							>
+								<div className="flex min-w-0 items-center gap-3">
+									<FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
+									<div className="min-w-0">
+										<p className="truncate font-medium text-sm">
+											{doc.originalName}
+										</p>
+										<p className="text-muted-foreground text-xs">
+											{(doc.size / 1024).toFixed(0)} KB
+										</p>
+									</div>
+								</div>
+								<div className="flex shrink-0 items-center gap-1">
+									<a
+										href={doc.url}
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										<Button
+											size="sm"
+											variant="outline"
+											className="h-8"
+										>
+											<Download className="mr-1 h-3 w-3" />
+											Descargar
+										</Button>
+									</a>
+									{isAccounting && (
+										<Button
+											size="sm"
+											variant="ghost"
+											className="h-8 text-destructive hover:text-destructive"
+											disabled={
+												deleteDisbursementDocMutation.isPending
+											}
+											onClick={() =>
+												deleteDisbursementDocMutation.mutate(
+													doc.id,
+												)
+											}
+										>
+											<Trash2 className="h-4 w-4" />
+										</Button>
+									)}
+								</div>
+							</div>
+						))}
+					</div>
+				) : (
+					<div className="rounded-lg border border-dashed p-6 text-center">
+						<FileText className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
+						<p className="text-muted-foreground text-sm">
+							No hay documentos de desembolso
+						</p>
+					</div>
+				)}
+
+				{/* Upload area - only for accounting */}
+				{isAccounting &&
+					disbursementQuery.data?.notificationId && (
+						<div
+							className="flex cursor-pointer items-center justify-center gap-2 rounded-md border-2 border-muted-foreground/25 border-dashed px-4 py-2.5 transition-colors hover:border-muted-foreground/50"
+							role="button"
+							tabIndex={0}
+							onClick={() => fileInputRef.current?.click()}
+							onKeyDown={(e) => {
+								if (e.key === "Enter" || e.key === " ") {
+									e.preventDefault();
+									fileInputRef.current?.click();
+								}
+							}}
+						>
+							{uploadingDisbursement ? (
+								<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+							) : (
+								<Upload className="h-4 w-4 text-muted-foreground/50" />
+							)}
+							<span className="text-muted-foreground text-sm">
+								{uploadingDisbursement
+									? "Subiendo..."
+									: "Subir boletas"}
+							</span>
+							<span className="text-[11px] text-muted-foreground/60">
+								(PDF, imágenes, Word, Excel)
+							</span>
+							<input
+								ref={fileInputRef}
+								type="file"
+								multiple
+								accept=".pdf,.jpg,.jpeg,.png,.webp,.doc,.docx,.xls,.xlsx"
+								className="hidden"
+								onChange={handleDisbursementFileSelect}
+								disabled={uploadingDisbursement}
+							/>
+						</div>
+					)}
+
+				{/* Notify sales button */}
+				{isAccounting && hasDocuments && (
+					<Button
+						variant="outline"
+						className="w-full gap-2"
+						disabled={notifySalesMutation.isPending}
+						onClick={() => notifySalesMutation.mutate()}
+					>
+						{notifySalesMutation.isPending ? (
+							<Loader2 className="h-4 w-4 animate-spin" />
+						) : (
+							<Send className="h-4 w-4" />
+						)}
+						Notificar a ventas que el desembolso fue completado
+					</Button>
+				)}
+
+				{!disbursementQuery.data?.notificationId &&
+					!disbursementQuery.isLoading && (
+						<p className="text-muted-foreground text-sm">
+							No hay notificación de desembolso para esta
+							oportunidad.
+						</p>
+					)}
+			</div>
+
+			{/* Checks section */}
+			<div className="space-y-3">
+				<div className="flex items-center gap-2">
+					<Banknote className="h-5 w-5 text-muted-foreground" />
+					<h3 className="font-semibold text-lg">
+						Cheques / Transferencias
+					</h3>
+				</div>
+
+				{checksQuery.isLoading ? (
+					<p className="text-muted-foreground text-sm">
+						Cargando cheques...
+					</p>
+				) : checksQuery.data &&
+					(checksQuery.data as any[]).length > 0 ? (
+					<div className="space-y-3">
+						{(checksQuery.data as any[]).map((check) => (
+							<div
+								key={check.id}
+								className="rounded-lg border bg-background p-5"
+							>
+								<div className="flex items-start justify-between gap-4">
+									<div className="space-y-2">
+										<div className="flex items-center gap-3">
+											<Badge
+												variant="outline"
+												className="text-sm"
+											>
+												{check.transferType}
+											</Badge>
+											<span className="font-semibold text-base">
+												{check.concept}
+											</span>
+										</div>
+										<div className="grid grid-cols-2 gap-x-6 gap-y-2">
+											<div>
+												<span className="text-muted-foreground text-xs">
+													Emisor
+												</span>
+												<p className="font-medium text-sm">
+													{check.issuer}
+													{check.issuerBank && (
+														<span className="font-normal text-muted-foreground">
+															{" "}
+															({check.issuerBank})
+														</span>
+													)}
+												</p>
+											</div>
+											<div>
+												<span className="text-muted-foreground text-xs">
+													Beneficiario
+												</span>
+												<p className="font-medium text-sm">
+													{check.beneficiary}
+													{check.beneficiaryBank && (
+														<span className="font-normal text-muted-foreground">
+															{" "}
+															({check.beneficiaryBank})
+														</span>
+													)}
+												</p>
+											</div>
+											{check.accountNumber && (
+												<div>
+													<span className="text-muted-foreground text-xs">
+														Cuenta
+													</span>
+													<p className="font-medium text-sm">
+														{check.accountNumber}{" "}
+														<span className="font-normal text-muted-foreground">
+															({check.accountType})
+														</span>
+													</p>
+												</div>
+											)}
+											<div>
+												<span className="text-muted-foreground text-xs">
+													Fecha
+												</span>
+												<p className="font-medium text-sm">
+													{format(
+														new Date(check.checkDate),
+														"dd/MM/yyyy",
+														{ locale: es },
+													)}
+												</p>
+											</div>
+										</div>
+									</div>
+									<div className="shrink-0 text-right">
+										<span className="text-muted-foreground text-xs">
+											Monto
+										</span>
+										<p className="font-bold text-green-600 text-xl">
+											{check.currency}{" "}
+											{Number(
+												check.amount,
+											).toLocaleString()}
+										</p>
+									</div>
+								</div>
+							</div>
+						))}
+					</div>
+				) : (
+					<div className="rounded-lg border border-dashed p-6 text-center">
+						<Banknote className="mx-auto mb-2 h-8 w-8 text-muted-foreground/50" />
+						<p className="text-muted-foreground text-sm">
+							No hay cheques registrados para esta oportunidad
+						</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -1,4 +1,4 @@
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
@@ -23,6 +23,7 @@ import { useState } from "react";
 import { ClientFormsSection } from "@/components/client-forms/ClientFormsSection";
 import { CoDebtorsView } from "@/components/co-debtors/CoDebtorsView";
 import { CreditDetailView } from "@/components/credit/CreditDetailView";
+import { DisbursementView } from "@/components/disbursement/DisbursementView";
 import { OpportunityDocumentUpload } from "@/components/opportunity-document-upload";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -110,6 +111,7 @@ type OpportunityDetailModalProps = {
 	onNavigateToLead?: (leadId: string) => void;
 	onNavigateToVehicle?: (vehicleId: string) => void;
 	onNavigateToQuoter?: (opportunityId: string) => void;
+	initialTab?: string;
 };
 
 export function OpportunityDetailModal({
@@ -123,6 +125,7 @@ export function OpportunityDetailModal({
 	onNavigateToLead,
 	onNavigateToVehicle,
 	onNavigateToQuoter,
+	initialTab,
 }: OpportunityDetailModalProps) {
 	const [opportunityHistory, setOpportunityHistory] = useState<any[]>([]);
 	const [isLoadingHistory, setIsLoadingHistory] = useState(false);
@@ -136,7 +139,7 @@ export function OpportunityDetailModal({
 			open &&
 			!!opportunity?.id &&
 			!!userRole &&
-			PERMISSIONS.canViewOpportunityContracts(userRole),
+			PERMISSIONS.canAccessClients(userRole),
 		queryKey: ["listLegalContractsByOpportunity", opportunity?.id, userRole],
 	});
 
@@ -149,7 +152,7 @@ export function OpportunityDetailModal({
 			open &&
 			!!opportunity?.id &&
 			!!userRole &&
-			PERMISSIONS.canAccessCRM(userRole),
+			PERMISSIONS.canAccessClients(userRole),
 		queryKey: ["listQuotationsByOpportunity", opportunity?.id, userRole],
 	});
 
@@ -187,6 +190,9 @@ export function OpportunityDetailModal({
 	const canViewContracts =
 		userRole && PERMISSIONS.canViewOpportunityContracts(userRole);
 	const canAccessCRM = userRole && PERMISSIONS.canAccessCRM(userRole);
+	const isAccounting =
+		userRole && PERMISSIONS.canAccessAccounting(userRole);
+	const isWon = opportunity?.status === "won";
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -195,7 +201,7 @@ export function OpportunityDetailModal({
 					<DialogTitle>Detalles de la Oportunidad</DialogTitle>
 				</DialogHeader>
 				<Tabs
-					defaultValue="details"
+					defaultValue={initialTab || "details"}
 					className="w-full"
 					onValueChange={(value) => {
 						if (value === "history") {
@@ -204,12 +210,23 @@ export function OpportunityDetailModal({
 					}}
 				>
 					<TabsList
-						className={`grid w-full ${readOnly ? "grid-cols-5" : "grid-cols-6"}`}
+						className={`grid w-full ${
+							isWon
+								? readOnly
+									? "grid-cols-6"
+									: "grid-cols-7"
+								: readOnly
+									? "grid-cols-5"
+									: "grid-cols-6"
+						}`}
 					>
 						<TabsTrigger value="details">Detalles</TabsTrigger>
 						<TabsTrigger value="documents">Documentos</TabsTrigger>
 						<TabsTrigger value="coDebtors">Co-firmantes</TabsTrigger>
 						<TabsTrigger value="credit">Crédito</TabsTrigger>
+						{isWon && (
+							<TabsTrigger value="disbursement">Desembolso</TabsTrigger>
+						)}
 						<TabsTrigger value="forms">Formularios</TabsTrigger>
 						{!readOnly && <TabsTrigger value="history">Historial</TabsTrigger>}
 					</TabsList>
@@ -425,6 +442,7 @@ export function OpportunityDetailModal({
 									</div>
 								</div>
 							)}
+
 						</div>
 
 						{/* Contracts Section */}
@@ -725,6 +743,29 @@ export function OpportunityDetailModal({
 							);
 						})()}
 					</TabsContent>
+
+					{isWon && (
+						<TabsContent value="disbursement" className="mt-6 space-y-6">
+							<DisbursementView
+								opportunityId={opportunity.id}
+								opportunityTitle={opportunity.title}
+								assignedUserId={opportunity.assignedUser?.id}
+								userRole={userRole}
+								quotation={
+									opportunityQuotationsQuery.data?.[0]
+										? {
+												amountToFinance:
+													(opportunityQuotationsQuery.data[0] as any)
+														.amountToFinance,
+												totalFinanced:
+													(opportunityQuotationsQuery.data[0] as any)
+														.totalFinanced,
+											}
+										: null
+								}
+							/>
+						</TabsContent>
+					)}
 
 					<TabsContent value="forms" className="mt-6 space-y-4">
 						{opportunity && (

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -75,6 +75,7 @@ export const Route = createFileRoute("/crm/clients")({
 	component: RouteComponent,
 	validateSearch: z.object({
 		opportunityId: z.string().optional(),
+		initialTab: z.string().optional(),
 		idLead: z.string().optional(),
 		edit: z.boolean().optional(),
 	}).parse,
@@ -1445,6 +1446,7 @@ function RouteComponent() {
 				opportunity={selectedOpportunityForModal}
 				userRole={userProfile.data?.role}
 				readOnly
+				initialTab={search.initialTab}
 				onNavigateToLead={(id: string) => {
 					//borrar los search params de oportunidad y agregar el id del lead a la pagina actual de clients
 					navigate({

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -116,6 +116,13 @@ const REDIRECT_CONFIG: Record<
 		label: "Ver cliente",
 		getRoute: (id) => ({ to: "/crm/clients", search: { opportunityId: id } }),
 	},
+	client_details_disbursement: {
+		label: "Ver desembolso",
+		getRoute: (id) => ({
+			to: "/crm/clients",
+			search: { opportunityId: id, initialTab: "disbursement" },
+		}),
+	},
 	contract_details: {
 		label: "Generar contratos",
 		getRoute: (id) => ({


### PR DESCRIPTION
Introduces a dedicated "Desembolso" tab in the opportunity detail view to manage financial summaries, checks, and disbursement documents.

The accounting team can now upload and manage disbursement slips stored in R2 and trigger notifications to sales advisors once the process is complete. This update also adds support for deep-linking to specific tabs within the client details view via URL search parameters.