### PR TITLE
fix: wrap asesor name filter conditions in parentheses to ensure corr…

### DIFF
--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1495,7 +1495,7 @@ export async function getPagosByVencimiento({
     const asesorNames = asesor.split(",").map((n) => n.trim()).filter((n) => n.length > 0);
     if (asesorNames.length > 0) {
       const orConditions = asesorNames.map((name) => sql`a.nombre ILIKE ${"%" + name + "%"}`);
-      filters.push(sql.join(orConditions, sql` OR `));
+      filters.push(sql`(${sql.join(orConditions, sql` OR `)})`);
     }
   }
   if (rango_mora) {


### PR DESCRIPTION
# fix: Corregir precedencia de operadores SQL en filtro de asesores

Se detectó que al seleccionar múltiples asesores, la cláusula `OR` se concatenaba sin paréntesis, lo que causaba que se ignoraran otros filtros (como mes y año) para los asesores adicionales debido a la precedencia del operador `AND`.

## Cambios Realizados
- Se envolvieron las condiciones de búsqueda de asesores (`ILIKE`) dentro de un bloque de paréntesis en la consulta SQL del reporte de Pagos por Vencimiento.
- Esto garantiza que el filtro de asesores se evalúe como un solo grupo lógico que debe coexistir con el resto de los filtros de la consulta.

## Verificación
- Se validó que al seleccionar 2 o más asesores, los resultados se mantengan restringidos correctamente al mes y año seleccionados.
