### PR TITLE
feat(cartera): botones Editar Inversionista / Compra de Cartera + fix saldo en pagos parciales

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -779,6 +779,26 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           )
           .orderBy(asc(pagos_credito.pago_id));
 
+        // Último pago PARCIAL aún `pending` de esta cuota (todavía no pasó por
+        // /aplicar-pago). El query de arriba excluye los `pending`, pero para
+        // el SALDO VIGENTE sí los necesitamos: si entran dos pagos a la misma
+        // cuota antes de validar el primero, el segundo debe partir del saldo
+        // que dejó el primero y NO re-aplicar los mismos rubros
+        // (interés/IVA/seguro/membresías). Ref: crédito 197, cuota 6.
+        const [ultimoParcialPendiente] = await db
+          .select({ pago: pagos_credito })
+          .from(pagos_credito)
+          .where(
+            and(
+              eq(pagos_credito.cuota_id, cuota.cuotas_credito.cuota_id),
+              eq(pagos_credito.credito_id, credito.credito_id),
+              eq(pagos_credito.validationStatus, "pending"),
+              eq(pagos_credito.paymentFalse, false)
+            )
+          )
+          .orderBy(desc(pagos_credito.pago_id))
+          .limit(1);
+
         const pagoOriginal = allExistingPagos.find(
           (p) => p.pago.validationStatus === "no_required"
         );
@@ -799,10 +819,22 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
         const tienePagosValidados = allExistingPagos.some(
           ({ pago }) => pago.validationStatus === "validated"
         );
-        // El pago original es la fila destino; el último validado parcial
-        // trae el saldo vigente cuando ya hubo abonos parciales.
+        // El pago original es la fila destino. Para el SALDO VIGENTE tomamos el
+        // abono parcial MÁS RECIENTE con restante —sea `validated` o `pending`—
+        // quedándonos con el de pago_id más alto. Así un 2.º pago a la misma
+        // cuota parte de lo que abonó el 1.º aunque aún no se haya validado, y
+        // no duplica interés/IVA/seguro/membresías.
         const existingPago = pagoOriginal ?? allExistingPagos[0];
-        const pagoSaldoVigente = ultimoPagoValidadoConRestante ?? existingPago;
+        const candidatosSaldo = [
+          ultimoPagoValidadoConRestante,
+          ultimoParcialPendiente && tieneRestante(ultimoParcialPendiente.pago)
+            ? ultimoParcialPendiente
+            : undefined,
+        ].filter(Boolean) as { pago: typeof pagos_credito.$inferSelect }[];
+        const saldoMasReciente = candidatosSaldo.sort(
+          (a, b) => b.pago.pago_id - a.pago.pago_id
+        )[0];
+        const pagoSaldoVigente = saldoMasReciente ?? existingPago;
         // Inicializar variables de abono
         // 2. OBTENER LOS RESTANTES DEL PAGO EXISTENTE (no de la cuota)
         const interes_restante = new Big(

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -556,6 +556,63 @@ export function TableInvestors() {
     setModalOpen(true);
   };
 
+  // Abre el modal de Compra de Cartera para un inversionista (reutilizable: tarjeta y header)
+  const handleAbrirCompraCartera = (inv: any) => {
+    setCompraCarteraInvId(inv.inversionista_id);
+    setCompraCarteraMonto("");
+    // Default compra_cartera → fecha de hoy (editable)
+    setCompraCarteraFecha(new Date().toISOString().split("T")[0]);
+    setCompraCarteraTipoReinversion("sin_reinversion");
+    setCompraCarteraTipoOperacion("compra_cartera");
+    // Calcular moda del porcentaje de participación desde créditos existentes
+    const creditos = inv.creditos ?? [];
+    if (creditos.length > 0) {
+      const freq = new Map<string, number>();
+      for (const c of creditos) {
+        const pct = String(Math.round(Number(c.porcentaje_inversionista ?? 0)));
+        freq.set(pct, (freq.get(pct) ?? 0) + 1);
+      }
+      let modaPct = "70";
+      let maxCount = 0;
+      for (const [pct, count] of freq) {
+        if (count > maxCount) { modaPct = pct; maxCount = count; }
+      }
+      setCompraCarteraPctInv(modaPct);
+      setCompraCarteraPctCashIn(String(100 - Number(modaPct)));
+    } else {
+      setCompraCarteraPctInv("70");
+      setCompraCarteraPctCashIn("30");
+    }
+    setCompraCarteraOpen(true);
+  };
+
+  // Inversionista objetivo para los botones del header: el de la lista filtrada (currentInv)
+  // o, si no tiene créditos y no aparece en la lista, el del catálogo (para igual permitir editar/comprar)
+  const headerInv = useMemo(() => {
+    if (currentInv) return currentInv;
+    if (selectedInvestor === "" || selectedInvestor === undefined) return null;
+    const cat: any = investors.find(
+      (i: any) => i.inversionista_id === Number(selectedInvestor)
+    );
+    if (!cat) return null;
+    return {
+      inversionista_id: cat.inversionista_id,
+      nombre_inversionista: cat.nombre,
+      emite_factura: cat.emite_factura,
+      reinversion: cat.reinversion,
+      banco_id: cat.banco,
+      tipo_cuenta: cat.tipo_cuenta,
+      numero_cuenta: cat.numero_cuenta,
+      re_inversion: cat.tipo_reinversion,
+      moneda: cat.moneda,
+      dpi: cat.dpi ?? "",
+      tipo_reinversion: cat.tipo_reinversion,
+      monto_reinversion: cat.monto_reinversion ?? 0,
+      email: cat.email,
+      creditos: cat.creditos ?? [],
+    };
+  }, [currentInv, selectedInvestor, investors]);
+
   // Dentro del componente, agregar estados
   const [modalBoletaOpen, setModalBoletaOpen] = useState(false);
 const [inversionistaParaBoleta, setInversionistaParaBoleta] = useState<{
@@ -825,6 +882,32 @@ const handleAbrirModalBoleta = (inversionista?: { id: number; nombre: string; dp
             >
               <RefreshCw className={`w-5 h-5 ${isFetching ? "animate-spin" : ""}`} />
               <span className="hidden sm:inline">Recargar</span>
+            </button>
+          )}
+
+          {/* Editar Inversionista - visible cuando hay inversionista seleccionado (aunque no tenga créditos) */}
+          {selectedInvestor !== "" && headerInv && (
+            <button
+              onClick={() => handleEditInvestor(headerInv)}
+              className="px-4 py-2 rounded-lg bg-amber-500 text-white font-bold hover:bg-amber-600 active:scale-95 transition-all flex items-center gap-2 justify-center shadow-sm"
+              title="Editar el inversionista seleccionado"
+            >
+              <Edit className="w-5 h-5" />
+              <span className="hidden sm:inline">Editar Inversionista</span>
+              <span className="sm:hidden">Editar</span>
+            </button>
+          )}
+
+          {/* Compra de Cartera - visible cuando hay inversionista seleccionado (aunque no tenga créditos) */}
+          {selectedInvestor !== "" && headerInv && (
+            <button
+              onClick={() => handleAbrirCompraCartera(headerInv)}
+              className="px-4 py-2 rounded-lg bg-emerald-600 text-white font-bold hover:bg-emerald-700 active:scale-95 transition-all flex items-center gap-2 justify-center shadow-sm"
+              title="Registrar compra de cartera / reinversión para el inversionista seleccionado"
+            >
+              <ShoppingCart className="w-5 h-5" />
+              <span className="hidden sm:inline">Compra de Cartera</span>
+              <span className="sm:hidden">Compra</span>
             </button>
           )}
 
@@ -1293,32 +1376,7 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 <DropdownMenuItem
                   onClick={(e) => {
                     e.stopPropagation();
-                    setCompraCarteraInvId(inv.inversionista_id);
-                    setCompraCarteraMonto("");
-                    // Default compra_cartera → fecha de hoy (editable)
-                    setCompraCarteraFecha(new Date().toISOString().split("T")[0]);
-                    setCompraCarteraTipoReinversion("sin_reinversion");
-                    setCompraCarteraTipoOperacion("compra_cartera");
-                    // Calcular moda del porcentaje de participación desde créditos existentes
-                    const creditos = inv.creditos ?? [];
-                    if (creditos.length > 0) {
-                      const freq = new Map<string, number>();
-                      for (const c of creditos) {
-                        const pct = String(Math.round(Number(c.porcentaje_inversionista ?? 0)));
-                        freq.set(pct, (freq.get(pct) ?? 0) + 1);
-                      }
-                      let modaPct = "70";
-                      let maxCount = 0;
-                      for (const [pct, count] of freq) {
-                        if (count > maxCount) { modaPct = pct; maxCount = count; }
-                      }
-                      setCompraCarteraPctInv(modaPct);
-                      setCompraCarteraPctCashIn(String(100 - Number(modaPct)));
-                    } else {
-                      setCompraCarteraPctInv("70");
-                      setCompraCarteraPctCashIn("30");
-                    }
-                    setCompraCarteraOpen(true);
+                    handleAbrirCompraCartera(inv);
                   }}
                   className="cursor-pointer rounded-lg px-3 py-2.5 focus:bg-emerald-50"
                 >


### PR DESCRIPTION
## Resumen
Dos cambios en cartera:
1. **Front** — botones **Editar Inversionista** y **Compra de Cartera** en el header de `TableInvestors`.
2. **Back** — fix de **saldo vigente** cuando hay varios pagos parciales a la misma cuota.

---

## 1) feat(front): botones en el header de TableInvestors
**Archivo:** `apps/carteraFront/src/private/cartera/components/tableInvestors.tsx`

- Agrega **Editar Inversionista** y **Compra de Cartera** a la fila de acciones del header.
- Se muestran cuando hay un inversionista seleccionado en el filtro — **aunque no tenga créditos** (fallback al catálogo de inversionistas).
- Se extrae `handleAbrirCompraCartera` como **helper reutilizable**, usado también en el menú de cada tarjeta (se elimina duplicación).

**Por qué:** antes, las acciones de inversionista solo eran accesibles desde una tarjeta de crédito; si el inversionista no tenía créditos listados, no había forma de editarlo ni registrarle una compra de cartera desde esa vista.

---

## 2) fix(back): saldo vigente con pagos parciales `pending`
**Archivo:** `apps/cartera-back/src/controllers/registerPayment.ts`

Cuando se hacen **varios pagos parciales a la misma cuota**, el segundo pago debe partir del **saldo que dejó el primero**, aunque ese primer pago **todavía no esté validado** (`pending`, antes de pasar por `/aplicar-pago`).

**Problema:** el query de pagos existentes excluía los `pending`, así que para el cálculo del saldo vigente solo se consideraban los `validated`. Resultado: un 2.º pago a la misma cuota **re-aplicaba los mismos rubros** (interés, IVA, seguro, membresías) en lugar de partir del restante.

**Fix:** ahora el **saldo vigente** se toma del abono parcial **más reciente con restante** — sea `validated` o `pending` — quedándose con el de `pago_id` más alto:
- Se busca el último parcial `pending` (`paymentFalse=false`) de la cuota.
- Se arma una lista de candidatos (`ultimoPagoValidadoConRestante` + el `pending` con restante) y se ordena por `pago_id` desc.
- El de mayor `pago_id` define el saldo de partida.

Así un 2.º pago parte de lo que abonó el 1.º y **no duplica** interés/IVA/seguro/membresías.

**Ref de reproducción:** crédito 197, cuota 6.

---

## Riesgo / alcance
- Cambio acotado a la lógica de **saldo restante** dentro de `registerPayment` (no toca certificación/facturación).
- El front es puramente de UI/acciones (no cambia datos).

## Cómo probar
1. **Front:** seleccionar un inversionista en el filtro de `TableInvestors` (incluido uno sin créditos) → deben verse los botones **Editar Inversionista** y **Compra de Cartera** en el header.
2. **Back:** sobre una cuota, registrar un pago parcial (queda `pending`) y luego un 2.º pago a la **misma cuota** antes de validar el 1.º → el 2.º debe partir del **restante** del 1.º, sin re-aplicar interés/IVA/seguro/membresías.

🤖 Generado con [Claude Code](https://claude.com/claude-code)
