### PR TITLE
feat: allow searching credits by SIFCO number in investor table

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -1210,9 +1210,10 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
 
           {(() => {
             const query = (creditSearchQuery[inv.inversionista_id] || "").toLowerCase();
-            const filteredCreditos = (inv.creditos ?? []).filter(cred => 
+            const filteredCreditos = (inv.creditos ?? []).filter(cred =>
               cred.nombre_usuario?.toLowerCase().includes(query) ||
-              cred.nit_usuario?.toLowerCase().includes(query)
+              cred.nit_usuario?.toLowerCase().includes(query) ||
+              cred.numero_credito_sifco?.toString().toLowerCase().includes(query)
             );
 
             return filteredCreditos.length === 0 ? (
@@ -1790,9 +1791,10 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
 
           {(() => {
             const query = (creditSearchQuery[inv.inversionista_id] || "").toLowerCase();
-            const filteredCreditos = (inv.creditos ?? []).filter(cred => 
+            const filteredCreditos = (inv.creditos ?? []).filter(cred =>
               cred.nombre_usuario?.toLowerCase().includes(query) ||
-              cred.nit_usuario?.toLowerCase().includes(query)
+              cred.nit_usuario?.toLowerCase().includes(query) ||
+              cred.numero_credito_sifco?.toString().toLowerCase().includes(query)
             );
 
             return filteredCreditos.length === 0 ? (


### PR DESCRIPTION
Updates the filtering logic for credits within the investor table to include the SIFCO credit number as a search criterion, alongside the username and NIT.
