### PR TITLE
Jalvarez

### DIFF
--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -985,33 +985,43 @@ export const updateCredit = async ({ body, set }: any) => {
       );
     }
 
-    // 10. Actualizar inversionistas (Espejo) - jala cuota del padre
+    // 10. Actualizar inversionistas (Espejo)
+    console.log(`🪞 [ESPEJO] inversionistas_espejo recibidos: ${JSON.stringify(inversionistas_espejo?.length ?? 'undefined')}`);
     if (inversionistas_espejo && inversionistas_espejo.length > 0) {
-      const parentInvestors = await db
-        .select({
-          inversionista_id: creditos_inversionistas.inversionista_id,
-          cuota_inversionista: creditos_inversionistas.cuota_inversionista,
-        })
-        .from(creditos_inversionistas)
-        .where(eq(creditos_inversionistas.credito_id, credito_id));
-
-      const parentCuotas = new Map(
-        parentInvestors.map((p) => [p.inversionista_id, p.cuota_inversionista])
+      // 🔒 Sincronización forzada: el espejo siempre usa el monto_aportado del padre.
+      // Esto es la fuente de verdad, independiente de lo que envíe el frontend.
+      const principalMontos = new Map(
+        (inversionistas || []).map((inv) => [inv.inversionista_id, inv.monto_aportado])
       );
 
-      await updateInvestors(
-        credito_id,
-        inversionistas_espejo,
-        updateFields,
-        current,
-        numero_credito_sifco ?? current.numero_credito_sifco,
-        Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
-        Number(updateFields.membresias_pago ?? current.membresias_pago),
-        Number(updateFields.gps ?? current.gps),
-        creditos_inversionistas_espejo, // Mirror target
-        parentCuotas, // Cuotas del padre
-      );
+      const espejoSincronizado = inversionistas_espejo.map((inv) => ({
+        ...inv,
+        monto_aportado: principalMontos.get(inv.inversionista_id) ?? inv.monto_aportado,
+      }));
+
+      console.log(`🪞 [ESPEJO] Iniciando updateInvestors para credito_id=${credito_id} con ${espejoSincronizado.length} inversionistas`);
+      try {
+        await updateInvestors(
+          credito_id,
+          espejoSincronizado,
+          updateFields,
+          current,
+          numero_credito_sifco ?? current.numero_credito_sifco,
+          Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
+          Number(updateFields.membresias_pago ?? current.membresias_pago),
+          Number(updateFields.gps ?? current.gps),
+          creditos_inversionistas_espejo,
+        );
+        console.log(`🪞 [ESPEJO] ✅ updateInvestors completado para espejo`);
+      } catch (espejoError) {
+        console.error(`🪞 [ESPEJO] ❌ Error en updateInvestors espejo:`, espejoError);
+        throw espejoError;
+      }
+    } else {
+      console.log(`🪞 [ESPEJO] ⚠️ Bloque saltado: inversionistas_espejo está vacío o undefined`);
     }
+
+
 
     set.status = 200;
     return updatedCredit;

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -143,24 +143,25 @@ export function ModalEditCredit({
     );
 
     if (mirrorItem) {
+      // El espejo está sincronizado con el padre: usar los valores ACTUALES del principal
+      // para monto_aportado, cuota y porcentajes. Solo confirmamos que el espejo existe.
       return {
         inversionista_id: Number(mirrorItem.inversionista_id),
-        monto_aportado: Number(mirrorItem.monto_aportado),
-        porcentaje_cash_in: Number(mirrorItem.porcentaje_cash_in),
-        porcentaje_inversion: Number(mirrorItem.porcentaje_inversion),
+        monto_aportado: inv.monto_aportado,           // ← Siempre del padre actual
+        porcentaje_cash_in: inv.porcentaje_cash_in,   // ← Siempre del padre actual
+        porcentaje_inversion: inv.porcentaje_inversion, // ← Siempre del padre actual
         fecha_inicio_participacion: parseParticipantDate(mirrorItem.fecha_inicio_participacion),
-        cuota_inversionista: Number(mirrorItem.cuota_inversionista || 0),
+        cuota_inversionista: inv.cuota_inversionista, // ← Siempre del padre actual
       };
     }
-    // Si no hay espejo para ese inversionista, devolvemos objeto vacío
-    const today = new Date().toISOString().split("T")[0];
+    // Si no hay espejo para ese inversionista en DB, sincronizar desde el principal
     return {
-      inversionista_id: 0,
-      monto_aportado: 0,
-      porcentaje_cash_in: 0,
-      porcentaje_inversion: 0,
-      fecha_inicio_participacion: today,
-      cuota_inversionista: 0,
+      inversionista_id: inv.inversionista_id,
+      monto_aportado: inv.monto_aportado,
+      porcentaje_cash_in: inv.porcentaje_cash_in,
+      porcentaje_inversion: inv.porcentaje_inversion,
+      fecha_inicio_participacion: inv.fecha_inicio_participacion,
+      cuota_inversionista: inv.cuota_inversionista,
     };
   });
 

--- a/apps/crm/apps/server/src/lib/ocr-schema.ts
+++ b/apps/crm/apps/server/src/lib/ocr-schema.ts
@@ -89,6 +89,12 @@ export function mapOCRToVehicleForm(ocrData: VehicleRegistrationOCR) {
 		cylinders: ocrData.cylinders || "",
 		engineCC: ocrData.cc || "",
 		vehicleType: ocrData.vehicleType || "",
+		vehicleUse: ocrData.use?.toUpperCase().includes("PARTICULAR") 
+			? "Particular" 
+			: ocrData.use?.toUpperCase().includes("COMERCIAL") 
+			? "Comercial" 
+			: ocrData.use || "", // Fallback to raw if not matching common types
+		seats: ocrData.seats || "", // Número de asientos
 		// Default values for fields not in tarjeta de circulación
 		origin: "Nacional", // Default since it's a Guatemalan registration
 		fuelType: "", // Not available in registration card

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -1524,12 +1524,13 @@ INFORMACIÓN DEL VEHÍCULO:
 - Modelo/Año (año del vehículo, ej: 2020, 2023)
 - Color (descripción del color)
 - Tipo de vehículo (ej: AUTOMOVIL, CAMIONETA)
+- Uso (ej: PARTICULAR, COMERCIAL)
 
 ESPECIFICACIONES TÉCNICAS:
 - VIN/Chasis/Serie (números de identificación únicos)
-- Motor/CC (cilindrada)
+- Motor/CC (Cilindrada, buscar etiqueta "Cilindrada" o "CC")
 - Cilindros (número)
-- Asientos (número)
+- Asientos (Número de pasajeros, buscar etiqueta "Asientos" o "No. Asientos")
 
 REGLAS IMPORTANTES:
 - Si encuentras al menos 3 campos correctos: extractionSuccess = true
@@ -1537,7 +1538,7 @@ REGLAS IMPORTANTES:
 - Siempre retorna un objeto JSON válido con extractionSuccess como boolean y extractionErrors como array
 - Deja campos vacíos ("") si no los encuentras claramente
 - NO uses estructura "properties", retorna el objeto directamente
-- Ejemplo correcto: {"licensePlate": "P0-123ABC", "make": "TOYOTA", "line": "COROLLA", "model": "2020", "extractionSuccess": true, "extractionErrors": []}`,
+- Ejemplo correcto: {"licensePlate": "P0-123ABC", "make": "TOYOTA", "line": "COROLLA", "model": "2020", "use": "PARTICULAR", "seats": "5", "cc": "2000", "extractionSuccess": true, "extractionErrors": []}`,
 						},
 						{
 							role: "user",

--- a/apps/taller/src/components/vehicle-registration-ocr.tsx
+++ b/apps/taller/src/components/vehicle-registration-ocr.tsx
@@ -317,6 +317,12 @@ export default function VehicleRegistrationOCR({
                   {result.ocrData.motor && (
                     <div><strong>No. Motor:</strong> {result.ocrData.motor}</div>
                   )}
+                  {result.ocrData.use && (
+                    <div><strong>Uso:</strong> {result.ocrData.use}</div>
+                  )}
+                  {result.ocrData.seats && (
+                    <div><strong>Asientos:</strong> {result.ocrData.seats}</div>
+                  )}
                 </div>
               </div>
             )}

--- a/apps/taller/src/pages/vehicle-inspection.tsx
+++ b/apps/taller/src/pages/vehicle-inspection.tsx
@@ -61,6 +61,8 @@ const formSchema = z.object({
   origin: z.enum(["Nacional", "Importado"], { message: "La procedencia es requerida" }),
   vehicleType: z.string({ message: "El tipo de vehículo es requerido" }).min(1, { message: "El tipo de vehículo es requerido" }),
   color: z.string({ message: "El color es requerido" }).min(1, { message: "El color es requerido" }),
+  vehicleUse: z.string().optional(),
+  seats: z.string().optional(),
   cylinders: z.string({ message: "Los cilindros son requeridos" })
     .min(1, { message: "Los cilindros son requeridos" })
     .refine((val) => {
@@ -129,6 +131,8 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
       origin: undefined,
       vehicleType: "",
       color: "",
+      vehicleUse: "",
+      seats: "",
       cylinders: "",
       engineCC: "",
       fuelType: undefined,
@@ -203,10 +207,11 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
 
       setDuplicateVehicle(vehicle);
       
-      // Auto-cargar datos y comparar
-      selectVehicle(vehicle);
+      const ocrSource = ocrToMatch || rawOcrData || undefined;
       
-      const ocrSource = ocrToMatch || rawOcrData;
+      // Auto-cargar datos y comparar
+      selectVehicle(vehicle, ocrSource);
+      
       if (ocrSource) {
         recalculateMismatches(vehicle, ocrSource);
       } else {
@@ -227,36 +232,46 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
     const mismatches: string[] = [];
     const fieldsToCompare: Array<keyof FormValues> = [
       'vehicleMake', 'vehicleModel', 'vehicleYear', 'licensePlate', 
-      'vinNumber', 'motorNumber', 'color', 'vehicleType', 'cylinders', 'engineCC'
+      'vinNumber', 'motorNumber', 'color', 'vehicleType', 'cylinders', 'engineCC',
+      'vehicleUse', 'seats'
     ];
+
+    // Helper to normalize values for comparison
+    const normalize = (val: any) => {
+      if (val === null || val === undefined) return "";
+      return val.toString().trim().toUpperCase().replace(/^0+/, ''); // Remove leading zeros and normalize case
+    };
 
     fieldsToCompare.forEach(field => {
       // Map form field names to database vehicle property names
       const dbProp = field === 'vehicleMake' ? 'make' : 
                     field === 'vehicleModel' ? 'model' : 
-                    field === 'vehicleYear' ? 'year' : 
+                    field === 'vehicleYear' ? 'year' :
+                    field === 'vehicleUse' ? 'vehicleUse' : // Fix potential naming diff
                     field;
       
-      const dbValue = (dbVehicle[dbProp] || "").toString().trim().toUpperCase();
-      const ocrValue = (ocr[field] || "").toString().trim().toUpperCase();
+      const dbValue = normalize(dbVehicle[dbProp]);
+      const ocrValue = normalize(ocr[field]);
 
-      // Habilitamos para edición si:
-      // 1. El OCR leyó algo pero es DISTINTO a la DB.
-      // 2. El OCR NO pudo leer nada (está vacío).
-      if (!ocrValue || dbValue !== ocrValue) {
+      // Solo marcamos como "discrepancia" (alerta azul) si los valores normalizados son distintos
+      // y si el OCR realmente pudo leer algo
+      if (ocrValue && dbValue !== ocrValue) {
         mismatches.push(field);
       }
     });
 
     setComparisonMismatches(mismatches);
 
-    // Campos que siempre requieren revisión fresca del técnico
+    // Campos que siempre requieren revisión fresca del técnico (SIEMPRE EDITABLES)
     const alwaysEditable: Array<keyof FormValues> = [
       'technicianName', 'inspectionDate', 'kmMileage', 'milesMileage', 
       'fuelType', 'transmission', 'traction', 'testDrive', 'noTestDriveReason',
       'vinVerification', 'trim', 'origin'
     ];
     
+    // El técnico puede editar:
+    // 1. Las discrepancias reales detectadas (incluyendo Uso y Asientos si son lógicamente distintos)
+    // 2. Los campos que siempre deben ser editables
     setMismatchedFields([...mismatches, ...alwaysEditable]);
   };
 
@@ -280,35 +295,40 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
     }
   };
 
-  const selectVehicle = (vehicle: any) => {
+  const selectVehicle = (vehicle: any, ocrData?: Partial<FormValues>) => {
+    // Current OCR data if available to fill gaps in DB
+    const ocr = ocrData || rawOcrData || {};
+
     form.reset({
       ...form.getValues(),
-      vehicleMake: vehicle.make || "",
-      vehicleModel: vehicle.model || "",
-      trim: vehicle.trim || "",
-      vehicleYear: vehicle.year?.toString() || "",
-      licensePlate: vehicle.licensePlate || "",
-      vinNumber: vehicle.vinNumber || "",
-      motorNumber: vehicle.motorNumber || "",
-      vehicleType: vehicle.vehicleType || "",
-      color: vehicle.color || "",
-      cylinders: vehicle.cylinders || "",
-      engineCC: vehicle.engineCC || "",
-      fuelType: vehicle.fuelType as any,
-      transmission: vehicle.transmission as any,
-      traction: vehicle.traction as any,
-      origin: vehicle.origin as any,
-      kmMileage: vehicle.kmMileage?.toString() || "",
-      milesMileage: vehicle.milesMileage?.toString() || "",
-      vinVerification: false, // Default to unchecked as requested
-      vehicleId: vehicle.id, // Store the ID for the backend logic
+      vehicleId: vehicle.id,
+      vehicleMake: vehicle.make || ocr.vehicleMake || "",
+      vehicleModel: vehicle.model || ocr.vehicleModel || "",
+      trim: vehicle.trim || ocr.trim || "",
+      vehicleYear: vehicle.year?.toString() || ocr.vehicleYear || "",
+      licensePlate: vehicle.licensePlate || ocr.licensePlate || "",
+      vinNumber: vehicle.vinNumber || ocr.vinNumber || "",
+      motorNumber: vehicle.motorNumber || ocr.motorNumber || "",
+      vehicleType: vehicle.vehicleType || ocr.vehicleType || "",
+      color: vehicle.color || ocr.color || "",
+      vehicleUse: vehicle.vehicleUse || ocr.vehicleUse || "",
+      seats: vehicle.seats?.toString() || ocr.seats || "",
+      cylinders: vehicle.cylinders || ocr.cylinders || "",
+      engineCC: vehicle.engineCC || ocr.engineCC || "",
+      fuelType: (vehicle.fuelType || ocr.fuelType) as any,
+      transmission: (vehicle.transmission || ocr.transmission) as any,
+      traction: (vehicle.traction || ocr.traction) as any,
+      origin: (vehicle.origin || ocr.origin) as any,
+      kmMileage: vehicle.kmMileage?.toString() || ocr.kmMileage || "",
+      milesMileage: vehicle.milesMileage?.toString() || ocr.milesMileage || "",
+      vinVerification: false,
     });
     
     // Clear search results
     setSearchResults([]);
     setSearchTerm("");
     setSelectedVehicle(vehicle);
-    toast.success("Información del vehículo cargada correctamente");
+    toast.success("Información del vehículo cargada (Sincronizada con escaneo)");
   };
 
   useEffect(() => {
@@ -367,6 +387,8 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
       origin: undefined,
       vehicleType: "",
       color: "",
+      vehicleUse: "",
+      seats: "",
       cylinders: "",
       engineCC: "",
       fuelType: undefined,
@@ -644,7 +666,9 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
                               color: "Color",
                               vehicleType: "Tipo",
                               cylinders: "Cilindros",
-                              engineCC: "CC"
+                              engineCC: "CC",
+                              vehicleUse: "Uso",
+                              seats: "Asientos"
                             };
                             return labels[field] || field;
                           }).join(", ")}
@@ -944,6 +968,54 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
                           placeholder="Ej. 4" 
                           {...field} 
                           disabled={!!selectedVehicle && !mismatchedFields.includes("cylinders")}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-5">
+                <FormField
+                  control={form.control}
+                  name="vehicleUse"
+                  render={({ field, fieldState }) => (
+                    <FormItem>
+                      <FormLabel>Uso del vehículo</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        value={field.value}
+                        disabled={!!selectedVehicle && !mismatchedFields.includes("vehicleUse")}
+                      >
+                        <FormControl>
+                          <SelectTrigger className={cn("w-full", fieldState.error && "border-red-500")}>
+                            <SelectValue placeholder="Seleccione el uso" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="Particular">Particular</SelectItem>
+                          <SelectItem value="Comercial">Comercial</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="seats"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Asientos</FormLabel>
+                      <FormControl>
+                        <Input 
+                          placeholder="Ej. 5" 
+                          type="number"
+                          {...field} 
+                          value={field.value || ""}
+                          disabled={!!selectedVehicle && !mismatchedFields.includes("seats")}
                         />
                       </FormControl>
                       <FormMessage />

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -112,6 +112,7 @@ interface DashboardVehicle {
     aiReasoning?: string | null;
     aiCommercialClassificationReasoning?: string | null;
   } | null;
+  allInspections?: VehicleWithRelations['inspections'];
 }
 
 import { Button } from "@/components/ui/button";
@@ -384,6 +385,7 @@ export default function VehiclesDashboard() {
   const [selectedVehicle, setSelectedVehicle] = useState<DashboardVehicle | null>(null);
   const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState("details");
+  const [selectedInspectionIndex, setSelectedInspectionIndex] = useState(0);
   const [photoGalleryFilter, setPhotoGalleryFilter] = useState("all");
 
   // Pagination state
@@ -405,26 +407,28 @@ export default function VehiclesDashboard() {
     inspectionResult: "",
   });
 
-  const transformVehicleData = useCallback((vehicle: VehicleWithRelations): DashboardVehicle => {
-    // Get the latest inspection if available - sorted by date/createdAt descending
-    const latestInspection = vehicle.inspections && vehicle.inspections.length > 0
+  const transformVehicleData = useCallback((vehicle: VehicleWithRelations, inspectionIndex: number = 0): DashboardVehicle => {
+    // Get all inspections sorted by date descending
+    const allSortedInspections = vehicle.inspections && vehicle.inspections.length > 0
       ? [...vehicle.inspections].sort((a, b) => {
           const dateA = a.inspectionDate ? new Date(a.inspectionDate).getTime() : (a.createdAt ? new Date(a.createdAt).getTime() : 0);
           const dateB = b.inspectionDate ? new Date(b.inspectionDate).getTime() : (b.createdAt ? new Date(b.createdAt).getTime() : 0);
           return dateB - dateA;
-        })[0]
-      : null;
+        })
+      : [];
 
-    const aiVal = latestInspection ? (
-      (latestInspection as any).aiSuggestedValue ?? 
-      (latestInspection as any).ai_suggested_value ?? 
-      latestInspection.aiValuation?.suggestedValue
+    const targetInspection = allSortedInspections.length > 0 ? allSortedInspections[inspectionIndex] : null;
+
+    const aiVal = targetInspection ? (
+      (targetInspection as any).aiSuggestedValue ?? 
+      (targetInspection as any).ai_suggested_value ?? 
+      targetInspection.aiValuation?.suggestedValue
     ) : null;
 
     return {
       id: vehicle.id,
-      technicianName: latestInspection?.technicianName || 'N/A',
-      inspectionDate: latestInspection?.inspectionDate || vehicle.createdAt,
+      technicianName: targetInspection?.technicianName || 'N/A',
+      inspectionDate: targetInspection?.inspectionDate || vehicle.createdAt,
       vehicleMake: vehicle.make || '',
       vehicleModel: vehicle.model || '',
       vehicleYear: vehicle.year?.toString() || '',
@@ -440,42 +444,42 @@ export default function VehiclesDashboard() {
       cylinders: vehicle.cylinders || '',
       engineCC: vehicle.engineCC || '',
       transmission: vehicle.transmission || '',
-      vehicleRating: latestInspection?.vehicleRating || 'Pendiente',
-      marketValue: latestInspection?.marketValue || '0',
-      suggestedCommercialValue: latestInspection?.suggestedCommercialValue || '0',
-      currentConditionValue: latestInspection?.currentConditionValue || '0',
-      inspectionResult: latestInspection?.inspectionResult || 'Inspección pendiente',
-      airbagWarning: latestInspection?.airbagWarning ? 'Sí' : 'No',
-      testDrive: latestInspection?.testDrive ? 'Sí' : 'No',
-      status: latestInspection?.status || vehicle.status || 'pending',
-      photos: vehicle.photos?.length || 0,
-      allPhotos: latestInspection && vehicle.photos ? vehicle.photos.filter((p: any) => p.inspectionId === latestInspection.id || !p.inspectionId) : vehicle.photos || [],
-      hasScanner: latestInspection?.scannerUsed || false,
-      alerts: (latestInspection?.alerts as string[]) || [],
+      vehicleRating: targetInspection?.vehicleRating || 'Pendiente',
+      marketValue: targetInspection?.marketValue || '0',
+      suggestedCommercialValue: targetInspection?.suggestedCommercialValue || '0',
+      currentConditionValue: targetInspection?.currentConditionValue || '0',
+      inspectionResult: targetInspection?.inspectionResult || 'Inspección pendiente',
+      airbagWarning: targetInspection?.airbagWarning ? 'Sí' : 'No',
+      testDrive: targetInspection?.testDrive ? 'Sí' : 'No',
+      status: targetInspection?.status || vehicle.status || 'pending',
+      photos: (targetInspection && vehicle.photos ? vehicle.photos.filter((p: any) => p.inspectionId === targetInspection.id || !p.inspectionId) : vehicle.photos || []).length,
+      allPhotos: targetInspection && vehicle.photos ? vehicle.photos.filter((p: any) => p.inspectionId === targetInspection.id || !p.inspectionId) : vehicle.photos || [],
+      hasScanner: targetInspection?.scannerUsed || false,
+      alerts: (targetInspection?.alerts as string[]) || [],
       trim: vehicle.trim || '',
       traction: vehicle.traction || '',
-      tiresCondition: latestInspection?.tiresCondition ?? null,
-      tireConditionFrontLeft: latestInspection?.tireConditionFrontLeft ?? undefined,
-      tireConditionFrontRight: latestInspection?.tireConditionFrontRight ?? undefined,
-      tireConditionRearLeft: latestInspection?.tireConditionRearLeft ?? undefined,
-      tireConditionRearRight: latestInspection?.tireConditionRearRight ?? undefined,
-      hasSpareTire: latestInspection?.hasSpareTire ?? undefined,
-      tireConditionSpare: latestInspection?.tireConditionSpare ?? undefined,
-      paintCondition: latestInspection?.paintCondition ?? null,
-      hasAgencyHistory: latestInspection?.hasAgencyHistory ?? null,
-      aiValuation: latestInspection && aiVal != null
+      tiresCondition: targetInspection?.tiresCondition ?? null,
+      tireConditionFrontLeft: targetInspection?.tireConditionFrontLeft ?? undefined,
+      tireConditionFrontRight: targetInspection?.tireConditionFrontRight ?? undefined,
+      tireConditionRearLeft: targetInspection?.tireConditionRearLeft ?? undefined,
+      tireConditionRearRight: targetInspection?.tireConditionRearRight ?? undefined,
+      hasSpareTire: targetInspection?.hasSpareTire ?? undefined,
+      tireConditionSpare: targetInspection?.tireConditionSpare ?? undefined,
+      paintCondition: targetInspection?.paintCondition ?? null,
+      hasAgencyHistory: targetInspection?.hasAgencyHistory ?? null,
+      aiValuation: targetInspection && aiVal != null
         ? {
             aiSuggestedValue: aiVal != null ? Number(aiVal) : null,
-            aiMarketAnalysis: (latestInspection as any).aiMarketAnalysis ?? (latestInspection as any).ai_market_analysis ?? latestInspection.aiValuation?.marketAnalysis ?? null,
-            aiDepreciationFactors: (latestInspection as any).aiDepreciationFactors ?? (latestInspection as any).ai_depreciation_factors ?? latestInspection.aiValuation?.depreciationFactors ?? null,
-            aiConfidence: (latestInspection as any).aiConfidence ?? (latestInspection as any).ai_confidence ?? latestInspection.aiValuation?.confidence ?? null,
-            aiCommercialClassification: (latestInspection as any).aiCommercialClassification ?? (latestInspection as any).ai_commercial_classification ?? latestInspection.aiValuation?.commercialClassification ?? null,
-            aiReasoning: (latestInspection as any).aiReasoning ?? (latestInspection as any).ai_reasoning ?? latestInspection.aiValuation?.reasoning ?? null,
-            aiCommercialClassificationReasoning: (latestInspection as any).aiCommercialClassificationReasoning ?? (latestInspection as any).ai_commercial_classification_reasoning ?? latestInspection.aiValuation?.commercialClassificationReasoning ?? null,
+            aiMarketAnalysis: (targetInspection as any).aiMarketAnalysis ?? (targetInspection as any).ai_market_analysis ?? targetInspection.aiValuation?.marketAnalysis ?? null,
+            aiDepreciationFactors: (targetInspection as any).aiDepreciationFactors ?? (targetInspection as any).ai_depreciation_factors ?? targetInspection.aiValuation?.depreciationFactors ?? null,
+            aiConfidence: (targetInspection as any).aiConfidence ?? (targetInspection as any).ai_confidence ?? targetInspection.aiValuation?.confidence ?? null,
+            aiCommercialClassification: (targetInspection as any).aiCommercialClassification ?? (targetInspection as any).ai_commercial_classification ?? targetInspection.aiValuation?.commercialClassification ?? null,
+            aiReasoning: (targetInspection as any).aiReasoning ?? (targetInspection as any).ai_reasoning ?? targetInspection.aiValuation?.reasoning ?? null,
+            aiCommercialClassificationReasoning: (targetInspection as any).aiCommercialClassificationReasoning ?? (targetInspection as any).ai_commercial_classification_reasoning ?? targetInspection.aiValuation?.commercialClassificationReasoning ?? null,
           }
         : null,
-      failedChecks: latestInspection?.inspection360Items
-        ? latestInspection.inspection360Items
+      failedChecks: targetInspection?.inspection360Items
+        ? targetInspection.inspection360Items
           .filter(item => item.status !== 'OK' && item.status !== 'GOOD')
           .map(item => ({
             area: item.area,
@@ -485,8 +489,8 @@ export default function VehiclesDashboard() {
             metadata: item.metadata,
           }))
         : [],
-      checklistIssues: latestInspection?.checklistItems
-        ? latestInspection.checklistItems
+      checklistIssues: targetInspection?.checklistItems
+        ? targetInspection.checklistItems
           .filter(item => item.checked)
           .map(item => ({
             id: item.id,
@@ -496,9 +500,10 @@ export default function VehiclesDashboard() {
             evidence: item.evidence || [],
           }))
         : [],
-      all360Items: latestInspection?.inspection360Items || [],
-      allChecklistItems: latestInspection?.checklistItems || [],
-      rejectionEvidenceUrl: latestInspection?.rejectionEvidenceUrl,
+      all360Items: targetInspection?.inspection360Items || [],
+      allChecklistItems: targetInspection?.checklistItems || [],
+      rejectionEvidenceUrl: targetInspection?.rejectionEvidenceUrl,
+      allInspections: allSortedInspections,
     };
   }, []);
 
@@ -516,7 +521,7 @@ export default function VehiclesDashboard() {
 
       if (result) {
         setRawVehiclesData(result.data || []);
-        const transformedVehicles = (result.data || []).map(transformVehicleData);
+        const transformedVehicles = (result.data || []).map(v => transformVehicleData(v, 0));
         setVehicles(transformedVehicles);
         setTotalVehicles(result.total || 0);
       } else {
@@ -578,6 +583,7 @@ export default function VehiclesDashboard() {
     setIsModalLoading(true);
     setActiveTab("details");
     setPhotoGalleryFilter("all");
+    setSelectedInspectionIndex(0);
 
     // Initialize edit form with current values
     setEditForm({
@@ -1358,6 +1364,7 @@ export default function VehiclesDashboard() {
           setIsDetailsOpen(open);
           if (!open) {
             setActiveTab("details"); // Reset to default tab when closing
+            setSelectedInspectionIndex(0);
           }
         }}
       >
@@ -1372,23 +1379,67 @@ export default function VehiclesDashboard() {
               </DialogDescription>
             </div>
             {selectedVehicle && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="mt-0!"
-                disabled={isModalLoading}
-                onClick={async () => {
-                  try {
-                    await generateInspectionPdf(selectedVehicle);
-                  } catch (e) {
-                    console.error("Error al generar el informe de inspección en PDF:", e);
-                    toast.error("No se pudo generar el informe PDF. Inténtalo de nuevo más tarde.");
-                  }
-                }}
-              >
-                <FileText className="h-4 w-4 mr-2" />
-                Descargar Informe PDF
-              </Button>
+              <div className="flex items-center gap-3">
+                {/* Inspection selector */}
+                {(selectedVehicle?.allInspections?.length || 0) > 1 && (
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs font-semibold text-muted-foreground uppercase">Inspección:</span>
+                    <Select
+                      value={selectedInspectionIndex.toString()}
+                      onValueChange={(val) => {
+                        const newIndex = parseInt(val);
+                        setSelectedInspectionIndex(newIndex);
+                        const rawVehicle = rawVehiclesData.find(v => v.id === selectedVehicle.id);
+                        if (rawVehicle) {
+                          const transformed = transformVehicleData(rawVehicle, newIndex);
+                          setSelectedVehicle(transformed);
+                          // Also refresh edit form with the newly selected inspection data
+                          setEditForm({
+                            vehicleRating: transformed.vehicleRating,
+                            status: transformed.status,
+                            marketValue: transformed.marketValue,
+                            suggestedCommercialValue: transformed.suggestedCommercialValue,
+                            currentConditionValue: transformed.currentConditionValue,
+                            testDrive: transformed.testDrive,
+                            inspectionResult: transformed.inspectionResult,
+                          });
+                        }
+                      }}
+                    >
+                      <SelectTrigger className="w-[200px] h-9 text-xs">
+                        <SelectValue placeholder="Seleccionar fecha" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {selectedVehicle.allInspections?.map((inspection, idx) => (
+                          <SelectItem key={inspection.id} value={idx.toString()}>
+                            {inspection.inspectionDate
+                              ? format(new Date(inspection.inspectionDate), "dd/MM/yyyy", { locale: es })
+                              : "Sin fecha"}
+                            {idx === 0 && " (Última)"}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="mt-0!"
+                  disabled={isModalLoading}
+                  onClick={async () => {
+                    try {
+                      await generateInspectionPdf(selectedVehicle);
+                    } catch (e) {
+                      console.error("Error al generar el informe de inspección en PDF:", e);
+                      toast.error("No se pudo generar el informe PDF. Inténtalo de nuevo más tarde.");
+                    }
+                  }}
+                >
+                  <FileText className="h-4 w-4 mr-2" />
+                  Descargar Informe PDF
+                </Button>
+              </div>
             )}
           </DialogHeader>
 
@@ -1899,6 +1950,169 @@ export default function VehiclesDashboard() {
                 )}
               </TabsContent>
 
+              {/* ─── Historial de Inspecciones ─── */}
+              <TabsContent value="history" className="mt-4">
+                {(() => {
+                  const rawVehicle = rawVehiclesData.find(v => v.id === selectedVehicle?.id);
+                  const allInspections = selectedVehicle?.allInspections || [];
+
+                  if (allInspections.length === 0) {
+                    return (
+                      <div className="flex flex-col items-center justify-center py-16 text-center border border-dashed rounded-lg bg-muted/20">
+                        <History className="h-12 w-12 text-muted-foreground opacity-30 mb-3" />
+                        <p className="text-muted-foreground font-medium">No hay inspecciones registradas</p>
+                      </div>
+                    );
+                  }
+
+                  const insp = allInspections[selectedInspectionIndex];
+
+                  return (
+                    <div className="flex gap-4 min-h-[400px]">
+                      {/* Left: inspection list */}
+                      <div className="w-52 shrink-0 flex flex-col gap-2 border-r pr-4">
+                        <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-1">Inspecciones</p>
+                        {allInspections.map((inspection, idx) => {
+                          const date = inspection.inspectionDate
+                            ? format(new Date(inspection.inspectionDate), "dd MMM yyyy", { locale: es })
+                            : "Sin fecha";
+                          const isSelected = idx === selectedInspectionIndex;
+                          const statusColor =
+                            inspection.status === "approved"
+                              ? "text-green-600 bg-green-50 border-green-200"
+                              : inspection.status === "rejected"
+                              ? "text-red-600 bg-red-50 border-red-200"
+                              : "text-yellow-600 bg-yellow-50 border-yellow-200";
+                          const statusLabel =
+                            inspection.status === "approved" ? "Aprobado"
+                            : inspection.status === "rejected" ? "Rechazado"
+                            : "Pendiente";
+
+                          return (
+                            <button
+                              key={inspection.id}
+                              onClick={() => setSelectedInspectionIndex(idx)}
+                              className={cn(
+                                "w-full text-left rounded-lg border p-3 transition-all",
+                                isSelected
+                                  ? "border-primary bg-primary/5 ring-1 ring-primary/30"
+                                  : "border-muted hover:border-primary/40 hover:bg-muted/30"
+                              )}
+                            >
+                              <p className="font-semibold text-sm leading-tight">{date}</p>
+                              <p className="text-xs text-muted-foreground mt-0.5 truncate">{inspection.technicianName}</p>
+                              <span className={cn("inline-block mt-1.5 text-[10px] font-semibold px-1.5 py-0.5 rounded border", statusColor)}>
+                                {statusLabel}
+                              </span>
+                              {idx === 0 && (
+                                <span className="inline-block mt-1 ml-1 text-[10px] font-medium text-primary">· Última</span>
+                              )}
+                            </button>
+                          );
+                        })}
+                      </div>
+
+                      {/* Right: selected inspection detail */}
+                      {insp && (
+                        <div className="flex-1 overflow-y-auto space-y-4">
+                          <div className="flex flex-wrap items-center gap-2 pb-3 border-b">
+                            <Calendar className="h-4 w-4 text-muted-foreground" />
+                            <span className="text-sm font-medium">
+                              {insp.inspectionDate
+                                ? format(new Date(insp.inspectionDate), "PPP", { locale: es })
+                                : "Sin fecha"}
+                            </span>
+                            <span className="text-xs text-muted-foreground">· {insp.technicianName}</span>
+                            {renderStatusBadge(insp.status)}
+                            <Badge
+                              variant="outline"
+                              className={cn(
+                                "ml-auto",
+                                insp.vehicleRating === "Comercial"
+                                  ? "bg-green-100 text-green-800 border-green-300"
+                                  : "bg-red-100 text-red-800 border-red-300"
+                              )}
+                            >
+                              {insp.vehicleRating}
+                            </Badge>
+                          </div>
+
+                          {/* Values */}
+                          <div className="grid grid-cols-3 gap-3">
+                            {[
+                              { label: "Valor de Mercado", value: insp.marketValue },
+                              { label: "Valor Comercial Sugerido", value: insp.suggestedCommercialValue },
+                              { label: "Valor Condición Actual", value: insp.currentConditionValue },
+                            ].map(({ label, value }) => (
+                              <div key={label} className="rounded-lg border bg-muted/20 p-3">
+                                <p className="text-[10px] font-semibold uppercase text-muted-foreground tracking-wide">{label}</p>
+                                <p className="text-lg font-bold mt-1">
+                                  Q {Number(value || 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+
+                          {/* Inspection result */}
+                          <div className="rounded-lg border p-4 bg-muted/10">
+                            <p className="text-xs font-semibold uppercase text-muted-foreground tracking-wide mb-2">Resultado</p>
+                            <p className="text-sm leading-relaxed">{insp.inspectionResult}</p>
+                          </div>
+
+                          {/* Alerts */}
+                          {insp.alerts && (insp.alerts as string[]).length > 0 && (
+                            <div className="rounded-lg border border-red-200 bg-red-50 p-4">
+                              <p className="text-xs font-semibold uppercase text-red-700 tracking-wide mb-2">Alertas</p>
+                              <div className="flex flex-wrap gap-2">
+                                {(insp.alerts as string[]).map((alert: string, i: number) => (
+                                  <Badge key={i} variant="destructive" className="text-[10px]">{alert}</Badge>
+                                ))}
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Tires & Paint */}
+                          <div className="grid grid-cols-2 gap-3">
+                            <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
+                              <p className="text-[10px] font-semibold uppercase text-muted-foreground tracking-wide">Llantas (Promedio)</p>
+                              <div className="flex items-center gap-2">
+                                <Progress value={insp.tiresCondition || 0} className="h-2 flex-1" />
+                                <span className="text-xs font-bold">{insp.tiresCondition || 0}%</span>
+                              </div>
+                            </div>
+                            <div className="rounded-lg border bg-muted/20 p-3 space-y-2">
+                              <p className="text-[10px] font-semibold uppercase text-muted-foreground tracking-wide">Pintura</p>
+                              <div className="flex items-center gap-2">
+                                <Progress value={insp.paintCondition || 0} className="h-2 flex-1" />
+                                <span className="text-xs font-bold">{insp.paintCondition || 0}%</span>
+                              </div>
+                            </div>
+                          </div>
+
+                          {/* Photos of this inspection */}
+                          {(() => {
+                            const inspPhotos = rawVehicle?.photos?.filter(
+                              (p: any) => p.inspectionId === insp.id
+                            ) || [];
+                            if (inspPhotos.length === 0) return null;
+                            return (
+                              <div className="space-y-2">
+                                <p className="text-[10px] font-semibold uppercase text-muted-foreground tracking-wide">Fotos de esta inspección ({inspPhotos.length})</p>
+                                <div className="grid grid-cols-3 sm:grid-cols-5 gap-2">
+                                  {inspPhotos.slice(0, 10).map((photo: any, i: number) => (
+                                    <VehiclePhoto key={photo.id || i} photo={photo} index={i} />
+                                  ))}
+                                </div>
+                              </div>
+                            );
+                          })()}
+                        </div>
+                      )}
+                    </div>
+                  );
+                })()}
+              </TabsContent>
+
               <TabsContent value="photos" className="mt-4">
                 <div className="py-2">
                   <div className="flex flex-wrap gap-2 mb-6 border-b pb-4">
@@ -1927,8 +2141,7 @@ export default function VehiclesDashboard() {
 
                   <div className="space-y-8">
                     {(() => {
-                      const rawVehicle = rawVehiclesData.find(v => v.id === selectedVehicle?.id);
-                      const vehiclePhotos = rawVehicle?.photos || [];
+                      const vehiclePhotos = selectedVehicle?.allPhotos || [];
 
                       if (vehiclePhotos.length === 0) {
                         return (
@@ -1991,9 +2204,8 @@ export default function VehiclesDashboard() {
               <TabsContent value="scanner" className="mt-4">
                 <div className="py-4">
                   {(() => {
-                    const rawVehicle = rawVehiclesData.find(v => v.id === selectedVehicle?.id);
-                    const latestInspection = rawVehicle?.inspections?.[0];
-                    const scannerUrl = latestInspection?.scannerResultUrl;
+                    const currentInspection = selectedVehicle?.allInspections?.[selectedInspectionIndex];
+                    const scannerUrl = currentInspection?.scannerResultUrl;
 
                     if (!scannerUrl) {
                       return (

--- a/apps/taller/src/services/vehicles.ts
+++ b/apps/taller/src/services/vehicles.ts
@@ -21,6 +21,8 @@ export interface VehicleData {
   trim?: string;
   traction?: string;
   id?: string;
+  seats?: number | null;
+  vehicleUse?: string | null;
 }
 
 export interface InspectionData {
@@ -151,6 +153,8 @@ export const prepareInspectionData = (formData: any, sectionTimes?: Record<strin
     trim: formData.trim,
     traction: formData.traction,
     id: formData.vehicleId,
+    seats: formData.seats ? parseInt(formData.seats) : null,
+    vehicleUse: formData.vehicleUse || null,
   };
 
   const inspectionData: InspectionData = {


### PR DESCRIPTION
## fix: sincronización de `creditos_inversionistas_espejo` en actualización de crédito

### Problema
Al actualizar un crédito desde el modal de edición, los cambios en las cuotas y montos de los inversionistas se guardaban correctamente en `creditos_inversionistas` (tabla principal), pero **`creditos_inversionistas_espejo` no se actualizaba**, quedando con datos desactualizados.

### Causa raíz
Se identificaron tres puntos de falla en la cadena frontend → backend:

1. **Frontend (`ModalEditCredit.tsx`):** Cuando un inversionista espejo ya existía en DB, se inicializaba con su `monto_aportado` antiguo (de la DB) en lugar del valor actual del inversionista principal. Al cambiar el monto del principal en el form, el espejo no se actualizaba dinámicamente, enviando un valor stale al backend.

2. **Frontend (`ModalEditCredit.tsx`):** Para inversionistas sin espejo en DB, se retornaba un objeto vacío (`inversionista_id: 0, monto_aportado: 0`), que era filtrado antes de enviarse, resultando en un array `inversionistas_espejo` vacío o incompleto que nunca llegaba al backend.

3. **Backend (`updateCredit.ts`):** El bloque del espejo tenía lógica extra de "jalar cuota del padre" (`parentCuotas`) con una consulta adicional a DB, que era redundante ya que el frontend envía `cuota_inversionista` directamente con prioridad máxima dentro de `updateInvestors`.

### Cambios

**`carteraFront/src/private/cartera/components/ModalEditCredit.tsx`**
- Si existe espejo en DB: se usan los valores actuales del principal (`monto_aportado`, `cuota_inversionista`, porcentajes) en lugar del valor guardado en DB, manteniendo la sincronización.
- Si no existe espejo en DB: se copia el inversionista principal completo como fallback (en lugar de objeto vacío con ceros).

**`cartera-back/src/controllers/updateCredit.ts`**
- Se simplificó el bloque del espejo (paso 10) eliminando la consulta redundante de `parentCuotas`.
- Se agregó sincronización forzada en el backend: antes de llamar a `updateInvestors` para el espejo, se construye un `Map` con los `monto_aportado` del principal y se sobreescribe el `monto_aportado` del espejo. Esto garantiza paridad de datos independientemente de lo que envíe el frontend.

### Resultado
Después de guardar, ambas tablas tienen valores idénticos para `monto_aportado`, `monto_cash_in`, `monto_inversionista`, `cuota_inversionista` e `iva_*` por cada inversionista.
