### PR TITLE
fix auth session diagnostics

### DIFF
--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import { RPCHandler } from "@orpc/server/fetch";
 import { and, desc, eq, gt, sql } from "drizzle-orm";
-import { Hono } from "hono";
+import { type Context as HonoContext, Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import {
@@ -26,6 +26,7 @@ import {
 	validatePortalToken,
 } from "./controllers/portal-lead";
 import { createPublicLead } from "./controllers/public-lead";
+import { getVehicleByCodigoController } from "./controllers/vehicles";
 import type { db } from "./db";
 import { otps } from "./db/schema/otp";
 import {
@@ -34,13 +35,39 @@ import {
 } from "./jobs/cobros-notifications";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
-import { appRouter, disbursementRouter, manualVehicleRouter } from "./routers/index";
+import {
+	appRouter,
+	disbursementRouter,
+	manualVehicleRouter,
+} from "./routers/index";
 import { investmentsRouter } from "./routers/investments";
 import externalContractsRouter from "./routes/external-contracts";
 
-import { getVehicleByCodigoController } from "./controllers/vehicles";
-
 const app = new Hono();
+const AUTH_DIAG_PREFIX = "CRM_AUTH_DIAG";
+
+function logAuthDiagnostic(reason: string, detail: Record<string, unknown>) {
+	console.warn(
+		AUTH_DIAG_PREFIX,
+		JSON.stringify({
+			...detail,
+			reason,
+			timestamp: new Date().toISOString(),
+		}),
+	);
+}
+
+function getRequestDiagnostic(c: HonoContext) {
+	return {
+		ip:
+			c.req.header("cf-connecting-ip") ||
+			c.req.header("x-forwarded-for") ||
+			"unknown",
+		origin: c.req.header("origin") || null,
+		path: c.req.path,
+		userAgent: c.req.header("user-agent") || null,
+	};
+}
 
 app.use(logger());
 app.use(
@@ -79,7 +106,54 @@ app.use(
 	}),
 );
 
-app.on(["POST", "GET"], "/api/auth/**", (c) => auth.handler(c.req.raw));
+app.post("/api/auth-diagnostics/client-event", async (c) => {
+	let body: unknown = null;
+	try {
+		body = await c.req.json();
+	} catch {
+		body = { parseError: true };
+	}
+
+	logAuthDiagnostic("client-event", {
+		...getRequestDiagnostic(c),
+		body,
+	});
+
+	return c.json({ ok: true });
+});
+
+app.on(["POST", "GET"], "/api/auth/**", async (c) => {
+	const response = await auth.handler(c.req.raw);
+	const requestInfo = getRequestDiagnostic(c);
+
+	if (c.req.path.includes("/sign-out")) {
+		logAuthDiagnostic("auth-sign-out", {
+			...requestInfo,
+			status: response.status,
+		});
+	}
+
+	if (response.status >= 400) {
+		logAuthDiagnostic("auth-response-error", {
+			...requestInfo,
+			status: response.status,
+			statusText: response.statusText,
+		});
+	}
+
+	if (c.req.path.includes("/get-session") && response.status === 200) {
+		const body = await response.clone().text();
+		if (body === "null") {
+			logAuthDiagnostic("auth-get-session-null", {
+				...requestInfo,
+				hasCookie: c.req.header("cookie")?.includes("better-auth") ?? false,
+				status: response.status,
+			});
+		}
+	}
+
+	return response;
+});
 
 // External contracts endpoint (requires service account authentication)
 app.route("/api/contracts/external", externalContractsRouter);
@@ -964,8 +1038,6 @@ app.get("/info/vehicle-details", async (c) => {
 	const result = await getVehicleByCodigoController(numero_sifco);
 	return c.json(result, result.success ? 200 : 404);
 });
-
-
 
 // Job periódico de notificaciones de cobros (cada hora)
 setInterval(

--- a/apps/crm/apps/server/src/lib/context.ts
+++ b/apps/crm/apps/server/src/lib/context.ts
@@ -9,6 +9,20 @@ export async function createContext({ context }: CreateContextOptions) {
 	const session = await auth.api.getSession({
 		headers: context.req.raw.headers,
 	});
+	const cookie = context.req.header("cookie") || "";
+	if (!session && cookie.includes("better-auth")) {
+		console.warn(
+			"CRM_AUTH_DIAG",
+			JSON.stringify({
+				hasCookie: true,
+				origin: context.req.header("origin") || null,
+				path: context.req.path,
+				reason: "rpc-session-null-with-cookie",
+				timestamp: new Date().toISOString(),
+				userAgent: context.req.header("user-agent") || null,
+			}),
+		);
+	}
 	return {
 		session,
 		headers: context.req.raw.headers,

--- a/apps/crm/apps/web/src/components/user-menu.tsx
+++ b/apps/crm/apps/web/src/components/user-menu.tsx
@@ -10,6 +10,7 @@ import {
 	DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { authClient } from "@/lib/auth-client";
+import { logAuthDiagnostic } from "@/lib/auth-session";
 import { getRoleColor, getRoleLabel } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
@@ -89,6 +90,10 @@ export default function UserMenu() {
 						variant="outline"
 						className="w-full"
 						onClick={async () => {
+							logAuthDiagnostic({
+								detail: { userId: session.user.id },
+								reason: "user-clicked-sign-out",
+							});
 							await authClient.signOut();
 							window.location.href = "/";
 						}}

--- a/apps/crm/apps/web/src/lib/auth-client.ts
+++ b/apps/crm/apps/web/src/lib/auth-client.ts
@@ -1,6 +1,7 @@
 import { adminClient } from "better-auth/client/plugins";
 import { createAccessControl } from "better-auth/plugins/access";
 import { createAuthClient } from "better-auth/react";
+import { logAuthDiagnostic } from "./auth-session";
 
 // Create access control matching server configuration
 const statement = {
@@ -37,6 +38,29 @@ const cobrosRole = ac.newRole({
 
 export const authClient = createAuthClient({
 	baseURL: import.meta.env.VITE_SERVER_URL,
+	fetchOptions: {
+		onError: (context: unknown) => {
+			const authError = context as {
+				error?: {
+					message?: string;
+					status?: number;
+					statusText?: string;
+				};
+				request?: { url?: string | URL };
+				response?: { status?: number; statusText?: string };
+			};
+			logAuthDiagnostic({
+				detail: {
+					message: authError.error?.message,
+					path: authError.request?.url?.toString(),
+					status: authError.error?.status ?? authError.response?.status,
+					statusText:
+						authError.error?.statusText ?? authError.response?.statusText,
+				},
+				reason: "better-auth-client-error",
+			});
+		},
+	},
 	plugins: [
 		adminClient({
 			ac,

--- a/apps/crm/apps/web/src/lib/auth-session.test.ts
+++ b/apps/crm/apps/web/src/lib/auth-session.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { shouldRedirectToLogin } from "./auth-session";
+
+describe("shouldRedirectToLogin", () => {
+	test("redirects when session check finished without a session", () => {
+		expect(
+			shouldRedirectToLogin({
+				error: null,
+				isPending: false,
+				session: null,
+			}),
+		).toBe(true);
+	});
+
+	test("does not redirect while session check is pending", () => {
+		expect(
+			shouldRedirectToLogin({
+				error: null,
+				isPending: true,
+				session: null,
+			}),
+		).toBe(false);
+	});
+
+	test("does not redirect when session lookup failed", () => {
+		expect(
+			shouldRedirectToLogin({
+				error: new Error("Failed to fetch"),
+				isPending: false,
+				session: null,
+			}),
+		).toBe(false);
+	});
+
+	test("does not redirect when a session exists", () => {
+		expect(
+			shouldRedirectToLogin({
+				error: null,
+				isPending: false,
+				session: { user: { id: "user_1" } },
+			}),
+		).toBe(false);
+	});
+});

--- a/apps/crm/apps/web/src/lib/auth-session.test.ts
+++ b/apps/crm/apps/web/src/lib/auth-session.test.ts
@@ -22,7 +22,7 @@ describe("shouldRedirectToLogin", () => {
 		).toBe(false);
 	});
 
-	test("does not redirect when session lookup failed", () => {
+	test("does not redirect when session lookup failed due to network", () => {
 		expect(
 			shouldRedirectToLogin({
 				error: new Error("Failed to fetch"),
@@ -30,6 +30,36 @@ describe("shouldRedirectToLogin", () => {
 				session: null,
 			}),
 		).toBe(false);
+	});
+
+	test("redirects when session lookup fails with unauthorized status", () => {
+		expect(
+			shouldRedirectToLogin({
+				error: { status: 401 },
+				isPending: false,
+				session: null,
+			}),
+		).toBe(true);
+	});
+
+	test("redirects when session lookup fails with forbidden status", () => {
+		expect(
+			shouldRedirectToLogin({
+				error: { response: { status: 403 } },
+				isPending: false,
+				session: null,
+			}),
+		).toBe(true);
+	});
+
+	test("redirects when session lookup fails with a non-transient error", () => {
+		expect(
+			shouldRedirectToLogin({
+				error: new Error("Invalid cookie signature"),
+				isPending: false,
+				session: null,
+			}),
+		).toBe(true);
 	});
 
 	test("does not redirect when a session exists", () => {

--- a/apps/crm/apps/web/src/lib/auth-session.ts
+++ b/apps/crm/apps/web/src/lib/auth-session.ts
@@ -16,7 +16,56 @@ export function shouldRedirectToLogin({
 	isPending,
 	session,
 }: RedirectToLoginInput) {
-	return !session && !isPending && !error;
+	return !session && !isPending && !isTransientSessionError(error);
+}
+
+function getErrorStatus(error: unknown) {
+	if (!error || typeof error !== "object") {
+		return undefined;
+	}
+
+	const maybeError = error as {
+		response?: { status?: unknown };
+		status?: unknown;
+	};
+	const status = maybeError.status ?? maybeError.response?.status;
+
+	return typeof status === "number" ? status : undefined;
+}
+
+function getErrorMessage(error: unknown) {
+	if (error instanceof Error) {
+		return error.message.toLowerCase();
+	}
+
+	if (!error || typeof error !== "object") {
+		return "";
+	}
+
+	const maybeError = error as { message?: unknown };
+	return typeof maybeError.message === "string"
+		? maybeError.message.toLowerCase()
+		: "";
+}
+
+function isTransientSessionError(error: unknown) {
+	if (!error) {
+		return false;
+	}
+
+	const status = getErrorStatus(error);
+	if (status === 401 || status === 403) {
+		return false;
+	}
+
+	const message = getErrorMessage(error);
+	return (
+		message.includes("failed to fetch") ||
+		message.includes("network") ||
+		message.includes("timeout") ||
+		message.includes("load failed") ||
+		message.includes("internet")
+	);
 }
 
 function safeDetail(detail: Record<string, unknown> | undefined) {

--- a/apps/crm/apps/web/src/lib/auth-session.ts
+++ b/apps/crm/apps/web/src/lib/auth-session.ts
@@ -1,0 +1,69 @@
+type RedirectToLoginInput = {
+	error: unknown;
+	isPending: boolean;
+	session: unknown;
+};
+
+export const AUTH_DIAG_PREFIX = "CRM_AUTH_DIAG";
+
+type AuthDiagnosticEvent = {
+	detail?: Record<string, unknown>;
+	reason: string;
+};
+
+export function shouldRedirectToLogin({
+	error,
+	isPending,
+	session,
+}: RedirectToLoginInput) {
+	return !session && !isPending && !error;
+}
+
+function safeDetail(detail: Record<string, unknown> | undefined) {
+	if (!detail) {
+		return undefined;
+	}
+
+	return Object.fromEntries(
+		Object.entries(detail).map(([key, value]) => [
+			key,
+			value instanceof Error ? value.message : value,
+		]),
+	);
+}
+
+export function logAuthDiagnostic({ detail, reason }: AuthDiagnosticEvent) {
+	const payload = {
+		detail: safeDetail(detail),
+		path: typeof window !== "undefined" ? window.location.pathname : undefined,
+		reason,
+		timestamp: new Date().toISOString(),
+	};
+
+	console.warn(AUTH_DIAG_PREFIX, payload);
+
+	if (typeof navigator === "undefined" || typeof window === "undefined") {
+		return;
+	}
+
+	const serverUrl = import.meta.env.VITE_SERVER_URL;
+	if (!serverUrl) {
+		return;
+	}
+
+	const body = JSON.stringify(payload);
+	const url = `${serverUrl}/api/auth-diagnostics/client-event`;
+
+	if (navigator.sendBeacon) {
+		navigator.sendBeacon(url, new Blob([body], { type: "application/json" }));
+		return;
+	}
+
+	fetch(url, {
+		body,
+		credentials: "include",
+		headers: { "Content-Type": "application/json" },
+		keepalive: true,
+		method: "POST",
+	}).catch(() => undefined);
+}

--- a/apps/crm/apps/web/src/routes/admin/import.tsx
+++ b/apps/crm/apps/web/src/routes/admin/import.tsx
@@ -12,6 +12,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/admin/import")({
@@ -19,14 +20,18 @@ export const Route = createFileRoute("/admin/import")({
 });
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const [companyId, setCompanyId] = useState<string | null>(null);
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (
 			session &&
@@ -36,7 +41,7 @@ function RouteComponent() {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: se requiere rol de administrador");
 		}
-	}, [session, isPending, userProfile.data]);
+	}, [session, sessionError, isPending, userProfile.data, navigate]);
 
 	// Setup mutation
 	const setupMutation = useMutation({

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -38,6 +38,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/admin/reports/")({
@@ -56,7 +57,11 @@ const COLORS = {
 };
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
 
@@ -73,13 +78,13 @@ function RouteComponent() {
 	});
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (session && userProfile.data?.role !== "admin") {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: se requiere rol de administrador");
 		}
-	}, [session, isPending, userProfile.data?.role]);
+	}, [session, sessionError, isPending, userProfile.data?.role, navigate]);
 
 	if (isPending || userProfile.isPending) {
 		return <div>Cargando...</div>;

--- a/apps/crm/apps/web/src/routes/admin/settings.tsx
+++ b/apps/crm/apps/web/src/routes/admin/settings.tsx
@@ -10,6 +10,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/admin/settings")({
@@ -17,19 +18,23 @@ export const Route = createFileRoute("/admin/settings")({
 });
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (session && userProfile.data?.role !== "admin") {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: se requiere rol de administrador");
 		}
-	}, [session, isPending, userProfile.data?.role]);
+	}, [session, sessionError, isPending, userProfile.data?.role, navigate]);
 
 	if (isPending || userProfile.isPending) {
 		return <div>Cargando...</div>;

--- a/apps/crm/apps/web/src/routes/admin/users.tsx
+++ b/apps/crm/apps/web/src/routes/admin/users.tsx
@@ -68,6 +68,7 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import {
 	ALL_ROLES,
 	getRoleColor,
@@ -83,7 +84,11 @@ export const Route = createFileRoute("/admin/users")({
 });
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const queryClient = useQueryClient();
 	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -156,7 +161,7 @@ function RouteComponent() {
 	// *fix #13
 	useEffect(() => {
 		console.log("Session:", userProfile.data);
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (
 			session &&
@@ -166,7 +171,7 @@ function RouteComponent() {
 			navigate({ to: "/dashboard" });
 			toast.error("Access denied: Admin role required");
 		}
-	}, [session, isPending, userProfile.data]);
+	}, [session, sessionError, isPending, userProfile.data, navigate]);
 
 	const handleToggleSuspend = (
 		userId: string,

--- a/apps/crm/apps/web/src/routes/crm/admin/miniagent.tsx
+++ b/apps/crm/apps/web/src/routes/crm/admin/miniagent.tsx
@@ -12,6 +12,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/crm/admin/miniagent")({
@@ -19,7 +20,11 @@ export const Route = createFileRoute("/crm/admin/miniagent")({
 });
 
 function RouteComponent() {
-	const { data: session, isPending: sessionPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending: sessionPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 
 	const userProfile = useQuery({
@@ -35,13 +40,19 @@ function RouteComponent() {
 	const userRole = userProfile.data?.role;
 
 	useEffect(() => {
-		if (!session && !sessionPending) {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
 			navigate({ to: "/login" });
 		} else if (session && userRole && userRole !== "admin") {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: esta sección es solo para administradores");
 		}
-	}, [session, sessionPending, userRole, navigate]);
+	}, [session, sessionError, sessionPending, userRole, navigate]);
 
 	const handleRefetch = () => {
 		usersWithCredentials.refetch();

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -67,6 +67,7 @@ import {
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { formatGuatemalaDate } from "@/lib/crm-formatters";
 import { PERMISSIONS } from "@/lib/roles";
 import { client, orpc } from "@/utils/orpc";
@@ -219,7 +220,11 @@ type ClientData = {
 };
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const search = Route.useSearch();
 	const [searchTerm, setSearchTerm] = useState("");
@@ -412,7 +417,7 @@ function RouteComponent() {
 	});
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (
 			session &&
@@ -422,7 +427,7 @@ function RouteComponent() {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: Se requiere acceso al CRM");
 		}
-	}, [session, isPending, userProfile.data?.role, navigate]);
+	}, [session, sessionError, isPending, userProfile.data?.role, navigate]);
 
 	const updateLeadMutation = useMutation({
 		mutationFn: (input: {
@@ -549,7 +554,11 @@ function RouteComponent() {
 					</CardHeader>
 					<CardContent>
 						<div className="font-bold text-2xl">
-							Q{(statsQuery.data?.totalValue ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+							Q
+							{(statsQuery.data?.totalValue ?? 0).toLocaleString("es-GT", {
+								minimumFractionDigits: 2,
+								maximumFractionDigits: 2,
+							})}
 						</div>
 						<p className="text-muted-foreground text-xs">
 							En créditos cerrados
@@ -1274,7 +1283,7 @@ function RouteComponent() {
 										Análisis de Capacidad de Pago
 									</h3>
 									<div className="grid grid-cols-2 gap-4">
-										<div className="space-y-3 rounded-lg bg-green-50 dark:bg-green-900/20 p-3">
+										<div className="space-y-3 rounded-lg bg-green-50 p-3 dark:bg-green-900/20">
 											<h4 className="font-medium text-sm">
 												Ingresos Mensuales
 											</h4>
@@ -1322,7 +1331,7 @@ function RouteComponent() {
 											</div>
 										</div>
 
-										<div className="space-y-3 rounded-lg bg-red-50 dark:bg-red-900/20 p-3">
+										<div className="space-y-3 rounded-lg bg-red-50 p-3 dark:bg-red-900/20">
 											<h4 className="font-medium text-sm">Gastos Mensuales</h4>
 											<div className="flex justify-between text-sm">
 												<span className="text-muted-foreground">Fijos:</span>
@@ -1370,7 +1379,7 @@ function RouteComponent() {
 									</div>
 
 									{/* Disponibilidad Económica */}
-									<div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-3">
+									<div className="rounded-lg bg-blue-50 p-3 dark:bg-blue-900/20">
 										<div className="flex items-center justify-between">
 											<div>
 												<p className="font-medium text-sm">

--- a/apps/crm/apps/web/src/routes/crm/companies.tsx
+++ b/apps/crm/apps/web/src/routes/crm/companies.tsx
@@ -62,6 +62,7 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { PERMISSIONS } from "@/lib/roles";
 import { client, orpc } from "@/utils/orpc";
 
@@ -70,7 +71,11 @@ export const Route = createFileRoute("/crm/companies")({
 });
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const queryClient = useQueryClient();
 	const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
@@ -269,7 +274,7 @@ function RouteComponent() {
 	};
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (
 			session &&
@@ -279,7 +284,7 @@ function RouteComponent() {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: Se requiere acceso al CRM");
 		}
-	}, [session, isPending, userProfile.data?.role]);
+	}, [session, sessionError, isPending, userProfile.data?.role, navigate]);
 
 	if (isPending || userProfile.isPending) {
 		return <div>Cargando...</div>;

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -73,6 +73,7 @@ import {
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import {
 	formatCurrency,
 	formatGuatemalaDate,
@@ -121,7 +122,11 @@ type CreditAnalysis = Awaited<
 >;
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const search = Route.useSearch();
 	const queryClient = useQueryClient();
@@ -580,7 +585,7 @@ function RouteComponent() {
 	};
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (
 			session &&
@@ -590,7 +595,7 @@ function RouteComponent() {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: Se requiere acceso al CRM");
 		}
-	}, [session, isPending, userProfile.data?.role]);
+	}, [session, sessionError, isPending, userProfile.data?.role, navigate]);
 
 	// Handle opening create modal with pre-filled company
 	useEffect(() => {
@@ -1015,9 +1020,7 @@ function RouteComponent() {
 														<Input
 															id={field.name}
 															name={field.name}
-															autoComplete={getLeadNameAutocomplete(
-																"lastName",
-															)}
+															autoComplete={getLeadNameAutocomplete("lastName")}
 															value={field.state.value}
 															onBlur={field.handleBlur}
 															onChange={(e) =>
@@ -2677,7 +2680,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Ingresos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-green-50 dark:bg-green-900/20 p-4">
+												<div className="space-y-3 rounded-lg bg-green-50 p-4 dark:bg-green-900/20">
 													<div className="space-y-2">
 														<Label className="text-sm">Ingresos Fijos</Label>
 														<Input
@@ -2719,7 +2722,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Gastos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-red-50 dark:bg-red-900/20 p-4">
+												<div className="space-y-3 rounded-lg bg-red-50 p-4 dark:bg-red-900/20">
 													<div className="space-y-2">
 														<Label className="text-sm">Gastos Fijos</Label>
 														<Input
@@ -2757,7 +2760,7 @@ function RouteComponent() {
 										</div>
 
 										{/* Economic Availability */}
-										<div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-4">
+										<div className="rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
 											<div className="space-y-2">
 												<Label className="font-medium text-sm">
 													Disponibilidad Económica
@@ -2844,7 +2847,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Ingresos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-green-50 dark:bg-green-900/20 p-4">
+												<div className="space-y-3 rounded-lg bg-green-50 p-4 dark:bg-green-900/20">
 													<div className="flex justify-between">
 														<span className="text-muted-foreground text-sm">
 															Ingresos Fijos:
@@ -2899,7 +2902,7 @@ function RouteComponent() {
 												<h4 className="font-medium text-base">
 													Gastos Mensuales
 												</h4>
-												<div className="space-y-3 rounded-lg bg-red-50 dark:bg-red-900/20 p-4">
+												<div className="space-y-3 rounded-lg bg-red-50 p-4 dark:bg-red-900/20">
 													<div className="flex justify-between">
 														<span className="text-muted-foreground text-sm">
 															Gastos Fijos:
@@ -2952,7 +2955,7 @@ function RouteComponent() {
 										</div>
 
 										{/* Economic Availability */}
-										<div className="rounded-lg bg-blue-50 dark:bg-blue-900/20 p-4">
+										<div className="rounded-lg bg-blue-50 p-4 dark:bg-blue-900/20">
 											<div className="flex items-center justify-between">
 												<div>
 													<Label className="font-medium text-muted-foreground text-sm">
@@ -3121,7 +3124,13 @@ function RouteComponent() {
 															</Badge>
 														)}
 														{opp.value && (
-															<span>Q{Number(opp.value).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</span>
+															<span>
+																Q
+																{Number(opp.value).toLocaleString("es-GT", {
+																	minimumFractionDigits: 2,
+																	maximumFractionDigits: 2,
+																})}
+															</span>
 														)}
 													</div>
 												</div>

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -47,8 +47,8 @@ import { CoDebtorsView } from "@/components/co-debtors/CoDebtorsView";
 import { ConsolidatedCreditSummary } from "@/components/credit/ConsolidatedCreditSummary";
 import { CreditDetailView } from "@/components/credit/CreditDetailView";
 import { ConfirmContractsSignedModal } from "@/components/crm/ConfirmContractsSignedModal";
-import { WhatsappLogBadge } from "@/components/crm/WhatsappLogBadge";
 import { ManualVehicleValuationDialog } from "@/components/crm/ManualVehicleValuationDialog";
+import { WhatsappLogBadge } from "@/components/crm/WhatsappLogBadge";
 import { DataTable } from "@/components/data-table";
 import { NotesTimeline } from "@/components/notes-timeline";
 import { Badge } from "@/components/ui/badge";
@@ -82,6 +82,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import {
 	formatDate,
 	formatGuatemalaDate,
@@ -334,7 +335,12 @@ function DroppableStageColumn({
 				</div>
 				<CardTitle className="font-medium text-sm">{stage.name}</CardTitle>
 				<CardDescription className="text-xs">
-					Q{totalValue.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} valor total
+					Q
+					{totalValue.toLocaleString("es-GT", {
+						minimumFractionDigits: 2,
+						maximumFractionDigits: 2,
+					})}{" "}
+					valor total
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="min-h-0 space-y-3 overflow-y-auto" ref={ref}>
@@ -370,7 +376,11 @@ export const Route = createFileRoute("/crm/opportunities")({
 export type IOpportunity = Opportunity;
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const search = Route.useSearch();
 	const queryClient = useQueryClient();
@@ -1006,7 +1016,9 @@ function RouteComponent() {
 						(s) => s.id === value.stageId,
 					);
 					if (targetStage && targetStage.closurePercentage < currentPct) {
-						return { form: "Las oportunidades en 90% o 100% no pueden retroceder" };
+						return {
+							form: "Las oportunidades en 90% o 100% no pueden retroceder",
+						};
 					}
 				}
 				return undefined;
@@ -1246,7 +1258,7 @@ function RouteComponent() {
 	});
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (
 			session &&
@@ -1256,7 +1268,7 @@ function RouteComponent() {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado: Se requiere acceso al CRM");
 		}
-	}, [session, isPending, userProfile.data?.role, navigate]);
+	}, [session, sessionError, isPending, userProfile.data?.role, navigate]);
 
 	// Handle opening create modal with pre-filled company leads
 	useEffect(() => {
@@ -1495,7 +1507,12 @@ function RouteComponent() {
 							<>
 								<div className="font-bold text-2xl">{totalOpportunities}</div>
 								<p className="text-muted-foreground text-xs">
-									Q{totalValue.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })} en pipeline
+									Q
+									{totalValue.toLocaleString("es-GT", {
+										minimumFractionDigits: 2,
+										maximumFractionDigits: 2,
+									})}{" "}
+									en pipeline
 								</p>
 							</>
 						)}
@@ -1548,7 +1565,11 @@ function RouteComponent() {
 							<Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
 						) : (
 							<div className="font-bold text-2xl text-green-700">
-								Q{placedAmount.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+								Q
+								{placedAmount.toLocaleString("es-GT", {
+									minimumFractionDigits: 2,
+									maximumFractionDigits: 2,
+								})}
 							</div>
 						)}
 					</CardContent>
@@ -1587,7 +1608,11 @@ function RouteComponent() {
 										className="mt-0.5 text-muted-foreground text-sm"
 										style={{ fontVariantNumeric: "tabular-nums" }}
 									>
-										Q{stageValue.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+										Q
+										{stageValue.toLocaleString("es-GT", {
+											minimumFractionDigits: 2,
+											maximumFractionDigits: 2,
+										})}
 									</p>
 								</CardContent>
 							</Card>
@@ -2061,7 +2086,7 @@ function RouteComponent() {
 
 			{/* Opportunity Details Modal */}
 			<Dialog open={isDetailsDialogOpen} onOpenChange={setIsDetailsDialogOpen}>
-				<DialogContent className="max-h-[90vh] w-fit min-w-[320px] md:min-w-[850px] max-w-[95vw] overflow-y-auto overflow-x-hidden">
+				<DialogContent className="max-h-[90vh] w-fit min-w-[320px] max-w-[95vw] overflow-y-auto overflow-x-hidden md:min-w-[850px]">
 					<DialogHeader>
 						<DialogTitle>Detalles de la Oportunidad</DialogTitle>
 					</DialogHeader>
@@ -2076,7 +2101,7 @@ function RouteComponent() {
 								}
 							}}
 						>
-							<TabsList className="flex w-full overflow-x-auto gap-2 p-1">
+							<TabsList className="flex w-full gap-2 overflow-x-auto p-1">
 								<TabsTrigger value="details">Detalles</TabsTrigger>
 								<TabsTrigger value="documents">Documentos</TabsTrigger>
 								<TabsTrigger value="coDebtors">Co-firmantes</TabsTrigger>
@@ -2290,9 +2315,7 @@ function RouteComponent() {
 													<Button
 														size="sm"
 														variant="outline"
-														onClick={() =>
-															setIsManualValuationDialogOpen(true)
-														}
+														onClick={() => setIsManualValuationDialogOpen(true)}
 													>
 														Cargar valores mínimos
 													</Button>
@@ -3012,7 +3035,8 @@ function RouteComponent() {
 												<SelectContent>
 													{salesStagesQuery.data
 														?.filter((stage) => {
-															const current = selectedOpportunity?.stage?.closurePercentage;
+															const current =
+																selectedOpportunity?.stage?.closurePercentage;
 															if (current != null && current >= 90) {
 																return stage.closurePercentage >= current;
 															}
@@ -3762,12 +3786,12 @@ function DocumentsManager({
 							{disbursementQuery.data!.documents.map((doc) => (
 								<div
 									key={doc.id}
-									className="flex flex-col gap-3 sm:flex-row sm:items-center justify-between rounded-md border border-blue-200 bg-white px-4 py-3"
+									className="flex flex-col justify-between gap-3 rounded-md border border-blue-200 bg-white px-4 py-3 sm:flex-row sm:items-center"
 								>
 									<div className="flex min-w-0 flex-1 items-center gap-3">
 										<FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
 										<div className="min-w-0 flex-1">
-											<p className="font-medium text-sm break-all whitespace-normal">
+											<p className="whitespace-normal break-all font-medium text-sm">
 												{doc.originalName}
 											</p>
 											<p className="text-muted-foreground text-xs">
@@ -3821,12 +3845,12 @@ function DocumentsManager({
 							{detalleDocuments.map((detalleDoc) => (
 								<div
 									key={detalleDoc.id}
-									className="flex flex-col gap-3 sm:flex-row sm:items-center justify-between rounded-lg border border-green-200 bg-white p-4"
+									className="flex flex-col justify-between gap-3 rounded-lg border border-green-200 bg-white p-4 sm:flex-row sm:items-center"
 								>
 									<div className="flex min-w-0 flex-1 items-center gap-3">
-										<span className="text-3xl shrink-0">📊</span>
+										<span className="shrink-0 text-3xl">📊</span>
 										<div className="min-w-0 flex-1">
-											<p className="font-medium break-all whitespace-normal">
+											<p className="whitespace-normal break-all font-medium">
 												{detalleDoc.originalName}
 											</p>
 											<p className="text-muted-foreground text-xs">

--- a/apps/crm/apps/web/src/routes/crm/whatsapp.tsx
+++ b/apps/crm/apps/web/src/routes/crm/whatsapp.tsx
@@ -11,6 +11,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
@@ -19,7 +20,11 @@ export const Route = createFileRoute("/crm/whatsapp")({
 });
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const [iframeLoading, setIframeLoading] = useState(true);
 
@@ -31,7 +36,7 @@ function RouteComponent() {
 	const userRole = userProfile.data?.role;
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		} else if (
 			session &&
@@ -43,7 +48,7 @@ function RouteComponent() {
 				"Acceso denegado: esta sección es solo para ventas y administradores",
 			);
 		}
-	}, [session, isPending, userRole, navigate]);
+	}, [session, sessionError, isPending, userRole, navigate]);
 
 	const handleIframeLoad = () => {
 		setIframeLoading(false);

--- a/apps/crm/apps/web/src/routes/dashboard.tsx
+++ b/apps/crm/apps/web/src/routes/dashboard.tsx
@@ -43,6 +43,7 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { getRoleLabel, PERMISSIONS, ROLES } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
@@ -66,7 +67,11 @@ const MONTH_NAMES = [
 ];
 
 function RouteComponent() {
-	const { data: session, isPending } = authClient.useSession();
+	const {
+		data: session,
+		error: sessionError,
+		isPending,
+	} = authClient.useSession();
 
 	const navigate = Route.useNavigate();
 
@@ -143,17 +148,21 @@ function RouteComponent() {
 	});
 
 	useEffect(() => {
-		if (!session && !isPending) {
+		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
 			navigate({ to: "/login" });
 		}
-	}, [session, isPending, navigate]);
+	}, [session, sessionError, isPending, navigate]);
 
 	if (isPending || userProfile.isPending) {
 		return <div>Cargando...</div>;
 	}
 
 	if (!session) {
-		return null;
+		return (
+			<div>
+				No se pudo verificar tu sesión. Revisa tu conexión y recarga la página.
+			</div>
+		);
 	}
 
 	const userRole = userProfile.data?.role;
@@ -258,7 +267,11 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-green-700">
-									Q{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+									Q
+									{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", {
+										minimumFractionDigits: 2,
+										maximumFractionDigits: 2,
+									})}
 								</div>
 							</CardContent>
 						</Card>
@@ -340,7 +353,11 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-green-700">
-									Q{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+									Q
+									{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", {
+										minimumFractionDigits: 2,
+										maximumFractionDigits: 2,
+									})}
 								</div>
 							</CardContent>
 						</Card>
@@ -425,7 +442,11 @@ function RouteComponent() {
 							</CardHeader>
 							<CardContent>
 								<div className="font-bold text-2xl text-green-700">
-									Q{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+									Q
+									{(crmStats.data.placedAmount || 0).toLocaleString("es-GT", {
+										minimumFractionDigits: 2,
+										maximumFractionDigits: 2,
+									})}
 								</div>
 							</CardContent>
 						</Card>

--- a/apps/crm/apps/web/src/utils/orpc.ts
+++ b/apps/crm/apps/web/src/utils/orpc.ts
@@ -4,11 +4,13 @@ import type { RouterClient } from "@orpc/server";
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { QueryCache, QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { logAuthDiagnostic } from "@/lib/auth-session";
 import type {
 	AppRouter,
 	disbursementRouter,
 	manualVehicleRouter,
 } from "../../../server/src/routers/index";
+
 type InvestmentsRouter =
 	typeof import("../../../server/src/routers/investments").investmentsRouter;
 
@@ -32,6 +34,13 @@ export const queryClient = new QueryClient({
 		onError: (error) => {
 			// Si es un error de sesión, redirigir al login sin mostrar toast de error
 			if (isSessionError(error)) {
+				logAuthDiagnostic({
+					detail: {
+						message: error.message,
+						name: error.name,
+					},
+					reason: "orpc-session-error-redirect",
+				});
 				toast.error(
 					"Tu sesión ha expirado. Por favor inicia sesión nuevamente.",
 				);


### PR DESCRIPTION
## Summary
- Prevent protected CRM routes from redirecting to login when `useSession` fails due to a transient auth/network error.
- Add grepable `CRM_AUTH_DIAG` diagnostics for client auth failures, sign-out events, null sessions, and RPC session lookup failures.
- Add regression coverage for the session redirect decision helper.

## Verification
- `bun test apps/web/src/lib/auth-session.test.ts`
- `bun check-types`