### PR TITLE
feat: implement pending portfolio purchase flag and enhance payment reporting

### DIFF
--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -153,7 +153,11 @@ if (facturasExistentes.length > 0) {
         return { success: false, error: "Pago no encontrado" };
       }
 
-      if (pagoData.validationStatus !== "validated") {
+      if (
+        pagoData.validationStatus !== "validated" &&
+        pagoData.validationStatus !== "reset" &&
+        pagoData.validationStatus !== "capital"
+      ) {
         set.status = 400;
         console.error(
           `❌ Pago no validado - Status: ${pagoData.validationStatus}`


### PR DESCRIPTION
Corrects the payment validation logic by recognizing 'reset' and 'capital' as valid `validationStatus` values.

Previously, payments with these statuses were incorrectly flagged as unvalidated, resulting in a 400 error. This update ensures that such payments are processed without error.