### PR TITLE
fix: update parameter validation and make 'estado' optional in credit…

### DIFF
--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -141,9 +141,9 @@ export const creditRouter = new Elysia()
   } = query as Record<string, string>;
 
   // Validar parámetros requeridos
-  if (!mes || !anio || !estado) {
+  if (!mes || !anio) {
     set.status = 400;
-    return { message: "Faltan parámetros 'mes', 'anio' y/o 'estado'." };
+    return { message: "Faltan parámetros 'mes' y/o 'anio'." };
   }
 
   // Convertir a número (ya que query params vienen como string)
@@ -162,14 +162,16 @@ export const creditRouter = new Elysia()
         .map((s) => s.trim())
         .filter((s) => s.length > 0)
     : undefined;
-  const estadoParam = String(estado) as
-    | "ACTIVO"
-    | "CANCELADO"
-    | "INCOBRABLE"
-    | "PENDIENTE_CANCELACION"
-    | "EN_CONVENIO"
-    | "MOROSO"
-    | "CAIDO";
+  const estadoParam = estado
+    ? (String(estado) as
+        | "ACTIVO"
+        | "CANCELADO"
+        | "INCOBRABLE"
+        | "PENDIENTE_CANCELACION"
+        | "EN_CONVENIO"
+        | "MOROSO"
+        | "CAIDO")
+    : undefined;
   
   // Convertir asesor_id a número si existe
   const asesorIdNum = asesor_id ? Number(asesor_id) : undefined;

--- a/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
+++ b/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
@@ -51,7 +51,6 @@ export function BuscadorUsuarioSifco({ onSelect, reset, onReset }: BuscadorUsuar
         anio: new Date().getFullYear(),
         page,
         perPage: 10,
-        estado: "ACTIVO",
         excel: false,
         ...(hasFilter && esSifco(searchTrimmed)
           ? { numero_credito_sifco: searchTrimmed }

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -462,7 +462,7 @@ export const getCreditosPaginados = async (params: {
   page?: number;
   perPage?: number;
   numero_credito_sifco?: string;
-  estado: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO";
+  estado?: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO";
   excel: boolean;
   asesor_id?: number;
   nombre_usuario?: string;


### PR DESCRIPTION
1. apps/cartera-back/src/routers/credits.ts 
- estado eliminado de la validación de parámetros requeridos — ahora solo mes y anio son obligatorios

2. apps/carteraFront/src/private/cartera/services/services.ts
- estado marcado como opcional (?) en el tipo de getCreditosPaginados

3.apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
- Removido estado: "ACTIVO" de la llamada — ahora el buscador busca en todos los estados
