### PR TITLE
fix(cartera-back): revertir-liquidacion elimina snapshots de historico_liquidaciones_espejo

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -2434,32 +2434,19 @@ export async function revertirLiquidacion(liquidacion_id: number) {
     }
 
     // ──────────────────────────────────────────────
-    // PASO 7: Revertir reinversión
-    //   Restamos el monto reinvertido del saldo_reinversion del inversionista
-    //   y restauramos los montos en la tabla reinversiones
+    // PASO 7: Eliminar snapshots del histórico de liquidaciones espejo
+    //   liquidateByInvestorId inserta una fila por (crédito, inversionista)
+    //   con el monto_aportado post-reducción como baseline del cuadre de la
+    //   siguiente liquidación. Hay que borrarlas ANTES de eliminar la
+    //   liquidación: el FK es onDelete "set null" y quedarían huérfanas
+    //   como baseline falso.
     // ──────────────────────────────────────────────
-    const reinvTotal = new Big(liquidacion.reinversion_total ?? 0);
-    if (reinvTotal.gt(0)) {
-      // Restar del saldo_reinversion
-      await tx
-        .update(inversionistas)
-        .set({
-          saldo_reinversion: sql`${inversionistas.saldo_reinversion} - ${reinvTotal.toFixed(2)}::numeric`,
-        })
-        .where(eq(inversionistas.inversionista_id, inv_id));
+    const historicoEliminado = await tx
+      .delete(historico_liquidaciones_espejo)
+      .where(eq(historico_liquidaciones_espejo.liquidacion_id, liquidacion_id))
+      .returning({ id: historico_liquidaciones_espejo.id });
 
-      // Restaurar montos en reinversiones
-      await tx
-        .update(reinversiones)
-        .set({
-          monto_capital: liquidacion.reinversion_capital ?? "0",
-          monto_interes: liquidacion.reinversion_interes ?? "0",
-          monto_total: liquidacion.reinversion_total ?? "0",
-        })
-        .where(eq(reinversiones.inversionista_id, inv_id));
-
-      console.log(`  ✅ Reinversión revertida (-${reinvTotal.toFixed(2)} del saldo)`);
-    }
+    console.log(`  ✅ ${historicoEliminado.length} snapshots de historico_liquidaciones_espejo eliminados`);
 
     // ──────────────────────────────────────────────
     // PASO 8: Eliminar la liquidación
@@ -2479,6 +2466,7 @@ export async function revertirLiquidacion(liquidacion_id: number) {
       inversionista_id: inv_id,
       pagos_revertidos: pagosLiquidados.length,
       creditos_afectados: pagosPorCredito.size,
+      historico_snapshots_eliminados: historicoEliminado.length,
     };
   });
 }

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -1320,7 +1320,8 @@ export const inversionistasRouter = new Elysia()
   })
   // ──────────────────────────────────────────────
   // Revertir una liquidación completa por liquidacion_id
-  // Deshace: pagos espejo, monto_aportado, cuotas, boleta, reinversión y liquidación
+  // Deshace: pagos espejo, monto_aportado, cuotas, boleta, snapshots del
+  // histórico de liquidaciones espejo y la liquidación
   // Todo dentro de una transacción
   // ──────────────────────────────────────────────
   .post("/investor/revertir-liquidacion", async ({ body, set }) => {


### PR DESCRIPTION
## Qué cambia

En `revertirLiquidacion` (`POST /investor/revertir-liquidacion`) se reemplaza el **PASO 7**:

- **Antes:** revertía la reinversión — restaba de `inversionistas.saldo_reinversion` y restauraba montos en `reinversiones`. Ese flujo ya no se usa.
- **Ahora:** elimina los snapshots de `historico_liquidaciones_espejo` asociados a la liquidación (`WHERE liquidacion_id = X`).

## Por qué

`liquidateByInvestorId` inserta en `historico_liquidaciones_espejo` una fila por (crédito, inversionista) con el `monto_aportado` post-reducción, que sirve como baseline del control de cuadre `[CUADRE_CAPITAL]` en la siguiente liquidación.

El FK de `historico_liquidaciones_espejo.liquidacion_id` es `onDelete: "set null"`, así que al borrar la liquidación (PASO 8) los snapshots quedaban huérfanos con `liquidacion_id = NULL`, actuando como **baseline falso**: el espejo se restaura (+abono capital) pero el histórico seguía con el monto post-reducción, y la próxima liquidación fallaba el cuadre. Por eso el delete va **antes** del PASO 8.

Al eliminarlos, el snapshot de la liquidación anterior vuelve a ser el baseline vigente, que coincide con el `monto_aportado` restaurado en el PASO 3.

También se agrega `historico_snapshots_eliminados` al response del endpoint y se actualiza el comentario del router.

## Validación

Ejecutado contra PROD con la **liquidación 465** (inversionista 136, 2026-06-10):

- ✅ 2 pagos espejo (créditos 8793 y 8805) de vuelta a `NO_LIQUIDADO`, sin `liquidacion_id`
- ✅ Montos espejo restaurados: crédito 8793 +42.75 → Q4,319.07; crédito 8805 +856.20 → Q148,880.93
- ✅ 2 snapshots de histórico eliminados (ids 6653 y 6655)
- ✅ Liquidación 465 eliminada
- ✅ Llamada registrada en `audit_logs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)