### PR TITLE
Fix: Implement persisted state for session filters and enhance input handling

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -86,6 +86,7 @@ export function ListaCreditosPagos() {
     handleAsesorId,
     setAsesorId,
     nombreUsuarioInput,
+    nombreUsuario,
     setNombreUsuarioInput,
     handleSearchNombreUsuario,
     clearNombreUsuario,
@@ -347,6 +348,9 @@ export function ListaCreditosPagos() {
             type="text"
             placeholder="# Crédito SIFCO"
             defaultValue={creditoSifco}
+            onChange={(e) => {
+              if (e.target.value === "") handleSifco("");
+            }}
             onBlur={(e) => {
               if (e.target.value !== creditoSifco) {
                 handleSifco(e.target.value);
@@ -381,7 +385,10 @@ export function ListaCreditosPagos() {
             <button
               type="button"
               className="p-1 rounded-full bg-blue-100 text-blue-600 hover:bg-blue-200 transition"
-              onClick={clearSifco}
+              onClick={() => {
+                clearSifco();
+                if (inputRef.current) inputRef.current.value = "";
+              }}
               title="Limpiar filtro"
             >
               <X className="w-4 h-4" />
@@ -398,7 +405,13 @@ export function ListaCreditosPagos() {
                 type="text"
                 placeholder="Buscar por nombre..."
                 value={nombreUsuarioInput}
-                onChange={(e) => setNombreUsuarioInput(e.target.value)}
+                onChange={(e) => {
+                  setNombreUsuarioInput(e.target.value);
+                  if (e.target.value === "") clearNombreUsuario();
+                }}
+                onBlur={() => {
+                  if (nombreUsuarioInput !== nombreUsuario) handleSearchNombreUsuario();
+                }}
                 onKeyDown={handleKeyPress}
                 className="border border-blue-200 rounded-lg px-3 py-2 pr-10 bg-blue-50 text-blue-800 focus:ring-2 focus:ring-blue-400 w-full"
               />
@@ -588,7 +601,10 @@ export function ListaCreditosPagos() {
             <Button
               type="button"
               variant="outline"
-              onClick={clearAllFilters}
+              onClick={() => {
+                clearAllFilters();
+                if (inputRef.current) inputRef.current.value = "";
+              }}
               className="flex items-center gap-2 rounded-lg border-gray-300 px-4 py-2 font-semibold text-gray-600 hover:bg-gray-100"
             >
               <X className="w-4 h-4" />

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -80,10 +80,10 @@ function distribuirMonto(
 const PAGE_SIZE = 10;
 
 export function SesionesPendientes() {
-  const [page, setPage] = useState(1);
-  const [search, setSearch] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [selectedStatuses, setSelectedStatuses] = useState<string[]>([
+  const [page, setPage] = usePersistedState<number>("cartera/sesionesPendientes/page", 1);
+  const [search, setSearch] = usePersistedState<string>("cartera/sesionesPendientes/search", "");
+  const [debouncedSearch, setDebouncedSearch] = usePersistedState<string>("cartera/sesionesPendientes/debouncedSearch", "");
+  const [selectedStatuses, setSelectedStatuses] = usePersistedState<string[]>("cartera/sesionesPendientes/selectedStatuses", [
     "pendiente_reinversion",
     "pendiente_compra_cartera",
     "pendiente_revision"
@@ -101,7 +101,7 @@ export function SesionesPendientes() {
     statusesParam
   );
 
-  const hasActiveFilters = search !== "";
+  const hasActiveFilters = search !== "" || selectedStatuses.length !== 3;
 
   // Debounce search to avoid firing on every keystroke
   useEffect(() => {
@@ -157,6 +157,7 @@ export function SesionesPendientes() {
   const clearSearch = useCallback(() => {
     setSearch("");
     setDebouncedSearch("");
+    setSelectedStatuses(["pendiente_reinversion", "pendiente_compra_cartera", "pendiente_revision"]);
     setPage(1);
   }, []);
 
@@ -216,7 +217,9 @@ export function SesionesPendientes() {
           {hasActiveFilters && (
             <Button variant="outline" size="sm" onClick={clearSearch} className="h-8 text-xs text-gray-600 border-gray-300 hover:bg-gray-100 gap-1">
               <X className="w-3.5 h-3.5" /> Limpiar
-              <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-xs">1</Badge>
+              <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-xs">
+                {[search !== "", selectedStatuses.length !== 3].filter(Boolean).length}
+              </Badge>
             </Button>
           )}
           <Badge variant="outline" className="text-[11px] border-blue-200 text-blue-700 bg-blue-50 tabular-nums">

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -838,6 +838,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
               <div>
                 <label className="text-[10px] text-gray-500 font-medium mb-0.5 block">Buscar</label>
                 <Combobox
+                  key={inversionistaId ?? "none"}
                   value={inversionistaId as unknown as number}
                   onChange={(value: any) => {
                     setInversionistaId(value === "" ? undefined : value);

--- a/apps/carteraFront/src/private/cartera/hooks/credits.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/credits.ts
@@ -199,6 +199,7 @@ export function useCreditosPaginadosWithFilters(options?: UseCreditosOptions) {
     clearAsesorId,
     // 🔥 Exports para nombre usuario (actualizados)
     nombreUsuarioInput,        // 👈 Para el input
+    nombreUsuario,             // 👈 Filtro aplicado (para comparación en onBlur)
     setNombreUsuarioInput,     // 👈 Para actualizar el input
     handleSearchNombreUsuario, // 👈 Para ejecutar la búsqueda
     clearNombreUsuario,        // 👈 Para limpiar


### PR DESCRIPTION
fix: mejoras en campos de búsqueda y persistencia de filtros en carteraFront
Se corrigieron bugs de comportamiento en los campos de búsqueda de CreditsPaymentsData y un problema visual en el combobox de inversionistas en PaymentsTable. Además se implementó persistencia de filtros en SesionesPendientes.

CreditsPaymentsData.tsx / credits.ts
  - El input de # Crédito SIFCO ahora dispara la búsqueda automáticamente cuando el usuario borra todos los caracteres manualmente, sin necesidad de presionar Enter o el botón de búsqueda.
  - Los botones X y "Limpiar filtros" ahora también limpian visualmente el valor del input SIFCO (era un input no controlado con defaultValue, por lo que el DOM no se actualizaba al limpiar el estado).
  - El campo "Buscar por nombre" ahora dispara la búsqueda al salir del campo (onBlur), igual que el campo SIFCO, y también limpia el filtro automáticamente al borrar todos los caracteres.
  - Se exporta nombreUsuario (filtro aplicado) desde el hook useCreditosPaginadosWithFilters para usarlo en la comparación del onBlur.

paymentsTable.tsx
  - Corregido bug visual en el combobox de Inversionista: al hacer click en "Limpiar filtros", el nombre del inversionista seleccionado permanecía visible aunque el filtro ya se había removido. Se resolvió agregando key={inversionistaId ?? "none"} al componente Combobox de headlessui, forzando un re-mount cuando el valor se limpia.
 
SesionesPendientes.tsx
  - Se migran los estados page, search, debouncedSearch y selectedStatuses de useState a usePersistedState, de modo que los filtros y la página activa se conservan al navegar entre secciones.
  - hasActiveFilters ahora también detecta cuando los chips de tipo de sesión están filtrados (no en "Todos").
  - El botón "Limpiar" resetea además los chips de estado a su valor por defecto ("Todos").
  - El Badge del botón refleja la cantidad real de categorías de filtros activas.