### PR TITLE
refactor: streamline investor liquidation summary generation by simpl…

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4627,10 +4627,6 @@ export async function resumenGlobalLiquidaciones(
     getBoletasLiquidacionMap(inversionistaIds, mes, anio),
   ]);
 
-  const noLiquidadosMap = new Map(
-    noLiquidados.map((inv) => [inv.inversionista_id, inv])
-  );
-
   const result: InversionistaResumenConEstado[] = [];
 
   for (const inv of noLiquidados) {
@@ -4638,9 +4634,7 @@ export async function resumenGlobalLiquidaciones(
     const estadoResumen = resolveEstadoLiquidacionResumen({
       requestedEstado: estado,
       hasNoLiquidado: true,
-      hasLiquidado: liquidados.some(
-        (liq) => liq.inversionista_id === inv.inversionista_id
-      ),
+      hasLiquidado: false, // 🆕 Forzamos false para que el primer loop solo genere estados pendientes/subidos
       hasBoletaPendiente: hasBoletaSubida,
     });
 
@@ -4659,10 +4653,6 @@ export async function resumenGlobalLiquidaciones(
   }
 
   for (const inv of liquidados) {
-    if (noLiquidadosMap.has(inv.inversionista_id)) {
-      continue;
-    }
-
     const estadoResumen = resolveEstadoLiquidacionResumen({
       requestedEstado: estado,
       hasNoLiquidado: false,

--- a/apps/cartera-back/src/utils/investorLiquidationSummary.ts
+++ b/apps/cartera-back/src/utils/investorLiquidationSummary.ts
@@ -29,7 +29,7 @@ export function resolveEstadoLiquidacionResumen({
   }
 
   if (requestedEstado === "liquidated") {
-    return !hasNoLiquidado && hasLiquidado ? "liquidated" : null;
+    return hasLiquidado ? "liquidated" : null;
   }
 
   if (hasNoLiquidado) {


### PR DESCRIPTION
# Fix: Visibilidad de Liquidaciones con Pagos Pendientes

## Descripción del Problema
Se identificó un bug en el reporte global de liquidaciones (`/resumen-global-liquidaciones`) donde los inversionistas que tenían nuevos pagos pendientes (`NO_LIQUIDADO`) desaparecían por completo de la vista de "Liquidados", o sus liquidaciones pasadas quedaban ocultas bajo el estado "Pendiente".

Esto ocurría debido a una lógica de deduplicación que priorizaba el estado pendiente y bloqueaba la visualización de registros históricos si existía deuda nueva en el mes o periodo consultado.

## Cambios Realizados

### 1. Desacoplamiento de Estados (`src/utils/investorLiquidationSummary.ts`)
- Se modificó el `resolveEstadoLiquidacionResumen` para permitir que un inversionista sea categorizado como `liquidated` independientemente de si tiene nuevos saldos pendientes.
- Esto elimina el bloqueo que causaba el flag `hasNoLiquidado` sobre el estado `liquidated`.

### 2. Independencia de Flujos en el Reporte (`src/controllers/investor.ts`)
- Se actualizó `resumenGlobalLiquidaciones` para procesar los pagos pendientes y las liquidaciones pasadas como entidades independientes.
- Se eliminó la lógica de `continue` que descartaba registros de liquidación si el inversionista ya había sido procesado en el bucle de pendientes.
- **Resultado**: Si un inversionista tiene ambos estados (pendientes y liquidados), ahora aparecerán como dos filas separadas en el reporte "Todo", o correctamente filtrados en sus respectivas pestañas, sin que uno oculte al otro.

## Verificación
- [x] Los inversionistas con liquidaciones pasadas ahora son visibles en la pestaña "Liquidado" incluso si tienen nuevos pagos pendientes.
- [x] La vista "Todo" muestra correctamente el desglose de lo que está procesado vs lo que queda por liquidar.
- [x] No hay cambios en la estructura del JSON devuelto, manteniendo la compatibilidad con el frontend.
- [x] El cambio no afecta procesos de escritura, liquidación real o cálculos de saldos en otros módulos.
