### PR TITLE
Refactors portfolio purchase reinvestment type

### DIFF
--- a/apps/crm/apps/server/src/routers/investor-documents.ts
+++ b/apps/crm/apps/server/src/routers/investor-documents.ts
@@ -297,10 +297,16 @@ export const investorDocumentsRouter = {
 			// 3. Si pidió compra de cartera, ejecutarla con el ID del nuevo inversionista
 			let compraResult = null;
 			if (input.hacerCompraCartera && input.montoCompraCartera) {
+				const tipoReinversionCompra: "sin_reinversion" | "reinversion_capital" | "reinversion_total" =
+					input.tipoReinversion === "reinversion_capital" ||
+					input.tipoReinversion === "reinversion_total"
+						? input.tipoReinversion
+						: "sin_reinversion";
 				compraResult = await carteraBackClient.compraCartera({
 					inversionista_id: created.inversionista_id,
 					monto_aportado: input.montoCompraCartera,
 					tipo_operacion: "compra_cartera",
+					tipo_reinversion: tipoReinversionCompra,
 					porcentaje_inversion: input.porcentajeInversion,
 					porcentaje_cash_in: input.porcentajeCashIn,
 					fecha_inicio_participacion:
@@ -313,6 +319,7 @@ export const investorDocumentsRouter = {
 					action: "compra_cartera",
 					details: {
 						monto_aportado: input.montoCompraCartera,
+						tipo_reinversion: tipoReinversionCompra,
 						fecha_inicio_participacion: input.fechaInicioParticipacion,
 					},
 					performedBy: context.session.user.id,
@@ -334,6 +341,11 @@ export const investorDocumentsRouter = {
 			z.object({
 				inversionistaId: z.number().int().positive(),
 				montoAportado: z.number().positive(),
+				tipoReinversion: z.enum([
+					"sin_reinversion",
+					"reinversion_capital",
+					"reinversion_total",
+				]),
 				porcentajeInversion: z.number().min(0).max(100).optional(),
 				porcentajeCashIn: z.number().min(0).max(100).optional(),
 				fechaInicioParticipacion: z.string().optional(),
@@ -345,6 +357,7 @@ export const investorDocumentsRouter = {
 				inversionista_id: input.inversionistaId,
 				monto_aportado: input.montoAportado,
 				tipo_operacion: "compra_cartera",
+				tipo_reinversion: input.tipoReinversion,
 				porcentaje_inversion: input.porcentajeInversion,
 				porcentaje_cash_in: input.porcentajeCashIn,
 				fecha_inicio_participacion: input.fechaInicioParticipacion || undefined,
@@ -356,6 +369,7 @@ export const investorDocumentsRouter = {
 				action: "compra_cartera",
 				details: {
 					monto_aportado: input.montoAportado,
+					tipo_reinversion: input.tipoReinversion,
 					porcentaje_inversion: input.porcentajeInversion,
 					porcentaje_cash_in: input.porcentajeCashIn,
 					fecha_inicio_participacion: input.fechaInicioParticipacion,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1063,6 +1063,10 @@ export class CarteraBackClient {
 		inversionista_id: number;
 		monto_aportado: number;
 		tipo_operacion: "compra_cartera";
+		tipo_reinversion?:
+			| "sin_reinversion"
+			| "reinversion_capital"
+			| "reinversion_total";
 		porcentaje_inversion?: number;
 		porcentaje_cash_in?: number;
 		fecha_inicio_participacion?: string;

--- a/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
+++ b/apps/crm/apps/web/src/routes/inversiones/liquidaciones.$inversionistaId.tsx
@@ -684,6 +684,10 @@ function InvestorLiquidacionesPage() {
 	// Compra de cartera
 	const [compraCarteraOpen, setCompraCarteraOpen] = useState(false);
 	const [compraCarteraMonto, setCompraCarteraMonto] = useState("");
+	const [compraCarteraTipoReinversion, setCompraCarteraTipoReinversion] =
+		useState<"sin_reinversion" | "reinversion_capital" | "reinversion_total">(
+			"sin_reinversion",
+		);
 	const [compraCarteraPctInversion, setCompraCarteraPctInversion] = useState("70");
 	const [compraCarteraPctCashIn, setCompraCarteraPctCashIn] = useState("30");
 	const [compraCarteraFecha, setCompraCarteraFecha] = useState(
@@ -926,7 +930,32 @@ function InvestorLiquidacionesPage() {
 								variant="outline"
 								size="sm"
 								className="gap-2"
-								onClick={() => setCompraCarteraOpen(true)}
+								onClick={() => {
+									const inv =
+										(investor?.tipoReinversion as string | undefined) ??
+										(investor as any)?.tipo_reinversion ??
+										"sin_reinversion";
+									const allowed = [
+										"sin_reinversion",
+										"reinversion_capital",
+										"reinversion_total",
+									];
+									const next = allowed.includes(inv)
+										? (inv as
+												| "sin_reinversion"
+												| "reinversion_capital"
+												| "reinversion_total")
+										: "sin_reinversion";
+									console.log("[CompraCartera] abrir modal", {
+										investorTipoReinversion: investor?.tipoReinversion,
+										investor_tipo_reinversion: (investor as any)
+											?.tipo_reinversion,
+										resolved: inv,
+										preselected: next,
+									});
+									setCompraCarteraTipoReinversion(next);
+									setCompraCarteraOpen(true);
+								}}
 							>
 								<ShoppingCart className="h-4 w-4" />
 								Compra de Cartera
@@ -1586,30 +1615,34 @@ function InvestorLiquidacionesPage() {
 						</DialogDescription>
 					</DialogHeader>
 
-					<div className="rounded-md border border-purple-200 bg-purple-50 p-3 dark:border-purple-800 dark:bg-purple-950/40">
-						<div className="flex items-center justify-between gap-2">
-							<span className="text-xs font-medium text-purple-900 dark:text-purple-200">
-								Modelo de reinversión
-							</span>
-							<Badge
-								variant="outline"
-								className="border-purple-300 bg-white text-[11px] text-purple-700 dark:border-purple-700 dark:bg-purple-950 dark:text-purple-300"
-							>
-								{{
-									reinversion_capital: "Reinversión Capital",
-									reinversion_interes: "Reinversión Interés",
-									reinversion_total: "Interés Compuesto",
-									reinversion_variable: "Reinversión Variable",
-									reinversion_combinada: "Reinversión Combinada",
-									sin_reinversion: "Sin reinversión",
-								}[
-									(investor?.tipoReinversion as string) ?? "sin_reinversion"
-								] ?? "Sin reinversión"}
-							</Badge>
-						</div>
-					</div>
-
 					<div className="space-y-4 py-2">
+						<div className="space-y-1.5">
+							<Label htmlFor="compra-modalidad">Modelo de Inversión</Label>
+							<Select
+								value={compraCarteraTipoReinversion}
+								onValueChange={(v) =>
+									setCompraCarteraTipoReinversion(
+										v as
+											| "sin_reinversion"
+											| "reinversion_capital"
+											| "reinversion_total",
+									)
+								}
+							>
+								<SelectTrigger id="compra-modalidad">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="sin_reinversion">Tradicional</SelectItem>
+									<SelectItem value="reinversion_capital">
+										Reinversión Capital
+									</SelectItem>
+									<SelectItem value="reinversion_total">
+										Interés Compuesto
+									</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
 						<div className="space-y-1.5">
 							<Label htmlFor="compra-monto">Monto aportado</Label>
 							<CurrencyInput
@@ -1691,6 +1724,7 @@ function InvestorLiquidacionesPage() {
 								compraCarteraMutation.mutate({
 									inversionistaId: investorIdNum,
 									montoAportado: Number(compraCarteraMonto),
+									tipoReinversion: compraCarteraTipoReinversion,
 									porcentajeInversion: Number(compraCarteraPctInversion),
 									porcentajeCashIn: Number(compraCarteraPctCashIn),
 									fechaInicioParticipacion: compraCarteraFecha || undefined,

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -242,9 +242,9 @@ export const sendInvestorAddedToCreditsNotification = async ({
       tipoOperacion === "compra_cartera" ? "Compra de Cartera" : "Reinversión";
 
     const modalidadLabel: Record<string, string> = {
-      reinversion_capital: "Reinversión de Capital",
+      reinversion_capital: "Reinversión Capital",
       reinversion_interes: "Reinversión de Interés",
-      reinversion_total: "Reinversión Total",
+      reinversion_total: "Interés Compuesto",
     };
 
     const filas = creditos
@@ -254,7 +254,7 @@ export const sendInvestorAddedToCreditsNotification = async ({
             <td style="padding:8px;border:1px solid #e5e7eb;">${c.numero_credito_sifco}</td>
             <td style="padding:8px;border:1px solid #e5e7eb;text-align:right;">${currencySymbol}${c.monto_asignado}</td>
             <td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">${
-              c.tipo_reinversion ? modalidadLabel[c.tipo_reinversion] ?? c.tipo_reinversion : "—"
+              c.tipo_reinversion ? modalidadLabel[c.tipo_reinversion] ?? c.tipo_reinversion : "Tradicional"
             }</td>
             <td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">
               <span style="background:#fef3c7;color:#92400e;padding:2px 8px;border-radius:9999px;font-size:12px;font-weight:600;">POR VALIDAR</span>
@@ -424,9 +424,9 @@ export const sendCompraCarteraAcceptedNotification = async ({
 
     const modalidadLabelCreditos: Record<string, string> = {
       sin_reinversion: "Sin Reinversión",
-      reinversion_capital: "Reinversión de Capital",
+      reinversion_capital: "Reinversión Capital",
       reinversion_interes: "Reinversión de Interés",
-      reinversion_total: "Reinversión Total",
+      reinversion_total: "Interés Compuesto",
       reinversion_variable: "Reinversión Variable",
       reinversion_combinada: "Reinversión Combinada",
     };
@@ -441,7 +441,7 @@ export const sendCompraCarteraAcceptedNotification = async ({
             <td style="padding:8px 12px;border:1px solid #f59e0b;background:#ffffff;text-align:center;">${
               c.tipo_reinversion
                 ? modalidadLabelCreditos[c.tipo_reinversion] ?? c.tipo_reinversion
-                : "—"
+                : "Tradicional"
             }</td>
           </tr>`
       )


### PR DESCRIPTION
Streamlines the portfolio purchase process by removing the ability to select the reinvestment type during purchase:
- Updates server endpoints to no longer accept `tipo_reinversion` for `compra_cartera` operations.
- Modifies the frontend UI to display the investor's current reinvestment model as a static badge, instead of providing a selection input.

Enhances the `DataTable` component with a `tableContainerClass` prop:
- Allows custom styling to be applied directly to the table's container.
- Utilizes this new prop in the `Cobros` page to enable fixed height and vertical scrolling for the table.