### PR TITLE
feat(cartera): actualizar-pagos-excel maneja pools "raros" y cuota 0

### DIFF
--- a/apps/cartera-back/src/routers/actualizarPagosExcel.ts
+++ b/apps/cartera-back/src/routers/actualizarPagosExcel.ts
@@ -200,7 +200,20 @@ export const actualizarPagosExcelRouter = new Elysia()
         dry_run = true,
         orden_cronologico = [],
         omitir_sin_match = true,
+        companions = {},
       } = body ?? {};
+
+      // Pools "raros": un mismo crédito repartido en varios SIFCOs distintos
+      // (no _N). El mapa { "<sifco base>": ["<sifco companion>", ...] } indica
+      // qué SIFCOs deben sumarse al crédito base. Se arma companion → base.
+      const companionToBase = new Map<string, string>();
+      for (const [target, comps] of Object.entries(companions ?? {})) {
+        const tBase = String(target).replace(/[^0-9]/g, "").padStart(14, "0");
+        for (const c of Array.isArray(comps) ? comps : []) {
+          const cBase = String(c).replace(/[^0-9]/g, "").padStart(14, "0");
+          companionToBase.set(cBase, tBase);
+        }
+      }
 
       if (!Array.isArray(lista) || lista.length === 0) {
         set.status = 400;
@@ -226,7 +239,12 @@ export const actualizarPagosExcelRouter = new Elysia()
       };
       const datosCredito = new Map<
         string,
-        { credito_id: number; base: string; cuotasPagadas: CuotaInfo[] }
+        {
+          credito_id: number;
+          base: string;
+          cuotasPagadas: CuotaInfo[];
+          cuotaCeroPagoIds: number[];
+        }
       >();
       const pedidos: Array<{ sifco: string; vencimientos: string[]; todos?: boolean }> = [];
 
@@ -241,7 +259,7 @@ export const actualizarPagosExcelRouter = new Elysia()
           .limit(1);
 
         if (!credito) {
-          datosCredito.set(sifco, { credito_id: -1, base, cuotasPagadas: [] });
+          datosCredito.set(sifco, { credito_id: -1, base, cuotasPagadas: [], cuotaCeroPagoIds: [] });
           continue;
         }
 
@@ -260,8 +278,14 @@ export const actualizarPagosExcelRouter = new Elysia()
           .orderBy(asc(cuotas_credito.numero_cuota), asc(pagos_credito.pago_id));
 
         const porCuota = new Map<number, CuotaInfo>();
+        const cuotaCeroPagoIds: number[] = [];
         for (const r of rows) {
           const c = r.cuotas_credito;
+          // Cuota 0 (desembolso): se guarda aparte para sembrarle el capital inicial.
+          if (c.numero_cuota === 0) {
+            cuotaCeroPagoIds.push(r.pagos_credito.pago_id);
+            continue;
+          }
           if (!c.pagado || c.numero_cuota <= 0) continue;
           if (!porCuota.has(c.numero_cuota)) {
             porCuota.set(c.numero_cuota, {
@@ -280,7 +304,12 @@ export const actualizarPagosExcelRouter = new Elysia()
         const cuotasPagadas = [...porCuota.values()].sort(
           (a, b) => b.numero_cuota - a.numero_cuota, // de la última a la primera
         );
-        datosCredito.set(sifco, { credito_id: credito.credito_id, base, cuotasPagadas });
+        datosCredito.set(sifco, {
+          credito_id: credito.credito_id,
+          base,
+          cuotasPagadas,
+          cuotaCeroPagoIds,
+        });
         pedidos.push({
           sifco,
           vencimientos: cuotasPagadas
@@ -291,7 +320,11 @@ export const actualizarPagosExcelRouter = new Elysia()
       }
 
       // 3️⃣ Leer del Excel solo las hojas necesarias.
-      const excelIdx = await leerPagosCarteraPorVencimiento(descarga.filePath, pedidos);
+      const excelIdx = await leerPagosCarteraPorVencimiento(
+        descarga.filePath,
+        pedidos,
+        companionToBase,
+      );
 
       // 4️⃣ Validar + construir updates (sin escribir).
       const resultados: any[] = [];
@@ -360,6 +393,27 @@ export const actualizarPagosExcelRouter = new Elysia()
             inversionistas: excel.inversionistas,
             datos: dry_run ? updates.map((u) => ({ pago_id: u.pago_id, ...u.datos })) : undefined,
           });
+
+          // Cuota 0 (desembolso): sembrar su total_restante con el capital
+          // inicial = total_restante + abono_capital de la PRIMERA cuota pagada
+          // (i === 0). Para pools, ambos vienen sumados, así que da el capital
+          // total. Solo se escribe total_restante (decisión de Daniel).
+          if (i === 0 && d.cuotaCeroPagoIds.length > 0) {
+            const inicial = Q(new Big(excel.total_restante).plus(excel.abono_capital));
+            for (const pagoId of d.cuotaCeroPagoIds) {
+              updatesGlobal.push({ pago_id: pagoId, datos: { total_restante: inicial } });
+              pagosAfectados += 1;
+            }
+            cambiosCredito.push({
+              numero_cuota: 0,
+              motivo: "cuota_cero_desembolso",
+              total_restante: inicial,
+              pagos: d.cuotaCeroPagoIds.length,
+              datos: dry_run
+                ? d.cuotaCeroPagoIds.map((id) => ({ pago_id: id, total_restante: inicial }))
+                : undefined,
+            });
+          }
         });
 
         resultados.push({
@@ -437,6 +491,7 @@ export const actualizarPagosExcelRouter = new Elysia()
         dry_run: t.Optional(t.Boolean()),
         orden_cronologico: t.Optional(t.Array(t.String())),
         omitir_sin_match: t.Optional(t.Boolean()),
+        companions: t.Optional(t.Record(t.String(), t.Array(t.String()))),
       }),
       detail: {
         summary: "Actualizar pagos pagados de créditos desde el Excel de cartera (R2)",

--- a/apps/cartera-back/src/services/carteraExcelR2.ts
+++ b/apps/cartera-back/src/services/carteraExcelR2.ts
@@ -188,6 +188,10 @@ export interface PagoCarteraExcel {
 export async function leerPagosCarteraPorVencimiento(
   filePath: string,
   pedidos: Array<{ sifco: string; vencimientos: string[]; todos?: boolean }>,
+  // Pools "raros": un mismo crédito repartido en SIFCOs distintos (no _N). Mapa
+  // companion-base (14 díg) → base destino (14 díg). Las filas del companion se
+  // reasignan al crédito destino y se suman como una parte más por mes.
+  companionToBase?: Map<string, string>,
 ): Promise<Map<string, Map<string, PagoCarteraExcel>>> {
   // base SIFCO → set de MESES (yyyy-mm) deseados, o "ALL" para traer todos
   // (modo cronológico: se necesitan todas las filas del crédito).
@@ -270,10 +274,13 @@ export async function leerPagosCarteraPorVencimiento(
 
       if (!col || col.pago === -1) continue;
 
-      const base = String(cell(v[col.sifco]) ?? "")
+      let base = String(cell(v[col.sifco]) ?? "")
         .split("_")[0]
         .replace(/[^0-9]/g, "")
         .padStart(14, "0");
+      // Si este SIFCO es companion de otro crédito (pool repartido), se trata
+      // como si fuera del crédito destino para que sus filas se sumen ahí.
+      if (companionToBase?.has(base)) base = companionToBase.get(base)!;
       const set = deseados.get(base);
       if (!set) continue;
 
@@ -311,11 +318,15 @@ export async function leerPagosCarteraPorVencimiento(
       const porVenc = intermedio.get(base)!;
       if (!porVenc.has(mes)) porVenc.set(mes, new Map());
       const porRaw = porVenc.get(mes)!;
-      // Dedup por inversionista (raw SIFCO): si esta fila aparece en varias
+      // Dedup por (raw SIFCO + inversionista): si esta fila aparece en varias
       // hojas, preferimos la que tenga abonos (cuota pagada) sobre la pendiente.
-      const prev = porRaw.get(rawSifco);
+      // OJO: la llave incluye el inversionista porque un crédito "pool" puede
+      // tener varios inversionistas bajo el MISMO SIFCO (sin sufijo _N); si solo
+      // se usara rawSifco, una fila pisaría a la otra y no se sumarían capitales.
+      const dedupKey = `${rawSifco}|${inv}`;
+      const prev = porRaw.get(dedupKey);
       if (!prev || pago.abono_capital !== 0 || pago.pago_del_mes !== 0) {
-        porRaw.set(rawSifco, { pago, inv });
+        porRaw.set(dedupKey, { pago, inv });
       }
     }
   }


### PR DESCRIPTION
## Qué

Mejora `POST /actualizar-pagos-excel` para manejar correctamente créditos **"pool"** y para sembrar la **cuota 0 (desembolso)**.

### ¿Qué es un "pool raro"?

Un mismo préstamo (mismo cliente) cuyo capital está **repartido entre varios inversionistas**. En el Excel de cartera aparece de dos formas:

1. **Mismo SIFCO, varias filas** — cada inversionista en su propia fila bajo el **mismo** número SIFCO.
2. **SIFCOs distintos** (el "pool raro") — la porción de cada inversionista quedó bajo un **número SIFCO diferente** (no con sufijo `_N`), aunque es el mismo crédito/cliente.

En ambos casos el saldo real de la cuota es la **suma** de las porciones, y antes el endpoint no las sumaba bien.

## Cambios

| # | Cambio | Archivo |
|---|--------|---------|
| 1 | Dedup por `rawSifco + inversionista` (antes solo `rawSifco` → una fila pisaba la otra) | `carteraExcelR2.ts` |
| 2 | Param `companions` para sumar SIFCOs distintos al crédito base | `carteraExcelR2.ts`, `actualizarPagosExcel.ts` |
| 3 | `pagado: true` en todos los parciales (antes solo el último) | `actualizarPagosExcel.ts` |
| 4 | Cuota 0 (desembolso): `total_restante = total_restante + abono_capital` de la 1ª cuota | `actualizarPagosExcel.ts` |

## Ejemplo real — crédito `01010214108810`

Cliente *Jhony Alfredo Carrillo Corado / Mayra Elizabeth Rosales / Pablo Roberto Batz Gudiel*. El mismo crédito aparece en el Excel bajo **3 SIFCOs**:

| SIFCO | Inversionista | Rol |
|-------|---------------|-----|
| `01010214108810` | Javier Arzu Perez (+ Evelyn cuotas 1–2) | base |
| `01010214108820` | Evelyn Lisseth Cordova Lopez | companion |
| `01010214115390` | Cube Investments S.A. | companion |

**Antes:** correr `01010214108810` solo sumaba la porción de Javier → en la cuota 3 el saldo caía ~10k (la porción de Evelyn "desaparecía").

**Request con el fix:**
```json
{
  "creditos": ["01010214108810"],
  "companions": { "01010214108810": ["01010214108820", "01010214115390"] },
  "dry_run": false
}
```

**Después:** todas las cuotas suman las porciones (`partes_excel: 2`), el saldo desciende parejo, y la cuota 0 queda en el capital inicial completo **Q58,500.00** (48,500 Javier + 10,000 Evelyn).

## Notas

- El param `companions` es **explícito** a propósito: el operador indica qué SIFCOs agrupar, sin auto-detección por nombre (evita colisiones de nombre y escaneos lentos del Excel).
- Probado en dev y prod con `01010214108810` (28 pagos, 0 omitidas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
