### PR TITLE
fix(cartera): eliminar doble descuento de ISR en interés neto reinvertido

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1573,14 +1573,14 @@ export async function resumeInvestor(
               const pagoNetoReal = abono_capital.plus(netIntParaMiso);
               total_cuota_sin_reinversion = total_cuota_sin_reinversion.plus(pagoNetoReal);
 
-              // 🔑 Reinversión Neta (Interés - ISR proporcional)
-              const isrReinv = inv.emite_factura ? new Big(0) : reinvInteres.times(0.07);
-              const totalReinvNeta = reinvCapital.plus(reinvInteres).minus(isrReinv);
-              const netReinvInt = reinvInteres.minus(isrReinv);
+              // 🔑 Reinversión Neta: `reinvInteres` YA viene neto (NO factura: int - isr;
+              // factura: int + iva), igual que en getInvestorTotalsGlobales. No re-aplicar
+              // el 7% de ISR aquí (causaba doble descuento: 483.47 → 449.63).
+              const totalReinvNeta = reinvCapital.plus(reinvInteres);
 
               total_reinversion_neta_global = total_reinversion_neta_global.plus(totalReinvNeta);
               total_reinversion_capital = total_reinversion_capital.plus(reinvCapital);
-              total_reinversion_interes = total_reinversion_interes.plus(netReinvInt);
+              total_reinversion_interes = total_reinversion_interes.plus(reinvInteres);
 
               if (reinversionActual === "reinversion_capital") total_reinv_tipo_capital = total_reinv_tipo_capital.plus(totalReinvNeta);
               else if (reinversionActual === "reinversion_interes") total_reinv_tipo_interes = total_reinv_tipo_interes.plus(totalReinvNeta);

--- a/apps/cartera-back/src/utils/functions/generalFunctions.ts
+++ b/apps/cartera-back/src/utils/functions/generalFunctions.ts
@@ -1066,16 +1066,12 @@ export async function buildInversionistaWorkbook(
           reinvCap_cap = reinvCap_cap.plus(cap);
         } else if (tipo === "reinversion_total") {
           reinvTot_cap = reinvTot_cap.plus(cap);
-          
-          const isrReinv = inv.emite_factura ? new Big(0) : abonoGeneralInteres.times(0.07);
-          const netInteresForReinv = abonoGeneralInteres.minus(isrReinv);
-          
-          reinvTot_int = reinvTot_int.plus(netInteresForReinv);
+          // `abonoGeneralInteres` YA es el interés neto (NO factura: int - isr; factura: int + iva).
+          // No re-aplicar el 7% de ISR aquí: causaba doble descuento (483.47 → 449.63).
+          reinvTot_int = reinvTot_int.plus(abonoGeneralInteres);
         } else if (tipo === "reinversion_interes") {
-          const isrReinv = inv.emite_factura ? new Big(0) : abonoGeneralInteres.times(0.07);
-          const netInteresForReinv = abonoGeneralInteres.minus(isrReinv);
-          
-          reinvInt_int = reinvInt_int.plus(netInteresForReinv);
+          // `abonoGeneralInteres` YA es el interés neto; no re-descontar ISR.
+          reinvInt_int = reinvInt_int.plus(abonoGeneralInteres);
         }
       }
     }


### PR DESCRIPTION
## Problema

En el reporte de liquidación, la sección **Totales de Reinversión** mostraba un valor incorrecto en **"Interés Compuesto (Interés Neto)"**.

Ejemplo real (inversionista que no emite factura):
- Tabla → `% Inv. Interés Neto` = **Q483.47** (correcto: `519.86 − 36.39` de ISR)
- Celda "Interés Compuesto (Interés Neto)" = **Q449.63** ❌
- `Total Reinversión` = Q1,265.24 → sí usa el 483.47 correcto (`284.40 + 497.37 + 483.47`)

Causa: **doble descuento de ISR**. `abonoGeneralInteres` / `interesTotal` ya vienen netos (no factura: `int − isr`; factura: `int + iva`), pero el código volvía a aplicar `.times(0.07)` sobre ese valor ya neto: `483.47 × 0.07 = 33.84` → `449.63`.

## Cambios

- **`generalFunctions.ts`** (celda del reporte): usa `abonoGeneralInteres` directo en `reinversion_total` / `reinversion_interes`.
- **`resumeInvestor` (`investor.ts`)**: mismo fix en `total_reinversion*` y `total_reinv_tipo_*`, dejándolos consistentes con `getInvestorTotalsGlobales`.

## Alcance / riesgo

- **La reinversión real NO estaba afectada.** Ya tomaba `total_reinv_tipo_*` de `getInvestorTotalsGlobales` (que descuenta ISR una sola vez). El dinero se reinvirtió bien; el bug era **solo visual** en el reporte.
- En el flujo de `liquidateByInvestorId`, el `subtotal` de `resumeInvestor` se sobrescribe con `getInvestorTotalsGlobales`, así que el fix #2 corrige principalmente los **demás consumidores** de `resumeInvestor` (endpoints de la API y `ajustarPagosLiquidacion`).

## Pendiente (no incluido)

`getInvestorMirrorSummary:3443` tiene el **mismo patrón de doble ISR** ("Fuente de Verdad"). Se dejó fuera de este PR a la espera de confirmación.

## Efecto esperado

Celda "Interés Compuesto (Interés Neto)": **449.63 → 483.47**, cuadrando con la tabla y el total (`284.40 + 497.37 + 483.47 = 1,265.24`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)