### PR TITLE
fix: update mirror credit status before notification processing

### DIFF
--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -200,6 +200,23 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
     }
 
 
+    // ── 4.5. Marcar el espejo como aceptado ──
+    // Pasamos a "pendiente_revision" todos los rows de los créditos que estén
+    // actualmente en "pendiente_compra_cartera".
+    const updateRes = await db
+      .update(creditos_inversionistas_espejo)
+      .set({ status: "pendiente_revision", updated_at: new Date() })
+      .where(
+        and(
+          inArray(creditos_inversionistas_espejo.credito_id, creditoIds),
+          eq(creditos_inversionistas_espejo.status, "pendiente_compra_cartera"),
+        ),
+      )
+      .returning({
+        credito_id: creditos_inversionistas_espejo.credito_id,
+        inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+      });
+
     // ── 4.6. Armar el header "VENTA DE CARTERA" a partir del inversionista
     //         que acaba de pasar de pendiente_revision → completado.
     //         Si hay exactamente 1 target, mostramos su Modalidad, Factura
@@ -291,23 +308,6 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
       usuarioNombre,
       usuarioEmail,
     });
-
-    // ── 6. Marcar el espejo como aceptado ──
-    // Pasamos a "pendiente_revision" todos los rows de los créditos que estén
-    // actualmente en "pendiente_compra_cartera".
-    const updateRes = await db
-      .update(creditos_inversionistas_espejo)
-      .set({ status: "pendiente_revision", updated_at: new Date() })
-      .where(
-        and(
-          inArray(creditos_inversionistas_espejo.credito_id, creditoIds),
-          eq(creditos_inversionistas_espejo.status, "pendiente_compra_cartera"),
-        ),
-      )
-      .returning({
-        credito_id: creditos_inversionistas_espejo.credito_id,
-        inversionista_id: creditos_inversionistas_espejo.inversionista_id,
-      });
 
     set.status = 200;
     return {

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -59,6 +59,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         )
       )
       .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
       .limit(1);
 
     if (creditoData.length === 0) {
@@ -90,6 +91,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         return {
           credito: currentCredit.creditos,
           usuario: currentCredit.usuarios,
+          asesor: currentCredit.asesores,
           cancelacion: cancelacion[0],
           flujo: "CANCELADO",
         };
@@ -442,6 +444,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       flujo: "ACTIVO",
       credito: currentCredit.creditos,
       usuario: currentCredit.usuarios,
+      asesor: currentCredit.asesores,
       cuotaActual,
       cuotaActualPagada,
       cuotaActualStatus,


### PR DESCRIPTION
Reorder the database update for credit mirror status to occur before notification headers are generated and emails are sent, ensuring the state is updated before the workflow continues.
