### PR TITLE
feat: implement automatic reinvestment and portfolio purchase functionality

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -39,6 +39,7 @@ import {
   type EstadoLiquidacionResumenFilter,
 } from "../utils/investorLiquidationSummary";
 import { getCreditCandidates, CUBE_ID } from "./assignCapital";
+import { addInvestorToCredit } from "./addInvestorToCredit";
 
 // ============================================
 // 🆕 TIPOS Y CONFIGURACIÓN PARA CONSULTAS ORIGINALES/ESPEJO
@@ -2672,7 +2673,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
       // FASE 2: TRANSACCION (datos financieros)
       // Si algo falla, se hace rollback de TODO
       // ========================================
-      const { liquidacion, updateResult } = await db.transaction(async (tx) => {
+      const { liquidacion, updateResult, debeReinvertir, montoReinvertido } = await db.transaction(async (tx) => {
 
         // Crear registro de liquidación
         const [liquidacion] = await tx
@@ -2706,6 +2707,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
 
         // Reinversiones
         const montoReinvertido = new Big(reinvTotal);
+        let debeReinvertir = false;
         if (montoReinvertido.gt(0)) {
           await tx.update(inversionistas)
             .set({
@@ -2717,6 +2719,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
             .set({ monto_capital: "0", monto_interes: "0", monto_total: "0" })
             .where(eq(reinversiones.inversionista_id, inv_id));
 
+          debeReinvertir = true;
           console.log(`  ✅ Saldo reinversión actualizado (+${montoReinvertido.toFixed(2)})`);
         }
 
@@ -2799,7 +2802,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
           }
         }
 
-        return { liquidacion, updateResult };
+        return { liquidacion, updateResult, debeReinvertir, montoReinvertido };
       });
 
       // ========================================
@@ -2884,6 +2887,57 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
             boleta_id: boletaPendiente?.boleta_id ?? 0,
             boleta_url: boletaPendiente?.boleta_url ?? "",
           });
+        }
+
+        // ========================================
+        // FASE 4: REINVERSIÓN AUTOMÁTICA (post-reporte)
+        // Si hubo monto de reinversión, se llama addInvestorToCredit
+        // para distribuir el saldo en créditos candidatos.
+        // ========================================
+        if (debeReinvertir) {
+          try {
+            console.log(`  🔄 Ejecutando reinversión automática por Q${montoReinvertido.toFixed(2)}...`);
+
+            // Calcular mediana de porcentajes desde los créditos actuales del inversionista
+            const creditosInv = await db
+              .select({
+                porcentaje_participacion_inversionista: creditos_inversionistas.porcentaje_participacion_inversionista,
+                porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
+              })
+              .from(creditos_inversionistas)
+              .where(eq(creditos_inversionistas.inversionista_id, inv_id));
+
+            const moda = (arr: number[]) => {
+              if (arr.length === 0) return 0;
+              const freq = new Map<number, number>();
+              for (const v of arr) freq.set(v, (freq.get(v) ?? 0) + 1);
+              let maxFreq = 0, result = arr[0];
+              for (const [val, count] of freq) {
+                if (count > maxFreq) { maxFreq = count; result = val; }
+              }
+              return result;
+            };
+
+            const modaInversion = moda(creditosInv.map((c) => Number(c.porcentaje_participacion_inversionista)));
+            const modaCashIn = moda(creditosInv.map((c) => Number(c.porcentaje_cash_in)));
+
+            console.log(`  📊 Moda porcentaje inversión: ${modaInversion}%, cash in: ${modaCashIn}%`);
+
+            const reinversionResult = await addInvestorToCredit({
+              body: {
+                inversionista_id: inv_id,
+                monto_aportado: montoReinvertido.toNumber(),
+                porcentaje_inversion: modaInversion,
+                porcentaje_cash_in: modaCashIn,
+                tipo_operacion: "reinversion",
+              },
+              set: { status: 200 },
+            });
+
+            console.log(`  ✅ Reinversión automática completada:`, reinversionResult);
+          } catch (reinvError) {
+            console.error(`  ❌ Error en reinversión automática (liquidación ya guardada):`, reinvError);
+          }
         }
       } catch (excelError) {
         console.error(`  ❌ Error generando Excel (datos financieros ya guardados):`, excelError);

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -17,6 +17,7 @@ import {
   Trash2,
   Upload,
   FileText,
+  ShoppingCart,
 } from "lucide-react";
 import {
   useGetInvestors,
@@ -59,6 +60,7 @@ import { ConfirmationModal } from "@/components/ui/confirmation-modal";
 import { CrearBoletaInversionista } from "./investorPayment";
 import { InvestorDocumentsModal } from "./investorDocuments";
 import { toast } from "sonner";
+import { useAgregarInversionistaCredito } from "../hooks/useAgregarInversionistaCredito";
 
 const PER_PAGE_OPTIONS = [5, 10, 20, 50, 100, 200, 500];
 
@@ -259,6 +261,13 @@ export function TableInvestors() {
   const [selectedInvestorData, setSelectedInvestorData] = useState<
     InvestorPayload | undefined
   >();
+  // Compra de cartera
+  const [compraCarteraOpen, setCompraCarteraOpen] = useState(false);
+  const [compraCarteraInvId, setCompraCarteraInvId] = useState<number | null>(null);
+  const [compraCarteraMonto, setCompraCarteraMonto] = useState("");
+  const [compraCarteraFecha, setCompraCarteraFecha] = useState("");
+  const agregarInvCredito = useAgregarInversionistaCredito();
+
   const [incluirLiquidados, setIncluirLiquidados] = useState(false);
   const [numeroCuota, setNumeroCuota] = useState<number | undefined>(undefined);
   // Consulta con paginación y filtro por id
@@ -1146,6 +1155,21 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 >
                   <Edit className="mr-2.5 h-4 w-4 text-amber-500" />
                   <span className="text-sm font-medium text-gray-700">Editar</span>
+                </DropdownMenuItem>
+
+                {/* Compra de Cartera */}
+                <DropdownMenuItem
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setCompraCarteraInvId(inv.inversionista_id);
+                    setCompraCarteraMonto("");
+                    setCompraCarteraFecha(new Date().toISOString().split("T")[0]);
+                    setCompraCarteraOpen(true);
+                  }}
+                  className="cursor-pointer rounded-lg px-3 py-2.5 focus:bg-emerald-50"
+                >
+                  <ShoppingCart className="mr-2.5 h-4 w-4 text-emerald-500" />
+                  <span className="text-sm font-medium text-gray-700">Compra de Cartera</span>
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
@@ -2286,6 +2310,97 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
         cancelText={null}
         variant="success"
       />
+
+      {/* Modal Compra de Cartera */}
+      <Dialog
+        open={compraCarteraOpen}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCompraCarteraOpen(false);
+            setCompraCarteraInvId(null);
+          }
+        }}
+      >
+        <DialogContent className="bg-white dark:bg-gray-900 sm:max-w-md z-[60]">
+          <DialogHeader>
+            <DialogTitle className="text-lg font-bold">Compra de Cartera</DialogTitle>
+            <DialogDescription>
+              Ingresa el monto y la fecha de inicio de participación
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div>
+              <label htmlFor="compra-monto" className="text-sm font-medium text-gray-700">
+                Monto aportado
+              </label>
+              <Input
+                id="compra-monto"
+                type="number"
+                min={0.01}
+                step="0.01"
+                placeholder="0.00"
+                value={compraCarteraMonto}
+                onChange={(e) => setCompraCarteraMonto(e.target.value)}
+                className="mt-1"
+              />
+            </div>
+            <div>
+              <label htmlFor="compra-fecha" className="text-sm font-medium text-gray-700">
+                Fecha inicio participación
+              </label>
+              <Input
+                id="compra-fecha"
+                type="date"
+                value={compraCarteraFecha}
+                onChange={(e) => setCompraCarteraFecha(e.target.value)}
+                className="mt-1"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <button
+              type="button"
+              onClick={() => {
+                setCompraCarteraOpen(false);
+                setCompraCarteraInvId(null);
+              }}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              disabled={agregarInvCredito.isPending || !compraCarteraMonto || Number(compraCarteraMonto) <= 0}
+              onClick={() => {
+                if (!compraCarteraInvId || !compraCarteraMonto) return;
+                agregarInvCredito.mutate(
+                  {
+                    inversionista_id: compraCarteraInvId,
+                    monto_aportado: Number(compraCarteraMonto),
+                    tipo_operacion: "compra_cartera",
+                    fecha_inicio_participacion: compraCarteraFecha || undefined,
+                  },
+                  {
+                    onSuccess: () => {
+                      toast.success("Compra de cartera registrada correctamente");
+                      setCompraCarteraOpen(false);
+                      setCompraCarteraInvId(null);
+                      refetch();
+                      refetchTotales();
+                    },
+                    onError: (err) => {
+                      toast.error(err?.message || "Error al registrar compra de cartera");
+                    },
+                  }
+                );
+              }}
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+            >
+              {agregarInvCredito.isPending ? "Guardando…" : "Confirmar"}
+            </button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       </div>
     </div>

--- a/apps/carteraFront/src/private/cartera/hooks/useAgregarInversionistaCredito.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useAgregarInversionistaCredito.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  agregarInversionistaCreditoService,
+  type AgregarInversionistaCreditoPayload,
+  type AgregarInversionistaCreditoResponse,
+} from "../services/services";
+import { investorsQueryKeys } from "./getInvestor";
+
+export function useAgregarInversionistaCredito() {
+  const queryClient = useQueryClient();
+
+  return useMutation<
+    AgregarInversionistaCreditoResponse,
+    Error,
+    AgregarInversionistaCreditoPayload
+  >({
+    mutationFn: (payload) => agregarInversionistaCreditoService(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: investorsQueryKeys.all });
+    },
+  });
+}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3433,6 +3433,33 @@ export async function getCreditosEspejoPendientesService(): Promise<Inversionist
   return res.data;
 }
 
+// ============================================================
+// Agregar inversionista a crédito (compra cartera / reinversión)
+// ============================================================
+export interface AgregarInversionistaCreditoPayload {
+  inversionista_id: number;
+  monto_aportado: number;
+  tipo_operacion: "reinversion" | "compra_cartera";
+  fecha_inicio_participacion?: string;
+  porcentaje_cash_in?: number;
+  porcentaje_inversion?: number;
+}
+
+export interface AgregarInversionistaCreditoResponse {
+  success: boolean;
+  message: string;
+}
+
+export async function agregarInversionistaCreditoService(
+  payload: AgregarInversionistaCreditoPayload
+): Promise<AgregarInversionistaCreditoResponse> {
+  const res = await api.post<AgregarInversionistaCreditoResponse>(
+    `${API_URL}/agregar-inversionista-credito`,
+    payload
+  );
+  return res.data;
+}
+
 export interface CompletarEspejoPayload {
   creditos: number[];
   inversionista_id: number;


### PR DESCRIPTION
- Automatically trigger reinvestment during the liquidation process using the statistical mode of an investor's current participation percentages to distribute funds.
- Add a "Compra de Cartera" action and modal to the investor management table to allow manual credit participation entry.
- Integrate the new `/agregar-inversionista-credito` endpoint with a dedicated service and React Query hook.
