### PR TITLE
fix: handle investor by id response format in liquidaciones

### DIFF
--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
@@ -661,7 +661,12 @@ function InvestorLiquidacionesPage() {
 			input: { id: investorIdNum, page: 1, perPage: 1 },
 		}),
 	});
-	const investor = (investorsQuery.data?.inversionistas as any[])?.[0] ?? null;
+	const investor = useMemo(() => {
+		const raw = investorsQuery.data?.inversionistas;
+		if (!raw) return null;
+		// Con id cartera devuelve objeto directo, sin id devuelve array
+		return Array.isArray(raw) ? raw[0] ?? null : raw;
+	}, [investorsQuery.data]);
 
 	// Fetch rendimiento/stats
 	const rendimientoQuery = useQuery({


### PR DESCRIPTION
## Summary
- Cuando se pasa `id` a `/investor`, cartera devuelve un objeto directo en vez de array
- Normaliza la respuesta en el frontend (liquidaciones) sin tocar el client ni afectar otros usos

## Test plan
- [ ] Abrir la página de liquidaciones de un inversionista y verificar que carga correctamente
- [ ] Verificar que la lista general de inversionistas (sin id) sigue funcionando

🤖 Generated with [Claude Code](https://claude.com/claude-code)