### PR TITLE
Add recurrent lead sources and opportunity reassignment functionality

### DIFF
--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -37,6 +37,8 @@ export const leadSourceEnum = pgEnum("lead_source", [
 	"Whatsapp",
 	"agency",
 	"property",
+	"recurrent",
+	"recurrent_active",
 ]);
 export const maritalStatusEnum = pgEnum("marital_status", [
 	"single",

--- a/apps/crm/apps/server/src/lib/lead-sources.ts
+++ b/apps/crm/apps/server/src/lib/lead-sources.ts
@@ -14,6 +14,8 @@ export const LEAD_SOURCE_LABELS = {
 	Whatsapp: "WhatsApp",
 	agency: "Agencia",
 	property: "Predio",
+	recurrent: "Recurrente",
+	recurrent_active: "Recurrente Activo",
 } as const satisfies Record<string, string>;
 
 export type LeadSource = keyof typeof LEAD_SOURCE_LABELS;
@@ -41,6 +43,8 @@ export const LEAD_SOURCE_BADGE_CLASSES = {
 	Whatsapp: "bg-emerald-100 text-emerald-800",
 	agency: "bg-teal-100 text-teal-800",
 	property: "bg-amber-100 text-amber-800",
+	recurrent: "bg-violet-100 text-violet-800",
+	recurrent_active: "bg-cyan-100 text-cyan-800",
 } as const satisfies Record<keyof typeof LEAD_SOURCE_LABELS, string>;
 
 export function getLeadSourceLabel(source: string | null | undefined): string {

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -2010,6 +2010,45 @@ export const crmRouter = {
 			return updatedOpportunity[0];
 		}),
 
+	reassignOpportunityAndLead: crmProcedure
+		.input(
+			z.object({
+				opportunityId: z.string().uuid(),
+				assignedTo: z.string(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			if (
+				context.userRole !== "admin" &&
+				context.userRole !== "sales_supervisor"
+			) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permisos para reasignar oportunidades",
+				});
+			}
+
+			await db.transaction(async (tx) => {
+				const [updated] = await tx
+					.update(opportunities)
+					.set({ assignedTo: input.assignedTo, updatedAt: new Date() })
+					.where(eq(opportunities.id, input.opportunityId))
+					.returning({ leadId: opportunities.leadId });
+
+				if (!updated) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "Oportunidad no encontrada",
+					});
+				}
+
+				if (updated.leadId) {
+					await tx
+						.update(leads)
+						.set({ assignedTo: input.assignedTo, updatedAt: new Date() })
+						.where(eq(leads.id, updated.leadId));
+				}
+			});
+		}),
+
 	// Analyst specific endpoints
 	getOpportunitiesForAnalysis: analystProcedure
 		.input(

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -2027,24 +2027,40 @@ export const crmRouter = {
 				});
 			}
 
+			const [current] = await db
+				.select({
+					leadId: opportunities.leadId,
+					closurePercentage: salesStages.closurePercentage,
+				})
+				.from(opportunities)
+				.innerJoin(salesStages, eq(opportunities.stageId, salesStages.id))
+				.where(eq(opportunities.id, input.opportunityId))
+				.limit(1);
+
+			if (!current) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Oportunidad no encontrada",
+				});
+			}
+
+			if (current.closurePercentage > 30) {
+				throw new ORPCError("FORBIDDEN", {
+					message:
+						"No se puede reasignar una oportunidad con etapa mayor al 30%",
+				});
+			}
+
 			await db.transaction(async (tx) => {
-				const [updated] = await tx
+				await tx
 					.update(opportunities)
 					.set({ assignedTo: input.assignedTo, updatedAt: new Date() })
-					.where(eq(opportunities.id, input.opportunityId))
-					.returning({ leadId: opportunities.leadId });
+					.where(eq(opportunities.id, input.opportunityId));
 
-				if (!updated) {
-					throw new ORPCError("NOT_FOUND", {
-						message: "Oportunidad no encontrada",
-					});
-				}
-
-				if (updated.leadId) {
+				if (current.leadId) {
 					await tx
 						.update(leads)
 						.set({ assignedTo: input.assignedTo, updatedAt: new Date() })
-						.where(eq(leads.id, updated.leadId));
+						.where(eq(leads.id, current.leadId));
 				}
 			});
 		}),

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -49,6 +49,7 @@ export const crmAppRouter = {
 	getOpportunities: crmRouter.getOpportunities,
 	createOpportunity: crmRouter.createOpportunity,
 	updateOpportunity: crmRouter.updateOpportunity,
+	reassignOpportunityAndLead: crmRouter.reassignOpportunityAndLead,
 	deleteOpportunity: crmRouter.deleteOpportunity,
 	getOpportunitiesForAnalysis: crmRouter.getOpportunitiesForAnalysis,
 	approveOpportunityAnalysis: crmRouter.approveOpportunityAnalysis,

--- a/apps/crm/apps/web/src/components/ui/combobox.tsx
+++ b/apps/crm/apps/web/src/components/ui/combobox.tsx
@@ -33,6 +33,7 @@ interface ComboboxDemoProps {
 	onSearchChange?: (search: string) => void;
 	isLoading?: boolean;
 	isInModal?: boolean;
+	maxListHeight?: string;
 }
 
 export function Combobox({
@@ -45,6 +46,7 @@ export function Combobox({
 	onSearchChange,
 	isLoading,
 	isInModal = false,
+	maxListHeight,
 }: ComboboxDemoProps) {
 	const [open, setOpen] = React.useState(false);
 	const [searchValue, setSearchValue] = React.useState("");
@@ -123,7 +125,7 @@ export function Combobox({
 							onSearchChange?.(value);
 						}}
 					/>
-					<CommandList>
+					<CommandList style={maxListHeight ? { maxHeight: maxListHeight, overflowY: "auto" } : undefined}>
 						{isLoading ? (
 							<div className="flex items-center justify-center py-6 text-muted-foreground text-sm">
 								<Loader2 className="mr-2 h-4 w-4 animate-spin" />

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -6,6 +6,7 @@ import { useForm } from "@tanstack/react-form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
+	AlertTriangle,
 	Banknote,
 	Building,
 	Calculator,
@@ -498,6 +499,8 @@ function RouteComponent() {
 
 	const [isDeleteConfirmOpen, setIsDeleteConfirmOpen] = useState(false);
 	const [deleteReason, setDeleteReason] = useState("");
+	const [reassignConfirmOpen, setReassignConfirmOpen] = useState(false);
+	const [pendingReassignUserId, setPendingReassignUserId] = useState<string | null>(null);
 
 	// State for confirm contracts signed modal
 	const [confirmSignedModalOpen, setConfirmSignedModalOpen] = useState(false);
@@ -547,6 +550,46 @@ function RouteComponent() {
 			toast.error(error.message || "Error al eliminar la oportunidad");
 		},
 	});
+
+	const reassignOpportunityMutation = useMutation({
+		mutationFn: ({
+			opportunityId,
+			assignedTo,
+		}: {
+			opportunityId: string;
+			assignedTo: string;
+		}) => client.reassignOpportunityAndLead({ opportunityId, assignedTo }),
+		onSuccess: async (_data, variables) => {
+			toast.success("Asesor reasignado exitosamente");
+			setReassignConfirmOpen(false);
+			setPendingReassignUserId(null);
+
+			await queryClient.invalidateQueries({
+				predicate: (q) =>
+					q.queryKey[0] === "getOpportunities" ||
+					q.queryKey[0] === "getLeads",
+			});
+
+			if (selectedOpportunity?.id === variables.opportunityId) {
+				const freshOpportunities = await client.getOpportunities();
+				const updated = freshOpportunities.find(
+					(opp) => opp.id === variables.opportunityId,
+				);
+				if (updated) setSelectedOpportunity(updated);
+			}
+		},
+		onError: (error: any) => {
+			toast.error(error.message || "Error al reasignar el asesor");
+		},
+	});
+
+	const handleConfirmReassign = () => {
+		if (!pendingReassignUserId || !selectedOpportunity) return;
+		reassignOpportunityMutation.mutate({
+			opportunityId: selectedOpportunity.id,
+			assignedTo: pendingReassignUserId,
+		});
+	};
 
 	const handleDropOpportunity = (opportunityId: string, newStageId: string) => {
 		// Find the opportunity and the target stage
@@ -1192,6 +1235,7 @@ function RouteComponent() {
 			asesorId?: number;
 			direccion?: string;
 			loanPurpose?: "personal" | "business";
+			assignedTo?: string;
 		}) => client.updateOpportunity(input),
 		onMutate: async (variables) => {
 			const opportunitiesQueryKey = [
@@ -2329,20 +2373,57 @@ function RouteComponent() {
 									)}
 
 									{/* Assigned To */}
-									{selectedOpportunity.assignedUser && (
-										<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
-											<Label className="font-semibold text-muted-foreground text-sm">
-												Asignado a
-											</Label>
-											<div className="flex items-center gap-3">
-												<Users className="h-5 w-5 text-muted-foreground" />
-												<span className="font-medium">
-													{selectedOpportunity.assignedUser.name ||
-														"Usuario sin nombre"}
-												</span>
-											</div>
-										</div>
-									)}
+									{(() => {
+										const canReassign =
+											canFilterBySalesperson &&
+											(selectedOpportunity.stage?.closurePercentage ?? 100) <= 30;
+										if (canReassign) {
+											return (
+												<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+													<Label className="font-semibold text-muted-foreground text-sm">
+														Asignado a
+													</Label>
+													<Combobox
+														options={
+															crmUsersQuery.data?.map((u) => ({
+																value: u.id,
+																label: u.name || u.email,
+															})) ?? []
+														}
+														value={selectedOpportunity.assignedUser?.id ?? null}
+														onChange={(value) => {
+															if (value) {
+																setPendingReassignUserId(value);
+																setReassignConfirmOpen(true);
+															}
+														}}
+														placeholder="Buscar asesor por nombre..."
+														width="full"
+														isInModal
+														isLoading={crmUsersQuery.isPending}
+														maxListHeight="400px"
+													/>
+												</div>
+											);
+										}
+										if (selectedOpportunity.assignedUser) {
+											return (
+												<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+													<Label className="font-semibold text-muted-foreground text-sm">
+														Asignado a
+													</Label>
+													<div className="flex items-center gap-3">
+														<Users className="h-5 w-5 text-muted-foreground" />
+														<span className="font-medium">
+															{selectedOpportunity.assignedUser.name ||
+																"Usuario sin nombre"}
+														</span>
+													</div>
+												</div>
+											);
+										}
+										return null;
+									})()}
 
 									{/* Loan Purpose */}
 									{selectedOpportunity.loanPurpose && (
@@ -3569,6 +3650,78 @@ function RouteComponent() {
 								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
 							) : null}
 							Sí, eliminar
+						</Button>
+					</div>
+				</DialogContent>
+			</Dialog>
+
+			{/* Dialog de confirmación para reasignar asesor */}
+			<Dialog
+				open={reassignConfirmOpen}
+				onOpenChange={(open) => {
+					setReassignConfirmOpen(open);
+					if (!open) setPendingReassignUserId(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>¿Confirmar reasignación?</DialogTitle>
+					</DialogHeader>
+					<div className="flex gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4">
+						<AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+						<div className="space-y-1 text-sm">
+							<p className="font-medium text-amber-800">
+								Esta acción actualizará opportunidad y Lead asociado
+							</p>
+							<p className="text-amber-700">
+								Se asignará{" "}
+								<strong>
+									{crmUsersQuery.data?.find((u) => u.id === pendingReassignUserId)
+										?.name ?? "el asesor seleccionado"}
+								</strong>{" "}
+								como responsable de la oportunidad{" "}
+								<strong>{selectedOpportunity?.title}</strong>.
+							</p>
+							{selectedOpportunity?.lead && (
+								<p className="text-amber-700">
+									Además, el Lead asociado{" "}
+									<strong>
+										{[
+											selectedOpportunity.lead.firstName,
+											selectedOpportunity.lead.lastName,
+										]
+											.filter(Boolean)
+											.join(" ")}
+									</strong>{" "}
+									también será reasignado automáticamente al mismo asesor{" "}
+									<strong>
+									{crmUsersQuery.data?.find((u) => u.id === pendingReassignUserId)
+										?.name ?? "el asesor seleccionado"}
+									</strong>{" "}
+								</p>
+							)}
+						</div>
+					</div>
+					<div className="flex gap-3 pt-2">
+						<Button
+							variant="outline"
+							className="flex-1"
+							onClick={() => {
+								setReassignConfirmOpen(false);
+								setPendingReassignUserId(null);
+							}}
+						>
+							Cancelar
+						</Button>
+						<Button
+							className="flex-1"
+							disabled={reassignOpportunityMutation.isPending}
+							onClick={handleConfirmReassign}
+						>
+							{reassignOpportunityMutation.isPending ? (
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							) : null}
+							Sí, reasignar
 						</Button>
 					</div>
 				</DialogContent>


### PR DESCRIPTION
1. Nuevas opciones en "Fuente de Lead"
Archivos: lead-sources.ts (servidor), crm.ts (schema)

      - Se agregaron recurrent ("Recurrente") y recurrent_active ("Recurrente Activo") al enum lead_source en base de datos y a los labels/badges del frontend.
      - Aparecen automáticamente en el formulario de creación/edición de leads y en el filtro de fuente.

2. Reasignación de asesor en Oportunidades
Archivo: opportunities.tsx

      - En el diálogo "Detalles de la Oportunidad", la sección "Asignado a" ahora es editable bajo dos condiciones simultáneas:
      - El usuario tiene rol admin o sales_supervisor
      - La oportunidad está en una etapa con closurePercentage <= 30%
      - El selector usa el componente Combobox con búsqueda por nombre integrada y alto máximo de 400px.
      - Si no se cumplen las condiciones, se muestra solo lectura como antes.

3. Mejora al Combobox
Archivo: combobox.tsx

      - Se agregó la prop opcional maxListHeight que limita el alto de la lista con scroll interno, sin afectar ningún uso existente del componente.

4. Endpoint transaccional reassignOpportunityAndLead
Archivos: crm.ts, index.ts, opportunities.tsx

      - Endpoint dedicado que dentro de una transacción de base de datos actualiza assignedTo en opportunities y en el lead asociado de forma atómica: si cualquiera falla, ninguno se aplica.
      - El servidor valida el rol nuevamente (doble seguridad).
      - Antes de ejecutar, el frontend muestra un dialog de confirmación con panel de alerta que indica explícitamente que se actualizarán tanto la oportunidad como el lead asociado, mostrando ambos nombres.