### PR TITLE
feat: display co-investors for pending mirror credits

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -5389,7 +5389,9 @@ export async function getCreditosEspejoPendientes(page: number = 1, pageSize: nu
   }
 
   // 2. Agrupar por inversionista
-  type CreditoSinInversionista = Omit<typeof pendientes[number], '_nombre_inversionista' | '_dpi' | '_email' | '_moneda'>;
+  type CreditoSinInversionista = Omit<typeof pendientes[number], '_nombre_inversionista' | '_dpi' | '_email' | '_moneda'> & {
+    otrosInversionistas: { nombre: string; monto_aportado: string }[];
+  };
 
   const agrupado = new Map<number, {
     inversionista_id: number;
@@ -5400,6 +5402,38 @@ export async function getCreditosEspejoPendientes(page: number = 1, pageSize: nu
     monto_reinversion: number;
     creditosPendientes: CreditoSinInversionista[];
   }>();
+
+  // 2.1 Obtener todos los inversionistas de los mismos créditos (sin importar status)
+  const creditoIds = [...new Set(pendientes.map((r) => r.credito_id))];
+
+  const otrosInversionistasRaw = creditoIds.length > 0
+    ? await db
+        .select({
+          credito_id: creditos_inversionistas_espejo.credito_id,
+          inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+          nombre: inversionistas.nombre,
+          monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+        })
+        .from(creditos_inversionistas_espejo)
+        .innerJoin(
+          inversionistas,
+          eq(creditos_inversionistas_espejo.inversionista_id, inversionistas.inversionista_id)
+        )
+        .where(inArray(creditos_inversionistas_espejo.credito_id, creditoIds))
+    : [];
+
+  // Agrupar otros inversionistas por credito_id para lookup rápido
+  const otrosPorCredito = new Map<number, { inversionista_id: number; nombre: string; monto_aportado: string }[]>();
+  for (const otro of otrosInversionistasRaw) {
+    if (!otrosPorCredito.has(otro.credito_id)) {
+      otrosPorCredito.set(otro.credito_id, []);
+    }
+    otrosPorCredito.get(otro.credito_id)!.push({
+      inversionista_id: otro.inversionista_id,
+      nombre: otro.nombre,
+      monto_aportado: otro.monto_aportado,
+    });
+  }
 
   for (const row of pendientes) {
     const { _nombre_inversionista, _dpi, _email, _moneda, ...creditoData } = row;
@@ -5416,7 +5450,18 @@ export async function getCreditosEspejoPendientes(page: number = 1, pageSize: nu
     }
     const grupo = agrupado.get(row.inversionista_id)!;
     grupo.monto_reinversion += parseFloat(creditoData.monto_aportado);
-    grupo.creditosPendientes.push(creditoData);
+
+    // Filtrar al inversionista actual y adjuntar los demás
+    const otrosEnEsteCredito = (otrosPorCredito.get(row.credito_id) || [])
+      .filter((o) => o.inversionista_id !== row.inversionista_id);
+
+    grupo.creditosPendientes.push({
+      ...creditoData,
+      otrosInversionistas: otrosEnEsteCredito.map((o) => ({
+        nombre: o.nombre,
+        monto_aportado: o.monto_aportado,
+      })),
+    });
   }
 
   let todos = Array.from(agrupado.values());

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -488,10 +488,18 @@ function InvestorCard({
                       </div>
                       <div className="flex items-center gap-4 mt-1 text-[11px] text-gray-500">
                         <span><b className="text-gray-800">{formatQ(credito.monto_aportado)}</b> aportado</span>
-                        <span>Cuota: {formatQ(credito.cuota_inversionista)}</span>
                         <span>{credito.porcentaje_participacion_inversionista}% part.</span>
-                        <span className="hidden sm:inline">Cash In: {formatQ(credito.monto_cash_in)} ({credito.porcentaje_cash_in}%)</span>
+                        <span>Cash In: {credito.porcentaje_cash_in}%</span>
                       </div>
+                      {credito.otrosInversionistas && credito.otrosInversionistas.length > 0 && (
+                        <div className="flex flex-wrap items-center gap-3 mt-1 text-[10px] text-gray-400">
+                          {credito.otrosInversionistas.map((otro, idx) => (
+                            <span key={idx}>
+                              {otro.nombre}: <b className="text-gray-600">{formatQ(otro.monto_aportado)}</b>
+                            </span>
+                          ))}
+                        </div>
+                      )}
                     </div>
 
                     {/* Botón quitar / cancelar */}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3419,6 +3419,10 @@ export interface CreditoEspejoPendiente {
   tipo_reinversion: string | null;
   numero_credito_sifco: string;
   nombre_usuario: string;
+  otrosInversionistas?: {
+    nombre: string;
+    monto_aportado: string;
+  }[];
 }
 
 export interface CreditCandidateInversionista {


### PR DESCRIPTION
- Update backend to fetch and group all investors sharing the same credits in pending mirror sessions.
- Display co-investors' names and contribution amounts in the frontend investor card.
- Refactor credit detail layout to improve readability of participation and cash-in data.
