### PR TITLE
feat(cartera): traslado de créditos de María Elena Roca a Boca-Terra Group (script SQL para PROD)

### DIFF
--- a/apps/cartera-back/scripts/traslado_creditos_maria_elena_a_boca_terra.sql
+++ b/apps/cartera-back/scripts/traslado_creditos_maria_elena_a_boca_terra.sql
@@ -1,0 +1,476 @@
+-- ============================================================================
+-- traslado_creditos_maria_elena_a_boca_terra.sql
+--
+-- Traslada la PARTICIPACIÓN EN CRÉDITOS de un inversionista persona natural
+-- (María Elena Roca) a su sociedad (Boca-Terra), manteniendo el historial de
+-- liquidaciones y pagos a nombre de la persona original.
+--
+-- SE MUEVEN (inversionista_id origen → destino):
+--   1) cartera.creditos_inversionistas          → participación vigente
+--   2) cartera.creditos_inversionistas_espejo   → participación espejo
+--   3) cartera.historico_liquidaciones_espejo   → snapshots de monto aportado
+--   4) cartera.historico_monto_aportado_espejo  → auditoría de cambios de monto
+--
+-- NO SE MUEVEN (quedan a nombre de María Elena):
+--   - cartera.liquidaciones
+--   - cartera.pagos_credito_inversionistas
+--   - cartera.pagos_credito_inversionistas_espejo
+--   - cartera.boletas_pago_inversionista
+--   - cartera.reinversiones
+--   - cartera.abonos_capital                (✋ BLOQUEA si hay sin liquidar)
+--   - cartera.compras_credito_inversionista (✋ BLOQUEA si hay pendientes)
+--   - cartera.documentos_inversionista
+--
+-- EFECTO DE NEGOCIO: a partir del traslado, los NUEVOS pagos de esos créditos
+-- se reparten a Boca-Terra (payments.ts lee creditos_inversionistas), y las
+-- próximas liquidaciones de esos pagos salen a nombre de Boca-Terra. Todo lo
+-- ya pagado/liquidado queda intacto a nombre de María Elena.
+--
+-- SALVAGUARDAS:
+--   1) BACKUP: copia las filas afectadas de las 4 tablas a tablas
+--      cartera.backup_traslado_* antes de modificar (permite revertir).
+--   2) ABORTA si el destino ya participa en alguno de los créditos del origen
+--      (violaría los unique ux_credito_inversionista / _espejo; ese caso es
+--      un MERGE de participaciones y debe decidirse aparte).
+--   3) ABORTA si el origen tiene compras/reinversiones con status <> completado
+--      o abonos a capital sin liquidar: hay que COMPLETARLOS PRIMERO y luego
+--      correr el traslado limpio (si se movieran a medias, la aceptación y la
+--      liquidación pierden el par credito+inversionista y quedan atorados).
+--   4) ABORTA si el origen tiene pagos con estado_liquidacion <> LIQUIDADO en
+--      pagos_credito_inversionistas o en el espejo: el traslado exige que la
+--      ÚLTIMA liquidación del origen ya haya corrido (origen 100% liquidado).
+--   5) Todo corre en UNA transacción: o se mueve todo o nada.
+--
+-- OPCIONAL (bloque al final, -v mover_ultima_liq=1): mover la ÚLTIMA
+-- liquidación del origen (la del corte final, liquidada a nombre de María
+-- Elena) al destino, junto con sus pagos (vía liquidacion_id) y su boleta de
+-- pago — para que esa liquidación quede como parte de la sociedad.
+--
+-- IDs según DEV (restore de PROD del 2026-06; CONFIRMAR contra PROD antes de correr):
+--   origen  = 96  → MARIA ELENA ROCA MARROQUIN        (dpi 1958265310101)
+--   destino = 153 → Boca-Terra Group, Sociedad Anónima (dpi 2119613290101)
+--
+-- Uso (psql):
+--   Preview:  psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=0 -f scripts/traslado_creditos_maria_elena_a_boca_terra.sql
+--   Aplicar:  psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=1 -f scripts/traslado_creditos_maria_elena_a_boca_terra.sql
+--
+-- Sin variables = PREVIEW (no modifica nada).
+--
+-- ⚠ ANTES DE CORRER EN PROD, el reviewer debe validar:
+--   - IDs reales de origen/destino en PROD (verificarlos con la query de
+--     "IDENTIFICACIÓN" de abajo; no asumir que coinciden con dev).
+--   - ORDEN OPERATIVO: 1) correr la ÚLTIMA liquidación de María Elena en el
+--     sistema → 2) preview de este script (todo en 0) → 3) apply=1 →
+--     4) opcional: mover_ultima_liq=1 si el negocio decide que esa última
+--     liquidación pase a nombre de la sociedad.
+--   - OJO con el check #4: en dev (2026-06-09) hay 61 pagos NO_LIQUIDADO en
+--     pagos_credito_inversionistas (tabla padre) aunque el espejo está en 0.
+--     Si la liquidación NO marca también la tabla padre (el flujo corre sobre
+--     el espejo), esas filas legacy van a bloquear el apply: el reviewer debe
+--     confirmar si son residuales y, de serlo, marcarlas LIQUIDADO o ajustar
+--     el check antes de correr.
+--   - Si hay triggers de auditoría sobre creditos_inversionistas_espejo
+--     (historico_monto_aportado_espejo se llena por trigger): el UPDATE de
+--     inversionista_id puede generar filas de auditoría espurias.
+-- ============================================================================
+
+-- Cortar en seco al primer error (la EXCEPTION del DO aborta todo el script)
+\set ON_ERROR_STOP on
+
+-- Defaults seguros (preview, IDs imposibles para forzar identificación)
+\if :{?origen} \else \set origen 0 \endif
+\if :{?destino} \else \set destino 0 \endif
+\if :{?apply} \else \set apply 0 \endif
+
+\echo ''
+\echo '============================================================'
+\echo ' IDENTIFICACIÓN DE INVERSIONISTAS'
+\echo '============================================================'
+
+SELECT inversionista_id, nombre, dpi, email, status, emite_factura
+FROM cartera.inversionistas
+WHERE inversionista_id IN (:origen, :destino)
+   OR nombre ILIKE '%maria%elena%roca%'
+   OR nombre ILIKE '%boca%terra%';
+
+\echo ''
+\echo '============================================================'
+\echo ' PREVIEW: filas que se moverían por tabla'
+\echo '============================================================'
+
+SELECT 'creditos_inversionistas' AS tabla, count(*) AS filas,
+       count(DISTINCT credito_id) AS creditos
+FROM cartera.creditos_inversionistas WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'creditos_inversionistas_espejo', count(*), count(DISTINCT credito_id)
+FROM cartera.creditos_inversionistas_espejo WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'historico_liquidaciones_espejo', count(*), count(DISTINCT credito_id)
+FROM cartera.historico_liquidaciones_espejo WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'historico_monto_aportado_espejo', count(*), count(DISTINCT credito_id)
+FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :origen;
+
+\echo ''
+\echo '--- Detalle de créditos a trasladar (participación vigente) ---'
+SELECT ci.credito_id, c.numero_credito_sifco, c."statusCredit",
+       ci.monto_aportado, ci.porcentaje_participacion_inversionista,
+       ci.cuota_inversionista
+FROM cartera.creditos_inversionistas ci
+JOIN cartera.creditos c ON c.credito_id = ci.credito_id
+WHERE ci.inversionista_id = :origen
+ORDER BY ci.credito_id;
+
+\echo ''
+\echo '============================================================'
+\echo ' CHECK BLOQUEANTE: créditos donde el destino YA participa'
+\echo ' (si devuelve filas, el script aborta en apply: es un MERGE)'
+\echo '============================================================'
+
+SELECT ci_o.credito_id, 'creditos_inversionistas' AS tabla
+FROM cartera.creditos_inversionistas ci_o
+JOIN cartera.creditos_inversionistas ci_d
+  ON ci_d.credito_id = ci_o.credito_id AND ci_d.inversionista_id = :destino
+WHERE ci_o.inversionista_id = :origen
+UNION ALL
+SELECT cie_o.credito_id, 'creditos_inversionistas_espejo'
+FROM cartera.creditos_inversionistas_espejo cie_o
+JOIN cartera.creditos_inversionistas_espejo cie_d
+  ON cie_d.credito_id = cie_o.credito_id AND cie_d.inversionista_id = :destino
+WHERE cie_o.inversionista_id = :origen;
+
+\echo ''
+\echo '============================================================'
+\echo ' CHECKS BLOQUEANTES: operaciones en vuelo del origen'
+\echo ' (si devuelven filas, el apply ABORTA: completarlas primero)'
+\echo '============================================================'
+
+\echo '--- Abonos a capital del origen sin liquidar (BLOQUEA) ---'
+SELECT abono_id, credito_id, monto, tipo, created_at
+FROM cartera.abonos_capital
+WHERE inversionista_id = :origen AND liquidado = false;
+
+\echo '--- Compras/reinversiones del origen pendientes (BLOQUEA) ---'
+SELECT id, credito_id, tipo_operacion, status, monto_aportado, fecha
+FROM cartera.compras_credito_inversionista
+WHERE inversionista_id = :origen AND status <> 'completado';
+
+\echo '--- Pagos del origen sin liquidar, normal y espejo (BLOQUEA) ---'
+\echo '    El traslado exige origen 100% liquidado: correr su liquidación primero.'
+SELECT 'pagos_credito_inversionistas' AS tabla, estado_liquidacion, count(*) AS filas,
+       sum(cuota) AS total_cuota
+FROM cartera.pagos_credito_inversionistas
+WHERE inversionista_id = :origen AND estado_liquidacion <> 'LIQUIDADO'
+GROUP BY estado_liquidacion
+UNION ALL
+SELECT 'pagos_credito_inversionistas_espejo', estado_liquidacion, count(*), sum(cuota)
+FROM cartera.pagos_credito_inversionistas_espejo
+WHERE inversionista_id = :origen AND estado_liquidacion <> 'LIQUIDADO'
+GROUP BY estado_liquidacion;
+
+-- ============================================================================
+-- APLICACIÓN
+-- ============================================================================
+\if :apply
+
+\echo ''
+\echo '>>> APLICANDO TRASLADO <<<'
+
+BEGIN;
+
+-- Validaciones duras ---------------------------------------------------------
+-- psql NO interpola :variables dentro de bloques DO $$...$$, así que se pasan
+-- como settings de sesión y se leen con current_setting().
+SELECT set_config('traslado.origen',  :'origen',  true),
+       set_config('traslado.destino', :'destino', true);
+
+DO $do$
+DECLARE
+  v_origen  int := current_setting('traslado.origen')::int;
+  v_destino int := current_setting('traslado.destino')::int;
+BEGIN
+  RAISE NOTICE 'Validando traslado % -> %', v_origen, v_destino;
+
+  IF NOT EXISTS (SELECT 1 FROM cartera.inversionistas WHERE inversionista_id = v_origen) THEN
+    RAISE EXCEPTION 'Inversionista ORIGEN % no existe', v_origen;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM cartera.inversionistas WHERE inversionista_id = v_destino) THEN
+    RAISE EXCEPTION 'Inversionista DESTINO % no existe', v_destino;
+  END IF;
+
+  IF v_origen = v_destino THEN
+    RAISE EXCEPTION 'Origen y destino son el mismo inversionista (%)', v_origen;
+  END IF;
+
+  -- Conflicto de unique: destino ya participa en algún crédito del origen
+  IF EXISTS (
+    SELECT 1
+    FROM cartera.creditos_inversionistas ci_o
+    JOIN cartera.creditos_inversionistas ci_d
+      ON ci_d.credito_id = ci_o.credito_id AND ci_d.inversionista_id = v_destino
+    WHERE ci_o.inversionista_id = v_origen
+  ) THEN
+    RAISE EXCEPTION 'ABORTADO: el destino ya participa en créditos del origen (creditos_inversionistas). Requiere MERGE manual.';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM cartera.creditos_inversionistas_espejo cie_o
+    JOIN cartera.creditos_inversionistas_espejo cie_d
+      ON cie_d.credito_id = cie_o.credito_id AND cie_d.inversionista_id = v_destino
+    WHERE cie_o.inversionista_id = v_origen
+  ) THEN
+    RAISE EXCEPTION 'ABORTADO: el destino ya participa en créditos del origen (espejo). Requiere MERGE manual.';
+  END IF;
+
+  -- Operaciones en vuelo del origen: si se mueve el espejo con esto pendiente,
+  -- la aceptación (completeEspejo/compraCarteraAceptada) ya no encuentra el par
+  -- (credito_id, inversionista_id) y la operación queda atorada para siempre.
+  IF EXISTS (
+    SELECT 1 FROM cartera.compras_credito_inversionista
+    WHERE inversionista_id = v_origen AND status <> 'completado'
+  ) THEN
+    RAISE EXCEPTION 'ABORTADO: el origen % tiene compras/reinversiones con status <> completado. Completarlas y volver a correr.', v_origen;
+  END IF;
+
+  -- Abonos a capital sin liquidar: tras el traslado la liquidación busca por el
+  -- inversionista vigente (destino) y el abono del origen queda huérfano.
+  IF EXISTS (
+    SELECT 1 FROM cartera.abonos_capital
+    WHERE inversionista_id = v_origen AND liquidado = false
+  ) THEN
+    RAISE EXCEPTION 'ABORTADO: el origen % tiene abonos a capital sin liquidar. Liquidarlos y volver a correr.', v_origen;
+  END IF;
+
+  -- Pagos sin liquidar (normal y espejo): el traslado solo procede con el
+  -- origen 100% liquidado (su última liquidación ya corrida). Si esto aborta,
+  -- correr la liquidación del origen primero.
+  IF EXISTS (
+    SELECT 1 FROM cartera.pagos_credito_inversionistas
+    WHERE inversionista_id = v_origen AND estado_liquidacion <> 'LIQUIDADO'
+  ) THEN
+    RAISE EXCEPTION 'ABORTADO: el origen % tiene pagos NO_LIQUIDADO/POR_LIQUIDAR en pagos_credito_inversionistas. Liquidar primero.', v_origen;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM cartera.pagos_credito_inversionistas_espejo
+    WHERE inversionista_id = v_origen AND estado_liquidacion <> 'LIQUIDADO'
+  ) THEN
+    RAISE EXCEPTION 'ABORTADO: el origen % tiene pagos NO_LIQUIDADO/POR_LIQUIDAR en el espejo. Liquidar primero.', v_origen;
+  END IF;
+END
+$do$;
+
+-- Backups -------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_creditos_inversionistas
+  (LIKE cartera.creditos_inversionistas, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_creditos_inv_espejo
+  (LIKE cartera.creditos_inversionistas_espejo, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_historico_liq_espejo
+  (LIKE cartera.historico_liquidaciones_espejo, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_historico_monto_espejo
+  (LIKE cartera.historico_monto_aportado_espejo, fecha_backup timestamptz DEFAULT now());
+
+INSERT INTO cartera.backup_traslado_creditos_inversionistas
+  SELECT *, now() FROM cartera.creditos_inversionistas WHERE inversionista_id = :origen;
+INSERT INTO cartera.backup_traslado_creditos_inv_espejo
+  SELECT *, now() FROM cartera.creditos_inversionistas_espejo WHERE inversionista_id = :origen;
+INSERT INTO cartera.backup_traslado_historico_liq_espejo
+  SELECT *, now() FROM cartera.historico_liquidaciones_espejo WHERE inversionista_id = :origen;
+INSERT INTO cartera.backup_traslado_historico_monto_espejo
+  SELECT *, now() FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :origen;
+
+-- Traslado ------------------------------------------------------------------
+UPDATE cartera.creditos_inversionistas
+   SET inversionista_id = :destino
+ WHERE inversionista_id = :origen;
+
+UPDATE cartera.creditos_inversionistas_espejo
+   SET inversionista_id = :destino,
+       updated_at = now()
+ WHERE inversionista_id = :origen;
+
+UPDATE cartera.historico_liquidaciones_espejo
+   SET inversionista_id = :destino
+ WHERE inversionista_id = :origen;
+
+UPDATE cartera.historico_monto_aportado_espejo
+   SET inversionista_id = :destino
+ WHERE inversionista_id = :origen;
+
+-- Verificación post-traslado --------------------------------------------------
+\echo ''
+\echo '--- POST: filas restantes a nombre del origen (deben ser 0) ---'
+SELECT 'creditos_inversionistas' AS tabla, count(*) AS restantes
+FROM cartera.creditos_inversionistas WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'creditos_inversionistas_espejo', count(*)
+FROM cartera.creditos_inversionistas_espejo WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'historico_liquidaciones_espejo', count(*)
+FROM cartera.historico_liquidaciones_espejo WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'historico_monto_aportado_espejo', count(*)
+FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :origen;
+
+\echo ''
+\echo '--- POST: filas ahora a nombre del destino ---'
+SELECT 'creditos_inversionistas' AS tabla, count(*) AS filas
+FROM cartera.creditos_inversionistas WHERE inversionista_id = :destino
+UNION ALL
+SELECT 'creditos_inversionistas_espejo', count(*)
+FROM cartera.creditos_inversionistas_espejo WHERE inversionista_id = :destino
+UNION ALL
+SELECT 'historico_liquidaciones_espejo', count(*)
+FROM cartera.historico_liquidaciones_espejo WHERE inversionista_id = :destino
+UNION ALL
+SELECT 'historico_monto_aportado_espejo', count(*)
+FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :destino;
+
+\echo ''
+\echo '--- Lo que NO se movió (debe seguir a nombre del origen) ---'
+SELECT 'liquidaciones' AS tabla, count(*) AS filas
+FROM cartera.liquidaciones WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'pagos_credito_inversionistas', count(*)
+FROM cartera.pagos_credito_inversionistas WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'pagos_credito_inversionistas_espejo', count(*)
+FROM cartera.pagos_credito_inversionistas_espejo WHERE inversionista_id = :origen;
+
+COMMIT;
+
+\echo ''
+\echo '>>> TRASLADO COMPLETADO. Backups en cartera.backup_traslado_* <<<'
+
+\else
+
+\echo ''
+\echo '>>> MODO PREVIEW: no se modificó nada. Usar -v apply=1 para aplicar. <<<'
+
+\endif
+
+-- ============================================================================
+-- OPCIONAL: mover la ÚLTIMA liquidación del origen al destino
+-- ============================================================================
+-- Contexto: la liquidación del día siguiente al corte será la ÚLTIMA de María
+-- Elena. El negocio puede decidir que, aunque se liquidó a su nombre, esa
+-- liquidación pase a formar parte de su sociedad (Boca-Terra). Este bloque
+-- mueve al destino:
+--   - la liquidación más reciente del origen (cartera.liquidaciones)
+--   - los pagos enlazados a ella (pagos_credito_inversionistas y _espejo,
+--     vía liquidacion_id)
+--   - la boleta de pago que la originó (boletas_pago_inversionista, vía
+--     liquidaciones.boleta_id)
+-- Las liquidaciones ANTERIORES del origen no se tocan.
+--
+-- Uso (independiente del apply principal; puede correrse después):
+--   psql "$PROD_URL" -v origen=96 -v destino=153 -v mover_ultima_liq=1 \
+--        -f scripts/traslado_creditos_maria_elena_a_boca_terra.sql
+-- ============================================================================
+\if :{?mover_ultima_liq} \else \set mover_ultima_liq 0 \endif
+
+\if :mover_ultima_liq
+
+\echo ''
+\echo '>>> MOVIENDO ÚLTIMA LIQUIDACIÓN DEL ORIGEN AL DESTINO <<<'
+
+BEGIN;
+
+-- La última liquidación del origen (por fecha; desempate por id)
+CREATE TEMP TABLE _ultima_liq ON COMMIT DROP AS
+SELECT liquidacion_id, boleta_id, fecha_liquidacion, total_cuota
+FROM cartera.liquidaciones
+WHERE inversionista_id = :origen
+ORDER BY fecha_liquidacion DESC, liquidacion_id DESC
+LIMIT 1;
+
+\echo '--- Liquidación que se va a mover (VERIFICAR que sea la esperada) ---'
+SELECT * FROM _ultima_liq;
+
+-- Aborta si el origen no tiene liquidaciones
+DO $do$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM _ultima_liq) THEN
+    RAISE EXCEPTION 'ABORTADO: el origen no tiene liquidaciones que mover.';
+  END IF;
+END
+$do$;
+
+-- Backups -------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_liquidaciones
+  (LIKE cartera.liquidaciones, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_pagos_inv
+  (LIKE cartera.pagos_credito_inversionistas, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_pagos_inv_espejo
+  (LIKE cartera.pagos_credito_inversionistas_espejo, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_boletas
+  (LIKE cartera.boletas_pago_inversionista, fecha_backup timestamptz DEFAULT now());
+
+INSERT INTO cartera.backup_traslado_liquidaciones
+  SELECT l.*, now() FROM cartera.liquidaciones l
+  WHERE l.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
+INSERT INTO cartera.backup_traslado_pagos_inv
+  SELECT p.*, now() FROM cartera.pagos_credito_inversionistas p
+  WHERE p.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
+INSERT INTO cartera.backup_traslado_pagos_inv_espejo
+  SELECT p.*, now() FROM cartera.pagos_credito_inversionistas_espejo p
+  WHERE p.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
+INSERT INTO cartera.backup_traslado_boletas
+  SELECT b.*, now() FROM cartera.boletas_pago_inversionista b
+  WHERE b.boleta_id IN (SELECT boleta_id FROM _ultima_liq WHERE boleta_id IS NOT NULL);
+
+-- Traslado ------------------------------------------------------------------
+UPDATE cartera.pagos_credito_inversionistas
+   SET inversionista_id = :destino
+ WHERE liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq)
+   AND inversionista_id = :origen;
+
+UPDATE cartera.pagos_credito_inversionistas_espejo
+   SET inversionista_id = :destino,
+       updated_at = now()
+ WHERE liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq)
+   AND inversionista_id = :origen;
+
+UPDATE cartera.boletas_pago_inversionista
+   SET inversionista_id = :destino
+ WHERE boleta_id IN (SELECT boleta_id FROM _ultima_liq WHERE boleta_id IS NOT NULL)
+   AND inversionista_id = :origen;
+
+UPDATE cartera.liquidaciones
+   SET inversionista_id = :destino
+ WHERE liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq)
+   AND inversionista_id = :origen;
+
+-- Verificación ----------------------------------------------------------------
+\echo ''
+\echo '--- POST: la liquidación movida y sus enlaces (todo debe decir destino) ---'
+SELECT l.liquidacion_id, l.inversionista_id AS inv_liquidacion,
+       b.inversionista_id AS inv_boleta,
+       (SELECT count(*) FROM cartera.pagos_credito_inversionistas p
+         WHERE p.liquidacion_id = l.liquidacion_id AND p.inversionista_id = :destino) AS pagos_norm_destino,
+       (SELECT count(*) FROM cartera.pagos_credito_inversionistas_espejo p
+         WHERE p.liquidacion_id = l.liquidacion_id AND p.inversionista_id = :destino) AS pagos_espejo_destino
+FROM cartera.liquidaciones l
+LEFT JOIN cartera.boletas_pago_inversionista b ON b.boleta_id = l.boleta_id
+WHERE l.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
+
+COMMIT;
+
+\echo ''
+\echo '>>> ÚLTIMA LIQUIDACIÓN MOVIDA AL DESTINO. Backups en cartera.backup_traslado_* <<<'
+
+\endif
+
+-- ============================================================================
+-- REVERSIÓN MANUAL (si algo sale mal después del COMMIT):
+--
+--   BEGIN;
+--   UPDATE cartera.creditos_inversionistas ci
+--      SET inversionista_id = b.inversionista_id
+--     FROM cartera.backup_traslado_creditos_inversionistas b
+--    WHERE ci.id = b.id;
+--   -- ... repetir con las otras 3 tablas backup_traslado_* (join por id) ...
+--   COMMIT;
+-- ============================================================================

--- a/apps/cartera-back/scripts/traslado_creditos_maria_elena_a_boca_terra.sql
+++ b/apps/cartera-back/scripts/traslado_creditos_maria_elena_a_boca_terra.sql
@@ -3,48 +3,49 @@
 --
 -- Traslada la PARTICIPACIÓN EN CRÉDITOS de un inversionista persona natural
 -- (María Elena Roca) a su sociedad (Boca-Terra), manteniendo el historial de
--- liquidaciones y pagos a nombre de la persona original.
+-- liquidaciones y pagos YA LIQUIDADOS a nombre de la persona original.
+--
+-- El traslado corre ANTES del próximo corte de liquidación: los pagos espejo
+-- que el origen tenga pendientes de liquidar se MUEVEN al destino, para que
+-- la próxima liquidación se los pague a la sociedad.
 --
 -- SE MUEVEN (inversionista_id origen → destino):
 --   1) cartera.creditos_inversionistas          → participación vigente
 --   2) cartera.creditos_inversionistas_espejo   → participación espejo
 --   3) cartera.historico_liquidaciones_espejo   → snapshots de monto aportado
 --   4) cartera.historico_monto_aportado_espejo  → auditoría de cambios de monto
+--   5) cartera.pagos_credito_inversionistas_espejo → SOLO las filas con
+--      estado_liquidacion <> 'LIQUIDADO' (pendientes del próximo corte)
+--   6) cartera.abonos_capital                   → SOLO las filas con
+--      liquidado = false (pendientes; los liquidará el destino)
 --
 -- NO SE MUEVEN (quedan a nombre de María Elena):
 --   - cartera.liquidaciones
---   - cartera.pagos_credito_inversionistas
---   - cartera.pagos_credito_inversionistas_espejo
+--   - cartera.pagos_credito_inversionistas      (historial; la liquidación
+--     corre sobre el espejo)
+--   - cartera.pagos_credito_inversionistas_espejo con estado LIQUIDADO
+--   - cartera.abonos_capital con liquidado = true
 --   - cartera.boletas_pago_inversionista
 --   - cartera.reinversiones
---   - cartera.abonos_capital                (✋ BLOQUEA si hay sin liquidar)
 --   - cartera.compras_credito_inversionista (✋ BLOQUEA si hay pendientes)
 --   - cartera.documentos_inversionista
 --
 -- EFECTO DE NEGOCIO: a partir del traslado, los NUEVOS pagos de esos créditos
--- se reparten a Boca-Terra (payments.ts lee creditos_inversionistas), y las
--- próximas liquidaciones de esos pagos salen a nombre de Boca-Terra. Todo lo
--- ya pagado/liquidado queda intacto a nombre de María Elena.
+-- se reparten a Boca-Terra (payments.ts lee creditos_inversionistas), y la
+-- próxima liquidación —incluyendo los pagos espejo y abonos pendientes que
+-- se trasladan— sale a nombre de Boca-Terra. Lo ya liquidado queda intacto
+-- a nombre de María Elena.
 --
 -- SALVAGUARDAS:
---   1) BACKUP: copia las filas afectadas de las 4 tablas a tablas
+--   1) BACKUP: copia las filas afectadas de las 6 tablas a tablas
 --      cartera.backup_traslado_* antes de modificar (permite revertir).
 --   2) ABORTA si el destino ya participa en alguno de los créditos del origen
 --      (violaría los unique ux_credito_inversionista / _espejo; ese caso es
 --      un MERGE de participaciones y debe decidirse aparte).
 --   3) ABORTA si el origen tiene compras/reinversiones con status <> completado
---      o abonos a capital sin liquidar: hay que COMPLETARLOS PRIMERO y luego
---      correr el traslado limpio (si se movieran a medias, la aceptación y la
---      liquidación pierden el par credito+inversionista y quedan atorados).
---   4) ABORTA si el origen tiene pagos con estado_liquidacion <> LIQUIDADO en
---      pagos_credito_inversionistas o en el espejo: el traslado exige que la
---      ÚLTIMA liquidación del origen ya haya corrido (origen 100% liquidado).
---   5) Todo corre en UNA transacción: o se mueve todo o nada.
---
--- OPCIONAL (bloque al final, -v mover_ultima_liq=1): mover la ÚLTIMA
--- liquidación del origen (la del corte final, liquidada a nombre de María
--- Elena) al destino, junto con sus pagos (vía liquidacion_id) y su boleta de
--- pago — para que esa liquidación quede como parte de la sociedad.
+--      (si se movieran a medias, la aceptación pierde el par
+--      credito+inversionista y la operación queda atorada).
+--   4) Todo corre en UNA transacción: o se mueve todo o nada.
 --
 -- IDs según DEV (restore de PROD del 2026-06; CONFIRMAR contra PROD antes de correr):
 --   origen  = 96  → MARIA ELENA ROCA MARROQUIN        (dpi 1958265310101)
@@ -59,16 +60,13 @@
 -- ⚠ ANTES DE CORRER EN PROD, el reviewer debe validar:
 --   - IDs reales de origen/destino en PROD (verificarlos con la query de
 --     "IDENTIFICACIÓN" de abajo; no asumir que coinciden con dev).
---   - ORDEN OPERATIVO: 1) correr la ÚLTIMA liquidación de María Elena en el
---     sistema → 2) preview de este script (todo en 0) → 3) apply=1 →
---     4) opcional: mover_ultima_liq=1 si el negocio decide que esa última
---     liquidación pase a nombre de la sociedad.
---   - OJO con el check #4: en dev (2026-06-09) hay 61 pagos NO_LIQUIDADO en
---     pagos_credito_inversionistas (tabla padre) aunque el espejo está en 0.
---     Si la liquidación NO marca también la tabla padre (el flujo corre sobre
---     el espejo), esas filas legacy van a bloquear el apply: el reviewer debe
---     confirmar si son residuales y, de serlo, marcarlas LIQUIDADO o ajustar
---     el check antes de correr.
+--   - ORDEN OPERATIVO: 1) preview de este script (checks bloqueantes vacíos,
+--     revisar cuántos pagos espejo pendientes viajan) → 2) apply=1 ANTES del
+--     corte de liquidación → 3) la próxima liquidación de esos créditos sale
+--     a nombre de Boca-Terra, incluyendo los pagos pendientes trasladados.
+--   - Los pagos NO_LIQUIDADO de la tabla normal (61 en dev al 2026-06-09)
+--     quedan con el origen: son historial, la liquidación corre sobre el
+--     espejo. No bloquean ni se mueven.
 --   - Si hay triggers de auditoría sobre creditos_inversionistas_espejo
 --     (historico_monto_aportado_espejo se llena por trigger): el UPDATE de
 --     inversionista_id puede generar filas de auditoría espurias.
@@ -145,26 +143,36 @@ WHERE cie_o.inversionista_id = :origen;
 \echo ' (si devuelven filas, el apply ABORTA: completarlas primero)'
 \echo '============================================================'
 
-\echo '--- Abonos a capital del origen sin liquidar (BLOQUEA) ---'
-SELECT abono_id, credito_id, monto, tipo, created_at
-FROM cartera.abonos_capital
-WHERE inversionista_id = :origen AND liquidado = false;
-
 \echo '--- Compras/reinversiones del origen pendientes (BLOQUEA) ---'
 SELECT id, credito_id, tipo_operacion, status, monto_aportado, fecha
 FROM cartera.compras_credito_inversionista
 WHERE inversionista_id = :origen AND status <> 'completado';
 
-\echo '--- Pagos del origen sin liquidar, normal y espejo (BLOQUEA) ---'
-\echo '    El traslado exige origen 100% liquidado: correr su liquidación primero.'
-SELECT 'pagos_credito_inversionistas' AS tabla, estado_liquidacion, count(*) AS filas,
-       sum(cuota) AS total_cuota
-FROM cartera.pagos_credito_inversionistas
-WHERE inversionista_id = :origen AND estado_liquidacion <> 'LIQUIDADO'
-GROUP BY estado_liquidacion
-UNION ALL
-SELECT 'pagos_credito_inversionistas_espejo', estado_liquidacion, count(*), sum(cuota)
+\echo ''
+\echo '============================================================'
+\echo ' SE MUEVEN TAMBIÉN: pendientes de liquidar del origen'
+\echo ' (el traslado corre ANTES del corte; los liquidará el destino)'
+\echo '============================================================'
+
+\echo '--- Pagos espejo sin liquidar (SE MUEVEN) ---'
+SELECT estado_liquidacion, count(*) AS filas, sum(cuota) AS total_cuota,
+       count(DISTINCT credito_id) AS creditos
 FROM cartera.pagos_credito_inversionistas_espejo
+WHERE inversionista_id = :origen AND estado_liquidacion <> 'LIQUIDADO'
+GROUP BY estado_liquidacion;
+
+\echo '--- Abonos a capital sin liquidar (SE MUEVEN) ---'
+SELECT abono_id, credito_id, monto, tipo, created_at
+FROM cartera.abonos_capital
+WHERE inversionista_id = :origen AND liquidado = false;
+
+\echo ''
+\echo '============================================================'
+\echo ' WARNINGS (no bloquean)'
+\echo '============================================================'
+\echo '--- Pagos NORMAL sin liquidar (quedan con el origen; la liquidación corre sobre el espejo) ---'
+SELECT estado_liquidacion, count(*) AS filas, sum(cuota) AS total_cuota
+FROM cartera.pagos_credito_inversionistas
 WHERE inversionista_id = :origen AND estado_liquidacion <> 'LIQUIDADO'
 GROUP BY estado_liquidacion;
 
@@ -234,31 +242,11 @@ BEGIN
     RAISE EXCEPTION 'ABORTADO: el origen % tiene compras/reinversiones con status <> completado. Completarlas y volver a correr.', v_origen;
   END IF;
 
-  -- Abonos a capital sin liquidar: tras el traslado la liquidación busca por el
-  -- inversionista vigente (destino) y el abono del origen queda huérfano.
-  IF EXISTS (
-    SELECT 1 FROM cartera.abonos_capital
-    WHERE inversionista_id = v_origen AND liquidado = false
-  ) THEN
-    RAISE EXCEPTION 'ABORTADO: el origen % tiene abonos a capital sin liquidar. Liquidarlos y volver a correr.', v_origen;
-  END IF;
-
-  -- Pagos sin liquidar (normal y espejo): el traslado solo procede con el
-  -- origen 100% liquidado (su última liquidación ya corrida). Si esto aborta,
-  -- correr la liquidación del origen primero.
-  IF EXISTS (
-    SELECT 1 FROM cartera.pagos_credito_inversionistas
-    WHERE inversionista_id = v_origen AND estado_liquidacion <> 'LIQUIDADO'
-  ) THEN
-    RAISE EXCEPTION 'ABORTADO: el origen % tiene pagos NO_LIQUIDADO/POR_LIQUIDAR en pagos_credito_inversionistas. Liquidar primero.', v_origen;
-  END IF;
-
-  IF EXISTS (
-    SELECT 1 FROM cartera.pagos_credito_inversionistas_espejo
-    WHERE inversionista_id = v_origen AND estado_liquidacion <> 'LIQUIDADO'
-  ) THEN
-    RAISE EXCEPTION 'ABORTADO: el origen % tiene pagos NO_LIQUIDADO/POR_LIQUIDAR en el espejo. Liquidar primero.', v_origen;
-  END IF;
+  -- NOTA: los pagos del ESPEJO con estado_liquidacion <> 'LIQUIDADO' y los
+  -- abonos a capital con liquidado = false NO bloquean: se TRASLADAN al
+  -- destino junto con la participación (el traslado corre ANTES de la
+  -- liquidación, y esos pendientes los liquidará el destino). Lo ya liquidado
+  -- y los pagos de la tabla normal quedan con el origen (solo historial).
 END
 $do$;
 
@@ -271,6 +259,10 @@ CREATE TABLE IF NOT EXISTS cartera.backup_traslado_historico_liq_espejo
   (LIKE cartera.historico_liquidaciones_espejo, fecha_backup timestamptz DEFAULT now());
 CREATE TABLE IF NOT EXISTS cartera.backup_traslado_historico_monto_espejo
   (LIKE cartera.historico_monto_aportado_espejo, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_pagos_inv_espejo
+  (LIKE cartera.pagos_credito_inversionistas_espejo, fecha_backup timestamptz DEFAULT now());
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_abonos_capital
+  (LIKE cartera.abonos_capital, fecha_backup timestamptz DEFAULT now());
 
 INSERT INTO cartera.backup_traslado_creditos_inversionistas
   SELECT *, now() FROM cartera.creditos_inversionistas WHERE inversionista_id = :origen;
@@ -280,6 +272,12 @@ INSERT INTO cartera.backup_traslado_historico_liq_espejo
   SELECT *, now() FROM cartera.historico_liquidaciones_espejo WHERE inversionista_id = :origen;
 INSERT INTO cartera.backup_traslado_historico_monto_espejo
   SELECT *, now() FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :origen;
+INSERT INTO cartera.backup_traslado_pagos_inv_espejo
+  SELECT *, now() FROM cartera.pagos_credito_inversionistas_espejo
+  WHERE inversionista_id = :origen AND estado_liquidacion <> 'LIQUIDADO';
+INSERT INTO cartera.backup_traslado_abonos_capital
+  SELECT *, now() FROM cartera.abonos_capital
+  WHERE inversionista_id = :origen AND liquidado = false;
 
 -- Traslado ------------------------------------------------------------------
 UPDATE cartera.creditos_inversionistas
@@ -299,6 +297,24 @@ UPDATE cartera.historico_monto_aportado_espejo
    SET inversionista_id = :destino
  WHERE inversionista_id = :origen;
 
+-- Pagos espejo pendientes de liquidar: pasan al destino para que su próxima
+-- liquidación se los pague a la sociedad (el traslado corre ANTES del corte).
+-- Los ya LIQUIDADO quedan con el origen como historial.
+UPDATE cartera.pagos_credito_inversionistas_espejo
+   SET inversionista_id = :destino,
+       updated_at = now()
+ WHERE inversionista_id = :origen
+   AND estado_liquidacion <> 'LIQUIDADO';
+
+-- Abonos a capital pendientes de liquidar: igual que los pagos espejo, pasan
+-- al destino (la liquidación los busca por el inversionista vigente del
+-- crédito, que tras el traslado es el destino). Los liquidados no se tocan.
+UPDATE cartera.abonos_capital
+   SET inversionista_id = :destino,
+       updated_at = now()
+ WHERE inversionista_id = :origen
+   AND liquidado = false;
+
 -- Verificación post-traslado --------------------------------------------------
 \echo ''
 \echo '--- POST: filas restantes a nombre del origen (deben ser 0) ---'
@@ -312,7 +328,15 @@ SELECT 'historico_liquidaciones_espejo', count(*)
 FROM cartera.historico_liquidaciones_espejo WHERE inversionista_id = :origen
 UNION ALL
 SELECT 'historico_monto_aportado_espejo', count(*)
-FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :origen;
+FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :origen
+UNION ALL
+SELECT 'pagos_espejo_sin_liquidar', count(*)
+FROM cartera.pagos_credito_inversionistas_espejo
+WHERE inversionista_id = :origen AND estado_liquidacion <> 'LIQUIDADO'
+UNION ALL
+SELECT 'abonos_capital_sin_liquidar', count(*)
+FROM cartera.abonos_capital
+WHERE inversionista_id = :origen AND liquidado = false;
 
 \echo ''
 \echo '--- POST: filas ahora a nombre del destino ---'
@@ -326,18 +350,27 @@ SELECT 'historico_liquidaciones_espejo', count(*)
 FROM cartera.historico_liquidaciones_espejo WHERE inversionista_id = :destino
 UNION ALL
 SELECT 'historico_monto_aportado_espejo', count(*)
-FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :destino;
+FROM cartera.historico_monto_aportado_espejo WHERE inversionista_id = :destino
+UNION ALL
+SELECT 'pagos_espejo_sin_liquidar', count(*)
+FROM cartera.pagos_credito_inversionistas_espejo
+WHERE inversionista_id = :destino AND estado_liquidacion <> 'LIQUIDADO'
+UNION ALL
+SELECT 'abonos_capital_sin_liquidar', count(*)
+FROM cartera.abonos_capital
+WHERE inversionista_id = :destino AND liquidado = false;
 
 \echo ''
-\echo '--- Lo que NO se movió (debe seguir a nombre del origen) ---'
+\echo '--- Lo que NO se movió (debe seguir a nombre del origen, solo historial) ---'
 SELECT 'liquidaciones' AS tabla, count(*) AS filas
 FROM cartera.liquidaciones WHERE inversionista_id = :origen
 UNION ALL
 SELECT 'pagos_credito_inversionistas', count(*)
 FROM cartera.pagos_credito_inversionistas WHERE inversionista_id = :origen
 UNION ALL
-SELECT 'pagos_credito_inversionistas_espejo', count(*)
-FROM cartera.pagos_credito_inversionistas_espejo WHERE inversionista_id = :origen;
+SELECT 'pagos_espejo_LIQUIDADOS (historial)', count(*)
+FROM cartera.pagos_credito_inversionistas_espejo
+WHERE inversionista_id = :origen AND estado_liquidacion = 'LIQUIDADO';
 
 COMMIT;
 
@@ -352,118 +385,6 @@ COMMIT;
 \endif
 
 -- ============================================================================
--- OPCIONAL: mover la ÚLTIMA liquidación del origen al destino
--- ============================================================================
--- Contexto: la liquidación del día siguiente al corte será la ÚLTIMA de María
--- Elena. El negocio puede decidir que, aunque se liquidó a su nombre, esa
--- liquidación pase a formar parte de su sociedad (Boca-Terra). Este bloque
--- mueve al destino:
---   - la liquidación más reciente del origen (cartera.liquidaciones)
---   - los pagos enlazados a ella (pagos_credito_inversionistas y _espejo,
---     vía liquidacion_id)
---   - la boleta de pago que la originó (boletas_pago_inversionista, vía
---     liquidaciones.boleta_id)
--- Las liquidaciones ANTERIORES del origen no se tocan.
---
--- Uso (independiente del apply principal; puede correrse después):
---   psql "$PROD_URL" -v origen=96 -v destino=153 -v mover_ultima_liq=1 \
---        -f scripts/traslado_creditos_maria_elena_a_boca_terra.sql
--- ============================================================================
-\if :{?mover_ultima_liq} \else \set mover_ultima_liq 0 \endif
-
-\if :mover_ultima_liq
-
-\echo ''
-\echo '>>> MOVIENDO ÚLTIMA LIQUIDACIÓN DEL ORIGEN AL DESTINO <<<'
-
-BEGIN;
-
--- La última liquidación del origen (por fecha; desempate por id)
-CREATE TEMP TABLE _ultima_liq ON COMMIT DROP AS
-SELECT liquidacion_id, boleta_id, fecha_liquidacion, total_cuota
-FROM cartera.liquidaciones
-WHERE inversionista_id = :origen
-ORDER BY fecha_liquidacion DESC, liquidacion_id DESC
-LIMIT 1;
-
-\echo '--- Liquidación que se va a mover (VERIFICAR que sea la esperada) ---'
-SELECT * FROM _ultima_liq;
-
--- Aborta si el origen no tiene liquidaciones
-DO $do$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM _ultima_liq) THEN
-    RAISE EXCEPTION 'ABORTADO: el origen no tiene liquidaciones que mover.';
-  END IF;
-END
-$do$;
-
--- Backups -------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS cartera.backup_traslado_liquidaciones
-  (LIKE cartera.liquidaciones, fecha_backup timestamptz DEFAULT now());
-CREATE TABLE IF NOT EXISTS cartera.backup_traslado_pagos_inv
-  (LIKE cartera.pagos_credito_inversionistas, fecha_backup timestamptz DEFAULT now());
-CREATE TABLE IF NOT EXISTS cartera.backup_traslado_pagos_inv_espejo
-  (LIKE cartera.pagos_credito_inversionistas_espejo, fecha_backup timestamptz DEFAULT now());
-CREATE TABLE IF NOT EXISTS cartera.backup_traslado_boletas
-  (LIKE cartera.boletas_pago_inversionista, fecha_backup timestamptz DEFAULT now());
-
-INSERT INTO cartera.backup_traslado_liquidaciones
-  SELECT l.*, now() FROM cartera.liquidaciones l
-  WHERE l.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
-INSERT INTO cartera.backup_traslado_pagos_inv
-  SELECT p.*, now() FROM cartera.pagos_credito_inversionistas p
-  WHERE p.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
-INSERT INTO cartera.backup_traslado_pagos_inv_espejo
-  SELECT p.*, now() FROM cartera.pagos_credito_inversionistas_espejo p
-  WHERE p.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
-INSERT INTO cartera.backup_traslado_boletas
-  SELECT b.*, now() FROM cartera.boletas_pago_inversionista b
-  WHERE b.boleta_id IN (SELECT boleta_id FROM _ultima_liq WHERE boleta_id IS NOT NULL);
-
--- Traslado ------------------------------------------------------------------
-UPDATE cartera.pagos_credito_inversionistas
-   SET inversionista_id = :destino
- WHERE liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq)
-   AND inversionista_id = :origen;
-
-UPDATE cartera.pagos_credito_inversionistas_espejo
-   SET inversionista_id = :destino,
-       updated_at = now()
- WHERE liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq)
-   AND inversionista_id = :origen;
-
-UPDATE cartera.boletas_pago_inversionista
-   SET inversionista_id = :destino
- WHERE boleta_id IN (SELECT boleta_id FROM _ultima_liq WHERE boleta_id IS NOT NULL)
-   AND inversionista_id = :origen;
-
-UPDATE cartera.liquidaciones
-   SET inversionista_id = :destino
- WHERE liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq)
-   AND inversionista_id = :origen;
-
--- Verificación ----------------------------------------------------------------
-\echo ''
-\echo '--- POST: la liquidación movida y sus enlaces (todo debe decir destino) ---'
-SELECT l.liquidacion_id, l.inversionista_id AS inv_liquidacion,
-       b.inversionista_id AS inv_boleta,
-       (SELECT count(*) FROM cartera.pagos_credito_inversionistas p
-         WHERE p.liquidacion_id = l.liquidacion_id AND p.inversionista_id = :destino) AS pagos_norm_destino,
-       (SELECT count(*) FROM cartera.pagos_credito_inversionistas_espejo p
-         WHERE p.liquidacion_id = l.liquidacion_id AND p.inversionista_id = :destino) AS pagos_espejo_destino
-FROM cartera.liquidaciones l
-LEFT JOIN cartera.boletas_pago_inversionista b ON b.boleta_id = l.boleta_id
-WHERE l.liquidacion_id IN (SELECT liquidacion_id FROM _ultima_liq);
-
-COMMIT;
-
-\echo ''
-\echo '>>> ÚLTIMA LIQUIDACIÓN MOVIDA AL DESTINO. Backups en cartera.backup_traslado_* <<<'
-
-\endif
-
--- ============================================================================
 -- REVERSIÓN MANUAL (si algo sale mal después del COMMIT):
 --
 --   BEGIN;
@@ -471,6 +392,7 @@ COMMIT;
 --      SET inversionista_id = b.inversionista_id
 --     FROM cartera.backup_traslado_creditos_inversionistas b
 --    WHERE ci.id = b.id;
---   -- ... repetir con las otras 3 tablas backup_traslado_* (join por id) ...
+--   -- ... repetir con las otras 5 tablas backup_traslado_* (join por id;
+--   --     en abonos_capital el id es abono_id) ...
 --   COMMIT;
 -- ============================================================================

--- a/apps/cartera-back/scripts/traslado_pagos_normal_maria_elena_a_boca_terra.sql
+++ b/apps/cartera-back/scripts/traslado_pagos_normal_maria_elena_a_boca_terra.sql
@@ -1,0 +1,186 @@
+-- ============================================================================
+-- traslado_pagos_normal_maria_elena_a_boca_terra.sql
+--
+-- COMPLEMENTO del script traslado_creditos_maria_elena_a_boca_terra.sql:
+-- mueve los pagos de la tabla NORMAL (cartera.pagos_credito_inversionistas)
+-- del origen al destino: TODAS sus filas, sin filtro de estado.
+--
+-- Correr DESPUÉS del traslado principal (o junto a él, mismo orden):
+--   1) traslado_creditos_maria_elena_a_boca_terra.sql  (participaciones,
+--      espejo, históricos, pagos espejo pendientes, abonos pendientes)
+--   2) este script                                     (todos los pagos normal)
+--
+-- SE MUEVEN (inversionista_id origen → destino):
+--   - cartera.pagos_credito_inversionistas: TODAS las filas del origen,
+--     sin filtro de estado. Verificado en datos de PROD (2026-06-09): la
+--     tabla entera (6,468 filas) está 100% en NO_LIQUIDADO con
+--     liquidacion_id NULL — el estado y el enlace a liquidaciones nunca se
+--     usan aquí; el flujo de liquidación corre sobre el espejo.
+--
+-- SALVAGUARDAS:
+--   1) BACKUP de las filas afectadas en cartera.backup_traslado_pagos_inv.
+--   2) ABORTA si algún pago del origen ya tiene fila del destino para el
+--      mismo pago_id (violaría el unique unique_pago_inversionista; sería
+--      un merge de distribución y se decide aparte).
+--   3) Todo corre en UNA transacción: o se mueve todo o nada.
+--
+-- WARNING (no bloquea): lista pagos con liquidacion_id no nulo por si en
+-- PROD apareciera alguno (no debería existir ninguno).
+--
+-- IDs según DEV (restore de PROD del 2026-06-09; CONFIRMAR contra PROD):
+--   origen  = 96  → MARIA ELENA ROCA MARROQUIN        (dpi 1958265310101)
+--   destino = 153 → Boca-Terra Group, Sociedad Anónima (dpi 2119613290101)
+--
+-- Uso (psql):
+--   Preview:  psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=0 -f scripts/traslado_pagos_normal_maria_elena_a_boca_terra.sql
+--   Aplicar:  psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=1 -f scripts/traslado_pagos_normal_maria_elena_a_boca_terra.sql
+--
+-- Sin variables = PREVIEW (no modifica nada).
+-- ============================================================================
+
+\set ON_ERROR_STOP on
+
+\if :{?origen} \else \set origen 0 \endif
+\if :{?destino} \else \set destino 0 \endif
+\if :{?apply} \else \set apply 0 \endif
+
+\echo ''
+\echo '============================================================'
+\echo ' IDENTIFICACIÓN DE INVERSIONISTAS'
+\echo '============================================================'
+
+SELECT inversionista_id, nombre, dpi, status
+FROM cartera.inversionistas
+WHERE inversionista_id IN (:origen, :destino);
+
+\echo ''
+\echo '============================================================'
+\echo ' PREVIEW: TODOS los pagos normal del origen (se mueven todos)'
+\echo '============================================================'
+
+SELECT estado_liquidacion, count(*) AS filas, sum(cuota) AS total_cuota,
+       count(DISTINCT credito_id) AS creditos
+FROM cartera.pagos_credito_inversionistas
+WHERE inversionista_id = :origen
+GROUP BY estado_liquidacion;
+
+\echo '--- Detalle por crédito ---'
+SELECT credito_id, count(*) AS pagos, sum(cuota) AS total_cuota,
+       min(fecha_pago)::date AS pago_mas_viejo, max(fecha_pago)::date AS pago_mas_nuevo
+FROM cartera.pagos_credito_inversionistas
+WHERE inversionista_id = :origen
+GROUP BY credito_id
+ORDER BY credito_id;
+
+\echo ''
+\echo '============================================================'
+\echo ' CHECKS BLOQUEANTES'
+\echo '============================================================'
+
+\echo '--- Pagos donde el destino YA tiene fila del mismo pago_id (unique; BLOQUEA) ---'
+SELECT p_o.pago_id, p_o.credito_id
+FROM cartera.pagos_credito_inversionistas p_o
+JOIN cartera.pagos_credito_inversionistas p_d
+  ON p_d.pago_id = p_o.pago_id AND p_d.inversionista_id = :destino
+WHERE p_o.inversionista_id = :origen;
+
+\echo '--- WARNING (no bloquea): pagos con liquidacion_id no nulo (no debería haber) ---'
+SELECT pago_id, credito_id, estado_liquidacion, liquidacion_id
+FROM cartera.pagos_credito_inversionistas
+WHERE inversionista_id = :origen
+  AND liquidacion_id IS NOT NULL;
+
+-- ============================================================================
+-- APLICACIÓN
+-- ============================================================================
+\if :apply
+
+\echo ''
+\echo '>>> APLICANDO TRASLADO DE PAGOS NORMAL <<<'
+
+BEGIN;
+
+SELECT set_config('traslado.origen',  :'origen',  true),
+       set_config('traslado.destino', :'destino', true);
+
+DO $do$
+DECLARE
+  v_origen  int := current_setting('traslado.origen')::int;
+  v_destino int := current_setting('traslado.destino')::int;
+BEGIN
+  RAISE NOTICE 'Validando traslado de pagos normal % -> %', v_origen, v_destino;
+
+  IF NOT EXISTS (SELECT 1 FROM cartera.inversionistas WHERE inversionista_id = v_origen) THEN
+    RAISE EXCEPTION 'Inversionista ORIGEN % no existe', v_origen;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM cartera.inversionistas WHERE inversionista_id = v_destino) THEN
+    RAISE EXCEPTION 'Inversionista DESTINO % no existe', v_destino;
+  END IF;
+
+  IF v_origen = v_destino THEN
+    RAISE EXCEPTION 'Origen y destino son el mismo inversionista (%)', v_origen;
+  END IF;
+
+  -- Unique (pago_id, inversionista_id): el destino no puede tener ya una
+  -- fila del mismo pago que se va a mover.
+  IF EXISTS (
+    SELECT 1
+    FROM cartera.pagos_credito_inversionistas p_o
+    JOIN cartera.pagos_credito_inversionistas p_d
+      ON p_d.pago_id = p_o.pago_id AND p_d.inversionista_id = v_destino
+    WHERE p_o.inversionista_id = v_origen
+  ) THEN
+    RAISE EXCEPTION 'ABORTADO: hay pagos del origen donde el destino ya tiene fila (unique_pago_inversionista). Requiere merge manual.';
+  END IF;
+END
+$do$;
+
+-- Backup ----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS cartera.backup_traslado_pagos_inv
+  (LIKE cartera.pagos_credito_inversionistas, fecha_backup timestamptz DEFAULT now());
+
+INSERT INTO cartera.backup_traslado_pagos_inv
+  SELECT *, now() FROM cartera.pagos_credito_inversionistas
+  WHERE inversionista_id = :origen;
+
+-- Traslado --------------------------------------------------------------------
+UPDATE cartera.pagos_credito_inversionistas
+   SET inversionista_id = :destino
+ WHERE inversionista_id = :origen;
+
+-- Verificación post -------------------------------------------------------------
+\echo ''
+\echo '--- POST: pagos normal restantes del origen (debe ser 0) ---'
+SELECT count(*) AS restantes_origen
+FROM cartera.pagos_credito_inversionistas
+WHERE inversionista_id = :origen;
+
+\echo '--- POST: pagos normal ahora del destino ---'
+SELECT estado_liquidacion, count(*) AS filas, sum(cuota) AS total_cuota
+FROM cartera.pagos_credito_inversionistas
+WHERE inversionista_id = :destino
+GROUP BY estado_liquidacion;
+
+COMMIT;
+
+\echo ''
+\echo '>>> PAGOS NORMAL TRASLADADOS. Backup en cartera.backup_traslado_pagos_inv <<<'
+
+\else
+
+\echo ''
+\echo '>>> MODO PREVIEW: no se modificó nada. Usar -v apply=1 para aplicar. <<<'
+
+\endif
+
+-- ============================================================================
+-- REVERSIÓN MANUAL (si algo sale mal después del COMMIT):
+--
+--   BEGIN;
+--   UPDATE cartera.pagos_credito_inversionistas p
+--      SET inversionista_id = b.inversionista_id
+--     FROM cartera.backup_traslado_pagos_inv b
+--    WHERE p.id = b.id;
+--   COMMIT;
+-- ============================================================================


### PR DESCRIPTION
## Qué es esto

**Dos scripts SQL** para correr en PROD: María Elena Roca pidió que todos sus créditos pasen a su sociedad **Boca-Terra Group, S.A.**. Sus liquidaciones históricas y pagos espejo ya liquidados **quedan a su nombre**; la participación en créditos, los pendientes de liquidar y todos los pagos de la tabla normal pasan a la sociedad.

1. `apps/cartera-back/scripts/traslado_creditos_maria_elena_a_boca_terra.sql` — el traslado principal
2. `apps/cartera-back/scripts/traslado_pagos_normal_maria_elena_a_boca_terra.sql` — complementario: pagos de la tabla normal

> **Importante:** el traslado corre **ANTES** del próximo corte de liquidación. Los pagos espejo y abonos pendientes viajan con el traslado — la próxima liquidación de esos créditos sale completa a nombre de Boca-Terra.

**IDs (verificados contra restore fresco de PROD del 2026-06-09 — confirmar contra PROD el día de la corrida):**
- Origen: `96` — MARIA ELENA ROCA MARROQUIN (dpi 1958265310101)
- Destino: `153` — Boca-Terra Group, Sociedad Anónima (dpi 2119613290101)

## Qué mueven (96 → 153)

| Script | Tabla | Filtro | Probado en dev |
|---|---|---|---|
| 1 | `creditos_inversionistas` | todas | 24 créditos |
| 1 | `creditos_inversionistas_espejo` | todas | 24 filas |
| 1 | `historico_liquidaciones_espejo` | todas | 24 filas |
| 1 | `historico_monto_aportado_espejo` | todas | 10 filas |
| 1 | `pagos_credito_inversionistas_espejo` | solo `<> 'LIQUIDADO'` | 24 pagos / Q118,369.42 |
| 1 | `abonos_capital` | solo `liquidado = false` | 1 abono (Q0) |
| 2 | `pagos_credito_inversionistas` | **todas (sin filtro)** | 63 pagos / Q437,469.88 |

**Por qué el script 2 mueve todo sin filtro:** se verificó contra los datos de PROD que la tabla `pagos_credito_inversionistas` entera (6,468 filas) está 100% en `NO_LIQUIDADO` con `liquidacion_id` NULL — el estado y el enlace a liquidaciones nunca se usan en esa tabla; el flujo de liquidación corre sobre el espejo.

## Qué NO se mueve (queda a nombre de María Elena)

`liquidaciones` (4), pagos espejo ya `LIQUIDADO` (64), abonos ya liquidados, `boletas_pago_inversionista`, `reinversiones`, compras completadas, `documentos_inversionista`.

## Salvaguardas (ambos scripts)

- **Preview por defecto** — sin `-v apply=1` no modifican nada.
- **Todo en una transacción** — o se mueve todo o nada (`ON_ERROR_STOP` + `RAISE EXCEPTION`).
- **Backups** de las filas afectadas en tablas `cartera.backup_traslado_*` (reversión documentada al final de cada script).
- **Checks bloqueantes**:
  - Script 1: origen/destino inválidos; destino ya participa en un crédito del origen (unique `ux_credito_inversionista` → sería MERGE); compras/reinversiones con `status <> 'completado'`. *(En dev: todo en 0.)*
  - Script 2: destino ya tiene fila del mismo `pago_id` (unique `unique_pago_inversionista` → sería merge). *(En dev: 0.)* Warning no bloqueante si aparece un `liquidacion_id` no nulo.

## ✅ Probado end-to-end en dev (Neon) con datos frescos de PROD

Dev se restauró hoy desde PROD (`pg_dump -Fc` + `pg_restore`, conteos verificados 1:1). Sobre esos datos corrieron los dos scripts en orden, preview → apply:

- **Script 1:** UPDATEs 24+24+24+10+24+1, COMMIT OK. Origen en 0 en las 6 tablas; Boca-Terra con 26 participaciones (24 movidas + 2 propias).
- **Script 2:** UPDATE 63, COMMIT OK. Origen en 0; Boca-Terra con los 63 pagos (Q437,469.88).
- María Elena conservó exactamente su historial: 4 liquidaciones y 64 pagos espejo liquidados.

## Cómo se corre en PROD (orden)

```bash
# 1. Traslado principal: preview y luego apply
psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=0 -f apps/cartera-back/scripts/traslado_creditos_maria_elena_a_boca_terra.sql
psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=1 -f apps/cartera-back/scripts/traslado_creditos_maria_elena_a_boca_terra.sql

# 2. Pagos tabla normal: preview y luego apply
psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=0 -f apps/cartera-back/scripts/traslado_pagos_normal_maria_elena_a_boca_terra.sql
psql "$PROD_URL" -v origen=96 -v destino=153 -v apply=1 -f apps/cartera-back/scripts/traslado_pagos_normal_maria_elena_a_boca_terra.sql
```

Notas técnicas para el reviewer:
- Las validaciones dentro de `DO $$` reciben los IDs vía `set_config`/`current_setting` (psql no interpola `:variables` en bloques dollar-quoted).
- En PROD hay trigger de auditoría sobre `creditos_inversionistas_espejo` que escribe en `historico_monto_aportado_espejo`: el UPDATE de `inversionista_id` puede generar filas con `monto_anterior = monto_nuevo` (inofensivas). En dev no se reproduce porque el restore es data-only.
- En el preview del script 2 aparece el crédito 8696: María Elena tiene un pago ahí sin tener participación vigente en ese crédito — se mueve igual (dato heredado, no afecta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)