### PR TITLE
[codex] Clarify excess capital abono action

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -465,6 +465,7 @@ export function PagoForm() {
         mode={modalMode}
         onClose={() => setModalExcesoOpen(false)}
         onAbonoCapital={permiteAbonoCapital || !(cuotasAtrasadasInfo && cuotasAtrasadasInfo.total > 0) ? handleAbonoCapital : undefined}
+        abonoCapitalLabel="Abonar excedente a capital"
         onAbonoSiguienteCuota={handleAbonoSiguienteCuota}
         excedente={excedente}
         onAbonoOtros={handleAbonoOtros}

--- a/apps/carteraFront/src/private/cartera/components/excessModal.tsx
+++ b/apps/carteraFront/src/private/cartera/components/excessModal.tsx
@@ -7,6 +7,7 @@ type OpcionesExcesoModalProps = {
   mode: "excedente" | "pagada";
   onClose: () => void;
   onAbonoCapital?: () => void;
+  abonoCapitalLabel?: string;
   onAbonoSiguienteCuota?: () => void;
   onAbonoOtros?: () => void;
   excedente?: number;
@@ -18,6 +19,7 @@ export function OpcionesExcesoModal({
   mode,
   onClose,
   onAbonoCapital,
+  abonoCapitalLabel = "Abonar a capital",
   onAbonoSiguienteCuota,
   onAbonoOtros,
   excedente = 0,
@@ -79,7 +81,7 @@ export function OpcionesExcesoModal({
                   onClick={onAbonoCapital}
                   className="w-full bg-green-600 hover:bg-green-700 text-lg font-bold shadow"
                 >
-                  Abonar a capital
+                  {abonoCapitalLabel}
                 </Button>
               )}
               {(rangoMedio || rangoAlto) && onAbonoSiguienteCuota && (
@@ -144,7 +146,7 @@ export function OpcionesExcesoModal({
                     onClick={onAbonoCapital}
                     className="w-full bg-green-600 hover:bg-green-700 text-lg font-bold shadow"
                   >
-                    Abonar a capital
+                    {abonoCapitalLabel}
                   </Button>
                 )}
                 {onAbonoSiguienteCuota && (

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -538,6 +538,7 @@ const handleAbonoCapitalDirecto = () => {
   formik.values.abono_directo_capital = montoBoleta;
   formik.values.cuotaApagar = cuotaSeleccionada;
 
+  setModalExcesoOpen(false);
   formik.handleSubmit();
 };
 const handleAbonoSiguienteCuota = () => {


### PR DESCRIPTION
## Summary

Clarifies the front-end excess-payment flow for capital abonos without changing the excess-only behavior.

## Root Cause

When the payment amount is greater than the selected cuota, the excess modal's capital action applies the selected cuota normally and sends only the excess as `abono_directo_capital`. The label "Abonar a capital" was ambiguous for users trying to send the entire receipt to capital.

## Changes

- Preserve the excess modal behavior: selected cuota payment plus only the excedente to capital.
- Rename the excess modal action to "Abonar excedente a capital" so it is clear it is not a full-receipt capital abono.
- Keep the separate direct-capital path for full-receipt capital abonos and close the modal before submitting from that path.

## Validation

- `bun run build` in `apps/carteraFront` passes.