### PR TITLE
feat(cartera): pagos por vencimiento — recálculo dinámico, detalle de abonos y Excel expandido

### DIFF
--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1938,8 +1938,14 @@ export async function getPagosByVencimiento({
           AND validation_status = 'validated'
           AND "paymentFalse" = false
           AND (
-            (fecha_pago::date >= ${fechaInicio}::date AND fecha_pago::date <= ${fechaFin}::date)
-            OR (fecha_boleta::date >= ${fechaInicio}::date AND fecha_boleta::date <= ${fechaFin}::date)
+            (cuota_id IS NOT NULL AND cuota_id IN (
+              SELECT cuota_id FROM cartera.cuotas_credito
+              WHERE fecha_vencimiento::date >= ${fechaInicio}::date
+                AND fecha_vencimiento::date <= ${fechaFin}::date
+            ))
+            OR (cuota_id IS NULL
+                AND fecha_vencimiento::date >= ${fechaInicio}::date
+                AND fecha_vencimiento::date <= ${fechaFin}::date)
           )
         ORDER BY credito_id ASC, fecha_boleta ASC, fecha_pago ASC
       `);
@@ -2105,8 +2111,14 @@ export async function getAbonosDelMesPorCredito({
       AND validation_status = 'validated'
       AND "paymentFalse" = false
       AND (
-        (fecha_pago::date >= ${fechaInicio}::date AND fecha_pago::date <= ${fechaFin}::date)
-        OR (fecha_boleta::date >= ${fechaInicio}::date AND fecha_boleta::date <= ${fechaFin}::date)
+        (cuota_id IS NOT NULL AND cuota_id IN (
+          SELECT cuota_id FROM cartera.cuotas_credito
+          WHERE fecha_vencimiento::date >= ${fechaInicio}::date
+            AND fecha_vencimiento::date <= ${fechaFin}::date
+        ))
+        OR (cuota_id IS NULL
+            AND fecha_vencimiento::date >= ${fechaInicio}::date
+            AND fecha_vencimiento::date <= ${fechaFin}::date)
       )
     ORDER BY fecha_boleta ASC, fecha_pago ASC
   `);

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1650,53 +1650,9 @@ export async function getPagosByVencimiento({
     COALESCE(p.monto_boleta, 0)::numeric
   )`;
 
-  // 1. Pagos agrupados por crédito con metadatos para recálculo dinámico
-  // capital_mes_anterior: total_restante del último pago (no falso) ANTES del mes consultado.
-  // total_restante guarda el saldo global del crédito después de ese pago → base correcta para calcular interés.
-  // Fallback: c.capital si es el primer mes del crédito (sin pagos previos).
-  const pagosResult = await db.execute<any>(sql`
-    SELECT
-      c.credito_id,
-      c.numero_credito_sifco,
-      u.nombre AS nombre_usuario,
-      a.nombre AS asesor,
-      c.royalti,
-      c.capital AS capital_actual,
-      c.porcentaje_interes,
-      c.cuota AS cuota_credito,
-      c.seguro_10_cuotas,
-      c.gps,
-      c.membresias_pago,
-      COALESCE(cap_anterior.total_restante, c.capital::numeric) AS capital_mes_anterior,
-      AVG(COALESCE(cube_data.cash_in_pct, 0))::numeric AS cash_in_pct,
-      MIN(q.numero_cuota) AS cuota_min,
-      MAX(q.numero_cuota) AS cuota_max,
-      COALESCE(SUM(p.capital_restante::numeric), 0) AS capital_restante_db,
-      COALESCE(SUM(p.interes_restante::numeric), 0) AS interes_restante_db,
-      COALESCE(SUM(p.iva_12_restante::numeric), 0) AS iva_12_restante_db,
-      COALESCE(SUM(p.seguro_restante::numeric), 0) AS seguro_restante_db,
-      COALESCE(SUM(p.gps_restante::numeric), 0) AS gps_restante_db,
-      COALESCE(SUM(p.membresias::numeric), 0) AS membresias_db,
-      COALESCE(SUM(p.monto_boleta::numeric), 0) AS monto_boleta,
-      COALESCE(SUM(p.monto_aplicado::numeric), 0) AS monto_aplicado,
-      COALESCE(MAX(m.monto_mora::numeric), 0) AS monto_mora,
-      CASE
-        WHEN MAX(m.cuotas_atrasadas) = 1 THEN 'Mora 30'
-        WHEN MAX(m.cuotas_atrasadas) = 2 THEN 'Mora 60'
-        WHEN MAX(m.cuotas_atrasadas) = 3 THEN 'Mora 90'
-        WHEN MAX(m.cuotas_atrasadas) >= 4 THEN 'Mora 120+'
-        ELSE 'Al día'
-      END AS dias_mora
-    FROM ${pagosDeduped}
-    INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
-    INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
-    INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
-    LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
-    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
-    ${cubeSubquery}
+  // Fragmentos SQL reutilizables entre query paginada y query de totales
+  const lateralCapAnterior = sql`
     LEFT JOIN LATERAL (
-      -- Último pago (no falso) anterior al mes consultado que tenga total_restante registrado.
-      -- total_restante = saldo global del crédito al momento de ese pago → capital real al cierre del mes anterior.
       SELECT pc_a.total_restante::numeric AS total_restante
       FROM cartera.pagos_credito pc_a
       WHERE pc_a.credito_id = c.credito_id
@@ -1713,63 +1669,73 @@ export async function getPagosByVencimiento({
                ) DESC, pc_a.pago_id DESC
       LIMIT 1
     ) cap_anterior ON true
+  `;
+
+  const commonFromJoins = sql`
+    FROM ${pagosDeduped}
+    INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
+    INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
+    INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
+    LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
+    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
+    ${cubeSubquery}
+    ${lateralCapAnterior}
     WHERE ${whereClause}
-    GROUP BY 
-      c.credito_id, 
-      c.numero_credito_sifco, 
-      u.nombre, 
-      a.nombre, 
-      c.royalti, 
-      c.capital, 
-      c.porcentaje_interes, 
-      c.cuota, 
-      c.seguro_10_cuotas, 
-      c.gps, 
-      c.membresias_pago,
+  `;
+
+  const commonGroupHaving = sql`
+    GROUP BY
+      c.credito_id, c.numero_credito_sifco, u.nombre, a.nombre, c.royalti,
+      c.capital, c.porcentaje_interes, c.cuota, c.seguro_10_cuotas, c.gps, c.membresias_pago,
       cap_anterior.total_restante
     HAVING SUM(${totalFilaSql}) <> 0
-    ORDER BY c.numero_credito_sifco
-  `);
+  `;
 
-  const allPagosRecalculated = pagosResult.rows.map((row: any) => {
-    // Capital al cierre del mes anterior: total_restante del último pago previo al mes.
-    // total_restante = saldo global del crédito (no de la cuota) → base correcta para interés.
-    // Fallback a c.capital si es el primer mes del crédito.
+  const pagosSelectFields = sql`
+    SELECT
+      c.credito_id,
+      c.numero_credito_sifco,
+      u.nombre AS nombre_usuario,
+      a.nombre AS asesor,
+      c.royalti,
+      c.porcentaje_interes,
+      c.cuota AS cuota_credito,
+      c.seguro_10_cuotas,
+      c.gps,
+      c.membresias_pago,
+      COALESCE(cap_anterior.total_restante, c.capital::numeric) AS capital_mes_anterior,
+      AVG(COALESCE(cube_data.cash_in_pct, 0))::numeric AS cash_in_pct,
+      MIN(q.numero_cuota) AS cuota_min,
+      MAX(q.numero_cuota) AS cuota_max,
+      COALESCE(SUM(p.monto_boleta::numeric), 0) AS monto_boleta,
+      COALESCE(SUM(p.monto_aplicado::numeric), 0) AS monto_aplicado,
+      COALESCE(MAX(m.monto_mora::numeric), 0) AS monto_mora,
+      CASE
+        WHEN MAX(m.cuotas_atrasadas) = 1 THEN 'Mora 30'
+        WHEN MAX(m.cuotas_atrasadas) = 2 THEN 'Mora 60'
+        WHEN MAX(m.cuotas_atrasadas) = 3 THEN 'Mora 90'
+        WHEN MAX(m.cuotas_atrasadas) >= 4 THEN 'Mora 120+'
+        ELSE 'Al día'
+      END AS dias_mora
+  `;
+
+  const recalcRow = (row: any) => {
     const capitalAnterior = new Big(row.capital_mes_anterior || 0);
-
     const porcentajeInteres = new Big(row.porcentaje_interes || 0).div(100);
-
-    // Interés y IVA dinámicos
     const interesCalculado = capitalAnterior.times(porcentajeInteres).round(2);
     const ivaCalculado = interesCalculado.times(0.12).round(2);
-    
-    // Rubros fijos
     const seguro = new Big(row.seguro_10_cuotas || 0);
     const gps = new Big(row.gps || 0);
     const membresia = new Big(row.membresias_pago || 0);
     const mora = new Big(row.monto_mora || 0);
-    
-    // Cuota del crédito
     const cuotaCredito = new Big(row.cuota_credito || 0);
-    
-    // Abono Capital = Cuota - (Interés + IVA + Seguro + GPS + Membresía)
     let abonoCapitalCalculado = cuotaCredito.minus(interesCalculado).minus(ivaCalculado).minus(seguro).minus(gps).minus(membresia);
-    if (abonoCapitalCalculado.lt(0)) {
-      abonoCapitalCalculado = new Big(0);
-    }
-    // Capped a capitalAnterior para no amortizar de más
-    if (abonoCapitalCalculado.gt(capitalAnterior)) {
-      abonoCapitalCalculado = capitalAnterior;
-    }
-    
-    // CUBE
+    if (abonoCapitalCalculado.lt(0)) abonoCapitalCalculado = new Big(0);
+    if (abonoCapitalCalculado.gt(capitalAnterior)) abonoCapitalCalculado = capitalAnterior;
     const cashInPct = new Big(row.cash_in_pct || 0);
     const interesCube = interesCalculado.times(cashInPct).round(2);
     const ivaCube = interesCube.times(0.12).round(2);
-    
-    // Total Pagos Mes = recalculated obligation (Abono Capital + Interés + IVA + Seguro + GPS + Membresía)
     const totalPagosDelMes = abonoCapitalCalculado.plus(interesCalculado).plus(ivaCalculado).plus(seguro).plus(gps).plus(membresia);
-    
     return {
       credito_id: row.credito_id,
       numero_credito_sifco: row.numero_credito_sifco,
@@ -1781,56 +1747,57 @@ export async function getPagosByVencimiento({
       dias_mora: row.dias_mora,
       monto_boleta: Number(row.monto_boleta).toFixed(2),
       monto_aplicado: Number(row.monto_aplicado).toFixed(2),
-      
-      // Reemplazamos los valores programados con los dinámicos
-      capital_restante: abonoCapitalCalculado.toFixed(2), // Se muestra como "Abono Capital"
+      capital_restante: abonoCapitalCalculado.toFixed(2),
       interes_restante: interesCalculado.toFixed(2),
       iva_12_restante: ivaCalculado.toFixed(2),
       seguro_restante: seguro.toFixed(2),
       gps_restante: gps.toFixed(2),
       membresias: membresia.toFixed(2),
       mora: mora.toFixed(2),
-      
-      // CUBE
       interes_cube: interesCube.toFixed(2),
       iva_cube: ivaCube.toFixed(2),
-      
-      total_pagos_del_mes: totalPagosDelMes.toFixed(2)
+      total_pagos_del_mes: totalPagosDelMes.toFixed(2),
     };
-  });
+  };
 
-  const total = allPagosRecalculated.length;
-  const offset = (page - 1) * pageSize;
-  const pagos = excel ? allPagosRecalculated : allPagosRecalculated.slice(offset, offset + pageSize);
-
-  // Totales globales recalculados
-  let totalCapitalRecalc = new Big(0);
-  let totalInteresRecalc = new Big(0);
-  let totalIvaRecalc = new Big(0);
-  let totalSeguroRecalc = new Big(0);
-  let totalGpsRecalc = new Big(0);
-  let totalMembresiasRecalc = new Big(0);
-  let totalInteresCubeRecalc = new Big(0);
-  let totalIvaCubeRecalc = new Big(0);
-  let totalMoraRecalc = new Big(0);
-  let totalMontoAplicadoRecalc = new Big(0);
-  let totalPagosDelMesRecalc = new Big(0);
-
-  allPagosRecalculated.forEach((p: any) => {
-    totalCapitalRecalc = totalCapitalRecalc.plus(p.capital_restante);
-    totalInteresRecalc = totalInteresRecalc.plus(p.interes_restante);
-    totalIvaRecalc = totalIvaRecalc.plus(p.iva_12_restante);
-    totalSeguroRecalc = totalSeguroRecalc.plus(p.seguro_restante);
-    totalGpsRecalc = totalGpsRecalc.plus(p.gps_restante);
-    totalMembresiasRecalc = totalMembresiasRecalc.plus(p.membresias);
-    totalInteresCubeRecalc = totalInteresCubeRecalc.plus(p.interes_cube);
-    totalIvaCubeRecalc = totalIvaCubeRecalc.plus(p.iva_cube);
-    totalMoraRecalc = totalMoraRecalc.plus(p.mora);
-    totalMontoAplicadoRecalc = totalMontoAplicadoRecalc.plus(p.monto_aplicado);
-    totalPagosDelMesRecalc = totalPagosDelMesRecalc.plus(p.total_pagos_del_mes);
-  });
-
+  // Excel: query completa sin LIMIT, totales en JS
   if (excel) {
+    const pagosResult = await db.execute<any>(sql`
+      ${pagosSelectFields}
+      ${commonFromJoins}
+      ${commonGroupHaving}
+      ORDER BY c.numero_credito_sifco
+    `);
+    const allPagosRecalculated = pagosResult.rows.map(recalcRow);
+
+    // Totales para fila resumen del Excel (JS, sobre todos los registros)
+    let totalCapitalRecalc = new Big(0);
+    let totalInteresRecalc = new Big(0);
+    let totalIvaRecalc = new Big(0);
+    let totalSeguroRecalc = new Big(0);
+    let totalGpsRecalc = new Big(0);
+    let totalMembresiasRecalc = new Big(0);
+    let totalInteresCubeRecalc = new Big(0);
+    let totalIvaCubeRecalc = new Big(0);
+    let totalMoraRecalc = new Big(0);
+    let totalMontoAplicadoRecalc = new Big(0);
+    let totalPagosDelMesRecalc = new Big(0);
+
+    allPagosRecalculated.forEach((p: any) => {
+      totalCapitalRecalc = totalCapitalRecalc.plus(p.capital_restante);
+      totalInteresRecalc = totalInteresRecalc.plus(p.interes_restante);
+      totalIvaRecalc = totalIvaRecalc.plus(p.iva_12_restante);
+      totalSeguroRecalc = totalSeguroRecalc.plus(p.seguro_restante);
+      totalGpsRecalc = totalGpsRecalc.plus(p.gps_restante);
+      totalMembresiasRecalc = totalMembresiasRecalc.plus(p.membresias);
+      totalInteresCubeRecalc = totalInteresCubeRecalc.plus(p.interes_cube);
+      totalIvaCubeRecalc = totalIvaCubeRecalc.plus(p.iva_cube);
+      totalMoraRecalc = totalMoraRecalc.plus(p.mora);
+      totalMontoAplicadoRecalc = totalMontoAplicadoRecalc.plus(p.monto_aplicado);
+      totalPagosDelMesRecalc = totalPagosDelMesRecalc.plus(p.total_pagos_del_mes);
+    });
+
+    {
     const workbook = new ExcelJS.Workbook();
     const sheet = workbook.addWorksheet("Pagos por Vencimiento");
 
@@ -1910,7 +1877,7 @@ export async function getPagosByVencimiento({
     totalesRow.getCell(1).alignment = { horizontal: "center", vertical: "middle" };
 
     // Query bulk: todos los pagos detalle de todos los créditos en una sola llamada
-    const creditoIds = (pagos as any[]).map((p: any) => Number(p.credito_id));
+    const creditoIds = allPagosRecalculated.map((p: any) => Number(p.credito_id));
     const abonosMap = new Map<number, any[]>();
     if (creditoIds.length > 0) {
       const abonosBulkResult = await db.execute<any>(sql`
@@ -1956,7 +1923,7 @@ export async function getPagosByVencimiento({
       }
     }
 
-    for (const [idx, item] of (pagos as any[]).entries()) {
+    for (const [idx, item] of allPagosRecalculated.entries()) {
       const rowData = {
         ...item,
         cuotas: item.cuota_min === item.cuota_max ? item.cuota_min : `${item.cuota_min}-${item.cuota_max}`,
@@ -2049,7 +2016,59 @@ export async function getPagosByVencimiento({
 
     const url = `${process.env.URL_PUBLIC_R2_REPORTS}/${filename}`;
     return { success: true, excelUrl: url };
-  }
+    } // close inner excel workbook block
+  } // close if (excel)
+
+  // Non-excel: 2 queries en paralelo — datos paginados (SQL LIMIT/OFFSET) + totales SQL (CTE)
+  const offset = (page - 1) * pageSize;
+  const [pagosPageResult, totalesResult] = await Promise.all([
+    db.execute<any>(sql`
+      ${pagosSelectFields}
+      ${commonFromJoins}
+      ${commonGroupHaving}
+      ORDER BY c.numero_credito_sifco
+      LIMIT ${pageSize} OFFSET ${offset}
+    `),
+    db.execute<any>(sql`
+      WITH per_credito AS (
+        SELECT
+          COALESCE(cap_anterior.total_restante, c.capital::numeric) AS cap_ant,
+          c.porcentaje_interes::numeric / 100 AS tasa,
+          c.cuota::numeric AS cuota_c,
+          COALESCE(c.seguro_10_cuotas::numeric, 0) AS seguro,
+          COALESCE(c.gps::numeric, 0) AS gps,
+          COALESCE(c.membresias_pago::numeric, 0) AS mem,
+          AVG(COALESCE(cube_data.cash_in_pct, 0))::numeric AS cash_pct,
+          COALESCE(MAX(m.monto_mora::numeric), 0) AS mora,
+          COALESCE(SUM(p.monto_aplicado::numeric), 0) AS monto_apl
+        ${commonFromJoins}
+        ${commonGroupHaving}
+      ),
+      calc AS (
+        SELECT *,
+          ROUND(cap_ant * tasa, 2) AS interes,
+          ROUND(ROUND(cap_ant * tasa, 2) * 0.12, 2) AS iva
+        FROM per_credito
+      )
+      SELECT
+        COUNT(*) AS total_count,
+        COALESCE(SUM(LEAST(GREATEST(cuota_c - interes - iva - seguro - gps - mem, 0::numeric), cap_ant)), 0) AS total_capital,
+        COALESCE(SUM(interes), 0) AS total_interes,
+        COALESCE(SUM(iva), 0) AS total_iva,
+        COALESCE(SUM(seguro), 0) AS total_seguro,
+        COALESCE(SUM(gps), 0) AS total_gps,
+        COALESCE(SUM(mem), 0) AS total_membresias,
+        COALESCE(SUM(ROUND(interes * cash_pct, 2)), 0) AS total_interes_cube,
+        COALESCE(SUM(ROUND(ROUND(interes * cash_pct, 2) * 0.12, 2)), 0) AS total_iva_cube,
+        COALESCE(SUM(mora), 0) AS total_mora,
+        COALESCE(SUM(monto_apl), 0) AS total_monto_aplicado
+      FROM calc
+    `),
+  ]);
+
+  const pagos = pagosPageResult.rows.map(recalcRow);
+  const totRow = totalesResult.rows[0];
+  const total = Number(totRow?.total_count ?? 0);
 
   return {
     data: pagos,
@@ -2060,15 +2079,15 @@ export async function getPagosByVencimiento({
       totalPages: Math.ceil(total / pageSize),
     },
     totales: {
-      capital_restante: totalCapitalRecalc.toFixed(2),
-      interes_restante: totalInteresRecalc.toFixed(2),
-      iva_12_restante: totalIvaRecalc.toFixed(2),
-      seguro_restante: totalSeguroRecalc.toFixed(2),
-      gps_restante: totalGpsRecalc.toFixed(2),
-      membresias: totalMembresiasRecalc.toFixed(2),
-      interes_cube: totalInteresCubeRecalc.toFixed(2),
-      iva_cube: totalIvaCubeRecalc.toFixed(2),
-      mora: totalMoraRecalc.toFixed(2),
+      capital_restante: Number(totRow?.total_capital ?? 0).toFixed(2),
+      interes_restante: Number(totRow?.total_interes ?? 0).toFixed(2),
+      iva_12_restante: Number(totRow?.total_iva ?? 0).toFixed(2),
+      seguro_restante: Number(totRow?.total_seguro ?? 0).toFixed(2),
+      gps_restante: Number(totRow?.total_gps ?? 0).toFixed(2),
+      membresias: Number(totRow?.total_membresias ?? 0).toFixed(2),
+      interes_cube: Number(totRow?.total_interes_cube ?? 0).toFixed(2),
+      iva_cube: Number(totRow?.total_iva_cube ?? 0).toFixed(2),
+      mora: Number(totRow?.total_mora ?? 0).toFixed(2),
     },
   };
 }

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -7,6 +7,7 @@ import { fetchImageBase64 } from "../utils/functions/internReportCancelations";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 import { db } from "../database";
 import { sql } from "drizzle-orm";
+import Big from "big.js";
 
 const LOGO_URL = process.env.LOGO_URL || "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
 
@@ -1606,6 +1607,12 @@ export async function getPagosByVencimiento({
         BOOL_OR(pc.pagado) AS pagado
       FROM cartera.pagos_credito pc
       WHERE pc.cuota_id IS NOT NULL
+        AND pc.cuota_id IN (
+          SELECT cuota_id 
+          FROM cartera.cuotas_credito 
+          WHERE fecha_vencimiento::date >= ${fechaInicio}::date 
+            AND fecha_vencimiento::date <= ${fechaFin}::date
+        )
       GROUP BY pc.credito_id, pc.cuota_id
 
       UNION ALL
@@ -1624,6 +1631,8 @@ export async function getPagosByVencimiento({
         pc.pagado
       FROM cartera.pagos_credito pc
       WHERE pc.cuota_id IS NULL
+        AND pc.fecha_vencimiento::date >= ${fechaInicio}::date
+        AND pc.fecha_vencimiento::date <= ${fechaFin}::date
     ) p
   `;
 
@@ -1639,34 +1648,10 @@ export async function getPagosByVencimiento({
     COALESCE(p.monto_boleta, 0)::numeric
   )`;
 
-  // 1. Totales globales y conteo de créditos únicos
-  const totalesResult = await db.execute<any>(sql`
-    SELECT
-      COUNT(DISTINCT c.credito_id)::int AS total_count,
-      COALESCE(SUM(p.capital_restante::numeric), 0) AS total_capital_restante,
-      COALESCE(SUM(p.interes_restante::numeric), 0) AS total_interes_restante,
-      COALESCE(SUM(p.iva_12_restante::numeric), 0) AS total_iva_12_restante,
-      COALESCE(SUM(p.seguro_restante::numeric), 0) AS total_seguro_restante,
-      COALESCE(SUM(p.gps_restante::numeric), 0) AS total_gps_restante,
-      COALESCE(SUM(p.membresias::numeric), 0) AS total_membresias,
-      COALESCE(SUM(p.interes_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_interes_cube,
-      COALESCE(SUM(p.iva_12_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS total_iva_cube
-    FROM ${pagosDeduped}
-    INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
-    INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
-    INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
-    LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
-    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
-    ${cubeSubquery}
-    WHERE ${whereClause}
-      AND ${totalFilaSql} <> 0
-  `);
-
-  const totalesRow = totalesResult.rows[0];
-  const total = Number(totalesRow?.total_count ?? 0);
-  const offset = (page - 1) * pageSize;
-
-  // 2. Pagos agrupados por crédito
+  // 1. Pagos agrupados por crédito con metadatos para recálculo dinámico
+  // capital_mes_anterior: total_restante del último pago (no falso) ANTES del mes consultado.
+  // total_restante guarda el saldo global del crédito después de ese pago → base correcta para calcular interés.
+  // Fallback: c.capital si es el primer mes del crédito (sin pagos previos).
   const pagosResult = await db.execute<any>(sql`
     SELECT
       c.credito_id,
@@ -1674,18 +1659,24 @@ export async function getPagosByVencimiento({
       u.nombre AS nombre_usuario,
       a.nombre AS asesor,
       c.royalti,
+      c.capital AS capital_actual,
+      c.porcentaje_interes,
+      c.cuota AS cuota_credito,
+      c.seguro_10_cuotas,
+      c.gps,
+      c.membresias_pago,
+      COALESCE(cap_anterior.total_restante, c.capital::numeric) AS capital_mes_anterior,
+      AVG(COALESCE(cube_data.cash_in_pct, 0))::numeric AS cash_in_pct,
       MIN(q.numero_cuota) AS cuota_min,
       MAX(q.numero_cuota) AS cuota_max,
-      COALESCE(SUM(p.capital_restante::numeric), 0) AS capital_restante,
-      COALESCE(SUM(p.interes_restante::numeric), 0) AS interes_restante,
-      COALESCE(SUM(p.iva_12_restante::numeric), 0) AS iva_12_restante,
-      COALESCE(SUM(p.seguro_restante::numeric), 0) AS seguro_restante,
-      COALESCE(SUM(p.gps_restante::numeric), 0) AS gps_restante,
-      COALESCE(SUM(p.membresias::numeric), 0) AS membresias,
+      COALESCE(SUM(p.capital_restante::numeric), 0) AS capital_restante_db,
+      COALESCE(SUM(p.interes_restante::numeric), 0) AS interes_restante_db,
+      COALESCE(SUM(p.iva_12_restante::numeric), 0) AS iva_12_restante_db,
+      COALESCE(SUM(p.seguro_restante::numeric), 0) AS seguro_restante_db,
+      COALESCE(SUM(p.gps_restante::numeric), 0) AS gps_restante_db,
+      COALESCE(SUM(p.membresias::numeric), 0) AS membresias_db,
       COALESCE(SUM(p.monto_boleta::numeric), 0) AS monto_boleta,
-      COALESCE(SUM(p.interes_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS interes_cube,
-      COALESCE(SUM(p.iva_12_restante::numeric * COALESCE(cube_data.cash_in_pct, 0)), 0) AS iva_cube,
-      COALESCE(SUM(${totalFilaSql}), 0) AS total_pagos_del_mes,
+      COALESCE(MAX(m.monto_mora::numeric), 0) AS monto_mora,
       CASE
         WHEN MAX(m.cuotas_atrasadas) = 1 THEN 'Mora 30'
         WHEN MAX(m.cuotas_atrasadas) = 2 THEN 'Mora 60'
@@ -1700,14 +1691,136 @@ export async function getPagosByVencimiento({
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
     LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
     ${cubeSubquery}
+    LEFT JOIN LATERAL (
+      -- Último pago (no falso) anterior al mes consultado que tenga total_restante registrado.
+      -- total_restante = saldo global del crédito al momento de ese pago → capital real al cierre del mes anterior.
+      SELECT pc_a.total_restante::numeric AS total_restante
+      FROM cartera.pagos_credito pc_a
+      WHERE pc_a.credito_id = c.credito_id
+        AND pc_a."paymentFalse" = false
+        AND pc_a.total_restante IS NOT NULL
+        AND pc_a.total_restante::numeric > 0
+        AND GREATEST(
+              COALESCE(pc_a.fecha_boleta::date, pc_a.fecha_pago::date, '1900-01-01'::date),
+              COALESCE(pc_a.fecha_pago::date,   pc_a.fecha_boleta::date, '1900-01-01'::date)
+            ) < ${fechaInicio}::date
+      ORDER BY GREATEST(
+                 COALESCE(pc_a.fecha_boleta::date, pc_a.fecha_pago::date, '1900-01-01'::date),
+                 COALESCE(pc_a.fecha_pago::date,   pc_a.fecha_boleta::date, '1900-01-01'::date)
+               ) DESC, pc_a.pago_id DESC
+      LIMIT 1
+    ) cap_anterior ON true
     WHERE ${whereClause}
-    GROUP BY c.credito_id, c.numero_credito_sifco, u.nombre, a.nombre, c.royalti
+    GROUP BY 
+      c.credito_id, 
+      c.numero_credito_sifco, 
+      u.nombre, 
+      a.nombre, 
+      c.royalti, 
+      c.capital, 
+      c.porcentaje_interes, 
+      c.cuota, 
+      c.seguro_10_cuotas, 
+      c.gps, 
+      c.membresias_pago,
+      cap_anterior.total_restante
     HAVING SUM(${totalFilaSql}) <> 0
     ORDER BY c.numero_credito_sifco
-    ${excel ? sql`` : sql`LIMIT ${pageSize} OFFSET ${offset}`}
   `);
 
-  const pagos = pagosResult.rows;
+  const allPagosRecalculated = pagosResult.rows.map((row: any) => {
+    // Capital al cierre del mes anterior: total_restante del último pago previo al mes.
+    // total_restante = saldo global del crédito (no de la cuota) → base correcta para interés.
+    // Fallback a c.capital si es el primer mes del crédito.
+    const capitalAnterior = new Big(row.capital_mes_anterior || 0);
+
+    const porcentajeInteres = new Big(row.porcentaje_interes || 0).div(100);
+
+    // Interés y IVA dinámicos
+    const interesCalculado = capitalAnterior.times(porcentajeInteres).round(2);
+    const ivaCalculado = interesCalculado.times(0.12).round(2);
+    
+    // Rubros fijos
+    const seguro = new Big(row.seguro_10_cuotas || 0);
+    const gps = new Big(row.gps || 0);
+    const membresia = new Big(row.membresias_pago || 0);
+    const mora = new Big(row.monto_mora || 0);
+    
+    // Cuota del crédito
+    const cuotaCredito = new Big(row.cuota_credito || 0);
+    
+    // Abono Capital = Cuota - (Interés + IVA + Seguro + GPS + Membresía)
+    let abonoCapitalCalculado = cuotaCredito.minus(interesCalculado).minus(ivaCalculado).minus(seguro).minus(gps).minus(membresia);
+    if (abonoCapitalCalculado.lt(0)) {
+      abonoCapitalCalculado = new Big(0);
+    }
+    // Capped a capitalAnterior para no amortizar de más
+    if (abonoCapitalCalculado.gt(capitalAnterior)) {
+      abonoCapitalCalculado = capitalAnterior;
+    }
+    
+    // CUBE
+    const cashInPct = new Big(row.cash_in_pct || 0);
+    const interesCube = interesCalculado.times(cashInPct).round(2);
+    const ivaCube = interesCube.times(0.12).round(2);
+    
+    // Total Pagos Mes = recalculated obligation (Abono Capital + Interés + IVA + Seguro + GPS + Membresía)
+    const totalPagosDelMes = abonoCapitalCalculado.plus(interesCalculado).plus(ivaCalculado).plus(seguro).plus(gps).plus(membresia);
+    
+    return {
+      credito_id: row.credito_id,
+      numero_credito_sifco: row.numero_credito_sifco,
+      nombre_usuario: row.nombre_usuario,
+      asesor: row.asesor,
+      royalti: row.royalti,
+      cuota_min: row.cuota_min,
+      cuota_max: row.cuota_max,
+      dias_mora: row.dias_mora,
+      monto_boleta: Number(row.monto_boleta).toFixed(2), // abonos reales
+      
+      // Reemplazamos los valores programados con los dinámicos
+      capital_restante: abonoCapitalCalculado.toFixed(2), // Se muestra como "Abono Capital"
+      interes_restante: interesCalculado.toFixed(2),
+      iva_12_restante: ivaCalculado.toFixed(2),
+      seguro_restante: seguro.toFixed(2),
+      gps_restante: gps.toFixed(2),
+      membresias: membresia.toFixed(2),
+      mora: mora.toFixed(2),
+      
+      // CUBE
+      interes_cube: interesCube.toFixed(2),
+      iva_cube: ivaCube.toFixed(2),
+      
+      total_pagos_del_mes: totalPagosDelMes.toFixed(2)
+    };
+  });
+
+  const total = allPagosRecalculated.length;
+  const offset = (page - 1) * pageSize;
+  const pagos = excel ? allPagosRecalculated : allPagosRecalculated.slice(offset, offset + pageSize);
+
+  // Totales globales recalculados
+  let totalCapitalRecalc = new Big(0);
+  let totalInteresRecalc = new Big(0);
+  let totalIvaRecalc = new Big(0);
+  let totalSeguroRecalc = new Big(0);
+  let totalGpsRecalc = new Big(0);
+  let totalMembresiasRecalc = new Big(0);
+  let totalInteresCubeRecalc = new Big(0);
+  let totalIvaCubeRecalc = new Big(0);
+  let totalMoraRecalc = new Big(0);
+
+  allPagosRecalculated.forEach((p: any) => {
+    totalCapitalRecalc = totalCapitalRecalc.plus(p.capital_restante);
+    totalInteresRecalc = totalInteresRecalc.plus(p.interes_restante);
+    totalIvaRecalc = totalIvaRecalc.plus(p.iva_12_restante);
+    totalSeguroRecalc = totalSeguroRecalc.plus(p.seguro_restante);
+    totalGpsRecalc = totalGpsRecalc.plus(p.gps_restante);
+    totalMembresiasRecalc = totalMembresiasRecalc.plus(p.membresias);
+    totalInteresCubeRecalc = totalInteresCubeRecalc.plus(p.interes_cube);
+    totalIvaCubeRecalc = totalIvaCubeRecalc.plus(p.iva_cube);
+    totalMoraRecalc = totalMoraRecalc.plus(p.mora);
+  });
 
   if (excel) {
     const workbook = new ExcelJS.Workbook();
@@ -1719,7 +1832,8 @@ export async function getPagosByVencimiento({
       { header: "Asesor", key: "asesor", width: 25 },
       { header: "Cuotas", key: "cuotas", width: 12 },
       { header: "Etapa Mora", key: "dias_mora", width: 15 },
-      { header: "Capital", key: "capital_restante", width: 15 },
+      { header: "Boletas Totales", key: "monto_boleta", width: 15 },
+      { header: "Abono Capital", key: "capital_restante", width: 15 },
       { header: "Interés", key: "interes_restante", width: 15 },
       { header: "IVA 12%", key: "iva_12_restante", width: 15 },
       { header: "Seguro", key: "seguro_restante", width: 15 },
@@ -1728,6 +1842,7 @@ export async function getPagosByVencimiento({
       { header: "Int. CUBE", key: "interes_cube", width: 15 },
       { header: "IVA CUBE", key: "iva_cube", width: 15 },
       { header: "Royalty", key: "royalti", width: 15 },
+      { header: "Mora", key: "mora", width: 15 },
       { header: "Total Mes", key: "total_pagos_del_mes", width: 18 },
     ];
 
@@ -1762,6 +1877,7 @@ export async function getPagosByVencimiento({
         ...item,
         cuotas: item.cuota_min === item.cuota_max ? item.cuota_min : `${item.cuota_min}-${item.cuota_max}`,
         royalti: item.cuota_min === 0 ? Number(item.royalti) : "--",
+        monto_boleta: Number(item.monto_boleta),
         capital_restante: Number(item.capital_restante),
         interes_restante: Number(item.interes_restante),
         iva_12_restante: Number(item.iva_12_restante),
@@ -1770,6 +1886,7 @@ export async function getPagosByVencimiento({
         membresias: Number(item.membresias),
         interes_cube: Number(item.interes_cube),
         iva_cube: Number(item.iva_cube),
+        mora: Number(item.mora),
         total_pagos_del_mes: Number(item.total_pagos_del_mes),
       };
 
@@ -1824,14 +1941,63 @@ export async function getPagosByVencimiento({
       totalPages: Math.ceil(total / pageSize),
     },
     totales: {
-      capital_restante: Number(totalesRow?.total_capital_restante ?? 0).toFixed(2),
-      interes_restante: Number(totalesRow?.total_interes_restante ?? 0).toFixed(2),
-      iva_12_restante: Number(totalesRow?.total_iva_12_restante ?? 0).toFixed(2),
-      seguro_restante: Number(totalesRow?.total_seguro_restante ?? 0).toFixed(2),
-      gps_restante: Number(totalesRow?.total_gps_restante ?? 0).toFixed(2),
-      membresias: Number(totalesRow?.total_membresias ?? 0).toFixed(2),
-      interes_cube: Number(totalesRow?.total_interes_cube ?? 0).toFixed(2),
-      iva_cube: Number(totalesRow?.total_iva_cube ?? 0).toFixed(2),
+      capital_restante: totalCapitalRecalc.toFixed(2),
+      interes_restante: totalInteresRecalc.toFixed(2),
+      iva_12_restante: totalIvaRecalc.toFixed(2),
+      seguro_restante: totalSeguroRecalc.toFixed(2),
+      gps_restante: totalGpsRecalc.toFixed(2),
+      membresias: totalMembresiasRecalc.toFixed(2),
+      interes_cube: totalInteresCubeRecalc.toFixed(2),
+      iva_cube: totalIvaCubeRecalc.toFixed(2),
+      mora: totalMoraRecalc.toFixed(2),
     },
   };
 }
+
+export async function getAbonosDelMesPorCredito({
+  credito_id,
+  mes,
+  anio,
+}: {
+  credito_id: number;
+  mes: number;
+  anio: number;
+}) {
+  const fechaInicio = `${anio}-${String(mes).padStart(2, "0")}-01`;
+  const fechaFinDate = new Date(anio, mes, 0);
+  const fechaFin = `${anio}-${String(mes).padStart(2, "0")}-${String(fechaFinDate.getDate()).padStart(2, "0")}`;
+
+  const result = await db.execute<any>(sql`
+    SELECT 
+      pago_id,
+      cuota_id,
+      cuota,
+      COALESCE(abono_capital, 0) AS abono_capital,
+      COALESCE(abono_interes, 0) AS abono_interes,
+      COALESCE(abono_iva_12, 0) AS abono_iva_12,
+      COALESCE(abono_seguro, 0) AS abono_seguro,
+      COALESCE(abono_gps, 0) AS abono_gps,
+      COALESCE(membresias_pago, 0) AS membresias,
+      COALESCE(abono_interes_ci, 0) AS interes_cube,
+      COALESCE(abono_iva_ci, 0) AS iva_cube,
+      COALESCE(mora, 0) AS mora,
+      COALESCE(otros, '0') AS otros,
+      COALESCE(monto_boleta, 0) AS monto_boleta,
+      COALESCE(monto_aplicado, 0) AS monto_aplicado,
+      TO_CHAR(fecha_boleta, 'YYYY-MM-DD') AS fecha_boleta,
+      TO_CHAR(fecha_pago AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala', 'YYYY-MM-DD HH24:MI:SS') AS fecha_pago,
+      numeroautorizacion AS numero_boleta
+    FROM cartera.pagos_credito
+    WHERE credito_id = ${credito_id}
+      AND validation_status = 'validated'
+      AND "paymentFalse" = false
+      AND (
+        (fecha_pago::date >= ${fechaInicio}::date AND fecha_pago::date <= ${fechaFin}::date)
+        OR (fecha_boleta::date >= ${fechaInicio}::date AND fecha_boleta::date <= ${fechaFin}::date)
+      )
+    ORDER BY fecha_boleta ASC, fecha_pago ASC
+  `);
+
+  return result.rows;
+}
+

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1603,6 +1603,7 @@ export async function getPagosByVencimiento({
         MIN(COALESCE(pc.gps_restante::numeric, 0))      + SUM(COALESCE(pc.abono_gps::numeric, 0))       AS gps_restante,
         MIN(COALESCE(pc.membresias::numeric, 0))        + SUM(COALESCE(pc.membresias_pago::numeric, 0)) AS membresias,
         SUM(COALESCE(pc.monto_boleta::numeric, 0)) AS monto_boleta,
+        SUM(COALESCE(pc.monto_aplicado::numeric, 0)) AS monto_aplicado,
         MIN(pc.fecha_vencimiento) AS fecha_vencimiento,
         BOOL_OR(pc.pagado) AS pagado
       FROM cartera.pagos_credito pc
@@ -1627,6 +1628,7 @@ export async function getPagosByVencimiento({
         COALESCE(pc.gps_restante::numeric, 0)      + COALESCE(pc.abono_gps::numeric, 0)       AS gps_restante,
         COALESCE(pc.membresias::numeric, 0)        + COALESCE(pc.membresias_pago::numeric, 0) AS membresias,
         COALESCE(pc.monto_boleta::numeric, 0) AS monto_boleta,
+        COALESCE(pc.monto_aplicado::numeric, 0) AS monto_aplicado,
         pc.fecha_vencimiento,
         pc.pagado
       FROM cartera.pagos_credito pc
@@ -1676,6 +1678,7 @@ export async function getPagosByVencimiento({
       COALESCE(SUM(p.gps_restante::numeric), 0) AS gps_restante_db,
       COALESCE(SUM(p.membresias::numeric), 0) AS membresias_db,
       COALESCE(SUM(p.monto_boleta::numeric), 0) AS monto_boleta,
+      COALESCE(SUM(p.monto_aplicado::numeric), 0) AS monto_aplicado,
       COALESCE(MAX(m.monto_mora::numeric), 0) AS monto_mora,
       CASE
         WHEN MAX(m.cuotas_atrasadas) = 1 THEN 'Mora 30'
@@ -1776,7 +1779,8 @@ export async function getPagosByVencimiento({
       cuota_min: row.cuota_min,
       cuota_max: row.cuota_max,
       dias_mora: row.dias_mora,
-      monto_boleta: Number(row.monto_boleta).toFixed(2), // abonos reales
+      monto_boleta: Number(row.monto_boleta).toFixed(2),
+      monto_aplicado: Number(row.monto_aplicado).toFixed(2),
       
       // Reemplazamos los valores programados con los dinámicos
       capital_restante: abonoCapitalCalculado.toFixed(2), // Se muestra como "Abono Capital"
@@ -1809,6 +1813,8 @@ export async function getPagosByVencimiento({
   let totalInteresCubeRecalc = new Big(0);
   let totalIvaCubeRecalc = new Big(0);
   let totalMoraRecalc = new Big(0);
+  let totalMontoAplicadoRecalc = new Big(0);
+  let totalPagosDelMesRecalc = new Big(0);
 
   allPagosRecalculated.forEach((p: any) => {
     totalCapitalRecalc = totalCapitalRecalc.plus(p.capital_restante);
@@ -1820,6 +1826,8 @@ export async function getPagosByVencimiento({
     totalInteresCubeRecalc = totalInteresCubeRecalc.plus(p.interes_cube);
     totalIvaCubeRecalc = totalIvaCubeRecalc.plus(p.iva_cube);
     totalMoraRecalc = totalMoraRecalc.plus(p.mora);
+    totalMontoAplicadoRecalc = totalMontoAplicadoRecalc.plus(p.monto_aplicado);
+    totalPagosDelMesRecalc = totalPagosDelMesRecalc.plus(p.total_pagos_del_mes);
   });
 
   if (excel) {
@@ -1827,12 +1835,12 @@ export async function getPagosByVencimiento({
     const sheet = workbook.addWorksheet("Pagos por Vencimiento");
 
     const columns = [
-      { header: "No. SIFCO", key: "numero_credito_sifco", width: 15 },
-      { header: "Cliente", key: "nombre_usuario", width: 35 },
+      { header: "No. SIFCO", key: "numero_credito_sifco", width: 18 },
+      { header: "Cliente / Fecha Boleta", key: "nombre_usuario", width: 35 },
       { header: "Asesor", key: "asesor", width: 25 },
       { header: "Cuotas", key: "cuotas", width: 12 },
       { header: "Etapa Mora", key: "dias_mora", width: 15 },
-      { header: "Boletas Totales", key: "monto_boleta", width: 15 },
+      { header: "Boletas Totales", key: "monto_aplicado", width: 16 },
       { header: "Abono Capital", key: "capital_restante", width: 15 },
       { header: "Interés", key: "interes_restante", width: 15 },
       { header: "IVA 12%", key: "iva_12_restante", width: 15 },
@@ -1872,12 +1880,82 @@ export async function getPagosByVencimiento({
       right: { style: "thin" as const, color: { argb: "D9D9D9" } },
     };
 
-    pagos.forEach((item: any, idx: number) => {
+    // Fila de totales
+    const totalesRowData = {
+      numero_credito_sifco: "TOTALES",
+      nombre_usuario: "",
+      asesor: "",
+      cuotas: "",
+      dias_mora: "",
+      monto_aplicado: Number(totalMontoAplicadoRecalc.toFixed(2)),
+      capital_restante: Number(totalCapitalRecalc.toFixed(2)),
+      interes_restante: Number(totalInteresRecalc.toFixed(2)),
+      iva_12_restante: Number(totalIvaRecalc.toFixed(2)),
+      seguro_restante: Number(totalSeguroRecalc.toFixed(2)),
+      gps_restante: Number(totalGpsRecalc.toFixed(2)),
+      membresias: Number(totalMembresiasRecalc.toFixed(2)),
+      interes_cube: Number(totalInteresCubeRecalc.toFixed(2)),
+      iva_cube: Number(totalIvaCubeRecalc.toFixed(2)),
+      royalti: "",
+      mora: Number(totalMoraRecalc.toFixed(2)),
+      total_pagos_del_mes: Number(totalPagosDelMesRecalc.toFixed(2)),
+    };
+    const totalesRow = sheet.addRow(totalesRowData);
+    totalesRow.font = { bold: true, size: 10 };
+    totalesRow.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "E2EFDA" } };
+    totalesRow.eachCell({ includeEmpty: true }, (cell) => {
+      cell.border = thinBorder;
+      cell.alignment = { vertical: "middle", horizontal: "right" };
+    });
+    totalesRow.getCell(1).alignment = { horizontal: "center", vertical: "middle" };
+
+    // Query bulk: todos los pagos detalle de todos los créditos en una sola llamada
+    const creditoIds = (pagos as any[]).map((p: any) => Number(p.credito_id));
+    const abonosMap = new Map<number, any[]>();
+    if (creditoIds.length > 0) {
+      const abonosBulkResult = await db.execute<any>(sql`
+        SELECT
+          credito_id,
+          pago_id,
+          cuota_id,
+          cuota,
+          COALESCE(abono_capital, 0) AS abono_capital,
+          COALESCE(abono_interes, 0) AS abono_interes,
+          COALESCE(abono_iva_12, 0) AS abono_iva_12,
+          COALESCE(abono_seguro, 0) AS abono_seguro,
+          COALESCE(abono_gps, 0) AS abono_gps,
+          COALESCE(membresias_pago, 0) AS membresias,
+          COALESCE(abono_interes_ci, 0) AS interes_cube,
+          COALESCE(abono_iva_ci, 0) AS iva_cube,
+          COALESCE(mora, 0) AS mora,
+          COALESCE(monto_boleta, 0) AS monto_boleta,
+          COALESCE(monto_aplicado, 0) AS monto_aplicado,
+          TO_CHAR(fecha_boleta, 'YYYY-MM-DD') AS fecha_boleta,
+          TO_CHAR(fecha_pago AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala', 'YYYY-MM-DD HH24:MI:SS') AS fecha_pago,
+          numeroautorizacion AS numero_boleta
+        FROM cartera.pagos_credito
+        WHERE credito_id = ANY(ARRAY[${sql.raw(creditoIds.join(","))}]::int[])
+          AND validation_status = 'validated'
+          AND "paymentFalse" = false
+          AND (
+            (fecha_pago::date >= ${fechaInicio}::date AND fecha_pago::date <= ${fechaFin}::date)
+            OR (fecha_boleta::date >= ${fechaInicio}::date AND fecha_boleta::date <= ${fechaFin}::date)
+          )
+        ORDER BY credito_id ASC, fecha_boleta ASC, fecha_pago ASC
+      `);
+      for (const abono of abonosBulkResult.rows) {
+        const list = abonosMap.get(Number(abono.credito_id)) ?? [];
+        list.push(abono);
+        abonosMap.set(Number(abono.credito_id), list);
+      }
+    }
+
+    for (const [idx, item] of (pagos as any[]).entries()) {
       const rowData = {
         ...item,
         cuotas: item.cuota_min === item.cuota_max ? item.cuota_min : `${item.cuota_min}-${item.cuota_max}`,
         royalti: item.cuota_min === 0 ? Number(item.royalti) : "--",
-        monto_boleta: Number(item.monto_boleta),
+        monto_aplicado: Number(item.monto_aplicado),
         capital_restante: Number(item.capital_restante),
         interes_restante: Number(item.interes_restante),
         iva_12_restante: Number(item.iva_12_restante),
@@ -1892,6 +1970,7 @@ export async function getPagosByVencimiento({
 
       const r = sheet.addRow(rowData);
       const isEven = idx % 2 === 0;
+      r.font = { bold: true, size: 10 };
       r.eachCell({ includeEmpty: true }, (cell) => {
         cell.border = thinBorder;
         cell.alignment = { vertical: "middle", horizontal: "right" };
@@ -1899,13 +1978,47 @@ export async function getPagosByVencimiento({
           cell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "F5F9FF" } };
         }
       });
-      // Alinear texto a la izquierda para las primeras columnas
       r.getCell(1).alignment = { horizontal: "center", vertical: "middle" };
       r.getCell(2).alignment = { horizontal: "left", vertical: "middle" };
       r.getCell(3).alignment = { horizontal: "left", vertical: "middle" };
       r.getCell(4).alignment = { horizontal: "center", vertical: "middle" };
       r.getCell(5).alignment = { horizontal: "center", vertical: "middle" };
-    });
+
+      // Filas detalle (pagos individuales del crédito)
+      const abonos = abonosMap.get(Number(item.credito_id)) ?? [];
+      for (const abono of abonos) {
+        const fechaLabel = abono.fecha_boleta
+          ? `  └ ${abono.fecha_boleta}${abono.numero_boleta ? ` (${abono.numero_boleta})` : ""}`
+          : `  └ ${(abono.fecha_pago ?? "").slice(0, 10)}`;
+        const detalleRowData = {
+          numero_credito_sifco: "",
+          nombre_usuario: fechaLabel,
+          asesor: "",
+          cuotas: "",
+          dias_mora: "",
+          monto_aplicado: Number(abono.monto_aplicado || 0),
+          capital_restante: Number(abono.abono_capital || 0),
+          interes_restante: Number(abono.abono_interes || 0),
+          iva_12_restante: Number(abono.abono_iva_12 || 0),
+          seguro_restante: Number(abono.abono_seguro || 0),
+          gps_restante: Number(abono.abono_gps || 0),
+          membresias: Number(abono.membresias || 0),
+          interes_cube: Number(abono.interes_cube || 0),
+          iva_cube: Number(abono.iva_cube || 0),
+          royalti: "--",
+          mora: Number(abono.mora || 0),
+          total_pagos_del_mes: Number(abono.monto_aplicado || 0),
+        };
+        const dr = sheet.addRow(detalleRowData);
+        dr.font = { italic: true, size: 9, color: { argb: "555555" } };
+        dr.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "F8F8F8" } };
+        dr.eachCell({ includeEmpty: true }, (cell) => {
+          cell.border = thinBorder;
+          cell.alignment = { vertical: "middle", horizontal: "right" };
+        });
+        dr.getCell(2).alignment = { horizontal: "left", vertical: "middle" };
+      }
+    }
 
     const buffer = await workbook.xlsx.writeBuffer();
     const filename = `reportes/pagos_vencimiento_${mes}_${anio}_${Date.now()}.xlsx`;

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { promises as fs } from "fs";
 import { mapPagosPorCreditos, mapPagosDesdeJson } from "../migration/migration";
 import { authMiddleware } from "./midleware";
-import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF, getPagosByVencimiento } from "../controllers/reports";
+import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF, getPagosByVencimiento, getAbonosDelMesPorCredito } from "../controllers/reports";
 import { actualizarCuentaPago, aplicarPagoAlCredito, insertPayment, aplicarMontoAPago, editarPago } from "../controllers/registerPayment";
 import { eq } from "drizzle-orm";
 import { db } from "../database";
@@ -427,6 +427,35 @@ export const paymentRouter = new Elysia()
       asesor: t.Optional(t.String()),
       rango_mora: t.Optional(t.String()),
       excel: t.Optional(t.Boolean({ default: false })),
+    }),
+  }
+)
+.get(
+  "/pagos-por-vencimiento/abonos",
+  async ({ query, set }) => {
+    try {
+      const result = await getAbonosDelMesPorCredito({
+        credito_id: Number(query.credito_id),
+        mes: Number(query.mes),
+        anio: Number(query.anio),
+      });
+      set.status = 200;
+      return { success: true, data: result };
+    } catch (error: any) {
+      console.error("Error en /pagos-por-vencimiento/abonos:", error);
+      set.status = 500;
+      return { success: false, error: error.message || "Error obteniendo abonos del mes" };
+    }
+  },
+  {
+    detail: {
+      summary: "Obtiene los abonos reales validados aplicados a un crédito en el mes",
+      tags: ["Pagos", "Reportes"],
+    },
+    query: t.Object({
+      credito_id: t.String(),
+      mes: t.Integer({ minimum: 1, maximum: 12 }),
+      anio: t.Integer({ minimum: 2020 }),
     }),
   }
 )

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -1,4 +1,4 @@
-import { useState, Fragment } from "react";
+import { useState, useRef, Fragment } from "react";
 import { usePersistedState } from "../hooks/usePersistedState";
 import { usePagosPorVencimiento } from "../hooks/usePagosPorVencimiento";
 import { useAdminData } from "../hooks/advisor";
@@ -58,13 +58,16 @@ export function PagosPorVencimiento() {
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
   const [abonosDetail, setAbonosDetail] = useState<AbonoDetalleItem[]>([]);
   const [loadingDetails, setLoadingDetails] = useState(false);
+  const pendingCreditoRef = useRef<number | null>(null);
 
   const handleToggleRow = async (creditoId: number) => {
     if (expandedRow === creditoId) {
       setExpandedRow(null);
       setAbonosDetail([]);
+      pendingCreditoRef.current = null;
     } else {
       setExpandedRow(creditoId);
+      pendingCreditoRef.current = creditoId;
       setLoadingDetails(true);
       setAbonosDetail([]);
       try {
@@ -73,13 +76,15 @@ export function PagosPorVencimiento() {
           mes,
           anio,
         });
-        if (response.success) {
+        if (response.success && pendingCreditoRef.current === creditoId) {
           setAbonosDetail(response.data);
         }
       } catch (error) {
         console.error("Error al obtener detalle de abonos:", error);
       } finally {
-        setLoadingDetails(false);
+        if (pendingCreditoRef.current === creditoId) {
+          setLoadingDetails(false);
+        }
       }
     }
   };

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -58,16 +58,17 @@ export function PagosPorVencimiento() {
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
   const [abonosDetail, setAbonosDetail] = useState<AbonoDetalleItem[]>([]);
   const [loadingDetails, setLoadingDetails] = useState(false);
-  const pendingCreditoRef = useRef<number | null>(null);
+  const pendingRequestRef = useRef<{ creditoId: number; mes: number; anio: number } | null>(null);
 
   const handleToggleRow = async (creditoId: number) => {
     if (expandedRow === creditoId) {
       setExpandedRow(null);
       setAbonosDetail([]);
-      pendingCreditoRef.current = null;
+      pendingRequestRef.current = null;
     } else {
+      const token = { creditoId, mes, anio };
       setExpandedRow(creditoId);
-      pendingCreditoRef.current = creditoId;
+      pendingRequestRef.current = token;
       setLoadingDetails(true);
       setAbonosDetail([]);
       try {
@@ -76,13 +77,15 @@ export function PagosPorVencimiento() {
           mes,
           anio,
         });
-        if (response.success && pendingCreditoRef.current === creditoId) {
+        const current = pendingRequestRef.current;
+        if (response.success && current?.creditoId === creditoId && current?.mes === mes && current?.anio === anio) {
           setAbonosDetail(response.data);
         }
       } catch (error) {
         console.error("Error al obtener detalle de abonos:", error);
       } finally {
-        if (pendingCreditoRef.current === creditoId) {
+        const current = pendingRequestRef.current;
+        if (current?.creditoId === creditoId && current?.mes === mes && current?.anio === anio) {
           setLoadingDetails(false);
         }
       }

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -461,7 +461,7 @@ export function PagosPorVencimiento() {
                           {item.dias_mora}
                         </span>
                       </TableCell>
-                      <TableCell className="text-right font-medium text-black border-r border-b border-blue-100">{formatQ(item.monto_boleta)}</TableCell>
+                      <TableCell className="text-right font-medium text-black border-r border-b border-blue-100">{formatQ(item.monto_aplicado)}</TableCell>
                       <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.capital_restante)}</TableCell>
                       <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.interes_restante)}</TableCell>
                       <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.iva_12_restante)}</TableCell>
@@ -521,9 +521,9 @@ export function PagosPorVencimiento() {
                         {/* 5. Etapa de Mora -> vacío */}
                         <TableCell className="border-r border-b border-blue-100" />
                         
-                        {/* 6. Boletas Totales -> Monto Boleta */}
+                        {/* 6. Boletas Totales -> Monto Aplicado */}
                         <TableCell className="text-right font-semibold text-blue-900 border-r border-b border-blue-100 bg-blue-50/10">
-                          {formatQ(abono.monto_boleta)}
+                          {formatQ(abono.monto_aplicado)}
                         </TableCell>
                         
                         {/* 7. Abono Capital */}

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useState, Fragment } from "react";
 import { usePersistedState } from "../hooks/usePersistedState";
 import { usePagosPorVencimiento } from "../hooks/usePagosPorVencimiento";
 import { useAdminData } from "../hooks/advisor";
-import type { PagoPorVencimientoItem, Advisor } from "../services/services";
+import type { PagoPorVencimientoItem, Advisor, AbonoDetalleItem } from "../services/services";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -14,7 +14,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Search, X, ChevronLeft, ChevronRight, Check, ChevronsUpDown, FileDown, Loader2, AlertCircle } from "lucide-react";
-import { getPagosPorVencimiento } from "../services/services";
+import { getPagosPorVencimiento, getAbonosPorVencimientoDetalle } from "../services/services";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Badge } from "@/components/ui/badge";
@@ -54,6 +54,35 @@ export function PagosPorVencimiento() {
   const [isExporting, setIsExporting] = useState(false);
   const [showErrorModal, setShowErrorModal] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
+
+  const [expandedRow, setExpandedRow] = useState<number | null>(null);
+  const [abonosDetail, setAbonosDetail] = useState<AbonoDetalleItem[]>([]);
+  const [loadingDetails, setLoadingDetails] = useState(false);
+
+  const handleToggleRow = async (creditoId: number) => {
+    if (expandedRow === creditoId) {
+      setExpandedRow(null);
+      setAbonosDetail([]);
+    } else {
+      setExpandedRow(creditoId);
+      setLoadingDetails(true);
+      setAbonosDetail([]);
+      try {
+        const response = await getAbonosPorVencimientoDetalle({
+          credito_id: creditoId,
+          mes,
+          anio,
+        });
+        if (response.success) {
+          setAbonosDetail(response.data);
+        }
+      } catch (error) {
+        console.error("Error al obtener detalle de abonos:", error);
+      } finally {
+        setLoadingDetails(false);
+      }
+    }
+  };
 
   const hasActiveFilters =
     sifcoFilter !== "" ||
@@ -345,16 +374,17 @@ export function PagosPorVencimiento() {
           <h2 className="text-sm font-bold text-blue-800 mb-3 uppercase tracking-wide">
             Totales del mes — {meses[mes - 1]} {anio}
           </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-3">
-            {[
-              { label: "Capital", value: totales.capital_restante },
-              { label: "Interés", value: totales.interes_restante },
+          <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-9 gap-3">
+              {[
+                { label: "Abono Capital", value: totales.capital_restante },
+                { label: "Interés", value: totales.interes_restante },
               { label: "IVA 12%", value: totales.iva_12_restante },
               { label: "Seguro", value: totales.seguro_restante },
               { label: "GPS", value: totales.gps_restante },
               { label: "Membresías", value: totales.membresias },
               { label: "Interés CUBE", value: totales.interes_cube },
               { label: "IVA CUBE", value: totales.iva_cube },
+              { label: "Mora", value: totales.mora },
             ].map((t) => (
               <div key={t.label} className="text-center">
                 <p className="text-xs text-gray-500 font-medium">{t.label}</p>
@@ -379,65 +409,180 @@ export function PagosPorVencimiento() {
       ) : (
         <>
           <div className="bg-white rounded-2xl shadow-lg border border-blue-100 overflow-x-auto">
-            <Table className="w-full">
+            <Table className="w-full border-collapse">
               <TableHeader>
                 <TableRow className="bg-gradient-to-r from-blue-50 to-blue-100">
-                  <TableHead className="font-bold text-blue-800">No. SIFCO</TableHead>
-                  <TableHead className="font-bold text-blue-800">Cliente</TableHead>
-                  <TableHead className="font-bold text-blue-800">Asesor</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-center">Cuotas</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-center">Etapa de Mora</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">Boletas Totales</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">Capital</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">Interés</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">IVA 12%</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">Seguro</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">GPS</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">Membresías</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">Int. CUBE</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">IVA CUBE</TableHead>
-                  <TableHead className="font-bold text-blue-800 text-right">Royalty</TableHead>
-                  <TableHead className="font-bold text-green-800 text-right">Total Pagos Mes</TableHead>
+                  <TableHead className="sticky left-0 bg-[#f8fafc] z-20 font-bold text-blue-800 border-r border-b border-blue-200 min-w-[140px] w-[140px]">No. SIFCO</TableHead>
+                  <TableHead className="sticky left-[140px] bg-[#f8fafc] z-20 font-bold text-blue-800 border-r border-b border-blue-300 min-w-[220px] w-[220px] shadow-[3px_0_5px_-2px_rgba(0,0,0,0.05)]">Cliente</TableHead>
+                  <TableHead className="font-bold text-blue-800 border-r border-b border-blue-200">Asesor</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-center border-r border-b border-blue-200">Cuotas</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-center border-r border-b border-blue-200">Etapa de Mora</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">Boletas Totales</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">Abono Capital</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">Interés</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">IVA 12%</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">Seguro</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">GPS</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">Membresías</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">Int. CUBE</TableHead>
+                   <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">IVA CUBE</TableHead>
+                  <TableHead className="font-bold text-blue-800 text-right border-r border-b border-blue-200">Royalty</TableHead>
+                  <TableHead className="font-bold text-red-800 text-right border-r border-b border-blue-200">Mora</TableHead>
+                  <TableHead className="font-bold text-green-800 text-right border-b border-blue-200">Total Pagos Mes</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {items.map((item) => (
-                  <TableRow key={item.credito_id} className="hover:bg-blue-50/50 transition">
-                    <TableCell className="font-semibold text-blue-700">
-                      {item.numero_credito_sifco}
-                    </TableCell>
-                    <TableCell className="text-black">{item.nombre_usuario}</TableCell>
-                    <TableCell className="text-black text-xs">{item.asesor || "--"}</TableCell>
-                    <TableCell className="text-black text-center">
-                      {item.cuota_min === item.cuota_max 
-                        ? item.cuota_min 
-                        : `${item.cuota_min} - ${item.cuota_max}`}
-                    </TableCell>
-                    <TableCell className="text-center">
-                      <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold ${
-                        item.dias_mora === 'Al día' 
-                          ? 'bg-green-100 text-green-700' 
-                          : 'bg-red-100 text-red-700'
-                      }`}>
-                        {item.dias_mora}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-right font-medium text-black">{formatQ(item.monto_boleta)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.capital_restante)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.interes_restante)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.iva_12_restante)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.seguro_restante)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.gps_restante)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.membresias)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.interes_cube)}</TableCell>
-                    <TableCell className="text-right text-black">{formatQ(item.iva_cube)}</TableCell>
-                    <TableCell className="text-right text-black">
-                      {item.cuota_min === 0 ? formatQ(item.royalti) : "--"}
-                    </TableCell>
-                    <TableCell className="text-right text-green-700 font-bold bg-green-50/50">
-                      {formatQ(item.total_pagos_del_mes)}
-                    </TableCell>
-                  </TableRow>
+                  <Fragment key={item.credito_id}>
+                    <TableRow 
+                      className={`hover:bg-[#f3f8ff] transition-colors group cursor-pointer ${
+                        expandedRow === item.credito_id ? "bg-blue-50/40 hover:bg-[#f3f8ff]" : ""
+                      }`}
+                      onClick={() => handleToggleRow(item.credito_id)}
+                    >
+                      <TableCell className="sticky left-0 bg-white group-hover:bg-[#f3f8ff] transition-colors z-10 font-semibold text-blue-700 border-r border-b border-blue-200 min-w-[140px] w-[140px]">
+                        {item.numero_credito_sifco}
+                      </TableCell>
+                      <TableCell className="sticky left-[140px] bg-white group-hover:bg-[#f3f8ff] transition-colors z-10 text-black border-r border-b border-blue-300 min-w-[220px] w-[220px] shadow-[3px_0_5px_-2px_rgba(0,0,0,0.05)]">
+                        {item.nombre_usuario}
+                      </TableCell>
+                      <TableCell className="text-black text-xs border-r border-b border-blue-100">{item.asesor || "--"}</TableCell>
+                      <TableCell className="text-black text-center border-r border-b border-blue-100">
+                        {item.cuota_min === item.cuota_max 
+                          ? item.cuota_min 
+                          : `${item.cuota_min} - ${item.cuota_max}`}
+                      </TableCell>
+                      <TableCell className="text-center border-r border-b border-blue-100">
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold ${
+                          item.dias_mora === 'Al día' 
+                            ? 'bg-green-100 text-green-700' 
+                            : 'bg-red-100 text-red-700'
+                        }`}>
+                          {item.dias_mora}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-right font-medium text-black border-r border-b border-blue-100">{formatQ(item.monto_boleta)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.capital_restante)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.interes_restante)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.iva_12_restante)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.seguro_restante)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.gps_restante)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.membresias)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.interes_cube)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">{formatQ(item.iva_cube)}</TableCell>
+                      <TableCell className="text-right text-black border-r border-b border-blue-100">
+                        {item.cuota_min === 0 ? formatQ(item.royalti) : "--"}
+                      </TableCell>
+                      <TableCell className="text-right text-red-700 font-semibold bg-red-50/30 border-r border-b border-blue-100">
+                        {formatQ(item.mora)}
+                      </TableCell>
+                      <TableCell className="text-right text-green-700 font-bold bg-green-50/30 border-b border-blue-100">
+                        {formatQ(item.total_pagos_del_mes)}
+                      </TableCell>
+                    </TableRow>
+
+                    {/* Fila colapsable de detalle de abonos */}
+                    {expandedRow === item.credito_id && loadingDetails && (
+                      <TableRow className="bg-slate-50/50 hover:bg-slate-50/50">
+                        <TableCell colSpan={17} className="p-4 border-b border-blue-200">
+                          <div className="flex items-center justify-center py-6 text-xs text-blue-500 font-semibold gap-2">
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                            Cargando abonos...
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    )}
+
+                    {expandedRow === item.credito_id && !loadingDetails && abonosDetail.length === 0 && (
+                      <TableRow className="bg-slate-50/50 hover:bg-slate-50/50">
+                        <TableCell colSpan={17} className="p-4 border-b border-blue-200 text-center text-xs text-gray-500 italic">
+                          No se encontraron abonos registrados y validados en este mes para este crédito.
+                        </TableCell>
+                      </TableRow>
+                    )}
+
+                    {expandedRow === item.credito_id && !loadingDetails && abonosDetail.length > 0 && abonosDetail.map((abono) => (
+                      <TableRow 
+                        key={abono.pago_id} 
+                        className="bg-slate-50/20 hover:bg-blue-50/30 border-b border-blue-100/50 text-[11px] text-gray-600 transition-colors group"
+                      >
+                        {/* 1. SIFCO -> vacío */}
+                        <TableCell className="sticky left-0 bg-slate-50/90 group-hover:bg-[#f3f8ff] border-r border-b border-blue-100 min-w-[140px] w-[140px]" />
+                        
+                        {/* 2. Cliente -> vacío */}
+                        <TableCell className="sticky left-[140px] bg-slate-50/90 group-hover:bg-[#f3f8ff] border-r border-b border-blue-200 min-w-[220px] w-[220px] shadow-[3px_0_5px_-2px_rgba(0,0,0,0.05)]" />
+                        
+                        {/* 3. Asesor -> vacío */}
+                        <TableCell className="border-r border-b border-blue-100" />
+                        
+                        {/* 4. Cuotas -> vacío */}
+                        <TableCell className="border-r border-b border-blue-100" />
+                        
+                        {/* 5. Etapa de Mora -> vacío */}
+                        <TableCell className="border-r border-b border-blue-100" />
+                        
+                        {/* 6. Boletas Totales -> Monto Boleta */}
+                        <TableCell className="text-right font-semibold text-blue-900 border-r border-b border-blue-100 bg-blue-50/10">
+                          {formatQ(abono.monto_boleta)}
+                        </TableCell>
+                        
+                        {/* 7. Abono Capital */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.abono_capital)}
+                        </TableCell>
+                        
+                        {/* 8. Interés */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.abono_interes)}
+                        </TableCell>
+                        
+                        {/* 9. IVA 12% */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.abono_iva_12)}
+                        </TableCell>
+                        
+                        {/* 10. Seguro */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.abono_seguro)}
+                        </TableCell>
+                        
+                        {/* 11. GPS */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.abono_gps)}
+                        </TableCell>
+                        
+                        {/* 12. Membresías */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.membresias)}
+                        </TableCell>
+                        
+                        {/* 13. Int. CUBE */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.interes_cube)}
+                        </TableCell>
+                        
+                        {/* 14. IVA CUBE */}
+                        <TableCell className="text-right text-gray-600 border-r border-b border-blue-100">
+                          {formatQ(abono.iva_cube)}
+                        </TableCell>
+                        
+                        {/* 15. Royalty */}
+                        <TableCell className="text-right text-gray-400 border-r border-b border-blue-100">
+                          --
+                        </TableCell>
+                        
+                        {/* 16. Mora */}
+                        <TableCell className="text-right text-red-600 bg-red-50/10 border-r border-b border-blue-100">
+                          {formatQ(abono.mora)}
+                        </TableCell>
+                        
+                        {/* 17. Total Pagos Mes (Monto Aplicado) */}
+                        <TableCell className="text-right text-green-700 font-bold bg-green-50/10 border-b border-blue-100">
+                          {formatQ(abono.monto_aplicado)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </Fragment>
                 ))}
               </TableBody>
             </Table>

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3574,6 +3574,7 @@ export interface PagoPorVencimientoItem {
   total_pagos_del_mes: string;
   dias_mora: string;
   royalti: string;
+  mora: string;
 }
 
 export interface PagoPorVencimientoTotales {
@@ -3585,6 +3586,7 @@ export interface PagoPorVencimientoTotales {
   membresias: string;
   interes_cube: string;
   iva_cube: string;
+  mora: string;
 }
 
 export interface PagosPorVencimientoResponse {
@@ -3638,6 +3640,45 @@ export async function getPagosPorVencimiento(
           rango_mora: params.rango_mora,
         }),
         excel: params.excel,
+      },
+    }
+  );
+  return res.data;
+}
+
+export interface AbonoDetalleItem {
+  pago_id: number;
+  cuota_id: number | null;
+  cuota: string;
+  abono_capital: string;
+  abono_interes: string;
+  abono_iva_12: string;
+  abono_seguro: string;
+  abono_gps: string;
+  membresias: string;
+  interes_cube: string;
+  iva_cube: string;
+  mora: string;
+  otros: string;
+  monto_boleta: string;
+  monto_aplicado: string;
+  fecha_boleta: string;
+  fecha_pago: string;
+  numero_boleta: string | null;
+}
+
+export async function getAbonosPorVencimientoDetalle(params: {
+  credito_id: number;
+  mes: number;
+  anio: number;
+}): Promise<{ success: boolean; data: AbonoDetalleItem[] }> {
+  const res = await api.get<{ success: boolean; data: AbonoDetalleItem[] }>(
+    `${API_URL}/pagos-por-vencimiento/abonos`,
+    {
+      params: {
+        credito_id: params.credito_id.toString(),
+        mes: params.mes,
+        anio: params.anio,
       },
     }
   );

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3569,6 +3569,7 @@ export interface PagoPorVencimientoItem {
   gps_restante: string;
   membresias: string;
   monto_boleta: string;
+  monto_aplicado: string;
   interes_cube: string;
   iva_cube: string;
   total_pagos_del_mes: string;


### PR DESCRIPTION
  Summary
  
  - Recálculo dinámico de cuotas: La vista "Pagos por Vencimiento" ahora recalcula interés, IVA, abono capital y total del mes usando el saldo real del
  crédito al cierre del mes anterior (total_restante del último pago previo), en lugar de los valores snapshot almacenados en DB que se inflaban con pagos
  parciales múltiples.
  - Columna "Boletas Totales" corregida: Ahora muestra SUM(monto_aplicado) — el monto realmente aplicado al crédito — en lugar de SUM(monto_boleta) que
  incluía mora y otros conceptos externos.
  - Detalle de abonos al expandir: Al hacer clic en un crédito, se muestran los pagos individuales del mes con sus montos aplicados por rubro. La suma de
  monto_aplicado en el detalle coincide con el total de "Boletas Totales" del padre.
  - Export Excel mejorado: El Excel ahora incluye (1) fila de totales globales al inicio, (2) filas de detalle de cada pago debajo de su crédito —
  equivalente a la vista web con todo expandido. Optimizado con una sola query bulk para todos los créditos (evita timeout por N+1 queries).
  - Nuevo endpoint GET /pagos-por-vencimiento/abonos: retorna los pagos validados de un crédito en un mes/año dado.


<img width="1839" height="1003" alt="image" src="https://github.com/user-attachments/assets/824ae49f-0894-452d-9209-d3b857d6ab04" />
<img width="1903" height="961" alt="image" src="https://github.com/user-attachments/assets/2334b1a6-fb98-4f03-b7db-e47b8750dad6" />
