### PR TITLE
feat: implement generic receipts and refactor dashboard navigation

### DIFF
--- a/apps/cartera-back/src/controllers/recibosGenericos.ts
+++ b/apps/cartera-back/src/controllers/recibosGenericos.ts
@@ -1,0 +1,362 @@
+import { eq, and, gte, lte, desc } from "drizzle-orm";
+import { db } from "../database";
+import {
+  recibos_genericos,
+  recibo_generico_montos,
+} from "../database/db";
+import puppeteer from "puppeteer";
+import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+
+const LOGO_URL = process.env.LOGO_URL || "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
+
+// ── CREATE ──
+export async function createReciboGenerico(data: {
+  nombre: string;
+  observaciones?: string;
+  montos: { concepto: string; monto: string }[];
+}) {
+  const [recibo] = await db
+    .insert(recibos_genericos)
+    .values({
+      nombre: data.nombre,
+      observaciones: data.observaciones,
+    })
+    .returning();
+
+  if (data.montos.length > 0) {
+    await db.insert(recibo_generico_montos).values(
+      data.montos.map((m) => ({
+        recibo_id: recibo.id,
+        concepto: m.concepto,
+        monto: m.monto,
+      }))
+    );
+  }
+
+  const montos = await db
+    .select()
+    .from(recibo_generico_montos)
+    .where(eq(recibo_generico_montos.recibo_id, recibo.id));
+
+  return { ...recibo, montos };
+}
+
+// ── GET ALL (filtro por fecha) ──
+export async function getRecibosGenericos(filters?: {
+  fecha_desde?: string;
+  fecha_hasta?: string;
+}) {
+  const conditions = [];
+
+  if (filters?.fecha_desde) {
+    conditions.push(gte(recibos_genericos.fecha, new Date(filters.fecha_desde)));
+  }
+  if (filters?.fecha_hasta) {
+    conditions.push(lte(recibos_genericos.fecha, new Date(filters.fecha_hasta)));
+  }
+
+  const recibos = await db
+    .select()
+    .from(recibos_genericos)
+    .where(conditions.length > 0 ? and(...conditions) : undefined)
+    .orderBy(desc(recibos_genericos.fecha));
+
+  const result = await Promise.all(
+    recibos.map(async (r) => {
+      const montos = await db
+        .select()
+        .from(recibo_generico_montos)
+        .where(eq(recibo_generico_montos.recibo_id, r.id));
+      return { ...r, montos };
+    })
+  );
+
+  return result;
+}
+
+// ── GET BY ID ──
+export async function getReciboGenericoById(id: number) {
+  const [recibo] = await db
+    .select()
+    .from(recibos_genericos)
+    .where(eq(recibos_genericos.id, id));
+
+  if (!recibo) return null;
+
+  const montos = await db
+    .select()
+    .from(recibo_generico_montos)
+    .where(eq(recibo_generico_montos.recibo_id, id));
+
+  return { ...recibo, montos };
+}
+
+// ── UPDATE ──
+export async function updateReciboGenerico(
+  id: number,
+  data: {
+    nombre?: string;
+    observaciones?: string;
+    montos?: { concepto: string; monto: string }[];
+  }
+) {
+  const updateFields: Record<string, any> = {};
+  if (data.nombre !== undefined) updateFields.nombre = data.nombre;
+  if (data.observaciones !== undefined) updateFields.observaciones = data.observaciones;
+
+  if (Object.keys(updateFields).length > 0) {
+    await db
+      .update(recibos_genericos)
+      .set(updateFields)
+      .where(eq(recibos_genericos.id, id));
+  }
+
+  if (data.montos !== undefined) {
+    await db
+      .delete(recibo_generico_montos)
+      .where(eq(recibo_generico_montos.recibo_id, id));
+
+    if (data.montos.length > 0) {
+      await db.insert(recibo_generico_montos).values(
+        data.montos.map((m) => ({
+          recibo_id: id,
+          concepto: m.concepto,
+          monto: m.monto,
+        }))
+      );
+    }
+  }
+
+  return getReciboGenericoById(id);
+}
+
+// ── DELETE ──
+export async function deleteReciboGenerico(id: number) {
+  const [deleted] = await db
+    .delete(recibos_genericos)
+    .where(eq(recibos_genericos.id, id))
+    .returning();
+
+  return deleted ?? null;
+}
+
+// ── GENERAR PDF Y SUBIR A R2 ──
+export async function generateReciboGenericoPDF(reciboId: number) {
+  const recibo = await getReciboGenericoById(reciboId);
+  if (!recibo) {
+    throw new Error(`No se encontró el recibo con ID ${reciboId}`);
+  }
+
+  const formatQ = (n: number) =>
+    `Q${n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+  const fechaRecibo = recibo.fecha
+    ? new Date(recibo.fecha).toLocaleDateString("es-GT", {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      })
+    : "N/A";
+
+  const totalMonto = recibo.montos.reduce(
+    (sum, m) => sum + Number(m.monto || 0),
+    0
+  );
+
+  const desgloseRows = recibo.montos
+    .map((m) => `<tr><td>${m.concepto}</td><td>${formatQ(Number(m.monto))}</td></tr>`)
+    .join("");
+
+  const html = `
+  <!DOCTYPE html>
+  <html>
+  <head>
+    <meta charset="UTF-8">
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      body { font-family: 'Segoe UI', Arial, sans-serif; background: #f5f5f5; padding: 40px; }
+      .recibo {
+        max-width: 500px;
+        margin: 0 auto;
+        background: #fff;
+        border-radius: 12px;
+        box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+        overflow: hidden;
+      }
+      .header {
+        background: linear-gradient(135deg, #1F4E79, #2E75B6);
+        color: #fff;
+        padding: 30px 30px 25px;
+        text-align: center;
+      }
+      .header img { width: 120px; margin-bottom: 12px; }
+      .header h1 { font-size: 20px; font-weight: 600; margin-bottom: 4px; }
+      .header p { font-size: 12px; opacity: 0.85; }
+      .badge {
+        display: inline-block;
+        background: rgba(255,255,255,0.2);
+        padding: 4px 14px;
+        border-radius: 20px;
+        font-size: 11px;
+        margin-top: 10px;
+        letter-spacing: 0.5px;
+      }
+      .body { padding: 25px 30px; }
+      .info-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 12px;
+        margin-bottom: 20px;
+      }
+      .info-item {
+        background: #f8fafc;
+        border-radius: 8px;
+        padding: 10px 12px;
+      }
+      .info-item.full { grid-column: 1 / -1; }
+      .info-label {
+        font-size: 10px;
+        color: #8899a6;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 2px;
+      }
+      .info-value {
+        font-size: 13px;
+        color: #1a1a2e;
+        font-weight: 500;
+      }
+      .divider {
+        border: none;
+        border-top: 1px dashed #e0e0e0;
+        margin: 20px 0;
+      }
+      .desglose h3 {
+        font-size: 13px;
+        color: #1F4E79;
+        margin-bottom: 10px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .desglose table { width: 100%; border-collapse: collapse; }
+      .desglose td {
+        padding: 8px 0;
+        font-size: 13px;
+        color: #333;
+      }
+      .desglose td:last-child { text-align: right; font-weight: 500; }
+      .desglose tr:not(:last-child) td { border-bottom: 1px solid #f0f0f0; }
+      .total-row {
+        background: linear-gradient(135deg, #1F4E79, #2E75B6);
+        border-radius: 8px;
+        padding: 14px 16px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-top: 16px;
+      }
+      .total-row span:first-child {
+        color: rgba(255,255,255,0.85);
+        font-size: 13px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+      .total-row span:last-child {
+        color: #fff;
+        font-size: 20px;
+        font-weight: 700;
+      }
+      .footer {
+        background: #f8fafc;
+        padding: 16px 30px;
+        text-align: center;
+        border-top: 1px solid #eee;
+      }
+      .footer p { font-size: 10px; color: #999; }
+      ${recibo.observaciones ? `.obs { background: #fffbeb; border-left: 3px solid #f59e0b; padding: 10px 12px; border-radius: 0 6px 6px 0; margin-top: 16px; font-size: 12px; color: #92400e; }` : ""}
+    </style>
+  </head>
+  <body>
+    <div class="recibo">
+      <div class="header">
+        <img src="${LOGO_URL}" alt="Cash-In" />
+        <h1>Recibo</h1>
+        <p>Club Cash-In</p>
+        <div class="badge">No. ${recibo.id}</div>
+      </div>
+      <div class="body">
+        <div class="info-grid">
+          <div class="info-item full">
+            <div class="info-label">Nombre</div>
+            <div class="info-value">${recibo.nombre}</div>
+          </div>
+          <div class="info-item full">
+            <div class="info-label">Fecha</div>
+            <div class="info-value">${fechaRecibo}</div>
+          </div>
+        </div>
+
+        <hr class="divider" />
+
+        <div class="desglose">
+          <h3>Detalle</h3>
+          <table>
+            ${desgloseRows}
+          </table>
+        </div>
+
+        <div class="total-row">
+          <span>Total</span>
+          <span>${formatQ(totalMonto)}</span>
+        </div>
+
+        ${recibo.observaciones ? `<div class="obs">${recibo.observaciones}</div>` : ""}
+      </div>
+      <div class="footer">
+        <p>Este documento es un recibo generado por el sistema de Club Cash-In.</p>
+        <p>Generado el ${new Date().toLocaleDateString("es-GT", { year: "numeric", month: "long", day: "numeric", hour: "2-digit", minute: "2-digit" })}</p>
+      </div>
+    </div>
+  </body>
+  </html>`;
+
+  // Generar PDF con Puppeteer
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
+  const page = await browser.newPage();
+  await page.setContent(html, { waitUntil: "networkidle0" });
+  const pdfData = await page.pdf({
+    format: "A4",
+    printBackground: true,
+    margin: { top: "10mm", bottom: "10mm", left: "10mm", right: "10mm" },
+  });
+  await browser.close();
+
+  // Subir a R2
+  const fileBuffer = Buffer.from(pdfData);
+  const filename = `recibos/recibo_generico_${reciboId}_${Date.now()}.pdf`;
+  const s3 = new S3Client({
+    endpoint: process.env.BUCKET_REPORTS_URL,
+    region: "auto",
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID as string,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY as string,
+    },
+  });
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: process.env.BUCKET_REPORTS as string,
+      Key: filename,
+      Body: fileBuffer,
+      ContentType: "application/pdf",
+    })
+  );
+
+  const url = `${process.env.URL_PUBLIC_R2_REPORTS}/${filename}`;
+  console.log("✅ Recibo genérico PDF subido:", url);
+
+  return { pdfUrl: url };
+}

--- a/apps/cartera-back/src/controllers/recibosGenericos.ts
+++ b/apps/cartera-back/src/controllers/recibosGenericos.ts
@@ -13,6 +13,8 @@ const LOGO_URL = process.env.LOGO_URL || "https://pub-8081c8d6e5e743f9adfc9e0db9
 export async function createReciboGenerico(data: {
   nombre: string;
   observaciones?: string;
+  fecha?: string;
+  moneda?: string;
   montos: { concepto: string; monto: string }[];
 }) {
   const [recibo] = await db
@@ -20,6 +22,8 @@ export async function createReciboGenerico(data: {
     .values({
       nombre: data.nombre,
       observaciones: data.observaciones,
+      ...(data.fecha ? { fecha: new Date(data.fecha) } : {}),
+      ...(data.moneda ? { moneda: data.moneda } : {}),
     })
     .returning();
 
@@ -97,12 +101,14 @@ export async function updateReciboGenerico(
   data: {
     nombre?: string;
     observaciones?: string;
+    moneda?: string;
     montos?: { concepto: string; monto: string }[];
   }
 ) {
   const updateFields: Record<string, any> = {};
   if (data.nombre !== undefined) updateFields.nombre = data.nombre;
   if (data.observaciones !== undefined) updateFields.observaciones = data.observaciones;
+  if (data.moneda !== undefined) updateFields.moneda = data.moneda;
 
   if (Object.keys(updateFields).length > 0) {
     await db
@@ -147,8 +153,9 @@ export async function generateReciboGenericoPDF(reciboId: number) {
     throw new Error(`No se encontró el recibo con ID ${reciboId}`);
   }
 
+  const simbolo = recibo.moneda === "USD" ? "$" : "Q";
   const formatQ = (n: number) =>
-    `Q${n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+    `${simbolo}${n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 
   const fechaRecibo = recibo.fecha
     ? new Date(recibo.fecha).toLocaleDateString("es-GT", {

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -969,3 +969,24 @@
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
   });
+
+  // ── Recibos genéricos (sin FK a créditos) ──
+  export const recibos_genericos = customSchema.table("recibos_genericos", {
+    id: serial("id").primaryKey(),
+    nombre: varchar("nombre", { length: 200 }).notNull(),
+    observaciones: text("observaciones"),
+    fecha: timestamp("fecha", { withTimezone: true })
+      .notNull()
+      .default(sql`NOW() AT TIME ZONE 'America/Guatemala'`),
+    created_at: timestamp("created_at", { withTimezone: true })
+      .default(sql`NOW() AT TIME ZONE 'America/Guatemala'`),
+  });
+
+  export const recibo_generico_montos = customSchema.table("recibo_generico_montos", {
+    id: serial("id").primaryKey(),
+    recibo_id: integer("recibo_id")
+      .notNull()
+      .references(() => recibos_genericos.id, { onDelete: "cascade" }),
+    concepto: varchar("concepto", { length: 300 }).notNull(),
+    monto: numeric("monto", { precision: 18, scale: 2 }).notNull(),
+  });

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -975,6 +975,7 @@
     id: serial("id").primaryKey(),
     nombre: varchar("nombre", { length: 200 }).notNull(),
     observaciones: text("observaciones"),
+    moneda: varchar("moneda", { length: 10 }).notNull().default("GTQ"),
     fecha: timestamp("fecha", { withTimezone: true })
       .notNull()
       .default(sql`NOW() AT TIME ZONE 'America/Guatemala'`),

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -30,7 +30,8 @@ const app = new Elysia()
   .use(routers.notificationsRouter)
   .use(routers.reconcileEspejoRouter)
   .use(routers.investorDocumentsRouter)
-  .use(routers.abonosCapitalRouter);
+  .use(routers.abonosCapitalRouter)
+  .use(routers.recibosGenericosRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor
 iniciarTareasProgramadas();

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -18,6 +18,7 @@ import { notificationsRouter } from "./notifications";
 import { reconcileEspejoRouter } from "./reconcileEspejo";
 import { investorDocumentsRouter } from "./investorDocuments";
 import { abonosCapitalRouter } from "./abonosCapital";
+import { recibosGenericosRouter } from "./recibosGenericos";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter
 }   

--- a/apps/cartera-back/src/routers/recibosGenericos.ts
+++ b/apps/cartera-back/src/routers/recibosGenericos.ts
@@ -1,0 +1,147 @@
+import { Elysia, t } from "elysia";
+import {
+  createReciboGenerico,
+  getRecibosGenericos,
+  getReciboGenericoById,
+  updateReciboGenerico,
+  deleteReciboGenerico,
+  generateReciboGenericoPDF,
+} from "../controllers/recibosGenericos";
+import { authMiddleware } from "./midleware";
+
+export const recibosGenericosRouter = new Elysia({
+  prefix: "/recibos-genericos",
+})
+  .use(authMiddleware)
+
+  // CREATE
+  .post(
+    "/",
+    async ({ body, set }) => {
+      try {
+        const recibo = await createReciboGenerico(body);
+        set.status = 201;
+        return recibo;
+      } catch (err: any) {
+        set.status = 500;
+        return { message: err.message };
+      }
+    },
+    {
+      body: t.Object({
+        nombre: t.String(),
+        observaciones: t.Optional(t.String()),
+        montos: t.Array(
+          t.Object({
+            concepto: t.String(),
+            monto: t.String(),
+          })
+        ),
+      }),
+    }
+  )
+
+  // GET ALL (filtro por fecha)
+  .get(
+    "/",
+    async ({ query, set }) => {
+      try {
+        const recibos = await getRecibosGenericos({
+          fecha_desde: query.fecha_desde,
+          fecha_hasta: query.fecha_hasta,
+        });
+        return recibos;
+      } catch (err: any) {
+        set.status = 500;
+        return { message: err.message };
+      }
+    },
+    {
+      query: t.Object({
+        fecha_desde: t.Optional(t.String()),
+        fecha_hasta: t.Optional(t.String()),
+      }),
+    }
+  )
+
+  // GET BY ID
+  .get(
+    "/:id",
+    async ({ params: { id }, set }) => {
+      try {
+        const recibo = await getReciboGenericoById(parseInt(id));
+        if (!recibo) {
+          set.status = 404;
+          return { message: "Recibo no encontrado" };
+        }
+        return recibo;
+      } catch (err: any) {
+        set.status = 500;
+        return { message: err.message };
+      }
+    }
+  )
+
+  // UPDATE
+  .put(
+    "/:id",
+    async ({ params: { id }, body, set }) => {
+      try {
+        const recibo = await updateReciboGenerico(parseInt(id), body);
+        if (!recibo) {
+          set.status = 404;
+          return { message: "Recibo no encontrado" };
+        }
+        return recibo;
+      } catch (err: any) {
+        set.status = 500;
+        return { message: err.message };
+      }
+    },
+    {
+      body: t.Object({
+        nombre: t.Optional(t.String()),
+        observaciones: t.Optional(t.String()),
+        montos: t.Optional(
+          t.Array(
+            t.Object({
+              concepto: t.String(),
+              monto: t.String(),
+            })
+          )
+        ),
+      }),
+    }
+  )
+
+  // DELETE
+  .delete(
+    "/:id",
+    async ({ params: { id }, set }) => {
+      try {
+        const deleted = await deleteReciboGenerico(parseInt(id));
+        if (!deleted) {
+          set.status = 404;
+          return { message: "Recibo no encontrado" };
+        }
+        return { message: "Recibo eliminado", recibo: deleted };
+      } catch (err: any) {
+        set.status = 500;
+        return { message: err.message };
+      }
+    }
+  )
+
+  // GENERAR PDF
+  .get(
+    "/:id/pdf",
+    async ({ params: { id }, set }) => {
+      try {
+        const result = await generateReciboGenericoPDF(parseInt(id));
+        return result;
+      } catch (err: any) {
+        set.status = err.message?.includes("No se encontró") ? 404 : 500;
+        return { message: err.message };
+      }
+    }
+  );

--- a/apps/cartera-back/src/routers/recibosGenericos.ts
+++ b/apps/cartera-back/src/routers/recibosGenericos.ts
@@ -31,6 +31,8 @@ export const recibosGenericosRouter = new Elysia({
       body: t.Object({
         nombre: t.String(),
         observaciones: t.Optional(t.String()),
+        fecha: t.Optional(t.String()),
+        moneda: t.Optional(t.String()),
         montos: t.Array(
           t.Object({
             concepto: t.String(),
@@ -102,6 +104,7 @@ export const recibosGenericosRouter = new Elysia({
       body: t.Object({
         nombre: t.Optional(t.String()),
         observaciones: t.Optional(t.String()),
+        moneda: t.Optional(t.String()),
         montos: t.Optional(
           t.Array(
             t.Object({

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -16,6 +16,7 @@ import { CreatePaymentAgreementForm } from "./private/cartera/components/payment
 import { FacturasGenericas } from "./private/cartera/components/FacturasGenericas";
 import EfectividadAsesores from "./private/cartera/components/EfectividadAsesores";
 import { HistorialLiquidaciones } from "./private/cartera/components/HistorialLiquidaciones";
+import { RecibosGenericos } from "./private/recibos-genericos/components/RecibosGenericos";
 
 // 🔒 Rutas privadas
 function PrivateRoute({ children }: { children: JSX.Element }) {
@@ -187,6 +188,15 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN", "ASESOR"]}>
               <EfectividadAsesores />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="recibos-genericos"
+          element={
+            <RoleRoute allowedRoles={["ADMIN"]}>
+              <RecibosGenericos />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -210,6 +210,7 @@ export function ModalEditCredit({
         capital: Number(values.capital),
         porcentaje_interes: Number(values.porcentaje_interes),
         plazo: Number(values.plazo),
+        asesor_id: Number(values.asesor_id) || undefined,
 
         observaciones: values.observaciones ?? "",
         mora: Number(values.mora ?? 0),

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -49,6 +49,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { DollarSign, Pencil } from "lucide-react";
+import { toast } from "sonner";
 // Iconos y colores por atributo
 const iconMap: Record<string, { icon: React.ReactNode; color: string }> = {
   pago_id: {
@@ -164,16 +165,18 @@ const EDIT_FIELDS: EditField[] = [
   { key: "abono_iva_12", label: "Abono IVA 12%", group: "abonos" },
   { key: "abono_seguro", label: "Abono Seguro", group: "abonos" },
   { key: "abono_gps", label: "Abono GPS", group: "abonos" },
+  { key: "membresias_pago", label: "Membresías Pago", group: "abonos" },
+  { key: "membresias_mes", label: "Membresías Mes", group: "abonos" },
   { key: "capital_restante", label: "Capital Restante", group: "restantes" },
   { key: "interes_restante", label: "Interés Restante", group: "restantes" },
   { key: "iva_12_restante", label: "IVA 12% Restante", group: "restantes" },
   { key: "seguro_restante", label: "Seguro Restante", group: "restantes" },
   { key: "gps_restante", label: "GPS Restante", group: "restantes" },
+  { key: "membresias", label: "Membresías Restante", group: "restantes" },
   { key: "monto_boleta", label: "Monto Boleta", group: "general" },
   { key: "monto_aplicado", label: "Monto Aplicado", group: "general" },
   { key: "mora", label: "Mora", group: "general" },
   { key: "otros", label: "Otros", group: "general" },
-  { key: "membresias", label: "Membresías", group: "general" },
   { key: "observaciones", label: "Observaciones", group: "general" },
 ];
 
@@ -228,9 +231,9 @@ function EditPaymentModal({
       { pagoId: pago.pago_id, params: payload },
       {
         onSuccess: () => {
+          onClose();
           toast.success("Pago actualizado correctamente");
           onSuccess();
-          onClose();
         },
         onError: (error: any) => {
           toast.error(error?.response?.data?.message || "Error al actualizar pago");

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -7,9 +7,16 @@ import {
   Landmark,
   ChevronDown,
   Receipt,
+  Users,
+  TrendingUp,
+  FolderOpen,
+  FileText,
+  Settings,
+  BarChart3,
+  Briefcase,
 } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { Menu, X } from "lucide-react";
 import { useAuth } from "@/Provider/authProvider";
 import {
@@ -20,99 +27,239 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 
-const menuOptions = [
+// --- Secciones del menú ---
+interface MenuItem {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  path: string;
+  roles: string[];
+}
+
+interface MenuSection {
+  key: string;
+  label: string;
+  icon: React.ReactNode;
+  items: MenuItem[];
+}
+
+const menuSections: MenuSection[] = [
   {
-    key: "registro-prestamo",
-    label: "Registro Crédito",
-    icon: <Banknote className="h-5 w-5" />,
-    path: "/realizarCredito",
-    roles: ["ADMIN"],
+    key: "operaciones",
+    label: "Operaciones",
+    icon: <Banknote className="h-4 w-4" />,
+    items: [
+      {
+        key: "registro-prestamo",
+        label: "Registro Crédito",
+        icon: <Banknote className="h-4 w-4" />,
+        path: "/realizarCredito",
+        roles: ["ADMIN"],
+      },
+      {
+        key: "registro-pago",
+        label: "Registro Pago",
+        icon: <CreditCard className="h-4 w-4" />,
+        path: "/realizarPago",
+        roles: ["ADMIN", "ASESOR"],
+      },
+    ],
   },
   {
-    key: "registro-pago",
-    label: "Registro Pago",
-    icon: <CreditCard className="h-5 w-5" />,
-    path: "/realizarPago",
-    roles: ["ADMIN", "ASESOR"],
+    key: "cartera",
+    label: "Cartera",
+    icon: <Briefcase className="h-4 w-4" />,
+    items: [
+      {
+        key: "total-prestamos",
+        label: "Créditos",
+        icon: <ListOrdered className="h-4 w-4" />,
+        path: "/creditos",
+        roles: ["ADMIN", "CONTA", "ASESOR"],
+      },
+      {
+        key: "total-pagos",
+        label: "Pagos",
+        icon: <ListOrdered className="h-4 w-4" />,
+        path: "/pagos",
+        roles: ["ADMIN", "CONTA", "ASESOR"],
+      },
+      {
+        key: "late-fee",
+        label: "Moras",
+        icon: <ListOrdered className="h-4 w-4" />,
+        path: "/mora",
+        roles: ["ADMIN"],
+      },
+      {
+        key: "payment-agreements",
+        label: "Convenios",
+        icon: <ListOrdered className="h-4 w-4" />,
+        path: "/convenios",
+        roles: ["ADMIN", "ASESOR"],
+      },
+    ],
   },
   {
-    key: "total-prestamos",
-    label: "Créditos",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/creditos",
-    roles: ["ADMIN", "CONTA", "ASESOR"],
-  },
-  {
-    key: "total-pagos",
-    label: "Pagos",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/pagos",
-    roles: ["ADMIN", "CONTA", "ASESOR"],
-  },
-  {
-    key: "investors",
+    key: "inversionistas",
     label: "Inversionistas",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/inversionistas",
-    roles: ["ADMIN"],
+    icon: <TrendingUp className="h-4 w-4" />,
+    items: [
+      {
+        key: "investors",
+        label: "Inversionistas",
+        icon: <Users className="h-4 w-4" />,
+        path: "/inversionistas",
+        roles: ["ADMIN"],
+      },
+      {
+        key: "liquidaciones-inversionistas",
+        label: "Liquidaciones",
+        icon: <Receipt className="h-4 w-4" />,
+        path: "/liquidaciones-inversionistas",
+        roles: ["ADMIN"],
+      },
+    ],
   },
   {
-    key: "liquidaciones-inversionistas",
-    label: "Liquidaciones Inversionistas",
-    icon: <Receipt className="h-5 w-5" />,
-    path: "/liquidaciones-inversionistas",
-    roles: ["ADMIN"],
+    key: "documentos",
+    label: "Documentos",
+    icon: <FolderOpen className="h-4 w-4" />,
+    items: [
+      {
+        key: "facturas-genericas",
+        label: "Facturas Genéricas",
+        icon: <FileText className="h-4 w-4" />,
+        path: "/facturas-genericas",
+        roles: ["ADMIN"],
+      },
+      {
+        key: "recibos-genericos",
+        label: "Recibos Genéricos",
+        icon: <Receipt className="h-4 w-4" />,
+        path: "/recibos-genericos",
+        roles: ["ADMIN"],
+      },
+    ],
   },
   {
-    key: "advisors",
-    label: "Usuarios",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/usuarios",
-    roles: ["ADMIN"],
+    key: "administracion",
+    label: "Administración",
+    icon: <Settings className="h-4 w-4" />,
+    items: [
+      {
+        key: "advisors",
+        label: "Usuarios",
+        icon: <Users className="h-4 w-4" />,
+        path: "/usuarios",
+        roles: ["ADMIN"],
+      },
+      {
+        key: "banks-fee",
+        label: "Bancos",
+        icon: <Landmark className="h-4 w-4" />,
+        path: "/bancos",
+        roles: ["ADMIN"],
+      },
+    ],
   },
   {
-    key: "late-fee",
-    label: "Moras",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/mora",
-    roles: ["ADMIN"],
-  },
-  {
-    key: "banks-fee",
-    label: "Bancos",
-    icon: <Landmark className="h-5 w-5" />,
-    path: "/bancos",
-    roles: ["ADMIN"],
-  },
-  {
-    key: "summary-advisors",
-    label: "Resumen de Asesores",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/resumenAsesores",
-    roles: ["ADMIN", "ASESOR"],
-  },
-  {
-    key: "payment-agreements",
-    label: "Convenios",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/convenios",
-    roles: ["ADMIN", "ASESOR"],
-  },
-  {
-    key: "facturas-genericas",
-    label: "Facturas Genéricas",
-    icon: <Receipt className="h-5 w-5" />,
-    path: "/facturas-genericas",
-    roles: ["ADMIN"],
-  },
-  {
-    key: "efectividad-asesores",
-    label: "Efectividad",
-    icon: <ListOrdered className="h-5 w-5" />,
-    path: "/efectividad-asesores",
-    roles: ["ADMIN", "ASESOR"],
+    key: "reportes",
+    label: "Reportes",
+    icon: <BarChart3 className="h-4 w-4" />,
+    items: [
+      {
+        key: "summary-advisors",
+        label: "Resumen de Asesores",
+        icon: <ListOrdered className="h-4 w-4" />,
+        path: "/resumenAsesores",
+        roles: ["ADMIN", "ASESOR"],
+      },
+      {
+        key: "efectividad-asesores",
+        label: "Efectividad",
+        icon: <BarChart3 className="h-4 w-4" />,
+        path: "/efectividad-asesores",
+        roles: ["ADMIN", "ASESOR"],
+      },
+    ],
   },
 ];
+
+// --- Dropdown para desktop ---
+function NavDropdown({
+  section,
+  userRole,
+  navigate,
+  currentPath,
+}: {
+  section: MenuSection;
+  userRole: string;
+  navigate: (path: string) => void;
+  currentPath: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const filteredItems = section.items.filter((item) =>
+    item.roles.includes(userRole)
+  );
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  if (filteredItems.length === 0) return null;
+
+  const isActive = filteredItems.some((item) => item.path === currentPath);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className={`flex items-center gap-1.5 px-3 py-2 rounded-lg font-medium transition-all duration-200 whitespace-nowrap text-sm ${
+          isActive
+            ? "bg-blue-600 text-white shadow-md"
+            : "text-gray-700 hover:bg-blue-100"
+        }`}
+      >
+        {section.icon}
+        <span>{section.label}</span>
+        <ChevronDown
+          className={`h-3.5 w-3.5 transition-transform duration-200 ${open ? "rotate-180" : ""}`}
+        />
+      </button>
+
+      {open && (
+        <div className="absolute top-full left-0 mt-1.5 bg-white rounded-xl shadow-xl border border-blue-100 py-1.5 min-w-[200px] z-50 animate-in fade-in slide-in-from-top-1 duration-150">
+          {filteredItems.map((item) => (
+            <button
+              key={item.key}
+              onClick={() => {
+                navigate(item.path);
+                setOpen(false);
+              }}
+              className={`w-full flex items-center gap-2.5 px-4 py-2.5 text-sm font-medium transition-colors ${
+                currentPath === item.path
+                  ? "bg-blue-50 text-blue-700"
+                  : "text-gray-700 hover:bg-gray-50"
+              }`}
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
 
 export function DashBoardCartera() {
   const navigate = useNavigate();
@@ -125,15 +272,21 @@ export function DashBoardCartera() {
     navigate("/login", { replace: true });
   };
 
-  const filteredOptions = menuOptions.filter((opt) =>
-    user ? opt.roles.includes(user.role) : false
-  );
+  // Flat list for mobile drawer
+  const allFilteredItems = menuSections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) =>
+        user ? item.roles.includes(user.role) : false
+      ),
+    }))
+    .filter((section) => section.items.length > 0);
 
   return (
     <>
-      {/* 🔥 NAVBAR DESKTOP (1280px+) - 100% ANCHO, CENTRADO */}
+      {/* NAVBAR DESKTOP (1280px+) */}
       <nav className="hidden xl:flex fixed top-0 left-0 right-0 z-40 bg-gradient-to-r from-white via-blue-50 to-white border-b-4 border-blue-600 shadow-lg">
-        <div className="w-full px-6 flex items-center justify-center gap-4 py-3 min-h-[64px]">
+        <div className="w-full px-6 flex items-center justify-center gap-3 py-3 min-h-[64px]">
           {/* Logo */}
           <div className="flex items-center flex-shrink-0">
             <img
@@ -144,22 +297,18 @@ export function DashBoardCartera() {
             />
           </div>
 
-          {/* Menu Items - Centrado con wrap */}
-          <div className="flex items-center justify-center gap-2 flex-wrap flex-1">
-            {filteredOptions.map((opt) => (
-              <button
-                key={opt.key}
-                onClick={() => navigate(opt.path)}
-                className={`flex items-center gap-1.5 px-3 py-2 rounded-lg font-medium transition-all duration-200 whitespace-nowrap text-sm ${
-                  location.pathname === opt.path
-                    ? "bg-blue-600 text-white shadow-md scale-105"
-                    : "text-gray-700 hover:bg-blue-100 hover:scale-105"
-                }`}
-              >
-                {opt.icon}
-                <span>{opt.label}</span>
-              </button>
-            ))}
+          {/* Menu Sections - Dropdowns */}
+          <div className="flex items-center justify-center gap-1 flex-wrap flex-1">
+            {user &&
+              menuSections.map((section) => (
+                <NavDropdown
+                  key={section.key}
+                  section={section}
+                  userRole={user.role}
+                  navigate={navigate}
+                  currentPath={location.pathname}
+                />
+              ))}
           </div>
 
           {/* User Info + Logout */}
@@ -184,7 +333,7 @@ export function DashBoardCartera() {
         </div>
       </nav>
 
-      {/* 🔥 NAVBAR MOBILE/TABLET (hasta 1280px) - 100% ANCHO, CENTRADO */}
+      {/* NAVBAR MOBILE/TABLET (hasta 1280px) */}
       <nav className="xl:hidden fixed top-0 left-0 right-0 z-40 bg-gradient-to-r from-white via-blue-50 to-white border-b-4 border-blue-600 shadow-lg h-16">
         <div className="w-full h-full px-4 flex items-center justify-between">
           {/* Hamburguesa */}
@@ -241,7 +390,7 @@ export function DashBoardCartera() {
         </div>
       </nav>
 
-      {/* 🔥 DRAWER MOBILE/TABLET */}
+      {/* DRAWER MOBILE/TABLET */}
       {menuOpen && (
         <div className="fixed inset-0 z-50 flex xl:hidden">
           {/* Overlay */}
@@ -281,28 +430,37 @@ export function DashBoardCartera() {
               )}
             </div>
 
-            {/* Menu Items */}
+            {/* Menu Items por sección */}
             <div className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-4">
-              <div className="flex flex-col gap-2">
-                {filteredOptions.map((opt) => (
-                  <button
-                    key={opt.key}
-                    onClick={() => {
-                      navigate(opt.path);
-                      setMenuOpen(false);
-                    }}
-                    className={`flex items-center gap-3 px-4 py-3 rounded-lg font-medium transition-all duration-200 text-left ${
-                      location.pathname === opt.path
-                        ? "bg-blue-600 text-white shadow-md"
-                        : "text-gray-700 hover:bg-blue-100"
-                    }`}
-                  >
-                    {opt.icon}
-                    <span>{opt.label}</span>
-                  </button>
+              <div className="flex flex-col gap-1">
+                {allFilteredItems.map((section, idx) => (
+                  <div key={section.key}>
+                    {idx > 0 && <div className="my-2 border-t border-blue-100" />}
+                    <p className="px-4 py-2 text-xs font-bold text-blue-500 uppercase tracking-wider flex items-center gap-2">
+                      {section.icon}
+                      {section.label}
+                    </p>
+                    {section.items.map((item) => (
+                      <button
+                        key={item.key}
+                        onClick={() => {
+                          navigate(item.path);
+                          setMenuOpen(false);
+                        }}
+                        className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-lg font-medium transition-all duration-200 text-left text-sm ${
+                          location.pathname === item.path
+                            ? "bg-blue-600 text-white shadow-md"
+                            : "text-gray-700 hover:bg-blue-100"
+                        }`}
+                      >
+                        {item.icon}
+                        <span>{item.label}</span>
+                      </button>
+                    ))}
+                  </div>
                 ))}
 
-                {/* Logout en el drawer */}
+                {/* Logout */}
                 <div className="mt-4 pt-4 border-t border-blue-200">
                   <button
                     onClick={() => {

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -754,6 +754,7 @@ export interface EditPaymentParams {
   gps_restante?: string;
   membresias?: string;
   membresias_pago?: string;
+  membresias_mes?: string;
   otros?: string;
   mora?: string;
   monto_boleta?: string;

--- a/apps/carteraFront/src/private/recibos-genericos/components/RecibosGenericos.tsx
+++ b/apps/carteraFront/src/private/recibos-genericos/components/RecibosGenericos.tsx
@@ -27,15 +27,15 @@ import {
   useDeleteReciboGenerico,
   useReciboGenericoPdf,
 } from "../hooks/useRecibosGenericos";
-import type { ReciboGenerico } from "../services/services";
+import type { ReciboGenerico, MonedaRecibo } from "../services/services";
 
 // --- Utilidades ---
-const formatCurrency = (val?: string | number | null) =>
+const formatCurrency = (val?: string | number | null, moneda: MonedaRecibo = "GTQ") =>
   val == null || isNaN(Number(val))
     ? "--"
-    : Number(val).toLocaleString("es-GT", {
+    : Number(val).toLocaleString(moneda === "USD" ? "en-US" : "es-GT", {
         style: "currency",
-        currency: "GTQ",
+        currency: moneda,
         minimumFractionDigits: 2,
       });
 
@@ -74,17 +74,22 @@ export function RecibosGenericos() {
 
   const isSaving = isCreando || isActualizando;
 
+  const todayStr = new Date().toISOString().split("T")[0];
+
   // Formik
   const formik = useFormik({
     initialValues: {
       nombre: "",
+      fecha: todayStr,
+      moneda: "GTQ" as MonedaRecibo,
       observaciones: "",
       montos: [{ concepto: "", monto: "" }] as { concepto: string; monto: string }[],
     },
-    enableReinitialize: true,
+    enableReinitialize: false,
     validate: (values) => {
       const errors: any = {};
       if (!values.nombre.trim()) errors.nombre = "El nombre es requerido";
+      if (!values.fecha) errors.fecha = "La fecha es requerida";
       if (values.montos.length === 0) errors.montos = "Debe agregar al menos un monto";
       const montosErrors: any[] = [];
       values.montos.forEach((m, i) => {
@@ -99,6 +104,8 @@ export function RecibosGenericos() {
     onSubmit: (values, { resetForm }) => {
       const payload = {
         nombre: values.nombre.trim(),
+        fecha: values.fecha ? `${values.fecha}T12:00:00` : undefined,
+        moneda: values.moneda,
         observaciones: values.observaciones.trim() || undefined,
         montos: values.montos.map((m) => ({
           concepto: m.concepto.trim(),
@@ -141,7 +148,7 @@ export function RecibosGenericos() {
   const openCreate = () => {
     setEditingRecibo(null);
     formik.resetForm({
-      values: { nombre: "", observaciones: "", montos: [{ concepto: "", monto: "" }] },
+      values: { nombre: "", fecha: todayStr, moneda: "GTQ" as MonedaRecibo, observaciones: "", montos: [{ concepto: "", monto: "" }] },
     });
     setModalOpen(true);
   };
@@ -151,6 +158,8 @@ export function RecibosGenericos() {
     formik.resetForm({
       values: {
         nombre: recibo.nombre,
+        fecha: recibo.fecha ? recibo.fecha.split("T")[0] : todayStr,
+        moneda: recibo.moneda || "GTQ",
         observaciones: recibo.observaciones || "",
         montos: recibo.montos.map((m) => ({ concepto: m.concepto, monto: m.monto })),
       },
@@ -271,6 +280,7 @@ export function RecibosGenericos() {
                   <th className="text-left px-4 py-3 font-semibold text-gray-700">Nombre</th>
                   <th className="text-left px-4 py-3 font-semibold text-gray-700">Fecha</th>
                   <th className="text-left px-4 py-3 font-semibold text-gray-700">Observaciones</th>
+                  <th className="text-center px-4 py-3 font-semibold text-gray-700">Moneda</th>
                   <th className="text-right px-4 py-3 font-semibold text-gray-700">Total</th>
                   <th className="text-center px-4 py-3 font-semibold text-gray-700">Acciones</th>
                 </tr>
@@ -296,11 +306,17 @@ export function RecibosGenericos() {
                       <td className="px-4 py-3 text-gray-500 max-w-[200px] truncate">
                         {r.observaciones || "--"}
                       </td>
+                      <td className="px-4 py-3 text-center">
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-bold ${
+                          r.moneda === "USD"
+                            ? "bg-green-100 text-green-700"
+                            : "bg-blue-100 text-blue-700"
+                        }`}>
+                          {r.moneda === "USD" ? "$ USD" : "Q GTQ"}
+                        </span>
+                      </td>
                       <td className="px-4 py-3 text-right font-bold text-green-700">
-                        <div className="flex items-center justify-end gap-1">
-                          <DollarSign className="h-4 w-4" />
-                          {formatCurrency(total)}
-                        </div>
+                        {formatCurrency(total, r.moneda || "GTQ")}
                       </td>
                       <td className="px-4 py-3">
                         <div className="flex items-center justify-center gap-1">
@@ -373,6 +389,33 @@ export function RecibosGenericos() {
                 {formik.errors.nombre && formik.touched.nombre && (
                   <span className="text-xs text-red-500">{formik.errors.nombre as string}</span>
                 )}
+              </div>
+
+              {/* Fecha */}
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">Fecha *</label>
+                <DatePickerMUI
+                  value={formik.values.fecha}
+                  onChange={(v) => formik.setFieldValue("fecha", v)}
+                  disableFuture={false}
+                />
+                {formik.errors.fecha && formik.touched.fecha && (
+                  <span className="text-xs text-red-500">{formik.errors.fecha as string}</span>
+                )}
+              </div>
+
+              {/* Moneda */}
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">Moneda</label>
+                <select
+                  name="moneda"
+                  value={formik.values.moneda}
+                  onChange={formik.handleChange}
+                  className="w-full h-10 rounded-lg border border-blue-200 bg-white px-3 text-sm text-gray-900 font-medium focus:ring-2 focus:ring-blue-400 focus:border-blue-500 transition"
+                >
+                  <option value="GTQ">Q - Quetzales (GTQ)</option>
+                  <option value="USD">$ - Dólares (USD)</option>
+                </select>
               </div>
 
               {/* Observaciones */}
@@ -452,7 +495,7 @@ export function RecibosGenericos() {
                 <div className="flex justify-end items-center gap-2 pt-2 border-t border-gray-100">
                   <span className="text-sm font-semibold text-gray-600">Total:</span>
                   <span className="text-lg font-bold text-green-700">
-                    {formatCurrency(totalMontos)}
+                    {formatCurrency(totalMontos, formik.values.moneda)}
                   </span>
                 </div>
               </div>

--- a/apps/carteraFront/src/private/recibos-genericos/components/RecibosGenericos.tsx
+++ b/apps/carteraFront/src/private/recibos-genericos/components/RecibosGenericos.tsx
@@ -1,0 +1,519 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState } from "react";
+import { useFormik } from "formik";
+import { toast } from "sonner";
+import {
+  Receipt,
+  Plus,
+  Trash2,
+  Loader2,
+  FileText,
+  X,
+  DollarSign,
+  Calendar,
+  User,
+  Download,
+  Pencil,
+  Search,
+} from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { DatePickerMUI } from "@/private/cartera/components/calendar";
+import {
+  useRecibosGenericos,
+  useCreateReciboGenerico,
+  useUpdateReciboGenerico,
+  useDeleteReciboGenerico,
+  useReciboGenericoPdf,
+} from "../hooks/useRecibosGenericos";
+import type { ReciboGenerico } from "../services/services";
+
+// --- Utilidades ---
+const formatCurrency = (val?: string | number | null) =>
+  val == null || isNaN(Number(val))
+    ? "--"
+    : Number(val).toLocaleString("es-GT", {
+        style: "currency",
+        currency: "GTQ",
+        minimumFractionDigits: 2,
+      });
+
+const formatDate = (d?: string) => {
+  if (!d) return "--";
+  const date = new Date(d);
+  return date.toLocaleDateString("es-GT", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+};
+
+export function RecibosGenericos() {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editingRecibo, setEditingRecibo] = useState<ReciboGenerico | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
+
+  // Filtros de fecha
+  const [fechaDesde, setFechaDesde] = useState("");
+  const [fechaHasta, setFechaHasta] = useState("");
+  const [fechaDesdeFiltro, setFechaDesdeFiltro] = useState("");
+  const [fechaHastaFiltro, setFechaHastaFiltro] = useState("");
+
+  // Hooks
+  const { data: recibos, isLoading, refetch } = useRecibosGenericos({
+    fecha_desde: fechaDesdeFiltro || undefined,
+    fecha_hasta: fechaHastaFiltro || undefined,
+  });
+  const { mutate: crear, isPending: isCreando } = useCreateReciboGenerico();
+  const { mutate: actualizar, isPending: isActualizando } = useUpdateReciboGenerico();
+  const { mutate: eliminar } = useDeleteReciboGenerico();
+  const { mutate: descargarPdf, isPending: isDescargando } = useReciboGenericoPdf();
+
+  const isSaving = isCreando || isActualizando;
+
+  // Formik
+  const formik = useFormik({
+    initialValues: {
+      nombre: "",
+      observaciones: "",
+      montos: [{ concepto: "", monto: "" }] as { concepto: string; monto: string }[],
+    },
+    enableReinitialize: true,
+    validate: (values) => {
+      const errors: any = {};
+      if (!values.nombre.trim()) errors.nombre = "El nombre es requerido";
+      if (values.montos.length === 0) errors.montos = "Debe agregar al menos un monto";
+      const montosErrors: any[] = [];
+      values.montos.forEach((m, i) => {
+        const err: any = {};
+        if (!m.concepto.trim()) err.concepto = "Requerido";
+        if (!m.monto || Number(m.monto) <= 0) err.monto = "Debe ser mayor a 0";
+        if (Object.keys(err).length > 0) montosErrors[i] = err;
+      });
+      if (montosErrors.length > 0) errors.montosDetail = montosErrors;
+      return errors;
+    },
+    onSubmit: (values, { resetForm }) => {
+      const payload = {
+        nombre: values.nombre.trim(),
+        observaciones: values.observaciones.trim() || undefined,
+        montos: values.montos.map((m) => ({
+          concepto: m.concepto.trim(),
+          monto: Number(m.monto).toFixed(2),
+        })),
+      };
+
+      if (editingRecibo) {
+        actualizar(
+          { id: editingRecibo.id, payload },
+          {
+            onSuccess: () => {
+              toast.success("Recibo actualizado");
+              resetForm();
+              setEditingRecibo(null);
+              setModalOpen(false);
+              refetch();
+            },
+            onError: (err: any) => {
+              toast.error(err?.response?.data?.message || "Error al actualizar");
+            },
+          }
+        );
+      } else {
+        crear(payload, {
+          onSuccess: () => {
+            toast.success("Recibo creado exitosamente");
+            resetForm();
+            setModalOpen(false);
+            refetch();
+          },
+          onError: (err: any) => {
+            toast.error(err?.response?.data?.message || "Error al crear recibo");
+          },
+        });
+      }
+    },
+  });
+
+  const openCreate = () => {
+    setEditingRecibo(null);
+    formik.resetForm({
+      values: { nombre: "", observaciones: "", montos: [{ concepto: "", monto: "" }] },
+    });
+    setModalOpen(true);
+  };
+
+  const openEdit = (recibo: ReciboGenerico) => {
+    setEditingRecibo(recibo);
+    formik.resetForm({
+      values: {
+        nombre: recibo.nombre,
+        observaciones: recibo.observaciones || "",
+        montos: recibo.montos.map((m) => ({ concepto: m.concepto, monto: m.monto })),
+      },
+    });
+    setModalOpen(true);
+  };
+
+  const handleDelete = (id: number) => {
+    eliminar(id, {
+      onSuccess: () => {
+        toast.success("Recibo eliminado");
+        setConfirmDelete(null);
+        refetch();
+      },
+      onError: (err: any) => {
+        toast.error(err?.response?.data?.message || "Error al eliminar");
+        setConfirmDelete(null);
+      },
+    });
+  };
+
+  const handlePdf = (id: number) => {
+    descargarPdf(id, {
+      onSuccess: (data) => {
+        window.open(data.pdfUrl, "_blank");
+      },
+      onError: (err: any) => {
+        toast.error(err?.response?.data?.message || "Error al generar PDF");
+      },
+    });
+  };
+
+  const totalMontos = formik.values.montos.reduce(
+    (sum, m) => sum + (Number(m.monto) || 0),
+    0
+  );
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 overflow-auto pt-8 pb-8">
+      <div className="bg-blue-50 rounded-xl shadow-md p-5 w-full max-w-6xl">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+        <h2 className="text-2xl font-bold text-blue-900 flex items-center gap-2">
+          <Receipt className="w-6 h-6 text-blue-700" />
+          Recibos Genéricos
+        </h2>
+        <Button
+          onClick={openCreate}
+          className="bg-blue-700 hover:bg-blue-800 text-white font-bold gap-2"
+        >
+          <Plus className="h-4 w-4" /> Nuevo Recibo
+        </Button>
+      </div>
+
+      {/* Filtros */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+        <div className="flex flex-col sm:flex-row items-end gap-4">
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-gray-600">Desde</label>
+            <DatePickerMUI
+              value={fechaDesde}
+              onChange={(v) => setFechaDesde(v)}
+              disableFuture={false}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-medium text-gray-600">Hasta</label>
+            <DatePickerMUI
+              value={fechaHasta}
+              onChange={(v) => setFechaHasta(v)}
+              disableFuture={false}
+            />
+          </div>
+          <Button
+            onClick={() => {
+              setFechaDesdeFiltro(fechaDesde);
+              setFechaHastaFiltro(fechaHasta);
+            }}
+            className="bg-blue-600 hover:bg-blue-700 text-white font-semibold gap-2"
+          >
+            <Search className="h-4 w-4" /> Buscar
+          </Button>
+          {(fechaDesdeFiltro || fechaHastaFiltro) && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                setFechaDesde("");
+                setFechaHasta("");
+                setFechaDesdeFiltro("");
+                setFechaHastaFiltro("");
+              }}
+              className="text-gray-600 gap-2"
+            >
+              <X className="h-4 w-4" /> Limpiar
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Tabla */}
+      <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-16">
+            <Loader2 className="h-8 w-8 animate-spin text-blue-600" />
+          </div>
+        ) : !recibos || recibos.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+            <FileText className="h-12 w-12 mb-3" />
+            <p className="font-medium">No hay recibos</p>
+            <p className="text-sm">Crea uno nuevo para empezar</p>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-gray-50 border-b border-gray-200">
+                  <th className="text-left px-4 py-3 font-semibold text-gray-700">ID</th>
+                  <th className="text-left px-4 py-3 font-semibold text-gray-700">Nombre</th>
+                  <th className="text-left px-4 py-3 font-semibold text-gray-700">Fecha</th>
+                  <th className="text-left px-4 py-3 font-semibold text-gray-700">Observaciones</th>
+                  <th className="text-right px-4 py-3 font-semibold text-gray-700">Total</th>
+                  <th className="text-center px-4 py-3 font-semibold text-gray-700">Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {recibos.map((r) => {
+                  const total = r.montos.reduce((s, m) => s + Number(m.monto), 0);
+                  return (
+                    <tr key={r.id} className="border-b border-gray-100 hover:bg-blue-50/40 transition-colors">
+                      <td className="px-4 py-3 font-mono text-gray-500">#{r.id}</td>
+                      <td className="px-4 py-3 font-medium text-gray-800">
+                        <div className="flex items-center gap-2">
+                          <User className="h-4 w-4 text-gray-400" />
+                          {r.nombre}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-600">
+                        <div className="flex items-center gap-2">
+                          <Calendar className="h-4 w-4 text-gray-400" />
+                          {formatDate(r.fecha)}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3 text-gray-500 max-w-[200px] truncate">
+                        {r.observaciones || "--"}
+                      </td>
+                      <td className="px-4 py-3 text-right font-bold text-green-700">
+                        <div className="flex items-center justify-end gap-1">
+                          <DollarSign className="h-4 w-4" />
+                          {formatCurrency(total)}
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="flex items-center justify-center gap-1">
+                          <button
+                            onClick={() => openEdit(r)}
+                            className="p-2 rounded-lg hover:bg-blue-100 text-blue-600 transition-colors"
+                            title="Editar"
+                          >
+                            <Pencil className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => handlePdf(r.id)}
+                            disabled={isDescargando}
+                            className="p-2 rounded-lg hover:bg-green-100 text-green-600 transition-colors"
+                            title="Descargar PDF"
+                          >
+                            <Download className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={() => setConfirmDelete(r.id)}
+                            className="p-2 rounded-lg hover:bg-red-100 text-red-500 transition-colors"
+                            title="Eliminar"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Modal Crear/Editar */}
+      {modalOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div
+            className="bg-white rounded-2xl shadow-2xl border border-blue-100 w-full max-w-lg mx-4 flex flex-col"
+            style={{ maxHeight: "90vh" }}
+          >
+            {/* Header */}
+            <div className="flex items-center justify-between px-6 pt-5 pb-3 border-b border-gray-100">
+              <h2 className="text-lg font-bold text-blue-800 flex items-center gap-2">
+                <Receipt className="h-5 w-5" />
+                {editingRecibo ? "Editar Recibo" : "Nuevo Recibo"}
+              </h2>
+              <button
+                onClick={() => { setModalOpen(false); setEditingRecibo(null); }}
+                className="p-1.5 rounded-lg hover:bg-gray-100 transition-colors"
+              >
+                <X className="h-5 w-5 text-gray-500" />
+              </button>
+            </div>
+
+            {/* Form */}
+            <form onSubmit={formik.handleSubmit} className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+              {/* Nombre */}
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">Nombre *</label>
+                <Input
+                  name="nombre"
+                  placeholder="Nombre de quien sale el recibo"
+                  value={formik.values.nombre}
+                  onChange={formik.handleChange}
+                  className="bg-white border-blue-200 text-gray-900 font-medium"
+                />
+                {formik.errors.nombre && formik.touched.nombre && (
+                  <span className="text-xs text-red-500">{formik.errors.nombre as string}</span>
+                )}
+              </div>
+
+              {/* Observaciones */}
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-gray-700">Observaciones</label>
+                <textarea
+                  name="observaciones"
+                  placeholder="Opcional"
+                  value={formik.values.observaciones}
+                  onChange={formik.handleChange}
+                  rows={2}
+                  className="w-full border rounded-lg px-3 py-2 bg-white border-blue-200 text-gray-900 font-medium text-sm focus:ring-2 focus:ring-blue-400 focus:border-blue-500 focus:outline-none resize-none"
+                />
+              </div>
+
+              {/* Montos */}
+              <div className="space-y-3">
+                <div className="flex items-center justify-between">
+                  <label className="text-sm font-bold text-gray-700">Detalle de Montos</label>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    className="text-blue-700 border-blue-300 hover:bg-blue-50 gap-1"
+                    onClick={() =>
+                      formik.setFieldValue("montos", [
+                        ...formik.values.montos,
+                        { concepto: "", monto: "" },
+                      ])
+                    }
+                  >
+                    <Plus className="h-3.5 w-3.5" /> Agregar
+                  </Button>
+                </div>
+
+                {formik.values.montos.map((item, idx) => (
+                  <div key={idx} className="flex gap-2 items-start">
+                    <div className="flex-1">
+                      <Input
+                        placeholder="Concepto"
+                        value={item.concepto}
+                        onChange={(e) =>
+                          formik.setFieldValue(`montos.${idx}.concepto`, e.target.value)
+                        }
+                        className="bg-white border-gray-200 text-sm text-gray-900 font-medium"
+                      />
+                    </div>
+                    <div className="w-32">
+                      <Input
+                        type="number"
+                        placeholder="0.00"
+                        step="any"
+                        min={0}
+                        value={item.monto}
+                        onChange={(e) =>
+                          formik.setFieldValue(`montos.${idx}.monto`, e.target.value)
+                        }
+                        className="bg-white border-gray-200 text-sm text-gray-900 font-medium text-right"
+                      />
+                    </div>
+                    {formik.values.montos.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          const updated = formik.values.montos.filter((_, i) => i !== idx);
+                          formik.setFieldValue("montos", updated);
+                        }}
+                        className="p-2 rounded-lg hover:bg-red-50 text-red-400 hover:text-red-600 transition-colors mt-0.5"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+
+                {/* Total */}
+                <div className="flex justify-end items-center gap-2 pt-2 border-t border-gray-100">
+                  <span className="text-sm font-semibold text-gray-600">Total:</span>
+                  <span className="text-lg font-bold text-green-700">
+                    {formatCurrency(totalMontos)}
+                  </span>
+                </div>
+              </div>
+            </form>
+
+            {/* Footer */}
+            <div className="flex gap-3 px-6 py-4 border-t border-gray-100">
+              <Button
+                type="button"
+                variant="outline"
+                className="flex-1 font-bold border-blue-600 text-blue-700 hover:bg-blue-50"
+                onClick={() => { setModalOpen(false); setEditingRecibo(null); }}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="button"
+                className="flex-1 bg-blue-700 hover:bg-blue-800 text-white font-bold gap-2"
+                disabled={isSaving}
+                onClick={() => formik.handleSubmit()}
+              >
+                {isSaving && <Loader2 className="h-4 w-4 animate-spin" />}
+                {editingRecibo ? "Guardar Cambios" : "Crear Recibo"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Modal Confirmar Eliminar */}
+      {confirmDelete !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-2xl shadow-2xl border border-red-100 w-full max-w-sm mx-4 p-6 space-y-4">
+            <div className="flex items-center gap-3">
+              <div className="bg-red-100 rounded-full p-2">
+                <Trash2 className="h-5 w-5 text-red-600" />
+              </div>
+              <h3 className="text-lg font-bold text-gray-900">Eliminar Recibo</h3>
+            </div>
+            <p className="text-sm text-gray-600">
+              ¿Estás seguro de que deseas eliminar este recibo? Esta acción no se puede deshacer.
+            </p>
+            <div className="flex gap-3">
+              <Button
+                variant="outline"
+                className="flex-1"
+                onClick={() => setConfirmDelete(null)}
+              >
+                Cancelar
+              </Button>
+              <Button
+                className="flex-1 bg-red-600 hover:bg-red-700 text-white font-bold"
+                onClick={() => handleDelete(confirmDelete)}
+              >
+                Eliminar
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+      </div>
+    </div>
+  );
+}

--- a/apps/carteraFront/src/private/recibos-genericos/hooks/useRecibosGenericos.ts
+++ b/apps/carteraFront/src/private/recibos-genericos/hooks/useRecibosGenericos.ts
@@ -1,0 +1,61 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getRecibosGenericosService,
+  createReciboGenericoService,
+  updateReciboGenericoService,
+  deleteReciboGenericoService,
+  getReciboGenericoPdfService,
+  type CreateReciboGenericoPayload,
+  type UpdateReciboGenericoPayload,
+} from "../services/services";
+
+const QUERY_KEY = "recibos-genericos";
+
+export function useRecibosGenericos(params?: {
+  fecha_desde?: string;
+  fecha_hasta?: string;
+}) {
+  return useQuery({
+    queryKey: [QUERY_KEY, params?.fecha_desde, params?.fecha_hasta],
+    queryFn: () => getRecibosGenericosService(params),
+    staleTime: 1000 * 60,
+  });
+}
+
+export function useCreateReciboGenerico() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateReciboGenericoPayload) =>
+      createReciboGenericoService(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+    },
+  });
+}
+
+export function useUpdateReciboGenerico() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: number; payload: UpdateReciboGenericoPayload }) =>
+      updateReciboGenericoService(id, payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+    },
+  });
+}
+
+export function useDeleteReciboGenerico() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => deleteReciboGenericoService(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+    },
+  });
+}
+
+export function useReciboGenericoPdf() {
+  return useMutation({
+    mutationFn: (id: number) => getReciboGenericoPdfService(id),
+  });
+}

--- a/apps/carteraFront/src/private/recibos-genericos/services/services.ts
+++ b/apps/carteraFront/src/private/recibos-genericos/services/services.ts
@@ -13,6 +13,8 @@ api.interceptors.request.use((config) => {
 
 // ===================== TIPOS =====================
 
+export type MonedaRecibo = "GTQ" | "USD";
+
 export interface ReciboGenericoMonto {
   id: number;
   recibo_id: number;
@@ -24,6 +26,7 @@ export interface ReciboGenerico {
   id: number;
   nombre: string;
   observaciones: string | null;
+  moneda: MonedaRecibo;
   fecha: string;
   created_at: string;
   montos: ReciboGenericoMonto[];
@@ -31,12 +34,16 @@ export interface ReciboGenerico {
 
 export interface CreateReciboGenericoPayload {
   nombre: string;
+  fecha?: string;
+  moneda?: MonedaRecibo;
   observaciones?: string;
   montos: { concepto: string; monto: string }[];
 }
 
 export interface UpdateReciboGenericoPayload {
   nombre?: string;
+  fecha?: string;
+  moneda?: MonedaRecibo;
   observaciones?: string;
   montos?: { concepto: string; monto: string }[];
 }

--- a/apps/carteraFront/src/private/recibos-genericos/services/services.ts
+++ b/apps/carteraFront/src/private/recibos-genericos/services/services.ts
@@ -1,0 +1,88 @@
+import axios from "axios";
+
+const API_URL = import.meta.env.VITE_BACK_URL || "https://qk4sw4kc4c088c8csos400wc.s3.devteamatcci.site";
+
+const api = axios.create({ baseURL: API_URL });
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("accessToken");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// ===================== TIPOS =====================
+
+export interface ReciboGenericoMonto {
+  id: number;
+  recibo_id: number;
+  concepto: string;
+  monto: string;
+}
+
+export interface ReciboGenerico {
+  id: number;
+  nombre: string;
+  observaciones: string | null;
+  fecha: string;
+  created_at: string;
+  montos: ReciboGenericoMonto[];
+}
+
+export interface CreateReciboGenericoPayload {
+  nombre: string;
+  observaciones?: string;
+  montos: { concepto: string; monto: string }[];
+}
+
+export interface UpdateReciboGenericoPayload {
+  nombre?: string;
+  observaciones?: string;
+  montos?: { concepto: string; monto: string }[];
+}
+
+// ===================== SERVICIOS =====================
+
+export async function createReciboGenericoService(
+  payload: CreateReciboGenericoPayload
+): Promise<ReciboGenerico> {
+  const res = await api.post("/recibos-genericos", payload);
+  return res.data;
+}
+
+export async function getRecibosGenericosService(params?: {
+  fecha_desde?: string;
+  fecha_hasta?: string;
+}): Promise<ReciboGenerico[]> {
+  const res = await api.get("/recibos-genericos", { params });
+  return res.data;
+}
+
+export async function getReciboGenericoByIdService(
+  id: number
+): Promise<ReciboGenerico> {
+  const res = await api.get(`/recibos-genericos/${id}`);
+  return res.data;
+}
+
+export async function updateReciboGenericoService(
+  id: number,
+  payload: UpdateReciboGenericoPayload
+): Promise<ReciboGenerico> {
+  const res = await api.put(`/recibos-genericos/${id}`, payload);
+  return res.data;
+}
+
+export async function deleteReciboGenericoService(
+  id: number
+): Promise<{ message: string; recibo: Omit<ReciboGenerico, "montos"> }> {
+  const res = await api.delete(`/recibos-genericos/${id}`);
+  return res.data;
+}
+
+export async function getReciboGenericoPdfService(
+  id: number
+): Promise<{ pdfUrl: string }> {
+  const res = await api.get(`/recibos-genericos/${id}/pdf`);
+  return res.data;
+}


### PR DESCRIPTION
- Add backend and frontend support for generic receipts, including CRUD operations and PDF generation via Puppeteer.
- Refactor the dashboard navigation to organize menu items into functional sections (Operations, Portfolio, Investors, Documents, Administration, and Reports).
- Update payment editing to include membership-related fields and ensure advisor ID is correctly handled in credit modifications.
