### PR TITLE
fix: ignore paid installments for mora status

### DIFF
--- a/apps/cartera-back/src/controllers/latefee.test.ts
+++ b/apps/cartera-back/src/controllers/latefee.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, mock } from "bun:test";
+
+mock.module("../database", () => ({
+  db: {},
+}));
+
+const { isOverdueInstallmentForMora } = await import("./latefee");
+
+describe("isOverdueInstallmentForMora", () => {
+  it("no cuenta como vencida una cuota con pago asociado ya pagado", () => {
+    const result = isOverdueInstallmentForMora(
+      {
+        fecha_vencimiento: new Date("2026-05-15T06:00:00.000Z"),
+        pagado: false,
+        hasPaidPayment: true,
+        statusCredit: "MOROSO",
+      },
+      new Date("2026-05-26T06:00:00.000Z"),
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("cuenta como vencida una cuota pasada sin cuota pagada ni pago asociado pagado", () => {
+    const result = isOverdueInstallmentForMora(
+      {
+        fecha_vencimiento: new Date("2026-05-15T06:00:00.000Z"),
+        pagado: false,
+        hasPaidPayment: false,
+        statusCredit: "ACTIVO",
+      },
+      new Date("2026-05-26T06:00:00.000Z"),
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it("no cuenta cuotas futuras como vencidas", () => {
+    const result = isOverdueInstallmentForMora(
+      {
+        fecha_vencimiento: new Date("2026-06-15T06:00:00.000Z"),
+        pagado: false,
+        hasPaidPayment: false,
+        statusCredit: "ACTIVO",
+      },
+      new Date("2026-05-26T06:00:00.000Z"),
+    );
+
+    expect(result).toBe(false);
+  });
+});

--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, gte, inArray, lte } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { db } from "../database";
 import { asesores, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, platform_users, usuarios } from "../database/db/schema";
 import Big from "big.js";
@@ -20,6 +20,31 @@ type MoraEventoOrigen =
   | "API_MANUAL"
   | "CONDONACION_INDIVIDUAL"
   | "CONDONACION_MASIVA";
+
+const STATUS_EXCLUIDOS_MORA = ["EN_CONVENIO", "INCOBRABLE", "CANCELADO", "PENDIENTE_CANCELACION", "CAIDO"];
+
+export function isOverdueInstallmentForMora(
+  cuota: {
+    fecha_vencimiento: Date | string;
+    pagado: boolean | null;
+    hasPaidPayment?: boolean | null;
+    statusCredit?: string | null;
+  },
+  hoy: Date,
+) {
+  const zona = "America/Guatemala";
+  const fechaVenc = toZonedTime(cuota.fecha_vencimiento, zona);
+  fechaVenc.setHours(0, 0, 0, 0);
+
+  const fechaHoy = toZonedTime(hoy, zona);
+  fechaHoy.setHours(0, 0, 0, 0);
+
+  const isOverdue = fechaVenc < fechaHoy;
+  const isUnpaid = cuota.pagado === false && cuota.hasPaidPayment !== true;
+  const isEligible = !STATUS_EXCLUIDOS_MORA.includes(cuota.statusCredit ?? "");
+
+  return isOverdue && isUnpaid && isEligible;
+}
 
 /**
  * Inserta un evento en moras_historial. No lanza si falla — el historial
@@ -459,10 +484,19 @@ export async function procesarMoras() {
     // 1. Get all installments WITH PROPER JOIN
     const cuotas = await db
       .select({
+        cuota_id: cuotas_credito.cuota_id,
         credito_id: cuotas_credito.credito_id,
         fecha_vencimiento: cuotas_credito.fecha_vencimiento,
         pagado: cuotas_credito.pagado,
         statusCredit: creditos.statusCredit,
+        hasPaidPayment: sql<boolean>`EXISTS (
+          SELECT 1
+          FROM cartera.pagos_credito pc
+          WHERE pc.cuota_id = ${cuotas_credito.cuota_id}
+            AND pc."paymentFalse" = false
+            AND pc.pagado = true
+            AND pc.validation_status IN ('validated', 'no_required')
+        )`,
       })
       .from(cuotas_credito)
       .innerJoin(creditos, eq(cuotas_credito.credito_id, creditos.credito_id));
@@ -470,17 +504,7 @@ export async function procesarMoras() {
     console.log(`[DEBUG] Total installments fetched: ${cuotas.length}`);
 
     // 2. Filter overdue installments (excluyendo estados que no aplican)
-    const statusExcluidos = ["EN_CONVENIO", "INCOBRABLE", "CANCELADO", "PENDIENTE_CANCELACION", "CAIDO"];
-    const cuotasVencidas = cuotas.filter((c) => {
-      const fechaVenc = toZonedTime(c.fecha_vencimiento, zona);
-      fechaVenc.setHours(0, 0, 0, 0);
-
-      const isOverdue = fechaVenc < hoy;
-      const isUnpaid = c.pagado === false;
-      const isEligible = !statusExcluidos.includes(c.statusCredit ?? "");
-
-      return isOverdue && isUnpaid && isEligible;
-    });
+    const cuotasVencidas = cuotas.filter((c) => isOverdueInstallmentForMora(c, hoy));
 
     console.log(`[DEBUG] Overdue installments found: ${cuotasVencidas.length}`);
 

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -2062,7 +2062,10 @@ export async function getPagosByVencimiento({
           COALESCE(c.gps::numeric, 0) AS gps,
           COALESCE(c.membresias_pago::numeric, 0) AS mem,
           AVG(COALESCE(cube_data.cash_in_pct, 0))::numeric AS cash_pct,
-          COALESCE(MAX(m.monto_mora::numeric), 0) AS mora,
+          CASE
+            WHEN MAX(mora_real.cuotas_atrasadas) > 0 THEN COALESCE(MAX(m.monto_mora::numeric), 0)
+            ELSE 0
+          END AS mora,
           COALESCE(SUM(p.monto_aplicado::numeric), 0) AS monto_apl
         ${commonFromJoins}
         ${commonGroupHaving}

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1548,10 +1548,10 @@ export async function getPagosByVencimiento({
     }
   }
   if (rango_mora) {
-    if (rango_mora === "0-30") filters.push(sql`m.cuotas_atrasadas = 1 AND m.activa = true AND p.pagado = false`);
-    else if (rango_mora === "31-60") filters.push(sql`m.cuotas_atrasadas = 2 AND m.activa = true AND p.pagado = false`);
-    else if (rango_mora === "61-90") filters.push(sql`m.cuotas_atrasadas = 3 AND m.activa = true AND p.pagado = false`);
-    else if (rango_mora === "+90") filters.push(sql`m.cuotas_atrasadas >= 4 AND m.activa = true AND p.pagado = false`);
+    if (rango_mora === "0-30") filters.push(sql`mora_real.cuotas_atrasadas = 1`);
+    else if (rango_mora === "31-60") filters.push(sql`mora_real.cuotas_atrasadas = 2`);
+    else if (rango_mora === "61-90") filters.push(sql`mora_real.cuotas_atrasadas = 3`);
+    else if (rango_mora === "+90") filters.push(sql`mora_real.cuotas_atrasadas >= 4`);
   }
   const whereClause = sql.join(filters, sql` AND `);
 
@@ -1683,6 +1683,21 @@ export async function getPagosByVencimiento({
     INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
     LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
     LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
+    LEFT JOIN LATERAL (
+      SELECT COUNT(*)::int AS cuotas_atrasadas
+      FROM cartera.cuotas_credito qc_mora
+      WHERE qc_mora.credito_id = c.credito_id
+        AND qc_mora.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
+        AND qc_mora.pagado = false
+        AND NOT EXISTS (
+          SELECT 1
+          FROM cartera.pagos_credito pc_mora
+          WHERE pc_mora.cuota_id = qc_mora.cuota_id
+            AND pc_mora."paymentFalse" = false
+            AND pc_mora.pagado = true
+            AND pc_mora.validation_status IN ('validated', 'no_required')
+        )
+    ) mora_real ON true
     ${cubeSubquery}
     ${lateralCapAnterior}
     WHERE ${whereClause}
@@ -1692,7 +1707,7 @@ export async function getPagosByVencimiento({
     GROUP BY
       c.credito_id, c.numero_credito_sifco, u.nombre, a.nombre, c.royalti,
       c.capital, c.porcentaje_interes, c.cuota, c.seguro_10_cuotas, c.gps, c.membresias_pago,
-      cap_anterior.total_restante
+      cap_anterior.total_restante, mora_real.cuotas_atrasadas
     HAVING SUM(${totalFilaSql}) <> 0
   `;
 
@@ -1714,12 +1729,15 @@ export async function getPagosByVencimiento({
       MAX(q.numero_cuota) AS cuota_max,
       COALESCE(SUM(p.monto_boleta::numeric), 0) AS monto_boleta,
       COALESCE(SUM(p.monto_aplicado::numeric), 0) AS monto_aplicado,
-      COALESCE(MAX(m.monto_mora::numeric), 0) AS monto_mora,
       CASE
-        WHEN MAX(m.cuotas_atrasadas) = 1 THEN 'Mora 30'
-        WHEN MAX(m.cuotas_atrasadas) = 2 THEN 'Mora 60'
-        WHEN MAX(m.cuotas_atrasadas) = 3 THEN 'Mora 90'
-        WHEN MAX(m.cuotas_atrasadas) >= 4 THEN 'Mora 120+'
+        WHEN MAX(mora_real.cuotas_atrasadas) > 0 THEN COALESCE(MAX(m.monto_mora::numeric), 0)
+        ELSE 0
+      END AS monto_mora,
+      CASE
+        WHEN MAX(mora_real.cuotas_atrasadas) = 1 THEN 'Mora 30'
+        WHEN MAX(mora_real.cuotas_atrasadas) = 2 THEN 'Mora 60'
+        WHEN MAX(mora_real.cuotas_atrasadas) = 3 THEN 'Mora 90'
+        WHEN MAX(mora_real.cuotas_atrasadas) >= 4 THEN 'Mora 120+'
         ELSE 'Al día'
       END AS dias_mora
   `;
@@ -2149,4 +2167,3 @@ export async function getAbonosDelMesPorCredito({
 
   return result.rows;
 }
-


### PR DESCRIPTION
## Summary
- Treat overdue installments with an associated paid/validated payment as paid when processing mora
- Recalculate CRM mora status from real overdue installments instead of stale active mora rows
- Add regression tests for paid-associated installments

## Validation
- bun test src/controllers/latefee.test.ts src/controllers/reports.test.ts

## Notes
- Full TypeScript check currently fails on develop in src/controllers/credits.ts:676 due to an existing Drizzle type issue unrelated to this change.