### PR TITLE
feat: refine lead assignment logic and update opportunity date formatting

### DIFF
--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -28,7 +28,7 @@ export async function getSalesUserWithLeastOpportunities() {
 			role: user.role,
 		})
 		.from(user)
-		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true)));
+		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true), eq(user.banned, false)));
 
 	if (salesUsers.length === 0) {
 		return null;
@@ -196,7 +196,6 @@ export async function getOpenOpportunityBySource(
 					eq(opportunities.status, "open"),
 					eq(opportunities.status, "on_hold"),
 				),
-				eq(opportunities.source, source),
 			),
 		)
 		.orderBy(desc(opportunities.createdAt))

--- a/apps/crm/apps/web/src/lib/opportunities/columns.tsx
+++ b/apps/crm/apps/web/src/lib/opportunities/columns.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import {
 	formatDate,
 	formatGuatemalaDate,
+	formatGuatemalaDateTime,
 	getStatusLabel,
 } from "@/lib/crm-formatters";
 import type { client } from "@/utils/orpc";
@@ -265,7 +266,7 @@ export const opportunitiesColumns: ColumnDef<Opportunity>[] = [
 		),
 		cell: ({ row }) => {
 			const date = row.getValue("createdAt") as Date | string;
-			return <span className="text-sm">{formatGuatemalaDate(date)}</span>;
+			return <span className="text-sm">{formatGuatemalaDateTime(date)}</span>;
 		},
 	},
 ];

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -84,6 +84,7 @@ import { authClient } from "@/lib/auth-client";
 import {
 	formatDate,
 	formatGuatemalaDate,
+	formatGuatemalaDateTime,
 	getContractTypeLabel,
 	getLoanPurposeLabel,
 	getSourceLabel,
@@ -239,7 +240,7 @@ function DraggableOpportunityCard({
 					<div className="flex items-center justify-between">
 						<span className="text-muted-foreground text-xs">Creada</span>
 						<span className="text-muted-foreground text-xs">
-							{formatGuatemalaDate(opportunity.createdAt)}
+							{formatGuatemalaDateTime(opportunity.createdAt)}
 						</span>
 					</div>
 					{opportunity.closedAt && (


### PR DESCRIPTION
- Prevent lead assignment to banned sales users in the automatic assignment process.
- Remove source constraint when checking for existing open opportunities to improve duplicate detection.
- Update UI components to display both date and time for opportunity creation.
