### PR TITLE
fix: add accounting permission to shared access middleware

### DIFF
--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -153,10 +153,11 @@ const requireCrmCobrosOrInvestments = o.middleware(async ({ context, next }) => 
 	if (
 		!PERMISSIONS.canAccessCRM(userRole) &&
 		!PERMISSIONS.canAccessCobros(userRole) &&
-		!PERMISSIONS.canAccessInvestments(userRole)
+		!PERMISSIONS.canAccessInvestments(userRole) &&
+		!PERMISSIONS.canAccessAccounting(userRole)
 	) {
 		throw new ORPCError("FORBIDDEN", {
-			message: "CRM, Cobros or Investments access required",
+			message: "CRM, Cobros, Investments or Accounting access required",
 		});
 	}
 


### PR DESCRIPTION
Updates the requireCrmCobrosOrInvestments middleware to include accounting access, ensuring users with the accounting role can access operations previously restricted to CRM, collections, and investments.
