### PR TITLE
Allow reporting/applying payments even if a pending validation exists

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -310,12 +310,9 @@ const obtenerInfoCompletaCredito = async (
           and(
             eq(cuotas_credito.credito_id, credito_id),
             eq(cuotas_credito.pagado, false),
-            sql`NOT EXISTS (
-              SELECT 1
-              FROM cartera.pagos_credito p_pending
-              WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
-                AND p_pending.validation_status = 'pending'
-            )`,
+            // Permitir reportar/aplicar pagos adicionales aunque la cuota
+            // ya tenga otro pago pendiente de validación. Contabilidad puede
+            // validar después y el cálculo usa los restantes del pago previo.
             gte(cuotas_credito.numero_cuota, cuotaApagar)
           )
         )
@@ -541,34 +538,9 @@ export const insertPayment = async ({ body, set }: any) => {
     // 4. Calcular disponible
     const montoBoleta = new Big(monto_boleta);
 
-    const [cuotaSolicitadaPendiente] = await db
-      .select({
-        cuota_id: cuotas_credito.cuota_id,
-        pago_id: pagos_credito.pago_id,
-      })
-      .from(cuotas_credito)
-      .innerJoin(
-        pagos_credito,
-        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
-      )
-      .where(
-        and(
-          eq(cuotas_credito.credito_id, credito_id),
-          eq(cuotas_credito.numero_cuota, cuotaApagar),
-          eq(pagos_credito.validationStatus, "pending")
-        )
-      )
-      .limit(1);
-
-    if (cuotaSolicitadaPendiente) {
-      set.status = 409;
-      return {
-        success: false,
-        message: `La cuota #${cuotaApagar} ya tiene un pago pendiente de validación`,
-        cuota_id: cuotaSolicitadaPendiente.cuota_id,
-        pago_id: cuotaSolicitadaPendiente.pago_id,
-      };
-    }
+    // Antes se bloqueaba la cuota si ya tenía un pago `pending`. Ahora se
+    // permite registrar otro pago sobre la misma cuota para no depender de
+    // validación contable antes de reportar el abono complementario.
 
     // 1. Obtener toda la info del crédito UNA SOLA VEZ
     const creditoData = await obtenerInfoCompletaCredito(

--- a/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
+++ b/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
@@ -122,9 +122,11 @@ export function MiniCardCredito({
     ...(cuotasPendientesInfo?.cuotas ?? []),
   ]
     // Permitir seleccionar cuotas con pagos pendientes; solo se ocultan las
-    // cuotas ya validadas/cerradas.
+    // cuotas ya validadas/cerradas. Se mantiene limitado a la cuota pagable
+    // más antigua para no saltar deuda anterior.
     .filter((c) => c.validationStatus !== "validated")
-    .sort((a, b) => a.numero_cuota - b.numero_cuota);
+    .sort((a, b) => a.numero_cuota - b.numero_cuota)
+    .slice(0, 1);
 
   return (
     <div className="w-full flex flex-col items-center gap-4">

--- a/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
+++ b/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
@@ -121,11 +121,10 @@ export function MiniCardCredito({
     ...(cuotasAtrasadasInfo?.cuotas ?? []),
     ...(cuotasPendientesInfo?.cuotas ?? []),
   ]
-    .filter(
-      (c) => c.validationStatus !== "pending" && c.validationStatus !== "validated"
-    )
-    .sort((a, b) => a.numero_cuota - b.numero_cuota)
-    .slice(0, 1);
+    // Permitir seleccionar cuotas con pagos pendientes; solo se ocultan las
+    // cuotas ya validadas/cerradas.
+    .filter((c) => c.validationStatus !== "validated")
+    .sort((a, b) => a.numero_cuota - b.numero_cuota);
 
   return (
     <div className="w-full flex flex-col items-center gap-4">

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -275,10 +275,9 @@ const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
         ...(result.cuotasAtrasadas ?? []),
         ...(result.cuotasPendientes ?? []),
       ]
-        .filter(
-          (c: any) =>
-            c.validationStatus !== "pending" && c.validationStatus !== "validated"
-        )
+        // Los pagos `pending` también son seleccionables para poder reportar
+        // abonos complementarios antes de que contabilidad valide el anterior.
+        .filter((c: any) => c.validationStatus !== "validated")
         .sort((a: any, b: any) => a.numero_cuota - b.numero_cuota)[0];
 
       setCuotaSeleccionada(siguienteCuotaPagable?.numero_cuota ?? cuotaActualNumero ?? 0);


### PR DESCRIPTION
### Motivation
- Facilitar que se puedan reportar o aplicar abonos adicionales sobre una misma cuota sin esperar a que contabilidad valide pagos previos pendientes, evitando bloqueos operativos.

### Description
- Backend: en `apps/cartera-back/src/controllers/registerPayment.ts` se eliminó el filtro que excluía cuotas con pagos `pending` al listar cuotas pendientes y se quitó el bloqueo (409) que impedía insertar un nuevo pago cuando ya existía un pago pendiente para la cuota, permitiendo registrar pagos complementarios.
- Frontend: en `apps/carteraFront/src/private/cartera/components/cardInfo.tsx` el selector de cuotas ahora muestra cuotas con estado `pending` y solo oculta las ya `validated` para permitir su selección.
- Frontend hook: en `apps/carteraFront/src/private/cartera/hooks/registerPayment.ts` se ajustó la lógica de selección por defecto para permitir que la cuota seleccionada pueda ser una con pago `pending`.
- Se añadieron comentarios explicativos en el código para dejar explícito el cambio de comportamiento y su justificación.

### Testing
- Intenté ejecutar TypeScript checks con `pnpm --filter cartera-front exec tsc -p tsconfig.app.json --noEmit` pero falló por configuraciones TS del repo (`baseUrl` deprecado), por lo que no fue posible un `tsc` limpio en el scope frontend (fallo no relacionado con los cambios funcionales).
- Intenté ejecutar TypeScript checks para backend con `pnpm --filter cartera-automatization exec tsc -p tsconfig.json --noEmit` y falló por configuración/typing (`bun-types` y deprecaciones), también no relacionado con la lógica aplicada.
- Verifiqué que no haya errores de formato/whitespace con `git diff --check`, que pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b0010f8e8832fa89fb0e2b4ef2942)