### PR TITLE
feat(crm): mostrar nombre completo en modales

### DIFF
--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -84,6 +84,18 @@ type LeadDetailModalProps = {
 	onEdit?: () => void;
 };
 
+
+function formatLeadFullName(lead: {
+	firstName?: string | null;
+	middleName?: string | null;
+	lastName?: string | null;
+	secondLastName?: string | null;
+}) {
+	return [lead.firstName, lead.middleName, lead.lastName, lead.secondLastName]
+		.filter((part): part is string => Boolean(part && part.trim()))
+		.join(" ");
+}
+
 // Helper function for source badge color
 function getSourceBadgeColor(source: string): string {
 	const colors: Record<string, string> = {
@@ -215,8 +227,7 @@ export function LeadDetailModal({
 					<div className="flex items-start justify-between">
 						<div>
 							<h3 className="font-semibold text-lg">
-								{displayLead.firstName} {displayLead.middleName || ""}{" "}
-								{displayLead.lastName} {displayLead.secondLastName || ""}
+								{formatLeadFullName(displayLead)}
 							</h3>
 							<p className="text-muted-foreground text-sm">
 								{displayLead.email}
@@ -253,8 +264,7 @@ export function LeadDetailModal({
 										Nombre Completo
 									</Label>
 									<p className="font-medium text-sm">
-										{displayLead.firstName} {displayLead.middleName || ""}{" "}
-										{displayLead.lastName} {displayLead.secondLastName || ""}
+										{formatLeadFullName(displayLead)}
 									</p>
 								</div>
 								<div>

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -100,6 +100,18 @@ export type OpportunityForModal = {
 	} | null;
 };
 
+
+function formatLeadFullName(lead: {
+	firstName?: string | null;
+	middleName?: string | null;
+	lastName?: string | null;
+	secondLastName?: string | null;
+}) {
+	return [lead.firstName, lead.middleName, lead.lastName, lead.secondLastName]
+		.filter((part): part is string => Boolean(part && part.trim()))
+		.join(" ");
+}
+
 type OpportunityDetailModalProps = {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
@@ -129,6 +141,14 @@ export function OpportunityDetailModal({
 }: OpportunityDetailModalProps) {
 	const [opportunityHistory, setOpportunityHistory] = useState<any[]>([]);
 	const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+
+	const leadQuery = useQuery({
+		...orpc.getLeads.queryOptions({
+			input: { id: opportunity?.lead?.id ?? "", limit: 1 },
+		}),
+		enabled: open && !!opportunity?.lead?.id,
+		queryKey: ["getLeads", opportunity?.lead?.id, "opportunity-modal"],
+	});
 
 	// Query for contracts associated with the opportunity
 	const opportunityContractsQuery = useQuery({
@@ -189,6 +209,24 @@ export function OpportunityDetailModal({
 
 	const canViewContracts =
 		userRole && PERMISSIONS.canViewOpportunityContracts(userRole);
+	const fullLead = leadQuery.data?.data?.[0];
+	const displayLead = fullLead
+		? {
+			...opportunity.lead,
+			firstName: fullLead.firstName,
+			middleName: fullLead.middleName,
+			lastName: fullLead.lastName,
+			secondLastName: fullLead.secondLastName,
+			dpi: fullLead.dpi,
+			email: fullLead.email,
+			phone: fullLead.phone,
+			age: fullLead.age,
+			direccion: fullLead.direccion,
+			departamento: fullLead.departamento,
+			municipio: fullLead.municipio,
+			zona: fullLead.zona,
+		}
+		: opportunity.lead;
 	const canAccessCRM = userRole && PERMISSIONS.canAccessCRM(userRole);
 	const isAccounting = userRole && PERMISSIONS.canAccessAccounting(userRole);
 	const isWon = opportunity?.status === "won";
@@ -268,7 +306,7 @@ export function OpportunityDetailModal({
 						{/* Details Grid */}
 						<div className="grid grid-cols-2 gap-6">
 							{/* Lead Information */}
-							{opportunity.lead && (
+							{displayLead && (
 								<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
 									<Label className="font-semibold text-muted-foreground text-sm">
 										Lead
@@ -280,41 +318,40 @@ export function OpportunityDetailModal({
 												className="cursor-pointer font-medium text-primary hover:underline"
 												role="button"
 												tabIndex={0}
-												onClick={() => onNavigateToLead(opportunity.lead!.id)}
+												onClick={() => onNavigateToLead(displayLead!.id)}
 												onKeyDown={(e) => {
 													if (e.key === "Enter" || e.key === " ") {
 														e.preventDefault();
-														onNavigateToLead(opportunity.lead!.id);
+														onNavigateToLead(displayLead!.id);
 													}
 												}}
 											>
-												{opportunity.lead.firstName} {opportunity.lead.lastName}
+												{formatLeadFullName(displayLead)}
 											</span>
 										) : (
 											<Link
 												to="/crm/leads"
 												search={{
-													leadId: opportunity.lead.id,
+													leadId: displayLead.id,
 												}}
 												className="font-medium text-primary hover:underline"
 												onClick={() => onOpenChange(false)}
 											>
 												<span className="font-medium">
-													{opportunity.lead.firstName}{" "}
-													{opportunity.lead.lastName}
+													{formatLeadFullName(displayLead)}
 												</span>
 											</Link>
 										)}
 									</div>
-									{opportunity.lead.dpi && (
+									{displayLead.dpi && (
 										<div className="flex items-center gap-3 text-muted-foreground text-sm">
-											<span className="font-mono">{opportunity.lead.dpi}</span>
+											<span className="font-mono">{displayLead.dpi}</span>
 										</div>
 									)}
-									{opportunity.lead.email && (
+									{displayLead.email && (
 										<div className="flex items-center gap-3 text-muted-foreground text-sm">
 											<Mail className="h-4 w-4" />
-											<span>{opportunity.lead.email}</span>
+											<span>{displayLead.email}</span>
 										</div>
 									)}
 								</div>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -259,10 +259,12 @@ function RouteComponent() {
 					? {
 							id: matchingOpportunity.lead.id,
 							firstName: matchingOpportunity.lead.firstName,
+							middleName: matchingOpportunity.lead.middleName,
 							lastName: matchingOpportunity.lead.lastName,
+							secondLastName: matchingOpportunity.lead.secondLastName,
 							email: matchingOpportunity.lead.email,
-							phone: null,
-							dpi: null,
+							phone: matchingOpportunity.lead.phone,
+							dpi: matchingOpportunity.lead.dpi,
 						}
 					: null,
 				stage: matchingOpportunity.stage


### PR DESCRIPTION
### Motivation
- Mostrar el nombre completo (incluyendo segundo nombre y segundo apellido cuando existan) en los modales de detalle del lead y de la oportunidad para evitar truncar la identificación de la persona.

### Description
- Agrega la función utilitaria `formatLeadFullName` en `lead-detail-modal.tsx` y `opportunity-detail-modal.tsx` para concatenar `firstName`, `middleName`, `lastName` y `secondLastName` sin producir espacios adicionales cuando un campo está vacío.
- Reemplaza los renders que concatenaban manualmente `firstName`/`lastName` por `formatLeadFullName(displayLead)` en el modal de lead para mostrar el nombre completo.
- En el modal de oportunidad se añadió una consulta (`orpc.getLeads`) al abrir el modal para recuperar el lead completo cuando sea posible, se construye `displayLead` a partir de esa respuesta y se usa para renderizar nombre, DPI y email, además de actualizar los handlers/links para usar el `id` del `displayLead`.
- Mantiene compatibilidad con payloads que sólo traen `firstName`/`lastName` usando el fallback al `opportunity.lead` cuando no se encuentra información adicional.

### Testing
- Ejecuté el chequeo de tipos con `pnpm --dir apps/crm/apps/web check-types` y la ejecución falló en este entorno debido a dependencias locales faltantes (`node_modules`) y ausencia del type definition `vite/client` en el entorno de CI local; el cambio es tipado y debería pasar con las dependencias instaladas.
- No se ejecutaron tests end-to-end o de integración adicionales en este entorno por falta de dependencias del paquete web.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1b4e0c310832f84e071cd73ecc292)