### PR TITLE
[codex] Avoid duplicate cuotas for direct capital payments

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -1389,15 +1389,15 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
       const monthPaymentsBig = new Big(
         (await getPagosDelMesActual(credito_id)) ?? 0
       ).plus(abonoCapital);
-      const newCuota = await db
-        .insert(cuotas_credito)
-        .values({
-          credito_id: credito_id,
-          numero_cuota: ultimaCuotaPagada?.numero_cuota ?? cuotasPendientes[0]?.cuotas_credito?.numero_cuota ?? 0,
-          fecha_vencimiento: ultimaCuotaPagada?.fecha_vencimiento ?? cuotasPendientes[0]?.cuotas_credito?.fecha_vencimiento ?? new Date().toISOString().slice(0, 10),
-          pagado: true,
-        })
-        .returning();
+      const cuotaReferencia =
+        ultimaCuotaPagada ?? cuotasPendientes[0]?.cuotas_credito;
+
+      if (!cuotaReferencia?.cuota_id) {
+        throw new Error(
+          "No se encontró una cuota existente para enlazar el abono directo a capital"
+        );
+      }
+
       const guatemalaTimeString = new Date().toLocaleString("en-US", {
         timeZone: "America/Guatemala",
         year: "numeric",
@@ -1438,7 +1438,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
         gps_restante: "0",
         total_restante: "0",
 
-        cuota_id: newCuota[0].cuota_id,
+        cuota_id: cuotaReferencia.cuota_id,
         numero_cuota: 0,
         llamada: llamada ?? "",
         fecha_pago: fechaGuatemala,


### PR DESCRIPTION
## Summary

- Reuse an existing cuota when registering direct capital payments instead of inserting a duplicate cuota row.
- Fail explicitly if no existing cuota can be linked to the direct-capital payment.

## Root Cause

For Ricardo Augusto Moran Castellanos 2 / 01010214106990, a direct capital payment of Q440.50 inserted a new cuota with the same numero_cuota as the latest paid installment (#32). That duplicate cuota, plus recalculation placeholders, left extra unpaid #32/#33 rows and blocked the payment screen from advancing to cuota #33.

## Production Data

- Cleaned the affected credit after backup: fix_duplicados_32_33_01010214106990_2026_06_01_pre.
- Preserved pago 134041 and its boleta/investor distribution by relinking it to the original cuota #32.
- Removed only empty duplicate placeholder payments/cuotas without boletas or investor rows.

## Validation

- Verified the new branch does not contain apps/cartera-back/src/migration/analizar_flujocapital.py.
- Ran: bun build src/controllers/registerPayment.ts --target=bun --outdir=/tmp/register-payment-check-direct-capital.