### PR TITLE
fix(cartera): Import extra investor accounts schema

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -26,6 +26,7 @@ import {
   liquidacion_locks,
   documentos_inversionista,
   abonos_capital,
+  cuentas_extra_inversionista,
 } from "../database/db/schema";
 import { getSignedDocumentUrl } from "../utils/functions/uploadsFiles";
 import { eq, and, or, sql, inArray, ilike, like, desc, count, SQL, isNull, isNotNull, ne } from "drizzle-orm";


### PR DESCRIPTION
Makes the 'cuentas_extra_inversionista' schema available in the investor controller to support upcoming fixes for the liquidation process.
