### PR TITLE
fix(cartera): conteo de cuotas pagadas en recalculateQuota (distinct + excluir cuota 0)

### DIFF
--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -204,13 +204,21 @@ export const recalculateQuota = async ({ body, set }: any) => {
     const capital = Number(credito.capital);
     const monthlyRate = Number(credito.porcentaje_interes);
 
+    // Contamos cuotas DISTINTAS por numero_cuota: una misma cuota puede tener
+    // varias filas (p. ej. un abono extraordinario que crea otra fila con el
+    // mismo numero_cuota). count(distinct numero_cuota) evita inflar el plazo.
+    // Excluimos numero_cuota 0: la numeración real arranca en 1, la 0 es una
+    // fila fantasma que no representa una cuota del plan.
     const [{ cuotasPagadas }] = await db
-      .select({ cuotasPagadas: sql<number>`count(*)::int` })
+      .select({
+        cuotasPagadas: sql<number>`count(distinct ${cuotas_credito.numero_cuota})::int`,
+      })
       .from(cuotas_credito)
       .where(
         and(
           eq(cuotas_credito.credito_id, credito.credito_id),
           eq(cuotas_credito.pagado, true),
+          gt(cuotas_credito.numero_cuota, 0),
         ),
       );
 


### PR DESCRIPTION
## Problema

`recalculateQuota` calcula la cuota con la fórmula **PMT** sobre el **plazo restante**:

```
termMonths = plazo - cuotasPagadas
```

`cuotasPagadas` se obtenía con `count(*)` sobre `cuotas_credito` (`pagado = true`). Ese conteo **se inflaba** en dos casos reales:

1. **Cuotas con varias filas para el mismo `numero_cuota`.** Un abono extraordinario (ej. **Q75,000**) puede crear una segunda fila con el mismo `numero_cuota` marcada `pagado = true`. `count(*)` la contaba como si fuera otra cuota del plan.
2. **Filas con `numero_cuota = 0`.** La numeración real del plan arranca en 1; la `0` es una fila fantasma que no es una cuota.

Con el conteo inflado, `termMonths` quedaba **más corto que lo real**, la fórmula PMT amortizaba el capital en menos meses y devolvía una **cuota equivocada**.

## Solución

Cambio **solo en el conteo** (no toca ningún pago):

```ts
// antes
count(*)::int

// ahora
count(distinct numero_cuota)::int
  WHERE pagado = true
    AND numero_cuota > 0
```

- `count(distinct numero_cuota)` → cada cuota cuenta **una sola vez** aunque tenga varias filas.
- `gt(numero_cuota, 0)` → excluye la cuota fantasma `0`.

## Caso real — crédito `01010214120150` (plazo 60)

| | `count(*)` (antes) | distinct + `>0` (ahora) |
|---|---|---|
| Cuotas pagadas | 9 ❌ | **7** ✅ |
| `termMonths` (60 − pagadas) | 51 | **53** |

Este crédito tenía: la cuota `numero 7` con 2 filas (la regular + la del abono de **Q75,000** del 1-jun) y una fila `numero 0`. Ambas inflaban el conteo.

## Garantías

- ✅ **No se borra ni modifica ningún pago.** El abono de Q75,000 y todos los registros quedan intactos.
- ✅ Cambio exclusivamente en cómo se **cuentan** las cuotas pagadas.
- ✅ Sin migraciones de datos.

## Cómo probar

`POST` al endpoint de recálculo con `numero_credito_sifco = "01010214120150"` y verificar que `data.plazo` (termMonths) sea **53** y la `nueva_cuota` se calcule sobre ese plazo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)