### PR TITLE
Feat: Add Capital Inversionistas report with filtering and Excel export

### DIFF
--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -2434,7 +2434,7 @@ export async function getCapitalInversionistas({
       inversionista: row.inversionista,
       capital: Number(row.capital),
       tasa_inversionista: Number(row.tasa_inversionista),
-      modalidad: row.modalidad ?? "",
+      modalidad: row.modalidad ? row.modalidad.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase()) : "",
       fecha_inicio_participacion: row.fecha_inicio_participacion
         ? row.fecha_inicio_participacion.slice(0, 10).split("-").reverse().join("/")
         : "",

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -2371,7 +2371,7 @@ export async function getCapitalInversionistas({
       i.inversionista_id,
       i.nombre AS inversionista,
       SUM(e.monto_aportado) AS capital,
-      ROUND(AVG(e.porcentaje_participacion_inversionista), 2) AS tasa_inversionista,
+      ROUND(SUM(e.porcentaje_participacion_inversionista * e.monto_aportado) / NULLIF(SUM(e.monto_aportado), 0), 2) AS tasa_inversionista,
       i.tipo_reinversion AS modalidad,
       MIN(e.fecha_inicio_participacion) AS fecha_inicio_participacion,
       CASE
@@ -2384,7 +2384,7 @@ export async function getCapitalInversionistas({
     ${whereClause}
     GROUP BY i.inversionista_id, i.nombre, i.tipo_reinversion
     HAVING SUM(e.monto_aportado) <> 0
-    ORDER BY i.inversionista_id, SUM(e.monto_aportado) DESC
+    ORDER BY SUM(e.monto_aportado) DESC
   `);
 
   const data = result.rows as {
@@ -2436,7 +2436,7 @@ export async function getCapitalInversionistas({
       tasa_inversionista: Number(row.tasa_inversionista),
       modalidad: row.modalidad ?? "",
       fecha_inicio_participacion: row.fecha_inicio_participacion
-        ? new Date(row.fecha_inicio_participacion).toLocaleDateString("es-GT")
+        ? row.fecha_inicio_participacion.slice(0, 10).split("-").reverse().join("/")
         : "",
       comentario: row.comentario,
     });

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -2342,3 +2342,176 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
 
   return { cuotas, totales };
 }
+
+export async function getCapitalInversionistas({
+  fecha_desde,
+  fecha_hasta,
+  excel = false,
+}: {
+  fecha_desde?: string;
+  fecha_hasta?: string;
+  excel?: boolean;
+}) {
+  const filters: any[] = [];
+
+  if (fecha_desde) {
+    filters.push(sql`e.fecha_inicio_participacion >= ${fecha_desde}::date`);
+  }
+  if (fecha_hasta) {
+    filters.push(sql`e.fecha_inicio_participacion <= ${fecha_hasta}::date`);
+  }
+
+  const whereClause =
+    filters.length > 0
+      ? sql`WHERE ${sql.join(filters, sql` AND `)}`
+      : sql``;
+
+  const result = await db.execute(sql`
+    SELECT
+      i.inversionista_id,
+      i.nombre AS inversionista,
+      SUM(e.monto_aportado) AS capital,
+      ROUND(AVG(e.porcentaje_participacion_inversionista), 2) AS tasa_inversionista,
+      i.tipo_reinversion AS modalidad,
+      MIN(e.fecha_inicio_participacion) AS fecha_inicio_participacion,
+      CASE
+        WHEN bool_or(e.status <> 'completado') THEN 'compra de cartera pendiente'
+        ELSE ''
+      END AS comentario
+    FROM cartera.creditos_inversionistas_espejo e
+    JOIN cartera.inversionistas i
+      ON i.inversionista_id = e.inversionista_id
+    ${whereClause}
+    GROUP BY i.inversionista_id, i.nombre, i.tipo_reinversion
+    HAVING SUM(e.monto_aportado) <> 0
+    ORDER BY i.inversionista_id, SUM(e.monto_aportado) DESC
+  `);
+
+  const data = result.rows as {
+    inversionista_id: number;
+    inversionista: string;
+    capital: string;
+    tasa_inversionista: string;
+    modalidad: string | null;
+    fecha_inicio_participacion: string | null;
+    comentario: string;
+  }[];
+
+  if (!excel) {
+    return { data };
+  }
+
+  const workbook = new ExcelJS.Workbook();
+  const sheet = workbook.addWorksheet("Capital Inversionistas");
+
+  sheet.columns = [
+    { header: "No.", key: "no", width: 6 },
+    { header: "Inversionista", key: "inversionista", width: 30 },
+    { header: "Capital (Q)", key: "capital", width: 18 },
+    { header: "Tasa (%)", key: "tasa_inversionista", width: 12 },
+    { header: "Modalidad", key: "modalidad", width: 20 },
+    { header: "Fecha Inicio Participación", key: "fecha_inicio_participacion", width: 26 },
+    { header: "Comentario", key: "comentario", width: 35 },
+  ];
+
+  const headerRow = sheet.getRow(1);
+  headerRow.eachCell((cell) => {
+    cell.font = { bold: true, color: { argb: "FFFFFFFF" } };
+    cell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FF1E3A5F" } };
+    cell.alignment = { horizontal: "center", vertical: "middle" };
+    cell.border = {
+      top: { style: "thin" },
+      left: { style: "thin" },
+      bottom: { style: "thin" },
+      right: { style: "thin" },
+    };
+  });
+  headerRow.height = 20;
+
+  data.forEach((row, idx) => {
+    const r = sheet.addRow({
+      no: idx + 1,
+      inversionista: row.inversionista,
+      capital: Number(row.capital),
+      tasa_inversionista: Number(row.tasa_inversionista),
+      modalidad: row.modalidad ?? "",
+      fecha_inicio_participacion: row.fecha_inicio_participacion
+        ? new Date(row.fecha_inicio_participacion).toLocaleDateString("es-GT")
+        : "",
+      comentario: row.comentario,
+    });
+
+    const isEven = idx % 2 === 0;
+    r.eachCell((cell) => {
+      cell.fill = {
+        type: "pattern",
+        pattern: "solid",
+        fgColor: { argb: isEven ? "FFF5F7FA" : "FFFFFFFF" },
+      };
+      cell.border = {
+        top: { style: "thin", color: { argb: "FFD1D5DB" } },
+        left: { style: "thin", color: { argb: "FFD1D5DB" } },
+        bottom: { style: "thin", color: { argb: "FFD1D5DB" } },
+        right: { style: "thin", color: { argb: "FFD1D5DB" } },
+      };
+    });
+
+    const capitalCell = r.getCell("capital");
+    capitalCell.numFmt = '"Q"#,##0.00';
+    capitalCell.alignment = { horizontal: "right" };
+
+    const tasaCell = r.getCell("tasa_inversionista");
+    tasaCell.numFmt = '0.00"%"';
+    tasaCell.alignment = { horizontal: "right" };
+  });
+
+  const totalCapital = data.reduce((acc, row) => acc + Number(row.capital ?? 0), 0);
+  const totalRow = sheet.addRow([]);
+  totalRow.getCell(1).value = null;
+  totalRow.getCell(2).value = "TOTAL";
+  totalRow.getCell(3).value = totalCapital;
+  totalRow.getCell(4).value = null;
+  totalRow.getCell(5).value = null;
+  totalRow.getCell(6).value = null;
+  totalRow.getCell(7).value = null;
+
+  for (let col = 1; col <= 7; col++) {
+    const cell = totalRow.getCell(col);
+    cell.font = { bold: true, color: { argb: "FF1E3A5F" } };
+    cell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFD1E8FF" } };
+    cell.border = {
+      top: { style: "medium", color: { argb: "FF1E3A5F" } },
+      left: { style: "thin", color: { argb: "FFD1D5DB" } },
+      bottom: { style: "medium", color: { argb: "FF1E3A5F" } },
+      right: { style: "thin", color: { argb: "FFD1D5DB" } },
+    };
+  }
+  const totalCapitalCell = totalRow.getCell(3);
+  totalCapitalCell.numFmt = '"Q"#,##0.00';
+  totalCapitalCell.alignment = { horizontal: "right" };
+  totalRow.getCell(2).alignment = { horizontal: "left" };
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  const filename = `reportes/capital_inversionistas_${Date.now()}.xlsx`;
+
+  const s3 = new S3Client({
+    endpoint: process.env.BUCKET_REPORTS_URL,
+    region: "auto",
+    credentials: {
+      accessKeyId: process.env.R2_ACCESS_KEY_ID as string,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY as string,
+    },
+  });
+
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: process.env.BUCKET_REPORTS,
+      Key: filename,
+      Body: Buffer.from(buffer),
+      ContentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    })
+  );
+
+  const excelUrl = `${process.env.URL_PUBLIC_R2_REPORTS}/${filename}`;
+  return { data, excelUrl };
+}

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -12,7 +12,7 @@ import { z } from "zod";
 import { promises as fs } from "fs";
 import { mapPagosPorCreditos, mapPagosDesdeJson } from "../migration/migration";
 import { authMiddleware } from "./midleware";
-import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF, getPagosByVencimiento, getAbonosDelMesPorCredito, getAcumuladoPorCredito } from "../controllers/reports";
+import { exportPagosConInversionistasExcel, exportPagosAdvisorExcel, exportPagosToExcel, generateReciboPagoPDF, getPagosByVencimiento, getAbonosDelMesPorCredito, getAcumuladoPorCredito, getCapitalInversionistas } from "../controllers/reports";
 import { actualizarCuentaPago, aplicarPagoAlCredito, insertPayment, aplicarMontoAPago, editarPago } from "../controllers/registerPayment";
 import { eq } from "drizzle-orm";
 import { db } from "../database";
@@ -1464,5 +1464,35 @@ export const paymentRouter = new Elysia()
       tags: ["Pagos"],
       summary: "Aplicar un monto adicional a los restantes de un pago existente",
     },
+  }
+)
+.get(
+  "/capital-inversionistas",
+  async ({ query, set }) => {
+    try {
+      const result = await getCapitalInversionistas({
+        fecha_desde: query.fecha_desde,
+        fecha_hasta: query.fecha_hasta,
+        excel: query.excel,
+      });
+      set.status = 200;
+      return { success: true, ...result };
+    } catch (error: any) {
+      console.error("Error en /capital-inversionistas:", error);
+      set.status = 500;
+      return { success: false, error: error.message || "Error obteniendo capital de inversionistas" };
+    }
+  },
+  {
+    detail: {
+      summary: "Reporte de capital por inversionista",
+      description: "Retorna el capital aportado, tasa promedio, modalidad y fecha de inicio de participación por inversionista.",
+      tags: ["Reportes", "Inversionistas"],
+    },
+    query: t.Object({
+      fecha_desde: t.Optional(t.String()),
+      fecha_hasta: t.Optional(t.String()),
+      excel: t.Optional(t.Boolean({ default: false })),
+    }),
   }
 )

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -1468,7 +1468,11 @@ export const paymentRouter = new Elysia()
 )
 .get(
   "/capital-inversionistas",
-  async ({ query, set }) => {
+  async ({ query, set, user }: any) => {
+    if (user?.role !== "ADMIN") {
+      set.status = 403;
+      return { success: false, error: "No autorizado" };
+    }
     try {
       const result = await getCapitalInversionistas({
         fecha_desde: query.fecha_desde,

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -24,6 +24,7 @@ import { FallenCredits } from "./private/cartera/components/FallenCredits";
 import { PagosPorVencimiento } from "./private/cartera/components/PagosPorVencimiento";
 import { DevolucionCube } from "./private/cartera/components/DevolucionCube";
 import { CierreCartera } from "./private/cartera/components/CierreCartera";
+import { CapitalInversionistas } from "./private/cartera/components/CapitalInversionistas";
 
 // 🔒 Rutas privadas
 function PrivateRoute({ children }: { children: JSX.Element }) {
@@ -267,6 +268,15 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN"]}>
               <CierreCartera />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="capital-inversionistas"
+          element={
+            <RoleRoute allowedRoles={["ADMIN"]}>
+              <CapitalInversionistas />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
@@ -1,0 +1,315 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { CalendarIcon, Download, Loader2, Search } from "lucide-react";
+import {
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  getCapitalInversionistas,
+  type CapitalInversionistaItem,
+} from "../services/services";
+import { useCapitalInversionistas } from "../hooks/useCapitalInversionistas";
+
+function formatQ(val: string | number | null | undefined): string {
+  const n = Number(val ?? 0);
+  if (isNaN(n)) return "Q 0.00";
+  return `Q ${n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function formatFecha(val: string | null | undefined): string {
+  if (!val) return "-";
+  const [year, month, day] = val.slice(0, 10).split("-");
+  return `${day}/${month}/${year}`;
+}
+
+function toDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+function DatePickerField({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (val: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const selected = value ? new Date(value + "T00:00:00") : undefined;
+
+  return (
+    <div className="min-w-[180px]">
+      <label className="text-sm font-semibold text-blue-800 mb-1 block">{label}</label>
+      <div className="flex items-center border border-blue-200 rounded-lg bg-blue-50 focus-within:ring-1 focus-within:ring-blue-400 overflow-hidden">
+        <input
+          type="text"
+          placeholder="YYYY-MM-DD"
+          value={value}
+          onChange={(e) => {
+            const digits = e.target.value.replace(/\D/g, "");
+            let formatted = digits;
+            if (digits.length > 4) formatted = digits.slice(0, 4) + "-" + digits.slice(4);
+            if (digits.length > 6) formatted = digits.slice(0, 4) + "-" + digits.slice(4, 6) + "-" + digits.slice(6, 8);
+            onChange(formatted);
+          }}
+          maxLength={10}
+          className="flex-1 px-3 py-2 text-sm text-blue-800 bg-transparent focus:outline-none"
+        />
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="px-2 py-2 text-blue-600 hover:text-blue-800 hover:bg-blue-100 transition-colors"
+            >
+              <CalendarIcon className="h-4 w-4" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="w-auto p-0 bg-white shadow-lg border border-slate-200 text-black" align="start">
+            <Calendar
+              mode="single"
+              selected={selected}
+              onSelect={(date) => {
+                if (date) onChange(toDateString(date));
+                setOpen(false);
+              }}
+              className="[--cell-size:--spacing(5)] w-60"
+            />
+          </PopoverContent>
+        </Popover>
+      </div>
+    </div>
+  );
+}
+
+export function CapitalInversionistas() {
+  const [fechaDesde, setFechaDesde] = useState("");
+  const [fechaHasta, setFechaHasta] = useState("");
+  const [queryEnabled, setQueryEnabled] = useState(true);
+  const [appliedDesde, setAppliedDesde] = useState("");
+  const [appliedHasta, setAppliedHasta] = useState("");
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const { data, isLoading, isError, refetch } = useCapitalInversionistas(
+    { fecha_desde: appliedDesde || undefined, fecha_hasta: appliedHasta || undefined },
+    queryEnabled
+  );
+
+  const rows: CapitalInversionistaItem[] = data?.data ?? [];
+
+  const totalCapital = rows.reduce((acc, r) => acc + Number(r.capital ?? 0), 0);
+
+  const handleGenerar = () => {
+    setAppliedDesde(fechaDesde);
+    setAppliedHasta(fechaHasta);
+    setQueryEnabled(true);
+    refetch();
+  };
+
+  const handleExcel = async () => {
+    setIsExporting(true);
+    setExportError(null);
+    try {
+      const res = await getCapitalInversionistas({
+        fecha_desde: appliedDesde || undefined,
+        fecha_hasta: appliedHasta || undefined,
+        excel: true,
+      });
+      if (res.success && res.excelUrl) {
+        window.open(res.excelUrl, "_blank");
+      } else {
+        setExportError("No se pudo generar el archivo Excel.");
+      }
+    } catch {
+      setExportError("Error al exportar el Excel.");
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-4 sm:p-6">
+      <div className="max-w-7xl mx-auto space-y-4 sm:space-y-6">
+
+        {/* Encabezado */}
+        <div className="text-center space-y-1">
+          <h1 className="text-xl sm:text-3xl font-bold text-blue-900">Capital Inversionistas</h1>
+          <p className="text-slate-500 text-xs sm:text-sm">
+            Resumen de capital aportado, tasa y modalidad por inversionista
+          </p>
+        </div>
+
+        {/* Filtros */}
+        <div className="bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-blue-100 p-4 sm:p-5">
+          <div className="flex flex-col sm:flex-row sm:flex-wrap sm:items-end gap-3 sm:gap-4">
+            <div className="w-full sm:min-w-[180px] sm:w-auto">
+              <DatePickerField label="Fecha Desde" value={fechaDesde} onChange={setFechaDesde} />
+            </div>
+            <div className="w-full sm:min-w-[180px] sm:w-auto">
+              <DatePickerField label="Fecha Hasta" value={fechaHasta} onChange={setFechaHasta} />
+            </div>
+            <div className="flex gap-2 sm:gap-3 sm:items-end">
+              <Button
+                onClick={handleGenerar}
+                disabled={isLoading}
+                className="flex-1 sm:flex-none bg-blue-700 hover:bg-blue-800 text-white"
+              >
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                ) : (
+                  <Search className="h-4 w-4 mr-2" />
+                )}
+                Generar Reporte
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handleExcel}
+                disabled={isExporting || rows.length === 0}
+                className="flex-1 sm:flex-none border-green-600 text-green-700 hover:bg-green-50"
+              >
+                {isExporting ? (
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
+                ) : (
+                  <Download className="h-4 w-4 mr-2" />
+                )}
+                Exportar Excel
+              </Button>
+            </div>
+          </div>
+          {exportError && (
+            <p className="mt-3 text-sm text-red-600">{exportError}</p>
+          )}
+        </div>
+
+        {/* Resultado */}
+        <div className="bg-white rounded-xl shadow-sm border border-slate-200">
+          {isLoading ? (
+            <div className="flex items-center justify-center h-48 text-slate-500">
+              <Loader2 className="h-6 w-6 animate-spin mr-2" />
+              Cargando datos...
+            </div>
+          ) : isError ? (
+            <div className="flex items-center justify-center h-48 text-red-500">
+              Error al cargar el reporte. Intente de nuevo.
+            </div>
+          ) : rows.length === 0 ? (
+            <div className="flex items-center justify-center h-48 text-slate-400">
+              Sin resultados para los filtros seleccionados.
+            </div>
+          ) : (
+            <>
+              {/* Vista móvil — tarjetas */}
+              <div className="block md:hidden divide-y divide-slate-100">
+                {rows.map((row, idx) => (
+                  <div key={row.inversionista_id} className={`p-4 space-y-2 ${idx % 2 === 0 ? "bg-slate-50" : "bg-white"}`}>
+                    <div className="flex items-start justify-between gap-2">
+                      <span className="font-semibold text-slate-800 text-sm leading-tight">{row.inversionista}</span>
+                      <span className="text-xs text-slate-400 shrink-0">#{idx + 1}</span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                      <div>
+                        <span className="text-slate-400 uppercase tracking-wide">Capital</span>
+                        <p className="font-mono font-semibold text-slate-700">{formatQ(row.capital)}</p>
+                      </div>
+                      <div>
+                        <span className="text-slate-400 uppercase tracking-wide">Tasa</span>
+                        <p className="text-slate-700">{row.tasa_inversionista}%</p>
+                      </div>
+                      <div>
+                        <span className="text-slate-400 uppercase tracking-wide">Modalidad</span>
+                        <p className="text-slate-600">{row.modalidad ?? "-"}</p>
+                      </div>
+                      <div>
+                        <span className="text-slate-400 uppercase tracking-wide">Fecha Inicio</span>
+                        <p className="text-slate-600">{formatFecha(row.fecha_inicio_participacion)}</p>
+                      </div>
+                      {row.comentario && (
+                        <div className="col-span-2">
+                          <span className="text-slate-400 uppercase tracking-wide">Comentario</span>
+                          <p className="text-slate-500 italic">{row.comentario}</p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                <div className="flex justify-between items-center px-4 py-3 bg-blue-50 border-t border-slate-200">
+                  <span className="text-sm font-semibold text-blue-900">Total Capital</span>
+                  <span className="text-sm font-bold text-blue-900 font-mono">{formatQ(totalCapital)}</span>
+                </div>
+              </div>
+
+              {/* Vista desktop — tabla con header fijo */}
+              <div className="hidden md:block w-full overflow-x-auto">
+                <table className="w-full caption-bottom text-sm table-fixed">
+                  <colgroup>
+                    <col className="w-[5%]" />
+                    <col className="w-[22%]" />
+                    <col className="w-[15%]" />
+                    <col className="w-[10%]" />
+                    <col className="w-[15%]" />
+                    <col className="w-[18%]" />
+                    <col className="w-[15%]" />
+                  </colgroup>
+                  <TableHeader>
+                    <TableRow className="bg-blue-900 hover:bg-blue-900">
+                      <TableHead className="text-white font-semibold text-center">#</TableHead>
+                      <TableHead className="text-white font-semibold">Inversionista</TableHead>
+                      <TableHead className="text-white font-semibold text-right">Capital</TableHead>
+                      <TableHead className="text-white font-semibold text-right">Tasa (%)</TableHead>
+                      <TableHead className="text-white font-semibold">Modalidad</TableHead>
+                      <TableHead className="text-white font-semibold">Fecha Inicio Participación</TableHead>
+                      <TableHead className="text-white font-semibold">Comentario</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                </table>
+                <div className="max-h-[500px] overflow-y-auto">
+                  <table className="w-full caption-bottom text-sm table-fixed">
+                    <colgroup>
+                      <col className="w-[5%]" />
+                      <col className="w-[22%]" />
+                      <col className="w-[15%]" />
+                      <col className="w-[10%]" />
+                      <col className="w-[15%]" />
+                      <col className="w-[18%]" />
+                      <col className="w-[15%]" />
+                    </colgroup>
+                    <TableBody>
+                      {rows.map((row, idx) => (
+                        <TableRow
+                          key={row.inversionista_id}
+                          className={idx % 2 === 0 ? "bg-slate-50 hover:bg-slate-100" : "bg-white hover:bg-slate-50"}
+                        >
+                          <TableCell className="text-center text-slate-500">{idx + 1}</TableCell>
+                          <TableCell className="font-medium text-slate-800 truncate">{row.inversionista}</TableCell>
+                          <TableCell className="text-right font-mono text-slate-700">{formatQ(row.capital)}</TableCell>
+                          <TableCell className="text-right text-slate-700">{row.tasa_inversionista}%</TableCell>
+                          <TableCell className="text-slate-600 truncate">{row.modalidad ?? "-"}</TableCell>
+                          <TableCell className="text-slate-600">{formatFecha(row.fecha_inicio_participacion)}</TableCell>
+                          <TableCell className="text-slate-500 italic whitespace-normal break-words">{row.comentario || "-"}</TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </table>
+                </div>
+                <div className="flex justify-end border-t border-slate-200 px-4 py-3 bg-blue-50">
+                  <span className="text-sm font-semibold text-blue-900 mr-4">Total Capital:</span>
+                  <span className="text-sm font-bold text-blue-900 font-mono">{formatQ(totalCapital)}</span>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
@@ -28,6 +28,11 @@ function formatFecha(val: string | null | undefined): string {
   return `${day}/${month}/${year}`;
 }
 
+function formatModalidad(val: string | null | undefined): string {
+  if (!val) return "-";
+  return val.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 function toDateString(date: Date): string {
   const y = date.getFullYear();
   const m = String(date.getMonth() + 1).padStart(2, "0");
@@ -94,13 +99,13 @@ function DatePickerField({
 export function CapitalInversionistas() {
   const [fechaDesde, setFechaDesde] = useState("");
   const [fechaHasta, setFechaHasta] = useState("");
-  const [queryEnabled, setQueryEnabled] = useState(true);
+  const [queryEnabled, setQueryEnabled] = useState(false);
   const [appliedDesde, setAppliedDesde] = useState("");
   const [appliedHasta, setAppliedHasta] = useState("");
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
 
-  const { data, isLoading, isError, refetch } = useCapitalInversionistas(
+  const { data, isLoading, isError } = useCapitalInversionistas(
     { fecha_desde: appliedDesde || undefined, fecha_hasta: appliedHasta || undefined },
     queryEnabled
   );
@@ -113,7 +118,6 @@ export function CapitalInversionistas() {
     setAppliedDesde(fechaDesde);
     setAppliedHasta(fechaHasta);
     setQueryEnabled(true);
-    refetch();
   };
 
   const handleExcel = async () => {
@@ -227,7 +231,7 @@ export function CapitalInversionistas() {
                       </div>
                       <div>
                         <span className="text-slate-400 uppercase tracking-wide">Modalidad</span>
-                        <p className="text-slate-600">{row.modalidad ?? "-"}</p>
+                        <p className="text-slate-600">{formatModalidad(row.modalidad)}</p>
                       </div>
                       <div>
                         <span className="text-slate-400 uppercase tracking-wide">Fecha Inicio</span>
@@ -293,7 +297,7 @@ export function CapitalInversionistas() {
                           <TableCell className="font-medium text-slate-800 truncate">{row.inversionista}</TableCell>
                           <TableCell className="text-right font-mono text-slate-700">{formatQ(row.capital)}</TableCell>
                           <TableCell className="text-right text-slate-700">{row.tasa_inversionista}%</TableCell>
-                          <TableCell className="text-slate-600 truncate">{row.modalidad ?? "-"}</TableCell>
+                          <TableCell className="text-slate-600 truncate">{formatModalidad(row.modalidad)}</TableCell>
                           <TableCell className="text-slate-600">{formatFecha(row.fecha_inicio_participacion)}</TableCell>
                           <TableCell className="text-slate-500 italic whitespace-normal break-words">{row.comentario || "-"}</TableCell>
                         </TableRow>

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -236,6 +236,13 @@ const menuSections: MenuSection[] = [
         path: "/cierre-cartera",
         roles: ["ADMIN"],
       },
+      {
+        key: "capital-inversionistas",
+        label: "Capital Inversionistas",
+        icon: <TrendingUp className="h-4 w-4" />,
+        path: "/capital-inversionistas",
+        roles: ["ADMIN"],
+      },
     ],
   },
 ];

--- a/apps/carteraFront/src/private/cartera/hooks/useCapitalInversionistas.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useCapitalInversionistas.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getCapitalInversionistas,
+  type CapitalInversionistasParams,
+  type CapitalInversionistasResponse,
+} from "../services/services";
+
+export const useCapitalInversionistas = (
+  params: CapitalInversionistasParams,
+  enabled: boolean
+) => {
+  return useQuery<CapitalInversionistasResponse, Error>({
+    queryKey: [
+      "capitalInversionistas",
+      params.fecha_desde,
+      params.fecha_hasta,
+    ],
+    queryFn: async () => {
+      const response = await getCapitalInversionistas(params);
+      if (!response.success) throw new Error("Error al obtener capital de inversionistas");
+      return response;
+    },
+    enabled,
+    refetchOnWindowFocus: false,
+    staleTime: 1000 * 60 * 5,
+    retry: 1,
+  });
+};

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -4354,3 +4354,41 @@ export const generarCierreMensual = async (
   const res = await api.post(`${API_URL}/cierre-mensual/generar`, periodo ? { periodo } : {});
   return res.data;
 };
+
+export interface CapitalInversionistaItem {
+  inversionista_id: number;
+  inversionista: string;
+  capital: string;
+  tasa_inversionista: string;
+  modalidad: string | null;
+  fecha_inicio_participacion: string | null;
+  comentario: string;
+}
+
+export interface CapitalInversionistasParams {
+  fecha_desde?: string;
+  fecha_hasta?: string;
+  excel?: boolean;
+}
+
+export interface CapitalInversionistasResponse {
+  success: boolean;
+  data: CapitalInversionistaItem[];
+  excelUrl?: string;
+}
+
+export async function getCapitalInversionistas(
+  params: CapitalInversionistasParams
+): Promise<CapitalInversionistasResponse> {
+  const res = await api.get<CapitalInversionistasResponse>(
+    `${API_URL}/capital-inversionistas`,
+    {
+      params: {
+        ...(params.fecha_desde && { fecha_desde: params.fecha_desde }),
+        ...(params.fecha_hasta && { fecha_hasta: params.fecha_hasta }),
+        excel: params.excel,
+      },
+    }
+  );
+  return res.data;
+}


### PR DESCRIPTION
Reporte: Capital Inversionistas
Descripción general
Se implementó un nuevo reporte de Capital Inversionistas de extremo a extremo, incluyendo endpoint en el backend, generación de Excel y una nueva página en el frontend accesible desde el menú de Reportes.

Backend — apps/cartera-back
src/controllers/reports.ts

- Se agregó la función getCapitalInversionistas() que ejecuta la siguiente lógica:
  - Consulta la tabla cartera.creditos_inversionistas_espejo agrupada por inversionista, calculando:
  - SUM(monto_aportado) como capital total
  - ROUND(AVG(porcentaje_participacion_inversionista), 2) como tasa promedio (evita duplicados por variación de tasa entre registros)
  - MIN(fecha_inicio_participacion) como fecha más temprana de participación
  - CASE WHEN bool_or(status <> 'completado') para detectar compras de cartera pendientes
  - Soporta filtros opcionales fecha_desde y fecha_hasta aplicados sobre fecha_inicio_participacion antes del GROUP BY, garantizando que el capital mostrado sea consistente con el rango de fechas parametrizado
  - Si se solicita Excel (excel=true), genera un archivo .xlsx con ExcelJS que incluye:
  - Columna Capital con formato Q#,##0.00 alineada a la derecha
  - Fila de TOTAL y la suma de todos los capitales 
  - Subida automática a Cloudflare R2 y retorno de URL pública

Frontend — apps/carteraFront

src/private/cartera/services/services.ts
- Se agregaron las interfaces CapitalInversionistaItem, CapitalInversionistasParams y CapitalInversionistasResponse
- Se agregó la función getCapitalInversionistas() que consume el nuevo endpoint

src/private/cartera/hooks/useCapitalInversionistas.ts (archivo nuevo)

- Hook con React Query (useQuery) que gestiona loading, error y cache del reporte, con staleTime de 5 minutos y enabled controlado externamente para no disparar la consulta hasta que el usuario presione "Generar Reporte"

src/private/cartera/components/CapitalInversionistas.tsx (archivo nuevo)

- Componente principal del reporte con:
  - Filtros de fecha — componente DatePickerField reutilizable que combina:
    - Input de texto con auto-formato a YYYY-MM-DD al escribir (solo permite dígitos, inserta guiones automáticamente)
    - Botón de calendario que abre un Popover con el componente Calendar de shadcn/react-day-picker
    - Fondo blanco explícito en PopoverContent para evitar transparencia

  - Botón Generar Reporte que aplica los filtros y dispara la consulta
  - Botón Exportar Excel que llama al endpoint con excel=true y abre la URL de descarga
  - Vista desktop — tabla con header fijo fuera del scroll:
  - Vista mobile (< md) — lista de tarjetas responsivas donde cada inversionista ocupa una card con grid de 2 columnas mostrando capital, tasa, modalidad, fecha y comentario

  - Corrección de zona horaria en el formateo de fechas: se parsean directamente las partes del string (YYYY-MM-DD) sin pasar por new Date(), evitando el desfase UTC-6 que mostraba fechas un día antes

src/private/cartera/components/dashBoard.tsx
- Se agregó la opción "Capital Inversionistas" en la sección Reportes del menú de navegación, con ícono TrendingUp, ruta /capital-inversionistas y acceso restringido a rol ADMIN

src/App.tsx
- Se registró la ruta capital-inversionistas como RoleRoute con allowedRoles: ["ADMIN"]


REPORTE EXCEL:
<img width="1008" height="698" alt="Captura de pantalla 2026-06-04 165201" src="https://github.com/user-attachments/assets/3a2fe3fb-3257-4007-9927-4643c02c8f03" />
<img width="1028" height="401" alt="Captura de pantalla 2026-06-04 165245" src="https://github.com/user-attachments/assets/1b40f59c-4a99-49fb-97de-beeca4dd5381" />

/capital-inversionistas/
<img width="1328" height="833" alt="Captura de pantalla 2026-06-04 165348" src="https://github.com/user-attachments/assets/dc8c3802-68aa-4091-975d-66687205dbb6" />

