### PR TITLE
feat(liquidacion): validar que el abono a capital no supere el saldo del inversionista en espejo

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3711,6 +3711,20 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
 
           const currentMonto = espejoRow?.monto_aportado ?? "0";
 
+          // Validation: abono capital no puede superar el capital del inversionista en el crédito
+          if (sumaCapitalBig.gt(new Big(currentMonto))) {
+            const [creditoRowAbono] = await tx
+              .select({ sifco: creditos.numero_credito_sifco })
+              .from(creditos)
+              .where(eq(creditos.credito_id, creditoId))
+              .limit(1);
+            const sifcoAbono = creditoRowAbono?.sifco ?? `ID:${creditoId}`;
+            throw new Error(
+              `[ABONO_SUPERA_CAPITAL] Crédito SIFCO ${sifcoAbono} (Inv ${inv_id}): ` +
+              `abono capital (${sumaCapitalBig.toFixed(2)}) supera capital en espejo (${new Big(currentMonto).toFixed(2)})`
+            );
+          }
+
           // Validation 3 (cuadre): espejo ajustado por compras nuevas == histórico
           const [lastHistorico] = await tx
             .select({


### PR DESCRIPTION
## Contexto

Durante el proceso de liquidación espejo, al calcular los pagos de capital
por crédito, no existía una validación que impidiera que la suma de
`abono_capital` superara el `monto_aportado` actual del inversionista en
`creditos_inversionistas_espejo`. Esto podría resultar en un saldo negativo
después de ejecutar `processAndReplaceCreditInvestors`.

## Cambio

Se agregó una validación dentro de la transacción de BD (antes de reducir
el saldo espejo) que lanza `[ABONO_SUPERA_CAPITAL]` si el total de abono
capital para un crédito supera el saldo actual del inversionista en espejo.

Al estar dentro del `db.transaction`, cualquier fallo genera un rollback
total — no se persiste ningún estado parcial para ese inversionista.

Formato del error:
`[ABONO_SUPERA_CAPITAL] Crédito SIFCO {sifco} (Inv {id}): abono capital ({X}) supera capital en espejo ({Y})`

## Comportamiento al fallar

- La transacción hace rollback completo para el inversionista afectado
- El error queda registrado en el array `errores[]` de la respuesta
- Los demás inversionistas del batch siguen procesándose con normalidad
