### PR TITLE
refactor: replace manual Excel state management with dedicated downlo…

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -52,6 +52,7 @@ import { ModalCaidoCredit } from "./ModalCaidoCredit";
 
 export function ListaCreditosPagos() {
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
+  const [isDownloadingExcel, setIsDownloadingExcel] = useState(false);
   const { user } = useAuth();
   const isAdmin = user?.role === "ADMIN";
   const userAsesorId = user?.asesor_id;
@@ -80,7 +81,7 @@ export function ListaCreditosPagos() {
     setEstado,
     estado,
     estados,
-    handleExcel,
+    downloadExcel,
     asesorId,
     handleAsesorId,
     setAsesorId,
@@ -240,6 +241,7 @@ export function ListaCreditosPagos() {
     investors: Investor[];
     advisors: any[];
     loading: boolean;
+    refetch: () => void;
   };
 
   const [openMoraModal, setOpenMoraModal] = useState(false);
@@ -580,13 +582,14 @@ export function ListaCreditosPagos() {
           </label>
           <button
             type="button"
+            disabled={isDownloadingExcel}
             onClick={async () => {
               try {
-                handleExcel(true);
-                const response = await refetch();
+                setIsDownloadingExcel(true);
+                const response = await downloadExcel();
 
-                if (response.data && "excelUrl" in response.data) {
-                  const url = (response.data as any).excelUrl;
+                if (response && "excelUrl" in response) {
+                  const url = (response as any).excelUrl;
                   window.open(url, "_blank");
                   toast.success("Excel generado correctamente");
                 } else {
@@ -596,13 +599,13 @@ export function ListaCreditosPagos() {
                 console.error("❌ Error generando Excel:", err);
                 toast.error("Error al generar el Excel");
               } finally {
-                handleExcel(false);
+                setIsDownloadingExcel(false);
               }
             }}
-            className="px-4 py-2 rounded-lg bg-green-600 text-white font-semibold hover:bg-green-700 transition shadow-md flex items-center gap-2"
+            className="px-4 py-2 rounded-lg bg-green-600 text-white font-semibold hover:bg-green-700 transition shadow-md flex items-center gap-2 disabled:opacity-70 disabled:cursor-not-allowed"
           >
-            <FileSpreadsheet className="w-5 h-5" />
-            Descargar Excel
+            {isDownloadingExcel ? <Loader2 className="w-5 h-5 animate-spin" /> : <FileSpreadsheet className="w-5 h-5" />}
+            {isDownloadingExcel ? "Generando..." : "Descargar Excel"}
           </button>
         </div>
       </div>
@@ -813,7 +816,7 @@ export function ListaCreditosPagos() {
           }}
           numeroCreditoSifco={selectedCreditFechaInicio.sifco}
           fechaActual={selectedCreditFechaInicio.fechaActual}
-          changedBy={user?.email ?? user?.name ?? "admin"}
+          changedBy={user?.email ?? "admin"}
           onSuccess={() => {
             setTimeout(() => {
               queryClient.invalidateQueries({

--- a/apps/carteraFront/src/private/cartera/hooks/credits.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/credits.ts
@@ -31,8 +31,6 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
   const [estado, setEstado] = useState<
     "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO"
   >("ACTIVO");
-  const [excel, setExcel] = useState(false);
-
   // 🆕 Nuevos states para filtros con valor inicial
   const [asesorId, setAsesorId] = useState<number | undefined>(options?.initialAsesorId);
   
@@ -57,7 +55,6 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
       perPage,
       creditoSifco,
       estado,
-      excel,
       asesorId,
       nombreUsuario, // 👈 Este es el que realmente busca
       isVehiculoPropio,
@@ -71,7 +68,7 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
         perPage,
         numero_credito_sifco: creditoSifco.trim() !== "" ? creditoSifco : undefined,
         estado,
-        excel,
+        excel: false,
         asesor_id: asesorId,
         nombre_usuario: nombreUsuario.trim() !== "" ? nombreUsuario : undefined,
         is_vehiculo_propio: isVehiculoPropio,
@@ -86,13 +83,26 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
     setPage(1);
   };
 
-  const handleExcel = (valor: boolean) => {
-    setExcel(valor);
-  };
-
   const clearSifco = () => {
     setCreditoSifco("");
     setPage(1);
+  };
+
+  // 🔥 Nueva función para descargar Excel
+  const downloadExcel = async () => {
+    return getCreditosPaginados({
+      mes,
+      anio,
+      page,
+      perPage,
+      numero_credito_sifco: creditoSifco.trim() !== "" ? creditoSifco : undefined,
+      estado,
+      excel: true,
+      asesor_id: asesorId,
+      nombre_usuario: nombreUsuario.trim() !== "" ? nombreUsuario : undefined,
+      is_vehiculo_propio: isVehiculoPropio,
+      inversionista_ids: inversionistaIds.length > 0 ? inversionistaIds.join(",") : undefined,
+    });
   };
 
   // 🆕 Handler para asesor
@@ -171,8 +181,7 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
     setEstado,
     estado,
     estados,
-    excel,
-    handleExcel,
+    downloadExcel,
     // 🆕 Exports para asesor
     asesorId,
     setAsesorId,


### PR DESCRIPTION
# Resumen (Summary)
Se corrigió un bug que obligaba al usuario a realizar doble clic en el botón de **Descargar Excel** de la tabla de Cartera para que el documento fuera generado exitosamente. 

Adicionalmente, se aplicaron correcciones de tipado de TypeScript relacionadas con la desestructuración del catálogo y el acceso a las propiedades del usuario logueado.

# Detalles de la implementación (Implementation Details)
- **Corrección de carrera asíncrona:** Se extrajo el desencadenador del proceso de Excel (`excel` status) de las dependencias de estado reactivas del hook `useCreditosPaginadosWithFilters`. Esto previene que TanStack Query dispare peticiones usando variables cacheadas erróneas (race conditions en los renderizados).
- **Nueva función asíncrona `downloadExcel`:** Se implementó una función pura que se puede ejecutar en el evento `onClick` recopilando el snapshot actual de los filtros de estado para obtener la URL de descarga (R2 url).
- **Indicador de Carga Mejorado:** Se agregó un estado booleano `isDownloadingExcel` a nivel componente que desactiva el botón y muestra "Generando..." mientras se espera la respuesta del API, logrando prever envíos redundantes.
- **Correcciones de TypeScript menores:** 
   - Se añadió `refetch: () => void;` al Type Cast del resultado de `useCatalogs()`.
   - Se reemplazó el acceso a `user?.name` nulo por `user?.email ?? "admin"` en las propiedades de control de la tabla, de acuerdo con la interfaz real de `User` en el contexto global de autorización local.

# ¿Cómo probarlo? (How to test)
1. Iniciar sesión y navegar al módulo de Cartera con varios créditos/registros.
2. Hacer clic en "Descargar Excel".
3. Verificar que el botón cambie a modo "Generando..." y se bloquee.
4. Esperar de 1 a 2 segundos a que culmine la petición y que el navegador accione un redirect (en una nueva tab) con el documento Excel listo.
5. Comprobar que en la consola/terminal no aparecen las alertas rojas generadas localmente por el uso indebido de las promesas del lado del cliente.
6. Verificar que la vista corra sin errores (`tsc --noEmit`).

# Fixes
- Cierra # [Colocar Número del Tíquet si aplica]
