### PR TITLE
feat(cartera): crédito solo-interés (no_amortiza_capital) — endpoint + front

### DIFF
--- a/apps/cartera-back/drizzle/0007_add_no_amortiza_capital_creditos.sql
+++ b/apps/cartera-back/drizzle/0007_add_no_amortiza_capital_creditos.sql
@@ -1,0 +1,5 @@
+-- Crédito solo-interés: cuando no_amortiza_capital = true, la cuota cubre
+-- interés + IVA + seguro + GPS + membresía, sin amortizar capital. El capital
+-- se paga vía abonos extraordinarios o pago final.
+ALTER TABLE cartera.creditos
+ADD COLUMN IF NOT EXISTS no_amortiza_capital boolean NOT NULL DEFAULT false;

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -163,13 +163,23 @@ function calculateMonthlyPayment(
   insuranceCost: number,
   gpsCost: number,
   membresiasCost: number,
+  noAmortizaCapital: boolean = false,
 ): number {
   const r = (monthlyRate / 100) * 1.12;
-  if (r === 0)
-    return principal / termMonths + insuranceCost + gpsCost + membresiasCost;
+  const cargosFijos = insuranceCost + gpsCost + membresiasCost;
+
+  // Crédito solo-interés: la cuota cubre interés + IVA + cargos fijos y NO
+  // amortiza capital (abono a capital = 0 cada mes). El capital se paga vía
+  // abonos extraordinarios o pago final. Como no hay amortización, la cuota no
+  // depende del plazo: es simplemente principal * r (interés + IVA) + fijos.
+  if (noAmortizaCapital) {
+    return principal * r + cargosFijos;
+  }
+
+  if (r === 0) return principal / termMonths + cargosFijos;
   const factor = (1 + r) ** termMonths;
   const baseMonthlyPayment = (principal * (r * factor)) / (factor - 1);
-  return baseMonthlyPayment + insuranceCost + gpsCost + membresiasCost;
+  return baseMonthlyPayment + cargosFijos;
 }
 
 const recalculateQuotaSchema = z.object({
@@ -236,7 +246,10 @@ export const recalculateQuota = async ({ body, set }: any) => {
     const gpsCost = Number(credito.gps ?? 0);
     const membresiasCost = Number(credito.membresias_pago ?? 0);
 
-    // 2. Calcular nueva cuota con PMT
+    // 2. Calcular nueva cuota.
+    // Si el crédito es solo-interés (no_amortiza_capital), la cuota cubre solo
+    // interés + IVA + cargos fijos; si no, se amortiza capital con PMT.
+    const noAmortizaCapital = Boolean(credito.no_amortiza_capital);
     const nuevaCuota = Number(
       new Big(
         calculateMonthlyPayment(
@@ -246,6 +259,7 @@ export const recalculateQuota = async ({ body, set }: any) => {
           insuranceCost,
           gpsCost,
           membresiasCost,
+          noAmortizaCapital,
         ),
       ).round(2),
     );
@@ -435,6 +449,7 @@ const creditUpdateSchema = z.object({
   // Formato de crédito manual
   formato_credito: z.string().max(50).optional(),
   permite_abono_capital: z.boolean().optional(),
+  no_amortiza_capital: z.boolean().optional(),
   estado_devolucion: z.enum(['NO_APLICA', 'PENDIENTE_AUTORIZACION', 'VERIFICADO', 'RECHAZADO']).optional(),
   motivo_devolucion: z.string().optional(),
   bandera_reinversion: z.boolean().optional(),
@@ -988,6 +1003,7 @@ export const updateCredit = async ({ body, set, request }: any) => {
       saldo_a_favor,
       formato_credito,
       permite_abono_capital,
+      no_amortiza_capital,
       estado_devolucion,
       motivo_devolucion,
       bandera_reinversion,
@@ -1079,6 +1095,9 @@ export const updateCredit = async ({ body, set, request }: any) => {
     }
     if (permite_abono_capital !== undefined) {
       updateFields.permite_abono_capital = permite_abono_capital;
+    }
+    if (no_amortiza_capital !== undefined) {
+      updateFields.no_amortiza_capital = no_amortiza_capital;
     }
     if (estado_devolucion !== undefined) {
       if (estado_devolucion !== current.estado_devolucion) {

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -187,6 +187,9 @@
     estado_devolucion: estadoDevolucionEnum("estado_devolucion").notNull().default("NO_APLICA"),
     is_vehiculo_propio: boolean("is_vehiculo_propio").notNull().default(false), // true si el vehículo es propiedad de Cash In
     bandera_reinversion: boolean("bandera_reinversion").notNull().default(false),
+    // true = crédito solo-interés: la cuota cubre interés + IVA + seguro + GPS +
+    // membresía, sin amortizar capital. El capital se paga vía abonos/pago final.
+    no_amortiza_capital: boolean("no_amortiza_capital").notNull().default(false),
   });
   export const historial_devolucion_credito = customSchema.table("historial_devolucion_credito", {
     id: serial("id").primaryKey(),

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -250,6 +250,8 @@ export function ModalEditCredit({
 
         // Abono capital
         permite_abono_capital: !!values.permite_abono_capital,
+        // Crédito solo-interés (no amortiza capital en la cuota)
+        no_amortiza_capital: !!values.no_amortiza_capital,
         estado_devolucion: values.estado_devolucion,
         motivo_devolucion:
           values.estado_devolucion === "PENDIENTE_AUTORIZACION"
@@ -597,6 +599,41 @@ export function ModalEditCredit({
                   <span
                     className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
                       formik.values.permite_abono_capital
+                        ? "translate-x-5"
+                        : "translate-x-0"
+                    }`}
+                  />
+                </button>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label className="text-gray-800 font-bold text-sm">
+                    Crédito solo interés (no amortiza capital)
+                  </Label>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    Si está activo, la cuota cubre solo interés, IVA, seguro, GPS y membresía. El capital se paga por abonos o pago final.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  role="switch"
+                  aria-checked={!!formik.values.no_amortiza_capital}
+                  onClick={() =>
+                    formik.setFieldValue(
+                      "no_amortiza_capital",
+                      !formik.values.no_amortiza_capital
+                    )
+                  }
+                  className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                    formik.values.no_amortiza_capital
+                      ? "bg-green-500"
+                      : "bg-gray-300"
+                  }`}
+                >
+                  <span
+                    className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                      formik.values.no_amortiza_capital
                         ? "translate-x-5"
                         : "translate-x-0"
                     }`}

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -130,6 +130,7 @@ export interface Credito {
   formato_credito: string;
   statusCredit: string; // ACTIVO, CANCELADO, INCOBRABLE
   permite_abono_capital?: boolean;
+  no_amortiza_capital?: boolean;
   estado_devolucion?: 'NO_APLICA' | 'PENDIENTE_AUTORIZACION' | 'VERIFICADO' | 'RECHAZADO';
 }
 
@@ -398,6 +399,7 @@ export interface Credito {
   royalti: string;
   mora: string;
   permite_abono_capital?: boolean;
+  no_amortiza_capital?: boolean;
   estado_devolucion?: 'NO_APLICA' | 'PENDIENTE_AUTORIZACION' | 'VERIFICADO' | 'RECHAZADO';
 }
 
@@ -684,6 +686,7 @@ export interface UpdateCreditBody {
 
   // Abono capital
   permite_abono_capital?: boolean;
+  no_amortiza_capital?: boolean;
   estado_devolucion?: 'NO_APLICA' | 'PENDIENTE_AUTORIZACION' | 'VERIFICADO' | 'RECHAZADO';
 
   // Inversionistas nuevos


### PR DESCRIPTION
## Qué hace

Agrega un flag por crédito, **`no_amortiza_capital`**, para marcar créditos **solo interés**:

> Cuando está activo, la cuota mensual cubre **interés + IVA + seguro + GPS + membresía**, y **no amortiza capital** (abono a capital en la cuota = 0). El capital se paga vía **abonos extraordinarios** o **pago final**.

## Cómo afecta la fórmula

`calculateMonthlyPayment` recibe un nuevo parámetro `noAmortizaCapital`:

```ts
// solo-interés: sin PMT, la cuota no depende del plazo
if (noAmortizaCapital) {
  return principal * r + cargosFijos;   // interés + IVA + seguro + GPS + membresía
}
// normal: PMT (amortiza capital)
const factor = (1 + r) ** termMonths;
return (principal * (r * factor)) / (factor - 1) + cargosFijos;
```

`r = (porcentaje_interes / 100) * 1.12` → `principal * r` = interés + 12% IVA.

## Cambios

### Backend
- **schema**: nueva columna `cartera.creditos.no_amortiza_capital` (`boolean NOT NULL DEFAULT false`).
- **migración**: `drizzle/0007_add_no_amortiza_capital_creditos.sql` (`ADD COLUMN IF NOT EXISTS`, idempotente).
- **`calculateMonthlyPayment`**: parámetro `noAmortizaCapital` con la fórmula solo-interés.
- **`recalculateQuota`**: lee `credito.no_amortiza_capital` y lo pasa a la fórmula.
- **endpoint update de crédito**: acepta y persiste `no_amortiza_capital` (zod + destructure + `updateFields`), mismo patrón que `permite_abono_capital`.

### Frontend (`ModalEditCredit`)
- Nuevo **toggle** "Crédito solo interés (no amortiza capital)" junto a "Permite Abono a Capital", misma UI.
- Se envía `no_amortiza_capital` en el submit; agregado a los tipos de `services.ts`.

## Estado de la base

La migración ya se aplicó en **local** y **prod** (additiva e idempotente). Todos los créditos existentes quedaron en **`false`**, así que **ningún crédito cambia de comportamiento** por defecto — solo los que se marquen manualmente.

| Base | Columna | Default | Créditos en `true` |
|---|---|---|---|
| LOCAL (5433) | ✅ | false | 0 |
| PROD (6543) | ✅ | false | 0 |

## Pendiente (fuera de este PR)

El flujo de **`registerPayment`** (pago mensual normal) todavía no contempla el flag; se abordará en un PR aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)