### PR TITLE
fix: keep mora-only payments out of installment totals

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -5,6 +5,7 @@ import {
   getCuotaIdForPaymentInsert,
   getRequestedInstallmentFloor,
   getSpecialPaymentCuotaId,
+  getSpecialPaymentInstallmentFields,
   shouldApplyStaleZeroRestanteAdjustment,
   shouldMarkInstallmentPaymentPaid,
 } from "./registerPaymentPolicy";
@@ -102,6 +103,13 @@ describe("register payment", () => {
         ],
       })
     ).toBe(100);
+  });
+
+  it("no cuenta pagos solo mora u otros como abono a cuota", () => {
+    expect(getSpecialPaymentInstallmentFields()).toEqual({
+      montoAplicado: 0,
+      pagado: false,
+    });
   });
 });
 

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -105,10 +105,10 @@ describe("register payment", () => {
     ).toBe(100);
   });
 
-  it("no cuenta pagos solo mora u otros como abono a cuota", () => {
+  it("no cuenta pagos solo mora u otros como abono a cuota pero conserva el pago liquidado", () => {
     expect(getSpecialPaymentInstallmentFields()).toEqual({
       montoAplicado: 0,
-      pagado: false,
+      pagado: true,
     });
   });
 });

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -25,6 +25,7 @@ import {
   calcularSaldoNetoCuota,
   getCuotaIdForPaymentInsert,
   getRequestedInstallmentFloor,
+  getSpecialPaymentInstallmentFields,
   getSpecialPaymentCuotaId,
   shouldApplyStaleZeroRestanteAdjustment,
   shouldMarkInstallmentPaymentPaid,
@@ -604,6 +605,7 @@ export const insertPayment = async ({ body, set }: any) => {
         cuotaId: cuota.cuotas_credito.cuota_id,
       })),
     });
+    const pagoEspecialCuota = getSpecialPaymentInstallmentFields();
 
     // 3. Preparar creditoInfo con las variables destructuradas
     const creditoInfo = {
@@ -630,12 +632,12 @@ export const insertPayment = async ({ body, set }: any) => {
         mora: 0,
         boleta: montoBoleta.toNumber(),
         urlBoletas: urlCompletas ?? [],
-        pagado: true,
+        pagado: pagoEspecialCuota.pagado,
         banco_id: banco_id ?? 0,
         numeroAutorizacion: numeroAutorizacion ?? "",
         registerBy: registerBy ?? "",
         fecha_boleta,
-        monto_aplicado: otrosBig.toNumber(),
+        monto_aplicado: pagoEspecialCuota.montoAplicado,
       });
     }
 
@@ -713,12 +715,12 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
             mora: resultadoMora.montoAplicadoMora,
             boleta: montoBoleta.toNumber(),
             urlBoletas: urlCompletas ?? [],
-            pagado: true,
+            pagado: pagoEspecialCuota.pagado,
             banco_id: banco_id ?? 0,
             numeroAutorizacion: numeroAutorizacion ?? "",
             registerBy: registerBy ?? "",
             fecha_boleta,
-            monto_aplicado: otrosBig.plus(resultadoMora.montoAplicadoMora).toNumber(),
+            monto_aplicado: pagoEspecialCuota.montoAplicado,
           });
         }
         console.log(
@@ -735,12 +737,12 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
             mora: resultadoMora.montoAplicadoMora,
             boleta: montoBoleta.toNumber(),
             urlBoletas: urlCompletas ?? [],
-            pagado: true,
+            pagado: pagoEspecialCuota.pagado,
             banco_id: banco_id ?? 0,
             numeroAutorizacion: numeroAutorizacion ?? "",
             registerBy: registerBy ?? "",
             fecha_boleta,
-            monto_aplicado: otrosBig.plus(resultadoMora.montoAplicadoMora).toNumber(),
+            monto_aplicado: pagoEspecialCuota.montoAplicado,
           });
         }
         return {
@@ -761,12 +763,12 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           mora: resultadoMora.montoAplicadoMora,
           boleta: montoBoleta.toNumber(),
           urlBoletas: urlCompletas ?? [],
-          pagado: true,
+          pagado: pagoEspecialCuota.pagado,
           banco_id: banco_id ?? 0,
           numeroAutorizacion: numeroAutorizacion ?? "",
           registerBy: registerBy ?? "",
           fecha_boleta,
-          monto_aplicado: otrosBig.plus(resultadoMora.montoAplicadoMora).toNumber(),
+          monto_aplicado: pagoEspecialCuota.montoAplicado,
         });
       }
       return {

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -61,6 +61,12 @@ export const getSpecialPaymentCuotaId = ({
   )?.cuotaId ??
   pendingInstallments[0]?.cuotaId ??
   0;
+
+export const getSpecialPaymentInstallmentFields = () => ({
+  montoAplicado: 0,
+  pagado: false,
+});
+
 export type SaldoCuotaInput = {
   /** Monto total de la cuota (credito.cuota). */
   montoCuota: BigInput;

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -64,7 +64,7 @@ export const getSpecialPaymentCuotaId = ({
 
 export const getSpecialPaymentInstallmentFields = () => ({
   montoAplicado: 0,
-  pagado: false,
+  pagado: true,
 });
 
 export type SaldoCuotaInput = {


### PR DESCRIPTION
## Summary
- keep mora/otros-only special payment rows from contributing to cuota totals by setting monto_aplicado=0
- keep those special rows marked as settled with pagado=true so close/reset flows do not void their mora/otros history
- add regression coverage for special payment installment fields

## Context
Incident credit 01010202108250 had a Q700 mora-only payment counted as cuota interest because special rows used monto_aplicado = mora/otros. Later processes sum monto_aplicado by cuota_id, so non-installment amounts can close or advance installments incorrectly.

## Verification
- bun test src/controllers/registerPayment.test.ts src/controllers/latefee.test.ts src/controllers/reports.test.ts