### PR TITLE
fix(cobros): clasificar estadoMora por cantidad de cuotas vencidas

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2063,10 +2063,10 @@ export const cobrosRouter = {
 						: 0;
 
 					let estadoMora: (typeof estadoMoraEnum.enumValues)[number] = "al_dia";
-					if (diasMora > 0 && diasMora <= 30) estadoMora = "mora_30";
-					else if (diasMora > 30 && diasMora <= 60) estadoMora = "mora_60";
-					else if (diasMora > 60 && diasMora <= 90) estadoMora = "mora_90";
-					else if (diasMora > 90) estadoMora = "mora_120";
+					if (cuotasAtrasadas === 1) estadoMora = "mora_30";
+					else if (cuotasAtrasadas === 2) estadoMora = "mora_60";
+					else if (cuotasAtrasadas === 3) estadoMora = "mora_90";
+					else if (cuotasAtrasadas >= 4) estadoMora = "mora_120";
 
 					const nuevosCasos = await db
 						.insert(casosCobros)
@@ -2118,12 +2118,11 @@ export const cobrosRouter = {
 				const montoEnMora =
 					Number(creditoCompleto.moraActual) || cuotaMensual * cuotasAtrasadas;
 
-				let estadoMora: string | null = null;
-				if (diasMora === 0) estadoMora = "al_dia";
-				else if (diasMora <= 30) estadoMora = "mora_30";
-				else if (diasMora <= 60) estadoMora = "mora_60";
-				else if (diasMora <= 90) estadoMora = "mora_90";
-				else estadoMora = "mora_120";
+				let estadoMora: string | null = "al_dia";
+				if (cuotasAtrasadas === 1) estadoMora = "mora_30";
+				else if (cuotasAtrasadas === 2) estadoMora = "mora_60";
+				else if (cuotasAtrasadas === 3) estadoMora = "mora_90";
+				else if (cuotasAtrasadas >= 4) estadoMora = "mora_120";
 
 				const statusCredit = creditoCompleto.credito.statusCredit;
 				let estadoContrato = "activo";


### PR DESCRIPTION
## Summary
- En el endpoint `getDetallesCreditoCarteraBack` el `estadoMora` se calculaba por días desde la cuota más antigua vencida, lo que causaba casos como **1 cuota vencida** etiquetada como **MORA 120** (al superar los 90 días).
- Ahora se clasifica por **número de cuotas atrasadas**, usando el mismo mapeo que ya emplea el filtro del listado (`1 → mora_30`, `2 → mora_60`, `3 → mora_90`, `4+ → mora_120`).
- El campo `diasMoraMaximo` sigue reportándose con los días reales (calculados con `calcularDiasMoraExactos`), solo cambia la clasificación del badge.

## Cambios
- [apps/crm/apps/server/src/routers/cobros.ts](apps/crm/apps/server/src/routers/cobros.ts): dos bloques actualizados
  - Creación inicial del caso de cobros (rama "caso no existe")
  - Mapeo de respuesta del endpoint

## Test plan
- [ ] Abrir un crédito con **1 cuota vencida** y >90 días de mora → debe mostrar **MORA 30** (antes mostraba MORA 120)
- [ ] Verificar que un crédito con 4+ cuotas vencidas siga mostrando **MORA 120**
- [ ] Verificar que un crédito al día siga mostrando **AL DÍA**
- [ ] Confirmar que `diasMoraMaximo` y `montoEnMora` no cambian

## Notas
La misma lógica por días vive aún en `sync-casos-cobros.ts` y `reportes-cartera.ts`; este PR solo ajusta el detalle del crédito en cobros. Si se quiere consistencia total habría que replicar el cambio en esos archivos en un PR aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)