### PR TITLE
feat: add devolucion_cube column to creditos schema and integrate int…

### DIFF
--- a/apps/cartera-back/drizzle/0001_add_requires_cube_to_creditos.sql
+++ b/apps/cartera-back/drizzle/0001_add_requires_cube_to_creditos.sql
@@ -1,0 +1,20 @@
+ALTER TABLE cartera.creditos
+ADD COLUMN IF NOT EXISTS devolucion_cube boolean NOT NULL DEFAULT false;
+
+-- Compatibilidad temporal si ya existía el nombre anterior
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'cartera'
+      AND table_name = 'creditos'
+      AND column_name = 'requires_cube'
+  ) THEN
+    ALTER TABLE cartera.creditos RENAME COLUMN requires_cube TO devolucion_cube;
+  END IF;
+EXCEPTION
+  WHEN duplicate_column THEN
+    -- Si ya existe devolucion_cube, solo ignora
+    NULL;
+END $$;

--- a/apps/cartera-back/src/controllers/devolucion.ts
+++ b/apps/cartera-back/src/controllers/devolucion.ts
@@ -1,0 +1,237 @@
+import { db } from "../database";
+import { creditos, historial_devolucion_credito, usuarios } from "../database/db/schema";
+import { eq, desc, sql, and, or, ilike } from "drizzle-orm";
+
+export async function listPendingDevolucion({ query, set }: any) {
+  try {
+    const page = parseInt(query.page || "1");
+    const limit = parseInt(query.limit || "10");
+    const offset = (page - 1) * limit;
+
+    const requestedStatusRaw = String(query.status || "PENDIENTE_AUTORIZACION").toUpperCase();
+    const requestedStatus =
+      requestedStatusRaw === "PENDIENTE_VERIFICACION" ||
+      requestedStatusRaw === "PENDIENTE_VERFICACION"
+        ? "PENDIENTE_AUTORIZACION"
+        : requestedStatusRaw;
+
+    const search = String(query.search || "").trim();
+
+    const whereClause = and(
+      eq(creditos.estado_devolucion, requestedStatus as any),
+      search
+        ? or(
+            ilike(usuarios.nombre, `%${search}%`),
+            ilike(creditos.numero_credito_sifco, `%${search}%`)
+          )
+        : undefined
+    );
+
+    const [totalResult] = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(creditos)
+      .leftJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+      .where(whereClause);
+
+    const total = Number(totalResult.count);
+    const totalPages = Math.ceil(total / limit);
+
+    const pendingCredits = await db
+      .select({
+        credito_id: creditos.credito_id,
+        numero_credito_sifco: creditos.numero_credito_sifco,
+        usuario_nombre: usuarios.nombre,
+        capital: creditos.capital,
+        cuota: creditos.cuota,
+        fecha_creacion: creditos.fecha_creacion,
+        estado_devolucion: creditos.estado_devolucion,
+        motivo_solicitud: sql<string | null>`(
+          SELECT h.motivo
+          FROM cartera.historial_devolucion_credito h
+          WHERE h.credito_id = ${creditos.credito_id}
+            AND h.estado_nuevo = 'PENDIENTE_AUTORIZACION'
+          ORDER BY h.created_at DESC
+          LIMIT 1
+        )`,
+      })
+      .from(creditos)
+      .leftJoin(usuarios, eq(usuarios.usuario_id, creditos.usuario_id))
+      .where(whereClause)
+      .orderBy(desc(creditos.fecha_creacion))
+      .limit(limit)
+      .offset(offset);
+
+    return {
+      success: true,
+      data: {
+        credits: pendingCredits,
+        pagination: { page, limit, total, totalPages },
+        status: requestedStatus,
+        search,
+      },
+    };
+  } catch (error) {
+    console.error("[listPendingDevolucion] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al obtener créditos pendientes de devolución",
+      error: String(error),
+    };
+  }
+}
+
+export async function aceptarDevolucion({ params, set }: any) {
+  try {
+    const { id: credito_id } = params;
+    const credito_id_num = parseInt(credito_id);
+
+    if (isNaN(credito_id_num)) {
+      set.status = 400;
+      return { message: "ID de crédito inválido" };
+    }
+
+    const [currentCredit] = await db
+      .select({ estado_devolucion: creditos.estado_devolucion })
+      .from(creditos)
+      .where(eq(creditos.credito_id, credito_id_num));
+
+    if (!currentCredit) {
+      set.status = 404;
+      return { message: "Crédito no encontrado" };
+    }
+
+    if (currentCredit.estado_devolucion !== "PENDIENTE_AUTORIZACION") {
+      set.status = 400;
+      return { message: "El crédito no está en estado pendiente de autorización" };
+    }
+
+    // Insertar log
+    await db.insert(historial_devolucion_credito).values({
+      credito_id: credito_id_num,
+      usuario_id: 1, // Placeholder para user_id autenticado
+      estado_anterior: currentCredit.estado_devolucion,
+      estado_nuevo: "VERIFICADO",
+      motivo: null, // Opcional para aprobación
+    });
+
+    // Actualizar crédito
+    await db
+      .update(creditos)
+      .set({ estado_devolucion: "VERIFICADO" })
+      .where(eq(creditos.credito_id, credito_id_num));
+
+    return {
+      success: true,
+      message: "Devolución aceptada y registrada correctamente",
+    };
+  } catch (error) {
+    console.error("[aceptarDevolucion] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al aceptar la devolución",
+      error: String(error),
+    };
+  }
+}
+
+export async function rechazarDevolucion({ params, body, set }: any) {
+  try {
+    const { id: credito_id } = params;
+    const { motivo } = body;
+    const credito_id_num = parseInt(credito_id);
+
+    if (isNaN(credito_id_num)) {
+      set.status = 400;
+      return { message: "ID de crédito inválido" };
+    }
+
+    if (!motivo || motivo.trim() === "") {
+      set.status = 400;
+      return { message: "Motivo de rechazo es obligatorio" };
+    }
+
+    const [currentCredit] = await db
+      .select({ estado_devolucion: creditos.estado_devolucion })
+      .from(creditos)
+      .where(eq(creditos.credito_id, credito_id_num));
+
+    if (!currentCredit) {
+      set.status = 404;
+      return { message: "Crédito no encontrado" };
+    }
+
+    if (currentCredit.estado_devolucion !== "PENDIENTE_AUTORIZACION") {
+      set.status = 400;
+      return { message: "El crédito no está en estado pendiente de autorización" };
+    }
+
+    // Insertar log
+    await db.insert(historial_devolucion_credito).values({
+      credito_id: credito_id_num,
+      usuario_id: 1, // Placeholder para user_id autenticado
+      estado_anterior: currentCredit.estado_devolucion,
+      estado_nuevo: "RECHAZADO",
+      motivo: motivo.trim(),
+    });
+
+    // Actualizar crédito
+    await db
+      .update(creditos)
+      .set({ estado_devolucion: "RECHAZADO" })
+      .where(eq(creditos.credito_id, credito_id_num));
+
+    return {
+      success: true,
+      message: "Devolución rechazada y registrada correctamente",
+    };
+  } catch (error) {
+    console.error("[rechazarDevolucion] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al rechazar la devolución",
+      error: String(error),
+    };
+  }
+}
+
+export async function getHistorialDevolucion({ params, set }: any) {
+  try {
+    const { id: credito_id } = params;
+    const credito_id_num = parseInt(credito_id);
+
+    if (isNaN(credito_id_num)) {
+      set.status = 400;
+      return { message: "ID de crédito inválido" };
+    }
+
+    const historial = await db
+      .select({
+        id: historial_devolucion_credito.id,
+        credito_id: historial_devolucion_credito.credito_id,
+        usuario_id: historial_devolucion_credito.usuario_id,
+        estado_anterior: historial_devolucion_credito.estado_anterior,
+        estado_nuevo: historial_devolucion_credito.estado_nuevo,
+        motivo: historial_devolucion_credito.motivo,
+        created_at: historial_devolucion_credito.created_at,
+      })
+      .from(historial_devolucion_credito)
+      .where(eq(historial_devolucion_credito.credito_id, credito_id_num))
+      .orderBy(desc(historial_devolucion_credito.created_at));
+
+    return {
+      success: true,
+      data: historial,
+    };
+  } catch (error) {
+    console.error("[getHistorialDevolucion] Error:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error al obtener historial de devolución",
+      error: String(error),
+    };
+  }
+}

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -28,7 +28,7 @@ import {
   abonos_capital,
 } from "../database/db/schema";
 import { getSignedDocumentUrl } from "../utils/functions/uploadsFiles";
-import { eq, and, sql, inArray, ilike, like, desc, count, SQL, isNull } from "drizzle-orm";
+import { eq, and, or, sql, inArray, ilike, like, desc, count, SQL, isNull, isNotNull, ne } from "drizzle-orm";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import Big from "big.js";
 import { sendLiquidationEmail, sendPlainEmail, sendSimpleEmail } from "@cci/email";
@@ -6233,6 +6233,333 @@ export async function resumenGlobalLiquidaciones(
   }
 
   return result;
+}
+
+const ID_BANCO_TRANSFERENCIA_NO_ACH = "45";
+
+const NOMBRES_MES_ES = [
+  "Enero",
+  "Febrero",
+  "Marzo",
+  "Abril",
+  "Mayo",
+  "Junio",
+  "Julio",
+  "Agosto",
+  "Septiembre",
+  "Octubre",
+  "Noviembre",
+  "Diciembre",
+];
+
+const CUENTA_MONETARIA_LARGO = 11;
+
+function parseCuentaMonetaria(numeroCuenta: string | null | undefined): {
+  agencia: string;
+  correlativo: string;
+  digito: string;
+  valido: boolean;
+} {
+  const limpia = (numeroCuenta ?? "").replace(/\D/g, "");
+  const valido = limpia.length === CUENTA_MONETARIA_LARGO;
+  return {
+    agencia: limpia.slice(0, 3),
+    correlativo: limpia.slice(3, -1),
+    digito: limpia.slice(-1),
+    valido,
+  };
+}
+
+function mapTipoCuentaCodigo(tipo: string | null | undefined): {
+  codigo: number | "";
+  valido: boolean;
+} {
+  if (!tipo) return { codigo: "", valido: false };
+  const upper = tipo.toUpperCase();
+  if (upper.includes("MONETARIA")) return { codigo: 1, valido: true };
+  if (upper.includes("AHORRO")) return { codigo: 2, valido: true };
+  return { codigo: "", valido: false };
+}
+
+function mapMonedaCodigo(moneda: string | null | undefined): 1 | 2 {
+  return moneda === "dolares" ? 2 : 1;
+}
+
+export type MonedaFiltroTransferencias = "quetzales" | "dolar" | "todas";
+
+export async function resumenTransferencias(
+  mes: number,
+  anio: number,
+  ach: boolean,
+  monedaFiltro: MonedaFiltroTransferencias = "todas"
+): Promise<{ success: boolean; url: string; filename: string }> {
+  const condicionesBanco = ach
+    ? and(
+        eq(inversionistas.permite_distribucion, false),
+        or(
+          isNull(bancos.id_banco_transferencia),
+          ne(bancos.id_banco_transferencia, ID_BANCO_TRANSFERENCIA_NO_ACH)
+        )
+      )
+    : and(
+        eq(inversionistas.permite_distribucion, false),
+        eq(bancos.id_banco_transferencia, ID_BANCO_TRANSFERENCIA_NO_ACH)
+      );
+
+  const inversionistasFiltro = await db
+    .select({
+      inversionista_id: inversionistas.inversionista_id,
+      id_banco_transferencia: bancos.id_banco_transferencia,
+    })
+    .from(inversionistas)
+    .innerJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
+    .where(condicionesBanco);
+
+  const bancoTransfMap = new Map(
+    inversionistasFiltro.map((i) => [i.inversionista_id, i.id_banco_transferencia ?? ""])
+  );
+
+  if (bancoTransfMap.size === 0) {
+    return ach
+      ? generateAchTransferenciasWorkbook([], mes, anio, bancoTransfMap)
+      : generateTransferenciasWorkbook([], mes, anio);
+  }
+
+  const resumen = await consultarResumenGlobalPorEstadoPago(
+    "NO_LIQUIDADO",
+    undefined,
+    mes,
+    anio,
+    true
+  );
+
+  let monedaPermitida: "quetzales" | "dolares" | null = null;
+  if (monedaFiltro === "quetzales") monedaPermitida = "quetzales";
+  else if (monedaFiltro === "dolar") monedaPermitida = "dolares";
+
+  const filtrados = resumen.filter((r) => {
+    if (!bancoTransfMap.has(r.inversionista_id)) return false;
+    if (monedaPermitida && r.moneda !== monedaPermitida) return false;
+    return true;
+  });
+  const filas = filtrados.map((inv) => mapResumenRow(inv, null, null));
+
+  return ach
+    ? generateAchTransferenciasWorkbook(filas, mes, anio, bancoTransfMap)
+    : generateTransferenciasWorkbook(filas, mes, anio);
+}
+
+async function generateAchTransferenciasWorkbook(
+  rows: InversionistaResumen[],
+  mes: number,
+  anio: number,
+  bancoTransfMap: Map<number, string>
+): Promise<{ success: boolean; url: string; filename: string }> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = "Club Cashin";
+  workbook.created = new Date();
+  const sheet = workbook.addWorksheet("Transferencias ACH");
+
+  const RED_FILL = "FFFFC7CE";
+  const HEADER_FILL = "FF1E40AF";
+  const HEADER_BORDER = "FF0F1B4C";
+  const nombreMes = NOMBRES_MES_ES[mes - 1] ?? `Mes ${mes}`;
+
+  const headers = [
+    "Nombre",
+    "Id Participante",
+    "Cuenta credito / debito",
+    "Tipo Cuenta",
+    "Moneda",
+    "Banco",
+    "Descripcion Corta",
+    "Adenda",
+    "Valor Q.",
+  ];
+  sheet.columns = [
+    { width: 28 }, // Nombre
+    { width: 18 }, // Id Participante
+    { width: 24 }, // Cuenta crédito / débito
+    { width: 14 }, // Tipo Cuenta
+    { width: 12 }, // Moneda
+    { width: 10 }, // Banco
+    { width: 24 }, // Descripción Corta
+    { width: 60 }, // Adenda
+    { width: 16 }, // Valor Q.
+  ];
+
+  const headerRow = sheet.addRow(headers);
+  headerRow.height = 24;
+  headerRow.font = { bold: true, color: { argb: "FFFFFFFF" }, size: 11 };
+  headerRow.alignment = { horizontal: "center", vertical: "middle", wrapText: true };
+  headerRow.eachCell((cell) => {
+    cell.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: HEADER_FILL },
+    };
+    cell.border = {
+      top: { style: "thin", color: { argb: HEADER_BORDER } },
+      bottom: { style: "medium", color: { argb: HEADER_BORDER } },
+      left: { style: "thin", color: { argb: HEADER_BORDER } },
+      right: { style: "thin", color: { argb: HEADER_BORDER } },
+    };
+  });
+
+  rows.forEach((inv) => {
+    const valor = Number(inv.total_cuota) || 0;
+    if (valor === 0) return;
+
+    const concepto = `Liquidación ${nombreMes} ${anio}, Club CashIn S.A`;
+    const adenda = concepto.slice(0, 80);
+    const tipoCuenta = mapTipoCuentaCodigo(inv.tipo_cuenta);
+    const moneda = mapMonedaCodigo(inv.moneda);
+    const banco = bancoTransfMap.get(inv.inversionista_id) ?? "";
+    const cuentaLimpia = (inv.numero_cuenta ?? "").replace(/\D/g, "");
+
+    const row = sheet.addRow([
+      inv.nombre,
+      "",
+      cuentaLimpia,
+      tipoCuenta.codigo,
+      moneda,
+      banco,
+      concepto,
+      adenda,
+      valor,
+    ]);
+    row.getCell(9).numFmt = "0.00";
+
+    const filaInvalida = !tipoCuenta.valido || !banco;
+    if (filaInvalida) {
+      row.eachCell({ includeEmpty: true }, (cell) => {
+        cell.fill = {
+          type: "pattern",
+          pattern: "solid",
+          fgColor: { argb: RED_FILL },
+        };
+      });
+    }
+  });
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  const filename = `transferencias_ach_${anio}_${String(mes).padStart(2, "0")}_${Date.now()}.xlsx`;
+  const s3 = new S3Client({
+    endpoint: process.env.BUCKET_REPORTS_URL,
+    region: "auto",
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID as string,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY as string,
+    },
+  });
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: process.env.BUCKET_REPORTS,
+      Key: filename,
+      Body: new Uint8Array(buffer),
+      ContentType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    })
+  );
+
+  return {
+    success: true,
+    url: `${process.env.URL_PUBLIC_R2_REPORTS}/${filename}`,
+    filename,
+  };
+}
+
+async function generateTransferenciasWorkbook(
+  rows: InversionistaResumen[],
+  mes: number,
+  anio: number
+): Promise<{ success: boolean; url: string; filename: string }> {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = "Club Cashin";
+  workbook.created = new Date();
+  const sheet = workbook.addWorksheet("Transferencias");
+
+  const RED_FILL = "FFFFC7CE";
+  const HEADER_FILL = "FF1E40AF";
+  const HEADER_BORDER = "FF0F1B4C";
+  const nombreMes = NOMBRES_MES_ES[mes - 1] ?? `Mes ${mes}`;
+
+  const headers = ["Agencia", "Correlativo", "Dígito", "Moneda", "Concepto", "Valor"];
+  sheet.columns = [
+    { width: 12 }, // Agencia
+    { width: 16 }, // Correlativo
+    { width: 10 }, // Dígito
+    { width: 12 }, // Moneda
+    { width: 60 }, // Concepto
+    { width: 16 }, // Valor
+  ];
+  const headerRow = sheet.addRow(headers);
+  headerRow.height = 24;
+  headerRow.font = { bold: true, color: { argb: "FFFFFFFF" }, size: 11 };
+  headerRow.alignment = { horizontal: "center", vertical: "middle" };
+  headerRow.eachCell((cell) => {
+    cell.fill = {
+      type: "pattern",
+      pattern: "solid",
+      fgColor: { argb: HEADER_FILL },
+    };
+    cell.border = {
+      top: { style: "thin", color: { argb: HEADER_BORDER } },
+      bottom: { style: "medium", color: { argb: HEADER_BORDER } },
+      left: { style: "thin", color: { argb: HEADER_BORDER } },
+      right: { style: "thin", color: { argb: HEADER_BORDER } },
+    };
+  });
+
+  rows.forEach((inv) => {
+    const valor = Number(inv.total_cuota) || 0;
+    if (valor === 0) return;
+
+    const { agencia, correlativo, digito, valido } = parseCuentaMonetaria(inv.numero_cuenta);
+    const concepto = `Liquidación ${nombreMes} ${anio} - ${inv.nombre}, Club CashIn S.A`;
+    const moneda = mapMonedaCodigo(inv.moneda);
+
+    const row = sheet.addRow([agencia, correlativo, digito, moneda, concepto, valor]);
+    row.getCell(6).numFmt = "0.00";
+
+    if (!valido) {
+      row.eachCell({ includeEmpty: true }, (cell) => {
+        cell.fill = {
+          type: "pattern",
+          pattern: "solid",
+          fgColor: { argb: RED_FILL },
+        };
+      });
+    }
+  });
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  const filename = `transferencias_${anio}_${String(mes).padStart(2, "0")}_${Date.now()}.xlsx`;
+  const s3 = new S3Client({
+    endpoint: process.env.BUCKET_REPORTS_URL,
+    region: "auto",
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID as string,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY as string,
+    },
+  });
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: process.env.BUCKET_REPORTS,
+      Key: filename,
+      Body: new Uint8Array(buffer),
+      ContentType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    })
+  );
+
+  return {
+    success: true,
+    url: `${process.env.URL_PUBLIC_R2_REPORTS}/${filename}`,
+    filename,
+  };
 }
 
 export const isNullorEmpty = (value: string | number | null | undefined): value is null | undefined | "" => {

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -6312,7 +6312,7 @@ export async function resumenTransferencias(
       id_banco_transferencia: bancos.id_banco_transferencia,
     })
     .from(inversionistas)
-    .innerJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
+    .leftJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
     .where(condicionesBanco);
 
   const bancoTransfMap = new Map(

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -2,10 +2,10 @@
 import { z } from "zod";
 import { formatToUSD } from "../utils/functions/currencyConverter";
 import { USD_EXCHANGE_RATE } from "../utils/functions/const";
-import { 
-  generarYSubirPDFInversionista, 
-  generarPDFBuffer, 
-  generarYSubirExcelInversionista 
+import {
+  generarYSubirPDFInversionista,
+  generarPDFBuffer,
+  generarYSubirExcelInversionista
 } from "../utils/functions/generalFunctions";
 import { db } from "../database/index";
 import {
@@ -56,12 +56,12 @@ type OrigenDatos = "original" | "espejo";
 export type TipoConsulta = "originales" | "espejos" | "ambas";
 
 // 🔥 MEJORADO: Usar tipos genéricos de Drizzle para type-safety completo
-type CreditosInversionistasTable = 
-  | typeof creditos_inversionistas 
+type CreditosInversionistasTable =
+  | typeof creditos_inversionistas
   | typeof creditos_inversionistas_espejo;
 
-type PagosCreditoInversionistasTable = 
-  | typeof pagos_credito_inversionistas 
+type PagosCreditoInversionistasTable =
+  | typeof pagos_credito_inversionistas
   | typeof pagos_credito_inversionistas_espejo;
 
 // Configuración de tablas según tipo
@@ -98,7 +98,7 @@ async function consultarCreditosInversionista(
 ) {
   // 🔥 Type assertion segura: sabemos que ambas tablas tienen la misma estructura
   const tabla = config.creditosInversionistas as typeof creditos_inversionistas;
-  
+
   return await db
     .select({
       credito_id: tabla.credito_id,
@@ -1254,8 +1254,8 @@ export async function resumeInvestor(
       email: inversionistas.email,
    tiene_boleta_pendiente: sql<boolean>`
       EXISTS (
-        SELECT 1 
-        FROM cartera.boletas_pago_inversionista 
+        SELECT 1
+        FROM cartera.boletas_pago_inversionista
         WHERE cartera.boletas_pago_inversionista.inversionista_id = ${inversionistas.inversionista_id}
         AND cartera.boletas_pago_inversionista.estado = 'PENDIENTE'
       )
@@ -1553,7 +1553,7 @@ export async function resumeInvestor(
               const isrReinv = inv.emite_factura ? new Big(0) : reinvInteres.times(0.07);
               const totalReinvNeta = reinvCapital.plus(reinvInteres).minus(isrReinv);
               const netReinvInt = reinvInteres.minus(isrReinv);
-              
+
               total_reinversion_neta_global = total_reinversion_neta_global.plus(totalReinvNeta);
               total_reinversion_capital = total_reinversion_capital.plus(reinvCapital);
               total_reinversion_interes = total_reinversion_interes.plus(netReinvInt);
@@ -1992,7 +1992,7 @@ export async function getInvestorTotalsGlobales(
       }
       subtotal.total_cuota = subtotal.total_cuota.plus(cuota_inversor);
       subtotal.totalAbonoGeneralInteres = subtotal.totalAbonoGeneralInteres.plus(abonoGeneralInteres);
-      
+
       // 🔑 ACUMULADOR NETO INDEPENDIENTE
       const pagoNetoGlobal = abono_capital.plus(interesTotal);
       subtotal.total_cuota_sin_reinversion = subtotal.total_cuota_sin_reinversion.plus(pagoNetoGlobal);
@@ -2654,7 +2654,7 @@ export async function getInvestorMirrorSummary(
       sg.total_isr                = sg.total_isr.plus(isr);
       sg.total_cuota              = sg.total_cuota.plus(cuota_inversor);
       sg.total_abono_general_interes = sg.total_abono_general_interes.plus(abonoGeneralInteres);
-      
+
       // 🔑 ACUMULADOR NETO INDEPENDIENTE
       const pagoNetoEspejo = abono_capital.plus(interesTotal);
       sg.total_cuota_sin_reinversion = sg.total_cuota_sin_reinversion.plus(pagoNetoEspejo);
@@ -2790,8 +2790,8 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
   let totalPagosLiquidados = 0;
   let totalLiquidaciones = 0;
   let inversionistasSaltados = 0;
-  const reportesGenerados: Array<{ 
-    inversionista_id: number; 
+  const reportesGenerados: Array<{
+    inversionista_id: number;
     url: string;
     boleta_id: number;
     boleta_url: string;
@@ -3060,7 +3060,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
             try {
               // Validar que subtotal existe para evitar crash
               const subtotalStr = inversionista.subtotal?.total_cuota_con_reinversion?.toString() || "0";
-              
+
               const emailResult = await sendLiquidationEmail({
                 to: inversionista.email,
                 investorName: inversionista.nombre_inversionista,
@@ -3074,7 +3074,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
                   content: excelBuffer,
                 }
               });
-              
+
               if (emailResult.success) {
                 console.log(`  ✅ Correo enviado exitosamente a ${inversionista.email}`);
               } else {
@@ -3160,6 +3160,43 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
         // forzamos el status a `inactivo` después.
         // ========================================
         try {
+          // 5A) Salida automática por créditos con devolucion_cube=true
+          //     (independiente del status del inversionista)
+          const creditoIdsConPagos = [
+            ...new Set(pagosNoLiquidados.map((p) => p.credito_id)),
+          ];
+
+          if (creditoIdsConPagos.length > 0) {
+            const creditosConDevolucion = await db
+              .select({ credito_id: creditos.credito_id })
+              .from(creditos)
+              .where(
+                and(
+                  inArray(creditos.credito_id, creditoIdsConPagos),
+                  eq(creditos.devolucion_cube, true)
+                )
+              );
+
+            const creditoIdsDevolucion = creditosConDevolucion.map((c) => c.credito_id);
+
+            if (creditoIdsDevolucion.length > 0) {
+              console.log(
+                `  🚪 Inversionista ${inv_id} → exitInvestor por devolucion_cube=true en ${creditoIdsDevolucion.length} crédito(s)`
+              );
+
+              const exitResultDevolucion = await exitInvestor({
+                body: {
+                  inversionista_id: inv_id,
+                  creditos: creditoIdsDevolucion,
+                },
+                set: { status: 200 },
+                request: {} as any,
+              });
+
+              console.log(`  ✅ Salida por devolucion_cube ejecutada:`, exitResultDevolucion);
+            }
+          }
+
           const [invRow] = await db
             .select({ status: inversionistas.status })
             .from(inversionistas)
@@ -3223,7 +3260,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
 
   // 📝 PASO 8: Mensaje final
   const mensaje = inversionista_id
-    ? totalLiquidaciones > 0 
+    ? totalLiquidaciones > 0
       ? `Inversionista ${inversionista_id} liquidado correctamente`
       : `No se pudo liquidar al inversionista ${inversionista_id}`
     : `${totalLiquidaciones} inversionistas liquidados correctamente (${inversionistasSaltados} saltados)`;
@@ -3234,7 +3271,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
   console.log(`   - Excels generados: ${reportesGenerados.length}`);
   console.log(`   - Boletas procesadas: ${reportesGenerados.length}`);
   console.log(`   - Inversionistas saltados: ${inversionistasSaltados}`);
-  
+
   if (errores.length > 0) {
     console.log(`\n⚠️ INVERSIONISTAS NO PROCESADOS:`);
     errores.forEach(e => {
@@ -3685,11 +3722,11 @@ export const findOrCreateInvestor = async (
   emite_factura: boolean = true
 ) => {
   console.log(`🔍 Buscando/creando inversionista: "${nombre}"`);
-  
+
   // 🧹 NORMALIZAR nombre
   const nombreNormalizado = nombre.trim();
   const nombreLower = nombreNormalizado.toLowerCase();
-  
+
   // 1️⃣ BÚSQUEDA EXACTA (case insensitive)
   console.log(`   🎯 Estrategia 1: Búsqueda exacta...`);
   const exactMatch = await db
@@ -3709,7 +3746,7 @@ export const findOrCreateInvestor = async (
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .toLowerCase();
-  
+
   const withoutAccents = await db
     .select()
     .from(inversionistas)
@@ -3717,8 +3754,8 @@ export const findOrCreateInvestor = async (
       sql`LOWER(
         TRIM(
           translate(
-            ${inversionistas.nombre}, 
-            'áéíóúÁÉÍÓÚñÑ', 
+            ${inversionistas.nombre},
+            'áéíóúÁÉÍÓÚñÑ',
             'aeiouAEIOUnN'
           )
         )
@@ -3733,20 +3770,20 @@ export const findOrCreateInvestor = async (
 
   // 3️⃣ BÚSQUEDA "COMIENZA CON" - Para nombres con apellidos extras
   console.log(`   🎯 Estrategia 3: Búsqueda "comienza con"...`);
-  
+
   // 🔥 BUSCAR SI ALGÚN NOMBRE EN BD ESTÁ CONTENIDO EN EL NOMBRE DEL EXCEL
   // Ejemplo: Si en BD hay "Ana Lucia Salvatierra" y en Excel "Ana Lucia Salvatierra Mayen"
   //          debería encontrar el de BD porque "Ana Lucia Salvatierra" está contenido
-  
+
   const allInvestors = await db
     .select()
     .from(inversionistas);
-  
+
   // Buscar si el nombre del Excel COMIENZA con algún nombre de BD
   const startsWithMatch = allInvestors.find(inv => {
     const invNombreLower = inv.nombre.toLowerCase().trim();
     const nombreLowerTrim = nombreLower.trim();
-    
+
     // Si el nombre de BD está contenido al inicio del nombre del Excel
     return nombreLowerTrim.startsWith(invNombreLower) && nombreLowerTrim.length > invNombreLower.length;
   });
@@ -3759,11 +3796,11 @@ export const findOrCreateInvestor = async (
 
   // 4️⃣ BÚSQUEDA INVERSA - Si en BD hay un nombre más largo
   console.log(`   🎯 Estrategia 4: Búsqueda inversa (nombre más largo en BD)...`);
-  
+
   const containsMatch = allInvestors.find(inv => {
     const invNombreLower = inv.nombre.toLowerCase().trim();
     const nombreLowerTrim = nombreLower.trim();
-    
+
     // Si el nombre del Excel está contenido al inicio del nombre de BD
     return invNombreLower.startsWith(nombreLowerTrim) && invNombreLower.length > nombreLowerTrim.length;
   });
@@ -3776,18 +3813,18 @@ export const findOrCreateInvestor = async (
 
   // 5️⃣ BÚSQUEDA POR PALABRAS CLAVE (más restrictiva)
   console.log(`   🎯 Estrategia 5: Búsqueda por palabras clave...`);
-  
+
   // Dividir en palabras (ignorar palabras muy cortas como "de", "la", etc.)
   const palabras = nombreNormalizado
     .split(/\s+/)
     .filter(p => p.length > 2 && !['del', 'de', 'la', 'los', 'las'].includes(p.toLowerCase()));
-  
+
   if (palabras.length >= 2) { // Solo si tiene al menos 2 palabras significativas
     // Buscar inversionistas que tengan TODAS las palabras importantes
     const wordMatches = allInvestors.filter(inv => {
       const invWords = inv.nombre.toLowerCase().split(/\s+/);
       // Verificar que TODAS las palabras del Excel estén en el nombre de BD
-      return palabras.every(palabra => 
+      return palabras.every(palabra =>
         invWords.some(w => w.includes(palabra.toLowerCase()))
       );
     });
@@ -3800,12 +3837,12 @@ export const findOrCreateInvestor = async (
       wordMatches.forEach((inv, idx) => {
         console.log(`      ${idx + 1}. ${inv.nombre} (ID: ${inv.inversionista_id})`);
       });
-      
+
       // 🔥 Usar el que tenga el nombre más corto (más probable que sea el base)
-      const shortest = wordMatches.reduce((prev, curr) => 
+      const shortest = wordMatches.reduce((prev, curr) =>
         prev.nombre.length < curr.nombre.length ? prev : curr
       );
-      
+
       console.log(`   ✅ Usando el más corto: ${shortest.nombre} (ID: ${shortest.inversionista_id})`);
       return shortest;
     }
@@ -3813,7 +3850,7 @@ export const findOrCreateInvestor = async (
 
   // 6️⃣ NO EXISTE → CREAR NUEVO
   console.log(`   ➕ Inversionista no encontrado, creando nuevo...`);
-  
+
   const [newInvestor] = await db
     .insert(inversionistas)
     .values({
@@ -4760,7 +4797,7 @@ export const fixCubeInvestment = async ({ set }: any) => {
     // 3. Procesar originales
     for (const oc of originalCredits) {
       // Verificar si ya tiene los porcentajes correctos para evitar updates innecesarios
-      const isCorrect = Number(oc.porcentaje_participacion_inversionista) === 0 && 
+      const isCorrect = Number(oc.porcentaje_participacion_inversionista) === 0 &&
                         Number(oc.porcentaje_cash_in) === 100;
 
       if (!isCorrect) {
@@ -4800,7 +4837,7 @@ export const fixCubeInvestment = async ({ set }: any) => {
 
     // 4. Procesar espejos existentes (para asegurar que todos tengan 0/100)
     for (const mc of mirrorCredits) {
-      const isCorrect = Number(mc.porcentaje_participacion_inversionista) === 0 && 
+      const isCorrect = Number(mc.porcentaje_participacion_inversionista) === 0 &&
                         Number(mc.porcentaje_cash_in) === 100;
 
       if (!isCorrect) {
@@ -4879,12 +4916,12 @@ export const reconcileMirrorPercentages = async ({ set }: any) => {
       if (mc) {
         const pInvOriginal = Number(oc.p_inversor);
         const pCashOriginal = Number(oc.p_cashin);
-        
+
         const pInvMirror = Number(mc.porcentaje_participacion_inversionista);
         const pCashMirror = Number(mc.porcentaje_cash_in);
 
         if (pInvOriginal !== pInvMirror || pCashOriginal !== pCashMirror) {
-          
+
           const isSwapped = pInvOriginal === pCashMirror && pCashOriginal === pInvMirror;
 
           const data = {
@@ -4908,7 +4945,7 @@ export const reconcileMirrorPercentages = async ({ set }: any) => {
                 porcentaje_cash_in: oc.p_cashin,
               })
               .where(eq(creditos_inversionistas_espejo.id, mc.id));
-            
+
             results.updatedSwappedCount++;
             results.updatedSwapped.push(data);
           } else {
@@ -4994,7 +5031,7 @@ export const auditMirrorPercentages = async ({ set }: any) => {
       if (mc) {
         const pInvOriginal = Number(oc.p_inversor);
         const pCashOriginal = Number(oc.p_cashin);
-        
+
         const pInvMirror = Number(mc.porcentaje_participacion_inversionista);
         const pCashMirror = Number(mc.porcentaje_cash_in);
 
@@ -5002,7 +5039,7 @@ export const auditMirrorPercentages = async ({ set }: any) => {
           results.discrepanciesCount++;
 
           const isSwapped = pInvOriginal === pCashMirror && pCashOriginal === pInvMirror;
-          
+
           const discrepancyData = {
             inversionista_id: oc.inversionista_id,
             inversionista_nombre: oc.inversionista_nombre,
@@ -6250,7 +6287,7 @@ export async function getLiquidaciones({
   } else if (!isNullorEmpty(dpi)) {
     conditions.push(eq(inversionistas.dpi, parseInt(dpi)));
   }
- 
+
 
   // 📊 Query principal con joins
   const query = db
@@ -6308,10 +6345,10 @@ export async function getLiquidaciones({
     liquidacionesData.map(async (liq) => {
       // 📄 Traer boleta asociada a esta liquidación (si existe)
       let boletaData = null;
-      
+
       if (liq.boleta_id) {
         console.log(`🔍 Buscando boleta ID: ${liq.boleta_id} para liquidación ${liq.liquidacion_id}`);
-        
+
         const [boleta] = await db
           .select({
             boleta_id: boletasPagoInversionista.boleta_id,
@@ -6344,7 +6381,7 @@ export async function getLiquidaciones({
             fecha_procesado: boleta.fecha_procesado,
             subido_por: boleta.subido_por_nombre,
           };
-          
+
           console.log(`✅ Boleta encontrada: ${boleta.boleta_url}`);
         } else {
           console.warn(`⚠️ Boleta ID ${liq.boleta_id} no encontrada en BD`);
@@ -6568,7 +6605,7 @@ export async function aplicarPagosEspejo(inversionistaId: number) {
           )
         );
 
-      // Drizzle update devuelve result info dependiendo del driver, 
+      // Drizzle update devuelve result info dependiendo del driver,
       // pero aquí simplemente contamos las iteraciones exitosas.
       totalActualizados++;
     }
@@ -6609,7 +6646,7 @@ export async function deletePagosEspejoNoLiquidados(inversionistaId: number) {
 // ============================================
 export async function testUploadAndEmail(investorId: number, testEmail: string) {
     console.log(`🧪 Iniciando prueba de envío (PDF Adjunto) para inversionista ${investorId}...`);
-    
+
     // 1. Obtener datos
     const result = await resumeInvestor(investorId, 1, 999);
     if (!result.inversionistas.length) {

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3173,7 +3173,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
               .where(
                 and(
                   inArray(creditos.credito_id, creditoIdsConPagos),
-                  eq(creditos.devolucion_cube, true)
+                  eq(creditos.estado_devolucion, 'VERIFICADO')
                 )
               );
 
@@ -3181,7 +3181,7 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
 
             if (creditoIdsDevolucion.length > 0) {
               console.log(
-                `  🚪 Inversionista ${inv_id} → exitInvestor por devolucion_cube=true en ${creditoIdsDevolucion.length} crédito(s)`
+                `  🚪 Inversionista ${inv_id} → exitInvestor por estado_devolucion=VERIFICADO en ${creditoIdsDevolucion.length} crédito(s)`
               );
 
               const exitResultDevolucion = await exitInvestor({

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -557,7 +557,7 @@ export async function insertPagosCreditoInversionistas(
       `   📊 totalIVA (cash_in + inversionista): ${totalIVA.toString()}`
     );
 
-    const aplicarDevolucionCube = !!currentCredit?.devolucion_cube;
+    const aplicarDevolucionCube = currentCredit?.estado_devolucion === 'VERIFICADO';
 
     if (aplicarDevolucionCube || inv.status_inversionista === "pendiente_devolucion") {
       // 🆕 CASO ESPECIAL:

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -557,14 +557,18 @@ export async function insertPagosCreditoInversionistas(
       `   📊 totalIVA (cash_in + inversionista): ${totalIVA.toString()}`
     );
 
-    if (inv.status_inversionista === "pendiente_devolucion") {
-      // 🆕 CASO ESPECIAL: inversionista pendiente de devolución.
-      // Se le devuelve TODO su monto_aportado como abono_capital en este pago
-      // (sin restar interés, IVA ni cargos fijos). El interés/IVA del último
-      // período se calcula normal y viaja en abono_interes/abono_iva_12.
+    const aplicarDevolucionCube = !!currentCredit?.devolucion_cube;
+
+    if (aplicarDevolucionCube || inv.status_inversionista === "pendiente_devolucion") {
+      // 🆕 CASO ESPECIAL:
+      // - crédito con devolucion_cube=true, o
+      // - inversionista en pendiente_devolucion.
+      // En ambos casos se devuelve TODO su monto_aportado como abono_capital
+      // (sin restar interés, IVA ni cargos fijos). El interés/IVA del período
+      // se sigue calculando y registrando normal en sus campos.
       abono_capital = new Big(inv.monto_aportado || 0);
       console.log(
-        `   ⭐ PENDIENTE DE DEVOLUCIÓN - abono_capital = monto_aportado completo: ${abono_capital.toString()}`
+        `   ⭐ DEVOLUCIÓN COMPLETA (${aplicarDevolucionCube ? "devolucion_cube" : "pendiente_devolucion"}) - abono_capital = monto_aportado completo: ${abono_capital.toString()}`
       );
     } else if (inv.inversionista_id === mayorCuotaInversionistaId && !excludeCube) {
       console.log(
@@ -646,14 +650,12 @@ export async function insertPagosCreditoInversionistas(
 
     let abonoCapitalId: number | null = null;
     if (abonosNoLiquidados.length > 0) {
-      if (inv.status_inversionista === "pendiente_devolucion") {
-        // 🆕 Si está en pendiente_devolucion, su abono_capital ya es el
-        // monto_aportado completo del espejo. Sumarle los abonos_capital
-        // pendientes sería devolverle más de lo que realmente tiene (doble
-        // conteo). Los registros quedan como liquidado=false para que otro
-        // flujo los resuelva después.
+      if (inv.status_inversionista === "pendiente_devolucion" || aplicarDevolucionCube) {
+        // 🆕 Si está en pendiente_devolucion o el crédito usa devolucion_cube,
+        // su abono_capital ya es el monto_aportado completo del espejo.
+        // Sumar abonos pendientes provocaría doble conteo.
         console.log(
-          `   ⏭️  PENDIENTE DE DEVOLUCIÓN: saltando ${abonosNoLiquidados.length} ` +
+          `   ⏭️  DEVOLUCIÓN COMPLETA: saltando ${abonosNoLiquidados.length} ` +
             `abono(s) a capital pendiente(s) (no se suman al abono_capital ` +
             `ni se linkea abono_capital_id)`
         );
@@ -1428,7 +1430,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
 
     // 🧩 Query principal
     const query = sql`
-      SELECT 
+      SELECT
         p.pago_id AS "pagoId",
         p.monto_boleta AS "montoBoleta",
         p.numeroAutorizacion AS "numeroAutorizacion",
@@ -1444,7 +1446,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
         p.registerBy AS "registerBy",
         p.numeroautorizacion AS "numeroautorizacion",
         b.nombre AS "bancoNombre",
-        
+
         -- 🏦 Info de la cuenta de empresa (NUEVO) 👇
         ce.nombre_cuenta AS "cuentaEmpresaNombre",
         ce.banco AS "cuentaEmpresaBanco",
@@ -1524,8 +1526,8 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           )
           FROM cartera.pagos_credito_inversionistas pci
           LEFT JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
-          LEFT JOIN cartera.creditos_inversionistas ci 
-            ON ci.credito_id = pci.credito_id 
+          LEFT JOIN cartera.creditos_inversionistas ci
+            ON ci.credito_id = pci.credito_id
             AND ci.inversionista_id = pci.inversionista_id
           WHERE pci.pago_id = p.pago_id
         ), '[]'::json) AS "inversionistas",
@@ -1796,7 +1798,7 @@ function obtenerRangoMesActual() {
   );
   const primerDia = new Date(hoy.getFullYear(), hoy.getMonth(), 1);
   const ultimoDia = new Date(hoy.getFullYear(), hoy.getMonth() + 1, 0);
-  
+
   return {
     inicio: primerDia.toISOString().slice(0, 10),
     fin: ultimoDia.toISOString().slice(0, 10),
@@ -1810,7 +1812,7 @@ export async function obtenerCreditosConPagosPendientes(
   try {
     const hoy = new Date().toISOString().slice(0, 10);
     const rangoMesActual = obtenerRangoMesActual();
-    
+
     console.log(`📆 Mes actual: ${rangoMesActual.inicio} - ${rangoMesActual.fin} (${rangoMesActual.mes})`);
 
     // 1️⃣ PASO 1: Obtener todos los créditos del inversionista (ESPEJO)
@@ -1851,10 +1853,10 @@ export async function obtenerCreditosConPagosPendientes(
     // 2️⃣ PASO 2: Por cada crédito, buscar la PRIMERA cuota NO LIQUIDADA
     const creditosConPagos = await Promise.all(
       creditosInversionista.map(async (credito) => {
-        
+
         // 🆕 PASO 0: Verificar si ESTE CRÉDITO tiene pagos pendientes de liquidar
         console.log(`\n🔍 ========== VERIFICANDO PAGOS PENDIENTES DEL CRÉDITO ${credito.creditoId} ==========`);
-        
+
         const pagosPendientesCredito = await db
           .select()
           .from(pagos_credito_inversionistas_espejo)
@@ -1872,14 +1874,14 @@ export async function obtenerCreditosConPagosPendientes(
           );
           console.log(`   NO se procesará este crédito hasta que se liquiden`);
           console.log(`========================================\n`);
-          
+
           // 🔥 SALTAR ESTE CRÉDITO
           return null;
         }
 
         console.log(`✅ El crédito ${credito.creditoId} NO tiene pagos pendientes, continuando...`);
         console.log(`========================================\n`);
-        
+
         // 📅 Buscar la PRIMERA cuota NO LIQUIDADA con sus PAGOS
         const cuotaConPagos = await db
           .select({
@@ -1938,7 +1940,7 @@ export async function obtenerCreditosConPagosPendientes(
           `📅 Crédito ${credito.creditoId}, Cuota ${numeroCuota}: fecha_vencimiento = ${fechaVencimiento}`
         );
 
-      
+
         console.log(
           `✅ Crédito ${credito.creditoId}, Cuota ${numeroCuota}: Es de mes anterior (${fechaVencimiento}), se PROCESA`
         );
@@ -1960,7 +1962,7 @@ export async function obtenerCreditosConPagosPendientes(
 
           const primerPago = pagosDeLaCuota[0];
           const cuotaPagada = primeraFila.pagadoCuota ?? false;
-          
+
           console.log(
             `  📊 Cuota ${numeroCuota} - Estado pagado: ${cuotaPagada ? 'SÍ' : 'NO'}`
           );
@@ -2208,7 +2210,7 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
         }
 
         const primeraFila = cuotaConPagos[0];
-        const { numeroCuota, cuotaId } = primeraFila;
+        const { numeroCuota } = primeraFila;
         const pagosDeLaCuota = cuotaConPagos.filter(
           (r) => r.numeroCuota === numeroCuota
         );
@@ -2224,9 +2226,9 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
           await insertPagosCreditoInversionistas(
             pagosDeLaCuota[0].pagoId,
             credito.creditoId,
-            false,  // excludeCube
-            false,  // cuotaPagada
-            false,  // updateCredito ← omite el UPDATE a creditos_inversionistas_espejo
+            false, // excludeCube
+            false, // cuotaPagada
+            false, // updateCredito ← omite el UPDATE a creditos_inversionistas_espejo
             inversionistaId
           );
 
@@ -2272,6 +2274,8 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
     };
   }
 }
+
+
 
 /**
  * Actualiza los pagos NO_LIQUIDADO en pagos_credito_inversionistas_espejo

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -424,6 +424,7 @@ const creditUpdateSchema = z.object({
   // Formato de crédito manual
   formato_credito: z.string().max(50).optional(),
   permite_abono_capital: z.boolean().optional(),
+  devolucion_cube: z.boolean().optional(),
   bandera_reinversion: z.boolean().optional(),
 });
 
@@ -576,7 +577,7 @@ const detectDebtAffectingChanges = (
     "otros",
     "cuota",
     "plazo",
-    
+
   ];
 
   return camposQueModificanDeuda.some((campo) => {
@@ -652,7 +653,7 @@ const updateInvestors = async (
     .select()
     .from(targetTable)
     .where(eq(targetTable.credito_id, credito_id));
-    
+
   const statePrevioMap = new Map();
   existingRecords.forEach((record: any) => {
       // Guardamos status y tipo_reinversion si existen en la tabla (aplica para tabla espejo)
@@ -873,8 +874,8 @@ const updateInvestors = async (
       iva_inversionista: ivaInversionista.toString(),
       iva_cash_in: ivaCashIn.toString(),
       fecha_creacion: new Date(),
-      fecha_inicio_participacion: inv.fecha_inicio_participacion 
-        ? new Date(inv.fecha_inicio_participacion).toISOString().split('T')[0] 
+      fecha_inicio_participacion: inv.fecha_inicio_participacion
+        ? new Date(inv.fecha_inicio_participacion).toISOString().split('T')[0]
         : "2025-12-01",
       cuota_inversionista: cuotaInversionista.toString(), // 🔥 CON LÓGICA CORRECTA
       numero_credito_sifco: numero_credito_sifco ?? undefined,
@@ -958,6 +959,7 @@ export const updateCredit = async ({ body, set }: any) => {
       saldo_a_favor,
       formato_credito,
       permite_abono_capital,
+      devolucion_cube,
       bandera_reinversion,
       ...fieldsToUpdate
     } = parseResult.data;
@@ -1047,6 +1049,9 @@ export const updateCredit = async ({ body, set }: any) => {
     if (permite_abono_capital !== undefined) {
       updateFields.permite_abono_capital = permite_abono_capital;
     }
+    if (devolucion_cube !== undefined) {
+      updateFields.devolucion_cube = devolucion_cube;
+    }
     if (bandera_reinversion !== undefined) {
       updateFields.bandera_reinversion = bandera_reinversion;
     }
@@ -1103,14 +1108,14 @@ export const updateCredit = async ({ body, set }: any) => {
       updateFields.seguro_10_cuotas =
         fieldsToUpdate.seguro_10_cuotas ?? current.seguro_10_cuotas;
 
-     
+
 
       // Actualizar "otros" en la cuota inicial si cambió
       if (otrosModificado) {
         await updateInitialQuotaOtros(credito_id, fieldsToUpdate.otros);
       }
 
-    
+
     }
 
     updateFields.membresias =
@@ -1219,7 +1224,7 @@ export const updateCredit = async ({ body, set }: any) => {
       const principalMontos = new Map(
         (inversionistas || []).map((inv) => [inv.inversionista_id, inv.monto_aportado])
       );
-      
+
       // 🔥 NUEVO: Sincronizar cuotas capturadas del padre
       const principalCuotas = new Map(
         (inversionistas || []).map((inv) => [inv.inversionista_id, inv.cuota_inversionista ?? 0])
@@ -2026,7 +2031,7 @@ export const calculateInvestorQuotas = async ({ body, set }: any) => {
     const resultados = inversionistas.map((inv) => {
       const montoAportado = new Big(inv.monto_aportado);
       // Usamos el capitalTotalCalculado para el % de participación exacto
-      const porcentajeParticipacion = capitalTotalCalculado.gt(0) 
+      const porcentajeParticipacion = capitalTotalCalculado.gt(0)
         ? montoAportado.div(capitalTotalCalculado)
         : new Big(0);
 

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -8,6 +8,7 @@ import {
   cuotas_credito,
   pagos_credito,
   usuarios,
+  historial_devolucion_credito,
 } from "../database/db";
 import z from "zod";
 import type { WSCrEstadoCuentaResponse } from "../services/sifco.interface";
@@ -424,7 +425,8 @@ const creditUpdateSchema = z.object({
   // Formato de crédito manual
   formato_credito: z.string().max(50).optional(),
   permite_abono_capital: z.boolean().optional(),
-  devolucion_cube: z.boolean().optional(),
+  estado_devolucion: z.enum(['NO_APLICA', 'PENDIENTE_AUTORIZACION', 'VERIFICADO', 'RECHAZADO']).optional(),
+  motivo_devolucion: z.string().optional(),
   bandera_reinversion: z.boolean().optional(),
 });
 
@@ -959,7 +961,8 @@ export const updateCredit = async ({ body, set }: any) => {
       saldo_a_favor,
       formato_credito,
       permite_abono_capital,
-      devolucion_cube,
+      estado_devolucion,
+      motivo_devolucion,
       bandera_reinversion,
       ...fieldsToUpdate
     } = parseResult.data;
@@ -1049,8 +1052,52 @@ export const updateCredit = async ({ body, set }: any) => {
     if (permite_abono_capital !== undefined) {
       updateFields.permite_abono_capital = permite_abono_capital;
     }
-    if (devolucion_cube !== undefined) {
-      updateFields.devolucion_cube = devolucion_cube;
+    if (estado_devolucion !== undefined) {
+      if (estado_devolucion !== current.estado_devolucion) {
+        const fromState = current.estado_devolucion;
+        let motivoFinal: string | null | undefined = motivo_devolucion;
+
+        const esSolicitudValida =
+          estado_devolucion === "PENDIENTE_AUTORIZACION" &&
+          (fromState === "NO_APLICA" ||
+            fromState === "RECHAZADO" ||
+            fromState === "VERIFICADO");
+        const esDesactivacionValida =
+          estado_devolucion === "NO_APLICA" && fromState === "PENDIENTE_AUTORIZACION";
+
+        // Este endpoint (editar crédito) solo puede solicitar o desactivar solicitud.
+        if (!esSolicitudValida && !esDesactivacionValida) {
+          set.status = 400;
+          return {
+            message: `Transición de estado de devolución no permitida en este endpoint (${fromState} -> ${estado_devolucion})`,
+          };
+        }
+
+        if (esSolicitudValida) {
+          if (!motivo_devolucion || motivo_devolucion.trim() === "") {
+            set.status = 400;
+            return {
+              message:
+                "Motivo de devolución es obligatorio al solicitar devolución",
+            };
+          }
+          motivoFinal = motivo_devolucion.trim();
+        }
+
+        if (esDesactivacionValida) {
+          motivoFinal = null;
+        }
+
+        await db.insert(historial_devolucion_credito).values({
+          credito_id,
+          usuario_id: 1, // TODO integrate auth for real user_id
+          estado_anterior: fromState,
+          estado_nuevo: estado_devolucion,
+          motivo: motivoFinal ?? null,
+        });
+
+        updateFields.estado_devolucion = estado_devolucion;
+      }
     }
     if (bandera_reinversion !== undefined) {
       updateFields.bandera_reinversion = bandera_reinversion;

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -46,6 +46,13 @@
     "inactivo",
     "pendiente_devolucion",
   ]);
+
+  export const estadoDevolucionEnum = customSchema.enum("estado_devolucion", [
+    "NO_APLICA",
+    "PENDIENTE_AUTORIZACION",
+    "VERIFICADO",
+    "RECHAZADO"
+  ]);
   export const admins = customSchema.table("admins", {
     admin_id: serial("admin_id").primaryKey(),
     nombre: varchar("nombre", { length: 150 }).notNull(),
@@ -176,10 +183,26 @@
       .default(StatusCredit.ACTIVO),
     otros: numeric("otros", { precision: 18, scale: 2 }).notNull().default("0"), // Otros cargos o pagos adicionales
     permite_abono_capital: boolean("permite_abono_capital").notNull().default(false),
-    devolucion_cube: boolean("devolucion_cube").notNull().default(false),
+    estado_devolucion: estadoDevolucionEnum("estado_devolucion").notNull().default("NO_APLICA"),
     is_vehiculo_propio: boolean("is_vehiculo_propio").notNull().default(false), // true si el vehículo es propiedad de Cash In
     bandera_reinversion: boolean("bandera_reinversion").notNull().default(false),
   });
+  export const historial_devolucion_credito = customSchema.table("historial_devolucion_credito", {
+    id: serial("id").primaryKey(),
+    credito_id: integer("credito_id")
+      .notNull()
+      .references(() => creditos.credito_id, { onDelete: "cascade" }),
+    usuario_id: integer("usuario_id")
+      .notNull()
+      .references(() => platform_users.id, { onDelete: "set null" }),
+    estado_anterior: estadoDevolucionEnum("estado_anterior").notNull(),
+    estado_nuevo: estadoDevolucionEnum("estado_nuevo").notNull(),
+    motivo: text("motivo"),
+    created_at: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  }, (table) => ({
+    idxCreditoCreated: index("idx_historial_credito_created").on(table.credito_id, table.created_at),
+  }));
+
   export const cuotas_credito = customSchema.table("cuotas_credito", {
     cuota_id: serial("cuota_id").primaryKey(),
     credito_id: integer("credito_id")

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -73,7 +73,7 @@
   });
   export const conta_users = customSchema.table("conta_users", {
     conta_id: serial("conta_id").primaryKey(),
-    nombre: varchar("nombre", { length: 150 }).notNull(), 
+    nombre: varchar("nombre", { length: 150 }).notNull(),
     email: varchar("email", { length: 150 }).notNull().unique(),
     telefono: varchar("telefono", { length: 30 }),
     activo: boolean("activo").notNull().default(true),
@@ -89,14 +89,14 @@
     usuario_id: serial("usuario_id").primaryKey(),
     nombre: varchar("nombre", { length: 200 }).notNull(),
     nit: varchar("nit", { length: 30 }),
-    
+
     // 🔥 CAMPOS NUEVOS PARA FACTURACIÓN
     direccion: varchar("direccion", { length: 300 }),
     municipio: varchar("municipio", { length: 100 }),
     departamento: varchar("departamento", { length: 100 }),
     codigo_postal: varchar("codigo_postal", { length: 10 }).default("01001"),
     pais: varchar("pais").default("GT"),
-    
+
     // Campos existentes
     categoria: varchar("categoria", { length: 100 }),
     como_se_entero: varchar("como_se_entero", { length: 100 }),
@@ -139,7 +139,7 @@
     iva_12: numeric("iva_12", { precision: 18, scale: 2 }).notNull(),
     seguro_10_cuotas: numeric("seguro_10_cuotas", {
       precision: 18,
-      scale: 2, 
+      scale: 2,
     }).notNull(),
     gps: numeric("gps", { precision: 18, scale: 2 }).notNull(),
     observaciones: text("observaciones").notNull(),
@@ -168,7 +168,7 @@
       precision: 18,
       scale: 2,
     }).notNull(),
-  
+
     statusCredit: text("statusCredit", {
       enum: ["ACTIVO", "CANCELADO", "INCOBRABLE", "PENDIENTE_CANCELACION","MOROSO", "EN_CONVENIO", "CAIDO"],
     })
@@ -176,6 +176,7 @@
       .default(StatusCredit.ACTIVO),
     otros: numeric("otros", { precision: 18, scale: 2 }).notNull().default("0"), // Otros cargos o pagos adicionales
     permite_abono_capital: boolean("permite_abono_capital").notNull().default(false),
+    devolucion_cube: boolean("devolucion_cube").notNull().default(false),
     is_vehiculo_propio: boolean("is_vehiculo_propio").notNull().default(false), // true si el vehículo es propiedad de Cash In
     bandera_reinversion: boolean("bandera_reinversion").notNull().default(false),
   });
@@ -187,11 +188,11 @@
     numero_cuota: integer("numero_cuota").notNull(), // Ej: 1, 2, 3...
     fecha_vencimiento: date("fecha_vencimiento").notNull(),
     pagado: boolean("pagado").default(false), // 👈 Si el cliente ya pagó esta cuota
-    
+
     // 👇 NUEVO - Para control de liquidación a inversionistas
     liquidado_inversionistas: boolean("liquidado_inversionistas").default(false).notNull(), // 👈 Si ya se liquidó a TODOS los inversionistas
     fecha_liquidacion_inversionistas: timestamp("fecha_liquidacion_inversionistas"), // 👈 Cuándo se liquidó
-    
+
     createdAt: timestamp("createdat").defaultNow(),
   });
   export const moras_credito = customSchema.table("moras_credito", {
@@ -207,7 +208,7 @@
       .notNull()
       .default("0"),
     cuotas_atrasadas: integer("cuotas_atrasadas").notNull().default(0),
-  
+
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
   });
@@ -260,7 +261,7 @@
     cuota_interes: numeric("cuota_interes").notNull(), //esto viene del credito
     cuota_id: integer("cuota_id")
       .references(() => cuotas_credito.cuota_id),
-    fecha_pago: timestamp("fecha_pago").defaultNow(), //esto viene del credito 
+    fecha_pago: timestamp("fecha_pago").defaultNow(), //esto viene del credito
     abono_capital: numeric("abono_capital", { precision: 18, scale: 2 }), //aca abonamos a capital solo si el monto de la cuota que viene del credito es igual al monto de la boleta y se van a restar todos los abonos
 
     abono_interes: numeric("abono_interes", { precision: 18, scale: 2 }), // aca jala el interes del credito si ? pero solo si  el monto de la boleta  es igual al de la cuota
@@ -273,7 +274,7 @@
 
     llamada: varchar("llamada", { length: 100 }), // ""
 
-    monto_boleta: numeric("monto_boleta", { precision: 18, scale: 2 }), // esto si viene del input 
+    monto_boleta: numeric("monto_boleta", { precision: 18, scale: 2 }), // esto si viene del input
     fecha_vencimiento: date("fecha_vencimiento").defaultNow(), // viene del credito
 
     renuevo_o_nuevo: varchar("renuevo_o_nuevo", { length: 50 }), //input
@@ -313,10 +314,10 @@
     .default('no_required'),
     createdAt: timestamp("createdat").defaultNow(),
       banco_id: integer("banco_id").references(() => bancos.banco_id), // 👈 OPCIONAL
-    numeroAutorizacion: varchar("numeroautorizacion", { length: 100 }), 
+    numeroAutorizacion: varchar("numeroautorizacion", { length: 100 }),
     registerBy:varchar("registerby",{length:150}).notNull(),
       cuenta_empresa_id: integer("cuenta_empresa_id")
-      .references(() => cuentasEmpresa.cuentaId), // 
+      .references(() => cuentasEmpresa.cuentaId), //
     pagoConvenio :numeric("pago_convenio",{precision:18,scale:2}).notNull(),
 
     fecha_boleta: date("fecha_boleta"), // Fecha del pago en la boleta
@@ -489,7 +490,7 @@
         .notNull()
         .default("NO_LIQUIDADO"),
       cuota: numeric("cuota", { precision: 18, scale: 2 }).notNull(),
-      
+
       // 🆕 ENLACE A LIQUIDACIÓN
       liquidacion_id: integer("liquidacion_id").references(
         () => liquidaciones.liquidacion_id,
@@ -550,7 +551,7 @@
         () => abonos_capital.abono_id,
         { onDelete: "set null" }
       ),
- 
+
       // 🆕 ENLACE A LIQUIDACIÓN
       liquidacion_id: integer("liquidacion_id").references(
         () => liquidaciones.liquidacion_id,
@@ -762,54 +763,54 @@
 
   export const convenios_pago = customSchema.table("convenios_pago", {
     convenio_id: serial("convenio_id").primaryKey(),
-    
+
     // Relación con el crédito
     credito_id: integer("credito_id")
       .notNull()
       .references(() => creditos.credito_id, { onDelete: "cascade" }),
-    
+
     // Detalles del convenio
-    monto_total_convenio: numeric("monto_total_convenio", { 
-      precision: 18, 
-      scale: 2 
+    monto_total_convenio: numeric("monto_total_convenio", {
+      precision: 18,
+      scale: 2
     }).notNull(),
-    
+
     numero_meses: integer("numero_meses").notNull(),
-    
-    cuota_mensual: numeric("cuota_mensual", { 
-      precision: 18, 
-      scale: 2 
+
+    cuota_mensual: numeric("cuota_mensual", {
+      precision: 18,
+      scale: 2
     }).notNull(),
-    
+
     fecha_convenio: timestamp("fecha_convenio").notNull(),
-    
+
     // 🎯 CONTROL DEL CONVENIO
-    monto_pagado: numeric("monto_pagado", { 
-      precision: 18, 
-      scale: 2 
+    monto_pagado: numeric("monto_pagado", {
+      precision: 18,
+      scale: 2
     }).notNull().default("0"), // Cuánto se ha pagado
-    
-    monto_pendiente: numeric("monto_pendiente", { 
-      precision: 18, 
-      scale: 2 
+
+    monto_pendiente: numeric("monto_pendiente", {
+      precision: 18,
+      scale: 2
     }).notNull(), // Cuánto falta (se actualiza con cada pago)
-    
+
     pagos_realizados: integer("pagos_realizados").notNull().default(0), // Cuántos pagos se han hecho
-    
+
     pagos_pendientes: integer("pagos_pendientes").notNull(), // Cuántos pagos faltan
-    
+
     // Estado del convenio
     activo: boolean("activo").notNull().default(true),
-    
+
     completado: boolean("completado").notNull().default(false),
-    
+
     // Metadata
     motivo: text("motivo"),
     observaciones: text("observaciones"),
-    
+
     created_by: integer("created_by")
       .references(() => platform_users.id),
-    
+
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
   });
@@ -817,27 +818,27 @@
 
   export const convenios_pagos_resume = customSchema.table("convenios_pagos_resume", {
     id: serial("id").primaryKey(),
-    
+
     convenio_id: integer("convenio_id")
       .notNull()
       .references(() => convenios_pago.convenio_id, { onDelete: "cascade" }),
-    
+
     pago_id: integer("pago_id")
       .notNull()
       .references(() => pagos_credito.pago_id, { onDelete: "cascade" }),
-    
+
     created_at: timestamp("created_at").defaultNow(),
   });export const convenio_cuotas = customSchema.table("convenio_cuotas", {
     cuota_convenio_id: serial("cuota_convenio_id").primaryKey(),
     convenio_id: integer("convenio_id")
       .references(() => convenios_pago.convenio_id)
       .notNull(),
-    
+
     // Control mínimo
     numero_cuota: integer("numero_cuota").notNull(), // 1, 2, 3... hasta numero_meses
     fecha_vencimiento: date("fecha_vencimiento").notNull(), // Cuándo vence esta cuota
     fecha_pago: timestamp("fecha_pago"), // NULL si no está pagada, timestamp cuando se paga
-    
+
     created_at: timestamp("created_at").defaultNow(),
   });
 
@@ -858,22 +859,22 @@
     // 🔥 Opcional: puede ser null para facturas genéricas (sin pago asociado)
     pago_id: integer("pago_id")
       .references(() => pagos_credito.pago_id, { onDelete: "set null" }),
-    
+
     // Datos del DTE
     serie: varchar("serie", { length: 50 }).notNull(),
     numero: varchar("numero", { length: 100 }).notNull(),
     uuid: varchar("uuid", { length: 255 }).notNull().unique(),
-    
+
     tipo_documento: varchar("tipo_documento", { length: 10 }).notNull(),
-    
+
     // Montos
     monto_total: numeric("monto_total", { precision: 18, scale: 2 }).notNull(),
     monto_iva: numeric("monto_iva", { precision: 18, scale: 2 }).notNull(),
-    
+
     // URLs
     pdf_url: varchar("pdf_url", { length: 500 }).notNull(),
     xml_url: varchar("xml_url", { length: 500 }),
-    
+
     // Emisor
     emisor_nit: varchar("emisor_nit", { length: 30 }),
     emisor_nombre: varchar("emisor_nombre", { length: 200 }),
@@ -881,17 +882,17 @@
     // Receptor
     receptor_nit: varchar("receptor_nit", { length: 30 }).notNull(),
     receptor_nombre: varchar("receptor_nombre", { length: 200 }).notNull(),
-    
+
     // Fechas
     fecha_emision: timestamp("fecha_emision").notNull(),
     fecha_certificacion: timestamp("fecha_certificacion").notNull(),
-    
+
     // STATUS Y ANULACIÓN
     status: statusFacturaEnum("status").notNull().default("ACTIVA"),
     fecha_anulacion: timestamp("fecha_anulacion"),
     motivo_anulacion: text("motivo_anulacion"),
     anulada_por: integer("anulada_por").references(() => platform_users.id),
-    
+
     // Metadata
     created_at: timestamp("created_at").defaultNow().notNull(),
     created_by: integer("created_by").references(() => platform_users.id),
@@ -914,28 +915,28 @@
     "boletas_pago_inversionista",
     {
       boleta_id: serial("boleta_id").primaryKey(),
-      
+
       // 🔥 INVERSIONISTA (obligatorio)
       inversionista_id: integer("inversionista_id")
         .notNull()
         .references(() => inversionistas.inversionista_id, { onDelete: "cascade" }),
-      
+
       // URL de la boleta del banco (foto o PDF)
       boleta_url: text("boleta_url").notNull(),
-      
+
       // Estado del comprobante
       estado: estadoBoletaEnum("estado").notNull().default("PENDIENTE"),
-      
+
       // Metadata
       notas: text("notas"),
       monto_boleta: numeric("monto_boleta", { precision: 18, scale: 2 }),
-      
+
       // Fechas
       fecha_subida: timestamp("fecha_subida", { withTimezone: true })
         .notNull()
         .$default(() => new Date()),
       fecha_procesado: timestamp("fecha_procesado", { withTimezone: true }),
-      
+
       // Quién subió la boleta
       subido_por: integer("subido_por")
         .references(() => platform_users.id, { onDelete: "set null" }),
@@ -956,16 +957,16 @@
     "liquidaciones",
     {
       liquidacion_id: serial("liquidacion_id").primaryKey(),
-      
+
       // Inversionista (OBLIGATORIO)
       inversionista_id: integer("inversionista_id")
         .notNull()
         .references(() => inversionistas.inversionista_id, { onDelete: "cascade" }),
-      
+
       // 🆕 ENLACE A LA BOLETA que originó esta liquidación
       boleta_id: integer("boleta_id")
         .references(() => boletasPagoInversionista.boleta_id, { onDelete: "set null" }),
-      
+
       // Totales de la liquidación
       total_pagos_liquidados: integer("total_pagos_liquidados").notNull().default(0),
       total_capital: numeric("total_capital", { precision: 18, scale: 2 }).notNull().default("0"),
@@ -981,12 +982,12 @@
 
       // Reporte de liquidación (Excel/PDF)
       reporte_liquidacion_url: text("reporte_liquidacion_url"),
-      
+
       // Fecha
       fecha_liquidacion: timestamp("fecha_liquidacion", { withTimezone: true })
         .notNull()
         .$default(() => new Date()),
-      
+
       // Metadata
       creado_por: integer("creado_por")
         .references(() => platform_users.id, { onDelete: "set null" }),

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -570,6 +570,7 @@
   export const bancos = customSchema.table('bancos', {
     banco_id: serial('banco_id').primaryKey(),
     nombre: varchar('nombre', { length: 100 }).notNull().unique(),
+    id_banco_transferencia: varchar('id_banco_transferencia', { length: 50 }).unique(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   });

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -40,6 +40,7 @@ const app = new Elysia()
   .use(routers.completeEspejoRouter)
   .use(routers.replaceInvestorCreditRouter)
   .use(routers.compraCarteraAceptadaRouter)
+  .use(routers.devolucionRouter)
   .use(routers.creditosNuevosConAbonosRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor

--- a/apps/cartera-back/src/routers/devolucion.ts
+++ b/apps/cartera-back/src/routers/devolucion.ts
@@ -1,0 +1,49 @@
+import { Elysia, t } from "elysia";
+import { authMiddleware } from "./midleware";
+import {
+  listPendingDevolucion,
+  aceptarDevolucion,
+  rechazarDevolucion,
+  getHistorialDevolucion,
+} from "../controllers/devolucion";
+
+export const devolucionRouter = new Elysia({ prefix: "/api/devolucion-credito" })
+  .use(authMiddleware)
+
+  // Listar créditos pendientes de autorización
+  .get(
+    "/list-pending",
+    listPendingDevolucion,
+    {
+      query: t.Object({
+        page: t.Optional(t.String({ pattern: "^[0-9]+$" })),
+        limit: t.Optional(t.String({ pattern: "^[0-9]+$" })),
+        status: t.Optional(t.String()),
+        search: t.Optional(t.String()),
+      }),
+    }
+  )
+
+  // Aceptar devolución
+  .post("/:id/aceptar", aceptarDevolucion, {
+    params: t.Object({
+      id: t.String({ pattern: "^[0-9]+$" }),
+    }),
+  })
+
+  // Rechazar devolución
+  .post("/:id/rechazar", rechazarDevolucion, {
+    params: t.Object({
+      id: t.String({ pattern: "^[0-9]+$" }),
+    }),
+    body: t.Object({
+      motivo: t.String({ minLength: 1 }),
+    }),
+  })
+
+  // Obtener historial de devolución
+  .get("/:id/historial", getHistorialDevolucion, {
+    params: t.Object({
+      id: t.String({ pattern: "^[0-9]+$" }),
+    }),
+  });

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -26,7 +26,8 @@ import { addInvestorToCreditRouter } from "./addInvestorToCredit";
 import { completeEspejoRouter } from "./completeEspejo";
 import { replaceInvestorCreditRouter } from "./replaceInvestorCredit";
 import { compraCarteraAceptadaRouter } from "./compraCarteraAceptada";
+import { devolucionRouter } from "./devolucion";
 import { creditosNuevosConAbonosRouter } from "./creditosNuevosConAbonos";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,creditosNuevosConAbonosRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,devolucionRouter,creditosNuevosConAbonosRouter
 }

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -36,7 +36,7 @@ import { obtenerCreditosConPagosPendientes, calcularYRegistrarPagosEspejo } from
 import { createBoleta, getBoletaById, getAllBoletas, getBoletasPendientes, updateBoleta, marcarBoletaComoProcesada, marcarBoletaComoPendiente, deleteBoleta, getBoletasStats } from "../controllers/liquidateInvestor";
 import { requierePeriodoLiquidacion } from "../utils/investorLiquidationSummary";
 // 🔥 IMPORTAR SERVICIO DE BOLETAS
- 
+
 
 export const inversionistasRouter = new Elysia()
   .use(authMiddleware)
@@ -125,7 +125,7 @@ export const inversionistasRouter = new Elysia()
 
       const incluirLiquidadosBool = incluirLiquidados === "true";
       const numeroCuotaNum = numeroCuota ? Number(numeroCuota) : undefined;
-      
+
       if (numeroCuota && isNaN(numeroCuotaNum!)) {
         set.status = 400;
         return { message: "El parámetro 'numeroCuota' debe ser numérico." };
@@ -355,12 +355,12 @@ export const inversionistasRouter = new Elysia()
     }
   )
   .post("/investor/pdf", async ({ body, set }) => {
-    const { id, page = 1, perPage = 1 } = body as { 
-      id?: number; 
-      page?: number; 
-      perPage?: number 
+    const { id, page = 1, perPage = 1 } = body as {
+      id?: number;
+      page?: number;
+      perPage?: number
     };
-    
+
     console.log("Generando PDF para inversionista ID:", id);
     const pageNum = Number(page);
     const perPageNum = Number(perPage);
@@ -841,8 +841,8 @@ export const inversionistasRouter = new Elysia()
         set.status = 200;
         return {
           success: true,
-          message: generateFalsePayment 
-            ? "✅ Pagos generados correctamente" 
+          message: generateFalsePayment
+            ? "✅ Pagos generados correctamente"
             : "📄 Datos obtenidos correctamente",
           inversionistaId: resultado.inversionistaId ?? inversionistaId,
           totalCreditosConPagos: resultado.totalCreditosConCuotas ?? 0,
@@ -1379,6 +1379,7 @@ export const inversionistasRouter = new Elysia()
       },
     }
   )
+
   .post(
     "/recalcularPagosEspejo",
     async ({ body, set }) => {
@@ -1493,7 +1494,7 @@ export const inversionistasRouter = new Elysia()
     "/deletePagosEspejoNoLiquidados",
     async ({ body, set }) => {
       const { inversionistaId } = body;
-      
+
       console.log(`🗑️ DELETE /deletePagosEspejoNoLiquidados (ID: ${inversionistaId})`);
 
       if (!inversionistaId) {
@@ -1503,10 +1504,10 @@ export const inversionistasRouter = new Elysia()
 
       try {
         const result = await deletePagosEspejoNoLiquidados(inversionistaId);
-        return { 
-          success: true, 
-          deletedCount: result.deletedCount, 
-          message: "Pagos eliminados correctamente" 
+        return {
+          success: true,
+          deletedCount: result.deletedCount,
+          message: "Pagos eliminados correctamente"
         };
       } catch (error: any) {
         console.error(error);

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -12,6 +12,7 @@ import {
   exitInvestor,
   resumenGlobalInversionistas,
   resumenGlobalLiquidaciones,
+  resumenTransferencias,
   getLiquidaciones,
   getInvestorPerformance,
   getInvestorTotalsGlobales,
@@ -745,6 +746,51 @@ export const inversionistasRouter = new Elysia()
       };
     }
   })
+  .get(
+    "/resumen-transferencias",
+    async ({ query, set }) => {
+      const { mes, anio, ach, moneda } = query;
+
+      const mesNum = Number(mes);
+      const anioNum = Number(anio);
+
+      if (!Number.isFinite(mesNum) || mesNum < 1 || mesNum > 12) {
+        set.status = 400;
+        return { message: "El parámetro 'mes' es obligatorio y debe estar entre 1 y 12." };
+      }
+      if (!Number.isFinite(anioNum) || anioNum < 2000) {
+        set.status = 400;
+        return { message: "El parámetro 'anio' es obligatorio y debe ser un año válido." };
+      }
+
+      let monedaFiltro: "quetzales" | "dolar" | "todas" = "todas";
+      if (moneda === "quetzales" || moneda === "dolar") {
+        monedaFiltro = moneda;
+      } else if (moneda) {
+        set.status = 400;
+        return { message: "El parámetro 'moneda' debe ser 'quetzales' o 'dolar'." };
+      }
+
+      try {
+        return await resumenTransferencias(mesNum, anioNum, ach === "true", monedaFiltro);
+      } catch (error) {
+        console.error("[investor/resumen-transferencias] Error:", error);
+        set.status = 500;
+        return {
+          message: "Error al generar el reporte de transferencias",
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    {
+      query: t.Object({
+        mes: t.String(),
+        anio: t.String(),
+        ach: t.Optional(t.String()),
+        moneda: t.Optional(t.String()),
+      }),
+    }
+  )
   .get(
     "/resumen-global",
     async ({ query }) => {

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -21,6 +21,7 @@ import { SesionesPendientes } from "./private/cartera/components/SesionesPendien
 import { RecibosGenericos } from "./private/recibos-genericos/components/RecibosGenericos";
 import { FallenCredits } from "./private/cartera/components/FallenCredits";
 import { PagosPorVencimiento } from "./private/cartera/components/PagosPorVencimiento";
+import { DevolucionCube } from "./private/cartera/components/DevolucionCube";
 
 // 🔒 Rutas privadas
 function PrivateRoute({ children }: { children: JSX.Element }) {
@@ -237,6 +238,15 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN"]}>
               <PagosPorVencimiento />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="devolucion-cube"
+          element={
+            <RoleRoute allowedRoles={["ADMIN"]}>
+              <DevolucionCube />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -200,6 +200,7 @@ export function ListaCreditosPagos() {
       gps: credit.gps ?? 0,
       asesor_id: credit.asesor_id,
       formato_credito: credit.formato_credito ?? "",
+      devolucion_cube: !!credit.devolucion_cube,
       nombre: usuario?.nombre ?? (usuario?.nombres ? `${usuario.nombres} ${usuario.apellidos ?? ""}`.trim() : ""),
       nit: usuario?.nit ?? "",
       direccion: usuario?.direccion ?? "",
@@ -321,9 +322,9 @@ export function ListaCreditosPagos() {
 
   return (
 
-    
+
   <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 overflow-auto pt-8 pb-8">
-   
+
     <div className="w-full max-w-[1400px]">
       <div className="flex flex-col items-center mb-6">
         <h1 className="text-3xl font-extrabold text-blue-700 text-center">
@@ -2228,4 +2229,3 @@ function InversionistasInfo({ inversionistas }: { inversionistas: any[] }) {
     </div>
   );
 }
- 

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -200,7 +200,7 @@ export function ListaCreditosPagos() {
       gps: credit.gps ?? 0,
       asesor_id: credit.asesor_id,
       formato_credito: credit.formato_credito ?? "",
-      devolucion_cube: !!credit.devolucion_cube,
+      estado_devolucion: credit.estado_devolucion ?? "NO_APLICA",
       nombre: usuario?.nombre ?? (usuario?.nombres ? `${usuario.nombres} ${usuario.apellidos ?? ""}`.trim() : ""),
       nit: usuario?.nit ?? "",
       direccion: usuario?.direccion ?? "",

--- a/apps/carteraFront/src/private/cartera/components/DevolucionCube.tsx
+++ b/apps/carteraFront/src/private/cartera/components/DevolucionCube.tsx
@@ -1,0 +1,367 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  getPendingDevolucion,
+  aceptarDevolucion,
+  rechazarDevolucion,
+  type DevolucionCreditoItem,
+} from "../services/services";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { toast } from "sonner";
+import { RefreshCw, Search } from "lucide-react";
+
+const PAGE_SIZE = 10;
+
+export function DevolucionCube() {
+  const [loading, setLoading] = useState(true);
+  const [actingId, setActingId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<DevolucionCreditoItem[]>([]);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [rejectCredit, setRejectCredit] = useState<DevolucionCreditoItem | null>(null);
+  const [rejectReason, setRejectReason] = useState("");
+  const [reasonOpen, setReasonOpen] = useState(false);
+  const [reasonCredit, setReasonCredit] = useState<DevolucionCreditoItem | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Acepta alias typo: PENDIENTE_VERFICACION / PENDIENTE_VERIFICACION
+      const res = await getPendingDevolucion(page, PAGE_SIZE, "PENDIENTE_VERFICACION", search);
+
+      const credits = res?.data?.credits ?? [];
+      const pagination = res?.data?.pagination;
+
+      setItems(Array.isArray(credits) ? credits : []);
+      setTotal(pagination?.total ?? 0);
+      setTotalPages(pagination?.totalPages ?? 1);
+    } catch (e: unknown) {
+      const candidate =
+        typeof e === "object" &&
+        e !== null &&
+        "response" in e
+          ? (e as { response?: { data?: { message?: string } } }).response?.data?.message
+          : undefined;
+      const msg =
+        typeof candidate === "string" && candidate.trim() !== ""
+          ? candidate
+          : "Error cargando devoluciones pendientes";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  }, [page, search]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onBuscar = () => {
+    setPage(1);
+    setSearch(searchInput.trim());
+  };
+
+  const onAceptar = async (creditoId: number) => {
+    try {
+      setActingId(creditoId);
+      const res = await aceptarDevolucion(creditoId);
+      toast.success(res.message || "Devolución aceptada");
+      await load();
+    } catch (e: unknown) {
+      const candidate =
+        typeof e === "object" &&
+        e !== null &&
+        "response" in e
+          ? (e as { response?: { data?: { message?: string } } }).response?.data?.message
+          : undefined;
+      toast.error(
+        typeof candidate === "string" && candidate.trim() !== ""
+          ? candidate
+          : "No se pudo aceptar la devolución"
+      );
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const onRechazar = async (creditoId: number, motivo: string) => {
+    if (!motivo || !motivo.trim()) {
+      toast.error("El motivo es obligatorio para rechazar");
+      return;
+    }
+
+    try {
+      setActingId(creditoId);
+      const res = await rechazarDevolucion(creditoId, motivo.trim());
+      toast.success(res.message || "Devolución rechazada");
+      await load();
+    } catch (e: unknown) {
+      const candidate =
+        typeof e === "object" &&
+        e !== null &&
+        "response" in e
+          ? (e as { response?: { data?: { message?: string } } }).response?.data?.message
+          : undefined;
+      toast.error(
+        typeof candidate === "string" && candidate.trim() !== ""
+          ? candidate
+          : "No se pudo rechazar la devolución"
+      );
+    } finally {
+      setActingId(null);
+    }
+  };
+
+  const subtitle = useMemo(() => {
+    if (search) return `Créditos pendientes filtrados por "${search}"`;
+    return "Créditos pendientes de autorización para devolución a Cube";
+  }, [search]);
+
+  const estadoLabel = (estado: string) => {
+    switch (estado) {
+      case "PENDIENTE_AUTORIZACION":
+        return "Pendiente de autorización";
+      case "VERIFICADO":
+        return "Verificado";
+      case "RECHAZADO":
+        return "Rechazado";
+      case "NO_APLICA":
+        return "No aplica";
+      default:
+        return estado;
+    }
+  };
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 overflow-auto pt-6 pb-20">
+      <div className="w-full max-w-[1400px] space-y-4">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h1 className="text-xl font-bold text-gray-900">Devolución Cube</h1>
+            <p className="text-xs text-gray-500 mt-0.5">{subtitle}</p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void load()}
+            disabled={loading}
+            className="gap-1.5 text-xs"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${loading ? "animate-spin" : ""}`} />
+            Actualizar
+          </Button>
+        </div>
+
+        {/* Search + Stats inline */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="relative flex-1 max-w-sm">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-gray-400" />
+            <Input
+              placeholder="Buscar por nombre o SIFCO"
+              value={searchInput}
+              onChange={(e) => setSearchInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") onBuscar();
+              }}
+              className="pl-9 h-8 text-xs text-gray-900"
+            />
+          </div>
+          <Button size="sm" className="h-8 text-xs" onClick={onBuscar}>
+            Buscar
+          </Button>
+          <Badge variant="outline" className="text-[11px] border-blue-200 text-blue-700 bg-blue-50 tabular-nums">
+            {total} créditos
+          </Badge>
+          <span className="text-xs text-gray-500">
+            Página {page} de {Math.max(totalPages, 1)}
+          </span>
+        </div>
+
+        <Card className="border border-slate-200 bg-white/95 shadow-sm">
+          <CardContent className="p-0">
+            {loading && <p className="text-sm text-slate-500 p-4">Cargando...</p>}
+            {error && <p className="text-sm text-red-600 p-4">{error}</p>}
+
+            {!loading && !error && items.length === 0 && (
+              <p className="text-sm text-slate-500 p-4">No hay créditos pendientes de autorización.</p>
+            )}
+
+            {!loading && !error && items.length > 0 && (
+              <div className="overflow-x-auto rounded-lg">
+                <table className="w-full text-sm text-slate-900">
+                  <thead className="bg-slate-50">
+                    <tr className="border-b border-slate-200">
+                      <th className="text-left py-2 px-3 font-semibold text-slate-700">No. Crédito SIFCO</th>
+                      <th className="text-left py-2 px-3 font-semibold text-slate-700">Cliente</th>
+                      <th className="text-right py-2 px-3 font-semibold text-slate-700">Capital</th>
+                      <th className="text-right py-2 px-3 font-semibold text-slate-700">Cuota</th>
+                      <th className="text-left py-2 px-3 font-semibold text-slate-700">Motivo de solicitud</th>
+                      <th className="text-left py-2 px-3 font-semibold text-slate-700">Estado</th>
+                      <th className="text-right py-2 px-3 font-semibold text-slate-700">Acciones</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {items.map((row) => (
+                      <tr key={row.credito_id} className="border-b border-slate-100 last:border-b-0">
+                        <td className="py-2 px-3 font-medium text-slate-900">{row.numero_credito_sifco}</td>
+                        <td className="py-2 px-3 text-slate-800">{row.usuario_nombre || "Sin nombre"}</td>
+                        <td className="py-2 px-3 text-right text-slate-900">
+                          Q {Number(row.capital).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                        </td>
+                        <td className="py-2 px-3 text-right text-slate-900">
+                          Q {Number(row.cuota).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                        </td>
+                        <td className="py-2 px-3 text-slate-700 max-w-[360px]">
+                          <p className="line-clamp-2 text-sm leading-5">
+                            {row.motivo_solicitud || "Sin motivo registrado"}
+                          </p>
+                          {!!row.motivo_solicitud && row.motivo_solicitud.length > 80 && (
+                            <button
+                              type="button"
+                              className="mt-1 text-xs font-medium text-blue-600 hover:text-blue-800 underline"
+                              onClick={() => {
+                                setReasonCredit(row);
+                                setReasonOpen(true);
+                              }}
+                            >
+                              Ver motivo completo
+                            </button>
+                          )}
+                        </td>
+                        <td className="py-2 px-3">
+                          <Badge className="bg-amber-100 text-amber-800 border-amber-300">
+                            {estadoLabel(row.estado_devolucion)}
+                          </Badge>
+                        </td>
+                        <td className="py-2 px-3">
+                          <div className="flex items-center justify-end gap-2">
+                            <Button
+                              size="sm"
+                              className="bg-green-600 hover:bg-green-700"
+                              disabled={actingId === row.credito_id}
+                              onClick={() => void onAceptar(row.credito_id)}
+                            >
+                              Aceptar
+                            </Button>
+                            <Button
+                              size="sm"
+                              className="bg-red-600 text-white hover:bg-red-700 border-none"
+                              disabled={actingId === row.credito_id}
+                              onClick={() => {
+                                setRejectCredit(row);
+                                setRejectReason("");
+                                setRejectOpen(true);
+                              }}
+                            >
+                              Rechazar
+                            </Button>
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Pagination fixed bottom */}
+      {totalPages > 1 && (
+        <div className="border-t border-gray-200 bg-white px-6 py-3 flex items-center justify-center gap-2 fixed bottom-0 inset-x-0 z-10 shadow-[0_-2px_10px_rgba(0,0,0,0.06)]">
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page <= 1 || loading}
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+          >
+            Anterior
+          </Button>
+          <span className="text-xs text-gray-600 tabular-nums">
+            Página {page} de {totalPages}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={page >= totalPages || loading}
+            onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          >
+            Siguiente
+          </Button>
+        </div>
+      )}
+
+      <Dialog open={reasonOpen} onOpenChange={setReasonOpen}>
+        <DialogContent className="max-w-2xl bg-white border border-slate-200 shadow-2xl text-slate-900">
+          <DialogHeader>
+            <DialogTitle className="text-slate-900">Motivo de solicitud</DialogTitle>
+            <DialogDescription className="text-slate-600">
+              Crédito {reasonCredit?.numero_credito_sifco} · Cliente {reasonCredit?.usuario_nombre || "Sin nombre"}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-800 leading-6 max-h-[55vh] overflow-auto whitespace-pre-wrap">
+            {reasonCredit?.motivo_solicitud || "Sin motivo registrado"}
+          </div>
+
+          <div className="flex justify-end">
+            <Button variant="outline" onClick={() => setReasonOpen(false)}>
+              Cerrar
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={rejectOpen} onOpenChange={setRejectOpen}>
+        <DialogContent className="max-w-lg bg-white border border-slate-200 shadow-2xl text-slate-900">
+          <DialogHeader>
+            <DialogTitle className="text-slate-900">Rechazar devolución</DialogTitle>
+            <DialogDescription className="text-slate-600">
+              Ingresa el motivo del rechazo para el crédito {rejectCredit?.numero_credito_sifco}.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-2">
+            <p className="text-xs text-slate-500">Cliente: {rejectCredit?.usuario_nombre || "Sin nombre"}</p>
+            <Textarea
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              placeholder="Escribe el motivo del rechazo"
+              className="min-h-28 text-sm text-slate-900 placeholder:text-slate-400 bg-white"
+            />
+          </div>
+
+          <div className="flex justify-end gap-2 mt-2">
+            <Button variant="outline" onClick={() => setRejectOpen(false)}>
+              Cancelar
+            </Button>
+            <Button
+              className="bg-red-600 text-white hover:bg-red-700 border-none"
+              disabled={!rejectCredit || actingId === rejectCredit.credito_id}
+              onClick={async () => {
+                if (!rejectCredit) return;
+                await onRechazar(rejectCredit.credito_id, rejectReason);
+                setRejectOpen(false);
+              }}
+            >
+              Confirmar rechazo
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -245,6 +245,7 @@ export function ModalEditCredit({
 
         // Abono capital
         permite_abono_capital: !!values.permite_abono_capital,
+        devolucion_cube: !!values.devolucion_cube,
 
         // Lista Principal
         inversionistas: values.investors.map((i: InvestorItem) => ({
@@ -558,7 +559,7 @@ export function ModalEditCredit({
             </div>
 
             {/* Opciones del crédito */}
-            <div className="mt-4 p-4 rounded-xl border border-blue-100 bg-blue-50/50">
+            <div className="mt-4 p-4 rounded-xl border border-blue-100 bg-blue-50/50 space-y-4">
               <div className="flex items-center justify-between">
                 <div>
                   <Label className="text-gray-800 font-bold text-sm">
@@ -587,6 +588,41 @@ export function ModalEditCredit({
                   <span
                     className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
                       formik.values.permite_abono_capital
+                        ? "translate-x-5"
+                        : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="text-gray-800 font-bold text-sm">
+                    Devolución a CUBE
+                  </Label>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    Si está activo, la generación de pagos usa la lógica de devolución a CUBE
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={!!formik.values.devolucion_cube}
+                  onClick={() =>
+                    formik.setFieldValue(
+                      "devolucion_cube",
+                      !formik.values.devolucion_cube
+                    )
+                  }
+                  className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    formik.values.devolucion_cube
+                      ? "bg-green-500"
+                      : "bg-gray-300"
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      formik.values.devolucion_cube
                         ? "translate-x-5"
                         : "translate-x-0"
                     }`}

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -36,7 +36,7 @@ interface InvestorOption {
 interface ModalEditCreditProps {
   open: boolean;
   onClose: () => void;
-  initialValues: Omit<UpdateCreditBody, "inversionistas">;
+  initialValues: Omit<UpdateCreditBody, "inversionistas"> | null;
   investorsInitial?: InvestorItem[];
   investorsMirrorInitial?: InvestorItem[]; // 🆕 Nueva prop para datos iniciales espejo
   onSuccess: () => void;
@@ -136,6 +136,9 @@ export function ModalEditCredit({
       cuota_inversionista: Number(inv.cuota_inversionista || 0),
     })) || [];
 
+  const safeInitialValues =
+    (initialValues ?? {}) as Omit<UpdateCreditBody, "inversionistas">;
+
   const parsedInvestors = parseInvestors(investorsInitial);
   // 🔥 Sincronización Real (Por ID de Inversionista)
   // Buscamos explícitamente el espejo que corresponda al mismo ID de inversionista.
@@ -169,7 +172,9 @@ export function ModalEditCredit({
 
   const formik = useFormik({
     initialValues: {
-      ...initialValues,
+      ...safeInitialValues,
+      estado_devolucion: safeInitialValues.estado_devolucion ?? "NO_APLICA",
+      motivo_devolucion: "",
       investors: parsedInvestors,
       investorsMirror: parsedInvestorsMirror, // 🆕 Campo para espejo
     },
@@ -245,7 +250,11 @@ export function ModalEditCredit({
 
         // Abono capital
         permite_abono_capital: !!values.permite_abono_capital,
-        devolucion_cube: !!values.devolucion_cube,
+        estado_devolucion: values.estado_devolucion,
+        motivo_devolucion:
+          values.estado_devolucion === "PENDIENTE_AUTORIZACION"
+            ? values.motivo_devolucion?.trim() || ""
+            : undefined,
 
         // Lista Principal
         inversionistas: values.investors.map((i: InvestorItem) => ({
@@ -596,39 +605,59 @@ export function ModalEditCredit({
               </div>
 
               <div className="flex items-center justify-between">
-                <div>
+                <div className="space-y-1">
                   <Label className="text-gray-800 font-bold text-sm">
-                    Devolución a CUBE
+                    Solicitar devolución de crédito
                   </Label>
                   <p className="text-xs text-gray-500 mt-0.5">
-                    Si está activo, la generación de pagos usa la lógica de devolución a CUBE
+                    Activar para solicitar devolución del crédito a Cube Investments. Requiere motivo.
                   </p>
                 </div>
                 <button
                   type="button"
                   role="switch"
-                  aria-checked={!!formik.values.devolucion_cube}
-                  onClick={() =>
-                    formik.setFieldValue(
-                      "devolucion_cube",
-                      !formik.values.devolucion_cube
-                    )
-                  }
+                  aria-checked={formik.values.estado_devolucion === 'PENDIENTE_AUTORIZACION'}
+                  onClick={() => {
+                    if (formik.values.estado_devolucion === 'PENDIENTE_AUTORIZACION') {
+                      formik.setFieldValue('estado_devolucion', 'NO_APLICA');
+                      formik.setFieldValue('motivo_devolucion', '');
+                    } else {
+                      formik.setFieldValue('estado_devolucion', 'PENDIENTE_AUTORIZACION');
+                    }
+                  }}
                   className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
-                    formik.values.devolucion_cube
+                    formik.values.estado_devolucion === 'PENDIENTE_AUTORIZACION'
                       ? "bg-green-500"
                       : "bg-gray-300"
                   }`}
                 >
                   <span
                     className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
-                      formik.values.devolucion_cube
+                      formik.values.estado_devolucion === 'PENDIENTE_AUTORIZACION'
                         ? "translate-x-5"
                         : "translate-x-0"
                     }`}
                   />
                 </button>
               </div>
+              {formik.values.estado_devolucion === 'PENDIENTE_AUTORIZACION' && (
+                <div className="mt-2">
+                  <Label className="text-gray-700 font-medium">Motivo de devolución *</Label>
+                  <Input
+                    type="text"
+                    name="motivo_devolucion"
+                    value={formik.values.motivo_devolucion || ''}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    placeholder="Explique el motivo de la solicitud de devolución"
+                    className={formik.touched.motivo_devolucion && formik.errors.motivo_devolucion ? 'border-red-500' : ''}
+                    required
+                  />
+                  {formik.touched.motivo_devolucion && formik.errors.motivo_devolucion && (
+                    <p className="text-red-500 text-xs mt-1">{formik.errors.motivo_devolucion}</p>
+                  )}
+                </div>
+              )}
             </div>
 
             {/* Datos del usuario */}

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -109,6 +109,13 @@ const menuSections: MenuSection[] = [
         path: "/creditos-caidos",
         roles: ["ADMIN"],
       },
+      {
+        key: "devolucion-cube",
+        label: "Devolución Cube",
+        icon: <Briefcase className="h-4 w-4" />,
+        path: "/devolucion-cube",
+        roles: ["ADMIN"],
+      },
     ],
   },
   {

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -141,7 +141,7 @@ export interface Credito {
   formato_credito: string;
   statusCredit: string; // ACTIVO, CANCELADO, INCOBRABLE
   permite_abono_capital?: boolean;
-  devolucion_cube?: boolean;
+  estado_devolucion?: 'NO_APLICA' | 'PENDIENTE_AUTORIZACION' | 'VERIFICADO' | 'RECHAZADO';
 }
 
 export interface Usuario {
@@ -386,7 +386,6 @@ export interface Rubro {
 export interface Credito {
   credito_id: number;
   usuario_id: number;
-  otros: number;
   fecha_creacion: string;
   numero_credito_sifco: string;
   capital: string;
@@ -410,7 +409,7 @@ export interface Credito {
   royalti: string;
   mora: string;
   permite_abono_capital?: boolean;
-  devolucion_cube?: boolean;
+  estado_devolucion?: 'NO_APLICA' | 'PENDIENTE_AUTORIZACION' | 'VERIFICADO' | 'RECHAZADO';
 }
 
 export interface Usuario {
@@ -692,7 +691,7 @@ export interface UpdateCreditBody {
 
   // Abono capital
   permite_abono_capital?: boolean;
-  devolucion_cube?: boolean;
+  estado_devolucion?: 'NO_APLICA' | 'PENDIENTE_AUTORIZACION' | 'VERIFICADO' | 'RECHAZADO';
 
   // Inversionistas nuevos
   inversionistas?: InversionistaPayload[];
@@ -3867,6 +3866,103 @@ export async function compraCarteraAceptadaService(
   const res = await api.post<CompraCarteraAceptadaResponse>(
     `${API_URL}/compra-cartera-aceptada`,
     payload
+  );
+  return res.data;
+}
+
+// ============================================================
+// Devolución crédito (módulo Devolución Cube)
+// ============================================================
+export type EstadoDevolucion =
+  | "NO_APLICA"
+  | "PENDIENTE_AUTORIZACION"
+  | "VERIFICADO"
+  | "RECHAZADO";
+
+export interface DevolucionCreditoItem {
+  credito_id: number;
+  numero_credito_sifco: string;
+  usuario_nombre: string | null;
+  capital: string;
+  cuota: string;
+  fecha_creacion: string;
+  estado_devolucion: EstadoDevolucion;
+  motivo_solicitud?: string | null;
+}
+
+export interface DevolucionHistorialItem {
+  id: number;
+  credito_id: number;
+  usuario_id: number | null;
+  estado_anterior: EstadoDevolucion;
+  estado_nuevo: EstadoDevolucion;
+  motivo?: string | null;
+  created_at: string;
+}
+
+export interface GetPendingDevolucionResponse {
+  success: boolean;
+  data: {
+    credits: DevolucionCreditoItem[];
+    pagination: {
+      page: number;
+      limit: number;
+      total: number;
+      totalPages: number;
+    };
+    status?: string;
+    search?: string;
+  };
+}
+
+export interface BasicDevolucionResponse {
+  success: boolean;
+  message: string;
+}
+
+export interface GetHistorialDevolucionResponse {
+  success: boolean;
+  data: DevolucionHistorialItem[];
+}
+
+export async function getPendingDevolucion(
+  page = 1,
+  limit = 10,
+  status = "PENDIENTE_AUTORIZACION",
+  search = ""
+): Promise<GetPendingDevolucionResponse> {
+  const res = await api.get<GetPendingDevolucionResponse>(
+    `/api/devolucion-credito/list-pending`,
+    { params: { page, limit, status, search } }
+  );
+  return res.data;
+}
+
+export async function aceptarDevolucion(
+  creditoId: number
+): Promise<BasicDevolucionResponse> {
+  const res = await api.post<BasicDevolucionResponse>(
+    `/api/devolucion-credito/${creditoId}/aceptar`
+  );
+  return res.data;
+}
+
+export async function rechazarDevolucion(
+  creditoId: number,
+  motivo: string
+): Promise<BasicDevolucionResponse> {
+  const res = await api.post<BasicDevolucionResponse>(
+    `/api/devolucion-credito/${creditoId}/rechazar`,
+    { motivo }
+  );
+  return res.data;
+}
+
+export async function getHistorialDevolucion(
+  creditoId: number
+): Promise<GetHistorialDevolucionResponse> {
+  const res = await api.get<GetHistorialDevolucionResponse>(
+    `/api/devolucion-credito/${creditoId}/historial`
   );
   return res.data;
 }

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -141,6 +141,7 @@ export interface Credito {
   formato_credito: string;
   statusCredit: string; // ACTIVO, CANCELADO, INCOBRABLE
   permite_abono_capital?: boolean;
+  devolucion_cube?: boolean;
 }
 
 export interface Usuario {
@@ -210,7 +211,7 @@ export interface ConvenioActivo {
   created_by: number;
   created_at: string;
   updated_at: string;
-  
+
   // 🔥 NUEVOS CAMPOS TIPADOS
   cuotasEnConvenio: CuotaEnConvenio[];
   pagosConvenio: PagoConvenio[];
@@ -267,10 +268,10 @@ export interface GetCreditoByNumeroActivoResponse {
   cuotasAtrasadas: Cuota[];
   cuotasPagadas: Cuota[];
   cuotasPendientes: Cuota[];
-  
+
   // 🔥 CONVENIO (puede ser null)
   convenioActivo: ConvenioActivo | null;
-  
+
   // 🔥 ESTOS YA NO SON NECESARIOS porque están dentro de convenioActivo
   // pero los dejamos para compatibilidad
   cuotasEnConvenio: Cuota[];
@@ -409,6 +410,7 @@ export interface Credito {
   royalti: string;
   mora: string;
   permite_abono_capital?: boolean;
+  devolucion_cube?: boolean;
 }
 
 export interface Usuario {
@@ -650,7 +652,7 @@ export interface InversionistaPayload {
   inversionista_id: number;
   monto_aportado: number;
   porcentaje_cash_in: number;
-  porcentaje_inversion: number; 
+  porcentaje_inversion: number;
   fecha_inicio_participacion?: string;
   cuota_inversionista?: number;
 }
@@ -666,7 +668,7 @@ export interface UpdateCreditBody {
   porcentaje_interes?: number;
   deudaTotal?: number;
   cuota: number;
-  iva_12?: number; 
+  iva_12?: number;
   gps?: number;
   observaciones?: string;
   no_poliza?: number;
@@ -690,6 +692,7 @@ export interface UpdateCreditBody {
 
   // Abono capital
   permite_abono_capital?: boolean;
+  devolucion_cube?: boolean;
 
   // Inversionistas nuevos
   inversionistas?: InversionistaPayload[];
@@ -936,9 +939,9 @@ export async function getInvestorTotalsService(
   if (params?.id !== undefined) query.append("id", String(params.id));
   if (params?.dpi) query.append("dpi", params.dpi);
   if (params?.tipo) query.append("tipo", params.tipo);
-  if (params?.incluirLiquidados !== undefined) 
+  if (params?.incluirLiquidados !== undefined)
     query.append("incluirLiquidados", String(params.incluirLiquidados));
-  if (params?.numeroCuota !== undefined) 
+  if (params?.numeroCuota !== undefined)
     query.append("numeroCuota", String(params.numeroCuota));
 
   const url = `${import.meta.env.VITE_BACK_URL}/getInvestorTotals${query.toString() ? `?${query.toString()}` : ""}`;
@@ -1161,7 +1164,7 @@ export async function downloadInvestorPDFService(
     {
       // Asegura que el backend responda JSON (no blob)
       headers: { Accept: "application/json" },
-      responseType: "json", 
+      responseType: "json",
     }
   );
 
@@ -1231,7 +1234,7 @@ export interface CancelCreditResponse {
   };
   error?: string;
 }
- 
+
 
 export async function cancelCreditService(creditId: number): Promise<CancelCreditResponse> {
   const res = await api.post(`${API_URL}/cancelCredit`, { creditId });
@@ -1271,7 +1274,7 @@ export interface PendingCancelCreditPayload {
 export interface ActivateCreditPayload {
   creditId: number;
   accion: "ACTIVAR";
-} 
+}
 export interface BadDebtCreditPayload {
   creditId: number;
   accion: "INCOBRABLE";
@@ -1293,7 +1296,7 @@ export interface CreditActionResponse {
   message: string;
 }
 
-// Cambia esta URL por la de tu backend 
+// Cambia esta URL por la de tu backend
 // Servicio para cancelar o activar crédito
 export async function creditAction(payload: CreditActionPayload): Promise<CreditActionResponse> {
   const { data } = await api.post(`${API_URL}/creditAction`, payload);
@@ -1451,7 +1454,7 @@ export async function getResumenInversionistas(params?: {
   email?: string;
 }
 
- 
+
 
 export const createAdvisor = async (data: Partial<Advisor> & { password?: string }) => {
   const res = await api.post(`${API_URL}/advisor`, data);
@@ -1648,7 +1651,7 @@ export async function getCondonacionesMoraService(params?: {
   );
   return data;}
 
- 
+
 export interface CuotaPago {
   cuotaId: number;
   numeroCuota: number;
@@ -1994,8 +1997,8 @@ export interface ResumenGlobalExcelResponse {
   filename: string;
 }
 
-export type ResumenGlobalResponse = 
-  | InversionistaResumen[] 
+export type ResumenGlobalResponse =
+  | InversionistaResumen[]
   | ResumenGlobalExcelResponse;
 
 
@@ -2010,11 +2013,11 @@ export const notificarContabilidadBoletas = async () => {
 };
 
 export const inversionistasService = {
-  
+
   // 📊 Obtener resumen global
   getResumenGlobal: async (params: ResumenGlobalParams): Promise<ResumenGlobalResponse> => {
     const queryParams = new URLSearchParams();
-    
+
     if (params.inversionistaId) {
       queryParams.append("inversionistaId", params.inversionistaId.toString());
     }
@@ -2031,7 +2034,7 @@ export const inversionistasService = {
     const { data } = await api.get(
       `/resumen-global?${queryParams.toString()}`
     );
-    
+
     return data;
   },
 
@@ -2203,17 +2206,17 @@ export interface GenerateFalsePaymentsError {
 }
 /**
  * 🚀 Genera pagos falsos para un inversionista
- * 
+ *
  * @param params - Parámetros del request
  * @returns Promesa con la respuesta del servidor
- * 
+ *
  * @example
  * // Solo consultar sin generar
  * const resultado = await generateFalsePaymentsService({
  *   inversionistaId: 123,
  *   generateFalsePayment: false
  * });
- * 
+ *
  * @example
  * // Consultar y generar pagos
  * const resultado = await generateFalsePaymentsService({
@@ -2233,7 +2236,7 @@ export async function generateFalsePaymentsService(
     return data;
   } catch (error: any) {
     console.error("❌ Error en generateFalsePaymentsService:", error);
-    
+
     // Retornar error estructurado
     return {
       success: false,
@@ -2598,7 +2601,7 @@ export async function actualizarCuentaPagoService(
     return data;
   } catch (error: any) {
     console.error("❌ Error en actualizarCuentaPagoService:", error);
-    
+
     return {
       success: false,
       message: error.response?.data?.message || "Error al actualizar la cuenta del pago",
@@ -2606,7 +2609,7 @@ export async function actualizarCuentaPagoService(
     };
   }
 }
- 
+
 export interface CreatePaymentAgreementInput {
   credit_id: number;
   payment_ids: number[];
@@ -2893,7 +2896,7 @@ interface Cliente {
   direccion: string;
 }
 
- 
+
 
 interface Factura {
   factura_id: number;
@@ -3016,7 +3019,7 @@ export const getBoletas = async (filters?: GetBoletasFilters) => {
     console.log("📋 Obteniendo boletas con filtros:", filters);
 
     const params = new URLSearchParams();
-    
+
     if (filters?.inversionista_id) {
       params.append("inversionista_id", filters.inversionista_id.toString());
     }

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -753,6 +753,42 @@ app.get("/api/accounting/resumen-global-excel", async (c) => {
 	}
 });
 
+// Obtener URL del Excel de transferencias (ACH / no-ACH)
+app.get("/api/accounting/resumen-transferencias-excel", async (c) => {
+	try {
+		const context = await createContext({ context: c });
+		if (!context.session?.user?.id) {
+			return c.json({ error: "No autorizado" }, 401);
+		}
+
+		const mes = c.req.query("mes");
+		const anio = c.req.query("anio");
+		const ach = c.req.query("ach");
+		const moneda = c.req.query("moneda");
+
+		if (!mes || !anio) {
+			return c.json({ error: "Los parámetros 'mes' y 'anio' son obligatorios" }, 400);
+		}
+
+		const monedaParam: "quetzales" | "dolar" | undefined =
+			moneda === "quetzales" || moneda === "dolar" ? moneda : undefined;
+
+		const { carteraBackClient } = await import(
+			"./services/cartera-back-client"
+		);
+		const result = await carteraBackClient.getResumenTransferenciasExcel({
+			mes: Number(mes),
+			anio: Number(anio),
+			ach: ach === "true",
+			moneda: monedaParam,
+		});
+		return c.json(result);
+	} catch (err: any) {
+		console.error("[ResumenTransferenciasExcel] Error:", err);
+		return c.json({ error: err.message || "Error al descargar Excel" }, 500);
+	}
+});
+
 // Upload boleta de inversionista a cartera-back
 app.post("/api/accounting/upload-boleta", async (c) => {
 	try {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -880,6 +880,32 @@ export class CarteraBackClient {
 		return response;
 	}
 
+	async getResumenTransferenciasExcel(filters: {
+		mes: number;
+		anio: number;
+		ach: boolean;
+		moneda?: "quetzales" | "dolar";
+	}): Promise<{ success: boolean; url: string; filename: string }> {
+		const queryParams = new URLSearchParams();
+		queryParams.set("mes", String(filters.mes));
+		queryParams.set("anio", String(filters.anio));
+		queryParams.set("ach", filters.ach ? "true" : "false");
+		if (filters.moneda) {
+			queryParams.set("moneda", filters.moneda);
+		}
+
+		const response = await this.request<{
+			success: boolean;
+			url: string;
+			filename: string;
+		}>(
+			`/resumen-transferencias?${queryParams.toString()}`,
+			{ method: "GET" },
+			false,
+		);
+		return response;
+	}
+
 	async uploadFile(
 		file: File | Blob,
 		filename: string,

--- a/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
+++ b/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
@@ -10,6 +10,7 @@ import {
 	FileCheck,
 	Loader2,
 	Search,
+	Send,
 	Upload,
 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -34,6 +35,14 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuLabel,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -552,6 +561,9 @@ function PagarInversionistas() {
 	const [search, setSearch] = useState("");
 	const [page, setPage] = useState(1);
 	const [downloadingExcel, setDownloadingExcel] = useState(false);
+	const [downloadingTransferencia, setDownloadingTransferencia] = useState<
+		null | "ach" | "no-ach"
+	>(null);
 	const [estadoBoletaFilter, setEstadoBoletaFilter] =
 		useState<EstadoBoletaFilter>("all");
 	const [mesFiltro, setMesFiltro] = useState(today.getMonth() + 1);
@@ -570,6 +582,42 @@ function PagarInversionistas() {
 		}),
 		[anioFiltro, estadoBoletaFilter, mesFiltro, requiresPeriodo],
 	);
+
+	const handleDownloadTransferencias = async (
+		ach: boolean,
+		moneda?: "quetzales" | "dolar",
+	) => {
+		const key = ach ? "ach" : "no-ach";
+		setDownloadingTransferencia(key);
+		try {
+			const serverUrl = import.meta.env.VITE_SERVER_URL;
+			const queryParams = new URLSearchParams({
+				mes: String(mesFiltro),
+				anio: String(anioFiltro),
+				ach: ach ? "true" : "false",
+			});
+			if (moneda) queryParams.set("moneda", moneda);
+
+			const res = await fetch(
+				`${serverUrl}/api/accounting/resumen-transferencias-excel?${queryParams.toString()}`,
+				{ credentials: "include" },
+			);
+			if (!res.ok) {
+				const err = await res.json();
+				throw new Error(err.error || "Error al descargar");
+			}
+			const data = await res.json();
+			if (!data.success || !data.url) {
+				throw new Error("No se pudo generar el Excel");
+			}
+			window.open(data.url, "_blank");
+			toast.success("Excel de transferencias descargado");
+		} catch (err: any) {
+			toast.error(err.message || "Error al descargar Excel");
+		} finally {
+			setDownloadingTransferencia(null);
+		}
+	};
 
 	const handleDownloadExcel = async () => {
 		setDownloadingExcel(true);
@@ -694,20 +742,36 @@ function PagarInversionistas() {
 						Resumen global de pagos pendientes
 					</p>
 				</div>
-				<Button
-					variant="outline"
-					size="sm"
-					className="gap-2"
-					disabled={downloadingExcel}
-					onClick={handleDownloadExcel}
-				>
-					{downloadingExcel ? (
-						<Loader2 className="h-4 w-4 animate-spin" />
-					) : (
-						<Download className="h-4 w-4" />
-					)}
-					Exportar Excel
-				</Button>
+				<div className="flex flex-wrap gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						className="gap-2"
+						disabled={downloadingExcel}
+						onClick={handleDownloadExcel}
+					>
+						{downloadingExcel ? (
+							<Loader2 className="h-4 w-4 animate-spin" />
+						) : (
+							<Download className="h-4 w-4" />
+						)}
+						Exportar Excel
+					</Button>
+
+					<TransferenciasDropdown
+						label="Transferencia a Terceros"
+						loading={downloadingTransferencia === "no-ach"}
+						disabled={downloadingTransferencia !== null}
+						onSelect={(moneda) => handleDownloadTransferencias(false, moneda)}
+					/>
+
+					<TransferenciasDropdown
+						label="Transferencias ACH"
+						loading={downloadingTransferencia === "ach"}
+						disabled={downloadingTransferencia !== null}
+						onSelect={(moneda) => handleDownloadTransferencias(true, moneda)}
+					/>
+				</div>
 			</div>
 
 			{/* Stats */}
@@ -887,6 +951,51 @@ function StatCard({
 				</div>
 			</CardContent>
 		</Card>
+	);
+}
+
+function TransferenciasDropdown({
+	label,
+	loading,
+	disabled,
+	onSelect,
+}: {
+	label: string;
+	loading: boolean;
+	disabled: boolean;
+	onSelect: (moneda?: "quetzales" | "dolar") => void;
+}) {
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button
+					variant="outline"
+					size="sm"
+					className="gap-2"
+					disabled={disabled}
+				>
+					{loading ? (
+						<Loader2 className="h-4 w-4 animate-spin" />
+					) : (
+						<Send className="h-4 w-4" />
+					)}
+					{label}
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				<DropdownMenuLabel>Seleccionar moneda</DropdownMenuLabel>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem onSelect={() => onSelect("quetzales")}>
+					Quetzales (Q)
+				</DropdownMenuItem>
+				<DropdownMenuItem onSelect={() => onSelect("dolar")}>
+					Dólares ($)
+				</DropdownMenuItem>
+				<DropdownMenuItem onSelect={() => onSelect(undefined)}>
+					Ambas
+				</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
 	);
 }
 


### PR DESCRIPTION
# Implementar campo devolucion_cube para lógica de devolución completa en pagos espejo y salida automática

## Cambios realizados

### Backend (CarteraBackend)
- **Nueva columna en schema**: Agregado `devolucion_cube` (boolean, default false) en tabla `creditos` (src/database/db/schema.ts).
- **Migración SQL**: Creada `0001_add_requires_cube_to_creditos.sql` (renombrada y adaptada) para agregar/renombrar la columna si existía legacy (drizzle/).
- **Endpoint updateCredit**: Persiste `devolucion_cube` en créditos (src/controllers/updateCredit.ts).
- **Lógica pagos espejo**: En `insertPagosCreditoInversionistas`, si `devolucion_cube=true`, asigna abono_capital = monto_aportado completo (sin restar cargos/interés/IVA), evitando doble conteo en abonos pendientes (src/controllers/payments.ts).
- **Flujo liquidación**: En `liquidateByInvestorId`, antes de validar pendiente_devolucion, filtra créditos de la corrida con `devolucion_cube=true` y ejecuta salida automática `exitInvestor` solo para ellos (src/controllers/investor.ts).

### Frontend (CarteraFront)
- **UI modal edición**: Agregado toggle "Devolución a CUBE" en opciones de crédito, con tooltip explicativo (src/private/cartera/components/ModalEditCredit.tsx).
- **Payload update**: Incluye `devolucion_cube` al guardar (sin legacy requires_cube).
- **Lectura inicial**: Carga `devolucion_cube` al abrir modal de edición (src/private/cartera/components/CreditsPaymentsData.tsx).
- **Tipos**: Actualizados en interfaces Credito y UpdateCreditBody para `devolucion_cube` (src/private/cartera/services/services.ts), removido legacy requires_cube.

## Objetivo
- Permite marcar créditos como "Devolución a CUBE" para que en generación de pagos espejo se devuelva el monto_aportado completo (lógica especial).
- En liquidaciones, aplica salida automática (exitInvestor) solo para créditos con esta marca, independientemente del status del inversionista.
- Limpieza de código: removido endpoint masivo (calcularPagosEspejoMasivo) y legacy requires_cube.

## Cómo probar
1. **Agregar campo**: Aplicar migración y restart server.
2. **Editar crédito**: En lista de créditos, click editar → activar "Devolución a CUBE" → guardar.
3. **Generar pagos espejo**: Para un crédito marcado, llamar `/calcularPagosEspejo` o flujo manual → verificar abono_capital = monto_aportado total (sin deducciones).
4. **Liquidación + salida**: Marcar crédito con devolucion_cube=true, liquidar → verificar que se ejecute exitInvestor solo para esos créditos, y inversionista quede inactivo.
5. **Diagnósticos**: No hay errores nuevos; warnings previos en CreditsPaymentsData.tsx no relacionados.

## Archivos modificados
- src/database/db/schema.ts
- drizzle/0001_add_requires_cube_to_creditos.sql
- src/controllers/updateCredit.ts
- src/controllers/payments.ts
- src/controllers/investor.ts
- src/private/cartera/components/ModalEditCredit.tsx
- src/private/cartera/components/CreditsPaymentsData.tsx
- src/private/cartera/services/services.ts
- src/routers/investor.ts
