### PR TITLE
feat: compra de cartera y creación de inversionistas desde CRM

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -359,39 +359,34 @@ export const addInvestorToCredit = async ({ body, set }: any) => {
             porcCashIn = new Big(porcentaje_cash_in);
             porcInversion = new Big(porcentaje_inversion ?? 80);
           } else {
-            // Buscar en ESTE crédito primero
-            const existenteEnPadre = inversionistasActuales.find(
-              (inv: any) => inv.inversionista_id === inversionista_id,
-            );
+            // Sin porcentajes explícitos → calcular la MODA desde TODOS los créditos del inversionista
+            const todosCreditos = await tx
+              .select({
+                porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
+                porcentaje_participacion_inversionista:
+                  creditos_inversionistas.porcentaje_participacion_inversionista,
+              })
+              .from(creditos_inversionistas)
+              .where(eq(creditos_inversionistas.inversionista_id, inversionista_id));
 
-            if (existenteEnPadre) {
-              porcCashIn = new Big(existenteEnPadre.porcentaje_cash_in);
-              porcInversion = new Big(
-                existenteEnPadre.porcentaje_participacion_inversionista,
-              );
-            } else {
-              // No existe en este crédito → buscar en CUALQUIER otro crédito
-              const [otroCredito] = await tx
-                .select({
-                  porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
-                  porcentaje_participacion_inversionista:
-                    creditos_inversionistas.porcentaje_participacion_inversionista,
-                })
-                .from(creditos_inversionistas)
-                .where(eq(creditos_inversionistas.inversionista_id, inversionista_id))
-                .limit(1);
-
-              if (otroCredito) {
-                // Encontró en otro crédito → jalar esos porcentajes
-                porcCashIn = new Big(otroCredito.porcentaje_cash_in);
-                porcInversion = new Big(
-                  otroCredito.porcentaje_participacion_inversionista,
-                );
-              } else {
-                // No existe en ningún crédito → defaults 80/20
-                porcCashIn = new Big(20);
-                porcInversion = new Big(80);
+            if (todosCreditos.length > 0) {
+              // Calcular la moda del porcentaje de inversión
+              const freq = new Map<string, number>();
+              for (const c of todosCreditos) {
+                const pct = String(Math.round(Number(c.porcentaje_participacion_inversionista ?? 0)));
+                freq.set(pct, (freq.get(pct) ?? 0) + 1);
               }
+              let modaInversion = "80";
+              let maxCount = 0;
+              for (const [pct, count] of freq) {
+                if (count > maxCount) { modaInversion = pct; maxCount = count; }
+              }
+              porcInversion = new Big(modaInversion);
+              porcCashIn = new Big(100).minus(porcInversion);
+            } else {
+              // No existe en ningún crédito → defaults 80/20
+              porcCashIn = new Big(20);
+              porcInversion = new Big(80);
             }
           }
 

--- a/apps/crm/apps/server/src/db/schema/investments.ts
+++ b/apps/crm/apps/server/src/db/schema/investments.ts
@@ -280,7 +280,7 @@ export const investmentAuditLog = pgTable("investment_audit_log", {
 // --- Investor Activity Log (acciones sobre inversionistas) ---
 export const investorActivityLogActionEnum = pgEnum(
 	"investor_activity_log_action",
-	["document_created", "document_deleted", "document_visibility_toggled"],
+	["document_created", "document_deleted", "document_visibility_toggled", "compra_cartera", "investor_created"],
 );
 
 export const investorActivityLog = pgTable("investor_activity_log", {

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -332,6 +332,9 @@ export const reportsAppRouter = {
 		investorDocumentsRouter.toggleInvestorDocumentVisibility,
 	deleteInvestorDocument: investorDocumentsRouter.deleteInvestorDocument,
 	getInvestorActivityLog: investorDocumentsRouter.getInvestorActivityLog,
+	getBancosCartera: investorDocumentsRouter.getBancosCartera,
+	compraCartera: investorDocumentsRouter.compraCartera,
+	crearInversionista: investorDocumentsRouter.crearInversionista,
 
 	// Accounting routes (Contabilidad)
 	getResumenGlobalInversionistas:

--- a/apps/crm/apps/server/src/routers/investor-documents.ts
+++ b/apps/crm/apps/server/src/routers/investor-documents.ts
@@ -143,6 +143,137 @@ export const investorDocumentsRouter = {
 			return result;
 		}),
 
+	// Bancos — catálogo desde cartera-back
+	getBancosCartera: crmCobrosOrInvestmentsProcedure
+		.handler(async () => {
+			return carteraBackClient.getBancos();
+		}),
+
+	// Crear inversionista — opcionalmente con compra de cartera
+	crearInversionista: investmentManagerProcedure
+		.input(
+			z.object({
+				nombre: z.string().min(1),
+				dpi: z.string().optional(),
+				email: z.string().email().optional(),
+				banco: z.number().nullable().optional(),
+				tipoCuenta: z.string().optional(),
+				numeroCuenta: z.string().optional(),
+				tipoReinversion: z.string().optional(),
+				montoReinversion: z.number().optional(),
+				moneda: z.enum(["quetzales", "dolares"]).optional(),
+				emiteFactura: z.boolean().optional(),
+				// Compra de cartera opcional
+				hacerCompraCartera: z.boolean().optional(),
+				montoCompraCartera: z.number().positive().optional(),
+				porcentajeInversion: z.number().min(0).max(100).optional(),
+				porcentajeCashIn: z.number().min(0).max(100).optional(),
+				fechaInicioParticipacion: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			// 1. Crear inversionista en cartera-back
+			const createResult = await carteraBackClient.createInvestor({
+				nombre: input.nombre,
+				dpi: input.dpi ? Number(input.dpi) : null,
+				email: input.email ?? null,
+				banco: input.banco ?? null,
+				tipo_cuenta: input.tipoCuenta ?? null,
+				numero_cuenta: input.numeroCuenta ?? null,
+				tipo_reinversion: input.tipoReinversion ?? "sin_reinversion",
+				monto_reinversion: input.montoReinversion ?? null,
+				moneda: input.moneda ?? "quetzales",
+				emite_factura: input.emiteFactura ?? false,
+			});
+
+			const created = createResult.data?.[0];
+			if (!created?.inversionista_id) {
+				throw new Error("No se pudo crear el inversionista en cartera");
+			}
+
+			// 2. Log de creación
+			await db.insert(investorActivityLog).values({
+				inversionistaId: created.inversionista_id,
+				action: "investor_created",
+				details: {
+					nombre: input.nombre,
+					dpi: input.dpi,
+					email: input.email,
+					moneda: input.moneda,
+				},
+				performedBy: context.session.user.id,
+				performedByName:
+					context.session.user.name ?? context.session.user.email,
+			});
+
+			// 3. Si pidió compra de cartera, ejecutarla con el ID del nuevo inversionista
+			let compraResult = null;
+			if (input.hacerCompraCartera && input.montoCompraCartera) {
+				compraResult = await carteraBackClient.compraCartera({
+					inversionista_id: created.inversionista_id,
+					monto_aportado: input.montoCompraCartera,
+					tipo_operacion: "compra_cartera",
+					porcentaje_inversion: input.porcentajeInversion,
+					porcentaje_cash_in: input.porcentajeCashIn,
+					fecha_inicio_participacion:
+						input.fechaInicioParticipacion || undefined,
+				});
+
+				// Log de compra de cartera
+				await db.insert(investorActivityLog).values({
+					inversionistaId: created.inversionista_id,
+					action: "compra_cartera",
+					details: {
+						monto_aportado: input.montoCompraCartera,
+						fecha_inicio_participacion: input.fechaInicioParticipacion,
+					},
+					performedBy: context.session.user.id,
+					performedByName:
+						context.session.user.name ?? context.session.user.email,
+				});
+			}
+
+			return {
+				success: true,
+				inversionista: created,
+				compraCartera: compraResult,
+			};
+		}),
+
+	// Compra de cartera — registra log y llama a cartera-back
+	compraCartera: investmentManagerProcedure
+		.input(
+			z.object({
+				inversionistaId: z.number().int().positive(),
+				montoAportado: z.number().positive(),
+				fechaInicioParticipacion: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			// 1. Llamar a cartera-back para registrar la compra
+			const result = await carteraBackClient.compraCartera({
+				inversionista_id: input.inversionistaId,
+				monto_aportado: input.montoAportado,
+				tipo_operacion: "compra_cartera",
+				fecha_inicio_participacion: input.fechaInicioParticipacion || undefined,
+			});
+
+			// 2. Registrar en investor_activity_log
+			await db.insert(investorActivityLog).values({
+				inversionistaId: input.inversionistaId,
+				action: "compra_cartera",
+				details: {
+					monto_aportado: input.montoAportado,
+					fecha_inicio_participacion: input.fechaInicioParticipacion,
+				},
+				performedBy: context.session.user.id,
+				performedByName:
+					context.session.user.name ?? context.session.user.email,
+			});
+
+			return result;
+		}),
+
 	// Solo manager/admin pueden ver el historial de actividad
 	getInvestorActivityLog: investmentManagerProcedure
 		.input(

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -947,6 +947,65 @@ export class CarteraBackClient {
 	}
 
 	// ========================================================================
+	// CREAR INVERSIONISTA
+	// ========================================================================
+
+	async createInvestor(input: {
+		nombre: string;
+		dpi?: number | null;
+		email?: string | null;
+		emite_factura?: boolean;
+		banco?: number | null;
+		tipo_cuenta?: string | null;
+		numero_cuenta?: string | null;
+		tipo_reinversion?: string | null;
+		monto_reinversion?: number | null;
+		moneda?: string;
+	}): Promise<{ message: string; data: { inversionista_id: number; nombre: string; [key: string]: any }[] }> {
+		const response = await this.request<{
+			message: string;
+			data: { inversionista_id: number; nombre: string; [key: string]: any }[];
+		}>("/investor", {
+			method: "POST",
+			body: JSON.stringify({
+				nombre: input.nombre,
+				dpi: input.dpi ?? null,
+				email: input.email ?? null,
+				emite_factura: input.emite_factura ?? false,
+				banco: input.banco ?? null,
+				tipo_cuenta: input.tipo_cuenta ?? null,
+				numero_cuenta: input.numero_cuenta ?? null,
+				tipo_reinversion: input.tipo_reinversion ?? "sin_reinversion",
+				monto_reinversion: input.monto_reinversion ?? null,
+				moneda: input.moneda ?? "quetzales",
+			}),
+		});
+		return response;
+	}
+
+	// ========================================================================
+	// COMPRA DE CARTERA
+	// ========================================================================
+
+	async compraCartera(input: {
+		inversionista_id: number;
+		monto_aportado: number;
+		tipo_operacion: "compra_cartera";
+		porcentaje_inversion?: number;
+		porcentaje_cash_in?: number;
+		fecha_inicio_participacion?: string;
+	}): Promise<{ success: boolean; message: string }> {
+		const response = await this.request<{
+			success: boolean;
+			message: string;
+		}>("/agregar-inversionista-credito", {
+			method: "POST",
+			body: JSON.stringify(input),
+		});
+		return response;
+	}
+
+	// ========================================================================
 	// CACHE MANAGEMENT
 	// ========================================================================
 

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
@@ -23,6 +23,7 @@ import {
 	Plus,
 	RefreshCw,
 	Shield,
+	ShoppingCart,
 	Trash2,
 	TrendingUp,
 	Upload,
@@ -42,6 +43,14 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { authClient } from "@/lib/auth-client";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
@@ -404,6 +413,7 @@ const ACTION_LABELS: Record<string, string> = {
 	document_created: "Documento creado",
 	document_deleted: "Documento eliminado",
 	document_visibility_toggled: "Visibilidad cambiada",
+	compra_cartera: "Compra de cartera",
 };
 
 const ACTION_COLORS: Record<string, string> = {
@@ -413,6 +423,8 @@ const ACTION_COLORS: Record<string, string> = {
 		"border-red-300 bg-red-50 text-red-700 dark:border-red-700 dark:bg-red-950 dark:text-red-300",
 	document_visibility_toggled:
 		"border-amber-300 bg-amber-50 text-amber-700 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-300",
+	compra_cartera:
+		"border-emerald-300 bg-emerald-50 text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950 dark:text-emerald-300",
 };
 
 function InvestorActivityLogSection({
@@ -656,6 +668,33 @@ function InvestorLiquidacionesPage() {
 	const [page, setPage] = useState(1);
 	const PER_PAGE = 25;
 
+	// Compra de cartera
+	const [compraCarteraOpen, setCompraCarteraOpen] = useState(false);
+	const [compraCarteraMonto, setCompraCarteraMonto] = useState("");
+	const [compraCarteraFecha, setCompraCarteraFecha] = useState(
+		new Date().toISOString().split("T")[0],
+	);
+
+	const queryClient = useQueryClient();
+	const compraCarteraMutation = useMutation({
+		...orpc.compraCartera.mutationOptions(),
+		onSuccess: () => {
+			toast.success("Compra de cartera registrada correctamente");
+			setCompraCarteraOpen(false);
+			setCompraCarteraMonto("");
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInvestorActivityLog.queryOptions({
+					input: { inversionistaId: investorIdNum },
+				}).queryKey,
+				refetchType: "all",
+			});
+			refetch();
+		},
+		onError: (err: any) => {
+			toast.error(err?.message ?? "Error al registrar compra de cartera");
+		},
+	});
+
 	// Fetch investor info by ID from cartera
 	const investorsQuery = useQuery({
 		...orpc.getInversionistas.queryOptions({
@@ -730,21 +769,34 @@ function InvestorLiquidacionesPage() {
 							<ArrowLeft className="h-5 w-5" />
 						</Link>
 					</Button>
-					<div className="flex items-center gap-3">
-						<div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
-							<Users className="h-5 w-5" />
+					<div className="flex flex-1 items-center justify-between">
+						<div className="flex items-center gap-3">
+							<div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+								<Users className="h-5 w-5" />
+							</div>
+							<div>
+								<h1 className="font-bold text-lg leading-tight">
+									{investor?.nombre ?? "Inversionista"}
+								</h1>
+								{investor?.dpi && (
+									<p className="flex items-center gap-1 text-muted-foreground text-xs">
+										<Shield className="h-3 w-3" />
+										{investor.dpi}
+									</p>
+								)}
+							</div>
 						</div>
-						<div>
-							<h1 className="font-bold text-lg leading-tight">
-								{investor?.nombre ?? "Inversionista"}
-							</h1>
-							{investor?.dpi && (
-								<p className="flex items-center gap-1 text-muted-foreground text-xs">
-									<Shield className="h-3 w-3" />
-									{investor.dpi}
-								</p>
-							)}
-						</div>
+						{isManager && (
+							<Button
+								variant="outline"
+								size="sm"
+								className="gap-2"
+								onClick={() => setCompraCarteraOpen(true)}
+							>
+								<ShoppingCart className="h-4 w-4" />
+								Compra de Cartera
+							</Button>
+						)}
 					</div>
 				</div>
 			</div>
@@ -1103,6 +1155,88 @@ function InvestorLiquidacionesPage() {
 					</Button>
 				</div>
 			)}
+
+			{/* Modal Compra de Cartera */}
+			<Dialog
+				open={compraCarteraOpen}
+				onOpenChange={(open) => {
+					setCompraCarteraOpen(open);
+					if (!open) setCompraCarteraMonto("");
+				}}
+			>
+				<DialogContent className="sm:max-w-md">
+					<DialogHeader>
+						<DialogTitle>Compra de Cartera</DialogTitle>
+						<DialogDescription>
+							Registrar una compra de cartera para{" "}
+							<span className="font-semibold">
+								{investor?.nombre ?? "este inversionista"}
+							</span>
+						</DialogDescription>
+					</DialogHeader>
+
+					<div className="space-y-4 py-2">
+						<div className="space-y-1.5">
+							<Label htmlFor="compra-monto">Monto aportado</Label>
+							<Input
+								id="compra-monto"
+								type="number"
+								min="0"
+								step="0.01"
+								placeholder="0.00"
+								value={compraCarteraMonto}
+								onChange={(e) => setCompraCarteraMonto(e.target.value)}
+							/>
+						</div>
+						<div className="space-y-1.5">
+							<Label htmlFor="compra-fecha">
+								Fecha inicio participación
+							</Label>
+							<Input
+								id="compra-fecha"
+								type="date"
+								value={compraCarteraFecha}
+								onChange={(e) => setCompraCarteraFecha(e.target.value)}
+							/>
+						</div>
+					</div>
+
+					<DialogFooter className="gap-2 sm:gap-0">
+						<Button
+							variant="outline"
+							onClick={() => {
+								setCompraCarteraOpen(false);
+								setCompraCarteraMonto("");
+							}}
+						>
+							Cancelar
+						</Button>
+						<Button
+							disabled={
+								compraCarteraMutation.isPending ||
+								!compraCarteraMonto ||
+								Number(compraCarteraMonto) <= 0
+							}
+							onClick={() => {
+								compraCarteraMutation.mutate({
+									inversionistaId: investorIdNum,
+									montoAportado: Number(compraCarteraMonto),
+									fechaInicioParticipacion: compraCarteraFecha || undefined,
+								});
+							}}
+						>
+							{compraCarteraMutation.isPending ? (
+								<>
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									Guardando...
+								</>
+							) : (
+								"Confirmar"
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.index.tsx
@@ -1,20 +1,41 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
 	ArrowRight,
 	Banknote,
 	CreditCard,
 	Landmark,
+	Loader2,
 	Mail,
+	Plus,
 	Search,
 	Shield,
 	Users,
 } from "lucide-react";
 import { useMemo, useState } from "react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { authClient } from "@/lib/auth-client";
+import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/inversiones/liquidaciones/")({
@@ -23,7 +44,71 @@ export const Route = createFileRoute("/inversiones/liquidaciones/")({
 
 function LiquidacionesInversionistas() {
 	const { data: session } = authClient.useSession();
+	const userRole = (session?.user as any)?.role ?? "";
+	const isManager = PERMISSIONS.canValidateInvestmentFunds(userRole);
 	const [search, setSearch] = useState("");
+
+	// Modal crear inversionista
+	const [crearOpen, setCrearOpen] = useState(false);
+	const [formNombre, setFormNombre] = useState("");
+	const [formDpi, setFormDpi] = useState("");
+	const [formEmail, setFormEmail] = useState("");
+	const [formBanco, setFormBanco] = useState("");
+	const [formTipoCuenta, setFormTipoCuenta] = useState("");
+	const [formNumeroCuenta, setFormNumeroCuenta] = useState("");
+	const [formMoneda, setFormMoneda] = useState("quetzales");
+	const [formEmiteFactura, setFormEmiteFactura] = useState(false);
+	const [formTipoReinversion, setFormTipoReinversion] = useState("sin_reinversion");
+	const [formMontoReinversion, setFormMontoReinversion] = useState("");
+	// Compra de cartera opcional
+	const [hacerCompra, setHacerCompra] = useState(false);
+	const [formMontoCompra, setFormMontoCompra] = useState("");
+	const [formPctInversion, setFormPctInversion] = useState("70");
+	const [formPctCashIn, setFormPctCashIn] = useState("30");
+	const [formFechaCompra, setFormFechaCompra] = useState(
+		new Date().toISOString().split("T")[0],
+	);
+
+	const queryClient = useQueryClient();
+
+	const resetForm = () => {
+		setFormNombre("");
+		setFormDpi("");
+		setFormEmail("");
+		setFormBanco("");
+		setFormTipoCuenta("");
+		setFormNumeroCuenta("");
+		setFormMoneda("quetzales");
+		setFormEmiteFactura(false);
+		setFormTipoReinversion("sin_reinversion");
+		setFormMontoReinversion("");
+		setHacerCompra(false);
+		setFormMontoCompra("");
+		setFormPctInversion("70");
+		setFormPctCashIn("30");
+		setFormFechaCompra(new Date().toISOString().split("T")[0]);
+	};
+
+	const crearMutation = useMutation({
+		...orpc.crearInversionista.mutationOptions(),
+		onSuccess: (data: any) => {
+			const msg = data.compraCartera
+				? "Inversionista creado y compra de cartera registrada"
+				: "Inversionista creado correctamente";
+			toast.success(msg);
+			setCrearOpen(false);
+			resetForm();
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInversionistas.queryOptions({
+					input: { page: 1, perPage: 100 },
+				}).queryKey,
+				refetchType: "all",
+			});
+		},
+		onError: (err: any) => {
+			toast.error(err?.message ?? "Error al crear inversionista");
+		},
+	});
 
 	const investorsQuery = useQuery({
 		...orpc.getInversionistas.queryOptions({
@@ -31,6 +116,12 @@ function LiquidacionesInversionistas() {
 		}),
 		enabled: !!session,
 	})
+
+	const bancosQuery = useQuery({
+		...orpc.getBancosCartera.queryOptions({ input: undefined as never }),
+		enabled: crearOpen,
+	});
+	const bancos = (bancosQuery.data as any) ?? [];
 
 	const investors = investorsQuery.data?.inversionistas ?? [];
 
@@ -68,12 +159,23 @@ function LiquidacionesInversionistas() {
 							className="pl-9"
 						/>
 					</div>
-					<div className="flex items-center gap-2 rounded-lg border bg-card px-3 py-2">
-						<Users className="h-4 w-4 text-muted-foreground" />
-						<div>
-							<p className="font-semibold text-sm">{investors.length}</p>
-							<p className="text-muted-foreground text-xs">Inversionistas</p>
+					<div className="ml-auto flex items-center gap-3">
+						<div className="flex items-center gap-2 rounded-lg border bg-card px-3 py-2">
+							<Users className="h-4 w-4 text-muted-foreground" />
+							<span className="font-semibold text-sm">
+								{investors.length} Inversionistas
+							</span>
 						</div>
+						{isManager && (
+							<Button
+								size="sm"
+								className="gap-2"
+								onClick={() => setCrearOpen(true)}
+							>
+								<Plus className="h-4 w-4" />
+								Crear Inversionista
+							</Button>
+						)}
 					</div>
 				</div>
 			</div>
@@ -206,6 +308,326 @@ function LiquidacionesInversionistas() {
 						</div>
 					)}
 			</div>
+
+			{/* Modal Crear Inversionista */}
+			<Dialog
+				open={crearOpen}
+				onOpenChange={(open) => {
+					setCrearOpen(open);
+					if (!open) resetForm();
+				}}
+			>
+				<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+					<DialogHeader>
+						<DialogTitle>Crear Inversionista</DialogTitle>
+						<DialogDescription>
+							Completa los datos del nuevo inversionista
+						</DialogDescription>
+					</DialogHeader>
+
+					<div className="space-y-4 py-2">
+						{/* Nombre */}
+						<div className="space-y-1.5">
+							<Label htmlFor="inv-nombre">Nombre *</Label>
+							<Input
+								id="inv-nombre"
+								value={formNombre}
+								onChange={(e) => setFormNombre(e.target.value)}
+								placeholder="Nombre completo"
+							/>
+						</div>
+
+						{/* DPI + Email */}
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1.5">
+								<Label htmlFor="inv-dpi">DPI</Label>
+								<Input
+									id="inv-dpi"
+									value={formDpi}
+									onChange={(e) => setFormDpi(e.target.value)}
+									placeholder="Número de DPI"
+								/>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="inv-email">Email</Label>
+								<Input
+									id="inv-email"
+									type="email"
+									value={formEmail}
+									onChange={(e) => setFormEmail(e.target.value)}
+									placeholder="correo@ejemplo.com"
+								/>
+							</div>
+						</div>
+
+						{/* Banco + Tipo cuenta */}
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1.5">
+								<Label htmlFor="inv-banco">Banco</Label>
+								<Select
+									value={formBanco}
+									onValueChange={setFormBanco}
+								>
+									<SelectTrigger id="inv-banco">
+										<SelectValue placeholder="Seleccionar banco..." />
+									</SelectTrigger>
+									<SelectContent>
+										{bancos.map((b: any) => (
+											<SelectItem
+												key={b.banco_id}
+												value={String(b.banco_id)}
+											>
+												{b.nombre}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="space-y-1.5">
+								<Label htmlFor="inv-tipo-cuenta">Tipo de cuenta</Label>
+								<Select
+									value={formTipoCuenta}
+									onValueChange={setFormTipoCuenta}
+								>
+									<SelectTrigger id="inv-tipo-cuenta">
+										<SelectValue placeholder="Seleccionar..." />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="AHORRO Q">Ahorro Q</SelectItem>
+										<SelectItem value="AHORRO $">Ahorro $</SelectItem>
+										<SelectItem value="MONETARIA Q">Monetaria Q</SelectItem>
+										<SelectItem value="MONETARIA $">Monetaria $</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+						</div>
+
+						{/* Número cuenta */}
+						<div className="space-y-1.5">
+							<Label htmlFor="inv-numero-cuenta">Número de cuenta</Label>
+							<Input
+								id="inv-numero-cuenta"
+								value={formNumeroCuenta}
+								onChange={(e) => setFormNumeroCuenta(e.target.value)}
+								placeholder="Número de cuenta bancaria"
+							/>
+						</div>
+
+						{/* Moneda + Factura */}
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1.5">
+								<Label htmlFor="inv-moneda">Moneda</Label>
+								<Select value={formMoneda} onValueChange={setFormMoneda}>
+									<SelectTrigger id="inv-moneda">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="quetzales">Quetzales (GTQ)</SelectItem>
+										<SelectItem value="dolares">Dólares (USD)</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							<div className="flex items-end pb-2">
+								<div className="flex items-center gap-2">
+									<Checkbox
+										id="inv-factura"
+										checked={formEmiteFactura}
+										onCheckedChange={(v) => setFormEmiteFactura(v === true)}
+									/>
+									<Label htmlFor="inv-factura">Emite factura</Label>
+								</div>
+							</div>
+						</div>
+
+						{/* Reinversión */}
+						<div className="grid grid-cols-2 gap-3">
+							<div className="space-y-1.5">
+								<Label htmlFor="inv-reinversion">Tipo reinversión</Label>
+								<Select
+									value={formTipoReinversion}
+									onValueChange={setFormTipoReinversion}
+								>
+									<SelectTrigger id="inv-reinversion">
+										<SelectValue />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="sin_reinversion">
+											Sin reinversión
+										</SelectItem>
+										<SelectItem value="reinversion_capital">Capital</SelectItem>
+										<SelectItem value="reinversion_interes">Interés</SelectItem>
+										<SelectItem value="reinversion_total">Total</SelectItem>
+										<SelectItem value="reinversion_variable">
+											Variable
+										</SelectItem>
+										<SelectItem value="reinversion_combinada">
+											Combinada
+										</SelectItem>
+									</SelectContent>
+								</Select>
+							</div>
+							{formTipoReinversion === "reinversion_variable" && (
+								<div className="space-y-1.5">
+									<Label htmlFor="inv-monto-reinversion">
+										Monto reinversión
+									</Label>
+									<Input
+										id="inv-monto-reinversion"
+										type="number"
+										min="0"
+										step="0.01"
+										value={formMontoReinversion}
+										onChange={(e) => setFormMontoReinversion(e.target.value)}
+										placeholder="0.00"
+									/>
+								</div>
+							)}
+						</div>
+
+						{/* Separador — Compra de cartera */}
+						<div className="rounded-lg border bg-muted/50 p-4 space-y-3">
+							<div className="flex items-center gap-2">
+								<Checkbox
+									id="inv-compra"
+									checked={hacerCompra}
+									onCheckedChange={(v) => setHacerCompra(v === true)}
+								/>
+								<Label htmlFor="inv-compra" className="font-semibold">
+									Hacer compra de cartera de una vez
+								</Label>
+							</div>
+
+							{hacerCompra && (
+								<div className="space-y-3">
+									<div className="grid grid-cols-2 gap-3">
+										<div className="space-y-1.5">
+											<Label htmlFor="inv-monto-compra">Monto aportado *</Label>
+											<Input
+												id="inv-monto-compra"
+												type="number"
+												min="0"
+												step="0.01"
+												placeholder="0.00"
+												value={formMontoCompra}
+												onChange={(e) => setFormMontoCompra(e.target.value)}
+											/>
+										</div>
+										<div className="space-y-1.5">
+											<Label htmlFor="inv-fecha-compra">
+												Fecha participación
+											</Label>
+											<Input
+												id="inv-fecha-compra"
+												type="date"
+												value={formFechaCompra}
+												onChange={(e) => setFormFechaCompra(e.target.value)}
+											/>
+										</div>
+									</div>
+									<div className="grid grid-cols-2 gap-3">
+										<div className="space-y-1.5">
+											<Label htmlFor="inv-pct-inv">% Inversión</Label>
+											<Input
+												id="inv-pct-inv"
+												type="number"
+												min="0"
+												max="100"
+												value={formPctInversion}
+												onChange={(e) => {
+													const val = e.target.value;
+													setFormPctInversion(val);
+													const num = Number(val);
+													if (!Number.isNaN(num)) {
+														setFormPctCashIn(String(100 - num));
+													}
+												}}
+											/>
+										</div>
+										<div className="space-y-1.5">
+											<Label htmlFor="inv-pct-cci">% CCI</Label>
+											<Input
+												id="inv-pct-cci"
+												type="number"
+												min="0"
+												max="100"
+												value={formPctCashIn}
+												onChange={(e) => {
+													const val = e.target.value;
+													setFormPctCashIn(val);
+													const num = Number(val);
+													if (!Number.isNaN(num)) {
+														setFormPctInversion(String(100 - num));
+													}
+												}}
+											/>
+										</div>
+									</div>
+								</div>
+							)}
+						</div>
+					</div>
+
+					<DialogFooter className="gap-2 sm:justify-between">
+						<Button
+							variant="outline"
+							onClick={() => {
+								setCrearOpen(false);
+								resetForm();
+							}}
+						>
+							Cancelar
+						</Button>
+						<Button
+							disabled={
+								crearMutation.isPending ||
+								!formNombre.trim() ||
+								(hacerCompra &&
+									(!formMontoCompra || Number(formMontoCompra) <= 0))
+							}
+							onClick={() => {
+								crearMutation.mutate({
+									nombre: formNombre.trim(),
+									dpi: formDpi.trim() || undefined,
+									email: formEmail.trim() || undefined,
+									banco: formBanco ? Number(formBanco) : null,
+									tipoCuenta: formTipoCuenta || undefined,
+									numeroCuenta: formNumeroCuenta.trim() || undefined,
+									moneda: formMoneda as "quetzales" | "dolares",
+									emiteFactura: formEmiteFactura,
+									tipoReinversion: formTipoReinversion,
+									montoReinversion: formMontoReinversion
+										? Number(formMontoReinversion)
+										: undefined,
+									hacerCompraCartera: hacerCompra,
+									montoCompraCartera: hacerCompra
+										? Number(formMontoCompra)
+										: undefined,
+									porcentajeInversion: hacerCompra
+										? Number(formPctInversion)
+										: undefined,
+									porcentajeCashIn: hacerCompra
+										? Number(formPctCashIn)
+										: undefined,
+									fechaInicioParticipacion: hacerCompra
+										? formFechaCompra || undefined
+										: undefined,
+								});
+							}}
+						>
+							{crearMutation.isPending ? (
+								<>
+									<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									Creando...
+								</>
+							) : hacerCompra ? (
+								"Crear y Comprar Cartera"
+							) : (
+								"Crear Inversionista"
+							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	)
 }


### PR DESCRIPTION
## Summary
- Agregar flujo completo de **compra de cartera** desde la página de liquidaciones del inversionista (modal con monto, fecha, porcentajes)
- Agregar flujo de **crear inversionista** desde el listado de liquidaciones, con opción de hacer compra de cartera de una vez (crea → toma ID → compra)
- Endpoint `getBancosCartera` para select dinámico de bancos en el modal
- Cálculo automático de la **moda** de porcentajes en el backend de cartera cuando no se envían explícitamente
- Registro de actividad (`investor_activity_log`) para creación de inversionistas y compras de cartera

## Archivos modificados
- `apps/cartera-back/src/controllers/addInvestorToCredit.ts` — cálculo de moda de porcentajes
- `apps/crm/apps/server/src/db/schema/investments.ts` — nuevas acciones en enum
- `apps/crm/apps/server/src/routers/investor-documents.ts` — endpoints crearInversionista, compraCartera, getBancosCartera
- `apps/crm/apps/server/src/routers/index.ts` — registro de endpoints
- `apps/crm/apps/server/src/services/cartera-back-client.ts` — métodos createInvestor y compraCartera
- `apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx` — modal compra de cartera
- `apps/crm/apps/web/src/routes/inversiones/liquidaciones.index.tsx` — modal crear inversionista + compra

## Test plan
- [ ] Crear inversionista sin compra de cartera y verificar que aparece en el listado
- [ ] Crear inversionista con compra de cartera marcada y verificar que se registran ambos logs
- [ ] Hacer compra de cartera desde la página de detalle del inversionista
- [ ] Verificar que el select de bancos carga correctamente
- [ ] Verificar que los porcentajes se calculan con la moda cuando no se envían
- [ ] Ejecutar `bun db:push` para sincronizar el nuevo valor del enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)