### PR TITLE
[codex] Fix cartera payment reporting edge cases

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -611,7 +611,8 @@ export async function getCreditosWithUserByMesAnio(
   fecha_hasta?: string,
   numeros_credito_sifco?: string[],
   capital_min?: number,
-  capital_max?: number
+  capital_max?: number,
+  estados_credito?: string[]
 ): Promise<{
   data: CreditoConInfo[];
   page: number;
@@ -656,7 +657,7 @@ export async function getCreditosWithUserByMesAnio(
       }
     }
 
-  if (estado && estado.length > 0) {
+    if (estado && estado.length > 0) {
       if (estado === "ACTIVO") {
         console.log(`🔎 Filtrando por estado: ACTIVO + MOROSO`);
         if (cuotas_atrasadas == 0 ) {
@@ -668,6 +669,11 @@ export async function getCreditosWithUserByMesAnio(
         console.log(`🔎 Filtrando por estado: ${estado}`);
         conditions.push(eq(creditos.statusCredit, estado));
       }
+    }
+
+    if (estados_credito && estados_credito.length > 0) {
+      console.log(`🔎 Filtrando por estados seleccionables: ${estados_credito.join(", ")}`);
+      conditions.push(inArray(creditos.statusCredit, estados_credito));
     }
 
     if (asesor_id) {

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -50,6 +50,14 @@ interface SetContext {
   status: number;
 }
 
+const CENTAVO_TOLERANCE = new Big("0.05");
+
+const montosCercanos = (
+  montoA: Big,
+  montoB: Big,
+  tolerance = CENTAVO_TOLERANCE
+) => montoA.minus(montoB).abs().lte(tolerance);
+
 // ========================================
 // 1. PREPARACIÓN DE DATOS
 // ========================================
@@ -796,6 +804,9 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
             ({ pago }) =>
               pago.validationStatus === "validated" && tieneRestante(pago)
           );
+        const tienePagosValidados = allExistingPagos.some(
+          ({ pago }) => pago.validationStatus === "validated"
+        );
         // El pago original es la fila destino; el último validado parcial
         // trae el saldo vigente cuando ya hubo abonos parciales.
         const existingPago = pagoOriginal ?? allExistingPagos[0];
@@ -968,7 +979,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
 
         // 4. CALCULAR NUEVOS RESTANTES
         console.log("\n🔍 ========== CALCULANDO NUEVOS RESTANTES ==========");
-        const nuevo_interes_restante = interes_restante.minus(abono_interes);
+        let nuevo_interes_restante = interes_restante.minus(abono_interes);
         const nuevo_iva_restante = iva_restante.minus(abono_iva_12);
         const nuevo_seguro_restante = seguro_restante.minus(abono_seguro);
         const nuevo_gps_restante = gps_restante.minus(abono_gps);
@@ -1014,15 +1025,47 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           nuevo_gps_restante.eq(0) &&
           nuevo_membresias_restante.eq(0) &&
           nuevo_capital_restante.eq(0);
-        // Solo marcar como pagada si los restantes están en 0 Y existía un pago previo
-        // (evita marcar como pagada cuando no hay pago existente y los restantes son 0 por default)
-        const cuota_pagada = todosRestantesEnCero && !!existingPago;
-        const totalPagado = abono_capital
+        let totalPagado = abono_capital
           .plus(abono_interes)
           .plus(abono_iva_12)
           .plus(abono_seguro)
           .plus(abono_gps)
           .plus(abono_membresias);
+        const esCuotaSeleccionadaInicial =
+          cuota.cuotas_credito.numero_cuota === cuotaApagar &&
+          cuotas_completas === 0 &&
+          cuotas_parciales === 0;
+        const pagoExactoDeUnaCuota = montosCercanos(
+          montoEfectivo,
+          montoCuota
+        );
+        const faltanteContraCuota = montoCuota.minus(totalPagado);
+
+        if (
+          !!existingPago &&
+          esCuotaSeleccionadaInicial &&
+          pagoExactoDeUnaCuota &&
+          !tienePagosValidados &&
+          todosRestantesEnCero &&
+          faltanteContraCuota.gt(CENTAVO_TOLERANCE) &&
+          disponible_restante.gte(faltanteContraCuota)
+        ) {
+          console.log(
+            "⚠️ Restantes de cuota subestimados; reteniendo pago exacto en la cuota seleccionada:",
+            {
+              cuota: cuota.cuotas_credito.numero_cuota,
+              faltanteContraCuota: faltanteContraCuota.toString(),
+              disponibleRestante: disponible_restante.toString(),
+            }
+          );
+          abono_interes = abono_interes.plus(faltanteContraCuota);
+          totalPagado = totalPagado.plus(faltanteContraCuota);
+          disponible_restante = disponible_restante.minus(faltanteContraCuota);
+          nuevo_interes_restante = new Big(0);
+        }
+        // Solo marcar como pagada si los restantes están en 0 Y existía un pago previo
+        // (evita marcar como pagada cuando no hay pago existente y los restantes son 0 por default)
+        const cuota_pagada = todosRestantesEnCero && !!existingPago;
         // Preparar datos del pago
         const currentDate = new Date();
         const months = [

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -50,14 +50,6 @@ interface SetContext {
   status: number;
 }
 
-const CENTAVO_TOLERANCE = new Big("0.05");
-
-const montosCercanos = (
-  montoA: Big,
-  montoB: Big,
-  tolerance = CENTAVO_TOLERANCE
-) => montoA.minus(montoB).abs().lte(tolerance);
-
 // ========================================
 // 1. PREPARACIÓN DE DATOS
 // ========================================
@@ -979,7 +971,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
 
         // 4. CALCULAR NUEVOS RESTANTES
         console.log("\n🔍 ========== CALCULANDO NUEVOS RESTANTES ==========");
-        let nuevo_interes_restante = interes_restante.minus(abono_interes);
+        const nuevo_interes_restante = interes_restante.minus(abono_interes);
         const nuevo_iva_restante = iva_restante.minus(abono_iva_12);
         const nuevo_seguro_restante = seguro_restante.minus(abono_seguro);
         const nuevo_gps_restante = gps_restante.minus(abono_gps);
@@ -1035,10 +1027,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           cuota.cuotas_credito.numero_cuota === cuotaApagar &&
           cuotas_completas === 0 &&
           cuotas_parciales === 0;
-        const pagoExactoDeUnaCuota = montosCercanos(
-          montoEfectivo,
-          montoCuota
-        );
+        const pagoExactoDeUnaCuota = montoEfectivo.eq(montoCuota);
         const faltanteContraCuota = montoCuota.minus(totalPagado);
 
         if (
@@ -1047,21 +1036,19 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           pagoExactoDeUnaCuota &&
           !tienePagosValidados &&
           todosRestantesEnCero &&
-          faltanteContraCuota.gt(CENTAVO_TOLERANCE) &&
+          faltanteContraCuota.gt(0) &&
           disponible_restante.gte(faltanteContraCuota)
         ) {
           console.log(
-            "⚠️ Restantes de cuota subestimados; reteniendo pago exacto en la cuota seleccionada:",
+            "⚠️ Restantes de cuota subestimados; reteniendo ajuste neutro en la cuota seleccionada:",
             {
               cuota: cuota.cuotas_credito.numero_cuota,
               faltanteContraCuota: faltanteContraCuota.toString(),
               disponibleRestante: disponible_restante.toString(),
             }
           );
-          abono_interes = abono_interes.plus(faltanteContraCuota);
           totalPagado = totalPagado.plus(faltanteContraCuota);
           disponible_restante = disponible_restante.minus(faltanteContraCuota);
-          nuevo_interes_restante = new Big(0);
         }
         // Solo marcar como pagada si los restantes están en 0 Y existía un pago previo
         // (evita marcar como pagada cuando no hay pago existente y los restantes son 0 por default)

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -138,6 +138,7 @@ export const creditRouter = new Elysia()
     fecha_hasta,
     capital_min,
     capital_max,
+    estados_credito,
   } = query as Record<string, string>;
 
   // Validar parámetros requeridos
@@ -244,6 +245,12 @@ export const creditRouter = new Elysia()
 
   const capitalMinParam = capital_min !== undefined ? Number(capital_min) : undefined;
   const capitalMaxParam = capital_max !== undefined ? Number(capital_max) : undefined;
+  const estadosCreditoArray = estados_credito
+    ? String(estados_credito)
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0)
+    : undefined;
 
   if (capitalMinParam !== undefined && isNaN(capitalMinParam)) {
     set.status = 400;
@@ -297,7 +304,8 @@ export const creditRouter = new Elysia()
         fechaHastaParam,
         numerosCreditoSifcoArray,
         capitalMinParam,
-        capitalMaxParam
+        capitalMaxParam,
+        estadosCreditoArray
       );
       set.status = 200;
       return result;
@@ -340,6 +348,7 @@ export const creditRouter = new Elysia()
         fecha_hasta,
         capital_min,
         capital_max,
+        estados_credito,
       } = body;
 
       if (mes === undefined || anio === undefined || !estado) {
@@ -352,6 +361,9 @@ export const creditRouter = new Elysia()
       }
 
       const sifcosLimpios = (numeros_credito_sifco as string[] | undefined)
+        ?.map((s: string) => s.trim())
+        .filter((s: string) => s.length > 0);
+      const estadosCreditoLimpios = (estados_credito as string[] | undefined)
         ?.map((s: string) => s.trim())
         .filter((s: string) => s.length > 0);
 
@@ -396,7 +408,8 @@ export const creditRouter = new Elysia()
           fecha_hasta ?? undefined,
           sifcosLimpios,
           capital_min,
-          capital_max
+          capital_max,
+          estadosCreditoLimpios
         );
         set.status = 200;
         return result;
@@ -442,6 +455,7 @@ export const creditRouter = new Elysia()
         fecha_hasta: t.Optional(t.String()),
         capital_min: t.Optional(t.Number()),
         capital_max: t.Optional(t.Number()),
+        estados_credito: t.Optional(t.Array(t.String())),
       }),
     }
   )

--- a/apps/carteraFront/src/Provider/interceptor.ts
+++ b/apps/carteraFront/src/Provider/interceptor.ts
@@ -1,8 +1,12 @@
 // src/api/axiosInstance.ts
 import axios, { AxiosError, type InternalAxiosRequestConfig } from "axios";
 
+const API_URL =
+  import.meta.env.VITE_BACK_URL ||
+  "https://qk4sw4kc4c088c8csos400wc.s3.devteamatcci.site";
+
 const api = axios.create({
-  baseURL: import.meta.env.VITE_BACK_URL,
+  baseURL: API_URL,
 });
 
 const REFRESH_MARGIN_SECONDS = 120; // refrescar si quedan ≤2 min de vida
@@ -55,7 +59,7 @@ async function refreshAccessToken(): Promise<string | null> {
     try {
       // Usamos axios "pelado" (no `api`) para no disparar nuestros propios interceptors.
       const res = await axios.post(
-        `${import.meta.env.VITE_BACK_URL}${AUTH_REFRESH_PATH}`,
+        `${API_URL}${AUTH_REFRESH_PATH}`,
         { refreshToken },
       );
 

--- a/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
+++ b/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
@@ -18,6 +18,7 @@ type OpcionSifco = {
 
 const ESTADOS_SELECCIONABLES = new Set([
   "ACTIVO",
+  "CANCELADO",
   "PENDIENTE_CANCELACION",
   "MOROSO",
   "EN_CONVENIO",
@@ -60,6 +61,7 @@ export function BuscadorUsuarioSifco({ onSelect, reset, onReset }: BuscadorUsuar
         page,
         perPage: 10,
         excel: false,
+        estados_credito: Array.from(ESTADOS_SELECCIONABLES).join(","),
         ...(hasFilter && esSifco(searchTrimmed)
           ? { numero_credito_sifco: searchTrimmed }
           : hasFilter

--- a/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
+++ b/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
@@ -16,6 +16,14 @@ type OpcionSifco = {
   sifco: string;
 };
 
+const ESTADOS_SELECCIONABLES = new Set([
+  "ACTIVO",
+  "PENDIENTE_CANCELACION",
+  "MOROSO",
+  "EN_CONVENIO",
+  "INCOBRABLE",
+]);
+
 interface BuscadorUsuarioSifcoProps {
   onSelect: (sifco: string) => void;
   reset?: boolean;
@@ -65,10 +73,12 @@ export function BuscadorUsuarioSifco({ onSelect, reset, onReset }: BuscadorUsuar
 
   const opciones: OpcionSifco[] = useMemo(() => {
     if (!data?.data) return [];
-    return data.data.map((item) => ({
-      nombre: item.usuarios.nombre,
-      sifco: item.creditos.numero_credito_sifco,
-    }));
+    return data.data
+      .filter((item) => ESTADOS_SELECCIONABLES.has(item.creditos.statusCredit))
+      .map((item) => ({
+        nombre: item.usuarios.nombre,
+        sifco: item.creditos.numero_credito_sifco,
+      }));
   }, [data]);
 
   const totalPages = data?.totalPages ?? 1;

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -452,6 +452,7 @@ export const getCreditosPaginados = async (params: {
   perPage?: number;
   numero_credito_sifco?: string;
   estado?: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | "PENDIENTE_CANCELACION" | "MOROSO" | "EN_CONVENIO" | "CAIDO";
+  estados_credito?: string;
   excel: boolean;
   asesor_id?: number;
   nombre_usuario?: string;
@@ -466,6 +467,9 @@ export const getCreditosPaginados = async (params: {
       page: params.page ?? 1,
       perPage: params.perPage ?? 10,
       estado: params.estado,
+      ...(params.estados_credito && {
+        estados_credito: params.estados_credito,
+      }),
       excel: params.excel,
       ...(params.numero_credito_sifco && {
         numero_credito_sifco: params.numero_credito_sifco,

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1,20 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import axios  from "axios";
+import api from "@/Provider/interceptor";
 import type { PagoFormValues } from "../hooks/registerPayment";
 import type { ReactNode } from "react";
 
 const API_URL = import.meta.env.VITE_BACK_URL  ||'https://qk4sw4kc4c088c8csos400wc.s3.devteamatcci.site'; ;
-const api = axios.create({
-  baseURL: API_URL,
-});
-api.interceptors.request.use((config) => {
-const token = localStorage.getItem("accessToken");
-
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-});
 
 // Traer todos los inversionistas
 export const getInvestors = async () => {
@@ -3020,7 +3009,7 @@ export const createBoleta = async (data: CreateBoletaDTO) => {
   try {
     console.log("📝 Creando boleta:", data);
 
-    const response = await axios.post<{
+    const response = await api.post<{
       success: boolean;
       message: string;
       data: Boleta;
@@ -3057,7 +3046,7 @@ export const getBoletas = async (filters?: GetBoletasFilters) => {
       params.append("offset", filters.offset.toString());
     }
 
-    const response = await axios.get<{
+    const response = await api.get<{
       success: boolean;
       data: BoletaConInversionista[];
       total: number;


### PR DESCRIPTION
## Summary

- Prevent exact one-cuota payments from spilling into the next cuota when legacy component balances understate the selected cuota balance.
- Keep that legacy-balance adjustment neutral by applying it only to `monto_aplicado`, not to `abono_interes` or any other accounting component.
- Move SIFCO selectable-status filtering into `/getAllCredits` before pagination so searchable credits are not hidden by filtered-out backend pages.
- Keep cancelled credits searchable for the existing cancellation/payment flow while excluding non-payable `CAIDO` credits from the payment selector.
- Preserve the shared frontend API interceptor fallback when `VITE_BACK_URL` is not configured.

## Root Cause

Some legacy cuota rows can have component-level `*_restante` values whose sum is lower than `credito.cuota`. The payment allocation loop then thinks the selected cuota is complete and carries the remaining payment amount into the next cuota, even when the boleta net amount is exactly one monthly cuota.

The search issue came from offering credits in statuses that the payment detail flow does not accept, and the first implementation filtered after backend pagination. That could hide valid selectable credits on later pages.

## Validation

- Checked affected production records in Supabase before applying manual corrections.
- Created backups before manual DB fixes.
- Verified Abner Alexander Santizo Cifuentes now has cuota #16 fully applied and no partial payment on cuota #17.
- Ran `bun build src/controllers/registerPayment.ts --target=bun --outdir=/tmp/register-payment-check`.
- Ran `bun build src/routers/credits.ts --target=bun --outdir=/tmp/credits-router-check`.
- Ran `npm run build` in `apps/carteraFront`.