### PR TITLE
Feat(cartera): spelling and update placeholders in Cartera components, no crédito sifco etc.

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -346,7 +346,7 @@ export function ListaCreditosPagos() {
             ref={inputRef}
             className="border border-blue-200 rounded-lg px-3 py-2 bg-blue-50 text-blue-800 focus:ring-2 focus:ring-blue-400 w-full"
             type="text"
-            placeholder="# Crédito SIFCO"
+            placeholder="No. Crédito SIFCO"
             defaultValue={creditoSifco}
             onChange={(e) => {
               if (e.target.value === "") handleSifco("");
@@ -1304,7 +1304,13 @@ function MobileView({
                     ? "En Convenio"
                     : item.creditos.statusCredit === "CAIDO"
                       ? "Caído"
-                      : item.creditos.statusCredit}
+                      : item.creditos.statusCredit === "ACTIVO"
+                        ? "Activo"
+                        : item.creditos.statusCredit === "CANCELADO"
+                          ? "Cancelado"
+                          : item.creditos.statusCredit === "MOROSO"
+                            ? "En Mora"
+                            : item.creditos.statusCredit}
             </span>
           </p>
 

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -1906,7 +1906,7 @@ function DetallesCredito({
           { label: "Seguro 10 Cuotas", value: item.creditos.seguro_10_cuotas, isMoney: true },
           { label: "GPS", value: item.creditos.gps, isMoney: true },
           { label: "Membresías", value: item.creditos.membresias, isMoney: true },
-          { label: "Royalti", value: item.creditos.royalti, isMoney: true },
+          { label: "Royalty", value: item.creditos.royalti, isMoney: true },
           { label: "Plazo", value: `${item.creditos.plazo} meses` },
           { label: "Formato Crédito", value: item.creditos.formato_credito },
           ...(item.fecha_inicio ? [{ label: "Fecha Primera Cuota", value: new Date(item.fecha_inicio + "T12:00:00").toLocaleDateString("es-ES", { day: "2-digit", month: "short", year: "numeric" }), isDate: true }] : []),

--- a/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
+++ b/apps/carteraFront/src/private/cartera/components/InvestorsList.tsx
@@ -598,7 +598,7 @@ export function InvestorsList({
                 }`}>
                   <Wallet className={`w-4 h-4 shrink-0 ${saldo > 0 ? "text-emerald-600" : "text-gray-400"}`} />
                   <span className={`text-sm font-semibold ${saldo > 0 ? "text-emerald-800" : "text-gray-500"}`}>
-                    Saldo de reinversion:
+                    Saldo de Reinversión:
                   </span>
                   <span className={`text-sm font-bold ${saldo > 0 ? "text-emerald-900" : "text-gray-600"}`}>
                     Q{saldo.toFixed(2)}

--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -190,7 +190,7 @@ export function PagoForm() {
     <DialogHeader>
       <DialogTitle className={`text-2xl font-bold flex items-center gap-2 ${creditoCanceladoInfo ? "text-red-700" : "text-blue-700"}`}>
         <CheckCircle2 className="w-7 h-7" />
-        {creditoCanceladoInfo ? "Confirmar Cancelacion de Credito" : "Confirmar Registro de Pago"}
+        {creditoCanceladoInfo ? "Confirmar Cancelación de Crédito" : "Confirmar Registro de Pago"}
       </DialogTitle>
     </DialogHeader>
 
@@ -207,12 +207,12 @@ export function PagoForm() {
             <div className="bg-gradient-to-br from-red-50 to-orange-50 rounded-xl p-5 border-2 border-red-200">
               <h3 className="font-bold text-lg text-red-900 mb-4 flex items-center gap-2">
                 <FileText className="w-5 h-5" />
-                Resumen de Cancelacion
+                Resumen de Cancelación
               </h3>
 
               <div className="space-y-3">
                 <div className="flex justify-between items-center py-2 px-3 border-b border-red-200">
-                  <span className="text-gray-700 font-medium">Monto de Cancelacion:</span>
+                  <span className="text-gray-700 font-medium">Monto de Cancelación:</span>
                   <span className="font-bold text-red-700 text-lg">Q{montoCancelacion.toFixed(2)}</span>
                 </div>
 
@@ -454,7 +454,7 @@ export function PagoForm() {
         disabled={formik.isSubmitting}
         className={`px-8 py-2.5 text-base font-bold shadow-md transition-all ${creditoCanceladoInfo ? "bg-red-600 hover:bg-red-700" : "bg-blue-600 hover:bg-blue-700"}`}
       >
-        {formik.isSubmitting ? "Procesando..." : creditoCanceladoInfo ? "Confirmar Cancelacion" : "Confirmar Pago"}
+        {formik.isSubmitting ? "Procesando..." : creditoCanceladoInfo ? "Confirmar Cancelación" : "Confirmar Pago"}
       </Button>
     </DialogFooter>
   </DialogContent>

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -831,7 +831,7 @@ const handleDownloadExcel = async () => {
                                             Monto Aportado
                                           </TableHead>
                                           <TableHead className="font-bold text-blue-700">
-                                            IVA inversionista
+                                            IVA Inversionista
                                           </TableHead>
                                           <TableHead className="font-bold text-blue-700">
                                             Detalles
@@ -918,7 +918,7 @@ const handleDownloadExcel = async () => {
                                                       </div>
                                                       <div>
                                                         <span className="font-bold text-blue-700">
-                                                          Cuota Interes Inversionista:{" "}
+                                                          Cuota Interés Inversionista:{" "}
                                                         </span>
                                                         <span className="font-semibold text-gray-900">
                                                           {formatCurrency(
@@ -928,7 +928,7 @@ const handleDownloadExcel = async () => {
                                                       </div>
                                                       <div>
                                                         <span className="font-bold text-blue-700">
-                                                          Cuota Interes Cash In:{" "}
+                                                          Cuota Interés Cash In:{" "}
                                                         </span>
                                                         <span className="font-semibold text-gray-900">
                                                           {formatCurrency(

--- a/apps/carteraFront/src/private/cartera/components/formCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/formCredit.tsx
@@ -60,7 +60,7 @@ const fields = [
   },
   {
     name: "numero_credito_sifco",
-    label: "Número crédito SIFCO",
+    label: "No. Crédito SIFCO",
     type: "text",
     icon: <CreditCard className="text-blue-500 mr-2 w-5 h-5" />,
   },

--- a/apps/carteraFront/src/private/cartera/components/formCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/formCredit.tsx
@@ -79,7 +79,7 @@ const fields = [
 
   {
     name: "seguro_10_cuotas",
-    label: "Seguro ",
+    label: "Seguro",
     type: "number",
     icon: <FileText className="text-blue-500 mr-2 w-5 h-5" />,
   },
@@ -140,13 +140,13 @@ const fields = [
   },
   {
     name: "royalti",
-    label: "Royalti",
+    label: "Royalty",
     type: "number",
     icon: <CreditCard className="text-blue-500 mr-2 w-5 h-5" />,
   },
   {
     name: "porcentaje_royalti",
-    label: "Porcentaje Royalti",
+    label: "Porcentaje Royalty",
     type: "number",
     icon: <Percent className="text-blue-500 mr-2 w-5 h-5" />,
   },


### PR DESCRIPTION
### Revisión de Textos — Correcciones Tipográficas y Estandarización de Terminología
Se realizó una revisión exhaustiva de los textos visibles al usuario en el módulo de cartera (carteraFront), corrigiendo errores tipográficos, tildes faltantes y falta de consistencia en etiquetas. No se modificó lógica de negocio ni estructura de componentes.

**formCredit.tsx**
Formulario de creación de crédito (/realizarCredito):
- Etiqueta "Seguro " tenía un espacio sobrante al final — eliminado.
- "Royalti" → "Royalty": corrección ortográfica del anglicismo. Se corrigió tanto en la etiqueta del campo como en el label "Porcentaje Royalti" → "Porcentaje Royalty".
- "Número crédito SIFCO" → "No. Crédito SIFCO": estandarización del label para que coincida con el formato usado en el resto del sistema (ver más abajo).

**InvestorsList.tsx**
Modal de edición de crédito, pestaña de inversionistas (/creditos → editar crédito):
- "Saldo de reinversion:" → "Saldo de Reinversión:": se agregó la tilde en "Reinversión" y se capitalizó correctamente la inicial de la segunda palabra.

**PaymentsCredits.tsx**
Vista de detalle de pagos de un crédito (/pagos/<numero_sifco>):
- "IVA inversionista" → "IVA Inversionista": "Inversionista" debe ir en mayúscula al ser parte del nombre del concepto.
- "Cuota Interes Inversionista" → "Cuota Interés Inversionista": tilde faltante en "Interés".
- "Cuota Interes Cash In" → "Cuota Interés Cash In": misma corrección de tilde.

**PagoForm.tsx**
Modal de cancelación de crédito (visible al realizar un pago de tipo cancelación):
- "Confirmar Cancelacion de Credito" → "Confirmar Cancelación de Crédito": tildes faltantes en "Cancelación" y "Crédito" tanto en el título del modal como en el botón de confirmación.
- "Resumen de Cancelacion" → "Resumen de Cancelación": tilde faltante en título de sección.
- "Monto de Cancelacion:" → "Monto de Cancelación:": tilde faltante en etiqueta de campo.
- Botón "Confirmar Cancelacion" → "Confirmar Cancelación": misma corrección de tilde.

**CreditsPaymentsData.tsx ---- No. Crédito SIFCO**
Vista principal de créditos y tabla de pagos (/creditos):
- "Royalti" → "Royalty": corrección ortográfica en la sección de detalle expandido de un crédito.
- Placeholder del filtro de búsqueda "# Crédito SIFCO" → "No. Crédito SIFCO": se estandariza el formato con el resto del sistema. Los componentes DevolucionCube.tsx, FallenCredits.tsx, ModalEditCredit.tsx y PagosPorVencimiento.tsx ya usaban "No. Crédito SIFCO" como etiqueta — con este cambio todos los puntos del sistema quedan consistentes.
- Vista mobile — estados de crédito: En pantallas pequeñas, los estados ACTIVO, CANCELADO y MOROSO se mostraban directamente con el valor crudo de la base de datos (en mayúsculas). Se agregaron los mapeos faltantes para que muestren "Activo", "Cancelado" y "En Mora" respectivamente, igualando el comportamiento que ya existía para PENDIENTE_CANCELACION, INCOBRABLE, EN_CONVENIO y CAIDO.