### PR TITLE
feat(cobros): filtrado por etiquetas server-side + mejoras WhatsApp masivo

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -594,7 +594,8 @@ export async function getCreditosWithUserByMesAnio(
   cuotas_atrasadas?: number,
   proximidad_pago?: ProximidadPago,
   is_vehiculo_propio?: boolean,
-  inversionista_ids?: number[]
+  inversionista_ids?: number[],
+  numeros_credito_sifco?: string[]
 ): Promise<{
   data: CreditoConInfo[];
   page: number;
@@ -617,7 +618,16 @@ export async function getCreditosWithUserByMesAnio(
 
   try {
     // 📌 Filtros
-    if (numero_credito_sifco && numero_credito_sifco.trim().length > 0) {
+    // Normalizar lista multi-SIFCO (tiene prioridad sobre el filtro single).
+    const sifcosLimpios = numeros_credito_sifco
+      ?.map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (sifcosLimpios && sifcosLimpios.length > 0) {
+      console.log(
+        `🔎 Filtrando por ${sifcosLimpios.length} número(s) de crédito (multi)`
+      );
+      conditions.push(inArray(creditos.numero_credito_sifco, sifcosLimpios));
+    } else if (numero_credito_sifco && numero_credito_sifco.trim().length > 0) {
       console.log(`🔎 Filtrando por número de crédito: ${numero_credito_sifco}`);
       conditions.push(eq(creditos.numero_credito_sifco, numero_credito_sifco.trim()));
     } else {

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -16,6 +16,7 @@ export async function getCreditosWithUserByMesAnioExcel(
     page?: number;
     perPage?: number;
     numero_credito_sifco?: string;
+    numeros_credito_sifco?: string[];
     estado?: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO";
     asesor_id?: number;
     nombre_usuario?: string;
@@ -43,7 +44,8 @@ export async function getCreditosWithUserByMesAnioExcel(
     rest.cuotas_atrasadas,
     rest.proximidad_pago,
     rest.is_vehiculo_propio,
-    rest.inversionista_ids
+    rest.inversionista_ids,
+    rest.numeros_credito_sifco
   );
 
   if (!excel) return result; // si no piden excel, devolvemos JSON normal

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -124,6 +124,7 @@ export const creditRouter = new Elysia()
     page = "1",
     perPage = "10",
     numero_credito_sifco,
+    numeros_credito_sifco,
     estado,
     excel,
     asesor_id,
@@ -148,6 +149,14 @@ export const creditRouter = new Elysia()
   const perPageNum = Number(perPage);
   const numeroCreditoSifco = numero_credito_sifco
     ? String(numero_credito_sifco)
+    : undefined;
+  // Lista opcional de números SIFCO separados por coma. Tiene prioridad
+  // sobre numero_credito_sifco cuando trae al menos un valor válido.
+  const numerosCreditoSifcoArray = numeros_credito_sifco
+    ? String(numeros_credito_sifco)
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
     : undefined;
   const estadoParam = String(estado) as
     | "ACTIVO"
@@ -225,6 +234,7 @@ export const creditRouter = new Elysia()
         page: pageNum,
         perPage: perPageNum,
         numero_credito_sifco: numeroCreditoSifco,
+        numeros_credito_sifco: numerosCreditoSifcoArray,
         estado: estadoParam,
         asesor_id: asesorIdNum,
         nombre_usuario: nombreUsuarioParam,
@@ -252,7 +262,8 @@ export const creditRouter = new Elysia()
         cuotasAtrasadasNum,
         proximidadPagoParam,
         isVehiculoPropioParam,
-        inversionistaIdsArray
+        inversionistaIdsArray,
+        numerosCreditoSifcoArray
       );
       set.status = 200;
       return result;

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -274,6 +274,132 @@ export const creditRouter = new Elysia()
   }
 })
 
+  /**
+   * Variante POST de /getAllCredits.
+   *
+   * Mismos parámetros y misma lógica que el GET — internamente llama al mismo
+   * controller — pero los recibe en el body. Pensado para casos donde la lista
+   * `numeros_credito_sifco` es demasiado grande para entrar en una URL (filtros
+   * por etiqueta que resuelven cientos/miles de SIFCOs disparaban 414 URI Too
+   * Long en proxies).
+   */
+  .post(
+    "/getAllCredits",
+    async ({ body, set }) => {
+      const {
+        mes,
+        anio,
+        page = 1,
+        perPage = 10,
+        numero_credito_sifco,
+        numeros_credito_sifco,
+        estado,
+        excel,
+        asesor_id,
+        nombre_usuario,
+        email_asesor,
+        cuotas_atrasadas,
+        proximidad_pago,
+        is_vehiculo_propio,
+        inversionista_ids,
+      } = body;
+
+      if (mes === undefined || anio === undefined || !estado) {
+        set.status = 400;
+        return { message: "Faltan parámetros 'mes', 'anio' y/o 'estado'." };
+      }
+      if (mes < 0 || mes > 12 || anio < 0) {
+        set.status = 400;
+        return { message: "Parámetros 'mes' y/o 'anio' inválidos." };
+      }
+
+      const sifcosLimpios = numeros_credito_sifco
+        ?.map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+      try {
+        if (excel) {
+          const result = await getCreditosWithUserByMesAnioExcel({
+            mes,
+            anio,
+            page,
+            perPage,
+            numero_credito_sifco,
+            numeros_credito_sifco: sifcosLimpios,
+            estado,
+            asesor_id,
+            nombre_usuario,
+            email_asesor,
+            cuotas_atrasadas,
+            proximidad_pago,
+            is_vehiculo_propio,
+            inversionista_ids,
+            excel: true,
+          });
+          set.status = 200;
+          return result;
+        }
+
+        const result = await getCreditosWithUserByMesAnio(
+          mes,
+          anio,
+          page,
+          perPage,
+          numero_credito_sifco,
+          estado,
+          asesor_id,
+          nombre_usuario,
+          email_asesor,
+          cuotas_atrasadas,
+          proximidad_pago,
+          is_vehiculo_propio,
+          inversionista_ids,
+          sifcosLimpios
+        );
+        set.status = 200;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return { message: "Error obteniendo créditos", error: String(error) };
+      }
+    },
+    {
+      body: t.Object({
+        mes: t.Number(),
+        anio: t.Number(),
+        page: t.Optional(t.Number()),
+        perPage: t.Optional(t.Number()),
+        numero_credito_sifco: t.Optional(t.String()),
+        numeros_credito_sifco: t.Optional(t.Array(t.String())),
+        estado: t.Union([
+          t.Literal("ACTIVO"),
+          t.Literal("CANCELADO"),
+          t.Literal("INCOBRABLE"),
+          t.Literal("PENDIENTE_CANCELACION"),
+          t.Literal("EN_CONVENIO"),
+          t.Literal("MOROSO"),
+          t.Literal("CAIDO"),
+        ]),
+        excel: t.Optional(t.Boolean()),
+        asesor_id: t.Optional(t.Number()),
+        nombre_usuario: t.Optional(t.String()),
+        email_asesor: t.Optional(t.String()),
+        cuotas_atrasadas: t.Optional(t.Number()),
+        proximidad_pago: t.Optional(
+          t.Union([
+            t.Literal("TODAY"),
+            t.Literal("WEEK"),
+            t.Literal("TWO_WEEKS"),
+            t.Literal("MONTH"),
+            t.Literal("DUEMONTH"),
+          ])
+        ),
+        is_vehiculo_propio: t.Optional(t.Boolean()),
+        inversionista_ids: t.Optional(t.Array(t.Number())),
+      }),
+    }
+  )
+
   .post("/cancelCredit", async ({ body, set }) => {
     // Validar que venga el creditId en el body
     const { creditId } = body as { creditId?: number };

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -89,6 +89,7 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 		| "MOROSO";
 	nombre_usuario?: string;
 	numero_credito_sifco?: string;
+	numeros_credito_sifco?: string[];
 	time?: "WEEK" | "MONTH" | "DUEMONTH" | "TODAY";
 	email_cobrador?: string;
 }) {
@@ -111,6 +112,10 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 			...(params.numero_credito_sifco !== undefined &&
 				params.numero_credito_sifco !== "" && {
 					numero_credito_sifco: params.numero_credito_sifco,
+				}),
+			...(params.numeros_credito_sifco !== undefined &&
+				params.numeros_credito_sifco.length > 0 && {
+					numeros_credito_sifco: params.numeros_credito_sifco,
 				}),
 			...(params.time !== undefined && { time: params.time }),
 			...(params.email_cobrador !== undefined &&
@@ -596,6 +601,7 @@ export const cobrosRouter = {
 				searchTerm: z.string().optional(),
 				time: z.enum(["WEEK", "MONTH", "DUEMONTH", "TODAY"]).optional(),
 				emailCobrador: z.string().optional(),
+				etiquetas: z.array(z.string()).optional(),
 			}),
 		)
 		.handler(async ({ input }) => {
@@ -655,8 +661,44 @@ export const cobrosRouter = {
 					}
 
 					console.log(
-						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${Math.floor((input.offset || 0) / (input.limit || 50)) + 1}, perPage=${input.limit || 50}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${input.time}, emailCobrador=${input.emailCobrador}, search=${input.searchTerm || ""}`,
+						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${Math.floor((input.offset || 0) / (input.limit || 50)) + 1}, perPage=${input.limit || 50}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${input.time}, emailCobrador=${input.emailCobrador}, search=${input.searchTerm || ""}, etiquetas=${input.etiquetas?.join(",") || ""}`,
 					);
+
+					// Si hay filtro de etiquetas, primero resolver en CRM la lista de
+					// numero_credito_sifco cuyos casos_cobros tengan AL MENOS UNA de las
+					// etiquetas seleccionadas (criterio OR / overlap con `&&`). Un caso
+					// con `{moras_pendientes,cobro}` matchea si el usuario filtra por
+					// `{cobro}` o por `{cobro,juridico}`. La lista resuelta se manda a
+					// cartera-back vía numeros_credito_sifco para filtrar en origen.
+					let sifcosPorEtiquetas: string[] | undefined;
+					if (input.etiquetas && input.etiquetas.length > 0) {
+						const filas = await db
+							.select({
+								numeroSifco: casosCobros.numeroCreditoSifco,
+								etiquetas: casosCobros.etiquetas,
+							})
+							.from(casosCobros)
+							.where(
+								sql`${casosCobros.etiquetas} && ${input.etiquetas}::text[]`,
+							);
+						sifcosPorEtiquetas = filas
+							.map((r) => r.numeroSifco)
+							.filter((s): s is string => !!s);
+						console.log(
+							`[Cobros] Filtro etiquetas resolvió ${sifcosPorEtiquetas.length} numero_credito_sifco`,
+						);
+						if (sifcosPorEtiquetas.length === 0) {
+							const limit = input.limit || 50;
+							const offset = input.offset || 0;
+							return {
+								data: [],
+								total: 0,
+								page: Math.floor(offset / limit) + 1,
+								perPage: limit,
+								totalPages: 0,
+							};
+						}
+					}
 
 					let creditosResponse;
 					if (isPlateSearch) {
@@ -716,6 +758,7 @@ export const cobrosRouter = {
 								estado: estadoCartera,
 								time: input.time,
 								email_cobrador: input.emailCobrador,
+								numeros_credito_sifco: sifcosPorEtiquetas,
 							});
 
 							const allCredits = [...firstPage.data];
@@ -730,6 +773,7 @@ export const cobrosRouter = {
 									estado: estadoCartera,
 									time: input.time,
 									email_cobrador: input.emailCobrador,
+									numeros_credito_sifco: sifcosPorEtiquetas,
 								});
 								allCredits.push(...nextPage.data);
 							}
@@ -755,6 +799,7 @@ export const cobrosRouter = {
 							time: input.time,
 							email_cobrador: input.emailCobrador,
 							nombre_usuario: isNameSearch ? searchTerm : undefined,
+							numeros_credito_sifco: sifcosPorEtiquetas,
 						});
 					}
 
@@ -2910,6 +2955,7 @@ export const cobrosRouter = {
 				estadoMora: z.string().optional(),
 				searchTerm: z.string().optional(),
 				time: z.enum(["WEEK", "MONTH", "DUEMONTH", "TODAY"]).optional(),
+				etiquetas: z.array(z.string()).optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -3010,6 +3056,36 @@ export const cobrosRouter = {
 				}
 			}
 
+			// 2.5 Si hay filtro de etiquetas, resolver primero la lista de
+			// numero_credito_sifco que tengan AL MENOS UNA de las etiquetas
+			// seleccionadas (operador `&&` / overlap) y mandarla a cartera-back
+			// para que filtre en origen, en vez de traer todo y filtrar acá.
+			let sifcosPorEtiquetas: string[] | undefined;
+			if (input.etiquetas && input.etiquetas.length > 0) {
+				const filas = await db
+					.select({
+						numeroSifco: casosCobros.numeroCreditoSifco,
+					})
+					.from(casosCobros)
+					.where(
+						sql`${casosCobros.etiquetas} && ${input.etiquetas}::text[]`,
+					);
+				sifcosPorEtiquetas = filas
+					.map((r) => r.numeroSifco)
+					.filter((s): s is string => !!s);
+				if (sifcosPorEtiquetas.length === 0) {
+					return {
+						plantillaId: input.plantillaId,
+						totalCreditos: 0,
+						elegibles: 0,
+						enviados: 0,
+						fallidos: 0,
+						descartados: [],
+						detalle: [],
+					};
+				}
+			}
+
 			// 3. Paginar getAllCreditos hasta traer todos los matcheos.
 			const creditosFiltrados: Awaited<
 				ReturnType<typeof carteraBackClient.getAllCreditos>
@@ -3027,6 +3103,7 @@ export const cobrosRouter = {
 						email_cobrador: emailCobrador,
 						nombre_usuario: isNameSearch ? searchTerm : undefined,
 						numero_credito_sifco: numeroSifcoFiltro,
+						numeros_credito_sifco: sifcosPorEtiquetas,
 						page,
 						perPage,
 					});

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -727,65 +727,108 @@ export const cobrosRouter = {
 								totalPages: 0,
 							};
 						} else if (matchingOpportunities.length === 1) {
-							// Una sola coincidencia: buscar directamente por número SIFCO (más rápido)
+							// Una sola coincidencia: buscar directamente por número SIFCO (más rápido).
+							// Si además hay filtro de etiquetas y el SIFCO de la placa no está en
+							// la lista, la combinación no produce match. Ojo: cartera-back le da
+							// prioridad al param multi sobre el single, por eso no mandamos ambos.
 							const numeroSifco = matchingOpportunities[0].numeroSifco!;
-							console.log(
-								`[Cobros] Placa ${searchTerm} encontró 1 coincidencia, buscando crédito SIFCO: ${numeroSifco}`,
-							);
-							creditosResponse = await obtenerTodosLosCreditosCarteraBack({
-								mes,
-								anio,
-								page: 1,
-								perPage: 50,
-								cuotasAtrasadas,
-								estado: estadoCartera,
-								time: input.time,
-								email_cobrador: input.emailCobrador,
-								numero_credito_sifco: numeroSifco,
-							});
-						} else {
-							// Múltiples coincidencias: traer todos los créditos y filtrar localmente
-							console.log(
-								`[Cobros] Placa ${searchTerm} encontró ${matchingOpportunities.length} coincidencias, trayendo todos los créditos`,
-							);
-							const perPage = 200;
-							const firstPage = await obtenerTodosLosCreditosCarteraBack({
-								mes,
-								anio,
-								page: 1,
-								perPage,
-								cuotasAtrasadas,
-								estado: estadoCartera,
-								time: input.time,
-								email_cobrador: input.emailCobrador,
-								numeros_credito_sifco: sifcosPorEtiquetas,
-							});
-
-							const allCredits = [...firstPage.data];
-
-							for (let page = 2; page <= firstPage.totalPages; page++) {
-								const nextPage = await obtenerTodosLosCreditosCarteraBack({
+							if (
+								sifcosPorEtiquetas &&
+								!sifcosPorEtiquetas.includes(numeroSifco)
+							) {
+								console.log(
+									`[Cobros] Placa ${searchTerm} matcheó SIFCO ${numeroSifco}, pero no está en las etiquetas seleccionadas — respuesta vacía`,
+								);
+								creditosResponse = {
+									data: [],
+									page: 1,
+									perPage: 0,
+									totalCount: 0,
+									totalPages: 0,
+								};
+							} else {
+								console.log(
+									`[Cobros] Placa ${searchTerm} encontró 1 coincidencia, buscando crédito SIFCO: ${numeroSifco}`,
+								);
+								creditosResponse = await obtenerTodosLosCreditosCarteraBack({
 									mes,
 									anio,
-									page,
+									page: 1,
+									perPage: 50,
+									cuotasAtrasadas,
+									estado: estadoCartera,
+									time: input.time,
+									email_cobrador: input.emailCobrador,
+									numero_credito_sifco: numeroSifco,
+								});
+							}
+						} else {
+							// Múltiples coincidencias: si además hay filtro de etiquetas,
+							// intersectar la lista de SIFCOs de la placa con la de las
+							// etiquetas y mandar la intersección a cartera (en vez de mandar
+							// todos los etiquetados o todos los de la placa por separado).
+							const sifcosPlaca = matchingOpportunities
+								.map((m) => m.numeroSifco)
+								.filter((s): s is string => !!s);
+							let sifcosFiltro: string[] | undefined;
+							if (sifcosPorEtiquetas) {
+								const setEtq = new Set(sifcosPorEtiquetas);
+								sifcosFiltro = sifcosPlaca.filter((s) => setEtq.has(s));
+							} else {
+								sifcosFiltro = sifcosPlaca;
+							}
+
+							if (sifcosFiltro.length === 0) {
+								creditosResponse = {
+									data: [],
+									page: 1,
+									perPage: 0,
+									totalCount: 0,
+									totalPages: 0,
+								};
+							} else {
+								console.log(
+									`[Cobros] Placa ${searchTerm} encontró ${matchingOpportunities.length} coincidencias (intersección con etiquetas: ${sifcosFiltro.length}), trayendo créditos`,
+								);
+								const perPage = 200;
+								const firstPage = await obtenerTodosLosCreditosCarteraBack({
+									mes,
+									anio,
+									page: 1,
 									perPage,
 									cuotasAtrasadas,
 									estado: estadoCartera,
 									time: input.time,
 									email_cobrador: input.emailCobrador,
-									numeros_credito_sifco: sifcosPorEtiquetas,
+									numeros_credito_sifco: sifcosFiltro,
 								});
-								allCredits.push(...nextPage.data);
-							}
 
-							creditosResponse = {
-								...firstPage,
-								data: allCredits,
-								totalCount: allCredits.length,
-								page: 1,
-								perPage: allCredits.length,
-								totalPages: 1,
-							};
+								const allCredits = [...firstPage.data];
+
+								for (let page = 2; page <= firstPage.totalPages; page++) {
+									const nextPage = await obtenerTodosLosCreditosCarteraBack({
+										mes,
+										anio,
+										page,
+										perPage,
+										cuotasAtrasadas,
+										estado: estadoCartera,
+										time: input.time,
+										email_cobrador: input.emailCobrador,
+										numeros_credito_sifco: sifcosFiltro,
+									});
+									allCredits.push(...nextPage.data);
+								}
+
+								creditosResponse = {
+									...firstPage,
+									data: allCredits,
+									totalCount: allCredits.length,
+									page: 1,
+									perPage: allCredits.length,
+									totalPages: 1,
+								};
+							}
 						}
 					} else {
 						// Búsqueda por nombre (cartera-back filtra) o sin búsqueda
@@ -3084,6 +3127,46 @@ export const cobrosRouter = {
 						detalle: [],
 					};
 				}
+			}
+
+			// 2.6 Intersectar búsqueda por placa con etiquetas. En cartera-back la
+			// lista multi-SIFCO tiene prioridad sobre el single, así que mandar
+			// ambos sin intersectar haría que la placa se ignore y el envío
+			// masivo salga a destinatarios incorrectos.
+			const respuestaVacia = {
+				plantillaId: input.plantillaId,
+				totalCreditos: 0,
+				elegibles: 0,
+				enviados: 0,
+				fallidos: 0,
+				descartados: [] as Array<{ numeroSifco: string | null; motivo: string }>,
+				detalle: [] as Array<{
+					numeroSifco: string;
+					telefono: string;
+					success: boolean;
+					error?: string;
+				}>,
+			};
+			if (sifcosPorEtiquetas && numeroSifcoFiltro) {
+				if (sifcosPorEtiquetas.includes(numeroSifcoFiltro)) {
+					// La placa única coincide con alguna etiqueta: basta mandar el
+					// single y descartar la lista para no perder ese filtro.
+					sifcosPorEtiquetas = undefined;
+				} else {
+					return respuestaVacia;
+				}
+			} else if (
+				sifcosPorEtiquetas &&
+				isPlateSearch &&
+				matchingSifcos.size > 0
+			) {
+				// Placa con varias coincidencias + etiquetas: mandar la intersección
+				// a cartera para no traer créditos que no son de la placa.
+				const setEtq = new Set(sifcosPorEtiquetas);
+				sifcosPorEtiquetas = Array.from(matchingSifcos).filter((s) =>
+					setEtq.has(s),
+				);
+				if (sifcosPorEtiquetas.length === 0) return respuestaVacia;
 			}
 
 			// 3. Paginar getAllCreditos hasta traer todos los matcheos.

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3167,6 +3167,16 @@ export const cobrosRouter = {
 					setEtq.has(s),
 				);
 				if (sifcosPorEtiquetas.length === 0) return respuestaVacia;
+			} else if (
+				!sifcosPorEtiquetas &&
+				isPlateSearch &&
+				!numeroSifcoFiltro &&
+				matchingSifcos.size > 0
+			) {
+				// Placa con varias coincidencias sin etiquetas: en lugar de traer
+				// toda la cartera y filtrar después, mandamos directo la lista de
+				// SIFCOs de la placa como numeros_credito_sifco.
+				sifcosPorEtiquetas = Array.from(matchingSifcos);
 			}
 
 			// 3. Paginar getAllCreditos hasta traer todos los matcheos.
@@ -3194,15 +3204,6 @@ export const cobrosRouter = {
 					if (resp.data.length < perPage) break;
 					if (page >= resp.totalPages) break;
 					page += 1;
-				}
-
-				// Filtrado local cuando la placa matcheó varias SIFCOs.
-				if (isPlateSearch && !numeroSifcoFiltro) {
-					for (let i = creditosFiltrados.length - 1; i >= 0; i--) {
-						const sifco = creditosFiltrados[i].creditos.numero_credito_sifco;
-						if (!sifco || !matchingSifcos.has(sifco))
-							creditosFiltrados.splice(i, 1);
-					}
 				}
 			}
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -95,45 +95,38 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 }) {
 	const estado = params.estado || "ACTIVO";
 
-	const response = await carteraBackClient
-		.getAllCreditos({
-			mes: params.mes,
-			anio: params.anio,
-			page: params.page,
-			perPage: params.perPage,
-			estado: estado,
-			...(params.cuotasAtrasadas !== undefined && {
-				cuotas_atrasadas: params.cuotasAtrasadas,
+	// Antes había un .catch que devolvía respuesta vacía si cartera fallaba.
+	// Eso enmascaraba errores reales (ej. 414 URI Too Long con listas grandes
+	// de SIFCOs) y hacía que la tabla mostrara 0 casos y el envío masivo
+	// despachara a 0 destinatarios silenciosamente. Ahora propagamos el error
+	// para que el endpoint ORPC lo levante como tal.
+	const response = await carteraBackClient.getAllCreditos({
+		mes: params.mes,
+		anio: params.anio,
+		page: params.page,
+		perPage: params.perPage,
+		estado: estado,
+		...(params.cuotasAtrasadas !== undefined && {
+			cuotas_atrasadas: params.cuotasAtrasadas,
+		}),
+		...(params.nombre_usuario !== undefined &&
+			params.nombre_usuario !== "" && {
+				nombre_usuario: params.nombre_usuario,
 			}),
-			...(params.nombre_usuario !== undefined &&
-				params.nombre_usuario !== "" && {
-					nombre_usuario: params.nombre_usuario,
-				}),
-			...(params.numero_credito_sifco !== undefined &&
-				params.numero_credito_sifco !== "" && {
-					numero_credito_sifco: params.numero_credito_sifco,
-				}),
-			...(params.numeros_credito_sifco !== undefined &&
-				params.numeros_credito_sifco.length > 0 && {
-					numeros_credito_sifco: params.numeros_credito_sifco,
-				}),
-			...(params.time !== undefined && { time: params.time }),
-			...(params.email_cobrador !== undefined &&
-				params.email_cobrador !== "" && {
-					email_cobrador: params.email_cobrador,
-				}),
-		})
-		.catch((error) => {
-			console.error("[Cobros] Error obteniendo créditos:", error);
-			// Retornar respuesta vacía si falla
-			return {
-				data: [],
-				page: params.page || 1,
-				perPage: params.perPage || 1000,
-				totalCount: 0,
-				totalPages: 0,
-			};
-		});
+		...(params.numero_credito_sifco !== undefined &&
+			params.numero_credito_sifco !== "" && {
+				numero_credito_sifco: params.numero_credito_sifco,
+			}),
+		...(params.numeros_credito_sifco !== undefined &&
+			params.numeros_credito_sifco.length > 0 && {
+				numeros_credito_sifco: params.numeros_credito_sifco,
+			}),
+		...(params.time !== undefined && { time: params.time }),
+		...(params.email_cobrador !== undefined &&
+			params.email_cobrador !== "" && {
+				email_cobrador: params.email_cobrador,
+			}),
+	});
 
 	return {
 		data: response.data,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -416,39 +416,84 @@ export class CarteraBackClient {
 	async getAllCreditos(
 		params: GetAllCreditsParams,
 	): Promise<PaginatedResponse<CreditoDetailResponse>> {
-		const queryParams = new URLSearchParams({
-			mes: params.mes.toString(),
-			anio: params.anio.toString(),
-			...(params.estado && { estado: params.estado }),
-			...(params.page && { page: params.page.toString() }),
-			...(params.perPage && { perPage: params.perPage.toString() }),
-			...(params.cuotas_atrasadas !== undefined && {
-				cuotas_atrasadas: params.cuotas_atrasadas.toString(),
-			}),
-			...(params.time && { proximidad_pago: params.time }),
-			...(params.nombre_usuario && { nombre_usuario: params.nombre_usuario }),
-			...(params.numero_credito_sifco && {
-				numero_credito_sifco: params.numero_credito_sifco,
-			}),
-			...(params.numeros_credito_sifco &&
-				params.numeros_credito_sifco.length > 0 && {
-					numeros_credito_sifco: params.numeros_credito_sifco.join(","),
-				}),
-			...(params.email_cobrador && { email_asesor: params.email_cobrador }),
-			excel: "false",
-		});
+		// Si la lista de SIFCOs es grande, usar POST para evitar URL too long
+		// (414). Threshold conservador: ~50 SIFCOs * 15 chars ≈ 750 bytes, muy
+		// por debajo de cualquier límite. Por arriba de eso, body en POST.
+		const SIFCO_LIST_POST_THRESHOLD = 50;
+		const useBulkPost =
+			!!params.numeros_credito_sifco &&
+			params.numeros_credito_sifco.length > SIFCO_LIST_POST_THRESHOLD;
 
-		console.log(
-			`[CarteraBackClient] getAllCreditos query: ${queryParams.toString()}`,
-		);
-		// Este endpoint retorna PaginatedResponse directamente, no envuelto en CarteraBackApiResponse
-		const response = await this.request<
-			PaginatedResponse<CreditoDetailResponse>
-		>(
-			`/getAllCredits?${queryParams}`,
-			{ method: "GET" },
-			true, // use cache
-		);
+		let response: PaginatedResponse<CreditoDetailResponse>;
+
+		if (useBulkPost) {
+			console.log(
+				`[CarteraBackClient] getAllCreditos: usando POST (${params.numeros_credito_sifco?.length} SIFCOs en lista)`,
+			);
+			response = await this.request<PaginatedResponse<CreditoDetailResponse>>(
+				`/getAllCredits`,
+				{
+					method: "POST",
+					body: JSON.stringify({
+						mes: params.mes,
+						anio: params.anio,
+						estado: params.estado,
+						...(params.page !== undefined && { page: params.page }),
+						...(params.perPage !== undefined && { perPage: params.perPage }),
+						...(params.cuotas_atrasadas !== undefined && {
+							cuotas_atrasadas: params.cuotas_atrasadas,
+						}),
+						...(params.time && { proximidad_pago: params.time }),
+						...(params.nombre_usuario && {
+							nombre_usuario: params.nombre_usuario,
+						}),
+						...(params.numero_credito_sifco && {
+							numero_credito_sifco: params.numero_credito_sifco,
+						}),
+						...(params.numeros_credito_sifco && {
+							numeros_credito_sifco: params.numeros_credito_sifco,
+						}),
+						...(params.email_cobrador && {
+							email_asesor: params.email_cobrador,
+						}),
+						excel: false,
+					}),
+				},
+			);
+		} else {
+			const queryParams = new URLSearchParams({
+				mes: params.mes.toString(),
+				anio: params.anio.toString(),
+				...(params.estado && { estado: params.estado }),
+				...(params.page && { page: params.page.toString() }),
+				...(params.perPage && { perPage: params.perPage.toString() }),
+				...(params.cuotas_atrasadas !== undefined && {
+					cuotas_atrasadas: params.cuotas_atrasadas.toString(),
+				}),
+				...(params.time && { proximidad_pago: params.time }),
+				...(params.nombre_usuario && {
+					nombre_usuario: params.nombre_usuario,
+				}),
+				...(params.numero_credito_sifco && {
+					numero_credito_sifco: params.numero_credito_sifco,
+				}),
+				...(params.numeros_credito_sifco &&
+					params.numeros_credito_sifco.length > 0 && {
+						numeros_credito_sifco: params.numeros_credito_sifco.join(","),
+					}),
+				...(params.email_cobrador && { email_asesor: params.email_cobrador }),
+				excel: "false",
+			});
+
+			console.log(
+				`[CarteraBackClient] getAllCreditos query: ${queryParams.toString()}`,
+			);
+			response = await this.request<PaginatedResponse<CreditoDetailResponse>>(
+				`/getAllCredits?${queryParams}`,
+				{ method: "GET" },
+				true, // use cache (solo GET)
+			);
+		}
 
 		// Validar que la respuesta tenga la estructura de PaginatedResponse
 		if (!response.data || !Array.isArray(response.data)) {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -430,6 +430,10 @@ export class CarteraBackClient {
 			...(params.numero_credito_sifco && {
 				numero_credito_sifco: params.numero_credito_sifco,
 			}),
+			...(params.numeros_credito_sifco &&
+				params.numeros_credito_sifco.length > 0 && {
+					numeros_credito_sifco: params.numeros_credito_sifco.join(","),
+				}),
 			...(params.email_cobrador && { email_asesor: params.email_cobrador }),
 			excel: "false",
 		});

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -541,6 +541,7 @@ export interface GetAllCreditsParams {
 	page?: number;
 	perPage?: number;
 	numero_credito_sifco?: string;
+	numeros_credito_sifco?: string[];
 	excel?: boolean;
 	cuotas_atrasadas?: number;
 	nombre_usuario?: string;

--- a/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
@@ -30,15 +30,38 @@ interface MassWhatsappModalProps {
 		estadoMora?: string;
 		searchTerm?: string;
 		time?: "WEEK" | "MONTH" | "DUEMONTH" | "TODAY";
+		etiquetas?: string[];
 	};
+	etiquetaLabels?: Record<string, string>;
+	totalDestinatarios?: number;
 	children: React.ReactNode;
 }
 
-export function MassWhatsappModal({ filtros, children }: MassWhatsappModalProps) {
+const ESTADO_MORA_LABELS: Record<string, string> = {
+	al_dia: "Al Día",
+	mora_30: "Mora 30",
+	mora_60: "Mora 60",
+	mora_90: "Mora 90",
+	mora_120: "Mora 120+",
+	incobrable: "Incobrable",
+	completado: "Completado",
+};
+
+const TIME_LABELS: Record<string, string> = {
+	TODAY: "Hoy",
+	WEEK: "Esta Semana",
+	DUEMONTH: "Esta Quincena",
+	MONTH: "Este Mes",
+};
+
+export function MassWhatsappModal({
+	filtros,
+	etiquetaLabels,
+	totalDestinatarios,
+	children,
+}: MassWhatsappModalProps) {
 	const [open, setOpen] = useState(false);
-	const [plantillaId, setPlantillaId] = useState<string>(
-		PLANTILLAS_MENSAJES[0]?.id ?? "",
-	);
+	const [plantillaId, setPlantillaId] = useState<string>("");
 
 	const plantillaSeleccionada = PLANTILLAS_MENSAJES.find(
 		(p) => p.id === plantillaId,
@@ -51,6 +74,10 @@ export function MassWhatsappModal({ filtros, children }: MassWhatsappModalProps)
 				estadoMora: filtros.estadoMora,
 				searchTerm: filtros.searchTerm,
 				time: filtros.time,
+				etiquetas:
+					filtros.etiquetas && filtros.etiquetas.length > 0
+						? filtros.etiquetas
+						: undefined,
 			}),
 		onSuccess: (res) => {
 			toast.success(
@@ -66,7 +93,7 @@ export function MassWhatsappModal({ filtros, children }: MassWhatsappModalProps)
 	return (
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>{children}</DialogTrigger>
-			<DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
 						<MessageCircle className="h-5 w-5" />
@@ -96,30 +123,76 @@ export function MassWhatsappModal({ filtros, children }: MassWhatsappModalProps)
 						</Select>
 					</div>
 
-					{plantillaSeleccionada && (
-						<div className="space-y-2">
-							<Label>Vista previa</Label>
-							<Textarea
-								readOnly
-								className="min-h-[220px] text-sm"
-								value={plantillaSeleccionada.cuerpo}
-							/>
+					{plantillaSeleccionada ? (
+						<>
+							<div className="space-y-2">
+								<Label>Vista previa</Label>
+								<Textarea
+									readOnly
+									className="min-h-55 text-sm"
+									value={plantillaSeleccionada.cuerpo}
+								/>
+								<p className="text-muted-foreground text-xs">
+									Las variables entre llaves se reemplazan por los datos
+									reales de cada crédito. Si un dato no existe (p. ej. placa),
+									queda vacío en el mensaje.
+								</p>
+							</div>
+
+							<div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
+								<p className="font-medium">Filtros aplicados</p>
+								<ul className="mt-1 list-inside list-disc text-muted-foreground text-xs">
+									<li>
+										Estado de mora:{" "}
+										{filtros.estadoMora
+											? (ESTADO_MORA_LABELS[filtros.estadoMora] ??
+												filtros.estadoMora)
+											: "Todos"}
+									</li>
+									<li>
+										Rango temporal:{" "}
+										{filtros.time
+											? (TIME_LABELS[filtros.time] ?? filtros.time)
+											: "Todos"}
+									</li>
+									<li>Búsqueda: {filtros.searchTerm ?? "—"}</li>
+									<li>
+										Etiquetas:{" "}
+										{filtros.etiquetas && filtros.etiquetas.length > 0
+											? filtros.etiquetas
+													.map((e) => etiquetaLabels?.[e] ?? e)
+													.join(", ")
+											: "Todas"}
+									</li>
+								</ul>
+							</div>
+
+							{typeof totalDestinatarios === "number" && (
+								<div className="rounded-md border border-primary/30 bg-primary/5 p-3 text-sm">
+									<p className="font-medium">
+										Se enviará a {totalDestinatarios.toLocaleString("es-GT")}{" "}
+										{totalDestinatarios === 1 ? "crédito" : "créditos"}
+									</p>
+									<p className="mt-1 text-muted-foreground text-xs">
+										Los créditos sin teléfono, sin cuota o sin asesor se
+										descartan automáticamente, por lo que el número final puede
+										ser menor.
+									</p>
+								</div>
+							)}
+						</>
+					) : (
+						<div className="flex flex-col items-center justify-center gap-2 rounded-md border border-border border-dashed bg-muted/20 p-8 text-center">
+							<MessageCircle className="h-8 w-8 text-muted-foreground" />
+							<p className="font-medium text-sm">
+								Selecciona una plantilla para continuar
+							</p>
 							<p className="text-muted-foreground text-xs">
-								Las variables entre llaves se reemplazan por los datos reales
-								de cada crédito. Si un dato no existe (p. ej. placa), queda
-								vacío en el mensaje.
+								Una vez elegida verás la vista previa, los filtros aplicados y
+								la cantidad de destinatarios.
 							</p>
 						</div>
 					)}
-
-					<div className="rounded-md border border-border bg-muted/30 p-3 text-sm">
-						<p className="font-medium">Filtros aplicados</p>
-						<ul className="mt-1 list-inside list-disc text-muted-foreground text-xs">
-							<li>Estado de mora: {filtros.estadoMora ?? "todos"}</li>
-							<li>Rango temporal: {filtros.time ?? "todos"}</li>
-							<li>Búsqueda: {filtros.searchTerm ?? "—"}</li>
-						</ul>
-					</div>
 				</div>
 
 				<DialogFooter>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -404,6 +404,7 @@ function RouteComponent() {
 				emailCobrador: !PERMISSIONS.canAssignCobros(userRole ?? "")
 					? session?.user?.email
 					: undefined,
+				etiquetas: filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
 			},
 		}),
 		enabled: !!session,
@@ -454,21 +455,12 @@ function RouteComponent() {
 		let filtrados = creditosConDias;
 
 		// Excluir completados e incobrables si el filtro está desactivado
-		// NOTA: El filtro por etapa ahora se hace en el servidor mediante estadoMora
+		// NOTA: El filtro por etapa y por etiquetas se hacen en el servidor.
 		if (!mostrarCompletadosIncobrables && !filtroEtapa) {
 			filtrados = filtrados.filter(
 				(c) =>
 					c.estadoContrato !== "completado" &&
 					c.estadoContrato !== "incobrable",
-			);
-		}
-
-		// Filtrar por etiquetas (AND: el caso debe tener todas las seleccionadas)
-		if (filtroEtiquetas.length > 0) {
-			filtrados = filtrados.filter(
-				(c) =>
-					c.etiquetas &&
-					filtroEtiquetas.every((et) => c.etiquetas!.includes(et)),
 			);
 		}
 
@@ -489,12 +481,7 @@ function RouteComponent() {
 			// Incluir casos en mora (días negativos) y casos próximos a vencer
 			return c?.diasHastaPago !== null && c?.diasHastaPago <= limite;
 		});
-	}, [
-		creditosConDias,
-		filtroTemporal,
-		mostrarCompletadosIncobrables,
-		filtroEtiquetas,
-	]);
+	}, [creditosConDias, filtroTemporal, mostrarCompletadosIncobrables, filtroEtapa]);
 
 	// Check permissions after all hooks
 	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {
@@ -988,7 +975,11 @@ function RouteComponent() {
 									estadoMora: filtroEtapa || undefined,
 									searchTerm: debouncedFilterValue || undefined,
 									time: timeParam,
+									etiquetas:
+										filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
 								}}
+								etiquetaLabels={ETIQUETA_LABELS_FILTRO}
+								totalDestinatarios={totalCreditos}
 							>
 								<Button
 									variant="outline"
@@ -1000,7 +991,7 @@ function RouteComponent() {
 								</Button>
 							</MassWhatsappModal>
 							<Badge variant="outline" className="text-sm">
-								{creditosFiltrados.length} casos mostrados
+								{totalCreditos} casos
 							</Badge>
 						</div>
 					</div>


### PR DESCRIPTION
## Resumen

Arregla el filtro por etiquetas del módulo de Cobros (que se hacía en cliente y estaba incompleto), moviéndolo al servidor. Para que funcione end-to-end, se extendió `cartera-back` para aceptar múltiples números de crédito SIFCO en una sola llamada. También se pulieron varios detalles del modal de envío masivo de WhatsApp.

## Cambios en cartera-back

**`GET /getAllCredits`** ahora acepta el query param `numeros_credito_sifco` (lista separada por comas):

- Se parsea a `string[]`, se limpia y se aplica `inArray(creditos.numero_credito_sifco, [...])`.
- Tiene **prioridad** sobre el filtro single `numero_credito_sifco`.
- Igual que el filtro single, omite el corte de mes/año cuando viene la lista (para no perder créditos creados en otros períodos).
- Se combina con los demás filtros (estado, cuotas_atrasadas, asesor, etc.) vía AND.

Tocados: `routers/credits.ts`, `controllers/credits.ts`, `controllers/reports.ts`.

## Cambios en CRM

### Filtrado por etiquetas (lo central del PR)

Antes el filtro era client-side: traía todos los créditos de cartera y los filtraba en el navegador con `filtroEtiquetas.every(...)`. Eso fallaba porque `getTodosLosCreditos` no devolvía las etiquetas, así que el filtro nunca matcheaba.

Ahora:

1. `getTodosLosCreditos` y `enviarWhatsappMasivoCobros` aceptan `etiquetas: string[]` como input.
2. Si vienen etiquetas, primero se resuelven los `numero_credito_sifco` desde `casos_cobros` con `etiquetas && input.etiquetas::text[]` (operador overlap → semántica **OR**: un caso con `{moras_pendientes, cobro}` matchea si el usuario filtra por `cobro`, por `moras_pendientes`, o por ambos).
3. Esa lista se manda a cartera-back vía el nuevo `numeros_credito_sifco` para que el filtrado pase del lado del servicio y se combine con los demás filtros.
4. Si la lista resuelta queda vacía, se corta antes de pegarle a cartera y se devuelve respuesta vacía.

Se eliminó el filtro client-side de `creditosFiltrados` en `cobros/index.tsx`.

### Modal de WhatsApp masivo (`mass-whatsapp-modal.tsx`)

- **Labels legibles** en "Filtros aplicados": `TODAY` → "Hoy", `mora_30` → "Mora 30", etc.
- **Etiquetas seleccionadas** ahora se listan en el resumen (antes ni se mostraban).
- **Conteo de destinatarios** ("Se enviará a N créditos") con nota de que los descartados (sin teléfono, sin cuota, sin asesor) reducen el número final.
- **Estado inicial sin plantilla seleccionada**: arranca con un placeholder "Selecciona una plantilla para continuar"; vista previa, filtros y conteo aparecen recién cuando se elige plantilla.
- **Ancho del modal aumentado** a `sm:max-w-4xl` (antes el `sm:max-w-lg` por defecto del Dialog dejaba el modal angosto y el `w-3xl` no lo overrideaba).

## Test plan

- [ ] Filtrar por una sola etiqueta (ej. "cobro") trae casos con esa etiqueta aunque tengan otras adicionales.
- [ ] Filtrar por varias etiquetas trae casos que tengan al menos una (OR).
- [ ] Combinar filtro de etiquetas con estado de mora, búsqueda por placa/nombre y rango temporal.
- [ ] Enviar WhatsApp masivo con etiquetas seleccionadas filtra correctamente los destinatarios.
- [ ] Modal de WhatsApp masivo: labels se ven en español, conteo es correcto, no se puede enviar sin plantilla.
- [ ] `GET /getAllCredits?numeros_credito_sifco=A,B,C` en cartera-back devuelve solo esos créditos respetando los demás filtros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)