### PR TITLE
feat(cobros): tokenized name search, SIFCO filter, filter layout + cartera token fix

### DIFF
--- a/apps/auth-google/src/services/cartera/investments.service.ts
+++ b/apps/auth-google/src/services/cartera/investments.service.ts
@@ -139,7 +139,7 @@ export const getLiquidaciones = async (
       `${env.CARTERA_API_URL}/liquidaciones?dpi=${dpi}&email=${email}&page=${page}&perPage=${perPage}`,
       {
         headers: {
-          // Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${token}`,
         },
       },
     );
@@ -171,7 +171,7 @@ export const getInvestmentsStats = async (
       `${env.CARTERA_API_URL}/inversionistas/rendimiento?dpi=${dpi}&email=${email}`,
       {
         headers: {
-          // Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${token}`,
         },
       },
     );
@@ -199,7 +199,7 @@ export const getAsesorById = async (asesorId: number): Promise<Asesor> => {
       `${env.CARTERA_API_URL}/advisor?id=${asesorId}`,
       {
         headers: {
-          // Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${token}`,
         },
       },
     );

--- a/apps/auth-google/src/services/cartera/investor.service.ts
+++ b/apps/auth-google/src/services/cartera/investor.service.ts
@@ -64,7 +64,7 @@ export interface InvestorDocument {
  * Crear o actualizar un inversionista
  */
 export const createInvestor = async (
-  payload: CreateInvestorPayload
+  payload: CreateInvestorPayload,
 ): Promise<CreateInvestorResponse> => {
   try {
     // Asegurar autenticación
@@ -76,7 +76,7 @@ export const createInvestor = async (
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        // Authorization: `Bearer ${token}`,
+        Authorization: `Bearer ${token}`,
       },
       body: JSON.stringify(payload),
     });
@@ -97,16 +97,22 @@ export const createInvestor = async (
 /**
  * Obtener perfil de inversionista por DPI
  */
-export const getInvestorProfile = async (dpi: string, email: string): Promise<InvestorProfile> => {
+export const getInvestorProfile = async (
+  dpi: string,
+  email: string,
+): Promise<InvestorProfile> => {
   try {
     // Asegurar autenticación
     const token = await ensureCarteraAuth();
 
-    const response = await fetch(`${env.CARTERA_API_URL}/investor?dpi=${dpi}&email=${email}`, {
-      headers: {
-        // Authorization: `Bearer ${token}`,
+    const response = await fetch(
+      `${env.CARTERA_API_URL}/investor?dpi=${dpi}&email=${email}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       },
-    });
+    );
 
     if (!response.ok) {
       throw new Error("Error al obtener perfil del inversionista");
@@ -123,7 +129,9 @@ export const getInvestorProfile = async (dpi: string, email: string): Promise<In
 /**
  * Obtener documentos de un inversionista por email
  */
-export const getInvestorDocuments = async (email: string): Promise<InvestorDocument[]> => {
+export const getInvestorDocuments = async (
+  email: string,
+): Promise<InvestorDocument[]> => {
   try {
     const token = await ensureCarteraAuth();
 
@@ -133,7 +141,7 @@ export const getInvestorDocuments = async (email: string): Promise<InvestorDocum
         headers: {
           Authorization: `Bearer ${token}`,
         },
-      }
+      },
     );
     console.log("Response status for getInvestorDocuments:", response);
 
@@ -141,7 +149,10 @@ export const getInvestorDocuments = async (email: string): Promise<InvestorDocum
       throw new Error("Error al obtener documentos del inversionista");
     }
 
-    const json = (await response.json()) as { success: boolean; data: InvestorDocument[] };
+    const json = (await response.json()) as {
+      success: boolean;
+      data: InvestorDocument[];
+    };
     return json.data;
   } catch (error) {
     console.error("Error al obtener documentos del inversionista:", error);

--- a/apps/auth-google/src/services/crm/credits.service.ts
+++ b/apps/auth-google/src/services/crm/credits.service.ts
@@ -109,7 +109,7 @@ export const getCredits = async (numerosSifco: string[]): Promise<CreditoRespons
         `${env.CARTERA_API_URL}/credito?numero_credito_sifco=${encodeURIComponent(numeroSifco)}`,
         {
           headers: {
-           //  Authorization: `Bearer ${token}`,
+            Authorization: `Bearer ${token}`,
           },
         }
       );
@@ -146,7 +146,7 @@ export const getCreditByNumeroSifco = async (
       `${env.CARTERA_API_URL}/credito?numero_credito_sifco=${encodeURIComponent(numeroSifco)}`,
       {
         headers: {
-          // Authorization: `Bearer ${token}`,
+          Authorization: `Bearer ${token}`,
         },
       }
     );

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -38,6 +38,7 @@ import {
 } from "drizzle-orm";
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
+import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
 
 export const getCreditoByNumero = async (numero_credito_sifco: string) => {
@@ -663,7 +664,8 @@ export async function getCreditosWithUserByMesAnio(
 
     if (nombre_usuario && nombre_usuario.trim().length > 0) {
       console.log(`🔎 Filtrando por nombre de usuario: ${nombre_usuario}`);
-      conditions.push(sql`${usuarios.nombre} ILIKE ${`%${nombre_usuario.trim()}%`}`);
+      const nameCond = buildNameSearchCondition(usuarios.nombre, nombre_usuario);
+      if (nameCond) conditions.push(nameCond);
     }
 
     if (email_asesor && email_asesor.trim().length > 0) {

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -4,6 +4,7 @@ import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getCreditosWithUserByMesAnio } from "./credits";
 import { getAllPagosWithCreditAndInversionistas, getPagosConInversionistas } from "./payments";
 import { fetchImageBase64 } from "../utils/functions/internReportCancelations";
+import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 import { db } from "../database";
 import { sql } from "drizzle-orm";
 
@@ -1462,7 +1463,8 @@ export async function getPagosByVencimiento({
     filters.push(sql`c.numero_credito_sifco ILIKE ${"%" + numero_credito_sifco + "%"}`);
   }
   if (nombre_usuario) {
-    filters.push(sql`u.nombre ILIKE ${"%" + nombre_usuario + "%"}`);
+    const nameCond = buildNameSearchCondition(sql`u.nombre`, nombre_usuario);
+    if (nameCond) filters.push(nameCond);
   }
   const whereClause = sql.join(filters, sql` AND `);
 

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -318,6 +318,8 @@ export const creditRouter = new Elysia()
         proximidad_pago,
         is_vehiculo_propio,
         inversionista_ids,
+        fecha_desde,
+        fecha_hasta,
       } = body;
 
       if (mes === undefined || anio === undefined || !estado) {
@@ -370,6 +372,8 @@ export const creditRouter = new Elysia()
           proximidad_pago,
           is_vehiculo_propio,
           inversionista_ids,
+          fecha_desde ?? undefined,
+          fecha_hasta ?? undefined,
           sifcosLimpios
         );
         set.status = 200;
@@ -412,6 +416,8 @@ export const creditRouter = new Elysia()
         ),
         is_vehiculo_propio: t.Optional(t.Boolean()),
         inversionista_ids: t.Optional(t.Array(t.Number())),
+        fecha_desde: t.Optional(t.String()),
+        fecha_hasta: t.Optional(t.String()),
       }),
     }
   )

--- a/apps/cartera-back/src/utils/functions/generalFunctions.ts
+++ b/apps/cartera-back/src/utils/functions/generalFunctions.ts
@@ -5,6 +5,7 @@ import ExcelJS from "exceljs";
 import axios from "axios";
 import Big from "big.js";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
+import { sql, type SQL } from "drizzle-orm";
 // Tipos auxiliares
 
 /**
@@ -21,6 +22,45 @@ export function removeAccents(str: string): string {
  * Nota: el searchTerm debe pasar por removeAccents() antes.
  */
 export const SQL_UNACCENT = `translate(lower(COLUMN), 'áéíóúàèìòùäëïöüâêîôûãõñÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÂÊÎÔÛÃÕÑ', 'aeiouaeiouaeiouaeiouaonAEIOUAEIOUAEIOUAEIOUAON')`;
+
+/**
+ * Construye un filtro SQL para búsqueda de nombres tolerante a:
+ * - Acentos/tildes (Óscar = Oscar)
+ * - Mayúsculas/minúsculas
+ * - Espacios extra entre palabras
+ * - Orden de palabras (cada token puede aparecer en cualquier posición)
+ *
+ * Ej: term "Oscar Alf" hace match con "Óscar Alfredo Méndez" porque divide
+ * la búsqueda en tokens ["oscar", "alf"] y exige que TODOS aparezcan en la
+ * columna (ya normalizada sin acentos y en minúsculas).
+ *
+ * @param column Columna o expresión SQL sobre la que buscar (ej: usuarios.nombre o sql`u.nombre`)
+ * @param term Texto de búsqueda del usuario
+ * @returns SQL con el filtro, o undefined si el término queda vacío
+ */
+export function buildNameSearchCondition(
+  column: unknown,
+  term: string | undefined | null
+): SQL | undefined {
+  if (!term) return undefined;
+  const normalized = removeAccents(term).toLowerCase().trim().replace(/\s+/g, " ");
+  if (!normalized) return undefined;
+  const tokens = normalized.split(" ").filter((t) => t.length > 0);
+  if (tokens.length === 0) return undefined;
+
+  const ACCENTS_FROM = "áéíóúàèìòùäëïöüâêîôûãõñÁÉÍÓÚÀÈÌÒÙÄËÏÖÜÂÊÎÔÛÃÕÑ";
+  const ACCENTS_TO = "aeiouaeiouaeiouaeiouaonAEIOUAEIOUAEIOUAEIOUAON";
+
+  // Aplicamos translate ANTES de lower: así, aunque el locale del Postgres no
+  // foldee mayúsculas acentuadas (ej. 'Ó' → 'ó'), translate ya las convirtió
+  // a ASCII y lower() funciona sobre puro ASCII.
+  const tokenConds = tokens.map(
+    (t) =>
+      sql`lower(translate(${column as any}, ${ACCENTS_FROM}, ${ACCENTS_TO})) LIKE ${"%" + t + "%"}`
+  );
+
+  return sql.join(tokenConds, sql` AND `);
+}
 
 
 export async function generarPDFBuffer(

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -596,6 +596,7 @@ export const cobrosRouter = {
 				offset: z.number().optional(),
 				estadoMora: z.string().optional(),
 				searchTerm: z.string().optional(),
+				numeroSifco: z.string().optional(),
 				time: z.enum(["WEEK", "MONTH", "DUEMONTH", "TODAY"]).optional(),
 				emailCobrador: z.string().optional(),
 				fechaDesde: z.string().optional(),
@@ -615,9 +616,14 @@ export const cobrosRouter = {
 					let cuotasAtrasadas: number | undefined;
 					let estadoCartera: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | undefined;
 					const searchTerm = input.searchTerm?.trim() || "";
+					const numeroSifcoExacto = input.numeroSifco?.trim() || "";
 					const hasNumber = /\d/.test(searchTerm);
-					const isPlateSearch = searchTerm.length > 0 && hasNumber;
-					const isNameSearch = searchTerm.length > 0 && !hasNumber;
+					// Si hay numeroSifco explícito, ignoramos cualquier búsqueda por
+					// cliente/placa: es un equals contra cartera-back y sólo retorna 0 ó 1.
+					const isPlateSearch =
+						!numeroSifcoExacto && searchTerm.length > 0 && hasNumber;
+					const isNameSearch =
+						!numeroSifcoExacto && searchTerm.length > 0 && !hasNumber;
 
 					if (input.estadoMora) {
 						switch (input.estadoMora) {
@@ -837,6 +843,36 @@ export const cobrosRouter = {
 									totalPages: 1,
 								};
 							}
+						}
+					} else if (numeroSifcoExacto) {
+						// Búsqueda exacta por número SIFCO. Si además hay etiquetas,
+						// validamos en el CRM que el SIFCO esté en la lista filtrada,
+						// porque cartera-back le da prioridad al multi sobre el single.
+						if (
+							sifcosPorEtiquetas &&
+							!sifcosPorEtiquetas.includes(numeroSifcoExacto)
+						) {
+							creditosResponse = {
+								data: [],
+								page: 1,
+								perPage: 0,
+								totalCount: 0,
+								totalPages: 0,
+							};
+						} else {
+							creditosResponse = await obtenerTodosLosCreditosCarteraBack({
+								mes,
+								anio,
+								page: 1,
+								perPage: input.limit || 50,
+								cuotasAtrasadas,
+								estado: estadoCartera,
+								time: input.time,
+								email_cobrador: input.emailCobrador,
+								numero_credito_sifco: numeroSifcoExacto,
+								fecha_desde: input.fechaDesde,
+								fecha_hasta: input.fechaHasta,
+							});
 						}
 					} else {
 						// Búsqueda por nombre (cartera-back filtra) o sin búsqueda
@@ -3041,6 +3077,7 @@ export const cobrosRouter = {
 				// su cartera).
 				estadoMora: z.string().optional(),
 				searchTerm: z.string().optional(),
+				numeroSifco: z.string().optional(),
 				time: z.enum(["WEEK", "MONTH", "DUEMONTH", "TODAY"]).optional(),
 				etiquetas: z.array(z.string()).optional(),
 			}),
@@ -3112,11 +3149,15 @@ export const cobrosRouter = {
 			// tiene dígitos se asume placa y se convierte a número SIFCO
 			// consultando el CRM; si es alfabético se usa nombre_usuario.
 			const searchTerm = input.searchTerm?.trim() || "";
+			const numeroSifcoExacto = input.numeroSifco?.trim() || "";
 			const hasNumber = /\d/.test(searchTerm);
-			const isPlateSearch = searchTerm.length > 0 && hasNumber;
-			const isNameSearch = searchTerm.length > 0 && !hasNumber;
+			// numeroSifco explícito tiene prioridad: ignora plate/name search.
+			const isPlateSearch =
+				!numeroSifcoExacto && searchTerm.length > 0 && hasNumber;
+			const isNameSearch =
+				!numeroSifcoExacto && searchTerm.length > 0 && !hasNumber;
 
-			let numeroSifcoFiltro: string | undefined;
+			let numeroSifcoFiltro: string | undefined = numeroSifcoExacto || undefined;
 			let searchPorPlacaSinMatch = false;
 			const matchingSifcos = new Set<string>();
 			if (isPlateSearch) {

--- a/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
@@ -29,6 +29,7 @@ interface MassWhatsappModalProps {
 	filtros: {
 		estadoMora?: string;
 		searchTerm?: string;
+		numeroSifco?: string;
 		time?: "WEEK" | "MONTH" | "DUEMONTH" | "TODAY";
 		etiquetas?: string[];
 	};
@@ -73,6 +74,7 @@ export function MassWhatsappModal({
 				plantillaId,
 				estadoMora: filtros.estadoMora,
 				searchTerm: filtros.searchTerm,
+				numeroSifco: filtros.numeroSifco,
 				time: filtros.time,
 				etiquetas:
 					filtros.etiquetas && filtros.etiquetas.length > 0
@@ -163,6 +165,7 @@ export function MassWhatsappModal({
 												: "Todos"}
 										</li>
 										<li>Búsqueda: {filtros.searchTerm ?? "—"}</li>
+										<li>No. SIFCO: {filtros.numeroSifco ?? "—"}</li>
 										<li>
 											Etiquetas:{" "}
 											{filtros.etiquetas && filtros.etiquetas.length > 0

--- a/apps/crm/apps/web/src/components/data-table.tsx
+++ b/apps/crm/apps/web/src/components/data-table.tsx
@@ -31,6 +31,7 @@ interface DataTableProps<TData, TValue> {
 	searchPlaceholder?: string;
 	searchColumn?: string;
 	filterContent?: React.ReactNode;
+	extraSearch?: React.ReactNode;
 	isLoading?: boolean;
 	// Paginación del servidor
 	serverPagination?: {
@@ -54,6 +55,7 @@ export function DataTable<TData, TValue>({
 	isLoading,
 	searchColumn,
 	filterContent,
+	extraSearch,
 	serverPagination,
 	setGlobalFilterParam,
 	onRowClick,
@@ -104,20 +106,25 @@ export function DataTable<TData, TValue>({
 
 	return (
 		<div className="space-y-4">
-			{(!hideSearch || filterContent) && (
+			{(!hideSearch || filterContent || extraSearch) && (
 				<div className="flex flex-col gap-4">
-					{!hideSearch && (
-						<Input
-							placeholder={searchPlaceholder}
-							value={globalFilter ?? ""}
-							onChange={(event) => {
-								if (setGlobalFilterParam) {
-									setGlobalFilterParam(event.target.value);
-								}
-								setGlobalFilter(event.target.value);
-							}}
-							className="max-w-sm"
-						/>
+					{(!hideSearch || extraSearch) && (
+						<div className="flex flex-wrap items-center gap-2">
+							{!hideSearch && (
+								<Input
+									placeholder={searchPlaceholder}
+									value={globalFilter ?? ""}
+									onChange={(event) => {
+										if (setGlobalFilterParam) {
+											setGlobalFilterParam(event.target.value);
+										}
+										setGlobalFilter(event.target.value);
+									}}
+									className="max-w-sm"
+								/>
+							)}
+							{extraSearch}
+						</div>
 					)}
 					{filterContent && (
 						<div className="flex flex-wrap gap-2">{filterContent}</div>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -22,6 +22,7 @@ import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { DataTable } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
 	Card,
 	CardContent,
@@ -295,6 +296,8 @@ function RouteComponent() {
 	const [page, setPage] = useState(1);
 	const [filterValue, setFilterValue] = useState("");
 	const [debouncedFilterValue, setDebouncedFilterValue] = useState("");
+	const [sifcoFilterValue, setSifcoFilterValue] = useState("");
+	const [debouncedSifcoFilterValue, setDebouncedSifcoFilterValue] = useState("");
 	const [pageSize, setPageSize] = useState(25);
 	const [fechaDesde, setFechaDesde] = useState<string | undefined>(undefined);
 	const [fechaHasta, setFechaHasta] = useState<string | undefined>(undefined);
@@ -310,6 +313,16 @@ function RouteComponent() {
 
 		return () => clearTimeout(timer);
 	}, [filterValue]);
+
+	// Debounce para el filtro por número SIFCO (1 segundo)
+	useEffect(() => {
+		const timer = setTimeout(() => {
+			setDebouncedSifcoFilterValue(sifcoFilterValue);
+			setPage(1);
+		}, 1000);
+
+		return () => clearTimeout(timer);
+	}, [sifcoFilterValue]);
 
 	const userRole = session?.user.role;
 
@@ -407,6 +420,7 @@ function RouteComponent() {
 				offset: (page - 1) * pageSize,
 				estadoMora: filtroEtapa || undefined,
 				searchTerm: debouncedFilterValue || undefined,
+				numeroSifco: debouncedSifcoFilterValue || undefined,
 				time: fechaDesde || fechaHasta ? undefined : timeParam,
 				emailCobrador: !PERMISSIONS.canAssignCobros(userRole ?? "")
 					? session?.user?.email
@@ -983,6 +997,7 @@ function RouteComponent() {
 								filtros={{
 									estadoMora: filtroEtapa || undefined,
 									searchTerm: debouncedFilterValue || undefined,
+									numeroSifco: debouncedSifcoFilterValue || undefined,
 									time: timeParam,
 									etiquetas:
 										filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
@@ -1006,28 +1021,6 @@ function RouteComponent() {
 					</div>
 				</CardHeader>
 				<CardContent className="space-y-4">
-					{/* Filtros Temporales */}
-					<div className="flex flex-wrap items-center gap-4">
-						<div className="flex flex-wrap gap-2">
-							{filtros.map((filtro) => {
-								const Icon = filtro.icon;
-								const isActive = filtroTemporal === filtro.key;
-
-								return (
-									<Button
-										key={filtro.key}
-										variant={isActive ? "default" : "outline"}
-										size="sm"
-										onClick={() => setFiltroTemporal(filtro.key)}
-									>
-										<Icon className="mr-2 h-4 w-4" />
-										{filtro.label}
-									</Button>
-								);
-							})}
-						</div>
-					</div>
-
 					{/* Data Table */}
 					<DataTable
 						columns={columns}
@@ -1035,6 +1028,14 @@ function RouteComponent() {
 						isLoading={todosLosCreditos.isLoading}
 						setGlobalFilterParam={setFilterValue}
 						searchPlaceholder="Buscar por cliente o placa"
+						extraSearch={
+							<Input
+								placeholder="Buscar por No. SIFCO (exacto)"
+								value={sifcoFilterValue}
+								onChange={(e) => setSifcoFilterValue(e.target.value)}
+								className="max-w-xs"
+							/>
+						}
 						onRowClick={(row) => {
 							const linkId = row.numeroCredito || row.contratoId;
 							const tipoLink = row.casoCobroId ? "caso" : "contrato";
@@ -1046,104 +1047,135 @@ function RouteComponent() {
 						}}
 						filterContent={
 							<div className="flex w-full flex-col gap-3">
-								<div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
-									<span className="font-semibold text-foreground text-sm">
-										Filtrar por fecha de pago:
+								{/* Período: presets rápidos + rango personalizado */}
+								<div className="flex flex-col gap-2">
+									<span className="font-semibold text-muted-foreground text-xs uppercase tracking-wide">
+										Período de pago
 									</span>
-									<DateRangeFilter
-										dateRange={dateRange}
-										onDateRangeChange={(range) => {
-											if (!range) {
-												setDateRange(undefined);
-												setFechaDesde(undefined);
-												setFechaHasta(undefined);
+									<div className="flex flex-wrap items-center gap-2">
+										{filtros.map((filtro) => {
+											const Icon = filtro.icon;
+											const isActive = filtroTemporal === filtro.key;
+											return (
+												<Button
+													key={filtro.key}
+													variant={isActive ? "default" : "outline"}
+													size="sm"
+													onClick={() => setFiltroTemporal(filtro.key)}
+												>
+													<Icon className="mr-2 h-4 w-4" />
+													{filtro.label}
+												</Button>
+											);
+										})}
+										<Separator orientation="vertical" className="mx-1 h-6" />
+										<DateRangeFilter
+											dateRange={dateRange}
+											onDateRangeChange={(range) => {
+												if (!range) {
+													setDateRange(undefined);
+													setFechaDesde(undefined);
+													setFechaHasta(undefined);
+													setFechaError(null);
+													setPage(1);
+													return;
+												}
+												const hoy = new Date();
+												hoy.setHours(0, 0, 0, 0);
+												if (range.from && range.from < hoy) {
+													setFechaError(
+														"La fecha no puede ser menor al día de hoy",
+													);
+													setDateRange(range);
+													return;
+												}
 												setFechaError(null);
-												setPage(1);
-												return;
-											}
-											const hoy = new Date();
-											hoy.setHours(0, 0, 0, 0);
-											if (range.from && range.from < hoy) {
-												setFechaError("La fecha no puede ser menor al día de hoy");
 												setDateRange(range);
-												return;
-											}
-											setFechaError(null);
-											setDateRange(range);
-											if (!range.from || !range.to) return;
-											setFechaDesde(range.from.toISOString().slice(0, 10));
-											setFechaHasta(range.to.toISOString().slice(0, 10));
-											setFiltroTemporal("todos");
-											setPage(1);
-										}}
-									/>
-									{fechaError && (
-										<span className="text-destructive text-xs">{fechaError}</span>
-									)}
+												if (!range.from || !range.to) return;
+												setFechaDesde(range.from.toISOString().slice(0, 10));
+												setFechaHasta(range.to.toISOString().slice(0, 10));
+												setFiltroTemporal("todos");
+												setPage(1);
+											}}
+										/>
+										{fechaError && (
+											<span className="text-destructive text-xs">
+												{fechaError}
+											</span>
+										)}
+									</div>
 								</div>
-								<div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
-									<span className="font-semibold text-foreground text-sm">
-										Filtrar por etapa:
+
+								{/* Etapa de mora */}
+								<div className="flex flex-col gap-2">
+									<span className="font-semibold text-muted-foreground text-xs uppercase tracking-wide">
+										Etapa de mora
 									</span>
-									<Button
-										variant={filtroEtapa === null ? "default" : "outline"}
-										size="sm"
-										onClick={() => {
-											setFiltroEtapa(null);
-											setPage(1);
-										}}
-									>
-										Todas
-									</Button>
-									{filtrosEtapa.map((filtro) => (
-										<Badge
-											key={filtro.key}
-											className={`cursor-pointer ${filtroEtapa === filtro.key ? filtro.color : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+									<div className="flex flex-wrap items-center gap-2">
+										<Button
+											variant={filtroEtapa === null ? "default" : "outline"}
+											size="sm"
 											onClick={() => {
-												setFiltroEtapa(
-													filtroEtapa === filtro.key ? null : filtro.key,
-												);
+												setFiltroEtapa(null);
 												setPage(1);
 											}}
 										>
-											{filtro.label}
-										</Badge>
-									))}
-								</div>
-								<div className="flex flex-wrap items-center gap-2 rounded-md border border-border/50 bg-muted/30 px-3 py-2">
-									<span className="font-semibold text-foreground text-sm">
-										Etiquetas:
-									</span>
-									<Button
-										variant={
-											filtroEtiquetas.length === 0 ? "default" : "outline"
-										}
-										size="sm"
-										onClick={() => {
-											setFiltroEtiquetas([]);
-											setPage(1);
-										}}
-									>
-										Todas
-									</Button>
-									{Object.entries(ETIQUETA_LABELS_FILTRO).map(
-										([key, label]) => (
+											Todas
+										</Button>
+										{filtrosEtapa.map((filtro) => (
 											<Badge
-												key={key}
-												className={`cursor-pointer ${filtroEtiquetas.includes(key) ? "bg-primary text-primary-foreground" : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+												key={filtro.key}
+												className={`cursor-pointer ${filtroEtapa === filtro.key ? filtro.color : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
 												onClick={() => {
-													setFiltroEtiquetas((prev) =>
-														prev.includes(key)
-															? prev.filter((e) => e !== key)
-															: [...prev, key],
+													setFiltroEtapa(
+														filtroEtapa === filtro.key ? null : filtro.key,
 													);
 													setPage(1);
 												}}
 											>
-												{label}
+												{filtro.label}
 											</Badge>
-										),
-									)}
+										))}
+									</div>
+								</div>
+
+								{/* Etiquetas */}
+								<div className="flex flex-col gap-2">
+									<span className="font-semibold text-muted-foreground text-xs uppercase tracking-wide">
+										Etiquetas
+									</span>
+									<div className="flex flex-wrap items-center gap-2">
+										<Button
+											variant={
+												filtroEtiquetas.length === 0 ? "default" : "outline"
+											}
+											size="sm"
+											onClick={() => {
+												setFiltroEtiquetas([]);
+												setPage(1);
+											}}
+										>
+											Todas
+										</Button>
+										{Object.entries(ETIQUETA_LABELS_FILTRO).map(
+											([key, label]) => (
+												<Badge
+													key={key}
+													className={`cursor-pointer ${filtroEtiquetas.includes(key) ? "bg-primary text-primary-foreground" : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+													onClick={() => {
+														setFiltroEtiquetas((prev) =>
+															prev.includes(key)
+																? prev.filter((e) => e !== key)
+																: [...prev, key],
+														);
+														setPage(1);
+													}}
+												>
+													{label}
+												</Badge>
+											),
+										)}
+									</div>
 								</div>
 							</div>
 						}


### PR DESCRIPTION
## Summary
- **cartera-back**: la búsqueda por nombre en \`/getAllCredits\` (normal y excel) y en el reporte que filtraba por \`u.nombre\` ahora tokeniza el término y matchea cada palabra de forma case-insensitive y sin acentos contra \`usuarios.nombre\`. \"Oscar Alf\" cae en \"Óscar Alfredo Méndez\" sin importar orden ni tildes. Se cambió a \`lower(translate(...))\` para ser robusto ante locales de Postgres que no foldean mayúsculas acentuadas.
- **cartera-back**: fix en POST \`/getAllCredits\` que pasaba la lista de SIFCOs en el slot de \`fecha_desde\` (faltaban dos \`undefined\` antes de \`numeros_credito_sifco\`).
- **CRM Cobros**: nuevo input \"Buscar por No. SIFCO (exacto)\" al lado del search de cliente/placa. Hace \`equals\` directo contra cartera-back (bypassea la heurística de placa/nombre). También se reenvía al modal de envío masivo de WhatsApp.
- **CRM Cobros**: reorganización de filtros — el date range \"Filtrar por fecha de pago\" estaba en su propia caja con borde antes de los presets temporales, dando la impresión de filtro principal. Ahora los filtros quedan en 3 grupos con label sutil: **Período de pago** (presets + date range inline, separados por divisor), **Etapa de mora** y **Etiquetas**.
- **DataTable**: nuevo prop \`extraSearch\` para slotear inputs adicionales junto al search principal.
- **auth-google (portal-web)**: en \`credits.service.ts\` los handlers \`getCredits\` y \`getCreditByNumeroSifco\` ya pedían el token con \`ensureCarteraAuth()\` pero el header \`Authorization: Bearer\` estaba comentado. Ahora que cartera-back exige el bearer en el middleware, las consultas del portal estaban respondiendo 401. Se descomentó el header en ambos lugares.

<img width="1544" height="489" alt="image" src="https://github.com/user-attachments/assets/3d89326b-035b-412f-9ac7-f1a0a143fbb5" />


## Test plan
- [ ] cartera-back: buscar usuario con tildes (ej. \"Oscar\" sobre \"Óscar Alfredo Méndez\") y verificar que aparece.
- [ ] Buscar con palabras parciales y orden distinto (ej. \"Alf Oscar\") y verificar match.
- [ ] CRM /cobros: ingresar SIFCO conocido, verificar que retorna exactamente ese crédito y que el modal masivo lo cuenta como 1.
- [ ] CRM /cobros: limpiar el filtro de SIFCO, confirmar que la búsqueda por cliente/placa sigue funcionando.
- [ ] Verificar que el date range sigue activando el filtro \"todos\" en presets y filtrando por fecha de cuota.
- [ ] Probar el envío masivo con cada combinación de filtros (etapa, etiquetas, SIFCO, búsqueda) para confirmar destinatarios correctos.
- [ ] portal-web: loguearse y abrir perfil de un usuario con créditos; confirmar que las cuotas y datos del crédito cargan (antes salían vacíos / 401 en cartera-back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)