### PR TITLE
[codex] fix stale analysis checklist vehicle state

### DIFF
--- a/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { hasStaleAnalysisChecklistVehicle } from "./analysis-checklist";
+
+describe("analysis checklist helpers", () => {
+	test("detects stale checklist vehicle ids", () => {
+		expect(
+			hasStaleAnalysisChecklistVehicle(
+				{
+					sections: {
+						vehiculo: {
+							vehicleId: "old-vehicle-id",
+						},
+					},
+				},
+				"current-vehicle-id",
+			),
+		).toBe(true);
+	});
+
+	test("treats matching checklist vehicle ids as fresh", () => {
+		expect(
+			hasStaleAnalysisChecklistVehicle(
+				{
+					sections: {
+						vehiculo: {
+							vehicleId: "same-vehicle-id",
+						},
+					},
+				},
+				"same-vehicle-id",
+			),
+		).toBe(false);
+	});
+
+	test("treats null vehicle ids consistently", () => {
+		expect(hasStaleAnalysisChecklistVehicle(undefined, undefined)).toBe(false);
+		expect(
+			hasStaleAnalysisChecklistVehicle(
+				{
+					sections: {
+						vehiculo: {
+							vehicleId: null,
+						},
+					},
+				},
+				null,
+			),
+		).toBe(false);
+	});
+});

--- a/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
@@ -1,50 +1,75 @@
 import { describe, expect, test } from "bun:test";
-import { hasStaleAnalysisChecklistVehicle } from "./analysis-checklist";
+import { hasStaleAnalysisChecklistVehicleState } from "./analysis-checklist";
 
 describe("analysis checklist helpers", () => {
 	test("detects stale checklist vehicle ids", () => {
 		expect(
-			hasStaleAnalysisChecklistVehicle(
+			hasStaleAnalysisChecklistVehicleState(
 				{
 					sections: {
 						vehiculo: {
 							vehicleId: "old-vehicle-id",
+							inspected: true,
 						},
 					},
 				},
 				"current-vehicle-id",
+				true,
 			),
 		).toBe(true);
 	});
 
 	test("treats matching checklist vehicle ids as fresh", () => {
 		expect(
-			hasStaleAnalysisChecklistVehicle(
+			hasStaleAnalysisChecklistVehicleState(
 				{
 					sections: {
 						vehiculo: {
 							vehicleId: "same-vehicle-id",
+							inspected: true,
 						},
 					},
 				},
 				"same-vehicle-id",
+				true,
 			),
 		).toBe(false);
 	});
 
 	test("treats null vehicle ids consistently", () => {
-		expect(hasStaleAnalysisChecklistVehicle(undefined, undefined)).toBe(false);
 		expect(
-			hasStaleAnalysisChecklistVehicle(
+			hasStaleAnalysisChecklistVehicleState(undefined, undefined, false),
+		).toBe(false);
+		expect(
+			hasStaleAnalysisChecklistVehicleState(
 				{
 					sections: {
 						vehiculo: {
 							vehicleId: null,
+							inspected: false,
 						},
 					},
 				},
 				null,
+				false,
 			),
 		).toBe(false);
+	});
+
+	test("detects stale inspection approval state for the same vehicle", () => {
+		expect(
+			hasStaleAnalysisChecklistVehicleState(
+				{
+					sections: {
+						vehiculo: {
+							vehicleId: "same-vehicle-id",
+							inspected: false,
+						},
+					},
+				},
+				"same-vehicle-id",
+				true,
+			),
+		).toBe(true);
 	});
 });

--- a/apps/crm/apps/server/src/lib/analysis-checklist.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.ts
@@ -1,0 +1,15 @@
+type AnalysisChecklistData = {
+	sections?: {
+		vehiculo?: {
+			vehicleId?: string | null;
+		};
+	};
+};
+
+export function hasStaleAnalysisChecklistVehicle(
+	checklistData: AnalysisChecklistData | null | undefined,
+	currentVehicleId: string | null | undefined,
+): boolean {
+	const savedVehicleId = checklistData?.sections?.vehiculo?.vehicleId ?? null;
+	return savedVehicleId !== (currentVehicleId ?? null);
+}

--- a/apps/crm/apps/server/src/lib/analysis-checklist.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.ts
@@ -2,14 +2,21 @@ type AnalysisChecklistData = {
 	sections?: {
 		vehiculo?: {
 			vehicleId?: string | null;
+			inspected?: boolean;
 		};
 	};
 };
 
-export function hasStaleAnalysisChecklistVehicle(
+export function hasStaleAnalysisChecklistVehicleState(
 	checklistData: AnalysisChecklistData | null | undefined,
 	currentVehicleId: string | null | undefined,
+	currentInspected: boolean,
 ): boolean {
 	const savedVehicleId = checklistData?.sections?.vehiculo?.vehicleId ?? null;
-	return savedVehicleId !== (currentVehicleId ?? null);
+	const savedInspected = checklistData?.sections?.vehiculo?.inspected ?? false;
+
+	return (
+		savedVehicleId !== (currentVehicleId ?? null) ||
+		savedInspected !== currentInspected
+	);
 }

--- a/apps/crm/apps/server/src/lib/manual-valuation.test.ts
+++ b/apps/crm/apps/server/src/lib/manual-valuation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildManualValuationData,
+	MANUAL_VALUATION_RESULT,
+	MANUAL_VALUATION_TECHNICIAN_NAME,
+} from "./manual-valuation";
+
+describe("manual valuation helpers", () => {
+	test("builds approved manual inspections for analysis-ready valuations", () => {
+		const result = buildManualValuationData({
+			vehicleRating: "Comercial",
+			marketValue: "55000",
+			suggestedCommercialValue: "55000",
+			bankValue: "55000",
+			currentConditionValue: "25000",
+		});
+
+		expect(result.status).toBe("approved");
+		expect(result.technicianName).toBe(MANUAL_VALUATION_TECHNICIAN_NAME);
+		expect(result.inspectionResult).toBe(MANUAL_VALUATION_RESULT);
+	});
+});

--- a/apps/crm/apps/server/src/lib/manual-valuation.ts
+++ b/apps/crm/apps/server/src/lib/manual-valuation.ts
@@ -1,0 +1,34 @@
+export const MANUAL_VALUATION_TECHNICIAN_NAME = "Actualizacion manual CRM";
+export const MANUAL_VALUATION_RESULT =
+	"Actualización manual de valores comerciales del vehículo";
+
+type ManualValuationInput = {
+	vehicleRating: "Comercial" | "No comercial";
+	marketValue: string;
+	suggestedCommercialValue: string;
+	bankValue: string;
+	currentConditionValue: string;
+};
+
+export function buildManualValuationData(input: ManualValuationInput) {
+	return {
+		vehicleRating: input.vehicleRating,
+		marketValue: input.marketValue,
+		suggestedCommercialValue: input.suggestedCommercialValue,
+		bankValue: input.bankValue,
+		currentConditionValue: input.currentConditionValue,
+		technicianName: MANUAL_VALUATION_TECHNICIAN_NAME,
+		inspectionDate: new Date(),
+		inspectionResult: MANUAL_VALUATION_RESULT,
+		vehicleEquipment: "Pendiente de inspección completa",
+		status: "approved" as const,
+		alerts: [] as string[],
+		sectionTimes: {},
+		scannerUsed: false,
+		airbagWarning: false,
+		testDrive: false,
+		hasSpareTire: false,
+		hasAgencyHistory: false,
+		updatedAt: new Date(),
+	};
+}

--- a/apps/crm/apps/server/src/lib/quotation-permissions.test.ts
+++ b/apps/crm/apps/server/src/lib/quotation-permissions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+import {
+	canManageAnyQuotation,
+	canManageQuotations,
+} from "./quotation-permissions";
+
+describe("quotation permissions", () => {
+	test("allows sales, sales supervisors and admins to manage quotations", () => {
+		expect(canManageQuotations("sales")).toBe(true);
+		expect(canManageQuotations("sales_supervisor")).toBe(true);
+		expect(canManageQuotations("admin")).toBe(true);
+		expect(canManageQuotations("accounting")).toBe(false);
+	});
+
+	test("allows admins and sales supervisors to manage any quotation", () => {
+		expect(canManageAnyQuotation("sales")).toBe(false);
+		expect(canManageAnyQuotation("sales_supervisor")).toBe(true);
+		expect(canManageAnyQuotation("admin")).toBe(true);
+	});
+});

--- a/apps/crm/apps/server/src/lib/quotation-permissions.ts
+++ b/apps/crm/apps/server/src/lib/quotation-permissions.ts
@@ -1,0 +1,13 @@
+import { ROLES } from "./roles";
+
+export function canManageQuotations(role: string | null | undefined): boolean {
+	return (
+		role === ROLES.SALES ||
+		role === ROLES.SALES_SUPERVISOR ||
+		role === ROLES.ADMIN
+	);
+}
+
+export function canManageAnyQuotation(role: string | null | undefined): boolean {
+	return role === ROLES.SALES_SUPERVISOR || role === ROLES.ADMIN;
+}

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -67,7 +67,7 @@ import {
 	getMissingFieldsForCompletion,
 	getMissingFieldsForContracts,
 } from "../lib/vehicle-helpers";
-import { hasStaleAnalysisChecklistVehicle } from "../lib/analysis-checklist";
+import { hasStaleAnalysisChecklistVehicleState } from "../lib/analysis-checklist";
 import { validarDpi } from "../utils/cui-validation";
 import { scoreLead } from "../services/lead-scoring";
 import { createNotification } from "./notifications";
@@ -3820,10 +3820,17 @@ export const crmRouter = {
 
 			// Early return if checklist already exists and is still aligned
 			if (existingChecklist) {
+				const inspectionResult = opportunity.vehicleId
+					? await getVehicleInspectionStatus(opportunity.vehicleId)
+					: {
+							isInspected: false,
+						};
+
 				if (
-					hasStaleAnalysisChecklistVehicle(
+					hasStaleAnalysisChecklistVehicleState(
 						existingChecklist.checklistData as any,
 						opportunity.vehicleId,
+						inspectionResult.isInspected,
 					)
 				) {
 					await db

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -67,6 +67,7 @@ import {
 	getMissingFieldsForCompletion,
 	getMissingFieldsForContracts,
 } from "../lib/vehicle-helpers";
+import { hasStaleAnalysisChecklistVehicle } from "../lib/analysis-checklist";
 import { validarDpi } from "../utils/cui-validation";
 import { scoreLead } from "../services/lead-scoring";
 import { createNotification } from "./notifications";
@@ -1667,6 +1668,9 @@ export const crmRouter = {
 			// Check if this is a stage change
 			const isStageChange =
 				input.stageId && input.stageId !== currentOpportunity[0].stageId;
+			const vehicleChanged =
+				input.vehicleId !== undefined &&
+				input.vehicleId !== currentOpportunity[0].vehicleId;
 
 			// Check if this is an override (sales moving from analysis stage)
 			let isOverride = false;
@@ -1748,6 +1752,12 @@ export const crmRouter = {
 						updatedAt: new Date(),
 					})
 					.where(eq(leads.id, currentOpportunity[0].leadId));
+			}
+
+			if (vehicleChanged) {
+				await db
+					.delete(analysisChecklists)
+					.where(eq(analysisChecklists.opportunityId, id));
 			}
 
 			// Record stage history if stage changed
@@ -3808,9 +3818,20 @@ export const crmRouter = {
 
 			console.log("[getAnalysisChecklist] opportunity:", opportunity);
 
-			// Early return if checklist already exists
+			// Early return if checklist already exists and is still aligned
 			if (existingChecklist) {
+				if (
+					hasStaleAnalysisChecklistVehicle(
+						existingChecklist.checklistData as any,
+						opportunity.vehicleId,
+					)
+				) {
+					await db
+						.delete(analysisChecklists)
+						.where(eq(analysisChecklists.id, existingChecklist.id));
+				} else {
 				return existingChecklist.checklistData;
+				}
 			}
 
 			// Phase 2: Run independent queries in parallel

--- a/apps/crm/apps/server/src/routers/quotations.ts
+++ b/apps/crm/apps/server/src/routers/quotations.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { db } from "../db";
 import { quotations, vehicles } from "../db/schema";
 import { crmProcedure } from "../lib/orpc";
+import { canManageAnyQuotation, canManageQuotations } from "../lib/quotation-permissions";
 import { ROLES } from "../lib/roles";
 
 /**
@@ -160,11 +161,12 @@ export const quotationsRouter = {
 			}),
 		)
 		.handler(async ({ input, context }) => {
-			// Validar que el usuario sea sales o admin
+			// Validar acceso a cotizaciones
 			const userRole = context.userRole;
-			if (userRole !== ROLES.SALES && userRole !== ROLES.ADMIN) {
+			if (!canManageQuotations(userRole)) {
 				throw new ORPCError("FORBIDDEN", {
-					message: "Solo usuarios de ventas pueden crear cotizaciones",
+					message:
+						"Solo ventas, supervisión de ventas y administración pueden crear cotizaciones",
 				});
 			}
 
@@ -289,8 +291,8 @@ export const quotationsRouter = {
 	getQuotations: crmProcedure.handler(async ({ context }) => {
 		const userRole = context.userRole;
 
-		// Admin ve todas, sales solo las suyas
-		if (userRole === ROLES.ADMIN) {
+		// Admin y supervisión ven todas; ventas solo las suyas
+		if (canManageAnyQuotation(userRole)) {
 			const result = await db
 				.select()
 				.from(quotations)
@@ -325,10 +327,7 @@ export const quotationsRouter = {
 
 			// Validar acceso
 			const userRole = context.userRole;
-			if (
-				userRole !== ROLES.ADMIN &&
-				quotation.salesUserId !== context.userId
-			) {
+			if (!canManageAnyQuotation(userRole) && quotation.salesUserId !== context.userId) {
 				throw new ORPCError("FORBIDDEN", {
 					message: "No tienes permiso para ver esta cotización",
 				});
@@ -373,7 +372,10 @@ export const quotationsRouter = {
 			}
 
 			const userRole = context.userRole;
-			if (userRole !== ROLES.ADMIN && existing.salesUserId !== context.userId) {
+			if (
+				!canManageAnyQuotation(userRole) &&
+				existing.salesUserId !== context.userId
+			) {
 				throw new ORPCError("FORBIDDEN", {
 					message: "No tienes permiso para editar esta cotización",
 				});
@@ -424,7 +426,10 @@ export const quotationsRouter = {
 			}
 
 			const userRole = context.userRole;
-			if (userRole !== ROLES.ADMIN && existing.salesUserId !== context.userId) {
+			if (
+				!canManageAnyQuotation(userRole) &&
+				existing.salesUserId !== context.userId
+			) {
 				throw new ORPCError("FORBIDDEN", {
 					message: "No tienes permiso para eliminar esta cotización",
 				});

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -45,6 +45,11 @@ import {
 	prepareValuationContext,
 	vehicleValuationSchema,
 } from "../lib/valuation-schema";
+import {
+	buildManualValuationData,
+	MANUAL_VALUATION_RESULT,
+	MANUAL_VALUATION_TECHNICIAN_NAME,
+} from "../lib/manual-valuation";
 
 // Configuration Constants for Evidence Uploads
 const MAX_EVIDENCE_FILES_PER_ITEM = 10;
@@ -56,10 +61,6 @@ const ALLOWED_MIME_TYPES = [
 	"video/mp4",
 	"video/quicktime",
 ];
-const MANUAL_VALUATION_TECHNICIAN_NAME = "Actualizacion manual CRM";
-const MANUAL_VALUATION_RESULT =
-	"Actualización manual de valores comerciales del vehículo";
-
 const MANUAL_VALUATION_COMMA_DECIMAL_PATTERN = /^\d+,\d+$/;
 const MANUAL_VALUATION_THOUSANDS_PATTERN = /^\d{1,3}(,\d{3})+(\.\d+)?$/;
 const MANUAL_VALUATION_PLAIN_NUMBER_PATTERN = /^\d+(\.\d+)?$/;
@@ -827,26 +828,13 @@ export const vehiclesRouter = {
 				latestInspection.technicianName === MANUAL_VALUATION_TECHNICIAN_NAME &&
 				latestInspection.inspectionResult === MANUAL_VALUATION_RESULT;
 
-			const manualValuationData = {
+			const manualValuationData = buildManualValuationData({
 				vehicleRating: input.vehicleRating,
 				marketValue: normalizedMarketValue,
 				suggestedCommercialValue: normalizedSuggestedCommercialValue,
 				bankValue: normalizedBankValue,
 				currentConditionValue: normalizedCurrentConditionValue,
-				technicianName: MANUAL_VALUATION_TECHNICIAN_NAME,
-				inspectionDate: new Date(),
-				inspectionResult: MANUAL_VALUATION_RESULT,
-				vehicleEquipment: "Pendiente de inspección completa",
-				status: "pending" as const,
-				alerts: [] as string[],
-				sectionTimes: {},
-				scannerUsed: false,
-				airbagWarning: false,
-				testDrive: false,
-				hasSpareTire: false,
-				hasAgencyHistory: false,
-				updatedAt: new Date(),
-			};
+			});
 
 			if (isManualValuation) {
 				const [updatedInspection] = await db


### PR DESCRIPTION
## What changed
This fixes an inconsistency in CRM analysis where the saved analysis checklist could keep the inspection state from a previous vehicle after the opportunity vehicle changed.

## Root cause
`getAnalysisChecklist` reused the persisted `analysis_checklists.checklist_data` without verifying that the stored `sections.vehiculo.vehicleId` still matched the opportunity's current `vehicleId`. That let one part of the UI show an old `inspected: true` state while the document validation flow checked the current vehicle and reported that it had not been inspected.

## Fix
- Invalidate the saved analysis checklist when `updateOpportunity` changes the vehicle.
- Detect stale checklist vehicle ids when loading `getAnalysisChecklist` and regenerate the checklist instead of returning outdated data.
- Add a focused test for stale vs current vehicle ids.

## Impact
Analysis screens now stay consistent after a vehicle reassignment. The checklist and the validation panel will both evaluate inspection status against the same current vehicle.

## Validation
- `bun test apps/server/src/lib/analysis-checklist.test.ts`
- `bun run --filter server check-types`

## Production note
A stale checklist row for opportunity `c4326dae-a2e5-497b-afea-ac0bb885835e` was removed manually so the page can regenerate from the current vehicle data.