### PR TITLE
Automatización de Seguimientos Recurrentes

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0021_create_seguimientos_programados.sql
+++ b/apps/crm/apps/server/src/db/migrations/0021_create_seguimientos_programados.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "seguimientos_programados" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"caso_cobro_id" uuid NOT NULL,
+	"agente_id" text NOT NULL,
+	"metodo_contacto" "metodo_contacto" NOT NULL,
+	"intervalo_dias" integer NOT NULL,
+	"ocurrencias_maximas" integer,
+	"ocurrencias_realizadas" integer DEFAULT 0 NOT NULL,
+	"fecha_inicio" timestamp NOT NULL,
+	"fecha_fin" timestamp,
+	"preset_original" text,
+	"activo" boolean DEFAULT true,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "intervalo_dias_positive" CHECK ("seguimientos_programados"."intervalo_dias" > 0)
+);
+--> statement-breakpoint
+ALTER TABLE "seguimientos_programados" ADD CONSTRAINT "seguimientos_programados_caso_cobro_id_casos_cobros_id_fk" FOREIGN KEY ("caso_cobro_id") REFERENCES "public"."casos_cobros"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+ALTER TABLE "seguimientos_programados" ADD CONSTRAINT "seguimientos_programados_agente_id_user_id_fk" FOREIGN KEY ("agente_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;

--- a/apps/crm/apps/server/src/db/schema/cobros.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros.ts
@@ -1,5 +1,6 @@
 import {
 	boolean,
+	check,
 	decimal,
 	index,
 	integer,
@@ -9,6 +10,7 @@ import {
 	timestamp,
 	uuid,
 } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { user } from "./auth";
 import { clients } from "./crm";
 import { vehicles } from "./vehicles";
@@ -336,3 +338,26 @@ export const metasMoraCobros = pgTable("metas_mora_cobros", {
 	createdAt: timestamp("created_at").notNull().defaultNow(),
 	updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });
+
+// Seguimientos programados recurrentes para casos de cobros
+export const seguimientosProgramados = pgTable("seguimientos_programados", {
+	id: uuid("id").primaryKey().defaultRandom(),
+	casoCobroId: uuid("caso_cobro_id")
+		.notNull()
+		.references(() => casosCobros.id, { onDelete: "cascade" }),
+	agenteId: text("agente_id")
+		.notNull()
+		.references(() => user.id),
+	metodoContacto: metodoContactoEnum("metodo_contacto").notNull(),
+	intervaloDias: integer("intervalo_dias").notNull(),
+	ocurrenciasMaximas: integer("ocurrencias_maximas"),
+	ocurrenciasRealizadas: integer("ocurrencias_realizadas").notNull().default(0),
+	fechaInicio: timestamp("fecha_inicio").notNull(),
+	fechaFin: timestamp("fecha_fin"),
+	presetOriginal: text("preset_original"),
+	activo: boolean("activo").default(true),
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
+}, (table) => [
+	check("intervalo_dias_positive", sql`${table.intervaloDias} > 0`),
+]);

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1096,10 +1096,18 @@ setTimeout(() => {
 	procesarSeguimientosRecurrentes().catch(console.error);
 }, 10_000);
 
-// ⚠️ TESTING: Ejecutar cada 2 minutos. Revertir a medianoche antes de producción.
-setInterval(async () => {
-	await procesarSeguimientosRecurrentes().catch(console.error);
-}, 2 * 60 * 1000);
+// Ejecutar procesarSeguimientosRecurrentes a medianoche GT (00:00 GT = 06:00 UTC) cada día.
+function scheduleAtMidnightGT() {
+	const now = new Date();
+	const next = new Date();
+	next.setUTCHours(6, 0, 0, 0);
+	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+	setTimeout(async () => {
+		await procesarSeguimientosRecurrentes().catch(console.error);
+		scheduleAtMidnightGT();
+	}, next.getTime() - now.getTime());
+}
+scheduleAtMidnightGT();
 
 
 export default {

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -32,6 +32,7 @@ import { otps } from "./db/schema/otp";
 import {
 	checkCasosSinContacto,
 	checkSeguimientosVencidos,
+	procesarSeguimientosRecurrentes,
 } from "./jobs/cobros-notifications";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
@@ -1092,7 +1093,14 @@ setInterval(
 setTimeout(() => {
 	checkSeguimientosVencidos().catch(console.error);
 	checkCasosSinContacto(3).catch(console.error);
+	procesarSeguimientosRecurrentes().catch(console.error);
 }, 10_000);
+
+// ⚠️ TESTING: Ejecutar cada 2 minutos. Revertir a medianoche antes de producción.
+setInterval(async () => {
+	await procesarSeguimientosRecurrentes().catch(console.error);
+}, 2 * 60 * 1000);
+
 
 export default {
 	port: process.env.PORT || 3000,

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -309,41 +309,31 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 			return;
 		}
 
-		// Query 4: batch update casosCobros.
-		// Excluir seguimientos terminales y deduplicar por casoCobroId.
-		const casoMap = new Map<string, ClaimRow>();
-		for (const r of claimed) {
-			const isTerminal =
-				(r.ocurrenciasMaximas != null && r.newOcurrencias >= r.ocurrenciasMaximas) ||
-				(r.fechaFin != null && r.proximaFecha > r.fechaFin);
-			if (isTerminal) continue;
-			const prev = casoMap.get(r.casoCobroId);
-			if (!prev || r.proximaFecha < prev.proximaFecha) casoMap.set(r.casoCobroId, r);
-		}
-		const uniqueCasoRows = Array.from(casoMap.values());
+		// Query 4: recompute proximo_contacto desde todos los seguimientos activos no-terminales.
+		// Los ocurrencias_realizadas ya actualizados por el CAS son visibles dentro de esta transacción.
+		const affectedCasoIds = [...new Set(claimed.map((r) => r.casoCobroId))];
 
-		if (uniqueCasoRows.length > 0) {
-			const casoParams: unknown[] = [];
-			const casoPh = uniqueCasoRows.map((r, i) => {
-				const b = i * 3;
-				casoParams.push(r.casoCobroId, r.proximaFecha.toISOString(), r.metodoContacto);
-				return `($${b + 1}::uuid, $${b + 2}::timestamptz, $${b + 3}::text)`;
-			}).join(", ");
-
-			await client.query(
-				`UPDATE casos_cobros AS cc
-				 SET proximo_contacto = LEAST(COALESCE(cc.proximo_contacto, v.proximo_contacto), v.proximo_contacto),
-				     metodo_contacto_proximo = CASE
-				         WHEN cc.proximo_contacto IS NULL OR v.proximo_contacto <= cc.proximo_contacto
-				         THEN v.metodo::metodo_contacto
-				         ELSE cc.metodo_contacto_proximo
-				     END,
-				     updated_at = NOW()
-				 FROM (VALUES ${casoPh}) AS v(id, proximo_contacto, metodo)
-				 WHERE cc.id = v.id`,
-				casoParams,
-			);
-		}
+		await client.query(
+			`UPDATE casos_cobros AS cc
+			 SET proximo_contacto = sub.min_fecha,
+			     metodo_contacto_proximo = sub.metodo::metodo_contacto,
+			     updated_at = NOW()
+			 FROM (
+			     SELECT DISTINCT ON (sp.caso_cobro_id)
+			         sp.caso_cobro_id,
+			         sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' AS min_fecha,
+			         sp.metodo_contacto AS metodo
+			     FROM seguimientos_programados sp
+			     WHERE sp.caso_cobro_id = ANY($1::uuid[])
+			       AND sp.activo = true
+			       AND (sp.ocurrencias_maximas IS NULL OR sp.ocurrencias_realizadas < sp.ocurrencias_maximas)
+			       AND (sp.fecha_fin IS NULL OR sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' <= sp.fecha_fin)
+			     ORDER BY sp.caso_cobro_id,
+			              sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' ASC
+			 ) sub
+			 WHERE cc.id = sub.caso_cobro_id`,
+			[affectedCasoIds],
+		);
 
 		// Query 5: batch insert notificaciones como raw SQL para permanecer en la misma transacción.
 		const notifParams: unknown[] = [];

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -251,7 +251,11 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 		// Largest k where fechaInicio + k*intervaloDias <= today
 		const ocurrenciasDebidas = Math.floor(diasTranscurridos / seg.intervaloDias);
 		if (ocurrenciasDebidas >= seg.ocurrenciasRealizadas) {
-			const newOcurrencias = ocurrenciasDebidas + 1;
+			// Acotar al límite máximo: si el scheduler estuvo caído varios intervalos,
+			// ocurrenciasDebidas puede superar ocurrenciasMaximas y disparar una notificación extra.
+			const newOcurrencias = seg.ocurrenciasMaximas != null
+				? Math.min(ocurrenciasDebidas + 1, seg.ocurrenciasMaximas)
+				: ocurrenciasDebidas + 1;
 			// Aritmética en ms — Guatemala no tiene DST.
 			const proximaFecha = new Date(
 				seg.fechaInicio.getTime() + seg.intervaloDias * newOcurrencias * 86_400_000,

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -332,7 +332,7 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 
 			await client.query(
 				`UPDATE casos_cobros AS cc
-				 SET proximo_contacto = LEAST(cc.proximo_contacto, v.proximo_contacto),
+				 SET proximo_contacto = LEAST(COALESCE(cc.proximo_contacto, v.proximo_contacto), v.proximo_contacto),
 				     metodo_contacto_proximo = CASE
 				         WHEN cc.proximo_contacto IS NULL OR v.proximo_contacto <= cc.proximo_contacto
 				         THEN v.metodo::metodo_contacto

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -237,7 +237,7 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 	for (const seg of seguimientos) {
 		// Datos corruptos — check constraint protege rows nuevos; esto cubre legacy.
 		if (seg.intervaloDias <= 0) { toDeactivateIds.push(seg.id); continue; }
-		if (seg.fechaFin && now > seg.fechaFin) { toDeactivateIds.push(seg.id); continue; }
+		if (seg.fechaFin && toDateStrGT(seg.fechaFin) < hoyStr) { toDeactivateIds.push(seg.id); continue; }
 		if (seg.ocurrenciasMaximas != null && seg.ocurrenciasRealizadas >= seg.ocurrenciasMaximas) {
 			toDeactivateIds.push(seg.id); continue;
 		}

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -299,8 +299,18 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 	}
 
 	// Query 4: batch update casosCobros via UPDATE FROM VALUES (1 query vs N)
+	// Deduplicar por casoCobroId: si hay múltiples seguimientos para el mismo caso,
+	// PostgreSQL UPDATE FROM con IDs duplicados en VALUES elige fila de forma no determinista.
+	// Quedarse con la proximaFecha más próxima para cada caso.
+	const casoMap = new Map<string, ClaimRow>();
+	for (const r of claimed) {
+		const prev = casoMap.get(r.casoCobroId);
+		if (!prev || r.proximaFecha < prev.proximaFecha) casoMap.set(r.casoCobroId, r);
+	}
+	const uniqueCasoRows = Array.from(casoMap.values());
+
 	const casoParams: unknown[] = [];
-	const casoPh = claimed.map((r, i) => {
+	const casoPh = uniqueCasoRows.map((r, i) => {
 		const b = i * 3;
 		casoParams.push(r.casoCobroId, r.proximaFecha.toISOString(), r.metodoContacto);
 		return `($${b + 1}::uuid, $${b + 2}::timestamptz, $${b + 3}::text)`;

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -332,8 +332,12 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 
 			await client.query(
 				`UPDATE casos_cobros AS cc
-				 SET proximo_contacto = v.proximo_contacto,
-				     metodo_contacto_proximo = v.metodo::metodo_contacto,
+				 SET proximo_contacto = LEAST(cc.proximo_contacto, v.proximo_contacto),
+				     metodo_contacto_proximo = CASE
+				         WHEN cc.proximo_contacto IS NULL OR v.proximo_contacto <= cc.proximo_contacto
+				         THEN v.metodo::metodo_contacto
+				         ELSE cc.metodo_contacto_proximo
+				     END,
 				     updated_at = NOW()
 				 FROM (VALUES ${casoPh}) AS v(id, proximo_contacto, metodo)
 				 WHERE cc.id = v.id`,

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -276,8 +276,9 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 		return;
 	}
 
-	// Query 3: batch CAS — UPDATE FROM VALUES con guard por ocurrencias_realizadas.
-	// Rows que ya fueron tomados por un runner concurrente no aparecen en RETURNING.
+	// Queries 3-5 en una sola transacción: CAS + update caso + insert notificaciones.
+	// Sin transacción, un fallo entre el CAS y el insert de notificaciones consumía el contador
+	// permanentemente (el siguiente run lo saltaba) sin generar el recordatorio.
 	const casParams: unknown[] = [];
 	const casPh = claimRows.map((r, i) => {
 		const b = i * 3;
@@ -285,73 +286,88 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 		return `($${b + 1}::uuid, $${b + 2}::int, $${b + 3}::int)`;
 	}).join(", ");
 
-	const casResult = await client.query<{ id: string }>(
-		`UPDATE seguimientos_programados AS sp
-		 SET ocurrencias_realizadas = v.new_occ, updated_at = NOW()
-		 FROM (VALUES ${casPh}) AS v(id, old_occ, new_occ)
-		 WHERE sp.id = v.id AND sp.ocurrencias_realizadas = v.old_occ
-		 RETURNING sp.id`,
-		casParams,
-	);
+	let claimed: ClaimRow[] = [];
 
-	const claimedIds = new Set(casResult.rows.map((r) => r.id));
-	const claimed = claimRows.filter((r) => claimedIds.has(r.id));
+	await client.query("BEGIN");
+	try {
+		// Query 3: batch CAS — rows tomados por runner concurrente no aparecen en RETURNING.
+		const casResult = await client.query<{ id: string }>(
+			`UPDATE seguimientos_programados AS sp
+			 SET ocurrencias_realizadas = v.new_occ, updated_at = NOW()
+			 FROM (VALUES ${casPh}) AS v(id, old_occ, new_occ)
+			 WHERE sp.id = v.id AND sp.ocurrencias_realizadas = v.old_occ
+			 RETURNING sp.id`,
+			casParams,
+		);
 
-	if (claimed.length === 0) {
-		console.log("[SeguimientosRecurrentes] 0 claims ganados (runner concurrente los tomó)");
-		return;
-	}
+		const claimedIds = new Set(casResult.rows.map((r) => r.id));
+		claimed = claimRows.filter((r) => claimedIds.has(r.id));
 
-	// Query 4: batch update casosCobros via UPDATE FROM VALUES (1 query vs N)
-	// Excluir seguimientos terminales (la proximaFecha nunca se ejecutará porque el siguiente
-	// job los desactiva antes): ocurrenciasMaximas alcanzadas o proximaFecha más allá de fechaFin.
-	// Deduplicar por casoCobroId para evitar UPDATE no determinista con IDs duplicados en VALUES.
-	const casoMap = new Map<string, ClaimRow>();
-	for (const r of claimed) {
-		const isTerminal =
-			(r.ocurrenciasMaximas != null && r.newOcurrencias >= r.ocurrenciasMaximas) ||
-			(r.fechaFin != null && r.proximaFecha > r.fechaFin);
-		if (isTerminal) continue;
-		const prev = casoMap.get(r.casoCobroId);
-		if (!prev || r.proximaFecha < prev.proximaFecha) casoMap.set(r.casoCobroId, r);
-	}
-	const uniqueCasoRows = Array.from(casoMap.values());
+		if (claimed.length === 0) {
+			await client.query("COMMIT");
+			console.log("[SeguimientosRecurrentes] 0 claims ganados (runner concurrente los tomó)");
+			return;
+		}
 
-	if (uniqueCasoRows.length > 0) {
-		const casoParams: unknown[] = [];
-		const casoPh = uniqueCasoRows.map((r, i) => {
-			const b = i * 3;
-			casoParams.push(r.casoCobroId, r.proximaFecha.toISOString(), r.metodoContacto);
-			return `($${b + 1}::uuid, $${b + 2}::timestamptz, $${b + 3}::text)`;
+		// Query 4: batch update casosCobros.
+		// Excluir seguimientos terminales y deduplicar por casoCobroId.
+		const casoMap = new Map<string, ClaimRow>();
+		for (const r of claimed) {
+			const isTerminal =
+				(r.ocurrenciasMaximas != null && r.newOcurrencias >= r.ocurrenciasMaximas) ||
+				(r.fechaFin != null && r.proximaFecha > r.fechaFin);
+			if (isTerminal) continue;
+			const prev = casoMap.get(r.casoCobroId);
+			if (!prev || r.proximaFecha < prev.proximaFecha) casoMap.set(r.casoCobroId, r);
+		}
+		const uniqueCasoRows = Array.from(casoMap.values());
+
+		if (uniqueCasoRows.length > 0) {
+			const casoParams: unknown[] = [];
+			const casoPh = uniqueCasoRows.map((r, i) => {
+				const b = i * 3;
+				casoParams.push(r.casoCobroId, r.proximaFecha.toISOString(), r.metodoContacto);
+				return `($${b + 1}::uuid, $${b + 2}::timestamptz, $${b + 3}::text)`;
+			}).join(", ");
+
+			await client.query(
+				`UPDATE casos_cobros AS cc
+				 SET proximo_contacto = v.proximo_contacto,
+				     metodo_contacto_proximo = v.metodo::metodo_contacto,
+				     updated_at = NOW()
+				 FROM (VALUES ${casoPh}) AS v(id, proximo_contacto, metodo)
+				 WHERE cc.id = v.id`,
+				casoParams,
+			);
+		}
+
+		// Query 5: batch insert notificaciones como raw SQL para permanecer en la misma transacción.
+		const notifParams: unknown[] = [];
+		const notifPh = claimed.map((r, i) => {
+			const b = i * 11;
+			notifParams.push(
+				"Nuevo seguimiento programado",
+				`Se ha programado automáticamente un contacto vía ${r.metodoContacto} para el crédito ${r.numeroCreditoSifco ?? r.casoCobroId.slice(0, 8)}`,
+				"reminder", "pending",
+				r.agenteId, "cobros", "cobros",
+				r.responsableCobros,
+				"collection_case", r.casoCobroId,
+				"cobros_detail",
+			);
+			return `($${b + 1}::text, $${b + 2}::text, $${b + 3}::notification_type, $${b + 4}::notification_status, $${b + 5}::text, $${b + 6}::user_role, $${b + 7}::user_role, $${b + 8}::text, $${b + 9}::notification_entity_type, $${b + 10}::uuid, $${b + 11}::notification_redirect_page)`;
 		}).join(", ");
 
 		await client.query(
-			`UPDATE casos_cobros AS cc
-			 SET proximo_contacto = v.proximo_contacto,
-			     metodo_contacto_proximo = v.metodo::metodo_contacto,
-			     updated_at = NOW()
-			 FROM (VALUES ${casoPh}) AS v(id, proximo_contacto, metodo)
-			 WHERE cc.id = v.id`,
-			casoParams,
+			`INSERT INTO notifications (titulo, descripcion, type, status, created_by, created_by_role, assigned_to_role, assigned_to, related_entity_type, related_entity_id, redirect_page)
+			 VALUES ${notifPh}`,
+			notifParams,
 		);
-	}
 
-	// Query 5: batch insert notifications (1 query vs N)
-	await db.insert(notifications).values(
-		claimed.map((r) => ({
-			titulo: "Nuevo seguimiento programado" as const,
-			descripcion: `Se ha programado automáticamente un contacto vía ${r.metodoContacto} para el crédito ${r.numeroCreditoSifco ?? r.casoCobroId.slice(0, 8)}`,
-			type: "reminder" as const,
-			status: "pending" as const,
-			createdBy: r.agenteId,
-			createdByRole: "cobros" as const,
-			assignedToRole: "cobros" as const,
-			assignedTo: r.responsableCobros,
-			relatedEntityType: "collection_case" as const,
-			relatedEntityId: r.casoCobroId,
-			redirectPage: "cobros_detail" as const,
-		})),
-	);
+		await client.query("COMMIT");
+	} catch (e) {
+		await client.query("ROLLBACK");
+		throw e;
+	}
 
 	for (const r of claimed) {
 		console.log(`[CobrosNotifications] ✅ Seguimiento disparado para caso ${r.casoCobroId} | próximo contacto: ${toDateStrGT(r.proximaFecha)}`);

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -299,32 +299,38 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 	}
 
 	// Query 4: batch update casosCobros via UPDATE FROM VALUES (1 query vs N)
-	// Deduplicar por casoCobroId: si hay múltiples seguimientos para el mismo caso,
-	// PostgreSQL UPDATE FROM con IDs duplicados en VALUES elige fila de forma no determinista.
-	// Quedarse con la proximaFecha más próxima para cada caso.
+	// Excluir seguimientos terminales (la proximaFecha nunca se ejecutará porque el siguiente
+	// job los desactiva antes): ocurrenciasMaximas alcanzadas o proximaFecha más allá de fechaFin.
+	// Deduplicar por casoCobroId para evitar UPDATE no determinista con IDs duplicados en VALUES.
 	const casoMap = new Map<string, ClaimRow>();
 	for (const r of claimed) {
+		const isTerminal =
+			(r.ocurrenciasMaximas != null && r.newOcurrencias >= r.ocurrenciasMaximas) ||
+			(r.fechaFin != null && r.proximaFecha > r.fechaFin);
+		if (isTerminal) continue;
 		const prev = casoMap.get(r.casoCobroId);
 		if (!prev || r.proximaFecha < prev.proximaFecha) casoMap.set(r.casoCobroId, r);
 	}
 	const uniqueCasoRows = Array.from(casoMap.values());
 
-	const casoParams: unknown[] = [];
-	const casoPh = uniqueCasoRows.map((r, i) => {
-		const b = i * 3;
-		casoParams.push(r.casoCobroId, r.proximaFecha.toISOString(), r.metodoContacto);
-		return `($${b + 1}::uuid, $${b + 2}::timestamptz, $${b + 3}::text)`;
-	}).join(", ");
+	if (uniqueCasoRows.length > 0) {
+		const casoParams: unknown[] = [];
+		const casoPh = uniqueCasoRows.map((r, i) => {
+			const b = i * 3;
+			casoParams.push(r.casoCobroId, r.proximaFecha.toISOString(), r.metodoContacto);
+			return `($${b + 1}::uuid, $${b + 2}::timestamptz, $${b + 3}::text)`;
+		}).join(", ");
 
-	await client.query(
-		`UPDATE casos_cobros AS cc
-		 SET proximo_contacto = v.proximo_contacto,
-		     metodo_contacto_proximo = v.metodo::metodo_contacto,
-		     updated_at = NOW()
-		 FROM (VALUES ${casoPh}) AS v(id, proximo_contacto, metodo)
-		 WHERE cc.id = v.id`,
-		casoParams,
-	);
+		await client.query(
+			`UPDATE casos_cobros AS cc
+			 SET proximo_contacto = v.proximo_contacto,
+			     metodo_contacto_proximo = v.metodo::metodo_contacto,
+			     updated_at = NOW()
+			 FROM (VALUES ${casoPh}) AS v(id, proximo_contacto, metodo)
+			 WHERE cc.id = v.id`,
+			casoParams,
+		);
+	}
 
 	// Query 5: batch insert notifications (1 query vs N)
 	await db.insert(notifications).values(

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -313,23 +313,29 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 		// Los ocurrencias_realizadas ya actualizados por el CAS son visibles dentro de esta transacción.
 		const affectedCasoIds = [...new Set(claimed.map((r) => r.casoCobroId))];
 
+		// LEFT JOIN LATERAL garantiza una fila por caso aunque no queden schedules activos,
+		// forzando proximo_contacto = NULL cuando el último seguimiento llega a terminal.
 		await client.query(
 			`UPDATE casos_cobros AS cc
 			 SET proximo_contacto = sub.min_fecha,
 			     metodo_contacto_proximo = sub.metodo::metodo_contacto,
 			     updated_at = NOW()
 			 FROM (
-			     SELECT DISTINCT ON (sp.caso_cobro_id)
-			         sp.caso_cobro_id,
-			         sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' AS min_fecha,
-			         sp.metodo_contacto AS metodo
-			     FROM seguimientos_programados sp
-			     WHERE sp.caso_cobro_id = ANY($1::uuid[])
-			       AND sp.activo = true
-			       AND (sp.ocurrencias_maximas IS NULL OR sp.ocurrencias_realizadas < sp.ocurrencias_maximas)
-			       AND (sp.fecha_fin IS NULL OR sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' <= sp.fecha_fin)
-			     ORDER BY sp.caso_cobro_id,
-			              sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' ASC
+			     SELECT c.id AS caso_cobro_id,
+			            earliest.min_fecha,
+			            earliest.metodo
+			     FROM unnest($1::uuid[]) AS c(id)
+			     LEFT JOIN LATERAL (
+			         SELECT sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' AS min_fecha,
+			                sp.metodo_contacto AS metodo
+			         FROM seguimientos_programados sp
+			         WHERE sp.caso_cobro_id = c.id
+			           AND sp.activo = true
+			           AND (sp.ocurrencias_maximas IS NULL OR sp.ocurrencias_realizadas < sp.ocurrencias_maximas)
+			           AND (sp.fecha_fin IS NULL OR sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' <= sp.fecha_fin)
+			         ORDER BY sp.fecha_inicio + sp.intervalo_dias * sp.ocurrencias_realizadas * INTERVAL '1 day' ASC
+			         LIMIT 1
+			     ) earliest ON true
 			 ) sub
 			 WHERE cc.id = sub.caso_cobro_id`,
 			[affectedCasoIds],

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -4,12 +4,15 @@
  * - Casos sin contacto por 3+ días
  *
  * Optimizado para batch queries (3 queries fijas por función en vez de N+1)
+ * procesarSeguimientosRecurrentes: 5 queries fijas (era 1+4N)
  */
 
 import { and, eq, gt, inArray, isNotNull, lt, max, sql } from "drizzle-orm";
+
 import { db } from "../db";
-import { casosCobros, contactosCobros } from "../db/schema/cobros";
+import { casosCobros, contactosCobros, seguimientosProgramados } from "../db/schema/cobros";
 import { notifications } from "../db/schema/notifications";
+import { toDateStrGT } from "../lib/guatemala-month-window";
 
 export async function checkSeguimientosVencidos() {
 	const now = new Date();
@@ -165,5 +168,176 @@ export async function checkCasosSinContacto(diasLimite = 3) {
 
 	console.log(
 		`[CobrosNotifications] Casos sin contacto (>${diasLimite} días): ${casosSinContacto.length} encontrados, ${nuevasNotificaciones.length} notificados`,
+	);
+}
+
+// Two-component advisory lock key: namespace=1 (cobros jobs), key=1 (procesarSeguimientosRecurrentes)
+const SEGUIMIENTOS_LOCK = [1, 1] as const;
+
+export async function procesarSeguimientosRecurrentes() {
+	const client = await db.$client.connect();
+	try {
+		const { rows } = await client.query<{ acquired: boolean }>(
+			"SELECT pg_try_advisory_lock($1, $2) AS acquired",
+			[...SEGUIMIENTOS_LOCK],
+		);
+		if (!rows[0].acquired) {
+			console.log("[SeguimientosRecurrentes] Already running (distributed lock held), skipping");
+			return;
+		}
+		await _procesarSeguimientosRecurrentes(client);
+	} finally {
+		await client.query("SELECT pg_advisory_unlock($1, $2)", [...SEGUIMIENTOS_LOCK]);
+		client.release();
+	}
+}
+
+// Minimal interface so we don't need to import pg types directly.
+interface RawClient {
+	query<T extends object>(text: string, values?: unknown[]): Promise<{ rows: T[] }>;
+}
+
+async function _procesarSeguimientosRecurrentes(client: RawClient) {
+	const now = new Date();
+	const hoyStr = toDateStrGT(now);
+	const hoyMs = new Date(`${hoyStr}T00:00:00`).getTime();
+
+	// Query 1: seguimientos activos + caso data en un solo JOIN (elimina per-row SELECT caso)
+	const seguimientos = await db
+		.select({
+			id: seguimientosProgramados.id,
+			casoCobroId: seguimientosProgramados.casoCobroId,
+			fechaInicio: seguimientosProgramados.fechaInicio,
+			fechaFin: seguimientosProgramados.fechaFin,
+			intervaloDias: seguimientosProgramados.intervaloDias,
+			ocurrenciasRealizadas: seguimientosProgramados.ocurrenciasRealizadas,
+			ocurrenciasMaximas: seguimientosProgramados.ocurrenciasMaximas,
+			metodoContacto: seguimientosProgramados.metodoContacto,
+			agenteId: seguimientosProgramados.agenteId,
+			numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+			responsableCobros: casosCobros.responsableCobros,
+		})
+		.from(seguimientosProgramados)
+		.innerJoin(casosCobros, eq(seguimientosProgramados.casoCobroId, casosCobros.id))
+		.where(eq(seguimientosProgramados.activo, true));
+
+	if (seguimientos.length === 0) {
+		console.log("[CobrosNotifications] procesarSeguimientosRecurrentes: 0 seguimientos activos, nada que procesar");
+		return;
+	}
+
+	console.log(`[CobrosNotifications] procesarSeguimientosRecurrentes: ${seguimientos.length} seguimientos activos encontrados`);
+
+	// Categorize in JS — no DB roundtrip per row
+	const toDeactivateIds: string[] = [];
+	type SegRow = typeof seguimientos[number];
+	type ClaimRow = SegRow & { oldOcurrencias: number; newOcurrencias: number; proximaFecha: Date };
+	const claimRows: ClaimRow[] = [];
+
+	for (const seg of seguimientos) {
+		// Datos corruptos — check constraint protege rows nuevos; esto cubre legacy.
+		if (seg.intervaloDias <= 0) { toDeactivateIds.push(seg.id); continue; }
+		if (seg.fechaFin && now > seg.fechaFin) { toDeactivateIds.push(seg.id); continue; }
+		if (seg.ocurrenciasMaximas != null && seg.ocurrenciasRealizadas >= seg.ocurrenciasMaximas) {
+			toDeactivateIds.push(seg.id); continue;
+		}
+
+		// Días transcurridos en zona GT — evita catch-up N-veces si el scheduler estuvo caído.
+		const diasTranscurridos = Math.floor(
+			(hoyMs - new Date(`${toDateStrGT(seg.fechaInicio)}T00:00:00`).getTime()) / 86_400_000,
+		);
+		if (diasTranscurridos < 0) continue;
+
+		// Largest k where fechaInicio + k*intervaloDias <= today
+		const ocurrenciasDebidas = Math.floor(diasTranscurridos / seg.intervaloDias);
+		if (ocurrenciasDebidas >= seg.ocurrenciasRealizadas) {
+			const newOcurrencias = ocurrenciasDebidas + 1;
+			// Aritmética en ms — Guatemala no tiene DST.
+			const proximaFecha = new Date(
+				seg.fechaInicio.getTime() + seg.intervaloDias * newOcurrencias * 86_400_000,
+			);
+			claimRows.push({ ...seg, oldOcurrencias: seg.ocurrenciasRealizadas, newOcurrencias, proximaFecha });
+		}
+	}
+
+	// Query 2: batch deactivate (1 query vs N)
+	if (toDeactivateIds.length > 0) {
+		await db.update(seguimientosProgramados)
+			.set({ activo: false, updatedAt: new Date() })
+			.where(inArray(seguimientosProgramados.id, toDeactivateIds));
+	}
+
+	if (claimRows.length === 0) {
+		console.log(`[SeguimientosRecurrentes] ${toDeactivateIds.length} desactivados, 0 a procesar`);
+		return;
+	}
+
+	// Query 3: batch CAS — UPDATE FROM VALUES con guard por ocurrencias_realizadas.
+	// Rows que ya fueron tomados por un runner concurrente no aparecen en RETURNING.
+	const casParams: unknown[] = [];
+	const casPh = claimRows.map((r, i) => {
+		const b = i * 3;
+		casParams.push(r.id, r.oldOcurrencias, r.newOcurrencias);
+		return `($${b + 1}::uuid, $${b + 2}::int, $${b + 3}::int)`;
+	}).join(", ");
+
+	const casResult = await client.query<{ id: string }>(
+		`UPDATE seguimientos_programados AS sp
+		 SET ocurrencias_realizadas = v.new_occ, updated_at = NOW()
+		 FROM (VALUES ${casPh}) AS v(id, old_occ, new_occ)
+		 WHERE sp.id = v.id AND sp.ocurrencias_realizadas = v.old_occ
+		 RETURNING sp.id`,
+		casParams,
+	);
+
+	const claimedIds = new Set(casResult.rows.map((r) => r.id));
+	const claimed = claimRows.filter((r) => claimedIds.has(r.id));
+
+	if (claimed.length === 0) {
+		console.log("[SeguimientosRecurrentes] 0 claims ganados (runner concurrente los tomó)");
+		return;
+	}
+
+	// Query 4: batch update casosCobros via UPDATE FROM VALUES (1 query vs N)
+	const casoParams: unknown[] = [];
+	const casoPh = claimed.map((r, i) => {
+		const b = i * 3;
+		casoParams.push(r.casoCobroId, r.proximaFecha.toISOString(), r.metodoContacto);
+		return `($${b + 1}::uuid, $${b + 2}::timestamptz, $${b + 3}::text)`;
+	}).join(", ");
+
+	await client.query(
+		`UPDATE casos_cobros AS cc
+		 SET proximo_contacto = v.proximo_contacto,
+		     metodo_contacto_proximo = v.metodo::metodo_contacto,
+		     updated_at = NOW()
+		 FROM (VALUES ${casoPh}) AS v(id, proximo_contacto, metodo)
+		 WHERE cc.id = v.id`,
+		casoParams,
+	);
+
+	// Query 5: batch insert notifications (1 query vs N)
+	await db.insert(notifications).values(
+		claimed.map((r) => ({
+			titulo: "Nuevo seguimiento programado" as const,
+			descripcion: `Se ha programado automáticamente un contacto vía ${r.metodoContacto} para el crédito ${r.numeroCreditoSifco ?? r.casoCobroId.slice(0, 8)}`,
+			type: "reminder" as const,
+			status: "pending" as const,
+			createdBy: r.agenteId,
+			createdByRole: "cobros" as const,
+			assignedToRole: "cobros" as const,
+			assignedTo: r.responsableCobros,
+			relatedEntityType: "collection_case" as const,
+			relatedEntityId: r.casoCobroId,
+			redirectPage: "cobros_detail" as const,
+		})),
+	);
+
+	for (const r of claimed) {
+		console.log(`[CobrosNotifications] ✅ Seguimiento disparado para caso ${r.casoCobroId} | próximo contacto: ${toDateStrGT(r.proximaFecha)}`);
+	}
+
+	console.log(
+		`[SeguimientosRecurrentes] ${toDeactivateIds.length} desactivados, ${claimed.length}/${claimRows.length} procesados`,
 	);
 }

--- a/apps/crm/apps/server/src/lib/guatemala-month-window.ts
+++ b/apps/crm/apps/server/src/lib/guatemala-month-window.ts
@@ -1,5 +1,15 @@
 const GUATEMALA_UTC_OFFSET_HOURS = 6;
 
+/** Retorna la fecha como string YYYY-MM-DD en la zona horaria de Guatemala (UTC-6). */
+export function toDateStrGT(date: Date): string {
+	return new Intl.DateTimeFormat("en-CA", { timeZone: "America/Guatemala" }).format(date);
+}
+
+/** Convierte un string YYYY-MM-DD (día calendario GT) a medianoche GT almacenada como UTC (T06:00:00Z). */
+export function gtDateStrToDate(dateStr: string): Date {
+	return new Date(`${dateStr}T06:00:00.000Z`);
+}
+
 export function getGuatemalaMonthWindow(year: number, month: number) {
 	return {
 		startOfMonth: new Date(

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1780,6 +1780,21 @@ export const cobrosRouter = {
 			try {
 				let numeroSifco: string = input.creditoId ?? "";
 
+				// 0. Si el creditoId es un UUID (viene de una notificación), resolverlo
+				//    al numeroCreditoSifco del caso de cobros antes de consultar cartera-back.
+				const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+				if (UUID_REGEX.test(numeroSifco)) {
+					const [casoPorUUID] = await db
+						.select({ numeroCreditoSifco: casosCobros.numeroCreditoSifco })
+						.from(casosCobros)
+						.where(eq(casosCobros.id, numeroSifco))
+						.limit(1);
+					if (!casoPorUUID?.numeroCreditoSifco) {
+						throw new ORPCError("NOT_FOUND", { message: "Caso no encontrado" });
+					}
+					numeroSifco = casoPorUUID.numeroCreditoSifco;
+				}
+
 				// 1. Buscar referencia por sifco número de crédito
 				let reference = await db
 					.select()

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -23,6 +23,7 @@ import { notificationsRouter } from "./notifications";
 import { quotationsRouter } from "./quotations";
 import { reportesCarteraRouter } from "./reportes-cartera";
 import * as reportsRouter from "./reports";
+import { seguimientosRouter } from "./seguimientos";
 import { uploadRouter } from "./upload";
 import { vehiclesRouter } from "./vehicles";
 import { vendorsRouter } from "./vendors";
@@ -166,6 +167,13 @@ export const cobrosAppRouter = {
 	getMetasMora: cobrosRouter.getMetasMora,
 	getMetasMoraAnual: cobrosRouter.getMetasMoraAnual,
 	upsertMetasMora: cobrosRouter.upsertMetasMora,
+	
+	// Seguimientos programados
+	createSeguimiento: seguimientosRouter.createSeguimiento,
+	getSeguimientosActivos: seguimientosRouter.getSeguimientosActivos,
+	updateSeguimiento: seguimientosRouter.updateSeguimiento,
+	deleteSeguimiento: seguimientosRouter.deleteSeguimiento,
+	runSeguimientosJob: seguimientosRouter.runSeguimientosJob,
 };
 
 /**

--- a/apps/crm/apps/server/src/routers/seguimientos.ts
+++ b/apps/crm/apps/server/src/routers/seguimientos.ts
@@ -81,20 +81,32 @@ export const seguimientosRouter = {
 				.limit(1);
 
 			if (caso) {
-				await db.update(casosCobros)
-					.set({
-						proximoContacto: fechaInicio,
-						metodoContactoProximo: input.metodoContacto,
-						updatedAt: new Date(),
-					})
-					.where(eq(casosCobros.id, input.casoCobroId));
-
-				// Si fechaInicio es exactamente hoy, crear notificación inmediata.
-				// Si es un día futuro, el job nocturno la creará cuando llegue la fecha.
 				const hoyStr = toDateStrGT(new Date());
 				const inicioStr = toDateStrGT(fechaInicio);
-				if (inicioStr === hoyStr) {
-					await Promise.all([
+				const isToday = inicioStr === hoyStr;
+
+				// Solo actualizar proximoContacto si no hay uno previo más temprano.
+				const shouldUpdateProximo =
+					!caso.proximoContacto || fechaInicio < caso.proximoContacto;
+
+				const ops: Promise<unknown>[] = [];
+
+				if (shouldUpdateProximo) {
+					ops.push(
+						db.update(casosCobros)
+							.set({
+								proximoContacto: fechaInicio,
+								metodoContactoProximo: input.metodoContacto,
+								updatedAt: new Date(),
+							})
+							.where(eq(casosCobros.id, input.casoCobroId)),
+					);
+				}
+
+				if (isToday) {
+					// Si fechaInicio es hoy, crear notificación inmediata y marcar ocurrencia 0
+					// como realizada para que el job nocturno no duplique la notificación.
+					ops.push(
 						db.insert(notifications).values({
 							titulo: "Seguimiento programado para hoy",
 							descripcion: `Tienes un contacto vía ${input.metodoContacto} pendiente hoy para el crédito ${caso.numeroCreditoSifco || caso.id.slice(0, 8)}`,
@@ -108,12 +120,13 @@ export const seguimientosRouter = {
 							relatedEntityId: caso.id,
 							redirectPage: "cobros_detail",
 						}),
-						// Marcar ocurrencia 0 como realizada para que el job nocturno no duplique.
 						db.update(seguimientosProgramados)
 							.set({ ocurrenciasRealizadas: 1, updatedAt: new Date() })
 							.where(eq(seguimientosProgramados.id, result[0].id)),
-					]);
+					);
 				}
+
+				if (ops.length > 0) await Promise.all(ops);
 			}
 
 			return result[0];

--- a/apps/crm/apps/server/src/routers/seguimientos.ts
+++ b/apps/crm/apps/server/src/routers/seguimientos.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { db } from "../db";
 import { casosCobros, seguimientosProgramados } from "../db/schema/cobros";
 import { notifications } from "../db/schema/notifications";
-import { cobrosProcedure } from "../lib/orpc";
+import { cobrosProcedure, cobrosSupervisorProcedure } from "../lib/orpc";
 import { procesarSeguimientosRecurrentes } from "../jobs/cobros-notifications";
 import { PERMISSIONS } from "../lib/roles";
 import { gtDateStrToDate, toDateStrGT } from "../lib/guatemala-month-window";
@@ -29,7 +29,7 @@ async function verifyCaseAccess(casoCobroId: string, userId: string, userRole: s
 }
 
 export const seguimientosRouter = {
-	runSeguimientosJob: cobrosProcedure
+	runSeguimientosJob: cobrosSupervisorProcedure
 		.handler(async () => {
 			await procesarSeguimientosRecurrentes();
 			return { success: true };
@@ -94,19 +94,25 @@ export const seguimientosRouter = {
 				const hoyStr = toDateStrGT(new Date());
 				const inicioStr = toDateStrGT(fechaInicio);
 				if (inicioStr === hoyStr) {
-					await db.insert(notifications).values({
-						titulo: "Seguimiento programado para hoy",
-						descripcion: `Tienes un contacto vía ${input.metodoContacto} pendiente hoy para el crédito ${caso.numeroCreditoSifco || caso.id.slice(0, 8)}`,
-						type: "reminder",
-						status: "pending",
-						createdBy: context.userId,
-						createdByRole: "cobros",
-						assignedToRole: "cobros",
-						assignedTo: caso.responsableCobros,
-						relatedEntityType: "collection_case",
-						relatedEntityId: caso.id,
-						redirectPage: "cobros_detail",
-					});
+					await Promise.all([
+						db.insert(notifications).values({
+							titulo: "Seguimiento programado para hoy",
+							descripcion: `Tienes un contacto vía ${input.metodoContacto} pendiente hoy para el crédito ${caso.numeroCreditoSifco || caso.id.slice(0, 8)}`,
+							type: "reminder",
+							status: "pending",
+							createdBy: context.userId,
+							createdByRole: "cobros",
+							assignedToRole: "cobros",
+							assignedTo: caso.responsableCobros,
+							relatedEntityType: "collection_case",
+							relatedEntityId: caso.id,
+							redirectPage: "cobros_detail",
+						}),
+						// Marcar ocurrencia 0 como realizada para que el job nocturno no duplique.
+						db.update(seguimientosProgramados)
+							.set({ ocurrenciasRealizadas: 1, updatedAt: new Date() })
+							.where(eq(seguimientosProgramados.id, result[0].id)),
+					]);
 				}
 			}
 

--- a/apps/crm/apps/server/src/routers/seguimientos.ts
+++ b/apps/crm/apps/server/src/routers/seguimientos.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/server";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { casosCobros, seguimientosProgramados } from "../db/schema/cobros";
@@ -207,6 +207,47 @@ export const seguimientosRouter = {
 				.delete(seguimientosProgramados)
 				.where(eq(seguimientosProgramados.id, input.id))
 				.returning();
+
+			// Recompute proximo_contacto del caso: el seguimiento eliminado podía ser la fuente
+			// del próximo contacto mostrado en la card. Sin actualización, queda una fecha fantasma.
+			const remaining = await db
+				.select({
+					fechaInicio: seguimientosProgramados.fechaInicio,
+					intervaloDias: seguimientosProgramados.intervaloDias,
+					ocurrenciasRealizadas: seguimientosProgramados.ocurrenciasRealizadas,
+					metodoContacto: seguimientosProgramados.metodoContacto,
+				})
+				.from(seguimientosProgramados)
+				.where(
+					and(
+						eq(seguimientosProgramados.casoCobroId, seguimiento.casoCobroId),
+						eq(seguimientosProgramados.activo, true),
+					)
+				)
+				.orderBy(asc(seguimientosProgramados.fechaInicio));
+
+			let nextContacto: Date | null = null;
+			let nextMetodo: string | null = null;
+			for (const seg of remaining) {
+				// Próxima fecha = fechaInicio + intervaloDias * ocurrenciasRealizadas
+				// Cuando ocurrenciasRealizadas=0, nextDate = fechaInicio (podría ser hoy o atrasada).
+				const nextDate = new Date(
+					seg.fechaInicio.getTime() + seg.intervaloDias * seg.ocurrenciasRealizadas * 86_400_000,
+				);
+				if (!nextContacto || nextDate < nextContacto) {
+					nextContacto = nextDate;
+					nextMetodo = seg.metodoContacto;
+				}
+			}
+
+			await db.update(casosCobros)
+				.set({
+					proximoContacto: nextContacto,
+					metodoContactoProximo: nextMetodo as typeof casosCobros.$inferInsert["metodoContactoProximo"],
+					updatedAt: new Date(),
+				})
+				.where(eq(casosCobros.id, seguimiento.casoCobroId));
+
 			return result[0];
 		}),
 };

--- a/apps/crm/apps/server/src/routers/seguimientos.ts
+++ b/apps/crm/apps/server/src/routers/seguimientos.ts
@@ -1,0 +1,193 @@
+import { ORPCError } from "@orpc/server";
+import { and, eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db";
+import { casosCobros, seguimientosProgramados } from "../db/schema/cobros";
+import { notifications } from "../db/schema/notifications";
+import { cobrosProcedure } from "../lib/orpc";
+import { procesarSeguimientosRecurrentes } from "../jobs/cobros-notifications";
+import { PERMISSIONS } from "../lib/roles";
+import { gtDateStrToDate, toDateStrGT } from "../lib/guatemala-month-window";
+
+/** Verifica que el usuario tenga acceso al caso de cobro. Lanza FORBIDDEN si no. */
+async function verifyCaseAccess(casoCobroId: string, userId: string, userRole: string) {
+	const [caso] = await db
+		.select({ id: casosCobros.id, responsableCobros: casosCobros.responsableCobros })
+		.from(casosCobros)
+		.where(eq(casosCobros.id, casoCobroId))
+		.limit(1);
+
+	if (!caso) {
+		throw new ORPCError("NOT_FOUND", { message: "Caso de cobro no encontrado" });
+	}
+
+	if (!PERMISSIONS.canViewAllCasosCobros(userRole) && caso.responsableCobros !== userId) {
+		throw new ORPCError("FORBIDDEN", { message: "No tienes acceso a este caso de cobro" });
+	}
+
+	return caso;
+}
+
+export const seguimientosRouter = {
+	runSeguimientosJob: cobrosProcedure
+		.handler(async () => {
+			await procesarSeguimientosRecurrentes();
+			return { success: true };
+		}),
+
+	createSeguimiento: cobrosProcedure
+		.input(
+			z.object({
+				casoCobroId: z.string().uuid(),
+				metodoContacto: z.enum([
+					"llamada",
+					"whatsapp",
+					"email",
+					"visita_domicilio",
+					"carta_notarial",
+				]),
+				intervaloDias: z.number().int().min(1),
+				ocurrenciasMaximas: z.number().int().optional().nullable(),
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional().nullable(),
+				presetOriginal: z.string().optional().nullable(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			await verifyCaseAccess(input.casoCobroId, context.userId, context.userRole);
+
+			const result = await db
+				.insert(seguimientosProgramados)
+				.values({
+					casoCobroId: input.casoCobroId,
+					agenteId: context.userId,
+					metodoContacto: input.metodoContacto,
+					intervaloDias: input.intervaloDias,
+					ocurrenciasMaximas: input.ocurrenciasMaximas ?? null,
+					fechaInicio: gtDateStrToDate(input.fechaInicio),
+					fechaFin: input.fechaFin ? gtDateStrToDate(input.fechaFin) : null,
+					presetOriginal: input.presetOriginal ?? null,
+				})
+				.returning();
+
+			const fechaInicio = gtDateStrToDate(input.fechaInicio);
+
+			// Actualizar proximoContacto de inmediato con la fechaInicio
+			// para que la card "Próximo Contacto" muestre la fecha sin esperar el job.
+			const [caso] = await db
+				.select()
+				.from(casosCobros)
+				.where(eq(casosCobros.id, input.casoCobroId))
+				.limit(1);
+
+			if (caso) {
+				await db.update(casosCobros)
+					.set({
+						proximoContacto: fechaInicio,
+						metodoContactoProximo: input.metodoContacto,
+						updatedAt: new Date(),
+					})
+					.where(eq(casosCobros.id, input.casoCobroId));
+
+				// Si fechaInicio es exactamente hoy, crear notificación inmediata.
+				// Si es un día futuro, el job nocturno la creará cuando llegue la fecha.
+				const hoyStr = toDateStrGT(new Date());
+				const inicioStr = toDateStrGT(fechaInicio);
+				if (inicioStr === hoyStr) {
+					await db.insert(notifications).values({
+						titulo: "Seguimiento programado para hoy",
+						descripcion: `Tienes un contacto vía ${input.metodoContacto} pendiente hoy para el crédito ${caso.numeroCreditoSifco || caso.id.slice(0, 8)}`,
+						type: "reminder",
+						status: "pending",
+						createdBy: context.userId,
+						createdByRole: "cobros",
+						assignedToRole: "cobros",
+						assignedTo: caso.responsableCobros,
+						relatedEntityType: "collection_case",
+						relatedEntityId: caso.id,
+						redirectPage: "cobros_detail",
+					});
+				}
+			}
+
+			return result[0];
+		}),
+
+	getSeguimientosActivos: cobrosProcedure
+		.input(
+			z.object({
+				casoCobroId: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			await verifyCaseAccess(input.casoCobroId, context.userId, context.userRole);
+
+			const seguimientos = await db
+				.select()
+				.from(seguimientosProgramados)
+				.where(
+					and(
+						eq(seguimientosProgramados.casoCobroId, input.casoCobroId),
+						eq(seguimientosProgramados.activo, true)
+					)
+				);
+			return seguimientos;
+		}),
+
+	updateSeguimiento: cobrosProcedure
+		.input(
+			z.object({
+				id: z.string().uuid(),
+				activo: z.boolean(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			const [seguimiento] = await db
+				.select({ casoCobroId: seguimientosProgramados.casoCobroId })
+				.from(seguimientosProgramados)
+				.where(eq(seguimientosProgramados.id, input.id))
+				.limit(1);
+
+			if (!seguimiento) {
+				throw new ORPCError("NOT_FOUND", { message: "Seguimiento no encontrado" });
+			}
+
+			await verifyCaseAccess(seguimiento.casoCobroId, context.userId, context.userRole);
+
+			const result = await db
+				.update(seguimientosProgramados)
+				.set({
+					activo: input.activo,
+					updatedAt: new Date(),
+				})
+				.where(eq(seguimientosProgramados.id, input.id))
+				.returning();
+			return result[0];
+		}),
+
+	deleteSeguimiento: cobrosProcedure
+		.input(
+			z.object({
+				id: z.string().uuid(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			const [seguimiento] = await db
+				.select({ casoCobroId: seguimientosProgramados.casoCobroId })
+				.from(seguimientosProgramados)
+				.where(eq(seguimientosProgramados.id, input.id))
+				.limit(1);
+
+			if (!seguimiento) {
+				throw new ORPCError("NOT_FOUND", { message: "Seguimiento no encontrado" });
+			}
+
+			await verifyCaseAccess(seguimiento.casoCobroId, context.userId, context.userRole);
+
+			const result = await db
+				.delete(seguimientosProgramados)
+				.where(eq(seguimientosProgramados.id, input.id))
+				.returning();
+			return result[0];
+		}),
+};

--- a/apps/crm/apps/server/src/routers/seguimientos.ts
+++ b/apps/crm/apps/server/src/routers/seguimientos.ts
@@ -13,8 +13,10 @@ async function recomputeProximoContacto(casoCobroId: string) {
 	const remaining = await db
 		.select({
 			fechaInicio: seguimientosProgramados.fechaInicio,
+			fechaFin: seguimientosProgramados.fechaFin,
 			intervaloDias: seguimientosProgramados.intervaloDias,
 			ocurrenciasRealizadas: seguimientosProgramados.ocurrenciasRealizadas,
+			ocurrenciasMaximas: seguimientosProgramados.ocurrenciasMaximas,
 			metodoContacto: seguimientosProgramados.metodoContacto,
 		})
 		.from(seguimientosProgramados)
@@ -32,6 +34,10 @@ async function recomputeProximoContacto(casoCobroId: string) {
 		const nextDate = new Date(
 			seg.fechaInicio.getTime() + seg.intervaloDias * seg.ocurrenciasRealizadas * 86_400_000,
 		);
+		const isTerminal =
+			(seg.ocurrenciasMaximas != null && seg.ocurrenciasRealizadas >= seg.ocurrenciasMaximas) ||
+			(seg.fechaFin != null && nextDate > seg.fechaFin);
+		if (isTerminal) continue;
 		if (!nextContacto || nextDate < nextContacto) {
 			nextContacto = nextDate;
 			nextMetodo = seg.metodoContacto;

--- a/apps/crm/apps/server/src/routers/seguimientos.ts
+++ b/apps/crm/apps/server/src/routers/seguimientos.ts
@@ -9,6 +9,44 @@ import { procesarSeguimientosRecurrentes } from "../jobs/cobros-notifications";
 import { PERMISSIONS } from "../lib/roles";
 import { gtDateStrToDate, toDateStrGT } from "../lib/guatemala-month-window";
 
+async function recomputeProximoContacto(casoCobroId: string) {
+	const remaining = await db
+		.select({
+			fechaInicio: seguimientosProgramados.fechaInicio,
+			intervaloDias: seguimientosProgramados.intervaloDias,
+			ocurrenciasRealizadas: seguimientosProgramados.ocurrenciasRealizadas,
+			metodoContacto: seguimientosProgramados.metodoContacto,
+		})
+		.from(seguimientosProgramados)
+		.where(
+			and(
+				eq(seguimientosProgramados.casoCobroId, casoCobroId),
+				eq(seguimientosProgramados.activo, true),
+			)
+		)
+		.orderBy(asc(seguimientosProgramados.fechaInicio));
+
+	let nextContacto: Date | null = null;
+	let nextMetodo: string | null = null;
+	for (const seg of remaining) {
+		const nextDate = new Date(
+			seg.fechaInicio.getTime() + seg.intervaloDias * seg.ocurrenciasRealizadas * 86_400_000,
+		);
+		if (!nextContacto || nextDate < nextContacto) {
+			nextContacto = nextDate;
+			nextMetodo = seg.metodoContacto;
+		}
+	}
+
+	await db.update(casosCobros)
+		.set({
+			proximoContacto: nextContacto,
+			metodoContactoProximo: nextMetodo as typeof casosCobros.$inferInsert["metodoContactoProximo"],
+			updatedAt: new Date(),
+		})
+		.where(eq(casosCobros.id, casoCobroId));
+}
+
 /** Verifica que el usuario tenga acceso al caso de cobro. Lanza FORBIDDEN si no. */
 async function verifyCaseAccess(casoCobroId: string, userId: string, userRole: string) {
 	const [caso] = await db
@@ -181,6 +219,8 @@ export const seguimientosRouter = {
 				})
 				.where(eq(seguimientosProgramados.id, input.id))
 				.returning();
+
+			await recomputeProximoContacto(seguimiento.casoCobroId);
 			return result[0];
 		}),
 
@@ -208,46 +248,7 @@ export const seguimientosRouter = {
 				.where(eq(seguimientosProgramados.id, input.id))
 				.returning();
 
-			// Recompute proximo_contacto del caso: el seguimiento eliminado podía ser la fuente
-			// del próximo contacto mostrado en la card. Sin actualización, queda una fecha fantasma.
-			const remaining = await db
-				.select({
-					fechaInicio: seguimientosProgramados.fechaInicio,
-					intervaloDias: seguimientosProgramados.intervaloDias,
-					ocurrenciasRealizadas: seguimientosProgramados.ocurrenciasRealizadas,
-					metodoContacto: seguimientosProgramados.metodoContacto,
-				})
-				.from(seguimientosProgramados)
-				.where(
-					and(
-						eq(seguimientosProgramados.casoCobroId, seguimiento.casoCobroId),
-						eq(seguimientosProgramados.activo, true),
-					)
-				)
-				.orderBy(asc(seguimientosProgramados.fechaInicio));
-
-			let nextContacto: Date | null = null;
-			let nextMetodo: string | null = null;
-			for (const seg of remaining) {
-				// Próxima fecha = fechaInicio + intervaloDias * ocurrenciasRealizadas
-				// Cuando ocurrenciasRealizadas=0, nextDate = fechaInicio (podría ser hoy o atrasada).
-				const nextDate = new Date(
-					seg.fechaInicio.getTime() + seg.intervaloDias * seg.ocurrenciasRealizadas * 86_400_000,
-				);
-				if (!nextContacto || nextDate < nextContacto) {
-					nextContacto = nextDate;
-					nextMetodo = seg.metodoContacto;
-				}
-			}
-
-			await db.update(casosCobros)
-				.set({
-					proximoContacto: nextContacto,
-					metodoContactoProximo: nextMetodo as typeof casosCobros.$inferInsert["metodoContactoProximo"],
-					updatedAt: new Date(),
-				})
-				.where(eq(casosCobros.id, seguimiento.casoCobroId));
-
+			await recomputeProximoContacto(seguimiento.casoCobroId);
 			return result[0];
 		}),
 };

--- a/apps/crm/apps/web/src/components/cobros/seguimiento-recurrente-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/seguimiento-recurrente-modal.tsx
@@ -1,0 +1,169 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { client, orpc } from "@/utils/orpc";
+import { DatePicker } from "@/components/ui/react-datepicker";
+
+function toLocalDateStr(date: Date): string {
+	return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}-${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export interface SeguimientoRecurrenteModalProps {
+	isOpen: boolean;
+	onClose: () => void;
+	casoCobroId: string;
+}
+
+export function SeguimientoRecurrenteModal({
+	isOpen,
+	onClose,
+	casoCobroId,
+}: SeguimientoRecurrenteModalProps) {
+	const queryClient = useQueryClient();
+
+	const [preset, setPreset] = useState<string>("diario");
+	const [metodo, setMetodo] = useState<
+		"llamada" | "whatsapp" | "email" | "visita_domicilio" | "carta_notarial"
+	>("llamada");
+	const [customInterval, setCustomInterval] = useState<number>(1);
+	const [fechaInicio, setFechaInicio] = useState<Date | undefined>(new Date());
+	const [fechaFin, setFechaFin] = useState<Date | undefined>(undefined);
+
+	const createMutation = useMutation({
+		mutationFn: async (data: any) => client.createSeguimiento(data),
+		onSuccess: () => {
+			toast.success("Seguimiento recurrente programado exitosamente");
+			queryClient.invalidateQueries(
+				orpc.getSeguimientosActivos.queryOptions({
+					input: { casoCobroId },
+				}),
+			);
+			onClose();
+		},
+		onError: (error: any) => {
+			toast.error(error.message || "Error al programar el seguimiento");
+		},
+	});
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+
+		let intervaloDias = 1;
+		if (preset === "diario") intervaloDias = 1;
+		else if (preset === "semanal") intervaloDias = 7;
+		else if (preset === "quincenal") intervaloDias = 15;
+		else if (preset === "custom") intervaloDias = customInterval;
+
+		const payload = {
+			casoCobroId,
+			metodoContacto: metodo,
+			intervaloDias,
+			ocurrenciasMaximas: null,
+			fechaInicio: toLocalDateStr(fechaInicio ?? new Date()),
+			fechaFin: fechaFin ? toLocalDateStr(fechaFin) : null,
+			presetOriginal: preset,
+		};
+
+		createMutation.mutate(payload);
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+			<DialogContent className="sm:max-w-[425px]">
+				<DialogHeader>
+					<DialogTitle>Programar Seguimiento Recurrente</DialogTitle>
+					<DialogDescription>
+						Automatiza los recordatorios y contactos periódicos para este caso.
+					</DialogDescription>
+				</DialogHeader>
+				<form onSubmit={handleSubmit} className="space-y-4 pt-4">
+					<div className="space-y-2">
+						<Label>Frecuencia</Label>
+						<Select value={preset} onValueChange={setPreset}>
+							<SelectTrigger>
+								<SelectValue placeholder="Seleccione una frecuencia" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="diario">Diario</SelectItem>
+								<SelectItem value="semanal">Semanal</SelectItem>
+								<SelectItem value="quincenal">Quincenal</SelectItem>
+								<SelectItem value="custom">Personalizado (N días)</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+
+					{preset === "custom" && (
+						<div className="space-y-2">
+							<Label>Intervalo (Días)</Label>
+							<Input
+								type="number"
+								min={1}
+								value={customInterval}
+								onChange={(e) => setCustomInterval(Number(e.target.value))}
+							/>
+						</div>
+					)}
+
+					<div className="space-y-2">
+						<Label>Método de Contacto</Label>
+						<Select value={metodo} onValueChange={(val: any) => setMetodo(val)}>
+							<SelectTrigger>
+								<SelectValue placeholder="Método" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="llamada">Llamada</SelectItem>
+								<SelectItem value="whatsapp">WhatsApp</SelectItem>
+								<SelectItem value="email">Email</SelectItem>
+								<SelectItem value="visita_domicilio">Visita a Domicilio</SelectItem>
+								<SelectItem value="carta_notarial">Carta Notarial</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="space-y-2">
+						<Label>Fecha de Inicio</Label>
+						<DatePicker
+							date={fechaInicio}
+							onDateChange={setFechaInicio}
+						/>
+					</div>
+
+
+					<div className="space-y-2">
+						<Label>Fecha Final</Label>
+						<DatePicker
+							date={fechaFin}
+							onDateChange={setFechaFin}
+							placeholder="Seleccione fecha de finalización"
+						/>
+					</div>
+
+					<div className="flex justify-end gap-2 pt-4">
+						<Button type="button" variant="outline" onClick={onClose}>
+							Cancelar
+						</Button>
+						<Button type="submit" disabled={createMutation.isPending}>
+							{createMutation.isPending ? "Guardando..." : "Programar"}
+						</Button>
+					</div>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/crm/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/crm/apps/web/src/components/ui/alert-dialog.tsx
@@ -141,6 +141,7 @@ function AlertDialogCancel({
 
 export {
 	AlertDialog,
+	AlertDialogTrigger,
 	AlertDialogContent,
 	AlertDialogHeader,
 	AlertDialogFooter,

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -11,6 +11,7 @@ import {
 	Clock,
 	Eye,
 	FileText,
+	Loader,
 	Mail,
 	MapPin,
 	MessageCircle,
@@ -21,15 +22,28 @@ import {
 	User,
 	Users,
 	X,
+	Play,
 } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import { ReferenciasView } from "@/components/cobros/ReferenciasView";
 import { ContactoModal } from "@/components/contacto-modal";
+import { SeguimientoRecurrenteModal } from "@/components/cobros/seguimiento-recurrente-modal";
 import {
 	OpportunityDetailModal,
 	type OpportunityForModal,
 } from "@/components/opportunity-detail-modal";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+	AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -184,6 +198,9 @@ function RouteComponent() {
 		emailContacto: "",
 	});
 
+	// Estado modal seguimiento
+	const [isSeguimientoModalOpen, setIsSeguimientoModalOpen] = useState(false);
+
 	const queryClient = useQueryClient();
 
 	// Obtener detalles del contrato/caso
@@ -198,6 +215,14 @@ function RouteComponent() {
 	// Obtener historial de contactos (solo para casos)
 	const historialContactos = useQuery({
 		...orpc.getHistorialContactos.queryOptions({
+			input: { casoCobroId: casoDetails.data?.id || "" },
+		}),
+		enabled: !!session && !!casoDetails.data?.id,
+	});
+
+	// Obtener seguimientos activos
+	const seguimientosActivos = useQuery({
+		...orpc.getSeguimientosActivos.queryOptions({
 			input: { casoCobroId: casoDetails.data?.id || "" },
 		}),
 		enabled: !!session && !!casoDetails.data?.id,
@@ -353,6 +378,39 @@ function RouteComponent() {
 		},
 		onError: (err: any) => {
 			toast.error(err.message || "Error al actualizar contacto");
+		},
+	});
+
+	const cancelSeguimientoMutation = useMutation({
+		mutationFn: (seguimientoId: string) =>
+			client.deleteSeguimiento({ id: seguimientoId }),
+		onSuccess: () => {
+			toast.success("Seguimiento eliminado");
+			queryClient.invalidateQueries(
+				orpc.getSeguimientosActivos.queryOptions({
+					input: { casoCobroId: casoDetails.data?.id || "" },
+				}),
+			);
+		},
+		onError: (err: any) => {
+			toast.error(err.message || "Error al cancelar seguimiento");
+		},
+	});
+
+	const runJobMutation = useMutation({
+		mutationFn: () => client.runSeguimientosJob(),
+		onSuccess: () => {
+			toast.success("Job de seguimientos ejecutado exitosamente");
+			const casoCobroId = casoDetails.data?.id || "";
+			queryClient.invalidateQueries(
+				orpc.getSeguimientosActivos.queryOptions({ input: { casoCobroId } }),
+			);
+			queryClient.invalidateQueries(
+				orpc.getHistorialContactos.queryOptions({ input: { casoCobroId } }),
+			);
+		},
+		onError: (err: any) => {
+			toast.error(err.message || "Error al ejecutar el job");
 		},
 	});
 
@@ -1044,6 +1102,7 @@ function RouteComponent() {
 											</Button>
 										</ContactoModal>
 									</div>
+
 								</>
 							) : (
 								<div className="rounded-md border border-yellow-200 bg-yellow-50 p-4">
@@ -1056,6 +1115,109 @@ function RouteComponent() {
 							)}
 						</CardContent>
 					</Card>
+
+					{/* Seguimientos Recurrentes */}
+					{caso.id && (
+						<Card className="border-blue-100/40 dark:border-blue-900/10">
+							<CardHeader className="flex flex-row items-center justify-between py-4">
+								<CardTitle className="flex items-center gap-2 text-sm font-semibold text-blue-800 dark:text-blue-400">
+									<CalendarClock className="h-4 w-4" />
+									Seguimiento Programado
+								</CardTitle>
+								<div className="flex items-center gap-2">
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-8 w-8 p-0 text-blue-600 border-blue-200 hover:bg-blue-50 hover:text-blue-700"
+										title="Ejecutar Job de Seguimientos Ahora"
+										onClick={() => runJobMutation.mutate()}
+										disabled={runJobMutation.isPending}
+									>
+										<Play className={`h-4 w-4 ${runJobMutation.isPending ? "animate-pulse" : ""}`} />
+									</Button>
+									<Button
+										variant="secondary"
+										size="sm"
+										className="h-8 flex items-center gap-2"
+										onClick={() => setIsSeguimientoModalOpen(true)}
+									>
+										<CalendarClock className="h-4 w-4" />
+										Programar
+									</Button>
+								</div>
+							</CardHeader>
+							<CardContent className="pb-4">
+								{seguimientosActivos.isLoading ? (
+									<div className="flex justify-center py-4">
+										<Loader className="h-4 w-4 animate-spin text-muted-foreground" />
+									</div>
+								) : seguimientosActivos.data?.length === 0 ? (
+									<p className="text-sm text-muted-foreground py-2 italic">
+										No hay seguimientos activos programados.
+									</p>
+								) : (
+									<div className="space-y-2">
+										{seguimientosActivos.data?.map((seg: any) => (
+											<div
+												key={seg.id}
+												className="flex items-center justify-between p-2.5 rounded-md border bg-muted/30 transition-colors hover:bg-muted/50"
+											>
+												<div className="flex items-center gap-3">
+													<div className="p-1.5 rounded-full bg-background border">
+														{getMetodoIcon(seg.metodoContacto)}
+													</div>
+													<div className="flex flex-col">
+														<span className="text-sm font-medium capitalize leading-none">
+															{seg.presetOriginal !== "custom"
+																? seg.presetOriginal
+																: `Cada ${seg.intervaloDias} días`}
+														</span>
+														<span className="text-[10px] text-muted-foreground uppercase mt-1">
+															{seg.metodoContacto.replace("_", " ")}
+														</span>
+													</div>
+												</div>
+												<AlertDialog>
+													<AlertDialogTrigger asChild>
+														<Button
+															variant="ghost"
+															size="sm"
+															className="h-7 w-7 p-0 text-muted-foreground hover:text-red-500"
+														>
+															<X className="h-4 w-4" />
+														</Button>
+													</AlertDialogTrigger>
+													<AlertDialogContent>
+														<AlertDialogHeader>
+															<AlertDialogTitle>¿Eliminar seguimiento?</AlertDialogTitle>
+															<AlertDialogDescription>
+																Esta acción eliminará el seguimiento programado permanentemente. No se generarán más notificaciones para este recordatorio.
+															</AlertDialogDescription>
+														</AlertDialogHeader>
+														<AlertDialogFooter>
+															<AlertDialogCancel>Cancelar</AlertDialogCancel>
+															<AlertDialogAction
+																onClick={() => cancelSeguimientoMutation.mutate(seg.id)}
+																className="bg-red-600 hover:bg-red-700 text-white"
+															>
+																Eliminar
+															</AlertDialogAction>
+														</AlertDialogFooter>
+													</AlertDialogContent>
+												</AlertDialog>
+											</div>
+										))}
+									</div>
+								)}
+							</CardContent>
+						</Card>
+					)}
+
+					<SeguimientoRecurrenteModal
+						isOpen={isSeguimientoModalOpen}
+						onClose={() => setIsSeguimientoModalOpen(false)}
+						casoCobroId={caso.id}
+					/>
 
 					{/* Referencias */}
 					{matchingOpportunity?.lead?.id && (

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -165,6 +165,7 @@ const REDIRECT_CONFIG: Record<
 		getRoute: (id) => ({
 			to: "/cobros/$id",
 			params: { id },
+			search: { tipo: "caso" },
 		}),
 	},
 };


### PR DESCRIPTION
## feat(cobros): Automatización de Seguimientos Recurrentes

### ¿Qué hace este PR?
Implementa el sistema de **seguimientos de cobranza programados y recurrentes** en el backend del CRM.

### Cambios principales

#### Schema (`schema/cobros.ts`)
- Nueva tabla `seguimientos_programados` con campos: `casoCobroId`, `agenteId`, `metodoContacto`, `intervaloDias`, `fechaInicio`, `fechaFin`, `ocurrenciasMaximas`, `ocurrenciasRealizadas`, `presetOriginal`, `activo`.

#### Router (`routers/seguimientos.ts`)
- `createSeguimiento`: crea el seguimiento, actualiza `proximoContacto` de inmediato y genera una notificación si `fechaInicio` es hoy.
- `getSeguimientosActivos`: lista los seguimientos activos por caso.
- `deleteSeguimiento`: elimina un seguimiento.
- `runSeguimientosJob`: endpoint manual para disparar el job (solo para testing/admin).

#### Job nocturno (`jobs/cobros-notifications.ts`)
- `procesarSeguimientosRecurrentes`: corre a medianoche todos los días.
  - Calcula la fecha teórica de cada seguimiento: `fechaInicio + intervaloDias * ocurrenciasRealizadas`.
  - Si la fecha ya llegó: actualiza `proximoContacto` al siguiente ciclo, crea notificación `reminder` al responsable e incrementa `ocurrenciasRealizadas`.
  - Desactiva automáticamente seguimientos que superaron `fechaFin` u `ocurrenciasMaximas`.
  - Todas las comparaciones de fecha usan `America/Guatemala` (UTC-6) vía `Intl.DateTimeFormat`.

#### Scheduler (`index.ts`)
- Registra `scheduleRecurrentes()` para ejecutar el job diario a medianoche.
- Corre una primera ejecución al arrancar (10s de delay).

#### Fix (`routers/cobros.ts`)
- `getDetallesCreditoCarteraBack` ahora resuelve UUIDs: si recibe un UUID (desde una notificación) busca el SIFCO en `casosCobros` antes de consultar cartera-back, eliminando el error 404/500 al navegar desde notificaciones.

### Notas técnicas
- Las notificaciones guardan `caso.id` (UUID) en `relatedEntityId` — el frontend resuelve el SIFCO dinámicamente.
- No hay riesgo de duplicados: el contador `ocurrenciasRealizadas` garantiza que cada ciclo se ejecute una sola vez por día.
