### PR TITLE
Feat: mplement persisted state for filters and search terms in CRM routes

### DIFF
--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -14,6 +14,7 @@ import {
 	TrendingDown,
 	TrendingUp,
 	Users,
+	X,
 } from "lucide-react";
 import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import { usePersistedState } from "@/hooks/usePersistedState";
@@ -310,6 +311,29 @@ function RouteComponent() {
 	const [fechaError, setFechaError] = useState<string | null>(null);
 	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>("cobros/capitalMin", undefined);
 	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>("cobros/capitalMax", undefined);
+
+	const hasActiveFilters =
+		filtroTemporal !== "hoy" ||
+		filtroEtapa !== null ||
+		filtroEtiquetas.length > 0 ||
+		filterValue !== "" ||
+		sifcoFilterValue !== "" ||
+		capitalMin !== undefined ||
+		capitalMax !== undefined ||
+		dateRange !== undefined;
+	const resetFilters = () => {
+		setFiltroTemporal("hoy");
+		setFiltroEtapa(null);
+		setFiltroEtiquetas([]);
+		setFilterValue("");
+		setSifcoFilterValue("");
+		setCapitalMin(undefined);
+		setCapitalMax(undefined);
+		setDateRange(undefined);
+		setPickerRange(undefined);
+		setFechaError(null);
+		setPage(1);
+	};
 
 	// Debounce para el filtro de búsqueda (1 segundos)
 	useEffect(() => {
@@ -1202,6 +1226,17 @@ function RouteComponent() {
 										}}
 									/>
 								</div>
+								{hasActiveFilters && (
+									<div className="border-t pt-2">
+										<Button variant="ghost" size="sm" onClick={resetFilters} className="w-full text-muted-foreground">
+											<X className="mr-1 h-3 w-3" />
+											Limpiar filtros
+											<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+												{[filtroTemporal !== "hoy", filtroEtapa !== null, filtroEtiquetas.length > 0, filterValue !== "", sifcoFilterValue !== "", capitalMin !== undefined, capitalMax !== undefined, dateRange !== undefined].filter(Boolean).length}
+											</Badge>
+										</Button>
+									</div>
+								)}
 							</div>
 						}
 						tableContainerClass="max-h-[600px] overflow-y-auto"

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -235,6 +235,14 @@ function RouteComponent() {
 	const [page, setPage] = usePersistedState<number>("crm/clients/page", 0);
 	const pageSize = 20;
 
+	const hasActiveFilters = searchTerm !== "" || dateRange !== undefined;
+	const resetFilters = () => {
+		setSearchTerm("");
+		setDebouncedSearch("");
+		setDateRange(undefined);
+		setPage(0);
+	};
+
 	const queryClient = useQueryClient();
 
 	// Modal state
@@ -599,6 +607,15 @@ function RouteComponent() {
 								setPage(0);
 							}}
 						/>
+						{hasActiveFilters && (
+							<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+								<X className="mr-1 h-3 w-3" />
+								Limpiar filtros
+								<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+									{[searchTerm !== "", dateRange !== undefined].filter(Boolean).length}
+								</Badge>
+							</Button>
+						)}
 					</div>
 
 					{clientsQuery.isPending ? (

--- a/apps/crm/apps/web/src/routes/crm/companies.tsx
+++ b/apps/crm/apps/web/src/routes/crm/companies.tsx
@@ -14,6 +14,7 @@ import {
 	Search,
 	Target,
 	Users,
+	X,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -86,6 +87,13 @@ function RouteComponent() {
 	const [searchTerm, setSearchTerm] = usePersistedState<string>("crm/companies/searchTerm", "");
 	const [industryFilter, setIndustryFilter] = usePersistedState<string>("crm/companies/industryFilter", "all");
 	const [sizeFilter, setSizeFilter] = usePersistedState<string>("crm/companies/sizeFilter", "all");
+
+	const hasActiveFilters = searchTerm !== "" || industryFilter !== "all" || sizeFilter !== "all";
+	const resetFilters = () => {
+		setSearchTerm("");
+		setIndustryFilter("all");
+		setSizeFilter("all");
+	};
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const companiesQuery = useQuery({
@@ -738,7 +746,7 @@ function RouteComponent() {
 				</CardHeader>
 				<CardContent>
 					{/* Filters */}
-					<div className="mb-6 flex gap-4">
+					<div className="mb-6 flex items-center gap-4">
 						<div className="flex-1">
 							<div className="relative">
 								<Search className="absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
@@ -781,6 +789,15 @@ function RouteComponent() {
 								<SelectItem value="enterprise">Corporativa</SelectItem>
 							</SelectContent>
 						</Select>
+						{hasActiveFilters && (
+							<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+								<X className="mr-1 h-3 w-3" />
+								Limpiar filtros
+								<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+									{[searchTerm !== "", industryFilter !== "all", sizeFilter !== "all"].filter(Boolean).length}
+								</Badge>
+							</Button>
+						)}
 					</div>
 
 					{companiesQuery.isPending ? (

--- a/apps/crm/apps/web/src/routes/crm/companies.tsx
+++ b/apps/crm/apps/web/src/routes/crm/companies.tsx
@@ -64,6 +64,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { PERMISSIONS } from "@/lib/roles";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/crm/companies")({
@@ -82,9 +83,9 @@ function RouteComponent() {
 	const [isDetailsDialogOpen, setIsDetailsDialogOpen] = useState(false);
 	const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 	const [selectedCompany, setSelectedCompany] = useState<any>(null);
-	const [searchTerm, setSearchTerm] = useState("");
-	const [industryFilter, setIndustryFilter] = useState<string>("all");
-	const [sizeFilter, setSizeFilter] = useState<string>("all");
+	const [searchTerm, setSearchTerm] = usePersistedState<string>("crm/companies/searchTerm", "");
+	const [industryFilter, setIndustryFilter] = usePersistedState<string>("crm/companies/industryFilter", "all");
+	const [sizeFilter, setSizeFilter] = usePersistedState<string>("crm/companies/sizeFilter", "all");
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const companiesQuery = useQuery({

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -142,6 +142,17 @@ function RouteComponent() {
 	const [statusFilter, setStatusFilter] = usePersistedState<string>("crm/leads/statusFilter", "all");
 	const [sourceFilter, setSourceFilter] = usePersistedState<string>("crm/leads/sourceFilter", "all");
 	const [page, setPage] = usePersistedState<number>("crm/leads/page", 0);
+
+	const hasActiveFilters = searchTerm !== "" || dateRange !== undefined || statusFilter !== "all" || sourceFilter !== "all";
+	const resetFilters = () => {
+		setSearchTerm("");
+		setDebouncedSearch("");
+		setDateRange(undefined);
+		setStatusFilter("all");
+		setSourceFilter("all");
+		setPage(0);
+	};
+
 	const [isEditingCreditAnalysis, setIsEditingCreditAnalysis] = useState(false);
 	const [isConvertDialogOpen, setIsConvertDialogOpen] = useState(false);
 	const [leadToConvert, setLeadToConvert] = useState<Lead | null>(null);
@@ -2021,6 +2032,15 @@ function RouteComponent() {
 								))}
 							</SelectContent>
 						</Select>
+						{hasActiveFilters && (
+							<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+								<X className="mr-1 h-3 w-3" />
+								Limpiar filtros
+								<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+									{[searchTerm !== "", dateRange !== undefined, statusFilter !== "all", sourceFilter !== "all"].filter(Boolean).length}
+								</Badge>
+							</Button>
+						)}
 					</div>
 
 					{leadsQuery.isPending ? (

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -36,6 +36,7 @@ import {
 	Trophy,
 	Upload,
 	Users,
+	X,
 	XCircle,
 } from "lucide-react";
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
@@ -435,6 +436,22 @@ function RouteComponent() {
 	// Month/year filter for placed amounts alignment with dashboard
 	const [month, setMonth] = usePersistedState<number>("crm/opportunities/month", new Date().getMonth() + 1);
 	const [year, setYear] = usePersistedState<number>("crm/opportunities/year", new Date().getFullYear());
+
+	const hasActiveFilters =
+		stageFilter !== "all" ||
+		showLostOpportunities ||
+		boardSearch !== "" ||
+		salespersonFilter !== "all" ||
+		sourceFilter !== "all" ||
+		stageIdFilter !== "all";
+	const resetFilters = () => {
+		setStageFilter("all");
+		setShowLostOpportunities(false);
+		setBoardSearch("");
+		setSalespersonFilter("all");
+		setSourceFilter("all");
+		setStageIdFilter("all");
+	};
 
 	const goToPreviousMonth = () => {
 		if (month === 1) {
@@ -1730,6 +1747,15 @@ function RouteComponent() {
 						/>
 						{showLostOpportunities ? "Ocultando perdidas" : "Mostrar perdidas"}
 					</Button>
+					{hasActiveFilters && (
+						<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+							<X className="mr-1 h-3 w-3" />
+							Limpiar filtros
+							<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+								{[stageFilter !== "all", showLostOpportunities, boardSearch !== "", salespersonFilter !== "all", sourceFilter !== "all", stageIdFilter !== "all"].filter(Boolean).length}
+							</Badge>
+						</Button>
+					)}
 				</div>
 			</div>
 

--- a/apps/crm/apps/web/src/routes/crm/vendors.tsx
+++ b/apps/crm/apps/web/src/routes/crm/vendors.tsx
@@ -58,6 +58,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/crm/vendors")({
@@ -82,8 +83,8 @@ const vendorSchema = z.object({
 type VendorFormData = z.infer<typeof vendorSchema>;
 
 function VendorsPage() {
-	const [searchTerm, setSearchTerm] = useState("");
-	const [vendorTypeFilter, setVendorTypeFilter] = useState("all");
+	const [searchTerm, setSearchTerm] = usePersistedState<string>("crm/vendors/searchTerm", "");
+	const [vendorTypeFilter, setVendorTypeFilter] = usePersistedState<string>("crm/vendors/vendorTypeFilter", "all");
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 	const [isEditOpen, setIsEditOpen] = useState(false);
 	const [selectedVendor, setSelectedVendor] = useState<any>(null);

--- a/apps/crm/apps/web/src/routes/crm/vendors.tsx
+++ b/apps/crm/apps/web/src/routes/crm/vendors.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { Building2, Edit, Plus, Search, Trash2, User } from "lucide-react";
+import { Building2, Edit, Plus, Search, Trash2, User, X } from "lucide-react";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -85,6 +85,12 @@ type VendorFormData = z.infer<typeof vendorSchema>;
 function VendorsPage() {
 	const [searchTerm, setSearchTerm] = usePersistedState<string>("crm/vendors/searchTerm", "");
 	const [vendorTypeFilter, setVendorTypeFilter] = usePersistedState<string>("crm/vendors/vendorTypeFilter", "all");
+
+	const hasActiveFilters = searchTerm !== "" || vendorTypeFilter !== "all";
+	const resetFilters = () => {
+		setSearchTerm("");
+		setVendorTypeFilter("all");
+	};
 	const [isCreateOpen, setIsCreateOpen] = useState(false);
 	const [isEditOpen, setIsEditOpen] = useState(false);
 	const [selectedVendor, setSelectedVendor] = useState<any>(null);
@@ -374,7 +380,7 @@ function VendorsPage() {
 			{/* Filters */}
 			<Card>
 				<CardContent className="pt-6">
-					<div className="flex gap-4">
+					<div className="flex items-center gap-4">
 						<div className="relative flex-1">
 							<Search className="absolute top-2.5 left-2.5 h-4 w-4 text-muted-foreground" />
 							<Input
@@ -397,6 +403,15 @@ function VendorsPage() {
 								<SelectItem value="empresa">Empresa</SelectItem>
 							</SelectContent>
 						</Select>
+						{hasActiveFilters && (
+							<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+								<X className="mr-1 h-3 w-3" />
+								Limpiar filtros
+								<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+									{[searchTerm !== "", vendorTypeFilter !== "all"].filter(Boolean).length}
+								</Badge>
+							</Button>
+						)}
 					</div>
 				</CardContent>
 			</Card>

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -39,6 +39,7 @@ import {
 import { authClient } from "@/lib/auth-client";
 import { getRoleLabel, ROLES } from "@/lib/roles";
 import { uploadFileToR2WithRetry } from "@/lib/upload-to-r2";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc, queryClient } from "@/utils/orpc";
 
 export const Route = createFileRoute("/notifications")({
@@ -171,7 +172,7 @@ const PAGE_SIZE = 20;
 const SUPERVISOR_ROLES = ["sales_supervisor", "analyst", "juridico"] as const;
 
 function usePagination(totalItems: number) {
-	const [page, setPage] = useState(1);
+	const [page, setPage] = usePersistedState<number>("notifications/page", 1);
 	const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
 	const safePage = Math.min(page, totalPages);
 
@@ -244,7 +245,7 @@ function NotificationsPage() {
 	const isAdmin = userRole === ROLES.ADMIN;
 	const isSalesSupervisor = userRole === ROLES.SALES_SUPERVISOR;
 
-	const [statusFilter, setStatusFilter] = useState<string>("all");
+	const [statusFilter, setStatusFilter] = usePersistedState<string>("notifications/statusFilter", "all");
 
 	// Admin: todas las notificaciones
 	const allNotifications = useQuery({

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -14,6 +14,7 @@ import {
 	Loader2,
 	Send,
 	Upload,
+	X,
 	XCircle,
 } from "lucide-react";
 import { useCallback, useMemo, useRef, useState } from "react";
@@ -246,6 +247,11 @@ function NotificationsPage() {
 	const isSalesSupervisor = userRole === ROLES.SALES_SUPERVISOR;
 
 	const [statusFilter, setStatusFilter] = usePersistedState<string>("notifications/statusFilter", "all");
+
+	const hasActiveFilters = statusFilter !== "all";
+	const resetFilters = () => {
+		setStatusFilter("all");
+	};
 
 	// Admin: todas las notificaciones
 	const allNotifications = useQuery({
@@ -562,6 +568,15 @@ function NotificationsPage() {
 						<SelectItem value="dismissed">Descartadas</SelectItem>
 					</SelectContent>
 				</Select>
+				{hasActiveFilters && (
+					<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+						<X className="mr-1 h-3 w-3" />
+						Limpiar filtros
+						<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+							{[statusFilter !== "all"].filter(Boolean).length}
+						</Badge>
+					</Button>
+				)}
 			</div>
 
 			{/* Sección: Mis notificaciones (o única sección para no-admins) */}

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -86,6 +86,7 @@ import {
 	renderInspectionStatusBadge,
 	renderNewVehicleBadges,
 } from "@/lib/vehicle-utils";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc } from "@/utils/orpc";
 
 // Helper para renderizar el badge del estado del vehículo
@@ -138,14 +139,14 @@ function VehiclesDashboard() {
 	const navigate = useNavigate();
 	const queryClient = useQueryClient();
 	const search = useSearch({ from: "/vehicles/" });
-	const [searchTerm, setSearchTerm] = useState("");
-	const [debouncedSearch, setDebouncedSearch] = useState("");
-	const [filterStatus, setFilterStatus] = useState("all");
-	const [filterOwnership, setFilterOwnership] = useState("all");
+	const [searchTerm, setSearchTerm] = usePersistedState<string>("vehicles/searchTerm", "");
+	const [debouncedSearch, setDebouncedSearch] = useState(searchTerm);
+	const [filterStatus, setFilterStatus] = usePersistedState<string>("vehicles/filterStatus", "all");
+	const [filterOwnership, setFilterOwnership] = usePersistedState<string>("vehicles/filterOwnership", "all");
 	const [selectedVehicle, setSelectedVehicle] = useState<any>(null);
 	const [isDetailsOpen, setIsDetailsOpen] = useState(false);
-	const [activeTab, setActiveTab] = useState("general");
-	const [page, setPage] = useState(0);
+	const [activeTab, setActiveTab] = usePersistedState<string>("vehicles/activeTab", "general");
+	const [page, setPage] = usePersistedState<number>("vehicles/page", 0);
 	const pageSize = 20;
 
 	// Refs to track processed URL params
@@ -318,7 +319,7 @@ function VehiclesDashboard() {
 	const [selectedEvidence, setSelectedEvidence] = useState<any[]>([]);
 	const [isEvidenceOpen, setIsEvidenceOpen] = useState(false);
 	const [evidenceItemName, setEvidenceItemName] = useState("");
-	const [photoCategoryFilter, setPhotoCategoryFilter] = useState("all");
+	const [photoCategoryFilter, setPhotoCategoryFilter] = usePersistedState<string>("vehicles/photoCategoryFilter", "all");
 	const [selectedPhoto, setSelectedPhoto] = useState<{
 		id: string;
 		url: string;

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -28,6 +28,7 @@ import {
 	Search,
 	Sparkles,
 	Wrench,
+	X,
 	XCircle,
 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
@@ -320,6 +321,15 @@ function VehiclesDashboard() {
 	const [isEvidenceOpen, setIsEvidenceOpen] = useState(false);
 	const [evidenceItemName, setEvidenceItemName] = useState("");
 	const [photoCategoryFilter, setPhotoCategoryFilter] = usePersistedState<string>("vehicles/photoCategoryFilter", "all");
+
+	const hasActiveFilters = searchTerm !== "" || filterStatus !== "all" || filterOwnership !== "all" || photoCategoryFilter !== "all";
+	const resetFilters = () => {
+		setSearchTerm("");
+		setFilterStatus("all");
+		setFilterOwnership("all");
+		setPhotoCategoryFilter("all");
+		setPage(0);
+	};
 	const [selectedPhoto, setSelectedPhoto] = useState<{
 		id: string;
 		url: string;
@@ -622,6 +632,15 @@ function VehiclesDashboard() {
 											Externos
 										</Button>
 									</div>
+									{hasActiveFilters && (
+										<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+											<X className="mr-1 h-3 w-3" />
+											Limpiar filtros
+											<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+												{[searchTerm !== "", filterStatus !== "all", filterOwnership !== "all", photoCategoryFilter !== "all"].filter(Boolean).length}
+											</Badge>
+										</Button>
+									)}
 								</div>
 							</div>
 


### PR DESCRIPTION
1.Persistencia de filtros a companies, vendors, notifications y vehicles
uso de usePersistedState y usePersistedDateRange, hooks ya existentes
reemplazo de useState por usePersistedState con su key de sessionStorage correspondiente.

src/routes/crm/companies.tsx
- Filtros persistidos: searchTerm, industryFilter, sizeFilter

src/routes/crm/vendors.tsx
- Filtros persistidos: searchTerm, vendorTypeFilter

src/routes/notifications.tsx 
- Filtros persistidos: statusFilter, page

src/routes/vehicles/index.tsx
- Filtros persistidos: searchTerm, filterStatus, filterOwnership, activeTab, page, photoCategoryFilter
- debouncedSearch se inicializa desde el valor persistido de searchTerm para que la query arranque con el filtro correcto al volver a la página, sin esperar el delay del debounce.