### PR TITLE
fix(cartera): order statement capital payments

### DIFF
--- a/apps/cartera-back/src/controllers/reports.test.ts
+++ b/apps/cartera-back/src/controllers/reports.test.ts
@@ -21,7 +21,7 @@ mock.module("@cci/email", () => ({
   sendInvestorAddedToCreditsNotification: mock(() => Promise.resolve()),
 }));
 
-const { buildEstadoCuentaTableHeader, renderEstadoCuentaPaymentRow, shouldIncludeEstadoCuentaPayment } = await import("./reports");
+const { applyEstadoCuentaRunningCapital, buildEstadoCuentaTableHeader, renderEstadoCuentaPaymentRow, shouldIncludeEstadoCuentaPayment, sortEstadoCuentaPayments } = await import("./reports");
 
 describe("estado de cuenta PDF", () => {
   it("incluye la columna de fecha de aplicacion del pago", () => {
@@ -106,6 +106,25 @@ describe("estado de cuenta PDF", () => {
     ).toBe(true);
   });
 
+  it("incluye reducciones de capital mixtas cuando ya fueron aplicadas", () => {
+    expect(
+      shouldIncludeEstadoCuentaPayment({
+        pagado: false,
+        paymentFalse: false,
+        validationStatus: "validated",
+        abono_capital: "456.39",
+        abono_interes: "0.00",
+        abono_iva_12: "0.00",
+        abono_seguro: "934.54",
+        abono_gps: "0.00",
+        membresias_pago: "484.07",
+        monto_aplicado: "1875.00",
+        fecha_pago: new Date("2026-06-08T22:31:28.000Z"),
+        fecha_aplicado: new Date("2026-06-09T21:44:42.260Z"),
+      }),
+    ).toBe(true);
+  });
+
   it("no incluye cuotas futuras sincronizadas aunque esten validadas", () => {
     expect(
       shouldIncludeEstadoCuentaPayment({
@@ -119,7 +138,67 @@ describe("estado de cuenta PDF", () => {
         abono_gps: "0.00",
         membresias_pago: "399.73",
         monto_aplicado: "1922.31",
+        fecha_pago: new Date("2030-12-30T06:00:00.000Z"),
+        fecha_aplicado: new Date("2030-12-30T06:00:00.000Z"),
       }),
     ).toBe(false);
+  });
+
+  it("ordena pagos de la misma cuota por fecha de pago", () => {
+    const sorted = sortEstadoCuentaPayments([
+      {
+        pago_id: 134345,
+        numero_cuota: 7,
+        fecha_pago: new Date("2026-06-01T22:03:29.000Z"),
+      },
+      {
+        pago_id: 17420,
+        numero_cuota: 7,
+        fecha_pago: new Date("2026-05-29T21:11:16.000Z"),
+      },
+      {
+        pago_id: 127060,
+        numero_cuota: 7,
+        fecha_pago: new Date("2026-05-09T02:31:31.111Z"),
+      },
+    ]);
+
+    expect(sorted.map((p) => p.pago_id)).toEqual([127060, 17420, 134345]);
+  });
+
+  it("calcula capital restante corrido para parciales y abonos a capital", () => {
+    const rows = applyEstadoCuentaRunningCapital([
+      {
+        pago_id: 17419,
+        pagado: true,
+        abono_capital: "1319.93",
+        abono_interes: "1767.89",
+        total_restante: "116539.07",
+      },
+      {
+        pago_id: 127060,
+        abono_capital: "0.00",
+        total_restante: "0.00",
+      },
+      {
+        pago_id: 17420,
+        pagado: true,
+        abono_capital: "1342.11",
+        abono_interes: "1748.09",
+        total_restante: "115196.94",
+      },
+      {
+        pago_id: 134345,
+        abono_capital: "75000.00",
+        total_restante: "39720.74",
+      },
+    ]);
+
+    expect(rows.map((p) => p.total_restante)).toEqual([
+      "116539.07",
+      "116539.07",
+      "115196.94",
+      "40196.94",
+    ]);
   });
 });

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -28,8 +28,22 @@ type EstadoCuentaPagoRow = {
   monto_aplicado?: number | string | null;
   total_restante?: number | string | null;
   fecha_vencimiento?: Date | string | null;
+  fecha_pago?: Date | string | null;
   fecha_aplicado?: Date | string | null;
 };
+
+const toEstadoCuentaTime = (fecha?: Date | string | null) => {
+  if (!fecha) return Number.MAX_SAFE_INTEGER;
+  const time = new Date(fecha).getTime();
+  return Number.isNaN(time) ? Number.MAX_SAFE_INTEGER : time;
+};
+
+const getEstadoCuentaOtrosRubros = (pago: EstadoCuentaPagoRow) =>
+  Number(pago.abono_interes || 0) +
+  Number(pago.abono_iva_12 || 0) +
+  Number(pago.abono_seguro || 0) +
+  Number(pago.abono_gps || 0) +
+  Number(pago.membresias_pago || 0);
 
 export function shouldIncludeEstadoCuentaPayment(pago: EstadoCuentaPagoRow) {
   if (pago.paymentFalse === true) return false;
@@ -37,19 +51,58 @@ export function shouldIncludeEstadoCuentaPayment(pago: EstadoCuentaPagoRow) {
 
   const abonoCapital = Number(pago.abono_capital || 0);
   const montoAplicado = Number(pago.monto_aplicado || 0);
-  const totalOtrosRubros =
-    Number(pago.abono_interes || 0) +
-    Number(pago.abono_iva_12 || 0) +
-    Number(pago.abono_seguro || 0) +
-    Number(pago.abono_gps || 0) +
-    Number(pago.membresias_pago || 0);
+  const fechaPago = pago.fecha_pago ? new Date(pago.fecha_pago) : null;
+  const pagoNoEsFuturo = fechaPago ? fechaPago <= new Date() : false;
+  const totalOtrosRubros = getEstadoCuentaOtrosRubros(pago);
+  const esAbonoCapitalPuro = totalOtrosRubros === 0;
+  const fueAplicado =
+    pago.fecha_aplicado !== null && pago.fecha_aplicado !== undefined;
 
   return (
     pago.validationStatus === "validated" &&
     abonoCapital > 0 &&
     montoAplicado > 0 &&
-    totalOtrosRubros === 0
+    (esAbonoCapitalPuro || (fueAplicado && pagoNoEsFuturo))
   );
+}
+
+export function sortEstadoCuentaPayments<T extends EstadoCuentaPagoRow>(pagos: T[]) {
+  return [...pagos].sort((a, b) => {
+    const cuotaDiff = Number(a.numero_cuota ?? 0) - Number(b.numero_cuota ?? 0);
+    if (cuotaDiff !== 0) return cuotaDiff;
+
+    const fechaDiff = toEstadoCuentaTime(a.fecha_pago) - toEstadoCuentaTime(b.fecha_pago);
+    if (fechaDiff !== 0) return fechaDiff;
+
+    return Number(a.pago_id ?? 0) - Number(b.pago_id ?? 0);
+  });
+}
+
+export function applyEstadoCuentaRunningCapital<T extends EstadoCuentaPagoRow>(pagos: T[]) {
+  let capitalRestante: Big | null = null;
+
+  return pagos.map((pago) => {
+    const abonoCapital = new Big(pago.abono_capital || 0);
+    const totalRestanteFila = new Big(pago.total_restante || 0);
+    const tieneRubrosDeCuota = getEstadoCuentaOtrosRubros(pago) > 0;
+    const snapshotConfiable =
+      pago.pagado === true && tieneRubrosDeCuota && totalRestanteFila.gt(0);
+
+    if (capitalRestante === null) {
+      capitalRestante = snapshotConfiable
+        ? totalRestanteFila
+        : totalRestanteFila.plus(abonoCapital);
+    }
+
+    capitalRestante = snapshotConfiable
+      ? totalRestanteFila
+      : capitalRestante.minus(abonoCapital);
+
+    return {
+      ...pago,
+      total_restante: capitalRestante.toFixed(2),
+    };
+  });
 }
 
 const formatEstadoCuentaMoney = (n: number) =>
@@ -429,7 +482,11 @@ export async function exportPagosToExcel(credito_sifco: string) {
   let totalCapital = 0;
   let totalInteres = 0;
 
-  const tableRows = pagosFiltrados.map(({ pago }, index) => {
+  const pagosOrdenados = applyEstadoCuentaRunningCapital(
+    sortEstadoCuentaPayments(pagosFiltrados.map(({ pago }) => pago))
+  );
+
+  const tableRows = pagosOrdenados.map((pago, index) => {
     const montoAplicado = Number(pago.monto_aplicado || 0);
     const capitalPago = Number(pago.abono_capital || 0);
     const interesPago = Number(pago.abono_interes || 0);
@@ -562,7 +619,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
     <div class="summary">
       <div class="summary-card">
         <div class="label">Total Pagos</div>
-        <div class="value">${pagosFiltrados.length}</div>
+        <div class="value">${pagosOrdenados.length}</div>
       </div>
       <div class="summary-card">
         <div class="label">Capital Abonado</div>


### PR DESCRIPTION
## Summary
- Orders account statement rows by installment and payment date so capital payments appear in sequence
- Keeps validated capital reductions in the statement while excluding future synchronized rows
- Computes displayed running capital balance to avoid stale row snapshots causing jumps in Capital Rest.

## Verification
- bun test src/controllers/reports.test.ts

## Notes
- Investigated Karen Azucena Lopez Lopez: current credit capital matches the applied sequence, Q40,196.94.
- The Q0.02 mismatch comes from a historical row snapshot before the large capital payment, so this PR fixes report presentation without mutating production data.