### PR TITLE
feat(inversionistas): Add CRUD for extra investor accounts and integrate into global summary

### DIFF
--- a/apps/cartera-back/src/controllers/cuentasExtraInversionista.ts
+++ b/apps/cartera-back/src/controllers/cuentasExtraInversionista.ts
@@ -1,0 +1,255 @@
+// services/cuentasExtraInversionista.service.ts
+import { and, eq, ilike } from "drizzle-orm";
+import { cuentas_extra_inversionista } from "../database/db";
+import { db } from "../database";
+
+type Moneda = "quetzales" | "dolares";
+type TipoCuenta =
+  | "AHORRO"
+  | "AHORRO Q"
+  | "AHORROS"
+  | "AHORRO $"
+  | "MONETARIA"
+  | "MONETARIA Q"
+  | "MONETARIA $"
+  | "Capital";
+
+type ListFilters = {
+  inversionistaId?: number;
+  bancoId?: number;
+  tipoCuenta?: TipoCuenta;
+  moneda?: Moneda;
+  numeroCuenta?: string; // búsqueda parcial (ilike)
+  motivoCuenta?: string; // búsqueda parcial (ilike)
+};
+
+export async function listCuentasExtra(filters?: ListFilters) {
+  try {
+    const conditions = [];
+    if (filters?.inversionistaId !== undefined) {
+      conditions.push(
+        eq(cuentas_extra_inversionista.inversionista_id, filters.inversionistaId)
+      );
+    }
+    if (filters?.bancoId !== undefined) {
+      conditions.push(eq(cuentas_extra_inversionista.banco_id, filters.bancoId));
+    }
+    if (filters?.tipoCuenta) {
+      conditions.push(eq(cuentas_extra_inversionista.tipo_cuenta, filters.tipoCuenta));
+    }
+    if (filters?.moneda) {
+      conditions.push(eq(cuentas_extra_inversionista.moneda, filters.moneda));
+    }
+    if (filters?.numeroCuenta) {
+      conditions.push(
+        ilike(cuentas_extra_inversionista.numero_cuenta, `%${filters.numeroCuenta}%`)
+      );
+    }
+    if (filters?.motivoCuenta) {
+      conditions.push(
+        ilike(cuentas_extra_inversionista.motivo_cuenta, `%${filters.motivoCuenta}%`)
+      );
+    }
+
+    const data = await db
+      .select()
+      .from(cuentas_extra_inversionista)
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(cuentas_extra_inversionista.cuenta_extra_id);
+
+    return {
+      success: true,
+      message: "✅ Cuentas extra obtenidas correctamente",
+      data,
+    };
+  } catch (error: any) {
+    console.error("❌ Error al listar cuentas extra:", error);
+    return {
+      success: false,
+      message: "❌ Error al obtener las cuentas extra",
+      error: error.message,
+      data: [],
+    };
+  }
+}
+
+export async function getCuentasExtraByInversionista(inversionistaId: number) {
+  try {
+    const data = await db
+      .select()
+      .from(cuentas_extra_inversionista)
+      .where(eq(cuentas_extra_inversionista.inversionista_id, inversionistaId))
+      .orderBy(cuentas_extra_inversionista.cuenta_extra_id);
+
+    return {
+      success: true,
+      message: "✅ Cuentas extra del inversionista obtenidas correctamente",
+      data,
+    };
+  } catch (error: any) {
+    console.error("❌ Error al obtener cuentas extra por inversionista:", error);
+    return {
+      success: false,
+      message: "❌ Error al obtener las cuentas extra del inversionista",
+      error: error.message,
+      data: [],
+    };
+  }
+}
+
+export async function getCuentaExtraById(cuentaExtraId: number) {
+  try {
+    const result = await db
+      .select()
+      .from(cuentas_extra_inversionista)
+      .where(eq(cuentas_extra_inversionista.cuenta_extra_id, cuentaExtraId))
+      .limit(1);
+
+    const cuenta = result[0] || null;
+    if (!cuenta) {
+      return {
+        success: false,
+        message: "❌ Cuenta extra no encontrada",
+        data: null,
+      };
+    }
+
+    return {
+      success: true,
+      message: "✅ Cuenta extra obtenida correctamente",
+      data: cuenta,
+    };
+  } catch (error: any) {
+    console.error("❌ Error al obtener cuenta extra por ID:", error);
+    return {
+      success: false,
+      message: "❌ Error al obtener la cuenta extra",
+      error: error.message,
+      data: null,
+    };
+  }
+}
+
+export async function createCuentaExtra(data: {
+  inversionistaId: number;
+  bancoId: number;
+  tipoCuenta: TipoCuenta;
+  numeroCuenta: string;
+  motivoCuenta: string;
+  moneda?: Moneda;
+}) {
+  try {
+    const [nueva] = await db
+      .insert(cuentas_extra_inversionista)
+      .values({
+        inversionista_id: data.inversionistaId,
+        banco_id: data.bancoId,
+        tipo_cuenta: data.tipoCuenta,
+        numero_cuenta: data.numeroCuenta,
+        motivo_cuenta: data.motivoCuenta,
+        ...(data.moneda ? { moneda: data.moneda } : {}),
+      })
+      .returning();
+
+    return {
+      success: true,
+      message: "✅ Cuenta extra creada correctamente",
+      data: nueva,
+    };
+  } catch (error: any) {
+    console.error("❌ Error al crear cuenta extra:", error);
+    return {
+      success: false,
+      message: "❌ Error al crear la cuenta extra",
+      error: error.message,
+      data: null,
+    };
+  }
+}
+
+export async function updateCuentaExtra(
+  cuentaExtraId: number,
+  data: Partial<{
+    bancoId: number;
+    tipoCuenta: TipoCuenta;
+    numeroCuenta: string;
+    motivoCuenta: string;
+    moneda: Moneda;
+  }>
+) {
+  try {
+    const updateValues: Record<string, unknown> = {};
+    if (data.bancoId !== undefined) updateValues.banco_id = data.bancoId;
+    if (data.tipoCuenta !== undefined) updateValues.tipo_cuenta = data.tipoCuenta;
+    if (data.numeroCuenta !== undefined) updateValues.numero_cuenta = data.numeroCuenta;
+    if (data.motivoCuenta !== undefined) updateValues.motivo_cuenta = data.motivoCuenta;
+    if (data.moneda !== undefined) updateValues.moneda = data.moneda;
+
+    if (Object.keys(updateValues).length === 0) {
+      return {
+        success: false,
+        message: "❌ No hay campos para actualizar",
+        data: null,
+      };
+    }
+
+    const [actualizada] = await db
+      .update(cuentas_extra_inversionista)
+      .set(updateValues)
+      .where(eq(cuentas_extra_inversionista.cuenta_extra_id, cuentaExtraId))
+      .returning();
+
+    if (!actualizada) {
+      return {
+        success: false,
+        message: "❌ Cuenta extra no encontrada",
+        data: null,
+      };
+    }
+
+    return {
+      success: true,
+      message: "✅ Cuenta extra actualizada correctamente",
+      data: actualizada,
+    };
+  } catch (error: any) {
+    console.error("❌ Error al actualizar cuenta extra:", error);
+    return {
+      success: false,
+      message: "❌ Error al actualizar la cuenta extra",
+      error: error.message,
+      data: null,
+    };
+  }
+}
+
+export async function deleteCuentaExtra(cuentaExtraId: number) {
+  try {
+    const [eliminada] = await db
+      .delete(cuentas_extra_inversionista)
+      .where(eq(cuentas_extra_inversionista.cuenta_extra_id, cuentaExtraId))
+      .returning();
+
+    if (!eliminada) {
+      return {
+        success: false,
+        message: "❌ Cuenta extra no encontrada",
+        data: null,
+      };
+    }
+
+    return {
+      success: true,
+      message: "✅ Cuenta extra eliminada correctamente",
+      data: eliminada,
+    };
+  } catch (error: any) {
+    console.error("❌ Error al eliminar cuenta extra:", error);
+    return {
+      success: false,
+      message: "❌ Error al eliminar la cuenta extra",
+      error: error.message,
+      data: null,
+    };
+  }
+}

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -5268,6 +5268,16 @@ interface BoletaPendiente {
   fecha_subida: Date;
 }
 
+interface CuentaExtraInfo {
+  cuenta_extra_id: number;
+  banco_id: number;
+  banco_nombre: string | null;
+  tipo_cuenta: string;
+  numero_cuenta: string;
+  moneda: "quetzales" | "dolares";
+  motivo_cuenta: string;
+}
+
 interface InversionistaResumen {
   inversionista_id: number;
   nombre: string;
@@ -5284,6 +5294,7 @@ interface InversionistaResumen {
   banco: string | null;
   tipo_cuenta: string | null;
   numero_cuenta: string | null;
+  cuentas_extra: CuentaExtraInfo[];
   total_abono_capital: number;
   total_abono_interes: number;
   total_abono_iva: number;
@@ -5414,6 +5425,45 @@ async function getBoletasMap(
   );
 
   return mapBoletasPendientes(boletasFiltradas);
+}
+
+async function getCuentasExtraMap(
+  inversionistaIds: number[]
+): Promise<Map<number, CuentaExtraInfo[]>> {
+  const map = new Map<number, CuentaExtraInfo[]>();
+  if (inversionistaIds.length === 0) return map;
+
+  const rows = await db
+    .select({
+      cuenta_extra_id: cuentas_extra_inversionista.cuenta_extra_id,
+      inversionista_id: cuentas_extra_inversionista.inversionista_id,
+      banco_id: cuentas_extra_inversionista.banco_id,
+      banco_nombre: bancos.nombre,
+      tipo_cuenta: cuentas_extra_inversionista.tipo_cuenta,
+      numero_cuenta: cuentas_extra_inversionista.numero_cuenta,
+      moneda: cuentas_extra_inversionista.moneda,
+      motivo_cuenta: cuentas_extra_inversionista.motivo_cuenta,
+    })
+    .from(cuentas_extra_inversionista)
+    .leftJoin(bancos, eq(cuentas_extra_inversionista.banco_id, bancos.banco_id))
+    .where(inArray(cuentas_extra_inversionista.inversionista_id, inversionistaIds))
+    .orderBy(cuentas_extra_inversionista.cuenta_extra_id);
+
+  for (const r of rows) {
+    const item: CuentaExtraInfo = {
+      cuenta_extra_id: r.cuenta_extra_id,
+      banco_id: r.banco_id,
+      banco_nombre: r.banco_nombre,
+      tipo_cuenta: r.tipo_cuenta,
+      numero_cuenta: r.numero_cuenta,
+      moneda: r.moneda as "quetzales" | "dolares",
+      motivo_cuenta: r.motivo_cuenta,
+    };
+    const existing = map.get(r.inversionista_id);
+    if (existing) existing.push(item);
+    else map.set(r.inversionista_id, [item]);
+  }
+  return map;
 }
 
 async function getBoletasLiquidacionMap(
@@ -5827,7 +5877,8 @@ async function consultarResumenGlobalDesdeLiquidaciones(
 function mapResumenRow(
   inv: InversionistaResumenRow,
   boleta_pendiente: BoletaPendiente | null,
-  boleta_liquidacion: BoletaPendiente | null = null
+  boleta_liquidacion: BoletaPendiente | null = null,
+  cuentas_extra: CuentaExtraInfo[] = []
 ): InversionistaResumen {
   const isUSD = inv.moneda === "dolares";
   const currencySymbol = isUSD ? "$" : "Q";
@@ -5848,6 +5899,7 @@ function mapResumenRow(
     banco: inv.banco_nombre,
     tipo_cuenta: inv.tipo_cuenta,
     numero_cuenta: inv.numero_cuenta,
+    cuentas_extra,
     total_abono_capital: convert(inv.total_abono_capital),
     total_abono_interes: convert(inv.total_abono_interes),
     total_abono_iva: convert(inv.total_abono_iva),
@@ -6276,10 +6328,11 @@ export async function resumenGlobalLiquidaciones(
       ...liquidados.map((inv) => inv.inversionista_id),
     ])
   );
-  const [boletaPendienteMap, boletaSubidaMap, boletaLiquidacionMap] = await Promise.all([
+  const [boletaPendienteMap, boletaSubidaMap, boletaLiquidacionMap, cuentasExtraMap] = await Promise.all([
     getBoletasPendientesMap(inversionistaIds, mes, anio),
     getBoletasMap(inversionistaIds, ["PENDIENTE", "PROCESADO"], mes, anio),
     getBoletasLiquidacionMap(inversionistaIds, mes, anio),
+    getCuentasExtraMap(inversionistaIds),
   ]);
 
   const result: InversionistaResumenConEstado[] = [];
@@ -6301,7 +6354,8 @@ export async function resumenGlobalLiquidaciones(
       ...mapResumenRow(
         inv,
         boletaPendienteMap.get(inv.inversionista_id) ?? null,
-        boletaLiquidacionMap.get(inv.inversionista_id) ?? null
+        boletaLiquidacionMap.get(inv.inversionista_id) ?? null,
+        cuentasExtraMap.get(inv.inversionista_id) ?? []
       ),
       estado_liquidacion_resumen: estadoResumen,
     });
@@ -6323,7 +6377,8 @@ export async function resumenGlobalLiquidaciones(
       ...mapResumenRow(
         inv,
         null,
-        boletaLiquidacionMap.get(inv.inversionista_id) ?? null
+        boletaLiquidacionMap.get(inv.inversionista_id) ?? null,
+        cuentasExtraMap.get(inv.inversionista_id) ?? []
       ),
       estado_liquidacion_resumen: estadoResumen,
     });
@@ -6351,6 +6406,11 @@ export async function resumenGlobalLiquidaciones(
       .from(inversionistas)
       .leftJoin(bancos, eq(inversionistas.banco_id, bancos.banco_id))
       .where(and(...filtros));
+
+    const idsSinMovimiento = todos
+      .filter((inv) => !idsConMovimiento.has(inv.inversionista_id))
+      .map((inv) => inv.inversionista_id);
+    const cuentasExtraSinMovMap = await getCuentasExtraMap(idsSinMovimiento);
 
     for (const inv of todos) {
       if (idsConMovimiento.has(inv.inversionista_id)) continue;
@@ -6380,7 +6440,12 @@ export async function resumenGlobalLiquidaciones(
       };
 
       result.push({
-        ...mapResumenRow(stub, null, null),
+        ...mapResumenRow(
+          stub,
+          null,
+          null,
+          cuentasExtraSinMovMap.get(inv.inversionista_id) ?? []
+        ),
         estado_liquidacion_resumen: "sin_movimiento",
       });
     }

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -651,6 +651,31 @@
     status: statusInversionistaEnum("status").notNull().default("activo"),
   });
 
+  export const cuentas_extra_inversionista = customSchema.table(
+    "cuentas_extra_inversionista",
+    {
+      cuenta_extra_id: serial("cuenta_extra_id").primaryKey(),
+      inversionista_id: integer("inversionista_id")
+        .notNull()
+        .references(() => inversionistas.inversionista_id, { onDelete: "cascade" }),
+      banco_id: integer("banco_id")
+        .notNull()
+        .references(() => bancos.banco_id),
+      tipo_cuenta: tipoCuentaEnum("tipo_cuenta").notNull(),
+      numero_cuenta: varchar("numero_cuenta", { length: 100 }).notNull(),
+      moneda: tipoMonedaEnum("moneda").notNull().default("quetzales"),
+      motivo_cuenta: varchar("motivo_cuenta", { length: 255 }).notNull(),
+    },
+    (t) => ({
+      inversionistaIdx: index("idx_cuentas_extra_inv_inversionista").on(t.inversionista_id),
+      uxCuentaExtra: uniqueIndex("ux_cuentas_extra_inv_numero").on(
+        t.inversionista_id,
+        t.banco_id,
+        t.numero_cuenta
+      ),
+    })
+  );
+
   export const reinversiones = customSchema.table("reinversiones", {
     reinversion_id: serial("reinversion_id").primaryKey(),
     inversionista_id: integer("inversionista_id")

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -41,7 +41,8 @@ const app = new Elysia()
   .use(routers.replaceInvestorCreditRouter)
   .use(routers.compraCarteraAceptadaRouter)
   .use(routers.devolucionRouter)
-  .use(routers.creditosNuevosConAbonosRouter);
+  .use(routers.creditosNuevosConAbonosRouter)
+  .use(routers.cuentasExtraInversionistaRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor
 iniciarTareasProgramadas();

--- a/apps/cartera-back/src/routers/cuentasExtraInversionista.ts
+++ b/apps/cartera-back/src/routers/cuentasExtraInversionista.ts
@@ -1,0 +1,251 @@
+// routes/cuentasExtraInversionista.routes.ts
+import { Elysia, t } from "elysia";
+import {
+  createCuentaExtra,
+  deleteCuentaExtra,
+  getCuentaExtraById,
+  getCuentasExtraByInversionista,
+  listCuentasExtra,
+  updateCuentaExtra,
+} from "../controllers/cuentasExtraInversionista";
+import { authMiddleware } from "./midleware";
+
+const tipoCuentaSchema = t.Union([
+  t.Literal("AHORRO"),
+  t.Literal("AHORRO Q"),
+  t.Literal("AHORROS"),
+  t.Literal("AHORRO $"),
+  t.Literal("MONETARIA"),
+  t.Literal("MONETARIA Q"),
+  t.Literal("MONETARIA $"),
+  t.Literal("Capital"),
+]);
+
+const monedaSchema = t.Union([t.Literal("quetzales"), t.Literal("dolares")]);
+
+export const cuentasExtraInversionistaRouter = new Elysia({
+  prefix: "/api/cuentas-extra-inversionista",
+})
+  .use(authMiddleware)
+
+  // 📋 GET - Listar todas las cuentas extra con filtros opcionales.
+  // Query: ?inversionistaId=12&bancoId=3&tipoCuenta=MONETARIA&moneda=quetzales&numeroCuenta=1234&motivoCuenta=pagos
+  .get(
+    "/",
+    async ({ query, set }) => {
+      try {
+        const inversionistaId = query.inversionistaId
+          ? parseInt(query.inversionistaId)
+          : undefined;
+        const bancoId = query.bancoId ? parseInt(query.bancoId) : undefined;
+
+        if (query.inversionistaId && isNaN(inversionistaId!)) {
+          set.status = 400;
+          return { success: false, message: "❌ inversionistaId inválido" };
+        }
+        if (query.bancoId && isNaN(bancoId!)) {
+          set.status = 400;
+          return { success: false, message: "❌ bancoId inválido" };
+        }
+
+        const result = await listCuentasExtra({
+          inversionistaId,
+          bancoId,
+          tipoCuenta: query.tipoCuenta as any,
+          moneda: query.moneda as any,
+          numeroCuenta: query.numeroCuenta,
+          motivoCuenta: query.motivoCuenta,
+        });
+
+        if (!result.success) set.status = 500;
+        return result;
+      } catch (error: any) {
+        console.error("❌ Error en GET /cuentas-extra-inversionista:", error);
+        set.status = 500;
+        return {
+          success: false,
+          message: "❌ Error interno del servidor",
+          error: error.message,
+        };
+      }
+    },
+    {
+      query: t.Object({
+        inversionistaId: t.Optional(t.String()),
+        bancoId: t.Optional(t.String()),
+        tipoCuenta: t.Optional(tipoCuentaSchema),
+        moneda: t.Optional(monedaSchema),
+        numeroCuenta: t.Optional(t.String()),
+        motivoCuenta: t.Optional(t.String()),
+      }),
+    }
+  )
+
+  // 👤 GET - Cuentas extra por inversionista
+  .get(
+    "/inversionista/:inversionistaId",
+    async ({ params: { inversionistaId }, set }) => {
+      try {
+        const id = parseInt(inversionistaId);
+        if (isNaN(id)) {
+          set.status = 400;
+          return { success: false, message: "❌ inversionistaId inválido" };
+        }
+
+        const result = await getCuentasExtraByInversionista(id);
+        if (!result.success) set.status = 500;
+        return result;
+      } catch (error: any) {
+        console.error(
+          "❌ Error en GET /cuentas-extra-inversionista/inversionista/:inversionistaId:",
+          error
+        );
+        set.status = 500;
+        return {
+          success: false,
+          message: "❌ Error interno del servidor",
+          error: error.message,
+        };
+      }
+    },
+    {
+      params: t.Object({ inversionistaId: t.String() }),
+    }
+  )
+
+  // 🔍 GET - Cuenta extra por ID
+  .get(
+    "/:id",
+    async ({ params: { id }, set }) => {
+      try {
+        const cuentaExtraId = parseInt(id);
+        if (isNaN(cuentaExtraId)) {
+          set.status = 400;
+          return { success: false, message: "❌ ID inválido" };
+        }
+
+        const result = await getCuentaExtraById(cuentaExtraId);
+        if (!result.success) set.status = 404;
+        return result;
+      } catch (error: any) {
+        console.error("❌ Error en GET /cuentas-extra-inversionista/:id:", error);
+        set.status = 500;
+        return {
+          success: false,
+          message: "❌ Error interno del servidor",
+          error: error.message,
+        };
+      }
+    },
+    {
+      params: t.Object({ id: t.String() }),
+    }
+  )
+
+  // ➕ POST - Crear cuenta extra
+  .post(
+    "/",
+    async ({ body, set }) => {
+      try {
+        const result = await createCuentaExtra({
+          inversionistaId: body.inversionistaId,
+          bancoId: body.bancoId,
+          tipoCuenta: body.tipoCuenta,
+          numeroCuenta: body.numeroCuenta,
+          motivoCuenta: body.motivoCuenta,
+          moneda: body.moneda,
+        });
+
+        if (!result.success) {
+          set.status = 400;
+          return result;
+        }
+
+        set.status = 201;
+        return result;
+      } catch (error: any) {
+        console.error("❌ Error en POST /cuentas-extra-inversionista:", error);
+        set.status = 500;
+        return {
+          success: false,
+          message: "❌ Error interno del servidor",
+          error: error.message,
+        };
+      }
+    },
+    {
+      body: t.Object({
+        inversionistaId: t.Number(),
+        bancoId: t.Number(),
+        tipoCuenta: tipoCuentaSchema,
+        numeroCuenta: t.String({ minLength: 1, maxLength: 100 }),
+        motivoCuenta: t.String({ minLength: 1, maxLength: 255 }),
+        moneda: t.Optional(monedaSchema),
+      }),
+    }
+  )
+
+  // ✏️ PUT - Actualizar cuenta extra
+  .put(
+    "/:id",
+    async ({ params: { id }, body, set }) => {
+      try {
+        const cuentaExtraId = parseInt(id);
+        if (isNaN(cuentaExtraId)) {
+          set.status = 400;
+          return { success: false, message: "❌ ID inválido" };
+        }
+
+        const result = await updateCuentaExtra(cuentaExtraId, body);
+        if (!result.success) set.status = 404;
+        return result;
+      } catch (error: any) {
+        console.error("❌ Error en PUT /cuentas-extra-inversionista/:id:", error);
+        set.status = 500;
+        return {
+          success: false,
+          message: "❌ Error interno del servidor",
+          error: error.message,
+        };
+      }
+    },
+    {
+      params: t.Object({ id: t.String() }),
+      body: t.Object({
+        bancoId: t.Optional(t.Number()),
+        tipoCuenta: t.Optional(tipoCuentaSchema),
+        numeroCuenta: t.Optional(t.String({ minLength: 1, maxLength: 100 })),
+        motivoCuenta: t.Optional(t.String({ minLength: 1, maxLength: 255 })),
+        moneda: t.Optional(monedaSchema),
+      }),
+    }
+  )
+
+  // 🗑️ DELETE - Eliminar cuenta extra
+  .delete(
+    "/:id",
+    async ({ params: { id }, set }) => {
+      try {
+        const cuentaExtraId = parseInt(id);
+        if (isNaN(cuentaExtraId)) {
+          set.status = 400;
+          return { success: false, message: "❌ ID inválido" };
+        }
+
+        const result = await deleteCuentaExtra(cuentaExtraId);
+        if (!result.success) set.status = 404;
+        return result;
+      } catch (error: any) {
+        console.error("❌ Error en DELETE /cuentas-extra-inversionista/:id:", error);
+        set.status = 500;
+        return {
+          success: false,
+          message: "❌ Error interno del servidor",
+          error: error.message,
+        };
+      }
+    },
+    {
+      params: t.Object({ id: t.String() }),
+    }
+  );

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -28,6 +28,7 @@ import { replaceInvestorCreditRouter } from "./replaceInvestorCredit";
 import { compraCarteraAceptadaRouter } from "./compraCarteraAceptada";
 import { devolucionRouter } from "./devolucion";
 import { creditosNuevosConAbonosRouter } from "./creditosNuevosConAbonos";
+import { cuentasExtraInversionistaRouter } from "./cuentasExtraInversionista";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,devolucionRouter,creditosNuevosConAbonosRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,devolucionRouter,creditosNuevosConAbonosRouter,cuentasExtraInversionistaRouter
 }


### PR DESCRIPTION
Introduces a new feature to manage multiple secondary bank accounts for investors.

This change includes:
- A new `cuentas_extra_inversionista` database schema.
- Full CRUD API endpoints for managing these extra accounts.
- Integration of these accounts into the global investor liquidation summary (`resumenGlobalLiquidaciones`) to provide a comprehensive financial overview per investor.