### PR TITLE
fix(cartera): compras del mes en cálculo de pagos espejo (monto viejo, mayor y GPS)

### DIFF
--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -169,6 +169,7 @@ mock.module("./latefee", () => ({
 let mockMontoRestarValidacion = new Big(0);
 let mockMontoRestarCalculo = new Big(0);
 let mockSumaComprasPendientes = new Big(0);
+let mockSumaComprasCompletadasMesActual = new Big(0);
 mock.module("../utils/comprasAjuste", () => ({
   calcularAjusteCompras: mock(() => Promise.resolve({
     montoRestarValidacion: mockMontoRestarValidacion,
@@ -176,6 +177,7 @@ mock.module("../utils/comprasAjuste", () => ({
   })),
   obtenerSumaComprasMesAnterior: mock(() => Promise.resolve(new Big(0))),
   obtenerSumaComprasPendientes: mock(() => Promise.resolve(mockSumaComprasPendientes)),
+  obtenerSumaComprasCompletadasMesActual: mock(() => Promise.resolve(mockSumaComprasCompletadasMesActual)),
 }));
 
 const { calcularYRegistrarPagosEspejo } = await import("./payments");
@@ -189,13 +191,31 @@ describe("Pruebas Unitarias - Reglas de Negocio de Pagos Espejo", () => {
     mockComprasCreditoInversionista = [];
     mockMontoRestarValidacion = new Big(0);
     mockMontoRestarCalculo = new Big(0);
+    mockSumaComprasPendientes = new Big(0);
+    mockSumaComprasCompletadasMesActual = new Big(0);
   });
 
   it("1. Nuevo inversionista con compra de cartera en mes actual → sin pagos", async () => {
-    // Comportamiento esperado: Dado que la participación inicia este mes (junio 2026),
-    // el filtro lt(fecha_inicio_participacion, inicioPeriodo) debe excluir este crédito.
-    // Como resultado, no se procesa ningún crédito y totalCreditosProcesados debe ser 0.
-    mockCreditosInversionistaEspejo = []; 
+    // Comportamiento esperado: la participación inicia este mes (junio 2026) y TODO su
+    // monto_aportado proviene de la compra del mes (no hay monto viejo). El gate de
+    // "monto viejo" debe omitir el crédito → totalCreditosProcesados = 0.
+    mockCreditosInversionistaEspejo = [
+      {
+        creditoId: 101,
+        inversionistaId: 99,
+        montoAportado: "5000.00000000",
+        porcentajeParticipacion: "50.00",
+        fechaInicioParticipacion: "2026-06-07", // mes en curso (compra lo re-selló)
+        numeroCreditoSifco: "CRED-101",
+        capital: "20000.00",
+        deudaTotal: "22000.00",
+        statusCredit: "ACTIVO",
+        cuota: "1000.00",
+      }
+    ];
+    // Toda la participación es compra de cartera completada este mes → monto viejo = 0.
+    mockSumaComprasCompletadasMesActual = new Big(5000);
+    mockPagosPendientesEspejo = [];
 
     const result = await calcularYRegistrarPagosEspejo(99, new Date("2026-06-10T12:00:00.000Z"));
     expect(result.success).toBeTrue();
@@ -212,6 +232,7 @@ describe("Pruebas Unitarias - Reglas de Negocio de Pagos Espejo", () => {
         inversionistaId: 99,
         montoAportado: "10000.00000000",
         porcentajeParticipacion: "50.00",
+        fechaInicioParticipacion: "2026-05-15", // mes anterior → no entra al gate, procesa normal
         numeroCreditoSifco: "CRED-101",
         capital: "20000.00",
         deudaTotal: "22000.00",
@@ -245,7 +266,7 @@ describe("Pruebas Unitarias - Reglas de Negocio de Pagos Espejo", () => {
       }
     ];
 
-    mockPagosPendientesEspejo = []; 
+    mockPagosPendientesEspejo = [];
 
     const result = await calcularYRegistrarPagosEspejo(99, new Date("2026-06-10T12:00:00.000Z"));
     expect(result.success).toBeTrue();
@@ -263,6 +284,7 @@ describe("Pruebas Unitarias - Reglas de Negocio de Pagos Espejo", () => {
         inversionistaId: 99,
         montoAportado: "15000.00000000",
         porcentajeParticipacion: "75.00",
+        fechaInicioParticipacion: "2026-05-15", // pendiente NO re-sella la fecha → mes anterior
         numeroCreditoSifco: "CRED-101",
         capital: "20000.00",
         deudaTotal: "22000.00",
@@ -337,5 +359,63 @@ describe("Pruebas Unitarias - Reglas de Negocio de Pagos Espejo", () => {
     const result = await calcularYRegistrarPagosEspejo(99, new Date("2026-06-10T12:00:00.000Z"));
     expect(result.success).toBeTrue();
     expect(result.totalCreditosProcesados).toBe(0);
+  });
+
+  it("5. Partícipe viejo + compra del mes actual → procesa el monto viejo (no lo pierde)", async () => {
+    // Comportamiento esperado: el inversionista YA participaba con X=10,000 y compró
+    // Y=15,000 el 7-jun; la compra le re-selló fecha_inicio_participacion a junio.
+    // Antes, el filtro SQL botaba el crédito entero y X se perdía. Ahora:
+    //   monto viejo = 25,000 − 15,000 (compra completada del mes) = 10,000 > 0 → procesa.
+    // La compra del mes se excluye en el cálculo (Caso 3) y X cobra mes completo.
+    mockCreditosInversionistaEspejo = [
+      {
+        creditoId: 101,
+        inversionistaId: 99,
+        montoAportado: "25000.00000000",
+        porcentajeParticipacion: "50.00",
+        fechaInicioParticipacion: "2026-06-07", // re-sellada por la compra al mes en curso
+        numeroCreditoSifco: "CRED-101",
+        capital: "20000.00",
+        deudaTotal: "22000.00",
+        statusCredit: "ACTIVO",
+        cuota: "1000.00",
+      }
+    ];
+
+    mockCuotasCreditoWithPagos = [
+      {
+        cuotaId: 501,
+        numeroCuota: 1,
+        fechaVencimiento: "2026-06-15",
+        pagadoCuota: false,
+        liquidadoInversionistas: false,
+        pagoId: 301,
+        fechaPago: new Date("2026-06-05"),
+        montoBoleta: "1000.00",
+        abonoCapital: "800.00",
+        abonoInteres: "200.00",
+        abonoIva: "24.00",
+        validationStatus: "validated",
+        numeroCuotaPrev: 1,
+      }
+    ];
+
+    mockHistoricoLiquidacionesEspejo = [
+      {
+        monto_aportado: "10000.00000000",
+        fecha: new Date("2026-05-15")
+      }
+    ];
+
+    // La compra del mes (15,000): completada del mes actual + se resta del cálculo (Caso 3)
+    // y de la validación (creada después del histórico) para cuadrar contra X=10,000.
+    mockSumaComprasCompletadasMesActual = new Big(15000);
+    mockMontoRestarValidacion = new Big(15000);
+    mockMontoRestarCalculo = new Big(15000);
+    mockPagosPendientesEspejo = [];
+
+    const result = await calcularYRegistrarPagosEspejo(99, new Date("2026-06-10T12:00:00.000Z"));
+    expect(result.success).toBeTrue();
+    expect(result.totalCreditosProcesados).toBe(1);
   });
 });

--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -445,4 +445,34 @@ describe("Pruebas Unitarias - Reglas de Negocio de Pagos Espejo", () => {
     expect(result.success).toBeTrue();
     expect(result.totalCreditosProcesados).toBe(0);
   });
+
+  it("7. Participación nueva DIRECTA del mes (sin compra) → sin pagos", async () => {
+    // Comportamiento esperado: el inversionista se agregó directo este mes (fecha_inicio
+    // del período) pero SIN compra_cartera. No hay compra que justifique un monto viejo,
+    // así que es una participación nueva → se omite (paga desde el mes siguiente), igual
+    // que el filtro SQL viejo. Sin este corte, montoViejo daría el monto completo y se
+    // procesaría por error.
+    mockCreditosInversionistaEspejo = [
+      {
+        creditoId: 101,
+        inversionistaId: 99,
+        montoAportado: "8000.00000000",
+        porcentajeParticipacion: "40.00",
+        fechaInicioParticipacion: "2026-06-07", // mes en curso, alta directa
+        numeroCreditoSifco: "CRED-101",
+        capital: "20000.00",
+        deudaTotal: "22000.00",
+        statusCredit: "ACTIVO",
+        cuota: "1000.00",
+      }
+    ];
+    // SIN compras del mes ni pendientes → no hay nada que justifique monto viejo.
+    mockSumaComprasCompletadasMesActual = new Big(0);
+    mockSumaComprasPendientes = new Big(0);
+    mockPagosPendientesEspejo = [];
+
+    const result = await calcularYRegistrarPagosEspejo(99, new Date("2026-06-10T12:00:00.000Z"));
+    expect(result.success).toBeTrue();
+    expect(result.totalCreditosProcesados).toBe(0);
+  });
 });

--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -418,4 +418,31 @@ describe("Pruebas Unitarias - Reglas de Negocio de Pagos Espejo", () => {
     expect(result.success).toBeTrue();
     expect(result.totalCreditosProcesados).toBe(1);
   });
+
+  it("6. Participación que empieza en un mes FUTURO al período → sin pagos", async () => {
+    // Comportamiento esperado: se calcula junio (2026-06) pero la fecha_inicio del
+    // crédito es de julio (mes posterior). No corresponde liquidar este período —
+    // el corte por mes futuro debe omitirlo, igual que el filtro SQL viejo (< inicio).
+    // Sin ese corte, al no tener compras del mes en curso, montoViejo daría el monto
+    // completo y lo procesaría por error.
+    mockCreditosInversionistaEspejo = [
+      {
+        creditoId: 101,
+        inversionistaId: 99,
+        montoAportado: "10000.00000000",
+        porcentajeParticipacion: "50.00",
+        fechaInicioParticipacion: "2026-07-15", // mes posterior al período (junio)
+        numeroCreditoSifco: "CRED-101",
+        capital: "20000.00",
+        deudaTotal: "22000.00",
+        statusCredit: "ACTIVO",
+        cuota: "1000.00",
+      }
+    ];
+    mockPagosPendientesEspejo = [];
+
+    const result = await calcularYRegistrarPagosEspejo(99, new Date("2026-06-10T12:00:00.000Z"));
+    expect(result.success).toBeTrue();
+    expect(result.totalCreditosProcesados).toBe(0);
+  });
 });

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -2172,6 +2172,14 @@ export async function obtenerCreditosConPagosPendientes(
           console.log(`⏭️  Crédito ${credito.creditoId}: sin fecha_inicio_participacion → se omite`);
           return null;
         }
+        // Participación que empieza DESPUÉS del período (mes futuro) → no corresponde
+        // liquidar este período. El filtro SQL viejo (`< inicio`) también la excluía;
+        // sin este corte, una fecha futura entraría al bloque de monto viejo y, como
+        // no tiene compras del mes en curso, se procesaría por error.
+        if (fechaInicioParticipacion > rangoMesActual.fin) {
+          console.log(`⏭️  Crédito ${credito.creditoId}: participación futura (${fechaInicioParticipacion} > ${rangoMesActual.fin}) → se omite`);
+          return null;
+        }
         if (fechaInicioParticipacion >= rangoMesActual.inicio) {
           const sumaPendientes = await obtenerSumaComprasPendientes(
             credito.creditoId,
@@ -2445,6 +2453,13 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
       baseCalculo.getUTCMonth(),
       baseCalculo.getUTCDate(),
     );
+    // Primer día del mes SIGUIENTE al período: cota superior para descartar
+    // participaciones futuras (fecha_inicio en un mes posterior al que se procesa).
+    const inicioMesSiguiente = new Date(
+      baseCalculo.getUTCFullYear(),
+      baseCalculo.getUTCMonth() + 1,
+      1
+    ).toISOString().slice(0, 10);
     console.log(`📅 Inicio de período: ${inicioPeriodo}`);
 
     // Paso 1: Se buscan todos los créditos en los que este inversionista participa
@@ -2537,6 +2552,16 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
           // Preserva el comportamiento previo: fecha_inicio nula quedaba excluida por el SQL.
           console.log(
             `⏭️  Crédito ${credito.creditoId}: sin fecha_inicio_participacion → se omite`
+          );
+          return null;
+        }
+        // Participación que empieza DESPUÉS del período (mes futuro) → no corresponde
+        // liquidar este período. El filtro SQL viejo (`< inicioPeriodo`) también la
+        // excluía; sin este corte, una fecha futura entraría al bloque de monto viejo y,
+        // como no tiene compras del mes en curso, se procesaría por error.
+        if (fechaInicioParticipacion >= inicioMesSiguiente) {
+          console.log(
+            `⏭️  Crédito ${credito.creditoId}: participación futura (${fechaInicioParticipacion} >= ${inicioMesSiguiente}) → se omite`
           );
           return null;
         }

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -24,7 +24,7 @@ import {
   processAndReplaceCreditInvestorsReverse,
 } from "./investor";
 import { updateMora } from "./latefee";
-import { calcularAjusteCompras, obtenerSumaComprasMesAnterior, obtenerSumaComprasPendientes } from "../utils/comprasAjuste";
+import { calcularAjusteCompras, obtenerSumaComprasMesAnterior, obtenerSumaComprasPendientes, obtenerSumaComprasCompletadasMesActual } from "../utils/comprasAjuste";
 import { t } from "elysia";
 export const pagoSchema = z.object({
   credito_id: z.number().int().positive(),
@@ -2025,6 +2025,8 @@ export async function obtenerCreditosConPagosPendientes(
         montoAportado: creditos_inversionistas_espejo.monto_aportado,
         porcentajeParticipacion:
           creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+        fechaInicioParticipacion:
+          creditos_inversionistas_espejo.fecha_inicio_participacion,
         // Datos del crédito
         numeroCreditoSifco: creditos.numero_credito_sifco,
         capital: creditos.capital,
@@ -2044,8 +2046,10 @@ export async function obtenerCreditosConPagosPendientes(
         and(
           eq(creditos_inversionistas_espejo.inversionista_id, inversionistaId),
           inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "PENDIENTE_CANCELACION", "EN_CONVENIO","INCOBRABLE"]),
-          eq(creditos_inversionistas_espejo.status, "completado"),
-          lt(creditos_inversionistas_espejo.fecha_inicio_participacion, rangoMesActual.inicio)
+          eq(creditos_inversionistas_espejo.status, "completado")
+          // El filtro por fecha_inicio_participacion se reemplazó por la evaluación de
+          // "monto viejo" en el loop (mismo criterio que calcularYRegistrarPagosEspejo):
+          // así un partícipe viejo que compró este mes no se pierde y sólo se excluye la compra.
         )
       );
 
@@ -2085,6 +2089,43 @@ export async function obtenerCreditosConPagosPendientes(
 
         console.log(`✅ El crédito ${credito.creditoId} NO tiene pagos pendientes, continuando...`);
         console.log(`========================================\n`);
+
+        // Monto viejo (mismo criterio que calcularYRegistrarPagosEspejo): el filtro SQL
+        // por fecha_inicio_participacion se quitó para no botar al partícipe viejo que
+        // compró este mes. Sólo evaluamos las participaciones cuya fecha cae en el mes en
+        // curso (las que el filtro botaba): se procesan si queda monto viejo y se omiten
+        // si la compra del mes cubre todo el monto_aportado (participación nueva).
+        const fechaInicioParticipacion = credito.fechaInicioParticipacion;
+        if (!fechaInicioParticipacion) {
+          console.log(`⏭️  Crédito ${credito.creditoId}: sin fecha_inicio_participacion → se omite`);
+          return null;
+        }
+        if (fechaInicioParticipacion >= rangoMesActual.inicio) {
+          const sumaPendientes = await obtenerSumaComprasPendientes(
+            credito.creditoId,
+            inversionistaId,
+          );
+          const sumaCompletadasMesActual = await obtenerSumaComprasCompletadasMesActual(
+            credito.creditoId,
+            inversionistaId,
+            new Date(),
+          );
+          const montoViejo = new Big(credito.montoAportado || 0)
+            .minus(sumaPendientes)
+            .minus(sumaCompletadasMesActual);
+
+          if (montoViejo.lte(0)) {
+            console.log(
+              `⏭️  Crédito ${credito.creditoId}: participación del período (${fechaInicioParticipacion}) ` +
+              `sin monto viejo [monto_aportado=${credito.montoAportado}, pendientes=${sumaPendientes.toString()}, ` +
+              `compras_mes_actual=${sumaCompletadasMesActual.toString()}] → participación nueva, se omite`
+            );
+            return null;
+          }
+          console.log(
+            `✅ Crédito ${credito.creditoId}: participación del período CON monto viejo ${montoViejo.toString()} → se procesa`
+          );
+        }
 
         // 📅 Buscar la PRIMERA cuota NO LIQUIDADA con sus PAGOS
         const cuotaConPagos = await db
@@ -2312,16 +2353,27 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
       console.log(`📅 Fecha de cálculo override: ${fechaCalculo.toISOString()}`);
     }
 
-    // Inicio del período a procesar: usa el mes de fechaCalculo si viene,
-    // si no el mes actual. Solo participaciones anteriores a este inicio
-    // deben generar pagos en este período (regla: compra del mes → paga desde el mes siguiente).
+    // Período a procesar: usa el mes de fechaCalculo si viene, si no el mes actual.
+    // Regla: una compra del mes en curso (pendiente o completada) NO genera interés
+    // este período; empieza el mes siguiente (proporcional). PERO el monto viejo del
+    // inversionista (lo que ya tenía antes de las compras del mes) sí debe liquidarse.
+    // Por eso ya NO filtramos el crédito por fecha_inicio_participacion en el SQL:
+    // la compra la re-sella al mes en curso (completeEspejo) y botaría el crédito
+    // entero, perdiendo el monto viejo. En su lugar, abajo se omite el crédito SÓLO
+    // cuando la participación es del período en curso y no queda monto viejo
+    // (participación genuinamente nueva / la compra cubre todo el monto_aportado).
     const baseCalculo = fechaCalculo ?? new Date();
     const inicioPeriodo = new Date(
       baseCalculo.getUTCFullYear(),
       baseCalculo.getUTCMonth(),
       1
     ).toISOString().slice(0, 10);
-    console.log(`📅 Inicio de período para filtro: ${inicioPeriodo}`);
+    const fechaCalcNormalizada = new Date(
+      baseCalculo.getUTCFullYear(),
+      baseCalculo.getUTCMonth(),
+      baseCalculo.getUTCDate(),
+    );
+    console.log(`📅 Inicio de período: ${inicioPeriodo}`);
 
     // Paso 1: Se buscan todos los créditos en los que este inversionista participa
     // y que aún están activos (pueden estar al día, en mora, en proceso de cancelación, etc.).
@@ -2332,6 +2384,8 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
         montoAportado: creditos_inversionistas_espejo.monto_aportado,
         porcentajeParticipacion:
           creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+        fechaInicioParticipacion:
+          creditos_inversionistas_espejo.fecha_inicio_participacion,
         numeroCreditoSifco: creditos.numero_credito_sifco,
         capital: creditos.capital,
         deudaTotal: creditos.deudatotal,
@@ -2346,7 +2400,6 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
       .where(
         and(
           eq(creditos_inversionistas_espejo.inversionista_id, inversionistaId),
-          lt(creditos_inversionistas_espejo.fecha_inicio_participacion, inicioPeriodo),
           inArray(creditos.statusCredit, [
             "ACTIVO",
             "MOROSO",
@@ -2398,6 +2451,49 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
             `⚠️  Crédito ${credito.creditoId} tiene ${pagosPendientes.length} pago(s) NO_LIQUIDADO → se omite`
           );
           return null;
+        }
+
+        // Regla "compra del mes → paga el mes siguiente", pero sólo para la parte
+        // comprada este mes; el monto viejo sí se liquida ahora. Antes esto lo hacía
+        // un filtro SQL (fecha_inicio < inicioPeriodo) que botaba el crédito entero
+        // cuando la compra le re-sellaba la fecha al mes en curso, perdiendo el monto
+        // viejo. Ahora sólo evaluamos las participaciones cuya fecha cae en el período
+        // en curso (las que el filtro botaba): se procesan si queda monto viejo y se
+        // omiten si la compra del mes cubre todo el monto_aportado (participación nueva).
+        const fechaInicioParticipacion = credito.fechaInicioParticipacion;
+        if (!fechaInicioParticipacion) {
+          // Preserva el comportamiento previo: fecha_inicio nula quedaba excluida por el SQL.
+          console.log(
+            `⏭️  Crédito ${credito.creditoId}: sin fecha_inicio_participacion → se omite`
+          );
+          return null;
+        }
+        if (fechaInicioParticipacion >= inicioPeriodo) {
+          const sumaPendientes = await obtenerSumaComprasPendientes(
+            credito.creditoId,
+            inversionistaId,
+          );
+          const sumaCompletadasMesActual = await obtenerSumaComprasCompletadasMesActual(
+            credito.creditoId,
+            inversionistaId,
+            fechaCalcNormalizada,
+          );
+          const montoViejo = new Big(credito.montoAportado || 0)
+            .minus(sumaPendientes)
+            .minus(sumaCompletadasMesActual);
+
+          if (montoViejo.lte(0)) {
+            console.log(
+              `⏭️  Crédito ${credito.creditoId}: participación del período (${fechaInicioParticipacion}) ` +
+              `sin monto viejo [monto_aportado=${credito.montoAportado}, pendientes=${sumaPendientes.toString()}, ` +
+              `compras_mes_actual=${sumaCompletadasMesActual.toString()}] → participación nueva, se omite`
+            );
+            return null;
+          }
+          console.log(
+            `✅ Crédito ${credito.creditoId}: participación del período CON monto viejo ${montoViejo.toString()} ` +
+            `→ se procesa (la compra del mes se excluye en el cálculo, el monto viejo cobra mes completo)`
+          );
         }
 
         const selectCuotaPagos = {

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -26,6 +26,12 @@ import {
 import { updateMora } from "./latefee";
 import { calcularAjusteCompras, obtenerSumaComprasMesAnterior, obtenerSumaComprasPendientes, obtenerSumaComprasCompletadasMesActual } from "../utils/comprasAjuste";
 import { t } from "elysia";
+
+// ID del inversionista Cube. Fuente canónica: assignCapital.ts (export const CUBE_ID = 86).
+// Se redefine local (igual que investor.ts) para no acoplar la carga de este módulo
+// con assignCapital. Toda compra de cartera se le hace a Cube.
+const CUBE_ID = 86;
+
 export const pagoSchema = z.object({
   credito_id: z.number().int().positive(),
   usuario_id: z.number().int().positive(),
@@ -417,15 +423,78 @@ export async function insertPagosCreditoInversionistas(
     return;
   }
 
-  const indexMayorCuota = filteredInversionistas.reduce(
-    (maxIdx, inv, idx, arr) =>
-      new Big(inv.cuota_inversionista || 0).gt(
-        new Big(arr[maxIdx].cuota_inversionista || 0)
+  // Elección del inversionista "mayor" (el que absorbe seguro + gps + membresías).
+  //
+  // Por defecto compara cuota_inversionista (comportamiento histórico, sin cambios).
+  //
+  // PERO toda compra de cartera SIEMPRE se le hace a Cube: cuando entra una compra
+  // del mes en curso, el espejo ya quedó con el comprador inflado (X+Y) y Cube
+  // reducido (−Y). Esa compra todavía NO es efectiva este período (paga el mes
+  // siguiente), así que el "mayor" debe decidirse con el estado PRE-compra:
+  //   - comprador → su monto viejo (monto_aportado − compras del mes − pendientes)
+  //   - Cube      → su monto + lo vendido este mes (se le devuelve)
+  //   - los demás → igual
+  // Sólo se activa si hay compras del mes en el crédito; si no, la comparación
+  // histórica por cuota_inversionista queda intacta.
+  const fechaPeriodoMayor = fechaPeriodo
+    ? new Date(
+        fechaPeriodo.getUTCFullYear(),
+        fechaPeriodo.getUTCMonth(),
+        fechaPeriodo.getUTCDate(),
       )
-        ? idx
-        : maxIdx,
-    0
+    : new Date();
+
+  const comprasMesPorInv = await Promise.all(
+    filteredInversionistas.map(async (inv) => {
+      // A Cube no se le suman compras propias: es el vendedor, recibe el total aparte.
+      if (inv.inversionista_id === CUBE_ID) return new Big(0);
+      const [pend, compMes] = await Promise.all([
+        obtenerSumaComprasPendientes(credito_id, inv.inversionista_id),
+        obtenerSumaComprasCompletadasMesActual(
+          credito_id,
+          inv.inversionista_id,
+          fechaPeriodoMayor,
+        ),
+      ]);
+      return pend.plus(compMes);
+    })
   );
+  const totalComprasMes = comprasMesPorInv.reduce(
+    (acc, m) => acc.plus(m),
+    new Big(0),
+  );
+
+  let indexMayorCuota: number;
+  if (totalComprasMes.gt(0)) {
+    // Estado pre-compra: comprador con monto viejo, Cube con lo vendido devuelto.
+    const montoEfectivo = filteredInversionistas.map((inv, idx) => {
+      const base = new Big(inv.monto_aportado || 0);
+      return inv.inversionista_id === CUBE_ID
+        ? base.plus(totalComprasMes)
+        : base.minus(comprasMesPorInv[idx]);
+    });
+    indexMayorCuota = montoEfectivo.reduce(
+      (maxIdx, val, idx) => (val.gt(montoEfectivo[maxIdx]) ? idx : maxIdx),
+      0
+    );
+    console.log(
+      `   🏆 Mayor por monto efectivo PRE-compra (hay compras del mes: ${totalComprasMes.toString()})`
+    );
+    filteredInversionistas.forEach((inv, idx) => {
+      console.log(`      ${inv.nombre}: efectivo=${montoEfectivo[idx].toString()} (aportado=${inv.monto_aportado}, compras_mes=${comprasMesPorInv[idx].toString()})`);
+    });
+  } else {
+    // Sin compras del mes → lógica histórica intacta (comparar cuota_inversionista).
+    indexMayorCuota = filteredInversionistas.reduce(
+      (maxIdx, inv, idx, arr) =>
+        new Big(inv.cuota_inversionista || 0).gt(
+          new Big(arr[maxIdx].cuota_inversionista || 0)
+        )
+          ? idx
+          : maxIdx,
+      0
+    );
+  }
   const mayorCuotaInversionistaId =
     filteredInversionistas[indexMayorCuota].inversionista_id;
 

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -599,14 +599,17 @@ export async function insertPagosCreditoInversionistas(
       const capitalTotalBig  = new Big(currentCredit?.capital ?? 0);
       const cuotaTotalBig    = new Big(currentCredit?.cuota ?? 0);
       const seguroBig        = new Big(currentCredit?.seguro_10_cuotas ?? 0);
+      const gpsBig           = new Big(currentCredit?.gps ?? 0);
       const membresiasBig    = new Big(currentCredit?.membresias_pago ?? 0);
-      const cuotaSinCargos   = cuotaTotalBig.minus(membresiasBig).minus(seguroBig);
+      // Mismo criterio que addInvestorToCredit: la base se reparte SIN los tres cargos
+      // fijos (seguro + gps + membresías) y esos cargos se suman SOLO al mayor.
+      const cuotaSinCargos   = cuotaTotalBig.minus(membresiasBig).minus(seguroBig).minus(gpsBig);
       const pctParticipacion = capitalTotalBig.gt(0)
         ? montoBaseCalculo.div(capitalTotalBig).times(100)
         : new Big(0);
       const cuotaBaseRecalc  = cuotaSinCargos.times(pctParticipacion.div(100)).round(2);
       cuotaRecalculada = (inv.inversionista_id === mayorCuotaInversionistaId && !excludeCube)
-        ? cuotaBaseRecalc.plus(seguroBig).plus(membresiasBig).round(2)
+        ? cuotaBaseRecalc.plus(seguroBig).plus(gpsBig).plus(membresiasBig).round(2)
         : cuotaBaseRecalc;
     } else {
       cuotaRecalculada = new Big(inv.cuota_inversionista ?? 0);

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -2190,15 +2190,17 @@ export async function obtenerCreditosConPagosPendientes(
             inversionistaId,
             new Date(),
           );
-          const montoViejo = new Big(credito.montoAportado || 0)
-            .minus(sumaPendientes)
-            .minus(sumaCompletadasMesActual);
+          const comprasDelMes = sumaPendientes.plus(sumaCompletadasMesActual);
+          const montoViejo = new Big(credito.montoAportado || 0).minus(comprasDelMes);
 
-          if (montoViejo.lte(0)) {
+          // Solo se procesa si hay una compra REAL del mes que justifique el monto viejo.
+          // Sin compra → participación nueva directa → se omite (como el filtro SQL viejo).
+          if (comprasDelMes.lte(0) || montoViejo.lte(0)) {
             console.log(
               `⏭️  Crédito ${credito.creditoId}: participación del período (${fechaInicioParticipacion}) ` +
-              `sin monto viejo [monto_aportado=${credito.montoAportado}, pendientes=${sumaPendientes.toString()}, ` +
-              `compras_mes_actual=${sumaCompletadasMesActual.toString()}] → participación nueva, se omite`
+              `sin monto viejo respaldado por compra [monto_aportado=${credito.montoAportado}, ` +
+              `pendientes=${sumaPendientes.toString()}, compras_mes_actual=${sumaCompletadasMesActual.toString()}] ` +
+              `→ participación nueva, se omite`
             );
             return null;
           }
@@ -2575,15 +2577,19 @@ export async function calcularYRegistrarPagosEspejo(inversionistaId: number, fec
             inversionistaId,
             fechaCalcNormalizada,
           );
-          const montoViejo = new Big(credito.montoAportado || 0)
-            .minus(sumaPendientes)
-            .minus(sumaCompletadasMesActual);
+          const comprasDelMes = sumaPendientes.plus(sumaCompletadasMesActual);
+          const montoViejo = new Big(credito.montoAportado || 0).minus(comprasDelMes);
 
-          if (montoViejo.lte(0)) {
+          // Solo se procesa una participación del mes en curso si hay una compra REAL
+          // del mes (pendiente o completada) que justifique el monto viejo. Sin compra,
+          // es una participación nueva directa → se omite (como el filtro SQL viejo).
+          // Con compra pero sin saldo previo (la compra cubre todo) → también se omite.
+          if (comprasDelMes.lte(0) || montoViejo.lte(0)) {
             console.log(
               `⏭️  Crédito ${credito.creditoId}: participación del período (${fechaInicioParticipacion}) ` +
-              `sin monto viejo [monto_aportado=${credito.montoAportado}, pendientes=${sumaPendientes.toString()}, ` +
-              `compras_mes_actual=${sumaCompletadasMesActual.toString()}] → participación nueva, se omite`
+              `sin monto viejo respaldado por compra [monto_aportado=${credito.montoAportado}, ` +
+              `pendientes=${sumaPendientes.toString()}, compras_mes_actual=${sumaCompletadasMesActual.toString()}] ` +
+              `→ participación nueva, se omite`
             );
             return null;
           }

--- a/apps/cartera-back/src/utils/comprasAjuste.ts
+++ b/apps/cartera-back/src/utils/comprasAjuste.ts
@@ -129,6 +129,50 @@ export async function obtenerSumaComprasMesAnterior(
 }
 
 /**
+ * Suma los monto_aportado de las compras de cartera (tipo_operacion = 'compra_cartera',
+ * status = 'completado') confirmadas durante el MES ACTUAL de `fechaPeriodo`
+ * (filtradas por `updated_at`).
+ *
+ * El cálculo de pagos corre a mitad de mes (≈ el 10). Toda compra confirmada del
+ * mes en curso —del día 1 hasta el momento del cálculo— todavía NO debe generar
+ * interés este período: igual que las pendientes, se excluye de la base y empieza
+ * a producir (proporcional) el mes siguiente. Sirve para calcular el "monto viejo"
+ * (monto_aportado − pendientes − compras_completadas_mes_actual) y así decidir si
+ * el crédito tiene saldo previo que liquidar este período o es una participación
+ * genuinamente nueva.
+ */
+export async function obtenerSumaComprasCompletadasMesActual(
+  credito_id: number,
+  inversionista_id: number,
+  fechaPeriodo: Date,
+): Promise<Big> {
+  const mes = fechaPeriodo.getMonth();
+  const anio = fechaPeriodo.getFullYear();
+
+  const inicioMesActual = new Date(anio, mes, 1);
+  const inicioMesSiguiente = new Date(anio, mes + 1, 1);
+
+  const compras = await db
+    .select({ monto_aportado: compras_credito_inversionista.monto_aportado })
+    .from(compras_credito_inversionista)
+    .where(
+      and(
+        eq(compras_credito_inversionista.credito_id, credito_id),
+        eq(compras_credito_inversionista.inversionista_id, inversionista_id),
+        eq(compras_credito_inversionista.tipo_operacion, "compra_cartera"),
+        eq(compras_credito_inversionista.status, "completado"),
+        gte(compras_credito_inversionista.updated_at, inicioMesActual),
+        lt(compras_credito_inversionista.updated_at, inicioMesSiguiente),
+      ),
+    );
+
+  return compras.reduce(
+    (acc, c) => acc.plus(new Big(c.monto_aportado ?? 0)),
+    new Big(0),
+  );
+}
+
+/**
  * Suma los monto_aportado de las compras de cartera que están PENDIENTES
  * (status pendiente_*) para el inversionista+crédito.
  *

--- a/apps/crm/apps/server/package.json
+++ b/apps/crm/apps/server/package.json
@@ -51,5 +51,8 @@
 		"drizzle-kit": "^0.31.2",
 		"tsc-alias": "^1.8.11",
 		"typescript": "^5.8.2"
+	},
+	"overrides": {
+		"kysely": "0.28.11"
 	}
 }


### PR DESCRIPTION
## Qué resuelve

Cuando un inversionista que **ya participaba** en un crédito hace una **compra de cartera** (que siempre se le compra a Cube), el cálculo de pagos espejo tenía 3 problemas. Este PR los corrige. Todo gira en torno a la regla del negocio: **una compra del mes en curso todavía no es efectiva ese período — paga desde el mes siguiente (proporcional) — pero la plata vieja del inversionista sí debe seguir liquidándose normal.**

---

### 1. No perder el "monto viejo" cuando hay compra del mes

**Antes:** al hacer la compra, se le re-sella la `fecha_inicio_participacion` al mes en curso. El orquestador filtraba por esa fecha y **botaba el crédito entero**, así que la plata vieja del inversionista (la que ya tenía antes de comprar) **no se liquidaba ese mes**.

**Ahora:** en vez de botar el crédito, se evalúa el **monto viejo** = `monto_aportado − compras pendientes − compras completadas del mes`:
- Si queda monto viejo (> 0) → **se procesa** (la compra del mes se excluye sola del cálculo; la plata vieja cobra mes completo).
- Si no queda (participante nuevo puro) → se omite, como antes.
- Para créditos **sin** compras del mes: comportamiento **idéntico** al de hoy.

### 2. Elegir al inversionista "mayor" por el monto real del período

El "mayor" es quien absorbe seguro + gps + membresías. Se elegía con `cuota_inversionista`, que **ya viene inflada** por la compra del mes. Como toda compra se le hace a **Cube (ID 86)**, una compra podía volver "mayor" al comprador con plata que ese mes todavía no es efectiva.

**Ahora**, solo si el crédito tiene compras del mes, el mayor se elige con el estado **pre-compra**:
- comprador → su monto viejo
- Cube → su monto + lo que vendió ese mes (se le devuelve)
- los demás → igual

Si no hay compras del mes, queda la comparación histórica intacta.

### 3. GPS en el recálculo de cuota

El recálculo de cuota (cuando hay compra pendiente o del mes) restaba de la base solo membresías + seguro y **dejaba el GPS repartido entre todos**, pero el abono sí restaba el GPS completo al mayor → su abono quedaba corto por ~GPS.

**Ahora** coincide con `addInvestorToCredit`: la base se reparte sin los tres cargos y los tres se le suman solo al mayor.

---

## Qué NO cambia

- Créditos **sin compras del mes**: cálculo byte-idéntico al actual.
- El cálculo del **interés** (proporcional / split monto viejo + compra) no se tocó.
- El **abono a capital** sigue restando el interés **completo** (regla confirmada con el equipo); el proporcional solo afecta lo que se **registra** como interés ganado.
- La validación contra el histórico no se tocó.

## Notas

- Incluye un commit chico de pin de `kysely` (no relacionado, vino arrastrado en la rama).
- Tests: `5/5` en `payments.test.ts` (incluye regresión de participante viejo, self-compra pendiente, NO_LIQUIDADO, nuevo del mes → omite, y viejo+compra → procesa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)