### PR TITLE
feat(compra-cartera): vigencia 3 días hábiles con expiración automática

### DIFF
--- a/apps/cartera-back/schedule.ts
+++ b/apps/cartera-back/schedule.ts
@@ -1,6 +1,7 @@
 import schedule from 'node-schedule';
 import { procesarMoras } from './src/controllers/latefee';
 import { upsertEfectividadAsesores } from './src/controllers/paymentsByAdvisor';
+import { expirarCompraCarteraVencidas } from './src/controllers/expirarCompraCartera';
 
 const TZ_GUATEMALA = 'America/Guatemala';
 
@@ -35,6 +36,22 @@ export function iniciarTareasProgramadas() {
       console.log('✅ upsertEfectividadAsesores:', result.ok ? 'OK' : result.error);
     } catch (error) {
       console.error('❌ Error al ejecutar upsertEfectividadAsesores:', error);
+    }
+  });
+
+  // ⏰ Expira compras de cartera aceptadas vencidas - 00:00 hora Guatemala.
+  //    Vigencia: 3 días hábiles desde aceptada_at. Cualquier row del espejo
+  //    con status="pendiente_revision" cuya fecha de baja (expira + 1 hábil)
+  //    sea <= hoy en GT se devuelve a CUBE.
+  schedule.scheduleJob({ rule: '0 0 * * *', tz: TZ_GUATEMALA }, async () => {
+    console.log('🕛 Ejecutando expirarCompraCarteraVencidas a las 00:00 Guatemala...');
+    try {
+      const res = await expirarCompraCarteraVencidas();
+      console.log(
+        `✅ expirarCompraCartera: escaneados=${res.escaneados}, vencidos=${res.vencidos}, creditosProcesados=${res.creditosProcesados}`,
+      );
+    } catch (error) {
+      console.error('❌ Error al ejecutar expirarCompraCarteraVencidas:', error);
     }
   });
 

--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -16,41 +16,20 @@ import {
 import z from "zod";
 import { sendCompraCarteraAcceptedNotification } from "@cci/email";
 import { getVehicleDetailsBySifco } from "../services/crm.service";
+import {
+  calcularExpiracionCompraCartera,
+  formatFechaLargaGT,
+  nowGT,
+} from "../utils/functions/businessDays";
+import { COMPRA_CARTERA_RECIPIENTS } from "../utils/functions/compraCarteraRecipients";
 
 const JWT_SECRET = process.env.JWT_SECRET || "supersecreto";
 
 // ID fijo de CUBE INVESTMENTS S.A. (siempre va primero en el pool)
 const CUBE_INVESTMENT_ID = 86;
 
-// ================================================================
-// DESTINATARIOS DEL CORREO "COMPRA DE CARTERA ACEPTADA"
-// Lista hardcodeada solicitada por negocio: TO + CC.
-// ================================================================
-const COMPRA_CARTERA_ACEPTADA_RECIPIENTS = {
-  to: [
-    "info@clubcashin.com",
-    "contabilidad@sepresta.com",
-    "arturo.a@sepresta.com",
-    "juridico2@sepresta.com",
-    "richard.kachler@clubcashin.com",
-    "andres@sepresta.com",
-    "juridico@sepresta.com",
-    "asistentejuridico@sepresta.com",
-    "doris.analiss@sepresta.com",
-    "lucia.s@clubcashin.com",
-    "diego.a@sepresta.com",
-    "sara.r@sepresta.com",
-    "caja@sepresta.com",
-    "alexander.p@clubcashin.com",
-    "juan.r@clubcashin.com",
-    "roxana.g@clubcashin.com"
-  ],
-  cc: [
-    "diego.l@clubcashin.com",
-    "guillermo.v@sepresta.com",
-    "pablo.z@clubcashin.com",
-  ],
-};
+// Destinatarios fijos (compartidos con el correo de expiración): ver
+// src/utils/functions/compraCarteraRecipients.ts
 
 const compraCarteraAceptadaSchema = z.object({
   creditos: z
@@ -206,10 +185,16 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
 
     // ── 4.5. Marcar el espejo como aceptado ──
     // Pasamos a "pendiente_revision" todos los rows de los créditos que estén
-    // actualmente en "pendiente_compra_cartera".
+    // actualmente en "pendiente_compra_cartera". Registramos cuándo y quién.
+    const ahora = nowGT();
     const updateRes = await db
       .update(creditos_inversionistas_espejo)
-      .set({ status: "pendiente_revision", updated_at: new Date() })
+      .set({
+        status: "pendiente_revision",
+        updated_at: ahora,
+        aceptada_at: ahora,
+        aceptada_por: usuarioEmail ?? null,
+      })
       .where(
         and(
           inArray(creditos_inversionistas_espejo.credito_id, creditoIds),
@@ -325,21 +310,27 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
       }),
     );
 
+    const { expira, diaBaja } = calcularExpiracionCompraCartera(ahora);
+
     const mailRes = await sendCompraCarteraAcceptedNotification({
-      to: COMPRA_CARTERA_ACEPTADA_RECIPIENTS.to, 
-      cc: COMPRA_CARTERA_ACEPTADA_RECIPIENTS.cc,
+      to: COMPRA_CARTERA_RECIPIENTS.to,
+      cc: COMPRA_CARTERA_RECIPIENTS.cc,
       creditos: creditosParaEmail,
       pool,
       operacionInfo,
       notasAdicionales: notas_adicionales,
       usuarioNombre,
       usuarioEmail,
+      expiracion: {
+        fechaExpiraLabel: formatFechaLargaGT(expira),
+        fechaBajaLabel: formatFechaLargaGT(diaBaja),
+      },
     });
 
     set.status = 200;
     return {
       success: true,
-      message: `Notificación enviada a ${COMPRA_CARTERA_ACEPTADA_RECIPIENTS.to.length} destinatario(s) + ${COMPRA_CARTERA_ACEPTADA_RECIPIENTS.cc.length} en CC`,
+      message: `Notificación enviada a ${COMPRA_CARTERA_RECIPIENTS.to.length} destinatario(s) + ${COMPRA_CARTERA_RECIPIENTS.cc.length} en CC`,
       creditos_notificados: creditosRows.length,
       pool_size: pool.length,
       espejo_actualizados: updateRes.length,

--- a/apps/cartera-back/src/controllers/expirarCompraCartera.ts
+++ b/apps/cartera-back/src/controllers/expirarCompraCartera.ts
@@ -1,0 +1,159 @@
+import Big from "big.js";
+import { and, eq, isNotNull } from "drizzle-orm";
+import { sendCompraCarteraExpiradaNotification } from "@cci/email";
+import { db } from "../database";
+import {
+  creditos,
+  creditos_inversionistas_espejo,
+  inversionistas,
+  usuarios,
+} from "../database/db";
+import {
+  calcularExpiracionCompraCartera,
+  formatFechaLargaGT,
+  gtDateKey,
+  nowGT,
+} from "../utils/functions/businessDays";
+import { COMPRA_CARTERA_RECIPIENTS } from "../utils/functions/compraCarteraRecipients";
+import { returnPendingInvestorsToCube } from "./replaceInvestorCredit";
+
+// ================================================================
+// JOB: Expira compras de cartera aceptadas que no se completaron
+// dentro de los 3 días hábiles de vigencia.
+//
+// Regla:
+//   - aceptada_at → expira = aceptada_at + 3 días hábiles GT
+//   - diaBaja     = expira + 1 día hábil (siguiente lunes–viernes)
+//   - Al correr el job, si hoy (GT) >= diaBaja y el row sigue en
+//     "pendiente_revision", se considera vencido y se devuelve a CUBE.
+//
+// Corre cada día a las 00:00 GT (ver schedule.ts).
+// Al finalizar, manda correo a los mismos destinatarios del aviso de
+// aceptación indicando qué inversionista(s) y crédito(s) se cancelaron.
+// ================================================================
+export async function expirarCompraCarteraVencidas(): Promise<{
+  success: boolean;
+  escaneados: number;
+  vencidos: number;
+  creditosProcesados: number;
+  resultado?: unknown;
+}> {
+  const ahora = nowGT();
+  const hoyKey = gtDateKey(ahora);
+
+  // 1) Traer candidatos junto con nombre de inversionista, SIFCO y cliente.
+  //    Lo hacemos ANTES del return-to-cube porque ese paso limpia los rows
+  //    del espejo y perderíamos la info para el correo.
+  const candidatos = await db
+    .select({
+      id: creditos_inversionistas_espejo.id,
+      credito_id: creditos_inversionistas_espejo.credito_id,
+      inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+      inversionista_nombre: inversionistas.nombre,
+      aceptada_at: creditos_inversionistas_espejo.aceptada_at,
+      monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+      numero_credito_sifco: creditos.numero_credito_sifco,
+      cliente_nombre: usuarios.nombre,
+    })
+    .from(creditos_inversionistas_espejo)
+    .innerJoin(
+      inversionistas,
+      eq(
+        creditos_inversionistas_espejo.inversionista_id,
+        inversionistas.inversionista_id,
+      ),
+    )
+    .innerJoin(
+      creditos,
+      eq(creditos_inversionistas_espejo.credito_id, creditos.credito_id),
+    )
+    .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+    .where(
+      and(
+        eq(creditos_inversionistas_espejo.status, "pendiente_revision"),
+        isNotNull(creditos_inversionistas_espejo.aceptada_at),
+      ),
+    );
+
+  // 2) Filtrar a los que ya cumplieron diaBaja.
+  const vencidos = candidatos.filter((row) => {
+    if (!row.aceptada_at) return false;
+    const { diaBaja } = calcularExpiracionCompraCartera(row.aceptada_at);
+    return gtDateKey(diaBaja) <= hoyKey;
+  });
+
+  if (vencidos.length === 0) {
+    console.log(
+      `[expirarCompraCartera] ${candidatos.length} rows escaneados, ninguno vencido al ${hoyKey}`,
+    );
+    return {
+      success: true,
+      escaneados: candidatos.length,
+      vencidos: 0,
+      creditosProcesados: 0,
+    };
+  }
+
+  // 3) Créditos únicos a limpiar.
+  const creditoIds = Array.from(new Set(vencidos.map((r) => r.credito_id)));
+
+  console.log(
+    `[expirarCompraCartera] ${vencidos.length} row(s) vencidos en ${creditoIds.length} crédito(s) al ${hoyKey}, devolviendo a CUBE...`,
+  );
+
+  // 4) Reusar el controller existente. Mock set mínimo porque internamente
+  //    solo escribe set.status.
+  const mockSet: { status: number } = { status: 200 };
+  const resultado = await returnPendingInvestorsToCube({
+    body: { creditos: creditoIds },
+    set: mockSet,
+  });
+  const success = mockSet.status < 400;
+
+  // 5) Si la limpieza fue bien, agrupar por inversionista y mandar correo.
+  if (success) {
+    type CreditoInfo = {
+      numero_credito_sifco: string;
+      cliente_nombre: string;
+      monto_aportado: string;
+    };
+    const porInversionista = new Map<
+      number,
+      { inversionista_nombre: string; creditos: CreditoInfo[] }
+    >();
+    for (const row of vencidos) {
+      const entry = porInversionista.get(row.inversionista_id) ?? {
+        inversionista_nombre: row.inversionista_nombre,
+        creditos: [],
+      };
+      entry.creditos.push({
+        numero_credito_sifco: row.numero_credito_sifco,
+        cliente_nombre: row.cliente_nombre,
+        monto_aportado: new Big(row.monto_aportado).toFixed(2),
+      });
+      porInversionista.set(row.inversionista_id, entry);
+    }
+
+    try {
+      await sendCompraCarteraExpiradaNotification({
+        to: COMPRA_CARTERA_RECIPIENTS.to,
+        cc: COMPRA_CARTERA_RECIPIENTS.cc,
+        inversionistas: Array.from(porInversionista.values()),
+        fechaEjecucionLabel: formatFechaLargaGT(ahora),
+      });
+    } catch (mailErr) {
+      console.error(
+        "[expirarCompraCartera] Falló el envío del correo de expiración:",
+        mailErr,
+      );
+    }
+  }
+
+  return {
+    success,
+    escaneados: candidatos.length,
+    vencidos: vencidos.length,
+    creditosProcesados: creditoIds.length,
+    resultado,
+  };
+}

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -367,6 +367,8 @@
       updated_at: timestamp("updated_at").defaultNow(),
       tipo_reinversion: tipoReinversionEnum("tipo_reinversion"),
       status: statusCreditoInversionistaEspejoEnum("status").notNull().default("completado"),
+      aceptada_at: timestamp("aceptada_at", { withTimezone: true }),
+      aceptada_por: text("aceptada_por"),
     },
     (t) => ({
       uxCreditoInvEspejo: uniqueIndex("ux_credito_inversionista_espejo").on(t.credito_id, t.inversionista_id),

--- a/apps/cartera-back/src/utils/functions/businessDays.ts
+++ b/apps/cartera-back/src/utils/functions/businessDays.ts
@@ -1,0 +1,88 @@
+// Helpers de días hábiles en zona America/Guatemala (UTC-6, sin DST).
+// Días hábiles = lunes a viernes. No considera feriados (se puede extender
+// en el futuro con una lista si Negocio la pide).
+
+const GT_TZ = "America/Guatemala";
+
+/**
+ * Instante actual. El valor devuelto es el mismo `new Date()`, pero el
+ * nombre deja explícito que cualquier formateo/interpretación posterior
+ * debe hacerse en zona `America/Guatemala`. Al guardarlo en columnas
+ * `timestamptz` Postgres lo almacena en UTC y el cliente lo convierte a
+ * la zona de su sesión al leer.
+ */
+export function nowGT(): Date {
+	return new Date();
+}
+
+function gtYMD(d: Date): { y: number; m: number; day: number } {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone: GT_TZ,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).formatToParts(d);
+	const get = (k: string) =>
+		Number(parts.find((p) => p.type === k)?.value ?? "0");
+	return { y: get("year"), m: get("month"), day: get("day") };
+}
+
+/**
+ * Devuelve una nueva Date igual a `from` pero avanzada `days` días hábiles
+ * (lun–vie) contados en zona Guatemala. La Date retornada apunta al mediodía
+ * UTC del día resultante para evitar ambigüedades por DST/tz.
+ */
+export function addBusinessDaysGT(from: Date, days: number): Date {
+	if (days <= 0) {
+		const { y, m, day } = gtYMD(from);
+		return new Date(Date.UTC(y, m - 1, day, 12, 0, 0));
+	}
+	const { y, m, day } = gtYMD(from);
+	let d = new Date(Date.UTC(y, m - 1, day, 12, 0, 0));
+	let remaining = days;
+	while (remaining > 0) {
+		d = new Date(d.getTime() + 24 * 60 * 60 * 1000);
+		const dow = d.getUTCDay(); // 0=Dom, 6=Sáb
+		if (dow !== 0 && dow !== 6) remaining--;
+	}
+	return d;
+}
+
+/**
+ * Resumen de expiración para la compra de cartera.
+ * - `expira`: último día hábil de vigencia (fromDate + 3 hábiles).
+ * - `diaBaja`: siguiente día hábil después de `expira` — el día en que
+ *   el job automático la dará de baja a las 00:00 GT.
+ */
+export function calcularExpiracionCompraCartera(fromDate: Date): {
+	expira: Date;
+	diaBaja: Date;
+} {
+	const expira = addBusinessDaysGT(fromDate, 3);
+	const diaBaja = addBusinessDaysGT(expira, 1);
+	return { expira, diaBaja };
+}
+
+/**
+ * Devuelve el día calendario en zona GT como `"YYYY-MM-DD"`. Útil para
+ * comparar fechas sin que horas/minutos metan ruido.
+ */
+export function gtDateKey(d: Date): string {
+	const { y, m, day } = gtYMD(d);
+	return `${y.toString().padStart(4, "0")}-${m
+		.toString()
+		.padStart(2, "0")}-${day.toString().padStart(2, "0")}`;
+}
+
+/**
+ * Formatea una fecha como "lunes 27 de abril de 2026" en es-GT.
+ */
+export function formatFechaLargaGT(d: Date): string {
+	return new Intl.DateTimeFormat("es-GT", {
+		timeZone: GT_TZ,
+		weekday: "long",
+		day: "2-digit",
+		month: "long",
+		year: "numeric",
+	}).format(d);
+}

--- a/apps/cartera-back/src/utils/functions/compraCarteraRecipients.ts
+++ b/apps/cartera-back/src/utils/functions/compraCarteraRecipients.ts
@@ -1,0 +1,27 @@
+// Destinatarios fijos para los correos relacionados a compras de cartera
+// (aceptación, expiración automática, etc.). Lista definida por negocio.
+export const COMPRA_CARTERA_RECIPIENTS = {
+  to: [
+    "info@clubcashin.com",
+    "contabilidad@sepresta.com",
+    "arturo.a@sepresta.com",
+    "juridico2@sepresta.com",
+    "richard.kachler@clubcashin.com",
+    "andres@sepresta.com",
+    "juridico@sepresta.com",
+    "asistentejuridico@sepresta.com",
+    "doris.analiss@sepresta.com",
+    "lucia.s@clubcashin.com",
+    "diego.a@sepresta.com",
+    "sara.r@sepresta.com",
+    "caja@sepresta.com",
+    "alexander.p@clubcashin.com",
+    "juan.r@clubcashin.com",
+    "roxana.g@clubcashin.com",
+  ],
+  cc: [
+    "diego.l@clubcashin.com",
+    "guillermo.v@sepresta.com",
+    "pablo.z@clubcashin.com",
+  ],
+};

--- a/apps/crm/apps/web/src/components/ui/currency-input.tsx
+++ b/apps/crm/apps/web/src/components/ui/currency-input.tsx
@@ -1,0 +1,100 @@
+import type * as React from "react";
+import { useEffect, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+type CurrencyInputProps = Omit<
+	React.ComponentProps<"input">,
+	"value" | "onChange" | "type" | "inputMode"
+> & {
+	value: string;
+	onChange: (value: string) => void;
+	symbol?: string;
+	locale?: string;
+};
+
+function formatWithSeparators(raw: string, locale: string) {
+	if (!raw) return "";
+	const [intPart, decPart] = raw.split(".");
+	const intFormatted = intPart ? Number(intPart).toLocaleString(locale) : "";
+	return decPart !== undefined ? `${intFormatted}.${decPart}` : intFormatted;
+}
+
+function sanitize(input: string) {
+	const clean = input.replace(/,/g, "").replace(/[^0-9.]/g, "");
+	const parts = clean.split(".");
+	const intPart = parts[0] ?? "";
+	const hasDecimal = parts.length > 1;
+	const decPart = hasDecimal ? parts.slice(1).join("").slice(0, 2) : null;
+	const normalized = decPart !== null ? `${intPart}.${decPart}` : intPart;
+	return { normalized, intPart, decPart };
+}
+
+export function CurrencyInput({
+	value,
+	onChange,
+	symbol = "Q",
+	locale = "es-GT",
+	className,
+	...props
+}: CurrencyInputProps) {
+	const [display, setDisplay] = useState(() =>
+		value
+			? new Intl.NumberFormat(locale, {
+					minimumFractionDigits: 2,
+					maximumFractionDigits: 2,
+				}).format(Number(value))
+			: "",
+	);
+
+	useEffect(() => {
+		if (!value) {
+			setDisplay("");
+			return;
+		}
+		const rawDisplay = display.replace(/,/g, "");
+		if (rawDisplay !== value) {
+			setDisplay(formatWithSeparators(value, locale));
+		}
+	}, [value, locale, display]);
+
+	return (
+		<div className="relative">
+			<span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground">
+				{symbol}
+			</span>
+			<Input
+				type="text"
+				inputMode="decimal"
+				placeholder="0.00"
+				className={cn("pl-7", className)}
+				value={display}
+				onChange={(e) => {
+					const { normalized, intPart, decPart } = sanitize(e.target.value);
+					onChange(normalized);
+					const intFormatted = intPart
+						? Number(intPart).toLocaleString(locale)
+						: "";
+					setDisplay(
+						decPart !== null ? `${intFormatted}.${decPart}` : intFormatted,
+					);
+				}}
+				onBlur={() => {
+					if (!value) {
+						setDisplay("");
+						return;
+					}
+					const n = Number(value);
+					if (Number.isNaN(n)) return;
+					setDisplay(
+						new Intl.NumberFormat(locale, {
+							minimumFractionDigits: 2,
+							maximumFractionDigits: 2,
+						}).format(n),
+					);
+				}}
+				{...props}
+			/>
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
@@ -35,6 +35,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { CurrencyInput } from "@/components/ui/currency-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -1374,7 +1375,7 @@ function InvestorLiquidacionesPage() {
 
 						<div className="grid grid-cols-2 gap-3">
 							<div className="space-y-1.5">
-								<Label htmlFor="edit-reinversion">Tipo reinversión</Label>
+								<Label htmlFor="edit-reinversion">Modelo de Inversión</Label>
 								<Select
 									value={editTipoReinversion}
 									onValueChange={setEditTipoReinversion}
@@ -1382,19 +1383,13 @@ function InvestorLiquidacionesPage() {
 									<SelectTrigger id="edit-reinversion">
 										<SelectValue />
 									</SelectTrigger>
+									
 									<SelectContent>
 										<SelectItem value="sin_reinversion">
-											Sin reinversión
+											Tradicional
 										</SelectItem>
-										<SelectItem value="reinversion_capital">Capital</SelectItem>
-										<SelectItem value="reinversion_interes">Interés</SelectItem>
-										<SelectItem value="reinversion_total">Total</SelectItem>
-										<SelectItem value="reinversion_variable">
-											Variable
-										</SelectItem>
-										<SelectItem value="reinversion_combinada">
-											Combinada
-										</SelectItem>
+										<SelectItem value="reinversion_capital">Reinversión Capital</SelectItem>
+										<SelectItem value="reinversion_total">Interés Compuesto</SelectItem>
 									</SelectContent>
 								</Select>
 							</div>
@@ -1479,22 +1474,41 @@ function InvestorLiquidacionesPage() {
 						</DialogDescription>
 					</DialogHeader>
 
+					<div className="rounded-md border border-purple-200 bg-purple-50 p-3 dark:border-purple-800 dark:bg-purple-950/40">
+						<div className="flex items-center justify-between gap-2">
+							<span className="text-xs font-medium text-purple-900 dark:text-purple-200">
+								Modelo de reinversión
+							</span>
+							<Badge
+								variant="outline"
+								className="border-purple-300 bg-white text-[11px] text-purple-700 dark:border-purple-700 dark:bg-purple-950 dark:text-purple-300"
+							>
+								{{
+									reinversion_capital: "Reinversión Capital",
+									reinversion_interes: "Reinversión Interés",
+									reinversion_total: "Interés Compuesto",
+									reinversion_variable: "Reinversión Variable",
+									reinversion_combinada: "Reinversión Combinada",
+									sin_reinversion: "Sin reinversión",
+								}[
+									(investor?.tipoReinversion as string) ?? "sin_reinversion"
+								] ?? "Sin reinversión"}
+							</Badge>
+						</div>
+					</div>
+
 					<div className="space-y-4 py-2">
 						<div className="space-y-1.5">
 							<Label htmlFor="compra-monto">Monto aportado</Label>
-							<Input
+							<CurrencyInput
 								id="compra-monto"
-								type="number"
-								min="0"
-								step="0.01"
-								placeholder="0.00"
 								value={compraCarteraMonto}
-								onChange={(e) => setCompraCarteraMonto(e.target.value)}
+								onChange={setCompraCarteraMonto}
 							/>
 						</div>
 						<div className="grid grid-cols-2 gap-3">
 							<div className="space-y-1.5">
-								<Label htmlFor="compra-pct-inv">% Inversión</Label>
+								<Label htmlFor="compra-pct-inv">% Inversiónista</Label>
 								<Input
 									id="compra-pct-inv"
 									type="number"
@@ -1543,7 +1557,7 @@ function InvestorLiquidacionesPage() {
 						</div>
 					</div>
 
-					<DialogFooter className="gap-2 sm:gap-0">
+					<DialogFooter className="gap-3 sm:gap-3">
 						<Button
 							variant="outline"
 							onClick={() => {

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.index.tsx
@@ -25,6 +25,7 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import { CurrencyInput } from "@/components/ui/currency-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -444,7 +445,7 @@ function LiquidacionesInversionistas() {
 						{/* Reinversión */}
 						<div className="grid grid-cols-2 gap-3">
 							<div className="space-y-1.5">
-								<Label htmlFor="inv-reinversion">Tipo reinversión</Label>
+								<Label htmlFor="inv-reinversion">Modelo de Inversión</Label>
 								<Select
 									value={formTipoReinversion}
 									onValueChange={setFormTipoReinversion}
@@ -454,17 +455,10 @@ function LiquidacionesInversionistas() {
 									</SelectTrigger>
 									<SelectContent>
 										<SelectItem value="sin_reinversion">
-											Sin reinversión
+											Tradicional
 										</SelectItem>
-										<SelectItem value="reinversion_capital">Capital</SelectItem>
-										<SelectItem value="reinversion_interes">Interés</SelectItem>
-										<SelectItem value="reinversion_total">Total</SelectItem>
-										<SelectItem value="reinversion_variable">
-											Variable
-										</SelectItem>
-										<SelectItem value="reinversion_combinada">
-											Combinada
-										</SelectItem>
+										<SelectItem value="reinversion_capital">Reinversión Capital</SelectItem>
+										<SelectItem value="reinversion_total">Interés Compuesto</SelectItem>
 									</SelectContent>
 								</Select>
 							</div>
@@ -495,7 +489,7 @@ function LiquidacionesInversionistas() {
 									onCheckedChange={(v) => setHacerCompra(v === true)}
 								/>
 								<Label htmlFor="inv-compra" className="font-semibold">
-									Hacer compra de cartera de una vez
+									Hacer compra de cartera
 								</Label>
 							</div>
 
@@ -504,14 +498,10 @@ function LiquidacionesInversionistas() {
 									<div className="grid grid-cols-2 gap-3">
 										<div className="space-y-1.5">
 											<Label htmlFor="inv-monto-compra">Monto aportado *</Label>
-											<Input
+											<CurrencyInput
 												id="inv-monto-compra"
-												type="number"
-												min="0"
-												step="0.01"
-												placeholder="0.00"
 												value={formMontoCompra}
-												onChange={(e) => setFormMontoCompra(e.target.value)}
+												onChange={setFormMontoCompra}
 											/>
 										</div>
 										<div className="space-y-1.5">
@@ -528,7 +518,7 @@ function LiquidacionesInversionistas() {
 									</div>
 									<div className="grid grid-cols-2 gap-3">
 										<div className="space-y-1.5">
-											<Label htmlFor="inv-pct-inv">% Inversión</Label>
+											<Label htmlFor="inv-pct-inv">% Inversiónista</Label>
 											<Input
 												id="inv-pct-inv"
 												type="number"

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -338,6 +338,13 @@ export interface SendCompraCarteraAcceptedNotificationParams {
   usuarioNombre?: string;
   usuarioEmail?: string;
   notasAdicionales?: string;
+  // Aviso de expiración por 3 días hábiles.
+  // `fechaExpiraLabel`: último día hábil de vigencia (ej. "viernes 24 de abril de 2026").
+  // `fechaBajaLabel`: día en que el job automático la dará de baja a las 00:00 (ej. "lunes 27 de abril de 2026").
+  expiracion?: {
+    fechaExpiraLabel: string;
+    fechaBajaLabel: string;
+  };
 }
 
 export const sendCompraCarteraAcceptedNotification = async ({
@@ -350,6 +357,7 @@ export const sendCompraCarteraAcceptedNotification = async ({
   usuarioNombre,
   usuarioEmail,
   notasAdicionales,
+  expiracion,
 }: SendCompraCarteraAcceptedNotificationParams) => {
   try {
     const validEmails = to.filter((email) => {
@@ -451,6 +459,21 @@ export const sendCompraCarteraAcceptedNotification = async ({
           <strong style="color:#166534;">✓ Compra de Cartera aceptada</strong>
         </div>
 
+        ${
+          expiracion
+            ? `
+          <div style="background:#fef3c7;border-left:4px solid #d97706;padding:12px 16px;border-radius:6px;margin-bottom:16px;color:#78350f;">
+            <p style="margin:0 0 6px 0;"><strong>⚠ Vigencia: 3 días hábiles</strong></p>
+            <p style="margin:0;font-size:13px;">
+              Esta compra tiene validez hasta el <strong>${expiracion.fechaExpiraLabel}</strong>.
+              Si no se completa, será dada de baja automáticamente el
+              <strong>${expiracion.fechaBajaLabel}</strong> a las 00:00 (GT).
+            </p>
+          </div>
+        `
+            : ""
+        }
+
         ${headerBlock}
 
         <p>${intro}</p>
@@ -535,6 +558,132 @@ export const sendCompraCarteraAcceptedNotification = async ({
     return { success: true, data };
   } catch (err) {
     console.error("[sendCompraCarteraAcceptedNotification] Unexpected Error:", err);
+    return { success: false, error: err };
+  }
+};
+
+// ================================================================
+// NOTIFICACIÓN: COMPRA DE CARTERA EXPIRADA / CANCELADA AUTOMÁTICAMENTE
+// Se dispara desde el job diario cuando una compra aceptada no se
+// completó dentro de los 3 días hábiles de vigencia.
+// ================================================================
+export interface SendCompraCarteraExpiradaNotificationParams {
+  to: string[];
+  cc?: string[];
+  // Cada inversionista cuya compra se canceló, con los créditos que afectaba.
+  inversionistas: Array<{
+    inversionista_nombre: string;
+    creditos: Array<{
+      numero_credito_sifco: string;
+      cliente_nombre: string;
+      monto_aportado: string;
+    }>;
+  }>;
+  currencySymbol?: string;
+  fechaEjecucionLabel?: string;
+}
+
+export const sendCompraCarteraExpiradaNotification = async ({
+  to,
+  cc,
+  inversionistas,
+  currencySymbol = "Q",
+  fechaEjecucionLabel,
+}: SendCompraCarteraExpiradaNotificationParams) => {
+  try {
+    const validEmails = to.filter((email) => {
+      try { emailSchema.parse(email); return true; } catch { return false; }
+    });
+
+    if (validEmails.length === 0) {
+      console.warn("[sendCompraCarteraExpiradaNotification] No valid admin emails found");
+      return { success: false, error: "No valid emails" };
+    }
+
+    if (inversionistas.length === 0) {
+      return { success: false, error: "No hay inversionistas para notificar" };
+    }
+
+    const bloqueInversionistas = inversionistas
+      .map((inv) => {
+        const filas = inv.creditos
+          .map(
+            (c) => `
+              <tr>
+                <td style="padding:8px 12px;border:1px solid #dc2626;background:#ffffff;">${c.numero_credito_sifco}</td>
+                <td style="padding:8px 12px;border:1px solid #dc2626;background:#ffffff;">${c.cliente_nombre}</td>
+                <td style="padding:8px 12px;border:1px solid #dc2626;background:#ffffff;text-align:right;">${currencySymbol} ${c.monto_aportado}</td>
+              </tr>`,
+          )
+          .join("");
+
+        return `
+          <h3 style="margin-top:20px;background:#dc2626;color:#ffffff;padding:8px 12px;border:1px solid #dc2626;display:inline-block;margin-bottom:0;">
+            ${inv.inversionista_nombre}
+          </h3>
+          <table style="border-collapse:collapse;width:100%;font-size:14px;margin-top:0;margin-bottom:12px;">
+            <thead>
+              <tr>
+                <th style="padding:8px 12px;border:1px solid #dc2626;background:#dc2626;color:#ffffff;text-align:left;">Número SIFCO</th>
+                <th style="padding:8px 12px;border:1px solid #dc2626;background:#dc2626;color:#ffffff;text-align:left;">Cliente</th>
+                <th style="padding:8px 12px;border:1px solid #dc2626;background:#dc2626;color:#ffffff;text-align:right;">Monto aportado</th>
+              </tr>
+            </thead>
+            <tbody>${filas}</tbody>
+          </table>
+        `;
+      })
+      .join("");
+
+    const html = `
+      <div style="font-family:Arial,sans-serif;color:#111827;max-width:720px;margin:0 auto;">
+        <div style="background:#fee2e2;border-left:4px solid #dc2626;padding:12px 16px;border-radius:6px;margin-bottom:16px;">
+          <strong style="color:#7f1d1d;">✕ Compra de Cartera cancelada por vencimiento</strong>
+          ${fechaEjecucionLabel ? `<div style="margin-top:4px;color:#7f1d1d;font-size:12px;">Ejecutado el ${fechaEjecucionLabel}</div>` : ""}
+        </div>
+
+        <p>
+          Los siguientes inversionistas no completaron su compra de cartera
+          dentro de los <strong>3 días hábiles</strong> de vigencia. Su monto
+          fue <strong>devuelto automáticamente a CUBE INVESTMENTS, S.A.</strong>
+          y los créditos quedaron restituidos.
+        </p>
+
+        ${bloqueInversionistas}
+
+        <p style="margin-top:24px;">Cualquier duda o consulta quedo a la orden,</p>
+        <p>saludos cordiales</p>
+      </div>
+    `;
+
+    const subjectLabel =
+      inversionistas.length === 1
+        ? inversionistas[0].inversionista_nombre
+        : `${inversionistas.length} inversionistas`;
+
+    const validCc = (cc ?? []).filter((email) => {
+      try { emailSchema.parse(email); return true; } catch { return false; }
+    });
+
+    const { data, error } = await resend.emails.send({
+      from: `Club Cash In <no-reply@${domain}>`,
+      to: validEmails,
+      cc: validCc.length > 0 ? validCc : undefined,
+      subject: `Compra de Cartera cancelada por vencimiento - ${subjectLabel}`,
+      html,
+    });
+
+    if (error) {
+      console.error("[sendCompraCarteraExpiradaNotification] Resend API Error:", error);
+      return { success: false, error };
+    }
+
+    console.log(
+      `[sendCompraCarteraExpiradaNotification] Email sent to ${validEmails.length} admins. ID: ${data?.id}`,
+    );
+    return { success: true, data };
+  } catch (err) {
+    console.error("[sendCompraCarteraExpiradaNotification] Unexpected Error:", err);
     return { success: false, error: err };
   }
 };


### PR DESCRIPTION
## Resumen

Agrega el flujo completo de vigencia y expiración automática para las **compras de cartera aceptadas**. Cuando una compra se acepta, queda vigente por **3 días hábiles** (zona Guatemala); si no se completa, un job diario la cancela a las 00:00 del día de baja y devuelve los montos a CUBE Investments, S.A., notificando por correo a las mismas personas que recibieron el aviso de aceptación.

## Flujo paso a paso

### 1. Aceptación de la compra
- El usuario toca **Aceptar Compra Cartera** en el front (`SesionesPendientes.tsx`).
- El endpoint `POST /compra-cartera-aceptada` (sin cambios de contrato) ahora:
  1. Pasa los rows del espejo de `pendiente_compra_cartera` → `pendiente_revision` (igual que antes).
  2. **Nuevo:** guarda `aceptada_at` (timestamptz) y `aceptada_por` (email del JWT) en esos rows.
  3. Calcula con `calcularExpiracionCompraCartera(ahora)`:
     - `expira` = `aceptada_at + 3 días hábiles` (el último día de vigencia, ej. viernes 24).
     - `diaBaja` = siguiente día hábil después de `expira` (el día en que el job correrá, ej. lunes 27).
  4. Manda el correo de aceptación con un **banner ámbar** de vigencia:
     > ⚠ Vigencia: 3 días hábiles
     > Esta compra tiene validez hasta el **viernes 24 de abril de 2026**. Si no se completa, será dada de baja automáticamente el **lunes 27 de abril de 2026** a las 00:00 (GT).

### 2. Columnas nuevas en el espejo
\`\`\`sql
ALTER TABLE cartera.creditos_inversionistas_espejo
  ADD COLUMN aceptada_at  timestamp with time zone,
  ADD COLUMN aceptada_por text;
\`\`\`
Ambas **nullable**, así las filas existentes no se rompen. Solo aceptaciones nuevas las llenan.

### 3. Utilidades de días hábiles GT (reutilizables)
Se agrega `src/utils/functions/businessDays.ts` con:
- `nowGT()` — instante actual (equivale a `new Date()`, marca intención explícita).
- `addBusinessDaysGT(from, days)` — suma N días hábiles excluyendo sáb/dom en zona Guatemala.
- `calcularExpiracionCompraCartera(from)` → `{ expira, diaBaja }`.
- `formatFechaLargaGT(d)` → `"lunes 27 de abril de 2026"`.
- `gtDateKey(d)` → `"YYYY-MM-DD"` en GT para comparar fechas sin ruido de horas.

### 4. Job diario de expiración
- Nuevo archivo `src/controllers/expirarCompraCartera.ts`.
- Registrado en `schedule.ts` con cron `0 0 * * *` zona `America/Guatemala`.
- Lógica:
  1. Trae del espejo los rows con `status = 'pendiente_revision'` y `aceptada_at IS NOT NULL`, ya joinados con `inversionistas`, `creditos` y `usuarios` (se captura la info **antes** de limpiar porque el return-to-cube borra los rows).
  2. Filtra los que cumplen `diaBaja <= hoy_GT`.
  3. Agrupa los `credito_id` únicos.
  4. Llama in-process a `returnPendingInvestorsToCube({ body: { creditos }, set: mockSet })` — reutiliza 100 % la lógica existente, sin HTTP ni duplicación.
  5. Si la limpieza fue exitosa, agrupa los vencidos por inversionista y envía el correo de cancelación.
  6. Si no hay vencidos, loguea y termina limpio.

### 5. Correo de cancelación por expiración
- Nuevo export `sendCompraCarteraExpiradaNotification` en `@cci/email`.
- Mismos destinatarios (TO + CC) que el correo de aceptación (se extrajeron a `src/utils/functions/compraCarteraRecipients.ts` para no duplicar la lista).
- Contenido: banner rojo "✕ Compra de Cartera cancelada por vencimiento", mensaje explicando que los montos fueron devueltos a **CUBE INVESTMENTS, S.A.** y una tabla por inversionista con SIFCO / Cliente / Monto aportado de cada crédito afectado.

### 6. Mejoras UI en CRM (apoyo del flujo)
- Nuevo componente reutilizable `CurrencyInput` (prefijo Q, separadores de miles en vivo, sanitización, 2 decimales al blur).
- Se usa en los modales de compra de cartera: `liquidaciones.index.tsx` (crear inversionista) y `liquidaciones.$inversionistaId.tsx` (registrar compra).
- En el modal de compra se muestra un callout con el **modelo de reinversión** del inversionista (badge morado), tomado de `investor.tipoReinversion`, para dar contexto antes de registrar la operación.

## Ejemplo concreto
- Aceptación: **martes 21 abr 2026**.
- `expira` = viernes 24 abr (3 hábiles).
- `diaBaja` = lunes 27 abr (siguiente hábil).
- Si no se completa, el **lunes 27 00:00 GT** el cron identifica el row como vencido (`"2026-04-27" <= "2026-04-27"`), devuelve los montos a CUBE y manda el correo de cancelación.

## Migración
Correr en la base de datos el `ALTER TABLE` del paso 2 (o `bun run migrate` desde `apps/cartera-back`, que con `drizzle-kit push` detecta el diff y genera el mismo ALTER).

## Test plan
- [ ] Correr `ALTER TABLE` en ambiente de staging.
- [ ] Aceptar una compra de cartera — validar que se llenen `aceptada_at` y `aceptada_por` en el espejo y que el correo muestre el banner de vigencia con las fechas correctas.
- [ ] Setear manualmente un `aceptada_at` antiguo en un row de staging y correr el job a demanda — validar que el row se limpie y llegue el correo de cancelación.
- [ ] Correr el job sin filas vencidas — validar que termina limpio y loguea el escaneo.
- [ ] En el CRM, probar el CurrencyInput en ambos modales (crear inversionista con compra / registrar compra desde perfil): tipear, borrar, decimal con dos dígitos, blur/focus, separadores de miles.
- [ ] Validar que el badge "Modelo de reinversión" se muestre correcto en el modal para inversionistas con `sin_reinversion` y otros tipos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)