### PR TITLE
Moves investor ID to root of reinvestment payload

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -90,7 +90,6 @@ export function ModalReinversionCombinada({
   const handleGuardar = () => {
     // Solo enviar los que el usuario cambió
     const cambios = Object.entries(asignaciones).map(([espejoId, tipo]) => ({
-      id_inversionista: inversionistaId,
       id_credito_inversionista_espejo: Number(espejoId),
       tipo_reinversion: tipo,
     }));
@@ -101,7 +100,7 @@ export function ModalReinversionCombinada({
     }
 
     asignarReinversion(
-      { asignaciones: cambios },
+      { inversionista_id: inversionistaId, asignaciones: cambios },
       {
         onSuccess: () => {
           toast.success("Reinversión combinada guardada correctamente.");

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3175,8 +3175,8 @@ export type TipoReinversionEspejo =
   | "reinversion_combinada";
 
 export interface AsignarReinversionPayload {
+  inversionista_id: number;
   asignaciones: {
-    id_inversionista: number;
     id_credito_inversionista_espejo: number;
     tipo_reinversion: TipoReinversionEspejo;
   }[];


### PR DESCRIPTION
Restructures the combined reinvestment payload by moving the `inversionista_id` from within each `asignacion` object to a top-level property.

This change centralizes the investor ID, reflecting that it pertains to the entire set of reinvestment assignments rather than being a redundant attribute for each individual assignment.