### PR TITLE
feat(cobros): WhatsApp masivo editable + send logs enriquecidos + descartados modal

### DIFF
--- a/apps/crm/apps/server/src/db/schema/cobros-send-logs.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros-send-logs.ts
@@ -41,10 +41,22 @@ export const cobrosSendLogs = pgTable(
 		asunto: text("asunto"),
 		mensaje: text("mensaje").notNull(),
 
+		// Plantilla seleccionada (whatsapp). Null para envíos ad-hoc (email/sms libres).
+		plantillaId: text("plantilla_id"),
+
+		// Agrupador para envíos masivos: todas las filas de un mismo
+		// enviarWhatsappMasivoCobros comparten este id. Null para envíos individuales.
+		batchId: uuid("batch_id"),
+
+		// Payload exacto enviado al proveedor (templateName, serviceIdentifier, body…)
+		// y respuesta cruda completa del proveedor para poder auditar/depurar
+		// sin tener que reconstruir nada desde los logs de stdout.
+		providerRequest: jsonb("provider_request").$type<Record<string, unknown>>(),
+		providerResponse: jsonb("provider_response").$type<Record<string, unknown>>(),
+
 		// Resultado
 		status: cobrosSendStatusEnum("status").notNull(),
 		errorMessage: text("error_message"),
-		providerResponse: jsonb("provider_response").$type<Record<string, unknown>>(),
 
 		// Auditoría
 		createdBy: text("created_by")
@@ -56,5 +68,6 @@ export const cobrosSendLogs = pgTable(
 	(t) => [
 		index("idx_cobros_send_logs_sifco").on(t.numeroCreditoSifco),
 		index("idx_cobros_send_logs_created_at").on(t.createdAt),
+		index("idx_cobros_send_logs_batch").on(t.batchId),
 	],
 );

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -1,9 +1,20 @@
 /**
- * Plantillas de mensajes de cobros (WhatsApp / Email).
+ * Plantillas de mensajes de cobros — versión SERVER usada por el envío masivo
+ * de WhatsApp (cobros.ts → enviarWhatsappMasivoCobros).
  *
- * Mantener en sincronía con `apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts`.
- * Eventualmente ambas versiones deberían leer desde una tabla `plantillas_mensaje`
- * en la BD (ver RFC en el archivo del front).
+ * Cada `cuerpo` tiene que coincidir EXACTAMENTE con la plantilla aprobada en
+ * Meta (WhatsApp Business). En particular, los párrafos separados por línea
+ * en blanco (`\n\n`) son lo que `splitTemplateParams` (simpletech.ts) usa
+ * para decidir cuántos parámetros tiene el template — ese conteo determina
+ * qué plantilla se selecciona vía `resolveTemplateNameByParamCount`.
+ *
+ * Por eso esta versión coincide con el `cuerpoWhastapp` del archivo del front
+ * (`apps/web/src/lib/cobros/plantillas-mensajes.ts`), no con el `cuerpo`
+ * largo orientado a email. Si tocás los párrafos, podés romper el match con
+ * la plantilla aprobada y SimpleTech rechazará el envío.
+ *
+ * Eventualmente ambas versiones deberían leer desde una tabla
+ * `plantillas_mensaje` en la BD (ver RFC en el archivo del front).
  */
 
 export interface VariablesPlantilla {
@@ -65,102 +76,71 @@ export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
 		nombre: "Bienvenida",
 		etapa: "al_dia",
 		asunto: "Bienvenido/a a su plan de financiamiento",
-		cuerpo: `Estimado/a {clienteNombre},
+		// 4 bloques separados por línea en blanco → template `mensaje4parametros`.
+		cuerpo: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
 
-Le damos la bienvenida a su plan de financiamiento para su vehículo {marcaLineaModelo} ({placa}).
+A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
-Su cuota mensual es de Q{cuotaMensual}, con fecha de pago el día {fechaPago} de cada mes.
+Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
 
-Cualquier consulta no dude en comunicarse con nosotros.
-
-Atentamente,
-{nombreAsesor}
-Tel: {telefonoAsesor}`,
+Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
 		id: "al_dia",
 		nombre: "Recordatorio de pago",
 		etapa: "al_dia",
 		asunto: "Recordatorio de pago - Vehículo {placa}",
-		cuerpo: `Estimado/a {clienteNombre},
+		// 2 bloques → template `mensaje2parametros`.
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
 
-Le recordamos que su próxima cuota de Q{cuotaMensual} vence el día {fechaPago}.
-
-Vehículo: {marcaLineaModelo} ({placa})
-
-Agradecemos su puntualidad. Si ya realizó el pago, por favor haga caso omiso de este mensaje.
-
-Saludos cordiales,
-{nombreAsesor}
-Tel: {telefonoAsesor}`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
 		id: "pre_mora",
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",
 		asunto: "Aviso de atraso en pago - Vehículo {placa}",
-		cuerpo: `Estimado/a {clienteNombre},
+		// 4 bloques → template `mensaje4parametros`.
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
-Hemos notado que su pago correspondiente al día {fechaPago} aún no ha sido registrado.
+Si tiene alguna duda por favor comunicarse por este medio.
 
-Vehículo: {marcaLineaModelo} ({placa})
-Monto pendiente: Q{montoAdeudado}
+SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 
-Le solicitamos ponerse al día a la brevedad para evitar recargos adicionales. Si ya realizó el pago, por favor envíenos el comprobante.
-
-Quedo a sus órdenes,
-{nombreAsesor}
-Tel: {telefonoAsesor}`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
 		id: "mora_30",
 		nombre: "Mora 30 días",
 		etapa: "mora_30",
 		asunto: "URGENTE: Mora de 30 días - Vehículo {placa}",
-		cuerpo: `Estimado/a {clienteNombre},
+		// 2 bloques → template `mensaje2parametros`.
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
 
-Su cuenta presenta un atraso de {cuotasAtraso} cuota(s) por un monto total de Q{montoAdeudado}.
-
-Vehículo: {marcaLineaModelo} ({placa})
-
-Es importante que regularice su situación a la brevedad posible para evitar acciones adicionales de cobro. Le invitamos a comunicarse con nosotros para buscar una solución.
-
-Atentamente,
-{nombreAsesor}
-Tel: {telefonoAsesor}`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
 		id: "mora_60",
 		nombre: "Mora 60 días",
 		etapa: "mora_60",
 		asunto: "AVISO IMPORTANTE: Mora de 60 días - Vehículo {placa}",
-		cuerpo: `Estimado/a {clienteNombre},
+		// 3 bloques → template `mensaje3parametros`.
+		cuerpo: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
 
-Su cuenta presenta un atraso significativo de {cuotasAtraso} cuota(s) con un saldo vencido de Q{montoAdeudado}.
+Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
 
-Vehículo: {marcaLineaModelo} ({placa})
-
-De no recibir respuesta o pago en los próximos días, nos veremos en la necesidad de escalar su caso a la siguiente fase de recuperación. Le urgimos comunicarse con nosotros para llegar a un acuerdo.
-
-Atentamente,
-{nombreAsesor}
-Tel: {telefonoAsesor}`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 	},
 	{
 		id: "aviso_juridico",
 		nombre: "Aviso jurídico",
 		etapa: "mora_90",
 		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
-		cuerpo: `Estimado/a {clienteNombre},
+		// 3 bloques → template `mensaje3parametros`.
+		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
-Por medio de la presente le notificamos que debido al incumplimiento reiterado en sus pagos ({cuotasAtraso} cuotas vencidas por Q{montoAdeudado}), su caso será trasladado al departamento jurídico para iniciar las acciones legales correspondientes.
+Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
-Vehículo: {marcaLineaModelo} ({placa})
-
-Tiene un plazo de 48 horas para comunicarse con nosotros y regularizar su situación antes de que se proceda con las acciones legales.
-
-Atentamente,
-{nombreAsesor}
-Tel: {telefonoAsesor}`,
+Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
 	},
 ];

--- a/apps/crm/apps/server/src/lib/simpletech.ts
+++ b/apps/crm/apps/server/src/lib/simpletech.ts
@@ -23,6 +23,17 @@ function splitTemplateParams(message: string): string[] {
 	return [...parts.slice(0, 3), parts.slice(3).join("\n\n")];
 }
 
+/**
+ * Resuelve el nombre del template según la cantidad de parámetros.
+ *
+ * Las plantillas aprobadas siguen la convención `mensaje{N}parametro`
+ * (`mensaje1parametro`, `mensaje2parametro`, …, `mensaje4parametro`).
+ *
+ * Esta función toma el primer dígito del nombre base
+ * (`SIMPLETECH_TEMPLATE_NAME`) y lo REEMPLAZA por `paramCount`. SimpleTech
+ * solo soporta hasta 4 parámetros, así que `splitTemplateParams` ya colapsa
+ * a 4 cualquier mensaje con más; aquí también clampeamos por seguridad.
+ */
 function resolveTemplateNameByParamCount(
 	baseTemplateName: string,
 	paramCount: number,
@@ -30,13 +41,8 @@ function resolveTemplateNameByParamCount(
 	const match = /\d+/.exec(baseTemplateName);
 	if (!match) return baseTemplateName;
 
-	const baseNumber = Number.parseInt(match[0], 10);
-	if (!Number.isFinite(baseNumber) || baseNumber <= 0) {
-		return baseTemplateName;
-	}
-
-	const nextNumber = baseNumber * Math.max(1, paramCount);
-	return baseTemplateName.replace(match[0], String(nextNumber));
+	const target = Math.min(4, Math.max(1, paramCount));
+	return baseTemplateName.replace(match[0], String(target));
 }
 
 function normalizeParamsForTemplate(
@@ -88,10 +94,70 @@ export function normalizePhone(phone: string): string {
 	return `+502${digits}`;
 }
 
+/**
+ * Extrae detalle útil de una excepción del SDK de SimpleTech para persistir
+ * en el log. Las `ConnectionError` del SDK exponen `statusCode` y
+ * `responseBody` con el mensaje real del proveedor (p. ej. "Template name
+ * not valid"); sin esto solo tendríamos `err.message` ("Error HTTP 400").
+ */
+function buildExceptionPayload(err: unknown): Record<string, unknown> {
+	const anyErr = err as Record<string, unknown> | null;
+	const message = err instanceof Error ? err.message : String(err);
+	const stack = err instanceof Error ? err.stack : undefined;
+
+	const payload: Record<string, unknown> = {
+		exception: message,
+		stack,
+	};
+	if (anyErr && typeof anyErr === "object") {
+		if ("statusCode" in anyErr) payload.statusCode = anyErr.statusCode;
+		if ("responseBody" in anyErr) {
+			const raw = anyErr.responseBody;
+			payload.responseBody = raw;
+			// El SDK suele entregar `responseBody` como string JSON; intentamos
+			// parsearlo para que en la DB quede como objeto consultable.
+			if (typeof raw === "string") {
+				try {
+					payload.responseBodyParsed = JSON.parse(raw);
+				} catch {
+					/* dejar solo el string crudo */
+				}
+			}
+		}
+		if ("name" in anyErr) payload.errorName = anyErr.name;
+	}
+	return payload;
+}
+
+/**
+ * Extrae un texto humano del payload de excepción para mostrarle al usuario.
+ * Combina el mensaje de la excepción con el `data`/`error` del responseBody
+ * parseado (típicamente algo como "Template name not valid"). Stringifica
+ * objetos como JSON en vez de "[object Object]".
+ */
+function formatExceptionMessage(
+	err: unknown,
+	payload: Record<string, unknown>,
+): string {
+	const baseMsg = err instanceof Error ? err.message : "Error desconocido";
+	const parsed = payload.responseBodyParsed as
+		| { data?: unknown; error?: unknown }
+		| undefined;
+	const detail = parsed?.data ?? parsed?.error;
+	if (detail === undefined || detail === null || detail === "") return baseMsg;
+	const detailStr =
+		typeof detail === "string" ? detail : JSON.stringify(detail);
+	return `${baseMsg} — ${detailStr}`;
+}
+
 export interface WhatsappSendResult {
 	success: boolean;
 	templateMessageId?: string;
 	error?: string;
+	/** Payload exacto que se envió al proveedor (para persistir en logs). */
+	providerRequest?: Record<string, unknown>;
+	/** Respuesta cruda del proveedor o detalle de la excepción de transporte. */
+	providerResponse?: Record<string, unknown>;
 }
 
 /**
@@ -132,21 +198,29 @@ export async function sendWhatsappTemplate(params: {
 	try {
 		const result = await client.sendTemplate(templateRequest);
 		console.log(`${prefix} Response:`, JSON.stringify(result, null, 2));
+		const providerResponse = result as unknown as Record<string, unknown>;
 		if (result.success) {
 			return {
 				success: true,
 				templateMessageId: result.results[0]?.templateMessageId,
+				providerRequest: templateRequest,
+				providerResponse,
 			};
 		}
 		return {
 			success: false,
 			error: result.failed[0]?.error ?? "Error desconocido",
+			providerRequest: templateRequest,
+			providerResponse,
 		};
 	} catch (err) {
 		console.error(`${prefix} Exception:`, err);
+		const payload = buildExceptionPayload(err);
 		return {
 			success: false,
-			error: err instanceof Error ? err.message : "Error desconocido",
+			error: formatExceptionMessage(err, payload),
+			providerRequest: templateRequest,
+			providerResponse: payload,
 		};
 	}
 }
@@ -172,6 +246,10 @@ export interface WhatsappBatchResultItem {
 export interface WhatsappBatchResult {
 	transportError?: string;
 	items: WhatsappBatchResultItem[];
+	/** Payload exacto que se envió al proveedor (para persistir en logs). */
+	providerRequest?: Record<string, unknown>;
+	/** Respuesta cruda del proveedor o detalle de la excepción de transporte. */
+	providerResponse?: Record<string, unknown>;
 }
 
 /**
@@ -205,6 +283,7 @@ export async function sendWhatsappTemplateBatch(params: {
 				success: false,
 				error: msg,
 			})),
+			providerResponse: { transportError: msg },
 		};
 	}
 
@@ -300,10 +379,13 @@ export async function sendWhatsappTemplateBatch(params: {
 							: "SimpleTech reportó fallo en el batch"),
 				};
 			}),
+			providerRequest: templateRequest,
+			providerResponse: result as unknown as Record<string, unknown>,
 		};
 	} catch (err) {
 		console.error(`${prefix} Exception:`, err);
-		const msg = err instanceof Error ? err.message : "Error desconocido";
+		const payload = buildExceptionPayload(err);
+		const msg = formatExceptionMessage(err, payload);
 		return {
 			transportError: msg,
 			items: normalized.map((r) => ({
@@ -313,6 +395,8 @@ export async function sendWhatsappTemplateBatch(params: {
 				success: false,
 				error: msg,
 			})),
+			providerRequest: templateRequest,
+			providerResponse: payload,
 		};
 	}
 }

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3034,6 +3034,7 @@ export const cobrosRouter = {
 				telefono: z.string().min(8, "Teléfono inválido"),
 				mensaje: z.string().min(1, "Mensaje requerido"),
 				casoCobroId: z.string().optional(),
+				plantillaId: z.string().optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -3052,10 +3053,13 @@ export const cobrosRouter = {
 				canal: "whatsapp",
 				telefono: telefonoDestino,
 				mensaje: input.mensaje,
+				plantillaId: input.plantillaId ?? null,
+				providerRequest: result.providerRequest ?? null,
 				result: result.success
 					? {
 							success: true,
 							providerResponse: {
+								...(result.providerResponse ?? {}),
 								templateMessageId: result.templateMessageId,
 								testMode,
 								realTarget: testMode ? input.telefono : undefined,
@@ -3064,9 +3068,10 @@ export const cobrosRouter = {
 					: {
 							success: false,
 							errorMessage: result.error,
-							providerResponse: testMode
-								? { testMode, realTarget: input.telefono }
-								: undefined,
+							providerResponse: {
+								...(result.providerResponse ?? {}),
+								...(testMode ? { testMode, realTarget: input.telefono } : {}),
+							},
 						},
 				createdBy: context.userId,
 			});
@@ -3088,6 +3093,12 @@ export const cobrosRouter = {
 		.input(
 			z.object({
 				plantillaId: z.string(),
+				// Texto del cuerpo editado por el usuario en la modal. Si viene,
+				// se usa este en lugar de `plantilla.cuerpo` para interpolar las
+				// variables por crédito. Las variables ({clienteNombre}, etc.)
+				// que no se reconozcan quedan literales — comportamiento esperado.
+				// Sin este campo, se cae al cuerpo definido en cobros-plantillas.ts.
+				cuerpoEditado: z.string().optional(),
 				// Mismos filtros que getTodosLosCreditos (salvo emailCobrador, que
 				// se deriva del context para evitar que un cobrador mande fuera de
 				// su cartera).
@@ -3096,6 +3107,8 @@ export const cobrosRouter = {
 				numeroSifco: z.string().optional(),
 				time: z.enum(["WEEK", "MONTH", "DUEMONTH", "TODAY"]).optional(),
 				etiquetas: z.array(z.string()).optional(),
+				fechaDesde: z.string().optional(),
+				fechaHasta: z.string().optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -3245,7 +3258,11 @@ export const cobrosRouter = {
 				elegibles: 0,
 				enviados: 0,
 				fallidos: 0,
-				descartados: [] as Array<{ numeroSifco: string | null; motivo: string }>,
+				descartados: [] as Array<{
+					numeroSifco: string | null;
+					clienteNombre: string | null;
+					motivo: string;
+				}>,
 				detalle: [] as Array<{
 					numeroSifco: string;
 					telefono: string;
@@ -3300,11 +3317,16 @@ export const cobrosRouter = {
 						anio: new Date().getFullYear(),
 						estado: estadoCartera,
 						cuotasAtrasadas,
-						time: input.time,
+						// Mismo criterio que getTodosLosCreditos: si hay rango de fechas
+						// custom, ignoramos el preset `time` para que no se pisen.
+						time:
+							input.fechaDesde || input.fechaHasta ? undefined : input.time,
 						email_cobrador: emailCobrador,
 						nombre_usuario: isNameSearch ? searchTerm : undefined,
 						numero_credito_sifco: numeroSifcoFiltro,
 						numeros_credito_sifco: sifcosPorEtiquetas,
+						fecha_desde: input.fechaDesde,
+						fecha_hasta: input.fechaHasta,
 						page,
 						perPage,
 					});
@@ -3395,6 +3417,7 @@ export const cobrosRouter = {
 			const candidatos: Candidato[] = [];
 			const descartados: Array<{
 				numeroSifco: string | null;
+				clienteNombre: string | null;
 				motivo: string;
 			}> = [];
 
@@ -3404,17 +3427,18 @@ export const cobrosRouter = {
 				const asesor = credito.asesores;
 				const info = sifco ? locales.get(sifco) : undefined;
 				const telefono = info?.telefono ?? null;
+				const clienteNombre = credito.usuarios.nombre ?? null;
 
 				if (!cuota || Number(cuota) === 0) {
-					descartados.push({ numeroSifco: sifco, motivo: "sin cuota" });
+					descartados.push({ numeroSifco: sifco, clienteNombre, motivo: "sin cuota" });
 					continue;
 				}
 				if (!telefono) {
-					descartados.push({ numeroSifco: sifco, motivo: "sin teléfono" });
+					descartados.push({ numeroSifco: sifco, clienteNombre, motivo: "sin teléfono" });
 					continue;
 				}
 				if (!asesor) {
-					descartados.push({ numeroSifco: sifco, motivo: "sin asesor" });
+					descartados.push({ numeroSifco: sifco, clienteNombre, motivo: "sin asesor" });
 					continue;
 				}
 
@@ -3433,7 +3457,11 @@ export const cobrosRouter = {
 				const totalACobrar =
 					montoMora > 0 ? montoMora + Number(cuota) : 0;
 
-				const mensaje = interpolarPlantilla(plantilla.cuerpo, {
+				const cuerpoBase = input.cuerpoEditado?.trim()
+					? input.cuerpoEditado
+					: plantilla.cuerpo;
+
+				const mensaje = interpolarPlantilla(cuerpoBase, {
 					clienteNombre: credito.usuarios.nombre ?? "",
 					fechaPago: "",
 					cuotaMensual: String(cuota),
@@ -3461,7 +3489,10 @@ export const cobrosRouter = {
 			}
 
 			// 5. Enviar en chunks de 100 y loguear cada resultado.
+			// batchId agrupa todas las filas de cobros_send_logs de este envío
+			// masivo para poder consultarlas como una unidad.
 			const CHUNK_SIZE = 100;
+			const batchId = crypto.randomUUID();
 			let enviados = 0;
 			let fallidos = 0;
 			const detalle: Array<{
@@ -3515,11 +3546,15 @@ export const cobrosRouter = {
 						canal: "whatsapp",
 						telefono: c.telefono,
 						mensaje: c.mensaje,
+						plantillaId: input.plantillaId,
+						batchId,
+						providerRequest: batch.providerRequest ?? null,
 						createdBy: context.userId,
 						result: ok
 							? {
 									success: true,
 									providerResponse: {
+										...(batch.providerResponse ?? {}),
 										templateMessageId: res?.templateMessageId,
 										testMode,
 										realTarget: testMode ? c.telefonoReal : undefined,
@@ -3531,9 +3566,12 @@ export const cobrosRouter = {
 										res?.error ??
 										batch.transportError ??
 										"Error desconocido",
-									providerResponse: testMode
-										? { testMode, realTarget: c.telefonoReal }
-										: undefined,
+									providerResponse: {
+										...(batch.providerResponse ?? {}),
+										...(testMode
+											? { testMode, realTarget: c.telefonoReal }
+											: {}),
+									},
 								},
 					});
 
@@ -3571,6 +3609,7 @@ export const cobrosRouter = {
 
 			return {
 				plantillaId: input.plantillaId,
+				batchId,
 				totalCreditos: creditosFiltrados.length,
 				elegibles: candidatos.length,
 				enviados,
@@ -3589,6 +3628,7 @@ export const cobrosRouter = {
 				asunto: z.string().min(1, "Asunto requerido").max(200),
 				mensaje: z.string().min(1, "Mensaje requerido"),
 				casoCobroId: z.string().optional(),
+				plantillaId: z.string().optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -3636,6 +3676,7 @@ export const cobrosRouter = {
 				email: emailDestino,
 				asunto: input.asunto,
 				mensaje: input.mensaje,
+				plantillaId: input.plantillaId ?? null,
 				result: sendError
 					? {
 							success: false,
@@ -3677,6 +3718,7 @@ export const cobrosRouter = {
 					.transform((v) => v.replace(/[^0-9]/g, "")),
 				mensaje: z.string().min(1, "Mensaje requerido"),
 				casoCobroId: z.string().optional(),
+				plantillaId: z.string().optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -3736,6 +3778,7 @@ export const cobrosRouter = {
 				canal: "sms",
 				telefono: telefonoDestino,
 				mensaje: input.mensaje,
+				plantillaId: input.plantillaId ?? null,
 				result: sendError
 					? {
 							success: false,
@@ -3795,6 +3838,9 @@ async function persistCobrosSendLog(params: {
 	email?: string;
 	asunto?: string;
 	mensaje: string;
+	plantillaId?: string | null;
+	batchId?: string | null;
+	providerRequest?: Record<string, unknown> | null;
 	createdBy: string;
 	result:
 		| { success: true; providerResponse?: Record<string, unknown> }
@@ -3808,6 +3854,9 @@ async function persistCobrosSendLog(params: {
 			email: params.email,
 			asunto: params.asunto,
 			mensaje: params.mensaje,
+			plantillaId: params.plantillaId ?? null,
+			batchId: params.batchId ?? null,
+			providerRequest: params.providerRequest ?? null,
 			status: params.result.success ? "sent" : "failed",
 			errorMessage: params.result.success ? null : params.result.errorMessage,
 			providerResponse: params.result.providerResponse,

--- a/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { MessageCircle, Send } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";
@@ -25,6 +25,69 @@ import { Textarea } from "@/components/ui/textarea";
 import { PLANTILLAS_MENSAJES } from "@/lib/cobros/plantillas-mensajes";
 import { client } from "@/utils/orpc";
 
+const VARIABLES_DISPONIBLES = [
+	"clienteNombre",
+	"fechaPago",
+	"cuotaMensual",
+	"placa",
+	"marcaLineaModelo",
+	"montoAdeudado",
+	"cuotasAtraso",
+	"telefonoAsesor",
+	"nombreAsesor",
+] as const;
+
+interface DescartadoItem {
+	numeroSifco: string | null;
+	clienteNombre: string | null;
+	motivo: string;
+}
+
+function formatRangoTemporal(filtros: {
+	fechaDesde?: string;
+	fechaHasta?: string;
+	time?: "WEEK" | "MONTH" | "DUEMONTH" | "TODAY";
+}): string {
+	if (filtros.fechaDesde || filtros.fechaHasta) {
+		return `${filtros.fechaDesde ?? "—"} a ${filtros.fechaHasta ?? "—"}`;
+	}
+	if (filtros.time) return TIME_LABELS[filtros.time] ?? filtros.time;
+	return "Todos";
+}
+
+function descartadosToCsv(items: DescartadoItem[]): string {
+	const escape = (val: string) => {
+		// Convención CSV: envolver en comillas si tiene coma, comilla o salto;
+		// duplicar comillas internas para escapar.
+		if (/["\n,]/.test(val)) return `"${val.replaceAll('"', '""')}"`;
+		return val;
+	};
+	const header = "numeroSifco,clienteNombre,motivo";
+	const filas = items.map((d) =>
+		[
+			escape(d.numeroSifco ?? ""),
+			escape(d.clienteNombre ?? ""),
+			escape(d.motivo),
+		].join(","),
+	);
+	return [header, ...filas].join("\n");
+}
+
+function descargarCsv(items: DescartadoItem[]) {
+	const csv = descartadosToCsv(items);
+	const blob = new Blob([`﻿${csv}`], {
+		type: "text/csv;charset=utf-8;",
+	});
+	const url = URL.createObjectURL(blob);
+	const link = document.createElement("a");
+	link.href = url;
+	link.download = `descartados-masivo-${new Date().toISOString().slice(0, 19).replaceAll(":", "-")}.csv`;
+	document.body.appendChild(link);
+	link.click();
+	link.remove();
+	URL.revokeObjectURL(url);
+}
+
 interface MassWhatsappModalProps {
 	filtros: {
 		estadoMora?: string;
@@ -32,6 +95,8 @@ interface MassWhatsappModalProps {
 		numeroSifco?: string;
 		time?: "WEEK" | "MONTH" | "DUEMONTH" | "TODAY";
 		etiquetas?: string[];
+		fechaDesde?: string;
+		fechaHasta?: string;
 	};
 	etiquetaLabels?: Record<string, string>;
 	totalDestinatarios?: number;
@@ -63,15 +128,55 @@ export function MassWhatsappModal({
 }: MassWhatsappModalProps) {
 	const [open, setOpen] = useState(false);
 	const [plantillaId, setPlantillaId] = useState<string>("");
+	const [cuerpoEditado, setCuerpoEditado] = useState<string>("");
+	const [descartadosResult, setDescartadosResult] = useState<
+		DescartadoItem[] | null
+	>(null);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+	const insertarVariable = (variable: string) => {
+		const token = `{${variable}}`;
+		const textarea = textareaRef.current;
+		// Sin foco/ref no podemos saber dónde está el cursor: caemos al append.
+		if (!textarea) {
+			setCuerpoEditado((prev) => `${prev}${token}`);
+			return;
+		}
+		const start = textarea.selectionStart ?? cuerpoEditado.length;
+		const end = textarea.selectionEnd ?? cuerpoEditado.length;
+		const nuevoTexto =
+			cuerpoEditado.slice(0, start) + token + cuerpoEditado.slice(end);
+		setCuerpoEditado(nuevoTexto);
+		// React aplica el value en el siguiente tick — esperamos para reposicionar
+		// el caret justo después del token insertado y devolver foco al textarea.
+		requestAnimationFrame(() => {
+			textarea.focus();
+			const cursorPos = start + token.length;
+			textarea.setSelectionRange(cursorPos, cursorPos);
+		});
+	};
 
 	const plantillaSeleccionada = PLANTILLAS_MENSAJES.find(
 		(p) => p.id === plantillaId,
 	);
 
+	// Pre-poblar el textarea con el cuerpoWhastapp (versión corta aprobada en
+	// Meta) cuando cambia la plantilla. Si no existe, caemos al cuerpo largo.
+	useEffect(() => {
+		if (!plantillaSeleccionada) {
+			setCuerpoEditado("");
+			return;
+		}
+		setCuerpoEditado(
+			plantillaSeleccionada.cuerpoWhastapp || plantillaSeleccionada.cuerpo,
+		);
+	}, [plantillaSeleccionada]);
+
 	const sendMutation = useMutation({
 		mutationFn: () =>
 			client.enviarWhatsappMasivoCobros({
 				plantillaId,
+				cuerpoEditado: cuerpoEditado || undefined,
 				estadoMora: filtros.estadoMora,
 				searchTerm: filtros.searchTerm,
 				numeroSifco: filtros.numeroSifco,
@@ -80,6 +185,8 @@ export function MassWhatsappModal({
 					filtros.etiquetas && filtros.etiquetas.length > 0
 						? filtros.etiquetas
 						: undefined,
+				fechaDesde: filtros.fechaDesde,
+				fechaHasta: filtros.fechaHasta,
 			}),
 		onSuccess: (res) => {
 			const partes = [
@@ -92,6 +199,9 @@ export function MassWhatsappModal({
 			}
 			toast.success(`WhatsApp masivo: ${partes.join(", ")}`);
 			setOpen(false);
+			if (res.descartados.length > 0) {
+				setDescartadosResult(res.descartados);
+			}
 		},
 		onError: (error: any) => {
 			toast.error(error?.message || "Error enviando WhatsApp masivo");
@@ -99,6 +209,7 @@ export function MassWhatsappModal({
 	});
 
 	return (
+		<>
 		<Dialog open={open} onOpenChange={setOpen}>
 			<DialogTrigger asChild>{children}</DialogTrigger>
 			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-4xl">
@@ -134,17 +245,48 @@ export function MassWhatsappModal({
 					{plantillaSeleccionada ? (
 						<>
 							<div className="space-y-2">
-								<Label>Vista previa</Label>
+								<div className="flex items-center justify-between">
+									<Label htmlFor="cuerpo-editado">Mensaje a enviar</Label>
+									<button
+										type="button"
+										onClick={() =>
+											setCuerpoEditado(
+												plantillaSeleccionada.cuerpoWhastapp ||
+													plantillaSeleccionada.cuerpo,
+											)
+										}
+										className="text-muted-foreground text-xs underline-offset-2 hover:text-foreground hover:underline"
+									>
+										Restaurar plantilla original
+									</button>
+								</div>
 								<Textarea
-									readOnly
+									ref={textareaRef}
+									id="cuerpo-editado"
 									className="min-h-55 text-sm"
-									value={plantillaSeleccionada.cuerpo}
+									value={cuerpoEditado}
+									onChange={(e) => setCuerpoEditado(e.target.value)}
 								/>
 								<p className="text-muted-foreground text-xs">
-									Las variables entre llaves se reemplazan por los datos
-									reales de cada crédito. Si un dato no existe (p. ej. placa),
-									queda vacío en el mensaje.
+									Separá con <strong>una línea en blanco</strong> para crear un
+									nuevo párrafo (= un parámetro del template). Mínimo 1, máximo
+									4. Las variables entre <code>{"{llaves}"}</code> se
+									reemplazan por los datos reales de cada crédito; si una
+									variable no existe o queda mal escrita, se manda literal.
 								</p>
+								<div className="flex flex-wrap gap-1">
+									{VARIABLES_DISPONIBLES.map((v) => (
+										<button
+											key={v}
+											type="button"
+											onClick={() => insertarVariable(v)}
+											className="cursor-pointer rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+											title={`Insertar {${v}} en la posición del cursor`}
+										>
+											{`{${v}}`}
+										</button>
+									))}
+								</div>
 							</div>
 
 							<div className="grid gap-3 md:grid-cols-2">
@@ -158,12 +300,7 @@ export function MassWhatsappModal({
 													filtros.estadoMora)
 												: "Todos"}
 										</li>
-										<li>
-											Rango temporal:{" "}
-											{filtros.time
-												? (TIME_LABELS[filtros.time] ?? filtros.time)
-												: "Todos"}
-										</li>
+										<li>Rango temporal: {formatRangoTemporal(filtros)}</li>
 										<li>Búsqueda: {filtros.searchTerm ?? "—"}</li>
 										<li>No. SIFCO: {filtros.numeroSifco ?? "—"}</li>
 										<li>
@@ -226,5 +363,83 @@ export function MassWhatsappModal({
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>
+
+		<Dialog
+			open={!!descartadosResult}
+			onOpenChange={(o) => {
+				if (!o) setDescartadosResult(null);
+			}}
+		>
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-3xl">
+				<DialogHeader>
+					<DialogTitle>
+						Descartados del envío masivo ({descartadosResult?.length ?? 0})
+					</DialogTitle>
+					<DialogDescription>
+						Estos créditos no recibieron mensaje porque les faltaba algún dato
+						(teléfono, cuota o asesor asignado). Podés exportarlos a CSV para
+						hacer seguimiento manual.
+					</DialogDescription>
+				</DialogHeader>
+
+				{descartadosResult && descartadosResult.length > 0 && (
+					<div className="max-h-96 overflow-y-auto rounded-md border border-border">
+						<table className="w-full text-sm">
+							<thead className="sticky top-0 bg-muted/60 backdrop-blur">
+								<tr className="border-b">
+									<th className="px-3 py-2 text-left font-medium text-muted-foreground text-xs">
+										No. SIFCO
+									</th>
+									<th className="px-3 py-2 text-left font-medium text-muted-foreground text-xs">
+										Cliente
+									</th>
+									<th className="px-3 py-2 text-left font-medium text-muted-foreground text-xs">
+										Motivo
+									</th>
+								</tr>
+							</thead>
+							<tbody>
+								{descartadosResult.map((d, idx) => (
+									<tr
+										key={`${d.numeroSifco ?? "sin-sifco"}-${idx}`}
+										className="border-b last:border-b-0"
+									>
+										<td className="px-3 py-2 font-mono text-muted-foreground text-xs">
+											{d.numeroSifco ?? "—"}
+										</td>
+										<td className="px-3 py-2">
+											{d.clienteNombre ?? "—"}
+										</td>
+										<td className="px-3 py-2">
+											<span className="rounded bg-amber-100 px-2 py-0.5 text-amber-900 text-xs">
+												{d.motivo}
+											</span>
+										</td>
+									</tr>
+								))}
+							</tbody>
+						</table>
+					</div>
+				)}
+
+				<DialogFooter>
+					<Button
+						variant="outline"
+						onClick={() => setDescartadosResult(null)}
+					>
+						Cerrar
+					</Button>
+					<Button
+						onClick={() =>
+							descartadosResult && descargarCsv(descartadosResult)
+						}
+						disabled={!descartadosResult || descartadosResult.length === 0}
+					>
+						Descargar CSV
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+		</>
 	);
 }

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -245,7 +245,11 @@ export function ContactoModal({
 
 	const whatsappApiMutation = useMutation({
 		mutationFn: (vars: { telefono: string; mensaje: string }) =>
-			client.enviarWhatsappCobros({ ...vars, casoCobroId }),
+			client.enviarWhatsappCobros({
+				...vars,
+				casoCobroId,
+				plantillaId: plantillaId || undefined,
+			}),
 		onSuccess: (res) => {
 			if (res.success) toast.success("WhatsApp enviado correctamente");
 		},
@@ -258,7 +262,12 @@ export function ContactoModal({
 			destinatario: string;
 			asunto: string;
 			mensaje: string;
-		}) => client.enviarEmailCobros({ ...vars, casoCobroId }),
+		}) =>
+			client.enviarEmailCobros({
+				...vars,
+				casoCobroId,
+				plantillaId: plantillaId || undefined,
+			}),
 		onSuccess: (res) => {
 			if (res.success) toast.success("Email enviado correctamente");
 		},
@@ -268,7 +277,11 @@ export function ContactoModal({
 
 	const smsApiMutation = useMutation({
 		mutationFn: (vars: { telefono: string; mensaje: string }) =>
-			client.enviarSmsCobros({ ...vars, casoCobroId }),
+			client.enviarSmsCobros({
+				...vars,
+				casoCobroId,
+				plantillaId: plantillaId || undefined,
+			}),
 		onSuccess: (res) => {
 			if (res.success) toast.success("SMS enviado correctamente");
 		},

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -1003,9 +1003,11 @@ function RouteComponent() {
 									estadoMora: filtroEtapa || undefined,
 									searchTerm: debouncedFilterValue || undefined,
 									numeroSifco: debouncedSifcoFilterValue || undefined,
-									time: timeParam,
+									time: fechaDesde || fechaHasta ? undefined : timeParam,
 									etiquetas:
 										filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
+									fechaDesde,
+									fechaHasta,
 								}}
 								etiquetaLabels={ETIQUETA_LABELS_FILTRO}
 								totalDestinatarios={totalCreditos}


### PR DESCRIPTION
## Summary
- **Mass WhatsApp editable**: la modal masiva ahora deja editar el cuerpo del mensaje (pre-poblado con `cuerpoWhastapp`), inserta variables en la posición del cursor con chips clickeables, y respeta el rango de fechas seleccionado en la página de cobros.
- **Send logs enriquecidos**: `cobros_send_logs` agrega `plantilla_id`, `batch_id` (agrupador de masivos), `provider_request` (templateName + body que se manda) y `provider_response` cruda con `statusCode` + `responseBody` parseado para poder auditar errores reales del proveedor (ej. `Template name not valid`).
- **Descartados modal**: cuando un masivo deja créditos sin enviar (sin teléfono / sin cuota / sin asesor), se abre una segunda modal con tabla **SIFCO | Cliente | Motivo** y botón **Descargar CSV** generado en el navegador.
- **Fix template resolution**: `resolveTemplateNameByParamCount` ahora reemplaza el dígito por `paramCount` en vez de multiplicarlo. Combinado con `SIMPLETECH_TEMPLATE_NAME=mensaje1parametro` resuelve a `mensaje{N}parametro` (las plantillas aprobadas en Meta).
- **Sync de plantillas back ↔ front**: el back usaba cuerpos distintos a los del front; se sincronizaron con el `cuerpoWhastapp` del frontend para que el preview de la modal coincida con lo que efectivamente se manda y con la plantilla aprobada en Meta.

## Test plan
- [ ] Reiniciar el server tras correr `bun push` y confirmar `SIMPLETECH_TEMPLATE_NAME=mensaje1parametro` en `.env`.
- [ ] Abrir la modal de masivo, elegir `Mora 30 días`, confirmar que el preview es editable.
- [ ] Posicionar cursor en medio del texto y clickear chip `{clienteNombre}`: debe insertarse exactamente ahí y dejar el caret después del token.
- [ ] Aplicar un rango de fechas en la página de cobros y verificar que el resumen "Filtros aplicados" de la modal muestra el rango y que el endpoint envía `fecha_desde`/`fecha_hasta`.
- [ ] Mandar masivo en TEST_MODE con un destinatario y revisar `cobros_send_logs`:
  - `plantilla_id` y `batch_id` poblados.
  - `provider_request.templateName` = `mensaje{N}parametro` según los párrafos del cuerpo.
  - En caso de error, `provider_response.responseBodyParsed.data` con el motivo crudo.
- [ ] Generar un masivo con créditos descartables (sin teléfono); verificar que se abre la segunda modal y que el CSV descargado tiene `numeroSifco,clienteNombre,motivo`.
- [ ] Enviar mensaje individual desde `contacto-modal` y verificar que `plantilla_id` queda registrado en el log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)