### PR TITLE
fix(crm-leads): Ensure selected lead data consistency after update

### DIFF
--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -457,12 +457,23 @@ function RouteComponent() {
 
 	const updateLeadMutation = useMutation({
 		mutationFn: (input: UpdateLeadInput) => client.updateLead(input),
-		onSuccess: (_data, variables) => {
-			queryClient.invalidateQueries({
+		onSuccess: async (_data, variables) => {
+			await queryClient.invalidateQueries({
 				predicate: (query) =>
 					query.queryKey[0] === "getLeads" ||
-					query.queryKey[0] === "getLeadsStats",
+					query.queryKey[0] === "getLeadsStats" ||
+					query.queryKey[0] === "getLeadById",
 			});
+
+			// Refrescar el lead seleccionado para que el modal muestre los datos actualizados
+			if (selectedLead?.id === variables.id) {
+				const freshResult = await client.getLeads({ id: variables.id });
+				const freshLead = (freshResult?.data as Lead[] | undefined)?.[0];
+				if (freshLead) {
+					setSelectedLead(freshLead);
+				}
+			}
+
 			// Solo mostrar toast y cerrar dialogs si NO es una conversión
 			if (variables.status !== "converted") {
 				toast.success("Lead actualizado exitosamente");

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -458,21 +458,12 @@ function RouteComponent() {
 	const updateLeadMutation = useMutation({
 		mutationFn: (input: UpdateLeadInput) => client.updateLead(input),
 		onSuccess: async (_data, variables) => {
-			await queryClient.invalidateQueries({
+			queryClient.invalidateQueries({
 				predicate: (query) =>
 					query.queryKey[0] === "getLeads" ||
 					query.queryKey[0] === "getLeadsStats" ||
 					query.queryKey[0] === "getLeadById",
 			});
-
-			// Refrescar el lead seleccionado para que el modal muestre los datos actualizados
-			if (selectedLead?.id === variables.id) {
-				const freshResult = await client.getLeads({ id: variables.id });
-				const freshLead = (freshResult?.data as Lead[] | undefined)?.[0];
-				if (freshLead) {
-					setSelectedLead(freshLead);
-				}
-			}
 
 			// Solo mostrar toast y cerrar dialogs si NO es una conversión
 			if (variables.status !== "converted") {
@@ -480,6 +471,22 @@ function RouteComponent() {
 				setIsCreateDialogOpen(false);
 				setEditingLead(null);
 				createLeadForm.reset();
+			}
+
+			// Refrescar el lead seleccionado para que el modal muestre los datos actualizados.
+			// Va al final y aislado en try/catch: la mutación ya tuvo éxito en el servidor,
+			// un fallo aquí (p. ej. red) no debe revertir el flujo de éxito de la UI.
+			if (selectedLead?.id === variables.id) {
+				try {
+					const freshResult = await client.getLeads({ id: variables.id });
+					const freshLead = (freshResult?.data as Lead[] | undefined)?.[0];
+					if (freshLead) {
+						setSelectedLead(freshLead);
+					}
+				} catch {
+					// Silenciar: la invalidación ya marcó las queries como stale
+					// y se refrescarán en el próximo re-fetch.
+				}
 			}
 		},
 		onError: (error: any) => {


### PR DESCRIPTION
Invalidates the `getLeadById` query and explicitly refreshes the local state
of the `selectedLead` when the updated lead is currently displayed. This
prevents stale data from appearing in modals or detail views immediately
following a lead modification.
