### PR TITLE
fix(espejo): no sobreescribir fecha_inicio_participacion en reinversión

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -107,7 +107,7 @@ function recalcularInversionistas(
   tipo_operacion: "reinversion" | "compra_cartera",
 ) {
   // Fallback de fecha de inicio cuando un inversionista llega sin fecha:
-  // - reinversion → un mes antes (la operación se ejecuta sobre rendimientos
+  // - reinversion → dos meses antes (la operación se ejecuta sobre rendimientos
   //   del período previo, así que la participación arranca ese mes)
   // - compra_cartera → fecha de hoy
   const hoy = new Date();

--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -109,7 +109,6 @@ export const completeEspejo = async ({ body, set, request }: any) => {
                 .update(creditos_inversionistas_espejo)
                 .set({
                   status: "completado",
-                  fecha_inicio_participacion: fechaDosMesesAtras,
                   updated_at: new Date(),
                 })
                 .where(
@@ -160,20 +159,8 @@ export const completeEspejo = async ({ body, set, request }: any) => {
         const updated = [...updatedReinversion, ...updatedOtros];
 
         // ── Update padre: misma partición para mantener consistencia ──
-        if (idsReinversion.length > 0) {
-          await tx
-            .update(creditos_inversionistas)
-            .set({ fecha_inicio_participacion: fechaDosMesesAtras })
-            .where(
-              and(
-                eq(creditos_inversionistas.credito_id, credito_id),
-                inArray(
-                  creditos_inversionistas.inversionista_id,
-                  idsReinversion,
-                ),
-              ),
-            );
-        }
+        // Para reinversión NO actualizamos fecha_inicio_participacion:
+        // addInvestorToCredit ya la dejó correcta (existente o 2 meses atrás si es nuevo).
 
         if (idsOtros.length > 0) {
           await tx

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -1119,7 +1119,11 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
 
         // ── Si el inversionista no existía en el destino, agregarlo en
         //    ambas tablas con el mismo monto (no hay valor histórico previo). ──
-        const hoyStr = new Date().toISOString().split("T")[0];
+        const hoy = new Date();
+        const hoyStr = hoy.toISOString().split("T")[0];
+        const dosMesesAtras = new Date(hoy.getFullYear(), hoy.getMonth() - 2, hoy.getDate())
+          .toISOString()
+          .split("T")[0];
         if (
           !arrayDestinoPadre.some(
             (inv) => inv.inversionista_id === inversionista_id,
@@ -1130,7 +1134,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
             monto_aportado: montoAsignar,
             porcentaje_cash_in: porcCashIn,
             porcentaje_inversion: porcInversion,
-            fecha_inicio_participacion: hoyStr,
+            fecha_inicio_participacion: tipo_operacion === "reinversion" ? dosMesesAtras : hoyStr,
           });
         }
         if (
@@ -1143,7 +1147,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
             monto_aportado: montoAsignar,
             porcentaje_cash_in: porcCashIn,
             porcentaje_inversion: porcInversion,
-            fecha_inicio_participacion: hoyStr,
+            fecha_inicio_participacion: tipo_operacion === "reinversion" ? dosMesesAtras : hoyStr,
           });
         }
 


### PR DESCRIPTION
## Summary
- `completeEspejo` ya no sobreescribe `fecha_inicio_participacion` cuando acepta reinversiones
- La fecha la define `addInvestorToCredit`: conserva la existente si el inversionista ya estaba en el crédito, o pone 2 meses atrás si es nuevo
- Compra de cartera sigue igual (pone fecha de hoy al aceptar)

## Context
Al aceptar reinversiones, `completeEspejo` estaba reseteando la fecha de inicio de participación a 2 meses atrás para **todos** los registros con status `pendiente_reinversion`, incluyendo inversionistas que ya tenían una fecha correcta desde antes. Esto desfasó ~83 registros en producción.

## Test plan
- [ ] Verificar que al hacer reinversión de un inversionista existente, su `fecha_inicio_participacion` no cambie al aceptar en completeEspejo
- [ ] Verificar que un inversionista nuevo en reinversión siga recibiendo fecha 2 meses atrás desde addInvestorToCredit
- [ ] Verificar que compra de cartera siga poniendo fecha de hoy al aceptar

🤖 Generated with [Claude Code](https://claude.com/claude-code)