### PR TITLE
refactor(cobros): remove client-side tag filtering

### DIFF
--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -473,15 +473,6 @@ function RouteComponent() {
 			);
 		}
 
-		// Filtrar por etiquetas (AND: el caso debe tener todas las seleccionadas)
-		if (filtroEtiquetas.length > 0) {
-			filtrados = filtrados.filter(
-				(c) =>
-					c.etiquetas &&
-					filtroEtiquetas.every((et) => c.etiquetas!.includes(et)),
-			);
-		}
-
 		// Filtrar por rango temporal
 		if (filtroTemporal === "todos") return filtrados;
 


### PR DESCRIPTION
Removes the client-side tag filtering logic from the `cobros` route. This filtering is now exclusively managed by the backend, completing the migration of tag-based credit filtering to the server.
