### PR TITLE
fix(crm): fix client form submission and navigation

### DIFF
--- a/apps/crm/apps/server/src/routers/client-forms.ts
+++ b/apps/crm/apps/server/src/routers/client-forms.ts
@@ -11,6 +11,58 @@ import { leads, opportunities } from "../db/schema/crm";
 import { vehicles } from "../db/schema/vehicles";
 import { crmProcedure, publicProcedure } from "../lib/orpc";
 
+// Fields that are decimal/integer in the DB and must not receive empty strings
+const DECIMAL_FIELDS = new Set([
+	"valorEstimado",
+	"montoSolicitado",
+	"sueldo",
+	"egresos",
+	"efectivo",
+	"cuentasCobrarAmigos",
+	"cuentasCobrarOtros",
+	"documentosCobrar",
+	"bienesInmueblesValor",
+	"vehiculosValor",
+	"maquinaria",
+	"muebles",
+	"menaje",
+	"cuentasPagarAmigos",
+	"cuentasPagarOtros",
+	"letrasPagar",
+	"sueldos",
+	"bonificaciones",
+	"arrendamientos",
+	"gastosPersonales",
+	"alquileres",
+	"amortizacionVivienda",
+	"deudasPersonales",
+]);
+
+const INTEGER_FIELDS = new Set([
+	"edad",
+	"dependientes",
+	"bienesInmueblesCantidad",
+	"vehiculosCantidad",
+]);
+
+function sanitizeFormData(
+	data: Record<string, unknown>,
+): Record<string, unknown> {
+	const sanitized: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(data)) {
+		if (DECIMAL_FIELDS.has(key)) {
+			sanitized[key] =
+				value === "" || value === null || value === undefined ? null : value;
+		} else if (INTEGER_FIELDS.has(key)) {
+			sanitized[key] =
+				value === "" || value === null || value === undefined ? null : value;
+		} else {
+			sanitized[key] = value;
+		}
+	}
+	return sanitized;
+}
+
 export const clientFormsRouter = {
 	// Protected: Generate a token for an opportunity
 	generateFormToken: crmProcedure
@@ -157,7 +209,7 @@ export const clientFormsRouter = {
 			// Upsert credit application
 			const values = {
 				opportunityId: tokenRow.opportunityId,
-				...input.data,
+				...sanitizeFormData(input.data),
 				updatedAt: new Date(),
 			};
 
@@ -215,7 +267,7 @@ export const clientFormsRouter = {
 			// Upsert financial statement
 			const values = {
 				opportunityId: tokenRow.opportunityId,
-				...input.data,
+				...sanitizeFormData(input.data),
 				updatedAt: new Date(),
 			};
 

--- a/apps/crm/apps/server/src/routers/client-forms.ts
+++ b/apps/crm/apps/server/src/routers/client-forms.ts
@@ -51,11 +51,19 @@ function sanitizeFormData(
 	const sanitized: Record<string, unknown> = {};
 	for (const [key, value] of Object.entries(data)) {
 		if (DECIMAL_FIELDS.has(key)) {
-			sanitized[key] =
-				value === "" || value === null || value === undefined ? null : value;
+			if (value === "" || value === null || value === undefined) {
+				sanitized[key] = null;
+			} else {
+				const num = Number(value);
+				sanitized[key] = Number.isNaN(num) ? null : String(num);
+			}
 		} else if (INTEGER_FIELDS.has(key)) {
-			sanitized[key] =
-				value === "" || value === null || value === undefined ? null : value;
+			if (value === "" || value === null || value === undefined) {
+				sanitized[key] = null;
+			} else {
+				const num = Number(value);
+				sanitized[key] = Number.isNaN(num) ? null : Math.trunc(num);
+			}
 		} else {
 			sanitized[key] = value;
 		}

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -302,10 +302,8 @@ export const appRouter = {
 export const disbursementRouter = {
 	getDisbursementForOpportunity:
 		notificationsRouter.getDisbursementForOpportunity,
-	deleteNotificationDocument:
-		notificationsRouter.deleteNotificationDocument,
-	notifyDisbursementCompleted:
-		notificationsRouter.notifyDisbursementCompleted,
+	deleteNotificationDocument: notificationsRouter.deleteNotificationDocument,
+	notifyDisbursementCompleted: notificationsRouter.notifyDisbursementCompleted,
 };
 
 export type AppRouter = typeof appRouter;

--- a/apps/crm/apps/server/src/routers/notifications.ts
+++ b/apps/crm/apps/server/src/routers/notifications.ts
@@ -626,8 +626,7 @@ export const notificationsRouter = {
 
 			if (!opportunity.assignedTo) {
 				throw new ORPCError("BAD_REQUEST", {
-					message:
-						"La oportunidad no tiene un asesor de ventas asignado",
+					message: "La oportunidad no tiene un asesor de ventas asignado",
 				});
 			}
 

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -398,7 +398,8 @@ export const vehiclesRouter = {
 					throw new ORPCError("BAD_REQUEST", {
 						message: `Ya existe un vehículo con la placa "${input.licensePlate}"`,
 					});
-				} else if (isUniqueViolation(error, "vehicles_vin_number_unique")) {
+				}
+				if (isUniqueViolation(error, "vehicles_vin_number_unique")) {
 					throw new ORPCError("BAD_REQUEST", {
 						message: `Ya existe un vehículo con el número de chasis/VIN "${input.vinNumber}"`,
 					});
@@ -1347,7 +1348,11 @@ REGLAS IMPORTANTES:
 
 				// Step 1: Web search for current market prices
 				console.log("Searching web for current market prices...");
-				const { text: marketResearch, sources, usage: searchUsage } = await generateText({
+				const {
+					text: marketResearch,
+					sources,
+					usage: searchUsage,
+				} = await generateText({
 					model: openai("gpt-5-mini"),
 					prompt: `Busca precios actuales de mercado para: ${context.make} ${context.model} ${context.year} usado en Guatemala.
 Incluye precios de venta en portales como OLX, Encuentra24, Facebook Marketplace Guatemala, y cualquier referencia relevante.
@@ -1482,20 +1487,30 @@ Por favor proporciona una valoración detallada en Quetzales para el mercado gua
 				console.log("AI valuation result:", object);
 
 				// Token usage tracking
-				const totalInputTokens = (searchUsage.inputTokens ?? 0) + (valuationUsage.inputTokens ?? 0);
-				const totalOutputTokens = (searchUsage.outputTokens ?? 0) + (valuationUsage.outputTokens ?? 0);
+				const totalInputTokens =
+					(searchUsage.inputTokens ?? 0) + (valuationUsage.inputTokens ?? 0);
+				const totalOutputTokens =
+					(searchUsage.outputTokens ?? 0) + (valuationUsage.outputTokens ?? 0);
 				const totalTokens = totalInputTokens + totalOutputTokens;
 
 				// gpt-5-mini pricing per 1M tokens
 				const GPT5_MINI_INPUT_COST_PER_M = 0.25;
-				const GPT5_MINI_OUTPUT_COST_PER_M = 2.00;
+				const GPT5_MINI_OUTPUT_COST_PER_M = 2.0;
 				const TOKENS_PER_M = 1_000_000;
-				const estimatedCostUSD = (totalInputTokens * GPT5_MINI_INPUT_COST_PER_M / TOKENS_PER_M) + (totalOutputTokens * GPT5_MINI_OUTPUT_COST_PER_M / TOKENS_PER_M);
+				const estimatedCostUSD =
+					(totalInputTokens * GPT5_MINI_INPUT_COST_PER_M) / TOKENS_PER_M +
+					(totalOutputTokens * GPT5_MINI_OUTPUT_COST_PER_M) / TOKENS_PER_M;
 
 				console.log("=== AI VALUATION TOKEN USAGE ===");
-				console.log(`Web Search - Input: ${searchUsage.inputTokens}, Output: ${searchUsage.outputTokens}, Total: ${searchUsage.totalTokens}`);
-				console.log(`Valuation  - Input: ${valuationUsage.inputTokens}, Output: ${valuationUsage.outputTokens}, Total: ${valuationUsage.totalTokens}`);
-				console.log(`Combined   - Input: ${totalInputTokens}, Output: ${totalOutputTokens}, Total: ${totalTokens}`);
+				console.log(
+					`Web Search - Input: ${searchUsage.inputTokens}, Output: ${searchUsage.outputTokens}, Total: ${searchUsage.totalTokens}`,
+				);
+				console.log(
+					`Valuation  - Input: ${valuationUsage.inputTokens}, Output: ${valuationUsage.outputTokens}, Total: ${valuationUsage.totalTokens}`,
+				);
+				console.log(
+					`Combined   - Input: ${totalInputTokens}, Output: ${totalOutputTokens}, Total: ${totalTokens}`,
+				);
 				console.log(`Estimated Cost: $${estimatedCostUSD.toFixed(6)} USD`);
 				console.log("================================");
 
@@ -1504,9 +1519,21 @@ Por favor proporciona una valoración detallada en Quetzales para el mercado gua
 					valuation: object,
 					message: "Valoración por IA generada exitosamente",
 					usage: {
-						webSearch: { inputTokens: searchUsage.inputTokens, outputTokens: searchUsage.outputTokens, totalTokens: searchUsage.totalTokens },
-						valuation: { inputTokens: valuationUsage.inputTokens, outputTokens: valuationUsage.outputTokens, totalTokens: valuationUsage.totalTokens },
-						total: { inputTokens: totalInputTokens, outputTokens: totalOutputTokens, totalTokens },
+						webSearch: {
+							inputTokens: searchUsage.inputTokens,
+							outputTokens: searchUsage.outputTokens,
+							totalTokens: searchUsage.totalTokens,
+						},
+						valuation: {
+							inputTokens: valuationUsage.inputTokens,
+							outputTokens: valuationUsage.outputTokens,
+							totalTokens: valuationUsage.totalTokens,
+						},
+						total: {
+							inputTokens: totalInputTokens,
+							outputTokens: totalOutputTokens,
+							totalTokens,
+						},
 						estimatedCostUSD: Number(estimatedCostUSD.toFixed(6)),
 					},
 				};

--- a/apps/crm/apps/web/src/components/client-forms/CreditApplicationForm.tsx
+++ b/apps/crm/apps/web/src/components/client-forms/CreditApplicationForm.tsx
@@ -256,7 +256,7 @@ export function CreditApplicationForm({
 				</CardHeader>
 				<CardContent className="grid grid-cols-1 gap-4 sm:grid-cols-2">
 					<div className="space-y-2">
-						<Label>Profesión</Label>
+						<Label>Profesión (último grado académico)</Label>
 						<Input {...register("profesion")} />
 					</div>
 					<div className="space-y-2">
@@ -383,7 +383,7 @@ export function CreditApplicationForm({
 			{/* Referencias Crediticias */}
 			<Card>
 				<CardHeader>
-					<CardTitle>Referencias Crediticias</CardTitle>
+					<CardTitle>Referencias Familiares</CardTitle>
 				</CardHeader>
 				<CardContent className="space-y-4">
 					{[0, 1, 2].map((i) => (

--- a/apps/crm/apps/web/src/components/client-forms/FinancialStatementForm.tsx
+++ b/apps/crm/apps/web/src/components/client-forms/FinancialStatementForm.tsx
@@ -19,6 +19,7 @@ interface FinancialStatementFormProps {
 	defaultValues?: Partial<FinancialStatementFormData>;
 	onSubmit: (data: FinancialStatementFormData) => void;
 	isSubmitting?: boolean;
+	onBack?: () => void;
 }
 
 function parseNum(val: string | undefined): number {
@@ -43,6 +44,7 @@ export function FinancialStatementForm({
 	defaultValues,
 	onSubmit,
 	isSubmitting,
+	onBack,
 }: FinancialStatementFormProps) {
 	const {
 		register,
@@ -713,7 +715,14 @@ export function FinancialStatementForm({
 				</CardContent>
 			</Card>
 
-			<div className="flex justify-end">
+			<div className="flex justify-between">
+				{onBack ? (
+					<Button type="button" variant="outline" size="lg" onClick={onBack}>
+						Volver
+					</Button>
+				) : (
+					<div />
+				)}
 				<Button type="submit" size="lg" disabled={isSubmitting}>
 					{isSubmitting ? "Guardando..." : "Continuar a Firma"}
 				</Button>

--- a/apps/crm/apps/web/src/components/client-forms/SignatureConsent.tsx
+++ b/apps/crm/apps/web/src/components/client-forms/SignatureConsent.tsx
@@ -9,6 +9,7 @@ interface SignatureConsentProps {
 	dpi: string;
 	nit?: string;
 	isSubmitting?: boolean;
+	onBack?: () => void;
 }
 
 export function SignatureConsent({
@@ -17,6 +18,7 @@ export function SignatureConsent({
 	dpi,
 	nit,
 	isSubmitting,
+	onBack,
 }: SignatureConsentProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const signaturePadRef = useRef<SignaturePad | null>(null);
@@ -149,7 +151,14 @@ export function SignatureConsent({
 				</CardContent>
 			</Card>
 
-			<div className="flex justify-end">
+			<div className="flex justify-between">
+				{onBack ? (
+					<Button type="button" variant="outline" size="lg" onClick={onBack}>
+						Volver
+					</Button>
+				) : (
+					<div />
+				)}
 				<Button
 					type="button"
 					size="lg"

--- a/apps/crm/apps/web/src/components/disbursement/DisbursementView.tsx
+++ b/apps/crm/apps/web/src/components/disbursement/DisbursementView.tsx
@@ -53,12 +53,8 @@ export function DisbursementView({
 	const isAccounting =
 		userRole != null && PERMISSIONS.canAccessAccounting(userRole);
 
-	const amountToFinance = quotation
-		? Number(quotation.amountToFinance)
-		: 0;
-	const totalFinanced = quotation
-		? Number(quotation.totalFinanced)
-		: 0;
+	const amountToFinance = quotation ? Number(quotation.amountToFinance) : 0;
+	const totalFinanced = quotation ? Number(quotation.totalFinanced) : 0;
 	const gastos = totalFinanced - amountToFinance;
 
 	// Query for disbursement info (accounting documents)
@@ -72,15 +68,13 @@ export function DisbursementView({
 	// Query for checks associated with the opportunity
 	const checksQuery = useQuery({
 		queryKey: ["getChecksByOpportunity", opportunityId],
-		queryFn: () =>
-			client.getChecksByOpportunity({ opportunityId }),
+		queryFn: () => client.getChecksByOpportunity({ opportunityId }),
 	});
 
 	const uploadDisbursementMutation = useMutation({
 		mutationFn: async (file: File) => {
 			const notificationId = disbursementQuery.data?.notificationId;
-			if (!notificationId)
-				throw new Error("No hay notificación de desembolso");
+			if (!notificationId) throw new Error("No hay notificación de desembolso");
 
 			const data = await new Promise<string>((resolve, reject) => {
 				const reader = new FileReader();
@@ -171,8 +165,7 @@ export function DisbursementView({
 	);
 
 	const hasDocuments =
-		disbursementQuery.data &&
-		disbursementQuery.data.documents.length > 0;
+		disbursementQuery.data && disbursementQuery.data.documents.length > 0;
 
 	return (
 		<div className="space-y-6">
@@ -188,9 +181,7 @@ export function DisbursementView({
 						</p>
 					</div>
 					<div className="rounded-lg border bg-muted/30 p-4">
-						<span className="text-muted-foreground text-xs">
-							Gastos
-						</span>
+						<span className="text-muted-foreground text-xs">Gastos</span>
 						<p className="font-bold text-2xl text-orange-600">
 							Q{gastos.toLocaleString()}
 						</p>
@@ -202,9 +193,7 @@ export function DisbursementView({
 			<div className="space-y-3">
 				<div className="flex items-center gap-2">
 					<FileText className="h-5 w-5 text-muted-foreground" />
-					<h3 className="font-semibold text-lg">
-						Boletas de desembolso
-					</h3>
+					<h3 className="font-semibold text-lg">Boletas de desembolso</h3>
 				</div>
 
 				{disbursementQuery.isLoading ? (
@@ -230,16 +219,8 @@ export function DisbursementView({
 									</div>
 								</div>
 								<div className="flex shrink-0 items-center gap-1">
-									<a
-										href={doc.url}
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										<Button
-											size="sm"
-											variant="outline"
-											className="h-8"
-										>
+									<a href={doc.url} target="_blank" rel="noopener noreferrer">
+										<Button size="sm" variant="outline" className="h-8">
 											<Download className="mr-1 h-3 w-3" />
 											Descargar
 										</Button>
@@ -249,13 +230,9 @@ export function DisbursementView({
 											size="sm"
 											variant="ghost"
 											className="h-8 text-destructive hover:text-destructive"
-											disabled={
-												deleteDisbursementDocMutation.isPending
-											}
+											disabled={deleteDisbursementDocMutation.isPending}
 											onClick={() =>
-												deleteDisbursementDocMutation.mutate(
-													doc.id,
-												)
+												deleteDisbursementDocMutation.mutate(doc.id)
 											}
 										>
 											<Trash2 className="h-4 w-4" />
@@ -275,44 +252,41 @@ export function DisbursementView({
 				)}
 
 				{/* Upload area - only for accounting */}
-				{isAccounting &&
-					disbursementQuery.data?.notificationId && (
-						<div
-							className="flex cursor-pointer items-center justify-center gap-2 rounded-md border-2 border-muted-foreground/25 border-dashed px-4 py-2.5 transition-colors hover:border-muted-foreground/50"
-							role="button"
-							tabIndex={0}
-							onClick={() => fileInputRef.current?.click()}
-							onKeyDown={(e) => {
-								if (e.key === "Enter" || e.key === " ") {
-									e.preventDefault();
-									fileInputRef.current?.click();
-								}
-							}}
-						>
-							{uploadingDisbursement ? (
-								<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-							) : (
-								<Upload className="h-4 w-4 text-muted-foreground/50" />
-							)}
-							<span className="text-muted-foreground text-sm">
-								{uploadingDisbursement
-									? "Subiendo..."
-									: "Subir boletas"}
-							</span>
-							<span className="text-[11px] text-muted-foreground/60">
-								(PDF, imágenes, Word, Excel)
-							</span>
-							<input
-								ref={fileInputRef}
-								type="file"
-								multiple
-								accept=".pdf,.jpg,.jpeg,.png,.webp,.doc,.docx,.xls,.xlsx"
-								className="hidden"
-								onChange={handleDisbursementFileSelect}
-								disabled={uploadingDisbursement}
-							/>
-						</div>
-					)}
+				{isAccounting && disbursementQuery.data?.notificationId && (
+					<div
+						className="flex cursor-pointer items-center justify-center gap-2 rounded-md border-2 border-muted-foreground/25 border-dashed px-4 py-2.5 transition-colors hover:border-muted-foreground/50"
+						role="button"
+						tabIndex={0}
+						onClick={() => fileInputRef.current?.click()}
+						onKeyDown={(e) => {
+							if (e.key === "Enter" || e.key === " ") {
+								e.preventDefault();
+								fileInputRef.current?.click();
+							}
+						}}
+					>
+						{uploadingDisbursement ? (
+							<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+						) : (
+							<Upload className="h-4 w-4 text-muted-foreground/50" />
+						)}
+						<span className="text-muted-foreground text-sm">
+							{uploadingDisbursement ? "Subiendo..." : "Subir boletas"}
+						</span>
+						<span className="text-[11px] text-muted-foreground/60">
+							(PDF, imágenes, Word, Excel)
+						</span>
+						<input
+							ref={fileInputRef}
+							type="file"
+							multiple
+							accept=".pdf,.jpg,.jpeg,.png,.webp,.doc,.docx,.xls,.xlsx"
+							className="hidden"
+							onChange={handleDisbursementFileSelect}
+							disabled={uploadingDisbursement}
+						/>
+					</div>
+				)}
 
 				{/* Notify sales button */}
 				{isAccounting && hasDocuments && (
@@ -334,8 +308,7 @@ export function DisbursementView({
 				{!disbursementQuery.data?.notificationId &&
 					!disbursementQuery.isLoading && (
 						<p className="text-muted-foreground text-sm">
-							No hay notificación de desembolso para esta
-							oportunidad.
+							No hay notificación de desembolso para esta oportunidad.
 						</p>
 					)}
 			</div>
@@ -344,17 +317,12 @@ export function DisbursementView({
 			<div className="space-y-3">
 				<div className="flex items-center gap-2">
 					<Banknote className="h-5 w-5 text-muted-foreground" />
-					<h3 className="font-semibold text-lg">
-						Cheques / Transferencias
-					</h3>
+					<h3 className="font-semibold text-lg">Cheques / Transferencias</h3>
 				</div>
 
 				{checksQuery.isLoading ? (
-					<p className="text-muted-foreground text-sm">
-						Cargando cheques...
-					</p>
-				) : checksQuery.data &&
-					checksQuery.data.length > 0 ? (
+					<p className="text-muted-foreground text-sm">Cargando cheques...</p>
+				) : checksQuery.data && checksQuery.data.length > 0 ? (
 					<div className="space-y-3">
 						{checksQuery.data.map((check: CreditCheck) => (
 							<div
@@ -364,10 +332,7 @@ export function DisbursementView({
 								<div className="flex items-start justify-between gap-4">
 									<div className="space-y-2">
 										<div className="flex items-center gap-3">
-											<Badge
-												variant="outline"
-												className="text-sm"
-											>
+											<Badge variant="outline" className="text-sm">
 												{check.transferType}
 											</Badge>
 											<span className="font-semibold text-base">
@@ -421,24 +386,17 @@ export function DisbursementView({
 													Fecha
 												</span>
 												<p className="font-medium text-sm">
-													{format(
-														new Date(check.checkDate),
-														"dd/MM/yyyy",
-														{ locale: es },
-													)}
+													{format(new Date(check.checkDate), "dd/MM/yyyy", {
+														locale: es,
+													})}
 												</p>
 											</div>
 										</div>
 									</div>
 									<div className="shrink-0 text-right">
-										<span className="text-muted-foreground text-xs">
-											Monto
-										</span>
+										<span className="text-muted-foreground text-xs">Monto</span>
 										<p className="font-bold text-green-600 text-xl">
-											{check.currency}{" "}
-											{Number(
-												check.amount,
-											).toLocaleString()}
+											{check.currency} {Number(check.amount).toLocaleString()}
 										</p>
 									</div>
 								</div>

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -190,8 +190,7 @@ export function OpportunityDetailModal({
 	const canViewContracts =
 		userRole && PERMISSIONS.canViewOpportunityContracts(userRole);
 	const canAccessCRM = userRole && PERMISSIONS.canAccessCRM(userRole);
-	const isAccounting =
-		userRole && PERMISSIONS.canAccessAccounting(userRole);
+	const isAccounting = userRole && PERMISSIONS.canAccessAccounting(userRole);
 	const isWon = opportunity?.status === "won";
 
 	return (
@@ -434,7 +433,6 @@ export function OpportunityDetailModal({
 									</div>
 								</div>
 							)}
-
 						</div>
 
 						{/* Contracts Section */}
@@ -746,12 +744,12 @@ export function OpportunityDetailModal({
 								quotation={
 									opportunityQuotationsQuery.data?.[0]
 										? {
-												amountToFinance:
-													(opportunityQuotationsQuery.data[0] as any)
-														.amountToFinance,
-												totalFinanced:
-													(opportunityQuotationsQuery.data[0] as any)
-														.totalFinanced,
+												amountToFinance: (
+													opportunityQuotationsQuery.data[0] as any
+												).amountToFinance,
+												totalFinanced: (
+													opportunityQuotationsQuery.data[0] as any
+												).totalFinanced,
 											}
 										: null
 								}

--- a/apps/crm/apps/web/src/routes/formulario.$token.tsx
+++ b/apps/crm/apps/web/src/routes/formulario.$token.tsx
@@ -113,22 +113,24 @@ function FormularioPage() {
 	};
 
 	// Build pre-fill defaults from lead data
-	const creditDefaults = validatedData?.lead
-		? {
-				primerNombre: (validatedData.lead.firstName as string) || "",
-				segundoNombre: (validatedData.lead.middleName as string) || "",
-				primerApellido: (validatedData.lead.lastName as string) || "",
-				segundoApellido: (validatedData.lead.secondLastName as string) || "",
-				dpi: (validatedData.lead.dpi as string) || "",
-				nit: (validatedData.lead.nit as string) || "",
-				email: (validatedData.lead.email as string) || "",
-				telMovil: (validatedData.lead.phone as string) || "",
-				direccionResidencia: (validatedData.lead.direccion as string) || "",
-				vehiculoMarca: (validatedData.vehicle?.make as string) || "",
-				vehiculoLinea: (validatedData.vehicle?.model as string) || "",
-				vehiculoModelo: (validatedData.vehicle?.year as string) || "",
-			}
-		: undefined;
+	const creditDefaults = creditDataRef.current
+		? creditDataRef.current
+		: validatedData?.lead
+			? {
+					primerNombre: (validatedData.lead.firstName as string) || "",
+					segundoNombre: (validatedData.lead.middleName as string) || "",
+					primerApellido: (validatedData.lead.lastName as string) || "",
+					segundoApellido: (validatedData.lead.secondLastName as string) || "",
+					dpi: (validatedData.lead.dpi as string) || "",
+					nit: (validatedData.lead.nit as string) || "",
+					email: (validatedData.lead.email as string) || "",
+					telMovil: (validatedData.lead.phone as string) || "",
+					direccionResidencia: (validatedData.lead.direccion as string) || "",
+					vehiculoMarca: (validatedData.vehicle?.make as string) || "",
+					vehiculoLinea: (validatedData.vehicle?.model as string) || "",
+					vehiculoModelo: (validatedData.vehicle?.year as string) || "",
+				}
+			: undefined;
 
 	const financialDefaults = creditDataRef.current
 		? {

--- a/apps/crm/apps/web/src/routes/formulario.$token.tsx
+++ b/apps/crm/apps/web/src/routes/formulario.$token.tsx
@@ -86,6 +86,9 @@ function FormularioPage() {
 		setStep("signature");
 	};
 
+	const handleBackToCredit = () => setStep("credit");
+	const handleBackToFinancial = () => setStep("financial");
+
 	const handleSignatureComplete = async (signatureDataUrl: string) => {
 		if (!financialDataRef.current) return;
 		setIsSubmitting(true);
@@ -255,6 +258,7 @@ function FormularioPage() {
 						defaultValues={financialDefaults}
 						onSubmit={handleFinancialSubmit}
 						isSubmitting={isSubmitting}
+						onBack={handleBackToCredit}
 					/>
 				)}
 				{step === "signature" && (
@@ -264,6 +268,7 @@ function FormularioPage() {
 						dpi={creditDataRef.current?.dpi || ""}
 						nit={creditDataRef.current?.nit}
 						isSubmitting={isSubmitting}
+						onBack={handleBackToFinancial}
 					/>
 				)}
 			</div>

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -79,11 +79,11 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Inspection360View } from "@/components/vehicles/inspection-360-view";
 import { VehicleDocumentUpload } from "@/components/vehicles/VehicleDocumentUpload";
+import { ROLES } from "@/lib/roles";
 import {
 	renderInspectionStatusBadge,
 	renderNewVehicleBadges,
 } from "@/lib/vehicle-utils";
-import { ROLES } from "@/lib/roles";
 import { client, orpc } from "@/utils/orpc";
 
 // Helper para renderizar el badge del estado del vehículo
@@ -180,9 +180,7 @@ function VehiclesDashboard() {
 	const { data: statistics } = useQuery(
 		orpc.getVehicleStatistics.queryOptions(),
 	);
-	const { data: userProfile } = useQuery(
-		orpc.getUserProfile.queryOptions(),
-	);
+	const { data: userProfile } = useQuery(orpc.getUserProfile.queryOptions());
 
 	// Get vehicles data from paginated response
 	const vehiclesList = vehicles?.data || [];
@@ -2438,72 +2436,73 @@ function VehiclesDashboard() {
 											<span className="font-medium">Vendido</span>
 										</div>
 										<p className="text-muted-foreground text-xs">
-											Solo un administrador o supervisor de ventas puede cambiar el estado de un vehículo vendido.
+											Solo un administrador o supervisor de ventas puede cambiar
+											el estado de un vehículo vendido.
 										</p>
 									</div>
 								) : (
-								<Select
-									value={editVehicleForm.status}
-									onValueChange={(
-										value:
-											| "pending"
-											| "available"
-											| "sold"
-											| "maintenance"
-											| "auction",
-									) =>
-										setEditVehicleForm({
-											...editVehicleForm,
-											status: value,
-										})
-									}
-								>
-									<SelectTrigger>
-										<SelectValue placeholder="Seleccionar estado" />
-									</SelectTrigger>
-									<SelectContent>
-										<SelectItem value="pending">
-											<div className="flex flex-col">
-												<span className="font-medium">Pendiente</span>
-												<span className="text-muted-foreground text-xs">
-													En espera o Próximo a la venta
-												</span>
-											</div>
-										</SelectItem>
-										<SelectItem value="available">
-											<div className="flex flex-col">
-												<span className="font-medium">Disponible</span>
-												<span className="text-muted-foreground text-xs">
-													Listo para venta o financiamiento
-												</span>
-											</div>
-										</SelectItem>
-										<SelectItem value="sold">
-											<div className="flex flex-col">
-												<span className="font-medium">Vendido</span>
-												<span className="text-muted-foreground text-xs">
-													Vehículo ya fue vendido/financiado
-												</span>
-											</div>
-										</SelectItem>
-										<SelectItem value="maintenance">
-											<div className="flex flex-col">
-												<span className="font-medium">En Mantenimiento</span>
-												<span className="text-muted-foreground text-xs">
-													En reparación o servicio técnico
-												</span>
-											</div>
-										</SelectItem>
-										<SelectItem value="auction">
-											<div className="flex flex-col">
-												<span className="font-medium">En Remate</span>
-												<span className="text-muted-foreground text-xs">
-													Disponible para subasta/remate
-												</span>
-											</div>
-										</SelectItem>
-									</SelectContent>
-								</Select>
+									<Select
+										value={editVehicleForm.status}
+										onValueChange={(
+											value:
+												| "pending"
+												| "available"
+												| "sold"
+												| "maintenance"
+												| "auction",
+										) =>
+											setEditVehicleForm({
+												...editVehicleForm,
+												status: value,
+											})
+										}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="Seleccionar estado" />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="pending">
+												<div className="flex flex-col">
+													<span className="font-medium">Pendiente</span>
+													<span className="text-muted-foreground text-xs">
+														En espera o Próximo a la venta
+													</span>
+												</div>
+											</SelectItem>
+											<SelectItem value="available">
+												<div className="flex flex-col">
+													<span className="font-medium">Disponible</span>
+													<span className="text-muted-foreground text-xs">
+														Listo para venta o financiamiento
+													</span>
+												</div>
+											</SelectItem>
+											<SelectItem value="sold">
+												<div className="flex flex-col">
+													<span className="font-medium">Vendido</span>
+													<span className="text-muted-foreground text-xs">
+														Vehículo ya fue vendido/financiado
+													</span>
+												</div>
+											</SelectItem>
+											<SelectItem value="maintenance">
+												<div className="flex flex-col">
+													<span className="font-medium">En Mantenimiento</span>
+													<span className="text-muted-foreground text-xs">
+														En reparación o servicio técnico
+													</span>
+												</div>
+											</SelectItem>
+											<SelectItem value="auction">
+												<div className="flex flex-col">
+													<span className="font-medium">En Remate</span>
+													<span className="text-muted-foreground text-xs">
+														Disponible para subasta/remate
+													</span>
+												</div>
+											</SelectItem>
+										</SelectContent>
+									</Select>
 								)}
 							</div>
 						</div>

--- a/apps/crm/apps/web/src/utils/orpc.ts
+++ b/apps/crm/apps/web/src/utils/orpc.ts
@@ -4,7 +4,10 @@ import type { RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import type { appRouter, disbursementRouter } from "../../../server/src/routers/index";
+import type {
+	appRouter,
+	disbursementRouter,
+} from "../../../server/src/routers/index";
 import type { investmentsRouter } from "../../../server/src/routers/investments";
 
 // Detectar si es un error de sesión/autenticación
@@ -59,7 +62,9 @@ export const link = new RPCLink({
 
 // Merge router types to avoid TS7056 with declaration emit
 // See: https://orpc.dev/docs/advanced/exceeds-the-maximum-length-problem
-type MergedRouter = typeof appRouter & typeof investmentsRouter & typeof disbursementRouter;
+type MergedRouter = typeof appRouter &
+	typeof investmentsRouter &
+	typeof disbursementRouter;
 
 export const client: RouterClient<MergedRouter> = createORPCClient(link);
 

--- a/apps/portal-web/src/features/Credit/Sections/StartToday.tsx
+++ b/apps/portal-web/src/features/Credit/Sections/StartToday.tsx
@@ -1,4 +1,5 @@
 import { BoottomSheets, ModalChatBot } from "@/components";
+import { IconMessage } from "@/components/icons/color";
 import { Whatsapp } from "@/features/footer/icons";
 import { motion } from "framer-motion";
 import { useModalOptionsCall } from "@/hooks";


### PR DESCRIPTION
## Summary
- Sanitiza strings vacíos a `null` para columnas `decimal`/`integer` en el servidor, corrigiendo el error de PostgreSQL que impedía enviar formularios
- Agrega validación numérica en el sanitizer para rechazar valores no-numéricos
- Agrega botones "Volver" en los pasos 2 (Estado Patrimonial) y 3 (Firma) del wizard de formularios
- Preserva datos del formulario de crédito al navegar hacia atrás
- Actualiza labels: "Profesión" → "Profesión (último grado académico)", "Referencias Crediticias" → "Referencias Familiares"
- Incluye fixes de formateo de Biome

## Test plan
- [ ] Abrir un enlace de formulario público con token válido
- [ ] Completar paso 1 (Solicitud de Crédito) y enviar — debe avanzar al paso 2
- [ ] En paso 2, presionar "Volver" — debe regresar al paso 1 con los datos previamente ingresados
- [ ] Enviar formularios dejando campos numéricos vacíos — no debe fallar
- [ ] Completar todo el flujo hasta la firma y verificar que se guarde correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)