### PR TITLE
feat(vehicles): sort list by latest inspection date, uninspected last

### DIFF
--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -181,20 +181,19 @@ export const vehiclesRouter = {
 				category === "alerts" ||
 				isInspectionStatus;
 
+			// Always LEFT JOIN for ordering by latest inspection date
 			const idsQueryBase = db
-				.selectDistinct({ id: vehicles.id, createdAt: vehicles.createdAt })
-				.from(vehicles);
+				.select({ id: vehicles.id, createdAt: vehicles.createdAt })
+				.from(vehicles)
+				.leftJoin(vehicleInspections, eq(vehicles.id, vehicleInspections.vehicleId))
+				.groupBy(vehicles.id, vehicles.createdAt);
 
 			const countQueryBase = db
 				.select({ count: sql<number>`count(distinct ${vehicles.id})` })
 				.from(vehicles);
 
-			const idsQuery = needsJoin
-				? idsQueryBase.innerJoin(
-						vehicleInspections,
-						eq(vehicles.id, vehicleInspections.vehicleId),
-					)
-				: idsQueryBase;
+			// idsQuery always has the leftJoin; countQuery only joins when needed for filters
+			const idsQuery = idsQueryBase;
 
 			const countQuery = needsJoin
 				? countQueryBase.innerJoin(
@@ -211,7 +210,10 @@ export const vehiclesRouter = {
 
 			const paginatedIds = await idsQuery
 				.where(whereClause)
-				.orderBy(desc(vehicles.createdAt))
+				.orderBy(
+				sql`CASE WHEN MAX(${vehicleInspections.inspectionDate}) IS NULL THEN 1 ELSE 0 END ASC`,
+				sql`COALESCE(MAX(${vehicleInspections.inspectionDate}), ${vehicles.createdAt}) DESC`,
+			)
 				.limit(limit)
 				.offset(offset);
 
@@ -235,7 +237,7 @@ export const vehiclesRouter = {
 					eq(vehicles.id, vehicleInspections.vehicleId),
 				)
 				.where(or(...vehicleIdsArray.map((id) => eq(vehicles.id, id))))
-				.orderBy(desc(vehicles.createdAt));
+				.orderBy(desc(vehicleInspections.inspectionDate), desc(vehicles.createdAt));
 
 			// Get photos only for these vehicles
 			const allPhotos = await db


### PR DESCRIPTION
Problema: El listado mostraba vehículos sin orden útil — mezclaba vehículos con y sin inspección, priorizando los más recientemente creados.

Causa raíz: La query usaba selectDistinct + ORDER BY created_at DESC. Intentar cambiar el orden a COALESCE(MAX(inspection_date), ...) causaba error 500 porque PostgreSQL exige que expresiones en ORDER BY aparezcan en el SELECT list cuando se usa DISTINCT.

Solución: En apps/crm/apps/server/src/routers/vehicles.ts:

Reemplazó selectDistinct por select + LEFT JOIN vehicle_inspections + GROUP BY vehicles.id — elimina la restricción de PostgreSQL y permite usar agregados en ORDER BY.
Nuevo orden de la lista (dos niveles):
Vehículos con inspección primero → ordenados por MAX(inspection_date) DESC
Vehículos sin inspección al fondo → ordenados por created_at DESC
El query secundario (fetch de datos completos) ahora ordena inspecciones por inspectionDate DESC, createdAt DESC, garantizando que inspections[0] siempre sea la inspección más reciente.
Archivos modificados:

apps/crm/apps/server/src/routers/vehicles.ts