### PR TITLE
refactor: centralize special exchange rate logic for investor 84

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1276,7 +1276,7 @@ export async function resumeInvestor(
       };
 
       const formatValue = (val: string | number | null | undefined) =>
-        inv.moneda === "dolares" ? formatToUSD(val) : Number(val || 0);
+        inv.moneda === "dolares" ? formatToUSD(val, inv.inversionista_id) : Number(val || 0);
 
       // Procesar créditos del inversionista
       const creditosData = await Promise.all(
@@ -1710,7 +1710,7 @@ export async function getInvestorTotalsGlobales(
 
   let creditosIds = creditosParticipa.map((c) => c.credito_id);
 
-  const formatValue = (val: string | number) => inv.moneda === "dolares" ? formatToUSD(val) : Number(val);
+  const formatValue = (val: string | number) => inv.moneda === "dolares" ? formatToUSD(val, inv.inversionista_id) : Number(val);
 
   if (creditosIds.length === 0) {
     return {
@@ -2372,7 +2372,7 @@ export async function getInvestorMirrorSummary(
     new Big(0)
   );
 
-  const formatValue = (val: string | number) => inv.moneda === "dolares" ? formatToUSD(val) : Number(val);
+  const formatValue = (val: string | number) => inv.moneda === "dolares" ? formatToUSD(val, inv.inversionista_id) : Number(val);
 
   // Caso sin créditos espejo: devolver ceros con monto base
   if (creditosEspejo.length === 0) {
@@ -4601,19 +4601,9 @@ function mapResumenRow(
   const isUSD = inv.moneda === "dolares";
   const currencySymbol = isUSD ? "$" : "Q";
 
-  // Special exchange rate for investor 84, others use global constant
-  const rate = inv.inversionista_id === 84 ? 7.78 : undefined;
-
   const convert = (val: number | string | null | undefined): number => {
     if (!isUSD) return Number(val || 0);
-    
-    // If we have a custom rate, use it directly
-    if (rate) {
-      const num = Number(val || 0);
-      return Number((num / rate).toFixed(2));
-    }
-    
-    return formatToUSD(val);
+    return formatToUSD(val, inv.inversionista_id);
   };
 
   return {

--- a/apps/cartera-back/src/utils/functions/currencyConverter.ts
+++ b/apps/cartera-back/src/utils/functions/currencyConverter.ts
@@ -1,12 +1,14 @@
 import { USD_EXCHANGE_RATE } from "./const";
 
-export const formatToUSD = (montoEnQuetzales: number | string | null | undefined): number => {
+export const formatToUSD = (montoEnQuetzales: number | string | null | undefined, inversionistaId?: number): number => {
   if (montoEnQuetzales === null || montoEnQuetzales === undefined) return 0;
   const val = Number(montoEnQuetzales);
   if (isNaN(val)) return 0;
-  
+
+  const exchangeRate = inversionistaId === 84 ? 7.78 : USD_EXCHANGE_RATE;
+
   // Prevenir división por cero si la variable de entorno no está correctamente configurada
-  if (!USD_EXCHANGE_RATE || USD_EXCHANGE_RATE <= 0) return 0;
-  
-  return Number((val / USD_EXCHANGE_RATE).toFixed(2));
+  if (!exchangeRate || exchangeRate <= 0) return 0;
+
+  return Number((val / exchangeRate).toFixed(2));
 };


### PR DESCRIPTION
Moves the special exchange rate logic for investor 84 from the controller into the formatToUSD utility. This ensures consistent currency conversion across the investor's summary, global totals, and mirror reports by passing the investor ID to the formatter.
