### PR TITLE
feat(cartera): mejoras UX en flujo de pagos y selector de fecha

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -15,7 +15,7 @@ import {
 import { useCreditosPaginadosWithFilters } from "../hooks/credits";
 import { getApiErrorMessage } from "@/lib/apiError";
 import { Button } from "@/components/ui/button";
-import { Eye, Pencil, XCircle, FileCheck, CheckCircle2 } from "lucide-react";
+import { Eye, Pencil, XCircle, FileCheck, CheckCircle2, DollarSign } from "lucide-react";
 
 import {
   Table,
@@ -1319,6 +1319,17 @@ function MobileView({
 
           {/* Acciones */}
           <div className="flex justify-center flex-wrap gap-2 mt-3">
+            {(user?.role === "ADMIN" || user?.role === "ASESOR") && (
+              <Button
+                variant="outline"
+                className="text-green-700 border-green-300 hover:bg-green-50"
+                onClick={() =>
+                  navigate(`/realizarPago?sifco=${item.creditos.numero_credito_sifco}`)
+                }
+              >
+                <DollarSign className="w-4 h-4 mr-1" /> Registrar Pago
+              </Button>
+            )}
             <Button
               variant="outline"
               className="text-blue-700 border-blue-300 hover:bg-blue-50"
@@ -1622,6 +1633,22 @@ function DesktopView({
                   <TableCell colSpan={6} className="p-0 bg-blue-50 rounded-b-2xl">
                     {/* Botones de acción */}
                     <div className="flex flex-wrap justify-center gap-2 px-6 py-4 border-b border-blue-100">
+                        {(user?.role === "ADMIN" || user?.role === "ASESOR") && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="flex items-center gap-1 text-green-700 border-green-300 hover:bg-green-50"
+                            onClick={() =>
+                              navigate(
+                                `/realizarPago?sifco=${item.creditos.numero_credito_sifco}`
+                              )
+                            }
+                          >
+                            <DollarSign className="w-4 h-4" />
+                            Registrar Pago
+                          </Button>
+                        )}
+
                         {canViewPayments(item.creditos.statusCredit) && (
                           <Button
                             variant="outline"

--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { DollarSign, Percent, Info, FileText, Building2, CheckCircle2, Calendar, ChevronsUpDown, Check } from "lucide-react";
 import { Combobox, Transition } from "@headlessui/react";
 import { Fragment, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
 import { toast } from "sonner";
 import { MiniCardCredito } from "./cardInfo";
 import { OpcionesExcesoModal } from "./excessModal";
@@ -89,6 +90,10 @@ export function PagoForm() {
   } = usePagoForm();
 
   const { bancos, loading: loadingBancos } = useBancos();
+
+  // Crédito preseleccionado vía URL (?sifco=...) desde el Historial de Pagos
+  const [searchParams, setSearchParams] = useSearchParams();
+  const sifcoFromUrl = searchParams.get("sifco") ?? undefined;
 
   // 🎯 Estado para el modal de confirmación
   const [modalConfirmacionOpen, setModalConfirmacionOpen] = useState(false);
@@ -497,10 +502,18 @@ export function PagoForm() {
             <BuscadorUsuarioSifco
               onSelect={(sifco) => {
                 if (sifco) { setCreditoVisible(true); fetchCredito(sifco); }
-                else setCreditoVisible(false);
+                else {
+                  setCreditoVisible(false);
+                  // Limpiar el ?sifco=... de la URL al deseleccionar
+                  if (searchParams.has("sifco")) {
+                    searchParams.delete("sifco");
+                    setSearchParams(searchParams, { replace: true });
+                  }
+                }
               }}
               reset={resetBuscador}
               onReset={() => setResetBuscador(false)}
+              initialSifco={sifcoFromUrl}
             />
           </div>
 

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -18,7 +18,6 @@ import { Label } from "@/components/ui/label";
 import {
   ChevronDown,
   ChevronUp,
-  Search,
   Calendar,
   Loader2,
   CheckCircle2,
@@ -410,7 +409,7 @@ export function PaymentsCredits() {
     usePagoForm();
   const [mesFiltro, setMesFiltro] = useState<string>("");
   const [anioFiltro, setAnioFiltro] = useState<string>("");
-  const [search, setSearch] = useState("");
+  const [descargandoExcel, setDescargandoExcel] = useState<boolean>(false);
   const { numero_credito_sifco } = useParams<{
     numero_credito_sifco: string;
   }>();
@@ -440,23 +439,23 @@ export function PaymentsCredits() {
     enabled: !!numero_credito_sifco,
   });
 const handleDownloadExcel = async () => {
-  if (!numero_credito_sifco) return;
+  if (!numero_credito_sifco || descargandoExcel) return;
 
+  setDescargandoExcel(true);
   try {
     const res = await getPagosByCredito(numero_credito_sifco, true); // 👈 pedimos excel
     // Check if response has excelUrl (is ExcelResponse)
     if ('excelUrl' in res && res.excelUrl) {
-      const link = document.createElement("a");
-      link.href = res.excelUrl;
-      link.download = `pagos_${numero_credito_sifco}.xlsx`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      // Abrir el estado de cuenta en otra pestaña
+      window.open(res.excelUrl, "_blank", "noopener,noreferrer");
     } else {
-      alert("⚠️ No se pudo generar el Excel.");
+      toast.error("No se pudo generar el estado de cuenta.");
     }
   } catch (error) {
-    console.error("❌ Error descargando Excel:", error);
+    console.error("❌ Error descargando estado de cuenta:", error);
+    toast.error("Error al generar el estado de cuenta.");
+  } finally {
+    setDescargandoExcel(false);
   }
 };
   const meses = [
@@ -484,18 +483,10 @@ const handleDownloadExcel = async () => {
       const anioOk = anioFiltro ? anio === anioFiltro : true;
       return mesOk && anioOk;
     })
-    .filter(
-      (pago: any) =>
-        !search ||
-        Object.values(pago)
-          .join(" ")
-          .toLowerCase()
-          .includes(search.toLowerCase())
-    )
     : [];
   return (
     <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 flex flex-col items-center justify-start bg-gradient-to-br from-blue-50 to-white px-2 overflow-auto pt-8 pb-8">
-      <div className="w-full max-w-6xl mx-auto">
+      <div className="w-full max-w-[1600px] mx-auto">
         <button
           className="mb-6 px-6 py-2 bg-blue-50 hover:bg-blue-100 rounded-lg font-bold text-blue-700 shadow"
           onClick={() => navigate(-1)}
@@ -509,14 +500,15 @@ const handleDownloadExcel = async () => {
           {numero_credito_sifco}
         </Label>
 
-        {/* Filtros */}
-        <div className="flex flex-col md:flex-row gap-4 mb-8 justify-center items-center">
-          <div className="flex items-center gap-2 bg-blue-50 border-2 border-blue-200 rounded-xl px-4 py-2 shadow-md">
-            <Calendar className="text-blue-500 w-5 h-5" />
+        {/* Filtros y acciones */}
+        <div className="flex flex-col md:flex-row gap-3 mb-8 justify-center items-center flex-wrap">
+          {/* Filtro de periodo */}
+          <div className="flex items-center gap-2 bg-white border border-blue-200 rounded-xl px-4 py-2.5 shadow-sm">
+            <Calendar className="text-blue-500 w-5 h-5 shrink-0" />
             <select
               value={mesFiltro}
               onChange={(e) => setMesFiltro(e.target.value)}
-              className="bg-transparent outline-none text-blue-800 font-semibold"
+              className="bg-transparent outline-none text-blue-800 font-semibold cursor-pointer"
             >
               <option value="">Mes</option>
               {meses.map((mes) => (
@@ -525,10 +517,11 @@ const handleDownloadExcel = async () => {
                 </option>
               ))}
             </select>
+            <span className="w-px h-5 bg-blue-200" />
             <select
               value={anioFiltro}
               onChange={(e) => setAnioFiltro(e.target.value)}
-              className="bg-transparent outline-none text-blue-800 font-semibold"
+              className="bg-transparent outline-none text-blue-800 font-semibold cursor-pointer"
             >
               <option value="">Año</option>
               {["2023", "2024", "2025", "2026"].map((anio) => (
@@ -538,26 +531,36 @@ const handleDownloadExcel = async () => {
               ))}
             </select>
           </div>
-          <div className="flex items-center gap-2 bg-blue-50 border-2 border-blue-200 rounded-xl px-4 py-2 shadow-md">
-            <Search className="text-blue-500 w-5 h-5" />
-            <input
-              type="text"
-              placeholder="Buscar pago (general)..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              className="border-none outline-none bg-transparent text-blue-800 font-semibold placeholder-blue-400"
-            />
-          </div>
-                <div className="flex items-center gap-2 bg-blue-50 border-2 border-blue-200 rounded-xl px-4 py-2 shadow-md">
+
+          {/* Descargar Estado de Cuenta */}
           <button
             onClick={handleDownloadExcel}
-            className="px-6 py-2 bg-green-600 hover:bg-green-700 text-white font-bold rounded-lg shadow-md transition flex items-center gap-2"
+            disabled={descargandoExcel}
+            className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-bold text-white bg-gradient-to-r from-emerald-500 to-green-600 hover:from-emerald-600 hover:to-green-700 shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200 disabled:opacity-70 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-md"
           >
-            <FileText className="w-5 h-5" />
-            Descargar Excel
+            {descargandoExcel ? (
+              <>
+                <Loader2 className="w-5 h-5 animate-spin" />
+                Generando...
+              </>
+            ) : (
+              <>
+                <FileText className="w-5 h-5" />
+                Descargar Estado de Cuenta
+              </>
+            )}
           </button>
-        </div>
 
+          {/* Registrar Pago */}
+          {(user?.role === "ADMIN" || user?.role === "ASESOR") && numero_credito_sifco && (
+            <button
+              onClick={() => navigate(`/realizarPago?sifco=${numero_credito_sifco}`)}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-bold text-white bg-gradient-to-r from-blue-500 to-indigo-600 hover:from-blue-600 hover:to-indigo-700 shadow-md hover:shadow-lg hover:-translate-y-0.5 active:translate-y-0 transition-all duration-200"
+            >
+              <DollarSign className="w-5 h-5" />
+              Registrar Pago
+            </button>
+          )}
         </div>
 
           {historialFecha.length > 0 && (

--- a/apps/carteraFront/src/private/cartera/components/calendar.tsx
+++ b/apps/carteraFront/src/private/cartera/components/calendar.tsx
@@ -1,52 +1,117 @@
-import * as React from "react"
-import dayjs, { Dayjs } from "dayjs"
-import "dayjs/locale/es"
+import { useState } from "react"
+import { format, parse, isValid } from "date-fns"
+import { es } from "date-fns/locale"
+import { CalendarIcon, ChevronLeft, ChevronRight, ChevronDown } from "lucide-react"
+import { DayPicker } from "react-day-picker"
 
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider"
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs"
-import { DatePicker } from "@mui/x-date-pickers/DatePicker"
-
-import TextField from "@mui/material/TextField"
-import CalendarMonthIcon from "@mui/icons-material/CalendarMonth"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
 
 interface DatePickerMUIProps {
   value?: string
   onChange?: (value: string) => void
   label?: string
   disableFuture?: boolean
+  className?: string
 }
 
+// Estilos del calendario con utilidades Tailwind v3 (react-day-picker no trae CSS propio)
+const dayPickerClassNames = {
+  months: "relative",
+  month: "space-y-3",
+  month_caption: "flex justify-center items-center h-8 relative px-8",
+  caption_label: "sr-only",
+  nav: "absolute top-0 inset-x-0 flex items-center justify-between h-8",
+  button_previous:
+    "h-7 w-7 inline-flex items-center justify-center rounded-md text-gray-600 hover:bg-blue-50 disabled:opacity-30 disabled:hover:bg-transparent",
+  button_next:
+    "h-7 w-7 inline-flex items-center justify-center rounded-md text-gray-600 hover:bg-blue-50 disabled:opacity-30 disabled:hover:bg-transparent",
+  dropdowns: "flex items-center justify-center gap-2",
+  dropdown_root: "relative inline-flex items-center",
+  dropdown:
+    "appearance-none bg-white border border-gray-300 rounded-md pl-2 pr-6 py-1 text-sm font-medium text-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-400 cursor-pointer",
+  month_grid: "w-full border-collapse",
+  weekdays: "flex",
+  weekday:
+    "w-9 h-8 text-xs font-semibold text-gray-400 flex items-center justify-center uppercase",
+  week: "flex w-full mt-1",
+  day: "w-9 h-9 p-0 text-center",
+  day_button:
+    "w-9 h-9 rounded-md text-sm text-gray-700 inline-flex items-center justify-center transition hover:bg-blue-50",
+  selected:
+    "[&>button]:bg-blue-600 [&>button]:text-white [&>button]:font-semibold [&>button:hover]:bg-blue-600",
+  today: "[&:not([data-selected])>button]:text-blue-600 [&:not([data-selected])>button]:font-bold",
+  outside: "[&>button]:text-gray-300",
+  disabled: "[&>button]:text-gray-300 [&>button]:cursor-not-allowed [&>button:hover]:bg-transparent",
+  hidden: "invisible",
+}
+
+/**
+ * Selector de fecha con calendario emergente (react-day-picker + Popover),
+ * estilizado con Tailwind para combinar con el resto de los campos.
+ * El valor se maneja siempre en formato "YYYY-MM-DD".
+ */
 export function DatePickerMUI({
   value,
   onChange,
   disableFuture = true,
+  className = "",
 }: DatePickerMUIProps) {
+  const [open, setOpen] = useState(false)
+
+  const parsed = value ? parse(value, "yyyy-MM-dd", new Date()) : undefined
+  const selected = parsed && isValid(parsed) ? parsed : undefined
+
+  const today = new Date()
+
   return (
-    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="es">
-      <DatePicker
-     
-        value={value ? dayjs(value) : null}
-        maxDate={disableFuture ? dayjs() : undefined} // 🚫 sin fechas futuras si disableFuture es true
-        enableAccessibleFieldDOMStructure={false} // 🔥 FIX CLAVE
-        onChange={(newValue: Dayjs | null) => {
-          onChange?.(
-            newValue ? newValue.format("YYYY-MM-DD") : ""
-          )
-        }}
-        slots={{
-          textField: TextField,
-          openPickerIcon: CalendarMonthIcon,
-        }}
-        slotProps={{
-          textField: {
-            fullWidth: true,
-            size: "medium",
-          },
-          popper: {
-            disablePortal: true,
-          },
-        }}
-      />
-    </LocalizationProvider>
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "w-full flex items-center justify-between gap-2 border border-gray-300 rounded-lg px-3 py-2.5 bg-white text-left focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition",
+            selected ? "text-gray-900" : "text-gray-400",
+            className
+          )}
+        >
+          <span>{selected ? format(selected, "dd/MM/yyyy") : "DD/MM/YYYY"}</span>
+          <CalendarIcon className="w-5 h-5 text-gray-400 shrink-0" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-auto p-3 bg-white border border-gray-200 rounded-xl shadow-lg"
+        align="start"
+      >
+        <DayPicker
+          mode="single"
+          locale={es}
+          selected={selected}
+          defaultMonth={selected ?? today}
+          captionLayout="dropdown"
+          startMonth={new Date(2000, 0)}
+          endMonth={disableFuture ? today : new Date(today.getFullYear() + 5, 11)}
+          disabled={disableFuture ? { after: today } : undefined}
+          onSelect={(date) => {
+            onChange?.(date ? format(date, "yyyy-MM-dd") : "")
+            setOpen(false)
+          }}
+          classNames={dayPickerClassNames}
+          components={{
+            Chevron: ({ orientation }) => {
+              if (orientation === "left") return <ChevronLeft className="w-4 h-4" />
+              if (orientation === "right") return <ChevronRight className="w-4 h-4" />
+              return (
+                <ChevronDown className="w-4 h-4 absolute right-1.5 top-1/2 -translate-y-1/2 pointer-events-none text-gray-500" />
+              )
+            },
+          }}
+        />
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
+++ b/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
@@ -8,8 +8,9 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
-import { BadgeCheck, AlertTriangle, FileText, ChevronDown, ChevronUp, Calendar } from "lucide-react";
+import { BadgeCheck, AlertTriangle, FileText, ChevronDown, ChevronUp, Calendar, Eye } from "lucide-react";
 import { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 
 export function MiniCardCredito({
   credito,
@@ -326,9 +327,14 @@ export function MiniCardCredito({
             <span className="font-bold text-blue-700 text-sm mb-1">
               Crédito SIFCO
             </span>
-            <span className="text-gray-900 text-xl font-bold tracking-wider">
+            <Link
+              to={`/pagos/${credito.numero_credito_sifco}`}
+              title="Ver historial de pagos"
+              className="group inline-flex items-center gap-1.5 text-blue-700 text-xl font-bold tracking-wider hover:text-blue-900 hover:underline underline-offset-2 transition-colors w-fit"
+            >
               {credito.numero_credito_sifco}
-            </span>
+              <Eye className="w-4 h-4 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </Link>
           </div>
 
           {/* Usuario */}
@@ -336,9 +342,14 @@ export function MiniCardCredito({
             <span className="font-bold text-blue-700 text-sm mb-1">
               Usuario
             </span>
-            <span className="text-gray-800 font-semibold text-base">
+            <Link
+              to={`/pagos/${credito.numero_credito_sifco}`}
+              title="Ver historial de pagos"
+              className="group inline-flex items-center gap-1.5 text-blue-700 font-semibold text-base hover:text-blue-900 hover:underline underline-offset-2 transition-colors w-fit"
+            >
               {usuario.nombre}
-            </span>
+              <Eye className="w-4 h-4 opacity-0 group-hover:opacity-100 transition-opacity" />
+            </Link>
           </div>
 
           {/* Deuda Total */}

--- a/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
@@ -223,8 +223,7 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
                 >
                   <option value="sin_reinversion">Sin Reinversión</option>
                   <option value="reinversion_capital">Reinversión Capital</option>
-                  <option value="reinversion_interes">Reinversión Interés</option>
-                  <option value="reinversion_total">Reinversión Total</option>
+                  <option value="reinversion_total">Interés Compuesto</option>
                   <option value="reinversion_variable">Reinversión Variable</option>
                   <option value="reinversion_excedente">Reinversión Excedente</option>
                   <option value="reinversion_combinada">Reinversión Combinada</option>

--- a/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
+++ b/apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { Label } from "@/components/ui/label";
 import {
   Select,
@@ -29,18 +29,20 @@ interface BuscadorUsuarioSifcoProps {
   onSelect: (sifco: string) => void;
   reset?: boolean;
   onReset?: () => void;
+  initialSifco?: string;
 }
 
 function esSifco(search: string): boolean {
   return /\d/.test(search);
 }
 
-export function BuscadorUsuarioSifco({ onSelect, reset, onReset }: BuscadorUsuarioSifcoProps) {
-  const [search, setSearch] = useState<string>("");
-  const [debouncedSearch, setDebouncedSearch] = useState<string>("");
+export function BuscadorUsuarioSifco({ onSelect, reset, onReset, initialSifco }: BuscadorUsuarioSifcoProps) {
+  const [search, setSearch] = useState<string>(initialSifco ?? "");
+  const [debouncedSearch, setDebouncedSearch] = useState<string>(initialSifco ?? "");
   const [page, setPage] = useState<number>(1);
   const [selectedSifco, setSelectedSifco] = useState<string>("");
   const [selectedOption, setSelectedOption] = useState<OpcionSifco | null>(null);
+  const initialAppliedRef = useRef<boolean>(false);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -104,9 +106,22 @@ export function BuscadorUsuarioSifco({ onSelect, reset, onReset }: BuscadorUsuar
   useEffect(() => {
     if (reset) {
       handleClear();
+      initialAppliedRef.current = false;
       onReset?.();
     }
   }, [reset, onReset]);
+
+  // Autoselección cuando se llega con un crédito preseleccionado por URL
+  useEffect(() => {
+    if (!initialSifco || initialAppliedRef.current) return;
+    const opt = opciones.find((o) => o.sifco === initialSifco);
+    if (opt) {
+      initialAppliedRef.current = true;
+      setSelectedOption(opt);
+      setSelectedSifco(opt.sifco);
+      onSelect(opt.sifco);
+    }
+  }, [opciones, initialSifco, onSelect]);
 
   return (
     <div className="mb-4 w-full max-w-md flex flex-col gap-2">


### PR DESCRIPTION
## Resumen

Conjunto de mejoras de UX en el módulo de cartera, centradas en el flujo de registro de pagos y el selector de fecha.

## Cambios

### Registrar Pago accesible y con preselección
- Nuevo botón **Registrar Pago** en el **Historial de Pagos del Crédito** ([PaymentsCredits.tsx](apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx)) y en la **tabla de créditos** ([CreditsPaymentsData.tsx](apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx), desktop y mobile, como primer botón). Navega a `/realizarPago?sifco=<numero_credito_sifco>`.
- [PagoForm.tsx](apps/carteraFront/src/private/cartera/components/PagoForm.tsx) + [searchByNameSifco.tsx](apps/carteraFront/src/private/cartera/components/searchByNameSifco.tsx): lee el query param `sifco` y **autoselecciona** el crédito en el buscador. Al limpiar con la **X** se elimina el param de la URL.
- Visible solo para roles `ADMIN`/`ASESOR` (los que tienen acceso a la ruta).

### Historial de Pagos del Crédito
- Botones rediseñados con degradado y efecto hover.
- **"Descargar Excel" → "Descargar Estado de Cuenta"**: ahora **abre en otra pestaña** con **spinner de carga** mientras se genera; errores con `toast`.
- Se eliminó el buscador de pagos (sin uso real) y se **ensanchó la tabla** para que la columna de Boleta se vea completa.

### Tarjeta del crédito (PagoForm)
- [cardInfo.tsx](apps/carteraFront/src/private/cartera/components/cardInfo.tsx): el **SIFCO** y el **Usuario** ahora son enlaces al historial de pagos (`/pagos/:sifco`).

### Modal de inversionista
- [modalInvestor.tsx](apps/carteraFront/src/private/cartera/components/modalInvestor.tsx): en *Tipo de Reinversión* se quitó **"Reinversión Interés"** y **"Reinversión Total"** pasó a **"Interés Compuesto"** (se mantiene el valor interno `reinversion_total` para no romper backend/datos).

### Selector de fecha (DatePickerMUI)
- [calendar.tsx](apps/carteraFront/src/private/cartera/components/calendar.tsx): se reemplazó el `DatePicker` de **MUI** (estilo inconsistente y salto de scroll al abrir) por **react-day-picker + Popover**, estilizado con Tailwind para combinar con el resto de los inputs. Calendario en español, con dropdowns de mes/año, sin salto de scroll (Portal) y respetando `disableFuture`. API idéntica (`value`/`onChange` en `YYYY-MM-DD`), reemplazo drop-in para los 15 usos.

## Notas
- El valor interno `reinversion_total` se mantuvo a propósito; renombrarlo requeriría coordinación con backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)