### PR TITLE
[codex] update consent terms copy

### DIFF
--- a/apps/portal-web/src/features/FormLeads/components/Formulario.tsx
+++ b/apps/portal-web/src/features/FormLeads/components/Formulario.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useSearch } from "@tanstack/react-router";
-import { Input, Button } from "@/components";
+import { Input, Button, Link } from "@/components";
 import { IconCar } from "@/components/icons/IconCar";
 import { IconLockClose } from "@/components/icons/IconLockClose";
 import { useFormLeads } from "../hooks/useForm";
@@ -176,6 +176,17 @@ export const Formulario = () => {
       >
         {isSubmitting ? "Enviando..." : "Enviar Formulario"}
       </Button>
+      <p className="text-xs text-[#7A7A8A]">
+        Al enviar tus datos, confirmas que has leído y aceptas los{" "}
+        <Link
+          href="/terms&conditions"
+          className="text-primary"
+          underline
+        >
+          Términos y Condiciones
+        </Link>
+        .
+      </p>
       <p className="text-xs text-[#7A7A8A]">
         Tus datos están protegidos. No compartimos tu información con terceros.
       </p>

--- a/apps/portal-web/src/features/LeadInvestor/components/FormularioInvestor.tsx
+++ b/apps/portal-web/src/features/LeadInvestor/components/FormularioInvestor.tsx
@@ -1,4 +1,4 @@
-import { Input, Button, Select } from "@/components";
+import { Input, Button, Link, Select } from "@/components";
 import { IconPersonIndividual } from "@/components/icons/IconPersonIndividual";
 import { IconPersonJuridica } from "@/components/icons/IconPersonJuridica";
 import { useFormInvestor } from "../hooks/useFormInvestor";
@@ -271,6 +271,17 @@ export const FormularioInvestor = ({
           >
             {isSubmitting ? "Enviando..." : "Enviar formulario"}
           </Button>
+          <p className="text-xs text-[#7A7A8A]">
+            Al enviar tus datos, confirmas que has leído y aceptas los{" "}
+            <Link
+              href="/terms&conditions"
+              className="text-primary"
+              underline
+            >
+              Términos y Condiciones
+            </Link>
+            .
+          </p>
           <p className="text-xs text-[#7A7A8A]">
             Tus datos están protegidos. No compartimos tu información con terceros.
           </p>

--- a/apps/portal-web/src/features/Login/components/ModalTerms.tsx
+++ b/apps/portal-web/src/features/Login/components/ModalTerms.tsx
@@ -4,12 +4,17 @@ import { useIsMobile } from "@/hooks";
 import { motion, AnimatePresence } from "framer-motion";
 
 const TERMS_CONTENT = `
-Autorizo voluntariamente que la información recopilada y/o proporcionada por entidades públicas o
-privadas y la generada de relaciones contractuales, crediticias o comerciales, sea reportada a entidades
-que prestan servicios de información, centrales de riesgo o burós de crédito para ser tratada, almacenada
-o transferida; y autorizo expresamente a las entidades que prestan servicios de información,
-centrales de riesgo y burós de crédito a recopilar, difundir o comercializar reportes
- o estudios que contengan información sobre mi persona.
+CLAUSULA DE CONSENTIMIENTO DEL CIUDADANO
+
+1. Autorizo expresamente a CREACION E IMAGEN, SOCIEDAD ANONIMA para que solicite, recopile, almacene, intercambie y utilice toda la informacion relacionada con mi historial crediticio, referencias personales, laborales, comerciales, financieras y patrimoniales, ante cualquier entidad publica o privada, buros de credito, centrales de riesgo, u otras fuentes de informacion, con el proposito de evaluar mi solicitud de credito y durante la vigencia del mismo.
+
+2. Autorizo a CREACION E IMAGEN, SOCIEDAD ANONIMA para que comparta mi informacion crediticia y financiera con terceros que tengan un interes legitimo, incluyendo pero no limitado a: entidades financieras, aseguradoras, empresas de cobro, y cualquier otra entidad que participe en la evaluacion, otorgamiento, administracion o recuperacion del credito solicitado.
+
+3. Declaro que toda la informacion proporcionada en esta solicitud es veridica y completa. Reconozco que cualquier falsedad u omision en la informacion proporcionada puede ser causa de rechazo de mi solicitud o de rescision del contrato de credito, sin perjuicio de las acciones legales que pudieran corresponder.
+
+4. Me comprometo a notificar a CREACION E IMAGEN, SOCIEDAD ANONIMA de cualquier cambio en mi informacion personal, laboral, financiera o patrimonial que pueda afectar las condiciones bajo las cuales se otorgo el credito.
+
+Al aceptar este documento y continuar con el proceso, confirmo que he leido, entendido y aceptado todos los terminos anteriores de forma libre y voluntaria.
 `;
 
 interface ModalTermsProps {

--- a/apps/portal-web/src/features/Terms/TermsAndConditions.tsx
+++ b/apps/portal-web/src/features/Terms/TermsAndConditions.tsx
@@ -2,12 +2,17 @@ import { Footer } from "@/features/footer";
 
 // Contenido de términos y condiciones (editable)
 const TERMS_CONTENT = `
-Autorizo voluntariamente que la información recopilada y/o proporcionada por entidades públicas o 
-privadas y la generada de relaciones contractuales, crediticias o comerciales, sea reportada a entidades
-que prestan servicios de información, centrales de riesgo o burós de crédito para ser tratada, almacenada
-o transferida; y autorizo expresamente a las entidades que prestan servicios de información,
-centrales de riesgo y burós de crédito a recopilar, difundir o comercializar reportes
- o estudios que contengan información sobre mi persona.
+CLAUSULA DE CONSENTIMIENTO DEL CIUDADANO
+
+1. Autorizo expresamente a CREACION E IMAGEN, SOCIEDAD ANONIMA para que solicite, recopile, almacene, intercambie y utilice toda la informacion relacionada con mi historial crediticio, referencias personales, laborales, comerciales, financieras y patrimoniales, ante cualquier entidad publica o privada, buros de credito, centrales de riesgo, u otras fuentes de informacion, con el proposito de evaluar mi solicitud de credito y durante la vigencia del mismo.
+
+2. Autorizo a CREACION E IMAGEN, SOCIEDAD ANONIMA para que comparta mi informacion crediticia y financiera con terceros que tengan un interes legitimo, incluyendo pero no limitado a: entidades financieras, aseguradoras, empresas de cobro, y cualquier otra entidad que participe en la evaluacion, otorgamiento, administracion o recuperacion del credito solicitado.
+
+3. Declaro que toda la informacion proporcionada en esta solicitud es veridica y completa. Reconozco que cualquier falsedad u omision en la informacion proporcionada puede ser causa de rechazo de mi solicitud o de rescision del contrato de credito, sin perjuicio de las acciones legales que pudieran corresponder.
+
+4. Me comprometo a notificar a CREACION E IMAGEN, SOCIEDAD ANONIMA de cualquier cambio en mi informacion personal, laboral, financiera o patrimonial que pueda afectar las condiciones bajo las cuales se otorgo el credito.
+
+Al aceptar este documento y continuar con el proceso, confirmo que he leido, entendido y aceptado todos los terminos anteriores de forma libre y voluntaria.
 `;
 
 export const TermsAndConditions = () => {


### PR DESCRIPTION
## What changed
Updated the terms and conditions copy shown on the public terms page and the registration modal to use the full citizen consent clause.

## Why it changed
The previous text only covered a shortened credit-bureau authorization and did not match the requested clause. The final acceptance sentence was adapted to digital acceptance in the current flow instead of a handwritten signature.

## Impact
Users now see the same expanded consent language in both places where terms are displayed.

## Validation
Built the app locally with `pnpm build`.
