### PR TITLE
[codex] Fix stale analysis checklist document sync

### DIFF
--- a/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+	carryForwardAnalysisChecklistVerificationState,
 	hasStaleAnalysisChecklistDocumentState,
 	hasStaleAnalysisChecklistVehicleState,
 } from "./analysis-checklist";
@@ -138,5 +139,70 @@ describe("analysis checklist helpers", () => {
 				new Set(["tarjeta_circulacion"]),
 			),
 		).toBe(false);
+	});
+
+	test("preserves manual verification state when regenerating checklist", () => {
+		const nextChecklistData = {
+			sections: {
+				verificaciones: {
+					items: [
+						{
+							type: "confirmacion_referencias",
+							completed: false,
+						},
+					],
+				},
+				vehiculo: {
+					verificaciones: {
+						items: [
+							{
+								type: "consulta_rgm",
+								completed: false,
+							},
+						],
+					},
+				},
+			},
+		};
+
+		carryForwardAnalysisChecklistVerificationState(nextChecklistData, {
+			sections: {
+				verificaciones: {
+					items: [
+						{
+							type: "confirmacion_referencias",
+							completed: true,
+							verifiedBy: "analyst-1",
+							verifiedAt: "2026-05-26T17:00:00.000Z",
+						},
+					],
+				},
+				vehiculo: {
+					verificaciones: {
+						items: [
+							{
+								type: "consulta_rgm",
+								completed: true,
+								verifiedBy: "analyst-2",
+								verifiedAt: "2026-05-26T17:05:00.000Z",
+							},
+						],
+					},
+				},
+			},
+		});
+
+		expect(nextChecklistData.sections.verificaciones.items[0]).toMatchObject({
+			completed: true,
+			verifiedBy: "analyst-1",
+			verifiedAt: "2026-05-26T17:00:00.000Z",
+		});
+		expect(
+			nextChecklistData.sections.vehiculo.verificaciones.items[0],
+		).toMatchObject({
+			completed: true,
+			verifiedBy: "analyst-2",
+			verifiedAt: "2026-05-26T17:05:00.000Z",
+		});
 	});
 });

--- a/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { hasStaleAnalysisChecklistVehicleState } from "./analysis-checklist";
+import {
+	hasStaleAnalysisChecklistDocumentState,
+	hasStaleAnalysisChecklistVehicleState,
+} from "./analysis-checklist";
 
 describe("analysis checklist helpers", () => {
 	test("detects stale checklist vehicle ids", () => {
@@ -71,5 +74,69 @@ describe("analysis checklist helpers", () => {
 				true,
 			),
 		).toBe(true);
+	});
+
+	test("detects stale client document upload state", () => {
+		expect(
+			hasStaleAnalysisChecklistDocumentState(
+				{
+					sections: {
+						documentos: {
+							items: [
+								{
+									documentType: "estados_cuenta_1",
+									uploaded: true,
+								},
+								{
+									documentType: "estados_cuenta_2",
+									uploaded: false,
+								},
+								{
+									documentType: "estados_cuenta_3",
+									uploaded: false,
+								},
+							],
+						},
+					},
+				},
+				new Set([
+					"estados_cuenta_1",
+					"estados_cuenta_2",
+					"estados_cuenta_3",
+				]),
+				new Set(),
+			),
+		).toBe(true);
+	});
+
+	test("treats matching client and vehicle document states as fresh", () => {
+		expect(
+			hasStaleAnalysisChecklistDocumentState(
+				{
+					sections: {
+						documentos: {
+							items: [
+								{
+									documentType: "dpi",
+									uploaded: true,
+								},
+							],
+						},
+						vehiculo: {
+							documentos: {
+								items: [
+									{
+										documentType: "tarjeta_circulacion",
+										uploaded: true,
+									},
+								],
+							},
+						},
+					},
+				},
+				new Set(["dpi"]),
+				new Set(["tarjeta_circulacion"]),
+			),
+		).toBe(false);
 	});
 });

--- a/apps/crm/apps/server/src/lib/analysis-checklist.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.ts
@@ -1,8 +1,20 @@
 type AnalysisChecklistData = {
 	sections?: {
+		documentos?: {
+			items?: Array<{
+				documentType?: string;
+				uploaded?: boolean;
+			}>;
+		};
 		vehiculo?: {
 			vehicleId?: string | null;
 			inspected?: boolean;
+			documentos?: {
+				items?: Array<{
+					documentType?: string;
+					uploaded?: boolean;
+				}>;
+			};
 		};
 	};
 };
@@ -18,5 +30,34 @@ export function hasStaleAnalysisChecklistVehicleState(
 	return (
 		savedVehicleId !== (currentVehicleId ?? null) ||
 		savedInspected !== currentInspected
+	);
+}
+
+function hasStaleDocumentItems(
+	items: Array<{ documentType?: string; uploaded?: boolean }> | undefined,
+	currentUploadedDocumentTypes: ReadonlySet<string>,
+) {
+	return (items ?? []).some(
+		(item) =>
+			!!item.documentType &&
+			(item.uploaded ?? false) !==
+				currentUploadedDocumentTypes.has(item.documentType),
+	);
+}
+
+export function hasStaleAnalysisChecklistDocumentState(
+	checklistData: AnalysisChecklistData | null | undefined,
+	currentUploadedClientDocumentTypes: ReadonlySet<string>,
+	currentUploadedVehicleDocumentTypes: ReadonlySet<string>,
+): boolean {
+	return (
+		hasStaleDocumentItems(
+			checklistData?.sections?.documentos?.items,
+			currentUploadedClientDocumentTypes,
+		) ||
+		hasStaleDocumentItems(
+			checklistData?.sections?.vehiculo?.documentos?.items,
+			currentUploadedVehicleDocumentTypes,
+		)
 	);
 }

--- a/apps/crm/apps/server/src/lib/analysis-checklist.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.ts
@@ -19,6 +19,13 @@ type AnalysisChecklistData = {
 	};
 };
 
+type VerificationItem = {
+	type?: string;
+	completed?: boolean;
+	verifiedBy?: string;
+	verifiedAt?: string;
+};
+
 export function hasStaleAnalysisChecklistVehicleState(
 	checklistData: AnalysisChecklistData | null | undefined,
 	currentVehicleId: string | null | undefined,
@@ -59,5 +66,51 @@ export function hasStaleAnalysisChecklistDocumentState(
 			checklistData?.sections?.vehiculo?.documentos?.items,
 			currentUploadedVehicleDocumentTypes,
 		)
+	);
+}
+
+function carryForwardVerificationItems(
+	nextItems: VerificationItem[] | undefined,
+	previousItems: VerificationItem[] | undefined,
+) {
+	const previousByType = new Map(
+		(previousItems ?? [])
+			.filter((item) => item.type)
+			.map((item) => [item.type, item]),
+	);
+
+	for (const nextItem of nextItems ?? []) {
+		if (!nextItem.type) continue;
+
+		const previousItem = previousByType.get(nextItem.type);
+		if (!previousItem) continue;
+
+		nextItem.completed = previousItem.completed ?? false;
+
+		if (previousItem.verifiedBy) {
+			nextItem.verifiedBy = previousItem.verifiedBy;
+		} else {
+			delete nextItem.verifiedBy;
+		}
+
+		if (previousItem.verifiedAt) {
+			nextItem.verifiedAt = previousItem.verifiedAt;
+		} else {
+			delete nextItem.verifiedAt;
+		}
+	}
+}
+
+export function carryForwardAnalysisChecklistVerificationState(
+	nextChecklistData: any,
+	previousChecklistData: any,
+) {
+	carryForwardVerificationItems(
+		nextChecklistData?.sections?.verificaciones?.items,
+		previousChecklistData?.sections?.verificaciones?.items,
+	);
+	carryForwardVerificationItems(
+		nextChecklistData?.sections?.vehiculo?.verificaciones?.items,
+		previousChecklistData?.sections?.vehiculo?.verificaciones?.items,
 	);
 }

--- a/apps/crm/apps/server/src/lib/checklist.ts
+++ b/apps/crm/apps/server/src/lib/checklist.ts
@@ -1,6 +1,6 @@
 import { eq } from "drizzle-orm";
 import { db } from "../db";
-import { analysisChecklists, opportunities } from "../db/schema";
+import { analysisChecklists, opportunities, opportunityDocuments } from "../db/schema";
 
 /**
  * Updates the analysis checklist when a client document is uploaded
@@ -27,6 +27,16 @@ export async function updateChecklistForClientDocument(
 		console.log("Existing checklist found:", existing.id);
 
 		const checklistData = existing.checklistData as any;
+		const currentDocuments = await db
+			.select({
+				id: opportunityDocuments.id,
+				documentType: opportunityDocuments.documentType,
+			})
+			.from(opportunityDocuments)
+			.where(eq(opportunityDocuments.opportunityId, opportunityId));
+		const currentDocumentsByType = new Map(
+			currentDocuments.map((doc) => [doc.documentType, doc.id]),
+		);
 
 		// Find the document item in the documentos section
 		const docItem = checklistData.sections.documentos.items.find(
@@ -52,9 +62,12 @@ export async function updateChecklistForClientDocument(
 			return; // Document type not in checklist, that's OK
 		}
 
-		// Mark as uploaded and add the documentId
-		docItem.uploaded = true;
-		docItem.documentId = documentId;
+		// Rebuild client document upload state from the source of truth in DB.
+		for (const item of checklistData.sections.documentos.items) {
+			const currentDocumentId = currentDocumentsByType.get(item.documentType);
+			item.uploaded = !!currentDocumentId;
+			item.documentId = currentDocumentId;
+		}
 
 		// Recalculate documentos section completion
 		checklistData.sections.documentos.completed =

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -50,7 +50,10 @@ import {
 	opportunityDocuments,
 	VEHICLE_DOCUMENT_TYPES,
 } from "../db/schema/documents";
-import { hasStaleAnalysisChecklistVehicleState } from "../lib/analysis-checklist";
+import {
+	hasStaleAnalysisChecklistDocumentState,
+	hasStaleAnalysisChecklistVehicleState,
+} from "../lib/analysis-checklist";
 import {
 	updateChecklistForClientDocument,
 	updateChecklistForVehicleDocument,
@@ -4015,29 +4018,6 @@ export const crmRouter = {
 
 			console.log("[getAnalysisChecklist] opportunity:", opportunity);
 
-			// Early return if checklist already exists and is still aligned
-			if (existingChecklist) {
-				const inspectionResult = opportunity.vehicleId
-					? await getVehicleInspectionStatus(opportunity.vehicleId)
-					: {
-							isInspected: false,
-						};
-
-				if (
-					hasStaleAnalysisChecklistVehicleState(
-						existingChecklist.checklistData as any,
-						opportunity.vehicleId,
-						inspectionResult.isInspected,
-					)
-				) {
-					await db
-						.delete(analysisChecklists)
-						.where(eq(analysisChecklists.id, existingChecklist.id));
-				} else {
-					return existingChecklist.checklistData;
-				}
-			}
-
 			// Phase 2: Run independent queries in parallel
 			const [requiredDocs, uploadedDocs, vehicleResult, creditAnalysisResult] =
 				await Promise.all([
@@ -4204,6 +4184,28 @@ export const crmRouter = {
 			const uploadedVehicleTypes = new Set(
 				uploadedVehicleDocs.map((d) => d.documentType),
 			);
+
+			// Early return if checklist already exists and is still aligned
+			if (existingChecklist) {
+				if (
+					hasStaleAnalysisChecklistVehicleState(
+						existingChecklist.checklistData as any,
+						opportunity.vehicleId,
+						vehicleInspected,
+					) ||
+					hasStaleAnalysisChecklistDocumentState(
+						existingChecklist.checklistData as any,
+						uploadedTypes,
+						uploadedVehicleTypes,
+					)
+				) {
+					await db
+						.delete(analysisChecklists)
+						.where(eq(analysisChecklists.id, existingChecklist.id));
+				} else {
+					return existingChecklist.checklistData;
+				}
+			}
 
 			// Create initial checklist structure
 			const checklistData = {

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -51,6 +51,7 @@ import {
 	VEHICLE_DOCUMENT_TYPES,
 } from "../db/schema/documents";
 import {
+	carryForwardAnalysisChecklistVerificationState,
 	hasStaleAnalysisChecklistDocumentState,
 	hasStaleAnalysisChecklistVehicleState,
 } from "../lib/analysis-checklist";
@@ -4018,6 +4019,8 @@ export const crmRouter = {
 
 			console.log("[getAnalysisChecklist] opportunity:", opportunity);
 
+			let shouldUpdateExistingChecklist = false;
+
 			// Phase 2: Run independent queries in parallel
 			const [requiredDocs, uploadedDocs, vehicleResult, creditAnalysisResult] =
 				await Promise.all([
@@ -4199,9 +4202,7 @@ export const crmRouter = {
 						uploadedVehicleTypes,
 					)
 				) {
-					await db
-						.delete(analysisChecklists)
-						.where(eq(analysisChecklists.id, existingChecklist.id));
+					shouldUpdateExistingChecklist = true;
 				} else {
 					return existingChecklist.checklistData;
 				}
@@ -4355,6 +4356,13 @@ export const crmRouter = {
 				canApprove: false,
 			};
 
+			if (shouldUpdateExistingChecklist) {
+				carryForwardAnalysisChecklistVerificationState(
+					checklistData,
+					existingChecklist?.checklistData,
+				);
+			}
+
 			// Calculate vehicle section completion
 			checklistData.sections.vehiculo.verificaciones.completed =
 				checklistData.sections.vehiculo.verificaciones.items
@@ -4420,11 +4428,21 @@ export const crmRouter = {
 					? checklistData.sections.vehiculo.completed
 					: true); // Only require vehicle section if there's a vehicle
 
-			// Save initial checklist
-			await db.insert(analysisChecklists).values({
-				opportunityId: input.opportunityId,
-				checklistData,
-			});
+			if (shouldUpdateExistingChecklist && existingChecklist) {
+				await db
+					.update(analysisChecklists)
+					.set({
+						checklistData,
+						updatedAt: new Date(),
+					})
+					.where(eq(analysisChecklists.id, existingChecklist.id));
+			} else {
+				// Save initial checklist
+				await db.insert(analysisChecklists).values({
+					opportunityId: input.opportunityId,
+					checklistData,
+				});
+			}
 
 			return checklistData;
 		}),


### PR DESCRIPTION
## Summary
- regenerate analysis checklists when persisted document state is stale
- rebuild client document upload state from opportunity documents on upload
- add tests for stale document detection

## Verification
- bun test apps/server/src/lib/analysis-checklist.test.ts
- bun run --filter server check-types