### PR TITLE
feat: modalidad de reinversión "excedente"

### DIFF
--- a/apps/cartera-back/src/controllers/ajustarPagosLiquidacion.ts
+++ b/apps/cartera-back/src/controllers/ajustarPagosLiquidacion.ts
@@ -217,6 +217,11 @@ async function computarTotalesFiltrados(opts: {
           // El ajuste global se aplica después del loop
           cuota_inversor = abono_capital.plus(interesTotal);
           break;
+        case "reinversion_excedente":
+          // Inverso de variable: el monto fijo es lo que RECIBE el inversionista
+          // y el sobrante se reinvierte. El ajuste global se aplica después del loop.
+          cuota_inversor = abono_capital.plus(interesTotal);
+          break;
         default:
           cuota_inversor = abono_capital.plus(interesTotal);
       }
@@ -259,6 +264,17 @@ async function computarTotalesFiltrados(opts: {
       : montoReinv;
     totales.total_reinversion = reinversion;
     totales.total_cuota = totales.total_cuota.minus(reinversion);
+  }
+
+  // Ajuste global para reinversion_excedente (inverso de variable):
+  // el monto fijo es lo que RECIBE el inversionista; el sobrante se reinvierte.
+  if (inv.reinversion === "reinversion_excedente") {
+    const montoRecibe = new Big(inv.monto_reinversion ?? 0);
+    const recibe = montoRecibe.gt(totales.total_cuota)
+      ? totales.total_cuota
+      : montoRecibe;
+    totales.total_reinversion = totales.total_cuota.minus(recibe);
+    totales.total_cuota = recibe;
   }
 
   return {

--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -271,6 +271,7 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
         | "reinversion_interes"
         | "reinversion_total"
         | "reinversion_variable"
+        | "reinversion_excedente"
         | "reinversion_combinada"
         | null,
       rows: (rowsPorCredito.get(c.credito_id) ?? [])
@@ -375,6 +376,7 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
           reinversion_interes: "Reinversión de Interés",
           reinversion_total: "Reinversión Total",
           reinversion_variable: "Reinversión Variable",
+          reinversion_excedente: "Reinversión Excedente",
           reinversion_combinada: "Reinversión Combinada",
         };
 

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1547,6 +1547,13 @@ export async function resumeInvestor(
                     .plus(inv.emite_factura ? abono_iva : isr.neg());
                   break;
 
+                case "reinversion_excedente":
+                  // Inverso de variable: per-pago se calcula completo; el ajuste global se aplica después
+                  cuota_inversor = abono_capital
+                    .plus(abono_interes)
+                    .plus(inv.emite_factura ? abono_iva : isr.neg());
+                  break;
+
                 case "reinversion_combinada":
                   // 🔑 Lógica combinada: tomamos lo que NO se reinvierte y le aplicamos impuesto
                   const capRestante = abono_capital.minus(reinvCapital);
@@ -1694,6 +1701,14 @@ export async function resumeInvestor(
         const montoReinv = new Big(inv.monto_reinversion ?? 0);
         const reinversion = montoReinv.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoReinv;
         subtotal.total_cuota = subtotal.total_cuota.minus(reinversion);
+      }
+
+      // Excedente (inverso de variable): el monto fijo es lo que RECIBE; el sobrante se reinvierte.
+      if (inv.reinversion === "reinversion_excedente") {
+        const montoRecibe = new Big(inv.monto_reinversion ?? 0);
+        const recibe = montoRecibe.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoRecibe;
+        subtotal.total_reinversion = subtotal.total_cuota.minus(recibe);
+        subtotal.total_cuota = recibe;
       }
 
       // 🔹 Retornar estructura del inversionista
@@ -1998,6 +2013,10 @@ export async function getInvestorTotalsGlobales(
           // Se calcula como sin_reinversion per-pago; el allCandidatese global se aplica después
           cuota_inversor = abono_capital.plus(interesTotal);
           break;
+        case "reinversion_excedente":
+          // Inverso de variable: per-pago se calcula completo; el ajuste global se aplica después
+          cuota_inversor = abono_capital.plus(interesTotal);
+          break;
         default:
           cuota_inversor = abono_capital.plus(interesTotal);
       }
@@ -2054,6 +2073,14 @@ export async function getInvestorTotalsGlobales(
     const reinversion = montoReinv.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoReinv;
     subtotal.total_reinversion = reinversion;
     subtotal.total_cuota = subtotal.total_cuota.minus(reinversion);
+  }
+
+  // Excedente (inverso de variable): el monto fijo es lo que RECIBE; el sobrante se reinvierte.
+  if (inv.reinversion === "reinversion_excedente") {
+    const montoRecibe = new Big(inv.monto_reinversion ?? 0);
+    const recibe = montoRecibe.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoRecibe;
+    subtotal.total_reinversion = subtotal.total_cuota.minus(recibe);
+    subtotal.total_cuota = recibe;
   }
 
   // 7. Upsert en reinversiones
@@ -3393,6 +3420,10 @@ export async function getInvestorMirrorSummary(
           // Se calcula como sin_reinversion per-pago; el allCandidatese global se aplica después
           cuota_inversor = abono_capital.plus(interesTotal);
           break;
+        case "reinversion_excedente":
+          // Inverso de variable: per-pago se calcula completo; el ajuste global se aplica después
+          cuota_inversor = abono_capital.plus(interesTotal);
+          break;
         default:
           cuota_inversor = abono_capital.plus(interesTotal);
       }
@@ -3430,6 +3461,14 @@ export async function getInvestorMirrorSummary(
     const reinversion = montoReinv.gt(sg.total_cuota) ? sg.total_cuota : montoReinv;
     sg.total_reinversion = reinversion;
     sg.total_cuota = sg.total_cuota.minus(reinversion);
+  }
+
+  // Excedente (inverso de variable): el monto fijo es lo que RECIBE; el sobrante se reinvierte.
+  if (inv.reinversion === "reinversion_excedente") {
+    const montoRecibe = new Big(inv.monto_reinversion ?? 0);
+    const recibe = montoRecibe.gt(sg.total_cuota) ? sg.total_cuota : montoRecibe;
+    sg.total_reinversion = sg.total_cuota.minus(recibe);
+    sg.total_cuota = recibe;
   }
 
   // ── PASO 5: Retornar datos del inversionista + subtotales globales ─────────
@@ -6494,6 +6533,19 @@ async function consultarResumenGlobalPorEstadoPago(
               END
           ), 0)
         )
+        WHEN 'reinversion_excedente' THEN GREATEST(
+          COALESCE(SUM(
+            ${pe.abono_capital}
+            + ${pe.abono_interes}
+            + CASE
+                WHEN ${inversionistas.emite_factura}
+                  THEN ${pe.abono_iva_12}
+                ELSE -ROUND(${pe.abono_interes} * 0.07, 2)
+              END
+          ), 0)
+          - COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
+          0
+        )
         ELSE 0
       END`,
       total_a_recibir_con_reinversion: sql<number>`
@@ -6538,6 +6590,19 @@ async function consultarResumenGlobalPorEstadoPago(
                     ELSE -ROUND(${pe.abono_interes} * 0.07, 2)
                   END
               ), 0)
+            )
+            WHEN 'reinversion_excedente' THEN GREATEST(
+              COALESCE(SUM(
+                ${pe.abono_capital}
+                + ${pe.abono_interes}
+                + CASE
+                    WHEN ${inversionistas.emite_factura}
+                      THEN ${pe.abono_iva_12}
+                    ELSE -ROUND(${pe.abono_interes} * 0.07, 2)
+                  END
+              ), 0)
+              - COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
+              0
             )
             ELSE 0
           END`,
@@ -6604,6 +6669,19 @@ async function consultarResumenGlobalPorEstadoPago(
                   END
               ), 0)
             )
+        WHEN 'reinversion_excedente' THEN
+          LEAST(
+            COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
+            COALESCE(SUM(
+              ${pe.abono_capital}
+              + ${pe.abono_interes}
+              + CASE
+                  WHEN ${inversionistas.emite_factura}
+                    THEN ${pe.abono_iva_12}
+                  ELSE -ROUND(${pe.abono_interes} * 0.07, 2)
+                END
+            ), 0)
+          )
         ELSE COALESCE(SUM(
           ${pe.abono_capital}
           + ${pe.abono_interes}

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -38,6 +38,7 @@
     "reinversion_interes",
     "reinversion_total",
     "reinversion_variable",
+    "reinversion_excedente",
     "reinversion_combinada"
   ]);
 

--- a/apps/cartera-back/src/routers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/routers/mirrorInvestor.ts
@@ -60,6 +60,7 @@ export const mirrorInvestorRouter = new Elysia()
                       reinversion_interes: "reinversion_interes",
                       reinversion_total: "reinversion_total",
                       reinversion_variable: "reinversion_variable",
+                      reinversion_excedente: "reinversion_excedente",
                       reinversion_combinada: "reinversion_combinada",
                   })
               }),

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -831,7 +831,8 @@ export function InvestorsList({
           type="button"
           onClick={addInvestor}
           variant="outline"
-          className="w-full border-blue-500 text-blue-700 hover:bg-blue-50 flex items-center justify-center gap-2"
+          disabled
+          className="w-full border-blue-500 text-blue-700 hover:bg-blue-50 flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <Plus className="w-4 h-4" />
           Agregar Inversionista

--- a/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
@@ -210,7 +210,7 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
                     onChange: (e) => {
                       const prev = watch("tipo_reinversion") ?? "sin_reinversion";
                       const val = e.target.value;
-                      if (val !== "reinversion_variable") {
+                      if (val !== "reinversion_variable" && val !== "reinversion_excedente") {
                         setValue("monto_reinversion", 0);
                       }
                       if (val === "reinversion_combinada") {
@@ -226,6 +226,7 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
                   <option value="reinversion_interes">Reinversión Interés</option>
                   <option value="reinversion_total">Reinversión Total</option>
                   <option value="reinversion_variable">Reinversión Variable</option>
+                  <option value="reinversion_excedente">Reinversión Excedente</option>
                   <option value="reinversion_combinada">Reinversión Combinada</option>
                 </select>
                 {watch("tipo_reinversion") === "reinversion_combinada" && mode === "update" && initialData?.inversionista_id && (
@@ -242,20 +243,33 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
 
             {/* Monto Reinversión */}
             <div>
-              <label className="block text-sm text-blue-800 mb-1">Monto Reinversión</label>
+              <label className="block text-sm text-blue-800 mb-1">
+                {watch("tipo_reinversion") === "reinversion_excedente"
+                  ? "Monto a Recibir"
+                  : "Monto Reinversión"}
+              </label>
               <input
                 {...register("monto_reinversion", { valueAsNumber: true })}
                 type="number"
                 step="any"
                 min={0}
-                disabled={watch("tipo_reinversion") !== "reinversion_variable"}
+                disabled={
+                  watch("tipo_reinversion") !== "reinversion_variable" &&
+                  watch("tipo_reinversion") !== "reinversion_excedente"
+                }
                 className={`border border-gray-300 rounded-lg px-4 py-2 w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition ${
-                  watch("tipo_reinversion") !== "reinversion_variable"
+                  watch("tipo_reinversion") !== "reinversion_variable" &&
+                  watch("tipo_reinversion") !== "reinversion_excedente"
                     ? "bg-gray-100 text-gray-400 cursor-not-allowed"
                     : "bg-white text-blue-900 placeholder-gray-400"
                 }`}
                 placeholder="0.00"
               />
+              {watch("tipo_reinversion") === "reinversion_excedente" && (
+                <p className="mt-1 text-xs text-blue-600">
+                  El inversionista recibe este monto fijo; el sobrante de su cuota se reinvierte.
+                </p>
+              )}
             </div>
 
             {/* Moneda */}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3470,6 +3470,7 @@ export type TipoReinversionEspejo =
   | "reinversion_interes"
   | "reinversion_total"
   | "reinversion_variable"
+  | "reinversion_excedente"
   | "reinversion_combinada";
 
 export interface AsignarReinversionPayload {

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -373,6 +373,7 @@ export interface SendCompraCarteraAcceptedNotificationParams {
       | "reinversion_interes"
       | "reinversion_total"
       | "reinversion_variable"
+      | "reinversion_excedente"
       | "reinversion_combinada"
       | null;
     rows: Array<{
@@ -434,6 +435,7 @@ export const sendCompraCarteraAcceptedNotification = async ({
       reinversion_interes: "Reinversión de Interés",
       reinversion_total: "Interés Compuesto",
       reinversion_variable: "Reinversión Variable",
+      reinversion_excedente: "Reinversión Excedente",
       reinversion_combinada: "Reinversión Combinada",
     };
 


### PR DESCRIPTION
## Resumen

Agrega una nueva modalidad de reinversión: **`reinversion_excedente`**.

Es la **inversa de `reinversion_variable`**: el campo de monto representa **lo que el inversionista quiere RECIBIR** (ej. Q30,000) y todo el **sobrante** de su cuota se reinvierte. Igual que variable, el monto es obligatorio.

| Modalidad | El monto significa | Resultado |
|---|---|---|
| `reinversion_variable` | lo que se **reinvierte** | recibe = cuota − monto |
| `reinversion_excedente` (nueva) | lo que se **recibe** | reinvierte = cuota − monto |

## Cambios

### Backend (`cartera-back`)
- **schema**: nuevo valor en el enum `tipo_reinversion`.
- **`investor.ts`**: casos en los switches per-pago y en los 3 bloques de ajuste global (`getInvestorTotals`, `getInvestorTotalsGlobales`, cálculo con `sg`). Fórmula: `total_reinversion = cuota − recibe`, `total_cuota = recibe`.
- **`ajustarPagosLiquidacion.ts`**: caso en switch + ajuste global.
- **`resumenGlobalLiquidaciones` (path pending)**: ramas de excedente en el SQL de `total_cuota`, `total_a_recibir_con_reinversion` y `total_reinversion`. ⚠️ **Sin esto el CRM mostraba/pagaba la cuota completa en vez del monto fijo** (el path liquidado ya estaba correcto porque lee de la tabla `liquidaciones`).
- **`mirrorInvestor` router**: valor agregado al `t.Enum` de validación.
- **`compraCarteraAceptada`**: union de tipos + `modalidadMap`.
- **`packages/email`**: union de tipos + `modalidadLabelCreditos`.

### Frontend (`carteraFront`)
- **`modalInvestor`**: nueva opción "Reinversión Excedente"; el campo de monto se habilita/exige también en excedente; etiqueta dinámica **"Monto a Recibir"** + nota aclaratoria.
- **`services`**: valor agregado a `TipoReinversionEspejo`.
- **`InvestorsList`**: botón "Agregar Inversionista" deshabilitado.

## Migración requerida (la corre el equipo)

\`\`\`sql
ALTER TYPE cartera.tipo_reinversion
  ADD VALUE IF NOT EXISTS 'reinversion_excedente'
  BEFORE 'reinversion_combinada';
\`\`\`
> Ya aplicada en local. Pendiente en prod. (`ADD VALUE` no debe ir dentro de una transacción que use el valor en la misma transacción.)

## Cobertura verificada del flujo de pago del CRM
- ✅ Card de pago (`total_cuota`) y monto de boleta (`total_a_recibir_con_reinversion`)
- ✅ Excel de transferencias ACH / terceros (usan `total_cuota`)
- ✅ Liquidación (`liquidateByInvestorId` → `getInvestorTotalsGlobales`)
- ✅ Sintaxis SQL validada contra Postgres local; las otras modalidades no cambian (solo se agregaron ramas nuevas al `CASE`)

## Pendiente de prueba
- [ ] Prueba end-to-end con un inversionista real en modalidad excedente (resumen pending + liquidación)

🤖 Generated with [Claude Code](https://claude.com/claude-code)