### PR TITLE
Convierte `cuentas_empresa` en un libro contable rea

### DIFF
--- a/apps/cartera-back/src/controllers/accounts.ts
+++ b/apps/cartera-back/src/controllers/accounts.ts
@@ -1,14 +1,34 @@
 // services/cuentas.service.ts
-import { eq } from "drizzle-orm";
-import { cuentasEmpresa } from "../database/db";
+import { and, eq, ilike } from "drizzle-orm";
+import { cuentasEmpresa, cuentas_empresa_movimientos } from "../database/db";
 import { db } from "../database";
 
-export async function getCuentasEmpresa() {
+type MonedaCuenta = "quetzales" | "dolares";
+type TipoMovimiento = "ingreso" | "egreso";
+
+// Lista cuentas con filtros opcionales: nombre (ilike, parcial),
+// cuentaId (exacto), soloActivas (default false: trae activas e inactivas).
+export async function getCuentasEmpresa(filters?: {
+  nombreCuenta?: string;
+  cuentaId?: number;
+  soloActivas?: boolean;
+}) {
   try {
+    const conditions = [];
+    if (filters?.cuentaId !== undefined) {
+      conditions.push(eq(cuentasEmpresa.cuentaId, filters.cuentaId));
+    }
+    if (filters?.nombreCuenta) {
+      conditions.push(ilike(cuentasEmpresa.nombreCuenta, `%${filters.nombreCuenta}%`));
+    }
+    if (filters?.soloActivas) {
+      conditions.push(eq(cuentasEmpresa.activo, true));
+    }
+
     const cuentas = await db
       .select()
       .from(cuentasEmpresa)
-      .where(eq(cuentasEmpresa.activo, true))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
       .orderBy(cuentasEmpresa.nombreCuenta);
 
     return {
@@ -66,6 +86,7 @@ export async function createCuentaEmpresa(data: {
   banco: string;
   numeroCuenta: string;
   descripcion?: string;
+  moneda?: MonedaCuenta;
 }) {
   try {
     const [nuevaCuenta] = await db
@@ -75,6 +96,7 @@ export async function createCuentaEmpresa(data: {
         banco: data.banco,
         numeroCuenta: data.numeroCuenta,
         descripcion: data.descripcion,
+        ...(data.moneda ? { moneda: data.moneda } : {}),
       })
       .returning();
 
@@ -102,15 +124,13 @@ export async function updateCuentaEmpresa(
     numeroCuenta: string;
     descripcion: string;
     activo: boolean;
+    moneda: MonedaCuenta;
   }>
 ) {
   try {
     const [cuentaActualizada] = await db
       .update(cuentasEmpresa)
-      .set({
-        ...data,
-        fechaActualizacion: new Date(),
-      })
+      .set(data)
       .where(eq(cuentasEmpresa.cuentaId, cuentaId))
       .returning();
 
@@ -143,10 +163,7 @@ export async function deleteCuentaEmpresa(cuentaId: number) {
     // Soft delete - solo desactivar
     const [cuentaDesactivada] = await db
       .update(cuentasEmpresa)
-      .set({
-        activo: false,
-        fechaActualizacion: new Date(),
-      })
+      .set({ activo: false })
       .where(eq(cuentasEmpresa.cuentaId, cuentaId))
       .returning();
 
@@ -168,6 +185,49 @@ export async function deleteCuentaEmpresa(cuentaId: number) {
       success: false,
       message: "❌ Error al desactivar la cuenta",
       error: error.message,
+    };
+  }
+}
+
+// Inserta un movimiento (ingreso/egreso) en el ledger.
+// Toda la lógica de saldo está en la DB:
+//   - El trigger trg_cuentas_empresa_mov_aplicar (BEFORE INSERT) suma o resta
+//     `monto` al saldo_actual de la cuenta y rellena `saldo_post`.
+//   - Si el cuenta_id no existe, el trigger tira RAISE EXCEPTION → cae al catch.
+// Pasamos saldo_post: "0" como placeholder porque la columna es NOT NULL;
+// el trigger lo sobrescribe antes de insertar.
+export async function crearMovimientoCuentaEmpresa(data: {
+  cuentaId: number;
+  tipo: TipoMovimiento;
+  monto: string;
+  motivo?: string;
+  createdBy?: number;
+}) {
+  try {
+    const [movimiento] = await db
+      .insert(cuentas_empresa_movimientos)
+      .values({
+        cuenta_id: data.cuentaId,
+        tipo: data.tipo,
+        monto: data.monto,
+        saldo_post: "0",
+        motivo: data.motivo,
+        created_by: data.createdBy,
+      })
+      .returning();
+
+    return {
+      success: true,
+      message: "✅ Movimiento registrado correctamente",
+      data: movimiento,
+    };
+  } catch (error: any) {
+    console.error("❌ Error al crear movimiento de cuenta:", error);
+    return {
+      success: false,
+      message: "❌ Error al registrar el movimiento",
+      error: error.message,
+      data: null,
     };
   }
 }

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -653,9 +653,111 @@
     numeroCuenta: varchar("numero_cuenta", { length: 50 }).notNull().unique(),
     descripcion: varchar("descripcion", { length: 255 }),
     activo: boolean("activo").default(true).notNull(),
-    fechaCreacion: timestamp("fecha_creacion").defaultNow().notNull(),
-    fechaActualizacion: timestamp("fecha_actualizacion").defaultNow().notNull(),
+    moneda: tipoMonedaEnum("moneda").notNull().default("quetzales"),
+    // saldo_actual NO se modifica desde la app: lo mueve solo el trigger
+    // BEFORE INSERT en cuentas_empresa_movimientos (ver más abajo).
+    saldo_actual: numeric("saldo_actual", { precision: 18, scale: 2 })
+      .notNull()
+      .default("0"),
+    fechaCreacion: timestamp("fecha_creacion")
+      .notNull()
+      .default(sql`NOW() AT TIME ZONE 'America/Guatemala'`),
+    fechaActualizacion: timestamp("fecha_actualizacion")
+      .notNull()
+      .default(sql`NOW() AT TIME ZONE 'America/Guatemala'`),
   });
+
+  export const tipoMovimientoCuentaEmpresaEnum = customSchema.enum(
+    "tipo_movimiento_cuenta_empresa",
+    ["ingreso", "egreso" ]
+  );
+
+  // Ledger de movimientos por cuenta. Cada fila es un evento de plata
+  // (entrada o salida). El saldo_actual de cuentas_empresa se deriva de
+  // la suma de estos movimientos — la columna saldo_actual es solo un
+  // cache mantenido por el trigger DB para lectura rápida.
+  //
+  // saldo_post guarda el saldo de la cuenta justo después de aplicar
+  // este movimiento (snapshot histórico, sirve para auditoría).
+  export const cuentas_empresa_movimientos = customSchema.table(
+    "cuentas_empresa_movimientos",
+    {
+      movimiento_id: serial("movimiento_id").primaryKey(),
+      // ON DELETE RESTRICT: no se puede borrar una cuenta con movimientos.
+      cuenta_id: integer("cuenta_id")
+        .notNull()
+        .references(() => cuentasEmpresa.cuentaId, { onDelete: "restrict" }),
+      tipo: tipoMovimientoCuentaEmpresaEnum("tipo").notNull(),
+      // monto siempre positivo; el signo lo determina `tipo` (CHECK monto > 0 en DB).
+      monto: numeric("monto", { precision: 18, scale: 2 }).notNull(),
+      // El trigger BEFORE INSERT sobrescribe este valor con el saldo real
+      // de la cuenta tras aplicar el movimiento.
+      saldo_post: numeric("saldo_post", { precision: 18, scale: 2 }).notNull(),
+      motivo: text("motivo"),
+      created_by: integer("created_by").references(() => platform_users.id),
+      created_at: timestamp("created_at", { withTimezone: true })
+        .notNull()
+        .default(sql`NOW() AT TIME ZONE 'America/Guatemala'`),
+    },
+    (t) => ({
+      cuentaIdx: index("idx_cuentas_empresa_mov_cuenta").on(t.cuenta_id),
+      fechaIdx: index("idx_cuentas_empresa_mov_fecha").on(t.created_at),
+    })
+  );
+
+  // ===== Funciones + triggers de cuentas_empresa (hora Guatemala) =====
+  // Aplica un movimiento al saldo_actual de la cuenta y guarda saldo_post.
+  export const aplicarMovimientoCuentaEmpresaFn = sql`
+    CREATE OR REPLACE FUNCTION cartera.aplicar_movimiento_cuenta_empresa()
+    RETURNS TRIGGER AS $$
+    DECLARE
+      v_delta numeric(18,2);
+      v_nuevo_saldo numeric(18,2);
+    BEGIN
+      v_delta := CASE NEW.tipo WHEN 'ingreso' THEN NEW.monto ELSE -NEW.monto END;
+
+      UPDATE cartera.cuentas_empresa
+         SET saldo_actual = saldo_actual + v_delta
+       WHERE cuenta_id = NEW.cuenta_id
+       RETURNING saldo_actual INTO v_nuevo_saldo;
+
+      IF v_nuevo_saldo IS NULL THEN
+        RAISE EXCEPTION 'cuenta_id % no existe', NEW.cuenta_id;
+      END IF;
+
+      NEW.saldo_post := v_nuevo_saldo;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `;
+
+  export const aplicarMovimientoCuentaEmpresaTrigger = sql`
+    DROP TRIGGER IF EXISTS trg_cuentas_empresa_mov_aplicar ON cartera.cuentas_empresa_movimientos;
+    CREATE TRIGGER trg_cuentas_empresa_mov_aplicar
+    BEFORE INSERT ON cartera.cuentas_empresa_movimientos
+    FOR EACH ROW
+    EXECUTE FUNCTION cartera.aplicar_movimiento_cuenta_empresa();
+  `;
+
+  // Auto-actualiza fecha_actualizacion en cualquier UPDATE.
+  export const setFechaActualizacionFn = sql`
+    CREATE OR REPLACE FUNCTION cartera.set_fecha_actualizacion()
+    RETURNS TRIGGER AS $$
+    BEGIN
+      NEW.fecha_actualizacion = NOW() AT TIME ZONE 'America/Guatemala';
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+  `;
+
+  export const cuentasEmpresaSetFechaTrigger = sql`
+    DROP TRIGGER IF EXISTS trg_cuentas_empresa_set_fecha_actualizacion ON cartera.cuentas_empresa;
+    CREATE TRIGGER trg_cuentas_empresa_set_fecha_actualizacion
+    BEFORE UPDATE ON cartera.cuentas_empresa
+    FOR EACH ROW
+    EXECUTE FUNCTION cartera.set_fecha_actualizacion();
+  `;
+
 
 
   export const convenios_pago = customSchema.table("convenios_pago", {

--- a/apps/cartera-back/src/routers/accounts.ts
+++ b/apps/cartera-back/src/routers/accounts.ts
@@ -1,6 +1,6 @@
 // routes/cuentas.routes.ts
 import { Elysia, t } from "elysia";
-import { createCuentaEmpresa, deleteCuentaEmpresa, getCuentaById, getCuentasEmpresa, updateCuentaEmpresa } from "../controllers/accounts";
+import { createCuentaEmpresa, crearMovimientoCuentaEmpresa, deleteCuentaEmpresa, getCuentaById, getCuentasEmpresa, updateCuentaEmpresa } from "../controllers/accounts";
 import { authMiddleware } from "./midleware";
 
 
@@ -8,31 +8,51 @@ export const cuentasRoutes = new Elysia({ prefix: "/api/cuentas" })
   // 🔒 Aplicar middleware de autenticación a todas las rutas
   .use(authMiddleware)
 
-  // 📋 GET - Obtener todas las cuentas activas
-  .get("/", async () => {
-    try {
-      const result = await getCuentasEmpresa();
+  // 📋 GET - Obtener cuentas (con filtros opcionales por nombre y/o cuentaId)
+  // Query: ?nombre=cube&cuentaId=9&soloActivas=true
+  .get(
+    "/",
+    async ({ query }) => {
+      try {
+        const cuentaIdNum = query.cuentaId ? parseInt(query.cuentaId) : undefined;
+        if (query.cuentaId && isNaN(cuentaIdNum!)) {
+          return {
+            status: 400,
+            body: { success: false, message: "❌ cuentaId inválido" },
+          };
+        }
 
-      if (!result.success) {
+        const result = await getCuentasEmpresa({
+          nombreCuenta: query.nombre,
+          cuentaId: cuentaIdNum,
+          soloActivas: query.soloActivas === "true",
+        });
+
+        if (!result.success) {
+          return { status: 500, body: result };
+        }
+
+        return result;
+      } catch (error: any) {
+        console.error("❌ Error en GET /cuentas:", error);
         return {
           status: 500,
-          body: result,
+          body: {
+            success: false,
+            message: "❌ Error interno del servidor",
+            error: error.message,
+          },
         };
       }
-
-      return result;
-    } catch (error: any) {
-      console.error("❌ Error en GET /cuentas:", error);
-      return {
-        status: 500,
-        body: {
-          success: false,
-          message: "❌ Error interno del servidor",
-          error: error.message,
-        },
-      };
+    },
+    {
+      query: t.Object({
+        nombre: t.Optional(t.String()),
+        cuentaId: t.Optional(t.String()),
+        soloActivas: t.Optional(t.String()),
+      }),
     }
-  })
+  )
 
   // 🔍 GET - Obtener cuenta por ID
   .get(
@@ -85,7 +105,7 @@ export const cuentasRoutes = new Elysia({ prefix: "/api/cuentas" })
     "/",
     async ({ body }) => {
       try {
-        const { nombreCuenta, banco, numeroCuenta, descripcion } = body;
+        const { nombreCuenta, banco, numeroCuenta, descripcion, moneda } = body;
 
         // Validaciones
         if (!nombreCuenta || !banco || !numeroCuenta) {
@@ -103,6 +123,7 @@ export const cuentasRoutes = new Elysia({ prefix: "/api/cuentas" })
           banco,
           numeroCuenta,
           descripcion,
+          moneda,
         });
 
         if (!result.success) {
@@ -134,6 +155,9 @@ export const cuentasRoutes = new Elysia({ prefix: "/api/cuentas" })
         banco: t.String(),
         numeroCuenta: t.String(),
         descripcion: t.Optional(t.String()),
+        moneda: t.Optional(
+          t.Union([t.Literal("quetzales"), t.Literal("dolares")])
+        ),
       }),
     }
   )
@@ -187,6 +211,9 @@ export const cuentasRoutes = new Elysia({ prefix: "/api/cuentas" })
         numeroCuenta: t.Optional(t.String()),
         descripcion: t.Optional(t.String()),
         activo: t.Optional(t.Boolean()),
+        moneda: t.Optional(
+          t.Union([t.Literal("quetzales"), t.Literal("dolares")])
+        ),
       }),
     }
   )
@@ -233,6 +260,62 @@ export const cuentasRoutes = new Elysia({ prefix: "/api/cuentas" })
     {
       params: t.Object({
         id: t.String(),
+      }),
+    }
+  )
+
+  // 💸 POST - Registrar movimiento (ingreso/egreso) en una cuenta.
+  // El trigger DB aplica el delta al saldo_actual y guarda saldo_post.
+  .post(
+    "/:id/movimientos",
+    async ({ params: { id }, body, user }: any) => {
+      try {
+        const cuentaId = parseInt(id);
+        if (isNaN(cuentaId)) {
+          return {
+            status: 400,
+            body: { success: false, message: "❌ ID de cuenta inválido" },
+          };
+        }
+
+        if (body.monto <= 0) {
+          return {
+            status: 400,
+            body: { success: false, message: "❌ El monto debe ser mayor a 0" },
+          };
+        }
+
+        const result = await crearMovimientoCuentaEmpresa({
+          cuentaId,
+          tipo: body.tipo,
+          monto: String(body.monto),
+          motivo: body.motivo,
+          createdBy: user?.id,
+        });
+
+        if (!result.success) {
+          return { status: 400, body: result };
+        }
+
+        return { status: 201, body: result };
+      } catch (error: any) {
+        console.error("❌ Error en POST /cuentas/:id/movimientos:", error);
+        return {
+          status: 500,
+          body: {
+            success: false,
+            message: "❌ Error interno del servidor",
+            error: error.message,
+          },
+        };
+      }
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      body: t.Object({
+        tipo: t.Union([t.Literal("ingreso"), t.Literal("egreso")]),
+        monto: t.Number({ minimum: 0.01 }),
+        motivo: t.Optional(t.String()),
       }),
     }
   );


### PR DESCRIPTION
## Resumen

Convierte `cuentas_empresa` en un libro contable real:

- **Saldo automático** vía un *ledger* de movimientos (ingreso/egreso). El saldo de cada cuenta se mantiene solo, sin riesgo de desincronización.
- **Hora Guatemala consistente** en todas las fechas de la tabla (defaults + trigger).
- **Soporte de moneda** (`quetzales`/`dolares`) reusando el enum `tipo_moneda` existente.
- **Filtros** en el listado de cuentas (`?nombre=`, `?cuentaId=`, `?soloActivas=`).
- **Endpoint nuevo** para registrar movimientos de plata.

## Cambios en la base de datos

### Modificaciones a `cartera.cuentas_empresa`
| Columna | Cambio |
|---|---|
| `moneda` | NUEVA — enum `tipo_moneda` (`quetzales`/`dolares`), default `quetzales` |
| `saldo_actual` | NUEVA — `numeric(18,2) NOT NULL DEFAULT 0`. **No se modifica desde la app**, solo vía trigger |
| `fecha_creacion` | Cambió default a `NOW() AT TIME ZONE 'America/Guatemala'` |
| `fecha_actualizacion` | Cambió default a `NOW() AT TIME ZONE 'America/Guatemala'` |

### Tabla nueva: `cartera.cuentas_empresa_movimientos`
Cada fila es un movimiento de plata atómico contra una cuenta:

| Columna | Tipo | Notas |
|---|---|---|
| `movimiento_id` | `serial PK` | |
| `cuenta_id` | FK a `cuentas_empresa` `ON DELETE RESTRICT` | no se puede borrar una cuenta con movimientos |
| `tipo` | enum `('ingreso','egreso')` | el signo del delta lo da el tipo |
| `monto` | `numeric(18,2)` | siempre positivo (`CHECK monto > 0`) |
| `saldo_post` | `numeric(18,2)` | snapshot del saldo después del movimiento (auditoría histórica) |
| `motivo` | `text` | libre, opcional |
| `created_by` | FK a `platform_users.id` | viene del JWT |
| `created_at` | `timestamptz` | hora Guatemala |

Más índices en `cuenta_id` y `created_at`.

### Funciones + triggers (todo a nivel DB, hora Guate)

1. **`cartera.aplicar_movimiento_cuenta_empresa()`** — trigger `BEFORE INSERT` en `cuentas_empresa_movimientos`:
   - Calcula delta según `tipo` (ingreso = +, egreso = -)
   - Hace `UPDATE cuentas_empresa SET saldo_actual = saldo_actual + delta` (lock automático de fila → seguro en concurrencia)
   - Setea `NEW.saldo_post` con el saldo resultante
   - Si `cuenta_id` no existe, tira `RAISE EXCEPTION`

2. **`cartera.set_fecha_actualizacion()`** — trigger `BEFORE UPDATE` en `cuentas_empresa`:
   - Setea `fecha_actualizacion = NOW() AT TIME ZONE 'America/Guatemala'` automáticamente
   - Hace innecesario setear `fecha_actualizacion` desde el código

**Cadena de eventos al insertar un movimiento:**
