### PR TITLE
fix: optimize payment calculations to prevent double counting in reports

### DIFF
--- a/apps/cartera-back/drizzle/0003_add_historico_liquidaciones_espejo.sql
+++ b/apps/cartera-back/drizzle/0003_add_historico_liquidaciones_espejo.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS cartera.historico_liquidaciones_espejo (
+    id SERIAL PRIMARY KEY,
+    monto_aportado NUMERIC(18, 8) NOT NULL,
+    fecha TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    inversionista_id INTEGER NOT NULL
+        REFERENCES cartera.inversionistas(inversionista_id) ON DELETE CASCADE,
+    credito_id INTEGER NOT NULL
+        REFERENCES cartera.creditos(credito_id) ON DELETE CASCADE,
+    liquidacion_id INTEGER
+        REFERENCES cartera.liquidaciones(liquidacion_id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS ix_historico_liq_inv_cred
+    ON cartera.historico_liquidaciones_espejo (inversionista_id, credito_id);
+
+CREATE INDEX IF NOT EXISTS ix_historico_liq_fecha
+    ON cartera.historico_liquidaciones_espejo (fecha);
+
+CREATE INDEX IF NOT EXISTS ix_historico_liq_liquidacion_id
+    ON cartera.historico_liquidaciones_espejo (liquidacion_id);

--- a/apps/cartera-back/drizzle/0004_audit_monto_aportado_espejo.sql
+++ b/apps/cartera-back/drizzle/0004_audit_monto_aportado_espejo.sql
@@ -1,0 +1,78 @@
+-- Auditoría de cambios en monto_aportado de creditos_inversionistas_espejo.
+-- El trigger captura DELETE e INSERT (el código hace DELETE+INSERT en cada actualización)
+-- y los correlaciona via txid para poder ver "anterior → nuevo" en una sola query.
+
+CREATE TABLE cartera.historico_monto_aportado_espejo (
+  id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  txid              BIGINT        NOT NULL,
+  operacion         TEXT          NOT NULL,
+  credito_id        INT           NOT NULL REFERENCES cartera.creditos(credito_id) ON DELETE CASCADE,
+  inversionista_id  INT           NOT NULL REFERENCES cartera.inversionistas(inversionista_id) ON DELETE CASCADE,
+  monto_aportado    NUMERIC(18,8) NOT NULL,
+  platform_user_id  INT           REFERENCES cartera.platform_users(id) ON DELETE SET NULL,
+  source            TEXT          NOT NULL DEFAULT 'unknown',
+  fecha             TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ix_hist_mont_txid  ON cartera.historico_monto_aportado_espejo (txid);
+CREATE INDEX ix_hist_mont_cred  ON cartera.historico_monto_aportado_espejo (credito_id, inversionista_id);
+CREATE INDEX ix_hist_mont_fecha ON cartera.historico_monto_aportado_espejo (fecha);
+
+-- ──────────────────────────────────────────────────────────────
+-- Función trigger
+-- ──────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION cartera.audit_monto_aportado_espejo_fn()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_user_id INT;
+  v_source  TEXT;
+  v_setting TEXT;
+  v_row     cartera.creditos_inversionistas_espejo%ROWTYPE;
+BEGIN
+  v_setting := current_setting('app.current_user_id', true);
+  IF v_setting IS NOT NULL AND v_setting <> '' THEN
+    v_user_id := v_setting::INT;
+    v_source  := 'api_session';
+  ELSE
+    v_user_id := NULL;
+    v_source  := 'manual';
+  END IF;
+
+  v_row := CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+
+  INSERT INTO cartera.historico_monto_aportado_espejo
+    (txid, operacion, credito_id, inversionista_id, monto_aportado, platform_user_id, source)
+  VALUES
+    (txid_current(), TG_OP, v_row.credito_id, v_row.inversionista_id,
+     v_row.monto_aportado, v_user_id, v_source);
+
+  RETURN v_row;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ──────────────────────────────────────────────────────────────
+-- Trigger en creditos_inversionistas_espejo
+-- ──────────────────────────────────────────────────────────────
+DROP TRIGGER IF EXISTS trg_audit_monto_aportado_espejo
+  ON cartera.creditos_inversionistas_espejo;
+
+CREATE TRIGGER trg_audit_monto_aportado_espejo
+AFTER INSERT OR DELETE
+ON cartera.creditos_inversionistas_espejo
+FOR EACH ROW
+EXECUTE FUNCTION cartera.audit_monto_aportado_espejo_fn();
+
+-- ──────────────────────────────────────────────────────────────
+-- Query de referencia: ver cambios "anterior → nuevo"
+-- SELECT d.monto_aportado AS anterior,
+--        i.monto_aportado AS nuevo,
+--        d.credito_id, d.inversionista_id, d.platform_user_id, d.source, d.fecha
+-- FROM cartera.historico_monto_aportado_espejo d
+-- JOIN cartera.historico_monto_aportado_espejo i
+--   ON d.txid = i.txid
+--  AND d.credito_id = i.credito_id
+--  AND d.inversionista_id = i.inversionista_id
+--  AND d.operacion = 'DELETE'
+--  AND i.operacion = 'INSERT'
+-- ORDER BY d.fecha DESC;
+-- ──────────────────────────────────────────────────────────────

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -28,6 +28,7 @@ import {
   abonos_capital,
   cuentas_extra_inversionista,
   compras_credito_inversionista,
+  historico_liquidaciones_espejo,
   statusCreditoInversionistaEspejoEnum,
 } from "../database/db/schema";
 import { getSignedDocumentUrl } from "../utils/functions/uploadsFiles";
@@ -3643,7 +3644,49 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
         const pagosIds = pagosNoLiquidados.map((p) => p.id);
 
         for (const [creditoId, pagosCred] of creditosConPagos) {
-          const sumaCapital = pagosCred.reduce((sum, p) => sum + Number(p.abono_capital || 0), 0);
+          const sumaCapitalBig = pagosCred.reduce(
+            (acc, p) => acc.plus(new Big(p.abono_capital || 0)),
+            new Big(0)
+          );
+          const sumaCapital = sumaCapitalBig.toNumber(); // para processAndReplaceCreditInvestors (código preexistente)
+
+          // Snapshot monto_aportado BEFORE reduction
+          const [espejoRow] = await tx
+            .select({ monto_aportado: creditos_inversionistas_espejo.monto_aportado })
+            .from(creditos_inversionistas_espejo)
+            .where(
+              and(
+                eq(creditos_inversionistas_espejo.credito_id, creditoId),
+                eq(creditos_inversionistas_espejo.inversionista_id, inv_id)
+              )
+            )
+            .limit(1);
+
+          const currentMonto = espejoRow?.monto_aportado ?? "0";
+
+          // Validation 3 (cuadre): current espejo must match last historico if one exists
+          const [lastHistorico] = await tx
+            .select({ monto_aportado: historico_liquidaciones_espejo.monto_aportado })
+            .from(historico_liquidaciones_espejo)
+            .where(
+              and(
+                eq(historico_liquidaciones_espejo.credito_id, creditoId),
+                eq(historico_liquidaciones_espejo.inversionista_id, inv_id)
+              )
+            )
+            .orderBy(desc(historico_liquidaciones_espejo.fecha))
+            .limit(1);
+
+          if (lastHistorico && !new Big(currentMonto).eq(new Big(lastHistorico.monto_aportado))) {
+            const capitalRestante = new Big(currentMonto).minus(sumaCapitalBig).toFixed(8);
+            const historicoMonto = new Big(lastHistorico.monto_aportado).toFixed(8);
+            throw new Error(
+              `[CUADRE_CAPITAL] Inv ${inv_id} Cred ${creditoId}: ` +
+              `Capital Restante (${capitalRestante}) + Abono Capital (${sumaCapitalBig.toFixed(8)}) ` +
+              `= ${new Big(currentMonto).toFixed(8)} ≠ histórico (${historicoMonto})`
+            );
+          }
+
           if (sumaCapital > 0) {
             await processAndReplaceCreditInvestors(
               creditoId,
@@ -3654,6 +3697,17 @@ export async function liquidateByInvestorId(inversionista_id?: number) {
               tx
             );
           }
+
+          // Save historico with POST-reduction value — becomes baseline for next liquidation's cuadre check
+          const montoPostReduccion = new Big(currentMonto).minus(sumaCapitalBig).toFixed(8);
+          await tx
+            .insert(historico_liquidaciones_espejo)
+            .values({
+              monto_aportado: montoPostReduccion,
+              inversionista_id: inv_id,
+              credito_id: creditoId,
+              liquidacion_id: liquidacion.liquidacion_id,
+            });
         }
 
         let updateResult: any = { rowCount: 0 };

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -11,6 +11,7 @@ import {
   boletas,
   cuotas_credito,
   abonos_capital,
+  historico_liquidaciones_espejo,
 } from "../database/db/schema";
 import { desc, gte } from "drizzle-orm";
 import Big from "big.js";
@@ -453,6 +454,25 @@ export async function insertPagosCreditoInversionistas(
 
     console.log(`   ¿Es Cube? ${isCube ? "SÍ ✅" : "NO ❌"}`);
 
+    // Validation 1: monto_aportado in espejo must match last historico (skip if no record = first period)
+    const [lastHistoricoV1] = await db
+      .select({ monto_aportado: historico_liquidaciones_espejo.monto_aportado })
+      .from(historico_liquidaciones_espejo)
+      .where(
+        and(
+          eq(historico_liquidaciones_espejo.credito_id, credito_id),
+          eq(historico_liquidaciones_espejo.inversionista_id, inv.inversionista_id)
+        )
+      )
+      .orderBy(desc(historico_liquidaciones_espejo.fecha))
+      .limit(1);
+
+    if (lastHistoricoV1 && !new Big(inv.monto_aportado).eq(new Big(lastHistoricoV1.monto_aportado))) {
+      throw new Error(
+        `[MONTO_ESPEJO_INCONSISTENTE] Inv ${inv.inversionista_id} Cred ${credito_id}: espejo (${inv.monto_aportado}) ≠ histórico (${lastHistoricoV1.monto_aportado})`
+      );
+    }
+
     // --- Calcular los 4 campos desde monto_aportado (misma lógica que processAndReplaceCreditInvestors) ---
     const porcentajeCashIn = new Big(inv.porcentaje_cash_in);
     const porcentajeInversion = new Big(inv.porcentaje_participacion_inversionista);
@@ -678,6 +698,13 @@ export async function insertPagosCreditoInversionistas(
         console.log(`   💰 Abono a capital encontrado (id: ${abonoCapitalId}): +${montoAbono.toFixed(6)} (tipo: ${abonosNoLiquidados[0].tipo})`);
         console.log(`      abono_capital con abono sumado: ${abono_capital.toString()}`);
       }
+    }
+
+    // Validation 2: abono_capital must not exceed monto_aportado (prevents negative balance)
+    if (abono_capital.gt(new Big(inv.monto_aportado || 0))) {
+      throw new Error(
+        `[ABONO_SUPERA_MONTO] Inv ${inv.inversionista_id} Cred ${credito_id}: abono_capital (${abono_capital.toString()}) > monto_aportado (${inv.monto_aportado})`
+      );
     }
 
     const resultado = {

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1585,35 +1585,73 @@ export async function getPagosByVencimiento({
     ) cube_data ON true
   `;
 
-  // SQL para calcular el total por fila (Suma de restantes + Suma de abonos)
+  // Pre-agrega pagos_credito a 1 fila por (credito_id, cuota_id) para evitar doble conteo
+  // cuando una cuota tiene múltiples filas de pagos parciales. Cada fila original guarda un
+  // "snapshot" del saldo restante → SUM(X_restante + abono_X) infla los valores 2x-4x.
+  // Fórmula correcta: SUM(abono_X) + MIN(X_restante) = total pagado + saldo pendiente = obligación original.
+  // UNION ALL para cuota_id IS NULL: GROUP BY fusionaría NULLs incorrectamente.
+  const pagosDeduped = sql`
+    (
+      SELECT
+        pc.credito_id,
+        pc.cuota_id,
+        MIN(COALESCE(pc.capital_restante::numeric, 0))  + SUM(COALESCE(pc.abono_capital::numeric, 0))   AS capital_restante,
+        MIN(COALESCE(pc.interes_restante::numeric, 0))  + SUM(COALESCE(pc.abono_interes::numeric, 0))   AS interes_restante,
+        MIN(COALESCE(pc.iva_12_restante::numeric, 0))   + SUM(COALESCE(pc.abono_iva_12::numeric, 0))    AS iva_12_restante,
+        MIN(COALESCE(pc.seguro_restante::numeric, 0))   + SUM(COALESCE(pc.abono_seguro::numeric, 0))    AS seguro_restante,
+        MIN(COALESCE(pc.gps_restante::numeric, 0))      + SUM(COALESCE(pc.abono_gps::numeric, 0))       AS gps_restante,
+        MIN(COALESCE(pc.membresias::numeric, 0))        + SUM(COALESCE(pc.membresias_pago::numeric, 0)) AS membresias,
+        SUM(COALESCE(pc.monto_boleta::numeric, 0)) AS monto_boleta,
+        MIN(pc.fecha_vencimiento) AS fecha_vencimiento,
+        BOOL_OR(pc.pagado) AS pagado
+      FROM cartera.pagos_credito pc
+      WHERE pc.cuota_id IS NOT NULL
+      GROUP BY pc.credito_id, pc.cuota_id
+
+      UNION ALL
+
+      SELECT
+        pc.credito_id,
+        pc.cuota_id,
+        COALESCE(pc.capital_restante::numeric, 0)  + COALESCE(pc.abono_capital::numeric, 0)   AS capital_restante,
+        COALESCE(pc.interes_restante::numeric, 0)  + COALESCE(pc.abono_interes::numeric, 0)   AS interes_restante,
+        COALESCE(pc.iva_12_restante::numeric, 0)   + COALESCE(pc.abono_iva_12::numeric, 0)    AS iva_12_restante,
+        COALESCE(pc.seguro_restante::numeric, 0)   + COALESCE(pc.abono_seguro::numeric, 0)    AS seguro_restante,
+        COALESCE(pc.gps_restante::numeric, 0)      + COALESCE(pc.abono_gps::numeric, 0)       AS gps_restante,
+        COALESCE(pc.membresias::numeric, 0)        + COALESCE(pc.membresias_pago::numeric, 0) AS membresias,
+        COALESCE(pc.monto_boleta::numeric, 0) AS monto_boleta,
+        pc.fecha_vencimiento,
+        pc.pagado
+      FROM cartera.pagos_credito pc
+      WHERE pc.cuota_id IS NULL
+    ) p
+  `;
+
+  // Cada campo pre-agregado ya = MIN(restante) + SUM(abono) = obligación total de la cuota.
+  // No sumar abono_* por separado — están incluidos.
   const totalFilaSql = sql`(
-    COALESCE(p.capital_restante, 0)::numeric + 
-    COALESCE(p.interes_restante, 0)::numeric + 
-    COALESCE(p.iva_12_restante, 0)::numeric + 
-    COALESCE(p.seguro_restante, 0)::numeric + 
-    COALESCE(p.gps_restante, 0)::numeric + 
-    COALESCE(p.membresias, 0)::numeric + 
-    COALESCE(p.membresias_pago, 0)::numeric + 
-    COALESCE(p.abono_capital, 0)::numeric + 
-    COALESCE(p.abono_interes, 0)::numeric + 
-    COALESCE(p.abono_iva_12, 0)::numeric + 
-    COALESCE(p.abono_seguro, 0)::numeric + 
-    COALESCE(p.abono_gps, 0)::numeric
+    COALESCE(p.capital_restante, 0)::numeric +
+    COALESCE(p.interes_restante, 0)::numeric +
+    COALESCE(p.iva_12_restante, 0)::numeric +
+    COALESCE(p.seguro_restante, 0)::numeric +
+    COALESCE(p.gps_restante, 0)::numeric +
+    COALESCE(p.membresias, 0)::numeric +
+    COALESCE(p.monto_boleta, 0)::numeric
   )`;
 
   // 1. Totales globales y conteo de créditos únicos
   const totalesResult = await db.execute<any>(sql`
     SELECT
       COUNT(DISTINCT c.credito_id)::int AS total_count,
-      COALESCE(SUM(p.capital_restante::numeric + COALESCE(p.abono_capital, 0)::numeric), 0) AS total_capital_restante,
-      COALESCE(SUM(p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric), 0) AS total_interes_restante,
-      COALESCE(SUM(p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric), 0) AS total_iva_12_restante,
-      COALESCE(SUM(p.seguro_restante::numeric + COALESCE(p.abono_seguro, 0)::numeric), 0) AS total_seguro_restante,
-      COALESCE(SUM(p.gps_restante::numeric + COALESCE(p.abono_gps, 0)::numeric), 0) AS total_gps_restante,
-      COALESCE(SUM(p.membresias::numeric + COALESCE(p.membresias_pago, 0)::numeric), 0) AS total_membresias,
-      COALESCE(SUM((p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_interes_cube,
-      COALESCE(SUM((p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_iva_cube
-    FROM cartera.pagos_credito p
+      COALESCE(SUM(p.capital_restante::numeric), 0) AS total_capital_restante,
+      COALESCE(SUM(p.interes_restante::numeric), 0) AS total_interes_restante,
+      COALESCE(SUM(p.iva_12_restante::numeric), 0) AS total_iva_12_restante,
+      COALESCE(SUM(p.seguro_restante::numeric), 0) AS total_seguro_restante,
+      COALESCE(SUM(p.gps_restante::numeric), 0) AS total_gps_restante,
+      COALESCE(SUM(p.membresias::numeric), 0) AS total_membresias,
+      COALESCE(SUM(p.interes_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_interes_cube,
+      COALESCE(SUM(p.iva_12_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_iva_cube
+    FROM ${pagosDeduped}
     INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
     INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
@@ -1638,15 +1676,15 @@ export async function getPagosByVencimiento({
       c.royalti,
       MIN(q.numero_cuota) AS cuota_min,
       MAX(q.numero_cuota) AS cuota_max,
-      COALESCE(SUM(p.capital_restante::numeric + COALESCE(p.abono_capital, 0)::numeric), 0) AS capital_restante,
-      COALESCE(SUM(p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric), 0) AS interes_restante,
-      COALESCE(SUM(p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric), 0) AS iva_12_restante,
-      COALESCE(SUM(p.seguro_restante::numeric + COALESCE(p.abono_seguro, 0)::numeric), 0) AS seguro_restante,
-      COALESCE(SUM(p.gps_restante::numeric + COALESCE(p.abono_gps, 0)::numeric), 0) AS gps_restante,
-      COALESCE(SUM(p.membresias::numeric + COALESCE(p.membresias_pago, 0)::numeric), 0) AS membresias,
+      COALESCE(SUM(p.capital_restante::numeric), 0) AS capital_restante,
+      COALESCE(SUM(p.interes_restante::numeric), 0) AS interes_restante,
+      COALESCE(SUM(p.iva_12_restante::numeric), 0) AS iva_12_restante,
+      COALESCE(SUM(p.seguro_restante::numeric), 0) AS seguro_restante,
+      COALESCE(SUM(p.gps_restante::numeric), 0) AS gps_restante,
+      COALESCE(SUM(p.membresias::numeric), 0) AS membresias,
       COALESCE(SUM(p.monto_boleta::numeric), 0) AS monto_boleta,
-      COALESCE(SUM((p.interes_restante::numeric + COALESCE(p.abono_interes, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS interes_cube,
-      COALESCE(SUM((p.iva_12_restante::numeric + COALESCE(p.abono_iva_12, 0)::numeric) * COALESCE(cube_data.cash_in_pct, 0)), 0) AS iva_cube,
+      COALESCE(SUM(p.interes_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS interes_cube,
+      COALESCE(SUM(p.iva_12_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS iva_cube,
       COALESCE(SUM(${totalFilaSql}), 0) AS total_pagos_del_mes,
       CASE
         WHEN MAX(m.cuotas_atrasadas) = 1 THEN 'Mora 30'
@@ -1655,7 +1693,7 @@ export async function getPagosByVencimiento({
         WHEN MAX(m.cuotas_atrasadas) >= 4 THEN 'Mora 120+'
         ELSE 'Al día'
       END AS dias_mora
-    FROM cartera.pagos_credito p
+    FROM ${pagosDeduped}
     INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
     INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
     INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -1,5 +1,6 @@
 import Big from "big.js";
 import { eq, and, inArray, asc, gt, lte, gte, sql } from "drizzle-orm";
+import jwt from "jsonwebtoken";
 import { db } from "../database";
 import {
   creditos,
@@ -13,6 +14,7 @@ import {
 import z from "zod";
 import type { WSCrEstadoCuentaResponse } from "../services/sifco.interface";
 import { consultarEstadoCuentaPrestamo } from "../services/sifcoIntegrations";
+import { withAuditContext } from "../utils/withAuditContext";
 
 interface UpdateInstallmentsParams {
   numero_credito_sifco: string;
@@ -647,11 +649,12 @@ const updateInvestors = async (
   gps: number,
   targetTable: any = creditos_inversionistas,
   parentCuotas?: Map<number, string>,
+  dbInstance: typeof db = db,
 ): Promise<Map<number, string>> => {
   if (!inversionistas || inversionistas.length === 0) return new Map();
 
   // 🔥 NUEVO: Obtener los datos existentes ANTES de borrar para preservar el estado
-  const existingRecords = await db
+  const existingRecords = await dbInstance
     .select()
     .from(targetTable)
     .where(eq(targetTable.credito_id, credito_id));
@@ -666,7 +669,7 @@ const updateInvestors = async (
   });
 
   // Eliminar inversionistas existentes
-  await db
+  await dbInstance
     .delete(targetTable)
     .where(eq(targetTable.credito_id, credito_id));
   console.log(current.capital, "current values ");
@@ -894,7 +897,7 @@ const updateInvestors = async (
 
   // Insertar nuevos inversionistas
   if (creditosInversionistasData.length > 0) {
-    await db.insert(targetTable).values(creditosInversionistasData);
+    await dbInstance.insert(targetTable).values(creditosInversionistasData);
   }
 
   // 🔥 CAPTURAR Y DEVOLVER MAP DE CUOTAS PARA SINCRONIZACIÓN CON ESPEJO
@@ -935,7 +938,21 @@ const syncScheduleOnTermsChange = async ({
 // FUNCIÓN PRINCIPAL DE ACTUALIZACIÓN
 // ========================================
 
-export const updateCredit = async ({ body, set }: any) => {
+const JWT_SECRET = process.env.JWT_SECRET || "supersecreto";
+
+const extractUserId = (request: Request): number | null => {
+  try {
+    const authHeader = request.headers.get("Authorization");
+    if (authHeader?.startsWith("Bearer ")) {
+      const token = authHeader.replace("Bearer ", "").trim();
+      const decoded = jwt.verify(token, JWT_SECRET) as any;
+      return decoded.id ?? decoded.user_id ?? null;
+    }
+  } catch { /* token inválido, continuar sin userId */ }
+  return null;
+};
+
+export const updateCredit = async ({ body, set, request }: any) => {
   try {
     console.log("Updating credit with body:", body);
 
@@ -1283,18 +1300,27 @@ export const updateCredit = async ({ body, set }: any) => {
 
       console.log(`🪞 [ESPEJO] Iniciando updateInvestors para credito_id=${credito_id} con ${espejoSincronizado.length} inversionistas`);
       try {
-        await updateInvestors(
-          credito_id,
-          espejoSincronizado,
-          updateFields,
-          current,
-          numero_credito_sifco ?? current.numero_credito_sifco,
-          Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
-          Number(updateFields.membresias_pago ?? current.membresias_pago),
-          Number(updateFields.gps ?? current.gps),
-          creditos_inversionistas_espejo,
-          parentCuotas, // 🔥 NUEVO: Pasar las cuotas capturadas del padre
-        );
+        const espejoUserId = extractUserId(request);
+        const runEspejoUpdate = async (dbInstance: typeof db) =>
+          updateInvestors(
+            credito_id,
+            espejoSincronizado,
+            updateFields,
+            current,
+            numero_credito_sifco ?? current.numero_credito_sifco,
+            Number(updateFields.seguro_10_cuotas ?? current.seguro_10_cuotas),
+            Number(updateFields.membresias_pago ?? current.membresias_pago),
+            Number(updateFields.gps ?? current.gps),
+            creditos_inversionistas_espejo,
+            parentCuotas,
+            dbInstance,
+          );
+
+        if (espejoUserId) {
+          await withAuditContext(espejoUserId, runEspejoUpdate);
+        } else {
+          await runEspejoUpdate(db);
+        }
         console.log(`🪞 [ESPEJO] ✅ updateInvestors completado para espejo`);
       } catch (espejoError) {
         console.error(`🪞 [ESPEJO] ❌ Error en updateInvestors espejo:`, espejoError);

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1226,6 +1226,28 @@
     updated_at: timestamp("updated_at").defaultNow(),
   });
 
+  export const historico_liquidaciones_espejo = customSchema.table(
+    "historico_liquidaciones_espejo",
+    {
+      id: serial("id").primaryKey(),
+      monto_aportado: numeric("monto_aportado", { precision: 18, scale: 8 }).notNull(),
+      fecha: timestamp("fecha", { withTimezone: true }).notNull().defaultNow(),
+      inversionista_id: integer("inversionista_id")
+        .notNull()
+        .references(() => inversionistas.inversionista_id, { onDelete: "cascade" }),
+      credito_id: integer("credito_id")
+        .notNull()
+        .references(() => creditos.credito_id, { onDelete: "cascade" }),
+      liquidacion_id: integer("liquidacion_id")
+        .references(() => liquidaciones.liquidacion_id, { onDelete: "set null" }),
+    },
+    (t) => ({
+      ixInvCred: index("ix_historico_liq_inv_cred").on(t.inversionista_id, t.credito_id),
+      ixFecha: index("ix_historico_liq_fecha").on(t.fecha),
+      ixLiquidacion: index("ix_historico_liq_liquidacion_id").on(t.liquidacion_id),
+    })
+  );
+
   // ── Recibos genéricos (sin FK a créditos) ──
   export const recibos_genericos = customSchema.table("recibos_genericos", {
     id: serial("id").primaryKey(),
@@ -1247,6 +1269,27 @@
     concepto: varchar("concepto", { length: 300 }).notNull(),
     monto: numeric("monto", { precision: 18, scale: 2 }).notNull(),
   });
+
+  // ── Historial de cambios de monto_aportado en creditos_inversionistas_espejo ──
+  export const historico_monto_aportado_espejo = customSchema.table(
+    "historico_monto_aportado_espejo",
+    {
+      id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+      txid: bigint("txid", { mode: "number" }).notNull(),
+      operacion: text("operacion").notNull(),
+      credito_id: integer("credito_id").notNull().references(() => creditos.credito_id, { onDelete: "cascade" }),
+      inversionista_id: integer("inversionista_id").notNull().references(() => inversionistas.inversionista_id, { onDelete: "cascade" }),
+      monto_aportado: numeric("monto_aportado", { precision: 18, scale: 8 }).notNull(),
+      platform_user_id: integer("platform_user_id").references(() => platform_users.id, { onDelete: "set null" }),
+      source: text("source").notNull().default("unknown"),
+      fecha: timestamp("fecha", { withTimezone: true }).notNull().defaultNow(),
+    },
+    (t) => ({
+      ixTxid:   index("ix_hist_mont_txid").on(t.txid),
+      ixCred:   index("ix_hist_mont_cred").on(t.credito_id, t.inversionista_id),
+      ixFecha:  index("ix_hist_mont_fecha").on(t.fecha),
+    })
+  );
 
   // ── Audit logs ──
   export const audit_logs = customSchema.table("audit_logs", {

--- a/apps/cartera-back/src/utils/withAuditContext.ts
+++ b/apps/cartera-back/src/utils/withAuditContext.ts
@@ -1,0 +1,14 @@
+import { sql } from "drizzle-orm";
+import { db } from "../database";
+
+type DbOrTx = typeof db;
+
+export async function withAuditContext<T>(
+  userId: number,
+  fn: (tx: DbOrTx) => Promise<T>
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    await tx.execute(sql`SET LOCAL app.current_user_id = ${userId.toString()}`);
+    return fn(tx as unknown as DbOrTx);
+  });
+}


### PR DESCRIPTION
## Fix: doble conteo de cuotas con pagos parciales en reporte Pagos por Vencimiento

### Problema

Cuando una cuota recibe múltiples pagos parciales, `pagos_credito` genera varias filas para el mismo `cuota_id`. Cada fila almacena un snapshot del saldo restante en ese momento. La fórmula anterior `SUM(X_restante + abono_X)` sumaba ese snapshot por cada fila, inflando los valores 2x–4x.

Mayo 2026: 111 créditos afectados. Ejemplo: crédito 604 reportaba Q12,744 de interés cuando el valor correcto es Q6,645.

Columnas afectadas: capital, interés, IVA, seguro, GPS, membresías, Int. CUBE, IVA CUBE.

### Solución

Se pre-agrega `pagos_credito` a una sola fila por `(credito_id, cuota_id)` antes de cualquier JOIN o suma, usando la fórmula:

SUM(abono_X) + MIN(X_restante) = total pagado + saldo pendiente = obligación original de la cuota



Se maneja `cuota_id IS NULL` con UNION ALL para evitar que GROUP BY fusione NULLs de distintas boletas incorrectamente.

### Archivos modificados

- `apps/cartera-back/src/controllers/reports.ts` — función `getPagosByVencimiento`
  - Subquery `pagosDeduped`: pre-agrega pagos por cuota con fórmula correcta
  - `totalFilaSql`: simplificado, sin sumar abonos por separado
  - Queries de totales y paginada/excel: `FROM pagosDeduped` y `SUM(p.X)` en lugar de `SUM(p.X_restante + abono_X)`

### También incluido en este branch

- Fix `cubeSubquery` (`Int. CUBE` / `IVA CUBE`): créditos con inversionistas externos mostraban Q0.00 porque CUBE no figuraba en `creditos_inversionistas`. Ahora calcula la participación implícita de CUBE como `capital - SUM(montos_externos)`, usando `porcentaje_cash_in` ponderado por monto para todos los inversionistas.
