### PR TITLE
[codex] Show Cash In vehicle badge in analysis

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1927,6 +1927,7 @@ export const crmRouter = {
 						licensePlate: vehicles.licensePlate,
 						color: vehicles.color,
 						isNew: vehicles.isNew,
+						isOwned: vehicles.isOwned,
 					},
 					stage: {
 						id: salesStages.id,
@@ -4992,6 +4993,7 @@ export const crmRouter = {
 								licensePlate: vehicles.licensePlate,
 								color: vehicles.color,
 								isNew: vehicles.isNew,
+								isOwned: vehicles.isOwned,
 							})
 							.from(vehicles)
 							.where(inArray(vehicles.id, vehicleIds))
@@ -5186,6 +5188,7 @@ export const crmRouter = {
 								licensePlate: vehicles.licensePlate,
 								color: vehicles.color,
 								isNew: vehicles.isNew,
+								isOwned: vehicles.isOwned,
 								vinNumber: vehicles.vinNumber,
 								motorNumber: vehicles.motorNumber,
 								seats: vehicles.seats,
@@ -5273,6 +5276,7 @@ export const crmRouter = {
 								description: `${vehicle.make} ${vehicle.model} ${vehicle.year}`,
 								licensePlate: vehicle.licensePlate,
 								isNew: vehicle.isNew,
+								isOwned: vehicle.isOwned,
 								hasRequiredData: !!(
 									vehicle.vinNumber &&
 									vehicle.seats &&

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -99,6 +99,7 @@ export type OpportunityForModal = {
 		licensePlate?: string | null;
 		color?: string | null;
 		isNew?: boolean;
+		isOwned?: boolean;
 	} | null;
 };
 
@@ -466,6 +467,14 @@ export function OpportunityDetailModal({
 												{opportunity.vehicle.isNew && (
 													<Badge variant="secondary" className="ml-2">
 														Nuevo
+													</Badge>
+												)}
+												{opportunity.vehicle.isOwned && (
+													<Badge
+														variant="outline"
+														className="ml-2 border-sky-300 bg-sky-50 text-[10px] text-sky-700 dark:border-sky-700 dark:bg-sky-950 dark:text-sky-300"
+													>
+														Cash In
 													</Badge>
 												)}
 											</Link>

--- a/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
@@ -307,6 +307,8 @@ function OpportunityDocumentsPage() {
 						year: opportunity.vehicle.year,
 						licensePlate: opportunity.vehicle.licensePlate,
 						color: opportunity.vehicle.color,
+						isNew: opportunity.vehicle.isNew,
+						isOwned: opportunity.vehicle.isOwned,
 					}
 				: null,
 		});

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -316,6 +316,7 @@ function AnalysisPage() {
 						licensePlate: opportunity.vehicle.licensePlate,
 						color: opportunity.vehicle.color,
 						isNew: opportunity.vehicle.isNew,
+						isOwned: opportunity.vehicle.isOwned,
 					}
 				: null,
 		});
@@ -820,6 +821,7 @@ function DisbursementSection({
 						licensePlate: opp.vehicle.licensePlate,
 						color: opp.vehicle.color,
 						isNew: opp.vehicle.isNew,
+						isOwned: opp.vehicle.isOwned,
 					}
 				: null,
 		});


### PR DESCRIPTION
## Summary

Propagates the vehicle ownership flag (`isOwned`) through the CRM analysis flows so analysts can see when a vehicle belongs to Cash In.

## Changes

- Includes `vehicle.isOwned` in analysis, investment, and disbursement opportunity responses.
- Passes `isOwned` into the analysis opportunity detail modal.
- Displays a `Cash In` badge in the opportunity vehicle section when the associated vehicle is owned by Cash In.
- Ensures the credit/check emission tab receives the same vehicle ownership data used to render its existing Cash In badge.

## Root Cause

The vehicle list already knew whether a car was Cash In-owned, but the analysis-facing opportunity payloads did not consistently include `isOwned`, so downstream analysis views could not render the badge.

## Validation

- Ran `bun run check-all` from `apps/crm` successfully.
- Confirmed the working tree only contained the intended CRM changes before commit.