### PR TITLE
fix: add treasury recipient to accepted portfolio purchase notifications

### DIFF
--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -38,6 +38,7 @@ const COMPRA_CARTERA_ACEPTADA_RECIPIENTS = {
     "lucia.s@clubcashin.com",
     "diego.a@sepresta.com",
     "sara.r@sepresta.com",
+    "caja@sepresta.com"
   ],
   cc: [
     "diego.l@clubcashin.com",


### PR DESCRIPTION
Includes "caja@sepresta.com" in the list of recipients notified when a portfolio purchase is accepted to ensure the treasury department is informed of the transaction.
