### PR TITLE
feat: add isOwned field to vehicle inspection

### DIFF
--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -1134,6 +1134,7 @@ export const vehiclesRouter = {
 					iscvCode: z.string().nullable().optional(),
 					trim: z.string().optional(),
 					traction: z.string().optional(),
+					isOwned: z.boolean().optional(),
 				}),
 				// Inspection data
 				inspection: z.object({

--- a/apps/taller/src/pages/vehicle-inspection.tsx
+++ b/apps/taller/src/pages/vehicle-inspection.tsx
@@ -80,6 +80,7 @@ const formSchema = z.object({
 
   vinVerification: z.boolean(),
   vehicleId: z.string().optional(),
+  isCashInOwned: z.boolean(),
 });
 
 type FormValues = z.infer<typeof formSchema>;
@@ -142,8 +143,9 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
       noTestDriveReason: "",
       vinVerification: false,
       vehicleId: "",
+      isCashInOwned: false,
       ...formData,
-    },
+    } as FormValues,
   });
 
   // Exponer método de validación para el wizard
@@ -322,6 +324,7 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
       kmMileage: vehicle.kmMileage?.toString() || ocr.kmMileage || "",
       milesMileage: vehicle.milesMileage?.toString() || ocr.milesMileage || "",
       vinVerification: false,
+      isCashInOwned: vehicle.isOwned || false,
     });
     
     // Clear search results
@@ -398,6 +401,7 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
       noTestDriveReason: "",
       vinVerification: false,
       vehicleId: "",
+      isCashInOwned: false,
     });
 
     setFormSubmitted(true);
@@ -476,6 +480,7 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
       vehicleId: isDevMode 
         ? "27484f6e-811d-467f-bdae-c2e3054769f3" 
         : "f710e3cc-deae-4320-97d4-6aaff963c410",
+      isCashInOwned: true,
     };
 
     // Use form.reset() to properly update all fields including selects
@@ -804,6 +809,30 @@ const VehicleInspectionForm = forwardRef<VehicleInspectionFormRef, VehicleInspec
                   )}
                 />
               </div>
+
+              <FormField
+                control={form.control}
+                name="isCashInOwned"
+                render={({ field }) => (
+                  <FormItem className="flex flex-row items-start space-x-3 space-y-0 p-1">
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        className="mt-1 h-5 w-5 border-gray-400"
+                      />
+                    </FormControl>
+                    <div className="space-y-1 leading-none">
+                      <FormLabel className="text-base font-semibold text-gray-800 cursor-pointer">
+                        ¿El vehículo es propio de Cash In?
+                      </FormLabel>
+                      <p className="text-sm text-gray-600">
+                        Marque esta opción si el vehículo pertenece a Cash In
+                      </p>
+                    </div>
+                  </FormItem>
+                )}
+              />
 
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-5">
                 <FormField

--- a/apps/taller/src/services/vehicles.ts
+++ b/apps/taller/src/services/vehicles.ts
@@ -23,6 +23,7 @@ export interface VehicleData {
   id?: string;
   seats?: number | null;
   vehicleUse?: string | null;
+  isOwned?: boolean;
 }
 
 export interface InspectionData {
@@ -155,6 +156,7 @@ export const prepareInspectionData = (formData: any, sectionTimes?: Record<strin
     id: formData.vehicleId,
     seats: formData.seats ? parseInt(formData.seats) : null,
     vehicleUse: formData.vehicleUse || null,
+    isOwned: formData.isCashInOwned || false,
   };
 
   const inspectionData: InspectionData = {


### PR DESCRIPTION
# Descripcion de los cambios

Se ha implementado una nueva funcionalidad en el modulo de inspeccion de vehiculos para identificar si un vehiculo pertenece al inventario propio de Cash In.

## Cambios en el Frontend (Taller)

1. **Interfaz de Usuario**: Se agrego un nuevo campo de tipo checkbox en la Etapa 1 del formulario de inspeccion con la etiqueta "¿El vehiculo es propio de Cash In?".
2. **Validacion y Estado**: Se actualizo el esquema de validacion (Zod) y los valores por defecto del formulario para incluir el campo `isCashInOwned`.
3. **Persistencia**: Se ajusto el servicio de vehiculos para mapear correctamente el valor del formulario hacia la propiedad `isOwned` requerida por el backend.
4. **Correccion de Tipos**: Se optimizo la inicializacion del formulario en `vehicle-inspection.tsx` para evitar errores de tipado con el estado persistido del contexto de inspeccion.

## Cambios en el Backend (CRM)

1. **Esquema de API**: Se actualizo el procedimiento `createFullInspection` en el router de vehiculos para aceptar el campo booleano `isOwned`.
2. **Persistencia en Base de Datos**: El campo se integra automaticamente en el flujo de upsert de vehiculos, asegurando que la propiedad se guarde correctamente en la tabla de vehiculos.

## Verificacion

- Se valido que el checkbox mantenga su estado durante el flujo del wizard.
- Se verifico que el valor se envie correctamente en el payload final de la inspeccion.
- Se confirmo la compatibilidad de tipos durante el proceso de compilacion.
