### PR TITLE
feat(reportes): add flujo de cuotas inversiones report generation

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -160,10 +160,15 @@ export async function getFlujoCuotasInversiones({
       if (!cashParcialPorTipo[tipo]) cashParcialPorTipo[tipo] = { capital: 0, interes: 0, iva: 0, monto_cash: 0 };
       const totalCuota = capital + interes + iva;
       const montoReinvInv = Number(row.monto_reinversion_inv ?? 0);
-      if (tipo === "reinversion_variable" || tipo === "reinversion_excedente") {
+      if (tipo === "reinversion_variable") {
         const reinvertido = Math.min(montoReinvInv, totalCuota);
         reinvPorTipo[tipo].monto_reinvertido += reinvertido;
         cashParcialPorTipo[tipo].monto_cash += Math.max(0, totalCuota - reinvertido);
+      } else if (tipo === "reinversion_excedente") {
+        // monto_reinversion = monto fijo que RECIBE en cash; el sobrante se reinvierte
+        const recibe = Math.min(montoReinvInv, totalCuota);
+        cashParcialPorTipo[tipo].monto_cash += recibe;
+        reinvPorTipo[tipo].monto_reinvertido += Math.max(0, totalCuota - recibe);
       } else if (tipo === "reinversion_capital") {
         reinvPorTipo[tipo].capital += capital;
         cashParcialPorTipo[tipo].interes += interes;

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -103,6 +103,143 @@ export async function getCobradoDelMes({
   };
 }
 
+export async function getFlujoCuotasInversiones({
+  fechaInicio,
+  fechaFin,
+}: {
+  fechaInicio: string;
+  fechaFin: string;
+}) {
+  const rows = await db.execute(sql`
+    SELECT
+      CASE
+        WHEN i.tipo_reinversion = 'reinversion_combinada'
+        THEN COALESCE(ce.tipo_reinversion::text, 'sin_reinversion')
+        ELSE i.tipo_reinversion::text
+      END AS tipo_reinv_efectivo,
+      i.inversionista_id,
+      i.nombre,
+      COALESCE(SUM(ci.cuota_inversionista::numeric), 0) AS total_capital,
+      COALESCE(SUM(ci.monto_inversionista::numeric), 0) AS total_interes,
+      COALESCE(SUM(ci.iva_inversionista::numeric), 0)   AS total_iva,
+      MAX(i.monto_reinversion::numeric)                  AS monto_reinversion_inv
+    FROM cartera.cuotas_credito c
+    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+    JOIN cartera.creditos_inversionistas ci ON cr.credito_id = ci.credito_id
+    JOIN cartera.inversionistas i ON ci.inversionista_id = i.inversionista_id
+    LEFT JOIN cartera.creditos_inversionistas_espejo ce
+      ON cr.credito_id = ce.credito_id AND ci.inversionista_id = ce.inversionista_id
+    WHERE c.pagado = false
+      AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
+      AND c.fecha_vencimiento >= ${fechaInicio}::date
+      AND c.fecha_vencimiento <= ${fechaFin}::date
+    GROUP BY tipo_reinv_efectivo, i.inversionista_id, i.nombre
+    ORDER BY tipo_reinv_efectivo, i.nombre
+  `);
+
+  const extrasRows = await db.execute(sql`
+    SELECT tipo, COALESCE(SUM(monto::numeric), 0) AS total
+    FROM cartera.abonos_capital
+    WHERE created_at::date >= ${fechaInicio}::date
+      AND created_at::date <= ${fechaFin}::date
+    GROUP BY tipo
+  `);
+
+  const reinvPorTipo: Record<string, { capital: number; interes: number; iva: number; monto_reinvertido: number }> = {};
+  const cashParcialPorTipo: Record<string, { capital: number; interes: number; iva: number; monto_cash: number }> = {};
+  const sinReinvTotals = { capital: 0, interes: 0, iva: 0 };
+  const porInversionista: Record<number, { inversionista_id: number; nombre: string; capital: number; interes: number; iva: number }> = {};
+
+  for (const row of rows.rows as Record<string, unknown>[]) {
+    const capital = Number(row.total_capital);
+    const interes = Number(row.total_interes);
+    const iva = Number(row.total_iva);
+    const tipo = String(row.tipo_reinv_efectivo);
+    if (tipo !== "sin_reinversion") {
+      if (!reinvPorTipo[tipo]) reinvPorTipo[tipo] = { capital: 0, interes: 0, iva: 0, monto_reinvertido: 0 };
+      if (!cashParcialPorTipo[tipo]) cashParcialPorTipo[tipo] = { capital: 0, interes: 0, iva: 0, monto_cash: 0 };
+      const totalCuota = capital + interes + iva;
+      const montoReinvInv = Number(row.monto_reinversion_inv ?? 0);
+      if (tipo === "reinversion_variable" || tipo === "reinversion_excedente") {
+        const reinvertido = Math.min(montoReinvInv, totalCuota);
+        reinvPorTipo[tipo].monto_reinvertido += reinvertido;
+        cashParcialPorTipo[tipo].monto_cash += Math.max(0, totalCuota - reinvertido);
+      } else if (tipo === "reinversion_capital") {
+        reinvPorTipo[tipo].capital += capital;
+        cashParcialPorTipo[tipo].interes += interes;
+        cashParcialPorTipo[tipo].iva += iva;
+      } else if (tipo === "reinversion_interes") {
+        reinvPorTipo[tipo].interes += interes;
+        reinvPorTipo[tipo].iva += iva;
+        cashParcialPorTipo[tipo].capital += capital;
+      } else {
+        // reinversion_total: nada va a cash
+        reinvPorTipo[tipo].capital += capital;
+        reinvPorTipo[tipo].interes += interes;
+        reinvPorTipo[tipo].iva += iva;
+      }
+    } else {
+      sinReinvTotals.capital += capital;
+      sinReinvTotals.interes += interes;
+      sinReinvTotals.iva += iva;
+      const id = Number(row.inversionista_id);
+      if (!porInversionista[id]) {
+        porInversionista[id] = { inversionista_id: id, nombre: String(row.nombre), capital: 0, interes: 0, iva: 0 };
+      }
+      porInversionista[id].capital += capital;
+      porInversionista[id].interes += interes;
+      porInversionista[id].iva += iva;
+    }
+  }
+
+  let abonosCapital = 0;
+  let cancelaciones = 0;
+  for (const row of extrasRows.rows as Record<string, unknown>[]) {
+    if (row.tipo === "CAPITAL") abonosCapital = Number(row.total);
+    if (row.tipo === "CANCELACION") cancelaciones = Number(row.total);
+  }
+
+  const fmt = (n: number) => n.toFixed(2);
+
+  return {
+    reinversionPorTipo: Object.entries(reinvPorTipo).map(([tipo, v]) => ({
+      tipo,
+      capital: fmt(v.capital),
+      interes: fmt(v.interes),
+      iva: fmt(v.iva),
+      monto_reinvertido: v.monto_reinvertido > 0 ? fmt(v.monto_reinvertido) : undefined,
+    })),
+    cashParcialPorTipo: Object.entries(cashParcialPorTipo)
+      .filter(([, v]) => v.capital + v.interes + v.iva + v.monto_cash > 0)
+      .map(([tipo, v]) => ({
+        tipo,
+        capital: fmt(v.capital),
+        interes: fmt(v.interes),
+        iva: fmt(v.iva),
+        monto_cash: v.monto_cash > 0 ? fmt(v.monto_cash) : undefined,
+      })),
+    sinReinversion: {
+      totales: {
+        capital: fmt(sinReinvTotals.capital),
+        interes: fmt(sinReinvTotals.interes),
+        iva: fmt(sinReinvTotals.iva),
+      },
+      porInversionista: Object.values(porInversionista).map((inv) => ({
+        inversionista_id: inv.inversionista_id,
+        nombre: inv.nombre,
+        capital: fmt(inv.capital),
+        interes: fmt(inv.interes),
+        iva: fmt(inv.iva),
+      })),
+    },
+    pagosExtras: {
+      abonos_capital: fmt(abonosCapital),
+      cancelaciones: fmt(cancelaciones),
+    },
+  };
+}
+
+
 export async function getEsperadoDelMes({
   mes,
   anio,

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,9 +1,11 @@
 import { Elysia } from "elysia";
-import { getCobradoDelMes, getEsperadoDelMes, getMontoACobrar } from "../controllers/reportes";
+import { getCobradoDelMes, getEsperadoDelMes, getFlujoCuotasInversiones, getMontoACobrar } from "../controllers/reportes";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
 type PeriodoValido = typeof PERIODOS_VALIDOS[number];
+
+const FECHA_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 function validarPeriodo(periodo: string | undefined, set: { status: number }): PeriodoValido | null {
   const p = periodo || "mes";
@@ -22,6 +24,10 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       if (!fechaInicio || !fechaFin) {
         set.status = 400;
         return { error: "fechaInicio y fechaFin son requeridos" };
+      }
+      if (!FECHA_REGEX.test(fechaInicio) || !FECHA_REGEX.test(fechaFin)) {
+        set.status = 400;
+        return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
       const p = validarPeriodo(periodo, set);
       if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };
@@ -49,6 +55,27 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/facturacion-mes-cobrado]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/flujo-cuotas-inversiones", async ({ query, set }) => {
+    try {
+      const { fechaInicio, fechaFin } = query as Record<string, string>;
+      if (!fechaInicio || !fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio y fechaFin son requeridos" };
+      }
+      if (!FECHA_REGEX.test(fechaInicio) || !FECHA_REGEX.test(fechaFin)) {
+        set.status = 400;
+        return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
+      }
+      const data = await getFlujoCuotasInversiones({ fechaInicio, fechaFin });
+      set.status = 200;
+      return data;
+    } catch (error) {
+      console.error("[/reportes/flujo-cuotas-inversiones]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -332,6 +332,7 @@ export const reportsAppRouter = {
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,
 	getMontoACobrar: reportesCarteraRouter.getMontoACobrar,
 	getFacturacionMes: reportesCarteraRouter.getFacturacionMes,
+	getFlujoCuotasInversiones: reportesCarteraRouter.getFlujoCuotasInversiones,
 
 	// MiniAgent routes
 	getMiniAgentCredentials: miniagentRouter.getMiniAgentCredentials,

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -14,6 +14,7 @@ import { adminProcedure } from "../lib/orpc";
 import {
 	carteraBackClient,
 	type FacturacionMesResponse,
+	type FlujoCuotasInversionesResponse,
 	type MontoACobrarRow,
 } from "../services/cartera-back-client";
 import { isCarteraBackEnabled } from "../services/cartera-back-integration";
@@ -407,8 +408,8 @@ export const reportesCarteraRouter = {
 				periodo: z
 					.enum(["anio", "trimestre", "mes", "semana", "dia"])
 					.default("mes"),
-				fechaInicio: z.string(),
-				fechaFin: z.string(),
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
 			}),
 		)
 		.handler(async ({ input }): Promise<{ data: MontoACobrarRow[] }> => {
@@ -450,4 +451,27 @@ export const reportesCarteraRouter = {
 				anio: input.anio,
 			});
 		}),
+
+	getFlujoCuotasInversiones: adminProcedure
+		.input(
+			z.object({
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+			}),
+		)
+		.handler(
+			async ({ input }): Promise<FlujoCuotasInversionesResponse> => {
+				if (!isCarteraBackEnabled()) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: "Integración con cartera-back no está habilitada",
+					});
+				}
+
+				return carteraBackClient.getFlujoCuotasInversiones({
+					fechaInicio: input.fechaInicio,
+					fechaFin: input.fechaFin,
+				});
+			},
+		),
+
 };

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -210,6 +210,30 @@ export type MontoACobrarRow = {
 	mora_promedio: string;
 };
 
+export type FlujoCuotasRubro = {
+	capital: string;
+	interes: string;
+	iva: string;
+};
+
+export type FlujoCuotasInversionista = FlujoCuotasRubro & {
+	inversionista_id: number;
+	nombre: string;
+};
+
+export type FlujoCuotasInversionesResponse = {
+	reinversionPorTipo: (FlujoCuotasRubro & { tipo: string; monto_reinvertido?: string })[];
+	cashParcialPorTipo: (FlujoCuotasRubro & { tipo: string; monto_cash?: string })[];
+	sinReinversion: {
+		totales: FlujoCuotasRubro;
+		porInversionista: FlujoCuotasInversionista[];
+	};
+	pagosExtras: {
+		abonos_capital: string;
+		cancelaciones: string;
+	};
+};
+
 // ============================================================================
 // HTTP CLIENT
 // ============================================================================
@@ -1240,6 +1264,21 @@ export class CarteraBackClient {
 		};
 
 		return { cobrado, esperado };
+	}
+
+	async getFlujoCuotasInversiones(params: {
+		fechaInicio: string;
+		fechaFin: string;
+	}): Promise<FlujoCuotasInversionesResponse> {
+		const qp = new URLSearchParams({
+			fechaInicio: params.fechaInicio,
+			fechaFin: params.fechaFin,
+		});
+		return this.request<FlujoCuotasInversionesResponse>(
+			`/reportes/flujo-cuotas-inversiones?${qp}`,
+			{ method: "GET" },
+			true,
+		);
 	}
 
 	// ========================================================================

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -101,6 +101,32 @@ type FacturacionMesResponse = {
 	esperado: FacturacionMesRubro;
 };
 
+type FlujoCuotasRubro = { capital: string; interes: string; iva: string };
+type FlujoCuotasInversionista = FlujoCuotasRubro & { inversionista_id: number; nombre: string };
+type FlujoCuotasInversionesResponse = {
+	reinversionPorTipo: (FlujoCuotasRubro & { tipo: string; monto_reinvertido?: string })[];
+	cashParcialPorTipo: (FlujoCuotasRubro & { tipo: string; monto_cash?: string })[];
+	sinReinversion: { totales: FlujoCuotasRubro; porInversionista: FlujoCuotasInversionista[] };
+	pagosExtras: { abonos_capital: string; cancelaciones: string };
+};
+
+const FLUJO_RUBROS: { key: keyof FlujoCuotasRubro; label: string }[] = [
+	{ key: "capital", label: "Capital" },
+	{ key: "interes", label: "Interés" },
+	{ key: "iva", label: "IVA 12%" },
+];
+
+function getDefaultFlujoCuotasRange(): { fechaInicio: string; fechaFin: string } {
+	const todayGt = formatDateInput(new Date());
+	const [year, month] = todayGt.split("-").map(Number);
+	const fechaInicio = `${year}-${String(month).padStart(2, "0")}-01`;
+	const nextM = month === 12 ? 1 : month + 1;
+	const nextY = month === 12 ? year + 1 : year;
+	const lastDay = new Date(`${nextY}-${String(nextM).padStart(2, "0")}-01T12:00:00`);
+	lastDay.setDate(lastDay.getDate() - 1);
+	return { fechaInicio, fechaFin: formatDateInput(lastDay) };
+}
+
 const FACTURACION_RUBROS: { key: keyof FacturacionMesRubro; label: string }[] = [
 	{ key: "capital", label: "Capital" },
 	{ key: "interes", label: "Interés" },
@@ -241,6 +267,7 @@ function RouteComponent() {
 		mes: new Date().getMonth() + 1,
 		anio: new Date().getFullYear(),
 	}));
+	const [flujoCuotasRange, setFlujoCuotasRange] = useState(getDefaultFlujoCuotasRange);
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const userRole = userProfile.data?.role;
@@ -291,6 +318,15 @@ function RouteComponent() {
 	const facturacionMesData = facturacionMesQuery.data as
 		| FacturacionMesResponse
 		| undefined;
+
+	const flujoCuotasQuery = useQuery({
+		...orpc.getFlujoCuotasInversiones.queryOptions({
+			input: { fechaInicio: flujoCuotasRange.fechaInicio, fechaFin: flujoCuotasRange.fechaFin },
+		}),
+		enabled: isAdmin,
+	});
+	const flujoCuotasData = flujoCuotasQuery.data as FlujoCuotasInversionesResponse | undefined;
+
 
 	useEffect(() => {
 		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
@@ -1069,8 +1105,225 @@ function RouteComponent() {
 							})()}
 						</CardContent>
 					</Card>
+
+					{/* Reporte: Flujo de Cuotas de Inversiones */}
+					<Card>
+						<CardHeader>
+							<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+								<div>
+									<CardTitle className="flex items-center gap-2">
+										<TrendingUp className="h-5 w-5" />
+										Flujo de Cuotas de Inversiones
+									</CardTitle>
+									<CardDescription>
+										Cuotas esperadas hacia reinversión y hacia pago en efectivo, por período
+									</CardDescription>
+								</div>
+								<div className="flex items-center gap-2">
+									<Input
+										type="date"
+										aria-label="Fecha inicio"
+										className="w-40"
+										value={flujoCuotasRange.fechaInicio}
+										onChange={(e) =>
+											setFlujoCuotasRange((prev) => ({ ...prev, fechaInicio: e.target.value }))
+										}
+									/>
+									<span className="text-muted-foreground text-sm">–</span>
+									<Input
+										type="date"
+										aria-label="Fecha fin"
+										className="w-40"
+										value={flujoCuotasRange.fechaFin}
+										onChange={(e) =>
+											setFlujoCuotasRange((prev) => ({ ...prev, fechaFin: e.target.value }))
+										}
+									/>
+								</div>
+							</div>
+						</CardHeader>
+						<CardContent className="space-y-6">
+							{flujoCuotasQuery.isPending && (
+								<div className="text-muted-foreground py-4 text-center text-sm">
+									Cargando...
+								</div>
+							)}
+							{flujoCuotasQuery.isError && (
+								<div className="text-destructive py-4 text-center text-sm">
+									Error al cargar datos
+								</div>
+							)}
+							{flujoCuotasData && (() => {
+								const { reinversionPorTipo, cashParcialPorTipo, sinReinversion, pagosExtras } = flujoCuotasData;
+								const TIPO_LABELS: Record<string, string> = {
+									reinversion_capital: "Reinversión Capital",
+									reinversion_interes: "Reinversión Interés",
+									reinversion_total: "Reinversión Total",
+									reinversion_variable: "Reinversión Variable",
+									reinversion_excedente: "Reinversión Excedente",
+								};
+								type ReinvertidoResult =
+									| { esTotal: true; total: number }
+									| { esTotal: false; capital: number; interes: number; iva: number };
+								function getReinvertido(tipo: string, t: FlujoCuotasRubro & { monto_reinvertido?: string }): ReinvertidoResult {
+									if (tipo === "reinversion_variable" || tipo === "reinversion_excedente")
+										return { esTotal: true, total: Number(t.monto_reinvertido ?? 0) };
+									if (tipo === "reinversion_capital")
+										return { esTotal: false, capital: Number(t.capital), interes: 0, iva: 0 };
+									if (tipo === "reinversion_interes")
+										return { esTotal: false, capital: 0, interes: Number(t.interes), iva: Number(t.iva) };
+									return { esTotal: false, capital: Number(t.capital), interes: Number(t.interes), iva: Number(t.iva) };
+								}
+								const totalesReinv = reinversionPorTipo.reduce(
+									(a, t) => {
+										const r = getReinvertido(t.tipo, t);
+										const tot = r.esTotal ? r.total : r.capital + r.interes + r.iva;
+										return {
+											total: a.total + tot,
+											capital: a.capital + (r.esTotal ? 0 : r.capital),
+											interes: a.interes + (r.esTotal ? 0 : r.interes),
+											iva: a.iva + (r.esTotal ? 0 : r.iva),
+										};
+									},
+									{ total: 0, capital: 0, interes: 0, iva: 0 },
+								);
+								const totalReinv = totalesReinv.total;
+								const cashParcialTotal = cashParcialPorTipo.reduce(
+									(a, t) => a + (t.monto_cash ? Number(t.monto_cash) : Number(t.capital) + Number(t.interes) + Number(t.iva)),
+									0,
+								);
+								const totalSinReinv = FLUJO_RUBROS.reduce((a, r) => a + Number(sinReinversion.totales[r.key] || 0), 0);
+								const totalExtras = Number(pagosExtras.abonos_capital) + Number(pagosExtras.cancelaciones);
+								return (
+									<>
+										{/* Sección 1: Hacia Reinversión por tipo */}
+										<div>
+											<p className="mb-2 text-sm font-semibold">Cuotas → Reinversión</p>
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Tipo de Reinversión</TableHead>
+														<TableHead className="text-right">Capital</TableHead>
+														<TableHead className="text-right">Interés</TableHead>
+														<TableHead className="text-right">IVA 12%</TableHead>
+														<TableHead className="text-right">Total</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{reinversionPorTipo.filter((t) => {
+														const r = getReinvertido(t.tipo, t);
+														const tot = r.esTotal ? r.total : r.capital + r.interes + r.iva;
+														return tot > 0;
+													}).map((t) => {
+														const r = getReinvertido(t.tipo, t);
+														const rowTotal = r.esTotal ? r.total : r.capital + r.interes + r.iva;
+														return (
+															<TableRow key={t.tipo}>
+																<TableCell>{TIPO_LABELS[t.tipo] ?? t.tipo}</TableCell>
+																<TableCell className="text-right text-muted-foreground">
+																	{r.esTotal ? "—" : formatCurrency(r.capital)}
+																</TableCell>
+																<TableCell className="text-right text-muted-foreground">
+																	{r.esTotal ? "—" : formatCurrency(r.interes)}
+																</TableCell>
+																<TableCell className="text-right text-muted-foreground">
+																	{r.esTotal ? "—" : formatCurrency(r.iva)}
+																</TableCell>
+																<TableCell className="text-right">{formatCurrency(rowTotal)}</TableCell>
+															</TableRow>
+														);
+													})}
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalesReinv.capital)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalesReinv.interes)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalesReinv.iva)}
+														</TableCell>
+														<TableCell className="text-right">{formatCurrency(totalReinv)}</TableCell>
+													</TableRow>
+												</TableBody>
+											</Table>
+										</div>
+
+										{/* Sección 2: Cash (sin reinversión + porciones cash de reinversión parcial) */}
+										<div>
+											<p className="mb-2 text-sm font-semibold">Cuotas → Cash</p>
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Origen</TableHead>
+														<TableHead className="text-right">Capital</TableHead>
+														<TableHead className="text-right">Interés</TableHead>
+														<TableHead className="text-right">IVA 12%</TableHead>
+														<TableHead className="text-right">Total</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{/* Inversionistas sin reinversión */}
+													<TableRow>
+														<TableCell>Sin Reinversión</TableCell>
+														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.capital))}</TableCell>
+														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.interes))}</TableCell>
+														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.iva))}</TableCell>
+														<TableCell className="text-right">{formatCurrency(totalSinReinv)}</TableCell>
+													</TableRow>
+													{/* Porciones cash de inversionistas con reinversión parcial — combinado */}
+													{cashParcialPorTipo.length > 0 && (
+														<TableRow>
+															<TableCell>Intereses y excedentes pagados a inversionistas</TableCell>
+															<TableCell colSpan={3} className="text-muted-foreground text-right text-sm">capital/interés/IVA según tipo</TableCell>
+															<TableCell className="text-right">{formatCurrency(cashParcialTotal)}</TableCell>
+														</TableRow>
+													)}
+													{/* Total general cash */}
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total Cash</TableCell>
+														<TableCell colSpan={3} />
+														<TableCell className="text-right">{formatCurrency(totalSinReinv + cashParcialTotal)}</TableCell>
+													</TableRow>
+												</TableBody>
+											</Table>
+										</div>
+
+										{/* Sección 3: Pagos Extras Recibidos */}
+										<div>
+											<p className="mb-2 text-sm font-semibold">Pagos Extras Recibidos</p>
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Tipo</TableHead>
+														<TableHead className="text-right">Monto</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													<TableRow>
+														<TableCell>Abonos Extra a Capital</TableCell>
+														<TableCell className="text-right">{formatCurrency(Number(pagosExtras.abonos_capital))}</TableCell>
+													</TableRow>
+													<TableRow>
+														<TableCell>Cancelaciones</TableCell>
+														<TableCell className="text-right">{formatCurrency(Number(pagosExtras.cancelaciones))}</TableCell>
+													</TableRow>
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total</TableCell>
+														<TableCell className="text-right">{formatCurrency(totalExtras)}</TableCell>
+													</TableRow>
+												</TableBody>
+											</Table>
+										</div>
+									</>
+								);
+							})()}
+						</CardContent>
+					</Card>
 				</>
 			)}
+
 		</div>
 	);
 }


### PR DESCRIPTION
# PR: Reporte de Flujo de Cuotas de Inversiones

## ¿Qué hace este PR?

Agrega el reporte **"Flujo de Cuotas de Inversiones"** al Dashboard Ejecutivo del CRM.

**Problema que resuelve:** el equipo de operaciones necesita saber, antes de que llegue cada fecha de corte, cuánto dinero en efectivo debe estar disponible para pagar a los inversionistas y cuánto quedará automáticamente reinvertido dentro del sistema. Sin este reporte, esa proyección se hacía manualmente.

**Resultado:** dado un rango de fechas (`fechaInicio` → `fechaFin`), el reporte responde:
- ¿Cuánto de las cuotas pendientes se reinvertirá? (desglosado por tipo de reinversión)
- ¿Cuánto debe salir de caja como pago en efectivo? (desglosado por origen)
- ¿Qué pagos extraordinarios de capital entraron en ese período?

---

## Flujo completo de datos

```
PostgreSQL (cartera-back DB)
  └─ controllers/reportes.ts          ← lógica de negocio + cálculos
       └─ routers/reportes.ts         ← endpoint HTTP con validaciones
            └─ cartera-back-client.ts ← cliente HTTP desde CRM server
                 └─ reportes-cartera.ts ← procedure oRPC con auth + validación Zod
                      └─ index.tsx    ← UI React con tablas y selector de fechas
```

---

## Capa 1 — Lógica de negocio (`apps/cartera-back/src/controllers/reportes.ts`)

### Query 1: cuotas pendientes por inversionista

```sql
SELECT
  CASE
    WHEN i.tipo_reinversion = 'reinversion_combinada'
    THEN COALESCE(ce.tipo_reinversion::text, 'sin_reinversion')
    ELSE i.tipo_reinversion::text
  END AS tipo_reinv_efectivo,
  i.inversionista_id,
  i.nombre,
  COALESCE(SUM(ci.cuota_inversionista::numeric), 0) AS total_capital,
  COALESCE(SUM(ci.monto_inversionista::numeric), 0) AS total_interes,
  COALESCE(SUM(ci.iva_inversionista::numeric), 0)   AS total_iva,
  MAX(i.monto_reinversion::numeric)                  AS monto_reinversion_inv
FROM cartera.cuotas_credito c
  JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
  JOIN cartera.creditos_inversionistas ci ON cr.credito_id = ci.credito_id
  JOIN cartera.inversionistas i ON ci.inversionista_id = i.inversionista_id
  LEFT JOIN cartera.creditos_inversionistas_espejo ce
    ON cr.credito_id = ce.credito_id AND ci.inversionista_id = ce.inversionista_id
WHERE c.pagado = false
  AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
  AND c.fecha_vencimiento BETWEEN :fechaInicio AND :fechaFin
GROUP BY tipo_reinv_efectivo, i.inversionista_id, i.nombre
ORDER BY tipo_reinv_efectivo, i.nombre
```

**Explicación paso a paso:**

**`FROM cuotas_credito c`** — punto de partida. Cada fila es una cuota mensual individual de un crédito. El filtro `c.pagado = false` descarta las ya cobradas: solo interesan cuotas que **todavía se esperan pagar**.

**`JOIN creditos cr ON c.credito_id = cr.credito_id`** — trae el estado del crédito. El filtro `statusCredit IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')` descarta créditos cancelados o incobrables: no tiene sentido proyectar flujos de créditos que ya no generarán pagos.

**`JOIN creditos_inversionistas ci ON cr.credito_id = ci.credito_id`** — esta tabla tiene **una fila por (crédito, inversionista)** con un índice único `(credito_id, inversionista_id)`. Cada fila almacena la parte proporcional que le corresponde al inversionista en cada cuota mensual de ese crédito: `cuota_inversionista` (capital), `monto_inversionista` (interés) e `iva_inversionista`. Al hacer el `JOIN` por `credito_id`, cada cuota en el rango de fechas produce una fila por cada inversionista participante en ese crédito. El `SUM` luego acumula todas esas cuotas del rango para obtener el total esperado por inversionista.

**`JOIN inversionistas i`** — trae el `tipo_reinversion` configurado en el perfil del inversionista y el `monto_reinversion` (usado para tipos variable/excedente).

**`LEFT JOIN creditos_inversionistas_espejo ce`** — esta tabla existe para el caso especial `reinversion_combinada`: un inversionista que tiene dos modalidades de reinversión simultáneas (una configurada en la tabla principal, otra en el espejo). El `LEFT JOIN` garantiza que si no hay fila en el espejo, el resultado sea `NULL` en lugar de que desaparezca la fila.

**`CASE WHEN i.tipo_reinversion = 'reinversion_combinada'`** — resuelve el tipo efectivo:
- Si el inversionista es `reinversion_combinada` → usa `ce.tipo_reinversion` (lo que dice el espejo).
- Si el espejo es `NULL` (no configurado aún) → cae a `'sin_reinversion'` via `COALESCE`.
- Para cualquier otro tipo → usa directamente `i.tipo_reinversion` sin modificación.

**`MAX(i.monto_reinversion)`** — trae el monto fijo de reinversión del inversionista. Se usa `MAX` porque el `GROUP BY` agrupa múltiples filas (una por cuota × inversionista) pero `monto_reinversion` es el mismo para todas las filas del mismo inversionista, así que `MAX` simplemente lo extrae sin cambios.

**`GROUP BY tipo_reinv_efectivo, i.inversionista_id, i.nombre`** — colapsa todas las cuotas del rango en una sola fila por (tipo de reinversión, inversionista). El resultado es: "inversionista X del tipo Y espera recibir en total Q_capital de capital, Q_interes de interés, Q_iva de IVA en el período".

---

### Query 2: pagos extraordinarios de capital

```sql
SELECT tipo, COALESCE(SUM(monto::numeric), 0) AS total
FROM cartera.abonos_capital
WHERE created_at::date BETWEEN :fechaInicio AND :fechaFin
GROUP BY tipo
```

La tabla `abonos_capital` registra dos tipos de eventos que no son cuotas regulares:
- **`CAPITAL`**: abonos voluntarios adelantados al capital (un cliente paga de más para reducir su deuda).
- **`CANCELACION`**: liquidaciones anticipadas completas de créditos.

Ambos generan entradas de caja que también afectan el flujo del período pero **no aparecen en `cuotas_credito`**, por eso tienen su propia query.

---

### Procesamiento TypeScript: distribución reinversión vs cash

Después de las dos queries, se procesan los resultados en memoria para separar qué parte de cada cuota va a reinversión y qué parte va a cash:

```typescript
const reinvPorTipo: Record<string, { capital, interes, iva, monto_reinvertido }> = {};
const cashParcialPorTipo: Record<string, { capital, interes, iva, monto_cash }> = {};
const sinReinvTotals = { capital: 0, interes: 0, iva: 0 };
const porInversionista: Record<number, { ... }> = {};
```

Se itera cada fila del resultado (un inversionista × un período) y se aplica la lógica según `tipo_reinv_efectivo`:

**Caso `reinversion_capital`**
El inversionista acordó reinvertir solo la parte de capital. Cada cuota se divide así:
```
→ Reinversión: capital (queda dentro del sistema como nuevo capital)
→ Cash:        interés + IVA (se paga en efectivo al inversionista)
```
```typescript
reinvPorTipo[tipo].capital        += capital
cashParcialPorTipo[tipo].interes  += interes
cashParcialPorTipo[tipo].iva      += iva
```

**Caso `reinversion_interes`**
El inversionista acordó reinvertir el interés y el IVA. El capital se le devuelve:
```
→ Reinversión: interés + IVA
→ Cash:        capital
```
```typescript
reinvPorTipo[tipo].interes       += interes
reinvPorTipo[tipo].iva           += iva
cashParcialPorTipo[tipo].capital += capital
```

**Caso `reinversion_total`**
El inversionista reinvierte el 100% de su cuota. No sale nada en cash:
```
→ Reinversión: capital + interés + IVA
→ Cash:        nada
```
```typescript
reinvPorTipo[tipo].capital += capital
reinvPorTipo[tipo].interes += interes
reinvPorTipo[tipo].iva     += iva
// cashParcialPorTipo no se toca
```

**Caso `reinversion_variable` / `reinversion_excedente`**
El inversionista tiene un monto fijo acordado de reinversión (`monto_reinversion_inv`). No se reinvierte por rubro (capital/interés/IVA) sino por un monto total:
```
totalCuota     = capital + interés + IVA
reinvertido    = min(monto_reinversion_inv, totalCuota)
cash_excedente = max(0, totalCuota - reinvertido)
```

Ejemplo concreto: inversionista con `monto_reinversion = Q1,000` y cuota total de Q1,400:
- Se reinvierten Q1,000 (el tope configurado).
- Se pagan Q400 en cash (el excedente que supera el tope).

Si la cuota total fuera Q800 (menor que el tope):
- Se reinvierten Q800 (toda la cuota, no puede reinvertir más de lo que entra).
- Se pagan Q0 en cash.

```typescript
const reinvertido = Math.min(montoReinvInv, totalCuota)
reinvPorTipo[tipo].monto_reinvertido += reinvertido
cashParcialPorTipo[tipo].monto_cash  += Math.max(0, totalCuota - reinvertido)
```

**Caso `sin_reinversion`**
El inversionista recibe todo en cash. Se acumula en dos estructuras:
- `sinReinvTotals`: totales globales (capital/interés/IVA sumados de todos los inversionistas sin reinversión).
- `porInversionista`: desglose individual para mostrar en la UI quién recibe qué.

```typescript
sinReinvTotals.capital += capital
sinReinvTotals.interes += interes
sinReinvTotals.iva     += iva
porInversionista[id].capital += capital   // por individuo
```

---

### Resultado final devuelto

```typescript
{
  reinversionPorTipo: [           // una entrada por tipo de reinversión
    { tipo, capital, interes, iva, monto_reinvertido? }
  ],
  cashParcialPorTipo: [           // porciones cash de inversionistas con reinv. parcial
    { tipo, capital, interes, iva, monto_cash? }
  ],
  sinReinversion: {
    totales: { capital, interes, iva },            // suma global sin-reinv
    porInversionista: [{ inversionista_id, nombre, capital, interes, iva }]
  },
  pagosExtras: {
    abonos_capital: "...",         // abonos adelantados de capital
    cancelaciones: "..."           // créditos liquidados anticipadamente
  }
}
```

Todos los montos se devuelven como `string` con 2 decimales fijos via `.toFixed(2)` para evitar problemas de precisión flotante en JSON.

---

## Capa 2 — Endpoint HTTP (`apps/cartera-back/src/routers/reportes.ts`)

```
GET /reportes/flujo-cuotas-inversiones?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD
```

Protegido por `authMiddleware` (Bearer token requerido, aplica a todo el router).

**Validaciones antes de llegar al controlador:**

1. **Presencia**: si falta `fechaInicio` o `fechaFin` → responde `400` con mensaje de error descriptivo. Evita que el controlador reciba `undefined` y lo pase al SQL.

2. **Formato**: `FECHA_REGEX = /^\d{4}-\d{2}-\d{2}$/` — valida que sean exactamente 4 dígitos, guión, 2 dígitos, guión, 2 dígitos. Sin esta validación, un string como `"banana"` o `"2026-1-1"` llegaría al cast `::date` de PostgreSQL, que lanzaría una excepción de SQL que el catch convertiría en un `500`. Con la regex, ese caso retorna `400` con un mensaje claro.

---

## Capa 3 — Tipos y cliente HTTP (`apps/crm/apps/server/src/services/cartera-back-client.ts`)

**Tipos exportados:**

```typescript
// Rubro base: los tres componentes de una cuota de inversionista
export type FlujoCuotasRubro = {
  capital: string;   // cuota_inversionista
  interes: string;   // monto_inversionista
  iva: string;       // iva_inversionista
};

// Inversionista individual con sus rubros
export type FlujoCuotasInversionista = FlujoCuotasRubro & {
  inversionista_id: number;
  nombre: string;
};

// Shape completo de la respuesta del endpoint
export type FlujoCuotasInversionesResponse = {
  reinversionPorTipo: (FlujoCuotasRubro & { tipo: string; monto_reinvertido?: string })[];
  cashParcialPorTipo: (FlujoCuotasRubro & { tipo: string; monto_cash?: string })[];
  sinReinversion: {
    totales: FlujoCuotasRubro;
    porInversionista: FlujoCuotasInversionista[];
  };
  pagosExtras: { abonos_capital: string; cancelaciones: string };
};
```

`monto_reinvertido` y `monto_cash` son `optional` porque solo aplican para los tipos `variable`/`excedente`. Para los demás tipos (que se expresan por rubro individual) estos campos son `undefined`.

**Método cliente:**
```typescript
async getFlujoCuotasInversiones(params: { fechaInicio, fechaFin })
```
Construye query params con `URLSearchParams`, llama al endpoint con autenticación automática (el cliente maneja refresh de token y reintentos), y devuelve la respuesta tipeada.

---

## Capa 4 — Procedure oRPC (`apps/crm/apps/server/src/routers/reportes-cartera.ts`)

```typescript
getFlujoCuotasInversiones: adminProcedure
  .input(z.object({
    fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
    fechaFin:    z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
  }))
  .handler(async ({ input }): Promise<FlujoCuotasInversionesResponse> => {
    if (!isCarteraBackEnabled()) throw new ORPCError("BAD_REQUEST", { ... })
    return carteraBackClient.getFlujoCuotasInversiones({ ... })
  })
```

- **`adminProcedure`**: solo usuarios con rol admin pueden ejecutarlo. Si el usuario no tiene el rol, oRPC rechaza antes de llegar al handler.
- **Zod regex en input**: valida el formato YYYY-MM-DD en el punto de entrada del CRM server, antes de enviar nada a cartera-back. Produce un error de validación descriptivo ("Formato YYYY-MM-DD requerido") en lugar de dejar que llegue un string malformado al backend.
- **`isCarteraBackEnabled()`**: guard que verifica la variable de entorno `CARTERA_BACK_URL`. Si el servicio no está configurado en el entorno actual, retorna `BAD_REQUEST` inmediatamente sin intentar una conexión que fallaría con un error críptico.
- **Retorno tipeado**: `Promise<FlujoCuotasInversionesResponse>` garantiza que el tipo fluya end-to-end hasta el frontend via la inferencia de oRPC.

---

## Capa 5 — Frontend (`apps/crm/apps/web/src/routes/admin/reports/index.tsx`)

### Estado y fetch

```typescript
const [flujoCuotasRange, setFlujoCuotasRange] = useState(getDefaultFlujoCuotasRange)
```

`getDefaultFlujoCuotasRange()` calcula el primer y último día del mes actual usando la zona horaria `America/Guatemala`:
1. Llama a `formatDateInput(new Date())` que formatea `Date` actual en zona GT usando `Intl.DateTimeFormat` con `timeZone: "America/Guatemala"` → produce un string `"YYYY-MM-DD"` en hora guatemalteca.
2. Extrae `year` y `month` del string ya formateado (no usa `Date.getMonth()` local, que daría el mes del browser y podría estar desfasado si el usuario está fuera de Guatemala).
3. `fechaInicio = YYYY-MM-01` (primer día del mes en GT).
4. Para `fechaFin`: calcula el primer día del mes siguiente, crea una `Date` a mediodía (para evitar problemas de DST), retrocede un día → obtiene el último día del mes actual, formatea de nuevo en zona GT.

```typescript
const flujoCuotasQuery = useQuery({
  ...orpc.getFlujoCuotasInversiones.queryOptions({
    input: { fechaInicio: flujoCuotasRange.fechaInicio, fechaFin: flujoCuotasRange.fechaFin }
  }),
  enabled: isAdmin   // no ejecuta si el usuario no es admin
})
```

### UI — Sección 1: Cuotas → Reinversión

Tabla que muestra cuánto del período se reinvertirá, fila por tipo.

**`getReinvertido(tipo, t): ReinvertidoResult`** — función auxiliar con tipo de retorno discriminado explícito:
```typescript
type ReinvertidoResult =
  | { esTotal: true;  total: number }
  | { esTotal: false; capital: number; interes: number; iva: number }
```
Para tipos `variable`/`excedente` devuelve `{ esTotal: true, total }` porque el monto reinvertido no se puede desglosar por rubro. Para los demás devuelve los tres rubros individuales. El discriminador `esTotal` permite que TypeScript infiera el tipo correcto en cada rama sin necesidad de non-null assertions (`!`).

**Precálculo de totales en un solo `reduce`:**
```typescript
const totalesReinv = reinversionPorTipo.reduce(
  (acc, t) => {
    const r = getReinvertido(t.tipo, t)
    const tot = r.esTotal ? r.total : r.capital + r.interes + r.iva
    return {
      total:   acc.total   + tot,
      capital: acc.capital + (r.esTotal ? 0 : r.capital),
      interes: acc.interes + (r.esTotal ? 0 : r.interes),
      iva:     acc.iva     + (r.esTotal ? 0 : r.iva),
    }
  },
  { total: 0, capital: 0, interes: 0, iva: 0 }
)
```
Un solo recorrido del arreglo calcula simultáneamente los cuatro totales para el pie de tabla. El pie de tabla usa directamente `totalesReinv.capital`, `totalesReinv.interes`, etc.

Para las filas con `esTotal: true`, las celdas de Capital/Interés/IVA muestran `"—"` porque ese tipo no desglosa por rubro; solo muestra el total en la última columna.

### UI — Sección 2: Cuotas → Cash

**`cashParcialTotal`** — pre-calculado una sola vez antes del JSX:
```typescript
const cashParcialTotal = cashParcialPorTipo.reduce(
  (a, t) => a + (t.monto_cash ? Number(t.monto_cash) : Number(t.capital) + Number(t.interes) + Number(t.iva)),
  0
)
```
Para tipos `variable`/`excedente` usa `monto_cash` directamente (es el excedente que no alcanzó a reinvertirse). Para los demás tipos suma los tres rubros. Este valor se reutiliza en dos filas de la tabla sin recalcular.

La tabla tiene tres filas:
1. **Sin Reinversión**: capital + interés + IVA de todos los inversionistas que reciben todo en cash (de `sinReinversion.totales`).
2. **Intereses y excedentes pagados a inversionistas**: cash que sale de inversionistas con reinversión parcial (de `cashParcialTotal`). Solo aparece si `cashParcialPorTipo.length > 0`.
3. **Total Cash**: suma de las dos filas anteriores (`totalSinReinv + cashParcialTotal`).

### UI — Sección 3: Pagos Extras Recibidos

Tabla simple con dos filas fijas:
- **Abonos Extra a Capital**: suma de `abonos_capital` tipo `CAPITAL` del período.
- **Cancelaciones**: suma de `abonos_capital` tipo `CANCELACION` del período.

Ambos representan entradas de caja que no provienen de cuotas regulares pero que también afectan la liquidez del período.

### Accesibilidad

Los dos `Input type="date"` incluyen `aria-label="Fecha inicio"` y `aria-label="Fecha fin"` respectivamente. Sin estos atributos, lectores de pantalla como NVDA o VoiceOver anunciarían ambos campos como inputs genéricos sin nombre, haciendo imposible distinguirlos.

---

## Archivos modificados

| Archivo | Qué cambió |
|---------|------------|
| `apps/cartera-back/src/controllers/reportes.ts` | Nueva función `getFlujoCuotasInversiones`: dos queries SQL + lógica de distribución reinv/cash por los 5 tipos de reinversión |
| `apps/cartera-back/src/routers/reportes.ts` | Nuevo endpoint `GET /reportes/flujo-cuotas-inversiones` con validación de presencia y formato YYYY-MM-DD |
| `apps/crm/apps/server/src/services/cartera-back-client.ts` | Tipos `FlujoCuotasRubro`, `FlujoCuotasInversionista`, `FlujoCuotasInversionesResponse` + método `getFlujoCuotasInversiones()` en el cliente HTTP |
| `apps/crm/apps/server/src/routers/reportes-cartera.ts` | Nuevo procedure oRPC `getFlujoCuotasInversiones` con validación Zod (regex YYYY-MM-DD), guard de integración y tipado end-to-end |
| `apps/crm/apps/server/src/routers/index.ts` | Registro del nuevo procedure en el router raíz del CRM server |
| `apps/crm/apps/web/src/routes/admin/reports/index.tsx` | Nueva sección "Flujo de Cuotas de Inversiones" con selector de fechas, tres tablas y precálculo eficiente de totales |
