### PR TITLE
fix(taller): requerir roles en flujos backend

### DIFF
--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -36,6 +36,7 @@ import {
 } from "./jobs/cobros-notifications";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
+import { PERMISSIONS } from "./lib/roles";
 import {
 	appRouter,
 	disbursementRouter,
@@ -193,13 +194,21 @@ app.get("/", (c) => {
 // Vehicle photo upload endpoint
 app.post("/api/upload-vehicle-photo", async (c) => {
 	try {
-		// Get the context (optional for this endpoint)
+		// Get the context and require authenticated taller/CRM access.
 		const context = await createContext({ context: c });
+		const userRole = context.session?.user?.role;
 
-		// Public endpoint - no auth required
-		// if (!context.session?.user?.id || !context.session?.user?.role) {
-		// 	return c.json({ error: "No autorizado" }, 401);
-		// }
+		if (!context.session?.user?.id) {
+			return c.json({ error: "No autorizado" }, 401);
+		}
+
+		if (
+			!userRole ||
+			(!PERMISSIONS.canAccessTaller(userRole) &&
+				!PERMISSIONS.canAccessCRM(userRole))
+		) {
+			return c.json({ error: "No tienes permiso para subir fotos" }, 403);
+		}
 
 		// Parse multipart form data
 		const formData = await c.req.formData();

--- a/apps/crm/apps/server/src/lib/roles.test.ts
+++ b/apps/crm/apps/server/src/lib/roles.test.ts
@@ -4,9 +4,21 @@ import { PERMISSIONS, ROLES } from "./roles";
 describe("taller role permissions", () => {
 	it("allows taller roles to access vehicles and taller", () => {
 		expect(PERMISSIONS.canAccessVehicles(ROLES.VEHICLE_VERIFIER)).toBe(true);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.SERVICE_CENTER_MANAGER)).toBe(
+			true,
+		);
 		expect(PERMISSIONS.canAccessTaller(ROLES.VEHICLE_VERIFIER)).toBe(true);
 		expect(PERMISSIONS.canAccessTaller(ROLES.SERVICE_CENTER_MANAGER)).toBe(
 			true,
 		);
+	});
+
+	it("keeps vehicle navigation aligned with backend vehicle guards", () => {
+		expect(PERMISSIONS.canAccessVehicles(ROLES.ADMIN)).toBe(true);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.SALES)).toBe(true);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.ANALYST)).toBe(true);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.COBROS)).toBe(false);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.ACCOUNTING)).toBe(false);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.INVESTMENT_MANAGER)).toBe(false);
 	});
 });

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -245,8 +245,9 @@ export const PERMISSIONS = {
 		role === ROLES.SALES_SUPERVISOR ||
 		role === ROLES.ANALYST,
 
-	// Vehicles Module Access - All roles can access
-	canAccessVehicles: (_role: UserRole | string): boolean => true,
+	// Vehicles Module Access
+	canAccessVehicles: (role: UserRole | string): boolean =>
+		PERMISSIONS.canAccessCRM(role) || PERMISSIONS.canAccessTaller(role),
 
 	// Taller Module Access
 	canAccessTaller: (role: UserRole | string): boolean =>

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -99,7 +99,7 @@ const normalizeManualValuationAmount = (
 
 export const vehiclesRouter = {
 	// Get all vehicles with their latest inspection and photos
-	getAll: publicProcedure
+	getAll: tallerOrCrmProcedure
 		.input(
 			z
 				.object({
@@ -728,7 +728,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Create vehicle inspection
-	createInspection: protectedProcedure
+	createInspection: tallerOrCrmProcedure
 		.input(
 			z.object({
 				vehicleId: z.string(),
@@ -925,7 +925,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Upload vehicle photo
-	uploadPhoto: protectedProcedure
+	uploadPhoto: tallerOrCrmProcedure
 		.input(
 			z.object({
 				vehicleId: z.string(),
@@ -1092,7 +1092,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Get statistics
-	getStatistics: publicProcedure.handler(async () => {
+	getStatistics: tallerOrCrmProcedure.handler(async () => {
 		const allVehicles = await db.select().from(vehicles);
 		const allInspections = await db.select().from(vehicleInspections);
 
@@ -1124,7 +1124,7 @@ export const vehiclesRouter = {
 	}),
 
 	// Create full inspection with all data (vehicle + inspection + checklist)
-	createFullInspection: publicProcedure
+	createFullInspection: tallerOrCrmProcedure
 		.input(
 			z.object({
 				// Vehicle data
@@ -1506,7 +1506,7 @@ export const vehiclesRouter = {
 		}),
 
 	// OCR endpoint for vehicle registration card (tarjeta de circulación)
-	processVehicleRegistrationOCR: publicProcedure
+	processVehicleRegistrationOCR: tallerOrCrmProcedure
 		.input(
 			z.object({
 				imageBase64: z
@@ -1637,7 +1637,7 @@ REGLAS IMPORTANTES:
 		}),
 
 	// AI Vehicle Valuation endpoint
-	getAIVehicleValuation: publicProcedure
+	getAIVehicleValuation: tallerOrCrmProcedure
 		.input(
 			z.object({
 				vehicleData: z.any().describe("Complete vehicle data from inspection"),

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -201,7 +201,7 @@ export default function Header() {
 							</Button>
 						)}
 
-						{/* Vehículos Dropdown - Visible para todos los roles */}
+						{/* Vehículos */}
 						{session && userRole && PERMISSIONS.canAccessVehicles(userRole) && (
 							<DropdownMenu>
 								<DropdownMenuTrigger asChild>


### PR DESCRIPTION
## Summary
- Cambia los endpoints de vehiculos usados por taller de public/protected generico a tallerOrCrmProcedure.
- Protege createFullInspection, OCR, AI valuation, estadisticas y listados con sesion + rol taller/CRM.
- Protege /api/upload-vehicle-photo con sesion y permisos de taller/CRM.

## Test Plan
- [x] bun run build en apps/crm/apps/server
- [x] bun test src/lib/roles.test.ts en apps/crm/apps/server
- [x] bun run build en apps/taller
- [x] bun test src/services/vehicles.test.ts en apps/taller

## Notes
- Verificado que los roles service_center_manager y vehicle_verifier entran por canAccessTaller/canManageTallerInspections.
- Este PR cierra los endpoints de backend reales que consume taller.