### PR TITLE
feat(crm): subir varias boletas y unificarlas en un solo PDF

### DIFF
--- a/apps/crm/apps/web/package.json
+++ b/apps/crm/apps/web/package.json
@@ -57,6 +57,7 @@
 		"jspdf-autotable": "^5.0.2",
 		"lucide-react": "^0.473.0",
 		"next-themes": "^0.4.6",
+		"pdf-lib": "^1.17.1",
 		"radix-ui": "^1.4.2",
 		"react": "^19.0.0",
 		"react-datepicker": "^7.5.0",

--- a/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
+++ b/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
@@ -139,6 +139,13 @@ const MONTH_OPTIONS = [
 
 const MAX_BOLETA_FILES = 5;
 const MAX_BOLETA_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB
+const ACCEPTED_BOLETA_MIMES = new Set([
+	"application/pdf",
+	"image/png",
+	"image/jpeg",
+	"image/jpg",
+]);
+const ACCEPT_BOLETA_INPUT = ".pdf,image/png,image/jpeg,image/jpg";
 
 async function mergeFilesToPdf(
 	files: File[],
@@ -161,11 +168,15 @@ async function mergeFilesToPdf(
 			continue;
 		}
 
-		if (file.type.startsWith("image/")) {
-			const isPng = file.type === "image/png";
-			const image = isPng
-				? await merged.embedPng(bytes)
-				: await merged.embedJpg(bytes);
+		if (
+			file.type === "image/png" ||
+			file.type === "image/jpeg" ||
+			file.type === "image/jpg"
+		) {
+			const image =
+				file.type === "image/png"
+					? await merged.embedPng(bytes)
+					: await merged.embedJpg(bytes);
 			const page = merged.addPage([image.width, image.height]);
 			page.drawImage(image, {
 				x: 0,
@@ -176,7 +187,9 @@ async function mergeFilesToPdf(
 			continue;
 		}
 
-		throw new Error(`Tipo de archivo no soportado: ${file.name}`);
+		throw new Error(
+			`Tipo de archivo no soportado: ${file.name}. Solo PDF, PNG o JPG.`,
+		);
 	}
 
 	const pdfBytes = await merged.save();
@@ -269,11 +282,11 @@ function SubirBoletaDialog({
 		if (!incoming || incoming.length === 0) return;
 		const incomingArr = Array.from(incoming);
 
-		const invalid = incomingArr.find(
-			(f) => !(f.type === "application/pdf" || f.type.startsWith("image/")),
-		);
+		const invalid = incomingArr.find((f) => !ACCEPTED_BOLETA_MIMES.has(f.type));
 		if (invalid) {
-			toast.error(`Tipo no soportado: ${invalid.name}`);
+			toast.error(
+				`Tipo no soportado: ${invalid.name}. Solo PDF, PNG o JPG.`,
+			);
 			return;
 		}
 
@@ -392,7 +405,7 @@ function SubirBoletaDialog({
 									</p>
 								</div>
 								<p className="text-[11.5px] text-emerald-800/90 leading-snug dark:text-emerald-200/80">
-									Arrastrá o seleccioná varios PDFs/imágenes a la vez. Se
+									Arrastrá o seleccioná varios PDFs, PNGs o JPGs a la vez. Se
 									unirán automáticamente en un solo archivo y se subirán como
 									una sola boleta.
 								</p>
@@ -448,7 +461,7 @@ function SubirBoletaDialog({
 									{dropzoneLabel}
 								</p>
 								<p className="mt-0.5 text-[11px] text-muted-foreground/70">
-									PDF o imágenes — se unirán en un solo PDF
+									PDF, PNG o JPG — se unirán en un solo PDF
 								</p>
 							</div>
 						</div>
@@ -456,7 +469,7 @@ function SubirBoletaDialog({
 							ref={fileInputRef}
 							id="boleta-file"
 							type="file"
-							accept="image/*,.pdf"
+							accept={ACCEPT_BOLETA_INPUT}
 							multiple
 							className="hidden"
 							onChange={(e) => {

--- a/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
+++ b/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
@@ -1,6 +1,8 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
+	ArrowDown,
+	ArrowUp,
 	Banknote,
 	ChevronLeft,
 	ChevronRight,
@@ -11,8 +13,11 @@ import {
 	Loader2,
 	Search,
 	Send,
+	Sparkles,
 	Upload,
+	X,
 } from "lucide-react";
+import { PDFDocument } from "pdf-lib";
 import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -130,6 +135,56 @@ const MONTH_OPTIONS = [
 	{ value: 12, label: "Diciembre" },
 ];
 
+// ─── Merge de archivos a un solo PDF ─────────────────────────────────────────
+
+const MAX_BOLETA_FILES = 5;
+const MAX_BOLETA_TOTAL_BYTES = 20 * 1024 * 1024; // 20 MB
+
+async function mergeFilesToPdf(
+	files: File[],
+	outputName: string,
+): Promise<File> {
+	// Atajo: 1 solo PDF → no re-encode, se sube tal cual.
+	if (files.length === 1 && files[0].type === "application/pdf") {
+		return files[0];
+	}
+
+	const merged = await PDFDocument.create();
+
+	for (const file of files) {
+		const bytes = new Uint8Array(await file.arrayBuffer());
+
+		if (file.type === "application/pdf") {
+			const src = await PDFDocument.load(bytes);
+			const copied = await merged.copyPages(src, src.getPageIndices());
+			for (const page of copied) merged.addPage(page);
+			continue;
+		}
+
+		if (file.type.startsWith("image/")) {
+			const isPng = file.type === "image/png";
+			const image = isPng
+				? await merged.embedPng(bytes)
+				: await merged.embedJpg(bytes);
+			const page = merged.addPage([image.width, image.height]);
+			page.drawImage(image, {
+				x: 0,
+				y: 0,
+				width: image.width,
+				height: image.height,
+			});
+			continue;
+		}
+
+		throw new Error(`Tipo de archivo no soportado: ${file.name}`);
+	}
+
+	const pdfBytes = await merged.save();
+	return new File([pdfBytes as BlobPart], outputName, {
+		type: "application/pdf",
+	});
+}
+
 // ─── Upload boleta hook ───────────────────────────────────────────────────────
 
 function useUploadBoleta() {
@@ -195,40 +250,119 @@ function SubirBoletaDialog({
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 }) {
-	const [file, setFile] = useState<File | null>(null);
+	const [files, setFiles] = useState<File[]>([]);
 	const [notas, setNotas] = useState("");
 	const [uploading, setUploading] = useState(false);
+	const [merging, setMerging] = useState(false);
+	const [dragActive, setDragActive] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const { upload } = useUploadBoleta();
 
+	const totalBytes = files.reduce((acc, f) => acc + f.size, 0);
+
+	let dropzoneLabel: string;
+	if (dragActive) dropzoneLabel = "Soltá los archivos aquí";
+	else if (files.length === 0) dropzoneLabel = "Arrastrá archivos o hacé click";
+	else dropzoneLabel = "Agregar más archivos";
+
+	const handleAddFiles = (incoming: FileList | null) => {
+		if (!incoming || incoming.length === 0) return;
+		const incomingArr = Array.from(incoming);
+
+		const invalid = incomingArr.find(
+			(f) => !(f.type === "application/pdf" || f.type.startsWith("image/")),
+		);
+		if (invalid) {
+			toast.error(`Tipo no soportado: ${invalid.name}`);
+			return;
+		}
+
+		const next = [...files, ...incomingArr];
+		if (next.length > MAX_BOLETA_FILES) {
+			toast.error(`Máximo ${MAX_BOLETA_FILES} archivos`);
+			return;
+		}
+		const nextBytes = next.reduce((acc, f) => acc + f.size, 0);
+		if (nextBytes > MAX_BOLETA_TOTAL_BYTES) {
+			toast.error("El tamaño total supera 20 MB");
+			return;
+		}
+		setFiles(next);
+	};
+
+	const removeFile = (index: number) => {
+		setFiles((prev) => prev.filter((_, i) => i !== index));
+	};
+
+	const moveFile = (index: number, direction: -1 | 1) => {
+		setFiles((prev) => {
+			const target = index + direction;
+			if (target < 0 || target >= prev.length) return prev;
+			const next = [...prev];
+			[next[index], next[target]] = [next[target], next[index]];
+			return next;
+		});
+	};
+
+	const handleDrag = (e: React.DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		if (uploading || files.length >= MAX_BOLETA_FILES) return;
+		if (e.type === "dragenter" || e.type === "dragover") setDragActive(true);
+		else if (e.type === "dragleave") setDragActive(false);
+	};
+
+	const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setDragActive(false);
+		if (uploading || files.length >= MAX_BOLETA_FILES) return;
+		if (e.dataTransfer?.files?.length) {
+			handleAddFiles(e.dataTransfer.files);
+		}
+	};
+
 	const handleSubmit = async () => {
-		if (!file) {
-			toast.error("Selecciona un archivo");
+		if (files.length === 0) {
+			toast.error("Selecciona al menos un archivo");
 			return;
 		}
 
 		setUploading(true);
 		try {
+			let toUpload: File;
+			if (files.length === 1 && files[0].type === "application/pdf") {
+				toUpload = files[0];
+			} else {
+				setMerging(true);
+				toUpload = await mergeFilesToPdf(
+					files,
+					`boleta-${inv.inversionista_id}-${Date.now()}.pdf`,
+				);
+				setMerging(false);
+			}
+
 			await upload({
-				file,
+				file: toUpload,
 				inversionista_id: inv.inversionista_id,
 				monto_boleta: String(inv.total_a_recibir_con_reinversion),
 				notas: notas.trim() || undefined,
 			});
 			toast.success("Boleta subida correctamente");
-			setFile(null);
+			setFiles([]);
 			setNotas("");
 			onOpenChange(false);
 		} catch (err: any) {
 			toast.error(err.message || "Error al subir boleta");
 		} finally {
+			setMerging(false);
 			setUploading(false);
 		}
 	};
 
 	const handleClose = (value: boolean) => {
 		if (!uploading) {
-			setFile(null);
+			setFiles([]);
 			setNotas("");
 			onOpenChange(value);
 		}
@@ -245,39 +379,148 @@ function SubirBoletaDialog({
 				</DialogHeader>
 
 				<div className="space-y-4 py-2">
-					{/* Archivo */}
+					{/* Banner: nueva funcionalidad de múltiples boletas */}
+					<div className="relative overflow-hidden rounded-lg border border-emerald-200 bg-linear-to-br from-emerald-50 to-teal-50 px-3.5 py-3 dark:border-emerald-900/50 dark:from-emerald-950/40 dark:to-teal-950/40">
+						<div className="flex items-start gap-2.5">
+							<div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-emerald-100 dark:bg-emerald-900/60">
+								<Sparkles className="h-3.5 w-3.5 text-emerald-700 dark:text-emerald-300" />
+							</div>
+							<div className="min-w-0 flex-1">
+								<div className="mb-0.5 flex items-center gap-1.5">
+									<p className="font-semibold text-[13px] text-emerald-900 dark:text-emerald-100">
+										¡Ahora podés subir varias boletas!
+									</p>
+								</div>
+								<p className="text-[11.5px] text-emerald-800/90 leading-snug dark:text-emerald-200/80">
+									Arrastrá o seleccioná varios PDFs/imágenes a la vez. Se
+									unirán automáticamente en un solo archivo y se subirán como
+									una sola boleta.
+								</p>
+							</div>
+						</div>
+					</div>
+
+					{/* Archivos */}
 					<div className="space-y-2">
-						<Label htmlFor="boleta-file">Archivo</Label>
+						<div className="flex items-center justify-between">
+							<Label htmlFor="boleta-file">
+								Archivos{" "}
+								<span className="font-normal text-muted-foreground text-xs">
+									(máx. 5 — 20 MB)
+								</span>
+							</Label>
+							{files.length > 0 && (
+								<span className="text-muted-foreground text-xs tabular-nums">
+									{files.length}/{MAX_BOLETA_FILES} ·{" "}
+									{(totalBytes / 1024 / 1024).toFixed(1)} MB
+								</span>
+							)}
+						</div>
+
 						<div
-							className="flex cursor-pointer items-center justify-center rounded-lg border-2 border-dashed px-4 py-6 transition-colors hover:border-primary/50 hover:bg-muted/50"
+							className={`flex cursor-pointer items-center justify-center rounded-lg border-2 border-dashed px-4 py-6 transition-colors ${
+								dragActive
+									? "border-primary bg-primary/5"
+									: "hover:border-primary/50 hover:bg-muted/50"
+							} ${
+								files.length >= MAX_BOLETA_FILES
+									? "pointer-events-none opacity-50"
+									: ""
+							}`}
 							onClick={() => fileInputRef.current?.click()}
 							onKeyDown={() => {}}
+							onDragEnter={handleDrag}
+							onDragLeave={handleDrag}
+							onDragOver={handleDrag}
+							onDrop={handleDrop}
 						>
-							{file ? (
-								<div className="text-center">
-									<FileCheck className="mx-auto mb-1 h-6 w-6 text-emerald-600" />
-									<p className="font-medium text-sm">{file.name}</p>
-									<p className="text-muted-foreground text-xs">
-										{(file.size / 1024).toFixed(0)} KB
-									</p>
-								</div>
-							) : (
-								<div className="text-center">
-									<Upload className="mx-auto mb-1 h-6 w-6 text-muted-foreground" />
-									<p className="text-muted-foreground text-sm">
-										Click para seleccionar archivo
-									</p>
-								</div>
-							)}
+							<div className="text-center">
+								<Upload
+									className={`mx-auto mb-1 h-6 w-6 transition-colors ${
+										dragActive ? "text-primary" : "text-muted-foreground"
+									}`}
+								/>
+								<p
+									className={`font-medium text-sm transition-colors ${
+										dragActive ? "text-primary" : "text-foreground"
+									}`}
+								>
+									{dropzoneLabel}
+								</p>
+								<p className="mt-0.5 text-[11px] text-muted-foreground/70">
+									PDF o imágenes — se unirán en un solo PDF
+								</p>
+							</div>
 						</div>
 						<input
 							ref={fileInputRef}
 							id="boleta-file"
 							type="file"
 							accept="image/*,.pdf"
+							multiple
 							className="hidden"
-							onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+							onChange={(e) => {
+								handleAddFiles(e.target.files);
+								if (fileInputRef.current) fileInputRef.current.value = "";
+							}}
 						/>
+
+						{files.length > 0 && (
+							<ul className="space-y-1.5">
+								{files.map((f, index) => (
+									<li
+										key={`${f.name}-${index}`}
+										className="flex items-center gap-2 rounded-md border bg-muted/30 px-2.5 py-1.5"
+									>
+										<span className="w-5 shrink-0 text-center font-mono text-muted-foreground text-xs tabular-nums">
+											{index + 1}
+										</span>
+										<FileCheck className="h-4 w-4 shrink-0 text-emerald-600" />
+										<div className="min-w-0 flex-1">
+											<p className="truncate font-medium text-xs">{f.name}</p>
+											<p className="text-[10px] text-muted-foreground">
+												{(f.size / 1024).toFixed(0)} KB
+											</p>
+										</div>
+										<div className="flex items-center gap-0.5">
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												className="h-7 w-7"
+												disabled={index === 0 || uploading}
+												onClick={() => moveFile(index, -1)}
+												title="Subir"
+											>
+												<ArrowUp className="h-3.5 w-3.5" />
+											</Button>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												className="h-7 w-7"
+												disabled={index === files.length - 1 || uploading}
+												onClick={() => moveFile(index, 1)}
+												title="Bajar"
+											>
+												<ArrowDown className="h-3.5 w-3.5" />
+											</Button>
+											<Button
+												type="button"
+												variant="ghost"
+												size="icon"
+												className="h-7 w-7 text-muted-foreground hover:text-destructive"
+												disabled={uploading}
+												onClick={() => removeFile(index)}
+												title="Quitar"
+											>
+												<X className="h-3.5 w-3.5" />
+											</Button>
+										</div>
+									</li>
+								))}
+							</ul>
+						)}
 					</div>
 
 					{/* Notas */}
@@ -301,9 +544,12 @@ function SubirBoletaDialog({
 					>
 						Cancelar
 					</Button>
-					<Button onClick={handleSubmit} disabled={uploading || !file}>
+					<Button
+						onClick={handleSubmit}
+						disabled={uploading || files.length === 0}
+					>
 						{uploading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-						Subir boleta
+						{merging ? "Uniendo archivos..." : "Subir boleta"}
 					</Button>
 				</DialogFooter>
 			</DialogContent>

--- a/apps/crm/bun.lock
+++ b/apps/crm/bun.lock
@@ -108,6 +108,7 @@
         "jspdf-autotable": "^5.0.2",
         "lucide-react": "^0.473.0",
         "next-themes": "^0.4.6",
+        "pdf-lib": "^1.17.1",
         "radix-ui": "^1.4.2",
         "react": "^19.0.0",
         "react-datepicker": "^7.5.0",
@@ -515,6 +516,10 @@
     "@orpc/standard-server-peer": ["@orpc/standard-server-peer@1.13.4", "", { "dependencies": { "@orpc/shared": "1.13.4", "@orpc/standard-server": "1.13.4" } }, "sha512-UfqnTLqevjCKUk4cmImOG8cQUwANpV1dp9e9u2O1ki6BRBsg/zlXFg6G2N6wP0zr9ayIiO1d2qJdH55yl/1BNw=="],
 
     "@orpc/tanstack-query": ["@orpc/tanstack-query@1.13.4", "", { "dependencies": { "@orpc/shared": "1.13.4" }, "peerDependencies": { "@orpc/client": "1.13.4", "@tanstack/query-core": ">=5.80.2" } }, "sha512-gCL/kh3kf6OUGKfXxSoOZpcX1jNYzxGfo/PkLQKX7ui4xiTbfWw3sCDF30sNS4I7yAOnBwDwJ3N2xzfkTftOBg=="],
+
+    "@pdf-lib/standard-fonts": ["@pdf-lib/standard-fonts@1.0.0", "", { "dependencies": { "pako": "^1.0.6" } }, "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA=="],
+
+    "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -1508,7 +1513,7 @@
 
     "ora": ["ora@5.4.1", "", { "dependencies": { "bl": "^4.1.0", "chalk": "^4.1.0", "cli-cursor": "^3.1.0", "cli-spinners": "^2.5.0", "is-interactive": "^1.0.0", "is-unicode-supported": "^0.1.0", "log-symbols": "^4.1.0", "strip-ansi": "^6.0.0", "wcwidth": "^1.0.1" } }, "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ=="],
 
-    "pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
 
@@ -1525,6 +1530,8 @@
     "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
 
     "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
 
     "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
@@ -1984,11 +1991,15 @@
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
+    "fast-png/pako": ["pako@2.1.0", "", {}, "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "pdf-lib/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "radix-ui/@radix-ui/react-avatar": ["@radix-ui/react-avatar@1.1.10", "", { "dependencies": { "@radix-ui/react-context": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog=="],
 


### PR DESCRIPTION
## Summary
- Permite subir múltiples PDFs/imágenes (máx. 5 archivos, 20 MB total) al subir boleta de inversionista en el dialog de **Pagar Inversionistas**.
- Los archivos se unen client-side con `pdf-lib` en un solo PDF antes de hacer el upload, así el backend recibe un único archivo y **no se toca el modelo liquidación↔boleta** (que es delicado por sus integraciones con portal web, CRM y cartera-front).
- Soporte de **drag & drop** sobre la zona de carga + reordenamiento de archivos con flechas ↑↓ + banner verde "NUEVO" explicando la funcionalidad.

## Cambios
- Nueva dependencia: `pdf-lib` en `apps/crm/apps/web`.
- `apps/crm/apps/web/src/routes/accounting/pay-investors.tsx`:
  - Helper `mergeFilesToPdf()` que copia páginas de PDFs y embebe imágenes (PNG/JPG) en un PDF único.
  - Atajo: si el usuario sube un solo PDF, no se re-encodea.
  - `SubirBoletaDialog` ahora maneja `files: File[]` con validación de tipo y límites.
  - Banner destacado y dropzone con feedback visual durante drag.
  
  
<img width="504" height="699" alt="Captura desde 2026-05-07 12-51-29" src="https://github.com/user-attachments/assets/7141fc64-679f-4cc0-ba2c-752a73485bf3" />


## Test plan
- [ ] Abrir `/accounting/pay-investors` con un usuario con permisos.
- [ ] En una card pendiente, click en "Subir".
- [ ] Verificar que aparece el banner verde de "NUEVO".
- [ ] Arrastrar 2-3 imágenes (JPG/PNG) sobre la zona — verificar que el borde cambia a color primario y se aceptan.
- [ ] Arrastrar 1-2 PDFs adicionales — verificar que se agregan a la lista.
- [ ] Reordenar con las flechas ↑↓ — verificar que el orden se actualiza.
- [ ] Subir y validar que la boleta resultante es un único PDF con las páginas en el orden seleccionado.
- [ ] Probar el atajo: subir 1 solo PDF y verificar que se sube tal cual (sin re-merge).
- [ ] Probar límites: intentar agregar un 6º archivo (debe rechazar) y archivos > 20 MB total (debe rechazar).
- [ ] Verificar que la liquidación posterior funciona igual que antes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)