### PR TITLE
feat(reportes): Reporte — Tiempo Cierre Crédito

### DIFF
--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -261,6 +261,35 @@ const requireClosedCreditsReport = o.middleware(async ({ context, next }) => {
 	});
 });
 
+const requireTiempoCierreReport = o.middleware(async ({ context, next }) => {
+	if (!context.session?.user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	const userId = context.session.user.id;
+	const userData = await db
+		.select()
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+	const userRole = userData[0]?.role;
+
+	if (!PERMISSIONS.canAccessTiempoCierreReport(userRole)) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Tiempo cierre report access required",
+		});
+	}
+
+	return next({
+		context: {
+			session: context.session,
+			user: userData[0],
+			userId,
+			userRole,
+		},
+	});
+});
+
 const requireViewOpportunityContracts = o.middleware(
 	async ({ context, next }) => {
 		if (!context.session?.user) {
@@ -479,6 +508,9 @@ export const cobrosSupervisorProcedure = publicProcedure.use(
 );
 export const closedCreditsReportProcedure = publicProcedure.use(
 	requireClosedCreditsReport,
+);
+export const tiempoCierreReportProcedure = publicProcedure.use(
+	requireTiempoCierreReport,
 );
 export const viewOpportunityContractsProcedure = publicProcedure.use(
 	requireViewOpportunityContracts,

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -134,6 +134,9 @@ export const PERMISSIONS = {
 	canAccessClosedCreditsReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
 
+	canAccessTiempoCierreReport: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
+
 	// Credit Detail Approval (40% → 50%)
 	canApproveCreditDetail: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -135,7 +135,7 @@ export const PERMISSIONS = {
 		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
 
 	canAccessTiempoCierreReport: (role: UserRole | string): boolean =>
-		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
+		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
 
 	// Credit Detail Approval (40% → 50%)
 	canApproveCreditDetail: (role: UserRole | string): boolean =>

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -327,6 +327,7 @@ export const reportsAppRouter = {
 	getReporteCreditosCerrados: reportsRouter.getReporteCreditosCerrados,
 	getReporteInventario: reportsRouter.getReporteInventario,
 	getReporteSubastas: reportsRouter.getReporteSubastas,
+	getReporteTiempoCierre: reportsRouter.getReporteTiempoCierre,
 	// Reportes unificados (cartera-back + CRM)
 	getReporteCarteraCompleto: reportesCarteraRouter.getReporteCarteraCompleto,
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -24,7 +24,6 @@ import {
 } from "../lib/orpc";
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
-const CLOSED_STAGE_THRESHOLD = 90;
 
 // Schema para filtros de fecha
 const dateRangeSchema = z.object({
@@ -486,7 +485,7 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 				.where(baseWhere),
 			db
 				.select({
-					source: opportunities.source,
+					source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
 					totalCreditos: count(),
 					avgDias: diasDesdeCreacion("AVG"),
 					minDias: diasDesdeCreacion("MIN"),
@@ -499,7 +498,7 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 				)
 				.leftJoin(leads, eq(opportunities.leadId, leads.id))
 				.where(baseWhere)
-				.groupBy(opportunities.source)
+				.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
 				.orderBy(desc(count())),
 		]);
 
@@ -511,8 +510,7 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 				maxDias: totalRows[0]?.maxDias ?? 0,
 			},
 			porFuente: porFuente.map((row) => ({
-				// "other" es el valor por defecto del enum leadSource (consistente con leads.source)
-				source: row.source ?? "other",
+				source: row.source,
 				totalCreditos: row.totalCreditos,
 				avgDias: row.avgDias ?? 0,
 				minDias: row.minDias ?? 0,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -17,7 +17,14 @@ import {
 	salesStages,
 } from "../db/schema/crm";
 import { vehicleInspections, vehicles } from "../db/schema/vehicles";
-import { closedCreditsReportProcedure, protectedProcedure } from "../lib/orpc";
+import {
+	closedCreditsReportProcedure,
+	protectedProcedure,
+	tiempoCierreReportProcedure,
+} from "../lib/orpc";
+
+const SECONDS_PER_DAY = 60 * 60 * 24;
+const CLOSED_STAGE_THRESHOLD = 90;
 
 // Schema para filtros de fecha
 const dateRangeSchema = z.object({
@@ -421,6 +428,98 @@ export const getReporteInventario = protectedProcedure.handler(async () => {
 		inspeccionesPorResultado,
 	};
 });
+
+/**
+ * Reporte de Tiempo de Cierre de Crédito
+ * Días desde la creación del prospecto hasta que la oportunidad alcanza etapa 90%+
+ * Desglosado por fuente (total y por fuente)
+ */
+export const getReporteTiempoCierre = tiempoCierreReportProcedure
+	.input(closedCreditsReportInputSchema)
+	.handler(async ({ input }) => {
+		const { start, end } = parseGuatemalaDateRange(
+			input.startDate,
+			input.endDate,
+		);
+
+		const firstClosedStageDates = db
+			.select({
+				opportunityId: opportunityStageHistory.opportunityId,
+				firstClosedStageAt:
+					sql<Date>`MIN(${opportunityStageHistory.changedAt})`.as(
+						"first_closed_stage_at",
+					),
+			})
+			.from(opportunityStageHistory)
+			.innerJoin(
+				salesStages,
+				eq(opportunityStageHistory.toStageId, salesStages.id),
+			)
+			.where(gte(salesStages.closurePercentage, CLOSED_STAGE_THRESHOLD))
+			.groupBy(opportunityStageHistory.opportunityId)
+			.as("first_closed_stage_dates");
+
+		// Fallback a opportunities.createdAt cuando leadId es null (oportunidades
+		// vinculadas directamente a empresa sin prospecto previo).
+		const diasDesdeCreacion = (fn: "AVG" | "MIN" | "MAX") =>
+			sql<number>`ROUND(${sql.raw(fn)}(EXTRACT(EPOCH FROM (${firstClosedStageDates.firstClosedStageAt} - COALESCE(${leads.createdAt}, ${opportunities.createdAt}))) / ${SECONDS_PER_DAY}), 1)`;
+
+		const baseWhere = and(
+			gte(firstClosedStageDates.firstClosedStageAt, start),
+			lte(firstClosedStageDates.firstClosedStageAt, end),
+		);
+
+		const [totalRows, porFuente] = await Promise.all([
+			db
+				.select({
+					totalCreditos: count(),
+					avgDias: diasDesdeCreacion("AVG"),
+					minDias: diasDesdeCreacion("MIN"),
+					maxDias: diasDesdeCreacion("MAX"),
+				})
+				.from(firstClosedStageDates)
+				.innerJoin(
+					opportunities,
+					eq(firstClosedStageDates.opportunityId, opportunities.id),
+				)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.where(baseWhere),
+			db
+				.select({
+					source: opportunities.source,
+					totalCreditos: count(),
+					avgDias: diasDesdeCreacion("AVG"),
+					minDias: diasDesdeCreacion("MIN"),
+					maxDias: diasDesdeCreacion("MAX"),
+				})
+				.from(firstClosedStageDates)
+				.innerJoin(
+					opportunities,
+					eq(firstClosedStageDates.opportunityId, opportunities.id),
+				)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.where(baseWhere)
+				.groupBy(opportunities.source)
+				.orderBy(desc(count())),
+		]);
+
+		return {
+			total: {
+				totalCreditos: totalRows[0]?.totalCreditos ?? 0,
+				avgDias: totalRows[0]?.avgDias ?? 0,
+				minDias: totalRows[0]?.minDias ?? 0,
+				maxDias: totalRows[0]?.maxDias ?? 0,
+			},
+			porFuente: porFuente.map((row) => ({
+				// "other" es el valor por defecto del enum leadSource (consistente con leads.source)
+				source: row.source ?? "other",
+				totalCreditos: row.totalCreditos,
+				avgDias: row.avgDias ?? 0,
+				minDias: row.minDias ?? 0,
+				maxDias: row.maxDias ?? 0,
+			})),
+		};
+	});
 
 /**
  * Reporte de Subastas

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -9,6 +9,7 @@ import {
 	Calculator,
 	Car,
 	ChevronDown,
+	Clock,
 	Database,
 	FileText,
 	Gavel,
@@ -149,6 +150,21 @@ export default function Header() {
 											</DropdownMenuItem>
 										</>
 									)}
+									{userRole &&
+										PERMISSIONS.canAccessTiempoCierreReport(userRole) && (
+											<>
+												<DropdownMenuSeparator />
+												<DropdownMenuItem asChild>
+													<Link
+														to="/crm/reportes/tiempo-cierre"
+														className="cursor-pointer"
+													>
+														<Clock className="mr-2 h-4 w-4" />
+														Tiempo Cierre Crédito
+													</Link>
+												</DropdownMenuItem>
+											</>
+										)}
 								</DropdownMenuContent>
 							</DropdownMenu>
 						)}

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -42,6 +42,7 @@ import { Route as CrmAnalysisIndexRouteImport } from './routes/crm/analysis/inde
 import { Route as AdminReportsIndexRouteImport } from './routes/admin/reports/index'
 import { Route as JuridicoGenerateOpportunityIdRouteImport } from './routes/juridico/generate.$opportunityId'
 import { Route as InversionesLiquidacionesInversionistaIdRouteImport } from './routes/inversiones/liquidaciones.$inversionistaId'
+import { Route as CrmReportesTiempoCierreRouteImport } from './routes/crm/reportes/tiempo-cierre'
 import { Route as CrmAnalysisOpportunityIdRouteImport } from './routes/crm/analysis/$opportunityId'
 import { Route as CrmAdminMiniagentRouteImport } from './routes/crm/admin/miniagent'
 
@@ -214,6 +215,11 @@ const InversionesLiquidacionesInversionistaIdRoute =
     path: '/inversiones/liquidaciones/$inversionistaId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const CrmReportesTiempoCierreRoute = CrmReportesTiempoCierreRouteImport.update({
+  id: '/crm/reportes/tiempo-cierre',
+  path: '/crm/reportes/tiempo-cierre',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CrmAnalysisOpportunityIdRoute =
   CrmAnalysisOpportunityIdRouteImport.update({
     id: '/crm/analysis/$opportunityId',
@@ -257,6 +263,7 @@ export interface FileRoutesByFullPath {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports/': typeof AdminReportsIndexRoute
@@ -294,6 +301,7 @@ export interface FileRoutesByTo {
   '/vehicles': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports': typeof AdminReportsIndexRoute
@@ -332,6 +340,7 @@ export interface FileRoutesById {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports/': typeof AdminReportsIndexRoute
@@ -371,6 +380,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/tiempo-cierre'
     | '/inversiones/liquidaciones/$inversionistaId'
     | '/juridico/generate/$opportunityId'
     | '/admin/reports/'
@@ -408,6 +418,7 @@ export interface FileRouteTypes {
     | '/vehicles'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/tiempo-cierre'
     | '/inversiones/liquidaciones/$inversionistaId'
     | '/juridico/generate/$opportunityId'
     | '/admin/reports'
@@ -445,6 +456,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/tiempo-cierre'
     | '/inversiones/liquidaciones/$inversionistaId'
     | '/juridico/generate/$opportunityId'
     | '/admin/reports/'
@@ -483,6 +495,7 @@ export interface RootRouteChildren {
   VehiclesIndexRoute: typeof VehiclesIndexRoute
   CrmAdminMiniagentRoute: typeof CrmAdminMiniagentRoute
   CrmAnalysisOpportunityIdRoute: typeof CrmAnalysisOpportunityIdRoute
+  CrmReportesTiempoCierreRoute: typeof CrmReportesTiempoCierreRoute
   InversionesLiquidacionesInversionistaIdRoute: typeof InversionesLiquidacionesInversionistaIdRoute
   JuridicoGenerateOpportunityIdRoute: typeof JuridicoGenerateOpportunityIdRoute
   AdminReportsIndexRoute: typeof AdminReportsIndexRoute
@@ -723,6 +736,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InversionesLiquidacionesInversionistaIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/crm/reportes/tiempo-cierre': {
+      id: '/crm/reportes/tiempo-cierre'
+      path: '/crm/reportes/tiempo-cierre'
+      fullPath: '/crm/reportes/tiempo-cierre'
+      preLoaderRoute: typeof CrmReportesTiempoCierreRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/crm/analysis/$opportunityId': {
       id: '/crm/analysis/$opportunityId'
       path: '/crm/analysis/$opportunityId'
@@ -771,6 +791,7 @@ const rootRouteChildren: RootRouteChildren = {
   VehiclesIndexRoute: VehiclesIndexRoute,
   CrmAdminMiniagentRoute: CrmAdminMiniagentRoute,
   CrmAnalysisOpportunityIdRoute: CrmAnalysisOpportunityIdRoute,
+  CrmReportesTiempoCierreRoute: CrmReportesTiempoCierreRoute,
   InversionesLiquidacionesInversionistaIdRoute:
     InversionesLiquidacionesInversionistaIdRoute,
   JuridicoGenerateOpportunityIdRoute: JuridicoGenerateOpportunityIdRoute,

--- a/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
@@ -1,0 +1,316 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { subMonths } from "date-fns";
+import { Activity, Clock, TrendingDown, TrendingUp } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { DateRange } from "react-day-picker";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { toast } from "sonner";
+import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import { ReportCard } from "@/components/reports/report-card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { getSourceLabel } from "@/lib/crm-formatters";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/crm/reportes/tiempo-cierre")({
+	component: RouteComponent,
+});
+
+const GUATEMALA_TZ = "America/Guatemala";
+const BAR_HEIGHT_PX = 52;
+
+const SOURCE_COLORS: Record<string, string> = {
+	website: "#8b5cf6",
+	referral: "#10b981",
+	cold_call: "#f97316",
+	email: "#6366f1",
+	social_media: "#d946ef",
+	event: "#a855f7",
+	facebook: "#3b82f6",
+	instagram: "#ec4899",
+	google: "#ef4444",
+	meta: "#0ea5e9",
+	linkedin: "#1d4ed8",
+	// "Whatsapp" con W mayúscula es el valor real del enum en BD
+	Whatsapp: "#22c55e",
+	agency: "#14b8a6",
+	property: "#f59e0b",
+	recurrent: "#7c3aed",
+	recurrent_active: "#0891b2",
+	other: "#9ca3af",
+};
+
+function getSourceColor(source: string): string {
+	return SOURCE_COLORS[source] ?? "#9ca3af";
+}
+
+function formatDateInput(date: Date): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: GUATEMALA_TZ,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+function getDefaultDateRange(): DateRange {
+	const today = new Date();
+	return { from: subMonths(today, 1), to: today };
+}
+
+function RouteComponent() {
+	const {
+		data: session,
+		error: sessionError,
+		isPending: sessionPending,
+	} = authClient.useSession();
+	const navigate = useNavigate();
+
+	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
+	const userRole = userProfile.data?.role;
+	const canAccess = userRole ? PERMISSIONS.canAccessTiempoCierreReport(userRole) : false;
+	const isPending = sessionPending || userProfile.isPending;
+
+	useEffect(() => {
+		if (shouldRedirectToLogin({ error: sessionError, isPending: sessionPending, session })) {
+			navigate({ to: "/login" });
+		} else if (session && !userProfile.isPending && !canAccess) {
+			navigate({ to: "/dashboard" });
+			toast.error("Acceso denegado");
+		}
+	}, [session, sessionError, sessionPending, userProfile.isPending, canAccess, navigate]);
+
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(getDefaultDateRange);
+
+	const input =
+		dateRange?.from && dateRange?.to
+			? { startDate: formatDateInput(dateRange.from), endDate: formatDateInput(dateRange.to) }
+			: null;
+
+	const reportQuery = useQuery({
+		...orpc.getReporteTiempoCierre.queryOptions({
+			input: input ?? { startDate: "", endDate: "" },
+		}),
+		enabled: canAccess && !!input,
+	});
+
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAccess) return null;
+
+	const data = reportQuery.data;
+	const isLoading = reportQuery.isLoading;
+
+	const chartData = (data?.porFuente ?? [])
+		.map((row) => ({
+			rawSource: row.source,
+			source: getSourceLabel(row.source),
+			avgDias: row.avgDias,
+			minDias: row.minDias,
+			maxDias: row.maxDias,
+			totalCreditos: row.totalCreditos,
+		}))
+		.sort((a, b) => a.avgDias - b.avgDias);
+
+	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<div>
+				<h1 className="font-bold text-3xl tracking-tight">
+					Tiempo Cierre Crédito
+				</h1>
+				<p className="mt-1 text-muted-foreground">
+					Días promedio desde la creación del prospecto hasta el cierre del
+					crédito (etapa 90%+), desglosado por fuente.
+				</p>
+			</div>
+
+			<DateRangeFilter
+				dateRange={dateRange}
+				onDateRangeChange={setDateRange}
+			/>
+
+			<div className="grid gap-4 md:grid-cols-4">
+				<ReportCard
+					title="Créditos Analizados"
+					value={isLoading ? "—" : (data?.total.totalCreditos ?? 0)}
+					description="Créditos cerrados en el período"
+					icon={Activity}
+				/>
+				<ReportCard
+					title="Promedio General"
+					value={isLoading ? "—" : `${data?.total.avgDias ?? 0} días`}
+					description="Tiempo promedio total del período"
+					icon={Clock}
+				/>
+				<ReportCard
+					title="Cierre Más Rápido"
+					value={isLoading ? "—" : `${data?.total.minDias ?? 0} días`}
+					description="Tiempo mínimo registrado"
+					icon={TrendingDown}
+				/>
+				<ReportCard
+					title="Cierre Más Lento"
+					value={isLoading ? "—" : `${data?.total.maxDias ?? 0} días`}
+					description="Tiempo máximo registrado"
+					icon={TrendingUp}
+				/>
+			</div>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Promedio de días por fuente</CardTitle>
+					<CardDescription>
+						Ordenado de menor a mayor tiempo de cierre
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{isLoading ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							Cargando datos...
+						</div>
+					) : chartData.length === 0 ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							No hay datos para el período seleccionado
+						</div>
+					) : (
+						<ResponsiveContainer width="100%" height={chartHeight}>
+							<BarChart
+								data={chartData}
+								layout="vertical"
+								margin={{ top: 0, right: 48, left: 0, bottom: 0 }}
+							>
+								<CartesianGrid strokeDasharray="3 3" horizontal={false} />
+								<XAxis
+									type="number"
+									tickFormatter={(v: number) => `${v}d`}
+									tick={{ fontSize: 12 }}
+								/>
+								<YAxis
+									dataKey="source"
+									type="category"
+									width={110}
+									tick={{ fontSize: 12 }}
+								/>
+								<Tooltip
+									formatter={(value) => [`${value} días`, "Promedio"]}
+									labelFormatter={(label) => `Fuente: ${label}`}
+								/>
+								<Bar dataKey="avgDias" name="Días promedio" radius={[0, 4, 4, 0]}>
+									{chartData.map((entry) => (
+										<Cell
+											key={entry.rawSource}
+											fill={getSourceColor(entry.rawSource)}
+										/>
+									))}
+								</Bar>
+							</BarChart>
+						</ResponsiveContainer>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Detalle por fuente</CardTitle>
+					<CardDescription>
+						Estadísticas completas de tiempo de cierre por canal de origen
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Fuente</TableHead>
+								<TableHead className="text-right">Créditos</TableHead>
+								<TableHead className="text-right">Promedio (días)</TableHead>
+								<TableHead className="text-right">Mínimo (días)</TableHead>
+								<TableHead className="text-right">Máximo (días)</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={5}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : chartData.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={5}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								chartData.map((row) => (
+									<TableRow key={row.rawSource}>
+										<TableCell className="font-medium">
+											<div className="flex items-center gap-2">
+												<span
+													className="h-2.5 w-2.5 shrink-0 rounded-full"
+													style={{ backgroundColor: getSourceColor(row.rawSource) }}
+												/>
+												{row.source}
+											</div>
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalCreditos}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.avgDias}
+										</TableCell>
+										<TableCell className="text-right text-green-600 dark:text-green-400">
+											{row.minDias ?? 0}
+										</TableCell>
+										<TableCell className="text-right text-orange-600 dark:text-orange-400">
+											{row.maxDias ?? 0}
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}


### PR DESCRIPTION
## Descripción

Implementa el reporte **"Tiempo Cierre Crédito"** bajo la sección de Ventas del CRM. El reporte muestra cuántos días tarda un crédito en cerrarse desde la creación del prospecto hasta que la oportunidad alcanza una etapa de cierre (≥90%), desglosado por fuente de origen.

### ¿Por qué estadísticas agregadas y no registros individuales?

Un listado de créditos individuales con sus fechas duplicaría el reporte "Créditos Cerrados" que ya existe en `/admin/reports`. El valor de este reporte está en responder *"¿qué tan rápido cerramos según el canal?"*, lo cual requiere promedios comparables entre fuentes, no una tabla de filas.

## Backend

**`apps/server/src/routers/reports.ts`**
- Nuevo procedimiento `getReporteTiempoCierre` que calcula:
  - Totales globales: cantidad de créditos, promedio, mínimo y máximo de días
  - Desglose por fuente con las mismas métricas, ordenado por volumen
- La fecha de cierre se toma como el **primer momento** en que la oportunidad entra a una etapa con `closurePercentage >= 90` (usando `opportunityStageHistory` + `salesStages`)
- La fecha de inicio se toma de `leads.createdAt`, con fallback a `opportunities.createdAt` para oportunidades vinculadas directamente a una empresa sin prospecto previo
- Se usan constantes nombradas (`SECONDS_PER_DAY`, `CLOSED_STAGE_THRESHOLD`) para evitar números mágicos

**`apps/server/src/lib/roles.ts`**
- Nueva función de permiso independiente: `canAccessTiempoCierreReport`
- Accesible solo para roles `admin` y `cobros_supervisor`
- Es una función separada (no reutiliza `canAccessClosedCreditsReport`) para que cada reporte tenga su propio control de acceso y pueda evolucionar de forma independiente en el futuro

**`apps/server/src/lib/orpc.ts`**
- Nuevo middleware independiente `requireTiempoCierreReport` que llama a `PERMISSIONS.canAccessTiempoCierreReport`
- Nuevo procedure export `tiempoCierreReportProcedure`
- Por la misma razón anterior: no reutiliza `closedCreditsReportProcedure` — cada reporte tiene su propia capa de autorización

**`apps/server/src/routers/index.ts`**
- Registro de `getReporteTiempoCierre` en `reportsAppRouter`

## Frontend

**`apps/web/src/routes/crm/reportes/tiempo-cierre.tsx`** *(archivo nuevo)*
- Ruta: `/crm/reportes/tiempo-cierre`
- Validación de acceso con `PERMISSIONS.canAccessTiempoCierreReport` — redirige a `/dashboard` con toast de error si el rol no tiene permiso
- Filtro de rango de fechas (por defecto: último mes)
- 4 KPI cards: Créditos Analizados, Promedio General, Cierre Más Rápido, Cierre Más Lento
- Gráfico de barras horizontales ordenado ascendente por promedio de días, coloreado por fuente
- Tabla de detalle con promedio / mínimo / máximo por fuente, con indicador de color consistente con el gráfico

**`apps/web/src/components/header.tsx`**
- Nueva entrada "Tiempo Cierre Crédito" en el dropdown de Ventas
- Visible únicamente para los roles con `canAccessTiempoCierreReport` (`admin` y `cobros_supervisor`)

## Acceso

| Rol | Acceso |
|-----|--------|
| `admin` | ✅ |
| `cobros_supervisor` | ✅ |
| Todos los demás | ❌ Redirige a `/dashboard` |

La restricción se aplica en tres capas independientes: middleware del servidor, validación en la ruta del frontend, y visibilidad en el header.

<img width="1600" height="889" alt="image" src="https://github.com/user-attachments/assets/4db7ee65-bfd9-4304-9ab8-07b080c63e50" />

<img width="1608" height="507" alt="image" src="https://github.com/user-attachments/assets/d5ac7a7c-aafd-48c2-875a-1d0dfe0996a1" />

