### PR TITLE
Add filter clearing and usePersistedState for date filters

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
@@ -107,7 +107,7 @@ export function CapitalInversionistas() {
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
 
-  const hasActiveFilters = fechaDesde !== "" || fechaHasta !== "" || appliedDesde !== "" || appliedHasta !== "";
+  const hasActiveFilters = fechaDesde !== "" || fechaHasta !== "" || appliedDesde !== "" || appliedHasta !== "" || queryEnabled;
 
   const clearFilters = () => {
     setFechaDesde("");
@@ -115,6 +115,7 @@ export function CapitalInversionistas() {
     setAppliedDesde("");
     setAppliedHasta("");
     setQueryEnabled(false);
+    setExportError(null);
   };
 
   const { data, isLoading, isError } = useCapitalInversionistas(
@@ -207,7 +208,7 @@ export function CapitalInversionistas() {
                   className="flex-1 sm:flex-none text-gray-600 border-gray-300 hover:bg-gray-100"
                 >
                   <X className="h-4 w-4 mr-2" />
-                  Limpiar filtros
+                  Limpiar
                   <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
                     {[fechaDesde !== "" || appliedDesde !== "", fechaHasta !== "" || appliedHasta !== ""].filter(Boolean).length}
                   </Badge>

--- a/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
@@ -122,7 +122,7 @@ export function CapitalInversionistas() {
     queryEnabled
   );
 
-  const rows: CapitalInversionistaItem[] = data?.data ?? [];
+  const rows: CapitalInversionistaItem[] = queryEnabled ? (data?.data ?? []) : [];
 
   const totalCapital = rows.reduce((acc, r) => acc + Number(r.capital ?? 0), 0);
 

--- a/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CapitalInversionistas.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
+import { usePersistedState } from "../hooks/usePersistedState";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { CalendarIcon, Download, Loader2, Search } from "lucide-react";
+import { CalendarIcon, Download, Loader2, Search, X } from "lucide-react";
 import {
   TableBody,
   TableCell,
@@ -97,13 +99,23 @@ function DatePickerField({
 }
 
 export function CapitalInversionistas() {
-  const [fechaDesde, setFechaDesde] = useState("");
-  const [fechaHasta, setFechaHasta] = useState("");
-  const [queryEnabled, setQueryEnabled] = useState(false);
-  const [appliedDesde, setAppliedDesde] = useState("");
-  const [appliedHasta, setAppliedHasta] = useState("");
+  const [fechaDesde, setFechaDesde] = usePersistedState<string>("cartera/capitalInversionistas/fechaDesde", "");
+  const [fechaHasta, setFechaHasta] = usePersistedState<string>("cartera/capitalInversionistas/fechaHasta", "");
+  const [queryEnabled, setQueryEnabled] = usePersistedState<boolean>("cartera/capitalInversionistas/queryEnabled", false);
+  const [appliedDesde, setAppliedDesde] = usePersistedState<string>("cartera/capitalInversionistas/appliedDesde", "");
+  const [appliedHasta, setAppliedHasta] = usePersistedState<string>("cartera/capitalInversionistas/appliedHasta", "");
   const [isExporting, setIsExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
+
+  const hasActiveFilters = fechaDesde !== "" || fechaHasta !== "" || appliedDesde !== "" || appliedHasta !== "";
+
+  const clearFilters = () => {
+    setFechaDesde("");
+    setFechaHasta("");
+    setAppliedDesde("");
+    setAppliedHasta("");
+    setQueryEnabled(false);
+  };
 
   const { data, isLoading, isError } = useCapitalInversionistas(
     { fecha_desde: appliedDesde || undefined, fecha_hasta: appliedHasta || undefined },
@@ -188,6 +200,19 @@ export function CapitalInversionistas() {
                 )}
                 Exportar Excel
               </Button>
+              {hasActiveFilters && (
+                <Button
+                  variant="outline"
+                  onClick={clearFilters}
+                  className="flex-1 sm:flex-none text-gray-600 border-gray-300 hover:bg-gray-100"
+                >
+                  <X className="h-4 w-4 mr-2" />
+                  Limpiar filtros
+                  <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
+                    {[fechaDesde !== "" || appliedDesde !== "", fechaHasta !== "" || appliedHasta !== ""].filter(Boolean).length}
+                  </Badge>
+                </Button>
+              )}
             </div>
           </div>
           {exportError && (


### PR DESCRIPTION
Persistencia de filtros y botón "Limpiar filtros" en CapitalInversionistas

  - Se migraron los estados fechaDesde, fechaHasta, appliedDesde, appliedHasta y queryEnabled de useState a usePersistedState, de modo que las fechas ingresadas y el reporte generado se conservan al navegar entre secciones y regresar a la página.
 
  - Se agregó un botón "Limpiar filtros" condicional que aparece cuando hay alguna fecha activa (ya sea en los inputs o aplicada al reporte), muestra un Badge con el conteo de campos activos (1 o 2), y al hacer click resetea todos los filtros y oculta el reporte (queryEnabled = false).