### PR TITLE
feat: optimize resumenGlobalLiquidaciones by using Promise.all for co…

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -7278,10 +7278,29 @@ export async function resumenGlobalLiquidaciones(
     const idsSinMovimiento = todos
       .filter((inv) => !idsConMovimiento.has(inv.inversionista_id))
       .map((inv) => inv.inversionista_id);
-    const cuentasExtraSinMovMap = await getCuentasExtraMap(idsSinMovimiento);
+
+    const [cuentasExtraSinMovMap, creditosRows, creditosEspejoRows] = await Promise.all([
+      getCuentasExtraMap(idsSinMovimiento),
+      idsSinMovimiento.length > 0
+        ? db.select({ inversionista_id: creditos_inversionistas.inversionista_id })
+            .from(creditos_inversionistas)
+            .where(inArray(creditos_inversionistas.inversionista_id, idsSinMovimiento))
+        : Promise.resolve([]),
+      idsSinMovimiento.length > 0
+        ? db.select({ inversionista_id: creditos_inversionistas_espejo.inversionista_id })
+            .from(creditos_inversionistas_espejo)
+            .where(inArray(creditos_inversionistas_espejo.inversionista_id, idsSinMovimiento))
+        : Promise.resolve([]),
+    ]);
+
+    const conCreditosSet = new Set<number>([
+      ...creditosRows.map((r) => r.inversionista_id),
+      ...creditosEspejoRows.map((r) => r.inversionista_id),
+    ]);
 
     for (const inv of todos) {
       if (idsConMovimiento.has(inv.inversionista_id)) continue;
+      if (!conCreditosSet.has(inv.inversionista_id)) continue;
 
       const stub: InversionistaResumenRow = {
         inversionista_id: inv.inversionista_id,


### PR DESCRIPTION
Summary
Investors without credits are now hidden from the gallery. Previously, all investors marked as sin_movimiento appeared in the Liquidaciones view regardless of whether they had any associated credits. Now the backend filters them out — if an investor has no records in either credito_inversionistas or credito_inversionistas_espejo, they are excluded from the response entirely.

"Generar Pagos" is no longer locked to the current month. The button was previously hidden when browsing past or future months. It now appears for any month, allowing payment generation for historical periods.

Payment generation uses the selected month's date automatically. When clicking "Generar Pagos", the system sends {anio}-{mes}-01 (the first day of the month shown in the selector) as fecha_calculo — no manual date input required.

Test plan
 Navigate to Liquidaciones, switch to a past month (e.g. Abril 2026) — "Generar Pagos" button still appears
 Click "Generar Pagos" — payments are generated for the 1st of that month, not today
 Confirm investors with zero credits in both tables do not appear in the gallery
 Investors with credits in either credito_inversionistas OR credito_inversionistas_espejo still appear normally
 Investors with pending, uploaded, or liquidated status are unaffected