### PR TITLE
feat: add filtering for overdue unpaid installments in getCreditCandi…

### DIFF
--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -260,6 +260,26 @@ export async function getCreditCandidates(
   console.log(`   Créditos descartados por compra pendiente de facturar: ${pendienteFacturarSet.size}`);
 
   // ──────────────────────────────────────────────────────────
+  // 2.6 Filtrar: cuotas vencidas sin pagar (moroso de facto)
+  //    Captura créditos cuyo statusCredit aún no fue actualizado a MOROSO
+  //    pero ya tienen cuotas con fecha_vencimiento < hoy y pagado = false
+  // ──────────────────────────────────────────────────────────
+  const cuotasVencidasRaw = await db
+    .selectDistinct({ credito_id: cuotas_credito.credito_id })
+    .from(cuotas_credito)
+    .where(
+      and(
+        inArray(cuotas_credito.credito_id, creditoIds),
+        gt(cuotas_credito.numero_cuota, 0),
+        eq(cuotas_credito.pagado, false),
+        lt(cuotas_credito.fecha_vencimiento, sql`CURRENT_DATE`)
+      )
+    );
+
+  const cuotasVencidasSet = new Set(cuotasVencidasRaw.map((r) => r.credito_id));
+  console.log(`   Créditos descartados por cuotas vencidas sin pagar: ${cuotasVencidasSet.size}`);
+
+  // ──────────────────────────────────────────────────────────
   // 3. Filtrar: espejo debe estar en 'completado'
   //    Significa que el ciclo anterior terminó y el capital está disponible
   //    para reinversión. Si tiene pendiente_* ya hay un proceso en curso.
@@ -455,6 +475,14 @@ export async function getCreditCandidates(
     if (pendienteFacturarSet.has(credito_id)) {
       console.log(
         `   ❌ [${numero_credito_sifco}] Descartado: tiene compra pendiente de facturar`
+      );
+      continue;
+    }
+
+    // Filtro: cuotas vencidas sin pagar (moroso de facto aunque statusCredit siga ACTIVO)
+    if (cuotasVencidasSet.has(credito_id)) {
+      console.log(
+        `   ❌ [${numero_credito_sifco}] Descartado: tiene cuotas vencidas sin pagar`
       );
       continue;
     }


### PR DESCRIPTION
Cambios en getCreditCandidates — assignCapital.ts
Se agregaron 3 nuevos filtros de descarte al motor de selección de créditos candidatos para asignación de capital:

Filtro 2.5 — Compra pendiente de facturar
Problema: Un crédito podía ser seleccionado como candidato aunque ya tuviera una operación de compra/reinversión registrada en compras_credito_inversionista que aún no había sido facturada (pendiente_facturar = true). Esto significaba que el crédito ya estaba comprometido en un proceso activo.

Solución: Se consulta compras_credito_inversionista buscando cualquier registro del crédito con pendiente_facturar = true. Si existe, el crédito se descarta antes de continuar evaluación.

Filtro 2.6 — Cuotas vencidas sin pagar (moroso de facto)
Problema identificado en investigación: Los créditos de Harlie Velásquez (338) y Hector Hernandez (507) fueron asignados al inversionista Rafael Figueroa en mayo 2026 aunque ambos llevaban cuotas sin pagar desde febrero de ese mismo año. El sistema los aceptó porque su statusCredit todavía decía ACTIVO — nadie lo había actualizado a MOROSO antes de la asignación. El filtro de pagos inválidos tampoco los atrapó porque no había intentos de pago registrados, solo cuotas vacías.

Solución: Se consulta cuotas_credito buscando cuotas con numero_cuota > 0, pagado = false, y fecha_vencimiento < CURRENT_DATE. Si el crédito tiene al menos una cuota así, se descarta. Se usa CURRENT_DATE (no NOW()) para comparación de tipo date puro y evitar desfases por zona horaria.

Este filtro actúa como red de seguridad independiente del campo statusCredit, capturando morosos de facto aunque el campo no haya sido actualizado manualmente.

Patrón de implementación (igual en los 3 filtros)

query → selectDistinct(credito_id) con condición → Set<number> → lookup O(1) en el loop