### PR TITLE
feat(portal-web): move thank you page to /thanks route

### DIFF
--- a/apps/portal-web/src/features/FormLeads/FormLeads.tsx
+++ b/apps/portal-web/src/features/FormLeads/FormLeads.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/components";
-import { Formulario, InfoLead, Thanks } from "./components";
+import { Formulario, InfoLead } from "./components";
 import { useIsMobile } from "@/hooks";
-import { useLead } from "./store/useLead";
 import { Link } from "@/components/ui";
 import { IconCCI } from "@/components/IconCCI";
 
@@ -19,7 +18,6 @@ export const IconCashIn = () => (
 export const FormLeads = () => {
   const imageUrl = urlImage + "/landingForm.png";
   const isMobile = useIsMobile();
-  const isSubmitted = useLead((state) => state.isSubmitted);
 
   const handleRedirectInfo = () => {
     const infoSection = document.getElementById("info-lead");
@@ -27,11 +25,6 @@ export const FormLeads = () => {
       infoSection.scrollIntoView({ behavior: "smooth" });
     }
   };
-
-  // Si ya se envió el formulario, mostrar pantalla de agradecimiento
-  if (isSubmitted) {
-    return <Thanks />;
-  }
 
   return (
     <div className="flex flex-col gap-2 pt-4 lg:pt-6 mb-20">

--- a/apps/portal-web/src/features/FormLeads/hooks/useForm.ts
+++ b/apps/portal-web/src/features/FormLeads/hooks/useForm.ts
@@ -2,7 +2,7 @@ import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
-import { useLead } from "../store/useLead";
+import { useNavigate } from "@tanstack/react-router";
 import { sendLead } from "../service/serviceLead";
 
 export type CreditType = "autocompra" | "sobre_vehiculo";
@@ -57,15 +57,15 @@ const initialValues: FormLeadsValues = {
 };
 
 export const useFormLeads = () => {
-  const setSubmitted = useLead((state) => state.setSubmitted);
+  const navigate = useNavigate();
   const [serverError, setServerError] = useState<string>("");
 
   const mutation = useMutation({
     mutationFn: sendLead,
-    onSuccess: (data, variables) => {
+    onSuccess: (data) => {
       console.log("Lead enviado exitosamente:", data);
       setServerError("");
-      setSubmitted(variables);
+      navigate({ to: "/thanks", search: { type: "lead" } });
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {

--- a/apps/portal-web/src/features/LeadInvestor/LeadInvestor.tsx
+++ b/apps/portal-web/src/features/LeadInvestor/LeadInvestor.tsx
@@ -1,6 +1,5 @@
 import { useIsMobile } from "@/hooks";
-import { useLeadInvestor } from "./store/useLeadInvestor";
-import { FormularioInvestor, ThanksInvestor } from "./components";
+import { FormularioInvestor } from "./components";
 import { IconCashIn } from "@/features/FormLeads/FormLeads";
 
 const urlImage = import.meta.env.VITE_IMAGE_URL;
@@ -14,11 +13,6 @@ interface LeadInvestorProps {
 export const LeadInvestor = ({ initialAmount, initialTerm, initialType }: LeadInvestorProps) => {
   const imageUrl = urlImage + "/Frame 1321315308.png";
   const isMobile = useIsMobile();
-  const isSubmitted = useLeadInvestor((state) => state.isSubmitted);
-
-  if (isSubmitted) {
-    return <ThanksInvestor />;
-  }
 
   return (
     <div className="flex flex-col  pt-4 lg:pt-6 mb-20">

--- a/apps/portal-web/src/features/LeadInvestor/hooks/useFormInvestor.ts
+++ b/apps/portal-web/src/features/LeadInvestor/hooks/useFormInvestor.ts
@@ -2,7 +2,7 @@ import { useFormik } from "formik";
 import * as Yup from "yup";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
-import { useLeadInvestor } from "../store/useLeadInvestor";
+import { useNavigate } from "@tanstack/react-router";
 import { sendLeadInvestor } from "../service/serviceLeadInvestor";
 
 export type ProfileType = "individual" | "juridica";
@@ -89,15 +89,15 @@ const buildInitialValues = (amount?: string, defaultMessage?: string): FormInves
 });
 
 export const useFormInvestor = (initialAmount?: string, defaultMessage?: string) => {
-  const setSubmitted = useLeadInvestor((state) => state.setSubmitted);
+  const navigate = useNavigate();
   const [serverError, setServerError] = useState<string>("");
 
   const mutation = useMutation({
     mutationFn: sendLeadInvestor,
-    onSuccess: (data, variables) => {
+    onSuccess: (data) => {
       console.log("Lead investor enviado exitosamente:", data);
       setServerError("");
-      setSubmitted(variables);
+      navigate({ to: "/thanks", search: { type: "investor" } });
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {

--- a/apps/portal-web/src/routes/thanks.tsx
+++ b/apps/portal-web/src/routes/thanks.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { Page } from "@/components";
+import { Thanks } from "@/features/FormLeads/components/Thanks";
+import { ThanksInvestor } from "@/features/LeadInvestor/components/ThanksInvestor";
+
+export const Route = createFileRoute("/thanks")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    type: (search.type as string) || "lead",
+  }),
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const { type } = Route.useSearch();
+
+  return (
+    <Page footerNotShowRedirects>
+      {type === "investor" ? <ThanksInvestor /> : <Thanks />}
+    </Page>
+  );
+}


### PR DESCRIPTION
## Summary
- Move the thank you page from rendering inline at `/leads` and `/leadInvestor` to a dedicated `/thanks` route
- After successful form submission, navigate to `/thanks?type=lead` or `/thanks?type=investor`
- This allows marketing to track conversions on a distinct URL instead of the form page

## Test plan
- [ ] Submit lead form → verify redirect to `/thanks?type=lead`
- [ ] Submit investor lead form → verify redirect to `/thanks?type=investor`
- [ ] Verify correct thank you message displays for each type
- [ ] Navigate directly to `/thanks` → verify it defaults to lead thank you

🤖 Generated with [Claude Code](https://claude.com/claude-code)