### PR TITLE
feat(cartera): filter /bancos route to show only transfer-capable banks

### DIFF
--- a/apps/auth-google/src/routes/cartera.routes.ts
+++ b/apps/auth-google/src/routes/cartera.routes.ts
@@ -119,7 +119,7 @@ carteraRoutes.get("/investor", async (c) => {
  */
 carteraRoutes.get("/bancos", async (c) => {
   try {
-    const bancos = await getBancos();
+    const bancos = await getBancos(true);
 
     return c.json({
       success: true,

--- a/apps/auth-google/src/services/cartera/investor.service.ts
+++ b/apps/auth-google/src/services/cartera/investor.service.ts
@@ -162,13 +162,21 @@ export const getInvestorDocuments = async (
 
 /**
  * Obtener catálogo de bancos
+ * @param soloConTransferencia Si es true, sólo devuelve bancos con id_banco_transferencia asignado
  */
-export const getBancos = async (): Promise<Banco[]> => {
+export const getBancos = async (
+  soloConTransferencia = false
+): Promise<Banco[]> => {
   try {
     // Asegurar autenticación
     const token = await ensureCarteraAuth();
 
-    const response = await fetch(`${env.CARTERA_API_URL}/bancos`, {
+    const url = new URL(`${env.CARTERA_API_URL}/bancos`);
+    
+    url.searchParams.set("con_transferencia", "true");
+    
+
+    const response = await fetch(url.toString(), {
       method: "GET",
       headers: {
         Authorization: `Bearer ${token}`,

--- a/apps/cartera-back/src/routers/banks.ts
+++ b/apps/cartera-back/src/routers/banks.ts
@@ -1,6 +1,6 @@
 // routes/bancos.ts
 import { Elysia, t } from "elysia";
-import { eq } from 'drizzle-orm';
+import { eq, isNotNull } from 'drizzle-orm';
 import { db } from '../database';
 import { bancos } from '../database/db';
 import { authMiddleware } from "./midleware";
@@ -9,12 +9,16 @@ export const bancosRouter = new Elysia()
   .use(authMiddleware)
 
   // 📋 GET - Obtener todos los bancos
-  .get("/bancos", async () => {
+  .get("/bancos", async ({ query }) => {
     try {
-      const todosBancos = await db
-        .select()
-        .from(bancos)
-        .orderBy(bancos.nombre);
+      const soloConTransferencia = query.con_transferencia === "true";
+
+      const baseQuery = db.select().from(bancos);
+      const todosBancos = soloConTransferencia
+        ? await baseQuery
+            .where(isNotNull(bancos.id_banco_transferencia))
+            .orderBy(bancos.nombre)
+        : await baseQuery.orderBy(bancos.nombre);
 
       return {
         success: true,
@@ -28,6 +32,10 @@ export const bancosRouter = new Elysia()
         error: error instanceof Error ? error.message : 'Error desconocido',
       };
     }
+  }, {
+    query: t.Object({
+      con_transferencia: t.Optional(t.String()),
+    }),
   })
   
   // ✨ POST - Crear nuevo banco


### PR DESCRIPTION
The `/bancos` route in the Google Auth application now retrieves only banks that are configured for electronic transfers. This ensures that only banks with an `id_banco_transferencia` assigned are displayed, making the bank selection more relevant for transfer-related operations.
