### PR TITLE
[codex] Skip pending installments in overdue query

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -205,6 +205,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
             FROM cartera.pagos_credito p_pending
             WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
               AND p_pending.validation_status = 'pending'
+              AND p_pending.pagado = true
           )`
         )
       )

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -199,7 +199,13 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         and(
           eq(cuotas_credito.credito_id, creditoId),
           eq(cuotas_credito.pagado, false),
-          lt(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10))
+          lt(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
+          sql`NOT EXISTS (
+            SELECT 1
+            FROM cartera.pagos_credito p_pending
+            WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
+              AND p_pending.validation_status = 'pending'
+          )`
         )
       )
       .orderBy(asc(cuotas_credito.numero_cuota));


### PR DESCRIPTION
## Summary

- Prevent exact one-cuota payments from spilling into the next cuota when legacy/restante values understate the selected cuota balance.
- Keep partially pending overdue installments visible by excluding only pending payments that already mark the cuota paid.
- Filter SIFCO search results to selectable credit statuses so fallen/closed duplicate credits are not selectable.
- Use the shared frontend API interceptor for cartera payment-related services so refreshed sessions are honored.

## Root Cause

Some existing cuota rows can have stale component-level `*_restante` values that total less than the actual monthly cuota. In that state, `registerPayment` believed the selected cuota was fully covered and carried the remaining amount into the next cuota, even when the payment was exactly one monthly cuota.

## Validation

- Checked affected production records in Supabase before applying manual corrections.
- Created backups before manual DB fixes.
- Verified Abner Alexander Santizo Cifuentes now has cuota #16 fully applied and no partial payment on cuota #17.
- Ran `bun build src/controllers/registerPayment.ts --target=bun --outdir=/tmp/register-payment-check`.
- Ran `npm run build` in `apps/carteraFront` after the frontend changes.