### PR TITLE
feat(crm): mejoras UX vehículos, clientes, cheques y desembolso

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1161,6 +1161,7 @@ export const crmRouter = {
 					kmMileage: vehicles.kmMileage,
 					status: vehicles.status,
 					isNew: vehicles.isNew,
+					isOwned: vehicles.isOwned,
 					fuelType: vehicles.fuelType,
 					transmission: vehicles.transmission,
 				},
@@ -2792,7 +2793,9 @@ export const crmRouter = {
 				conditions.push(
 					or(
 						ilike(leads.firstName, searchPattern),
+						ilike(leads.middleName, searchPattern),
 						ilike(leads.lastName, searchPattern),
+						ilike(leads.secondLastName, searchPattern),
 						ilike(leads.email, searchPattern),
 						ilike(leads.phone, searchPattern),
 						ilike(leads.dpi, searchPattern),
@@ -2825,7 +2828,9 @@ export const crmRouter = {
 				.select({
 					id: leads.id,
 					firstName: leads.firstName,
+					middleName: leads.middleName,
 					lastName: leads.lastName,
+					secondLastName: leads.secondLastName,
 					email: leads.email,
 					phone: leads.phone,
 					dpi: leads.dpi,
@@ -4482,6 +4487,21 @@ export const crmRouter = {
 	// ============================================================
 	// DISBURSEMENT CHECKLIST ENDPOINTS (90% → 100%)
 	// ============================================================
+
+	// Get disbursement notes for an opportunity (lightweight, no stage check)
+	getDisbursementNotes: crmProcedure
+		.input(z.object({ opportunityId: z.string().uuid() }))
+		.handler(async ({ input }) => {
+			const [checklist] = await db
+				.select({ notes: disbursementChecklists.notes })
+				.from(disbursementChecklists)
+				.where(
+					eq(disbursementChecklists.opportunityId, input.opportunityId),
+				)
+				.limit(1);
+
+			return { notes: checklist?.notes ?? null };
+		}),
 
 	// Get or create disbursement checklist for an opportunity
 	getDisbursementChecklist: analystProcedure

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -80,6 +80,7 @@ export const appRouter = {
 	updateAnalysisChecklistVehicleVerification:
 		crmRouter.updateAnalysisChecklistVehicleVerification,
 	// Disbursement checklist (90% → 100%)
+	getDisbursementNotes: crmRouter.getDisbursementNotes,
 	getDisbursementChecklist: crmRouter.getDisbursementChecklist,
 	updateDisbursementChecklistItem: crmRouter.updateDisbursementChecklistItem,
 	updateDisbursementChecklistNotes: crmRouter.updateDisbursementChecklistNotes,

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -1140,8 +1140,8 @@ export async function closeOpportunity(
 
 		// 3. Generate invoices in background (fire-and-forget)
 		// This runs asynchronously after the credit is created
-		// Skip invoice generation if the vehicle belongs to a company (has companyId)
-		const vehicleHasCompany = opportunity.vehicleId && vehicleData?.companyId;
+		// Skip invoice generation if the vehicle is owned
+		const vehicleHasCompany = vehicleData?.isOwned
 
 		if (isCarteraBackEnabled() && !vehicleHasCompany) {
 			const royalti = opportunity.royalti

--- a/apps/crm/apps/web/src/components/analysis/DisbursementChecklistView.tsx
+++ b/apps/crm/apps/web/src/components/analysis/DisbursementChecklistView.tsx
@@ -122,6 +122,12 @@ export function DisbursementChecklistView({
 	// Approve disbursement mutation
 	const approveMutation = useMutation({
 		mutationFn: async () => {
+			if (notes !== (checklist?.notes ?? "")) {
+				await client.updateDisbursementChecklistNotes({
+					opportunityId,
+					notes,
+				});
+			}
 			return client.approveDisbursement({ opportunityId });
 		},
 		onSuccess: () => {
@@ -241,7 +247,7 @@ export function DisbursementChecklistView({
 				</div>
 
 				{/* Notes */}
-				<div className="space-y-2">
+				<div className="flex flex-col gap-2">
 					<label className="font-medium text-sm">
 						Notas
 						<Textarea

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -2556,6 +2556,22 @@ export function CreditDetailView({
 								</Dialog>
 							</div>
 						</CardHeader>
+						{vehiculo && (
+							<div className="mx-6 mb-2 flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2">
+								<Car className="h-4 w-4 shrink-0 text-muted-foreground" />
+								<span className="text-muted-foreground text-sm">
+									{vehicleString}
+								</span>
+								{(vehiculo as any).isOwned && (
+									<Badge
+										variant="outline"
+										className="border-sky-300 bg-sky-50 text-[10px] text-sky-700 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-300"
+									>
+										Cash In
+									</Badge>
+								)}
+							</div>
+						)}
 						<CardContent>
 							{checksQuery.isLoading ? (
 								<p className="text-center text-muted-foreground">

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -15,6 +15,7 @@ import {
 	FileText,
 	History,
 	Mail,
+	StickyNote,
 	Target,
 	UserPlus,
 	Users,
@@ -184,6 +185,14 @@ export function OpportunityDetailModal({
 		}),
 		enabled: open && !!opportunity?.id,
 		queryKey: ["getOpportunityDocuments", opportunity?.id],
+	});
+
+	// Query for disbursement notes (only for won opportunities)
+	const disbursementNotesQuery = useQuery({
+		...orpc.getDisbursementNotes.queryOptions({
+			input: { opportunityId: opportunity?.id ?? "" },
+		}),
+		enabled: open && !!opportunity?.id && opportunity?.status === "won",
 	});
 
 	// Load history when history tab is opened
@@ -630,6 +639,20 @@ export function OpportunityDetailModal({
 								)}
 							</div>
 						)}
+
+						{/* Disbursement Notes */}
+						{opportunity.status === "won" &&
+							disbursementNotesQuery.data?.notes && (
+								<div className="rounded-lg border bg-muted/20 px-4 py-3">
+									<div className="flex items-center gap-2 text-muted-foreground text-xs">
+										<StickyNote className="h-3.5 w-3.5" />
+										Notas de desembolso
+									</div>
+									<p className="mt-1 whitespace-pre-wrap text-sm">
+										{disbursementNotesQuery.data.notes}
+									</p>
+								</div>
+							)}
 
 						{/* Opportunity ID */}
 						<div className="rounded-lg border bg-muted/20 px-4 py-3">

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -82,6 +82,17 @@ export const Route = createFileRoute("/crm/clients")({
 });
 
 // Helper functions
+function formatLeadFullName(lead: {
+	firstName?: string | null;
+	middleName?: string | null;
+	lastName?: string | null;
+	secondLastName?: string | null;
+}) {
+	return [lead.firstName, lead.middleName, lead.lastName, lead.secondLastName]
+		.filter((part): part is string => Boolean(part && part.trim()))
+		.join(" ");
+}
+
 const getClientTypeLabel = (type: string) => {
 	switch (type) {
 		case "individual":
@@ -622,7 +633,7 @@ function RouteComponent() {
 													<User className="h-4 w-4 text-muted-foreground" />
 													<div>
 														<div className="font-medium">
-															{clientData.firstName} {clientData.lastName}
+															{formatLeadFullName(clientData)}
 														</div>
 														{clientData.dpi && (
 															<div className="text-muted-foreground text-xs">
@@ -792,7 +803,7 @@ function RouteComponent() {
 								<div className="min-w-0 flex-1">
 									<div className="flex items-center gap-2">
 										<h3 className="truncate font-semibold text-xl">
-											{selectedClient.firstName} {selectedClient.lastName}
+											{formatLeadFullName(selectedClient)}
 										</h3>
 										<Badge variant="outline" className="shrink-0 text-xs">
 											{getClientTypeLabel(selectedClient.clientType)}
@@ -1001,7 +1012,7 @@ function RouteComponent() {
 													Nombre Completo
 												</p>
 												<p className="font-medium text-sm">
-													{selectedClient.firstName} {selectedClient.lastName}
+													{formatLeadFullName(selectedClient)}
 												</p>
 											</div>
 											<div>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -29,6 +29,7 @@ import {
 	Plus,
 	RefreshCw,
 	Search,
+	StickyNote,
 	Target,
 	Trash2,
 	TrendingUp,
@@ -399,6 +400,16 @@ function RouteComponent() {
 	const processedOpportunityIdRef = useRef<string | null>(null);
 	const prevOpenRef = useRef(isCreateDialogOpen);
 	const prevDetailsOpenRef = useRef(isDetailsDialogOpen);
+
+	const disbursementNotesQuery = useQuery({
+		...orpc.getDisbursementNotes.queryOptions({
+			input: { opportunityId: selectedOpportunity?.id ?? "" },
+		}),
+		enabled:
+			isDetailsDialogOpen &&
+			!!selectedOpportunity?.id &&
+			selectedOpportunity?.status === "won",
+	});
 
 	// Month/year filter for placed amounts alignment with dashboard
 	const [month, setMonth] = useState(() => new Date().getMonth() + 1);
@@ -2492,6 +2503,20 @@ function RouteComponent() {
 													No hay cotizaciones asociadas a esta oportunidad
 												</p>
 											)}
+										</div>
+									)}
+
+								{/* Disbursement Notes */}
+								{selectedOpportunity.status === "won" &&
+									disbursementNotesQuery.data?.notes && (
+										<div className="rounded-lg border bg-muted/20 px-4 py-3">
+											<div className="flex items-center gap-2 text-muted-foreground text-xs">
+												<StickyNote className="h-3.5 w-3.5" />
+												Notas de desembolso
+											</div>
+											<p className="mt-1 whitespace-pre-wrap text-sm">
+												{disbursementNotesQuery.data.notes}
+											</p>
 										</div>
 									)}
 

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -2426,12 +2426,16 @@ function VehiclesDashboard() {
 											| "sold"
 											| "maintenance"
 											| "auction",
-									) =>
+									) => {
+										const wasVendido = editVehicleForm.status === "sold";
 										setEditVehicleForm({
 											...editVehicleForm,
 											status: value,
-										})
-									}
+											...(wasVendido && value !== "sold"
+												? { isOwned: true }
+												: {}),
+										});
+									}}
 								>
 									<SelectTrigger>
 										<SelectValue placeholder="Seleccionar estado" />


### PR DESCRIPTION
## Summary

- **Vehículos**: activar `isOwned` automáticamente al cambiar estado de vendido a otro (recuperación)
- **Clientes**: mostrar nombre completo (segundo nombre y segundo apellido) en tabla, modal y búsqueda server-side
- **Cheques**: banner con info del vehículo (marca, modelo, año) y badge "Cash In" si es propio
- **Desembolso**: guardar notas pendientes al aprobar para no perderlas; fix `space-y` en Tailwind v4
- **Oportunidades**: mostrar notas de desembolso en modales de detalle (solo oportunidades ganadas)
- **Facturación**: corregir skip de facturas usando `isOwned` en vez de `companyId`
- Nuevo endpoint `getDisbursementNotes` (ligero, sin validación de etapa)

## Test plan

- [ ] Cambiar estado de vehículo de "Vendido" a "Disponible" y verificar que isOwned se activa
- [ ] Buscar clientes por segundo nombre o segundo apellido
- [ ] Verificar nombre completo en tabla y modal de clientes
- [ ] Verificar banner de vehículo con badge Cash In en tab de cheques
- [ ] Escribir notas de desembolso, aprobar sin guardar y verificar que se persisten
- [ ] Verificar notas de desembolso visibles en modales de detalle de oportunidad ganada

🤖 Generated with [Claude Code](https://claude.com/claude-code)