### PR TITLE
feat(carteraFront): mensajes de error descriptivos en cartera part2

### DIFF
--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -10,27 +10,27 @@ const TRADUCCIONES: Array<{
   patron: RegExp;
   traduccion: string | ((match: RegExpExecArray) => string);
 }> = [
-  { patron: /jwt expired/i, traduccion: "tu sesión expiró, vuelve a iniciar sesión" },
+  { patron: /jwt expired/i, traduccion: "Tu sesión expiró, vuelve a iniciar sesión" },
   {
     patron: /jwt|invalid signature|invalid token|token no proporcionado|token inválido/i,
-    traduccion: "tu sesión no es válida, vuelve a iniciar sesión",
+    traduccion: "Tu sesión no es válida, vuelve a iniciar sesión",
   },
   {
     patron: /^Expected /,
-    traduccion: (m) => `uno de los filtros o datos enviados no es válido (${m.input})`,
+    traduccion: (m) => `Uno de los filtros o datos enviados no es válido (${m.input})`,
   },
-  { patron: /payment\s+(\d+)\s+not found/i, traduccion: (m) => `no se encontró el pago ${m[1]}` },
-  { patron: /payment not found/i, traduccion: "no se encontró el pago" },
-  { patron: /credit not found or not active/i, traduccion: "no se encontró el crédito o no está activo" },
-  { patron: /credit not found/i, traduccion: "no se encontró el crédito" },
-  { patron: /user not found/i, traduccion: "no se encontró el usuario" },
+  { patron: /payment\s+(\d+)\s+not found/i, traduccion: (m) => `No se encontró el pago ${m[1]}` },
+  { patron: /payment not found/i, traduccion: "No se encontró el pago" },
+  { patron: /credit not found or not active/i, traduccion: "No se encontró el crédito o no está activo" },
+  { patron: /credit not found/i, traduccion: "No se encontró el crédito" },
+  { patron: /user not found/i, traduccion: "No se encontró el usuario" },
   {
     patron: /validation failed/i,
-    traduccion: "los datos enviados no son válidos, revisa los campos e intenta de nuevo",
+    traduccion: "Los datos enviados no son válidos, revisa los campos e intenta de nuevo",
   },
   {
     patron: /internal server error/i,
-    traduccion: "error interno del servidor, intenta de nuevo o contacta soporte",
+    traduccion: "Error interno del servidor, intenta de nuevo o contacta soporte",
   },
 ];
 
@@ -87,10 +87,10 @@ function esDetalleTecnicoCrudo(detail: string): boolean {
 export function getApiErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof AxiosError) {
     if (error.code === "ECONNABORTED") {
-      return `${fallback}: el servidor tardó demasiado en responder, intenta de nuevo`;
+      return `${fallback}: El servidor tardó demasiado en responder, intenta de nuevo`;
     }
     if (!error.response) {
-      return `${fallback}: sin conexión con el servidor`;
+      return `${fallback}: Sin conexión con el servidor`;
     }
     const { status, data } = error.response;
     let detail: unknown;
@@ -113,10 +113,10 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
       return `${fallback}: ${traducirDetalleTecnico(detail.trim())}`;
     }
     if (status === 401 || status === 403) {
-      return `${fallback}: tu sesión no es válida, vuelve a iniciar sesión`;
+      return `${fallback}: Tu sesión no es válida, vuelve a iniciar sesión`;
     }
     if (status >= 500) {
-      return `${fallback}: error interno del servidor (HTTP ${status})`;
+      return `${fallback}: Error interno del servidor (HTTP ${status})`;
     }
     return `${fallback} (HTTP ${status})`;
   }

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -50,12 +50,31 @@ function traducirDetalleTecnico(detail: string): string {
 
 /**
  * `message` genérico que no aporta información: si el endpoint también
- * manda en `error` un motivo de negocio conocido (con traducción en
- * TRADUCCIONES), se prefiere `error`. Si `error` es un crudo no reconocido
- * (stack de driver, excepción inesperada), NO se promueve: el usuario ve
- * el genérico y el crudo no se filtra a la UI.
+ * manda en `error` un motivo de negocio legible, se prefiere `error`.
+ * Los crudos técnicos (excepción inesperada, driver de DB, stack) se
+ * detectan con DETALLE_TECNICO y NO se promueven: el usuario ve el
+ * genérico y el crudo no se filtra a la UI.
  */
 const MENSAJE_SIN_INFORMACION = /^internal server error$/i;
+
+/**
+ * Firmas de errores técnicos que nunca deben mostrarse al usuario.
+ * Los throws de negocio del backend ("Payment not found", "No se encontró
+ * el pago con id 123") no calzan con ninguna de estas.
+ */
+const DETALLE_TECNICO = [
+  /^\s*\w*(Error|Exception)\s*:/, // "TypeError: ...", "PostgresError: ..."
+  /\bat\s+\S+\s+\(.+\)/, // frame de stack trace
+  /\b(ECONN\w+|ETIMEDOUT|ENOTFOUND|EPIPE|EAI_AGAIN)\b/,
+  /\b(undefined|null|NaN)\b/i,
+  /cannot read|is not a function|is not defined/i,
+  /\b(query|relation|column|constraint|duplicate key|violates|syntax)\b/i,
+  /fetch failed|socket|connection|timeout/i,
+];
+
+function esDetalleTecnicoCrudo(detail: string): boolean {
+  return DETALLE_TECNICO.some((patron) => patron.test(detail));
+}
 
 /**
  * Extrae el motivo real de un error de API para mostrarlo al usuario.
@@ -83,7 +102,9 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
         typeof detail === "string" &&
         MENSAJE_SIN_INFORMACION.test(detail.trim()) &&
         typeof data?.error === "string" &&
-        buscarTraduccion(data.error.trim()) !== null
+        data.error.trim() &&
+        (buscarTraduccion(data.error.trim()) !== null ||
+          !esDetalleTecnicoCrudo(data.error.trim()))
       ) {
         detail = data.error;
       }

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -34,19 +34,26 @@ const TRADUCCIONES: Array<{
   },
 ];
 
-function traducirDetalleTecnico(detail: string): string {
+function buscarTraduccion(detail: string): string | null {
   for (const { patron, traduccion } of TRADUCCIONES) {
     const match = patron.exec(detail);
     if (match) {
       return typeof traduccion === "function" ? traduccion(match) : traduccion;
     }
   }
-  return detail;
+  return null;
+}
+
+function traducirDetalleTecnico(detail: string): string {
+  return buscarTraduccion(detail) ?? detail;
 }
 
 /**
  * `message` genérico que no aporta información: si el endpoint también
- * manda `error` con el motivo real, se prefiere `error`.
+ * manda en `error` un motivo de negocio conocido (con traducción en
+ * TRADUCCIONES), se prefiere `error`. Si `error` es un crudo no reconocido
+ * (stack de driver, excepción inesperada), NO se promueve: el usuario ve
+ * el genérico y el crudo no se filtra a la UI.
  */
 const MENSAJE_SIN_INFORMACION = /^internal server error$/i;
 
@@ -76,7 +83,7 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
         typeof detail === "string" &&
         MENSAJE_SIN_INFORMACION.test(detail.trim()) &&
         typeof data?.error === "string" &&
-        data.error.trim()
+        buscarTraduccion(data.error.trim()) !== null
       ) {
         detail = data.error;
       }

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -1,34 +1,62 @@
 import { AxiosError } from "axios";
 
 /**
- * Traduce mensajes técnicos conocidos (jwt, validación de Elysia, etc.)
- * a texto entendible para el usuario final. Si el mensaje ya es legible
- * (el backend lo mandó en español), se devuelve tal cual.
+ * Traducciones de mensajes técnicos o en inglés conocidos. Se recorre en
+ * orden y gana la primera regla que matchea, así que las reglas específicas
+ * van antes que las generales (p. ej. "credit not found or not active"
+ * antes que "credit not found").
  */
+const TRADUCCIONES: Array<{
+  patron: RegExp;
+  traduccion: string | ((match: RegExpExecArray) => string);
+}> = [
+  { patron: /jwt expired/i, traduccion: "tu sesión expiró, vuelve a iniciar sesión" },
+  {
+    patron: /jwt|invalid signature|invalid token|token no proporcionado|token inválido/i,
+    traduccion: "tu sesión no es válida, vuelve a iniciar sesión",
+  },
+  {
+    patron: /^Expected /,
+    traduccion: (m) => `uno de los filtros o datos enviados no es válido (${m.input})`,
+  },
+  { patron: /payment\s+(\d+)\s+not found/i, traduccion: (m) => `no se encontró el pago ${m[1]}` },
+  { patron: /payment not found/i, traduccion: "no se encontró el pago" },
+  { patron: /credit not found or not active/i, traduccion: "no se encontró el crédito o no está activo" },
+  { patron: /credit not found/i, traduccion: "no se encontró el crédito" },
+  { patron: /user not found/i, traduccion: "no se encontró el usuario" },
+  {
+    patron: /validation failed/i,
+    traduccion: "los datos enviados no son válidos, revisa los campos e intenta de nuevo",
+  },
+  {
+    patron: /internal server error/i,
+    traduccion: "error interno del servidor, intenta de nuevo o contacta soporte",
+  },
+];
+
 function traducirDetalleTecnico(detail: string): string {
-  const d = detail.toLowerCase();
-  if (d.includes("jwt expired")) {
-    return "tu sesión expiró, vuelve a iniciar sesión";
-  }
-  if (
-    d.includes("jwt") ||
-    d.includes("invalid signature") ||
-    d.includes("invalid token") ||
-    d.includes("token no proporcionado") ||
-    d.includes("token inválido")
-  ) {
-    return "tu sesión no es válida, vuelve a iniciar sesión";
-  }
-  if (detail.startsWith("Expected ")) {
-    return `uno de los filtros o datos enviados no es válido (${detail})`;
+  for (const { patron, traduccion } of TRADUCCIONES) {
+    const match = patron.exec(detail);
+    if (match) {
+      return typeof traduccion === "function" ? traduccion(match) : traduccion;
+    }
   }
   return detail;
 }
 
 /**
+ * `message` genérico que no aporta información: si el endpoint también
+ * manda `error` con el motivo real, se prefiere `error`.
+ */
+const MENSAJE_SIN_INFORMACION = /^internal server error$/i;
+
+/**
  * Extrae el motivo real de un error de API para mostrarlo al usuario.
- * El backend devuelve el detalle en `error`, `message` o `mensaje`
- * según el endpoint, por lo que se revisan los tres campos.
+ *
+ * Prioridad de campos: `message` (texto curado de los endpoints) primero;
+ * `error` cuando no hay `message` o cuando este es un genérico sin
+ * información, porque hay endpoints donde los roles están invertidos
+ * (`message: "Internal server error"` y el motivo real en `error`).
  */
 export function getApiErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof AxiosError) {
@@ -39,10 +67,20 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
       return `${fallback}: sin conexión con el servidor`;
     }
     const { status, data } = error.response;
-    const detail =
-      typeof data === "string"
-        ? data
-        : (data?.error ?? data?.message ?? data?.mensaje);
+    let detail: unknown;
+    if (typeof data === "string") {
+      detail = data;
+    } else {
+      detail = data?.message ?? data?.error ?? data?.mensaje;
+      if (
+        typeof detail === "string" &&
+        MENSAJE_SIN_INFORMACION.test(detail.trim()) &&
+        typeof data?.error === "string" &&
+        data.error.trim()
+      ) {
+        detail = data.error;
+      }
+    }
     if (typeof detail === "string" && detail.trim()) {
       return `${fallback}: ${traducirDetalleTecnico(detail.trim())}`;
     }

--- a/apps/carteraFront/src/private/cartera/hooks/account.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/account.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
  
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { getCuentasEmpresaService, type ActualizarCuentaPagoRequest, actualizarCuentaPagoService } from "../services/services";
 
 // 📋 Hook para obtener todas las cuentas de empresa
@@ -38,7 +39,7 @@ export function useActualizarCuentaPago() {
 
     onError: (error) => {
       console.error("❌ Error al actualizar cuenta:", error);
-      toast.error("❌ Error al actualizar la cuenta del pago");
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar la cuenta del pago"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/advisor.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/advisor.ts
@@ -31,6 +31,7 @@ import {
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PagoFormValues } from "./registerPayment";
 import { toast } from "sonner"; // 🔥 O tu librería de toast preferida
+import { getApiErrorMessage } from "@/lib/apiError";
 
 // ========== Hook ==========
 // 🚀 Administración de asesores, contadores, inversionistas, créditos y pagos
@@ -57,7 +58,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error creando asesor:", error);
-      toast.error(`❌ Error al crear asesor: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al crear asesor"));
     },
   });
 
@@ -71,7 +72,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando asesor:", error);
-      toast.error(`❌ Error al actualizar asesor: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar asesor"));
     },
   });
 
@@ -95,7 +96,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error creando contador:", error);
-      toast.error(`❌ Error al crear contador: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al crear contador"));
     },
   });
 
@@ -108,7 +109,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando contador:", error);
-      toast.error(`❌ Error al actualizar contador: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar contador"));
     },
   });
 
@@ -132,7 +133,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error con inversionista:", error);
-      toast.error(`❌ Error al procesar inversionista: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al procesar inversionista"));
     },
   });
 
@@ -144,7 +145,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando inversionista:", error);
-      toast.error(`❌ Error al actualizar inversionista: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar inversionista"));
     },
   });
 
@@ -157,7 +158,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error creando crédito:", error);
-      toast.error(`❌ Error al crear crédito: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al crear crédito"));
     },
   });
 
@@ -169,7 +170,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando crédito:", error);
-      toast.error(`❌ Error al actualizar crédito: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar crédito"));
     },
   });
 
@@ -197,7 +198,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error registrando pago:", error);
-      toast.error(`❌ Error al registrar pago: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al registrar pago"));
     },
   });
 

--- a/apps/carteraFront/src/private/cartera/hooks/recalculateQuota.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/recalculateQuota.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { recalculateQuotaService, type RecalculateQuotaPayload } from "../services/services";
 
 export function useRecalculateQuota() {
@@ -10,8 +11,7 @@ export function useRecalculateQuota() {
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {
-      const msg = error?.response?.data?.message || "Error recalculando cuota";
-      toast.error(msg);
+      toast.error(getApiErrorMessage(error, "Error recalculando cuota"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -20,6 +20,7 @@ import {
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useResetCredit } from "./resetCredit";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { useAuth } from "@/Provider/authProvider";
 import { toast } from "sonner";
 export const pagoSchema = z.object({
@@ -207,9 +208,11 @@ const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
         setArchivosParaSubir([]);
         setResetBuscador(true);
       } catch (error: any) {
-        const backendMessage =
-          error?.response?.data?.message || "Error desconocido";
-        toast.error(`No se pudo registrar el pago: ${backendMessage}`);
+        const backendMessage = getApiErrorMessage(
+          error,
+          "No se pudo registrar el pago",
+        );
+        toast.error(backendMessage);
         setStatus({ success: false, error: backendMessage });
       } finally {
         setSubmitting(false);
@@ -596,7 +599,7 @@ const handleAbonoOtros = () => {
         }
       },
       onError: (err: any) => {
-        toast.error(err?.response?.data?.message || "Error al liquidar pagos");
+        toast.error(getApiErrorMessage(err, "Error al liquidar pagos"));
       },
     });
   }
@@ -608,7 +611,7 @@ const handleAbonoOtros = () => {
         toast.success("Pago reversado correctamente");
       },
       onError: (err: any) => {
-        toast.error("Error al reversar pago: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al reversar pago"));
       },
     });
   }
@@ -621,7 +624,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
-        toast.error("Error al reversar pago a pendiente: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al reversar pago a pendiente"));
       },
     });
   }
@@ -634,7 +637,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
-        toast.error("Error al revalidar pago: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al revalidar pago"));
       },
     });
   }
@@ -647,7 +650,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
-        toast.error("Error al procesar inversionistas: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al procesar inversionistas"));
       },
     });
   }
@@ -668,7 +671,7 @@ const handleAbonoOtros = () => {
 
       // Aquí podrías hacer un refetch/queryClient.invalidateQueries para actualizar
     } catch (error) {
-      toast.error("Error al liquidar el pago");
+      toast.error(getApiErrorMessage(error, "Error al liquidar el pago"));
       console.error("Error liquidando pago:", error);
     }
   }
@@ -685,7 +688,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagosByCredito"] });
       },
       onError: (err: any) => {
-        toast.error("Error al recalcular pagos: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al recalcular pagos"));
       },
     });
   }
@@ -770,7 +773,7 @@ async function handleResetCredito() {
         }
     },
     onError: (error) => {
-      toast.error("Error al reiniciar crédito: " + (error?.message || error));
+      toast.error(getApiErrorMessage(error, "Error al reiniciar crédito"));
     }
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/updateCredit.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/updateCredit.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner"; // o donde uses tu toast
+import { getApiErrorMessage } from "@/lib/apiError";
 import { updateCreditService, type UpdateCreditBody } from "../services/services";
 
 export function useUpdateCredit() {
@@ -10,8 +11,7 @@ export function useUpdateCredit() {
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {
-      const msg = error?.response?.data?.message || "Error actualizando crédito";
-      toast.error(msg);
+      toast.error(getApiErrorMessage(error, "Error actualizando crédito"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/useReciboPago.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useReciboPago.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { generarReciboPago } from "../services/services";
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 
 export function useReciboPago() {
   return useMutation({
@@ -10,7 +11,7 @@ export function useReciboPago() {
       window.open(data.pdfUrl, "_blank");
     },
     onError: (err: any) => {
-      toast.error(err?.response?.data?.message || "Error al generar el recibo de pago");
+      toast.error(getApiErrorMessage(err, "Error al generar el recibo de pago"));
     },
   });
 }


### PR DESCRIPTION
## Contexto

Este PR continúa el trabajo iniciado en #860, extendiendo los mensajes de error descriptivos del usuario final desde los reportes hacia los hooks principales de operación de cartera. El objetivo es que en lugar de toasts genéricos como `"Error al registrar el pago"`, el usuario vea el motivo real: `"Error al registrar el pago: no se encontró el crédito o no está activo"`.

---

## Archivos modificados

### `src/lib/apiError.ts` — tres mejoras sobre la versión de #860

**1. Corrección de prioridad de campos (`message` vs `error`)**

La versión anterior leía `data?.error ?? data?.message`. Esto era incorrecto para la mayoría de los endpoints de `cartera-back`, que siguen el contrato:

```json
{ "message": "Error reiniciando el crédito", "error": "TypeError: Cannot read..." }
```

donde `message` es el texto curado en español y `error` es el stack técnico que **no debe** llegar al usuario. Con el orden anterior, se mostraba el stack técnico.

Fix: se invierte a `data?.message ?? data?.error ?? data?.mensaje`.

**2. Caso especial para endpoints con roles invertidos (`MENSAJE_SIN_INFORMACION`)**

Existe un subconjunto de endpoints (`reversePayment`, `revertPaymentToPending`, `revalidatePayment`) que sigue el contrato opuesto:

```json
{ "message": "Internal server error", "error": "Payment not found" }
```

Aquí `message` es un genérico sin información y `error` contiene el motivo real. Para no perder este detalle, se agrega la constante `MENSAJE_SIN_INFORMACION = /^internal server error$/i`: cuando `message` calza con este patrón **y** existe `error` con contenido, se usa `error` en su lugar.

Esto preserva el comportamiento correcto para ambas familias de endpoints sin necesidad de conocer cuál aplica en cada caso.

**3. Tabla de traducciones `TRADUCCIONES` (refactor del `if`-chain)**

Los mensajes de error de los controladores de `cartera-back` llegan en inglés (p. ej. `"Payment not found"`, `"Credit not found or not active"`). Corregirlos en el backend es el camino ideal a largo plazo, pero presenta dos riesgos inmediatos:

- Requeriría coordinar un deploy sincronizado: si el front asume mensajes en español pero el backend viejo sigue en producción, los usuarios verían strings en inglés.
- `traducirDetalleTecnico` ya existe como red de seguridad desde #860 para mensajes de autenticación; extenderla a mensajes de negocio mantiene un único punto de control.

Se reemplaza el `if`-chain anterior por un array `TRADUCCIONES` de `{ patron: RegExp, traduccion: string | fn }`, recorrido en orden (las reglas específicas van antes que las generales). Las traducciones con captura de grupos (p. ej. `"Payment 12345 not found"` → `"no se encontró el pago 12345"`) se expresan como funciones.

Mensajes cubiertos:
- `jwt expired` → sesión expirada
- `jwt / invalid signature / invalid token` → sesión no válida
- `Expected ...` (Elysia validation) → filtro o dato no válido
- `Payment <id> not found` → no se encontró el pago `<id>`
- `Payment not found` → no se encontró el pago
- `Credit not found or not active` → no se encontró el crédito o no está activo
- `Credit not found` → no se encontró el crédito
- `User not found` → no se encontró el usuario
- `Validation failed` → datos no válidos
- `Internal server error` → error interno del servidor

> **Deuda técnica registrada:** corregir los `throw new Error(...)` en inglés en los controladores del backend (`reversePayment`, `revalidatePayment`, `investor`, `credits`, etc.) para que las traducciones del front sean innecesarias. Ese cambio beneficia también a otros clientes del API (portal-web).

---

### Hooks migrados — 6 archivos

Cada hook reemplaza el acceso directo a `error?.response?.data?.message` (o patrones ad-hoc) por `getApiErrorMessage(error, fallback)`:

| Hook | Mutaciones migradas |
|---|---|
| `registerPayment.ts` | registrar pago, liquidar pagos inversionistas, reversar pago, reversar a pendiente, revalidar pago, procesar inversionistas, recalcular pagos, liquidar pago (catch interno), reiniciar crédito |
| `advisor.ts` | crear asesor, actualizar asesor, crear contador, actualizar contador, crear inversionista, actualizar inversionista, crear crédito, actualizar crédito, crear pago |
| `account.ts` | actualizar cuenta de pago |
| `updateCredit.ts` | actualizar crédito |
| `recalculateQuota.ts` | recalcular cuota |
| `useReciboPago.ts` | generar recibo de pago |

---

## Validación

Se ejecutó un script temporal contra el backend local con 13 escenarios de error real (IDs inexistentes, bodies inválidos). Todos los mensajes resultantes están en español y exponen el motivo específico. Muestra representativa:

| Escenario | Antes | Ahora |
|---|---|---|
| Reversar pago inexistente | `"Error al reversar pago: Payment not found"` | `"Error al reversar pago: no se encontró el pago"` |
| Reversar pago inexistente (con ID) | `"Payment 99999999 not found"` | `"Error al reversar pago: no se encontró el pago 99999999"` |
| Reiniciar crédito inexistente | `"Error al reiniciar crédito: [TypeError crudo]"` | `"Error al reiniciar crédito: Error reiniciando el crédito"` |
| Body inválido (Elysia 422) | `"Expected..."` | `"No se pudo registrar el pago: uno de los filtros o datos enviados no es válido (Expected ...)"` |
| Sin conexión | fallback genérico | `"…: sin conexión con el servidor"` |
| Timeout | fallback genérico | `"…: el servidor tardó demasiado en responder, intenta de nuevo"` |