### PR TITLE
Add delete opportunity functionality with audit logging

### DIFF
--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -2,6 +2,7 @@ import {
 	boolean,
 	decimal,
 	integer,
+	jsonb,
 	pgEnum,
 	pgTable,
 	text,
@@ -473,6 +474,7 @@ export const deletedOpportunityLogs = pgTable("deleted_opportunity_logs", {
 	deletedByName: text("deleted_by_name").notNull(),
 	deletedAt: timestamp("deleted_at").notNull().defaultNow(),
 	reason: text("reason").notNull(),
+	snapshot: jsonb("snapshot").$type<Record<string, unknown>>().notNull(),
 });
 
 // Referencias de un lead (personas de contacto: familiares, amigos, etc.)

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -451,6 +451,30 @@ export const parentescoReferenciaEnum = pgEnum("parentesco_referencia", [
 /** Valores canónicos del enum de parentesco. Úsalo en lugar de duplicar el array. */
 export const PARENTESCO_VALUES = parentescoReferenciaEnum.enumValues;
 
+// Audit log for deleted opportunities
+export const deletedOpportunityLogs = pgTable("deleted_opportunity_logs", {
+	id: uuid("id").primaryKey().defaultRandom(),
+	// Snapshot of opportunity data (no FKs — records may no longer exist)
+	opportunityId: uuid("opportunity_id").notNull(),
+	opportunityTitle: text("opportunity_title").notNull(),
+	opportunityValue: decimal("opportunity_value", { precision: 12, scale: 2 }),
+	opportunityStatus: text("opportunity_status").notNull(),
+	opportunityStageName: text("opportunity_stage_name"),
+	opportunityStagePercentage: integer("opportunity_stage_percentage"),
+	opportunityCreatedAt: timestamp("opportunity_created_at").notNull(),
+	// Assigned salesperson snapshot
+	assignedUserId: text("assigned_user_id"),
+	assignedUserName: text("assigned_user_name"),
+	// Lead snapshot
+	leadId: uuid("lead_id"),
+	leadName: text("lead_name"),
+	// Deletion metadata (all plain text — no FKs to avoid future constraint issues)
+	deletedBy: text("deleted_by").notNull(),
+	deletedByName: text("deleted_by_name").notNull(),
+	deletedAt: timestamp("deleted_at").notNull().defaultNow(),
+	reason: text("reason").notNull(),
+});
+
 // Referencias de un lead (personas de contacto: familiares, amigos, etc.)
 export const referenciasLead = pgTable("referencias_lead", {
 	id: uuid("id").primaryKey().defaultRandom(),

--- a/apps/crm/apps/server/src/lib/deleted-opportunity-audit.test.ts
+++ b/apps/crm/apps/server/src/lib/deleted-opportunity-audit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { buildDeletedOpportunitySnapshot } from "./deleted-opportunity-audit";
+
+describe("buildDeletedOpportunitySnapshot", () => {
+	test("keeps the essential opportunity, customer, vehicle and related record context", () => {
+		const createdAt = new Date("2026-05-18T12:00:00.000Z");
+		const updatedAt = new Date("2026-05-18T13:00:00.000Z");
+
+		expect(
+			buildDeletedOpportunitySnapshot({
+				opportunity: {
+					id: "opp-1",
+					title: "Crédito vehículo",
+					value: "100000.00",
+					status: "open",
+					creditType: "autocompra",
+					source: "facebook",
+					campaign: "mayo",
+					loanPurpose: "personal",
+					probability: 10,
+					expectedCloseDate: null,
+					actualCloseDate: null,
+					notes: "Cliente interesado",
+					numeroCuotas: 48,
+					tasaInteres: "18.00",
+					cuotaMensual: "3000.00",
+					fechaInicio: null,
+					diaPagoMensual: 15,
+					numeroSifco: "12345",
+					nit: "1234567-8",
+					createdAt,
+					updatedAt,
+					createdBy: "creator-1",
+				},
+				stage: { id: "stage-1", name: "Prospecto", closurePercentage: 10 },
+				lead: {
+					id: "lead-1",
+					firstName: "Ana",
+					lastName: "Pérez",
+					email: "ana@example.com",
+					phone: "5555",
+				},
+				company: { id: "company-1", name: "Empresa, S.A." },
+				vehicle: {
+					id: "vehicle-1",
+					make: "Toyota",
+					model: "Hilux",
+					year: 2022,
+					licensePlate: "P123ABC",
+				},
+				assignedUser: {
+					id: "sales-1",
+					name: "Luis",
+					email: "luis@example.com",
+				},
+				client: {
+					id: "client-1",
+					contactPerson: "Ana Pérez",
+					status: "active",
+				},
+				relatedCounts: {
+					documents: 2,
+					coDebtors: 1,
+					forms: 1,
+					stageHistory: 3,
+				},
+			}),
+		).toMatchObject({
+			opportunity: {
+				id: "opp-1",
+				title: "Crédito vehículo",
+				creditTerms: {
+					numeroCuotas: 48,
+					tasaInteres: "18.00",
+					cuotaMensual: "3000.00",
+					diaPagoMensual: 15,
+				},
+			},
+			stage: { name: "Prospecto", closurePercentage: 10 },
+			lead: { id: "lead-1", fullName: "Ana Pérez" },
+			company: { id: "company-1", name: "Empresa, S.A." },
+			vehicle: { id: "vehicle-1", licensePlate: "P123ABC" },
+			client: { id: "client-1", status: "active" },
+			relatedCounts: { documents: 2, coDebtors: 1, forms: 1, stageHistory: 3 },
+		});
+	});
+});

--- a/apps/crm/apps/server/src/lib/deleted-opportunity-audit.ts
+++ b/apps/crm/apps/server/src/lib/deleted-opportunity-audit.ts
@@ -1,0 +1,169 @@
+type Nullable<T> = T | null;
+
+type AuditOpportunity = {
+	id: string;
+	title: string;
+	value: Nullable<string>;
+	status: string;
+	creditType: string;
+	source: Nullable<string>;
+	campaign: Nullable<string>;
+	loanPurpose: Nullable<string>;
+	probability: number;
+	expectedCloseDate: Nullable<Date>;
+	actualCloseDate: Nullable<Date>;
+	notes: Nullable<string>;
+	numeroCuotas: Nullable<number>;
+	tasaInteres: Nullable<string>;
+	cuotaMensual: Nullable<string>;
+	fechaInicio: Nullable<Date>;
+	diaPagoMensual: Nullable<number>;
+	numeroSifco: Nullable<string>;
+	nit: Nullable<string>;
+	createdAt: Date;
+	updatedAt: Date;
+	createdBy: string;
+};
+
+type AuditStage = {
+	id: string | null;
+	name: string | null;
+	closurePercentage: number | null;
+};
+
+type AuditLead = {
+	id: string | null;
+	firstName: string | null;
+	lastName: string | null;
+	email: string | null;
+	phone: string | null;
+};
+
+type AuditCompany = { id: string | null; name: string | null };
+
+type AuditVehicle = {
+	id: string | null;
+	make: string | null;
+	model: string | null;
+	year: number | null;
+	licensePlate: string | null;
+};
+
+type AuditUser = {
+	id: string | null;
+	name: string | null;
+	email: string | null;
+};
+
+type AuditClient = {
+	id: string | null;
+	contactPerson: string | null;
+	status: string | null;
+};
+
+export type DeletedOpportunitySnapshot = {
+	opportunity: {
+		id: string;
+		title: string;
+		value: Nullable<string>;
+		status: string;
+		creditType: string;
+		source: Nullable<string>;
+		campaign: Nullable<string>;
+		loanPurpose: Nullable<string>;
+		probability: number;
+		expectedCloseDate: Nullable<string>;
+		actualCloseDate: Nullable<string>;
+		notes: Nullable<string>;
+		numeroSifco: Nullable<string>;
+		nit: Nullable<string>;
+		creditTerms: {
+			numeroCuotas: Nullable<number>;
+			tasaInteres: Nullable<string>;
+			cuotaMensual: Nullable<string>;
+			fechaInicio: Nullable<string>;
+			diaPagoMensual: Nullable<number>;
+		};
+		createdAt: string;
+		updatedAt: string;
+		createdBy: string;
+	};
+	stage: AuditStage;
+	lead: (AuditLead & { fullName: string | null }) | null;
+	company: AuditCompany | null;
+	vehicle: AuditVehicle | null;
+	assignedUser: AuditUser | null;
+	client: AuditClient | null;
+	relatedCounts: {
+		documents: number;
+		coDebtors: number;
+		forms: number;
+		stageHistory: number;
+	};
+};
+
+function serializeDate(value: Date | null): string | null {
+	return value ? value.toISOString() : null;
+}
+
+function buildFullName(lead: AuditLead | null): string | null {
+	if (!lead) return null;
+	const fullName = [lead.firstName, lead.lastName].filter(Boolean).join(" ");
+	return fullName || null;
+}
+
+export function buildDeletedOpportunitySnapshot({
+	opportunity,
+	stage,
+	lead,
+	company,
+	vehicle,
+	assignedUser,
+	client,
+	relatedCounts,
+}: {
+	opportunity: AuditOpportunity;
+	stage: AuditStage;
+	lead: AuditLead | null;
+	company: AuditCompany | null;
+	vehicle: AuditVehicle | null;
+	assignedUser: AuditUser | null;
+	client: AuditClient | null;
+	relatedCounts: DeletedOpportunitySnapshot["relatedCounts"];
+}): DeletedOpportunitySnapshot {
+	return {
+		opportunity: {
+			id: opportunity.id,
+			title: opportunity.title,
+			value: opportunity.value,
+			status: opportunity.status,
+			creditType: opportunity.creditType,
+			source: opportunity.source,
+			campaign: opportunity.campaign,
+			loanPurpose: opportunity.loanPurpose,
+			probability: opportunity.probability,
+			expectedCloseDate: serializeDate(opportunity.expectedCloseDate),
+			actualCloseDate: serializeDate(opportunity.actualCloseDate),
+			notes: opportunity.notes,
+			numeroSifco: opportunity.numeroSifco,
+			nit: opportunity.nit,
+			creditTerms: {
+				numeroCuotas: opportunity.numeroCuotas,
+				tasaInteres: opportunity.tasaInteres,
+				cuotaMensual: opportunity.cuotaMensual,
+				fechaInicio: serializeDate(opportunity.fechaInicio),
+				diaPagoMensual: opportunity.diaPagoMensual,
+			},
+			createdAt: opportunity.createdAt.toISOString(),
+			updatedAt: opportunity.updatedAt.toISOString(),
+			createdBy: opportunity.createdBy,
+		},
+		stage,
+		lead: lead ? { ...lead, fullName: buildFullName(lead) } : null,
+		company,
+		vehicle,
+		assignedUser,
+		client,
+		relatedCounts,
+	};
+}

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -125,6 +125,9 @@ export const PERMISSIONS = {
 	canApproveOpportunities: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.ANALYST,
 
+	canDeleteOpportunities: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
+
 	canExportReports: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN ||
 		role === ROLES.ANALYST ||

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -30,6 +30,7 @@ import {
 	coDebtors,
 	companies,
 	creditAnalysis,
+	deletedOpportunityLogs,
 	leadSourceEnum,
 	leads,
 	opportunities,
@@ -1279,6 +1280,98 @@ export const crmRouter = {
 			}
 
 			return await baseQuery.orderBy(desc(opportunities.createdAt));
+		}),
+
+	deleteOpportunity: crmProcedure
+		.input(
+			z.object({
+				opportunityId: z.string().uuid(),
+				reason: z.string().min(1, "El motivo de eliminación es requerido"),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			if (!PERMISSIONS.canDeleteOpportunities(context.userRole)) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permiso para eliminar oportunidades",
+				});
+			}
+
+			const [opportunity] = await db
+				.select({
+					id: opportunities.id,
+					title: opportunities.title,
+					value: opportunities.value,
+					status: opportunities.status,
+					assignedTo: opportunities.assignedTo,
+					leadId: opportunities.leadId,
+					createdAt: opportunities.createdAt,
+					stage: {
+						name: salesStages.name,
+						closurePercentage: salesStages.closurePercentage,
+					},
+					lead: {
+						firstName: leads.firstName,
+						lastName: leads.lastName,
+					},
+					assignedUser: {
+						name: user.name,
+					},
+				})
+				.from(opportunities)
+				.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.leftJoin(user, eq(opportunities.assignedTo, user.id))
+				.where(eq(opportunities.id, input.opportunityId))
+				.limit(1);
+
+			if (!opportunity) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Oportunidad no encontrada",
+				});
+			}
+
+			if (!opportunity.stage || opportunity.stage.closurePercentage >= 30) {
+				throw new ORPCError("BAD_REQUEST", {
+					message:
+						"Solo se pueden eliminar oportunidades en etapas menores al 30% de cierre",
+				});
+			}
+
+			const leadName = opportunity.lead?.firstName
+				? [opportunity.lead.firstName, opportunity.lead.lastName]
+						.filter(Boolean)
+						.join(" ")
+				: null;
+
+			// Insert audit log before deleting
+			await db.insert(deletedOpportunityLogs).values({
+				opportunityId: opportunity.id,
+				opportunityTitle: opportunity.title,
+				opportunityValue: opportunity.value,
+				opportunityStatus: opportunity.status,
+				opportunityStageName: opportunity.stage?.name ?? null,
+				opportunityStagePercentage: opportunity.stage?.closurePercentage ?? null,
+				opportunityCreatedAt: opportunity.createdAt,
+				assignedUserId: opportunity.assignedTo,
+				assignedUserName: opportunity.assignedUser?.name ?? null,
+				leadId: opportunity.leadId,
+				leadName,
+				deletedBy: context.userId,
+				deletedByName: context.user?.name ?? context.userId,
+				reason: input.reason,
+			});
+
+			// Nullify clients.opportunityId before delete to avoid FK restriction
+			await db
+				.update(clients)
+				.set({ opportunityId: null })
+				.where(eq(clients.opportunityId, input.opportunityId));
+
+			await db
+				.delete(opportunities)
+				.where(eq(opportunities.id, input.opportunityId));
+
+			return { message: "Oportunidad eliminada exitosamente" };
 		}),
 
 	createOpportunity: crmProcedure

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -26,6 +26,10 @@ import {
 } from "../db/schema";
 import { user } from "../db/schema/auth";
 import {
+	creditApplications,
+	financialStatements,
+} from "../db/schema/client-forms";
+import {
 	clients,
 	coDebtors,
 	companies,
@@ -46,11 +50,12 @@ import {
 	opportunityDocuments,
 	VEHICLE_DOCUMENT_TYPES,
 } from "../db/schema/documents";
-import { generatedLegalContracts } from "../db/schema/legal-contracts";
+import { hasStaleAnalysisChecklistVehicleState } from "../lib/analysis-checklist";
 import {
 	updateChecklistForClientDocument,
 	updateChecklistForVehicleDocument,
 } from "../lib/checklist";
+import { buildDeletedOpportunitySnapshot } from "../lib/deleted-opportunity-audit";
 import { getGuatemalaMonthWindow } from "../lib/guatemala-month-window";
 import {
 	formatMissingLeadFields,
@@ -70,9 +75,8 @@ import {
 	getMissingFieldsForCompletion,
 	getMissingFieldsForContracts,
 } from "../lib/vehicle-helpers";
-import { hasStaleAnalysisChecklistVehicleState } from "../lib/analysis-checklist";
-import { validarDpi } from "../utils/cui-validation";
 import { scoreLead } from "../services/lead-scoring";
+import { validarDpi } from "../utils/cui-validation";
 import { createNotification } from "./notifications";
 
 export const getLeadsInputSchema = z.object({
@@ -1286,7 +1290,10 @@ export const crmRouter = {
 		.input(
 			z.object({
 				opportunityId: z.string().uuid(),
-				reason: z.string().min(1, "El motivo de eliminación es requerido"),
+				reason: z
+					.string()
+					.trim()
+					.min(1, "El motivo de eliminación es requerido"),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -1296,80 +1303,163 @@ export const crmRouter = {
 				});
 			}
 
-			const [opportunity] = await db
-				.select({
-					id: opportunities.id,
-					title: opportunities.title,
-					value: opportunities.value,
-					status: opportunities.status,
-					assignedTo: opportunities.assignedTo,
-					leadId: opportunities.leadId,
-					createdAt: opportunities.createdAt,
-					stage: {
-						name: salesStages.name,
-						closurePercentage: salesStages.closurePercentage,
-					},
-					lead: {
-						firstName: leads.firstName,
-						lastName: leads.lastName,
-					},
-					assignedUser: {
-						name: user.name,
-					},
-				})
-				.from(opportunities)
-				.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
-				.leftJoin(leads, eq(opportunities.leadId, leads.id))
-				.leftJoin(user, eq(opportunities.assignedTo, user.id))
-				.where(eq(opportunities.id, input.opportunityId))
-				.limit(1);
+			await db.transaction(async (tx) => {
+				const [opportunity] = await tx
+					.select({
+						id: opportunities.id,
+						title: opportunities.title,
+						value: opportunities.value,
+						status: opportunities.status,
+						creditType: opportunities.creditType,
+						source: opportunities.source,
+						campaign: opportunities.campaign,
+						loanPurpose: opportunities.loanPurpose,
+						probability: opportunities.probability,
+						expectedCloseDate: opportunities.expectedCloseDate,
+						actualCloseDate: opportunities.actualCloseDate,
+						notes: opportunities.notes,
+						numeroCuotas: opportunities.numeroCuotas,
+						tasaInteres: opportunities.tasaInteres,
+						cuotaMensual: opportunities.cuotaMensual,
+						fechaInicio: opportunities.fechaInicio,
+						diaPagoMensual: opportunities.diaPagoMensual,
+						numeroSifco: opportunities.numeroSifco,
+						nit: opportunities.nit,
+						assignedTo: opportunities.assignedTo,
+						leadId: opportunities.leadId,
+						createdAt: opportunities.createdAt,
+						updatedAt: opportunities.updatedAt,
+						createdBy: opportunities.createdBy,
+						stage: {
+							id: salesStages.id,
+							name: salesStages.name,
+							closurePercentage: salesStages.closurePercentage,
+						},
+						lead: {
+							id: leads.id,
+							firstName: leads.firstName,
+							lastName: leads.lastName,
+							email: leads.email,
+							phone: leads.phone,
+						},
+						company: {
+							id: companies.id,
+							name: companies.name,
+						},
+						vehicle: {
+							id: vehicles.id,
+							make: vehicles.make,
+							model: vehicles.model,
+							year: vehicles.year,
+							licensePlate: vehicles.licensePlate,
+						},
+						assignedUser: {
+							id: user.id,
+							name: user.name,
+							email: user.email,
+						},
+						client: {
+							id: clients.id,
+							contactPerson: clients.contactPerson,
+							status: clients.status,
+						},
+					})
+					.from(opportunities)
+					.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
+					.leftJoin(leads, eq(opportunities.leadId, leads.id))
+					.leftJoin(companies, eq(opportunities.companyId, companies.id))
+					.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+					.leftJoin(user, eq(opportunities.assignedTo, user.id))
+					.leftJoin(clients, eq(clients.opportunityId, opportunities.id))
+					.where(eq(opportunities.id, input.opportunityId))
+					.limit(1);
 
-			if (!opportunity) {
-				throw new ORPCError("NOT_FOUND", {
-					message: "Oportunidad no encontrada",
+				if (!opportunity) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "Oportunidad no encontrada",
+					});
+				}
+
+				if (!opportunity.stage || opportunity.stage.closurePercentage >= 30) {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"Solo se pueden eliminar oportunidades en etapas menores al 30% de cierre",
+					});
+				}
+
+				const [documentsCount] = await tx
+					.select({ count: count() })
+					.from(opportunityDocuments)
+					.where(eq(opportunityDocuments.opportunityId, input.opportunityId));
+				const [coDebtorsCount] = await tx
+					.select({ count: count() })
+					.from(coDebtors)
+					.where(eq(coDebtors.opportunityId, input.opportunityId));
+				const [creditApplicationsCount] = await tx
+					.select({ count: count() })
+					.from(creditApplications)
+					.where(eq(creditApplications.opportunityId, input.opportunityId));
+				const [financialStatementsCount] = await tx
+					.select({ count: count() })
+					.from(financialStatements)
+					.where(eq(financialStatements.opportunityId, input.opportunityId));
+				const [stageHistoryCount] = await tx
+					.select({ count: count() })
+					.from(opportunityStageHistory)
+					.where(
+						eq(opportunityStageHistory.opportunityId, input.opportunityId),
+					);
+
+				const snapshot = buildDeletedOpportunitySnapshot({
+					opportunity,
+					stage: opportunity.stage,
+					lead: opportunity.lead?.id ? opportunity.lead : null,
+					company: opportunity.company?.id ? opportunity.company : null,
+					vehicle: opportunity.vehicle?.id ? opportunity.vehicle : null,
+					assignedUser: opportunity.assignedUser?.id
+						? opportunity.assignedUser
+						: null,
+					client: opportunity.client?.id ? opportunity.client : null,
+					relatedCounts: {
+						documents: documentsCount?.count ?? 0,
+						coDebtors: coDebtorsCount?.count ?? 0,
+						forms:
+							(creditApplicationsCount?.count ?? 0) +
+							(financialStatementsCount?.count ?? 0),
+						stageHistory: stageHistoryCount?.count ?? 0,
+					},
 				});
-			}
 
-			if (!opportunity.stage || opportunity.stage.closurePercentage >= 30) {
-				throw new ORPCError("BAD_REQUEST", {
-					message:
-						"Solo se pueden eliminar oportunidades en etapas menores al 30% de cierre",
+				const leadName = snapshot.lead?.fullName ?? null;
+
+				await tx.insert(deletedOpportunityLogs).values({
+					opportunityId: opportunity.id,
+					opportunityTitle: opportunity.title,
+					opportunityValue: opportunity.value,
+					opportunityStatus: opportunity.status,
+					opportunityStageName: opportunity.stage?.name ?? null,
+					opportunityStagePercentage:
+						opportunity.stage?.closurePercentage ?? null,
+					opportunityCreatedAt: opportunity.createdAt,
+					assignedUserId: opportunity.assignedTo,
+					assignedUserName: opportunity.assignedUser?.name ?? null,
+					leadId: opportunity.leadId,
+					leadName,
+					deletedBy: context.userId,
+					deletedByName: context.user?.name ?? context.userId,
+					reason: input.reason,
+					snapshot,
 				});
-			}
 
-			const leadName = opportunity.lead?.firstName
-				? [opportunity.lead.firstName, opportunity.lead.lastName]
-						.filter(Boolean)
-						.join(" ")
-				: null;
+				await tx
+					.update(clients)
+					.set({ opportunityId: null })
+					.where(eq(clients.opportunityId, input.opportunityId));
 
-			// Insert audit log before deleting
-			await db.insert(deletedOpportunityLogs).values({
-				opportunityId: opportunity.id,
-				opportunityTitle: opportunity.title,
-				opportunityValue: opportunity.value,
-				opportunityStatus: opportunity.status,
-				opportunityStageName: opportunity.stage?.name ?? null,
-				opportunityStagePercentage: opportunity.stage?.closurePercentage ?? null,
-				opportunityCreatedAt: opportunity.createdAt,
-				assignedUserId: opportunity.assignedTo,
-				assignedUserName: opportunity.assignedUser?.name ?? null,
-				leadId: opportunity.leadId,
-				leadName,
-				deletedBy: context.userId,
-				deletedByName: context.user?.name ?? context.userId,
-				reason: input.reason,
+				await tx
+					.delete(opportunities)
+					.where(eq(opportunities.id, input.opportunityId));
 			});
-
-			// Nullify clients.opportunityId before delete to avoid FK restriction
-			await db
-				.update(clients)
-				.set({ opportunityId: null })
-				.where(eq(clients.opportunityId, input.opportunityId));
-
-			await db
-				.delete(opportunities)
-				.where(eq(opportunities.id, input.opportunityId));
 
 			return { message: "Oportunidad eliminada exitosamente" };
 		}),
@@ -3944,7 +4034,7 @@ export const crmRouter = {
 						.delete(analysisChecklists)
 						.where(eq(analysisChecklists.id, existingChecklist.id));
 				} else {
-				return existingChecklist.checklistData;
+					return existingChecklist.checklistData;
 				}
 			}
 

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -48,6 +48,7 @@ export const crmAppRouter = {
 	getOpportunities: crmRouter.getOpportunities,
 	createOpportunity: crmRouter.createOpportunity,
 	updateOpportunity: crmRouter.updateOpportunity,
+	deleteOpportunity: crmRouter.deleteOpportunity,
 	getOpportunitiesForAnalysis: crmRouter.getOpportunitiesForAnalysis,
 	approveOpportunityAnalysis: crmRouter.approveOpportunityAnalysis,
 	approveCreditDetail: crmRouter.approveCreditDetail,

--- a/apps/crm/apps/web/src/lib/roles.test.ts
+++ b/apps/crm/apps/web/src/lib/roles.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { PERMISSIONS, ROLES } from "./roles";
+
+describe("shared role permissions", () => {
+	test("allows only admin and sales supervisor to delete opportunities", () => {
+		expect(PERMISSIONS.canDeleteOpportunities(ROLES.ADMIN)).toBe(true);
+		expect(PERMISSIONS.canDeleteOpportunities(ROLES.SALES_SUPERVISOR)).toBe(
+			true,
+		);
+		expect(PERMISSIONS.canDeleteOpportunities(ROLES.SALES)).toBe(false);
+	});
+});

--- a/apps/crm/apps/web/src/lib/roles.ts
+++ b/apps/crm/apps/web/src/lib/roles.ts
@@ -1,2 +1,2 @@
 // Re-export roles configuration from server - single source of truth
-export * from "server/src/lib/roles";
+export * from "../../../server/src/lib/roles";

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -496,6 +496,9 @@ function RouteComponent() {
 		localStorage.setItem("opportunities-view-mode", mode);
 	};
 
+	const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
+	const [deleteReason, setDeleteReason] = useState("");
+
 	// State for confirm contracts signed modal
 	const [confirmSignedModalOpen, setConfirmSignedModalOpen] = useState(false);
 	const [opportunityToConfirmSigned, setOpportunityToConfirmSigned] = useState<{
@@ -517,6 +520,31 @@ function RouteComponent() {
 		},
 		onError: (error: Error) => {
 			toast.error(error.message || "Error al confirmar firma de contratos");
+		},
+	});
+
+	const deleteOpportunityMutation = useMutation({
+		mutationFn: async ({
+			opportunityId,
+			reason,
+		}: {
+			opportunityId: string;
+			reason: string;
+		}) => {
+			return await client.deleteOpportunity({ opportunityId, reason });
+		},
+		onSuccess: (data) => {
+			toast.success(data.message);
+			setIsDeleteConfirmOpen(false);
+			setDeleteReason("");
+			setIsDetailsDialogOpen(false);
+			setSelectedOpportunity(null);
+			queryClient.invalidateQueries({
+				queryKey: ["getOpportunities"],
+			});
+		},
+		onError: (error: Error) => {
+			toast.error(error.message || "Error al eliminar la oportunidad");
 		},
 	});
 
@@ -2630,6 +2658,23 @@ function RouteComponent() {
 										Cambiar Etapa
 									</Button>
 								</div>
+								{PERMISSIONS.canDeleteOpportunities(
+									userProfile.data?.role ?? "",
+								) &&
+									(selectedOpportunity?.stage?.closurePercentage ?? 100) <
+										30 && (
+										<div className="pt-2">
+											<Button
+												variant="destructive"
+												size="default"
+												className="w-full"
+												onClick={() => setIsDeleteConfirmOpen(true)}
+											>
+												<Trash2 className="mr-2 h-4 w-4" />
+												Eliminar Oportunidad
+											</Button>
+										</div>
+									)}
 							</TabsContent>
 
 							<TabsContent value="forms" className="mt-6 space-y-4">
@@ -3463,6 +3508,71 @@ function RouteComponent() {
 					}
 				/>
 			)}
+
+			{/* Dialog de confirmación para eliminar oportunidad */}
+			<Dialog
+				open={isDeleteConfirmOpen}
+				onOpenChange={(open) => {
+					setIsDeleteConfirmOpen(open);
+					if (!open) setDeleteReason("");
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>¿Eliminar oportunidad?</DialogTitle>
+					</DialogHeader>
+					<p className="text-muted-foreground text-sm">
+						Esta acción es permanente y no se puede deshacer. Se eliminará la
+						oportunidad <strong>{selectedOpportunity?.title}</strong> y todos
+						sus datos asociados.
+					</p>
+					<div className="space-y-2">
+						<Label htmlFor="delete-reason">
+							Motivo de eliminación <span className="text-destructive">*</span>
+						</Label>
+						<Textarea
+							id="delete-reason"
+							placeholder="Describe el motivo por el que se elimina esta oportunidad..."
+							value={deleteReason}
+							onChange={(e) => setDeleteReason(e.target.value)}
+							rows={3}
+						/>
+					</div>
+					<div className="flex gap-3 pt-2">
+						<Button
+							variant="outline"
+							className="flex-1"
+							onClick={() => {
+								setIsDeleteConfirmOpen(false);
+								setDeleteReason("");
+							}}
+						>
+							Cancelar
+						</Button>
+						<Button
+							variant="destructive"
+							className="flex-1"
+							disabled={
+								deleteOpportunityMutation.isPending ||
+								deleteReason.trim().length === 0
+							}
+							onClick={() => {
+								if (selectedOpportunity) {
+									deleteOpportunityMutation.mutate({
+										opportunityId: selectedOpportunity.id,
+										reason: deleteReason.trim(),
+									});
+								}
+							}}
+						>
+							{deleteOpportunityMutation.isPending ? (
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							) : null}
+							Sí, eliminar
+						</Button>
+					</div>
+				</DialogContent>
+			</Dialog>
 
 			{/* Modal para confirmar firma de contratos (85% → 90%) */}
 			<ConfirmContractsSignedModal


### PR DESCRIPTION

feat(opportunities): eliminar oportunidad con menos del 30%


Permite a los roles admin y sales_supervisor eliminar oportunidades que se encuentren en etapas de cierre menores al 30%, con confirmación obligatoria de motivo y registro de auditoría completo.


Cambios
db/schema/crm.ts — Nueva tabla deleted_opportunity_logs

Registra un snapshot de la oportunidad al momento de eliminarse: título, valor, etapa, lead, usuario asignado, quién eliminó y el motivo
Diseñada sin FKs (campos de texto plano) para que los logs persistan aunque los registros referenciados sean eliminados posteriormente

lib/roles.ts — Nuevo permiso canDeleteOpportunities

Retorna true únicamente para admin y sales_supervisor
Fuente única de verdad, compartida automáticamente entre backend y frontend

routers/crm.ts — Nuevo procedimiento deleteOpportunity

Valida rol con PERMISSIONS.canDeleteOpportunities → FORBIDDEN si no aplica
Valida que el stage de la oportunidad sea < 30% → BAD_REQUEST si no aplica
Inserta el log de auditoría antes de eliminar
Nullifica clients.opportunityId (sin cascade definido) antes del hard delete
El resto de tablas relacionadas se limpian automáticamente vía onDelete: "cascade" en el schema
routers/index.ts — Registro de deleteOpportunity en el router raíz

opportunities.tsx — UI del botón y diálogo de confirmación

Botón "Eliminar Oportunidad" (destructivo, ancho completo) visible solo si el rol y el stage cumplen la condición
Diálogo de confirmación con Textarea para el motivo (campo obligatorio, botón deshabilitado si está vacío)
Mutation que invalida la query de oportunidades al completarse


Rol permitido (admin / sales_supervisor) | Backend (FORBIDDEN) + Frontend (oculta el botón)
Stage < 30%                                             | Backend (BAD_REQUEST) + Frontend (oculta el botón)
Motivo obligatorio (min: 1)                      | Backend (Zod) + Frontend (botón deshabilitado)
Oportunidad existe                                  | Backend (NOT_FOUND)
FK clients sin cascade                               | Backend (nullify antes del delete)
Confirmación explícita del usuario           | Frontend (Dialog de confirmación)