### PR TITLE
fix(cartera-auth): Only refresh token if refresh token is present

### DIFF
--- a/apps/crm/apps/server/src/services/cartera-auth.service.ts
+++ b/apps/crm/apps/server/src/services/cartera-auth.service.ts
@@ -127,7 +127,9 @@ export async function getCarteraAccessToken(): Promise<string> {
 	if (tokenCache.accessToken && Date.now() < tokenCache.expiresAt) {
 		const verified = await verifyCarteraToken(tokenCache.accessToken);
 		if (verified) return verified;
+	}
 
+	if (tokenCache.refreshToken) {
 		const refreshed = await refreshCarteraToken();
 		if (refreshed) return refreshed;
 	}


### PR DESCRIPTION
Prevents attempting to refresh the Cartera access token if no refresh token is available in the cache, avoiding unnecessary API calls and potential errors.
