### PR TITLE
fix(cartera): include capital payments in statements

### DIFF
--- a/apps/cartera-back/src/controllers/reports.test.ts
+++ b/apps/cartera-back/src/controllers/reports.test.ts
@@ -21,7 +21,7 @@ mock.module("@cci/email", () => ({
   sendInvestorAddedToCreditsNotification: mock(() => Promise.resolve()),
 }));
 
-const { buildEstadoCuentaTableHeader, renderEstadoCuentaPaymentRow } = await import("./reports");
+const { buildEstadoCuentaTableHeader, renderEstadoCuentaPaymentRow, shouldIncludeEstadoCuentaPayment } = await import("./reports");
 
 describe("estado de cuenta PDF", () => {
   it("incluye la columna de fecha de aplicacion del pago", () => {
@@ -75,5 +75,51 @@ describe("estado de cuenta PDF", () => {
     );
 
     expect(row).toContain("<td>-</td>");
+  });
+
+  it("incluye abonos a capital validados aunque no cierren cuota", () => {
+    expect(
+      shouldIncludeEstadoCuentaPayment({
+        pagado: false,
+        paymentFalse: false,
+        validationStatus: "validated",
+        abono_capital: "75000.00",
+        monto_aplicado: "75000.00",
+      }),
+    ).toBe(true);
+  });
+
+  it("mantiene incluidos los pagos parciales que ya estan marcados como pagados", () => {
+    expect(
+      shouldIncludeEstadoCuentaPayment({
+        pagado: true,
+        paymentFalse: false,
+        validationStatus: "pending",
+        abono_capital: "0.00",
+        abono_interes: "147.78",
+        abono_iva_12: "0.00",
+        abono_seguro: "0.00",
+        abono_gps: "0.00",
+        membresias_pago: "0.00",
+        monto_aplicado: "147.78",
+      }),
+    ).toBe(true);
+  });
+
+  it("no incluye cuotas futuras sincronizadas aunque esten validadas", () => {
+    expect(
+      shouldIncludeEstadoCuentaPayment({
+        pagado: false,
+        paymentFalse: false,
+        validationStatus: "validated",
+        abono_capital: "73.68",
+        abono_interes: "1060.69",
+        abono_iva_12: "127.28",
+        abono_seguro: "260.93",
+        abono_gps: "0.00",
+        membresias_pago: "399.73",
+        monto_aplicado: "1922.31",
+      }),
+    ).toBe(false);
   });
 });

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -13,6 +13,9 @@ const LOGO_URL = process.env.LOGO_URL || "https://pub-8081c8d6e5e743f9adfc9e0db9
 
 type EstadoCuentaPagoRow = {
   pago_id?: number | string | null;
+  pagado?: boolean | null;
+  paymentFalse?: boolean | null;
+  validationStatus?: string | null;
   numero_cuota?: number | string | null;
   cuota?: number | string | null;
   abono_capital?: number | string | null;
@@ -27,6 +30,27 @@ type EstadoCuentaPagoRow = {
   fecha_vencimiento?: Date | string | null;
   fecha_aplicado?: Date | string | null;
 };
+
+export function shouldIncludeEstadoCuentaPayment(pago: EstadoCuentaPagoRow) {
+  if (pago.paymentFalse === true) return false;
+  if (pago.pagado === true) return true;
+
+  const abonoCapital = Number(pago.abono_capital || 0);
+  const montoAplicado = Number(pago.monto_aplicado || 0);
+  const totalOtrosRubros =
+    Number(pago.abono_interes || 0) +
+    Number(pago.abono_iva_12 || 0) +
+    Number(pago.abono_seguro || 0) +
+    Number(pago.abono_gps || 0) +
+    Number(pago.membresias_pago || 0);
+
+  return (
+    pago.validationStatus === "validated" &&
+    abonoCapital > 0 &&
+    montoAplicado > 0 &&
+    totalOtrosRubros === 0
+  );
+}
 
 const formatEstadoCuentaMoney = (n: number) =>
   `Q${n.toLocaleString("es-GT", {
@@ -382,9 +406,9 @@ export async function exportPagosToExcel(credito_sifco: string) {
     throw new Error(`No hay pagos para el crédito ${credito_sifco}`);
   }
 
-  // Filtrar solo pagos pagados
-  const pagosFiltrados = pagosData.filter(
-    ({ pago }) => pago.pagado === true
+  // Incluye cuotas pagadas y abonos a capital ya validados aunque no cierren cuota.
+  const pagosFiltrados = pagosData.filter(({ pago }) =>
+    shouldIncludeEstadoCuentaPayment(pago)
   );
 
   if (!pagosFiltrados.length) {


### PR DESCRIPTION
## Summary
- Include validated direct capital payments in account statements even when they do not close an installment
- Keep existing paid-installment behavior unchanged
- Add tests for capital payments, existing partial payments, and synchronized unpaid installments

## Verification
- bun test src/controllers/reports.test.ts