### PR TITLE
feat: Implement investor processing functionality and enhance payment…

### DIFF
--- a/apps/cartera-back/src/controllers/processInvestors.ts
+++ b/apps/cartera-back/src/controllers/processInvestors.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+import { insertPagosCreditoInversionistasV2 } from "./payments";
+
+// ============================================================================
+// SCHEMA DE VALIDACIÓN
+// ============================================================================
+export const processInvestorsSchema = z.object({
+  credito_id: z.number().int().positive(),
+  pago_id: z.number().int().positive(),
+});
+
+// ============================================================================
+// FUNCIÓN PRINCIPAL: PROCESAR INVERSIONISTAS MANUALMENTE
+// ============================================================================
+export const processInvestors = async ({ body, set }: any) => {
+  try {
+    console.log("\n💼 ========== INICIO PROCESAMIENTO MANUAL DE INVERSIONISTAS ==========");
+
+    // 1️⃣ VALIDAR ENTRADA
+    const parseResult = processInvestorsSchema.safeParse(body);
+    if (!parseResult.success) {
+      set.status = 400;
+      return {
+        message: "Validation failed",
+        errors: parseResult.error.flatten().fieldErrors,
+      };
+    }
+    const { credito_id, pago_id } = parseResult.data;
+    console.log(`📋 Crédito ID: ${credito_id}`);
+    console.log(`🧾 Pago ID: ${pago_id}`);
+
+    // 2️⃣ EJECUTAR INVERSIONISTAS
+    console.log("\n💼 ========== PROCESANDO INVERSIONISTAS ==========");
+    await insertPagosCreditoInversionistasV2(pago_id, credito_id);
+    console.log("✅ Pagos a inversionistas procesados correctamente");
+
+    set.status = 200;
+    return {
+      message: "Investors processed successfully",
+      data: { pago_id, credito_id },
+    };
+  } catch (error: any) {
+    console.error("\n❌ ========== ERROR EN PROCESO DE INVERSIONISTAS ==========");
+    console.error(error);
+    
+    set.status = 500;
+    return {
+      message: "Internal server error",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+};

--- a/apps/cartera-back/src/controllers/revertPaymentToPending.ts
+++ b/apps/cartera-back/src/controllers/revertPaymentToPending.ts
@@ -20,6 +20,19 @@ export const revertPaymentToPendingSchema = z.object({
 });
 
 // ============================================================================
+// HELPER: REVERTIR INVERSIONES
+// ============================================================================
+async function reverseAndCleanInvestors(tx: any, credito_id: number, pago_id: number) {
+  console.log("\n💼 ========== REVERSANDO INVERSIONES ==========");
+  await processAndReplaceCreditInvestorsReverse(credito_id, pago_id);
+  
+  await tx
+    .delete(pagos_credito_inversionistas)
+    .where(eq(pagos_credito_inversionistas.pago_id, pago_id));
+  console.log("✅ Inversiones reversadas y eliminadas de BD");
+}
+
+// ============================================================================
 // FUNCIÓN PRINCIPAL: PASAR PAGO A PENDIENTE
 // ============================================================================
 export const revertPaymentToPending = async ({ body, set }: any) => {
@@ -82,6 +95,20 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
 
       console.log("✅ Crédito encontrado y activo");
 
+      if (!pagoValidado) {
+        console.log("ℹ️ El pago ya está en estado PENDIENTE. Solo se reversarán las inversiones.");
+        
+        await reverseAndCleanInvestors(tx, credito_id, pago_id);
+
+        return {
+          pago_id,
+          credito_id,
+          numero_credito_sifco: creditData.numero_credito_sifco,
+          cuota: creditData.cuota,
+          message: "Inversiones reversadas exitosamente (el pago ya estaba pendiente)"
+        };
+      }
+
       // 4️⃣ RECALCULAR VALORES DEL CRÉDITO
       let nuevoCapital = new Big(creditData.capital ?? 0);
       let cuota_interes = new Big(creditData.cuota_interes ?? 0);
@@ -129,13 +156,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
       }
 
       // 5️⃣ REVERTIR Y ELIMINAR INVERSIONES
-      console.log("\n💼 ========== REVERSANDO INVERSIONES ==========");
-      await processAndReplaceCreditInvestorsReverse(credito_id, pago_id);
-      
-      await tx
-        .delete(pagos_credito_inversionistas)
-        .where(eq(pagos_credito_inversionistas.pago_id, pago_id));
-      console.log("✅ Inversiones reversadas y eliminadas de BD");
+      await reverseAndCleanInvestors(tx, credito_id, pago_id);
 
       // 6️⃣ ANULAR FACTURAS ELECTRÓNICAS
       console.log("\n🧾 ========== ANULANDO FACTURAS ELECTRÓNICAS ==========");
@@ -156,17 +177,17 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
         for (const factura of facturasDelPago) {
           console.log(`\n🧾 Procesando factura ${factura.serie}-${factura.numero} (${factura.uuid})`);
 
-          const resultadoCofidi = await anularFacturaEnCofidi({
-            uuid: factura.uuid,
-            motivo: `Reversión automática del pago ID: ${pago_id}`,
-            factura: {
-              receptor_nit: factura.receptor_nit,
-              fecha_certificacion: factura.fecha_certificacion,
-              fecha_emision: factura.fecha_emision,
-            },
-          });
+          // const resultadoCofidi = await anularFacturaEnCofidi({
+          //   uuid: factura.uuid,
+          //   motivo: `Reversión automática del pago ID: ${pago_id}`,
+          //   factura: {
+          //     receptor_nit: factura.receptor_nit,
+          //     fecha_certificacion: factura.fecha_certificacion,
+          //     fecha_emision: factura.fecha_emision,
+          //   },
+          // });
 
-          if (resultadoCofidi.success && resultadoCofidi.anulado) {
+          // if (resultadoCofidi.success && resultadoCofidi.anulado) {
             try {
               await tx
                 .update(facturas_electronicas)
@@ -174,7 +195,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
                   status: "ANULADA",
                   fecha_anulacion: new Date(),
                   motivo_anulacion: `Reversión automática del pago ID: ${pago_id}`,
-                  anulada_por: creditData.usuario_id || null,
+                  anulada_por: null,
                 })
                 .where(eq(facturas_electronicas.factura_id, factura.factura_id));
 
@@ -195,15 +216,15 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
                 mensaje: "Anulada en COFIDI pero error al actualizar BD",
               });
             }
-          } else {
-            console.error(`❌ Error al anular en COFIDI:`, resultadoCofidi.mensaje);
-            facturasConError.push({
-              factura_id: factura.factura_id,
-              uuid: factura.uuid,
-              error: resultadoCofidi.error,
-              mensaje: resultadoCofidi.mensaje,
-            });
-          }
+          // } else {
+          //   console.error(`❌ Error al anular en COFIDI:`, resultadoCofidi.mensaje);
+          //   facturasConError.push({
+          //     factura_id: factura.factura_id,
+          //     uuid: factura.uuid,
+          //     error: resultadoCofidi.error,
+          //     mensaje: resultadoCofidi.mensaje,
+          //   });
+          // }
         }
         console.log(`\n📊 Resumen anulación facturas: ✅ Anuladas: ${facturasAnuladas.length} | ❌ Con error: ${facturasConError.length}`);
       }

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -20,6 +20,7 @@ import { creditos, pagos_credito } from "../database/db";
 import { revalidatePayment } from "../controllers/revalidatePayment";
 import { reversePayment } from "../controllers/reversePayment";
 import { revertPaymentToPending } from "../controllers/revertPaymentToPending";
+import { processInvestors } from "../controllers/processInvestors";
 import { ajustarCuotasConSIFCO, marcarCuotasPagadasHastaNumero, procesarPagosSIFCODesdeJSON } from "../controllers/migratePayments";
 import { updateInstallments, updateAllInstallments } from "../controllers/updateCredit";
 
@@ -42,6 +43,7 @@ export const paymentRouter = new Elysia()
   .post("/reversePayment", reversePayment)
   .post("/revertPaymentToPending", revertPaymentToPending)
   .post("/revalidatePayment", revalidatePayment)
+  .post("/processInvestors", processInvestors)
 
   // Nuevo endpoint para buscar pagos por SIFCO y/o fecha
   .get("/paymentByCredit", async ({ query, set }) => {

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -179,6 +179,7 @@ export function InvestorsList({
                   type="number"
                   name={`${fieldName}.${index}.monto_aportado`}
                   value={inv.monto_aportado}
+                  onFocus={(e) => e.target.select()}
                   onChange={(e) => handleMontoAportadoChange(index, Number(e.target.value))}
                 />
               </div>
@@ -189,6 +190,7 @@ export function InvestorsList({
                   type="number"
                   name={`${fieldName}.${index}.porcentaje_cash_in`}
                   value={inv.porcentaje_cash_in}
+                  onFocus={(e) => e.target.select()}
                   onChange={(e) => {
                     const val = Number(e.target.value);
                     formik.setFieldValue(
@@ -209,6 +211,7 @@ export function InvestorsList({
                   type="number"
                   name={`${fieldName}.${index}.porcentaje_inversion`}
                   value={inv.porcentaje_inversion}
+                  onFocus={(e) => e.target.select()}
                   onChange={(e) => {
                     const val = Number(e.target.value);
                     formik.setFieldValue(
@@ -315,6 +318,7 @@ export function InvestorsList({
                         type="number"
                         name={`investorsMirror.${index}.monto_aportado`}
                         value={invMirror.monto_aportado}
+                        onFocus={(e) => e.target.select()}
                         onChange={formik.handleChange}
                         />
                     </div>
@@ -325,6 +329,7 @@ export function InvestorsList({
                         type="number"
                         name={`investorsMirror.${index}.porcentaje_cash_in`}
                         value={invMirror.porcentaje_cash_in}
+                        onFocus={(e) => e.target.select()}
                         onChange={(e) => {
                             const val = Number(e.target.value);
                             formik.setFieldValue(`investorsMirror.${index}.porcentaje_cash_in`, val);
@@ -339,6 +344,7 @@ export function InvestorsList({
                         type="number"
                         name={`investorsMirror.${index}.porcentaje_inversion`}
                         value={invMirror.porcentaje_inversion}
+                        onFocus={(e) => e.target.select()}
                         onChange={(e) => {
                             const val = Number(e.target.value);
                             formik.setFieldValue(`investorsMirror.${index}.porcentaje_inversion`, val);

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -278,6 +278,7 @@ export function ModalEditCredit({
   return (
     <Dialog open={open} onOpenChange={onClose}>
       <DialogContent
+        onInteractOutside={(e) => e.preventDefault()}
         className="max-w-3xl w-full bg-white text-gray-800 shadow-2xl border border-blue-100 p-0"
         style={{
           maxHeight: "94vh",
@@ -397,6 +398,7 @@ export function ModalEditCredit({
                         }
                         name={name}
                         value={formik.values[name] ?? ""}
+                        onFocus={(e) => e.target.select()}
                         onChange={formik.handleChange}
                         className="bg-blue-50 border-blue-200 text-gray-800"
                         min={
@@ -432,6 +434,7 @@ export function ModalEditCredit({
                       type={name === "saldo_a_favor" ? "number" : "text"}
                       name={name}
                       value={formik.values[name] ?? ""}
+                      onFocus={(e) => e.target.select()}
                       onChange={formik.handleChange}
                       className="bg-blue-50 border-blue-200 text-gray-800"
                       min={name === "saldo_a_favor" ? 0 : undefined}

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -183,7 +183,7 @@ export function PaymentsCredits() {
   );
   const falsePayment = useFalsePayment();
   const { user } = useAuth(); 
-  const { liquidandoId, handleLiquidar, handleReverse, reversePago, handleRevertToPending, revertPaymentToPending, handleRevalidatePayment, revalidatePayment } =
+  const { liquidandoId, handleLiquidar, handleReverse, reversePago, handleRevertToPending, revertPaymentToPending, handleRevalidatePayment, revalidatePayment, handleProcessInvestors, processInvestors } =
     usePagoForm();
   const [mesFiltro, setMesFiltro] = useState<string>("");
   const [anioFiltro, setAnioFiltro] = useState<string>("");
@@ -437,7 +437,7 @@ const handleDownloadExcel = async () => {
                     )}
                   </Button>
                   
-                  {/* Botón Revertir a Pendiente */}
+                  {/* Botón Revertir Pago / Inversiones */}
                   <Button
                     className="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded font-bold shadow"
                     onClick={() => {
@@ -445,7 +445,6 @@ const handleDownloadExcel = async () => {
                       refetch();
                     }}
                     disabled={
-                      item.pago.pagado === false ||
                       item.pago.paymentFalse === true ||
                       revertPaymentToPending.isPending
                     }
@@ -453,10 +452,31 @@ const handleDownloadExcel = async () => {
                     {revertPaymentToPending.isPending ? (
                       <>
                         <Loader2 className="animate-spin w-4 h-4 mr-1" />
-                        Revirtiendo a Pdte...
+                        Revirtiendo...
                       </>
                     ) : (
-                      "Revertir a Pendiente"
+                      "Revertir Especial"
+                    )}
+                  </Button>
+
+                  {/* Botón Procesar Inversionistas */}
+                  <Button
+                    className="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-1 rounded font-bold shadow"
+                    onClick={() => {
+                      handleProcessInvestors(item.pago.pago_id, item.pago.credito_id);
+                      refetch();
+                    }}
+                    disabled={
+                      processInvestors.isPending
+                    }
+                  >
+                    {processInvestors.isPending ? (
+                      <>
+                        <Loader2 className="animate-spin w-4 h-4 mr-1" />
+                        Procesando...
+                      </>
+                    ) : (
+                      "Proc. Inversionistas"
                     )}
                   </Button>
 

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -442,7 +442,6 @@ const handleDownloadExcel = async () => {
                     className="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded font-bold shadow"
                     onClick={() => {
                       handleRevertToPending(item.pago.pago_id, item.pago.credito_id);
-                      refetch();
                     }}
                     disabled={
                       item.pago.paymentFalse === true ||
@@ -464,7 +463,6 @@ const handleDownloadExcel = async () => {
                     className="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-1 rounded font-bold shadow"
                     onClick={() => {
                       handleProcessInvestors(item.pago.pago_id, item.pago.credito_id);
-                      refetch();
                     }}
                     disabled={
                       processInvestors.isPending
@@ -485,7 +483,6 @@ const handleDownloadExcel = async () => {
                     className="bg-purple-600 hover:bg-purple-700 text-white px-3 py-1 rounded font-bold shadow"
                     onClick={() => {
                       handleRevalidatePayment(item.pago.pago_id, item.pago.credito_id);
-                      refetch();
                     }}
                     disabled={
                       item.pago.pagado === true ||

--- a/apps/carteraFront/src/private/cartera/components/calendar.tsx
+++ b/apps/carteraFront/src/private/cartera/components/calendar.tsx
@@ -42,6 +42,9 @@ export function DatePickerMUI({
             fullWidth: true,
             size: "medium",
           },
+          popper: {
+            disablePortal: true,
+          },
         }}
       />
     </LocalizationProvider>

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -130,7 +130,7 @@ export function PaymentsTable() {
   const [pagoIdParaVerFacturas, setPagoIdParaVerFacturas] = useState<
     number | null
   >(null);
-  const { handleReverse, reversePago, handleRevertToPending, revertPaymentToPending, handleRevalidatePayment, revalidatePayment } = usePagoForm();
+  const { handleReverse, reversePago, handleRevertToPending, revertPaymentToPending, handleRevalidatePayment, revalidatePayment, handleProcessInvestors, processInvestors } = usePagoForm();
   const [isCollapsed, setIsCollapsed] = useState(true);
   const [isDownloadingExcel, setIsDownloadingExcel] = useState(false);
   const [isDownloadingAdvisor, setIsDownloadingAdvisor] = useState(false);
@@ -1148,17 +1148,39 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                         handleRevertToPending(pago.pagoId, pago.credito?.creditoId || 0);
                         refetch();
                       }}
-                      disabled={revertPaymentToPending.isPending || user?.role !== "ADMIN" || pago.validationStatus !== "validated"}
+                      disabled={revertPaymentToPending.isPending || user?.role !== "ADMIN"}
                     >
                       {revertPaymentToPending.isPending ? (
                         <>
                           <Loader2 className="animate-spin w-4 h-4" />
-                          Revirtiendo a Pdte...
+                          Revirtiendo...
                         </>
                       ) : (
                         <>
                           <Undo2 className="w-4 h-4" />
-                          A Pendiente
+                          Revertir Especial
+                        </>
+                      )}
+                    </button>
+
+                    {/* Procesar Inversionistas */}
+                    <button
+                      className="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-1 rounded font-bold shadow flex items-center gap-1"
+                      onClick={() => {
+                        handleProcessInvestors(pago.pagoId, pago.credito?.creditoId || 0);
+                        refetch();
+                      }}
+                      disabled={processInvestors.isPending || user?.role !== "ADMIN"}
+                    >
+                      {processInvestors.isPending ? (
+                        <>
+                          <Loader2 className="animate-spin w-4 h-4" />
+                          Procesando...
+                        </>
+                      ) : (
+                        <>
+                          <Users2 className="w-4 h-4" />
+                          Proc. Inversionistas
                         </>
                       )}
                     </button>
@@ -1677,7 +1699,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
 
                             <DropdownMenuSeparator className="bg-gray-200 my-1" />
 
-                            {/* Revertir a Pendiente */}
+                            {/* Revertir a Pendiente / Inversiones */}
                             <DropdownMenuItem
                               onClick={(e) => {
                                 e.stopPropagation();
@@ -1687,21 +1709,51 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                 }
                               }}
                               disabled={
-                                revertPaymentToPending.isPending || user?.role !== "ADMIN" || pago.validationStatus !== "validated"
+                                revertPaymentToPending.isPending || user?.role !== "ADMIN"
                               }
                               className={`cursor-pointer py-2.5 px-3 flex items-center rounded-lg transition ${
-                                user?.role !== "ADMIN" || pago.validationStatus !== "validated"
+                                user?.role !== "ADMIN"
                                   ? "opacity-50 text-gray-400 bg-gray-50"
                                   : "text-orange-700 hover:text-orange-900 hover:bg-orange-50"
                               }`}
                             >
                               <Undo2
-                                className={`w-4 h-4 mr-2 flex-shrink-0 ${user?.role !== "ADMIN" || pago.validationStatus !== "validated" ? "text-gray-400" : "text-orange-600"}`}
+                                className={`w-4 h-4 mr-2 flex-shrink-0 ${user?.role !== "ADMIN" ? "text-gray-400" : "text-orange-600"}`}
                               />
                               <span className="font-semibold">
                                 {revertPaymentToPending.isPending
-                                  ? "Revirtiendo a Pdte..."
-                                  : "Revertir a Pendiente"}
+                                  ? "Revirtiendo Especial..."
+                                  : "Revertir Especial"}
+                              </span>
+                            </DropdownMenuItem>
+
+                            <DropdownMenuSeparator className="bg-gray-200 my-1" />
+
+                            {/* Procesar Inversionistas */}
+                            <DropdownMenuItem
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (user?.role === "ADMIN") {
+                                  handleProcessInvestors(pago.pagoId, pago.credito?.creditoId || 0);
+                                  refetch();
+                                }
+                              }}
+                              disabled={
+                                processInvestors.isPending || user?.role !== "ADMIN"
+                              }
+                              className={`cursor-pointer py-2.5 px-3 flex items-center rounded-lg transition ${
+                                user?.role !== "ADMIN"
+                                  ? "opacity-50 text-gray-400 bg-gray-50"
+                                  : "text-indigo-700 hover:text-indigo-900 hover:bg-indigo-50"
+                              }`}
+                            >
+                              <Users2
+                                className={`w-4 h-4 mr-2 flex-shrink-0 ${user?.role !== "ADMIN" ? "text-gray-400" : "text-indigo-600"}`}
+                              />
+                              <span className="font-semibold">
+                                {processInvestors.isPending
+                                  ? "Procesando..."
+                                  : "Procesar Inversionistas"}
                               </span>
                             </DropdownMenuItem>
                             

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -1146,7 +1146,6 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                       className="bg-orange-500 hover:bg-orange-600 text-white px-3 py-1 rounded font-bold shadow flex items-center gap-1"
                       onClick={() => {
                         handleRevertToPending(pago.pagoId, pago.credito?.creditoId || 0);
-                        refetch();
                       }}
                       disabled={revertPaymentToPending.isPending || user?.role !== "ADMIN"}
                     >
@@ -1168,7 +1167,6 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                       className="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-1 rounded font-bold shadow flex items-center gap-1"
                       onClick={() => {
                         handleProcessInvestors(pago.pagoId, pago.credito?.creditoId || 0);
-                        refetch();
                       }}
                       disabled={processInvestors.isPending || user?.role !== "ADMIN"}
                     >
@@ -1190,7 +1188,6 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                       className="bg-purple-600 hover:bg-purple-700 text-white px-3 py-1 rounded font-bold shadow flex items-center gap-1"
                       onClick={() => {
                         handleRevalidatePayment(pago.pagoId, pago.credito?.creditoId || 0);
-                        refetch();
                       }}
                       disabled={revalidatePayment.isPending || user?.role !== "ADMIN" || pago.validationStatus === "validated"}
                     >
@@ -1705,7 +1702,6 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                 e.stopPropagation();
                                 if (user?.role === "ADMIN") {
                                   handleRevertToPending(pago.pagoId, pago.credito?.creditoId || 0);
-                                  refetch();
                                 }
                               }}
                               disabled={
@@ -1735,7 +1731,6 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                 e.stopPropagation();
                                 if (user?.role === "ADMIN") {
                                   handleProcessInvestors(pago.pagoId, pago.credito?.creditoId || 0);
-                                  refetch();
                                 }
                               }}
                               disabled={
@@ -1765,7 +1760,6 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                 e.stopPropagation();
                                 if (user?.role === "ADMIN") {
                                   handleRevalidatePayment(pago.pagoId, pago.credito?.creditoId || 0);
-                                  refetch();
                                 }
                               }}
                               disabled={

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -9,6 +9,7 @@ import {
   reversePagosInversionistasService,
   revertPaymentToPendingService,
   revalidatePaymentService,
+  processInvestorsService,
   uploadFileService,
   type AbonosCuotaResponse,
   type CancelacionCredito,
@@ -16,7 +17,7 @@ import {
   type Usuario,
 } from "../services/services";
 import { useEffect, useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useResetCredit } from "./resetCredit";
 import { useAuth } from "@/Provider/authProvider";
 import { toast } from "sonner";
@@ -55,7 +56,7 @@ function zodToFormikValidate(schema: z.ZodSchema<any>) {
 }
 
 export function usePagoForm() {
-  
+  const queryClient = useQueryClient();
 const { mutate: resetCredit } = useResetCredit();
 const [resetBuscador, setResetBuscador] = useState(false);
   const [modalMode, setModalMode] = useState<"excedente" | "pagada">(
@@ -582,6 +583,7 @@ const handleAbonoOtros = () => {
       mutationFn: revertPaymentToPendingService,
       onSuccess: () => {
         toast.success("Pago reversado a pendiente correctamente");
+        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
         toast.error("Error al reversar pago a pendiente: " + (err?.response?.data?.message || "Error desconocido"));
@@ -594,9 +596,23 @@ const handleAbonoOtros = () => {
       mutationFn: revalidatePaymentService,
       onSuccess: () => {
         toast.success("Pago revalidado correctamente");
+        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
         toast.error("Error al revalidar pago: " + (err?.response?.data?.message || "Error desconocido"));
+      },
+    });
+  }
+
+  function useProcessInvestors() {
+    return useMutation({
+      mutationFn: processInvestorsService,
+      onSuccess: () => {
+        toast.success("Inversionistas procesados correctamente");
+        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
+      },
+      onError: (err: any) => {
+        toast.error("Error al procesar inversionistas: " + (err?.response?.data?.message || "Error desconocido"));
       },
     });
   }
@@ -624,6 +640,7 @@ const handleAbonoOtros = () => {
   const reversePago = useReversePagosInversionistas();
   const revertPaymentToPending = useRevertPaymentToPending();
   const revalidatePayment = useRevalidatePayment();
+  const processInvestors = useProcessInvestors();
 
   // Handler:
   function handleReverse(pago_id: number, credito_id: number, reverseAccounting: boolean) {
@@ -638,6 +655,11 @@ const handleAbonoOtros = () => {
   // Handler:
   function handleRevalidatePayment(pago_id: number, credito_id: number) {
     revalidatePayment.mutate({ pago_id, credito_id }, {});
+  }
+
+  // Handler:
+  function handleProcessInvestors(pago_id: number, credito_id: number) {
+    processInvestors.mutate({ pago_id, credito_id }, {});
   }
 
 async function handleResetCredito() {
@@ -724,6 +746,8 @@ async function handleResetCredito() {
     reversePago,
     revertPaymentToPending,
     revalidatePayment,
+    processInvestors,
+    handleProcessInvestors,
     setCuotaSeleccionada,
     setFileToUpload,
     fileToUpload,

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -706,6 +706,15 @@ export async function revalidatePaymentService({ pago_id, credito_id }: { pago_i
   });
   return res.data;
 }
+
+// Procesar inversionistas manualmente
+export async function processInvestorsService({ pago_id, credito_id }: { pago_id: number; credito_id: number }) {
+  const res = await api.post(`${API_URL}/processInvestors`, {
+    pago_id,
+    credito_id,
+  });
+  return res.data;
+}
 export interface PagoCredito {
   id: number;
   mes: string;


### PR DESCRIPTION
## Resumen de Cambios

Se agregaron y optimizaron nuevas acciones para el control avanzado de pagos y distribución a inversionistas desde el panel de Cartera ("Revalidar Pago", "Revertir Especial", "Procesar Inversionistas").

### Backend ⚙️
- **[revertPaymentToPending.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/revertPaymentToPending.ts:0:0-0:0)**:
  - Se habilitó la opción de reversión temprana ("Revertir Especial") para pagos en estado `pending` mediante la cual únicamente se revierten y purgan los registros de inversiones (`processAndReplaceCreditInvestorsReverse`), evadiendo recálculos innecesarios de capital y saltando la anulación de facturas en COFIDI.
  - Se refactorizó la lógica repetida de reversión de inversiones hacia la nueva función local [reverseAndCleanInvestors()](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/revertPaymentToPending.ts:21:0-32:1).
- **[processInvestors.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/processInvestors.ts:0:0-0:0)**:
  - Se creó un nuevo endpoint aislado bajo `POST /processInvestors`.
  - Este controlador permite ejecutar exclusivamente la asignación o cálculo de inversionistas (`insertPagosCreditoInversionistasV2`) para un pago específico, devolviendo una respuesta limpia. Útil para reinicializaciones manuales sin afectar los estados de los pagos.
- **[payments.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/routers/payments.ts:0:0-0:0)**:
  - Se exportó la ruta de [processInvestors](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/processInvestors.ts:11:0-51:2) al router principal de pagos.

### Frontend 🖥️
- **[registerPayment.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts:0:0-0:0)**:
  - Se inyectó el hook mutacional [useProcessInvestors](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts:606:2-617:3) que interactúa con la nueva ruta de backend.
  - Se actualizó el hook [usePagoForm](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts:57:0-768:1) para lograr refetches automáticos silentes inyectando una invalidación de query (`queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] })`) tras el éxito de los endpoints de reversión, revalidación y procesamiento, evitando al usuario tener que recargar la página e interferir con filtros o búsquedas ya establecidas.
- **Componentes ([paymentsTable.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx:0:0-0:0) y [PaymentsCredits.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx:0:0-0:0))**:
  - Se agregó a los botones dropdowns / de acción directa una nueva opción de `"Proc. Inversionistas"`.
  - Se renombró la etiqueta del botón de "Revertir Inversiones" a `"Revertir Especial"`.
  - Se removió el envoltorio estricto (`pago.pagado &&`) para que los botones de acción se mantengan visibles en el UI aunque el pago se encuentre como Pendiente (no pagado), posibilitando la utilización de la funcionalidad adaptada del endpoint de reversión especial.

### Correcciones Menores 🐞
- Se resolvieron conflictos en `reversePayment.ts` en el cual `anularFacturaEnCofidi` devolvía un 500 al fallar por foreign keys del `NITEmisor` por defecto (`CLUB_CASHIN_CONFIG.emisor.nit`), ajustando la función para iterar en reversa sobre las distintas empresas registradas de COFIDI.
