### PR TITLE
fix: report photo comments, scanner pdf, and ai valuation retries

### DIFF
--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -956,6 +956,8 @@ export const vehiclesRouter = {
 							title: z.string(),
 							description: z.string().optional(),
 							url: z.string(),
+							valuatorComment: z.string().optional(),
+							noCommentsChecked: z.boolean().optional(),
 						}),
 					)
 					.optional(),

--- a/apps/taller/src/components/vehicle-valuation.tsx
+++ b/apps/taller/src/components/vehicle-valuation.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Sparkles, Loader2, TrendingUp } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -86,6 +86,25 @@ interface AIValuationResult {
   commercialClassificationReasoning?: string;
 }
 
+const MAX_AI_ATTEMPTS = 2;
+
+function isRetryableAIError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  const message = error.message.toLowerCase();
+  return (
+    error.name === "TimeoutError" ||
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("network") ||
+    message.includes("fetch") ||
+    message.includes("conexi") ||
+    message.includes("abort")
+  );
+}
+
 export default function VehicleValuation({
   vehicleData,
   onComplete,
@@ -97,6 +116,7 @@ export default function VehicleValuation({
   const [loadingAI, setLoadingAI] = useState(false);
   const [aiAttemptCount, setAiAttemptCount] = useState(0);
   const [aiFailed, setAiFailed] = useState(false);
+  const [aiLoadingMessage, setAiLoadingMessage] = useState("Analizando vehículo...");
   const [scannerFile, setScannerFile] = useState<File | null>(null);
   const [uploadingScanner, setUploadingScanner] = useState(false);
   const [scannerUploadUrl, setScannerUploadUrl] = useState<string | null>(null);
@@ -173,10 +193,38 @@ export default function VehicleValuation({
     return result.data.url as string;
   };
 
+  useEffect(() => {
+    if (!loadingAI) {
+      setAiLoadingMessage("Analizando vehículo...");
+      return;
+    }
+
+    setAiLoadingMessage("Analizando vehículo...");
+
+    const timers = [
+      setTimeout(() => {
+        setAiLoadingMessage("Buscando referencias en internet...");
+      }, 8000),
+      setTimeout(() => {
+        setAiLoadingMessage("Comparando mercado y condición del vehículo...");
+      }, 18000),
+      setTimeout(() => {
+        setAiLoadingMessage("La valoración sigue procesándose. Puede tardar un poco más.");
+      }, 30000),
+    ];
+
+    return () => {
+      timers.forEach(clearTimeout);
+    };
+  }, [loadingAI]);
+
   // AI valuation logic
   const getAIValuation = async () => {
+    if (loadingAI || aiAttemptCount >= MAX_AI_ATTEMPTS) {
+      return;
+    }
+
     setLoadingAI(true);
-    setAiAttemptCount(prev => prev + 1);
     setAiFailed(false);
 
     const values = form.getValues();
@@ -236,7 +284,12 @@ export default function VehicleValuation({
       toast.success("Valoración por IA completada");
     } catch (error) {
       setAiFailed(true);
-      toast.error("Error al obtener valoración por IA. Complete manualmente.");
+      if (isRetryableAIError(error)) {
+        toast.error("La valoración tardó demasiado o falló la conexión. Puede reintentar sin consumir intento.");
+      } else {
+        setAiAttemptCount(prev => Math.min(prev + 1, MAX_AI_ATTEMPTS));
+        toast.error("Error al obtener valoración por IA. Complete manualmente.");
+      }
       console.error(error);
     } finally {
       setLoadingAI(false);
@@ -513,13 +566,13 @@ export default function VehicleValuation({
               <Button
                 type="button"
                 onClick={getAIValuation}
-                disabled={loadingAI || aiAttemptCount >= 2}
+                disabled={loadingAI || aiAttemptCount >= MAX_AI_ATTEMPTS}
                 className="w-full"
               >
                 {loadingAI ? (
                   <>
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    Analizando vehículo...
+                    {aiLoadingMessage}
                   </>
                 ) : (
                   <>
@@ -528,7 +581,12 @@ export default function VehicleValuation({
                   </>
                 )}
               </Button>
-              {aiAttemptCount >= 2 && aiFailed && (
+              {loadingAI && (
+                <p className="text-xs text-muted-foreground text-center mt-2">
+                  La valoración con búsqueda en internet puede tardar varios segundos. No cierre esta pantalla mientras termina.
+                </p>
+              )}
+              {aiAttemptCount >= MAX_AI_ATTEMPTS && aiFailed && (
                 <p className="text-xs text-muted-foreground text-center mt-2">
                   Se alcanzó el límite de intentos. Complete la valoración manualmente.
                 </p>

--- a/apps/taller/src/components/vehicle-valuation.tsx
+++ b/apps/taller/src/components/vehicle-valuation.tsx
@@ -92,12 +92,18 @@ export default function VehicleValuation({
   isWizardMode = false,
   isSubmitting = false
 }: VehicleValuationProps) {
-  const { checklistItems, photos } = useInspection();
+  const { checklistItems, photos, setFormData } = useInspection();
   const [aiValuation, setAiValuation] = useState<AIValuationResult | null>(null);
   const [loadingAI, setLoadingAI] = useState(false);
   const [aiAttemptCount, setAiAttemptCount] = useState(0);
   const [aiFailed, setAiFailed] = useState(false);
   const [scannerFile, setScannerFile] = useState<File | null>(null);
+  const [uploadingScanner, setUploadingScanner] = useState(false);
+  const [scannerUploadUrl, setScannerUploadUrl] = useState<string | null>(null);
+  const [tempUploadId] = useState(() => {
+    const stableId = vehicleData?.vinNumber || vehicleData?.licensePlate || Date.now().toString();
+    return `scanner-${String(stableId).replace(/[^a-zA-Z0-9-_]/g, "_")}`;
+  });
 
 
 
@@ -129,11 +135,42 @@ export default function VehicleValuation({
       const file = e.target.files[0];
       if (file.type === "application/pdf") {
         setScannerFile(file);
+        setScannerUploadUrl(null);
         form.setValue("scannerResult", file);
       } else {
         alert("Por favor suba un archivo PDF");
       }
     }
+  };
+
+  const uploadScannerToServer = async (file: File) => {
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("vehicleId", tempUploadId);
+    formData.append("category", "scanner");
+    formData.append("photoType", "scanner-report");
+    formData.append("title", "Reporte de scanner");
+    formData.append("description", "Reporte PDF del scanner");
+
+    const response = await fetch(`${import.meta.env.VITE_SERVER_URL || 'http://localhost:3000'}/api/upload-vehicle-photo`, {
+      method: "POST",
+      credentials: "include",
+      body: formData,
+    });
+
+    if (!response.ok) {
+      let errorMessage = `Upload failed: ${response.statusText}`;
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.error || errorMessage;
+      } catch {
+        // Keep generic error if response is not JSON
+      }
+      throw new Error(errorMessage);
+    }
+
+    const result = await response.json();
+    return result.data.url as string;
   };
 
   // AI valuation logic
@@ -206,8 +243,39 @@ export default function VehicleValuation({
     }
   };
 
-  const onSubmit = (values: ValuationFormValues) => {
-    onComplete(values, aiValuation || undefined);
+  const onSubmit = async (values: ValuationFormValues) => {
+    let scannerResultUrl: string | undefined;
+
+    if (values.scannerUsed === "Sí") {
+      const scannerDocument = values.scannerResult as File | undefined;
+
+      if (scannerDocument) {
+        try {
+          setUploadingScanner(true);
+          scannerResultUrl = scannerUploadUrl || await uploadScannerToServer(scannerDocument);
+          setScannerUploadUrl(scannerResultUrl);
+        } catch (error) {
+          toast.error(error instanceof Error ? error.message : "Error subiendo el PDF del scanner");
+          return;
+        } finally {
+          setUploadingScanner(false);
+        }
+      } else {
+        scannerResultUrl = scannerUploadUrl || undefined;
+      }
+    }
+
+    const submissionData = {
+      ...values,
+      scannerResultUrl,
+    };
+
+    setFormData((prev: any) => ({
+      ...prev,
+      ...submissionData,
+    }));
+
+    onComplete(submissionData, aiValuation || undefined);
   };
 
   return (
@@ -736,11 +804,11 @@ export default function VehicleValuation({
           </Card>
 
           {isWizardMode && (
-            <Button type="submit" className="w-full" disabled={isSubmitting}>
-              {isSubmitting ? (
+            <Button type="submit" className="w-full" disabled={isSubmitting || uploadingScanner}>
+              {(isSubmitting || uploadingScanner) ? (
                 <>
                   <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Enviando inspección...
+                  {uploadingScanner ? "Subiendo scanner..." : "Enviando inspección..."}
                 </>
               ) : (
                 "Finalizar Inspección"

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -332,7 +332,7 @@ const VehiclePhoto = ({ photo, index }: { photo: any; index: number }) => {
     );
   }
 
-  const comment = photo.valuatorComment || photo.description;
+  const comment = photo.valuatorComment?.trim();
 
   return (
     <div


### PR DESCRIPTION
## Summary
- persist scanner PDF data and hide the photo guide text when appropriate
- improve AI valuation retry handling in taller flows
- persist vehicle photo comments in the full inspection flow

## Testing
- not run
