### PR TITLE
fix(cobros): derivar diaPagoMensual desde fecha_vencimiento de cartera

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2124,6 +2124,21 @@ export const cobrosRouter = {
 				else if (cuotasAtrasadas === 3) estadoMora = "mora_90";
 				else if (cuotasAtrasadas >= 4) estadoMora = "mora_120";
 
+				// Día de pago: extraer desde la fecha_vencimiento de una cuota real
+				// de cartera (prioriza pendiente, luego atrasada, luego pagada),
+				// con fallback al diaPago de la oportunidad.
+				const cuotaParaDiaPago =
+					creditoCompleto.cuotasPendientes?.find((c) => c.numero_cuota !== 0) ||
+					creditoCompleto.cuotasAtrasadas?.find((c) => c.numero_cuota !== 0) ||
+					creditoCompleto.cuotasPagadas?.find((c) => c.numero_cuota !== 0) ||
+					null;
+				const diaPagoMensual = cuotaParaDiaPago
+					? Number.parseInt(
+							cuotaParaDiaPago.fecha_vencimiento.substring(8, 10),
+							10,
+						) || oportunidadData?.diaPago || null
+					: oportunidadData?.diaPago || null;
+
 				const statusCredit = creditoCompleto.credito.statusCredit;
 				let estadoContrato = "activo";
 				if (statusCredit === "CANCELADO") estadoContrato = "completado";
@@ -2156,7 +2171,7 @@ export const cobrosRouter = {
 						creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual,
 					numeroCuotas: creditoCompleto.credito.plazo,
 					fechaInicio: creditoCompleto.credito.fecha_creacion,
-					diaPagoMensual: oportunidadData?.diaPago || null,
+					diaPagoMensual,
 					estadoContrato,
 
 					// Datos del cliente (de cartera-back o lead)


### PR DESCRIPTION
## Summary
- En el endpoint `getDetallesCreditoCarteraBack`, el campo `diaPagoMensual` se tomaba de la oportunidad del CRM (`oportunidadData?.diaPago`), lo que no siempre refleja el día real de pago del crédito en cartera.
- Ahora se extrae el día desde la `fecha_vencimiento` de una cuota real de cartera-back, con la siguiente prioridad:
  1. Primera cuota **pendiente** (la más próxima a pagar)
  2. Primera cuota **atrasada**
  3. Primera cuota **pagada**
- Se excluye `numero_cuota === 0` (cuota de desembolso) porque no representa el día de pago mensual.
- Si no hay cuotas disponibles, se mantiene el fallback a `oportunidadData?.diaPago`.

## Detalles técnicos
- Se usa `substring(8, 10)` sobre el string `YYYY-MM-DD...` en vez de `new Date().getDate()` para evitar desplazamientos por timezone (GT es UTC-6 y una fecha ISO sin hora podría caer un día antes al convertir a local).

## Cambios
- [apps/crm/apps/server/src/routers/cobros.ts](apps/crm/apps/server/src/routers/cobros.ts) — bloque de cálculo de `diaPagoMensual` antes del `return` del endpoint.

## Test plan
- [ ] Abrir un crédito que tenga cuotas pendientes → el "Día de Pago" debe coincidir con el día del mes de la próxima cuota a pagar
- [ ] Validar un crédito donde el `diaPago` en la oportunidad estaba mal y comparar con el día correcto que ahora devuelve cartera
- [ ] Confirmar que un crédito sin cuotas en cartera siga mostrando el `diaPago` de la oportunidad (fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)