### PR TITLE
feat: implement pending portfolio purchase flag and enhance payment reporting

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -5,6 +5,7 @@ import { db } from "../database";
 import {
   admins,
   asesores,
+  creditos,
   creditos_inversionistas,
   creditos_inversionistas_espejo,
   inversionistas,
@@ -541,13 +542,13 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
 
           // ── Determinar el status del espejo según tipo_operacion ──
           // "reinversion" → "pendiente_reinversion"
-          // "compra_cartera" → "pendiente_revision" (queda esperando aprobación)
+          // "compra_cartera" → "pendiente_compra_cartera" (espera aceptación)
           // Solo el inversionista nuevo recibe este status.
           // Los demás inversionistas quedan como "completado".
           const statusEspejo =
             tipo_operacion === "reinversion"
               ? "pendiente_reinversion"
-              : "pendiente_revision";
+              : "pendiente_compra_cartera";
 
           const dataEspejoConStatus = dataEspejo.map((inv) => ({
             ...inv,
@@ -559,7 +560,7 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
             // Los demás se mantienen como "completado"
             status: (inv.inversionista_id === inversionista_id
                 ? statusEspejo
-                : "completado") as "pendiente_reinversion" | "pendiente_revision" | "completado",
+                : "completado") as "pendiente_reinversion" | "pendiente_compra_cartera" | "completado",
             updated_at: new Date(),
           }));
 
@@ -575,6 +576,20 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
             await tx
               .insert(creditos_inversionistas_espejo)
               .values(dataEspejoConStatus);
+          }
+
+          // ================================================================
+          // Activar bandera_reinversion en el crédito cuando sea compra_cartera
+          // Mientras el espejo esté en pendiente_compra_cartera, cofidi
+          // redirige los intereses del inversionista nuevo a CUBE.
+          // Se apaga en compraCarteraAceptada (o en replaceInvestorCredit
+          // si se cancela/reasigna).
+          // ================================================================
+          if (tipo_operacion === "compra_cartera") {
+            await tx
+              .update(creditos)
+              .set({ bandera_reinversion: true })
+              .where(eq(creditos.credito_id, credito_id));
           }
 
           // ================================================================

--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -217,6 +217,19 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
         inversionista_id: creditos_inversionistas_espejo.inversionista_id,
       });
 
+    // ── 4.5.1 Apagar bandera_reinversion de los créditos aceptados ──
+    // Ya no hay que redirigir intereses a CUBE: el espejo pasó a
+    // pendiente_revision y el nuevo inversionista empieza a cobrar.
+    if (updateRes.length > 0) {
+      const creditosAfectados = Array.from(
+        new Set(updateRes.map((r) => r.credito_id)),
+      );
+      await db
+        .update(creditos)
+        .set({ bandera_reinversion: false })
+        .where(inArray(creditos.credito_id, creditosAfectados));
+    }
+
     // ── 4.6. Armar el header "VENTA DE CARTERA" a partir del inversionista
     //         que acaba de pasar de pendiente_revision → completado.
     //         Si hay exactamente 1 target, mostramos su Modalidad, Factura

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1266,6 +1266,8 @@ interface GetPagosOptions {
   soloAplicados?: boolean;
   fechaAplicado?: string;
   fechaBoleta?: string;
+  fechaBoletaInicio?: string;
+  fechaBoletaFin?: string;
 }
 /**
  * 📊 Obtiene los pagos junto con su información detallada de créditos, usuarios, cuotas e inversionistas.
@@ -1296,6 +1298,8 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
     soloAplicados,
     fechaAplicado,
     fechaBoleta,
+    fechaBoletaInicio,
+    fechaBoletaFin,
   } = options;
 
   try {
@@ -1358,6 +1362,18 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
     if (fechaBoleta) {
       whereClauses.push(
         `(p.fecha_boleta AT TIME ZONE 'America/Guatemala')::date = '${fechaBoleta}'::date`
+      );
+    }
+    // 📅 Rango de fecha_boleta (zona Guatemala). Inclusivo en ambos extremos.
+    // Se puede usar combinado o por separado con fechaBoleta (exacta).
+    if (fechaBoletaInicio) {
+      whereClauses.push(
+        `(p.fecha_boleta AT TIME ZONE 'America/Guatemala')::date >= '${fechaBoletaInicio}'::date`
+      );
+    }
+    if (fechaBoletaFin) {
+      whereClauses.push(
+        `(p.fecha_boleta AT TIME ZONE 'America/Guatemala')::date <= '${fechaBoletaFin}'::date`
       );
     }
 
@@ -1435,8 +1451,12 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           'deudaTotal', c.deudatotal,
           'statusCredit', c."statusCredit",
           'porcentajeInteres', c.porcentaje_interes,
-          'fechaCreacion', c.fecha_creacion
+          'fechaCreacion', c.fecha_creacion,
+          'banderaReinversion', c.bandera_reinversion
         ) AS "credito",
+
+        -- 🚩 Bandera top-level: crédito con compra de cartera / reinversión pendiente
+        c.bandera_reinversion AS "banderaReinversion",
 
         -- 📅 Info de la cuota
         (
@@ -1569,6 +1589,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       monto_aplicado: r.monto_aplicado,
       origenPago: r.origenPago,
       credito: r.credito,
+      banderaReinversion: r.banderaReinversion ?? false,
       cuota: r.cuota,
       usuario: r.usuario,
       inversionistas: Array.isArray(r.inversionistas)
@@ -2369,8 +2390,11 @@ export async function getAbonosPorCuota(
     throw new Error(`No se encontró el crédito con SIFCO: ${numero_credito_sifco}`);
   }
 
-  // 2. Buscar la cuota
-  const [cuota] = await db
+  // 2. Buscar la(s) cuota(s) con ese numero_cuota
+  // Nota: pueden existir cuotas duplicadas con el mismo numero_cuota para un mismo
+  // credito (p. ej. tras regeneraciones de calendario). Se consideran todas para
+  // no perder pagos vinculados al cuota_id "viejo".
+  const cuotasMatch = await db
     .select({ cuota_id: cuotas_credito.cuota_id })
     .from(cuotas_credito)
     .where(
@@ -2378,14 +2402,15 @@ export async function getAbonosPorCuota(
         eq(cuotas_credito.credito_id, credito.credito_id),
         eq(cuotas_credito.numero_cuota, numero_cuota)
       )
-    )
-    .limit(1);
+    );
 
-  if (!cuota) {
+  if (cuotasMatch.length === 0) {
     throw new Error(`No se encontró la cuota ${numero_cuota} para el crédito ${numero_credito_sifco}`);
   }
 
-  // 3. Buscar los pagos de esa cuota
+  const cuotaIds = cuotasMatch.map((c) => c.cuota_id);
+
+  // 3. Buscar los pagos de esas cuotas
   const pagos = await db
     .select({
       pago_id: pagos_credito.pago_id,
@@ -2401,7 +2426,7 @@ export async function getAbonosPorCuota(
     .where(
       and(
         eq(pagos_credito.credito_id, credito.credito_id),
-        eq(pagos_credito.cuota_id, cuota.cuota_id)
+        inArray(pagos_credito.cuota_id, cuotaIds)
       )
     );
 

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -354,6 +354,13 @@ export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
           await tx.insert(creditos_inversionistas_espejo).values(dataEspejo);
         }
 
+        // ── Apagar bandera_reinversion del crédito ──
+        // Ya no hay pendientes: el espejo quedó todo en "completado".
+        await tx
+          .update(creditos)
+          .set({ bandera_reinversion: false })
+          .where(eq(creditos.credito_id, creditoId));
+
         resultados.push({
           credito_id: creditoId,
           numero_credito_sifco: creditoData.numero_credito_sifco,
@@ -760,6 +767,17 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
             .values(dataEspejoDestinoFinal);
         }
 
+        // ── Activar bandera_reinversion en el destino si es compra_cartera ──
+        // Mientras el espejo esté en pendiente_compra_cartera, cofidi redirige
+        // los intereses del inversionista nuevo a CUBE. Se apaga al aceptar
+        // la compra o si se limpia/cancela después.
+        if (tipo_operacion === "compra_cartera") {
+          await tx
+            .update(creditos)
+            .set({ bandera_reinversion: true })
+            .where(eq(creditos.credito_id, credito_destino_id));
+        }
+
         resultadosAsignacion.push({
           credito_destino_id,
           numero_credito_sifco: creditoDestino.numero_credito_sifco,
@@ -914,6 +932,14 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
           .insert(creditos_inversionistas_espejo)
           .values(dataEspejoOrigenConStatus);
       }
+
+      // ── Apagar bandera_reinversion del crédito origen ──
+      // El espejo del origen quedó todo en "completado": ya no hay
+      // inversionistas pendientes a quienes redirigir intereses.
+      await tx
+        .update(creditos)
+        .set({ bandera_reinversion: false })
+        .where(eq(creditos.credito_id, credito_espejo_removido_id));
 
       console.log(
         `   🧹 Crédito origen ${creditoOrigen.numero_credito_sifco} limpio - ${dataPadreOrigenFinal.length} inversionistas restantes`,

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -239,6 +239,8 @@ export const paymentRouter = new Elysia()
           soloAplicados,
           fechaAplicado,
           fechaBoleta,
+          fechaBoletaInicio,
+          fechaBoletaFin,
         } = query;
 
         // ✅ Si viene reportAdvisor=true, generamos el reporte Excel de asesores (sin inversionistas)
@@ -261,6 +263,8 @@ export const paymentRouter = new Elysia()
             soloAplicados,
             fechaAplicado,
             fechaBoleta,
+            fechaBoletaInicio,
+            fechaBoletaFin,
           });
           set.status = 200;
           return {
@@ -289,6 +293,8 @@ export const paymentRouter = new Elysia()
             soloAplicados,
             fechaAplicado,
             fechaBoleta,
+            fechaBoletaInicio,
+            fechaBoletaFin,
           });
           set.status = 200;
           return {
@@ -316,6 +322,8 @@ export const paymentRouter = new Elysia()
           soloAplicados,
           fechaAplicado,
           fechaBoleta,
+          fechaBoletaInicio,
+          fechaBoletaFin,
         });
 
         set.status = 200;
@@ -356,6 +364,8 @@ export const paymentRouter = new Elysia()
         soloAplicados: t.Optional(t.Boolean()),
         fechaAplicado: t.Optional(t.String({ format: "date" })),
         fechaBoleta: t.Optional(t.String({ format: "date" })),
+        fechaBoletaInicio: t.Optional(t.String({ format: "date" })),
+        fechaBoletaFin: t.Optional(t.String({ format: "date" })),
       }),
       response: {
         200: t.Object({

--- a/apps/cartera-back/src/scripts/compararFlujocapital.py
+++ b/apps/cartera-back/src/scripts/compararFlujocapital.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import openpyxl
+import psycopg2
+from decimal import Decimal
+
+EXCEL_PATH = r"C:\Users\Kelvin Palacios\Downloads\flujo).xlsx"
+SHEET = sys.argv[1] if len(sys.argv) > 1 else "marzo 2026"
+INVERSIONISTA_ID = 84
+
+DSN = os.environ.get("SUPABASE_DB_URL")
+if not DSN:
+    # Fallback: try reading from .env
+    with open(r"c:\Users\Kelvin Palacios\Documents\universe\apps\cartera-back\.env") as f:
+        for line in f:
+            if line.startswith("SUPABASE_DB_URL="):
+                DSN = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+
+# 1) Excel: SIFCO -> CAPITAL RESTANTE (col M = index 12, 0-based)
+wb = openpyxl.load_workbook(EXCEL_PATH, data_only=True)
+ws = wb[SHEET]
+excel = {}
+total_cap_restante = Decimal("0")
+for r in ws.iter_rows(min_row=5, values_only=True):
+    sifco, capital_restante = r[0], r[12]
+    if sifco is None:
+        continue
+    s = str(sifco).strip()
+    if s.endswith("_2"):
+        s = s[:-2]
+    cr = Decimal(str(capital_restante)) if capital_restante is not None else Decimal("0")
+    excel[s] = cr
+    total_cap_restante += cr
+
+print(f"=== EXCEL {SHEET} ===")
+print(f"Creditos: {len(excel)}")
+print(f"Total CAPITAL RESTANTE: {total_cap_restante:,.2f}")
+
+# 2) DB: SIFCO -> monto_aportado (inversionista 84)
+conn = psycopg2.connect(DSN)
+cur = conn.cursor()
+cur.execute(
+    """
+    SELECT c.numero_credito_sifco, cie.monto_aportado, c."statusCredit"
+    FROM cartera.creditos_inversionistas_espejo cie
+    JOIN cartera.creditos c ON c.credito_id = cie.credito_id
+    WHERE cie.inversionista_id = %s
+    """,
+    (INVERSIONISTA_ID,),
+)
+db = {}
+total_aportado = Decimal("0")
+status_map = {}
+for sifco, monto, status in cur.fetchall():
+    s = str(sifco).strip()
+    db[s] = Decimal(str(monto))
+    status_map[s] = status
+    total_aportado += Decimal(str(monto))
+
+print(f"\n=== DB ESPEJO (inv 84) ===")
+print(f"Creditos: {len(db)}")
+print(f"Total monto_aportado: {total_aportado:,.2f}")
+
+# 3) Comparar
+all_s = sorted(set(excel) | set(db))
+iguales, diffs, solo_excel, solo_db = 0, [], [], []
+for s in all_s:
+    e, d = excel.get(s), db.get(s)
+    if e is None:
+        solo_db.append((s, d, status_map.get(s)))
+    elif d is None:
+        solo_excel.append((s, e))
+    else:
+        diff = d - e
+        if abs(diff) > Decimal("0.01"):
+            diffs.append((s, e, d, diff, status_map.get(s)))
+        else:
+            iguales += 1
+
+print(f"\n=== RESUMEN ===")
+print(f"Coinciden (|diff|<=0.01): {iguales}")
+print(f"Con diferencia: {len(diffs)}")
+print(f"Solo en Excel: {len(solo_excel)}")
+print(f"Solo en DB: {len(solo_db)}")
+print(f"Diff global monto_aportado - capital_restante: {total_aportado - total_cap_restante:,.2f}")
+
+if diffs:
+    print(f"\n--- DIFERENCIAS (DB monto_aportado vs Excel capital_restante) ---")
+    print(f"{'SIFCO':<20} {'Excel CR':>15} {'DB Aport':>15} {'Diff':>15}  Status")
+    total_diff = Decimal("0")
+    # Mayores diferencias primero
+    for s, e, d, diff, st in sorted(diffs, key=lambda x: abs(x[3]), reverse=True):
+        print(f"{s:<20} {e:>15,.2f} {d:>15,.2f} {diff:>15,.2f}  {st}")
+        total_diff += diff
+    print(f"{'TOTAL DIFF':<20} {'':>15} {'':>15} {total_diff:>15,.2f}")
+
+if solo_excel:
+    print(f"\n--- SOLO EN EXCEL ({len(solo_excel)}) ---")
+    for s, e in solo_excel[:30]:
+        print(f"  {s:<20} {e:>15,.2f}")
+
+if solo_db:
+    print(f"\n--- SOLO EN DB ({len(solo_db)}) ---  (primeros 30)")
+    for s, d, st in solo_db[:30]:
+        print(f"  {s:<20} {d:>15,.2f}  {st}")
+
+cur.close()
+conn.close()

--- a/apps/cartera-back/src/scripts/exportarDiffFlujocapital.py
+++ b/apps/cartera-back/src/scripts/exportarDiffFlujocapital.py
@@ -1,0 +1,180 @@
+import os
+import sys
+import openpyxl
+from openpyxl.styles import Font, PatternFill, Alignment
+import psycopg2
+from decimal import Decimal
+from datetime import datetime, timezone, timedelta
+
+EXCEL_PATH = r"C:\Users\Kelvin Palacios\Downloads\flujo).xlsx"
+SHEET = sys.argv[1] if len(sys.argv) > 1 else "marzo 2026"
+INVERSIONISTA_ID = 84
+
+GT = timezone(timedelta(hours=-6))
+stamp = datetime.now(GT).strftime("%Y%m%d_%H%M")
+OUT_PATH = rf"C:\Users\Kelvin Palacios\Downloads\comparacion_flujocapital_{stamp}.xlsx"
+
+DSN = os.environ.get("SUPABASE_DB_URL")
+if not DSN:
+    with open(r"c:\Users\Kelvin Palacios\Documents\universe\apps\cartera-back\.env") as f:
+        for line in f:
+            if line.startswith("SUPABASE_DB_URL="):
+                DSN = line.split("=", 1)[1].strip().strip('"').strip("'")
+                break
+
+wb_in = openpyxl.load_workbook(EXCEL_PATH, data_only=True)
+ws = wb_in[SHEET]
+excel = {}
+total_cap_restante = Decimal("0")
+for r in ws.iter_rows(min_row=5, values_only=True):
+    sifco, capital_restante = r[0], r[12]
+    if sifco is None:
+        continue
+    s = str(sifco).strip()
+    sifco_original = s
+    if s.endswith("_2"):
+        s = s[:-2]
+    cr = Decimal(str(capital_restante)) if capital_restante is not None else Decimal("0")
+    excel[s] = (cr, sifco_original)
+    total_cap_restante += cr
+
+conn = psycopg2.connect(DSN)
+cur = conn.cursor()
+cur.execute(
+    """
+    SELECT c.numero_credito_sifco, cie.monto_aportado, c."statusCredit", u.nombre
+    FROM cartera.creditos_inversionistas_espejo cie
+    JOIN cartera.creditos c ON c.credito_id = cie.credito_id
+    LEFT JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+    WHERE cie.inversionista_id = %s
+    """,
+    (INVERSIONISTA_ID,),
+)
+db = {}
+total_aportado = Decimal("0")
+for sifco, monto, status, cliente in cur.fetchall():
+    s = str(sifco).strip()
+    monto = Decimal(str(monto))
+    db[s] = (monto, status, cliente)
+    total_aportado += monto
+cur.close()
+conn.close()
+
+all_s = sorted(set(excel) | set(db))
+rows_ok, rows_diff, rows_only_excel, rows_only_db = [], [], [], []
+
+for s in all_s:
+    e = excel.get(s)
+    d = db.get(s)
+    if e is None:
+        monto, status, cliente = d
+        rows_only_db.append([s, cliente, status, None, float(monto), None])
+    elif d is None:
+        cr, sifco_original = e
+        rows_only_excel.append([s, sifco_original, float(cr)])
+    else:
+        cr, sifco_original = e
+        monto, status, cliente = d
+        diff = monto - cr
+        categoria = "OK" if abs(diff) <= Decimal("0.01") else "DIFERENCIA"
+        row = [
+            s, sifco_original, cliente, status,
+            float(cr), float(monto), float(diff), categoria,
+        ]
+        if categoria == "OK":
+            rows_ok.append(row)
+        else:
+            rows_diff.append(row)
+
+rows_diff.sort(key=lambda r: abs(r[6]), reverse=True)
+
+wb = openpyxl.Workbook()
+wb.remove(wb.active)
+
+header_font = Font(bold=True, color="FFFFFF")
+header_fill = PatternFill("solid", fgColor="1F4E78")
+diff_fill = PatternFill("solid", fgColor="F8CBAD")
+ok_fill = PatternFill("solid", fgColor="C6EFCE")
+
+def write_sheet(name, headers, rows, highlight_col=None):
+    s = wb.create_sheet(name)
+    for c, h in enumerate(headers, 1):
+        cell = s.cell(1, c, h)
+        cell.font = header_font
+        cell.fill = header_fill
+        cell.alignment = Alignment(horizontal="center")
+    for r, row in enumerate(rows, 2):
+        for c, v in enumerate(row, 1):
+            cell = s.cell(r, c, v)
+            if isinstance(v, float):
+                cell.number_format = "#,##0.00"
+        if highlight_col is not None and len(row) > highlight_col:
+            val = row[highlight_col]
+            if isinstance(val, (int, float)) and abs(val) > 0.01:
+                for c in range(1, len(row) + 1):
+                    s.cell(r, c).fill = diff_fill
+    for col_cells in s.columns:
+        max_len = max((len(str(c.value)) if c.value is not None else 0) for c in col_cells)
+        s.column_dimensions[col_cells[0].column_letter].width = min(max_len + 2, 50)
+
+resumen = wb.create_sheet("Resumen")
+resumen["A1"] = "Comparación Flujocapital — capital_restante (Excel) vs monto_aportado (DB)"
+resumen["A1"].font = Font(bold=True, size=14)
+resumen["A3"] = "Hoja Excel analizada"
+resumen["B3"] = SHEET
+resumen["A4"] = "Archivo origen"
+resumen["B4"] = EXCEL_PATH
+resumen["A5"] = "Inversionista ID"
+resumen["B5"] = INVERSIONISTA_ID
+resumen["A6"] = "Fecha ejecución"
+resumen["B6"] = datetime.now(GT).strftime("%Y-%m-%d %H:%M GT")
+
+rows_sum = [
+    ("Créditos en Excel", len(excel), float(total_cap_restante)),
+    ("Créditos en DB", len(db), float(total_aportado)),
+    ("Coinciden (|diff|<=0.01)", len(rows_ok), None),
+    ("Con diferencia", len(rows_diff), sum(r[6] for r in rows_diff)),
+    ("Solo Excel", len(rows_only_excel), sum(r[2] for r in rows_only_excel)),
+    ("Solo DB", len(rows_only_db), sum(r[4] for r in rows_only_db)),
+    ("Diff global (DB - Excel)", "", float(total_aportado - total_cap_restante)),
+]
+resumen["A8"] = "Métrica"; resumen["B8"] = "Cantidad"; resumen["C8"] = "Monto"
+for c in ["A8", "B8", "C8"]:
+    resumen[c].font = header_font
+    resumen[c].fill = header_fill
+for i, (k, qty, amt) in enumerate(rows_sum, 9):
+    resumen.cell(i, 1, k)
+    resumen.cell(i, 2, qty)
+    if amt is not None:
+        cell = resumen.cell(i, 3, amt)
+        cell.number_format = "#,##0.00"
+resumen.column_dimensions["A"].width = 32
+resumen.column_dimensions["B"].width = 14
+resumen.column_dimensions["C"].width = 18
+
+write_sheet(
+    "Diferencias",
+    ["SIFCO_base", "SIFCO_excel", "Cliente", "Status", "Excel_capital_restante", "DB_monto_aportado", "Diff (DB-Excel)", "Categoria"],
+    rows_diff,
+    highlight_col=6,
+)
+write_sheet(
+    "Solo en Excel",
+    ["SIFCO_base", "SIFCO_excel", "Excel_capital_restante"],
+    rows_only_excel,
+)
+write_sheet(
+    "Solo en DB",
+    ["SIFCO", "Cliente", "Status", "Excel_capital_restante", "DB_monto_aportado", "_"],
+    [[r[0], r[1], r[2], r[3], r[4], r[5]] for r in rows_only_db],
+)
+write_sheet(
+    "Coinciden",
+    ["SIFCO_base", "SIFCO_excel", "Cliente", "Status", "Excel_capital_restante", "DB_monto_aportado", "Diff", "Categoria"],
+    rows_ok,
+)
+
+wb.save(OUT_PATH)
+print(f"OK: {OUT_PATH}")
+print(f"Excel total: {total_cap_restante:,.2f} | DB total: {total_aportado:,.2f}")
+print(f"OK={len(rows_ok)} DIFF={len(rows_diff)} SoloExcel={len(rows_only_excel)} SoloDB={len(rows_only_db)}")

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -264,6 +264,8 @@ export function PaymentsTable() {
   const [fechaFin, setFechaFin] = React.useState("");
   const [fechaAplicado, setFechaAplicado] = React.useState("");
   const [fechaBoleta, setFechaBoleta] = React.useState("");
+  const [fechaBoletaInicio, setFechaBoletaInicio] = React.useState("");
+  const [fechaBoletaFin, setFechaBoletaFin] = React.useState("");
 
   // Filtros de crédito
   const [sifco, setSifco] = React.useState("");
@@ -451,21 +453,23 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
     page,
     pageSize,
     numeroCredito: sifco || undefined,
-    // Fecha: modo simple, rango o aplicado (mutuamente excluyentes)
+    // Fecha: modo simple, rango, aplicado o boleta (mutuamente excluyentes)
     ...(modoFecha === "simple"
       ? { dia, mes, anio }
       : modoFecha === "rango"
         ? { fechaInicio: fechaInicio || undefined, fechaFin: fechaFin || undefined }
         : modoFecha === "aplicado"
           ? { fechaAplicado: fechaAplicado || undefined }
-          : { fechaBoleta: fechaBoleta || undefined }),
+          : {
+              fechaBoletaInicio: fechaBoletaInicio || undefined,
+              fechaBoletaFin: fechaBoletaFin || undefined,
+            }),
     categoriaCredito: categoriaCredito || undefined,
     formatoCredito: formatoCredito || undefined,
     soloAplicados,
     inversionistaId,
     usuarioNombre: usuarioNombre || undefined,
     validationStatus: validationStatusFilter || undefined,
-    fechaBoleta: fechaBoleta || undefined,
   });
 
   const pagos: PagoDataInvestor[] = data?.data || [];
@@ -497,14 +501,18 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
           ? { dia, mes, anio }
           : modoFecha === "rango"
             ? { fechaInicio: fechaInicio || undefined, fechaFin: fechaFin || undefined }
-            : { fechaAplicado: fechaAplicado || undefined }),
+            : modoFecha === "aplicado"
+              ? { fechaAplicado: fechaAplicado || undefined }
+              : {
+                  fechaBoletaInicio: fechaBoletaInicio || undefined,
+                  fechaBoletaFin: fechaBoletaFin || undefined,
+                }),
         categoriaCredito: categoriaCredito || undefined,
         formatoCredito: formatoCredito || undefined,
         soloAplicados,
         inversionistaId,
         usuarioNombre: usuarioNombre || undefined,
         validationStatus: validationStatusFilter || undefined,
-        fechaBoleta: fechaBoleta || undefined,
         excel: true,
       });
 
@@ -537,14 +545,18 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
           ? { dia, mes, anio }
           : modoFecha === "rango"
             ? { fechaInicio: fechaInicio || undefined, fechaFin: fechaFin || undefined }
-            : { fechaAplicado: fechaAplicado || undefined }),
+            : modoFecha === "aplicado"
+              ? { fechaAplicado: fechaAplicado || undefined }
+              : {
+                  fechaBoletaInicio: fechaBoletaInicio || undefined,
+                  fechaBoletaFin: fechaBoletaFin || undefined,
+                }),
         categoriaCredito: categoriaCredito || undefined,
         formatoCredito: formatoCredito || undefined,
         soloAplicados,
         inversionistaId,
         usuarioNombre: usuarioNombre || undefined,
         validationStatus: validationStatusFilter || undefined,
-        fechaBoleta: fechaBoleta || undefined,
         reportAdvisor: true,
       });
 
@@ -599,6 +611,8 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                 setFechaFin("");
                 setFechaAplicado("");
                 setFechaBoleta("");
+                setFechaBoletaInicio("");
+                setFechaBoletaFin("");
                 setCategoriaCredito("");
                 setFormatoCredito("");
                 setSoloAplicados(undefined);
@@ -625,28 +639,28 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
               <div className="flex gap-1 flex-wrap">
                 <button
                   type="button"
-                  onClick={() => { setModoFecha("simple"); setFechaInicio(""); setFechaFin(""); setFechaAplicado(""); setFechaBoleta(""); setPage(1); }}
+                  onClick={() => { setModoFecha("simple"); setFechaInicio(""); setFechaFin(""); setFechaAplicado(""); setFechaBoleta(""); setFechaBoletaInicio(""); setFechaBoletaFin(""); setPage(1); }}
                   className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "simple" ? "bg-blue-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
                 >
                   Fecha
                 </button>
                 <button
                   type="button"
-                  onClick={() => { setModoFecha("rango"); setDia(undefined); setFechaAplicado(""); setFechaBoleta(""); setPage(1); }}
+                  onClick={() => { setModoFecha("rango"); setDia(undefined); setFechaAplicado(""); setFechaBoleta(""); setFechaBoletaInicio(""); setFechaBoletaFin(""); setPage(1); }}
                   className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "rango" ? "bg-blue-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
                 >
                   Rango
                 </button>
                 <button
                   type="button"
-                  onClick={() => { setModoFecha("aplicado"); setDia(undefined); setFechaInicio(""); setFechaFin(""); setFechaBoleta(""); setPage(1); }}
+                  onClick={() => { setModoFecha("aplicado"); setDia(undefined); setFechaInicio(""); setFechaFin(""); setFechaBoleta(""); setFechaBoletaInicio(""); setFechaBoletaFin(""); setPage(1); }}
                   className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "aplicado" ? "bg-emerald-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
                 >
                   Aplicado
                 </button>
                 <button
                   type="button"
-                  onClick={() => { setModoFecha("boleta"); setDia(undefined); setFechaInicio(""); setFechaFin(""); setFechaAplicado(""); setPage(1); }}
+                  onClick={() => { setModoFecha("boleta"); setDia(undefined); setFechaInicio(""); setFechaFin(""); setFechaAplicado(""); setFechaBoleta(""); setPage(1); }}
                   className={`px-2 py-0.5 rounded-full text-[10px] font-semibold transition-all ${modoFecha === "boleta" ? "bg-amber-600 text-white shadow-sm" : "bg-gray-100 text-gray-600 hover:bg-gray-200"}`}
                 >
                   Boleta
@@ -716,23 +730,25 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                   />
                 </div>
               ) : (
-                <div>
-                  <label className="text-[10px] text-gray-500 font-medium mb-0.5 block">Fecha de Boleta</label>
-                  <DatePickerMUI
-                    value={fechaBoleta}
-                    onChange={(value) => { setFechaBoleta(value); setPage(1); }}
-                    disableFuture={false}
-                  />
+                <div className="space-y-1.5">
+                  <div>
+                    <label className="text-[10px] text-gray-500 font-medium mb-0.5 block">Boleta desde</label>
+                    <DatePickerMUI
+                      value={fechaBoletaInicio}
+                      onChange={(value) => { setFechaBoletaInicio(value); setPage(1); }}
+                      disableFuture={false}
+                    />
+                  </div>
+                  <div>
+                    <label className="text-[10px] text-gray-500 font-medium mb-0.5 block">Boleta hasta</label>
+                    <DatePickerMUI
+                      value={fechaBoletaFin}
+                      onChange={(value) => { setFechaBoletaFin(value); setPage(1); }}
+                      disableFuture={false}
+                    />
+                  </div>
                 </div>
               )}
-              <div className="pt-1">
-                <label className="text-[10px] text-gray-500 font-medium mb-0.5 block">Fecha de Boleta</label>
-                <DatePickerMUI
-                  value={fechaBoleta}
-                  onChange={(value) => { setFechaBoleta(value); setPage(1); }}
-                  disableFuture={false}
-                />
-              </div>
             </div>
 
             {/* Columna 2: Crédito y Usuario */}
@@ -1153,13 +1169,22 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                     </p>
 
                     {/* Badge de estado en móvil */}
-                    <div className="mt-2 flex items-center gap-2">
+                    <div className="mt-2 flex items-center gap-2 flex-wrap">
                       <span
                         className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full font-semibold text-sm ${statusConfig.bgColor} ${statusConfig.color}`}
                       >
                         {statusConfig.icon}
                         {statusConfig.label}
                       </span>
+                      {pago.banderaReinversion && (
+                        <span
+                          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full font-semibold text-sm bg-red-100 text-red-700"
+                          title="Mientras esté activa, los intereses del inversionista pendiente se redirigen a CUBE"
+                        >
+                          <AlertCircle className="w-4 h-4" />
+                          Compra cartera pendiente
+                        </span>
+                      )}
                     </div>
                   </div>
 
@@ -1556,7 +1581,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                     <div className="flex items-center justify-between">
                       {/* Info principal */}
                       <div className="flex-1">
-                        <div className="flex items-center gap-3 mb-3">
+                        <div className="flex items-center gap-3 mb-3 flex-wrap">
                           <h3 className="text-2xl font-bold text-blue-900">
                             #{pago.credito?.numeroCreditoSifco}
                           </h3>
@@ -1566,6 +1591,15 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                             {statusConfig.icon}
                             {statusConfig.label}
                           </span>
+                          {pago.banderaReinversion && (
+                            <span
+                              className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full font-semibold text-sm bg-red-100 text-red-700"
+                              title="Mientras esté activa, los intereses del inversionista pendiente se redirigen a CUBE"
+                            >
+                              <AlertCircle className="w-4 h-4" />
+                              Compra cartera pendiente
+                            </span>
+                          )}
                         </div>
 
                         {/* Stats Grid */}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1684,6 +1684,7 @@ export interface CreditoPago {
   statusCredit: string;
   porcentajeInteres: number;
   fechaCreacion: string;
+  banderaReinversion?: boolean;
 }
 
 // 🧍‍♂️ Información del usuario del crédito
@@ -1755,6 +1756,10 @@ export interface PagoDataInvestor {
   cuentaEmpresaNombre: string | null;
   cuentaEmpresaNumero: string | null;
 
+  // 🚩 Bandera del crédito: true mientras haya compra de cartera o reinversión pendiente.
+  // Cuando es true, cofidi redirige a CUBE los intereses del inversionista en ese status.
+  banderaReinversion?: boolean;
+
   // 🔄 Cancelación (solo presente en pagos reset)
   cancelacion?: CancelacionPago | null;
 }
@@ -1818,6 +1823,8 @@ export interface GetPagosParams {
   validationStatus?: string;
   reportAdvisor?: boolean;
   fechaBoleta?: string;
+  fechaBoletaInicio?: string;
+  fechaBoletaFin?: string;
 }
 
 /**


### PR DESCRIPTION
- Introduce `bandera_reinversion` to track credits with pending portfolio purchases, ensuring correct interest redirection while in transition.
- Add date range filtering for "Boleta" dates in the payments API and frontend table.
- Update `getAbonosPorCuota` to handle duplicate quota IDs during calendar regenerations.
- Add utility scripts for reconciling capital flow data between Excel and the database.
