### PR TITLE
feat: add celular to investor detail & filter by id

### DIFF
--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -595,6 +595,7 @@
     monto_reinversion: numeric("monto_reinversion", { precision: 18, scale: 2 }),
     saldo_reinversion: numeric("saldo_reinversion", { precision: 18, scale: 2 }).notNull().default("0"),
     dpi_rep_legal: varchar("dpi_rep_legal", { length: 20 }),
+    celular: varchar("celular", { length: 100 }),
   });
 
   export const reinversiones = customSchema.table("reinversiones", {

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2113,6 +2113,7 @@ export const cobrosRouter = {
 	getInversionistas: crmCobrosOrInvestmentsProcedure
 		.input(
 			z.object({
+				id: z.number().int().positive().optional(),
 				page: z.number().min(1).optional().default(1),
 				perPage: z.number().min(1).max(100).optional().default(20),
 			}),
@@ -2129,6 +2130,7 @@ export const cobrosRouter = {
 
 			try {
 				const result = await carteraBackClient.getInvestors({
+					id: input.id,
 					page: input.page,
 					perPage: input.perPage,
 				});
@@ -2152,6 +2154,7 @@ export const cobrosRouter = {
 						tipoCuenta: inv.tipo_cuenta ?? null,
 						numeroCuenta: inv.numero_cuenta ?? null,
 						moneda: inv.moneda ?? "quetzales",
+						celular: inv.celular ?? null,
 					})),
 					pagination: {
 						page: result.page,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -573,6 +573,7 @@ export class CarteraBackClient {
 		params: GetInvestorsParams = {},
 	): Promise<PaginatedResponse<CarteraInversionista>> {
 		const queryParams = new URLSearchParams({
+			...(params.id && { id: params.id.toString() }),
 			...(params.page && { page: params.page.toString() }),
 			...(params.perPage && { perPage: params.perPage.toString() }),
 		});

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -357,6 +357,7 @@ export interface CarteraInversionista {
 	tipo_cuenta: TipoCuentaEnum | null;
 	numero_cuenta: string | null;
 	moneda: "quetzales" | "dolares";
+	celular: string | null;
 }
 
 export interface CreateInversionistaInput {
@@ -535,6 +536,7 @@ export interface GetPaymentsParams {
 }
 
 export interface GetInvestorsParams {
+	id?: number;
 	page?: number;
 	perPage?: number;
 }

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
@@ -19,6 +19,7 @@ import {
 	Layers,
 	Loader2,
 	Mail,
+	Phone,
 	Plus,
 	RefreshCw,
 	Shield,
@@ -654,18 +655,13 @@ function InvestorLiquidacionesPage() {
 	const [page, setPage] = useState(1);
 	const PER_PAGE = 25;
 
-	// Fetch investor info from list
+	// Fetch investor info by ID from cartera
 	const investorsQuery = useQuery({
 		...orpc.getInversionistas.queryOptions({
-			input: { page: 1, perPage: 100 },
+			input: { id: investorIdNum, page: 1, perPage: 1 },
 		}),
 	});
-	const investor = useMemo(() => {
-		const list = investorsQuery.data?.inversionistas ?? [];
-		return (list as any[]).find(
-			(inv: any) => inv.inversionistaId === investorIdNum,
-		);
-	}, [investorsQuery.data, investorIdNum]);
+	const investor = (investorsQuery.data?.inversionistas as any[])?.[0] ?? null;
 
 	// Fetch rendimiento/stats
 	const rendimientoQuery = useQuery({
@@ -763,6 +759,26 @@ function InvestorLiquidacionesPage() {
 										<p className="truncate font-medium text-xs">
 											{investor.email}
 										</p>
+									</div>
+								</div>
+							)}
+							{investor.celular && (
+								<div className="flex items-center gap-2.5 rounded-lg border bg-card px-3 py-2">
+									<Phone className="h-4 w-4 shrink-0 text-muted-foreground" />
+									<div className="min-w-0">
+										<p className="text-[10px] text-muted-foreground uppercase tracking-wide">
+											Celular
+										</p>
+										<div className="flex flex-wrap gap-1">
+											{investor.celular.split(",").map((num: string) => (
+												<span
+													key={num.trim()}
+													className="rounded bg-muted px-1.5 py-0.5 font-medium font-mono text-xs"
+												>
+													{num.trim()}
+												</span>
+											))}
+										</div>
 									</div>
 								</div>
 							)}


### PR DESCRIPTION
## Summary
- Agrega parámetro `id` opcional a `getInversionistas` para filtrar un solo inversionista desde cartera (evita traer los 100)
- Agrega campo `celular` al tipo `CarteraInversionista` y lo mapea en el endpoint
- Muestra los números de celular como badges separados en la página de liquidaciones del inversionista
- Actualiza schema de cartera-back para columna de celulares

## Test plan
- [ ] Abrir la página de liquidaciones de un inversionista y verificar que carga la info correctamente (sin traer todos los inversionistas)
- [ ] Verificar que los celulares se muestran como badges separados
- [ ] Verificar que la lista general de inversionistas sigue funcionando (sin pasar id)

🤖 Generated with [Claude Code](https://claude.com/claude-code)