### PR TITLE
feat(cartera): facturación de inversionistas como rubro del desglose (desde cofidi)

### DIFF
--- a/apps/cartera-back/drizzle/0011_add_interes_inversionistas_rubro.sql
+++ b/apps/cartera-back/drizzle/0011_add_interes_inversionistas_rubro.sql
@@ -1,0 +1,10 @@
+-- Nuevo rubro para la FACTURACIÓN DE INVERSIONISTAS en facturacion_desglose:
+-- el residuo del interés que NO factura CUBE = (interés total del pago con IVA)
+-- − (interés que factura CUBE). cofidi lo guarda como 1 fila por pago
+-- (factura_id NULL, ya con IVA). El snapshot diario lee facturacion_inversionistas
+-- de este rubro de aquí en adelante (los días históricos quedan en 0 hasta
+-- que se re-facture el pago).
+--
+-- ADD VALUE IF NOT EXISTS es idempotente (Postgres 10+). Debe correrse y
+-- commitearse ANTES de desplegar el código que usa el valor.
+ALTER TYPE cartera.rubro_facturacion ADD VALUE IF NOT EXISTS 'INTERES_INVERSIONISTAS';

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -136,7 +136,7 @@ export async function generarSnapshotDiario(fecha: string) {
   const inv = await db.execute(sql`
     SELECT COALESCE(SUM(monto_total), 0) AS total
     FROM cartera.facturacion_desglose
-    WHERE rubro = 'INTERES_INVERSIONISTAS'
+    WHERE rubro::text = 'INTERES_INVERSIONISTAS'
       AND fecha_aplicado_gt = ${fecha}::date
   `);
   const factInv = new Big((inv as any).rows?.[0]?.total || 0);
@@ -171,7 +171,7 @@ export async function generarSnapshotDiario(fecha: string) {
   const invMtd = await db.execute(sql`
     SELECT COALESCE(SUM(monto_total), 0) AS total
     FROM cartera.facturacion_desglose
-    WHERE rubro = 'INTERES_INVERSIONISTAS'
+    WHERE rubro::text = 'INTERES_INVERSIONISTAS'
       AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
   // Reserva acumulada (MTD) desde pagos_credito.reserva

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -129,14 +129,15 @@ export async function generarSnapshotDiario(fecha: string) {
   `);
   const ingresoCarros = new Big((carr as any).rows?.[0]?.total || 0);
 
-  // 4) Facturación a inversionistas del día (no-CUBE, de pci)
+  // 4) Facturación a inversionistas del día = rubro INTERES_INVERSIONISTAS del
+  //    desglose (el residuo del interés que NO factura CUBE, ya con IVA, que
+  //    cofidi guarda por pago). Se lee del desglose —no de pci— para tener una
+  //    sola fuente y la misma fecha (COALESCE fecha_aplicado/fecha_pago).
   const inv = await db.execute(sql`
-    SELECT COALESCE(SUM(pci.abono_interes + pci.abono_iva_12), 0) AS total
-    FROM cartera.pagos_credito_inversionistas pci
-    INNER JOIN cartera.pagos_credito p ON p.pago_id = pci.pago_id
-    INNER JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
-    WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
-      AND UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
+    SELECT COALESCE(SUM(monto_total), 0) AS total
+    FROM cartera.facturacion_desglose
+    WHERE rubro = 'INTERES_INVERSIONISTAS'
+      AND fecha_aplicado_gt = ${fecha}::date
   `);
   const factInv = new Big((inv as any).rows?.[0]?.total || 0);
 
@@ -168,12 +169,10 @@ export async function generarSnapshotDiario(fecha: string) {
     WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
   const invMtd = await db.execute(sql`
-    SELECT COALESCE(SUM(pci.abono_interes + pci.abono_iva_12), 0) AS total
-    FROM cartera.pagos_credito_inversionistas pci
-    INNER JOIN cartera.pagos_credito p ON p.pago_id = pci.pago_id
-    INNER JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
-    WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
-      AND UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
+    SELECT COALESCE(SUM(monto_total), 0) AS total
+    FROM cartera.facturacion_desglose
+    WHERE rubro = 'INTERES_INVERSIONISTAS'
+      AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
   // Reserva acumulada (MTD) desde pagos_credito.reserva
   const reservaMtd = await db.execute(sql`

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -64,6 +64,7 @@
     "GPS",
     "MORA",
     "OTROS",
+    "INTERES_INVERSIONISTAS",
   ]);
   export const admins = customSchema.table("admins", {
     admin_id: serial("admin_id").primaryKey(),

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -1914,8 +1914,19 @@ if (facturasExistentes.length > 0) {
         `);
         const capitalCube = (capCubeRes as any).rows?.[0]?.capital_cube ?? 0;
 
+        // 🆕 Interés que se factura a inversionistas (no-CUBE) = interés total
+        //    del pago − lo que factura CUBE, CON IVA. Un solo registro agregado
+        //    por pago (sin importar cuántos inversionistas se lo repartan).
+        //    factura_id NULL: no es factura de CUBE, es el residuo de los inv.
+        const interesTotalConIvaPago = new Big(pagoData.abono_interes || 0).plus(
+          new Big(pagoData.abono_iva_12 || 0)
+        );
+        const interesInversionistasConIva =
+          interesTotalConIvaPago.minus(interesCubeConIva);
+
         pushRubro("CAPITAL", capitalCube, false); // solo capital de CUBE (de pci), sin IVA
         pushRubro("INTERES", interesCubeConIva, true); // residuo CUBE, ya con IVA
+        pushRubro("INTERES_INVERSIONISTAS", interesInversionistasConIva, true); // residuo no-CUBE, con IVA
         pushRubro("MEMBRESIA", pagoData.membresias_pago, true);
         pushRubro("SEGURO", pagoData.abono_seguro, true);
         pushRubro("GPS", pagoData.abono_gps, true);

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -936,6 +936,11 @@ if (facturasExistentes.length > 0) {
       //    Se setea dentro de cada flujo (estándar/prorrateado) y se usa al
       //    final para guardar el rubro INTERES en facturacion_desglose.
       let interesCubeConIva = new Big(0);
+      // Marca que el flujo de interés realmente se calculó (NO abortó). Si
+      // queda en false con interés > 0 (p. ej. abort por espejo sin fecha de
+      // participación), NO escribimos los rubros INTERES / INTERES_INVERSIONISTAS,
+      // para no atribuir todo el interés a inversionistas con interesCubeConIva=0.
+      let interesFlujoOk = false;
 
       if (!hayInteresEnPago) {
         console.log("\n⏭️  NO hay intereses en este pago - Saltando facturas de intereses (ambos flujos)");
@@ -1286,6 +1291,7 @@ if (facturasExistentes.length > 0) {
 
           // 🧾 Guardar para el desglose de facturación (rubro INTERES, con IVA).
           interesCubeConIva = totalCubeFinal;
+          interesFlujoOk = true;
 
           // Set con todos los IDs de inversionistas que aparecieron en cualquier
           // ventana (algunos podrían tener parte solo en una de las dos).
@@ -1757,6 +1763,7 @@ if (facturasExistentes.length > 0) {
 
         // 🧾 Guardar para el desglose de facturación (rubro INTERES, con IVA).
         interesCubeConIva = totalCube;
+        interesFlujoOk = true;
 
         console.log(`   📊 Cash-in acumulado de otros: Q${cashInAcumulado.toFixed(2)}`);
         console.log(`   💵 Total CUBE: Q${totalCube.toFixed(2)} (residuo + cash_in)`);
@@ -1925,8 +1932,13 @@ if (facturasExistentes.length > 0) {
           interesTotalConIvaPago.minus(interesCubeConIva);
 
         pushRubro("CAPITAL", capitalCube, false); // solo capital de CUBE (de pci), sin IVA
-        pushRubro("INTERES", interesCubeConIva, true); // residuo CUBE, ya con IVA
-        pushRubro("INTERES_INVERSIONISTAS", interesInversionistasConIva, true); // residuo no-CUBE, con IVA
+        // Solo si el flujo de interés se calculó OK (no abortó). Si abortó,
+        // interesCubeConIva quedó en 0 y NO debemos volcar todo el interés a
+        // INTERES_INVERSIONISTAS → dejamos ambos rubros sin escribir.
+        if (interesFlujoOk) {
+          pushRubro("INTERES", interesCubeConIva, true); // residuo CUBE, ya con IVA
+          pushRubro("INTERES_INVERSIONISTAS", interesInversionistasConIva, true); // residuo no-CUBE, con IVA
+        }
         pushRubro("MEMBRESIA", pagoData.membresias_pago, true);
         pushRubro("SEGURO", pagoData.abono_seguro, true);
         pushRubro("GPS", pagoData.abono_gps, true);


### PR DESCRIPTION
## 🎯 Qué hace

La **facturación de inversionistas** del reporte diario ahora se **guarda como facturación al momento de facturar** (en `facturacion_desglose`), en vez de que el snapshot la calcule en vivo desde `pagos_credito_inversionistas`.

Lo que se guarda por pago es **el residuo del interés que NO factura CUBE**:

```
interés total del pago (con IVA)  −  interés que factura CUBE  =  facturación inversionistas
        (ej. 100)                          (ej. 20)                      (ej. 80)
```

Un **solo registro agregado por pago** (sin importar cuántos inversionistas se lo repartan).

## 🧩 Cambios

1. **`schema.ts` + `drizzle/0011_…sql`**: nuevo valor de enum **`INTERES_INVERSIONISTAS`** en `rubro_facturacion` (`ALTER TYPE … ADD VALUE IF NOT EXISTS`, idempotente).
2. **`cofidi.ts`** (`/facturar-pago-completo`, bloque del desglose): calcula `interés total del pago (con IVA) − interesCubeConIva` y lo guarda con `pushRubro("INTERES_INVERSIONISTAS", …)`. `factura_id NULL` (no es factura de CUBE). Best-effort, dentro del mismo `try` del desglose → no afecta la facturación.
3. **`facturacionSnapshot.ts`**: `facturacion_inversionistas` y `acumulado_inversionistas` pasan a leer `SUM(monto_total) WHERE rubro='INTERES_INVERSIONISTAS'` del desglose (una sola fuente, misma `fecha_aplicado_gt` que el resto del desglose).

## ✅ Por qué es mejor
- **Una sola fuente** (el desglose) para todo el reporte, igual que CUBE.
- **Congelado al facturar** (no depende del estado de liquidación de pci después).
- **Arregla** el hueco de fecha: el desglose usa `COALESCE(fecha_aplicado, fecha_pago)`, así que pagos con `fecha_aplicado` NULL ya no se pierden (antes la query de pci usaba solo `fecha_aplicado`).
- No contamina los totales de CUBE: las agregaciones MTD suman `rubro IN ('INTERES','MEMBRESIA','OTROS','MORA')` y el mapeo por producto usa `RUBRO_PREFIX`; `INTERES_INVERSIONISTAS` no está en ninguno → queda aislado.

## ⚠️ Consideraciones
- **Solo de aquí en adelante**: los días **históricos** quedan en 0 en `facturacion_inversionistas` hasta que se **re-facture** el pago (decisión acordada; sin backfill).
- **Orden de despliegue**: correr la migración (`ALTER TYPE … ADD VALUE`) **antes** de desplegar el código que la usa.
- Aplica a **dev (Neon)** ya (ver checklist). **Prod** pendiente de aplicar antes del deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
