### PR TITLE
Fix cartera-back type errors

### DIFF
--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -5,6 +5,7 @@ import Big from "big.js";
 
 export async function createAbonoCapital(data: {
   credito_id: number;
+  inversionista_id: number;
   monto: string;
   tipo: "CANCELACION" | "CAPITAL";
   liquidado?: boolean;
@@ -14,6 +15,7 @@ export async function createAbonoCapital(data: {
       .insert(abonos_capital)
       .values({
         credito_id: data.credito_id,
+        inversionista_id: data.inversionista_id,
         monto: data.monto,
         tipo: data.tipo,
         liquidado: data.liquidado ?? false,
@@ -208,5 +210,4 @@ export async function updateAbonoCapital(
     };
   }
 }
-
 

--- a/apps/cartera-back/src/controllers/cancelCredit.ts
+++ b/apps/cartera-back/src/controllers/cancelCredit.ts
@@ -9,50 +9,7 @@ import {
   moras_credito,
 } from "../database/db/schema";
 import { eq, and } from "drizzle-orm";
-
-type ClosureInfo =
-  | { kind: "CANCELACION"; id: number; motivo: string; observaciones: string | null; fecha: Date | string | null; monto: string; traspaso: string; garantia_mobiliaria: string; otros: string }
-  | { kind: "INCOBRABLE"; id: number; motivo: string; observaciones: string | null; fecha: Date | string | null; monto: string }
-  | null;
-
-type CuotaExcelRow = {
-  no: number;
-  mes: string;
-  interes: string;
-  servicios: string;
-  mora: string;
-  otros: string;
-  capital_pendiente: string;
-  total_cancelar: string;
-  fecha_vencimiento: string;
-  seguro: string;
-  membresias: string;
-};
-
-type GetCreditDTO = {
-  header: {
-    usuario: string;
-    numero_credito_sifco: string;
-    moneda: "Quetzal";
-    saldo_total: string;
-    extras_total: string;
-    saldo_total_con_extras: string;
-  };
-  closure: ClosureInfo;
-  cuotas_atrasadas: {
-    total: number;
-    items: CuotaExcelRow[];
-  };
-  extras: {
-    total_items: number;
-    items: Array<{
-      id: number;
-      concepto: string;
-      monto: string;
-      fecha_registro: Date | string | null;
-    }>;
-  };
-};
+import type { ClosureInfo, CuotaExcelRow, GetCreditDTO } from "../utils/interface";
 
 export async function getCreditWithCancellationDetails(
   numero_credito_sifco: string
@@ -71,6 +28,8 @@ export async function getCreditWithCancellationDetails(
           iva: creditos.iva_12,
           gps: creditos.gps,
           status: creditos.statusCredit,
+          tipo_credito: creditos.tipoCredito,
+          observaciones: creditos.observaciones,
         },
         user: {
           name: usuarios.nombre,
@@ -179,6 +138,7 @@ export async function getCreditWithCancellationDetails(
         total_cancelar: total.toFixed(2),
         fecha_vencimiento: "",
         seguro: seguro_unitario.toFixed(2),
+        gps: gps_unitario.toFixed(2),
         membresias: membresias_unitario.toFixed(2),
       };
     });
@@ -212,6 +172,8 @@ export async function getCreditWithCancellationDetails(
         saldo_total: saldo_total.toFixed(2),
         extras_total: extras_total.toFixed(2),
         saldo_total_con_extras: saldo_total.plus(extras_total).toFixed(2),
+        tipo_credito: r.credit.tipo_credito,
+        observaciones: r.credit.observaciones ?? null,
       },
       closure,
       totales,

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1007,10 +1007,12 @@ export async function processAndReplaceCreditInvestorsReverse(
   }
 
   // 4. Obtener TODOS los pagos de esa cuota
-  const pagosDeEsaCuota = await db
-    .select({ pago_id: pagos_credito.pago_id })
-    .from(pagos_credito)
-    .where(eq(pagos_credito.cuota_id, pago.cuota_id));
+  const pagosDeEsaCuota = pago.cuota_id === null
+    ? []
+    : await db
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .where(eq(pagos_credito.cuota_id, pago.cuota_id));
 
   const pagoIds = pagosDeEsaCuota.map((p) => p.pago_id);
 
@@ -1138,7 +1140,13 @@ export async function reversePagosEspejoPorInversionista(
   }
 
   // 5. Obtener cuotas asociadas a los pagos y marcarlas como NO liquidadas
-  const pagoIds = [...new Set(pagosEspejo.map((p) => p.pago_id))];
+  const pagoIds = [
+    ...new Set(
+      pagosEspejo
+        .map((p) => p.pago_id)
+        .filter((id): id is number => id !== null)
+    ),
+  ];
   console.log(`\n📅 Revirtiendo liquidación de cuotas (${pagoIds.length} pago_ids únicos)...`);
 
   if (pagoIds.length > 0) {
@@ -2240,7 +2248,13 @@ export async function revertirLiquidacion(liquidacion_id: number) {
     // PASO 5: Revertir cuotas del crédito
     //   Marcamos liquidado_inversionistas = false y limpiamos fecha
     // ──────────────────────────────────────────────
-    const allPagoIds = [...new Set(pagosLiquidados.map((p) => p.pago_id))];
+    const allPagoIds = [
+      ...new Set(
+        pagosLiquidados
+          .map((p) => p.pago_id)
+          .filter((id): id is number => id !== null)
+      ),
+    ];
     if (allPagoIds.length > 0) {
       const cuotasDeLosPagos = await tx
         .select({ cuota_id: pagos_credito.cuota_id })
@@ -2975,14 +2989,26 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
         }
 
         // Marcar cuotas como liquidado_inversionistas
-        const allPagoIds = [...new Set(pagosNoLiquidados.map((p) => p.pago_id))];
+        const allPagoIds = [
+          ...new Set(
+            pagosNoLiquidados
+              .map((p) => p.pago_id)
+              .filter((id): id is number => id !== null)
+          ),
+        ];
         if (allPagoIds.length > 0) {
           const cuotasDeLosPagos = await tx
             .select({ cuota_id: pagos_credito.cuota_id })
             .from(pagos_credito)
             .where(inArray(pagos_credito.pago_id, allPagoIds));
 
-          const uniqueCuotaIds = [...new Set(cuotasDeLosPagos.map((c) => c.cuota_id))];
+          const uniqueCuotaIds = [
+            ...new Set(
+              cuotasDeLosPagos
+                .map((c) => c.cuota_id)
+                .filter((id): id is number => id !== null)
+            ),
+          ];
           if (uniqueCuotaIds.length > 0) {
             const fechaGuatemala = new Date(
               new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })

--- a/apps/cartera-back/src/controllers/migrateInvestor.ts
+++ b/apps/cartera-back/src/controllers/migrateInvestor.ts
@@ -13,6 +13,7 @@ interface FilaExcelInversionista {
   CreditoSIFCO: string;
   Inversionista: string;
   Capital: number | string;
+  CapitalRestante?: number | string;
   porcentaje: number | string;
   PorcentajeCashIn?: number | string;
   PorcentajeInversionista?: number | string;

--- a/apps/cartera-back/src/controllers/migratePayments.ts
+++ b/apps/cartera-back/src/controllers/migratePayments.ts
@@ -66,7 +66,7 @@ export const ajustarCuotasConSIFCO = async ({
     const infoPagos = await consultarEstadoCuentaPrestamo(numero_credito_sifco);
     
     // 🔥 Agarrar la PRIMERA transacción (el desembolso)
-    const transaccionDesembolso = infoPagos.ConsultaResultado.EstadoCuenta_Transacciones[0];
+    const transaccionDesembolso = infoPagos?.ConsultaResultado?.EstadoCuenta_Transacciones?.[0];
     
     if (transaccionDesembolso && transaccionDesembolso.EstadoCuenta_Detalles) {
       // Buscar el detalle "LIQUIDO A DESEMBOLSAR" (CrMoDeSalCod: 59)
@@ -728,7 +728,7 @@ export const marcarCuotasPagadasHastaNumero = async ({
 
   try {
     const infoPagos = await consultarEstadoCuentaPrestamo(numero_credito_sifco);
-    const trx = infoPagos.ConsultaResultado.EstadoCuenta_Transacciones?.[0];
+    const trx = infoPagos?.ConsultaResultado?.EstadoCuenta_Transacciones?.[0];
     const liquido = trx?.EstadoCuenta_Detalles?.find(
       (d: any) => d.CrMoDeSalCod === 59
     );

--- a/apps/cartera-back/src/controllers/processFromExcelFull.ts
+++ b/apps/cartera-back/src/controllers/processFromExcelFull.ts
@@ -261,6 +261,9 @@ export async function procesarCreditoDesdeExcelFull(
     filaRef.ComoSeEntero || null
   );
   const advisor = await findOrCreateAdvisorByName(filaRef.Asesor || "", true);
+  if (!advisor) {
+    throw new Error(`No se pudo encontrar o crear asesor: ${filaRef.Asesor || ""}`);
+  }
 
   // ───────────────────────────────────────────────────────
   // 3. Upsert crédito (limpia pagos/cuotas/inversionistas si existe)

--- a/apps/cartera-back/src/controllers/reconcileEspejo.ts
+++ b/apps/cartera-back/src/controllers/reconcileEspejo.ts
@@ -333,6 +333,7 @@ export const reconcileEspejo = async ({ body, set }: any) => {
 
         let posterioresActualizados = 0;
         for (const otro of otrosRegistros) {
+          if (otro.pago_id === null) continue;
 
           // Buscar la cuota de este pago
           const [pagoOtro] = await tx

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -1994,10 +1994,12 @@ export async function aplicarPagoAlCredito(pago_id: number) {
       .set({ validationStatus: "validated", fecha_aplicado: new Date() })
       .where(eq(pagos_credito.pago_id, pago_id));
 
-    await db
-      .update(cuotas_credito)
-      .set({ pagado: true })
-      .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+    if (pago.cuota_id !== null) {
+      await db
+        .update(cuotas_credito)
+        .set({ pagado: true })
+        .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+    }
 
     console.log("✅ Crédito actualizado y pago validado");
  // 8. Distribuir entre inversionistas

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -580,6 +580,9 @@ export async function exportPagosConInversionistasExcel(
     formatoCredito?: string;
     soloAplicados?: boolean;
     fechaAplicado?: string;
+    fechaBoleta?: string;
+    fechaBoletaInicio?: string;
+    fechaBoletaFin?: string;
   }
 ) {
   // 1️⃣ Obtener los datos completos de tu servicio
@@ -887,6 +890,9 @@ export async function exportPagosAdvisorExcel(
     formatoCredito?: string;
     soloAplicados?: boolean;
     fechaAplicado?: string;
+    fechaBoleta?: string;
+    fechaBoletaInicio?: string;
+    fechaBoletaFin?: string;
   }
 ) {
   const result = await getPagosConInversionistas({

--- a/apps/cartera-back/src/controllers/revalidatePayment.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.ts
@@ -76,15 +76,17 @@ export const revalidatePayment = async ({ body, set }: any) => {
 
       // 4️⃣ CALCULAR NUEVO CAPITAL (restar el abono_capital del pago)
       const capital_actual = new Big(credito.capital ?? 0);
-      const todosPagosCuota = await tx
-        .select({ abono_capital: pagos_credito.abono_capital })
-        .from(pagos_credito)
-        .where(
-          and(
-            eq(pagos_credito.cuota_id, pago.cuota_id),
-            eq(pagos_credito.validationStatus, "validated")
-          )
-        );
+      const todosPagosCuota = pago.cuota_id === null
+        ? []
+        : await tx
+            .select({ abono_capital: pagos_credito.abono_capital })
+            .from(pagos_credito)
+            .where(
+              and(
+                eq(pagos_credito.cuota_id, pago.cuota_id),
+                eq(pagos_credito.validationStatus, "validated")
+              )
+            );
 
       let abono_capital_total = new Big(0);
       for (const p of todosPagosCuota) {

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -281,10 +281,12 @@ export const reversePayment = async ({ body, set }: any) => {
           "📝 Pago estaba PAGADO - Marcando cuota como NO pagada y reseteando pago",
         );
 
-        await tx
-          .update(cuotas_credito)
-          .set({ pagado: false })
-          .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+        if (pago.cuota_id !== null) {
+          await tx
+            .update(cuotas_credito)
+            .set({ pagado: false })
+            .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+        }
 
         console.log("✅ Cuota marcada como NO pagada");
 
@@ -347,10 +349,12 @@ export const reversePayment = async ({ body, set }: any) => {
         console.log("✅ Boletas eliminadas");
       } else {
         // Pago parcial - verificar si es el único registro de la cuota
-        const [{ count: cantidadPagos }] = await tx
-          .select({ count: sql<number>`COUNT(*)` })
-          .from(pagos_credito)
-          .where(eq(pagos_credito.cuota_id, pago.cuota_id));
+        const cantidadPagos = pago.cuota_id === null
+          ? 0
+          : (await tx
+              .select({ count: sql<number>`COUNT(*)` })
+              .from(pagos_credito)
+              .where(eq(pagos_credito.cuota_id, pago.cuota_id)))[0].count;
 
         await tx.delete(boletas).where(eq(boletas.pago_id, pago_id));
         console.log("✅ Boletas eliminadas");
@@ -563,16 +567,18 @@ export const reversePayment = async ({ body, set }: any) => {
         console.log("\n🧹 ========== LIMPIANDO PAGOS DUPLICADOS ==========");
 
         // Primero obtener los IDs de pagos duplicados
-        const pagosDuplicadosIds = await tx
-          .select({ pago_id: pagos_credito.pago_id })
-          .from(pagos_credito)
-          .where(
-            and(
-              eq(pagos_credito.cuota_id, pago.cuota_id),
-              eq(pagos_credito.credito_id, credito_id),
-              not(eq(pagos_credito.pago_id, pago_id))
-            )
-          );
+        const pagosDuplicadosIds = pago.cuota_id === null
+          ? []
+          : await tx
+              .select({ pago_id: pagos_credito.pago_id })
+              .from(pagos_credito)
+              .where(
+                and(
+                  eq(pagos_credito.cuota_id, pago.cuota_id),
+                  eq(pagos_credito.credito_id, credito_id),
+                  not(eq(pagos_credito.pago_id, pago_id))
+                )
+              );
 
         const ids = pagosDuplicadosIds.map((p) => p.pago_id);
 

--- a/apps/cartera-back/src/controllers/updateDueDate.ts
+++ b/apps/cartera-back/src/controllers/updateDueDate.ts
@@ -218,9 +218,7 @@ export const updateDueDates = async ({
           );
 
           // Solo actualizar si la fecha cambió
-          const fechaOriginalStr = typeof fechaOriginal === "string"
-            ? fechaOriginal
-            : `${fechaOriginal.getFullYear()}-${(fechaOriginal.getMonth() + 1).toString().padStart(2, "0")}-${fechaOriginal.getDate().toString().padStart(2, "0")}`;
+          const fechaOriginalStr = fechaOriginal;
 
           if (nuevaFecha !== fechaOriginalStr) {
             // Actualizar cuotas_credito
@@ -363,9 +361,7 @@ export const fixCreditosWithoutFebruary = async ({
 
       if (ultimaCuotaPagada) {
         const fecha = ultimaCuotaPagada.fecha_vencimiento;
-        const dia = typeof fecha === "string"
-          ? parseInt(fecha.split("-")[2], 10)
-          : fecha.getDate();
+        const dia = parseInt(fecha.split("-")[2], 10);
 
         // Si el día es 28 o 29, probablemente es un ajuste de febrero, usar 30
         const diaPago = dia >= 28 && dia <= 29 ? 30 : dia;
@@ -497,9 +493,7 @@ export const cambiarFechaInicio = async ({
       return { success: false, message: "El crédito no tiene cuota 1" };
     }
 
-    const fechaAnterior = typeof cuotaUno.fecha_vencimiento === "string"
-      ? cuotaUno.fecha_vencimiento
-      : `${cuotaUno.fecha_vencimiento.getFullYear()}-${(cuotaUno.fecha_vencimiento.getMonth() + 1).toString().padStart(2, "0")}-${cuotaUno.fecha_vencimiento.getDate().toString().padStart(2, "0")}`;
+    const fechaAnterior = cuotaUno.fecha_vencimiento;
 
     await db.insert(historial_cambio_fecha).values({
       credito_id: creditoDb.credito_id,
@@ -528,9 +522,7 @@ export const cambiarFechaInicio = async ({
         diaInicio
       );
 
-      const fechaOriginalStr = typeof cuota.fecha_vencimiento === "string"
-        ? cuota.fecha_vencimiento
-        : `${cuota.fecha_vencimiento.getFullYear()}-${(cuota.fecha_vencimiento.getMonth() + 1).toString().padStart(2, "0")}-${cuota.fecha_vencimiento.getDate().toString().padStart(2, "0")}`;
+      const fechaOriginalStr = cuota.fecha_vencimiento;
 
       if (nuevaFecha !== fechaOriginalStr) {
         // Actualizar cuotas_credito

--- a/apps/cartera-back/src/migration/migration.ts
+++ b/apps/cartera-back/src/migration/migration.ts
@@ -86,6 +86,9 @@ export async function mapPrestamoDetalleToCredito(
     : 0;
 
   const advisor = await findOrCreateAdvisorByName(excelRow?.Asesor || "", true);
+  if (!advisor) {
+    throw new Error(`No se pudo encontrar o crear asesor: ${excelRow?.Asesor || ""}`);
+  }
 
   const realPorcentaje = porcentaje_interes.mul(100).toFixed(2);
 

--- a/apps/cartera-back/src/migration/migrationCredits.ts
+++ b/apps/cartera-back/src/migration/migrationCredits.ts
@@ -206,6 +206,9 @@ const membresias_pago = toBigExcel(obtenerMembresias(excelRow), 0);
   );
 
   const advisor = await findOrCreateAdvisorByName(excelRow?.Asesor || "", true);
+  if (!advisor) {
+    throw new Error(`No se pudo encontrar o crear asesor: ${excelRow?.Asesor || ""}`);
+  }
 
   const realPorcentaje = porcentaje_interes.mul(100).toFixed(2);
 

--- a/apps/cartera-back/src/routers/abonosCapital.ts
+++ b/apps/cartera-back/src/routers/abonosCapital.ts
@@ -17,6 +17,7 @@ export const abonosCapitalRouter = new Elysia({ prefix: "/api/abonos-capital" })
     {
       body: t.Object({
         credito_id: t.Number(),
+        inversionista_id: t.Number(),
         monto: t.String(),
         tipo: t.Union([t.Literal("CANCELACION"), t.Literal("CAPITAL")]),
         liquidado: t.Optional(t.Boolean()),

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -22,6 +22,7 @@ import { eq, desc, and, sql, gte, lte } from "drizzle-orm";
 import ExcelJS from "exceljs";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { NITSoapClient } from "../cofidi/nitGenerator";
+import type { DTERequest } from "../cofidi/types";
 import {
   SAT_CONFIG,
   CLUB_CASHIN_CONFIG,
@@ -50,6 +51,11 @@ const EMISORES_CONFIG = {
 } as const;
 
 type EmisorKey = keyof typeof EMISORES_CONFIG;
+type FacturadorConfig = Pick<DTERequest, "emisor" | "tipoDocumento" | "codigoMoneda" | "frases">;
+type FacturarGenericoItem = {
+  monto: number;
+  rubro: string;
+};
 
 // 🔥 Mapa inverso: NIT emisor → config (para anulación automática)
 const EMISOR_POR_NIT: Record<string, { config: typeof CLUB_CASHIN_CONFIG; satConfig: typeof SAT_CONFIG }> = {};
@@ -1378,6 +1384,7 @@ if (facturasExistentes.length > 0) {
     const emisoresParaIntentar = Object.entries(EMISORES_CONFIG);
     let resultado: any = null;
     let emisorUsado = "";
+    let xmlAnulacion = "";
 
     for (const [emisorKey, emisorConf] of emisoresParaIntentar) {
       const nitEmisor = emisorConf.config.emisor.nit;
@@ -1400,6 +1407,7 @@ if (facturasExistentes.length > 0) {
 </dte:GTAnulacionDocumento>`;
 
       const xmlBase64Emisor = Buffer.from(xmlAnulacionEmisor, 'utf-8').toString('base64');
+      xmlAnulacion = xmlAnulacionEmisor;
 
       const satClient = new SATClientService(
         {
@@ -2297,7 +2305,7 @@ if (facturasExistentes.length > 0) {
         };
 
         let totalFactura = new Big(0);
-        const itemsFactura = itemsInput.map((item, index) => {
+        const itemsFactura = itemsInput.map((item: FacturarGenericoItem, index: number) => {
           const calc = calcularIvaExacto(item.monto);
           totalFactura = totalFactura.plus(calc.total);
 
@@ -2515,7 +2523,7 @@ if (facturasExistentes.length > 0) {
               const logoResponse = await fetch(logoUrl);
               const logoBuffer = Buffer.from(await logoResponse.arrayBuffer());
               const logoImage = workbook.addImage({
-                buffer: logoBuffer,
+                base64: `data:image/png;base64,${logoBuffer.toString("base64")}`,
                 extension: "png",
               });
               sheet.addImage(logoImage, {
@@ -2762,7 +2770,7 @@ async function certificarFacturaHelper({
   items: any[];
   complementos: any[];
   created_by?: number;
-  customConfig?: typeof CLUB_CASHIN_CONFIG;
+  customConfig?: FacturadorConfig;
   customSatConfig?: {
     requestor: string;
     user: string;

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -331,9 +331,9 @@ export const creditRouter = new Elysia()
         return { message: "Parámetros 'mes' y/o 'anio' inválidos." };
       }
 
-      const sifcosLimpios = numeros_credito_sifco
-        ?.map((s) => s.trim())
-        .filter((s) => s.length > 0);
+      const sifcosLimpios = (numeros_credito_sifco as string[] | undefined)
+        ?.map((s: string) => s.trim())
+        .filter((s: string) => s.length > 0);
 
       try {
         if (excel) {
@@ -1233,7 +1233,9 @@ export const creditRouter = new Elysia()
   // ========================================
   // ENDPOINT: ACTUALIZAR FECHAS DE VENCIMIENTO
   // ========================================
-  .post("/update-due-dates", updateDueDates, {
+  .post("/update-due-dates", async ({ body, set }) =>
+    updateDueDates({ body, set: set as { status: number } }),
+  {
     body: t.Object({
       creditos: t.Array(
         t.Object({
@@ -1266,7 +1268,9 @@ export const creditRouter = new Elysia()
       tags: ["Créditos", "Cuotas"],
     },
   })
-  .post("/update-single-due-date", updateSingleDueDate, {
+  .post("/update-single-due-date", async ({ body, set }) =>
+    updateSingleDueDate({ body, set: set as { status: number } }),
+  {
     body: t.Object({
       numero_credito_sifco: t.String({ minLength: 1 }),
       dia_pago: t.Number({ minimum: 1, maximum: 31 }),

--- a/apps/cartera-back/src/routers/migration.ts
+++ b/apps/cartera-back/src/routers/migration.ts
@@ -367,8 +367,18 @@ export const sifcoRouter = new Elysia()
   async ({ body }) => {
     const { numeroCredito, inversionistasData } = body;
 
+    type InversionistaPagoInput = {
+      inversionista: string;
+      capital: string | number;
+      porcentajeCashIn: string | number;
+      porcentajeInversionista: string | number;
+      porcentaje: string | number;
+      cuota?: string | number;
+      cuotaInversionista?: string | number;
+    };
+
     // Transform inversionistasData to match expected type
-    const inversionistasDataTyped = inversionistasData.map((inv) => ({
+    const inversionistasDataTyped = inversionistasData.map((inv: InversionistaPagoInput) => ({
       inversionista: inv.inversionista,
       capital: inv.capital,
       porcentajeCashIn: inv.porcentajeCashIn,

--- a/apps/cartera-back/src/routers/recalculateFromJson.ts
+++ b/apps/cartera-back/src/routers/recalculateFromJson.ts
@@ -239,7 +239,7 @@ export const recalculateFromJsonRouter = new Elysia({ prefix: "/recalculate" })
         // Construir el formato esperado
         const creditoAgrupado = {
           numeroCredito,
-          creditos: inversionistas.map((inv, idx) => ({
+          creditos: inversionistas.map((inv: { nombre: string; capitalRestante: number }, idx: number) => ({
             numeroCredito: idx === 0 ? numeroCredito : `${numeroCredito}_${idx + 1}`,
             capitalRestante: inv.capitalRestante.toString(),
             inversionista: inv.nombre,

--- a/apps/cartera-back/src/utils/interface.ts
+++ b/apps/cartera-back/src/utils/interface.ts
@@ -151,6 +151,9 @@ export type CuotaExcelRow = {
   capital_pendiente: string; // numeric -> string
   total_cancelar: string; // numeric -> string
   fecha_vencimiento: string; // YYYY-MM-DD
+  seguro: string;
+  gps: string;
+  membresias: string;
 };
 
 // DTO principal
@@ -166,6 +169,16 @@ export interface GetCreditDTO {
     observaciones: string | null;
   };
   closure: ClosureInfo;
+  totales?: {
+    total_interes: string;
+    total_seguro: string;
+    total_membresias: string;
+    total_mora: string;
+    total_otros: string;
+    total_gps: string;
+    total_cuotas_atrasadas: string;
+    gran_total: string;
+  };
   cuotas_atrasadas: {
     total: number;
     items: CuotaExcelRow[];


### PR DESCRIPTION
## Summary
- Fix nullable Drizzle comparisons and DTO mismatches that blocked cartera-back typechecking.
- Align report, migration, Cofidi, due-date, and abono-capital typings with runtime/schema shapes.
- Keep the PR stacked on `lralda` so the already-approved investor intent PR is not modified.

## Test Plan
- [x] bunx tsc --noEmit --pretty false
- [x] bun test src/controllers/investor.test.ts