### PR TITLE
Feat: Integrate persisted state and date range hooks for state management

### DIFF
--- a/apps/crm/apps/web/src/hooks/usePersistedDateRange.ts
+++ b/apps/crm/apps/web/src/hooks/usePersistedDateRange.ts
@@ -1,0 +1,24 @@
+import type { DateRange } from "react-day-picker";
+import { usePersistedState } from "./usePersistedState";
+
+export function usePersistedDateRange(key: string) {
+	const [persisted, setPersisted] = usePersistedState<
+		{ from?: string; to?: string } | undefined
+	>(key, undefined);
+
+	const dateRange: DateRange | undefined = persisted
+		? {
+				from: persisted.from ? new Date(persisted.from) : undefined,
+				to: persisted.to ? new Date(persisted.to) : undefined,
+			}
+		: undefined;
+
+	const setDateRange = (range: DateRange | undefined) =>
+		setPersisted(
+			range
+				? { from: range.from?.toISOString(), to: range.to?.toISOString() }
+				: undefined,
+		);
+
+	return [dateRange, setDateRange] as const;
+}

--- a/apps/crm/apps/web/src/hooks/usePersistedState.ts
+++ b/apps/crm/apps/web/src/hooks/usePersistedState.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+export function usePersistedState<T>(key: string, defaultValue: T) {
+	const [state, setState] = useState<T>(() => {
+		try {
+			const saved = sessionStorage.getItem(key);
+			return saved !== null ? (JSON.parse(saved) as T) : defaultValue;
+		} catch {
+			return defaultValue;
+		}
+	});
+
+	useEffect(() => {
+		try {
+			if (state === undefined || state === null) {
+				sessionStorage.removeItem(key);
+			} else {
+				sessionStorage.setItem(key, JSON.stringify(state));
+			}
+		} catch {
+			// sessionStorage puede no estar disponible en algunos contextos
+		}
+	}, [key, state]);
+
+	return [state, setState] as const;
+}

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -304,6 +304,7 @@ function RouteComponent() {
 	const [debouncedSifcoFilterValue, setDebouncedSifcoFilterValue] = useState(sifcoFilterValue);
 	const [pageSize, setPageSize] = usePersistedState<number>("cobros/pageSize", 25);
 	const [dateRange, setDateRange] = usePersistedDateRange("cobros/dateRange");
+	const [pickerRange, setPickerRange] = useState<DateRange | undefined>(dateRange);
 	const fechaDesde = dateRange?.from && dateRange?.to ? dateRange.from.toISOString().slice(0, 10) : undefined;
 	const fechaHasta = dateRange?.from && dateRange?.to ? dateRange.to.toISOString().slice(0, 10) : undefined;
 	const [fechaError, setFechaError] = useState<string | null>(null);
@@ -1080,10 +1081,11 @@ function RouteComponent() {
 										})}
 										<Separator orientation="vertical" className="mx-1 h-6" />
 										<DateRangeFilter
-											dateRange={dateRange}
+											dateRange={pickerRange}
 											onDateRangeChange={(range) => {
 												if (!range) {
 													setDateRange(undefined);
+													setPickerRange(undefined);
 													setFechaError(null);
 													setPage(1);
 													return;
@@ -1094,11 +1096,12 @@ function RouteComponent() {
 													setFechaError(
 														"La fecha no puede ser menor al día de hoy",
 													);
-													setDateRange(range);
+													setPickerRange(range); // muestra selección en UI sin afectar la query
 													return;
 												}
 												setFechaError(null);
-												setDateRange(range);
+												setDateRange(range);    // persiste y afecta la query
+												setPickerRange(range);  // actualiza display
 												if (!range.from || !range.to) return;
 												setFiltroTemporal("todos");
 												setPage(1);

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -15,6 +15,8 @@ import {
 	TrendingUp,
 	Users,
 } from "lucide-react";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { useEffect, useMemo, useState } from "react";
 import type { DateRange } from "react-day-picker";
 import { MassWhatsappModal } from "@/components/cobros/mass-whatsapp-modal";
@@ -290,23 +292,23 @@ const ETIQUETA_LABELS_FILTRO: Record<string, string> = {
 function RouteComponent() {
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
-	const [filtroTemporal, setFiltroTemporal] = useState<FiltroTemporal>("hoy");
+	const [filtroTemporal, setFiltroTemporal] = usePersistedState<FiltroTemporal>("cobros/filtroTemporal", "hoy");
 	const [mostrarCompletadosIncobrables, setMostrarCompletadosIncobrables] =
 		useState(false);
-	const [filtroEtapa, setFiltroEtapa] = useState<string | null>(null);
-	const [filtroEtiquetas, setFiltroEtiquetas] = useState<string[]>([]);
-	const [page, setPage] = useState(1);
-	const [filterValue, setFilterValue] = useState("");
-	const [debouncedFilterValue, setDebouncedFilterValue] = useState("");
-	const [sifcoFilterValue, setSifcoFilterValue] = useState("");
-	const [debouncedSifcoFilterValue, setDebouncedSifcoFilterValue] = useState("");
-	const [pageSize, setPageSize] = useState(25);
-	const [fechaDesde, setFechaDesde] = useState<string | undefined>(undefined);
-	const [fechaHasta, setFechaHasta] = useState<string | undefined>(undefined);
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
+	const [filtroEtapa, setFiltroEtapa] = usePersistedState<string | null>("cobros/filtroEtapa", null);
+	const [filtroEtiquetas, setFiltroEtiquetas] = usePersistedState<string[]>("cobros/filtroEtiquetas", []);
+	const [page, setPage] = usePersistedState<number>("cobros/page", 1);
+	const [filterValue, setFilterValue] = usePersistedState<string>("cobros/filterValue", "");
+	const [debouncedFilterValue, setDebouncedFilterValue] = useState(filterValue);
+	const [sifcoFilterValue, setSifcoFilterValue] = usePersistedState<string>("cobros/sifcoFilterValue", "");
+	const [debouncedSifcoFilterValue, setDebouncedSifcoFilterValue] = useState(sifcoFilterValue);
+	const [pageSize, setPageSize] = usePersistedState<number>("cobros/pageSize", 25);
+	const [dateRange, setDateRange] = usePersistedDateRange("cobros/dateRange");
+	const fechaDesde = dateRange?.from && dateRange?.to ? dateRange.from.toISOString().slice(0, 10) : undefined;
+	const fechaHasta = dateRange?.from && dateRange?.to ? dateRange.to.toISOString().slice(0, 10) : undefined;
 	const [fechaError, setFechaError] = useState<string | null>(null);
-	const [capitalMin, setCapitalMin] = useState<number | undefined>(undefined);
-	const [capitalMax, setCapitalMax] = useState<number | undefined>(undefined);
+	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>("cobros/capitalMin", undefined);
+	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>("cobros/capitalMax", undefined);
 
 	// Debounce para el filtro de búsqueda (1 segundos)
 	useEffect(() => {
@@ -1080,14 +1082,25 @@ function RouteComponent() {
 										<DateRangeFilter
 											dateRange={dateRange}
 											onDateRangeChange={(range) => {
-												const filtro = getPaymentDateRangeFilter(range);
-												setDateRange(filtro.dateRange);
-												setFechaDesde(filtro.fechaDesde);
-												setFechaHasta(filtro.fechaHasta);
-												setFechaError(filtro.fechaError);
-												if (filtro.fechaDesde && filtro.fechaHasta) {
-													setFiltroTemporal("todos");
+												if (!range) {
+													setDateRange(undefined);
+													setFechaError(null);
+													setPage(1);
+													return;
 												}
+												const hoy = new Date();
+												hoy.setHours(0, 0, 0, 0);
+												if (range.from && range.from < hoy) {
+													setFechaError(
+														"La fecha no puede ser menor al día de hoy",
+													);
+													setDateRange(range);
+													return;
+												}
+												setFechaError(null);
+												setDateRange(range);
+												if (!range.from || !range.to) return;
+												setFiltroTemporal("todos");
 												setPage(1);
 											}}
 										/>

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -70,6 +70,8 @@ import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { formatGuatemalaDate } from "@/lib/crm-formatters";
 import { PERMISSIONS } from "@/lib/roles";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/crm/clients")({
@@ -227,10 +229,10 @@ function RouteComponent() {
 	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const search = Route.useSearch();
-	const [searchTerm, setSearchTerm] = useState("");
-	const [debouncedSearch, setDebouncedSearch] = useState("");
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
-	const [page, setPage] = useState(0);
+	const [searchTerm, setSearchTerm] = usePersistedState<string>("crm/clients/searchTerm", "");
+	const [debouncedSearch, setDebouncedSearch] = useState(searchTerm);
+	const [dateRange, setDateRange] = usePersistedDateRange("crm/clients/dateRange");
+	const [page, setPage] = usePersistedState<number>("crm/clients/page", 0);
 	const pageSize = 20;
 
 	const queryClient = useQueryClient();

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -72,6 +72,8 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { Textarea } from "@/components/ui/textarea";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import {
@@ -134,12 +136,12 @@ function RouteComponent() {
 	const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false);
 	const [selectedLead, setSelectedLead] = useState<Lead | null>(null);
 	const [editingLead, setEditingLead] = useState<Lead | null>(null);
-	const [searchTerm, setSearchTerm] = useState("");
-	const [debouncedSearch, setDebouncedSearch] = useState("");
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
-	const [statusFilter, setStatusFilter] = useState<string>("all");
-	const [sourceFilter, setSourceFilter] = useState<string>("all");
-	const [page, setPage] = useState(0);
+	const [searchTerm, setSearchTerm] = usePersistedState("crm/leads/searchTerm", "");
+	const [debouncedSearch, setDebouncedSearch] = useState(searchTerm);
+	const [dateRange, setDateRange] = usePersistedDateRange("crm/leads/dateRange");
+	const [statusFilter, setStatusFilter] = usePersistedState<string>("crm/leads/statusFilter", "all");
+	const [sourceFilter, setSourceFilter] = usePersistedState<string>("crm/leads/sourceFilter", "all");
+	const [page, setPage] = usePersistedState<number>("crm/leads/page", 0);
 	const [isEditingCreditAnalysis, setIsEditingCreditAnalysis] = useState(false);
 	const [isConvertDialogOpen, setIsConvertDialogOpen] = useState(false);
 	const [leadToConvert, setLeadToConvert] = useState<Lead | null>(null);

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -104,6 +104,7 @@ import {
 	renderNewVehicleBadges,
 } from "@/lib/vehicle-utils";
 import { isVehicleAvailable } from "@/utils/constants";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc } from "@/utils/orpc";
 
 function formatLeadFullName(lead: {
@@ -393,7 +394,7 @@ function RouteComponent() {
 	const [selectedOpportunity, setSelectedOpportunity] =
 		useState<Opportunity | null>(null);
 	const [selectedStage, setSelectedStage] = useState<string>("");
-	const [stageFilter, setStageFilter] = useState<string>("all");
+	const [stageFilter, setStageFilter] = usePersistedState<string>("crm/opportunities/stageFilter", "all");
 	const [opportunityHistory, setOpportunityHistory] = useState<any[]>([]);
 	const [isLoadingHistory, setIsLoadingHistory] = useState(false);
 	const [stageChangeReason, setStageChangeReason] = useState<string>("");
@@ -401,10 +402,10 @@ function RouteComponent() {
 	const [debouncedLeadsSearch, setDebouncedLeadsSearch] = useState("");
 	const [vehiclesSearch, setVehiclesSearch] = useState("");
 	const [debouncedVehiclesSearch, setDebouncedVehiclesSearch] = useState("");
-	const [showLostOpportunities, setShowLostOpportunities] = useState(false);
-	const [boardSearch, setBoardSearch] = useState("");
-	const [salespersonFilter, setSalespersonFilter] = useState<string>("all");
-	const [sourceFilter, setSourceFilter] = useState<string>("all");
+	const [showLostOpportunities, setShowLostOpportunities] = usePersistedState<boolean>("crm/opportunities/showLostOpportunities", false);
+	const [boardSearch, setBoardSearch] = usePersistedState<string>("crm/opportunities/boardSearch", "");
+	const [salespersonFilter, setSalespersonFilter] = usePersistedState<string>("crm/opportunities/salespersonFilter", "all");
+	const [sourceFilter, setSourceFilter] = usePersistedState<string>("crm/opportunities/sourceFilter", "all");
 	const debouncedBoardSearch = useDeferredValue(boardSearch);
 	// View toggle: "kanban" or "table" - persist in localStorage
 	const [viewMode, setViewMode] = useState<"kanban" | "table">(() => {
@@ -415,7 +416,7 @@ function RouteComponent() {
 		return "kanban";
 	});
 	// Filtro por etapa (stage ID) para vista tabla
-	const [stageIdFilter, setStageIdFilter] = useState<string>("all");
+	const [stageIdFilter, setStageIdFilter] = usePersistedState<string>("crm/opportunities/stageIdFilter", "all");
 	const processedCompanyIdRef = useRef<string | null>(null);
 	const processedOpportunityIdRef = useRef<string | null>(null);
 	const prevOpenRef = useRef(isCreateDialogOpen);
@@ -432,8 +433,8 @@ function RouteComponent() {
 	});
 
 	// Month/year filter for placed amounts alignment with dashboard
-	const [month, setMonth] = useState(() => new Date().getMonth() + 1);
-	const [year, setYear] = useState(() => new Date().getFullYear());
+	const [month, setMonth] = usePersistedState<number>("crm/opportunities/month", new Date().getMonth() + 1);
+	const [year, setYear] = usePersistedState<number>("crm/opportunities/year", new Date().getFullYear());
 
 	const goToPreviousMonth = () => {
 		if (month === 1) {


### PR DESCRIPTION
Hooks creados
apps/web/src/hooks/usePersistedState.ts — hook genérico de estado persistido
apps/web/src/hooks/usePersistedDateRange.ts — hook especializado para rangos de fecha

Se crearon dos hooks reutilizables que actúan como reemplazos drop-in de useState, con persistencia automática en sessionStorage. sessionStorage persiste mientras dura la sesión del navegador (tab abierta) y se limpia automáticamente al cerrarla.

usePersistedState
- Reemplaza directamente a useState. Lee el valor de sessionStorage al montar el componente y lo escribe cada vez que cambia. El estado sobrevive la navegación dentro de la misma sesión del navegador.

usePersistedDateRange
- Especialización de usePersistedState para el tipo DateRange de react-day-picker. Encapsula la serialización/deserialización de objetos Date a strings ISO y viceversa, evitando que esta lógica se repita en cada componente que use un filtro de fecha.

Filtros persistidos: searchTerm, dateRange, statusFilter, sourceFilter, page

src/routes/cobros/index.tsx
- Filtros persistidos: filtroTemporal, filtroEtapa, filtroEtiquetas, filterValue, sifcoFilterValue, pageSize, capitalMin, capitalMax, dateRange, page
- Adicionalmente: fechaDesde y fechaHasta dejaron de ser estado independiente y ahora se derivan directamente de dateRange, eliminando la necesidad de mantenerlos sincronizados manualmente.

src/routes/crm/opportunities.tsx
- Filtros persistidos: stageFilter, showLostOpportunities, boardSearch, salespersonFilter, sourceFilter, stageIdFilter, month, year

src/routes/crm/clients.tsx
- Filtros persistidos: searchTerm, dateRange, page