### PR TITLE
fix: ensure opportunity only moves to 90% after cartera credit creation

### DIFF
--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -944,7 +944,20 @@ export const legalContractsRouter = {
 				});
 			}
 
-			// En transacción: re-verificar etapa + marcar contratos + mover a 90%
+			// Primero: cerrar la oportunidad (crear crédito en cartera-back, cliente, contrato)
+			// Si falla, la oportunidad se queda en 85% y no se mueve a 90%
+			const closeResult = await closeOpportunity({
+				opportunityId: input.opportunityId,
+				userId: context.userId,
+			});
+
+			if (!closeResult.success) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: closeResult.error || "Error al cerrar la oportunidad",
+				});
+			}
+
+			// Solo si cartera-back respondió OK: marcar contratos + mover a 90%
 			await db.transaction(async (tx) => {
 				// Re-verificar que la oportunidad sigue en 85% (previene race condition)
 				const [currentOpp] = await tx
@@ -979,13 +992,11 @@ export const legalContractsRouter = {
 						),
 					);
 
-				// Mover oportunidad a 90% y marcar como ganada
+				// Mover oportunidad a 90% (closeOpportunity ya seteó status "won")
 				await tx
 					.update(opportunities)
 					.set({
 						stageId: targetStage.id,
-						status: "won",
-						actualCloseDate: new Date(),
 						updatedAt: new Date(),
 					})
 					.where(eq(opportunities.id, input.opportunityId));
@@ -999,18 +1010,6 @@ export const legalContractsRouter = {
 					reason: "Contratos firmados confirmados - Avanza a formalización",
 				});
 			});
-
-			// Cerrar la oportunidad (crear crédito, cliente, contrato en cartera)
-			const closeResult = await closeOpportunity({
-				opportunityId: input.opportunityId,
-				userId: context.userId,
-			});
-
-			if (!closeResult.success) {
-				throw new ORPCError("BAD_REQUEST", {
-					message: closeResult.error || "Error al cerrar la oportunidad",
-				});
-			}
 
 			// Notificar a análisis que está lista para desembolso
 			await createNotification({


### PR DESCRIPTION
## Summary
- **Root cause:** `confirmContractsSigned` moved the opportunity to 90% (and marked as "won") in a transaction BEFORE calling `closeOpportunity`. If cartera-back creation failed, the opportunity stayed at 90%/won without a credit record — found 8 affected opportunities in production.
- **Fix:** Reorder the flow so `closeOpportunity()` (which creates the credit in cartera-back) runs FIRST. Only if it succeeds does the transaction move the stage to 90% and mark contracts as signed.
- Also fixes pre-existing TypeScript errors in web app (Recharts Tooltip formatter types, TanStack Form setFieldValue types).

## Test plan
- [ ] Confirm contracts signed on a test opportunity at 85% — should create credit in cartera and move to 90%
- [ ] Simulate cartera-back failure (e.g. disable integration) — opportunity should stay at 85%, no orphaned "won" status
- [ ] Verify `bun check-types` passes cleanly for both server and web

🤖 Generated with [Claude Code](https://claude.com/claude-code)