### PR TITLE
fix(cartera): false-payment no debe descontar monto_aportado del espejo

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1380,7 +1380,9 @@ export async function falsePayment(pago_id: number, credito_id: number) {
   console.log(
     `Falsificando pago con ID: ${pago_id} para crédito ID: ${credito_id}`
   );
-  insertPagosCreditoInversionistas(pago_id, credito_id, true); // Excluir Cube Investments
+  // updateCredito=false → NO actualiza creditos_inversionistas_espejo (monto_aportado).
+  // Falsear un pago no debe descontar el aporte del crédito/espejo.
+  insertPagosCreditoInversionistas(pago_id, credito_id, true, false, false); // excludeCube=true, cuotaPagada=false, updateCredito=false
   // Actualizar el estado del pago a falso
   const result = await db
     .update(pagos_credito)

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -35,7 +35,6 @@ import {
 } from "lucide-react";
 import { usePagoForm } from "../hooks/registerPayment";
 import { Button } from "@/components/ui/button";
-import { useFalsePayment } from "../hooks/falsePayments";
 import { useReciboPago } from "../hooks/useReciboPago";
 import {
   DropdownMenu,
@@ -405,7 +404,6 @@ export function PaymentsCredits() {
   const [collapseInv, setCollapseInv] = useState<{ [key: number]: boolean }>(
     {}
   );
-  const falsePayment = useFalsePayment();
   const reciboPago = useReciboPago();
   const { user } = useAuth(); 
   const { liquidandoId, handleLiquidar, handleReverse, reversePago, handleRevertToPending, revertPaymentToPending, handleRevalidatePayment, revalidatePayment, handleProcessInvestors, processInvestors, recalcularPagos, handleRecalcularPagos } =
@@ -495,9 +493,6 @@ const handleDownloadExcel = async () => {
           .includes(search.toLowerCase())
     )
     : [];
-  const handleFalsePayment = (pago_id: number, credito_id: number) => {
-    falsePayment.mutate({ pago_id, credito_id });
-  };
   return (
     <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-2 overflow-auto pt-8 pb-8">
       <div className="w-full max-w-6xl mx-auto">
@@ -707,13 +702,6 @@ const handleDownloadExcel = async () => {
                         onClick={(e) => { e.stopPropagation(); handleRevalidatePayment(item.pago.pago_id, item.pago.credito_id); }}
                         disabled={item.pago.pagado === true || item.pago.paymentFalse === true || revalidatePayment.isPending}>
                         {revalidatePayment.isPending ? <Loader2 className="animate-spin w-4 h-4" /> : null} Revalidar Pago
-                      </button>
-                    </DropdownMenuItem>
-                    <DropdownMenuItem asChild>
-                      <button className="w-full flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-semibold hover:bg-red-50 text-red-700 transition disabled:opacity-40 disabled:cursor-not-allowed"
-                        onClick={(e) => { e.stopPropagation(); handleFalsePayment(item.pago.pago_id, item.pago.credito_id); refetch(); }}
-                        disabled={falsePayment.isPending || item.pago.pagado === true || item.pago.paymentFalse === true}>
-                        {falsePayment.isPending ? <Loader2 className="animate-spin w-4 h-4" /> : null} Pago Falso
                       </button>
                     </DropdownMenuItem>
                     <DropdownMenuItem asChild>


### PR DESCRIPTION
## Problema

El endpoint `POST /false-payment` estaba **descontando el `monto_aportado`** de los inversionistas en `creditos_inversionistas_espejo` al marcar un pago como falso.

`falsePayment()` (`apps/cartera-back/src/controllers/payments.ts:1383`) llamaba a:
```ts
insertPagosCreditoInversionistas(pago_id, credito_id, true);
```
Como el 5º parámetro `updateCredito` quedaba en su default `true`, dentro de esa función se ejecutaba `processAndReplaceCreditInvestors(..., updateMirror=true)`, que **resta** el `monto_aportado` del espejo a **cada** inversionista del crédito (sin mirar `permite_distribucion`).

### Por qué pasó
- `falsePayment` no cambió desde **ago-2025** (`cc83f8ff`), cuando esa función operaba sobre la tabla **padre** (`creditos_inversionistas`).
- En **feb-2026** (`efbefc76`) la función `insertPagosCreditoInversionistas` fue reapuntada de **padre → espejo**, arrastrando a `falsePayment` a escribir el espejo sin que nadie lo tocara.

### Efecto observado
Crédito **459**, inversionista **3** (`permite_distribucion=false`): `monto_aportado` **194,309.36 → 191,270.83** (Q**3,038.53**) tras marcar el pago `27429` como falso el 2026-06-01 11:01 GT (usuario `Caja@sepresta.com`).

## Cambios

### Backend
Pasar `updateCredito=false` en la llamada de `falsePayment`:
```ts
insertPagosCreditoInversionistas(pago_id, credito_id, true, false, false);
```
- ❌ Ya **no** llama a `processAndReplaceCreditInvestors` → **no descuenta** el `monto_aportado` del espejo.
- ✅ Sigue marcando el pago como `paymentFalse=true`.

### Frontend
Se elimina el botón **"Pago Falso"** del menú de acciones de pagos (`PaymentsCredits.tsx`) — esa acción ya no debe existir desde la UI — junto con sus referencias huérfanas (import `useFalsePayment`, hook y handler).
- El hook `falsePayments.ts` se conserva porque `tableInvestors.tsx` aún usa `useFalsePayments` (solo el flag `isPending`).

## Notas / pendientes (no incluidos en este PR)
- La llamada del back sigue siendo **fire-and-forget** (sin `await`).
- `insertPagosCreditoInversionistas` aún inserta filas en `pagos_credito_inversionistas_espejo`; si se quiere que `false-payment` no escriba **nada** del espejo, requiere un cambio adicional.
- Conviene revisar si, conceptualmente, falsear un pago debería **revertir** (sumar) en el padre en lugar de no hacer nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)