### PR TITLE
fix: show documents menu for investors on mobile navbar

### DIFF
--- a/apps/portal-web/src/components/ui/NavBar.tsx
+++ b/apps/portal-web/src/components/ui/NavBar.tsx
@@ -64,7 +64,7 @@ export const NavBar = () => {
       id: "/documents",
       label: "Documentos",
       icon: <IconDocument width="24" height="24" />,
-      roles: ["CLIENT"],
+      roles: ["CLIENT", "INVESTOR"],
     },
   ];
 


### PR DESCRIPTION
## Summary
- The "Documentos" menu item in the mobile navbar was only visible to `CLIENT` role, while the desktop sidebar (`Menu.tsx`) correctly showed it to both `CLIENT` and `INVESTOR`
- Added `INVESTOR` to the roles array in `NavBar.tsx` to match the desktop behavior

## Test plan
- [ ] Login as an investor on mobile and verify "Documentos" appears in the hamburger menu
- [ ] Login as a client on mobile and verify "Documentos" still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)