### PR TITLE
Enhances investor payment adjustments and credit assignment

### DIFF
--- a/apps/cartera-back/ajustarPagos/masivo.json
+++ b/apps/cartera-back/ajustarPagos/masivo.json
@@ -1,0 +1,506 @@
+[
+  {
+    "inversionista_id": 2,
+    "inversionista_nombre": "Aida Irene Dubois",
+    "liquidacion_id": 371,
+    "cambios": [
+      {
+        "credito_id": 8683,
+        "abono_capital": 7.47,
+        "monto_aportado": 736.4
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 3,
+    "inversionista_nombre": "Alejandro Mayen Herrera",
+    "liquidacion_id": 384,
+    "cambios": [
+      {
+        "credito_id": 8685,
+        "monto_aportado": 8424.31
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 4,
+    "inversionista_nombre": "Ana Lucia Salvatierra",
+    "liquidacion_id": 382,
+    "cambios": [
+      {
+        "credito_id": 8724,
+        "abono_capital": 18.348752,
+        "abono_interes": 21.92232,
+        "iva": 2.6306784,
+        "monto_aportado": 1808.52
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 7,
+    "inversionista_nombre": "Anna Lisseth Lorenzo Rodas",
+    "liquidacion_id": 432,
+    "cambios": [
+      {
+        "credito_id": 4789,
+        "monto_aportado": 5375.74
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 10,
+    "inversionista_nombre": "Bibiana Moyano",
+    "liquidacion_id": 340,
+    "cambios": [
+      {
+        "credito_id": 330,
+        "abono_capital": 7.79,
+        "abono_interes": 6.21,
+        "iva": 0.7452,
+        "monto_aportado": 509.69
+      },
+      {
+        "credito_id": 691,
+        "abono_capital": 6.7656,
+        "abono_interes": 7.66,
+        "iva": 0.9192,
+        "monto_aportado": 631.5944
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 11,
+    "inversionista_nombre": "Boris Gilberto Lemus Villatoro",
+    "liquidacion_id": 446,
+    "cambios": [
+      {
+        "credito_id": 743,
+        "abono_capital": 28.44,
+        "abono_interes": 58.00044,
+        "iva": 6.9600528,
+        "monto_aportado": 4804.93
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 19,
+    "inversionista_nombre": "Diego Arturo Bracamonte",
+    "liquidacion_id": 351,
+    "cambios": [
+      {
+        "credito_id": 955,
+        "abono_capital": 0.0,
+        "monto_aportado": 0.0
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 26,
+    "inversionista_nombre": "Giancarlo Massis Clubcashin.com",
+    "liquidacion_id": 376,
+    "cambios": [
+      {
+        "credito_id": 8699,
+        "monto_aportado": 9231.394984
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 27,
+    "inversionista_nombre": "Glenda Roxana Godoy Bedoya",
+    "liquidacion_id": 394,
+    "cambios": [
+      {
+        "credito_id": 8736,
+        "monto_aportado": 374.375032
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 30,
+    "inversionista_nombre": "Guillermo Zaid",
+    "liquidacion_id": 354,
+    "cambios": [
+      {
+        "credito_id": 4857,
+        "monto_aportado": 6551.22
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 33,
+    "inversionista_nombre": "Inversiones CASCAI  Sociedad Anonima",
+    "liquidacion_id": 412,
+    "cambios": [
+      {
+        "credito_id": 8705,
+        "monto_aportado": 10762.71
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 34,
+    "inversionista_nombre": "INVERSIONES DELFINA , S.A.",
+    "liquidacion_id": 385,
+    "cambios": [
+      {
+        "credito_id": 8871,
+        "abono_capital": 21.06,
+        "abono_interes": 32.44,
+        "iva": 3.8928,
+        "monto_aportado": 2862.28
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 51,
+    "inversionista_nombre": "Juan Guzman",
+    "liquidacion_id": 383,
+    "cambios": [
+      {
+        "credito_id": 8738,
+        "monto_aportado": 346.29
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 61,
+    "inversionista_nombre": "Maria Ines Rodas",
+    "liquidacion_id": 426,
+    "cambios": [
+      {
+        "credito_id": 600,
+        "monto_aportado": 939.33992
+      },
+      {
+        "credito_id": 8719,
+        "monto_aportado": 1912.455248
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 63,
+    "inversionista_nombre": "Mario Estuardo Samperio Torrebiarte",
+    "liquidacion_id": 390,
+    "cambios": [
+      {
+        "credito_id": 8684,
+        "monto_aportado": 5406.032784
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 67,
+    "inversionista_nombre": "Milton Jose Barascout Ramirez",
+    "liquidacion_id": 392,
+    "cambios": [
+      {
+        "credito_id": 261,
+        "monto_aportado": 22708.691096
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 69,
+    "inversionista_nombre": "NXGN  Investments, S.A.",
+    "liquidacion_id": 352,
+    "cambios": [
+      {
+        "credito_id": 8674,
+        "abono_capital": 5.741912,
+        "monto_aportado": 566.168088
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 71,
+    "inversionista_nombre": "PEDRO PABLO CARRILLO GULARTE",
+    "liquidacion_id": 355,
+    "cambios": [
+      {
+        "credito_id": 8759,
+        "abono_capital": 0.981128,
+        "abono_interes": 2.418045,
+        "iva": 0.2901654,
+        "monto_aportado": 229.308872
+      },
+      {
+        "credito_id": 733,
+        "monto_aportado": 206.771032
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 74,
+    "inversionista_nombre": "Rafael Figueroa",
+    "liquidacion_id": 398,
+    "cambios": [
+      {
+        "credito_id": 8707,
+        "monto_aportado": 11195.1628
+      },
+      {
+        "credito_id": 433,
+        "monto_aportado": 19419.648664
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 77,
+    "inversionista_nombre": "Rodrigo Estrada Osorio",
+    "liquidacion_id": 411,
+    "cambios": [
+      {
+        "credito_id": 8776,
+        "monto_aportado": 5197.69528
+      },
+      {
+        "credito_id": 832,
+        "abono_interes": 9.9857835,
+        "iva": 1.19829402
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 78,
+    "inversionista_nombre": "Rodrigo Mendieta",
+    "liquidacion_id": 419,
+    "cambios": [
+      {
+        "credito_id": 25,
+        "abono_capital": 1342.83,
+        "abono_interes": 759.28,
+        "iva": 91.1136,
+        "monto_aportado": 61930.63
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 80,
+    "inversionista_nombre": "Rut Noemí Toledo Jerez",
+    "liquidacion_id": 408,
+    "cambios": [
+      {
+        "credito_id": 701,
+        "monto_aportado": 140.099208
+      },
+      {
+        "credito_id": 735,
+        "abono_capital": 1.615648,
+        "monto_aportado": 151.024352
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 82,
+    "inversionista_nombre": "Werner Oswaldo Osoy Trejo",
+    "liquidacion_id": 443,
+    "cambios": [
+      {
+        "credito_id": 503,
+        "abono_capital": 62.947144,
+        "abono_interes": 122.70204,
+        "iva": 14.7242448,
+        "monto_aportado": 10162.222856
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 84,
+    "inversionista_nombre": "Flujocapital",
+    "liquidacion_id": 450,
+    "cambios": [
+      {
+        "credito_id": 1092,
+        "abono_capital": 0.0,
+        "monto_aportado": 0.0
+      },
+      {
+        "credito_id": 88,
+        "abono_capital": 55232.35,
+        "monto_aportado": 0.0
+      },
+      {
+        "credito_id": 848,
+        "abono_capital": 193341.57,
+        "monto_aportado": 0.0
+      },
+      {
+        "credito_id": 11,
+        "abono_capital": 14916.26,
+        "monto_aportado": 0.0
+      },
+      {
+        "credito_id": 157,
+        "abono_capital": 23.5,
+        "monto_aportado": 0.0
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 87,
+    "inversionista_nombre": "Avinsa  S.A",
+    "liquidacion_id": 436,
+    "cambios": [
+      {
+        "credito_id": 396,
+        "abono_capital": 192.01,
+        "monto_aportado": 14451.55
+      },
+      {
+        "credito_id": 8708,
+        "abono_capital": 1183.47,
+        "monto_aportado": 82513.38
+      },
+      {
+        "credito_id": 776,
+        "abono_capital": 12810.44,
+        "monto_aportado": 0.0
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 90,
+    "inversionista_nombre": "Felipe Gonzalez",
+    "liquidacion_id": 358,
+    "cambios": [
+      {
+        "credito_id": 8751,
+        "abono_capital": 6.727736,
+        "abono_interes": 2.632665,
+        "iva": 0.3159198,
+        "monto_aportado": 244.002264
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 91,
+    "inversionista_nombre": "Pedro Jose Ramirez Lopez",
+    "liquidacion_id": 365,
+    "cambios": [
+      {
+        "credito_id": 43,
+        "abono_capital": 6.926352,
+        "abono_interes": 3.035925,
+        "iva": 0.364311,
+        "monto_aportado": 262.933648
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+   {
+    "inversionista_id": 92,
+    "inversionista_nombre": "Inversiones Monaco S.A.",
+    "liquidacion_id": 437,
+    "cambios": [
+      {
+        "credito_id": 930,
+        "abono_capital": 0,
+         "abono_interes": 0,
+        "iva": 0,
+        "monto_aportado": 0.0
+      },
+      {
+        "credito_id": 781,
+        "abono_capital": 44514.87,
+        "monto_aportado": 0,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 110,
+    "inversionista_nombre": "Carlos Fernando Carrillo Gularte",
+    "liquidacion_id": 393,
+    "cambios": [
+      {
+        "credito_id": 701,
+        "monto_aportado": 208.64
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 118,
+    "inversionista_nombre": "Mario Andres Barrios Ramirez",
+    "liquidacion_id": 361,
+    "cambios": [
+      {
+        "credito_id": 8690,
+        "monto_aportado": 786.771968
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
+    "inversionista_id": 123,
+    "inversionista_nombre": "Esdras Samuel Gamboa Martínez",
+    "liquidacion_id": 364,
+    "cambios": [
+      {
+        "credito_id": 8670,
+        "abono_capital": 220.14,
+        "monto_aportado": 9575.41
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  }
+]

--- a/apps/cartera-back/ajustarPagos/masivo.json
+++ b/apps/cartera-back/ajustarPagos/masivo.json
@@ -1,5 +1,25 @@
 [
   {
+    "inversionista_id": 127,
+    "inversionista_nombre": "Selvyn",
+    "liquidacion_id": 447,
+    "cambios": [
+      {
+        "credito_id": 8707,
+        "abono_interes": 8.85,
+        "iva": 1.06,
+        "abono_capital": 4.64,
+        "monto_aportado": 838.39
+      },
+       {
+        "credito_id": 8700,
+        "monto_aportado": 49445.11
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  },
+  {
     "inversionista_id": 2,
     "inversionista_nombre": "Aida Irene Dubois",
     "liquidacion_id": 371,
@@ -504,5 +524,23 @@
     ],
     "force": true,
     "generar_reporte": true
-  }
+  },
+  {
+  "inversionista_id": 76,
+  "liquidacion_id": 375,
+  "cambios": [
+    {
+      "credito_id": 1046,
+      "abono_interes": 298.29,
+      "iva": 35.7948
+    },
+    {
+      "credito_id": 287,
+      "abono_interes": 295.335,
+      "iva": 35.4402
+    }
+  ],
+  "force": true,
+  "generar_reporte": true
+}
 ]

--- a/apps/cartera-back/ajustarPagos/masivo.json
+++ b/apps/cartera-back/ajustarPagos/masivo.json
@@ -101,6 +101,8 @@
     "cambios": [
       {
         "credito_id": 955,
+         "abono_interes": 0,
+        "iva": 0,
         "abono_capital": 0.0,
         "monto_aportado": 0.0
       }

--- a/apps/cartera-back/ajustarPagos/masivo_comparativo.json
+++ b/apps/cartera-back/ajustarPagos/masivo_comparativo.json
@@ -1,0 +1,504 @@
+[
+  {
+    "inversionista_id": 2,
+    "liquidacion_id": 371,
+    "cambios": [
+      {
+        "credito_id": 8683,
+        "abono_capital": 7.47,
+        "monto_aportado": 736.4,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 3,
+    "liquidacion_id": 384,
+    "cambios": [
+      {
+        "credito_id": 8685,
+        "monto_aportado": 8424.31,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 4,
+    "liquidacion_id": 382,
+    "cambios": [
+      {
+        "credito_id": 8724,
+        "abono_capital": 18.348752,
+        "abono_interes": 21.92232,
+        "iva": 2.6306784,
+        "monto_aportado": 1826.86,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 7,
+    "liquidacion_id": 432,
+    "cambios": [
+      {
+        "credito_id": 4789,
+        "monto_aportado": 5375.74,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 10,
+    "liquidacion_id": 340,
+    "cambios": [
+      {
+        "credito_id": 330,
+        "abono_capital": 7.79,
+        "abono_interes": 6.21,
+        "iva": 0.7452,
+        "monto_aportado": 509.69,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 691,
+        "abono_capital": 6.7656,
+        "abono_interes": 7.66,
+        "iva": 0.9192,
+        "monto_aportado": 631.5944,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 11,
+    "liquidacion_id": 446,
+    "cambios": [
+      {
+        "credito_id": 743,
+        "abono_capital": 28.44,
+        "abono_interes": 58.00044,
+        "iva": 6.9600528,
+        "monto_aportado": 4804.93,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 19,
+    "liquidacion_id": 351,
+    "cambios": [
+      {
+        "credito_id": 955,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 26,
+    "liquidacion_id": 376,
+    "cambios": [
+      {
+        "credito_id": 8699,
+        "monto_aportado": 9231.394984,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 27,
+    "liquidacion_id": 394,
+    "cambios": [
+      {
+        "credito_id": 8736,
+        "monto_aportado": 374.375032,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 30,
+    "liquidacion_id": 354,
+    "cambios": [
+      {
+        "credito_id": 4857,
+        "monto_aportado": 6551.22,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 33,
+    "liquidacion_id": 412,
+    "cambios": [
+      {
+        "credito_id": 8705,
+        "monto_aportado": 10762.71,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 34,
+    "liquidacion_id": 385,
+    "cambios": [
+      {
+        "credito_id": 8871,
+        "abono_capital": 21.06,
+        "abono_interes": 32.44,
+        "iva": 3.8928,
+        "monto_aportado": 2862.28,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 51,
+    "liquidacion_id": 383,
+    "cambios": [
+      {
+        "credito_id": 8738,
+        "monto_aportado": 346.29,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 61,
+    "liquidacion_id": 426,
+    "cambios": [
+      {
+        "credito_id": 600,
+        "monto_aportado": 939.33992,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 8719,
+        "monto_aportado": 1912.455248,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 63,
+    "liquidacion_id": 390,
+    "cambios": [
+      {
+        "credito_id": 8684,
+        "monto_aportado": 5406.032784,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 67,
+    "liquidacion_id": 392,
+    "cambios": [
+      {
+        "credito_id": 261,
+        "monto_aportado": 22708.691096,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 69,
+    "liquidacion_id": 352,
+    "cambios": [
+      {
+        "credito_id": 8674,
+        "abono_capital": 5.741912,
+        "monto_aportado": 566.168088,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 71,
+    "liquidacion_id": 355,
+    "cambios": [
+      {
+        "credito_id": 8759,
+        "abono_capital": 0.981128,
+        "abono_interes": 2.418045,
+        "iva": 0.2901654,
+        "monto_aportado": 229.308872,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 733,
+        "monto_aportado": 206.771032,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 74,
+    "liquidacion_id": 398,
+    "cambios": [
+      {
+        "credito_id": 8707,
+        "monto_aportado": 11195.1628,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 433,
+        "monto_aportado": 19419.648664,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 77,
+    "liquidacion_id": 411,
+    "cambios": [
+      {
+        "credito_id": 8776,
+        "monto_aportado": 5197.69528,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 832,
+        "abono_interes": 9.9857835,
+        "iva": 1.19829402,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 78,
+    "liquidacion_id": 419,
+    "cambios": [
+      {
+        "credito_id": 25,
+        "abono_capital": 1342.83,
+        "abono_interes": 759.28,
+        "iva": 91.1136,
+        "monto_aportado": 61930.63,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 80,
+    "liquidacion_id": 408,
+    "cambios": [
+      {
+        "credito_id": 701,
+        "monto_aportado": 140.099208,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 735,
+        "abono_capital": 1.615648,
+        "monto_aportado": 151.024352,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 82,
+    "liquidacion_id": 443,
+    "cambios": [
+      {
+        "credito_id": 503,
+        "abono_capital": 62.947144,
+        "abono_interes": 122.70204,
+        "iva": 14.7242448,
+        "monto_aportado": 10162.222856,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 84,
+    "liquidacion_id": 450,
+    "cambios": [
+      {
+        "credito_id": 1092,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 88,
+        "abono_capital": 55232.35,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 848,
+        "abono_capital": 193341.57,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 11,
+        "abono_capital": 14916.26,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 157,
+        "abono_capital": 23.5,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 87,
+    "liquidacion_id": 436,
+    "cambios": [
+      {
+        "credito_id": 396,
+        "abono_capital": 192.01,
+        "monto_aportado": 14451.55,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 8708,
+        "abono_capital": 1183.47,
+        "monto_aportado": 82513.38,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 776,
+        "abono_capital": 12810.44,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 90,
+    "liquidacion_id": 358,
+    "cambios": [
+      {
+        "credito_id": 8751,
+        "abono_capital": 6.727736,
+        "abono_interes": 2.632665,
+        "iva": 0.3159198,
+        "monto_aportado": 244.002264,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 91,
+    "liquidacion_id": 365,
+    "cambios": [
+      {
+        "credito_id": 43,
+        "abono_capital": 6.926352,
+        "abono_interes": 3.035925,
+        "iva": 0.364311,
+        "monto_aportado": 262.933648,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 92,
+    "liquidacion_id": 437,
+    "cambios": [
+      {
+        "credito_id": 781,
+        "abono_capital": 44514.87,
+        "monto_aportado_forzado": false
+      },
+      {
+        "credito_id": 930,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 110,
+    "liquidacion_id": 393,
+    "cambios": [
+      {
+        "credito_id": 701,
+        "monto_aportado": 208.64,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 118,
+    "liquidacion_id": 361,
+    "cambios": [
+      {
+        "credito_id": 8690,
+        "monto_aportado": 786.771968,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  },
+  {
+    "inversionista_id": 123,
+    "liquidacion_id": 364,
+    "cambios": [
+      {
+        "credito_id": 8670,
+        "abono_capital": 220.14,
+        "monto_aportado": 9575.41,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": false,
+    "generar_reporte": false
+  }
+]

--- a/apps/cartera-back/ajustarPagos/monaco.json
+++ b/apps/cartera-back/ajustarPagos/monaco.json
@@ -1,0 +1,22 @@
+   {
+    "inversionista_id": 92,
+    "inversionista_nombre": "Inversiones Monaco S.A.",
+    "liquidacion_id": 437,
+    "cambios": [
+      {
+        "credito_id": 930,
+        "abono_capital": 0,
+         "abono_interes": 0,
+        "iva": 0,
+        "monto_aportado": 0.0
+      },
+      {
+        "credito_id": 781,
+        "abono_capital": 44514.87,
+        "monto_aportado": 0,
+        "monto_aportado_forzado": false
+      }
+    ],
+    "force": true,
+    "generar_reporte": true
+  }

--- a/apps/cartera-back/ajustarPagos/monaco.json
+++ b/apps/cartera-back/ajustarPagos/monaco.json
@@ -1,20 +1,14 @@
-   {
-    "inversionista_id": 92,
-    "inversionista_nombre": "Inversiones Monaco S.A.",
-    "liquidacion_id": 437,
+  {
+    "inversionista_id": 19,
+    "inversionista_nombre": "Diego Arturo Bracamonte",
+    "liquidacion_id": 351,
     "cambios": [
       {
-        "credito_id": 930,
-        "abono_capital": 0,
+        "credito_id": 955,
          "abono_interes": 0,
         "iva": 0,
+        "abono_capital": 0.0,
         "monto_aportado": 0.0
-      },
-      {
-        "credito_id": 781,
-        "abono_capital": 44514.87,
-        "monto_aportado": 0,
-        "monto_aportado_forzado": false
       }
     ],
     "force": true,

--- a/apps/cartera-back/ajustarPagos/monaco.json
+++ b/apps/cartera-back/ajustarPagos/monaco.json
@@ -1,14 +1,18 @@
   {
-    "inversionista_id": 19,
-    "inversionista_nombre": "Diego Arturo Bracamonte",
-    "liquidacion_id": 351,
+    "inversionista_id": 127,
+    "inversionista_nombre": "Selvyn",
+    "liquidacion_id": 447,
     "cambios": [
       {
-        "credito_id": 955,
-         "abono_interes": 0,
-        "iva": 0,
-        "abono_capital": 0.0,
-        "monto_aportado": 0.0
+        "credito_id": 8707,
+        "abono_interes": 8.85,
+        "iva": 1.06,
+        "abono_capital": 4.64,
+        "monto_aportado": 838.39
+      },
+       {
+        "credito_id": 8700,
+        "monto_aportado": 49445.11
       }
     ],
     "force": true,

--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -62,7 +62,12 @@ const addInvestorToCreditSchema = z.object({
   porcentaje_inversion: z.number().min(0).max(100).optional(),
   tipo_operacion: z.enum(["reinversion", "compra_cartera"]),
   tipo_reinversion: z
-    .enum(["reinversion_capital", "reinversion_interes", "reinversion_total"])
+    .enum([
+      "sin_reinversion",
+      "reinversion_capital",
+      "reinversion_interes",
+      "reinversion_total",
+    ])
     .optional(),
   fecha_inicio_participacion: z.string().optional(),
   // Nuevos campos para el buscador de capital
@@ -107,15 +112,13 @@ function recalcularInversionistas(
   tipo_operacion: "reinversion" | "compra_cartera",
 ) {
   // Fallback de fecha de inicio cuando un inversionista llega sin fecha:
-  // - reinversion → dos meses antes (la operación se ejecuta sobre rendimientos
-  //   del período previo, así que la participación arranca ese mes)
-  // - compra_cartera → fecha de hoy
+  // - reinversion → 1 de diciembre de 2025 (fecha fija acordada).
+  // - compra_cartera → fecha de hoy (el front debería mandar siempre la que
+  //   el usuario eligió; este fallback solo aplica si no viene).
   const hoy = new Date();
   const fechaInicioFallback =
     tipo_operacion === "reinversion"
-      ? new Date(hoy.getFullYear(), hoy.getMonth() - 2, hoy.getDate())
-          .toISOString()
-          .split("T")[0]
+      ? "2025-12-01"
       : hoy.toISOString().split("T")[0];
   // ── PASO 1: Sumar el capital total de todos los inversionistas ──
   // Esto es la base para calcular el porcentaje de participación de cada uno.
@@ -337,6 +340,68 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
       };
     }
 
+    // ================================================================
+    // FILTRO: créditos compatibles con la modalidad solicitada (Y)
+    // Aplica SIEMPRE que vino un `tipo_reinversion` (Y) en el request.
+    // Vale para compra_cartera y reinversión.
+    //
+    // Acepta créditos cuyo espejo:
+    //   • tiene la MISMA modalidad que Y
+    //   • está en NULL (modalidad no asignada todavía)
+    // Descarta créditos cuyo espejo tiene a algún inversionista con un
+    // tipo_reinversion no-null distinto a Y. Esto incluye "sin_reinversion"
+    // como un valor concreto: si Y ≠ sin_reinversion, los espejos en
+    // sin_reinversion se descartan.
+    // ================================================================
+    const filtradosPorTipoReinversion: {
+      credito_id: number;
+      numero_credito_sifco: string;
+      razon: string;
+      tipo_reinversion_actual: string;
+      tipo_reinversion_solicitado: string;
+    }[] = [];
+
+    if (tipo_reinversion) {
+      candidatos = candidatos.filter((candidato) => {
+        const espejoActual = candidato.credito_completo?.espejo ?? [];
+
+        // Conflicto: algún inv del espejo con tipo no-null distinto a Y.
+        // (Solo NULL no es conflicto; misma modalidad tampoco.)
+        const conflicto = espejoActual.find(
+          (e: any) =>
+            e.tipo_reinversion !== null &&
+            e.tipo_reinversion !== tipo_reinversion,
+        );
+
+        if (conflicto) {
+          filtradosPorTipoReinversion.push({
+            credito_id: candidato.credito_id,
+            numero_credito_sifco: candidato.numero_credito_sifco,
+            razon: `inversionista ${conflicto.inversionista_id} del espejo ya tiene modalidad ${conflicto.tipo_reinversion}`,
+            tipo_reinversion_actual: String(conflicto.tipo_reinversion),
+            tipo_reinversion_solicitado: tipo_reinversion,
+          });
+          return false;
+        }
+
+        return true;
+      });
+
+      console.log(
+        `[addInvestorToCredit] Filtro tipo_reinversion: ${filtradosPorTipoReinversion.length} descartados, ${candidatos.length} compatibles`,
+      );
+
+      if (candidatos.length === 0) {
+        set.status = 404;
+        return {
+          success: false,
+          message:
+            "No se encontraron créditos candidatos compatibles (todos tienen alguna modalidad ya asignada)",
+          descartados: filtradosPorTipoReinversion,
+        };
+      }
+    }
+
     const resultados: any[] = [];
     const errores: any[] = [];
 
@@ -460,9 +525,20 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
           membresias_pago: creditoRaw.membresias_pago,
         };
 
-        // ── Mapear inversionistas actuales del crédito ──
-        // Estos también vienen del GET (inversionistas_detalle)
-        const inversionistasActuales = inversionistas_detalle.map((inv: any) => ({
+        // ── Mapear inversionistas del PADRE y del ESPEJO por separado ──
+        // monto_aportado y los montos derivados (monto_inversionista,
+        // monto_cash_in, iva_*) se calculan independientemente por tabla.
+        // cuota_inversionista y los porcentajes se calculan desde el ESPEJO
+        // y se replican al padre.
+        const inversionistasPadre = inversionistas_detalle.map((inv: any) => ({
+          inversionista_id: inv.inversionista_id,
+          monto_aportado: inv.monto_aportado,
+          porcentaje_cash_in: inv.porcentaje_cash_in,
+          porcentaje_participacion_inversionista: inv.porcentaje_participacion_inversionista,
+          fecha_inicio_participacion: inv.fecha_inicio_participacion,
+        }));
+
+        const inversionistasEspejo = (espejoActual ?? []).map((inv: any) => ({
           inversionista_id: inv.inversionista_id,
           monto_aportado: inv.monto_aportado,
           porcentaje_cash_in: inv.porcentaje_cash_in,
@@ -471,40 +547,32 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
         }));
 
         // ================================================================
-        // PASO 3a: BUSCAR CUBE EN LOS INVERSIONISTAS DEL CRÉDITO
-        // CUBE (ID 86) siempre debe estar. Si no está, es un error
-        // y saltamos este crédito.
+        // PASO 3a: BUSCAR CUBE EN EL PADRE (autoridad para montoParaEsteCredito)
+        // CUBE (ID 86) siempre debe estar en el padre. Si no está, es un
+        // error y saltamos este crédito.
         // ================================================================
-        const cubeActual = inversionistasActuales.find(
+        const cubePadre = inversionistasPadre.find(
           (inv: any) => inv.inversionista_id === CUBE_INVESTMENT_ID,
         );
 
-        if (!cubeActual) {
+        if (!cubePadre) {
           errores.push({
             credito_id,
-            razon: "CUBE no encontrado en este crédito",
+            razon: "CUBE no encontrado en el padre del crédito",
           });
           continue;
         }
 
-        const montoCubeActual = new Big(cubeActual.monto_aportado);
+        const montoCubePadre = new Big(cubePadre.monto_aportado);
 
         // ================================================================
         // PASO 3b: DETERMINAR CUÁNTO TOMAR DE ESTE CRÉDITO
-        // Si el monto restante es MAYOR que lo que CUBE tiene:
-        //   → Tomar TODO lo de CUBE (CUBE se elimina)
-        //   → El sobrante se lleva al siguiente crédito
-        // Si el monto restante es MENOR o IGUAL que lo de CUBE:
-        //   → Tomar solo lo que falta (CUBE se queda con el resto)
-        //   → Ya no se procesan más créditos
-        //
-        // Ejemplo:
-        //   montoRestante = Q30,000 | CUBE tiene Q20,000
-        //   → montoParaEsteCredito = Q20,000 (todo lo de CUBE)
-        //   → montoRestante después = Q10,000 (sigue al siguiente crédito)
+        // El monto se basa en el CUBE del PADRE (es la verdad confirmada).
+        // Si el espejo tiene un CUBE con monto distinto, se le aplicará la
+        // misma operación pero con su propio monto inicial.
         // ================================================================
-        const montoParaEsteCredito = montoRestante.gt(montoCubeActual)
-          ? montoCubeActual
+        const montoParaEsteCredito = montoRestante.gt(montoCubePadre)
+          ? montoCubePadre
           : montoRestante;
 
         // ================================================================
@@ -555,33 +623,65 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
         }
 
         // ================================================================
-        // PASO 3d: ARMAR EL NUEVO ARRAY DE INVERSIONISTAS
-        // Recorremos los inversionistas actuales del crédito y:
-        //   - CUBE: le restamos el montoParaEsteCredito. Si queda en 0, NO lo incluimos.
-        //   - Inversionista nuevo (si ya existía): le SUMAMOS el montoParaEsteCredito.
-        //   - Los demás: se copian tal cual (no cambian).
-        // Si el inversionista NO existía en el crédito, lo agregamos al final.
-        //
-        // El resultado es un array NUEVO con la distribución correcta,
-        // listo para recalcular todas las cuotas.
+        // PASO 3d: ARMAR LOS NUEVOS ARRAYS (PADRE y ESPEJO) INDEPENDIENTES
+        // Aplicamos la misma operación (restar a CUBE, sumar/agregar al
+        // inversionista nuevo) a cada fuente con SU propio monto_aportado.
+        // Si CUBE queda en Q0 en una fuente, se elimina de esa fuente
+        // (independencia total entre padre y espejo).
         // ================================================================
-        const nuevoArray: {
-          inversionista_id: number;
-          monto_aportado: Big;
-          porcentaje_cash_in: Big;
-          porcentaje_inversion: Big;
-          fecha_inicio_participacion: string;
-        }[] = [];
 
-        for (const inv of inversionistasActuales) {
-          if (inv.inversionista_id === CUBE_INVESTMENT_ID) {
-            // ── CUBE: restarle el monto asignado a este crédito ──
-            const nuevoMontoCube = montoCubeActual.minus(montoParaEsteCredito);
-            if (nuevoMontoCube.gt(0)) {
-              // CUBE todavía tiene saldo → se queda con el resto
-              nuevoArray.push({
+        // Fecha por defecto para el inversionista nuevo (cuando no existía):
+        // reinversion → 2025-12-01 (fija), compra_cartera → fecha de hoy.
+        const fechaPorDefecto =
+          tipo_operacion === "reinversion"
+            ? "2025-12-01"
+            : new Date().toISOString().split("T")[0];
+
+        // Helper: aplica la operación a una fuente (padre o espejo) y
+        // devuelve el array operado listo para recalcular.
+        const construirArrayOperado = (fuente: any[]) => {
+          const result: {
+            inversionista_id: number;
+            monto_aportado: Big;
+            porcentaje_cash_in: Big;
+            porcentaje_inversion: Big;
+            fecha_inicio_participacion: string;
+          }[] = [];
+
+          for (const inv of fuente) {
+            if (inv.inversionista_id === CUBE_INVESTMENT_ID) {
+              // ── CUBE: restarle el monto operativo. Si queda en 0, se elimina. ──
+              const nuevoMontoCube = new Big(inv.monto_aportado).minus(
+                montoParaEsteCredito,
+              );
+              if (nuevoMontoCube.gt(0)) {
+                result.push({
+                  inversionista_id: inv.inversionista_id,
+                  monto_aportado: nuevoMontoCube,
+                  porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
+                  porcentaje_inversion: new Big(
+                    inv.porcentaje_participacion_inversionista,
+                  ),
+                  fecha_inicio_participacion: inv.fecha_inicio_participacion,
+                });
+              }
+            } else if (inv.inversionista_id === inversionista_id) {
+              // ── Inversionista ya existía en esta fuente: sumarle el monto ──
+              result.push({
                 inversionista_id: inv.inversionista_id,
-                monto_aportado: nuevoMontoCube,
+                monto_aportado: new Big(inv.monto_aportado).plus(
+                  montoParaEsteCredito,
+                ),
+                porcentaje_cash_in: porcCashIn,
+                porcentaje_inversion: porcInversion,
+                fecha_inicio_participacion:
+                  fecha_inicio_participacion ?? inv.fecha_inicio_participacion,
+              });
+            } else {
+              // ── Otro inversionista: se copia igual ──
+              result.push({
+                inversionista_id: inv.inversionista_id,
+                monto_aportado: new Big(inv.monto_aportado),
                 porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
                 porcentaje_inversion: new Big(
                   inv.porcentaje_participacion_inversionista,
@@ -589,68 +689,48 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
                 fecha_inicio_participacion: inv.fecha_inicio_participacion,
               });
             }
-            // Si nuevoMontoCube <= 0, CUBE se elimina (no se incluye en el array)
-          } else if (inv.inversionista_id === inversionista_id) {
-            // ── Inversionista ya existía: sumarle el monto nuevo ──
-            nuevoArray.push({
-              inversionista_id: inv.inversionista_id,
-              monto_aportado: new Big(inv.monto_aportado).plus(montoParaEsteCredito),
+          }
+
+          // Si el inversionista no existía en esta fuente, agregarlo
+          const yaExiste = result.some(
+            (i) => i.inversionista_id === inversionista_id,
+          );
+          if (!yaExiste) {
+            result.push({
+              inversionista_id,
+              monto_aportado: montoParaEsteCredito,
               porcentaje_cash_in: porcCashIn,
               porcentaje_inversion: porcInversion,
               fecha_inicio_participacion:
-                fecha_inicio_participacion ??
-                inv.fecha_inicio_participacion,
-            });
-          } else {
-            // ── Otro inversionista: se copia igual, no cambia ──
-            nuevoArray.push({
-              inversionista_id: inv.inversionista_id,
-              monto_aportado: new Big(inv.monto_aportado),
-              porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
-              porcentaje_inversion: new Big(
-                inv.porcentaje_participacion_inversionista,
-              ),
-              fecha_inicio_participacion: inv.fecha_inicio_participacion,
+                fecha_inicio_participacion ?? fechaPorDefecto,
             });
           }
-        }
 
-        // ── Si el inversionista NO existía en el crédito, agregarlo como nuevo ──
-        const yaExiste = nuevoArray.some(
-          (inv) => inv.inversionista_id === inversionista_id,
+          return result;
+        };
+
+        const nuevoArrayPadre = construirArrayOperado(inversionistasPadre);
+        // Si el espejo está vacío (no había filas), caemos al padre como fuente
+        const nuevoArrayEspejo =
+          inversionistasEspejo.length > 0
+            ? construirArrayOperado(inversionistasEspejo)
+            : nuevoArrayPadre.map((x) => ({ ...x }));
+
+        // ================================================================
+        // PASO 3e: RECALCULAR INDEPENDIENTEMENTE PADRE Y ESPEJO
+        // Cada uno con su propio capital total → cada uno con sus propios
+        // montos derivados (monto_inversionista, monto_cash_in, iva_*).
+        // ================================================================
+        const dataPadreRaw = recalcularInversionistas(
+          nuevoArrayPadre,
+          creditoData,
+          credito_id,
+          numero_credito_sifco,
+          tipo_operacion,
         );
-        if (!yaExiste) {
-          // Para reinversión, la participación arranca un mes antes (la
-          // reinversión se ejecuta sobre rendimientos del período previo,
-          // así que la fecha de inicio refleja ese mes anterior).
-          // Para compra_cartera, usamos la fecha del día.
-          const hoy = new Date();
-          const fechaPorDefecto =
-            tipo_operacion === "reinversion"
-              ? new Date(hoy.getFullYear(), hoy.getMonth() - 2, hoy.getDate())
-                  .toISOString()
-                  .split("T")[0]
-              : hoy.toISOString().split("T")[0];
 
-          nuevoArray.push({
-            inversionista_id,
-            monto_aportado: montoParaEsteCredito,
-            porcentaje_cash_in: porcCashIn,
-            porcentaje_inversion: porcInversion,
-            fecha_inicio_participacion:
-              fecha_inicio_participacion ?? fechaPorDefecto,
-          });
-        }
-
-        // ================================================================
-        // PASO 3e: RECALCULAR CUOTAS PARA TABLA PADRE (creditos_inversionistas)
-        // Con el nuevo array redistribuido, recalculamos:
-        //   - Porcentaje de participación de cada uno
-        //   - Cuota del inversionista (el mayor absorbe cargos fijos)
-        //   - Intereses, distribución cash-in/inversionista, IVA
-        // ================================================================
-        const dataPadre = recalcularInversionistas(
-          nuevoArray,
+        const dataEspejoRaw = recalcularInversionistas(
+          nuevoArrayEspejo,
           creditoData,
           credito_id,
           numero_credito_sifco,
@@ -658,10 +738,34 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
         );
 
         // ================================================================
+        // PASO 3e.1: REPLICAR cuota_inversionista Y porcentajes DEL ESPEJO
+        // AL PADRE. monto_aportado, monto_inversionista, monto_cash_in,
+        // iva_* quedan independientes (cada uno con su cálculo propio).
+        // ================================================================
+        const espejoPorInv = new Map<
+          number,
+          (typeof dataEspejoRaw)[number]
+        >();
+        for (const e of dataEspejoRaw) {
+          espejoPorInv.set(e.inversionista_id, e);
+        }
+
+        const dataPadre = dataPadreRaw.map((inv) => {
+          const e = espejoPorInv.get(inv.inversionista_id);
+          return {
+            ...inv,
+            // Si el inversionista existe en el espejo, replicar su cuota
+            // y porcentajes para que coincidan. Si no, mantener los propios.
+            cuota_inversionista: e?.cuota_inversionista ?? inv.cuota_inversionista,
+            porcentaje_cash_in: e?.porcentaje_cash_in ?? inv.porcentaje_cash_in,
+            porcentaje_participacion_inversionista:
+              e?.porcentaje_participacion_inversionista ??
+              inv.porcentaje_participacion_inversionista,
+          };
+        });
+
+        // ================================================================
         // PASO 3f: NUKE & REBUILD EN creditos_inversionistas
-        // Borramos TODOS los registros del crédito en la tabla padre
-        // y reinsertamos el array recalculado.
-        // Es más limpio que hacer updates parciales y evita inconsistencias.
         // ================================================================
         await tx
           .delete(creditos_inversionistas)
@@ -672,36 +776,32 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
         }
 
         // ================================================================
-        // PASO 3h: ARMAR DATA DEL ESPEJO A PARTIR DEL PADRE
-        // El espejo hereda exactamente la cuota_inversionista del padre,
-        // así que reusamos dataPadre y solo le agregamos status + updated_at.
+        // PASO 3h: ARMAR DATA DEL ESPEJO DESDE dataEspejoRaw (no del padre)
+        // El espejo lleva sus propios montos derivados; solo le agregamos
+        // status + tipo_reinversion + updated_at.
         // ================================================================
-
-        // ── Determinar el status del espejo según tipo_operacion ──
-        // "reinversion" → "pendiente_reinversion"
-        // "compra_cartera" → "pendiente_compra_cartera" (espera aceptación)
-        // Solo el inversionista nuevo recibe este status.
-        // Los demás inversionistas quedan como "completado".
         const statusEspejo =
           tipo_operacion === "reinversion"
             ? "pendiente_reinversion"
             : "pendiente_compra_cartera";
 
-        const dataEspejoConStatus = dataPadre.map((inv) => ({
+        const dataEspejoConStatus = dataEspejoRaw.map((inv) => ({
           ...inv,
           // Solo el inversionista nuevo recibe el status pendiente
           // Los demás se mantienen como "completado"
           status: (inv.inversionista_id === inversionista_id
               ? statusEspejo
               : "completado") as "pendiente_reinversion" | "pendiente_compra_cartera" | "completado",
-          // tipo_reinversion:
-          //   - target (inversionista que entra en esta op): Y (solo en compra_cartera)
-          //   - resto: preservamos el valor existente del espejo (si tenía)
+          // tipo_reinversion (prioridad: lo que viene > viejo del espejo > null):
+          //   - target: si viene Y en el request lo usa; si no, preserva el
+          //     valor previo del espejo. Aplica tanto en compra_cartera como
+          //     en reinversión (no perdemos trazabilidad de la modalidad).
+          //   - resto: preserva el valor existente del espejo.
           tipo_reinversion:
             inv.inversionista_id === inversionista_id
-              ? tipo_operacion === "compra_cartera"
-                ? tipo_reinversion ?? null
-                : null
+              ? tipo_reinversion ??
+                tipoReinvActualPorInv.get(inv.inversionista_id) ??
+                null
               : tipoReinvActualPorInv.get(inv.inversionista_id) ?? null,
           updated_at: new Date(),
         }));
@@ -733,10 +833,12 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
           inversionista_id,
           monto_aportado: montoParaEsteCredito.toString(),
           tipo_operacion,
+          // Misma lógica que el espejo: si vino en el request lo usa, sino
+          // preserva el viejo del espejo, sino null. Aplica en ambas operaciones.
           tipo_reinversion:
-            tipo_operacion === "compra_cartera"
-              ? tipo_reinversion ?? null
-              : null,
+            tipo_reinversion ??
+            tipoReinvActualPorInv.get(inversionista_id) ??
+            null,
           status: statusEspejo,
         });
 
@@ -768,7 +870,7 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
           monto_asignado: montoParaEsteCredito.toString(),
           inversionistas_padre: dataPadre.length,
           inversionistas_espejo: dataEspejoConStatus.length,
-          cube_eliminado: !nuevoArray.some(
+          cube_eliminado: !nuevoArrayPadre.some(
             (inv) => inv.inversionista_id === CUBE_INVESTMENT_ID,
           ),
         });
@@ -835,7 +937,12 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
             numero_credito_sifco: r.numero_credito_sifco,
             monto_asignado: r.monto_asignado,
             cube_eliminado: r.cube_eliminado,
-            tipo_reinversion: tipo_reinversion ?? null,
+            // El email muestra "Tradicional" cuando tipo_reinversion es null,
+            // así que mapeamos sin_reinversion → null para preservar ese label.
+            tipo_reinversion:
+              tipo_reinversion && tipo_reinversion !== "sin_reinversion"
+                ? tipo_reinversion
+                : null,
           })),
           usuarioNombre,
           usuarioEmail,

--- a/apps/cartera-back/src/controllers/ajustarPagosLiquidacion.ts
+++ b/apps/cartera-back/src/controllers/ajustarPagosLiquidacion.ts
@@ -1,0 +1,902 @@
+// ============================================
+// ajustarPagosLiquidacion
+// ============================================
+//
+// Endpoint para corregir manualmente pagos espejo y monto_aportado de un
+// inversionista en una liquidación específica. Soporta dry-run cuando algún
+// crédito tiene compras del mes en curso registradas en
+// compras_credito_inversionista (donde el monto_aportado del espejo es el
+// acumulado y no refleja la posición pre-compra).
+//
+// Para cada cambio:
+//   - Actualiza el pago espejo (abono_capital, abono_interes, abono_iva_12)
+//     SOLO con los campos no-null del request.
+//   - Para monto_aportado, evalúa si el crédito tiene compras del mes y
+//     ajusta sumando la compra al valor del endpoint, salvo que se mande
+//     monto_aportado_forzado=true (valor literal sin ajuste).
+//
+// Dry-run global: si algún cambio tiene compra del mes Y el override no está
+// activo Y force=false → no aplica nada, devuelve el plan.
+//
+// Opcional: si generar_reporte=true tras aplicar, genera el Excel con el
+// mismo flujo que /investor/reporte-liquidados, filtrando los créditos por
+// las compras del mes (excluir si monto<=compra, restar compra si monto>compra).
+// Devuelve solo la URL (no actualiza reporte_liquidacion_url en la liquidación).
+// ============================================
+
+import Big from "big.js";
+import { and, eq, inArray, sql } from "drizzle-orm";
+import { db } from "../database/index";
+import {
+  compras_credito_inversionista,
+  creditos_inversionistas_espejo,
+  inversionistas,
+  liquidaciones,
+  pagos_credito_inversionistas_espejo,
+} from "../database/db/schema";
+import { formatToUSD } from "../utils/functions/currencyConverter";
+import { generarYSubirExcelInversionista } from "../utils/functions/generalFunctions";
+import { resumeInvestor } from "./investor";
+
+export type AjustarCambio = {
+  credito_id: number;
+  abono_capital?: number | null;
+  abono_interes?: number | null;
+  iva?: number | null;
+  monto_aportado?: number | null;
+  monto_aportado_forzado?: boolean;
+};
+
+export type AjustarPagosLiquidacionInput = {
+  inversionista_id: number;
+  liquidacion_id: number;
+  cambios: AjustarCambio[];
+  force?: boolean;
+  generar_reporte?: boolean;
+};
+
+// ============================================
+// computarTotalesFiltrados
+// ============================================
+// Recomputa los totales del inversionista para una liquidación, sobre los
+// créditos NO excluidos del reporte y con el monto_aportado ajustado por
+// la compra del mes cuando corresponde.
+//
+// Reglas (decididas con el user):
+//   - Créditos en `creditos_excluidos`: no aportan a ningún total.
+//   - Créditos en `monto_aportado_ajustado`: aportan todos sus abonos
+//     COMPLETOS, solo `total_monto_aportado` usa el monto ajustado.
+//
+// La lógica de cálculo (sin_reinversion / reinversion_capital / interes /
+// total / variable / combinada, ISR sobre interés, IVA, neto) replica
+// EXACTAMENTE la de getInvestorTotalsGlobales en investor.ts para que el
+// total_reinversion sea comparable contra liquidaciones.reinversion_total.
+//
+// Devuelve valores RAW en Quetzales (sin conversión a USD).
+// ============================================
+async function computarTotalesFiltrados(opts: {
+  inversionista_id: number;
+  liquidacion_id: number;
+  creditos_excluidos: Set<number>;
+  monto_aportado_ajustado: Map<number, Big>;
+}): Promise<{
+  total_abono_capital: Big;
+  total_abono_interes: Big;
+  total_abono_iva: Big;
+  total_isr: Big;
+  total_cuota_sin_reinversion: Big;
+  total_cuota: Big;
+  total_monto_aportado: Big;
+  total_abono_general_interes: Big;
+  total_reinversion: Big;
+  total_reinversion_capital: Big;
+  total_reinversion_interes: Big;
+  pagos_count: number;
+  moneda: string;
+  emite_factura: boolean;
+}> {
+  const {
+    inversionista_id,
+    liquidacion_id,
+    creditos_excluidos,
+    monto_aportado_ajustado,
+  } = opts;
+
+  const [inv] = await db
+    .select({
+      emite_factura: inversionistas.emite_factura,
+      reinversion: inversionistas.tipo_reinversion,
+      monto_reinversion: inversionistas.monto_reinversion,
+      moneda: inversionistas.moneda,
+    })
+    .from(inversionistas)
+    .where(eq(inversionistas.inversionista_id, inversionista_id))
+    .limit(1);
+
+  if (!inv) {
+    throw new Error(`Inversionista ${inversionista_id} no encontrado.`);
+  }
+
+  const creditosEspejo = await db
+    .select({
+      credito_id: creditos_inversionistas_espejo.credito_id,
+      monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+      tipo_reinversion: creditos_inversionistas_espejo.tipo_reinversion,
+    })
+    .from(creditos_inversionistas_espejo)
+    .where(eq(creditos_inversionistas_espejo.inversionista_id, inversionista_id));
+
+  const pagos = await db
+    .select({
+      credito_id: pagos_credito_inversionistas_espejo.credito_id,
+      abono_capital: pagos_credito_inversionistas_espejo.abono_capital,
+      abono_interes: pagos_credito_inversionistas_espejo.abono_interes,
+      abono_iva_12: pagos_credito_inversionistas_espejo.abono_iva_12,
+    })
+    .from(pagos_credito_inversionistas_espejo)
+    .where(
+      and(
+        eq(pagos_credito_inversionistas_espejo.inversionista_id, inversionista_id),
+        eq(pagos_credito_inversionistas_espejo.liquidacion_id, liquidacion_id),
+      ),
+    );
+
+  const pagosPorCredito = new Map<number, typeof pagos>();
+  for (const p of pagos) {
+    const arr = pagosPorCredito.get(p.credito_id) ?? [];
+    arr.push(p);
+    pagosPorCredito.set(p.credito_id, arr);
+  }
+
+  const totales = {
+    total_abono_capital: new Big(0),
+    total_abono_interes: new Big(0),
+    total_abono_iva: new Big(0),
+    total_isr: new Big(0),
+    total_cuota_sin_reinversion: new Big(0),
+    total_cuota: new Big(0),
+    total_monto_aportado: new Big(0),
+    total_abono_general_interes: new Big(0),
+    total_reinversion: new Big(0),
+    total_reinversion_capital: new Big(0),
+    total_reinversion_interes: new Big(0),
+    pagos_count: 0,
+  };
+
+  for (const c of creditosEspejo) {
+    if (creditos_excluidos.has(c.credito_id)) continue;
+    const creditoPagos = pagosPorCredito.get(c.credito_id) ?? [];
+    if (creditoPagos.length === 0) continue;
+
+    const montoCredito =
+      monto_aportado_ajustado.get(c.credito_id) ?? new Big(c.monto_aportado);
+    totales.total_monto_aportado = totales.total_monto_aportado.plus(montoCredito);
+    totales.pagos_count += creditoPagos.length;
+
+    for (const pago of creditoPagos) {
+      const abono_capital = new Big(pago.abono_capital);
+      const abono_interes = new Big(pago.abono_interes);
+      const abono_iva = new Big(pago.abono_iva_12).round(2);
+      const isr = abono_interes.times(0.07);
+
+      const abonoGeneralInteres = inv.emite_factura
+        ? abono_interes.plus(abono_iva)
+        : abono_interes.minus(isr);
+
+      let reinversionActual = inv.reinversion;
+      if (inv.reinversion === "reinversion_combinada") {
+        reinversionActual = c.tipo_reinversion ?? "sin_reinversion";
+      }
+
+      const interesTotal = abono_interes.plus(
+        inv.emite_factura ? abono_iva : isr.neg(),
+      );
+
+      let reinvCapital = new Big(0);
+      let reinvInteres = new Big(0);
+      let cuota_inversor: Big;
+
+      switch (reinversionActual) {
+        case "sin_reinversion":
+          cuota_inversor = abono_capital.plus(interesTotal);
+          break;
+        case "reinversion_capital":
+          reinvCapital = abono_capital;
+          cuota_inversor = interesTotal;
+          break;
+        case "reinversion_interes":
+          reinvInteres = interesTotal;
+          cuota_inversor = abono_capital;
+          break;
+        case "reinversion_total":
+          reinvCapital = abono_capital;
+          reinvInteres = interesTotal;
+          cuota_inversor = new Big(0);
+          break;
+        case "reinversion_variable":
+          // El ajuste global se aplica después del loop
+          cuota_inversor = abono_capital.plus(interesTotal);
+          break;
+        default:
+          cuota_inversor = abono_capital.plus(interesTotal);
+      }
+
+      totales.total_abono_capital = totales.total_abono_capital.plus(abono_capital);
+      totales.total_abono_interes = totales.total_abono_interes.plus(abono_interes);
+      totales.total_abono_iva = totales.total_abono_iva.plus(abono_iva);
+      if (!inv.emite_factura) {
+        totales.total_isr = totales.total_isr.plus(isr);
+      }
+      totales.total_cuota = totales.total_cuota.plus(cuota_inversor);
+      totales.total_abono_general_interes = totales.total_abono_general_interes.plus(
+        abonoGeneralInteres,
+      );
+
+      const pagoNeto = abono_capital.plus(interesTotal);
+      totales.total_cuota_sin_reinversion =
+        totales.total_cuota_sin_reinversion.plus(pagoNeto);
+
+      // Reinversión: NO se vuelve a aplicar ISR aquí. `reinvInteres` ya viene
+      // neto desde `interesTotal` (que ya restó ISR cuando no emite_factura).
+      // Mismo criterio que getInvestorTotalsGlobales — restar otra vez el 7%
+      // dejaría los totales un ~7% por debajo de lo que ve el inversionista
+      // en la columna "% Inv. Interés Neto" del Excel.
+      totales.total_reinversion = totales.total_reinversion.plus(
+        reinvCapital.plus(reinvInteres),
+      );
+      totales.total_reinversion_capital =
+        totales.total_reinversion_capital.plus(reinvCapital);
+      totales.total_reinversion_interes =
+        totales.total_reinversion_interes.plus(reinvInteres);
+    }
+  }
+
+  // Ajuste global para reinversion_variable (mismo que getInvestorTotalsGlobales)
+  if (inv.reinversion === "reinversion_variable") {
+    const montoReinv = new Big(inv.monto_reinversion ?? 0);
+    const reinversion = montoReinv.gt(totales.total_cuota)
+      ? totales.total_cuota
+      : montoReinv;
+    totales.total_reinversion = reinversion;
+    totales.total_cuota = totales.total_cuota.minus(reinversion);
+  }
+
+  return {
+    ...totales,
+    moneda: inv.moneda ?? "quetzales",
+    emite_factura: inv.emite_factura,
+  };
+}
+
+function getMesEnCursoGuatemala(): { inicio: Date; fin: Date } {
+  // Rango [inicio, fin) del mes calendario en zona Guatemala.
+  // Se construye en UTC interpretando que Guatemala es UTC-6 sin DST.
+  const now = new Date();
+  const gtNow = new Date(now.getTime() - 6 * 60 * 60 * 1000);
+  const y = gtNow.getUTCFullYear();
+  const m = gtNow.getUTCMonth();
+  const inicio = new Date(Date.UTC(y, m, 1, 6, 0, 0)); // 00:00 GT = 06:00 UTC
+  const fin = new Date(Date.UTC(y, m + 1, 1, 6, 0, 0));
+  return { inicio, fin };
+}
+
+export async function ajustarPagosLiquidacion(input: AjustarPagosLiquidacionInput) {
+  const {
+    inversionista_id,
+    liquidacion_id,
+    cambios,
+    force = false,
+    generar_reporte = false,
+  } = input;
+
+  if (cambios.length === 0) {
+    return { success: false, message: "El arreglo `cambios` está vacío.", status: 400 as const };
+  }
+
+  // ── PASO 1: VALIDAR QUE LA LIQUIDACIÓN PERTENEZCA AL INVERSIONISTA ──
+  const [liq] = await db
+    .select({ liquidacion_id: liquidaciones.liquidacion_id })
+    .from(liquidaciones)
+    .where(
+      and(
+        eq(liquidaciones.liquidacion_id, liquidacion_id),
+        eq(liquidaciones.inversionista_id, inversionista_id),
+      ),
+    )
+    .limit(1);
+
+  if (!liq) {
+    return {
+      success: false,
+      message: `Liquidación ${liquidacion_id} no encontrada para inversionista ${inversionista_id}.`,
+      status: 404 as const,
+    };
+  }
+
+  const creditoIds = Array.from(new Set(cambios.map((c) => c.credito_id)));
+
+  // ── PASO 2: TRAER PAGOS ESPEJO ACTUALES ──
+  const pagosActuales = await db
+    .select({
+      id: pagos_credito_inversionistas_espejo.id,
+      credito_id: pagos_credito_inversionistas_espejo.credito_id,
+      abono_capital: pagos_credito_inversionistas_espejo.abono_capital,
+      abono_interes: pagos_credito_inversionistas_espejo.abono_interes,
+      abono_iva_12: pagos_credito_inversionistas_espejo.abono_iva_12,
+    })
+    .from(pagos_credito_inversionistas_espejo)
+    .where(
+      and(
+        eq(pagos_credito_inversionistas_espejo.inversionista_id, inversionista_id),
+        eq(pagos_credito_inversionistas_espejo.liquidacion_id, liquidacion_id),
+        inArray(pagos_credito_inversionistas_espejo.credito_id, creditoIds),
+      ),
+    );
+
+  const pagoPorCredito = new Map(pagosActuales.map((p) => [p.credito_id, p]));
+
+  // ── PASO 3: TRAER monto_aportado ACTUAL DEL ESPEJO ──
+  const espejoActual = await db
+    .select({
+      credito_id: creditos_inversionistas_espejo.credito_id,
+      monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+    })
+    .from(creditos_inversionistas_espejo)
+    .where(
+      and(
+        eq(creditos_inversionistas_espejo.inversionista_id, inversionista_id),
+        inArray(creditos_inversionistas_espejo.credito_id, creditoIds),
+      ),
+    );
+
+  const espejoPorCredito = new Map(
+    espejoActual.map((e) => [e.credito_id, new Big(e.monto_aportado)]),
+  );
+
+  // ── PASO 4: TRAER COMPRAS DEL MES (todos los status: completado +
+  //         pendientes; las canceladas no existen, se borran del histórico) ──
+  const { inicio, fin } = getMesEnCursoGuatemala();
+  const comprasMes = await db
+    .select({
+      credito_id: compras_credito_inversionista.credito_id,
+      monto_aportado: compras_credito_inversionista.monto_aportado,
+    })
+    .from(compras_credito_inversionista)
+    .where(
+      and(
+        eq(compras_credito_inversionista.inversionista_id, inversionista_id),
+        inArray(compras_credito_inversionista.credito_id, creditoIds),
+        sql`${compras_credito_inversionista.fecha} >= ${inicio}`,
+        sql`${compras_credito_inversionista.fecha} < ${fin}`,
+      ),
+    );
+
+  const compraPorCredito = new Map<number, Big>();
+  for (const c of comprasMes) {
+    const prev = compraPorCredito.get(c.credito_id) ?? new Big(0);
+    compraPorCredito.set(c.credito_id, prev.plus(new Big(c.monto_aportado)));
+  }
+
+  // ── Filtrar compras CANCELADAS ──
+  // Regla del negocio: para saber si una compra fue efectivamente aplicada,
+  // el monto_aportado del espejo tiene que ser >= la suma de la compra.
+  // Si es MENOR, la compra fue cancelada (la operación nunca se cerró) y
+  // se debe ignorar para los efectos del filtro. El crédito entra normal
+  // al reporte y la lógica del monto_aportado no debe sumar/restar nada.
+  for (const [credId, compraVal] of Array.from(compraPorCredito.entries())) {
+    const espejoVal = espejoPorCredito.get(credId);
+    if (espejoVal !== undefined && compraVal.gt(espejoVal)) {
+      compraPorCredito.delete(credId);
+    }
+  }
+
+  // ── PASO 5: ARMAR PLAN POR CAMBIO ──
+  type PlanItem = {
+    credito_id: number;
+    error?: string;
+    sin_cambios?: boolean;
+    pago_espejo_id?: number;
+    pago_espejo?: {
+      abono_capital?: { actual: string; nuevo: string };
+      abono_interes?: { actual: string; nuevo: string };
+      abono_iva_12?: { actual: string; nuevo: string };
+    };
+    monto_aportado?: {
+      actual: string;
+      compra_mes: string;
+      monto_endpoint: string;
+      monto_erroneo?: string;
+      nuevo: string | null;
+      modo:
+        | "ajustado_con_compra"
+        | "literal_forzado"
+        | "literal_sin_compra"
+        | "sin_cambio_coincide";
+    };
+    requiere_dry_run: boolean;
+  };
+
+  const plan: PlanItem[] = [];
+  let algunRequiereDryRun = false;
+
+  for (const cambio of cambios) {
+    const pago = pagoPorCredito.get(cambio.credito_id);
+    const espejoMonto = espejoPorCredito.get(cambio.credito_id);
+
+    if (!pago) {
+      plan.push({
+        credito_id: cambio.credito_id,
+        error: `No existe pago espejo para credito ${cambio.credito_id} en la liquidación ${liquidacion_id}.`,
+        requiere_dry_run: false,
+      });
+      continue;
+    }
+
+    const item: PlanItem = {
+      credito_id: cambio.credito_id,
+      pago_espejo_id: pago.id,
+      requiere_dry_run: false,
+    };
+
+    // Plan del pago espejo (solo campos no-null)
+    const pe: NonNullable<PlanItem["pago_espejo"]> = {};
+    if (cambio.abono_capital != null) {
+      pe.abono_capital = {
+        actual: pago.abono_capital,
+        nuevo: new Big(cambio.abono_capital).toFixed(10),
+      };
+    }
+    if (cambio.abono_interes != null) {
+      pe.abono_interes = {
+        actual: pago.abono_interes,
+        nuevo: new Big(cambio.abono_interes).toFixed(10),
+      };
+    }
+    if (cambio.iva != null) {
+      pe.abono_iva_12 = {
+        actual: pago.abono_iva_12,
+        nuevo: new Big(cambio.iva).toFixed(2),
+      };
+    }
+    if (Object.keys(pe).length > 0) {
+      item.pago_espejo = pe;
+    }
+
+    // Plan del monto_aportado
+    if (cambio.monto_aportado != null) {
+      if (espejoMonto == null) {
+        item.error = `No existe creditos_inversionistas_espejo para inversionista ${inversionista_id}, credito ${cambio.credito_id}.`;
+        plan.push(item);
+        continue;
+      }
+
+      const montoEndpoint = new Big(cambio.monto_aportado);
+      const compra = compraPorCredito.get(cambio.credito_id) ?? new Big(0);
+      const forzado = cambio.monto_aportado_forzado === true;
+
+      if (forzado) {
+        item.monto_aportado = {
+          actual: espejoMonto.toFixed(8),
+          compra_mes: compra.toFixed(8),
+          monto_endpoint: montoEndpoint.toFixed(8),
+          nuevo: montoEndpoint.toFixed(8),
+          modo: "literal_forzado",
+        };
+      } else if (compra.eq(0)) {
+        item.monto_aportado = {
+          actual: espejoMonto.toFixed(8),
+          compra_mes: "0",
+          monto_endpoint: montoEndpoint.toFixed(8),
+          nuevo: montoEndpoint.toFixed(8),
+          modo: "literal_sin_compra",
+        };
+      } else {
+        const montoErroneo = espejoMonto.minus(compra);
+        const diff = montoErroneo.minus(montoEndpoint).abs();
+        if (diff.lt(0.01)) {
+          item.monto_aportado = {
+            actual: espejoMonto.toFixed(8),
+            compra_mes: compra.toFixed(8),
+            monto_endpoint: montoEndpoint.toFixed(8),
+            monto_erroneo: montoErroneo.toFixed(8),
+            nuevo: null,
+            modo: "sin_cambio_coincide",
+          };
+        } else {
+          const nuevo = montoEndpoint.plus(compra);
+          item.monto_aportado = {
+            actual: espejoMonto.toFixed(8),
+            compra_mes: compra.toFixed(8),
+            monto_endpoint: montoEndpoint.toFixed(8),
+            monto_erroneo: montoErroneo.toFixed(8),
+            nuevo: nuevo.toFixed(8),
+            modo: "ajustado_con_compra",
+          };
+          item.requiere_dry_run = true;
+        }
+      }
+    }
+
+    if (!item.pago_espejo && !item.monto_aportado && !item.error) {
+      item.sin_cambios = true;
+    }
+
+    if (item.requiere_dry_run) algunRequiereDryRun = true;
+    plan.push(item);
+  }
+
+  // ── PASO 6: DECIDIR DRY-RUN GLOBAL ──
+  // El dry-run NO bloquea la generación del reporte (eso se decide aparte).
+  // Solo decide si se aplican los cambios al espejo o no.
+  const isDryRun = algunRequiereDryRun && !force;
+
+  // ── PASO 7: APLICAR EN TRANSACCIÓN (si no es dry-run) ──
+  if (!isDryRun) {
+    await db.transaction(async (tx) => {
+      for (const item of plan) {
+        if (item.error || item.sin_cambios) continue;
+
+        // Update pago espejo
+        if (item.pago_espejo && item.pago_espejo_id != null) {
+          const setObj: Record<string, unknown> = { updated_at: new Date() };
+          if (item.pago_espejo.abono_capital) {
+            setObj.abono_capital = item.pago_espejo.abono_capital.nuevo;
+          }
+          if (item.pago_espejo.abono_interes) {
+            setObj.abono_interes = item.pago_espejo.abono_interes.nuevo;
+          }
+          if (item.pago_espejo.abono_iva_12) {
+            setObj.abono_iva_12 = item.pago_espejo.abono_iva_12.nuevo;
+          }
+          if (Object.keys(setObj).length > 1) {
+            await tx
+              .update(pagos_credito_inversionistas_espejo)
+              .set(setObj)
+              .where(eq(pagos_credito_inversionistas_espejo.id, item.pago_espejo_id));
+          }
+        }
+
+        // Update monto_aportado en espejo
+        if (item.monto_aportado && item.monto_aportado.nuevo != null) {
+          await tx
+            .update(creditos_inversionistas_espejo)
+            .set({
+              monto_aportado: item.monto_aportado.nuevo,
+              updated_at: new Date(),
+            })
+            .where(
+              and(
+                eq(creditos_inversionistas_espejo.inversionista_id, inversionista_id),
+                eq(creditos_inversionistas_espejo.credito_id, item.credito_id),
+              ),
+            );
+        }
+      }
+    });
+  }
+
+  // ── PASO 8: COMPUTAR FILTRO DE COMPRAS DEL MES (siempre) ──
+  // Necesario tanto para la comparación de reinversion_total como para el
+  // reporte (si se pide). Se hace sobre TODOS los créditos del inversionista
+  // en el espejo (no solo los del payload de cambios).
+  const todasComprasMes = await db
+    .select({
+      credito_id: compras_credito_inversionista.credito_id,
+      monto_aportado: compras_credito_inversionista.monto_aportado,
+    })
+    .from(compras_credito_inversionista)
+    .where(
+      and(
+        eq(compras_credito_inversionista.inversionista_id, inversionista_id),
+        sql`${compras_credito_inversionista.fecha} >= ${inicio}`,
+        sql`${compras_credito_inversionista.fecha} < ${fin}`,
+      ),
+    );
+
+  const compraTodosPorCredito = new Map<number, Big>();
+  for (const c of todasComprasMes) {
+    const prev = compraTodosPorCredito.get(c.credito_id) ?? new Big(0);
+    compraTodosPorCredito.set(c.credito_id, prev.plus(new Big(c.monto_aportado)));
+  }
+
+  // Construir conjuntos de excluidos / ajustados a partir del espejo actual.
+  const todosEspejos = await db
+    .select({
+      credito_id: creditos_inversionistas_espejo.credito_id,
+      monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+    })
+    .from(creditos_inversionistas_espejo)
+    .where(
+      eq(creditos_inversionistas_espejo.inversionista_id, inversionista_id),
+    );
+
+  const creditos_excluidos_reporte: number[] = [];
+  const creditos_ajustados_reporte: {
+    credito_id: number;
+    monto_original: string;
+    monto_ajustado: string;
+  }[] = [];
+  // Créditos donde detectamos que la compra del mes en realidad fue
+  // CANCELADA (monto_espejo < compra). Se reportan para diagnóstico pero
+  // no se filtran ni ajustan: el crédito entra normal al reporte.
+  const compras_canceladas: {
+    credito_id: number;
+    espejo_monto: string;
+    compra_monto: string;
+  }[] = [];
+  const ajustadosMap = new Map<number, Big>();
+
+  for (const e of todosEspejos) {
+    const compra = compraTodosPorCredito.get(e.credito_id);
+    if (!compra || compra.eq(0)) continue;
+    const monto = new Big(e.monto_aportado);
+    // Compra cancelada: el espejo nunca llegó al monto de la compra,
+    // así que la operación nunca se cerró efectivamente. Ignorarla.
+    if (monto.lt(compra)) {
+      compras_canceladas.push({
+        credito_id: e.credito_id,
+        espejo_monto: monto.toFixed(2),
+        compra_monto: compra.toFixed(2),
+      });
+      continue;
+    }
+    if (monto.eq(compra)) {
+      creditos_excluidos_reporte.push(e.credito_id);
+    } else {
+      const ajustado = monto.minus(compra);
+      ajustadosMap.set(e.credito_id, ajustado);
+      creditos_ajustados_reporte.push({
+        credito_id: e.credito_id,
+        monto_original: monto.toFixed(2),
+        monto_ajustado: ajustado.toFixed(2),
+      });
+    }
+  }
+
+  const excluidosSet = new Set(creditos_excluidos_reporte);
+
+  // ── PASO 9: RECOMPUTAR TOTALES FILTRADOS Y COMPARAR CONTRA LIQUIDACION ──
+  // Recomputa todos los totales en RAW Q sobre los créditos del espejo que
+  // sobreviven al filtro, con monto_aportado ajustado donde aplica.
+  // Para cada campo de `liquidaciones` que dependa de estos totales:
+  //   - Si difiere del valor guardado: se incluye en el update (cuando NO
+  //     es dry-run) y se reporta en `totales_update`.
+  //   - Si no difiere: se ignora (no se sobreescribe innecesariamente).
+  const totalesFiltrados = await computarTotalesFiltrados({
+    inversionista_id,
+    liquidacion_id,
+    creditos_excluidos: excluidosSet,
+    monto_aportado_ajustado: ajustadosMap,
+  });
+
+  const [liqRow] = await db
+    .select({
+      total_pagos_liquidados: liquidaciones.total_pagos_liquidados,
+      total_capital: liquidaciones.total_capital,
+      total_interes: liquidaciones.total_interes,
+      total_iva: liquidaciones.total_iva,
+      total_isr: liquidaciones.total_isr,
+      total_cuota: liquidaciones.total_cuota,
+      reinversion_capital: liquidaciones.reinversion_capital,
+      reinversion_interes: liquidaciones.reinversion_interes,
+      reinversion_total: liquidaciones.reinversion_total,
+    })
+    .from(liquidaciones)
+    .where(eq(liquidaciones.liquidacion_id, liquidacion_id))
+    .limit(1);
+
+  // total_iva en `liquidaciones` se guarda según emite_factura, igual que
+  // hace getInvestorTotalsGlobales al rendear el header del Excel.
+  const totalIvaFinal = totalesFiltrados.emite_factura
+    ? totalesFiltrados.total_abono_iva
+    : totalesFiltrados.total_abono_interes.round(2).times(0.12);
+
+  // Mapeo: campo de liquidaciones → valor recalculado.
+  const nuevosValores: Record<string, Big | number> = {
+    total_pagos_liquidados: totalesFiltrados.pagos_count,
+    total_capital: totalesFiltrados.total_abono_capital.round(2),
+    total_interes: totalesFiltrados.total_abono_interes.round(2),
+    total_iva: totalIvaFinal.round(2),
+    total_isr: totalesFiltrados.total_isr.round(2),
+    total_cuota: totalesFiltrados.total_cuota.round(2),
+    reinversion_capital: totalesFiltrados.total_reinversion_capital.round(2),
+    reinversion_interes: totalesFiltrados.total_reinversion_interes.round(2),
+    reinversion_total: totalesFiltrados.total_reinversion.round(2),
+  };
+
+  // SIEMPRE reportamos los 9 campos (cambien o no), con anterior/nuevo/diferencia.
+  // Eso permite al cliente confirmar que la comparación se hizo y ver que
+  // ningún total quedó descalibrado. Solo los que tienen `cambio=true`
+  // entran al UPDATE.
+  type TotalesUpdateField = {
+    anterior: string;
+    nuevo: string;
+    diferencia: string;
+    cambio: boolean;
+    aplicado: boolean;
+  };
+
+  const totales_update: Record<string, TotalesUpdateField> = {};
+  const setObj: Record<string, unknown> = {};
+  const previos: Record<string, string | number> = liqRow
+    ? {
+        total_pagos_liquidados: liqRow.total_pagos_liquidados,
+        total_capital: liqRow.total_capital,
+        total_interes: liqRow.total_interes,
+        total_iva: liqRow.total_iva,
+        total_isr: liqRow.total_isr,
+        total_cuota: liqRow.total_cuota,
+        reinversion_capital: liqRow.reinversion_capital,
+        reinversion_interes: liqRow.reinversion_interes,
+        reinversion_total: liqRow.reinversion_total,
+      }
+    : {};
+
+  if (liqRow) {
+    for (const [campo, nuevo] of Object.entries(nuevosValores)) {
+      if (campo === "total_pagos_liquidados") {
+        const ant = Number(previos[campo] ?? 0);
+        const nue = Number(nuevo);
+        const cambio = ant !== nue;
+        totales_update[campo] = {
+          anterior: String(ant),
+          nuevo: String(nue),
+          diferencia: String(nue - ant),
+          cambio,
+          aplicado: cambio && !isDryRun,
+        };
+        if (cambio) setObj[campo] = nue;
+        continue;
+      }
+      const ant = new Big(previos[campo] ?? 0);
+      const nue = nuevo as Big;
+      const diff = nue.minus(ant);
+      const cambio = !diff.eq(0);
+      totales_update[campo] = {
+        anterior: ant.toFixed(2),
+        nuevo: nue.toFixed(2),
+        diferencia: diff.toFixed(2),
+        cambio,
+        aplicado: cambio && !isDryRun,
+      };
+      if (cambio) setObj[campo] = nue.toFixed(2);
+    }
+  }
+
+  const huboCambiosTotales = Object.keys(setObj).length > 0;
+  if (huboCambiosTotales && !isDryRun) {
+    await db
+      .update(liquidaciones)
+      .set(setObj as any)
+      .where(eq(liquidaciones.liquidacion_id, liquidacion_id));
+  }
+
+  // ── PASO 10: GENERAR REPORTE (OPCIONAL, también en dry-run) ──
+  // En dry-run el espejo no se actualizó, así que el reporte refleja el
+  // estado actual con el filtro de compras del mes aplicado. Tras force=true
+  // refleja el estado post-aplicación.
+  let reporte_url: string | null = null;
+
+  if (generar_reporte) {
+    try {
+      const result = await resumeInvestor(
+        inversionista_id,
+        1,
+        999999,
+        undefined,
+        undefined,
+        undefined,
+        false,
+        undefined,
+        "espejos",
+        true,
+        liquidacion_id,
+        undefined,
+      );
+
+      if (!result.inversionistas.length) {
+        return {
+          success: true,
+          dry_run: isDryRun,
+          message: isDryRun
+            ? "Plan en dry-run, no se generó reporte: inversionista sin pagos liquidados."
+            : "Cambios aplicados, pero no se generó reporte: inversionista sin pagos liquidados.",
+          cambios: plan,
+          reporte_url: null,
+          creditos_excluidos_reporte,
+          creditos_ajustados_reporte,
+          compras_canceladas,
+          totales_update,
+          status: 200 as const,
+        };
+      }
+
+      const inversionista = result.inversionistas[0] as any;
+
+      // Filtrar / ajustar créditos del Excel
+      const ajustadoPorIdStr = new Map(
+        creditos_ajustados_reporte.map((c) => [c.credito_id, c.monto_ajustado]),
+      );
+      const creditosFiltrados: any[] = [];
+      for (const c of inversionista.creditos ?? []) {
+        if (excluidosSet.has(c.credito_id)) continue;
+        const ajustado = ajustadoPorIdStr.get(c.credito_id);
+        if (ajustado != null) {
+          creditosFiltrados.push({ ...c, monto_aportado: ajustado });
+        } else {
+          creditosFiltrados.push(c);
+        }
+      }
+      inversionista.creditos = creditosFiltrados;
+
+      // Subtotales consistentes con el filtro. Recomputados en Q y luego
+      // convertidos a USD si el inversionista usa esa moneda (para que el
+      // Excel los muestre correctamente formateados).
+      const esDolares = totalesFiltrados.moneda === "dolares";
+      const fmt = (val: Big): number =>
+        esDolares
+          ? formatToUSD(val.toString(), inversionista_id)
+          : Number(val.round(2).toString());
+
+      const totalAbonoIvaShown = totalesFiltrados.emite_factura
+        ? totalesFiltrados.total_abono_iva
+        : totalesFiltrados.total_abono_interes.round(2).times(0.12);
+
+      inversionista.subtotal = {
+        total_abono_capital: fmt(totalesFiltrados.total_abono_capital),
+        total_abono_interes: fmt(totalesFiltrados.total_abono_interes),
+        total_abono_iva: fmt(totalAbonoIvaShown),
+        total_isr: fmt(totalesFiltrados.total_isr),
+        total_cuota_sin_reinversion: fmt(totalesFiltrados.total_cuota_sin_reinversion),
+        total_cuota_con_reinversion: fmt(totalesFiltrados.total_cuota),
+        total_cuota: fmt(totalesFiltrados.total_cuota),
+        total_monto_aportado: fmt(totalesFiltrados.total_monto_aportado),
+        total_abono_general_interes: fmt(totalesFiltrados.total_abono_general_interes),
+        total_reinversion: fmt(totalesFiltrados.total_reinversion),
+        total_reinversion_capital: fmt(totalesFiltrados.total_reinversion_capital),
+        total_reinversion_interes: fmt(totalesFiltrados.total_reinversion_interes),
+      };
+
+      const logoUrl = (import.meta as any).env?.LOGO_URL || "";
+      const filename = `ajuste_liquidados_${liquidacion_id}_${Date.now()}.xlsx`;
+      const { url } = await generarYSubirExcelInversionista(
+        inversionista,
+        filename,
+        logoUrl,
+      );
+      reporte_url = url;
+
+      // En modo aplicar (no dry-run), persistir la nueva URL en la
+      // liquidación para que `reporte_liquidacion_url` quede sincronizada
+      // con el Excel que acabamos de generar.
+      if (!isDryRun) {
+        await db
+          .update(liquidaciones)
+          .set({ reporte_liquidacion_url: url })
+          .where(eq(liquidaciones.liquidacion_id, liquidacion_id));
+      }
+    } catch (err) {
+      console.error("[ajustarPagosLiquidacion] Error generando reporte:", err);
+      reporte_url = null;
+    }
+  }
+
+  const cambiosAplicables = plan.filter((p) => !p.error && !p.sin_cambios).length;
+
+  return {
+    success: true,
+    dry_run: isDryRun,
+    message: isDryRun
+      ? "Dry-run: hay créditos con compra del mes registrada. Revisá el plan y volvé a llamar con force=true (o mandá monto_aportado_forzado=true en los cambios donde corresponda)."
+      : `Cambios aplicados a ${cambiosAplicables} crédito(s).`,
+    cambios: plan,
+    reporte_url,
+    creditos_excluidos_reporte,
+    creditos_ajustados_reporte,
+    compras_canceladas,
+    totales_update,
+    totales_cambios_count: Object.values(totales_update).filter((t) => t.cambio)
+      .length,
+    status: 200 as const,
+  };
+}

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -1119,11 +1119,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
 
         // ── Si el inversionista no existía en el destino, agregarlo en
         //    ambas tablas con el mismo monto (no hay valor histórico previo). ──
-        const hoy = new Date();
-        const hoyStr = hoy.toISOString().split("T")[0];
-        const dosMesesAtras = new Date(hoy.getFullYear(), hoy.getMonth() - 2, hoy.getDate())
-          .toISOString()
-          .split("T")[0];
+        const hoyStr = new Date().toISOString().split("T")[0];
         if (
           !arrayDestinoPadre.some(
             (inv) => inv.inversionista_id === inversionista_id,
@@ -1134,7 +1130,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
             monto_aportado: montoAsignar,
             porcentaje_cash_in: porcCashIn,
             porcentaje_inversion: porcInversion,
-            fecha_inicio_participacion: tipo_operacion === "reinversion" ? dosMesesAtras : hoyStr,
+            fecha_inicio_participacion: hoyStr,
           });
         }
         if (
@@ -1147,7 +1143,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
             monto_aportado: montoAsignar,
             porcentaje_cash_in: porcCashIn,
             porcentaje_inversion: porcInversion,
-            fecha_inicio_participacion: tipo_operacion === "reinversion" ? dosMesesAtras : hoyStr,
+            fecha_inicio_participacion: hoyStr,
           });
         }
 

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -34,14 +34,255 @@ import {
   getCreditosEspejoPendientes,
   detectPagosHuerfanos,
 } from "../controllers/investor";
+import { ajustarPagosLiquidacion } from "../controllers/ajustarPagosLiquidacion";
 import { InversionistaReporte, RespuestaReporte } from "../utils/interface";
 import { generarYSubirPDFInversionista, generarYSubirExcelInversionista } from "../utils/functions/generalFunctions";
 import { authMiddleware } from "./midleware";
 import { obtenerCreditosConPagosPendientes, calcularYRegistrarPagosEspejo } from "../controllers/payments";
 import { createBoleta, getBoletaById, getAllBoletas, getBoletasPendientes, updateBoleta, marcarBoletaComoProcesada, marcarBoletaComoPendiente, deleteBoleta, getBoletasStats } from "../controllers/liquidateInvestor";
 import { requierePeriodoLiquidacion } from "../utils/investorLiquidationSummary";
+import ExcelJS from "exceljs";
+import { promises as fsp } from "node:fs";
+import path from "node:path";
 // 🔥 IMPORTAR SERVICIO DE BOLETAS
 
+
+// ──────────────────────────────────────────────
+// Helper: serializar resultados del bulk ajuste-pagos-liquidacion a CSV.
+// Una fila por item enviado, con la URL del reporte (si se generó) y los
+// deltas anterior/nuevo de cada total de la liquidación.
+// ──────────────────────────────────────────────
+function armarCsvBulkAjuste(
+  resultados: Array<{
+    index: number;
+    inversionista_id?: number;
+    liquidacion_id?: number;
+    success: boolean;
+    result?: any;
+    error?: string;
+  }>,
+): string {
+  const camposTotales = [
+    "total_pagos_liquidados",
+    "total_capital",
+    "total_interes",
+    "total_iva",
+    "total_isr",
+    "total_cuota",
+    "reinversion_capital",
+    "reinversion_interes",
+    "reinversion_total",
+  ] as const;
+
+  // Header: una columna anterior + nuevo por cada total
+  const headerBase = [
+    "index",
+    "inversionista_id",
+    "liquidacion_id",
+    "success",
+    "dry_run",
+    "reporte_url",
+    "creditos_excluidos",
+    "creditos_ajustados",
+    "compras_canceladas",
+    "totales_cambios_count",
+    "error",
+  ];
+  const headerTotales = camposTotales.flatMap((c) => [
+    `${c}_anterior`,
+    `${c}_nuevo`,
+    `${c}_diferencia`,
+  ]);
+  const header = [...headerBase, ...headerTotales];
+
+  // Escape simple para CSV (RFC 4180): si tiene coma, comilla doble o salto
+  // de línea, encerrar entre comillas y doblar las comillas internas.
+  const esc = (v: unknown): string => {
+    if (v === null || v === undefined) return "";
+    const s = String(v);
+    if (/[",\n\r]/.test(s)) {
+      return `"${s.replace(/"/g, '""')}"`;
+    }
+    return s;
+  };
+
+  const filas: string[] = [header.join(",")];
+
+  for (const r of resultados) {
+    const res = r.result ?? {};
+    const tu = res.totales_update ?? {};
+    const fila = [
+      esc(r.index),
+      esc(r.inversionista_id ?? ""),
+      esc(r.liquidacion_id ?? ""),
+      esc(r.success),
+      esc(res.dry_run ?? ""),
+      esc(res.reporte_url ?? ""),
+      esc(
+        Array.isArray(res.creditos_excluidos_reporte)
+          ? res.creditos_excluidos_reporte.join("|")
+          : "",
+      ),
+      esc(
+        Array.isArray(res.creditos_ajustados_reporte)
+          ? res.creditos_ajustados_reporte
+              .map(
+                (c: any) =>
+                  `${c.credito_id}:${c.monto_original}->${c.monto_ajustado}`,
+              )
+              .join("|")
+          : "",
+      ),
+      esc(
+        Array.isArray(res.compras_canceladas)
+          ? res.compras_canceladas
+              .map(
+                (c: any) =>
+                  `${c.credito_id}:espejo=${c.espejo_monto},compra=${c.compra_monto}`,
+              )
+              .join("|")
+          : "",
+      ),
+      esc(res.totales_cambios_count ?? ""),
+      esc(r.error ?? ""),
+    ];
+
+    for (const campo of camposTotales) {
+      const t = tu[campo];
+      if (t) {
+        fila.push(esc(t.anterior), esc(t.nuevo), esc(t.diferencia));
+      } else {
+        fila.push("", "", "");
+      }
+    }
+
+    filas.push(fila.join(","));
+  }
+
+  return filas.join("\n");
+}
+
+// ──────────────────────────────────────────────
+// Helper: serializar resultados del bulk a XLSX y dejarlo escrito en disco.
+// Mismas columnas y semántica que armarCsvBulkAjuste; columnas vacías cuando
+// el campo no cambió, para que destaquen los cambios visualmente.
+// Devuelve el path absoluto donde se escribió el archivo.
+// ──────────────────────────────────────────────
+async function armarYGuardarXlsxBulkAjuste(
+  resultados: Array<{
+    index: number;
+    inversionista_id?: number;
+    liquidacion_id?: number;
+    success: boolean;
+    result?: any;
+    error?: string;
+  }>,
+): Promise<string> {
+  const camposTotales = [
+    "total_pagos_liquidados",
+    "total_capital",
+    "total_interes",
+    "total_iva",
+    "total_isr",
+    "total_cuota",
+    "reinversion_capital",
+    "reinversion_interes",
+    "reinversion_total",
+  ] as const;
+
+  const headerBase = [
+    "index",
+    "inversionista_id",
+    "liquidacion_id",
+    "success",
+    "dry_run",
+    "reporte_url",
+    "creditos_excluidos",
+    "creditos_ajustados",
+    "compras_canceladas",
+    "totales_cambios_count",
+    "error",
+  ];
+  const headerTotales = camposTotales.flatMap((c) => [
+    `${c}_anterior`,
+    `${c}_nuevo`,
+    `${c}_diferencia`,
+  ]);
+  const header = [...headerBase, ...headerTotales];
+
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet("bulk_ajuste");
+
+  // Header con negrita y freeze pane
+  ws.addRow(header);
+  ws.getRow(1).font = { bold: true };
+  ws.views = [{ state: "frozen", ySplit: 1 }];
+
+  for (const r of resultados) {
+    const res = r.result ?? {};
+    const tu = res.totales_update ?? {};
+    const fila: (string | number | null)[] = [
+      r.index,
+      r.inversionista_id ?? "",
+      r.liquidacion_id ?? "",
+      r.success,
+      res.dry_run ?? "",
+      res.reporte_url ?? "",
+      Array.isArray(res.creditos_excluidos_reporte)
+        ? res.creditos_excluidos_reporte.join("|")
+        : "",
+      Array.isArray(res.creditos_ajustados_reporte)
+        ? res.creditos_ajustados_reporte
+            .map(
+              (c: any) =>
+                `${c.credito_id}:${c.monto_original}->${c.monto_ajustado}`,
+            )
+            .join("|")
+        : "",
+      Array.isArray(res.compras_canceladas)
+        ? res.compras_canceladas
+            .map(
+              (c: any) =>
+                `${c.credito_id}:espejo=${c.espejo_monto},compra=${c.compra_monto}`,
+            )
+            .join("|")
+        : "",
+      res.totales_cambios_count ?? "",
+      r.error ?? "",
+    ];
+
+    for (const campo of camposTotales) {
+      const t = tu[campo];
+      if (t) {
+        // Convertir a número cuando sea posible (Excel hace mejor pivote/sort)
+        const ant = isNaN(Number(t.anterior)) ? t.anterior : Number(t.anterior);
+        const nue = isNaN(Number(t.nuevo)) ? t.nuevo : Number(t.nuevo);
+        const dif = isNaN(Number(t.diferencia))
+          ? t.diferencia
+          : Number(t.diferencia);
+        fila.push(ant, nue, dif);
+      } else {
+        fila.push("", "", "");
+      }
+    }
+
+    ws.addRow(fila);
+  }
+
+  // Auto width básico (mín 12, máx 50, según el largo del header)
+  ws.columns.forEach((col, i) => {
+    const headerStr = String(header[i] ?? "");
+    col.width = Math.min(Math.max(headerStr.length + 2, 12), 50);
+  });
+
+  // Path: <cwd>/ajustarPagos/bulk_resultado.xlsx
+  // Cuando el back arranca desde apps/cartera-back/, cwd ya apunta ahí.
+  const outDir = path.join(process.cwd(), "ajustarPagos");
+  await fsp.mkdir(outDir, { recursive: true });
+  const outPath = path.join(outDir, "bulk_resultado.xlsx");
+  await wb.xlsx.writeFile(outPath);
+  return outPath;
+}
 
 export const inversionistasRouter = new Elysia()
   .use(authMiddleware)
@@ -822,6 +1063,259 @@ export const inversionistasRouter = new Elysia()
         error: error instanceof Error ? error.message : String(error),
       };
     }
+  })
+  // ──────────────────────────────────────────────
+  // Ajustar pagos espejo + monto_aportado de un inversionista en una
+  // liquidación específica. Soporta dry-run cuando hay compras del mes
+  // que afectan el cálculo del monto_aportado.
+  //
+  // Body:
+  //   inversionista_id: number
+  //   liquidacion_id: number
+  //   cambios: [{ credito_id, abono_capital?, abono_interes?, iva?,
+  //               monto_aportado?, monto_aportado_forzado? }]
+  //   force?: boolean         (saltar dry-run y aplicar)
+  //   generar_reporte?: boolean (tras aplicar, generar Excel filtrado)
+  // ──────────────────────────────────────────────
+  .post("/investor/ajustar-pagos-liquidacion", async ({ body, set }) => {
+    const parsed = body as {
+      inversionista_id?: number;
+      liquidacion_id?: number;
+      cambios?: Array<{
+        credito_id?: number;
+        abono_capital?: number | null;
+        abono_interes?: number | null;
+        iva?: number | null;
+        monto_aportado?: number | null;
+        monto_aportado_forzado?: boolean;
+      }>;
+      force?: boolean;
+      generar_reporte?: boolean;
+    };
+
+    if (!parsed.inversionista_id || isNaN(Number(parsed.inversionista_id))) {
+      set.status = 400;
+      return { message: "El parámetro 'inversionista_id' es obligatorio y debe ser numérico." };
+    }
+    if (!parsed.liquidacion_id || isNaN(Number(parsed.liquidacion_id))) {
+      set.status = 400;
+      return { message: "El parámetro 'liquidacion_id' es obligatorio y debe ser numérico." };
+    }
+    if (!Array.isArray(parsed.cambios) || parsed.cambios.length === 0) {
+      set.status = 400;
+      return { message: "El parámetro 'cambios' debe ser un arreglo no vacío." };
+    }
+    for (const [i, c] of parsed.cambios.entries()) {
+      if (!c.credito_id || isNaN(Number(c.credito_id))) {
+        set.status = 400;
+        return { message: `cambios[${i}].credito_id es obligatorio y debe ser numérico.` };
+      }
+    }
+
+    try {
+      const result = await ajustarPagosLiquidacion({
+        inversionista_id: Number(parsed.inversionista_id),
+        liquidacion_id: Number(parsed.liquidacion_id),
+        cambios: parsed.cambios.map((c) => ({
+          credito_id: Number(c.credito_id),
+          abono_capital: c.abono_capital ?? null,
+          abono_interes: c.abono_interes ?? null,
+          iva: c.iva ?? null,
+          monto_aportado: c.monto_aportado ?? null,
+          monto_aportado_forzado: c.monto_aportado_forzado === true,
+        })),
+        force: parsed.force === true,
+        generar_reporte: parsed.generar_reporte === true,
+      });
+
+      const { status, ...payload } = result as any;
+      set.status = status ?? 200;
+      return payload;
+    } catch (error) {
+      console.error("[investor/ajustar-pagos-liquidacion] Error:", error);
+      set.status = 500;
+      return {
+        success: false,
+        message: "Error ajustando pagos de liquidación",
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  })
+  // ──────────────────────────────────────────────
+  // BULK: ajustar-pagos-liquidacion en lote
+  //
+  // Recibe un array `items`, cada uno con la misma forma que el endpoint
+  // single. Se procesan SECUENCIALMENTE con try/catch por item — si uno
+  // falla, los demás siguen. Cada item maneja su propio dry-run y
+  // generar_reporte de manera independiente.
+  //
+  // Body:
+  //   items: [{
+  //     inversionista_id, liquidacion_id, cambios: [...],
+  //     force?, generar_reporte?
+  //   }]
+  //
+  // Response:
+  //   procesados: número total enviado
+  //   exitosos:   cuántos terminaron con success=true
+  //   fallidos:   cuántos lanzaron error
+  //   dry_runs:   cuántos quedaron en dry-run
+  //   resultados: [{ index, inversionista_id, liquidacion_id, result | error }]
+  // ──────────────────────────────────────────────
+  .post("/investor/ajustar-pagos-liquidacion/bulk", async ({ body, set }) => {
+    type BulkItem = {
+      inversionista_id?: number;
+      liquidacion_id?: number;
+      cambios?: Array<{
+        credito_id?: number;
+        abono_capital?: number | null;
+        abono_interes?: number | null;
+        iva?: number | null;
+        monto_aportado?: number | null;
+        monto_aportado_forzado?: boolean;
+      }>;
+      force?: boolean;
+      generar_reporte?: boolean;
+    };
+
+    // Aceptar tanto un array directo como `{ items: [...] }`.
+    const items: BulkItem[] = Array.isArray(body)
+      ? (body as BulkItem[])
+      : Array.isArray((body as any)?.items)
+        ? ((body as any).items as BulkItem[])
+        : [];
+    const parsed = { items };
+
+    if (parsed.items.length === 0) {
+      set.status = 400;
+      return {
+        message:
+          "El body debe ser un arreglo de items o `{ items: [...] }` no vacío.",
+      };
+    }
+
+    const resultados: Array<{
+      index: number;
+      inversionista_id?: number;
+      liquidacion_id?: number;
+      success: boolean;
+      result?: unknown;
+      error?: string;
+    }> = [];
+    let exitosos = 0;
+    let fallidos = 0;
+    let dry_runs = 0;
+
+    for (let i = 0; i < parsed.items.length; i++) {
+      const item = parsed.items[i];
+
+      // Validación liviana por item (no aborta el batch, marca el item como error)
+      if (!item.inversionista_id || isNaN(Number(item.inversionista_id))) {
+        resultados.push({
+          index: i,
+          success: false,
+          error: "inversionista_id es obligatorio y debe ser numérico.",
+        });
+        fallidos++;
+        continue;
+      }
+      if (!item.liquidacion_id || isNaN(Number(item.liquidacion_id))) {
+        resultados.push({
+          index: i,
+          inversionista_id: Number(item.inversionista_id),
+          success: false,
+          error: "liquidacion_id es obligatorio y debe ser numérico.",
+        });
+        fallidos++;
+        continue;
+      }
+      if (!Array.isArray(item.cambios) || item.cambios.length === 0) {
+        resultados.push({
+          index: i,
+          inversionista_id: Number(item.inversionista_id),
+          liquidacion_id: Number(item.liquidacion_id),
+          success: false,
+          error: "cambios debe ser un arreglo no vacío.",
+        });
+        fallidos++;
+        continue;
+      }
+
+      try {
+        const result = await ajustarPagosLiquidacion({
+          inversionista_id: Number(item.inversionista_id),
+          liquidacion_id: Number(item.liquidacion_id),
+          cambios: item.cambios.map((c) => ({
+            credito_id: Number(c.credito_id),
+            abono_capital: c.abono_capital ?? null,
+            abono_interes: c.abono_interes ?? null,
+            iva: c.iva ?? null,
+            monto_aportado: c.monto_aportado ?? null,
+            monto_aportado_forzado: c.monto_aportado_forzado === true,
+          })),
+          force: item.force === true,
+          generar_reporte: item.generar_reporte === true,
+        });
+
+        // El controller devuelve `status` con el código HTTP que correspondería
+        // si fuera single. Lo usamos para clasificar pero no lo propagamos al
+        // status del response del bulk (que siempre es 200 OK del batch).
+        const { status, ...payload } = result as any;
+        const ok = (payload as any).success === true;
+        const isDry = (payload as any).dry_run === true;
+
+        resultados.push({
+          index: i,
+          inversionista_id: Number(item.inversionista_id),
+          liquidacion_id: Number(item.liquidacion_id),
+          success: ok,
+          result: payload,
+        });
+
+        if (ok) {
+          exitosos++;
+          if (isDry) dry_runs++;
+        } else {
+          fallidos++;
+        }
+      } catch (error) {
+        console.error(
+          `[investor/ajustar-pagos-liquidacion/bulk] Item ${i} (inv=${item.inversionista_id}, liq=${item.liquidacion_id}) falló:`,
+          error,
+        );
+        resultados.push({
+          index: i,
+          inversionista_id: Number(item.inversionista_id),
+          liquidacion_id: Number(item.liquidacion_id),
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        fallidos++;
+      }
+    }
+
+    // Generar Excel y guardarlo en disco (best-effort: si falla, no rompe la respuesta).
+    let xlsx_path: string | null = null;
+    let xlsx_error: string | undefined;
+    try {
+      xlsx_path = await armarYGuardarXlsxBulkAjuste(resultados);
+    } catch (err) {
+      console.error("[investor/ajustar-pagos-liquidacion/bulk] Error generando XLSX:", err);
+      xlsx_error = err instanceof Error ? err.message : String(err);
+    }
+
+    set.status = 200;
+    return {
+      success: fallidos === 0,
+      procesados: parsed.items.length,
+      exitosos,
+      fallidos,
+      dry_runs,
+      resultados,
+      csv: armarCsvBulkAjuste(resultados),
+      xlsx_path,
+      ...(xlsx_error ? { xlsx_error } : {}),
+    };
   })
   // ──────────────────────────────────────────────
   // Revertir una liquidación completa por liquidacion_id

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -56,6 +56,13 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Combobox, Transition } from "@headlessui/react";
 import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Fragment, useState, useEffect, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 import { ConfirmationModal } from "@/components/ui/confirmation-modal";
@@ -288,6 +295,17 @@ export function TableInvestors() {
   const [compraCarteraFecha, setCompraCarteraFecha] = useState("");
   const [compraCarteraPctInv, setCompraCarteraPctInv] = useState("70");
   const [compraCarteraPctCashIn, setCompraCarteraPctCashIn] = useState("30");
+  const [compraCarteraTipoReinversion, setCompraCarteraTipoReinversion] =
+    useState<
+      | "sin_reinversion"
+      | "reinversion_capital"
+      | "reinversion_total"
+    >("sin_reinversion");
+  const [compraCarteraTipoOperacion, setCompraCarteraTipoOperacion] = useState<
+    "compra_cartera" | "reinversion"
+  >("compra_cartera");
+  // Fecha por defecto bloqueada (diciembre 2025).
+  const FECHA_INICIO_DEFAULT = "2025-12-01";
   const agregarInvCredito = useAgregarInversionistaCredito();
 
   const [incluirLiquidados, setIncluirLiquidados] = useState(false);
@@ -1243,7 +1261,10 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                     e.stopPropagation();
                     setCompraCarteraInvId(inv.inversionista_id);
                     setCompraCarteraMonto("");
+                    // Default compra_cartera → fecha de hoy (editable)
                     setCompraCarteraFecha(new Date().toISOString().split("T")[0]);
+                    setCompraCarteraTipoReinversion("sin_reinversion");
+                    setCompraCarteraTipoOperacion("compra_cartera");
                     // Calcular moda del porcentaje de participación desde créditos existentes
                     const creditos = inv.creditos ?? [];
                     if (creditos.length > 0) {
@@ -2453,16 +2474,78 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
           }
         }}
       >
-        <DialogContent className="!bg-[#1e293b] sm:max-w-md z-[60] border border-slate-600/40 shadow-2xl rounded-2xl">
+        <DialogContent className="!bg-white sm:max-w-md z-[60] border border-gray-200 shadow-2xl rounded-2xl">
           <DialogHeader>
-            <DialogTitle className="text-lg font-bold text-white">Compra de Cartera</DialogTitle>
-            <DialogDescription className="text-slate-400 text-sm">
+            <DialogTitle className="text-lg font-bold text-gray-900">
+              {compraCarteraTipoOperacion === "reinversion"
+                ? "Reinversión"
+                : "Compra de Cartera"}
+            </DialogTitle>
+            <DialogDescription className="text-gray-500 text-sm">
               Ingresa el monto, porcentajes y la fecha de inicio de participación
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-2">
+            <div className="grid grid-cols-2 gap-2 p-1 bg-gray-100 rounded-xl">
+              <button
+                type="button"
+                onClick={() => {
+                  setCompraCarteraTipoOperacion("compra_cartera");
+                  setCompraCarteraFecha(new Date().toISOString().split("T")[0]);
+                }}
+                className={`px-3 py-2 text-sm font-medium rounded-lg transition-all ${
+                  compraCarteraTipoOperacion === "compra_cartera"
+                    ? "bg-white text-gray-900 shadow-sm"
+                    : "text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                Compra de Cartera
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setCompraCarteraTipoOperacion("reinversion");
+                  setCompraCarteraFecha(FECHA_INICIO_DEFAULT);
+                }}
+                className={`px-3 py-2 text-sm font-medium rounded-lg transition-all ${
+                  compraCarteraTipoOperacion === "reinversion"
+                    ? "bg-white text-gray-900 shadow-sm"
+                    : "text-gray-500 hover:text-gray-700"
+                }`}
+              >
+                Reinversión
+              </button>
+            </div>
             <div>
-              <label htmlFor="compra-monto" className="text-sm font-medium text-slate-300">
+              <label htmlFor="compra-modalidad" className="text-sm font-medium text-gray-700">
+                Modelo de Inversión
+              </label>
+              <Select
+                value={compraCarteraTipoReinversion}
+                onValueChange={(v) =>
+                  setCompraCarteraTipoReinversion(
+                    v as
+                      | "sin_reinversion"
+                      | "reinversion_capital"
+                      | "reinversion_total",
+                  )
+                }
+              >
+                <SelectTrigger
+                  id="compra-modalidad"
+                  className="mt-1 w-full !bg-white !border-gray-300 !text-gray-900 focus:!border-emerald-500 focus:!ring-emerald-500/30"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="!bg-white !border-gray-200 !text-gray-900 z-[70]">
+                  <SelectItem value="sin_reinversion">Tradicional</SelectItem>
+                  <SelectItem value="reinversion_capital">Reinversión Capital</SelectItem>
+                  <SelectItem value="reinversion_total">Interés Compuesto</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label htmlFor="compra-monto" className="text-sm font-medium text-gray-700">
                 Monto aportado
               </label>
               <Input
@@ -2473,12 +2556,12 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 placeholder="0.00"
                 value={compraCarteraMonto}
                 onChange={(e) => setCompraCarteraMonto(e.target.value)}
-                className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white placeholder:text-slate-500 focus:!border-emerald-400 focus:!ring-emerald-400/30"
+                className="mt-1 !bg-white !border-gray-300 !text-gray-900 placeholder:text-gray-400 focus:!border-emerald-500 focus:!ring-emerald-500/30"
               />
             </div>
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <label htmlFor="compra-pct-inv" className="text-sm font-medium text-slate-300">
+                <label htmlFor="compra-pct-inv" className="text-sm font-medium text-gray-700">
                   % Inversionista
                 </label>
                 <Input
@@ -2496,11 +2579,11 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                       setCompraCarteraPctCashIn(String(100 - num));
                     }
                   }}
-                  className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white placeholder:text-slate-500 focus:!border-emerald-400 focus:!ring-emerald-400/30"
+                  className="mt-1 !bg-white !border-gray-300 !text-gray-900 placeholder:text-gray-400 focus:!border-emerald-500 focus:!ring-emerald-500/30"
                 />
               </div>
               <div>
-                <label htmlFor="compra-pct-cashin" className="text-sm font-medium text-slate-300">
+                <label htmlFor="compra-pct-cashin" className="text-sm font-medium text-gray-700">
                   % Cash In
                 </label>
                 <Input
@@ -2518,12 +2601,12 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                       setCompraCarteraPctInv(String(100 - num));
                     }
                   }}
-                  className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white placeholder:text-slate-500 focus:!border-emerald-400 focus:!ring-emerald-400/30"
+                  className="mt-1 !bg-white !border-gray-300 !text-gray-900 placeholder:text-gray-400 focus:!border-emerald-500 focus:!ring-emerald-500/30"
                 />
               </div>
             </div>
             <div>
-              <label htmlFor="compra-fecha" className="text-sm font-medium text-slate-300">
+              <label htmlFor="compra-fecha" className="text-sm font-medium text-gray-700">
                 Fecha inicio participación
               </label>
               <Input
@@ -2531,7 +2614,13 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 type="date"
                 value={compraCarteraFecha}
                 onChange={(e) => setCompraCarteraFecha(e.target.value)}
-                className="mt-1 !bg-slate-700/50 !border-slate-500/50 !text-white focus:!border-emerald-400 focus:!ring-emerald-400/30 [color-scheme:dark]"
+                disabled={compraCarteraTipoOperacion === "reinversion"}
+                readOnly={compraCarteraTipoOperacion === "reinversion"}
+                className={
+                  compraCarteraTipoOperacion === "reinversion"
+                    ? "mt-1 !bg-gray-100 !border-gray-300 !text-gray-700 cursor-not-allowed focus:!border-gray-300 focus:!ring-0"
+                    : "mt-1 !bg-white !border-gray-300 !text-gray-900 focus:!border-emerald-500 focus:!ring-emerald-500/30"
+                }
               />
             </div>
           </div>
@@ -2542,7 +2631,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 setCompraCarteraOpen(false);
                 setCompraCarteraInvId(null);
               }}
-              className="px-4 py-2 text-sm font-medium text-slate-300 bg-slate-700/60 border border-slate-500/40 rounded-lg hover:bg-slate-600/60 transition-colors"
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
             >
               Cancelar
             </button>
@@ -2551,30 +2640,42 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
               disabled={agregarInvCredito.isPending || !compraCarteraMonto || Number(compraCarteraMonto) <= 0}
               onClick={() => {
                 if (!compraCarteraInvId || !compraCarteraMonto) return;
+                const esReinversion =
+                  compraCarteraTipoOperacion === "reinversion";
                 agregarInvCredito.mutate(
                   {
                     inversionista_id: compraCarteraInvId,
                     monto_aportado: Number(compraCarteraMonto),
-                    tipo_operacion: "compra_cartera",
+                    tipo_operacion: compraCarteraTipoOperacion,
+                    tipo_reinversion: compraCarteraTipoReinversion,
                     porcentaje_inversion: Number(compraCarteraPctInv),
                     porcentaje_cash_in: Number(compraCarteraPctCashIn),
                     fecha_inicio_participacion: compraCarteraFecha || undefined,
                   },
                   {
                     onSuccess: () => {
-                      toast.success("Compra de cartera registrada correctamente");
+                      toast.success(
+                        esReinversion
+                          ? "Reinversión registrada correctamente"
+                          : "Compra de cartera registrada correctamente",
+                      );
                       setCompraCarteraOpen(false);
                       setCompraCarteraInvId(null);
                       refetch();
                       refetchTotales();
                     },
                     onError: (err) => {
-                      toast.error(err?.message || "Error al registrar compra de cartera");
+                      toast.error(
+                        err?.message ||
+                          (esReinversion
+                            ? "Error al registrar reinversión"
+                            : "Error al registrar compra de cartera"),
+                      );
                     },
                   }
                 );
               }}
-              className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-lg hover:bg-emerald-500 disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed transition-colors"
+              className="px-4 py-2 text-sm font-medium text-white bg-emerald-600 rounded-lg hover:bg-emerald-500 disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed transition-colors"
             >
               {agregarInvCredito.isPending ? "Guardando…" : "Confirmar"}
             </button>

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3743,6 +3743,11 @@ export interface AgregarInversionistaCreditoPayload {
   inversionista_id: number;
   monto_aportado: number;
   tipo_operacion: "reinversion" | "compra_cartera";
+  tipo_reinversion?:
+    | "sin_reinversion"
+    | "reinversion_capital"
+    | "reinversion_interes"
+    | "reinversion_total";
   fecha_inicio_participacion?: string;
   porcentaje_cash_in?: number;
   porcentaje_inversion?: number;


### PR DESCRIPTION
Introduces a new API endpoint to manually adjust investor mirror payments and contributed amounts within specific liquidations. This enhancement supports dry-run functionality, handles in-month credit purchases, and offers optional report generation. A bulk adjustment endpoint is also available, providing CSV/XLSX exports of results.

Reinforces investor credit assignment logic by decoupling calculations between parent and mirror tables, ensuring consistency in participation percentages and quotas. New validation prevents conflicting reinvestment types when assigning credits. The frontend UI now includes options for selecting the investment model (e.g., Traditional, Capital Reinvestment, Compound Interest) during the assignment process.

Further refines various functionalities:
*   Updates the calculation logic for Cube's cash-in percentage in payment reports.
*   Removes a specific scoring criterion (`vencimiento_dia_30`) from the credit candidate assignment process, streamlining candidate selection.
*   Simplifies client form token generation in the CRM by removing the confirmation prompt for data deletion, improving user flow.
*   Adjusts delinquency status (`estadoMora`) calculation in the CRM to be based on days in arrears rather than the number of overdue installments.
*   Adds an environment variable option for local database SSL configuration.

Relates to the `reinversionCombinada` feature.