### PR TITLE
feat(cobros): reportes de cobros (mora, pagos esperados, no recibidos, descuentos)

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -145,6 +145,43 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 	};
 }
 
+// Helper: Pagina getAllCreditos hasta traer la cartera completa que matchea
+// los filtros. Sin esto, un solo fetch trunca silenciosamente cuando la
+// cartera supera el perPage.
+async function obtenerTodasLasPaginasCreditos(
+	params: Omit<
+		Parameters<typeof obtenerTodosLosCreditosCarteraBack>[0],
+		"page" | "perPage"
+	>,
+) {
+	const perPage = 100;
+	// Tope duro: si cartera-back devolviera totalPages null/undefined y siempre
+	// exactamente `perPage` items, el loop no terminaría. 200 páginas = 20k
+	// créditos, muy por encima de la cartera real.
+	const MAX_PAGES = 200;
+	const data: Awaited<
+		ReturnType<typeof obtenerTodosLosCreditosCarteraBack>
+	>["data"] = [];
+	let page = 1;
+	while (page <= MAX_PAGES) {
+		const resp = await obtenerTodosLosCreditosCarteraBack({
+			...params,
+			page,
+			perPage,
+		});
+		data.push(...resp.data);
+		if (resp.data.length < perPage) break;
+		if (resp.totalPages != null && page >= resp.totalPages) break;
+		page += 1;
+	}
+	if (page > MAX_PAGES) {
+		console.warn(
+			`[obtenerTodasLasPaginasCreditos] Se alcanzó MAX_PAGES=${MAX_PAGES} (${data.length} créditos). Posible truncamiento — la cartera supera el tope.`,
+		);
+	}
+	return data;
+}
+
 /**
  * Verifica si la auto-creación de datos migrate está habilitada
  */
@@ -3877,6 +3914,376 @@ export const cobrosRouter = {
 				success: true,
 				mailingId,
 				casoCobroId: input.casoCobroId,
+			};
+		}),
+
+	// ========================================================================
+	// MORA POR ETAPA Y ASESOR
+	// ========================================================================
+
+	getMoraByEtapaYAsesor: cobrosSupervisorProcedure
+		.input(
+			z
+				.object({
+					emailCobrador: z.string().optional(),
+				})
+				.optional(),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			// Traer cartera completa (mes=0 = todos los créditos)
+			const creditos = await obtenerTodasLasPaginasCreditos({
+				mes: 0,
+				anio: new Date().getFullYear(),
+				estado: "ACTIVO",
+				email_cobrador: input?.emailCobrador,
+			});
+
+			type BucketAcc = {
+				cantidad: number;
+				sumaCapital: number;
+				sumaMora: number;
+			};
+			type BucketsAcc = {
+				mora_30: BucketAcc;
+				mora_60: BucketAcc;
+				mora_90: BucketAcc;
+				mora_120_plus: BucketAcc;
+			};
+			const emptyBuckets = (): BucketsAcc => ({
+				mora_30: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+				mora_60: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+				mora_90: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+				mora_120_plus: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+			});
+
+			const serializeBuckets = (b: BucketsAcc) => {
+				const fmt = (v: number) => v.toFixed(2);
+				const totalCantidad =
+					b.mora_30.cantidad + b.mora_60.cantidad + b.mora_90.cantidad + b.mora_120_plus.cantidad;
+				const totalMora =
+					b.mora_30.sumaMora + b.mora_60.sumaMora + b.mora_90.sumaMora + b.mora_120_plus.sumaMora;
+				return {
+					mora_30: { cantidad: b.mora_30.cantidad, sumaCapital: fmt(b.mora_30.sumaCapital), sumaMora: fmt(b.mora_30.sumaMora) },
+					mora_60: { cantidad: b.mora_60.cantidad, sumaCapital: fmt(b.mora_60.sumaCapital), sumaMora: fmt(b.mora_60.sumaMora) },
+					mora_90: { cantidad: b.mora_90.cantidad, sumaCapital: fmt(b.mora_90.sumaCapital), sumaMora: fmt(b.mora_90.sumaMora) },
+					mora_120_plus: { cantidad: b.mora_120_plus.cantidad, sumaCapital: fmt(b.mora_120_plus.sumaCapital), sumaMora: fmt(b.mora_120_plus.sumaMora) },
+					totalEnMora: { cantidad: totalCantidad, sumaMora: fmt(totalMora) },
+				};
+			};
+
+			const acumuladoTotal = emptyBuckets();
+
+			type AsesorEntry = { asesorId: number; nombre: string; email: string; buckets: BucketsAcc };
+			const porAsesorMap = new Map<string, AsesorEntry>();
+
+			const addToBucket = (acc: BucketsAcc, cuotasAtrasadas: number, capital: number, mora: number) => {
+				const key =
+					cuotasAtrasadas >= 4 ? "mora_120_plus" :
+					cuotasAtrasadas === 3 ? "mora_90" :
+					cuotasAtrasadas === 2 ? "mora_60" :
+					"mora_30";
+				acc[key].cantidad += 1;
+				acc[key].sumaCapital += capital;
+				acc[key].sumaMora += mora;
+			};
+
+			for (const item of creditos) {
+				const cuotasAtrasadas = item.mora?.cuotas_atrasadas ?? 0;
+				if (cuotasAtrasadas < 1) continue;
+
+				const capital = parseFloat(item.creditos.capital as string || "0");
+				const montoMora = parseFloat(item.mora?.monto_mora ?? "0");
+
+				addToBucket(acumuladoTotal, cuotasAtrasadas, capital, montoMora);
+
+				// Agrupar por asesor usando emailCashIn del crédito mismo
+				const emailAsesor = item.asesores?.emailCashIn ?? "sin_asesor";
+				const nombreAsesor = item.asesores?.nombre ?? "Sin asesor";
+				const asesorId = item.asesores?.asesor_id ?? 0;
+
+				let entry = porAsesorMap.get(emailAsesor);
+				if (!entry) {
+					entry = { asesorId, nombre: nombreAsesor, email: emailAsesor, buckets: emptyBuckets() };
+					porAsesorMap.set(emailAsesor, entry);
+				}
+				addToBucket(entry.buckets, cuotasAtrasadas, capital, montoMora);
+			}
+
+			const porAsesor = Array.from(porAsesorMap.values())
+				.sort((a, b) => {
+					const totalA = a.buckets.mora_30.sumaMora + a.buckets.mora_60.sumaMora + a.buckets.mora_90.sumaMora + a.buckets.mora_120_plus.sumaMora;
+					const totalB = b.buckets.mora_30.sumaMora + b.buckets.mora_60.sumaMora + b.buckets.mora_90.sumaMora + b.buckets.mora_120_plus.sumaMora;
+					return totalB - totalA;
+				})
+				.map((e) => ({
+					asesorId: e.asesorId,
+					nombre: e.nombre,
+					email: e.email,
+					...serializeBuckets(e.buckets),
+				}));
+
+			return { totales: serializeBuckets(acumuladoTotal), porAsesor };
+		}),
+
+	// ========================================================================
+	// PAGOS ESPERADOS (COBROS)
+	// ========================================================================
+
+	getPagosEsperadosCobros: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				temporalidad: z.enum(["hoy", "semana", "quincena", "mes"]),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			const hoy = new Date();
+			const pad = (n: number) => n.toString().padStart(2, "0");
+			const toISO = (d: Date) =>
+				`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+			const fechaInicio = toISO(hoy);
+
+			const diasAdelanteMap: Record<typeof input.temporalidad, number> = {
+				hoy: 0,
+				semana: 6,
+				quincena: 14,
+				mes: 29,
+			};
+			const diasAdelante = diasAdelanteMap[input.temporalidad];
+
+			const fechaFinDate = new Date(hoy);
+			fechaFinDate.setDate(fechaFinDate.getDate() + diasAdelante);
+			const fechaFin = toISO(fechaFinDate);
+
+			const desglose = await carteraBackClient.getMontoACobrar({
+				periodo: "dia",
+				fechaInicio,
+				fechaFin,
+			});
+
+			// Ojo: en cartera-back `total_cuota` ES el capital de las cuotas
+			// (mismo criterio que el reporte de monto-a-cobrar existente, que lo
+			// etiqueta "Capital" y calcula el total sumando todos los rubros).
+			let totalCapital = 0;
+			let totalInteres = 0;
+			let totalIva = 0;
+			let totalSeguro = 0;
+			let totalGps = 0;
+			let totalMembresias = 0;
+			let totalRoyalti = 0;
+			let cantidadCuotas = 0;
+
+			for (const row of desglose) {
+				totalCapital += parseFloat(row.total_cuota);
+				totalInteres += parseFloat(row.total_interes);
+				totalIva += parseFloat(row.total_iva);
+				totalSeguro += parseFloat(row.total_seguro);
+				totalGps += parseFloat(row.total_gps);
+				totalMembresias += parseFloat(row.total_membresias);
+				totalRoyalti += parseFloat(row.total_royalti);
+				cantidadCuotas += row.cuotas_count;
+			}
+
+			const totalACobrar =
+				totalCapital +
+				totalInteres +
+				totalIva +
+				totalSeguro +
+				totalGps +
+				totalMembresias;
+
+			return {
+				fechaInicio,
+				fechaFin,
+				temporalidad: input.temporalidad,
+				desglose,
+				totales: {
+					capital: totalCapital.toFixed(2),
+					interes: totalInteres.toFixed(2),
+					iva: totalIva.toFixed(2),
+					seguro: totalSeguro.toFixed(2),
+					gps: totalGps.toFixed(2),
+					membresias: totalMembresias.toFixed(2),
+					royalti: totalRoyalti.toFixed(2),
+					totalCuota: totalACobrar.toFixed(2),
+					cantidadCuotas,
+				},
+			};
+		}),
+
+	// ========================================================================
+	// PAGOS NO RECIBIDOS
+	// ========================================================================
+
+	getPagosNoRecibidos: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				emailCobrador: z.string().optional(),
+				capitalMin: z.number().optional(),
+				capitalMax: z.number().optional(),
+				cuotasAtrasadasMin: z.number().min(1).optional(),
+				cuotasAtrasadasMax: z.number().min(1).optional(),
+				fechaDesde: z.string().optional(),
+				fechaHasta: z.string().optional(),
+				page: z.number().min(1).default(1),
+				pageSize: z.number().min(1).max(100).default(25),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			// mes=0 trae TODOS los créditos sin filtrar por mes (mismo criterio
+			// que getTodosLosCreditos); con el mes actual cartera-back devuelve
+			// solo el snapshot mensual y el listado sale vacío.
+			const creditos = await obtenerTodasLasPaginasCreditos({
+				mes: 0,
+				anio: new Date().getFullYear(),
+				estado: "ACTIVO",
+				email_cobrador: input.emailCobrador,
+				capital_min: input.capitalMin,
+				capital_max: input.capitalMax,
+				fecha_desde: input.fechaDesde,
+				fecha_hasta: input.fechaHasta,
+			});
+
+			const minCuotas = input.cuotasAtrasadasMin ?? 1;
+
+			const todosOverdue = creditos.filter((item) => {
+				const cuotasAtrasadas = item.mora?.cuotas_atrasadas ?? 0;
+				if (cuotasAtrasadas < minCuotas) return false;
+				if (
+					input.cuotasAtrasadasMax !== undefined &&
+					cuotasAtrasadas > input.cuotasAtrasadasMax
+				)
+					return false;
+				return true;
+			});
+
+			const total = todosOverdue.length;
+			const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
+			const start = (input.page - 1) * input.pageSize;
+			const pageData = todosOverdue.slice(start, start + input.pageSize);
+
+			const items = pageData.map((item) => ({
+				sifco: item.creditos.numero_credito_sifco,
+				clienteNombre: item.usuarios.nombre,
+				asesorNombre: item.asesores?.nombre ?? "Sin asesor",
+				cuotasAtrasadas: item.mora?.cuotas_atrasadas ?? 0,
+				montoMora: item.mora?.monto_mora ?? "0",
+				capital: item.proxima_cuota?.capital_restante ?? item.creditos.capital,
+				cuotaMensual: item.creditos.cuota,
+				proximaFechaVencimiento:
+					item.proxima_cuota?.fecha_vencimiento ?? null,
+				tipoCredito: item.creditos.tipoCredito ?? null,
+			}));
+
+			return {
+				data: items,
+				total,
+				page: input.page,
+				pageSize: input.pageSize,
+				totalPages,
+			};
+		}),
+
+	// ========================================================================
+	// DESCUENTOS / RUBROS POR CRÉDITO
+	// ========================================================================
+
+	getDescuentosCRM: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				page: z.number().min(1).default(1),
+				pageSize: z.number().min(1).max(100).default(25),
+				emailCobrador: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			const creditos = await obtenerTodasLasPaginasCreditos({
+				mes: 0,
+				anio: new Date().getFullYear(),
+				estado: "ACTIVO",
+				email_cobrador: input.emailCobrador,
+			});
+
+			type RubroItem = { nombre_rubro: string; monto: string | number };
+
+			const todos = creditos
+				.map((item) => {
+					const cred = item.creditos;
+					const gps = parseFloat(cred.gps || "0");
+					const seguro = parseFloat(cred.seguro_10_cuotas || "0");
+					const membresias = parseFloat(cred.membresias_pago || "0");
+					const otros = parseFloat(cred.otros || "0");
+
+					const rubros = (
+						(item.rubros as RubroItem[] | null) ?? []
+					).map((r) => ({
+						nombre: r.nombre_rubro,
+						monto: parseFloat(String(r.monto || "0")).toFixed(2),
+					}));
+					const rubrosTotal = rubros.reduce(
+						(s, r) => s + parseFloat(r.monto),
+						0,
+					);
+
+					const totalDescuentos = gps + seguro + membresias + otros + rubrosTotal;
+					if (totalDescuentos <= 0) return null;
+
+					return {
+						sifco: cred.numero_credito_sifco,
+						clienteNombre: item.usuarios.nombre,
+						asesorNombre: item.asesores?.nombre ?? "Sin asesor",
+						gps: gps.toFixed(2),
+						seguro: seguro.toFixed(2),
+						membresias: membresias.toFixed(2),
+						otros: otros.toFixed(2),
+						rubros,
+						rubrosTotal: rubrosTotal.toFixed(2),
+						totalDescuentos: totalDescuentos.toFixed(2),
+						capital: cred.capital,
+						tipoCredito: cred.tipoCredito ?? null,
+					};
+				})
+				.filter(
+					(
+						v,
+					): v is NonNullable<typeof v> => v !== null,
+				);
+
+			const total = todos.length;
+			const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
+			const start = (input.page - 1) * input.pageSize;
+			const pageData = todos.slice(start, start + input.pageSize);
+
+			return {
+				data: pageData,
+				total,
+				page: input.page,
+				pageSize: input.pageSize,
+				totalPages,
 			};
 		}),
 };

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -71,6 +71,7 @@ import {
 	getUltimasSincronizaciones,
 	sincronizarCasosCobros,
 } from "../services/sync-casos-cobros";
+import { toDateStrGT } from "../lib/guatemala-month-window";
 import type { CreditoDirectoResponse } from "../types/cartera-back";
 import { createNotification } from "./notifications";
 
@@ -4048,12 +4049,7 @@ export const cobrosRouter = {
 				});
 			}
 
-			const hoy = new Date();
 			const pad = (n: number) => n.toString().padStart(2, "0");
-			const toISO = (d: Date) =>
-				`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-
-			const fechaInicio = toISO(hoy);
 
 			const diasAdelanteMap: Record<typeof input.temporalidad, number> = {
 				hoy: 0,
@@ -4063,9 +4059,16 @@ export const cobrosRouter = {
 			};
 			const diasAdelante = diasAdelanteMap[input.temporalidad];
 
-			const fechaFinDate = new Date(hoy);
-			fechaFinDate.setDate(fechaFinDate.getDate() + diasAdelante);
-			const fechaFin = toISO(fechaFinDate);
+			// Las fechas de negocio son días calendario de Guatemala (UTC-6). Si el
+			// server corre en UTC, usar getFullYear/getMonth/getDate directo desplaza
+			// "hoy" un día entre las 00:00 y 05:59 UTC. Anclamos en la fecha GT y
+			// hacemos la aritmética de días sobre esos componentes en UTC puro.
+			const fechaInicio = toDateStrGT(new Date());
+			const [anioGT, mesGT, diaGT] = fechaInicio.split("-").map(Number);
+			const fechaFinUTC = new Date(
+				Date.UTC(anioGT, mesGT - 1, diaGT + diasAdelante),
+			);
+			const fechaFin = `${fechaFinUTC.getUTCFullYear()}-${pad(fechaFinUTC.getUTCMonth() + 1)}-${pad(fechaFinUTC.getUTCDate())}`;
 
 			const desglose = await carteraBackClient.getMontoACobrar({
 				periodo: "dia",

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -169,6 +169,12 @@ export const cobrosAppRouter = {
 	getMetasMoraAnual: cobrosRouter.getMetasMoraAnual,
 	upsertMetasMora: cobrosRouter.upsertMetasMora,
 
+	// CRM Cobros — nuevas vistas
+	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
+	getPagosEsperadosCobros: cobrosRouter.getPagosEsperadosCobros,
+	getPagosNoRecibidos: cobrosRouter.getPagosNoRecibidos,
+	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
+
 	// Seguimientos programados
 	createSeguimiento: seguimientosRouter.createSeguimiento,
 	getSeguimientosActivos: seguimientosRouter.getSeguimientosActivos,

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -272,6 +272,17 @@ export default function Header() {
 											</Link>
 										</DropdownMenuItem>
 									)}
+									{PERMISSIONS.canAssignCobros(userRole) && (
+										<>
+											<DropdownMenuSeparator />
+											<DropdownMenuItem asChild>
+												<Link to="/cobros/reportes" className="cursor-pointer">
+													<BarChart3 className="mr-2 h-4 w-4" />
+													Reportes
+												</Link>
+											</DropdownMenuItem>
+										</>
+									)}
 								</DropdownMenuContent>
 							</DropdownMenu>
 						)}

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as CrmOpportunitiesRouteImport } from './routes/crm/opportunities
 import { Route as CrmLeadsRouteImport } from './routes/crm/leads'
 import { Route as CrmCompaniesRouteImport } from './routes/crm/companies'
 import { Route as CrmClientsRouteImport } from './routes/crm/clients'
+import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
 import { Route as CobrosIdRouteImport } from './routes/cobros/$id'
 import { Route as AdminUsersRouteImport } from './routes/admin/users'
@@ -158,6 +159,11 @@ const CrmClientsRoute = CrmClientsRouteImport.update({
   path: '/crm/clients',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosReportesRoute = CobrosReportesRouteImport.update({
+  id: '/cobros/reportes',
+  path: '/cobros/reportes',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosMetasRoute = CobrosMetasRouteImport.update({
   id: '/cobros/metas',
   path: '/cobros/metas',
@@ -250,6 +256,7 @@ export interface FileRoutesByFullPath {
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
   '/crm/leads': typeof CrmLeadsRoute
@@ -289,6 +296,7 @@ export interface FileRoutesByTo {
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
   '/crm/leads': typeof CrmLeadsRoute
@@ -329,6 +337,7 @@ export interface FileRoutesById {
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
   '/crm/leads': typeof CrmLeadsRoute
@@ -370,6 +379,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/cobros/$id'
     | '/cobros/metas'
+    | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
     | '/crm/leads'
@@ -409,6 +419,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/cobros/$id'
     | '/cobros/metas'
+    | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
     | '/crm/leads'
@@ -448,6 +459,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/cobros/$id'
     | '/cobros/metas'
+    | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
     | '/crm/leads'
@@ -488,6 +500,7 @@ export interface RootRouteChildren {
   AdminUsersRoute: typeof AdminUsersRoute
   CobrosIdRoute: typeof CobrosIdRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
+  CobrosReportesRoute: typeof CobrosReportesRoute
   CrmClientsRoute: typeof CrmClientsRoute
   CrmCompaniesRoute: typeof CrmCompaniesRoute
   CrmLeadsRoute: typeof CrmLeadsRoute
@@ -673,6 +686,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CrmClientsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/reportes': {
+      id: '/cobros/reportes'
+      path: '/cobros/reportes'
+      fullPath: '/cobros/reportes'
+      preLoaderRoute: typeof CobrosReportesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/metas': {
       id: '/cobros/metas'
       path: '/cobros/metas'
@@ -792,6 +812,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminUsersRoute: AdminUsersRoute,
   CobrosIdRoute: CobrosIdRoute,
   CobrosMetasRoute: CobrosMetasRoute,
+  CobrosReportesRoute: CobrosReportesRoute,
   CrmClientsRoute: CrmClientsRoute,
   CrmCompaniesRoute: CrmCompaniesRoute,
   CrmLeadsRoute: CrmLeadsRoute,

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -329,7 +329,7 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 	});
 
 	const { data: asesoresData } = useQuery({
-		...orpc.getAsesores.queryOptions({ input: {} }),
+		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
 		enabled: !!session && canSeeAll,
 	});
 
@@ -563,7 +563,7 @@ function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof auth
 	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
 
 	const { data: asesoresData } = useQuery({
-		...orpc.getAsesores.queryOptions({ input: {} }),
+		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
 		enabled: !!session && canSeeAll,
 	});
 

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -1,0 +1,670 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
+import { BarChart3, CalendarClock, RefreshCw, TrendingDown } from "lucide-react";
+import { useState } from "react";
+import { CapitalRangeFilter } from "@/components/cobros/capital-range-filter";
+import { DataTable } from "@/components/data-table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { usePersistedState } from "@/hooks/usePersistedState";
+import { authClient } from "@/lib/auth-client";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/reportes")({
+	component: RouteComponent,
+});
+
+// ─── shared helpers ────────────────────────────────────────────────────────
+
+function fmtQ(v: string | number) {
+	const n = parseFloat(String(v));
+	return `Q${isNaN(n) ? "0.00" : n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function fmtTime(d: Date) {
+	return d.toLocaleTimeString("es-GT", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+// ─── Mora ──────────────────────────────────────────────────────────────────
+
+const ETAPAS = [
+	{ key: "mora_30" as const, label: "Mora 30", color: "bg-yellow-100 text-yellow-800" },
+	{ key: "mora_60" as const, label: "Mora 60", color: "bg-orange-100 text-orange-800" },
+	{ key: "mora_90" as const, label: "Mora 90", color: "bg-red-100 text-red-800" },
+	{ key: "mora_120_plus" as const, label: "Mora 120+", color: "bg-red-300 text-red-950" },
+];
+
+function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
+	const emailCobrador = canSeeAll ? undefined : (session?.user?.email ?? undefined);
+
+	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
+		...orpc.getMoraByEtapaYAsesor.queryOptions({ input: { emailCobrador } }),
+		enabled: !!session,
+		refetchInterval: 60_000,
+		refetchIntervalInBackground: false,
+	});
+
+	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<TrendingDown className="h-5 w-5 text-red-600" />
+					<h2 className="font-semibold text-xl">Análisis de Mora</h2>
+				</div>
+				<div className="flex items-center gap-3">
+					{ultimaAct && (
+						<span className="text-muted-foreground text-xs">Actualizado: {ultimaAct}</span>
+					)}
+					<Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+						<RefreshCw className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+						Actualizar
+					</Button>
+				</div>
+			</div>
+
+			{isLoading ? (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{ETAPAS.map((e) => (
+						<Card key={e.key}><CardContent className="pt-6"><div className="h-12 animate-pulse rounded bg-muted" /></CardContent></Card>
+					))}
+				</div>
+			) : (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{ETAPAS.map((etapa) => {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const bucket = (data as any)?.totales?.[etapa.key];
+						return (
+							<Card key={etapa.key}>
+								<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+									<CardTitle className="font-medium text-sm">{etapa.label}</CardTitle>
+									<Badge className={etapa.color}>{bucket?.cantidad ?? 0}</Badge>
+								</CardHeader>
+								<CardContent>
+									<div className="font-bold text-2xl">{fmtQ(bucket?.sumaMora ?? "0")}</div>
+									<p className="text-muted-foreground text-xs">Capital: {fmtQ(bucket?.sumaCapital ?? "0")}</p>
+								</CardContent>
+							</Card>
+						);
+					})}
+				</div>
+			)}
+
+			{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+			{!!(data as any)?.totales?.totalEnMora && (
+				<Card className="border-red-200 bg-red-50">
+					<CardContent className="pt-4">
+						<div className="flex items-center justify-between">
+							<div>
+								<p className="font-semibold text-sm text-red-700">Total en Mora</p>
+								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+								<p className="font-bold text-3xl text-red-800">{fmtQ((data as any).totales.totalEnMora.sumaMora)}</p>
+							</div>
+							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+							<div className="text-right"><p className="text-muted-foreground text-sm">Créditos</p><p className="font-bold text-2xl">{(data as any).totales.totalEnMora.cantidad}</p></div>
+						</div>
+					</CardContent>
+				</Card>
+			)}
+
+			<div>
+				<h3 className="mb-3 font-semibold text-base">Desglose por Asesor</h3>
+				{isLoading ? (
+					<div className="h-32 animate-pulse rounded bg-muted" />
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				) : !(data as any)?.porAsesor?.length ? (
+					<p className="text-muted-foreground text-sm">No hay datos disponibles.</p>
+				) : (
+					<div className="overflow-x-auto rounded-lg border">
+						<table className="w-full text-sm">
+							<thead className="bg-muted/50">
+								<tr>
+									<th className="px-4 py-3 text-left font-semibold">Asesor</th>
+									{ETAPAS.map((e) => <th key={e.key} className="px-4 py-3 text-right font-semibold">{e.label}</th>)}
+									<th className="px-4 py-3 text-right font-semibold">Total en Mora</th>
+								</tr>
+							</thead>
+							<tbody>
+								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+								{(data as any).porAsesor.map((asesor: any) => (
+									<tr key={asesor.asesorId} className="border-t hover:bg-muted/30">
+										<td className="px-4 py-3 font-medium">{asesor.nombre}</td>
+										{ETAPAS.map((etapa) => {
+											const bucket = asesor[etapa.key];
+											return (
+												<td key={etapa.key} className="px-4 py-3 text-right">
+													{bucket?.cantidad > 0 ? (
+														<div>
+															<div className="font-medium">{fmtQ(bucket.sumaMora)}</div>
+															<div className="text-muted-foreground text-xs">{bucket.cantidad} créd.</div>
+														</div>
+													) : <span className="text-muted-foreground">—</span>}
+												</td>
+											);
+										})}
+										<td className="px-4 py-3 text-right">
+											<div className="font-semibold text-red-700">{fmtQ(asesor.totalEnMora?.sumaMora ?? "0")}</div>
+											<div className="text-muted-foreground text-xs">{asesor.totalEnMora?.cantidad ?? 0} créd.</div>
+										</td>
+									</tr>
+								))}
+							</tbody>
+							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+							{!!(data as any)?.totales && (
+								<tfoot className="border-t-2 bg-muted/50 font-semibold">
+									<tr>
+										<td className="px-4 py-3">TOTAL</td>
+										{ETAPAS.map((etapa) => {
+											// eslint-disable-next-line @typescript-eslint/no-explicit-any
+											const bucket = (data as any).totales[etapa.key];
+											return (
+												<td key={etapa.key} className="px-4 py-3 text-right">
+													<div>{fmtQ(bucket?.sumaMora ?? "0")}</div>
+													<div className="font-normal text-muted-foreground text-xs">{bucket?.cantidad ?? 0} créd.</div>
+												</td>
+											);
+										})}
+										<td className="px-4 py-3 text-right text-red-700">
+											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+											<div>{fmtQ((data as any).totales.totalEnMora?.sumaMora ?? "0")}</div>
+											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+											<div className="font-normal text-muted-foreground text-xs">{(data as any).totales.totalEnMora?.cantidad ?? 0} créd.</div>
+										</td>
+									</tr>
+								</tfoot>
+							)}
+						</table>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ─── Pagos Esperados ────────────────────────────────────────────────────────
+
+type Temporalidad = "hoy" | "semana" | "quincena" | "mes";
+
+const TEMPORALIDAD_LABELS: Record<Temporalidad, string> = {
+	hoy: "Hoy",
+	semana: "Esta Semana",
+	quincena: "Esta Quincena",
+	mes: "Este Mes",
+};
+
+const RUBROS = [
+	{ key: "totalCuota" as const, label: "Total a Cobrar", highlight: true },
+	{ key: "capital" as const, label: "Capital" },
+	{ key: "interes" as const, label: "Interés" },
+	{ key: "iva" as const, label: "IVA" },
+	{ key: "seguro" as const, label: "Seguro" },
+	{ key: "gps" as const, label: "GPS" },
+	{ key: "membresias" as const, label: "Membresías" },
+	{ key: "royalti" as const, label: "Royaltí" },
+];
+
+type DesgloseDia = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	total_royalti: string;
+};
+
+// Buckets date-only se parsean como mediodía local para evitar que el
+// offset de zona horaria los desplace al día anterior.
+function fmtBucketDia(bucket: string) {
+	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
+	return date.toLocaleDateString("es-GT", { weekday: "short", day: "2-digit", month: "short" });
+}
+
+// `total_cuota` de cartera-back es el capital; el total a cobrar de la fila
+// es la suma de rubros (mismo criterio que el reporte monto-a-cobrar).
+function totalDeFila(row: DesgloseDia) {
+	return (
+		parseFloat(row.total_cuota) +
+		parseFloat(row.total_interes) +
+		parseFloat(row.total_iva) +
+		parseFloat(row.total_seguro) +
+		parseFloat(row.total_gps) +
+		parseFloat(row.total_membresias)
+	);
+}
+
+type PagoNoRecibido = {
+	sifco: string;
+	clienteNombre: string;
+	asesorNombre: string;
+	cuotasAtrasadas: number;
+	montoMora: string;
+	capital: string;
+	cuotaMensual: string;
+	proximaFechaVencimiento: string | null;
+	tipoCredito: string | null;
+};
+
+function getMoraBadge(cuotas: number) {
+	if (cuotas >= 4) return <Badge className="bg-red-300 text-red-950">Mora 120+</Badge>;
+	if (cuotas === 3) return <Badge className="bg-red-100 text-red-800">Mora 90</Badge>;
+	if (cuotas === 2) return <Badge className="bg-orange-100 text-orange-800">Mora 60</Badge>;
+	return <Badge className="bg-yellow-100 text-yellow-800">Mora 30</Badge>;
+}
+
+const colsPagos: ColumnDef<PagoNoRecibido>[] = [
+	{
+		accessorKey: "sifco",
+		header: "Crédito",
+		cell: ({ row }) => (
+			<Link to="/cobros/$id" params={{ id: row.original.sifco }} search={{ tipo: "contrato" }} className="font-mono text-blue-600 text-xs hover:underline">
+				{row.original.sifco}
+			</Link>
+		),
+	},
+	{ accessorKey: "clienteNombre", header: "Cliente" },
+	{ accessorKey: "asesorNombre", header: "Asesor" },
+	{
+		accessorKey: "cuotasAtrasadas",
+		header: "Cuotas Atrasadas",
+		cell: ({ row }) => getMoraBadge(row.original.cuotasAtrasadas),
+	},
+	{
+		accessorKey: "montoMora",
+		header: "Monto Mora",
+		cell: ({ row }) => <span className="font-medium text-red-700">{fmtQ(row.original.montoMora)}</span>,
+	},
+	{ accessorKey: "capital", header: "Capital Restante", cell: ({ row }) => fmtQ(row.original.capital) },
+	{ accessorKey: "cuotaMensual", header: "Cuota Mensual", cell: ({ row }) => fmtQ(row.original.cuotaMensual) },
+	{
+		accessorKey: "proximaFechaVencimiento",
+		header: "Próx. Vencimiento",
+		cell: ({ row }) =>
+			row.original.proximaFechaVencimiento
+				? new Date(`${row.original.proximaFechaVencimiento}T00:00:00`).toLocaleDateString("es-GT")
+				: "—",
+	},
+];
+
+function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
+	const [temporalidad, setTemporalidad] = usePersistedState<Temporalidad>("cobros/reportes/temporalidad", "hoy");
+	const [emailAsesor, setEmailAsesor] = usePersistedState<string>("cobros/reportes/pagos/emailAsesor", "");
+	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>("cobros/reportes/pagos/capitalMin", undefined);
+	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>("cobros/reportes/pagos/capitalMax", undefined);
+	const [cuotasMin, setCuotasMin] = usePersistedState<string>("cobros/reportes/pagos/cuotasMin", "");
+	const [cuotasMax, setCuotasMax] = usePersistedState<string>("cobros/reportes/pagos/cuotasMax", "");
+	const [fechaDesde, setFechaDesde] = usePersistedState<string>("cobros/reportes/pagos/fechaDesde", "");
+	const [fechaHasta, setFechaHasta] = usePersistedState<string>("cobros/reportes/pagos/fechaHasta", "");
+	const [page, setPage] = usePersistedState<number>("cobros/reportes/pagos/page", 1);
+	const [pageSize] = usePersistedState<number>("cobros/reportes/pagos/pageSize", 25);
+
+	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
+
+	const { data: resumenData, isLoading: resumenLoading, dataUpdatedAt, refetch: refetchResumen, isFetching: resumenFetching } = useQuery({
+		...orpc.getPagosEsperadosCobros.queryOptions({ input: { temporalidad } }),
+		enabled: !!session,
+		staleTime: 5 * 60 * 1000,
+	});
+
+	const { data: asesoresData } = useQuery({
+		...orpc.getAsesores.queryOptions({ input: {} }),
+		enabled: !!session && canSeeAll,
+	});
+
+	const { data: noRecibidosData, isLoading: noRecibidosLoading } = useQuery({
+		...orpc.getPagosNoRecibidos.queryOptions({
+			input: {
+				emailCobrador,
+				capitalMin,
+				capitalMax,
+				cuotasAtrasadasMin: cuotasMin ? parseInt(cuotasMin, 10) : undefined,
+				cuotasAtrasadasMax: cuotasMax ? parseInt(cuotasMax, 10) : undefined,
+				fechaDesde: fechaDesde || undefined,
+				fechaHasta: fechaHasta || undefined,
+				page,
+				pageSize,
+			},
+		}),
+		enabled: !!session,
+		staleTime: 5 * 60 * 1000,
+	});
+
+	const ultimaAct = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleTimeString("es-GT", { hour: "2-digit", minute: "2-digit" }) : null;
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center gap-2">
+				<CalendarClock className="h-5 w-5 text-blue-600" />
+				<h2 className="font-semibold text-xl">Pagos Esperados</h2>
+			</div>
+
+			{/* Período selector */}
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="font-medium text-sm">Período:</span>
+				{(Object.keys(TEMPORALIDAD_LABELS) as Temporalidad[]).map((t) => (
+					<Button key={t} variant={temporalidad === t ? "default" : "outline"} size="sm" onClick={() => setTemporalidad(t)}>
+						{TEMPORALIDAD_LABELS[t]}
+					</Button>
+				))}
+				<div className="ml-auto flex items-center gap-2">
+					{ultimaAct && <span className="text-muted-foreground text-xs">Actualizado: {ultimaAct}</span>}
+					<Button variant="outline" size="sm" onClick={() => refetchResumen()} disabled={resumenFetching}>
+						<RefreshCw className={`mr-2 h-4 w-4 ${resumenFetching ? "animate-spin" : ""}`} />
+						Actualizar
+					</Button>
+				</div>
+			</div>
+
+			{resumenLoading ? (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{RUBROS.map((r) => <Card key={r.key}><CardContent className="pt-6"><div className="h-10 animate-pulse rounded bg-muted" /></CardContent></Card>)}
+				</div>
+			) : (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{RUBROS.map((r) => {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const value = (resumenData as any)?.totales?.[r.key] as string | number | undefined;
+						return (
+							<Card key={r.key} className={r.highlight ? "border-blue-200 bg-blue-50" : ""}>
+								<CardHeader className="pb-2">
+									<CardTitle className={`font-medium text-sm ${r.highlight ? "text-blue-700" : ""}`}>{r.label}</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<div className={`font-bold text-xl ${r.highlight ? "text-blue-800" : ""}`}>{fmtQ(String(value ?? "0"))}</div>
+								</CardContent>
+							</Card>
+						);
+					})}
+					<Card>
+						<CardHeader className="pb-2"><CardTitle className="font-medium text-sm">Cant. Cuotas</CardTitle></CardHeader>
+						{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+						<CardContent><div className="font-bold text-xl">{(resumenData as any)?.totales?.cantidadCuotas ?? 0}</div></CardContent>
+					</Card>
+				</div>
+			)}
+
+			{!!resumenData && (
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				<p className="text-muted-foreground text-xs">Período: {(resumenData as any).fechaInicio} → {(resumenData as any).fechaFin}</p>
+			)}
+
+			{(() => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const desglose = ((resumenData as any)?.desglose ?? []) as DesgloseDia[];
+				if (temporalidad === "hoy" || desglose.length <= 1) return null;
+				return (
+					<div>
+						<h3 className="mb-3 font-semibold text-base">Desglose por Día</h3>
+						<div className="overflow-x-auto rounded-lg border">
+							<table className="w-full text-sm">
+								<thead className="bg-muted/50">
+									<tr>
+										<th className="px-4 py-3 text-left font-semibold">Fecha</th>
+										<th className="px-4 py-3 text-right font-semibold">Cuotas</th>
+										<th className="px-4 py-3 text-right font-semibold">Capital</th>
+										<th className="px-4 py-3 text-right font-semibold">Interés</th>
+										<th className="px-4 py-3 text-right font-semibold">IVA</th>
+										<th className="px-4 py-3 text-right font-semibold">Total a Cobrar</th>
+									</tr>
+								</thead>
+								<tbody>
+									{desglose.map((row) => (
+										<tr key={row.bucket} className="border-t hover:bg-muted/30">
+											<td className="px-4 py-3 font-medium">{fmtBucketDia(row.bucket)}</td>
+											<td className="px-4 py-3 text-right">{row.cuotas_count}</td>
+											<td className="px-4 py-3 text-right">{fmtQ(row.total_cuota)}</td>
+											<td className="px-4 py-3 text-right">{fmtQ(row.total_interes)}</td>
+											<td className="px-4 py-3 text-right">{fmtQ(row.total_iva)}</td>
+											<td className="px-4 py-3 text-right font-medium">{fmtQ(totalDeFila(row))}</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				);
+			})()}
+
+			<Separator />
+
+			<h3 className="font-semibold text-base">Pagos No Recibidos</h3>
+
+			<div className="flex flex-wrap items-end gap-4">
+				{canSeeAll && (
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Asesor</Label>
+						<Select value={emailAsesor} onValueChange={(v) => { setEmailAsesor(v === "todos" ? "" : v); setPage(1); }}>
+							<SelectTrigger className="w-52"><SelectValue placeholder="Todos los asesores" /></SelectTrigger>
+							<SelectContent>
+								<SelectItem value="todos">Todos</SelectItem>
+								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+								{(asesoresData as any)?.asesores?.map((a: any) => <SelectItem key={a.asesorId} value={a.email}>{a.nombre}</SelectItem>)}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+				<CapitalRangeFilter capitalMin={capitalMin} capitalMax={capitalMax} onCapitalRangeChange={(min, max) => { setCapitalMin(min); setCapitalMax(max); setPage(1); }} />
+				<div className="flex items-end gap-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Cuotas atrasadas mín.</Label>
+						<Input type="number" min={1} className="w-24" placeholder="1" value={cuotasMin} onChange={(e) => { setCuotasMin(e.target.value); setPage(1); }} />
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Cuotas atrasadas máx.</Label>
+						<Input type="number" min={1} className="w-24" placeholder="—" value={cuotasMax} onChange={(e) => { setCuotasMax(e.target.value); setPage(1); }} />
+					</div>
+				</div>
+				<div className="flex items-end gap-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Fecha pago desde</Label>
+						<Input type="date" className="w-40" value={fechaDesde} onChange={(e) => { setFechaDesde(e.target.value); setPage(1); }} />
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Fecha pago hasta</Label>
+						<Input type="date" className="w-40" value={fechaHasta} onChange={(e) => { setFechaHasta(e.target.value); setPage(1); }} />
+					</div>
+				</div>
+			</div>
+
+			<DataTable
+				columns={colsPagos}
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				data={(noRecibidosData as any)?.data ?? []}
+				isLoading={noRecibidosLoading}
+				hideSearch
+				serverPagination={
+					noRecibidosData
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						? { page: (noRecibidosData as any).page, pageSize: (noRecibidosData as any).pageSize, totalPages: (noRecibidosData as any).totalPages, totalItems: (noRecibidosData as any).total, onPageChange: setPage }
+						: undefined
+				}
+			/>
+		</div>
+	);
+}
+
+// ─── Descuentos ─────────────────────────────────────────────────────────────
+
+type DescuentoRow = {
+	sifco: string;
+	clienteNombre: string;
+	asesorNombre: string;
+	gps: string;
+	seguro: string;
+	membresias: string;
+	otros: string;
+	rubros: { nombre: string; monto: string }[];
+	rubrosTotal: string;
+	totalDescuentos: string;
+	capital: string;
+	tipoCredito: string | null;
+};
+
+const colsDescuentos: ColumnDef<DescuentoRow>[] = [
+	{
+		accessorKey: "sifco",
+		header: "Crédito",
+		cell: ({ row }) => (
+			<Link to="/cobros/$id" params={{ id: row.original.sifco }} search={{ tipo: "contrato" }} className="font-mono text-blue-600 text-xs hover:underline">
+				{row.original.sifco}
+			</Link>
+		),
+	},
+	{ accessorKey: "clienteNombre", header: "Cliente" },
+	{ accessorKey: "asesorNombre", header: "Asesor" },
+	{ accessorKey: "capital", header: "Capital", cell: ({ row }) => fmtQ(row.original.capital) },
+	{ accessorKey: "gps", header: "GPS", cell: ({ row }) => fmtQ(row.original.gps) },
+	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtQ(row.original.seguro) },
+	{ accessorKey: "membresias", header: "Membresías", cell: ({ row }) => fmtQ(row.original.membresias) },
+	{ accessorKey: "otros", header: "Otros", cell: ({ row }) => fmtQ(row.original.otros) },
+	{
+		accessorKey: "rubrosTotal",
+		header: "Rubros Extra",
+		cell: ({ row }) => {
+			const monto = fmtQ(row.original.rubrosTotal);
+			if (parseFloat(row.original.rubrosTotal) <= 0) return <span className="text-muted-foreground">—</span>;
+			return <div title={row.original.rubros.map((r) => `${r.nombre}: ${fmtQ(r.monto)}`).join("\n")}>{monto}</div>;
+		},
+	},
+	{
+		accessorKey: "totalDescuentos",
+		header: "Total Descuentos",
+		cell: ({ row }) => <span className="font-semibold">{fmtQ(row.original.totalDescuentos)}</span>,
+	},
+];
+
+function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
+	const [emailAsesor, setEmailAsesor] = usePersistedState<string>("cobros/reportes/desc/emailAsesor", "");
+	const [page, setPage] = usePersistedState<number>("cobros/reportes/desc/page", 1);
+	const [pageSize] = usePersistedState<number>("cobros/reportes/desc/pageSize", 25);
+
+	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
+
+	const { data: asesoresData } = useQuery({
+		...orpc.getAsesores.queryOptions({ input: {} }),
+		enabled: !!session && canSeeAll,
+	});
+
+	const { data, isLoading } = useQuery({
+		...orpc.getDescuentosCRM.queryOptions({ input: { page, pageSize, emailCobrador } }),
+		enabled: !!session,
+		staleTime: 5 * 60 * 1000,
+	});
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center gap-2">
+				<BarChart3 className="h-5 w-5 text-purple-600" />
+				<h2 className="font-semibold text-xl">Descuentos por Crédito</h2>
+			</div>
+
+			{canSeeAll && (
+				<div className="flex flex-col gap-1">
+					<Label className="text-xs">Asesor</Label>
+					<Select value={emailAsesor} onValueChange={(v) => { setEmailAsesor(v === "todos" ? "" : v); setPage(1); }}>
+						<SelectTrigger className="w-52"><SelectValue placeholder="Todos los asesores" /></SelectTrigger>
+						<SelectContent>
+							<SelectItem value="todos">Todos</SelectItem>
+							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+							{(asesoresData as any)?.asesores?.map((a: any) => <SelectItem key={a.asesorId} value={a.email}>{a.nombre}</SelectItem>)}
+						</SelectContent>
+					</Select>
+				</div>
+			)}
+
+			<DataTable
+				columns={colsDescuentos}
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				data={(data as any)?.data ?? []}
+				isLoading={isLoading}
+				hideSearch
+				serverPagination={
+					data
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						? { page: (data as any).page, pageSize: (data as any).pageSize, totalPages: (data as any).totalPages, totalItems: (data as any).total, onPageChange: setPage }
+						: undefined
+				}
+			/>
+		</div>
+	);
+}
+
+// ─── Root ───────────────────────────────────────────────────────────────────
+
+function RouteComponent() {
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user.role;
+	const canSeeAll = PERMISSIONS.canAssignCobros(userRole ?? "");
+	const [tab, setTab] = useState("mora");
+
+	// Reportes restringidos a admin/supervisor de cobros. Los endpoints ya
+	// devuelven 403 a otros roles; aquí evitamos renderizar la página rota.
+	if (session && !canSeeAll) {
+		return (
+			<div className="space-y-2 p-6">
+				<h1 className="font-bold text-2xl">Reportes de Cobros</h1>
+				<p className="text-muted-foreground">
+					No tienes permiso para ver estos reportes.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-6 p-6">
+			<div className="flex items-center gap-2">
+				<BarChart3 className="h-6 w-6 text-blue-600" />
+				<h1 className="font-bold text-2xl">Reportes de Cobros</h1>
+			</div>
+
+			<Tabs value={tab} onValueChange={setTab}>
+				<TabsList>
+					<TabsTrigger value="mora">
+						<TrendingDown className="mr-2 h-4 w-4" />
+						Análisis de Mora
+					</TabsTrigger>
+					<TabsTrigger value="pagos">
+						<CalendarClock className="mr-2 h-4 w-4" />
+						Pagos Esperados
+					</TabsTrigger>
+					<TabsTrigger value="descuentos">
+						<BarChart3 className="mr-2 h-4 w-4" />
+						Descuentos
+					</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="mora" className="mt-6">
+					<TabMora session={session} canSeeAll={canSeeAll} />
+				</TabsContent>
+				<TabsContent value="pagos" className="mt-6">
+					<TabPagos session={session} canSeeAll={canSeeAll} />
+				</TabsContent>
+				<TabsContent value="descuentos" className="mt-6">
+					<TabDescuentos session={session} canSeeAll={canSeeAll} />
+				</TabsContent>
+			</Tabs>
+		</div>
+	);
+}


### PR DESCRIPTION
## Resumen

Nueva página **`/cobros/reportes`** con 4 reportes de cobros, alimentados desde **cartera-back**. Acceso restringido a **admin / supervisor de cobros** (`cobrosSupervisorProcedure` → `ROLES.ADMIN || ROLES.COBROS_SUPERVISOR`), tanto en backend (los 4 endpoints devuelven 403 a otros roles) como en frontend (link oculto en header + guard en la página).

Endpoints nuevos en `apps/server/src/routers/cobros.ts`, página en `apps/web/src/routes/cobros/reportes.tsx`.

### Helper común de paginación
`obtenerTodasLasPaginasCreditos` recorre **toda** la cartera activa (cartera-back pagina de 100 en 100) acumulando resultados, en vez de un solo fetch que truncaba. Tope duro `MAX_PAGES=200` (≈20k créditos) con `console.warn` si se alcanza, para no truncar en silencio. Todos los reportes consultan con `mes: 0` = **todos los créditos sin filtrar por mes** (mismo criterio que la lista principal de cobros `getTodosLosCreditos`).

---

## Reporte 1 — Análisis de Mora (por etapa y por asesor)

**Endpoint:** `getMoraByEtapaYAsesor`
**Fuente:** `obtenerTodasLasPaginasCreditos({ mes: 0, estado: "ACTIVO" })` → cada crédito trae su objeto `mora` inline.

**Cálculo:**
- Se recorren los créditos activos; se incluye solo los que tienen `mora.cuotas_atrasadas >= 1`.
- **Bucket por etapa** según `cuotas_atrasadas`: `1 → Mora 30`, `2 → Mora 60`, `3 → Mora 90`, `>= 4 → Mora 120+`.
- Por bucket se acumula:
  - `cantidad` = número de créditos
  - `sumaMora` = Σ `mora.monto_mora`
  - `sumaCapital` = Σ `creditos.capital`
- **Por asesor:** se agrupa por `asesores.emailCashIn` del crédito (no por el endpoint `/stats?email=`, que para roles admin ignoraba el filtro y devolvía la cartera completa a todos). El nombre se toma de `asesores.nombre`; créditos sin asesor caen en "Sin asesor".
- **Total en mora** = suma de los 4 buckets (cantidad y monto). Los totales de la tabla por asesor cuadran con las cards superiores.

**Tiempo real:** `refetchInterval: 60s` (`refetchIntervalInBackground: false` para no refetch en pestaña en segundo plano).

---

## Reporte 2 — Pagos Esperados (por período, total y por rubro)

**Endpoint:** `getPagosEsperadosCobros`
**Fuente:** `carteraBackClient.getMontoACobrar({ periodo: "dia", fechaInicio, fechaFin })` → endpoint `/reportes/monto-cobrar` de cartera-back. Devuelve una fila por día con cuotas que **vencen** ese día.

**Ventana de fechas** (rodante desde hoy):
| Período | Días hacia adelante |
|---|---|
| Hoy | 0 |
| Esta Semana | +6 |
| Esta Quincena | +14 |
| Este Mes | +29 |

**Cálculo de totales** (suma sobre todas las filas del rango):
- ⚠️ En cartera-back **`total_cuota` ES el capital** de las cuotas (mismo criterio que el reporte monto-a-cobrar existente, que lo etiqueta "Capital").
- `Capital` = Σ `total_cuota`
- `Interés` = Σ `total_interes`, `IVA` = Σ `total_iva`, `Seguro` = Σ `total_seguro`, `GPS` = Σ `total_gps`, `Membresías` = Σ `total_membresias`, `Royaltí` = Σ `total_royalti`
- **Total a Cobrar** = Capital + Interés + IVA + Seguro + GPS + Membresías. **Excluye royaltí** a propósito (paridad con el reporte monto-a-cobrar existente; el royaltí es comisión del lado inversionista, no se le cobra al cliente).
- `cantidadCuotas` = Σ `cuotas_count`.

**Desglose por día:** tabla bajo las cards (Fecha · Cuotas · Capital · Interés · IVA · Total a Cobrar). Oculta cuando el período es "Hoy". Las fechas date-only se parsean como mediodía local (`T12:00:00`) para evitar desplazamiento por zona horaria.

---

## Reporte 3 — Pagos No Recibidos (listado filtrable)

**Endpoint:** `getPagosNoRecibidos`
**Fuente:** `obtenerTodasLasPaginasCreditos({ mes: 0, estado: "ACTIVO", email_cobrador, capital_min, capital_max, fecha_desde, fecha_hasta })`.

**Cálculo / filtros:**
- Se incluye créditos con `mora.cuotas_atrasadas` dentro de `[cuotasAtrasadasMin, cuotasAtrasadasMax]` (default `min = 1`; `max` opcional con `.min(1)` para no vaciar el listado por error).
- Filtros pasados nativamente a cartera-back: **asesor** (`email_cobrador`), **rango de capital** (`capital_min/max`), **fecha de pago** (`fecha_desde/fecha_hasta`).
- Columnas por crédito:
  - `Monto Mora` = `mora.monto_mora`
  - `Capital Restante` = `proxima_cuota.capital_restante` (saldo antes del próximo pago); cae a `creditos.capital` si la cuota no trae el campo
  - `Cuota Mensual` = `creditos.cuota`
  - `Próx. Vencimiento` = `proxima_cuota.fecha_vencimiento`
  - Badge de mora derivado de `cuotas_atrasadas` (mismo mapeo que el reporte 1)
- **Paginación server-side** (`page`, `pageSize`, default 25). `parseInt(x, 10)` con radix en los filtros numéricos.

---

## Reporte 4 — Descuentos por Crédito

**Endpoint:** `getDescuentosCRM`
**Fuente:** `obtenerTodasLasPaginasCreditos({ mes: 0, estado: "ACTIVO", email_cobrador })`.

**Cálculo por crédito:**
- `gps` = `creditos.gps`
- `seguro` = `creditos.seguro_10_cuotas`
- `membresias` = `creditos.membresias_pago`
- `otros` = `creditos.otros`
- `rubros[]` = `item.rubros` (rubros extra, cada uno `nombre_rubro` + `monto`); `rubrosTotal` = Σ montos
- **Total Descuentos** = gps + seguro + membresías + otros + rubrosTotal
- Solo se listan créditos con `Total Descuentos > 0`.
- Paginación server-side. Tooltip en "Rubros Extra" con el desglose de cada rubro.

---

## Seguridad / correcciones de review

- 🔴 **Authz:** los 4 endpoints migraron de `cobrosProcedure` a `cobrosSupervisorProcedure`. Antes un cobrador podía pedir la cartera de otros (o toda la empresa) por API; el guard solo existía en frontend.
- `cuotasAtrasadasMax` ahora `.min(1)` (evita listado vacío silencioso).
- Paginación con tope `MAX_PAGES` + warning (evita truncamiento silencioso y loop infinito si `totalPages` viniera null).
- `staleTime: 5min` en pagos-no-recibidos y descuentos; `refetchIntervalInBackground: false` en mora.

## Cómo probar
1. Como admin/supervisor: abrir **Cobros → Reportes**.
2. Mora: verificar que los totales de la tabla por asesor cuadren con las cards y con el dashboard de cobros.
3. Pagos esperados: cambiar período y validar que el rango de fechas y el desglose diario se ajusten.
4. Pagos no recibidos: filtrar por asesor, capital, cuotas y fecha de pago.
5. Como cobrador normal: confirmar que el link no aparece y que la página/endpoints devuelven acceso denegado / 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
