### PR TITLE
feat: add fecha_inicio_participacion to investor data mapping and per…

### DIFF
--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -1,5 +1,5 @@
 import { db } from "../database";
-import { creditos_inversionistas_espejo } from "../database/db";
+import { creditos_inversionistas_espejo, creditos_inversionistas } from "../database/db";
 import { eq, inArray, and } from "drizzle-orm";
 import z from "zod";
 
@@ -62,6 +62,20 @@ export const completeEspejo = async ({ body, set }: any) => {
             inversionista_id: creditos_inversionistas_espejo.inversionista_id,
             status: creditos_inversionistas_espejo.status,
           });
+
+        const whereConditionsPadre = inversionista_id
+          ? and(
+              eq(creditos_inversionistas.credito_id, credito_id),
+              eq(creditos_inversionistas.inversionista_id, inversionista_id),
+            )
+          : eq(creditos_inversionistas.credito_id, credito_id);
+
+        await tx
+          .update(creditos_inversionistas)
+          .set({
+            fecha_inicio_participacion: new Date().toISOString().split('T')[0],
+          })
+          .where(whereConditionsPadre);
 
         resultados.push({
           credito_id,

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -519,6 +519,7 @@ export interface CreditoConInfo {
     porcentaje_participacion_inversionista: string;
     porcentaje_cash_in: string;
     cuota_inversionista: string;
+    fecha_inicio_participacion?: string;
   }[];
   resumen: {
     total_cash_in_monto: number;
@@ -543,6 +544,7 @@ export interface CreditoConInfo {
     monto_cash_in: string;
     monto_inversionista: string;
     cuota_inversionista: string;
+    fecha_inicio_participacion?: string;
   }[];
   fecha_inicio?: string | null;
 }
@@ -835,6 +837,7 @@ export async function getCreditosWithUserByMesAnio(
             creditos_inversionistas.porcentaje_participacion_inversionista,
           porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
           cuota_inversionista: creditos_inversionistas.cuota_inversionista,
+          fecha_inicio_participacion: creditos_inversionistas.fecha_inicio_participacion,
         })
         .from(creditos_inversionistas)
         .innerJoin(
@@ -863,6 +866,8 @@ export async function getCreditosWithUserByMesAnio(
             creditos_inversionistas_espejo.monto_inversionista,
           cuota_inversionista:
             creditos_inversionistas_espejo.cuota_inversionista,
+          fecha_inicio_participacion:
+            creditos_inversionistas_espejo.fecha_inicio_participacion,
         })
         .from(creditos_inversionistas_espejo)
         .innerJoin(

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -207,12 +207,13 @@ export function ListaCreditosPagos() {
     });
 
     const mappedInvestors = inversionistas.map((inv: any) => ({
-      inversionista_id: inv.inversionista_id,
+      inversionista_id: inv.inversionista_id || inv.inversionista?.inversionista_id,
       porcentaje_participacion: inv.porcentaje_participacion,
       monto_aportado: inv.monto_aportado,
       porcentaje_cash_in: inv.porcentaje_cash_in,
       porcentaje_inversion: inv.porcentaje_participacion_inversionista,
       cuota_inversionista: inv.cuota_inversionista ?? 0,
+      fecha_inicio_participacion: inv.fecha_inicio_participacion,
     }));
 
     setInvestorsToEdit(mappedInvestors);
@@ -220,12 +221,13 @@ export function ListaCreditosPagos() {
     // Mapeo seguro de espejo
     const mirrorData = credit.creditos_inversionistas_espejo || [];
     const mappedMirror = mirrorData.map((inv: any) => ({
-      inversionista_id: inv.inversionista_id,
+      inversionista_id: inv.inversionista_id || inv.inversionista?.inversionista_id,
       porcentaje_participacion: inv.porcentaje_participacion,
       monto_aportado: inv.monto_aportado,
       porcentaje_cash_in: inv.porcentaje_cash_in,
       porcentaje_inversion: inv.porcentaje_inversion,
       cuota_inversionista: inv.cuota_inversionista ?? 0,
+      fecha_inicio_participacion: inv.fecha_inicio_participacion,
     }));
 
     setInvestorsMirrorToEdit(mappedMirror);


### PR DESCRIPTION
###  Sincronización de Fechas de Participación y Corrección de Mapeo de Inversionistas

####  Descripción de los cambios:

**1. Backend (cartera-back):**
*   **Sincronización Fiscal/Espejo:** Se actualizó el controlador `completeEspejo.ts` para que, al confirmar una sesión, la `fecha_inicio_participacion` se registre atómicamente tanto en la tabla espejo como en la tabla padre (`creditos_inversionistas`).
*   **Integridad de Datos en API:** Se modificó el controlador de créditos (`credits.ts`) para incluir el campo `fecha_inicio_participacion` en los selects de inversionistas y espejos, y se actualizó la interfaz `CreditoConInfo` para asegurar la transferencia del campo al frontend.
*   **Ajuste de Reglas:** Se añadió el ID de inversionista `38` a las exclusiones de detección de pagos huérfanos en `investor.ts`.

**2. Frontend (cartera-front):**
*   **Mapeo Robusto de IDs:** Se refactorizó la lógica en `CreditsPaymentsData.tsx` para extraer correctamente el `inversionista_id` soportando tanto estructuras planas como anidadas (`inv.inversionista_id || inv.inversionista?.inversionista_id`).
*   **Corrección de Fechas en Modal:** Se habilitó el paso del campo `fecha_inicio_participacion` hacia el modal de edición, eliminando el fallback a fechas por defecto cuando el dato ya existe en DB.
*   **Independencia UI:** Se aseguró que la sección de "Datos Espejo" sea una fuente de verdad independiente del inversionista fiscal.

####  Problemas resueltos:
*   Corregido el error de Comboboxes vacíos ("Buscar inversionista...") en el modal de edición de créditos.
*   Resuelta la falta de sincronización de fechas al confirmar sesiones desde la cartera.
*   Asegurada la visualización de fechas reales del espejo en la interfaz de usuario.
