### PR TITLE
feat(cartera): API de reporte de facturación diaria (snapshot, gastos, metas, carros)

### DIFF
--- a/apps/cartera-back/drizzle/0007_add_facturacion_desglose.sql
+++ b/apps/cartera-back/drizzle/0007_add_facturacion_desglose.sql
@@ -1,0 +1,33 @@
+-- Desglose por rubro de LO QUE FACTURA CUBE en cada pago, para el reporte
+-- diario de facturación (matriz categoría × rubro × día).
+--   - 1 fila por (pago_id, rubro).
+--   - INTERES = residuo CUBE CON IVA (totalCube de /facturar-pago-completo).
+--   - CAPITAL no se factura -> factura_id NULL, monto_iva 0.
+--   - monto_total incluye IVA (misma convención que facturas_electronicas).
+--   - fecha_aplicado_gt = fecha_aplicado del pago en zona America/Guatemala.
+--   - La categoría NO se guarda: sale por JOIN pago -> crédito -> usuario.
+
+DO $$ BEGIN
+  CREATE TYPE cartera.rubro_facturacion AS ENUM (
+    'CAPITAL','INTERES','MEMBRESIA','SEGURO','GPS','MORA','OTROS'
+  );
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+CREATE TABLE IF NOT EXISTS cartera.facturacion_desglose (
+  id                serial PRIMARY KEY,
+  pago_id           integer NOT NULL REFERENCES cartera.pagos_credito(pago_id) ON DELETE CASCADE,
+  factura_id        integer REFERENCES cartera.facturas_electronicas(factura_id) ON DELETE SET NULL,
+  rubro             cartera.rubro_facturacion NOT NULL,
+  monto_total       numeric(18,2) NOT NULL DEFAULT 0,   -- con IVA incluido
+  monto_iva         numeric(18,2) NOT NULL DEFAULT 0,
+  fecha_aplicado_gt date,                                -- fecha_aplicado en America/Guatemala
+  created_at        timestamp NOT NULL DEFAULT now()
+);
+
+-- 1 fila por (pago, rubro) -> permite upsert idempotente al re-facturar.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facturacion_desglose_pago_rubro
+  ON cartera.facturacion_desglose (pago_id, rubro);
+
+-- El reporte filtra por día.
+CREATE INDEX IF NOT EXISTS idx_facturacion_desglose_fecha
+  ON cartera.facturacion_desglose (fecha_aplicado_gt);

--- a/apps/cartera-back/drizzle/0008_add_gastos_admin_metas.sql
+++ b/apps/cartera-back/drizzle/0008_add_gastos_admin_metas.sql
@@ -1,0 +1,35 @@
+-- Gastos administrativos (manuales, itemizados por día) y metas financieras
+-- (manuales, por año/mes) para el reporte diario de facturación.
+
+-- 🧾 Gastos administrativos: varios por día (concepto + monto). El reporte suma por día.
+CREATE TABLE IF NOT EXISTS cartera.gastos_administrativos (
+  id          serial PRIMARY KEY,
+  fecha       date NOT NULL,                       -- fecha del gasto (America/Guatemala)
+  concepto    varchar(200) NOT NULL,
+  monto       numeric(18,2) NOT NULL DEFAULT 0,
+  created_at  timestamp NOT NULL DEFAULT now(),
+  created_by  integer
+);
+
+CREATE INDEX IF NOT EXISTS idx_gastos_admin_fecha
+  ON cartera.gastos_administrativos (fecha);
+
+-- 🎯 Metas financieras por (año, mes). Globales (no por categoría).
+--    meta_mensual/semanal/diaria capturadas por separado; deuda_* opcionales.
+CREATE TABLE IF NOT EXISTS cartera.metas_facturacion (
+  id             serial PRIMARY KEY,
+  anio           integer NOT NULL,
+  mes            integer NOT NULL,                 -- 1-12
+  meta_mensual   numeric(18,2) NOT NULL DEFAULT 0,
+  meta_semanal   numeric(18,2) NOT NULL DEFAULT 0,
+  meta_diaria    numeric(18,2) NOT NULL DEFAULT 0, -- aplica a cada día del mes
+  deuda_mensual  numeric(18,2),
+  deuda_semanal  numeric(18,2),
+  deuda_diaria   numeric(18,2),
+  created_at     timestamp NOT NULL DEFAULT now(),
+  updated_at     timestamp NOT NULL DEFAULT now()
+);
+
+-- 1 fila por (año, mes) -> permite upsert.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_metas_facturacion_anio_mes
+  ON cartera.metas_facturacion (anio, mes);

--- a/apps/cartera-back/drizzle/0009_add_facturacion_snapshot_diario.sql
+++ b/apps/cartera-back/drizzle/0009_add_facturacion_snapshot_diario.sql
@@ -1,0 +1,93 @@
+-- Snapshot diario tipo Excel "Reuniones diarias" -> hoja Facturación.
+-- 1 fila por día (columnas A→BK), congeladas. Money = numeric(18,2).
+CREATE TABLE IF NOT EXISTS cartera.facturacion_snapshot_diario (
+  id                          serial PRIMARY KEY,
+  fecha                       date NOT NULL,
+  anio                        integer,
+  mes                         integer,
+
+  -- Capital (B–H)
+  cap_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  cap_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_cap_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  cap_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  cap_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  cap_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  capital_total               numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Interés (I–O)
+  int_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  int_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_int_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  int_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  int_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  int_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  interes_cube                numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Membresía (P–V)
+  mem_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  mem_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_mem_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  mem_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  mem_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  mem_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  membresia                   numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Otros ingresos (W–AE)
+  oi_autocompras              numeric(18,2) NOT NULL DEFAULT 0,
+  oi_sobre_vehiculo           numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_oi_autocompras        numeric(18,2) NOT NULL DEFAULT 0,
+  oi_hipotecario              numeric(18,2) NOT NULL DEFAULT 0,
+  oi_extra_financiamiento     numeric(18,2) NOT NULL DEFAULT 0,
+  oi_reestructura             numeric(18,2) NOT NULL DEFAULT 0,
+  otros_ingresos              numeric(18,2) NOT NULL DEFAULT 0,
+  administrativos             numeric(18,2) NOT NULL DEFAULT 0,
+  otros_cobros                numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Mora (AF–AL)
+  mora_autocompras            numeric(18,2) NOT NULL DEFAULT 0,
+  mora_sobre_vehiculo         numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_mora_autocompras      numeric(18,2) NOT NULL DEFAULT 0,
+  mora_hipotecario            numeric(18,2) NOT NULL DEFAULT 0,
+  mora_extra_financiamiento   numeric(18,2) NOT NULL DEFAULT 0,
+  mora_reestructura           numeric(18,2) NOT NULL DEFAULT 0,
+  mora_cube                   numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Royalty (AM–AS)
+  roy_autocompras             numeric(18,2) NOT NULL DEFAULT 0,
+  roy_sobre_vehiculo          numeric(18,2) NOT NULL DEFAULT 0,
+  nuevo_roy_autocompras       numeric(18,2) NOT NULL DEFAULT 0,
+  roy_hipotecario             numeric(18,2) NOT NULL DEFAULT 0,
+  roy_extra_financiamiento    numeric(18,2) NOT NULL DEFAULT 0,
+  roy_reestructura            numeric(18,2) NOT NULL DEFAULT 0,
+  royalty                     numeric(18,2) NOT NULL DEFAULT 0,
+
+  -- Totales / acumulados (AT–BE)
+  facturacion                 numeric(18,2) NOT NULL DEFAULT 0,
+  facturacion_acumulado       numeric(18,2) NOT NULL DEFAULT 0,
+  servicios_seguro_gps        numeric(18,2) NOT NULL DEFAULT 0,
+  acum_servicios_seguro_gps   numeric(18,2) NOT NULL DEFAULT 0,
+  facturacion_mas_servicios   numeric(18,2) NOT NULL DEFAULT 0,
+  acumulado_total             numeric(18,2) NOT NULL DEFAULT 0,
+  facturacion_inversionistas  numeric(18,2) NOT NULL DEFAULT 0,
+  acumulado_inversionistas    numeric(18,2) NOT NULL DEFAULT 0,
+  tendencia_fin_mes           numeric(18,2) NOT NULL DEFAULT 0,
+  tendencia_semanal           numeric(18,2) NOT NULL DEFAULT 0,
+  ingreso_carros              numeric(18,2) NOT NULL DEFAULT 0,
+  reserva_acumulada           numeric(18,2) NOT NULL DEFAULT 0,
+  semana                      integer,
+
+  -- Metas (BG–BK)
+  meta_facturacion_mensual    numeric(18,2) NOT NULL DEFAULT 0,
+  meta_facturacion_semanal    numeric(18,2) NOT NULL DEFAULT 0,
+  meta_facturacion_diaria     numeric(18,2) NOT NULL DEFAULT 0,
+  porcentaje_meta_mensual     numeric(9,4)  NOT NULL DEFAULT 0,
+  meta_diaria                 numeric(18,2) NOT NULL DEFAULT 0,
+
+  created_at                  timestamp NOT NULL DEFAULT now(),
+  updated_at                  timestamp NOT NULL DEFAULT now()
+);
+
+-- 1 fila por día -> permite upsert (regenerar el snapshot del día).
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facturacion_snapshot_diario_fecha
+  ON cartera.facturacion_snapshot_diario (fecha);

--- a/apps/cartera-back/drizzle/0010_add_ingresos_carros.sql
+++ b/apps/cartera-back/drizzle/0010_add_ingresos_carros.sql
@@ -1,0 +1,13 @@
+-- Ingresos por carros (manuales, itemizados por día) para el reporte diario
+-- de facturación (columna "Ingreso Carros" del Excel). El snapshot suma por día.
+CREATE TABLE IF NOT EXISTS cartera.ingresos_carros (
+  id          serial PRIMARY KEY,
+  fecha       date NOT NULL,                       -- America/Guatemala
+  concepto    varchar(200) NOT NULL,
+  monto       numeric(18,2) NOT NULL DEFAULT 0,
+  created_at  timestamp NOT NULL DEFAULT now(),
+  created_by  integer
+);
+
+CREATE INDEX IF NOT EXISTS idx_ingresos_carros_fecha
+  ON cartera.ingresos_carros (fecha);

--- a/apps/cartera-back/schedule.ts
+++ b/apps/cartera-back/schedule.ts
@@ -7,6 +7,7 @@ import {
   verificarFacturasSat,
   reportarFacturasFallidasSat,
 } from './src/controllers/verificarFacturasSat';
+import { asegurarSnapshotDiario } from './src/controllers/facturacionSnapshot';
 
 const TZ_GUATEMALA = 'America/Guatemala';
 
@@ -18,6 +19,17 @@ function getFechaGuatemala() {
     mes: guate.getMonth() + 1,
     anio: guate.getFullYear(),
   };
+}
+
+// "YYYY-MM-DD" en hora Guatemala, con offset de días (ej. -1 = ayer).
+function getFechaGuatemalaISO(offsetDays = 0) {
+  const now = new Date();
+  const guate = new Date(now.toLocaleString('en-US', { timeZone: TZ_GUATEMALA }));
+  guate.setDate(guate.getDate() + offsetDays);
+  const y = guate.getFullYear();
+  const m = String(guate.getMonth() + 1).padStart(2, '0');
+  const d = String(guate.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
 }
 
 export function iniciarTareasProgramadas() {
@@ -95,6 +107,21 @@ export function iniciarTareasProgramadas() {
       console.log(`✅ reportarFacturasFallidasSat: enviadas=${res.enviadas}`);
     } catch (error) {
       console.error('❌ Error al ejecutar reportarFacturasFallidasSat:', error);
+    }
+  });
+
+  // 📸 Snapshot diario de facturación - 01:00 hora Guatemala (respaldo).
+  //    Genera el snapshot del DÍA ANTERIOR SOLO si no se guardó ya manualmente.
+  schedule.scheduleJob({ rule: '0 1 * * *', tz: TZ_GUATEMALA }, async () => {
+    const fecha = getFechaGuatemalaISO(-1); // ayer en GT
+    console.log(`📸 Ejecutando asegurarSnapshotDiario para ${fecha} (01:00 Guatemala)...`);
+    try {
+      const res = await asegurarSnapshotDiario(fecha);
+      console.log(
+        `✅ snapshotDiario ${fecha}: ${res.created ? 'generado' : 'ya existía'}`,
+      );
+    } catch (error) {
+      console.error('❌ Error al ejecutar asegurarSnapshotDiario:', error);
     }
   });
 

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -1,0 +1,585 @@
+import Big from "big.js";
+import ExcelJS from "exceljs";
+import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
+import { db } from "../database";
+import { facturacion_snapshot_diario } from "../database/db/schema";
+import { fetchImageBase64 } from "../utils/functions/internReportCancelations";
+
+const LOGO_URL =
+  process.env.LOGO_URL ||
+  "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
+
+// ============================================================================
+// 📸 SNAPSHOT DIARIO DE FACTURACIÓN (tipo Excel "Reuniones diarias")
+//    Calcula y CONGELA una fila por día con las columnas A→BK.
+//    Fuentes: facturacion_desglose (CUBE), creditos.royalti (royalty),
+//    gastos_administrativos, pagos_credito.reserva, pci (inversionistas),
+//    metas_facturacion. Upsert por fecha (regenerable).
+// ============================================================================
+
+// Prefijo de columna por rubro (lo que factura CUBE).
+const RUBRO_PREFIX: Record<string, string> = {
+  CAPITAL: "cap",
+  INTERES: "int",
+  MEMBRESIA: "mem",
+  OTROS: "oi",
+  MORA: "mora",
+};
+
+// categoría BD -> producto Excel (sufijo). "__NUEVO__" usa el patrón nuevo_<prefijo>_autocompras.
+// Claves NORMALIZADas (trim + lowercase) porque la data trae variantes de mayúsculas
+// (p. ej. "CV Vehículo nuevo" y "CV Vehículo Nuevo").
+// ⚠️ Pendiente de confirmar: Extra financiamiento (¿Fiduciario/Contraseña?) y Reestructura.
+const CAT_PROD: Record<string, string> = {
+  "cv vehículo": "autocompras",
+  "cv vehículo nuevo": "__NUEVO__",
+  "vehículo": "sobre_vehiculo",
+  "hipotecario": "hipotecario",
+};
+
+const PRODS = [
+  "autocompras",
+  "sobre_vehiculo",
+  "hipotecario",
+  "extra_financiamiento",
+  "reestructura",
+];
+
+function colProducto(prefix: string, categoria: string): string | null {
+  const p = CAT_PROD[(categoria ?? "").trim().toLowerCase()];
+  if (!p) return null; // categoría sin mapear: no va a columna de producto (igual cuenta en el total)
+  if (p === "__NUEVO__") return `nuevo_${prefix}_autocompras`;
+  return `${prefix}_${p}`;
+}
+
+export async function generarSnapshotDiario(fecha: string) {
+  // "YYYY-MM-DD"
+  const [y, m, d] = fecha.split("-").map(Number);
+  const monthStart = `${y}-${String(m).padStart(2, "0")}-01`;
+  const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  const dayOfMonth = d;
+
+  // Acumulador de columnas (Big.js)
+  const C: Record<string, Big> = {};
+  const add = (col: string | null, v: any) => {
+    if (!col) return;
+    C[col] = (C[col] ?? new Big(0)).plus(v || 0);
+  };
+  const g = (col: string) => C[col] ?? new Big(0);
+
+  // 1) Desglose CUBE del día: por categoría × rubro
+  const desg = await db.execute(sql`
+    SELECT u.categoria AS categoria, fd.rubro AS rubro, SUM(fd.monto_total) AS total
+    FROM cartera.facturacion_desglose fd
+    INNER JOIN cartera.pagos_credito p ON p.pago_id   = fd.pago_id
+    INNER JOIN cartera.creditos      c ON c.credito_id = p.credito_id
+    INNER JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
+    WHERE fd.fecha_aplicado_gt = ${fecha}::date
+    GROUP BY u.categoria, fd.rubro
+  `);
+  for (const r of (desg as any).rows ?? []) {
+    const cat = r.categoria as string;
+    const rubro = r.rubro as string;
+    const total = r.total;
+    if (rubro === "SEGURO" || rubro === "GPS") {
+      add("servicios_seguro_gps", total);
+      continue;
+    }
+    const prefix = RUBRO_PREFIX[rubro];
+    if (!prefix) continue;
+    // total por rubro (columna *_cube / total)
+    const totalCol =
+      rubro === "CAPITAL"
+        ? "capital_total"
+        : rubro === "INTERES"
+        ? "interes_cube"
+        : rubro === "MEMBRESIA"
+        ? "membresia"
+        : rubro === "OTROS"
+        ? "otros_ingresos"
+        : "mora_cube"; // MORA
+    add(totalCol, total);
+    add(colProducto(prefix, cat), total);
+  }
+
+  // 2) Royalty del día: de creditos.royalti por fecha_creacion (GT) + categoría
+  const roy = await db.execute(sql`
+    SELECT u.categoria AS categoria, COALESCE(SUM(c.royalti), 0) AS total
+    FROM cartera.creditos c
+    INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+    WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+    GROUP BY u.categoria
+  `);
+  for (const r of (roy as any).rows ?? []) {
+    add("royalty", r.total);
+    add(colProducto("roy", r.categoria as string), r.total);
+  }
+
+  // 3) Gastos administrativos del día
+  const adm = await db.execute(sql`
+    SELECT COALESCE(SUM(monto), 0) AS total
+    FROM cartera.gastos_administrativos WHERE fecha = ${fecha}::date
+  `);
+  const administrativos = new Big((adm as any).rows?.[0]?.total || 0);
+
+  // 3.1) Ingresos por carros del día
+  const carr = await db.execute(sql`
+    SELECT COALESCE(SUM(monto), 0) AS total
+    FROM cartera.ingresos_carros WHERE fecha = ${fecha}::date
+  `);
+  const ingresoCarros = new Big((carr as any).rows?.[0]?.total || 0);
+
+  // 4) Facturación a inversionistas del día (no-CUBE, de pci)
+  const inv = await db.execute(sql`
+    SELECT COALESCE(SUM(pci.abono_interes + pci.abono_iva_12), 0) AS total
+    FROM cartera.pagos_credito_inversionistas pci
+    INNER JOIN cartera.pagos_credito p ON p.pago_id = pci.pago_id
+    INNER JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+    WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+      AND UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
+  `);
+  const factInv = new Big((inv as any).rows?.[0]?.total || 0);
+
+  // 5) Totales derivados del día
+  const interes_cube = g("interes_cube");
+  const membresia = g("membresia");
+  const otros_ingresos = g("otros_ingresos");
+  const mora_cube = g("mora_cube");
+  const royalty = g("royalty");
+  const servicios = g("servicios_seguro_gps");
+  const otros_cobros = otros_ingresos.minus(administrativos);
+  const facturacion = royalty
+    .plus(mora_cube)
+    .plus(otros_ingresos)
+    .plus(membresia)
+    .plus(interes_cube);
+  const facturacion_mas_servicios = facturacion.plus(servicios);
+
+  // 6) Acumulados MTD (recalculados sobre [monthStart, fecha])
+  const mtd = await db.execute(sql`
+    SELECT
+      COALESCE(SUM(CASE WHEN rubro IN ('INTERES','MEMBRESIA','OTROS','MORA') THEN monto_total ELSE 0 END), 0) AS fact_desg,
+      COALESCE(SUM(CASE WHEN rubro IN ('SEGURO','GPS') THEN monto_total ELSE 0 END), 0) AS servicios
+    FROM cartera.facturacion_desglose
+    WHERE fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
+  `);
+  const royMtd = await db.execute(sql`
+    SELECT COALESCE(SUM(c.royalti), 0) AS total FROM cartera.creditos c
+    WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
+  `);
+  const invMtd = await db.execute(sql`
+    SELECT COALESCE(SUM(pci.abono_interes + pci.abono_iva_12), 0) AS total
+    FROM cartera.pagos_credito_inversionistas pci
+    INNER JOIN cartera.pagos_credito p ON p.pago_id = pci.pago_id
+    INNER JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+    WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
+      AND UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
+  `);
+  // Reserva acumulada (MTD) desde pagos_credito.reserva
+  const reservaMtd = await db.execute(sql`
+    SELECT COALESCE(SUM(reserva), 0) AS total FROM cartera.pagos_credito
+    WHERE (fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
+  `);
+  const carrosMtd = await db.execute(sql`
+    SELECT COALESCE(SUM(monto), 0) AS total FROM cartera.ingresos_carros
+    WHERE fecha BETWEEN ${monthStart}::date AND ${fecha}::date
+  `);
+  const facturacion_acumulado = new Big((mtd as any).rows[0].fact_desg).plus(
+    (royMtd as any).rows[0].total
+  );
+  const acum_servicios = new Big((mtd as any).rows[0].servicios);
+  const ingresoCarrosMtd = new Big((carrosMtd as any).rows[0].total);
+  // AY (Excel): facturación + servicios + ingreso carros (acumulado del mes).
+  const acumulado_total = facturacion_acumulado
+    .plus(acum_servicios)
+    .plus(ingresoCarrosMtd);
+  const acumulado_inversionistas = new Big((invMtd as any).rows[0].total);
+  const reserva_acumulada = new Big((reservaMtd as any).rows[0].total);
+
+  // 7) Tendencias (proyección lineal sobre MTD)
+  const tendencia_fin_mes =
+    dayOfMonth > 0
+      ? facturacion_acumulado.div(dayOfMonth).times(daysInMonth)
+      : new Big(0);
+  const tendencia_semanal =
+    dayOfMonth > 0 ? facturacion_acumulado.div(dayOfMonth).times(5) : new Big(0);
+
+  // 8) Metas del mes
+  const meta = await db.execute(sql`
+    SELECT * FROM cartera.metas_facturacion WHERE anio = ${y} AND mes = ${m} LIMIT 1
+  `);
+  const M = (meta as any).rows?.[0] || {};
+  const meta_mensual = new Big(M.meta_mensual || 0);
+  const meta_semanal = new Big(M.meta_semanal || 0);
+  const meta_diaria = new Big(M.meta_diaria || 0);
+  const porcentaje_meta_mensual = meta_mensual.gt(0)
+    ? facturacion_acumulado.div(meta_mensual).times(100)
+    : new Big(0);
+
+  // 9) Semana del año
+  const wk = await db.execute(sql`SELECT EXTRACT(WEEK FROM ${fecha}::date)::int AS w`);
+  const semana = (wk as any).rows[0].w;
+
+  // ───────────────── armar la fila completa ─────────────────
+  const f2 = (b: Big) => b.round(2).toString();
+  const f4 = (b: Big) => b.round(4).toString();
+
+  const row: Record<string, any> = {
+    fecha,
+    anio: y,
+    mes: m,
+    semana,
+    capital_total: f2(g("capital_total")),
+    interes_cube: f2(interes_cube),
+    membresia: f2(membresia),
+    otros_ingresos: f2(otros_ingresos),
+    administrativos: f2(administrativos),
+    otros_cobros: f2(otros_cobros),
+    mora_cube: f2(mora_cube),
+    royalty: f2(royalty),
+    facturacion: f2(facturacion),
+    facturacion_acumulado: f2(facturacion_acumulado),
+    servicios_seguro_gps: f2(servicios),
+    acum_servicios_seguro_gps: f2(acum_servicios),
+    facturacion_mas_servicios: f2(facturacion_mas_servicios),
+    acumulado_total: f2(acumulado_total),
+    facturacion_inversionistas: f2(factInv),
+    acumulado_inversionistas: f2(acumulado_inversionistas),
+    tendencia_fin_mes: f2(tendencia_fin_mes),
+    tendencia_semanal: f2(tendencia_semanal),
+    ingreso_carros: f2(ingresoCarros),
+    reserva_acumulada: f2(reserva_acumulada),
+    meta_facturacion_mensual: f2(meta_mensual),
+    meta_facturacion_semanal: f2(meta_semanal),
+    meta_facturacion_diaria: f2(meta_diaria),
+    porcentaje_meta_mensual: f4(porcentaje_meta_mensual),
+    meta_diaria: f2(meta_diaria),
+    updated_at: new Date(),
+  };
+
+  // Columnas por producto (incluye las pendientes en 0)
+  for (const prefix of [...Object.values(RUBRO_PREFIX), "roy"]) {
+    for (const pr of PRODS) row[`${prefix}_${pr}`] = f2(g(`${prefix}_${pr}`));
+    row[`nuevo_${prefix}_autocompras`] = f2(g(`nuevo_${prefix}_autocompras`));
+  }
+
+  // Upsert por fecha
+  const setObj: Record<string, any> = { ...row };
+  delete setObj.fecha;
+
+  const [saved] = await db
+    .insert(facturacion_snapshot_diario)
+    .values(row as any)
+    .onConflictDoUpdate({
+      target: facturacion_snapshot_diario.fecha,
+      set: setObj,
+    })
+    .returning();
+
+  return { success: true, data: saved };
+}
+
+// ✅ Aplica SOLO carros + administrativos al snapshot de un día (sin recalcular
+//    los montos importados). Si el día no tiene fila, la genera primero.
+//    - administrativos = SUM(gastos del día); otros_cobros = otros_ingresos − administrativos
+//    - ingreso_carros = SUM(carros del día); acumulado_total = fact_acum + acum_servicios + carros MTD
+export async function aplicarManualesEnSnapshotDia(fecha: string) {
+  const existe = await db
+    .select({ id: facturacion_snapshot_diario.id })
+    .from(facturacion_snapshot_diario)
+    .where(eq(facturacion_snapshot_diario.fecha, fecha))
+    .limit(1);
+  if (!existe.length) await generarSnapshotDiario(fecha); // día nuevo: sin montos que perder
+
+  await db.execute(sql`
+    UPDATE cartera.facturacion_snapshot_diario s
+    SET administrativos = COALESCE((
+          SELECT SUM(monto) FROM cartera.gastos_administrativos g WHERE g.fecha = ${fecha}::date), 0),
+        otros_cobros = s.otros_ingresos - COALESCE((
+          SELECT SUM(monto) FROM cartera.gastos_administrativos g WHERE g.fecha = ${fecha}::date), 0),
+        ingreso_carros = COALESCE((
+          SELECT SUM(monto) FROM cartera.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
+        acumulado_total = s.facturacion_acumulado + s.acum_servicios_seguro_gps + COALESCE((
+          SELECT SUM(monto) FROM cartera.ingresos_carros c
+          WHERE c.fecha >= make_date(EXTRACT(YEAR FROM ${fecha}::date)::int, EXTRACT(MONTH FROM ${fecha}::date)::int, 1)
+            AND c.fecha <= ${fecha}::date), 0),
+        updated_at = now()
+    WHERE s.fecha = ${fecha}::date
+  `);
+  return { success: true };
+}
+
+// ✅ Aplica SOLO las columnas de meta a los snapshots del mes (sin recalcular
+//    los montos importados). Recalcula el % meta con el acumulado existente.
+export async function aplicarMetaEnSnapshotsMes(anio: number, mes: number) {
+  const res = await db.execute(sql`
+    UPDATE cartera.facturacion_snapshot_diario s
+    SET meta_facturacion_mensual = m.meta_mensual,
+        meta_facturacion_semanal = m.meta_semanal,
+        meta_facturacion_diaria  = m.meta_diaria,
+        meta_diaria              = m.meta_diaria,
+        porcentaje_meta_mensual  = CASE
+          WHEN m.meta_mensual > 0
+          THEN ROUND(s.facturacion_acumulado / m.meta_mensual * 100, 4)
+          ELSE 0 END,
+        updated_at = now()
+    FROM cartera.metas_facturacion m
+    WHERE m.anio = ${anio} AND m.mes = ${mes}
+      AND s.fecha >= make_date(${anio}, ${mes}, 1)
+      AND s.fecha < (make_date(${anio}, ${mes}, 1) + INTERVAL '1 month')
+  `);
+  return { success: true, actualizados: (res as any).rowCount ?? 0 };
+}
+
+// Genera el snapshot del día SOLO si todavía no existe (job de respaldo).
+export async function asegurarSnapshotDiario(fecha: string) {
+  const existe = await db
+    .select({ id: facturacion_snapshot_diario.id })
+    .from(facturacion_snapshot_diario)
+    .where(eq(facturacion_snapshot_diario.fecha, fecha))
+    .limit(1);
+  if (existe.length) return { success: true, created: false, fecha };
+  await generarSnapshotDiario(fecha);
+  return { success: true, created: true, fecha };
+}
+
+// ============================================================================
+// 📥 EXPORTAR A EXCEL (diseño tipo Reuniones diarias, con logo y totales)
+// ============================================================================
+const prodCols = (p: string) => [
+  { k: `${p}_autocompras`, l: "Autocompras" },
+  { k: `${p}_sobre_vehiculo`, l: "Sobre vehículo" },
+  { k: `nuevo_${p}_autocompras`, l: "Nuevo Autocompras" },
+  { k: `${p}_hipotecario`, l: "Hipotecario" },
+  { k: `${p}_extra_financiamiento`, l: "Extra financ." },
+  { k: `${p}_reestructura`, l: "Reestructura" },
+];
+
+const EXCEL_GRUPOS: { label: string; color: string; cols: { k: string; l: string }[] }[] = [
+  { label: "Capital", color: "FF1E40AF", cols: [...prodCols("cap"), { k: "capital_total", l: "Capital total" }] },
+  { label: "Interés", color: "FF1D4ED8", cols: [...prodCols("int"), { k: "interes_cube", l: "Interés Cube" }] },
+  { label: "Membresía", color: "FF2563EB", cols: [...prodCols("mem"), { k: "membresia", l: "Membresía" }] },
+  {
+    label: "Otros ingresos",
+    color: "FF1E40AF",
+    cols: [...prodCols("oi"), { k: "otros_ingresos", l: "Otros ingresos" }, { k: "administrativos", l: "Administrativos" }, { k: "otros_cobros", l: "Otros cobros" }],
+  },
+  { label: "Mora", color: "FF1D4ED8", cols: [...prodCols("mora"), { k: "mora_cube", l: "Mora Cube" }] },
+  { label: "Royalty", color: "FF2563EB", cols: [...prodCols("roy"), { k: "royalty", l: "Royalty" }] },
+  {
+    label: "Totales / Acumulados",
+    color: "FF0F766E",
+    cols: [
+      { k: "facturacion", l: "Facturación" },
+      { k: "facturacion_acumulado", l: "Fact. acumulada" },
+      { k: "servicios_seguro_gps", l: "Servicios (Seg+GPS)" },
+      { k: "acum_servicios_seguro_gps", l: "Acum. servicios" },
+      { k: "facturacion_mas_servicios", l: "Fact. + Servicios" },
+      { k: "acumulado_total", l: "Acumulado total" },
+      { k: "facturacion_inversionistas", l: "Fact. Inversionistas" },
+      { k: "acumulado_inversionistas", l: "Acum. inversionistas" },
+      { k: "tendencia_fin_mes", l: "Tendencia fin mes" },
+      { k: "tendencia_semanal", l: "Tendencia semanal" },
+      { k: "ingreso_carros", l: "Ingreso Carros" },
+      { k: "reserva_acumulada", l: "Reserva acumulada" },
+    ],
+  },
+  {
+    label: "Metas",
+    color: "FF7C3AED",
+    cols: [
+      { k: "meta_facturacion_mensual", l: "Meta mensual" },
+      { k: "meta_facturacion_semanal", l: "Meta semanal" },
+      { k: "meta_facturacion_diaria", l: "Meta diaria" },
+      { k: "porcentaje_meta_mensual", l: "% Meta" },
+      { k: "meta_diaria", l: "Meta diaria (BK)" },
+    ],
+  },
+];
+
+export async function generarExcelFacturacionDiaria(
+  fechaInicio?: string,
+  fechaFin?: string
+): Promise<Buffer> {
+  const { data, totales } = await getSnapshotsDiarios({ fechaInicio, fechaFin });
+  const filas: any[] = [...data].sort((a, b) => a.fecha.localeCompare(b.fecha));
+
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet("Facturación Diaria", {
+    views: [{ state: "frozen", xSplit: 1, ySplit: 6 }],
+  });
+
+  const flat = [{ k: "fecha", l: "Fecha" }, ...EXCEL_GRUPOS.flatMap((g) => g.cols)];
+  const nCols = flat.length;
+
+  // Logo (A1:B3)
+  const logo = await fetchImageBase64(LOGO_URL);
+  if (logo) {
+    const imgId = wb.addImage({ base64: logo.data, extension: logo.ext });
+    ws.addImage(imgId, "A1:B3");
+  }
+  for (let r = 1; r <= 3; r++) ws.getRow(r).height = 20;
+
+  // Título
+  ws.mergeCells(1, 3, 1, nCols);
+  const t = ws.getCell(1, 3);
+  t.value = "Facturación Diaria";
+  t.font = { bold: true, size: 18, color: { argb: "FF1E3A8A" } };
+  ws.mergeCells(2, 3, 2, nCols);
+  const st = ws.getCell(2, 3);
+  st.value = `Del ${fechaInicio ?? "—"} al ${fechaFin ?? "—"}`;
+  st.font = { italic: true, size: 11, color: { argb: "FF64748B" } };
+
+  const HEADER_GROUP_ROW = 5;
+  const HEADER_COL_ROW = 6;
+  const border = {
+    top: { style: "thin" as const, color: { argb: "FFCBD5E1" } },
+    left: { style: "thin" as const, color: { argb: "FFCBD5E1" } },
+    bottom: { style: "thin" as const, color: { argb: "FFCBD5E1" } },
+    right: { style: "thin" as const, color: { argb: "FFCBD5E1" } },
+  };
+
+  // Encabezado "Fecha" (vertical merge)
+  ws.mergeCells(HEADER_GROUP_ROW, 1, HEADER_COL_ROW, 1);
+  const fh = ws.getCell(HEADER_GROUP_ROW, 1);
+  fh.value = "Fecha";
+  fh.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FF1E3A8A" } };
+  fh.font = { bold: true, color: { argb: "FFFFFFFF" } };
+  fh.alignment = { vertical: "middle", horizontal: "center" };
+  fh.border = border;
+
+  // Grupos + columnas
+  let col = 2;
+  for (const g of EXCEL_GRUPOS) {
+    const start = col;
+    for (const c of g.cols) {
+      const cell = ws.getCell(HEADER_COL_ROW, col);
+      cell.value = c.l;
+      cell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFDBEAFE" } };
+      cell.font = { bold: true, size: 9, color: { argb: "FF1E3A8A" } };
+      cell.alignment = { vertical: "middle", horizontal: "center", wrapText: true };
+      cell.border = border;
+      ws.getColumn(col).width = 15;
+      col++;
+    }
+    ws.mergeCells(HEADER_GROUP_ROW, start, HEADER_GROUP_ROW, col - 1);
+    const gc = ws.getCell(HEADER_GROUP_ROW, start);
+    gc.value = g.label;
+    gc.fill = { type: "pattern", pattern: "solid", fgColor: { argb: g.color } };
+    gc.font = { bold: true, size: 11, color: { argb: "FFFFFFFF" } };
+    gc.alignment = { vertical: "middle", horizontal: "center" };
+    gc.border = border;
+  }
+  ws.getColumn(1).width = 13;
+
+  // Datos
+  let r = HEADER_COL_ROW + 1;
+  for (const row of filas) {
+    ws.getCell(r, 1).value = row.fecha;
+    ws.getCell(r, 1).font = { bold: true, color: { argb: "FF1E3A8A" } };
+    ws.getCell(r, 1).border = border;
+    let cc = 2;
+    for (const g of EXCEL_GRUPOS) {
+      for (const c of g.cols) {
+        const cell = ws.getCell(r, cc);
+        cell.value = Number(row[c.k] ?? 0);
+        cell.numFmt = c.k === "porcentaje_meta_mensual" ? '#,##0.00"%"' : "#,##0.00";
+        cell.alignment = { horizontal: "right" };
+        cell.border = border;
+        if (c.k.endsWith("_total") || c.k === "interes_cube" || c.k === "mora_cube" || c.k === "facturacion" || c.k === "royalty" || c.k === "membresia") {
+          cell.font = { bold: true, color: { argb: "FF1E3A8A" } };
+          cell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFEFF6FF" } };
+        }
+        cc++;
+      }
+    }
+    if ((r - HEADER_COL_ROW) % 2 === 0) {
+      // zebra suave en la col fecha ya va; dejamos números limpios
+    }
+    r++;
+  }
+
+  // Totales
+  const tcell = ws.getCell(r, 1);
+  tcell.value = "TOTALES";
+  tcell.font = { bold: true, color: { argb: "FFFFFFFF" } };
+  tcell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FF1E3A8A" } };
+  tcell.alignment = { horizontal: "center" };
+  tcell.border = border;
+  let tc = 2;
+  for (const g of EXCEL_GRUPOS) {
+    for (const c of g.cols) {
+      const cell = ws.getCell(r, tc);
+      if (c.k in totales) {
+        cell.value = totales[c.k];
+        cell.numFmt = "#,##0.00";
+      }
+      cell.font = { bold: true, color: { argb: "FF1E3A8A" } };
+      cell.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFBFDBFE" } };
+      cell.alignment = { horizontal: "right" };
+      cell.border = border;
+      tc++;
+    }
+  }
+
+  ws.getRow(HEADER_GROUP_ROW).height = 22;
+  ws.getRow(HEADER_COL_ROW).height = 30;
+
+  const buf = await wb.xlsx.writeBuffer();
+  return Buffer.from(buf);
+}
+
+export async function getSnapshotsDiarios(opts: {
+  fechaInicio?: string;
+  fechaFin?: string;
+}) {
+  const where = [];
+  if (opts.fechaInicio)
+    where.push(gte(facturacion_snapshot_diario.fecha, opts.fechaInicio));
+  if (opts.fechaFin)
+    where.push(lte(facturacion_snapshot_diario.fecha, opts.fechaFin));
+
+  const rows = await db
+    .select()
+    .from(facturacion_snapshot_diario)
+    .where(where.length ? and(...where) : undefined)
+    .orderBy(desc(facturacion_snapshot_diario.fecha));
+
+  // 🧮 Totales por columna (solo columnas ADITIVAS: montos diarios).
+  //    Se excluyen acumulados, tendencias, metas y % (no tiene sentido sumarlos).
+  const NO_SUMAR = new Set([
+    "id",
+    "fecha",
+    "anio",
+    "mes",
+    "semana",
+    "facturacion_acumulado",
+    "acum_servicios_seguro_gps",
+    "acumulado_total",
+    "acumulado_inversionistas",
+    "tendencia_fin_mes",
+    "tendencia_semanal",
+    "reserva_acumulada",
+    "meta_facturacion_mensual",
+    "meta_facturacion_semanal",
+    "meta_facturacion_diaria",
+    "porcentaje_meta_mensual",
+    "meta_diaria",
+    "created_at",
+    "updated_at",
+  ]);
+  const totales: Record<string, number> = {};
+  for (const r of rows as any[]) {
+    for (const [k, v] of Object.entries(r)) {
+      if (NO_SUMAR.has(k)) continue;
+      const n = Number(v ?? 0);
+      if (!Number.isFinite(n)) continue;
+      totales[k] = (totales[k] ?? 0) + n;
+    }
+  }
+  for (const k of Object.keys(totales)) {
+    totales[k] = Math.round(totales[k] * 100) / 100;
+  }
+
+  return { success: true, data: rows, totales };
+}

--- a/apps/cartera-back/src/controllers/gastosAdministrativos.ts
+++ b/apps/cartera-back/src/controllers/gastosAdministrativos.ts
@@ -1,0 +1,57 @@
+import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { db } from "../database";
+import { gastos_administrativos } from "../database/db/schema";
+
+// ============================================================================
+// 🧾 GASTOS ADMINISTRATIVOS (manuales, itemizados por día)
+//    Para el reporte diario de facturación: "Otros cobros" = Otros ingresos −
+//    SUM(gastos del día). Se guardan varios por día (concepto + monto).
+// ============================================================================
+
+export async function crearGastoAdministrativo(input: {
+  fecha: string; // "YYYY-MM-DD" (America/Guatemala)
+  concepto: string;
+  monto: number | string;
+  created_by?: number | null;
+}) {
+  const [row] = await db
+    .insert(gastos_administrativos)
+    .values({
+      fecha: input.fecha,
+      concepto: input.concepto,
+      monto: String(input.monto),
+      created_by: input.created_by ?? null,
+    })
+    .returning();
+  return { success: true, data: row };
+}
+
+export async function listarGastosAdministrativos(opts: {
+  fechaInicio?: string;
+  fechaFin?: string;
+}) {
+  const where = [];
+  if (opts.fechaInicio)
+    where.push(gte(gastos_administrativos.fecha, opts.fechaInicio));
+  if (opts.fechaFin) where.push(lte(gastos_administrativos.fecha, opts.fechaFin));
+
+  const rows = await db
+    .select()
+    .from(gastos_administrativos)
+    .where(where.length ? and(...where) : undefined)
+    .orderBy(
+      desc(gastos_administrativos.fecha),
+      desc(gastos_administrativos.id)
+    );
+
+  return { success: true, data: rows };
+}
+
+export async function eliminarGastoAdministrativo(id: number) {
+  const [row] = await db
+    .delete(gastos_administrativos)
+    .where(eq(gastos_administrativos.id, id))
+    .returning();
+  if (!row) return { success: false, message: "Gasto no encontrado" };
+  return { success: true, data: row };
+}

--- a/apps/cartera-back/src/controllers/ingresosCarros.ts
+++ b/apps/cartera-back/src/controllers/ingresosCarros.ts
@@ -1,0 +1,52 @@
+import { and, desc, eq, gte, lte } from "drizzle-orm";
+import { db } from "../database";
+import { ingresos_carros } from "../database/db/schema";
+
+// ============================================================================
+// 🚗 INGRESOS POR CARROS (manuales, itemizados por día)
+//    Columna "Ingreso Carros" del Excel. El snapshot suma por día.
+// ============================================================================
+
+export async function crearIngresoCarro(input: {
+  fecha: string; // "YYYY-MM-DD" (America/Guatemala)
+  concepto: string;
+  monto: number | string;
+  created_by?: number | null;
+}) {
+  const [row] = await db
+    .insert(ingresos_carros)
+    .values({
+      fecha: input.fecha,
+      concepto: input.concepto,
+      monto: String(input.monto),
+      created_by: input.created_by ?? null,
+    })
+    .returning();
+  return { success: true, data: row };
+}
+
+export async function listarIngresosCarros(opts: {
+  fechaInicio?: string;
+  fechaFin?: string;
+}) {
+  const where = [];
+  if (opts.fechaInicio) where.push(gte(ingresos_carros.fecha, opts.fechaInicio));
+  if (opts.fechaFin) where.push(lte(ingresos_carros.fecha, opts.fechaFin));
+
+  const rows = await db
+    .select()
+    .from(ingresos_carros)
+    .where(where.length ? and(...where) : undefined)
+    .orderBy(desc(ingresos_carros.fecha), desc(ingresos_carros.id));
+
+  return { success: true, data: rows };
+}
+
+export async function eliminarIngresoCarro(id: number) {
+  const [row] = await db
+    .delete(ingresos_carros)
+    .where(eq(ingresos_carros.id, id))
+    .returning();
+  if (!row) return { success: false, message: "Ingreso no encontrado" };
+  return { success: true, data: row };
+}

--- a/apps/cartera-back/src/controllers/metasFacturacion.ts
+++ b/apps/cartera-back/src/controllers/metasFacturacion.ts
@@ -1,0 +1,69 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db } from "../database";
+import { metas_facturacion } from "../database/db/schema";
+
+// ============================================================================
+// 🎯 METAS DE FACTURACIÓN (manuales, por año/mes, globales)
+//    1 fila por (anio, mes). Upsert: si ya existe el mes, lo actualiza.
+// ============================================================================
+
+export async function upsertMetaFacturacion(input: {
+  anio: number;
+  mes: number;
+  meta_mensual?: number | string;
+  meta_semanal?: number | string;
+  meta_diaria?: number | string;
+  deuda_mensual?: number | string | null;
+  deuda_semanal?: number | string | null;
+  deuda_diaria?: number | string | null;
+}) {
+  const num = (v: any) => (v === undefined || v === null ? null : String(v));
+
+  const values = {
+    anio: input.anio,
+    mes: input.mes,
+    meta_mensual: num(input.meta_mensual) ?? "0",
+    meta_semanal: num(input.meta_semanal) ?? "0",
+    meta_diaria: num(input.meta_diaria) ?? "0",
+    deuda_mensual: num(input.deuda_mensual),
+    deuda_semanal: num(input.deuda_semanal),
+    deuda_diaria: num(input.deuda_diaria),
+    updated_at: new Date(),
+  };
+
+  const [row] = await db
+    .insert(metas_facturacion)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [metas_facturacion.anio, metas_facturacion.mes],
+      set: {
+        meta_mensual: values.meta_mensual,
+        meta_semanal: values.meta_semanal,
+        meta_diaria: values.meta_diaria,
+        deuda_mensual: values.deuda_mensual,
+        deuda_semanal: values.deuda_semanal,
+        deuda_diaria: values.deuda_diaria,
+        updated_at: values.updated_at,
+      },
+    })
+    .returning();
+
+  return { success: true, data: row };
+}
+
+export async function getMetasFacturacion(opts: {
+  anio?: number;
+  mes?: number;
+}) {
+  const where = [];
+  if (opts.anio) where.push(eq(metas_facturacion.anio, opts.anio));
+  if (opts.mes) where.push(eq(metas_facturacion.mes, opts.mes));
+
+  const rows = await db
+    .select()
+    .from(metas_facturacion)
+    .where(where.length ? and(...where) : undefined)
+    .orderBy(desc(metas_facturacion.anio), desc(metas_facturacion.mes));
+
+  return { success: true, data: rows };
+}

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -54,6 +54,17 @@
     "VERIFICADO",
     "RECHAZADO"
   ]);
+
+  // 🧾 Rubros del desglose de facturación (lo que factura CUBE) para el reporte diario.
+  export const rubroFacturacionEnum = customSchema.enum("rubro_facturacion", [
+    "CAPITAL",
+    "INTERES",
+    "MEMBRESIA",
+    "SEGURO",
+    "GPS",
+    "MORA",
+    "OTROS",
+  ]);
   export const admins = customSchema.table("admins", {
     admin_id: serial("admin_id").primaryKey(),
     nombre: varchar("nombre", { length: 150 }).notNull(),
@@ -1077,6 +1088,231 @@
     created_at: timestamp("created_at").defaultNow().notNull(),
     created_by: integer("created_by").references(() => platform_users.id),
   });
+
+  // ============================================
+  // 🧾 TABLA: facturacion_desglose
+  //    Desglose por rubro de LO QUE FACTURA CUBE en cada pago, para el
+  //    reporte diario de facturación (matriz categoría × rubro × día).
+  //    - 1 fila por (pago_id, rubro).
+  //    - INTERES = residuo CUBE CON IVA (totalCube de /facturar-pago-completo).
+  //    - CAPITAL no se factura → factura_id NULL, monto_iva 0.
+  //    - monto_total incluye IVA (misma convención que facturas_electronicas).
+  //    - fecha_aplicado_gt = fecha_aplicado del pago en zona America/Guatemala.
+  //    - La categoría NO se guarda: sale por JOIN pago→crédito→usuario.
+  // ============================================
+  export const facturacion_desglose = customSchema.table(
+    "facturacion_desglose",
+    {
+      id: serial("id").primaryKey(),
+      pago_id: integer("pago_id")
+        .notNull()
+        .references(() => pagos_credito.pago_id, { onDelete: "cascade" }),
+      factura_id: integer("factura_id").references(
+        () => facturas_electronicas.factura_id,
+        { onDelete: "set null" }
+      ),
+      rubro: rubroFacturacionEnum("rubro").notNull(),
+      monto_total: numeric("monto_total", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"), // con IVA incluido
+      monto_iva: numeric("monto_iva", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      fecha_aplicado_gt: date("fecha_aplicado_gt"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqPagoRubro: uniqueIndex("uq_facturacion_desglose_pago_rubro").on(
+        table.pago_id,
+        table.rubro
+      ),
+      idxFecha: index("idx_facturacion_desglose_fecha").on(
+        table.fecha_aplicado_gt
+      ),
+    })
+  );
+
+  // ============================================
+  // 🧾 TABLA: gastos_administrativos
+  //    Gastos administrativos manuales para el reporte diario de facturación.
+  //    Itemizados por día (concepto + monto). El reporte suma por día.
+  //    En el Excel: "Otros cobros" = Otros ingresos − SUM(gastos del día).
+  // ============================================
+  export const gastos_administrativos = customSchema.table(
+    "gastos_administrativos",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(), // fecha del gasto (America/Guatemala)
+      concepto: varchar("concepto", { length: 200 }).notNull(),
+      monto: numeric("monto", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      created_by: integer("created_by"),
+    },
+    (table) => ({
+      idxFecha: index("idx_gastos_admin_fecha").on(table.fecha),
+    })
+  );
+
+  // ============================================
+  // 🚗 TABLA: ingresos_carros
+  //    Ingresos por carros manuales para el reporte diario (columna "Ingreso
+  //    Carros" del Excel). Itemizados por día. El snapshot suma por día.
+  // ============================================
+  export const ingresos_carros = customSchema.table(
+    "ingresos_carros",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(), // America/Guatemala
+      concepto: varchar("concepto", { length: 200 }).notNull(),
+      monto: numeric("monto", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      created_by: integer("created_by"),
+    },
+    (table) => ({
+      idxFecha: index("idx_ingresos_carros_fecha").on(table.fecha),
+    })
+  );
+
+  // ============================================
+  // 🎯 TABLA: metas_facturacion
+  //    Metas financieras manuales por (año, mes). Globales (no por categoría).
+  //    - meta_mensual/semanal/diaria se capturan por separado.
+  //    - meta_diaria aplica a cada día del mes.
+  //    - deuda_* opcionales (mismo bloque del Excel).
+  // ============================================
+  export const metas_facturacion = customSchema.table(
+    "metas_facturacion",
+    {
+      id: serial("id").primaryKey(),
+      anio: integer("anio").notNull(),
+      mes: integer("mes").notNull(), // 1-12
+      meta_mensual: numeric("meta_mensual", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      meta_semanal: numeric("meta_semanal", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      meta_diaria: numeric("meta_diaria", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      deuda_mensual: numeric("deuda_mensual", { precision: 18, scale: 2 }),
+      deuda_semanal: numeric("deuda_semanal", { precision: 18, scale: 2 }),
+      deuda_diaria: numeric("deuda_diaria", { precision: 18, scale: 2 }),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      updated_at: timestamp("updated_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqAnioMes: uniqueIndex("uq_metas_facturacion_anio_mes").on(
+        table.anio,
+        table.mes
+      ),
+    })
+  );
+
+  // ============================================
+  // 📸 TABLA: facturacion_snapshot_diario
+  //    Snapshot diario tipo Excel "Reuniones diarias" → hoja Facturación.
+  //    1 fila por día (columnas A→BK del Excel), congeladas.
+  //    Se llena con endpoint manual + job de respaldo si el día no se guardó.
+  //    Money = numeric(18,2). Sufijos de producto = categoría del crédito.
+  // ============================================
+  export const facturacion_snapshot_diario = customSchema.table(
+    "facturacion_snapshot_diario",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(), // A — día (America/Guatemala)
+      anio: integer("anio"), // helper
+      mes: integer("mes"), // helper
+
+      // 💰 Capital (B–H)
+      cap_autocompras: numeric("cap_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_sobre_vehiculo: numeric("cap_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_cap_autocompras: numeric("nuevo_cap_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_hipotecario: numeric("cap_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_extra_financiamiento: numeric("cap_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      cap_reestructura: numeric("cap_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      capital_total: numeric("capital_total", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 💵 Interés (I–O)
+      int_autocompras: numeric("int_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_sobre_vehiculo: numeric("int_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_int_autocompras: numeric("nuevo_int_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_hipotecario: numeric("int_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_extra_financiamiento: numeric("int_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      int_reestructura: numeric("int_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      interes_cube: numeric("interes_cube", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 🎟️ Membresía (P–V)
+      mem_autocompras: numeric("mem_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_sobre_vehiculo: numeric("mem_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_mem_autocompras: numeric("nuevo_mem_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_hipotecario: numeric("mem_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_extra_financiamiento: numeric("mem_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      mem_reestructura: numeric("mem_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      membresia: numeric("membresia", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 📦 Otros ingresos (W–AE)
+      oi_autocompras: numeric("oi_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_sobre_vehiculo: numeric("oi_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_oi_autocompras: numeric("nuevo_oi_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_hipotecario: numeric("oi_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_extra_financiamiento: numeric("oi_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      oi_reestructura: numeric("oi_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      otros_ingresos: numeric("otros_ingresos", { precision: 18, scale: 2 }).notNull().default("0"),
+      administrativos: numeric("administrativos", { precision: 18, scale: 2 }).notNull().default("0"),
+      otros_cobros: numeric("otros_cobros", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // ⚠️ Mora (AF–AL)
+      mora_autocompras: numeric("mora_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_sobre_vehiculo: numeric("mora_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_mora_autocompras: numeric("nuevo_mora_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_hipotecario: numeric("mora_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_extra_financiamiento: numeric("mora_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_reestructura: numeric("mora_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      mora_cube: numeric("mora_cube", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 👑 Royalty (AM–AS)
+      roy_autocompras: numeric("roy_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_sobre_vehiculo: numeric("roy_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_roy_autocompras: numeric("nuevo_roy_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_hipotecario: numeric("roy_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_extra_financiamiento: numeric("roy_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      roy_reestructura: numeric("roy_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      royalty: numeric("royalty", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 📊 Totales / acumulados (AT–BE)
+      facturacion: numeric("facturacion", { precision: 18, scale: 2 }).notNull().default("0"),
+      facturacion_acumulado: numeric("facturacion_acumulado", { precision: 18, scale: 2 }).notNull().default("0"),
+      servicios_seguro_gps: numeric("servicios_seguro_gps", { precision: 18, scale: 2 }).notNull().default("0"),
+      acum_servicios_seguro_gps: numeric("acum_servicios_seguro_gps", { precision: 18, scale: 2 }).notNull().default("0"),
+      facturacion_mas_servicios: numeric("facturacion_mas_servicios", { precision: 18, scale: 2 }).notNull().default("0"),
+      acumulado_total: numeric("acumulado_total", { precision: 18, scale: 2 }).notNull().default("0"),
+      facturacion_inversionistas: numeric("facturacion_inversionistas", { precision: 18, scale: 2 }).notNull().default("0"),
+      acumulado_inversionistas: numeric("acumulado_inversionistas", { precision: 18, scale: 2 }).notNull().default("0"),
+      tendencia_fin_mes: numeric("tendencia_fin_mes", { precision: 18, scale: 2 }).notNull().default("0"),
+      tendencia_semanal: numeric("tendencia_semanal", { precision: 18, scale: 2 }).notNull().default("0"),
+      ingreso_carros: numeric("ingreso_carros", { precision: 18, scale: 2 }).notNull().default("0"),
+      reserva_acumulada: numeric("reserva_acumulada", { precision: 18, scale: 2 }).notNull().default("0"),
+      semana: integer("semana"), // BF
+
+      // 🎯 Metas (BG–BK)
+      meta_facturacion_mensual: numeric("meta_facturacion_mensual", { precision: 18, scale: 2 }).notNull().default("0"),
+      meta_facturacion_semanal: numeric("meta_facturacion_semanal", { precision: 18, scale: 2 }).notNull().default("0"),
+      meta_facturacion_diaria: numeric("meta_facturacion_diaria", { precision: 18, scale: 2 }).notNull().default("0"),
+      porcentaje_meta_mensual: numeric("porcentaje_meta_mensual", { precision: 9, scale: 4 }).notNull().default("0"),
+      meta_diaria: numeric("meta_diaria", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      created_at: timestamp("created_at").defaultNow().notNull(),
+      updated_at: timestamp("updated_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqFecha: uniqueIndex("uq_facturacion_snapshot_diario_fecha").on(table.fecha),
+    })
+  );
 
   // ============================================
   // 🆕 TABLA: facturas_fallidas_sat

--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -44,7 +44,11 @@ const app = new Elysia()
   .use(routers.creditosNuevosConAbonosRouter)
   .use(routers.cuentasExtraInversionistaRouter)
   .use(routers.cierreMensualRouter)
-  .use(routers.actualizarPagosExcelRouter);
+  .use(routers.actualizarPagosExcelRouter)
+  .use(routers.gastosAdministrativosRouter)
+  .use(routers.metasFacturacionRouter)
+  .use(routers.facturacionSnapshotRouter)
+  .use(routers.ingresosCarrosRouter);
 
 // 🚀 Iniciar tareas programadas ANTES de levantar el servidor
 iniciarTareasProgramadas();

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -932,6 +932,11 @@ if (facturasExistentes.length > 0) {
       // ============================================
       const hayInteresEnPago = new Big(pagoData.abono_interes || "0").gt(0);
 
+      // 🧾 Interés que finalmente factura CUBE (residuo + cash_in), CON IVA.
+      //    Se setea dentro de cada flujo (estándar/prorrateado) y se usa al
+      //    final para guardar el rubro INTERES en facturacion_desglose.
+      let interesCubeConIva = new Big(0);
+
       if (!hayInteresEnPago) {
         console.log("\n⏭️  NO hay intereses en este pago - Saltando facturas de intereses (ambos flujos)");
       } else if (tieneOperacionesPendientesFacturar) {
@@ -1278,6 +1283,9 @@ if (facturasExistentes.length > 0) {
 
           // Total que va a CUBE = lo de las DOS ventanas sumado.
           const totalCubeFinal = repartoAntes.totalCubeParcial.plus(repartoDespues.totalCubeParcial);
+
+          // 🧾 Guardar para el desglose de facturación (rubro INTERES, con IVA).
+          interesCubeConIva = totalCubeFinal;
 
           // Set con todos los IDs de inversionistas que aparecieron en cualquier
           // ventana (algunos podrían tener parte solo en una de las dos).
@@ -1747,6 +1755,9 @@ if (facturasExistentes.length > 0) {
 
         const totalCube = cubePropio.plus(cashInAcumulado);
 
+        // 🧾 Guardar para el desglose de facturación (rubro INTERES, con IVA).
+        interesCubeConIva = totalCube;
+
         console.log(`   📊 Cash-in acumulado de otros: Q${cashInAcumulado.toFixed(2)}`);
         console.log(`   💵 Total CUBE: Q${totalCube.toFixed(2)} (residuo + cash_in)`);
 
@@ -1846,12 +1857,119 @@ if (facturasExistentes.length > 0) {
         `✅ Exitosas: ${facturasExitosas.length} | ❌ Errores: ${facturasConError.length}`
       );
 
-      if (facturasExitosas.length === 0) {
+      // ⛔ Si NO se generó ninguna factura y hubo errores de certificación, es un
+      //    fallo real: NO escribimos el desglose (no se facturó nada de verdad).
+      if (facturasExitosas.length === 0 && facturasConError.length > 0) {
         set.status = 500;
         return {
           success: false,
           error: "No se pudo generar ninguna factura",
           errores: facturasConError,
+        };
+      }
+
+      // ============================================
+      // 🧾 DESGLOSE DE FACTURACIÓN (reporte diario)
+      //    Guarda 1 fila por (pago, rubro) con LO QUE FACTURA CUBE, con IVA.
+      //    - INTERES = interesCubeConIva (residuo + cash_in, ya con IVA).
+      //    - Resto de rubros = abono del pago tratado como total con IVA.
+      //    - CAPITAL no se factura: factura_id NULL, monto_iva 0.
+      //    - fecha_aplicado_gt se calcula en SQL (zona America/Guatemala).
+      //    Best-effort: si falla, NO rompe la facturación (solo loguea).
+      // ============================================
+      let rubrosGuardados = 0;
+      try {
+        const rubrosDesglose: {
+          rubro: string;
+          monto_total: string;
+          monto_iva: string;
+        }[] = [];
+
+        const pushRubro = (
+          rubro: string,
+          totalConIva: any,
+          gravadoIva: boolean
+        ) => {
+          const t = new Big(totalConIva || 0);
+          if (t.lte(0)) return;
+          const iva = gravadoIva
+            ? new Big(calcularIvaExacto(parseFloat(t.toFixed(2))).montoImpuesto)
+            : new Big(0);
+          rubrosDesglose.push({
+            rubro,
+            monto_total: t.toFixed(2),
+            monto_iva: iva.toFixed(2),
+          });
+        };
+
+        // 💰 Capital de CUBE: NO es el abono_capital total del pago, sino la
+        //    porción de CUBE en pagos_credito_inversionistas (el capital sí se
+        //    reparte y se guarda por inversionista). Solo guardamos lo de CUBE.
+        const capCubeRes = await db.execute(sql`
+          SELECT COALESCE(SUM(pci.abono_capital), 0) AS capital_cube
+          FROM cartera.pagos_credito_inversionistas pci
+          JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+          WHERE pci.pago_id = ${pago_id}
+            AND UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
+        `);
+        const capitalCube = (capCubeRes as any).rows?.[0]?.capital_cube ?? 0;
+
+        pushRubro("CAPITAL", capitalCube, false); // solo capital de CUBE (de pci), sin IVA
+        pushRubro("INTERES", interesCubeConIva, true); // residuo CUBE, ya con IVA
+        pushRubro("MEMBRESIA", pagoData.membresias_pago, true);
+        pushRubro("SEGURO", pagoData.abono_seguro, true);
+        pushRubro("GPS", pagoData.abono_gps, true);
+        pushRubro("MORA", pagoData.mora, true);
+        pushRubro("OTROS", pagoData.otros, true);
+
+        await db.transaction(async (tx) => {
+          // Reemplazar para que re-facturar no duplique ni deje rubros viejos.
+          await tx.execute(
+            sql`DELETE FROM cartera.facturacion_desglose WHERE pago_id = ${pago_id}`
+          );
+          for (const r of rubrosDesglose) {
+            await tx.execute(sql`
+              INSERT INTO cartera.facturacion_desglose
+                (pago_id, factura_id, rubro, monto_total, monto_iva, fecha_aplicado_gt)
+              VALUES (
+                ${pago_id},
+                NULL,
+                ${r.rubro}::cartera.rubro_facturacion,
+                ${r.monto_total},
+                ${r.monto_iva},
+                (SELECT (COALESCE(pc.fecha_aplicado, pc.fecha_pago) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date
+                   FROM cartera.pagos_credito pc WHERE pc.pago_id = ${pago_id})
+              )
+            `);
+          }
+        });
+
+        rubrosGuardados = rubrosDesglose.length;
+        console.log(
+          `🧾 Desglose facturación guardado: ${rubrosDesglose.length} rubro(s) para pago ${pago_id}`
+        );
+      } catch (desgloseError: any) {
+        console.error(
+          `⚠️ No se pudo guardar facturacion_desglose para pago ${pago_id} (NO afecta la facturación):`,
+          desgloseError?.message
+        );
+      }
+
+      // Pago solo-capital (sin DTE que emitir y sin errores): no es fallo.
+      // El desglose ya quedó guardado arriba (capital de CUBE).
+      if (facturasExitosas.length === 0) {
+        return {
+          success: true,
+          data: {
+            pago_id,
+            cliente: { nombre: pagoData.nombre, nit: pagoData.nit },
+            total_facturas: 0,
+            facturas: [],
+          },
+          mensaje:
+            rubrosGuardados > 0
+              ? "Sin DTE que emitir (p. ej. solo capital). Guardado en el registro diario de facturación."
+              : "Sin DTE que emitir y sin montos para el registro diario.",
         };
       }
 

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -1,0 +1,114 @@
+import { Elysia, t } from "elysia";
+import { authMiddleware } from "./midleware";
+import {
+  aplicarManualesEnSnapshotDia,
+  aplicarMetaEnSnapshotsMes,
+  generarExcelFacturacionDiaria,
+  generarSnapshotDiario,
+  getSnapshotsDiarios,
+} from "../controllers/facturacionSnapshot";
+
+export const facturacionSnapshotRouter = new Elysia({
+  prefix: "/api/facturacion-snapshot",
+})
+  .use(authMiddleware)
+
+  // POST - Generar (o regenerar) el snapshot de un día. { fecha: "YYYY-MM-DD" }.
+  .post(
+    "/generar",
+    async ({ body, set }: any) => {
+      try {
+        const result = await generarSnapshotDiario(body.fecha);
+        set.status = 200;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Error generando snapshot diario",
+          error: String(error),
+        };
+      }
+    },
+    {
+      body: t.Object({
+        fecha: t.String(), // "YYYY-MM-DD"
+      }),
+    }
+  )
+
+  // POST - Aplicar SOLO carros + administrativos al día (sin recalcular montos).
+  .post(
+    "/aplicar-manuales-dia",
+    async ({ body, set }: any) => {
+      try {
+        return await aplicarManualesEnSnapshotDia(body.fecha);
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error aplicando manuales al día", error: String(error) };
+      }
+    },
+    {
+      body: t.Object({ fecha: t.String() }),
+    }
+  )
+
+  // POST - Aplicar SOLO las metas al mes (sin recalcular montos importados).
+  .post(
+    "/aplicar-meta-mes",
+    async ({ body, set }: any) => {
+      try {
+        return await aplicarMetaEnSnapshotsMes(body.anio, body.mes);
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error aplicando la meta al mes", error: String(error) };
+      }
+    },
+    {
+      body: t.Object({ anio: t.Number(), mes: t.Number() }),
+    }
+  )
+
+  // GET - Descargar Excel (diseño tipo Excel + logo + totales).
+  //       ?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD
+  .get(
+    "/excel",
+    async ({ query, set }: any) => {
+      try {
+        const buffer = await generarExcelFacturacionDiaria(query.fechaInicio, query.fechaFin);
+        return new Response(buffer as unknown as BodyInit, {
+          headers: {
+            "Content-Type":
+              "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "Content-Disposition": `attachment; filename="facturacion-diaria-${query.fechaInicio}_${query.fechaFin}.xlsx"`,
+          },
+        });
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error generando el Excel", error: String(error) };
+      }
+    },
+    {
+      query: t.Object({
+        fechaInicio: t.String(),
+        fechaFin: t.String(),
+      }),
+    }
+  )
+
+  // GET - Leer snapshots. ?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD (opcionales).
+  .get("/", async ({ query, set }: any) => {
+    try {
+      return await getSnapshotsDiarios({
+        fechaInicio: query.fechaInicio,
+        fechaFin: query.fechaFin,
+      });
+    } catch (error) {
+      set.status = 500;
+      return {
+        success: false,
+        message: "Error obteniendo snapshots",
+        error: String(error),
+      };
+    }
+  });

--- a/apps/cartera-back/src/routers/gastosAdministrativos.ts
+++ b/apps/cartera-back/src/routers/gastosAdministrativos.ts
@@ -1,0 +1,64 @@
+import { Elysia, t } from "elysia";
+import { authMiddleware } from "./midleware";
+import {
+  crearGastoAdministrativo,
+  eliminarGastoAdministrativo,
+  listarGastosAdministrativos,
+} from "../controllers/gastosAdministrativos";
+
+export const gastosAdministrativosRouter = new Elysia({
+  prefix: "/api/gastos-administrativos",
+})
+  .use(authMiddleware)
+
+  // POST - Crear un gasto administrativo (concepto + monto en una fecha).
+  .post(
+    "/",
+    async ({ body, user, set }: any) => {
+      try {
+        const result = await crearGastoAdministrativo({
+          fecha: body.fecha,
+          concepto: body.concepto,
+          monto: body.monto,
+          created_by: user?.id ?? null,
+        });
+        set.status = 201;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error creando gasto", error: String(error) };
+      }
+    },
+    {
+      body: t.Object({
+        fecha: t.String(), // "YYYY-MM-DD"
+        concepto: t.String(),
+        monto: t.Union([t.Number(), t.String()]),
+      }),
+    }
+  )
+
+  // GET - Listar gastos. ?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD (opcionales).
+  .get("/", async ({ query, set }: any) => {
+    try {
+      return await listarGastosAdministrativos({
+        fechaInicio: query.fechaInicio,
+        fechaFin: query.fechaFin,
+      });
+    } catch (error) {
+      set.status = 500;
+      return { success: false, message: "Error listando gastos", error: String(error) };
+    }
+  })
+
+  // DELETE - Eliminar un gasto por id.
+  .delete("/:id", async ({ params, set }: any) => {
+    try {
+      const result = await eliminarGastoAdministrativo(Number(params.id));
+      if (!result.success) set.status = 404;
+      return result;
+    } catch (error) {
+      set.status = 500;
+      return { success: false, message: "Error eliminando gasto", error: String(error) };
+    }
+  });

--- a/apps/cartera-back/src/routers/index.ts
+++ b/apps/cartera-back/src/routers/index.ts
@@ -31,6 +31,10 @@ import { creditosNuevosConAbonosRouter } from "./creditosNuevosConAbonos";
 import { cuentasExtraInversionistaRouter } from "./cuentasExtraInversionista";
 import { cierreMensualRouter } from "./cierreMensual";
 import { actualizarPagosExcelRouter } from "./actualizarPagosExcel";
+import { gastosAdministrativosRouter } from "./gastosAdministrativos";
+import { metasFacturacionRouter } from "./metasFacturacion";
+import { facturacionSnapshotRouter } from "./facturacionSnapshot";
+import { ingresosCarrosRouter } from "./ingresosCarros";
 export {
-    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,devolucionRouter,creditosNuevosConAbonosRouter,cuentasExtraInversionistaRouter,cierreMensualRouter,actualizarPagosExcelRouter
+    defaultRouter,inversionistasRouter,advisorRouter,usersRouter,creditRouter,paymentRouter,uploadRouter,sifcoRouter,authRouter,morasRouter,bancosRouter,cuentasRoutes,paymentAgreementsRouter,dteController,recalculateFromJsonRouter,mirrorInvestorRouter,notificationsRouter,reconcileEspejoRouter,investorDocumentsRouter,abonosCapitalRouter,recibosGenericosRouter,fallenCreditsRouter,sifcoSyncRouter,assignCapitalRouter,addInvestorToCreditRouter,completeEspejoRouter,replaceInvestorCreditRouter,compraCarteraAceptadaRouter,devolucionRouter,creditosNuevosConAbonosRouter,cuentasExtraInversionistaRouter,cierreMensualRouter,actualizarPagosExcelRouter,gastosAdministrativosRouter,metasFacturacionRouter,facturacionSnapshotRouter,ingresosCarrosRouter
 }

--- a/apps/cartera-back/src/routers/ingresosCarros.ts
+++ b/apps/cartera-back/src/routers/ingresosCarros.ts
@@ -1,0 +1,64 @@
+import { Elysia, t } from "elysia";
+import { authMiddleware } from "./midleware";
+import {
+  crearIngresoCarro,
+  eliminarIngresoCarro,
+  listarIngresosCarros,
+} from "../controllers/ingresosCarros";
+
+export const ingresosCarrosRouter = new Elysia({
+  prefix: "/api/ingresos-carros",
+})
+  .use(authMiddleware)
+
+  // POST - Crear un ingreso por carro (concepto + monto en una fecha).
+  .post(
+    "/",
+    async ({ body, user, set }: any) => {
+      try {
+        const result = await crearIngresoCarro({
+          fecha: body.fecha,
+          concepto: body.concepto,
+          monto: body.monto,
+          created_by: user?.id ?? null,
+        });
+        set.status = 201;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error creando ingreso", error: String(error) };
+      }
+    },
+    {
+      body: t.Object({
+        fecha: t.String(), // "YYYY-MM-DD"
+        concepto: t.String(),
+        monto: t.Union([t.Number(), t.String()]),
+      }),
+    }
+  )
+
+  // GET - Listar. ?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD (opcionales).
+  .get("/", async ({ query, set }: any) => {
+    try {
+      return await listarIngresosCarros({
+        fechaInicio: query.fechaInicio,
+        fechaFin: query.fechaFin,
+      });
+    } catch (error) {
+      set.status = 500;
+      return { success: false, message: "Error listando ingresos", error: String(error) };
+    }
+  })
+
+  // DELETE - Eliminar por id.
+  .delete("/:id", async ({ params, set }: any) => {
+    try {
+      const result = await eliminarIngresoCarro(Number(params.id));
+      if (!result.success) set.status = 404;
+      return result;
+    } catch (error) {
+      set.status = 500;
+      return { success: false, message: "Error eliminando ingreso", error: String(error) };
+    }
+  });

--- a/apps/cartera-back/src/routers/metasFacturacion.ts
+++ b/apps/cartera-back/src/routers/metasFacturacion.ts
@@ -1,0 +1,51 @@
+import { Elysia, t } from "elysia";
+import { authMiddleware } from "./midleware";
+import {
+  getMetasFacturacion,
+  upsertMetaFacturacion,
+} from "../controllers/metasFacturacion";
+
+export const metasFacturacionRouter = new Elysia({
+  prefix: "/api/metas-facturacion",
+})
+  .use(authMiddleware)
+
+  // POST - Crear o actualizar la meta de un (anio, mes). Upsert por (anio, mes).
+  .post(
+    "/",
+    async ({ body, set }: any) => {
+      try {
+        const result = await upsertMetaFacturacion(body);
+        set.status = 200;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error guardando meta", error: String(error) };
+      }
+    },
+    {
+      body: t.Object({
+        anio: t.Number(),
+        mes: t.Number(), // 1-12
+        meta_mensual: t.Optional(t.Union([t.Number(), t.String(), t.Null()])),
+        meta_semanal: t.Optional(t.Union([t.Number(), t.String(), t.Null()])),
+        meta_diaria: t.Optional(t.Union([t.Number(), t.String(), t.Null()])),
+        deuda_mensual: t.Optional(t.Union([t.Number(), t.String(), t.Null()])),
+        deuda_semanal: t.Optional(t.Union([t.Number(), t.String(), t.Null()])),
+        deuda_diaria: t.Optional(t.Union([t.Number(), t.String(), t.Null()])),
+      }),
+    }
+  )
+
+  // GET - Consultar metas. ?anio=2026&mes=6 (ambos opcionales).
+  .get("/", async ({ query, set }: any) => {
+    try {
+      return await getMetasFacturacion({
+        anio: query.anio ? Number(query.anio) : undefined,
+        mes: query.mes ? Number(query.mes) : undefined,
+      });
+    } catch (error) {
+      set.status = 500;
+      return { success: false, message: "Error obteniendo metas", error: String(error) };
+    }
+  });


### PR DESCRIPTION
## 🎯 Qué hace
Endpoints del módulo **Facturación Diaria**: snapshot diario tipo Excel + registros manuales.

> 🔗 **Stacked sobre #834** (base = `feat/cartera-facturacion-back-db`). Mergear #834 primero. El diff acá es solo la capa de API.

## 📦 Cambios
- **`facturacionSnapshot`** (controller+router):
  - `POST /api/facturacion-snapshot/generar` — genera/regenera el snapshot de un día (matriz categoría×rubro + acumulados/tendencias/metas).
  - `GET /api/facturacion-snapshot?fechaInicio&fechaFin` — lee el rango **con `totales` por columna**.
  - `GET /api/facturacion-snapshot/excel` — Excel con **logo Cash-In**, headers agrupados y fila TOTALES.
  - `POST /aplicar-meta-mes` y `POST /aplicar-manuales-dia` — updates **quirúrgicos** (solo columnas de meta / carros+gastos) que **no recalculan** los montos.
- **CRUD** de `gastos-administrativos`, `metas-facturacion` (upsert por año/mes) e `ingresos-carros`.
- **`schedule.ts`**: job diario 01:00 GT que genera el snapshot de *ayer* si falta.
- Registro de routers en `index`.

## 🧪 Pruebas
- Probado en local: generar/leer snapshot, totales, Excel (xlsx válido + logo), aplicar-meta-mes (preserva montos importados), aplicar-manuales-dia. `tsc` sin errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)