### PR TITLE
fix(cartera): corregir variable no definida en registerPayment

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -843,7 +843,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
         // no duplica interés/IVA/seguro/membresías.
         const existingPago = pagoOriginal ?? allExistingPagos[0];
         const candidatosSaldo = [
-          ultimoPagoValidadoConRestante,
+          ultimoPagoParcialConRestante,
           ultimoParcialPendiente && tieneRestante(ultimoParcialPendiente.pago)
             ? ultimoParcialPendiente
             : undefined,


### PR DESCRIPTION
## Problema

Al registrar un pago, el endpoint fallaba con:

```
{ "message": "Internal server error", "error": "ultimoPagoValidadoConRestante is not defined" }
```

## Causa

En `registerPayment.ts`, la variable está declarada como `ultimoPagoParcialConRestante`, pero en el arreglo `candidatosSaldo` se referenciaba con el nombre viejo `ultimoPagoValidadoConRestante`, que no existe. Quedó así tras un renombrado (el comentario de contexto ya hablaba de "abono parcial... sea `validated` o `pending`").

## Solución

Referenciar la variable con el nombre correcto `ultimoPagoParcialConRestante`.

- 1 línea cambiada.
- `tsc --noEmit` no reporta errores en el archivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)