### PR TITLE
fix(cobros): allow inclusive date range filter

### DIFF
--- a/apps/crm/apps/web/src/components/reports/date-range-filter.tsx
+++ b/apps/crm/apps/web/src/components/reports/date-range-filter.tsx
@@ -15,12 +15,14 @@ interface DateRangeFilterProps {
 	dateRange: DateRange | undefined;
 	onDateRangeChange: (range: DateRange | undefined) => void;
 	className?: string;
+	required?: boolean;
 }
 
 export function DateRangeFilter({
 	dateRange,
 	onDateRangeChange,
 	className,
+	required,
 }: DateRangeFilterProps) {
 	return (
 		<div className={cn("grid gap-2", className)}>
@@ -65,6 +67,7 @@ export function DateRangeFilter({
 					<Calendar
 						initialFocus
 						mode="range"
+						required={required}
 						defaultMonth={dateRange?.from}
 						selected={dateRange}
 						onSelect={onDateRangeChange}

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -1106,21 +1106,13 @@ function RouteComponent() {
 										<Separator orientation="vertical" className="mx-1 h-6" />
 										<DateRangeFilter
 											dateRange={pickerRange}
+											required
 											onDateRangeChange={(range) => {
 												if (!range) {
 													setDateRange(undefined);
 													setPickerRange(undefined);
 													setFechaError(null);
 													setPage(1);
-													return;
-												}
-												const hoy = new Date();
-												hoy.setHours(0, 0, 0, 0);
-												if (range.from && range.from < hoy) {
-													setFechaError(
-														"La fecha no puede ser menor al día de hoy",
-													);
-													setPickerRange(range); // muestra selección en UI sin afectar la query
 													return;
 												}
 												setFechaError(null);


### PR DESCRIPTION
## Summary
- Remove the cobros date filter restriction that blocked dates before today.
- Keep one-day ranges selected so filters like today-to-today work as an inclusive subset.

## Test Plan
- bun run --filter web check-types