### PR TITLE
fix(cartera): abono a capital aplicado — fecha_aplicado + estado capital_validated

### DIFF
--- a/apps/cartera-back/drizzle/0012_add_capital_validated_enum.sql
+++ b/apps/cartera-back/drizzle/0012_add_capital_validated_enum.sql
@@ -1,0 +1,16 @@
+-- Nuevo valor del enum payment_validation_status: 'capital_validated'.
+--
+-- Representa un ABONO DIRECTO A CAPITAL YA APLICADO. Antes este caso quedaba
+-- como 'validated', lo que lo hacía entrar al set de hermanos de la cuota e
+-- inflaba su faltante (un abono a capital NO es pago de cuota) → rechazo
+-- "sobre-aplicada" o el pago cayendo a saldo a favor.
+--
+-- Con el estado propio:
+--   - La lógica de cuota (sibling query / cuotaCompleta) filtra solo
+--     'validated'/'pending' → los abonos a capital quedan fuera.
+--   - Reportes/reversa/revalidación lo tratan como aplicado (cuenta como plata).
+--
+-- NOTA: ALTER TYPE ... ADD VALUE no puede correr dentro de una transacción que
+-- además use el valor; ejecutar este archivo solo (sin envolver en BEGIN/COMMIT
+-- junto a otros statements que lo referencien).
+ALTER TYPE public.payment_validation_status ADD VALUE IF NOT EXISTS 'capital_validated';

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1637,7 +1637,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       whereClauses.push(`p.validation_status = '${validationStatus}'`);
     } else {
       whereClauses.push(
-        `p.validation_status IN ('validated', 'pending' ,'reset', 'capital')`
+        `p.validation_status IN ('validated', 'pending' ,'reset', 'capital', 'capital_validated')`
       );
     }
 

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -17,7 +17,7 @@ import {
 import { desc, gte } from "drizzle-orm";
 import Big from "big.js";
 import { z } from "zod";
-import { and, eq, lt, sql, asc, lte, inArray } from "drizzle-orm";
+import { and, eq, lt, sql, asc, lte, inArray, notInArray } from "drizzle-orm";
 import { removeAccents } from "../utils/functions/generalFunctions";
 import {
   processAndReplaceCreditInvestors,
@@ -2935,7 +2935,12 @@ export async function getAbonosPorCuota(
     .where(
       and(
         eq(pagos_credito.credito_id, credito.credito_id),
-        inArray(pagos_credito.cuota_id, cuotaIds)
+        inArray(pagos_credito.cuota_id, cuotaIds),
+        // Excluir abonos directos a capital (no son pago de cuota) y reversados.
+        // `capital` = sin aplicar, `capital_validated` = aplicado; ninguno es
+        // abono de la cuota, así que no deben aparecer en este desglose.
+        eq(pagos_credito.paymentFalse, false),
+        notInArray(pagos_credito.validationStatus, ["capital", "capital_validated"])
       )
     );
 

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2765,11 +2765,15 @@ export async function aplicarAbonoCapitalInversionistas(
   await db
     .update(pagos_credito)
     .set({
-      validationStatus: "validated",
+      // Estado propio del abono a capital APLICADO. No usamos `validated`
+      // porque ese estado entra al set de hermanos de la cuota e inflaría su
+      // faltante (un abono a capital NO es pago de cuota). `capital_validated`
+      // lo deja distinguible: cuenta como aplicado en reportes/reversa, pero
+      // queda fuera de la lógica de cuota.
+      validationStatus: "capital_validated",
       // Estampar la fecha de aplicación en hora de Guatemala (igual que
-      // `fecha_pago`). Antes este flujo marcaba `validated` pero dejaba
-      // `fecha_aplicado` en NULL → el abono a capital quedaba "validado sin
-      // fecha" y no se podía saber cuándo se aplicó.
+      // `fecha_pago`). Antes este flujo dejaba `fecha_aplicado` en NULL → el
+      // abono a capital quedaba "validado sin fecha".
       fecha_aplicado: convertirAHoraGuatemala(new Date().toISOString()),
     })
     .where(eq(pagos_credito.pago_id, pago_id));

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2764,7 +2764,14 @@ export async function aplicarAbonoCapitalInversionistas(
   }
   await db
     .update(pagos_credito)
-    .set({ validationStatus: "validated" })
+    .set({
+      validationStatus: "validated",
+      // Estampar la fecha de aplicación en hora de Guatemala (igual que
+      // `fecha_pago`). Antes este flujo marcaba `validated` pero dejaba
+      // `fecha_aplicado` en NULL → el abono a capital quedaba "validado sin
+      // fecha" y no se podía saber cuándo se aplicó.
+      fecha_aplicado: convertirAHoraGuatemala(new Date().toISOString()),
+    })
     .where(eq(pagos_credito.pago_id, pago_id));
 
   console.log(`✅ ========== ABONO APLICADO EXITOSAMENTE ==========\n`);

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -19,7 +19,6 @@ import { insertPagosCreditoInversionistas, insertPagosCreditoInversionistasV2 } 
 import { processAndReplaceCreditInvestors } from "./investor"; 
 import { processConvenioPayment } from "./paymentAgreement";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
-import { convertirAHoraGuatemala } from "../utils/functions/generalFunctions";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
@@ -2771,10 +2770,13 @@ export async function aplicarAbonoCapitalInversionistas(
       // lo deja distinguible: cuenta como aplicado en reportes/reversa, pero
       // queda fuera de la lógica de cuota.
       validationStatus: "capital_validated",
-      // Estampar la fecha de aplicación en hora de Guatemala (igual que
-      // `fecha_pago`). Antes este flujo dejaba `fecha_aplicado` en NULL → el
-      // abono a capital quedaba "validado sin fecha".
-      fecha_aplicado: convertirAHoraGuatemala(new Date().toISOString()),
+      // Estampar la fecha de aplicación. Antes este flujo dejaba `fecha_aplicado`
+      // en NULL → el abono quedaba "validado sin fecha". Se guarda en UTC con
+      // `new Date()` igual que los demás writers de `fecha_aplicado` (~2149/2266
+      // y revalidatePayment): los consumidores ya convierten a hora de Guatemala
+      // con `AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala'`. Guardar el
+      // wall-clock GT aquí lo shiftearía dos veces (P2 de Codex).
+      fecha_aplicado: new Date(),
     })
     .where(eq(pagos_credito.pago_id, pago_id));
 

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -3,6 +3,7 @@ import puppeteer from "puppeteer";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getCreditosWithUserByMesAnio } from "./credits";
 import { getAllPagosWithCreditAndInversionistas, getPagosConInversionistas } from "./payments";
+import { esPagoAplicado } from "../utils/paymentStatus";
 import { fetchImageBase64 } from "../utils/functions/internReportCancelations";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 import { db } from "../database";
@@ -95,7 +96,7 @@ export function shouldIncludeEstadoCuentaPayment(pago: EstadoCuentaPagoRow) {
     pago.fecha_aplicado !== null && pago.fecha_aplicado !== undefined;
 
   return (
-    pago.validationStatus === "validated" &&
+    esPagoAplicado(pago.validationStatus) &&
     abonoCapital > 0 &&
     montoAplicado > 0 &&
     (esAbonoCapitalPuro || (fueAplicado && pagoNoEsFuturo))
@@ -2049,7 +2050,7 @@ export async function getPagosByVencimiento({
           numeroautorizacion AS numero_boleta
         FROM cartera.pagos_credito
         WHERE credito_id = ANY(ARRAY[${sql.raw(creditoIds.join(","))}]::int[])
-          AND validation_status = 'validated'
+          AND validation_status IN ('validated', 'capital_validated')
           AND "paymentFalse" = false
           AND (
             (cuota_id IS NOT NULL AND cuota_id IN (
@@ -2381,7 +2382,7 @@ export async function getAbonosDelMesPorCredito({
       numeroautorizacion AS numero_boleta
     FROM cartera.pagos_credito
     WHERE credito_id = ${credito_id}
-      AND validation_status = 'validated'
+      AND validation_status IN ('validated', 'capital_validated')
       AND "paymentFalse" = false
       AND (
         (cuota_id IS NOT NULL AND cuota_id IN (

--- a/apps/cartera-back/src/controllers/revalidatePayment.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.ts
@@ -4,6 +4,7 @@ import Big from "big.js";
 import { db } from "../database";
 import { pagos_credito, creditos } from "../database/db";
 import { insertPagosCreditoInversionistasV2 } from "./payments";
+import { esPagoAplicado } from "../utils/paymentStatus";
 
 // ============================================================================
 // SCHEMA DE VALIDACIÓN
@@ -51,7 +52,7 @@ export const revalidatePayment = async ({ body, set }: any) => {
         throw new Error(`Payment ${pago_id} not found`);
       }
       
-      if (pago.validationStatus === "validated") {
+      if (esPagoAplicado(pago.validationStatus)) {
         throw new Error(`Payment ${pago_id} is already validated`);
       }
 

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -18,6 +18,7 @@ import { updateMora } from "./latefee";
 import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
 import { updateInstallments } from "./updateCredit";
+import { esPagoAplicado } from "../utils/paymentStatus";
 import {
   getRemainingPaymentPaidStatusAfterReversal,
   shouldInstallmentRemainPaidAfterReversal,
@@ -89,7 +90,7 @@ export const reversePayment = async ({ body, set }: any) => {
         throw new Error("Payment not found");
       }
 
-      const pagoValidado = pago.validationStatus === "validated";
+      const pagoValidado = esPagoAplicado(pago.validationStatus);
 
       console.log(`✅ Pago encontrado | Validado: ${pagoValidado}`);
 

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -389,7 +389,8 @@
     'no_required',    // No necesita validación (pagos normales/automáticos)
     'pending',        // Pendiente de validación
     'validated',        // Validado
-    'capital',
+    'capital',          // Abono directo a capital REGISTRADO (sin aplicar)
+    'capital_validated',// Abono directo a capital YA APLICADO (no es pago de cuota)
     'reset'
   ]);
 

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -199,7 +199,8 @@ if (facturasExistentes.length > 0) {
       if (
         pagoData.validationStatus !== "validated" &&
         pagoData.validationStatus !== "reset" &&
-        pagoData.validationStatus !== "capital"
+        pagoData.validationStatus !== "capital" &&
+        pagoData.validationStatus !== "capital_validated"
       ) {
         set.status = 400;
         console.error(

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -23,6 +23,7 @@ import { revertPaymentToPending } from "../controllers/revertPaymentToPending";
 import { processInvestors } from "../controllers/processInvestors";
 import { ajustarCuotasConSIFCO, marcarCuotasPagadasHastaNumero, procesarPagosSIFCODesdeJSON } from "../controllers/migratePayments";
 import { updateInstallments, updateAllInstallments } from "../controllers/updateCredit";
+import { esPagoAplicado } from "../utils/paymentStatus";
 
 export const liquidatePaymentsSchema = z.object({
   pago_id: z.number().int().positive(),
@@ -524,8 +525,8 @@ export const paymentRouter = new Elysia()
         };
       }
 
-      // Verificar que el pago no esté ya validado
-      if (pagoExiste.validationStatus === 'validated') {
+      // Verificar que el pago no esté ya validado (incluye abono a capital aplicado)
+      if (esPagoAplicado(pagoExiste.validationStatus)) {
         set.status = 400;
         return {
           success: false,

--- a/apps/cartera-back/src/utils/paymentStatus.ts
+++ b/apps/cartera-back/src/utils/paymentStatus.ts
@@ -1,0 +1,17 @@
+// Estados de `validation_status` que representan un pago APLICADO/real (cuenta
+// como plata en reportes, reversa, revalidación, estado de cuenta).
+//
+// Incluye `capital_validated` (abono directo a capital ya aplicado), que es
+// dinero real pero NO es pago de cuota. Por eso NO se usa este grupo en la
+// lógica de cuota (sibling query, cuotaCompleta, saldo vigente), que sigue
+// filtrando solo por `validated`/`pending` y así deja fuera a los abonos a
+// capital.
+export const ESTADOS_PAGO_APLICADO = ["validated", "capital_validated"] as const;
+
+export type EstadoPagoAplicado = (typeof ESTADOS_PAGO_APLICADO)[number];
+
+/** ¿El pago está aplicado/validado (incluye abono a capital aplicado)? */
+export const esPagoAplicado = (
+  status?: string | null
+): boolean =>
+  status === "validated" || status === "capital_validated";

--- a/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
+++ b/apps/carteraFront/src/private/cartera/components/cardInfo.tsx
@@ -124,7 +124,7 @@ export function MiniCardCredito({
     // Permitir seleccionar cuotas con pagos pendientes; solo se ocultan las
     // cuotas ya validadas/cerradas. Se mantiene limitado a la cuota pagable
     // más antigua para no saltar deuda anterior.
-    .filter((c) => c.validationStatus !== "validated")
+    .filter((c) => c.validationStatus !== "validated" && c.validationStatus !== "capital_validated")
     .sort((a, b) => a.numero_cuota - b.numero_cuota)
     .slice(0, 1);
 

--- a/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
+++ b/apps/carteraFront/src/private/cartera/components/paymentsTable.tsx
@@ -971,6 +971,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                       : validationStatusFilter === "pending" ? "#a16207"
                       : validationStatusFilter === "reset" ? "#c2410c"
                       : validationStatusFilter === "capital" ? "#1d4ed8"
+                      : validationStatusFilter === "capital_validated" ? "#0e7490"
                       : validationStatusFilter === "no_required" ? "#374151"
                       : "#1f2937"
                   }}
@@ -980,6 +981,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                   <option value="pending" style={{ color: "#a16207" }}>Pendiente</option>
                   <option value="reset" style={{ color: "#c2410c" }}>Reset</option>
                   <option value="capital" style={{ color: "#1d4ed8" }}>Capital</option>
+                  <option value="capital_validated" style={{ color: "#0e7490" }}>Capital Aplicado</option>
                   <option value="no_required" style={{ color: "#374151" }}>No Requiere</option>
                 </select>
               </div>
@@ -1316,11 +1318,11 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                       disabled={
                         user?.role !== "ADMIN" ||
                         isPending ||
-                        pago.validationStatus === "validated" ||
+                        (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ||
                         !tieneCuentaAsignada(pago)
                       }
                       className={`font-semibold flex items-center gap-1 ${
-                        pago.validationStatus === "validated"
+                        (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")
                           ? "text-gray-400 cursor-not-allowed"
                           : user?.role !== "ADMIN"
                             ? "text-gray-400 cursor-not-allowed opacity-50"
@@ -1331,13 +1333,13 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                           ? "Solo administradores"
                           : !tieneCuentaAsignada(pago)
                             ? "Debe asignar una cuenta primero"
-                            : pago.validationStatus === "validated"
+                            : (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")
                               ? "Ya validado"
                               : ""
                       }
                     >
                       <Check className="w-4 h-4" />
-                      {pago.validationStatus === "validated"
+                      {(pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")
                         ? "Ya Validado"
                         : !tieneCuentaAsignada(pago)
                           ? "Sin Cuenta"
@@ -1445,7 +1447,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                       onClick={() => {
                         handleRevalidatePayment(pago.pagoId, pago.credito?.creditoId || 0);
                       }}
-                      disabled={revalidatePayment.isPending || user?.role !== "ADMIN" || pago.validationStatus === "validated"}
+                      disabled={revalidatePayment.isPending || user?.role !== "ADMIN" || (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")}
                     >
                       {revalidatePayment.isPending ? (
                         <>
@@ -1821,7 +1823,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                               onClick={() => {
                                 if (
                                   user?.role === "ADMIN" &&
-                                  pago.validationStatus !== "validated" &&
+                                  (pago.validationStatus !== "validated" && pago.validationStatus !== "capital_validated") &&
                                   tieneCuentaAsignada(pago)
                                 ) {
                                   setValidandoPagoId(pago.pagoId);
@@ -1839,11 +1841,11 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                 user?.role !== "ADMIN" ||
                                 isPending ||
                                 validandoPagoId === pago.pagoId ||
-                                pago.validationStatus === "validated" ||
+                                (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ||
                                 !tieneCuentaAsignada(pago)
                               }
                               className={`cursor-pointer py-2.5 px-3 flex items-center rounded-lg transition ${
-                                pago.validationStatus === "validated" ||
+                                (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ||
                                 user?.role !== "ADMIN" ||
                                 !tieneCuentaAsignada(pago)
                                   ? "opacity-50 text-gray-400 bg-gray-50"
@@ -1852,7 +1854,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                             >
                               <Check
                                 className={`w-4 h-4 mr-2 flex-shrink-0 ${
-                                  pago.validationStatus === "validated" ||
+                                  (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ||
                                   user?.role !== "ADMIN" ||
                                   !tieneCuentaAsignada(pago)
                                     ? "text-gray-400"
@@ -1862,7 +1864,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                               <span className="font-semibold">
                                 {validandoPagoId === pago.pagoId
                                   ? "Validando..."
-                                  : pago.validationStatus === "validated"
+                                  : (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")
                                     ? "Ya Validado"
                                     : !tieneCuentaAsignada(pago)
                                       ? "Sin Cuenta"
@@ -1880,7 +1882,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                               onClick={() => {
                                 if (
                                   user?.role === "ADMIN" &&
-                                  pago.validationStatus !== "validated" &&
+                                  (pago.validationStatus !== "validated" && pago.validationStatus !== "capital_validated") &&
                                   tieneCuentaAsignada(pago)
                                 ) {
                                   setValidandoPagoId(pago.pagoId);
@@ -1903,11 +1905,11 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                 isPending ||
                                 validandoPagoId === pago.pagoId ||
                                 generandoFacturaId === pago.pagoId ||
-                                pago.validationStatus === "validated" ||
+                                (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ||
                                 !tieneCuentaAsignada(pago)
                               }
                               className={`cursor-pointer py-2.5 px-3 flex items-center rounded-lg transition ${
-                                pago.validationStatus === "validated" ||
+                                (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ||
                                 user?.role !== "ADMIN" ||
                                 !tieneCuentaAsignada(pago)
                                   ? "opacity-50 text-gray-400 bg-gray-50"
@@ -1916,7 +1918,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                             >
                               <Check
                                 className={`w-4 h-4 mr-2 flex-shrink-0 ${
-                                  pago.validationStatus === "validated" ||
+                                  (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ||
                                   user?.role !== "ADMIN" ||
                                   !tieneCuentaAsignada(pago)
                                     ? "text-gray-400"
@@ -1928,7 +1930,7 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                   ? "Validando pago..."
                                   : generandoFacturaId === pago.pagoId
                                     ? "Generando factura..."
-                                    : pago.validationStatus === "validated"
+                                    : (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")
                                       ? "Ya Validado"
                                       : !tieneCuentaAsignada(pago)
                                         ? "Sin Cuenta"
@@ -2099,16 +2101,16 @@ const handleFacturarPago = (pagoId: number, e?: React.MouseEvent) => {
                                 }
                               }}
                               disabled={
-                                revalidatePayment.isPending || user?.role !== "ADMIN" || pago.validationStatus === "validated"
+                                revalidatePayment.isPending || user?.role !== "ADMIN" || (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")
                               }
                               className={`cursor-pointer py-2.5 px-3 flex items-center rounded-lg transition ${
-                                user?.role !== "ADMIN" || pago.validationStatus === "validated"
+                                user?.role !== "ADMIN" || (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated")
                                   ? "opacity-50 text-gray-400 bg-gray-50"
                                   : "text-purple-700 hover:text-purple-900 hover:bg-purple-50"
                               }`}
                             >
                               <Check
-                                className={`w-4 h-4 mr-2 flex-shrink-0 ${user?.role !== "ADMIN" || pago.validationStatus === "validated" ? "text-gray-400" : "text-purple-600"}`}
+                                className={`w-4 h-4 mr-2 flex-shrink-0 ${user?.role !== "ADMIN" || (pago.validationStatus === "validated" || pago.validationStatus === "capital_validated") ? "text-gray-400" : "text-purple-600"}`}
                               />
                               <span className="font-semibold">
                                 {revalidatePayment.isPending

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -70,7 +70,7 @@ const [resetBuscador, setResetBuscador] = useState(false);
   const [cuotaActualInfo, setCuotaActualInfo] = useState<{
     numero: number;
     pagada: boolean;
-    validationStatus?: 'no_required' | 'pending' | 'validated' | 'capital' | 'reset';
+    validationStatus?: 'no_required' | 'pending' | 'validated' | 'capital' | 'capital_validated' | 'reset';
     data?: any;
   } | null>(null);
   const [mora, setMora] = useState<number>(0);
@@ -277,7 +277,7 @@ const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
       ]
         // Los pagos `pending` también son seleccionables para poder reportar
         // abonos complementarios antes de que contabilidad valide el anterior.
-        .filter((c: any) => c.validationStatus !== "validated")
+        .filter((c: any) => c.validationStatus !== "validated" && c.validationStatus !== "capital_validated")
         .sort((a: any, b: any) => a.numero_cuota - b.numero_cuota)[0];
 
       setCuotaSeleccionada(siguienteCuotaPagable?.numero_cuota ?? cuotaActualNumero ?? 0);


### PR DESCRIPTION
## Problema

Al aplicar un **abono directo a capital**, `aplicarAbonoCapitalInversionistas` marcaba el pago como `validated` pero **nunca seteaba `fecha_aplicado`** → los abonos a capital quedaban *"validados sin fecha"*, sin forma de saber cuándo se aplicaron.

`fecha_aplicado = new Date()` sólo se estampaba en el **flujo normal de cuota** (`aplicarPagoAlCredito`, dos lugares), que la rama de capital se salta con un `return` temprano.

Caso real detectado: pago `136149` (crédito `01010101001460`) quedó `validation_status='validated'` con `fecha_aplicado=NULL`.

## Fix

En el mismo `update` que ya marca `validated` al final de `aplicarAbonoCapitalInversionistas`, se agrega `fecha_aplicado` en **hora de Guatemala** (misma convención que `fecha_pago`, vía `convertirAHoraGuatemala`):

```ts
await db.update(pagos_credito)
  .set({
    validationStatus: "validated",
    fecha_aplicado: convertirAHoraGuatemala(new Date().toISOString()),
  })
  .where(eq(pagos_credito.pago_id, pago_id));
```

## Alcance / notas
- Aplica a abonos a capital **de aquí en adelante**; no corrige retroactivamente filas ya existentes con `fecha_aplicado=NULL` (eso es un fix de datos aparte).
- Cambio de 1 línea efectiva (+ comentario). `tsc --noEmit`: 0 errores.
- Independiente del PR #846 (toca otra función).

---

## Update: nuevo estado `capital_validated` (raíz del problema)

El `fecha_aplicado` no destrababa el caso real: un abono a capital **aplicado** quedaba como `validated`, entraba al set de hermanos de la cuota e inflaba su faltante (un abono a capital **no es pago de cuota**) → rechazo "sobre-aplicada" o el pago cayendo a saldo a favor. Reclasificar a `'capital'` no aguanta porque al aplicarse vuelve a `validated`.

**Solución:** estado propio `capital_validated`.

### Cambios
- **Enum** `payment_validation_status` += `capital_validated` (Drizzle `schema.ts` + migración `drizzle/0012`).
- **Set point**: `aplicarAbonoCapitalInversionistas` marca `capital_validated` (con `fecha_aplicado` GT).
- **Cuota** (sibling query, `cuotaCompleta`): siguen filtrando `validated`/`pending` → abonos a capital **fuera** → destraba la cuota. *(sin cambio, excluyen el nuevo enum por construcción)*
- **Incluir** (`esPagoAplicado` = `validated`|`capital_validated`, helper en `utils/paymentStatus.ts`): `reports` (estado de cuenta + detector abono capital), `reversePayment`, `revalidatePayment`, `cofidi` (gate facturación), `payments` (guard re-validación).
- **`getAbonosPorCuota`**: excluye `capital`/`capital_validated` + `paymentFalse` → `/abonos-cuota/.../5` deja de mostrar el abono a capital.
- **Front** (`carteraFront`): `capital_validated` tratado como validado en `paymentsTable`/`cardInfo`/`hooks` + opción de filtro "Capital Aplicado".

### Verificado en local (dump prod) tras migrar `136149` → `capital_validated`
- Sibling query cuota 5 → **vacío** → faltante = 1,793.40 → **cuota destrabada**.
- `/abonos-cuota` cuota 5 → **sin los 20k**.
- Reportes → **siguen contando** el abono (`capital_validated`, 20000).
- 28 tests verde · `tsc` 0 errores.

### Pasos en PROD (al desplegar)
1. Correr `drizzle/0012_add_capital_validated_enum.sql` (`ALTER TYPE … ADD VALUE`, suelto, no en transacción con uso).
2. `UPDATE cartera.pagos_credito SET validation_status='capital_validated' WHERE pago_id=136149 AND validation_status='validated';` (backfill solo este pago, por decisión).

### Notas
- Conservador: sitios de **contexto-cuota** que suman/cuentan `validated` (saldo vigente :855/867, distribución :2321, `reversePaymentPolicy`, `revalidatePayment`:87 cálculo de capital) **se dejan** filtrando solo `validated` → los abonos a capital quedan correctamente fuera de la lógica de cuota.
