### PR TITLE
Add source handling and improve proposed amount field validation

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1891,6 +1891,18 @@ export const crmRouter = {
 				}
 			}
 
+			// If lead is being changed and no explicit source provided, copy source from new lead
+			if (input.leadId && !updateData.source) {
+				const newLead = await db
+					.select({ source: leads.source })
+					.from(leads)
+					.where(eq(leads.id, input.leadId))
+					.limit(1);
+				if (newLead[0]?.source) {
+					updateData.source = newLead[0].source;
+				}
+			}
+
 			const updatedOpportunity = await db
 				.update(opportunities)
 				.set({

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1891,8 +1891,8 @@ export const crmRouter = {
 				}
 			}
 
-			// If lead is being changed and no explicit source provided, copy source from new lead
-			if (input.leadId && !updateData.source) {
+			// If lead is being changed (not just preserved) and no explicit source provided, copy source from new lead
+			if (input.leadId && input.leadId !== currentOpportunity[0].leadId && !updateData.source) {
 				const newLead = await db
 					.select({ source: leads.source })
 					.from(leads)

--- a/apps/crm/apps/web/src/lib/opportunities/columns.tsx
+++ b/apps/crm/apps/web/src/lib/opportunities/columns.tsx
@@ -7,6 +7,8 @@ import {
 	formatDate,
 	formatGuatemalaDate,
 	formatGuatemalaDateTime,
+	getLeadSourceBadgeClass,
+	getSourceLabel,
 	getStatusLabel,
 } from "@/lib/crm-formatters";
 import type { client } from "@/utils/orpc";
@@ -144,6 +146,37 @@ export const opportunitiesColumns: ColumnDef<Opportunity>[] = [
 			const a = rowA.original.stage?.closurePercentage ?? 0;
 			const b = rowB.original.stage?.closurePercentage ?? 0;
 			return a - b;
+		},
+	},
+	{
+		accessorKey: "source",
+		header: "Canal",
+		cell: ({ row }) => {
+			const source = row.original.source;
+			if (!source) return <span className="text-muted-foreground">—</span>;
+			return (
+				<Badge className={getLeadSourceBadgeClass(source)} variant="outline">
+					{getSourceLabel(source)}
+				</Badge>
+			);
+		},
+	},
+	{
+		accessorKey: "creditType",
+		header: "Tipo de Crédito",
+		cell: ({ row }) => {
+			const creditType = row.original.creditType;
+			const label =
+				creditType === "sobre_vehiculo" ? "Sobre Vehículo" : "Autocompra";
+			const className =
+				creditType === "sobre_vehiculo"
+					? "bg-purple-100 text-purple-800"
+					: "bg-sky-100 text-sky-800";
+			return (
+				<Badge className={className} variant="outline">
+					{label}
+				</Badge>
+			);
 		},
 	},
 	{

--- a/apps/portal-web/src/features/LeadInvestor/components/FormularioInvestor.tsx
+++ b/apps/portal-web/src/features/LeadInvestor/components/FormularioInvestor.tsx
@@ -236,7 +236,7 @@ export const FormularioInvestor = ({
               setFieldValue("proposedAmount", value);
               setFieldTouched("proposedAmount", true, false);
             }}
-            placeholder="Monto propuesto"
+            placeholder="Monto a Invertir"
             variant="secondary"
           />
           {touched.proposedAmount && errors.proposedAmount && (

--- a/apps/portal-web/src/features/LeadInvestor/hooks/useFormInvestor.ts
+++ b/apps/portal-web/src/features/LeadInvestor/hooks/useFormInvestor.ts
@@ -69,7 +69,7 @@ const validationSchema = Yup.object({
     })
     .required("El número telefónico es requerido"),
   experiencia: Yup.string().required("Selecciona tu experiencia en inversión"),
-  proposedAmount: Yup.string().required("Selecciona un monto propuesto"),
+  proposedAmount: Yup.string().required("Selecciona un monto a invertir"),
   mensaje: Yup.string(),
 });
 


### PR DESCRIPTION
CRM — apps/crm
1. Nuevas columnas en la tabla de oportunidades (columns.tsx)
    - Se agregó la columna Canal (source) con badge colorido por fuente usando getLeadSourceBadgeClass y getSourceLabel.
    - Se agregó la columna Tipo de Crédito (creditType) con badge diferenciado: azul para "Autocompra" y púrpura para "Sobre Vehículo".
    - Ambas columnas se ubican entre Etapa y Valor

2. Fix: propagación de source al editar oportunidad (crm.ts)
    - Se corrigió updateOpportunity para que al asignar o cambiar el lead de una oportunidad, se copie automáticamente el source del nuevo lead si no se envió uno explícito. Esto iguala el comportamiento que ya existía en createOpportunity y resuelve dos casos: oportunidades creadas sin lead a las que luego se les asigna uno, y oportunidades cuyo lead se cambia posteriormente.

Portal Web — apps/portal-web
1. Renombrar campo del formulario de inversión (FormularioInvestor.tsx)
    - Se cambió el placeholder del campo de monto de "Monto propuesto" a "Monto a Invertir" para mayor claridad para el usuario.

2. Actualización del mensaje de validación (useFormInvestor.ts))
    - Se actualizó el mensaje de error de validación de "Selecciona un monto propuesto" a "Selecciona un monto a invertir" para ser consistente con el cambio anterior.