### PR TITLE
feat(cartera): mostrar deuda acumulada por cuotas vencidas en collapse de Pagos por Vencimiento

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagosPorVencimiento.tsx
@@ -677,7 +677,9 @@ export function PagosPorVencimiento() {
                             {/* 15. Royalty */}
                             <TableCell className="text-right text-gray-400 border-r border-b border-red-300 text-[11px]">--</TableCell>
                             {/* 16. Mora */}
-                            <TableCell className="border-r border-b border-red-300" />
+                            <TableCell className="text-right font-bold text-red-800 border-r border-b border-red-300 text-[11px]">
+                              {formatQ(item.mora)}
+                            </TableCell>
                             {/* 17. Total */}
                             <TableCell className="text-right font-bold text-red-800 bg-red-100/30 border-b border-red-300 text-[11px]">
                               {formatQ(String(acumuladoTotales.total.toFixed(2)))}


### PR DESCRIPTION
## fix(cartera): mostrar mora del crédito en fila de totales de deuda acumulada

La fila "Deuda acumulada total" en el collapse de Pagos por Vencimiento
tenía la columna Mora vacía. Se agrega `item.mora` (ya disponible desde
la fila padre) en la celda correspondiente del totales acumulado.

Sin cambios en backend.
<img width="1345" height="461" alt="image" src="https://github.com/user-attachments/assets/c6b99d33-19fb-4f27-9235-21d47480f36c" />
