### PR TITLE
fix(cartera): sincronizar *_restante en todas las filas de la cuota tras cada pago

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -1506,6 +1506,37 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
               
             }
           }
+
+          // ── Sincronizar `*_restante` en TODAS las filas vivas de la cuota ──
+          // Antes los `*_restante` se guardaban por fila (snapshot del momento)
+          // y se desincronizaban entre pagos hermanos: la fila `no_required` y
+          // las intermedias quedaban con saldos viejos, así que el front (que
+          // puede leer cualquier fila, ej. la `no_required`) mostraba restantes
+          // que NO reflejaban los parciales ya aplicados. Replicamos el saldo
+          // VIVO recién calculado (`nuevo_*_restante`) a todas las filas de la
+          // cuota → `*_restante` pasa a ser un valor consistente por cuota,
+          // leíble desde cualquier fila. No cambia la distribución: interés/IVA
+          // se distribuyen con la fila vigente (la última, que ya trae el saldo
+          // correcto) y los rubros planos se netean contra objetivos+Σmonto_
+          // aplicado, no contra estos saldos.
+          await db
+            .update(pagos_credito)
+            .set({
+              capital_restante: nuevo_capital_restante.toString(),
+              interes_restante: nuevo_interes_restante.toString(),
+              iva_12_restante: nuevo_iva_restante.toString(),
+              seguro_restante: nuevo_seguro_restante.toString(),
+              gps_restante: nuevo_gps_restante.toString(),
+              membresias: nuevo_membresias_restante.toString(),
+            })
+            .where(
+              and(
+                eq(pagos_credito.cuota_id, cuota.cuotas_credito.cuota_id),
+                eq(pagos_credito.credito_id, credito.credito_id),
+                eq(pagos_credito.paymentFalse, false)
+              )
+            );
+
           if (disponible_restante.lte(0)) {
             break;
           }


### PR DESCRIPTION
## Qué hace
Tras escribir cada pago en `insertPayment`, replica el saldo vivo recién calculado (`nuevo_*_restante`) a **todas las filas vivas de la cuota** (`cuota_id + paymentFalse=false`, incl. la `no_required`), para que los `*_restante` sean consistentes por cuota.

## Por qué
Los `*_restante` se guardaban por fila (snapshot) y se desincronizaban entre pagos hermanos: la fila `no_required` (que el front lee) quedaba con el saldo original y mostraba deuda fantasma aunque los parciales ya estuvieran aplicados. **No cambia la distribución** (interés/IVA usan la fila vigente; rubros planos netean contra objetivos + Σ monto_aplicado) — solo denormaliza el display.

---
## 🧪 Evidencia de pruebas — fix de `*_restante` por fila

### El problema
Los `*_restante` se guardaban **por fila (snapshot)** y se desincronizaban entre pagos hermanos de una misma cuota. La fila `no_required` (que el front suele leer) quedaba con el saldo original, mostrando deuda fantasma aunque los parciales ya estuvieran aplicados.

**Ejemplo real (crédito `01010214116680` cuota 12, cuota Q3,075.83 — pagada completa):**
| Fila | Estado | capital_rest | membresías_rest | **Restante total** |
|---|---|---|---|---|
| `no_required` | original | 0 | 506.41 | **506.41** ❌ |
| 134336 | validado | 0 | 0 | **0.00** ✅ |
| 134337 | validado | 0 | 506.41 | **506.41** ❌ |

→ La cuota debe **Q0** pero el front la veía debiendo Q506.41.

### El fix
Tras escribir cada pago, se replica el saldo vivo (`nuevo_*_restante`) a **todas las filas vivas** de la cuota (`cuota_id + paymentFalse=false`).

### Prueba 1 — Replay multi-parcial (10 parciales sobre la misma cuota)
Crédito 890, 10 boletas forzadas a `cuotaApagar=11` vía `/newPayment` contra back local. Llenan la cuota 11 y desbordan a la 12, respetando prelación (interés→IVA→seguro→membresías→capital):

| | Aplicado | Restante |
|---|---|---|
| Cuota 11 | 3,379.08 | 0.00 (completa) |
| Cuota 12 | 2,610.92 | 768.16 (capital) |

### Prueba 2 — Todas las filas quedan iguales (el fix)
Cuota 12 tras los parciales — **las 8 filas con el MISMO restante** (incl. `no_required`):
```
 pago_id |     vs      | aplic  | cap_r  | int_r | iva_r | seg_r | memb_r
   51480 | no_required |   0.00 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
  135968 | pending     | 900.92 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
  135969 | pending     | 500.00 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
  135970 | pending     | 100.00 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
  135971 | pending     | 730.00 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
  135972 | pending     | 292.00 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
  135973 | pending     |   8.00 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
  135974 | pending     |  80.00 | 768.16 |  0.00 |  0.00 |  0.00 |   0.00
```
Cuota 11 (cerrada): las 4 filas en `0`.

### Prueba 3 — La distribución NO cambia
Mismo replay pre-fix vs post-fix → totales idénticos: cuota 11 = **3,379.08**, cuota 12 = **2,610.92 / rest 768.16**. El fix solo denormaliza el display; la matemática de aplicación queda intacta (verificado al centavo).
