### PR TITLE
fix(taller): persistir valor comercial

### DIFF
--- a/apps/crm/apps/server/.env.example
+++ b/apps/crm/apps/server/.env.example
@@ -3,6 +3,8 @@ DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 
 # CORS
 CORS_ORIGIN=http://localhost:3001
+TALLER_URL=http://localhost:3000
+FRONT_URL=http://localhost:3001
 
 # Better Auth
 BETTER_AUTH_SECRET=your-secret-key-here

--- a/apps/crm/apps/server/src/db/migrations/0022_add_taller_roles.sql
+++ b/apps/crm/apps/server/src/db/migrations/0022_add_taller_roles.sql
@@ -1,0 +1,11 @@
+DO $$ BEGIN
+	ALTER TYPE "user_role" ADD VALUE IF NOT EXISTS 'service_center_manager';
+EXCEPTION
+	WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+	ALTER TYPE "user_role" ADD VALUE IF NOT EXISTS 'vehicle_verifier';
+EXCEPTION
+	WHEN duplicate_object THEN null;
+END $$;

--- a/apps/crm/apps/server/src/db/schema/auth.ts
+++ b/apps/crm/apps/server/src/db/schema/auth.ts
@@ -12,6 +12,8 @@ export const userRoleEnum = pgEnum("user_role", [
 	"investment_advisor_jr",
 	"investment_advisor_sr",
 	"investment_manager",
+	"service_center_manager",
+	"vehicle_verifier",
 ]);
 
 export const user = pgTable("user", {

--- a/apps/crm/apps/server/src/lib/auth.ts
+++ b/apps/crm/apps/server/src/lib/auth.ts
@@ -80,6 +80,18 @@ export const investmentManagerRole = ac.newRole({
 	report: ["read", "export"],
 });
 
+export const serviceCenterManagerRole = ac.newRole({
+	user: ["read"],
+	lead: ["read"],
+	report: ["read"],
+});
+
+export const vehicleVerifierRole = ac.newRole({
+	user: ["read"],
+	lead: ["read"],
+	report: ["read"],
+});
+
 export const auth = betterAuth({
 	database: drizzleAdapter(db, {
 		provider: "pg",
@@ -100,6 +112,8 @@ export const auth = betterAuth({
 				investment_advisor_jr: investmentAdvisorJrRole,
 				investment_advisor_sr: investmentAdvisorSrRole,
 				investment_manager: investmentManagerRole,
+				service_center_manager: serviceCenterManagerRole,
+				vehicle_verifier: vehicleVerifierRole,
 			},
 			schema: {
 				user: {
@@ -117,7 +131,11 @@ export const auth = betterAuth({
 			},
 		}),
 	],
-	trustedOrigins: [process.env.CORS_ORIGIN || ""],
+	trustedOrigins: [
+		process.env.CORS_ORIGIN,
+		process.env.FRONT_URL,
+		process.env.TALLER_URL,
+	].filter((origin): origin is string => Boolean(origin && origin !== "*")),
 	emailAndPassword: {
 		enabled: true,
 		requireEmailVerification: false,

--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -323,64 +323,7 @@ const requireJuridico = o.middleware(async ({ context, next }) => {
 	});
 });
 
-const requireTallerOrigin = o.middleware(async ({ context, next }) => {
-	const tallerUrl = process.env.TALLER_URL;
-	const frontUrl = process.env.FRONT_URL;
-
-	if (!tallerUrl && !frontUrl) {
-		throw new ORPCError("INTERNAL_SERVER_ERROR", {
-			message: "TALLER_URL or FRONT_URL not configured",
-		});
-	}
-
-	const origin = context.headers.get("origin");
-	const referer = context.headers.get("referer");
-
-	// Verificar si la petición viene del taller o del front del CRM
-	const isFromTaller =
-		(tallerUrl &&
-			(origin === tallerUrl ||
-				referer?.startsWith(tallerUrl) ||
-				referer?.startsWith(`${tallerUrl}/`))) ||
-		(frontUrl &&
-			(origin === frontUrl ||
-				referer?.startsWith(frontUrl) ||
-				referer?.startsWith(`${frontUrl}/`)));
-
-	if (!isFromTaller) {
-		throw new ORPCError("FORBIDDEN", {
-			message: "Access denied - Invalid origin",
-		});
-	}
-
-	return next({
-		context,
-	});
-});
-
-// Middleware que permite acceso desde taller (por origen) O desde CRM (por rol)
-const requireTallerOrCrm = o.middleware(async ({ context, next }) => {
-	const tallerUrl = process.env.TALLER_URL;
-	const frontUrl = process.env.FRONT_URL;
-	const origin = context.headers.get("origin");
-	const referer = context.headers.get("referer");
-
-	// Verificar si viene del taller
-	const isFromTaller =
-		(tallerUrl &&
-			(origin === tallerUrl ||
-				referer?.startsWith(tallerUrl) ||
-				referer?.startsWith(`${tallerUrl}/`))) ||
-		(frontUrl &&
-			(origin === frontUrl ||
-				referer?.startsWith(frontUrl) ||
-				referer?.startsWith(`${frontUrl}/`)));
-
-	if (isFromTaller) {
-		return next({ context });
-	}
-
-	// Si no viene del taller, verificar si tiene acceso CRM
+const requireTallerAccess = o.middleware(async ({ context, next }) => {
 	if (!context.session?.user) {
 		throw new ORPCError("UNAUTHORIZED");
 	}
@@ -393,7 +336,41 @@ const requireTallerOrCrm = o.middleware(async ({ context, next }) => {
 		.limit(1);
 	const userRole = userData[0]?.role;
 
-	if (!PERMISSIONS.canAccessCRM(userRole)) {
+	if (!userRole || !PERMISSIONS.canAccessTaller(userRole)) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Taller access required",
+		});
+	}
+
+	return next({
+		context: {
+			...context,
+			user: userData[0],
+			userId,
+			userRole,
+		},
+	});
+});
+
+// Middleware que permite acceso autenticado desde Taller O desde CRM por rol.
+const requireTallerOrCrm = o.middleware(async ({ context, next }) => {
+	if (!context.session?.user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	const userId = context.session.user.id;
+	const userData = await db
+		.select()
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+	const userRole = userData[0]?.role;
+	const hasAccess =
+		!!userRole &&
+		(PERMISSIONS.canAccessCRM(userRole) ||
+			PERMISSIONS.canAccessTaller(userRole));
+
+	if (!hasAccess) {
 		throw new ORPCError("FORBIDDEN", {
 			message: "CRM or Taller access required",
 		});
@@ -484,7 +461,7 @@ export const viewOpportunityContractsProcedure = publicProcedure.use(
 	requireViewOpportunityContracts,
 );
 export const juridicoProcedure = publicProcedure.use(requireJuridico);
-export const tallerProcedure = publicProcedure.use(requireTallerOrigin);
+export const tallerProcedure = publicProcedure.use(requireTallerAccess);
 export const tallerOrCrmProcedure = publicProcedure.use(requireTallerOrCrm);
 export const investmentProcedure = publicProcedure.use(requireInvestmentAccess);
 export const investmentManagerProcedure = publicProcedure.use(

--- a/apps/crm/apps/server/src/lib/roles.test.ts
+++ b/apps/crm/apps/server/src/lib/roles.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { PERMISSIONS, ROLES } from "./roles";
+
+describe("taller role permissions", () => {
+	it("allows taller roles to access vehicles and taller", () => {
+		expect(PERMISSIONS.canAccessVehicles(ROLES.VEHICLE_VERIFIER)).toBe(true);
+		expect(PERMISSIONS.canAccessTaller(ROLES.VEHICLE_VERIFIER)).toBe(true);
+		expect(PERMISSIONS.canAccessTaller(ROLES.SERVICE_CENTER_MANAGER)).toBe(
+			true,
+		);
+	});
+});

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -13,6 +13,8 @@ export const ROLES = {
 	INVESTMENT_ADVISOR_JR: "investment_advisor_jr",
 	INVESTMENT_ADVISOR_SR: "investment_advisor_sr",
 	INVESTMENT_MANAGER: "investment_manager",
+	SERVICE_CENTER_MANAGER: "service_center_manager",
+	VEHICLE_VERIFIER: "vehicle_verifier",
 } as const;
 
 export type UserRole = (typeof ROLES)[keyof typeof ROLES];
@@ -73,6 +75,16 @@ export const ROLE_CONFIG = {
 		label: "Gerente de Inversiones",
 		color: "bg-sky-100 text-sky-800",
 		icon: "Landmark" as const,
+	},
+	[ROLES.SERVICE_CENTER_MANAGER]: {
+		label: "Gerente de Centro de Servicio",
+		color: "bg-violet-100 text-violet-800",
+		icon: "Wrench" as const,
+	},
+	[ROLES.VEHICLE_VERIFIER]: {
+		label: "Verificador de Vehículo",
+		color: "bg-lime-100 text-lime-800",
+		icon: "ClipboardCheck" as const,
 	},
 } as const;
 
@@ -213,6 +225,20 @@ export const PERMISSIONS = {
 
 	// Vehicles Module Access - All roles can access
 	canAccessVehicles: (_role: UserRole | string): boolean => true,
+
+	// Taller Module Access
+	canAccessTaller: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN ||
+		role === ROLES.SERVICE_CENTER_MANAGER ||
+		role === ROLES.VEHICLE_VERIFIER,
+
+	canManageTallerInspections: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN ||
+		role === ROLES.SERVICE_CENTER_MANAGER ||
+		role === ROLES.VEHICLE_VERIFIER,
+
+	canManageTallerVehicleStatus: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.SERVICE_CENTER_MANAGER,
 
 	// Accounting Module Access (Contabilidad)
 	canAccessAccounting: (role: UserRole | string): boolean =>

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -862,7 +862,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Update inspection
-	updateInspection: protectedProcedure
+	updateInspection: tallerOrCrmProcedure
 		.input(
 			z.object({
 				id: z.string(),

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -34,7 +34,7 @@ import {
 	publicProcedure,
 	tallerOrCrmProcedure,
 } from "../lib/orpc";
-import { ROLES } from "../lib/roles";
+import { PERMISSIONS, ROLES } from "../lib/roles";
 import {
 	buildUploadPrefix,
 	deleteFileFromR2,
@@ -550,8 +550,18 @@ export const vehiclesRouter = {
 				}),
 			}),
 		)
-		.handler(async ({ input }) => {
+		.handler(async ({ input, context }) => {
 			try {
+				if (
+					input.data.status &&
+					!PERMISSIONS.canManageTallerVehicleStatus(context.userRole) &&
+					!PERMISSIONS.canAccessCRM(context.userRole)
+				) {
+					throw new ORPCError("FORBIDDEN", {
+						message: "No tienes permiso para cambiar el estado del vehículo",
+					});
+				}
+
 				const [updated] = await db
 					.update(vehicles)
 					.set({
@@ -890,7 +900,16 @@ export const vehiclesRouter = {
 				}),
 			}),
 		)
-		.handler(async ({ input }) => {
+		.handler(async ({ input, context }) => {
+			if (
+				!PERMISSIONS.canManageTallerInspections(context.userRole) &&
+				!PERMISSIONS.canAccessCRM(context.userRole)
+			) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permiso para actualizar inspecciones",
+				});
+			}
+
 			const [updated] = await db
 				.update(vehicleInspections)
 				.set({

--- a/apps/crm/apps/web/src/lib/auth-client.ts
+++ b/apps/crm/apps/web/src/lib/auth-client.ts
@@ -36,6 +36,18 @@ const cobrosRole = ac.newRole({
 	report: ["read"],
 });
 
+const serviceCenterManagerRole = ac.newRole({
+	user: ["read"],
+	lead: ["read"],
+	report: ["read"],
+});
+
+const vehicleVerifierRole = ac.newRole({
+	user: ["read"],
+	lead: ["read"],
+	report: ["read"],
+});
+
 export const authClient = createAuthClient({
 	baseURL: import.meta.env.VITE_SERVER_URL,
 	fetchOptions: {
@@ -69,6 +81,8 @@ export const authClient = createAuthClient({
 				sales: salesRole,
 				analyst: analystRole,
 				cobros: cobrosRole,
+				service_center_manager: serviceCenterManagerRole,
+				vehicle_verifier: vehicleVerifierRole,
 			},
 		}),
 	],

--- a/apps/taller/index.html
+++ b/apps/taller/index.html
@@ -1,17 +1,31 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="/favicon.ico" />
-    <meta name="theme-color" content="#000000" />
+    <meta name="theme-color" content="#4E57EA" />
     <meta
       name="description"
-      content="Web site created using create-tsrouter-app"
+      content="Plataforma de inspecciones vehiculares de Cash In para taller, valuaciones, evidencias y seguimiento de vehículos."
+    />
+    <meta name="application-name" content="Taller Cash In" />
+    <meta name="apple-mobile-web-app-title" content="Taller Cash In" />
+    <meta property="og:title" content="Taller Cash In | Inspecciones vehiculares" />
+    <meta
+      property="og:description"
+      content="Gestiona inspecciones, fotos, scanner y valores comerciales de vehículos desde la plataforma de taller."
+    />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Taller Cash In | Inspecciones vehiculares" />
+    <meta
+      name="twitter:description"
+      content="Plataforma de inspecciones vehiculares, evidencias y valores comerciales para taller."
     />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Create TanStack App - taller</title>
+    <title>Taller Cash In | Inspecciones vehiculares</title>
   </head>
   <body>
     <div id="app"></div>

--- a/apps/taller/package.json
+++ b/apps/taller/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@standard-schema/spec": "^1.1.0",
     "@standard-schema/utils": "^0.3.0",
+    "better-auth": "^1.2.10",
     "@tailwindcss/vite": "^4.0.6",
     "@tanstack/react-query": "^5.66.5",
     "@tanstack/react-query-devtools": "^5.66.5",

--- a/apps/taller/public/manifest.json
+++ b/apps/taller/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "TanStack App",
-  "name": "Create TanStack App Sample",
+  "short_name": "Taller Cash In",
+  "name": "Taller Cash In | Inspecciones vehiculares",
   "icons": [
     {
       "src": "favicon.ico",
@@ -20,6 +20,6 @@
   ],
   "start_url": ".",
   "display": "standalone",
-  "theme_color": "#000000",
+  "theme_color": "#4E57EA",
   "background_color": "#ffffff"
 }

--- a/apps/taller/src/App.tsx
+++ b/apps/taller/src/App.tsx
@@ -1,10 +1,29 @@
 import { Link } from '@tanstack/react-router'
-import { Car, FileText } from 'lucide-react'
+import { Car, FileText, LogOut } from 'lucide-react'
+import { Button } from './components/ui/button'
+import { authClient } from './lib/auth-client'
 
 function App() {
+  const { data: session } = authClient.useSession()
+
   return (
     <div className="min-h-screen bg-gray-50">
       <div className="container mx-auto px-4 py-8">
+        <div className="mb-6 flex justify-end">
+          {session ? (
+            <div className="flex items-center gap-3 text-sm text-gray-600">
+              <span>{session.user.email}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => authClient.signOut()}
+              >
+                <LogOut className="mr-2 h-4 w-4" />
+                Cerrar sesión
+              </Button>
+            </div>
+          ) : null}
+        </div>
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-gray-900 mb-4">
             Sistema de Gestión de Taller

--- a/apps/taller/src/components/auth/require-auth.tsx
+++ b/apps/taller/src/components/auth/require-auth.tsx
@@ -1,0 +1,27 @@
+import { Navigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { authClient } from "../../lib/auth-client";
+
+type RequireAuthProps = {
+  children: ReactNode;
+};
+
+export function RequireAuth({ children }: RequireAuthProps) {
+  const { data: session, isPending } = authClient.useSession();
+
+  if (isPending) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 text-gray-600">
+        <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+        Verificando sesión...
+      </div>
+    );
+  }
+
+  if (!session) {
+    return <Navigate to="/login" />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/taller/src/lib/auth-client.ts
+++ b/apps/taller/src/lib/auth-client.ts
@@ -1,0 +1,5 @@
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  baseURL: import.meta.env.VITE_SERVER_URL,
+});

--- a/apps/taller/src/main.tsx
+++ b/apps/taller/src/main.tsx
@@ -19,6 +19,7 @@ import './styles.css'
 import reportWebVitals from './reportWebVitals.ts'
 
 import App from './App.tsx'
+import { LoginPage } from './pages/login.tsx'
 
 const rootRoute = createRootRoute({
   component: () => (
@@ -35,8 +36,15 @@ const indexRoute = createRoute({
   component: App,
 })
 
+const loginRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/login',
+  component: LoginPage,
+})
+
 const routeTree = rootRoute.addChildren([
   indexRoute,
+  loginRoute,
   VehiclesDashboardRoute(rootRoute as any),
   VehicleInspectionRoute(rootRoute as any),
 ])

--- a/apps/taller/src/pages/login.tsx
+++ b/apps/taller/src/pages/login.tsx
@@ -1,0 +1,79 @@
+import { useNavigate } from "@tanstack/react-router";
+import { Loader2 } from "lucide-react";
+import type React from "react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "../components/ui/button";
+import { Input } from "../components/ui/input";
+import { Label } from "../components/ui/label";
+import { authClient } from "../lib/auth-client";
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setIsLoading(true);
+
+    const { error } = await authClient.signIn.email({
+      email,
+      password,
+      rememberMe: true,
+    });
+
+    setIsLoading(false);
+
+    if (error) {
+      toast.error(error.message || "No se pudo iniciar sesión");
+      return;
+    }
+
+    await navigate({ to: "/" });
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 p-4">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 rounded-xl border bg-white p-6 shadow-sm"
+      >
+        <div>
+          <h1 className="font-bold text-2xl text-gray-900">Taller Cash In</h1>
+          <p className="text-gray-600 text-sm">
+            Inicia sesión para gestionar inspecciones vehiculares.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Correo electrónico</Label>
+          <Input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="password">Contraseña</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </div>
+
+        <Button type="submit" className="w-full" disabled={isLoading}>
+          {isLoading ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+          Iniciar sesión
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -27,8 +27,9 @@ import {
   Hash,
   ExternalLink,
 } from "lucide-react";
-import { getVehicleStatistics, getVehicleById } from "../services/vehicles";
+import { getVehicleStatusUpdate, getVehicleStatistics, getVehicleById } from "../services/vehicles";
 import { generateInspectionPdf } from "../lib/generate-inspection-pdf";
+import { authClient } from "../lib/auth-client";
 import { vehiclesApi, client } from "../utils/orpc";
 import { toast } from "sonner";
 import { INSPECTION_AREAS } from "../lib/inspection-data";
@@ -375,6 +376,9 @@ const VehiclePhoto = ({ photo, index }: { photo: any; index: number }) => {
 };
 
 export default function VehiclesDashboard() {
+  const { data: session } = authClient.useSession();
+  const userRole = (session?.user as { role?: string } | undefined)?.role;
+  const canManageVehicleStatus = userRole === "admin" || userRole === "service_center_manager";
   const [vehicles, setVehicles] = useState<DashboardVehicle[]>([]);
   const [rawVehiclesData, setRawVehiclesData] = useState<VehicleWithRelations[]>([]);
   const [statistics, setStatistics] = useState<any>(null);
@@ -635,19 +639,16 @@ export default function VehiclesDashboard() {
 
     setIsSaving(true);
     try {
-      const vehicleStatus =
-        editForm.status === "approved"
-          ? "available"
-          : editForm.status === "rejected"
-            ? "maintenance"
-            : editForm.status;
-
-      await vehiclesApi.update(selectedVehicle.id, {
-        status: vehicleStatus as "pending" | "available" | "sold" | "maintenance" | "auction",
-      });
-
-      // Get the raw vehicle to update its inspection
+      // Get the raw vehicle to compare vehicle status and update its inspection
       const rawVehicle = rawVehiclesData.find(v => v.id === selectedVehicle.id);
+      const vehicleStatus = getVehicleStatusUpdate(editForm.status, rawVehicle?.status, canManageVehicleStatus);
+
+      if (vehicleStatus) {
+        await vehiclesApi.update(selectedVehicle.id, {
+          status: vehicleStatus,
+        });
+      }
+
       const sortedInspections = rawVehicle?.inspections
         ? [...rawVehicle.inspections].sort((a, b) => {
             const dateA = a.inspectionDate ? new Date(a.inspectionDate).getTime() : (a.createdAt ? new Date(a.createdAt).getTime() : 0);

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -635,7 +635,12 @@ export default function VehiclesDashboard() {
 
     setIsSaving(true);
     try {
-      const vehicleStatus = editForm.status === "approved" ? "available" : editForm.status;
+      const vehicleStatus =
+        editForm.status === "approved"
+          ? "available"
+          : editForm.status === "rejected"
+            ? "maintenance"
+            : editForm.status;
 
       await vehiclesApi.update(selectedVehicle.id, {
         status: vehicleStatus as "pending" | "available" | "sold" | "maintenance" | "auction",
@@ -2001,7 +2006,24 @@ export default function VehiclesDashboard() {
                           return (
                             <button
                               key={inspection.id}
-                              onClick={() => setSelectedInspectionIndex(idx)}
+                              onClick={() => {
+                                setSelectedInspectionIndex(idx);
+                                if (!selectedVehicle) return;
+                                const rawVehicle = rawVehiclesData.find(v => v.id === selectedVehicle.id);
+                                if (rawVehicle) {
+                                  const transformed = transformVehicleData(rawVehicle, idx);
+                                  setSelectedVehicle(transformed);
+                                  setEditForm({
+                                    vehicleRating: transformed.vehicleRating,
+                                    status: transformed.status,
+                                    marketValue: transformed.marketValue,
+                                    suggestedCommercialValue: transformed.suggestedCommercialValue,
+                                    currentConditionValue: transformed.currentConditionValue,
+                                    testDrive: transformed.testDrive,
+                                    inspectionResult: transformed.inspectionResult,
+                                  });
+                                }
+                              }}
                               className={cn(
                                 "w-full text-left rounded-lg border p-3 transition-all",
                                 isSelected

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -635,13 +635,22 @@ export default function VehiclesDashboard() {
 
     setIsSaving(true);
     try {
+      const vehicleStatus = editForm.status === "approved" ? "available" : editForm.status;
+
       await vehiclesApi.update(selectedVehicle.id, {
-        status: editForm.status as "pending" | "available" | "sold" | "maintenance" | "auction",
+        status: vehicleStatus as "pending" | "available" | "sold" | "maintenance" | "auction",
       });
 
       // Get the raw vehicle to update its inspection
       const rawVehicle = rawVehiclesData.find(v => v.id === selectedVehicle.id);
-      const inspectionId = rawVehicle?.inspections?.[0]?.id;
+      const sortedInspections = rawVehicle?.inspections
+        ? [...rawVehicle.inspections].sort((a, b) => {
+            const dateA = a.inspectionDate ? new Date(a.inspectionDate).getTime() : (a.createdAt ? new Date(a.createdAt).getTime() : 0);
+            const dateB = b.inspectionDate ? new Date(b.inspectionDate).getTime() : (b.createdAt ? new Date(b.createdAt).getTime() : 0);
+            return dateB - dateA;
+          })
+        : [];
+      const inspectionId = sortedInspections[selectedInspectionIndex]?.id;
 
       if (inspectionId) {
         // Update the inspection data via the API

--- a/apps/taller/src/pages/vehicles-dashboard.tsx
+++ b/apps/taller/src/pages/vehicles-dashboard.tsx
@@ -681,7 +681,8 @@ export default function VehiclesDashboard() {
       setActiveTab("details");
     } catch (error) {
       console.error("Error saving changes:", error);
-      toast.error("Error al guardar los cambios");
+      const message = error instanceof Error ? error.message : "Error al guardar los cambios";
+      toast.error(message);
     } finally {
       setIsSaving(false);
     }

--- a/apps/taller/src/routes/vehicle-inspection.tsx
+++ b/apps/taller/src/routes/vehicle-inspection.tsx
@@ -1,9 +1,14 @@
 import { createRoute, type AnyRoute } from '@tanstack/react-router'
+import { RequireAuth } from '../components/auth/require-auth'
 import VehicleInspectionWizard from '../pages/vehicle-inspection-wizard'
 
 export default (parentRoute: AnyRoute) =>
   createRoute({
     path: '/vehicle-inspection',
-    component: VehicleInspectionWizard,
+    component: () => (
+      <RequireAuth>
+        <VehicleInspectionWizard />
+      </RequireAuth>
+    ),
     getParentRoute: () => parentRoute,
   })

--- a/apps/taller/src/routes/vehicles-dashboard.tsx
+++ b/apps/taller/src/routes/vehicles-dashboard.tsx
@@ -1,9 +1,14 @@
 import { createRoute, type AnyRoute } from '@tanstack/react-router'
+import { RequireAuth } from '../components/auth/require-auth'
 import VehiclesDashboard from '../pages/vehicles-dashboard'
 
 export default (parentRoute: AnyRoute) =>
   createRoute({
     path: '/vehicles',
-    component: VehiclesDashboard,
+    component: () => (
+      <RequireAuth>
+        <VehiclesDashboard />
+      </RequireAuth>
+    ),
     getParentRoute: () => parentRoute,
   })

--- a/apps/taller/src/services/vehicles.test.ts
+++ b/apps/taller/src/services/vehicles.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { getVehicleStatusUpdate } from "./vehicles";
 import { prepareInspectionData } from "./vehicles";
 
 describe("prepareInspectionData", () => {
@@ -32,5 +33,19 @@ describe("prepareInspectionData", () => {
     });
 
     expect(inspectionData.suggestedCommercialValue).toBe("85000");
+  });
+});
+
+describe("getVehicleStatusUpdate", () => {
+  it("skips vehicle status update when mapped inspection status is unchanged", () => {
+    expect(getVehicleStatusUpdate("approved", "available")).toBeUndefined();
+  });
+
+  it("returns mapped vehicle status when inspection status changed the vehicle state", () => {
+    expect(getVehicleStatusUpdate("rejected", "available")).toBe("maintenance");
+  });
+
+  it("skips vehicle status update when user cannot manage vehicle status", () => {
+    expect(getVehicleStatusUpdate("rejected", "available", false)).toBeUndefined();
   });
 });

--- a/apps/taller/src/services/vehicles.test.ts
+++ b/apps/taller/src/services/vehicles.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { prepareInspectionData } from "./vehicles";
+
+describe("prepareInspectionData", () => {
+  it("includes suggested commercial value in inspection data", () => {
+    const { inspectionData } = prepareInspectionData({
+      technicianName: "Inspector",
+      inspectionDate: new Date("2026-06-10T00:00:00.000Z"),
+      inspectionResult: "Aprobado",
+      vehicleRating: "Comercial",
+      marketValue: "100000",
+      suggestedCommercialValue: "85000",
+      currentConditionValue: "80000",
+      vehicleEquipment: "Equipo base",
+      scannerUsed: "No",
+      airbagWarning: "No",
+      testDrive: "Sí",
+      vehicleMake: "Toyota",
+      vehicleModel: "Hilux",
+      vehicleYear: "2023",
+      licensePlate: "P123ABC",
+      vinNumber: "VIN123",
+      motorNumber: "MOTOR123",
+      color: "Blanco",
+      vehicleType: "Pickup",
+      kmMileage: "10000",
+      origin: "Nacional",
+      cylinders: "4",
+      engineCC: "2400",
+      fuelType: "Diesel",
+      transmission: "Manual",
+    });
+
+    expect(inspectionData.suggestedCommercialValue).toBe("85000");
+  });
+});

--- a/apps/taller/src/services/vehicles.ts
+++ b/apps/taller/src/services/vehicles.ts
@@ -97,6 +97,31 @@ export interface Inspection360Item {
   metadata?: Record<string, any>;
 }
 
+export type VehicleStatus = "pending" | "available" | "sold" | "maintenance" | "auction";
+
+export const getVehicleStatusUpdate = (
+  inspectionStatus: string,
+  currentVehicleStatus?: string | null,
+  canManageVehicleStatus = true,
+): VehicleStatus | undefined => {
+  if (!canManageVehicleStatus) {
+    return undefined;
+  }
+
+  const vehicleStatus =
+    inspectionStatus === "approved"
+      ? "available"
+      : inspectionStatus === "rejected"
+        ? "maintenance"
+        : inspectionStatus;
+
+  if (vehicleStatus === currentVehicleStatus) {
+    return undefined;
+  }
+
+  return vehicleStatus as VehicleStatus;
+};
+
 // Main function to create a full vehicle inspection
 export const createFullInspection = async (
   vehicleData: VehicleData,

--- a/apps/taller/src/services/vehicles.ts
+++ b/apps/taller/src/services/vehicles.ts
@@ -32,6 +32,7 @@ export interface InspectionData {
   inspectionResult: string;
   vehicleRating: 'Comercial' | 'No comercial';
   marketValue?: string;
+  suggestedCommercialValue?: string;
   currentConditionValue: string;
   vehicleEquipment: string;
   importantConsiderations?: string;
@@ -165,6 +166,7 @@ export const prepareInspectionData = (formData: any, sectionTimes?: Record<strin
     inspectionResult: formData.inspectionResult,
     vehicleRating: formData.vehicleRating,
     marketValue: formData.marketValue || undefined,
+    suggestedCommercialValue: formData.suggestedCommercialValue || undefined,
     currentConditionValue: formData.currentConditionValue,
     vehicleEquipment: formData.vehicleEquipment,
     importantConsiderations: formData.importantConsiderations,


### PR DESCRIPTION
## Summary
- Envia suggestedCommercialValue desde el flujo de inspeccion de taller al backend.
- Corrige el modal de edicion para actualizar la inspeccion seleccionada y no enviar estados invalidos al endpoint de vehiculo.
- Agrega roles service_center_manager y vehicle_verifier al enum, permisos compartidos y Better Auth admin roles.
- Agrega login Better Auth en apps/taller reutilizando el mismo server y usuarios del CRM.
- Protege rutas de taller con sesion y cambia tallerOrCrmProcedure para requerir sesion/rol, no Origin/Referer publico.
- Permite a vehicle_verifier y service_center_manager actualizar inspecciones; solo service_center_manager/admin pueden cambiar estado de vehiculo desde taller.
- Agrega TALLER_URL al ejemplo de env; en produccion debe ser https://inspecciones.servicioscashin.com.
- Reemplaza SEO/manifest generico de TanStack por metadatos de Taller Cash In.

## Test Plan
- [x] bun test src/services/vehicles.test.ts en apps/taller
- [x] bun test src/lib/roles.test.ts en apps/crm/apps/server
- [x] bun run build en apps/taller
- [x] bun run build en apps/crm/apps/server
- [x] bun run build en apps/crm/apps/web

## Deployment Notes
- Aplicar migracion 0022_add_taller_roles.sql antes de desplegar server.
- Configurar TALLER_URL=https://inspecciones.servicioscashin.com en el entorno del server.
- Asignar role vehicle_verifier o service_center_manager a los usuarios de taller existentes.

## Notes
- bun test completo en apps/taller mantiene un fallo existente en App.test.tsx: document is not defined por entorno de prueba sin jsdom.