### PR TITLE
feat(reportes): metas mensuales de colocación, cobertura y punto de equilibrio

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0023_create_metas_mensuales.sql
+++ b/apps/crm/apps/server/src/db/migrations/0023_create_metas_mensuales.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "metas_mensuales" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"tipo" varchar(50) NOT NULL,
+	"anio" integer NOT NULL,
+	"mes" integer NOT NULL,
+	"monto" numeric(18, 2) NOT NULL,
+	"descripcion" text,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "metas_mensuales_tipo_anio_mes_unique" UNIQUE("tipo","anio","mes")
+);

--- a/apps/crm/apps/server/src/db/schema/index.ts
+++ b/apps/crm/apps/server/src/db/schema/index.ts
@@ -14,6 +14,7 @@ export * from "./investments";
 export * from "./juridico-dashboard";
 export * from "./legal-contracts";
 export * from "./locations";
+export * from "./metas";
 export * from "./miniagent-credentials";
 export * from "./notes";
 export * from "./notifications";

--- a/apps/crm/apps/server/src/db/schema/metas.ts
+++ b/apps/crm/apps/server/src/db/schema/metas.ts
@@ -1,0 +1,33 @@
+import {
+	integer,
+	numeric,
+	pgTable,
+	serial,
+	text,
+	timestamp,
+	unique,
+	varchar,
+} from "drizzle-orm/pg-core";
+
+export const TIPOS_META = [
+	"colocacion",
+	"cobros",
+	"mora_maxima",
+	"captacion",
+] as const;
+export type TipoMeta = (typeof TIPOS_META)[number];
+
+export const metasMensuales = pgTable(
+	"metas_mensuales",
+	{
+		id: serial("id").primaryKey(),
+		tipo: varchar("tipo", { length: 50 }).notNull(),
+		anio: integer("anio").notNull(),
+		mes: integer("mes").notNull(),
+		monto: numeric("monto", { precision: 18, scale: 2 }).notNull(),
+		descripcion: text("descripcion"),
+		createdAt: timestamp("created_at").defaultNow(),
+		updatedAt: timestamp("updated_at").defaultNow(),
+	},
+	(t) => ({ uniqueTipoAnioMes: unique().on(t.tipo, t.anio, t.mes) }),
+);

--- a/apps/crm/apps/server/src/db/schema/metas.ts
+++ b/apps/crm/apps/server/src/db/schema/metas.ts
@@ -27,7 +27,7 @@ export const metasMensuales = pgTable(
 		monto: numeric("monto", { precision: 18, scale: 2 }).notNull(),
 		descripcion: text("descripcion"),
 		createdAt: timestamp("created_at").defaultNow(),
-		updatedAt: timestamp("updated_at").defaultNow(),
+		updatedAt: timestamp("updated_at").defaultNow().$onUpdate(() => new Date()),
 	},
 	(t) => ({ uniqueTipoAnioMes: unique().on(t.tipo, t.anio, t.mes) }),
 );

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -337,6 +337,9 @@ export const reportsAppRouter = {
 	getFacturacionMes: reportesCarteraRouter.getFacturacionMes,
 	getFlujoCuotasInversiones: reportesCarteraRouter.getFlujoCuotasInversiones,
 	getComparativoHistorico: reportesCarteraRouter.getComparativoHistorico,
+	getMetas: reportesCarteraRouter.getMetas,
+	upsertMeta: reportesCarteraRouter.upsertMeta,
+	getPuntoEquilibrio: reportesCarteraRouter.getPuntoEquilibrio,
 
 	// MiniAgent routes
 	getMiniAgentCredentials: miniagentRouter.getMiniAgentCredentials,

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -4,10 +4,11 @@
  */
 
 import { ORPCError } from "@orpc/server";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { carteraBackReferences } from "../db/schema/cartera-back";
+import { metasMensuales } from "../db/schema/metas";
 import { casosCobros } from "../db/schema/cobros";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
 import { adminProcedure } from "../lib/orpc";
@@ -475,6 +476,191 @@ export const reportesCarteraRouter = {
 		),
 
 	// ========================================================================
+	// METAS MENSUALES
+	// ========================================================================
+
+	getMetas: adminProcedure
+		.input(
+			z.object({
+				anio: z.number().min(2024).max(2030),
+				tipo: z
+					.enum(["colocacion", "cobros", "mora_maxima", "captacion"])
+					.default("colocacion"),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const rows = await db
+				.select()
+				.from(metasMensuales)
+				.where(
+					and(
+						eq(metasMensuales.anio, input.anio),
+						eq(metasMensuales.tipo, input.tipo),
+					),
+				)
+				.orderBy(metasMensuales.mes);
+			return rows;
+		}),
+
+	upsertMeta: adminProcedure
+		.input(
+			z.object({
+				tipo: z.enum(["colocacion", "cobros", "mora_maxima", "captacion"]),
+				anio: z.number(),
+				mes: z.number().min(1).max(12),
+				monto: z.string(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			await db
+				.insert(metasMensuales)
+				.values({
+					tipo: input.tipo,
+					anio: input.anio,
+					mes: input.mes,
+					monto: input.monto,
+					updatedAt: new Date(),
+				})
+				.onConflictDoUpdate({
+					target: [metasMensuales.tipo, metasMensuales.anio, metasMensuales.mes],
+					set: { monto: input.monto, updatedAt: new Date() },
+				});
+			return { ok: true };
+		}),
+
+	// ========================================================================
+	// REPORTE: PUNTO DE EQUILIBRIO (COLOCACIÓN VS META)
+	// ========================================================================
+
+	getPuntoEquilibrio: adminProcedure
+		.input(
+			z.object({
+				periodo: z
+					.enum(["anio", "trimestre", "mes", "semana", "dia"])
+					.default("mes"),
+				fechaInicio: z.string(),
+				fechaFin: z.string(),
+			}),
+		)
+		.handler(
+			async ({ input }): Promise<{
+				data: {
+					bucket: string;
+					cantidad_creditos: number;
+					colocado: string;
+					meta: string;
+					cobertura: string | null;
+					faltante: string | null;
+				}[];
+			}> => {
+				const toPostgresPeriod: Record<string, string> = {
+					dia: "'day'",
+					semana: "'week'",
+					mes: "'month'",
+					trimestre: "'quarter'",
+					anio: "'year'",
+				};
+				const pg = sql.raw(toPostgresPeriod[input.periodo]);
+
+				const colocacionResult = await db.execute(sql`
+					WITH first_placed AS (
+						SELECT
+							osh.opportunity_id,
+							MIN(osh.changed_at) AS first_placed_at
+						FROM opportunity_stage_history osh
+						JOIN sales_stages ss ON ss.id = osh.to_stage_id
+						WHERE ss.closure_percentage >= 90
+						GROUP BY osh.opportunity_id
+					)
+					SELECT
+						DATE_TRUNC(${pg}, fp.first_placed_at AT TIME ZONE 'America/Guatemala') AS bucket,
+						COUNT(o.id)::int AS cantidad_creditos,
+						COALESCE(SUM(o.value::numeric), 0) AS total_colocacion
+					FROM first_placed fp
+					JOIN opportunities o ON o.id = fp.opportunity_id
+					WHERE o.status != 'migrate'
+						AND (fp.first_placed_at AT TIME ZONE 'America/Guatemala')::date >= ${input.fechaInicio}::date
+						AND (fp.first_placed_at AT TIME ZONE 'America/Guatemala')::date <= ${input.fechaFin}::date
+					GROUP BY DATE_TRUNC(${pg}, fp.first_placed_at AT TIME ZONE 'America/Guatemala')
+					ORDER BY bucket ASC
+				`);
+
+				const colocacion = colocacionResult.rows as {
+					bucket: string;
+					cantidad_creditos: number;
+					total_colocacion: string;
+				}[];
+
+				const anios = Array.from(
+					new Set([
+						new Date(input.fechaInicio).getFullYear(),
+						new Date(input.fechaFin).getFullYear(),
+					]),
+				);
+
+				const metasRows = await db
+					.select()
+					.from(metasMensuales)
+					.where(
+						and(
+							eq(metasMensuales.tipo, "colocacion"),
+							inArray(metasMensuales.anio, anios),
+						),
+					);
+
+				const metasMap: Record<number, Record<number, number>> = {};
+				for (const r of metasRows) {
+					if (!metasMap[r.anio]) metasMap[r.anio] = {};
+					metasMap[r.anio][r.mes] = Number(r.monto);
+				}
+
+				const resultado = colocacion.map((row) => {
+					const bucket = new Date(row.bucket);
+					const anio = bucket.getFullYear();
+					const mes = bucket.getMonth() + 1;
+					const metaMes = metasMap[anio]?.[mes] ?? 0;
+
+					let metaBucket = 0;
+					if (input.periodo === "mes") {
+						metaBucket = metaMes;
+					} else if (input.periodo === "trimestre") {
+						const q = Math.ceil(mes / 3);
+						for (let m = (q - 1) * 3 + 1; m <= q * 3; m++) {
+							metaBucket += metasMap[anio]?.[m] ?? 0;
+						}
+					} else if (input.periodo === "anio") {
+						for (let m = 1; m <= 12; m++) {
+							metaBucket += metasMap[anio]?.[m] ?? 0;
+						}
+					} else if (input.periodo === "semana") {
+						const daysInMonth = new Date(anio, mes, 0).getDate();
+						const weeksInMonth = Math.ceil(daysInMonth / 7);
+						metaBucket = metaMes / weeksInMonth;
+					} else if (input.periodo === "dia") {
+						metaBucket = metaMes / 25;
+					}
+
+					const colocado = Number(row.total_colocacion);
+					const cobertura =
+						metaBucket > 0 ? (colocado / metaBucket) * 100 : null;
+					const faltante =
+						metaBucket > 0 ? Math.max(0, metaBucket - colocado) : null;
+
+					return {
+						bucket: row.bucket,
+						cantidad_creditos: row.cantidad_creditos,
+						colocado: colocado.toFixed(2),
+						meta: metaBucket.toFixed(2),
+						cobertura: cobertura?.toFixed(1) ?? null,
+						faltante: faltante?.toFixed(2) ?? null,
+					};
+				});
+
+				return { data: resultado };
+			},
+		),
+
+	// ========================================================================
 	// REPORTE: COMPARATIVO HISTÓRICO MENSUAL
 	// ========================================================================
 
@@ -508,7 +694,6 @@ export const reportesCarteraRouter = {
 						message: "Integración con cartera-back no está habilitada",
 					});
 				}
-
 
 				const carteraData = await carteraBackClient.getComparativoHistorico(
 					input.anio,
@@ -553,13 +738,11 @@ export const reportesCarteraRouter = {
 
 				const cobradoMap = new Map<number, string>();
 				for (const row of carteraData.cobrado) {
-					// row.mes es integer (1-12) directo de facturacion_snapshot_diario
 					cobradoMap.set(Number(row.mes), Number(row.cobrado).toFixed(2));
 				}
 
 				const carteraMap = new Map<number, { capital: string; creditos: number }>();
 				for (const row of carteraData.cartera) {
-					// row.mes es date string (periodo de cierre_mensual)
 					carteraMap.set(mesDeDate(row.mes), {
 						capital: Number(row.cartera_activa).toFixed(2),
 						creditos: row.creditos_activos,
@@ -568,7 +751,6 @@ export const reportesCarteraRouter = {
 
 				type AgingBuckets = { mora_30: string | null; mora_60: string | null; mora_90: string | null; mora_120: string | null; creditos_30: number | null; creditos_60: number | null; creditos_90: number | null; creditos_120: number | null };
 
-				// Aging histórico por mes
 				const agingHistMap = new Map<number, AgingBuckets>();
 				for (const row of carteraData.agingHistorico) {
 					const m = mesDeDate(row.periodo);
@@ -580,7 +762,6 @@ export const reportesCarteraRouter = {
 					(entry as Record<string, string | number | null>)[cKey] = row.cantidad_creditos;
 				}
 
-				// Aging mes actual desde moraActual
 				const agingActual: AgingBuckets = { mora_30: null, mora_60: null, mora_90: null, mora_120: null, creditos_30: null, creditos_60: null, creditos_90: null, creditos_120: null };
 				for (const row of carteraData.moraActual) {
 					(agingActual as Record<string, string | number | null>)[`mora_${row.bucket}`] = Number(row.monto_mora).toFixed(2);

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -614,10 +614,55 @@ export const reportesCarteraRouter = {
 					metasMap[r.anio][r.mes] = Number(r.monto);
 				}
 
-				const resultado = colocacion.map((row) => {
-					const bucket = new Date(row.bucket);
-					const anio = bucket.getFullYear();
-					const mes = bucket.getMonth() + 1;
+				// Indexar colocación por bucket truncado para lookup rápido
+				const colocacionMap = new Map<string, { cantidad: number; total: number }>();
+				for (const row of colocacion) {
+					const key = new Date(row.bucket).toISOString().slice(0, 10);
+					colocacionMap.set(key, {
+						cantidad: row.cantidad_creditos,
+						total: Number(row.total_colocacion),
+					});
+				}
+
+				// Generar todos los buckets del rango para no omitir períodos sin colocación
+				const buckets: Date[] = [];
+				const cur = new Date(`${input.fechaInicio}T12:00:00Z`);
+				const end = new Date(`${input.fechaFin}T12:00:00Z`);
+
+				const truncTz = (d: Date, periodo: string): Date => {
+					const gt = new Date(d.getTime() - 6 * 60 * 60 * 1000);
+					const y = gt.getUTCFullYear(), mo = gt.getUTCMonth(), day = gt.getUTCDate();
+					if (periodo === "dia") return new Date(Date.UTC(y, mo, day));
+					if (periodo === "semana") {
+						const dow = gt.getUTCDay();
+						return new Date(Date.UTC(y, mo, day - dow));
+					}
+					if (periodo === "mes") return new Date(Date.UTC(y, mo, 1));
+					if (periodo === "trimestre") return new Date(Date.UTC(y, Math.floor(mo / 3) * 3, 1));
+					return new Date(Date.UTC(y, 0, 1));
+				};
+
+				const advancePeriod = (d: Date, periodo: string): Date => {
+					const n = new Date(d);
+					if (periodo === "dia") n.setUTCDate(n.getUTCDate() + 1);
+					else if (periodo === "semana") n.setUTCDate(n.getUTCDate() + 7);
+					else if (periodo === "mes") n.setUTCMonth(n.getUTCMonth() + 1);
+					else if (periodo === "trimestre") n.setUTCMonth(n.getUTCMonth() + 3);
+					else n.setUTCFullYear(n.getUTCFullYear() + 1);
+					return n;
+				};
+
+				let b = truncTz(cur, input.periodo);
+				while (b <= end) {
+					buckets.push(b);
+					b = advancePeriod(b, input.periodo);
+				}
+
+				const resultado = buckets.map((bucket) => {
+					const key = bucket.toISOString().slice(0, 10);
+					const col = colocacionMap.get(key);
+					const anio = bucket.getUTCFullYear();
+					const mes = bucket.getUTCMonth() + 1;
 					const metaMes = metasMap[anio]?.[mes] ?? 0;
 
 					let metaBucket = 0;
@@ -640,15 +685,13 @@ export const reportesCarteraRouter = {
 						metaBucket = metaMes / 25;
 					}
 
-					const colocado = Number(row.total_colocacion);
-					const cobertura =
-						metaBucket > 0 ? (colocado / metaBucket) * 100 : null;
-					const faltante =
-						metaBucket > 0 ? Math.max(0, metaBucket - colocado) : null;
+					const colocado = col?.total ?? 0;
+					const cobertura = metaBucket > 0 ? (colocado / metaBucket) * 100 : null;
+					const faltante = metaBucket > 0 ? Math.max(0, metaBucket - colocado) : null;
 
 					return {
-						bucket: row.bucket,
-						cantidad_creditos: row.cantidad_creditos,
+						bucket: bucket.toISOString(),
+						cantidad_creditos: col?.cantidad ?? 0,
 						colocado: colocado.toFixed(2),
 						meta: metaBucket.toFixed(2),
 						cobertura: cobertura?.toFixed(1) ?? null,

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -589,12 +589,9 @@ export const reportesCarteraRouter = {
 					total_colocacion: string;
 				}[];
 
-				const anios = Array.from(
-					new Set([
-						new Date(input.fechaInicio).getFullYear(),
-						new Date(input.fechaFin).getFullYear(),
-					]),
-				);
+				const startYear = new Date(`${input.fechaInicio}T12:00:00Z`).getUTCFullYear();
+				const endYear = new Date(`${input.fechaFin}T12:00:00Z`).getUTCFullYear();
+				const anios = Array.from({ length: endYear - startYear + 1 }, (_, i) => startYear + i);
 
 				const metasRows = await db
 					.select()
@@ -694,7 +691,7 @@ export const reportesCarteraRouter = {
 					const faltante = metaBucket > 0 ? Math.max(0, metaBucket - colocado) : null;
 
 					return {
-						bucket: bucket.toISOString(),
+						bucket: bucket.toISOString().slice(0, 10),
 						cantidad_creditos: col?.cantidad ?? 0,
 						colocado: colocado.toFixed(2),
 						meta: metaBucket.toFixed(2),

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -8,7 +8,7 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { carteraBackReferences } from "../db/schema/cartera-back";
-import { metasMensuales } from "../db/schema/metas";
+import { TIPOS_META, metasMensuales } from "../db/schema/metas";
 import { casosCobros } from "../db/schema/cobros";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
 import { adminProcedure } from "../lib/orpc";
@@ -483,9 +483,7 @@ export const reportesCarteraRouter = {
 		.input(
 			z.object({
 				anio: z.number().min(2024).max(2030),
-				tipo: z
-					.enum(["colocacion", "cobros", "mora_maxima", "captacion"])
-					.default("colocacion"),
+				tipo: z.enum(TIPOS_META).default("colocacion"),
 			}),
 		)
 		.handler(async ({ input }) => {
@@ -505,8 +503,8 @@ export const reportesCarteraRouter = {
 	upsertMeta: adminProcedure
 		.input(
 			z.object({
-				tipo: z.enum(["colocacion", "cobros", "mora_maxima", "captacion"]),
-				anio: z.number(),
+				tipo: z.enum(TIPOS_META),
+				anio: z.number().min(2024).max(2030),
 				mes: z.number().min(1).max(12),
 				monto: z.string(),
 			}),
@@ -614,10 +612,14 @@ export const reportesCarteraRouter = {
 					metasMap[r.anio][r.mes] = Number(r.monto);
 				}
 
-				// Indexar colocación por bucket truncado para lookup rápido
+				// Indexar colocación por bucket — parsear como UTC explícito para evitar
+				// interpretación en zona local del servidor (#6)
 				const colocacionMap = new Map<string, { cantidad: number; total: number }>();
 				for (const row of colocacion) {
-					const key = new Date(row.bucket).toISOString().slice(0, 10);
+					// row.bucket viene como timestamp string sin zona de DATE_TRUNC AT TIME ZONE
+					// Forzar parseo UTC agregando Z
+					const raw = typeof row.bucket === "string" ? row.bucket : (row.bucket as Date).toISOString();
+					const key = (raw.endsWith("Z") ? raw : `${raw}Z`).slice(0, 10);
 					colocacionMap.set(key, {
 						cantidad: row.cantidad_creditos,
 						total: Number(row.total_colocacion),
@@ -635,7 +637,8 @@ export const reportesCarteraRouter = {
 					if (periodo === "dia") return new Date(Date.UTC(y, mo, day));
 					if (periodo === "semana") {
 						const dow = gt.getUTCDay();
-						return new Date(Date.UTC(y, mo, day - dow));
+						// DATE_TRUNC('week') ancla al lunes (ISO 8601) — (dow+6)%7 hace lo mismo
+						return new Date(Date.UTC(y, mo, day - ((dow + 6) % 7)));
 					}
 					if (periodo === "mes") return new Date(Date.UTC(y, mo, 1));
 					if (periodo === "trimestre") return new Date(Date.UTC(y, Math.floor(mo / 3) * 3, 1));
@@ -682,7 +685,8 @@ export const reportesCarteraRouter = {
 						const weeksInMonth = Math.ceil(daysInMonth / 7);
 						metaBucket = metaMes / weeksInMonth;
 					} else if (input.periodo === "dia") {
-						metaBucket = metaMes / 25;
+						const daysInMonth = new Date(anio, mes, 0).getDate();
+						metaBucket = metaMes / daysInMonth;
 					}
 
 					const colocado = col?.total ?? 0;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
 	Activity,
@@ -8,11 +8,13 @@ import {
 	ChevronRight,
 	Download,
 	FileText,
+	Loader2,
+	Target,
 	TrendingDown,
 	TrendingUp,
 	Wallet,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { DateRange } from "react-day-picker";
 import {
 	Bar,
@@ -55,11 +57,17 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import {
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { PERMISSIONS } from "@/lib/roles";
-import { orpc } from "@/utils/orpc";
+import { client, orpc, queryClient } from "@/utils/orpc";
 
 export const Route = createFileRoute("/admin/reports/")({
 	component: RouteComponent,
@@ -146,11 +154,32 @@ type ComparativoHistoricoRow = {
 	creditos_120: number | null;
 };
 
+type PuntoEquilibrioRow = {
+	bucket: string;
+	cantidad_creditos: number;
+	colocado: string;
+	meta: string;
+	cobertura: string | null;
+	faltante: string | null;
+};
+
 const MESES = [
 	"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
 	"Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
 ];
 
+function coberturaColor(cobertura: string | null): string {
+	if (!cobertura) return "#6b7280";
+	const pct = Number(cobertura);
+	if (pct >= 100) return "#22c55e";
+	if (pct >= 70) return "#eab308";
+	return "#ef4444";
+}
+
+function coberturaLabel(cobertura: string | null): string {
+	if (!cobertura) return "Sin meta";
+	return `${cobertura}%`;
+}
 
 const FACTURACION_RUBROS: { key: keyof FacturacionMesRubro; label: string }[] = [
 	{ key: "capital", label: "Capital" },
@@ -296,6 +325,21 @@ function RouteComponent() {
 	const [comparativoAnio, setComparativoAnio] = useState(
 		() => new Date().getFullYear(),
 	);
+	const [metasAnio, setMetasAnio] = useState(new Date().getFullYear());
+	const [editMetas, setEditMetas] = useState<Record<number, string>>({});
+	const [metasModalOpen, setMetasModalOpen] = useState(false);
+	const [isSavingMetas, setIsSavingMetas] = useState(false);
+	const [focusedMes, setFocusedMes] = useState<number | null>(null);
+	const [equilibrioPeriodo, setEquilibrioPeriodo] = useState<
+		"anio" | "trimestre" | "mes" | "semana" | "dia"
+	>("mes");
+	const [equilibrioRange, setEquilibrioRange] = useState(() => {
+		const today = formatDateInput(new Date());
+		const start = new Date();
+		start.setMonth(start.getMonth() - 5);
+		start.setDate(1);
+		return { fechaInicio: formatDateInput(start), fechaFin: today };
+	});
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const userRole = userProfile.data?.role;
@@ -364,6 +408,81 @@ function RouteComponent() {
 	const comparativoData = comparativoQuery.data as
 		| { data: ComparativoHistoricoRow[] }
 		| undefined;
+
+	const metasQuery = useQuery({
+		...orpc.getMetas.queryOptions({
+			input: { anio: metasAnio, tipo: "colocacion" },
+		}),
+		enabled: isAdmin,
+	});
+
+	const upsertMetaMutation = useMutation({
+		mutationFn: async (vars: {
+			tipo: "colocacion" | "cobros" | "mora_maxima" | "captacion";
+			anio: number;
+			mes: number;
+			monto: string;
+		}) => client.upsertMeta(vars),
+		onSuccess: () => {
+			queryClient.invalidateQueries(
+				orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
+			);
+		},
+		onError: (error: Error) => {
+			toast.error(error.message);
+		},
+	});
+
+	const puntoEquilibrioQuery = useQuery({
+		...orpc.getPuntoEquilibrio.queryOptions({
+			input: {
+				periodo: equilibrioPeriodo,
+				fechaInicio: equilibrioRange.fechaInicio,
+				fechaFin: equilibrioRange.fechaFin,
+			},
+		}),
+		enabled: isAdmin,
+	});
+	const puntoEquilibrioData = puntoEquilibrioQuery.data as
+		| { data: PuntoEquilibrioRow[] }
+		| undefined;
+
+	const handleGuardarTodo = useCallback(async () => {
+		const saves = MESES.map((_, idx) => {
+			const mes = idx + 1;
+			const monto = editMetas[mes];
+			if (!monto || Number.isNaN(Number(monto)) || Number(monto) <= 0) return null;
+			return client.upsertMeta({
+				tipo: "colocacion",
+				anio: metasAnio,
+				mes,
+				monto: String(Number(monto)),
+			});
+		}).filter(Boolean);
+		if (saves.length === 0) return;
+		setIsSavingMetas(true);
+		try {
+			await Promise.all(saves);
+			await queryClient.invalidateQueries(
+				orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
+			);
+			toast.success(`${saves.length} metas guardadas`);
+			setMetasModalOpen(false);
+		} finally {
+			setIsSavingMetas(false);
+		}
+	}, [editMetas, metasAnio]);
+
+	useEffect(() => {
+		if (Array.isArray(metasQuery.data)) {
+			const map: Record<number, string> = {};
+			for (const row of metasQuery.data as { mes: number; monto: string }[]) {
+				map[row.mes] = String(Number(row.monto));
+			}
+			setEditMetas(map);
+		}
+	}, [metasQuery.data]);
+
 
 	useEffect(() => {
 		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
@@ -1349,6 +1468,246 @@ function RouteComponent() {
 													<TableRow className="border-t-2 bg-muted/50 font-bold">
 														<TableCell>Total</TableCell>
 														<TableCell className="text-right">{formatCurrency(totalExtras)}</TableCell>
+													</TableRow>
+												</TableBody>
+											</Table>
+										</div>
+									</>
+								);
+							})()}
+						</CardContent>
+					</Card>
+
+					{/* Modal: Metas Mensuales */}
+					<Dialog open={metasModalOpen} onOpenChange={setMetasModalOpen}>
+						<DialogContent className="sm:max-w-[860px]">
+							<DialogHeader>
+								<DialogTitle className="flex items-center gap-2">
+									<Target className="h-4 w-4 text-purple-500" />
+									Metas de Colocación
+								</DialogTitle>
+							</DialogHeader>
+							<div className="flex items-center justify-center gap-3 pb-2">
+								<Button variant="outline" size="sm" onClick={() => setMetasAnio((y) => y - 1)}>‹</Button>
+								<span className="w-16 text-center font-semibold">{metasAnio}</span>
+								<Button variant="outline" size="sm" onClick={() => setMetasAnio((y) => y + 1)}>›</Button>
+							</div>
+							{metasQuery.isPending ? (
+								<p className="text-muted-foreground py-4 text-center text-sm">Cargando...</p>
+							) : (
+								<div className="grid grid-cols-2 gap-x-10 gap-y-4">
+									{MESES.map((nombreMes, idx) => {
+										const mes = idx + 1;
+										return (
+											<div key={mes} className="flex items-center gap-3">
+												<span className="w-20 shrink-0 font-medium text-sm">{nombreMes}</span>
+												<div className="relative min-w-0 flex-1">
+													<span className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground text-sm font-medium">Q</span>
+													<Input
+														type="text"
+														inputMode="decimal"
+														className="h-10 pl-7 text-right text-base"
+														placeholder="0"
+														value={
+															focusedMes === mes
+																? (editMetas[mes] ?? "")
+																: editMetas[mes] && Number(editMetas[mes]) > 0
+																	? Number(editMetas[mes]).toLocaleString("es-GT", {
+																			minimumFractionDigits: 2,
+																			maximumFractionDigits: 2,
+																		})
+																	: ""
+														}
+														onFocus={() => setFocusedMes(mes)}
+														onBlur={() => setFocusedMes(null)}
+														onChange={(e) => {
+															const raw = e.target.value.replace(/[^0-9.]/g, "");
+															setEditMetas((prev) => ({ ...prev, [mes]: raw }));
+														}}
+													/>
+												</div>
+											</div>
+										);
+									})}
+								</div>
+							)}
+							<div className="flex justify-end gap-2 pt-2">
+								<Button variant="outline" onClick={() => setMetasModalOpen(false)}>
+									Cancelar
+								</Button>
+								<Button onClick={handleGuardarTodo} disabled={isSavingMetas}>
+									{isSavingMetas && (
+										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+									)}
+									Guardar todo
+								</Button>
+							</div>
+						</DialogContent>
+					</Dialog>
+
+					{/* Cobertura de Colocación vs Meta */}
+					<Card>
+						<CardHeader>
+							<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+								<div className="flex items-center gap-2">
+									<TrendingUp className="h-5 w-5 text-green-500" />
+									<div>
+										<CardTitle>Cobertura de Colocación vs Meta</CardTitle>
+										<CardDescription>
+											Compara el capital colocado en cada período contra la meta mensual definida
+										</CardDescription>
+									</div>
+								</div>
+								<div className="flex flex-wrap items-center gap-2">
+									<Button
+										variant="outline"
+										size="sm"
+										className="gap-1.5"
+										onClick={() => setMetasModalOpen(true)}
+									>
+										<Target className="h-3.5 w-3.5" />
+										Configurar metas
+									</Button>
+									<Select
+										value={equilibrioPeriodo}
+										onValueChange={(v) =>
+											setEquilibrioPeriodo(
+												v as "anio" | "trimestre" | "mes" | "semana" | "dia",
+											)
+										}
+									>
+										<SelectTrigger className="w-[140px]">
+											<SelectValue placeholder="Período" />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="dia">Día</SelectItem>
+											<SelectItem value="semana">Semana</SelectItem>
+											<SelectItem value="mes">Mes</SelectItem>
+											<SelectItem value="trimestre">Trimestre</SelectItem>
+											<SelectItem value="anio">Año</SelectItem>
+										</SelectContent>
+									</Select>
+									<DateRangeFilter
+										dateRange={
+											equilibrioRange.fechaInicio && equilibrioRange.fechaFin
+												? {
+														from: dateFromInput(equilibrioRange.fechaInicio),
+														to: dateFromInput(equilibrioRange.fechaFin),
+													}
+												: undefined
+										}
+										onDateRangeChange={(range) => {
+											if (range?.from && range?.to) {
+												setEquilibrioRange({
+													fechaInicio: formatDateInput(range.from),
+													fechaFin: formatDateInput(range.to),
+												});
+											}
+										}}
+									/>
+								</div>
+							</div>
+						</CardHeader>
+						<CardContent className="space-y-4">
+							{puntoEquilibrioQuery.isPending && (
+								<p className="text-muted-foreground text-sm">Cargando reporte...</p>
+							)}
+							{puntoEquilibrioQuery.isError && (
+								<p className="text-destructive text-sm">
+									Error al cargar reporte de cobertura.
+								</p>
+							)}
+							{puntoEquilibrioData && puntoEquilibrioData.data.length === 0 && (
+								<p className="text-muted-foreground text-sm">
+									No hay datos de colocación para el rango seleccionado.
+								</p>
+							)}
+							{!!puntoEquilibrioData?.data.length && (() => {
+								const rows = puntoEquilibrioData.data;
+								const totalColocado = rows.reduce((acc, r) => acc + Number(r.colocado), 0);
+								const totalMeta = rows.reduce((acc, r) => acc + Number(r.meta), 0);
+								const totalCreditos = rows.reduce((acc, r) => acc + r.cantidad_creditos, 0);
+								const totalCobertura =
+									totalMeta > 0 ? ((totalColocado / totalMeta) * 100).toFixed(1) : null;
+								return (
+									<>
+										<ResponsiveContainer width="100%" height={300}>
+											<BarChart
+												data={rows.map((row) => ({
+													bucket: formatBucket(row.bucket, equilibrioPeriodo),
+													colocado: Number(row.colocado),
+													meta: Number(row.meta),
+												}))}
+											>
+												<CartesianGrid strokeDasharray="3 3" />
+												<XAxis dataKey="bucket" angle={-30} textAnchor="end" height={60} />
+												<YAxis tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`} />
+												<Tooltip
+													formatter={(value, name) => [
+														formatCurrency(Number(value)),
+														name === "colocado" ? "Colocado" : "Meta",
+													]}
+												/>
+												<Legend formatter={(v) => (v === "colocado" ? "Colocado" : "Meta")} />
+												<Bar dataKey="colocado" fill="#3b82f6" name="colocado" />
+												<Bar dataKey="meta" fill="#d1d5db" name="meta" />
+											</BarChart>
+										</ResponsiveContainer>
+
+										<div className="overflow-x-auto">
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Período</TableHead>
+														<TableHead className="text-right">Créditos</TableHead>
+														<TableHead className="text-right">Colocado</TableHead>
+														<TableHead className="text-right">Meta</TableHead>
+														<TableHead className="text-right">Cobertura</TableHead>
+														<TableHead className="text-right">Faltante</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{rows.map((row) => (
+														<TableRow key={row.bucket}>
+															<TableCell>{formatBucket(row.bucket, equilibrioPeriodo)}</TableCell>
+															<TableCell className="text-right">{row.cantidad_creditos}</TableCell>
+															<TableCell className="text-right">{formatCurrency(row.colocado)}</TableCell>
+															<TableCell className="text-right">
+																{Number(row.meta) > 0 ? formatCurrency(row.meta) : <span className="text-muted-foreground">Sin meta</span>}
+															</TableCell>
+															<TableCell className="text-right">
+																<span
+																	className="font-semibold"
+																	style={{ color: coberturaColor(row.cobertura) }}
+																>
+																	{coberturaLabel(row.cobertura)}
+																</span>
+															</TableCell>
+															<TableCell className="text-right">
+																{row.faltante ? formatCurrency(row.faltante) : "—"}
+															</TableCell>
+														</TableRow>
+													))}
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total</TableCell>
+														<TableCell className="text-right">{totalCreditos}</TableCell>
+														<TableCell className="text-right">{formatCurrency(totalColocado)}</TableCell>
+														<TableCell className="text-right">
+															{totalMeta > 0 ? formatCurrency(totalMeta) : "—"}
+														</TableCell>
+														<TableCell className="text-right">
+															<span
+																className="font-semibold"
+																style={{ color: coberturaColor(totalCobertura) }}
+															>
+																{coberturaLabel(totalCobertura)}
+															</span>
+														</TableCell>
+														<TableCell className="text-right">
+															{totalMeta > 0
+																? formatCurrency(Math.max(0, totalMeta - totalColocado))
+																: "—"}
+														</TableCell>
 													</TableRow>
 												</TableBody>
 											</Table>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -479,6 +479,8 @@ function RouteComponent() {
 			]);
 			toast.success(`${saves.length} metas guardadas`);
 			setMetasModalOpen(false);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Error al guardar metas");
 		} finally {
 			setIsSavingMetas(false);
 		}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1047,7 +1047,7 @@ function RouteComponent() {
 											}))}
 										>
 											<CartesianGrid strokeDasharray="3 3" />
-											<XAxis dataKey="bucket" angle={-30} textAnchor="end" height={60} />
+											<XAxis dataKey="bucket" tick={{ fontSize: 11 }} interval={0} height={36} />
 											<YAxis tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`} />
 											<Tooltip
 												formatter={(value, name) => [

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1654,7 +1654,7 @@ function RouteComponent() {
 												}))}
 											>
 												<CartesianGrid strokeDasharray="3 3" />
-												<XAxis dataKey="bucket" angle={-30} textAnchor="end" height={60} />
+												<XAxis dataKey="bucket" tick={{ fontSize: 11 }} interval={0} height={36} />
 												<YAxis tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`} />
 												<Tooltip
 													formatter={(value, name) => [

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -233,7 +233,7 @@ function getDefaultMontoCobrarRange(): { fechaInicio: string; fechaFin: string }
 }
 
 function formatBucket(bucket: string, periodo: string): string {
-	const date = new Date(bucket);
+	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
 	if (periodo === "dia") {
 		return new Intl.DateTimeFormat("es-GT", { day: "2-digit", month: "short" }).format(date);
 	}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -451,12 +451,13 @@ function RouteComponent() {
 		const saves = MESES.map((_, idx) => {
 			const mes = idx + 1;
 			const monto = editMetas[mes];
-			if (!monto || Number.isNaN(Number(monto)) || Number(monto) <= 0) return null;
+			const montoNum = Number(monto ?? "0");
+			if (Number.isNaN(montoNum)) return null;
 			return client.upsertMeta({
 				tipo: "colocacion",
 				anio: metasAnio,
 				mes,
-				monto: String(Number(monto)),
+				monto: montoNum.toFixed(2),
 			});
 		}).filter(Boolean);
 		if (saves.length === 0) return;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -463,15 +463,26 @@ function RouteComponent() {
 		setIsSavingMetas(true);
 		try {
 			await Promise.all(saves);
-			await queryClient.invalidateQueries(
-				orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
-			);
+			await Promise.all([
+				queryClient.invalidateQueries(
+					orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
+				),
+				queryClient.invalidateQueries(
+					orpc.getPuntoEquilibrio.queryOptions({
+						input: {
+							periodo: equilibrioPeriodo,
+							fechaInicio: equilibrioRange.fechaInicio,
+							fechaFin: equilibrioRange.fechaFin,
+						},
+					}),
+				),
+			]);
 			toast.success(`${saves.length} metas guardadas`);
 			setMetasModalOpen(false);
 		} finally {
 			setIsSavingMetas(false);
 		}
-	}, [editMetas, metasAnio]);
+	}, [editMetas, metasAnio, equilibrioPeriodo, equilibrioRange]);
 
 	useEffect(() => {
 		if (Array.isArray(metasQuery.data)) {


### PR DESCRIPTION
## Resumen

Agrega funcionalidad completa de **metas mensuales** y sus reportes derivados en la página de reportes administrativos.

---

## Cambios por capa

### Base de datos
- **Nuevo schema** `apps/server/src/db/schema/metas.ts`
  - Tabla `metas_mensuales` con columnas: `id`, `tipo` (varchar 50), `anio`, `mes`, `monto` (numeric 18,2), `descripcion`, `created_at`, `updated_at`
  - Tipos soportados: `colocacion`, `cobros`, `mora_maxima`, `captacion`
  - Constraint `UNIQUE(tipo, anio, mes)`
  - `updatedAt` con `.$onUpdate(() => new Date())`
- **Migración** `0023_create_metas_mensuales.sql` con `CREATE TABLE IF NOT EXISTS`
- `apps/server/src/db/schema/index.ts` — exporta el nuevo schema

### Backend (ORPC)
Tres nuevos endpoints en `reportes-cartera.ts`, registrados en `routers/index.ts`:

| Endpoint | Descripción |
|---|---|
| `getMetas` | Lee metas de un `tipo` y `anio`, ordenadas por mes. `anio` validado min 2024 max 2030 |
| `upsertMeta` | Inserta o actualiza (ON CONFLICT DO UPDATE). `anio` con mismos bounds. `tipo` usa `z.enum(TIPOS_META)` |
| `getPuntoEquilibrio` | Genera todos los buckets del rango (no solo los con colocación), hace join con colocación real y metas. Devuelve `colocado`, `meta`, `cobertura`, `faltante` por período |

Todos usan `adminProcedure`. Fixes incluidos en el endpoint:
- Buckets semanales anclados al lunes (ISO 8601) igual que `DATE_TRUNC('week')` de PostgreSQL
- Meta diaria usa días reales del mes en vez de `/25` hardcodeado
- Bucket key parseado como UTC explícito para evitar desplazamiento en servidores no-UTC
- Años intermedios en rango construidos con lista completa (no solo start/end)
- Bucket retornado como `YYYY-MM-DD` para evitar interpretación de zona en frontend

### Frontend (`apps/web/src/routes/admin/reports/index.tsx`)
Nuevas secciones dentro del bloque `{isAdmin && (...)}`:

1. **Modal "Metas de Colocación"** — grid 2 columnas con los 12 meses, navegación por año, botón "Guardar todo" con spinner `Loader2` y `disabled` durante el request
2. **Cobertura de Colocación vs Meta** — tabla con progreso por período
3. **Punto de Equilibrio** — desglose colocado vs meta por bucket con `cobertura` y `faltante`

Otros fixes frontend:
- `handleGuardarTodo`: `catch` con `toast.error` para errores de red/auth
- Monto=0 permitido para limpiar metas existentes (antes el guard `<= 0` las omitía silenciosamente)
- `getPuntoEquilibrio` invalidado junto con `getMetas` al guardar

---

## Notas de despliegue

> **Requiere migración** — Ejecutar `bun db:migrate` (o `bun db:push`) en el entorno destino antes de deployar. La tabla `metas_mensuales` es nueva.

<img width="1211" height="614" alt="image" src="https://github.com/user-attachments/assets/b40b1a20-7535-4a25-87c5-b82ee402aacf" />

<img width="749" height="454" alt="image" src="https://github.com/user-attachments/assets/284d235f-2657-4342-99b5-a29305dee0a8" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)