### PR TITLE
fix(admin): incluir roles de taller en usuarios

### DIFF
--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -17,6 +17,22 @@ export const ROLES = {
 	VEHICLE_VERIFIER: "vehicle_verifier",
 } as const;
 
+export const USER_ROLE_VALUES = [
+	ROLES.ADMIN,
+	ROLES.SALES,
+	ROLES.SALES_SUPERVISOR,
+	ROLES.ANALYST,
+	ROLES.COBROS,
+	ROLES.COBROS_SUPERVISOR,
+	ROLES.JURIDICO,
+	ROLES.ACCOUNTING,
+	ROLES.INVESTMENT_ADVISOR_JR,
+	ROLES.INVESTMENT_ADVISOR_SR,
+	ROLES.INVESTMENT_MANAGER,
+	ROLES.SERVICE_CENTER_MANAGER,
+	ROLES.VEHICLE_VERIFIER,
+] as const;
+
 export type UserRole = (typeof ROLES)[keyof typeof ROLES];
 
 // Role display configuration
@@ -284,7 +300,7 @@ export const getRoleIcon = (role: UserRole | string): string => {
 };
 
 // Export all roles as an array for iteration
-export const ALL_ROLES = Object.values(ROLES);
+export const ALL_ROLES = [...USER_ROLE_VALUES];
 
 // Type guard
 export const isValidRole = (role: string): role is UserRole => {

--- a/apps/crm/apps/server/src/routers/admin.ts
+++ b/apps/crm/apps/server/src/routers/admin.ts
@@ -5,6 +5,7 @@ import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { auth } from "../lib/auth";
 import { adminProcedure } from "../lib/orpc";
+import { USER_ROLE_VALUES } from "../lib/roles";
 
 export const adminRouter = {
 	getStats: adminProcedure.handler(async ({ context: _ }) => {
@@ -42,19 +43,7 @@ export const adminRouter = {
 		.input(
 			z.object({
 				userId: z.string(),
-				role: z.enum([
-					"admin",
-					"sales",
-					"sales_supervisor",
-					"analyst",
-					"cobros",
-					"cobros_supervisor",
-					"juridico",
-					"accounting",
-					"investment_advisor_jr",
-					"investment_advisor_sr",
-					"investment_manager",
-				]),
+				role: z.enum(USER_ROLE_VALUES),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -145,19 +134,7 @@ export const adminRouter = {
 				email: z.string().email("Invalid email address"),
 				password: z.string().min(8, "Password must be at least 8 characters"),
 				role: z
-					.enum([
-						"admin",
-						"sales",
-						"sales_supervisor",
-						"analyst",
-						"cobros",
-						"cobros_supervisor",
-						"juridico",
-						"accounting",
-						"investment_advisor_jr",
-						"investment_advisor_sr",
-						"investment_manager",
-					])
+					.enum(USER_ROLE_VALUES)
 					.default("sales"),
 			}),
 		)


### PR DESCRIPTION
## Summary
- Centraliza los valores de roles en USER_ROLE_VALUES.
- Usa esa lista en los inputs de admin para crear/actualizar usuarios.
- Permite asignar service_center_manager y vehicle_verifier desde admin sin error de validacion.

## Test Plan
- [x] bun run build en apps/crm/apps/server
- [x] bun test src/lib/roles.test.ts en apps/crm/apps/server

## Notes
- Base solicitada: develop.
- Esta rama incluye los commits del login de taller porque parte del trabajo del PR anterior.