### PR TITLE
fix(cobros): completar día de pago en WhatsApp masivo

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3503,9 +3503,21 @@ export const cobrosRouter = {
 					? input.cuerpoEditado
 					: plantilla.cuerpo;
 
+				// Día de pago: tomar el día del mes de la fecha de vencimiento de la
+				// próxima cuota que devuelve cartera (`proxima_cuota`). Es el mismo
+				// criterio que usa el detalle individual de este router, y la única
+				// fuente del día de pago que vive en cartera. Sin esto el masivo
+				// dejaba "{fechaPago}" vacío ("Su día de pago es el .").
+				const diaPago = credito.proxima_cuota?.fecha_vencimiento
+					? Number.parseInt(
+							credito.proxima_cuota.fecha_vencimiento.substring(8, 10),
+							10,
+						) || null
+					: null;
+
 				const mensaje = interpolarPlantilla(cuerpoBase, {
 					clienteNombre: credito.usuarios.nombre ?? "",
-					fechaPago: "",
+					fechaPago: diaPago ? String(diaPago) : "",
 					cuotaMensual: String(cuota),
 					placa: info?.placa ?? "",
 					marcaLineaModelo,


### PR DESCRIPTION
## Problema

En la página de **Cobros**, el botón *"Enviar WhatsApp masivo"* mandaba la plantilla **"Aviso de atraso"** sin el día de pago: salía `Su día de pago es el .` (vacío). En cambio, el envío **individual** del mismo caso sí mostraba el día (ej. `Su día de pago es el 15.`).

## Causa de raíz

El endpoint `enviarWhatsappMasivoCobros` tenía el día de pago **hardcodeado en vacío** al interpolar la plantilla:

```ts
fechaPago: "",
```

El detalle individual sí lo llena tomando el día del mes de la `fecha_vencimiento` de una cuota de cartera. Los dos caminos piden a cartera-back, pero el masivo ignoraba la fecha que ya venía en la respuesta.

> Nota: la tabla `creditos` de cartera **no tiene** columna `dia_pago_mensual`; la única fuente real del día de pago en cartera es la `fecha_vencimiento` de la cuota.

## Fix

El masivo ahora usa la misma fuente de cartera que el individual: `proxima_cuota.fecha_vencimiento` (ya incluida en la respuesta de `getAllCredits` de cartera-back), extrayendo el día del mes.

```ts
const diaPago = credito.proxima_cuota?.fecha_vencimiento
    ? Number.parseInt(credito.proxima_cuota.fecha_vencimiento.substring(8, 10), 10) || null
    : null;
// ...
fechaPago: diaPago ? String(diaPago) : "",
```

Toda la info sigue viniendo de cartera-back. Resultado: el masivo muestra el mismo día que el individual.

## Pruebas
- `bunx tsc --noEmit` del server pasa limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)