### PR TITLE
fix: update monto_aportado validation to allow zero values in updateC…

### DIFF
--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -403,7 +403,7 @@ const creditUpdateSchema = z.object({
     .array(
       z.object({
         inversionista_id: z.number().int().positive(),
-        monto_aportado: z.number().positive(),
+        monto_aportado: z.number().nonnegative(),
         porcentaje_cash_in: z.number().min(0).max(100),
         porcentaje_inversion: z.number().min(0).max(100),
         fecha_inicio_participacion: z.string().optional(),


### PR DESCRIPTION
Se actualiza el esquema de validación de inversionistas y espejo para aceptar el valor cero en el campo monto_aportado, cambiando el requerimiento de .positive() a .nonnegative() en el schema de Zod. Esto evita errores de validación cuando un inversionista ya no tiene capital aportado en el crédito.