### PR TITLE
feat(accounting): refine credit quota retrieval and enable filterable liquidation reports

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -186,7 +186,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         pago_otros: pagos_credito.otros,
       })
       .from(cuotas_credito)
-      .innerJoin(
+      .leftJoin(
         pagos_credito,
         eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
       )
@@ -298,7 +298,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       .orderBy(cuotas_credito.fecha_vencimiento)
       .limit(1);
 
-    // 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos vacíos
+    // 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos sin cuota activa
     if (!cuotaActualDataResult || cuotaActualDataResult.length === 0) {
       return {
         flujo: "ACTIVO",
@@ -307,9 +307,9 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         cuotaActual: null,
         cuotaActualPagada: false,
         cuotaActualStatus: null,
-        cuotasPendientes: [],
-        cuotasAtrasadas: [],
-        cuotasPagadas: [],
+        cuotasPendientes,
+        cuotasAtrasadas,
+        cuotasPagadas,
         moraActual: 0,
         mora: null,
         convenioActivo: null,

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1263,7 +1263,7 @@ export async function resumeInvestor(
               const abono_capital = new Big(pago.abono_capital ?? 0);
               const abono_interes = new Big(pago.abono_interes ?? 0);
               const abono_iva = new Big(pago.abono_iva_12 ?? 0);
-              const isr = abono_interes.times(0.07).round(2);
+              const isr = abono_interes.times(0.07);
               const cuota = pago.cuota ?? 0;
               let cuota_inversor;
               let abonoGeneralInteres;
@@ -1338,7 +1338,7 @@ const mes = fechaParaMes
                 abono_capital: formatValue(abono_capital.toString()),
                 abono_interes: formatValue(abono_interes.toString()),
                 abono_iva: formatValue(abono_iva.toString()),
-                isr: inv.emite_factura ? 0 : formatValue(isr.toString()),
+                isr: inv.emite_factura ? 0 : formatValue(isr.round(2).toString()),
                 porcentaje_inversor: pago.porcentaje_participacion,
                 cuota_inversor: formatValue(cuota_inversor.toString()),
                 cuota: formatValue(cuota),
@@ -1395,9 +1395,19 @@ const mes = fechaParaMes
             pagos: pagos_detalle,
             total_abono_capital: formatValue(total_abono_capital.toString()),
             total_abono_interes: formatValue(total_abono_interes.toString()),
-            total_abono_iva: formatValue(total_abono_iva.toString()),
-            total_isr: formatValue(total_isr.toString()),
-            total_cuota: formatValue(total_cuota.toString()),
+            total_abono_iva: formatValue(
+              (inv.emite_factura
+                ? total_abono_iva
+                : total_abono_interes.round(2).times(0.12)
+              ).round(2).toString()
+            ),
+            total_isr: formatValue(
+              (inv.emite_factura
+                ? new Big(0)
+                : total_abono_interes.round(2).times(0.07)
+              ).round(2).toString()
+            ),
+            total_cuota: formatValue(total_cuota.round(2).toString()),
             meses_en_credito,
             origen: c.origen, // 🆕 NUEVO: Indica si viene de tabla original o espejo
           };
@@ -1432,9 +1442,19 @@ const mes = fechaParaMes
         subtotal: {
           total_abono_capital: formatValue(subtotal.total_abono_capital.toString()),
           total_abono_interes: formatValue(subtotal.total_abono_interes.toString()),
-          total_abono_iva: formatValue(subtotal.total_abono_iva.toString()),
-          total_isr: formatValue(subtotal.total_isr.toString()),
-          total_cuota: formatValue(subtotal.total_cuota.toString()),
+          total_abono_iva: formatValue(
+            (inv.emite_factura
+              ? subtotal.total_abono_iva
+              : subtotal.total_abono_interes.round(2).times(0.12)
+            ).round(2).toString()
+          ),
+          total_isr: formatValue(
+            (inv.emite_factura
+              ? new Big(0)
+              : subtotal.total_abono_interes.round(2).times(0.07)
+            ).round(2).toString()
+          ),
+          total_cuota: formatValue(subtotal.total_cuota.round(2).toString()),
           total_monto_aportado: formatValue(subtotal.total_monto_aportado.toString()),
           total_abono_general_interes: formatValue(subtotal.totalAbonoGeneralInteres.toString()),
           total_capital_creditos: formatValue(subtotal.total_capital_creditos.toString()),
@@ -1649,8 +1669,8 @@ export async function getInvestorTotalsGlobales(
     for (const pago of pagos) {
       const abono_capital = new Big(pago.abono_capital ?? 0);
       const abono_interes = new Big(pago.abono_interes ?? 0);
-      const abono_iva = new Big(pago.abono_iva_12 ?? 0);
-      const isr = abono_interes.times(0.07).round(2);
+      const abono_iva = new Big(pago.abono_iva_12 ?? 0).round(2);
+      const isr = abono_interes.times(0.07);
 
       let abonoGeneralInteres;
       if (inv.emite_factura) {
@@ -1746,19 +1766,24 @@ export async function getInvestorTotalsGlobales(
     moneda: inv.moneda,
     currencySymbol: inv.moneda === "dolares" ? "$" : "Q.",
     totales: {
-      total_abono_capital: formatValue(subtotal.total_abono_capital.toString()),
-      total_abono_interes: formatValue(subtotal.total_abono_interes.toString()),
-      total_abono_iva: formatValue(subtotal.total_abono_iva.toString()),
-      total_isr: formatValue(subtotal.total_isr.toString()),
-      total_cuota_sin_reinversion: formatValue(subtotal.total_cuota.plus(subtotal.total_reinversion).toString()),
-      total_cuota_con_reinversion: formatValue(subtotal.total_cuota.toString()),
-      total_monto_aportado: formatValue(subtotal.total_monto_aportado.toString()),
-      total_abono_general_interes: formatValue(subtotal.totalAbonoGeneralInteres.toString()),
-      total_capital_creditos: formatValue(subtotal.total_capital_creditos.toString()),
-      total_capital_actual: formatValue(subtotal.total_capital_actual.toString()),
-      total_reinversion_capital: formatValue(subtotal.total_reinversion_capital.toString()),
-      total_reinversion_interes: formatValue(subtotal.total_reinversion_interes.toString()),
-      total_reinversion: formatValue(subtotal.total_reinversion.toString()),
+      total_abono_capital: formatValue(subtotal.total_abono_capital.round(2).toString()),
+      total_abono_interes: formatValue(subtotal.total_abono_interes.round(2).toString()),
+      total_abono_iva: formatValue(
+        (inv.emite_factura
+          ? subtotal.total_abono_iva
+          : subtotal.total_abono_interes.round(2).times(0.12)
+        ).round(2).toString()
+      ),
+      total_isr: formatValue(subtotal.total_isr.round(2).toString()),
+      total_cuota_sin_reinversion: formatValue(subtotal.total_cuota.plus(subtotal.total_reinversion).round(2).toString()),
+      total_cuota_con_reinversion: formatValue(subtotal.total_cuota.round(2).toString()),
+      total_monto_aportado: formatValue(subtotal.total_monto_aportado.round(2).toString()),
+      total_abono_general_interes: formatValue(subtotal.totalAbonoGeneralInteres.round(2).toString()),
+      total_capital_creditos: formatValue(subtotal.total_capital_creditos.round(2).toString()),
+      total_capital_actual: formatValue(subtotal.total_capital_actual.round(2).toString()),
+      total_reinversion_capital: formatValue(subtotal.total_reinversion_capital.round(2).toString()),
+      total_reinversion_interes: formatValue(subtotal.total_reinversion_interes.round(2).toString()),
+      total_reinversion: formatValue(subtotal.total_reinversion.round(2).toString()),
     },
   };
 }

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -349,7 +349,7 @@ export const inversionistasRouter = new Elysia()
     };
   })
   .post("/investor/reporte-liquidados", async ({ body, set }) => {
-    const { id } = body as { id?: number };
+    const { id, fecha_liquidacion } = body as { id?: number; fecha_liquidacion?: string };
 
     if (!id || isNaN(Number(id))) {
       set.status = 400;
@@ -357,6 +357,22 @@ export const inversionistasRouter = new Elysia()
     }
 
     try {
+      const todasLiquidaciones = await getLiquidaciones({ inversionista_id: Number(id), perPage: 999 });
+      let liquidacionReciente = todasLiquidaciones.liquidaciones?.[0];
+
+      if (fecha_liquidacion) {
+        const porFecha = todasLiquidaciones.liquidaciones?.find((l: any) =>
+          new Date(l.fecha_liquidacion).toISOString().slice(0, 10) === fecha_liquidacion
+        );
+        if (porFecha) liquidacionReciente = porFecha;
+      }
+
+      if (!liquidacionReciente) {
+        set.status = 404;
+        return { message: "Inversionista no encontrado o sin liquidaciones." };
+      }
+      const liquidacionId = liquidacionReciente.liquidacion_id;
+
       const result = await resumeInvestor(
         Number(id),
         1,
@@ -367,7 +383,8 @@ export const inversionistasRouter = new Elysia()
         false,
         undefined,
         "espejos",
-        true // soloLiquidados
+        true, // soloLiquidados
+        liquidacionId
       );
 
       if (!result.inversionistas.length) {
@@ -383,7 +400,8 @@ export const inversionistasRouter = new Elysia()
         "espejos",
         false,
         undefined,
-        true // soloLiquidados
+        true, // soloLiquidados
+        liquidacionId
       );
       inversionista.subtotal = totales.totales as any;
 


### PR DESCRIPTION
- Change payment join to a left join to ensure quotas are returned even without payment records.
- Fix logic in credit details to preserve calculated quota lists when no active current quota is found.
- Update investor reports to support filtering by liquidation date and ID for more granular auditing.
