### PR TITLE
fix(crm): show real close date in kanban opportunity cards

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1004,6 +1004,19 @@ export const crmRouter = {
 		.handler(async ({ input, context }) => {
 			const leadIdFilter = input?.leadId;
 			const searchTerm = input?.search;
+			const firstClosedStageDates = db
+				.select({
+					opportunityId: opportunityStageHistory.opportunityId,
+					firstClosedStageAt:
+						sql<Date>`min(${opportunityStageHistory.changedAt})`.as(
+							"first_closed_stage_at",
+						),
+				})
+				.from(opportunityStageHistory)
+				.innerJoin(salesStages, eq(opportunityStageHistory.toStageId, salesStages.id))
+				.where(gte(salesStages.closurePercentage, 90))
+				.groupBy(opportunityStageHistory.opportunityId)
+				.as("first_closed_stage_dates");
 
 			const selectFields = {
 				id: opportunities.id,
@@ -1017,6 +1030,10 @@ export const crmRouter = {
 				assignedTo: opportunities.assignedTo,
 				notes: opportunities.notes,
 				createdAt: opportunities.createdAt,
+				closedAt:
+					sql<Date | null>`coalesce(${opportunities.actualCloseDate}, ${firstClosedStageDates.firstClosedStageAt})`.as(
+						"closed_at",
+					),
 				updatedAt: opportunities.updatedAt,
 				numeroSifco: opportunities.numeroSifco,
 				// Analysis status for tracking rejection/resubmission
@@ -1090,6 +1107,10 @@ export const crmRouter = {
 			const baseQuery = db
 				.select(selectFields)
 				.from(opportunities)
+				.leftJoin(
+					firstClosedStageDates,
+					eq(opportunities.id, firstClosedStageDates.opportunityId),
+				)
 				.leftJoin(companies, eq(opportunities.companyId, companies.id))
 				.leftJoin(leads, eq(opportunities.leadId, leads.id))
 				.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -212,22 +212,32 @@ function DraggableOpportunityCard({
 						Reenviado a Análisis
 					</Badge>
 				)}
-				{opportunity.expectedCloseDate && (
-					<div className="flex items-center gap-1 text-muted-foreground text-xs">
-						<Calendar className="h-3 w-3" />
-						{formatDate(opportunity.expectedCloseDate)}
+				<div className="space-y-1 border-t pt-1">
+					<div className="flex items-center justify-between">
+						<span className="text-muted-foreground text-xs">Probabilidad</span>
+						<span className="text-muted-foreground text-xs">
+							{opportunity.probability ||
+								opportunity.stage?.closurePercentage ||
+								0}
+							%
+						</span>
 					</div>
-				)}
-				<div className="flex items-center justify-between pt-1">
-					<span className="text-muted-foreground text-xs">
-						{opportunity.probability ||
-							opportunity.stage?.closurePercentage ||
-							0}
-						% probabilidad
-					</span>
-					<span className="text-muted-foreground text-xs">
-						{formatGuatemalaDate(opportunity.createdAt)}
-					</span>
+					<div className="flex items-center justify-between">
+						<span className="text-muted-foreground text-xs">Creada</span>
+						<span className="text-muted-foreground text-xs">
+							{formatGuatemalaDate(opportunity.createdAt)}
+						</span>
+					</div>
+					{opportunity.closedAt && (
+						<div className="flex items-center justify-between">
+							<span className="text-muted-foreground text-xs">
+								Cierre real
+							</span>
+							<span className="text-muted-foreground text-xs">
+								{formatGuatemalaDate(opportunity.closedAt)}
+							</span>
+						</div>
+					)}
 				</div>
 				<div className="border-t pt-1">
 					<span className="font-mono text-[10px] text-muted-foreground/60">


### PR DESCRIPTION
## Summary
- remove the ambiguous expected close date from kanban opportunity cards
- show the opportunity creation date explicitly
- show the real close date using actual close date or the first transition into a 90%+ stage

## Testing
- bun run check-types
