### PR TITLE
refactor(crm): simplify won opportunity filtering logic

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -2654,32 +2654,14 @@ export const crmRouter = {
 		.handler(async ({ input, context }) => {
 			const { limit, offset, search } = input;
 
-			// First, get all stages with 100% closure
-			const closedStages = await db
-				.select({ id: salesStages.id })
-				.from(salesStages)
-				.where(gte(salesStages.closurePercentage, 100));
-
-			const closedStageIds = closedStages.map((s) => s.id);
-
-			// Build subquery to find leads with at least one closed opportunity
-			// A closed opportunity is one with numeroSifco OR in a 100% stage
+			// Build subquery to find leads with at least one won opportunity
 			const leadsWithClosedOpportunities = await db
 				.selectDistinct({ leadId: opportunities.leadId })
 				.from(opportunities)
-				.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
 				.where(
 					and(
 						isNotNull(opportunities.leadId),
-						or(
-							isNotNull(opportunities.numeroSifco),
-							closedStageIds.length > 0
-								? sql`${opportunities.stageId} IN (${sql.join(
-										closedStageIds.map((id) => sql`${id}`),
-										sql`, `,
-									)})`
-								: sql`false`,
-						),
+						eq(opportunities.status, "won"),
 					),
 				);
 


### PR DESCRIPTION
Update the query to identify leads with won opportunities by checking the status field directly instead of manually filtering by 100% closure stages and Sifco numbers.