### PR TITLE
fix: exclude fallen credits from late fee processing

### DIFF
--- a/apps/cartera-back/src/controllers/createCredit.ts
+++ b/apps/cartera-back/src/controllers/createCredit.ts
@@ -186,7 +186,7 @@ const creditSchema = z.object({
     .array(
       z.object({
         inversionista_id: z.number().int().positive(),
-        monto_aportado: z.number().positive(),
+        monto_aportado: z.number().nonnegative(),
         porcentaje_cash_in: z.number().min(0).max(100),
         porcentaje_inversion: z.number().min(0).max(100),
         tipo_inversion: z.enum(["compra_cartera", "reinversion"]).optional(),
@@ -361,7 +361,9 @@ const creditosInversionistasData: InversionistaData[] = creditData.inversionista
   console.log(`💵 Capital Total del Crédito: Q${capitalTotal.toFixed(2)}`);
   
   // 🔥 CALCULAR PORCENTAJE DE PARTICIPACIÓN
-  const porcentajeParticipacion = montoAportado.div(capitalTotal).times(100);
+  const porcentajeParticipacion = capitalTotal.eq(0)
+    ? new Big(0)
+    : montoAportado.div(capitalTotal).times(100);
   
   console.log(`\n📐 CÁLCULO DE PARTICIPACIÓN:`);
   console.log(`   Fórmula: (${montoAportado.toFixed(2)} / ${capitalTotal.toFixed(2)}) * 100`);

--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -377,7 +377,7 @@ export async function procesarMoras() {
       
       const isOverdue = fechaVenc < hoy;
       const isUnpaid = c.pagado === false;
-      const statusExcluidos = ["EN_CONVENIO", "INCOBRABLE", "CANCELADO", "PENDIENTE_CANCELACION"];
+      const statusExcluidos = ["EN_CONVENIO", "INCOBRABLE", "CANCELADO", "PENDIENTE_CANCELACION","CAIDO"];
       const isEligible = !statusExcluidos.includes(c.statusCredit ?? "");
 
       if (isOverdue && isUnpaid) {

--- a/apps/carteraFront/src/private/cartera/hooks/registerCredit.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerCredit.ts
@@ -36,7 +36,7 @@ export const creditSchema = z.object({
     .array(
       z.object({
         inversionista_id: z.number().int().positive(),
-        monto_aportado: z.number().positive("Monto debe ser mayor a 0"),
+        monto_aportado: z.number().nonnegative("Monto no puede ser negativo"),
         porcentaje_cash_in: z.number().min(0).max(100),
         porcentaje_inversion: z.number().min(0).max(100),
         tipo_inversion: z.enum(["compra_cartera", "reinversion"]).optional(),


### PR DESCRIPTION
Adds the "CAIDO" status to the list of excluded statuses in the late fee calculation logic to prevent overdue fees from being applied to fallen credits.
