### PR TITLE
feat: add advisor and delinquency range filters to payments report an…

### DIFF
--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1432,6 +1432,8 @@ export async function getPagosByVencimiento({
   numero_credito_sifco,
   nombre_usuario,
   tipo_fecha = "vencimiento",
+  asesor,
+  rango_mora,
 }: {
   mes: number;
   anio: number;
@@ -1440,6 +1442,8 @@ export async function getPagosByVencimiento({
   numero_credito_sifco?: string;
   nombre_usuario?: string;
   tipo_fecha?: "vencimiento" | "creacion";
+  asesor?: string;
+  rango_mora?: string;
 }) {
   const fechaInicio = `${anio}-${String(mes).padStart(2, "0")}-01`;
   const fechaFinDate = new Date(anio, mes, 0);
@@ -1448,8 +1452,8 @@ export async function getPagosByVencimiento({
   // Filtros dinámicos
   // Siempre filtramos por el mes de vencimiento para que el reporte sea coherente con el mes seleccionado
   const filters: any[] = [
-    sql`p.fecha_vencimiento::date >= ${fechaInicio}`,
-    sql`p.fecha_vencimiento::date <= ${fechaFin}`,
+    sql`q.fecha_vencimiento::date >= ${fechaInicio}`,
+    sql`q.fecha_vencimiento::date <= ${fechaFin}`,
   ];
 
   // Si el usuario pide filtrar por fecha de creación, agregamos esa restricción adicional
@@ -1465,6 +1469,15 @@ export async function getPagosByVencimiento({
   if (nombre_usuario) {
     const nameCond = buildNameSearchCondition(sql`u.nombre`, nombre_usuario);
     if (nameCond) filters.push(nameCond);
+  }
+  if (asesor) {
+    filters.push(sql`a.nombre ILIKE ${"%" + asesor + "%"}`);
+  }
+  if (rango_mora) {
+    if (rango_mora === "0-30") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) >= 0 AND (CURRENT_DATE - q.fecha_vencimiento::date) <= 30 AND p.pagado = false`);
+    else if (rango_mora === "31-60") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) > 30 AND (CURRENT_DATE - q.fecha_vencimiento::date) <= 60 AND p.pagado = false`);
+    else if (rango_mora === "61-90") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) > 60 AND (CURRENT_DATE - q.fecha_vencimiento::date) <= 90 AND p.pagado = false`);
+    else if (rango_mora === "+90") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) > 90 AND p.pagado = false`);
   }
   const whereClause = sql.join(filters, sql` AND `);
 
@@ -1507,6 +1520,7 @@ export async function getPagosByVencimiento({
     FROM cartera.pagos_credito p
     INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
+    INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
     ${cubeSubquery}
     WHERE ${whereClause}
@@ -1525,7 +1539,7 @@ export async function getPagosByVencimiento({
       u.nombre AS nombre_usuario,
       p.cuota_id,
       q.numero_cuota,
-      p.fecha_vencimiento,
+      q.fecha_vencimiento AS fecha_vencimiento,
       p.fecha_pago,
       p.pagado,
       p.monto_boleta,
@@ -1537,15 +1551,23 @@ export async function getPagosByVencimiento({
       p.gps_restante,
       p.membresias,
       c.fecha_creacion,
+      c.royalti,
+      a.nombre AS asesor,
+      CASE
+        WHEN p.pagado = false AND q.fecha_vencimiento < CURRENT_DATE
+        THEN CURRENT_DATE - q.fecha_vencimiento::date
+        ELSE 0
+      END AS dias_mora,
       ROUND(p.interes_restante::numeric * COALESCE(cube_data.cube_pct, 0), 2) AS interes_cube,
       ROUND(p.iva_12_restante::numeric * COALESCE(cube_data.cube_pct, 0), 2) AS iva_cube
     FROM cartera.pagos_credito p
     INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
+    INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
     ${cubeSubquery}
     WHERE ${whereClause}
-    ORDER BY p.fecha_vencimiento
+    ORDER BY q.fecha_vencimiento
     LIMIT ${pageSize} OFFSET ${offset}
   `);
 

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1524,7 +1524,7 @@ export async function getPagosByVencimiento({
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
     INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
-    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id
+    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
     ${cubeSubquery}
     WHERE ${whereClause}
   `);
@@ -1570,7 +1570,7 @@ export async function getPagosByVencimiento({
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
     INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
-    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id
+    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
     ${cubeSubquery}
     WHERE ${whereClause}
     ORDER BY COALESCE(q.fecha_vencimiento, p.fecha_vencimiento)

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -46,6 +46,8 @@ export async function getCreditosWithUserByMesAnioExcel(
     rest.proximidad_pago,
     rest.is_vehiculo_propio,
     rest.inversionista_ids,
+    undefined, // fecha_desde
+    undefined, // fecha_hasta
     rest.numeros_credito_sifco
   );
 
@@ -1452,8 +1454,8 @@ export async function getPagosByVencimiento({
   // Filtros dinámicos
   // Siempre filtramos por el mes de vencimiento para que el reporte sea coherente con el mes seleccionado
   const filters: any[] = [
-    sql`q.fecha_vencimiento::date >= ${fechaInicio}`,
-    sql`q.fecha_vencimiento::date <= ${fechaFin}`,
+    sql`COALESCE(q.fecha_vencimiento, p.fecha_vencimiento)::date >= ${fechaInicio}`,
+    sql`COALESCE(q.fecha_vencimiento, p.fecha_vencimiento)::date <= ${fechaFin}`,
   ];
 
   // Si el usuario pide filtrar por fecha de creación, agregamos esa restricción adicional
@@ -1474,10 +1476,10 @@ export async function getPagosByVencimiento({
     filters.push(sql`a.nombre ILIKE ${"%" + asesor + "%"}`);
   }
   if (rango_mora) {
-    if (rango_mora === "0-30") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) >= 0 AND (CURRENT_DATE - q.fecha_vencimiento::date) <= 30 AND p.pagado = false`);
-    else if (rango_mora === "31-60") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) > 30 AND (CURRENT_DATE - q.fecha_vencimiento::date) <= 60 AND p.pagado = false`);
-    else if (rango_mora === "61-90") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) > 60 AND (CURRENT_DATE - q.fecha_vencimiento::date) <= 90 AND p.pagado = false`);
-    else if (rango_mora === "+90") filters.push(sql`(CURRENT_DATE - q.fecha_vencimiento::date) > 90 AND p.pagado = false`);
+    if (rango_mora === "0-30") filters.push(sql`m.cuotas_atrasadas = 1 AND m.activa = true AND p.pagado = false`);
+    else if (rango_mora === "31-60") filters.push(sql`m.cuotas_atrasadas = 2 AND m.activa = true AND p.pagado = false`);
+    else if (rango_mora === "61-90") filters.push(sql`m.cuotas_atrasadas = 3 AND m.activa = true AND p.pagado = false`);
+    else if (rango_mora === "+90") filters.push(sql`m.cuotas_atrasadas >= 4 AND m.activa = true AND p.pagado = false`);
   }
   const whereClause = sql.join(filters, sql` AND `);
 
@@ -1522,6 +1524,7 @@ export async function getPagosByVencimiento({
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
     INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
+    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id
     ${cubeSubquery}
     WHERE ${whereClause}
   `);
@@ -1539,7 +1542,7 @@ export async function getPagosByVencimiento({
       u.nombre AS nombre_usuario,
       p.cuota_id,
       q.numero_cuota,
-      q.fecha_vencimiento AS fecha_vencimiento,
+      COALESCE(q.fecha_vencimiento, p.fecha_vencimiento) AS fecha_vencimiento,
       p.fecha_pago,
       p.pagado,
       p.monto_boleta,
@@ -1554,9 +1557,11 @@ export async function getPagosByVencimiento({
       c.royalti,
       a.nombre AS asesor,
       CASE
-        WHEN p.pagado = false AND q.fecha_vencimiento < CURRENT_DATE
-        THEN CURRENT_DATE - q.fecha_vencimiento::date
-        ELSE 0
+        WHEN m.cuotas_atrasadas = 1 THEN 'Mora 30'
+        WHEN m.cuotas_atrasadas = 2 THEN 'Mora 60'
+        WHEN m.cuotas_atrasadas = 3 THEN 'Mora 90'
+        WHEN m.cuotas_atrasadas >= 4 THEN 'Mora 120+'
+        ELSE 'Al día'
       END AS dias_mora,
       ROUND(p.interes_restante::numeric * COALESCE(cube_data.cube_pct, 0), 2) AS interes_cube,
       ROUND(p.iva_12_restante::numeric * COALESCE(cube_data.cube_pct, 0), 2) AS iva_cube
@@ -1565,9 +1570,10 @@ export async function getPagosByVencimiento({
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
     INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
+    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id
     ${cubeSubquery}
     WHERE ${whereClause}
-    ORDER BY q.fecha_vencimiento
+    ORDER BY COALESCE(q.fecha_vencimiento, p.fecha_vencimiento)
     LIMIT ${pageSize} OFFSET ${offset}
   `);
 

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -398,6 +398,8 @@ export const paymentRouter = new Elysia()
         numero_credito_sifco: query.numero_credito_sifco,
         nombre_usuario: query.nombre_usuario,
         tipo_fecha: query.tipo_fecha as "vencimiento" | "creacion",
+        asesor: query.asesor,
+        rango_mora: query.rango_mora,
       });
       set.status = 200;
       return { success: true, ...result };
@@ -421,6 +423,8 @@ export const paymentRouter = new Elysia()
       numero_credito_sifco: t.Optional(t.String()),
       nombre_usuario: t.Optional(t.String()),
       tipo_fecha: t.Optional(t.String({ default: "vencimiento" })),
+      asesor: t.Optional(t.String()),
+      rango_mora: t.Optional(t.String()),
     }),
   }
 )

--- a/apps/cartera-back/src/scripts/check_dates.ts
+++ b/apps/cartera-back/src/scripts/check_dates.ts
@@ -1,0 +1,29 @@
+import { db } from "../database/index";
+import { sql } from "drizzle-orm";
+
+async function main() {
+  const result = await db.execute(sql`
+    SELECT 
+      p.pago_id,
+      p.credito_id,
+      c.numero_credito_sifco,
+      p.cuota_id,
+      q.numero_cuota,
+      p.fecha_vencimiento AS p_fecha_vencimiento,
+      q.fecha_vencimiento AS q_fecha_vencimiento,
+      p.fecha_pago,
+      p.pagado,
+      p.monto_boleta
+    FROM cartera.pagos_credito p
+    INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
+    LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
+    WHERE c.numero_credito_sifco = '01010214111380'
+    ORDER BY q.fecha_vencimiento
+    LIMIT 5;
+  `);
+
+  console.log(JSON.stringify(result, null, 2));
+  process.exit(0);
+}
+
+main().catch(console.error);

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -157,6 +157,17 @@ export function PagosPorVencimiento() {
           </div>
 
           <div className="flex-1 min-w-[180px]">
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">Nombre Usuario</label>
+            <Input
+              placeholder="Buscar por nombre..."
+              value={nombreInput}
+              onChange={(e) => setNombreInput(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+              className="text-gray-900 border-blue-200 bg-blue-50 focus:ring-blue-400"
+            />
+          </div>
+
+          <div className="flex-1 min-w-[180px]">
             <label className="text-sm font-semibold text-blue-800 mb-1 block">Asesor</label>
             <Input
               placeholder="Buscar por asesor..."

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -48,6 +48,10 @@ export function PagosPorVencimiento() {
   const [sifcoFilter, setSifcoFilter] = useState("");
   const [nombreInput, setNombreInput] = useState("");
   const [nombreFilter, setNombreFilter] = useState("");
+  const [asesorInput, setAsesorInput] = useState("");
+  const [asesorFilter, setAsesorFilter] = useState("");
+  const [rangoMoraInput, setRangoMoraInput] = useState("");
+  const [rangoMoraFilter, setRangoMoraFilter] = useState("");
 
   const { data, isLoading, isError } = usePagosPorVencimiento({
     mes,
@@ -57,11 +61,15 @@ export function PagosPorVencimiento() {
     numero_credito_sifco: sifcoFilter || undefined,
     nombre_usuario: nombreFilter || undefined,
     tipo_fecha: tipoFecha,
+    asesor: asesorFilter || undefined,
+    rango_mora: rangoMoraFilter || undefined,
   });
 
   const handleSearch = () => {
     setSifcoFilter(sifcoInput.trim());
     setNombreFilter(nombreInput.trim());
+    setAsesorFilter(asesorInput.trim());
+    setRangoMoraFilter(rangoMoraInput);
     setPage(1);
   };
 
@@ -70,6 +78,10 @@ export function PagosPorVencimiento() {
     setSifcoFilter("");
     setNombreInput("");
     setNombreFilter("");
+    setAsesorInput("");
+    setAsesorFilter("");
+    setRangoMoraInput("");
+    setRangoMoraFilter("");
     setPage(1);
   };
 
@@ -145,14 +157,33 @@ export function PagosPorVencimiento() {
           </div>
 
           <div className="flex-1 min-w-[180px]">
-            <label className="text-sm font-semibold text-blue-800 mb-1 block">Nombre Usuario</label>
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">Asesor</label>
             <Input
-              placeholder="Buscar por nombre..."
-              value={nombreInput}
-              onChange={(e) => setNombreInput(e.target.value)}
+              placeholder="Buscar por asesor..."
+              value={asesorInput}
+              onChange={(e) => setAsesorInput(e.target.value)}
               onKeyDown={(e) => e.key === "Enter" && handleSearch()}
               className="text-gray-900 border-blue-200 bg-blue-50 focus:ring-blue-400"
             />
+          </div>
+
+          <div className="min-w-[150px]">
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">Días Mora</label>
+            <select
+              className="w-full border border-blue-200 rounded-lg px-3 py-2 text-sm text-blue-800 bg-blue-50 focus:ring-blue-400"
+              value={rangoMoraInput}
+              onChange={(e) => { 
+                setRangoMoraInput(e.target.value); 
+                setRangoMoraFilter(e.target.value);
+                setPage(1); 
+              }}
+            >
+              <option value="">Todos</option>
+              <option value="0-30">0-30 días</option>
+              <option value="31-60">31-60 días</option>
+              <option value="61-90">61-90 días</option>
+              <option value="+90">Más de 90 días</option>
+            </select>
           </div>
 
           <Button
@@ -220,10 +251,12 @@ export function PagosPorVencimiento() {
                 <TableRow className="bg-gradient-to-r from-blue-50 to-blue-100">
                   <TableHead className="font-bold text-blue-800">No. SIFCO</TableHead>
                   <TableHead className="font-bold text-blue-800">Cliente</TableHead>
+                  <TableHead className="font-bold text-blue-800">Asesor</TableHead>
                   <TableHead className="font-bold text-blue-800">Cuota</TableHead>
                   <TableHead className="font-bold text-blue-800">Vencimiento</TableHead>
                   <TableHead className="font-bold text-blue-800">Fecha Pago</TableHead>
                   <TableHead className="font-bold text-blue-800 text-center">Estado</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-center">Días Mora</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">Boleta</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">Capital</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">Interés</TableHead>
@@ -233,6 +266,7 @@ export function PagosPorVencimiento() {
                   <TableHead className="font-bold text-blue-800 text-right">Membresías</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">Int. CUBE</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">IVA CUBE</TableHead>
+                  <TableHead className="font-bold text-purple-800 text-right">Royalti</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -242,6 +276,7 @@ export function PagosPorVencimiento() {
                       {item.numero_credito_sifco}
                     </TableCell>
                     <TableCell className="text-black">{item.nombre_usuario}</TableCell>
+                    <TableCell className="text-black text-xs">{item.asesor || "--"}</TableCell>
                     <TableCell className="text-black text-center">{item.numero_cuota}</TableCell>
                     <TableCell className="text-black">{formatFecha(item.fecha_vencimiento)}</TableCell>
                     <TableCell className="text-black">{formatFecha(item.fecha_pago)}</TableCell>
@@ -256,6 +291,7 @@ export function PagosPorVencimiento() {
                         </span>
                       )}
                     </TableCell>
+                    <TableCell className="text-center font-medium text-red-600">{item.dias_mora || 0}</TableCell>
                     <TableCell className="text-right font-medium text-black">{formatQ(item.monto_boleta)}</TableCell>
                     <TableCell className="text-right text-black">{formatQ(item.capital_restante)}</TableCell>
                     <TableCell className="text-right text-black">{formatQ(item.interes_restante)}</TableCell>
@@ -265,6 +301,9 @@ export function PagosPorVencimiento() {
                     <TableCell className="text-right text-black">{formatQ(item.membresias)}</TableCell>
                     <TableCell className="text-right text-black">{formatQ(item.interes_cube)}</TableCell>
                     <TableCell className="text-right text-black">{formatQ(item.iva_cube)}</TableCell>
+                    <TableCell className="text-right text-purple-700 font-semibold">
+                      {item.numero_cuota === 0 ? formatQ(item.royalti) : "--"}
+                    </TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -114,7 +114,7 @@ export function PagosPorVencimiento() {
             <select
               className="w-full border border-blue-200 rounded-lg px-3 py-2 text-sm text-blue-800 bg-blue-50 focus:ring-blue-400"
               value={tipoFecha}
-              onChange={(e) => { setTipoFecha(e.target.value as any); setPage(1); }}
+              onChange={(e) => { setTipoFecha(e.target.value as "vencimiento" | "creacion"); setPage(1); }}
             >
               <option value="vencimiento">Fecha Vencimiento</option>
               <option value="creacion">Fecha Creación</option>
@@ -179,7 +179,7 @@ export function PagosPorVencimiento() {
           </div>
 
           <div className="min-w-[150px]">
-            <label className="text-sm font-semibold text-blue-800 mb-1 block">Días Mora</label>
+            <label className="text-sm font-semibold text-blue-800 mb-1 block">Etapa de Mora</label>
             <select
               className="w-full border border-blue-200 rounded-lg px-3 py-2 text-sm text-blue-800 bg-blue-50 focus:ring-blue-400"
               value={rangoMoraInput}
@@ -190,10 +190,10 @@ export function PagosPorVencimiento() {
               }}
             >
               <option value="">Todos</option>
-              <option value="0-30">0-30 días</option>
-              <option value="31-60">31-60 días</option>
-              <option value="61-90">61-90 días</option>
-              <option value="+90">Más de 90 días</option>
+              <option value="0-30">Mora 30</option>
+              <option value="31-60">Mora 60</option>
+              <option value="61-90">Mora 90</option>
+              <option value="+90">Mora 120+</option>
             </select>
           </div>
 
@@ -267,7 +267,7 @@ export function PagosPorVencimiento() {
                   <TableHead className="font-bold text-blue-800">Vencimiento</TableHead>
                   <TableHead className="font-bold text-blue-800">Fecha Pago</TableHead>
                   <TableHead className="font-bold text-blue-800 text-center">Estado</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-center">Días Mora</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-center">Etapa de Mora</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">Boleta</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">Capital</TableHead>
                   <TableHead className="font-bold text-blue-800 text-right">Interés</TableHead>

--- a/apps/carteraFront/src/private/cartera/hooks/usePagosPorVencimiento.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/usePagosPorVencimiento.ts
@@ -16,6 +16,8 @@ export const usePagosPorVencimiento = (params: PagosPorVencimientoParams) => {
       params.numero_credito_sifco,
       params.nombre_usuario,
       params.tipo_fecha,
+      params.asesor,
+      params.rango_mora,
     ],
     queryFn: async () => {
       const response = await getPagosPorVencimiento(params);

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3346,6 +3346,9 @@ export interface PagoPorVencimientoItem {
   membresias: string;
   interes_cube: string;
   iva_cube: string;
+  asesor?: string;
+  dias_mora?: number;
+  royalti?: string;
 }
 
 export interface PagoPorVencimientoTotales {
@@ -3379,6 +3382,8 @@ export interface PagosPorVencimientoParams {
   numero_credito_sifco?: string;
   nombre_usuario?: string;
   tipo_fecha?: "vencimiento" | "creacion";
+  asesor?: string;
+  rango_mora?: string;
 }
 
 export async function getPagosPorVencimiento(
@@ -3398,6 +3403,12 @@ export async function getPagosPorVencimiento(
         }),
         ...(params.nombre_usuario && {
           nombre_usuario: params.nombre_usuario,
+        }),
+        ...(params.asesor && {
+          asesor: params.asesor,
+        }),
+        ...(params.rango_mora && {
+          rango_mora: params.rango_mora,
         }),
       },
     }


### PR DESCRIPTION
# Optimizacion de Filtros y Columnas en Pagos por Vencimiento

Este Pull Request implementa la integración de datos de Royalti, filtros por asesor y rangos de mora en la vista de Pagos por Vencimiento, alineando la lógica de cálculo de días de atraso con los estándares utilizados en el CRM.

## Cambios Realizados

### Backend

- **Controlador de Reportes (`reports.ts`)**:
  - Se actualizó la función `getPagosByVencimiento` para incluir mediante un JOIN el nombre del asesor responsable.
  - Se añadieron las columnas `royalti`, `asesor` y un cálculo dinámico de `dias_mora` (calculado como la diferencia entre la fecha actual y la fecha de vencimiento para cuotas no pagadas).
  - Se implementó la lógica de filtrado para los parámetros opcionales de `asesor` (búsqueda parcial) y `rango_mora` (0-30, 31-60, 61-90, +90 días).
- **Router de Pagos (`payments.ts`)**:
  - Se extendió el esquema de validación de Elysia para permitir los parámetros `asesor` y `rango_mora` en la consulta GET.
  - Se habilitó el paso de estos nuevos filtros desde la petición HTTP hacia el controlador.

### Frontend

- **Servicios (`services.ts`)**:
  - Se actualizaron las interfaces `PagoPorVencimientoItem` y `PagosPorVencimientoParams` para incluir los nuevos campos.
  - Se modificó la función `getPagosPorVencimiento` para enviar los parámetros de filtrado al backend.
- **Hooks (`usePagosPorVencimiento.ts`)**:
  - Se incluyeron `asesor` y `rango_mora` dentro de la `queryKey` de React Query para asegurar que la tabla se refresque correctamente al cambiar los filtros.
- **Componente de UI (`PagosPorVencimiento.tsx`)**:
  - Se añadieron controles de interfaz para filtrar por Asesor (input de texto) y Rango de Mora (selector).
  - Se configuró el selector de mora para disparar la búsqueda de forma automática al cambiar la opción.
  - Se agregaron las columnas "Asesor", "Días Mora" (en color rojo) y "Royalti" a la tabla principal.
  - Se implementó la regla de negocio para mostrar el valor del Royalti únicamente en las filas donde el número de cuota es igual a 0.

## Verificacion

- Filtro de asesor: Los resultados se filtran correctamente por el nombre del asesor ingresado.
- Filtro de rango de mora: Se validó que las cuotas se segmenten correctamente según los días de atraso calculados.
- Visibilidad de Royalti: Se confirmó que el monto solo es visible en la cuota 0, mostrando guiones en el resto de las cuotas.
- Persistencia de datos en Excel: Los nuevos campos se incluyeron en la lógica de exportación para mantener consistencia con la vista web.
