### PR TITLE
feat: daily auto-assignment balancing for leads

### DIFF
--- a/apps/crm/apps/server/src/controllers/portal-lead.ts
+++ b/apps/crm/apps/server/src/controllers/portal-lead.ts
@@ -693,6 +693,7 @@ export async function createPortalRegisterLead(c: Context) {
 				notes,
 				source: "website",
 				status: "new",
+				assignmentType: "auto",
 				clientType: "individual",
 				dependents: 0,
 				ownsHome: false,

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, desc, eq, or } from "drizzle-orm";
+import { and, asc, count, desc, eq, gte, or } from "drizzle-orm";
 import type { Context } from "hono";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
@@ -88,7 +88,10 @@ export async function getSalesUserWithLeastLeads() {
 		return null;
 	}
 
-	// Contar leads por usuario (solo leads activos, no convertidos)
+	// Contar leads automáticos asignados hoy por usuario
+	const startOfToday = new Date();
+	startOfToday.setHours(0, 0, 0, 0);
+
 	const leadCounts = await db
 		.select({
 			assignedTo: leads.assignedTo,
@@ -96,10 +99,9 @@ export async function getSalesUserWithLeastLeads() {
 		})
 		.from(leads)
 		.where(
-			or(
-				eq(leads.status, "new"),
-				eq(leads.status, "contacted"),
-				eq(leads.status, "qualified"),
+			and(
+				eq(leads.assignmentType, "auto"),
+				gte(leads.createdAt, startOfToday),
 			),
 		)
 		.groupBy(leads.assignedTo);
@@ -383,6 +385,7 @@ export async function createPublicLead(c: Context) {
 				source: body.source || "website",
 				campaign: body.campaign,
 				status: "new",
+				assignmentType: "auto",
 				assignedTo: salesUserForLead.id,
 				createdBy: salesUserForLead.id,
 				updatedAt: new Date(),

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -57,6 +57,10 @@ export const creditTypeEnum = pgEnum("credit_type", [
 	"autocompra",
 	"sobre_vehiculo",
 ]);
+export const assignmentTypeEnum = pgEnum("assignment_type", [
+	"auto",
+	"manual",
+]);
 export const creditCategoryEnum = pgEnum("credit_category", [
 	"Contraseña",
 	"CV Vehículo",
@@ -180,6 +184,9 @@ export const leads = pgTable("leads", {
 	createdAt: timestamp("created_at").notNull().defaultNow(),
 	updatedAt: timestamp("updated_at").notNull().defaultNow(),
 	livenessValidated: boolean("liveness_validated").notNull().default(false),
+	assignmentType: assignmentTypeEnum("assignment_type")
+		.notNull()
+		.default("manual"),
 	createdBy: text("created_by")
 		.notNull()
 		.references(() => user.id),


### PR DESCRIPTION
## Summary
- Agrega enum `assignment_type` (`auto` / `manual`) a la tabla `leads`
- El balanceo round-robin ahora cuenta solo leads `auto` creados **hoy**, no todos los leads activos
- Leads creados manualmente desde el CRM no afectan la distribución automática

## Test plan
- [ ] Crear leads desde el endpoint público y verificar que se distribuyan equitativamente por día
- [ ] Crear leads manualmente desde el CRM y verificar que no afecten el conteo de balanceo
- [ ] Verificar que al día siguiente el conteo se reinicia

🤖 Generated with [Claude Code](https://claude.com/claude-code)