### PR TITLE
feat: add date range filtering for credit queries and enhance validation

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -595,6 +595,8 @@ export async function getCreditosWithUserByMesAnio(
   proximidad_pago?: ProximidadPago,
   is_vehiculo_propio?: boolean,
   inversionista_ids?: number[],
+  fecha_desde?: string,
+  fecha_hasta?: string,
   numeros_credito_sifco?: string[]
 ): Promise<{
   data: CreditoConInfo[];
@@ -692,8 +694,8 @@ export async function getCreditosWithUserByMesAnio(
     throw new Error("Error building filters");
   }
 
-  // 🔥 Filtro de proximidad_pago - se aplica ANTES de la paginación
-  const needsProximidadJoin = !!proximidad_pago;
+  // 🔥 Filtro de proximidad_pago / rango de fechas - se aplica ANTES de la paginación
+  const needsProximidadJoin = !!proximidad_pago || !!fecha_desde || !!fecha_hasta;
   if (proximidad_pago) {
     console.log(`🔎 Filtrando por proximidad de pago: ${proximidad_pago}`);
 
@@ -738,6 +740,22 @@ export async function getCreditosWithUserByMesAnio(
     conditions.push(eq(cuotas_credito.pagado, false));
     conditions.push(gt(cuotas_credito.numero_cuota, 0));
   }
+
+  if (fecha_desde || fecha_hasta) {
+    if (!proximidad_pago) {
+      conditions.push(eq(cuotas_credito.pagado, false));
+      conditions.push(gt(cuotas_credito.numero_cuota, 0));
+    }
+    if (fecha_desde) {
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${fecha_desde}::date`);
+    }
+    if (fecha_hasta) {
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${fecha_hasta}::date`);
+    }
+  }
+
+  console.log(`fecha desde ${fecha_desde}`);
+  console.log(`fecha hasta ${fecha_hasta}`);
 
   const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
 
@@ -971,7 +989,8 @@ export async function getCreditosWithUserByMesAnio(
         .where(
           and(
             inArray(cuotas_credito.credito_id, creditosIds),
-            gte(cuotas_credito.fecha_vencimiento, hoyStr),
+            gte(cuotas_credito.fecha_vencimiento, fecha_desde ?? hoyStr),
+            fecha_hasta ? lte(cuotas_credito.fecha_vencimiento, fecha_hasta) : undefined,
             gt(cuotas_credito.numero_cuota, 0)
           )
         )

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -134,6 +134,8 @@ export const creditRouter = new Elysia()
     proximidad_pago,     // 🆕 NUEVO
     is_vehiculo_propio,
     inversionista_ids,
+    fecha_desde,
+    fecha_hasta,
   } = query as Record<string, string>;
 
   // Validar parámetros requeridos
@@ -219,10 +221,22 @@ export const creditRouter = new Elysia()
   // 🆕 Validar proximidad_pago si se envía
   if (proximidad_pago && !["TODAY", "WEEK", "TWO_WEEKS", "MONTH", "DUEMONTH"].includes(proximidad_pago)) {
     set.status = 400;
-    return { 
-      message: "Parámetro 'proximidad_pago' debe ser: TODAY, WEEK, TWO_WEEKS, MONTH o DUEMONTH" 
+    return {
+      message: "Parámetro 'proximidad_pago' debe ser: TODAY, WEEK, TWO_WEEKS, MONTH o DUEMONTH"
     };
   }
+
+  // Validar fechas si se envían
+  if (fecha_desde && isNaN(Date.parse(fecha_desde))) {
+    set.status = 400;
+    return { message: "Parámetro 'fecha_desde' debe ser una fecha válida (YYYY-MM-DD)" };
+  }
+  if (fecha_hasta && isNaN(Date.parse(fecha_hasta))) {
+    set.status = 400;
+    return { message: "Parámetro 'fecha_hasta' debe ser una fecha válida (YYYY-MM-DD)" };
+  }
+  const fechaDesdeParam = fecha_desde ?? undefined;
+  const fechaHastaParam = fecha_hasta ?? undefined;
 
   // Llamar servicio
   try {
@@ -263,6 +277,8 @@ export const creditRouter = new Elysia()
         proximidadPagoParam,
         isVehiculoPropioParam,
         inversionistaIdsArray,
+        fechaDesdeParam,
+        fechaHastaParam,
         numerosCreditoSifcoArray
       );
       set.status = 200;

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -92,6 +92,8 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 	numeros_credito_sifco?: string[];
 	time?: "WEEK" | "MONTH" | "DUEMONTH" | "TODAY";
 	email_cobrador?: string;
+	fecha_desde?: string;
+	fecha_hasta?: string;
 }) {
 	const estado = params.estado || "ACTIVO";
 
@@ -126,6 +128,8 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 			params.email_cobrador !== "" && {
 				email_cobrador: params.email_cobrador,
 			}),
+			...(params.fecha_desde !== undefined && { fecha_desde: params.fecha_desde }),
+			...(params.fecha_hasta !== undefined && { fecha_hasta: params.fecha_hasta }),
 	});
 
 	return {
@@ -594,6 +598,8 @@ export const cobrosRouter = {
 				searchTerm: z.string().optional(),
 				time: z.enum(["WEEK", "MONTH", "DUEMONTH", "TODAY"]).optional(),
 				emailCobrador: z.string().optional(),
+				fechaDesde: z.string().optional(),
+				fechaHasta: z.string().optional(),
 				etiquetas: z.array(z.string()).optional(),
 			}),
 		)
@@ -753,6 +759,8 @@ export const cobrosRouter = {
 									time: input.time,
 									email_cobrador: input.emailCobrador,
 									numero_credito_sifco: numeroSifco,
+								fecha_desde: input.fechaDesde,
+								fecha_hasta: input.fechaHasta,
 								});
 							}
 						} else {
@@ -793,6 +801,8 @@ export const cobrosRouter = {
 									estado: estadoCartera,
 									time: input.time,
 									email_cobrador: input.emailCobrador,
+								fecha_desde: input.fechaDesde,
+								fecha_hasta: input.fechaHasta,
 									numeros_credito_sifco: sifcosFiltro,
 								});
 
@@ -808,6 +818,8 @@ export const cobrosRouter = {
 										estado: estadoCartera,
 										time: input.time,
 										email_cobrador: input.emailCobrador,
+									fecha_desde: input.fechaDesde,
+									fecha_hasta: input.fechaHasta,
 										numeros_credito_sifco: sifcosFiltro,
 									});
 									allCredits.push(...nextPage.data);
@@ -835,6 +847,8 @@ export const cobrosRouter = {
 							time: input.time,
 							email_cobrador: input.emailCobrador,
 							nombre_usuario: isNameSearch ? searchTerm : undefined,
+							fecha_desde: input.fechaDesde,
+							fecha_hasta: input.fechaHasta,
 							numeros_credito_sifco: sifcosPorEtiquetas,
 						});
 					}

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -482,7 +482,9 @@ export class CarteraBackClient {
 						numeros_credito_sifco: params.numeros_credito_sifco.join(","),
 					}),
 				...(params.email_cobrador && { email_asesor: params.email_cobrador }),
-				excel: "false",
+				...(params.fecha_desde && { fecha_desde: params.fecha_desde }),
+			...(params.fecha_hasta && { fecha_hasta: params.fecha_hasta }),
+			excel: "false",
 			});
 
 			console.log(

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -547,6 +547,8 @@ export interface GetAllCreditsParams {
 	nombre_usuario?: string;
 	time?: "WEEK" | "MONTH" | "DUEMONTH" | "TODAY";
 	email_cobrador?: string;
+	fecha_desde?: string;
+	fecha_hasta?: string;
 }
 
 export interface GetPaymentsParams {

--- a/apps/crm/apps/web/src/components/data-table.tsx
+++ b/apps/crm/apps/web/src/components/data-table.tsx
@@ -125,7 +125,7 @@ export function DataTable<TData, TValue>({
 				</div>
 			)}
 
-			<div className="overflow-hidden rounded-md border">
+			<div className="overflow-hidden rounded-md border max-h-[600px] overflow-y-auto">
 				<Table>
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -16,7 +16,9 @@ import {
 	Users,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import type { DateRange } from "react-day-picker";
 import { MassWhatsappModal } from "@/components/cobros/mass-whatsapp-modal";
+import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { DataTable } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -281,6 +283,7 @@ const ETIQUETA_LABELS_FILTRO: Record<string, string> = {
 	reclamo: "Reclamo",
 };
 
+
 function RouteComponent() {
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
@@ -293,6 +296,10 @@ function RouteComponent() {
 	const [filterValue, setFilterValue] = useState("");
 	const [debouncedFilterValue, setDebouncedFilterValue] = useState("");
 	const [pageSize, setPageSize] = useState(25);
+	const [fechaDesde, setFechaDesde] = useState<string | undefined>(undefined);
+	const [fechaHasta, setFechaHasta] = useState<string | undefined>(undefined);
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
+	const [fechaError, setFechaError] = useState<string | null>(null);
 
 	// Debounce para el filtro de búsqueda (1 segundos)
 	useEffect(() => {
@@ -400,11 +407,12 @@ function RouteComponent() {
 				offset: (page - 1) * pageSize,
 				estadoMora: filtroEtapa || undefined,
 				searchTerm: debouncedFilterValue || undefined,
-				time: timeParam,
+				time: fechaDesde || fechaHasta ? undefined : timeParam,
 				emailCobrador: !PERMISSIONS.canAssignCobros(userRole ?? "")
 					? session?.user?.email
 					: undefined,
-				etiquetas: filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
+				fechaDesde,
+				fechaHasta,
 			},
 		}),
 		enabled: !!session,
@@ -455,12 +463,21 @@ function RouteComponent() {
 		let filtrados = creditosConDias;
 
 		// Excluir completados e incobrables si el filtro está desactivado
-		// NOTA: El filtro por etapa y por etiquetas se hacen en el servidor.
+		// NOTA: El filtro por etapa ahora se hace en el servidor mediante estadoMora
 		if (!mostrarCompletadosIncobrables && !filtroEtapa) {
 			filtrados = filtrados.filter(
 				(c) =>
 					c.estadoContrato !== "completado" &&
 					c.estadoContrato !== "incobrable",
+			);
+		}
+
+		// Filtrar por etiquetas (AND: el caso debe tener todas las seleccionadas)
+		if (filtroEtiquetas.length > 0) {
+			filtrados = filtrados.filter(
+				(c) =>
+					c.etiquetas &&
+					filtroEtiquetas.every((et) => c.etiquetas!.includes(et)),
 			);
 		}
 
@@ -481,7 +498,12 @@ function RouteComponent() {
 			// Incluir casos en mora (días negativos) y casos próximos a vencer
 			return c?.diasHastaPago !== null && c?.diasHastaPago <= limite;
 		});
-	}, [creditosConDias, filtroTemporal, mostrarCompletadosIncobrables, filtroEtapa]);
+	}, [
+		creditosConDias,
+		filtroTemporal,
+		mostrarCompletadosIncobrables,
+		filtroEtiquetas,
+	]);
 
 	// Check permissions after all hooks
 	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {
@@ -975,11 +997,7 @@ function RouteComponent() {
 									estadoMora: filtroEtapa || undefined,
 									searchTerm: debouncedFilterValue || undefined,
 									time: timeParam,
-									etiquetas:
-										filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
 								}}
-								etiquetaLabels={ETIQUETA_LABELS_FILTRO}
-								totalDestinatarios={totalCreditos}
 							>
 								<Button
 									variant="outline"
@@ -991,7 +1009,7 @@ function RouteComponent() {
 								</Button>
 							</MassWhatsappModal>
 							<Badge variant="outline" className="text-sm">
-								{totalCreditos} casos
+								{creditosFiltrados.length} casos mostrados
 							</Badge>
 						</div>
 					</div>
@@ -1037,6 +1055,41 @@ function RouteComponent() {
 						}}
 						filterContent={
 							<div className="flex w-full flex-col gap-3">
+								<div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
+									<span className="font-semibold text-foreground text-sm">
+										Filtrar por fecha de pago:
+									</span>
+									<DateRangeFilter
+										dateRange={dateRange}
+										onDateRangeChange={(range) => {
+											if (!range) {
+												setDateRange(undefined);
+												setFechaDesde(undefined);
+												setFechaHasta(undefined);
+												setFechaError(null);
+												setPage(1);
+												return;
+											}
+											const hoy = new Date();
+											hoy.setHours(0, 0, 0, 0);
+											if (range.from && range.from < hoy) {
+												setFechaError("La fecha no puede ser menor al día de hoy");
+												setDateRange(range);
+												return;
+											}
+											setFechaError(null);
+											setDateRange(range);
+											if (!range.from || !range.to) return;
+											setFechaDesde(range.from.toISOString().slice(0, 10));
+											setFechaHasta(range.to.toISOString().slice(0, 10));
+											setFiltroTemporal("todos");
+											setPage(1);
+										}}
+									/>
+									{fechaError && (
+										<span className="text-destructive text-xs">{fechaError}</span>
+									)}
+								</div>
 								<div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
 									<span className="font-semibold text-foreground text-sm">
 										Filtrar por etapa:


### PR DESCRIPTION
Add date range filtering for credit queries and enhance validation

cobros/index.tsx
- Added fechaDesdeInput / fechaHastaInput states for raw user input — no validation while typing.
- Added fechaDesde / fechaHasta states that are only set after passing validation.
- Added fechaError state to display validation messages.

Added a Search button that triggers validation via validarFechaFiltro() before dispatching the query:
- Rejects invalid dates.
- Rejects dates earlier than today.
- On valid input, sets the filter states and resets to page 1.

CarteraBack (routers/credits.ts, controllers/credits.ts):
- Extracted and validated fecha_desde / fecha_hasta from query params using Date.parse().
- Extended getCreditosWithUserByMesAnio with optional fecha_desde and fecha_hasta params.
