### PR TITLE
fix: restrict email notifications to HTTP requests and sanitize CC ad…

### DIFF
--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -434,30 +434,32 @@ export const returnPendingInvestorsToCube = async ({ body, set, request }: any) 
     });
 
     // ================================================================
-    // PASO 5: NOTIFICACIÓN POR CORREO
+    // PASO 5: NOTIFICACIÓN POR CORREO (Solo si es acción manual/HTTP)
     // ================================================================
-    try {
-      const affectedInvestorNames = Array.from(new Set(pendientes.map(p => investorMap.get(p.inversionista_id)))).join(", ");
-      
-      const emailCredits = Array.from(porCredito.entries()).map(([creditoId, info]) => {
-        const details = creditMap.get(creditoId);
-        return {
-          sifco: details?.sifco || "N/A",
-          cliente: details?.cliente || "Desconocido",
-          monto: info.monto_total_a_cube.toFixed(2)
-        };
-      });
+    if (request) {
+      try {
+        const affectedInvestorNames = Array.from(new Set(pendientes.map(p => investorMap.get(p.inversionista_id)))).join(", ");
+        
+        const emailCredits = Array.from(porCredito.entries()).map(([creditoId, info]) => {
+          const details = creditMap.get(creditoId);
+          return {
+            sifco: details?.sifco || "N/A",
+            cliente: details?.cliente || "Desconocido",
+            monto: info.monto_total_a_cube.toFixed(2)
+          };
+        });
 
-      await sendSessionCancelledNotification({
-        to: COMPRA_CARTERA_RECIPIENTS.to,
-        cc: COMPRA_CARTERA_RECIPIENTS.cc,
-        affectedInvestorNames,
-        adminName,
-        adminEmail,
-        credits: emailCredits
-      });
-    } catch (mailErr) {
-      console.error("[returnPendingInvestorsToCube] Falló envío de correo:", mailErr);
+        await sendSessionCancelledNotification({
+          to: COMPRA_CARTERA_RECIPIENTS.to,
+          cc: COMPRA_CARTERA_RECIPIENTS.cc,
+          affectedInvestorNames,
+          adminName,
+          adminEmail,
+          credits: emailCredits
+        });
+      } catch (mailErr) {
+        console.error("[returnPendingInvestorsToCube] Falló envío de correo:", mailErr);
+      }
     }
 
     // ================================================================

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -773,6 +773,15 @@ export const sendSessionCancelledNotification = async ({
       }
     });
 
+    const validCcEmails = cc.filter((email) => {
+      try {
+        emailSchema.parse(email);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+
     if (validEmails.length === 0) {
       console.warn("[sendSessionCancelledNotification] No valid emails found");
       return { success: false, error: "No valid emails" };
@@ -839,7 +848,7 @@ export const sendSessionCancelledNotification = async ({
     `;
 
     const subject = `Sesión CANCELADA — ${affectedInvestorNames}`;
-    return await sendPlainEmail(validEmails, subject, html, cc);
+    return await sendPlainEmail(validEmails, subject, html, validCcEmails);
   } catch (err) {
     console.error("[sendSessionCancelledNotification] Unexpected Error:", err);
     return { success: false, error: err };


### PR DESCRIPTION
# Correcciones basadas en code review

Se han implementado soluciones para los problemas detectados en la revisión de código automatizada:

### 1. Prevención de notificaciones duplicadas en Jobs internos
- **Problema:** El job `expirarCompraCarteraVencidas` invoca el controlador de devolución dentro de un ciclo por cada inversionista. Al ejecutarse, enviaba el correo de cancelación `N` veces de forma incondicional, llenando la bandeja de los destinatarios.
- **Solución:** Se envolvió el bloque de envío de correos dentro de la validación `if (request)`. De esta forma, el correo de "Sesión Cancelada" solo se dispara cuando la acción es invocada manualmente desde la interfaz gráfica (petición HTTP), dejando que el Job maneje sus propios correos de resumen por separado.

### 2. Validación estricta de destinatarios en copia (CC)
- **Problema:** La función `sendSessionCancelledNotification` filtraba correos inválidos para la lista principal (`to`), pero enviaba la lista `cc` directamente a la API de Resend sin validación. Un error tipográfico en la lista CC provocaba que el correo rebotara por completo.
- **Solución:** Se implementó el mismo chequeo de validación usando `emailSchema.parse` para la lista de destinatarios en `cc` antes de despachar el correo hacia Resend.

### 3. Estandarización del fallback para JWT_SECRET
- **Problema:** El controlador usaba una llave de respaldo distinta al resto de la aplicación, ocasionando que los tokens de sesión válidos no pudieran ser decodificados localmente si la variable `JWT_SECRET` no estaba definida en el `.env`. Esto rompía la auditoría de "Quién canceló la sesión".
- **Solución:** Se actualizó el fallback de la constante a `"supersecreto"` para asegurar la misma paridad con el middleware de autenticación del sistema.
