### PR TITLE
feat: add fecha_calculo parameter to calcularYRegistrarPagosEspejo an…

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -746,6 +746,7 @@ export async function insertPagosCreditoInversionistas(
       cuota: currentPago?.cuota ?? "0",
       estado_liquidacion: "NO_LIQUIDADO" as const,
       abono_capital_id: abonoCapitalId,
+      fecha_pago: fechaPeriodo ?? new Date(),
     };
 
     console.log(`   ✅ Resultado final para ${inv.nombre}:`, {

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -2193,7 +2193,7 @@ export async function obtenerCreditosConPagosPendientes(
  *
  * @param inversionistaId - ID del inversionista a procesar
  */
-export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
+export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fechaCalculo?: Date) {
   try {
     const rangoMesActual = obtenerRangoMesActual();
     console.log(
@@ -2202,6 +2202,9 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
     console.log(
       `📆 Mes actual: ${rangoMesActual.inicio} - ${rangoMesActual.fin}`
     );
+    if (fechaCalculo) {
+      console.log(`📅 Fecha de cálculo override: ${fechaCalculo.toISOString()}`);
+    }
 
     // ── PASO 1: Obtener créditos espejo del inversionista (ACTIVO/MOROSO/etc.) ──
     const creditosInversionista = await db
@@ -2331,7 +2334,8 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number) {
             false, // excludeCube
             false, // cuotaPagada
             false, // updateCredito ← omite el UPDATE a creditos_inversionistas_espejo
-            inversionistaId
+            inversionistaId,
+            fechaCalculo
           );
 
           console.log(

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -474,8 +474,7 @@ export async function insertPagosCreditoInversionistas(
 
     // fechaPeriodo: viene del front (fecha explícita del período a liquidar).
     // Fallback: fecha_vencimiento del pago registrado.
-    const fechaDelPeriodo = fechaPeriodo
-      ?? (currentPago?.fecha_vencimiento ? new Date(currentPago.fecha_vencimiento) : new Date());
+    const fechaDelPeriodo = fechaPeriodo ?? new Date();
 
     const periodoMes = fechaDelPeriodo.getMonth();
     const periodoAnio = fechaDelPeriodo.getFullYear();

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -2005,7 +2005,7 @@ export const inversionistasRouter = new Elysia()
     "/calcularPagosEspejo",
     async ({ body, set }) => {
       try {
-        const { inversionistaId, fecha_calculo } = body as any;
+        const { inversionistaId, fecha_calculo } = body;
 
         console.log(
           `\n🚀 POST /calcularPagosEspejo → inversionistaId: ${inversionistaId}, fecha_calculo: ${fecha_calculo ?? "no enviada"}`
@@ -2054,6 +2054,9 @@ export const inversionistasRouter = new Elysia()
           description: "ID del inversionista a procesar",
           minimum: 1,
         }),
+        fecha_calculo: t.Optional(t.String({
+          description: "Fecha ISO del período de cálculo (YYYY-MM-DD). Determina periodoMes/periodoAnio para la validación del histórico.",
+        })),
       }),
       response: {
         200: t.Object({

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -2005,13 +2005,14 @@ export const inversionistasRouter = new Elysia()
     "/calcularPagosEspejo",
     async ({ body, set }) => {
       try {
-        const { inversionistaId } = body;
+        const { inversionistaId, fecha_calculo } = body as any;
 
         console.log(
-          `\n🚀 POST /calcularPagosEspejo → inversionistaId: ${inversionistaId}`
+          `\n🚀 POST /calcularPagosEspejo → inversionistaId: ${inversionistaId}, fecha_calculo: ${fecha_calculo ?? "no enviada"}`
         );
 
-        const resultado = await calcularYRegistrarPagosEspejo(inversionistaId);
+        const fechaCalculoDate = fecha_calculo ? new Date(fecha_calculo) : undefined;
+        const resultado = await calcularYRegistrarPagosEspejo(inversionistaId, fechaCalculoDate);
 
         if (!resultado.success) {
           set.status = 500;

--- a/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
+++ b/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
@@ -422,7 +422,8 @@ export function HistorialLiquidaciones() {
       const inv = data?.find((d) => d.inversionista_id === inversionistaId);
       const nombre = inv?.nombre ?? `Inversionista #${inversionistaId}`;
       setGenerandoId(inversionistaId);
-      calcularPagosEspejo(inversionistaId, {
+      const fecha_calculo = new Date(anio, mes - 1, 1).toISOString().slice(0, 10);
+      calcularPagosEspejo({ inversionistaId, fecha_calculo }, {
         onSuccess: (res: any) => {
           setResultadoModal({
             nombre,

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -103,6 +103,11 @@ export function TableInvestors() {
   const [showSuccessRevertModal, setShowSuccessRevertModal] = useState(false);
   const [inversionistaARevertir, setInversionistaARevertir] = useState<number | null>(null);
 
+  // Modal calcular pagos — igual al de liquidar pero con fecha de cálculo
+  const [calcularModalTarget, setCalcularModalTarget] = useState<number | undefined>(undefined);
+  const showCalcularModal = calcularModalTarget !== undefined;
+  const [fechaCalculo, setFechaCalculo] = useState<string>(() => new Date().toISOString().slice(0, 10));
+
   // 🆕 Hook para calcular pagos espejo
   const { mutate: calcularPagosEspejo, isPending: isCalculando } =
     useCalcularPagosEspejo();
@@ -188,12 +193,12 @@ export function TableInvestors() {
   const handleConfirmarGenerarPagos = async () => {
     if (!selectedInversionista) return;
 
-    calcularPagosEspejo(selectedInversionista, {
+    calcularPagosEspejo({ inversionistaId: selectedInversionista, fecha_calculo: fechaCalculo }, {
       onSuccess: (data) => {
         if (data.success) {
           setShowGenerarPagosModal(false);
           setSelectedInversionista(null);
-          setIsDraft(true);   // ← activar modo borrador
+          setIsDraft(true);
           refetch();
           refetchTotales();
         }
@@ -204,13 +209,21 @@ export function TableInvestors() {
     });
   };
 
-  // 🚀 Cálculo directo sin modal (Nuevo flujo)
+  // Abre modal de confirmación con fecha para calcular pagos
   const handleCalcularPagosDirecto = (inversionistaId: number) => {
-    setSelectedInversionista(inversionistaId); // Para que el spinner se muestre en el row correcto
+    setCalcularModalTarget(inversionistaId);
+  };
 
-    calcularPagosEspejo(inversionistaId, {
+  // Ejecuta el cálculo tras confirmar fecha en el modal
+  const handleConfirmarCalcularPagos = () => {
+    if (calcularModalTarget === undefined) return;
+    const inversionistaId = calcularModalTarget;
+    setSelectedInversionista(inversionistaId);
+
+    calcularPagosEspejo({ inversionistaId, fecha_calculo: fechaCalculo }, {
       onSuccess: (data) => {
         if (data.success) {
+          setCalcularModalTarget(undefined);
           setIsDraft(true);
           setDraftInvestorId(inversionistaId);
           refetch();
@@ -232,6 +245,7 @@ export function TableInvestors() {
       onError: (error) => {
         console.error("❌ Error al calcular pagos:", error);
         alert(`Error al calcular pagos: ${error.message}`);
+        setCalcularModalTarget(undefined);
         setSelectedInversionista(null);
       },
     });
@@ -2331,6 +2345,57 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
             </DialogFooter>
           </DialogContent>
         </Dialog>
+        {/* Modal confirmar cálculo de pagos */}
+        <Dialog
+          open={showCalcularModal}
+          onOpenChange={(open) => { if (!open) setCalcularModalTarget(undefined); }}
+        >
+          <DialogContent className="bg-white dark:bg-gray-900 max-w-md">
+            <DialogHeader>
+              <DialogTitle className="text-purple-700 dark:text-purple-400 text-xl font-bold flex items-center gap-2">
+                <FileSpreadsheet className="h-5 w-5" />
+                Confirmar cálculo de pagos
+              </DialogTitle>
+              <DialogDescription className="space-y-4 pt-4">
+                <div className="space-y-2">
+                  <label className="block text-sm font-bold text-gray-700 dark:text-gray-300">
+                    Fecha del período de cálculo
+                  </label>
+                  <input
+                    type="date"
+                    value={fechaCalculo}
+                    onChange={(e) => setFechaCalculo(e.target.value)}
+                    className="w-full border border-purple-300 rounded-lg px-3 py-2 bg-purple-50 text-purple-900 focus:ring-2 focus:ring-purple-400 focus:outline-none"
+                  />
+                  <p className="text-xs text-gray-500">
+                    Esta fecha determina el período al que pertenece el cálculo de pagos espejo.
+                  </p>
+                </div>
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter className="gap-2 sm:gap-0 pt-4">
+              <button
+                className="px-4 py-2 rounded-lg bg-gray-200 hover:bg-gray-300 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-900 dark:text-gray-100 font-medium transition-colors disabled:opacity-50"
+                onClick={() => setCalcularModalTarget(undefined)}
+                disabled={isCalculando}
+              >
+                Cancelar
+              </button>
+              <button
+                className="px-4 py-2 rounded-lg bg-purple-600 hover:bg-purple-700 text-white font-bold transition-colors disabled:opacity-50 inline-flex items-center gap-2"
+                onClick={handleConfirmarCalcularPagos}
+                disabled={isCalculando}
+              >
+                {isCalculando ? (
+                  <><Loader2 className="h-4 w-4 animate-spin" /><span>Calculando...</span></>
+                ) : (
+                  <><FileSpreadsheet className="h-4 w-4" /><span>Confirmar</span></>
+                )}
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
         {/* Modal unificado de liquidación — individual o todos */}
         <Dialog
           open={showLiquidarModal}

--- a/apps/carteraFront/src/private/cartera/hooks/getInvestor.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/getInvestor.ts
@@ -289,8 +289,8 @@ export function useGetInvestorMirrorSummary(
 // ============================================================
 export function useCalcularPagosEspejo() {
   return useMutation({
-    mutationFn: (inversionistaId: number) =>
-      calcularPagosEspejoService(inversionistaId),
+    mutationFn: ({ inversionistaId, fecha_calculo }: { inversionistaId: number; fecha_calculo?: string }) =>
+      calcularPagosEspejoService(inversionistaId, fecha_calculo),
 
     onError: (error: Error) => console.error("❌ Error en calcularPagosEspejo:", error),
   });

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -972,11 +972,12 @@ export interface CalcularPagosEspejoResponse {
 }
 
 export async function calcularPagosEspejoService(
-  inversionistaId: number
+  inversionistaId: number,
+  fecha_calculo?: string
 ): Promise<CalcularPagosEspejoResponse> {
   const res = await api.post<CalcularPagosEspejoResponse>(
     `${import.meta.env.VITE_BACK_URL}/calcularPagosEspejo`,
-    { inversionistaId }
+    { inversionistaId, ...(fecha_calculo ? { fecha_calculo } : {}) }
   );
   return res.data;
 }


### PR DESCRIPTION
## Summary
- Add confirmation modal (matching liquidar UX) before executing "Calcular Pagos", allowing user to select the billing period date
- Pass `fecha_calculo` from frontend through service → hook → router → `calcularYRegistrarPagosEspejo` → `insertPagosCreditoInversionistas`
- `insertPagosCreditoInversionistas` now uses the explicit period date for `calcularAjusteCompras` and the `MONTO_ESPEJO_INCONSISTENTE` historical validation instead of falling back to `fecha_vencimiento`
- `HistorialLiquidaciones` automatically derives `fecha_calculo` from the selected `mes`/`anio` filter

## Test plan
- [ ] Click "Calcular Pagos" from investor dropdown → modal appears with today's date pre-filled
- [ ] Change date to a past month → confirm → backend uses that period for calculation and historical validation
- [ ] If `MONTO_ESPEJO_INCONSISTENTE` triggers, error surfaces correctly in the UI
- [ ] `HistorialLiquidaciones` "Generar Pagos" still works, uses selected mes/año automatically
- [ ] Liquidar modal unaffected