### PR TITLE
feat(cartera): mensajes de error descriptivos en la UI (front + back)

### DIFF
--- a/apps/cartera-back/src/index.ts
+++ b/apps/cartera-back/src/index.ts
@@ -4,8 +4,10 @@ import * as routers from "./routers";
 import { cors } from "@elysiajs/cors";
 import { iniciarTareasProgramadas } from "../schedule";
 import { auditLogMiddleware } from "./middleware/auditLog";
+import { validationErrorMiddleware } from "./middleware/validationError";
 
 const app = new Elysia()
+  .use(validationErrorMiddleware)
   .use(cors({
     origin: true,
     methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],

--- a/apps/cartera-back/src/middleware/validationError.ts
+++ b/apps/cartera-back/src/middleware/validationError.ts
@@ -1,0 +1,42 @@
+import { Elysia } from "elysia";
+
+// Cuando un request no pasa la validación de esquema (los t.Object de cada
+// ruta), Elysia lo rechaza ANTES de ejecutar el handler, por lo que ningún
+// try/catch de las rutas alcanza a traducir el error técnico de TypeBox
+// (en inglés). Este hook es el único punto central donde se puede
+// interceptar para responder { success, error } en español.
+
+const extraerCampo = (error: any): string => {
+  const errores = error?.all;
+  let campo = "";
+  if (Array.isArray(errores)) {
+    const conPath = errores.find(
+      (e: any) => typeof e?.path === "string" && e.path.length > 0
+    );
+    campo = conPath?.path?.replace(/^\//, "") ?? "";
+  }
+  if (!campo) {
+    // El mensaje de TypeBox es un JSON con la propiedad inválida
+    try {
+      campo = (JSON.parse(error?.message)?.property ?? "").replace(/^\//, "");
+    } catch {
+      /* mensaje no es JSON, se usa el texto genérico */
+    }
+  }
+  // "root" significa que TypeBox no identificó un campo puntual
+  return campo === "root" ? "" : campo;
+};
+
+export const validationErrorMiddleware = (app: Elysia) =>
+  app.onError(({ code, error, set }) => {
+    if (code !== "VALIDATION") return;
+
+    set.status = 422;
+    const campo = extraerCampo(error);
+    return {
+      success: false,
+      error: campo
+        ? `El valor del campo "${campo}" no es válido. Corrígelo e intenta de nuevo.`
+        : "Los datos enviados no son válidos. Revisa los filtros e intenta de nuevo.",
+    };
+  });

--- a/apps/cartera-back/src/routers/midleware.ts
+++ b/apps/cartera-back/src/routers/midleware.ts
@@ -4,15 +4,16 @@ const JWT_SECRET = process.env.JWT_SECRET || "supersecreto";
 
 export const authMiddleware = (app: any) =>
   app.derive(async ({ request, set }: { request: any; set: any }) => {
+    const authHeader = request.headers.get("Authorization");
+
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      set.status = 401;
+      throw new Error("No has iniciado sesión. Vuelve a iniciar sesión.");
+    }
+
+    const token = authHeader.replace("Bearer ", "").trim();
+
     try {
-      const authHeader = request.headers.get("Authorization");
-
-      if (!authHeader || !authHeader.startsWith("Bearer ")) {
-        set.status = 401;
-        throw new Error("Token no proporcionado");
-      }
-
-      const token = authHeader.replace("Bearer ", "").trim();
       const decoded = jwt.verify(token, JWT_SECRET) as any;
 
       console.log("✅ Token decodificado:", decoded);
@@ -20,8 +21,13 @@ export const authMiddleware = (app: any) =>
       // 🔑 Retornar el usuario para que esté disponible en el contexto
       return { user: decoded };
     } catch (err: any) {
+      // El detalle técnico queda solo en el log; al cliente siempre va un mensaje amigable
       console.error("❌ Error en jwt.verify:", err.name, "-", err.message);
       set.status = 401;
-      throw new Error(err.message || "Token inválido o expirado");
+      throw new Error(
+        err.name === "TokenExpiredError"
+          ? "Tu sesión expiró. Vuelve a iniciar sesión."
+          : "Tu sesión no es válida. Vuelve a iniciar sesión."
+      );
     }
   });

--- a/apps/carteraFront/src/Provider/interceptor.ts
+++ b/apps/carteraFront/src/Provider/interceptor.ts
@@ -134,6 +134,22 @@ api.interceptors.request.use(
 api.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
+    // En peticiones con responseType:"blob", el cuerpo del error llega como Blob
+    // y el mensaje del backend se perdería; lo convertimos a JSON/texto aquí
+    // (getApiErrorMessage es síncrona y no puede leer el Blob).
+    if (error.response?.data instanceof Blob) {
+      try {
+        const text = await error.response.data.text();
+        try {
+          error.response.data = JSON.parse(text);
+        } catch {
+          error.response.data = text;
+        }
+      } catch {
+        // Blob ilegible: se continúa con el error original
+      }
+    }
+
     const originalRequest = error.config as
       | (InternalAxiosRequestConfig & { _retry?: boolean })
       | undefined;

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -1,0 +1,61 @@
+import { AxiosError } from "axios";
+
+/**
+ * Traduce mensajes técnicos conocidos (jwt, validación de Elysia, etc.)
+ * a texto entendible para el usuario final. Si el mensaje ya es legible
+ * (el backend lo mandó en español), se devuelve tal cual.
+ */
+function traducirDetalleTecnico(detail: string): string {
+  const d = detail.toLowerCase();
+  if (d.includes("jwt expired")) {
+    return "tu sesión expiró, vuelve a iniciar sesión";
+  }
+  if (
+    d.includes("jwt") ||
+    d.includes("invalid signature") ||
+    d.includes("invalid token") ||
+    d.includes("token no proporcionado") ||
+    d.includes("token inválido")
+  ) {
+    return "tu sesión no es válida, vuelve a iniciar sesión";
+  }
+  if (detail.startsWith("Expected ")) {
+    return `uno de los filtros o datos enviados no es válido (${detail})`;
+  }
+  return detail;
+}
+
+/**
+ * Extrae el motivo real de un error de API para mostrarlo al usuario.
+ * El backend devuelve el detalle en `error`, `message` o `mensaje`
+ * según el endpoint, por lo que se revisan los tres campos.
+ */
+export function getApiErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof AxiosError) {
+    if (error.code === "ECONNABORTED") {
+      return `${fallback}: el servidor tardó demasiado en responder, intenta de nuevo`;
+    }
+    if (!error.response) {
+      return `${fallback}: sin conexión con el servidor`;
+    }
+    const { status, data } = error.response;
+    const detail =
+      typeof data === "string"
+        ? data
+        : (data?.error ?? data?.message ?? data?.mensaje);
+    if (typeof detail === "string" && detail.trim()) {
+      return `${fallback}: ${traducirDetalleTecnico(detail.trim())}`;
+    }
+    if (status === 401 || status === 403) {
+      return `${fallback}: tu sesión no es válida, vuelve a iniciar sesión`;
+    }
+    if (status >= 500) {
+      return `${fallback}: error interno del servidor (HTTP ${status})`;
+    }
+    return `${fallback} (HTTP ${status})`;
+  }
+  if (error instanceof Error && error.message) {
+    return `${fallback}: ${error.message}`;
+  }
+  return fallback;
+}

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from "lucide-react";
 import { useCreditosPaginadosWithFilters } from "../hooks/credits";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { Button } from "@/components/ui/button";
 import { Eye, Pencil, XCircle, FileCheck, CheckCircle2 } from "lucide-react";
 
@@ -173,7 +174,9 @@ export function ListaCreditosPagos() {
           }
         },
         onError: (err: any) => {
-          toast.error(err?.message || `Error al generar reporte ${reportType}`);
+          toast.error(
+            getApiErrorMessage(err, `Error al generar reporte ${reportType}`),
+          );
         },
       }
     );
@@ -631,7 +634,7 @@ export function ListaCreditosPagos() {
                 }
               } catch (err) {
                 console.error("❌ Error generando Excel:", err);
-                toast.error("Error al generar el Excel");
+                toast.error(getApiErrorMessage(err, "Error al generar el Excel"));
               } finally {
                 setIsDownloadingExcel(false);
               }

--- a/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
+++ b/apps/carteraFront/src/private/cartera/components/HistorialLiquidaciones.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useState, useMemo, useCallback } from "react";
 import { usePersistedState } from "../hooks/usePersistedState";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import {
@@ -405,7 +406,7 @@ export function HistorialLiquidaciones() {
         toast.error("No se pudo generar el Excel");
       }
     } catch (err: any) {
-      toast.error(err?.message ?? "Error al generar el Excel");
+      toast.error(getApiErrorMessage(err, "Error al generar el Excel"));
     } finally {
       setDescargandoExcel(false);
     }

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, Fragment } from "react";
 import { usePersistedState } from "../hooks/usePersistedState";
+import { getApiErrorMessage } from "@/lib/apiError";
 
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -391,8 +392,9 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
           // Otros errores del backend
           toast.error(errorData.message);
         } else {
-          // Error genérico
-          toast.error("Error al generar facturas electrónicas");
+          toast.error(
+            getApiErrorMessage(error, "Error al generar facturas electrónicas"),
+          );
         }
       }
     },
@@ -548,7 +550,9 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
       }
     } catch (error: any) {
       console.error("Error al generar Excel:", error);
-      toast.error("Error al generar el reporte", { id: "excel-download" });
+      toast.error(getApiErrorMessage(error, "Error al generar el reporte"), {
+        id: "excel-download",
+      });
     } finally {
       setIsDownloadingExcel(false);
     }
@@ -590,7 +594,10 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
       }
     } catch (error: any) {
       console.error("Error al generar reporte asesores:", error);
-      toast.error("Error al generar el reporte", { id: "advisor-download" });
+      toast.error(
+        getApiErrorMessage(error, "Error al generar el reporte de asesores"),
+        { id: "advisor-download" },
+      );
     } finally {
       setIsDownloadingAdvisor(false);
     }

--- a/apps/carteraFront/src/private/cartera/hooks/downloadReporteNoLiquidados.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/downloadReporteNoLiquidados.ts
@@ -1,5 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { getReporteNoLiquidados } from "../services/services";
+import { getApiErrorMessage } from "@/lib/apiError";
 
 export function useDownloadReporteNoLiquidados() {
   return useMutation({
@@ -10,11 +12,11 @@ export function useDownloadReporteNoLiquidados() {
       if (data?.url) {
         window.open(data.url, "_blank");
       } else {
-        alert("No se recibió la URL del reporte.");
+        toast.error("No se recibió la URL del reporte");
       }
     },
-    onError: () => {
-      alert("Error al generar el reporte. Intenta de nuevo o contacta soporte.");
+    onError: (err) => {
+      toast.error(getApiErrorMessage(err, "Error al generar el reporte"));
     },
   });
 }


### PR DESCRIPTION
# Mensajes de error descriptivos en la UI de Cartera (front + back)

### Problema

Casi todas las vistas de `carteraFront` mostraban mensajes de error fijos y genéricos ("Error al generar el reporte") aunque el backend sí devolvía el motivo real del fallo. El usuario no tenía forma de saber si el problema era de datos, de sesión, de conexión o del servidor. Adicionalmente, cuando el motivo sí llegaba, podía ser un mensaje técnico crudo en inglés ("jwt malformed", "Expected integer to be greater or equal to 2000").

### Cambios

### Frontend (`carteraFront`)

- **Nuevo helper `src/lib/apiError.ts` (`getApiErrorMessage`)**: extrae el detalle real de la respuesta del backend revisando los tres campos que usa según el endpoint (`error`, `message`, `mensaje`), y distingue casos: timeout ("el servidor tardó demasiado en responder"), sin respuesta ("sin conexión con el servidor"), 401/403 sin detalle, 5xx sin detalle. El resultado es `"<contexto>: <motivo real>"`.
- **Aplicado en los flujos de reportes** que mostraban texto genérico: `paymentsTable.tsx` (Descargar Reporte Excel, Reporte Asesores, facturas electrónicas), `CreditsPaymentsData.tsx` (reportes de cancelación/detalle de costos y Excel), `HistorialLiquidaciones.tsx` (Excel) y `downloadReporteNoLiquidados.ts`.
- **Interceptor de axios**: si el cuerpo de un error llega como `Blob` (peticiones con `responseType: "blob"`, p. ej. `facturacionDiaria.services.ts`), se convierte a JSON/texto en el interceptor de respuesta (que es async) antes de llegar al helper (que es síncrono y no puede hacer `blob.text()`). Sin esto, el mensaje del backend se perdería y solo se vería "(HTTP 4xx)".
- **`downloadReporteNoLiquidados.ts`**: se unificó `alert()` → `toast` (éxito sin URL y error), consistente con el resto de la app.

### Backend (`cartera-back`)

- **`authMiddleware` (`routers/midleware.ts`)**: los errores de JWT ya no llegan crudos al cliente. El check del header está fuera del `try` y lanza directamente el mensaje final ("No has iniciado sesión..."), eliminando la comparación frágil por string que existía antes. El `catch` decide solo por `err.name` (`TokenExpiredError` → "Tu sesión expiró...", resto → "Tu sesión no es válida...") y **nunca propaga `err.message`** al cliente: el detalle técnico queda únicamente en `console.error`.
- **Nuevo `validationErrorMiddleware` (`middleware/validationError.ts`)**: los errores de validación de esquema (los `t.Object` de cada ruta) se rechazan **antes** de ejecutar el handler, por lo que ningún `try/catch` de las rutas podía traducirlos — el hook global `onError` con `code === "VALIDATION"` es el único punto de intercepción posible. Responde `{ success: false, error }` (422) en español, indicando el campo inválido cuando TypeBox lo identifica. Sigue el mismo patrón de plugin que `auditLogMiddleware` y cubre los ~250 endpoints de un solo golpe.

### Decisiones de diseño

1. **Cambio de contrato en errores de validación** (antes: JSON técnico de TypeBox; ahora: `{ success: false, error }` con 422). Consumidores verificados en el monorepo: `carteraFront` (actualizado en este PR) y `portal-web` vía proxy Better Auth (`/api/cartera/*`), que **no** parsea el cuerpo de errores de validación (sus services solo leen `success`/`data` en 200 y relanzan el error). El formato nuevo coincide con el que ya usan las respuestas 500 del resto del API, así que esto estandariza el contrato, no lo rompe.
2. **El mensaje de validación expone el nombre del parámetro del API** (`fecha_inicio`, no "Fecha de inicio") **y solo el primer campo inválido**. Punto medio deliberado: el backend no conoce las etiquetas de la UI y mapearlas lo acoplaría a las vistas; un toast con N campos sería ilegible. El nombre del parámetro sigue siendo mucho más útil que un genérico.
3. **Doble traducción front/back de errores JWT y de validación**: intencional. El front puede desplegarse antes que el backend (o apuntar a un entorno sin estos cambios); `traducirDetalleTecnico` en `apiError.ts` es la red de seguridad para esos casos. Con el backend actualizado, esas ramas casi no se disparan.
4. **La rama `"Expected ..."` del front conserva el detalle técnico entre paréntesis**: deliberado — solo se dispara contra backends sin actualizar y el detalle ayuda a soporte sin sacrificar el mensaje principal en español.
5. **Los mensajes de error de negocio del backend se muestran tal cual** (p. ej. "No se encontraron pagos para generar el Excel."): ese es justamente el objetivo del PR — mostrar el porqué. Los throws de los controllers están mayormente en español descriptivo.
6. **Toast de sesión + redirect a login**: con un 401 el interceptor intenta refresh y redirige si falla; el toast puede verse una fracción de segundo antes del redirect. Comportamiento preexistente del interceptor, fuera del alcance de este PR.

## Validación

Se probó contra el backend local (Elysia en :9000, BD de dev) ejercitando el flujo completo axios → interceptor → `getApiErrorMessage`:

| Escenario | Toast antes | Toast ahora |
|---|---|---|
| Excel sin datos (filtros sin pagos) | "Error al generar el reporte" | "Error al generar el reporte: No se encontraron pagos para generar el Excel." |
| Reporte Asesores sin datos | "Error al generar el reporte" | "Error al generar el reporte de asesores: No se encontraron pagos para generar el Excel." |
| Parámetro inválido (validación de esquema) | "Error al generar el reporte" | "Error al generar el reporte: Los datos enviados no son válidos. Revisa los filtros e intenta de nuevo." |
| Token inválido | "Error al generar el reporte" | "Error al generar el reporte: Tu sesión no es válida. Vuelve a iniciar sesión." |
| Backend apagado | "Error al generar el reporte" | "Error al generar el reporte: sin conexión con el servidor" |


