### PR TITLE
feat: add endpoint to list payments by due date with Cube breakdown  Adds GET /pagos-por-vencimiento to filter payments by month/year using fecha_vencimiento, with pagination, search by credito SIFCO and user name, and global totals including Cube interest/IVA split.

### DIFF
--- a/apps/cartera-back/drizzle.sifco.config.ts
+++ b/apps/cartera-back/drizzle.sifco.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "drizzle-kit";
+import "dotenv/config";
+
+export default defineConfig({
+  dialect: "postgresql",
+  schema: "./src/database/sifco/schema.ts",
+  out: "./drizzle/sifco",
+  dbCredentials: {
+    url: process.env.SIFCO_DB_URL!,
+  },
+  schemaFilter: ["sifco"],
+});

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1314,3 +1314,138 @@ export async function generateReciboPagoPDF(pagoId: number) {
 
   return { pdfUrl: url };
 }
+
+export async function getPagosByVencimiento({
+  mes,
+  anio,
+  page = 1,
+  pageSize = 20,
+  numero_credito_sifco,
+  nombre_usuario,
+}: {
+  mes: number;
+  anio: number;
+  page?: number;
+  pageSize?: number;
+  numero_credito_sifco?: string;
+  nombre_usuario?: string;
+}) {
+  const fechaInicio = `${anio}-${String(mes).padStart(2, "0")}-01`;
+  const fechaFinDate = new Date(anio, mes, 0);
+  const fechaFin = `${anio}-${String(mes).padStart(2, "0")}-${String(fechaFinDate.getDate()).padStart(2, "0")}`;
+
+  // Filtros dinámicos
+  const filters: any[] = [
+    sql`p.fecha_vencimiento >= ${fechaInicio}`,
+    sql`p.fecha_vencimiento <= ${fechaFin}`,
+  ];
+  if (numero_credito_sifco) {
+    filters.push(sql`c.numero_credito_sifco ILIKE ${"%" + numero_credito_sifco + "%"}`);
+  }
+  if (nombre_usuario) {
+    filters.push(sql`u.nombre ILIKE ${"%" + nombre_usuario + "%"}`);
+  }
+  const whereClause = sql.join(filters, sql` AND `);
+
+  // Subquery para los porcentajes de Cube por crédito (1 solo query)
+  // cube_pct = (porcentaje_cash_in / 100) * (monto_aportado / sum_montos)
+  const cubeSubquery = sql`
+    LEFT JOIN LATERAL (
+      SELECT
+        CASE
+          WHEN sum_montos.total > 0 THEN
+            (ci_cube.porcentaje_cash_in::numeric / 100.0) * (ci_cube.monto_aportado::numeric / sum_montos.total)
+          ELSE 0
+        END AS cube_pct
+      FROM cartera.creditos_inversionistas ci_cube
+      INNER JOIN cartera.inversionistas inv_cube
+        ON ci_cube.inversionista_id = inv_cube.inversionista_id
+      CROSS JOIN LATERAL (
+        SELECT COALESCE(SUM(ci_all.monto_aportado::numeric), 0) AS total
+        FROM cartera.creditos_inversionistas ci_all
+        WHERE ci_all.credito_id = p.credito_id
+      ) sum_montos
+      WHERE ci_cube.credito_id = p.credito_id
+        AND LOWER(TRIM(inv_cube.nombre)) = 'cube investments s.a.'
+      LIMIT 1
+    ) cube_data ON true
+  `;
+
+  // 1. Count + totales globales en un solo query
+  const totalesResult = await db.execute<any>(sql`
+    SELECT
+      COUNT(*)::int AS total_count,
+      COALESCE(SUM(p.capital_restante::numeric), 0) AS total_capital_restante,
+      COALESCE(SUM(p.interes_restante::numeric), 0) AS total_interes_restante,
+      COALESCE(SUM(p.iva_12_restante::numeric), 0) AS total_iva_12_restante,
+      COALESCE(SUM(p.seguro_restante::numeric), 0) AS total_seguro_restante,
+      COALESCE(SUM(p.gps_restante::numeric), 0) AS total_gps_restante,
+      COALESCE(SUM(p.membresias::numeric), 0) AS total_membresias,
+      COALESCE(SUM(p.interes_restante::numeric * COALESCE(cube_data.cube_pct, 0)), 0) AS total_interes_cube,
+      COALESCE(SUM(p.iva_12_restante::numeric * COALESCE(cube_data.cube_pct, 0)), 0) AS total_iva_cube
+    FROM cartera.pagos_credito p
+    INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
+    INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
+    INNER JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
+    ${cubeSubquery}
+    WHERE ${whereClause}
+  `);
+
+  const totalesRow = totalesResult.rows[0];
+  const total = Number(totalesRow?.total_count ?? 0);
+  const offset = (page - 1) * pageSize;
+
+  // 2. Pagos paginados con Cube ya calculado
+  const pagosResult = await db.execute<any>(sql`
+    SELECT
+      p.pago_id,
+      p.credito_id,
+      c.numero_credito_sifco,
+      u.nombre AS nombre_usuario,
+      p.cuota_id,
+      q.numero_cuota,
+      p.fecha_vencimiento,
+      p.fecha_pago,
+      p.pagado,
+      p.monto_boleta,
+      p.cuota,
+      p.capital_restante,
+      p.interes_restante,
+      p.iva_12_restante,
+      p.seguro_restante,
+      p.gps_restante,
+      p.membresias,
+      ROUND(p.interes_restante::numeric * COALESCE(cube_data.cube_pct, 0), 2) AS interes_cube,
+      ROUND(p.iva_12_restante::numeric * COALESCE(cube_data.cube_pct, 0), 2) AS iva_cube
+    FROM cartera.pagos_credito p
+    INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
+    INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
+    INNER JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
+    ${cubeSubquery}
+    WHERE ${whereClause}
+    ORDER BY p.fecha_vencimiento
+    LIMIT ${pageSize} OFFSET ${offset}
+  `);
+
+  const pagos = pagosResult.rows;
+
+  return {
+    data: pagos,
+    pagination: {
+      page,
+      pageSize,
+      total,
+      totalPages: Math.ceil(total / pageSize),
+    },
+    totales: {
+      capital_restante: Number(totalesRow?.total_capital_restante ?? 0).toFixed(2),
+      interes_restante: Number(totalesRow?.total_interes_restante ?? 0).toFixed(2),
+      iva_12_restante: Number(totalesRow?.total_iva_12_restante ?? 0).toFixed(2),
+      seguro_restante: Number(totalesRow?.total_seguro_restante ?? 0).toFixed(2),
+      gps_restante: Number(totalesRow?.total_gps_restante ?? 0).toFixed(2),
+      membresias: Number(totalesRow?.total_membresias ?? 0).toFixed(2),
+      interes_cube: Number(totalesRow?.total_interes_cube ?? 0).toFixed(2),
+      iva_cube: Number(totalesRow?.total_iva_cube ?? 0).toFixed(2),
+    },
+  };
+}

--- a/apps/cartera-back/src/controllers/sifcoSync.ts
+++ b/apps/cartera-back/src/controllers/sifcoSync.ts
@@ -1,0 +1,450 @@
+import { sifcoDb } from "../database/sifco";
+import {
+  clientes,
+  prestamos,
+  recargos,
+  estado_cuenta_transacciones,
+  estado_cuenta_detalles,
+  plan_pagos,
+  plan_pagos_otros,
+} from "../database/sifco/schema";
+import {
+  consultarClientesPorEmail,
+  consultarPrestamosPorCliente,
+  consultarPrestamoDetalle,
+  consultarRecargosLibres,
+  consultarEstadoCuentaPrestamo,
+} from "../services/sifcoIntegrations";
+import { eq, sql } from "drizzle-orm";
+import { writeFileSync } from "fs";
+import { join } from "path";
+
+interface SyncExito {
+  codigoCliente: string;
+  nombre: string;
+  prestamos: {
+    preNumero: string;
+    detalle: boolean;
+    recargos: number;
+    transacciones: number;
+    detallesTransaccion: number;
+    cuotasPlanPago: number;
+    otrosCargos: number;
+  }[];
+  timestamp: string;
+}
+
+interface SyncError {
+  codigoCliente: string;
+  nombre: string;
+  preNumero?: string;
+  paso: string;
+  error: string;
+  stack?: string;
+  timestamp: string;
+}
+
+/**
+ * Sincroniza TODOS los clientes de SIFCO.
+ * Genera dos archivos JSON: éxitos y errores.
+ */
+export async function syncTodosLosClientes() {
+  const exitos: SyncExito[] = [];
+  const errores: SyncError[] = [];
+  const outputDir = join(process.cwd(), "src", "scripts");
+
+  console.log("🚀 Iniciando sincronización masiva de SIFCO...");
+
+  // Paso 1: Traer todos los clientes
+  const clientesResp = await consultarClientesPorEmail();
+  if (!clientesResp?.Clientes?.length) {
+    throw new Error("No se pudo obtener la lista de clientes de SIFCO");
+  }
+
+  const totalClientes = clientesResp.Clientes.length;
+  console.log(`📋 ${totalClientes} clientes encontrados en SIFCO`);
+
+  // Paso 2: Iterar cada cliente
+  for (let i = 0; i < totalClientes; i++) {
+    const cliente = clientesResp.Clientes[i];
+    const progreso = `[${i + 1}/${totalClientes}]`;
+
+    try {
+      console.log(`${progreso} Procesando: ${cliente.CodigoCliente} - ${cliente.NombreCompleto}`);
+      const resultado = await syncClienteCompleto(cliente);
+
+      exitos.push({
+        codigoCliente: cliente.CodigoCliente,
+        nombre: cliente.NombreCompleto,
+        prestamos: resultado.prestamosDetalle,
+        timestamp: new Date().toISOString(),
+      });
+
+      console.log(`${progreso} ✅ ${cliente.NombreCompleto} - ${resultado.prestamosDetalle.length} préstamo(s)`);
+    } catch (error: any) {
+      errores.push({
+        codigoCliente: cliente.CodigoCliente,
+        nombre: cliente.NombreCompleto,
+        paso: "syncClienteCompleto",
+        error: error.message,
+        stack: error.stack,
+        timestamp: new Date().toISOString(),
+      });
+
+      console.error(`${progreso} ❌ ${cliente.NombreCompleto}: ${error.message}`);
+    }
+
+    // Guardar archivos cada 50 clientes (por si se cae)
+    if ((i + 1) % 50 === 0 || i === totalClientes - 1) {
+      writeFileSync(join(outputDir, "sifco-sync-success.json"), JSON.stringify(exitos, null, 2));
+      writeFileSync(join(outputDir, "sifco-sync-errors.json"), JSON.stringify(errores, null, 2));
+    }
+  }
+
+  // Guardar archivos finales
+  writeFileSync(join(outputDir, "sifco-sync-success.json"), JSON.stringify(exitos, null, 2));
+  writeFileSync(join(outputDir, "sifco-sync-errors.json"), JSON.stringify(errores, null, 2));
+
+  const resumen = {
+    totalClientes,
+    exitosos: exitos.length,
+    fallidos: errores.length,
+    archivos: {
+      exitos: "src/scripts/sifco-sync-success.json",
+      errores: "src/scripts/sifco-sync-errors.json",
+    },
+  };
+
+  console.log(`\n🏁 Sincronización finalizada:`, resumen);
+  return resumen;
+}
+
+/**
+ * Sincroniza un cliente completo desde SIFCO:
+ * 1. Inserta el cliente
+ * 2. Trae sus préstamos
+ * 3. Por cada préstamo: detalle, recargos, estado de cuenta
+ */
+export async function syncClienteCompleto(clienteSifco: {
+  CodigoCliente: string;
+  NombreCompleto: string;
+  CodigoReferencia: string;
+  DireccionEMailPrincipal: string;
+  DireccionEMailSecundario: string;
+  ExcluirDeMensajesDeCorreo: number;
+}) {
+  const pasos: string[] = [];
+  const prestamosDetalle: SyncExito["prestamos"] = [];
+  const codigoCliente = clienteSifco.CodigoCliente;
+
+  // ── Paso 1: Guardar cliente ──
+  await sifcoDb
+    .insert(clientes)
+    .values({
+      codigo_cliente: clienteSifco.CodigoCliente,
+      nombre_completo: clienteSifco.NombreCompleto,
+      codigo_referencia: clienteSifco.CodigoReferencia,
+      email_principal: clienteSifco.DireccionEMailPrincipal,
+      email_secundario: clienteSifco.DireccionEMailSecundario,
+      excluir_correos: clienteSifco.ExcluirDeMensajesDeCorreo,
+    })
+    .onConflictDoUpdate({
+      target: clientes.codigo_cliente,
+      set: {
+        nombre_completo: clienteSifco.NombreCompleto,
+        codigo_referencia: clienteSifco.CodigoReferencia,
+        email_principal: clienteSifco.DireccionEMailPrincipal,
+        email_secundario: clienteSifco.DireccionEMailSecundario,
+        excluir_correos: clienteSifco.ExcluirDeMensajesDeCorreo,
+        updated_at: new Date(),
+      },
+    });
+
+  pasos.push(`Cliente ${codigoCliente} - ${clienteSifco.NombreCompleto} sincronizado`);
+
+  // ── Paso 2: Traer préstamos del cliente ──
+  const prestamosResp = await consultarPrestamosPorCliente(Number(codigoCliente));
+  if (!prestamosResp?.Prestamos?.length) {
+    return { pasos, prestamosDetalle, mensaje: "Cliente sincronizado pero no tiene préstamos" };
+  }
+
+  pasos.push(`${prestamosResp.Prestamos.length} préstamo(s) encontrado(s)`);
+
+  // ── Paso 3: Por cada préstamo, traer detalle + recargos + estado de cuenta ──
+  for (const p of prestamosResp.Prestamos) {
+    const preNumero = p.NumeroPrestamo;
+
+    // 3a. Detalle del préstamo
+    const detalle = await consultarPrestamoDetalle(preNumero);
+    if (!detalle) {
+      pasos.push(`Préstamo ${preNumero}: no se pudo obtener detalle, saltando`);
+      continue;
+    }
+
+    await sifcoDb
+      .insert(prestamos)
+      .values({
+        pre_numero: detalle.PreNumero,
+        pre_correlativo: detalle.PreCorrelativo,
+        pre_nombre: detalle.PreNombre,
+        pre_cli_cod: detalle.PreCliCod,
+        pre_cli_nom: detalle.PreCliNom,
+        pre_cli_promotor: detalle.PreCliPromotor,
+        pre_prd_cod: detalle.PrePrdCod,
+        pre_prd_nombre: detalle.PrePrdNombre,
+        pre_prd_tipo: detalle.PrePrdTipo,
+        pre_mon_original: detalle.PreMonOriginal,
+        pre_mon_total: detalle.PreMonTotal,
+        pre_sal_capital: detalle.PreSalCapital,
+        pre_cap_atrasado: detalle.PreCapAtrasado,
+        pre_val_cuota: detalle.PreValCuota,
+        pre_tasa_base: detalle.PreTasaBase,
+        pre_base_mora: detalle.PreBaseMora,
+        pre_int_mes: detalle.PreIntMes,
+        pre_int_acumulado: detalle.PreIntAcumulado,
+        pre_int_vencido: detalle.PreIntVencido,
+        pre_int_mora: detalle.PreIntMora,
+        pre_int_anticipado: detalle.PreIntAnticipado,
+        pre_int_devengado: detalle.PreIntDevengado,
+        pre_plazo: detalle.PrePlazo,
+        pre_num_cuotas: detalle.PreNumCuotas,
+        pre_fac_plazo: detalle.PreFacPlazo,
+        pre_periodo_frecuencia: detalle.PrePeriodoFrecuencia,
+        pre_dia_pago: detalle.PreDiaPago,
+        pre_fec_aprobacion: detalle.PreFecAprobacion,
+        pre_fec_concesion: detalle.PreFecConcesion,
+        pre_fec_vencimiento: detalle.PreFecVencimiento,
+        pre_fec_1_cap: detalle.PreFec1Cap,
+        pre_fec_1_int: detalle.PreFec1Int,
+        pre_fec_p_cap: detalle.PreFecPCap,
+        pre_fec_p_int: detalle.PreFecPInt,
+        pre_fec_u_cap: detalle.PreFecUCap,
+        pre_fec_u_int: detalle.PreFecUInt,
+        pre_moneda_cod: detalle.PreMonedaCod,
+        pre_moneda_nombre: detalle.PreMonedaNombre,
+        pre_moneda_simbolo: detalle.PreMonedaSimbolo,
+        ap_est_cod: detalle.ApEstCod,
+        ap_est_des: detalle.ApEstDes,
+        pre_estado: detalle.PreEstado,
+        pre_anulado: detalle.PreAnulado,
+        pre_gar_cod: detalle.PreGarCod,
+        pre_gar_des: detalle.PreGarDes,
+        ap_cac_cod: detalle.ApCaCCod,
+        ap_cac_des: detalle.ApCaCDes,
+        pre_numero_refinanciamiento: detalle.PreNumeroRefinanciamiento,
+        pre_tipo_credito: detalle.PreTipoCredito,
+        pre_referencia: detalle.PreReferencia,
+        pre_ref_externo: detalle.PreRefExterno,
+        pre_comentario: detalle.PreComentario,
+        pre_division_destino: detalle.PreDivisionDestino,
+        pre_division_origen: detalle.PreDivisionOrigen,
+        pre_division_es_originado: detalle.PreDivisionEsOriginado,
+        pre_division_es_originador: detalle.PreDivisionEsOriginador,
+      })
+      .onConflictDoUpdate({
+        target: prestamos.pre_numero,
+        set: {
+          pre_sal_capital: detalle.PreSalCapital,
+          pre_cap_atrasado: detalle.PreCapAtrasado,
+          pre_int_mes: detalle.PreIntMes,
+          pre_int_acumulado: detalle.PreIntAcumulado,
+          pre_int_vencido: detalle.PreIntVencido,
+          pre_int_mora: detalle.PreIntMora,
+          pre_int_anticipado: detalle.PreIntAnticipado,
+          pre_int_devengado: detalle.PreIntDevengado,
+          ap_est_cod: detalle.ApEstCod,
+          ap_est_des: detalle.ApEstDes,
+          pre_estado: detalle.PreEstado,
+          ap_cac_cod: detalle.ApCaCCod,
+          ap_cac_des: detalle.ApCaCDes,
+          pre_fec_p_cap: detalle.PreFecPCap,
+          pre_fec_p_int: detalle.PreFecPInt,
+          pre_fec_u_cap: detalle.PreFecUCap,
+          pre_fec_u_int: detalle.PreFecUInt,
+          updated_at: new Date(),
+        },
+      });
+
+    pasos.push(`Préstamo ${preNumero}: detalle sincronizado`);
+
+    // 3b. Recargos libres (batch insert)
+    await sifcoDb.delete(recargos).where(eq(recargos.pre_numero, preNumero));
+
+    const recargosResp = await consultarRecargosLibres(preNumero);
+    if (recargosResp?.ConsultaResultados?.length) {
+      await sifcoDb.insert(recargos).values(
+        recargosResp.ConsultaResultados.map((r) => ({
+          pre_numero: preNumero,
+          nombre_prestamo: r.NombreDePrestamo,
+          codigo_saldo: r.CodigoDeSaldo,
+          descripcion_codigo_saldo: r.DescripcionCodigoDeSaldo,
+          valor_saldo: r.ValorDeSaldo,
+          fecha_proximo_pago: r.FechaProximoPago,
+          fecha_ultimo_pago: r.FechaUltimoPago,
+          valor_recargo_usuario: r.ValorRecargoDefinidoPorUsuario,
+          usuario_actualizo: r.UsuarioQueActualizoElRecargo,
+          fecha_actualizacion: r.FechaActualizacionDeRecargo,
+          cuenta_acreditacion: r.CuentaAcreditacionRecargoLibre,
+          nombre_cuenta_acreditacion: r.NombreCuentaAcreditacionRecargoLibre,
+        }))
+      );
+      pasos.push(`Préstamo ${preNumero}: ${recargosResp.ConsultaResultados.length} recargo(s) sincronizado(s)`);
+    } else {
+      pasos.push(`Préstamo ${preNumero}: sin recargos`);
+    }
+
+    // 3c. Estado de cuenta (transacciones + plan de pagos)
+    const estadoCuenta = await consultarEstadoCuentaPrestamo(preNumero);
+    if (!estadoCuenta?.ConsultaResultado) {
+      pasos.push(`Préstamo ${preNumero}: sin estado de cuenta`);
+      continue;
+    }
+
+    // Limpiar datos anteriores (hijos primero, luego padres)
+    await sifcoDb.execute(
+      sql`DELETE FROM sifco.estado_cuenta_detalles WHERE transaccion_id IN (SELECT id FROM sifco.estado_cuenta_transacciones WHERE pre_numero = ${preNumero})`
+    );
+    await sifcoDb.delete(estado_cuenta_transacciones).where(eq(estado_cuenta_transacciones.pre_numero, preNumero));
+
+    await sifcoDb.execute(
+      sql`DELETE FROM sifco.plan_pagos_otros WHERE plan_pago_id IN (SELECT id FROM sifco.plan_pagos WHERE pre_numero = ${preNumero})`
+    );
+    await sifcoDb.delete(plan_pagos).where(eq(plan_pagos.pre_numero, preNumero));
+
+    // Batch insert transacciones
+    const transacciones = estadoCuenta.ConsultaResultado.EstadoCuenta_Transacciones || [];
+    if (transacciones.length) {
+      const BATCH_SIZE = 500;
+      for (let i = 0; i < transacciones.length; i += BATCH_SIZE) {
+        const batch = transacciones.slice(i, i + BATCH_SIZE);
+        const insertedTrx = await sifcoDb
+          .insert(estado_cuenta_transacciones)
+          .values(
+            batch.map((trx) => ({
+              pre_numero: preNumero,
+              numero_movimiento: trx.CrMoNuMov,
+              usuario_cod: trx.CrMoUsuCod,
+              trx_cod: trx.CrMoTrxCod,
+              trx_descripcion: trx.CrMoTrxDes,
+              fecha_transaccion: trx.CrMoFeTrx,
+              hora_transaccion: trx.CrMoHoTrx,
+              fecha_valor: trx.CrMoFeVal,
+              estado: trx.CrMoEstado,
+              forma_pago: trx.CrMoFoPa,
+              capital_desembolsado: trx.CapitalDesembolsado,
+              capital_pagado: trx.CapitalPagado,
+              interes: trx.Interes,
+              interes_moratorio: trx.InteresMoratorio,
+              otros: trx.Otros,
+              saldo_capital: trx.SaldoCapital,
+              referencia: trx.CrMoReferencia,
+              num_documento: trx.CrMoNumDoc,
+              factura_serie: trx.CrMoFacturaSerie,
+              factura_correlativo: trx.CrMoFacturaCorrelativo,
+            }))
+          )
+          .returning({ id: estado_cuenta_transacciones.id });
+
+        // Batch insert detalles de este batch de transacciones
+        const allDetalles: { transaccion_id: string; codigo_saldo: number; descripcion_saldo: string; valor: string }[] = [];
+        batch.forEach((trx, idx) => {
+          if (trx.EstadoCuenta_Detalles?.length) {
+            for (const det of trx.EstadoCuenta_Detalles) {
+              allDetalles.push({
+                transaccion_id: insertedTrx[idx].id,
+                codigo_saldo: det.CrMoDeSalCod,
+                descripcion_saldo: det.ApSalDes,
+                valor: det.CrMoDeValor,
+              });
+            }
+          }
+        });
+
+        if (allDetalles.length) {
+          await sifcoDb.insert(estado_cuenta_detalles).values(allDetalles);
+        }
+      }
+    }
+
+    pasos.push(`Préstamo ${preNumero}: ${transacciones.length} transacción(es) sincronizada(s)`);
+
+    // Batch insert plan de pagos
+    const cuotas = estadoCuenta.ConsultaResultado.PlanPagos_Cuotas || [];
+    if (cuotas.length) {
+      const insertedPPs = await sifcoDb
+        .insert(plan_pagos)
+        .values(
+          cuotas.map((cuota) => ({
+            pre_numero: preNumero,
+            fecha: cuota.Fecha,
+            capital_numero_cuota: cuota.CapitalNumeroCuota,
+            capital_monto: cuota.CapitalMonto,
+            capital_abonado: cuota.CapitalAbonado,
+            capital_atrasado: cuota.CapitaAtrasado,
+            capital_pagado: cuota.CapitalPagado,
+            capital_saldo: cuota.CapitalSaldo,
+            capital_estado: cuota.CapitalEstado,
+            capital_movimiento: cuota.CapitalMovimiento,
+            capital_mora_monto: cuota.CapitalMoraMonto,
+            capital_mora_valor_pagado: cuota.CapitalMoraValorPagado,
+            capital_mora_pagada: cuota.CapitalMoraPagada,
+            capital_mora_saldo: cuota.CapitalMoraSaldo,
+            capital_mora_dias: cuota.CapitalMoraDias,
+            interes_numero_cuota: cuota.InteresNumeroCuota,
+            interes_monto: cuota.InteresMonto,
+            interes_abonado: cuota.InteresAbonado,
+            interes_atrasado: cuota.InteresAtrasado,
+            interes_pagado: cuota.InteresPagado,
+            interes_saldo: cuota.InteresSaldo,
+            interes_estado: cuota.InteresEstado,
+            interes_movimiento: cuota.InteresMovimiento,
+            interes_mora_monto: cuota.InteresMoraMonto,
+            interes_mora_valor_pagado: cuota.InteresMoraValorPagado,
+            interes_mora_pagada: cuota.InteresMoraPagada,
+            interes_mora_saldo: cuota.InteresMoraSaldo,
+            interes_mora_dias: cuota.InteresMoraDias,
+            otros_monto: cuota.OtrosMonto,
+            prestamo: cuota.Prestamo,
+          }))
+        )
+        .returning({ id: plan_pagos.id });
+
+      // Batch insert otros cargos
+      const allOtros: { plan_pago_id: string; numero_cuota: number; monto: string; abonado: string; atrasado: string; pagado: string; saldo: number; saldo_descripcion: string }[] = [];
+      cuotas.forEach((cuota, idx) => {
+        if (cuota.Otros?.length) {
+          for (const otro of cuota.Otros) {
+            allOtros.push({
+              plan_pago_id: insertedPPs[idx].id,
+              numero_cuota: otro.NumeroCuota,
+              monto: otro.Monto,
+              abonado: otro.Abonado,
+              atrasado: otro.Atrasado,
+              pagado: otro.Pagado,
+              saldo: otro.Saldo,
+              saldo_descripcion: otro.SaldoDescripcion,
+            });
+          }
+        }
+      });
+
+      if (allOtros.length) {
+        await sifcoDb.insert(plan_pagos_otros).values(allOtros);
+      }
+    }
+
+    pasos.push(`Préstamo ${preNumero}: ${cuotas.length} cuota(s) del plan de pagos sincronizada(s)`);
+
+    prestamosDetalle.push({
+      preNumero,
+      detalle: true,
+      recargos: recargosResp?.ConsultaResultados?.length || 0,
+      transacciones: transacciones.length,
+      detallesTransaccion: transacciones.reduce((acc, trx) => acc + (trx.EstadoCuenta_Detalles?.length || 0), 0),
+      cuotasPlanPago: cuotas.length,
+      otrosCargos: cuotas.reduce((acc, c) => acc + (c.Otros?.length || 0), 0),
+    });
+  }
+
+  return { pasos, prestamosDetalle, mensaje: "Sincronización completa" };
+}

--- a/apps/cartera-back/src/database/sifco/index.ts
+++ b/apps/cartera-back/src/database/sifco/index.ts
@@ -1,0 +1,18 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import * as sifcoSchema from "./schema";
+
+const connectionString = process.env.SIFCO_DB_URL;
+if (!connectionString) {
+  throw new Error("SIFCO_DB_URL environment variable not set");
+}
+
+const sifcoClient = new Pool({
+  connectionString,
+  ssl: { rejectUnauthorized: false },
+});
+
+console.log("Conexión a la base de datos SIFCO establecida");
+
+export { sifcoClient };
+export const sifcoDb = drizzle(sifcoClient, { schema: sifcoSchema });

--- a/apps/cartera-back/src/database/sifco/schema.ts
+++ b/apps/cartera-back/src/database/sifco/schema.ts
@@ -1,0 +1,346 @@
+import {
+  pgTable,
+  pgSchema,
+  uuid,
+  varchar,
+  integer,
+  numeric,
+  boolean,
+  text,
+  timestamp,
+  date,
+  index,
+} from "drizzle-orm/pg-core";
+import { relations, sql } from "drizzle-orm";
+
+export const sifcoSchema = pgSchema("sifco");
+
+// =============================================
+// CLIENTES — consultarClientesPorEmail
+// =============================================
+export const clientes = sifcoSchema.table("clientes", {
+  codigo_cliente: varchar("codigo_cliente", { length: 50 }).primaryKey(),
+  nombre_completo: varchar("nombre_completo", { length: 300 }).notNull(),
+  codigo_referencia: varchar("codigo_referencia", { length: 100 }),
+  email_principal: varchar("email_principal", { length: 250 }),
+  email_secundario: varchar("email_secundario", { length: 250 }),
+  excluir_correos: integer("excluir_correos").default(0),
+  created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+});
+
+// =============================================
+// PRESTAMOS — consultarPrestamoDetalle
+// =============================================
+export const prestamos = sifcoSchema.table(
+  "prestamos",
+  {
+    pre_numero: varchar("pre_numero", { length: 50 }).primaryKey(),
+    pre_correlativo: varchar("pre_correlativo", { length: 50 }),
+    pre_nombre: varchar("pre_nombre", { length: 300 }),
+
+    // Cliente
+    pre_cli_cod: varchar("pre_cli_cod", { length: 50 })
+      .notNull()
+      .references(() => clientes.codigo_cliente),
+    pre_cli_nom: varchar("pre_cli_nom", { length: 300 }),
+    pre_cli_promotor: varchar("pre_cli_promotor", { length: 200 }),
+
+    // Producto
+    pre_prd_cod: integer("pre_prd_cod"),
+    pre_prd_nombre: varchar("pre_prd_nombre", { length: 200 }),
+    pre_prd_tipo: integer("pre_prd_tipo"),
+
+    // Montos
+    pre_mon_original: numeric("pre_mon_original", { precision: 18, scale: 2 }),
+    pre_mon_total: numeric("pre_mon_total", { precision: 18, scale: 2 }),
+    pre_sal_capital: numeric("pre_sal_capital", { precision: 18, scale: 2 }),
+    pre_cap_atrasado: numeric("pre_cap_atrasado", { precision: 18, scale: 2 }),
+    pre_val_cuota: numeric("pre_val_cuota", { precision: 18, scale: 2 }),
+
+    // Intereses
+    pre_tasa_base: numeric("pre_tasa_base", { precision: 10, scale: 6 }),
+    pre_base_mora: numeric("pre_base_mora", { precision: 10, scale: 6 }),
+    pre_int_mes: numeric("pre_int_mes", { precision: 18, scale: 2 }),
+    pre_int_acumulado: numeric("pre_int_acumulado", { precision: 18, scale: 2 }),
+    pre_int_vencido: numeric("pre_int_vencido", { precision: 18, scale: 2 }),
+    pre_int_mora: numeric("pre_int_mora", { precision: 18, scale: 2 }),
+    pre_int_anticipado: numeric("pre_int_anticipado", { precision: 18, scale: 2 }),
+    pre_int_devengado: numeric("pre_int_devengado", { precision: 18, scale: 2 }),
+
+    // Plazos y cuotas
+    pre_plazo: integer("pre_plazo"),
+    pre_num_cuotas: integer("pre_num_cuotas"),
+    pre_fac_plazo: integer("pre_fac_plazo"),
+    pre_periodo_frecuencia: varchar("pre_periodo_frecuencia", { length: 10 }),
+    pre_dia_pago: integer("pre_dia_pago"),
+
+    // Fechas
+    pre_fec_aprobacion: varchar("pre_fec_aprobacion", { length: 20 }),
+    pre_fec_concesion: varchar("pre_fec_concesion", { length: 20 }),
+    pre_fec_vencimiento: varchar("pre_fec_vencimiento", { length: 20 }),
+    pre_fec_1_cap: varchar("pre_fec_1_cap", { length: 20 }),
+    pre_fec_1_int: varchar("pre_fec_1_int", { length: 20 }),
+    pre_fec_p_cap: varchar("pre_fec_p_cap", { length: 20 }),
+    pre_fec_p_int: varchar("pre_fec_p_int", { length: 20 }),
+    pre_fec_u_cap: varchar("pre_fec_u_cap", { length: 20 }),
+    pre_fec_u_int: varchar("pre_fec_u_int", { length: 20 }),
+
+    // Moneda
+    pre_moneda_cod: integer("pre_moneda_cod"),
+    pre_moneda_nombre: varchar("pre_moneda_nombre", { length: 50 }),
+    pre_moneda_simbolo: varchar("pre_moneda_simbolo", { length: 10 }),
+
+    // Estado
+    ap_est_cod: varchar("ap_est_cod", { length: 10 }),
+    ap_est_des: varchar("ap_est_des", { length: 100 }),
+    pre_estado: boolean("pre_estado"),
+    pre_anulado: varchar("pre_anulado", { length: 5 }),
+
+    // Garantía
+    pre_gar_cod: integer("pre_gar_cod"),
+    pre_gar_des: varchar("pre_gar_des", { length: 200 }),
+
+    // Categoría
+    ap_cac_cod: integer("ap_cac_cod"),
+    ap_cac_des: varchar("ap_cac_des", { length: 100 }),
+
+    // Refinanciamiento
+    pre_numero_refinanciamiento: varchar("pre_numero_refinanciamiento", { length: 50 }),
+    pre_tipo_credito: integer("pre_tipo_credito"),
+
+    // Referencia
+    pre_referencia: varchar("pre_referencia", { length: 100 }),
+    pre_ref_externo: varchar("pre_ref_externo", { length: 100 }),
+    pre_comentario: text("pre_comentario"),
+
+    // División
+    pre_division_destino: varchar("pre_division_destino", { length: 100 }),
+    pre_division_origen: varchar("pre_division_origen", { length: 100 }),
+    pre_division_es_originado: boolean("pre_division_es_originado"),
+    pre_division_es_originador: boolean("pre_division_es_originador"),
+
+    created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [index("idx_prestamos_cli_cod").on(table.pre_cli_cod)]
+);
+
+// =============================================
+// RECARGOS LIBRES — consultarRecargosLibres
+// =============================================
+export const recargos = sifcoSchema.table(
+  "recargos",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    pre_numero: varchar("pre_numero", { length: 50 })
+      .notNull()
+      .references(() => prestamos.pre_numero),
+    nombre_prestamo: varchar("nombre_prestamo", { length: 300 }),
+    codigo_saldo: integer("codigo_saldo"),
+    descripcion_codigo_saldo: varchar("descripcion_codigo_saldo", { length: 200 }),
+    valor_saldo: numeric("valor_saldo", { precision: 18, scale: 2 }),
+    fecha_proximo_pago: varchar("fecha_proximo_pago", { length: 20 }),
+    fecha_ultimo_pago: varchar("fecha_ultimo_pago", { length: 20 }),
+    valor_recargo_usuario: numeric("valor_recargo_usuario", { precision: 18, scale: 2 }),
+    usuario_actualizo: varchar("usuario_actualizo", { length: 100 }),
+    fecha_actualizacion: varchar("fecha_actualizacion", { length: 20 }),
+    cuenta_acreditacion: varchar("cuenta_acreditacion", { length: 100 }),
+    nombre_cuenta_acreditacion: varchar("nombre_cuenta_acreditacion", { length: 200 }),
+    created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [index("idx_recargos_pre_numero").on(table.pre_numero)]
+);
+
+// =============================================
+// ESTADO DE CUENTA — consultarEstadoCuentaPrestamo
+// Transacciones del estado de cuenta
+// =============================================
+export const estado_cuenta_transacciones = sifcoSchema.table(
+  "estado_cuenta_transacciones",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    pre_numero: varchar("pre_numero", { length: 50 })
+      .notNull()
+      .references(() => prestamos.pre_numero),
+    numero_movimiento: varchar("numero_movimiento", { length: 50 }),
+    usuario_cod: varchar("usuario_cod", { length: 50 }),
+    trx_cod: integer("trx_cod"),
+    trx_descripcion: varchar("trx_descripcion", { length: 200 }),
+    fecha_transaccion: varchar("fecha_transaccion", { length: 20 }),
+    hora_transaccion: varchar("hora_transaccion", { length: 20 }),
+    fecha_valor: varchar("fecha_valor", { length: 20 }),
+    estado: integer("estado"),
+    forma_pago: integer("forma_pago"),
+    capital_desembolsado: numeric("capital_desembolsado", { precision: 18, scale: 2 }),
+    capital_pagado: numeric("capital_pagado", { precision: 18, scale: 2 }),
+    interes: numeric("interes", { precision: 18, scale: 2 }),
+    interes_moratorio: numeric("interes_moratorio", { precision: 18, scale: 2 }),
+    otros: numeric("otros", { precision: 18, scale: 2 }),
+    saldo_capital: numeric("saldo_capital", { precision: 18, scale: 2 }),
+    referencia: varchar("referencia", { length: 200 }),
+    num_documento: varchar("num_documento", { length: 100 }),
+    factura_serie: varchar("factura_serie", { length: 50 }),
+    factura_correlativo: varchar("factura_correlativo", { length: 50 }),
+    created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    index("idx_estado_cuenta_pre_numero").on(table.pre_numero),
+    index("idx_estado_cuenta_fecha").on(table.fecha_transaccion),
+  ]
+);
+
+// =============================================
+// ESTADO DE CUENTA DETALLES
+// Detalles de cada transacción (CAPITAL, ROYALTY, etc.)
+// =============================================
+export const estado_cuenta_detalles = sifcoSchema.table(
+  "estado_cuenta_detalles",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    transaccion_id: uuid("transaccion_id")
+      .notNull()
+      .references(() => estado_cuenta_transacciones.id),
+    codigo_saldo: integer("codigo_saldo"),
+    descripcion_saldo: varchar("descripcion_saldo", { length: 200 }),
+    valor: numeric("valor", { precision: 18, scale: 2 }),
+    created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  }
+);
+
+// =============================================
+// PLAN DE PAGOS — parte del estado de cuenta
+// =============================================
+export const plan_pagos = sifcoSchema.table(
+  "plan_pagos",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    pre_numero: varchar("pre_numero", { length: 50 })
+      .notNull()
+      .references(() => prestamos.pre_numero),
+    fecha: varchar("fecha", { length: 20 }),
+
+    // Capital
+    capital_numero_cuota: integer("capital_numero_cuota"),
+    capital_monto: numeric("capital_monto", { precision: 18, scale: 2 }),
+    capital_abonado: numeric("capital_abonado", { precision: 18, scale: 2 }),
+    capital_atrasado: varchar("capital_atrasado", { length: 5 }),
+    capital_pagado: varchar("capital_pagado", { length: 5 }),
+    capital_saldo: numeric("capital_saldo", { precision: 18, scale: 2 }),
+    capital_estado: varchar("capital_estado", { length: 20 }),
+    capital_movimiento: varchar("capital_movimiento", { length: 20 }),
+    capital_mora_monto: numeric("capital_mora_monto", { precision: 18, scale: 2 }),
+    capital_mora_valor_pagado: numeric("capital_mora_valor_pagado", { precision: 18, scale: 2 }),
+    capital_mora_pagada: varchar("capital_mora_pagada", { length: 5 }),
+    capital_mora_saldo: numeric("capital_mora_saldo", { precision: 18, scale: 2 }),
+    capital_mora_dias: integer("capital_mora_dias"),
+
+    // Interés
+    interes_numero_cuota: integer("interes_numero_cuota"),
+    interes_monto: numeric("interes_monto", { precision: 18, scale: 2 }),
+    interes_abonado: numeric("interes_abonado", { precision: 18, scale: 2 }),
+    interes_atrasado: varchar("interes_atrasado", { length: 5 }),
+    interes_pagado: varchar("interes_pagado", { length: 5 }),
+    interes_saldo: numeric("interes_saldo", { precision: 18, scale: 2 }),
+    interes_estado: varchar("interes_estado", { length: 20 }),
+    interes_movimiento: varchar("interes_movimiento", { length: 20 }),
+    interes_mora_monto: numeric("interes_mora_monto", { precision: 18, scale: 2 }),
+    interes_mora_valor_pagado: numeric("interes_mora_valor_pagado", { precision: 18, scale: 2 }),
+    interes_mora_pagada: varchar("interes_mora_pagada", { length: 5 }),
+    interes_mora_saldo: numeric("interes_mora_saldo", { precision: 18, scale: 2 }),
+    interes_mora_dias: integer("interes_mora_dias"),
+
+    // Otros
+    otros_monto: numeric("otros_monto", { precision: 18, scale: 2 }),
+    prestamo: varchar("prestamo", { length: 50 }),
+
+    created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+    updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [
+    index("idx_plan_pagos_pre_numero").on(table.pre_numero),
+    index("idx_plan_pagos_cuota").on(table.capital_numero_cuota),
+  ]
+);
+
+// =============================================
+// PLAN DE PAGOS OTROS — cargos adicionales por cuota
+// (CUOTA SEGURO DAÑOS, MEMBRESIA, etc.)
+// =============================================
+export const plan_pagos_otros = sifcoSchema.table(
+  "plan_pagos_otros",
+  {
+    id: uuid("id").primaryKey().default(sql`gen_random_uuid()`),
+    plan_pago_id: uuid("plan_pago_id")
+      .notNull()
+      .references(() => plan_pagos.id),
+    numero_cuota: integer("numero_cuota"),
+    monto: numeric("monto", { precision: 18, scale: 2 }),
+    abonado: numeric("abonado", { precision: 18, scale: 2 }),
+    atrasado: varchar("atrasado", { length: 5 }),
+    pagado: varchar("pagado", { length: 5 }),
+    saldo: integer("saldo"),
+    saldo_descripcion: varchar("saldo_descripcion", { length: 200 }),
+    created_at: timestamp("created_at", { withTimezone: true }).defaultNow(),
+  },
+  (table) => [index("idx_plan_pagos_otros_plan_pago").on(table.plan_pago_id)]
+);
+
+// =============================================
+// RELACIONES
+// =============================================
+export const clientesRelations = relations(clientes, ({ many }) => ({
+  prestamos: many(prestamos),
+}));
+
+export const prestamosRelations = relations(prestamos, ({ one, many }) => ({
+  cliente: one(clientes, {
+    fields: [prestamos.pre_cli_cod],
+    references: [clientes.codigo_cliente],
+  }),
+  recargos: many(recargos),
+  transacciones: many(estado_cuenta_transacciones),
+  plan_pagos: many(plan_pagos),
+}));
+
+export const recargosRelations = relations(recargos, ({ one }) => ({
+  prestamo: one(prestamos, {
+    fields: [recargos.pre_numero],
+    references: [prestamos.pre_numero],
+  }),
+}));
+
+export const transaccionesRelations = relations(
+  estado_cuenta_transacciones,
+  ({ one, many }) => ({
+    prestamo: one(prestamos, {
+      fields: [estado_cuenta_transacciones.pre_numero],
+      references: [prestamos.pre_numero],
+    }),
+    detalles: many(estado_cuenta_detalles),
+  })
+);
+
+export const detallesRelations = relations(estado_cuenta_detalles, ({ one }) => ({
+  transaccion: one(estado_cuenta_transacciones, {
+    fields: [estado_cuenta_detalles.transaccion_id],
+    references: [estado_cuenta_transacciones.id],
+  }),
+}));
+
+export const planPagosRelations = relations(plan_pagos, ({ one, many }) => ({
+  prestamo: one(prestamos, {
+    fields: [plan_pagos.pre_numero],
+    references: [prestamos.pre_numero],
+  }),
+  otros: many(plan_pagos_otros),
+}));
+
+export const planPagosOtrosRelations = relations(plan_pagos_otros, ({ one }) => ({
+  plan_pago: one(plan_pagos, {
+    fields: [plan_pagos_otros.plan_pago_id],
+    references: [plan_pagos.id],
+  }),
+}));

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -33,7 +33,8 @@ const app = new Elysia()
   .use(routers.investorDocumentsRouter)
   .use(routers.abonosCapitalRouter)
   .use(routers.recibosGenericosRouter)
-  .use(routers.fallenCreditsRouter);
+  .use(routers.fallenCreditsRouter)
+  .use(routers.sifcoSyncRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor
 iniciarTareasProgramadas();

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -20,6 +20,7 @@ import { investorDocumentsRouter } from "./investorDocuments";
 import { abonosCapitalRouter } from "./abonosCapital";
 import { recibosGenericosRouter } from "./recibosGenericos";
 import { fallenCreditsRouter } from "./fallenCredits";
+import { sifcoSyncRouter } from "./sifcoSync";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter
 }   

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { promises as fs } from "fs";
 import { mapPagosPorCreditos, mapPagosDesdeJson } from "../migration/migration";
 import { authMiddleware } from "./midleware";
-import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF } from "../controllers/reports";
+import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF, getPagosByVencimiento } from "../controllers/reports";
 import { actualizarCuentaPago, aplicarPagoAlCredito, insertPayment, aplicarMontoAPago, editarPago } from "../controllers/registerPayment";
 import { eq } from "drizzle-orm";
 import { db } from "../database";
@@ -370,6 +370,42 @@ export const paymentRouter = new Elysia()
       },
     }
   )
+.get(
+  "/pagos-por-vencimiento",
+  async ({ query, set }) => {
+    try {
+      const result = await getPagosByVencimiento({
+        mes: query.mes,
+        anio: query.anio,
+        page: query.page,
+        pageSize: query.pageSize,
+        numero_credito_sifco: query.numero_credito_sifco,
+        nombre_usuario: query.nombre_usuario,
+      });
+      set.status = 200;
+      return { success: true, ...result };
+    } catch (error: any) {
+      console.error("Error en /pagos-por-vencimiento:", error);
+      set.status = 500;
+      return { success: false, error: error.message || "Error obteniendo pagos por vencimiento" };
+    }
+  },
+  {
+    detail: {
+      summary: "Obtiene pagos filtrados por mes/año de vencimiento",
+      description: "Lista paginada de pagos filtrados por fecha de vencimiento con totales globales (capital, interés, IVA, seguro, membresías) y desglose de Cube.",
+      tags: ["Pagos", "Reportes"],
+    },
+    query: t.Object({
+      mes: t.Integer({ minimum: 1, maximum: 12 }),
+      anio: t.Integer({ minimum: 2020 }),
+      page: t.Optional(t.Integer({ minimum: 1, default: 1 })),
+      pageSize: t.Optional(t.Integer({ minimum: 1, default: 20 })),
+      numero_credito_sifco: t.Optional(t.String()),
+      nombre_usuario: t.Optional(t.String()),
+    }),
+  }
+)
 .post(
   "/aplicar-pago",
   async ({ query, set }) => {

--- a/apps/cartera-back/src/routers/sifcoSync.ts
+++ b/apps/cartera-back/src/routers/sifcoSync.ts
@@ -1,0 +1,17 @@
+import { Elysia } from "elysia";
+import { syncTodosLosClientes } from "../controllers/sifcoSync";
+
+export const sifcoSyncRouter = new Elysia({ prefix: "/api/sifco-sync" }).post(
+  "/all",
+  async () => {
+    // Lanzar en background y responder inmediatamente
+    syncTodosLosClientes().catch((err) => {
+      console.error("❌ Error en sincronización masiva:", err.message);
+    });
+
+    return {
+      success: true,
+      message: "Sincronización iniciada en background. Revisá los archivos en src/scripts/ cuando termine.",
+    };
+  }
+);

--- a/apps/cartera-back/src/scripts/insertAbonosCapital.ts
+++ b/apps/cartera-back/src/scripts/insertAbonosCapital.ts
@@ -1,0 +1,119 @@
+import pg from "pg";
+
+const pool = new pg.Pool({
+  connectionString: process.env.SUPABASE_DB_URL,
+  ssl: { rejectUnauthorized: false },
+});
+
+// ============================================
+// 🔧 CONFIGURACIÓN - Créditos a procesar
+// ============================================
+// Pago IDs específicos (1 por crédito, sin duplicados)
+const PAGO_IDS = [
+  60959,   // Diego Padilla - Q906.79
+  113720,  // José Cumez - Q786.10
+];
+
+// 1. Buscar pagos por ID
+const abonos = await pool.query(`
+  SELECT
+    p.pago_id,
+    p.credito_id,
+    p.abono_capital,
+    p.fecha_pago,
+    p.validation_status,
+    c.numero_credito_sifco,
+    u.nombre AS nombre_usuario
+  FROM cartera.pagos_credito p
+  INNER JOIN cartera.creditos c ON c.credito_id = p.credito_id
+  INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+  WHERE p.pago_id = ANY($1)
+  ORDER BY p.fecha_pago
+`, [PAGO_IDS]);
+
+console.log(`Found ${abonos.rowCount} pagos con abono a capital (marzo 2026)\n`);
+
+let totalInserted = 0;
+let sinEspejo = 0;
+let yaExiste = 0;
+
+for (const abono of abonos.rows) {
+  const invs = await pool.query(`
+    SELECT
+      cie.inversionista_id,
+      cie.monto_aportado,
+      i.nombre
+    FROM cartera.creditos_inversionistas_espejo cie
+    INNER JOIN cartera.inversionistas i ON i.inversionista_id = cie.inversionista_id
+    WHERE cie.credito_id = $1
+  `, [abono.credito_id]);
+
+  if (invs.rowCount === 0) {
+    console.log(`⚠️ Crédito ${abono.credito_id} (${abono.nombre_usuario}) - SIN espejo, saltando`);
+    sinEspejo++;
+    continue;
+  }
+
+  // Suma de montos aportados
+  let sumMontos = 0;
+  for (const inv of invs.rows) {
+    sumMontos += parseFloat(inv.monto_aportado);
+  }
+
+  if (sumMontos <= 0) {
+    console.log(`⚠️ Crédito ${abono.credito_id} (${abono.nombre_usuario}) - SUM aportado = 0, saltando`);
+    continue;
+  }
+
+  console.log(`💰 Pago ${abono.pago_id} | ${abono.nombre_usuario} | Crédito ${abono.credito_id} | Capital: Q${abono.abono_capital} | SUM aportado: ${sumMontos.toFixed(2)}`);
+
+  for (const inv of invs.rows) {
+    const montoAportado = parseFloat(inv.monto_aportado);
+    const porcentajeGeneral = montoAportado / sumMontos;
+    const montoInv = (parseFloat(abono.abono_capital) * porcentajeGeneral).toFixed(6);
+
+    // Verificar si ya existe uno no liquidado para este credito + inversionista
+    const existente = await pool.query(`
+      SELECT abono_id, monto FROM cartera.abonos_capital
+      WHERE credito_id = $1 AND inversionista_id = $2 AND liquidado = false
+      LIMIT 1
+    `, [abono.credito_id, inv.inversionista_id]);
+
+    if (existente.rowCount && existente.rowCount > 0) {
+      // Sumar al existente
+      const nuevoMonto = (parseFloat(existente.rows[0].monto) + parseFloat(montoInv)).toFixed(6);
+      await pool.query(`
+        UPDATE cartera.abonos_capital SET monto = $1, updated_at = NOW()
+        WHERE abono_id = $2
+      `, [nuevoMonto, existente.rows[0].abono_id]);
+
+      console.log(`   👤 ${inv.nombre} (${(porcentajeGeneral * 100).toFixed(4)}%) → Q${montoInv} [SUMADO a existente, total: Q${nuevoMonto}]`);
+      yaExiste++;
+    } else {
+      // Insertar nuevo
+      await pool.query(`
+        INSERT INTO cartera.abonos_capital (credito_id, inversionista_id, monto, tipo, liquidado, created_at)
+        VALUES ($1, $2, $3, 'CAPITAL', false, $4)
+      `, [abono.credito_id, inv.inversionista_id, montoInv, abono.fecha_pago]);
+
+      console.log(`   👤 ${inv.nombre} (${(porcentajeGeneral * 100).toFixed(4)}%) → Q${montoInv} [NUEVO]`);
+    }
+
+    totalInserted++;
+  }
+}
+
+console.log(`\n✅ Total procesados: ${totalInserted}`);
+console.log(`🔄 Sumados a existentes: ${yaExiste}`);
+console.log(`⚠️ Sin espejo: ${sinEspejo}`);
+
+// Verificar totales
+const check = await pool.query(`
+  SELECT tipo, COUNT(*) as registros, SUM(CAST(monto AS NUMERIC)) as total_monto
+  FROM cartera.abonos_capital
+  GROUP BY tipo
+`);
+console.log(`\n📋 Resumen tabla abonos_capital:`);
+console.table(check.rows);
+
+await pool.end();

--- a/apps/cartera-back/src/scripts/sifcoSyncAll.ts
+++ b/apps/cartera-back/src/scripts/sifcoSyncAll.ts
@@ -1,0 +1,14 @@
+import "dotenv/config";
+import { syncTodosLosClientes } from "../controllers/sifcoSync";
+
+console.log("🚀 Iniciando script de sincronización SIFCO...\n");
+
+syncTodosLosClientes()
+  .then((resumen) => {
+    console.log("\n✅ Script finalizado:", resumen);
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error("\n❌ Error fatal:", err.message);
+    process.exit(1);
+  });

--- a/apps/cartera-back/src/services/sifco.interface.ts
+++ b/apps/cartera-back/src/services/sifco.interface.ts
@@ -222,6 +222,10 @@ export interface PrestamoDetalle {
   PrestamosInversionistasPromotorPorcentaje: string;
   PrestamosInversionistasAgentePorcentaje: string;
   PrestamosInversionistasContratoFlexible: boolean;
+  PreDivisionDestino: string;
+  PreDivisionOrigen: string;
+  PreDivisionEsOriginado: boolean;
+  PreDivisionEsOriginador: boolean;
   gx_md5_hash: string;
 }
 

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -18,6 +18,7 @@ import EfectividadAsesores from "./private/cartera/components/EfectividadAsesore
 import { HistorialLiquidaciones } from "./private/cartera/components/HistorialLiquidaciones";
 import { RecibosGenericos } from "./private/recibos-genericos/components/RecibosGenericos";
 import { FallenCredits } from "./private/cartera/components/FallenCredits";
+import { PagosPorVencimiento } from "./private/cartera/components/PagosPorVencimiento";
 
 // 🔒 Rutas privadas
 function PrivateRoute({ children }: { children: JSX.Element }) {
@@ -207,6 +208,15 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN"]}>
               <FallenCredits />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="pagos-por-vencimiento"
+          element={
+            <RoleRoute allowedRoles={["ADMIN"]}>
+              <PagosPorVencimiento />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -1,0 +1,298 @@
+import { useState } from "react";
+import { usePagosPorVencimiento } from "../hooks/usePagosPorVencimiento";
+import type { PagoPorVencimientoItem } from "../services/services";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Search, X, ChevronLeft, ChevronRight, CheckCircle2, Clock } from "lucide-react";
+
+function formatQ(val: string | null | undefined): string {
+  if (!val) return "Q 0.00";
+  const n = Number(val);
+  if (isNaN(n)) return "Q 0.00";
+  return `Q ${n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatFecha(val: string | null | undefined): string {
+  if (!val) return "--";
+  try {
+    return new Date(val).toLocaleDateString("es-GT", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    });
+  } catch {
+    return "--";
+  }
+}
+
+const currentDate = new Date();
+
+export function PagosPorVencimiento() {
+  const [mes, setMes] = useState(currentDate.getMonth() + 1);
+  const [anio, setAnio] = useState(currentDate.getFullYear());
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const [sifcoInput, setSifcoInput] = useState("");
+  const [sifcoFilter, setSifcoFilter] = useState("");
+  const [nombreInput, setNombreInput] = useState("");
+  const [nombreFilter, setNombreFilter] = useState("");
+
+  const { data, isLoading, isError } = usePagosPorVencimiento({
+    mes,
+    anio,
+    page,
+    pageSize,
+    numero_credito_sifco: sifcoFilter || undefined,
+    nombre_usuario: nombreFilter || undefined,
+  });
+
+  const handleSearch = () => {
+    setSifcoFilter(sifcoInput.trim());
+    setNombreFilter(nombreInput.trim());
+    setPage(1);
+  };
+
+  const clearFilters = () => {
+    setSifcoInput("");
+    setSifcoFilter("");
+    setNombreInput("");
+    setNombreFilter("");
+    setPage(1);
+  };
+
+  const items: PagoPorVencimientoItem[] = data?.data ?? [];
+  const pagination = data?.pagination;
+  const totales = data?.totales;
+
+  const meses = [
+    "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
+    "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+  ];
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 overflow-auto pt-8 pb-8">
+    <div className="w-full max-w-[1400px]">
+      <div className="flex flex-col items-center mb-6">
+        <h1 className="text-3xl font-extrabold text-blue-700 text-center">
+          Pagos por Vencimiento
+        </h1>
+        <p className="text-lg text-gray-600 leading-relaxed text-center mt-2">
+          Detalle de pagos y cuotas por mes de vencimiento.
+        </p>
+      </div>
+
+      {/* Filtros */}
+      <div className="bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-blue-100 p-5 mb-6">
+        <div className="flex flex-wrap items-end gap-4">
+          <div className="min-w-[140px]">
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">Mes</label>
+            <select
+              className="w-full border border-blue-200 rounded-lg px-3 py-2 text-sm text-blue-800 bg-blue-50 focus:ring-blue-400"
+              value={mes}
+              onChange={(e) => { setMes(Number(e.target.value)); setPage(1); }}
+            >
+              {meses.map((m, i) => (
+                <option key={i + 1} value={i + 1}>{m}</option>
+              ))}
+            </select>
+          </div>
+
+          <div className="min-w-[100px]">
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">Año</label>
+            <Input
+              type="number"
+              min={2020}
+              value={anio}
+              onChange={(e) => { setAnio(Number(e.target.value)); setPage(1); }}
+              className="text-gray-900 border-blue-200 bg-blue-50 focus:ring-blue-400"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[180px]">
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">No. Crédito SIFCO</label>
+            <Input
+              placeholder="Buscar por SIFCO..."
+              value={sifcoInput}
+              onChange={(e) => setSifcoInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              className="text-gray-900 border-blue-200 bg-blue-50 focus:ring-blue-400"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[180px]">
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">Nombre Usuario</label>
+            <Input
+              placeholder="Buscar por nombre..."
+              value={nombreInput}
+              onChange={(e) => setNombreInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              className="text-gray-900 border-blue-200 bg-blue-50 focus:ring-blue-400"
+            />
+          </div>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleSearch}
+            className="text-blue-700 border-blue-300 hover:bg-blue-50"
+          >
+            <Search className="w-4 h-4 mr-1" /> Buscar
+          </Button>
+
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={clearFilters}
+            className="text-gray-600 border-gray-300 hover:bg-gray-100"
+          >
+            <X className="w-4 h-4 mr-1" /> Limpiar
+          </Button>
+        </div>
+      </div>
+
+      {/* Totales globales */}
+      {totales && (
+        <div className="bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-blue-100 p-5 mb-6">
+          <h2 className="text-sm font-bold text-blue-800 mb-3 uppercase tracking-wide">
+            Totales del mes — {meses[mes - 1]} {anio}
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-3">
+            {[
+              { label: "Capital", value: totales.capital_restante },
+              { label: "Interés", value: totales.interes_restante },
+              { label: "IVA 12%", value: totales.iva_12_restante },
+              { label: "Seguro", value: totales.seguro_restante },
+              { label: "GPS", value: totales.gps_restante },
+              { label: "Membresías", value: totales.membresias },
+              { label: "Interés CUBE", value: totales.interes_cube },
+              { label: "IVA CUBE", value: totales.iva_cube },
+            ].map((t) => (
+              <div key={t.label} className="text-center">
+                <p className="text-xs text-gray-500 font-medium">{t.label}</p>
+                <p className="text-sm font-bold text-blue-700">{formatQ(t.value)}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Contenido */}
+      {isLoading ? (
+        <div className="text-center py-16 text-blue-400 font-semibold text-lg">Cargando...</div>
+      ) : isError ? (
+        <div className="text-center py-16 text-red-500 font-semibold">
+          Error al cargar pagos por vencimiento
+        </div>
+      ) : !items.length ? (
+        <div className="text-center py-16 text-gray-400 font-semibold text-lg">
+          No hay pagos para este periodo
+        </div>
+      ) : (
+        <>
+          <div className="bg-white rounded-2xl shadow-lg border border-blue-100 overflow-x-auto">
+            <Table className="w-full">
+              <TableHeader>
+                <TableRow className="bg-gradient-to-r from-blue-50 to-blue-100">
+                  <TableHead className="font-bold text-blue-800">No. SIFCO</TableHead>
+                  <TableHead className="font-bold text-blue-800">Cliente</TableHead>
+                  <TableHead className="font-bold text-blue-800">Cuota</TableHead>
+                  <TableHead className="font-bold text-blue-800">Vencimiento</TableHead>
+                  <TableHead className="font-bold text-blue-800">Fecha Pago</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-center">Estado</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">Boleta</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">Capital</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">Interés</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">IVA 12%</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">Seguro</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">GPS</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">Membresías</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">Int. CUBE</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right">IVA CUBE</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {items.map((item) => (
+                  <TableRow key={item.pago_id} className="hover:bg-blue-50/50 transition">
+                    <TableCell className="font-semibold text-blue-700">
+                      {item.numero_credito_sifco}
+                    </TableCell>
+                    <TableCell className="text-black">{item.nombre_usuario}</TableCell>
+                    <TableCell className="text-black text-center">{item.numero_cuota}</TableCell>
+                    <TableCell className="text-black">{formatFecha(item.fecha_vencimiento)}</TableCell>
+                    <TableCell className="text-black">{formatFecha(item.fecha_pago)}</TableCell>
+                    <TableCell className="text-center">
+                      {item.pagado ? (
+                        <span className="inline-flex items-center gap-1 text-green-600 font-semibold text-xs">
+                          <CheckCircle2 className="w-4 h-4" /> Pagado
+                        </span>
+                      ) : (
+                        <span className="inline-flex items-center gap-1 text-amber-600 font-semibold text-xs">
+                          <Clock className="w-4 h-4" /> Pendiente
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right font-medium text-black">{formatQ(item.monto_boleta)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.capital_restante)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.interes_restante)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.iva_12_restante)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.seguro_restante)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.gps_restante)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.membresias)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.interes_cube)}</TableCell>
+                    <TableCell className="text-right text-black">{formatQ(item.iva_cube)}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Paginación */}
+          <div className="flex flex-wrap items-center justify-between mt-5 gap-3">
+            <span className="text-sm text-gray-600">
+              Página {pagination?.page ?? 1} de {pagination?.totalPages ?? 1} ({pagination?.total ?? 0} total)
+            </span>
+            <div className="flex items-center gap-2">
+              <select
+                className="border border-blue-200 rounded-lg px-3 py-2 text-sm text-blue-800 bg-blue-50 focus:ring-blue-400"
+                value={pageSize}
+                onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}
+              >
+                {[10, 20, 50].map((n) => (
+                  <option key={n} value={n}>{n} por página</option>
+                ))}
+              </select>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page <= 1}
+                onClick={() => setPage((p) => p - 1)}
+                className="border-blue-200 text-blue-700"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={page >= (pagination?.totalPages ?? 1)}
+                onClick={() => setPage((p) => p + 1)}
+                className="border-blue-200 text-blue-700"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+    </div>
+  );
+}

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -191,6 +191,13 @@ const menuSections: MenuSection[] = [
         path: "/efectividad-asesores",
         roles: ["ADMIN", "ASESOR"],
       },
+      {
+        key: "pagos-por-vencimiento",
+        label: "Pagos por Vencimiento",
+        icon: <Receipt className="h-4 w-4" />,
+        path: "/pagos-por-vencimiento",
+        roles: ["ADMIN"],
+      },
     ],
   },
 ];

--- a/apps/carteraFront/src/private/cartera/hooks/usePagosPorVencimiento.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/usePagosPorVencimiento.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getPagosPorVencimiento,
+  type PagosPorVencimientoParams,
+  type PagosPorVencimientoResponse,
+} from "../services/services";
+
+export const usePagosPorVencimiento = (params: PagosPorVencimientoParams) => {
+  return useQuery<PagosPorVencimientoResponse, Error>({
+    queryKey: [
+      "pagosPorVencimiento",
+      params.mes,
+      params.anio,
+      params.page,
+      params.pageSize,
+      params.numero_credito_sifco,
+      params.nombre_usuario,
+    ],
+    queryFn: async () => {
+      const response = await getPagosPorVencimiento(params);
+      if (!response.success) throw new Error("Error al obtener pagos por vencimiento");
+      return response;
+    },
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+};

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3274,3 +3274,83 @@ export async function getFallenCredits(params: {
   );
   return res.data;
 }
+
+// ============================================
+// Pagos por Vencimiento
+// ============================================
+
+export interface PagoPorVencimientoItem {
+  pago_id: number;
+  credito_id: number;
+  numero_credito_sifco: string;
+  nombre_usuario: string;
+  cuota_id: number;
+  numero_cuota: number;
+  fecha_vencimiento: string;
+  fecha_pago: string | null;
+  pagado: boolean;
+  monto_boleta: string;
+  capital_restante: string;
+  interes_restante: string;
+  iva_12_restante: string;
+  seguro_restante: string;
+  gps_restante: string;
+  membresias: string;
+  interes_cube: string;
+  iva_cube: string;
+}
+
+export interface PagoPorVencimientoTotales {
+  capital_restante: string;
+  interes_restante: string;
+  iva_12_restante: string;
+  seguro_restante: string;
+  gps_restante: string;
+  membresias: string;
+  interes_cube: string;
+  iva_cube: string;
+}
+
+export interface PagosPorVencimientoResponse {
+  success: boolean;
+  data: PagoPorVencimientoItem[];
+  pagination: {
+    page: number;
+    pageSize: number;
+    total: number;
+    totalPages: number;
+  };
+  totales: PagoPorVencimientoTotales;
+}
+
+export interface PagosPorVencimientoParams {
+  mes: number;
+  anio: number;
+  page?: number;
+  pageSize?: number;
+  numero_credito_sifco?: string;
+  nombre_usuario?: string;
+}
+
+export async function getPagosPorVencimiento(
+  params: PagosPorVencimientoParams
+): Promise<PagosPorVencimientoResponse> {
+  const res = await api.get<PagosPorVencimientoResponse>(
+    `${API_URL}/pagos-por-vencimiento`,
+    {
+      params: {
+        mes: params.mes,
+        anio: params.anio,
+        page: params.page ?? 1,
+        pageSize: params.pageSize ?? 20,
+        ...(params.numero_credito_sifco && {
+          numero_credito_sifco: params.numero_credito_sifco,
+        }),
+        ...(params.nombre_usuario && {
+          nombre_usuario: params.nombre_usuario,
+        }),
+      },
+    }
+  );
+  return res.data;
+}


### PR DESCRIPTION
…Adds GET /pagos-por-vencimiento to filter payments by month/year using fecha_vencimiento, with pagination, search by credito SIFCO and user name, and global totals including Cube interest/IVA split.