### PR TITLE
Fix: UTC handling for date parsing of fecha_inicio and fecha_fin

### DIFF
--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -3343,14 +3343,15 @@ if (facturasExistentes.length > 0) {
           conditions.push(eq(facturas_electronicas.receptor_nit, nit));
         }
 
-        // "YYYY-MM-DD" sin hora se parsea como medianoche UTC (= 18:00 del día
-        // anterior en Guatemala); con hora explícita se interpreta en hora local.
+        // Offset explícito de Guatemala (UTC-6 fijo, sin horario de verano):
+        // sin él, "YYYY-MM-DD" se interpreta en la zona horaria del proceso
+        // (UTC en el contenedor) y el rango se corre 6 horas.
         if (fecha_inicio) {
-          conditions.push(gte(facturas_electronicas.fecha_emision, new Date(`${fecha_inicio}T00:00:00`)));
+          conditions.push(gte(facturas_electronicas.fecha_emision, new Date(`${fecha_inicio}T00:00:00-06:00`)));
         }
 
         if (fecha_fin) {
-          conditions.push(lte(facturas_electronicas.fecha_emision, new Date(`${fecha_fin}T23:59:59.999`)));
+          conditions.push(lte(facturas_electronicas.fecha_emision, new Date(`${fecha_fin}T23:59:59.999-06:00`)));
         }
 
         if (tipo === "pago") {

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -3343,14 +3343,14 @@ if (facturasExistentes.length > 0) {
           conditions.push(eq(facturas_electronicas.receptor_nit, nit));
         }
 
+        // "YYYY-MM-DD" sin hora se parsea como medianoche UTC (= 18:00 del día
+        // anterior en Guatemala); con hora explícita se interpreta en hora local.
         if (fecha_inicio) {
-          conditions.push(gte(facturas_electronicas.fecha_emision, new Date(fecha_inicio)));
+          conditions.push(gte(facturas_electronicas.fecha_emision, new Date(`${fecha_inicio}T00:00:00`)));
         }
 
         if (fecha_fin) {
-          const fin = new Date(fecha_fin);
-          fin.setHours(23, 59, 59, 999);
-          conditions.push(lte(facturas_electronicas.fecha_emision, fin));
+          conditions.push(lte(facturas_electronicas.fecha_emision, new Date(`${fecha_fin}T23:59:59.999`)));
         }
 
         if (tipo === "pago") {


### PR DESCRIPTION
###Filtro de fechas en Facturas Genéricas
Se modificaron las dos condiciones de fecha del endpoint /facturas-genericas en cofidi.ts

  - fecha_inicio: ahora se parsea como 2026-06-01T00:00:00 (medianoche local de Guatemala) en vez de medianoche UTC.
  - fecha_fin: ahora se parsea como 2026-06-01T23:59:59.999 (fin del día local), eliminando el setHours que operaba sobre la fecha ya desplazada.

**Excel queda corregido automáticamente, por dos razones:**

- Mismo filtro. El Excel no tiene su propia consulta: usa exactamente el mismo arreglo conditions que la vista paginada. La única diferencia es que cuando excel=true se omite la paginación y trae todos los registros. Como la corrección se hizo sobre conditions, aplica a ambos caminos por igual.
- Las fechas en las celdas ya se mostraban bien. Cada fila del Excel formatea la fecha con toLocaleDateString("es-GT", { timeZone: "America/Guatemala" } 