### PR TITLE
feat: implement automated email notifications for investor session ca…

### DIFF
--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -5,8 +5,15 @@ import {
   creditos,
   creditos_inversionistas,
   creditos_inversionistas_espejo,
+  inversionistas,
+  usuarios,
 } from "../database/db";
 import z from "zod";
+import jwt from "jsonwebtoken";
+import { sendSessionCancelledNotification } from "@cci/email";
+import { INVESTOR_STATUS_CHANGE_RECIPIENTS } from "../utils/functions/investorStatusRecipients";
+
+const JWT_SECRET = process.env.JWT_SECRET || "6b7a1d9e4f27b4c8d91e5f03a7aa9378db7e2b5c8f3c83de7a9e5f16f5b2a6df";
 
 // ========================================
 // ID fijo de CUBE INVESTMENTS S.A.
@@ -157,8 +164,26 @@ function recalcularInversionistas(
 //    e. Nuke & rebuild en padre y espejo (todos "completado")
 // ========================================
 
-export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
+export const returnPendingInvestorsToCube = async ({ body, set, request }: any) => {
   try {
+    // ================================================================
+    // PASO 0: IDENTIFICACIÓN DEL USUARIO (JWT)
+    // ================================================================
+    const authHeader = request.headers.get("authorization");
+    const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+    let adminName = "Sistema";
+    let adminEmail = "";
+
+    if (token) {
+      try {
+        const decoded = jwt.verify(token, JWT_SECRET) as any;
+        adminName = decoded.nombre || decoded.email || "Administrador";
+        adminEmail = decoded.email || "";
+      } catch (err) {
+        console.warn("[returnPendingInvestorsToCube] Token inválido o expirado");
+      }
+    }
+
     // ================================================================
     // PASO 1: VALIDAR SCHEMA
     // Acepta un solo credito_id o un arreglo de credito_ids.
@@ -219,9 +244,7 @@ export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
     }
 
     // ================================================================
-    // PASO 3: AGRUPAR POR CRÉDITO
-    // Por cada crédito: qué inversionistas hay que sacar y cuánto
-    // monto total se devuelve a CUBE.
+    // PASO 3: AGRUPAR POR CRÉDITO Y RECOPILAR DATA PARA CORREO
     // ================================================================
     const porCredito = new Map<
       number,
@@ -243,6 +266,25 @@ export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
       entry.inversionistas_a_sacar.add(p.inversionista_id);
     }
 
+    // ── Data adicional para el reporte (Inversionistas y Clientes) ──
+    const uniqueInvestorIds = Array.from(new Set(pendientes.map(p => p.inversionista_id)));
+    const invData = await db
+      .select({ id: inversionistas.inversionista_id, nombre: inversionistas.nombre })
+      .from(inversionistas)
+      .where(inArray(inversionistas.inversionista_id, uniqueInvestorIds));
+    const investorMap = new Map(invData.map(i => [i.id, i.nombre]));
+
+    const creditDetails = await db
+      .select({
+        id: creditos.credito_id,
+        sifco: creditos.numero_credito_sifco,
+        cliente: usuarios.nombre
+      })
+      .from(creditos)
+      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+      .where(inArray(creditos.credito_id, Array.from(porCredito.keys())));
+    const creditMap = new Map(creditDetails.map(c => [c.id, c]));
+
     console.log(
       `🧹 ${porCredito.size} crédito(s) a limpiar`,
     );
@@ -250,10 +292,7 @@ export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
     const resultados: any[] = [];
 
     // ================================================================
-    // PASO 4: LIMPIAR CADA CRÉDITO
-    // - Sacar a los inversionistas pendientes
-    // - Devolver el monto total a CUBE (crear CUBE si no existía)
-    // - Recalcular cuotas y nuke & rebuild en padre y espejo
+    // PASO 4: TRANSACCIÓN DE LIMPIEZA
     // ================================================================
     await db.transaction(async (tx) => {
       for (const [creditoId, info] of porCredito) {
@@ -372,7 +411,6 @@ export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
         }
 
         // ── Apagar bandera_reinversion del crédito ──
-        // Ya no hay pendientes: el espejo quedó todo en "completado".
         await tx
           .update(creditos)
           .set({ bandera_reinversion: false })
@@ -393,7 +431,33 @@ export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
     });
 
     // ================================================================
-    // PASO 5: RESPUESTA
+    // PASO 5: NOTIFICACIÓN POR CORREO
+    // ================================================================
+    try {
+      const affectedInvestorNames = Array.from(new Set(pendientes.map(p => investorMap.get(p.inversionista_id)))).join(", ");
+      
+      const emailCredits = Array.from(porCredito.entries()).map(([creditoId, info]) => {
+        const details = creditMap.get(creditoId);
+        return {
+          sifco: details?.sifco || "N/A",
+          cliente: details?.cliente || "Desconocido",
+          monto: info.monto_total_a_cube.toFixed(2)
+        };
+      });
+
+      await sendSessionCancelledNotification({
+        to: INVESTOR_STATUS_CHANGE_RECIPIENTS,
+        affectedInvestorNames,
+        adminName,
+        adminEmail,
+        credits: emailCredits
+      });
+    } catch (mailErr) {
+      console.error("[returnPendingInvestorsToCube] Falló envío de correo:", mailErr);
+    }
+
+    // ================================================================
+    // PASO 6: RESPUESTA
     // ================================================================
     set.status = 200;
     return {

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -740,21 +740,127 @@ export const sendCompraCarteraExpiradaNotification = async ({
   }
 };
 
+export interface SendSessionCancelledNotificationParams {
+  to: string[];
+  affectedInvestorNames: string;
+  adminName: string;
+  adminEmail?: string;
+  credits: Array<{
+    sifco: string;
+    cliente: string;
+    monto: string;
+  }>;
+  currencySymbol?: string;
+}
+
+export const sendSessionCancelledNotification = async ({
+  to,
+  affectedInvestorNames,
+  adminName,
+  adminEmail,
+  credits,
+  currencySymbol = "Q",
+}: SendSessionCancelledNotificationParams) => {
+  try {
+    const validEmails = to.filter((email) => {
+      try {
+        emailSchema.parse(email);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
+    if (validEmails.length === 0) {
+      console.warn("[sendSessionCancelledNotification] No valid emails found");
+      return { success: false, error: "No valid emails" };
+    }
+
+    const nowGT = new Date().toLocaleString("es-GT", {
+      timeZone: "America/Guatemala",
+    });
+
+    const rowsHtml = credits
+      .map(
+        (c) => `
+      <tr>
+        <td style="padding:10px;border:1px solid #e5e7eb;">${c.sifco}</td>
+        <td style="padding:10px;border:1px solid #e5e7eb;">${c.cliente}</td>
+        <td style="padding:10px;border:1px solid #e5e7eb;text-align:right;">${currencySymbol}${c.monto}</td>
+      </tr>
+    `,
+      )
+      .join("");
+
+    const html = `
+      <div style="font-family:Arial,sans-serif;color:#111827;max-width:640px;margin:0 auto;">
+        <h2 style="color:#111827;margin-bottom:16px;">Sesión <span style="color:#dc2626;">CANCELADA</span> (Devuelta a Cube)</h2>
+        <p style="color:#374151;line-height:1.5;">Los siguientes créditos tenían inversionistas pendientes que han sido <strong>removidos</strong> y su participación devuelta a Cube Investments S.A.</p>
+        
+        <table style="width:100%;margin-bottom:24px;font-size:14px;">
+          <tr>
+            <td style="padding:4px 0;width:180px;"><strong>Inversionista(s) afectados:</strong></td>
+            <td style="padding:4px 0;">${affectedInvestorNames}</td>
+          </tr>
+          <tr>
+            <td style="padding:4px 0;"><strong>Créditos afectados:</strong></td>
+            <td style="padding:4px 0;">${credits.length}</td>
+          </tr>
+          <tr>
+            <td style="padding:4px 0;"><strong>Fecha (GT):</strong></td>
+            <td style="padding:4px 0;">${nowGT}</td>
+          </tr>
+          <tr>
+            <td style="padding:4px 0;"><strong>Cancelada por:</strong></td>
+            <td style="padding:4px 0;">${adminName}${adminEmail ? ` &lt;${adminEmail}&gt;` : ""}</td>
+          </tr>
+        </table>
+
+        <h3 style="margin-bottom:12px;font-size:16px;">Detalle de montos devueltos a Cube</h3>
+        <table style="width:100%;border-collapse:collapse;font-size:13px;">
+          <thead>
+            <tr style="background:#f9fafb;">
+              <th style="padding:10px;border:1px solid #e5e7eb;text-align:left;">SIFCO</th>
+              <th style="padding:10px;border:1px solid #e5e7eb;text-align:left;">Cliente</th>
+              <th style="padding:10px;border:1px solid #e5e7eb;text-align:right;">Monto a Cube</th>
+            </tr>
+          </thead>
+          <tbody>
+            ${rowsHtml}
+          </tbody>
+        </table>
+
+        <p style="margin-top:24px;color:#6b7280;font-size:11px;border-top:1px solid #eee;padding-top:12px;">
+          Correo automático — Club Cash In / Cartera.
+        </p>
+      </div>
+    `;
+
+    const subject = `Sesión CANCELADA — ${affectedInvestorNames}`;
+
+    return await sendPlainEmail(validEmails, subject, html);
+  } catch (err) {
+    console.error("[sendSessionCancelledNotification] Unexpected Error:", err);
+    return { success: false, error: err };
+  }
+};
+
 /**
  * Envía un correo con HTML arbitrario (sin envolver en <strong>).
  * Útil para mensajes editados por el usuario, donde el caller arma el HTML.
  */
 export const sendPlainEmail = async (
-  to: string,
+  to: string | string[],
   subject: string,
   html: string,
 ) => {
-  emailSchema.parse(to);
+  const recipients = Array.isArray(to) ? to : [to];
+  recipients.forEach(email => emailSchema.parse(email));
 
   try {
     const { data, error } = await resend.emails.send({
       from: `Club Cash In <no-reply@${domain}>`,
-      to: [to],
+      to: recipients,
       subject,
       html,
     });
@@ -764,7 +870,7 @@ export const sendPlainEmail = async (
       return { success: false, error };
     }
 
-    console.log(`[sendPlainEmail] Email sent to ${to}. ID: ${data?.id}`);
+    console.log(`[sendPlainEmail] Email sent to ${recipients.length} recipients. ID: ${data?.id}`);
     return { success: true, data };
   } catch (err) {
     console.error("[sendPlainEmail] Unexpected Error:", err);


### PR DESCRIPTION
# Descripcion de los cambios

Se ha implementado el sistema de notificaciones por correo electrónico para la cancelación de sesiones (Devolución a Cube) en el módulo de Sesiones Pendientes.

## Cambios principales

### 1. Paquete de correos (@cci/email)
- Se actualizó la función sendPlainEmail para dar soporte a múltiples destinatarios en un solo envío, optimizando el uso de la API de Resend y evitando límites de velocidad (Rate Limits).
- Se creó la función centralizada sendSessionCancelledNotification para manejar el diseño y la estructura del correo de cancelación desde el paquete de utilidades, mejorando la mantenibilidad del código.

### 2. Backend (cartera-back)
- Se modificó el controlador replaceInvestorCredit.ts para integrar la lógica de notificaciones tras una limpieza exitosa de inversionistas pendientes.
- Se implementó la extracción de datos del administrador (nombre y correo) a través del token JWT para identificar quién realizó la acción en el cuerpo del correo.
- Se añadió la recolección dinámica de nombres de clientes y números SIFCO para generar el reporte detallado de los créditos afectados.

## Ajustes de diseño en el correo
- Se eliminó la columna "Crédito ID" de la tabla resumen de créditos según lo solicitado, manteniendo únicamente las columnas de SIFCO, Cliente y Monto devuelto a Cube.
- El asunto del correo ahora incluye los nombres de los inversionistas cuya sesión fue cancelada para facilitar su identificación rápida.

## Archivos modificados
- packages/email/src/index.ts
- apps/cartera-back/src/controllers/replaceInvestorCredit.ts
