### PR TITLE
[codex] permitir buscar cobros por placa y corregir tipos en inversiones

### DIFF
--- a/apps/crm/apps/server/src/lib/cobros-search.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-search.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import {
+	filterCobrosSearchResults,
+	matchesCobrosSearch,
+	normalizeCobrosSearchValue,
+} from "./cobros-search";
+
+describe("cobros search helpers", () => {
+	test("normalizes values for flexible plate matching", () => {
+		expect(normalizeCobrosSearchValue(" P-123 abc ")).toBe("p123abc");
+		expect(normalizeCobrosSearchValue("abc 123")).toBe("abc123");
+	});
+
+	test("matches by customer name or flexible vehicle plate", () => {
+		expect(
+			matchesCobrosSearch(
+				{ clienteNombre: "Juan Perez", vehiculoPlaca: "P-123 ABC" },
+				"123ab",
+			),
+		).toBe(true);
+
+		expect(
+			matchesCobrosSearch(
+				{ clienteNombre: "Maria Lopez", vehiculoPlaca: "QWE-987" },
+				"maria",
+			),
+		).toBe(true);
+
+		expect(
+			matchesCobrosSearch(
+				{ clienteNombre: "Maria Lopez", vehiculoPlaca: "QWE-987" },
+				"zzz",
+			),
+		).toBe(false);
+	});
+
+	test("filters and paginates locally after matching", () => {
+		const results = filterCobrosSearchResults(
+			[
+				{ clienteNombre: "Juan Perez", vehiculoPlaca: "P-123 ABC" },
+				{ clienteNombre: "Ana Gomez", vehiculoPlaca: "X-999" },
+				{ clienteNombre: "Pedro Ruiz", vehiculoPlaca: "P-456 XYZ" },
+			],
+			"p",
+			0,
+			1,
+		);
+
+		expect(results.total).toBe(2);
+		expect(results.items).toEqual([
+			{ clienteNombre: "Juan Perez", vehiculoPlaca: "P-123 ABC" },
+		]);
+	});
+});

--- a/apps/crm/apps/server/src/lib/cobros-search.ts
+++ b/apps/crm/apps/server/src/lib/cobros-search.ts
@@ -1,0 +1,40 @@
+type CobrosSearchable = {
+	clienteNombre?: string | null;
+	vehiculoPlaca?: string | null;
+};
+
+export function normalizeCobrosSearchValue(value: string | null | undefined) {
+	return (value ?? "").toLowerCase().replace(/[\s-]+/g, "").trim();
+}
+
+export function matchesCobrosSearch(
+	item: CobrosSearchable,
+	searchTerm: string | null | undefined,
+) {
+	const rawQuery = (searchTerm ?? "").trim().toLowerCase();
+	if (!rawQuery) return true;
+
+	const normalizedQuery = normalizeCobrosSearchValue(searchTerm);
+	const customerName = (item.clienteNombre ?? "").toLowerCase();
+	const vehiclePlate = normalizeCobrosSearchValue(item.vehiculoPlaca);
+
+	return (
+		customerName.includes(rawQuery) ||
+		(normalizedQuery.length > 0 && vehiclePlate.includes(normalizedQuery))
+	);
+}
+
+export function filterCobrosSearchResults<T extends CobrosSearchable>(
+	items: T[],
+	searchTerm: string | null | undefined,
+	offset = 0,
+	limit?: number,
+) {
+	const filtered = items.filter((item) => matchesCobrosSearch(item, searchTerm));
+
+	return {
+		total: filtered.length,
+		items:
+			limit === undefined ? filtered : filtered.slice(offset, offset + limit),
+	};
+}

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -25,6 +25,7 @@ import {
 } from "../db/schema/crm";
 import { vehicles } from "../db/schema/vehicles";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
+import { filterCobrosSearchResults } from "../lib/cobros-search";
 import {
 	cobrosProcedure,
 	cobrosSupervisorProcedure,
@@ -565,7 +566,7 @@ export const cobrosRouter = {
 				limit: z.number().optional(),
 				offset: z.number().optional(),
 				estadoMora: z.string().optional(),
-				nombreUsuario: z.string().optional(),
+				searchTerm: z.string().optional(),
 				time: z.enum(["WEEK", "MONTH", "DUEMONTH", "TODAY"]).optional(),
 				emailCobrador: z.string().optional(),
 			}),
@@ -581,8 +582,7 @@ export const cobrosRouter = {
 					// Mapear filtro de estadoMora a parámetros de cartera-back
 					let cuotasAtrasadas: number | undefined;
 					let estadoCartera: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | undefined;
-					const nombre_usuario: string | undefined =
-						input.nombreUsuario ?? undefined;
+					const shouldSearchLocally = !!input.searchTerm?.trim();
 
 					if (input.estadoMora) {
 						switch (input.estadoMora) {
@@ -625,21 +625,61 @@ export const cobrosRouter = {
 					}
 
 					console.log(
-						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${Math.floor((input.offset || 0) / (input.limit || 50)) + 1}, perPage=${input.limit || 50}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${input.time}, emailCobrador=${input.emailCobrador}`,
+						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${Math.floor((input.offset || 0) / (input.limit || 50)) + 1}, perPage=${input.limit || 50}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${input.time}, emailCobrador=${input.emailCobrador}, search=${input.searchTerm || ""}`,
 					);
 
-					// Obtener todos los créditos de Cartera-Back con los filtros
-					const creditosResponse = await obtenerTodosLosCreditosCarteraBack({
-						mes,
-						anio,
-						page: Math.floor((input.offset || 0) / (input.limit || 50)) + 1,
-						perPage: input.limit || 50,
-						cuotasAtrasadas,
-						estado: estadoCartera,
-						nombre_usuario,
-						time: input.time,
-						email_cobrador: input.emailCobrador,
-					}); // Validar que la respuesta tenga la estructura esperada
+					let creditosResponse;
+					if (shouldSearchLocally) {
+						const perPage = 200;
+						const firstPage = await obtenerTodosLosCreditosCarteraBack({
+							mes,
+							anio,
+							page: 1,
+							perPage,
+							cuotasAtrasadas,
+							estado: estadoCartera,
+							time: input.time,
+							email_cobrador: input.emailCobrador,
+						});
+
+						const allCredits = [...firstPage.data];
+
+						for (let page = 2; page <= firstPage.totalPages; page++) {
+							const nextPage = await obtenerTodosLosCreditosCarteraBack({
+								mes,
+								anio,
+								page,
+								perPage,
+								cuotasAtrasadas,
+								estado: estadoCartera,
+								time: input.time,
+								email_cobrador: input.emailCobrador,
+							});
+							allCredits.push(...nextPage.data);
+						}
+
+						creditosResponse = {
+							...firstPage,
+							data: allCredits,
+							totalCount: allCredits.length,
+							page: 1,
+							perPage: allCredits.length,
+							totalPages: 1,
+						};
+					} else {
+						creditosResponse = await obtenerTodosLosCreditosCarteraBack({
+							mes,
+							anio,
+							page: Math.floor((input.offset || 0) / (input.limit || 50)) + 1,
+							perPage: input.limit || 50,
+							cuotasAtrasadas,
+							estado: estadoCartera,
+							time: input.time,
+							email_cobrador: input.emailCobrador,
+						});
+					}
+
+					// Validar que la respuesta tenga la estructura esperada
 					if (!creditosResponse || !creditosResponse.data) {
 						console.error(
 							"[Cobros] Respuesta inválida de Cartera-Back:",
@@ -753,6 +793,25 @@ export const cobrosRouter = {
 					console.log(
 						`[Cobros] Mapeados ${contratos.length} contratos para el frontend`,
 					);
+
+					if (shouldSearchLocally) {
+						const limit = input.limit || 50;
+						const offset = input.offset || 0;
+						const filtered = filterCobrosSearchResults(
+							contratos,
+							input.searchTerm,
+							offset,
+							limit,
+						);
+
+						return {
+							data: filtered.items,
+							total: filtered.total,
+							page: Math.floor(offset / limit) + 1,
+							perPage: limit,
+							totalPages: Math.max(1, Math.ceil(filtered.total / limit)),
+						};
+					}
 
 					return {
 						data: contratos,

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -397,7 +397,7 @@ function RouteComponent() {
 				limit: pageSize,
 				offset: (page - 1) * pageSize,
 				estadoMora: filtroEtapa || undefined,
-				nombreUsuario: debouncedFilterValue || undefined,
+				searchTerm: debouncedFilterValue || undefined,
 				time: timeParam,
 				emailCobrador: !PERMISSIONS.canAssignCobros(userRole ?? "")
 					? session?.user?.email
@@ -1014,7 +1014,7 @@ function RouteComponent() {
 						data={creditosFiltrados}
 						isLoading={todosLosCreditos.isLoading}
 						setGlobalFilterParam={setFilterValue}
-						searchPlaceholder="Buscar por cliente"
+						searchPlaceholder="Buscar por cliente o placa"
 						onRowClick={(row) => {
 							const linkId = row.numeroCredito || row.contratoId;
 							const tipoLink = row.casoCobroId ? "caso" : "contrato";

--- a/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/$opportunityId.tsx
@@ -66,6 +66,9 @@ const STAGE_CONFIG = Object.fromEntries(
 
 const WON_STAGE_ID = "initial_onboarding_senior_handoff";
 
+type InvestmentActiveStageId =
+	(typeof INVESTMENT_ACTIVE_STAGES)[number]["id"];
+
 function formatUnknownStageLabel(stage: string | null | undefined): string {
 	if (!stage) return "Etapa desconocida";
 	return stage
@@ -447,7 +450,7 @@ function RouteComponent() {
 	const retreatMutation = useMutation({
 		mutationFn: (data: {
 			opportunityId: string;
-			expectedCurrentStage: string;
+			expectedCurrentStage: InvestmentActiveStageId;
 			reason?: string;
 		}) =>
 			client.retreatInvestmentStage(data),
@@ -482,7 +485,7 @@ function RouteComponent() {
 	function confirmRetreatStage() {
 		retreatMutation.mutate({
 			opportunityId,
-			expectedCurrentStage: currentStage as (typeof INVESTMENT_ACTIVE_STAGES)[number]["id"],
+			expectedCurrentStage: currentStage as InvestmentActiveStageId,
 			reason: "Regreso manual de etapa por corrección",
 		});
 	}

--- a/apps/crm/apps/web/src/routes/inversiones/index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/index.tsx
@@ -108,6 +108,9 @@ type InvestmentOpportunityItem = Awaited<
 	ReturnType<typeof client.getInvestmentOpportunities>
 >[number];
 
+type InvestmentActiveStageId =
+	(typeof INVESTMENT_ACTIVE_STAGES)[number]["id"];
+
 // ─── Draggable Card ──────────────────────────────────────────────────────────
 
 function DraggableInvestmentCard({
@@ -435,8 +438,8 @@ function RouteComponent() {
 	const queryClient = useQueryClient();
 	const [pendingRetreat, setPendingRetreat] = useState<{
 		opportunityId: string;
-		expectedCurrentStage: string;
-		targetStage: string;
+		expectedCurrentStage: InvestmentActiveStageId;
+		targetStage: InvestmentActiveStageId;
 	} | null>(null);
 
 	const opportunitiesQuery = useQuery({
@@ -490,7 +493,7 @@ function RouteComponent() {
 	const retreatStageMutation = useMutation({
 		mutationFn: (data: {
 			opportunityId: string;
-			expectedCurrentStage: string;
+			expectedCurrentStage: InvestmentActiveStageId;
 			reason?: string;
 		}) =>
 			client.retreatInvestmentStage(data),
@@ -549,8 +552,8 @@ function RouteComponent() {
 		if (canRetreatToPreviousStage(item.opportunity.stage, newStage)) {
 			setPendingRetreat({
 				opportunityId,
-				expectedCurrentStage: item.opportunity.stage,
-				targetStage: newStage,
+				expectedCurrentStage: item.opportunity.stage as InvestmentActiveStageId,
+				targetStage: newStage as InvestmentActiveStageId,
 			});
 			return;
 		}


### PR DESCRIPTION
## Qué cambió

Este PR incluye dos ajustes puntuales:

1. Se mejoró el buscador del módulo de cobros para permitir búsqueda flexible por cliente o placa del vehículo.
2. Se corrigió un error de tipado en inversiones relacionado con `retreatInvestmentStage`, donde el frontend estaba degradando la etapa esperada a `string` en lugar de preservar la unión literal de etapas activas.

## Por qué cambió

- En cobros, el backend ya resolvía el vehículo vinculado al caso/crédito, pero la búsqueda solo usaba el nombre del cliente. Eso impedía localizar casos por placa aunque la información ya estuviera disponible.
- En inversiones, `check-all` fallaba porque el payload enviado a la mutación de retroceso de etapa no coincidía con el tipo exigido por el router.

## Impacto

- El equipo de cobros ahora puede encontrar casos escribiendo placas con coincidencia flexible, ignorando mayúsculas, espacios y guiones.
- El frontend de inversiones vuelve a compilar correctamente y el flujo de retroceso de etapa queda alineado con el contrato tipado del backend.

## Root cause

- Cobros: la caja de búsqueda enviaba únicamente `nombreUsuario` y no existía filtrado por `vehiculoPlaca`.
- Inversiones: el tipo `expectedCurrentStage` se anotaba manualmente como `string` en el frontend, rompiendo la inferencia esperada por ORPC.

## Validación

- `bun test apps/server/src/lib/cobros-search.test.ts`
- `bun run --filter server check-types`
- `bun run --filter web check-types`
- `bun run check-all`
