### PR TITLE
feat: add scoring logic for last payment day bonus in credit candidates

### DIFF
--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -37,6 +37,7 @@ interface ScoreBreakdown {
   cuotas: number;
   proximidad: number;
   reinversion: number;
+  vencimiento_dia_30: number;
   total: number;
 }
 
@@ -81,6 +82,7 @@ const SCORE_REINVERSION = 3000;       // Prioridad para inversionistas existente
 const SCORE_NUEVO_INVERSIONISTA_INDIVIDUAL = 1000;
 const SCORE_COMPRA_TOTAL_CUBE_INDIVIDUAL = 2000;   // Bono full si queda solo el inversionista
 const SCORE_COMPRA_TOTAL_CUBE_POOL = 500;         // Bono reducido si sigue siendo un Pool
+const SCORE_VENCIMIENTO_DIA_30 = 1000;            // Crédito cuya última cuota vence el día 30
 
 // ============================================================
 // FUNCIONES DE SCORING
@@ -367,6 +369,30 @@ export async function getCreditCandidates(
   }
 
   // ──────────────────────────────────────────────────────────
+  // 5.2 Día de la última cuota por crédito (para bonus vencimiento día 30)
+  // ──────────────────────────────────────────────────────────
+  const ultimaCuotaRaw = await db
+    .select({
+      credito_id: cuotas_credito.credito_id,
+      dia_max: sql<number>`EXTRACT(DAY FROM MAX(${cuotas_credito.fecha_vencimiento}))::int`,
+    })
+    .from(cuotas_credito)
+    .where(
+      and(
+        inArray(cuotas_credito.credito_id, creditoIds),
+        gt(cuotas_credito.numero_cuota, 0)
+      )
+    )
+    .groupBy(cuotas_credito.credito_id);
+
+  const ultimaCuotaDiaByCredito = new Map<number, number>();
+  for (const row of ultimaCuotaRaw) {
+    if (row.credito_id !== null && row.dia_max !== null) {
+      ultimaCuotaDiaByCredito.set(row.credito_id, row.dia_max);
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────
   // 6. Capital activo por crédito
   //    capital_activo = capital - SUM(abono_capital donde pagado=true)
   // ──────────────────────────────────────────────────────────
@@ -506,10 +532,13 @@ export async function getCreditCandidates(
       }
     }
 
-    const score = SCORE_BASE + crmBonus + nuevoInvBonus + formatoBonus + cuotasBonus + proximityBonus + reinversionBonus + compraTotalBonus;
+    const diaUltimaCuota = ultimaCuotaDiaByCredito.get(credito_id);
+    const vencimientoBonus = diaUltimaCuota === 30 ? SCORE_VENCIMIENTO_DIA_30 : 0;
+
+    const score = SCORE_BASE + crmBonus + nuevoInvBonus + formatoBonus + cuotasBonus + proximityBonus + reinversionBonus + compraTotalBonus + vencimientoBonus;
 
     console.log(
-      `   ✅ [${numero_credito_sifco}] score=${score} (crm=${crmBonus}, nuevo=${nuevoInvBonus}, fmt=${formatoBonus}, cuotas=${cuotasBonus}, prox=${proximityBonus}, reinv=${reinversionBonus}, total=${compraTotalBonus})`
+      `   ✅ [${numero_credito_sifco}] score=${score} (crm=${crmBonus}, nuevo=${nuevoInvBonus}, fmt=${formatoBonus}, cuotas=${cuotasBonus}, prox=${proximityBonus}, reinv=${reinversionBonus}, total=${compraTotalBonus}, venc30=${vencimientoBonus})`
     );
 
     candidates.push({
@@ -528,6 +557,7 @@ export async function getCreditCandidates(
         cuotas: cuotasBonus,
         proximidad: proximityBonus,
         reinversion: reinversionBonus,
+        vencimiento_dia_30: vencimientoBonus,
         total: score,
       },
       capital_evaluado: capitalParaEvaluar,

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1554,26 +1554,34 @@ export async function getPagosByVencimiento({
   }
   const whereClause = sql.join(filters, sql` AND `);
 
-  // Subquery para los porcentajes de Cube por crédito
+  // cash_in_pct = fracción del interés total que corresponde a Cash-In (suma ponderada de porcentaje_cash_in de todos los inversionistas):
+  //   - Cada inv aporta: monto_i * porcentaje_cash_in_i / 100
+  //   - CUBE siempre usa porcentaje_cash_in = 100 (corrige bug replaceInvestorCredit donde queda en 0)
+  //   - Si CUBE fue eliminado de CI, su porción implícita = GREATEST(0, capital - SUM_CI) * 100%
+  //   - Fallback para créditos legacy (capital=0 y montos=0): promedio simple de porcentaje_cash_in
   const cubeSubquery = sql`
     LEFT JOIN LATERAL (
       SELECT
-        CASE
-          WHEN sum_montos.total > 0 THEN
-            (ci_cube.porcentaje_cash_in::numeric / 100.0) * (ci_cube.monto_aportado::numeric / sum_montos.total)
-          ELSE 0
-        END AS cube_pct
-      FROM cartera.creditos_inversionistas ci_cube
-      INNER JOIN cartera.inversionistas inv_cube
-        ON ci_cube.inversionista_id = inv_cube.inversionista_id
-      CROSS JOIN LATERAL (
-        SELECT COALESCE(SUM(ci_all.monto_aportado::numeric), 0) AS total
-        FROM cartera.creditos_inversionistas ci_all
-        WHERE ci_all.credito_id = p.credito_id
-      ) sum_montos
-      WHERE ci_cube.credito_id = p.credito_id
-        AND LOWER(TRIM(inv_cube.nombre)) = 'cube investments s.a.'
-      LIMIT 1
+        COALESCE((
+          SELECT
+            CASE
+              WHEN COALESCE(SUM(ci_all.monto_aportado::numeric), 0) > 0 OR c.capital::numeric > 0 THEN
+                (COALESCE(SUM(
+                  ci_all.monto_aportado::numeric *
+                  CASE WHEN ci_all.inversionista_id = 86 THEN 100::numeric
+                       ELSE ci_all.porcentaje_cash_in::numeric
+                  END
+                ), 0) / 100.0
+                + GREATEST(0, c.capital::numeric - COALESCE(SUM(ci_all.monto_aportado::numeric), 0)))
+                / NULLIF(GREATEST(c.capital::numeric, COALESCE(SUM(ci_all.monto_aportado::numeric), 0)), 0)
+              WHEN COUNT(*) > 0 THEN
+                AVG(CASE WHEN ci_all.inversionista_id = 86 THEN 100::numeric
+                         ELSE ci_all.porcentaje_cash_in::numeric END) / 100.0
+              ELSE 0
+            END
+          FROM cartera.creditos_inversionistas ci_all
+          WHERE ci_all.credito_id = p.credito_id
+        ), 0) AS cash_in_pct
     ) cube_data ON true
   `;
 
@@ -1603,8 +1611,8 @@ export async function getPagosByVencimiento({
       COALESCE(SUM(p.seguro_restante::numeric + COALESCE(p.abono_seguro, 0)::numeric), 0) AS total_seguro_restante,
       COALESCE(SUM(p.gps_restante::numeric + COALESCE(p.abono_gps, 0)::numeric), 0) AS total_gps_restante,
       COALESCE(SUM(p.membresias::numeric + COALESCE(p.membresias_pago, 0)::numeric), 0) AS total_membresias,
-      COALESCE(SUM((p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric) * COALESCE(cube_data.cube_pct, 0)), 0) AS total_interes_cube,
-      COALESCE(SUM((p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric) * COALESCE(cube_data.cube_pct, 0)), 0) AS total_iva_cube
+      COALESCE(SUM((p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_interes_cube,
+      COALESCE(SUM((p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_iva_cube
     FROM cartera.pagos_credito p
     INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
@@ -1637,8 +1645,8 @@ export async function getPagosByVencimiento({
       COALESCE(SUM(p.gps_restante::numeric + COALESCE(p.abono_gps, 0)::numeric), 0) AS gps_restante,
       COALESCE(SUM(p.membresias::numeric + COALESCE(p.membresias_pago, 0)::numeric), 0) AS membresias,
       COALESCE(SUM(p.monto_boleta::numeric), 0) AS monto_boleta,
-      COALESCE(SUM((p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric) * COALESCE(cube_data.cube_pct, 0)), 0) AS interes_cube,
-      COALESCE(SUM((p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric) * COALESCE(cube_data.cube_pct, 0)), 0) AS iva_cube,
+      COALESCE(SUM((p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS interes_cube,
+      COALESCE(SUM((p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS iva_cube,
       COALESCE(SUM(${totalFilaSql}), 0) AS total_pagos_del_mes,
       CASE
         WHEN MAX(m.cuotas_atrasadas) = 1 THEN 'Mora 30'


### PR DESCRIPTION
## Cambios en `assignCapital` — Bonus de score para créditos con vencimiento el día 30

### Contexto

El endpoint `GET /assign-capital/candidates` rankea créditos por score para asignación de capital. No consideraba la fecha de vencimiento de los créditos como factor de prioridad.

### Cambios

**Nueva constante de scoring:**
- `SCORE_VENCIMIENTO_DIA_30 = 1000` — bonus para créditos cuya última cuota vence el día 30 del mes.

**Nuevo batch query (paso 5.2):**
- Se consulta `EXTRACT(DAY FROM MAX(cuotas_credito.fecha_vencimiento))::int` por crédito para obtener el día de la última cuota directamente en SQL, evitando problemas de timezone en parsing de fechas en JS.

**Scoring:**
- Si `diaUltimaCuota === 30`, se suman 1000 pts al score del crédito.
- Se agrega `vencimiento_dia_30` al objeto `score_breakdown` retornado en la respuesta.

### Posición en el ranking de bonos

| Bonus | Puntos |
|---|---|
| Reinversión existente | 3000 |
| Formato Individual | 2500 |
| Compra total Cube (Individual) | 2000 |
| Nuevo inversionista (Individual) | 1000 |
| **Vencimiento día 30** | **1000** |
| Formato Pool solo Cube | 500 |
