### PR TITLE
fix(cartera): interés mes completo cuando la participación inicia el día 1

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -557,7 +557,10 @@ export async function insertPagosCreditoInversionistas(
       !isCube &&
       fechaInicio !== null &&
       fechaInicio.getMonth() === mesAnterior &&
-      fechaInicio.getFullYear() === anioMesAnterior;
+      fechaInicio.getFullYear() === anioMesAnterior &&
+      // Si inicia el día 1, participó el mes COMPLETO → interés normal (no proporcional).
+      // Prorratear con (diasDelMes - 1) cobraría un día de menos y descuadra por centavos.
+      fechaInicio.getDate() !== 1;
 
     let bigInteres: Big;
     let bigIVA: Big;


### PR DESCRIPTION
## Problema

En `insertPagosCreditoInversionistas` (`apps/cartera-back/src/controllers/payments.ts`), cuando `fecha_inicio_participacion` cae en el **mes anterior** al período que se liquida, el interés se prorratea por días:

```ts
const diaInicio = fechaInicio.getDate();              // si inicia el 1 → 1
const diasProporcionales = diasDelMes - diaInicio;    // 31 - 1 = 30  ❌
```

Si la participación **inicia el día 1**, el inversionista participó el **mes completo**, pero la fórmula daba `diasDelMes - 1` (ej. **30/31**), cobrando un día de menos → **descuadre por centavos**.

## Cambio

Excluir `getDate() === 1` de la rama proporcional, para que un inicio el día 1 caiga en el cálculo de **mes completo** (interés normal):

```ts
const esMesAnterior =
  !isCube &&
  fechaInicio !== null &&
  fechaInicio.getMonth() === mesAnterior &&
  fechaInicio.getFullYear() === anioMesAnterior &&
  fechaInicio.getDate() !== 1;   // día 1 = mes completo → interés normal
```

| Caso | Antes | Ahora |
|---|---|---|
| Inicia el **1** del mes anterior | proporcional × 30/31 | **interés normal / mes completo** ✅ |
| Inicia el 7 (u otro día) | proporcional × (31−7)/31 | igual (proporcional) |

## Nota / a definir

Solo se ajustó el **día 1** (lo reportado). Queda abierto si la regla de negocio correcta es "contar el día de inicio inclusive siempre" (`diasDelMes - diaInicio + 1`), lo que afectaría también los demás días. Si se confirma, se hace en otro PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)