### PR TITLE
[codex] Fix cierre real date timezone

### DIFF
--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -14,6 +14,7 @@ import {
 import { Label } from "@/components/ui/label";
 import {
 	formatCurrency,
+	formatGuatemalaCalendarDate,
 	formatGuatemalaDate,
 	formatGuatemalaDateTime,
 	getClientTypeLabel,
@@ -295,7 +296,7 @@ export function LeadDetailModal({
 									</Label>
 									<p className="text-sm">
 										{displayLead.birthDate
-											? formatGuatemalaDate(displayLead.birthDate)
+											? formatGuatemalaCalendarDate(displayLead.birthDate)
 											: "No especificado"}
 									</p>
 								</div>

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -37,6 +37,7 @@ import {
 import { Label } from "@/components/ui/label";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
+	formatGuatemalaCalendarDate,
 	formatGuatemalaDate,
 	getContractTypeLabel,
 	getDocumentTypeLabel,
@@ -392,7 +393,7 @@ export function OpportunityDetailModal({
 									<div className="flex items-center gap-3">
 										<Calendar className="h-5 w-5 text-muted-foreground" />
 										<span className="font-medium">
-											{formatGuatemalaDate(opportunity.expectedCloseDate)}
+											{formatGuatemalaCalendarDate(opportunity.expectedCloseDate)}
 										</span>
 									</div>
 								</div>

--- a/apps/crm/apps/web/src/lib/crm-formatters.ts
+++ b/apps/crm/apps/web/src/lib/crm-formatters.ts
@@ -44,6 +44,16 @@ export const getStatusLabel = (status: string) => {
 
 export const formatGuatemalaDate = (date: string | Date) => {
 	return new Date(date).toLocaleDateString("es-GT", {
+		timeZone: "America/Guatemala",
+		day: "2-digit",
+		month: "2-digit",
+		year: "numeric",
+	});
+};
+
+export const formatGuatemalaCalendarDate = (date: string | Date) => {
+	return new Date(date).toLocaleDateString("es-GT", {
+		timeZone: "UTC",
 		day: "2-digit",
 		month: "2-digit",
 		year: "numeric",

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -87,6 +87,7 @@ import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import {
 	formatDate,
+	formatGuatemalaCalendarDate,
 	formatGuatemalaDate,
 	formatGuatemalaDateTime,
 	getContractTypeLabel,
@@ -2364,7 +2365,7 @@ function RouteComponent() {
 											<div className="flex items-center gap-3">
 												<Calendar className="h-5 w-5 text-muted-foreground" />
 												<span className="font-medium">
-													{formatGuatemalaDate(
+													{formatGuatemalaCalendarDate(
 														selectedOpportunity.expectedCloseDate,
 													)}
 												</span>


### PR DESCRIPTION
## Summary

- Keeps `formatGuatemalaDate` for real timestamp/instant values and renders them in `America/Guatemala`.
- Adds `formatGuatemalaCalendarDate` for date-only calendar values and renders them in UTC to avoid day shifts.
- Uses the calendar formatter only for `birthDate` and `expectedCloseDate` displays.

## Root Cause

`Cierre real` and other instant fields need timezone conversion to Guatemala, including exact-midnight instants like `2026-05-28T00:00:00.000Z` -> `27/05/2026`. Date-only values like birth dates and expected close dates are calendar selections stored as UTC midnight, so those need UTC calendar rendering instead of Guatemala conversion.

## Validation

- Confirmed Kendel Cancinos has `actual_close_date` stored as `2026-05-28 01:34:19`, which converts to `2026-05-27 19:34:19` in Guatemala.
- Verified formatter behavior:
  - instant `2026-05-28T00:00:00.000Z` -> `27/05/2026`
  - instant `2026-05-28T01:34:19.416Z` -> `27/05/2026`
  - calendar `2024-02-15T00:00:00.000Z` -> `15/02/2024`
  - calendar `2024-02-15` -> `15/02/2024`
- `bun run check-types` passed in `apps/crm/apps/web`.