### PR TITLE
fix: CUBE always 100% cash_in / 0% inversion

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -651,6 +651,9 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
           for (const inv of fuente) {
             if (inv.inversionista_id === CUBE_INVESTMENT_ID) {
               // ── CUBE: restarle el monto operativo. Si queda en 0, se elimina. ──
+              // CUBE siempre es 100% cash_in / 0% inversión — ignoramos los
+              // valores que vengan en la fuente porque pueden estar corruptos
+              // (ver bug histórico de los 19 créditos invertidos).
               const nuevoMontoCube = new Big(inv.monto_aportado).minus(
                 montoParaEsteCredito,
               );
@@ -658,10 +661,8 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
                 result.push({
                   inversionista_id: inv.inversionista_id,
                   monto_aportado: nuevoMontoCube,
-                  porcentaje_cash_in: new Big(inv.porcentaje_cash_in),
-                  porcentaje_inversion: new Big(
-                    inv.porcentaje_participacion_inversionista,
-                  ),
+                  porcentaje_cash_in: new Big(100),
+                  porcentaje_inversion: new Big(0),
                   fecha_inicio_participacion: inv.fecha_inicio_participacion,
                 });
               }

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -501,25 +501,20 @@ export const returnPendingInvestorsToCube = async ({ body, set, request }: any) 
                 invP.fecha_inicio_participacion,
             });
           } else if (invP.inversionista_id === CUBE_INVESTMENT_ID) {
+            // CUBE siempre 100% cash_in / 0% inversión, sin importar lo
+            // que venga en la fuente (defensivo contra filas corruptas).
             arrayPadre.push({
               inversionista_id: invP.inversionista_id,
               monto_aportado: montoPadreActual.plus(monto_total_a_cube),
-              porcentaje_cash_in: new Big(invP.porcentaje_cash_in),
-              porcentaje_inversion: new Big(
-                invP.porcentaje_participacion_inversionista,
-              ),
+              porcentaje_cash_in: new Big(100),
+              porcentaje_inversion: new Big(0),
               fecha_inicio_participacion: invP.fecha_inicio_participacion,
             });
             arrayEspejo.push({
               inversionista_id: invP.inversionista_id,
               monto_aportado: montoEspejoActual.plus(monto_total_a_cube),
-              porcentaje_cash_in: new Big(
-                invE?.porcentaje_cash_in ?? invP.porcentaje_cash_in,
-              ),
-              porcentaje_inversion: new Big(
-                invE?.porcentaje_participacion_inversionista ??
-                  invP.porcentaje_participacion_inversionista,
-              ),
+              porcentaje_cash_in: new Big(100),
+              porcentaje_inversion: new Big(0),
               fecha_inicio_participacion:
                 invE?.fecha_inicio_participacion ??
                 invP.fecha_inicio_participacion,
@@ -553,13 +548,15 @@ export const returnPendingInvestorsToCube = async ({ body, set, request }: any) 
         }
 
         // ── Si CUBE no existía en alguna tabla, crearlo ──
+        // CUBE siempre es 100% cash_in / 0% inversión (es "la casa", se queda
+        // con el spread completo de su capital).
         const fechaCubeDefault = new Date().toISOString().split("T")[0];
         if (!arrayPadre.some((i) => i.inversionista_id === CUBE_INVESTMENT_ID)) {
           arrayPadre.push({
             inversionista_id: CUBE_INVESTMENT_ID,
             monto_aportado: monto_total_a_cube,
-            porcentaje_cash_in: new Big(0),
-            porcentaje_inversion: new Big(100),
+            porcentaje_cash_in: new Big(100),
+            porcentaje_inversion: new Big(0),
             fecha_inicio_participacion: fechaCubeDefault,
           });
         }
@@ -567,8 +564,8 @@ export const returnPendingInvestorsToCube = async ({ body, set, request }: any) 
           arrayEspejo.push({
             inversionista_id: CUBE_INVESTMENT_ID,
             monto_aportado: monto_total_a_cube,
-            porcentaje_cash_in: new Big(0),
-            porcentaje_inversion: new Big(100),
+            porcentaje_cash_in: new Big(100),
+            porcentaje_inversion: new Big(0),
             fecha_inicio_participacion: fechaCubeDefault,
           });
         }


### PR DESCRIPTION
## Summary
- **Root cause**: `replaceInvestorCredit.ts` inserta CUBE Investments (id 86) con porcentajes invertidos (`cash_in=0`, `inversion=100`) cuando CUBE se tiene que **recrear** en un crédito (porque un flow previo lo eliminó). Resultado: la fila queda con `monto_inversionista > 0` y `monto_cash_in = 0`, es decir, la "casa" cobrando como inversor normal en lugar de quedarse con el spread.
- **Fixes** (todos defensivos: fuerzan `pct_cash_in=100, pct_inversion=0` para CUBE sin importar lo que venga en la fuente):
  - `replaceInvestorCredit.ts:560-579` — recreación de CUBE (era el origen del bug).
  - `replaceInvestorCredit.ts:503-521` — preservación de CUBE cuando ya existe.
  - `addInvestorToCredit.ts:652-668` — preservación de CUBE cuando se le resta capital.

## Impacto en producción
Encontramos **19 créditos** con este patrón corrupto en prod. Ya fueron arreglados con un UPDATE puntual (separado de este PR). Este PR previene la recurrencia.

Créditos arreglados manualmente en prod: `239, 909, 1034, 1062, 1077, 4859, 8724, 8731, 8746, 8748, 8751, 8755, 8762, 8791, 8815, 8823, 8831, 8846, 8864`.

## Pruebas en DB local

El dump local de Supabase reproduce el mismo bug (mismos 19 créditos). Apliqué el SQL de fix en local y verifiqué:

```
BUG en LOCAL antes del fix:
 padre_bug | espejo_bug
-----------+------------
        19 |         19

UPDATE 19
UPDATE 19
COMMIT

BUG en LOCAL despues del fix:
 padre_bug | espejo_bug
-----------+------------
         0 |          0

Suma monto_aportado de Cube (debe ser igual a antes):
 total_capital_cube
--------------------
  68630805.90810476
```

Sanity check: el capital total de Cube (`monto_aportado` sumado) no cambia — solo se redistribuye `monto_inversionista` → `monto_cash_in` (y lo mismo para el IVA). El `monto_aportado` es intocable porque es el capital realmente aportado por Cube.

### Verificación post-prod
```sql
SELECT
  (SELECT COUNT(*) FROM cartera.creditos_inversionistas        WHERE inversionista_id = 86 AND porcentaje_cash_in::numeric <> 100) AS padre_pendientes,
  (SELECT COUNT(*) FROM cartera.creditos_inversionistas_espejo WHERE inversionista_id = 86 AND porcentaje_cash_in::numeric <> 100) AS espejo_pendientes;
-- → 0 | 0
```

### Tests automatizados
- `bun test src/utils src/controllers/reports.test.ts src/controllers/reversePaymentPolicy.test.ts src/controllers/investor.test.ts` → **20 pass / 0 fail**.
- `createCredit.test.ts` falla por un mock pre-existente no relacionado (export `sendNewCreditNotification` no existe en `@cci/email`) — no introducido por este PR.
- `tsc --noEmit` sobre los archivos modificados → sin errores.

## Test plan
- [ ] Code review del cambio (3 bloques cortos en 2 archivos).
- [ ] QA: crear un escenario que dispare `replaceInvestorCredit` recreando CUBE (por ejemplo, sacar al último inversionista no-CUBE de un crédito) y validar que CUBE queda con `pct_cash_in=100, pct_inversion=0` en padre y espejo.
- [ ] QA: llamar `addInvestorToCredit` sobre un crédito con CUBE preservado y validar que CUBE mantiene `100/0`.
- [ ] Validar en staging que ningún flow que no sea `createCredit` deje filas con `pct_cash_in <> 100` para `inversionista_id = 86`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)