### PR TITLE
feat(cartera): refine investor capital display for accepted cessions

### DIFF
--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -272,10 +272,19 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
           if (b.inversionista_id === CUBE_INVESTMENT_ID) return 1;
           return 0;
         })
-        .map((r) => ({
-          inversionista_nombre: r.inversionista_nombre,
-          capital: r.monto.toFixed(2),
-        })),
+        .map((r) => {
+          // Para el inversionista nuevo de la cesión mostramos el delta
+          // (monto que entró en ESTA operación, desde compras_credito_inversionista).
+          // Para inversionistas que no participaron en la cesión (ej. CUBE que
+          // ya estaba) caemos al acumulado del espejo/padre.
+          const montoCesion =
+            montoNuevoPorPar.get(`${c.credito_id}-${r.inversionista_id}`) ??
+            r.monto;
+          return {
+            inversionista_nombre: r.inversionista_nombre,
+            capital: montoCesion.toFixed(2),
+          };
+        }),
     }));
 
     // ── 4.5.1 Apagar bandera_reinversion de los créditos aceptados ──

--- a/apps/cartera-back/src/utils/functions/compraCarteraRecipients.ts
+++ b/apps/cartera-back/src/utils/functions/compraCarteraRecipients.ts
@@ -20,5 +20,8 @@ export const COMPRA_CARTERA_RECIPIENTS = {
     "diego.l@clubcashin.com",
     "guillermo.v@sepresta.com",
     "pablo.z@clubcashin.com",
+    "jalvarado@clubcashin.com",
+    "daniel.r@clubcashin.com",
+    "jalvarez@clubcashin.com"
   ],
 };


### PR DESCRIPTION
For new investors participating in a credit cession, the displayed capital now shows the amount contributed specifically for that operation (delta). Existing investors' capital will continue to reflect their accumulated total.

Adds new recipients to `COMPRA_CARTERA_RECIPIENTS.DEVELOPMENT`.
