### PR TITLE
Add investment stage rollback

### DIFF
--- a/apps/crm/apps/server/src/lib/investment-stage-flow.test.ts
+++ b/apps/crm/apps/server/src/lib/investment-stage-flow.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getNextInvestmentStage,
+	getPreviousInvestmentStage,
+} from "./investment-stage-flow";
+
+describe("investment stage flow helpers", () => {
+	test("returns the previous stage for a valid active stage", () => {
+		expect(getPreviousInvestmentStage("model_presentation")).toBe(
+			"profiling_and_qualification",
+		);
+	});
+
+	test("returns null when the stage is the first one", () => {
+		expect(getPreviousInvestmentStage("data_collection")).toBeNull();
+	});
+
+	test("returns null for lost or unknown stages", () => {
+		expect(getPreviousInvestmentStage("lost")).toBeNull();
+		expect(getPreviousInvestmentStage("unknown_stage")).toBeNull();
+	});
+
+	test("returns the next stage for a valid active stage", () => {
+		expect(getNextInvestmentStage("active_follow_up")).toBe(
+			"verbal_commitment_contract_sent",
+		);
+	});
+
+	test("returns null when the stage is the last active one", () => {
+		expect(
+			getNextInvestmentStage("initial_onboarding_senior_handoff"),
+		).toBeNull();
+	});
+});

--- a/apps/crm/apps/server/src/lib/investment-stage-flow.ts
+++ b/apps/crm/apps/server/src/lib/investment-stage-flow.ts
@@ -1,0 +1,39 @@
+export const INVESTMENT_STAGE_FLOW = [
+	"data_collection",
+	"basic_profile_validation",
+	"profiling_and_qualification",
+	"model_presentation",
+	"active_follow_up",
+	"verbal_commitment_contract_sent",
+	"ticket_closure_transfer_activation",
+	"initial_onboarding_senior_handoff",
+] as const;
+
+export const INVESTMENT_STAGE_VALUES = [...INVESTMENT_STAGE_FLOW, "lost"] as const;
+
+export type InvestmentActiveStage = (typeof INVESTMENT_STAGE_FLOW)[number];
+export type InvestmentStageValue = (typeof INVESTMENT_STAGE_VALUES)[number];
+
+export function getPreviousInvestmentStage(
+	stage: string | null | undefined,
+): InvestmentActiveStage | null {
+	if (!stage || stage === "lost") return null;
+
+	const currentIndex = INVESTMENT_STAGE_FLOW.indexOf(stage as InvestmentActiveStage);
+	if (currentIndex <= 0) return null;
+
+	return INVESTMENT_STAGE_FLOW[currentIndex - 1];
+}
+
+export function getNextInvestmentStage(
+	stage: string | null | undefined,
+): InvestmentActiveStage | null {
+	if (!stage || stage === "lost") return null;
+
+	const currentIndex = INVESTMENT_STAGE_FLOW.indexOf(stage as InvestmentActiveStage);
+	if (currentIndex === -1 || currentIndex >= INVESTMENT_STAGE_FLOW.length - 1) {
+		return null;
+	}
+
+	return INVESTMENT_STAGE_FLOW[currentIndex + 1];
+}

--- a/apps/crm/apps/server/src/routers/investments.ts
+++ b/apps/crm/apps/server/src/routers/investments.ts
@@ -350,6 +350,7 @@ export const investmentsRouter = {
 		.input(
 			z.object({
 				opportunityId: z.string().uuid(),
+				expectedCurrentStage: z.enum(INVESTMENT_STAGE_FLOW),
 				reason: z.string().optional(),
 			}),
 		)
@@ -366,7 +367,16 @@ export const investmentsRouter = {
 				});
 			}
 
-			const previousStage = getPreviousInvestmentStage(opp.stage);
+			if (opp.stage !== input.expectedCurrentStage) {
+				throw new ORPCError("CONFLICT", {
+					message:
+						"La etapa cambió antes de confirmar. Recargue la pagina.",
+				});
+			}
+
+			const previousStage = getPreviousInvestmentStage(
+				input.expectedCurrentStage,
+			);
 			if (!previousStage) {
 				throw new ORPCError("BAD_REQUEST", {
 					message: "No se puede regresar desde esta etapa",
@@ -384,7 +394,10 @@ export const investmentsRouter = {
 				.where(
 					and(
 						eq(investmentOpportunities.id, opp.id),
-						eq(investmentOpportunities.stage, opp.stage),
+						eq(
+							investmentOpportunities.stage,
+							input.expectedCurrentStage,
+						),
 					),
 				)
 				.returning();
@@ -398,7 +411,7 @@ export const investmentsRouter = {
 
 			await db.insert(investmentStageHistory).values({
 				investmentOpportunityId: opp.id,
-				fromStage: opp.stage,
+				fromStage: input.expectedCurrentStage,
 				toStage: previousStage,
 				changedBy: context.userId,
 				reason: input.reason,
@@ -407,7 +420,7 @@ export const investmentsRouter = {
 			await db.insert(investmentAuditLog).values({
 				investmentOpportunityId: opp.id,
 				action: "stage_retreated",
-				details: { from: opp.stage, to: previousStage },
+				details: { from: input.expectedCurrentStage, to: previousStage },
 				performedBy: context.userId,
 			});
 

--- a/apps/crm/apps/server/src/routers/investments.ts
+++ b/apps/crm/apps/server/src/routers/investments.ts
@@ -19,6 +19,12 @@ import {
 	calculateInvestment,
 } from "../lib/investment-calculator";
 import {
+	getNextInvestmentStage,
+	getPreviousInvestmentStage,
+	INVESTMENT_STAGE_FLOW,
+	INVESTMENT_STAGE_VALUES,
+} from "../lib/investment-stage-flow";
+import {
 	analystProcedure,
 	investmentManagerProcedure,
 	investmentProcedure,
@@ -26,19 +32,6 @@ import {
 import { ROLES } from "../lib/roles";
 import { getFileUrl } from "../lib/storage";
 import { createNotification } from "./notifications";
-
-const INVESTMENT_STAGE_FLOW = [
-	"data_collection",
-	"basic_profile_validation",
-	"profiling_and_qualification",
-	"model_presentation",
-	"active_follow_up",
-	"verbal_commitment_contract_sent",
-	"ticket_closure_transfer_activation",
-	"initial_onboarding_senior_handoff",
-] as const;
-
-const INVESTMENT_STAGE_VALUES = [...INVESTMENT_STAGE_FLOW, "lost"] as const;
 
 export const investmentsRouter = {
 	// ============ LEADS ============
@@ -301,19 +294,12 @@ export const investmentsRouter = {
 				});
 			}
 
-			const currentIndex = INVESTMENT_STAGE_FLOW.indexOf(
-				opp.stage as (typeof INVESTMENT_STAGE_FLOW)[number],
-			);
-			if (
-				currentIndex === -1 ||
-				currentIndex >= INVESTMENT_STAGE_FLOW.length - 1
-			) {
+			const nextStage = getNextInvestmentStage(opp.stage);
+			if (!nextStage) {
 				throw new ORPCError("BAD_REQUEST", {
 					message: "No se puede avanzar desde esta etapa",
 				});
 			}
-
-			const nextStage = INVESTMENT_STAGE_FLOW[currentIndex + 1];
 
 			// Actualizar etapa (con condicion de stage actual para evitar race condition)
 			const [updated] = await db
@@ -354,6 +340,74 @@ export const investmentsRouter = {
 				investmentOpportunityId: opp.id,
 				action: "stage_advanced",
 				details: { from: opp.stage, to: nextStage },
+				performedBy: context.userId,
+			});
+
+			return updated;
+		}),
+
+	retreatInvestmentStage: investmentProcedure
+		.input(
+			z.object({
+				opportunityId: z.string().uuid(),
+				reason: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			const [opp] = await db
+				.select()
+				.from(investmentOpportunities)
+				.where(eq(investmentOpportunities.id, input.opportunityId))
+				.limit(1);
+
+			if (!opp) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Oportunidad no encontrada",
+				});
+			}
+
+			const previousStage = getPreviousInvestmentStage(opp.stage);
+			if (!previousStage) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "No se puede regresar desde esta etapa",
+				});
+			}
+
+			const [updated] = await db
+				.update(investmentOpportunities)
+				.set({
+					stage: previousStage,
+					status: "open",
+					stageEnteredAt: new Date(),
+					updatedAt: new Date(),
+				})
+				.where(
+					and(
+						eq(investmentOpportunities.id, opp.id),
+						eq(investmentOpportunities.stage, opp.stage),
+					),
+				)
+				.returning();
+
+			if (!updated) {
+				throw new ORPCError("CONFLICT", {
+					message:
+						"La etapa fue modificada por otro usuario. Recargue la pagina.",
+				});
+			}
+
+			await db.insert(investmentStageHistory).values({
+				investmentOpportunityId: opp.id,
+				fromStage: opp.stage,
+				toStage: previousStage,
+				changedBy: context.userId,
+				reason: input.reason,
+			});
+
+			await db.insert(investmentAuditLog).values({
+				investmentOpportunityId: opp.id,
+				action: "stage_retreated",
+				details: { from: opp.stage, to: previousStage },
 				performedBy: context.userId,
 			});
 

--- a/apps/crm/apps/web/src/components/investments/RetreatStageConfirmDialog.tsx
+++ b/apps/crm/apps/web/src/components/investments/RetreatStageConfirmDialog.tsx
@@ -1,0 +1,44 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+type RetreatStageConfirmDialogProps = {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	onConfirm: () => void;
+	isLoading?: boolean;
+};
+
+export function RetreatStageConfirmDialog({
+	open,
+	onOpenChange,
+	onConfirm,
+	isLoading = false,
+}: RetreatStageConfirmDialogProps) {
+	return (
+		<AlertDialog open={open} onOpenChange={onOpenChange}>
+			<AlertDialogContent>
+				<AlertDialogHeader>
+					<AlertDialogTitle>¿Regresar etapa?</AlertDialogTitle>
+					<AlertDialogDescription>
+						Esto moverá la oportunidad a la etapa inmediata anterior y dejará
+						registro en el historial y la auditoría.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel disabled={isLoading}>Cancelar</AlertDialogCancel>
+					<AlertDialogAction onClick={onConfirm} disabled={isLoading}>
+						{isLoading ? "Regresando..." : "Confirmar"}
+					</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
@@ -468,6 +468,9 @@ function RouteComponent() {
 		},
 	});
 
+	const isStageTransitionPending =
+		advanceMutation.isPending || retreatMutation.isPending;
+
 	function handleAdvanceStage() {
 		advanceMutation.mutate({ opportunityId });
 	}
@@ -590,11 +593,13 @@ function RouteComponent() {
 								size="sm"
 								variant="outline"
 								onClick={() => setIsRetreatDialogOpen(true)}
-								disabled={retreatMutation.isPending}
+								disabled={isStageTransitionPending}
 							>
 								<ArrowUpLeft className="mr-2 h-4 w-4" />
 								{retreatMutation.isPending
 									? "Regresando..."
+									: advanceMutation.isPending
+										? "Avanzando..."
 									: "Regresar Etapa"}
 							</Button>
 						)}
@@ -602,10 +607,14 @@ function RouteComponent() {
 							<Button
 								size="sm"
 								onClick={handleAdvanceStage}
-								disabled={advanceMutation.isPending}
+								disabled={isStageTransitionPending}
 							>
 								<ArrowRight className="mr-2 h-4 w-4" />
-								{advanceMutation.isPending ? "Avanzando..." : "Avanzar Etapa"}
+								{advanceMutation.isPending
+									? "Avanzando..."
+									: retreatMutation.isPending
+										? "Regresando..."
+										: "Avanzar Etapa"}
 							</Button>
 						)}
 						{!isLost && !isClosed && (
@@ -620,7 +629,7 @@ function RouteComponent() {
 					open={isRetreatDialogOpen}
 					onOpenChange={setIsRetreatDialogOpen}
 					onConfirm={confirmRetreatStage}
-					isLoading={retreatMutation.isPending}
+					isLoading={isStageTransitionPending}
 				/>
 
 				{isLost && opportunity.lostReason && (

--- a/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
@@ -445,7 +445,11 @@ function RouteComponent() {
 	});
 
 	const retreatMutation = useMutation({
-		mutationFn: (data: { opportunityId: string; reason?: string }) =>
+		mutationFn: (data: {
+			opportunityId: string;
+			expectedCurrentStage: string;
+			reason?: string;
+		}) =>
 			client.retreatInvestmentStage(data),
 		onSuccess: () => {
 			toast.success("Etapa regresada correctamente");
@@ -478,6 +482,7 @@ function RouteComponent() {
 	function confirmRetreatStage() {
 		retreatMutation.mutate({
 			opportunityId,
+			expectedCurrentStage: currentStage as (typeof INVESTMENT_ACTIVE_STAGES)[number]["id"],
 			reason: "Regreso manual de etapa por corrección",
 		});
 	}

--- a/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
@@ -4,6 +4,7 @@ import {
 	AlertCircle,
 	ArrowLeft,
 	ArrowRight,
+	ArrowUpLeft,
 	ChevronRight,
 	FileText,
 	History,
@@ -17,6 +18,7 @@ import {
 import { useState } from "react";
 import { toast } from "sonner";
 import { InvestmentCalculator } from "@/components/investments/InvestmentCalculator";
+import { RetreatStageConfirmDialog } from "@/components/investments/RetreatStageConfirmDialog";
 import { InvestmentContracts } from "@/components/investments/InvestmentContracts";
 import { InvestmentDocuments } from "@/components/investments/InvestmentDocuments";
 import { InvestmentInteractions } from "@/components/investments/InvestmentInteractions";
@@ -40,7 +42,10 @@ import {
 	formatInvestmentStage,
 	formatOpportunityStatus,
 } from "@/lib/investment-labels";
-import { INVESTMENT_STAGES } from "@/lib/investment-stage-config";
+import {
+	INVESTMENT_ACTIVE_STAGES,
+	INVESTMENT_STAGES,
+} from "@/lib/investment-stage-config";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/inversiones/$opportunityId")({
@@ -196,6 +201,7 @@ function MarkAsLostDialog({
 
 const AUDIT_ACTION_LABELS: Record<string, string> = {
 	stage_advanced: "Etapa avanzada",
+	stage_retreated: "Etapa regresada",
 	marked_as_lost: "Marcada como perdida",
 	scenario_created: "Escenario creado",
 	scenario_accepted: "Escenario aceptado",
@@ -220,6 +226,7 @@ function formatAuditDetails(
 
 	switch (action) {
 		case "stage_advanced":
+		case "stage_retreated":
 			return (
 				<span>
 					{details.from ? (
@@ -405,6 +412,7 @@ function RouteComponent() {
 	const { opportunityId } = Route.useParams();
 	const { data: session } = authClient.useSession();
 	const queryClient = useQueryClient();
+	const [isRetreatDialogOpen, setIsRetreatDialogOpen] = useState(false);
 
 	const query = useQuery({
 		...orpc.getInvestmentOpportunityById.queryOptions({
@@ -436,8 +444,39 @@ function RouteComponent() {
 		},
 	});
 
+	const retreatMutation = useMutation({
+		mutationFn: (data: { opportunityId: string; reason?: string }) =>
+			client.retreatInvestmentStage(data),
+		onSuccess: () => {
+			toast.success("Etapa regresada correctamente");
+			setIsRetreatDialogOpen(false);
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInvestmentOpportunityById.queryOptions({
+					input: { id: opportunityId },
+				}).queryKey,
+			});
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInvestmentOpportunities.queryOptions({ input: {} })
+					.queryKey,
+			});
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInvestmentDashboardStats.queryOptions().queryKey,
+			});
+		},
+		onError: (error) => {
+			toast.error(`No se pudo regresar la etapa: ${error.message}`);
+		},
+	});
+
 	function handleAdvanceStage() {
 		advanceMutation.mutate({ opportunityId });
+	}
+
+	function confirmRetreatStage() {
+		retreatMutation.mutate({
+			opportunityId,
+			reason: "Regreso manual de etapa por corrección",
+		});
 	}
 
 	function handleRefresh() {
@@ -495,6 +534,10 @@ function RouteComponent() {
 	const isClosed =
 		!isLost && (currentStage === WON_STAGE_ID || opportunity.status === "won");
 	const canAdvance = !isLost && !isClosed;
+	const currentStageIndex = INVESTMENT_ACTIVE_STAGES.findIndex(
+		(stage) => stage.id === currentStage,
+	);
+	const canRetreat = currentStageIndex > 0;
 
 	return (
 		<div className="flex h-full flex-col">
@@ -542,6 +585,19 @@ function RouteComponent() {
 
 					{/* Actions */}
 					<div className="flex flex-wrap items-center gap-2">
+						{canRetreat && (
+							<Button
+								size="sm"
+								variant="outline"
+								onClick={() => setIsRetreatDialogOpen(true)}
+								disabled={retreatMutation.isPending}
+							>
+								<ArrowUpLeft className="mr-2 h-4 w-4" />
+								{retreatMutation.isPending
+									? "Regresando..."
+									: "Regresar Etapa"}
+							</Button>
+						)}
 						{canAdvance && (
 							<Button
 								size="sm"
@@ -560,6 +616,12 @@ function RouteComponent() {
 						)}
 					</div>
 				</div>
+				<RetreatStageConfirmDialog
+					open={isRetreatDialogOpen}
+					onOpenChange={setIsRetreatDialogOpen}
+					onConfirm={confirmRetreatStage}
+					isLoading={retreatMutation.isPending}
+				/>
 
 				{isLost && opportunity.lostReason && (
 					<div className="mt-4 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900 dark:bg-red-950">

--- a/apps/crm/apps/web/src/routes/inversiones/index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/index.tsx
@@ -435,6 +435,7 @@ function RouteComponent() {
 	const queryClient = useQueryClient();
 	const [pendingRetreat, setPendingRetreat] = useState<{
 		opportunityId: string;
+		expectedCurrentStage: string;
 		targetStage: string;
 	} | null>(null);
 
@@ -487,7 +488,11 @@ function RouteComponent() {
 	});
 
 	const retreatStageMutation = useMutation({
-		mutationFn: (data: { opportunityId: string; reason?: string }) =>
+		mutationFn: (data: {
+			opportunityId: string;
+			expectedCurrentStage: string;
+			reason?: string;
+		}) =>
 			client.retreatInvestmentStage(data),
 		onSuccess: () => {
 			toast.success("Etapa regresada correctamente");
@@ -544,6 +549,7 @@ function RouteComponent() {
 		if (canRetreatToPreviousStage(item.opportunity.stage, newStage)) {
 			setPendingRetreat({
 				opportunityId,
+				expectedCurrentStage: item.opportunity.stage,
 				targetStage: newStage,
 			});
 			return;
@@ -587,8 +593,9 @@ function RouteComponent() {
 		}
 
 		if (
+			item.opportunity.stage !== pendingRetreat.expectedCurrentStage ||
 			!canRetreatToPreviousStage(
-				item.opportunity.stage,
+				pendingRetreat.expectedCurrentStage,
 				pendingRetreat.targetStage,
 			)
 		) {
@@ -602,6 +609,7 @@ function RouteComponent() {
 
 		retreatStageMutation.mutate({
 			opportunityId: pendingRetreat.opportunityId,
+			expectedCurrentStage: pendingRetreat.expectedCurrentStage,
 			reason: "Regreso manual de etapa por corrección desde tablero",
 		});
 	}

--- a/apps/crm/apps/web/src/routes/inversiones/index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/index.tsx
@@ -20,6 +20,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import invariant from "tiny-invariant";
 import * as XLSX from "xlsx";
+import { RetreatStageConfirmDialog } from "@/components/investments/RetreatStageConfirmDialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -81,6 +82,24 @@ function canAdvanceToNextStage(
 	}
 
 	return targetStageIdx === currentStageIdx + 1;
+}
+
+function canRetreatToPreviousStage(
+	currentStage: string,
+	targetStage: string,
+): boolean {
+	const currentStageIdx = INVESTMENT_ACTIVE_STAGES.findIndex(
+		(stage) => stage.id === currentStage,
+	);
+	const targetStageIdx = INVESTMENT_ACTIVE_STAGES.findIndex(
+		(stage) => stage.id === targetStage,
+	);
+
+	if (currentStageIdx === -1 || targetStageIdx === -1) {
+		return false;
+	}
+
+	return targetStageIdx === currentStageIdx - 1;
 }
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -414,6 +433,9 @@ function CreateLeadDialog({ onSuccess }: { onSuccess: () => void }) {
 function RouteComponent() {
 	const { data: session } = authClient.useSession();
 	const queryClient = useQueryClient();
+	const [pendingRetreatOpportunityId, setPendingRetreatOpportunityId] = useState<
+		string | null
+	>(null);
 
 	const opportunitiesQuery = useQuery({
 		...orpc.getInvestmentOpportunities.queryOptions({ input: {} }),
@@ -463,6 +485,26 @@ function RouteComponent() {
 		},
 	});
 
+	const retreatStageMutation = useMutation({
+		mutationFn: (data: { opportunityId: string; reason?: string }) =>
+			client.retreatInvestmentStage(data),
+		onSuccess: () => {
+			toast.success("Etapa regresada correctamente");
+			setPendingRetreatOpportunityId(null);
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInvestmentOpportunities.queryOptions({ input: {} })
+					.queryKey,
+			});
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInvestmentDashboardStats.queryOptions({ input: {} })
+					.queryKey,
+			});
+		},
+		onError: (error) => {
+			toast.error(`No se pudo regresar la etapa: ${error.message}`);
+		},
+	});
+
 	const allItems = opportunitiesQuery.data ?? [];
 	const activeStageIds = new Set<string>(
 		INVESTMENT_ACTIVE_STAGES.map((stage) => stage.id),
@@ -493,12 +535,26 @@ function RouteComponent() {
 		const item = allItems.find((i) => i.opportunity.id === opportunityId);
 		if (!item) return;
 
-		if (!canAdvanceToNextStage(item.opportunity.stage, newStage)) {
-			toast.error("Solo se permite avanzar a la siguiente etapa");
+		if (canAdvanceToNextStage(item.opportunity.stage, newStage)) {
+			advanceStageMutation.mutate({ opportunityId });
 			return;
 		}
 
-		advanceStageMutation.mutate({ opportunityId });
+		if (canRetreatToPreviousStage(item.opportunity.stage, newStage)) {
+			setPendingRetreatOpportunityId(opportunityId);
+			return;
+		}
+
+		if (
+			advanceStageMutation.isPending ||
+			retreatStageMutation.isPending
+		) {
+			return;
+		}
+
+		toast.error(
+			"Solo se permite mover a la etapa inmediata siguiente o anterior",
+		);
 	}
 
 	function handleRefresh() {
@@ -509,6 +565,15 @@ function RouteComponent() {
 		queryClient.invalidateQueries({
 			queryKey: orpc.getInvestmentDashboardStats.queryOptions({ input: {} })
 				.queryKey,
+		});
+	}
+
+	function confirmBoardRetreat() {
+		if (!pendingRetreatOpportunityId) return;
+
+		retreatStageMutation.mutate({
+			opportunityId: pendingRetreatOpportunityId,
+			reason: "Regreso manual de etapa por corrección desde tablero",
 		});
 	}
 
@@ -727,6 +792,14 @@ function RouteComponent() {
 					</div>
 				)}
 			</div>
+			<RetreatStageConfirmDialog
+				open={pendingRetreatOpportunityId !== null}
+				onOpenChange={(open) => {
+					if (!open) setPendingRetreatOpportunityId(null);
+				}}
+				onConfirm={confirmBoardRetreat}
+				isLoading={retreatStageMutation.isPending}
+			/>
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/inversiones/index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/index.tsx
@@ -433,9 +433,10 @@ function CreateLeadDialog({ onSuccess }: { onSuccess: () => void }) {
 function RouteComponent() {
 	const { data: session } = authClient.useSession();
 	const queryClient = useQueryClient();
-	const [pendingRetreatOpportunityId, setPendingRetreatOpportunityId] = useState<
-		string | null
-	>(null);
+	const [pendingRetreat, setPendingRetreat] = useState<{
+		opportunityId: string;
+		targetStage: string;
+	} | null>(null);
 
 	const opportunitiesQuery = useQuery({
 		...orpc.getInvestmentOpportunities.queryOptions({ input: {} }),
@@ -490,7 +491,7 @@ function RouteComponent() {
 			client.retreatInvestmentStage(data),
 		onSuccess: () => {
 			toast.success("Etapa regresada correctamente");
-			setPendingRetreatOpportunityId(null);
+			setPendingRetreat(null);
 			queryClient.invalidateQueries({
 				queryKey: orpc.getInvestmentOpportunities.queryOptions({ input: {} })
 					.queryKey,
@@ -541,7 +542,10 @@ function RouteComponent() {
 		}
 
 		if (canRetreatToPreviousStage(item.opportunity.stage, newStage)) {
-			setPendingRetreatOpportunityId(opportunityId);
+			setPendingRetreat({
+				opportunityId,
+				targetStage: newStage,
+			});
 			return;
 		}
 
@@ -569,10 +573,35 @@ function RouteComponent() {
 	}
 
 	function confirmBoardRetreat() {
-		if (!pendingRetreatOpportunityId) return;
+		if (!pendingRetreat) return;
+
+		const item = allItems.find(
+			(candidate) => candidate.opportunity.id === pendingRetreat.opportunityId,
+		);
+
+		if (!item) {
+			setPendingRetreat(null);
+			handleRefresh();
+			toast.error("La oportunidad ya no está disponible. Se recargó el tablero.");
+			return;
+		}
+
+		if (
+			!canRetreatToPreviousStage(
+				item.opportunity.stage,
+				pendingRetreat.targetStage,
+			)
+		) {
+			setPendingRetreat(null);
+			handleRefresh();
+			toast.error(
+				"La oportunidad cambió de etapa antes de confirmar. Se actualizó el tablero.",
+			);
+			return;
+		}
 
 		retreatStageMutation.mutate({
-			opportunityId: pendingRetreatOpportunityId,
+			opportunityId: pendingRetreat.opportunityId,
 			reason: "Regreso manual de etapa por corrección desde tablero",
 		});
 	}
@@ -793,9 +822,9 @@ function RouteComponent() {
 				)}
 			</div>
 			<RetreatStageConfirmDialog
-				open={pendingRetreatOpportunityId !== null}
+				open={pendingRetreat !== null}
 				onOpenChange={(open) => {
-					if (!open) setPendingRetreatOpportunityId(null);
+					if (!open) setPendingRetreat(null);
 				}}
 				onConfirm={confirmBoardRetreat}
 				isLoading={retreatStageMutation.isPending}

--- a/apps/crm/apps/web/src/utils/orpc.ts
+++ b/apps/crm/apps/web/src/utils/orpc.ts
@@ -9,7 +9,8 @@ import type {
 	disbursementRouter,
 	manualVehicleRouter,
 } from "../../../server/src/routers/index";
-import type { investmentsRouter } from "../../../server/src/routers/investments";
+type InvestmentsRouter =
+	typeof import("../../../server/src/routers/investments").investmentsRouter;
 
 // Detectar si es un error de sesión/autenticación
 const isSessionError = (error: Error): boolean => {
@@ -65,7 +66,7 @@ export const link = new RPCLink({
 // See: https://orpc.dev/docs/advanced/exceeds-the-maximum-length-problem
 type MergedRouter = AppRouter &
 	typeof manualVehicleRouter &
-	typeof investmentsRouter &
+	InvestmentsRouter &
 	typeof disbursementRouter;
 
 export const client: RouterClient<MergedRouter> = createORPCClient(link);


### PR DESCRIPTION
## What changed
- add safe rollback for the investment pipeline so an opportunity can return to the immediately previous stage
- support rollback from both the investment detail view and the kanban board with confirmation dialogs
- harden the flow against race conditions by sharing in-flight transition state in the UI and requiring the expected current stage in the rollback RPC
- add focused stage-flow tests and keep the web oRPC typing aligned with the server router composition

## Why it changed
Users needed a way to undo accidental stage movements in the investment CRM, especially when a lead is moved by mistake.

## Impact
- investment users can move an opportunity back one stage safely
- rollback actions are recorded in stage history and audit log
- stale confirmations are rejected instead of applying rollback from an unexpected newer stage

## Validation
- `bun test apps/server/src/lib/investment-stage-flow.test.ts`
- `bun run check-types` in `apps/server`
- `bun run check-types` in `apps/web`
