### PR TITLE
Add manual vehicle valuation flow

### DIFF
--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -34,7 +34,7 @@ import {
 } from "./jobs/cobros-notifications";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
-import { appRouter, disbursementRouter } from "./routers/index";
+import { appRouter, disbursementRouter, manualVehicleRouter } from "./routers/index";
 import { investmentsRouter } from "./routers/investments";
 import externalContractsRouter from "./routes/external-contracts";
 
@@ -84,9 +84,13 @@ app.route("/api/contracts/external", externalContractsRouter);
 
 const handler = new RPCHandler({
 	...appRouter,
+	...manualVehicleRouter,
 	...investmentsRouter,
 	...disbursementRouter,
-} as typeof appRouter & typeof investmentsRouter & typeof disbursementRouter);
+} as typeof appRouter &
+	typeof manualVehicleRouter &
+	typeof investmentsRouter &
+	typeof disbursementRouter);
 app.use("/rpc/*", async (c, next) => {
 	const context = await createContext({ context: c });
 	const { matched, response } = await handler.handle(c.req.raw, {

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -316,4 +316,8 @@ export const disbursementRouter = {
 	updateJuridicoDashboardSnapshot: juridicoDashboardRouter.updateSnapshot,
 };
 
+export const manualVehicleRouter = {
+	upsertManualVehicleValuation: vehiclesRouter.upsertManualValuation,
+};
+
 export type AppRouter = typeof appRouter;

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -639,10 +639,32 @@ export const vehiclesRouter = {
 			z.object({
 				vehicleId: z.string().uuid(),
 				vehicleRating: z.enum(["Comercial", "No comercial"]),
-				marketValue: z.string().min(1),
-				suggestedCommercialValue: z.string().min(1),
-				bankValue: z.string().min(1),
-				currentConditionValue: z.string().min(1),
+				marketValue: z
+					.string()
+					.trim()
+					.regex(/^\d+(\.\d+)?$/, {
+						message: "El valor de mercado debe ser un número decimal válido",
+					}),
+				suggestedCommercialValue: z
+					.string()
+					.trim()
+					.regex(/^\d+(\.\d+)?$/, {
+						message:
+							"El valor comercial sugerido debe ser un número decimal válido",
+					}),
+				bankValue: z
+					.string()
+					.trim()
+					.regex(/^\d+(\.\d+)?$/, {
+						message: "El valor bancario debe ser un número decimal válido",
+					}),
+				currentConditionValue: z
+					.string()
+					.trim()
+					.regex(/^\d+(\.\d+)?$/, {
+						message:
+							"El valor en condición actual debe ser un número decimal válido",
+					}),
 			}),
 		)
 		.handler(async ({ input, context }) => {

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -34,6 +34,7 @@ import {
 	publicProcedure,
 	tallerOrCrmProcedure,
 } from "../lib/orpc";
+import { ROLES } from "../lib/roles";
 import {
 	buildUploadPrefix,
 	deleteFileFromR2,
@@ -631,6 +632,106 @@ export const vehiclesRouter = {
 			}
 
 			return newInspection;
+		}),
+
+	upsertManualValuation: crmProcedure
+		.input(
+			z.object({
+				vehicleId: z.string().uuid(),
+				vehicleRating: z.enum(["Comercial", "No comercial"]),
+				marketValue: z.string().min(1),
+				suggestedCommercialValue: z.string().min(1),
+				bankValue: z.string().min(1),
+				currentConditionValue: z.string().min(1),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			const userRole = context.userRole || "";
+			const canManageManualValuation =
+				userRole === ROLES.ADMIN || userRole === ROLES.SALES_SUPERVISOR;
+
+			if (!canManageManualValuation) {
+				throw new ORPCError("FORBIDDEN", {
+					message:
+						"Solo administradores y supervisores de ventas pueden cargar valores manuales",
+				});
+			}
+
+			const [vehicle] = await db
+				.select({ id: vehicles.id })
+				.from(vehicles)
+				.where(eq(vehicles.id, input.vehicleId))
+				.limit(1);
+
+			if (!vehicle) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Vehículo no encontrado",
+				});
+			}
+
+			const [latestInspection] = await db
+				.select()
+				.from(vehicleInspections)
+				.where(eq(vehicleInspections.vehicleId, input.vehicleId))
+				.orderBy(
+					desc(vehicleInspections.inspectionDate),
+					desc(vehicleInspections.createdAt),
+				)
+				.limit(1);
+
+			const isManualValuation =
+				latestInspection &&
+				latestInspection.technicianName === "Actualizacion manual CRM" &&
+				latestInspection.inspectionResult ===
+					"Actualización manual de valores comerciales del vehículo";
+
+			const manualValuationData = {
+				vehicleRating: input.vehicleRating,
+				marketValue: input.marketValue,
+				suggestedCommercialValue: input.suggestedCommercialValue,
+				bankValue: input.bankValue,
+				currentConditionValue: input.currentConditionValue,
+				technicianName: "Actualizacion manual CRM",
+				inspectionDate: new Date(),
+				inspectionResult:
+					"Actualización manual de valores comerciales del vehículo",
+				vehicleEquipment: "Pendiente de inspección completa",
+				status: "pending" as const,
+				alerts: [] as string[],
+				sectionTimes: {},
+				scannerUsed: false,
+				airbagWarning: false,
+				testDrive: false,
+				hasSpareTire: false,
+				hasAgencyHistory: false,
+				updatedAt: new Date(),
+			};
+
+			if (isManualValuation) {
+				const [updatedInspection] = await db
+					.update(vehicleInspections)
+					.set(manualValuationData)
+					.where(eq(vehicleInspections.id, latestInspection.id))
+					.returning();
+
+				return {
+					action: "updated" as const,
+					inspection: updatedInspection,
+				};
+			}
+
+			const [newInspection] = await db
+				.insert(vehicleInspections)
+				.values({
+					vehicleId: input.vehicleId,
+					...manualValuationData,
+				})
+				.returning();
+
+			return {
+				action: "created" as const,
+				inspection: newInspection,
+			};
 		}),
 
 	// Update inspection

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -639,32 +639,10 @@ export const vehiclesRouter = {
 			z.object({
 				vehicleId: z.string().uuid(),
 				vehicleRating: z.enum(["Comercial", "No comercial"]),
-				marketValue: z
-					.string()
-					.trim()
-					.regex(/^\d+(\.\d+)?$/, {
-						message: "El valor de mercado debe ser un número decimal válido",
-					}),
-				suggestedCommercialValue: z
-					.string()
-					.trim()
-					.regex(/^\d+(\.\d+)?$/, {
-						message:
-							"El valor comercial sugerido debe ser un número decimal válido",
-					}),
-				bankValue: z
-					.string()
-					.trim()
-					.regex(/^\d+(\.\d+)?$/, {
-						message: "El valor bancario debe ser un número decimal válido",
-					}),
-				currentConditionValue: z
-					.string()
-					.trim()
-					.regex(/^\d+(\.\d+)?$/, {
-						message:
-							"El valor en condición actual debe ser un número decimal válido",
-					}),
+				marketValue: z.string().trim(),
+				suggestedCommercialValue: z.string().trim(),
+				bankValue: z.string().trim(),
+				currentConditionValue: z.string().trim(),
 			}),
 		)
 		.handler(async ({ input, context }) => {

--- a/apps/crm/apps/web/src/components/crm/ManualVehicleValuationDialog.tsx
+++ b/apps/crm/apps/web/src/components/crm/ManualVehicleValuationDialog.tsx
@@ -1,0 +1,281 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, PencilLine } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { client, orpc } from "@/utils/orpc";
+
+type ManualVehicleValuationDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	vehicleId: string;
+	vehicleLabel: string;
+};
+
+const MANUAL_TECHNICIAN_NAME = "Actualizacion manual CRM";
+const clientWithManualValuation = client as typeof client & {
+	upsertManualVehicleValuation: (input: {
+		vehicleId: string;
+		vehicleRating: "Comercial" | "No comercial";
+		marketValue: string;
+		suggestedCommercialValue: string;
+		bankValue: string;
+		currentConditionValue: string;
+	}) => Promise<{ action: "created" | "updated"; inspection: { id: string } }>;
+};
+
+export function ManualVehicleValuationDialog({
+	open,
+	onOpenChange,
+	vehicleId,
+	vehicleLabel,
+}: ManualVehicleValuationDialogProps) {
+	const queryClient = useQueryClient();
+	const [vehicleRating, setVehicleRating] = useState<"Comercial" | "No comercial">(
+		"Comercial",
+	);
+	const [marketValue, setMarketValue] = useState("");
+	const [suggestedCommercialValue, setSuggestedCommercialValue] = useState("");
+	const [bankValue, setBankValue] = useState("");
+	const [currentConditionValue, setCurrentConditionValue] = useState("");
+
+	const latestInspectionQuery = useQuery({
+		...orpc.getLatestInspectionByVehicleId.queryOptions({
+			input: { vehicleId },
+		}),
+		enabled: open && !!vehicleId,
+		queryKey: ["getLatestInspectionByVehicleId", vehicleId],
+	});
+	const latestInspection = latestInspectionQuery.data as
+		| {
+				technicianName?: string | null;
+				vehicleRating?: string | null;
+				marketValue?: string | number | null;
+				suggestedCommercialValue?: string | number | null;
+				bankValue?: string | number | null;
+				currentConditionValue?: string | number | null;
+		  }
+		| null
+		| undefined;
+
+	useEffect(() => {
+		if (!open) {
+			return;
+		}
+
+		if (!latestInspection) {
+			setVehicleRating("Comercial");
+			setMarketValue("");
+			setSuggestedCommercialValue("");
+			setBankValue("");
+			setCurrentConditionValue("");
+			return;
+		}
+
+		setVehicleRating(
+			latestInspection.vehicleRating === "No comercial"
+				? "No comercial"
+				: "Comercial",
+		);
+		setMarketValue(latestInspection.marketValue?.toString() ?? "");
+		setSuggestedCommercialValue(
+			latestInspection.suggestedCommercialValue?.toString() ?? "",
+		);
+		setBankValue(latestInspection.bankValue?.toString() ?? "");
+		setCurrentConditionValue(
+			latestInspection.currentConditionValue?.toString() ??
+				latestInspection.suggestedCommercialValue?.toString() ??
+				"",
+		);
+	}, [open, latestInspection]);
+
+	const saveMutation = useMutation({
+		mutationFn: async () => {
+			return clientWithManualValuation.upsertManualVehicleValuation({
+				vehicleId,
+				vehicleRating,
+				marketValue,
+				suggestedCommercialValue,
+				bankValue,
+				currentConditionValue,
+			});
+		},
+		onSuccess: (result) => {
+			toast.success(
+				result.action === "updated"
+					? "Valores mínimos actualizados"
+					: "Valores mínimos cargados",
+			);
+			queryClient.invalidateQueries({
+				queryKey: ["getLatestInspectionByVehicleId", vehicleId],
+			});
+			queryClient.invalidateQueries({ queryKey: ["getVehicleById", vehicleId] });
+			onOpenChange(false);
+		},
+	});
+
+	const isManualValuation =
+		latestInspection?.technicianName === MANUAL_TECHNICIAN_NAME;
+	const isDisabled =
+		!marketValue ||
+		!suggestedCommercialValue ||
+		!bankValue ||
+		!currentConditionValue ||
+		saveMutation.isPending;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-xl">
+				<DialogHeader>
+					<DialogTitle>Carga de valores mínimos</DialogTitle>
+					<DialogDescription>{vehicleLabel}</DialogDescription>
+				</DialogHeader>
+
+				<div className="space-y-4">
+					{latestInspectionQuery.isLoading ? (
+						<div className="flex items-center gap-2 text-muted-foreground text-sm">
+							<Loader2 className="h-4 w-4 animate-spin" />
+							Cargando última inspección...
+						</div>
+					) : latestInspection ? (
+						<div className="rounded-lg border bg-muted/30 p-3 text-sm">
+							<div className="font-medium">
+								{isManualValuation
+									? "Última carga manual encontrada"
+									: "Última inspección registrada"}
+							</div>
+							<div className="mt-2 grid gap-1 text-muted-foreground">
+								<span>
+									Clasificación: {latestInspection.vehicleRating || "Sin dato"}
+								</span>
+								<span>
+									Mercado: Q
+									{Number(latestInspection.marketValue || 0).toLocaleString()}
+								</span>
+								<span>
+									Sugerido: Q
+									{Number(
+										latestInspection.suggestedCommercialValue || 0,
+									).toLocaleString()}
+								</span>
+								<span>
+									Bancario: Q
+									{Number(latestInspection.bankValue || 0).toLocaleString()}
+								</span>
+							</div>
+						</div>
+					) : (
+						<div className="rounded-lg border border-dashed p-3 text-muted-foreground text-sm">
+							Este vehículo no tiene inspección previa. Se creará una carga
+							manual nueva.
+						</div>
+					)}
+
+					<div className="grid gap-4 sm:grid-cols-2">
+						<div className="space-y-2">
+							<Label>Clasificación</Label>
+							<Select
+								value={vehicleRating}
+								onValueChange={(value) =>
+									setVehicleRating(value as "Comercial" | "No comercial")
+								}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="Comercial">Comercial</SelectItem>
+									<SelectItem value="No comercial">No comercial</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="space-y-2">
+							<Label>Valor mercado</Label>
+							<Input
+								inputMode="decimal"
+								value={marketValue}
+								onChange={(event) => setMarketValue(event.target.value)}
+								placeholder="60000"
+							/>
+						</div>
+
+						<div className="space-y-2">
+							<Label>Valor comercial sugerido</Label>
+							<Input
+								inputMode="decimal"
+								value={suggestedCommercialValue}
+								onChange={(event) => {
+									const value = event.target.value;
+									setSuggestedCommercialValue(value);
+									if (!currentConditionValue) {
+										setCurrentConditionValue(value);
+									}
+								}}
+								placeholder="56000"
+							/>
+						</div>
+
+						<div className="space-y-2">
+							<Label>Valor bancario</Label>
+							<Input
+								inputMode="decimal"
+								value={bankValue}
+								onChange={(event) => setBankValue(event.target.value)}
+								placeholder="47000"
+							/>
+						</div>
+
+						<div className="space-y-2 sm:col-span-2">
+							<Label>Valor condiciones actuales</Label>
+							<Input
+								inputMode="decimal"
+								value={currentConditionValue}
+								onChange={(event) =>
+									setCurrentConditionValue(event.target.value)
+								}
+								placeholder="56000"
+							/>
+						</div>
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={() => onOpenChange(false)}>
+						Cancelar
+					</Button>
+					<Button disabled={isDisabled} onClick={() => saveMutation.mutate()}>
+						{saveMutation.isPending ? (
+							<>
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+								Guardando...
+							</>
+						) : (
+							<>
+								<PencilLine className="mr-2 h-4 w-4" />
+								Guardar valores mínimos
+							</>
+						)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/crm/apps/web/src/components/crm/ManualVehicleValuationDialog.tsx
+++ b/apps/crm/apps/web/src/components/crm/ManualVehicleValuationDialog.tsx
@@ -129,6 +129,13 @@ export function ManualVehicleValuationDialog({
 			queryClient.invalidateQueries({ queryKey: ["getVehicleById", vehicleId] });
 			onOpenChange(false);
 		},
+		onError: (error: any) => {
+			const message =
+				error?.message && typeof error.message === "string"
+					? error.message
+					: "Ocurrió un error al guardar la valoración. Inténtalo nuevamente.";
+			toast.error(message);
+		},
 	});
 
 	const isManualValuation =

--- a/apps/crm/apps/web/src/components/juridico/juridico-dashboard.tsx
+++ b/apps/crm/apps/web/src/components/juridico/juridico-dashboard.tsx
@@ -74,7 +74,7 @@ const getNextShortMonth = (currentShort: string) => {
 	return SPANISH_SHORT_MONTHS[(index + 1) % 12];
 };
 
-export interface JuridicoDashboardPayload {
+export interface JuridicoDashboardSinglePayload {
 	header: {
 		title: string;
 		subtitle: string;
@@ -113,20 +113,21 @@ export interface JuridicoDashboardPayload {
 		pct: number;
 		tone: "success" | "warning" | "danger";
 	}>;
-	history?: Array<{
-		periodLabel: string;
-		metrics: JuridicoDashboardPayload["metrics"];
-		funnel: JuridicoDashboardPayload["funnel"];
-		orders: JuridicoDashboardPayload["orders"];
-		quality: JuridicoDashboardPayload["quality"];
-	}>;
 }
 
+export type JuridicoDashboardPayload =
+	| JuridicoDashboardSinglePayload
+	| JuridicoDashboardSinglePayload[];
+
 interface SnapshotRecord {
+	id?: string;
+	scope?: string;
 	periodLabel: string;
 	notes: string | null;
 	payload: JuridicoDashboardPayload;
 	publishedAt: string | Date;
+	updatedBy?: string;
+	updatedAt?: string | Date;
 }
 
 export const JURIDICO_DASHBOARD_TEMPLATE: SnapshotRecord = {
@@ -228,7 +229,9 @@ export const JURIDICO_DASHBOARD_TEMPLATE: SnapshotRecord = {
 	publishedAt: new Date().toISOString(),
 };
 
-function formatMetricValue(metric: JuridicoDashboardPayload["metrics"][number]) {
+function formatMetricValue(
+	metric: JuridicoDashboardSinglePayload["metrics"][number],
+) {
 	const label = metric.label.toLowerCase();
 
 	if (label.includes("recaudación")) {
@@ -256,7 +259,7 @@ function getToneClasses(
 }
 
 function getFunnelClasses(
-	tone: JuridicoDashboardPayload["funnel"][number]["tone"] = "primary",
+	tone: JuridicoDashboardSinglePayload["funnel"][number]["tone"] = "primary",
 ) {
 	if (tone === "success") return "bg-emerald-500";
 	if (tone === "warning") return "bg-amber-500";
@@ -265,7 +268,7 @@ function getFunnelClasses(
 }
 
 function getQualityClasses(
-	tone: JuridicoDashboardPayload["quality"][number]["tone"],
+	tone: JuridicoDashboardSinglePayload["quality"][number]["tone"],
 ) {
 	if (tone === "success") return "bg-emerald-500";
 	if (tone === "warning") return "bg-amber-500";
@@ -310,7 +313,7 @@ const juridicoDashboardQualityItemSchema = z.object({
 	tone: z.enum(["success", "warning", "danger"]),
 });
 
-const juridicoDashboardPayloadSchema = z.object({
+const juridicoDashboardSinglePayloadSchema = z.object({
 	header: z.object({
 		title: z.string().min(1).default("Jurídico"),
 		subtitle: z
@@ -337,7 +340,7 @@ const SPANISH_MONTHS_MAP: Record<string, number> = {
 	julio: 6, agosto: 7, septiembre: 8, octubre: 9, noviembre: 10, diciembre: 11
 };
 
-function sortHistory(history: any[]) {
+function sortHistory(history: JuridicoDashboardSinglePayload[]) {
 	return [...history].sort((a, b) => {
 		const labelA = a.header.periodLabel.toLowerCase();
 		const labelB = b.header.periodLabel.toLowerCase();
@@ -395,7 +398,7 @@ export function JuridicoDashboardView({
 
 	// NEW: The payload can now be a single object or an array (for history)
 	const rawPayload = snapshot.payload;
-	const history: any[] = sortHistory(
+	const history = sortHistory(
 		(Array.isArray(rawPayload) ? rawPayload : [rawPayload]).filter(Boolean),
 	);
 	const hasHistory = history.length > 1;
@@ -419,7 +422,7 @@ export function JuridicoDashboardView({
 	const normalizedActive = activePeriod ? normalizePeriod(activePeriod) : null;
 	const selectedSnapshot =
 		normalizedActive
-			? history.find((h: any) => normalizePeriod(h.header.periodLabel) === normalizedActive) ||
+			? history.find((h) => normalizePeriod(h.header.periodLabel) === normalizedActive) ||
 				latestPeriod
 			: latestPeriod;
 
@@ -450,7 +453,7 @@ export function JuridicoDashboardView({
 											<SelectValue placeholder="Seleccionar periodo" />
 										</SelectTrigger>
 										<SelectContent>
-											{history.map((h: any) => (
+											{history.map((h) => (
 												<SelectItem 
 													key={h.header.periodLabel} 
 													value={normalizePeriod(h.header.periodLabel)}
@@ -496,7 +499,7 @@ export function JuridicoDashboardView({
 			</div>
 
 			<div className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
-				{selectedSnapshot.metrics.map((metric: any) => (
+				{selectedSnapshot.metrics.map((metric) => (
 					<Card key={metric.label}>
 						<CardHeader className="pb-2">
 							<CardDescription>{metric.label}</CardDescription>
@@ -529,7 +532,7 @@ export function JuridicoDashboardView({
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-4">
-						{selectedSnapshot.funnel.map((step: any) => (
+						{selectedSnapshot.funnel.map((step) => (
 							<div key={step.label} className="space-y-2">
 								<div className="flex items-center justify-between text-sm">
 									<span className="text-muted-foreground">{step.label}</span>
@@ -632,7 +635,7 @@ export function JuridicoDashboardView({
 								No hay órdenes cargadas para este período.
 							</p>
 						) : (
-							selectedSnapshot.orders.map((order: any) => (
+							selectedSnapshot.orders.map((order) => (
 								<div
 									key={order.id}
 									className="grid gap-3 rounded-lg border p-4 md:grid-cols-[0.8fr_0.9fr_0.8fr_0.7fr_0.7fr]"
@@ -682,7 +685,7 @@ export function JuridicoDashboardView({
 						</CardDescription>
 					</CardHeader>
 					<CardContent className="space-y-4">
-						{selectedSnapshot.quality.map((item: any) => (
+						{selectedSnapshot.quality.map((item) => (
 							<div key={item.label} className="space-y-2">
 								<div className="flex items-center justify-between text-sm">
 									<div className="flex items-center gap-2">
@@ -718,7 +721,11 @@ export function JuridicoDashboardEditor({
 }) {
 	const initialPayload = (() => {
 		const raw = snapshot?.payload;
-		const hist = sortHistory((Array.isArray(raw) ? raw : raw ? [raw] : []).filter(Boolean));
+		const hist = sortHistory(
+			(Array.isArray(raw) ? raw : raw ? [raw] : []).filter(
+				Boolean,
+			) as JuridicoDashboardSinglePayload[],
+		);
 		return hist[hist.length - 1] || JURIDICO_DASHBOARD_TEMPLATE.payload;
 	})();
 	const [periodLabel, setPeriodLabel] = useState(
@@ -729,7 +736,8 @@ export function JuridicoDashboardEditor({
 			"<!--DASHBOARD_HISTORY:",
 		)[0].trim(),
 	);
-	const [payload, setPayload] = useState<JuridicoDashboardPayload>(initialPayload);
+	const [payload, setPayload] =
+		useState<JuridicoDashboardSinglePayload>(initialPayload);
 	const [rawJson, setRawJson] = useState(() => JSON.stringify(initialPayload, null, 2));
 	const [validationErrors, setValidationErrors] = useState<string[]>([]);
 	const [parseError, setParseError] = useState<string | null>(null);
@@ -750,7 +758,11 @@ export function JuridicoDashboardEditor({
 		
 		// If payload is array, take latest for current editor state
 		const rawPayload = snapshot.payload;
-		const history: any[] = sortHistory((Array.isArray(rawPayload) ? rawPayload : [rawPayload]).filter(Boolean));
+		const history = sortHistory(
+			(Array.isArray(rawPayload) ? rawPayload : [rawPayload]).filter(
+				Boolean,
+			) as JuridicoDashboardSinglePayload[],
+		);
 		const latest = history[history.length - 1] || JURIDICO_DASHBOARD_TEMPLATE.payload;
 		
 		// Priority: Payload header label correctly reflects the content
@@ -770,7 +782,7 @@ export function JuridicoDashboardEditor({
 
 				// Track actual validity for indicators
 				setSectionsPresence({
-					header: juridicoDashboardPayloadSchema.shape.header.safeParse(currentPayload.header).success,
+					header: juridicoDashboardSinglePayloadSchema.shape.header.safeParse(currentPayload.header).success,
 					metrics: z.array(juridicoDashboardMetricSchema).min(4).max(6).safeParse(currentPayload.metrics).success,
 					trend: z.array(juridicoDashboardTrendPointSchema).min(1).max(12).safeParse(currentPayload.trend).success,
 					funnel: z.array(juridicoDashboardFunnelStepSchema).min(3).max(6).safeParse(currentPayload.funnel).success,
@@ -778,7 +790,7 @@ export function JuridicoDashboardEditor({
 					quality: z.array(juridicoDashboardQualityItemSchema).min(1).max(5).safeParse(currentPayload.quality).success,
 				});
 
-				const result = juridicoDashboardPayloadSchema.safeParse(currentPayload);
+				const result = juridicoDashboardSinglePayloadSchema.safeParse(currentPayload);
 				if (!result.success) {
 					// Humanize Zod errors
 					const humanErrors = result.error.issues.map((issue) => {
@@ -819,7 +831,9 @@ export function JuridicoDashboardEditor({
 	const handleNewMonth = () => {
 		// Get latest available data from history or template
 		const rawPayload = snapshot?.payload;
-		const historyList: any[] = (Array.isArray(rawPayload) ? rawPayload : [rawPayload]).filter(Boolean);
+		const historyList = (
+			Array.isArray(rawPayload) ? rawPayload : [rawPayload]
+		).filter(Boolean) as JuridicoDashboardSinglePayload[];
 		const base = historyList[historyList.length - 1] || JURIDICO_DASHBOARD_TEMPLATE.payload;
 
 		const nextPeriodHeader = getNextMonthLabel(base.header.periodLabel);
@@ -833,18 +847,18 @@ export function JuridicoDashboardEditor({
 			{ label: nextTrendLabel, collectedAmount: 0, casesIntervened: 0 }
 		];
 
-		const cleanPayload: JuridicoDashboardPayload = {
+		const cleanPayload: JuridicoDashboardSinglePayload = {
 			...base,
 			header: {
 				...base.header,
 				periodLabel: nextPeriodHeader,
 				sourceLabel: base.header.sourceLabel || "",
 			},
-			metrics: base.metrics.map((m: any) => ({ ...m, value: 0, changeText: "" })),
+			metrics: base.metrics.map((m) => ({ ...m, value: 0, changeText: "" })),
 			trend: newTrend,
-			funnel: base.funnel.map((s: any) => ({ ...s, value: 0, pct: 0 })),
+			funnel: base.funnel.map((s) => ({ ...s, value: 0, pct: 0 })),
 			orders: [],
-			quality: base.quality.map((q: any) => ({ ...q, pct: 0 })),
+			quality: base.quality.map((q) => ({ ...q, pct: 0 })),
 		};
 		
 		setPeriodLabel(nextPeriodHeader);
@@ -861,7 +875,9 @@ export function JuridicoDashboardEditor({
 	};
 
 	const syncPayload = (
-		updater: (current: JuridicoDashboardPayload) => JuridicoDashboardPayload,
+		updater: (
+			current: JuridicoDashboardSinglePayload,
+		) => JuridicoDashboardSinglePayload,
 	) => {
 		setPayload((current) => {
 			const next = updater(current);
@@ -906,7 +922,7 @@ export function JuridicoDashboardEditor({
 
 	const updateOrder = (
 		index: number,
-		key: keyof JuridicoDashboardPayload["orders"][number],
+		key: keyof JuridicoDashboardSinglePayload["orders"][number],
 		value: string,
 	) => {
 		syncPayload((current) => {
@@ -959,7 +975,7 @@ export function JuridicoDashboardEditor({
 
 	const updateQuality = (
 		index: number,
-		key: keyof JuridicoDashboardPayload["quality"][number],
+		key: keyof JuridicoDashboardSinglePayload["quality"][number],
 		value: string,
 	) => {
 		syncPayload((current) => {
@@ -982,7 +998,7 @@ export function JuridicoDashboardEditor({
 
 		if (showAdvancedEditor) {
 			try {
-				parsedData = JSON.parse(rawJson) as JuridicoDashboardPayload;
+				parsedData = JSON.parse(rawJson) as JuridicoDashboardSinglePayload;
 				setPayload(parsedData);
 			} catch (e) {
 				setParseError("El JSON no es válido");
@@ -992,7 +1008,9 @@ export function JuridicoDashboardEditor({
 
 		// --- SMART UPSERT ARRAY LOGIC ---
 		const rawPayload = snapshot?.payload;
-		const history: any[] = Array.isArray(rawPayload) ? rawPayload : rawPayload ? [rawPayload] : [];
+		const history = (
+			Array.isArray(rawPayload) ? rawPayload : rawPayload ? [rawPayload] : []
+		) as JuridicoDashboardSinglePayload[];
 		
 		// Priority: Use the label from the JSON content to avoid mismatches
 		const currentPeriodLabel = parsedData.header.periodLabel || periodLabel;
@@ -1080,7 +1098,7 @@ export function JuridicoDashboardEditor({
 			<div className="space-y-3">
 				<h3 className="font-medium text-sm">Métricas principales (4 a 6)</h3>
 				<div className="grid gap-3 sm:grid-cols-2">
-					{payload?.metrics?.map((metric: any, index: number) => (
+					{payload?.metrics?.map((metric, index: number) => (
 						<div key={`${metric.label}-${index}`} className="grid gap-2 rounded-lg border p-3">
 							<div className="font-medium text-xs text-muted-foreground">
 								{metric.label}
@@ -1108,7 +1126,7 @@ export function JuridicoDashboardEditor({
 			<div className="space-y-3">
 				<h3 className="font-medium text-sm">Tendencia mensual</h3>
 				<div className="max-h-[300px] overflow-y-auto pr-2">
-					{payload?.trend?.map((point: any, index: number) => (
+					{payload?.trend?.map((point, index: number) => (
 						<div
 							key={`${point.label}-${index}`}
 							className="mb-3 grid gap-2 rounded-lg border p-3 md:grid-cols-3"
@@ -1143,7 +1161,7 @@ export function JuridicoDashboardEditor({
 		<div className="space-y-8">
 			<div className="space-y-3">
 				<h3 className="font-medium text-sm">Embudo jurídico</h3>
-				{payload?.funnel?.map((step: any, index: number) => (
+				{payload?.funnel?.map((step, index: number) => (
 					<div
 						key={`${step.label}-${index}`}
 						className="grid gap-2 rounded-lg border p-3 md:grid-cols-2"
@@ -1260,7 +1278,7 @@ export function JuridicoDashboardEditor({
 
 			<div className="space-y-3">
 				<h3 className="font-medium text-sm">Semáforo de calidad</h3>
-				{payload?.quality?.map((item: any, index: number) => (
+				{payload?.quality?.map((item, index: number) => (
 					<div
 						key={`${item.label}-${index}`}
 						className="grid gap-2 rounded-lg border p-3 md:grid-cols-2"
@@ -1306,11 +1324,12 @@ export function JuridicoDashboardEditor({
 					<div className="space-y-2">
 						<div className="flex items-center justify-between font-medium text-sm">
 							<label htmlFor="periodLabel">Período visible</label>
-							{(Array.isArray(snapshot?.payload) && (snapshot.payload as unknown as any[]).length > 0) && (
+							{Array.isArray(snapshot?.payload) && snapshot.payload.length > 0 && (
 								<Select
 									value={periodLabel}
 									onValueChange={(val) => {
-										const history = (snapshot.payload as unknown as any[]);
+										const history =
+											snapshot.payload as JuridicoDashboardSinglePayload[];
 										const selected = history.find(
 											(m) => normalizePeriod(m.header.periodLabel) === normalizePeriod(val)
 										);
@@ -1325,7 +1344,9 @@ export function JuridicoDashboardEditor({
 										<SelectValue placeholder="Editar existente..." />
 									</SelectTrigger>
 									<SelectContent>
-										{sortHistory(snapshot.payload as unknown as any[]).map((m: any) => (
+										{sortHistory(
+											snapshot.payload as JuridicoDashboardSinglePayload[],
+										).map((m) => (
 											<SelectItem 
 												key={m.header.periodLabel} 
 												value={m.header.periodLabel}

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -46,6 +46,7 @@ import { CoDebtorsView } from "@/components/co-debtors/CoDebtorsView";
 import { ConsolidatedCreditSummary } from "@/components/credit/ConsolidatedCreditSummary";
 import { CreditDetailView } from "@/components/credit/CreditDetailView";
 import { ConfirmContractsSignedModal } from "@/components/crm/ConfirmContractsSignedModal";
+import { ManualVehicleValuationDialog } from "@/components/crm/ManualVehicleValuationDialog";
 import { DataTable } from "@/components/data-table";
 import { NotesTimeline } from "@/components/notes-timeline";
 import { Badge } from "@/components/ui/badge";
@@ -355,6 +356,8 @@ function RouteComponent() {
 	const queryClient = useQueryClient();
 	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
 	const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false);
+	const [isManualValuationDialogOpen, setIsManualValuationDialogOpen] =
+		useState(false);
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 	const [isChangeStageDialogOpen, setIsChangeStageDialogOpen] = useState(false);
 	const [selectedOpportunity, setSelectedOpportunity] =
@@ -758,6 +761,9 @@ function RouteComponent() {
 	});
 
 	const canFilterBySalesperson =
+		userProfile.data?.role === ROLES.ADMIN ||
+		userProfile.data?.role === ROLES.SALES_SUPERVISOR;
+	const canManageManualVehicleValuation =
 		userProfile.data?.role === ROLES.ADMIN ||
 		userProfile.data?.role === ROLES.SALES_SUPERVISOR;
 
@@ -2220,9 +2226,22 @@ function RouteComponent() {
 									{/* Vehicle Info */}
 									{selectedOpportunity.vehicle && (
 										<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
-											<Label className="font-semibold text-muted-foreground text-sm">
-												Vehículo
-											</Label>
+											<div className="flex items-start justify-between gap-3">
+												<Label className="font-semibold text-muted-foreground text-sm">
+													Vehículo
+												</Label>
+												{canManageManualVehicleValuation && (
+													<Button
+														size="sm"
+														variant="outline"
+														onClick={() =>
+															setIsManualValuationDialogOpen(true)
+														}
+													>
+														Cargar valores mínimos
+													</Button>
+												)}
+											</div>
 											<div className="flex items-center gap-3">
 												<Car className="h-5 w-5 text-muted-foreground" />
 												<div className="flex flex-col gap-1">
@@ -3327,6 +3346,15 @@ function RouteComponent() {
 				isLoading={confirmContractsSignedMutation.isPending}
 				opportunityTitle={opportunityToConfirmSigned?.title}
 			/>
+
+			{selectedOpportunity?.vehicle?.id && (
+				<ManualVehicleValuationDialog
+					open={isManualValuationDialogOpen}
+					onOpenChange={setIsManualValuationDialogOpen}
+					vehicleId={selectedOpportunity.vehicle.id}
+					vehicleLabel={`${selectedOpportunity.vehicle.year} ${selectedOpportunity.vehicle.make} ${selectedOpportunity.vehicle.model}${selectedOpportunity.vehicle.licensePlate ? ` • ${selectedOpportunity.vehicle.licensePlate}` : ""}`}
+				/>
+			)}
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- add a manual vehicle valuation flow in CRM opportunity details for admin and sales supervisors
- add a dedicated backend upsert endpoint for manual minimum valuations
- fix juridico dashboard payload typing to match the backend snapshot shape

## Testing
- bun run check-types (apps/server)
- focused web typecheck validation for juridico files and manual valuation files
