### PR TITLE
Enhance investor registration and profile completion logic

### DIFF
--- a/apps/auth-google/src/services/cartera/investor.service.ts
+++ b/apps/auth-google/src/services/cartera/investor.service.ts
@@ -14,10 +14,10 @@ export interface CreateInvestorPayload {
   dpi: number;
   email?: string;
   emite_factura?: boolean;
-  tipo_reinversion: string;
+  tipo_reinversion?: string;
   banco?: string | null;
   tipo_cuenta?: string | null;
-  numero_cuenta?: string;
+  numero_cuenta?: string | null;
 }
 
 export interface CreateInvestorResponse {

--- a/apps/auth-google/src/services/unified/registerExternal.service.ts
+++ b/apps/auth-google/src/services/unified/registerExternal.service.ts
@@ -65,11 +65,6 @@ export const registerExternalUser = async (
         nombre: fullName,
         dpi: parseInt(dpi, 10),
         email: email,
-        emite_factura: false,
-        tipo_reinversion: "sin_reinversion",
-        banco: null,
-        tipo_cuenta: null,
-        numero_cuenta: "",
       });
 
       return {

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -313,15 +313,6 @@ export const insertInvestor = async ({ body, set }: any) => {
       if (inv.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inv.email)) {
         errores.push(`Inversionista #${index + 1}: email inválido`);
       }
-      // 🔥 Validar emite_factura si viene
-      if (
-        inv.emite_factura !== undefined &&
-        typeof inv.emite_factura !== "boolean"
-      ) {
-        errores.push(
-          `Inversionista #${index + 1}: emite_factura debe ser boolean`
-        );
-      }
 
       // 🔥 Si viene banco (nombre o id), resolverlo
       if (inv.banco) {

--- a/apps/crm/Dockerfile
+++ b/apps/crm/Dockerfile
@@ -11,7 +11,7 @@ COPY apps/crm/apps/server/package.json ./apps/crm/apps/server/
 COPY packages/infornet ./packages/infornet
 COPY packages/sms ./packages/sms
 
-WORKDIR /app/apps/crm/apps/web
+WORKDIR /app/apps/crm
 RUN bun install --frozen-lockfile
 
 # Stage 2: Build (invalidated only on source changes)

--- a/apps/portal-web/src/features/Profile/MyProfile/CompleteProfileForm.tsx
+++ b/apps/portal-web/src/features/Profile/MyProfile/CompleteProfileForm.tsx
@@ -7,10 +7,12 @@ import { registerExternalUser } from "../services";
 
 interface CompleteProfileFormProps {
   onSuccess: () => void;
+  onlyApi?: boolean; // Si es true, no actualiza el rol en better-auth (usado para completar perfil desde admin)
 }
 
 export const CompleteProfileForm = ({
   onSuccess,
+  onlyApi = false,
 }: CompleteProfileFormProps) => {
   const { user } = useAuth();
   const [dpi, setDpi] = useState("");
@@ -27,10 +29,12 @@ export const CompleteProfileForm = ({
       }
 
       // 1. Actualizar usuario en better-auth
-      await authClient.updateUser({
-        dpi: dpi,
-        role: userType,
-      } as any);
+      if (!onlyApi) {
+        await authClient.updateUser({
+          dpi: dpi,
+          role: userType,
+        } as any);
+      }
 
       await registerExternalUser({
         userType: userType,

--- a/apps/portal-web/src/features/Profile/MyProfile/Profile.tsx
+++ b/apps/portal-web/src/features/Profile/MyProfile/Profile.tsx
@@ -9,7 +9,7 @@ export const Profile = () => {
   const { user, isLoading } = useProfile();
   const [isCompletingProfile, setIsCompletingProfile] = useState(false);
 
-  const needsProfileCompletion = !user?.dpi && !isCompletingProfile;
+  const needsProfileCompletion = !user?.dpi && !isCompletingProfile && user?.role !== "INVESTOR";
 
   const handleProfileCompleted = () => {
     // Activar estado de carga antes de recargar


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the investor creation flow, profile completion logic, and Dockerfile configuration. The main focus is on making certain fields optional or nullable for investor creation, refining profile completion triggers, and improving flexibility in profile update operations.

**Investor creation and validation improvements:**

* Made `tipo_reinversion` and `numero_cuenta` optional or nullable in the `CreateInvestorPayload` interface to better handle cases where these values may not be provided.
* Removed default values for `emite_factura`, `tipo_reinversion`, `banco`, `tipo_cuenta`, and `numero_cuenta` in the `registerExternalUser` service, allowing for more flexible investor registration.
* Removed validation logic that enforced `emite_factura` to be a boolean, reducing unnecessary validation errors when the field is omitted.

**Profile completion logic and flexibility:**

* Updated the profile completion check to exclude users with the `INVESTOR` role from being prompted to complete their profile, preventing unnecessary prompts.
* Added an `onlyApi` prop to `CompleteProfileForm` to allow skipping the role update in `better-auth`, supporting admin-triggered profile completions without affecting user roles. [[1]](diffhunk://#diff-ee8c659cf41fc5ab21d9184f0068ccedd28df5101f1e0d241e5127931b24a6a2R10-R15) [[2]](diffhunk://#diff-ee8c659cf41fc5ab21d9184f0068ccedd28df5101f1e0d241e5127931b24a6a2R32-R37)

**Dockerfile configuration:**

* Changed the working directory in the CRM Dockerfile to `/app/apps/crm` to align with the actual project structure and prevent build issues.