### PR TITLE
feat: reportar como descartados los envíos masivos que fallan en el proveedor

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3442,6 +3442,7 @@ export const cobrosRouter = {
 				telefonoReal: string; // destino original (para trazabilidad)
 				mensaje: string;
 				casoCobroId: string | null;
+				clienteNombre: string | null; // para reportar en descartados si falla
 			};
 			const candidatos: Candidato[] = [];
 			const descartados: Array<{
@@ -3514,6 +3515,7 @@ export const cobrosRouter = {
 					telefonoReal: telefono,
 					mensaje,
 					casoCobroId: sifco ? (casoIdPorSifco.get(sifco) ?? null) : null,
+					clienteNombre,
 				});
 			}
 
@@ -3560,8 +3562,22 @@ export const cobrosRouter = {
 				for (const c of chunk) {
 					const res = byRef.get(c.numeroSifco);
 					const ok = res?.success === true;
-					if (ok) enviados += 1;
-					else fallidos += 1;
+					if (ok) {
+						enviados += 1;
+					} else {
+						fallidos += 1;
+						// Los que el proveedor rechazó también se reportan como
+						// descartados para que aparezcan en la tabla/CSV y se les
+						// pueda dar seguimiento manual, igual que los pre-descartes.
+						const motivoFallo = res?.error?.trim()
+							? `Falló el envío: ${res.error.trim()}`
+							: "Falló el envío";
+						descartados.push({
+							numeroSifco: c.numeroSifco || null,
+							clienteNombre: c.clienteNombre,
+							motivo: motivoFallo,
+						});
+					}
 
 					detalle.push({
 						numeroSifco: c.numeroSifco,

--- a/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
@@ -189,9 +189,10 @@ export function MassWhatsappModal({
 				fechaHasta: filtros.fechaHasta,
 			}),
 		onSuccess: (res) => {
+			// `descartados` ya incluye los que fallaron en el proveedor, así que
+			// no se listan los `fallidos` aparte para no contarlos dos veces.
 			const partes = [
 				`${res.enviados} enviados`,
-				`${res.fallidos} fallidos`,
 				`${res.descartados.length} descartados`,
 			];
 			if (typeof res.contactosRegistrados === "number") {
@@ -376,9 +377,10 @@ export function MassWhatsappModal({
 						Descartados del envío masivo ({descartadosResult?.length ?? 0})
 					</DialogTitle>
 					<DialogDescription>
-						Estos créditos no recibieron mensaje porque les faltaba algún dato
-						(teléfono, cuota o asesor asignado). Podés exportarlos a CSV para
-						hacer seguimiento manual.
+						Estos créditos no recibieron el mensaje: o les faltaba algún dato
+						(teléfono, cuota o asesor asignado) o el envío falló en el
+						proveedor. El motivo de cada uno se indica en la última columna.
+						Podés exportarlos a CSV para hacer seguimiento manual.
 					</DialogDescription>
 				</DialogHeader>
 


### PR DESCRIPTION
## Contexto

En el envío **masivo de WhatsApp de cobros**, cuando un envío fallaba en el proveedor (SimpleTech) el caso solo sumaba al contador `fallidos` del toast, **sin decir cuál** crédito había fallado. Y en el caso de números inválidos que el proveedor aceptaba con `success: true` (p. ej. los números concatenados), el fallo era directamente **silencioso**: se contaba como enviado.

## Cambio

Los envíos que el proveedor rechaza ahora se agregan al array **`descartados`** con el motivo `"Falló el envío: <error>"`, de modo que:

- Aparecen en la **tabla de descartados** de la modal, junto a los pre-descartes (sin teléfono / cuota / asesor).
- Se pueden **exportar a CSV** para seguimiento manual.
- El **motivo** de cada uno se muestra en la última columna.

El toast deja de listar `fallidos` por separado para no contarlos dos veces (ya quedan dentro de `descartados`).

### Detalle técnico
- `cobros.ts`: se agrega `clienteNombre` al candidato y, en el loop de envío, los `!ok` se empujan a `descartados` con su motivo.
- `mass-whatsapp-modal.tsx`: toast sin doble conteo y descripción del diálogo actualizada para reflejar que ahí también caen los fallos de envío.

## Notas
- Sin migraciones de DB.
- Complementa el fix de normalización de teléfono (PR #793), que ataca la causa de los números inválidos. Este PR mejora la **visibilidad** de cualquier fallo de envío.

🤖 Generated with [Claude Code](https://claude.com/claude-code)