### PR TITLE
fix: add investor ID to individual reinvestment assignments

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -90,6 +90,7 @@ export function ModalReinversionCombinada({
   const handleGuardar = () => {
     // Solo enviar los que el usuario cambió
     const cambios = Object.entries(asignaciones).map(([espejoId, tipo]) => ({
+      id_inversionista: inversionistaId,
       id_credito_inversionista_espejo: Number(espejoId),
       tipo_reinversion: tipo,
     }));

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3177,6 +3177,7 @@ export type TipoReinversionEspejo =
 export interface AsignarReinversionPayload {
   inversionista_id: number;
   asignaciones: {
+    id_inversionista: number;
     id_credito_inversionista_espejo: number;
     tipo_reinversion: TipoReinversionEspejo;
   }[];


### PR DESCRIPTION
Updates the reinvestment payload structure and component logic to include the investor ID within each item of the assignment list, ensuring the backend receives the required context for each record.