### PR TITLE
fix(credits): track per-operation deltas for compra/reinversion emails

### DIFF
--- a/apps/cartera-back/drizzle/0002_add_compras_credito_inversionista.sql
+++ b/apps/cartera-back/drizzle/0002_add_compras_credito_inversionista.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS cartera.compras_credito_inversionista (
+    id SERIAL PRIMARY KEY,
+    credito_id INTEGER NOT NULL REFERENCES cartera.creditos(credito_id),
+    inversionista_id INTEGER NOT NULL REFERENCES cartera.inversionistas(inversionista_id),
+    monto_aportado NUMERIC(18, 8) NOT NULL,
+    tipo_operacion VARCHAR(30) NOT NULL,
+    tipo_reinversion cartera.tipo_reinversion,
+    status cartera.status_credito_inversionista_espejo NOT NULL,
+    fecha TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMP WITH TIME ZONE
+);
+
+CREATE INDEX IF NOT EXISTS ix_compras_credito_inv_status
+    ON cartera.compras_credito_inversionista (status);
+
+CREATE INDEX IF NOT EXISTS ix_compras_credito_inv_credito_inv
+    ON cartera.compras_credito_inversionista (credito_id, inversionista_id);

--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -5,6 +5,7 @@ import { db } from "../database";
 import {
   admins,
   asesores,
+  compras_credito_inversionista,
   creditos,
   creditos_inversionistas,
   creditos_inversionistas_espejo,
@@ -694,6 +695,26 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
             .insert(creditos_inversionistas_espejo)
             .values(dataEspejoConStatus);
         }
+
+        // ================================================================
+        // PASO 3i.2: REGISTRAR LA OPERACIÓN EN compras_credito_inversionista
+        // Guardamos SOLO el monto nuevo que entró a este crédito en esta
+        // operación (montoParaEsteCredito), NO la suma acumulada que ya
+        // queda en el padre/espejo. Esto permite que, cuando se acepte la
+        // compra/reinversión, el correo reporte el monto real ingresado
+        // en esta operación (buscando los registros por status pendiente).
+        // ================================================================
+        await tx.insert(compras_credito_inversionista).values({
+          credito_id,
+          inversionista_id,
+          monto_aportado: montoParaEsteCredito.toString(),
+          tipo_operacion,
+          tipo_reinversion:
+            tipo_operacion === "compra_cartera"
+              ? tipo_reinversion ?? null
+              : null,
+          status: statusEspejo,
+        });
 
         // ================================================================
         // Activar bandera_reinversion en el crédito cuando sea compra_cartera

--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -1,12 +1,13 @@
 import { db } from "../database";
 import {
+  compras_credito_inversionista,
   creditos_inversionistas_espejo,
   creditos_inversionistas,
   creditos,
   inversionistas,
   usuarios,
 } from "../database/db";
-import { eq, inArray, and } from "drizzle-orm";
+import { eq, inArray, and, ne } from "drizzle-orm";
 import z from "zod";
 import jwt from "jsonwebtoken";
 import { sendPlainEmail } from "@cci/email";
@@ -103,6 +104,33 @@ export const completeEspejo = async ({ body, set, request }: any) => {
             fecha_inicio_participacion: new Date().toISOString().split('T')[0],
           })
           .where(whereConditionsPadre);
+
+        // ────────────────────────────────────────────────────────────────
+        // Cerrar también el registro de compras_credito_inversionista.
+        // Pasamos a "completado" cualquier registro pendiente
+        // (pendiente_compra_cartera / pendiente_revision / pendiente_reinversion)
+        // que coincida con el (credito_id, inversionista_id?) del request.
+        // Filtramos por status != "completado" para no resellar registros
+        // ya cerrados de operaciones anteriores.
+        // ────────────────────────────────────────────────────────────────
+        const whereConditionsCompras = inversionista_id
+          ? and(
+              eq(compras_credito_inversionista.credito_id, credito_id),
+              eq(
+                compras_credito_inversionista.inversionista_id,
+                inversionista_id,
+              ),
+              ne(compras_credito_inversionista.status, "completado"),
+            )
+          : and(
+              eq(compras_credito_inversionista.credito_id, credito_id),
+              ne(compras_credito_inversionista.status, "completado"),
+            );
+
+        await tx
+          .update(compras_credito_inversionista)
+          .set({ status: "completado", updated_at: new Date() })
+          .where(whereConditionsCompras);
 
         resultados.push({
           credito_id,

--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -5,6 +5,7 @@ import { db } from "../database";
 import {
   admins,
   asesores,
+  compras_credito_inversionista,
   creditos,
   creditos_inversionistas,
   creditos_inversionistas_espejo,
@@ -166,6 +167,40 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
     }
 
 
+    // ── 4.4. Leer los montos NUEVOS de la operación pendiente ──
+    // compras_credito_inversionista guarda el delta de cada operación
+    // (no la posición acumulada del inversionista en el crédito). Para
+    // el correo necesitamos el monto que entró en ESTA compra, no la
+    // suma con lo que el inversionista ya tenía antes.
+    // Si el mismo (credito_id, inversionista_id) tiene varios registros
+    // en pendiente (porque hubo varias operaciones sin aceptar todavía),
+    // los sumamos: ese es el monto total que falta por aceptar.
+    const comprasPendientes = await db
+      .select({
+        credito_id: compras_credito_inversionista.credito_id,
+        inversionista_id: compras_credito_inversionista.inversionista_id,
+        monto_aportado: compras_credito_inversionista.monto_aportado,
+      })
+      .from(compras_credito_inversionista)
+      .where(
+        and(
+          inArray(compras_credito_inversionista.credito_id, creditoIds),
+          eq(
+            compras_credito_inversionista.status,
+            "pendiente_compra_cartera",
+          ),
+        ),
+      );
+
+    // Map (credito_id-inversionista_id) → monto nuevo (Big), sumado si
+    // hay varios registros pendientes para el mismo par.
+    const montoNuevoPorPar = new Map<string, Big>();
+    for (const row of comprasPendientes) {
+      const key = `${row.credito_id}-${row.inversionista_id}`;
+      const prev = montoNuevoPorPar.get(key) ?? new Big(0);
+      montoNuevoPorPar.set(key, prev.plus(new Big(row.monto_aportado)));
+    }
+
     // ── 4.5. Marcar el espejo como aceptado ──
     // Pasamos a "pendiente_revision" todos los rows de los créditos que estén
     // actualmente en "pendiente_compra_cartera". Registramos cuándo y quién.
@@ -189,6 +224,23 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
         inversionista_id: creditos_inversionistas_espejo.inversionista_id,
         tipo_reinversion: creditos_inversionistas_espejo.tipo_reinversion,
       });
+
+    // ── 4.5.bis. Marcar las compras pendientes como aceptadas ──
+    // Mismo cambio que el espejo, sobre compras_credito_inversionista.
+    // Así los próximos accept/queries ya no traen estos registros (el
+    // correo ya se mandó con esos montos).
+    await db
+      .update(compras_credito_inversionista)
+      .set({ status: "pendiente_revision", updated_at: ahora })
+      .where(
+        and(
+          inArray(compras_credito_inversionista.credito_id, creditoIds),
+          eq(
+            compras_credito_inversionista.status,
+            "pendiente_compra_cartera",
+          ),
+        ),
+      );
 
     // ── Mapa credito_id → tipo_reinversion del target ──
     // El update filtró por status "pendiente_compra_cartera", y esa es la
@@ -275,14 +327,23 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
 
       // Sumamos el monto total del target entre todos los créditos
       // y calculamos su % de inversión ponderado por monto.
+      //
+      // OJO: usamos el monto NUEVO (delta de la operación) que viene de
+      // compras_credito_inversionista, NO el acumulado del espejo/padre.
+      // El acumulado incluiría lo que el inversionista ya tenía antes en
+      // el crédito, inflando el "Monto" del header del correo.
+      // Fallback al monto acumulado solo si no hay registro de compra
+      // (operaciones viejas previas a esta tabla).
       let targetMontoTotal = new Big(0);
       let targetInversionPonderada = new Big(0);
-      for (const rows of rowsPorCredito.values()) {
+      for (const [creditoId, rows] of rowsPorCredito.entries()) {
         for (const r of rows) {
           if (r.inversionista_id === targetId) {
-            targetMontoTotal = targetMontoTotal.plus(r.monto);
+            const montoNuevo =
+              montoNuevoPorPar.get(`${creditoId}-${targetId}`) ?? r.monto;
+            targetMontoTotal = targetMontoTotal.plus(montoNuevo);
             targetInversionPonderada = targetInversionPonderada.plus(
-              r.porcentajeInversion.times(r.monto),
+              r.porcentajeInversion.times(montoNuevo),
             );
           }
         }

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -2,6 +2,7 @@ import Big from "big.js";
 import { eq, and, inArray, ne } from "drizzle-orm";
 import { db } from "../database";
 import {
+  compras_credito_inversionista,
   creditos,
   creditos_inversionistas,
   creditos_inversionistas_espejo,
@@ -369,6 +370,30 @@ export const returnPendingInvestorsToCube = async ({ body, set }: any) => {
 
         if (dataEspejo.length > 0) {
           await tx.insert(creditos_inversionistas_espejo).values(dataEspejo);
+        }
+
+        // ── Limpiar compras_credito_inversionista pendientes ──
+        // Como la operación de los inversionistas que salen NUNCA llegó
+        // a completarse (cancelación / expiración), borramos sus filas
+        // pendientes en compras_credito_inversionista. Si no, quedarían
+        // como deltas "huérfanos" y una próxima aceptación de otra
+        // compra sobre el mismo crédito los sumaría, inflando el monto
+        // del correo y el % ponderado.
+        // Conservamos los registros con status "completado" (audit
+        // trail de operaciones que sí cerraron en el pasado).
+        if (inversionistas_a_sacar.size > 0) {
+          await tx
+            .delete(compras_credito_inversionista)
+            .where(
+              and(
+                eq(compras_credito_inversionista.credito_id, creditoId),
+                inArray(
+                  compras_credito_inversionista.inversionista_id,
+                  Array.from(inversionistas_a_sacar),
+                ),
+                ne(compras_credito_inversionista.status, "completado"),
+              ),
+            );
         }
 
         // ── Apagar bandera_reinversion del crédito ──
@@ -784,6 +809,19 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
             .values(dataEspejoDestinoFinal);
         }
 
+        // ── Registrar el delta de esta reasignación en compras_credito_inversionista ──
+        // Mismo patrón que addInvestorToCredit: guardamos SOLO el monto
+        // nuevo asignado a este destino (montoAsignar), no el acumulado.
+        // El correo de aceptación/expiración después lo lee desde aquí.
+        await tx.insert(compras_credito_inversionista).values({
+          credito_id: credito_destino_id,
+          inversionista_id,
+          monto_aportado: montoAsignar.toString(),
+          tipo_operacion,
+          tipo_reinversion: null,
+          status: statusEspejo,
+        });
+
         // ── Activar bandera_reinversion en el destino si es compra_cartera ──
         // Mientras el espejo esté en pendiente_compra_cartera, cofidi redirige
         // los intereses del inversionista nuevo a CUBE. Se apaga al aceptar
@@ -949,6 +987,28 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
           .insert(creditos_inversionistas_espejo)
           .values(dataEspejoOrigenConStatus);
       }
+
+      // ── Limpiar compras_credito_inversionista pendientes del origen ──
+      // El inversionista salió del crédito origen (su monto volvió a CUBE
+      // y/o se reasignó a los destinos). Cualquier delta pendiente que
+      // hubiera quedado para ese par (origen, inversionista) ya no es
+      // válido: si lo dejamos, una próxima aceptación lo sumaría como
+      // monto fantasma. Conservamos los "completado" (audit trail).
+      await tx
+        .delete(compras_credito_inversionista)
+        .where(
+          and(
+            eq(
+              compras_credito_inversionista.credito_id,
+              credito_espejo_removido_id,
+            ),
+            eq(
+              compras_credito_inversionista.inversionista_id,
+              inversionista_id,
+            ),
+            ne(compras_credito_inversionista.status, "completado"),
+          ),
+        );
 
       // ── Apagar bandera_reinversion del crédito origen ──
       // El espejo del origen quedó todo en "completado": ya no hay

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -405,6 +405,38 @@
     })
   );
 
+  // ====================================================================
+  // compras_credito_inversionista
+  // ====================================================================
+  // Registro de cada operación (compra_cartera o reinversion) que entra
+  // sobre un crédito para un inversionista. Guarda SOLO el monto nuevo
+  // aportado en esa operación (no la suma acumulada en el padre/espejo).
+  //
+  // Se usa para que el correo de aceptación de compra/reinversión pueda
+  // reportar el monto real ingresado en la operación, en vez de leer el
+  // monto_aportado del espejo (que ya incluye lo que el inversionista
+  // tenía antes en el crédito).
+  // ====================================================================
+  export const compras_credito_inversionista = customSchema.table(
+    "compras_credito_inversionista",
+    {
+      id: serial("id").primaryKey(),
+      credito_id: integer("credito_id").notNull().references(() => creditos.credito_id),
+      inversionista_id: integer("inversionista_id").notNull().references(() => inversionistas.inversionista_id),
+      monto_aportado: numeric("monto_aportado", { precision: 18, scale: 8 }).notNull(),
+      tipo_operacion: varchar("tipo_operacion", { length: 30 }).notNull(),
+      tipo_reinversion: tipoReinversionEnum("tipo_reinversion"),
+      status: statusCreditoInversionistaEspejoEnum("status").notNull(),
+      fecha: timestamp("fecha", { withTimezone: true }).notNull().$default(() => new Date()),
+      created_at: timestamp("created_at", { withTimezone: true }).notNull().$default(() => new Date()),
+      updated_at: timestamp("updated_at", { withTimezone: true }),
+    },
+    (t) => ({
+      ixStatus: index("ix_compras_credito_inv_status").on(t.status),
+      ixCreditoInv: index("ix_compras_credito_inv_credito_inv").on(t.credito_id, t.inversionista_id),
+    })
+  );
+
   export const liquidacion_locks = customSchema.table("liquidacion_locks", {
     id: serial("id").primaryKey(),
     inversionista_id: integer("inversionista_id"),


### PR DESCRIPTION
## Summary

- El correo de aceptación de compra de cartera reportaba el **monto acumulado** del inversionista en el crédito (incluyendo posiciones previas), en vez de **solo el monto que entró en esa operación**. Caso típico: un inversionista que ya tenía Q10K en un crédito hacía otra compra de Q5K → el correo decía Q15K.
- Se agrega la tabla `cartera.compras_credito_inversionista` para guardar el **delta** de cada operación (credito_id, inversionista_id, monto_aportado nuevo, tipo_operacion, tipo_reinversion, status, fechas).
- `addInvestorToCredit` ahora hace `INSERT` en esa tabla por cada crédito procesado, con el monto **delta** (`montoParaEsteCredito`), no el acumulado.
- `compraCarteraAceptada` lee `compras_credito_inversionista` por `status='pendiente_compra_cartera'` y usa la suma de los deltas para `operacionInfo.monto` y el `%` ponderado del header del correo. Después de actualizar el espejo, también marca esos registros como `pendiente_revision`.
- `completeEspejo` (botón "Confirmar Sesión") cierra el ciclo: pasa cualquier registro pendiente de `compras_credito_inversionista` a `completado` junto con el espejo.

## Ciclo de vida de `compras_credito_inversionista`

| Endpoint | Acción |
|---|---|
| `addInvestorToCredit` | INSERT con status `pendiente_compra_cartera` o `pendiente_reinversion` |
| `compraCarteraAceptada` | `pendiente_compra_cartera` → `pendiente_revision` |
| `completeEspejo` | cualquier pendiente → `completado` |

## Migración

`apps/cartera-back/drizzle/0002_add_compras_credito_inversionista.sql` — crea la tabla y dos índices (status, y credito_id+inversionista_id). Falta correr en cada ambiente.

## Test plan

- [ ] Correr la migración 0002 en dev/staging.
- [ ] **Caso bug original:** Inversionista A ya tiene Q10K en crédito X. Hacer compra_cartera por Q5K en X. Aceptar compra → verificar que el correo dice **Monto: Q5,000** en el header (no Q15,000), y que el % ponderado refleja solo la nueva operación.
- [ ] **Inversionista nuevo:** Inversionista B sin posición previa en crédito Y. Compra_cartera por Q20K → correo dice Q20K (igual que antes).
- [ ] **Multi-crédito:** Una sola operación distribuida entre 2 créditos → correo suma solo los deltas nuevos en `operacionInfo.monto`.
- [ ] **Reinversión:** Hacer reinversión, confirmar sesión → verificar que `compras_credito_inversionista` queda en `completado`.
- [ ] **Pool resultante por crédito:** Sigue mostrando los montos acumulados post-operación (no cambia, es intencional).
- [ ] **Status sincronizado:** Después de aceptar compra y confirmar sesión, no debe quedar ningún registro en `compras_credito_inversionista` con status pendiente para ese crédito/inversionista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)