### PR TITLE
feat: include 4 or more overdue installments in credit stats

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -2779,7 +2779,9 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
       .where(
         and(
           ...baseConditionsActive,
-          sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) = ${cuotasNum}`
+          cuotasNum === 4
+            ? sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) >= 4`
+            : sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) = ${cuotasNum}`
         )
       );
 


### PR DESCRIPTION
Updates the credit statistics query to treat the 4-installment filter as an open-ended "4 or more" category, ensuring the highest delinquency bracket captures all relevant credits.
