### PR TITLE
feat(docuseal): agregar categoría inversiones_sociedad

### DIFF
--- a/apps/backend-2/src/controllers/docuseal.ts
+++ b/apps/backend-2/src/controllers/docuseal.ts
@@ -18,7 +18,7 @@ function formatDocumentName(name: string): string {
     .join(" ");
 }
 
-export type DocumentCategoria = "ventas" | "inversiones" | "carta_poder";
+export type DocumentCategoria = "ventas" | "inversiones" | "inversiones_sociedad" | "carta_poder";
 
 /**
  * 🎯 Controller: Fetch unique document names with both enum and formatted label.

--- a/apps/backend-2/src/database/schemas/docuseal.ts
+++ b/apps/backend-2/src/database/schemas/docuseal.ts
@@ -7,6 +7,7 @@ export const docusealSchema = pgSchema("docuseal");
 export const documentCategoriaEnum = docusealSchema.enum("document_categoria_enum", [
   "ventas",
   "inversiones",
+  "inversiones_sociedad",
   "carta_poder"
 ]);
 

--- a/apps/backend-2/src/routers/docuSeal.ts
+++ b/apps/backend-2/src/routers/docuSeal.ts
@@ -815,6 +815,7 @@ const docuSealRouter = new Elysia({
           t.Union([
             t.Literal("ventas"),
             t.Literal("inversiones"),
+            t.Literal("inversiones_sociedad"),
             t.Literal("carta_poder"),
           ])
         ),

--- a/apps/legal-documents/src/feature/generateDocument/components/StepCategory.tsx
+++ b/apps/legal-documents/src/feature/generateDocument/components/StepCategory.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Briefcase, TrendingUp, FileSignature, CheckCircle } from "lucide-react";
+import { Briefcase, TrendingUp, Building2, FileSignature, CheckCircle } from "lucide-react";
 import type { DocumentCategoria } from "@/services/documents";
 
 interface StepCategoryProps {
@@ -19,19 +19,25 @@ const CATEGORIES: ReadonlyArray<{
   {
     value: "ventas",
     label: "Ventas",
-    description: "Documentos relacionados con la venta y financiamiento de vehículos",
+    description: "Contratos de compraventa y financiamiento de vehículos",
     icon: Briefcase,
   },
   {
     value: "inversiones",
     label: "Inversiones",
-    description: "Documentos para inversionistas: acuerdos, anexos, cesiones y contratos",
+    description: "Acuerdos, anexos, cesiones y contratos para inversionistas",
     icon: TrendingUp,
+  },
+  {
+    value: "inversiones_sociedad",
+    label: "Inversiones Sociedad",
+    description: "Contratos y acuerdos de inversión bajo figura de sociedad",
+    icon: Building2,
   },
   {
     value: "carta_poder",
     label: "Carta Poder",
-    description: "Documentos de representación y carta poder",
+    description: "Documentos de representación y poderes de mandato",
     icon: FileSignature,
   },
 ];
@@ -45,7 +51,7 @@ export function StepCategory({ data, onChange }: StepCategoryProps) {
         Selecciona la categoría del documento que deseas generar.
       </p>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
         {CATEGORIES.map((cat) => {
           const isSelected = selected === cat.value;
           const Icon = cat.icon;

--- a/apps/legal-documents/src/services/documents.ts
+++ b/apps/legal-documents/src/services/documents.ts
@@ -3,7 +3,7 @@ import { fetchWithRetry } from './fetchWithRetry';
 import { ValidationError, ServerError } from './errors';
 
 // Types
-export type DocumentCategoria = "ventas" | "inversiones" | "carta_poder"
+export type DocumentCategoria = "ventas" | "inversiones" | "inversiones_sociedad" | "carta_poder"
 
 export interface DocumentType {
   enum: string


### PR DESCRIPTION
## Resumen

Agrega la nueva categoría de documentos **`inversiones_sociedad`** en el flujo de generación de documentos (DocuSeal).

## Cambios

### Frontend — `apps/legal-documents`
- Nueva tarjeta de categoría **"Inversiones Sociedad"** en `StepCategory` (ícono `Building2`).
- Descripciones de todas las categorías corregidas/pulidas para que sean consistentes.
- Grid de categorías ajustado de `md:grid-cols-3` → `md:grid-cols-2 lg:grid-cols-4` para acomodar 4 tarjetas.
- `DocumentCategoria` incluye `inversiones_sociedad`.

### Backend — `apps/backend-2`
- **Fix del error 422**: el `t.Union` de validación del query `categoria` en `GET /docuSeal/documents` ahora acepta `inversiones_sociedad`.
- `documentCategoriaEnum` (Drizzle) y el type `DocumentCategoria` actualizados.

## Pendientes fuera de este PR
- [ ] **DB**: `ALTER TYPE docuseal.document_categoria_enum ADD VALUE 'inversiones_sociedad'` + INSERT de los 18 documentos (9 tipos × hombre/mujer). Las corre el equipo de DB.
- [ ] Reemplazar `id_docuseal` / `serialid` / `url_insercion` placeholder por los valores reales de las plantillas de DocuSeal.
- [ ] Deploy de backend-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
