### PR TITLE
Add validations and UI constraints for credit start date

### DIFF
--- a/apps/cartera-back/src/controllers/updateDueDate.ts
+++ b/apps/cartera-back/src/controllers/updateDueDate.ts
@@ -438,6 +438,11 @@ export const cambiarFechaInicio = async ({
 
     const { numero_credito_sifco, nueva_fecha_inicio, changed_by, razon } = parseResult.data;
 
+    // Cuota mínima a partir de la cual, si está pagada, se bloquea el cambio de fecha.
+    // Ej: 2 = permite cambio si solo cuotas 0 y/o 1 están pagadas.
+    //     1 = solo permite si únicamente cuota 0 está pagada.
+    const CUOTA_MINIMA_BLOQUEO = 2;
+
     console.log(`\n${"=".repeat(60)}`);
     console.log(`CAMBIAR FECHA DE INICIO: ${numero_credito_sifco}`);
     console.log(`Nueva fecha inicio: ${nueva_fecha_inicio}`);
@@ -462,6 +467,7 @@ export const cambiarFechaInicio = async ({
         cuota_id: cuotas_credito.cuota_id,
         fecha_vencimiento: cuotas_credito.fecha_vencimiento,
         numero_cuota: cuotas_credito.numero_cuota,
+        pagado: cuotas_credito.pagado,
       })
       .from(cuotas_credito)
       .where(eq(cuotas_credito.credito_id, creditoDb.credito_id))
@@ -470,6 +476,18 @@ export const cambiarFechaInicio = async ({
     if (todasLasCuotas.length === 0) {
       set.status = 400;
       return { success: false, message: "El crédito no tiene cuotas" };
+    }
+
+    // 2.5 Validar que no haya cuotas >= CUOTA_MINIMA_BLOQUEO pagadas
+    const cuotaPagadaMayor = todasLasCuotas.find(
+      (c) => c.numero_cuota >= CUOTA_MINIMA_BLOQUEO && c.pagado
+    );
+    if (cuotaPagadaMayor) {
+      set.status = 400;
+      return {
+        success: false,
+        message: `No se puede cambiar la fecha de inicio porque la cuota ${cuotaPagadaMayor.numero_cuota} ya está pagada. Solo se permite el cambio si únicamente las cuotas menores a ${CUOTA_MINIMA_BLOQUEO} están pagadas.`,
+      };
     }
 
     // 3. Guardar historial del cambio (fecha anterior de cuota 1)

--- a/apps/carteraFront/src/private/cartera/components/ModalCambiarFechaInicio.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalCambiarFechaInicio.tsx
@@ -6,7 +6,30 @@ import { useMutation } from "@tanstack/react-query";
 import { cambiarFechaInicioService } from "../services/services";
 import { toast } from "sonner";
 import { CalendarClock } from "lucide-react";
-import { DatePickerMUI } from "./calendar";
+
+const MESES = [
+  { value: 1, label: "Enero" },
+  { value: 2, label: "Febrero" },
+  { value: 3, label: "Marzo" },
+  { value: 4, label: "Abril" },
+  { value: 5, label: "Mayo" },
+  { value: 6, label: "Junio" },
+  { value: 7, label: "Julio" },
+  { value: 8, label: "Agosto" },
+  { value: 9, label: "Septiembre" },
+  { value: 10, label: "Octubre" },
+  { value: 11, label: "Noviembre" },
+  { value: 12, label: "Diciembre" },
+];
+
+function getDiasPermitidos(mes: number, anio: number): number[] {
+  if (mes === 2) {
+    // Febrero: 15 y último día (28 o 29)
+    const ultimoDia = new Date(anio, 2, 0).getDate();
+    return [15, ultimoDia];
+  }
+  return [15, 30];
+}
 
 export function ModalCambiarFechaInicio({
   open,
@@ -23,22 +46,29 @@ export function ModalCambiarFechaInicio({
   changedBy: string;
   onSuccess?: () => void;
 }) {
-  const [nuevaFecha, setNuevaFecha] = useState("");
+  const now = new Date();
+  const [mes, setMes] = useState(now.getMonth() + 1);
+  const [anio, setAnio] = useState(now.getFullYear());
+  const [dia, setDia] = useState<number | "">(15);
   const [razon, setRazon] = useState("");
+
+  const diasPermitidos = getDiasPermitidos(mes, anio);
 
   const mutation = useMutation({
     mutationFn: cambiarFechaInicioService,
   });
 
   const handleSubmit = () => {
-    if (!nuevaFecha) {
-      toast.error("Selecciona una nueva fecha");
+    if (!dia) {
+      toast.error("Selecciona un día");
       return;
     }
     if (!razon.trim()) {
       toast.error("Ingresa una razón para el cambio");
       return;
     }
+
+    const nuevaFecha = `${anio}-${String(mes).padStart(2, "0")}-${String(dia).padStart(2, "0")}`;
 
     mutation.mutate(
       {
@@ -63,7 +93,9 @@ export function ModalCambiarFechaInicio({
   };
 
   const handleClose = () => {
-    setNuevaFecha("");
+    setMes(now.getMonth() + 1);
+    setAnio(now.getFullYear());
+    setDia(15);
     setRazon("");
     onClose();
   };
@@ -75,6 +107,9 @@ export function ModalCambiarFechaInicio({
         year: "numeric",
       })
     : "No definida";
+
+  // Años disponibles: actual -1 hasta actual +2
+  const aniosDisponibles = Array.from({ length: 4 }, (_, i) => now.getFullYear() - 1 + i);
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
@@ -102,16 +137,63 @@ export function ModalCambiarFechaInicio({
 
         <div className="grid gap-4">
           <div>
-            <Label className="text-gray-800 font-semibold mb-1">
+            <Label className="text-gray-800 font-semibold mb-2 block">
               Nueva fecha de inicio
             </Label>
-            <div className="[&_.MuiInputBase-root]:h-10 [&_.MuiInputBase-root]:text-sm [&_.MuiInputBase-root]:bg-white [&_.MuiOutlinedInput-notchedOutline]:border-gray-200 [&_.MuiOutlinedInput-notchedOutline]:rounded-md">
-              <DatePickerMUI
-                disableFuture={false}
-                value={nuevaFecha}
-                onChange={(val) => setNuevaFecha(val)}
-              />
+            <div className="grid grid-cols-3 gap-2">
+              <div>
+                <label className="text-xs text-gray-500 mb-1 block">Día</label>
+                <select
+                  value={dia}
+                  onChange={(e) => setDia(Number(e.target.value))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white text-gray-900 focus:ring-2 focus:ring-blue-400"
+                >
+                  {diasPermitidos.map((d) => (
+                    <option key={d} value={d}>{d}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs text-gray-500 mb-1 block">Mes</label>
+                <select
+                  value={mes}
+                  onChange={(e) => {
+                    const nuevoMes = Number(e.target.value);
+                    setMes(nuevoMes);
+                    // Si el día actual no es válido para el nuevo mes, resetear a 15
+                    const nuevosDias = getDiasPermitidos(nuevoMes, anio);
+                    if (!nuevosDias.includes(dia as number)) {
+                      setDia(15);
+                    }
+                  }}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white text-gray-900 focus:ring-2 focus:ring-blue-400"
+                >
+                  {MESES.map((m) => (
+                    <option key={m.value} value={m.value}>{m.label}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-xs text-gray-500 mb-1 block">Año</label>
+                <select
+                  value={anio}
+                  onChange={(e) => {
+                    const nuevoAnio = Number(e.target.value);
+                    setAnio(nuevoAnio);
+                    const nuevosDias = getDiasPermitidos(mes, nuevoAnio);
+                    if (!nuevosDias.includes(dia as number)) {
+                      setDia(15);
+                    }
+                  }}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm bg-white text-gray-900 focus:ring-2 focus:ring-blue-400"
+                >
+                  {aniosDisponibles.map((a) => (
+                    <option key={a} value={a}>{a}</option>
+                  ))}
+                </select>
+              </div>
             </div>
+            <p className="text-xs text-gray-400 mt-1.5">Solo días 15 o 30 (28/29 en febrero)</p>
           </div>
 
           <div>

--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -730,26 +730,23 @@ export function PagoForm() {
                   <Label className="text-gray-700 font-semibold text-sm">
                     Origen de Pago <span className="text-red-500">*</span>
                   </Label>
-                  <Select
+                  <select
                     value={formik.values.origen_pago || ""}
-                    onValueChange={(value) => {
-                      formik.setFieldValue("origen_pago", value);
+                    onChange={(e) => {
+                      formik.setFieldValue("origen_pago", e.target.value);
                       formik.setFieldTouched("origen_pago", true, false);
                     }}
-                  >
-                    <SelectTrigger className={`w-full border rounded-lg px-3 py-2.5 text-gray-900 bg-white [&>span]:text-gray-900 ${
+                    className={`w-full border rounded-lg px-3 py-2.5 text-gray-900 bg-white ${
                       formik.errors.origen_pago && formik.touched.origen_pago && !formik.values.origen_pago
                         ? "border-red-500"
                         : "border-gray-300"
-                    }`}>
-                      <SelectValue placeholder="Seleccionar origen..." />
-                    </SelectTrigger>
-                    <SelectContent className="bg-white border border-gray-200 shadow-lg">
-                      <SelectItem value="transferencia" className="text-gray-900 hover:bg-blue-50 cursor-pointer">Transferencia</SelectItem>
-                      <SelectItem value="cheque" className="text-gray-900 hover:bg-blue-50 cursor-pointer">Cheque</SelectItem>
-                      <SelectItem value="boleta" className="text-gray-900 hover:bg-blue-50 cursor-pointer">Boleta</SelectItem>
-                    </SelectContent>
-                  </Select>
+                    }`}
+                  >
+                    <option value="" disabled>Seleccionar origen...</option>
+                    <option value="transferencia">Transferencia</option>
+                    <option value="cheque">Cheque</option>
+                    <option value="boleta">Boleta</option>
+                  </select>
                   {formik.errors.origen_pago && formik.touched.origen_pago && !formik.values.origen_pago && (
                     <div className="text-red-500 text-xs mt-0.5">{formik.errors.origen_pago}</div>
                   )}

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -111,7 +111,6 @@ const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
   const [archivosParaSubir, setArchivosParaSubir] = useState<File[]>([]);
   const [abonosCuota, setAbonosCuota] = useState<AbonosCuotaResponse | null>(null);
   const { user } = useAuth(); //
-  console.log(user)
 
   // Fetch abonos cuando cambia la cuota seleccionada
   useEffect(() => {


### PR DESCRIPTION
This pull request introduces important improvements to the process of changing the start date of a credit and enhances the user interface for selecting dates. It also simplifies the payment form and cleans up unused code. The main focus is on enforcing business rules for allowed date changes and making the date selection more user-friendly and robust.

**Backend: Business rule enforcement for changing start date**
- Added a rule in `cambiarFechaInicio` to block changing the start date if any installment (`cuota`) with a number greater than or equal to a defined minimum (default 2) is already paid. Now, the change is only allowed if only the earliest installments are paid. [[1]](diffhunk://#diff-7df6322a5c491019b284fc32ceaa07ea97fc6f0c58a398253beb952c488625deR441-R445) [[2]](diffhunk://#diff-7df6322a5c491019b284fc32ceaa07ea97fc6f0c58a398253beb952c488625deR470) [[3]](diffhunk://#diff-7df6322a5c491019b284fc32ceaa07ea97fc6f0c58a398253beb952c488625deR481-R492)

**Frontend: Improved date selection UI for changing start date**
- Replaced the generic date picker in `ModalCambiarFechaInicio.tsx` with custom dropdowns for day, month, and year, only allowing the 15th and 30th of each month (and 28/29 for February), and limited year selection to a sensible range. This ensures users can only select valid dates according to business rules. [[1]](diffhunk://#diff-5c82e87b07deca6e4d19548d3867da9a9b9c7012e91a87e074d8cc7bcf94036bL9-R32) [[2]](diffhunk://#diff-5c82e87b07deca6e4d19548d3867da9a9b9c7012e91a87e074d8cc7bcf94036bL26-R72) [[3]](diffhunk://#diff-5c82e87b07deca6e4d19548d3867da9a9b9c7012e91a87e074d8cc7bcf94036bR111-R113) [[4]](diffhunk://#diff-5c82e87b07deca6e4d19548d3867da9a9b9c7012e91a87e074d8cc7bcf94036bL105-R196) [[5]](diffhunk://#diff-5c82e87b07deca6e4d19548d3867da9a9b9c7012e91a87e074d8cc7bcf94036bL66-R98)

**Frontend: Payment form simplification**
- Simplified the payment origin selection in `PagoForm.tsx` by replacing a custom `Select` component with a standard HTML `<select>`, improving maintainability and consistency.

**Frontend: Code cleanup**
- Removed an unused `console.log` statement from the `registerPayment.ts` hook.