### PR TITLE
feat: daily auto-assignment balancing for leads

### DIFF
--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -88,9 +88,10 @@ export async function getSalesUserWithLeastLeads() {
 		return null;
 	}
 
-	// Contar leads automáticos asignados hoy por usuario
-	const startOfToday = new Date();
-	startOfToday.setHours(0, 0, 0, 0);
+	// Contar leads automáticos asignados hoy por usuario (hora Guatemala UTC-6)
+	const startOfToday = new Date(
+		new Date().toLocaleDateString("en-US", { timeZone: "America/Guatemala" }),
+	);
 
 	const leadCounts = await db
 		.select({


### PR DESCRIPTION
## Summary
- Agrega enum `assignment_type` (`auto` / `manual`) a la tabla `leads`
- El balanceo round-robin ahora cuenta solo leads `auto` creados **hoy** (zona horaria Guatemala UTC-6), no todos los leads activos
- Leads creados manualmente desde el CRM no afectan la distribución automática

## Test plan
- [ ] Crear leads desde el endpoint público y verificar que se distribuyan equitativamente por día
- [ ] Crear leads manualmente desde el CRM y verificar que no afecten el conteo de balanceo
- [ ] Verificar que al día siguiente el conteo se reinicia

🤖 Generated with [Claude Code](https://claude.com/claude-code)