### PR TITLE
feat(cobros): CTA para registrar contacto desde la tabla + refactor de columnas

### DIFF
--- a/apps/crm/apps/web/src/components/cobros/contacto-quick-action.tsx
+++ b/apps/crm/apps/web/src/components/cobros/contacto-quick-action.tsx
@@ -1,16 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { Loader2, Phone } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ContactoModal } from "@/components/contacto-modal";
 import { orpc } from "@/utils/orpc";
 
 interface ContactoQuickActionProps {
-	numeroCredito: string;
+	readonly numeroCredito: string;
 }
 
-export function ContactoQuickAction({ numeroCredito }: ContactoQuickActionProps) {
+export function ContactoQuickAction({
+	numeroCredito,
+}: ContactoQuickActionProps) {
 	const [open, setOpen] = useState(false);
 
 	const detalles = useQuery({
@@ -21,10 +23,22 @@ export function ContactoQuickAction({ numeroCredito }: ContactoQuickActionProps)
 		retry: 1,
 	});
 
-	// Si el fetch falla, evitar quedar atrapado en el estado de carga: avisar al
-	// usuario y resetear `open` para que el botón vuelva a estar habilitado.
+	// Detectar errores SOLO al cerrar un ciclo de fetch real (transición
+	// fetching → idle). Sin este gate, un error cacheado en react-query haría
+	// disparar el toast + close instantáneamente al reabrir, atrapando al usuario
+	// en un loop sin posibilidad de reintentar.
+	const fetchCycleStartedRef = useRef(false);
 	useEffect(() => {
-		if (detalles.isError && open) {
+		if (!open) {
+			fetchCycleStartedRef.current = false;
+			return;
+		}
+		if (detalles.isFetching) {
+			fetchCycleStartedRef.current = true;
+			return;
+		}
+		if (fetchCycleStartedRef.current && detalles.isError) {
+			fetchCycleStartedRef.current = false;
 			toast.error(
 				detalles.error instanceof Error
 					? detalles.error.message
@@ -32,7 +46,7 @@ export function ContactoQuickAction({ numeroCredito }: ContactoQuickActionProps)
 			);
 			setOpen(false);
 		}
-	}, [detalles.isError, detalles.error, open]);
+	}, [open, detalles.isFetching, detalles.isError, detalles.error]);
 
 	// Radix Dialog usa un Portal en el DOM, pero React propaga eventos por el
 	// árbol virtual. Sin esto, cualquier click dentro de la modal subiría hasta
@@ -65,11 +79,23 @@ export function ContactoQuickAction({ numeroCredito }: ContactoQuickActionProps)
 	);
 
 	if (!open) {
-		return <span onClick={detenerPropagacion}>{renderBoton(false)}</span>;
+		return (
+			// biome-ignore lint/a11y/useKeyWithClickEvents: wrapper sólo intercepta clicks para evitar que el row-click navegue; el Button interno mantiene accesibilidad de teclado.
+			// biome-ignore lint/a11y/noStaticElementInteractions: wrapper presentacional, sin rol interactivo propio.
+			<span role="none" onClick={detenerPropagacion}>
+				{renderBoton(false)}
+			</span>
+		);
 	}
 
 	if (detalles.isLoading || !detalles.data) {
-		return <span onClick={detenerPropagacion}>{renderBoton(true)}</span>;
+		return (
+			// biome-ignore lint/a11y/useKeyWithClickEvents: wrapper sólo intercepta clicks para evitar que el row-click navegue; el Button interno mantiene accesibilidad de teclado.
+			// biome-ignore lint/a11y/noStaticElementInteractions: wrapper presentacional, sin rol interactivo propio.
+			<span role="none" onClick={detenerPropagacion}>
+				{renderBoton(true)}
+			</span>
+		);
 	}
 
 	const d = detalles.data;
@@ -83,7 +109,9 @@ export function ContactoQuickAction({ numeroCredito }: ContactoQuickActionProps)
 	});
 
 	return (
-		<span onClick={detenerPropagacion}>
+		// biome-ignore lint/a11y/useKeyWithClickEvents: wrapper sólo intercepta clicks dentro del portal de Radix para evitar que el row-click navegue.
+		// biome-ignore lint/a11y/noStaticElementInteractions: wrapper presentacional, sin rol interactivo propio.
+		<span role="none" onClick={detenerPropagacion}>
 			{renderBoton(false)}
 			<ContactoModal
 				open={open}

--- a/apps/crm/apps/web/src/components/cobros/contacto-quick-action.tsx
+++ b/apps/crm/apps/web/src/components/cobros/contacto-quick-action.tsx
@@ -1,0 +1,97 @@
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, Phone } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ContactoModal } from "@/components/contacto-modal";
+import { orpc } from "@/utils/orpc";
+
+interface ContactoQuickActionProps {
+	numeroCredito: string;
+}
+
+export function ContactoQuickAction({ numeroCredito }: ContactoQuickActionProps) {
+	const [open, setOpen] = useState(false);
+
+	const detalles = useQuery({
+		...orpc.getDetallesCreditoCarteraBack.queryOptions({
+			input: { creditoId: numeroCredito },
+		}),
+		enabled: open,
+	});
+
+	// Radix Dialog usa un Portal en el DOM, pero React propaga eventos por el
+	// árbol virtual. Sin esto, cualquier click dentro de la modal subiría hasta
+	// el <TableRow onClick> y navegaría a /cobros/$id.
+	const detenerPropagacion = (e: React.MouseEvent) => {
+		e.stopPropagation();
+	};
+
+	const handleTriggerClick = (e: React.MouseEvent) => {
+		e.stopPropagation();
+		setOpen(true);
+	};
+
+	const renderBoton = (cargando: boolean) => (
+		<Button
+			size="icon"
+			variant="outline"
+			className="h-7 w-7 shrink-0"
+			onClick={cargando ? detenerPropagacion : handleTriggerClick}
+			disabled={cargando}
+			title="Registrar contacto"
+			aria-label="Registrar contacto con el cliente"
+		>
+			{cargando ? (
+				<Loader2 className="h-3.5 w-3.5 animate-spin" />
+			) : (
+				<Phone className="h-3.5 w-3.5" />
+			)}
+		</Button>
+	);
+
+	if (!open) {
+		return <span onClick={detenerPropagacion}>{renderBoton(false)}</span>;
+	}
+
+	if (detalles.isLoading || !detalles.data) {
+		return <span onClick={detenerPropagacion}>{renderBoton(true)}</span>;
+	}
+
+	const d = detalles.data;
+	const marcaLineaModelo =
+		`${d.vehiculoMarca || ""} ${d.vehiculoModelo || ""} ${d.vehiculoYear || ""}`.trim();
+	const montoAdeudado = (
+		Number(d.montoEnMora || 0) + Number(d.cuotaMensual || 0)
+	).toLocaleString("es-GT", {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	});
+
+	return (
+		<span onClick={detenerPropagacion}>
+			{renderBoton(false)}
+			<ContactoModal
+				open={open}
+				onOpenChange={setOpen}
+				casoCobroId={d.id || ""}
+				clienteNombre={d.clienteNombre || ""}
+				telefonoPrincipal={d.telefonoPrincipal || ""}
+				telefonoAlternativo={
+					d.telefonoAlternativo ? String(d.telefonoAlternativo) : undefined
+				}
+				emailCliente={d.emailContacto || ""}
+				metodoInicial="llamada"
+				fechaPago={String(d.diaPagoMensual || 15)}
+				cuotaMensual={Number(d.cuotaMensual || 0).toLocaleString()}
+				placa={d.vehiculoPlaca || ""}
+				marcaLineaModelo={marcaLineaModelo}
+				montoAdeudado={montoAdeudado}
+				cuotasAtraso={d.cuotasVencidas ?? 0}
+				estadoMora={d.estadoMora || undefined}
+				fechaInicio={d.fechaInicio || null}
+				nombreAsesor={d.asesor?.nombre || ""}
+				telefonoAsesor={d.asesor?.telefono || ""}
+			/>
+		</span>
+	);
+}

--- a/apps/crm/apps/web/src/components/cobros/contacto-quick-action.tsx
+++ b/apps/crm/apps/web/src/components/cobros/contacto-quick-action.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Loader2, Phone } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { ContactoModal } from "@/components/contacto-modal";
 import { orpc } from "@/utils/orpc";
@@ -17,7 +18,21 @@ export function ContactoQuickAction({ numeroCredito }: ContactoQuickActionProps)
 			input: { creditoId: numeroCredito },
 		}),
 		enabled: open,
+		retry: 1,
 	});
+
+	// Si el fetch falla, evitar quedar atrapado en el estado de carga: avisar al
+	// usuario y resetear `open` para que el botón vuelva a estar habilitado.
+	useEffect(() => {
+		if (detalles.isError && open) {
+			toast.error(
+				detalles.error instanceof Error
+					? detalles.error.message
+					: "No se pudo cargar el caso. Reintentá.",
+			);
+			setOpen(false);
+		}
+	}, [detalles.isError, detalles.error, open]);
 
 	// Radix Dialog usa un Portal en el DOM, pero React propaga eventos por el
 	// árbol virtual. Sin esto, cualquier click dentro de la modal subiría hasta

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -64,7 +64,10 @@ interface ContactoModalProps {
 	telefonoAlternativo?: string;
 	emailCliente?: string;
 	metodoInicial: "llamada" | "whatsapp" | "email";
-	children: React.ReactNode;
+	children?: React.ReactNode;
+	// Modo controlado opcional (cuando el padre maneja el estado open)
+	open?: boolean;
+	onOpenChange?: (open: boolean) => void;
 	// Variables para plantillas de mensaje
 	fechaPago?: string;
 	cuotaMensual?: string;
@@ -86,6 +89,8 @@ export function ContactoModal({
 	emailCliente,
 	metodoInicial,
 	children,
+	open,
+	onOpenChange,
 	fechaPago = "",
 	cuotaMensual = "",
 	placa = "",
@@ -371,8 +376,8 @@ export function ContactoModal({
 		metodoInicial === "whatsapp" || metodoInicial === "email";
 
 	return (
-		<Dialog>
-			<DialogTrigger asChild>{children}</DialogTrigger>
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			{children && <DialogTrigger asChild>{children}</DialogTrigger>}
 			<DialogContent className="max-h-[90vh] min-w-3xl max-w-4xl overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -2,7 +2,16 @@ import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { ContactoQuickAction } from "@/components/cobros/contacto-quick-action";
 import { parseFechaLocal } from "@/lib/date-utils";
+
+const ESTADOS_MORA_CTA = new Set([
+	"mora_30",
+	"mora_60",
+	"mora_90",
+	"mora_120",
+	"mora_120_plus",
+]);
 
 export type ContratoCobranza = {
 	contratoId: string;
@@ -29,7 +38,7 @@ export type ContratoCobranza = {
 function getEstadoBadge(estado: string) {
 	const colors: Record<string, string> = {
 		al_dia: "bg-green-100 text-green-800",
-		pre_mora: "bg-yellow-50 text-yellow-700 border-yellow-200", // Nuevo: próximo a vencer
+		pre_mora: "bg-yellow-50 text-yellow-700 border-yellow-200",
 		mora_30: "bg-yellow-100 text-yellow-800",
 		mora_60: "bg-orange-100 text-orange-800",
 		mora_90: "bg-red-100 text-red-800",
@@ -84,7 +93,41 @@ const ETIQUETA_COLORS: Record<string, string> = {
 	reclamo: "bg-pink-100 text-pink-800",
 };
 
-export const columns: ColumnDef<ContratoCobranza>[] = [
+// Trunca UUIDs largos al medio (ej: "CRM-935cceeb-b88f-449f-..." → "CRM-935c…5c069").
+// Para strings cortos (≤18 chars) devuelve el original.
+function truncarCredito(numero: string): string {
+	if (numero.length <= 18) return numero;
+	return `${numero.slice(0, 8)}…${numero.slice(-5)}`;
+}
+
+// Detecta vehículos placeholder generados por auto-migrate ("N/A N/A 2000" o "- -").
+function esVehiculoPlaceholder(marca: string, modelo: string): boolean {
+	const m = marca?.trim();
+	const mo = modelo?.trim();
+	return (
+		(m === "N/A" && mo === "N/A") ||
+		(m === "-" && mo === "-") ||
+		(!m && !mo) ||
+		m === "" ||
+		mo === ""
+	);
+}
+
+interface GetColumnsOptions {
+	/**
+	 * Etapa de mora actualmente filtrada en la tabla. Cuando coincide con un
+	 * estado de mora (mora_30/60/90/120+), se muestra el CTA de contacto rápido
+	 * en la primera columna.
+	 */
+	filtroEtapa: string | null;
+}
+
+export function getCobrosColumns({
+	filtroEtapa,
+}: GetColumnsOptions): ColumnDef<ContratoCobranza>[] {
+	const mostrarCtaContacto = !!filtroEtapa && ESTADOS_MORA_CTA.has(filtroEtapa);
+
+	return [
 	{
 		accessorKey: "fechaProximoPago",
 		header: ({ column }) => {
@@ -101,27 +144,21 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 		cell: ({ row }) => {
 			const fecha = row.getValue("fechaProximoPago") as string | null;
 			const dias = row.original.diasHastaPago;
+			const numeroCredito = row.original.numeroCredito;
 
-			if (!fecha) {
-				return (
-					<div className="font-medium text-gray-500">Sin fecha definida</div>
-				);
-			}
-
-			const fechaFormateada = parseFechaLocal(fecha).toLocaleDateString(
-				"es-GT",
-				{
-					day: "2-digit",
-					month: "short",
-					year: "numeric",
-				},
-			);
+			const fechaFormateada = fecha
+				? parseFechaLocal(fecha).toLocaleDateString("es-GT", {
+						day: "2-digit",
+						month: "short",
+						year: "numeric",
+					})
+				: null;
 
 			let diasClassName = "text-xs mt-0.5";
 			let diasText = "";
 
 			if (dias === null) {
-				diasText = "";
+				// sin texto secundario
 			} else if (dias === 0) {
 				diasClassName += " text-red-600 font-semibold";
 				diasText = "¡Hoy!";
@@ -140,9 +177,18 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 			}
 
 			return (
-				<div className="font-medium">
-					<div>{fechaFormateada}</div>
-					{diasText && <div className={diasClassName}>{diasText}</div>}
+				<div className="flex items-center gap-2">
+					<div className="font-medium">
+						{fechaFormateada ? (
+							<div>{fechaFormateada}</div>
+						) : (
+							<div className="text-gray-500">Sin fecha definida</div>
+						)}
+						{diasText && <div className={diasClassName}>{diasText}</div>}
+					</div>
+					{mostrarCtaContacto && numeroCredito && (
+						<ContactoQuickAction numeroCredito={numeroCredito} />
+					)}
 				</div>
 			);
 		},
@@ -155,18 +201,34 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 					variant="ghost"
 					onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
 				>
-					Cliente
+					Cliente / Crédito
 					<ArrowUpDown className="ml-2 h-4 w-4" />
 				</Button>
 			);
 		},
 		cell: ({ row }) => {
+			const nombre = row.getValue("clienteNombre") as string;
+			const numero = row.original.numeroCredito;
+			const isPool = row.original.isPool;
 			return (
-				<div
-					className="w-[350px] whitespace-normal font-medium"
-					style={{ wordBreak: "break-word" }}
-				>
-					{row.getValue("clienteNombre")}
+				<div className="flex min-w-0 max-w-[320px] flex-col gap-0.5">
+					<div className="flex items-center gap-2">
+						<span className="truncate font-medium">{nombre}</span>
+						{isPool && (
+							<Badge
+								variant="secondary"
+								className="shrink-0 bg-indigo-100 text-indigo-800 text-xs"
+							>
+								Pool
+							</Badge>
+						)}
+					</div>
+					<span
+						className="truncate font-mono text-muted-foreground text-xs"
+						title={numero || undefined}
+					>
+						{numero ? truncarCredito(numero) : "—"}
+					</span>
 				</div>
 			);
 		},
@@ -184,56 +246,45 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 		),
 		cell: ({ row }) => {
 			const asesor = row.getValue("responsableCobros") as string | null;
-			if (!asesor) return <span className="text-muted-foreground text-xs">Sin asignar</span>;
+			if (!asesor)
+				return (
+					<span className="text-muted-foreground text-xs">Sin asignar</span>
+				);
 			return <span className="font-medium text-sm">{asesor}</span>;
-		},
-	},
-	{
-		accessorKey: "numeroCredito",
-		header: "No. Crédito",
-		cell: ({ row }) => {
-			const numero = row.getValue("numeroCredito") as string | null;
-			const isPool = row.original.isPool;
-			return (
-				<div
-					className="w-[180px] whitespace-normal font-mono text-sm"
-					style={{ wordBreak: "break-all" }}
-				>
-					{numero || "-"}
-					{isPool && (
-						<Badge
-							variant="secondary"
-							className="ml-2 bg-indigo-100 text-indigo-800"
-						>
-							Pool
-						</Badge>
-					)}
-				</div>
-			);
 		},
 	},
 	{
 		id: "vehiculo",
 		accessorFn: (row) =>
-			`${row.vehiculoMarca} ${row.vehiculoModelo} ${row.vehiculoYear}`,
+			`${row.vehiculoMarca} ${row.vehiculoModelo} ${row.vehiculoYear} ${row.vehiculoPlaca}`,
 		header: "Vehículo",
 		cell: ({ row }) => {
-			return (
-				<div className="font-medium">
-					{row.original.vehiculoMarca} {row.original.vehiculoModelo}{" "}
-					{row.original.vehiculoYear}
-				</div>
+			const { vehiculoMarca, vehiculoModelo, vehiculoYear, vehiculoPlaca } =
+				row.original;
+			const esPlaceholder = esVehiculoPlaceholder(
+				vehiculoMarca,
+				vehiculoModelo,
 			);
-		},
-	},
-	{
-		accessorKey: "vehiculoPlaca",
-		header: "Placa",
-		cell: ({ row }) => {
+			const placaLimpia = vehiculoPlaca?.trim();
+			const tienePlaca = placaLimpia && placaLimpia !== "-" && placaLimpia !== "";
+
+			if (esPlaceholder && !tienePlaca) {
+				return <span className="text-muted-foreground">—</span>;
+			}
+
 			return (
-				<Badge variant="outline" className="font-mono">
-					{row.getValue("vehiculoPlaca")}
-				</Badge>
+				<div className="flex min-w-0 max-w-[180px] flex-col gap-0.5">
+					<span className="whitespace-normal break-words font-medium text-sm leading-tight">
+						{esPlaceholder
+							? "Sin datos"
+							: `${vehiculoMarca} ${vehiculoModelo} ${vehiculoYear ?? ""}`.trim()}
+					</span>
+					{tienePlaca && (
+						<span className="font-mono text-muted-foreground text-xs">
+							{placaLimpia}
+						</span>
+					)}
+				</div>
 			);
 		},
 	},
@@ -263,7 +314,7 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 
 			return (
 				<div
-					className={`font-medium ${monto > 0 ? "text-right" : "text-center"}`}
+					className={`font-medium tabular-nums ${monto > 0 ? "text-right" : "text-center"}`}
 				>
 					{monto > 0 ? formatted : "-"}
 				</div>
@@ -295,7 +346,9 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 			}).format(monto);
 
 			return (
-				<div className={`font-medium ${monto > 0 ? "text-right" : "text-center"}`}>
+				<div
+					className={`font-medium tabular-nums ${monto > 0 ? "text-right" : "text-center"}`}
+				>
 					{monto > 0 ? formatted : "-"}
 				</div>
 			);
@@ -321,7 +374,7 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 		cell: ({ row }) => {
 			const etiquetas = row.original.etiquetas;
 			if (!etiquetas || etiquetas.length === 0)
-				return <span className="text-muted-foreground text-xs">Sin etiquetas</span>;
+				return <span className="text-muted-foreground text-xs">—</span>;
 			return (
 				<div className="flex flex-wrap gap-1">
 					{etiquetas.map((etiqueta) => (
@@ -356,4 +409,8 @@ export const columns: ColumnDef<ContratoCobranza>[] = [
 			return getEstadoBadge(estadoVisual);
 		},
 	},
-];
+	];
+}
+
+// Mantener export legacy para consumidores existentes que no necesiten el CTA.
+export const columns = getCobrosColumns({ filtroEtapa: null });

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -100,17 +100,16 @@ function truncarCredito(numero: string): string {
 	return `${numero.slice(0, 8)}…${numero.slice(-5)}`;
 }
 
-// Detecta vehículos placeholder generados por auto-migrate ("N/A N/A 2000" o "- -").
+// Detecta vehículos placeholder generados por auto-migrate ("N/A N/A 2000" o
+// "- -"). Sólo se considera placeholder cuando AMBOS campos (marca y modelo)
+// son vacíos o sentinelas; filas con datos parciales útiles (ej. marca presente
+// y modelo vacío) se preservan tal cual.
 function esVehiculoPlaceholder(marca: string, modelo: string): boolean {
-	const m = marca?.trim();
-	const mo = modelo?.trim();
-	return (
-		(m === "N/A" && mo === "N/A") ||
-		(m === "-" && mo === "-") ||
-		(!m && !mo) ||
-		m === "" ||
-		mo === ""
-	);
+	const esSentinela = (v: string | null | undefined) => {
+		const t = v?.trim() ?? "";
+		return t === "" || t === "N/A" || t === "-";
+	};
+	return esSentinela(marca) && esSentinela(modelo);
 }
 
 interface GetColumnsOptions {

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -41,7 +41,7 @@ import {
 } from "@/components/ui/collapsible";
 import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
-import { type ContratoCobranza, columns } from "@/lib/cobros/columns";
+import { getCobrosColumns } from "@/lib/cobros/columns";
 import { getPaymentDateRangeFilter } from "@/lib/cobros/payment-date-range-filter";
 import { parseFechaLocal } from "@/lib/date-utils";
 import { PERMISSIONS, ROLES } from "@/lib/roles";
@@ -471,6 +471,13 @@ function RouteComponent() {
 	const creditos = creditosData?.data || [];
 	const totalCreditos = creditosData?.total || 0;
 	const totalPages = creditosData?.totalPages || 1;
+
+	// Recalcular columnas cuando cambia el filtro de etapa: el CTA de contacto
+	// rápido sólo aparece para estados de mora activa.
+	const columns = useMemo(
+		() => getCobrosColumns({ filtroEtapa }),
+		[filtroEtapa],
+	);
 
 	// Procesar creditos y calcular días hasta pago
 	const creditosConDias = useMemo(() => {


### PR DESCRIPTION
## Summary
- **Refactor de la tabla de cobros**: pasa de 10 a 8 columnas. Se fusionan datos relacionados (Cliente + No. Crédito + Pool en una sola celda; Vehículo + Placa en otra), se aplica `tabular-nums` a montos, y los placeholders de vehículo (`N/A N/A 2000`, `- -`) se normalizan a `—`.
- **CTA de contacto rápido**: cuando se filtra por etapa de mora (`mora_30/60/90/120/120+`), aparece un botón 📞 en la celda "Fecha de Pago" que abre la `ContactoModal` directamente desde la tabla, sin tener que navegar al detalle. Hace fetch on-demand vía `getDetallesCreditoCarteraBack` (que crea la `cartera_back_reference` si no existe) y mapea todos los campos requeridos (teléfono, email, vehículo, asesor, plantillas).
- **`ContactoModal` ahora soporta modo controlado** (`open` / `onOpenChange` opcionales) para permitir abrirla programáticamente desde el wrapper.
- **`columns` convertido en factory** `getCobrosColumns({ filtroEtapa })` para condicionar el CTA al filtro activo. Se mantiene `export const columns` legacy para compatibilidad.

## Archivos tocados
- `apps/crm/apps/web/src/components/contacto-modal.tsx` — modo controlado opcional
- `apps/crm/apps/web/src/components/cobros/contacto-quick-action.tsx` — nuevo wrapper
- `apps/crm/apps/web/src/lib/cobros/columns.tsx` — factory + refactor visual
- `apps/crm/apps/web/src/routes/cobros/index.tsx` — usa la factory con `useMemo`

## Detalle técnico clave
El wrapper `ContactoQuickAction` está envuelto en un `<span onClick={detenerPropagacion}>` porque Radix Dialog renderiza el contenido en un Portal del DOM pero React propaga eventos por el árbol virtual — sin este wrapper, cualquier click dentro de la modal subía hasta el `<TableRow onClick>` y disparaba la navegación a `/cobros/$id`.

## Test plan
- [ ] Cargar `/cobros` sin filtro → la tabla muestra 8 columnas, sin scroll horizontal en 1080p
- [ ] Verificar que `Capital` aparece (con `tabular-nums` y sort)
- [ ] Vehículos con datos válidos muestran marca/modelo/año + placa debajo
- [ ] Vehículos placeholder (`N/A N/A 2000` / `- -`) muestran `—`
- [ ] No. de crédito largo (UUID `CRM-...`) se trunca al medio (`CRM-935c…5c069`)
- [ ] Filtrar por `Mora 30` → aparece botón 📞 en cada fila
- [ ] Click en el botón abre la `ContactoModal` con datos del cliente, **sin** redirigir a `/cobros/$id`
- [ ] Click dentro de la modal tampoco redirige
- [ ] Quitar el filtro de mora → el botón desaparece
- [ ] Submit de la modal registra el contacto correctamente y la cierra

🤖 Generated with [Claude Code](https://claude.com/claude-code)