### PR TITLE
fix: allow non-negative values for monto_aportado in updateCredit con…

### DIFF
--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -778,6 +778,9 @@ export async function reverseConvenioPayment(
     console.log("📊 Monto pendiente nuevo:", nuevoMontoPendienteBig.toString());
 
     // 5. Recalcular cuántas cuotas completas se han pagado
+    if (cuotaMensualBig.eq(0)) {
+      throw new Error("La cuota mensual del convenio es 0, no se puede recalcular");
+    }
     const cuotasCompletasPagadas = nuevoMontoPagadoBig
       .div(cuotaMensualBig)
       .round(0, Big.roundDown);

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -390,7 +390,7 @@ const creditUpdateSchema = z.object({
     .array(
       z.object({
         inversionista_id: z.number().int().positive(),
-        monto_aportado: z.number().positive(),
+        monto_aportado: z.number().nonnegative(),
         porcentaje_cash_in: z.number().min(0).max(100),
         porcentaje_inversion: z.number().min(0).max(100),
         fecha_inicio_participacion: z.string().optional(),

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -696,7 +696,9 @@ const updateInvestors = async (
     console.log(`💵 Capital Total del Crédito: Q${capitalTotal.toFixed(2)}`);
 
     // 🔥 CALCULAR PORCENTAJE DE PARTICIPACIÓN
-    const porcentajeParticipacion = montoAportado.div(capitalTotal).times(100);
+    const porcentajeParticipacion = capitalTotal.gt(0)
+      ? montoAportado.div(capitalTotal).times(100)
+      : new Big(0);
 
     console.log(`\n📐 CÁLCULO DE PARTICIPACIÓN:`);
     console.log(


### PR DESCRIPTION
Se actualiza el esquema de validación de inversionistas y espejo para aceptar el valor cero en el campo monto_aportado, cambiando el requerimiento de .positive() a .nonnegative() en el schema de Zod. Esto evita errores de validación cuando un inversionista ya no tiene capital aportado en el crédito.