### PR TITLE
feat(credits): Expose per-operation delta in sesiones pendientes view

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -27,6 +27,7 @@ import {
   documentos_inversionista,
   abonos_capital,
   cuentas_extra_inversionista,
+  compras_credito_inversionista,
 } from "../database/db/schema";
 import { getSignedDocumentUrl } from "../utils/functions/uploadsFiles";
 import { eq, and, or, sql, inArray, ilike, like, desc, count, SQL, isNull, isNotNull, ne } from "drizzle-orm";
@@ -7350,9 +7351,47 @@ export async function getCreditosEspejoPendientes(
     return { data: [], total: 0, page, pageSize };
   }
 
+  // 1.b. Obtener montos delta por operación desde compras_credito_inversionista
+  // (status no completado). Si hay varios pendientes para el mismo par
+  // (credito_id, inversionista_id), se suman porque así se enviarán juntos al aceptar.
+  const parKeys = pendientes.map((r) => ({
+    credito_id: r.credito_id,
+    inversionista_id: r.inversionista_id,
+  }));
+  const comprasRows = parKeys.length > 0
+    ? await db
+        .select({
+          credito_id: compras_credito_inversionista.credito_id,
+          inversionista_id: compras_credito_inversionista.inversionista_id,
+          monto_aportado: compras_credito_inversionista.monto_aportado,
+        })
+        .from(compras_credito_inversionista)
+        .where(
+          and(
+            inArray(
+              compras_credito_inversionista.credito_id,
+              parKeys.map((k) => k.credito_id),
+            ),
+            inArray(
+              compras_credito_inversionista.inversionista_id,
+              parKeys.map((k) => k.inversionista_id),
+            ),
+            ne(compras_credito_inversionista.status, "completado"),
+          ),
+        )
+    : [];
+
+  const montoNuevoPorPar = new Map<string, Big>();
+  for (const row of comprasRows) {
+    const key = `${row.credito_id}-${row.inversionista_id}`;
+    const prev = montoNuevoPorPar.get(key) ?? new Big(0);
+    montoNuevoPorPar.set(key, prev.plus(new Big(row.monto_aportado)));
+  }
+
   // 2. Agrupar por inversionista
   type CreditoSinInversionista = Omit<typeof pendientes[number], '_nombre_inversionista' | '_dpi' | '_email' | '_moneda'> & {
     otrosInversionistas: { nombre: string; monto_aportado: string }[];
+    monto_aportado_nuevo: string | null;
   };
 
   const agrupado = new Map<number, {
@@ -7417,12 +7456,16 @@ export async function getCreditosEspejoPendientes(
     const otrosEnEsteCredito = (otrosPorCredito.get(row.credito_id) || [])
       .filter((o) => o.inversionista_id !== row.inversionista_id);
 
+    const montoNuevoKey = `${row.credito_id}-${row.inversionista_id}`;
+    const montoNuevo = montoNuevoPorPar.get(montoNuevoKey);
+
     grupo.creditosPendientes.push({
       ...creditoData,
       otrosInversionistas: otrosEnEsteCredito.map((o) => ({
         nombre: o.nombre,
         monto_aportado: o.monto_aportado,
       })),
+      monto_aportado_nuevo: montoNuevo ? montoNuevo.toString() : null,
     });
   }
 

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -7354,10 +7354,13 @@ export async function getCreditosEspejoPendientes(
   // 1.b. Obtener montos delta por operación desde compras_credito_inversionista
   // (status no completado). Si hay varios pendientes para el mismo par
   // (credito_id, inversionista_id), se suman porque así se enviarán juntos al aceptar.
-  const parKeys = pendientes.map((r) => ({
-    credito_id: r.credito_id,
-    inversionista_id: r.inversionista_id,
-  }));
+  const parKeysSet = new Set(
+    pendientes.map((r) => `${r.credito_id}-${r.inversionista_id}`),
+  );
+  const parKeys = Array.from(parKeysSet).map((k) => {
+    const [c, i] = k.split("-").map(Number);
+    return { credito_id: c, inversionista_id: i };
+  });
   const comprasRows = parKeys.length > 0
     ? await db
         .select({
@@ -7368,13 +7371,16 @@ export async function getCreditosEspejoPendientes(
         .from(compras_credito_inversionista)
         .where(
           and(
-            inArray(
-              compras_credito_inversionista.credito_id,
-              parKeys.map((k) => k.credito_id),
-            ),
-            inArray(
-              compras_credito_inversionista.inversionista_id,
-              parKeys.map((k) => k.inversionista_id),
+            or(
+              ...parKeys.map((k) =>
+                and(
+                  eq(compras_credito_inversionista.credito_id, k.credito_id),
+                  eq(
+                    compras_credito_inversionista.inversionista_id,
+                    k.inversionista_id,
+                  ),
+                ),
+              ),
             ),
             ne(compras_credito_inversionista.status, "completado"),
           ),

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -515,6 +515,12 @@ function InvestorCard({
                       </div>
                       <div className="flex items-center gap-4 mt-1 text-[11px] text-gray-500">
                         <span><b className="text-gray-800">{formatQ(credito.monto_aportado)}</b> aportado</span>
+                        {credito.monto_aportado_nuevo != null
+                          && Number(credito.monto_aportado_nuevo) !== Number(credito.monto_aportado) && (
+                            <span className="text-emerald-700">
+                              <b className="text-emerald-800">{formatQ(credito.monto_aportado_nuevo)}</b> monto aportado nuevo
+                            </span>
+                          )}
                         <span>Cuota: {formatQ(credito.cuota_inversionista)}</span>
                         <span>{credito.porcentaje_participacion_inversionista}% part.</span>
                         <span>Cash In: {credito.porcentaje_cash_in}%</span>

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3662,6 +3662,7 @@ export interface CreditoEspejoPendiente {
   tipo_reinversion: string | null;
   numero_credito_sifco: string;
   nombre_usuario: string;
+  monto_aportado_nuevo: string | null;
   otrosInversionistas?: {
     nombre: string;
     monto_aportado: string;


### PR DESCRIPTION
## Summary
- `getCreditosEspejoPendientes` ahora cruza `compras_credito_inversionista` (status distinto de `completado`) y suma el delta por par `(credito_id, inversionista_id)`, exponiendo `monto_aportado_nuevo` por crédito.
- El tipo `CreditoEspejoPendiente` agrega `monto_aportado_nuevo: string | null`.
- En `SesionesPendientes.tsx`, se muestra un chip verde con "monto aportado nuevo" solo cuando difiere del `monto_aportado` cumulativo del espejo, para que el operador vea claramente el delta de la operación.

## Test plan
- [ ] Abrir Sesiones Pendientes con un inversionista que ya tenía posición previa y realizó una compra/reinversión adicional: verificar que aparece el chip "monto aportado nuevo" con el delta y no se muestra cuando el monto es nuevo en el crédito (igual al cumulativo).
- [ ] Verificar que al aceptar la operación, el monto del correo coincide con el `monto_aportado_nuevo` mostrado en la vista.

🤖 Generated with [Claude Code](https://claude.com/claude-code)