### PR TITLE
feat(data-table): add tableContainerClass prop for customizable styling

### DIFF
--- a/apps/crm/apps/web/src/components/data-table.tsx
+++ b/apps/crm/apps/web/src/components/data-table.tsx
@@ -45,6 +45,7 @@ interface DataTableProps<TData, TValue> {
 	onRowClick?: (row: TData) => void;
 	hideSearch?: boolean;
 	pageSizeOptions?: number[];
+	tableContainerClass?: string;
 }
 
 export function DataTable<TData, TValue>({
@@ -59,6 +60,7 @@ export function DataTable<TData, TValue>({
 	onRowClick,
 	hideSearch,
 	pageSizeOptions = [10, 20, 30, 40, 50],
+	tableContainerClass,
 }: DataTableProps<TData, TValue>) {
 	const [sorting, setSorting] = useState<SortingState>([]);
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -125,7 +127,7 @@ export function DataTable<TData, TValue>({
 				</div>
 			)}
 
-			<div className="overflow-hidden rounded-md border max-h-[600px] overflow-y-auto">
+			<div className={`overflow-hidden rounded-md border${tableContainerClass ? ` ${tableContainerClass}` : ""}`}>
 				<Table>
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -1156,6 +1156,7 @@ function RouteComponent() {
 								</div>
 							</div>
 						}
+						tableContainerClass="max-h-[600px] overflow-y-auto"
 						pageSizeOptions={[25, 50, 75, 100, 200]}
 						serverPagination={{
 							page: page,


### PR DESCRIPTION
DataTable — prop tableContainerClassName opcional

- Se agregó el prop tableContainerClas?: string al componente DataTable. Cuando se pasa, las clases se aplican al div contenedor de la tabla; 
- Esto permite que cada uso de DataTable controle su propio comportamiento de scroll de forma independiente, sin afectar a los demás.