### PR TITLE
feat(inversionistas): salida automática por pendiente_devolucion + badge de status

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3072,6 +3072,61 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
             console.error(`  ❌ Error en reinversión automática (liquidación ya guardada):`, reinvError);
           }
         }
+
+        // ========================================
+        // FASE 5: SALIDA AUTOMÁTICA (pendiente_devolucion)
+        // Si el inversionista quedó marcado como `pendiente_devolucion`,
+        // se ejecuta exitInvestor sobre los créditos con pagos liquidados
+        // en esta corrida. exitInvestor traslada la participación a CUBE
+        // y marca al inversionista como `inactivo`. Como salvaguarda,
+        // forzamos el status a `inactivo` después.
+        // ========================================
+        try {
+          const [invRow] = await db
+            .select({ status: inversionistas.status })
+            .from(inversionistas)
+            .where(eq(inversionistas.inversionista_id, inv_id))
+            .limit(1);
+
+          if (invRow?.status === "pendiente_devolucion") {
+            const creditoIdsSalida = [
+              ...new Set(pagosNoLiquidados.map((p) => p.credito_id)),
+            ];
+
+            if (creditoIdsSalida.length > 0) {
+              console.log(
+                `  🚪 Inversionista ${inv_id} en pendiente_devolucion → exitInvestor sobre ${creditoIdsSalida.length} crédito(s)`
+              );
+
+              const exitResult = await exitInvestor({
+                body: {
+                  inversionista_id: inv_id,
+                  creditos: creditoIdsSalida,
+                },
+                set: { status: 200 },
+                request: {} as any,
+              });
+
+              console.log(`  ✅ Salida ejecutada:`, exitResult);
+
+              await db
+                .update(inversionistas)
+                .set({ status: "inactivo" })
+                .where(eq(inversionistas.inversionista_id, inv_id));
+
+              console.log(`  ✅ Inversionista ${inv_id} marcado como inactivo`);
+            } else {
+              console.warn(
+                `  ⚠️ Inversionista ${inv_id} pendiente_devolucion pero sin créditos con pagos en esta corrida; se omite exitInvestor`
+              );
+            }
+          }
+        } catch (exitError) {
+          console.error(
+            `  ❌ Error en salida automática (liquidación ya guardada):`,
+            exitError
+          );
+        }
       } catch (excelError) {
         console.error(`  ❌ Error generando Excel (datos financieros ya guardados):`, excelError);
       }
@@ -6011,14 +6066,19 @@ export async function getInvestorPerformance(dpi?: string, email?: string) {
     throw new Error(`No se encontró inversionista con ${dpi ? 'DPI: ' + dpi : 'email: ' + email}`);
   }
 
-  // 2️⃣ Obtener totales de inversiones de forma agregada
+  // 2️⃣ Obtener totales de inversiones de forma agregada (solo créditos completados)
   const [totalesInversion] = await db
     .select({
       capital_total: sql<string>`coalesce(sum(${creditos_inversionistas_espejo.monto_aportado}), 0)`,
       cantidad: count(),
     })
     .from(creditos_inversionistas_espejo)
-    .where(eq(creditos_inversionistas_espejo.inversionista_id, inversionista.inversionista_id));
+    .where(
+      and(
+        eq(creditos_inversionistas_espejo.inversionista_id, inversionista.inversionista_id),
+        eq(creditos_inversionistas_espejo.status, "completado"),
+      ),
+    );
 
   // 3️⃣ Obtener total de rendimiento (intereses liquidados * 1.2) de forma agregada
   const [totalesRendimiento] = await db

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2317,6 +2317,7 @@ export const cobrosRouter = {
 						numeroCuenta: inv.numero_cuenta ?? null,
 						moneda: inv.moneda ?? "quetzales",
 						celular: inv.celular ?? null,
+						status: inv.status ?? null,
 					})),
 					pagination: {
 						page: result.page,

--- a/apps/crm/apps/server/src/routers/contract-generation.ts
+++ b/apps/crm/apps/server/src/routers/contract-generation.ts
@@ -407,9 +407,18 @@ export const contractGenerationRouter = {
 			);
 
 			try {
+				// Derivar isPlural automáticamente desde deudoresAdicionales
+				const contractsWithPlural = input.contracts.map((contract) => ({
+					...contract,
+					options: {
+						...contract.options,
+						isPlural: (contract.data.deudoresAdicionales?.length ?? 0) > 0,
+					},
+				}));
+
 				// Llamar a la API de generación de contratos
 				const apiResult = await generateContractsBatch({
-					contracts: input.contracts,
+					contracts: contractsWithPlural,
 				});
 
 				// Transformar resultados al formato esperado por el frontend
@@ -531,6 +540,7 @@ export const contractGenerationRouter = {
 							options: z.object({
 								gender: z.enum(["male", "female"]),
 								generatePdf: z.boolean(),
+								isPlural: z.boolean().optional(),
 								filenamePrefix: z.string(),
 							}),
 						}),
@@ -655,6 +665,7 @@ export const contractGenerationRouter = {
 						options: z.object({
 							gender: z.enum(["male", "female"]),
 							generatePdf: z.boolean(),
+							isPlural: z.boolean().optional(),
 							filenamePrefix: z.string(),
 						}),
 					}),
@@ -810,6 +821,11 @@ export const contractGenerationRouter = {
 					return {
 						...contract,
 						data: newData,
+						options: {
+							...contract.options,
+							isPlural:
+								(newData.deudoresAdicionales?.length ?? 0) > 0,
+						},
 					};
 				});
 

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -341,6 +341,8 @@ export const reportsAppRouter = {
 	compraCartera: investorDocumentsRouter.compraCartera,
 	crearInversionista: investorDocumentsRouter.crearInversionista,
 	editarInversionista: investorDocumentsRouter.editarInversionista,
+	cambiarStatusInversionista:
+		investorDocumentsRouter.cambiarStatusInversionista,
 
 	// Accounting routes (Contabilidad)
 	getResumenGlobalInversionistas:

--- a/apps/crm/apps/server/src/routers/investor-documents.ts
+++ b/apps/crm/apps/server/src/routers/investor-documents.ts
@@ -202,6 +202,41 @@ export const investorDocumentsRouter = {
 			return { success: true, data: result.data };
 		}),
 
+	// Cambiar status del inversionista — pendiente_devolucion / activo / inactivo
+	cambiarStatusInversionista: crmCobrosOrInvestmentsProcedure
+		.input(
+			z.object({
+				inversionistaId: z.number().int().positive(),
+				status: z.enum(["activo", "inactivo", "pendiente_devolucion"]),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			const result = await carteraBackClient.setInvestorStatus({
+				inversionista_id: input.inversionistaId,
+				status: input.status,
+			});
+
+			try {
+				await db.insert(investorActivityLog).values({
+					inversionistaId: input.inversionistaId,
+					action: "investor_updated",
+					details: {
+						statusChange: input.status,
+					},
+					performedBy: context.session.user.id,
+					performedByName:
+						context.session.user.name ?? context.session.user.email,
+				});
+			} catch (logError) {
+				console.error(
+					"Error al registrar log de cambio de status:",
+					logError,
+				);
+			}
+
+			return { success: true, data: result };
+		}),
+
 	// Crear inversionista — opcionalmente con compra de cartera
 	crearInversionista: crmCobrosOrInvestmentsProcedure
 		.input(

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -987,6 +987,26 @@ export class CarteraBackClient {
 	}
 
 	// ========================================================================
+	// CAMBIAR STATUS INVERSIONISTA
+	// ========================================================================
+
+	async setInvestorStatus(input: {
+		inversionista_id: number;
+		status: "activo" | "inactivo" | "pendiente_devolucion";
+	}): Promise<{ success?: boolean; message?: string; data?: any }> {
+		const response = await this.request<{
+			success?: boolean;
+			message?: string;
+			data?: any;
+		}>("/investor/status", {
+			method: "POST",
+			body: JSON.stringify(input),
+		});
+		this.cache.invalidate("investor");
+		return response;
+	}
+
+	// ========================================================================
 	// COMPRA DE CARTERA
 	// ========================================================================
 

--- a/apps/crm/apps/web/src/components/investments/InvestorStatusBadge.tsx
+++ b/apps/crm/apps/web/src/components/investments/InvestorStatusBadge.tsx
@@ -1,0 +1,66 @@
+import { AlertCircle, CheckCircle2, XCircle } from "lucide-react";
+
+const INVESTOR_STATUS_CONFIG = {
+	activo: {
+		label: "Activo",
+		icon: CheckCircle2,
+		className:
+			"border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-300",
+		dotClassName: "bg-emerald-500",
+	},
+	inactivo: {
+		label: "Inactivo",
+		icon: XCircle,
+		className:
+			"border-rose-500/40 bg-rose-500/15 text-rose-700 dark:text-rose-300",
+		dotClassName: "bg-rose-500",
+	},
+	pendiente_devolucion: {
+		label: "Pendiente devolución",
+		icon: AlertCircle,
+		className:
+			"border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300",
+		dotClassName: "bg-amber-500",
+	},
+} as const;
+
+type InvestorStatus = keyof typeof INVESTOR_STATUS_CONFIG;
+
+export function InvestorStatusBadge({
+	status,
+	size = "md",
+}: {
+	status?: string | null;
+	size?: "sm" | "md";
+}) {
+	const config = INVESTOR_STATUS_CONFIG[status as InvestorStatus] ?? null;
+	if (!config) return null;
+	const Icon = config.icon;
+	const isSmall = size === "sm";
+	return (
+		<span
+			className={`inline-flex items-center gap-1.5 rounded-full border font-semibold shadow-sm ${config.className} ${
+				isSmall
+					? "px-2 py-0.5 text-[10px]"
+					: "px-2.5 py-0.5 text-xs"
+			}`}
+		>
+			<span
+				className={`relative flex ${isSmall ? "h-1.5 w-1.5" : "h-2 w-2"}`}
+			>
+				{status === "pendiente_devolucion" && (
+					<span
+						className={`absolute inline-flex h-full w-full animate-ping rounded-full opacity-75 ${config.dotClassName}`}
+					/>
+				)}
+				<span
+					className={`relative inline-flex rounded-full ${config.dotClassName} ${
+						isSmall ? "h-1.5 w-1.5" : "h-2 w-2"
+					}`}
+				/>
+			</span>
+			<Icon className={isSmall ? "h-3 w-3" : "h-3.5 w-3.5"} />
+			{config.label}
+		</span>
+	);
+}

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import {
+	AlertCircle,
 	ArrowLeft,
 	Banknote,
 	CalendarDays,
@@ -32,6 +33,7 @@ import {
 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import { InvestorStatusBadge } from "@/components/investments/InvestorStatusBadge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -676,6 +678,9 @@ function InvestorLiquidacionesPage() {
 	const [page, setPage] = useState(1);
 	const PER_PAGE = 25;
 
+	// Liquidar todo el monto aportado (cambia status a pendiente_devolucion)
+	const [liquidarTodoOpen, setLiquidarTodoOpen] = useState(false);
+
 	// Compra de cartera
 	const [compraCarteraOpen, setCompraCarteraOpen] = useState(false);
 	const [compraCarteraMonto, setCompraCarteraMonto] = useState("");
@@ -775,6 +780,31 @@ function InvestorLiquidacionesPage() {
 		},
 	});
 
+	const cambiarStatusMutation = useMutation({
+		...orpc.cambiarStatusInversionista.mutationOptions(),
+		onSuccess: () => {
+			toast.success(
+				"Inversionista marcado para devolución total. Se liquidará en la próxima corrida.",
+			);
+			setLiquidarTodoOpen(false);
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInversionistas.queryOptions({
+					input: { id: investorIdNum, page: 1, perPage: 1 },
+				}).queryKey,
+				refetchType: "all",
+			});
+			queryClient.invalidateQueries({
+				queryKey: orpc.getInvestorActivityLog.queryOptions({
+					input: { inversionistaId: investorIdNum },
+				}).queryKey,
+				refetchType: "all",
+			});
+		},
+		onError: (err: any) => {
+			toast.error(err?.message ?? "Error al cambiar el status del inversionista");
+		},
+	});
+
 	// Fetch investor info by ID from cartera
 	const investorsQuery = useQuery({
 		...orpc.getInversionistas.queryOptions({
@@ -855,9 +885,12 @@ function InvestorLiquidacionesPage() {
 								<Users className="h-5 w-5" />
 							</div>
 							<div>
-								<h1 className="font-bold text-lg leading-tight">
-									{investor?.nombre ?? "Inversionista"}
-								</h1>
+								<div className="flex flex-wrap items-center gap-2">
+									<h1 className="font-bold text-lg leading-tight">
+										{investor?.nombre ?? "Inversionista"}
+									</h1>
+									<InvestorStatusBadge status={investor?.status} />
+								</div>
 								{investor?.dpi && (
 									<p className="flex items-center gap-1 text-muted-foreground text-xs">
 										<Shield className="h-3 w-3" />
@@ -878,6 +911,17 @@ function InvestorLiquidacionesPage() {
 								<Pencil className="h-4 w-4" />
 								Editar
 							</Button>
+							{investor?.status === "activo" && (
+								<Button
+									variant="outline"
+									size="sm"
+									className="gap-2 border-orange-500/60 text-orange-700 hover:bg-orange-500/10 hover:text-orange-800 dark:text-orange-300 dark:hover:text-orange-200"
+									onClick={() => setLiquidarTodoOpen(true)}
+								>
+									<Banknote className="h-4 w-4" />
+									Liquidar todo el monto aportado
+								</Button>
+							)}
 							<Button
 								variant="outline"
 								size="sm"
@@ -1446,6 +1490,74 @@ function InvestorLiquidacionesPage() {
 							) : (
 								"Guardar cambios"
 							)}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Modal confirmación — devolución total del monto aportado */}
+			<Dialog
+				open={liquidarTodoOpen}
+				onOpenChange={(open) => {
+					if (cambiarStatusMutation.isPending) return;
+					setLiquidarTodoOpen(open);
+				}}
+			>
+				<DialogContent className="sm:max-w-md">
+					<DialogHeader>
+						<div className="flex items-center gap-3">
+							<div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-orange-500/15 text-orange-600 dark:text-orange-300">
+								<AlertCircle className="h-5 w-5" />
+							</div>
+							<DialogTitle>Liquidar todo el monto aportado</DialogTitle>
+						</div>
+						<DialogDescription className="pt-2">
+							Estás por marcar a{" "}
+							<span className="font-semibold">
+								{investor?.nombre ?? "este inversionista"}
+							</span>{" "}
+							como{" "}
+							<span className="font-semibold text-orange-700 dark:text-orange-300">
+								pendiente de devolución
+							</span>
+							{". "}
+							En la próxima corrida de liquidación se le entregará la
+							totalidad de su monto aportado.
+						</DialogDescription>
+					</DialogHeader>
+
+					<div className="rounded-md border border-orange-300/60 bg-orange-50 p-3 text-sm text-orange-900 dark:border-orange-800/60 dark:bg-orange-950/40 dark:text-orange-200">
+						<p className="font-semibold">Esta acción no se puede revertir.</p>
+						<p className="mt-1 text-xs">
+							Una vez confirmada, el inversionista quedará bloqueado para
+							nuevas operaciones hasta completarse la devolución.
+						</p>
+					</div>
+
+					<DialogFooter className="gap-2 sm:gap-2">
+						<Button
+							variant="outline"
+							onClick={() => setLiquidarTodoOpen(false)}
+							disabled={cambiarStatusMutation.isPending}
+						>
+							Cancelar
+						</Button>
+						<Button
+							className="gap-2 bg-orange-600 text-white hover:bg-orange-700"
+							onClick={() =>
+								cambiarStatusMutation.mutate({
+									inversionistaId: investorIdNum,
+									status: "pendiente_devolucion",
+								})
+							}
+							disabled={cambiarStatusMutation.isPending}
+						>
+							{cambiarStatusMutation.isPending ? (
+								<Loader2 className="h-4 w-4 animate-spin" />
+							) : (
+								<Banknote className="h-4 w-4" />
+							)}
+							Sí, marcar para devolución total
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.index.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.index.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
+import { InvestorStatusBadge } from "@/components/investments/InvestorStatusBadge";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -305,6 +306,10 @@ function LiquidacionesInversionistas() {
 												}[inv.tipoReinversion as string] ?? "Reinversión"}
 											</Badge>
 										)}
+										<InvestorStatusBadge
+											status={(inv as any).status}
+											size="sm"
+										/>
 									</div>
 								</Link>
 							))}


### PR DESCRIPTION
## Summary

- **UI** — Badge de status del inversionista (activo / inactivo / pendiente_devolucion) en el header del detalle y en cada tarjeta del listado de liquidaciones. Componente compartido `InvestorStatusBadge`.
- **UI** — Nuevo botón **"Liquidar todo el monto aportado"** (solo visible cuando `status = activo`) con modal de confirmación. Llama al nuevo procedure ORPC `cambiarStatusInversionista` para marcar al inversionista como `pendiente_devolucion` en cartera-back.
- **Server (CRM)** — Procedure `cambiarStatusInversionista` + método `setInvestorStatus` en `cartera-back-client`. `getInversionistas` ahora expone el campo `status`.
- **cartera-back** — `getInvestorRendimiento` suma `capital_total` y `cantidad` solo sobre `creditos_inversionistas_espejo` con `status = "completado"` (excluye `pendiente_reinversion`, `pendiente_compra_cartera`, `pendiente_revision`).
- **cartera-back** — **Fase 5** en `liquidateByInvestorId`: si el inversionista quedó marcado como `pendiente_devolucion`, después de la reinversión automática se ejecuta `exitInvestor` sobre los créditos con pagos de la corrida y se fuerza el status a `inactivo`. Tiene su propio `try/catch` para no romper la liquidación si falla.

## Test plan

- [ ] Detalle de inversionista activo: aparece badge verde "Activo" y el botón naranja "Liquidar todo el monto aportado".
- [ ] Detalle de inversionista inactivo / pendiente_devolucion: el botón naranja NO aparece.
- [ ] Click en "Liquidar todo el monto aportado" → modal de confirmación → confirmar → status pasa a `pendiente_devolucion`, badge ámbar con animación, toast de éxito.
- [ ] Listado `/inversiones/liquidaciones`: cada tarjeta muestra el badge correcto al final de la fila de badges.
- [ ] `getInvestorRendimiento` para un inversionista con créditos en estado pendiente: el `capital_total_aportado` y `cantidad_inversiones` reflejan únicamente los créditos `completado`.
- [ ] Correr liquidación para un inversionista marcado `pendiente_devolucion`: en logs aparece `🚪 Inversionista X en pendiente_devolucion → exitInvestor sobre N crédito(s)`, los créditos pasan a CUBE y el inversionista queda en `inactivo`.
- [ ] Correr liquidación para un inversionista `activo`: la Fase 5 no se dispara, comportamiento normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)