### PR TITLE
feat(cartera): tablas de facturación diaria + desglose CUBE al facturar

### DIFF
--- a/apps/cartera-back/drizzle/0007_add_facturacion_desglose.sql
+++ b/apps/cartera-back/drizzle/0007_add_facturacion_desglose.sql
@@ -1,0 +1,33 @@
+-- Desglose por rubro de LO QUE FACTURA CUBE en cada pago, para el reporte
+-- diario de facturación (matriz categoría × rubro × día).
+--   - 1 fila por (pago_id, rubro).
+--   - INTERES = residuo CUBE CON IVA (totalCube de /facturar-pago-completo).
+--   - CAPITAL no se factura -> factura_id NULL, monto_iva 0.
+--   - monto_total incluye IVA (misma convención que facturas_electronicas).
+--   - fecha_aplicado_gt = fecha_aplicado del pago en zona America/Guatemala.
+--   - La categoría NO se guarda: sale por JOIN pago -> crédito -> usuario.
+
+DO $$ BEGIN
+  CREATE TYPE cartera.rubro_facturacion AS ENUM (
+    'CAPITAL','INTERES','MEMBRESIA','SEGURO','GPS','MORA','OTROS'
+  );
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+CREATE TABLE IF NOT EXISTS cartera.facturacion_desglose (
+  id                serial PRIMARY KEY,
+  pago_id           integer NOT NULL REFERENCES cartera.pagos_credito(pago_id) ON DELETE CASCADE,
+  factura_id        integer REFERENCES cartera.facturas_electronicas(factura_id) ON DELETE SET NULL,
+  rubro             cartera.rubro_facturacion NOT NULL,
+  monto_total       numeric(18,2) NOT NULL DEFAULT 0,   -- con IVA incluido
+  monto_iva         numeric(18,2) NOT NULL DEFAULT 0,
+  fecha_aplicado_gt date,                                -- fecha_aplicado en America/Guatemala
+  created_at        timestamp NOT NULL DEFAULT now()
+);
+
+-- 1 fila por (pago, rubro) -> permite upsert idempotente al re-facturar.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facturacion_desglose_pago_rubro
+  ON cartera.facturacion_desglose (pago_id, rubro);
+
+-- El reporte filtra por día.
+CREATE INDEX IF NOT EXISTS idx_facturacion_desglose_fecha
+  ON cartera.facturacion_desglose (fecha_aplicado_gt);

--- a/apps/cartera-back/drizzle/0008_add_gastos_admin_metas.sql
+++ b/apps/cartera-back/drizzle/0008_add_gastos_admin_metas.sql
@@ -1,0 +1,35 @@
+-- Gastos administrativos (manuales, itemizados por día) y metas financieras
+-- (manuales, por año/mes) para el reporte diario de facturación.
+
+-- 🧾 Gastos administrativos: varios por día (concepto + monto). El reporte suma por día.
+CREATE TABLE IF NOT EXISTS cartera.gastos_administrativos (
+  id          serial PRIMARY KEY,
+  fecha       date NOT NULL,                       -- fecha del gasto (America/Guatemala)
+  concepto    varchar(200) NOT NULL,
+  monto       numeric(18,2) NOT NULL DEFAULT 0,
+  created_at  timestamp NOT NULL DEFAULT now(),
+  created_by  integer
+);
+
+CREATE INDEX IF NOT EXISTS idx_gastos_admin_fecha
+  ON cartera.gastos_administrativos (fecha);
+
+-- 🎯 Metas financieras por (año, mes). Globales (no por categoría).
+--    meta_mensual/semanal/diaria capturadas por separado; deuda_* opcionales.
+CREATE TABLE IF NOT EXISTS cartera.metas_facturacion (
+  id             serial PRIMARY KEY,
+  anio           integer NOT NULL,
+  mes            integer NOT NULL,                 -- 1-12
+  meta_mensual   numeric(18,2) NOT NULL DEFAULT 0,
+  meta_semanal   numeric(18,2) NOT NULL DEFAULT 0,
+  meta_diaria    numeric(18,2) NOT NULL DEFAULT 0, -- aplica a cada día del mes
+  deuda_mensual  numeric(18,2),
+  deuda_semanal  numeric(18,2),
+  deuda_diaria   numeric(18,2),
+  created_at     timestamp NOT NULL DEFAULT now(),
+  updated_at     timestamp NOT NULL DEFAULT now()
+);
+
+-- 1 fila por (año, mes) -> permite upsert.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_metas_facturacion_anio_mes
+  ON cartera.metas_facturacion (anio, mes);

--- a/apps/cartera-back/drizzle/0009_add_facturacion_snapshot_diario.sql
+++ b/apps/cartera-back/drizzle/0009_add_facturacion_snapshot_diario.sql
@@ -1,0 +1,93 @@
+-- Snapshot diario tipo Excel "Reuniones diarias" -> hoja Facturación.
+-- 1 fila por día (columnas A→BK), congeladas. Money = numeric(18,2).
+CREATE TABLE IF NOT EXISTS cartera.facturacion_snapshot_diario (
+  id                          serial PRIMARY KEY,
+  fecha                       date NOT NULL,
+  anio                        integer,
+  mes                         integer,
+
+  -- Capital (B–H)
+  cap_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  cap_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_cap_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  cap_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  cap_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  cap_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  capital_total               numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Interés (I–O)
+  int_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  int_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_int_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  int_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  int_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  int_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  interes_cube                numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Membresía (P–V)
+  mem_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  mem_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_mem_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  mem_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  mem_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  mem_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  membresia                   numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Otros ingresos (W–AE)
+  oi_autocompras              numeric(18,2) NOT NULL DEFAULT 0,
+  oi_sobre_vehiculo           numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_oi_autocompras        numeric(18,2) NOT NULL DEFAULT 0,
+  oi_hipotecario              numeric(18,2) NOT NULL DEFAULT 0,
+  oi_extra_financiamiento     numeric(18,2) NOT NULL DEFAULT 0,
+  oi_reestructura             numeric(18,2) NOT NULL DEFAULT 0,
+  otros_ingresos              numeric(18,2) NOT NULL DEFAULT 0,
+  administrativos             numeric(18,2) NOT NULL DEFAULT 0,
+  otros_cobros                numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Mora (AF–AL)
+  mora_autocompras            numeric(18,2) NOT NULL DEFAULT 0,
+  mora_sobre_vehiculo         numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_mora_autocompras      numeric(18,2) NOT NULL DEFAULT 0,
+  mora_hipotecario            numeric(18,2) NOT NULL DEFAULT 0,
+  mora_extra_financiamiento   numeric(18,2) NOT NULL DEFAULT 0,
+  mora_reestructura           numeric(18,2) NOT NULL DEFAULT 0,
+  mora_cube                   numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Royalty (AM–AS)
+  roy_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  roy_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_roy_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  roy_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  roy_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  roy_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  royalty                     numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Totales / acumulados (AT–BE)
+  facturacion                 numeric(18,2) NOT NULL DEFAULT 0,
+  facturacion_acumulado       numeric(18,2) NOT NULL DEFAULT 0,
+  servicios_seguro_gps        numeric(18,2) NOT NULL DEFAULT 0,
+  acum_servicios_seguro_gps   numeric(18,2) NOT NULL DEFAULT 0,
+  facturacion_mas_servicios   numeric(18,2) NOT NULL DEFAULT 0,
+  acumulado_total             numeric(18,2) NOT NULL DEFAULT 0,
+  facturacion_inversionistas  numeric(18,2) NOT NULL DEFAULT 0,
+  acumulado_inversionistas    numeric(18,2) NOT NULL DEFAULT 0,
+  tendencia_fin_mes           numeric(18,2) NOT NULL DEFAULT 0,
+  tendencia_semanal           numeric(18,2) NOT NULL DEFAULT 0,
+  ingreso_carros              numeric(18,2) NOT NULL DEFAULT 0,
+  reserva_acumulada           numeric(18,2) NOT NULL DEFAULT 0,
+  semana                      integer,
+
+  -- Metas (BG–BK)
+  meta_facturacion_mensual    numeric(18,2) NOT NULL DEFAULT 0,
+  meta_facturacion_semanal    numeric(18,2) NOT NULL DEFAULT 0,
+  meta_facturacion_diaria     numeric(18,2) NOT NULL DEFAULT 0,
+  porcentaje_meta_mensual     numeric(9,4)  NOT NULL DEFAULT 0,
+  meta_diaria                 numeric(18,2) NOT NULL DEFAULT 0,
+
+  created_at                  timestamp NOT NULL DEFAULT now(),
+  updated_at                  timestamp NOT NULL DEFAULT now()
+);
+
+-- 1 fila por día -> permite upsert (regenerar el snapshot del día).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facturacion_snapshot_diario_fecha
+  ON cartera.facturacion_snapshot_diario (fecha);

--- a/apps/cartera-back/drizzle/0010_add_ingresos_carros.sql
+++ b/apps/cartera-back/drizzle/0010_add_ingresos_carros.sql
@@ -1,0 +1,13 @@
+-- Ingresos por carros (manuales, itemizados por día) para el reporte diario
+-- de facturación (columna "Ingreso Carros" del Excel). El snapshot suma por día.
+CREATE TABLE IF NOT EXISTS cartera.ingresos_carros (
+  id          serial PRIMARY KEY,
+  fecha       date NOT NULL,                       -- America/Guatemala
+  concepto    varchar(200) NOT NULL,
+  monto       numeric(18,2) NOT NULL DEFAULT 0,
+  created_at  timestamp NOT NULL DEFAULT now(),
+  created_by  integer
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingresos_carros_fecha
+  ON cartera.ingresos_carros (fecha);

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -54,6 +54,17 @@
     "VERIFICADO",
     "RECHAZADO"
   ]);
+
+  // 🧾 Rubros del desglose de facturación (lo que factura CUBE) para el reporte diario.
+  export const rubroFacturacionEnum = customSchema.enum("rubro_facturacion", [
+    "CAPITAL",
+    "INTERES",
+    "MEMBRESIA",
+    "SEGURO",
+    "GPS",
+    "MORA",
+    "OTROS",
+  ]);
   export const admins = customSchema.table("admins", {
     admin_id: serial("admin_id").primaryKey(),
     nombre: varchar("nombre", { length: 150 }).notNull(),
@@ -1077,6 +1088,231 @@
     created_at: timestamp("created_at").defaultNow().notNull(),
     created_by: integer("created_by").references(() => platform_users.id),
   });
+
+  // ============================================
+  // 🧾 TABLA: facturacion_desglose
+  //    Desglose por rubro de LO QUE FACTURA CUBE en cada pago, para el
+  //    reporte diario de facturación (matriz categoría × rubro × día).
+  //    - 1 fila por (pago_id, rubro).
+  //    - INTERES = residuo CUBE CON IVA (totalCube de /facturar-pago-completo).
+  //    - CAPITAL no se factura → factura_id NULL, monto_iva 0.
+  //    - monto_total incluye IVA (misma convención que facturas_electronicas).
+  //    - fecha_aplicado_gt = fecha_aplicado del pago en zona America/Guatemala.
+  //    - La categoría NO se guarda: sale por JOIN pago→crédito→usuario.
+  // ============================================
+  export const facturacion_desglose = customSchema.table(
+    "facturacion_desglose",
+    {
+      id: serial("id").primaryKey(),
+      pago_id: integer("pago_id")
+        .notNull()
+        .references(() => pagos_credito.pago_id, { onDelete: "cascade" }),
+      factura_id: integer("factura_id").references(
+        () => facturas_electronicas.factura_id,
+        { onDelete: "set null" }
+      ),
+      rubro: rubroFacturacionEnum("rubro").notNull(),
+      monto_total: numeric("monto_total", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"), // con IVA incluido
+      monto_iva: numeric("monto_iva", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      fecha_aplicado_gt: date("fecha_aplicado_gt"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqPagoRubro: uniqueIndex("uq_facturacion_desglose_pago_rubro").on(
+        table.pago_id,
+        table.rubro
+      ),
+      idxFecha: index("idx_facturacion_desglose_fecha").on(
+        table.fecha_aplicado_gt
+      ),
+    })
+  );
+
+  // ============================================
+  // 🧾 TABLA: gastos_administrativos
+  //    Gastos administrativos manuales para el reporte diario de facturación.
+  //    Itemizados por día (concepto + monto). El reporte suma por día.
+  //    En el Excel: "Otros cobros" = Otros ingresos − SUM(gastos del día).
+  // ============================================
+  export const gastos_administrativos = customSchema.table(
+    "gastos_administrativos",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(), // fecha del gasto (America/Guatemala)
+      concepto: varchar("concepto", { length: 200 }).notNull(),
+      monto: numeric("monto", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      created_by: integer("created_by"),
+    },
+    (table) => ({
+      idxFecha: index("idx_gastos_admin_fecha").on(table.fecha),
+    })
+  );
+
+  // ============================================
+  // 🚗 TABLA: ingresos_carros
+  //    Ingresos por carros manuales para el reporte diario (columna "Ingreso
+  //    Carros" del Excel). Itemizados por día. El snapshot suma por día.
+  // ============================================
+  export const ingresos_carros = customSchema.table(
+    "ingresos_carros",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(), // America/Guatemala
+      concepto: varchar("concepto", { length: 200 }).notNull(),
+      monto: numeric("monto", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      created_by: integer("created_by"),
+    },
+    (table) => ({
+      idxFecha: index("idx_ingresos_carros_fecha").on(table.fecha),
+    })
+  );
+
+  // ============================================
+  // 🎯 TABLA: metas_facturacion
+  //    Metas financieras manuales por (año, mes). Globales (no por categoría).
+  //    - meta_mensual/semanal/diaria se capturan por separado.
+  //    - meta_diaria aplica a cada día del mes.
+  //    - deuda_* opcionales (mismo bloque del Excel).
+  // ============================================
+  export const metas_facturacion = customSchema.table(
+    "metas_facturacion",
+    {
+      id: serial("id").primaryKey(),
+      anio: integer("anio").notNull(),
+      mes: integer("mes").notNull(), // 1-12
+      meta_mensual: numeric("meta_mensual", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      meta_semanal: numeric("meta_semanal", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      meta_diaria: numeric("meta_diaria", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      deuda_mensual: numeric("deuda_mensual", { precision: 18, scale: 2 }),
+      deuda_semanal: numeric("deuda_semanal", { precision: 18, scale: 2 }),
+      deuda_diaria: numeric("deuda_diaria", { precision: 18, scale: 2 }),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      updated_at: timestamp("updated_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqAnioMes: uniqueIndex("uq_metas_facturacion_anio_mes").on(
+        table.anio,
+        table.mes
+      ),
+    })
+  );
+
+  // ============================================
+  // 📸 TABLA: facturacion_snapshot_diario
+  //    Snapshot diario tipo Excel "Reuniones diarias" → hoja Facturación.
+  //    1 fila por día (columnas A→BK del Excel), congeladas.
+  //    Se llena con endpoint manual + job de respaldo si el día no se guardó.
+  //    Money = numeric(18,2). Sufijos de producto = categoría del crédito.
+  // ============================================
+  export const facturacion_snapshot_diario = customSchema.table(
+    "facturacion_snapshot_diario",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(), // A — día (America/Guatemala)
+      anio: integer("anio"), // helper
+      mes: integer("mes"), // helper
+
+      // 💰 Capital (B–H)
+      cap_autocompras: numeric("cap_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_sobre_vehiculo: numeric("cap_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_cap_autocompras: numeric("nuevo_cap_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_hipotecario: numeric("cap_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_extra_financiamiento: numeric("cap_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_reestructura: numeric("cap_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      capital_total: numeric("capital_total", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 💵 Interés (I–O)
+      int_autocompras: numeric("int_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_sobre_vehiculo: numeric("int_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_int_autocompras: numeric("nuevo_int_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_hipotecario: numeric("int_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_extra_financiamiento: numeric("int_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_reestructura: numeric("int_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      interes_cube: numeric("interes_cube", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 🎟️ Membresía (P–V)
+      mem_autocompras: numeric("mem_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_sobre_vehiculo: numeric("mem_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_mem_autocompras: numeric("nuevo_mem_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_hipotecario: numeric("mem_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_extra_financiamiento: numeric("mem_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_reestructura: numeric("mem_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      membresia: numeric("membresia", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 📦 Otros ingresos (W–AE)
+      oi_autocompras: numeric("oi_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_sobre_vehiculo: numeric("oi_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_oi_autocompras: numeric("nuevo_oi_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_hipotecario: numeric("oi_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_extra_financiamiento: numeric("oi_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_reestructura: numeric("oi_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      otros_ingresos: numeric("otros_ingresos", { precision: 18, scale: 2 }).notNull().default("0"),
+      administrativos: numeric("administrativos", { precision: 18, scale: 2 }).notNull().default("0"),
+      otros_cobros: numeric("otros_cobros", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // ⚠️ Mora (AF–AL)
+      mora_autocompras: numeric("mora_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_sobre_vehiculo: numeric("mora_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_mora_autocompras: numeric("nuevo_mora_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_hipotecario: numeric("mora_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_extra_financiamiento: numeric("mora_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_reestructura: numeric("mora_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_cube: numeric("mora_cube", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 👑 Royalty (AM–AS)
+      roy_autocompras: numeric("roy_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_sobre_vehiculo: numeric("roy_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_roy_autocompras: numeric("nuevo_roy_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_hipotecario: numeric("roy_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_extra_financiamiento: numeric("roy_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_reestructura: numeric("roy_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      royalty: numeric("royalty", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 📊 Totales / acumulados (AT–BE)
+      facturacion: numeric("facturacion", { precision: 18, scale: 2 }).notNull().default("0"),
+      facturacion_acumulado: numeric("facturacion_acumulado", { precision: 18, scale: 2 }).notNull().default("0"),
+      servicios_seguro_gps: numeric("servicios_seguro_gps", { precision: 18, scale: 2 }).notNull().default("0"),
+      acum_servicios_seguro_gps: numeric("acum_servicios_seguro_gps", { precision: 18, scale: 2 }).notNull().default("0"),
+      facturacion_mas_servicios: numeric("facturacion_mas_servicios", { precision: 18, scale: 2 }).notNull().default("0"),
+      acumulado_total: numeric("acumulado_total", { precision: 18, scale: 2 }).notNull().default("0"),
+      facturacion_inversionistas: numeric("facturacion_inversionistas", { precision: 18, scale: 2 }).notNull().default("0"),
+      acumulado_inversionistas: numeric("acumulado_inversionistas", { precision: 18, scale: 2 }).notNull().default("0"),
+      tendencia_fin_mes: numeric("tendencia_fin_mes", { precision: 18, scale: 2 }).notNull().default("0"),
+      tendencia_semanal: numeric("tendencia_semanal", { precision: 18, scale: 2 }).notNull().default("0"),
+      ingreso_carros: numeric("ingreso_carros", { precision: 18, scale: 2 }).notNull().default("0"),
+      reserva_acumulada: numeric("reserva_acumulada", { precision: 18, scale: 2 }).notNull().default("0"),
+      semana: integer("semana"), // BF
+
+      // 🎯 Metas (BG–BK)
+      meta_facturacion_mensual: numeric("meta_facturacion_mensual", { precision: 18, scale: 2 }).notNull().default("0"),
+      meta_facturacion_semanal: numeric("meta_facturacion_semanal", { precision: 18, scale: 2 }).notNull().default("0"),
+      meta_facturacion_diaria: numeric("meta_facturacion_diaria", { precision: 18, scale: 2 }).notNull().default("0"),
+      porcentaje_meta_mensual: numeric("porcentaje_meta_mensual", { precision: 9, scale: 4 }).notNull().default("0"),
+      meta_diaria: numeric("meta_diaria", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      updated_at: timestamp("updated_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqFecha: uniqueIndex("uq_facturacion_snapshot_diario_fecha").on(table.fecha),
+    })
+  );
 
   // ============================================
   // 🆕 TABLA: facturas_fallidas_sat

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -932,6 +932,11 @@ if (facturasExistentes.length > 0) {
       // ============================================
       const hayInteresEnPago = new Big(pagoData.abono_interes || "0").gt(0);
 
+      // 🧾 Interés que finalmente factura CUBE (residuo + cash_in), CON IVA.
+      //    Se setea dentro de cada flujo (estándar/prorrateado) y se usa al
+      //    final para guardar el rubro INTERES en facturacion_desglose.
+      let interesCubeConIva = new Big(0);
+
       if (!hayInteresEnPago) {
         console.log("\n⏭️  NO hay intereses en este pago - Saltando facturas de intereses (ambos flujos)");
       } else if (tieneOperacionesPendientesFacturar) {
@@ -1278,6 +1283,9 @@ if (facturasExistentes.length > 0) {
 
           // Total que va a CUBE = lo de las DOS ventanas sumado.
           const totalCubeFinal = repartoAntes.totalCubeParcial.plus(repartoDespues.totalCubeParcial);
+
+          // 🧾 Guardar para el desglose de facturación (rubro INTERES, con IVA).
+          interesCubeConIva = totalCubeFinal;
 
           // Set con todos los IDs de inversionistas que aparecieron en cualquier
           // ventana (algunos podrían tener parte solo en una de las dos).
@@ -1747,6 +1755,9 @@ if (facturasExistentes.length > 0) {
 
         const totalCube = cubePropio.plus(cashInAcumulado);
 
+        // 🧾 Guardar para el desglose de facturación (rubro INTERES, con IVA).
+        interesCubeConIva = totalCube;
+
         console.log(`   📊 Cash-in acumulado de otros: Q${cashInAcumulado.toFixed(2)}`);
         console.log(`   💵 Total CUBE: Q${totalCube.toFixed(2)} (residuo + cash_in)`);
 
@@ -1846,12 +1857,119 @@ if (facturasExistentes.length > 0) {
         `✅ Exitosas: ${facturasExitosas.length} | ❌ Errores: ${facturasConError.length}`
       );
 
-      if (facturasExitosas.length === 0) {
+      // ⛔ Si NO se generó ninguna factura y hubo errores de certificación, es un
+      //    fallo real: NO escribimos el desglose (no se facturó nada de verdad).
+      if (facturasExitosas.length === 0 && facturasConError.length > 0) {
         set.status = 500;
         return {
           success: false,
           error: "No se pudo generar ninguna factura",
           errores: facturasConError,
+        };
+      }
+
+      // ============================================
+      // 🧾 DESGLOSE DE FACTURACIÓN (reporte diario)
+      //    Guarda 1 fila por (pago, rubro) con LO QUE FACTURA CUBE, con IVA.
+      //    - INTERES = interesCubeConIva (residuo + cash_in, ya con IVA).
+      //    - Resto de rubros = abono del pago tratado como total con IVA.
+      //    - CAPITAL no se factura: factura_id NULL, monto_iva 0.
+      //    - fecha_aplicado_gt se calcula en SQL (zona America/Guatemala).
+      //    Best-effort: si falla, NO rompe la facturación (solo loguea).
+      // ============================================
+      let rubrosGuardados = 0;
+      try {
+        const rubrosDesglose: {
+          rubro: string;
+          monto_total: string;
+          monto_iva: string;
+        }[] = [];
+
+        const pushRubro = (
+          rubro: string,
+          totalConIva: any,
+          gravadoIva: boolean
+        ) => {
+          const t = new Big(totalConIva || 0);
+          if (t.lte(0)) return;
+          const iva = gravadoIva
+            ? new Big(calcularIvaExacto(parseFloat(t.toFixed(2))).montoImpuesto)
+            : new Big(0);
+          rubrosDesglose.push({
+            rubro,
+            monto_total: t.toFixed(2),
+            monto_iva: iva.toFixed(2),
+          });
+        };
+
+        // 💰 Capital de CUBE: NO es el abono_capital total del pago, sino la
+        //    porción de CUBE en pagos_credito_inversionistas (el capital sí se
+        //    reparte y se guarda por inversionista). Solo guardamos lo de CUBE.
+        const capCubeRes = await db.execute(sql`
+          SELECT COALESCE(SUM(pci.abono_capital), 0) AS capital_cube
+          FROM cartera.pagos_credito_inversionistas pci
+          JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+          WHERE pci.pago_id = ${pago_id}
+            AND UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
+        `);
+        const capitalCube = (capCubeRes as any).rows?.[0]?.capital_cube ?? 0;
+
+        pushRubro("CAPITAL", capitalCube, false); // solo capital de CUBE (de pci), sin IVA
+        pushRubro("INTERES", interesCubeConIva, true); // residuo CUBE, ya con IVA
+        pushRubro("MEMBRESIA", pagoData.membresias_pago, true);
+        pushRubro("SEGURO", pagoData.abono_seguro, true);
+        pushRubro("GPS", pagoData.abono_gps, true);
+        pushRubro("MORA", pagoData.mora, true);
+        pushRubro("OTROS", pagoData.otros, true);
+
+        await db.transaction(async (tx) => {
+          // Reemplazar para que re-facturar no duplique ni deje rubros viejos.
+          await tx.execute(
+            sql`DELETE FROM cartera.facturacion_desglose WHERE pago_id = ${pago_id}`
+          );
+          for (const r of rubrosDesglose) {
+            await tx.execute(sql`
+              INSERT INTO cartera.facturacion_desglose
+                (pago_id, factura_id, rubro, monto_total, monto_iva, fecha_aplicado_gt)
+              VALUES (
+                ${pago_id},
+                NULL,
+                ${r.rubro}::cartera.rubro_facturacion,
+                ${r.monto_total},
+                ${r.monto_iva},
+                (SELECT (COALESCE(pc.fecha_aplicado, pc.fecha_pago) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date
+                   FROM cartera.pagos_credito pc WHERE pc.pago_id = ${pago_id})
+              )
+            `);
+          }
+        });
+
+        rubrosGuardados = rubrosDesglose.length;
+        console.log(
+          `🧾 Desglose facturación guardado: ${rubrosDesglose.length} rubro(s) para pago ${pago_id}`
+        );
+      } catch (desgloseError: any) {
+        console.error(
+          `⚠️ No se pudo guardar facturacion_desglose para pago ${pago_id} (NO afecta la facturación):`,
+          desgloseError?.message
+        );
+      }
+
+      // Pago solo-capital (sin DTE que emitir y sin errores): no es fallo.
+      // El desglose ya quedó guardado arriba (capital de CUBE).
+      if (facturasExitosas.length === 0) {
+        return {
+          success: true,
+          data: {
+            pago_id,
+            cliente: { nombre: pagoData.nombre, nit: pagoData.nit },
+            total_facturas: 0,
+            facturas: [],
+          },
+          mensaje:
+            rubrosGuardados > 0
+              ? "Sin DTE que emitir (p. ej. solo capital). Guardado en el registro diario de facturación."
+              : "Sin DTE que emitir y sin montos para el registro diario.",
         };
       }
 


### PR DESCRIPTION
## 🎯 Qué hace
Capa de datos del nuevo módulo **Facturación Diaria** + captura del **desglose de lo que factura CUBE** en cada pago.

## 📦 Cambios
- **Migraciones `0007`–`0010`** (aditivas e idempotentes, `IF NOT EXISTS`):
  - `facturacion_desglose` (+ enum `rubro_facturacion`)
  - `gastos_administrativos`, `metas_facturacion`, `facturacion_snapshot_diario`, `ingresos_carros`
- **`schema.ts`**: definiciones Drizzle de las 5 tablas.
- **`cofidi.ts` (`/facturar-pago-completo`)**: al facturar guarda 1 fila por rubro de **lo que factura CUBE**:
  - `INTERES` = residuo de CUBE **con IVA** (mismo cálculo del endpoint).
  - `CAPITAL` = porción de CUBE desde `pagos_credito_inversionistas`.
  - `MEMBRESIA / SEGURO / GPS / MORA / OTROS` desde los abonos del pago.
  - Fecha en zona **America/Guatemala** (`COALESCE(fecha_aplicado, fecha_pago)`).
  - **Best-effort**: si el insert falla NO rompe la facturación; y **no se guarda si todas las facturas fallan**.
  - Pago **solo-capital** responde éxito con "registro diario" (antes daba 500).

## 🧪 Pruebas
- Probado en local (DB Docker) en modo `SIMULAR_FACTURAS=true`: desglose correcto (interés CUBE = total − inversionistas, IVA, fecha GT), capital de CUBE, solo-capital OK.
- `tsc` sin errores nuevos.

## ⚠️ Nota de despliegue
Las 5 tablas **ya existen en prod** (migraciones aplicadas manualmente, idempotentes). Re-correrlas es seguro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)