### PR TITLE
refactor(crm): remove redundant local lead name formatter

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1038,22 +1038,7 @@ export const crmRouter = {
 					createdMonth: z.number().min(1).max(12).optional(),
 					createdYear: z.number().optional(),
 					// NEW: Filtro por fuente/medio
-					source: z
-						.enum([
-							"website",
-							"referral",
-							"cold_call",
-							"email",
-							"social_media",
-							"event",
-							"other",
-							"facebook",
-							"instagram",
-							"google",
-							"meta",
-							"Whatsapp",
-						])
-						.optional(),
+					source: z.enum(leadSourceEnum.enumValues).optional(),
 				})
 				.optional(),
 		)
@@ -1141,7 +1126,9 @@ export const crmRouter = {
 				lead: {
 					id: leads.id,
 					firstName: leads.firstName,
+					middleName: leads.middleName,
 					lastName: leads.lastName,
+					secondLastName: leads.secondLastName,
 					email: leads.email,
 					phone: leads.phone,
 					age: leads.age,

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -47,16 +47,6 @@ import {
 import { getRoleLabel, PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
-function formatLeadFullName(lead: {
-	firstName?: string | null;
-	middleName?: string | null;
-	lastName?: string | null;
-	secondLastName?: string | null;
-}) {
-	return [lead.firstName, lead.middleName, lead.lastName, lead.secondLastName]
-		.filter((part): part is string => Boolean(part && part.trim()))
-		.join(" ");
-}
 
 // Type for the opportunity data
 export type OpportunityForModal = {


### PR DESCRIPTION
- Remove the local `formatLeadFullName` helper in favor of the standardized version used across the application.