### PR TITLE
Enhance CRM search functionality for middle and second last names

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -286,7 +286,9 @@ export const crmRouter = {
 					const searchPattern = `%${term}%`;
 					return or(
 						ilike(leads.firstName, searchPattern),
+						ilike(leads.middleName, searchPattern),
 						ilike(leads.lastName, searchPattern),
+						ilike(leads.secondLastName, searchPattern),
 						ilike(leads.email, searchPattern),
 						ilike(companies.name, searchPattern),
 					);


### PR DESCRIPTION
1. routers/crm.ts
El endpoint getLeads permite buscar leads por nombre. Al recibir el texto de búsqueda, lo divide por espacios y exige que cada palabra encuentre coincidencia en algún campo del lead (lógica AND entre palabras, OR entre campos).
Se agregaron dos campos adicionales al OR:
- middleName (segundo nombre)
- secondLastName (segundo apellido)