### PR TITLE
feat: implement capital payments and consolidate service fees in reports

### DIFF
--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -1,0 +1,78 @@
+import { eq } from "drizzle-orm";
+import { abonos_capital } from "../database/db";
+import { db } from "../database";
+
+export async function createAbonoCapital(data: {
+  credito_id: number;
+  monto: string;
+  tipo: "CANCELACION" | "CAPITAL";
+  liquidado?: boolean;
+}) {
+  try {
+    const [nuevoAbono] = await db
+      .insert(abonos_capital)
+      .values({
+        credito_id: data.credito_id,
+        monto: data.monto,
+        tipo: data.tipo,
+        liquidado: data.liquidado ?? false,
+      })
+      .returning();
+
+    return {
+      success: true,
+      message: "Abono a capital creado correctamente",
+      data: nuevoAbono,
+    };
+  } catch (error: any) {
+    console.error("Error al crear abono a capital:", error);
+    return {
+      success: false,
+      message: "Error al crear el abono a capital",
+      error: error.message,
+      data: null,
+    };
+  }
+}
+
+export async function updateAbonoCapital(
+  abonoId: number,
+  data: Partial<{
+    monto: string;
+    tipo: "CANCELACION" | "CAPITAL";
+    liquidado: boolean;
+  }>
+) {
+  try {
+    const [abonoActualizado] = await db
+      .update(abonos_capital)
+      .set({
+        ...data,
+        updated_at: new Date(),
+      })
+      .where(eq(abonos_capital.abono_id, abonoId))
+      .returning();
+
+    if (!abonoActualizado) {
+      return {
+        success: false,
+        message: "Abono no encontrado",
+        data: null,
+      };
+    }
+
+    return {
+      success: true,
+      message: "Abono a capital actualizado correctamente",
+      data: abonoActualizado,
+    };
+  } catch (error: any) {
+    console.error("Error al actualizar abono a capital:", error);
+    return {
+      success: false,
+      message: "Error al actualizar el abono a capital",
+      error: error.message,
+      data: null,
+    };
+  }
+}

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -243,8 +243,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
       <td class="money">${formatQ(capitalPago)}</td>
       <td class="money">${formatQ(interesPago)}</td>
       <td class="money">${formatQ(Number(pago.abono_iva_12 || 0))}</td>
-      <td class="money">${formatQ(Number(pago.abono_seguro || 0))}</td>
-      <td class="money">${formatQ(Number(pago.abono_gps || 0))}</td>
+      <td class="money">${formatQ(Number(pago.abono_seguro || 0) + Number(pago.abono_gps || 0) + Number(pago.membresias_pago || 0))}</td>
       <td class="money">${formatQ(Number(pago.mora || 0))}</td>
       <td class="money total">${formatQ(montoAplicado)}</td>
       <td class="money">${formatQ(Number(pago.capital_restante || 0))}</td>
@@ -365,8 +364,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
           <th>Capital</th>
           <th>Interés</th>
           <th>IVA 12%</th>
-          <th>Seguro</th>
-          <th>GPS</th>
+          <th>Servicios</th>
           <th>Mora</th>
           <th>Monto Aplicado</th>
           <th>Capital Rest.</th>
@@ -380,7 +378,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
           <td colspan="4">TOTALES</td>
           <td class="money">${formatQ(totalCapital)}</td>
           <td class="money">${formatQ(totalInteres)}</td>
-          <td colspan="4"></td>
+          <td colspan="3"></td>
           <td class="money">${formatQ(totalMontoAplicado)}</td>
           <td colspan="3"></td>
         </tr>

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -939,3 +939,23 @@
   }, (table) => ({
     inversionistaIdx: index("idx_docs_inversionista").on(table.inversionista_id),
   }));
+
+  // ========================================
+  // ABONOS A CAPITAL
+  // ========================================
+  export const tipoAbonoEnum = customSchema.enum("tipo_abono", [
+    "CANCELACION",
+    "CAPITAL",
+  ]);
+
+  export const abonos_capital = customSchema.table("abonos_capital", {
+    abono_id: serial("abono_id").primaryKey(),
+    credito_id: integer("credito_id")
+      .notNull()
+      .references(() => creditos.credito_id),
+    monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
+    tipo: tipoAbonoEnum("tipo").notNull(),
+    liquidado: boolean("liquidado").notNull().default(false),
+    created_at: timestamp("created_at").defaultNow(),
+    updated_at: timestamp("updated_at").defaultNow(),
+  });

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -953,6 +953,9 @@
     credito_id: integer("credito_id")
       .notNull()
       .references(() => creditos.credito_id),
+    inversionista_id: integer("inversionista_id")
+      .notNull()
+      .references(() => inversionistas.inversionista_id),
     monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
     tipo: tipoAbonoEnum("tipo").notNull(),
     liquidado: boolean("liquidado").notNull().default(false),

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -29,7 +29,8 @@ const app = new Elysia()
   .use(routers.mirrorInvestorRouter)
   .use(routers.notificationsRouter)
   .use(routers.reconcileEspejoRouter)
-  .use(routers.investorDocumentsRouter);
+  .use(routers.investorDocumentsRouter)
+  .use(routers.abonosCapitalRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor
 iniciarTareasProgramadas();

--- a/apps/cartera-back/src/routers/abonosCapital.ts
+++ b/apps/cartera-back/src/routers/abonosCapital.ts
@@ -1,0 +1,52 @@
+import { Elysia, t } from "elysia";
+import { createAbonoCapital, updateAbonoCapital } from "../controllers/abonosCapital";
+import { authMiddleware } from "./midleware";
+
+export const abonosCapitalRouter = new Elysia({ prefix: "/api/abonos-capital" })
+  .use(authMiddleware)
+
+  .post(
+    "/",
+    async ({ body }) => {
+      const result = await createAbonoCapital(body);
+      if (!result.success) {
+        return { status: 500, body: result };
+      }
+      return result;
+    },
+    {
+      body: t.Object({
+        credito_id: t.Number(),
+        monto: t.String(),
+        tipo: t.Union([t.Literal("CANCELACION"), t.Literal("CAPITAL")]),
+        liquidado: t.Optional(t.Boolean()),
+      }),
+    }
+  )
+
+  .put(
+    "/:id",
+    async ({ params: { id }, body }) => {
+      const abonoId = parseInt(id);
+      if (isNaN(abonoId)) {
+        return {
+          status: 400,
+          body: { success: false, message: "ID de abono inválido" },
+        };
+      }
+
+      const result = await updateAbonoCapital(abonoId, body);
+      if (!result.success) {
+        return { status: 404, body: result };
+      }
+      return result;
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      body: t.Object({
+        monto: t.Optional(t.String()),
+        tipo: t.Optional(t.Union([t.Literal("CANCELACION"), t.Literal("CAPITAL")])),
+        liquidado: t.Optional(t.Boolean()),
+      }),
+    }
+  );

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -17,6 +17,7 @@ import { mirrorInvestorRouter } from "./mirrorInvestor";
 import { notificationsRouter } from "./notifications";
 import { reconcileEspejoRouter } from "./reconcileEspejo";
 import { investorDocumentsRouter } from "./investorDocuments";
+import { abonosCapitalRouter } from "./abonosCapital";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter
 }   


### PR DESCRIPTION
Adds the abonos_capital table, controllers, and routes to manage principal payments (CAPITAL or CANCELACION). Additionally, updates the Excel export logic to group insurance, GPS, and membership fees into a single "Servicios" column.
