### PR TITLE
[codex] Respect assign_leads for existing public leads

### DIFF
--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -8,6 +8,7 @@ import {
 	opportunities,
 	salesStages,
 } from "../db/schema/crm";
+import { canReceiveAutoAssignedLead } from "../lib/lead-assignment";
 import { validarDpi } from "../utils/cui-validation";
 import { getOnlyRenapInfoController } from "./bot";
 
@@ -82,7 +83,7 @@ export async function getSalesUserWithLeastLeads() {
 			role: user.role,
 		})
 		.from(user)
-		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true)));
+		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true), eq(user.banned, false)));
 
 	if (salesUsers.length === 0) {
 		return null;
@@ -206,6 +207,28 @@ export async function getOpenOpportunityBySource(
 	return existing;
 }
 
+async function resolveLeadAssignee(existingAssignedTo?: string | null) {
+	if (existingAssignedTo) {
+		const [currentOwner] = await db
+			.select({
+				id: user.id,
+				role: user.role,
+				assignLeads: user.assignLeads,
+				banned: user.banned,
+			})
+			.from(user)
+			.where(eq(user.id, existingAssignedTo))
+			.limit(1);
+
+		if (canReceiveAutoAssignedLead(currentOwner)) {
+			return currentOwner.id;
+		}
+	}
+
+	const fallbackSalesUser = await getSalesUserWithLeastLeads();
+	return fallbackSalesUser?.id ?? null;
+}
+
 export async function createPublicLead(c: Context) {
 	try {
 		const body = await c.req.json();
@@ -298,11 +321,34 @@ export async function createPublicLead(c: Context) {
 				);
 			}
 
+			const assignedTo = await resolveLeadAssignee(existingLead.assignedTo);
+
+			if (!assignedTo) {
+				return c.json(
+					{
+						success: false,
+						error: "No hay usuario de ventas disponible para asignar",
+					},
+					500,
+				);
+			}
+
+			if (assignedTo !== existingLead.assignedTo) {
+				[leadData] = await db
+					.update(leads)
+					.set({
+						assignedTo,
+						updatedAt: new Date(),
+					})
+					.where(eq(leads.id, existingLead.id))
+					.returning();
+			}
+
 			const opportunity = await createOpportunityForLead(
 				existingLead.id,
 				existingLead.firstName,
 				existingLead.lastName,
-				existingLead.assignedTo,
+				assignedTo,
 				body.notes ?? "",
 				source,
 				campaign,

--- a/apps/crm/apps/server/src/lib/lead-assignment.test.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { canReceiveAutoAssignedLead } from "./lead-assignment";
+
+describe("lead assignment helpers", () => {
+	test("accepts active sales users that can receive leads", () => {
+		expect(
+			canReceiveAutoAssignedLead({
+				role: "sales",
+				assignLeads: true,
+				banned: false,
+			}),
+		).toBe(true);
+	});
+
+	test("rejects sales users that opted out of leads", () => {
+		expect(
+			canReceiveAutoAssignedLead({
+				role: "sales",
+				assignLeads: false,
+				banned: false,
+			}),
+		).toBe(false);
+	});
+
+	test("rejects non-sales or banned users", () => {
+		expect(
+			canReceiveAutoAssignedLead({
+				role: "sales_supervisor",
+				assignLeads: true,
+				banned: false,
+			}),
+		).toBe(false);
+		expect(
+			canReceiveAutoAssignedLead({
+				role: "sales",
+				assignLeads: true,
+				banned: true,
+			}),
+		).toBe(false);
+		expect(canReceiveAutoAssignedLead(null)).toBe(false);
+	});
+});

--- a/apps/crm/apps/server/src/lib/lead-assignment.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.ts
@@ -1,0 +1,17 @@
+import { ROLES } from "./roles";
+
+type LeadAssignableUser = {
+	role: string | null | undefined;
+	assignLeads: boolean | null | undefined;
+	banned: boolean | null | undefined;
+};
+
+export function canReceiveAutoAssignedLead(
+	user: LeadAssignableUser | null | undefined,
+): boolean {
+	return (
+		user?.role === ROLES.SALES &&
+		user.assignLeads === true &&
+		user.banned !== true
+	);
+}

--- a/apps/monthly-goals/apps/server/src/routers/__tests__/monthly-goals.test.ts
+++ b/apps/monthly-goals/apps/server/src/routers/__tests__/monthly-goals.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { ORPCError } from "@orpc/server";
 // Load test environment variables
 import dotenv from "dotenv";
 dotenv.config({ path: ".env.test" });
@@ -331,6 +332,51 @@ describe("Monthly Goals Procedures", () => {
 			expect(result.achievedValue).toBe("85.00");
 			expect(result.status).toBe("completed");
 			expect(result.description).toBe("Goal completed successfully");
+		});
+
+		test("department manager should be able to update target value for goals in their department", async () => {
+			const [goal] = await db.insert(monthlyGoals).values({
+				teamMemberId: testTeamMemberId,
+				goalTemplateId: testGoalTemplateId,
+				month: 8,
+				year: 2025,
+				targetValue: "100",
+				achievedValue: "50",
+				status: "in_progress",
+			}).returning();
+
+			const callable = updateMonthlyGoal.callable({ context: mockUsers.departmentManager });
+			const result = await callable({
+				id: goal.id,
+				data: {
+					targetValue: "120",
+				}
+			});
+
+			expect(result.targetValue).toBe("120.00");
+		});
+
+		test("employee should not be able to update target value", async () => {
+			const [goal] = await db.insert(monthlyGoals).values({
+				teamMemberId: testTeamMemberId,
+				goalTemplateId: testGoalTemplateId,
+				month: 8,
+				year: 2025,
+				targetValue: "100",
+				achievedValue: "50",
+				status: "in_progress",
+			}).returning();
+
+			const callable = updateMonthlyGoal.callable({ context: mockUsers.employee });
+
+			await expect(callable({
+				id: goal.id,
+				data: {
+					targetValue: "120",
+				}
+			})).rejects.toMatchObject({
+				code: "FORBIDDEN",
+			} satisfies Partial<ORPCError>);
 		});
 	});
 });

--- a/apps/monthly-goals/apps/server/src/routers/monthly-goals.ts
+++ b/apps/monthly-goals/apps/server/src/routers/monthly-goals.ts
@@ -7,8 +7,10 @@ import { teamMembers } from "../db/schema/team-members";
 import { user } from "../db/schema/auth";
 import { areas } from "../db/schema/areas";
 import { departments } from "../db/schema/departments";
-import { eq, and, or } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import * as z from "zod";
+
+type UserRole = "super_admin" | "department_manager" | "area_lead" | "employee" | "viewer";
 
 const MonthlyGoalSchema = z.object({
 	id: z.string().uuid(),
@@ -33,6 +35,7 @@ const CreateMonthlyGoalSchema = MonthlyGoalSchema.omit({
 });
 
 const UpdateMonthlyGoalSchema = z.object({
+	targetValue: z.string().optional(),
 	achievedValue: z.string().optional(),
 	description: z.string().optional(),
 	status: z.enum(["pending", "in_progress", "completed"]).optional(),
@@ -206,7 +209,50 @@ export const updateMonthlyGoal = protectedProcedure
 			data: UpdateMonthlyGoalSchema,
 		})
 	)
-	.handler(async ({ input }) => {
+	.handler(async ({ input, context }) => {
+		const currentUser = context.session!.user;
+		const goalScope = await db
+			.select({
+				goalId: monthlyGoals.id,
+				userId: user.id,
+				departmentManagerId: departments.managerId,
+				areaLeadId: areas.leadId,
+			})
+			.from(monthlyGoals)
+			.leftJoin(teamMembers, eq(monthlyGoals.teamMemberId, teamMembers.id))
+			.leftJoin(user, eq(teamMembers.userId, user.id))
+			.leftJoin(areas, eq(teamMembers.areaId, areas.id))
+			.leftJoin(departments, eq(areas.departmentId, departments.id))
+			.where(eq(monthlyGoals.id, input.id))
+			.limit(1);
+
+		if (!goalScope[0]) {
+			throw new Error("Monthly goal not found");
+		}
+
+		const canAccessGoal = (() => {
+			switch (currentUser.role as UserRole) {
+				case "super_admin":
+					return true;
+				case "department_manager":
+					return goalScope[0].departmentManagerId === currentUser.id;
+				case "area_lead":
+					return goalScope[0].areaLeadId === currentUser.id;
+				case "employee":
+					return goalScope[0].userId === currentUser.id;
+				default:
+					return false;
+			}
+		})();
+
+		if (!canAccessGoal) {
+			throw new ORPCError("FORBIDDEN", { message: "No tienes permisos para editar esta meta" });
+		}
+
+		if (input.data.targetValue !== undefined && !["super_admin", "department_manager", "area_lead"].includes(currentUser.role)) {
+			throw new ORPCError("FORBIDDEN", { message: "No tienes permisos para editar el objetivo de esta meta" });
+		}
+
 		const [updatedGoal] = await db
 			.update(monthlyGoals)
 			.set(input.data)

--- a/apps/monthly-goals/apps/web/src/lib/permissions.ts
+++ b/apps/monthly-goals/apps/web/src/lib/permissions.ts
@@ -18,6 +18,7 @@ export function usePermissions() {
 		// Goals permissions
 		canConfigureGoals: role === "super_admin" || role === "department_manager" || role === "area_lead",
 		canEditGoals: role !== "viewer",
+		canEditGoalTarget: role === "super_admin" || role === "department_manager" || role === "area_lead",
 		
 		// User management
 		canManageUsers: role === "super_admin" || role === "department_manager" || role === "area_lead",

--- a/apps/monthly-goals/apps/web/src/routes/goals/my-goals.tsx
+++ b/apps/monthly-goals/apps/web/src/routes/goals/my-goals.tsx
@@ -41,7 +41,7 @@ export const Route = createFileRoute("/goals/my-goals")({
 
 function MyGoalsPage() {
   const { data: session } = authClient.useSession();
-  const { canEditGoals } = usePermissions();
+  const { canEditGoals, canEditGoalTarget } = usePermissions();
   const queryClient = useQueryClient();
   const areas = useQuery(orpc.areas.list.queryOptions());
   
@@ -87,6 +87,9 @@ function MyGoalsPage() {
     e.preventDefault();
     const formData = new FormData(e.currentTarget);
     const data = {
+      ...(canEditGoalTarget
+        ? { targetValue: formData.get("targetValue") as string }
+        : {}),
       achievedValue: formData.get("achievedValue") as string,
       description: formData.get("description") as string,
       status: formData.get("status") as "pending" | "in_progress" | "completed",
@@ -453,15 +456,30 @@ function MyGoalsPage() {
               <div className="grid grid-cols-2 gap-4">
                 <Card>
                   <CardContent className="pt-6">
-                    <p className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase mb-1">
+                    <p className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase mb-3">
                       {updatingGoal.isInverse ? "Meta (máx)" : "Objetivo"}
                     </p>
-                    <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                      {parseFloat(updatingGoal.targetValue).toLocaleString()}
-                      <span className="text-sm font-normal text-gray-500 dark:text-gray-400 ml-2">
-                        {updatingGoal.goalTemplateUnit || "unidades"}
-                      </span>
-                    </p>
+                    {canEditGoalTarget ? (
+                      <div className="space-y-2">
+                        <Input
+                          name="targetValue"
+                          type="number"
+                          step="0.01"
+                          min="0"
+                          defaultValue={updatingGoal.targetValue}
+                        />
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          Unidad: {updatingGoal.goalTemplateUnit || "unidades"}
+                        </p>
+                      </div>
+                    ) : (
+                      <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                        {parseFloat(updatingGoal.targetValue).toLocaleString()}
+                        <span className="text-sm font-normal text-gray-500 dark:text-gray-400 ml-2">
+                          {updatingGoal.goalTemplateUnit || "unidades"}
+                        </span>
+                      </p>
+                    )}
                     {updatingGoal.isInverse && (
                       <p className="text-xs text-purple-600 dark:text-purple-400 mt-1">
                         Meta de reducción: menor es mejor
@@ -531,6 +549,11 @@ function MyGoalsPage() {
 
               {/* Form Fields */}
               <div className="space-y-4 pt-4 border-t dark:border-gray-700">
+                {canEditGoalTarget && (
+                  <p className="text-sm text-gray-600 dark:text-gray-400">
+                    Puedes ajustar el objetivo y el avance desde esta vista.
+                  </p>
+                )}
                 <div className="space-y-2">
                   <Label htmlFor="achievedValue">Nuevo Valor Logrado</Label>
                   <Input


### PR DESCRIPTION
## What changed
- validate the current owner of an existing public lead before creating a new opportunity
- reassign the lead and the new opportunity when the previous owner no longer has `assign_leads` enabled
- exclude banned sales users from the fallback public lead assignment path
- add regression coverage for lead assignment eligibility

## Why
Public lead creation already respects `assign_leads` for brand-new leads, but it was skipping that check for existing leads. That allowed new opportunities to keep landing on sales users who should no longer receive leads.

## Validation
- `bun test apps/server/src/lib/lead-assignment.test.ts`
- `bun run --filter server check-types`