### PR TITLE
feat: carga lazy de candidatos y mejoras modal compra cartera

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -38,7 +38,6 @@ import {
   type EstadoLiquidacionResumen,
   type EstadoLiquidacionResumenFilter,
 } from "../utils/investorLiquidationSummary";
-import { getCreditCandidates, CUBE_ID } from "./assignCapital";
 import { addInvestorToCredit } from "./addInvestorToCredit";
 
 // ============================================
@@ -5466,14 +5465,6 @@ export async function getCreditosEspejoPendientes(page: number = 1, pageSize: nu
   const start = (page - 1) * pageSize;
   const paginados = todos.slice(start, start + pageSize);
 
-  // 4. Obtener opciones de crédito para cada inversionista
-  const data = await Promise.all(
-    paginados.map(async (inv) => {
-      const opciones_de_credito = await getCreditCandidates(inv.monto_reinversion, 10);
-      return { ...inv, opciones_de_credito };
-    })
-  );
-
-  return { data, total, page, pageSize };
+  return { data: paginados, total, page, pageSize };
 }
 

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useMemo, useCallback, useEffect } from "react";
-import { useSesionesPendientes, useCompletarEspejo, useReemplazarInversionistaCredito } from "../hooks/useSesionesPendientes";
+import { useSesionesPendientes, useCompletarEspejo, useReemplazarInversionistaCredito, useCreditCandidates } from "../hooks/useSesionesPendientes";
 import type { InversionistaSesionPendiente, OtroCreditoDisponible } from "../services/services";
 import {
   Loader2,
@@ -281,10 +281,13 @@ function InvestorCard({
   const isEditing = editingCreditId !== null;
   const editingCredit = investor.creditosPendientes.find((c) => c.id === editingCreditId);
 
+  const montoParaCandidatos = editingCredit ? Number(editingCredit.monto_aportado) : null;
+  const { data: candidates, isLoading: isLoadingCandidates } = useCreditCandidates(montoParaCandidatos);
+
   const destinos = useMemo(() => {
-    if (!editingCreditId) return [];
-    return buildDestinos(investor.opciones_de_credito ?? [], investor.moneda);
-  }, [editingCreditId, investor]);
+    if (!editingCreditId || !candidates) return [];
+    return buildDestinos(candidates, investor.moneda);
+  }, [editingCreditId, candidates, investor.moneda]);
 
   const montoAportado = editingCredit ? Number(editingCredit.monto_aportado) : 0;
 
@@ -507,7 +510,12 @@ function InvestorCard({
                       </div>
 
                       <div className="space-y-1.5">
-                        {destinos.length === 0 ? (
+                        {isLoadingCandidates ? (
+                          <div className="flex items-center gap-2 py-2">
+                            <Loader2 className="w-3.5 h-3.5 animate-spin text-amber-600" aria-hidden="true" />
+                            <p className="text-[11px] text-gray-500">Cargando créditos disponibles&hellip;</p>
+                          </div>
+                        ) : destinos.length === 0 ? (
                           <p className="text-[11px] text-gray-500 italic">Sin créditos disponibles</p>
                         ) : (
                           destinos.map((d) => {

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -267,6 +267,8 @@ export function TableInvestors() {
   const [compraCarteraInvId, setCompraCarteraInvId] = useState<number | null>(null);
   const [compraCarteraMonto, setCompraCarteraMonto] = useState("");
   const [compraCarteraFecha, setCompraCarteraFecha] = useState("");
+  const [compraCarteraPctInv, setCompraCarteraPctInv] = useState("70");
+  const [compraCarteraPctCashIn, setCompraCarteraPctCashIn] = useState("30");
   const agregarInvCredito = useAgregarInversionistaCredito();
 
   const [incluirLiquidados, setIncluirLiquidados] = useState(false);
@@ -1223,6 +1225,25 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                     setCompraCarteraInvId(inv.inversionista_id);
                     setCompraCarteraMonto("");
                     setCompraCarteraFecha(new Date().toISOString().split("T")[0]);
+                    // Calcular moda del porcentaje de participación desde créditos existentes
+                    const creditos = inv.creditos ?? [];
+                    if (creditos.length > 0) {
+                      const freq = new Map<string, number>();
+                      for (const c of creditos) {
+                        const pct = String(Math.round(Number(c.porcentaje_inversionista ?? 0)));
+                        freq.set(pct, (freq.get(pct) ?? 0) + 1);
+                      }
+                      let modaPct = "70";
+                      let maxCount = 0;
+                      for (const [pct, count] of freq) {
+                        if (count > maxCount) { modaPct = pct; maxCount = count; }
+                      }
+                      setCompraCarteraPctInv(modaPct);
+                      setCompraCarteraPctCashIn(String(100 - Number(modaPct)));
+                    } else {
+                      setCompraCarteraPctInv("70");
+                      setCompraCarteraPctCashIn("30");
+                    }
                     setCompraCarteraOpen(true);
                   }}
                   className="cursor-pointer rounded-lg px-3 py-2.5 focus:bg-emerald-50"
@@ -2413,16 +2434,16 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
           }
         }}
       >
-        <DialogContent className="bg-white dark:bg-gray-900 sm:max-w-md z-[60]">
+        <DialogContent className="!bg-[#1e293b] sm:max-w-md z-[60] border border-slate-600/40 shadow-2xl rounded-2xl">
           <DialogHeader>
-            <DialogTitle className="text-lg font-bold">Compra de Cartera</DialogTitle>
-            <DialogDescription>
-              Ingresa el monto y la fecha de inicio de participación
+            <DialogTitle className="text-lg font-bold text-white">Compra de Cartera</DialogTitle>
+            <DialogDescription className="text-slate-400 text-sm">
+              Ingresa el monto, porcentajes y la fecha de inicio de participación
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
             <div>
-              <label htmlFor="compra-monto" className="text-sm font-medium text-gray-700">
+              <label htmlFor="compra-monto" className="text-sm font-medium text-slate-300">
                 Monto aportado
               </label>
               <Input
@@ -2433,11 +2454,57 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 placeholder="0.00"
                 value={compraCarteraMonto}
                 onChange={(e) => setCompraCarteraMonto(e.target.value)}
-                className="mt-1"
+                className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white placeholder:text-slate-500 focus:!border-emerald-400 focus:!ring-emerald-400/30"
               />
             </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label htmlFor="compra-pct-inv" className="text-sm font-medium text-slate-300">
+                  % Inversionista
+                </label>
+                <Input
+                  id="compra-pct-inv"
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="1"
+                  value={compraCarteraPctInv}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setCompraCarteraPctInv(val);
+                    const num = Number(val);
+                    if (!isNaN(num) && num >= 0 && num <= 100) {
+                      setCompraCarteraPctCashIn(String(100 - num));
+                    }
+                  }}
+                  className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white placeholder:text-slate-500 focus:!border-emerald-400 focus:!ring-emerald-400/30"
+                />
+              </div>
+              <div>
+                <label htmlFor="compra-pct-cashin" className="text-sm font-medium text-slate-300">
+                  % Cash In
+                </label>
+                <Input
+                  id="compra-pct-cashin"
+                  type="number"
+                  min={0}
+                  max={100}
+                  step="1"
+                  value={compraCarteraPctCashIn}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    setCompraCarteraPctCashIn(val);
+                    const num = Number(val);
+                    if (!isNaN(num) && num >= 0 && num <= 100) {
+                      setCompraCarteraPctInv(String(100 - num));
+                    }
+                  }}
+                  className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white placeholder:text-slate-500 focus:!border-emerald-400 focus:!ring-emerald-400/30"
+                />
+              </div>
+            </div>
             <div>
-              <label htmlFor="compra-fecha" className="text-sm font-medium text-gray-700">
+              <label htmlFor="compra-fecha" className="text-sm font-medium text-slate-300">
                 Fecha inicio participación
               </label>
               <Input
@@ -2445,7 +2512,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 type="date"
                 value={compraCarteraFecha}
                 onChange={(e) => setCompraCarteraFecha(e.target.value)}
-                className="mt-1"
+                className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white focus:!border-emerald-400 focus:!ring-emerald-400/30 [color-scheme:dark]"
               />
             </div>
           </div>
@@ -2456,7 +2523,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 setCompraCarteraOpen(false);
                 setCompraCarteraInvId(null);
               }}
-              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50"
+              className="px-4 py-2 text-sm font-medium text-slate-300 bg-slate-700/60 border border-slate-500/40 rounded-lg hover:bg-slate-600/60 transition-colors"
             >
               Cancelar
             </button>
@@ -2470,6 +2537,8 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                     inversionista_id: compraCarteraInvId,
                     monto_aportado: Number(compraCarteraMonto),
                     tipo_operacion: "compra_cartera",
+                    porcentaje_inversion: Number(compraCarteraPctInv),
+                    porcentaje_cash_in: Number(compraCarteraPctCashIn),
                     fecha_inicio_participacion: compraCarteraFecha || undefined,
                   },
                   {
@@ -2486,7 +2555,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                   }
                 );
               }}
-              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed"
+              className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-lg hover:bg-emerald-500 disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors"
             >
               {agregarInvCredito.isPending ? "Guardando…" : "Confirmar"}
             </button>

--- a/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
@@ -3,11 +3,13 @@ import {
   getCreditosEspejoPendientesService,
   completarEspejoService,
   reemplazarInversionistaCreditoService,
+  getCreditCandidatesService,
   type CompletarEspejoPayload,
   type CompletarEspejoResponse,
   type ReemplazarInversionistaCreditoPayload,
   type ReemplazarInversionistaCreditoResponse,
   type SesionesPendientesPaginatedResponse,
+  type OtroCreditoDisponible,
 } from "../services/services";
 
 export const sesionesPendientesKeys = {
@@ -51,5 +53,15 @@ export function useReemplazarInversionistaCredito() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: sesionesPendientesKeys.all });
     },
+  });
+}
+
+export function useCreditCandidates(monto: number | null) {
+  return useQuery<OtroCreditoDisponible[]>({
+    queryKey: ["credit-candidates", monto] as const,
+    queryFn: () => getCreditCandidatesService({ monto: monto! }),
+    enabled: monto !== null && monto > 0,
+    staleTime: 1000 * 60 * 2,
+    gcTime: 1000 * 60 * 5,
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
@@ -17,6 +17,10 @@ export const sesionesPendientesKeys = {
   list: (page: number, pageSize: number, search: string) => [...sesionesPendientesKeys.all, "list", page, pageSize, search] as const,
 };
 
+export const creditCandidatesKeys = {
+  all: ["credit-candidates"] as const,
+};
+
 export function useSesionesPendientes(page: number, pageSize: number, search: string) {
   return useQuery<SesionesPendientesPaginatedResponse>({
     queryKey: sesionesPendientesKeys.list(page, pageSize, search),
@@ -52,13 +56,14 @@ export function useReemplazarInversionistaCredito() {
     mutationFn: (payload) => reemplazarInversionistaCreditoService(payload),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: sesionesPendientesKeys.all });
+      queryClient.invalidateQueries({ queryKey: creditCandidatesKeys.all });
     },
   });
 }
 
 export function useCreditCandidates(monto: number | null) {
   return useQuery<OtroCreditoDisponible[]>({
-    queryKey: ["credit-candidates", monto] as const,
+    queryKey: [...creditCandidatesKeys.all, monto] as const,
     queryFn: () => getCreditCandidatesService({ monto: monto! }),
     enabled: monto !== null && monto > 0,
     staleTime: 1000 * 60 * 2,

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3442,7 +3442,7 @@ export interface InversionistaSesionPendiente {
   monto_reinversion: string | null;
   saldo_reinversion: string;
   creditosPendientes: CreditoEspejoPendiente[];
-  opciones_de_credito: OtroCreditoDisponible[];
+  opciones_de_credito?: OtroCreditoDisponible[];
 }
 
 export interface SesionesPendientesPaginatedResponse {
@@ -3507,10 +3507,10 @@ export interface CandidatesResponse {
   candidates: OtroCreditoDisponible[];
 }
 
-export async function getCreditCandidatesService(minimo = 10): Promise<OtroCreditoDisponible[]> {
+export async function getCreditCandidatesService(params?: { monto?: number; minimo?: number }): Promise<OtroCreditoDisponible[]> {
   const res = await api.get<CandidatesResponse>(
     `${API_URL}/assign-capital/candidates`,
-    { params: { minimo } }
+    { params: { monto: params?.monto, minimo: params?.minimo ?? 10 } }
   );
   return res.data.candidates;
 }


### PR DESCRIPTION
## Resumen

- **Sesiones Pendientes**: el endpoint `/creditos-espejo-pendientes` ya no trae `opciones_de_credito` precargadas. Ahora los candidatos se cargan on-demand al hacer clic en "Quitar", llamando a `/assign-capital/candidates` con el `monto_aportado` del crédito específico. Esto aligera la respuesta inicial.
- **Modal Compra de Cartera**: se agregaron campos de `% Inversionista` y `% Cash In` que se sincronizan automáticamente (suman 100%). Los valores default se calculan desde la moda del `porcentaje_inversionista` de los créditos existentes del inversionista (si no tiene, 70/30).
- **Rediseño visual de la modal**: tema oscuro consistente con el resto de la app, inputs con estilo slate/emerald.

## Cambios por archivo

| Archivo | Cambio |
|---------|--------|
| `cartera-back/.../investor.ts` | Remover llamada a `getCreditCandidates` del endpoint |
| `carteraFront/.../SesionesPendientes.tsx` | Usar hook `useCreditCandidates` con loader |
| `carteraFront/.../tableInvestors.tsx` | Modal rediseñada con porcentajes y tema oscuro |
| `carteraFront/.../useSesionesPendientes.ts` | Nuevo hook `useCreditCandidates` |
| `carteraFront/.../services.ts` | `getCreditCandidatesService` acepta `monto` |

## Plan de pruebas

- [ ] Verificar que Sesiones Pendientes carga sin `opciones_de_credito`
- [ ] Al hacer clic en "Quitar" en un crédito, verificar que se muestre loader y luego los candidatos
- [ ] Abrir modal Compra de Cartera con inversionista que tiene créditos: verificar que porcentajes se pre-llenan con la moda
- [ ] Abrir modal con inversionista sin créditos: verificar default 70/30
- [ ] Cambiar un porcentaje y verificar que el otro se ajusta automáticamente
- [ ] Confirmar compra de cartera y verificar que se envían los porcentajes al backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)