### PR TITLE
fix: calcularPagosEspejo procesa créditos casi liquidados con fallback + clamp

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -322,7 +322,12 @@ export async function insertPagosCreditoInversionistas(
   cuotaPagada:boolean = false,
   updateCredito: boolean = true,  // si false, omite el UPDATE a creditos_inversionistas_espejo
   inversionista_id?: number,
-  fechaPeriodo?: Date
+  fechaPeriodo?: Date,
+  // si true, cuando abono_capital supera al monto_aportado del espejo
+  // se hace clamp al monto_aportado (en vez de tirar [ABONO_SUPERA_MONTO]).
+  // Caso de uso: fallback de calcularYRegistrarPagosEspejo sobre créditos casi
+  // liquidados donde la cuota mensual completa superaría el saldo restante.
+  allowClampAbonoCapital: boolean = false,
 ) {
   console.log(
     "\n🔍 ========== INICIO insertPagosCreditoInversionistas =========="
@@ -809,9 +814,20 @@ export async function insertPagosCreditoInversionistas(
 
     // Validation 2: abono_capital must not exceed monto_aportado (prevents negative balance)
     if (abono_capital.gt(new Big(inv.monto_aportado || 0))) {
-      throw new Error(
-        `[ABONO_SUPERA_MONTO] Inv ${inv.inversionista_id} Cred ${credito_id}: abono_capital (${abono_capital.toString()}) > monto_aportado (${inv.monto_aportado})`
-      );
+      if (allowClampAbonoCapital) {
+        // Crédito casi liquidado: la cuota mensual completa supera el saldo restante.
+        // Devolvemos al inversionista solo lo que le queda → espejo terminará en 0.
+        console.warn(
+          `   ⚠️  [CLAMP_ABONO] Inv ${inv.inversionista_id} Cred ${credito_id}: ` +
+          `abono_capital (${abono_capital.toString()}) > monto_aportado (${inv.monto_aportado}). ` +
+          `Clamp aplicado → abono_capital = monto_aportado.`
+        );
+        abono_capital = new Big(inv.monto_aportado || 0);
+      } else {
+        throw new Error(
+          `[ABONO_SUPERA_MONTO] Inv ${inv.inversionista_id} Cred ${credito_id}: abono_capital (${abono_capital.toString()}) > monto_aportado (${inv.monto_aportado})`
+        );
+      }
     }
 
     const resultado = {
@@ -2331,22 +2347,24 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
           return null;
         }
 
+        const selectCuotaPagos = {
+          cuotaId: cuotas_credito.cuota_id,
+          numeroCuota: cuotas_credito.numero_cuota,
+          fechaVencimiento: cuotas_credito.fecha_vencimiento,
+          pagadoCuota: cuotas_credito.pagado,
+          liquidadoInversionistas: cuotas_credito.liquidado_inversionistas,
+          pagoId: pagos_credito.pago_id,
+          fechaPago: pagos_credito.fecha_pago,
+          montoBoleta: pagos_credito.monto_boleta,
+          abonoCapital: pagos_credito.abono_capital,
+          abonoInteres: pagos_credito.abono_interes,
+          abonoIva: pagos_credito.abono_iva_12,
+          validationStatus: pagos_credito.validationStatus,
+        };
+
         // Buscar la primera cuota NO liquidada con sus pagos
-        const cuotaConPagos = await db
-          .select({
-            cuotaId: cuotas_credito.cuota_id,
-            numeroCuota: cuotas_credito.numero_cuota,
-            fechaVencimiento: cuotas_credito.fecha_vencimiento,
-            pagadoCuota: cuotas_credito.pagado,
-            liquidadoInversionistas: cuotas_credito.liquidado_inversionistas,
-            pagoId: pagos_credito.pago_id,
-            fechaPago: pagos_credito.fecha_pago,
-            montoBoleta: pagos_credito.monto_boleta,
-            abonoCapital: pagos_credito.abono_capital,
-            abonoInteres: pagos_credito.abono_interes,
-            abonoIva: pagos_credito.abono_iva_12,
-            validationStatus: pagos_credito.validationStatus,
-          })
+        let cuotaConPagos = await db
+          .select(selectCuotaPagos)
           .from(cuotas_credito)
           .innerJoin(
             pagos_credito,
@@ -2360,9 +2378,32 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
           )
           .orderBy(cuotas_credito.numero_cuota, pagos_credito.fecha_pago);
 
+        // Fallback: si todas las cuotas ya están liquidadas, tomar la última cuota
+        // con pagos (mayor numero_cuota). Esto permite reflejar pagos nuevos que
+        // entraron a una cuota ya marcada como liquidada para el inversionista.
+        let esFallback = false;
+        if (cuotaConPagos.length === 0) {
+          cuotaConPagos = await db
+            .select(selectCuotaPagos)
+            .from(cuotas_credito)
+            .innerJoin(
+              pagos_credito,
+              eq(cuotas_credito.cuota_id, pagos_credito.cuota_id)
+            )
+            .where(eq(cuotas_credito.credito_id, credito.creditoId))
+            .orderBy(desc(cuotas_credito.numero_cuota), desc(pagos_credito.fecha_pago));
+
+          if (cuotaConPagos.length > 0) {
+            esFallback = true;
+            console.log(
+              `↩️  Crédito ${credito.creditoId}: fallback → usando última cuota ${cuotaConPagos[0].numeroCuota} (todas liquidadas)`
+            );
+          }
+        }
+
         if (cuotaConPagos.length === 0) {
           console.log(
-            `⚠️  Crédito ${credito.creditoId}: sin cuotas pendientes con pagos`
+            `⚠️  Crédito ${credito.creditoId}: sin cuotas con pagos`
           );
           return null;
         }
@@ -2391,7 +2432,8 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
             false, // cuotaPagada
             false, // updateCredito ← omite el UPDATE a creditos_inversionistas_espejo
             inversionistaId,
-            fechaCalculo
+            fechaCalculo,
+            true, // allowClampAbonoCapital ← cualquier crédito casi liquidado cierra a 0
           );
 
           console.log(


### PR DESCRIPTION
## Problema

\`calcularYRegistrarPagosEspejo\` dejaba 3 créditos sin procesar (caso real con inversionista 84 / Flujocapital):

| credito_id | SIFCO | Cliente | Causa |
|---|---|---|---|
| 988 | 01010202117910 | Edgar Giovanni Juarez Alvarez | Cuotas con \`liquidado_inversionistas=false\` pero solo con pagos pre-creados (\`abono_capital=0\`, \`abono_interes=0\`) |
| 958 | 01010214105820 | Bryan Javier Arriaza Guitron | Misma situación |
| 946 | 01010214103090 | Christopher Rene Santizo Coque | **Todas** las cuotas con \`liquidado_inversionistas=true\` pero un pago nuevo (\`pago_id=133217\` del 28 may) sobre la última cuota |

Resultado: el reporte de Flujocapital quedaba Q3,883.59 corto vs la suma del espejo en BD porque esos 3 créditos no aparecían.

## Cambios

### 1. Fallback en \`calcularYRegistrarPagosEspejo\`

Antes solo buscaba cuotas con \`liquidado_inversionistas=false\` con pagos. Si esa búsqueda no devolvía nada → \`return null\` y el crédito quedaba huérfano.

Ahora si esa búsqueda viene vacía, hace un segundo SELECT:

\`\`\`ts
.from(cuotas_credito)
.innerJoin(pagos_credito, ...)
.where(eq(cuotas_credito.credito_id, credito.creditoId))   // SIN filtro de liquidado_inversionistas
.orderBy(desc(cuotas_credito.numero_cuota), desc(pagos_credito.fecha_pago));
\`\`\`

Toma la última cuota del crédito (mayor \`numero_cuota\`) y su pago más reciente. Cubre el caso 946 (Christopher): pago nuevo entró a cuota ya liquidada → se refleja en el espejo.

Loguea \`↩️ Crédito X: fallback → usando última cuota Y (todas liquidadas)\` cuando entra a esta rama.

### 2. Nuevo parámetro \`allowClampAbonoCapital\` en \`insertPagosCreditoInversionistas\`

La validación existente:
\`\`\`ts
if (abono_capital > monto_aportado) throw [ABONO_SUPERA_MONTO]
\`\`\`

Tira en créditos casi liquidados donde \`cuota_inversionista\` (mensualidad completa) es mayor que el saldo restante del inversionista en el espejo:

| Cred | monto_aportado espejo | cuota_inversionista |
|---|---|---|
| 946 | Q0.28 | Q2,022.44 |
| 958 | Q2,593.42 | Q3,277.35 |
| 988 | Q1,289.89 | Q2,629.75 |

Cuando \`allowClampAbonoCapital=true\`, en vez de tirar el error hace **clamp** a \`monto_aportado\` y loguea warning:

\`\`\`
⚠️ [CLAMP_ABONO] Inv X Cred Y: abono_capital (Z) > monto_aportado (W). Clamp aplicado → abono_capital = monto_aportado.
\`\`\`

Resultado: el inversionista cobra solo lo que le queda y el espejo termina en 0 cuando se liquide el pago.

\`calcularYRegistrarPagosEspejo\` lo pasa siempre como \`true\`. Los **otros callers** de \`insertPagosCreditoInversionistas\` (\`newPayment\`, \`processInvestors\`, etc) mantienen el comportamiento estricto (\`throw [ABONO_SUPERA_MONTO]\`) porque siguen con el default \`false\` — no se altera ningún otro flujo.

## Test plan

- [ ] Correr \`/calcularPagosEspejo\` para inv 84 → los 3 créditos (988, 958, 946) ya no aparecen en la lista de fallidos.
- [ ] Confirmar que para 946 se genera pago espejo del \`pago_id=133217\` (el nuevo de la última cuota ya liquidada).
- [ ] Confirmar que para 988 y 958 se genera pago espejo con \`abono_capital\` clampado al \`monto_aportado\` del espejo (Q1,289.89 y Q2,593.42 respectivamente).
- [ ] Probar \`/newPayment\` con un crédito normal → la validación estricta \`[ABONO_SUPERA_MONTO]\` sigue activa (default \`false\`).

## Notas

- El flag \`esFallback\` queda como rastro en el log pero ya no controla el clamp — el clamp aplica siempre desde \`calcularYRegistrarPagosEspejo\`.
- Después de este fix, la diferencia Q3,883.59 entre la suma del espejo (Q21,193,566.55) y el reporte de junio (Q21,189,682.96) debería cerrarse: ahora los 3 créditos casi liquidados aparecen en el reporte con sus montos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)