### PR TITLE
feat(server): update billing payload for new credit identification

### DIFF
--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -605,10 +605,11 @@ function generateInvoicesInBackground(params: GenerateInvoicesParams): void {
 
 					// Construir el payload exacto que se envía al endpoint
 					const requestBody = {
-						nit: nit || "CF", // CF = Consumidor Final si no hay NIT
+						nit: nit,
 						items: invoice.items,
 						emisor: "CUBE",
 						created_by: FACTURACION_CREATED_BY,
+						credito_nuevo: true, // Indicamos que es un crédito nuevo para que cartera-back lo maneje como tal
 					};
 
 					// Llamar al endpoint de facturación genérica


### PR DESCRIPTION
- Add the `credito_nuevo` flag to the billing request payload to ensure the downstream service processes the record as a new credit.
- Remove the "CF" (Consumidor Final) fallback for the NIT field to allow the actual value to be passed directly.