### PR TITLE
feat: Add `reinversion_combinada` type for mirror investor credits, i…

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -100,6 +100,7 @@ async function consultarCreditosInversionista(
       porcentaje_inversionista: tabla.porcentaje_participacion_inversionista,
       cuota_inversionista: tabla.cuota_inversionista,
       origen: sql<OrigenDatos>`${config.origen}`.as('origen'),
+      tipo_reinversion: config.origen === "espejo" ? (tabla as any).tipo_reinversion : sql<string | null>`NULL`.as("tipo_reinversion"),
     })
     .from(tabla)
     .where(inArray(tabla.inversionista_id, inversionistaIds));
@@ -1367,7 +1368,12 @@ const mes = fechaParaMes
                 abonoGeneralInteres = abono_interes.minus(isr);
               }
 
-              switch (inv.reinversion) {
+              let reinversionActual = inv.reinversion;
+              if (inv.reinversion === "reinversion_combinada") {
+                reinversionActual = c.tipo_reinversion || "sin_reinversion";
+              }
+
+              switch (reinversionActual) {
                 case "sin_reinversion":
                   cuota_inversor = abono_capital
                     .plus(abono_interes)
@@ -1773,7 +1779,12 @@ export async function getInvestorTotalsGlobales(
       let reinvInteres = new Big(0);
       const interesTotal = abono_interes.plus(inv.emite_factura ? abono_iva : isr.neg());
 
-      switch (inv.reinversion) {
+      let reinversionActual = inv.reinversion;
+      if (inv.reinversion === "reinversion_combinada") {
+        reinversionActual = c.tipo_reinversion || "sin_reinversion";
+      }
+
+      switch (reinversionActual) {
         case "sin_reinversion":
           cuota_inversor = abono_capital.plus(interesTotal);
           break;
@@ -3648,6 +3659,7 @@ async function consultarResumenGlobalPorEstadoPago(
   }
 
   const pe = pagos_credito_inversionistas_espejo;
+  const ce = creditos_inversionistas_espejo;
   const condicionesJoinPagos: any[] = [
     eq(inversionistas.inversionista_id, pe.inversionista_id),
     eq(pe.estado_liquidacion, estadoPago),
@@ -3692,6 +3704,14 @@ async function consultarResumenGlobalPorEstadoPago(
         WHEN 'reinversion_capital' THEN COALESCE(SUM(${pe.abono_capital}), 0)
         WHEN 'reinversion_interes' THEN COALESCE(SUM(${pe.abono_interes}), 0)
         WHEN 'reinversion_total' THEN COALESCE(SUM(${pe.abono_capital} + ${pe.abono_interes}), 0)
+        WHEN 'reinversion_combinada' THEN COALESCE(SUM(
+          CASE ${ce.tipo_reinversion}
+            WHEN 'reinversion_capital' THEN ${pe.abono_capital}
+            WHEN 'reinversion_interes' THEN ${pe.abono_interes}
+            WHEN 'reinversion_total' THEN ${pe.abono_capital} + ${pe.abono_interes}
+            ELSE 0
+          END
+        ), 0)
         WHEN 'reinversion_variable' THEN LEAST(
           COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
           COALESCE(SUM(
@@ -3721,6 +3741,14 @@ async function consultarResumenGlobalPorEstadoPago(
             WHEN 'reinversion_capital' THEN COALESCE(SUM(${pe.abono_capital}), 0)
             WHEN 'reinversion_interes' THEN COALESCE(SUM(${pe.abono_interes}), 0)
             WHEN 'reinversion_total' THEN COALESCE(SUM(${pe.abono_capital} + ${pe.abono_interes}), 0)
+            WHEN 'reinversion_combinada' THEN COALESCE(SUM(
+              CASE ${ce.tipo_reinversion}
+                WHEN 'reinversion_capital' THEN ${pe.abono_capital}
+                WHEN 'reinversion_interes' THEN ${pe.abono_interes}
+                WHEN 'reinversion_total' THEN ${pe.abono_capital} + ${pe.abono_interes}
+                ELSE 0
+              END
+            ), 0)
             WHEN 'reinversion_variable' THEN LEAST(
               COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
               COALESCE(SUM(
@@ -3762,6 +3790,20 @@ async function consultarResumenGlobalPorEstadoPago(
             END
         ), 0)
         WHEN 'reinversion_total' THEN 0
+        WHEN 'reinversion_combinada' THEN COALESCE(SUM(
+          CASE ${ce.tipo_reinversion}
+            WHEN 'reinversion_total' THEN 0
+            WHEN 'reinversion_capital' THEN (
+              ${pe.abono_interes} + CASE WHEN ${inversionistas.emite_factura} THEN ${pe.abono_iva_12} ELSE -ROUND(${pe.abono_interes} * 0.07, 2) END
+            )
+            WHEN 'reinversion_interes' THEN (
+              ${pe.abono_capital} + CASE WHEN ${inversionistas.emite_factura} THEN ${pe.abono_iva_12} ELSE -ROUND(${pe.abono_interes} * 0.07, 2) END
+            )
+            ELSE (
+               ${pe.abono_capital} + ${pe.abono_interes} + CASE WHEN ${inversionistas.emite_factura} THEN ${pe.abono_iva_12} ELSE -ROUND(${pe.abono_interes} * 0.07, 2) END
+            )
+          END
+        ), 0)
         WHEN 'reinversion_variable' THEN
           COALESCE(SUM(
             ${pe.abono_capital}
@@ -3821,14 +3863,17 @@ async function consultarResumenGlobalPorEstadoPago(
     );
   }
 
-  return db
+  const result = await db
     .select(selectObj as any)
     .from(inversionistas)
     .leftJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
     .leftJoin(pe, and(...condicionesJoinPagos))
+    .leftJoin(ce, and(eq(pe.credito_id, ce.credito_id), eq(pe.inversionista_id, ce.inversionista_id)))
     .where(and(...condicionesWhere))
     .groupBy(...groupByFields)
     .having(excel ? undefined : sql`COUNT(${pe.id}) > 0`);
+
+  return result as unknown as InversionistaResumenRow[];
 }
 
 async function consultarResumenGlobalDesdeLiquidaciones(
@@ -3896,7 +3941,7 @@ async function consultarResumenGlobalDesdeLiquidaciones(
     );
   }
 
-  return db
+  const result = await db
     .select(selectFields as any)
     .from(liquidaciones)
     .innerJoin(
@@ -3906,6 +3951,8 @@ async function consultarResumenGlobalDesdeLiquidaciones(
     .leftJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
     .where(and(...condicionesWhere))
     .groupBy(...groupByFields);
+
+  return result as unknown as InversionistaResumenRow[];
 }
 
 function mapResumenRow(

--- a/apps/cartera-back/src/controllers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/controllers/mirrorInvestor.ts
@@ -651,3 +651,62 @@ export const getCreditsByInvestor = async ({ query, set }: any) => {
     };
   }
 };
+
+/**
+ * Controller: asignarReinversionEspejo
+ *
+ * Body:
+ * {
+ *   asignaciones: [{
+ *     id_credito_inversionista_espejo: number,
+ *     tipo_reinversion: string
+ *   }]
+ * }
+ */
+export const asignarReinversionEspejo = async ({ body, set }: any) => {
+  try {
+    const { asignaciones } = body;
+
+    const resultados: any[] = [];
+    const omitidos: any[] = [];
+
+    await db.transaction(async (tx) => {
+      for (const req of asignaciones) {
+        const { id_credito_inversionista_espejo, tipo_reinversion } = req;
+        const [registro] = await tx
+          .select()
+          .from(creditos_inversionistas_espejo)
+          .where(eq(creditos_inversionistas_espejo.id, id_credito_inversionista_espejo))
+          .limit(1);
+
+        if (!registro) {
+          omitidos.push({ id_credito_inversionista_espejo, razon: "No existe el registro" });
+          continue;
+        }
+
+        await tx
+          .update(creditos_inversionistas_espejo)
+          .set({ tipo_reinversion, updated_at: new Date() })
+          .where(eq(creditos_inversionistas_espejo.id, id_credito_inversionista_espejo));
+
+        resultados.push({ id_credito_inversionista_espejo, tipo_reinversion });
+      }
+    });
+
+    set.status = 200;
+    return {
+      success: true,
+      message: `Se asignó reinversión a ${resultados.length} registros, ${omitidos.length} omitidos.`,
+      resultados,
+      omitidos
+    };
+  } catch (error) {
+    console.error("[asignarReinversionEspejo] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al asignar tipos de reinversión",
+      error: String(error)
+    };
+  }
+};

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -24,6 +24,15 @@
   }
   export const userRoleEnum = pgEnum("user_role", ["ADMIN", "ASESOR","CONTA"]);
   export const customSchema = pgSchema("cartera");
+
+  export const tipoReinversionEnum = customSchema.enum("tipo_reinversion", [
+    "sin_reinversion",
+    "reinversion_capital",
+    "reinversion_interes",
+    "reinversion_total",
+    "reinversion_variable",
+    "reinversion_combinada"
+  ]);
   export const admins = customSchema.table("admins", {
     admin_id: serial("admin_id").primaryKey(),
     nombre: varchar("nombre", { length: 150 }).notNull(),
@@ -348,6 +357,7 @@
       fecha_creacion: timestamp("fecha_creacion", { withTimezone: true }).notNull().$default(() => new Date()),
       fecha_inicio_participacion: date("fecha_inicio_participacion").notNull().default("2025-12-01"),
       updated_at: timestamp("updated_at").defaultNow(),
+      tipo_reinversion: tipoReinversionEnum("tipo_reinversion"),
     },
     (t) => ({
       uxCreditoInvEspejo: uniqueIndex("ux_credito_inversionista_espejo").on(t.credito_id, t.inversionista_id),
@@ -560,13 +570,7 @@
     "Capital"
   ]);
 
-    export const tipoReinversionEnum = customSchema.enum("tipo_reinversion", [
-      "sin_reinversion",
-      "reinversion_capital",
-      "reinversion_interes",
-      "reinversion_total",
-      "reinversion_variable"
-    ]);
+
 
   export const tipoMonedaEnum = customSchema.enum("tipo_moneda", ["quetzales", "dolares"]);
 

--- a/apps/cartera-back/src/routers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/routers/mirrorInvestor.ts
@@ -1,5 +1,5 @@
 import { Elysia, t } from "elysia";
-import { llenarTablaEspejo, getCreditsWithMirrors, getCreditsByInvestor } from "../controllers/mirrorInvestor";
+import { llenarTablaEspejo, getCreditsWithMirrors, getCreditsByInvestor, asignarReinversionEspejo } from "../controllers/mirrorInvestor";
 
 export const mirrorInvestorRouter = new Elysia()
   .post("/llenar-tabla-espejo", llenarTablaEspejo, {
@@ -43,6 +43,29 @@ export const mirrorInvestorRouter = new Elysia()
           summary: "Obtener créditos asociados a un inversionista (Real o Espejo)",
           description: "Devuelve todos los créditos donde el ID proporcionado participa, junto con sus inversionistas originales y espejo.",
           tags: ["Inversionistas", "Espejo"]
+      }
+  })
+  .post("/asignar-reinversion", asignarReinversionEspejo, {
+      body: t.Object({
+          asignaciones: t.Array(
+              t.Object({
+                  id_credito_inversionista_espejo: t.Number(),
+                  tipo_reinversion: t.Enum({
+                      sin_reinversion: "sin_reinversion",
+                      reinversion_capital: "reinversion_capital",
+                      reinversion_interes: "reinversion_interes",
+                      reinversion_total: "reinversion_total",
+                      reinversion_variable: "reinversion_variable",
+                      reinversion_combinada: "reinversion_combinada",
+                  })
+              }),
+              { minItems: 1 }
+          )
+      }),
+      detail: {
+          summary: "Asignar tipo de reinversión a créditos espejo",
+          description: "Recibe un arreglo con id_credito_inversionista_espejo y el tipo_reinversion para actualizar en lote.",
+          tags: ["Inversionistas", "Espejo", "Reinversión"]
       }
   });
 

--- a/apps/crm/apps/web/src/components/vehicles/inspection-360-view.tsx
+++ b/apps/crm/apps/web/src/components/vehicles/inspection-360-view.tsx
@@ -5,8 +5,6 @@ import {
 	MinusCircle,
 	XCircle,
 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 interface Inspection360Item {
@@ -49,14 +47,14 @@ export function Inspection360View({ items }: Inspection360ViewProps) {
 		switch (status) {
 			case "GOOD":
 			case "OK":
-				return <CheckCircle2 className="h-4 w-4 text-green-500" />;
+				return <CheckCircle2 className="h-3.5 w-3.5 text-green-500 shrink-0" />;
 			case "REGULAR":
-				return <AlertTriangle className="h-4 w-4 text-amber-500" />;
+				return <AlertTriangle className="h-3.5 w-3.5 text-amber-500 shrink-0" />;
 			case "BAD":
 			case "LEGACY_BAD":
-				return <XCircle className="h-4 w-4 text-red-500" />;
+				return <XCircle className="h-3.5 w-3.5 text-red-500 shrink-0" />;
 			case "NA":
-				return <MinusCircle className="h-4 w-4 text-muted-foreground" />;
+				return <MinusCircle className="h-3.5 w-3.5 text-muted-foreground shrink-0" />;
 			default:
 				return null;
 		}
@@ -66,82 +64,99 @@ export function Inspection360View({ items }: Inspection360ViewProps) {
 		switch (status) {
 			case "GOOD":
 			case "OK":
-				return "Bueno";
+				return { label: "Bueno", cls: "text-green-600 bg-green-50" };
 			case "REGULAR":
-				return "Regular";
+				return { label: "Regular", cls: "text-amber-600 bg-amber-50" };
 			case "BAD":
 			case "LEGACY_BAD":
-				return "Malo";
+				return { label: "Malo", cls: "text-red-600 bg-red-50" };
 			case "NA":
-				return "N/A";
+				return { label: "N/A", cls: "text-muted-foreground bg-muted/40" };
 			default:
-				return status;
+				return { label: status, cls: "text-muted-foreground bg-muted/40" };
 		}
 	};
 
 	return (
-		<div className="space-y-6">
+		<div className="space-y-4">
 			{Object.entries(groupedItems).map(([area, areaItems]) => (
-				<div key={area} className="space-y-3">
-					<h5 className="font-semibold text-muted-foreground text-sm uppercase tracking-tight">
-						{area}
-					</h5>
-					<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-						{areaItems.map((item, idx) => (
-							<Card
-								key={`${area}-${item.checkpoint}-${idx}`}
-								className="overflow-hidden border-muted/60 transition-colors hover:border-muted-foreground/20"
-							>
-								<CardHeader className="bg-muted/20 p-3">
-									<div className="flex items-start justify-between gap-2">
-										<p className="font-medium text-sm leading-tight">
-											{item.checkpoint}
-										</p>
-										<div className="shrink-0">{getStatusIcon(item.status)}</div>
-									</div>
-								</CardHeader>
-								<CardContent className="space-y-2 p-3">
-									<div className="flex items-center justify-between">
-										<Badge
-											variant="outline"
-											className="py-0 font-normal text-[10px]"
-										>
-											{getStatusLabel(item.status)}
-										</Badge>
-										{item.metadata && Object.keys(item.metadata).length > 0 && (
-											<span className="text-[10px] text-muted-foreground italic">
-												Contiene datos técnicos
-											</span>
+				<div key={area}>
+					{/* Area subheader */}
+					<div className="flex items-center gap-2 mb-1.5">
+						<span className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+							{area.replace(/_/g, " ")}
+						</span>
+						<div className="flex-1 h-px bg-border" />
+					</div>
+
+					{/* Items 2-col grid */}
+					<div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+						{areaItems.map((item, idx) => {
+							const { label, cls } = getStatusLabel(item.status);
+							const hasCompression =
+								item.metadata &&
+								item.checkpoint.toLowerCase().includes("compresiones");
+
+							const psiEntries = hasCompression
+								? Object.entries(item.metadata!)
+										.filter(
+											([key, value]) =>
+												key.startsWith("cilindro_") &&
+												value !== 0 &&
+												value !== "0" &&
+												value !== "" &&
+												value !== null,
+										)
+										.sort(
+											([a], [b]) =>
+												parseInt(a.split("_")[1]) - parseInt(b.split("_")[1]),
+										)
+								: [];
+
+							return (
+								<div
+									key={`${area}-${item.checkpoint}-${idx}`}
+									className="flex items-start justify-between gap-2 rounded-lg border bg-muted/20 hover:bg-muted/40 transition-colors px-3 py-2"
+								>
+									{/* Left: icon + name + optional extras */}
+									<div className="min-w-0 flex-1">
+										<div className="flex items-center gap-1.5">
+											{getStatusIcon(item.status)}
+											<span className="font-medium text-xs truncate">{item.checkpoint}</span>
+										</div>
+										{item.comment && (
+											<p className="text-muted-foreground text-[10px] mt-0.5 ml-5 leading-snug line-clamp-2">
+												{item.comment}
+											</p>
 										)}
-									</div>
-
-									{item.comment && (
-										<p className="line-clamp-3 text-muted-foreground text-xs">
-											{item.comment}
-										</p>
-									)}
-
-									{/* Compression Data Special Display */}
-									{item.metadata &&
-										item.checkpoint.toLowerCase().includes("compresiones") && (
-											<div className="mt-2 grid grid-cols-4 gap-1 border-t pt-2">
-												{Object.entries(item.metadata)
-													.filter(([key]) => key.startsWith("cilindro_"))
-													.map(([key, value]) => (
-														<div key={key} className="text-center">
-															<p className="text-[8px] text-muted-foreground uppercase">
-																C{key.split("_")[1]}
-															</p>
-															<p className="font-bold font-mono text-[10px]">
-																{value}
-															</p>
-														</div>
-													))}
+										{psiEntries.length > 0 && (
+											<div className="mt-1 ml-5 flex flex-wrap gap-1">
+												{psiEntries.map(([key, value]) => (
+													<span
+														key={key}
+														className="inline-flex items-center gap-0.5 rounded bg-blue-50 border border-blue-100 px-1.5 py-0.5 font-mono text-[9px] text-blue-700"
+													>
+														<span className="font-semibold">C{key.split("_")[1]}</span>
+														<span className="text-blue-400">·</span>
+														{value} PSI
+													</span>
+												))}
 											</div>
 										)}
-								</CardContent>
-							</Card>
-						))}
+									</div>
+
+									{/* Right: status badge */}
+									<span
+										className={cn(
+											"mt-0.5 shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold whitespace-nowrap",
+											cls,
+										)}
+									>
+										{label}
+									</span>
+								</div>
+							);
+						})}
 					</div>
 				</div>
 			))}

--- a/apps/taller/src/lib/generate-inspection-pdf.ts
+++ b/apps/taller/src/lib/generate-inspection-pdf.ts
@@ -88,22 +88,44 @@ export async function generateInspectionPdf(vehicle: any) {
   doc.setFontSize(10);
   doc.setFont("helvetica", "bold");
   doc.setTextColor(secondaryColor[0], secondaryColor[1], secondaryColor[2]);
-  doc.text("Marca/Modelo:", 14, y);
-  doc.text("VIN:", 14, y + 6);
+  doc.text("Marca/Modelo/Año:", 14, y);
+  doc.text("Versión/Equip.:", 14, y + 6);
+  doc.text("Placa:", 14, y + 12);
+  doc.text("VIN/Chasis:", 14, y + 18);
+  doc.text("No. Motor:", 14, y + 24);
+  doc.text("Tipo:", 14, y + 30);
+  doc.text("Procedencia:", 14, y + 36);
+
   doc.text("Color:", 105, y);
-  doc.text("Kilometraje:", 105, y + 6);
-  doc.text("Combustible:", 105, y + 12);
+  doc.text("Millas:", 105, y + 6);
+  doc.text("Kilómetros:", 105, y + 12);
+  doc.text("Combustible:", 105, y + 18);
+  doc.text("Cilindros:", 105, y + 24);
+  doc.text("Motor (CC):", 105, y + 30);
+  doc.text("Transmisión:", 105, y + 36);
+  doc.text("Tracción:", 105, y + 42);
 
   doc.setFont("helvetica", "normal");
   doc.setTextColor(0, 0, 0);
-  doc.text(`${vehicle.vehicleMake} ${vehicle.vehicleModel} ${vehicle.vehicleYear}`, 45, y);
-  doc.text(vehicle.vinNumber, 45, y + 6);
-  doc.text(vehicle.color, 135, y);
-  doc.text(`${Number(vehicle.kmMileage).toLocaleString()} km`, 135, y + 6);
-  doc.text(vehicle.fuelType, 135, y + 12);
+  doc.text(`${vehicle.vehicleMake || ""} ${vehicle.vehicleModel || ""} ${vehicle.vehicleYear || ""}`, 47, y);
+  doc.text(vehicle.trim || "N/A", 47, y + 6);
+  doc.text(vehicle.licensePlate || "N/A", 47, y + 12);
+  doc.text(vehicle.vinNumber || "N/A", 47, y + 18);
+  doc.text(vehicle.motorNumber || "N/A", 47, y + 24);
+  doc.text(vehicle.vehicleType || "N/A", 47, y + 30);
+  doc.text(vehicle.origin || "N/A", 47, y + 36);
+
+  doc.text(vehicle.color || "N/A", 135, y);
+  doc.text(vehicle.milesMileage ? `${Number(vehicle.milesMileage).toLocaleString()} mi` : "N/A", 135, y + 6);
+  doc.text(`${Number(vehicle.kmMileage).toLocaleString()} km`, 135, y + 12);
+  doc.text(vehicle.fuelType || "N/A", 135, y + 18);
+  doc.text(vehicle.cylinders || "N/A", 135, y + 24);
+  doc.text(vehicle.engineCC || "N/A", 135, y + 30);
+  doc.text(vehicle.transmission || "N/A", 135, y + 36);
+  doc.text(vehicle.traction || "N/A", 135, y + 42);
 
   // Conditions
-  y += 22;
+  y += 52;
   doc.setFontSize(14);
   doc.setFont("helvetica", "bold");
   doc.setTextColor(primaryColor[0], primaryColor[1], primaryColor[2]);
@@ -152,27 +174,131 @@ export async function generateInspectionPdf(vehicle: any) {
   doc.text("Revisión 360", 14, y);
 
   if (vehicle.all360Items && vehicle.all360Items.length > 0) {
-    const checksData = vehicle.all360Items.map((check: any) => [
-      formatAreaName(check.area),
-      check.checkpoint,
-      check.status,
-      check.comment || "",
-    ]);
+    const getStandardCategory = (area: string) => {
+      if (!area) return "Otros";
+      const raw = area.toLowerCase().replace(/_/g, ' ');
+      if (raw.includes('exterior')) return "Exterior";
+      if (raw.includes('aro') || raw.includes('llanta')) return "Aros y Llantas";
+      if (raw.includes('interior')) return "Interior";
+      if (raw.includes('seguridad')) return "Seguridad";
+      if (raw.includes('herramienta')) return "Herramientas";
+      if (raw.includes('electric') || raw.includes('eléctric')) return "Sistema Eléctrico, Electrónico y Otros";
+      if (raw.includes('motor') || raw.includes('transmisi')) return "Motor y Transmisión";
+      if (raw.includes('identificacion') || raw.includes('identificación') || raw.includes('numeros')) return "Números de identificación del vehículo";
+      if (raw.includes('freno') || raw.includes('suspen')) return "Frenos y Suspensión";
+      if (raw.includes('tren') || raw.includes('direcci')) return "Tren Delantero y Dirección";
+      if (raw.includes('chasis')) return "Chasis";
+      return formatAreaName(area);
+    };
+
+    const sortedItems = [...vehicle.all360Items].sort((a: any, b: any) => {
+      const categoryOrder = [
+        "Exterior",
+        "Aros y Llantas",
+        "Interior",
+        "Seguridad",
+        "Herramientas",
+        "Sistema Eléctrico, Electrónico y Otros",
+        "Motor y Transmisión",
+        "Números de identificación del vehículo",
+        "Frenos y Suspensión",
+        "Tren Delantero y Dirección",
+        "Chasis",
+      ];
+      
+      const stdA = getStandardCategory(a.area);
+      const stdB = getStandardCategory(b.area);
+
+      const getIndex = (stdCat: string) => {
+        const index = categoryOrder.indexOf(stdCat);
+        return index !== -1 ? index : 998;
+      };
+
+      const indexA = getIndex(stdA);
+      const indexB = getIndex(stdB);
+      
+      if (indexA !== indexB) {
+        return indexA - indexB;
+      }
+      
+      if (stdA !== stdB) {
+         return stdA.localeCompare(stdB);
+      }
+      
+      return (a.checkpoint || "").localeCompare(b.checkpoint || "");
+    });
+
+    const checksData: any[] = [];
+    let currentArea = "";
+
+    sortedItems.forEach((check: any) => {
+      const areaName = getStandardCategory(check.area).toUpperCase();
+      if (areaName !== currentArea) {
+        currentArea = areaName;
+        checksData.push([
+          { content: `Área: ${areaName}`, colSpan: 3, styles: { fillColor: primaryColor as any, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'left' } }
+        ]);
+        checksData.push([
+          { content: "Punto de Verificación", styles: { fillColor: primaryColor as any, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'center' } },
+          { content: "ESTADO", styles: { fillColor: primaryColor as any, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'center', cellWidth: 25 } },
+          { content: "Comentarios", styles: { fillColor: primaryColor as any, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'center' } }
+        ]);
+      }
+      let commentStr = check.comment || "";
+      if (check.checkpoint.toLowerCase().includes("compresiones") && check.metadata) {
+        try {
+          const mData = typeof check.metadata === 'string' ? JSON.parse(check.metadata) : check.metadata;
+          if (mData && typeof mData === 'object') {
+
+            // Use vehicle cylinder count to limit the loop
+            let cylCount = 8;
+            if (vehicle.cylinders) {
+              const parsed = parseInt(vehicle.cylinders.toString().replace(/\D/g, ''), 10);
+              if (!isNaN(parsed) && parsed > 0 && parsed <= 16) {
+                cylCount = parsed;
+              }
+            }
+
+            const psiList: string[] = [];
+            for (let i = 1; i <= cylCount; i++) {
+              const val = mData[`cilindro_${i}`];  // Actual DB key format: cilindro_N
+              if (val !== undefined && val !== null && val !== "" && val !== 0 && val !== "0") {
+                psiList.push(`• C${i}: ${val} PSI`);
+              }
+            }
+
+            if (psiList.length > 0) {
+              commentStr += (commentStr ? "\n\n" : "") + `Presiones Registradas:\n${psiList.join('\n')}`;
+            }
+          }
+        } catch (e) { /* ignore */ }
+      }
+
+      checksData.push([
+        check.checkpoint,
+        check.status,
+        commentStr,
+      ]);
+    });
 
     autoTable(doc, {
       startY: y + 5,
-      head: [["Área", "Punto de revisión", "Estado", "Comentarios"]],
       body: checksData,
       theme: 'grid',
       styles: { fontSize: 8, cellPadding: 2 },
-      headStyles: { fillColor: primaryColor as any, textColor: [255, 255, 255] },
       alternateRowStyles: { fillColor: [245, 247, 250] },
+      columnStyles: {
+        0: { cellWidth: 55 },   // Punto de Verificación — más corto
+        1: { cellWidth: 22, halign: 'center' },  // ESTADO — fijo
+        2: { cellWidth: 'auto' },  // Comentarios — ocupa el resto del espacio
+      },
       willDrawCell: function (data) {
-        if (data.section === "body" && data.column.index === 2) {
+        if (data.section === "body" && data.column.index === 1) {
           const status = data.cell.text[0];
           if (status === "BAD" || status === "LEGACY_BAD") doc.setTextColor(200, 50, 50);
           else if (status === "REGULAR") doc.setTextColor(200, 150, 50);
           else if (status === "GOOD" || status === "OK") doc.setTextColor(50, 150, 50);
+          else if (status === "ESTADO") doc.setTextColor(255, 255, 255);
         }
       },
       didDrawCell: function (data) {
@@ -205,34 +331,29 @@ export async function generateInspectionPdf(vehicle: any) {
     const checklistData = vehicle.allChecklistItems.map((item: any) => [
       item.item,
       item.checked ? "Sí" : "No",
-      item.severity === "critical" ? "Crítico" : item.severity === "warning" ? "Advertencia" : item.severity,
       item.notes || "",
       (item.evidence && item.evidence.length > 0) ? `Fotos: ${item.evidence.map((_: any, i: number) => `[${i + 1}]`).join(' ')}` : ""
     ]);
 
     autoTable(doc, {
       startY: y + 5,
-      head: [["Punto Evaluado", "Anomalía", "Gravedad", "Notas Adicionales", "Evidencia"]],
+      head: [["Punto Evaluado", "Anomalía", "Notas Adicionales", "Evidencia"]],
       body: checklistData,
       theme: 'grid',
       styles: { fontSize: 8, cellPadding: 2 },
       headStyles: { fillColor: primaryColor as any, textColor: [255, 255, 255] },
       alternateRowStyles: { fillColor: [245, 247, 250] },
       willDrawCell: function (data) {
-        if (data.section === "body" && data.column.index === 4 && data.cell.text.length > 0 && data.cell.text[0].startsWith("Fotos:")) {
+        if (data.section === "body" && data.column.index === 3 && data.cell.text.length > 0 && data.cell.text[0].startsWith("Fotos:")) {
           doc.setTextColor(0, 102, 204); // Link color
         }
         if (data.section === "body" && data.column.index === 1 && data.cell.text[0] === "Sí") {
            doc.setTextColor(200, 50, 50); // Red if marked anomaly
         }
-        if (data.section === "body" && data.column.index === 2) {
-           if (data.cell.text[0] === "Crítico") doc.setTextColor(200, 50, 50);
-           else if (data.cell.text[0] === "Advertencia") doc.setTextColor(200, 150, 50);
-        }
       },
       didDrawCell: function (data) {
         doc.setTextColor(0, 0, 0); // reset
-        if (data.section === "body" && data.column.index === 4 && data.cell.text.length > 0 && data.cell.text[0].startsWith("Fotos:")) {
+        if (data.section === "body" && data.column.index === 3 && data.cell.text.length > 0 && data.cell.text[0].startsWith("Fotos:")) {
           const check = vehicle.allChecklistItems[data.row.index];
           if (check && check.evidence && check.evidence.length > 0) {
             const padding = typeof data.cell.styles.cellPadding === 'number' 
@@ -287,65 +408,74 @@ export async function generateInspectionPdf(vehicle: any) {
   doc.text("Registro Fotográfico Principal", 14, y);
 
   if (vehicle.allPhotos && vehicle.allPhotos.length > 0) {
-    // Select one photo per available category
-    const photosByCategory: Record<string, any[]> = {};
-    vehicle.allPhotos.forEach((p: any) => {
-      const cat = p.category ? p.category.toLowerCase() : 'otros';
-      if (!photosByCategory[cat]) photosByCategory[cat] = [];
-      photosByCategory[cat].push(p);
-    });
-
-    const preferredOrder = [
-      'exterior',
-      'interior',
-      'engine', 'motor',
-      'wheels', 'llantas',
-      'damage', 'daños',
-      'others', 'otros'
-    ];
-    let mainPhotos: any[] = [];
-    
-    preferredOrder.forEach(cat => {
-      // Find matches treating 'fotografías exteriores' as 'exterior', etc.
-      const matchedKeys = Object.keys(photosByCategory).filter(k => k.includes(cat));
-      if (matchedKeys.length > 0) {
-        mainPhotos.push(photosByCategory[matchedKeys[0]][0]);
-        // Remove so we don't pick it again
-        delete photosByCategory[matchedKeys[0]];
-      }
-    });
-
-    // Add any remaining categories
-    Object.keys(photosByCategory).forEach(cat => {
-      if (photosByCategory[cat].length > 0) {
-        mainPhotos.push(photosByCategory[cat][0]);
-      }
-    });
-
-    // Limit to max 6 photos to keep it concise
-    mainPhotos = mainPhotos.slice(0, 6);
-    
-    const formatCategoryName = (cat: string) => {
-      const map: Record<string, string> = {
-        'exterior': 'Exterior',
-        'interior': 'Interior',
-        'engine': 'Motor',
-        'wheels': 'Llantas',
-        'damage': 'Daños',
-        'others': 'Otros'
-      };
-      return map[cat.toLowerCase()] || cat.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+    const getStandardPhotoCategory = (cat: string) => {
+      const raw = cat.toLowerCase().replace(/_/g, ' ');
+      if (raw.includes('exterior')) return "Exterior";
+      if (raw.includes('interior')) return "Interior";
+      if (raw.includes('motor') || raw.includes('engine')) return "Motor";
+      if (raw.includes('llanta') || raw.includes('wheel') || raw.includes('rueda')) return "Ruedas y Neumáticos";
+      if (raw.includes('daño') || raw.includes('damage')) return "Daños y Áreas Específicas";
+      return "Otros";
     };
 
-    const photosTableData = mainPhotos.map((photo: any) => [
-      formatCategoryName(photo.category || "Otros"),
-      photo.title || photo.photoType || "Sin título",
-      photo.url ? "Ver foto" : "N/A"
-    ]);
+    const photosByCategoryAndType: Record<string, Record<string, any[]>> = {};
+
+    vehicle.allPhotos.forEach((p: any) => {
+      const dbCat = p.category ? p.category : 'otros';
+      const normCat = getStandardPhotoCategory(dbCat);
+      const type = p.photoType || p.title || "Otro";
+
+      if (!photosByCategoryAndType[normCat]) photosByCategoryAndType[normCat] = {};
+      if (!photosByCategoryAndType[normCat][type]) photosByCategoryAndType[normCat][type] = [];
+      photosByCategoryAndType[normCat][type].push(p);
+    });
+
+    const preferredCatOrder = [
+      'Exterior', 'Ruedas y Neumáticos', 'Interior', 'Motor', 'Daños y Áreas Específicas', 'Otros'
+    ];
+    
+    const photosTableData: any[] = [];
+    const urlMap = new Map<number, string>();
+    let rIndex = 0;
+    
+    preferredCatOrder.forEach(cat => {
+      if (photosByCategoryAndType[cat]) {
+        photosTableData.push([
+          { content: `Categoría: ${cat.toUpperCase()}`, colSpan: 3, styles: { fillColor: primaryColor as any, textColor: [255, 255, 255], fontStyle: 'bold', halign: 'left' } }
+        ]);
+        rIndex++;
+
+        const typesInCat = Object.keys(photosByCategoryAndType[cat]).sort();
+        typesInCat.forEach(type => {
+            const photos = photosByCategoryAndType[cat][type];
+            photos.sort((a, b) => {
+              const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+              const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+              return timeB - timeA;
+            });
+            const mostRecentPhoto = photos[0];
+            
+            photosTableData.push([
+              mostRecentPhoto.title || mostRecentPhoto.photoType || "Sin título",
+              mostRecentPhoto.comment || "", // Strict user comments
+              mostRecentPhoto.url ? "Ver foto" : "N/A"
+            ]);
+            
+            if (mostRecentPhoto.url) {
+              let photoUrl = mostRecentPhoto.url;
+              if (!photoUrl.startsWith('http')) {
+                 photoUrl = 'https://' + photoUrl;
+              }
+              urlMap.set(rIndex, photoUrl);
+            }
+            rIndex++;
+        });
+      }
+    });
 
     autoTable(doc, {
       startY: y + 5,
-      head: [["Categoría", "Descripción", "Enlace"]],
+      head: [["Descripción", "Comentarios", "Enlace"]],
       body: photosTableData,
       theme: 'grid',
       styles: { fontSize: 8, cellPadding: 3 },
@@ -359,11 +489,9 @@ export async function generateInspectionPdf(vehicle: any) {
       didDrawCell: function (data) {
         doc.setTextColor(0, 0, 0); // reset
         if (data.section === "body" && data.column.index === 2 && data.cell.text[0] === "Ver foto") {
-          const photo = mainPhotos[data.row.index];
-          if (photo && photo.url) {
-            doc.link(data.cell.x, data.cell.y, data.cell.width, data.cell.height, {
-              url: photo.url
-            });
+          const url = urlMap.get(data.row.index);
+          if (url) {
+            doc.link(data.cell.x, data.cell.y, data.cell.width, data.cell.height, { url });
           }
         }
       }

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -70,6 +70,11 @@ interface DashboardVehicle {
   vehicleType: string;
   color: string;
   fuelType: string;
+  motorNumber?: string;
+  milesMileage?: string | number;
+  cylinders?: string;
+  engineCC?: string;
+  transmission?: string;
   vehicleRating: string;
   marketValue: string;
   suggestedCommercialValue: string;
@@ -93,7 +98,7 @@ interface DashboardVehicle {
   tireConditionSpare?: number;
   paintCondition: number | null;
   hasAgencyHistory: boolean | null;
-  failedChecks: { area: string; checkpoint: string; status?: string; comment?: string | null }[];
+  failedChecks: { area: string; checkpoint: string; status?: string; comment?: string | null; metadata?: any }[];
   all360Items?: VehicleInspection360Item[];
   checklistIssues?: { id?: string; item: string; severity: string; notes?: string | null; evidence?: ChecklistItemEvidence[] }[];
   allChecklistItems?: InspectionChecklistItem[];
@@ -430,6 +435,11 @@ export default function VehiclesDashboard() {
       vehicleType: vehicle.vehicleType || '',
       color: vehicle.color || '',
       fuelType: vehicle.fuelType || '',
+      motorNumber: vehicle.motorNumber || '',
+      milesMileage: vehicle.milesMileage?.toString() || '',
+      cylinders: vehicle.cylinders || '',
+      engineCC: vehicle.engineCC || '',
+      transmission: vehicle.transmission || '',
       vehicleRating: latestInspection?.vehicleRating || 'Pendiente',
       marketValue: latestInspection?.marketValue || '0',
       suggestedCommercialValue: latestInspection?.suggestedCommercialValue || '0',
@@ -471,7 +481,8 @@ export default function VehiclesDashboard() {
             area: item.area,
             checkpoint: item.checkpoint,
             status: item.status,
-            comment: item.comment
+            comment: item.comment,
+            metadata: item.metadata,
           }))
         : [],
       checklistIssues: latestInspection?.checklistItems
@@ -1445,32 +1456,49 @@ export default function VehiclesDashboard() {
                             <div className="text-muted-foreground">Marca</div>
                             <div className="font-medium">{selectedVehicle.vehicleMake}</div>
 
-                            <div className="text-muted-foreground">Modelo</div>
+                            <div className="text-muted-foreground">Línea del vehículo</div>
                             <div className="font-medium">{selectedVehicle.vehicleModel}</div>
 
-                            <div className="text-muted-foreground">Versión/Trim</div>
+                            <div className="text-muted-foreground">Versión/Equipamiento</div>
                             <div className="font-medium">{selectedVehicle.trim || "N/A"}</div>
 
                             <div className="text-muted-foreground">Año</div>
                             <div className="font-medium">{selectedVehicle.vehicleYear}</div>
 
-                            <div className="text-muted-foreground">Tipo</div>
+                            <div className="text-muted-foreground">Procedencia</div>
+                            <div className="font-medium">{selectedVehicle.origin || "N/A"}</div>
+
+                            <div className="text-muted-foreground">Tipo de vehículo</div>
                             <div className="font-medium">{selectedVehicle.vehicleType}</div>
+                            
+                            <div className="text-muted-foreground">Transmisión</div>
+                            <div className="font-medium">{selectedVehicle.transmission || "N/A"}</div>
 
                             <div className="text-muted-foreground">Tracción</div>
                             <div className="font-medium">{selectedVehicle.traction || "N/A"}</div>
+                            
+                            <div className="text-muted-foreground">Cilindros</div>
+                            <div className="font-medium">{selectedVehicle.cylinders || "N/A"}</div>
+                            
+                            <div className="text-muted-foreground">Motor (CC)</div>
+                            <div className="font-medium">{selectedVehicle.engineCC || "N/A"}</div>
                           </div>
 
                           <div className="pt-2 border-t space-y-2">
                             <div className="flex items-center gap-2 text-sm">
                               <Hash className="h-3.5 w-3.5 text-muted-foreground" />
-                              <span className="text-muted-foreground">Placa:</span>
+                              <span className="text-muted-foreground">No. de placa:</span>
                               <span className="font-mono font-medium">{selectedVehicle.licensePlate}</span>
                             </div>
                             <div className="flex items-start gap-2 text-sm">
                               <Hash className="h-3.5 w-3.5 text-muted-foreground mt-0.5" />
-                              <span className="text-muted-foreground">VIN:</span>
+                              <span className="text-muted-foreground">No. VIN/Chasis:</span>
                               <span className="font-mono text-xs break-all">{selectedVehicle.vinNumber}</span>
+                            </div>
+                            <div className="flex items-start gap-2 text-sm">
+                              <Hash className="h-3.5 w-3.5 text-muted-foreground mt-0.5" />
+                              <span className="text-muted-foreground">No. de Motor:</span>
+                              <span className="font-mono text-xs break-all">{selectedVehicle.motorNumber || "N/A"}</span>
                             </div>
                             <div className="flex items-center gap-2 text-sm">
                               <Palette className="h-3.5 w-3.5 text-muted-foreground" />
@@ -1479,7 +1507,12 @@ export default function VehiclesDashboard() {
                             </div>
                             <div className="flex items-center gap-2 text-sm">
                               <Gauge className="h-3.5 w-3.5 text-muted-foreground" />
-                              <span className="text-muted-foreground">Kilometraje:</span>
+                              <span className="text-muted-foreground">Millas recorridas:</span>
+                              <span className="font-medium">{selectedVehicle.milesMileage ? `${Number(selectedVehicle.milesMileage).toLocaleString()} mi` : "N/A"}</span>
+                            </div>
+                            <div className="flex items-center gap-2 text-sm">
+                              <Gauge className="h-3.5 w-3.5 text-muted-foreground" />
+                              <span className="text-muted-foreground">Kilómetros recorridos:</span>
                               <span className="font-medium">{Number(selectedVehicle.kmMileage).toLocaleString()} km</span>
                             </div>
                             <div className="flex items-center gap-2 text-sm">
@@ -1741,6 +1774,40 @@ export default function VehiclesDashboard() {
                                         {check.comment}
                                       </p>
                                     )}
+                                    {check.metadata && check.checkpoint.toLowerCase().includes("compresiones") && (() => {
+                                      try {
+                                        const mData = typeof check.metadata === 'string' ? JSON.parse(check.metadata) : check.metadata;
+                                        let cylCount = 8;
+                                        if (selectedVehicle.cylinders) {
+                                           const parsed = parseInt(selectedVehicle.cylinders.toString().replace(/\D/g, ''), 10);
+                                           if (!isNaN(parsed) && parsed > 0 && parsed <= 16) cylCount = parsed;
+                                        }
+
+                                        const validPts = [];
+                                        for (let i = 1; i <= cylCount; i++) {
+                                          const val = mData[`c${i}`];
+                                          if (val !== undefined && val !== null && val !== 0 && val !== "0" && val !== "") {
+                                             validPts.push({ c: i, val });
+                                          }
+                                        }
+
+                                        if (validPts.length === 0) return null;
+
+                                        return (
+                                          <div className="mt-2 text-xs">
+                                            <div className="font-semibold text-slate-700 mb-1">Presiones Registradas:</div>
+                                            <div className="grid grid-cols-4 sm:grid-cols-8 gap-2 border-t border-slate-100 pt-2">
+                                              {validPts.map((pt) => (
+                                                <div key={pt.c} className="text-center bg-slate-50 rounded flex flex-col items-center border border-slate-200 shadow-sm py-1.5 transition-colors hover:border-blue-200 hover:bg-blue-50/50">
+                                                  <p className="text-[10px] text-blue-600 font-semibold mb-0.5">C{pt.c}</p>
+                                                  <p className="font-mono text-xs font-bold text-slate-700">{String(pt.val)} <span className="text-[9px] font-normal text-slate-500">PSI</span></p>
+                                                </div>
+                                              ))}
+                                            </div>
+                                          </div>
+                                        );
+                                      } catch(e) { return null; }
+                                    })()}
                                   </div>
                                 </div>
                               );


### PR DESCRIPTION
# 🚀 Feature: Reinversión Combinada para Inversionistas

## 📝 Descripción
Este Pull Request introduce la funcionalidad de **"Reinversión Combinada"**, permitiendo a los inversionistas tener diferentes reglas de reinversión (capital, interés, etc.) aplicadas de manera independiente para cada uno de sus créditos espejo, en lugar de estar atados a una única regla global.

## 🛠 Cambios Implementados

### 1. Base de Datos ([schema.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/database/db/schema.ts:0:0-0:0))
- Se movió la declaración del `tipoReinversionEnum` hacia arriba para solucionar errores de inicialización del linter.
- Se agregó el nuevo valor `'reinversion_combinada'` al `tipoReinversionEnum`.
- Se añadió la columna `tipo_reinversion` a la tabla `creditos_inversionistas_espejo`. Esta columna se configuró nativamente para aceptar nulos (`NULL`) para mantener la retrocompatibilidad y evitar romper los endpoints existentes que aún no envían este campo.

### 2. Nuevo Endpoint ([mirrorInvestor.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/routers/mirrorInvestor.ts:0:0-0:0))
- **Controller:** Se creó la función [asignarReinversionEspejo](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/mirrorInvestor.ts:654:0-711:2) para manejar la asignación masiva (*batch*) de tipos de reinversión por crédito utilizando transacciones de base de datos seguras.
- **Router:** Se expuso el endpoint `POST /asignar-reinversion` que recibe un array de IDs de créditos espejo y su respectivo tipo de reinversión a asignar.

### 3. Lógica de Cálculo Dinámico ([investor.ts](cci:7://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/routers/investor.ts:0:0-0:0))
- **Resúmenes Individuales:** Se modificaron los *loops* de cálculo ([resumeInvestor](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/investor.ts:1098:0-1565:1), [getInvestorTotalsGlobales](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/investor.ts:1567:0-1888:1), [getInvestorMirrorSummary](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/investor.ts:2212:0-2475:1)). Ahora, si el inversionista tiene el tipo global en `'reinversion_combinada'`, el sistema ignora la regla global y calcula la distribución de capital e interés evaluando el campo `tipo_reinversion` del crédito específico.
- **Resúmenes Globales (SQL Raw):** En la función [consultarResumenGlobalPorEstadoPago](cci:1://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/controllers/investor.ts:3645:0-3876:1), se incorporó un `LEFT JOIN` hacia `creditos_inversionistas_espejo` ([ce](cci:2://file:///home/jalvarezatcci/Documentos/universe/apps/cartera-back/src/utils/interface.ts:139:0-149:2)).
- Se introdujo lógica `CASE WHEN` dinámica dentro de las sumatorias SQL de Drizzle (`SUM()`) para que los subtotales generales sumen capital, interés o nada, dependiendo de la configuración individual del crédito en la tabla espejo.
- **Fixes TypeScript:** Se resolvieron problemas de inferencia estricta de Drizzle ORM al retornar agrupciones complejas con `.leftJoin` aplicando transformaciones explícitas de tipos (`as unknown as InversionistaResumenRow[]`).

