### PR TITLE
[codex] Fix capital abonos not closing cuotas

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -1387,15 +1387,6 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
       const monthPaymentsBig = new Big(
         (await getPagosDelMesActual(credito_id)) ?? 0
       ).plus(abonoCapital);
-      const newCuota = await db
-        .insert(cuotas_credito)
-        .values({
-          credito_id: credito_id,
-          numero_cuota: ultimaCuotaPagada?.numero_cuota ?? cuotasPendientes[0]?.cuotas_credito?.numero_cuota ?? 0,
-          fecha_vencimiento: ultimaCuotaPagada?.fecha_vencimiento ?? cuotasPendientes[0]?.cuotas_credito?.fecha_vencimiento ?? new Date().toISOString().slice(0, 10),
-          pagado: true,
-        })
-        .returning();
       const guatemalaTimeString = new Date().toLocaleString("en-US", {
         timeZone: "America/Guatemala",
         year: "numeric",
@@ -1436,7 +1427,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
         gps_restante: "0",
         total_restante: "0",
 
-        cuota_id: newCuota[0].cuota_id,
+        cuota_id: null,
         numero_cuota: 0,
         llamada: llamada ?? "",
         fecha_pago: fechaGuatemala,
@@ -1512,7 +1503,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           abono_capital: abonoCapital.toString(),
           fecha_pago,
           pagado: true,
-          validationStatus: "pending",
+          validationStatus: "capital",
         },
       };
     } else {
@@ -1791,7 +1782,7 @@ export async function aplicarPagoAlCredito(pago_id: number) {
       if (pago.credito_id === null) {
         throw new Error("No se puede aplicar el abono: credito_id es null");
       }
-      aplicarAbonoCapitalInversionistas(
+      await aplicarAbonoCapitalInversionistas(
         pago.credito_id,
         pago.abono_capital ?? "0",
         pago_id


### PR DESCRIPTION
## Summary

Fixes the capital abono flow so an abono directo a capital no longer creates or marks an installment as paid.

## Root Cause

The `abono_directo_capital` path inserted a new `cuotas_credito` row with `pagado: true` and attached the payment to that cuota. That made the next pending installment, such as June, appear paid even though the user intended a capital-only abono.

## Changes

- Stop creating a paid cuota for direct capital abonos.
- Store capital abono payments with `cuota_id: null` and `validationStatus: "capital"`.
- Await capital abono application during validation so the response reflects completed processing.

## Validation

- `bun test` was run in `apps/cartera-back`; existing failure remains in `src/controllers/createCredit.test.ts` due to missing `sendNewCreditNotification` export from `packages/email/src/index.ts`.
- `tsc --noEmit` was run in `apps/cartera-back`; existing type errors remain for missing `pg` declaration files.