### PR TITLE
chore(web): Set default language to Spanish and prevent auto-translation

### DIFF
--- a/apps/crm/apps/web/index.html
+++ b/apps/crm/apps/web/index.html
@@ -1,12 +1,13 @@
 <!doctype html>
-<html lang="en">
+<html lang="es" translate="no">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google" content="notranslate" />
   </head>
 
   <body>
-    <div id="app"></div>
+    <div id="app" translate="no"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
Explicitly configures the base HTML document to be Spanish (`lang="es"`) and uses `translate="no"` and `meta name="google" content="notranslate"` to prevent browsers and search engines from automatically translating the page content, ensuring the intended language is always displayed.