### PR TITLE
feat: pendiente_facturar y fecha_completada en compras_credito_inversionista

### DIFF
--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -196,9 +196,16 @@ export const completeEspejo = async ({ body, set, request }: any) => {
               ne(compras_credito_inversionista.status, "completado"),
             );
 
+        // Fecha de completado en hora de Guatemala (UTC - 6h)
+        const fechaCompletadaGT = new Date(Date.now() - 6 * 60 * 60 * 1000);
+
         await tx
           .update(compras_credito_inversionista)
-          .set({ status: "completado", updated_at: new Date() })
+          .set({
+            status: "completado",
+            fecha_completada: fechaCompletadaGT,
+            updated_at: new Date(),
+          })
           .where(whereConditionsCompras);
 
         resultados.push({

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -471,6 +471,8 @@
       tipo_operacion: varchar("tipo_operacion", { length: 30 }).notNull(),
       tipo_reinversion: tipoReinversionEnum("tipo_reinversion"),
       status: statusCreditoInversionistaEspejoEnum("status").notNull(),
+      pendiente_facturar: boolean("pendiente_facturar").notNull().default(true),
+      fecha_completada: timestamp("fecha_completada", { withTimezone: true }),
       fecha: timestamp("fecha", { withTimezone: true }).notNull().$default(() => new Date()),
       created_at: timestamp("created_at", { withTimezone: true }).notNull().$default(() => new Date()),
       updated_at: timestamp("updated_at", { withTimezone: true }),


### PR DESCRIPTION
## Summary
- Se agregan dos columnas a `compras_credito_inversionista`:
  - `pendiente_facturar` (boolean, NOT NULL, default `true`) — bandera para saber si la compra aún está pendiente de facturar.
  - `fecha_completada` (timestamptz, nullable) — se llena cuando la compra pasa a `completado`.
- En `completeEspejo`, al cerrar los registros de `compras_credito_inversionista` ahora se guarda `fecha_completada` con la hora de Guatemala (UTC - 6h).

## Migración manual
Para correr en prod después del merge:

```sql
ALTER TABLE cartera.compras_credito_inversionista
  ADD COLUMN pendiente_facturar boolean NOT NULL DEFAULT true,
  ADD COLUMN fecha_completada timestamptz;

UPDATE cartera.compras_credito_inversionista
SET pendiente_facturar = true
WHERE tipo_operacion = 'compra_cartera';

UPDATE cartera.compras_credito_inversionista
SET pendiente_facturar = false
WHERE tipo_operacion = 'reinversion';
```

## Test plan
- [ ] Correr ALTER TABLE en staging y verificar valores backfilleados por `tipo_operacion`.
- [ ] Aceptar una compra de cartera desde `completeEspejo` y validar que `fecha_completada` refleje la hora GT.
- [ ] Confirmar que registros previos no se ven afectados (default cubre los existentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)