### PR TITLE
feat(assignCapital): add porcentaje filter to prevent self-purchase

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -322,9 +322,10 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
     console.log(` - monto: ${monto_aportado}`);
     console.log(` - limit (minimo): ${minimo ?? "Sin límite"}`);
     console.log(` - inversionista_id: ${inversionista_id}`);
+    console.log(` - porcentaje_inversion: ${porcentaje_inversion}`);
     console.log("================================================================");
 
-    let candidatos = await getCreditCandidates(monto_aportado, minimo, inversionista_id);
+    let candidatos = await getCreditCandidates(monto_aportado, minimo, inversionista_id, porcentaje_inversion);
 
     console.log(`[addInvestorToCredit] Candidatos encontrados: ${candidatos.length}`);
     candidatos.forEach((c, i) => {

--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -143,7 +143,8 @@ function calcCapitalProximityBonus(
 export async function getCreditCandidates(
   monto?: number,
   limit?: number,
-  inversionistaIdSolicitante?: number
+  inversionistaIdSolicitante?: number,
+  porcentaje?: number
 ): Promise<CreditCandidate[]> {
   console.log("\n🔍 ========== getCreditCandidates ==========");
   console.log(`   monto: ${monto ?? "no especificado"}`);
@@ -333,6 +334,7 @@ export async function getCreditCandidates(
       credito_id: creditos_inversionistas.credito_id,
       inversionista_id: creditos_inversionistas.inversionista_id,
       monto_aportado: creditos_inversionistas.monto_aportado,
+      porcentaje_participacion_inversionista: creditos_inversionistas.porcentaje_participacion_inversionista,
       nombre: inversionistas.nombre,
     })
     .from(creditos_inversionistas)
@@ -346,6 +348,8 @@ export async function getCreditCandidates(
     .where(inArray(creditos_inversionistas.credito_id, creditoIds));
 
   const invsByCredito = new Map<number, InversionistaResult[]>();
+  const porcentajeMismatchSet = new Set<number>();
+
   for (const row of invRows) {
     if (!invsByCredito.has(row.credito_id)) {
       invsByCredito.set(row.credito_id, []);
@@ -357,6 +361,21 @@ export async function getCreditCandidates(
       monto_aportado: Number(row.monto_aportado),
       es_cube: esCube,
     });
+
+    // Detectar mismatch de porcentaje en memoria (sin round-trip extra)
+    if (
+      inversionistaIdSolicitante !== undefined &&
+      porcentaje !== undefined &&
+      row.inversionista_id === inversionistaIdSolicitante &&
+      Number(row.monto_aportado) > 0 &&
+      Number(row.porcentaje_participacion_inversionista) !== porcentaje
+    ) {
+      if (row.credito_id !== null) porcentajeMismatchSet.add(row.credito_id);
+    }
+  }
+
+  if (inversionistaIdSolicitante !== undefined && porcentaje !== undefined) {
+    console.log(`   Créditos descartados por porcentaje incompatible (inversionista propio): ${porcentajeMismatchSet.size}`);
   }
 
   // ──────────────────────────────────────────────────────────
@@ -483,6 +502,14 @@ export async function getCreditCandidates(
     if (cuotasVencidasSet.has(credito_id)) {
       console.log(
         `   ❌ [${numero_credito_sifco}] Descartado: tiene cuotas vencidas sin pagar`
+      );
+      continue;
+    }
+
+    // Filtro: inversionista ya participa con porcentaje distinto al solicitado
+    if (porcentajeMismatchSet.has(credito_id)) {
+      console.log(
+        `   ❌ [${numero_credito_sifco}] Descartado: inversionista ya participa con porcentaje distinto`
       );
       continue;
     }

--- a/apps/cartera-back/src/routers/assignCapital.ts
+++ b/apps/cartera-back/src/routers/assignCapital.ts
@@ -33,6 +33,7 @@ export const assignCapitalRouter = new Elysia()
       solo_insertable: soloInsertableStr,
       minimo: minimoStr,
       inversionista_id: inversionistaIdStr,
+      porcentaje: porcentajeStr,
     } = query as Record<string, string | undefined>;
 
     // ── Validar monto ──────────────────────────────────────────
@@ -77,8 +78,19 @@ export const assignCapitalRouter = new Elysia()
       }
     }
 
+    // ── Validar porcentaje ─────────────────────────────────────
+    let porcentaje: number | undefined;
+    if (porcentajeStr !== undefined) {
+      const parsed = Number(porcentajeStr);
+      if (isNaN(parsed) || parsed <= 0 || parsed > 100) {
+        set.status = 400;
+        return { ok: false, message: "El parámetro 'porcentaje' debe ser un número mayor a 0 y máximo 100." };
+      }
+      porcentaje = parsed;
+    }
+
     try {
-      const allCandidates = await getCreditCandidates(monto, minimo, inversionista_id);
+      const allCandidates = await getCreditCandidates(monto, minimo, inversionista_id, porcentaje);
 
       let result: CreditCandidate[];
 

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -761,7 +761,8 @@ function InvestorCard({
   const editingCredit = investor.creditosPendientes.find((c) => c.id === editingCreditId);
 
   const montoParaCandidatos = editingCredit ? Number(editingCredit.monto_aportado) : null;
-  const { data: candidates, isLoading: isLoadingCandidates } = useCreditCandidates(montoParaCandidatos, investor.inversionista_id);
+  const porcentajeParaCandidatos = editingCredit ? (Number(editingCredit.porcentaje_participacion_inversionista) || undefined) : undefined;
+  const { data: candidates, isLoading: isLoadingCandidates } = useCreditCandidates(montoParaCandidatos, investor.inversionista_id, porcentajeParaCandidatos);
 
   const destinos = useMemo(() => {
     if (!editingCreditId || !candidates) return [];

--- a/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts
@@ -71,10 +71,10 @@ export function useReemplazarInversionistaCredito() {
   });
 }
 
-export function useCreditCandidates(monto: number | null, inversionista_id?: number) {
+export function useCreditCandidates(monto: number | null, inversionista_id?: number, porcentaje?: number) {
   return useQuery<OtroCreditoDisponible[]>({
-    queryKey: [...creditCandidatesKeys.all, monto, inversionista_id] as const,
-    queryFn: () => getCreditCandidatesService({ monto: monto!, inversionista_id }),
+    queryKey: [...creditCandidatesKeys.all, monto, inversionista_id, porcentaje] as const,
+    queryFn: () => getCreditCandidatesService({ monto: monto!, inversionista_id, porcentaje }),
     enabled: monto !== null && monto > 0,
     staleTime: 1000 * 60 * 2,
     gcTime: 1000 * 60 * 5,

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3927,10 +3927,10 @@ export interface CandidatesResponse {
   candidates: OtroCreditoDisponible[];
 }
 
-export async function getCreditCandidatesService(params?: { monto?: number; minimo?: number; inversionista_id?: number }): Promise<OtroCreditoDisponible[]> {
+export async function getCreditCandidatesService(params?: { monto?: number; minimo?: number; inversionista_id?: number; porcentaje?: number }): Promise<OtroCreditoDisponible[]> {
   const res = await api.get<CandidatesResponse>(
     `${API_URL}/assign-capital/candidates`,
-    { params: { monto: params?.monto, minimo: params?.minimo ?? 10, inversionista_id: params?.inversionista_id } }
+    { params: { monto: params?.monto, minimo: params?.minimo ?? 10, inversionista_id: params?.inversionista_id, porcentaje: params?.porcentaje } }
   );
   return res.data.candidates;
 }


### PR DESCRIPTION
# feat(assignCapital): filtro de porcentaje para prevenir auto-compra con términos distintos

## Resumen

Agrega un parámetro opcional `porcentaje` al motor de selección de
créditos candidatos para prevenir que un inversionista se compre a sí
mismo en términos distintos a los que ya tiene en un crédito.

---

## Problema

Un inversionista con participación existente al 70% podía recibir el
mismo crédito como candidato para una compra al 80%. Esto generaría dos
registros contradictorios en `creditos_inversionistas` para el mismo
crédito e inversionista, con porcentajes distintos.

---

## Cambios

### `apps/cartera-back/src/controllers/assignCapital.ts`

**Firma actualizada:**
```ts
export async function getCreditCandidates(
  monto?: number,
  limit?: number,
  inversionistaIdSolicitante?: number,
  porcentaje?: number   // nuevo, opcional
): Promise<CreditCandidate[]>
```

**`invRows` query — campo adicional:**
```ts
porcentaje_participacion_inversionista:
  creditos_inversionistas.porcentaje_participacion_inversionista,
```

**Detección de mismatch en el loop de `invRows` (sin round-trip extra):**
```ts
const porcentajeMismatchSet = new Set<number>();

// dentro del for (const row of invRows):
if (
  inversionistaIdSolicitante !== undefined &&
  porcentaje !== undefined &&
  row.inversionista_id === inversionistaIdSolicitante &&
  Number(row.monto_aportado) > 0 &&
  Number(row.porcentaje_participacion_inversionista) !== porcentaje
) {
  if (row.credito_id !== null) porcentajeMismatchSet.add(row.credito_id);
}
```

Reutiliza la query existente del paso 4; no agrega ninguna consulta
adicional a la base de datos.

**Filtro en el loop principal (después de `cuotasVencidasSet`):**
```ts
if (porcentajeMismatchSet.has(credito_id)) {
  console.log(`   ❌ [${numero_credito_sifco}] Descartado: inversionista ya participa con porcentaje distinto`);
  continue;
}
```

Si `inversionistaIdSolicitante` o `porcentaje` no vienen, el set queda
vacío y el filtro no afecta nada — comportamiento idéntico al anterior.

---

### `apps/cartera-back/src/routers/assignCapital.ts`

Nuevo query param opcional `porcentaje` con validación y pass-through:

```ts
const { ..., porcentaje: porcentajeStr } = query as Record<string, string | undefined>;

let porcentaje: number | undefined;
if (porcentajeStr !== undefined) {
  const parsed = Number(porcentajeStr);
  if (isNaN(parsed) || parsed <= 0 || parsed > 100) {
    set.status = 400;
    return { ok: false, message: "El parámetro 'porcentaje' debe ser un número mayor a 0 y máximo 100." };
  }
  porcentaje = parsed;
}

const allCandidates = await getCreditCandidates(monto, minimo, inversionista_id, porcentaje);
```

---

### `apps/cartera-back/src/controllers/addInvestorToCredit.ts`

`porcentaje_inversion` ya venía en el body del request. Se pasa como
cuarto argumento al call interno de `getCreditCandidates`, activando el
filtro automáticamente en el flujo de asignación directa:

```ts
// antes:
let candidatos = await getCreditCandidates(monto_aportado, minimo, inversionista_id);
// después:
let candidatos = await getCreditCandidates(monto_aportado, minimo, inversionista_id, porcentaje_inversion);
```

---

### `apps/carteraFront/src/private/cartera/services/services.ts`

`getCreditCandidatesService` acepta y envía `porcentaje`:

```ts
export async function getCreditCandidatesService(params?: {
  monto?: number;
  minimo?: number;
  inversionista_id?: number;
  porcentaje?: number;  // nuevo
}): Promise<OtroCreditoDisponible[]> {
  const res = await api.get<CandidatesResponse>(
    `${API_URL}/assign-capital/candidates`,
    { params: { monto: params?.monto, minimo: params?.minimo ?? 10, inversionista_id: params?.inversionista_id, porcentaje: params?.porcentaje } }
  );
  return res.data.candidates;
}
```

---

### `apps/carteraFront/src/private/cartera/hooks/useSesionesPendientes.ts`

`useCreditCandidates` acepta `porcentaje`, lo incluye en el `queryKey`
y lo pasa al service:

```ts
export function useCreditCandidates(
  monto: number | null,
  inversionista_id?: number,
  porcentaje?: number   // nuevo
) {
  return useQuery<OtroCreditoDisponible[]>({
    queryKey: [...creditCandidatesKeys.all, monto, inversionista_id, porcentaje] as const,
    queryFn: () => getCreditCandidatesService({ monto: monto!, inversionista_id, porcentaje }),
    enabled: monto !== null && monto > 0,
    staleTime: 1000 * 60 * 2,
    gcTime: 1000 * 60 * 5,
  });
}
```

---

### `apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx`

Se extrae el porcentaje del crédito en edición y se pasa al hook. Guard
contra `NaN` para evitar enviar un 400 cuando el valor viene nulo o vacío:

```ts
const porcentajeParaCandidatos = editingCredit
  ? (Number(editingCredit.porcentaje_participacion_inversionista) || undefined)
  : undefined;

const { data: candidates, isLoading: isLoadingCandidates } = useCreditCandidates(
  montoParaCandidatos,
  investor.inversionista_id,
  porcentajeParaCandidatos
);
```

---

## Comportamiento cuando no viene `porcentaje`

Sin el parámetro, `porcentajeMismatchSet` queda vacío y el filtro no
corre. El endpoint y el hook son 100% retrocompatibles.

---

## Plan de prueba

- [ ] `GET /assign-capital/candidates?inversionista_id=74&porcentaje=80` — créditos donde inv 74 ya tiene 80% aparecen; créditos donde tiene porcentaje distinto no aparecen
- [ ] Sin `porcentaje` — comportamiento idéntico al anterior
- [ ] `porcentaje=0` o `porcentaje=101` retorna 400 con mensaje claro
- [ ] `porcentaje_participacion_inversionista` nulo en frontend → `undefined`, no `NaN`, no 400
