### PR TITLE
fix: prevent duplicate opportunities by source dedup

### DIFF
--- a/apps/crm/apps/server/src/controllers/bot.ts
+++ b/apps/crm/apps/server/src/controllers/bot.ts
@@ -17,6 +17,7 @@ import { salesUser } from "@/utils/constants";
 import { db } from "../db";
 import { validarDpi } from "../utils/cui-validation";
 import { otpController } from "./otp";
+import { getOpenOpportunityBySource } from "./public-lead";
 
 // Type for document type enum
 type DocumentType = (typeof documentTypeEnum.enumValues)[number];
@@ -479,35 +480,51 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 	}
 
 	// ========================
-	// 5. 🔥 SIEMPRE crear nueva oportunidad
+	// 5. Crear oportunidad solo si no existe una abierta con mismo source
 	// ========================
-	const [firstStage] = await db
-		.select()
-		.from(salesStages)
-		.orderBy(asc(salesStages.order))
-		.limit(1);
+	const existingOpportunity = await getOpenOpportunityBySource(
+		leadId,
+		"Whatsapp",
+	);
 
-	if (!firstStage) {
-		throw new Error("[ERROR] No sales stage found");
+	let opportunityId: string;
+
+	if (existingOpportunity) {
+		console.log(
+			`[DEBUG] Lead ${leadId} already has open opportunity from Whatsapp: ${existingOpportunity.id}`,
+		);
+		opportunityId = existingOpportunity.id;
+	} else {
+		const [firstStage] = await db
+			.select()
+			.from(salesStages)
+			.orderBy(asc(salesStages.order))
+			.limit(1);
+
+		if (!firstStage) {
+			throw new Error("[ERROR] No sales stage found");
+		}
+
+		console.log(`[DEBUG] Creating NEW opportunity for lead ${leadId}`);
+
+		const [newOpportunity] = await db
+			.insert(opportunities)
+			.values({
+				leadId: leadId,
+				status: "open",
+				probability: 0,
+				createdAt: new Date(),
+				updatedAt: new Date(),
+				assignedTo: assignedUserId,
+				createdBy: createdByUserId,
+				title: `Oportunidad de crédito para ${renapData.firstName} ${renapData.firstLastName}`,
+				stageId: firstStage.id,
+				source: "Whatsapp",
+			})
+			.returning();
+
+		opportunityId = newOpportunity.id;
 	}
-
-	console.log(`[DEBUG] Creating NEW opportunity for lead ${leadId}`);
-
-	const [newOpportunity] = await db
-		.insert(opportunities)
-		.values({
-			leadId: leadId,
-			status: "open",
-			probability: 0,
-			createdAt: new Date(),
-			updatedAt: new Date(),
-			assignedTo: assignedUserId,
-			createdBy: createdByUserId,
-			title: `Oportunidad de crédito para ${renapData.firstName} ${renapData.firstLastName}`,
-			stageId: firstStage.id,
-			source: "Whatsapp", // Bot source
-		})
-		.returning();
 
 	// ========================
 	// 6. Response
@@ -516,11 +533,12 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 
 	return {
 		success: true,
-		message:
-			"RENAP data processed, lead synced, and opportunity created successfully",
+		message: existingOpportunity
+			? "RENAP data processed, lead synced, existing opportunity reused"
+			: "RENAP data processed, lead synced, and opportunity created successfully",
 		data: renapData,
 		leadId,
-		opportunityId: newOpportunity.id,
+		opportunityId,
 		magicUrl: magicUrlValue,
 	};
 };

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, gte, or } from "drizzle-orm";
+import { and, asc, count, desc, eq, or } from "drizzle-orm";
 import type { Context } from "hono";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
@@ -176,11 +176,13 @@ export async function createOpportunityForLead(
 }
 
 /**
- * Verifica si un lead ya tiene una oportunidad creada en las últimas 24 horas.
+ * Verifica si un lead ya tiene una oportunidad abierta con el mismo source.
  */
-export async function getRecentOpportunity(leadId: string) {
-	const twentyFourHoursAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
-	const [recent] = await db
+export async function getOpenOpportunityBySource(
+	leadId: string,
+	source: LeadSource,
+) {
+	const [existing] = await db
 		.select({
 			id: opportunities.id,
 			source: opportunities.source,
@@ -194,12 +196,12 @@ export async function getRecentOpportunity(leadId: string) {
 					eq(opportunities.status, "open"),
 					eq(opportunities.status, "on_hold"),
 				),
-				gte(opportunities.createdAt, twentyFourHoursAgo),
+				eq(opportunities.source, source),
 			),
 		)
 		.orderBy(desc(opportunities.createdAt))
 		.limit(1);
-	return recent;
+	return existing;
 }
 
 export async function createPublicLead(c: Context) {
@@ -267,18 +269,20 @@ export async function createPublicLead(c: Context) {
 					.returning();
 			}
 
-			// Verificar oportunidad reciente antes de crear una nueva
-			const recentOpportunity = await getRecentOpportunity(existingLead.id);
-			if (recentOpportunity) {
-				if (body.source || body.campaign) {
+			// Verificar si ya tiene una oportunidad abierta con el mismo source
+			const existingOpportunity = await getOpenOpportunityBySource(
+				existingLead.id,
+				source,
+			);
+			if (existingOpportunity) {
+				if (body.campaign) {
 					await db
 						.update(opportunities)
 						.set({
-							source,
 							campaign,
 							updatedAt: new Date(),
 						})
-						.where(eq(opportunities.id, recentOpportunity.id));
+						.where(eq(opportunities.id, existingOpportunity.id));
 				}
 
 				return c.json(
@@ -286,7 +290,7 @@ export async function createPublicLead(c: Context) {
 						success: true,
 						data: leadData,
 						message:
-							"Lead ya tiene una oportunidad reciente (últimas 24 horas)",
+							"Lead ya tiene una oportunidad abierta con el mismo source",
 					},
 					200,
 				);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1814,7 +1814,7 @@ export const cobrosRouter = {
 					etiquetas: casoCobro?.etiquetas || [],
 
 					// Datos del contrato (cartera primero, fallback a nuestra BD)
-					montoFinanciado: creditoCompleto.credito.deudatotal,
+					montoFinanciado: creditoCompleto.credito.capital ?? creditoCompleto.credito.deudatotal ?? "0.00",
 					cuotaMensual:
 						creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual,
 					numeroCuotas: creditoCompleto.credito.plazo,


### PR DESCRIPTION
## Summary
- Reemplaza la verificación por ventana de 24 horas con búsqueda por oportunidad abierta + mismo source para evitar duplicados
- Aplica la misma lógica de dedup al flujo del bot de WhatsApp
- Corrige montoFinanciado para usar capital con fallback a deudatotal

## Test plan
- [ ] Crear lead desde landing con mismo source dos veces → no debe duplicar oportunidad
- [ ] Crear lead desde landing con diferente source → debe crear nueva oportunidad
- [ ] Enviar DPI por WhatsApp bot dos veces → no debe duplicar oportunidad
- [ ] Verificar que montoFinanciado muestra capital correctamente en cobros

🤖 Generated with [Claude Code](https://claude.com/claude-code)