### PR TITLE
feat(liquidaciones): enable payment generation from history with detailed feedback

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1542,6 +1542,20 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           WHERE bol.pago_id = p.pago_id
         ), '[]'::json) AS "boletas",
 
+        -- 🧾 Facturas electrónicas activas asociadas
+        COALESCE((
+          SELECT json_agg(
+            json_build_object(
+              'facturaId', fe.factura_id,
+              'serie', fe.serie,
+              'numero', fe.numero
+            )
+          )
+          FROM cartera.facturas_electronicas fe
+          WHERE fe.pago_id = p.pago_id
+            AND fe.status = 'ACTIVA'
+        ), '[]'::json) AS "facturas",
+
         -- 🔴 Cancelación del crédito (solo si validation_status = 'reset')
         CASE WHEN p.validation_status = 'reset' THEN (
           SELECT json_build_object(
@@ -1629,6 +1643,11 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
         ? r.boletas
         : JSON.parse(
             typeof r.boletas === "string" ? r.boletas : "[]"
+          ),
+      facturas: Array.isArray(r.facturas)
+        ? r.facturas
+        : JSON.parse(
+            typeof r.facturas === "string" ? r.facturas : "[]"
           ),
       cancelacion: r.cancelacion ?? null,
     }));
@@ -1839,7 +1858,9 @@ export async function obtenerCreditosConPagosPendientes(
       .where(
         and(
           eq(creditos_inversionistas_espejo.inversionista_id, inversionistaId),
-          inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "PENDIENTE_CANCELACION", "EN_CONVENIO"])
+          inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "PENDIENTE_CANCELACION", "EN_CONVENIO"]),
+          eq(creditos_inversionistas_espejo.status, "completado"),
+          lt(creditos_inversionistas_espejo.fecha_inicio_participacion, rangoMesActual.inicio)
         )
       );
 

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -648,6 +648,8 @@ export async function exportPagosConInversionistasExcel(
     { header: "Cuenta Empresa", key: "cuentaEmpresaNombre", width: 20 },
     { header: "Banco Empresa", key: "cuentaEmpresaBanco", width: 20 },
     { header: "Número Cuenta Empresa", key: "cuentaEmpresaNumero", width: 20 },
+    { header: "¿Tiene Factura?", key: "tieneFactura", width: 15 },
+    { header: "Números Factura", key: "numerosFactura", width: 30 },
   ];
 
   const totalCols = columns.length;
@@ -712,6 +714,12 @@ export async function exportPagosConInversionistasExcel(
     const inversionistas = item.inversionistas ?? [];
     const txFirstInvRow = sheet.rowCount + 1;
 
+    const facturas = item.facturas ?? [];
+    const tieneFactura = facturas.length > 0 ? "Sí" : "No";
+    const numerosFactura = facturas
+      .map((f: any) => `[${f.serie}-${f.numero}]`)
+      .join("");
+
     // Campos comunes del pago
     const commonPayFields = {
       categoriaCredito: item.usuario?.categoria ?? "",
@@ -723,6 +731,8 @@ export async function exportPagosConInversionistasExcel(
       cuentaEmpresaNombre: item.cuentaEmpresaNombre ?? "",
       cuentaEmpresaBanco: item.cuentaEmpresaBanco ?? "",
       cuentaEmpresaNumero: item.cuentaEmpresaNumero ?? "",
+      tieneFactura,
+      numerosFactura,
     };
 
     if (inversionistas.length === 0) {
@@ -971,6 +981,8 @@ export async function exportPagosAdvisorExcel(
     { header: "Reserva", key: "reserva", width: 15 },
     { header: "Registrado Por (Email)", key: "registerBy", width: 30 },
     { header: "Pago ID", key: "pagoId", width: 12 },
+    { header: "¿Tiene Factura?", key: "tieneFactura", width: 15 },
+    { header: "Números Factura", key: "numerosFactura", width: 30 },
   );
 
   // Setear solo key + width (sin header, para no escribir en row 1 automáticamente)
@@ -1035,6 +1047,10 @@ export async function exportPagosAdvisorExcel(
       reserva: item.reserva,
       registerBy: item.registerBy,
       pagoId: item.pagoId,
+      tieneFactura: (item.facturas ?? []).length > 0 ? "Sí" : "No",
+      numerosFactura: (item.facturas ?? [])
+        .map((f: any) => `[${f.serie}-${f.numero}]`)
+        .join(""),
     };
 
     // Boletas dinámicas

--- a/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
+++ b/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useMemo, useCallback } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { useNavigate } from "react-router-dom";
 import {
   getResumenGlobalLiquidaciones,
   descargarResumenLiquidacionesExcel,
   type LiquidacionResumen,
+  type CalcularPagosEspejoResponse,
 } from "../services/services";
+import { useCalcularPagosEspejo } from "../hooks/getInvestor";
 import {
   ChevronLeft,
   ChevronRight,
@@ -16,10 +19,23 @@ import {
   Loader2,
   Landmark,
   RefreshCw,
+  Eye,
+  Calculator,
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { toast } from "sonner";
 
 const PER_PAGE = 25;
@@ -98,12 +114,26 @@ const ESTADO_META: Record<
   },
 };
 
-function LiquidacionCard({ item }: { item: LiquidacionResumen }) {
+interface LiquidacionCardProps {
+  item: LiquidacionResumen;
+  onGenerarPagos: (id: number) => void;
+  onVerPagos: (id: number) => void;
+  generandoId: number | null;
+  navegandoId: number | null;
+}
+
+function LiquidacionCard({ item, onGenerarPagos, onVerPagos, generandoId, navegandoId }: LiquidacionCardProps) {
   const s = item.currencySymbol;
   const boleta = item.boleta_liquidacion;
   const estadoMeta = ESTADO_META[item.estado_liquidacion_resumen];
   const reinvCap = Number(item.total_reinversion_capital ?? 0);
   const reinvInt = Number(item.total_reinversion_interes ?? 0);
+  const estado = item.estado_liquidacion_resumen;
+
+  const puedeGenerarPagos = estado === "sin_movimiento";
+  const puedeVerPagos = estado !== "sin_movimiento";
+  const generandoEste = generandoId === item.inversionista_id;
+  const navegandoEste = navegandoId === item.inversionista_id;
 
   const cuentaTexto = item.banco
     ? `${item.banco} — ${item.tipo_cuenta ?? ""} ${item.numero_cuenta ?? ""}`.trim()
@@ -197,14 +227,54 @@ function LiquidacionCard({ item }: { item: LiquidacionResumen }) {
         </div>
       </div>
 
-      {/* Boleta + Reporte */}
+      {/* Acciones */}
       <div className="flex flex-wrap gap-2 pt-2 border-t border-gray-100 mt-auto">
+        {puedeGenerarPagos && (
+          <button
+            type="button"
+            onClick={() => onGenerarPagos(item.inversionista_id)}
+            disabled={generandoEste}
+            className="inline-flex items-center gap-1.5 text-xs font-semibold text-white bg-purple-600 hover:bg-purple-700 disabled:opacity-60 px-3.5 py-2 rounded-lg shadow-sm transition-colors"
+          >
+            {generandoEste ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Generando...
+              </>
+            ) : (
+              <>
+                <Calculator className="w-3.5 h-3.5" />
+                Generar Pagos
+              </>
+            )}
+          </button>
+        )}
+        {puedeVerPagos && (
+          <button
+            type="button"
+            onClick={() => onVerPagos(item.inversionista_id)}
+            disabled={navegandoEste}
+            className="inline-flex items-center gap-1.5 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-60 px-3.5 py-2 rounded-lg shadow-sm transition-colors"
+          >
+            {navegandoEste ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Abriendo...
+              </>
+            ) : (
+              <>
+                <Eye className="w-3.5 h-3.5" />
+                Ver Detalle
+              </>
+            )}
+          </button>
+        )}
         {boleta?.boleta_url && (
           <a
             href={boleta.boleta_url}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1.5 text-xs font-semibold text-white bg-blue-600 hover:bg-blue-700 px-3.5 py-2 rounded-lg shadow-sm transition-colors"
+            className="inline-flex items-center gap-1.5 text-xs font-semibold text-gray-700 bg-white hover:bg-gray-50 border border-gray-300 px-3.5 py-2 rounded-lg shadow-sm transition-colors"
           >
             <Download className="w-3.5 h-3.5" />
             Boleta
@@ -221,9 +291,6 @@ function LiquidacionCard({ item }: { item: LiquidacionResumen }) {
             Reporte
           </a>
         )}
-        {!boleta?.boleta_url && !item.reporte_liquidacion_url && (
-          <span className="text-xs text-gray-400 italic">Sin documentos adjuntos</span>
-        )}
       </div>
     </div>
   );
@@ -237,6 +304,16 @@ export function HistorialLiquidaciones() {
   const [page, setPage] = useState(1);
   const [estadoFiltro, setEstadoFiltro] = useState<EstadoFiltro>("all");
   const [descargandoExcel, setDescargandoExcel] = useState(false);
+  const [generandoId, setGenerandoId] = useState<number | null>(null);
+  const [navegandoId, setNavegandoId] = useState<number | null>(null);
+  const [resultadoModal, setResultadoModal] = useState<{
+    nombre: string;
+    inversionistaId: number;
+    response?: CalcularPagosEspejoResponse;
+    errorMsg?: string;
+  } | null>(null);
+  const navigate = useNavigate();
+  const { mutate: calcularPagosEspejo } = useCalcularPagosEspejo();
 
   const { data, isLoading, isError, refetch } = useQuery<LiquidacionResumen[]>({
     queryKey: ["historial-liquidaciones", mes, anio],
@@ -300,6 +377,44 @@ export function HistorialLiquidaciones() {
     setEstadoFiltro(estado);
     setPage(1);
   }, []);
+
+  const handleGenerarPagos = useCallback(
+    (inversionistaId: number) => {
+      const inv = data?.find((d) => d.inversionista_id === inversionistaId);
+      const nombre = inv?.nombre ?? `Inversionista #${inversionistaId}`;
+      setGenerandoId(inversionistaId);
+      calcularPagosEspejo(inversionistaId, {
+        onSuccess: (res: any) => {
+          setResultadoModal({
+            nombre,
+            inversionistaId,
+            response: res as CalcularPagosEspejoResponse,
+          });
+          if (res?.success) refetch();
+        },
+        onError: (err: any) => {
+          setResultadoModal({
+            nombre,
+            inversionistaId,
+            errorMsg: err?.message ?? "Error al generar los pagos",
+          });
+        },
+        onSettled: () => setGenerandoId(null),
+      });
+    },
+    [calcularPagosEspejo, refetch, data],
+  );
+
+  const handleVerPagos = useCallback(
+    (inversionistaId: number) => {
+      setNavegandoId(inversionistaId);
+      // Pequeño delay para que el spinner sea visible antes del cambio de ruta
+      setTimeout(() => {
+        navigate(`/inversionistas?id=${inversionistaId}`);
+      }, 250);
+    },
+    [navigate],
+  );
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / PER_PAGE));
   const paginated = useMemo(
@@ -510,7 +625,14 @@ export function HistorialLiquidaciones() {
         {!isLoading && !isError && paginated.length > 0 && (
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 w-full items-stretch auto-rows-fr">
             {paginated.map((item) => (
-              <LiquidacionCard key={item.inversionista_id} item={item} />
+              <LiquidacionCard
+                key={item.inversionista_id}
+                item={item}
+                onGenerarPagos={handleGenerarPagos}
+                onVerPagos={handleVerPagos}
+                generandoId={generandoId}
+                navegandoId={navegandoId}
+              />
             ))}
           </div>
         )}
@@ -563,6 +685,134 @@ export function HistorialLiquidaciones() {
           </button>
         </div>
       )}
+
+      <ResultadoGeneracionModal
+        resultado={resultadoModal}
+        onClose={() => setResultadoModal(null)}
+        onVerDetalle={(id) => {
+          setResultadoModal(null);
+          navigate(`/inversionistas?id=${id}`);
+        }}
+      />
     </div>
+  );
+}
+
+interface ResultadoGeneracionModalProps {
+  resultado: {
+    nombre: string;
+    inversionistaId: number;
+    response?: CalcularPagosEspejoResponse;
+    errorMsg?: string;
+  } | null;
+  onClose: () => void;
+  onVerDetalle: (inversionistaId: number) => void;
+}
+
+function ResultadoGeneracionModal({ resultado, onClose, onVerDetalle }: ResultadoGeneracionModalProps) {
+  if (!resultado) return null;
+
+  const { nombre, inversionistaId, response, errorMsg } = resultado;
+  const success = !!response?.success && !errorMsg;
+  const totalCreditos = response?.totalCreditosProcesados ?? 0;
+  const totalPagos = (response?.data ?? []).reduce(
+    (acc, d) => acc + (Number(d.pagosRegistrados) || 0),
+    0,
+  );
+  const huboPagos = success && totalPagos > 0;
+  const sinPagos = success && totalPagos === 0;
+  const fallo = !success;
+
+  let icon: React.ReactNode;
+  let titulo: string;
+  let descripcion: string;
+  let toneClass: string;
+
+  if (fallo) {
+    icon = <XCircle className="w-6 h-6 text-rose-600" />;
+    titulo = "No se pudieron generar los pagos";
+    descripcion = errorMsg ?? response?.message ?? "Ocurrió un error al procesar la solicitud.";
+    toneClass = "bg-rose-50 border-rose-200";
+  } else if (sinPagos) {
+    icon = <AlertTriangle className="w-6 h-6 text-amber-600" />;
+    titulo = "No se generaron pagos";
+    descripcion =
+      totalCreditos === 0
+        ? "El inversionista no tiene créditos elegibles para generar pagos en este momento."
+        : "Se procesaron créditos pero ninguno tenía cuotas pendientes para generar pagos.";
+    toneClass = "bg-amber-50 border-amber-200";
+  } else {
+    icon = <CheckCircle2 className="w-6 h-6 text-emerald-600" />;
+    titulo = "Pagos generados correctamente";
+    descripcion = `Se procesaron ${totalCreditos} crédito${totalCreditos !== 1 ? "s" : ""} y se registraron ${totalPagos} pago${totalPagos !== 1 ? "s" : ""}.`;
+    toneClass = "bg-emerald-50 border-emerald-200";
+  }
+
+  return (
+    <Dialog open={!!resultado} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-gray-900">
+            {icon}
+            {titulo}
+          </DialogTitle>
+          <DialogDescription className="text-gray-600">
+            <span className="font-medium text-gray-800">{nombre}</span>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className={`rounded-lg border p-3 text-sm text-gray-700 ${toneClass}`}>
+          {descripcion}
+        </div>
+
+        {huboPagos && response?.data && response.data.length > 0 && (
+          <div className="max-h-64 overflow-y-auto rounded-lg border border-gray-200">
+            <table className="w-full text-sm">
+              <thead className="bg-gray-50 text-xs uppercase text-gray-600 sticky top-0">
+                <tr>
+                  <th className="px-3 py-2 text-left font-semibold">Crédito SIFCO</th>
+                  <th className="px-3 py-2 text-center font-semibold">Cuota</th>
+                  <th className="px-3 py-2 text-right font-semibold">Pagos</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {response.data.map((row) => (
+                  <tr key={row.creditoId} className="hover:bg-gray-50">
+                    <td className="px-3 py-2 font-medium text-gray-800">{row.numeroCreditoSifco}</td>
+                    <td className="px-3 py-2 text-center text-gray-600">#{row.cuotaProcesada}</td>
+                    <td className="px-3 py-2 text-right">
+                      <Badge
+                        variant="outline"
+                        className={
+                          row.pagosRegistrados > 0
+                            ? "border-emerald-300 text-emerald-700 bg-emerald-50"
+                            : "border-gray-300 text-gray-600 bg-gray-50"
+                        }
+                      >
+                        {row.pagosRegistrados}
+                      </Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        <DialogFooter className="gap-2">
+          <Button variant="outline" onClick={onClose}>
+            Cerrar
+          </Button>
+          {huboPagos && (
+            <Button
+              onClick={() => onVerDetalle(inversionistaId)}
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              Ver Detalle
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -57,6 +57,7 @@ import {
 import { Combobox, Transition } from "@headlessui/react";
 import { Input } from "@/components/ui/input";
 import { Fragment, useState, useEffect, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { ConfirmationModal } from "@/components/ui/confirmation-modal";
 import { CrearBoletaInversionista } from "./investorPayment";
 import { InvestorDocumentsModal } from "./investorDocuments";
@@ -246,11 +247,29 @@ export function TableInvestors() {
   const handleCancelarLiquidarTodos = () => {
     setShowLiquidarTodosModal(false);
   };
-  const [selectedInvestor, setSelectedInvestor] = useState<number | "">("");
+  const [searchParams] = useSearchParams();
+  const initialInvestorIdFromUrl = (() => {
+    const raw = searchParams.get("id");
+    const n = raw ? Number(raw) : NaN;
+    return Number.isFinite(n) && n > 0 ? n : "";
+  })();
+  const [selectedInvestor, setSelectedInvestor] = useState<number | "">(initialInvestorIdFromUrl);
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
   const [expandedCredit, setExpandedCredit] = useState<number | null>(null);
+
+  // Si cambia el ?id= en la URL después de montado (navegación interna), reflejarlo
+  useEffect(() => {
+    const raw = searchParams.get("id");
+    if (!raw) return;
+    const n = Number(raw);
+    if (Number.isFinite(n) && n > 0 && n !== selectedInvestor) {
+      setSelectedInvestor(n);
+      setPage(1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
 
   // Catálogo de inversionistas (para el filtro)
   const { investors = [], loading: loadingCatalogs } = useCatalogs() as {


### PR DESCRIPTION
Introduces the ability to trigger investor payment calculation and registration directly from the liquidation history.

- Adds a "Generar Pagos" action to individual investor liquidation cards, with a detailed modal summarizing the outcome.
- Integrates active electronic invoice data into payment queries and Excel reports.
- Refines eligibility criteria for pending investor credits to ensure accurate monthly payment calculations.
- Enhances navigation by allowing deep linking to specific investor details via URL parameters.
