### PR TITLE
fix(portal-web): code review fixes - alt text, aria attrs, smooth scroll

### DIFF
--- a/apps/portal-web/src/features/Credit/Sections/GetMoney.tsx
+++ b/apps/portal-web/src/features/Credit/Sections/GetMoney.tsx
@@ -75,7 +75,7 @@ export const GetMoney = () => {
             )}
             <img
               src={imageSrc}
-              alt="Auto"
+              alt="Vehículo disponible para préstamo con garantía"
               className="w-full h-full object-cover rounded-2xl relative"
             />
             {/* Badge en esquina superior derecha */}
@@ -126,7 +126,7 @@ export const GetMoney = () => {
         <div className="relative  lg:w-[40vw]">
           <img
             src={imageSrc}
-            alt="Auto"
+            alt="Vehículo disponible para préstamo con garantía"
             className="w-full h-full object-cover rounded-2xl"
           />
           {/* Badge en esquina superior derecha */}

--- a/apps/portal-web/src/features/FormLeads/components/Thanks.tsx
+++ b/apps/portal-web/src/features/FormLeads/components/Thanks.tsx
@@ -5,7 +5,7 @@ import { Link } from "@tanstack/react-router";
 
 export const Thanks = () => {
   useEffect(() => {
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }, []);
 
   return (

--- a/apps/portal-web/src/features/LeadInvestor/components/ThanksInvestor.tsx
+++ b/apps/portal-web/src/features/LeadInvestor/components/ThanksInvestor.tsx
@@ -5,7 +5,7 @@ import { Link } from "@tanstack/react-router";
 
 export const ThanksInvestor = () => {
   useEffect(() => {
-    window.scrollTo(0, 0);
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }, []);
 
   return (

--- a/apps/portal-web/src/features/footer/Footer.tsx
+++ b/apps/portal-web/src/features/footer/Footer.tsx
@@ -116,6 +116,8 @@ export const Footer: React.FC<FooterProps> = ({ notShowRedirects = false }) => {
                       <span
                         key={link.label}
                         className="text-gray-600 cursor-not-allowed"
+                        aria-disabled="true"
+                        role="link"
                       >
                         {link.label}
                       </span>


### PR DESCRIPTION
## Summary
- Add descriptive alt text to GetMoney vehicle images for accessibility
- Add aria-disabled and role attributes to disabled footer links
- Use smooth scroll behavior in thank you pages

Addresses code review feedback from PR #359.

## Test plan
- [ ] Verify alt text on credit page vehicle images
- [ ] Verify disabled "Compramos tu auto" link in footer has proper ARIA attrs
- [ ] Verify thank you pages scroll smoothly to top

Generated with [Claude Code](https://claude.com/claude-code)
