### PR TITLE
Normalize investor response to array in cobros endpoint

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2139,8 +2139,13 @@ export const cobrosRouter = {
 				const bancos = await carteraBackClient.getBancos();
 				const bancosMap = new Map(bancos.map((b) => [b.banco_id, b.nombre]));
 
+				// Con id cartera devuelve objeto directo, sin id devuelve array
+				const inversionistasList = Array.isArray(result.data)
+					? result.data
+					: [result.data];
+
 				return {
-					inversionistas: result.data.map((inv: any) => ({
+					inversionistas: inversionistasList.map((inv: any) => ({
 						inversionistaId: inv.inversionista_id,
 						nombre: inv.nombre,
 						dpi: inv.dpi ?? null,


### PR DESCRIPTION
This pull request addresses an issue in the `cobrosRouter` where the structure of the `result.data` response could vary between an object and an array, depending on the presence of an ID. The code now ensures consistent handling by always converting `result.data` to an array before mapping.

Data normalization:

* Updated the `cobrosRouter` in `cobros.ts` to normalize `result.data` to an array, ensuring consistent processing whether the response is a single object or an array of objects.