### PR TITLE
fix(cartera): Import extra investor accounts schema

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -26,6 +26,7 @@ import {
   liquidacion_locks,
   documentos_inversionista,
   abonos_capital,
+  cuentas_extra_inversionista,
 } from "../database/db/schema";
 import { getSignedDocumentUrl } from "../utils/functions/uploadsFiles";
 import { eq, and, or, sql, inArray, ilike, like, desc, count, SQL, isNull, isNotNull, ne } from "drizzle-orm";

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1841,7 +1841,7 @@ export async function obtenerCreditosConPagosPendientes(
       .where(
         and(
           eq(creditos_inversionistas_espejo.inversionista_id, inversionistaId),
-          inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "PENDIENTE_CANCELACION", "EN_CONVENIO"]),
+          inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "PENDIENTE_CANCELACION", "EN_CONVENIO","INCOBRABLE"]),
           eq(creditos_inversionistas_espejo.status, "completado"),
           lt(creditos_inversionistas_espejo.fecha_inicio_participacion, rangoMesActual.inicio)
         )


### PR DESCRIPTION
Makes the 'cuentas_extra_inversionista' schema available in the investor controller to support upcoming fixes for the liquidation process.
