### PR TITLE
Link and track capital advances in investor payments

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -25,6 +25,7 @@ import {
   usuarios,
   liquidacion_locks,
   documentos_inversionista,
+  abonos_capital,
 } from "../database/db/schema";
 import { getSignedDocumentUrl } from "../utils/functions/uploadsFiles";
 import { eq, and, sql, inArray, ilike, like, desc, count, SQL } from "drizzle-orm";
@@ -164,6 +165,9 @@ async function consultarPagosInversionista(
       estado_liquidacion: tabla.estado_liquidacion,
       fecha_vencimiento_cuota: cuotas_credito.fecha_vencimiento,
       fecha_pago_efectivo_cuota: cuotas_credito.fecha_liquidacion_inversionistas,
+      abono_capital_id: config.origen === "espejo"
+        ? (tabla as any).abono_capital_id
+        : sql<number | null>`null`,
       origen: sql<OrigenDatos>`${config.origen}`.as('origen'),
     })
     .from(tabla)
@@ -1336,6 +1340,27 @@ export async function resumeInvestor(
           }
 
           // 🧮 Detalle de pagos
+          // Pre-cargar abonos a capital referenciados por los pagos
+          const abonoIds = pagos
+            .map((p) => (p as any).abono_capital_id)
+            .filter((id): id is number => id != null);
+
+          let abonosMap = new Map<number, { monto: string; tipo: string }>();
+          if (abonoIds.length > 0) {
+            const abonos = await db
+              .select({
+                abono_id: abonos_capital.abono_id,
+                monto: abonos_capital.monto,
+                tipo: abonos_capital.tipo,
+              })
+              .from(abonos_capital)
+              .where(inArray(abonos_capital.abono_id, abonoIds));
+
+            for (const a of abonos) {
+              abonosMap.set(a.abono_id, { monto: a.monto, tipo: a.tipo });
+            }
+          }
+
           const pagos_detalle = pagos
             .sort((a, b) => {
               // 🔥 ORDENAR POR FECHA DE VENCIMIENTO DE LA CUOTA
@@ -1439,6 +1464,10 @@ const mes = fechaParaMes
                   )
                 ),
                 estado_liquidacion: pago.estado_liquidacion,
+                abono_capital_id: (pago as any).abono_capital_id ?? null,
+                abono_capital_detalle: (pago as any).abono_capital_id
+                  ? abonosMap.get((pago as any).abono_capital_id) ?? null
+                  : null,
               };
             });
 
@@ -2588,6 +2617,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
           pago_id: pagos_credito_inversionistas_espejo.pago_id,
           credito_id: pagos_credito_inversionistas_espejo.credito_id,
           abono_capital: pagos_credito_inversionistas_espejo.abono_capital,
+          abono_capital_id: pagos_credito_inversionistas_espejo.abono_capital_id,
         })
         .from(pagos_credito_inversionistas_espejo)
         .where(
@@ -2705,6 +2735,22 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
         }
 
         console.log(`  ✅ ${updateResult.rowCount ?? 0} pagos espejo actualizados`);
+
+        // Marcar abonos a capital como liquidados
+        const abonoIdsALiquidar = [
+          ...new Set(
+            pagosNoLiquidados
+              .map((p) => p.abono_capital_id)
+              .filter((id): id is number => id != null)
+          ),
+        ];
+        if (abonoIdsALiquidar.length > 0) {
+          await tx
+            .update(abonos_capital)
+            .set({ liquidado: true, updated_at: new Date() })
+            .where(inArray(abonos_capital.abono_id, abonoIdsALiquidar));
+          console.log(`  ✅ ${abonoIdsALiquidar.length} abono(s) a capital marcados como liquidados`);
+        }
 
         // Marcar cuotas como liquidado_inversionistas
         const allPagoIds = [...new Set(pagosNoLiquidados.map((p) => p.pago_id))];

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -10,6 +10,7 @@ import {
   pagos_credito_inversionistas_espejo,
   boletas,
   cuotas_credito,
+  abonos_capital,
 } from "../database/db/schema";
 import { desc, gte } from "drizzle-orm";
 import Big from "big.js";
@@ -590,6 +591,31 @@ export async function insertPagosCreditoInversionistas(
       `      porcentaje_participacion_inversionista: ${inv.porcentaje_participacion_inversionista}`
     );
 
+    // ── Buscar abonos a capital NO liquidados para este crédito/inversionista ──
+    const abonosNoLiquidados = await db
+      .select()
+      .from(abonos_capital)
+      .where(
+        and(
+          eq(abonos_capital.credito_id, credito_id),
+          eq(abonos_capital.inversionista_id, inv.inversionista_id),
+          eq(abonos_capital.liquidado, false)
+        )
+      );
+
+    let abonoCapitalId: number | null = null;
+    if (abonosNoLiquidados.length > 0) {
+      let montoAbono = new Big(0);
+      for (const abono of abonosNoLiquidados) {
+        montoAbono = montoAbono.plus(abono.monto);
+      }
+      abono_capital = abono_capital.plus(montoAbono);
+      abonoCapitalId = abonosNoLiquidados[0].abono_id;
+
+      console.log(`   💰 Abono a capital encontrado (id: ${abonoCapitalId}): +${montoAbono.toFixed(6)}`);
+      console.log(`      abono_capital con abono sumado: ${abono_capital.toString()}`);
+    }
+
     const resultado = {
       pago_id,
       inversionista_id: inv.inversionista_id,
@@ -602,6 +628,7 @@ export async function insertPagosCreditoInversionistas(
         : inv.porcentaje_participacion_inversionista,
       cuota: currentPago?.cuota ?? "0",
       estado_liquidacion: "NO_LIQUIDADO" as const,
+      abono_capital_id: abonoCapitalId,
     };
 
     console.log(`   ✅ Resultado final para ${inv.nombre}:`, {
@@ -620,26 +647,10 @@ export async function insertPagosCreditoInversionistas(
 
   // 4. Insertar todos los registros (ESPEJO)
   const resolvedInserts = await Promise.all(inserts);
-await db
-  .insert(pagos_credito_inversionistas_espejo)
-  .values(resolvedInserts)
-  .onConflictDoUpdate({
-    target: [
-      pagos_credito_inversionistas_espejo.pago_id,
-      pagos_credito_inversionistas_espejo.inversionista_id,
-    ],
-    set: {
-      abono_capital: sql`EXCLUDED.abono_capital`,
-      abono_interes: sql`EXCLUDED.abono_interes`,
-      abono_iva_12: sql`EXCLUDED.abono_iva_12`,
-      porcentaje_participacion: sql`EXCLUDED.porcentaje_participacion`,
-      cuota: sql`EXCLUDED.cuota`,
-      fecha_pago: sql`EXCLUDED.fecha_pago`,
-      estado_liquidacion: sql`EXCLUDED.estado_liquidacion`,
-      credito_id: sql`EXCLUDED.credito_id`,
-      updated_at: sql`now()`,
-    },
-  });
+
+  await db
+    .insert(pagos_credito_inversionistas_espejo)
+    .values(resolvedInserts);
 
   return resolvedInserts;
 }
@@ -2092,7 +2103,7 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
             credito.creditoId,
             false,  // excludeCube
             false,  // cuotaPagada
-            false,   // updateCredito ← omite el UPDATE a creditos_inversionistas_espejo
+            false,  // updateCredito ← omite el UPDATE a creditos_inversionistas_espejo
             inversionistaId
           );
 

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -508,6 +508,12 @@
         .default("NO_LIQUIDADO"),
       cuota: numeric("cuota", { precision: 18, scale: 2 }).notNull(),
 
+      // FK al abono a capital asociado (nullable)
+      abono_capital_id: integer("abono_capital_id").references(
+        () => abonos_capital.abono_id,
+        { onDelete: "set null" }
+      ),
+ 
       // 🆕 ENLACE A LIQUIDACIÓN
       liquidacion_id: integer("liquidacion_id").references(
         () => liquidaciones.liquidacion_id,
@@ -517,10 +523,6 @@
       updated_at: timestamp("updated_at").defaultNow(),
     },
     (table) => ({
-      uniquePagoInversionistaEspejo: unique("unique_pago_inversionista_espejo").on(
-        table.pago_id,
-        table.inversionista_id
-      ),
       // 🆕 Índice para búsquedas por liquidación
       liquidacionIdxEspejo: index("idx_pagos_liquidacion_espejo").on(
         table.liquidacion_id

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -190,8 +190,20 @@ const DetailSections = ({ pago }: { pago: any }) => (
             {section.fields.map((field) => {
               if (pago[field] === undefined) return null;
               return (
-                <div key={field} className="flex items-center justify-between text-sm">
-                  <span className="text-gray-500 font-medium">{FIELD_LABELS[field] || field.replace(/_/g, " ")}</span>
+                <div key={field} className="flex items-center justify-between text-sm gap-1">
+                  <span className="text-gray-500 font-medium flex items-center gap-1">
+                    {FIELD_LABELS[field] || field.replace(/_/g, " ")}
+                    {field === "abono_capital" && pago.abono_capital_detalle && (
+                      <>
+                        <span className="inline-flex items-center px-1 py-0 rounded text-[9px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+                          {pago.abono_capital_detalle.tipo}
+                        </span>
+                        <span className="inline-flex items-center px-1 py-0 rounded text-[9px] font-semibold bg-blue-100 text-blue-800 border border-blue-300">
+                          +{formatCurrency(pago.abono_capital_detalle.monto)}
+                        </span>
+                      </>
+                    )}
+                  </span>
                   <span className="font-bold text-gray-900 text-right">{formatFieldValue(field, pago[field])}</span>
                 </div>
               );
@@ -832,6 +844,16 @@ const handleDownloadExcel = async () => {
                                                       pagoInv.abono_capital
                                                     )}
                                                   </span>
+                                                  {pagoInv.abono_capital_detalle && (
+                                                    <>
+                                                      <span className="inline-flex items-center px-1 py-0 rounded text-[9px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+                                                        {pagoInv.abono_capital_detalle.tipo}
+                                                      </span>
+                                                      <span className="inline-flex items-center px-1 py-0 rounded text-[9px] font-semibold bg-blue-100 text-blue-800 border border-blue-300">
+                                                        +{formatCurrency(pagoInv.abono_capital_detalle.monto)}
+                                                      </span>
+                                                    </>
+                                                  )}
                                                 </div>
                                               </TableCell>
                                               <TableCell className="border px-2 py-1 font-semibold">

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -1347,7 +1347,19 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                                 <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
                                   {/* 💵 ABONO CAPITAL */}
                                   <div className="bg-white rounded-lg p-2 border border-blue-200">
-                                    <div className="text-xs text-blue-700">💵 Abono Capital</div>
+                                    <div className="flex items-center justify-between">
+                                      <span className="text-xs text-blue-700">💵 Abono Capital</span>
+                                      {pago.abono_capital_detalle && (
+                                        <div className="flex items-center gap-1">
+                                          <span className="inline-flex items-center px-1 py-0 rounded text-[10px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+                                            {pago.abono_capital_detalle.tipo}
+                                          </span>
+                                          <span className="inline-flex items-center px-1 py-0 rounded text-[10px] font-semibold bg-blue-100 text-blue-800 border border-blue-300">
+                                            +{inv.currencySymbol} {Number(pago.abono_capital_detalle.monto).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                          </span>
+                                        </div>
+                                      )}
+                                    </div>
                                     {isDraft ? (
                                       <div className="flex items-center mt-1">
                                         <span className="text-blue-900 font-bold text-sm mr-1">{inv.currencySymbol}</span>
@@ -1891,7 +1903,19 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                             <div className="grid grid-cols-2 gap-2">
                               {/* 💵 ABONO CAPITAL */}
                               <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-2 border border-blue-200">
-                                <div className="text-xs text-blue-700">💵 Abono Capital</div>
+                                <div className="flex items-center justify-between">
+                                  <span className="text-xs text-blue-700">💵 Abono Capital</span>
+                                  {pago.abono_capital_detalle && (
+                                    <div className="flex items-center gap-1">
+                                      <span className="inline-flex items-center px-1 py-0 rounded text-[9px] font-semibold bg-amber-100 text-amber-800 border border-amber-300">
+                                        {pago.abono_capital_detalle.tipo}
+                                      </span>
+                                      <span className="inline-flex items-center px-1 py-0 rounded text-[9px] font-semibold bg-blue-100 text-blue-800 border border-blue-300">
+                                        +{inv.currencySymbol} {Number(pago.abono_capital_detalle.monto).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                      </span>
+                                    </div>
+                                  )}
+                                </div>
                                 {isDraft ? (
                                   <div className="flex items-center mt-1">
                                     <span className="text-blue-900 font-bold text-sm mr-1">{inv.currencySymbol}</span>

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -548,8 +548,11 @@ export interface PagoData {
     paymentFalse:boolean
     boletas:string[]
     monto_aplicado: string | null;
-    // Agrega más campos si los necesitas
-    // Puedes agregar campos extra si necesitas
+    abono_capital_id?: number | null;
+    abono_capital_detalle?: {
+      monto: string;
+      tipo: string;
+    } | null;
   };
   inversionistasData: {
     id: number;
@@ -581,6 +584,11 @@ export interface PagoData {
     fecha_pago: string;
     estado_liquidacion: "NO_LIQUIDADO" | "POR_LIQUIDAR" | "LIQUIDADO";
     cuota: string;
+    abono_capital_id?: number | null;
+    abono_capital_detalle?: {
+      monto: string;
+      tipo: string;
+    } | null;
   }[];
 }
 export const getPagosByCredito = async (
@@ -745,6 +753,11 @@ export interface PagoCredito {
   fecha_pago: string;
    abonoGeneralInteres?:number
      tasaInteresInvesor?:number
+  abono_capital_id?: number | null;
+  abono_capital_detalle?: {
+    monto: string;
+    tipo: string;
+  } | null;
 }
 
 // Detalle de cada crédito en el que participa un inversionista


### PR DESCRIPTION
This pull request implements support for tracking and displaying detailed information about "abonos a capital" (capital repayments) associated with investor payments. The changes span backend logic, database schema, and frontend display, ensuring that capital repayments are properly linked, liquidated, and shown with their details in the UI.

**Backend and Database Enhancements:**

* Capital repayments are now linked to individual payments via a new nullable foreign key `abono_capital_id` in the `pagos_credito_inversionistas_espejo` table, allowing each payment to reference a specific capital repayment.
* When generating or updating payments, the backend now looks up any unliquidated capital repayments for the relevant credit/investor, sums their amounts, and attaches both the total and the corresponding `abono_capital_id` to the payment. [[1]](diffhunk://#diff-ad2cbfc1983946e7082611de01a4844e63884884a34e9245310922e9b0a16b8aR594-R618) [[2]](diffhunk://#diff-ad2cbfc1983946e7082611de01a4844e63884884a34e9245310922e9b0a16b8aR631)
* On liquidation, the backend marks all referenced capital repayments as liquidated, ensuring data consistency and preventing double application.
* The summary and detail endpoints preload capital repayment details (amount and type) for each payment, making this information available to the frontend. [[1]](diffhunk://#diff-f570ffe6e6f487742368f81b1514259e8bdae67017faf8e605572587245878d2R1343-R1363) [[2]](diffhunk://#diff-f570ffe6e6f487742368f81b1514259e8bdae67017faf8e605572587245878d2R1467-R1470)

**Frontend Display Improvements:**

* The UI now displays badges next to capital repayment amounts, showing both the type and the specific amount of the associated capital repayment, wherever payment details are shown (including tables, detail sections, and Excel exports). [[1]](diffhunk://#diff-958b216afd532bc003490b5ca7eb0f72ba59b07bc72a872bb5cda0f0499e3c7bL193-R206) [[2]](diffhunk://#diff-958b216afd532bc003490b5ca7eb0f72ba59b07bc72a872bb5cda0f0499e3c7bR847-R856) [[3]](diffhunk://#diff-4c648e0570edef47c5e0b88160edb39591420288b99a9137146975dc1ece36fdL1350-R1362) [[4]](diffhunk://#diff-4c648e0570edef47c5e0b88160edb39591420288b99a9137146975dc1ece36fdL1894-R1918)
* Types and interfaces have been updated to include the new `abono_capital_id` and `abono_capital_detalle` fields, ensuring type safety and clarity across the codebase. [[1]](diffhunk://#diff-c92348d4c6c15333fd6bd5ff4c15a17907c451d85a01c3bc5206289bf933d550L551-R555) [[2]](diffhunk://#diff-c92348d4c6c15333fd6bd5ff4c15a17907c451d85a01c3bc5206289bf933d550R587-R591) [[3]](diffhunk://#diff-c92348d4c6c15333fd6bd5ff4c15a17907c451d85a01c3bc5206289bf933d550R756-R760)

**Database and Logic Refactoring:**

* Removed the unique constraint on `pago_id` and `inversionista_id` in the payments mirror table to support the new linkage logic.
* Adjusted the payment insertion logic to remove the upsert operation, simplifying how new payments are inserted.

**Summary of Most Important Changes:**

**Backend and Database:**
- Added `abono_capital_id` foreign key to `pagos_credito_inversionistas_espejo` and logic to link payments with capital repayments, including preloading and marking repayments as liquidated. [[1]](diffhunk://#diff-4775e7054371acef1e4b69ac1b52287a1aa07401873f3f7068ba7f62b886c5a7R511-R516) [[2]](diffhunk://#diff-ad2cbfc1983946e7082611de01a4844e63884884a34e9245310922e9b0a16b8aR594-R618) [[3]](diffhunk://#diff-ad2cbfc1983946e7082611de01a4844e63884884a34e9245310922e9b0a16b8aR631) [[4]](diffhunk://#diff-f570ffe6e6f487742368f81b1514259e8bdae67017faf8e605572587245878d2R1343-R1363) [[5]](diffhunk://#diff-f570ffe6e6f487742368f81b1514259e8bdae67017faf8e605572587245878d2R1467-R1470) [[6]](diffhunk://#diff-f570ffe6e6f487742368f81b1514259e8bdae67017faf8e605572587245878d2R2739-R2754)
- Removed the unique constraint from the payments mirror table and simplified the payment insert logic. [[1]](diffhunk://#diff-4775e7054371acef1e4b69ac1b52287a1aa07401873f3f7068ba7f62b886c5a7L520-L523) [[2]](diffhunk://#diff-ad2cbfc1983946e7082611de01a4844e63884884a34e9245310922e9b0a16b8aR650-R653)

**Frontend:**
- Enhanced payment displays to show detailed capital repayment badges (type and amount) in all relevant UI sections. [[1]](diffhunk://#diff-958b216afd532bc003490b5ca7eb0f72ba59b07bc72a872bb5cda0f0499e3c7bL193-R206) [[2]](diffhunk://#diff-958b216afd532bc003490b5ca7eb0f72ba59b07bc72a872bb5cda0f0499e3c7bR847-R856) [[3]](diffhunk://#diff-4c648e0570edef47c5e0b88160edb39591420288b99a9137146975dc1ece36fdL1350-R1362) [[4]](diffhunk://#diff-4c648e0570edef47c5e0b88160edb39591420288b99a9137146975dc1ece36fdL1894-R1918)
- Updated TypeScript interfaces to include capital repayment fields for type safety and clarity. [[1]](diffhunk://#diff-c92348d4c6c15333fd6bd5ff4c15a17907c451d85a01c3bc5206289bf933d550L551-R555) [[2]](diffhunk://#diff-c92348d4c6c15333fd6bd5ff4c15a17907c451d85a01c3bc5206289bf933d550R587-R591) [[3]](diffhunk://#diff-c92348d4c6c15333fd6bd5ff4c15a17907c451d85a01c3bc5206289bf933d550R756-R760)