### PR TITLE
fix: pendiente_facturar default false y guardar fecha_completada en UTC

### DIFF
--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -196,17 +196,41 @@ export const completeEspejo = async ({ body, set, request }: any) => {
               ne(compras_credito_inversionista.status, "completado"),
             );
 
-        // Fecha de completado en hora de Guatemala (UTC - 6h)
-        const fechaCompletadaGT = new Date(Date.now() - 6 * 60 * 60 * 1000);
+        // Instante real (UTC). La columna es timestamptz; la conversión a
+        // hora de Guatemala se hace al mostrar/consultar, no al guardar.
+        const ahora = new Date();
+
+        // Solo las compras de cartera quedan pendientes de facturar al
+        // completarse. Las reinversiones no generan factura, así que
+        // mantienen pendiente_facturar = false.
+        await tx
+          .update(compras_credito_inversionista)
+          .set({
+            status: "completado",
+            fecha_completada: ahora,
+            pendiente_facturar: true,
+            updated_at: ahora,
+          })
+          .where(
+            and(
+              whereConditionsCompras,
+              eq(compras_credito_inversionista.tipo_operacion, "compra_cartera"),
+            ),
+          );
 
         await tx
           .update(compras_credito_inversionista)
           .set({
             status: "completado",
-            fecha_completada: fechaCompletadaGT,
-            updated_at: new Date(),
+            fecha_completada: ahora,
+            updated_at: ahora,
           })
-          .where(whereConditionsCompras);
+          .where(
+            and(
+              whereConditionsCompras,
+              eq(compras_credito_inversionista.tipo_operacion, "reinversion"),
+            ),
+          );
 
         resultados.push({
           credito_id,

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -471,7 +471,7 @@
       tipo_operacion: varchar("tipo_operacion", { length: 30 }).notNull(),
       tipo_reinversion: tipoReinversionEnum("tipo_reinversion"),
       status: statusCreditoInversionistaEspejoEnum("status").notNull(),
-      pendiente_facturar: boolean("pendiente_facturar").notNull().default(true),
+      pendiente_facturar: boolean("pendiente_facturar").notNull().default(false),
       fecha_completada: timestamp("fecha_completada", { withTimezone: true }),
       fecha: timestamp("fecha", { withTimezone: true }).notNull().$default(() => new Date()),
       created_at: timestamp("created_at", { withTimezone: true }).notNull().$default(() => new Date()),


### PR DESCRIPTION
## Summary
Sigue al PR #753. Dos ajustes:

1. **`pendiente_facturar` default `false`** — solo se marca `true` cuando una **compra de cartera** se completa via `completeEspejo`. Las reinversiones no generan factura, así que se quedan en `false`.
2. **`fecha_completada` se guarda como instante UTC real** (`new Date()`), no `now − 6h`. La columna es `timestamptz`; restar 6h al guardar provocaba un doble offset al leerla en `America/Guatemala`. La conversión a hora GT se hace al mostrar/consultar.

## Migración manual (ya correr en DB)
```sql
-- Cambiar default a false
ALTER TABLE cartera.compras_credito_inversionista
  ALTER COLUMN pendiente_facturar SET DEFAULT false;

-- Corregir compras_cartera pendientes que se backfillearon en true
UPDATE cartera.compras_credito_inversionista
SET pendiente_facturar = false
WHERE tipo_operacion = 'compra_cartera'
  AND status <> 'completado';
```

Estado esperado después:
- `compra_cartera` + `completado` → `true`
- `compra_cartera` + pendiente → `false`
- `reinversion` → `false`

## Test plan
- [ ] Correr el ALTER en staging y validar el backfill.
- [ ] Aceptar una compra de cartera y verificar que `pendiente_facturar = true` y `fecha_completada` refleje el instante real (al renderizar en GT debe coincidir con la hora local del completado).
- [ ] Aceptar una reinversión y verificar que `pendiente_facturar` siga en `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)