### PR TITLE
feat: desglose interes proporcional sin/con compras del mes anterior

### DIFF
--- a/apps/cartera-back/drizzle/0005_add_pago_espejo_proporcional_compras.sql
+++ b/apps/cartera-back/drizzle/0005_add_pago_espejo_proporcional_compras.sql
@@ -1,0 +1,19 @@
+-- Desglosa el interés/IVA del pago espejo cuando el inversionista entró en el
+-- mes anterior y, dentro de ese mismo crédito, hizo una o varias compras
+-- (tipo_operacion = 'compra_cartera', status = 'completado') en ese mes.
+--
+-- abono_interes_sin_compras / abono_iva_12_sin_compras:
+--   Parte del monto que ya tenía en el crédito ANTES de las compras del mes
+--   (cobra interés mensual completo, sin prorratear).
+--
+-- abono_interes_con_compras / abono_iva_12_con_compras:
+--   Parte aportada por las compras nuevas del mes (cobra interés proporcional
+--   por los días restantes del mes desde fecha_inicio_participacion).
+--
+-- abono_interes / abono_iva_12 siguen siendo la suma de ambos componentes;
+-- las nuevas columnas solo dejan rastro del desglose para auditoría.
+ALTER TABLE cartera.pagos_credito_inversionistas_espejo
+  ADD COLUMN IF NOT EXISTS abono_interes_sin_compras NUMERIC(18, 10),
+  ADD COLUMN IF NOT EXISTS abono_interes_con_compras NUMERIC(18, 10),
+  ADD COLUMN IF NOT EXISTS abono_iva_12_sin_compras  NUMERIC(18, 2),
+  ADD COLUMN IF NOT EXISTS abono_iva_12_con_compras  NUMERIC(18, 2);

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -23,7 +23,7 @@ import {
   processAndReplaceCreditInvestorsReverse,
 } from "./investor";
 import { updateMora } from "./latefee";
-import { calcularAjusteCompras } from "../utils/comprasAjuste";
+import { calcularAjusteCompras, obtenerSumaComprasMesAnterior } from "../utils/comprasAjuste";
 import { t } from "elysia";
 export const pagoSchema = z.object({
   credito_id: z.number().int().positive(),
@@ -532,15 +532,12 @@ export async function insertPagosCreditoInversionistas(
     const fechaInicio = inv.fecha_inicio_participacion
       ? new Date(inv.fecha_inicio_participacion + "T00:00:00")
       : null;
-    // Usar hora de Guatemala (UTC-6) en lugar de la hora del servidor
-    const fechaPago = new Date(
-      new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
-    );
 
-    const mesAnterior = fechaPago.getMonth() === 0 ? 11 : fechaPago.getMonth() - 1;
-    const anioMesAnterior = fechaPago.getMonth() === 0
-      ? fechaPago.getFullYear() - 1
-      : fechaPago.getFullYear();
+    // Comparar contra la fecha del PERÍODO que se está liquidando (no contra "hoy").
+    const mesAnterior = fechaDelPeriodo.getMonth() === 0 ? 11 : fechaDelPeriodo.getMonth() - 1;
+    const anioMesAnterior = fechaDelPeriodo.getMonth() === 0
+      ? fechaDelPeriodo.getFullYear() - 1
+      : fechaDelPeriodo.getFullYear();
 
     const esMesAnterior =
       !isCube &&
@@ -550,6 +547,11 @@ export async function insertPagosCreditoInversionistas(
 
     let bigInteres: Big;
     let bigIVA: Big;
+    // Desglose para auditoría: solo se setea cuando hay compras del mes anterior.
+    let interesSinCompras: Big | null = null;
+    let interesConCompras: Big | null = null;
+    let ivaSinCompras: Big | null = null;
+    let ivaConCompras: Big | null = null;
 
     if (esMesAnterior) {
       // Días totales del mes de la fecha de inicio (ej: enero = 31)
@@ -561,22 +563,86 @@ export async function insertPagosCreditoInversionistas(
       const diaInicio = fechaInicio!.getDate(); // ej: 7
       const diasProporcionales = diasDelMes - diaInicio; // ej: 31 - 7 = 24 días restantes
 
-      // Interés proporcional = (montoInversionistaCalc / diasDelMes) * diasProporcionales
-      bigInteres = montoInversionistaCalc
-        .div(diasDelMes)
-        .times(diasProporcionales)
-        .round(2);
+      // ¿El inversionista ya era partícipe y además hizo compras este mes?
+      // Buscamos compras de tipo 'compra_cartera' completadas en el mes anterior.
+      const sumaCompras = await obtenerSumaComprasMesAnterior(
+        credito_id,
+        inv.inversionista_id,
+        fechaDelPeriodo,
+      );
 
-      // IVA proporcional = interés proporcional * 12%
-      bigIVA = bigInteres.times(0.12).round(2);
+      const montoAportadoBig = new Big(inv.monto_aportado || 0);
+      // monto viejo = lo que ya tenía antes de las compras del mes (cobra mes completo).
+      // Si las compras igualan o superan el espejo, queda 0 → actúa como hoy (todo proporcional).
+      const montoViejo = montoAportadoBig.minus(sumaCompras);
 
-      console.log(`   📅 INTERÉS PROPORCIONAL:`);
-      console.log(`      fecha_inicio: ${inv.fecha_inicio_participacion}`);
-      console.log(`      días del mes: ${diasDelMes}`);
-      console.log(`      día inicio: ${diaInicio}`);
-      console.log(`      días proporcionales: ${diasProporcionales}`);
-      console.log(`      interés proporcional: ${bigInteres.toString()}`);
-      console.log(`      IVA proporcional: ${bigIVA.toString()}`);
+      if (sumaCompras.gt(montoAportadoBig)) {
+        console.warn(
+          `   ⚠️  [COMPRAS_EXCEDEN_MONTO_ESPEJO] Inv ${inv.inversionista_id} Cred ${credito_id}: ` +
+          `suma_compras_mes_anterior (${sumaCompras.toFixed(8)}) > monto_aportado_espejo (${montoAportadoBig.toFixed(8)}). ` +
+          `Se trata como caso proporcional puro (sin desglose sin/con compras).`
+        );
+      }
+
+      const hayMontoViejo = sumaCompras.gt(0) && montoViejo.gt(0);
+
+      const porcentajeInteresBig = new Big(currentCredit?.porcentaje_interes ?? 0);
+
+      if (hayMontoViejo) {
+        // Tarifa mensual completa sobre el monto viejo.
+        interesSinCompras = montoViejo
+          .times(porcentajeInteresBig)
+          .div(100)
+          .times(porcentajeInversion)
+          .div(100)
+          .round(2);
+
+        // Proporcional sobre lo aportado por las compras del mes.
+        interesConCompras = sumaCompras
+          .times(porcentajeInteresBig)
+          .div(100)
+          .times(porcentajeInversion)
+          .div(100)
+          .times(diasProporcionales)
+          .div(diasDelMes)
+          .round(2);
+
+        ivaSinCompras = interesSinCompras.gt(0)
+          ? interesSinCompras.times(0.12).round(2)
+          : new Big(0);
+        ivaConCompras = interesConCompras.gt(0)
+          ? interesConCompras.times(0.12).round(2)
+          : new Big(0);
+
+        bigInteres = interesSinCompras.plus(interesConCompras);
+        bigIVA = ivaSinCompras.plus(ivaConCompras);
+
+        console.log(`   📅 INTERÉS PROPORCIONAL CON COMPRAS DEL MES ANTERIOR:`);
+        console.log(`      fecha_inicio: ${inv.fecha_inicio_participacion}`);
+        console.log(`      días del mes: ${diasDelMes}, días proporcionales: ${diasProporcionales}`);
+        console.log(`      monto_aportado espejo: ${montoAportadoBig.toString()}`);
+        console.log(`      suma compras mes anterior: ${sumaCompras.toString()}`);
+        console.log(`      monto viejo (mes completo): ${montoViejo.toString()}`);
+        console.log(`      interes_sin_compras: ${interesSinCompras.toString()}`);
+        console.log(`      interes_con_compras: ${interesConCompras.toString()}`);
+        console.log(`      iva_sin_compras: ${ivaSinCompras.toString()}`);
+        console.log(`      iva_con_compras: ${ivaConCompras.toString()}`);
+        console.log(`      bigInteres total: ${bigInteres.toString()}`);
+        console.log(`      bigIVA total: ${bigIVA.toString()}`);
+      } else {
+        // Sin compras del mes anterior (o compras ≥ monto aportado): todo proporcional como hoy.
+        bigInteres = montoInversionistaCalc
+          .div(diasDelMes)
+          .times(diasProporcionales)
+          .round(2);
+        bigIVA = bigInteres.times(0.12).round(2);
+
+        console.log(`   📅 INTERÉS PROPORCIONAL (sin compras separables):`);
+        console.log(`      fecha_inicio: ${inv.fecha_inicio_participacion}`);
+        console.log(`      días del mes: ${diasDelMes}, días proporcionales: ${diasProporcionales}`);
+        console.log(`      interés proporcional: ${bigInteres.toString()}`);
+        console.log(`      IVA proporcional: ${bigIVA.toString()}`);
+      }
     } else {
       bigInteres = isCube ? montoCashInCalc : montoInversionistaCalc;
       bigIVA = isCube ? ivaCashInCalc : ivaInversionistaCalc;
@@ -746,6 +812,10 @@ export async function insertPagosCreditoInversionistas(
       abono_capital: abono_capital.toString(),
       abono_interes: bigInteres.toString(),
       abono_iva_12: bigIVA.toString(),
+      abono_interes_sin_compras: interesSinCompras?.toString() ?? null,
+      abono_interes_con_compras: interesConCompras?.toString() ?? null,
+      abono_iva_12_sin_compras: ivaSinCompras?.toString() ?? null,
+      abono_iva_12_con_compras: ivaConCompras?.toString() ?? null,
       porcentaje_participacion: isCube
         ? inv.porcentaje_cash_in
         : inv.porcentaje_participacion_inversionista,

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -647,6 +647,27 @@
         .default("NO_LIQUIDADO"),
       cuota: numeric("cuota", { precision: 18, scale: 2 }).notNull(),
 
+      // Desglose del interés/IVA cuando hay compras en el mes anterior.
+      // _sin_compras: parte que el inversionista ya tenía → interés mensual completo.
+      // _con_compras: parte aportada por compras del mes → interés proporcional.
+      // abono_interes / abono_iva_12 siguen siendo la suma de ambos.
+      abono_interes_sin_compras: numeric("abono_interes_sin_compras", {
+        precision: 18,
+        scale: 10,
+      }),
+      abono_interes_con_compras: numeric("abono_interes_con_compras", {
+        precision: 18,
+        scale: 10,
+      }),
+      abono_iva_12_sin_compras: numeric("abono_iva_12_sin_compras", {
+        precision: 18,
+        scale: 2,
+      }),
+      abono_iva_12_con_compras: numeric("abono_iva_12_con_compras", {
+        precision: 18,
+        scale: 2,
+      }),
+
       // FK al abono a capital asociado (nullable)
       abono_capital_id: integer("abono_capital_id").references(
         () => abonos_capital.abono_id,

--- a/apps/cartera-back/src/utils/comprasAjuste.ts
+++ b/apps/cartera-back/src/utils/comprasAjuste.ts
@@ -1,6 +1,6 @@
 import { db } from "../database/index";
 import { compras_credito_inversionista } from "../database/db/schema";
-import { and, eq, desc, inArray } from "drizzle-orm";
+import { and, eq, desc, gte, inArray, lt } from "drizzle-orm";
 import Big from "big.js";
 
 export interface AjusteCompras {
@@ -83,4 +83,47 @@ export async function calcularAjusteCompras(
   }
 
   return { montoRestarValidacion, montoRestarCalculo };
+}
+
+/**
+ * Suma los monto_aportado de las compras de cartera (tipo_operacion = 'compra_cartera',
+ * status = 'completado') que el inversionista hizo sobre el crédito durante el
+ * MES ANTERIOR a `fechaPeriodo`, filtradas por `updated_at`.
+ *
+ * Excluye reinversiones y compras pendientes — solo cuentan las compras nuevas
+ * de cartera ya completadas que se sumaron al monto_aportado del espejo durante
+ * ese mes. Sirve para separar la parte "vieja" del monto (interés mensual completo)
+ * de la parte aportada por estas compras (interés proporcional).
+ */
+export async function obtenerSumaComprasMesAnterior(
+  credito_id: number,
+  inversionista_id: number,
+  fechaPeriodo: Date,
+): Promise<Big> {
+  const mes = fechaPeriodo.getMonth();
+  const anio = fechaPeriodo.getFullYear();
+  const mesAnterior = mes === 0 ? 11 : mes - 1;
+  const anioMesAnterior = mes === 0 ? anio - 1 : anio;
+
+  const inicioMesAnterior = new Date(anioMesAnterior, mesAnterior, 1);
+  const inicioMesActual = new Date(anio, mes, 1);
+
+  const compras = await db
+    .select({ monto_aportado: compras_credito_inversionista.monto_aportado })
+    .from(compras_credito_inversionista)
+    .where(
+      and(
+        eq(compras_credito_inversionista.credito_id, credito_id),
+        eq(compras_credito_inversionista.inversionista_id, inversionista_id),
+        eq(compras_credito_inversionista.tipo_operacion, "compra_cartera"),
+        eq(compras_credito_inversionista.status, "completado"),
+        gte(compras_credito_inversionista.updated_at, inicioMesAnterior),
+        lt(compras_credito_inversionista.updated_at, inicioMesActual),
+      ),
+    );
+
+  return compras.reduce(
+    (acc, c) => acc.plus(new Big(c.monto_aportado ?? 0)),
+    new Big(0),
+  );
 }


### PR DESCRIPTION
## Resumen

Cuando un inversionista entra a un crédito en el **mes anterior** al período liquidado (caso que ya disparaba el cálculo proporcional) y ADEMÁS hizo **compras de cartera completadas** durante ese mes, hoy el sistema prorrateaba el interés sobre el `monto_aportado` completo del espejo. Eso ignora que la parte que el inversionista ya tenía **antes** de las compras tiene derecho a la tarifa mensual completa, no a la proporcional.

Este PR separa el cálculo en dos componentes y deja registro del desglose en la tabla `pagos_credito_inversionistas_espejo`.

## Ejemplo concreto

Supongamos:
- Inversionista entra al crédito en **mayo** (`fecha_inicio_participacion = 2026-05-07`).
- Ya tenía **Q10,000** en el crédito desde antes (compras viejas, históricas).
- El **día 7 de mayo** hizo una compra adicional de **Q15,000**.
- El espejo queda con `monto_aportado = Q25,000`.
- Cuando se calculan pagos para **junio**, se dispara el proporcional (mayo = mes anterior).
- Crédito con `porcentaje_interes = 5%`, inversionista con `porcentaje_participacion = 100%`.
- Mayo tiene 31 días, fecha de inicio día 7 → `diasProporcionales = 31 - 7 = 24`.

### Antes (bug)
```
montoInversionistaCalc = 25,000 × 5% × 100% = Q1,250
bigInteres = 1,250 / 31 × 24 = Q967.74
```
Se prorratean los Q25k completos. Los Q10k que ya estaban (con derecho a mes entero) se subpagan.

### Ahora
```
sumaCompras  = 15,000          ← compras_credito_inversionista (mayo, completadas, compra_cartera)
montoViejo   = 25,000 - 15,000 = 10,000

interesSinCompras = 10,000 × 5% × 100%             = Q500.00     ← mensual completo
interesConCompras = 15,000 × 5% × 100% × (24/31)   = Q580.65     ← proporcional

abono_interes = 500.00 + 580.65 = Q1,080.65
abono_iva_12  = (500 + 580.65) × 12% = Q129.68
```

El inversionista cobra **Q112.91 más** de interés en este caso. Las columnas `abono_interes_sin_compras = 500.00` y `abono_interes_con_compras = 580.65` quedan registradas en la fila del pago espejo para auditoría.

## Casos cubiertos

| Caso | Comportamiento |
|---|---|
| `sumaCompras = 0` (no hubo compras del mes anterior) | Igual que hoy — todo proporcional sobre `montoInversionistaCalc`. Las 4 columnas nuevas quedan NULL. |
| `sumaCompras > 0` y `montoViejo > 0` (caso del ejemplo) | Cálculo dual. Las 4 columnas se guardan. |
| `sumaCompras = monto_aportado` (las compras son todo lo aportado) | `montoViejo = 0` → todo proporcional como hoy. |
| `sumaCompras > monto_aportado` (inconsistencia) | `console.warn` con datos + cae al caso "todo proporcional" — no falla. En la buena teoría no debería pasar (otras validaciones del flujo lo cazarían antes), pero queda el log defensivo. |
| `!esMesAnterior` | Sin cambios — flujo normal. |
| `isCube` | Sin cambios — Cube nunca prorratea. |

## Cambios

### 1. Migration `drizzle/0005_add_pago_espejo_proporcional_compras.sql`
Agrega 4 columnas nullable a `cartera.pagos_credito_inversionistas_espejo`:
- `abono_interes_sin_compras NUMERIC(18, 10)`
- `abono_interes_con_compras NUMERIC(18, 10)`
- `abono_iva_12_sin_compras NUMERIC(18, 2)`
- `abono_iva_12_con_compras NUMERIC(18, 2)`

### 2. `schema.ts`
Refleja las 4 columnas en la definición Drizzle.

### 3. `utils/comprasAjuste.ts` — helper `obtenerSumaComprasMesAnterior`
Suma `monto_aportado` de compras filtradas por:
- `credito_id` + `inversionista_id`
- `tipo_operacion = 'compra_cartera'` (excluye reinversión)
- `status = 'completado'` (excluye pendientes — esas todavía no actualizaron `fecha_inicio_participacion`)
- `updated_at` dentro del **mes anterior** a `fechaPeriodo`

No reusamos `calcularAjusteCompras` porque ese ahora incluye reinversiones y maneja casos 2/3 con lógica distinta.

### 4. `controllers/payments.ts` — `insertPagosCreditoInversionistas`
Dos cambios:

**(a)** `esMesAnterior` ahora se compara contra `fechaDelPeriodo` (la fecha del período liquidado), no contra `new Date()` ("hoy"). Era un fix pendiente del PR #757 — incluido acá porque está en el mismo bloque.

**(b)** Bloque proporcional reescrito con lógica dual sin/con compras (ver pseudocódigo del ejemplo arriba).

## Test plan
- [ ] Correr migration `0005_add_pago_espejo_proporcional_compras.sql` (manual).
- [ ] Calcular pagos para un inversionista que **entró el mes anterior** y **no tiene compras** del mes anterior → resultado idéntico al de hoy, las 4 columnas en NULL.
- [ ] Calcular pagos para un inversionista que **entró el mes anterior** y **sí tiene compras** del mes anterior → `abono_interes` = suma del desglose, las 4 columnas con valor.
- [ ] Caso borde: `sumaCompras = monto_aportado` → resultado igual al actual.
- [ ] Caso borde: inversionista que entró este mes (no el anterior) → no aplica proporcional ni dual.
- [ ] Inversionista Cube → sigue sin proporcional ni dual.

## Notas
- El IVA se calcula sobre cada componente por separado (`ivaSinCompras = interesSinCompras × 0.12`, idem `ivaConCompras`). La suma `abono_iva_12` puede diferir en centavos vs `abono_interes × 0.12` por redondeo, pero deja claro el origen.
- Las 4 columnas nuevas son nullable. Registros viejos / casos sin desglose quedan NULL, así no hay que rellenar nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)