### PR TITLE
feat: optimizar búsqueda de cobros por nombre y placa

### DIFF
--- a/apps/crm/apps/server/src/lib/cobros-search.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-search.test.ts
@@ -1,54 +1,40 @@
 import { describe, expect, test } from "bun:test";
-import {
-	filterCobrosSearchResults,
-	matchesCobrosSearch,
-	normalizeCobrosSearchValue,
-} from "./cobros-search";
+import { filterCobrosSearchResults } from "./cobros-search";
 
 describe("cobros search helpers", () => {
-	test("normalizes values for flexible plate matching", () => {
-		expect(normalizeCobrosSearchValue(" P-123 abc ")).toBe("p123abc");
-		expect(normalizeCobrosSearchValue("abc 123")).toBe("abc123");
+	test("filters by vehicle plate with normalized matching", () => {
+		const items = [
+			{ vehiculoPlaca: "P-123 ABC" },
+			{ vehiculoPlaca: "X-999" },
+			{ vehiculoPlaca: "P-456 XYZ" },
+		];
+
+		const byPlate = filterCobrosSearchResults(items, "123ab", 0, 10);
+		expect(byPlate.total).toBe(1);
+		expect(byPlate.items).toEqual([{ vehiculoPlaca: "P-123 ABC" }]);
+
+		const noMatch = filterCobrosSearchResults(items, "zzz", 0, 10);
+		expect(noMatch.total).toBe(0);
 	});
 
-	test("matches by customer name or flexible vehicle plate", () => {
-		expect(
-			matchesCobrosSearch(
-				{ clienteNombre: "Juan Perez", vehiculoPlaca: "P-123 ABC" },
-				"123ab",
-			),
-		).toBe(true);
+	test("paginates filtered results", () => {
+		const items = [
+			{ vehiculoPlaca: "P-123 ABC" },
+			{ vehiculoPlaca: "P-456 XYZ" },
+			{ vehiculoPlaca: "P-789 DEF" },
+		];
 
-		expect(
-			matchesCobrosSearch(
-				{ clienteNombre: "Maria Lopez", vehiculoPlaca: "QWE-987" },
-				"maria",
-			),
-		).toBe(true);
+		const page = filterCobrosSearchResults(items, "p", 0, 2);
+		expect(page.total).toBe(3);
+		expect(page.items.length).toBe(2);
 
-		expect(
-			matchesCobrosSearch(
-				{ clienteNombre: "Maria Lopez", vehiculoPlaca: "QWE-987" },
-				"zzz",
-			),
-		).toBe(false);
+		const page2 = filterCobrosSearchResults(items, "p", 2, 2);
+		expect(page2.items.length).toBe(1);
 	});
 
-	test("filters and paginates locally after matching", () => {
-		const results = filterCobrosSearchResults(
-			[
-				{ clienteNombre: "Juan Perez", vehiculoPlaca: "P-123 ABC" },
-				{ clienteNombre: "Ana Gomez", vehiculoPlaca: "X-999" },
-				{ clienteNombre: "Pedro Ruiz", vehiculoPlaca: "P-456 XYZ" },
-			],
-			"p",
-			0,
-			1,
-		);
-
-		expect(results.total).toBe(2);
-		expect(results.items).toEqual([
-			{ clienteNombre: "Juan Perez", vehiculoPlaca: "P-123 ABC" },
-		]);
+	test("returns all items when no search term", () => {
+		const items = [{ vehiculoPlaca: "P-123" }, { vehiculoPlaca: "X-999" }];
+		const result = filterCobrosSearchResults(items, "", 0, 10);
+		expect(result.total).toBe(2);
 	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-search.ts
+++ b/apps/crm/apps/server/src/lib/cobros-search.ts
@@ -1,27 +1,9 @@
 type CobrosSearchable = {
-	clienteNombre?: string | null;
 	vehiculoPlaca?: string | null;
 };
 
-export function normalizeCobrosSearchValue(value: string | null | undefined) {
-	return (value ?? "").toLowerCase().replace(/[\s-]+/g, "").trim();
-}
-
-export function matchesCobrosSearch(
-	item: CobrosSearchable,
-	searchTerm: string | null | undefined,
-) {
-	const rawQuery = (searchTerm ?? "").trim().toLowerCase();
-	if (!rawQuery) return true;
-
-	const normalizedQuery = normalizeCobrosSearchValue(searchTerm);
-	const customerName = (item.clienteNombre ?? "").toLowerCase();
-	const vehiclePlate = normalizeCobrosSearchValue(item.vehiculoPlaca);
-
-	return (
-		customerName.includes(rawQuery) ||
-		(normalizedQuery.length > 0 && vehiclePlate.includes(normalizedQuery))
-	);
+function normalizePlate(value: string | null | undefined) {
+	return (value ?? "").toLowerCase().replace(/[\s-]+/g, "");
 }
 
 export function filterCobrosSearchResults<T extends CobrosSearchable>(
@@ -30,7 +12,10 @@ export function filterCobrosSearchResults<T extends CobrosSearchable>(
 	offset = 0,
 	limit?: number,
 ) {
-	const filtered = items.filter((item) => matchesCobrosSearch(item, searchTerm));
+	const query = normalizePlate(searchTerm);
+	if (!query) return { total: items.length, items: limit === undefined ? items : items.slice(offset, offset + limit) };
+
+	const filtered = items.filter((item) => normalizePlate(item.vehiculoPlaca).includes(query));
 
 	return {
 		total: filtered.length,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -582,7 +582,10 @@ export const cobrosRouter = {
 					// Mapear filtro de estadoMora a parámetros de cartera-back
 					let cuotasAtrasadas: number | undefined;
 					let estadoCartera: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | undefined;
-					const shouldSearchLocally = !!input.searchTerm?.trim();
+					const searchTerm = input.searchTerm?.trim() || "";
+					const hasNumber = /\d/.test(searchTerm);
+					const isPlateSearch = searchTerm.length > 0 && hasNumber;
+					const isNameSearch = searchTerm.length > 0 && !hasNumber;
 
 					if (input.estadoMora) {
 						switch (input.estadoMora) {
@@ -629,7 +632,8 @@ export const cobrosRouter = {
 					);
 
 					let creditosResponse;
-					if (shouldSearchLocally) {
+					if (isPlateSearch) {
+						// Búsqueda por placa: traer todos los créditos para filtrar localmente por vehículo
 						const perPage = 200;
 						const firstPage = await obtenerTodosLosCreditosCarteraBack({
 							mes,
@@ -667,6 +671,7 @@ export const cobrosRouter = {
 							totalPages: 1,
 						};
 					} else {
+						// Búsqueda por nombre (cartera-back filtra) o sin búsqueda
 						creditosResponse = await obtenerTodosLosCreditosCarteraBack({
 							mes,
 							anio,
@@ -676,6 +681,7 @@ export const cobrosRouter = {
 							estado: estadoCartera,
 							time: input.time,
 							email_cobrador: input.emailCobrador,
+							nombre_usuario: isNameSearch ? searchTerm : undefined,
 						});
 					}
 
@@ -794,12 +800,12 @@ export const cobrosRouter = {
 						`[Cobros] Mapeados ${contratos.length} contratos para el frontend`,
 					);
 
-					if (shouldSearchLocally) {
+					if (isPlateSearch) {
 						const limit = input.limit || 50;
 						const offset = input.offset || 0;
 						const filtered = filterCobrosSearchResults(
 							contratos,
-							input.searchTerm,
+							searchTerm,
 							offset,
 							limit,
 						);


### PR DESCRIPTION
## Summary
- Búsqueda por nombre ahora se delega a cartera-back via `nombre_usuario`, evitando descargar todas las páginas
- Búsqueda por placa (cuando el texto contiene números) se mantiene local con `filterCobrosSearchResults` simplificado
- Se eliminó filtrado redundante por `clienteNombre` en `cobros-search.ts`

## Test plan
- [ ] Buscar por nombre de cliente (texto sin números) → debe filtrar server-side sin lag
- [ ] Buscar por placa (texto con números) → debe filtrar localmente por placa
- [ ] Sin búsqueda → debe paginar normalmente desde cartera-back
- [ ] Tests unitarios de `cobros-search` pasan

🤖 Generated with [Claude Code](https://claude.com/claude-code)