### PR TITLE
Add support for EN_CONVENIO status and enhance debt calculations

### DIFF
--- a/apps/crm/apps/server/src/db/schema/cobros.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros.ts
@@ -18,6 +18,7 @@ import { vehicles } from "./vehicles";
 // Enums para cobros
 export const estadoMoraEnum = pgEnum("estado_mora", [
 	"al_dia", // Pagos al día
+	"en_convenio", // Crédito con convenio de pago activo
 	"mora_30", // 1-30 días de retraso
 	"mora_60", // 31-60 días de retraso
 	"mora_90", // 61-90 días de retraso

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -662,6 +662,9 @@ export const cobrosRouter = {
 								// Solo cambiar el estado, sin filtrar por cuotas
 								estadoCartera = "CANCELADO";
 								break;
+							case "en_convenio":
+								estadoCartera = "EN_CONVENIO" as typeof estadoCartera;
+								break;
 							default:
 								// Sin filtro, mantener ACTIVO como predeterminado
 								estadoCartera = "ACTIVO";
@@ -969,9 +972,10 @@ export const cobrosRouter = {
 							// Calcular monto en mora como: cuota mensual * cuotas atrasadas
 							const montoEnMora = cuotaMensual * cuotasAtrasadas;
 
-							// Determinar estado de mora según días de mora
+							// Determinar estado de mora según statusCredit y días de mora
 							let estadoMora: string | null = null;
-							if (diasMora === 0) estadoMora = "al_dia";
+							if (statusCredit === "EN_CONVENIO") estadoMora = "en_convenio";
+							else if (diasMora === 0) estadoMora = "al_dia";
 							else if (diasMora <= 30) estadoMora = "mora_30";
 							else if (diasMora <= 60) estadoMora = "mora_60";
 							else if (diasMora <= 90) estadoMora = "mora_90";
@@ -2115,14 +2119,19 @@ export const cobrosRouter = {
 				const diasMora = calcularDiasMoraExactos(
 					creditoCompleto.cuotasAtrasadas || [],
 				);
-				const montoEnMora =
-					Number(creditoCompleto.moraActual) || cuotaMensual * cuotasAtrasadas;
+				const montoEnMora = Number(creditoCompleto.moraActual ?? 0);
 
+				const tieneMoraActiva = creditoCompleto.mora != null;
+				const tieneConvenioActivo = creditoCompleto.convenioActivo != null;
 				let estadoMora: string | null = "al_dia";
-				if (cuotasAtrasadas === 1) estadoMora = "mora_30";
-				else if (cuotasAtrasadas === 2) estadoMora = "mora_60";
-				else if (cuotasAtrasadas === 3) estadoMora = "mora_90";
-				else if (cuotasAtrasadas >= 4) estadoMora = "mora_120";
+				if (tieneConvenioActivo) {
+					estadoMora = "en_convenio";
+				} else if (tieneMoraActiva) {
+					if (cuotasAtrasadas === 1) estadoMora = "mora_30";
+					else if (cuotasAtrasadas === 2) estadoMora = "mora_60";
+					else if (cuotasAtrasadas === 3) estadoMora = "mora_90";
+					else if (cuotasAtrasadas >= 4) estadoMora = "mora_120";
+				}
 
 				// Día de pago: extraer desde la fecha_vencimiento de una cuota real
 				// de cartera (prioriza pendiente, luego atrasada, luego pagada),
@@ -2149,11 +2158,14 @@ export const cobrosRouter = {
 					id: casoCobro?.id || null,
 					contratoId: contratoId,
 
-					// Datos de mora
+					// Datos de mora / convenio
 					estadoMora,
 					montoEnMora: montoEnMora.toFixed(2),
 					diasMoraMaximo: diasMora,
 					cuotasVencidas: cuotasAtrasadas,
+					cuotaConvenio: tieneConvenioActivo
+						? Number(creditoCompleto.convenioActivo!.cuota_mensual ?? 0).toFixed(2)
+						: null,
 
 					// Datos de contacto (del caso de cobros primero, fallback al lead)
 					telefonoPrincipal:

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -12,7 +12,8 @@ export type StatusCreditEnum =
 	| "CANCELADO"
 	| "INCOBRABLE"
 	| "PENDIENTE_CANCELACION"
-	| "MOROSO";
+	| "MOROSO"
+	| "EN_CONVENIO";
 
 export type EstadoLiquidacionEnum =
 	| "NO_LIQUIDADO"
@@ -226,6 +227,27 @@ export interface CarteraAsesorCredito {
  * Estructura real devuelta por el endpoint /credito?numero_credito_sifco=XXX
  * Retorna los datos del crédito con las cuotas separadas por estado
  */
+export interface CarteraConvenio {
+	convenio_id: number;
+	credito_id: number;
+	monto_total_convenio: string;
+	numero_meses: number;
+	cuota_mensual: string;
+	activo: boolean;
+	completado: boolean;
+	created_at?: string | null;
+	updated_at?: string | null;
+	fecha_convenio?: string | null;
+	monto_pagado?: string | null;
+	monto_pendiente?: string | null;
+	pagos_realizados?: number | null;
+	pagos_pendientes?: number | null;
+	motivo?: string | null;
+	observaciones?: string | null;
+	created_by?: number | null;
+	cuotaConvenioAPagar?: string | null;
+}
+
 export interface CreditoDirectoResponse {
 	credito: CarteraCredito;
 	usuario: CarteraUsuario;
@@ -235,6 +257,7 @@ export interface CreditoDirectoResponse {
 	cuotasAtrasadas: CarteraCuotaCredito[];
 	moraActual: string; // decimal viene como string
 	mora?: CarteraMoraCredito | null;
+	convenioActivo?: CarteraConvenio | null;
 }
 
 export interface UpdateCreditoInput {

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -471,6 +471,7 @@ function RouteComponent() {
 
 	const getEstadoBadge = (estado: string | null | undefined) => {
 		const colors: Record<string, string> = {
+			en_convenio: "bg-green-100 text-green-800",
 			mora_30: "bg-yellow-100 text-yellow-800",
 			mora_60: "bg-orange-100 text-orange-800",
 			mora_90: "bg-red-100 text-red-800",
@@ -581,7 +582,18 @@ function RouteComponent() {
 										<CalendarClock className="h-4 w-4 text-muted-foreground" />
 										<span className="font-medium">Días de Mora:</span>
 									</div>
-									<p>{caso.diasMoraMaximo} días</p>
+									<p>
+										{caso.estadoMora === "mora_30"
+											? "30"
+											: caso.estadoMora === "mora_60"
+												? "60"
+												: caso.estadoMora === "mora_90"
+													? "90"
+													: caso.estadoMora === "mora_120"
+														? "120+"
+														: "0"}{" "}
+										días
+									</p>
 								</div>
 								<div className="space-y-2">
 									<div className="flex items-center gap-2 text-sm">
@@ -596,6 +608,21 @@ function RouteComponent() {
 										})}
 									</p>
 								</div>
+								{caso.cuotaConvenio != null && (
+									<div className="space-y-2">
+										<div className="flex items-center gap-2 text-sm">
+											<Banknote className="h-4 w-4 text-muted-foreground" />
+											<span className="font-medium">Cuota Convenio:</span>
+										</div>
+										<p className="font-bold text-green-600 text-lg">
+											Q
+											{Number(caso.cuotaConvenio ?? 0).toLocaleString("es-GT", {
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											})}
+										</p>
+									</div>
+								)}
 								<div className="space-y-2">
 									<div className="flex items-center gap-2 text-sm">
 										<Banknote className="h-4 w-4 text-muted-foreground" />
@@ -615,7 +642,9 @@ function RouteComponent() {
 										<span className="font-medium">
 											Total a Pagar{" "}
 											<span className="text-muted-foreground text-xs">
-												(Mora + Cuota)
+												{caso.cuotaConvenio != null
+													? "(Convenio + Cuota)"
+													: "(Mora + Cuota)"}
 											</span>
 											:
 										</span>
@@ -623,7 +652,9 @@ function RouteComponent() {
 									<p className="font-bold text-lg text-orange-600">
 										Q
 										{(
-											Number(caso.montoEnMora) + Number(caso.cuotaMensual || 0)
+											caso.cuotaConvenio != null
+												? Number(caso.cuotaConvenio) + Number(caso.cuotaMensual || 0)
+												: Number(caso.montoEnMora) + Number(caso.cuotaMensual || 0)
 										).toLocaleString()}
 									</p>
 								</div>
@@ -706,7 +737,49 @@ function RouteComponent() {
 									</div>
 								</div>
 							)}
-							{/* Strip visual: Total a Cobrar */}
+							{/* Strip visual: Total a Cobrar - Convenio */}
+							{caso.cuotaConvenio != null && (
+								<div className="mt-2 rounded-lg border border-green-200 bg-green-50 p-4">
+									<div className="flex items-center justify-between">
+										<div>
+											<p className="font-semibold text-green-900 text-sm">
+												Total a Cobrar (Convenio + Cuota)
+											</p>
+											<div className="mt-1 flex items-center gap-3 text-green-700 text-xs">
+												<span>
+													Convenio:{" "}
+													<strong>
+														Q
+														{Number(caso.cuotaConvenio ?? 0).toLocaleString("es-GT", {
+															minimumFractionDigits: 2,
+															maximumFractionDigits: 2,
+														})}
+													</strong>
+												</span>
+												<span>+</span>
+												<span>
+													Cuota:{" "}
+													<strong>
+														Q
+														{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", {
+															minimumFractionDigits: 2,
+															maximumFractionDigits: 2,
+														})}
+													</strong>
+												</span>
+											</div>
+										</div>
+										<p className="font-extrabold text-2xl text-green-700">
+											Q
+											{(
+												Number(caso.cuotaConvenio ?? 0) +
+												Number(caso.cuotaMensual || 0)
+											).toLocaleString()}
+										</p>
+									</div>
+								</div>
+							)}
+							{/* Strip visual: Total a Cobrar - Mora */}
 							{Number(caso.montoEnMora) > 0 && (
 								<div className="mt-2 rounded-lg border border-orange-200 bg-orange-50 p-4">
 									<div className="flex items-center justify-between">

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -573,6 +573,11 @@ function RouteComponent() {
 	const filtrosEtapa = [
 		{ key: "al_dia", label: "Al Día", color: "bg-green-100 text-green-800" },
 		{
+			key: "en_convenio",
+			label: "En Convenio",
+			color: "bg-green-100 text-green-800",
+		},
+		{
 			key: "mora_30",
 			label: "Mora 30",
 			color: "bg-yellow-100 text-yellow-800",


### PR DESCRIPTION
CAMBIOS EN apps/crm/apps/server/src/routers/cobros.ts

  - Reemplazado Number(moraActual) || fallback por Number(moraActual ?? 0) para respetar el valor 0 que retorna cartera-back cuando no hay mora activa.
  - estadoMora ahora solo asigna etiquetas de mora (mora_30, mora_60, etc.) cuando el objeto mora de cartera-back es distinto de null. Si no hay mora activa retorna al_dia.
  - Se agrega prioridad para convenios: cuando convenioActivo != null, estadoMora retorna en_convenio antes de evaluar mora.
  - Se agrega cuotaConvenio al objeto de retorno del endpoint getDetallesCreditoCarteraBack (valor de la cuota del convenio activo, null si no hay convenio).
  - Se agrega case en_convenio al switch de getTodosLosCreditos para pasar estado=EN_CONVENIO a la API de cartera-back al filtrar.
  - En el mapeo de la lista (getTodosLosCreditos), estadoMora ahora verifica statusCredit === EN_CONVENIO primero, haciendo consistente la lista con el detalle.

CAMBIOS EN apps/crm/apps/server/src/types/cartera-back.ts

  - Nuevo interface CarteraConvenio con los campos del convenio activo retornado por cartera-back.
  - Agregado convenioActivo?: CarteraConvenio | null a CreditoDirectoResponse.
  - Agregado EN_CONVENIO a StatusCreditEnum.

CAMBIOS EN apps/crm/apps/web/src/routes/cobros/$id.tsx

  - getEstadoBadge: agregado color verde (bg-green-100 text-green-800) para el estado en_convenio.
  - Nuevo campo Cuota Convenio en Información del Caso, visible solo cuando hay convenio activo, muestra Q0.00 si la cuota es cero.
  - Total a Pagar: etiqueta y cálculo cambian dinámicamente entre (Convenio + Cuota) y (Mora + Cuota) según corresponda.
  - Nuevo strip verde inferior para créditos EN_CONVENIO mostrando Convenio + Cuota. El strip naranja de mora se mantiene para créditos con mora activa.
  - Días de Mora: cambiado de valor calculado manualmente a valor derivado de estadoMora (0, 30, 60, 90 o 120 días), evitando inconsistencias entre la etiqueta y el número mostrado.

CAMBIOS EN apps/crm/apps/server/src/db/schema/cobros.ts

  - Agregado el valor en_convenio al enum estadoMoraEnum de PostgreSQL/Drizzle. Requiere ejecutar db:push o ALTER TYPE estado_mora ADD VALUE 'en_convenio' AFTER 'al_dia' en base de datos.

CAMBIOS EN apps/crm/apps/web/src/routes/cobros/index.tsx

  - Agregado filtro En Convenio a filtrosEtapa, posicionado después de Al Día, con color verde.