### PR TITLE
Jalvarez

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1077,6 +1077,18 @@ export const crmRouter = {
 				.groupBy(opportunityStageHistory.opportunityId)
 				.as("first_closed_stage_dates");
 
+			const latestStageHistory = db
+				.select({
+					opportunityId: opportunityStageHistory.opportunityId,
+					latestStageChangedAt:
+						sql<Date>`max(${opportunityStageHistory.changedAt})`.as(
+							"latest_stage_changed_at",
+						),
+				})
+				.from(opportunityStageHistory)
+				.groupBy(opportunityStageHistory.opportunityId)
+				.as("latest_stage_history");
+
 			const selectFields = {
 				id: opportunities.id,
 				title: opportunities.title,
@@ -1092,6 +1104,10 @@ export const crmRouter = {
 				closedAt:
 					sql<Date | null>`coalesce(${opportunities.actualCloseDate}, ${firstClosedStageDates.firstClosedStageAt})`.as(
 						"closed_at",
+					),
+				latestStageChangedAt:
+					sql<Date>`coalesce(${latestStageHistory.latestStageChangedAt}, ${opportunities.createdAt})`.as(
+						"latest_stage_changed_at",
 					),
 				updatedAt: opportunities.updatedAt,
 				numeroSifco: opportunities.numeroSifco,
@@ -1169,6 +1185,10 @@ export const crmRouter = {
 				.leftJoin(
 					firstClosedStageDates,
 					eq(opportunities.id, firstClosedStageDates.opportunityId),
+				)
+				.leftJoin(
+					latestStageHistory,
+					eq(opportunities.id, latestStageHistory.opportunityId),
 				)
 				.leftJoin(companies, eq(opportunities.companyId, companies.id))
 				.leftJoin(leads, eq(opportunities.leadId, leads.id))

--- a/apps/crm/apps/web/src/components/analysis/DisbursementChecklistView.tsx
+++ b/apps/crm/apps/web/src/components/analysis/DisbursementChecklistView.tsx
@@ -166,6 +166,8 @@ export function DisbursementChecklistView({
 		return new Intl.NumberFormat("es-GT", {
 			style: "currency",
 			currency: "GTQ",
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 2,
 		}).format(Number(value));
 	};
 

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -558,6 +558,8 @@ export function InvestmentAssignmentSection({
 		return new Intl.NumberFormat("es-GT", {
 			style: "currency",
 			currency: "GTQ",
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 2,
 		}).format(Number(value));
 	};
 

--- a/apps/crm/apps/web/src/components/disbursement/DisbursementView.tsx
+++ b/apps/crm/apps/web/src/components/disbursement/DisbursementView.tsx
@@ -173,13 +173,13 @@ export function DisbursementView({
 							Monto a desembolsar
 						</span>
 						<p className="font-bold text-2xl text-green-600">
-							Q{amountToFinance.toLocaleString()}
+							Q{amountToFinance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 						</p>
 					</div>
 					<div className="rounded-lg border bg-muted/30 p-4">
 						<span className="text-muted-foreground text-xs">Gastos</span>
 						<p className="font-bold text-2xl text-orange-600">
-							Q{gastos.toLocaleString()}
+							Q{gastos.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 						</p>
 					</div>
 				</div>

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -563,7 +563,7 @@ export function OpportunityDetailModal({
 														</span>
 													)}
 													<span className="text-muted-foreground text-xs">
-														Q{Number(quotation.vehicleValue).toLocaleString()} •{" "}
+														Q{Number(quotation.vehicleValue).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} •{" "}
 														{quotation.termMonths} meses •{" "}
 														{quotation.status === "draft"
 															? "Borrador"
@@ -576,7 +576,7 @@ export function OpportunityDetailModal({
 												</div>
 												<div className="text-right">
 													<p className="font-bold text-green-600">
-														Q{Number(quotation.monthlyPayment).toLocaleString()}
+														Q{Number(quotation.monthlyPayment).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 													</p>
 													<p className="text-muted-foreground text-xs">
 														cuota mensual

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -238,6 +238,8 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 			const formatted = new Intl.NumberFormat("es-GT", {
 				style: "currency",
 				currency: "GTQ",
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
 			}).format(monto);
 
 			return (

--- a/apps/crm/apps/web/src/lib/crm-formatters.ts
+++ b/apps/crm/apps/web/src/lib/crm-formatters.ts
@@ -166,6 +166,8 @@ export const formatCurrency = (amount: number | string) => {
 	return new Intl.NumberFormat("es-GT", {
 		style: "currency",
 		currency: "GTQ",
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
 	}).format(Number(amount));
 };
 

--- a/apps/crm/apps/web/src/lib/opportunities/columns.tsx
+++ b/apps/crm/apps/web/src/lib/opportunities/columns.tsx
@@ -152,7 +152,7 @@ export const opportunitiesColumns: ColumnDef<Opportunity>[] = [
 			const numericValue = value ? Number.parseFloat(value) : null;
 			return numericValue !== null ? (
 				<span className="font-medium text-green-600 tabular-nums">
-					Q{numericValue.toLocaleString()}
+					Q{numericValue.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 				</span>
 			) : (
 				<span className="text-muted-foreground">—</span>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -95,6 +95,8 @@ function RouteComponent() {
 		return new Intl.NumberFormat("es-GT", {
 			style: "currency",
 			currency: "GTQ",
+			minimumFractionDigits: 2,
+			maximumFractionDigits: 2,
 		}).format(num);
 	};
 

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -523,7 +523,7 @@ function RouteComponent() {
 										<span className="font-medium">Monto en Mora:</span>
 									</div>
 									<p className="font-bold text-lg text-red-600">
-										Q{Number(caso.montoEnMora).toLocaleString()}
+										Q{Number(caso.montoEnMora).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 									</p>
 								</div>
 								<div className="space-y-2">
@@ -532,7 +532,7 @@ function RouteComponent() {
 										<span className="font-medium">Cuota Mensual:</span>
 									</div>
 									<p className="font-bold text-blue-600 text-lg uppercase tracking-tight">
-										Q{Number(caso.cuotaMensual || 0).toLocaleString()}
+										Q{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 									</p>
 								</div>
 								<div className="space-y-2">
@@ -644,14 +644,14 @@ function RouteComponent() {
 												<span>
 													Mora:{" "}
 													<strong>
-														Q{Number(caso.montoEnMora).toLocaleString()}
+														Q{Number(caso.montoEnMora).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 													</strong>
 												</span>
 												<span>+</span>
 												<span>
 													Cuota:{" "}
 													<strong>
-														Q{Number(caso.cuotaMensual || 0).toLocaleString()}
+														Q{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 													</strong>
 												</span>
 											</div>
@@ -1217,11 +1217,11 @@ function RouteComponent() {
 															</div>
 															<div className="text-right">
 																<p className="font-medium text-sm">
-																	Q{Number(cuota.montoCuota).toLocaleString()}
+																	Q{Number(cuota.montoCuota).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																</p>
 																{tieneMora && (
 																	<p className="text-red-600 text-xs">
-																		+Q{Number(cuota.montoMora).toLocaleString()}{" "}
+																		+Q{Number(cuota.montoMora).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}{" "}
 																		mora
 																	</p>
 																)}
@@ -1476,13 +1476,13 @@ function RouteComponent() {
 							<div>
 								<p className="text-muted-foreground text-sm">Capital Activo</p>
 								<p className="font-medium">
-									Q{Number(caso.montoFinanciado || 0).toLocaleString()}
+									Q{Number(caso.montoFinanciado || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 								</p>
 							</div>
 							<div>
 								<p className="text-muted-foreground text-sm">Cuota Mensual</p>
 								<p className="font-medium">
-									Q{Number(caso.cuotaMensual || 0).toLocaleString()}
+									Q{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 								</p>
 							</div>
 							<div>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -167,13 +167,13 @@ function EmbudoRow({
 						<div className="flex items-center justify-end gap-2">
 							<span className="text-muted-foreground text-xs">Mora:</span>
 							<span className="font-medium">
-								Q{Number(estadoStats.montoTotal || 0).toLocaleString()}
+								Q{Number(estadoStats.montoTotal || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 							</span>
 						</div>
 						<div className="flex items-center justify-end gap-2">
 							<span className="text-muted-foreground text-xs">Capital:</span>
 							<span className="font-medium">
-								Q{Number(estadoStats.sumaCapital || 0).toLocaleString()}
+								Q{Number(estadoStats.sumaCapital || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 							</span>
 						</div>
 					</div>
@@ -234,15 +234,15 @@ function EmbudoRow({
 											{caso.numeroCredito || "-"}
 										</td>
 										<td className="py-2 text-right tabular-nums">
-											Q{Number(caso.montoFinanciado || 0).toLocaleString()}
+											Q{Number(caso.montoFinanciado || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 										</td>
 										<td className="py-2 text-right text-red-600 tabular-nums">
 											{Number(caso.montoEnMora || 0) > 0
-												? `Q${Number(caso.montoEnMora).toLocaleString()}`
+												? `Q${Number(caso.montoEnMora).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 												: "-"}
 										</td>
 										<td className="py-2 pr-3 text-right tabular-nums">
-											Q{Number(caso.cuotaMensual || 0).toLocaleString()}
+											Q{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 										</td>
 									</tr>
 								))}
@@ -638,7 +638,7 @@ function RouteComponent() {
 							Q
 							{stats
 								.reduce((sum, s) => sum + Number(s.montoTotal || 0), 0)
-								.toLocaleString()}
+								.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 						</div>
 						<p className="text-muted-foreground text-xs">
 							Suma de todos los montos en mora
@@ -658,7 +658,7 @@ function RouteComponent() {
 							Q
 							{stats
 								.reduce((sum, s) => sum + Number(s.sumaCapital || 0), 0)
-								.toLocaleString()}
+								.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 						</div>
 						<p className="text-muted-foreground text-xs">
 							Suma de todos los capitales

--- a/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
@@ -464,7 +464,7 @@ function OpportunityDocumentsPage() {
 							<p className="font-medium text-muted-foreground text-sm">Valor</p>
 							<p className="mt-1 font-medium">
 								{opportunity.value
-									? `Q${Number(opportunity.value).toLocaleString()}`
+									? `Q${Number(opportunity.value).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
 									: "Sin valor"}
 							</p>
 						</div>

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -523,7 +523,7 @@ function AnalysisPage() {
 													<TableCell>
 														{opportunity.value ? (
 															<span className="font-medium">
-																Q{Number(opportunity.value).toLocaleString()}
+																Q{Number(opportunity.value).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 															</span>
 														) : (
 															<span className="text-muted-foreground">
@@ -931,7 +931,7 @@ function DisbursementSection({
 											</div>
 											<div className="text-right">
 												<p className="font-medium">
-													Q{Number(opp.value).toLocaleString()}
+													Q{Number(opp.value).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 												</p>
 												<div className="flex items-center gap-2">
 													{opp.hasChecklist ? (

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -538,7 +538,7 @@ function RouteComponent() {
 					</CardHeader>
 					<CardContent>
 						<div className="font-bold text-2xl">
-							Q{(statsQuery.data?.totalValue ?? 0).toLocaleString()}
+							Q{(statsQuery.data?.totalValue ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 						</div>
 						<p className="text-muted-foreground text-xs">
 							En créditos cerrados

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -3129,7 +3129,7 @@ function RouteComponent() {
 															</Badge>
 														)}
 														{opp.value && (
-															<span>Q{Number(opp.value).toLocaleString()}</span>
+															<span>Q{Number(opp.value).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
 														)}
 													</div>
 												</div>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -312,7 +312,7 @@ function DroppableStageColumn({
 				</div>
 				<CardTitle className="font-medium text-sm">{stage.name}</CardTitle>
 				<CardDescription className="text-xs">
-					Q{totalValue.toLocaleString()} valor total
+					Q{totalValue.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} valor total
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="min-h-0 space-y-3 overflow-y-auto" ref={ref}>
@@ -1438,7 +1438,7 @@ function RouteComponent() {
 							<>
 								<div className="font-bold text-2xl">{totalOpportunities}</div>
 								<p className="text-muted-foreground text-xs">
-									Q{totalValue.toLocaleString()} en pipeline
+									Q{totalValue.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} en pipeline
 								</p>
 							</>
 						)}
@@ -1491,7 +1491,7 @@ function RouteComponent() {
 							<Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
 						) : (
 							<div className="font-bold text-2xl text-green-700">
-								Q{placedAmount.toLocaleString()}
+								Q{placedAmount.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 							</div>
 						)}
 					</CardContent>
@@ -1530,7 +1530,7 @@ function RouteComponent() {
 										className="mt-0.5 text-muted-foreground text-sm"
 										style={{ fontVariantNumeric: "tabular-nums" }}
 									>
-										Q{stageValue.toLocaleString()}
+										Q{stageValue.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 									</p>
 								</CardContent>
 							</Card>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -1308,25 +1308,35 @@ function RouteComponent() {
 		() =>
 			salesStagesQuery.data?.map((stage) => {
 				const stageOpportunities =
-					filteredData?.filter(
-						(opp) =>
-							opp.stage?.id === stage.id &&
-							(stageFilter === "all" || opp.status === stageFilter) &&
-							(showLostOpportunities || opp.status !== "lost") &&
-							(!debouncedBoardSearch.trim() ||
-								`${opp.lead?.firstName ?? ""} ${opp.lead?.lastName ?? ""}`
-									.toLowerCase()
-									.includes(debouncedBoardSearch.trim().toLowerCase()) ||
-								(opp.title ?? "")
-									.toLowerCase()
-									.includes(debouncedBoardSearch.trim().toLowerCase()) ||
-								(opp.lead?.phone ?? "")
-									.toLowerCase()
-									.includes(debouncedBoardSearch.trim().toLowerCase()) ||
-								opp.id
-									.toLowerCase()
-									.includes(debouncedBoardSearch.trim().toLowerCase())),
-					) || [];
+					filteredData
+						?.filter(
+							(opp) =>
+								opp.stage?.id === stage.id &&
+								(stageFilter === "all" || opp.status === stageFilter) &&
+								(showLostOpportunities || opp.status !== "lost") &&
+								(!debouncedBoardSearch.trim() ||
+									`${opp.lead?.firstName ?? ""} ${opp.lead?.lastName ?? ""}`
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+									(opp.title ?? "")
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+									(opp.lead?.phone ?? "")
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase()) ||
+									opp.id
+										.toLowerCase()
+										.includes(debouncedBoardSearch.trim().toLowerCase())),
+						)
+						.sort((a, b) => {
+							const dateA = a.latestStageChangedAt
+								? new Date(a.latestStageChangedAt).getTime()
+								: 0;
+							const dateB = b.latestStageChangedAt
+								? new Date(b.latestStageChangedAt).getTime()
+								: 0;
+							return dateB - dateA; // Most recent first
+						}) || [];
 
 				const totalValue = stageOpportunities.reduce(
 					(sum, opp) => sum + (Number.parseFloat(opp.value || "0") || 0),

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -2104,16 +2104,16 @@ function QuoterPage() {
 																{row.period}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.initialBalance.toFixed(2)}
+																Q{row.initialBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.interestPlusVAT.toFixed(2)}
+																Q{row.interestPlusVAT.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.principal.toFixed(2)}
+																Q{row.principal.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.finalBalance.toFixed(2)}
+																Q{row.finalBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 															</TableCell>
 														</TableRow>
 													))}
@@ -2422,10 +2422,10 @@ function QuotationDetailDialog({
 										.map((row: any) => (
 											<TableRow key={row.period}>
 												<TableCell>{row.period}</TableCell>
-												<TableCell>Q{row.initialBalance.toFixed(2)}</TableCell>
-												<TableCell>Q{row.interestPlusVAT.toFixed(2)}</TableCell>
-												<TableCell>Q{row.principal.toFixed(2)}</TableCell>
-												<TableCell>Q{row.finalBalance.toFixed(2)}</TableCell>
+												<TableCell>Q{row.initialBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
+												<TableCell>Q{row.interestPlusVAT.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
+												<TableCell>Q{row.principal.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
+												<TableCell>Q{row.finalBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
 											</TableRow>
 										))}
 								</TableBody>

--- a/apps/crm/apps/web/src/routes/dashboard.tsx
+++ b/apps/crm/apps/web/src/routes/dashboard.tsx
@@ -258,7 +258,7 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-green-700">
-									Q{(crmStats.data.placedAmount || 0).toLocaleString()}
+									Q{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 								</div>
 							</CardContent>
 						</Card>
@@ -340,7 +340,7 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-green-700">
-									Q{(crmStats.data.placedAmount || 0).toLocaleString()}
+									Q{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 								</div>
 							</CardContent>
 						</Card>
@@ -425,7 +425,7 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-green-700">
-									Q{(crmStats.data.placedAmount || 0).toLocaleString()}
+									Q{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 								</div>
 							</CardContent>
 						</Card>

--- a/apps/crm/apps/web/src/routes/inversiones/index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/index.tsx
@@ -74,7 +74,7 @@ function formatAmount(amount: string | null | undefined): string {
 	if (!amount) return "—";
 	const num = Number.parseFloat(amount);
 	if (Number.isNaN(num)) return "—";
-	return `Q${num.toLocaleString("es-GT")}`;
+	return `Q${num.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -215,7 +215,7 @@ function DroppableInvestmentColumn({
 				</div>
 				<p className="mt-1.5 font-medium text-sm">{stage.name}</p>
 				<p className="text-muted-foreground text-xs">
-					{totalAmount > 0 ? `Q${totalAmount.toLocaleString("es-GT")}` : "—"}{" "}
+					{totalAmount > 0 ? `Q${totalAmount.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : "—"}{" "}
 					monto total
 				</p>
 			</div>

--- a/apps/crm/apps/web/src/routes/vehicles/auction-vehicles.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/auction-vehicles.tsx
@@ -181,7 +181,7 @@ function AuctionsDashboard() {
 															Q
 															{Number(
 																latestInspection.marketValue,
-															).toLocaleString("es-GT")}
+															).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 														</>
 													) : (
 														<span className="text-gray-400">N/A</span>
@@ -189,10 +189,10 @@ function AuctionsDashboard() {
 												</TableCell>
 												<TableCell>
 													Q
-													{Number(auction.auctionPrice).toLocaleString("es-GT")}
+													{Number(auction.auctionPrice).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 												</TableCell>
 												<TableCell className="font-medium text-red-600">
-													Q{Number(auction.lossValue).toLocaleString("es-GT")}
+													Q{Number(auction.lossValue).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 												</TableCell>
 												<TableCell>
 													{renderAuctionStatus(auction.auctionStatus)}
@@ -270,7 +270,7 @@ function AuctionsDashboard() {
 									<p className="font-medium text-green-600">
 										<strong>Precio Final de Venta:</strong> Q
 										{Number(selectedAuction.auctionPrice).toLocaleString(
-											"es-GT",
+											"es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 }
 										)}
 									</p>
 								) : (
@@ -409,18 +409,18 @@ function AuctionsDashboard() {
 																	<strong>Valor mercado:</strong> Q
 																	{Number(
 																		inspection.marketValue,
-																	).toLocaleString("es-GT")}
+																	).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																</p>
 																<p>
 																	<strong>Valor comercial:</strong> Q
 																	{Number(
 																		inspection.suggestedCommercialValue,
-																	).toLocaleString("es-GT")}
+																	).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																</p>
 																<p>
 																	<strong>Valor bancario:</strong> Q
 																	{Number(inspection.bankValue).toLocaleString(
-																		"es-GT",
+																		"es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 }
 																	)}
 																</p>
 																<p>
@@ -447,7 +447,7 @@ function AuctionsDashboard() {
 																				Q
 																				{Number(
 																					inspection.aiSuggestedValue,
-																				).toLocaleString("es-GT")}
+																				).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																			</p>
 																		</div>
 																		{inspection.aiReasoning && (

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -678,7 +678,7 @@ function VehiclesDashboard() {
 																		Q
 																		{Number(
 																			latestInspection.suggestedCommercialValue,
-																		).toLocaleString("es-GT")}
+																		).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																	</div>
 																	<div
 																		className={
@@ -963,7 +963,7 @@ function VehiclesDashboard() {
 												<span className="font-medium">Valor Comercial: </span>Q
 												{Number(
 													auctionInspection.suggestedCommercialValue,
-												).toLocaleString("es-GT")}
+												).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 											</p>
 											{auctionPrice !== null && auctionPrice > 0 && (
 												<p
@@ -980,7 +980,7 @@ function VehiclesDashboard() {
 														Number(auctionInspection.suggestedCommercialValue) -
 															auctionPrice,
 														0,
-													).toLocaleString("es-GT")}
+													).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 												</p>
 											)}
 										</div>
@@ -1277,7 +1277,7 @@ function VehiclesDashboard() {
 																				Q
 																				{Number(
 																					inspection.marketValue,
-																				).toLocaleString("es-GT")}
+																				).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																			</div>
 																			<div className="font-medium text-muted-foreground">
 																				Valor comercial sugerido:
@@ -1286,7 +1286,7 @@ function VehiclesDashboard() {
 																				Q
 																				{Number(
 																					inspection.suggestedCommercialValue,
-																				).toLocaleString("es-GT")}
+																				).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																			</div>
 																			<div className="text-pretty font-medium text-muted-foreground">
 																				Valor actual condición:
@@ -1295,7 +1295,7 @@ function VehiclesDashboard() {
 																				Q
 																				{Number(
 																					inspection.currentConditionValue,
-																				).toLocaleString("es-GT")}
+																				).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																			</div>
 																		</div>
 
@@ -1317,7 +1317,7 @@ function VehiclesDashboard() {
 																							Q
 																							{Number(
 																								inspection.aiSuggestedValue,
-																							).toLocaleString("es-GT")}
+																							).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
 																						</p>
 																					</div>
 																					<div className="flex flex-col items-end">


### PR DESCRIPTION
## Descripción del PR

Se implementó la estandarización global de la visualización de montos en Quetzales (Q) para que **siempre muestren exactamente dos decimales**, independientemente de si el valor es un entero (ej. `Q0.00` en lugar de `Q0`) o si tiene más decimales en origen.

Esto resuelve inconsistencias visuales en múltiples módulos del CRM donde la moneda perdía el formato de centavos por usar llamadas nativas sin parámetros de configuración.

### Cambios realizados 🛠️

Se forzó el formato de localización `es-GT` añadiendo los parámetros `{ minimumFractionDigits: 2, maximumFractionDigits: 2 }` explícitamente en:

1. **Utilidad Core:** Se actualizó la función base [formatCurrency](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/web/src/routes/crm/quoter.tsx:636:1-637:95) en [apps/web/src/lib/crm-formatters.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/web/src/lib/crm-formatters.ts:0:0-0:0).
2. **Dashboard de Cobros:** Se solucionó el problema donde métricas de "Monto en Mora", "Capital" y el "Embudo de Cobranza" mostraban agrupados enteros como `Q0`.
3. **Módulo de Oportunidades y Análisis:**
   - Tablas de listado de oportunidades pendientes ([routes/crm/analysis/index.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/web/src/routes/crm/analysis/index.tsx:0:0-0:0)).
   - Detalle modal de oportunidades analizadas.
   - Vista de desembolsos ([DisbursementChecklistView.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/web/src/components/analysis/DisbursementChecklistView.tsx:0:0-0:0)).
4. **Vehículos y Remates:**
   - Precios base y cálculos de utilidad/pérdida en el dashboard de remates ([auction-vehicles.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/web/src/routes/vehicles/auction-vehicles.tsx:0:0-0:0)).
   - Modal de valoración e historial en el catálogo de vehículos ([vehicles/index.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/web/src/routes/vehicles/index.tsx:0:0-0:0)).
5. **Cotizador y Clientes:**
   - Tablas de amortización y balances en el cotizador ([routes/crm/quoter.tsx](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/crm/apps/web/src/routes/crm/quoter.tsx:0:0-0:0)).
   - Métricas globales en el listado de clientes y leads de CRM.

### Cómo probarlo 🧪

1. Levantar el entorno interactivo de `apps/web`.
2. Navegar al **Dashboard de Cobros** y verificar que los cuadros superiores de total muestran la moneda de forma correcta (ej: `Q0.00`).
3. Crear o visualizar un Remate en **Vehículos > Vehículos en Remate** y observar que el cálculo de pérdida y los historiales de inspección muestran los montos forzando los centavos.
4. Generar una cotización y confirmar que toda la tabla de intereses y capital ahora respeta el formato monetario con comas y 2 decimales sin usar redondeos en duro como `toFixed()`.

