### PR TITLE
feat: implement dark mode support for financial summary cards

### DIFF
--- a/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
+++ b/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
@@ -507,7 +507,7 @@ function CoDebtorCard({
 								<div className="space-y-3">
 									{/* Resumen de ingresos y gastos */}
 									<div className="grid grid-cols-2 gap-4 text-sm">
-										<div className="rounded bg-green-50 p-2">
+										<div className="rounded bg-green-50 dark:bg-green-900/20 p-2">
 											<p className="text-muted-foreground text-xs">
 												Total Ingresos
 											</p>
@@ -523,7 +523,7 @@ function CoDebtorCard({
 												)}
 											</p>
 										</div>
-										<div className="rounded bg-red-50 p-2">
+										<div className="rounded bg-red-50 dark:bg-red-900/20 p-2">
 											<p className="text-muted-foreground text-xs">
 												Total Gastos
 											</p>
@@ -542,7 +542,7 @@ function CoDebtorCard({
 									</div>
 
 									{/* Disponibilidad */}
-									<div className="rounded bg-blue-50 p-2 text-center">
+									<div className="rounded bg-blue-50 dark:bg-blue-900/20 p-2 text-center">
 										<p className="text-muted-foreground text-xs">
 											Disponibilidad Económica
 										</p>

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -876,7 +876,7 @@ function RouteComponent() {
 											key={opp.id}
 											className={`group flex items-center gap-3 rounded-lg border p-3 transition-all hover:shadow-sm ${
 												opp.isClosed
-													? "border-green-200 bg-green-50/50"
+													? "border-green-200 bg-green-50/50 dark:bg-green-900/20"
 													: "bg-card hover:bg-muted/40"
 											}`}
 										>
@@ -1274,7 +1274,7 @@ function RouteComponent() {
 										Análisis de Capacidad de Pago
 									</h3>
 									<div className="grid grid-cols-2 gap-4">
-										<div className="space-y-3 rounded-lg bg-green-50 p-3">
+										<div className="space-y-3 rounded-lg bg-green-50 dark:bg-green-900/20 p-3">
 											<h4 className="font-medium text-sm">
 												Ingresos Mensuales
 											</h4>
@@ -1322,7 +1322,7 @@ function RouteComponent() {
 											</div>
 										</div>
 
-										<div className="space-y-3 rounded-lg bg-red-50 p-3">
+										<div className="space-y-3 rounded-lg bg-red-50 dark:bg-red-900/20 p-3">
 											<h4 className="font-medium text-sm">Gastos Mensuales</h4>
 											<div className="flex justify-between text-sm">
 												<span className="text-muted-foreground">Fijos:</span>
@@ -1370,7 +1370,7 @@ function RouteComponent() {
 									</div>
 
 									{/* Disponibilidad Económica */}
-									<div className="rounded-lg bg-blue-50 p-3">
+									<div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3">
 										<div className="flex items-center justify-between">
 											<div>
 												<p className="font-medium text-sm">

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -2677,7 +2677,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Ingresos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-green-50 p-4">
+												<div className="space-y-3 rounded-lg bg-green-50 dark:bg-green-900/20 p-4">
 													<div className="space-y-2">
 														<Label className="text-sm">Ingresos Fijos</Label>
 														<Input
@@ -2719,7 +2719,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Gastos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-red-50 p-4">
+												<div className="space-y-3 rounded-lg bg-red-50 dark:bg-red-900/20 p-4">
 													<div className="space-y-2">
 														<Label className="text-sm">Gastos Fijos</Label>
 														<Input
@@ -2757,7 +2757,7 @@ function RouteComponent() {
 										</div>
 
 										{/* Economic Availability */}
-										<div className="rounded-lg bg-blue-50 p-4">
+										<div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-4">
 											<div className="space-y-2">
 												<Label className="font-medium text-sm">
 													Disponibilidad Económica
@@ -2844,7 +2844,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Ingresos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-green-50 p-4">
+												<div className="space-y-3 rounded-lg bg-green-50 dark:bg-green-900/20 p-4">
 													<div className="flex justify-between">
 														<span className="text-muted-foreground text-sm">
 															Ingresos Fijos:
@@ -2899,7 +2899,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Gastos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-red-50 p-4">
+												<div className="space-y-3 rounded-lg bg-red-50 dark:bg-red-900/20 p-4">
 													<div className="flex justify-between">
 														<span className="text-muted-foreground text-sm">
 															Gastos Fijos:
@@ -2952,7 +2952,7 @@ function RouteComponent() {
 										</div>
 
 										{/* Economic Availability */}
-										<div className="rounded-lg bg-blue-50 p-4">
+										<div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-4">
 											<div className="flex items-center justify-between">
 												<div>
 													<Label className="font-medium text-muted-foreground text-sm">


### PR DESCRIPTION
## Resumen de Cambios: Corrección de Visibilidad en Modo Oscuro (Análisis de Capacidad de Pago)

### Problema
Se detectó que en el **Modo Oscuro**, los resúmenes financieros del "Análisis de Capacidad de Pago" eran ilegibles. Esto ocurría porque los contenedores de Ingresos, Gastos y Disponibilidad utilizaban fondos claros fijos (`bg-green-50`, `bg-red-50`, `bg-blue-50`), mientras que el sistema cambiaba el color del texto a blanco, resultando en un contraste nulo (texto blanco sobre fondo casi blanco).

### Solución
Se implementaron variantes de Tailwind CSS para el modo oscuro en todos los componentes que muestran el resumen del análisis crediticio. Se ajustaron los fondos para que en modo oscuro utilicen tonos oscuros traslúcidos que permiten la lectura clara del texto claro.

**Cambios principales:**
- `bg-green-50` ➔ `bg-green-50 dark:bg-green-900/20`
- `bg-red-50` ➔ `bg-red-50 dark:bg-red-900/20`
- `bg-blue-50` ➔ `bg-blue-50 dark:bg-blue-900/20`

### Archivos Modificados
- `apps/crm/apps/web/src/routes/crm/leads.tsx`: Corrección en el detalle de leads y formularios de edición.
- `apps/crm/apps/web/src/routes/crm/clients.tsx`: Ajuste en la vista detallada de clientes.
- `apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx`: Corrección en el resumen de capacidad de pago para co-deudores.

### Verificación
- [x] Verificado en Modo Claro (mantiene estética original).
- [x] Verificado en Modo Oscuro (texto blanco ahora es legible sobre fondos oscuros).
