### PR TITLE
feat: monitoreo de facturas no certificadas en SAT (tabla + 2 jobs)

### DIFF
--- a/apps/cartera-back/schedule.ts
+++ b/apps/cartera-back/schedule.ts
@@ -3,6 +3,10 @@ import { procesarMoras } from './src/controllers/latefee';
 import { upsertEfectividadAsesores } from './src/controllers/paymentsByAdvisor';
 import { expirarCompraCarteraVencidas } from './src/controllers/expirarCompraCartera';
 import { generarCierreMensual } from './src/controllers/cierreMensual';
+import {
+  verificarFacturasSat,
+  reportarFacturasFallidasSat,
+} from './src/controllers/verificarFacturasSat';
 
 const TZ_GUATEMALA = 'America/Guatemala';
 
@@ -66,6 +70,31 @@ export function iniciarTareasProgramadas() {
       console.log(`✅ cierreMensual: periodo=${res.periodo}, filas=${res.filas}`);
     } catch (error) {
       console.error('❌ Error al ejecutar generarCierreMensual:', error);
+    }
+  });
+
+  // 🧾 Verificación de facturas en SAT - cada 15 min, 8:00–19:00 hora Guatemala.
+  //    Revisa las facturas ACTIVA nuevas (desde el último cursor) y registra en
+  //    cartera.facturas_fallidas_sat las que NO se encuentran en SAT.
+  schedule.scheduleJob({ rule: '*/15 8-19 * * *', tz: TZ_GUATEMALA }, async () => {
+    console.log('🧾 Ejecutando verificarFacturasSat...');
+    try {
+      const res = await verificarFacturasSat();
+      console.log(`✅ verificarFacturasSat: revisadas=${res.revisadas}, fallidas=${res.fallidas}`);
+    } catch (error) {
+      console.error('❌ Error al ejecutar verificarFacturasSat:', error);
+    }
+  });
+
+  // 📧 Reporte por correo de facturas fallidas - cada hora, 8:00–19:00 hora Guatemala.
+  //    Envía todas las fallidas PENDIENTE; si no hay, no envía correo.
+  schedule.scheduleJob({ rule: '0 8-19 * * *', tz: TZ_GUATEMALA }, async () => {
+    console.log('📧 Ejecutando reportarFacturasFallidasSat...');
+    try {
+      const res = await reportarFacturasFallidasSat();
+      console.log(`✅ reportarFacturasFallidasSat: enviadas=${res.enviadas}`);
+    } catch (error) {
+      console.error('❌ Error al ejecutar reportarFacturasFallidasSat:', error);
     }
   });
 

--- a/apps/cartera-back/src/cofidi/satClientService.ts
+++ b/apps/cartera-back/src/cofidi/satClientService.ts
@@ -24,6 +24,22 @@ interface CertificacionResponse {
   xmlCertificado: string;
 }
 
+function normalizarMensajeCofidi(mensaje: string): string {
+  return mensaje
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+}
+
+function esDocumentoNoEncontrado(mensaje: string | undefined): boolean {
+  if (!mensaje) return false;
+  const normalizado = normalizarMensajeCofidi(mensaje);
+  return (
+    /(documento|dte|uuid).*no (se )?(encontro|encontrado|existe)/.test(normalizado) ||
+    /no (se )?(encontro|existe).*(documento|dte|uuid)/.test(normalizado)
+  );
+}
+
 export class SATClientService {
   private credentials: SATCredentials;
   private endpointUrl: string;
@@ -351,9 +367,14 @@ export class SATClientService {
       const resultSuccess = response?.['Result'] === 'true' || response?.['Result'] === true;
       
       if (!resultSuccess) {
+        const mensaje = response?.['Description'];
+        if (!esDocumentoNoEncontrado(mensaje)) {
+          throw new Error(`GET_DOCUMENT fallo: ${mensaje || 'sin descripcion'}`);
+        }
+
         return {
           encontrado: false,
-          mensaje: response?.['Description'] || 'Documento no encontrado'
+          mensaje
         };
       }
 

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -93,10 +93,29 @@ async function verificarEnSat(
   }
 }
 
+// Marca como RESUELTA toda fallida PENDIENTE cuya factura ya esté ANULADA en
+// la BD (así deja de aparecer en el reporte). Devuelve cuántas resolvió.
+async function resolverFallidasAnuladas(): Promise<number> {
+  const r: any = await db.execute(sql`
+    UPDATE cartera.facturas_fallidas_sat AS ff
+    SET status = 'RESUELTA', resuelta_at = now(), updated_at = now()
+    FROM cartera.facturas_electronicas AS fe
+    WHERE ff.factura_id = fe.factura_id
+      AND ff.status = 'PENDIENTE'
+      AND fe.status = 'ANULADA'
+  `);
+  const n = r?.rowCount ?? 0;
+  if (n > 0) console.log(`🧹 [facturas_fallidas_sat] ${n} resuelta(s) por estar ANULADA en BD`);
+  return n;
+}
+
 // ============================================================
 // JOB 1: verificar facturas nuevas contra SAT
 // ============================================================
 export async function verificarFacturasSat() {
+  // 0) Limpiar fallidas que ya fueron anuladas en la BD
+  await resolverFallidasAnuladas();
+
   // 1) Cursor
   const [chk] = await db
     .select()
@@ -194,6 +213,9 @@ export async function verificarFacturasSat() {
 // JOB 2: reportar por correo las fallidas pendientes
 // ============================================================
 export async function reportarFacturasFallidasSat() {
+  // Quitar del reporte las que ya fueron anuladas en la BD
+  await resolverFallidasAnuladas();
+
   const pendientes = await db
     .select()
     .from(facturas_fallidas_sat)

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -165,7 +165,8 @@ export async function verificarFacturasSat() {
     .where(eq(job_checkpoints.job_name, JOB_NAME));
   const cursor = chk?.last_factura_id ?? 0;
 
-  // 2) Candidatos: ACTIVA, factura_id > cursor, certificadas hace >= GRACE_MINUTES
+  // 2) Candidatos: ACTIVA, factura_id > cursor. El grace se valida en orden
+  // dentro del loop para no saltar facturas recientes con IDs menores.
   const candidatos = await db
     .select({
       factura_id: facturas_electronicas.factura_id,
@@ -183,8 +184,7 @@ export async function verificarFacturasSat() {
     .where(
       and(
         gt(facturas_electronicas.factura_id, cursor),
-        eq(facturas_electronicas.status, "ACTIVA"),
-        sql`${facturas_electronicas.fecha_certificacion} <= now() - (${GRACE_MINUTES} || ' minutes')::interval`
+        eq(facturas_electronicas.status, "ACTIVA")
       )
     )
     .orderBy(facturas_electronicas.factura_id);
@@ -197,13 +197,26 @@ export async function verificarFacturasSat() {
 
   let fallidas = 0;
   let errores = 0;
+  let revisadas = 0;
   let maxId = cursor;
   // Una vez que una consulta a SAT falla, NO avanzamos el cursor más allá de
   // esa factura: se reintentará en la próxima corrida. Así una caída de SAT no
   // hace que se salten facturas para siempre.
   let congelado = false;
+  const fechaLimite = Date.now() - GRACE_MINUTES * 60 * 1000;
 
   for (const f of candidatos) {
+    const fechaCertificacion = f.fecha_certificacion
+      ? new Date(f.fecha_certificacion).getTime()
+      : Number.NaN;
+    if (!Number.isFinite(fechaCertificacion) || fechaCertificacion > fechaLimite) {
+      console.log(
+        `🧾 [verificarFacturasSat] Factura ${f.serie}-${f.numero} (${f.factura_id}) aún no es elegible por grace. Cursor detenido en ${maxId}.`
+      );
+      break;
+    }
+
+    revisadas++;
     const { estado, mensaje } = await verificarEnSat(f.uuid, f.emisor_nit);
 
     if (estado === "error") {
@@ -264,9 +277,9 @@ export async function verificarFacturasSat() {
   }
 
   console.log(
-    `🧾 [verificarFacturasSat] revisadas=${candidatos.length} fallidas=${fallidas} errores=${errores} cursor=${cursor}->${maxId}`
+    `🧾 [verificarFacturasSat] revisadas=${revisadas} fallidas=${fallidas} errores=${errores} cursor=${cursor}->${maxId}`
   );
-  return { revisadas: candidatos.length, fallidas, errores };
+  return { revisadas, fallidas, errores };
 }
 
 // ============================================================

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -109,12 +109,48 @@ async function resolverFallidasAnuladas(): Promise<number> {
   return n;
 }
 
+// Re-verifica contra SAT las fallidas que siguen PENDIENTE. Si una ya aparece
+// en SAT (apareció después del grace por propagación lenta), la marca RESUELTA
+// para que no genere alertas falsas para siempre. Devuelve cuántas resolvió.
+async function revalidarPendientes(): Promise<number> {
+  const pendientes = await db
+    .select({
+      factura_id: facturas_fallidas_sat.factura_id,
+      uuid: facturas_fallidas_sat.uuid,
+      emisor_nit: facturas_fallidas_sat.emisor_nit,
+    })
+    .from(facturas_fallidas_sat)
+    .where(eq(facturas_fallidas_sat.status, "PENDIENTE"));
+
+  let resueltas = 0;
+  for (const p of pendientes) {
+    const { encontrado, mensaje } = await verificarEnSat(p.uuid, p.emisor_nit);
+    if (encontrado) {
+      resueltas++;
+      await db
+        .update(facturas_fallidas_sat)
+        .set({
+          status: "RESUELTA",
+          resuelta_at: sql`now()`,
+          updated_at: sql`now()`,
+          mensaje_sat: `Apareció en SAT al revalidar (${mensaje})`,
+        })
+        .where(eq(facturas_fallidas_sat.factura_id, p.factura_id));
+    }
+  }
+  if (resueltas > 0)
+    console.log(`🔁 [facturas_fallidas_sat] ${resueltas} resuelta(s) al reaparecer en SAT`);
+  return resueltas;
+}
+
 // ============================================================
 // JOB 1: verificar facturas nuevas contra SAT
 // ============================================================
 export async function verificarFacturasSat() {
-  // 0) Limpiar fallidas que ya fueron anuladas en la BD
+  // 0) Limpiar fallidas que ya fueron anuladas en la BD y re-validar las que
+  //    ya aparecieron en SAT (evita alertas falsas permanentes).
   await resolverFallidasAnuladas();
+  await revalidarPendientes();
 
   // 1) Cursor
   const [chk] = await db
@@ -213,8 +249,10 @@ export async function verificarFacturasSat() {
 // JOB 2: reportar por correo las fallidas pendientes
 // ============================================================
 export async function reportarFacturasFallidasSat() {
-  // Quitar del reporte las que ya fueron anuladas en la BD
+  // Quitar del reporte las que ya fueron anuladas en la BD y las que ya
+  // reaparecieron en SAT, para que el correo solo liste fallidas reales.
   await resolverFallidasAnuladas();
+  await revalidarPendientes();
 
   const pendientes = await db
     .select()
@@ -278,11 +316,23 @@ export async function reportarFacturasFallidasSat() {
       <p style="color:#888;font-size:12px;margin-top:16px;">Reporte automático — Cartera Cash-In.</p>
     </div>`;
 
-  await sendPlainEmail(
+  const envio = await sendPlainEmail(
     destinatarios,
     `⚠️ ${pendientes.length} factura(s) no certificada(s) en SAT`,
     html
   );
+
+  // sendPlainEmail NO lanza si Resend falla: resuelve { success:false, error }.
+  // Hay que detectarlo para no reportar como enviado algo que no salió.
+  if (!envio?.success) {
+    console.error(
+      `❌ [reportarFacturasFallidasSat] El correo NO se pudo enviar:`,
+      envio?.error
+    );
+    throw new Error(
+      `Falló el envío del reporte de facturas fallidas: ${JSON.stringify(envio?.error)}`
+    );
+  }
 
   console.log(
     `📧 [reportarFacturasFallidasSat] correo enviado a ${destinatarios.length} destinatario(s) con ${pendientes.length} pendiente(s)`

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -39,6 +39,7 @@ const DEFAULT_EMAILS = [
   "daniel.r@clubcashin.com",
   "diego.a@sepresta.com",
   "lralda@clubcashin.com",
+  "caja@sepresta.com",
 ];
 
 // ------------------------------------------------------------

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -35,7 +35,7 @@ const REINTENTO_MS = 2000;
 // Destinatarios del correo (configurable por env, con default).
 const DEFAULT_EMAILS = [
   "diego.l@clubcashin.com",
-  "jalvarado@clubcashin.com",
+  "jalvaradp@clubcashin.com",
   "daniel.r@clubcashin.com",
   "diego.a@sepresta.com",
   "lralda@clubcashin.com",

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -74,11 +74,17 @@ function getSatClientPorEmisor(emisorNit: string | null | undefined): SATClientS
   );
 }
 
-// Consulta SAT con un reintento corto. Devuelve {encontrado, mensaje}.
+type EstadoSat = "found" | "not_found" | "error";
+
+// Consulta SAT con un reintento corto. Devuelve un estado de 3 valores:
+//  - "found": la factura está en SAT.
+//  - "not_found": SAT respondió que NO existe -> es una fallida real.
+//  - "error": la consulta falló (red/timeout/parse). NO concluye nada: la
+//    factura no se marca fallida y el cursor NO debe avanzar más allá de ella.
 async function verificarEnSat(
   uuid: string,
   emisorNit: string | null | undefined
-): Promise<{ encontrado: boolean; mensaje: string }> {
+): Promise<{ estado: EstadoSat; mensaje: string }> {
   const client = getSatClientPorEmisor(emisorNit);
   try {
     let r = await client.obtenerPorUUID(uuid);
@@ -86,10 +92,10 @@ async function verificarEnSat(
       await new Promise((res) => setTimeout(res, REINTENTO_MS));
       r = await client.obtenerPorUUID(uuid);
     }
-    return { encontrado: !!r.encontrado, mensaje: r.mensaje || "" };
+    return { estado: r.encontrado ? "found" : "not_found", mensaje: r.mensaje || "" };
   } catch (e) {
-    // Un error de red NO debe marcar la factura como fallida.
-    return { encontrado: true, mensaje: `error_consulta: ${(e as Error).message}` };
+    // Error de red: no concluye. No marca fallida ni avanza cursor.
+    return { estado: "error", mensaje: `error_consulta: ${(e as Error).message}` };
   }
 }
 
@@ -124,8 +130,8 @@ async function revalidarPendientes(): Promise<number> {
 
   let resueltas = 0;
   for (const p of pendientes) {
-    const { encontrado, mensaje } = await verificarEnSat(p.uuid, p.emisor_nit);
-    if (encontrado) {
+    const { estado, mensaje } = await verificarEnSat(p.uuid, p.emisor_nit);
+    if (estado === "found") {
       resueltas++;
       await db
         .update(facturas_fallidas_sat)
@@ -190,12 +196,26 @@ export async function verificarFacturasSat() {
   }
 
   let fallidas = 0;
+  let errores = 0;
   let maxId = cursor;
+  // Una vez que una consulta a SAT falla, NO avanzamos el cursor más allá de
+  // esa factura: se reintentará en la próxima corrida. Así una caída de SAT no
+  // hace que se salten facturas para siempre.
+  let congelado = false;
 
   for (const f of candidatos) {
-    const { encontrado, mensaje } = await verificarEnSat(f.uuid, f.emisor_nit);
+    const { estado, mensaje } = await verificarEnSat(f.uuid, f.emisor_nit);
 
-    if (!encontrado) {
+    if (estado === "error") {
+      errores++;
+      congelado = true;
+      console.warn(
+        `⚠️ [verificarFacturasSat] Error consultando SAT: ${f.serie}-${f.numero} (${f.uuid}) - ${mensaje}. Se reintentará.`
+      );
+      continue; // no concluye: no marca fallida ni avanza cursor
+    }
+
+    if (estado === "not_found") {
       fallidas++;
       console.warn(
         `❌ [verificarFacturasSat] NO está en SAT: ${f.serie}-${f.numero} (${f.uuid}) - ${mensaje}`
@@ -227,22 +247,26 @@ export async function verificarFacturasSat() {
         });
     }
 
-    if (f.factura_id > maxId) maxId = f.factura_id;
+    // Solo avanzamos el cursor mientras no haya habido un error antes (para no
+    // saltarnos la factura que falló, que sigue siendo > cursor).
+    if (!congelado && f.factura_id > maxId) maxId = f.factura_id;
   }
 
-  // 4) Avanzar cursor
-  await db
-    .insert(job_checkpoints)
-    .values({ job_name: JOB_NAME, last_factura_id: maxId })
-    .onConflictDoUpdate({
-      target: job_checkpoints.job_name,
-      set: { last_factura_id: maxId, updated_at: sql`now()` },
-    });
+  // 4) Avanzar cursor (hasta la última factura concluyente contigua)
+  if (maxId > cursor) {
+    await db
+      .insert(job_checkpoints)
+      .values({ job_name: JOB_NAME, last_factura_id: maxId })
+      .onConflictDoUpdate({
+        target: job_checkpoints.job_name,
+        set: { last_factura_id: maxId, updated_at: sql`now()` },
+      });
+  }
 
   console.log(
-    `🧾 [verificarFacturasSat] revisadas=${candidatos.length} fallidas=${fallidas} cursor=${cursor}->${maxId}`
+    `🧾 [verificarFacturasSat] revisadas=${candidatos.length} fallidas=${fallidas} errores=${errores} cursor=${cursor}->${maxId}`
   );
-  return { revisadas: candidatos.length, fallidas };
+  return { revisadas: candidatos.length, fallidas, errores };
 }
 
 // ============================================================

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -1,0 +1,264 @@
+// ============================================================
+// Monitoreo de facturas no certificadas en SAT
+// ------------------------------------------------------------
+// - verificarFacturasSat(): job cada 15 min. Revisa las facturas
+//   ACTIVA nuevas (desde el último cursor) y, si alguna NO está en
+//   SAT, la registra en cartera.facturas_fallidas_sat.
+// - reportarFacturasFallidasSat(): job cada hora. Envía un correo
+//   con todas las fallidas PENDIENTE.
+// ============================================================
+import { db } from "../database";
+import {
+  facturas_electronicas,
+  facturas_fallidas_sat,
+  job_checkpoints,
+} from "../database/db";
+import { and, eq, gt, sql } from "drizzle-orm";
+import { SATClientService } from "../cofidi/satClientService";
+import {
+  SAT_CONFIG,
+  SE_PRESTA_SAT_CONFIG,
+  AMJK_SAT_CONFIG,
+  CREACION_IMAGEN_SAT_CONFIG,
+  GRUPO_BATRO_SAT_CONFIG,
+  AUTOCASH_SAT_CONFIG,
+} from "../utils/functions/const";
+import { sendPlainEmail } from "@cci/email";
+
+const JOB_NAME = "verificar_facturas_sat";
+// Grace para evitar falsos negativos por propagación SAT (la factura recién
+// certificada puede tardar unos segundos en ser consultable).
+const GRACE_MINUTES = 2;
+// Reintento corto antes de marcar una factura como fallida.
+const REINTENTO_MS = 2000;
+
+// Destinatarios del correo (configurable por env, con default).
+const DEFAULT_EMAILS = [
+  "diego.l@clubcashin.com",
+  "jalvarado@clubcashin.com",
+  "daniel.r@clubcashin.com",
+  "diego.a@sepresta.com",
+  "lralda@clubcashin.com",
+];
+
+// ------------------------------------------------------------
+// Mapa NIT emisor -> SAT config. Las configs no-CUBE usan `nit`,
+// CUBE usa `entity`; se normaliza a `entity`.
+// ------------------------------------------------------------
+const SAT_CONFIGS: any[] = [
+  SAT_CONFIG,
+  SE_PRESTA_SAT_CONFIG,
+  AMJK_SAT_CONFIG,
+  CREACION_IMAGEN_SAT_CONFIG,
+  GRUPO_BATRO_SAT_CONFIG,
+  AUTOCASH_SAT_CONFIG,
+];
+
+const nitDeConfig = (cfg: any): string => cfg.entity ?? cfg.nit;
+
+const SAT_CONFIG_POR_NIT: Record<string, any> = {};
+for (const cfg of SAT_CONFIGS) {
+  SAT_CONFIG_POR_NIT[nitDeConfig(cfg)] = cfg;
+}
+
+function getSatClientPorEmisor(emisorNit: string | null | undefined): SATClientService {
+  const cfg = (emisorNit && SAT_CONFIG_POR_NIT[emisorNit]) || SAT_CONFIG;
+  return new SATClientService(
+    {
+      requestor: cfg.requestor,
+      user: cfg.user,
+      userName: cfg.userName,
+      entity: nitDeConfig(cfg),
+    },
+    cfg.endpointUrl
+  );
+}
+
+// Consulta SAT con un reintento corto. Devuelve {encontrado, mensaje}.
+async function verificarEnSat(
+  uuid: string,
+  emisorNit: string | null | undefined
+): Promise<{ encontrado: boolean; mensaje: string }> {
+  const client = getSatClientPorEmisor(emisorNit);
+  try {
+    let r = await client.obtenerPorUUID(uuid);
+    if (!r.encontrado) {
+      await new Promise((res) => setTimeout(res, REINTENTO_MS));
+      r = await client.obtenerPorUUID(uuid);
+    }
+    return { encontrado: !!r.encontrado, mensaje: r.mensaje || "" };
+  } catch (e) {
+    // Un error de red NO debe marcar la factura como fallida.
+    return { encontrado: true, mensaje: `error_consulta: ${(e as Error).message}` };
+  }
+}
+
+// ============================================================
+// JOB 1: verificar facturas nuevas contra SAT
+// ============================================================
+export async function verificarFacturasSat() {
+  // 1) Cursor
+  const [chk] = await db
+    .select()
+    .from(job_checkpoints)
+    .where(eq(job_checkpoints.job_name, JOB_NAME));
+  const cursor = chk?.last_factura_id ?? 0;
+
+  // 2) Candidatos: ACTIVA, factura_id > cursor, certificadas hace >= GRACE_MINUTES
+  const candidatos = await db
+    .select({
+      factura_id: facturas_electronicas.factura_id,
+      uuid: facturas_electronicas.uuid,
+      serie: facturas_electronicas.serie,
+      numero: facturas_electronicas.numero,
+      emisor_nit: facturas_electronicas.emisor_nit,
+      emisor_nombre: facturas_electronicas.emisor_nombre,
+      receptor_nit: facturas_electronicas.receptor_nit,
+      receptor_nombre: facturas_electronicas.receptor_nombre,
+      monto_total: facturas_electronicas.monto_total,
+      fecha_certificacion: facturas_electronicas.fecha_certificacion,
+    })
+    .from(facturas_electronicas)
+    .where(
+      and(
+        gt(facturas_electronicas.factura_id, cursor),
+        eq(facturas_electronicas.status, "ACTIVA"),
+        sql`${facturas_electronicas.fecha_certificacion} <= now() - (${GRACE_MINUTES} || ' minutes')::interval`
+      )
+    )
+    .orderBy(facturas_electronicas.factura_id);
+
+  // 3) Sin candidatos -> no hace nada (no toca cursor)
+  if (candidatos.length === 0) {
+    console.log("🧾 [verificarFacturasSat] Sin facturas nuevas para revisar");
+    return { revisadas: 0, fallidas: 0 };
+  }
+
+  let fallidas = 0;
+  let maxId = cursor;
+
+  for (const f of candidatos) {
+    const { encontrado, mensaje } = await verificarEnSat(f.uuid, f.emisor_nit);
+
+    if (!encontrado) {
+      fallidas++;
+      console.warn(
+        `❌ [verificarFacturasSat] NO está en SAT: ${f.serie}-${f.numero} (${f.uuid}) - ${mensaje}`
+      );
+      await db
+        .insert(facturas_fallidas_sat)
+        .values({
+          factura_id: f.factura_id,
+          uuid: f.uuid,
+          serie: f.serie,
+          numero: f.numero,
+          emisor_nit: f.emisor_nit,
+          emisor_nombre: f.emisor_nombre,
+          receptor_nit: f.receptor_nit,
+          receptor_nombre: f.receptor_nombre,
+          monto_total: f.monto_total,
+          fecha_certificacion: f.fecha_certificacion,
+          mensaje_sat: mensaje,
+          status: "PENDIENTE",
+        })
+        .onConflictDoUpdate({
+          target: facturas_fallidas_sat.factura_id,
+          set: {
+            intentos: sql`${facturas_fallidas_sat.intentos} + 1`,
+            mensaje_sat: mensaje,
+            status: "PENDIENTE",
+            updated_at: sql`now()`,
+          },
+        });
+    }
+
+    if (f.factura_id > maxId) maxId = f.factura_id;
+  }
+
+  // 4) Avanzar cursor
+  await db
+    .insert(job_checkpoints)
+    .values({ job_name: JOB_NAME, last_factura_id: maxId })
+    .onConflictDoUpdate({
+      target: job_checkpoints.job_name,
+      set: { last_factura_id: maxId, updated_at: sql`now()` },
+    });
+
+  console.log(
+    `🧾 [verificarFacturasSat] revisadas=${candidatos.length} fallidas=${fallidas} cursor=${cursor}->${maxId}`
+  );
+  return { revisadas: candidatos.length, fallidas };
+}
+
+// ============================================================
+// JOB 2: reportar por correo las fallidas pendientes
+// ============================================================
+export async function reportarFacturasFallidasSat() {
+  const pendientes = await db
+    .select()
+    .from(facturas_fallidas_sat)
+    .where(eq(facturas_fallidas_sat.status, "PENDIENTE"))
+    .orderBy(facturas_fallidas_sat.fecha_certificacion);
+
+  if (pendientes.length === 0) {
+    console.log("📧 [reportarFacturasFallidasSat] Sin pendientes, no se envía correo");
+    return { enviadas: 0 };
+  }
+
+  const destinatarios = (process.env.FACTURAS_FALLIDAS_EMAILS
+    ? process.env.FACTURAS_FALLIDAS_EMAILS.split(",").map((e) => e.trim()).filter(Boolean)
+    : DEFAULT_EMAILS);
+
+  const filas = pendientes
+    .map((f) => {
+      const fecha = f.fecha_certificacion
+        ? new Date(f.fecha_certificacion).toLocaleString("es-GT", {
+            timeZone: "America/Guatemala",
+          })
+        : "";
+      return `<tr>
+        <td style="padding:6px 10px;border:1px solid #ddd;">${f.serie}-${f.numero}</td>
+        <td style="padding:6px 10px;border:1px solid #ddd;font-family:monospace;font-size:12px;">${f.uuid}</td>
+        <td style="padding:6px 10px;border:1px solid #ddd;">${f.emisor_nombre ?? f.emisor_nit ?? ""}</td>
+        <td style="padding:6px 10px;border:1px solid #ddd;">${f.receptor_nombre ?? ""} (${f.receptor_nit ?? ""})</td>
+        <td style="padding:6px 10px;border:1px solid #ddd;text-align:right;">Q${f.monto_total ?? ""}</td>
+        <td style="padding:6px 10px;border:1px solid #ddd;">${fecha}</td>
+        <td style="padding:6px 10px;border:1px solid #ddd;text-align:center;">${f.intentos}</td>
+        <td style="padding:6px 10px;border:1px solid #ddd;">${f.mensaje_sat ?? ""}</td>
+      </tr>`;
+    })
+    .join("");
+
+  const html = `
+    <div style="font-family:Arial,sans-serif;color:#222;">
+      <h2>⚠️ Facturas no encontradas en SAT</h2>
+      <p>Se detectaron <strong>${pendientes.length}</strong> factura(s) que están <strong>ACTIVA</strong> en el sistema pero <strong>no aparecen en SAT</strong>.</p>
+      <table style="border-collapse:collapse;border:1px solid #ddd;font-size:13px;">
+        <thead>
+          <tr style="background:#f4f4f4;">
+            <th style="padding:6px 10px;border:1px solid #ddd;">Serie-Número</th>
+            <th style="padding:6px 10px;border:1px solid #ddd;">UUID</th>
+            <th style="padding:6px 10px;border:1px solid #ddd;">Emisor</th>
+            <th style="padding:6px 10px;border:1px solid #ddd;">Receptor</th>
+            <th style="padding:6px 10px;border:1px solid #ddd;">Monto</th>
+            <th style="padding:6px 10px;border:1px solid #ddd;">Certificación</th>
+            <th style="padding:6px 10px;border:1px solid #ddd;">Intentos</th>
+            <th style="padding:6px 10px;border:1px solid #ddd;">Mensaje SAT</th>
+          </tr>
+        </thead>
+        <tbody>${filas}</tbody>
+      </table>
+      <p style="color:#888;font-size:12px;margin-top:16px;">Reporte automático — Cartera Cash-In.</p>
+    </div>`;
+
+  await sendPlainEmail(
+    destinatarios,
+    `⚠️ ${pendientes.length} factura(s) no certificada(s) en SAT`,
+    html
+  );
+
+  console.log(
+    `📧 [reportarFacturasFallidasSat] correo enviado a ${destinatarios.length} destinatario(s) con ${pendientes.length} pendiente(s)`
+  );
+  return { enviadas: pendientes.length };
+}

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -35,7 +35,7 @@ const REINTENTO_MS = 2000;
 // Destinatarios del correo (configurable por env, con default).
 const DEFAULT_EMAILS = [
   "diego.l@clubcashin.com",
-  "jalvaradp@clubcashin.com",
+  "jalvarado@clubcashin.com",
   "daniel.r@clubcashin.com",
   "diego.a@sepresta.com",
   "lralda@clubcashin.com",

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -255,6 +255,11 @@ export async function reportarFacturasFallidasSat() {
     <div style="font-family:Arial,sans-serif;color:#222;">
       <h2>⚠️ Facturas no encontradas en SAT</h2>
       <p>Se detectaron <strong>${pendientes.length}</strong> factura(s) que están <strong>ACTIVA</strong> en el sistema pero <strong>no aparecen en SAT</strong>.</p>
+      <div style="background:#fff4f4;border:1px solid #f0c2c2;border-radius:6px;padding:12px 16px;margin:12px 0;">
+        <strong>📌 Acción requerida:</strong> para que estas facturas queden registradas correctamente en SAT,
+        hay que <strong>anularlas y volver a facturarlas</strong>. Una vez anuladas en el sistema, dejarán de
+        aparecer en este reporte automáticamente.
+      </div>
       <table style="border-collapse:collapse;border:1px solid #ddd;font-size:13px;">
         <thead>
           <tr style="background:#f4f4f4;">

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1078,6 +1078,53 @@
     created_by: integer("created_by").references(() => platform_users.id),
   });
 
+  // ============================================
+  // 🆕 TABLA: facturas_fallidas_sat
+  //    Registro de facturas que están ACTIVA en BD pero NO se
+  //    encontraron en SAT al verificarlas con obtenerPorUUID.
+  // ============================================
+  export const facturas_fallidas_sat = customSchema.table("facturas_fallidas_sat", {
+    id: serial("id").primaryKey(),
+
+    // Una fila por factura (UNIQUE para upsert / no duplicar)
+    factura_id: integer("factura_id")
+      .notNull()
+      .unique()
+      .references(() => facturas_electronicas.factura_id),
+
+    // Datos de la factura (copiados para el reporte)
+    uuid: varchar("uuid", { length: 255 }).notNull(),
+    serie: varchar("serie", { length: 50 }).notNull(),
+    numero: varchar("numero", { length: 100 }).notNull(),
+    emisor_nit: varchar("emisor_nit", { length: 30 }),
+    emisor_nombre: varchar("emisor_nombre", { length: 200 }),
+    receptor_nit: varchar("receptor_nit", { length: 30 }),
+    receptor_nombre: varchar("receptor_nombre", { length: 200 }),
+    monto_total: numeric("monto_total", { precision: 18, scale: 2 }),
+    fecha_certificacion: timestamp("fecha_certificacion"),
+
+    // Resultado de la verificación
+    mensaje_sat: text("mensaje_sat"),
+    intentos: integer("intentos").notNull().default(1),
+    status: varchar("status", { length: 20 }).notNull().default("PENDIENTE"), // PENDIENTE | RESUELTA
+
+    // Metadata
+    detectada_at: timestamp("detectada_at").defaultNow().notNull(),
+    resuelta_at: timestamp("resuelta_at"),
+    updated_at: timestamp("updated_at").defaultNow().notNull(),
+  });
+
+  // ============================================
+  // 🆕 TABLA: job_checkpoints
+  //    Cursor genérico para jobs incrementales (arrancar desde
+  //    donde se quedó). Ej: verificar_facturas_sat.
+  // ============================================
+  export const job_checkpoints = customSchema.table("job_checkpoints", {
+    job_name: varchar("job_name", { length: 100 }).primaryKey(),
+    last_factura_id: integer("last_factura_id").notNull().default(0),
+    updated_at: timestamp("updated_at").defaultNow().notNull(),
+  });
+
 
   // 🆕 TABLA: liquidaciones
   // ============================================

--- a/apps/cartera-back/src/scripts/crear-tablas-fallidas.ts
+++ b/apps/cartera-back/src/scripts/crear-tablas-fallidas.ts
@@ -1,0 +1,71 @@
+// ============================================================
+// Bootstrap idempotente de las tablas del monitoreo de facturas
+// no certificadas en SAT (schema "cartera").
+//   - cartera.facturas_fallidas_sat
+//   - cartera.job_checkpoints
+//
+// Uso (una vez, contra la BD destino):
+//   bun run src/scripts/crear-tablas-fallidas.ts
+// (Nota: drizzle-kit push no aplica para estas tablas porque la
+//  config apunta a un schema inexistente; por eso se crean con SQL.)
+// ============================================================
+import { client } from "../database";
+
+async function main() {
+  console.log("🛠️  Creando tablas (IF NOT EXISTS) en schema cartera...");
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS cartera.facturas_fallidas_sat (
+      id                  serial PRIMARY KEY,
+      factura_id          integer NOT NULL UNIQUE REFERENCES cartera.facturas_electronicas(factura_id),
+      uuid                varchar(255) NOT NULL,
+      serie               varchar(50)  NOT NULL,
+      numero              varchar(100) NOT NULL,
+      emisor_nit          varchar(30),
+      emisor_nombre       varchar(200),
+      receptor_nit        varchar(30),
+      receptor_nombre     varchar(200),
+      monto_total         numeric(18,2),
+      fecha_certificacion timestamp,
+      mensaje_sat         text,
+      intentos            integer NOT NULL DEFAULT 1,
+      status              varchar(20) NOT NULL DEFAULT 'PENDIENTE',
+      detectada_at        timestamp NOT NULL DEFAULT now(),
+      resuelta_at         timestamp,
+      updated_at          timestamp NOT NULL DEFAULT now()
+    );
+  `);
+  console.log("   ✅ cartera.facturas_fallidas_sat");
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS cartera.job_checkpoints (
+      job_name        varchar(100) PRIMARY KEY,
+      last_factura_id integer NOT NULL DEFAULT 0,
+      updated_at      timestamp NOT NULL DEFAULT now()
+    );
+  `);
+  console.log("   ✅ cartera.job_checkpoints");
+
+  // Sembrar el cursor con el max(factura_id) actual para empezar a monitorear
+  // SOLO las facturas nuevas (no reprocesar todo el histórico). No pisa si ya existe.
+  const seed = await client.query(`
+    INSERT INTO cartera.job_checkpoints (job_name, last_factura_id)
+    SELECT 'verificar_facturas_sat', COALESCE(MAX(factura_id), 0)
+    FROM cartera.facturas_electronicas
+    ON CONFLICT (job_name) DO NOTHING
+    RETURNING last_factura_id;
+  `);
+  if (seed.rows.length > 0) {
+    console.log(`   ✅ cursor inicial sembrado en factura_id=${seed.rows[0].last_factura_id}`);
+  } else {
+    console.log("   ℹ️ cursor ya existía, no se modificó");
+  }
+
+  console.log("🎉 Listo");
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("💥 Error creando tablas:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Qué hace

Monitoreo automático de facturas que quedan **ACTIVA en BD pero no certificadas en SAT**.

### 1. Tablas nuevas (schema `cartera`)
- **`facturas_fallidas_sat`** — registro de facturas no encontradas en SAT (con `intentos`, `mensaje_sat`, `status` PENDIENTE/RESUELTA).
- **`job_checkpoints`** — cursor genérico para jobs incrementales.

### 2. Job cada 15 min (8:00–19:00 GT) — `verificarFacturasSat()`
- Arranca **desde el último cursor** (no reprocesa histórico).
- Toma las facturas `ACTIVA` nuevas, con **grace de 2 min** (evita falsos negativos por propagación SAT).
- Verifica cada una con `obtenerPorUUID` usando la **config SAT del emisor correcto** (el query SAT es por NIT emisor) + **1 reintento corto**.
- Si no está en SAT → upsert en `facturas_fallidas_sat` (incrementa `intentos`).
- Si no hay facturas nuevas → no hace nada.

### 3. Job cada hora (8:00–19:00 GT) — `reportarFacturasFallidasSat()`
- Manda un correo con **todas las fallidas PENDIENTE** (tabla HTML).
- Si no hay pendientes → no envía.
- Destinatarios configurables por env `FACTURAS_FALLIDAS_EMAILS` (con default).

### 4. Bootstrap — `scripts/crear-tablas-fallidas.ts`
- Crea las tablas con `CREATE TABLE IF NOT EXISTS` (drizzle-kit push no aplica aquí) y **siembra el cursor** con el `max(factura_id)` actual.

## Notas
- Deploy es instancia única → sin cron duplicado.
- Errores de red en la consulta SAT **no** marcan la factura como fallida.

## Pendiente
- Confirmar correo `jalvarado@clubcashin.com` (en la pregunta salió `jalvaradp@`); quedó configurable por env.
- Correr `crear-tablas-fallidas.ts` contra prod antes/al desplegar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)