### PR TITLE
fix(cartera): datar compras por fecha_completada en el filtro de mes

### DIFF
--- a/apps/cartera-back/src/utils/comprasAjuste.ts
+++ b/apps/cartera-back/src/utils/comprasAjuste.ts
@@ -1,7 +1,19 @@
 import { db } from "../database/index";
 import { compras_credito_inversionista } from "../database/db/schema";
-import { and, eq, desc, gte, inArray, lt } from "drizzle-orm";
+import { and, eq, desc, gte, inArray, lt, sql } from "drizzle-orm";
 import Big from "big.js";
+
+/**
+ * Fecha con la que se data económicamente una compra para decidir a qué mes
+ * pertenece: se prioriza `fecha_completada` (instante real en que la compra
+ * pasó a "completado") y, si está NULL (columna nueva, registros viejos que
+ * aún no la tienen), cae a `updated_at`.
+ *
+ * Importante: NO usar `updated_at` solo, porque otros procesos lo pisan
+ * (p. ej. el cierre de facturación en cofidi setea updated_at = fecha del pago
+ * del cliente), lo que re-clasificaría la compra a un mes equivocado.
+ */
+const fechaEfectivaCompra = sql`COALESCE(${compras_credito_inversionista.fecha_completada}, ${compras_credito_inversionista.updated_at})`;
 
 export interface AjusteCompras {
   /** Restar del espejo antes de comparar con histórico (compras post-historico). */
@@ -31,6 +43,7 @@ export async function calcularAjusteCompras(
     .select({
       monto_aportado: compras_credito_inversionista.monto_aportado,
       status: compras_credito_inversionista.status,
+      fecha_completada: compras_credito_inversionista.fecha_completada,
       updated_at: compras_credito_inversionista.updated_at,
       created_at: compras_credito_inversionista.created_at,
     })
@@ -68,11 +81,18 @@ export async function calcularAjusteCompras(
     if (esPendiente) {
       // Caso 2: pendiente → restar de cálculo
       montoRestarCalculo = montoRestarCalculo.plus(montoCompra);
-    } else if (compra.status === "completado" && compra.updated_at) {
-      const updatedAt = new Date(compra.updated_at);
+    } else if (
+      compra.status === "completado" &&
+      (compra.fecha_completada || compra.updated_at)
+    ) {
+      // Datar por fecha_completada y caer a updated_at solo si está NULL.
+      const fechaEfectiva = new Date(
+        (compra.fecha_completada ?? compra.updated_at) as Date,
+      );
       const esDelPeriodoODespues =
-        updatedAt.getFullYear() > periodoAnio ||
-        (updatedAt.getFullYear() === periodoAnio && updatedAt.getMonth() >= periodoMes);
+        fechaEfectiva.getFullYear() > periodoAnio ||
+        (fechaEfectiva.getFullYear() === periodoAnio &&
+          fechaEfectiva.getMonth() >= periodoMes);
 
       if (esDelPeriodoODespues) {
         // Caso 3: completada en el período o después → restar de cálculo
@@ -117,8 +137,8 @@ export async function obtenerSumaComprasMesAnterior(
         eq(compras_credito_inversionista.inversionista_id, inversionista_id),
         eq(compras_credito_inversionista.tipo_operacion, "compra_cartera"),
         eq(compras_credito_inversionista.status, "completado"),
-        gte(compras_credito_inversionista.updated_at, inicioMesAnterior),
-        lt(compras_credito_inversionista.updated_at, inicioMesActual),
+        gte(fechaEfectivaCompra, inicioMesAnterior),
+        lt(fechaEfectivaCompra, inicioMesActual),
       ),
     );
 
@@ -161,8 +181,8 @@ export async function obtenerSumaComprasCompletadasMesActual(
         eq(compras_credito_inversionista.inversionista_id, inversionista_id),
         eq(compras_credito_inversionista.tipo_operacion, "compra_cartera"),
         eq(compras_credito_inversionista.status, "completado"),
-        gte(compras_credito_inversionista.updated_at, inicioMesActual),
-        lt(compras_credito_inversionista.updated_at, inicioMesSiguiente),
+        gte(fechaEfectivaCompra, inicioMesActual),
+        lt(fechaEfectivaCompra, inicioMesSiguiente),
       ),
     );
 


### PR DESCRIPTION
## Qué pasaba

El cálculo de pagos del espejo decide a **qué mes pertenece una compra de cartera** mirando una fecha. Hasta ahora usaba `updated_at`.

El problema: **`updated_at` lo pisan otros procesos**. En particular, el cierre de facturación (`cofidi.ts:1549`) hace `set({ pendiente_facturar: false, updated_at: new Date() })` cuando el cliente paga y se cierra el ciclo — o sea le mete la **fecha del pago**, no la de la compra.

Caso real de pruebas: una compra **completada el 19 de mayo** quedó con `updated_at = 1 de junio` (el día que cerró la facturación). Como las ventanas de mes son `[inicio, inicioSiguiente)` con tope exclusivo, esa compra se contó como de **junio**, no de mayo.

Consecuencia: el gate de "participación del período" (`payments.ts:2583`) no encontró una compra del mes que respaldara el **monto viejo**, lo confundió con un **alta nueva directa** y **botó el crédito entero** (`return null`) → **no se generó ningún pago** (ni el completo ni el proporcional; el proporcional ni siquiera se alcanza porque está después del gate).

## El fix

Datar la compra por **`COALESCE(fecha_completada, updated_at)`**:
- se prioriza `fecha_completada` (instante real en que la compra pasó a `completado`),
- y solo cae a `updated_at` si `fecha_completada` está **NULL** (es una columna nueva; registros viejos pueden no tenerla todavía — habrá un update masivo para rellenarla).

Así una compra completada en mayo se queda en mayo aunque la facturación corra después.

## Archivos / funciones afectadas (`utils/comprasAjuste.ts`)

- `obtenerSumaComprasMesAnterior`
- `obtenerSumaComprasCompletadasMesActual`
- `calcularAjusteCompras` (Caso 3: completadas del período o después)

`cofidi` se deja **intacto** a propósito (sigue pisando `updated_at`; ya no importa porque dejamos de datar por ese campo).

## Pruebas

`bun test src/controllers/payments.test.ts` → **7 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)