### PR TITLE
feat: integrate reassignment and confirm endpoints for pending sessions

### DIFF
--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -16,7 +16,7 @@ import Big from "big.js";
 // ============================================================
 
 // ID fijo de Cube Investments S.A. en la base de datos
-const CUBE_ID = 86;
+export const CUBE_ID = 86;
 
 interface InversionistaResult {
   inversionista_id: number;
@@ -112,7 +112,8 @@ function calcCapitalProximityBonus(
 // ============================================================
 
 export async function getCreditCandidates(
-  monto?: number
+  monto?: number,
+  limit?: number
 ): Promise<CreditCandidate[]> {
   console.log("\n🔍 ========== getCreditCandidates ==========");
   console.log(`   monto: ${monto ?? "no especificado"}`);
@@ -425,6 +426,11 @@ export async function getCreditCandidates(
 
   // Ordenar DESC por score
   candidates.sort((a, b) => b.score - a.score);
+
+  // Si se especificó un límite, cortar antes de las queries de relaciones
+  if (limit !== undefined) {
+    candidates.splice(limit);
+  }
 
   // ──────────────────────────────────────────────────────────
   // 8. Opcional: Agregar todos los datos relaciones (a petición)

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -38,6 +38,7 @@ import {
   type EstadoLiquidacionResumen,
   type EstadoLiquidacionResumenFilter,
 } from "../utils/investorLiquidationSummary";
+import { getCreditCandidates, CUBE_ID } from "./assignCapital";
 
 // ============================================
 // 🆕 TIPOS Y CONFIGURACIÓN PARA CONSULTAS ORIGINALES/ESPEJO
@@ -1423,7 +1424,7 @@ const mes = fechaParaMes
                   break;
 
                 case "reinversion_variable":
-                  // Se calcula como sin_reinversion per-pago; el tope global se aplica después
+                  // Se calcula como sin_reinversion per-pago; el allCandidatese global se aplica después
                   cuota_inversor = abono_capital
                     .plus(abono_interes)
                     .plus(inv.emite_factura ? abono_iva : isr.neg());
@@ -1538,7 +1539,7 @@ const mes = fechaParaMes
         })
       );
 
-      // Aplicar reinversión variable como tope global sobre el total
+      // Aplicar reinversión variable como allCandidatese global sobre el total
       if (inv.reinversion === "reinversion_variable") {
         const montoReinv = new Big(inv.monto_reinversion ?? 0);
         const reinversion = montoReinv.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoReinv;
@@ -1835,7 +1836,7 @@ export async function getInvestorTotalsGlobales(
           cuota_inversor = new Big(0);
           break;
         case "reinversion_variable":
-          // Se calcula como sin_reinversion per-pago; el tope global se aplica después
+          // Se calcula como sin_reinversion per-pago; el allCandidatese global se aplica después
           cuota_inversor = abono_capital.plus(interesTotal);
           break;
         default:
@@ -1860,7 +1861,7 @@ export async function getInvestorTotalsGlobales(
     subtotal.total_capital_actual = subtotal.total_capital_actual.plus(capital_actual);
   }
 
-  // Aplicar reinversión variable como tope global sobre el total
+  // Aplicar reinversión variable como allCandidatese global sobre el total
   if (inv.reinversion === "reinversion_variable") {
     const montoReinv = new Big(inv.monto_reinversion ?? 0);
     const reinversion = montoReinv.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoReinv;
@@ -2452,7 +2453,7 @@ export async function getInvestorMirrorSummary(
           cuota_inversor = new Big(0);
           break;
         case "reinversion_variable":
-          // Se calcula como sin_reinversion per-pago; el tope global se aplica después
+          // Se calcula como sin_reinversion per-pago; el allCandidatese global se aplica después
           cuota_inversor = abono_capital.plus(interesTotal);
           break;
         default:
@@ -2477,7 +2478,7 @@ export async function getInvestorMirrorSummary(
     sg.total_capital_actual = sg.total_capital_actual.plus(capital_actual);
   }
 
-  // Aplicar reinversión variable como tope global sobre el total
+  // Aplicar reinversión variable como allCandidatese global sobre el total
   if (inv.reinversion === "reinversion_variable") {
     const montoReinv = new Big(inv.monto_reinversion ?? 0);
     const reinversion = montoReinv.gt(sg.total_cuota) ? sg.total_cuota : montoReinv;
@@ -5166,7 +5167,7 @@ export async function testUploadAndEmail(investorId: number, testEmail: string) 
  * que será reemplazado por la consulta real cuando esté lista.
  */
 export async function getCreditosEspejoPendientes() {
-  // 1. Créditos espejo pendientes con info del inversionista
+  // 1. Créditos espejo pendientes con info del inversionista + crédito + usuario
   const pendientes = await db
     .select({
       id: creditos_inversionistas_espejo.id,
@@ -5184,6 +5185,9 @@ export async function getCreditosEspejoPendientes() {
       fecha_inicio_participacion: creditos_inversionistas_espejo.fecha_inicio_participacion,
       status: creditos_inversionistas_espejo.status,
       tipo_reinversion: creditos_inversionistas_espejo.tipo_reinversion,
+      // Info del crédito
+      numero_credito_sifco: creditos.numero_credito_sifco,
+      nombre_usuario: usuarios.nombre,
       // Info inversionista (solo para agrupar, no se incluye en creditosPendientes)
       _nombre_inversionista: inversionistas.nombre,
       _dpi: inversionistas.dpi,
@@ -5197,6 +5201,14 @@ export async function getCreditosEspejoPendientes() {
       inversionistas,
       eq(creditos_inversionistas_espejo.inversionista_id, inversionistas.inversionista_id)
     )
+    .innerJoin(
+      creditos,
+      eq(creditos_inversionistas_espejo.credito_id, creditos.credito_id)
+    )
+    .innerJoin(
+      usuarios,
+      eq(creditos.usuario_id, usuarios.usuario_id)
+    )
     .where(
       sql`${creditos_inversionistas_espejo.status} IN ('pendiente_reinversion', 'pendiente_compra_cartera')`
     );
@@ -5205,10 +5217,7 @@ export async function getCreditosEspejoPendientes() {
     return [];
   }
 
-  // 2. Placeholder: traer 5 créditos random (reemplazar después por la consulta real)
-  const otrosCreditos = await getOtrosCreditosPlaceholder();
-
-  // 3. Agrupar por inversionista
+  // 2. Agrupar por inversionista
   type CreditoSinInversionista = Omit<typeof pendientes[number], '_nombre_inversionista' | '_dpi' | '_email' | '_moneda' | '_monto_reinversion' | '_saldo_reinversion'>;
 
   const agrupado = new Map<number, {
@@ -5220,7 +5229,6 @@ export async function getCreditosEspejoPendientes() {
     monto_reinversion: string | null;
     saldo_reinversion: string;
     creditosPendientes: CreditoSinInversionista[];
-    otrosCreditos: typeof otrosCreditos;
   }>();
 
   for (const row of pendientes) {
@@ -5235,7 +5243,6 @@ export async function getCreditosEspejoPendientes() {
         monto_reinversion: _monto_reinversion,
         saldo_reinversion: _saldo_reinversion,
         creditosPendientes: [],
-        otrosCreditos,
       });
     }
     agrupado.get(row.inversionista_id)!.creditosPendientes.push(creditoData);
@@ -5244,38 +5251,3 @@ export async function getCreditosEspejoPendientes() {
   return Array.from(agrupado.values());
 }
 
-/**
- * TODO: Reemplazar esta función por la consulta real cuando esté lista.
- * Por ahora trae 5 créditos random de la tabla creditos.
- */
-async function getOtrosCreditosPlaceholder() {
-  // TODO: Reemplazar por la consulta real cuando esté lista
-  const resultado = await db
-    .select({
-      credito_id: creditos.credito_id,
-      usuario_id: creditos.usuario_id,
-      numero_credito_sifco: creditos.numero_credito_sifco,
-      capital: creditos.capital,
-      porcentaje_interes: creditos.porcentaje_interes,
-      deudatotal: creditos.deudatotal,
-      cuota_interes: creditos.cuota_interes,
-      cuota: creditos.cuota,
-      iva_12: creditos.iva_12,
-      plazo: creditos.plazo,
-      statusCredit: creditos.statusCredit,
-      formato_credito: creditos.formato_credito,
-      tipoCredito: creditos.tipoCredito,
-      fecha_creacion: creditos.fecha_creacion,
-      monto_aportado_cash_in: creditos_inversionistas.monto_aportado,
-    })
-    .from(creditos)
-    .innerJoin(
-      creditos_inversionistas,
-      and(
-        eq(creditos.credito_id, creditos_inversionistas.credito_id),
-        eq(creditos_inversionistas.inversionista_id, 86)
-      )
-    )
-    .limit(5);
-  return resultado;
-}

--- a/apps/cartera-back/src/routers/assignCapital.ts
+++ b/apps/cartera-back/src/routers/assignCapital.ts
@@ -66,7 +66,7 @@ export const assignCapitalRouter = new Elysia()
     }
 
     try {
-      const allCandidates = await getCreditCandidates(monto);
+      const allCandidates = await getCreditCandidates(monto, minimo);
 
       let result: CreditCandidate[];
 
@@ -81,11 +81,7 @@ export const assignCapitalRouter = new Elysia()
         }
         result = insertables;
 
-      } else if (minimo !== undefined) {
-        // ── Top N por score ────────────────────────────────────
-        result = allCandidates.slice(0, minimo);
-
-      } else {
+      }  else {
         // ── Default: todos ─────────────────────────────────────
         result = allCandidates;
       }

--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -245,11 +245,11 @@ export function ModalReinversionCombinada({
 
         {/* Paginación */}
         {totalPages > 1 && (
-          <div className="px-6 py-2 border-t flex items-center justify-center gap-2">
+          <div className="px-6 py-2 border-t border-gray-200 flex items-center justify-center gap-2">
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="px-3 py-1 text-sm rounded border disabled:opacity-40 hover:bg-gray-50"
+              className="px-3 py-1 text-sm rounded border border-gray-300 bg-white text-gray-700 disabled:opacity-40 hover:bg-gray-100"
             >
               Anterior
             </button>
@@ -259,7 +259,7 @@ export function ModalReinversionCombinada({
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page === totalPages}
-              className="px-3 py-1 text-sm rounded border disabled:opacity-40 hover:bg-gray-50"
+              className="px-3 py-1 text-sm rounded border border-gray-300 bg-white text-gray-700 disabled:opacity-40 hover:bg-gray-100"
             >
               Siguiente
             </button>

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useMemo, useCallback } from "react";
-import { useSesionesPendientes } from "../hooks/useSesionesPendientes";
-import type { InversionistaSesionPendiente } from "../services/services";
+import { useSesionesPendientes, useCompletarEspejo, useReemplazarInversionistaCredito, useCreditCandidates } from "../hooks/useSesionesPendientes";
+import type { InversionistaSesionPendiente, OtroCreditoDisponible } from "../services/services";
 import {
   Loader2,
   Search,
@@ -16,7 +16,6 @@ import {
   Mail,
   CreditCard,
   X,
-  ChevronRight,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -164,7 +163,7 @@ export function SesionesPendientes() {
         ) : (
           <div className="space-y-4">
             {filtered.map((inv) => (
-              <InvestorCard key={inv.inversionista_id} investor={inv} onRefetch={refetch} />
+              <InvestorCard key={inv.inversionista_id} investor={inv} />
             ))}
           </div>
         )}
@@ -173,34 +172,30 @@ export function SesionesPendientes() {
   );
 }
 
+function getCashInMonto(oc: OtroCreditoDisponible): number {
+  const cube = oc.inversionistas.find((i) => i.es_cube);
+  return cube?.monto_aportado ?? 0;
+}
+
 // ============================================
 // Construir destinos con capacidad
 // ============================================
 function buildDestinos(
-  investor: InversionistaSesionPendiente,
-  removedCreditId: number,
+  candidates: OtroCreditoDisponible[],
   moneda: string
 ): CreditoDestino[] {
   const destinos: CreditoDestino[] = [];
 
-  for (const oc of investor.otrosCreditos) {
+  for (const oc of candidates) {
+    const cashInMonto = getCashInMonto(oc);
     destinos.push({
       id: oc.credito_id,
-      label: `${oc.numero_credito_sifco || `#${oc.credito_id}`} · Aportado: ${formatQ(oc.monto_aportado_cash_in, moneda)}`,
-      capacidad: Number(oc.monto_aportado_cash_in) || Infinity,
+      label: `${oc.numero_credito_sifco || `#${oc.credito_id}`} · ${oc.credito_completo?.usuario?.nombre ?? ""} · Aportado: ${formatQ(cashInMonto, moneda)}`,
+      capacidad: cashInMonto || oc.capital_activo,
       tipo: "existente",
     });
   }
 
-  for (const cp of investor.creditosPendientes) {
-    if (cp.id === removedCreditId) continue;
-    destinos.push({
-      id: cp.credito_id * -1,
-      label: `#${cp.credito_id} · ${statusLabel(cp.status)} · Aportado: ${formatQ(cp.monto_aportado, moneda)}`,
-      capacidad: Number(cp.monto_aportado) || Infinity,
-      tipo: "pendiente",
-    });
-  }
 
   return destinos;
 }
@@ -210,25 +205,23 @@ function buildDestinos(
 // ============================================
 function InvestorCard({
   investor,
-  onRefetch,
 }: {
   investor: InversionistaSesionPendiente;
-  onRefetch: () => void;
 }) {
   const [expanded, setExpanded] = useState(true);
-  const [showCreditos, setShowCreditos] = useState(false);
   const [editingCreditId, setEditingCreditId] = useState<number | null>(null);
   const [selectedDestinoIds, setSelectedDestinoIds] = useState<Set<number>>(new Set());
-  const [isSaving, setIsSaving] = useState(false);
-  const [isConfirming, setIsConfirming] = useState(false);
+  const reemplazar = useReemplazarInversionistaCredito();
+  const completarEspejo = useCompletarEspejo();
+  const { data: candidates = [] } = useCreditCandidates();
 
   const isEditing = editingCreditId !== null;
   const editingCredit = investor.creditosPendientes.find((c) => c.id === editingCreditId);
 
   const destinos = useMemo(() => {
     if (!editingCreditId) return [];
-    return buildDestinos(investor, editingCreditId, investor.moneda);
-  }, [editingCreditId, investor]);
+    return buildDestinos(candidates, investor.moneda);
+  }, [editingCreditId, investor, candidates]);
 
   const montoAportado = editingCredit ? Number(editingCredit.monto_aportado) : 0;
 
@@ -265,50 +258,54 @@ function InvestorCard({
     });
   }, []);
 
-  const handleSave = useCallback(async () => {
-    if (!editingCreditId || !isBalanced) return;
-    setIsSaving(true);
-    try {
-      const payload = {
+  const handleSave = useCallback(() => {
+    if (!editingCreditId || !isBalanced || !editingCredit) return;
+
+    const tipoOp = editingCredit.status === "pendiente_reinversion"
+      ? "reinversion" as const
+      : "compra_cartera" as const;
+
+    reemplazar.mutate(
+      {
         inversionista_id: investor.inversionista_id,
         credito_espejo_removido_id: editingCreditId,
+        tipo_operacion: tipoOp,
+        porcentaje_cash_in: Number(editingCredit.porcentaje_cash_in),
+        porcentaje_inversion: Number(editingCredit.porcentaje_participacion_inversionista),
         reasignaciones: Array.from(distribucion.entries()).map(([destId, monto]) => ({
           credito_destino_id: destId,
           monto,
         })),
-      };
+      },
+      {
+        onSuccess: () => {
+          toast.success("Reasignación guardada correctamente.");
+          setEditingCreditId(null);
+          setSelectedDestinoIds(new Set());
+        },
+        onError: (err) => {
+          toast.error(err?.message || "Error al guardar la reasignación");
+        },
+      }
+    );
+  }, [editingCreditId, isBalanced, editingCredit, distribucion, investor, reemplazar]);
 
-      // TODO: reemplazar con el POST real cuando el endpoint exista
-      console.log("POST /reasignar-credito-espejo", payload);
-      toast.info("Reasignación guardada (endpoint pendiente).");
-      setEditingCreditId(null);
-      setSelectedDestinoIds(new Set());
-      onRefetch();
-    } catch (err: any) {
-      toast.error(err?.message || "Error al guardar");
-    } finally {
-      setIsSaving(false);
-    }
-  }, [editingCreditId, isBalanced, distribucion, investor, onRefetch]);
-
-  const handleConfirm = useCallback(async () => {
-    setIsConfirming(true);
-    try {
-      const payload = {
+  const handleConfirm = useCallback(() => {
+    completarEspejo.mutate(
+      {
+        creditos: investor.creditosPendientes.map((c) => c.credito_id),
         inversionista_id: investor.inversionista_id,
-        creditos_ids: investor.creditosPendientes.map((c) => c.id),
-      };
-
-      // TODO: reemplazar con el POST real cuando el endpoint exista
-      console.log("POST /confirmar-sesion-inversionista", payload);
-      toast.info("Sesión confirmada (endpoint pendiente).");
-      onRefetch();
-    } catch (err: any) {
-      toast.error(err?.message || "Error al confirmar");
-    } finally {
-      setIsConfirming(false);
-    }
-  }, [investor, onRefetch]);
+      },
+      {
+        onSuccess: () => {
+          toast.success("Sesión confirmada correctamente.");
+        },
+        onError: (err) => {
+          toast.error(err?.message || "Error al confirmar la sesión");
+        },
+      }
+    );
+  }, [completarEspejo, investor]);
 
   return (
     <div className="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden">
@@ -387,7 +384,8 @@ function InvestorCard({
                   <div className="flex items-center gap-3 px-3 py-2.5">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-1.5 flex-wrap">
-                        <span className="text-xs font-bold text-gray-900">#{credito.credito_id}</span>
+                        <span className="text-xs font-bold text-gray-900">{credito.numero_credito_sifco}</span>
+                        <span className="text-[11px] text-gray-500">{credito.nombre_usuario}</span>
                         <Badge variant="outline" className={`text-[9px] py-0 ${statusColor(credito.status)}`}>
                           {statusLabel(credito.status)}
                         </Badge>
@@ -418,10 +416,9 @@ function InvestorCard({
                       <button
                         type="button"
                         onClick={() => handleStartEdit(credito.id)}
-                        className="text-gray-300 hover:text-red-400 transition-colors p-1 rounded hover:bg-red-50 shrink-0"
-                        title="Quitar crédito y reasignar"
+                        className="text-[11px] text-gray-400 hover:text-red-500 transition-colors flex items-center gap-1 px-1.5 py-1 rounded hover:bg-red-50 shrink-0"
                       >
-                        <X className="w-3.5 h-3.5" />
+                        <X className="w-3 h-3" />Quitar
                       </button>
                     ) : null}
                   </div>
@@ -492,12 +489,12 @@ function InvestorCard({
                           <Button
                             size="sm"
                             onClick={handleSave}
-                            disabled={isSaving || !isBalanced}
+                            disabled={reemplazar.isPending || !isBalanced}
                             className={`gap-1 text-[11px] h-7 text-white ${
                               isBalanced ? "bg-blue-600 hover:bg-blue-700" : "bg-gray-400 cursor-not-allowed"
                             }`}
                           >
-                            {isSaving
+                            {reemplazar.isPending
                               ? <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
                               : <Check className="w-3 h-3" aria-hidden="true" />
                             }
@@ -512,45 +509,7 @@ function InvestorCard({
             })}
           </div>
 
-          {/* Créditos disponibles (colapsado) */}
-          {investor.otrosCreditos.length > 0 && (
-            <div>
-              <button
-                type="button"
-                className="flex items-center gap-1.5 text-[11px] font-semibold text-gray-400 uppercase tracking-wide hover:text-gray-600 transition-colors"
-                onClick={() => setShowCreditos((p) => !p)}
-              >
-                {showCreditos
-                  ? <ChevronDown className="w-3 h-3" aria-hidden="true" />
-                  : <ChevronRight className="w-3 h-3" aria-hidden="true" />
-                }
-                Créditos Disponibles ({investor.otrosCreditos.length})
-              </button>
-              {showCreditos && (
-                <div className="space-y-1.5 mt-2">
-                  {investor.otrosCreditos.map((oc) => (
-                    <div key={oc.credito_id} className="flex items-center justify-between bg-gray-50 rounded-md px-3 py-2 border border-gray-100 text-xs">
-                      <div className="min-w-0">
-                        <span className="font-medium text-gray-800">{oc.numero_credito_sifco || `#${oc.credito_id}`}</span>
-                        <span className="text-gray-400 ml-2">
-                          {oc.tipoCredito && <span className="capitalize">{oc.tipoCredito.toLowerCase()}</span>}
-                          {oc.capital && Number(oc.capital) > 0 && <span> · Capital: {formatQ(oc.capital, investor.moneda)}</span>}
-                        </span>
-                        {oc.statusCredit && (
-                          <Badge variant="outline" className="text-[9px] py-0 ml-2 border-green-200 text-green-700 bg-green-50">
-                            {oc.statusCredit}
-                          </Badge>
-                        )}
-                      </div>
-                      <span className="font-bold text-blue-700 tabular-nums shrink-0 ml-3">
-                        {formatQ(oc.monto_aportado_cash_in, investor.moneda)}
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
+
 
           {/* Confirmar sesión - solo visible cuando NO hay reasignación activa */}
           {!isEditing && (
@@ -558,10 +517,10 @@ function InvestorCard({
               <Button
                 size="sm"
                 onClick={handleConfirm}
-                disabled={isConfirming}
+                disabled={completarEspejo.isPending}
                 className="gap-1 text-[11px] h-7 bg-blue-600 text-white hover:bg-blue-700"
               >
-                {isConfirming
+                {completarEspejo.isPending
                   ? <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
                   : <Check className="w-3 h-3" aria-hidden="true" />
                 }

--- a/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
@@ -1,9 +1,19 @@
-import { useQuery } from "@tanstack/react-query";
-import { getCreditosEspejoPendientesService } from "../services/services";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getCreditosEspejoPendientesService,
+  completarEspejoService,
+  reemplazarInversionistaCreditoService,
+  getCreditCandidatesService,
+  type CompletarEspejoPayload,
+  type CompletarEspejoResponse,
+  type ReemplazarInversionistaCreditoPayload,
+  type ReemplazarInversionistaCreditoResponse,
+} from "../services/services";
 
 export const sesionesPendientesKeys = {
   all: ["sesiones-pendientes"] as const,
   list: () => [...sesionesPendientesKeys.all, "list"] as const,
+  candidates: () => [...sesionesPendientesKeys.all, "candidates"] as const,
 };
 
 export function useSesionesPendientes() {
@@ -16,5 +26,42 @@ export function useSesionesPendientes() {
     refetchOnReconnect: true,
     retry: 2,
     retryDelay: (attemptIndex) => Math.min(1000 * 2 ** attemptIndex, 30000),
+  });
+}
+
+export function useCreditCandidates() {
+  return useQuery({
+    queryKey: sesionesPendientesKeys.candidates(),
+    queryFn: () => getCreditCandidatesService(10),
+    staleTime: 0, // siempre fresco
+    gcTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+    retry: 2,
+  });
+}
+
+export function useCompletarEspejo() {
+  const queryClient = useQueryClient();
+
+  return useMutation<CompletarEspejoResponse, Error, CompletarEspejoPayload>({
+    mutationFn: (payload) => completarEspejoService(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: sesionesPendientesKeys.all });
+    },
+  });
+}
+
+export function useReemplazarInversionistaCredito() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    ReemplazarInversionistaCreditoResponse,
+    Error,
+    ReemplazarInversionistaCreditoPayload
+  >({
+    mutationFn: (payload) => reemplazarInversionistaCreditoService(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: sesionesPendientesKeys.all });
+    },
   });
 }

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3386,24 +3386,33 @@ export interface CreditoEspejoPendiente {
   fecha_inicio_participacion: string;
   status: "pendiente_reinversion" | "pendiente_compra_cartera";
   tipo_reinversion: string | null;
+  numero_credito_sifco: string;
+  nombre_usuario: string;
+}
+
+export interface CreditCandidateInversionista {
+  inversionista_id: number;
+  nombre: string;
+  monto_aportado: number;
+  es_cube: boolean;
 }
 
 export interface OtroCreditoDisponible {
   credito_id: number;
-  usuario_id: number;
   numero_credito_sifco: string;
-  capital: string;
-  porcentaje_interes: string;
-  deudatotal: string;
-  cuota_interes: string;
-  cuota: string;
-  iva_12: string;
-  plazo: number;
-  statusCredit: string;
+  capital: number;
+  capital_activo: number;
   formato_credito: string;
-  tipoCredito: string;
-  fecha_creacion: string;
-  monto_aportado_cash_in: string;
+  cuotas_pagadas: number;
+  total_cuotas: number;
+  inversionistas: CreditCandidateInversionista[];
+  score: number;
+  credito_completo?: {
+    credito: any;
+    usuario: { nombre: string; [key: string]: any } | null;
+    espejo: any[];
+    inversionistas_detalle: any[];
+  };
 }
 
 export interface InversionistaSesionPendiente {
@@ -3415,12 +3424,72 @@ export interface InversionistaSesionPendiente {
   monto_reinversion: string | null;
   saldo_reinversion: string;
   creditosPendientes: CreditoEspejoPendiente[];
-  otrosCreditos: OtroCreditoDisponible[];
 }
 
 export async function getCreditosEspejoPendientesService(): Promise<InversionistaSesionPendiente[]> {
   const res = await api.get<InversionistaSesionPendiente[]>(
     `${API_URL}/creditos-espejo-pendientes`
+  );
+  return res.data;
+}
+
+export interface CompletarEspejoPayload {
+  creditos: number[];
+  inversionista_id: number;
+}
+
+export interface CompletarEspejoResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface CandidatesResponse {
+  ok: boolean;
+  total: number;
+  candidates: OtroCreditoDisponible[];
+}
+
+export async function getCreditCandidatesService(minimo = 10): Promise<OtroCreditoDisponible[]> {
+  const res = await api.get<CandidatesResponse>(
+    `${API_URL}/assign-capital/candidates`,
+    { params: { minimo } }
+  );
+  return res.data.candidates;
+}
+
+export interface ReemplazarInversionistaCreditoPayload {
+  inversionista_id: number;
+  credito_espejo_removido_id: number;
+  tipo_operacion?: "reinversion" | "compra_cartera";
+  porcentaje_cash_in?: number;
+  porcentaje_inversion?: number;
+  reasignaciones: {
+    credito_destino_id: number;
+    monto: number;
+  }[];
+}
+
+export interface ReemplazarInversionistaCreditoResponse {
+  success: boolean;
+  message: string;
+}
+
+export async function reemplazarInversionistaCreditoService(
+  payload: ReemplazarInversionistaCreditoPayload
+): Promise<ReemplazarInversionistaCreditoResponse> {
+  const res = await api.post<ReemplazarInversionistaCreditoResponse>(
+    `${API_URL}/reemplazar-inversionista-credito`,
+    payload
+  );
+  return res.data;
+}
+
+export async function completarEspejoService(
+  payload: CompletarEspejoPayload
+): Promise<CompletarEspejoResponse> {
+  const res = await api.post<CompletarEspejoResponse>(
+    `${API_URL}/completar-espejo`,
+    payload
   );
   return res.data;
 }


### PR DESCRIPTION
## Summary
- Integrate `POST /reemplazar-inversionista-credito` for credit reassignment with `tipo_operacion`, `porcentaje_cash_in`, `porcentaje_inversion` from the removed credit
- Integrate `POST /completar-espejo` for confirming investor sessions (marks pending credits as completed)
- Load credit candidates separately via `GET /assign-capital/candidates?minimo=10`, auto-refetch after each reassignment
- Remove `otrosCreditos` from `/creditos-espejo-pendientes` to avoid duplicate `getCreditCandidates` calls
- Show `numero_credito_sifco` + `nombre_usuario` on pending credit cards and reassignment options
- Hide "Confirmar Sesión" button during active reassignment
- Fix white pagination buttons in ModalReinversionCombinada

## Test plan
- [ ] Open Sesiones Pendientes, verify pending credits show SIFCO number and user name
- [ ] Click "Quitar" on a credit, verify candidate credits load with names and amounts
- [ ] Select multiple candidates to cover the removed amount, verify "Guardar Reasignación" enables when balanced
- [ ] Save reassignment, verify list refreshes and candidates update
- [ ] Verify "Confirmar Sesión" is hidden during reassignment and visible otherwise
- [ ] Click "Confirmar Sesión", verify it calls the endpoint and refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)