### PR TITLE
[codex] Fix stale analysis checklist document sync

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -49,6 +49,7 @@ import {
   type EstadoLiquidacionResumenFilter,
 } from "../utils/investorLiquidationSummary";
 import { addInvestorToCredit } from "./addInvestorToCredit";
+import { getPaymentIdsForInvestorReverse } from "./reversePaymentPolicy";
 
 // ============================================
 // 🆕 TIPOS Y CONFIGURACIÓN PARA CONSULTAS ORIGINALES/ESPEJO
@@ -1019,15 +1020,20 @@ export async function processAndReplaceCreditInvestorsReverse(
     throw new Error(`Pago ${pago_id} no encontrado`);
   }
 
-  // 4. Obtener TODOS los pagos de esa cuota
+  // 4. Obtener pagos de esa cuota como contexto. La reversa de inversionistas
+  // debe aplicar únicamente al pago seleccionado; otros pagos de la misma cuota
+  // pueden ser boletas legítimas y no se deben revertir parejo.
   const pagosDeEsaCuota = await db
     .select({ pago_id: pagos_credito.pago_id })
     .from(pagos_credito)
     .where(eq(pagos_credito.cuota_id, pago.cuota_id));
 
-  const pagoIds = pagosDeEsaCuota.map((p) => p.pago_id);
+  const pagoIds = getPaymentIdsForInvestorReverse(
+    pago_id,
+    pagosDeEsaCuota.map((p) => p.pago_id),
+  );
 
-  // 5. Por cada inversionista, sumar abono_capital de TODOS los pagos de esa cuota
+  // 5. Por cada inversionista, sumar abono_capital solo del pago reversado.
   for (const inv of investors) {
     const abonos = pagoIds.length > 0
       ? await db

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1023,10 +1023,12 @@ export async function processAndReplaceCreditInvestorsReverse(
   // 4. Obtener pagos de esa cuota como contexto. La reversa de inversionistas
   // debe aplicar únicamente al pago seleccionado; otros pagos de la misma cuota
   // pueden ser boletas legítimas y no se deben revertir parejo.
-  const pagosDeEsaCuota = await db
-    .select({ pago_id: pagos_credito.pago_id })
-    .from(pagos_credito)
-    .where(eq(pagos_credito.cuota_id, pago.cuota_id));
+  const pagosDeEsaCuota = pago.cuota_id === null
+    ? []
+    : await db
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .where(eq(pagos_credito.cuota_id, pago.cuota_id));
 
   const pagoIds = getPaymentIdsForInvestorReverse(
     pago_id,
@@ -1157,7 +1159,13 @@ export async function reversePagosEspejoPorInversionista(
   }
 
   // 5. Obtener cuotas asociadas a los pagos y marcarlas como NO liquidadas
-  const pagoIds = [...new Set(pagosEspejo.map((p) => p.pago_id))];
+  const pagoIds = [
+    ...new Set(
+      pagosEspejo
+        .map((p) => p.pago_id)
+        .filter((id): id is number => id !== null)
+    ),
+  ];
   console.log(`\n📅 Revirtiendo liquidación de cuotas (${pagoIds.length} pago_ids únicos)...`);
 
   if (pagoIds.length > 0) {
@@ -2332,7 +2340,13 @@ export async function revertirLiquidacion(liquidacion_id: number) {
     // PASO 5: Revertir cuotas del crédito
     //   Marcamos liquidado_inversionistas = false y limpiamos fecha
     // ──────────────────────────────────────────────
-    const allPagoIds = [...new Set(pagosLiquidados.map((p) => p.pago_id))];
+    const allPagoIds = [
+      ...new Set(
+        pagosLiquidados
+          .map((p) => p.pago_id)
+          .filter((id): id is number => id !== null)
+      ),
+    ];
     if (allPagoIds.length > 0) {
       const cuotasDeLosPagos = await tx
         .select({ cuota_id: pagos_credito.cuota_id })
@@ -3693,14 +3707,26 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
         }
 
         // Marcar cuotas como liquidado_inversionistas
-        const allPagoIds = [...new Set(pagosNoLiquidados.map((p) => p.pago_id))];
+        const allPagoIds = [
+          ...new Set(
+            pagosNoLiquidados
+              .map((p) => p.pago_id)
+              .filter((id): id is number => id !== null)
+          ),
+        ];
         if (allPagoIds.length > 0) {
           const cuotasDeLosPagos = await tx
             .select({ cuota_id: pagos_credito.cuota_id })
             .from(pagos_credito)
             .where(inArray(pagos_credito.pago_id, allPagoIds));
 
-          const uniqueCuotaIds = [...new Set(cuotasDeLosPagos.map((c) => c.cuota_id))];
+          const uniqueCuotaIds = [
+            ...new Set(
+              cuotasDeLosPagos
+                .map((c) => c.cuota_id)
+                .filter((id): id is number => id !== null)
+            ),
+          ];
           if (uniqueCuotaIds.length > 0) {
             const fechaGuatemala = new Date(
               new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -1227,7 +1227,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
           monto_asignado: montoAsignar.toString(),
           inversionistas_padre: dataPadreDestino.length,
           inversionistas_espejo: dataEspejoDestinoFinal.length,
-          cube_eliminado: !nuevoArrayDestino.some(
+          cube_eliminado: !arrayDestinoPadre.some(
             (inv) => inv.inversionista_id === CUBE_INVESTMENT_ID,
           ),
         });

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -18,6 +18,10 @@ import { updateMora } from "./latefee";
 import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
 import { updateInstallments } from "./updateCredit";
+import {
+  shouldInstallmentRemainPaidAfterReversal,
+  shouldRemoveSameInstallmentPaymentOnReverse,
+} from "./reversePaymentPolicy";
 // ============================================================================
 // SCHEMA DE VALIDACIÓN
 // ============================================================================
@@ -281,14 +285,7 @@ export const reversePayment = async ({ body, set }: any) => {
           "📝 Pago estaba PAGADO - Marcando cuota como NO pagada y reseteando pago",
         );
 
-        if (pago.cuota_id !== null) {
-          await tx
-            .update(cuotas_credito)
-            .set({ pagado: false })
-            .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
-        }
-
-        console.log("✅ Cuota marcada como NO pagada");
+        console.log("✅ El estado de la cuota se recalculará con los pagos restantes");
 
         // ======================================================================
         // 1️⃣1️⃣ RESETEAR EL PAGO (devolver a estado inicial)
@@ -559,18 +556,24 @@ export const reversePayment = async ({ body, set }: any) => {
       console.log("✅ Saldo a favor actualizado");
 
       // ======================================================================
-      // 1️⃣5️⃣ LIMPIAR PAGOS DUPLICADOS DE LA MISMA CUOTA
+      // 1️⃣5️⃣ LIMPIAR SOLO PLACEHOLDERS Y RECALCULAR ESTADO DE LA CUOTA
       // ======================================================================
       let pagosDuplicados: { pago_id: number }[] = [];
 
       if (pagoEstabaPagado) {
-        console.log("\n🧹 ========== LIMPIANDO PAGOS DUPLICADOS ==========");
+        console.log("\n🧹 ========== RECALCULANDO PAGOS DE LA CUOTA ==========");
 
-        // Primero obtener los IDs de pagos duplicados
-        const pagosDuplicadosIds = pago.cuota_id === null
+        const pagosMismaCuota = pago.cuota_id === null
           ? []
           : await tx
-              .select({ pago_id: pagos_credito.pago_id })
+              .select({
+                pago_id: pagos_credito.pago_id,
+                monto_aplicado: pagos_credito.monto_aplicado,
+                monto_boleta: pagos_credito.monto_boleta,
+                validationStatus: pagos_credito.validationStatus,
+                paymentFalse: pagos_credito.paymentFalse,
+                pagado: pagos_credito.pagado,
+              })
               .from(pagos_credito)
               .where(
                 and(
@@ -580,7 +583,9 @@ export const reversePayment = async ({ body, set }: any) => {
                 )
               );
 
-        const ids = pagosDuplicadosIds.map((p) => p.pago_id);
+        const ids = pagosMismaCuota
+          .filter((p) => shouldRemoveSameInstallmentPaymentOnReverse(p))
+          .map((p) => p.pago_id);
 
         if (ids.length > 0) {
           // Eliminar registros relacionados primero (evita FK constraint)
@@ -596,7 +601,25 @@ export const reversePayment = async ({ body, set }: any) => {
             .returning({ pago_id: pagos_credito.pago_id });
         }
 
-        console.log(`🗑️ Pagos duplicados eliminados: ${pagosDuplicados.length}`);
+        const pagosRestantesCuota = pagosMismaCuota.filter(
+          (p) => !ids.includes(p.pago_id),
+        );
+        const cuotaPermanecePagada = shouldInstallmentRemainPaidAfterReversal({
+          cuota: creditData.creditos.cuota,
+          remainingPayments: pagosRestantesCuota,
+        });
+
+        if (pago.cuota_id !== null) {
+          await tx
+            .update(cuotas_credito)
+            .set({ pagado: cuotaPermanecePagada })
+            .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+        }
+
+        console.log(`🗑️ Placeholders eliminados: ${pagosDuplicados.length}`);
+        console.log(
+          `✅ Cuota recalculada como ${cuotaPermanecePagada ? "PAGADA" : "NO pagada"}`,
+        );
       } else {
         console.log("\n⏭️ Pago eliminado - no se limpian duplicados");
       }

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import {
+  getPaymentIdsForInvestorReverse,
+  shouldInstallmentRemainPaidAfterReversal,
+  shouldRemoveSameInstallmentPaymentOnReverse,
+} from "./reversePaymentPolicy";
+
+describe("reverse payment policy", () => {
+  it("no elimina otros pagos reales de la misma cuota al reversar un pago", () => {
+    expect(
+      shouldRemoveSameInstallmentPaymentOnReverse({
+        pago_id: 101,
+        monto_aplicado: "1500.00",
+        monto_boleta: "1500.00",
+        validationStatus: "validated",
+        paymentFalse: false,
+        pagado: true,
+      }),
+    ).toBeFalse();
+  });
+
+  it("solo considera removible un placeholder sin monto real", () => {
+    expect(
+      shouldRemoveSameInstallmentPaymentOnReverse({
+        pago_id: 102,
+        monto_aplicado: "0.00",
+        monto_boleta: "0.00",
+        validationStatus: "no_required",
+        paymentFalse: false,
+        pagado: false,
+      }),
+    ).toBeTrue();
+  });
+
+  it("mantiene la cuota pagada si los pagos restantes aun cubren la cuota", () => {
+    expect(
+      shouldInstallmentRemainPaidAfterReversal({
+        cuota: "2445.18",
+        remainingPayments: [
+          { monto_aplicado: "1500.00", validationStatus: "validated", paymentFalse: false },
+          { monto_aplicado: "945.18", validationStatus: "validated", paymentFalse: false },
+        ],
+      }),
+    ).toBeTrue();
+  });
+
+  it("marca la cuota como no pagada si los pagos restantes no cubren la cuota", () => {
+    expect(
+      shouldInstallmentRemainPaidAfterReversal({
+        cuota: "2445.18",
+        remainingPayments: [
+          { monto_aplicado: "500.00", validationStatus: "validated", paymentFalse: false },
+          { monto_aplicado: "445.18", validationStatus: "pending", paymentFalse: false },
+        ],
+      }),
+    ).toBeFalse();
+  });
+
+  it("reversa inversionistas solo para el pago seleccionado", () => {
+    expect(getPaymentIdsForInvestorReverse(101, [101, 102, 103])).toEqual([101]);
+  });
+});

--- a/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/reversePaymentPolicy.ts
@@ -1,0 +1,58 @@
+import Big from "big.js";
+
+type SameInstallmentPayment = {
+  pago_id?: number | string | null;
+  monto_aplicado?: string | number | null;
+  monto_boleta?: string | number | null;
+  validationStatus?: string | null;
+  paymentFalse?: boolean | null;
+  pagado?: boolean | null;
+};
+
+type RemainingPayment = {
+  monto_aplicado?: string | number | null;
+  validationStatus?: string | null;
+  paymentFalse?: boolean | null;
+};
+
+const toBig = (value?: string | number | null) => new Big(value ?? 0);
+
+export function shouldRemoveSameInstallmentPaymentOnReverse(
+  payment: SameInstallmentPayment,
+) {
+  return (
+    toBig(payment.monto_aplicado).eq(0) &&
+    toBig(payment.monto_boleta).eq(0) &&
+    payment.validationStatus === "no_required" &&
+    payment.pagado === false &&
+    payment.paymentFalse !== true
+  );
+}
+
+export function shouldInstallmentRemainPaidAfterReversal({
+  cuota,
+  remainingPayments,
+}: {
+  cuota?: string | number | null;
+  remainingPayments: RemainingPayment[];
+}) {
+  const cuotaAmount = toBig(cuota);
+  if (cuotaAmount.lte(0)) return false;
+
+  const totalValidated = remainingPayments.reduce((total, payment) => {
+    if (payment.validationStatus !== "validated" || payment.paymentFalse === true) {
+      return total;
+    }
+
+    return total.plus(toBig(payment.monto_aplicado));
+  }, new Big(0));
+
+  return totalValidated.gte(cuotaAmount.minus(0.01));
+}
+
+export function getPaymentIdsForInvestorReverse(
+  selectedPagoId: number,
+  _sameInstallmentPagoIds: number[],
+) {
+  return [selectedPagoId];
+}

--- a/apps/cartera-back/src/utils/investorLiquidationSummary.ts
+++ b/apps/cartera-back/src/utils/investorLiquidationSummary.ts
@@ -32,7 +32,7 @@ export function resolveEstadoLiquidacionResumen({
   }
 
   if (requestedEstado === "liquidated") {
-    return hasLiquidado ? "liquidated" : null;
+    return !hasNoLiquidado && hasLiquidado ? "liquidated" : null;
   }
 
   if (hasNoLiquidado) {

--- a/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { hasStaleAnalysisChecklistVehicleState } from "./analysis-checklist";
+import {
+	hasStaleAnalysisChecklistDocumentState,
+	hasStaleAnalysisChecklistVehicleState,
+} from "./analysis-checklist";
 
 describe("analysis checklist helpers", () => {
 	test("detects stale checklist vehicle ids", () => {
@@ -71,5 +74,69 @@ describe("analysis checklist helpers", () => {
 				true,
 			),
 		).toBe(true);
+	});
+
+	test("detects stale client document upload state", () => {
+		expect(
+			hasStaleAnalysisChecklistDocumentState(
+				{
+					sections: {
+						documentos: {
+							items: [
+								{
+									documentType: "estados_cuenta_1",
+									uploaded: true,
+								},
+								{
+									documentType: "estados_cuenta_2",
+									uploaded: false,
+								},
+								{
+									documentType: "estados_cuenta_3",
+									uploaded: false,
+								},
+							],
+						},
+					},
+				},
+				new Set([
+					"estados_cuenta_1",
+					"estados_cuenta_2",
+					"estados_cuenta_3",
+				]),
+				new Set(),
+			),
+		).toBe(true);
+	});
+
+	test("treats matching client and vehicle document states as fresh", () => {
+		expect(
+			hasStaleAnalysisChecklistDocumentState(
+				{
+					sections: {
+						documentos: {
+							items: [
+								{
+									documentType: "dpi",
+									uploaded: true,
+								},
+							],
+						},
+						vehiculo: {
+							documentos: {
+								items: [
+									{
+										documentType: "tarjeta_circulacion",
+										uploaded: true,
+									},
+								],
+							},
+						},
+					},
+				},
+				new Set(["dpi"]),
+				new Set(["tarjeta_circulacion"]),
+			),
+		).toBe(false);
 	});
 });

--- a/apps/crm/apps/server/src/lib/analysis-checklist.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.ts
@@ -1,8 +1,20 @@
 type AnalysisChecklistData = {
 	sections?: {
+		documentos?: {
+			items?: Array<{
+				documentType?: string;
+				uploaded?: boolean;
+			}>;
+		};
 		vehiculo?: {
 			vehicleId?: string | null;
 			inspected?: boolean;
+			documentos?: {
+				items?: Array<{
+					documentType?: string;
+					uploaded?: boolean;
+				}>;
+			};
 		};
 	};
 };
@@ -18,5 +30,34 @@ export function hasStaleAnalysisChecklistVehicleState(
 	return (
 		savedVehicleId !== (currentVehicleId ?? null) ||
 		savedInspected !== currentInspected
+	);
+}
+
+function hasStaleDocumentItems(
+	items: Array<{ documentType?: string; uploaded?: boolean }> | undefined,
+	currentUploadedDocumentTypes: ReadonlySet<string>,
+) {
+	return (items ?? []).some(
+		(item) =>
+			!!item.documentType &&
+			(item.uploaded ?? false) !==
+				currentUploadedDocumentTypes.has(item.documentType),
+	);
+}
+
+export function hasStaleAnalysisChecklistDocumentState(
+	checklistData: AnalysisChecklistData | null | undefined,
+	currentUploadedClientDocumentTypes: ReadonlySet<string>,
+	currentUploadedVehicleDocumentTypes: ReadonlySet<string>,
+): boolean {
+	return (
+		hasStaleDocumentItems(
+			checklistData?.sections?.documentos?.items,
+			currentUploadedClientDocumentTypes,
+		) ||
+		hasStaleDocumentItems(
+			checklistData?.sections?.vehiculo?.documentos?.items,
+			currentUploadedVehicleDocumentTypes,
+		)
 	);
 }

--- a/apps/crm/apps/server/src/lib/checklist.ts
+++ b/apps/crm/apps/server/src/lib/checklist.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db";
-import { analysisChecklists, opportunities } from "../db/schema";
+import { analysisChecklists, opportunities, opportunityDocuments } from "../db/schema";
 
 /**
  * Updates the analysis checklist when a client document is uploaded
@@ -27,6 +27,16 @@ export async function updateChecklistForClientDocument(
 		console.log("Existing checklist found:", existing.id);
 
 		const checklistData = existing.checklistData as any;
+		const currentDocuments = await db
+			.select({
+				id: opportunityDocuments.id,
+				documentType: opportunityDocuments.documentType,
+			})
+			.from(opportunityDocuments)
+			.where(eq(opportunityDocuments.opportunityId, opportunityId));
+		const currentDocumentsByType = new Map(
+			currentDocuments.map((doc) => [doc.documentType, doc.id]),
+		);
 
 		// Find the document item in the documentos section
 		const docItem = checklistData.sections.documentos.items.find(
@@ -52,9 +62,12 @@ export async function updateChecklistForClientDocument(
 			return; // Document type not in checklist, that's OK
 		}
 
-		// Mark as uploaded and add the documentId
-		docItem.uploaded = true;
-		docItem.documentId = documentId;
+		// Rebuild client document upload state from the source of truth in DB.
+		for (const item of checklistData.sections.documentos.items) {
+			const currentDocumentId = currentDocumentsByType.get(item.documentType);
+			item.uploaded = !!currentDocumentId;
+			item.documentId = currentDocumentId;
+		}
 
 		// Recalculate documentos section completion
 		checklistData.sections.documentos.completed =

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -50,7 +50,10 @@ import {
 	opportunityDocuments,
 	VEHICLE_DOCUMENT_TYPES,
 } from "../db/schema/documents";
-import { hasStaleAnalysisChecklistVehicleState } from "../lib/analysis-checklist";
+import {
+	hasStaleAnalysisChecklistDocumentState,
+	hasStaleAnalysisChecklistVehicleState,
+} from "../lib/analysis-checklist";
 import {
 	updateChecklistForClientDocument,
 	updateChecklistForVehicleDocument,
@@ -4015,29 +4018,6 @@ export const crmRouter = {
 
 			console.log("[getAnalysisChecklist] opportunity:", opportunity);
 
-			// Early return if checklist already exists and is still aligned
-			if (existingChecklist) {
-				const inspectionResult = opportunity.vehicleId
-					? await getVehicleInspectionStatus(opportunity.vehicleId)
-					: {
-							isInspected: false,
-						};
-
-				if (
-					hasStaleAnalysisChecklistVehicleState(
-						existingChecklist.checklistData as any,
-						opportunity.vehicleId,
-						inspectionResult.isInspected,
-					)
-				) {
-					await db
-						.delete(analysisChecklists)
-						.where(eq(analysisChecklists.id, existingChecklist.id));
-				} else {
-					return existingChecklist.checklistData;
-				}
-			}
-
 			// Phase 2: Run independent queries in parallel
 			const [requiredDocs, uploadedDocs, vehicleResult, creditAnalysisResult] =
 				await Promise.all([
@@ -4204,6 +4184,28 @@ export const crmRouter = {
 			const uploadedVehicleTypes = new Set(
 				uploadedVehicleDocs.map((d) => d.documentType),
 			);
+
+			// Early return if checklist already exists and is still aligned
+			if (existingChecklist) {
+				if (
+					hasStaleAnalysisChecklistVehicleState(
+						existingChecklist.checklistData as any,
+						opportunity.vehicleId,
+						vehicleInspected,
+					) ||
+					hasStaleAnalysisChecklistDocumentState(
+						existingChecklist.checklistData as any,
+						uploadedTypes,
+						uploadedVehicleTypes,
+					)
+				) {
+					await db
+						.delete(analysisChecklists)
+						.where(eq(analysisChecklists.id, existingChecklist.id));
+				} else {
+					return existingChecklist.checklistData;
+				}
+			}
 
 			// Create initial checklist structure
 			const checklistData = {


### PR DESCRIPTION
## Summary
- regenerate analysis checklists when persisted document state is stale
- rebuild client document upload state from opportunity documents on upload
- add tests for stale document detection

## Verification
- bun test apps/server/src/lib/analysis-checklist.test.ts
- bun run --filter server check-types