### PR TITLE
feat(crm): clasificar facturas del cierre con rubro_desglose (para el reporte de cartera)

### DIFF
--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -456,6 +456,7 @@ function buildInvoices(
 				{
 					monto: royalti,
 					rubro: "Royalty",
+					rubro_desglose: "ROYALTY",
 				},
 			],
 		});
@@ -480,6 +481,7 @@ function buildInvoices(
 				{
 					monto: FACTURACION_TRASPASO_COSTO,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -497,6 +499,7 @@ function buildInvoices(
 				{
 					monto: leasingContractCost,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -514,6 +517,7 @@ function buildInvoices(
 				{
 					monto: FACTURACION_GARANTIA_MOBILIARIA_COSTO,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -533,12 +537,14 @@ function buildInvoices(
 			cuota0Items.push({
 				monto: interestCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "INTERES",
 			});
 		}
 		if (extraMembershipCost > 0) {
 			cuota0Items.push({
 				monto: extraMembershipCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "MEMBRESIA",
 			});
 		}
 		if (cuota0Items.length > 0) {
@@ -562,6 +568,7 @@ function buildInvoices(
 				{
 					monto: FACTURACION_NOMBRAMIENTO_COSTO,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -579,6 +586,7 @@ function buildInvoices(
 				{
 					monto: keyCopyDiffCost,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -598,12 +606,14 @@ function buildInvoices(
 			seguroGastosItems.push({
 				monto: extraInsuranceCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "SEGURO",
 			});
 		}
 		if (extraAdminCost > 0) {
 			seguroGastosItems.push({
 				monto: extraAdminCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "OTROS",
 			});
 		}
 		if (seguroGastosItems.length > 0) {

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -665,6 +665,9 @@ export interface GetStatsParams {
 export interface FacturaItem {
 	monto: number;
 	rubro: string;
+	/** Rubro del REPORTE (enum rubro_facturacion de cartera-back) para el desglose.
+	 *  Opcional: si viene, cartera lo guarda en facturacion_desglose y el snapshot lo suma. */
+	rubro_desglose?: string;
 }
 
 /** Input para facturación genérica */


### PR DESCRIPTION
## 🎯 Qué hace
Al cerrar una oportunidad, las facturas genéricas que el CRM manda a cartera ahora incluyen **`rubro_desglose`** por item (el rubro del reporte diario). Así cartera las guarda en `facturacion_desglose` y el snapshot captura **otros ingresos / royalty / etc.** facturados en el cierre (antes salían en ~0).

## 🗂️ Mapeo
| Factura del cierre | rubro_desglose |
|---|---|
| Royalty | `ROYALTY` |
| Traspaso / Contrato abogado / Garantía / Nombramiento / Copia de llave | `OTROS` |
| Cuota 0 — interés anticipado | `INTERES` |
| Cuota 0 — membresía | `MEMBRESIA` |
| Seguro extra | `SEGURO` |
| Gastos administrativos | `OTROS` |

## 🧩 Cambios
- `FacturaItem` gana el campo **opcional** `rubro_desglose?: string`.
- `buildInvoices` setea el `rubro_desglose` de cada item (10 items).

## ⚠️ Depende de
**#873** (cartera-back: `/facturar-generico` acepta `rubro_desglose` y lo guarda en `facturacion_desglose`). Mergear/desplegar #873 primero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
