### PR TITLE
feat(cartera): bulk transfer Excel reports (ACH y terceros)

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -28,7 +28,7 @@ import {
   abonos_capital,
 } from "../database/db/schema";
 import { getSignedDocumentUrl } from "../utils/functions/uploadsFiles";
-import { eq, and, sql, inArray, ilike, like, desc, count, SQL, isNull } from "drizzle-orm";
+import { eq, and, or, sql, inArray, ilike, like, desc, count, SQL, isNull, isNotNull, ne } from "drizzle-orm";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import Big from "big.js";
 import { sendLiquidationEmail, sendPlainEmail, sendSimpleEmail } from "@cci/email";
@@ -6196,6 +6196,333 @@ export async function resumenGlobalLiquidaciones(
   }
 
   return result;
+}
+
+const ID_BANCO_TRANSFERENCIA_NO_ACH = "45";
+
+const NOMBRES_MES_ES = [
+  "Enero",
+  "Febrero",
+  "Marzo",
+  "Abril",
+  "Mayo",
+  "Junio",
+  "Julio",
+  "Agosto",
+  "Septiembre",
+  "Octubre",
+  "Noviembre",
+  "Diciembre",
+];
+
+const CUENTA_MONETARIA_LARGO = 11;
+
+function parseCuentaMonetaria(numeroCuenta: string | null | undefined): {
+  agencia: string;
+  correlativo: string;
+  digito: string;
+  valido: boolean;
+} {
+  const limpia = (numeroCuenta ?? "").replace(/\D/g, "");
+  const valido = limpia.length === CUENTA_MONETARIA_LARGO;
+  return {
+    agencia: limpia.slice(0, 3),
+    correlativo: limpia.slice(3, -1),
+    digito: limpia.slice(-1),
+    valido,
+  };
+}
+
+function mapTipoCuentaCodigo(tipo: string | null | undefined): {
+  codigo: number | "";
+  valido: boolean;
+} {
+  if (!tipo) return { codigo: "", valido: false };
+  const upper = tipo.toUpperCase();
+  if (upper.includes("MONETARIA")) return { codigo: 1, valido: true };
+  if (upper.includes("AHORRO")) return { codigo: 2, valido: true };
+  return { codigo: "", valido: false };
+}
+
+function mapMonedaCodigo(moneda: string | null | undefined): 1 | 2 {
+  return moneda === "dolares" ? 2 : 1;
+}
+
+export type MonedaFiltroTransferencias = "quetzales" | "dolar" | "todas";
+
+export async function resumenTransferencias(
+  mes: number,
+  anio: number,
+  ach: boolean,
+  monedaFiltro: MonedaFiltroTransferencias = "todas"
+): Promise<{ success: boolean; url: string; filename: string }> {
+  const condicionesBanco = ach
+    ? and(
+        eq(inversionistas.permite_distribucion, false),
+        or(
+          isNull(bancos.id_banco_transferencia),
+          ne(bancos.id_banco_transferencia, ID_BANCO_TRANSFERENCIA_NO_ACH)
+        )
+      )
+    : and(
+        eq(inversionistas.permite_distribucion, false),
+        eq(bancos.id_banco_transferencia, ID_BANCO_TRANSFERENCIA_NO_ACH)
+      );
+
+  const inversionistasFiltro = await db
+    .select({
+      inversionista_id: inversionistas.inversionista_id,
+      id_banco_transferencia: bancos.id_banco_transferencia,
+    })
+    .from(inversionistas)
+    .innerJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
+    .where(condicionesBanco);
+
+  const bancoTransfMap = new Map(
+    inversionistasFiltro.map((i) => [i.inversionista_id, i.id_banco_transferencia ?? ""])
+  );
+
+  if (bancoTransfMap.size === 0) {
+    return ach
+      ? generateAchTransferenciasWorkbook([], mes, anio, bancoTransfMap)
+      : generateTransferenciasWorkbook([], mes, anio);
+  }
+
+  const resumen = await consultarResumenGlobalPorEstadoPago(
+    "NO_LIQUIDADO",
+    undefined,
+    mes,
+    anio,
+    true
+  );
+
+  let monedaPermitida: "quetzales" | "dolares" | null = null;
+  if (monedaFiltro === "quetzales") monedaPermitida = "quetzales";
+  else if (monedaFiltro === "dolar") monedaPermitida = "dolares";
+
+  const filtrados = resumen.filter((r) => {
+    if (!bancoTransfMap.has(r.inversionista_id)) return false;
+    if (monedaPermitida && r.moneda !== monedaPermitida) return false;
+    return true;
+  });
+  const filas = filtrados.map((inv) => mapResumenRow(inv, null, null));
+
+  return ach
+    ? generateAchTransferenciasWorkbook(filas, mes, anio, bancoTransfMap)
+    : generateTransferenciasWorkbook(filas, mes, anio);
+}
+
+async function generateAchTransferenciasWorkbook(
+  rows: InversionistaResumen[],
+  mes: number,
+  anio: number,
+  bancoTransfMap: Map<number, string>
+): Promise<{ success: boolean; url: string; filename: string }> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = "Club Cashin";
+  workbook.created = new Date();
+  const sheet = workbook.addWorksheet("Transferencias ACH");
+
+  const RED_FILL = "FFFFC7CE";
+  const HEADER_FILL = "FF1E40AF";
+  const HEADER_BORDER = "FF0F1B4C";
+  const nombreMes = NOMBRES_MES_ES[mes - 1] ?? `Mes ${mes}`;
+
+  const headers = [
+    "Nombre",
+    "Id Participante",
+    "Cuenta credito / debito",
+    "Tipo Cuenta",
+    "Moneda",
+    "Banco",
+    "Descripcion Corta",
+    "Adenda",
+    "Valor Q.",
+  ];
+  sheet.columns = [
+    { width: 28 }, // Nombre
+    { width: 18 }, // Id Participante
+    { width: 24 }, // Cuenta crédito / débito
+    { width: 14 }, // Tipo Cuenta
+    { width: 12 }, // Moneda
+    { width: 10 }, // Banco
+    { width: 24 }, // Descripción Corta
+    { width: 60 }, // Adenda
+    { width: 16 }, // Valor Q.
+  ];
+
+  const headerRow = sheet.addRow(headers);
+  headerRow.height = 24;
+  headerRow.font = { bold: true, color: { argb: "FFFFFFFF" }, size: 11 };
+  headerRow.alignment = { horizontal: "center", vertical: "middle", wrapText: true };
+  headerRow.eachCell((cell) => {
+    cell.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: HEADER_FILL },
+    };
+    cell.border = {
+      top: { style: "thin", color: { argb: HEADER_BORDER } },
+      bottom: { style: "medium", color: { argb: HEADER_BORDER } },
+      left: { style: "thin", color: { argb: HEADER_BORDER } },
+      right: { style: "thin", color: { argb: HEADER_BORDER } },
+    };
+  });
+
+  rows.forEach((inv) => {
+    const valor = Number(inv.total_cuota) || 0;
+    if (valor === 0) return;
+
+    const concepto = `Liquidación ${nombreMes} ${anio}, Club CashIn S.A`;
+    const adenda = concepto.slice(0, 80);
+    const tipoCuenta = mapTipoCuentaCodigo(inv.tipo_cuenta);
+    const moneda = mapMonedaCodigo(inv.moneda);
+    const banco = bancoTransfMap.get(inv.inversionista_id) ?? "";
+    const cuentaLimpia = (inv.numero_cuenta ?? "").replace(/\D/g, "");
+
+    const row = sheet.addRow([
+      inv.nombre,
+      "",
+      cuentaLimpia,
+      tipoCuenta.codigo,
+      moneda,
+      banco,
+      concepto,
+      adenda,
+      valor,
+    ]);
+    row.getCell(9).numFmt = "0.00";
+
+    const filaInvalida = !tipoCuenta.valido || !banco;
+    if (filaInvalida) {
+      row.eachCell({ includeEmpty: true }, (cell) => {
+        cell.fill = {
+          type: "pattern",
+          pattern: "solid",
+          fgColor: { argb: RED_FILL },
+        };
+      });
+    }
+  });
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  const filename = `transferencias_ach_${anio}_${String(mes).padStart(2, "0")}_${Date.now()}.xlsx`;
+  const s3 = new S3Client({
+    endpoint: process.env.BUCKET_REPORTS_URL,
+    region: "auto",
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID as string,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY as string,
+    },
+  });
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: process.env.BUCKET_REPORTS,
+      Key: filename,
+      Body: new Uint8Array(buffer),
+      ContentType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    })
+  );
+
+  return {
+    success: true,
+    url: `${process.env.URL_PUBLIC_R2_REPORTS}/${filename}`,
+    filename,
+  };
+}
+
+async function generateTransferenciasWorkbook(
+  rows: InversionistaResumen[],
+  mes: number,
+  anio: number
+): Promise<{ success: boolean; url: string; filename: string }> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = "Club Cashin";
+  workbook.created = new Date();
+  const sheet = workbook.addWorksheet("Transferencias");
+
+  const RED_FILL = "FFFFC7CE";
+  const HEADER_FILL = "FF1E40AF";
+  const HEADER_BORDER = "FF0F1B4C";
+  const nombreMes = NOMBRES_MES_ES[mes - 1] ?? `Mes ${mes}`;
+
+  const headers = ["Agencia", "Correlativo", "Dígito", "Moneda", "Concepto", "Valor"];
+  sheet.columns = [
+    { width: 12 }, // Agencia
+    { width: 16 }, // Correlativo
+    { width: 10 }, // Dígito
+    { width: 12 }, // Moneda
+    { width: 60 }, // Concepto
+    { width: 16 }, // Valor
+  ];
+  const headerRow = sheet.addRow(headers);
+  headerRow.height = 24;
+  headerRow.font = { bold: true, color: { argb: "FFFFFFFF" }, size: 11 };
+  headerRow.alignment = { horizontal: "center", vertical: "middle" };
+  headerRow.eachCell((cell) => {
+    cell.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: HEADER_FILL },
+    };
+    cell.border = {
+      top: { style: "thin", color: { argb: HEADER_BORDER } },
+      bottom: { style: "medium", color: { argb: HEADER_BORDER } },
+      left: { style: "thin", color: { argb: HEADER_BORDER } },
+      right: { style: "thin", color: { argb: HEADER_BORDER } },
+    };
+  });
+
+  rows.forEach((inv) => {
+    const valor = Number(inv.total_cuota) || 0;
+    if (valor === 0) return;
+
+    const { agencia, correlativo, digito, valido } = parseCuentaMonetaria(inv.numero_cuenta);
+    const concepto = `Liquidación ${nombreMes} ${anio} - ${inv.nombre}, Club CashIn S.A`;
+    const moneda = mapMonedaCodigo(inv.moneda);
+
+    const row = sheet.addRow([agencia, correlativo, digito, moneda, concepto, valor]);
+    row.getCell(6).numFmt = "0.00";
+
+    if (!valido) {
+      row.eachCell({ includeEmpty: true }, (cell) => {
+        cell.fill = {
+          type: "pattern",
+          pattern: "solid",
+          fgColor: { argb: RED_FILL },
+        };
+      });
+    }
+  });
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  const filename = `transferencias_${anio}_${String(mes).padStart(2, "0")}_${Date.now()}.xlsx`;
+  const s3 = new S3Client({
+    endpoint: process.env.BUCKET_REPORTS_URL,
+    region: "auto",
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID as string,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY as string,
+    },
+  });
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: process.env.BUCKET_REPORTS,
+      Key: filename,
+      Body: new Uint8Array(buffer),
+      ContentType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    })
+  );
+
+  return {
+    success: true,
+    url: `${process.env.URL_PUBLIC_R2_REPORTS}/${filename}`,
+    filename,
+  };
 }
 
 export const isNullorEmpty = (value: string | number | null | undefined): value is null | undefined | "" => {

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -6275,7 +6275,7 @@ export async function resumenTransferencias(
       id_banco_transferencia: bancos.id_banco_transferencia,
     })
     .from(inversionistas)
-    .innerJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
+    .leftJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
     .where(condicionesBanco);
 
   const bancoTransfMap = new Map(

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -569,6 +569,7 @@
   export const bancos = customSchema.table('bancos', {
     banco_id: serial('banco_id').primaryKey(),
     nombre: varchar('nombre', { length: 100 }).notNull().unique(),
+    id_banco_transferencia: varchar('id_banco_transferencia', { length: 50 }).unique(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   });

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -12,6 +12,7 @@ import {
   exitInvestor,
   resumenGlobalInversionistas,
   resumenGlobalLiquidaciones,
+  resumenTransferencias,
   getLiquidaciones,
   getInvestorPerformance,
   getInvestorTotalsGlobales,
@@ -745,6 +746,51 @@ export const inversionistasRouter = new Elysia()
       };
     }
   })
+  .get(
+    "/resumen-transferencias",
+    async ({ query, set }) => {
+      const { mes, anio, ach, moneda } = query;
+
+      const mesNum = Number(mes);
+      const anioNum = Number(anio);
+
+      if (!Number.isFinite(mesNum) || mesNum < 1 || mesNum > 12) {
+        set.status = 400;
+        return { message: "El parámetro 'mes' es obligatorio y debe estar entre 1 y 12." };
+      }
+      if (!Number.isFinite(anioNum) || anioNum < 2000) {
+        set.status = 400;
+        return { message: "El parámetro 'anio' es obligatorio y debe ser un año válido." };
+      }
+
+      let monedaFiltro: "quetzales" | "dolar" | "todas" = "todas";
+      if (moneda === "quetzales" || moneda === "dolar") {
+        monedaFiltro = moneda;
+      } else if (moneda) {
+        set.status = 400;
+        return { message: "El parámetro 'moneda' debe ser 'quetzales' o 'dolar'." };
+      }
+
+      try {
+        return await resumenTransferencias(mesNum, anioNum, ach === "true", monedaFiltro);
+      } catch (error) {
+        console.error("[investor/resumen-transferencias] Error:", error);
+        set.status = 500;
+        return {
+          message: "Error al generar el reporte de transferencias",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    {
+      query: t.Object({
+        mes: t.String(),
+        anio: t.String(),
+        ach: t.Optional(t.String()),
+        moneda: t.Optional(t.String()),
+      }),
+    }
+  )
   .get(
     "/resumen-global",
     async ({ query }) => {

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -753,6 +753,42 @@ app.get("/api/accounting/resumen-global-excel", async (c) => {
 	}
 });
 
+// Obtener URL del Excel de transferencias (ACH / no-ACH)
+app.get("/api/accounting/resumen-transferencias-excel", async (c) => {
+	try {
+		const context = await createContext({ context: c });
+		if (!context.session?.user?.id) {
+			return c.json({ error: "No autorizado" }, 401);
+		}
+
+		const mes = c.req.query("mes");
+		const anio = c.req.query("anio");
+		const ach = c.req.query("ach");
+		const moneda = c.req.query("moneda");
+
+		if (!mes || !anio) {
+			return c.json({ error: "Los parámetros 'mes' y 'anio' son obligatorios" }, 400);
+		}
+
+		const monedaParam: "quetzales" | "dolar" | undefined =
+			moneda === "quetzales" || moneda === "dolar" ? moneda : undefined;
+
+		const { carteraBackClient } = await import(
+			"./services/cartera-back-client"
+		);
+		const result = await carteraBackClient.getResumenTransferenciasExcel({
+			mes: Number(mes),
+			anio: Number(anio),
+			ach: ach === "true",
+			moneda: monedaParam,
+		});
+		return c.json(result);
+	} catch (err: any) {
+		console.error("[ResumenTransferenciasExcel] Error:", err);
+		return c.json({ error: err.message || "Error al descargar Excel" }, 500);
+	}
+});
+
 // Upload boleta de inversionista a cartera-back
 app.post("/api/accounting/upload-boleta", async (c) => {
 	try {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -880,6 +880,32 @@ export class CarteraBackClient {
 		return response;
 	}
 
+	async getResumenTransferenciasExcel(filters: {
+		mes: number;
+		anio: number;
+		ach: boolean;
+		moneda?: "quetzales" | "dolar";
+	}): Promise<{ success: boolean; url: string; filename: string }> {
+		const queryParams = new URLSearchParams();
+		queryParams.set("mes", String(filters.mes));
+		queryParams.set("anio", String(filters.anio));
+		queryParams.set("ach", filters.ach ? "true" : "false");
+		if (filters.moneda) {
+			queryParams.set("moneda", filters.moneda);
+		}
+
+		const response = await this.request<{
+			success: boolean;
+			url: string;
+			filename: string;
+		}>(
+			`/resumen-transferencias?${queryParams.toString()}`,
+			{ method: "GET" },
+			false,
+		);
+		return response;
+	}
+
 	async uploadFile(
 		file: File | Blob,
 		filename: string,

--- a/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
+++ b/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
@@ -10,6 +10,7 @@ import {
 	FileCheck,
 	Loader2,
 	Search,
+	Send,
 	Upload,
 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -34,6 +35,14 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -552,6 +561,9 @@ function PagarInversionistas() {
 	const [search, setSearch] = useState("");
 	const [page, setPage] = useState(1);
 	const [downloadingExcel, setDownloadingExcel] = useState(false);
+	const [downloadingTransferencia, setDownloadingTransferencia] = useState<
+		null | "ach" | "no-ach"
+	>(null);
 	const [estadoBoletaFilter, setEstadoBoletaFilter] =
 		useState<EstadoBoletaFilter>("all");
 	const [mesFiltro, setMesFiltro] = useState(today.getMonth() + 1);
@@ -570,6 +582,42 @@ function PagarInversionistas() {
 		}),
 		[anioFiltro, estadoBoletaFilter, mesFiltro, requiresPeriodo],
 	);
+
+	const handleDownloadTransferencias = async (
+		ach: boolean,
+		moneda?: "quetzales" | "dolar",
+	) => {
+		const key = ach ? "ach" : "no-ach";
+		setDownloadingTransferencia(key);
+		try {
+			const serverUrl = import.meta.env.VITE_SERVER_URL;
+			const queryParams = new URLSearchParams({
+				mes: String(mesFiltro),
+				anio: String(anioFiltro),
+				ach: ach ? "true" : "false",
+			});
+			if (moneda) queryParams.set("moneda", moneda);
+
+			const res = await fetch(
+				`${serverUrl}/api/accounting/resumen-transferencias-excel?${queryParams.toString()}`,
+				{ credentials: "include" },
+			);
+			if (!res.ok) {
+				const err = await res.json();
+				throw new Error(err.error || "Error al descargar");
+			}
+			const data = await res.json();
+			if (!data.success || !data.url) {
+				throw new Error("No se pudo generar el Excel");
+			}
+			window.open(data.url, "_blank");
+			toast.success("Excel de transferencias descargado");
+		} catch (err: any) {
+			toast.error(err.message || "Error al descargar Excel");
+		} finally {
+			setDownloadingTransferencia(null);
+		}
+	};
 
 	const handleDownloadExcel = async () => {
 		setDownloadingExcel(true);
@@ -694,20 +742,36 @@ function PagarInversionistas() {
 						Resumen global de pagos pendientes
 					</p>
 				</div>
-				<Button
-					variant="outline"
-					size="sm"
-					className="gap-2"
-					disabled={downloadingExcel}
-					onClick={handleDownloadExcel}
-				>
-					{downloadingExcel ? (
-						<Loader2 className="h-4 w-4 animate-spin" />
-					) : (
-						<Download className="h-4 w-4" />
-					)}
-					Exportar Excel
-				</Button>
+				<div className="flex flex-wrap gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						className="gap-2"
+						disabled={downloadingExcel}
+						onClick={handleDownloadExcel}
+					>
+						{downloadingExcel ? (
+							<Loader2 className="h-4 w-4 animate-spin" />
+						) : (
+							<Download className="h-4 w-4" />
+						)}
+						Exportar Excel
+					</Button>
+
+					<TransferenciasDropdown
+						label="Transferencia a Terceros"
+						loading={downloadingTransferencia === "no-ach"}
+						disabled={downloadingTransferencia !== null}
+						onSelect={(moneda) => handleDownloadTransferencias(false, moneda)}
+					/>
+
+					<TransferenciasDropdown
+						label="Transferencias ACH"
+						loading={downloadingTransferencia === "ach"}
+						disabled={downloadingTransferencia !== null}
+						onSelect={(moneda) => handleDownloadTransferencias(true, moneda)}
+					/>
+				</div>
 			</div>
 
 			{/* Stats */}
@@ -887,6 +951,51 @@ function StatCard({
 				</div>
 			</CardContent>
 		</Card>
+	);
+}
+
+function TransferenciasDropdown({
+	label,
+	loading,
+	disabled,
+	onSelect,
+}: {
+	label: string;
+	loading: boolean;
+	disabled: boolean;
+	onSelect: (moneda?: "quetzales" | "dolar") => void;
+}) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="outline"
+					size="sm"
+					className="gap-2"
+					disabled={disabled}
+				>
+					{loading ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<Send className="h-4 w-4" />
+					)}
+					{label}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuLabel>Seleccionar moneda</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem onSelect={() => onSelect("quetzales")}>
+					Quetzales (Q)
+				</DropdownMenuItem>
+				<DropdownMenuItem onSelect={() => onSelect("dolar")}>
+					Dólares ($)
+				</DropdownMenuItem>
+				<DropdownMenuItem onSelect={() => onSelect(undefined)}>
+					Ambas
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 


### PR DESCRIPTION
## Summary
- Nuevo endpoint `GET /resumen-transferencias` en cartera-back que genera el Excel listo para subir al banco con los pagos pendientes de los inversionistas (filtrable por mes / año / modalidad / moneda).
- Dos formatos de salida según la modalidad: **Transferencia a Terceros** (no-ACH, banco interno con `id_banco_transferencia = '45'`) y **ACH** (resto de bancos), cada uno con las columnas exactas que pide la plantilla del banco.
- Se agrega la columna `id_banco_transferencia` a `bancos` (con su ALTER) para mapear el catálogo del banco emisor.
- El CRM (`/accounting/pay-investors`) expone los dos reportes como dropdowns con tres opciones: **Quetzales (Q) / Dólares ($) / Ambas**, reusando el patrón existente del botón "Exportar Excel" (server CRM → cartera-back-client → cartera-back → R2 → URL pública).

### Detalles relevantes

**Terceros**
Columnas: `Agencia | Correlativo | Dígito | Moneda | Concepto | Valor`. La cuenta se parsea con agencia (3 dígitos) + correlativo + dígito; si la cuenta no tiene 11 dígitos limpios, la fila se pinta en rojo.

**ACH**
Columnas: `Nombre | Id Participante | Cuenta credito / debito | Tipo Cuenta | Moneda | Banco | Descripcion Corta | Adenda | Valor Q.`. La cuenta se limpia (sin guiones / espacios). `Tipo Cuenta` se infiere por `includes("MONETARIA")` → 1, `includes("AHORRO")` → 2, otro → fila roja. `Moneda` mapea `quetzales` → 1, `dolares` → 2. `Banco` toma el `id_banco_transferencia` del banco asociado; si está vacío también pinta la fila en rojo.

**Concepto**
- Terceros: `Liquidación <Mes> <Anio> - <nombre>, Club CashIn S.A`
- ACH: `Liquidaciones <Mes> <Anio>, Club CashIn S.A` (adenda truncada a 80 chars).

Las filas con `total_cuota = 0` se omiten en ambos formatos.

### ALTER pendiente
```sql
ALTER TABLE cartera.bancos
  ADD COLUMN id_banco_transferencia VARCHAR(50);

ALTER TABLE cartera.bancos
  ADD CONSTRAINT bancos_id_banco_transferencia_unique UNIQUE (id_banco_transferencia);
```

## Test plan
- [ ] Aplicar el ALTER en el ambiente de staging y poblar `id_banco_transferencia` para los bancos correspondientes (45 = banco interno; resto = ACH).
- [ ] `GET /resumen-transferencias?mes=5&anio=2026&ach=false` devuelve el Excel de terceros con cuentas parseadas correctamente y sin filas con valor 0.
- [ ] `GET /resumen-transferencias?mes=5&anio=2026&ach=true` devuelve el Excel ACH y marca en rojo las filas con tipo de cuenta inválido o sin `id_banco_transferencia`.
- [ ] Filtros `moneda=quetzales` y `moneda=dolar` regresan únicamente los inversionistas de esa moneda; sin el param regresa ambas.
- [ ] En el CRM, los dos botones nuevos abren el dropdown con Q / $ / Ambas y descargan el Excel correcto en cada combinación.
- [ ] Los archivos se suben a R2 y la URL pública abre el .xlsx sin problema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)