### PR TITLE
feat: pass inversionista_id to credit candidates query for filtered r…

### DIFF
--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -36,6 +36,7 @@ interface ScoreBreakdown {
   formato: number;
   cuotas: number;
   proximidad: number;
+  reinversion: number;
   total: number;
 }
 
@@ -74,6 +75,7 @@ const SCORE_PENALTY_PER_CUOTA = 30; // Reducido de 50 a 30
 const SCORE_PROXIMITY_BASE_FITS = 300; // Bono porque el capital del crédito cubre todo el monto
 const SCORE_PROXIMITY_HIGH = 200;      // Diferencia < 10%
 const SCORE_PROXIMITY_MED = 100;       // Diferencia < 25%
+const SCORE_REINVERSION = 3000;       // Prioridad para inversionistas existentes
 
 // ============================================================
 // FUNCIONES DE SCORING
@@ -132,7 +134,8 @@ function calcCapitalProximityBonus(
 
 export async function getCreditCandidates(
   monto?: number,
-  limit?: number
+  limit?: number,
+  inversionistaIdSolicitante?: number
 ): Promise<CreditCandidate[]> {
   console.log("\n🔍 ========== getCreditCandidates ==========");
   console.log(`   monto: ${monto ?? "no especificado"}`);
@@ -387,17 +390,18 @@ export async function getCreditCandidates(
     const invs = invsByCredito.get(credito_id) ?? [];
     const cubeInv = invs.find((i) => i.es_cube);
 
+    // Filtro Universal: Todo crédito candidato DEBE tener a Cube
+    if (!cubeInv) {
+      console.log(
+        `   ❌ [${numero_credito_sifco}] Descartado: Crédito sin participación de Cube (ID ${CUBE_ID})`
+      );
+      continue;
+    }
+
     // Identificar formato dinámicamente si viene null (para evitar saltarse validación de Pool)
     const actualFormadoCredito = formato_credito ?? (invs.length > 1 ? "Pool" : "Individual");
 
     if (actualFormadoCredito === "Pool") {
-      // No tiene a Cube → descartado
-      if (!cubeInv) {
-        console.log(
-          `   ❌ [${numero_credito_sifco}] Descartado: Pool sin Cube (ID ${CUBE_ID})`
-        );
-        continue;
-      }
 
       // VALIDACIÓN: Cube debe ser el líder del Pool.
       // Si existe algún otro inversionista con un monto estrictamente mayor, se descarta.
@@ -430,10 +434,19 @@ export async function getCreditCandidates(
     const capitalParaEvaluar = cubeInv ? cubeInv.monto_aportado : capitalActivoNum;
     const proximityBonus = monto !== undefined ? calcCapitalProximityBonus(capitalParaEvaluar, monto) : 0;
 
-    const score = SCORE_BASE + crmBonus + formatoBonus + cuotasBonus + proximityBonus;
+    // Bono de Reinversión: Si el inversionista ya tiene participación en este crédito
+    let reinversionBonus = 0;
+    if (inversionistaIdSolicitante !== undefined) {
+      const yaParticipa = invs.some((i) => i.inversionista_id === inversionistaIdSolicitante);
+      if (yaParticipa) {
+        reinversionBonus = SCORE_REINVERSION;
+      }
+    }
+
+    const score = SCORE_BASE + crmBonus + formatoBonus + cuotasBonus + proximityBonus + reinversionBonus;
 
     console.log(
-      `   ✅ [${numero_credito_sifco}] score=${score} (crm=${crmBonus}, fmt=${formatoBonus}, cuotas=${cuotasBonus}, prox=${proximityBonus})`
+      `   ✅ [${numero_credito_sifco}] score=${score} (crm=${crmBonus}, fmt=${formatoBonus}, cuotas=${cuotasBonus}, prox=${proximityBonus}, reinv=${reinversionBonus})`
     );
 
     candidates.push({
@@ -451,6 +464,7 @@ export async function getCreditCandidates(
         formato: formatoBonus,
         cuotas: cuotasBonus,
         proximidad: proximityBonus,
+        reinversion: reinversionBonus,
         total: score,
       },
       capital_evaluado: capitalParaEvaluar,

--- a/apps/cartera-back/src/routers/assignCapital.ts
+++ b/apps/cartera-back/src/routers/assignCapital.ts
@@ -30,6 +30,7 @@ export const assignCapitalRouter = new Elysia()
       monto: montoStr,
       solo_insertable: soloInsertableStr,
       minimo: minimoStr,
+      inversionista_id: inversionistaIdStr,
     } = query as Record<string, string | undefined>;
 
     // ── Validar monto ──────────────────────────────────────────
@@ -65,8 +66,17 @@ export const assignCapitalRouter = new Elysia()
       minimo = parsed;
     }
 
+    // ── Validar inversionista_id ───────────────────────────────
+    let inversionista_id: number | undefined;
+    if (inversionistaIdStr !== undefined) {
+      const parsed = Number(inversionistaIdStr);
+      if (!isNaN(parsed)) {
+        inversionista_id = parsed;
+      }
+    }
+
     try {
-      const allCandidates = await getCreditCandidates(monto, minimo);
+      const allCandidates = await getCreditCandidates(monto, minimo, inversionista_id);
 
       let result: CreditCandidate[];
 

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -286,7 +286,7 @@ function InvestorCard({
   const editingCredit = investor.creditosPendientes.find((c) => c.id === editingCreditId);
 
   const montoParaCandidatos = editingCredit ? Number(editingCredit.monto_aportado) : null;
-  const { data: candidates, isLoading: isLoadingCandidates } = useCreditCandidates(montoParaCandidatos);
+  const { data: candidates, isLoading: isLoadingCandidates } = useCreditCandidates(montoParaCandidatos, investor.inversionista_id);
 
   const destinos = useMemo(() => {
     if (!editingCreditId || !candidates) return [];

--- a/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
@@ -67,10 +67,10 @@ export function useReemplazarInversionistaCredito() {
   });
 }
 
-export function useCreditCandidates(monto: number | null) {
+export function useCreditCandidates(monto: number | null, inversionista_id?: number) {
   return useQuery<OtroCreditoDisponible[]>({
-    queryKey: [...creditCandidatesKeys.all, monto] as const,
-    queryFn: () => getCreditCandidatesService({ monto: monto! }),
+    queryKey: [...creditCandidatesKeys.all, monto, inversionista_id] as const,
+    queryFn: () => getCreditCandidatesService({ monto: monto!, inversionista_id }),
     enabled: monto !== null && monto > 0,
     staleTime: 1000 * 60 * 2,
     gcTime: 1000 * 60 * 5,

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3531,10 +3531,10 @@ export interface CandidatesResponse {
   candidates: OtroCreditoDisponible[];
 }
 
-export async function getCreditCandidatesService(params?: { monto?: number; minimo?: number }): Promise<OtroCreditoDisponible[]> {
+export async function getCreditCandidatesService(params?: { monto?: number; minimo?: number; inversionista_id?: number }): Promise<OtroCreditoDisponible[]> {
   const res = await api.get<CandidatesResponse>(
     `${API_URL}/assign-capital/candidates`,
-    { params: { monto: params?.monto, minimo: params?.minimo ?? 10 } }
+    { params: { monto: params?.monto, minimo: params?.minimo ?? 10, inversionista_id: params?.inversionista_id } }
   );
   return res.data.candidates;
 }


### PR DESCRIPTION
# Priorización de Reinversión y Filtro Estricto de Cube en Candidatos de Capital

## Objetivo
Optimizar el motor de búsqueda de candidatos para asignación de capital, asegurando la integridad de las inversiones y priorizando el fondeo total de créditos donde el inversionista ya tiene participación activa.

## Cambios Realizados

### Backend (cartera-back)
- **Filtro Universal de Cube:** Se implementó una validación obligatoria en getCreditCandidates para que únicamente se sugieran créditos donde Cube Investments S.A. tenga participación activa. Esto evita sugerir créditos cuyo capital pertenece íntegramente a terceros.
- **Bono de Reinversión:** Se agregó una lógica de puntuación que otorga 3,000 puntos adicionales (SCORE_REINVERSION) a los créditos donde el inversionista_id solicitante ya posee una inversión. Esto garantiza que aparezcan en el top de la lista para incentivar la reinversión.
- **Desglose de Score:** Se actualizó la interfaz ScoreBreakdown para incluir el campo reinversion, permitiendo total transparencia en el cálculo del puntaje desde los logs y la API.
- **Router:** Se habilitó la captura del parámetro inversionista_id desde los query params en el endpoint de candidatos.

### Frontend (carteraFront)
- **Integración de API:** Se actualizó el servicio getCreditCandidatesService para soportar el nuevo parámetro opcional inversionista_id.
- **Hooks de Datos:** Se modificó el hook useCreditCandidates para incluir el ID del inversionista en la queryKey, asegurando un cacheo correcto y refresco de datos por cada inversionista específico.
- **Interfaz de Sesiones Pendientes:** Se actualizó el componente SesionesPendientes.tsx para pasar el ID del inversionista al motor de búsqueda al momento de intentar reasignar o quitar un crédito pendiente.

## Verificación Realizada
1. **Filtro de Cube:** Se validó que créditos con dueños externos (sin Cube) ya no aparecen en la lista de candidatos.
2. **Prioridad:** Se verificó mediante logs que los créditos existentes para un inversionista reciben el bono de 3,000 pts y se posicionan al inicio de la lista.
3. **Cálculo de Montos:** Se confirmó que el capital disponible sugerido se basa estrictamente en la participación de Cube, no en el capital total del crédito.

---
*Nota: Este cambio no afecta la lógica de créditos de meses anteriores (filtros de fecha) previamente implementada.*
