### PR TITLE
Modify Investor

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -28,7 +28,8 @@ const COMPRA_CARTERA_PENDIENTE_RECIPIENTS = {
     "jalvaradp@clubcashin.com",
     "daniel.r@clubcashin.com",
       "diego.a@sepresta.com",
-      "pablo.z@clubcashin.com"
+      "pablo.z@clubcashin.com",
+      "sara.r@clubcashin.com"
 
   ],
 };

--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -4,6 +4,7 @@ import {
   creditos_inversionistas,
   creditos,
   inversionistas,
+  usuarios,
 } from "../database/db";
 import { eq, inArray, and } from "drizzle-orm";
 import z from "zod";
@@ -23,6 +24,10 @@ const completeEspejoSchema = z.object({
     z.array(z.number().int().positive()).min(1),
   ]),
   inversionista_id: z.number().int().positive().optional(),
+  // Si viene true, el correo dice "Aceptada por el inversionista {nombre}"
+  // en lugar del usuario del JWT / "Contabilidad". Útil cuando el flujo
+  // se dispara desde el portal del inversionista.
+  aceptada_por_inversionista: z.boolean().optional(),
 });
 
 // ========================================
@@ -40,7 +45,11 @@ export const completeEspejo = async ({ body, set, request }: any) => {
       };
     }
 
-    const { creditos: creditosInput, inversionista_id } = parseResult.data;
+    const {
+      creditos: creditosInput,
+      inversionista_id,
+      aceptada_por_inversionista,
+    } = parseResult.data;
 
     // Normalizar a array
     const creditoIds = Array.isArray(creditosInput)
@@ -57,6 +66,14 @@ export const completeEspejo = async ({ body, set, request }: any) => {
               eq(creditos_inversionistas_espejo.inversionista_id, inversionista_id),
             )
           : eq(creditos_inversionistas_espejo.credito_id, credito_id);
+
+        // Capturar status PREVIOS antes de hacer el update.
+        // Lo usamos abajo para decidir el asunto/encabezado del correo
+        // (reinversion vs compra de cartera).
+        const previos = await tx
+          .select({ status: creditos_inversionistas_espejo.status })
+          .from(creditos_inversionistas_espejo)
+          .where(whereConditions);
 
         const updated = await tx
           .update(creditos_inversionistas_espejo)
@@ -91,6 +108,7 @@ export const completeEspejo = async ({ body, set, request }: any) => {
           credito_id,
           registros_actualizados: updated.length,
           detalle: updated,
+          statuses_previos: previos.map((p) => p.status),
         });
 
         console.log(
@@ -98,6 +116,20 @@ export const completeEspejo = async ({ body, set, request }: any) => {
         );
       }
     });
+
+    // Determinar el tipo de operación que se está cerrando a partir de los
+    // status previos. Usamos esto para personalizar el asunto/encabezado.
+    const allPrevStatuses = resultados.flatMap((r) => r.statuses_previos);
+    const huboReinversion = allPrevStatuses.includes("pendiente_reinversion");
+    const huboCompraCartera = allPrevStatuses.some(
+      (s) => s === "pendiente_revision" || s === "pendiente_compra_cartera",
+    );
+    const tipoOperacion: "reinversion" | "compra_cartera" | "otro" =
+      huboReinversion && !huboCompraCartera
+        ? "reinversion"
+        : !huboReinversion && huboCompraCartera
+          ? "compra_cartera"
+          : "otro";
 
     const totalActualizados = resultados.reduce(
       (acc, r) => acc + r.registros_actualizados,
@@ -130,16 +162,21 @@ export const completeEspejo = async ({ body, set, request }: any) => {
           console.warn("[completeEspejo] No se pudo resolver el usuario del JWT:", jwtErr);
         }
 
-        // Datos de los créditos para la tabla del correo
+        // Datos de los créditos para la tabla del correo (incluye cliente)
         const creditosInfo = await db
           .select({
             credito_id: creditos.credito_id,
             numero_credito_sifco: creditos.numero_credito_sifco,
+            cliente_nombre: usuarios.nombre,
           })
           .from(creditos)
+          .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
           .where(inArray(creditos.credito_id, creditoIds));
         const sifcoPorCredito = new Map(
           creditosInfo.map((c) => [c.credito_id, c.numero_credito_sifco]),
+        );
+        const clientePorCredito = new Map(
+          creditosInfo.map((c) => [c.credito_id, c.cliente_nombre]),
         );
 
         // Nombre del inversionista si el completar fue filtrado por uno solo
@@ -159,9 +196,11 @@ export const completeEspejo = async ({ body, set, request }: any) => {
         const filasCreditos = resultados
           .map((r) => {
             const sifco = sifcoPorCredito.get(r.credito_id) ?? "—";
+            const cliente = clientePorCredito.get(r.credito_id) ?? "—";
             return `
               <tr>
                 <td style="padding:6px 10px; border:1px solid #e5e7eb;">${sifco}</td>
+                <td style="padding:6px 10px; border:1px solid #e5e7eb;">${cliente}</td>
                 <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.credito_id}</td>
                 <td style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">${r.registros_actualizados}</td>
               </tr>
@@ -169,13 +208,28 @@ export const completeEspejo = async ({ body, set, request }: any) => {
           })
           .join("");
 
+        // ── Asunto y encabezado dinámicos según tipo de operación ──
+        const subjectPrefix =
+          tipoOperacion === "reinversion"
+            ? "Reinversión completada"
+            : tipoOperacion === "compra_cartera"
+              ? "Compra de cartera aceptada por contabilidad"
+              : "Espejos marcados como completado";
+
+        const headingHtml =
+          tipoOperacion === "reinversion"
+            ? `Reinversión <strong style="color:#16a34a;">COMPLETADA</strong>`
+            : tipoOperacion === "compra_cartera"
+              ? `Compra de cartera <strong style="color:#16a34a;">ACEPTADA POR CONTABILIDAD</strong>`
+              : `Espejos <strong style="color:#16a34a;">COMPLETADOS</strong>`;
+
         const subject = inversionista_id
-          ? `Compra de cartera aceptada por contabilidad — ${inversionistaNombre ?? `Inversionista ${inversionista_id}`}`
-          : `Compra de cartera aceptada por contabilidad — ${creditoIds.length} crédito(s)`;
+          ? `${subjectPrefix} — ${inversionistaNombre ?? `Inversionista ${inversionista_id}`}`
+          : `${subjectPrefix} — ${creditoIds.length} crédito(s)`;
 
         const html = `
           <div style="font-family: Arial, sans-serif; color:#111;">
-            <h2 style="margin-bottom: 8px;">Compra de cartera <strong style="color:#16a34a;">ACEPTADA POR CONTABILIDAD</strong></h2>
+            <h2 style="margin-bottom: 8px;">${headingHtml}</h2>
             <p>Los registros espejo de los créditos listados fueron marcados como <strong>completado</strong>.</p>
             <table style="border-collapse: collapse; margin-top: 8px;">
               ${inversionista_id
@@ -184,9 +238,11 @@ export const completeEspejo = async ({ body, set, request }: any) => {
               <tr><td style="padding:4px 8px;"><strong>Créditos:</strong></td><td style="padding:4px 8px;">${creditoIds.length}</td></tr>
               <tr><td style="padding:4px 8px;"><strong>Registros actualizados:</strong></td><td style="padding:4px 8px;"><strong>${totalActualizados}</strong></td></tr>
               <tr><td style="padding:4px 8px;"><strong>Fecha (GT):</strong></td><td style="padding:4px 8px;">${fechaGT}</td></tr>
-              ${usuarioNombre || usuarioEmail
-                ? `<tr><td style="padding:4px 8px;"><strong>Aceptada por:</strong></td><td style="padding:4px 8px;">${[usuarioNombre, usuarioEmail].filter(Boolean).join(" — ")}</td></tr>`
-                : `<tr><td style="padding:4px 8px;"><strong>Aceptada por:</strong></td><td style="padding:4px 8px;">Contabilidad</td></tr>`}
+              ${aceptada_por_inversionista
+                ? `<tr><td style="padding:4px 8px;"><strong>Aceptada por:</strong></td><td style="padding:4px 8px;">El inversionista ${inversionistaNombre ?? (inversionista_id ? `(ID: ${inversionista_id})` : "(desconocido)")}</td></tr>`
+                : usuarioNombre || usuarioEmail
+                  ? `<tr><td style="padding:4px 8px;"><strong>Aceptada por:</strong></td><td style="padding:4px 8px;">${[usuarioNombre, usuarioEmail].filter(Boolean).join(" — ")}</td></tr>`
+                  : `<tr><td style="padding:4px 8px;"><strong>Aceptada por:</strong></td><td style="padding:4px 8px;">Contabilidad</td></tr>`}
             </table>
 
             <h3 style="margin-top:16px;">Detalle por crédito</h3>
@@ -194,6 +250,7 @@ export const completeEspejo = async ({ body, set, request }: any) => {
               <thead>
                 <tr style="background:#f3f4f6;">
                   <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">SIFCO</th>
+                  <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">Cliente</th>
                   <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">Crédito ID</th>
                   <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">Registros completados</th>
                 </tr>

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -6268,7 +6268,12 @@ export async function testUploadAndEmail(investorId: number, testEmail: string) 
  * agrupados por inversionista. Incluye un array `otrosCreditos` placeholder (5 créditos random)
  * que será reemplazado por la consulta real cuando esté lista.
  */
-export async function getCreditosEspejoPendientes(page: number = 1, pageSize: number = 10, search?: string) {
+export async function getCreditosEspejoPendientes(
+  page: number = 1,
+  pageSize: number = 10,
+  search?: string,
+  inversionistaId?: number,
+) {
   // 1. Créditos espejo pendientes con info del inversionista + crédito + usuario
   const pendientes = await db
     .select({
@@ -6310,7 +6315,12 @@ export async function getCreditosEspejoPendientes(page: number = 1, pageSize: nu
       eq(creditos.usuario_id, usuarios.usuario_id)
     )
     .where(
-      sql`${creditos_inversionistas_espejo.status} IN ('pendiente_reinversion', 'pendiente_compra_cartera', 'pendiente_revision')`
+      and(
+        sql`${creditos_inversionistas_espejo.status} IN ('pendiente_reinversion', 'pendiente_compra_cartera', 'pendiente_revision')`,
+        inversionistaId !== undefined
+          ? eq(creditos_inversionistas_espejo.inversionista_id, inversionistaId)
+          : undefined,
+      ),
     );
 
   if (pendientes.length === 0) {

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -200,7 +200,27 @@ export const recalculateQuota = async ({ body, set }: any) => {
 
     const capital = Number(credito.capital);
     const monthlyRate = Number(credito.porcentaje_interes);
-    const termMonths = Number(credito.plazo);
+
+    const [{ cuotasPagadas }] = await db
+      .select({ cuotasPagadas: sql<number>`count(*)::int` })
+      .from(cuotas_credito)
+      .where(
+        and(
+          eq(cuotas_credito.credito_id, credito.credito_id),
+          eq(cuotas_credito.pagado, true),
+        ),
+      );
+
+    const termMonths = Number(credito.plazo) - Number(cuotasPagadas);
+
+    if (termMonths <= 0) {
+      set.status = 400;
+      return {
+        message:
+          "No hay cuotas pendientes para recalcular (plazo - cuotas pagadas <= 0)",
+      };
+    }
+
     const insuranceCost = Number(credito.seguro_10_cuotas ?? 0);
     const gpsCost = Number(credito.gps ?? 0);
     const membresiasCost = Number(credito.membresias_pago ?? 0);
@@ -233,6 +253,79 @@ export const recalculateQuota = async ({ body, set }: any) => {
       nueva_cuota: nuevaCuota,
     });
 
+    // 5. Recalcular cuotas de inversionistas (padre + espejo) con la nueva cuota total
+    const updateFieldsRecalc = {
+      cuota: nuevaCuota.toString(),
+      porcentaje_interes: credito.porcentaje_interes,
+      seguro_10_cuotas: credito.seguro_10_cuotas,
+      gps: credito.gps,
+      membresias_pago: credito.membresias_pago,
+    };
+
+    const invsPadre = await db
+      .select()
+      .from(creditos_inversionistas)
+      .where(eq(creditos_inversionistas.credito_id, credito.credito_id));
+
+    const invsEspejo = await db
+      .select()
+      .from(creditos_inversionistas_espejo)
+      .where(eq(creditos_inversionistas_espejo.credito_id, credito.credito_id));
+
+    const mapToInvestorInput = (inv: any) => ({
+      inversionista_id: inv.inversionista_id,
+      monto_aportado: inv.monto_aportado,
+      porcentaje_cash_in: inv.porcentaje_cash_in,
+      porcentaje_inversion: inv.porcentaje_participacion_inversionista,
+      fecha_inicio_participacion: inv.fecha_inicio_participacion,
+    });
+
+    let parentCuotas: Map<number, string> = new Map();
+    if (invsPadre.length > 0) {
+      parentCuotas = await updateInvestors(
+        credito.credito_id,
+        invsPadre.map(mapToInvestorInput) as any,
+        updateFieldsRecalc,
+        credito,
+        numero_credito_sifco,
+        Number(credito.seguro_10_cuotas ?? 0),
+        Number(credito.membresias_pago ?? 0),
+        Number(credito.gps ?? 0),
+        creditos_inversionistas,
+      );
+    }
+
+    if (invsEspejo.length > 0) {
+      const espejoSincronizado = invsEspejo.map((inv) => ({
+        ...mapToInvestorInput(inv),
+        cuota_inversionista: parentCuotas.get(inv.inversionista_id),
+      }));
+
+      await updateInvestors(
+        credito.credito_id,
+        espejoSincronizado as any,
+        updateFieldsRecalc,
+        credito,
+        numero_credito_sifco,
+        Number(credito.seguro_10_cuotas ?? 0),
+        Number(credito.membresias_pago ?? 0),
+        Number(credito.gps ?? 0),
+        creditos_inversionistas_espejo,
+        parentCuotas,
+      );
+    }
+
+    // 6. Traer los inversionistas ya recalculados para devolverlos
+    const invsPadreActualizado = await db
+      .select()
+      .from(creditos_inversionistas)
+      .where(eq(creditos_inversionistas.credito_id, credito.credito_id));
+
+    const invsEspejoActualizado = await db
+      .select()
+      .from(creditos_inversionistas_espejo)
+      .where(eq(creditos_inversionistas_espejo.credito_id, credito.credito_id));
+
     set.status = 200;
     return {
       success: true,
@@ -243,6 +336,32 @@ export const recalculateQuota = async ({ body, set }: any) => {
         nueva_cuota: nuevaCuota.toString(),
         porcentaje_interes: monthlyRate.toString(),
         plazo: termMonths,
+        inversionistas: invsPadreActualizado.map((inv) => ({
+          inversionista_id: inv.inversionista_id,
+          monto_aportado: inv.monto_aportado,
+          porcentaje_participacion_inversionista:
+            inv.porcentaje_participacion_inversionista,
+          porcentaje_cash_in: inv.porcentaje_cash_in,
+          cuota_inversionista: inv.cuota_inversionista,
+          monto_inversionista: inv.monto_inversionista,
+          monto_cash_in: inv.monto_cash_in,
+          iva_inversionista: inv.iva_inversionista,
+          iva_cash_in: inv.iva_cash_in,
+        })),
+        inversionistas_espejo: invsEspejoActualizado.map((inv) => ({
+          inversionista_id: inv.inversionista_id,
+          monto_aportado: inv.monto_aportado,
+          porcentaje_participacion_inversionista:
+            inv.porcentaje_participacion_inversionista,
+          porcentaje_cash_in: inv.porcentaje_cash_in,
+          cuota_inversionista: inv.cuota_inversionista,
+          monto_inversionista: inv.monto_inversionista,
+          monto_cash_in: inv.monto_cash_in,
+          iva_inversionista: inv.iva_inversionista,
+          iva_cash_in: inv.iva_cash_in,
+          status: inv.status,
+          tipo_reinversion: inv.tipo_reinversion,
+        })),
       },
     };
   } catch (error) {
@@ -1004,8 +1123,77 @@ export const updateCredit = async ({ body, set }: any) => {
       .where(eq(creditos.credito_id, credito_id))
       .returning();
 
+    // 8.1 Si la cuota cambió, sincronizar cuotas pendientes y recalcular
+    // cuotas de inversionistas (solo si NO vinieron en el body — si vinieron,
+    // el bloque siguiente las maneja con la cuota nueva).
+    if (willChangeCuota) {
+      const sifco = numero_credito_sifco ?? current.numero_credito_sifco;
+      const cuotaNuevaNum = Number(updateFields.cuota);
 
-        
+      await updateInstallments({
+        numero_credito_sifco: sifco,
+        nueva_cuota: cuotaNuevaNum,
+      });
+
+      const bodyTraeInversionistas =
+        (inversionistas && inversionistas.length > 0) ||
+        (inversionistas_espejo && inversionistas_espejo.length > 0);
+
+      if (!bodyTraeInversionistas) {
+        const invsPadreActuales = await db
+          .select()
+          .from(creditos_inversionistas)
+          .where(eq(creditos_inversionistas.credito_id, credito_id));
+
+        const invsEspejoActuales = await db
+          .select()
+          .from(creditos_inversionistas_espejo)
+          .where(eq(creditos_inversionistas_espejo.credito_id, credito_id));
+
+        const mapToInvestorInput = (inv: any) => ({
+          inversionista_id: inv.inversionista_id,
+          monto_aportado: inv.monto_aportado,
+          porcentaje_cash_in: inv.porcentaje_cash_in,
+          porcentaje_inversion: inv.porcentaje_participacion_inversionista,
+          fecha_inicio_participacion: inv.fecha_inicio_participacion,
+        });
+
+        let cuotasPadreAuto: Map<number, string> = new Map();
+        if (invsPadreActuales.length > 0) {
+          cuotasPadreAuto = await updateInvestors(
+            credito_id,
+            invsPadreActuales.map(mapToInvestorInput) as any,
+            updateFields,
+            current,
+            sifco,
+            Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
+            Number(updateFields.membresias_pago ?? current.membresias_pago),
+            Number(updateFields.gps ?? current.gps),
+            creditos_inversionistas,
+          );
+        }
+
+        if (invsEspejoActuales.length > 0) {
+          const espejoSinc = invsEspejoActuales.map((inv) => ({
+            ...mapToInvestorInput(inv),
+            cuota_inversionista: cuotasPadreAuto.get(inv.inversionista_id),
+          }));
+
+          await updateInvestors(
+            credito_id,
+            espejoSinc as any,
+            updateFields,
+            current,
+            sifco,
+            Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
+            Number(updateFields.membresias_pago ?? current.membresias_pago),
+            Number(updateFields.gps ?? current.gps),
+            creditos_inversionistas_espejo,
+            cuotasPadreAuto,
+          );
+        }
+      }
+    }
 
     // 9. Actualizar inversionistas (Principal)
     let parentCuotas: Map<number, string> = new Map();

--- a/apps/cartera-back/src/routers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/routers/addInvestorToCredit.ts
@@ -1,7 +1,10 @@
 import { Elysia, t } from "elysia";
 import { addInvestorToCredit } from "../controllers/addInvestorToCredit";
+import { authMiddleware } from "./midleware";
 
-export const addInvestorToCreditRouter = new Elysia().post(
+export const addInvestorToCreditRouter = new Elysia()
+  .use(authMiddleware)
+  .post(
   "/agregar-inversionista-credito",
   addInvestorToCredit,
   {

--- a/apps/cartera-back/src/routers/advisor.ts
+++ b/apps/cartera-back/src/routers/advisor.ts
@@ -11,7 +11,8 @@ import {
 import { authMiddleware } from "./midleware";
 
 export const advisorRouter = new Elysia()
- 
+  .use(authMiddleware)
+
   .post("/advisor", insertAdvisor)
   .post("/updateAdvisor", updateAdvisor)
   .get("/advisor", getAdvisors)

--- a/apps/cartera-back/src/routers/assignCapital.ts
+++ b/apps/cartera-back/src/routers/assignCapital.ts
@@ -1,7 +1,9 @@
 import { Elysia } from "elysia";
 import { getCreditCandidates, type CreditCandidate } from "../controllers/assignCapital";
+import { authMiddleware } from "./midleware";
 
 export const assignCapitalRouter = new Elysia()
+  .use(authMiddleware)
 
   /**
    * GET /assign-capital/candidates

--- a/apps/cartera-back/src/routers/banks.ts
+++ b/apps/cartera-back/src/routers/banks.ts
@@ -6,8 +6,8 @@ import { bancos } from '../database/db';
 import { authMiddleware } from "./midleware";
 
 export const bancosRouter = new Elysia()
- 
-  
+  .use(authMiddleware)
+
   // 📋 GET - Obtener todos los bancos
   .get("/bancos", async () => {
     try {

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -2,6 +2,7 @@
 
 import { Elysia, t } from "elysia";
 import jwt from "jsonwebtoken";
+import { authMiddleware } from "./midleware";
 import { SATClientService } from "../cofidi/satClientService";
 import { DTEService } from "../cofidi/dteService";
 import { generarHTMLFacturaPro } from "../cofidi/functions";
@@ -64,6 +65,7 @@ function generarIdInternoRandom(): string {
 
 
 export const dteController = new Elysia({ prefix: "/api/dte" })
+  .use(authMiddleware)
 
   // 🔥 POST - Certificar DTE
   // ========================================================================

--- a/apps/cartera-back/src/routers/completeEspejo.ts
+++ b/apps/cartera-back/src/routers/completeEspejo.ts
@@ -1,7 +1,10 @@
 import { Elysia, t } from "elysia";
 import { completeEspejo } from "../controllers/completeEspejo";
+import { authMiddleware } from "./midleware";
 
-export const completeEspejoRouter = new Elysia().post(
+export const completeEspejoRouter = new Elysia()
+  .use(authMiddleware)
+  .post(
   "/completar-espejo",
   completeEspejo,
   {
@@ -11,6 +14,7 @@ export const completeEspejoRouter = new Elysia().post(
         t.Array(t.Number({ minimum: 1 }), { minItems: 1 }),
       ]),
       inversionista_id: t.Optional(t.Number({ minimum: 1 })),
+      aceptada_por_inversionista: t.Optional(t.Boolean()),
     }),
     detail: {
       summary: "Marcar créditos espejo como completado",

--- a/apps/cartera-back/src/routers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/routers/compraCarteraAceptada.ts
@@ -1,7 +1,10 @@
 import { Elysia, t } from "elysia";
 import { compraCarteraAceptada } from "../controllers/compraCarteraAceptada";
+import { authMiddleware } from "./midleware";
 
-export const compraCarteraAceptadaRouter = new Elysia().post(
+export const compraCarteraAceptadaRouter = new Elysia()
+  .use(authMiddleware)
+  .post(
   "/compra-cartera-aceptada",
   compraCarteraAceptada,
   {

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -81,7 +81,7 @@ const RouterBodySchema = z.object({
 });
 export const creditRouter = new Elysia()
  
-//.use(authMiddleware)
+.use(authMiddleware)
   // Crear nuevo crédito
 .post("/newCredit", async ({ body, set }) => {
   const result = await insertCredit({ body, set });

--- a/apps/cartera-back/src/routers/fallenCredits.ts
+++ b/apps/cartera-back/src/routers/fallenCredits.ts
@@ -1,7 +1,9 @@
 import { Elysia, t } from "elysia";
 import { marcarCreditoComoCaido, getCreditosCaidos } from "../controllers/fallenCredits";
+import { authMiddleware } from "./midleware";
 
 export const fallenCreditsRouter = new Elysia()
+  .use(authMiddleware)
 
   // POST - Marcar crédito como caído
   .post(

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -39,6 +39,7 @@ import { requierePeriodoLiquidacion } from "../utils/investorLiquidationSummary"
  
 
 export const inversionistasRouter = new Elysia()
+  .use(authMiddleware)
   .post("/investor", insertInvestor)
   .get("/investor", getInvestors)
   .post("/investor/update", updateInvestor)
@@ -1528,7 +1529,15 @@ export const inversionistasRouter = new Elysia()
         const page = Number(query.page) || 1;
         const pageSize = Number(query.pageSize) || 10;
         const search = query.search || undefined;
-        const result = await getCreditosEspejoPendientes(page, pageSize, search);
+        const inversionistaId = query.inversionista_id
+          ? Number(query.inversionista_id)
+          : undefined;
+        const result = await getCreditosEspejoPendientes(
+          page,
+          pageSize,
+          search,
+          inversionistaId,
+        );
         return result;
       } catch (error: any) {
         console.error("[GET /creditos-espejo-pendientes] Error:", error);
@@ -1541,13 +1550,14 @@ export const inversionistasRouter = new Elysia()
         page: t.Optional(t.String()),
         pageSize: t.Optional(t.String()),
         search: t.Optional(t.String()),
+        inversionista_id: t.Optional(t.String()),
       }),
       detail: {
         summary: "Créditos espejo pendientes agrupados por inversionista (paginado)",
         description:
-          "Devuelve los créditos espejo con status pendiente_reinversion o pendiente_compra_cartera, " +
-          "agrupados por inversionista. Cada inversionista incluye opciones_de_credito (10 candidatos). " +
-          "Soporta paginación con query params page y pageSize.",
+          "Devuelve los créditos espejo con status pendiente_reinversion, pendiente_compra_cartera " +
+          "o pendiente_revision, agrupados por inversionista. Soporta paginación (page, pageSize), " +
+          "búsqueda por nombre (search) y filtro por inversionista_id.",
         tags: ["Inversionistas", "Espejos"],
       },
     }

--- a/apps/cartera-back/src/routers/investorDocuments.ts
+++ b/apps/cartera-back/src/routers/investorDocuments.ts
@@ -7,8 +7,10 @@ import {
   getSignedDocumentUrl,
   deleteDocumentoFromR2,
 } from "../utils/functions/uploadsFiles";
+import { authMiddleware } from "./midleware";
 
 export const investorDocumentsRouter = new Elysia()
+  .use(authMiddleware)
 
   // POST - Crear documento
   .post(

--- a/apps/cartera-back/src/routers/latefee.ts
+++ b/apps/cartera-back/src/routers/latefee.ts
@@ -6,7 +6,7 @@ import { authMiddleware } from "./midleware";
 import { createMora, updateMora, procesarMoras, condonarMora, getCreditosWithMoras, getCondonacionesMora, condonarTodasLasMoras } from "../controllers/latefee";
 
 export const morasRouter = new Elysia()
- 
+  .use(authMiddleware)
 
   /**
    * Crear una mora manualmente

--- a/apps/cartera-back/src/routers/migration.ts
+++ b/apps/cartera-back/src/routers/migration.ts
@@ -121,7 +121,8 @@ const csvMoraPath = path.resolve(
   "C:/Users/Kelvin Palacios/Documents/analis de datos/moraGeneral.csv"
 );
 export const sifcoRouter = new Elysia()
- 
+  .use(authMiddleware)
+
   /**
    * 🔄 Sincronizar cliente(s) con préstamos desde SIFCO
    */

--- a/apps/cartera-back/src/routers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/routers/mirrorInvestor.ts
@@ -1,7 +1,9 @@
 import { Elysia, t } from "elysia";
 import { llenarTablaEspejo, getCreditsWithMirrors, getCreditsByInvestor, asignarReinversionEspejo } from "../controllers/mirrorInvestor";
+import { authMiddleware } from "./midleware";
 
 export const mirrorInvestorRouter = new Elysia()
+  .use(authMiddleware)
   .post("/llenar-tabla-espejo", llenarTablaEspejo, {
     query: t.Object({
       calcular_cuota: t.Optional(t.String()),

--- a/apps/cartera-back/src/routers/notifications.ts
+++ b/apps/cartera-back/src/routers/notifications.ts
@@ -1,7 +1,9 @@
 import { Elysia, t } from "elysia";
 import { notifyPayInvestors } from "../services/crm.service";
+import { authMiddleware } from "./midleware";
 
 export const notificationsRouter = new Elysia({ prefix: "/notifications" })
+  .use(authMiddleware)
   .post(
     "/pay-investors",
     async ({ body, set }) => {

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -37,7 +37,8 @@ const falsePaymentSchema = z.object({
 
 
 
-export const paymentRouter = new Elysia() 
+export const paymentRouter = new Elysia()
+  .use(authMiddleware)
   // Endpoint para registrar pago (ya lo tienes)
   .post("/newPayment", insertPayment)
   .post("/reversePayment", reversePayment)

--- a/apps/cartera-back/src/routers/recalculateFromJson.ts
+++ b/apps/cartera-back/src/routers/recalculateFromJson.ts
@@ -8,6 +8,7 @@ import {
   eliminarCreditos,
   actualizarCuotasInversionistas,
 } from "../controllers/recalculateFromJson";
+import { authMiddleware } from "./midleware";
 
 // ========================================
 // SCHEMA PARA VALIDACIÓN
@@ -59,6 +60,7 @@ const CreditoEliminarSchema = t.Object({
 // ========================================
 
 export const recalculateFromJsonRouter = new Elysia({ prefix: "/recalculate" })
+  .use(authMiddleware)
   // 📌 POST: Recibir JSON directamente en el body
   .post(
     "/from-json",

--- a/apps/cartera-back/src/routers/reconcileEspejo.ts
+++ b/apps/cartera-back/src/routers/reconcileEspejo.ts
@@ -1,7 +1,9 @@
 import { Elysia, t } from "elysia";
 import { reconcileEspejo } from "../controllers/reconcileEspejo";
+import { authMiddleware } from "./midleware";
 
 export const reconcileEspejoRouter = new Elysia()
+  .use(authMiddleware)
   .post("/reconcile-espejo", reconcileEspejo, {
     body: t.Object({
       inversionista: t.String({ minLength: 1 }),

--- a/apps/cartera-back/src/routers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/routers/replaceInvestorCredit.ts
@@ -3,8 +3,10 @@ import {
   manualReassignInvestor,
   returnPendingInvestorsToCube,
 } from "../controllers/replaceInvestorCredit";
+import { authMiddleware } from "./midleware";
 
 export const replaceInvestorCreditRouter = new Elysia()
+  .use(authMiddleware)
   .post(
     "/reemplazar-inversionista-credito",
     manualReassignInvestor,

--- a/apps/cartera-back/src/routers/sifcoSync.ts
+++ b/apps/cartera-back/src/routers/sifcoSync.ts
@@ -1,7 +1,10 @@
 import { Elysia } from "elysia";
 import { syncTodosLosClientes } from "../controllers/sifcoSync";
+import { authMiddleware } from "./midleware";
 
-export const sifcoSyncRouter = new Elysia({ prefix: "/api/sifco-sync" }).post(
+export const sifcoSyncRouter = new Elysia({ prefix: "/api/sifco-sync" })
+  .use(authMiddleware)
+  .post(
   "/all",
   async () => {
     // Lanzar en background y responder inmediatamente

--- a/apps/cartera-back/src/routers/uploads.ts
+++ b/apps/cartera-back/src/routers/uploads.ts
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 import { uploadFileController } from "../utils/functions/uploadsFiles";
- 
+import { authMiddleware } from "./midleware";
 
-export const uploadRouter = (app: Elysia) =>
-  app.post("/upload", uploadFileController);
+export const uploadRouter = new Elysia()
+  .use(authMiddleware)
+  .post("/upload", uploadFileController);

--- a/apps/cartera-back/src/utils/functions/compraCarteraRecipients.ts
+++ b/apps/cartera-back/src/utils/functions/compraCarteraRecipients.ts
@@ -13,11 +13,8 @@ export const COMPRA_CARTERA_RECIPIENTS = {
     "doris.analiss@sepresta.com",
     "lucia.s@clubcashin.com",
     "diego.a@sepresta.com",
-    "sara.r@sepresta.com",
-    "caja@sepresta.com",
-    "alexander.p@clubcashin.com",
-    "juan.r@clubcashin.com",
-    "roxana.g@clubcashin.com",
+    "sara.r@clubcashin.com",
+    "caja@sepresta.com", 
   ],
   cc: [
     "diego.l@clubcashin.com",

--- a/apps/cartera-back/src/utils/functions/investorStatusRecipients.ts
+++ b/apps/cartera-back/src/utils/functions/investorStatusRecipients.ts
@@ -3,7 +3,7 @@
 export const INVESTOR_STATUS_CHANGE_RECIPIENTS = [
   "info@clubcashin.com",
   "diego.a@sepresta.com",
-  "sara.r@sepresta.com",
+  "sara.r@clubcashin.com",
   "caja@sepresta.com",
   "alexander.p@clubcashin.com",
   "juan.r@clubcashin.com",

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -39,6 +39,9 @@ interface InvestorsListProps {
   errorMessage?: string | string[];
   errorMessageMirror?: string | string[];
   onSaldoChanges?: (changes: Record<number, number>) => void;
+  recalculatedQuotas?: Record<number, number>;
+  recalculatedQuotasMirror?: Record<number, number>;
+  onClearRecalculatedQuota?: (inversionistaId: number, isMirror: boolean) => void;
 }
 
 export function InvestorsList({
@@ -51,6 +54,9 @@ export function InvestorsList({
   errorMessage,
   errorMessageMirror,
   onSaldoChanges,
+  recalculatedQuotas,
+  recalculatedQuotasMirror,
+  onClearRecalculatedQuota,
 }: InvestorsListProps) {
   // Estado local para saber qué items tienen el espejo expandido
   const [expandedMirrors, setExpandedMirrors] = useState<Set<number>>(new Set());
@@ -449,19 +455,36 @@ export function InvestorsList({
                 <div className="flex items-center justify-between h-5">
                   <Label className="text-blue-900">Cuota</Label>
                 </div>
-                <Input
-                  className={`mt-1 transition-all duration-300 ${showRecalculated ? "bg-emerald-50 border-emerald-400 ring-2 ring-emerald-100" : ""}`}
-                  type="number"
-                  name={`${fieldName}.${index}.cuota_inversionista`}
-                  value={inv.cuota_inversionista ?? 0}
-                  onFocus={(e) => e.target.select()}
-                  onChange={formik.handleChange}
-                  onBlur={(e) => {
-                    const val = Number(e.target.value);
-                    formik.setFieldValue(`${fieldName}.${index}.cuota_inversionista`, Number(val.toFixed(2)));
-                    setShowRecalculated(false);
-                  }}
-                />
+                {(() => {
+                  const invId = Number(inv.inversionista_id);
+                  const recalc = recalculatedQuotas?.[invId];
+                  const highlight = showRecalculated || recalc !== undefined;
+                  return (
+                    <>
+                      <Input
+                        className={`mt-1 transition-all duration-300 ${highlight ? "bg-emerald-50 border-emerald-400 ring-2 ring-emerald-100" : ""}`}
+                        type="number"
+                        name={`${fieldName}.${index}.cuota_inversionista`}
+                        value={inv.cuota_inversionista ?? 0}
+                        onFocus={(e) => e.target.select()}
+                        onChange={(e) => {
+                          formik.handleChange(e);
+                          if (recalc !== undefined) onClearRecalculatedQuota?.(invId, false);
+                        }}
+                        onBlur={(e) => {
+                          const val = Number(e.target.value);
+                          formik.setFieldValue(`${fieldName}.${index}.cuota_inversionista`, Number(val.toFixed(2)));
+                          setShowRecalculated(false);
+                        }}
+                      />
+                      {recalc !== undefined && (
+                        <span className="text-xs font-semibold text-emerald-600 mt-1 block">
+                          Nueva cuota: Q{recalc.toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                        </span>
+                      )}
+                    </>
+                  );
+                })()}
               </div>
               <div className="w-24">
                 <div className="h-5 flex items-center">
@@ -707,20 +730,37 @@ export function InvestorsList({
                         <div className="flex items-center justify-between h-5">
                           <Label className="text-purple-900 text-xs">Cuota Espejo</Label>
                         </div>
-                        <Input
-                        className={`mt-1 h-9 text-sm border-purple-200 transition-all duration-300 ${isNew ? "bg-gray-100 cursor-not-allowed" : showRecalculated ? "bg-emerald-50 border-emerald-400 ring-2 ring-emerald-100" : ""}`}
-                        type="number"
-                        name={`investorsMirror.${index}.cuota_inversionista`}
-                        value={invMirror.cuota_inversionista ?? 0}
-                        onFocus={(e) => e.target.select()}
-                        onChange={formik.handleChange}
-                        onBlur={(e) => {
-                          const val = Number(e.target.value);
-                          formik.setFieldValue(`investorsMirror.${index}.cuota_inversionista`, Number(val.toFixed(2)));
-                          setShowRecalculated(false);
-                        }}
-                        disabled={isNew}
-                        />
+                        {(() => {
+                          const invId = Number(invMirror.inversionista_id);
+                          const recalc = recalculatedQuotasMirror?.[invId];
+                          const highlight = showRecalculated || recalc !== undefined;
+                          return (
+                            <>
+                              <Input
+                                className={`mt-1 h-9 text-sm border-purple-200 transition-all duration-300 ${isNew ? "bg-gray-100 cursor-not-allowed" : highlight ? "bg-emerald-50 border-emerald-400 ring-2 ring-emerald-100" : ""}`}
+                                type="number"
+                                name={`investorsMirror.${index}.cuota_inversionista`}
+                                value={invMirror.cuota_inversionista ?? 0}
+                                onFocus={(e) => e.target.select()}
+                                onChange={(e) => {
+                                  formik.handleChange(e);
+                                  if (recalc !== undefined) onClearRecalculatedQuota?.(invId, true);
+                                }}
+                                onBlur={(e) => {
+                                  const val = Number(e.target.value);
+                                  formik.setFieldValue(`investorsMirror.${index}.cuota_inversionista`, Number(val.toFixed(2)));
+                                  setShowRecalculated(false);
+                                }}
+                                disabled={isNew}
+                              />
+                              {recalc !== undefined && (
+                                <span className="text-xs font-semibold text-emerald-600 mt-1 block">
+                                  Nueva: Q{recalc.toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                                </span>
+                              )}
+                            </>
+                          );
+                        })()}
                     </div>
                     <div className="w-24">
                         <div className="h-5 flex items-center">

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -107,6 +107,8 @@ export function ModalEditCredit({
   // Ref para acumular los cambios de saldo reinversion desde InvestorsList
   const saldoChangesRef = useRef<Record<number, number>>({});
   const [nuevaCuota, setNuevaCuota] = useState<number | null>(null);
+  const [nuevasCuotasInvestors, setNuevasCuotasInvestors] = useState<Record<number, number>>({});
+  const [nuevasCuotasInvestorsMirror, setNuevasCuotasInvestorsMirror] = useState<Record<number, number>>({});
   const [asesorQuery, setAsesorQuery] = useState("");
 
   const filteredAdvisors = useMemo(
@@ -336,7 +338,8 @@ export function ModalEditCredit({
                 {
                   onSuccess: (data: any) => {
                     console.log("Recalculate response:", data);
-                    const raw = data?.cuota ?? data?.nueva_cuota ?? data?.newQuota ?? data?.data?.cuota ?? data?.data?.nueva_cuota ?? data?.result?.cuota;
+                    const payload = data?.data ?? data?.result ?? data;
+                    const raw = payload?.cuota ?? payload?.nueva_cuota ?? payload?.newQuota;
                     const cuotaRecalculada = Number(Number(raw || 0).toFixed(2));
                     if (cuotaRecalculada > 0) {
                       setNuevaCuota(cuotaRecalculada);
@@ -346,6 +349,42 @@ export function ModalEditCredit({
                       if (currentCuota > 0) {
                         setNuevaCuota(currentCuota);
                       }
+                    }
+
+                    const mergeCuota = (
+                      list: typeof formik.values.investors,
+                      incoming: any[] | undefined
+                    ) => {
+                      const highlights: Record<number, number> = {};
+                      const merged = list.map((inv) => {
+                        const match = incoming?.find(
+                          (i) => Number(i.inversionista_id) === Number(inv.inversionista_id)
+                        );
+                        if (!match) return inv;
+                        const nueva = Number(Number(match.cuota_inversionista || 0).toFixed(2));
+                        if (Math.abs(nueva - Number(inv.cuota_inversionista || 0)) > 0.005) {
+                          highlights[Number(inv.inversionista_id)] = nueva;
+                        }
+                        return { ...inv, cuota_inversionista: nueva };
+                      });
+                      return { merged, highlights };
+                    };
+
+                    if (Array.isArray(payload?.inversionistas)) {
+                      const { merged, highlights } = mergeCuota(
+                        formik.values.investors,
+                        payload.inversionistas
+                      );
+                      formik.setFieldValue("investors", merged);
+                      setNuevasCuotasInvestors(highlights);
+                    }
+                    if (Array.isArray(payload?.inversionistas_espejo)) {
+                      const { merged, highlights } = mergeCuota(
+                        formik.values.investorsMirror,
+                        payload.inversionistas_espejo
+                      );
+                      formik.setFieldValue("investorsMirror", merged);
+                      setNuevasCuotasInvestorsMirror(highlights);
                     }
                   },
                 }
@@ -600,6 +639,23 @@ export function ModalEditCredit({
               errorMessage={formik.errors.investors as string}
               errorMessageMirror={formik.errors.investorsMirror as string}
               onSaldoChanges={(changes) => { saldoChangesRef.current = changes; }}
+              recalculatedQuotas={nuevasCuotasInvestors}
+              recalculatedQuotasMirror={nuevasCuotasInvestorsMirror}
+              onClearRecalculatedQuota={(invId, isMirror) => {
+                if (isMirror) {
+                  setNuevasCuotasInvestorsMirror((prev) => {
+                    const next = { ...prev };
+                    delete next[invId];
+                    return next;
+                  });
+                } else {
+                  setNuevasCuotasInvestors((prev) => {
+                    const next = { ...prev };
+                    delete next[invId];
+                    return next;
+                  });
+                }
+              }}
             />
           </form>
         </div>

--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -111,12 +111,13 @@ export function PagoForm() {
     const files = Array.from(e.dataTransfer.files).filter(
       (f) => f.type.startsWith("image/") || f.type === "application/pdf"
     );
-    if (files.length + archivosParaSubir.length > 3) {
-      toast.error("Solo puedes seleccionar hasta 3 archivos en total");
+    if (files.length === 0) return;
+    if (files.length > 1) {
+      toast.error("Solo se puede cargar una boleta");
       return;
     }
-    setArchivosParaSubir([...archivosParaSubir, ...files]);
-  }, [archivosParaSubir, setArchivosParaSubir]);
+    setArchivosParaSubir([files[0]]);
+  }, [setArchivosParaSubir]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -811,37 +812,43 @@ export function PagoForm() {
               </div>
               <div className="flex flex-col gap-1">
                 <Label className="text-gray-700 font-semibold text-sm">
-                  Boletas / Comprobantes
+                  Boleta / Comprobante
                 </Label>
                 <label
                   htmlFor="boleta-upload"
-                  className={`flex items-center justify-center gap-2 w-full border-2 border-dashed rounded-lg px-4 py-3 cursor-pointer transition text-sm ${
-                    isDragging
-                      ? "border-blue-500 bg-blue-50 text-blue-600"
-                      : "border-gray-300 hover:border-blue-400 hover:bg-blue-50/50 text-gray-500"
+                  className={`flex items-center justify-center gap-2 w-full border-2 border-dashed rounded-lg px-4 py-3 transition text-sm ${
+                    archivosParaSubir.length >= 1
+                      ? "border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed"
+                      : isDragging
+                        ? "border-blue-500 bg-blue-50 text-blue-600 cursor-pointer"
+                        : "border-gray-300 hover:border-blue-400 hover:bg-blue-50/50 text-gray-500 cursor-pointer"
                   }`}
-                  onDrop={handleDrop}
-                  onDragOver={handleDragOver}
-                  onDragLeave={handleDragLeave}
+                  onDrop={archivosParaSubir.length >= 1 ? undefined : handleDrop}
+                  onDragOver={archivosParaSubir.length >= 1 ? undefined : handleDragOver}
+                  onDragLeave={archivosParaSubir.length >= 1 ? undefined : handleDragLeave}
                 >
                   <Info className="w-4 h-4" />
-                  {isDragging
-                    ? "Suelta los archivos aquí"
-                    : "Haz clic o arrastra archivos aquí (max. 3)"}
+                  {archivosParaSubir.length >= 1
+                    ? "Ya hay una boleta cargada (elimínala para subir otra)"
+                    : isDragging
+                      ? "Suelta el archivo aquí"
+                      : "Haz clic o arrastra el archivo aquí (solo 1)"}
                 </label>
                 <input
                   id="boleta-upload"
                   type="file"
                   accept="image/*,application/pdf"
-                  multiple
                   className="hidden"
+                  disabled={archivosParaSubir.length >= 1}
                   onChange={(e) => {
                     const files = Array.from(e.target.files ?? []);
-                    if (files.length + archivosParaSubir.length > 3) {
-                      toast.error("Solo puedes seleccionar hasta 3 archivos en total");
+                    if (files.length === 0) return;
+                    if (archivosParaSubir.length >= 1) {
+                      toast.error("Solo se puede cargar una boleta");
+                      e.target.value = "";
                       return;
                     }
-                    setArchivosParaSubir([...archivosParaSubir, ...files]);
+                    setArchivosParaSubir([files[0]]);
                     e.target.value = "";
                   }}
                 />

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -392,13 +392,20 @@ app.post("/api/upload-opportunity-document", async (c) => {
 });
 app.post("/info/renap", async (c) => {
 	try {
-		const body = await c.req.json<{ dpi: string; phone: string }>();
+		const body = await c.req.json<{ dpi: unknown; phone: unknown }>();
 
-		const result = await getRenapInfoController(body.dpi, body.phone);
+		const dpi = String(body.dpi ?? "").trim();
+		const phone = String(body.phone ?? "").trim();
+
+		if (!dpi || !phone) {
+			return c.json({ error: "dpi y phone son requeridos" }, 400);
+		}
+
+		const result = await getRenapInfoController(dpi, phone);
 
 		return c.json(result);
 	} catch (err: any) {
-		console.error("[ERROR] /test/renap:", err);
+		console.error("[ERROR] /info/renap:", err);
 		return c.json({ error: err.message || "Internal server error" }, 500);
 	}
 });

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -25,6 +25,37 @@ if (!domain) {
 
 const resend = new Resend(apiKey);
 
+// ================================================================
+// DEV MODE: redirige TODOS los correos a un solo destinatario.
+// Controlado por la env SERVER (default: "DEV"):
+//   - SERVER=DEV   → todos los correos van solo a EMAIL_DEV_RECIPIENT
+//                    (default: jalvarado@clubcashin.com).
+//   - SERVER=PROD  → envío normal con destinatarios originales.
+// Por seguridad, el default es DEV: si la env no está seteada, NO se
+// mandan correos a destinatarios reales.
+// ================================================================
+const SERVER = (process.env.SERVER ?? "DEV").toUpperCase();
+const EMAIL_DEV_RECIPIENT =
+  process.env.EMAIL_DEV_RECIPIENT ?? "jalvarado@clubcashin.com";
+
+if (SERVER !== "PROD") {
+  const originalSend = resend.emails.send.bind(resend.emails);
+  resend.emails.send = (async (payload: any, options?: any) => {
+    const original = { to: payload?.to, cc: payload?.cc, bcc: payload?.bcc };
+    const overridden = {
+      ...payload,
+      to: [EMAIL_DEV_RECIPIENT],
+      cc: undefined,
+      bcc: undefined,
+    };
+    console.log(
+      `[Email ${SERVER}] Redirigiendo correo a ${EMAIL_DEV_RECIPIENT}. Originales:`,
+      original,
+    );
+    return originalSend(overridden, options);
+  }) as typeof resend.emails.send;
+}
+
 // Schema para validación de correo
 const emailSchema = z.string().email({ message: "Formato de correo electrónico inválido" });
 


### PR DESCRIPTION
Improves the espejo completion workflow and email notifications:
- Introduces dynamic email subjects and headings based on the operation type (reinversion, compra de cartera).
- Includes client names in the completion notification emails.
- Adds an option to specify if the completion was accepted directly by an investor, affecting the email's "Accepted by" line.

Implements robust investor quota recalculation:
- Recalculates individual investor quotas (both parent and espejo) based on the credit's remaining term, taking into account paid installments.
- Provides the newly calculated investor quotas in the API response and highlights them in the frontend UI.
- Automatically recalculates investor quotas when the main credit quota is updated if no investor data is explicitly provided in the request.

Refactors the CRM collections module:
- Decouples credit listing and mass WhatsApp sending from direct case management and label filtering on the backend.
- Moves the filtering logic for collection case labels to the frontend for improved flexibility.

Integrates authentication middleware across numerous backend routes to enhance security.

Adds the capability to filter pending espejo credits by a specific investor ID.

Implements a critical email safety feature that redirects all outbound emails to a designated development recipient in non-production environments, preventing accidental real-user notifications.

Includes minor improvements such as validation for Renap info endpoint parameters and cleanup of investment calculator deployment scripts.