### PR TITLE
fix:solve problems

### DIFF
--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -1,7 +1,17 @@
 import { db } from "../database";
-import { creditos_inversionistas_espejo, creditos_inversionistas } from "../database/db";
+import {
+  creditos_inversionistas_espejo,
+  creditos_inversionistas,
+  creditos,
+  inversionistas,
+} from "../database/db";
 import { eq, inArray, and } from "drizzle-orm";
 import z from "zod";
+import jwt from "jsonwebtoken";
+import { sendPlainEmail } from "@cci/email";
+import { INVESTOR_STATUS_CHANGE_RECIPIENTS } from "../utils/functions/investorStatusRecipients";
+
+const JWT_SECRET = process.env.JWT_SECRET || "supersecreto";
 
 // ========================================
 // SCHEMA DE VALIDACIÓN
@@ -19,7 +29,7 @@ const completeEspejoSchema = z.object({
 // CONTROLLER
 // ========================================
 
-export const completeEspejo = async ({ body, set }: any) => {
+export const completeEspejo = async ({ body, set, request }: any) => {
   try {
     const parseResult = completeEspejoSchema.safeParse(body);
     if (!parseResult.success) {
@@ -89,11 +99,142 @@ export const completeEspejo = async ({ body, set }: any) => {
       }
     });
 
+    const totalActualizados = resultados.reduce(
+      (acc, r) => acc + r.registros_actualizados,
+      0,
+    );
+
+    // ========================================================================
+    // CORREO DE NOTIFICACIÓN
+    // ========================================================================
+    // Se manda solo si hubo al menos un registro actualizado.
+    // Va a la misma lista hardcodeada que los cambios de status del
+    // inversionista (INVESTOR_STATUS_CHANGE_RECIPIENTS).
+    let correos_enviados = 0;
+    let correos_fallidos = 0;
+
+    if (totalActualizados > 0) {
+      try {
+        // Resolver ejecutor desde el JWT (opcional, best-effort)
+        let usuarioEmail: string | undefined;
+        let usuarioNombre: string | undefined;
+        try {
+          const authHeader = request?.headers?.get?.("Authorization");
+          if (authHeader?.startsWith("Bearer ")) {
+            const token = authHeader.replace("Bearer ", "").trim();
+            const decoded = jwt.verify(token, JWT_SECRET) as any;
+            usuarioEmail = decoded.email ?? decoded.correo ?? undefined;
+            usuarioNombre = decoded.nombre ?? decoded.name ?? undefined;
+          }
+        } catch (jwtErr) {
+          console.warn("[completeEspejo] No se pudo resolver el usuario del JWT:", jwtErr);
+        }
+
+        // Datos de los créditos para la tabla del correo
+        const creditosInfo = await db
+          .select({
+            credito_id: creditos.credito_id,
+            numero_credito_sifco: creditos.numero_credito_sifco,
+          })
+          .from(creditos)
+          .where(inArray(creditos.credito_id, creditoIds));
+        const sifcoPorCredito = new Map(
+          creditosInfo.map((c) => [c.credito_id, c.numero_credito_sifco]),
+        );
+
+        // Nombre del inversionista si el completar fue filtrado por uno solo
+        let inversionistaNombre: string | undefined;
+        if (inversionista_id) {
+          const [invRow] = await db
+            .select({ nombre: inversionistas.nombre })
+            .from(inversionistas)
+            .where(eq(inversionistas.inversionista_id, inversionista_id));
+          inversionistaNombre = invRow?.nombre;
+        }
+
+        const fechaGT = new Date().toLocaleString("es-GT", {
+          timeZone: "America/Guatemala",
+        });
+
+        const filasCreditos = resultados
+          .map((r) => {
+            const sifco = sifcoPorCredito.get(r.credito_id) ?? "—";
+            return `
+              <tr>
+                <td style="padding:6px 10px; border:1px solid #e5e7eb;">${sifco}</td>
+                <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.credito_id}</td>
+                <td style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">${r.registros_actualizados}</td>
+              </tr>
+            `;
+          })
+          .join("");
+
+        const subject = inversionista_id
+          ? `Compra de cartera aceptada por contabilidad — ${inversionistaNombre ?? `Inversionista ${inversionista_id}`}`
+          : `Compra de cartera aceptada por contabilidad — ${creditoIds.length} crédito(s)`;
+
+        const html = `
+          <div style="font-family: Arial, sans-serif; color:#111;">
+            <h2 style="margin-bottom: 8px;">Compra de cartera <strong style="color:#16a34a;">ACEPTADA POR CONTABILIDAD</strong></h2>
+            <p>Los registros espejo de los créditos listados fueron marcados como <strong>completado</strong>.</p>
+            <table style="border-collapse: collapse; margin-top: 8px;">
+              ${inversionista_id
+                ? `<tr><td style="padding:4px 8px;"><strong>Inversionista:</strong></td><td style="padding:4px 8px;">${inversionistaNombre ?? "(desconocido)"} (ID: ${inversionista_id})</td></tr>`
+                : `<tr><td style="padding:4px 8px;"><strong>Alcance:</strong></td><td style="padding:4px 8px;">Todos los inversionistas de los créditos listados</td></tr>`}
+              <tr><td style="padding:4px 8px;"><strong>Créditos:</strong></td><td style="padding:4px 8px;">${creditoIds.length}</td></tr>
+              <tr><td style="padding:4px 8px;"><strong>Registros actualizados:</strong></td><td style="padding:4px 8px;"><strong>${totalActualizados}</strong></td></tr>
+              <tr><td style="padding:4px 8px;"><strong>Fecha (GT):</strong></td><td style="padding:4px 8px;">${fechaGT}</td></tr>
+              ${usuarioNombre || usuarioEmail
+                ? `<tr><td style="padding:4px 8px;"><strong>Aceptada por:</strong></td><td style="padding:4px 8px;">${[usuarioNombre, usuarioEmail].filter(Boolean).join(" — ")}</td></tr>`
+                : `<tr><td style="padding:4px 8px;"><strong>Aceptada por:</strong></td><td style="padding:4px 8px;">Contabilidad</td></tr>`}
+            </table>
+
+            <h3 style="margin-top:16px;">Detalle por crédito</h3>
+            <table style="border-collapse: collapse; margin-top: 4px; min-width: 420px;">
+              <thead>
+                <tr style="background:#f3f4f6;">
+                  <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">SIFCO</th>
+                  <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">Crédito ID</th>
+                  <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">Registros completados</th>
+                </tr>
+              </thead>
+              <tbody>${filasCreditos}</tbody>
+            </table>
+
+            <p style="margin-top:16px; color:#555; font-size:12px;">Correo automático — Club Cash In / Cartera.</p>
+          </div>
+        `;
+
+        const mailResults = await Promise.allSettled(
+          INVESTOR_STATUS_CHANGE_RECIPIENTS.map((to) =>
+            sendPlainEmail(to, subject, html),
+          ),
+        );
+
+        correos_enviados = mailResults.filter(
+          (r) => r.status === "fulfilled" && (r as any).value?.success,
+        ).length;
+        correos_fallidos = INVESTOR_STATUS_CHANGE_RECIPIENTS.length - correos_enviados;
+
+        if (correos_fallidos > 0) {
+          console.warn(
+            `[completeEspejo] ${correos_fallidos} correo(s) fallaron de ${INVESTOR_STATUS_CHANGE_RECIPIENTS.length}`,
+            mailResults,
+          );
+        }
+      } catch (mailErr) {
+        console.error("[completeEspejo] Error enviando correo:", mailErr);
+      }
+    }
+
     set.status = 200;
     return {
       success: true,
-      message: `${resultados.reduce((acc, r) => acc + r.registros_actualizados, 0)} registros marcados como completado`,
+      message: `${totalActualizados} registros marcados como completado`,
       resultados,
+      correos_enviados,
+      correos_fallidos,
+      total_destinatarios: INVESTOR_STATUS_CHANGE_RECIPIENTS.length,
     };
   } catch (error) {
     console.error("[completeEspejo] Error:", error);

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4355,7 +4355,7 @@ export const exitInvestor = async ({ body, set, request }: any) => {
               .set({
                 inversionista_id: CUBE_INVESTMENT_ID,
                 porcentaje_cash_in: "100",
-                porcentaje_participacion_inversionista: "100",
+                porcentaje_participacion_inversionista: "0",
                 monto_aportado: nuevoMontoCubePadre.toString(),
                 status: "completado",
                 updated_at: new Date(),
@@ -4379,7 +4379,7 @@ export const exitInvestor = async ({ body, set, request }: any) => {
 
             const payloadE = {
               monto_aportado: nuevoMontoCubePadre.toString(),
-              porcentaje_participacion_inversionista: "100",
+              porcentaje_participacion_inversionista: "0",
               porcentaje_cash_in: "100",
               monto_inversionista: suma(cubeEnEspejo.monto_inversionista, invEnEspejo.monto_inversionista),
               monto_cash_in: suma(cubeEnEspejo.monto_cash_in, invEnEspejo.monto_cash_in),
@@ -4389,7 +4389,7 @@ export const exitInvestor = async ({ body, set, request }: any) => {
               status: "completado" as const,
               updated_at: new Date(),
             };
-            log(`   🔀 [ESPEJO] Caso B (MERGE): porcentajes 100/100, monto_aportado=${nuevoMontoCubePadre.toString()} (sincronizado con padre) →`, payloadE);
+            log(`   🔀 [ESPEJO] Caso B (MERGE): porcentajes 100, monto_aportado=${nuevoMontoCubePadre.toString()} (sincronizado con padre) →`, payloadE);
 
             const resEB1 = await tx
               .update(creditos_inversionistas_espejo)

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -36,14 +36,7 @@ import jwt from "jsonwebtoken";
 
 const JWT_SECRET = process.env.JWT_SECRET || "supersecreto";
 
-const INVESTOR_STATUS_CHANGE_RECIPIENTS = [
-  "alexander.p@clubcashin.com",
-  "juan.r@clubcashin.com",
-  "roxana.g@clubcashin.com",
-  "sara.r@sepresta.com",
-  "jalvarado@clubcashin.com",
-  "lralda@clubcashin.com",
-];
+import { INVESTOR_STATUS_CHANGE_RECIPIENTS } from "../utils/functions/investorStatusRecipients";
 import {
   boletaEstaEnPeriodo,
   resolveEstadoLiquidacionResumen,
@@ -3949,6 +3942,20 @@ export const updateInvestorStatus = async ({ body, set, request }: any) => {
       </div>
     `;
 
+    // Cuando el inversionista pasa a 'activo' NO se envía correo: solo
+    // se notifica en salidas (inactivo / pendiente_devolucion).
+    if (status === "activo") {
+      set.status = 200;
+      return {
+        success: true,
+        message: `Inversionista marcado como ${status} correctamente (sin correo)`,
+        inversionista: updated,
+        correos_enviados: 0,
+        correos_fallidos: 0,
+        total_destinatarios: 0,
+      };
+    }
+
     const mailResults = await Promise.allSettled(
       INVESTOR_STATUS_CHANGE_RECIPIENTS.map((to) => sendPlainEmail(to, subject, html))
     );
@@ -4209,6 +4216,15 @@ export const exitInvestor = async ({ body, set, request }: any) => {
         const montoTransferido = new Big(invEnPadre.monto_aportado);
         const cubePreexistente = !!cubeEnPadre;
 
+        // Monto final que va a tener CUBE en PADRE tras la operación.
+        // - SWAP: lo que aportaba el inversionista (el row es el mismo).
+        // - MERGE: suma del que ya tenía CUBE + el del inversionista.
+        // Este mismo valor se fuerza en el espejo para que espejo = padre
+        // (Opción 1: sincronización total de capital).
+        const nuevoMontoCubePadre: Big = cubeEnPadre
+          ? new Big(cubeEnPadre.monto_aportado).plus(new Big(invEnPadre.monto_aportado))
+          : new Big(invEnPadre.monto_aportado);
+
         if (cubePreexistente && cubeEnPadre) {
           log(`   🟡 CUBE YA existe en el crédito (padre): monto_aportado=${cubeEnPadre.monto_aportado}`);
         } else {
@@ -4218,16 +4234,19 @@ export const exitInvestor = async ({ body, set, request }: any) => {
         if (!cubeEnPadre) {
           // ──────────────────────────────────────────────────────────────────
           // 4.4A — CASO A: SWAP en PADRE
-          // CUBE no está en el crédito → sencillamente cambiamos el
-          // `inversionista_id` del row del inversionista a CUBE. El row
-          // conserva monto, cuota, porcentajes, fechas, etc. Es la operación
-          // más barata (un solo UPDATE) y no modifica ningún otro row del
-          // pool.
+          // CUBE no está en el crédito → cambiamos el `inversionista_id` del
+          // row del inversionista a CUBE. El row conserva monto, cuota, etc.,
+          // pero forzamos los porcentajes de CUBE (100/100): CUBE siempre
+          // tiene participación total y cash-in total en el row que ocupa.
           // ──────────────────────────────────────────────────────────────────
-          log(`   🔄 [PADRE] Caso A (SWAP): cambiando inversionista_id ${inversionista_id} → ${CUBE_INVESTMENT_ID}`);
+          log(`   🔄 [PADRE] Caso A (SWAP): cambiando inversionista_id ${inversionista_id} → ${CUBE_INVESTMENT_ID} (porcentajes forzados a 100/100)`);
           const resA = await tx
             .update(creditos_inversionistas)
-            .set({ inversionista_id: CUBE_INVESTMENT_ID })
+            .set({
+              inversionista_id: CUBE_INVESTMENT_ID,
+              porcentaje_cash_in: "100",
+              porcentaje_participacion_inversionista: "100",
+            })
             .where(
               and(
                 eq(creditos_inversionistas.credito_id, credito_id),
@@ -4241,26 +4260,26 @@ export const exitInvestor = async ({ body, set, request }: any) => {
           // 4.4B — CASO B: MERGE en PADRE
           // CUBE ya está en el crédito → no podemos tener dos rows de CUBE
           // (uniqueIndex ux_credito_inversionista). Entonces:
-          //   1. Sumar todos los campos numéricos del inversionista al row
-          //      de CUBE (monto, %participación, cuota, intereses, IVA).
-          //   2. Borrar el row del inversionista.
-          // No se tocan otros inversionistas del pool. `porcentaje_cash_in`
-          // de CUBE se preserva (es config, no acumulable).
+          //   1. Sumar los campos de monto/cuota/intereses/IVA del
+          //      inversionista al row de CUBE.
+          //   2. Forzar porcentaje_cash_in=100 y
+          //      porcentaje_participacion_inversionista=100 (no se suman —
+          //      CUBE siempre queda al 100/100 en su row).
+          //   3. Borrar el row del inversionista.
+          // No se tocan otros inversionistas del pool.
           // ──────────────────────────────────────────────────────────────────
           const suma = (a: string | number, b: string | number) => new Big(a).plus(new Big(b)).toString();
           const payload = {
             monto_aportado: suma(cubeEnPadre.monto_aportado, invEnPadre.monto_aportado),
-            porcentaje_participacion_inversionista: suma(
-              cubeEnPadre.porcentaje_participacion_inversionista,
-              invEnPadre.porcentaje_participacion_inversionista,
-            ),
+            porcentaje_participacion_inversionista: "100",
+            porcentaje_cash_in: "100",
             monto_inversionista: suma(cubeEnPadre.monto_inversionista, invEnPadre.monto_inversionista),
             monto_cash_in: suma(cubeEnPadre.monto_cash_in, invEnPadre.monto_cash_in),
             iva_inversionista: suma(cubeEnPadre.iva_inversionista, invEnPadre.iva_inversionista),
             iva_cash_in: suma(cubeEnPadre.iva_cash_in, invEnPadre.iva_cash_in),
             cuota_inversionista: suma(cubeEnPadre.cuota_inversionista, invEnPadre.cuota_inversionista),
           };
-          log(`   🔀 [PADRE] Caso B (MERGE): sumando en CUBE →`, payload);
+          log(`   🔀 [PADRE] Caso B (MERGE): sumando en CUBE + porcentajes 100/100 →`, payload);
 
           const resB1 = await tx
             .update(creditos_inversionistas)
@@ -4326,12 +4345,18 @@ export const exitInvestor = async ({ body, set, request }: any) => {
             .limit(1);
 
           if (!cubeEnEspejo) {
-            // 4.5A — ESPEJO SWAP: sólo cambia el id y fuerza status completado.
-            log(`   🔄 [ESPEJO] Caso A (SWAP): cambiando inversionista_id ${inversionista_id} → ${CUBE_INVESTMENT_ID}, status→completado`);
+            // 4.5A — ESPEJO SWAP: cambia id, fuerza status=completado,
+            // fija porcentajes de CUBE a 100/100 y sincroniza monto_aportado
+            // con el valor del PADRE (para que CUBE quede con el capital
+            // "original", sin descuentos por pagos previos).
+            log(`   🔄 [ESPEJO] Caso A (SWAP): cambiando inversionista_id ${inversionista_id} → ${CUBE_INVESTMENT_ID}, status→completado, porcentajes 100/100, monto_aportado=${nuevoMontoCubePadre.toString()} (sincronizado con padre)`);
             const resEA = await tx
               .update(creditos_inversionistas_espejo)
               .set({
                 inversionista_id: CUBE_INVESTMENT_ID,
+                porcentaje_cash_in: "100",
+                porcentaje_participacion_inversionista: "100",
+                monto_aportado: nuevoMontoCubePadre.toString(),
                 status: "completado",
                 updated_at: new Date(),
               })
@@ -4344,17 +4369,18 @@ export const exitInvestor = async ({ body, set, request }: any) => {
               .returning({ id: creditos_inversionistas_espejo.id });
             log(`   ✅ [ESPEJO] SWAP aplicado (${resEA.length})`);
           } else {
-            // 4.5B — ESPEJO MERGE: mismos campos que el padre + status=completado.
+            // 4.5B — ESPEJO MERGE: sumar intereses/IVA del investor al row
+            // CUBE, forzar porcentajes a 100/100 y fijar monto_aportado al
+            // valor del PADRE (sincroniza capital, ignora cuánto había en
+            // espejo para ese campo).
             log(`   🟡 [ESPEJO] CUBE YA existe en espejo: monto_aportado=${cubeEnEspejo.monto_aportado}, status=${cubeEnEspejo.status}`);
             const suma = (a: string | number, b: string | number) =>
               new Big(a).plus(new Big(b)).toString();
 
             const payloadE = {
-              monto_aportado: suma(cubeEnEspejo.monto_aportado, invEnEspejo.monto_aportado),
-              porcentaje_participacion_inversionista: suma(
-                cubeEnEspejo.porcentaje_participacion_inversionista,
-                invEnEspejo.porcentaje_participacion_inversionista,
-              ),
+              monto_aportado: nuevoMontoCubePadre.toString(),
+              porcentaje_participacion_inversionista: "100",
+              porcentaje_cash_in: "100",
               monto_inversionista: suma(cubeEnEspejo.monto_inversionista, invEnEspejo.monto_inversionista),
               monto_cash_in: suma(cubeEnEspejo.monto_cash_in, invEnEspejo.monto_cash_in),
               iva_inversionista: suma(cubeEnEspejo.iva_inversionista, invEnEspejo.iva_inversionista),
@@ -4363,7 +4389,7 @@ export const exitInvestor = async ({ body, set, request }: any) => {
               status: "completado" as const,
               updated_at: new Date(),
             };
-            log(`   🔀 [ESPEJO] Caso B (MERGE): sumando en CUBE →`, payloadE);
+            log(`   🔀 [ESPEJO] Caso B (MERGE): porcentajes 100/100, monto_aportado=${nuevoMontoCubePadre.toString()} (sincronizado con padre) →`, payloadE);
 
             const resEB1 = await tx
               .update(creditos_inversionistas_espejo)

--- a/apps/cartera-back/src/utils/functions/investorStatusRecipients.ts
+++ b/apps/cartera-back/src/utils/functions/investorStatusRecipients.ts
@@ -1,0 +1,14 @@
+// Destinatarios fijos para los correos de cambio de status de inversionista
+// (updateInvestorStatus y exitInvestor). Lista definida por negocio.
+export const INVESTOR_STATUS_CHANGE_RECIPIENTS = [
+  "info@clubcashin.com",
+  "diego.a@sepresta.com",
+  "sara.r@sepresta.com",
+  "caja@sepresta.com",
+  "alexander.p@clubcashin.com",
+  "juan.r@clubcashin.com",
+  "roxana.g@clubcashin.com",
+  "pablo.z@clubcashin.com",
+  "diego.l@clubcashin.com",
+  "jalvarado@clubcashin.com",
+];

--- a/apps/cartera-back/src/utils/functions/uploadsFiles.ts
+++ b/apps/cartera-back/src/utils/functions/uploadsFiles.ts
@@ -11,39 +11,42 @@ export const s3 = new S3Client({
   },
 });
 
-export async function uploadFileController({ request, set }: any) {
+export async function uploadFileController({ body, set }: any) {
   try {
-  const form = await request.formData();
-  const file = form.get("file");
-  console.log("Received file:", file);
-  if (!file || !(file instanceof Blob)) {
-    set.status = 400;
-    return { error: "No file uploaded" };
-  }
+    // Elysia ya parseó el multipart. El archivo llega en `body.file` como un
+    // File/Blob. NO usar `request.formData()` acá: el body ya fue consumido
+    // por el parser interno de Elysia y tirar "ERR_BODY_ALREADY_USED".
+    const file = body?.file;
+    console.log("Received file:", file);
 
-  // Obtener extensión
-  let ext = "";
-  if ("name" in file) {
-    const parts = (file as any).name.split(".");
-    if (parts.length > 1) ext = "." + parts.pop();
-  }
-  const filename = `${uuidv4()}${ext}`;
+    if (!file || !(file instanceof Blob)) {
+      set.status = 400;
+      return { error: "No file uploaded" };
+    }
 
-  // Convertir Blob a Buffer
-  const buffer = Buffer.from(await file.arrayBuffer());
+    // Obtener extensión
+    let ext = "";
+    if ("name" in file) {
+      const parts = (file as any).name.split(".");
+      if (parts.length > 1) ext = "." + parts.pop();
+    }
+    const filename = `${uuidv4()}${ext}`;
 
-  await s3.send(
-    new PutObjectCommand({
-      Bucket: process.env.R2_BUCKET,
-      Key: filename,
-      Body: buffer,
-      ContentType: file.type || "application/octet-stream",
-    })
-  );
+    // Convertir Blob a Buffer
+    const buffer = Buffer.from(await file.arrayBuffer());
 
-  const url = `${filename}`;
-  return { success: true, url, filename };}
-  catch (error) {
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: process.env.R2_BUCKET,
+        Key: filename,
+        Body: buffer,
+        ContentType: file.type || "application/octet-stream",
+      })
+    );
+
+    const url = `${filename}`;
+    return { success: true, url, filename };
+  } catch (error) {
     console.error("Error uploading file:", error);
     set.status = 500;
     return { error: "Error uploading file" };

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -1390,7 +1390,7 @@ function MobileView({
                 </Button>
               )}
             {canViewReports(item.creditos.statusCredit) &&
-              user?.role === "ADMIN" && (
+              (user?.role === "ADMIN" || user?.role === "ASESOR") && (
                 <Button
                   variant="outline"
                   size="sm"
@@ -1695,7 +1695,7 @@ function DesktopView({
                           )}
 
                         {canViewReports(item.creditos.statusCredit) &&
-                          user?.role === "ADMIN" && (
+                          (user?.role === "ADMIN" || user?.role === "ASESOR") && (
                             <Button
                               variant="outline"
                               className="text-green-700 border-green-300 hover:bg-green-50"


### PR DESCRIPTION
## Summary

Adds a full investor offboarding lifecycle:
- New `inversionistas.status` column (`activo` / `inactivo` / `pendiente_devolucion`).
- `POST /investor/status` — toggles status + sends notification. Forces
  `tipo_reinversion = sin_reinversion` when marking a pendiente_devolucion.
- `POST /investor/exit` — transfers the investor's participations to
  CUBE Investments (ID 86) in the given credits, marks the investor as
  `inactivo` and emails the ops list.
- Integrates the `pendiente_devolucion` state into payment distribution
  so capital gets fully returned in the next pago.
- Notifies contabilidad when a `completeEspejo` runs.

## Changes

### Schema
- `statusInversionistaEnum`: `activo | inactivo | pendiente_devolucion`.
- `inversionistas.status` (default `activo`).

### Controllers
- `updateInvestorStatus` (`POST /investor/status`): validates body,
  updates status, auto-applies `sin_reinversion` when entering
  `pendiente_devolucion`, emails recipients only on non-`activo` changes.
- `exitInvestor` (`POST /investor/exit`): for each credit:
  - **SWAP** when CUBE doesn't exist in the credit — changes the row's
    `inversionista_id` to 86 and forces `porcentaje_cash_in=100`,
    `porcentaje_participacion_inversionista=100`.
  - **MERGE** when CUBE already exists — sums monto/cuota/interest/IVA
    into CUBE's row, enforces 100/100 percentages, deletes the
    investor's row.
  - Syncs `creditos_inversionistas_espejo.monto_aportado` with the
    resulting padre value (so CUBE holds the original capital, not the
    decremented espejo balance).
  - Sets `bandera_reinversion = false` on the credit.
  - Flips investor to `inactivo` once at least one credit is processed.
  - Everything inside a single DB transaction.
- `completeEspejo`: sends "Compra de cartera aceptada por contabilidad"
  email after the status update.

### Payments (`insertPagosCreditoInversionistas`)
- Fetches investor status alongside name.
- When status is `pendiente_devolucion`:
  - `abono_capital = monto_aportado` (full return of remaining capital).
  - Skips pending `abonos_capital` (avoids double-counting).
- Interest and IVA continue being computed normally.

### Misc
- Extracted recipients list to
  `utils/functions/investorStatusRecipients.ts`.
- Fixed `uploadFileController` `ERR_BODY_ALREADY_USED` — reads from
  `body.file` instead of `request.formData()`.
 
