### PR TITLE
fix: opportunity filters, independent form downloads, search, per-document signatures

### DIFF
--- a/apps/crm/apps/server/src/routers/client-forms.ts
+++ b/apps/crm/apps/server/src/routers/client-forms.ts
@@ -370,6 +370,7 @@ export const clientFormsRouter = {
 				lead,
 				vehicle,
 				creditApplicationExists: !!existingCredit,
+				creditHasSignature: !!existingCredit?.firmaImagen,
 				financialStatementExists: !!existingFinancial,
 				// Only return fields needed for pre-fill, not the full row
 				existingCreditApplication: existingCredit
@@ -441,6 +442,56 @@ export const clientFormsRouter = {
 				);
 				throw new ORPCError("INTERNAL_SERVER_ERROR", {
 					message: "Error al guardar la solicitud de crédito",
+				});
+			}
+
+			return { success: true };
+		}),
+
+	// Public: Sign credit application (add signature after submission)
+	signCreditApplication: publicProcedure
+		.input(
+			z.object({
+				token: z.string().uuid(),
+				firmaImagen: z.string(),
+				fechaFirma: z.string(),
+				horaFirma: z.string(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const tokenRow = await getValidToken(input.token);
+
+			try {
+				const [existing] = await db
+					.select()
+					.from(creditApplications)
+					.where(eq(creditApplications.opportunityId, tokenRow.opportunityId))
+					.limit(1);
+
+				if (!existing) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "No se encontró la solicitud de crédito para firmar",
+					});
+				}
+
+				await db
+					.update(creditApplications)
+					.set({
+						firmaImagen: input.firmaImagen,
+						fechaFirma: input.fechaFirma,
+						horaFirma: input.horaFirma,
+						updatedAt: new Date(),
+					})
+					.where(eq(creditApplications.id, existing.id));
+			} catch (error) {
+				if (error instanceof ORPCError) throw error;
+				console.error(
+					"[signCreditApplication] DB error for opportunity:",
+					tokenRow.opportunityId,
+					error,
+				);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "Error al firmar la solicitud de crédito",
 				});
 			}
 

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -106,6 +106,7 @@ export const appRouter = {
 	generateFormToken: clientFormsRouter.generateFormToken,
 	validateFormToken: clientFormsRouter.validateFormToken,
 	submitCreditApplication: clientFormsRouter.submitCreditApplication,
+	signCreditApplication: clientFormsRouter.signCreditApplication,
 	submitFinancialStatement: clientFormsRouter.submitFinancialStatement,
 	getClientFormData: clientFormsRouter.getClientFormData,
 	getFormTokenByOpportunity: clientFormsRouter.getFormTokenByOpportunity,

--- a/apps/crm/apps/web/src/components/client-forms/ClientFormsSection.tsx
+++ b/apps/crm/apps/web/src/components/client-forms/ClientFormsSection.tsx
@@ -189,8 +189,6 @@ export function ClientFormsSection({ opportunityId }: ClientFormsSectionProps) {
 							onClick={() =>
 								generateCreditApplicationPdf(
 									formData.creditApplication as Record<string, unknown>,
-									(formData.financialStatement as Record<string, unknown>)
-										?.firmaImagen as string | undefined,
 								)
 							}
 						>

--- a/apps/crm/apps/web/src/lib/generate-client-form-pdfs.ts
+++ b/apps/crm/apps/web/src/lib/generate-client-form-pdfs.ts
@@ -28,10 +28,7 @@ function sumArray(arr: unknown): number {
 // biome-ignore lint: PDF generation uses any for flexible data
 type FormData = Record<string, any>;
 
-export function generateCreditApplicationPdf(
-	data: FormData,
-	signatureOverride?: string,
-) {
+export function generateCreditApplicationPdf(data: FormData) {
 	const doc = new jsPDF();
 	const pageWidth = doc.internal.pageSize.getWidth();
 	let y = 15;
@@ -324,7 +321,7 @@ export function generateCreditApplicationPdf(
 	y = (doc as any).lastAutoTable.finalY + 15;
 
 	// Signature
-	const firmaImg = data.firmaImagen || signatureOverride;
+	const firmaImg = data.firmaImagen;
 	if (y > 230) {
 		doc.addPage();
 		y = 15;

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -1287,6 +1287,12 @@ function RouteComponent() {
 									.includes(debouncedBoardSearch.trim().toLowerCase()) ||
 								(opp.title ?? "")
 									.toLowerCase()
+									.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+								(opp.lead?.phone ?? "")
+									.toLowerCase()
+									.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+								opp.id
+									.toLowerCase()
 									.includes(debouncedBoardSearch.trim().toLowerCase())),
 					) || [];
 
@@ -3193,6 +3199,12 @@ function RouteComponent() {
 										.toLowerCase()
 										.includes(debouncedBoardSearch.trim().toLowerCase()) ||
 									(opp.title ?? "")
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+									(opp.lead?.phone ?? "")
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+									opp.id
 										.toLowerCase()
 										.includes(debouncedBoardSearch.trim().toLowerCase())),
 						) ?? []

--- a/apps/crm/apps/web/src/routes/formulario.$token.tsx
+++ b/apps/crm/apps/web/src/routes/formulario.$token.tsx
@@ -13,8 +13,9 @@ import { client } from "@/utils/orpc";
 type FormStep =
 	| "loading"
 	| "credit"
+	| "credit-signature"
 	| "financial"
-	| "signature"
+	| "financial-signature"
 	| "success"
 	| "error";
 
@@ -43,6 +44,8 @@ function FormularioPage() {
 				setValidatedData(result);
 				if (result.creditApplicationExists && result.financialStatementExists) {
 					setStep("success");
+				} else if (result.creditApplicationExists && !result.creditHasSignature) {
+					setStep("credit-signature");
 				} else if (result.creditApplicationExists) {
 					setStep("financial");
 				} else {
@@ -68,7 +71,7 @@ function FormularioPage() {
 			});
 			creditDataRef.current = data;
 			toast.success("Solicitud de crédito guardada");
-			setStep("financial");
+			setStep("credit-signature");
 		} catch (error) {
 			console.error(
 				"[FormularioPage] Error al enviar solicitud de crédito:",
@@ -82,13 +85,33 @@ function FormularioPage() {
 
 	const handleFinancialSubmit = async (data: FinancialStatementFormData) => {
 		financialDataRef.current = data;
-		setStep("signature");
+		setStep("financial-signature");
 	};
 
 	const handleBackToCredit = () => setStep("credit");
 	const handleBackToFinancial = () => setStep("financial");
 
-	const handleSignatureComplete = async (signatureDataUrl: string) => {
+	const handleCreditSignatureComplete = async (signatureDataUrl: string) => {
+		setIsSubmitting(true);
+		try {
+			const now = new Date();
+			await client.signCreditApplication({
+				token,
+				firmaImagen: signatureDataUrl,
+				fechaFirma: now.toISOString().split("T")[0],
+				horaFirma: now.toTimeString().split(" ")[0],
+			});
+			toast.success("Solicitud firmada exitosamente");
+			setStep("financial");
+		} catch (error) {
+			console.error("[FormularioPage] Error al firmar solicitud:", error);
+			toast.error("Error al firmar la solicitud");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	const handleFinancialSignatureComplete = async (signatureDataUrl: string) => {
 		if (!financialDataRef.current) return;
 		setIsSubmitting(true);
 		try {
@@ -221,15 +244,27 @@ function FormularioPage() {
 		);
 	}
 
-	const stepNumber = step === "credit" ? 1 : step === "financial" ? 2 : 3;
+	const stepNumber =
+		step === "credit" ? 1
+			: step === "credit-signature" ? 2
+				: step === "financial" ? 3
+					: 4;
 	const stepLabel =
 		step === "credit"
 			? "Paso 1: Solicitud de Crédito"
-			: step === "financial"
-				? "Paso 2: Estado Patrimonial"
-				: "Paso 3: Firma y Consentimiento";
+			: step === "credit-signature"
+				? "Paso 2: Firma de Solicitud"
+				: step === "financial"
+					? "Paso 3: Estado Patrimonial"
+					: "Paso 4: Firma Estado Patrimonial";
 	const progressWidth =
-		step === "credit" ? "33%" : step === "financial" ? "66%" : "100%";
+		step === "credit"
+			? "25%"
+			: step === "credit-signature"
+				? "50%"
+				: step === "financial"
+					? "75%"
+					: "100%";
 
 	return (
 		<div className="min-h-screen bg-background">
@@ -240,7 +275,7 @@ function FormularioPage() {
 						<div className="flex-1">
 							<div className="flex items-center justify-between text-sm">
 								<span className="font-medium">{stepLabel}</span>
-								<span className="text-muted-foreground">{stepNumber}/3</span>
+								<span className="text-muted-foreground">{stepNumber}/4</span>
 							</div>
 							<div className="mt-1 h-2 w-full rounded-full bg-muted">
 								<div
@@ -262,6 +297,16 @@ function FormularioPage() {
 						isSubmitting={isSubmitting}
 					/>
 				)}
+				{step === "credit-signature" && (
+					<SignatureConsent
+						onComplete={handleCreditSignatureComplete}
+						fullName={signatureFullName}
+						dpi={creditSource?.dpi || ""}
+						nit={creditSource?.nit || undefined}
+						isSubmitting={isSubmitting}
+						onBack={handleBackToCredit}
+					/>
+				)}
 				{step === "financial" && (
 					<FinancialStatementForm
 						defaultValues={financialDefaults}
@@ -270,9 +315,9 @@ function FormularioPage() {
 						onBack={handleBackToCredit}
 					/>
 				)}
-				{step === "signature" && (
+				{step === "financial-signature" && (
 					<SignatureConsent
-						onComplete={handleSignatureComplete}
+						onComplete={handleFinancialSignatureComplete}
 						fullName={signatureFullName}
 						dpi={creditSource?.dpi || ""}
 						nit={creditSource?.nit || undefined}

--- a/apps/crm/apps/web/src/routes/formulario.$token.tsx
+++ b/apps/crm/apps/web/src/routes/formulario.$token.tsx
@@ -89,6 +89,7 @@ function FormularioPage() {
 	};
 
 	const handleBackToCredit = () => setStep("credit");
+	const handleBackToCreditSignature = () => setStep("credit-signature");
 	const handleBackToFinancial = () => setStep("financial");
 
 	const handleCreditSignatureComplete = async (signatureDataUrl: string) => {
@@ -312,7 +313,7 @@ function FormularioPage() {
 						defaultValues={financialDefaults}
 						onSubmit={handleFinancialSubmit}
 						isSubmitting={isSubmitting}
-						onBack={handleBackToCredit}
+						onBack={handleBackToCreditSignature}
 					/>
 				)}
 				{step === "financial-signature" && (


### PR DESCRIPTION
## Summary
- La búsqueda en la vista de oportunidades (kanban y tabla) solo buscaba por nombre del lead y título
- Ahora también busca por **teléfono** e **ID de oportunidad**

### Filtro de oportunidades por mes (mejorado)
- Las oportunidades **abiertas/on_hold** siempre se muestran sin importar el mes seleccionado
- Las oportunidades **won/lost** se filtran por `actual_close_date` del mes seleccionado
- Si una oportunidad cerrada no tiene `actual_close_date`, hace fallback a `created_at`
- Aplica para todos los roles

### Descarga independiente de PDFs
- Cada formulario (solicitud de crédito / estado patrimonial) se puede descargar individualmente sin requerir que ambos estén completos

### Firma por documento
- Cada formulario ahora tiene su propio paso de firma (4 pasos en vez de 3)
- Flujo: Solicitud → Firma₁ → Estado Patrimonial → Firma₂ → Completado
- La solicitud firmada se puede descargar inmediatamente para consultar buró sin esperar el estado patrimonial
- **Formularios a medias**: si el cliente ya llenó la solicitud pero no la firmó, al volver se le pide firmarla antes de continuar
- Nuevo endpoint `signCreditApplication` para guardar la firma de la solicitud de crédito
- `validateFormToken` ahora devuelve `creditHasSignature` para manejar el flujo correctamente

## Test plan
- [ ] Buscar una oportunidad por número de teléfono del lead
- [ ] Buscar una oportunidad pegando el UUID de la oportunidad
- [ ] Verificar que oportunidades abiertas persisten al cambiar de mes
- [ ] Verificar que oportunidades won/lost se filtran por mes de cierre
- [ ] Descargar PDF con solo un formulario completado
- [ ] Formulario nuevo: 4 pasos (credit → firma₁ → financial → firma₂ → success)
- [ ] Reabrir enlace con solicitud sin firma: va a paso de firma
- [ ] Reabrir enlace con solicitud firmada: va a estado patrimonial
- [ ] PDF de solicitud tiene su propia firma
- [ ] Botón atrás desde estado patrimonial va a firma de solicitud (no a solicitud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)