### PR TITLE
Fix granular payment reversal

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -49,6 +49,7 @@ import {
   type EstadoLiquidacionResumenFilter,
 } from "../utils/investorLiquidationSummary";
 import { addInvestorToCredit } from "./addInvestorToCredit";
+import { getPaymentIdsForInvestorReverse } from "./reversePaymentPolicy";
 
 // ============================================
 // 🆕 TIPOS Y CONFIGURACIÓN PARA CONSULTAS ORIGINALES/ESPEJO
@@ -1019,15 +1020,20 @@ export async function processAndReplaceCreditInvestorsReverse(
     throw new Error(`Pago ${pago_id} no encontrado`);
   }
 
-  // 4. Obtener TODOS los pagos de esa cuota
+  // 4. Obtener pagos de esa cuota como contexto. La reversa de inversionistas
+  // debe aplicar únicamente al pago seleccionado; otros pagos de la misma cuota
+  // pueden ser boletas legítimas y no se deben revertir parejo.
   const pagosDeEsaCuota = await db
     .select({ pago_id: pagos_credito.pago_id })
     .from(pagos_credito)
     .where(eq(pagos_credito.cuota_id, pago.cuota_id));
 
-  const pagoIds = pagosDeEsaCuota.map((p) => p.pago_id);
+  const pagoIds = getPaymentIdsForInvestorReverse(
+    pago_id,
+    pagosDeEsaCuota.map((p) => p.pago_id),
+  );
 
-  // 5. Por cada inversionista, sumar abono_capital de TODOS los pagos de esa cuota
+  // 5. Por cada inversionista, sumar abono_capital solo del pago reversado.
   for (const inv of investors) {
     const abonos = pagoIds.length > 0
       ? await db

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1023,10 +1023,12 @@ export async function processAndReplaceCreditInvestorsReverse(
   // 4. Obtener pagos de esa cuota como contexto. La reversa de inversionistas
   // debe aplicar únicamente al pago seleccionado; otros pagos de la misma cuota
   // pueden ser boletas legítimas y no se deben revertir parejo.
-  const pagosDeEsaCuota = await db
-    .select({ pago_id: pagos_credito.pago_id })
-    .from(pagos_credito)
-    .where(eq(pagos_credito.cuota_id, pago.cuota_id));
+  const pagosDeEsaCuota = pago.cuota_id === null
+    ? []
+    : await db
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .where(eq(pagos_credito.cuota_id, pago.cuota_id));
 
   const pagoIds = getPaymentIdsForInvestorReverse(
     pago_id,
@@ -1157,7 +1159,13 @@ export async function reversePagosEspejoPorInversionista(
   }
 
   // 5. Obtener cuotas asociadas a los pagos y marcarlas como NO liquidadas
-  const pagoIds = [...new Set(pagosEspejo.map((p) => p.pago_id))];
+  const pagoIds = [
+    ...new Set(
+      pagosEspejo
+        .map((p) => p.pago_id)
+        .filter((id): id is number => id !== null)
+    ),
+  ];
   console.log(`\n📅 Revirtiendo liquidación de cuotas (${pagoIds.length} pago_ids únicos)...`);
 
   if (pagoIds.length > 0) {
@@ -2332,7 +2340,13 @@ export async function revertirLiquidacion(liquidacion_id: number) {
     // PASO 5: Revertir cuotas del crédito
     //   Marcamos liquidado_inversionistas = false y limpiamos fecha
     // ──────────────────────────────────────────────
-    const allPagoIds = [...new Set(pagosLiquidados.map((p) => p.pago_id))];
+    const allPagoIds = [
+      ...new Set(
+        pagosLiquidados
+          .map((p) => p.pago_id)
+          .filter((id): id is number => id !== null)
+      ),
+    ];
     if (allPagoIds.length > 0) {
       const cuotasDeLosPagos = await tx
         .select({ cuota_id: pagos_credito.cuota_id })
@@ -3693,14 +3707,26 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
         }
 
         // Marcar cuotas como liquidado_inversionistas
-        const allPagoIds = [...new Set(pagosNoLiquidados.map((p) => p.pago_id))];
+        const allPagoIds = [
+          ...new Set(
+            pagosNoLiquidados
+              .map((p) => p.pago_id)
+              .filter((id): id is number => id !== null)
+          ),
+        ];
         if (allPagoIds.length > 0) {
           const cuotasDeLosPagos = await tx
             .select({ cuota_id: pagos_credito.cuota_id })
             .from(pagos_credito)
             .where(inArray(pagos_credito.pago_id, allPagoIds));
 
-          const uniqueCuotaIds = [...new Set(cuotasDeLosPagos.map((c) => c.cuota_id))];
+          const uniqueCuotaIds = [
+            ...new Set(
+              cuotasDeLosPagos
+                .map((c) => c.cuota_id)
+                .filter((id): id is number => id !== null)
+            ),
+          ];
           if (uniqueCuotaIds.length > 0) {
             const fechaGuatemala = new Date(
               new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -49,7 +49,6 @@ import {
   type EstadoLiquidacionResumenFilter,
 } from "../utils/investorLiquidationSummary";
 import { addInvestorToCredit } from "./addInvestorToCredit";
-import { getPaymentIdsForInvestorReverse } from "./reversePaymentPolicy";
 
 // ============================================
 // 🆕 TIPOS Y CONFIGURACIÓN PARA CONSULTAS ORIGINALES/ESPEJO
@@ -1020,20 +1019,8 @@ export async function processAndReplaceCreditInvestorsReverse(
     throw new Error(`Pago ${pago_id} no encontrado`);
   }
 
-  // 4. Obtener pagos de esa cuota como contexto. La reversa de inversionistas
-  // debe aplicar únicamente al pago seleccionado; otros pagos de la misma cuota
-  // pueden ser boletas legítimas y no se deben revertir parejo.
-  const pagosDeEsaCuota = pago.cuota_id === null
-    ? []
-    : await db
-        .select({ pago_id: pagos_credito.pago_id })
-        .from(pagos_credito)
-        .where(eq(pagos_credito.cuota_id, pago.cuota_id));
-
-  const pagoIds = getPaymentIdsForInvestorReverse(
-    pago_id,
-    pagosDeEsaCuota.map((p) => p.pago_id),
-  );
+  // 4. La reversa de inversionistas aplica únicamente al pago seleccionado.
+  const pagoIds = [pago_id];
 
   // 5. Por cada inversionista, sumar abono_capital solo del pago reversado.
   for (const inv of investors) {

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -1227,7 +1227,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
           monto_asignado: montoAsignar.toString(),
           inversionistas_padre: dataPadreDestino.length,
           inversionistas_espejo: dataEspejoDestinoFinal.length,
-          cube_eliminado: !nuevoArrayDestino.some(
+          cube_eliminado: !arrayDestinoPadre.some(
             (inv) => inv.inversionista_id === CUBE_INVESTMENT_ID,
           ),
         });

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -19,6 +19,7 @@ import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
 import { updateInstallments } from "./updateCredit";
 import {
+  getRemainingPaymentPaidStatusAfterReversal,
   shouldInstallmentRemainPaidAfterReversal,
   shouldRemoveSameInstallmentPaymentOnReverse,
 } from "./reversePaymentPolicy";
@@ -614,6 +615,21 @@ export const reversePayment = async ({ body, set }: any) => {
             .update(cuotas_credito)
             .set({ pagado: cuotaPermanecePagada })
             .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+        }
+
+        const pagosPagadosRestantesIds = pagosRestantesCuota
+          .filter((p) => p.pagado === true)
+          .map((p) => p.pago_id);
+
+        if (pagosPagadosRestantesIds.length > 0) {
+          await tx
+            .update(pagos_credito)
+            .set({
+              pagado: getRemainingPaymentPaidStatusAfterReversal(
+                cuotaPermanecePagada,
+              ),
+            })
+            .where(inArray(pagos_credito.pago_id, pagosPagadosRestantesIds));
         }
 
         console.log(`🗑️ Placeholders eliminados: ${pagosDuplicados.length}`);

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -18,6 +18,10 @@ import { updateMora } from "./latefee";
 import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
 import { updateInstallments } from "./updateCredit";
+import {
+  shouldInstallmentRemainPaidAfterReversal,
+  shouldRemoveSameInstallmentPaymentOnReverse,
+} from "./reversePaymentPolicy";
 // ============================================================================
 // SCHEMA DE VALIDACIÓN
 // ============================================================================
@@ -281,14 +285,7 @@ export const reversePayment = async ({ body, set }: any) => {
           "📝 Pago estaba PAGADO - Marcando cuota como NO pagada y reseteando pago",
         );
 
-        if (pago.cuota_id !== null) {
-          await tx
-            .update(cuotas_credito)
-            .set({ pagado: false })
-            .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
-        }
-
-        console.log("✅ Cuota marcada como NO pagada");
+        console.log("✅ El estado de la cuota se recalculará con los pagos restantes");
 
         // ======================================================================
         // 1️⃣1️⃣ RESETEAR EL PAGO (devolver a estado inicial)
@@ -559,18 +556,24 @@ export const reversePayment = async ({ body, set }: any) => {
       console.log("✅ Saldo a favor actualizado");
 
       // ======================================================================
-      // 1️⃣5️⃣ LIMPIAR PAGOS DUPLICADOS DE LA MISMA CUOTA
+      // 1️⃣5️⃣ LIMPIAR SOLO PLACEHOLDERS Y RECALCULAR ESTADO DE LA CUOTA
       // ======================================================================
       let pagosDuplicados: { pago_id: number }[] = [];
 
       if (pagoEstabaPagado) {
-        console.log("\n🧹 ========== LIMPIANDO PAGOS DUPLICADOS ==========");
+        console.log("\n🧹 ========== RECALCULANDO PAGOS DE LA CUOTA ==========");
 
-        // Primero obtener los IDs de pagos duplicados
-        const pagosDuplicadosIds = pago.cuota_id === null
+        const pagosMismaCuota = pago.cuota_id === null
           ? []
           : await tx
-              .select({ pago_id: pagos_credito.pago_id })
+              .select({
+                pago_id: pagos_credito.pago_id,
+                monto_aplicado: pagos_credito.monto_aplicado,
+                monto_boleta: pagos_credito.monto_boleta,
+                validationStatus: pagos_credito.validationStatus,
+                paymentFalse: pagos_credito.paymentFalse,
+                pagado: pagos_credito.pagado,
+              })
               .from(pagos_credito)
               .where(
                 and(
@@ -580,7 +583,9 @@ export const reversePayment = async ({ body, set }: any) => {
                 )
               );
 
-        const ids = pagosDuplicadosIds.map((p) => p.pago_id);
+        const ids = pagosMismaCuota
+          .filter((p) => shouldRemoveSameInstallmentPaymentOnReverse(p))
+          .map((p) => p.pago_id);
 
         if (ids.length > 0) {
           // Eliminar registros relacionados primero (evita FK constraint)
@@ -596,7 +601,25 @@ export const reversePayment = async ({ body, set }: any) => {
             .returning({ pago_id: pagos_credito.pago_id });
         }
 
-        console.log(`🗑️ Pagos duplicados eliminados: ${pagosDuplicados.length}`);
+        const pagosRestantesCuota = pagosMismaCuota.filter(
+          (p) => !ids.includes(p.pago_id),
+        );
+        const cuotaPermanecePagada = shouldInstallmentRemainPaidAfterReversal({
+          cuota: creditData.creditos.cuota,
+          remainingPayments: pagosRestantesCuota,
+        });
+
+        if (pago.cuota_id !== null) {
+          await tx
+            .update(cuotas_credito)
+            .set({ pagado: cuotaPermanecePagada })
+            .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+        }
+
+        console.log(`🗑️ Placeholders eliminados: ${pagosDuplicados.length}`);
+        console.log(
+          `✅ Cuota recalculada como ${cuotaPermanecePagada ? "PAGADA" : "NO pagada"}`,
+        );
       } else {
         console.log("\n⏭️ Pago eliminado - no se limpian duplicados");
       }

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getPaymentIdsForInvestorReverse,
+  shouldInstallmentRemainPaidAfterReversal,
+  shouldRemoveSameInstallmentPaymentOnReverse,
+} from "./reversePaymentPolicy";
+
+describe("reverse payment policy", () => {
+  it("no elimina otros pagos reales de la misma cuota al reversar un pago", () => {
+    expect(
+      shouldRemoveSameInstallmentPaymentOnReverse({
+        pago_id: 101,
+        monto_aplicado: "1500.00",
+        monto_boleta: "1500.00",
+        validationStatus: "validated",
+        paymentFalse: false,
+        pagado: true,
+      }),
+    ).toBeFalse();
+  });
+
+  it("solo considera removible un placeholder sin monto real", () => {
+    expect(
+      shouldRemoveSameInstallmentPaymentOnReverse({
+        pago_id: 102,
+        monto_aplicado: "0.00",
+        monto_boleta: "0.00",
+        validationStatus: "no_required",
+        paymentFalse: false,
+        pagado: false,
+      }),
+    ).toBeTrue();
+  });
+
+  it("mantiene la cuota pagada si los pagos restantes aun cubren la cuota", () => {
+    expect(
+      shouldInstallmentRemainPaidAfterReversal({
+        cuota: "2445.18",
+        remainingPayments: [
+          { monto_aplicado: "1500.00", validationStatus: "validated", paymentFalse: false },
+          { monto_aplicado: "945.18", validationStatus: "validated", paymentFalse: false },
+        ],
+      }),
+    ).toBeTrue();
+  });
+
+  it("marca la cuota como no pagada si los pagos restantes no cubren la cuota", () => {
+    expect(
+      shouldInstallmentRemainPaidAfterReversal({
+        cuota: "2445.18",
+        remainingPayments: [
+          { monto_aplicado: "500.00", validationStatus: "validated", paymentFalse: false },
+          { monto_aplicado: "445.18", validationStatus: "pending", paymentFalse: false },
+        ],
+      }),
+    ).toBeFalse();
+  });
+
+  it("reversa inversionistas solo para el pago seleccionado", () => {
+    expect(getPaymentIdsForInvestorReverse(101, [101, 102, 103])).toEqual([101]);
+  });
+});

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
-  getPaymentIdsForInvestorReverse,
+  getRemainingPaymentPaidStatusAfterReversal,
   shouldInstallmentRemainPaidAfterReversal,
   shouldRemoveSameInstallmentPaymentOnReverse,
 } from "./reversePaymentPolicy";
@@ -56,7 +56,8 @@ describe("reverse payment policy", () => {
     ).toBeFalse();
   });
 
-  it("reversa inversionistas solo para el pago seleccionado", () => {
-    expect(getPaymentIdsForInvestorReverse(101, [101, 102, 103])).toEqual([101]);
+  it("marca los pagos restantes igual que el estado recalculado de la cuota", () => {
+    expect(getRemainingPaymentPaidStatusAfterReversal(true)).toBeTrue();
+    expect(getRemainingPaymentPaidStatusAfterReversal(false)).toBeFalse();
   });
 });

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
@@ -56,6 +56,17 @@ describe("reverse payment policy", () => {
     ).toBeFalse();
   });
 
+  it("marca la cuota como no pagada si falta un centavo", () => {
+    expect(
+      shouldInstallmentRemainPaidAfterReversal({
+        cuota: "2445.18",
+        remainingPayments: [
+          { monto_aplicado: "2445.17", validationStatus: "validated", paymentFalse: false },
+        ],
+      }),
+    ).toBeFalse();
+  });
+
   it("marca los pagos restantes igual que el estado recalculado de la cuota", () => {
     expect(getRemainingPaymentPaidStatusAfterReversal(true)).toBeTrue();
     expect(getRemainingPaymentPaidStatusAfterReversal(false)).toBeFalse();

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
@@ -47,8 +47,7 @@ export function shouldInstallmentRemainPaidAfterReversal({
     return total.plus(toBig(payment.monto_aplicado));
   }, new Big(0));
 
-  // Payments can differ by one cent due to prior decimal rounding in cuotas.
-  return totalValidated.gte(cuotaAmount.minus(0.01));
+  return totalValidated.gte(cuotaAmount);
 }
 
 export function getRemainingPaymentPaidStatusAfterReversal(

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
@@ -1,0 +1,58 @@
+import Big from "big.js";
+
+type SameInstallmentPayment = {
+  pago_id?: number | string | null;
+  monto_aplicado?: string | number | null;
+  monto_boleta?: string | number | null;
+  validationStatus?: string | null;
+  paymentFalse?: boolean | null;
+  pagado?: boolean | null;
+};
+
+type RemainingPayment = {
+  monto_aplicado?: string | number | null;
+  validationStatus?: string | null;
+  paymentFalse?: boolean | null;
+};
+
+const toBig = (value?: string | number | null) => new Big(value ?? 0);
+
+export function shouldRemoveSameInstallmentPaymentOnReverse(
+  payment: SameInstallmentPayment,
+) {
+  return (
+    toBig(payment.monto_aplicado).eq(0) &&
+    toBig(payment.monto_boleta).eq(0) &&
+    payment.validationStatus === "no_required" &&
+    payment.pagado === false &&
+    payment.paymentFalse !== true
+  );
+}
+
+export function shouldInstallmentRemainPaidAfterReversal({
+  cuota,
+  remainingPayments,
+}: {
+  cuota?: string | number | null;
+  remainingPayments: RemainingPayment[];
+}) {
+  const cuotaAmount = toBig(cuota);
+  if (cuotaAmount.lte(0)) return false;
+
+  const totalValidated = remainingPayments.reduce((total, payment) => {
+    if (payment.validationStatus !== "validated" || payment.paymentFalse === true) {
+      return total;
+    }
+
+    return total.plus(toBig(payment.monto_aplicado));
+  }, new Big(0));
+
+  return totalValidated.gte(cuotaAmount.minus(0.01));
+}
+
+export function getPaymentIdsForInvestorReverse(
+  selectedPagoId: number,
+  _sameInstallmentPagoIds: number[],
+) {
+  return [selectedPagoId];
+}

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
@@ -47,12 +47,12 @@ export function shouldInstallmentRemainPaidAfterReversal({
     return total.plus(toBig(payment.monto_aplicado));
   }, new Big(0));
 
+  // Payments can differ by one cent due to prior decimal rounding in cuotas.
   return totalValidated.gte(cuotaAmount.minus(0.01));
 }
 
-export function getPaymentIdsForInvestorReverse(
-  selectedPagoId: number,
-  _sameInstallmentPagoIds: number[],
+export function getRemainingPaymentPaidStatusAfterReversal(
+  installmentRemainsPaid: boolean,
 ) {
-  return [selectedPagoId];
+  return installmentRemainsPaid;
 }

--- a/apps/cartera-back/src/utils/investorLiquidationSummary.ts
+++ b/apps/cartera-back/src/utils/investorLiquidationSummary.ts
@@ -32,7 +32,7 @@ export function resolveEstadoLiquidacionResumen({
   }
 
   if (requestedEstado === "liquidated") {
-    return hasLiquidado ? "liquidated" : null;
+    return !hasNoLiquidado && hasLiquidado ? "liquidated" : null;
   }
 
   if (hasNoLiquidado) {


### PR DESCRIPTION
## Summary
- reverse only the selected payment instead of deleting other real payments from the same installment
- remove only empty no_required placeholders and recalculate installment paid status from remaining validated payments
- reverse investor allocations only for the selected payment
- clean up investor liquidation/type checks so tests and typecheck pass

## Tests
- bun test
- bunx tsc --noEmit --project tsconfig.json