### PR TITLE
feat(cartera): acumulados del snapshot como suma corrida (continuo tipo Excel)

### DIFF
--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -179,63 +179,36 @@ export async function generarSnapshotDiario(fecha: string) {
     .plus(interes_cube);
   const facturacion_mas_servicios = facturacion.plus(servicios);
 
-  // 6) Acumulados MTD (recalculados sobre [monthStart, fecha])
-  const mtd = await db.execute(sql`
+  // 6) Acumulados del mes = SUMA CORRIDA de las columnas DIARIAS del snapshot
+  //    [1º del mes … este día]: se suman los días PREVIOS ya guardados y se agrega
+  //    lo de HOY (recién calculado). Así enlazan CONTINUO aunque parte del mes venga
+  //    del Excel importado y parte del sistema (antes se recalculaba del desglose
+  //    MTD y se rompía en el corte Excel↔sistema). Reserva NO (no tiene columna
+  //    diaria y pagos_credito sí tiene histórico → se deja MTD de pagos).
+  const prev = await db.execute(sql`
     SELECT
-      COALESCE(SUM(CASE WHEN rubro IN ('INTERES','MEMBRESIA','OTROS','MORA') THEN monto_total ELSE 0 END), 0) AS fact_desg,
-      COALESCE(SUM(CASE WHEN rubro IN ('SEGURO','GPS') THEN monto_total ELSE 0 END), 0) AS servicios
-    FROM cartera.facturacion_desglose
-    WHERE fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
+      COALESCE(SUM(facturacion), 0)                AS fact,
+      COALESCE(SUM(servicios_seguro_gps), 0)       AS serv,
+      COALESCE(SUM(facturacion_inversionistas), 0) AS inv,
+      COALESCE(SUM(ingreso_carros), 0)             AS carros
+    FROM cartera.facturacion_snapshot_diario
+    WHERE fecha >= ${monthStart}::date AND fecha < ${fecha}::date
   `);
-  // Royalty MTD: lo REALMENTE facturado (rubro ROYALTY del desglose) + RESPALDO de
-  // creditos.royalti, pero SOLO de créditos cuyo NIT NO tenga factura genérica
-  // ROYALTY en el mes (dedup por NIT, mismo criterio que el día → la suma de los
-  // días cuadra con el MTD y no hay doble conteo por fechas distintas).
-  const royMtd = await db.execute(sql`
-    SELECT
-      COALESCE((SELECT SUM(monto_total) FROM cartera.facturacion_desglose
-                WHERE rubro::text = 'ROYALTY'
-                  AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date), 0)
-      +
-      COALESCE((SELECT SUM(c.royalti)
-                FROM cartera.creditos c
-                JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-                WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
-                  AND NOT EXISTS (
-                    SELECT 1
-                    FROM cartera.facturacion_desglose fdr
-                    JOIN cartera.facturas_electronicas fe ON fe.factura_id = fdr.factura_id
-                    WHERE fdr.rubro::text = 'ROYALTY' AND fdr.pago_id IS NULL
-                      AND fdr.fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
-                      AND regexp_replace(COALESCE(fe.receptor_nit, ''), '[^0-9A-Za-z]', '', 'g')
-                        = regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g')
-                  )), 0) AS total
-  `);
-  const invMtd = await db.execute(sql`
-    SELECT COALESCE(SUM(monto_total), 0) AS total
-    FROM cartera.facturacion_desglose
-    WHERE rubro::text = 'INTERES_INVERSIONISTAS'
-      AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
-  `);
-  // Reserva acumulada (MTD) desde pagos_credito.reserva
-  const reservaMtd = await db.execute(sql`
-    SELECT COALESCE(SUM(reserva), 0) AS total FROM cartera.pagos_credito
-    WHERE (fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
-  `);
-  const carrosMtd = await db.execute(sql`
-    SELECT COALESCE(SUM(monto), 0) AS total FROM cartera.ingresos_carros
-    WHERE fecha BETWEEN ${monthStart}::date AND ${fecha}::date
-  `);
-  const facturacion_acumulado = new Big((mtd as any).rows[0].fact_desg).plus(
-    (royMtd as any).rows[0].total
-  );
-  const acum_servicios = new Big((mtd as any).rows[0].servicios);
-  const ingresoCarrosMtd = new Big((carrosMtd as any).rows[0].total);
+  const P = (prev as any).rows?.[0] ?? {};
+  // Suma corrida = (días previos del mes ya guardados) + (lo de HOY recién calculado).
+  const facturacion_acumulado = new Big(P.fact || 0).plus(facturacion);
+  const acum_servicios = new Big(P.serv || 0).plus(servicios);
+  const acumulado_inversionistas = new Big(P.inv || 0).plus(factInv);
+  const ingresoCarrosMtd = new Big(P.carros || 0).plus(ingresoCarros);
   // AY (Excel): facturación + servicios + ingreso carros (acumulado del mes).
   const acumulado_total = facturacion_acumulado
     .plus(acum_servicios)
     .plus(ingresoCarrosMtd);
-  const acumulado_inversionistas = new Big((invMtd as any).rows[0].total);
+  // Reserva acumulada (MTD) desde pagos_credito.reserva (pagos tiene histórico → sin corte).
+  const reservaMtd = await db.execute(sql`
+    SELECT COALESCE(SUM(reserva), 0) AS total FROM cartera.pagos_credito
+    WHERE (fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
+  `);
   const reserva_acumulada = new Big((reservaMtd as any).rows[0].total);
 
   // 7) Tendencias (proyección lineal sobre MTD)


### PR DESCRIPTION
## 🎯 Qué resuelve
Los acumulados del reporte diario **se rompían** en meses con corte Excel↔sistema. Ejemplo real en prod (junio 2026):
```
06-08  acum 393,454   (Excel)
06-09  acum 0         ❌ se reinicia
06-11  acum 252,768   ❌ arranca de nuevo (recalculado del desglose, < 393k)
```
Causa: el acumulado se **recalculaba MTD desde el desglose**, que no tiene la data de inicios de mes importada del Excel → discontinuidad.

## 🧩 Cambio
Los acumulados pasan a ser **suma corrida de las columnas DIARIAS del snapshot** del mes (días previos ya guardados + lo de hoy):
```
acum(día) = SUM(columna diaria de [1º..día-1]) + (valor de hoy)
```
Aplica a: `facturacion_acumulado`, `acum_servicios_seguro_gps`, `acumulado_total`, `acumulado_inversionistas`. Como las columnas diarias ya tienen Excel (días viejos) + sistema (días nuevos), el acumulado queda **continuo** tipo Excel.

- `reserva_acumulada` se queda MTD de `pagos_credito.reserva` (no tiene columna diaria y `pagos` sí tiene histórico → no sufre el corte).
- Se eliminan las queries MTD del desglose (`mtd`/`royMtd`/`invMtd`/`carrosMtd`) que ya no se usan. El dedup de royalty vive ahora en el cálculo DIARIO (sección 2), y la suma corrida lo arrastra correcto.

## ⚠️ Notas
- **Order-dependent**: para aplicarlo a un mes YA guardado hay que **regenerar sus días EN ORDEN** (el cron de #872 y `regenerar-rango` ya procesan en orden). Regenerar un día pasado obliga a regenerar los posteriores.
- **Stacked sobre #873** (`feat/cartera-desglose-facturas-genericas`) — depende del dedup de royalty del día. Mergear #873 primero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
