### PR TITLE
Add visibility state for credit information and improve validation

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -92,6 +92,7 @@ export function PagoForm() {
 
   // 🎯 Estado para el modal de confirmación
   const [modalConfirmacionOpen, setModalConfirmacionOpen] = useState(false);
+  const [creditoVisible, setCreditoVisible] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const [bancoQuery, setBancoQuery] = useState("");
 
@@ -493,7 +494,10 @@ export function PagoForm() {
         <CardContent className="flex-1 flex flex-col items-center justify-center">
           <div className="mb-4 flex gap-2 items-center">
             <BuscadorUsuarioSifco
-              onSelect={(sifco) => fetchCredito(sifco)}
+              onSelect={(sifco) => {
+                if (sifco) { setCreditoVisible(true); fetchCredito(sifco); }
+                else setCreditoVisible(false);
+              }}
               reset={resetBuscador}
               onReset={() => setResetBuscador(false)}
             />
@@ -550,6 +554,7 @@ export function PagoForm() {
               </div>
             </div>
           ) : (
+            creditoVisible &&
             dataCredito?.credito &&
             dataCredito?.usuario && (
               <MiniCardCredito

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -223,6 +223,7 @@ const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
   } | null>(null);
   // Función para buscar crédito y setear los campos
     const fetchCredito = async (numero_credito_sifco: string) => {
+    if (!numero_credito_sifco.trim()) return;
     setLoadingCredito(true);
     setErrorCredito(null);
     try {


### PR DESCRIPTION
1. registerPayment.ts)
- Guard en fetchCredito: si el SIFCO llega vacío, retorna sin hacer la llamada al backend

2. PagoForm.tsx
- Estado local creditoVisible para controlar la visibilidad de MiniCardCredito
- Al seleccionar SIFCO → setCreditoVisible(true) + fetchCredito
- Al hacer click en la X → setCreditoVisible(false) → MiniCardCredito desaparece