### PR TITLE
fix(cartera): el cron regenera los días recientes del snapshot (no solo-si-falta) + regenerar-rango

### DIFF
--- a/apps/cartera-back/schedule.ts
+++ b/apps/cartera-back/schedule.ts
@@ -7,7 +7,7 @@ import {
   verificarFacturasSat,
   reportarFacturasFallidasSat,
 } from './src/controllers/verificarFacturasSat';
-import { asegurarSnapshotDiario } from './src/controllers/facturacionSnapshot';
+import { generarSnapshotDiario } from './src/controllers/facturacionSnapshot';
 
 const TZ_GUATEMALA = 'America/Guatemala';
 
@@ -111,18 +111,21 @@ export function iniciarTareasProgramadas() {
     }
   });
 
-  // 📸 Snapshot diario de facturación - 01:00 hora Guatemala (respaldo).
-  //    Genera el snapshot del DÍA ANTERIOR SOLO si no se guardó ya manualmente.
+  // 📸 Snapshot diario de facturación - 01:00 hora Guatemala.
+  //    REGENERA (force) los últimos 3 días, NO "solo si falta": así captura
+  //    facturación que entró con fecha atrasada y refresca filas pre-creadas
+  //    (p. ej. del import del Excel hasta 2026-12-31) que de otro modo
+  //    quedarían congeladas en su valor viejo/0.
   schedule.scheduleJob({ rule: '0 1 * * *', tz: TZ_GUATEMALA }, async () => {
-    const fecha = getFechaGuatemalaISO(-1); // ayer en GT
-    console.log(`📸 Ejecutando asegurarSnapshotDiario para ${fecha} (01:00 Guatemala)...`);
-    try {
-      const res = await asegurarSnapshotDiario(fecha);
-      console.log(
-        `✅ snapshotDiario ${fecha}: ${res.created ? 'generado' : 'ya existía'}`,
-      );
-    } catch (error) {
-      console.error('❌ Error al ejecutar asegurarSnapshotDiario:', error);
+    for (const off of [-1, -2, -3]) {
+      const fecha = getFechaGuatemalaISO(off); // ayer, antier, trasantier (GT)
+      console.log(`📸 Regenerando snapshot diario ${fecha} (01:00 Guatemala)...`);
+      try {
+        await generarSnapshotDiario(fecha);
+        console.log(`✅ snapshotDiario ${fecha}: regenerado`);
+      } catch (error) {
+        console.error(`❌ Error regenerando snapshot ${fecha}:`, error);
+      }
     }
   });
 

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -342,6 +342,34 @@ export async function asegurarSnapshotDiario(fecha: string) {
   return { success: true, created: true, fecha };
 }
 
+// Regenera (force, upsert) el snapshot de CADA día en [fechaInicio, fechaFin].
+// A diferencia de asegurarSnapshotDiario, SIEMPRE recalcula aunque la fila ya
+// exista — útil para refrescar días pre-creados (p. ej. del import del Excel)
+// o capturar facturación que entró con fecha atrasada.
+export async function regenerarSnapshotRango(
+  fechaInicio: string,
+  fechaFin: string
+) {
+  const dias: string[] = [];
+  const d = new Date(`${fechaInicio}T00:00:00Z`);
+  const fin = new Date(`${fechaFin}T00:00:00Z`);
+  if (Number.isNaN(d.getTime()) || Number.isNaN(fin.getTime()) || d > fin) {
+    return { success: false, message: "Rango de fechas inválido" };
+  }
+  while (d <= fin) {
+    dias.push(d.toISOString().slice(0, 10));
+    d.setUTCDate(d.getUTCDate() + 1);
+    if (dias.length > 400) break; // tope defensivo
+  }
+  for (const f of dias) await generarSnapshotDiario(f);
+  return {
+    success: true,
+    regenerados: dias.length,
+    desde: dias[0],
+    hasta: dias[dias.length - 1],
+  };
+}
+
 // ============================================================================
 // 📥 EXPORTAR A EXCEL (diseño tipo Reuniones diarias, con logo y totales)
 // ============================================================================

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -6,6 +6,7 @@ import {
   generarExcelFacturacionDiaria,
   generarSnapshotDiario,
   getSnapshotsDiarios,
+  regenerarSnapshotRango,
 } from "../controllers/facturacionSnapshot";
 
 export const facturacionSnapshotRouter = new Elysia({
@@ -33,6 +34,35 @@ export const facturacionSnapshotRouter = new Elysia({
     {
       body: t.Object({
         fecha: t.String(), // "YYYY-MM-DD"
+      }),
+    }
+  )
+
+  // POST - Regenerar (force) el snapshot de un RANGO de días. Recalcula aunque
+  //        la fila exista. { fechaInicio: "YYYY-MM-DD", fechaFin: "YYYY-MM-DD" }
+  .post(
+    "/regenerar-rango",
+    async ({ body, set }: any) => {
+      try {
+        const result = await regenerarSnapshotRango(
+          body.fechaInicio,
+          body.fechaFin
+        );
+        if (!result.success) set.status = 400;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Error regenerando rango de snapshots",
+          error: String(error),
+        };
+      }
+    },
+    {
+      body: t.Object({
+        fechaInicio: t.String(), // "YYYY-MM-DD"
+        fechaFin: t.String(), // "YYYY-MM-DD"
       }),
     }
   )


### PR DESCRIPTION
## 🐞 Problema

El snapshot diario de facturación **no se actualizaba** para los días recientes en prod.

Causa: el job era `asegurarSnapshotDiario` = **"generar SOLO si la fila no existe"**. Como el import del Excel "Reuniones diarias" pre-creó **todas las fechas hasta 2026-12-31**, el cron las veía "existentes" y **nunca las regeneraba** → se quedaban congeladas con el valor del Excel (o en 0 las futuras).

Ejemplo real en prod: **2026-06-12** mostraba `facturacion = 0` aunque el desglose tenía **46k (CUBE) + 13.5k (inversionistas)** ese día.

## 🔧 Cambios

1. **`schedule.ts`** — el cron de 01:00 GT ahora **REGENERA (force) los últimos 3 días** (ayer, antier, trasantier) con `generarSnapshotDiario`, en vez de `asegurarSnapshotDiario`. Beneficios:
   - Refresca filas pre-creadas (las del import) que "solo si falta" nunca tocaba.
   - Captura facturación que entra con **fecha atrasada** (`fecha_aplicado` backdated).
   - Recalcula el cierre del día con la data ya completa.
2. **`facturacionSnapshot.ts`** — nueva `regenerarSnapshotRango(fechaInicio, fechaFin)`: fuerza el recálculo de cada día del rango (upsert), con tope defensivo de 400 días.
3. **`routers/facturacionSnapshot.ts`** — `POST /api/facturacion-snapshot/regenerar-rango { fechaInicio, fechaFin }` para regenerar un rango a mano (p. ej. backfills).

`asegurarSnapshotDiario` se mantiene exportada por compatibilidad.

## 🧪 Ya aplicado en prod (data)
Regeneré a mano **2026-06-10 → 06-14** con la función real apuntando a prod (corte acordado en 06-10): 06-12 quedó en `facturacion = 97,962` con `inversionistas = 13,503` (antes 0); 06-10/06-11 pasaron del valor del Excel al valor real del sistema. Este PR evita que el problema se repita de aquí en adelante.

## ⚠️ Nota
Las filas placeholder de fechas **futuras** (> hoy) siguen existiendo en 0; se irán regenerando solas conforme cada día entra en la ventana de los últimos 3 días. Si se quieren limpiar de una, se puede usar `regenerar-rango` o borrarlas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
