### PR TITLE
feat: agregar fecha de aplicación en estados de cuenta

### DIFF
--- a/apps/cartera-back/src/controllers/reports.test.ts
+++ b/apps/cartera-back/src/controllers/reports.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("../database", () => ({
+  db: {},
+}));
+
+mock.module("./credits", () => ({
+  getCreditosWithUserByMesAnio: mock(() => Promise.resolve({ data: [] })),
+}));
+
+mock.module("./payments", () => ({
+  getAllPagosWithCreditAndInversionistas: mock(() => Promise.resolve([])),
+  getPagosConInversionistas: mock(() => Promise.resolve([])),
+}));
+
+mock.module("@cci/email", () => ({
+  sendEmail: mock(() => Promise.resolve()),
+  sendLiquidationEmail: mock(() => Promise.resolve()),
+  sendPlainEmail: mock(() => Promise.resolve()),
+  sendSimpleEmail: mock(() => Promise.resolve()),
+  sendInvestorAddedToCreditsNotification: mock(() => Promise.resolve()),
+}));
+
+const { buildEstadoCuentaTableHeader, renderEstadoCuentaPaymentRow } = await import("./reports");
+
+describe("estado de cuenta PDF", () => {
+  it("incluye la columna de fecha de aplicacion del pago", () => {
+    expect(buildEstadoCuentaTableHeader()).toContain("Fecha Aplicación");
+  });
+
+  it("muestra fecha_aplicado en el renglon del pago", () => {
+    const row = renderEstadoCuentaPaymentRow(
+      {
+        pago_id: 78303,
+        numero_cuota: 17,
+        cuota: "2445.18",
+        abono_capital: "841.50",
+        abono_interes: "812.53",
+        abono_iva_12: "97.50",
+        abono_seguro: "260.93",
+        abono_gps: "0.00",
+        membresias_pago: "432.72",
+        mora: "0.00",
+        monto_aplicado: "2445.18",
+        total_restante: "53327.49",
+        fecha_vencimiento: new Date("2026-05-15T06:00:00.000Z"),
+        fecha_aplicado: new Date("2026-05-19T16:36:25.000Z"),
+      },
+      0,
+    );
+
+    expect(row).toContain("19/05/2026");
+    expect(row).toContain("15/05/2026");
+  });
+
+  it("muestra guion cuando el pago no tiene fecha_aplicado", () => {
+    const row = renderEstadoCuentaPaymentRow(
+      {
+        pago_id: 78304,
+        numero_cuota: 18,
+        cuota: "2445.18",
+        abono_capital: "0.00",
+        abono_interes: "0.00",
+        abono_iva_12: "0.00",
+        abono_seguro: "0.00",
+        abono_gps: "0.00",
+        membresias_pago: "0.00",
+        mora: "0.00",
+        monto_aplicado: "0.00",
+        total_restante: "54168.99",
+        fecha_vencimiento: new Date("2026-06-15T06:00:00.000Z"),
+        fecha_aplicado: null,
+      },
+      0,
+    );
+
+    expect(row).toContain("<td>-</td>");
+  });
+});

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -10,6 +10,83 @@ import { sql } from "drizzle-orm";
 
 const LOGO_URL = process.env.LOGO_URL || "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
 
+type EstadoCuentaPagoRow = {
+  pago_id?: number | string | null;
+  numero_cuota?: number | string | null;
+  cuota?: number | string | null;
+  abono_capital?: number | string | null;
+  abono_interes?: number | string | null;
+  abono_iva_12?: number | string | null;
+  abono_seguro?: number | string | null;
+  abono_gps?: number | string | null;
+  membresias_pago?: number | string | null;
+  mora?: number | string | null;
+  monto_aplicado?: number | string | null;
+  total_restante?: number | string | null;
+  fecha_vencimiento?: Date | string | null;
+  fecha_aplicado?: Date | string | null;
+};
+
+const formatEstadoCuentaMoney = (n: number) =>
+  `Q${n.toLocaleString("es-GT", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+
+const formatEstadoCuentaDate = (fecha?: Date | string | null) => {
+  if (!fecha) return "-";
+
+  return new Date(fecha).toLocaleDateString("es-GT", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+};
+
+export function buildEstadoCuentaTableHeader() {
+  return `<tr>
+          <th>No.</th>
+          <th>Pago ID</th>
+          <th># Cuota</th>
+          <th>Cuota</th>
+          <th>Capital</th>
+          <th>Interés</th>
+          <th>IVA 12%</th>
+          <th>Servicios</th>
+          <th>Mora</th>
+          <th>Monto Aplicado</th>
+          <th>Capital Rest.</th>
+          <th>Fecha Vencimiento Cuota</th>
+          <th>Fecha Aplicación</th>
+        </tr>`;
+}
+
+export function renderEstadoCuentaPaymentRow(
+  pago: EstadoCuentaPagoRow,
+  index: number,
+) {
+  const montoAplicado = Number(pago.monto_aplicado || 0);
+  const capitalPago = Number(pago.abono_capital || 0);
+  const interesPago = Number(pago.abono_interes || 0);
+  const isEven = index % 2 === 0;
+
+  return `<tr class="${isEven ? "even" : ""}">
+      <td>${index + 1}</td>
+      <td>${pago.pago_id}</td>
+      <td>${pago.numero_cuota ?? ""}</td>
+      <td class="money">${formatEstadoCuentaMoney(Number(pago.cuota || 0))}</td>
+      <td class="money">${formatEstadoCuentaMoney(capitalPago)}</td>
+      <td class="money">${formatEstadoCuentaMoney(interesPago)}</td>
+      <td class="money">${formatEstadoCuentaMoney(Number(pago.abono_iva_12 || 0))}</td>
+      <td class="money">${formatEstadoCuentaMoney(Number(pago.abono_seguro || 0) + Number(pago.abono_gps || 0) + Number(pago.membresias_pago || 0))}</td>
+      <td class="money">${formatEstadoCuentaMoney(Number(pago.mora || 0))}</td>
+      <td class="money total">${formatEstadoCuentaMoney(montoAplicado)}</td>
+      <td class="money">${formatEstadoCuentaMoney(Number(pago.total_restante || 0))}</td>
+      <td>${formatEstadoCuentaDate(pago.fecha_vencimiento)}</td>
+      <td>${formatEstadoCuentaDate(pago.fecha_aplicado)}</td>
+    </tr>`;
+}
+
 export async function getCreditosWithUserByMesAnioExcel(
   params: {
     mes: number;
@@ -320,7 +397,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
   const numCredito = primerPago.numero_credito_sifco ?? credito_sifco;
   const fechaGen = new Date().toLocaleDateString("es-GT", { year: "numeric", month: "long", day: "numeric" });
 
-  const formatQ = (n: number) => `Q${n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const formatQ = formatEstadoCuentaMoney;
 
   // Calcular totales
   let totalMontoAplicado = 0;
@@ -335,25 +412,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
     totalCapital += capitalPago;
     totalInteres += interesPago;
 
-    const fechaPago = pago.fecha_vencimiento
-      ? new Date(pago.fecha_vencimiento).toLocaleDateString("es-GT", { year: "numeric", month: "2-digit", day: "2-digit" })
-      : "";
-
-    const isEven = index % 2 === 0;
-    return `<tr class="${isEven ? "even" : ""}">
-      <td>${index + 1}</td>
-      <td>${pago.pago_id}</td>
-      <td>${pago.numero_cuota ?? ""}</td>
-      <td class="money">${formatQ(Number(pago.cuota || 0))}</td>
-      <td class="money">${formatQ(capitalPago)}</td>
-      <td class="money">${formatQ(interesPago)}</td>
-      <td class="money">${formatQ(Number(pago.abono_iva_12 || 0))}</td>
-      <td class="money">${formatQ(Number(pago.abono_seguro || 0) + Number(pago.abono_gps || 0) + Number(pago.membresias_pago || 0))}</td>
-      <td class="money">${formatQ(Number(pago.mora || 0))}</td>
-      <td class="money total">${formatQ(montoAplicado)}</td>
-      <td class="money">${formatQ(Number(pago.total_restante || 0))}</td>
-      <td>${fechaPago}</td>
-    </tr>`;
+    return renderEstadoCuentaPaymentRow(pago, index);
   }).join("");
 
   // 2️⃣ HTML del reporte
@@ -460,20 +519,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
 
     <table>
       <thead>
-        <tr>
-          <th>No.</th>
-          <th>Pago ID</th>
-          <th># Cuota</th>
-          <th>Cuota</th>
-          <th>Capital</th>
-          <th>Interés</th>
-          <th>IVA 12%</th>
-          <th>Servicios</th>
-          <th>Mora</th>
-          <th>Monto Aplicado</th>
-          <th>Capital Rest.</th>
-          <th>Fecha Vencimiento Cuota</th>
-        </tr>
+        ${buildEstadoCuentaTableHeader()}
       </thead>
       <tbody>
         ${tableRows}
@@ -483,7 +529,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
           <td class="money">${formatQ(totalInteres)}</td>
           <td colspan="3"></td>
           <td class="money">${formatQ(totalMontoAplicado)}</td>
-          <td colspan="2"></td>
+          <td colspan="3"></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Resumen

- Se agrega la columna "Fecha Aplicación" al PDF de estado de cuenta.
- La columna muestra el valor de `pagos_credito.fecha_aplicado` para cada pago.
- Si el pago no tiene fecha de aplicación, se muestra `-`.
- Se agregan pruebas para validar la nueva columna y el fallback sin fecha.

## Pruebas

- `bun test src/controllers/reports.test.ts`

## Nota

- `bun test` completo tiene una falla existente no relacionada en `src/utils/investorLiquidationSummary.test.ts`.