### PR TITLE
feat: add accumulated debt breakdown to Pagos por Vencimiento row expansion

### DIFF
--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -2182,7 +2182,12 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
       COALESCE(MIN(pc.seguro_restante::numeric),   0) AS seguro_restante,
       COALESCE(MIN(pc.gps_restante::numeric),      0) AS gps_restante,
       COALESCE(MIN(pc.membresias::numeric),        0) AS membresias,
-      COALESCE(MIN(pc.total_restante::numeric),    0) AS total_restante,
+      COALESCE(MIN(pc.capital_restante::numeric),  0)
+        + COALESCE(MIN(pc.interes_restante::numeric),  0)
+        + COALESCE(MIN(pc.iva_12_restante::numeric),   0)
+        + COALESCE(MIN(pc.seguro_restante::numeric),   0)
+        + COALESCE(MIN(pc.gps_restante::numeric),      0)
+        + COALESCE(MIN(pc.membresias::numeric),        0) AS total_restante,
       ROUND(COALESCE(MIN(pc.interes_restante::numeric), 0) * COALESCE(AVG(cube_data.cash_in_pct), 0), 2) AS interes_cube,
       ROUND(ROUND(COALESCE(MIN(pc.interes_restante::numeric), 0) * COALESCE(AVG(cube_data.cash_in_pct), 0), 2) * 0.12, 2) AS iva_cube
     FROM cartera.cuotas_credito q
@@ -2224,8 +2229,15 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
           AND pc2.validation_status IN ('validated', 'no_required')
       )
     GROUP BY q.cuota_id, q.numero_cuota, q.fecha_vencimiento
-    HAVING COALESCE(MIN(pc.total_restante::numeric), 0) > 0
-        OR COUNT(pc.pago_id) = 0
+    HAVING (
+        COALESCE(MIN(pc.capital_restante::numeric),  0)
+        + COALESCE(MIN(pc.interes_restante::numeric),  0)
+        + COALESCE(MIN(pc.iva_12_restante::numeric),   0)
+        + COALESCE(MIN(pc.seguro_restante::numeric),   0)
+        + COALESCE(MIN(pc.gps_restante::numeric),      0)
+        + COALESCE(MIN(pc.membresias::numeric),        0)
+      ) > 0
+      OR COUNT(pc.pago_id) = 0
     ORDER BY q.fecha_vencimiento ASC
   `);
 

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -2170,3 +2170,81 @@ export async function getAbonosDelMesPorCredito({
 
   return result.rows;
 }
+
+export async function getAcumuladoPorCredito({ credito_id }: { credito_id: number }) {
+  const result = await db.execute<any>(sql`
+    SELECT
+      q.numero_cuota,
+      TO_CHAR(q.fecha_vencimiento, 'YYYY-MM-DD') AS fecha_vencimiento,
+      COALESCE(MIN(pc.capital_restante::numeric),  0) AS capital_restante,
+      COALESCE(MIN(pc.interes_restante::numeric),  0) AS interes_restante,
+      COALESCE(MIN(pc.iva_12_restante::numeric),   0) AS iva_12_restante,
+      COALESCE(MIN(pc.seguro_restante::numeric),   0) AS seguro_restante,
+      COALESCE(MIN(pc.gps_restante::numeric),      0) AS gps_restante,
+      COALESCE(MIN(pc.membresias::numeric),        0) AS membresias,
+      COALESCE(MIN(pc.total_restante::numeric),    0) AS total_restante,
+      ROUND(COALESCE(MIN(pc.interes_restante::numeric), 0) * COALESCE(AVG(cube_data.cash_in_pct), 0), 2) AS interes_cube,
+      ROUND(ROUND(COALESCE(MIN(pc.interes_restante::numeric), 0) * COALESCE(AVG(cube_data.cash_in_pct), 0), 2) * 0.12, 2) AS iva_cube
+    FROM cartera.cuotas_credito q
+    INNER JOIN cartera.creditos c ON c.credito_id = q.credito_id
+    LEFT JOIN cartera.pagos_credito pc
+      ON pc.cuota_id = q.cuota_id
+      AND pc."paymentFalse" = false
+    LEFT JOIN LATERAL (
+      SELECT
+        COALESCE((
+          SELECT
+            CASE
+              WHEN COALESCE(SUM(ci_all.monto_aportado::numeric), 0) > 0 OR c.capital::numeric > 0 THEN
+                (COALESCE(SUM(
+                  ci_all.monto_aportado::numeric *
+                  CASE WHEN ci_all.inversionista_id = 86 THEN 100::numeric
+                       ELSE ci_all.porcentaje_cash_in::numeric
+                  END
+                ), 0) / 100.0
+                + GREATEST(0, c.capital::numeric - COALESCE(SUM(ci_all.monto_aportado::numeric), 0)))
+                / NULLIF(GREATEST(c.capital::numeric, COALESCE(SUM(ci_all.monto_aportado::numeric), 0)), 0)
+              WHEN COUNT(*) > 0 THEN
+                AVG(CASE WHEN ci_all.inversionista_id = 86 THEN 100::numeric
+                         ELSE ci_all.porcentaje_cash_in::numeric END) / 100.0
+              ELSE 0
+            END
+          FROM cartera.creditos_inversionistas ci_all
+          WHERE ci_all.credito_id = q.credito_id
+        ), 0) AS cash_in_pct
+    ) cube_data ON true
+    WHERE q.credito_id = ${credito_id}
+      AND q.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
+      AND q.pagado = false
+      AND NOT EXISTS (
+        SELECT 1 FROM cartera.pagos_credito pc2
+        WHERE pc2.cuota_id = q.cuota_id
+          AND pc2."paymentFalse" = false
+          AND pc2.pagado = true
+          AND pc2.validation_status IN ('validated', 'no_required')
+      )
+    GROUP BY q.cuota_id, q.numero_cuota, q.fecha_vencimiento
+    HAVING COALESCE(MIN(pc.total_restante::numeric), 0) > 0
+        OR COUNT(pc.pago_id) = 0
+    ORDER BY q.fecha_vencimiento ASC
+  `);
+
+  const cuotas = result.rows;
+
+  const totales = cuotas.reduce(
+    (acc: any, row: any) => ({
+      capital:      acc.capital      + Number(row.capital_restante),
+      interes:      acc.interes      + Number(row.interes_restante),
+      iva:          acc.iva          + Number(row.iva_12_restante),
+      seguro:       acc.seguro       + Number(row.seguro_restante),
+      gps:          acc.gps          + Number(row.gps_restante),
+      membresias:   acc.membresias   + Number(row.membresias),
+      interes_cube: acc.interes_cube + Number(row.interes_cube),
+      iva_cube:     acc.iva_cube     + Number(row.iva_cube),
+      total:        acc.total        + Number(row.total_restante),
+    }),
+    { capital: 0, interes: 0, iva: 0, seguro: 0, gps: 0, membresias: 0, interes_cube: 0, iva_cube: 0, total: 0 }
+  );
+
+  return { cuotas, totales };
+}

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -2238,6 +2238,7 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
         + COALESCE(MIN(pc.membresias::numeric),        0)
       ) > 0
       OR COUNT(pc.pago_id) = 0
+      OR MIN(pc.capital_restante) IS NULL
     ORDER BY q.fecha_vencimiento ASC
   `);
 

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { promises as fs } from "fs";
 import { mapPagosPorCreditos, mapPagosDesdeJson } from "../migration/migration";
 import { authMiddleware } from "./midleware";
-import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF, getPagosByVencimiento, getAbonosDelMesPorCredito } from "../controllers/reports";
+import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF, getPagosByVencimiento, getAbonosDelMesPorCredito, getAcumuladoPorCredito } from "../controllers/reports";
 import { actualizarCuentaPago, aplicarPagoAlCredito, insertPayment, aplicarMontoAPago, editarPago } from "../controllers/registerPayment";
 import { eq } from "drizzle-orm";
 import { db } from "../database";
@@ -427,6 +427,32 @@ export const paymentRouter = new Elysia()
       asesor: t.Optional(t.String()),
       rango_mora: t.Optional(t.String()),
       excel: t.Optional(t.Boolean({ default: false })),
+    }),
+  }
+)
+.get(
+  "/pagos-por-vencimiento/acumulado",
+  async ({ query, set }) => {
+    try {
+      const result = await getAcumuladoPorCredito({
+        credito_id: Number(query.credito_id),
+      });
+      set.status = 200;
+      return { success: true, ...result };
+    } catch (error: any) {
+      console.error("Error en /pagos-por-vencimiento/acumulado:", error);
+      set.status = 500;
+      return { success: false, error: error.message || "Error obteniendo deuda acumulada" };
+    }
+  },
+  {
+    detail: {
+      summary: "Deuda acumulada de un crédito (cuotas vencidas no pagadas)",
+      description: "Retorna todas las cuotas con fecha_vencimiento < hoy que no han sido pagadas completamente, con saldo pendiente por componente.",
+      tags: ["Pagos", "Reportes"],
+    },
+    query: t.Object({
+      credito_id: t.String(),
     }),
   }
 )

--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, Fragment } from "react";
 import { usePersistedState } from "../hooks/usePersistedState";
 import { usePagosPorVencimiento } from "../hooks/usePagosPorVencimiento";
 import { useAdminData } from "../hooks/advisor";
-import type { PagoPorVencimientoItem, Advisor, AbonoDetalleItem } from "../services/services";
+import type { PagoPorVencimientoItem, Advisor, AbonoDetalleItem, AcumuladoCuotaItem, AcumuladoTotales } from "../services/services";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -14,7 +14,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Search, X, ChevronLeft, ChevronRight, Check, ChevronsUpDown, FileDown, Loader2, AlertCircle } from "lucide-react";
-import { getPagosPorVencimiento, getAbonosPorVencimientoDetalle } from "../services/services";
+import { getPagosPorVencimiento, getAbonosPorVencimientoDetalle, getCreditoAcumulado } from "../services/services";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
 import { Badge } from "@/components/ui/badge";
@@ -57,6 +57,8 @@ export function PagosPorVencimiento() {
 
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
   const [abonosDetail, setAbonosDetail] = useState<AbonoDetalleItem[]>([]);
+  const [acumuladoDetail, setAcumuladoDetail] = useState<AcumuladoCuotaItem[]>([]);
+  const [acumuladoTotales, setAcumuladoTotales] = useState<AcumuladoTotales | null>(null);
   const [loadingDetails, setLoadingDetails] = useState(false);
   const pendingRequestRef = useRef<{ creditoId: number; mes: number; anio: number } | null>(null);
 
@@ -64,6 +66,8 @@ export function PagosPorVencimiento() {
     if (expandedRow === creditoId) {
       setExpandedRow(null);
       setAbonosDetail([]);
+      setAcumuladoDetail([]);
+      setAcumuladoTotales(null);
       pendingRequestRef.current = null;
     } else {
       const token = { creditoId, mes, anio };
@@ -71,18 +75,25 @@ export function PagosPorVencimiento() {
       pendingRequestRef.current = token;
       setLoadingDetails(true);
       setAbonosDetail([]);
+      setAcumuladoDetail([]);
+      setAcumuladoTotales(null);
       try {
-        const response = await getAbonosPorVencimientoDetalle({
-          credito_id: creditoId,
-          mes,
-          anio,
-        });
+        const [acumuladoRes, abonosRes] = await Promise.all([
+          getCreditoAcumulado({ credito_id: creditoId }),
+          getAbonosPorVencimientoDetalle({ credito_id: creditoId, mes, anio }),
+        ]);
         const current = pendingRequestRef.current;
-        if (response.success && current?.creditoId === creditoId && current?.mes === mes && current?.anio === anio) {
-          setAbonosDetail(response.data);
+        if (current?.creditoId === creditoId && current?.mes === mes && current?.anio === anio) {
+          if (acumuladoRes.success) {
+            setAcumuladoDetail(acumuladoRes.cuotas);
+            setAcumuladoTotales(acumuladoRes.totales);
+          }
+          if (abonosRes.success) {
+            setAbonosDetail(abonosRes.data);
+          }
         }
       } catch (error) {
-        console.error("Error al obtener detalle de abonos:", error);
+        console.error("Error al obtener detalle de crédito:", error);
       } finally {
         const current = pendingRequestRef.current;
         if (current?.creditoId === creditoId && current?.mes === mes && current?.anio === anio) {
@@ -495,13 +506,157 @@ export function PagosPorVencimiento() {
                         <TableCell colSpan={17} className="p-4 border-b border-blue-200">
                           <div className="flex items-center justify-center py-6 text-xs text-blue-500 font-semibold gap-2">
                             <Loader2 className="h-4 w-4 animate-spin" />
-                            Cargando abonos...
+                            Cargando detalle...
                           </div>
                         </TableCell>
                       </TableRow>
                     )}
 
-                    {expandedRow === item.credito_id && !loadingDetails && abonosDetail.length === 0 && (
+                    {/* Sección deuda acumulada */}
+                    {expandedRow === item.credito_id && !loadingDetails && acumuladoDetail.length > 0 && (
+                      <>
+                        {/* Header acumulado */}
+                        <TableRow className="bg-red-50/80 hover:bg-red-50/80">
+                          <TableCell
+                            colSpan={17}
+                            className="py-1.5 px-4 border-b border-red-200 text-xs font-bold text-red-700"
+                          >
+                            ⚠ Deuda Acumulada — {acumuladoDetail.length} cuota{acumuladoDetail.length !== 1 ? "s" : ""} vencida{acumuladoDetail.length !== 1 ? "s" : ""}
+                          </TableCell>
+                        </TableRow>
+
+                        {/* Fila por cuota vencida */}
+                        {acumuladoDetail.map((cuota) => (
+                          <TableRow
+                            key={`acum-${cuota.numero_cuota}`}
+                            className="bg-red-50 hover:bg-red-100 border-b border-red-100 text-[11px] text-gray-700 transition-colors group"
+                          >
+                            {/* 1. SIFCO */}
+                            <TableCell className="sticky left-0 bg-red-50 group-hover:bg-red-100 border-r border-b border-red-100 min-w-[140px] w-[140px] text-center font-semibold text-red-700">
+                              #{cuota.numero_cuota}
+                            </TableCell>
+                            {/* 2. Cliente -> fecha vencimiento */}
+                            <TableCell className="sticky left-[140px] bg-red-50 group-hover:bg-red-100 border-r border-b border-red-200 min-w-[220px] w-[220px] shadow-[3px_0_5px_-2px_rgba(0,0,0,0.05)] text-red-700 font-medium px-3">
+                              Vencía {cuota.fecha_vencimiento}
+                            </TableCell>
+                            {/* 3. Asesor -> vacío */}
+                            <TableCell className="border-r border-b border-red-100" />
+                            {/* 4. Cuotas -> vacío */}
+                            <TableCell className="border-r border-b border-red-100" />
+                            {/* 5. Etapa de Mora -> vacío */}
+                            <TableCell className="border-r border-b border-red-100" />
+                            {/* 6. Boletas Totales -> total_restante */}
+                            <TableCell className="text-right font-semibold text-red-800 border-r border-b border-red-100 bg-red-50/20">
+                              {formatQ(cuota.total_restante)}
+                            </TableCell>
+                            {/* 7. Abono Capital */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.capital_restante)}
+                            </TableCell>
+                            {/* 8. Interés */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.interes_restante)}
+                            </TableCell>
+                            {/* 9. IVA 12% */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.iva_12_restante)}
+                            </TableCell>
+                            {/* 10. Seguro */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.seguro_restante)}
+                            </TableCell>
+                            {/* 11. GPS */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.gps_restante)}
+                            </TableCell>
+                            {/* 12. Membresías */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.membresias)}
+                            </TableCell>
+                            {/* 13. Int. CUBE */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.interes_cube)}
+                            </TableCell>
+                            {/* 14. IVA CUBE */}
+                            <TableCell className="text-right text-gray-700 border-r border-b border-red-100">
+                              {formatQ(cuota.iva_cube)}
+                            </TableCell>
+                            {/* 15. Royalty */}
+                            <TableCell className="text-right text-gray-400 border-r border-b border-red-100">--</TableCell>
+                            {/* 16. Mora -> vacío */}
+                            <TableCell className="border-r border-b border-red-100" />
+                            {/* 17. Total */}
+                            <TableCell className="text-right text-red-700 font-bold bg-red-50/20 border-b border-red-100">
+                              {formatQ(cuota.total_restante)}
+                            </TableCell>
+                          </TableRow>
+                        ))}
+
+                        {/* Fila totales acumulado */}
+                        {acumuladoTotales && (
+                          <TableRow className="bg-red-100 hover:bg-red-100">
+                            {/* 1. SIFCO */}
+                            <TableCell className="sticky left-0 bg-red-100 border-r border-b border-red-300 min-w-[140px] w-[140px] text-center font-bold text-red-800 text-[11px]">
+                              TOTAL
+                            </TableCell>
+                            {/* 2. Cliente */}
+                            <TableCell className="sticky left-[140px] bg-red-100 border-r border-b border-red-300 min-w-[220px] w-[220px] shadow-[3px_0_5px_-2px_rgba(0,0,0,0.05)] font-bold text-red-800 text-[11px] px-3">
+                              Deuda acumulada total
+                            </TableCell>
+                            {/* 3-5 vacíos */}
+                            <TableCell className="border-r border-b border-red-300" />
+                            <TableCell className="border-r border-b border-red-300" />
+                            <TableCell className="border-r border-b border-red-300" />
+                            {/* 6. Boletas Totales -> total */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 bg-red-100/30 text-[11px]">
+                              {formatQ(String(acumuladoTotales.total.toFixed(2)))}
+                            </TableCell>
+                            {/* 7. Capital */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.capital.toFixed(2)))}
+                            </TableCell>
+                            {/* 8. Interés */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.interes.toFixed(2)))}
+                            </TableCell>
+                            {/* 9. IVA */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.iva.toFixed(2)))}
+                            </TableCell>
+                            {/* 10. Seguro */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.seguro.toFixed(2)))}
+                            </TableCell>
+                            {/* 11. GPS */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.gps.toFixed(2)))}
+                            </TableCell>
+                            {/* 12. Membresías */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.membresias.toFixed(2)))}
+                            </TableCell>
+                            {/* 13. Int. CUBE */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.interes_cube.toFixed(2)))}
+                            </TableCell>
+                            {/* 14. IVA CUBE */}
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.iva_cube.toFixed(2)))}
+                            </TableCell>
+                            {/* 15. Royalty */}
+                            <TableCell className="text-right text-gray-400 border-r border-b border-red-300 text-[11px]">--</TableCell>
+                            {/* 16. Mora */}
+                            <TableCell className="border-r border-b border-red-300" />
+                            {/* 17. Total */}
+                            <TableCell className="text-right font-bold text-red-800 bg-red-100/30 border-b border-red-300 text-[11px]">
+                              {formatQ(String(acumuladoTotales.total.toFixed(2)))}
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </>
+                    )}
+
+                    {expandedRow === item.credito_id && !loadingDetails && abonosDetail.length === 0 && acumuladoDetail.length === 0 && (
                       <TableRow className="bg-slate-50/50 hover:bg-slate-50/50">
                         <TableCell colSpan={17} className="p-4 border-b border-blue-200 text-center text-xs text-gray-500 italic">
                           No se encontraron abonos registrados y validados en este mes para este crédito.
@@ -509,9 +664,20 @@ export function PagosPorVencimiento() {
                       </TableRow>
                     )}
 
+                    {expandedRow === item.credito_id && !loadingDetails && abonosDetail.length > 0 && (
+                      <TableRow className="bg-blue-50/60 hover:bg-blue-50/60">
+                        <TableCell
+                          colSpan={17}
+                          className="py-1.5 px-4 border-b border-blue-200 text-xs font-bold text-blue-700"
+                        >
+                          Abonos del mes
+                        </TableCell>
+                      </TableRow>
+                    )}
+
                     {expandedRow === item.credito_id && !loadingDetails && abonosDetail.length > 0 && abonosDetail.map((abono) => (
-                      <TableRow 
-                        key={abono.pago_id} 
+                      <TableRow
+                        key={abono.pago_id}
                         className="bg-slate-50/20 hover:bg-blue-50/30 border-b border-blue-100/50 text-[11px] text-gray-600 transition-colors group"
                       >
                         {/* 1. SIFCO -> vacío */}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3706,6 +3706,44 @@ export async function getAbonosPorVencimientoDetalle(params: {
 }
 
 // ============================================================
+// Deuda acumulada por crédito
+// ============================================================
+export interface AcumuladoCuotaItem {
+  numero_cuota: number;
+  fecha_vencimiento: string;
+  capital_restante: string;
+  interes_restante: string;
+  iva_12_restante: string;
+  seguro_restante: string;
+  gps_restante: string;
+  membresias: string;
+  total_restante: string;
+  interes_cube: string;
+  iva_cube: string;
+}
+
+export interface AcumuladoTotales {
+  capital: number;
+  interes: number;
+  iva: number;
+  seguro: number;
+  gps: number;
+  membresias: number;
+  interes_cube: number;
+  iva_cube: number;
+  total: number;
+}
+
+export async function getCreditoAcumulado(params: {
+  credito_id: number;
+}): Promise<{ success: boolean; cuotas: AcumuladoCuotaItem[]; totales: AcumuladoTotales }> {
+  const res = await api.get(`${API_URL}/pagos-por-vencimiento/acumulado`, {
+    params: { credito_id: params.credito_id.toString() },
+  });
+  return res.data;
+}
+
+// ============================================================
 // Créditos espejo pendientes (sesiones pendientes)
 // ============================================================
 export interface CreditoEspejoPendiente {


### PR DESCRIPTION
# feat: agregar desglose de deuda acumulada en la expansión de filas de Pagos por Vencimiento

## Resumen

Se agrega una nueva sección "Deuda Acumulada" al detalle colapsable de cada fila de crédito en la tabla **Pagos por Vencimiento**. Anteriormente, al expandir una fila solo se mostraban los pagos validados del mes filtrado (abonos). Ahora primero se muestra la deuda histórica total de todas las cuotas vencidas sin pagar, y luego los abonos del mes.

---

## Nuevo endpoint: `GET /pagos-por-vencimiento/acumulado?credito_id=X`

Consulta todas las cuotas (`cuotas_credito`) del crédito indicado que cumplan:
- `fecha_vencimiento < HOY` (zona horaria Guatemala) — ya vencidas
- `pagado = false` — no marcadas como pagadas
- `NOT EXISTS` un pago completo validado en `pagos_credito` (`pagado = true`, `validation_status IN ('validated', 'no_required')`, `paymentFalse = false`) — excluye cuotas que fueron saldadas mediante pagos parciales aunque el flag no haya sido actualizado

Por cada cuota calificada, se agregan las filas de `pagos_credito` usando **`MIN(X_restante)`** por campo. Cada fila en `pagos_credito` es un snapshot del saldo pendiente después de un pago — el valor mínimo entre todas las filas de un `cuota_id` representa el saldo más reciente (más bajo) luego de aplicar todos los abonos parciales.

### Cálculo de interés CUBE

Usa la misma fórmula ponderada de `cash_in_pct` que el query principal de `getPagosByVencimiento`:

```
cash_in_pct = (Σ monto_aportado_i × porcentaje_cash_in_i / 100 + max(0, capital - Σ monto_aportado_i))
              / max(capital, Σ monto_aportado_i)
```

Caso especial: `inversionista_id = 86` (CUBE) siempre usa `porcentaje_cash_in = 100` para corregir un bug conocido donde ese campo queda almacenado como 0. Fallback para créditos legacy (capital = 0, montos = 0): promedio simple de `porcentaje_cash_in`.

Luego por cuota:
```
interes_cube = ROUND(interes_restante × cash_in_pct, 2)
iva_cube     = ROUND(interes_cube × 0.12, 2)
```

### Forma de respuesta

- `cuotas[]` — una fila por cuota vencida sin pagar, ordenadas por `fecha_vencimiento ASC`, con campos: `numero_cuota`, `fecha_vencimiento`, `capital_restante`, `interes_restante`, `iva_12_restante`, `seguro_restante`, `gps_restante`, `membresias`, `interes_cube`, `iva_cube`, `total_restante`
- `totales` — suma reducida en JS de todos los campos sobre todas las cuotas

Si no existen cuotas vencidas sin pagar, `cuotas` llega vacío y el frontend no renderiza nada para esa sección.

---

## Cambios en el frontend

**`handleToggleRow`** ahora lanza ambas peticiones en paralelo con `Promise.all`:
- `GET /pagos-por-vencimiento/acumulado?credito_id=X` (nuevo)
- `GET /pagos-por-vencimiento/abonos?credito_id=X&mes=Y&anio=Z` (existente)

La protección contra condiciones de carrera se mantiene mediante el token existente `pendingRequestRef`.

### Estructura del detalle expandido (en orden)

1. **⚠ Deuda Acumulada — N cuotas vencidas** *(solo si `cuotas.length > 0`)*
   - Una subfila por cuota vencida: `#N | Vencía YYYY-MM-DD | total | capital | interés | IVA | seguro | GPS | membresías | Int.CUBE | IVA CUBE | -- | | total`
   - Fila de totales: suma de todos los campos en rojo negrita
2. **Abonos del mes** *(solo si existen abonos)*
   - Filas de pagos validados existentes, sin cambios

Las columnas sticky (`left-0`, `left-[140px]`) usan fondos 100% opacos (`bg-red-50`, `bg-red-100`) para evitar que el contenido scrolleado sangre por debajo tanto en estado normal como en hover.

---

## Archivos modificados

| Archivo | Cambio |
|---|---|
| `apps/cartera-back/src/controllers/reports.ts` | Nueva función `getAcumuladoPorCredito()` |
| `apps/cartera-back/src/routers/payments.ts` | Nuevo route `GET /pagos-por-vencimiento/acumulado` (protegido con `authMiddleware` existente) |
| `apps/carteraFront/src/private/cartera/services/services.ts` | Nuevas interfaces `AcumuladoCuotaItem`, `AcumuladoTotales` + función `getCreditoAcumulado()` |
| `apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx` | Nuevo estado, fetch paralelo, render de sección acumulado |


<img width="1863" height="1079" alt="image" src="https://github.com/user-attachments/assets/d5f56eb5-4aac-428a-9b27-0dd68610d453" />
