### PR TITLE
fix(cartera): medir lo aplicado a la cuota por rubros, no por monto_aplicado

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import Big from "big.js";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
@@ -8,6 +9,7 @@ import {
   getSpecialPaymentInstallmentFields,
   shouldApplyStaleZeroRestanteAdjustment,
   shouldMarkInstallmentPaymentPaid,
+  sumarAplicadoACuota,
 } from "./registerPaymentPolicy";
 
 describe("register payment", () => {
@@ -110,6 +112,197 @@ describe("register payment", () => {
       montoAplicado: 0,
       pagado: true,
     });
+  });
+});
+
+describe("sumarAplicadoACuota", () => {
+  // Caso reportado: la cuota #5 vale 1793.40 pero el detector veía 20000
+  // "ya aplicado" porque sumaba `monto_aplicado` de filas de mora/otros. Esas
+  // filas traen TODOS los `abono_*` en 0, así que no deben sumar nada a la
+  // cuota: lo aplicado real son sólo los rubros de cuota de los pagos normales.
+  it("ignora mora/otros (rubros en 0) y sólo cuenta lo aplicado a la cuota", () => {
+    const rows = [
+      // fila de sólo mora/otros: monto_aplicado=20000 pero rubros en 0
+      {
+        abono_capital: 0,
+        abono_interes: 0,
+        abono_iva_12: 0,
+        abono_seguro: 0,
+        abono_gps: 0,
+        membresias_pago: 0,
+      },
+      // pago de cuota normal: rubros suman 1793.40
+      {
+        abono_capital: 1400.0,
+        abono_interes: 350.0,
+        abono_iva_12: 42.0,
+        abono_seguro: 0,
+        abono_gps: 1.4,
+        membresias_pago: 0,
+      },
+    ];
+    expect(sumarAplicadoACuota(rows).toFixed(2)).toBe("1793.40");
+  });
+
+  it("suma todos los rubros de cuota (incluido el capital de la cuota)", () => {
+    const r = sumarAplicadoACuota([
+      {
+        abono_capital: 845.12,
+        abono_interes: 177.86,
+        abono_iva_12: 21.34,
+        abono_seguro: 260.93,
+        abono_gps: 138.0,
+        membresias_pago: 0,
+      },
+    ]);
+    expect(r.toFixed(2)).toBe("1443.25");
+  });
+
+  it("es 0 sin hermanos y tolera campos nulos/ausentes", () => {
+    expect(sumarAplicadoACuota([]).toFixed(2)).toBe("0.00");
+    expect(
+      sumarAplicadoACuota([
+        { abono_capital: null, abono_interes: "100" },
+      ]).toFixed(2)
+    ).toBe("100.00");
+  });
+
+  it("trabaja con strings (la forma real que devuelve Drizzle para numeric)", () => {
+    // Las columnas numeric de pagos_credito vuelven como string, no number.
+    const r = sumarAplicadoACuota([
+      {
+        abono_capital: "1400.00",
+        abono_interes: "350.00",
+        abono_iva_12: "42.00",
+        abono_seguro: "0",
+        abono_gps: "1.40",
+        membresias_pago: "0",
+      },
+    ]);
+    expect(r.toFixed(2)).toBe("1793.40");
+  });
+
+  it("suma varios parciales de cuota (filas hermanas) sin perder centavos", () => {
+    const r = sumarAplicadoACuota([
+      { abono_capital: "500.00", abono_interes: "100.00", abono_iva_12: "12.00" },
+      { abono_capital: "300.00", abono_interes: "50.00", abono_iva_12: "6.00" },
+      { abono_seguro: "260.93", abono_gps: "138.00", membresias_pago: "0" },
+    ]);
+    expect(r.toFixed(2)).toBe("1366.93");
+  });
+
+  it("una fila de sólo mora/otros (todos los abono_* en 0) aporta 0 aunque su monto_aplicado sea enorme", () => {
+    // monto_aplicado=20000 vive en la fila pero NO se mira aquí: sólo rubros.
+    expect(
+      sumarAplicadoACuota([
+        {
+          abono_capital: "0",
+          abono_interes: "0",
+          abono_iva_12: "0",
+          abono_seguro: "0",
+          abono_gps: "0",
+          membresias_pago: "0",
+        },
+      ]).toFixed(2)
+    ).toBe("0.00");
+  });
+});
+
+// Reproducción end-to-end del caso reportado a nivel de política: la cuota #5
+// (1793.40) tiene un hermano de SÓLO mora/otros con monto_aplicado=20000. Antes,
+// `aplicadoPrevioCuota = Σ monto_aplicado = 20000` colapsaba `saldoRealCuota` a 0
+// → la cuota no se podía pagar Y la red de seguridad tronaba con "sobre-aplicada".
+// Con `sumarAplicadoACuota` (rubros, no monto_aplicado) el hermano aporta 0 y la
+// cuota vuelve a ser pagable por su monto completo.
+describe("regresión: mora/otros no debe colapsar el saldo de la cuota", () => {
+  const hermanoSoloMora = {
+    abono_capital: "0",
+    abono_interes: "0",
+    abono_iva_12: "0",
+    abono_seguro: "0",
+    abono_gps: "0",
+    membresias_pago: "0",
+  };
+
+  it("con el cálculo VIEJO (monto_aplicado) el saldo de la cuota se iría a 0 (estado a evitar)", () => {
+    // Simula el bug: medir por monto_aplicado de la fila de mora.
+    const aplicadoViejo = 20000;
+    const saldo = calcularSaldoNetoCuota({
+      montoCuota: 1793.4,
+      aplicadoPrevioCuota: aplicadoViejo,
+      filaInteresRestante: 0,
+      filaIvaRestante: 0,
+      filaSeguroRestante: 0,
+      filaGpsRestante: 0,
+      filaMembresiasRestante: 0,
+      filaCapitalRestante: 1793.4,
+      objetivoSeguro: 0,
+      objetivoGps: 0,
+      objetivoMembresias: 0,
+      hermanosSeguro: 0,
+      hermanosGps: 0,
+      hermanosMembresias: 0,
+      hermanosInteres: 0,
+      hermanosIva: 0,
+    });
+    expect(saldo.saldoRealCuota.toFixed(2)).toBe("0.00"); // cuota trabada (bug)
+  });
+
+  it("con el cálculo NUEVO (sumarAplicadoACuota) la cuota sigue siendo pagable por su monto completo", () => {
+    const aplicadoNuevo = sumarAplicadoACuota([hermanoSoloMora]); // = 0
+    expect(aplicadoNuevo.toFixed(2)).toBe("0.00");
+
+    const saldo = calcularSaldoNetoCuota({
+      montoCuota: 1793.4,
+      aplicadoPrevioCuota: aplicadoNuevo,
+      filaInteresRestante: 0,
+      filaIvaRestante: 0,
+      filaSeguroRestante: 0,
+      filaGpsRestante: 0,
+      filaMembresiasRestante: 0,
+      filaCapitalRestante: 1793.4,
+      objetivoSeguro: 0,
+      objetivoGps: 0,
+      objetivoMembresias: 0,
+      hermanosSeguro: 0,
+      hermanosGps: 0,
+      hermanosMembresias: 0,
+      hermanosInteres: 0,
+      hermanosIva: 0,
+    });
+    expect(saldo.saldoRealCuota.toFixed(2)).toBe("1793.40"); // cuota pagable
+    expect(saldo.capitalRestante.toFixed(2)).toBe("1793.40");
+
+    // Y la red de seguridad ya no tronaría: aplicado(0) + pago(1793.40) == cuota.
+    const totalProyectado = aplicadoNuevo.plus(1793.4);
+    expect(totalProyectado.gt(new Big(1793.4).plus(0.01))).toBe(false);
+  });
+
+  it("un hermano REAL de cuota (con rubros) sí cuenta y topa el faltante correctamente", () => {
+    // Hermano que ya aplicó 793.40 de cuota (capital+interés) → faltan 1000.
+    const aplicado = sumarAplicadoACuota([
+      { abono_capital: "700.00", abono_interes: "82.50", abono_iva_12: "10.90" },
+    ]);
+    expect(aplicado.toFixed(2)).toBe("793.40");
+    const saldo = calcularSaldoNetoCuota({
+      montoCuota: 1793.4,
+      aplicadoPrevioCuota: aplicado,
+      filaInteresRestante: 0,
+      filaIvaRestante: 0,
+      filaSeguroRestante: 0,
+      filaGpsRestante: 0,
+      filaMembresiasRestante: 0,
+      filaCapitalRestante: 1793.4,
+      objetivoSeguro: 0,
+      objetivoGps: 0,
+      objetivoMembresias: 0,
+      hermanosSeguro: 0,
+      hermanosGps: 0,
+      hermanosMembresias: 0,
+      hermanosInteres: 0,
+      hermanosIva: 0,
+    });
+    expect(saldo.saldoRealCuota.toFixed(2)).toBe("1000.00");
   });
 });
 

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -29,6 +29,7 @@ import {
   getSpecialPaymentCuotaId,
   shouldApplyStaleZeroRestanteAdjustment,
   shouldMarkInstallmentPaymentPaid,
+  sumarAplicadoACuota,
 } from "./registerPaymentPolicy";
 
 type LockConn = {
@@ -914,6 +915,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           .select({
             pago_id: pagos_credito.pago_id,
             monto_aplicado: pagos_credito.monto_aplicado,
+            abono_capital: pagos_credito.abono_capital,
             abono_interes: pagos_credito.abono_interes,
             abono_iva_12: pagos_credito.abono_iva_12,
             abono_seguro: pagos_credito.abono_seguro,
@@ -942,7 +944,13 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
             (acc, p) => acc.plus(new Big(sel(p) ?? 0)),
             new Big(0)
           );
-        const aplicadoPrevioCuota = sumaHermanos((p) => p.monto_aplicado);
+        // Lo aplicado a la CUOTA por los hermanos = Σ de sus rubros de cuota
+        // (capital+interés+IVA+seguro+GPS+membresías), NO `monto_aplicado`.
+        // `monto_aplicado` legacy carga mora/otros (filas de sólo mora traen
+        // rubros en 0) y abonos directos a capital; contarlos inflaba el
+        // faltante de la cuota → colapsaba `saldoRealCuota` a 0 y disparaba el
+        // rechazo falso de "sobre-aplicación". Ver `sumarAplicadoACuota`.
+        const aplicadoPrevioCuota = sumarAplicadoACuota(pagosHermanos);
         const interesPrevioCuota = sumaHermanos((p) => p.abono_interes);
         const seguroPrevioCuota = sumaHermanos((p) => p.abono_seguro);
         const gpsPrevioCuota = sumaHermanos((p) => p.abono_gps);

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -70,7 +70,12 @@ export const getSpecialPaymentInstallmentFields = () => ({
 export type SaldoCuotaInput = {
   /** Monto total de la cuota (credito.cuota). */
   montoCuota: BigInput;
-  /** Σ monto_aplicado de los pagos hermanos vivos (validated/pending). */
+  /**
+   * Σ de los rubros de cuota aplicados por los pagos hermanos vivos
+   * (validated/pending): capital + interés + IVA + seguro + GPS + membresías.
+   * Excluye mora/otros y abonos directos a capital (no son parte de la cuota).
+   * Ver `sumarAplicadoACuota`.
+   */
   aplicadoPrevioCuota: BigInput;
   // Saldos que indica la fila de pago vigente (pueden estar desincronizados).
   filaInteresRestante: BigInput;
@@ -99,6 +104,45 @@ export type SaldoCuotaInput = {
   hermanosIva: BigInput;
 };
 
+/** Fila de pago hermano con sus rubros de cuota (los `abono_*`). */
+export type RubrosCuotaRow = {
+  abono_capital?: BigInput | null;
+  abono_interes?: BigInput | null;
+  abono_iva_12?: BigInput | null;
+  abono_seguro?: BigInput | null;
+  abono_gps?: BigInput | null;
+  membresias_pago?: BigInput | null;
+};
+
+/**
+ * Σ de lo que los pagos hermanos aplicaron a la CUOTA contractual
+ * (`credito.cuota`): capital + interés + IVA + seguro + GPS + membresías.
+ *
+ * A propósito NO usa `monto_aplicado` ni suma `mora`/`otros`. Esos buckets no
+ * son parte de la cuota:
+ *  - Las filas de sólo mora/otros traen TODOS los `abono_*` en 0, así que
+ *    aportan 0 (su `monto_aplicado` legacy = mora+otros, que no es cuota).
+ *  - Los abonos directos a capital viven en `validationStatus = "capital"` y
+ *    ni siquiera entran al set de hermanos vivos.
+ *
+ * Para una fila de cuota normal `monto_aplicado` == esta suma, así que en datos
+ * limpios es equivalente; sólo deja de inflar el faltante con mora/otros, que
+ * antes colapsaba `saldoRealCuota` a 0 y disparaba un rechazo falso de
+ * "sobre-aplicación".
+ */
+export const sumarAplicadoACuota = (rows: RubrosCuotaRow[]): Big =>
+  rows.reduce(
+    (acc, r) =>
+      acc
+        .plus(new Big(r.abono_capital ?? 0))
+        .plus(new Big(r.abono_interes ?? 0))
+        .plus(new Big(r.abono_iva_12 ?? 0))
+        .plus(new Big(r.abono_seguro ?? 0))
+        .plus(new Big(r.abono_gps ?? 0))
+        .plus(new Big(r.membresias_pago ?? 0)),
+    new Big(0)
+  );
+
 export type SaldoCuotaNeto = {
   saldoRealCuota: Big;
   interesRestante: Big;
@@ -113,7 +157,9 @@ export type SaldoCuotaNeto = {
  * Saldo NETO de una cuota para distribuir un pago, robusto ante `*_restante`
  * desincronizados entre pagos hermanos.
  *
- * - Faltante real de la cuota = monto_cuota − Σ monto_aplicado hermanos.
+ * - Faltante real de la cuota = monto_cuota − Σ rubros de cuota de hermanos
+ *   (capital+interés+IVA+seguro+GPS+membresías; ver `sumarAplicadoACuota`).
+ *   NO se cuenta mora/otros ni abonos directos a capital: no son cuota.
  * - Rubros planos (seguro/GPS/membresías) = mín(saldo de la fila, objetivo −
  *   ya abonado por hermanos), nunca negativo. Así un rubro ya cubierto por un
  *   pago previo no se vuelve a aplicar aunque la fila vigente lo muestre lleno.


### PR DESCRIPTION
## Síntoma

`/newPayment` rechazaba pagos con:

> Pago rechazado: la cuota #5 quedaría sobre-aplicada (21793.40 > monto de cuota 1793.40). Ya aplicado por otros pagos: 20000.00; este pago intentaría aplicar 1793.40 más.

donde el "ya aplicado" (20000) es muchísimo mayor que la cuota.

## Causa raíz (no es bug de datos ni de la detección — medía mal)

La red de seguridad anti-sobreaplicación y `calcularSaldoNetoCuota` calculaban `aplicadoPrevioCuota` sumando **`monto_aplicado`** de los pagos hermanos de la cuota.

Pero las filas de **sólo mora/otros** (creadas por `insertarPago`, `validation_status='pending'`) guardan `monto_aplicado = mora + otros` con **todos los `abono_*` en 0**. Esa plata no es parte de la cuota contractual (`creditos.cuota`), pero al sumarse inflaba el faltante:

1. Disparaba el throw `"cuota #N sobre-aplicada"`.
2. Peor: en `calcularSaldoNetoCuota`, `saldoRealCuota = montoCuota − aplicadoPrevio` colapsaba a **0** → la cuota quedaba **imposible de pagar**.

Los abonos **directos a capital** ya estaban bien excluidos (viven en `validation_status='capital'`, que el query de hermanos no cuenta).

## Fix

`aplicadoPrevioCuota` ahora mide **lo aplicado a la cuota** = Σ de los rubros de cuota (`capital + interés + IVA + seguro + GPS + membresías`), vía el helper puro **`sumarAplicadoACuota`** en `registerPaymentPolicy.ts`.

Excluye por construcción:
- **mora / otros** → viven en columnas aparte, no se suman.
- **abono directo a capital** → ya fuera por `validation_status='capital'`.

Para datos limpios es **idéntico** (en una fila de cuota normal `monto_aplicado == Σrubros`), así que **no cambia la distribución**; sólo deja de contar mora/otros.

### Cambios
- `registerPaymentPolicy.ts`: nuevo helper `sumarAplicadoACuota` + tipo `RubrosCuotaRow`; JSDoc actualizado.
- `registerPayment.ts`: se agregó `abono_capital` al select de hermanos y `aplicadoPrevioCuota` usa el helper.
- `registerPayment.test.ts`: +9 tests.

## Validación

**Datos reales (dump de prod en local):** una query de auditoría encontró **111 cuotas** donde el cálculo viejo (`Σ monto_aplicado`) supera la cuota y tronaría/colapsaría, mientras el nuevo (`Σ rubros`) **no** (`Σrubros ≤ cuota` en las 111). Ejemplo: crédito `01010214121480` cuota 5 — rubros = 3615.52 (== cuota completa) pero `monto_aplicado` = 7808.52 porque un hermano cargó `mora=4193` en `monto_aplicado`.

**Unit tests** (`bun test src/controllers/registerPayment.test.ts` → 22 pass):
- `sumarAplicadoACuota`: ignora filas de sólo mora/otros (rubros en 0, aunque `monto_aplicado` sea enorme), suma rubros incl. capital de cuota, trabaja con strings (forma real de Drizzle), múltiples parciales, nulos/vacíos.
- Reproducción del caso encadenando `calcularSaldoNetoCuota`: con el cálculo **viejo** `saldoRealCuota` → 0 (cuota trabada); con el **nuevo** la cuota sigue pagable por su monto completo y la red de seguridad ya no trona.

> Nota: las 8 fallas en `payments.test.ts` (*Pagos Espejo*) son **pre-existentes en `develop`** (contaminación de mocks entre archivos al correr la suite completa; aislado pasa 7/7). Este PR pasa de 46→55 passing sin introducir fallas. `tsc --noEmit`: 0 errores.

## Caveat
Si existieran filas legacy con `monto_aplicado > 0` pero `abono_*` sin poblar, el rubro-sum las sub-contaría. No observado en créditos activos (las filas las escribe el código actual con rubros poblados).

## Pendiente opcional
Replay HTTP A/B sobre el crédito de pruebas `890` (con backup/restore) si se quiere confirmación end-to-end vía endpoint; no se hizo aquí para no contaminar el dump de prod que se está auditando en local.

---

## Revisión de código (hallazgos)

Revisado con enfoque en recall + validación empírica contra el dump de prod en local. **Mergeable**: el fix deja el sistema mejor que antes en todos los casos que ocurren hoy. Hallazgos:

### 🟠 Latente (no dispara hoy): el rubro-sum sub-cuenta pagos de cuota "sin itemizar"
Existen filas vivas (`validated`) que son pagos reales de cuota cuyo monto sólo vive en `monto_aplicado` con los `abono_*` en 0 (las traídas de SIFCO, ej. `obs="pago sincronizado desde SIFCO cuota N"`). El cálculo viejo las contaba; el nuevo las descarta.
- **Tamaño en local:** 40 filas vivas, **Q113,389** de `monto_aplicado` descartado.
- **Por qué no dispara:** las 40 están en cuotas con `cuotas_credito.pagado=true`, y `cuotasPendientes` filtra `pagado=false` → esas cuotas nunca se reprocesan. Para que muerda haría falta una fila sin itemizar en una cuota **aún abierta** (hoy: 0 casos).
- **Por qué no hay fix limpio:** una fila "SIFCO sin itemizar" y un "abono a capital validado" son indistinguibles por columnas (ambas rubros=0, mora=0, otros=0, `monto_aplicado>0`). El híbrido `monto_aplicado − mora − otros` rompería las filas de primera cuota pagada junto con mora/otros (caso más común). El rubro-sum es la opción más segura.
- **Decisión:** se acepta como **invariante a vigilar** (filas sin itemizar sólo existen en cuotas ya pagadas). Queda documentado aquí.

### 🟡 Limpieza menor
`monto_aplicado` sigue en el `select` de hermanos pero ya no se lee. Se deja a propósito (comentado) para que no se "sume de vuelta" a la luz del hallazgo anterior.

### 🔴 Follow-up (pre-existente, fuera de este PR)
`aplicarPagoAlCredito` decide `cuotaCompleta` sumando `Σ monto_aplicado` de los pagos `validated` vs `credito.cuota` — el mismo patrón que aquí se corrige. Una fila de mora/otros validada puede inflar esa suma y marcar una cuota como completa prematuramente. **No lo introduce este PR**; va en ticket aparte (reusar `sumarAplicadoACuota`).
