### PR TITLE
feat(crm): filter leads by source

### DIFF
--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { leadSourceEnum } from "../db/schema/crm";
+import { getLeadsInputSchema } from "./crm";
+
+describe("getLeadsInputSchema", () => {
+	test("accepts every configured lead source as a filter", () => {
+		for (const source of leadSourceEnum.enumValues) {
+			expect(getLeadsInputSchema.parse({ source }).source).toBe(source);
+		}
+	});
+
+	test("rejects unknown lead source filters", () => {
+		expect(() =>
+			getLeadsInputSchema.parse({ source: "unknown-source" }),
+		).toThrow();
+	});
+});

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -74,6 +74,19 @@ import { validarDpi } from "../utils/cui-validation";
 import { scoreLead } from "../services/lead-scoring";
 import { createNotification } from "./notifications";
 
+export const getLeadsInputSchema = z.object({
+	limit: z.number().min(1).max(100).default(20),
+	offset: z.number().min(0).default(0),
+	search: z.string().optional(),
+	status: z
+		.enum(["new", "contacted", "qualified", "converted", "unqualified"])
+		.optional(),
+	id: z.string().uuid().optional(),
+	source: z.enum(leadSourceEnum.enumValues).optional(),
+	dateFrom: z.string().optional(),
+	dateTo: z.string().optional(),
+});
+
 /**
  * Helper function to check vehicle inspection status.
  * Reduces code duplication across the codebase.
@@ -225,27 +238,14 @@ export const crmRouter = {
 
 	// Leads
 	getLeads: crmProcedure
-		.input(
-			z
-				.object({
-					limit: z.number().min(1).max(100).default(20),
-					offset: z.number().min(0).default(0),
-					search: z.string().optional(),
-					status: z
-						.enum(["new", "contacted", "qualified", "converted", "unqualified"])
-						.optional(),
-					id: z.string().uuid().optional(),
-					dateFrom: z.string().optional(),
-					dateTo: z.string().optional(),
-				})
-				.optional(),
-		)
+		.input(getLeadsInputSchema.optional())
 		.handler(async ({ input, context }) => {
 			const limit = input?.limit ?? 20;
 			const offset = input?.offset ?? 0;
 			const search = input?.search;
 			const status = input?.status;
 			const id = input?.id;
+			const source = input?.source;
 
 			// Build conditions
 			const conditions = [];
@@ -271,6 +271,11 @@ export const crmRouter = {
 			// Status filter
 			if (status) {
 				conditions.push(eq(leads.status, status));
+			}
+
+			// Source filter
+			if (source) {
+				conditions.push(eq(leads.source, source));
 			}
 
 			// Search filter (name, email, company name)

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -133,6 +133,7 @@ function RouteComponent() {
 	const [debouncedSearch, setDebouncedSearch] = useState("");
 	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
 	const [statusFilter, setStatusFilter] = useState<string>("all");
+	const [sourceFilter, setSourceFilter] = useState<string>("all");
 	const [page, setPage] = useState(0);
 	const [isEditingCreditAnalysis, setIsEditingCreditAnalysis] = useState(false);
 	const [isConvertDialogOpen, setIsConvertDialogOpen] = useState(false);
@@ -194,6 +195,8 @@ function RouteComponent() {
 								| "converted"
 								| "unqualified")
 						: undefined,
+				source:
+					sourceFilter !== "all" ? (sourceFilter as LeadSource) : undefined,
 				dateFrom: dateRange?.from?.toISOString(),
 				dateTo: dateRange?.to?.toISOString(),
 			},
@@ -210,6 +213,7 @@ function RouteComponent() {
 			pageSize,
 			debouncedSearch,
 			statusFilter,
+			sourceFilter,
 			dateRange?.from?.toISOString(),
 			dateRange?.to?.toISOString(),
 		],
@@ -1972,6 +1976,26 @@ function RouteComponent() {
 								<SelectItem value="qualified">Calificado</SelectItem>
 								<SelectItem value="unqualified">No Calificado</SelectItem>
 								<SelectItem value="converted">Convertido</SelectItem>
+							</SelectContent>
+						</Select>
+						<Select
+							value={sourceFilter}
+							onValueChange={(value) => {
+								setSourceFilter(value);
+								setPage(0);
+							}}
+						>
+							<SelectTrigger className="w-[190px]">
+								<Filter className="mr-2 h-4 w-4" />
+								<SelectValue placeholder="Filtrar por fuente" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="all">Todas las Fuentes</SelectItem>
+								{LEAD_SOURCE_OPTIONS.map((source) => (
+									<SelectItem key={source.value} value={source.value}>
+										{source.label}
+									</SelectItem>
+								))}
 							</SelectContent>
 						</Select>
 					</div>


### PR DESCRIPTION
## Summary
- Add backend support for filtering leads by source in `getLeads`.
- Add a Fuente selector to the leads filters using all configured lead sources.
- Add input schema coverage for accepted and invalid source filters.

## Verification
- `bun test apps/server/src/routers/crm-get-leads-input.test.ts`
- `bun check-types`