### PR TITLE
feat: display investor quota in pending sessions view

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -488,6 +488,7 @@ function InvestorCard({
                       </div>
                       <div className="flex items-center gap-4 mt-1 text-[11px] text-gray-500">
                         <span><b className="text-gray-800">{formatQ(credito.monto_aportado)}</b> aportado</span>
+                        <span>Cuota: {formatQ(credito.cuota_inversionista)}</span>
                         <span>{credito.porcentaje_participacion_inversionista}% part.</span>
                         <span>Cash In: {credito.porcentaje_cash_in}%</span>
                       </div>


### PR DESCRIPTION
Adds the installment amount (cuota_inversionista) to the investor card details to provide more comprehensive credit information in the pending sessions component.
