### PR TITLE
Feat(reports): Add effectiveness percentage report

### DIFF
--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -261,6 +261,37 @@ const requireClosedCreditsReport = o.middleware(async ({ context, next }) => {
 	});
 });
 
+const requirePorcentajeEfectividadReport = o.middleware(
+	async ({ context, next }) => {
+		if (!context.session?.user) {
+			throw new ORPCError("UNAUTHORIZED");
+		}
+
+		const userId = context.session.user.id;
+		const userData = await db
+			.select()
+			.from(user)
+			.where(eq(user.id, userId))
+			.limit(1);
+		const userRole = userData[0]?.role;
+
+		if (!PERMISSIONS.canAccessPorcentajeEfectividadReport(userRole)) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "Porcentaje efectividad report access required",
+			});
+		}
+
+		return next({
+			context: {
+				session: context.session,
+				user: userData[0],
+				userId,
+				userRole,
+			},
+		});
+	},
+);
+
 const requireViewOpportunityContracts = o.middleware(
 	async ({ context, next }) => {
 		if (!context.session?.user) {
@@ -479,6 +510,9 @@ export const cobrosSupervisorProcedure = publicProcedure.use(
 );
 export const closedCreditsReportProcedure = publicProcedure.use(
 	requireClosedCreditsReport,
+);
+export const porcentajeEfectividadReportProcedure = publicProcedure.use(
+	requirePorcentajeEfectividadReport,
 );
 export const viewOpportunityContractsProcedure = publicProcedure.use(
 	requireViewOpportunityContracts,

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -134,6 +134,9 @@ export const PERMISSIONS = {
 	canAccessClosedCreditsReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
 
+	canAccessPorcentajeEfectividadReport: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
+
 	// Credit Detail Approval (40% → 50%)
 	canApproveCreditDetail: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -135,7 +135,7 @@ export const PERMISSIONS = {
 		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
 
 	canAccessPorcentajeEfectividadReport: (role: UserRole | string): boolean =>
-		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
+		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
 
 	// Credit Detail Approval (40% → 50%)
 	canApproveCreditDetail: (role: UserRole | string): boolean =>

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -327,6 +327,8 @@ export const reportsAppRouter = {
 	getReporteCreditosCerrados: reportsRouter.getReporteCreditosCerrados,
 	getReporteInventario: reportsRouter.getReporteInventario,
 	getReporteSubastas: reportsRouter.getReporteSubastas,
+	getReportePorcentajeEfectividad:
+		reportsRouter.getReportePorcentajeEfectividad,
 	// Reportes unificados (cartera-back + CRM)
 	getReporteCarteraCompleto: reportesCarteraRouter.getReporteCarteraCompleto,
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -478,7 +478,7 @@ export const getReportePorcentajeEfectividad =
 
 				db
 					.select({
-						source: opportunities.source,
+						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
 						totalOportunidades: count(opportunities.id),
 						totalCerradas,
 						porcentaje,
@@ -486,14 +486,14 @@ export const getReportePorcentajeEfectividad =
 					.from(opportunities)
 					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
 					.where(baseWhere)
-					.groupBy(opportunities.source)
+					.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
 					.orderBy(desc(count(opportunities.id))),
 
 				db
 					.select({
 						id: opportunities.id,
 						createdAt: opportunities.createdAt,
-						source: opportunities.source,
+						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
 						nombre: sql<string | null>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
 						etapaNombre: salesStages.name,
 						etapaPorcentaje: salesStages.closurePercentage,
@@ -522,7 +522,7 @@ export const getReportePorcentajeEfectividad =
 					porcentaje: totalRows[0]?.porcentaje ?? 0,
 				},
 				porFuente: porFuente.map((row) => ({
-					source: row.source ?? "other",
+					source: row.source,
 					totalOportunidades: row.totalOportunidades,
 					totalCerradas: row.totalCerradas ?? 0,
 					porcentaje: row.porcentaje ?? 0,
@@ -530,7 +530,7 @@ export const getReportePorcentajeEfectividad =
 				registros: registrosRaw.map((row) => ({
 					id: row.id,
 					createdAt: row.createdAt,
-					source: row.source ?? "other",
+					source: row.source,
 					nombre: row.nombre,
 					etapaNombre: row.etapaNombre,
 					etapaPorcentaje: row.etapaPorcentaje,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -17,7 +17,12 @@ import {
 	salesStages,
 } from "../db/schema/crm";
 import { vehicleInspections, vehicles } from "../db/schema/vehicles";
-import { closedCreditsReportProcedure, protectedProcedure } from "../lib/orpc";
+import {
+	closedCreditsReportProcedure,
+	porcentajeEfectividadReportProcedure,
+	protectedProcedure,
+} from "../lib/orpc";
+
 
 // Schema para filtros de fecha
 const dateRangeSchema = z.object({
@@ -421,6 +426,118 @@ export const getReporteInventario = protectedProcedure.handler(async () => {
 		inspeccionesPorResultado,
 	};
 });
+
+const CLOSED_STAGE_THRESHOLD = 90;
+const MAX_REPORT_ROWS = 10_000;
+/**
+ * Reporte Porcentaje Efectividad
+ * Tasa de conversión de oportunidades a créditos cerrados, por fuente.
+ */
+export const getReportePorcentajeEfectividad =
+	porcentajeEfectividadReportProcedure
+		.input(closedCreditsReportInputSchema)
+		.handler(async ({ input }) => {
+			const { start, end } = parseGuatemalaDateRange(
+				input.startDate,
+				input.endDate,
+			);
+
+			// Sin filtro de fechas intencional: la cohorte es "creadas en el período,
+			// ¿alguna vez cerraron?", no "creadas y cerradas dentro del mismo período".
+			const everClosed = db
+				.select({ opportunityId: opportunityStageHistory.opportunityId })
+				.from(opportunityStageHistory)
+				.innerJoin(
+					salesStages,
+					eq(opportunityStageHistory.toStageId, salesStages.id),
+				)
+				.where(gte(salesStages.closurePercentage, CLOSED_STAGE_THRESHOLD))
+				.groupBy(opportunityStageHistory.opportunityId)
+				.as("ever_closed");
+
+			const baseWhere = and(
+				gte(opportunities.createdAt, start),
+				lte(opportunities.createdAt, end),
+			);
+
+			const totalCerradas =
+				sql<number>`COUNT(${everClosed.opportunityId})`;
+			const porcentaje =
+				sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
+
+			const [totalRows, porFuente, registrosRaw] = await Promise.all([
+				db
+					.select({
+						totalOportunidades: count(opportunities.id),
+						totalCerradas,
+						porcentaje,
+					})
+					.from(opportunities)
+					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+					.where(baseWhere),
+
+				db
+					.select({
+						source: opportunities.source,
+						totalOportunidades: count(opportunities.id),
+						totalCerradas,
+						porcentaje,
+					})
+					.from(opportunities)
+					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+					.where(baseWhere)
+					.groupBy(opportunities.source)
+					.orderBy(desc(count(opportunities.id))),
+
+				db
+					.select({
+						id: opportunities.id,
+						createdAt: opportunities.createdAt,
+						source: opportunities.source,
+						nombre: sql<string | null>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
+						etapaNombre: salesStages.name,
+						etapaPorcentaje: salesStages.closurePercentage,
+						cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
+					})
+					.from(opportunities)
+					.leftJoin(leads, eq(opportunities.leadId, leads.id))
+					.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
+					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+					.where(baseWhere)
+					.orderBy(desc(opportunities.createdAt))
+					.limit(MAX_REPORT_ROWS + 1),
+			]);
+
+			if (registrosRaw.length > MAX_REPORT_ROWS) {
+				throw new ORPCError("BAD_REQUEST", {
+					message:
+						"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
+				});
+			}
+
+			return {
+				total: {
+					totalOportunidades: totalRows[0]?.totalOportunidades ?? 0,
+					totalCerradas: totalRows[0]?.totalCerradas ?? 0,
+					porcentaje: totalRows[0]?.porcentaje ?? 0,
+				},
+				porFuente: porFuente.map((row) => ({
+					source: row.source ?? "other",
+					totalOportunidades: row.totalOportunidades,
+					totalCerradas: row.totalCerradas ?? 0,
+					porcentaje: row.porcentaje ?? 0,
+				})),
+				registros: registrosRaw.map((row) => ({
+					id: row.id,
+					createdAt: row.createdAt,
+					source: row.source ?? "other",
+					nombre: row.nombre,
+					etapaNombre: row.etapaNombre,
+					etapaPorcentaje: row.etapaPorcentaje,
+					cerro: row.cerro,
+				})),
+			};
+		});
 
 /**
  * Reporte de Subastas

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -16,6 +16,7 @@ import {
 	Landmark,
 	LayoutDashboard,
 	MessageSquare,
+	Percent,
 	Scale,
 	Settings,
 	Target,
@@ -149,6 +150,23 @@ export default function Header() {
 											</DropdownMenuItem>
 										</>
 									)}
+									{userRole &&
+										PERMISSIONS.canAccessPorcentajeEfectividadReport(
+											userRole,
+										) && (
+											<>
+												<DropdownMenuSeparator />
+												<DropdownMenuItem asChild>
+													<Link
+														to="/crm/reportes/porcentaje-efectividad"
+														className="cursor-pointer"
+													>
+														<Percent className="mr-2 h-4 w-4" />
+														Porcentaje Efectividad
+													</Link>
+												</DropdownMenuItem>
+											</>
+										)}
 								</DropdownMenuContent>
 							</DropdownMenu>
 						)}

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as CrmAnalysisIndexRouteImport } from './routes/crm/analysis/inde
 import { Route as AdminReportsIndexRouteImport } from './routes/admin/reports/index'
 import { Route as JuridicoGenerateOpportunityIdRouteImport } from './routes/juridico/generate.$opportunityId'
 import { Route as InversionesLiquidacionesInversionistaIdRouteImport } from './routes/inversiones/liquidaciones.$inversionistaId'
+import { Route as CrmReportesPorcentajeEfectividadRouteImport } from './routes/crm/reportes/porcentaje-efectividad'
 import { Route as CrmAnalysisOpportunityIdRouteImport } from './routes/crm/analysis/$opportunityId'
 import { Route as CrmAdminMiniagentRouteImport } from './routes/crm/admin/miniagent'
 
@@ -214,6 +215,12 @@ const InversionesLiquidacionesInversionistaIdRoute =
     path: '/inversiones/liquidaciones/$inversionistaId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const CrmReportesPorcentajeEfectividadRoute =
+  CrmReportesPorcentajeEfectividadRouteImport.update({
+    id: '/crm/reportes/porcentaje-efectividad',
+    path: '/crm/reportes/porcentaje-efectividad',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CrmAnalysisOpportunityIdRoute =
   CrmAnalysisOpportunityIdRouteImport.update({
     id: '/crm/analysis/$opportunityId',
@@ -257,6 +264,7 @@ export interface FileRoutesByFullPath {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports/': typeof AdminReportsIndexRoute
@@ -294,6 +302,7 @@ export interface FileRoutesByTo {
   '/vehicles': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports': typeof AdminReportsIndexRoute
@@ -332,6 +341,7 @@ export interface FileRoutesById {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports/': typeof AdminReportsIndexRoute
@@ -371,6 +381,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/porcentaje-efectividad'
     | '/inversiones/liquidaciones/$inversionistaId'
     | '/juridico/generate/$opportunityId'
     | '/admin/reports/'
@@ -408,6 +419,7 @@ export interface FileRouteTypes {
     | '/vehicles'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/porcentaje-efectividad'
     | '/inversiones/liquidaciones/$inversionistaId'
     | '/juridico/generate/$opportunityId'
     | '/admin/reports'
@@ -445,6 +457,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/porcentaje-efectividad'
     | '/inversiones/liquidaciones/$inversionistaId'
     | '/juridico/generate/$opportunityId'
     | '/admin/reports/'
@@ -483,6 +496,7 @@ export interface RootRouteChildren {
   VehiclesIndexRoute: typeof VehiclesIndexRoute
   CrmAdminMiniagentRoute: typeof CrmAdminMiniagentRoute
   CrmAnalysisOpportunityIdRoute: typeof CrmAnalysisOpportunityIdRoute
+  CrmReportesPorcentajeEfectividadRoute: typeof CrmReportesPorcentajeEfectividadRoute
   InversionesLiquidacionesInversionistaIdRoute: typeof InversionesLiquidacionesInversionistaIdRoute
   JuridicoGenerateOpportunityIdRoute: typeof JuridicoGenerateOpportunityIdRoute
   AdminReportsIndexRoute: typeof AdminReportsIndexRoute
@@ -723,6 +737,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InversionesLiquidacionesInversionistaIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/crm/reportes/porcentaje-efectividad': {
+      id: '/crm/reportes/porcentaje-efectividad'
+      path: '/crm/reportes/porcentaje-efectividad'
+      fullPath: '/crm/reportes/porcentaje-efectividad'
+      preLoaderRoute: typeof CrmReportesPorcentajeEfectividadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/crm/analysis/$opportunityId': {
       id: '/crm/analysis/$opportunityId'
       path: '/crm/analysis/$opportunityId'
@@ -771,6 +792,7 @@ const rootRouteChildren: RootRouteChildren = {
   VehiclesIndexRoute: VehiclesIndexRoute,
   CrmAdminMiniagentRoute: CrmAdminMiniagentRoute,
   CrmAnalysisOpportunityIdRoute: CrmAnalysisOpportunityIdRoute,
+  CrmReportesPorcentajeEfectividadRoute: CrmReportesPorcentajeEfectividadRoute,
   InversionesLiquidacionesInversionistaIdRoute:
     InversionesLiquidacionesInversionistaIdRoute,
   JuridicoGenerateOpportunityIdRoute: JuridicoGenerateOpportunityIdRoute,

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -1,0 +1,575 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { subMonths } from "date-fns";
+import { Activity, CheckCircle2, Download, Target, XCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { DateRange } from "react-day-picker";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { toast } from "sonner";
+import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import { ReportCard } from "@/components/reports/report-card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { getSourceLabel } from "@/lib/crm-formatters";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/crm/reportes/porcentaje-efectividad")({
+	component: RouteComponent,
+});
+
+const GUATEMALA_TZ = "America/Guatemala";
+const BAR_HEIGHT_PX = 52;
+
+const SOURCE_COLORS: Record<string, string> = {
+	website: "#8b5cf6",
+	referral: "#10b981",
+	cold_call: "#f97316",
+	email: "#6366f1",
+	social_media: "#d946ef",
+	event: "#a855f7",
+	facebook: "#3b82f6",
+	instagram: "#ec4899",
+	google: "#ef4444",
+	meta: "#0ea5e9",
+	linkedin: "#1d4ed8",
+	// "Whatsapp" con W mayúscula es el valor real del enum en BD
+	Whatsapp: "#22c55e",
+	agency: "#14b8a6",
+	property: "#f59e0b",
+	recurrent: "#7c3aed",
+	recurrent_active: "#0891b2",
+	other: "#9ca3af",
+};
+
+function getSourceColor(source: string): string {
+	return SOURCE_COLORS[source] ?? "#9ca3af";
+}
+
+function formatDateInput(date: Date): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: GUATEMALA_TZ,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+function formatDisplayDate(date: Date | string | null): string {
+	if (!date) return "—";
+	return new Intl.DateTimeFormat("es-GT", {
+		timeZone: GUATEMALA_TZ,
+		day: "2-digit",
+		month: "2-digit",
+		year: "numeric",
+	}).format(new Date(date));
+}
+
+function getDefaultDateRange(): DateRange {
+	const today = new Date();
+	return { from: subMonths(today, 1), to: today };
+}
+
+// Prefija celdas que empiecen con operadores de fórmula para evitar CSV injection
+function sanitizeCSVCell(value: string): string {
+	return /^[=+\-@]/.test(value) ? `'${value}` : value;
+}
+
+function RouteComponent() {
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(
+		getDefaultDateRange,
+	);
+	const [pageSize, setPageSize] = useState(25);
+	const [page, setPage] = useState(0);
+
+	const {
+		data: session,
+		error: sessionError,
+		isPending: sessionPending,
+	} = authClient.useSession();
+	const navigate = useNavigate();
+
+	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
+	const userRole = userProfile.data?.role;
+	const canAccess = userRole
+		? PERMISSIONS.canAccessPorcentajeEfectividadReport(userRole)
+		: false;
+	const isPending = sessionPending || userProfile.isPending;
+
+	useEffect(() => {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
+			navigate({ to: "/login" });
+		} else if (session && !userProfile.isPending && !canAccess) {
+			navigate({ to: "/dashboard" });
+			toast.error("Acceso denegado");
+		}
+	}, [
+		session,
+		sessionError,
+		sessionPending,
+		userProfile.isPending,
+		canAccess,
+		navigate,
+	]);
+
+	const input =
+		dateRange?.from && dateRange?.to
+			? {
+					startDate: formatDateInput(dateRange.from),
+					endDate: formatDateInput(dateRange.to),
+				}
+			: null;
+
+	const reportQuery = useQuery({
+		...orpc.getReportePorcentajeEfectividad.queryOptions({
+			input: input ?? { startDate: "", endDate: "" },
+		}),
+		enabled: canAccess && !!input,
+	});
+
+	// Reiniciar página al recibir datos nuevos
+	useEffect(() => {
+		setPage(0);
+	}, [reportQuery.data]);
+
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAccess) return null;
+
+	const data = reportQuery.data;
+	const isLoading = reportQuery.isLoading;
+
+	const allRegistros = data?.registros ?? [];
+	const totalPages = Math.ceil(allRegistros.length / pageSize);
+	const visibleRegistros = allRegistros.slice(
+		page * pageSize,
+		(page + 1) * pageSize,
+	);
+
+	// exportCSV cierra sobre allRegistros para que el tipo sea inferido por oRPC
+	function exportCSV() {
+		const headers = ["Fecha", "Prospecto", "Fuente", "Etapa", "% Etapa", "¿Cerró?"];
+		const rows = allRegistros.map((row) => [
+			formatDisplayDate(row.createdAt),
+			row.nombre || "Sin nombre",
+			getSourceLabel(row.source),
+			row.etapaNombre || "Sin etapa",
+			row.etapaPorcentaje != null ? `${row.etapaPorcentaje}%` : "",
+			row.cerro ? "Sí" : "No",
+		]);
+		const csv = [headers, ...rows]
+			.map((row) =>
+				row
+					.map(
+						(cell) =>
+							`"${sanitizeCSVCell(String(cell)).replace(/"/g, '""')}"`,
+					)
+					.join(","),
+			)
+			.join("\n");
+		// BOM para que Excel en Windows interprete UTF-8 correctamente
+		const blob = new Blob(["\uFEFF", csv], { type: "text/csv;charset=utf-8;" });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement("a");
+		a.href = url;
+		// formatDateInput usa zona horaria de Guatemala, consistente con el resto del archivo
+		a.download = `efectividad-${formatDateInput(new Date())}.csv`;
+		a.click();
+		URL.revokeObjectURL(url);
+	}
+
+	const chartData = (data?.porFuente ?? [])
+		.map((row) => ({
+			rawSource: row.source,
+			source: getSourceLabel(row.source),
+			porcentaje: row.porcentaje,
+			totalOportunidades: row.totalOportunidades,
+			totalCerradas: row.totalCerradas,
+		}))
+		.sort((a, b) => b.porcentaje - a.porcentaje);
+
+	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<div>
+				<h1 className="font-bold text-3xl tracking-tight">
+					Porcentaje Efectividad
+				</h1>
+				<p className="mt-1 text-muted-foreground">
+					Oportunidades creadas en el período y si alcanzaron cierre (90%+),
+					con resumen de conversión por fuente.
+				</p>
+			</div>
+
+			<DateRangeFilter
+				dateRange={dateRange}
+				onDateRangeChange={setDateRange}
+			/>
+
+			{/* ── Registros individuales (prioridad) ── */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-start justify-between gap-4">
+						<div>
+							<CardTitle>Oportunidades del período</CardTitle>
+							<CardDescription className="mt-1">
+								Todas las oportunidades creadas en el rango seleccionado y su
+								estado de conversión
+							</CardDescription>
+						</div>
+						{allRegistros.length > 0 && (
+							<Button
+								variant="outline"
+								size="sm"
+								className="shrink-0"
+								onClick={exportCSV}
+							>
+								<Download className="mr-2 h-4 w-4" />
+								Exportar CSV
+							</Button>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					<div className="max-h-[600px] overflow-y-auto rounded-md border">
+						<Table>
+							<TableHeader className="sticky top-0 z-10 bg-background">
+								<TableRow>
+									<TableHead>Fecha</TableHead>
+									<TableHead>Prospecto</TableHead>
+									<TableHead>Fuente</TableHead>
+									<TableHead>Etapa actual</TableHead>
+									<TableHead className="text-center">¿Cerró?</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{isLoading ? (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className="py-8 text-center text-muted-foreground"
+										>
+											Cargando...
+										</TableCell>
+									</TableRow>
+								) : visibleRegistros.length === 0 ? (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className="py-8 text-center text-muted-foreground"
+										>
+											No hay datos para el período seleccionado
+										</TableCell>
+									</TableRow>
+								) : (
+									visibleRegistros.map((row) => (
+										<TableRow key={row.id}>
+											<TableCell className="whitespace-nowrap text-muted-foreground text-sm">
+												{formatDisplayDate(row.createdAt)}
+											</TableCell>
+											<TableCell className="font-medium">
+												{row.nombre || (
+													<span className="italic text-muted-foreground">
+														Sin nombre
+													</span>
+												)}
+											</TableCell>
+											<TableCell>
+												<div className="flex items-center gap-2">
+													<span
+														className="h-2 w-2 shrink-0 rounded-full"
+														style={{
+															backgroundColor: getSourceColor(row.source),
+														}}
+													/>
+													{getSourceLabel(row.source)}
+												</div>
+											</TableCell>
+											<TableCell>
+												{row.etapaNombre ? (
+													<span className="text-sm">
+														{row.etapaNombre}{" "}
+														<span className="text-muted-foreground">
+															({row.etapaPorcentaje}%)
+														</span>
+													</span>
+												) : (
+													<span className="italic text-muted-foreground text-sm">
+														Sin etapa
+													</span>
+												)}
+											</TableCell>
+											<TableCell className="text-center">
+												{row.cerro ? (
+													<Badge className="gap-1 bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-900/30 dark:text-green-400">
+														<CheckCircle2 className="h-3 w-3" />
+														Sí
+													</Badge>
+												) : (
+													<Badge
+														variant="outline"
+														className="gap-1 text-muted-foreground"
+													>
+														<XCircle className="h-3 w-3" />
+														No
+													</Badge>
+												)}
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
+
+					{/* Footer: paginación + selector de page size */}
+					{!isLoading && allRegistros.length > 0 && (
+						<div className="flex items-center justify-between text-sm text-muted-foreground">
+							<span>
+								{`Mostrando ${page * pageSize + 1}–${Math.min((page + 1) * pageSize, allRegistros.length)} de ${allRegistros.length} registros`}
+							</span>
+							<div className="flex items-center gap-3">
+								<div className="flex items-center gap-2">
+									<span>Mostrar</span>
+									<Select
+										value={String(pageSize)}
+										onValueChange={(v) => {
+											setPageSize(Number(v));
+											setPage(0);
+										}}
+									>
+										<SelectTrigger className="h-7 w-16 text-xs">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="25">25</SelectItem>
+											<SelectItem value="50">50</SelectItem>
+											<SelectItem value="100">100</SelectItem>
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="flex items-center gap-1">
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-7 px-2 text-xs"
+										disabled={page === 0}
+										onClick={() => setPage((p) => p - 1)}
+									>
+										Anterior
+									</Button>
+									<span className="px-2">
+										{page + 1} / {totalPages}
+									</span>
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-7 px-2 text-xs"
+										disabled={page + 1 >= totalPages}
+										onClick={() => setPage((p) => p + 1)}
+									>
+										Siguiente
+									</Button>
+								</div>
+							</div>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* ── Resumen estadístico ── */}
+			<div className="grid gap-4 md:grid-cols-3">
+				<ReportCard
+					title="Oportunidades Creadas"
+					value={isLoading ? "—" : (data?.total.totalOportunidades ?? 0)}
+					description="Total en el período seleccionado"
+					icon={Activity}
+				/>
+				<ReportCard
+					title="Créditos Cerrados"
+					value={isLoading ? "—" : (data?.total.totalCerradas ?? 0)}
+					description="Oportunidades que alcanzaron etapa 90%+"
+					icon={CheckCircle2}
+				/>
+				<ReportCard
+					title="Efectividad Global"
+					value={isLoading ? "—" : `${data?.total.porcentaje ?? 0}%`}
+					description="Tasa de conversión total del período"
+					icon={Target}
+				/>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Efectividad por fuente</CardTitle>
+					<CardDescription>
+						Ordenado de mayor a menor tasa de conversión
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{isLoading ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							Cargando...
+						</div>
+					) : chartData.length === 0 ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							No hay datos para el período seleccionado
+						</div>
+					) : (
+						<ResponsiveContainer width="100%" height={chartHeight}>
+							<BarChart
+								data={chartData}
+								layout="vertical"
+								margin={{ top: 0, right: 56, left: 0, bottom: 0 }}
+							>
+								<CartesianGrid strokeDasharray="3 3" horizontal={false} />
+								<XAxis
+									type="number"
+									domain={[0, 100]}
+									tickFormatter={(v: number) => `${v}%`}
+									tick={{ fontSize: 12 }}
+								/>
+								<YAxis
+									dataKey="source"
+									type="category"
+									width={110}
+									tick={{ fontSize: 12 }}
+								/>
+								<Tooltip
+									formatter={(value) => [`${value}%`, "Efectividad"]}
+									labelFormatter={(label) => `Fuente: ${label}`}
+								/>
+								<Bar
+									dataKey="porcentaje"
+									name="Efectividad"
+									radius={[0, 4, 4, 0]}
+								>
+									{chartData.map((entry) => (
+										<Cell
+											key={entry.rawSource}
+											fill={getSourceColor(entry.rawSource)}
+										/>
+									))}
+								</Bar>
+							</BarChart>
+						</ResponsiveContainer>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Detalle por fuente</CardTitle>
+					<CardDescription>
+						Oportunidades creadas, cerradas y tasa de conversión por canal de
+						origen
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Fuente</TableHead>
+								<TableHead className="text-right">Oportunidades</TableHead>
+								<TableHead className="text-right">Cerradas</TableHead>
+								<TableHead className="text-right">Efectividad</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={4}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : chartData.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={4}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								chartData.map((row) => (
+									<TableRow key={row.rawSource}>
+										<TableCell className="font-medium">
+											<div className="flex items-center gap-2">
+												<span
+													className="h-2.5 w-2.5 shrink-0 rounded-full"
+													style={{
+														backgroundColor: getSourceColor(row.rawSource),
+													}}
+												/>
+												{row.source}
+											</div>
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalOportunidades}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalCerradas}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.porcentaje}%
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}


### PR DESCRIPTION
## feat: reporte Porcentaje Efectividad (total y por fuente)
Resumen
Agrega el reporte Porcentaje Efectividad a la sección Ventas del CRM. El reporte responde a la pregunta: de todas las oportunidades creadas en un período, ¿qué porcentaje alguna vez llegó a etapa de cierre? Muestra primero los registros individuales y luego estadísticas agregadas por fuente.
Acceso restringido a Admin y Cobros Supervisor.

### Backend
**apps/crm/apps/server/src/lib/roles.ts**
Se agrega una función de permiso independiente:

```
canAccessPorcentajeEfectividadReport: (role: UserRole | string): boolean =>
role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
```

Se crea como función propia y no se reutiliza ninguna existente, siguiendo el principio de que cada reporte tiene su propia autorización. Si en el futuro cambian los roles con acceso a este reporte, el cambio es local y no afecta ningún otro.

**apps/crm/apps/server/src/lib/orpc.ts**
Se agrega middleware y procedure base independientes:

```
const requirePorcentajeEfectividadReport = publicProcedure.use(...)
export const porcentajeEfectividadReportProcedure = publicProcedure.use(requirePorcentajeEfectividadReport)
```
Mismo patrón que los demás reportes. El middleware lanza UNAUTHORIZED si el rol no tiene permiso.

**apps/crm/apps/server/src/routers/reports.ts**
Se agrega getReportePorcentajeEfectividad usando porcentajeEfectividadReportProcedure.

Constante de umbral de cierre:

`const CLOSED_STAGE_THRESHOLD = 90;`
Define qué significa "cerrado": una oportunidad que haya pasado por una etapa con closurePercentage >= 90. Constante nombrada para que el criterio sea explícito en el código.

Límite de filas:

`const MAX_REPORT_ROWS = 10_000;
`Se consulta con .limit(MAX_REPORT_ROWS + 1). Si el resultado supera el límite se lanza ORPCError("BAD_REQUEST") pidiendo al usuario que reduzca el rango de fechas. Protege contra queries que devuelvan volúmenes inmanejables en el frontend.

Subquery everClosed — sin filtro de fechas (intencional):

```
const everClosed = db
  .select({ opportunityId: opportunityStageHistory.opportunityId })
  .from(opportunityStageHistory)
  .innerJoin(salesStages, ...)
  .where(gte(salesStages.closurePercentage, CLOSED_STAGE_THRESHOLD))
  .groupBy(opportunityStageHistory.opportunityId)
  .as("ever_closed");
```

La subquery no lleva filtro de fechas de cierre de forma deliberada. El reporte usa un diseño de cohorte: "de las oportunidades creadas en el período X, ¿alguna vez cerraron?" — independientemente de cuándo ocurrió el cierre. Si se filtrara también la fecha de cierre, un crédito creado en diciembre que cierra en enero quedaría excluido, subestimando la efectividad real del período.

Tres queries en paralelo:

`const [totalRows, porFuente, registrosRaw] = await Promise.all([...])`

- totalRows — conteo global + efectividad total
- porFuente — agrupado por source, ordenado por volumen descendente
- registrosRaw — registros individuales con nombre del prospecto, etapa actual, % de etapa y flag cerro

El nombre del prospecto se construye en SQL con NULLIF(TRIM(CONCAT_WS(' ', firstName, lastName)), '') para devolver null cuando no hay datos, en vez de strings vacíos.

Retorno:

```
{ total: { totalOportunidades, totalCerradas, porcentaje },
  porFuente: [...],
  registros: [...] }
```

**apps/crm/apps/server/src/routers/index.ts**
Se registra getReportePorcentajeEfectividad en el router principal.

### Frontend
**apps/crm/apps/web/src/components/header.tsx**

Se agrega entrada al menú Ventas gateada por PERMISSIONS.canAccessPorcentajeEfectividadReport(userRole), con ícono Percent de lucide-react y link a /crm/reportes/porcentaje-efectividad.

**apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx**

Componente autocontenido. No se crean archivos de utilidades compartidas porque los reportes son PRs independientes y no hay garantía de que los reportes 1 y 4 se construyan.

**Autenticación y control de acceso:**
Mismo patrón que el resto del CRM: authClient.useSession() + orpc.getUserProfile + PERMISSIONS.canAccessPorcentajeEfectividadReport. Redirige a /login si no hay sesión, a /dashboard si no tiene permiso.

**Zona horaria Guatemala en todo el componente:**
formatDateInput y formatDisplayDate usan Intl.DateTimeFormat con timeZone: "America/Guatemala". Esto aplica tanto al filtro de fechas, a las fechas mostradas en tabla y al nombre del archivo CSV exportado.

**Estructura de la página — registros primero:**
La tabla de registros individuales va arriba porque es la vista diferencial de este reporte: muestra todas las oportunidades creadas en el período (abiertas y cerradas) junto con su estado de conversión. Ningún otro reporte existente cruza oportunidades abiertas con su historial de cierre. Las estadísticas agregadas (KPIs + gráfica + tabla por fuente) van debajo como resumen.

Tabla de registros con scroll y paginación client-side:

- Altura máxima de 600px con overflow-y-auto y header sticky
- page state con botones Anterior/Siguiente y selector de tamaño de página (25 / 50 / 100)
- La paginación es client-side sobre el array ya cargado: no hay requests adicionales al cambiar de página
- El footer muestra el rango exacto: "Mostrando 1–25 de 843 registros"
- Ambos estados se reinician a cero al llegar datos nuevos (useEffect sobre reportQuery.data)

**Exporta todos los registros, no solo la página visible**

- BOM UTF-8 explícito: "\uFEFF" como primer elemento del Blob — necesario para que Excel en Windows interprete correctamente los acentos del español (é, ó, ú, ñ, etc.)
- Protección contra CSV injection: sanitizeCSVCell prefija con ' cualquier celda cuyo valor empiece con =, +, - o @, evitando que Excel los interprete como fórmulas
- Nombre del archivo con fecha en zona horaria Guatemala: efectividad-2025-06-10.csv

**KPI cards (3):** Oportunidades Creadas, Créditos Cerrados, Efectividad Global. Muestran "—" mientras cargan.
**Gráfica horizontal:** ordenada descendente por porcentaje de efectividad, con color por fuente. Usa recharts con BarChart layout="vertical", altura dinámica proporcional al número de fuentes.
**Tabla de detalle por fuente:** oportunidades, cerradas y % efectividad por canal de origen.

<img width="1416" height="842" alt="Captura de pantalla 2026-06-10 165121" src="https://github.com/user-attachments/assets/c90e6134-893c-4668-9e1c-c7e0f440fbc0" />

<img width="1426" height="932" alt="Captura de pantalla 2026-06-10 165131" src="https://github.com/user-attachments/assets/cbb217ac-5f31-4e89-8d51-67b048ffd946" />

<img width="1470" height="794" alt="Captura de pantalla 2026-06-10 165142" src="https://github.com/user-attachments/assets/76044b10-97e1-4dbe-acc4-3ad44c9f5350" />
