### PR TITLE
fix: normalizar fechaPeriodo del endpoint /calcularPagosEspejo para evitar off-by-one por TZ

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -472,9 +472,18 @@ export async function insertPagosCreditoInversionistas(
       .orderBy(desc(historico_liquidaciones_espejo.fecha))
       .limit(1);
 
-    // fechaPeriodo: viene del front (fecha explícita del período a liquidar).
-    // Fallback: fecha_vencimiento del pago registrado.
-    const fechaDelPeriodo = fechaPeriodo ?? new Date();
+    // fechaPeriodo viene del front (fecha explícita del período a liquidar).
+    // Normalización: si llega como "2026-06-01" → new Date() lo parsea UTC 00:00,
+    // que en hora local GT (UTC-6) es "2026-05-31 18:00" y getMonth() devuelve mayo.
+    // Reconstruimos a partir del día calendario UTC para anclar el mes correcto
+    // en hora local sin importar el TZ del server.
+    const fechaDelPeriodo = fechaPeriodo
+      ? new Date(
+          fechaPeriodo.getUTCFullYear(),
+          fechaPeriodo.getUTCMonth(),
+          fechaPeriodo.getUTCDate(),
+        )
+      : new Date();
 
     const periodoMes = fechaDelPeriodo.getMonth();
     const periodoAnio = fechaDelPeriodo.getFullYear();
@@ -822,7 +831,7 @@ export async function insertPagosCreditoInversionistas(
       cuota: currentPago?.cuota ?? "0",
       estado_liquidacion: "NO_LIQUIDADO" as const,
       abono_capital_id: abonoCapitalId,
-      fecha_pago: fechaPeriodo ?? new Date(),
+      fecha_pago: fechaDelPeriodo,
     };
 
     console.log(`   ✅ Resultado final para ${inv.nombre}:`, {


### PR DESCRIPTION
## Summary

Bug en \`/calcularPagosEspejo\` cuando el front manda \`fecha_calculo=\"YYYY-MM-DD\"\`:

\`new Date(\"2026-06-01\")\` parsea como **UTC 00:00**. En hora local de Guatemala (UTC-6) eso es \`\"2026-05-31 18:00\"\`, y \`getMonth()\` devuelve **mayo**, no junio. Resultado: \`esMesAnterior\` compara contra el mes equivocado y dispara cálculo proporcional indebidamente.

### Caso real reproducido

Front mandó \`fecha_calculo=2026-06-01\` para el inversionista 9, crédito 380:

\`\`\`
fechaPeriodo recibida: 2026-06-01T00:00:00.000Z
fechaDelPeriodo usada: 2026-06-01T00:00:00.000Z | mes=4 año=2026   ← bug
mesAnterior esperado: 3 | anioMesAnterior: 2026
fecha_inicio_participacion: 2026-04-17 | mes=3 año=2026
esMesAnterior: true   ← INCORRECTO (debería ser false)
\`\`\`

El crédito facturó proporcional aunque el inversionista entró en abril (no en el mes anterior a junio).

## Fix

Normalizamos \`fechaDelPeriodo\` reconstruyendo desde el día calendario UTC para anclar el mes correcto en hora local sin importar el TZ del server:

\`\`\`ts
const fechaDelPeriodo = fechaPeriodo
  ? new Date(
      fechaPeriodo.getUTCFullYear(),
      fechaPeriodo.getUTCMonth(),
      fechaPeriodo.getUTCDate(),
    )
  : new Date();
\`\`\`

Así \`2026-06-01T00:00Z\` → \`2026-06-01 00:00 LOCAL\` → \`getMonth()\` da junio (5) correctamente.

### Cobertura: TODOS los usos de la fecha del endpoint

| Punto | Antes | Ahora |
|---|---|---|
| \`periodoMes\`/\`periodoAnio\` para \`calcularAjusteCompras\` | \`fechaDelPeriodo.getMonth/Year()\` (con bug TZ) | \`fechaDelPeriodo\` normalizada ✓ |
| \`mesAnterior\`/\`anioMesAnterior\` para \`esMesAnterior\` | \`fechaDelPeriodo.getMonth/Year()\` (con bug TZ) | \`fechaDelPeriodo\` normalizada ✓ |
| \`obtenerSumaComprasMesAnterior\` (PR #762) | recibe \`fechaDelPeriodo\` | normalizada propaga ✓ |
| \`fecha_pago\` guardado en BD | \`fechaPeriodo\` cruda (UTC 00:00) | \`fechaDelPeriodo\` normalizada (día correcto en BD) |

## Test plan

- [ ] Mandar \`fecha_calculo=\"2026-06-01\"\` a \`/calcularPagosEspejo\` para un inversionista con \`fecha_inicio_participacion\` en abril → \`esMesAnterior=false\`, NO debe entrar al proporcional.
- [ ] Mandar \`fecha_calculo=\"2026-06-01\"\` para un inversionista con \`fecha_inicio_participacion\` en mayo → \`esMesAnterior=true\`, SÍ entra al proporcional.
- [ ] Verificar que la columna \`fecha_pago\` en \`pagos_credito_inversionistas_espejo\` quede con el día/mes correcto en hora local (no off-by-one).

## Notas

- Este fix se descubrió probando el PR #762 (desglose sin/con compras), pero el bug es **independiente** y aplica al flujo actual de \`calcularPagosEspejo\` aunque ese PR no se mergee primero.
- La línea original \`const fechaDelPeriodo = fechaPeriodo ?? new Date()\` viene del PR #757, que conectó el front con el backend pero no contempló el problema de timezone al parsear ISO date sin hora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)