### PR TITLE
feat: allow sales role to upload manual vehicle valuation

### DIFF
--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -699,7 +699,9 @@ export const vehiclesRouter = {
 		.handler(async ({ input, context }) => {
 			const userRole = context.userRole || "";
 			const canManageManualValuation =
-				userRole === ROLES.ADMIN || userRole === ROLES.SALES_SUPERVISOR;
+				userRole === ROLES.ADMIN ||
+				userRole === ROLES.SALES_SUPERVISOR ||
+				userRole === ROLES.SALES;
 
 			if (!canManageManualValuation) {
 				throw new ORPCError("FORBIDDEN", {

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -797,7 +797,8 @@ function RouteComponent() {
 	const canFilterBySalesperson =
 		userProfile.data?.role === ROLES.ADMIN ||
 		userProfile.data?.role === ROLES.SALES_SUPERVISOR;
-	const canManageManualVehicleValuation = canFilterBySalesperson;
+	const canManageManualVehicleValuation =
+		canFilterBySalesperson || userProfile.data?.role === ROLES.SALES;
 
 	const crmUsersQuery = useQuery({
 		...orpc.getCrmUsers.queryOptions(),


### PR DESCRIPTION
## Summary
- Habilita el botón "Cargar valores mínimos" para el rol de ventas (`SALES`)
- Agrega `ROLES.SALES` a la validación del endpoint `upsertManualValuation`

## Test plan
- [ ] Iniciar sesión con rol `sales` y verificar que el botón "Cargar valores mínimos" aparece en el detalle de oportunidad
- [ ] Cargar valores mínimos con rol `sales` y verificar que se guardan correctamente
- [ ] Verificar que otros roles sin permiso siguen sin ver el botón

🤖 Generated with [Claude Code](https://claude.com/claude-code)