### PR TITLE
Reallocates pending investor mirror credits

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -8,10 +8,24 @@ import {
 import z from "zod";
 import { getCreditCandidates } from "./assignCapital";
 
+// ========================================
+// ID fijo de CUBE INVESTMENTS S.A. en la tabla inversionistas.
+// CUBE es el inversionista principal/"la casa". Siempre está presente
+// en los créditos y es al que se le resta participación cuando
+// entra un nuevo inversionista.
+// ========================================
 const CUBE_INVESTMENT_ID = 86;
 
 // ========================================
 // SCHEMA DE VALIDACIÓN
+// ========================================
+// Valida el body del request:
+//   - inversionista_id: ID del inversionista que se quiere agregar
+//   - monto_aportado: cuánto capital va a aportar (se distribuye entre créditos)
+//   - porcentaje_cash_in / porcentaje_inversion: opcionales, si el inversionista
+//     ya existe en creditos_inversionistas se jalan de ahí
+//   - tipo_operacion: define el status del espejo ("reinversion" o "compra_cartera")
+//   - fecha_inicio_participacion: opcional, fecha desde cuándo participa
 // ========================================
 
 const addInvestorToCreditSchema = z.object({
@@ -25,6 +39,20 @@ const addInvestorToCreditSchema = z.object({
 
 // ========================================
 // RECALCULAR INVERSIONISTAS
+// ========================================
+// Esta función toma un array de inversionistas (ya con montos redistribuidos)
+// y recalcula TODA la distribución financiera para cada uno:
+//   - Porcentaje de participación
+//   - Cuota del inversionista
+//   - Intereses
+//   - Distribución entre inversionista y cash-in
+//   - IVA
+//
+// Es la misma lógica que usa updateInvestors en updateCredit.ts
+// pero encapsulada como función pura (recibe datos, devuelve datos).
+//
+// IMPORTANTE: El capital total del crédito NO cambia, solo se redistribuye
+// entre los inversionistas. La cuota total tampoco cambia.
 // ========================================
 
 function recalcularInversionistas(
@@ -45,31 +73,55 @@ function recalcularInversionistas(
   credito_id: number,
   numero_credito_sifco: string,
 ) {
+  // ── PASO 1: Sumar el capital total de todos los inversionistas ──
+  // Esto es la base para calcular el porcentaje de participación de cada uno.
+  // Ejemplo: si CUBE tiene Q70,000 y el nuevo tiene Q30,000 → capitalTotal = Q100,000
   const capitalTotal = inversionistasArray.reduce(
     (acc, inv) => acc.plus(inv.monto_aportado),
     new Big(0),
   );
+
+  // ── PASO 2: Extraer datos fijos del crédito ──
+  // Estos valores vienen del crédito y NO cambian durante la redistribución
   const cuotaTotal = new Big(creditoData.cuota);
   const seguro = new Big(creditoData.seguro_10_cuotas ?? 0);
   const gps = new Big(creditoData.gps ?? 0);
   const membresias = new Big(creditoData.membresias_pago ?? 0);
   const tasaInteres = new Big(creditoData.porcentaje_interes ?? 0);
 
+  // ── PASO 3: Encontrar al inversionista con mayor monto aportado ──
+  // El inversionista mayor es el que "absorbe" los cargos fijos
+  // (seguro, GPS, membresías) en su cuota. Los demás no los pagan.
   const inversionistaMayor = inversionistasArray.reduce((max, current) =>
     current.monto_aportado.gt(max.monto_aportado) ? current : max,
   );
 
+  // ── PASO 4: Calcular cuota sin cargos fijos ──
+  // cuotaSinCargos = cuotaTotal - seguro - GPS - membresías
+  // Esta es la base que se reparte proporcionalmente entre inversionistas.
+  // Los cargos fijos se suman SOLO al inversionista mayor.
   const cuotaSinCargos = cuotaTotal.minus(seguro).minus(gps).minus(membresias);
 
+  // ── PASO 5: Calcular todo para cada inversionista ──
   return inversionistasArray.map((inv) => {
+    // ── 5a. Porcentaje de participación ──
+    // Fórmula: (montoAportado / capitalTotal) * 100
+    // Ejemplo: Q30,000 / Q100,000 * 100 = 30%
     const porcentajeParticipacion = inv.monto_aportado
       .div(capitalTotal)
       .times(100);
 
+    // ── 5b. Cuota base ──
+    // Fórmula: cuotaSinCargos * (porcentajeParticipacion / 100)
+    // Es la porción de la cuota mensual que le corresponde a este inversionista
+    // SIN incluir los cargos fijos.
     const cuotaBase = cuotaSinCargos
       .times(porcentajeParticipacion.div(100))
       .round(6);
 
+    // ── 5c. Determinar si es el inversionista mayor ──
+    // Si es el mayor, se le suman seguro + GPS + membresías a su cuota.
+    // Si NO es el mayor, su cuota es solo la cuotaBase.
     const esMayor =
       inv.inversionista_id === inversionistaMayor.inversionista_id;
 
@@ -77,8 +129,17 @@ function recalcularInversionistas(
       ? cuotaBase.plus(seguro).plus(gps).plus(membresias).round(6)
       : cuotaBase;
 
+    // ── 5d. Calcular interés mensual sobre el monto aportado ──
+    // Fórmula: montoAportado * (tasaInteres / 100)
+    // Ejemplo: Q30,000 * (3% / 100) = Q900
     const cuotaInteres = inv.monto_aportado.times(tasaInteres.div(100)).round(2);
 
+    // ── 5e. Distribuir el interés entre inversionista y cash-in ──
+    // montoInversionista = interés que se queda el inversionista
+    // montoCashIn = interés que se queda Cash-In (la empresa)
+    // Ejemplo: si porcentaje_inversion = 80% y porcentaje_cash_in = 20%
+    //   montoInversionista = Q900 * 80% = Q720
+    //   montoCashIn = Q900 * 20% = Q180
     const montoInversionista = cuotaInteres
       .times(inv.porcentaje_inversion)
       .div(100)
@@ -89,6 +150,8 @@ function recalcularInversionistas(
       .div(100)
       .round(2);
 
+    // ── 5f. Calcular IVA (12%) sobre cada porción de interés ──
+    // Solo se calcula si el monto es mayor a 0
     const ivaInversionista = montoInversionista.gt(0)
       ? montoInversionista.times(0.12).round(2)
       : new Big(0);
@@ -97,6 +160,7 @@ function recalcularInversionistas(
       ? montoCashIn.times(0.12).round(2)
       : new Big(0);
 
+    // ── 5g. Retornar objeto listo para insertar en la BD ──
     return {
       credito_id,
       inversionista_id: inv.inversionista_id,
@@ -118,12 +182,40 @@ function recalcularInversionistas(
 }
 
 // ========================================
-// CONTROLLER PRINCIPAL
+// CONTROLLER PRINCIPAL: addInvestorToCredit
+// ========================================
+//
+// FLUJO GENERAL:
+// 1. Validar el body del request
+// 2. Llamar a getCreditCandidates() para obtener los créditos candidatos
+//    (ya vienen ordenados por score, con toda la data: crédito, inversionistas, espejo)
+// 3. Iterar los créditos candidatos y DISTRIBUIR el monto del inversionista:
+//    - Si CUBE en el crédito tiene suficiente → tomar todo el monto restante
+//    - Si CUBE tiene MENOS de lo que falta → tomar todo lo de CUBE y pasar al siguiente crédito
+//    - Si CUBE queda en 0 → se elimina del crédito
+//    - El monto se va descontando crédito por crédito hasta agotarse
+// 4. Para cada crédito procesado:
+//    a. Armar el nuevo array de inversionistas (CUBE restado, nuevo inversionista agregado)
+//    b. Recalcular cuotas, intereses, IVA para TODOS los inversionistas del crédito
+//    c. Borrar y reinsertar en creditos_inversionistas (PADRE)
+//    d. Borrar y reinsertar en creditos_inversionistas_espejo (ESPEJO)
+//       con el status correspondiente (pendiente_reinversion o pendiente_compra_cartera)
+// 5. Devolver resumen: monto total, distribuido, sin asignar, detalle por crédito
+//
+// EJEMPLO:
+//   Inversionista quiere meter Q50,000
+//   Crédito 1 (score 1800): CUBE tiene Q20,000 → toma Q20,000, CUBE se elimina, quedan Q30,000
+//   Crédito 2 (score 1600): CUBE tiene Q40,000 → toma Q30,000, CUBE queda con Q10,000, quedan Q0
+//   FIN - Se procesaron 2 créditos, monto_distribuido = Q50,000, monto_sin_asignar = Q0
 // ========================================
 
 export const addInvestorToCredit = async ({ body, set }: any) => {
   try {
-    // 1. Validar schema
+    // ================================================================
+    // PASO 1: VALIDAR SCHEMA DEL REQUEST
+    // Verifica que el body tenga todos los campos requeridos y con
+    // los tipos correctos. Si falla, devuelve 400 con los errores.
+    // ================================================================
     const parseResult = addInvestorToCreditSchema.safeParse(body);
     if (!parseResult.success) {
       set.status = 400;
@@ -142,7 +234,17 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
       fecha_inicio_participacion,
     } = parseResult.data;
 
-    // 2. GET interno — traer créditos candidatos con toda su data
+    // ================================================================
+    // PASO 2: GET INTERNO - OBTENER CRÉDITOS CANDIDATOS
+    // Llama a getCreditCandidates() de assignCapital.ts que:
+    //   - Trae créditos ACTIVOS de tipo Vehículo
+    //   - Filtra los que tienen pagos sin validar
+    //   - Filtra los que tienen espejo en proceso (pendiente_*)
+    //   - Valida que CUBE esté presente y sea el líder del pool
+    //   - Calcula un score de prioridad para cada crédito
+    //   - Los ordena por score DESC (mejores primero)
+    //   - Incluye credito_completo con toda la data relacional
+    // ================================================================
     const candidatos = await getCreditCandidates(monto_aportado);
 
     if (candidatos.length === 0) {
@@ -155,17 +257,28 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
 
     const resultados: any[] = [];
     const errores: any[] = [];
+
+    // ================================================================
+    // MONTO RESTANTE: es el "saldo" que falta por distribuir.
+    // Empieza con el monto total y se va descontando crédito por crédito.
+    // Cuando llega a 0, se deja de procesar.
+    // ================================================================
     let montoRestante = new Big(monto_aportado);
 
-    // 3. Para cada crédito candidato (ordenados por score), distribuir monto
+    // ================================================================
+    // PASO 3: ITERAR CRÉDITOS Y DISTRIBUIR MONTO
+    // Todo dentro de una transacción para que si algo falla,
+    // se haga rollback de TODOS los cambios.
+    // ================================================================
     await db.transaction(async (tx) => {
       for (const candidato of candidatos) {
-        // Si ya no queda monto por distribuir, salir
+        // ── Si ya se distribuyó todo el monto, no seguir ──
         if (montoRestante.lte(0)) break;
 
         try {
           const { credito_id, numero_credito_sifco, credito_completo } = candidato;
 
+          // ── Validar que el candidato tenga data completa ──
           if (!credito_completo) {
             errores.push({ credito_id, razon: "Sin data completa del crédito" });
             continue;
@@ -173,7 +286,8 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
 
           const { credito: creditoRaw, inversionistas_detalle } = credito_completo;
 
-          // Datos del crédito desde el GET
+          // ── Extraer datos del crédito que necesitamos para recalcular ──
+          // Estos vienen del GET, no hacemos queries adicionales
           const creditoData = {
             cuota: creditoRaw.cuota,
             porcentaje_interes: creditoRaw.porcentaje_interes,
@@ -182,7 +296,8 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             membresias_pago: creditoRaw.membresias_pago,
           };
 
-          // Inversionistas actuales desde el GET
+          // ── Mapear inversionistas actuales del crédito ──
+          // Estos también vienen del GET (inversionistas_detalle)
           const inversionistasActuales = inversionistas_detalle.map((inv: any) => ({
             inversionista_id: inv.inversionista_id,
             monto_aportado: inv.monto_aportado,
@@ -191,7 +306,11 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             fecha_inicio_participacion: inv.fecha_inicio_participacion,
           }));
 
-          // 3a. Buscar CUBE
+          // ================================================================
+          // PASO 3a: BUSCAR CUBE EN LOS INVERSIONISTAS DEL CRÉDITO
+          // CUBE (ID 86) siempre debe estar. Si no está, es un error
+          // y saltamos este crédito.
+          // ================================================================
           const cubeActual = inversionistasActuales.find(
             (inv: any) => inv.inversionista_id === CUBE_INVESTMENT_ID,
           );
@@ -206,13 +325,32 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
 
           const montoCubeActual = new Big(cubeActual.monto_aportado);
 
-          // 3b. Determinar cuánto tomar de este crédito
-          // Si CUBE tiene menos que lo que resta, tomar todo lo de CUBE
+          // ================================================================
+          // PASO 3b: DETERMINAR CUÁNTO TOMAR DE ESTE CRÉDITO
+          // Si el monto restante es MAYOR que lo que CUBE tiene:
+          //   → Tomar TODO lo de CUBE (CUBE se elimina)
+          //   → El sobrante se lleva al siguiente crédito
+          // Si el monto restante es MENOR o IGUAL que lo de CUBE:
+          //   → Tomar solo lo que falta (CUBE se queda con el resto)
+          //   → Ya no se procesan más créditos
+          //
+          // Ejemplo:
+          //   montoRestante = Q30,000 | CUBE tiene Q20,000
+          //   → montoParaEsteCredito = Q20,000 (todo lo de CUBE)
+          //   → montoRestante después = Q10,000 (sigue al siguiente crédito)
+          // ================================================================
           const montoParaEsteCredito = montoRestante.gt(montoCubeActual)
             ? montoCubeActual
             : montoRestante;
 
-          // 3c. Determinar porcentajes del nuevo inversionista
+          // ================================================================
+          // PASO 3c: DETERMINAR PORCENTAJES DEL NUEVO INVERSIONISTA
+          // Si el inversionista YA EXISTE en creditos_inversionistas de
+          // este crédito Y no se pasaron porcentajes en el request:
+          //   → Jalar los porcentajes que ya tiene (porcentaje_cash_in, porcentaje_inversion)
+          // Si NO existe o sí se pasaron porcentajes:
+          //   → Usar los del request (default: cash_in=0%, inversion=100%)
+          // ================================================================
           let porcCashIn: Big;
           let porcInversion: Big;
 
@@ -221,16 +359,28 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
           );
 
           if (existenteEnPadre && porcentaje_cash_in === undefined) {
+            // Ya existe → jalar sus porcentajes actuales
             porcCashIn = new Big(existenteEnPadre.porcentaje_cash_in);
             porcInversion = new Big(
               existenteEnPadre.porcentaje_participacion_inversionista,
             );
           } else {
+            // No existe o se pasaron porcentajes explícitos
             porcCashIn = new Big(porcentaje_cash_in ?? 0);
             porcInversion = new Big(porcentaje_inversion ?? 100);
           }
 
-          // 3d. Armar nuevo array de inversionistas
+          // ================================================================
+          // PASO 3d: ARMAR EL NUEVO ARRAY DE INVERSIONISTAS
+          // Recorremos los inversionistas actuales del crédito y:
+          //   - CUBE: le restamos el montoParaEsteCredito. Si queda en 0, NO lo incluimos.
+          //   - Inversionista nuevo (si ya existía): le SUMAMOS el montoParaEsteCredito.
+          //   - Los demás: se copian tal cual (no cambian).
+          // Si el inversionista NO existía en el crédito, lo agregamos al final.
+          //
+          // El resultado es un array NUEVO con la distribución correcta,
+          // listo para recalcular todas las cuotas.
+          // ================================================================
           const nuevoArray: {
             inversionista_id: number;
             monto_aportado: Big;
@@ -241,8 +391,10 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
 
           for (const inv of inversionistasActuales) {
             if (inv.inversionista_id === CUBE_INVESTMENT_ID) {
+              // ── CUBE: restarle el monto asignado a este crédito ──
               const nuevoMontoCube = montoCubeActual.minus(montoParaEsteCredito);
               if (nuevoMontoCube.gt(0)) {
+                // CUBE todavía tiene saldo → se queda con el resto
                 nuevoArray.push({
                   inversionista_id: inv.inversionista_id,
                   monto_aportado: nuevoMontoCube,
@@ -253,8 +405,9 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
                   fecha_inicio_participacion: inv.fecha_inicio_participacion,
                 });
               }
-              // Si queda en 0, no se incluye
+              // Si nuevoMontoCube <= 0, CUBE se elimina (no se incluye en el array)
             } else if (inv.inversionista_id === inversionista_id) {
+              // ── Inversionista ya existía: sumarle el monto nuevo ──
               nuevoArray.push({
                 inversionista_id: inv.inversionista_id,
                 monto_aportado: new Big(inv.monto_aportado).plus(montoParaEsteCredito),
@@ -265,6 +418,7 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
                   inv.fecha_inicio_participacion,
               });
             } else {
+              // ── Otro inversionista: se copia igual, no cambia ──
               nuevoArray.push({
                 inversionista_id: inv.inversionista_id,
                 monto_aportado: new Big(inv.monto_aportado),
@@ -277,7 +431,7 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             }
           }
 
-          // Si el inversionista no existía, agregarlo
+          // ── Si el inversionista NO existía en el crédito, agregarlo como nuevo ──
           const yaExiste = nuevoArray.some(
             (inv) => inv.inversionista_id === inversionista_id,
           );
@@ -293,7 +447,13 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             });
           }
 
-          // 3e. Recalcular PADRE
+          // ================================================================
+          // PASO 3e: RECALCULAR CUOTAS PARA TABLA PADRE (creditos_inversionistas)
+          // Con el nuevo array redistribuido, recalculamos:
+          //   - Porcentaje de participación de cada uno
+          //   - Cuota del inversionista (el mayor absorbe cargos fijos)
+          //   - Intereses, distribución cash-in/inversionista, IVA
+          // ================================================================
           const dataPadre = recalcularInversionistas(
             nuevoArray,
             creditoData,
@@ -301,7 +461,12 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             numero_credito_sifco,
           );
 
-          // 3f. Borrar e insertar en creditos_inversionistas
+          // ================================================================
+          // PASO 3f: NUKE & REBUILD EN creditos_inversionistas
+          // Borramos TODOS los registros del crédito en la tabla padre
+          // y reinsertamos el array recalculado.
+          // Es más limpio que hacer updates parciales y evita inconsistencias.
+          // ================================================================
           await tx
             .delete(creditos_inversionistas)
             .where(eq(creditos_inversionistas.credito_id, credito_id));
@@ -310,12 +475,21 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             await tx.insert(creditos_inversionistas).values(dataPadre);
           }
 
-          // 3g. Armar cuotas del padre para el espejo
+          // ================================================================
+          // PASO 3g: PREPARAR CUOTAS DEL PADRE PARA EL ESPEJO
+          // El espejo HEREDA la cuota_inversionista del padre.
+          // Armamos un Map para poder buscar rápido por inversionista_id.
+          // ================================================================
           const parentCuotas = new Map(
             dataPadre.map((p) => [p.inversionista_id, p.cuota_inversionista]),
           );
 
-          // 3h. Recalcular ESPEJO
+          // ================================================================
+          // PASO 3h: RECALCULAR CUOTAS PARA TABLA ESPEJO (creditos_inversionistas_espejo)
+          // Misma lógica que el padre, pero después sobreescribimos la
+          // cuota_inversionista con la del padre (herencia) y le asignamos
+          // el status según el tipo de operación.
+          // ================================================================
           const dataEspejo = recalcularInversionistas(
             nuevoArray,
             creditoData,
@@ -323,6 +497,11 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             numero_credito_sifco,
           );
 
+          // ── Determinar el status del espejo según tipo_operacion ──
+          // "reinversion" → "pendiente_reinversion"
+          // "compra_cartera" → "pendiente_compra_cartera"
+          // Solo el inversionista nuevo recibe este status.
+          // Los demás inversionistas quedan como "completado".
           const statusEspejo =
             tipo_operacion === "reinversion"
               ? "pendiente_reinversion"
@@ -330,16 +509,22 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
 
           const dataEspejoConStatus = dataEspejo.map((inv) => ({
             ...inv,
+            // Heredar cuota del padre (si existe), sino usar la calculada
             cuota_inversionista:
               parentCuotas.get(inv.inversionista_id) ??
               inv.cuota_inversionista,
+            // Solo el inversionista nuevo recibe el status pendiente
+            // Los demás se mantienen como "completado"
             status: (inv.inversionista_id === inversionista_id
                 ? statusEspejo
                 : "completado") as "pendiente_reinversion" | "pendiente_compra_cartera" | "completado",
             updated_at: new Date(),
           }));
 
-          // 3i. Borrar e insertar en creditos_inversionistas_espejo
+          // ================================================================
+          // PASO 3i: NUKE & REBUILD EN creditos_inversionistas_espejo
+          // Mismo patrón que el padre: borrar todo y reinsertar.
+          // ================================================================
           await tx
             .delete(creditos_inversionistas_espejo)
             .where(eq(creditos_inversionistas_espejo.credito_id, credito_id));
@@ -350,7 +535,12 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
               .values(dataEspejoConStatus);
           }
 
-          // 3j. Restar lo asignado del monto restante
+          // ================================================================
+          // PASO 3j: DESCONTAR EL MONTO ASIGNADO DEL SALDO RESTANTE
+          // Si aún queda monto, el loop continúa al siguiente crédito.
+          // Si ya se agotó (montoRestante <= 0), el break al inicio del
+          // loop cortará la iteración.
+          // ================================================================
           montoRestante = montoRestante.minus(montoParaEsteCredito);
 
           resultados.push({
@@ -376,6 +566,15 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
       }
     });
 
+    // ================================================================
+    // PASO 4: RESPUESTA FINAL
+    // Devuelve un resumen completo de la distribución:
+    //   - monto_total: lo que pidió el inversionista
+    //   - monto_distribuido: lo que efectivamente se asignó a créditos
+    //   - monto_sin_asignar: lo que sobró (si no hubo suficientes créditos)
+    //   - resultados: detalle por crédito procesado
+    //   - errores: créditos que fallaron y por qué
+    // ================================================================
     set.status = 200;
     return {
       success: true,

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -977,13 +977,16 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
         );
         console.log("💵 Pago del mes TOTAL:", pago_del_mesBig.toString());
         console.log("🔍 ========== FIN ==========\n");
-        const cuota_pagada =
+        const todosRestantesEnCero =
           nuevo_interes_restante.eq(0) &&
           nuevo_iva_restante.eq(0) &&
           nuevo_seguro_restante.eq(0) &&
           nuevo_gps_restante.eq(0) &&
           nuevo_membresias_restante.eq(0) &&
           nuevo_capital_restante.eq(0);
+        // Solo marcar como pagada si los restantes están en 0 Y existía un pago previo
+        // (evita marcar como pagada cuando no hay pago existente y los restantes son 0 por default)
+        const cuota_pagada = todosRestantesEnCero && !!existingPago;
         const totalPagado = abono_capital
           .plus(abono_interes)
           .plus(abono_iva_12)

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -1,0 +1,714 @@
+import Big from "big.js";
+import { eq, and, inArray, ne } from "drizzle-orm";
+import { db } from "../database";
+import {
+  creditos,
+  creditos_inversionistas,
+  creditos_inversionistas_espejo,
+} from "../database/db";
+import z from "zod";
+import { getCreditCandidates } from "./assignCapital";
+
+// ========================================
+// ID fijo de CUBE INVESTMENTS S.A.
+// CUBE es el inversionista principal/"la casa" al que se le
+// resta/devuelve participación cuando entran/salen inversionistas.
+// ========================================
+const CUBE_INVESTMENT_ID = 86;
+
+// ========================================
+// SCHEMA DE VALIDACIÓN
+// ========================================
+// Recibe:
+//   - creditos: un credito_id o un arreglo de credito_ids
+//     Estos son los créditos ORIGINALES de donde se van a SACAR
+//     los inversionistas pendientes y reubicarlos en créditos nuevos.
+// ========================================
+
+const replaceInvestorCreditSchema = z.object({
+  creditos: z.union([
+    z.number().int().positive(),
+    z.array(z.number().int().positive()).min(1),
+  ]),
+});
+
+// ========================================
+// RECALCULAR INVERSIONISTAS
+// ========================================
+// Misma función que en addInvestorToCredit.ts
+// Toma un array de inversionistas con montos redistribuidos y
+// recalcula toda la distribución financiera:
+//   - Porcentaje de participación
+//   - Cuota del inversionista (mayor absorbe cargos fijos)
+//   - Intereses y distribución cash-in/inversionista
+//   - IVA 12%
+// ========================================
+
+function recalcularInversionistas(
+  inversionistasArray: {
+    inversionista_id: number;
+    monto_aportado: Big;
+    porcentaje_cash_in: Big;
+    porcentaje_inversion: Big;
+    fecha_inicio_participacion: string;
+  }[],
+  creditoData: {
+    cuota: string;
+    porcentaje_interes: string;
+    seguro_10_cuotas: string;
+    gps: string;
+    membresias_pago: string;
+  },
+  credito_id: number,
+  numero_credito_sifco: string,
+) {
+  const capitalTotal = inversionistasArray.reduce(
+    (acc, inv) => acc.plus(inv.monto_aportado),
+    new Big(0),
+  );
+  const cuotaTotal = new Big(creditoData.cuota);
+  const seguro = new Big(creditoData.seguro_10_cuotas ?? 0);
+  const gps = new Big(creditoData.gps ?? 0);
+  const membresias = new Big(creditoData.membresias_pago ?? 0);
+  const tasaInteres = new Big(creditoData.porcentaje_interes ?? 0);
+
+  const inversionistaMayor = inversionistasArray.reduce((max, current) =>
+    current.monto_aportado.gt(max.monto_aportado) ? current : max,
+  );
+
+  const cuotaSinCargos = cuotaTotal.minus(seguro).minus(gps).minus(membresias);
+
+  return inversionistasArray.map((inv) => {
+    const porcentajeParticipacion = inv.monto_aportado
+      .div(capitalTotal)
+      .times(100);
+
+    const cuotaBase = cuotaSinCargos
+      .times(porcentajeParticipacion.div(100))
+      .round(6);
+
+    const esMayor =
+      inv.inversionista_id === inversionistaMayor.inversionista_id;
+
+    const cuotaInversionista = esMayor
+      ? cuotaBase.plus(seguro).plus(gps).plus(membresias).round(6)
+      : cuotaBase;
+
+    const cuotaInteres = inv.monto_aportado.times(tasaInteres.div(100)).round(2);
+
+    const montoInversionista = cuotaInteres
+      .times(inv.porcentaje_inversion)
+      .div(100)
+      .round(2);
+
+    const montoCashIn = cuotaInteres
+      .times(inv.porcentaje_cash_in)
+      .div(100)
+      .round(2);
+
+    const ivaInversionista = montoInversionista.gt(0)
+      ? montoInversionista.times(0.12).round(2)
+      : new Big(0);
+
+    const ivaCashIn = montoCashIn.gt(0)
+      ? montoCashIn.times(0.12).round(2)
+      : new Big(0);
+
+    return {
+      credito_id,
+      inversionista_id: inv.inversionista_id,
+      monto_aportado: inv.monto_aportado.toString(),
+      porcentaje_cash_in: inv.porcentaje_cash_in.toString(),
+      porcentaje_participacion_inversionista:
+        inv.porcentaje_inversion.toString(),
+      monto_inversionista: montoInversionista.toString(),
+      monto_cash_in: montoCashIn.toString(),
+      iva_inversionista: ivaInversionista.toString(),
+      iva_cash_in: ivaCashIn.toString(),
+      fecha_creacion: new Date(),
+      fecha_inicio_participacion:
+        inv.fecha_inicio_participacion || "2025-12-01",
+      cuota_inversionista: cuotaInversionista.toString(),
+      numero_credito_sifco: numero_credito_sifco ?? undefined,
+    };
+  });
+}
+
+// ========================================
+// CONTROLLER PRINCIPAL: replaceInvestorCredit
+// ========================================
+//
+// FLUJO GENERAL:
+// Este método REVIERTE inversionistas pendientes de créditos viejos
+// y los REUBICA en créditos nuevos.
+//
+// 1. Recibir credito_id(s) — los créditos ORIGINALES donde hay inversionistas pendientes
+// 2. Buscar en esos créditos los registros espejo con status != "completado"
+//    (pendiente_reinversion o pendiente_compra_cartera)
+// 3. Agrupar por inversionista: juntar el monto total y tipo de operación
+// 4. Para cada inversionista pendiente:
+//    a. Llamar getCreditCandidates() → busca NUEVOS créditos (los viejos NO aparecen
+//       porque todavía tienen pendings — por eso NO los borramos primero)
+//    b. Distribuir el monto en los nuevos créditos (misma lógica de addInvestorToCredit:
+//       restarle a CUBE, recalcular cuotas, nuke & rebuild en padre y espejo)
+// 5. DESPUÉS de asignar los nuevos créditos, limpiar los VIEJOS:
+//    a. Quitar al inversionista pendiente del crédito viejo (padre y espejo)
+//    b. Devolverle el monto a CUBE
+//    c. Recalcular cuotas de los inversionistas que quedan
+//    d. Nuke & rebuild en ambas tablas
+//
+// ¿POR QUÉ BORRAR DESPUÉS Y NO ANTES?
+// Porque getCreditCandidates() filtra créditos con espejo en status pendiente.
+// Si borramos los pendings ANTES del GET, esos mismos créditos aparecerían
+// como candidatos y el inversionista podría terminar en el mismo crédito
+// del que lo estamos sacando. Borrando DESPUÉS, nos aseguramos de que
+// los nuevos créditos sean realmente NUEVOS.
+//
+// EJEMPLO:
+//   Crédito 101 tiene a inversionista 42 con Q20,000 en status "pendiente_reinversion"
+//   1. Buscamos nuevos candidatos → el crédito 101 NO aparece (tiene pending)
+//   2. Encontramos crédito 205 y 310 como candidatos
+//   3. Distribuimos Q20,000 entre crédito 205 y 310 (restando a CUBE en cada uno)
+//   4. AHORA sí limpiamos crédito 101:
+//      - Sacamos a inversionista 42
+//      - Le devolvemos Q20,000 a CUBE
+//      - Recalculamos cuotas de los que quedan
+// ========================================
+
+export const replaceInvestorCredit = async ({ body, set }: any) => {
+  try {
+    // ================================================================
+    // PASO 1: VALIDAR SCHEMA
+    // Acepta un solo credito_id o un arreglo de credito_ids.
+    // Estos son los créditos de donde se van a SACAR los inversionistas
+    // pendientes para reubicarlos.
+    // ================================================================
+    const parseResult = replaceInvestorCreditSchema.safeParse(body);
+    if (!parseResult.success) {
+      set.status = 400;
+      return {
+        message: "Validation failed",
+        errors: parseResult.error.flatten().fieldErrors,
+      };
+    }
+
+    const { creditos: creditosInput } = parseResult.data;
+
+    // Normalizar a array
+    const creditoIds = Array.isArray(creditosInput)
+      ? creditosInput
+      : [creditosInput];
+
+    // ================================================================
+    // PASO 2: BUSCAR INVERSIONISTAS PENDIENTES EN LOS CRÉDITOS INDICADOS
+    // Traemos todos los registros de creditos_inversionistas_espejo que
+    // NO tienen status "completado". Estos son los que vamos a revertir.
+    //
+    // De cada registro necesitamos:
+    //   - inversionista_id: quién es
+    //   - credito_id: de qué crédito lo vamos a sacar
+    //   - monto_aportado: cuánto tiene (para redistribuir)
+    //   - status: para saber el tipo_operacion (reinversion o compra_cartera)
+    //   - porcentaje_cash_in / porcentaje_participacion: para reusar
+    // ================================================================
+    const pendientes = await db
+      .select({
+        id: creditos_inversionistas_espejo.id,
+        credito_id: creditos_inversionistas_espejo.credito_id,
+        inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+        monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+        porcentaje_cash_in: creditos_inversionistas_espejo.porcentaje_cash_in,
+        porcentaje_participacion_inversionista:
+          creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+        status: creditos_inversionistas_espejo.status,
+      })
+      .from(creditos_inversionistas_espejo)
+      .where(
+        and(
+          inArray(creditos_inversionistas_espejo.credito_id, creditoIds),
+          ne(creditos_inversionistas_espejo.status, "completado"),
+        ),
+      );
+
+    if (pendientes.length === 0) {
+      set.status = 404;
+      return {
+        success: false,
+        message: "No se encontraron inversionistas pendientes en los créditos indicados",
+      };
+    }
+
+    // ================================================================
+    // PASO 3: AGRUPAR POR INVERSIONISTA
+    // Un mismo inversionista puede estar pendiente en varios créditos.
+    // Agrupamos para saber:
+    //   - Monto total a redistribuir (suma de todos sus montos pendientes)
+    //   - Tipo de operación (reinversion o compra_cartera)
+    //   - Porcentajes (tomamos los del primer registro encontrado)
+    //   - De qué créditos hay que sacarlo (para la limpieza posterior)
+    //
+    // Ejemplo:
+    //   Inversionista 42 pendiente en crédito 101 (Q15,000) y crédito 102 (Q10,000)
+    //   → montoTotal = Q25,000
+    //   → creditosOrigen = [101, 102]
+    // ================================================================
+    const porInversionista = new Map<
+      number,
+      {
+        inversionista_id: number;
+        montoTotal: Big;
+        tipo_operacion: "reinversion" | "compra_cartera";
+        porcentaje_cash_in: string;
+        porcentaje_inversion: string;
+        creditosOrigen: { credito_id: number; monto: string }[];
+      }
+    >();
+
+    for (const p of pendientes) {
+      if (!porInversionista.has(p.inversionista_id)) {
+        porInversionista.set(p.inversionista_id, {
+          inversionista_id: p.inversionista_id,
+          montoTotal: new Big(0),
+          tipo_operacion:
+            p.status === "pendiente_reinversion"
+              ? "reinversion"
+              : "compra_cartera",
+          porcentaje_cash_in: p.porcentaje_cash_in,
+          porcentaje_inversion: p.porcentaje_participacion_inversionista,
+          creditosOrigen: [],
+        });
+      }
+      const entry = porInversionista.get(p.inversionista_id)!;
+      entry.montoTotal = entry.montoTotal.plus(p.monto_aportado);
+      entry.creditosOrigen.push({
+        credito_id: p.credito_id,
+        monto: p.monto_aportado,
+      });
+    }
+
+    console.log(
+      `🔄 ${porInversionista.size} inversionista(s) pendiente(s) a reubicar`,
+    );
+
+    const resultadosNuevos: any[] = [];
+    const resultadosLimpieza: any[] = [];
+    const errores: any[] = [];
+
+    // ================================================================
+    // PASO 4: PARA CADA INVERSIONISTA PENDIENTE, BUSCAR NUEVOS CRÉDITOS
+    // Y DISTRIBUIR SU MONTO
+    //
+    // IMPORTANTE: Hacemos esto ANTES de limpiar los créditos viejos.
+    // ¿Por qué? Porque getCreditCandidates() filtra créditos con espejo
+    // en status pendiente. Si borramos los pendings primero, esos mismos
+    // créditos aparecerían como candidatos y el inversionista podría
+    // terminar en el mismo crédito del que lo sacamos.
+    //
+    // Al hacer el GET primero, garantizamos que los candidatos sean
+    // créditos DIFERENTES a los que ya tienen pendings.
+    // ================================================================
+    await db.transaction(async (tx) => {
+      for (const [, invData] of porInversionista) {
+        const {
+          inversionista_id,
+          montoTotal,
+          tipo_operacion,
+          porcentaje_cash_in,
+          porcentaje_inversion,
+          creditosOrigen,
+        } = invData;
+
+        console.log(
+          `\n📊 Procesando inversionista ${inversionista_id} - Q${montoTotal} desde ${creditosOrigen.length} crédito(s)`,
+        );
+
+        // ── 4a. Buscar NUEVOS créditos candidatos ──
+        // El GET no traerá los créditos viejos porque tienen pendings
+        const candidatos = await getCreditCandidates(montoTotal.toNumber());
+
+        if (candidatos.length === 0) {
+          errores.push({
+            inversionista_id,
+            razon: "No se encontraron créditos candidatos nuevos",
+          });
+          continue;
+        }
+
+        // ── 4b. Distribuir el monto entre los nuevos créditos ──
+        // Misma lógica que addInvestorToCredit: ir crédito por crédito,
+        // tomar lo que CUBE tenga disponible, pasar al siguiente si no alcanza.
+        let montoRestante = new Big(montoTotal);
+        const porcCashIn = new Big(porcentaje_cash_in);
+        const porcInversion = new Big(porcentaje_inversion);
+
+        const statusEspejo =
+          tipo_operacion === "reinversion"
+            ? "pendiente_reinversion"
+            : "pendiente_compra_cartera";
+
+        for (const candidato of candidatos) {
+          if (montoRestante.lte(0)) break;
+
+          const { credito_id, numero_credito_sifco, credito_completo } = candidato;
+
+          if (!credito_completo) continue;
+
+          const { credito: creditoRaw, inversionistas_detalle } = credito_completo;
+
+          const creditoData = {
+            cuota: creditoRaw.cuota,
+            porcentaje_interes: creditoRaw.porcentaje_interes,
+            seguro_10_cuotas: creditoRaw.seguro_10_cuotas,
+            gps: creditoRaw.gps,
+            membresias_pago: creditoRaw.membresias_pago,
+          };
+
+          const inversionistasActuales = inversionistas_detalle.map((inv: any) => ({
+            inversionista_id: inv.inversionista_id,
+            monto_aportado: inv.monto_aportado,
+            porcentaje_cash_in: inv.porcentaje_cash_in,
+            porcentaje_participacion_inversionista:
+              inv.porcentaje_participacion_inversionista,
+            fecha_inicio_participacion: inv.fecha_inicio_participacion,
+          }));
+
+          // ── Buscar CUBE en el nuevo crédito ──
+          const cubeActual = inversionistasActuales.find(
+            (inv: any) => inv.inversionista_id === CUBE_INVESTMENT_ID,
+          );
+
+          if (!cubeActual) continue;
+
+          const montoCubeActual = new Big(cubeActual.monto_aportado);
+
+          // ── Cuánto tomar: lo que CUBE tenga o lo que falta, lo que sea menor ──
+          const montoParaEsteCredito = montoRestante.gt(montoCubeActual)
+            ? montoCubeActual
+            : montoRestante;
+
+          // ── Armar nuevo array de inversionistas para el nuevo crédito ──
+          const nuevoArray: {
+            inversionista_id: number;
+            monto_aportado: Big;
+            porcentaje_cash_in: Big;
+            porcentaje_inversion: Big;
+            fecha_inicio_participacion: string;
+          }[] = [];
+
+          for (const inv of inversionistasActuales) {
+            if (inv.inversionista_id === CUBE_INVESTMENT_ID) {
+              const nuevoMontoCube = montoCubeActual.minus(montoParaEsteCredito);
+              if (nuevoMontoCube.gt(0)) {
+                nuevoArray.push({
+                  inversionista_id: inv.inversionista_id,
+                  monto_aportado: nuevoMontoCube,
+                  porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
+                  porcentaje_inversion: new Big(
+                    inv.porcentaje_participacion_inversionista,
+                  ),
+                  fecha_inicio_participacion: inv.fecha_inicio_participacion,
+                });
+              }
+            } else if (inv.inversionista_id === inversionista_id) {
+              nuevoArray.push({
+                inversionista_id: inv.inversionista_id,
+                monto_aportado: new Big(inv.monto_aportado).plus(montoParaEsteCredito),
+                porcentaje_cash_in: porcCashIn,
+                porcentaje_inversion: porcInversion,
+                fecha_inicio_participacion: inv.fecha_inicio_participacion,
+              });
+            } else {
+              nuevoArray.push({
+                inversionista_id: inv.inversionista_id,
+                monto_aportado: new Big(inv.monto_aportado),
+                porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
+                porcentaje_inversion: new Big(
+                  inv.porcentaje_participacion_inversionista,
+                ),
+                fecha_inicio_participacion: inv.fecha_inicio_participacion,
+              });
+            }
+          }
+
+          // Si el inversionista no existía en este crédito, agregarlo
+          const yaExiste = nuevoArray.some(
+            (inv) => inv.inversionista_id === inversionista_id,
+          );
+          if (!yaExiste) {
+            nuevoArray.push({
+              inversionista_id,
+              monto_aportado: montoParaEsteCredito,
+              porcentaje_cash_in: porcCashIn,
+              porcentaje_inversion: porcInversion,
+              fecha_inicio_participacion: new Date().toISOString().split("T")[0],
+            });
+          }
+
+          // ── Recalcular y nuke & rebuild en PADRE ──
+          const dataPadre = recalcularInversionistas(
+            nuevoArray,
+            creditoData,
+            credito_id,
+            numero_credito_sifco,
+          );
+
+          await tx
+            .delete(creditos_inversionistas)
+            .where(eq(creditos_inversionistas.credito_id, credito_id));
+
+          if (dataPadre.length > 0) {
+            await tx.insert(creditos_inversionistas).values(dataPadre);
+          }
+
+          // ── Recalcular y nuke & rebuild en ESPEJO ──
+          const parentCuotas = new Map(
+            dataPadre.map((p) => [p.inversionista_id, p.cuota_inversionista]),
+          );
+
+          const dataEspejo = recalcularInversionistas(
+            nuevoArray,
+            creditoData,
+            credito_id,
+            numero_credito_sifco,
+          );
+
+          const dataEspejoConStatus = dataEspejo.map((inv) => ({
+            ...inv,
+            cuota_inversionista:
+              parentCuotas.get(inv.inversionista_id) ??
+              inv.cuota_inversionista,
+            status: (inv.inversionista_id === inversionista_id
+              ? statusEspejo
+              : "completado") as
+              | "pendiente_reinversion"
+              | "pendiente_compra_cartera"
+              | "completado",
+            updated_at: new Date(),
+          }));
+
+          await tx
+            .delete(creditos_inversionistas_espejo)
+            .where(eq(creditos_inversionistas_espejo.credito_id, credito_id));
+
+          if (dataEspejoConStatus.length > 0) {
+            await tx
+              .insert(creditos_inversionistas_espejo)
+              .values(dataEspejoConStatus);
+          }
+
+          montoRestante = montoRestante.minus(montoParaEsteCredito);
+
+          resultadosNuevos.push({
+            credito_id,
+            numero_credito_sifco,
+            inversionista_id,
+            monto_asignado: montoParaEsteCredito.toString(),
+            cube_eliminado: !nuevoArray.some(
+              (inv) => inv.inversionista_id === CUBE_INVESTMENT_ID,
+            ),
+          });
+
+          console.log(
+            `   ✅ Nuevo crédito ${numero_credito_sifco} - asignado Q${montoParaEsteCredito} - quedan Q${montoRestante}`,
+          );
+        }
+
+        // ================================================================
+        // PASO 5: LIMPIAR LOS CRÉDITOS VIEJOS
+        // AHORA que ya asignamos los nuevos créditos, volvemos a los viejos
+        // y limpiamos:
+        //   - Sacamos al inversionista pendiente del padre y espejo
+        //   - Le devolvemos el monto a CUBE
+        //   - Recalculamos las cuotas de los que quedan
+        //
+        // Para cada crédito origen:
+        //   a. Traer inversionistas actuales del padre
+        //   b. Quitar al inversionista pendiente del array
+        //   c. Sumarle su monto a CUBE (devolverle lo que le quitamos)
+        //   d. Recalcular todo
+        //   e. Nuke & rebuild en padre y espejo
+        // ================================================================
+        for (const origen of creditosOrigen) {
+          const { credito_id: origenCreditoId, monto: montoOrigen } = origen;
+
+          console.log(
+            `   🧹 Limpiando crédito origen ${origenCreditoId} - devolviendo Q${montoOrigen} a CUBE`,
+          );
+
+          // ── Traer data fresca del crédito origen ──
+          const [creditoOrigenData] = await tx
+            .select({
+              credito_id: creditos.credito_id,
+              cuota: creditos.cuota,
+              porcentaje_interes: creditos.porcentaje_interes,
+              seguro_10_cuotas: creditos.seguro_10_cuotas,
+              gps: creditos.gps,
+              membresias_pago: creditos.membresias_pago,
+              numero_credito_sifco: creditos.numero_credito_sifco,
+            })
+            .from(creditos)
+            .where(eq(creditos.credito_id, origenCreditoId))
+            .limit(1);
+
+          if (!creditoOrigenData) continue;
+
+          // ── Traer inversionistas actuales del padre ──
+          const invActualesOrigen = await tx
+            .select({
+              inversionista_id: creditos_inversionistas.inversionista_id,
+              monto_aportado: creditos_inversionistas.monto_aportado,
+              porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
+              porcentaje_participacion_inversionista:
+                creditos_inversionistas.porcentaje_participacion_inversionista,
+              fecha_inicio_participacion:
+                creditos_inversionistas.fecha_inicio_participacion,
+            })
+            .from(creditos_inversionistas)
+            .where(eq(creditos_inversionistas.credito_id, origenCreditoId));
+
+          // ── Armar array SIN el inversionista pendiente y CON CUBE restaurado ──
+          const arrayLimpio: {
+            inversionista_id: number;
+            monto_aportado: Big;
+            porcentaje_cash_in: Big;
+            porcentaje_inversion: Big;
+            fecha_inicio_participacion: string;
+          }[] = [];
+
+          for (const inv of invActualesOrigen) {
+            if (inv.inversionista_id === inversionista_id) {
+              // ── Quitar al inversionista pendiente ──
+              // No lo incluimos en el array, se va del crédito
+              continue;
+            } else if (inv.inversionista_id === CUBE_INVESTMENT_ID) {
+              // ── CUBE: devolverle el monto del inversionista que sale ──
+              arrayLimpio.push({
+                inversionista_id: inv.inversionista_id,
+                monto_aportado: new Big(inv.monto_aportado).plus(montoOrigen),
+                porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
+                porcentaje_inversion: new Big(
+                  inv.porcentaje_participacion_inversionista,
+                ),
+                fecha_inicio_participacion: inv.fecha_inicio_participacion,
+              });
+            } else {
+              // ── Los demás: se quedan igual ──
+              arrayLimpio.push({
+                inversionista_id: inv.inversionista_id,
+                monto_aportado: new Big(inv.monto_aportado),
+                porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
+                porcentaje_inversion: new Big(
+                  inv.porcentaje_participacion_inversionista,
+                ),
+                fecha_inicio_participacion: inv.fecha_inicio_participacion,
+              });
+            }
+          }
+
+          // ── Si CUBE no existía (raro pero por seguridad), crearlo con el monto devuelto ──
+          const cubeEnArray = arrayLimpio.some(
+            (inv) => inv.inversionista_id === CUBE_INVESTMENT_ID,
+          );
+          if (!cubeEnArray) {
+            arrayLimpio.push({
+              inversionista_id: CUBE_INVESTMENT_ID,
+              monto_aportado: new Big(montoOrigen),
+              porcentaje_cash_in: new Big(0),
+              porcentaje_inversion: new Big(100),
+              fecha_inicio_participacion: "2025-12-01",
+            });
+          }
+
+          // ── Recalcular y nuke & rebuild PADRE del crédito origen ──
+          const dataPadreOrigen = recalcularInversionistas(
+            arrayLimpio,
+            creditoOrigenData,
+            origenCreditoId,
+            creditoOrigenData.numero_credito_sifco,
+          );
+
+          await tx
+            .delete(creditos_inversionistas)
+            .where(eq(creditos_inversionistas.credito_id, origenCreditoId));
+
+          if (dataPadreOrigen.length > 0) {
+            await tx.insert(creditos_inversionistas).values(dataPadreOrigen);
+          }
+
+          // ── Recalcular y nuke & rebuild ESPEJO del crédito origen ──
+          // Solo los inversionistas que quedan (sin el pendiente), todos con status "completado"
+          const parentCuotasOrigen = new Map(
+            dataPadreOrigen.map((p) => [
+              p.inversionista_id,
+              p.cuota_inversionista,
+            ]),
+          );
+
+          const dataEspejoOrigen = recalcularInversionistas(
+            arrayLimpio,
+            creditoOrigenData,
+            origenCreditoId,
+            creditoOrigenData.numero_credito_sifco,
+          );
+
+          const dataEspejoOrigenFinal = dataEspejoOrigen.map((inv) => ({
+            ...inv,
+            cuota_inversionista:
+              parentCuotasOrigen.get(inv.inversionista_id) ??
+              inv.cuota_inversionista,
+            status: "completado" as const,
+            updated_at: new Date(),
+          }));
+
+          await tx
+            .delete(creditos_inversionistas_espejo)
+            .where(
+              eq(creditos_inversionistas_espejo.credito_id, origenCreditoId),
+            );
+
+          if (dataEspejoOrigenFinal.length > 0) {
+            await tx
+              .insert(creditos_inversionistas_espejo)
+              .values(dataEspejoOrigenFinal);
+          }
+
+          resultadosLimpieza.push({
+            credito_id: origenCreditoId,
+            numero_credito_sifco: creditoOrigenData.numero_credito_sifco,
+            inversionista_removido: inversionista_id,
+            monto_devuelto_a_cube: montoOrigen,
+            inversionistas_restantes: dataPadreOrigen.length,
+          });
+
+          console.log(
+            `   🧹 Crédito ${creditoOrigenData.numero_credito_sifco} limpio - ${dataPadreOrigen.length} inversionistas restantes`,
+          );
+        }
+      }
+    });
+
+    // ================================================================
+    // PASO 6: RESPUESTA FINAL
+    // Devuelve el detalle de:
+    //   - nuevos_creditos: a dónde fueron los inversionistas
+    //   - creditos_limpiados: de dónde se sacaron y cómo quedaron
+    //   - errores: si algo falló
+    // ================================================================
+    set.status = 200;
+    return {
+      success: true,
+      message: `Reubicados: ${resultadosNuevos.length} nuevos, ${resultadosLimpieza.length} limpiados, ${errores.length} errores`,
+      nuevos_creditos: resultadosNuevos,
+      creditos_limpiados: resultadosLimpieza,
+      errores,
+    };
+  } catch (error) {
+    console.error("[replaceInvestorCredit] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al reubicar inversionistas",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+};

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -37,7 +37,8 @@ const app = new Elysia()
   .use(routers.sifcoSyncRouter)
   .use(routers.assignCapitalRouter)
   .use(routers.addInvestorToCreditRouter)
-  .use(routers.completeEspejoRouter);
+  .use(routers.completeEspejoRouter)
+  .use(routers.replaceInvestorCreditRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor
 iniciarTareasProgramadas();

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -24,6 +24,7 @@ import { sifcoSyncRouter } from "./sifcoSync";
 import { assignCapitalRouter } from "./assignCapital";
 import { addInvestorToCreditRouter } from "./addInvestorToCredit";
 import { completeEspejoRouter } from "./completeEspejo";
+import { replaceInvestorCreditRouter } from "./replaceInvestorCredit";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter
 }   

--- a/apps/cartera-back/src/routers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/routers/replaceInvestorCredit.ts
@@ -1,0 +1,21 @@
+import { Elysia, t } from "elysia";
+import { replaceInvestorCredit } from "../controllers/replaceInvestorCredit";
+
+export const replaceInvestorCreditRouter = new Elysia().post(
+  "/reemplazar-inversionista-credito",
+  replaceInvestorCredit,
+  {
+    body: t.Object({
+      creditos: t.Union([
+        t.Number({ minimum: 1 }),
+        t.Array(t.Number({ minimum: 1 }), { minItems: 1 }),
+      ]),
+    }),
+    detail: {
+      summary: "Reemplazar inversionistas pendientes en créditos",
+      description:
+        "Recibe credito_id(s), busca los inversionistas con status pendiente en espejo, los reubica en créditos nuevos (via getCreditCandidates), y luego limpia los créditos viejos devolviendo el monto a CUBE.",
+      tags: ["Inversionistas", "Créditos", "Espejo"],
+    },
+  },
+);

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -254,7 +254,7 @@ export function PaymentsTable() {
   const facturarPago = useFacturarPagoCompleto(); // 🆕 NUEVO HOOK
 
   // Filtros de fecha - modo "simple" (año/mes/día), "rango" (fechaInicio/fechaFin) o "aplicado" (fechaAplicado)
-  const [modoFecha, setModoFecha] = React.useState<"simple" | "rango" | "aplicado">("simple");
+  const [modoFecha, setModoFecha] = React.useState<"simple" | "rango" | "aplicado" | "boleta">("simple");
   const [mes, setMes] = React.useState(new Date().getMonth() + 1);
   const [anio, setAnio] = React.useState(new Date().getFullYear());
   const [dia, setDia] = React.useState<number | undefined>(
@@ -263,6 +263,7 @@ export function PaymentsTable() {
   const [fechaInicio, setFechaInicio] = React.useState("");
   const [fechaFin, setFechaFin] = React.useState("");
   const [fechaAplicado, setFechaAplicado] = React.useState("");
+  const [fechaBoleta, setFechaBoleta] = React.useState("");
 
   // Filtros de crédito
   const [sifco, setSifco] = React.useState("");
@@ -455,7 +456,9 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
       ? { dia, mes, anio }
       : modoFecha === "rango"
         ? { fechaInicio: fechaInicio || undefined, fechaFin: fechaFin || undefined }
-        : { fechaAplicado: fechaAplicado || undefined }),
+        : modoFecha === "aplicado"
+          ? { fechaAplicado: fechaAplicado || undefined }
+          : { fechaBoleta: fechaBoleta || undefined }),
     categoriaCredito: categoriaCredito || undefined,
     formatoCredito: formatoCredito || undefined,
     soloAplicados,
@@ -592,6 +595,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                 setFechaInicio("");
                 setFechaFin("");
                 setFechaAplicado("");
+                setFechaBoleta("");
                 setCategoriaCredito("");
                 setFormatoCredito("");
                 setSoloAplicados(undefined);
@@ -618,24 +622,31 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
               <div className="flex gap-1 flex-wrap">
                 <button
                   type="button"
-                  onClick={() => { setModoFecha("simple"); setFechaInicio(""); setFechaFin(""); setFechaAplicado(""); setPage(1); }}
+                  onClick={() => { setModoFecha("simple"); setFechaInicio(""); setFechaFin(""); setFechaAplicado(""); setFechaBoleta(""); setPage(1); }}
                   className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "simple" ? "bg-blue-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
                 >
                   Fecha
                 </button>
                 <button
                   type="button"
-                  onClick={() => { setModoFecha("rango"); setDia(undefined); setFechaAplicado(""); setPage(1); }}
+                  onClick={() => { setModoFecha("rango"); setDia(undefined); setFechaAplicado(""); setFechaBoleta(""); setPage(1); }}
                   className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "rango" ? "bg-blue-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
                 >
                   Rango
                 </button>
                 <button
                   type="button"
-                  onClick={() => { setModoFecha("aplicado"); setDia(undefined); setFechaInicio(""); setFechaFin(""); setPage(1); }}
+                  onClick={() => { setModoFecha("aplicado"); setDia(undefined); setFechaInicio(""); setFechaFin(""); setFechaBoleta(""); setPage(1); }}
                   className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "aplicado" ? "bg-emerald-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
                 >
                   Aplicado
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setModoFecha("boleta"); setDia(undefined); setFechaInicio(""); setFechaFin(""); setFechaAplicado(""); setPage(1); }}
+                  className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "boleta" ? "bg-amber-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
+                >
+                  Boleta
                 </button>
               </div>
               {modoFecha === "simple" ? (
@@ -692,12 +703,21 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                     />
                   </div>
                 </div>
-              ) : (
+              ) : modoFecha === "aplicado" ? (
                 <div>
                   <label className="text-[10px] text-gray-500 font-medium mb-0.5 block">Fecha de Aplicación</label>
                   <DatePickerMUI
                     value={fechaAplicado}
                     onChange={(value) => { setFechaAplicado(value); setPage(1); }}
+                    disableFuture={false}
+                  />
+                </div>
+              ) : (
+                <div>
+                  <label className="text-[10px] text-gray-500 font-medium mb-0.5 block">Fecha de Boleta</label>
+                  <DatePickerMUI
+                    value={fechaBoleta}
+                    onChange={(value) => { setFechaBoleta(value); setPage(1); }}
                     disableFuture={false}
                   />
                 </div>

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1790,6 +1790,7 @@ export interface GetPagosParams {
   usuarioNombre?: string;
   validationStatus?: string;
   reportAdvisor?: boolean;
+  fechaBoleta?: string;
 }
 
 /**


### PR DESCRIPTION
Implements a new system to reallocate investor funds from pending mirror credits to new investment opportunities. This feature centralizes the management of 'reinversion' and 'compra_cartera' processes.

**Key Changes:**
*   **Investor Credit Reallocation:** Introduces a new `replaceInvestorCredit` backend controller. It identifies investors with pending mirror investments (reinversion or portfolio purchase) in specified credits, finds suitable new credit candidates, and reallocates the investor's capital. This process includes adjusting CUBE's participation, recalculating all financial distributions (percentages, quotas, cash-in, IVA), and performing a "nuke & rebuild" on both parent (`creditos_inversionistas`) and mirror (`creditos_inversionistas_espejo`) tables for both the new and original credits.
*   **Retired 'Sesiones Pendientes' Feature:** Removes the previous backend endpoint and frontend component that displayed and managed pending mirror investment sessions.
*   **Payment Table Enhancements:** Adds a new filter option to the payments table on the frontend, allowing users to search by 'Fecha de Boleta' (invoice date).
*   **CRM Query Refinements:** Updates CRM logic for fetching sales users and open opportunities, including more precise filtering by opportunity source and user assignment status. Standardizes date display for `createdAt` fields in CRM tables and cards to show only the date, not the time.

Relates to jdReinversion