### PR TITLE
fix: correct reinversion combinada modal totals and cancel

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { createPortal } from "react-dom";
 import { Search, X, Save, Loader2 } from "lucide-react";
 import { useGetInvestors } from "../hooks/getInvestor";
@@ -21,7 +21,8 @@ const TIPOS_REINVERSION: { value: TipoReinversionEspejo; label: string; color: s
   { value: "reinversion_total", label: "Total", color: "bg-purple-100 text-purple-700" },
 ];
 
-const PER_PAGE = 25;
+const ALL_CREDITS_PER_PAGE = 500;
+const DISPLAY_PER_PAGE = 25;
 
 export function ModalReinversionCombinada({
   open,
@@ -35,24 +36,51 @@ export function ModalReinversionCombinada({
   // Map: credito_inversionista_espejo_id -> tipo_reinversion seleccionado (solo los que cambiaron)
   const [asignaciones, setAsignaciones] = useState<Record<number, TipoReinversionEspejo>>({});
 
-  const { data, isLoading } = useGetInvestors({
+  // Traer todos los créditos de una vez (500) para totales correctos
+  const { data, isLoading, refetch } = useGetInvestors({
     id: inversionistaId,
-    page,
-    perPage: PER_PAGE,
+    page: 1,
+    perPage: ALL_CREDITS_PER_PAGE,
     tipo: "espejos",
-    nombreUsuario: search || undefined,
   });
+
+  // Refrescar datos y resetear estados cada vez que se abre el modal
+  useEffect(() => {
+    if (open) {
+      setPage(1);
+      setSearch("");
+      setAsignaciones({});
+      refetch();
+    }
+  }, [open, refetch]);
 
   const { mutate: asignarReinversion, isPending: isSaving } = useAsignarReinversion();
 
   // Todos los créditos del inversionista actual
-  const creditos: CreditoInversionistaData[] = useMemo(() => {
+  const allCreditos: CreditoInversionistaData[] = useMemo(() => {
     if (!data?.inversionistas?.length) return [];
     const inv = data.inversionistas.find((i) => i.inversionista_id === inversionistaId);
     return inv?.creditos ?? [];
   }, [data, inversionistaId]);
 
-  // Resumen: contar por tipo y sumar montos
+  // Filtro visual por búsqueda (no afecta totales)
+  const creditosFiltrados = useMemo(() => {
+    if (!search.trim()) return allCreditos;
+    const term = search.toLowerCase();
+    return allCreditos.filter((c) =>
+      c.nombre_usuario?.toLowerCase().includes(term) ||
+      c.numero_credito_sifco?.toLowerCase().includes(term)
+    );
+  }, [allCreditos, search]);
+
+  // Paginación en el cliente sobre los filtrados
+  const totalPages = Math.max(1, Math.ceil(creditosFiltrados.length / DISPLAY_PER_PAGE));
+  const creditosPagina = useMemo(() => {
+    const start = (page - 1) * DISPLAY_PER_PAGE;
+    return creditosFiltrados.slice(start, start + DISPLAY_PER_PAGE);
+  }, [creditosFiltrados, page]);
+
+  // Resumen: contar por tipo y sumar montos — siempre sobre TODOS los créditos
   const resumen = useMemo(() => {
     const counts: Record<string, { cantidad: number; monto: number }> = {
       reinversion_capital: { cantidad: 0, monto: 0 },
@@ -61,7 +89,7 @@ export function ModalReinversionCombinada({
       sin_reinversion: { cantidad: 0, monto: 0 },
     };
 
-    creditos.forEach((cred) => {
+    allCreditos.forEach((cred) => {
       const espejoId = cred.credito_inversionista_espejo_id;
       const tipoOriginal = cred.tipo_reinversion ?? "sin_reinversion";
       const tipo = (espejoId && asignaciones[espejoId]) ? asignaciones[espejoId] : tipoOriginal;
@@ -72,7 +100,7 @@ export function ModalReinversionCombinada({
     });
 
     return counts;
-  }, [creditos, asignaciones]);
+  }, [allCreditos, asignaciones]);
 
   const handleTipoChange = (espejoId: number, tipo: TipoReinversionEspejo, tipoOriginal: string) => {
     setAsignaciones((prev) => {
@@ -114,8 +142,6 @@ export function ModalReinversionCombinada({
       }
     );
   };
-
-  const totalPages = data?.totalPages ?? 1;
 
   if (!open) return null;
 
@@ -177,13 +203,13 @@ export function ModalReinversionCombinada({
               <Loader2 className="w-6 h-6 animate-spin text-blue-500" />
               <span className="ml-2 text-gray-500">Cargando créditos...</span>
             </div>
-          ) : creditos.length === 0 ? (
+          ) : creditosPagina.length === 0 ? (
             <div className="text-center py-12 text-gray-400">
               No se encontraron créditos.
             </div>
           ) : (
             <div className="space-y-2">
-              {creditos.filter((c) => c.credito_inversionista_espejo_id).map((cred) => {
+              {creditosPagina.filter((c) => c.credito_inversionista_espejo_id).map((cred) => {
                 const espejoId = cred.credito_inversionista_espejo_id!;
                 const tipoOriginal = cred.tipo_reinversion ?? "sin_reinversion";
                 const tipoActual = asignaciones[espejoId] ?? tipoOriginal;

--- a/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
@@ -21,7 +21,9 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
   const { bancos, loading: loadingBancos, loadBancos } = useBancos();
   const queryClient = useQueryClient();
   const [showCombinada, setShowCombinada] = useState(false);
-  const [prevTipoReinversion, setPrevTipoReinversion] = useState<string>("sin_reinversion");
+  const [prevTipoReinversion, setPrevTipoReinversion] = useState<string>(
+    initialData?.tipo_reinversion ?? "sin_reinversion"
+  );
 
   const { register, handleSubmit, reset, watch, setValue } = useForm<InvestorPayload>({
     defaultValues: {
@@ -52,6 +54,7 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
     if (mode === "update" && initialData) {
       console.log("Reseteando con initialData:", initialData);
       reset(initialData);
+      setPrevTipoReinversion(initialData.tipo_reinversion ?? "sin_reinversion");
     } else if (mode === "create") {
       reset({
         nombre: "",


### PR DESCRIPTION
## Summary
- **Totales correctos**: Se traen todos los créditos (500) en una sola query y los totales se calculan sobre todos, no solo la página visible
- **Búsqueda visual**: El buscador filtra en el cliente sin re-consultar al servidor, manteniendo los totales estables
- **Cancelar restaura el tipo real**: Al cancelar el modal combinada, se restaura el tipo de reinversión que tenía el inversionista antes (no siempre "sin_reinversion")
- **Refetch al abrir**: Cada vez que se abre el modal se resetean estados y se piden datos frescos

## Test plan
- [ ] Abrir modal de reinversión combinada y verificar que los totales no cambian al paginar
- [ ] Buscar un cliente y verificar que los totales del resumen no cambian
- [ ] Cambiar tipo de reinversión en página 1, ir a página 2 y volver — el cambio debe persistir
- [ ] Seleccionar "Reinversión Combinada" en el select y luego cancelar — debe volver al tipo anterior, no a "Sin Reinversión"

🤖 Generated with [Claude Code](https://claude.com/claude-code)