### PR TITLE
fix: normalizar teléfono en envío de cobros (primer número + código internacional)

### DIFF
--- a/apps/crm/apps/server/src/lib/simpletech.ts
+++ b/apps/crm/apps/server/src/lib/simpletech.ts
@@ -89,7 +89,15 @@ export function getSimpletechClient(): SimpleTechClient | null {
 }
 
 export function normalizePhone(phone: string): string {
-	const digits = phone.replaceAll(/\D/g, "");
+	// Un mismo registro puede traer varios teléfonos separados por coma
+	// (p. ej. "49289881, 25099248, 31123811"). Antes de limpiar no-dígitos
+	// nos quedamos SOLO con el primero; de lo contrario las comas se borran
+	// y los números quedan concatenados en uno inválido.
+	const primero = (phone.split(",")[0] ?? phone).trim();
+	const digits = primero.replaceAll(/\D/g, "");
+	// Si ya viene en formato internacional explícito (+<código>…, p. ej. "+1…"
+	// o "+01…"), respetamos ese código de país tal cual y NO anteponemos el 502.
+	if (primero.startsWith("+")) return `+${digits}`;
 	if (digits.startsWith("502")) return `+${digits}`;
 	return `+502${digits}`;
 }


### PR DESCRIPTION
## Problema

El envío **masivo de WhatsApp de cobros** fallaba para clientes con varios teléfonos registrados. El campo de teléfono puede traer varios números separados por coma, p. ej. `"49289881, 25099248, 31123811"`.

`normalizePhone` hacía `replaceAll(/\D/g, "")` sobre **todo** el string, lo que borraba las comas y **concatenaba** los números en uno solo inválido:

```
"49289881, 25099248, 31123811" → 502492898812509924831123811
```

Ejemplo real de respuesta del proveedor con números concatenados:
```json
{"number": "5025510597133023010", ...}
{"number": "50259589030463341415812207066692492", ...}
{"number": "502492898812509924831123811", ...}
```

## Solución

En `normalizePhone` (`apps/crm/apps/server/src/lib/simpletech.ts`), único punto por el que pasan **todos** los envíos (masivo e individual):

1. Tomar **solo el primer número** (corte por coma) antes de limpiar no-dígitos.
2. Si el teléfono ya viene en **formato internacional explícito** (`+<código>…`, p. ej. `+1…` / `+01…`), respetar ese código de país y **no** anteponer el `502`.

| Entrada | Salida |
|---|---|
| `"49289881, 25099248"` | `+50249289881` |
| `"50249289881"` | `+50249289881` |
| `"+1 555 123 4567"` | `+15551234567` |

## Notas

- La **modal de contacto individual** ya manejaba el caso: separa los números por coma en un selector y envía solo el seleccionado. Este fix cubre el masivo y queda como red de seguridad para todos los flujos.
- Sin migraciones de DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)