### PR TITLE
fix: opportunity month filter, independent form downloads, search improvements

### DIFF
--- a/apps/crm/apps/server/src/routers/client-forms.ts
+++ b/apps/crm/apps/server/src/routers/client-forms.ts
@@ -78,9 +78,7 @@ const creditApplicationServerSchema = z.object({
 	conyugeDireccion: z.string().optional(),
 	conyugeTelOficina: z.string().optional(),
 	conyugeTelMovil: z.string().optional(),
-	referenciasCrediticias: z
-		.array(referenciaCrediticiaServerSchema)
-		.optional(),
+	referenciasCrediticias: z.array(referenciaCrediticiaServerSchema).optional(),
 	cuentasBancarias: z.array(cuentaBancariaServerSchema).optional(),
 	referenciasPersonales: z.array(referenciaPersonalServerSchema).optional(),
 	esPep: z.boolean().optional(),
@@ -251,9 +249,7 @@ function sanitizeFormData(
 				sanitized[key] = Number.isNaN(num) ? null : Math.trunc(num);
 			}
 		} else if (JSONB_ARRAY_FIELDS.has(key) && Array.isArray(value)) {
-			sanitized[key] = sanitizeJsonbArray(
-				value as Record<string, unknown>[],
-			);
+			sanitized[key] = sanitizeJsonbArray(value as Record<string, unknown>[]);
 		} else {
 			sanitized[key] = value;
 		}

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1109,7 +1109,7 @@ export const crmRouter = {
 				conditions.push(eq(opportunities.id, input.opportunityId));
 			}
 
-			// Search filter (by title, company name, or lead name)
+			// Search filter (by title, company name, lead name, phone, or opportunity ID)
 			if (searchTerm) {
 				conditions.push(
 					or(
@@ -1118,6 +1118,8 @@ export const crmRouter = {
 						ilike(leads.firstName, `%${searchTerm}%`),
 						ilike(leads.lastName, `%${searchTerm}%`),
 						ilike(opportunities.numeroSifco, `%${searchTerm}%`),
+						ilike(leads.phone, `%${searchTerm}%`),
+						ilike(opportunities.id, `%${searchTerm}%`),
 					),
 				);
 			}

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1134,7 +1134,7 @@ export const crmRouter = {
 				conditions.push(eq(opportunities.source, input.source));
 			}
 
-			// Filtro por mes/año: createdAt para oportunidades < 90%, actual_close_date para >= 90%
+			// Filtro por mes/año: oportunidades abiertas siempre visibles, cerradas filtradas por actual_close_date
 			if (input?.createdMonth && input?.createdYear) {
 				const startOfMonth = new Date(
 					input.createdYear,
@@ -1143,34 +1143,18 @@ export const crmRouter = {
 				);
 				const endOfMonth = new Date(input.createdYear, input.createdMonth, 1);
 
-				const PLACED_STAGE_THRESHOLD = 90;
-				const placedStages = await db
-					.select({ id: salesStages.id })
-					.from(salesStages)
-					.where(gte(salesStages.closurePercentage, PLACED_STAGE_THRESHOLD));
-				const placedStageIds = placedStages.map((s) => s.id);
-
-				if (placedStageIds.length > 0) {
-					conditions.push(
-						or(
-							// < 90%: filtrar por fecha de creación
-							and(
-								not(inArray(opportunities.stageId, placedStageIds)),
-								gte(opportunities.createdAt, startOfMonth),
-								lt(opportunities.createdAt, endOfMonth),
-							),
-							// >= 90%: filtrar por fecha de cierre
-							and(
-								inArray(opportunities.stageId, placedStageIds),
-								gte(opportunities.actualCloseDate, startOfMonth),
-								lt(opportunities.actualCloseDate, endOfMonth),
-							),
+				conditions.push(
+					or(
+						// Oportunidades abiertas/on_hold: siempre visibles
+						inArray(opportunities.status, ["open", "on_hold"]),
+						// Oportunidades cerradas (won/lost): filtrar por fecha de cierre
+						and(
+							inArray(opportunities.status, ["won", "lost"]),
+							gte(opportunities.actualCloseDate, startOfMonth),
+							lt(opportunities.actualCloseDate, endOfMonth),
 						),
-					);
-				} else {
-					conditions.push(gte(opportunities.createdAt, startOfMonth));
-					conditions.push(lt(opportunities.createdAt, endOfMonth));
-				}
+					),
+				);
 			}
 
 			// Role-based filter: admin and sales_supervisor can see all, others only their own

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -8,6 +8,7 @@ import {
 	ilike,
 	inArray,
 	isNotNull,
+	isNull,
 	lt,
 	lte,
 	not,
@@ -1119,7 +1120,7 @@ export const crmRouter = {
 						ilike(leads.lastName, `%${searchTerm}%`),
 						ilike(opportunities.numeroSifco, `%${searchTerm}%`),
 						ilike(leads.phone, `%${searchTerm}%`),
-						ilike(opportunities.id, `%${searchTerm}%`),
+						sql`${opportunities.id}::text ILIKE ${`%${searchTerm}%`}`,
 					),
 				);
 			}
@@ -1152,8 +1153,18 @@ export const crmRouter = {
 						// Oportunidades cerradas (won/lost): filtrar por fecha de cierre
 						and(
 							inArray(opportunities.status, ["won", "lost"]),
-							gte(opportunities.actualCloseDate, startOfMonth),
-							lt(opportunities.actualCloseDate, endOfMonth),
+							or(
+								and(
+									gte(opportunities.actualCloseDate, startOfMonth),
+									lt(opportunities.actualCloseDate, endOfMonth),
+								),
+								// Fallback: si no tiene fecha de cierre, usar fecha de creación
+								and(
+									isNull(opportunities.actualCloseDate),
+									gte(opportunities.createdAt, startOfMonth),
+									lt(opportunities.createdAt, endOfMonth),
+								),
+							),
 						),
 					),
 				);

--- a/apps/crm/apps/web/src/components/client-forms/ClientFormsSection.tsx
+++ b/apps/crm/apps/web/src/components/client-forms/ClientFormsSection.tsx
@@ -180,34 +180,38 @@ export function ClientFormsSection({ opportunityId }: ClientFormsSectionProps) {
 			</div>
 
 			{/* PDF Downloads */}
-			{isComplete && formData && (
+			{(hasCreditApp || hasFinancialStmt) && formData && (
 				<div className="flex gap-3">
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() =>
-							generateCreditApplicationPdf(
-								formData.creditApplication as Record<string, unknown>,
-								(formData.financialStatement as Record<string, unknown>)
-									?.firmaImagen as string | undefined,
-							)
-						}
-					>
-						<Download className="mr-2 h-4 w-4" />
-						Descargar Solicitud PDF
-					</Button>
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() =>
-							generateFinancialStatementPdf(
-								formData.financialStatement as Record<string, unknown>,
-							)
-						}
-					>
-						<Download className="mr-2 h-4 w-4" />
-						Descargar Estado Patrimonial PDF
-					</Button>
+					{hasCreditApp && (
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() =>
+								generateCreditApplicationPdf(
+									formData.creditApplication as Record<string, unknown>,
+									(formData.financialStatement as Record<string, unknown>)
+										?.firmaImagen as string | undefined,
+								)
+							}
+						>
+							<Download className="mr-2 h-4 w-4" />
+							Descargar Solicitud PDF
+						</Button>
+					)}
+					{hasFinancialStmt && (
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() =>
+								generateFinancialStatementPdf(
+									formData.financialStatement as Record<string, unknown>,
+								)
+							}
+						>
+							<Download className="mr-2 h-4 w-4" />
+							Descargar Estado Patrimonial PDF
+						</Button>
+					)}
 				</div>
 			)}
 		</div>

--- a/apps/crm/apps/web/src/lib/generate-client-form-pdfs.ts
+++ b/apps/crm/apps/web/src/lib/generate-client-form-pdfs.ts
@@ -355,12 +355,9 @@ export function generateCreditApplicationPdf(
 	y = 20;
 	doc.setFontSize(13);
 	doc.setFont("helvetica", "bold");
-	doc.text(
-		"CLAUSULA DE CONSENTIMIENTO DEL CIUDADANO",
-		pageWidth / 2,
-		y,
-		{ align: "center" },
-	);
+	doc.text("CLAUSULA DE CONSENTIMIENTO DEL CIUDADANO", pageWidth / 2, y, {
+		align: "center",
+	});
 	y += 10;
 
 	doc.setFontSize(8);
@@ -424,7 +421,11 @@ export function generateCreditApplicationPdf(
 	doc.setFont("helvetica", "bold");
 	doc.text("Fecha:", consentMargin, y);
 	doc.setFont("helvetica", "normal");
-	doc.text(val(data.fechaFirma) || new Date().toLocaleDateString("es-GT"), consentMargin + 35, y);
+	doc.text(
+		val(data.fechaFirma) || new Date().toLocaleDateString("es-GT"),
+		consentMargin + 35,
+		y,
+	);
 	y += 10;
 
 	// Consent signature

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -683,6 +683,8 @@ function RouteComponent() {
 		...orpc.getOpportunities.queryOptions({
 			input: {
 				excludeStatuses: ["migrate"],
+				createdMonth: month,
+				createdYear: year,
 				...(sourceFilter !== "all" ? { source: sourceFilter as any } : {}),
 			},
 		}),
@@ -694,6 +696,8 @@ function RouteComponent() {
 			"getOpportunities",
 			session?.user?.id,
 			userProfile.data?.role,
+			month,
+			year,
 			sourceFilter,
 		],
 	});

--- a/apps/crm/apps/web/src/routes/formulario.$token.tsx
+++ b/apps/crm/apps/web/src/routes/formulario.$token.tsx
@@ -136,7 +136,8 @@ function FormularioPage() {
 			: undefined;
 
 	// Source for financial pre-fill: in-session data or existing credit from DB
-	const creditSource = creditDataRef.current ?? validatedData?.existingCreditApplication;
+	const creditSource =
+		creditDataRef.current ?? validatedData?.existingCreditApplication;
 
 	const financialDefaults = creditSource
 		? {


### PR DESCRIPTION
## Summary
- **Filtro por mes mejorado**: Las oportunidades abiertas/on_hold siempre se muestran sin importar el mes seleccionado. Las cerradas (won/lost) se filtran por `actual_close_date`. Aplica para todos los roles.
- **Descarga independiente de PDFs**: Cada formulario (solicitud de crédito / estado patrimonial) se puede descargar individualmente sin requerir que ambos estén completos.
- **Búsqueda ampliada**: Se puede buscar oportunidades por teléfono del lead e ID de la oportunidad.

## Test plan
- [ ] Verificar que oportunidades abiertas persisten al cambiar de mes
- [ ] Verificar que oportunidades won/lost se filtran por mes de cierre
- [ ] Verificar descarga de PDF con solo un formulario completado
- [ ] Verificar búsqueda por teléfono y por ID de oportunidad

🤖 Generated with [Claude Code](https://claude.com/claude-code)