### PR TITLE
feat(cartera-back): cierre mensual de cartera por estado

### DIFF
--- a/apps/cartera-back/drizzle/0006_add_cierre_mensual.sql
+++ b/apps/cartera-back/drizzle/0006_add_cierre_mensual.sql
@@ -1,0 +1,16 @@
+-- Cierre mensual de cartera: foto del estado por cada statusCredit.
+-- El job corre el día 5 de cada mes y `periodo` apunta al mes anterior (el que se cierra).
+CREATE TABLE IF NOT EXISTS cartera.cierre_mensual (
+  id                 serial PRIMARY KEY,
+  periodo            date NOT NULL,                       -- primer día del mes cerrado, ej. 2026-05-01
+  status_credit      text NOT NULL,
+  cantidad_creditos  integer NOT NULL DEFAULT 0,
+  capital_total      numeric(18,2) NOT NULL DEFAULT 0,    -- suma del campo capital (monto colocado) por estado
+  creditos_con_mora  integer NOT NULL DEFAULT 0,          -- créditos del estado con mora activa
+  capital_en_mora    numeric(18,2) NOT NULL DEFAULT 0,    -- capital de los créditos en mora
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+-- Idempotencia del job: una sola fila por (periodo, estado) -> permite upsert.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_cierre_mensual_periodo_status
+  ON cartera.cierre_mensual (periodo, status_credit);

--- a/apps/cartera-back/schedule.ts
+++ b/apps/cartera-back/schedule.ts
@@ -2,6 +2,7 @@ import schedule from 'node-schedule';
 import { procesarMoras } from './src/controllers/latefee';
 import { upsertEfectividadAsesores } from './src/controllers/paymentsByAdvisor';
 import { expirarCompraCarteraVencidas } from './src/controllers/expirarCompraCartera';
+import { generarCierreMensual } from './src/controllers/cierreMensual';
 
 const TZ_GUATEMALA = 'America/Guatemala';
 
@@ -52,6 +53,19 @@ export function iniciarTareasProgramadas() {
       );
     } catch (error) {
       console.error('❌ Error al ejecutar expirarCompraCarteraVencidas:', error);
+    }
+  });
+
+  // 📊 Cierre mensual de cartera - día 5 de cada mes a las 00:00 hora Guatemala.
+  //    Genera la foto del mes ANTERIOR (el que se cierra): conteo y capital por estado,
+  //    más el detalle de mora actual al momento de correr.
+  schedule.scheduleJob({ rule: '0 0 5 * *', tz: TZ_GUATEMALA }, async () => {
+    console.log('🗓️ Ejecutando generarCierreMensual (día 5, 00:00 Guatemala)...');
+    try {
+      const res = await generarCierreMensual();
+      console.log(`✅ cierreMensual: periodo=${res.periodo}, filas=${res.filas}`);
+    } catch (error) {
+      console.error('❌ Error al ejecutar generarCierreMensual:', error);
     }
   });
 

--- a/apps/cartera-back/src/controllers/cierreMensual.ts
+++ b/apps/cartera-back/src/controllers/cierreMensual.ts
@@ -1,0 +1,172 @@
+import { eq } from "drizzle-orm";
+import { db } from "../database";
+import {
+  creditos,
+  moras_credito,
+  cierre_mensual,
+  StatusCredit,
+} from "../database/db/schema";
+import Big from "big.js";
+import { toZonedTime } from "date-fns-tz";
+
+const TZ_GUATEMALA = "America/Guatemala";
+
+// Todos los estados posibles, para que la foto siempre tenga una fila por estado
+// (aunque ese mes no haya créditos en él).
+const TODOS_LOS_ESTADOS = Object.values(StatusCredit) as string[];
+
+/**
+ * Devuelve el primer día (YYYY-MM-01) del mes ANTERIOR a la fecha dada, en hora Guatemala.
+ * Ej: si hoy es 2026-06-05 → "2026-05-01" (se cierra mayo).
+ */
+function periodoMesAnterior(ref: Date): string {
+  const guate = toZonedTime(ref, TZ_GUATEMALA);
+  const anio = guate.getFullYear();
+  const mes = guate.getMonth(); // 0-index; este valor YA es el mes anterior al +1 humano
+  // mes actual humano = guate.getMonth()+1. El mes anterior es guate.getMonth() (1..12 cuando no es enero).
+  const primerDiaMesAnterior = new Date(anio, mes - 1, 1);
+  const y = primerDiaMesAnterior.getFullYear();
+  const m = String(primerDiaMesAnterior.getMonth() + 1).padStart(2, "0");
+  return `${y}-${m}-01`;
+}
+
+interface AcumEstado {
+  cantidad_creditos: number;
+  capital_total: Big;
+  creditos_con_mora: Set<number>;
+  capital_en_mora: Big;
+}
+
+/**
+ * Genera (o regenera) la foto mensual de la cartera.
+ *
+ * - `capital_total`: suma del campo `capital` (monto colocado) de los créditos por estado.
+ * - Las columnas de mora salen de la tabla OFICIAL de mora (`moras_credito` con `activa = true`),
+ *   la misma que llena el job `procesarMoras` junto con el estado MOROSO. Por eso un crédito
+ *   ACTIVO no arrastra mora (la mora activa va de la mano del estado MOROSO).
+ *
+ * Idempotente: hace upsert sobre (periodo, status_credit).
+ *
+ * @param periodoOverride opcional "YYYY-MM-01" para regenerar un mes específico.
+ *                        Si no se pasa, usa el mes anterior a hoy (hora Guatemala).
+ */
+export async function generarCierreMensual(periodoOverride?: string) {
+  const ahora = new Date();
+  const periodo = periodoOverride ?? periodoMesAnterior(ahora);
+
+  console.log("\n╔════════════════════════════════════════════════════════════");
+  console.log(`║ [JOB] 📊 GENERANDO CIERRE MENSUAL — periodo ${periodo}`);
+  console.log("╚════════════════════════════════════════════════════════════\n");
+
+  // 1. Inicializar acumulador con TODOS los estados en cero.
+  const acum: Record<string, AcumEstado> = {};
+  for (const estado of TODOS_LOS_ESTADOS) {
+    acum[estado] = {
+      cantidad_creditos: 0,
+      capital_total: new Big(0),
+      creditos_con_mora: new Set<number>(),
+      capital_en_mora: new Big(0),
+    };
+  }
+
+  // 2. Conteo y capital por estado (foto actual de creditos).
+  const creditosRows = await db
+    .select({
+      credito_id: creditos.credito_id,
+      capital: creditos.capital,
+      statusCredit: creditos.statusCredit,
+    })
+    .from(creditos);
+
+  // Mapa credito_id -> { estado, capital } para cruzar con la mora.
+  const creditoInfo = new Map<number, { estado: string; capital: Big }>();
+
+  for (const c of creditosRows) {
+    const estado = c.statusCredit ?? StatusCredit.ACTIVO;
+    if (!acum[estado]) {
+      // Estado inesperado (no en el enum): lo agregamos igual para no perder data.
+      acum[estado] = {
+        cantidad_creditos: 0,
+        capital_total: new Big(0),
+        creditos_con_mora: new Set<number>(),
+        cuotas_atrasadas: 0,
+        capital_en_mora: new Big(0),
+      };
+    }
+    const capital = new Big(c.capital ?? 0);
+    acum[estado].cantidad_creditos += 1;
+    acum[estado].capital_total = acum[estado].capital_total.plus(capital);
+    creditoInfo.set(c.credito_id, { estado, capital });
+  }
+
+  // 3. Mora OFICIAL: tabla moras_credito con activa=true (la que llena procesarMoras
+  //    junto con el estado MOROSO). Atribuimos cada mora a la fila del estado del crédito.
+  const moras = await db
+    .select({
+      credito_id: moras_credito.credito_id,
+    })
+    .from(moras_credito)
+    .where(eq(moras_credito.activa, true));
+
+  for (const m of moras) {
+    const info = creditoInfo.get(m.credito_id);
+    if (!info) continue; // mora huérfana, ignorar
+
+    const bucket = acum[info.estado];
+    if (!bucket.creditos_con_mora.has(m.credito_id)) {
+      bucket.creditos_con_mora.add(m.credito_id);
+      bucket.capital_en_mora = bucket.capital_en_mora.plus(info.capital);
+    }
+  }
+
+  // 4. Upsert por estado.
+  let filas = 0;
+  for (const [estado, data] of Object.entries(acum)) {
+    const valores = {
+      periodo,
+      status_credit: estado,
+      cantidad_creditos: data.cantidad_creditos,
+      capital_total: data.capital_total.toFixed(2),
+      creditos_con_mora: data.creditos_con_mora.size,
+      capital_en_mora: data.capital_en_mora.toFixed(2),
+    };
+
+    await db
+      .insert(cierre_mensual)
+      .values(valores)
+      .onConflictDoUpdate({
+        target: [cierre_mensual.periodo, cierre_mensual.status_credit],
+        set: {
+          cantidad_creditos: valores.cantidad_creditos,
+          capital_total: valores.capital_total,
+          creditos_con_mora: valores.creditos_con_mora,
+          capital_en_mora: valores.capital_en_mora,
+          created_at: new Date(),
+        },
+      });
+
+    console.log(
+      `  [${estado}] créditos=${valores.cantidad_creditos} capital=${valores.capital_total} ` +
+        `conMora=${valores.creditos_con_mora} capitalMora=${valores.capital_en_mora}`
+    );
+    filas++;
+  }
+
+  console.log(`\n✅ Cierre mensual generado: ${filas} filas para el periodo ${periodo}\n`);
+
+  return { ok: true, periodo, filas };
+}
+
+/**
+ * Lista las filas de cierre mensual, opcionalmente filtrando por periodo.
+ */
+export async function getCierreMensual(periodo?: string) {
+  const rows = periodo
+    ? await db
+        .select()
+        .from(cierre_mensual)
+        .where(eq(cierre_mensual.periodo, periodo))
+    : await db.select().from(cierre_mensual);
+
+  return rows;
+}

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -219,6 +219,36 @@
 
     createdAt: timestamp("createdat").defaultNow(),
   });
+  // 📊 Cierre mensual de cartera — foto del estado por cada statusCredit.
+  //    El job corre el día 5 de cada mes y `periodo` apunta al mes anterior (el que se cierra).
+  //    `capital_total` = suma del campo capital (monto colocado) de los créditos en ese estado.
+  //    Las columnas de mora reflejan el atraso ACTUAL al momento de generar la foto.
+  export const cierre_mensual = customSchema.table(
+    "cierre_mensual",
+    {
+      id: serial("id").primaryKey(),
+      periodo: date("periodo").notNull(), // Primer día del mes cerrado, ej. 2026-05-01 = cierre de mayo
+      status_credit: text("status_credit").notNull(),
+      cantidad_creditos: integer("cantidad_creditos").notNull().default(0),
+      capital_total: numeric("capital_total", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      creditos_con_mora: integer("creditos_con_mora").notNull().default(0),
+      capital_en_mora: numeric("capital_en_mora", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      created_at: timestamp("created_at", { withTimezone: true })
+        .notNull()
+        .defaultNow(),
+    },
+    (table) => ({
+      uqPeriodoStatus: uniqueIndex("uq_cierre_mensual_periodo_status").on(
+        table.periodo,
+        table.status_credit
+      ),
+    })
+  );
+
   export const moras_credito = customSchema.table("moras_credito", {
     mora_id: serial("mora_id").primaryKey(),
     credito_id: integer("credito_id")

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -42,7 +42,8 @@ const app = new Elysia()
   .use(routers.compraCarteraAceptadaRouter)
   .use(routers.devolucionRouter)
   .use(routers.creditosNuevosConAbonosRouter)
-  .use(routers.cuentasExtraInversionistaRouter);
+  .use(routers.cuentasExtraInversionistaRouter)
+  .use(routers.cierreMensualRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor
 iniciarTareasProgramadas();

--- a/apps/cartera-back/src/routers/cierreMensual.ts
+++ b/apps/cartera-back/src/routers/cierreMensual.ts
@@ -1,0 +1,44 @@
+import { Elysia, t } from "elysia";
+import { generarCierreMensual, getCierreMensual } from "../controllers/cierreMensual";
+import { authMiddleware } from "./midleware";
+
+export const cierreMensualRouter = new Elysia()
+  .use(authMiddleware)
+
+  // POST - Generar (o regenerar) la foto de cierre de un mes.
+  //   Sin body → usa el mes anterior a hoy (hora Guatemala).
+  //   Con { periodo: "2026-05-01" } → regenera ese mes específico.
+  .post(
+    "/cierre-mensual/generar",
+    async ({ body, set }) => {
+      try {
+        const periodo = (body as { periodo?: string })?.periodo;
+        const result = await generarCierreMensual(periodo);
+        set.status = 200;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return { message: "Error generando cierre mensual", error: String(error) };
+      }
+    },
+    {
+      body: t.Optional(
+        t.Object({
+          periodo: t.Optional(t.String()), // "YYYY-MM-01"
+        })
+      ),
+    }
+  )
+
+  // GET - Consultar el cierre. ?periodo=2026-05-01 para filtrar un mes.
+  .get("/cierre-mensual", async ({ query, set }) => {
+    try {
+      const { periodo } = query as Record<string, string>;
+      const rows = await getCierreMensual(periodo || undefined);
+      set.status = 200;
+      return rows;
+    } catch (error) {
+      set.status = 500;
+      return { message: "Error obteniendo cierre mensual", error: String(error) };
+    }
+  });

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -29,6 +29,7 @@ import { compraCarteraAceptadaRouter } from "./compraCarteraAceptada";
 import { devolucionRouter } from "./devolucion";
 import { creditosNuevosConAbonosRouter } from "./creditosNuevosConAbonos";
 import { cuentasExtraInversionistaRouter } from "./cuentasExtraInversionista";
+import { cierreMensualRouter } from "./cierreMensual";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,devolucionRouter,creditosNuevosConAbonosRouter,cuentasExtraInversionistaRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,devolucionRouter,creditosNuevosConAbonosRouter,cuentasExtraInversionistaRouter,cierreMensualRouter
 }


### PR DESCRIPTION
## Resumen

Backend del módulo **Cierre de Cartera**: genera y guarda una **foto mensual** de la cartera en una tabla nueva, para ver **con cuánto cerramos cada mes** — capital colocado por estado y detalle de mora. Incluye la tabla, un job programado y los endpoints.

> 🔗 El frontend que consume estos endpoints va en un PR aparte: `feat/cierre-cartera-front`.

## ¿Qué hace?

Cada mes genera una fila por cada estado de crédito (`statusCredit`) con:

- **Cantidad de créditos** en ese estado.
- **Capital total** = suma del campo `capital` (monto colocado) de esos créditos.
- **Créditos con mora** y **Capital en mora**, tomados de la tabla oficial de mora (`moras_credito` con `activa = true`), la misma que llena el job `procesarMoras` junto con el estado MOROSO.

> El `periodo` apunta al **mes anterior** (el que se cierra). El job corre el **día 5 de cada mes a las 00:00 hora Guatemala**, que es cuando se hace el cierre en la práctica.

## Cambios

### Base de datos
- Nueva tabla `cartera.cierre_mensual` (`drizzle/0006_add_cierre_mensual.sql` + definición en `schema.ts`).
- Columnas: `periodo`, `status_credit`, `cantidad_creditos`, `capital_total`, `creditos_con_mora`, `capital_en_mora`, `created_at`.
- Índice único en `(periodo, status_credit)` → el job es **idempotente** (hace upsert, nunca duplica).

### Controllers / Routers
- `src/controllers/cierreMensual.ts`:
  - `generarCierreMensual(periodo?)` — arma la foto. Incluye **todos** los estados (aunque tengan 0). Sin `periodo`, usa el mes anterior a hoy (hora Guatemala).
  - `getCierreMensual(periodo?)` — consulta.
- `src/routers/cierreMensual.ts`:
  - `POST /cierre-mensual/generar` — generar/regenerar manual (body opcional `{ "periodo": "YYYY-MM-01" }`).
  - `GET /cierre-mensual?periodo=YYYY-MM-01` — consultar.
  - Registrado en `routers/index.ts` e `index.ts`.

### Job programado
- `schedule.ts` — nuevo job `'0 0 5 * *'` (día 5, 00:00 GT), siguiendo el patrón de los jobs existentes (`procesarMoras`, etc.).

## Decisión de diseño: la mora se alinea al estado

La primera versión calculaba la mora como **atraso crudo** (cualquier cuota vencida y no pagada), lo que hacía que créditos **ACTIVO** mostraran capital en mora. Se cambió para que la mora salga de la tabla oficial `moras_credito` (activa), de modo que **un ACTIVO no arrastra mora**. También se decidió **no guardar cuotas atrasadas** y dejar la mora a nivel de crédito (créditos con mora + capital en mora).

## Pruebas realizadas

**1. Migración aplicada en local y en PROD** (idempotente, `CREATE TABLE IF NOT EXISTS`). Verificadas columnas e índices (`cierre_mensual_pkey`, `uq_cierre_mensual_periodo_status`).

**2. Generación ejecutada contra datos reales** (periodo `2026-05-01`):

| Estado | Créditos | Capital total | Créditos con mora | Capital en mora |
|---|---|---|---|---|
| ACTIVO | 635 | 70,007,809.41 | 1 | 49,150.84 |
| MOROSO | 763 | 73,798,457.04 | 763 | 73,798,457.04 |
| EN_CONVENIO | 47 | 4,285,944.49 | 0 | 0.00 |
| CAIDO | 26 | 3,536,320.02 | 0 | 0.00 |
| INCOBRABLE | 29 | 1,087,482.60 | 0 | 0.00 |
| PENDIENTE_CANCELACION | 19 | 742,281.48 | 0 | 0.00 |
| CANCELADO | 34 | 607,799.01 | 0 | 0.00 |

**3. Idempotencia**: generación corrida 3 veces seguidas → se mantienen **7 filas / 7 combinaciones únicas** (el upsert no duplica).

**4. Type-check**: sin errores (bun).

## Notas / pendiente

- El **job del día 5** y los endpoints empiezan a operar al desplegar esta rama. La tabla ya está creada en prod esperándolo.
- Queda **1 crédito ACTIVO con mora activa** (Q49,150) — es un **dato inconsistente real** (debería estar MOROSO), no un error del reporte. Pendiente decidir si se corrige el dato o se fuerza el reporte a contar mora solo en MOROSO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
