### PR TITLE
[codex] redesign investment funnel

### DIFF
--- a/apps/crm/apps/server/src/controllers/investment-lead.ts
+++ b/apps/crm/apps/server/src/controllers/investment-lead.ts
@@ -3,8 +3,8 @@ import type { Context } from "hono";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import {
-	investmentLeadSourceEnum,
 	investmentAuditLog,
+	type investmentLeadSourceEnum,
 	investmentLeads,
 	investmentOpportunities,
 	investmentStageHistory,
@@ -81,13 +81,13 @@ export async function createInvestmentLeadWithOpportunity(
 		})
 		.returning();
 
-	// Crear oportunidad automaticamente en etapa Prospeccion
+	// Crear oportunidad automaticamente en etapa de recoleccion de datos
 	const [opportunity] = await db
 		.insert(investmentOpportunities)
 		.values({
 			investmentLeadId: lead.id,
 			assignedAdvisorId: assignedTo,
-			stage: "prospecting",
+			stage: "data_collection",
 			status: "open",
 		})
 		.returning();
@@ -107,7 +107,7 @@ export async function createInvestmentLeadWithOpportunity(
 	// Registrar stage history
 	await db.insert(investmentStageHistory).values({
 		investmentOpportunityId: opportunity.id,
-		toStage: "prospecting",
+		toStage: "data_collection",
 		changedBy: performedBy,
 	});
 

--- a/apps/crm/apps/server/src/db/migrations/0019_replace_investment_pipeline_stages.sql
+++ b/apps/crm/apps/server/src/db/migrations/0019_replace_investment_pipeline_stages.sql
@@ -22,8 +22,8 @@ ALTER TABLE "investment_opportunities"
 			WHEN "stage"::text = 'contacted' THEN 'basic_profile_validation'
 			WHEN "stage"::text = 'negotiation' THEN 'active_follow_up'
 			WHEN "stage"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
-			WHEN "stage"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
-			WHEN "stage"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "stage"::text = 'welcome' THEN 'ticket_closure_transfer_activation'
+			WHEN "stage"::text = 'closed' THEN 'initial_onboarding_senior_handoff'
 			WHEN "stage"::text = 'lost' THEN 'lost'
 		END
 	)::"public"."investment_stage";--> statement-breakpoint
@@ -40,8 +40,8 @@ ALTER TABLE "investment_opportunities"
 			WHEN "last_stage_before_lost"::text = 'contacted' THEN 'basic_profile_validation'
 			WHEN "last_stage_before_lost"::text = 'negotiation' THEN 'active_follow_up'
 			WHEN "last_stage_before_lost"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
-			WHEN "last_stage_before_lost"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
-			WHEN "last_stage_before_lost"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "last_stage_before_lost"::text = 'welcome' THEN 'ticket_closure_transfer_activation'
+			WHEN "last_stage_before_lost"::text = 'closed' THEN 'initial_onboarding_senior_handoff'
 			WHEN "last_stage_before_lost"::text = 'lost' THEN 'lost'
 		END
 	)::"public"."investment_stage";--> statement-breakpoint
@@ -55,8 +55,8 @@ ALTER TABLE "investment_stage_history"
 			WHEN "from_stage"::text = 'contacted' THEN 'basic_profile_validation'
 			WHEN "from_stage"::text = 'negotiation' THEN 'active_follow_up'
 			WHEN "from_stage"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
-			WHEN "from_stage"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
-			WHEN "from_stage"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "from_stage"::text = 'welcome' THEN 'ticket_closure_transfer_activation'
+			WHEN "from_stage"::text = 'closed' THEN 'initial_onboarding_senior_handoff'
 			WHEN "from_stage"::text = 'lost' THEN 'lost'
 		END
 	)::"public"."investment_stage";--> statement-breakpoint
@@ -69,8 +69,8 @@ ALTER TABLE "investment_stage_history"
 			WHEN "to_stage"::text = 'contacted' THEN 'basic_profile_validation'
 			WHEN "to_stage"::text = 'negotiation' THEN 'active_follow_up'
 			WHEN "to_stage"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
-			WHEN "to_stage"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
-			WHEN "to_stage"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "to_stage"::text = 'welcome' THEN 'ticket_closure_transfer_activation'
+			WHEN "to_stage"::text = 'closed' THEN 'initial_onboarding_senior_handoff'
 			WHEN "to_stage"::text = 'lost' THEN 'lost'
 		END
 	)::"public"."investment_stage";--> statement-breakpoint

--- a/apps/crm/apps/server/src/db/migrations/0019_replace_investment_pipeline_stages.sql
+++ b/apps/crm/apps/server/src/db/migrations/0019_replace_investment_pipeline_stages.sql
@@ -1,0 +1,78 @@
+ALTER TYPE "public"."investment_stage" RENAME TO "investment_stage_old";--> statement-breakpoint
+CREATE TYPE "public"."investment_stage" AS ENUM(
+	'data_collection',
+	'basic_profile_validation',
+	'profiling_and_qualification',
+	'model_presentation',
+	'active_follow_up',
+	'verbal_commitment_contract_sent',
+	'ticket_closure_transfer_activation',
+	'initial_onboarding_senior_handoff',
+	'lost'
+);--> statement-breakpoint
+
+ALTER TABLE "investment_opportunities"
+	ALTER COLUMN "stage" DROP DEFAULT;--> statement-breakpoint
+
+ALTER TABLE "investment_opportunities"
+	ALTER COLUMN "stage" TYPE "public"."investment_stage"
+	USING (
+		CASE
+			WHEN "stage"::text = 'prospecting' THEN 'data_collection'
+			WHEN "stage"::text = 'contacted' THEN 'basic_profile_validation'
+			WHEN "stage"::text = 'negotiation' THEN 'active_follow_up'
+			WHEN "stage"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
+			WHEN "stage"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
+			WHEN "stage"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "stage"::text = 'lost' THEN 'lost'
+		END
+	)::"public"."investment_stage";--> statement-breakpoint
+
+ALTER TABLE "investment_opportunities"
+	ALTER COLUMN "stage" SET DEFAULT 'data_collection'::"public"."investment_stage";--> statement-breakpoint
+
+ALTER TABLE "investment_opportunities"
+	ALTER COLUMN "last_stage_before_lost" TYPE "public"."investment_stage"
+	USING (
+		CASE
+			WHEN "last_stage_before_lost" IS NULL THEN NULL
+			WHEN "last_stage_before_lost"::text = 'prospecting' THEN 'data_collection'
+			WHEN "last_stage_before_lost"::text = 'contacted' THEN 'basic_profile_validation'
+			WHEN "last_stage_before_lost"::text = 'negotiation' THEN 'active_follow_up'
+			WHEN "last_stage_before_lost"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
+			WHEN "last_stage_before_lost"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
+			WHEN "last_stage_before_lost"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "last_stage_before_lost"::text = 'lost' THEN 'lost'
+		END
+	)::"public"."investment_stage";--> statement-breakpoint
+
+ALTER TABLE "investment_stage_history"
+	ALTER COLUMN "from_stage" TYPE "public"."investment_stage"
+	USING (
+		CASE
+			WHEN "from_stage" IS NULL THEN NULL
+			WHEN "from_stage"::text = 'prospecting' THEN 'data_collection'
+			WHEN "from_stage"::text = 'contacted' THEN 'basic_profile_validation'
+			WHEN "from_stage"::text = 'negotiation' THEN 'active_follow_up'
+			WHEN "from_stage"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
+			WHEN "from_stage"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
+			WHEN "from_stage"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "from_stage"::text = 'lost' THEN 'lost'
+		END
+	)::"public"."investment_stage";--> statement-breakpoint
+
+ALTER TABLE "investment_stage_history"
+	ALTER COLUMN "to_stage" TYPE "public"."investment_stage"
+	USING (
+		CASE
+			WHEN "to_stage"::text = 'prospecting' THEN 'data_collection'
+			WHEN "to_stage"::text = 'contacted' THEN 'basic_profile_validation'
+			WHEN "to_stage"::text = 'negotiation' THEN 'active_follow_up'
+			WHEN "to_stage"::text = 'acceptance_signatures' THEN 'verbal_commitment_contract_sent'
+			WHEN "to_stage"::text = 'welcome' THEN 'initial_onboarding_senior_handoff'
+			WHEN "to_stage"::text = 'closed' THEN 'ticket_closure_transfer_activation'
+			WHEN "to_stage"::text = 'lost' THEN 'lost'
+		END
+	)::"public"."investment_stage";--> statement-breakpoint
+
+DROP TYPE "public"."investment_stage_old";

--- a/apps/crm/apps/server/src/db/schema/investments.ts
+++ b/apps/crm/apps/server/src/db/schema/investments.ts
@@ -30,12 +30,14 @@ export const investmentLeadSourceEnum = pgEnum("investment_lead_source", [
 ]);
 
 export const investmentStageEnum = pgEnum("investment_stage", [
-	"prospecting",
-	"contacted",
-	"negotiation",
-	"acceptance_signatures",
-	"welcome",
-	"closed",
+	"data_collection",
+	"basic_profile_validation",
+	"profiling_and_qualification",
+	"model_presentation",
+	"active_follow_up",
+	"verbal_commitment_contract_sent",
+	"ticket_closure_transfer_activation",
+	"initial_onboarding_senior_handoff",
 	"lost",
 ]);
 
@@ -150,7 +152,7 @@ export const investmentOpportunities = pgTable("investment_opportunities", {
 	investorId: uuid("investor_id").references(() => investors.id, {
 		onDelete: "set null",
 	}),
-	stage: investmentStageEnum("stage").notNull().default("prospecting"),
+	stage: investmentStageEnum("stage").notNull().default("data_collection"),
 	assignedAdvisorId: text("assigned_advisor_id")
 		.notNull()
 		.references(() => user.id),

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -25,14 +25,13 @@ import * as reportsRouter from "./reports";
 import { uploadRouter } from "./upload";
 import { vehiclesRouter } from "./vehicles";
 import { vendorsRouter } from "./vendors";
-export const appRouter = {
+const healthRouter = {
 	healthCheck: publicProcedure.handler(() => {
 		return "OK";
 	}),
+};
 
-	// Auth routes
-	...authRouter,
-
+const adminRoutes = {
 	// Admin routes (prefixed for clarity)
 	adminOnlyData: adminRouter.getStats,
 	getAllUsers: adminRouter.getAllUsers,
@@ -40,11 +39,15 @@ export const appRouter = {
 	toggleUserSuspension: adminRouter.toggleUserSuspension,
 	deleteUser: adminRouter.deleteUser,
 	createUser: adminRouter.createUser,
+};
 
+const adminImportRoutes = {
 	// Admin Import routes
 	setupImportacion: adminImportRouter.setupImportacion,
 	analizarImportacionCreditos: adminImportRouter.analizarImportacionCreditos,
+};
 
+const crmRoutes = {
 	// CRM routes
 	getSalesStages: crmRouter.getSalesStages,
 	getCrmUsers: crmRouter.getCrmUsers,
@@ -105,7 +108,9 @@ export const appRouter = {
 	updateCoDebtor: crmRouter.updateCoDebtor,
 	deleteCoDebtor: crmRouter.deleteCoDebtor,
 	getConsolidatedCreditAnalysis: crmRouter.getConsolidatedCreditAnalysis,
+};
 
+const clientFormsRoutes = {
 	// Client Forms routes (Formularios del cliente - link público)
 	generateFormToken: clientFormsRouter.generateFormToken,
 	validateFormToken: clientFormsRouter.validateFormToken,
@@ -114,10 +119,14 @@ export const appRouter = {
 	submitFinancialStatement: clientFormsRouter.submitFinancialStatement,
 	getClientFormData: clientFormsRouter.getClientFormData,
 	getFormTokenByOpportunity: clientFormsRouter.getFormTokenByOpportunity,
+};
 
+const bankAnalysisRoutes = {
 	// Bank Analysis routes (Análisis de estados de cuenta)
 	analyzeBankStatements: bankAnalysisRouter.analyzeBankStatements,
+};
 
+const vehicleRoutes = {
 	// Vehicles routes
 	getVehicles: vehiclesRouter.getAll,
 	getVehicleById: vehiclesRouter.getById,
@@ -140,7 +149,9 @@ export const appRouter = {
 	uploadVehicleDocument: vehiclesRouter.uploadVehicleDocument,
 	deleteVehicleDocument: vehiclesRouter.deleteVehicleDocument,
 	validateLicensePlate: vehiclesRouter.validateLicensePlate,
+};
 
+const cobrosRoutes = {
 	// Cobros routes
 	getCobrosDashboardStats: cobrosRouter.getDashboardStats,
 	getCasosCobros: cobrosRouter.getCasosCobros,
@@ -176,7 +187,9 @@ export const appRouter = {
 	getMetasMora: cobrosRouter.getMetasMora,
 	getMetasMoraAnual: cobrosRouter.getMetasMoraAnual,
 	upsertMetasMora: cobrosRouter.upsertMetasMora,
+};
 
+const legalContractRoutes = {
 	// Legal Contracts routes (Jurídico)
 	createLegalContract: legalContractsRouter.createLegalContract,
 	updateLegalContract: legalContractsRouter.updateLegalContract,
@@ -195,7 +208,9 @@ export const appRouter = {
 		legalContractsRouter.getOpportunitiesForContracts,
 	approveOpportunityLegal: legalContractsRouter.approveOpportunityLegal,
 	confirmContractsSigned: legalContractsRouter.confirmContractsSigned,
+};
 
+const contractGenerationRoutes = {
 	// Contract Generation routes (Generación automática de contratos)
 	getContractTypes: contractGenerationRouter.getContractTypes,
 	getDocumentsByDpi: contractGenerationRouter.getDocumentsByDpi,
@@ -210,7 +225,9 @@ export const appRouter = {
 	getGeneratedContracts: contractGenerationRouter.getGeneratedContracts,
 	getGenerationSnapshot: contractGenerationRouter.getGenerationSnapshot,
 	regenerateContracts: contractGenerationRouter.regenerateContracts,
+};
 
+const vendorRoutes = {
 	// Vendors routes
 	getVendors: vendorsRouter.getAll,
 	getVendorById: vendorsRouter.getById,
@@ -219,14 +236,18 @@ export const appRouter = {
 	updateVendor: vendorsRouter.update,
 	deleteVendor: vendorsRouter.delete,
 	searchVendors: vendorsRouter.search,
+};
 
+const noteRoutes = {
 	// Notes routes
 	getEntityNotes: notesRouter.getEntityNotes,
 	createNote: notesRouter.createNote,
 	updateNote: notesRouter.updateNote,
 	togglePinNote: notesRouter.togglePinNote,
 	deleteNote: notesRouter.deleteNote,
+};
 
+const notificationRoutes = {
 	// Notifications routes
 	getUnreadNotificationCount: notificationsRouter.getUnreadNotificationCount,
 	getAllNotifications: notificationsRouter.getAllNotifications,
@@ -239,7 +260,9 @@ export const appRouter = {
 	getAccountDocumentsByOpportunities:
 		notificationsRouter.getAccountDocumentsByOpportunities,
 	markAllNotificationsAsRead: notificationsRouter.markAllNotificationsAsRead,
+};
 
+const quotationRoutes = {
 	// Quotations routes
 	createQuotation: quotationsRouter.createQuotation,
 	getQuotations: quotationsRouter.getQuotations,
@@ -247,7 +270,9 @@ export const appRouter = {
 	updateQuotation: quotationsRouter.updateQuotation,
 	deleteQuotation: quotationsRouter.deleteQuotation,
 	listQuotationsByOpportunity: quotationsRouter.listQuotationsByOpportunity,
+};
 
+const checkRoutes = {
 	// Credit Checks routes (Emisión de Cheques)
 	createCheck: checksRouter.createCheck,
 	getChecksByOpportunity: checksRouter.getChecksByOpportunity,
@@ -255,23 +280,31 @@ export const appRouter = {
 	updateCheck: checksRouter.updateCheck,
 	deleteCheck: checksRouter.deleteCheck,
 	getChecksSummary: checksRouter.getChecksSummary,
+};
 
+const locationRoutes = {
 	// Guatemala Locations routes (Catálogo de ubicaciones)
 	getDepartamentos: locationsRouter.getDepartamentos,
 	getMunicipiosByDepartamento: locationsRouter.getMunicipiosByDepartamento,
 	getAllLocations: locationsRouter.getAllLocations,
 	seedLocations: locationsRouter.seedLocations,
+};
 
+const insuranceRoutes = {
 	// Insurance routes
 	getInsuranceCost: insuranceRouter.getInsuranceCost,
+};
 
+const auctionRoutes = {
 	// Auction routes (subastas 🚗💸)
 	createAuction: auctionRouter.createAuction,
 	closeAuction: auctionRouter.closeAuction,
 	getAuctions: auctionRouter.getAuctions,
 	addAuctionExpense: auctionRouter.addAuctionExpense,
 	cancelAuction: auctionRouter.cancelAuction,
+};
 
+const reportRoutes = {
 	// Reports routes (reportes 📊)
 	getDashboardExecutivo: reportsRouter.getDashboardExecutivo,
 	getReporteCobranza: reportsRouter.getReporteCobranza,
@@ -281,16 +314,22 @@ export const appRouter = {
 	// Reportes unificados (cartera-back + CRM)
 	getReporteCarteraCompleto: reportesCarteraRouter.getReporteCarteraCompleto,
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,
+};
 
+const miniagentRoutes = {
 	// MiniAgent routes
 	getMiniAgentCredentials: miniagentRouter.getMiniAgentCredentials,
+};
 
+const adminMiniagentRoutes = {
 	// Admin MiniAgent routes
 	adminListUsersWithCredentials: adminMiniagentRouter.listUsersWithCredentials,
 	adminSetMiniAgentCredentials: adminMiniagentRouter.setMiniAgentCredentials,
 	adminDeleteMiniAgentCredentials:
 		adminMiniagentRouter.deleteMiniAgentCredentials,
+};
 
+const investorDocumentRoutes = {
 	// Investor Documents routes (Documentos de inversionista)
 	getInvestorRendimiento: investorDocumentsRouter.getInvestorRendimiento,
 	getInvestorDocumentsAdmin: investorDocumentsRouter.getInvestorDocumentsAdmin,
@@ -299,12 +338,66 @@ export const appRouter = {
 		investorDocumentsRouter.toggleInvestorDocumentVisibility,
 	deleteInvestorDocument: investorDocumentsRouter.deleteInvestorDocument,
 	getInvestorActivityLog: investorDocumentsRouter.getInvestorActivityLog,
+};
 
+const accountingRoutes = {
 	// Accounting routes (Contabilidad)
 	getResumenGlobalInversionistas:
 		accountingRouter.getResumenGlobalInversionistas,
 	createBoleta: accountingRouter.createBoleta,
 	liquidateInversionista: accountingRouter.liquidateInversionista,
+};
+
+type BaseAppRouter = typeof healthRouter &
+	typeof authRouter &
+	typeof adminRoutes &
+	typeof adminImportRoutes &
+	typeof crmRoutes &
+	typeof clientFormsRoutes &
+	typeof bankAnalysisRoutes &
+	typeof vehicleRoutes &
+	typeof cobrosRoutes &
+	typeof legalContractRoutes &
+	typeof contractGenerationRoutes &
+	typeof vendorRoutes &
+	typeof noteRoutes &
+	typeof notificationRoutes &
+	typeof quotationRoutes &
+	typeof checkRoutes &
+	typeof locationRoutes &
+	typeof insuranceRoutes &
+	typeof auctionRoutes &
+	typeof reportRoutes &
+	typeof miniagentRoutes &
+	typeof adminMiniagentRoutes &
+	typeof investorDocumentRoutes &
+	typeof accountingRoutes;
+
+export const appRouter: BaseAppRouter = {
+	...healthRouter,
+	...authRouter,
+	...adminRoutes,
+	...adminImportRoutes,
+	...crmRoutes,
+	...clientFormsRoutes,
+	...bankAnalysisRoutes,
+	...vehicleRoutes,
+	...cobrosRoutes,
+	...legalContractRoutes,
+	...contractGenerationRoutes,
+	...vendorRoutes,
+	...noteRoutes,
+	...notificationRoutes,
+	...quotationRoutes,
+	...checkRoutes,
+	...locationRoutes,
+	...insuranceRoutes,
+	...auctionRoutes,
+	...reportRoutes,
+	...miniagentRoutes,
+	...adminMiniagentRoutes,
+	...investorDocumentRoutes,
+	...accountingRoutes,
 };
 
 // Investment routes exported separately to avoid TS7056 with declaration emit.

--- a/apps/crm/apps/server/src/routers/investments.ts
+++ b/apps/crm/apps/server/src/routers/investments.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/server";
-import { and, desc, eq } from "drizzle-orm";
+import { and, desc, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import { createInvestmentLeadWithOpportunity } from "../controllers/investment-lead";
 import { db } from "../db";
@@ -167,7 +167,9 @@ export const investmentsRouter = {
 				.optional(),
 		)
 		.handler(async ({ input, context }) => {
-			const conditions = [eq(investmentOpportunities.status, "open")];
+			const conditions = [
+				inArray(investmentOpportunities.status, ["open", "won"]),
+			];
 
 			if (input?.stage) {
 				conditions.push(eq(investmentOpportunities.stage, input.stage));

--- a/apps/crm/apps/server/src/routers/investments.ts
+++ b/apps/crm/apps/server/src/routers/investments.ts
@@ -27,6 +27,19 @@ import { ROLES } from "../lib/roles";
 import { getFileUrl } from "../lib/storage";
 import { createNotification } from "./notifications";
 
+const INVESTMENT_STAGE_FLOW = [
+	"data_collection",
+	"basic_profile_validation",
+	"profiling_and_qualification",
+	"model_presentation",
+	"active_follow_up",
+	"verbal_commitment_contract_sent",
+	"ticket_closure_transfer_activation",
+	"initial_onboarding_senior_handoff",
+] as const;
+
+const INVESTMENT_STAGE_VALUES = [...INVESTMENT_STAGE_FLOW, "lost"] as const;
+
 export const investmentsRouter = {
 	// ============ LEADS ============
 
@@ -149,17 +162,7 @@ export const investmentsRouter = {
 		.input(
 			z
 				.object({
-					stage: z
-						.enum([
-							"prospecting",
-							"contacted",
-							"negotiation",
-							"acceptance_signatures",
-							"welcome",
-							"closed",
-							"lost",
-						])
-						.optional(),
+					stage: z.enum(INVESTMENT_STAGE_VALUES).optional(),
 				})
 				.optional(),
 		)
@@ -296,135 +299,27 @@ export const investmentsRouter = {
 				});
 			}
 
-			// Definir orden de etapas y gates
-			const stageOrder = [
-				"prospecting",
-				"contacted",
-				"negotiation",
-				"acceptance_signatures",
-				"welcome",
-				"closed",
-			] as const;
-
-			const currentIndex = stageOrder.indexOf(
-				opp.stage as (typeof stageOrder)[number],
+			const currentIndex = INVESTMENT_STAGE_FLOW.indexOf(
+				opp.stage as (typeof INVESTMENT_STAGE_FLOW)[number],
 			);
-			if (currentIndex === -1 || currentIndex >= stageOrder.length - 1) {
+			if (
+				currentIndex === -1 ||
+				currentIndex >= INVESTMENT_STAGE_FLOW.length - 1
+			) {
 				throw new ORPCError("BAD_REQUEST", {
 					message: "No se puede avanzar desde esta etapa",
 				});
 			}
 
-			const nextStage = stageOrder[currentIndex + 1];
-
-			// Validar gates segun etapa actual
-			switch (opp.stage) {
-				case "prospecting": {
-					// Gate: al menos una interaccion registrada
-					const [interaction] = await db
-						.select()
-						.from(investmentInteractions)
-						.where(eq(investmentInteractions.investmentOpportunityId, opp.id))
-						.limit(1);
-					if (!interaction) {
-						throw new ORPCError("BAD_REQUEST", {
-							message:
-								"Debe registrar al menos una interaccion antes de avanzar",
-						});
-					}
-					break;
-				}
-				case "contacted": {
-					// Gate: al menos una interaccion
-					const [interaction] = await db
-						.select()
-						.from(investmentInteractions)
-						.where(eq(investmentInteractions.investmentOpportunityId, opp.id))
-						.limit(1);
-					if (!interaction) {
-						throw new ORPCError("BAD_REQUEST", {
-							message:
-								"Debe registrar al menos una interaccion antes de avanzar",
-						});
-					}
-					break;
-				}
-				case "negotiation": {
-					// Gate: todos los checklist completados
-					if (
-						!opp.scenariosCompleted ||
-						!opp.documentsApproved ||
-						!opp.kycCompleted ||
-						!opp.profileCompleted ||
-						!opp.webappProfileCreated
-					) {
-						const missing = [];
-						if (!opp.scenariosCompleted)
-							missing.push("escenarios de inversion");
-						if (!opp.documentsApproved) missing.push("documentacion aprobada");
-						if (!opp.kycCompleted) missing.push("KYC completado");
-						if (!opp.profileCompleted) missing.push("perfil del inversionista");
-						if (!opp.webappProfileCreated) missing.push("perfil en webapp CCI");
-						throw new ORPCError("BAD_REQUEST", {
-							message: `Faltan requisitos: ${missing.join(", ")}`,
-						});
-					}
-					// Notificar a juridico, contabilidad, gerencia
-					const [lead] = await db
-						.select()
-						.from(investmentLeads)
-						.where(eq(investmentLeads.id, opp.investmentLeadId))
-						.limit(1);
-
-					await createNotification({
-						titulo: `Nueva inversion en etapa de firmas - ${lead?.name}`,
-						descripcion: `La inversion de ${lead?.name} esta lista para generacion de contratos`,
-						type: "action_required",
-						createdBy: context.userId,
-						createdByRole: context.userRole,
-						assignedToRole: "juridico",
-						relatedEntityType: "opportunity",
-						relatedEntityId: opp.id,
-					});
-					await createNotification({
-						titulo: `Nueva inversion aprobada - ${lead?.name}`,
-						descripcion: `La inversion de ${lead?.name} paso a etapa de firmas`,
-						type: "aviso",
-						createdBy: context.userId,
-						createdByRole: context.userRole,
-						assignedToRole: "accounting",
-						relatedEntityType: "opportunity",
-						relatedEntityId: opp.id,
-					});
-					break;
-				}
-				case "acceptance_signatures": {
-					// Gate: todas las firmas completadas
-					if (opp.signaturesCompleted < opp.signaturesTotal) {
-						throw new ORPCError("BAD_REQUEST", {
-							message: `Faltan firmas: ${opp.signaturesCompleted}/${opp.signaturesTotal}`,
-						});
-					}
-					break;
-				}
-				case "welcome": {
-					// Gate: fondos validados por gerente
-					if (!opp.fundsValidated) {
-						throw new ORPCError("BAD_REQUEST", {
-							message:
-								"Los fondos deben ser validados por el gerente de inversiones",
-						});
-					}
-					break;
-				}
-			}
+			const nextStage = INVESTMENT_STAGE_FLOW[currentIndex + 1];
 
 			// Actualizar etapa (con condicion de stage actual para evitar race condition)
 			const [updated] = await db
 				.update(investmentOpportunities)
 				.set({
 					stage: nextStage,
-					status: nextStage === "closed" ? "won" : "open",
+					status:
+						nextStage === "initial_onboarding_senior_handoff" ? "won" : "open",
 					stageEnteredAt: new Date(),
 					updatedAt: new Date(),
 				})

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -220,22 +220,22 @@ export function OpportunityDetailModal({
 	const canViewContracts =
 		userRole && PERMISSIONS.canViewOpportunityContracts(userRole);
 	const fullLead = leadQuery.data?.data?.[0];
-	const displayLead = fullLead
+	const displayLead: OpportunityForModal["lead"] = fullLead
 		? {
-			...opportunity.lead,
-			firstName: fullLead.firstName,
-			middleName: fullLead.middleName,
-			lastName: fullLead.lastName,
-			secondLastName: fullLead.secondLastName,
-			dpi: fullLead.dpi,
-			email: fullLead.email,
-			phone: fullLead.phone,
-			age: fullLead.age,
-			direccion: fullLead.direccion,
-			departamento: fullLead.departamento,
-			municipio: fullLead.municipio,
-			zona: fullLead.zona,
-		}
+				id: opportunity.lead?.id ?? fullLead.id,
+				firstName: fullLead.firstName,
+				middleName: fullLead.middleName,
+				lastName: fullLead.lastName,
+				secondLastName: fullLead.secondLastName,
+				dpi: fullLead.dpi,
+				email: fullLead.email,
+				phone: fullLead.phone,
+				age: fullLead.age,
+				direccion: fullLead.direccion,
+				departamento: fullLead.departamento,
+				municipio: fullLead.municipio,
+				zona: fullLead.zona,
+			}
 		: opportunity.lead;
 	const canAccessCRM = userRole && PERMISSIONS.canAccessCRM(userRole);
 	const isAccounting = userRole && PERMISSIONS.canAccessAccounting(userRole);
@@ -323,16 +323,16 @@ export function OpportunityDetailModal({
 									</Label>
 									<div className="flex items-center gap-3">
 										<Users className="h-5 w-5 text-muted-foreground" />
-										{onNavigateToLead ? (
+										{onNavigateToLead && displayLead.id ? (
 											<span
 												className="cursor-pointer font-medium text-primary hover:underline"
 												role="button"
 												tabIndex={0}
-												onClick={() => onNavigateToLead(displayLead!.id)}
+												onClick={() => onNavigateToLead(displayLead.id)}
 												onKeyDown={(e) => {
 													if (e.key === "Enter" || e.key === " ") {
 														e.preventDefault();
-														onNavigateToLead(displayLead!.id);
+														onNavigateToLead(displayLead.id);
 													}
 												}}
 											>

--- a/apps/crm/apps/web/src/lib/investment-labels.ts
+++ b/apps/crm/apps/web/src/lib/investment-labels.ts
@@ -2,6 +2,8 @@
  * Labels en español para los enums del módulo de inversiones.
  */
 
+import { INVESTMENT_STAGES } from "@/lib/investment-stage-config";
+
 const LEAD_SOURCE_LABELS: Record<string, string> = {
 	website: "Sitio web",
 	referral: "Referido",
@@ -28,4 +30,11 @@ export function formatOpportunityStatus(
 ): string {
 	if (!status) return "—";
 	return OPPORTUNITY_STATUS_LABELS[status] ?? status;
+}
+
+export function formatInvestmentStage(
+	stage: string | null | undefined,
+): string {
+	if (!stage) return "—";
+	return INVESTMENT_STAGES.find((item) => item.id === stage)?.name ?? stage;
 }

--- a/apps/crm/apps/web/src/lib/investment-stage-config.ts
+++ b/apps/crm/apps/web/src/lib/investment-stage-config.ts
@@ -1,0 +1,80 @@
+const INVESTMENT_ACTIVE_STAGE_DEFINITIONS = [
+	{
+		id: "data_collection",
+		name: "Levantamiento de Datos",
+		color: "#2563eb",
+		kind: "active",
+	},
+	{
+		id: "basic_profile_validation",
+		name: "Contactado / Validación de Perfil Básico",
+		color: "#4f46e5",
+		kind: "active",
+	},
+	{
+		id: "profiling_and_qualification",
+		name: "Perfilado y Calificación",
+		color: "#7c3aed",
+		kind: "active",
+	},
+	{
+		id: "model_presentation",
+		name: "Presentación del Modelo",
+		color: "#0f766e",
+		kind: "active",
+	},
+	{
+		id: "active_follow_up",
+		name: "Seguimiento Activo",
+		color: "#d97706",
+		kind: "active",
+	},
+	{
+		id: "verbal_commitment_contract_sent",
+		name: "Compromiso Verbal y Envío de Contrato",
+		color: "#dc2626",
+		kind: "active",
+	},
+	{
+		id: "ticket_closure_transfer_activation",
+		name: "Cierre del Ticket",
+		color: "#059669",
+		kind: "active",
+	},
+	{
+		id: "initial_onboarding_senior_handoff",
+		name: "Onboarding Inicial y Transferencia al Senior",
+		color: "#16a34a",
+		kind: "active",
+	},
+] as const;
+
+export const INVESTMENT_LOST_STAGE = {
+	id: "lost",
+	name: "Perdida",
+	color: "#dc2626",
+	kind: "terminal",
+} as const;
+
+export const INVESTMENT_STAGE_CATALOG = [
+	...INVESTMENT_ACTIVE_STAGE_DEFINITIONS,
+	INVESTMENT_LOST_STAGE,
+] as const;
+
+export type InvestmentStageId = (typeof INVESTMENT_STAGE_CATALOG)[number]["id"];
+
+export type InvestmentStageKind =
+	(typeof INVESTMENT_STAGE_CATALOG)[number]["kind"];
+
+export type InvestmentStageConfig = {
+	id: InvestmentStageId;
+	name: string;
+	color: string;
+	kind: InvestmentStageKind;
+};
+
+export const INVESTMENT_ACTIVE_STAGES =
+	INVESTMENT_ACTIVE_STAGE_DEFINITIONS satisfies readonly InvestmentStageConfig[];
+
+export const INVESTMENT_STAGES =
+	INVESTMENT_STAGE_CATALOG satisfies readonly InvestmentStageConfig[];

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -247,6 +247,12 @@ function RouteComponent() {
 	// Función para abrir el modal de detalle de oportunidad
 	const handleOpenOpportunityDetail = () => {
 		if (matchingOpportunity) {
+			const leadDpi =
+				matchingOpportunity.lead &&
+				"dpi" in matchingOpportunity.lead &&
+				typeof matchingOpportunity.lead.dpi === "string"
+					? matchingOpportunity.lead.dpi
+					: null;
 			const opportunityForModal: OpportunityForModal = {
 				id: matchingOpportunity.id,
 				title: matchingOpportunity.title,
@@ -264,7 +270,7 @@ function RouteComponent() {
 							secondLastName: matchingOpportunity.lead.secondLastName,
 							email: matchingOpportunity.lead.email,
 							phone: matchingOpportunity.lead.phone,
-							dpi: matchingOpportunity.lead.dpi,
+							dpi: leadDpi,
 						}
 					: null,
 				stage: matchingOpportunity.stage

--- a/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
@@ -36,7 +36,10 @@ import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
-import { formatOpportunityStatus } from "@/lib/investment-labels";
+import {
+	formatInvestmentStage,
+	formatOpportunityStatus,
+} from "@/lib/investment-labels";
 import { INVESTMENT_STAGES } from "@/lib/investment-stage-config";
 import { client, orpc } from "@/utils/orpc";
 
@@ -189,6 +192,104 @@ function MarkAsLostDialog({
 	);
 }
 
+// ─── Audit Helpers ───────────────────────────────────────────────────────────
+
+const AUDIT_ACTION_LABELS: Record<string, string> = {
+	stage_advanced: "Etapa avanzada",
+	marked_as_lost: "Marcada como perdida",
+	scenario_created: "Escenario creado",
+	scenario_accepted: "Escenario aceptado",
+	document_uploaded: "Documento subido",
+	document_approved: "Documento aprobado",
+	document_rejected: "Documento rechazado",
+	interaction_created: "Interacción registrada",
+	funds_validated: "Fondos validados",
+	signature_updated: "Firmas actualizadas",
+	non_advance_survey_submitted: "Encuesta de no avance enviada",
+};
+
+function formatAuditAction(action: string): string {
+	return AUDIT_ACTION_LABELS[action] ?? action;
+}
+
+function formatAuditDetails(
+	action: string,
+	details: Record<string, unknown>,
+): React.ReactNode {
+	const str = (key: string) => String(details[key] ?? "");
+
+	switch (action) {
+		case "stage_advanced":
+			return (
+				<span>
+					{details.from ? (
+						<>De <strong>{formatInvestmentStage(str("from"))}</strong> a </>
+					) : null}
+					<strong>{formatInvestmentStage(str("to"))}</strong>
+				</span>
+			);
+		case "marked_as_lost":
+			return (
+				<span>
+					Etapa anterior: <strong>{formatInvestmentStage(str("previousStage"))}</strong>
+					{details.reason ? <> — Razón: {str("reason")}</> : null}
+				</span>
+			);
+		case "scenario_created":
+			return (
+				<span>
+					Modalidad: <strong>{str("modality")}</strong>
+					{details.amount ? <> — Monto: Q{Number(details.amount).toLocaleString("es-GT")}</> : null}
+				</span>
+			);
+		case "scenario_accepted":
+			return <span>Escenario seleccionado</span>;
+		case "document_uploaded":
+			return (
+				<span>
+					Tipo: <strong>{str("documentType")}</strong>
+					{details.fileName ? <> — Archivo: {str("fileName")}</> : null}
+				</span>
+			);
+		case "document_approved":
+		case "document_rejected":
+			return (
+				<span>
+					Documento {action === "document_approved" ? "aprobado" : "rechazado"}
+					{details.documentType ? <> — Tipo: {str("documentType")}</> : null}
+				</span>
+			);
+		case "interaction_created":
+			return (
+				<span>
+					Tipo: <strong>{str("type")}</strong>
+					{details.date ? <> — Fecha: {str("date")}</> : null}
+				</span>
+			);
+		case "signature_updated":
+			return (
+				<span>
+					{details.completed ? "Completadas" : "Pendientes"}
+					{details.total != null ? <> — Total: {String(details.total)}</> : null}
+				</span>
+			);
+		case "non_advance_survey_submitted":
+			return (
+				<span>
+					Razón: {str("reason")}
+				</span>
+			);
+		default:
+			return (
+				<span>
+					{Object.entries(details)
+						.map(([k, v]) => `${k}: ${v}`)
+						.join(" — ")}
+				</span>
+			);
+	}
+}
+
 // ─── Audit Log Tab ────────────────────────────────────────────────────────────
 
 function AuditLogTab({
@@ -277,11 +378,13 @@ function AuditLogTab({
 							>
 								<History className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
 								<div className="min-w-0 flex-1">
-									<p className="font-medium text-sm">{entry.action}</p>
+									<p className="font-medium text-sm">
+										{formatAuditAction(entry.action)}
+									</p>
 									{entry.details != null && (
-										<pre className="mt-1 overflow-x-auto rounded bg-muted px-2 py-1 font-mono text-xs">
-											{JSON.stringify(entry.details, null, 2)}
-										</pre>
+										<div className="mt-1 text-muted-foreground text-xs">
+											{formatAuditDetails(entry.action, entry.details as Record<string, unknown>)}
+										</div>
 									)}
 									<p className="mt-1 text-muted-foreground text-xs">
 										{formatDateTime(entry.createdAt)}

--- a/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
@@ -4,9 +4,7 @@ import {
 	AlertCircle,
 	ArrowLeft,
 	ArrowRight,
-	CheckCircle2,
 	ChevronRight,
-	Clock,
 	FileText,
 	History,
 	Info,
@@ -25,13 +23,7 @@ import { InvestmentInteractions } from "@/components/investments/InvestmentInter
 import { InvestorProfile } from "@/components/investments/InvestorProfile";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
 	Dialog,
 	DialogContent,
@@ -44,6 +36,8 @@ import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
+import { formatOpportunityStatus } from "@/lib/investment-labels";
+import { INVESTMENT_STAGES } from "@/lib/investment-stage-config";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/inversiones/$opportunityId")({
@@ -52,55 +46,40 @@ export const Route = createFileRoute("/inversiones/$opportunityId")({
 
 // ─── Stage Config ─────────────────────────────────────────────────────────────
 
-const STAGE_CONFIG: Record<
-	string,
-	{ label: string; color: string; bgColor: string }
-> = {
-	prospecting: {
-		label: "Prospección",
-		color: "#6366f1",
-		bgColor: "bg-indigo-100 text-indigo-800",
-	},
-	contacted: {
-		label: "Contactado",
-		color: "#8b5cf6",
-		bgColor: "bg-purple-100 text-purple-800",
-	},
-	negotiation: {
-		label: "Negociación",
-		color: "#f59e0b",
-		bgColor: "bg-amber-100 text-amber-800",
-	},
-	acceptance_signatures: {
-		label: "Aceptado/Firmas",
-		color: "#3b82f6",
-		bgColor: "bg-blue-100 text-blue-800",
-	},
-	welcome: {
-		label: "Bienvenida",
-		color: "#10b981",
-		bgColor: "bg-emerald-100 text-emerald-800",
-	},
-	closed: {
-		label: "Cerrado",
-		color: "#22c55e",
-		bgColor: "bg-green-100 text-green-800",
-	},
-	lost: {
-		label: "Perdido",
-		color: "#ef4444",
-		bgColor: "bg-red-100 text-red-800",
-	},
-};
+const STAGE_CONFIG = Object.fromEntries(
+	INVESTMENT_STAGES.map((stage) => [
+		stage.id,
+		{
+			label: stage.name,
+			color: stage.color,
+		},
+	]),
+) satisfies Record<string, { label: string; color: string }>;
 
-function StageBadge({ stage }: { stage: string }) {
-	const config = STAGE_CONFIG[stage] ?? {
-		label: stage,
-		bgColor: "bg-gray-100 text-gray-800",
+const WON_STAGE_ID = "initial_onboarding_senior_handoff";
+
+function formatUnknownStageLabel(stage: string | null | undefined): string {
+	if (!stage) return "Etapa desconocida";
+	return stage
+		.split(/[_-]+/)
+		.filter(Boolean)
+		.map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+		.join(" ");
+}
+
+function StageBadge({ stage }: { stage: string | null | undefined }) {
+	const config = (stage ? STAGE_CONFIG[stage] : undefined) ?? {
+		label: formatUnknownStageLabel(stage),
+		color: "#6b7280",
 	};
+
 	return (
 		<span
-			className={`inline-flex items-center rounded-full px-2.5 py-0.5 font-medium text-xs ${config.bgColor}`}
+			className="inline-flex items-center rounded-full px-2.5 py-0.5 font-medium text-xs"
+			style={{
+				backgroundColor: `${config.color}1A`,
+				color: config.color,
+			}}
 		>
 			{config.label}
 		</span>
@@ -207,114 +186,6 @@ function MarkAsLostDialog({
 				</form>
 			</DialogContent>
 		</Dialog>
-	);
-}
-
-// ─── Negotiation Checklist ────────────────────────────────────────────────────
-
-function NegotiationChecklist({
-	opportunity,
-}: {
-	opportunity: {
-		scenariosCompleted: boolean | null;
-		documentsApproved: boolean | null;
-		kycCompleted: boolean | null;
-		profileCompleted: boolean | null;
-		webappProfileCreated: boolean | null;
-	};
-}) {
-	const items = [
-		{
-			key: "scenariosCompleted",
-			label: "Escenarios de inversión",
-			done: opportunity.scenariosCompleted,
-		},
-		{
-			key: "documentsApproved",
-			label: "Documentación aprobada",
-			done: opportunity.documentsApproved,
-		},
-		{
-			key: "kycCompleted",
-			label: "KYC completado",
-			done: opportunity.kycCompleted,
-		},
-		{
-			key: "profileCompleted",
-			label: "Perfil del inversionista",
-			done: opportunity.profileCompleted,
-		},
-		{
-			key: "webappProfileCreated",
-			label: "Perfil en webapp CCI",
-			done: opportunity.webappProfileCreated,
-		},
-	];
-
-	const completedCount = items.filter((i) => i.done).length;
-
-	return (
-		<Card>
-			<CardHeader className="pb-3">
-				<CardTitle className="text-sm">Requisitos de Negociación</CardTitle>
-				<CardDescription className="text-xs">
-					{completedCount}/{items.length} completados
-				</CardDescription>
-			</CardHeader>
-			<CardContent className="space-y-2">
-				{items.map((item) => (
-					<div key={item.key} className="flex items-center gap-2">
-						{item.done ? (
-							<CheckCircle2 className="h-4 w-4 text-green-500" />
-						) : (
-							<AlertCircle className="h-4 w-4 text-amber-500" />
-						)}
-						<span
-							className={`text-sm ${item.done ? "text-foreground" : "text-muted-foreground"}`}
-						>
-							{item.label}
-						</span>
-					</div>
-				))}
-			</CardContent>
-		</Card>
-	);
-}
-
-// ─── Signatures Progress ──────────────────────────────────────────────────────
-
-function SignaturesProgress({
-	completed,
-	total,
-}: {
-	completed: number;
-	total: number;
-}) {
-	const percentage = total > 0 ? Math.round((completed / total) * 100) : 0;
-
-	return (
-		<Card>
-			<CardHeader className="pb-3">
-				<CardTitle className="text-sm">Progreso de Firmas</CardTitle>
-				<CardDescription className="text-xs">
-					{completed} de {total} firmas completadas
-				</CardDescription>
-			</CardHeader>
-			<CardContent>
-				<div className="space-y-2">
-					<div className="flex items-center justify-between text-sm">
-						<span className="text-muted-foreground">Avance</span>
-						<span className="font-medium">{percentage}%</span>
-					</div>
-					<div className="h-2 w-full overflow-hidden rounded-full bg-muted">
-						<div
-							className="h-full rounded-full bg-blue-500 transition-all duration-300"
-							style={{ width: `${percentage}%` }}
-						/>
-					</div>
-				</div>
-			</CardContent>
-		</Card>
 	);
 }
 
@@ -516,9 +387,10 @@ function RouteComponent() {
 	const displayName = investor
 		? `${investor.firstName} ${investor.lastName}`
 		: (lead?.name ?? "Sin nombre");
-	const currentStage = opportunity.stage;
+	const currentStage: string = opportunity.stage;
 	const isLost = currentStage === "lost" || opportunity.status === "lost";
-	const isClosed = currentStage === "closed";
+	const isClosed =
+		!isLost && (currentStage === WON_STAGE_ID || opportunity.status === "won");
 	const canAdvance = !isLost && !isClosed;
 
 	return (
@@ -548,6 +420,11 @@ function RouteComponent() {
 							<div className="flex flex-wrap items-center gap-2">
 								<h1 className="font-bold text-xl">{displayName}</h1>
 								<StageBadge stage={currentStage} />
+								{isClosed && (
+									<Badge className="bg-green-100 text-green-800 hover:bg-green-100">
+										Ganada
+									</Badge>
+								)}
 								{isLost && (
 									<Badge variant="destructive" className="text-xs">
 										Perdida
@@ -580,22 +457,6 @@ function RouteComponent() {
 						)}
 					</div>
 				</div>
-
-				{/* Stage-specific progress */}
-				{currentStage === "negotiation" && (
-					<div className="mt-4 max-w-sm">
-						<NegotiationChecklist opportunity={opportunity} />
-					</div>
-				)}
-
-				{currentStage === "acceptance_signatures" && (
-					<div className="mt-4 max-w-sm">
-						<SignaturesProgress
-							completed={opportunity.signaturesCompleted ?? 0}
-							total={opportunity.signaturesTotal ?? 0}
-						/>
-					</div>
-				)}
 
 				{isLost && opportunity.lostReason && (
 					<div className="mt-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900 dark:bg-red-950">
@@ -741,7 +602,7 @@ function RouteComponent() {
 											Estado
 										</span>
 										<span className="font-medium text-sm">
-											{opportunity.status}
+											{formatOpportunityStatus(opportunity.status)}
 										</span>
 									</div>
 									<Separator />

--- a/apps/crm/apps/web/src/routes/inversiones/index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/index.tsx
@@ -542,7 +542,7 @@ function RouteComponent() {
 	}
 
 	return (
-		<div className="flex h-full flex-col">
+		<div className="flex h-full min-w-0 flex-col overflow-hidden">
 			{/* Header */}
 			<div className="border-b bg-background px-6 py-4">
 				<div className="flex items-center justify-between">

--- a/apps/crm/apps/web/src/routes/inversiones/index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/index.tsx
@@ -22,13 +22,7 @@ import invariant from "tiny-invariant";
 import * as XLSX from "xlsx";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardDescription,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+import { Card } from "@/components/ui/card";
 import {
 	Dialog,
 	DialogContent,
@@ -47,22 +41,16 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
+import { formatInvestmentStage } from "@/lib/investment-labels";
+import {
+	INVESTMENT_ACTIVE_STAGES,
+	type InvestmentStageConfig,
+} from "@/lib/investment-stage-config";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/inversiones/")({
 	component: RouteComponent,
 });
-
-const INVESTMENT_STAGES = [
-	{ id: "prospecting", name: "Prospección", color: "#6366f1" },
-	{ id: "contacted", name: "Contactado", color: "#8b5cf6" },
-	{ id: "negotiation", name: "Negociación", color: "#f59e0b" },
-	{ id: "acceptance_signatures", name: "Aceptado/Firmas", color: "#3b82f6" },
-	{ id: "welcome", name: "Bienvenida", color: "#10b981" },
-	{ id: "closed", name: "Cerrado", color: "#22c55e" },
-] as const;
-
-type StageId = (typeof INVESTMENT_STAGES)[number]["id"];
 
 function getDaysInStage(updatedAt: string | Date | null): number {
 	if (!updatedAt) return 0;
@@ -75,6 +63,24 @@ function formatAmount(amount: string | null | undefined): string {
 	const num = Number.parseFloat(amount);
 	if (Number.isNaN(num)) return "—";
 	return `Q${num.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function canAdvanceToNextStage(
+	currentStage: string,
+	targetStage: string,
+): boolean {
+	const currentStageIdx = INVESTMENT_ACTIVE_STAGES.findIndex(
+		(stage) => stage.id === currentStage,
+	);
+	const targetStageIdx = INVESTMENT_ACTIVE_STAGES.findIndex(
+		(stage) => stage.id === targetStage,
+	);
+
+	if (currentStageIdx === -1 || targetStageIdx === -1) {
+		return false;
+	}
+
+	return targetStageIdx === currentStageIdx + 1;
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -164,7 +170,7 @@ function DroppableInvestmentColumn({
 	items,
 	onDrop,
 }: {
-	stage: (typeof INVESTMENT_STAGES)[number];
+	stage: InvestmentStageConfig;
 	items: InvestmentOpportunityItem[];
 	onDrop: (opportunityId: string, newStage: string) => void;
 }) {
@@ -215,11 +221,16 @@ function DroppableInvestmentColumn({
 				</div>
 				<p className="mt-1.5 font-medium text-sm">{stage.name}</p>
 				<p className="text-muted-foreground text-xs">
-					{totalAmount > 0 ? `Q${totalAmount.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : "—"}{" "}
+					{totalAmount > 0
+						? `Q${totalAmount.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+						: "—"}{" "}
 					monto total
 				</p>
 			</div>
-			<div className="flex min-h-0 flex-col gap-3 overflow-y-auto px-3 pb-3" ref={ref}>
+			<div
+				className="flex min-h-0 flex-col gap-3 overflow-y-auto px-3 pb-3"
+				ref={ref}
+			>
 				{items.length === 0 ? (
 					<div className="py-8 text-center text-muted-foreground">
 						<Target className="mx-auto mb-2 h-8 w-8 opacity-50" />
@@ -434,41 +445,37 @@ function RouteComponent() {
 	});
 
 	const allItems = opportunitiesQuery.data ?? [];
+	const activeStageIds = new Set<string>(
+		INVESTMENT_ACTIVE_STAGES.map((stage) => stage.id),
+	);
 
 	// Filter out "lost" — only show open pipeline
 	const openItems = allItems.filter(
 		(item) => item.opportunity.stage !== "lost",
 	);
+	const unknownStageItems = openItems.filter(
+		(item) => !activeStageIds.has(String(item.opportunity.stage)),
+	);
+	const activeStageItems = openItems.filter((item) =>
+		activeStageIds.has(String(item.opportunity.stage)),
+	);
 
-	const itemsByStage = INVESTMENT_STAGES.reduce(
+	const itemsByStage = INVESTMENT_ACTIVE_STAGES.reduce(
 		(acc, stage) => {
-			acc[stage.id] = openItems.filter(
-				(item) => item.opportunity.stage === stage.id,
+			acc[stage.id] = activeStageItems.filter(
+				(item) => String(item.opportunity.stage) === stage.id,
 			);
 			return acc;
 		},
-		{} as Record<StageId, typeof openItems>,
+		{} as Partial<Record<string, typeof openItems>>,
 	);
 
 	function handleDrop(opportunityId: string, newStage: string) {
-		// Find the current stage of the opportunity
 		const item = allItems.find((i) => i.opportunity.id === opportunityId);
 		if (!item) return;
 
-		const currentStageIdx = INVESTMENT_STAGES.findIndex(
-			(s) => s.id === item.opportunity.stage,
-		);
-		const targetStageIdx = INVESTMENT_STAGES.findIndex(
-			(s) => s.id === newStage,
-		);
-
-		// Only allow advancing to the immediate next stage
-		if (targetStageIdx !== currentStageIdx + 1) {
-			if (targetStageIdx <= currentStageIdx) {
-				toast.error("No se puede retroceder de etapa");
-			} else {
-				toast.error("Solo se puede avanzar una etapa a la vez");
-			}
+		if (!canAdvanceToNextStage(item.opportunity.stage, newStage)) {
+			toast.error("Solo se permite avanzar a la siguiente etapa");
 			return;
 		}
 
@@ -494,10 +501,6 @@ function RouteComponent() {
 			return;
 		}
 
-		const stageMap = Object.fromEntries(
-			INVESTMENT_STAGES.map((s) => [s.id, s.name]),
-		);
-
 		const rows = allItems.map((item) => {
 			const name = item.investor
 				? `${item.investor.firstName} ${item.investor.lastName}`
@@ -507,8 +510,7 @@ function RouteComponent() {
 			const amount = item.lead?.proposedAmount
 				? Number.parseFloat(item.lead.proposedAmount)
 				: "";
-			const stage =
-				stageMap[item.opportunity.stage as string] ?? item.opportunity.stage;
+			const stage = formatInvestmentStage(item.opportunity.stage);
 
 			return {
 				Nombre: name,
@@ -635,15 +637,57 @@ function RouteComponent() {
 						</div>
 					</div>
 				) : (
-					<div className="flex gap-4">
-						{INVESTMENT_STAGES.map((stage) => (
-							<DroppableInvestmentColumn
-								key={stage.id}
-								stage={stage}
-								items={itemsByStage[stage.id] ?? []}
-								onDrop={handleDrop}
-							/>
-						))}
+					<div className="space-y-4">
+						{unknownStageItems.length > 0 && (
+							<div className="rounded-xl border border-amber-300 bg-amber-50 p-4 text-amber-950">
+								<div className="flex items-start gap-3">
+									<AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+									<div className="space-y-2">
+										<div>
+											<p className="font-medium text-sm">
+												Oportunidades en etapas no reconocidas
+											</p>
+											<p className="text-sm/6">
+												Estas oportunidades siguen abiertas, pero su etapa no
+												pertenece al funnel activo configurado.
+											</p>
+										</div>
+										<div className="space-y-2">
+											{unknownStageItems.map((item) => {
+												const displayName = item.investor
+													? `${item.investor.firstName} ${item.investor.lastName}`
+													: (item.lead?.name ?? "Sin nombre");
+
+												return (
+													<div
+														key={item.opportunity.id}
+														className="flex flex-wrap items-center gap-2 rounded-lg border border-amber-200 bg-background/80 px-3 py-2 text-sm"
+													>
+														<Badge variant="outline">
+															{formatInvestmentStage(item.opportunity.stage)}
+														</Badge>
+														<span className="font-medium">{displayName}</span>
+														<span className="text-muted-foreground">
+															ID: {item.opportunity.id.slice(0, 8)}
+														</span>
+													</div>
+												);
+											})}
+										</div>
+									</div>
+								</div>
+							</div>
+						)}
+						<div className="flex gap-4">
+							{INVESTMENT_ACTIVE_STAGES.map((stage) => (
+								<DroppableInvestmentColumn
+									key={stage.id}
+									stage={stage}
+									items={itemsByStage[stage.id] ?? []}
+									onDrop={handleDrop}
+								/>
+							))}
+						</div>
 					</div>
 				)}
 			</div>

--- a/apps/crm/apps/web/src/utils/orpc.ts
+++ b/apps/crm/apps/web/src/utils/orpc.ts
@@ -5,7 +5,7 @@ import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import type {
-	appRouter,
+	AppRouter,
 	disbursementRouter,
 	manualVehicleRouter,
 } from "../../../server/src/routers/index";
@@ -63,7 +63,7 @@ export const link = new RPCLink({
 
 // Merge router types to avoid TS7056 with declaration emit
 // See: https://orpc.dev/docs/advanced/exceeds-the-maximum-length-problem
-type MergedRouter = typeof appRouter &
+type MergedRouter = AppRouter &
 	typeof manualVehicleRouter &
 	typeof investmentsRouter &
 	typeof disbursementRouter;


### PR DESCRIPTION
## Summary
- replace the investment funnel with the new 8-stage pipeline plus `lost`
- add a safe migration for legacy investment stages and correct the legacy `welcome`/`closed` mapping order
- align backend stage creation/advancement and the investments UI with the new funnel
- fix the server router TS7056 serialization issue and the remaining web typecheck blockers touched during this work

## Why
The CRM investment pipeline needed to match the new operating process while staying safe for legacy data and keeping the repo buildable.

## Impact
- new investment leads now start in `data_collection`
- the investments kanban and detail views now use the new stage names/order
- legacy investment stage data will migrate to the new enum values
- server and web typecheck pass again for the touched scope

## Validation
- `bun run --filter server check-types`
- `bun run --filter web check-types`
- `../../node_modules/.bin/tsc --noEmit --pretty false` in `apps/server`
- `../../node_modules/.bin/tsc --noEmit --pretty false` in `apps/web`

## Notes
- Kept `advanceInvestmentStage` with minimal validation only, per the agreed scope for this change.
- The PR is draft so the workflow/guard decision can still be discussed before merge.