### PR TITLE
[codex] Allow next cuota after pending report

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -33,7 +33,6 @@ import {
   lt,
   gte,
   gt,
-  ne,
   isNull,
 } from "drizzle-orm";
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
@@ -248,7 +247,12 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         and(
           eq(cuotas_credito.credito_id, creditoId),
           eq(cuotas_credito.pagado, false),
-          ne(pagos_credito.validationStatus, "pending")
+          sql`NOT EXISTS (
+            SELECT 1
+            FROM cartera.pagos_credito p_pending
+            WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
+              AND p_pending.validation_status = 'pending'
+          )`
         )
       )
       .orderBy(cuotas_credito.numero_cuota);

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -540,6 +540,36 @@ export const insertPayment = async ({ body, set }: any) => {
       }
     // 4. Calcular disponible
     const montoBoleta = new Big(monto_boleta);
+
+    const [cuotaSolicitadaPendiente] = await db
+      .select({
+        cuota_id: cuotas_credito.cuota_id,
+        pago_id: pagos_credito.pago_id,
+      })
+      .from(cuotas_credito)
+      .innerJoin(
+        pagos_credito,
+        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
+      )
+      .where(
+        and(
+          eq(cuotas_credito.credito_id, credito_id),
+          eq(cuotas_credito.numero_cuota, cuotaApagar),
+          eq(pagos_credito.validationStatus, "pending")
+        )
+      )
+      .limit(1);
+
+    if (cuotaSolicitadaPendiente) {
+      set.status = 409;
+      return {
+        success: false,
+        message: `La cuota #${cuotaApagar} ya tiene un pago pendiente de validación`,
+        cuota_id: cuotaSolicitadaPendiente.cuota_id,
+        pago_id: cuotaSolicitadaPendiente.pago_id,
+      };
+    }
+
     // 1. Obtener toda la info del crédito UNA SOLA VEZ
     const creditoData = await obtenerInfoCompletaCredito(
       credito_id,

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -310,7 +310,12 @@ const obtenerInfoCompletaCredito = async (
           and(
             eq(cuotas_credito.credito_id, credito_id),
             eq(cuotas_credito.pagado, false),
-            ne(pagos_credito.validationStatus, "pending"),
+            sql`NOT EXISTS (
+              SELECT 1
+              FROM cartera.pagos_credito p_pending
+              WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
+                AND p_pending.validation_status = 'pending'
+            )`,
             gte(cuotas_credito.numero_cuota, cuotaApagar)
           )
         )


### PR DESCRIPTION
## Summary

- Updates the cartera payment lookup so a cuota is excluded when any associated payment is pending validation.
- Applies the same rule in the payment registration flow so the next cuota can be reported while the previous reported cuota waits for accounting validation.

## Root Cause

The previous filter only checked the joined `pagos_credito` row with `validationStatus != 'pending'`. If a cuota had both its base payment row and a newly reported pending payment, the base row could still make that cuota appear selectable, blocking the next cuota visually.

## Validation

- `git diff --check` passed.
- `./node_modules/.bin/tsc --noEmit` was attempted, but the project currently fails on existing missing `pg` type declarations in database/script files unrelated to this change.