### PR TITLE
feat(ci): cancelar deploys de cartera dev obsoletos (concurrency)

### DIFF
--- a/.github/workflows/deploy-cartera-dev.yaml
+++ b/.github/workflows/deploy-cartera-dev.yaml
@@ -50,7 +50,9 @@ jobs:
   backend:
     name: Backend (dev)
     needs: changes
-    if: needs.changes.outputs.back == 'true'
+    # En dispatch manual no hay diff que filtrar: construir siempre, para
+    # poder forzar un redeploy tras un run fallido.
+    if: needs.changes.outputs.back == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     # Si llega un push nuevo que también reconstruye el back, cancela este run
     # y deploya solo el último. Por job (no global) para que un push solo-front
@@ -91,7 +93,7 @@ jobs:
   frontend:
     name: Frontend (dev)
     needs: changes
-    if: needs.changes.outputs.front == 'true'
+    if: needs.changes.outputs.front == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     concurrency:
       group: deploy-cartera-front-dev

--- a/.github/workflows/deploy-cartera-dev.yaml
+++ b/.github/workflows/deploy-cartera-dev.yaml
@@ -52,6 +52,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.back == 'true'
     runs-on: ubuntu-latest
+    # Si llega un push nuevo que también reconstruye el back, cancela este run
+    # y deploya solo el último. Por job (no global) para que un push solo-front
+    # no cancele un deploy de back en curso.
+    concurrency:
+      group: deploy-cartera-back-dev
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 
@@ -87,6 +93,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.front == 'true'
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-cartera-front-dev
+      cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Qué hace

Con varios pushes consecutivos a `develop`, hoy corren N workflows en paralelo (comportamiento default de GitHub Actions). Esto agrega `concurrency` + `cancel-in-progress: true` para que el run viejo se cancele y solo se construya/deploye el último push.

## Por qué por job y no a nivel workflow

Si fuera global, un push que solo toca el front cancelaría un deploy de back en curso de un push anterior — y ese cambio de back quedaría **sin deployar** (el run nuevo solo detecta cambios de front, por el `paths-filter` con `base`). Con grupos por job (`deploy-cartera-back-dev` / `deploy-cartera-front-dev`), un job solo se cancela cuando el run nuevo va a reconstruir esa misma app — que ya incluye los commits del anterior, así que no se pierde nada.

Los jobs saltados (`if: false`) no entran al grupo de concurrency, por eso esto funciona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)