### PR TITLE
feat: add Excel report for unliquidated investor payments

### DIFF
--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -426,6 +426,77 @@ export const inversionistasRouter = new Elysia()
       };
     }
   })
+  .get(
+    "/investor/reporte-no-liquidados",
+    async ({ query, set }) => {
+      const { id } = query;
+
+      if (!id || isNaN(Number(id))) {
+        set.status = 400;
+        return { message: "El parámetro 'id' es obligatorio y debe ser numérico." };
+      }
+
+      try {
+        const result = await resumeInvestor(
+          Number(id),
+          1,
+          999999,
+          undefined,
+          undefined,
+          undefined,
+          false,
+          undefined,
+          "espejos"
+        );
+
+        if (!result.inversionistas.length) {
+          set.status = 404;
+          return { message: "Inversionista no encontrado." };
+        }
+
+        const inversionista = result.inversionistas[0];
+
+        const totales = await getInvestorTotalsGlobales(
+          Number(id),
+          undefined,
+          "espejos",
+          false
+        );
+        inversionista.subtotal = totales.totales as any;
+
+        const logoUrl = import.meta.env.LOGO_URL || "";
+        const filename = `reporte_no_liquidados_${id}_${Date.now()}.xlsx`;
+        const { url } = await generarYSubirExcelInversionista(
+          inversionista as any,
+          filename,
+          logoUrl
+        );
+
+        return {
+          success: true,
+          url,
+          filename,
+        };
+      } catch (error) {
+        console.error("[GET /investor/reporte-no-liquidados] Error:", error);
+        set.status = 500;
+        return {
+          message: "Error al obtener reporte de pagos no liquidados",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    {
+      query: t.Object({
+        id: t.String(),
+      }),
+      detail: {
+        summary: "Genera Excel con pagos no liquidados de un inversionista",
+        description: "Genera y sube un Excel con el resumen de pagos espejo no liquidados del inversionista, y devuelve la URL del archivo.",
+        tags: ["Inversionistas"],
+      },
+    }
+  )
   .post("/investor/reporte-liquidados-masivo", async ({ body, set }) => {
     const { fecha_liquidacion } = body as { fecha_liquidacion?: string };
 

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -36,6 +36,7 @@ import {
 } from "../services/services";
 import { useLiquidateByInvestor } from "../hooks/liquidateAllInvestor";
 import { useDownloadInvestorPDF } from "../hooks/downloadInvestorReport";
+import { useDownloadReporteNoLiquidados } from "../hooks/downloadReporteNoLiquidados";
 import { InvestorModal } from "./modalInvestor";
 import { useFalsePayments } from "../hooks/falsePayments";
 import {
@@ -329,6 +330,7 @@ export function TableInvestors() {
   const liquidateMutation = useLiquidateByInvestor();
   const reinversionEnCero = Number(subtotales.total_cuota_con_reinversion) === 0;
   const downloadPDF = useDownloadInvestorPDF();
+  const downloadNoLiquidados = useDownloadReporteNoLiquidados();
   const [query, setQuery] = useState("");
 
   const filteredInvestors =
@@ -934,6 +936,19 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                         <RefreshCw className="w-4 h-4" />
                     )}
                     Recalcular
+                    </button>
+
+                    <button
+                        onClick={() => downloadNoLiquidados.mutate(inv.inversionista_id)}
+                        disabled={downloadNoLiquidados.isPending}
+                        className="flex-1 sm:flex-none bg-emerald-600 text-white px-4 py-2 rounded-lg font-bold shadow-md hover:bg-emerald-700 hover:shadow-lg transition-all active:scale-95 flex items-center justify-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                        {downloadNoLiquidados.isPending ? (
+                            <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                            <FileSpreadsheet className="w-4 h-4" />
+                        )}
+                        No Liquidados
                     </button>
 
                     <button

--- a/apps/carteraFront/src/private/cartera/hooks/downloadReporteNoLiquidados.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/downloadReporteNoLiquidados.ts
@@ -1,0 +1,20 @@
+import { useMutation } from "@tanstack/react-query";
+import { getReporteNoLiquidados } from "../services/services";
+
+export function useDownloadReporteNoLiquidados() {
+  return useMutation({
+    mutationFn: async (investorId: number) => {
+      return await getReporteNoLiquidados(investorId);
+    },
+    onSuccess: (data) => {
+      if (data?.url) {
+        window.open(data.url, "_blank");
+      } else {
+        alert("No se recibió la URL del reporte.");
+      }
+    },
+    onError: () => {
+      alert("Error al generar el reporte. Intenta de nuevo o contacta soporte.");
+    },
+  });
+}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1158,6 +1158,19 @@ export async function downloadInvestorPDFService(
   return data;
 }
 
+export async function getReporteNoLiquidados(investorId: number): Promise<{ success: boolean; url: string; filename: string }> {
+  const { data } = await api.get<{ success: boolean; url: string; filename: string }>(
+    `/investor/reporte-no-liquidados`,
+    { params: { id: investorId } }
+  );
+
+  if (!data?.url) {
+    throw new Error("La respuesta no contiene la URL del reporte.");
+  }
+
+  return data;
+}
+
 export async function uploadFileService(file: File | Blob): Promise<{ url: string; filename: string }> {
   const BACK_URL = import.meta.env.VITE_BACK_URL || ""; // tu variable de entorno
 


### PR DESCRIPTION
- Implement a new backend endpoint to generate and upload Excel reports for non-liquidated mirror payments.
- Add a "No Liquidados" button in the investor table to trigger the report generation and download.
