### PR TITLE
Enhance liquidation report URLs and refine HTML report layout

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1740,6 +1740,35 @@ export async function getInvestorTotalsGlobales(
   };
 }
 
+export async function updateLiquidacionReporteUrl(inversionistaId: number, url: string) {
+  const [liquidacion] = await db
+    .select({
+      liquidacion_id: liquidaciones.liquidacion_id,
+      fecha_liquidacion: liquidaciones.fecha_liquidacion,
+      reporte_liquidacion_url: liquidaciones.reporte_liquidacion_url,
+    })
+    .from(liquidaciones)
+    .where(eq(liquidaciones.inversionista_id, inversionistaId))
+    .orderBy(desc(liquidaciones.fecha_liquidacion))
+    .limit(1);
+
+  if (liquidacion) {
+    await db
+      .update(liquidaciones)
+      .set({ reporte_liquidacion_url: url })
+      .where(eq(liquidaciones.liquidacion_id, liquidacion.liquidacion_id));
+
+    return {
+      liquidacion_id: liquidacion.liquidacion_id,
+      fecha_liquidacion: liquidacion.fecha_liquidacion,
+      url_anterior: liquidacion.reporte_liquidacion_url,
+      url_nueva: url,
+    };
+  }
+
+  return null;
+}
+
 // ============================================
 // upsertPagosEspejo
 // ============================================
@@ -2783,7 +2812,10 @@ export function generarHTMLReporte(
           <tr class="total">
             <td>Total</td>
             <td></td>
-            <td></td>
+            <td>${
+              (Number(subtotal.total_monto_aportado || 0) + Number(subtotal.total_abono_capital || 0))
+                .toLocaleString("es-GT", { style: "currency", currency: "GTQ" })
+            }</td>
             <td></td>
             <td></td>
             <td></td>

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -2604,6 +2604,7 @@ export function generarHTMLReporte(
       width: 210px;
       height: auto;
       margin-right: 32px;
+      margin-top: -50px;
     }
     .header-totals-row {
       flex: 1;

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -18,6 +18,7 @@ import {
   aplicarPagosEspejo,
   deletePagosEspejoNoLiquidados,
   updateSaldoReinversion,
+  updateLiquidacionReporteUrl,
 } from "../controllers/investor";
 import { InversionistaReporte, RespuestaReporte } from "../utils/interface";
 import { generarYSubirPDFInversionista } from "../utils/functions/generalFunctions";
@@ -392,7 +393,14 @@ export const inversionistasRouter = new Elysia()
         logoUrl
       );
 
-      return { success: true, url, filename };
+      const liquidacionActualizada = await updateLiquidacionReporteUrl(Number(id), url);
+
+      return {
+        success: true,
+        url,
+        filename,
+        liquidacion: liquidacionActualizada || null,
+      };
     } catch (error) {
       console.error("[investor/pdf-liquidados] Error:", error);
       set.status = 500;

--- a/apps/cartera-back/src/utils/interface.ts
+++ b/apps/cartera-back/src/utils/interface.ts
@@ -54,6 +54,8 @@ export interface Subtotal {
   total_reinversion_capital: number;
   total_reinversion_interes: number;
   total_reinversion: number;
+  total_capital_creditos: number;
+  total_capital_actual: number;
 }
 
 export interface InversionistaReporte {

--- a/apps/portal-web/src/features/Profile/MyInvestments/MyInvestments.tsx
+++ b/apps/portal-web/src/features/Profile/MyInvestments/MyInvestments.tsx
@@ -468,7 +468,7 @@ export const MyInvestments = () => {
                             : `Ver ${liquidacion.pagos.length} pagos`}
                         </button>
 
-                        {/*liquidacion.reporte_liquidacion && (
+                        {liquidacion.reporte_liquidacion && (
                           <a
                             href={liquidacion.reporte_liquidacion}
                             target="_blank"
@@ -478,7 +478,7 @@ export const MyInvestments = () => {
                             Ver reporte de liquidación
                             <span aria-hidden="true">&rarr;</span>
                           </a>
-                        )*/}
+                        )}
                       </div>
                     </div>
 


### PR DESCRIPTION
This pull request introduces enhancements to the investor liquidation report workflow, including updating the report URL in the database after generating a new report, improving the HTML report output, and exposing the updated report URL to the frontend. The changes also add new fields to the subtotal interface and fix the display of liquidation report links in the web portal.

**Liquidation Report Workflow Improvements:**

* Added `updateLiquidacionReporteUrl` function in `investor.ts` to update the latest liquidation record with a new report URL for a given investor.
* Modified the `/pdf-liquidados` endpoint in `inversionistasRouter` to call `updateLiquidacionReporteUrl` after generating and uploading the report, returning the updated liquidation info in the response. [[1]](diffhunk://#diff-dfe70ad8a9b021cdd367ad390168236a8aae84fc8a096f2426590be999d4d16dL395-R403) [[2]](diffhunk://#diff-dfe70ad8a9b021cdd367ad390168236a8aae84fc8a096f2426590be999d4d16dR21)

**HTML Report Generation Enhancements:**

* Improved the total row in the HTML report to display the sum of `total_monto_aportado` and `total_abono_capital` as a formatted currency value.
* Adjusted the logo styling in the report for better layout.

**Interface and Frontend Updates:**

* Added `total_capital_creditos` and `total_capital_actual` fields to the `Subtotal` interface for more detailed reporting.
* Fixed the frontend in `MyInvestments.tsx` to correctly display the liquidation report link when available. [[1]](diffhunk://#diff-b33ecc2650e416e39c44e535878708b11e4432d44aafda2b1db16f97d453a35eL471-R471) [[2]](diffhunk://#diff-b33ecc2650e416e39c44e535878708b11e4432d44aafda2b1db16f97d453a35eL481-R481)