### PR TITLE
Add responsableCobros field and customizable page size options

### DIFF
--- a/apps/crm/apps/web/src/components/data-table.tsx
+++ b/apps/crm/apps/web/src/components/data-table.tsx
@@ -44,6 +44,7 @@ interface DataTableProps<TData, TValue> {
 	setGlobalFilterParam?: (filter: string) => void;
 	onRowClick?: (row: TData) => void;
 	hideSearch?: boolean;
+	pageSizeOptions?: number[];
 }
 
 export function DataTable<TData, TValue>({
@@ -57,6 +58,7 @@ export function DataTable<TData, TValue>({
 	setGlobalFilterParam,
 	onRowClick,
 	hideSearch,
+	pageSizeOptions = [10, 20, 30, 40, 50],
 }: DataTableProps<TData, TValue>) {
 	const [sorting, setSorting] = useState<SortingState>([]);
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -219,24 +221,31 @@ export function DataTable<TData, TValue>({
 					)}
 				</div>
 				<div className="flex items-center space-x-6 lg:space-x-8">
-					{!isServerPagination && (
-						<div className="flex items-center space-x-2">
-							<p className="font-medium text-sm">Filas por página</p>
-							<select
-								value={table.getState().pagination.pageSize}
-								onChange={(e) => {
-									table.setPageSize(Number(e.target.value));
-								}}
-								className="h-8 w-[70px] rounded-md border border-input bg-background px-2 py-1 text-sm"
-							>
-								{[10, 20, 30, 40, 50].map((pageSize) => (
-									<option key={pageSize} value={pageSize}>
-										{pageSize}
-									</option>
-								))}
-							</select>
-						</div>
-					)}
+					<div className="flex items-center space-x-2">
+						<p className="font-medium text-sm">Filas por página</p>
+						<select
+							value={
+								isServerPagination
+									? serverPagination.pageSize
+									: table.getState().pagination.pageSize
+							}
+							onChange={(e) => {
+								const size = Number(e.target.value);
+								if (isServerPagination) {
+									serverPagination.onPageSizeChange?.(size);
+								} else {
+									table.setPageSize(size);
+								}
+							}}
+							className="h-8 w-[70px] rounded-md border border-input bg-background px-2 py-1 text-sm"
+						>
+							{pageSizeOptions.map((pageSize) => (
+								<option key={pageSize} value={pageSize}>
+									{pageSize}
+								</option>
+							))}
+						</select>
+					</div>
 					<div className="flex w-[100px] items-center justify-center font-medium text-sm">
 						Página{" "}
 						{isServerPagination

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -22,6 +22,7 @@ export type ContratoCobranza = {
 	cuotaMensual: string | null;
 	etiquetas: string[] | null;
 	isPool?: boolean;
+	responsableCobros: string | null;
 };
 
 function getEstadoBadge(estado: string) {
@@ -167,6 +168,23 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 					{row.getValue("clienteNombre")}
 				</div>
 			);
+		},
+	},
+	{
+		accessorKey: "responsableCobros",
+		header: ({ column }) => (
+			<Button
+				variant="ghost"
+				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+			>
+				Asesor
+				<ArrowUpDown className="ml-2 h-4 w-4" />
+			</Button>
+		),
+		cell: ({ row }) => {
+			const asesor = row.getValue("responsableCobros") as string | null;
+			if (!asesor) return <span className="text-muted-foreground text-xs">Sin asignar</span>;
+			return <span className="font-medium text-sm">{asesor}</span>;
 		},
 	},
 	{

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -1112,12 +1112,17 @@ function RouteComponent() {
 								</div>
 							</div>
 						}
+						pageSizeOptions={[25, 50, 75, 100, 200]}
 						serverPagination={{
 							page: page,
 							pageSize: pageSize,
 							totalPages: totalPages,
 							totalItems: totalCreditos,
 							onPageChange: (newPage) => setPage(newPage),
+							onPageSizeChange: (newSize) => {
+								setPageSize(newSize);
+								setPage(1);
+							},
 						}}
 					/>
 				</CardContent>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -292,7 +292,7 @@ function RouteComponent() {
 	const [page, setPage] = useState(1);
 	const [filterValue, setFilterValue] = useState("");
 	const [debouncedFilterValue, setDebouncedFilterValue] = useState("");
-	const [pageSize, setPageSize] = useState(10);
+	const [pageSize, setPageSize] = useState(25);
 
 	// Debounce para el filtro de búsqueda (1 segundos)
 	useEffect(() => {


### PR DESCRIPTION
CRM agregación de asesor de cobros en tabla casos de cobranza y mejora de paginación
- Agregado campo responsableCobros: string | null al tipo ContratoCobranza en columns.tsx
- Nueva columna Asesor de Cobros en la tabla de Casos de Cobranza muestra el nombre del asesor asignado al crédito o "Sin asignar" si no hay asesor, se puede filtrar la tabla por dicha columna columna de forma ascendente/descendente
- Selector de Filas por página ahora es de 25, 50, 75, 100, 200
- Agregada prop pageSizeOptions al componente DataTable para configurar las opciones por tabla por defecto [10, 20, 30, 40, 50] mantiene el comportamiento original en opportunities