### PR TITLE
Adds combined reinvestment for mirror investors

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -102,6 +102,7 @@ async function consultarCreditosInversionista(
       cuota_inversionista: tabla.cuota_inversionista,
       origen: sql<OrigenDatos>`${config.origen}`.as('origen'),
       tipo_reinversion: config.origen === "espejo" ? (tabla as any).tipo_reinversion : sql<string | null>`NULL`.as("tipo_reinversion"),
+      credito_inversionista_espejo_id: config.origen === "espejo" ? (tabla as typeof creditos_inversionistas_espejo).id : sql<number | null>`NULL`.as("credito_inversionista_espejo_id"),
     })
     .from(tabla)
     .where(inArray(tabla.inversionista_id, inversionistaIds));
@@ -1512,6 +1513,8 @@ const mes = fechaParaMes
             monto_aportado: formatValue(c.monto_aportado),
             porcentaje_inversionista: c.porcentaje_inversionista,
             cuota_inversionista: formatValue(c.cuota_inversionista),
+            tipo_reinversion: (c as any).tipo_reinversion ?? null,
+            credito_inversionista_espejo_id: (c as any).credito_inversionista_espejo_id ?? null,
             plazo: credito.plazo,
             pagos: pagos_detalle,
             total_abono_capital: formatValue(total_abono_capital.toString()),

--- a/apps/cartera-back/src/routers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/routers/mirrorInvestor.ts
@@ -49,6 +49,7 @@ export const mirrorInvestorRouter = new Elysia()
       body: t.Object({
           asignaciones: t.Array(
               t.Object({
+                  id_inversionista: t.Number(),
                   id_credito_inversionista_espejo: t.Number(),
                   tipo_reinversion: t.Enum({
                       sin_reinversion: "sin_reinversion",

--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -1,0 +1,304 @@
+import { useState, useMemo } from "react";
+import { createPortal } from "react-dom";
+import { Search, X, Save, Loader2 } from "lucide-react";
+import { useGetInvestors } from "../hooks/getInvestor";
+import { useAsignarReinversion } from "../hooks/getInvestor";
+import type { TipoReinversionEspejo, CreditoInversionistaData } from "../services/services";
+import { toast } from "sonner";
+
+interface ModalReinversionCombinadaProps {
+  open: boolean;
+  onClose: () => void;
+  inversionistaId: number;
+  inversionistaNombre: string;
+  onSaved?: () => void;
+}
+
+const TIPOS_REINVERSION: { value: TipoReinversionEspejo; label: string; color: string }[] = [
+  { value: "sin_reinversion", label: "Sin Reinversión", color: "bg-gray-100 text-gray-700" },
+  { value: "reinversion_capital", label: "Capital", color: "bg-green-100 text-green-700" },
+  { value: "reinversion_interes", label: "Interés", color: "bg-blue-100 text-blue-700" },
+  { value: "reinversion_total", label: "Total", color: "bg-purple-100 text-purple-700" },
+];
+
+const PER_PAGE = 25;
+
+export function ModalReinversionCombinada({
+  open,
+  onClose,
+  inversionistaId,
+  inversionistaNombre,
+  onSaved,
+}: ModalReinversionCombinadaProps) {
+  const [page, setPage] = useState(1);
+  const [search, setSearch] = useState("");
+  // Map: credito_inversionista_espejo_id -> tipo_reinversion seleccionado (solo los que cambiaron)
+  const [asignaciones, setAsignaciones] = useState<Record<number, TipoReinversionEspejo>>({});
+
+  const { data, isLoading } = useGetInvestors({
+    id: inversionistaId,
+    page,
+    perPage: PER_PAGE,
+    tipo: "espejos",
+    nombreUsuario: search || undefined,
+  });
+
+  const { mutate: asignarReinversion, isPending: isSaving } = useAsignarReinversion();
+
+  // Todos los créditos del inversionista actual
+  const creditos: CreditoInversionistaData[] = useMemo(() => {
+    if (!data?.inversionistas?.length) return [];
+    const inv = data.inversionistas.find((i) => i.inversionista_id === inversionistaId);
+    return inv?.creditos ?? [];
+  }, [data, inversionistaId]);
+
+  // Resumen: contar por tipo y sumar montos
+  const resumen = useMemo(() => {
+    const counts: Record<string, { cantidad: number; monto: number }> = {
+      reinversion_capital: { cantidad: 0, monto: 0 },
+      reinversion_interes: { cantidad: 0, monto: 0 },
+      reinversion_total: { cantidad: 0, monto: 0 },
+      sin_reinversion: { cantidad: 0, monto: 0 },
+    };
+
+    creditos.forEach((cred) => {
+      const espejoId = cred.credito_inversionista_espejo_id;
+      const tipoOriginal = cred.tipo_reinversion ?? "sin_reinversion";
+      const tipo = (espejoId && asignaciones[espejoId]) ? asignaciones[espejoId] : tipoOriginal;
+      if (counts[tipo]) {
+        counts[tipo].cantidad++;
+        counts[tipo].monto += Number(cred.monto_aportado || 0);
+      }
+    });
+
+    return counts;
+  }, [creditos, asignaciones]);
+
+  const handleTipoChange = (espejoId: number, tipo: TipoReinversionEspejo, tipoOriginal: string) => {
+    setAsignaciones((prev) => {
+      const next = { ...prev };
+      // Si vuelve al valor original, quitar del map (no hubo cambio)
+      if (tipo === tipoOriginal) {
+        delete next[espejoId];
+      } else {
+        next[espejoId] = tipo;
+      }
+      return next;
+    });
+  };
+
+  const handleGuardar = () => {
+    // Solo enviar los que el usuario cambió
+    const cambios = Object.entries(asignaciones).map(([espejoId, tipo]) => ({
+      id_inversionista: inversionistaId,
+      id_credito_inversionista_espejo: Number(espejoId),
+      tipo_reinversion: tipo,
+    }));
+
+    if (cambios.length === 0) {
+      toast.error("No hay cambios para guardar.");
+      return;
+    }
+
+    asignarReinversion(
+      { asignaciones: cambios },
+      {
+        onSuccess: () => {
+          toast.success("Reinversión combinada guardada correctamente.");
+          onSaved?.();
+          onClose();
+        },
+        onError: (err) => {
+          toast.error(`Error al asignar reinversión: ${err.message}`);
+        },
+      }
+    );
+  };
+
+  const totalPages = data?.totalPages ?? 1;
+
+  if (!open) return null;
+
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999]">
+      <div className="bg-white rounded-2xl shadow-2xl w-full max-w-3xl max-h-[85vh] flex flex-col">
+        {/* Header */}
+        <div className="px-6 py-4 border-b flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-bold text-blue-800">
+              Reinversión Combinada
+            </h2>
+            <p className="text-sm text-gray-500">{inversionistaNombre}</p>
+          </div>
+          <button onClick={onClose} className="p-2 hover:bg-gray-100 rounded-lg transition">
+            <X className="w-5 h-5 text-gray-500" />
+          </button>
+        </div>
+
+        {/* Resumen por tipo */}
+        <div className="px-6 py-3 border-b bg-gray-50">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            {TIPOS_REINVERSION.map((tipo) => {
+              const data = resumen[tipo.value];
+              return (
+                <div key={tipo.value} className={`rounded-lg px-3 py-2 ${tipo.color}`}>
+                  <div className="text-xs font-medium opacity-75">{tipo.label}</div>
+                  <div className="text-lg font-bold">{data?.cantidad ?? 0} créditos</div>
+                  <div className="text-xs">
+                    Q {(data?.monto ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Buscador */}
+        <div className="px-6 py-3 border-b">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+            <input
+              type="text"
+              value={search}
+              onChange={(e) => {
+                setSearch(e.target.value);
+                setPage(1);
+              }}
+              placeholder="Buscar por nombre del cliente..."
+              className="w-full pl-10 pr-4 py-2 bg-blue-50 border border-blue-200 rounded-lg text-sm text-blue-900 placeholder-blue-400 focus:ring-2 focus:ring-blue-400 focus:border-blue-400"
+            />
+          </div>
+        </div>
+
+        {/* Lista de créditos */}
+        <div className="flex-1 overflow-y-auto px-6 py-3">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="w-6 h-6 animate-spin text-blue-500" />
+              <span className="ml-2 text-gray-500">Cargando créditos...</span>
+            </div>
+          ) : creditos.length === 0 ? (
+            <div className="text-center py-12 text-gray-400">
+              No se encontraron créditos.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {creditos.filter((c) => c.credito_inversionista_espejo_id).map((cred) => {
+                const espejoId = cred.credito_inversionista_espejo_id!;
+                const tipoOriginal = cred.tipo_reinversion ?? "sin_reinversion";
+                const tipoActual = asignaciones[espejoId] ?? tipoOriginal;
+                return (
+                  <div
+                    key={espejoId}
+                    className="border border-gray-200 rounded-lg p-3 hover:border-blue-300 transition flex items-center gap-4"
+                  >
+                    {/* Info del crédito resumida */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 mb-1">
+                        <span className="font-bold text-indigo-900 text-sm">
+                          {cred.numero_credito_sifco}
+                        </span>
+                        <span className="text-xs text-gray-400">|</span>
+                        <span className="text-xs text-gray-600 truncate">
+                          {cred.nombre_usuario}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-4 text-xs text-gray-500">
+                        <span>
+                          Capital:{" "}
+                          <span className="font-semibold text-green-700">
+                            Q {Number(cred.monto_aportado).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                          </span>
+                        </span>
+                        <span>Plazo: {cred.plazo}m</span>
+                        <span>Interés: {cred.porcentaje_interes}%</span>
+                      </div>
+                    </div>
+
+                    {/* Select de tipo reinversión */}
+                    <select
+                      value={tipoActual}
+                      onChange={(e) =>
+                        handleTipoChange(espejoId, e.target.value as TipoReinversionEspejo, tipoOriginal)
+                      }
+                      className={`text-sm border rounded-lg px-3 py-1.5 font-medium transition ${
+                        tipoActual === "sin_reinversion"
+                          ? "border-gray-300 bg-gray-50 text-gray-600"
+                          : tipoActual === "reinversion_capital"
+                          ? "border-green-300 bg-green-50 text-green-700"
+                          : tipoActual === "reinversion_interes"
+                          ? "border-blue-300 bg-blue-50 text-blue-700"
+                          : "border-purple-300 bg-purple-50 text-purple-700"
+                      }`}
+                    >
+                      <option value="sin_reinversion">Sin Reinversión</option>
+                      <option value="reinversion_capital">Capital</option>
+                      <option value="reinversion_interes">Interés</option>
+                      <option value="reinversion_total">Total</option>
+                    </select>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Paginación */}
+        {totalPages > 1 && (
+          <div className="px-6 py-2 border-t flex items-center justify-center gap-2">
+            <button
+              onClick={() => setPage((p) => Math.max(1, p - 1))}
+              disabled={page === 1}
+              className="px-3 py-1 text-sm rounded border disabled:opacity-40 hover:bg-gray-50"
+            >
+              Anterior
+            </button>
+            <span className="text-sm text-gray-600">
+              Página {page} de {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+              disabled={page === totalPages}
+              className="px-3 py-1 text-sm rounded border disabled:opacity-40 hover:bg-gray-50"
+            >
+              Siguiente
+            </button>
+          </div>
+        )}
+
+        {/* Footer con botones */}
+        <div className="px-6 py-4 border-t flex items-center justify-between">
+          <div className="text-xs text-gray-400">
+            {Object.keys(asignaciones).length} créditos con cambios
+          </div>
+          <div className="flex gap-3">
+            <button
+              onClick={onClose}
+              className="px-4 py-2 rounded-lg bg-gray-200 hover:bg-gray-300 text-gray-700 font-semibold transition"
+            >
+              Cancelar
+            </button>
+            <button
+              onClick={handleGuardar}
+              disabled={isSaving}
+              className="px-4 py-2 rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-bold transition disabled:opacity-50 flex items-center gap-2"
+            >
+              {isSaving ? (
+                <>
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  Guardando...
+                </>
+              ) : (
+                <>
+                  <Save className="w-4 h-4" />
+                  Guardar Asignaciones
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
@@ -1,11 +1,13 @@
 // components/InvestorModal.tsx
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import { useForm } from "react-hook-form";
 import { useInvestor } from "../hooks/investor";
 import { useBancos } from "../hooks/bancos";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type { InvestorPayload } from "../services/services";
+import { ModalReinversionCombinada } from "./ModalReinversionCombinada";
 
 interface InvestorModalProps {
   open: boolean;
@@ -15,9 +17,11 @@ interface InvestorModalProps {
 }
 
 export function InvestorModal({ open, onClose, mode, initialData }: InvestorModalProps) {
-  const { insertInvestor } = useInvestor(); // 🔥 Solo usamos insertInvestor (hace upsert)
+  const { insertInvestor } = useInvestor();
   const { bancos, loading: loadingBancos, loadBancos } = useBancos();
   const queryClient = useQueryClient();
+  const [showCombinada, setShowCombinada] = useState(false);
+  const [prevTipoReinversion, setPrevTipoReinversion] = useState<string>("sin_reinversion");
 
   const { register, handleSubmit, reset, watch, setValue } = useForm<InvestorPayload>({
     defaultValues: {
@@ -102,8 +106,8 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
 
   if (!open) return null;
 
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-50">
+  return createPortal(
+    <div className="fixed inset-0 bg-black bg-opacity-40 flex items-center justify-center z-[9998]">
       <div className="bg-white rounded-xl shadow-2xl p-6 w-full max-w-md">
         <h2 className="text-xl font-bold mb-6 text-blue-700 text-center">
           {mode === "create" ? "Crear Inversionista" : "Editar Inversionista"}
@@ -184,21 +188,40 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
           {/* Tipo de Reinversión */}
           <div>
             <label className="block text-sm text-blue-800 mb-1">Tipo de Reinversión</label>
-            <select
-              {...register("tipo_reinversion", {
-                onChange: (e) => {
-                  if (e.target.value !== "reinversion_variable") {
-                    setValue("monto_reinversion", 0);
-                  }
-                },
-              })}
-              className="bg-white text-blue-900 border border-gray-300 rounded-lg px-4 py-2 w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-            >
-              <option value="sin_reinversion">Sin Reinversión</option>
-              <option value="reinversion_capital">Reinversión Capital</option>
-              <option value="reinversion_interes">Reinversión Interés</option>
-              <option value="reinversion_variable">Reinversión Variable</option>
-            </select>
+            <div className="flex gap-2">
+              <select
+                {...register("tipo_reinversion", {
+                  onChange: (e) => {
+                    const prev = watch("tipo_reinversion") ?? "sin_reinversion";
+                    const val = e.target.value;
+                    if (val !== "reinversion_variable") {
+                      setValue("monto_reinversion", 0);
+                    }
+                    if (val === "reinversion_combinada") {
+                      setPrevTipoReinversion(prev === "reinversion_combinada" ? "sin_reinversion" : prev);
+                      setShowCombinada(true);
+                    }
+                  },
+                })}
+                className="bg-white text-blue-900 border border-gray-300 rounded-lg px-4 py-2 w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
+              >
+                <option value="sin_reinversion">Sin Reinversión</option>
+                <option value="reinversion_capital">Reinversión Capital</option>
+                <option value="reinversion_interes">Reinversión Interés</option>
+                <option value="reinversion_total">Reinversión Total</option>
+                <option value="reinversion_variable">Reinversión Variable</option>
+                <option value="reinversion_combinada">Reinversión Combinada</option>
+              </select>
+              {watch("tipo_reinversion") === "reinversion_combinada" && mode === "update" && initialData?.inversionista_id && (
+                <button
+                  type="button"
+                  onClick={() => setShowCombinada(true)}
+                  className="px-3 py-2 rounded-lg bg-purple-100 hover:bg-purple-200 text-purple-700 font-semibold text-sm transition whitespace-nowrap border border-purple-300"
+                >
+                  Configurar
+                </button>
+              )}
+            </div>
           </div>
 
           {/* Monto Reinversión */}
@@ -268,6 +291,50 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
           </div>
         </form>
       </div>
-    </div>
+
+      {/* Modal de Reinversión Combinada */}
+      {mode === "update" && initialData?.inversionista_id && (
+        <ModalReinversionCombinada
+          open={showCombinada}
+          onClose={() => {
+            setShowCombinada(false);
+            // Si cancela, regresar al tipo de reinversión que tenía antes
+            const currentVal = watch("tipo_reinversion");
+            if (currentVal === "reinversion_combinada") {
+              setValue("tipo_reinversion", prevTipoReinversion);
+              setValue("re_inversion", prevTipoReinversion);
+            }
+          }}
+          inversionistaId={initialData.inversionista_id}
+          inversionistaNombre={initialData.nombre}
+          onSaved={() => {
+            // Guardar el inversionista con reinversion_combinada y cerrar todo
+            const currentFormData = watch();
+            const payload = {
+              ...currentFormData,
+              dpi: currentFormData.dpi ? Number(currentFormData.dpi) : null,
+              banco: currentFormData.banco ? Number(currentFormData.banco) : null,
+              monto_reinversion: currentFormData.monto_reinversion ? Number(currentFormData.monto_reinversion) : 0,
+              tipo_reinversion: "reinversion_combinada",
+              re_inversion: "reinversion_combinada",
+            };
+            insertInvestor.mutate(payload, {
+              onSuccess: () => {
+                toast.success("Inversionista actualizado con reinversión combinada.");
+                queryClient.invalidateQueries({ queryKey: ["investors"] });
+                queryClient.invalidateQueries({ queryKey: ["investor-mirror-summary"] });
+                queryClient.invalidateQueries({ queryKey: ["investor-totals"] });
+                reset();
+                onClose();
+              },
+              onError: (error: any) => {
+                toast.error(`Error al actualizar inversionista: ${error.message || ""}`);
+              },
+            });
+          }}
+        />
+      )}
+    </div>,
+    document.body
   );
 }

--- a/apps/carteraFront/src/private/cartera/hooks/getInvestor.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/getInvestor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { 
+import {
   getInvestorServices,
   getInvestorTotalsService,
   calcularPagosEspejoService,
@@ -10,9 +10,12 @@ import {
   downloadInvestorPDFService,
   recalcularPagosEspejoService,
   reversePagosEspejoService,
+  asignarReinversionService,
   type RecalcularPagoPayload,
   type LiquidateByInvestorRequest,
   type LiquidateByInvestorResponse,
+  type AsignarReinversionPayload,
+  type AsignarReinversionResponse,
 } from "../services/services";
 
 // ============================================
@@ -335,6 +338,26 @@ export function useReversePagosEspejo() {
     },
     onError: (error: Error) => {
       console.error("❌ Error revirtiendo pagos:", error);
+    },
+  });
+}
+
+// ============================================================
+// useAsignarReinversion
+// ============================================================
+export function useAsignarReinversion() {
+  const queryClient = useQueryClient();
+
+  return useMutation<AsignarReinversionResponse, Error, AsignarReinversionPayload>({
+    mutationFn: (payload) => asignarReinversionService(payload),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: investorsQueryKeys.lists() });
+      queryClient.invalidateQueries({ queryKey: ["investor-mirror-summary"] });
+      queryClient.invalidateQueries({ queryKey: ["investor-totals"] });
+    },
+    onError: (error: Error) => {
+      console.error("Error asignando reinversión:", error);
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -763,6 +763,8 @@ export interface PagoCredito {
 // Detalle de cada crédito en el que participa un inversionista
 export interface CreditoInversionistaData {
   credito_id: number;
+  credito_inversionista_espejo_id?: number;
+  tipo_reinversion?: string;
   numero_credito_sifco: string;
   nombre_usuario: string;
   nit_usuario: string;
@@ -3106,4 +3108,39 @@ export async function toggleDocumentVisibility(documentoId: number, visible: boo
 export async function deleteInvestorDocument(documentoId: number) {
   const { data } = await api.patch(`/investor-documents/${documentoId}/delete`);
   return data;
+}
+
+// ============================================================
+// asignarReinversion — POST /asignar-reinversion
+// ============================================================
+export type TipoReinversionEspejo =
+  | "sin_reinversion"
+  | "reinversion_capital"
+  | "reinversion_interes"
+  | "reinversion_total"
+  | "reinversion_variable"
+  | "reinversion_combinada";
+
+export interface AsignarReinversionPayload {
+  asignaciones: {
+    id_inversionista: number;
+    id_credito_inversionista_espejo: number;
+    tipo_reinversion: TipoReinversionEspejo;
+  }[];
+}
+
+export interface AsignarReinversionResponse {
+  success: boolean;
+  message: string;
+  actualizados: number;
+}
+
+export async function asignarReinversionService(
+  payload: AsignarReinversionPayload
+): Promise<AsignarReinversionResponse> {
+  const res = await api.post<AsignarReinversionResponse>(
+    `${import.meta.env.VITE_BACK_URL}/asignar-reinversion`,
+    payload
+  );
+  return res.data;
 }


### PR DESCRIPTION
Introduces the "Reinversión Combinada" feature, providing investors with flexible and granular control over how their individual mirror credits are reinvested. Previously, an investor could only apply a single reinvestment type across all their mirror credits. This enhancement allows for configuring distinct reinvestment strategies (capital, interest, total, or none) for each specific mirror credit.

Key updates include:

*   **Frontend:**
    *   Adds "Reinversión Combinada" as a new option in the investor editing modal.
    *   Introduces a dedicated modal (`ModalReinversionCombinada`) for individually managing the reinvestment type of each mirror credit. This modal features search, pagination, and a summary of current assignments.
    *   Integrates new hooks and services to facilitate the saving of these individual credit assignments to the backend.
    
<img width="840" height="880" alt="image" src="https://github.com/user-attachments/assets/bce9307c-78bf-495f-a7ba-4d22ff1fd7c4" />
    
    
*   **Backend:**
    *   Enhances the investor controller to expose `credito_inversionista_espejo_id` and individual `tipo_reinversion` values for mirror credits.
    *   Implements a new endpoint (`/asignar-reinversion`) to process and store the combined reinvestment assignments for specific mirror credits.

This feature significantly improves the customization and management capabilities for mirror investor portfolios.