### PR TITLE
feat: implement usePersistedState hook for state persistence across c…

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -93,6 +93,8 @@ export function ListaCreditosPagos() {
     setIsVehiculoPropio,
     inversionistaIds,
     setInversionistaIds,
+    clearAllFilters,
+    hasActiveFilters,
   } = useCreditosPaginadosWithFilters({
     initialAsesorId: !isAdmin && userAsesorId ? userAsesorId : undefined,
   });
@@ -582,6 +584,20 @@ export function ListaCreditosPagos() {
             />
             <span className="text-sm">Solo Vehículo Cash-In</span>
           </label>
+          {hasActiveFilters && (
+            <Button
+              type="button"
+              variant="outline"
+              onClick={clearAllFilters}
+              className="flex items-center gap-2 rounded-lg border-gray-300 px-4 py-2 font-semibold text-gray-600 hover:bg-gray-100"
+            >
+              <X className="w-4 h-4" />
+              Limpiar filtros
+              <Badge variant="secondary" className="ml-1 h-5 px-1.5 text-xs">
+                {[creditoSifco !== "", nombreUsuarioInput !== "", isAdmin && asesorId !== undefined, estado !== "ACTIVO", isVehiculoPropio !== undefined, inversionistaIds.length > 0].filter(Boolean).length}
+              </Badge>
+            </Button>
+          )}
           <button
             type="button"
             disabled={isDownloadingExcel}

--- a/apps/carteraFront/src/private/cartera/components/DevolucionCube.tsx
+++ b/apps/carteraFront/src/private/cartera/components/DevolucionCube.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 import {
   getPendingDevolucion,
   aceptarDevolucion,
@@ -12,7 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { toast } from "sonner";
-import { RefreshCw, Search } from "lucide-react";
+import { RefreshCw, Search, X } from "lucide-react";
 
 const PAGE_SIZE = 10;
 
@@ -21,11 +22,13 @@ export function DevolucionCube() {
   const [actingId, setActingId] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [items, setItems] = useState<DevolucionCreditoItem[]>([]);
-  const [page, setPage] = useState(1);
+  const [page, setPage] = usePersistedState<number>("cartera/devolucionCube/page", 1);
   const [totalPages, setTotalPages] = useState(1);
   const [total, setTotal] = useState(0);
-  const [searchInput, setSearchInput] = useState("");
-  const [search, setSearch] = useState("");
+  const [searchInput, setSearchInput] = usePersistedState<string>("cartera/devolucionCube/searchInput", "");
+  const [search, setSearch] = usePersistedState<string>("cartera/devolucionCube/search", "");
+
+  const hasActiveFilters = searchInput !== "" || search !== "";
   const [rejectOpen, setRejectOpen] = useState(false);
   const [rejectCredit, setRejectCredit] = useState<DevolucionCreditoItem | null>(null);
   const [rejectReason, setRejectReason] = useState("");
@@ -70,6 +73,12 @@ export function DevolucionCube() {
   const onBuscar = () => {
     setPage(1);
     setSearch(searchInput.trim());
+  };
+
+  const clearFilters = () => {
+    setSearchInput("");
+    setSearch("");
+    setPage(1);
   };
 
   const onAceptar = async (creditoId: number) => {
@@ -181,6 +190,12 @@ export function DevolucionCube() {
           <Button size="sm" className="h-8 text-xs" onClick={onBuscar}>
             Buscar
           </Button>
+          {hasActiveFilters && (
+            <Button variant="outline" size="sm" onClick={clearFilters} className="h-8 text-xs text-gray-600 border-gray-300 hover:bg-gray-100 gap-1">
+              <X className="w-3.5 h-3.5" /> Limpiar
+              <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-xs">1</Badge>
+            </Button>
+          )}
           <Badge variant="outline" className="text-[11px] border-blue-200 text-blue-700 bg-blue-50 tabular-nums">
             {total} créditos
           </Badge>

--- a/apps/carteraFront/src/private/cartera/components/FacturasGenericas.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturasGenericas.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 import { useFormik, FieldArray, FormikProvider } from "formik";
 import * as Yup from "yup";
 import { toast } from "sonner";
@@ -25,6 +26,7 @@ import {
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/Provider/authProvider";
 import { useFacturarGenerico, useFacturasGenericas, useAnularFactura, useExportFacturasExcel } from "../hooks/cofidi";
 import { DatePickerMUI } from "./calendar";
@@ -105,16 +107,16 @@ const validationSchema = Yup.object({
 export function FacturasGenericas() {
   const { user } = useAuth();
   const [modalOpen, setModalOpen] = useState(false);
-  const [page, setPage] = useState(1);
-  const [limit, setLimit] = useState(10);
-  const [nitBusqueda, setNitBusqueda] = useState("");
-  const [nitFiltro, setNitFiltro] = useState("");
-  const [fechaInicio, setFechaInicio] = useState("");
-  const [fechaFin, setFechaFin] = useState("");
-  const [fechaInicioFiltro, setFechaInicioFiltro] = useState("");
-  const [fechaFinFiltro, setFechaFinFiltro] = useState("");
-  const [tipoFactura, setTipoFactura] = useState<TipoFacturaGenerica | "">("");
-  const [tipoFacturaFiltro, setTipoFacturaFiltro] = useState<TipoFacturaGenerica | "">("");
+  const [page, setPage] = usePersistedState<number>("cartera/facturasGenericas/page", 1);
+  const [limit, setLimit] = usePersistedState<number>("cartera/facturasGenericas/limit", 10);
+  const [nitBusqueda, setNitBusqueda] = usePersistedState<string>("cartera/facturasGenericas/nitBusqueda", "");
+  const [nitFiltro, setNitFiltro] = usePersistedState<string>("cartera/facturasGenericas/nitFiltro", "");
+  const [fechaInicio, setFechaInicio] = usePersistedState<string>("cartera/facturasGenericas/fechaInicio", "");
+  const [fechaFin, setFechaFin] = usePersistedState<string>("cartera/facturasGenericas/fechaFin", "");
+  const [fechaInicioFiltro, setFechaInicioFiltro] = usePersistedState<string>("cartera/facturasGenericas/fechaInicioFiltro", "");
+  const [fechaFinFiltro, setFechaFinFiltro] = usePersistedState<string>("cartera/facturasGenericas/fechaFinFiltro", "");
+  const [tipoFactura, setTipoFactura] = usePersistedState<TipoFacturaGenerica | "">("cartera/facturasGenericas/tipoFactura", "");
+  const [tipoFacturaFiltro, setTipoFacturaFiltro] = usePersistedState<TipoFacturaGenerica | "">("cartera/facturasGenericas/tipoFacturaFiltro", "");
 
   // Estados para anulación
   const [facturaParaAnular, setFacturaParaAnular] = useState<string | null>(null);
@@ -260,9 +262,13 @@ export function FacturasGenericas() {
                     setTipoFacturaFiltro("");
                     setPage(1);
                   }}
-                  className="text-xs font-semibold text-purple-600 hover:text-purple-800 hover:underline transition"
+                  className="inline-flex items-center gap-1.5 text-xs font-semibold text-purple-600 hover:text-purple-800 hover:underline transition"
                 >
+                  <X className="w-3 h-3" />
                   Limpiar filtros
+                  <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-xs">
+                    {[nitFiltro !== "", fechaInicioFiltro !== "", fechaFinFiltro !== "", tipoFacturaFiltro !== ""].filter(Boolean).length}
+                  </Badge>
                 </button>
               )}
             </div>

--- a/apps/carteraFront/src/private/cartera/components/FallenCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FallenCredits.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { getFallenCredits, type GetFallenCreditsResponse } from "../services/services";
+import { usePersistedState } from "../hooks/usePersistedState";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -36,12 +37,14 @@ function formatFecha(val: any): string {
 }
 
 export function FallenCredits() {
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(10);
-  const [sifcoInput, setSifcoInput] = useState("");
-  const [sifcoFilter, setSifcoFilter] = useState("");
-  const [fechaDesde, setFechaDesde] = useState("");
-  const [fechaHasta, setFechaHasta] = useState("");
+  const [page, setPage] = usePersistedState<number>("cartera/fallenCredits/page", 1);
+  const [perPage, setPerPage] = usePersistedState<number>("cartera/fallenCredits/perPage", 10);
+  const [sifcoInput, setSifcoInput] = usePersistedState<string>("cartera/fallenCredits/sifcoInput", "");
+  const [sifcoFilter, setSifcoFilter] = usePersistedState<string>("cartera/fallenCredits/sifcoFilter", "");
+  const [fechaDesde, setFechaDesde] = usePersistedState<string>("cartera/fallenCredits/fechaDesde", "");
+  const [fechaHasta, setFechaHasta] = usePersistedState<string>("cartera/fallenCredits/fechaHasta", "");
+
+  const hasActiveFilters = sifcoInput !== "" || fechaDesde !== "" || fechaHasta !== "";
 
   const { data, isLoading, isError } = useQuery<GetFallenCreditsResponse>({
     queryKey: ["fallen-credits", page, perPage, sifcoFilter, fechaDesde, fechaHasta],
@@ -139,14 +142,19 @@ export function FallenCredits() {
             />
           </div>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={clearFilters}
-            className="text-gray-600 border-gray-300 hover:bg-gray-100"
-          >
-            <X className="w-4 h-4 mr-1" /> Limpiar
-          </Button>
+          {hasActiveFilters && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={clearFilters}
+              className="text-gray-600 border-gray-300 hover:bg-gray-100"
+            >
+              <X className="w-4 h-4 mr-1" /> Limpiar filtros
+              <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+                {[sifcoInput !== "", fechaDesde !== "", fechaHasta !== ""].filter(Boolean).length}
+              </Badge>
+            </Button>
+          )}
         </div>
       </div>
 

--- a/apps/carteraFront/src/private/cartera/components/FallenCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FallenCredits.tsx
@@ -44,7 +44,7 @@ export function FallenCredits() {
   const [fechaDesde, setFechaDesde] = usePersistedState<string>("cartera/fallenCredits/fechaDesde", "");
   const [fechaHasta, setFechaHasta] = usePersistedState<string>("cartera/fallenCredits/fechaHasta", "");
 
-  const hasActiveFilters = sifcoInput !== "" || fechaDesde !== "" || fechaHasta !== "";
+  const hasActiveFilters = sifcoFilter !== "" || fechaDesde !== "" || fechaHasta !== "";
 
   const { data, isLoading, isError } = useQuery<GetFallenCreditsResponse>({
     queryKey: ["fallen-credits", page, perPage, sifcoFilter, fechaDesde, fechaHasta],
@@ -151,7 +151,7 @@ export function FallenCredits() {
             >
               <X className="w-4 h-4 mr-1" /> Limpiar filtros
               <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
-                {[sifcoInput !== "", fechaDesde !== "", fechaHasta !== ""].filter(Boolean).length}
+                {[sifcoFilter !== "", fechaDesde !== "", fechaHasta !== ""].filter(Boolean).length}
               </Badge>
             </Button>
           )}

--- a/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
+++ b/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useMemo, useCallback } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import {
@@ -24,6 +25,7 @@ import {
   CheckCircle2,
   AlertTriangle,
   XCircle,
+  X,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -310,13 +312,21 @@ function LiquidacionCard({ item, onGenerarPagos, onVerPagos, generandoId, navega
 
 export function HistorialLiquidaciones() {
   const ahoraGT = useMemo(() => getMesAnioActualGT(), []);
-  const [mes, setMes] = useState(ahoraGT.mes);
-  const [anio, setAnio] = useState(ahoraGT.anio);
+  const [mes, setMes] = usePersistedState<number>("cartera/historialLiquidaciones/mes", ahoraGT.mes);
+  const [anio, setAnio] = usePersistedState<number>("cartera/historialLiquidaciones/anio", ahoraGT.anio);
   const esMesActual = mes === ahoraGT.mes && anio === ahoraGT.anio;
-  const [search, setSearch] = useState("");
-  const [page, setPage] = useState(1);
-  const [estadoFiltro, setEstadoFiltro] = useState<EstadoFiltro>("all");
+  const [search, setSearch] = usePersistedState<string>("cartera/historialLiquidaciones/search", "");
+  const [page, setPage] = usePersistedState<number>("cartera/historialLiquidaciones/page", 1);
+  const [estadoFiltro, setEstadoFiltro] = usePersistedState<EstadoFiltro>("cartera/historialLiquidaciones/estadoFiltro", "all");
   const [descargandoExcel, setDescargandoExcel] = useState(false);
+
+  const hasActiveFilters = search !== "" || estadoFiltro !== "all";
+
+  const clearFilters = useCallback(() => {
+    setSearch("");
+    setEstadoFiltro("all");
+    setPage(1);
+  }, []);
   const [generandoId, setGenerandoId] = useState<number | null>(null);
   const [navegandoId, setNavegandoId] = useState<number | null>(null);
   const [resultadoModal, setResultadoModal] = useState<{
@@ -599,12 +609,22 @@ export function HistorialLiquidaciones() {
 
         {/* Info bar */}
         <div className="flex items-center justify-between mt-3">
-          <span className="text-sm text-gray-500">
-            {filtered.length} resultado{filtered.length !== 1 ? "s" : ""}
-            {search && ` para "${search}"`}
-            {" — "}
-            <span className="font-medium text-gray-700">{getMesLabel(mes)} {anio}</span>
-          </span>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-500">
+              {filtered.length} resultado{filtered.length !== 1 ? "s" : ""}
+              {search && ` para "${search}"`}
+              {" — "}
+              <span className="font-medium text-gray-700">{getMesLabel(mes)} {anio}</span>
+            </span>
+            {hasActiveFilters && (
+              <Button variant="outline" size="sm" onClick={clearFilters} className="h-7 text-xs text-gray-600 border-gray-300 hover:bg-gray-100 gap-1">
+                <X className="w-3 h-3" /> Limpiar filtros
+                <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-xs">
+                  {[search !== "", estadoFiltro !== "all"].filter(Boolean).length}
+                </Badge>
+              </Button>
+            )}
+          </div>
           <span className="text-sm text-gray-500">
             Página {page} de {totalPages}
           </span>

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -56,8 +56,8 @@ export function PagosPorVencimiento() {
   const [errorMessage, setErrorMessage] = useState("");
 
   const hasActiveFilters =
-    sifcoInput !== "" ||
-    nombreInput !== "" ||
+    sifcoFilter !== "" ||
+    nombreFilter !== "" ||
     selectedAdvisors.length > 0 ||
     rangoMoraFilter !== "" ||
     tipoFecha !== "vencimiento";
@@ -331,7 +331,7 @@ export function PagosPorVencimiento() {
             >
               <X className="w-4 h-4 mr-1" /> Limpiar filtros
               <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
-                {[sifcoInput !== "", nombreInput !== "", selectedAdvisors.length > 0, rangoMoraFilter !== "", tipoFecha !== "vencimiento"].filter(Boolean).length}
+                {[sifcoFilter !== "", nombreFilter !== "", selectedAdvisors.length > 0, rangoMoraFilter !== "", tipoFecha !== "vencimiento"].filter(Boolean).length}
               </Badge>
             </Button>
           )}

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 import { usePagosPorVencimiento } from "../hooks/usePagosPorVencimiento";
 import { useAdminData } from "../hooks/advisor";
 import type { PagoPorVencimientoItem, Advisor } from "../services/services";
@@ -37,23 +38,29 @@ function formatQ(val: string | null | undefined): string {
 const currentDate = new Date();
 
 export function PagosPorVencimiento() {
-  const [mes, setMes] = useState(currentDate.getMonth() + 1);
-  const [anio, setAnio] = useState(currentDate.getFullYear());
-  const [page, setPage] = useState(1);
-  const [pageSize, setPageSize] = useState(20);
-  const [tipoFecha, setTipoFecha] = useState<"vencimiento" | "creacion">("vencimiento");
-
-  const [sifcoInput, setSifcoInput] = useState("");
-  const [sifcoFilter, setSifcoFilter] = useState("");
-  const [nombreInput, setNombreInput] = useState("");
-  const [nombreFilter, setNombreFilter] = useState("");
-  const [selectedAdvisors, setSelectedAdvisors] = useState<string[]>([]);
+  const [mes, setMes] = usePersistedState<number>("cartera/pagosPorVencimiento/mes", currentDate.getMonth() + 1);
+  const [anio, setAnio] = usePersistedState<number>("cartera/pagosPorVencimiento/anio", currentDate.getFullYear());
+  const [page, setPage] = usePersistedState<number>("cartera/pagosPorVencimiento/page", 1);
+  const [pageSize, setPageSize] = usePersistedState<number>("cartera/pagosPorVencimiento/pageSize", 20);
+  const [tipoFecha, setTipoFecha] = usePersistedState<"vencimiento" | "creacion">("cartera/pagosPorVencimiento/tipoFecha", "vencimiento");
+  const [sifcoInput, setSifcoInput] = usePersistedState<string>("cartera/pagosPorVencimiento/sifcoInput", "");
+  const [sifcoFilter, setSifcoFilter] = usePersistedState<string>("cartera/pagosPorVencimiento/sifcoFilter", "");
+  const [nombreInput, setNombreInput] = usePersistedState<string>("cartera/pagosPorVencimiento/nombreInput", "");
+  const [nombreFilter, setNombreFilter] = usePersistedState<string>("cartera/pagosPorVencimiento/nombreFilter", "");
+  const [selectedAdvisors, setSelectedAdvisors] = usePersistedState<string[]>("cartera/pagosPorVencimiento/selectedAdvisors", []);
+  const [rangoMoraInput, setRangoMoraInput] = usePersistedState<string>("cartera/pagosPorVencimiento/rangoMoraInput", "");
+  const [rangoMoraFilter, setRangoMoraFilter] = usePersistedState<string>("cartera/pagosPorVencimiento/rangoMoraFilter", "");
   const [advisorPopoverOpen, setAdvisorPopoverOpen] = useState(false);
-  const [rangoMoraInput, setRangoMoraInput] = useState("");
-  const [rangoMoraFilter, setRangoMoraFilter] = useState("");
   const [isExporting, setIsExporting] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+
+  const hasActiveFilters =
+    sifcoInput !== "" ||
+    nombreInput !== "" ||
+    selectedAdvisors.length > 0 ||
+    rangoMoraFilter !== "" ||
+    tipoFecha !== "vencimiento";
   const { advisors } = useAdminData();
 
   const { data, isLoading, isError } = usePagosPorVencimiento({
@@ -315,14 +322,19 @@ export function PagosPorVencimiento() {
             {isExporting ? "Generando..." : "Exportar Excel"}
           </Button>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={clearFilters}
-            className="text-gray-600 border-gray-300 hover:bg-gray-100"
-          >
-            <X className="w-4 h-4 mr-1" /> Limpiar
-          </Button>
+          {hasActiveFilters && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={clearFilters}
+              className="text-gray-600 border-gray-300 hover:bg-gray-100"
+            >
+              <X className="w-4 h-4 mr-1" /> Limpiar filtros
+              <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+                {[sifcoInput !== "", nombreInput !== "", selectedAdvisors.length > 0, rangoMoraFilter !== "", tipoFecha !== "vencimiento"].filter(Boolean).length}
+              </Badge>
+            </Button>
+          )}
         </div>
       </div>
 

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -119,6 +119,7 @@ export function PagosPorVencimiento() {
     setSelectedAdvisors([]);
     setRangoMoraInput("");
     setRangoMoraFilter("");
+    setTipoFecha("vencimiento");
     setPage(1);
   };
 

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useMemo, useCallback, useEffect } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 import { useSesionesPendientes, useCompletarEspejo, useReemplazarInversionistaCredito, useCreditCandidates, useDevolverPendientesACube, useCompraCarteraAceptada } from "../hooks/useSesionesPendientes";
 import type { InversionistaSesionPendiente, OtroCreditoDisponible } from "../services/services";
 import {
@@ -79,10 +80,12 @@ function distribuirMonto(
 const PAGE_SIZE = 10;
 
 export function SesionesPendientes() {
-  const [page, setPage] = useState(1);
-  const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const [page, setPage] = usePersistedState<number>("cartera/sesionesPendientes/page", 1);
+  const [search, setSearch] = usePersistedState<string>("cartera/sesionesPendientes/search", "");
+  const [debouncedSearch, setDebouncedSearch] = usePersistedState<string>("cartera/sesionesPendientes/debouncedSearch", "");
   const { data: response, isLoading, isError, error, refetch, isFetching } = useSesionesPendientes(page, PAGE_SIZE, debouncedSearch);
+
+  const hasActiveFilters = search !== "";
 
   // Debounce search to avoid firing on every keystroke
   useEffect(() => {
@@ -106,6 +109,12 @@ export function SesionesPendientes() {
     },
     [],
   );
+
+  const clearSearch = useCallback(() => {
+    setSearch("");
+    setDebouncedSearch("");
+    setPage(1);
+  }, []);
 
   if (isLoading) {
     return (
@@ -160,6 +169,12 @@ export function SesionesPendientes() {
               aria-label="Buscar inversionistas"
             />
           </div>
+          {hasActiveFilters && (
+            <Button variant="outline" size="sm" onClick={clearSearch} className="h-8 text-xs text-gray-600 border-gray-300 hover:bg-gray-100 gap-1">
+              <X className="w-3.5 h-3.5" /> Limpiar
+              <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-xs">1</Badge>
+            </Button>
+          )}
           <Badge variant="outline" className="text-[11px] border-blue-200 text-blue-700 bg-blue-50 tabular-nums">
             {total} inversionistas
           </Badge>

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, Fragment } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -254,39 +255,50 @@ export function PaymentsTable() {
   const facturarPago = useFacturarPagoCompleto(); // 🆕 NUEVO HOOK
 
   // Filtros de fecha - modo "simple" (año/mes/día), "rango" (fechaInicio/fechaFin) o "aplicado" (fechaAplicado)
-  const [modoFecha, setModoFecha] = React.useState<"simple" | "rango" | "aplicado" | "boleta">("simple");
-  const [mes, setMes] = React.useState(new Date().getMonth() + 1);
-  const [anio, setAnio] = React.useState(new Date().getFullYear());
-  const [dia, setDia] = React.useState<number | undefined>(
-    new Date().getDate(),
-  );
-  const [fechaInicio, setFechaInicio] = React.useState("");
-  const [fechaFin, setFechaFin] = React.useState("");
-  const [fechaAplicado, setFechaAplicado] = React.useState("");
-  const [fechaBoleta, setFechaBoleta] = React.useState("");
-  const [fechaBoletaInicio, setFechaBoletaInicio] = React.useState("");
-  const [fechaBoletaFin, setFechaBoletaFin] = React.useState("");
+  const [modoFecha, setModoFecha] = usePersistedState<"simple" | "rango" | "aplicado" | "boleta">("cartera/pagos/modoFecha", "simple");
+  const [mes, setMes] = usePersistedState<number>("cartera/pagos/mes", new Date().getMonth() + 1);
+  const [anio, setAnio] = usePersistedState<number>("cartera/pagos/anio", new Date().getFullYear());
+  const [dia, setDia] = usePersistedState<number | undefined>("cartera/pagos/dia", new Date().getDate());
+  const [fechaInicio, setFechaInicio] = usePersistedState<string>("cartera/pagos/fechaInicio", "");
+  const [fechaFin, setFechaFin] = usePersistedState<string>("cartera/pagos/fechaFin", "");
+  const [fechaAplicado, setFechaAplicado] = usePersistedState<string>("cartera/pagos/fechaAplicado", "");
+  const [fechaBoleta, setFechaBoleta] = usePersistedState<string>("cartera/pagos/fechaBoleta", "");
+  const [fechaBoletaInicio, setFechaBoletaInicio] = usePersistedState<string>("cartera/pagos/fechaBoletaInicio", "");
+  const [fechaBoletaFin, setFechaBoletaFin] = usePersistedState<string>("cartera/pagos/fechaBoletaFin", "");
 
   // Filtros de crédito
-  const [sifco, setSifco] = React.useState("");
-  const [categoriaCredito, setCategoriaCredito] = React.useState("");
-  const [formatoCredito, setFormatoCredito] = React.useState("");
+  const [sifco, setSifco] = usePersistedState<string>("cartera/pagos/sifco", "");
+  const [categoriaCredito, setCategoriaCredito] = usePersistedState<string>("cartera/pagos/categoriaCredito", "");
+  const [formatoCredito, setFormatoCredito] = usePersistedState<string>("cartera/pagos/formatoCredito", "");
 
   // Filtros generales
-  const [usuarioNombre, setUsuarioNombre] = React.useState("");
-  const [inversionistaId, setInversionistaId] = React.useState<
-    number | undefined
-  >();
-  const [soloAplicados, setSoloAplicados] = React.useState<boolean | undefined>(undefined);
-  const [validationStatusFilter, setValidationStatusFilter] = React.useState<string>("");
-  const [queryInv, setQueryInv] = React.useState("");
+  const [usuarioNombre, setUsuarioNombre] = usePersistedState<string>("cartera/pagos/usuarioNombre", "");
+  const [inversionistaId, setInversionistaId] = usePersistedState<number | undefined>("cartera/pagos/inversionistaId", undefined);
+  const [soloAplicados, setSoloAplicados] = usePersistedState<boolean | undefined>("cartera/pagos/soloAplicados", undefined);
+  const [validationStatusFilter, setValidationStatusFilter] = usePersistedState<string>("cartera/pagos/validationStatusFilter", "");
+  const [queryInv, setQueryInv] = usePersistedState<string>("cartera/pagos/queryInv", "");
   const filteredInvestors = queryInv === ""
     ? investors
     : investors.filter((inv) => inv.nombre.toLowerCase().includes(queryInv.toLowerCase()));
 
+  const [page, setPage] = usePersistedState<number>("cartera/pagos/page", 1);
+  const [pageSize, setPageSize] = usePersistedState<number>("cartera/pagos/pageSize", 10);
 
-  const [page, setPage] = React.useState(1);
-  const [pageSize, setPageSize] = React.useState(10);
+  const hasActiveFilters =
+    sifco !== "" ||
+    usuarioNombre !== "" ||
+    inversionistaId !== undefined ||
+    soloAplicados !== undefined ||
+    validationStatusFilter !== "" ||
+    categoriaCredito !== "" ||
+    formatoCredito !== "" ||
+    modoFecha !== "simple" ||
+    fechaInicio !== "" ||
+    fechaFin !== "" ||
+    fechaAplicado !== "" ||
+    fechaBoleta !== "" ||
+    fechaBoletaInicio !== "" ||
+    fechaBoletaFin !== "";
   const { data: cuentas, isLoading: cargandoCuentas } = useCuentasEmpresa();
   const { mutate: actualizarCuenta, isPending: actualizandoCuenta } =
     useActualizarCuentaPago();
@@ -598,33 +610,50 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
               <ListFilter className="w-4 h-4 text-blue-600" />
               <span className="font-bold text-blue-900 text-sm">Filtros</span>
             </div>
-            <button
-              type="button"
-              onClick={() => {
-                setModoFecha("simple");
-                setSifco("");
-                setUsuarioNombre("");
-                setMes(new Date().getMonth() + 1);
-                setAnio(new Date().getFullYear());
-                setDia(new Date().getDate());
-                setFechaInicio("");
-                setFechaFin("");
-                setFechaAplicado("");
-                setFechaBoleta("");
-                setFechaBoletaInicio("");
-                setFechaBoletaFin("");
-                setCategoriaCredito("");
-                setFormatoCredito("");
-                setSoloAplicados(undefined);
-                setInversionistaId(undefined);
-                setQueryInv("");
-                setPage(1);
-              }}
-              className="px-3 py-1.5 rounded-lg text-xs font-semibold text-gray-500 hover:text-red-600 hover:bg-red-50 transition-all flex items-center gap-1.5"
-            >
-              <RotateCcw className="w-3 h-3" />
-              Limpiar
-            </button>
+            {hasActiveFilters && (
+              <button
+                type="button"
+                onClick={() => {
+                  setModoFecha("simple");
+                  setSifco("");
+                  setUsuarioNombre("");
+                  setMes(new Date().getMonth() + 1);
+                  setAnio(new Date().getFullYear());
+                  setDia(new Date().getDate());
+                  setFechaInicio("");
+                  setFechaFin("");
+                  setFechaAplicado("");
+                  setFechaBoleta("");
+                  setFechaBoletaInicio("");
+                  setFechaBoletaFin("");
+                  setCategoriaCredito("");
+                  setFormatoCredito("");
+                  setSoloAplicados(undefined);
+                  setInversionistaId(undefined);
+                  setQueryInv("");
+                  setPage(1);
+                }}
+                className="px-3 py-1.5 rounded-lg text-xs font-semibold text-gray-500 hover:text-red-600 hover:bg-red-50 transition-all flex items-center gap-1.5"
+              >
+                <RotateCcw className="w-3 h-3" />
+                Limpiar filtros
+                <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-xs">
+                  {[
+                    sifco !== "",
+                    usuarioNombre !== "",
+                    inversionistaId !== undefined,
+                    soloAplicados !== undefined,
+                    validationStatusFilter !== "",
+                    categoriaCredito !== "",
+                    formatoCredito !== "",
+                    modoFecha !== "simple",
+                    fechaInicio !== "" || fechaFin !== "",
+                    fechaAplicado !== "",
+                    fechaBoleta !== "" || fechaBoletaInicio !== "" || fechaBoletaFin !== "",
+                  ].filter(Boolean).length}
+                </Badge>
+              </button>
+            )}
           </div>
 
           {/* Grid principal de filtros */}

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -636,6 +636,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                   setFormatoCredito("");
                   setSoloAplicados(undefined);
                   setInversionistaId(undefined);
+                  setValidationStatusFilter("");
                   setQueryInv("");
                   setPage(1);
                 }}

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -284,6 +284,7 @@ export function PaymentsTable() {
   const [page, setPage] = usePersistedState<number>("cartera/pagos/page", 1);
   const [pageSize, setPageSize] = usePersistedState<number>("cartera/pagos/pageSize", 10);
 
+  const today = new Date();
   const hasActiveFilters =
     sifco !== "" ||
     usuarioNombre !== "" ||
@@ -293,6 +294,11 @@ export function PaymentsTable() {
     categoriaCredito !== "" ||
     formatoCredito !== "" ||
     modoFecha !== "simple" ||
+    (modoFecha === "simple" && (
+      mes !== today.getMonth() + 1 ||
+      anio !== today.getFullYear() ||
+      dia !== today.getDate()
+    )) ||
     fechaInicio !== "" ||
     fechaFin !== "" ||
     fechaAplicado !== "" ||
@@ -646,7 +652,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                     validationStatusFilter !== "",
                     categoriaCredito !== "",
                     formatoCredito !== "",
-                    modoFecha !== "simple",
+                    modoFecha !== "simple" || (modoFecha === "simple" && (mes !== today.getMonth() + 1 || anio !== today.getFullYear() || dia !== today.getDate())),
                     fechaInicio !== "" || fechaFin !== "",
                     fechaAplicado !== "",
                     fechaBoleta !== "" || fechaBoletaInicio !== "" || fechaBoletaFin !== "",

--- a/apps/carteraFront/src/private/cartera/components/resumeAdvisor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/resumeAdvisor.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 import {
   Card,
   CardContent,
@@ -7,6 +8,7 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -14,14 +16,16 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
 import { useCreditosPorAsesor } from "../hooks/resumeAdvisor";
 
 export default function CreditosPorAsesorManager() {
-  const [search, setSearch] = useState("");
+  const [search, setSearch] = usePersistedState<string>("cartera/resumeAdvisor/search", "");
   const [openAsesor, setOpenAsesor] = useState<number | null>(null);
   const [openCredito, setOpenCredito] = useState<number | null>(null);
   const { data, isLoading, error, refetch } = useCreditosPorAsesor(search);
+
+  const hasActiveFilters = search !== "";
 
   return (  <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 overflow-auto pt-8 pb-8">
    
@@ -38,6 +42,16 @@ export default function CreditosPorAsesorManager() {
           className="max-w-md border-gray-400 text-gray-900"
         />
         <Button onClick={() => refetch()}>Buscar</Button>
+        {hasActiveFilters && (
+          <Button
+            variant="outline"
+            onClick={() => setSearch("")}
+            className="text-gray-600 border-gray-300 hover:bg-gray-100"
+          >
+            <X className="w-4 h-4 mr-1" /> Limpiar filtros
+            <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">1</Badge>
+          </Button>
+        )}
       </div>
 
       {isLoading && <p className="text-center text-blue-600">Cargando datos...</p>}

--- a/apps/carteraFront/src/private/cartera/hooks/credits.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/credits.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
+import { usePersistedState } from "./usePersistedState";
 import { getCreditosPaginados, type GetCreditosResponse } from "../services/services";
 
 // 🆕 Interfaz para opciones iniciales
@@ -23,27 +24,27 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
   const years = Array.from({ length: 10 }, (_, i) => 2021 + i);
 
   // States
-  const [mes, setMes] = useState(0);
-  const [anio, setAnio] = useState(2025);
-  const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(10);
-  const [creditoSifco, setCreditoSifco] = useState("");
-  const [estado, setEstado] = useState<
+  const [mes, setMes] = usePersistedState<number>("cartera/credits/mes", 0);
+  const [anio, setAnio] = usePersistedState<number>("cartera/credits/anio", 2025);
+  const [page, setPage] = usePersistedState<number>("cartera/credits/page", 1);
+  const [perPage, setPerPage] = usePersistedState<number>("cartera/credits/perPage", 10);
+  const [creditoSifco, setCreditoSifco] = usePersistedState<string>("cartera/credits/creditoSifco", "");
+  const [estado, setEstado] = usePersistedState<
     "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO"
-  >("ACTIVO");
-  // 🆕 Nuevos states para filtros con valor inicial
+  >("cartera/credits/estado", "ACTIVO");
+  // Asesor no se persiste (depende del rol del usuario autenticado)
   const [asesorId, setAsesorId] = useState<number | undefined>(options?.initialAsesorId);
-  
+
   // 🆕 Filtro vehículo propio
-  const [isVehiculoPropio, setIsVehiculoPropio] = useState<boolean | undefined>(undefined);
+  const [isVehiculoPropio, setIsVehiculoPropio] = usePersistedState<boolean | undefined>("cartera/credits/isVehiculoPropio", undefined);
 
   // Filtro por inversionistas (multi-select)
-  const [inversionistaIds, setInversionistaIds] = useState<number[]>([]);
+  const [inversionistaIds, setInversionistaIds] = usePersistedState<number[]>("cartera/credits/inversionistaIds", []);
 
-  // 🔥 Estado local del input (lo que escribe el usuario)
-  const [nombreUsuarioInput, setNombreUsuarioInput] = useState("");
-  // 🔥 Estado que realmente dispara la búsqueda
-  const [nombreUsuario, setNombreUsuario] = useState("");
+  // Estado local del input (lo que escribe el usuario)
+  const [nombreUsuarioInput, setNombreUsuarioInput] = usePersistedState<string>("cartera/credits/nombreUsuarioInput", "");
+  // Estado que realmente dispara la búsqueda
+  const [nombreUsuario, setNombreUsuario] = usePersistedState<string>("cartera/credits/nombreUsuario", "");
 
   // React Query consulta con todos los filtros
   const query = useQuery<GetCreditosResponse, Error>({
@@ -129,7 +130,7 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
     setPage(1);
   };
 
-  // 🆕 Limpiar todos los filtros
+  // Limpiar todos los filtros
   const clearAllFilters = () => {
     setCreditoSifco("");
     setNombreUsuarioInput("");
@@ -137,8 +138,17 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
     setAsesorId(options?.initialAsesorId);
     setIsVehiculoPropio(undefined);
     setInversionistaIds([]);
+    setEstado("ACTIVO");
     setPage(1);
   };
+
+  const hasActiveFilters =
+    creditoSifco !== "" ||
+    nombreUsuario !== "" ||
+    nombreUsuarioInput !== "" ||
+    estado !== "ACTIVO" ||
+    isVehiculoPropio !== undefined ||
+    inversionistaIds.length > 0;
 
   const estados = [
     { value: "ACTIVO", label: "Activo", color: "bg-green-200 text-green-800" },
@@ -192,8 +202,8 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
     setNombreUsuarioInput,     // 👈 Para actualizar el input
     handleSearchNombreUsuario, // 👈 Para ejecutar la búsqueda
     clearNombreUsuario,        // 👈 Para limpiar
-    // 🆕 Limpiar todos
     clearAllFilters,
+    hasActiveFilters,
     // 🆕 Filtro vehículo propio
     isVehiculoPropio,
     setIsVehiculoPropio,

--- a/apps/carteraFront/src/private/cartera/hooks/credits.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/credits.ts
@@ -31,7 +31,8 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
   const [estado, setEstado] = usePersistedState<
     "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO"
   >("cartera/credits/estado", "ACTIVO");
-  const [asesorId, setAsesorId] = usePersistedState<number | undefined>("cartera/credits/asesorId", options?.initialAsesorId);
+  const [asesorIdStored, setAsesorId] = usePersistedState<number | undefined>("cartera/credits/asesorId", options?.initialAsesorId);
+  const asesorId = options?.initialAsesorId !== undefined ? options.initialAsesorId : asesorIdStored;
 
   // 🆕 Filtro vehículo propio
   const [isVehiculoPropio, setIsVehiculoPropio] = usePersistedState<boolean | undefined>("cartera/credits/isVehiculoPropio", undefined);

--- a/apps/carteraFront/src/private/cartera/hooks/credits.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/credits.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
-import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { usePersistedState } from "./usePersistedState";
 import { getCreditosPaginados, type GetCreditosResponse } from "../services/services";
@@ -32,8 +31,7 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
   const [estado, setEstado] = usePersistedState<
     "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO"
   >("cartera/credits/estado", "ACTIVO");
-  // Asesor no se persiste (depende del rol del usuario autenticado)
-  const [asesorId, setAsesorId] = useState<number | undefined>(options?.initialAsesorId);
+  const [asesorId, setAsesorId] = usePersistedState<number | undefined>("cartera/credits/asesorId", options?.initialAsesorId);
 
   // 🆕 Filtro vehículo propio
   const [isVehiculoPropio, setIsVehiculoPropio] = usePersistedState<boolean | undefined>("cartera/credits/isVehiculoPropio", undefined);
@@ -148,7 +146,8 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
     nombreUsuarioInput !== "" ||
     estado !== "ACTIVO" ||
     isVehiculoPropio !== undefined ||
-    inversionistaIds.length > 0;
+    inversionistaIds.length > 0 ||
+    asesorId !== options?.initialAsesorId;
 
   const estados = [
     { value: "ACTIVO", label: "Activo", color: "bg-green-200 text-green-800" },

--- a/apps/carteraFront/src/private/cartera/hooks/usePersistedState.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/usePersistedState.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from "react";
+
+export function usePersistedState<T>(key: string, defaultValue: T) {
+  const [state, setState] = useState<T>(() => {
+    try {
+      const saved = sessionStorage.getItem(key);
+      return saved !== null ? (JSON.parse(saved) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      if (state === undefined || state === null) {
+        sessionStorage.removeItem(key);
+      } else {
+        sessionStorage.setItem(key, JSON.stringify(state));
+      }
+    } catch {}
+  }, [key, state]);
+
+  return [state, setState] as const;
+}

--- a/apps/carteraFront/src/private/recibos-genericos/components/RecibosGenericos.tsx
+++ b/apps/carteraFront/src/private/recibos-genericos/components/RecibosGenericos.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState } from "react";
+import { usePersistedState } from "@/private/cartera/hooks/usePersistedState";
 import { useFormik } from "formik";
 import { toast } from "sonner";
 import {
@@ -19,6 +20,7 @@ import {
 
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { DatePickerMUI } from "@/private/cartera/components/calendar";
 import {
   useRecibosGenericos,
@@ -57,10 +59,10 @@ export function RecibosGenericos() {
   const [confirmDelete, setConfirmDelete] = useState<number | null>(null);
 
   // Filtros de fecha
-  const [fechaDesde, setFechaDesde] = useState("");
-  const [fechaHasta, setFechaHasta] = useState("");
-  const [fechaDesdeFiltro, setFechaDesdeFiltro] = useState("");
-  const [fechaHastaFiltro, setFechaHastaFiltro] = useState("");
+  const [fechaDesde, setFechaDesde] = usePersistedState<string>("cartera/recibosGenericos/fechaDesde", "");
+  const [fechaHasta, setFechaHasta] = usePersistedState<string>("cartera/recibosGenericos/fechaHasta", "");
+  const [fechaDesdeFiltro, setFechaDesdeFiltro] = usePersistedState<string>("cartera/recibosGenericos/fechaDesdeFiltro", "");
+  const [fechaHastaFiltro, setFechaHastaFiltro] = usePersistedState<string>("cartera/recibosGenericos/fechaHastaFiltro", "");
 
   // Hooks
   const { data: recibos, isLoading, refetch } = useRecibosGenericos({
@@ -253,7 +255,10 @@ export function RecibosGenericos() {
               }}
               className="text-gray-600 gap-2"
             >
-              <X className="h-4 w-4" /> Limpiar
+              <X className="h-4 w-4" /> Limpiar filtros
+              <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+                {[fechaDesdeFiltro !== "", fechaHastaFiltro !== ""].filter(Boolean).length}
+              </Badge>
             </Button>
           )}
         </div>


### PR DESCRIPTION
feat(carteraFront): persistir filtros en sessionStorage + botón limpiar filtros

Se implementó persistencia de estado de filtros en todas las páginas de carteraFront
usando sessionStorage. Los filtros ahora sobreviven la navegación entre rutas y un F5,
y se limpian al cerrar la pestaña.

Hook creado:
- usePersistedState<T>(key, defaultValue): reemplaza useState con persistencia en sessionStorage

Archivos modificados:
- hooks/credits.ts: mes, anio, page, perPage, creditoSifco, estado, isVehiculoPropio, inversionistaIds, nombreUsuarioInput, nombreUsuario
- components/CreditsPaymentsData.tsx: botón "Limpiar filtros" + Badge con count
- components/FallenCredits.tsx: page, perPage, sifcoInput, sifcoFilter, fechaDesde, fechaHasta
- components/PagosPorVencimiento.tsx: mes, anio, page, pageSize, tipoFecha, sifco, nombre, selectedAdvisors, rangoMora
- components/resumeAdvisor.tsx: search
- components/SesionesPendientes.tsx: page, search, debouncedSearch
- components/DevolucionCube.tsx: page, searchInput, search
- components/HistorialLiquidaciones.tsx: mes, anio, search, page, estadoFiltro
- components/FacturasGenericas.tsx: page, limit, nit, fechas, tipoFactura
- components/paymentsTable.tsx: modoFecha, mes, anio, dia, fechas, sifco, categoriaCredito, formatoCredito, usuarioNombre, inversionistaId, soloAplicados, validationStatusFilter, page, pageSize
- recibos-genericos/RecibosGenericos.tsx: fechaDesde, fechaHasta y sus filtros aplicados

Patrón aplicado en cada página:
- Botón "Limpiar filtros" visible solo cuando hay filtros activos
- Badge que muestra el número de filtros activos
- Función clearFilters que resetea todos los valores a sus defaults