### PR TITLE
fix(auth-google): Adapt Dockerfile for Coolify persistent volumes

### DIFF
--- a/apps/auth-google/Dockerfile
+++ b/apps/auth-google/Dockerfile
@@ -1,50 +1,24 @@
-FROM docker.io/oven/bun:1 AS base
-WORKDIR /usr/src/app
+FROM docker.io/oven/bun:1
+WORKDIR /app
 
-# =========================
-# Etapa: install
-# Solo re-corre cuando cambian package.json, bun.lockb o packages/email
-# =========================
-FROM base AS install
+# Copiar manifest del root (declara los workspaces)
+COPY package.json ./
 
-# 1. Archivos de configuración (más estables → van primero para maximizar cache)
-COPY package.json bun.lockb* ./
-COPY packages/email/package.json ./packages/email/package.json
-COPY apps/auth-google/package.json ./apps/auth-google/package.json
-
-# 2. Instalar deps del workspace (cacheado mientras no cambie lockb/package.json)
-RUN bun install
-
-# 3. Source de @cci/email (cambia menos frecuente que el app)
+# Copiar packages/email completo (es workspace dep de auth-google)
 COPY packages/email ./packages/email
 
-# 4. Hacer @cci/email físico con sus dependencias
-WORKDIR /usr/src/app/apps/auth-google
-RUN rm -rf node_modules/@cci/email && \
-    mkdir -p node_modules/@cci && \
-    cp -r /usr/src/app/packages/email node_modules/@cci/email
-
-WORKDIR /usr/src/app/apps/auth-google/node_modules/@cci/email
-RUN bun install --production
-
-# =========================
-# Etapa: runner
-# Re-corre cuando cambia el source del app — sin installs, rápido
-# =========================
-FROM base AS runner
-WORKDIR /usr/src/app
-
-# Node_modules del stage de install (vienen cacheados del stage anterior)
-COPY --from=install /usr/src/app/node_modules ./node_modules
-COPY --from=install /usr/src/app/apps/auth-google/node_modules ./apps/auth-google/node_modules
-
-# Solo el source del app (node_modules excluido por .dockerignore → no sobreescribe lo de arriba)
+# Copiar app source
 COPY apps/auth-google ./apps/auth-google
 
-WORKDIR /usr/src/app/apps/auth-google
+# Install en build (camino feliz: si no hay volumen montado, ya queda listo).
+RUN bun install --filter=auth-google --linker=hoisted --production
 
-USER bun
+WORKDIR /app/apps/auth-google
 
 EXPOSE 9500
 
-CMD ["bun", "start"]
+# En runtime: si Coolify monta un volumen persistente sobre node_modules con datos
+# fosilizados (symlinks colgantes de un build viejo), reinstalamos. La detección
+# `! [ -e node_modules/hono/package.json ]` falla cuando el symlink existe pero
+# su target no, así que cubre el caso del volumen stale.
+CMD ["sh", "-c", "if ! [ -e node_modules/hono/package.json ]; then echo '>> volumen stale detectado, limpiando y reinstalando deps' && rm -rf /app/node_modules /app/apps/auth-google/node_modules /app/packages/email/node_modules && cd /app && bun install --filter=auth-google --linker=hoisted --production; fi && cd /app/apps/auth-google && exec bun run src/index.ts"]


### PR DESCRIPTION
Simplify the Dockerfile to a single build stage. Implement a runtime check
in the CMD to detect and reinstall dependencies if a persistent volume
from Coolify contains stale `node_modules` (e.g., broken symlinks from
an older build). This prevents startup errors in environments that mount
volumes over `node_modules`.
