### PR TITLE
fix: resolve cartera type errors

### DIFF
--- a/apps/cartera-back/src/controllers/cierreMensual.ts
+++ b/apps/cartera-back/src/controllers/cierreMensual.ts
@@ -89,7 +89,6 @@ export async function generarCierreMensual(periodoOverride?: string) {
         cantidad_creditos: 0,
         capital_total: new Big(0),
         creditos_con_mora: new Set<number>(),
-        cuotas_atrasadas: 0,
         capital_en_mora: new Big(0),
       };
     }

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -17,6 +17,7 @@ import {
   moras_credito,
   pagos_credito,
   platform_users,
+  StatusCredit,
   usuarios,
 } from "../database/db/schema";
 import { z } from "zod";
@@ -611,7 +612,7 @@ export async function getCreditosWithUserByMesAnio(
   numeros_credito_sifco?: string[],
   capital_min?: number,
   capital_max?: number,
-  estados_credito?: string[]
+  estados_credito?: StatusCredit[]
 ): Promise<{
   data: CreditoConInfo[];
   page: number;

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -30,8 +30,10 @@ import {
   shouldMarkInstallmentPaymentPaid,
 } from "./registerPaymentPolicy";
 
-// Tipo de conexión del pool (pg no expone tipos; lo derivamos de client.connect)
-type PoolConn = Awaited<ReturnType<typeof client.connect>>;
+type LockConn = {
+  query: (text: string, values?: unknown[]) => Promise<unknown>;
+  release: () => void;
+};
 
 // Namespace para advisory locks de pagos (evita colisión con otros locks).
 // pg_advisory_lock(ns, credito_id) serializa pagos concurrentes del mismo crédito.
@@ -501,7 +503,7 @@ const insertarBoletas = async (pago_id: number, urlCompletas: string[]) => {
 
 export const insertPayment = async ({ body, set }: any) => {
   // 🔒 Conexión dedicada para el advisory lock (se libera en finally).
-  let lockConn: PoolConn | undefined;
+  let lockConn: LockConn | undefined;
   let lockedCreditoId: number | undefined;
   try {
     // 1. Validar schema

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -80,6 +80,20 @@ const RouterBodySchema = z.object({
   otros: z.number().optional(),
   cuotas_atrasadas: z.number().int().min(0).optional(),
 });
+
+const STATUS_CREDIT_VALUES = new Set<string>(Object.values(StatusCredit));
+
+const isStatusCredit = (value: string): value is StatusCredit =>
+  STATUS_CREDIT_VALUES.has(value);
+
+const parseStatusCreditList = (values: string[] | undefined) => {
+  if (!values) return undefined;
+  const invalid = values.find((value) => !isStatusCredit(value));
+  if (invalid) {
+    return { invalid };
+  }
+  return { values: values.filter(isStatusCredit) };
+};
 export const creditRouter = new Elysia()
  
 .use(authMiddleware)
@@ -252,6 +266,7 @@ export const creditRouter = new Elysia()
         .map((s) => s.trim())
         .filter((s) => s.length > 0)
     : undefined;
+  const estadosCreditoParsed = parseStatusCreditList(estadosCreditoArray);
 
   if (capitalMinParam !== undefined && isNaN(capitalMinParam)) {
     set.status = 400;
@@ -260,6 +275,10 @@ export const creditRouter = new Elysia()
   if (capitalMaxParam !== undefined && isNaN(capitalMaxParam)) {
     set.status = 400;
     return { message: "Parámetro 'capital_max' debe ser un número válido." };
+  }
+  if (estadosCreditoParsed && "invalid" in estadosCreditoParsed) {
+    set.status = 400;
+    return { message: `Estado de crédito inválido: ${estadosCreditoParsed.invalid}` };
   }
 
   // Llamar servicio
@@ -306,7 +325,7 @@ export const creditRouter = new Elysia()
         numerosCreditoSifcoArray,
         capitalMinParam,
         capitalMaxParam,
-        estadosCreditoArray as StatusCredit[] | undefined
+        estadosCreditoParsed?.values
       );
       set.status = 200;
       return result;
@@ -367,6 +386,11 @@ export const creditRouter = new Elysia()
       const estadosCreditoLimpios = (estados_credito as string[] | undefined)
         ?.map((s: string) => s.trim())
         .filter((s: string) => s.length > 0);
+      const estadosCreditoParsed = parseStatusCreditList(estadosCreditoLimpios);
+      if (estadosCreditoParsed && "invalid" in estadosCreditoParsed) {
+        set.status = 400;
+        return { message: `Estado de crédito inválido: ${estadosCreditoParsed.invalid}` };
+      }
 
       try {
         if (excel) {
@@ -410,7 +434,7 @@ export const creditRouter = new Elysia()
           sifcosLimpios,
           capital_min,
           capital_max,
-          estadosCreditoLimpios as StatusCredit[] | undefined
+          estadosCreditoParsed?.values
         );
         set.status = 200;
         return result;

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -44,6 +44,7 @@ import { updateDueDates, updateSingleDueDate, fixCreditosWithoutFebruary, update
 import { creditos, cuotas_credito } from "../database/db";
 import { and, desc, eq } from "drizzle-orm";
 import { db } from "../database"; 
+import { StatusCredit } from "../database/db/schema";
 
 const MontoAdicionalSchema = z.object({
   concepto: z.string().min(1, "concepto requerido"),
@@ -305,7 +306,7 @@ export const creditRouter = new Elysia()
         numerosCreditoSifcoArray,
         capitalMinParam,
         capitalMaxParam,
-        estadosCreditoArray
+        estadosCreditoArray as StatusCredit[] | undefined
       );
       set.status = 200;
       return result;
@@ -409,7 +410,7 @@ export const creditRouter = new Elysia()
           sifcosLimpios,
           capital_min,
           capital_max,
-          estadosCreditoLimpios
+          estadosCreditoLimpios as StatusCredit[] | undefined
         );
         set.status = 200;
         return result;


### PR DESCRIPTION
## Summary
- remove stale cierre mensual accumulator field
- type estados_credito as StatusCredit and validate GET/POST filters before controller calls
- use a structural lock connection type for advisory lock cleanup

## Verification
- bunx tsc --noEmit
- bun test src/controllers/registerPayment.test.ts src/controllers/latefee.test.ts src/controllers/reports.test.ts