### PR TITLE
feat(reportes): simulador de escenarios "qué pasaría si"

### DIFF
--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -28,13 +28,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import {
 	Table,
 	TableBody,
 	TableCell,
@@ -46,7 +39,6 @@ import {
 	cuotaIlustrativa,
 	DEFAULT_SCENARIO_PARAMS,
 	type LeverKey,
-	type MetodoCuota,
 	type ScenarioParams,
 } from "@/lib/reports/scenario";
 import type {
@@ -215,26 +207,11 @@ export function ScenarioModal<T>({
 
 							{config.usaMetodoCuota && (
 								<div className="space-y-2 border-t pt-3">
-									<Label className="text-sm">Método de cuota</Label>
-									<Select
-										value={params.metodoCuota}
-										onValueChange={(v) =>
-											setField("metodoCuota", v as MetodoCuota)
-										}
-									>
-										<SelectTrigger className="h-9">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="actual">Actual</SelectItem>
-											<SelectItem value="frances">
-												Francés (nivelada)
-											</SelectItem>
-											<SelectItem value="fija">
-												Cuota fija de capital
-											</SelectItem>
-										</SelectContent>
-									</Select>
+									<Label className="text-sm">Cuota mensual por método</Label>
+									<p className="text-muted-foreground text-xs">
+										Compara la cuota de un crédito promedio según el método de
+										amortización.
+									</p>
 									<div className="grid grid-cols-3 gap-2">
 										<div>
 											<Label className="text-muted-foreground text-xs">

--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -1,0 +1,380 @@
+/**
+ * Modal de simulación "qué pasaría si" para los reportes.
+ *
+ * Recibe los datos reales del reporte y su config, aplica los supuestos en el
+ * cliente y muestra el resultado simulado vs real. No modifica datos reales.
+ */
+
+import { Sparkles } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Legend,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import {
+	cuotaIlustrativa,
+	DEFAULT_SCENARIO_PARAMS,
+	type LeverKey,
+	type MetodoCuota,
+	type ScenarioParams,
+} from "@/lib/reports/scenario";
+import type {
+	ScenarioReportConfig,
+	SummaryRow,
+} from "@/lib/reports/scenario-configs";
+
+function formatQ(value: number): string {
+	return `Q${value.toLocaleString("es-GT", {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	})}`;
+}
+
+function deltaPct(real: number, escenario: number): string {
+	if (real === 0) return escenario === 0 ? "0%" : "—";
+	const pct = ((escenario - real) / Math.abs(real)) * 100;
+	const sign = pct > 0 ? "+" : "";
+	return `${sign}${pct.toFixed(1)}%`;
+}
+
+function deltaColor(real: number, escenario: number): string {
+	if (escenario > real) return "text-green-600";
+	if (escenario < real) return "text-red-600";
+	return "text-muted-foreground";
+}
+
+const LEVER_LABELS: Record<
+	Exclude<LeverKey, "metodo">,
+	{ label: string; hint: string; max: number }
+> = {
+	colocacion: {
+		label: "Colocar más (%)",
+		hint: "Aumenta el capital colocado",
+		max: 100,
+	},
+	mora: { label: "Bajar mora (%)", hint: "Reduce la mora", max: 100 },
+	efectividad: {
+		label: "Subir efectividad (%)",
+		hint: "Cierra la brecha contra lo esperado",
+		max: 100,
+	},
+};
+
+const LEVER_FIELD: Record<Exclude<LeverKey, "metodo">, keyof ScenarioParams> = {
+	colocacion: "colocacionDeltaPct",
+	mora: "moraReduccionPct",
+	efectividad: "efectividadDeltaPct",
+};
+
+function LeverSlider({
+	lever,
+	value,
+	onChange,
+}: {
+	lever: Exclude<LeverKey, "metodo">;
+	value: number;
+	onChange: (v: number) => void;
+}) {
+	const cfg = LEVER_LABELS[lever];
+	return (
+		<div className="space-y-1.5">
+			<div className="flex items-center justify-between">
+				<Label className="text-sm">{cfg.label}</Label>
+				<span className="text-muted-foreground text-xs">{cfg.hint}</span>
+			</div>
+			<div className="flex items-center gap-3">
+				<input
+					type="range"
+					min={0}
+					max={cfg.max}
+					step={1}
+					value={value}
+					onChange={(e) => onChange(Number(e.target.value))}
+					className="h-2 flex-1 cursor-pointer accent-purple-500"
+				/>
+				<div className="relative w-20 shrink-0">
+					<Input
+						type="number"
+						min={0}
+						max={cfg.max}
+						value={value}
+						onChange={(e) => onChange(Number(e.target.value) || 0)}
+						className="h-9 pr-6 text-right"
+					/>
+					<span className="pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 text-muted-foreground text-sm">
+						%
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface ScenarioModalProps<T> {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	config: ScenarioReportConfig<T>;
+	baseData: T | undefined;
+}
+
+export function ScenarioModal<T>({
+	open,
+	onOpenChange,
+	config,
+	baseData,
+}: ScenarioModalProps<T>) {
+	const [params, setParams] = useState<ScenarioParams>(DEFAULT_SCENARIO_PARAMS);
+
+	const setField = <K extends keyof ScenarioParams>(
+		key: K,
+		value: ScenarioParams[K],
+	) => setParams((prev) => ({ ...prev, [key]: value }));
+
+	const { realRows, simRows } = useMemo(() => {
+		if (!baseData) return { realRows: [], simRows: [] as SummaryRow[] };
+		const sim = config.transform(baseData, params);
+		return {
+			realRows: config.summarize(baseData),
+			simRows: config.summarize(sim),
+		};
+	}, [baseData, config, params]);
+
+	const chartData = useMemo(
+		() =>
+			realRows.map((row, i) => ({
+				concepto: row.concepto,
+				Real: row.valor,
+				Escenario: simRows[i]?.valor ?? 0,
+			})),
+		[realRows, simRows],
+	);
+
+	const cuota = config.usaMetodoCuota ? cuotaIlustrativa(params) : null;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[900px]">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<Sparkles className="h-4 w-4 text-purple-500" />
+						Simular: {config.titulo}
+					</DialogTitle>
+					<DialogDescription>{config.descripcion}</DialogDescription>
+				</DialogHeader>
+
+				{!baseData ? (
+					<p className="py-8 text-center text-muted-foreground text-sm">
+						Carga primero el reporte para poder simular.
+					</p>
+				) : (
+					<div className="grid gap-6 md:grid-cols-[280px_1fr]">
+						{/* Supuestos */}
+						<div className="space-y-4">
+							<h4 className="font-semibold text-sm">Supuestos</h4>
+							{config.levers
+								.filter((l): l is Exclude<LeverKey, "metodo"> => l !== "metodo")
+								.map((lever) => (
+									<LeverSlider
+										key={lever}
+										lever={lever}
+										value={params[LEVER_FIELD[lever]] as number}
+										onChange={(v) => setField(LEVER_FIELD[lever], v)}
+									/>
+								))}
+
+							{config.usaMetodoCuota && (
+								<div className="space-y-2 border-t pt-3">
+									<Label className="text-sm">Método de cuota</Label>
+									<Select
+										value={params.metodoCuota}
+										onValueChange={(v) =>
+											setField("metodoCuota", v as MetodoCuota)
+										}
+									>
+										<SelectTrigger className="h-9">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="actual">Actual</SelectItem>
+											<SelectItem value="frances">
+												Francés (nivelada)
+											</SelectItem>
+											<SelectItem value="fija">
+												Cuota fija de capital
+											</SelectItem>
+										</SelectContent>
+									</Select>
+									<div className="grid grid-cols-3 gap-2">
+										<div>
+											<Label className="text-muted-foreground text-xs">
+												Capital
+											</Label>
+											<Input
+												type="number"
+												value={params.metodoCapital}
+												onChange={(e) =>
+													setField("metodoCapital", Number(e.target.value) || 0)
+												}
+												className="h-9"
+											/>
+										</div>
+										<div>
+											<Label className="text-muted-foreground text-xs">
+												Plazo
+											</Label>
+											<Input
+												type="number"
+												value={params.metodoPlazoMeses}
+												onChange={(e) =>
+													setField(
+														"metodoPlazoMeses",
+														Number(e.target.value) || 1,
+													)
+												}
+												className="h-9"
+											/>
+										</div>
+										<div>
+											<Label className="text-muted-foreground text-xs">
+												Tasa %
+											</Label>
+											<Input
+												type="number"
+												step="0.01"
+												value={params.metodoTasaMensual}
+												onChange={(e) =>
+													setField(
+														"metodoTasaMensual",
+														Number(e.target.value) || 0,
+													)
+												}
+												className="h-9"
+											/>
+										</div>
+									</div>
+									{cuota && (
+										<div className="rounded-md bg-muted/50 p-2 text-xs">
+											<div className="flex justify-between">
+												<span>Cuota francés:</span>
+												<span className="font-medium">
+													{formatQ(cuota.frances)}
+												</span>
+											</div>
+											<div className="flex justify-between">
+												<span>Cuota fija (1ª):</span>
+												<span className="font-medium">
+													{formatQ(cuota.fija)}
+												</span>
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+
+							<Button
+								variant="outline"
+								size="sm"
+								className="w-full"
+								onClick={() => setParams(DEFAULT_SCENARIO_PARAMS)}
+							>
+								Restablecer
+							</Button>
+						</div>
+
+						{/* Resultado */}
+						<div className="space-y-4">
+							<ResponsiveContainer width="100%" height={240}>
+								<BarChart data={chartData}>
+									<CartesianGrid strokeDasharray="3 3" />
+									<XAxis dataKey="concepto" tick={{ fontSize: 11 }} />
+									<YAxis
+										tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`}
+										tick={{ fontSize: 11 }}
+									/>
+									<Tooltip formatter={(v) => formatQ(Number(v))} />
+									<Legend />
+									<Bar dataKey="Real" fill="#94a3b8" radius={[4, 4, 0, 0]} />
+									<Bar
+										dataKey="Escenario"
+										fill="#a855f7"
+										radius={[4, 4, 0, 0]}
+									/>
+								</BarChart>
+							</ResponsiveContainer>
+
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Concepto</TableHead>
+										<TableHead className="text-right">Real</TableHead>
+										<TableHead className="text-right">Escenario</TableHead>
+										<TableHead className="text-right">Δ</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{realRows.map((row, i) => {
+										const esc = simRows[i]?.valor ?? 0;
+										return (
+											<TableRow key={row.concepto}>
+												<TableCell className="font-medium">
+													{row.concepto}
+												</TableCell>
+												<TableCell className="text-right">
+													{formatQ(row.valor)}
+												</TableCell>
+												<TableCell className="text-right">
+													{formatQ(esc)}
+												</TableCell>
+												<TableCell
+													className={`text-right ${deltaColor(row.valor, esc)}`}
+												>
+													{deltaPct(row.valor, esc)}
+												</TableCell>
+											</TableRow>
+										);
+									})}
+								</TableBody>
+							</Table>
+
+							<p className="text-muted-foreground text-xs">
+								Resultados estimados a partir de los datos del reporte. No
+								modifican datos reales.
+							</p>
+						</div>
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -90,18 +90,31 @@ export const flujoCuotasConfig: ScenarioReportConfig<FlujoCuotasInversionesRespo
 		usaMetodoCuota: true,
 		transform: transformFlujoCuotas,
 		summarize: (data) => {
-			const reinvCap = sumBy(data.reinversionPorTipo, (r) => num(r.capital));
-			const reinvInt = sumBy(data.reinversionPorTipo, (r) => num(r.interes));
-			const cash = sumBy(
-				data.cashParcialPorTipo,
-				(r) => num(r.capital) + num(r.interes),
+			// Réplica de la lógica de totales del reporte (admin/reports/index.tsx):
+			// variable/excedente son total-only (monto_reinvertido), interés incluye
+			// IVA, cash usa monto_cash si existe, y sin-reinversión suma capital+interés+IVA.
+			const reinversion = sumBy(data.reinversionPorTipo, (r) => {
+				if (
+					r.tipo === "reinversion_variable" ||
+					r.tipo === "reinversion_excedente"
+				)
+					return num(r.monto_reinvertido);
+				if (r.tipo === "reinversion_capital") return num(r.capital);
+				if (r.tipo === "reinversion_interes")
+					return num(r.interes) + num(r.iva);
+				return num(r.capital) + num(r.interes) + num(r.iva);
+			});
+			const cash = sumBy(data.cashParcialPorTipo, (r) =>
+				r.monto_cash
+					? num(r.monto_cash)
+					: num(r.capital) + num(r.interes) + num(r.iva),
 			);
 			const sinReinv =
 				num(data.sinReinversion.totales.capital) +
-				num(data.sinReinversion.totales.interes);
+				num(data.sinReinversion.totales.interes) +
+				num(data.sinReinversion.totales.iva);
 			return [
-				{ concepto: "Reinv. capital", valor: reinvCap },
-				{ concepto: "Reinv. interés", valor: reinvInt },
+				{ concepto: "Reinversión", valor: reinversion },
 				{ concepto: "Cash parcial", valor: cash },
 				{ concepto: "Sin reinversión", valor: sinReinv },
 				{

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -59,8 +59,12 @@ export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
 		},
 		{ concepto: "Royalti", valor: sumBy(rows, (r) => num(r.total_royalti)) },
 		{
+			// mora_promedio ya es un promedio por bucket; promediamos entre
+			// buckets para no inflar el valor con la cantidad de períodos.
 			concepto: "Mora prom.",
-			valor: sumBy(rows, (r) => num(r.mora_promedio)),
+			valor: rows.length
+				? sumBy(rows, (r) => num(r.mora_promedio)) / rows.length
+				: 0,
 		},
 	],
 };

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -1,0 +1,155 @@
+/**
+ * Config de escenarios por reporte: qué palancas aplican, cómo transformar los
+ * datos y cómo resumirlos para la comparación real vs escenario del modal.
+ */
+import {
+	type ComparativoHistoricoRow,
+	type FacturacionMesResponse,
+	type FlujoCuotasInversionesResponse,
+	type LeverKey,
+	type MontoACobrarRow,
+	type PuntoEquilibrioRow,
+	type ScenarioParams,
+	transformCobertura,
+	transformComparativo,
+	transformFacturacion,
+	transformFlujoCuotas,
+	transformMontoACobrar,
+} from "./scenario";
+
+export interface SummaryRow {
+	concepto: string;
+	valor: number;
+}
+
+export interface ScenarioReportConfig<T> {
+	titulo: string;
+	descripcion: string;
+	levers: LeverKey[];
+	/** Muestra controles de cuota ilustrativa (método de amortización). */
+	usaMetodoCuota: boolean;
+	transform: (base: T, p: ScenarioParams) => T;
+	summarize: (data: T) => SummaryRow[];
+}
+
+const num = (v: string | number | null | undefined): number => {
+	const x = Number(v);
+	return Number.isFinite(x) ? x : 0;
+};
+
+const sumBy = <T>(rows: T[], pick: (r: T) => number): number =>
+	rows.reduce((acc, r) => acc + pick(r), 0);
+
+export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
+	titulo: "Monto a Cobrarse por Período",
+	descripcion:
+		"Estima cómo cambian las cuotas a cobrar si crece la colocación o baja la mora.",
+	levers: ["colocacion", "mora", "metodo"],
+	usaMetodoCuota: true,
+	transform: transformMontoACobrar,
+	summarize: (rows) => [
+		{ concepto: "Capital", valor: sumBy(rows, (r) => num(r.total_cuota)) },
+		{ concepto: "Interés", valor: sumBy(rows, (r) => num(r.total_interes)) },
+		{ concepto: "IVA", valor: sumBy(rows, (r) => num(r.total_iva)) },
+		{ concepto: "Seguro", valor: sumBy(rows, (r) => num(r.total_seguro)) },
+		{ concepto: "GPS", valor: sumBy(rows, (r) => num(r.total_gps)) },
+		{
+			concepto: "Membresías",
+			valor: sumBy(rows, (r) => num(r.total_membresias)),
+		},
+		{ concepto: "Royalti", valor: sumBy(rows, (r) => num(r.total_royalti)) },
+		{
+			concepto: "Mora prom.",
+			valor: sumBy(rows, (r) => num(r.mora_promedio)),
+		},
+	],
+};
+
+export const facturacionConfig: ScenarioReportConfig<FacturacionMesResponse> = {
+	titulo: "Facturado del Mes vs Esperado",
+	descripcion:
+		"Estima cuánto más se cobraría al subir la efectividad o bajar la mora.",
+	levers: ["efectividad", "mora"],
+	usaMetodoCuota: false,
+	transform: transformFacturacion,
+	summarize: (data) => [
+		{ concepto: "Capital", valor: num(data.cobrado.capital) },
+		{ concepto: "Interés", valor: num(data.cobrado.interes) },
+		{ concepto: "IVA", valor: num(data.cobrado.iva) },
+		{ concepto: "Seguro", valor: num(data.cobrado.seguro) },
+		{ concepto: "GPS", valor: num(data.cobrado.gps) },
+		{ concepto: "Membresías", valor: num(data.cobrado.membresias) },
+	],
+};
+
+export const flujoCuotasConfig: ScenarioReportConfig<FlujoCuotasInversionesResponse> =
+	{
+		titulo: "Flujo de Cuotas de Inversiones",
+		descripcion: "Estima cómo escalan los flujos si crece la colocación.",
+		levers: ["colocacion", "metodo"],
+		usaMetodoCuota: true,
+		transform: transformFlujoCuotas,
+		summarize: (data) => {
+			const reinvCap = sumBy(data.reinversionPorTipo, (r) => num(r.capital));
+			const reinvInt = sumBy(data.reinversionPorTipo, (r) => num(r.interes));
+			const cash = sumBy(
+				data.cashParcialPorTipo,
+				(r) => num(r.capital) + num(r.interes),
+			);
+			const sinReinv =
+				num(data.sinReinversion.totales.capital) +
+				num(data.sinReinversion.totales.interes);
+			return [
+				{ concepto: "Reinv. capital", valor: reinvCap },
+				{ concepto: "Reinv. interés", valor: reinvInt },
+				{ concepto: "Cash parcial", valor: cash },
+				{ concepto: "Sin reinversión", valor: sinReinv },
+				{
+					concepto: "Abonos capital",
+					valor: num(data.pagosExtras.abonos_capital),
+				},
+				{
+					concepto: "Cancelaciones",
+					valor: num(data.pagosExtras.cancelaciones),
+				},
+			];
+		},
+	};
+
+export const coberturaConfig: ScenarioReportConfig<PuntoEquilibrioRow[]> = {
+	titulo: "Cobertura de Colocación vs Meta",
+	descripcion: "Estima la cobertura si se coloca más capital.",
+	levers: ["colocacion"],
+	usaMetodoCuota: false,
+	transform: transformCobertura,
+	summarize: (rows) => [
+		{ concepto: "Colocado", valor: sumBy(rows, (r) => num(r.colocado)) },
+		{ concepto: "Meta", valor: sumBy(rows, (r) => num(r.meta)) },
+		{ concepto: "Faltante", valor: sumBy(rows, (r) => num(r.faltante)) },
+	],
+};
+
+export const comparativoConfig: ScenarioReportConfig<
+	ComparativoHistoricoRow[]
+> = {
+	titulo: "Comparativo Histórico Mensual",
+	descripcion:
+		"Estima el año si crece la colocación, sube la efectividad o baja la mora.",
+	levers: ["colocacion", "efectividad", "mora"],
+	usaMetodoCuota: false,
+	transform: transformComparativo,
+	summarize: (rows) => [
+		{
+			concepto: "Colocación",
+			valor: sumBy(rows, (r) => num(r.colocacion_monto)),
+		},
+		{
+			concepto: "Facturación",
+			valor: sumBy(rows, (r) => num(r.facturacion)),
+		},
+		{ concepto: "Mora 30", valor: sumBy(rows, (r) => num(r.mora_30)) },
+		{ concepto: "Mora 60", valor: sumBy(rows, (r) => num(r.mora_60)) },
+		{ concepto: "Mora 90", valor: sumBy(rows, (r) => num(r.mora_90)) },
+		{ concepto: "Mora 120+", valor: sumBy(rows, (r) => num(r.mora_120)) },
+	],
+};

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -107,6 +107,18 @@ describe("transformFacturacion", () => {
 		);
 		expect(out.esperado.capital).toBe("1000");
 	});
+
+	test("rubro sobre-cobrado (cobrado > esperado) se preserva intacto", () => {
+		const over: FacturacionMesResponse = {
+			cobrado: { ...data.cobrado, interes: "150" },
+			esperado: { ...data.esperado, interes: "100" },
+		};
+		const out = transformFacturacion(
+			over,
+			params({ efectividadDeltaPct: 100 }),
+		);
+		expect(out.cobrado.interes).toBe("150.00");
+	});
 });
 
 describe("transformCobertura", () => {

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type ComparativoHistoricoRow,
+	cuotaIlustrativa,
+	DEFAULT_SCENARIO_PARAMS,
+	type FacturacionMesResponse,
+	type MontoACobrarRow,
+	type PuntoEquilibrioRow,
+	type ScenarioParams,
+	transformCobertura,
+	transformComparativo,
+	transformFacturacion,
+	transformMontoACobrar,
+} from "./scenario";
+
+const params = (overrides: Partial<ScenarioParams> = {}): ScenarioParams => ({
+	...DEFAULT_SCENARIO_PARAMS,
+	...overrides,
+});
+
+const montoRow = (over: Partial<MontoACobrarRow> = {}): MontoACobrarRow => ({
+	bucket: "2026-01-01",
+	cuotas_count: 10,
+	total_cuota: "1000",
+	total_interes: "200",
+	total_iva: "24",
+	total_seguro: "50",
+	total_gps: "30",
+	total_membresias: "40",
+	total_royalti: "10",
+	mora_promedio: "100",
+	...over,
+});
+
+describe("transformMontoACobrar", () => {
+	test("método actual sin cambios = identidad", () => {
+		const rows = [montoRow()];
+		const out = transformMontoACobrar(rows, params());
+		expect(out[0].total_cuota).toBe("1000.00");
+		expect(out[0].mora_promedio).toBe("100.00");
+		expect(out[0].cuotas_count).toBe(10);
+	});
+
+	test("bajar mora 10% reduce mora_promedio 10%", () => {
+		const out = transformMontoACobrar(
+			[montoRow()],
+			params({ moraReduccionPct: 10 }),
+		);
+		expect(out[0].mora_promedio).toBe("90.00");
+	});
+
+	test("bajar mora >100% se acota a 0 (sin mora negativa)", () => {
+		const out = transformMontoACobrar(
+			[montoRow()],
+			params({ moraReduccionPct: 120 }),
+		);
+		expect(out[0].mora_promedio).toBe("0.00");
+	});
+
+	test("colocar +20% escala los rubros", () => {
+		const out = transformMontoACobrar(
+			[montoRow()],
+			params({ colocacionDeltaPct: 20 }),
+		);
+		expect(out[0].total_cuota).toBe("1200.00");
+		expect(out[0].cuotas_count).toBe(12);
+	});
+});
+
+describe("transformFacturacion", () => {
+	const data: FacturacionMesResponse = {
+		cobrado: {
+			capital: "800",
+			interes: "100",
+			iva: "12",
+			seguro: "0",
+			gps: "0",
+			membresias: "0",
+		},
+		esperado: {
+			capital: "1000",
+			interes: "100",
+			iva: "12",
+			seguro: "0",
+			gps: "0",
+			membresias: "0",
+		},
+	};
+
+	test("efectividad +100% iguala cobrado a esperado", () => {
+		const out = transformFacturacion(
+			data,
+			params({ efectividadDeltaPct: 100 }),
+		);
+		expect(out.cobrado.capital).toBe("1000.00");
+	});
+
+	test("efectividad +50% cierra la mitad de la brecha", () => {
+		const out = transformFacturacion(data, params({ efectividadDeltaPct: 50 }));
+		expect(out.cobrado.capital).toBe("900.00");
+	});
+
+	test("esperado no cambia", () => {
+		const out = transformFacturacion(
+			data,
+			params({ efectividadDeltaPct: 100 }),
+		);
+		expect(out.esperado.capital).toBe("1000");
+	});
+});
+
+describe("transformCobertura", () => {
+	const rows: PuntoEquilibrioRow[] = [
+		{
+			bucket: "2026-01-01",
+			cantidad_creditos: 5,
+			colocado: "50000",
+			meta: "100000",
+			cobertura: "50.0",
+			faltante: "50000.00",
+		},
+	];
+
+	test("colocar +100% duplica colocado y recalcula cobertura/faltante", () => {
+		const out = transformCobertura(rows, params({ colocacionDeltaPct: 100 }));
+		expect(out[0].colocado).toBe("100000.00");
+		expect(out[0].cobertura).toBe("100.0");
+		expect(out[0].faltante).toBe("0.00");
+	});
+});
+
+describe("transformComparativo", () => {
+	const rows: ComparativoHistoricoRow[] = [
+		{
+			mes: 1,
+			colocacion_monto: "100000",
+			colocacion_creditos: 10,
+			facturacion: "50000",
+			cartera_activa: "200000",
+			creditos_activos: 30,
+			mora_30: "1000",
+			mora_60: "500",
+			mora_90: "200",
+			mora_120: "100",
+			creditos_30: 4,
+			creditos_60: 2,
+			creditos_90: 1,
+			creditos_120: 1,
+		},
+	];
+
+	test("bajar mora 50% reduce buckets de mora a la mitad", () => {
+		const out = transformComparativo(rows, params({ moraReduccionPct: 50 }));
+		expect(out[0].mora_30).toBe("500.00");
+		expect(out[0].mora_120).toBe("50.00");
+	});
+
+	test("colocar +10% escala colocación; nulos siguen nulos", () => {
+		const withNull = [{ ...rows[0], colocacion_monto: null }];
+		const out = transformComparativo(
+			withNull,
+			params({ colocacionDeltaPct: 10 }),
+		);
+		expect(out[0].colocacion_monto).toBeNull();
+		expect(out[0].cartera_activa).toBe("220000.00");
+	});
+});
+
+describe("cuotaIlustrativa", () => {
+	test("francés y fija son positivas y la fija (1ª) es mayor", () => {
+		const { frances, fija } = cuotaIlustrativa(
+			params({
+				metodoCapital: 50000,
+				metodoPlazoMeses: 12,
+				metodoTasaMensual: 1.78,
+			}),
+		);
+		expect(frances).toBeGreaterThan(0);
+		expect(fija).toBeGreaterThan(0);
+		expect(fija).toBeGreaterThan(frances);
+	});
+});

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -110,6 +110,16 @@ describe("transformFacturacion", () => {
 		expect(out.esperado.capital).toBe("1000");
 	});
 
+	test("efectividad negativa no cancela reducción de mora válida", () => {
+		// mora=100 debería cerrar el 100% de la brecha aunque efectividad=-100
+		const out = transformFacturacion(
+			data,
+			params({ moraReduccionPct: 100, efectividadDeltaPct: -100 }),
+		);
+		// capital: cobrado=800, esperado=1000, brecha=200, close=clamp01(0+1)=1 → 1000
+		expect(out.cobrado.capital).toBe("1000.00");
+	});
+
 	test("rubro sobre-cobrado (cobrado > esperado) se preserva intacto", () => {
 		const over: FacturacionMesResponse = {
 			cobrado: { ...data.cobrado, interes: "150" },

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -169,6 +169,14 @@ describe("transformComparativo", () => {
 		expect(out[0].mora_120).toBe("50.00");
 	});
 
+	test("efectividad negativa se acota a 0 (facturación no baja)", () => {
+		const out = transformComparativo(
+			rows,
+			params({ efectividadDeltaPct: -150 }),
+		);
+		expect(out[0].facturacion).toBe("50000.00");
+	});
+
 	test("colocar +10% escala colocación; nulos siguen nulos", () => {
 		const withNull = [{ ...rows[0], colocacion_monto: null }];
 		const out = transformComparativo(

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -4,6 +4,7 @@ import {
 	cuotaIlustrativa,
 	DEFAULT_SCENARIO_PARAMS,
 	type FacturacionMesResponse,
+	type FlujoCuotasInversionesResponse,
 	type MontoACobrarRow,
 	type PuntoEquilibrioRow,
 	type ScenarioParams,
@@ -12,6 +13,7 @@ import {
 	transformFacturacion,
 	transformMontoACobrar,
 } from "./scenario";
+import { flujoCuotasConfig, montoACobrarConfig } from "./scenario-configs";
 
 const params = (overrides: Partial<ScenarioParams> = {}): ScenarioParams => ({
 	...DEFAULT_SCENARIO_PARAMS,
@@ -175,6 +177,57 @@ describe("transformComparativo", () => {
 		);
 		expect(out[0].colocacion_monto).toBeNull();
 		expect(out[0].cartera_activa).toBe("220000.00");
+	});
+});
+
+describe("montoACobrarConfig.summarize", () => {
+	test("mora se promedia entre buckets, no se suma", () => {
+		const rows: MontoACobrarRow[] = [
+			montoRow({ mora_promedio: "100" }),
+			montoRow({ mora_promedio: "100" }),
+		];
+		const summary = montoACobrarConfig.summarize(rows);
+		const mora = summary.find((s) => s.concepto === "Mora prom.");
+		expect(mora?.valor).toBe(100);
+	});
+});
+
+describe("flujoCuotasConfig.summarize", () => {
+	const data: FlujoCuotasInversionesResponse = {
+		reinversionPorTipo: [
+			{
+				tipo: "reinversion_variable",
+				capital: "0",
+				interes: "0",
+				iva: "0",
+				monto_reinvertido: "5000",
+			},
+			{ tipo: "reinversion_interes", capital: "0", interes: "200", iva: "24" },
+		],
+		cashParcialPorTipo: [
+			{ tipo: "cash", capital: "0", interes: "0", iva: "0", monto_cash: "300" },
+		],
+		sinReinversion: {
+			totales: { capital: "100", interes: "50", iva: "6" },
+			porInversionista: [],
+		},
+		pagosExtras: { abonos_capital: "0", cancelaciones: "0" },
+	};
+
+	test("reinversión variable usa monto_reinvertido e interés incluye IVA", () => {
+		const summary = flujoCuotasConfig.summarize(data);
+		const reinv = summary.find((s) => s.concepto === "Reinversión");
+		// 5000 (variable total-only) + 200 + 24 (interés + IVA)
+		expect(reinv?.valor).toBe(5224);
+	});
+
+	test("cash usa monto_cash y sin-reinversión incluye IVA", () => {
+		const summary = flujoCuotasConfig.summarize(data);
+		expect(summary.find((s) => s.concepto === "Cash parcial")?.valor).toBe(300);
+		// 100 + 50 + 6
+		expect(summary.find((s) => s.concepto === "Sin reinversión")?.valor).toBe(
+			156,
+		);
 	});
 });
 

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -270,7 +270,8 @@ export function transformComparativo(
 ): ComparativoHistoricoRow[] {
 	const col = colocacionFactor(p);
 	const mora = moraFactor(p);
-	const fact = 1 + p.efectividadDeltaPct / 100;
+	// Acotado a ≥0: "subir efectividad" nunca debe reducir la facturación.
+	const fact = 1 + Math.max(0, p.efectividadDeltaPct) / 100;
 	const scale = (v: string | null, f: number) =>
 		v == null ? null : money(num(v) * f);
 	const scaleN = (v: number | null, f: number) =>

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -199,7 +199,10 @@ export function transformFacturacion(
 	for (const k of rubros) {
 		const c = num(data.cobrado[k]);
 		const e = num(data.esperado[k]);
-		cobrado[k] = money(c + (e - c) * close);
+		// Solo cerramos brechas positivas (esperado > cobrado). Si ya está
+		// sobre-cobrado (c >= e), se preserva el monto real intacto.
+		const gap = e - c;
+		cobrado[k] = money(gap > 0 ? c + gap * close : c);
 	}
 	return { cobrado, esperado: data.esperado };
 }

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -60,9 +60,13 @@ const colocacionFactor = (p: ScenarioParams) =>
 	1 + Math.max(0, p.colocacionDeltaPct) / 100;
 /** Reducción de mora acotada a [0, 100]% → factor en [0, 1]. */
 const moraFactor = (p: ScenarioParams) => 1 - clamp01(p.moraReduccionPct / 100);
-/** Fracción de la brecha cobrado→esperado que se cierra (efectividad + mora). */
+/** Fracción de la brecha cobrado→esperado que se cierra (efectividad + mora).
+ *  Cada palanca se acota individualmente a [0,1] antes de sumar para evitar
+ *  que valores negativos en una cancelen una reducción válida en la otra. */
 const gapClose = (p: ScenarioParams) =>
-	clamp01(p.efectividadDeltaPct / 100 + p.moraReduccionPct / 100);
+	clamp01(
+		clamp01(p.efectividadDeltaPct / 100) + clamp01(p.moraReduccionPct / 100),
+	);
 
 // ---------------------------------------------------------------------------
 // Tipos de fila de cada reporte (estructuralmente iguales a los de la ruta)

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -1,0 +1,325 @@
+/**
+ * Motor de escenarios "qué pasaría si" para los reportes.
+ *
+ * Funciones puras que toman los datos reales de un reporte + supuestos y
+ * devuelven una versión simulada del mismo tipo. Todo el cálculo ocurre en el
+ * cliente sobre los agregados que el reporte ya cargó, por lo que los
+ * resultados son ESTIMACIONES y no modifican datos reales.
+ */
+import {
+	calculateMonthlyPayment,
+	IVA_FACTOR,
+} from "@/utils/quoter-calculations";
+
+export type MetodoCuota = "actual" | "frances" | "fija";
+
+export type LeverKey = "colocacion" | "mora" | "efectividad" | "metodo";
+
+export interface ScenarioParams {
+	/** % extra de colocación (0 = sin cambio). */
+	colocacionDeltaPct: number;
+	/** Reduce la mora en X% (0 = sin cambio). */
+	moraReduccionPct: number;
+	/** Cierra la brecha cobrado vs esperado en X% (0 = sin cambio). */
+	efectividadDeltaPct: number;
+	/** Método de amortización para la cuota ilustrativa. */
+	metodoCuota: MetodoCuota;
+	/** Plazo promedio (meses) para la cuota ilustrativa. */
+	metodoPlazoMeses: number;
+	/** Tasa mensual (%) para la cuota ilustrativa. */
+	metodoTasaMensual: number;
+	/** Capital del crédito promedio para la cuota ilustrativa. */
+	metodoCapital: number;
+}
+
+export const DEFAULT_SCENARIO_PARAMS: ScenarioParams = {
+	colocacionDeltaPct: 0,
+	moraReduccionPct: 0,
+	efectividadDeltaPct: 0,
+	metodoCuota: "actual",
+	metodoPlazoMeses: 12,
+	metodoTasaMensual: 1.78,
+	metodoCapital: 50000,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convierte string|null a número seguro. */
+function num(value: string | number | null | undefined): number {
+	const x = Number(value);
+	return Number.isFinite(x) ? x : 0;
+}
+
+/** Número a string con 2 decimales (formato de los reportes). */
+function money(value: number): string {
+	return value.toFixed(2);
+}
+
+function clamp01(value: number): number {
+	return Math.min(1, Math.max(0, value));
+}
+
+const colocacionFactor = (p: ScenarioParams) =>
+	1 + Math.max(0, p.colocacionDeltaPct) / 100;
+/** Reducción de mora acotada a [0, 100]% → factor en [0, 1]. */
+const moraFactor = (p: ScenarioParams) => 1 - clamp01(p.moraReduccionPct / 100);
+/** Fracción de la brecha cobrado→esperado que se cierra (efectividad + mora). */
+const gapClose = (p: ScenarioParams) =>
+	clamp01(p.efectividadDeltaPct / 100 + p.moraReduccionPct / 100);
+
+// ---------------------------------------------------------------------------
+// Tipos de fila de cada reporte (estructuralmente iguales a los de la ruta)
+// ---------------------------------------------------------------------------
+
+export type MontoACobrarRow = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	total_royalti: string;
+	mora_promedio: string;
+};
+
+export type FacturacionMesRubro = {
+	capital: string;
+	interes: string;
+	iva: string;
+	seguro: string;
+	gps: string;
+	membresias: string;
+};
+
+export type FacturacionMesResponse = {
+	cobrado: FacturacionMesRubro;
+	esperado: FacturacionMesRubro;
+};
+
+export type FlujoCuotasRubro = {
+	capital: string;
+	interes: string;
+	iva: string;
+};
+export type FlujoCuotasInversionesResponse = {
+	reinversionPorTipo: (FlujoCuotasRubro & {
+		tipo: string;
+		monto_reinvertido?: string;
+	})[];
+	cashParcialPorTipo: (FlujoCuotasRubro & {
+		tipo: string;
+		monto_cash?: string;
+	})[];
+	sinReinversion: {
+		totales: FlujoCuotasRubro;
+		porInversionista: (FlujoCuotasRubro & {
+			inversionista_id: number;
+			nombre: string;
+		})[];
+	};
+	pagosExtras: { abonos_capital: string; cancelaciones: string };
+};
+
+export type PuntoEquilibrioRow = {
+	bucket: string;
+	cantidad_creditos: number;
+	colocado: string;
+	meta: string;
+	cobertura: string | null;
+	faltante: string | null;
+};
+
+export type ComparativoHistoricoRow = {
+	mes: number;
+	colocacion_monto: string | null;
+	colocacion_creditos: number | null;
+	facturacion: string | null;
+	cartera_activa: string | null;
+	creditos_activos: number | null;
+	mora_30: string | null;
+	mora_60: string | null;
+	mora_90: string | null;
+	mora_120: string | null;
+	creditos_30: number | null;
+	creditos_60: number | null;
+	creditos_90: number | null;
+	creditos_120: number | null;
+};
+
+// ---------------------------------------------------------------------------
+// Transformaciones por reporte
+// ---------------------------------------------------------------------------
+
+/**
+ * Monto a Cobrar: colocación escala los rubros (más cartera ≈ más cuotas),
+ * la mora reduce el promedio de mora por bucket.
+ */
+export function transformMontoACobrar(
+	rows: MontoACobrarRow[],
+	p: ScenarioParams,
+): MontoACobrarRow[] {
+	const col = colocacionFactor(p);
+	const mora = moraFactor(p);
+	return rows.map((r) => ({
+		...r,
+		cuotas_count: Math.round(r.cuotas_count * col),
+		total_cuota: money(num(r.total_cuota) * col),
+		total_interes: money(num(r.total_interes) * col),
+		total_iva: money(num(r.total_iva) * col),
+		total_seguro: money(num(r.total_seguro) * col),
+		total_gps: money(num(r.total_gps) * col),
+		total_membresias: money(num(r.total_membresias) * col),
+		total_royalti: money(num(r.total_royalti) * col),
+		mora_promedio: money(num(r.mora_promedio) * mora),
+	}));
+}
+
+/**
+ * Facturado vs Esperado: efectividad y mora cierran la brecha entre lo
+ * cobrado y lo esperado por rubro. Lo esperado no cambia.
+ */
+export function transformFacturacion(
+	data: FacturacionMesResponse,
+	p: ScenarioParams,
+): FacturacionMesResponse {
+	const close = gapClose(p);
+	const rubros: (keyof FacturacionMesRubro)[] = [
+		"capital",
+		"interes",
+		"iva",
+		"seguro",
+		"gps",
+		"membresias",
+	];
+	const cobrado = { ...data.cobrado };
+	for (const k of rubros) {
+		const c = num(data.cobrado[k]);
+		const e = num(data.esperado[k]);
+		cobrado[k] = money(c + (e - c) * close);
+	}
+	return { cobrado, esperado: data.esperado };
+}
+
+/** Flujo de Cuotas de Inversiones: la colocación escala todos los flujos. */
+export function transformFlujoCuotas(
+	data: FlujoCuotasInversionesResponse,
+	p: ScenarioParams,
+): FlujoCuotasInversionesResponse {
+	const col = colocacionFactor(p);
+	const scaleRubro = <T extends FlujoCuotasRubro>(r: T): T => ({
+		...r,
+		capital: money(num(r.capital) * col),
+		interes: money(num(r.interes) * col),
+		iva: money(num(r.iva) * col),
+	});
+	return {
+		reinversionPorTipo: data.reinversionPorTipo.map((r) => ({
+			...scaleRubro(r),
+			monto_reinvertido:
+				r.monto_reinvertido != null
+					? money(num(r.monto_reinvertido) * col)
+					: r.monto_reinvertido,
+		})),
+		cashParcialPorTipo: data.cashParcialPorTipo.map((r) => ({
+			...scaleRubro(r),
+			monto_cash:
+				r.monto_cash != null ? money(num(r.monto_cash) * col) : r.monto_cash,
+		})),
+		sinReinversion: {
+			totales: scaleRubro(data.sinReinversion.totales),
+			porInversionista: data.sinReinversion.porInversionista.map(scaleRubro),
+		},
+		pagosExtras: {
+			abonos_capital: money(num(data.pagosExtras.abonos_capital) * col),
+			cancelaciones: money(num(data.pagosExtras.cancelaciones) * col),
+		},
+	};
+}
+
+/**
+ * Cobertura vs Meta: la colocación escala lo colocado; cobertura y faltante
+ * se recalculan con la misma fórmula del backend.
+ */
+export function transformCobertura(
+	rows: PuntoEquilibrioRow[],
+	p: ScenarioParams,
+): PuntoEquilibrioRow[] {
+	const col = colocacionFactor(p);
+	return rows.map((r) => {
+		const colocado = num(r.colocado) * col;
+		const meta = num(r.meta);
+		return {
+			...r,
+			cantidad_creditos: Math.round(r.cantidad_creditos * col),
+			colocado: money(colocado),
+			cobertura: meta > 0 ? ((colocado / meta) * 100).toFixed(1) : null,
+			faltante: meta > 0 ? money(Math.max(0, meta - colocado)) : null,
+		};
+	});
+}
+
+/**
+ * Comparativo Histórico: colocación escala colocación/cartera, efectividad
+ * sube la facturación y la mora reduce los buckets de mora.
+ */
+export function transformComparativo(
+	rows: ComparativoHistoricoRow[],
+	p: ScenarioParams,
+): ComparativoHistoricoRow[] {
+	const col = colocacionFactor(p);
+	const mora = moraFactor(p);
+	const fact = 1 + p.efectividadDeltaPct / 100;
+	const scale = (v: string | null, f: number) =>
+		v == null ? null : money(num(v) * f);
+	const scaleN = (v: number | null, f: number) =>
+		v == null ? null : Math.round(v * f);
+	return rows.map((r) => ({
+		...r,
+		colocacion_monto: scale(r.colocacion_monto, col),
+		colocacion_creditos: scaleN(r.colocacion_creditos, col),
+		cartera_activa: scale(r.cartera_activa, col),
+		creditos_activos: scaleN(r.creditos_activos, col),
+		facturacion: scale(r.facturacion, fact),
+		mora_30: scale(r.mora_30, mora),
+		mora_60: scale(r.mora_60, mora),
+		mora_90: scale(r.mora_90, mora),
+		mora_120: scale(r.mora_120, mora),
+		creditos_30: scaleN(r.creditos_30, mora),
+		creditos_60: scaleN(r.creditos_60, mora),
+		creditos_90: scaleN(r.creditos_90, mora),
+		creditos_120: scaleN(r.creditos_120, mora),
+	}));
+}
+
+// ---------------------------------------------------------------------------
+// Cuota ilustrativa por método de amortización
+// ---------------------------------------------------------------------------
+
+export interface CuotaIlustrativa {
+	frances: number;
+	fija: number;
+}
+
+/**
+ * Cuota mensual de un crédito promedio según método. Francés = cuota nivelada
+ * (reusa calculateMonthlyPayment). Fija = capital/plazo + interés sobre saldo
+ * (primera cuota, la más alta). Ambas con IVA sobre el interés.
+ */
+export function cuotaIlustrativa(p: ScenarioParams): CuotaIlustrativa {
+	const capital = p.metodoCapital;
+	const plazo = p.metodoPlazoMeses > 0 ? p.metodoPlazoMeses : 1;
+	const frances = calculateMonthlyPayment(
+		capital,
+		p.metodoTasaMensual,
+		plazo,
+		0,
+		0,
+	);
+	const r = (p.metodoTasaMensual / 100) * IVA_FACTOR;
+	const fija = Math.round((capital / plazo + capital * r) * 100) / 100;
+	return { frances, fija };
+}

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -11,8 +11,6 @@ import {
 	IVA_FACTOR,
 } from "@/utils/quoter-calculations";
 
-export type MetodoCuota = "actual" | "frances" | "fija";
-
 export type LeverKey = "colocacion" | "mora" | "efectividad" | "metodo";
 
 export interface ScenarioParams {
@@ -22,8 +20,6 @@ export interface ScenarioParams {
 	moraReduccionPct: number;
 	/** Cierra la brecha cobrado vs esperado en X% (0 = sin cambio). */
 	efectividadDeltaPct: number;
-	/** Método de amortización para la cuota ilustrativa. */
-	metodoCuota: MetodoCuota;
 	/** Plazo promedio (meses) para la cuota ilustrativa. */
 	metodoPlazoMeses: number;
 	/** Tasa mensual (%) para la cuota ilustrativa. */
@@ -36,7 +32,6 @@ export const DEFAULT_SCENARIO_PARAMS: ScenarioParams = {
 	colocacionDeltaPct: 0,
 	moraReduccionPct: 0,
 	efectividadDeltaPct: 0,
-	metodoCuota: "actual",
 	metodoPlazoMeses: 12,
 	metodoTasaMensual: 1.78,
 	metodoCapital: 50000,

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -9,6 +9,7 @@ import {
 	Download,
 	FileText,
 	Loader2,
+	Sparkles,
 	Target,
 	TrendingDown,
 	TrendingUp,
@@ -34,6 +35,7 @@ import {
 import { toast } from "sonner";
 import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { ReportCard } from "@/components/reports/report-card";
+import { ScenarioModal } from "@/components/reports/scenario-modal";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -43,13 +45,12 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "@/components/ui/table";
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import {
 	Select,
 	SelectContent,
@@ -58,14 +59,31 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import {
-	Dialog,
-	DialogContent,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
+import type {
+	ComparativoHistoricoRow,
+	FacturacionMesResponse,
+	FacturacionMesRubro,
+	FlujoCuotasInversionesResponse,
+	FlujoCuotasRubro,
+	MontoACobrarRow,
+	PuntoEquilibrioRow,
+} from "@/lib/reports/scenario";
+import {
+	coberturaConfig,
+	comparativoConfig,
+	facturacionConfig,
+	flujoCuotasConfig,
+	montoACobrarConfig,
+} from "@/lib/reports/scenario-configs";
 import { PERMISSIONS } from "@/lib/roles";
 import { client, orpc, queryClient } from "@/utils/orpc";
 
@@ -84,88 +102,41 @@ const COLORS = {
 	incobrable: "#7f1d1d",
 };
 
-type MontoACobrarRow = {
-	bucket: string;
-	cuotas_count: number;
-	total_cuota: string;
-	total_interes: string;
-	total_iva: string;
-	total_seguro: string;
-	total_gps: string;
-	total_membresias: string;
-	total_royalti: string;
-	mora_promedio: string;
-};
-
-type FacturacionMesRubro = {
-	capital: string;
-	interes: string;
-	iva: string;
-	seguro: string;
-	gps: string;
-	membresias: string;
-};
-
-type FacturacionMesResponse = {
-	cobrado: FacturacionMesRubro;
-	esperado: FacturacionMesRubro;
-};
-
-type FlujoCuotasRubro = { capital: string; interes: string; iva: string };
-type FlujoCuotasInversionista = FlujoCuotasRubro & { inversionista_id: number; nombre: string };
-type FlujoCuotasInversionesResponse = {
-	reinversionPorTipo: (FlujoCuotasRubro & { tipo: string; monto_reinvertido?: string })[];
-	cashParcialPorTipo: (FlujoCuotasRubro & { tipo: string; monto_cash?: string })[];
-	sinReinversion: { totales: FlujoCuotasRubro; porInversionista: FlujoCuotasInversionista[] };
-	pagosExtras: { abonos_capital: string; cancelaciones: string };
-};
-
 const FLUJO_RUBROS: { key: keyof FlujoCuotasRubro; label: string }[] = [
 	{ key: "capital", label: "Capital" },
 	{ key: "interes", label: "Interés" },
 	{ key: "iva", label: "IVA 12%" },
 ];
 
-function getDefaultFlujoCuotasRange(): { fechaInicio: string; fechaFin: string } {
+function getDefaultFlujoCuotasRange(): {
+	fechaInicio: string;
+	fechaFin: string;
+} {
 	const todayGt = formatDateInput(new Date());
 	const [year, month] = todayGt.split("-").map(Number);
 	const fechaInicio = `${year}-${String(month).padStart(2, "0")}-01`;
 	const nextM = month === 12 ? 1 : month + 1;
 	const nextY = month === 12 ? year + 1 : year;
-	const lastDay = new Date(`${nextY}-${String(nextM).padStart(2, "0")}-01T12:00:00`);
+	const lastDay = new Date(
+		`${nextY}-${String(nextM).padStart(2, "0")}-01T12:00:00`,
+	);
 	lastDay.setDate(lastDay.getDate() - 1);
 	return { fechaInicio, fechaFin: formatDateInput(lastDay) };
 }
 
-type ComparativoHistoricoRow = {
-	mes: number;
-	colocacion_monto: string | null;
-	colocacion_creditos: number | null;
-	facturacion: string | null;
-	cartera_activa: string | null;
-	creditos_activos: number | null;
-	mora_30: string | null;
-	mora_60: string | null;
-	mora_90: string | null;
-	mora_120: string | null;
-	creditos_30: number | null;
-	creditos_60: number | null;
-	creditos_90: number | null;
-	creditos_120: number | null;
-};
-
-type PuntoEquilibrioRow = {
-	bucket: string;
-	cantidad_creditos: number;
-	colocado: string;
-	meta: string;
-	cobertura: string | null;
-	faltante: string | null;
-};
-
 const MESES = [
-	"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
-	"Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+	"Enero",
+	"Febrero",
+	"Marzo",
+	"Abril",
+	"Mayo",
+	"Junio",
+	"Julio",
+	"Agosto",
+	"Septiembre",
+	"Octubre",
+	"Noviembre",
+	"Diciembre",
 ];
 
 function coberturaColor(cobertura: string | null): string {
@@ -181,14 +152,15 @@ function coberturaLabel(cobertura: string | null): string {
 	return `${cobertura}%`;
 }
 
-const FACTURACION_RUBROS: { key: keyof FacturacionMesRubro; label: string }[] = [
-	{ key: "capital", label: "Capital" },
-	{ key: "interes", label: "Interés" },
-	{ key: "iva", label: "IVA 12%" },
-	{ key: "seguro", label: "Seguro" },
-	{ key: "gps", label: "GPS" },
-	{ key: "membresias", label: "Membresías" },
-];
+const FACTURACION_RUBROS: { key: keyof FacturacionMesRubro; label: string }[] =
+	[
+		{ key: "capital", label: "Capital" },
+		{ key: "interes", label: "Interés" },
+		{ key: "iva", label: "IVA 12%" },
+		{ key: "seguro", label: "Seguro" },
+		{ key: "gps", label: "GPS" },
+		{ key: "membresias", label: "Membresías" },
+	];
 
 const MONTO_COBRAR_COLORS = {
 	total_cuota: "#3b82f6",
@@ -225,7 +197,10 @@ function dateFromInput(value: string) {
 	return new Date(`${value}T12:00:00`);
 }
 
-function getDefaultMontoCobrarRange(): { fechaInicio: string; fechaFin: string } {
+function getDefaultMontoCobrarRange(): {
+	fechaInicio: string;
+	fechaFin: string;
+} {
 	const today = formatDateInput(new Date());
 	const fin = new Date();
 	fin.setFullYear(fin.getFullYear() + 1);
@@ -235,7 +210,10 @@ function getDefaultMontoCobrarRange(): { fechaInicio: string; fechaFin: string }
 function formatBucket(bucket: string, periodo: string): string {
 	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
 	if (periodo === "dia") {
-		return new Intl.DateTimeFormat("es-GT", { day: "2-digit", month: "short" }).format(date);
+		return new Intl.DateTimeFormat("es-GT", {
+			day: "2-digit",
+			month: "short",
+		}).format(date);
 	}
 	if (periodo === "semana") {
 		return `Sem ${new Intl.DateTimeFormat("es-GT", { day: "2-digit", month: "short" }).format(date)}`;
@@ -247,7 +225,10 @@ function formatBucket(bucket: string, periodo: string): string {
 	if (periodo === "anio") {
 		return String(date.getFullYear());
 	}
-	return new Intl.DateTimeFormat("es-GT", { month: "short", year: "numeric" }).format(date);
+	return new Intl.DateTimeFormat("es-GT", {
+		month: "short",
+		year: "numeric",
+	}).format(date);
 }
 
 function getDefaultClosedCreditsRange(): DateRange {
@@ -286,6 +267,15 @@ function downloadCsv(filename: string, rows: (string | number | null)[][]) {
 	URL.revokeObjectURL(url);
 }
 
+function SimularButton({ onClick }: { onClick: () => void }) {
+	return (
+		<Button variant="outline" size="sm" className="gap-1.5" onClick={onClick}>
+			<Sparkles className="h-3.5 w-3.5 text-purple-500" />
+			Simular
+		</Button>
+	);
+}
+
 function ProgressBar({ value, max }: { value: number; max: number }) {
 	const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
 	const color = pct >= 100 ? "#22c55e" : pct >= 80 ? "#eab308" : "#ef4444";
@@ -316,18 +306,25 @@ function RouteComponent() {
 	const [montoCobrarPeriodo, setMontoCobrarPeriodo] = useState<
 		"anio" | "trimestre" | "mes" | "semana" | "dia"
 	>("mes");
-	const [montoCobrarRange, setMontoCobrarRange] = useState(getDefaultMontoCobrarRange);
+	const [montoCobrarRange, setMontoCobrarRange] = useState(
+		getDefaultMontoCobrarRange,
+	);
 	const [facturacionMes, setFacturacionMes] = useState(() => ({
 		mes: new Date().getMonth() + 1,
 		anio: new Date().getFullYear(),
 	}));
-	const [flujoCuotasRange, setFlujoCuotasRange] = useState(getDefaultFlujoCuotasRange);
-	const [comparativoAnio, setComparativoAnio] = useState(
-		() => new Date().getFullYear(),
+	const [flujoCuotasRange, setFlujoCuotasRange] = useState(
+		getDefaultFlujoCuotasRange,
+	);
+	const [comparativoAnio, setComparativoAnio] = useState(() =>
+		new Date().getFullYear(),
 	);
 	const [metasAnio, setMetasAnio] = useState(new Date().getFullYear());
 	const [editMetas, setEditMetas] = useState<Record<number, string>>({});
 	const [metasModalOpen, setMetasModalOpen] = useState(false);
+	const [scenarioOpen, setScenarioOpen] = useState<
+		null | "monto" | "facturacion" | "flujo" | "cobertura" | "comparativo"
+	>(null);
 	const [isSavingMetas, setIsSavingMetas] = useState(false);
 	const [focusedMes, setFocusedMes] = useState<number | null>(null);
 	const [equilibrioPeriodo, setEquilibrioPeriodo] = useState<
@@ -393,11 +390,16 @@ function RouteComponent() {
 
 	const flujoCuotasQuery = useQuery({
 		...orpc.getFlujoCuotasInversiones.queryOptions({
-			input: { fechaInicio: flujoCuotasRange.fechaInicio, fechaFin: flujoCuotasRange.fechaFin },
+			input: {
+				fechaInicio: flujoCuotasRange.fechaInicio,
+				fechaFin: flujoCuotasRange.fechaFin,
+			},
 		}),
 		enabled: isAdmin,
 	});
-	const flujoCuotasData = flujoCuotasQuery.data as FlujoCuotasInversionesResponse | undefined;
+	const flujoCuotasData = flujoCuotasQuery.data as
+		| FlujoCuotasInversionesResponse
+		| undefined;
 
 	const comparativoQuery = useQuery({
 		...orpc.getComparativoHistorico.queryOptions({
@@ -425,7 +427,9 @@ function RouteComponent() {
 		}) => client.upsertMeta(vars),
 		onSuccess: () => {
 			queryClient.invalidateQueries(
-				orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
+				orpc.getMetas.queryOptions({
+					input: { anio: metasAnio, tipo: "colocacion" },
+				}),
 			);
 		},
 		onError: (error: Error) => {
@@ -466,7 +470,9 @@ function RouteComponent() {
 			await Promise.all(saves);
 			await Promise.all([
 				queryClient.invalidateQueries(
-					orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
+					orpc.getMetas.queryOptions({
+						input: { anio: metasAnio, tipo: "colocacion" },
+					}),
 				),
 				queryClient.invalidateQueries(
 					orpc.getPuntoEquilibrio.queryOptions({
@@ -481,7 +487,9 @@ function RouteComponent() {
 			toast.success(`${saves.length} metas guardadas`);
 			setMetasModalOpen(false);
 		} catch (err) {
-			toast.error(err instanceof Error ? err.message : "Error al guardar metas");
+			toast.error(
+				err instanceof Error ? err.message : "Error al guardar metas",
+			);
 		} finally {
 			setIsSavingMetas(false);
 		}
@@ -496,7 +504,6 @@ function RouteComponent() {
 			setEditMetas(map);
 		}
 	}, [metasQuery.data]);
-
 
 	useEffect(() => {
 		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
@@ -973,11 +980,13 @@ function RouteComponent() {
 									<div>
 										<CardTitle>Monto a Cobrarse por Período</CardTitle>
 										<CardDescription>
-											Cuotas pendientes desglosadas por rubro (capital, interés, seguro, etc.)
+											Cuotas pendientes desglosadas por rubro (capital, interés,
+											seguro, etc.)
 										</CardDescription>
 									</div>
 								</div>
 								<div className="flex flex-wrap items-center gap-2">
+									<SimularButton onClick={() => setScenarioOpen("monto")} />
 									<Select
 										value={montoCobrarPeriodo}
 										onValueChange={(v) =>
@@ -1035,33 +1044,52 @@ function RouteComponent() {
 									{/* Gráfica de barras apiladas */}
 									<ResponsiveContainer width="100%" height={350}>
 										<BarChart
-											data={montoCobrarData.data.map((row: MontoACobrarRow) => ({
-												bucket: formatBucket(row.bucket, montoCobrarPeriodo),
-												total_cuota: Number.parseFloat(row.total_cuota),
-												total_interes: Number.parseFloat(row.total_interes),
-												total_iva: Number.parseFloat(row.total_iva),
-												total_seguro: Number.parseFloat(row.total_seguro),
-												total_gps: Number.parseFloat(row.total_gps),
-												total_membresias: Number.parseFloat(row.total_membresias),
-												total_royalti: Number.parseFloat(row.total_royalti),
-											}))}
+											data={montoCobrarData.data.map(
+												(row: MontoACobrarRow) => ({
+													bucket: formatBucket(row.bucket, montoCobrarPeriodo),
+													total_cuota: Number.parseFloat(row.total_cuota),
+													total_interes: Number.parseFloat(row.total_interes),
+													total_iva: Number.parseFloat(row.total_iva),
+													total_seguro: Number.parseFloat(row.total_seguro),
+													total_gps: Number.parseFloat(row.total_gps),
+													total_membresias: Number.parseFloat(
+														row.total_membresias,
+													),
+													total_royalti: Number.parseFloat(row.total_royalti),
+												}),
+											)}
 										>
 											<CartesianGrid strokeDasharray="3 3" />
-											<XAxis dataKey="bucket" tick={{ fontSize: 11 }} interval={0} height={36} />
-											<YAxis tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`} />
+											<XAxis
+												dataKey="bucket"
+												tick={{ fontSize: 11 }}
+												interval={0}
+												height={36}
+											/>
+											<YAxis
+												tickFormatter={(v) =>
+													`Q${(Number(v) / 1000).toFixed(0)}k`
+												}
+											/>
 											<Tooltip
 												formatter={(value, name) => [
 													formatCurrency(Number(value)),
-													MONTO_COBRAR_LABELS[name as keyof typeof MONTO_COBRAR_LABELS] ?? name,
+													MONTO_COBRAR_LABELS[
+														name as keyof typeof MONTO_COBRAR_LABELS
+													] ?? name,
 												]}
 											/>
 											<Legend
 												formatter={(value) =>
-													MONTO_COBRAR_LABELS[value as keyof typeof MONTO_COBRAR_LABELS] ?? value
+													MONTO_COBRAR_LABELS[
+														value as keyof typeof MONTO_COBRAR_LABELS
+													] ?? value
 												}
 											/>
 											{(
-												Object.keys(MONTO_COBRAR_COLORS) as (keyof typeof MONTO_COBRAR_COLORS)[]
+												Object.keys(
+													MONTO_COBRAR_COLORS,
+												) as (keyof typeof MONTO_COBRAR_COLORS)[]
 											).map((key) => (
 												<Bar
 													key={key}
@@ -1085,10 +1113,16 @@ function RouteComponent() {
 													<TableHead className="text-right">IVA</TableHead>
 													<TableHead className="text-right">Seguro</TableHead>
 													<TableHead className="text-right">GPS</TableHead>
-													<TableHead className="text-right">Membresías</TableHead>
+													<TableHead className="text-right">
+														Membresías
+													</TableHead>
 													<TableHead className="text-right">Royalti</TableHead>
-													<TableHead className="text-right">Mora Prom.</TableHead>
-													<TableHead className="text-right font-bold">Total</TableHead>
+													<TableHead className="text-right">
+														Mora Prom.
+													</TableHead>
+													<TableHead className="text-right font-bold">
+														Total
+													</TableHead>
 												</TableRow>
 											</TableHeader>
 											<TableBody>
@@ -1099,30 +1133,55 @@ function RouteComponent() {
 														Number.parseFloat(row.total_iva) +
 														Number.parseFloat(row.total_seguro) +
 														Number.parseFloat(row.total_gps) +
-														Number.parseFloat(row.total_membresias);
+														Number.parseFloat(row.total_membresias) +
+														Number.parseFloat(row.total_royalti);
 													return (
 														<TableRow key={row.bucket}>
-															<TableCell>{formatBucket(row.bucket, montoCobrarPeriodo)}</TableCell>
-															<TableCell className="text-right">{row.cuotas_count}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_cuota)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_interes)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_iva)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_seguro)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_gps)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_membresias)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_royalti)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.mora_promedio)}</TableCell>
-															<TableCell className="text-right font-bold">{formatCurrency(total)}</TableCell>
+															<TableCell>
+																{formatBucket(row.bucket, montoCobrarPeriodo)}
+															</TableCell>
+															<TableCell className="text-right">
+																{row.cuotas_count}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_cuota)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_interes)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_iva)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_seguro)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_gps)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_membresias)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_royalti)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.mora_promedio)}
+															</TableCell>
+															<TableCell className="text-right font-bold">
+																{formatCurrency(total)}
+															</TableCell>
 														</TableRow>
 													);
 												})}
 												{/* Fila de totales */}
 												{(() => {
-													const rows = montoCobrarData.data as MontoACobrarRow[];
+													const rows =
+														montoCobrarData.data as MontoACobrarRow[];
 													const sum = (key: keyof MontoACobrarRow) =>
 														rows.reduce(
 															(acc: number, r: MontoACobrarRow) =>
-																acc + Number.parseFloat((r[key] as string) || "0"),
+																acc +
+																Number.parseFloat((r[key] as string) || "0"),
 															0,
 														);
 													const grandTotal =
@@ -1131,22 +1190,42 @@ function RouteComponent() {
 														sum("total_iva") +
 														sum("total_seguro") +
 														sum("total_gps") +
-														sum("total_membresias");
+														sum("total_membresias") +
+														sum("total_royalti");
 													return (
 														<TableRow className="border-t-2 bg-muted/50 font-bold">
 															<TableCell>Total</TableCell>
 															<TableCell className="text-right">
-																{rows.reduce((acc, r) => acc + r.cuotas_count, 0)}
+																{rows.reduce(
+																	(acc, r) => acc + r.cuotas_count,
+																	0,
+																)}
 															</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_cuota"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_interes"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_iva"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_seguro"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_gps"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_membresias"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_royalti"))}</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_cuota"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_interes"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_iva"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_seguro"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_gps"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_membresias"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_royalti"))}
+															</TableCell>
 															<TableCell className="text-right">—</TableCell>
-															<TableCell className="text-right">{formatCurrency(grandTotal)}</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(grandTotal)}
+															</TableCell>
 														</TableRow>
 													);
 												})()}
@@ -1168,10 +1247,14 @@ function RouteComponent() {
 										Facturado del Mes vs Esperado
 									</CardTitle>
 									<CardDescription>
-										Compara lo cobrado en el mes contra lo esperado según fecha de vencimiento
+										Compara lo cobrado en el mes contra lo esperado según fecha
+										de vencimiento
 									</CardDescription>
 								</div>
 								<div className="flex items-center gap-2">
+									<SimularButton
+										onClick={() => setScenarioOpen("facturacion")}
+									/>
 									<Select
 										value={String(facturacionMes.mes)}
 										onValueChange={(v) =>
@@ -1183,8 +1266,18 @@ function RouteComponent() {
 										</SelectTrigger>
 										<SelectContent>
 											{[
-												"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
-												"Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+												"Enero",
+												"Febrero",
+												"Marzo",
+												"Abril",
+												"Mayo",
+												"Junio",
+												"Julio",
+												"Agosto",
+												"Septiembre",
+												"Octubre",
+												"Noviembre",
+												"Diciembre",
 											].map((label, i) => (
 												<SelectItem key={i + 1} value={String(i + 1)}>
 													{label}
@@ -1210,69 +1303,73 @@ function RouteComponent() {
 						</CardHeader>
 						<CardContent>
 							{facturacionMesQuery.isPending && (
-								<div className="text-muted-foreground py-4 text-center text-sm">
+								<div className="py-4 text-center text-muted-foreground text-sm">
 									Cargando...
 								</div>
 							)}
 							{facturacionMesQuery.isError && (
-								<div className="text-destructive py-4 text-center text-sm">
+								<div className="py-4 text-center text-destructive text-sm">
 									Error al cargar datos
 								</div>
 							)}
-							{facturacionMesData && (() => {
-								const { cobrado, esperado } = facturacionMesData;
-								const totalCobrado = FACTURACION_RUBROS.reduce(
-									(acc, r) => acc + Number(cobrado[r.key] || 0),
-									0,
-								);
-								const totalEsperado = FACTURACION_RUBROS.reduce(
-									(acc, r) => acc + Number(esperado[r.key] || 0),
-									0,
-								);
-								return (
-									<Table>
-										<TableHeader>
-											<TableRow>
-												<TableHead>Rubro</TableHead>
-												<TableHead className="text-right">Cobrado</TableHead>
-												<TableHead className="text-right">Esperado</TableHead>
-												<TableHead className="w-48">Progreso</TableHead>
-											</TableRow>
-										</TableHeader>
-										<TableBody>
-											{FACTURACION_RUBROS.map(({ key, label }) => (
-												<TableRow key={key}>
-													<TableCell>{label}</TableCell>
+							{facturacionMesData &&
+								(() => {
+									const { cobrado, esperado } = facturacionMesData;
+									const totalCobrado = FACTURACION_RUBROS.reduce(
+										(acc, r) => acc + Number(cobrado[r.key] || 0),
+										0,
+									);
+									const totalEsperado = FACTURACION_RUBROS.reduce(
+										(acc, r) => acc + Number(esperado[r.key] || 0),
+										0,
+									);
+									return (
+										<Table>
+											<TableHeader>
+												<TableRow>
+													<TableHead>Rubro</TableHead>
+													<TableHead className="text-right">Cobrado</TableHead>
+													<TableHead className="text-right">Esperado</TableHead>
+													<TableHead className="w-48">Progreso</TableHead>
+												</TableRow>
+											</TableHeader>
+											<TableBody>
+												{FACTURACION_RUBROS.map(({ key, label }) => (
+													<TableRow key={key}>
+														<TableCell>{label}</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(Number(cobrado[key] || 0))}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(Number(esperado[key] || 0))}
+														</TableCell>
+														<TableCell>
+															<ProgressBar
+																value={Number(cobrado[key] || 0)}
+																max={Number(esperado[key] || 0)}
+															/>
+														</TableCell>
+													</TableRow>
+												))}
+												<TableRow className="border-t-2 bg-muted/50 font-bold">
+													<TableCell>Total</TableCell>
 													<TableCell className="text-right">
-														{formatCurrency(Number(cobrado[key] || 0))}
+														{formatCurrency(totalCobrado)}
 													</TableCell>
 													<TableCell className="text-right">
-														{formatCurrency(Number(esperado[key] || 0))}
+														{formatCurrency(totalEsperado)}
 													</TableCell>
 													<TableCell>
 														<ProgressBar
-															value={Number(cobrado[key] || 0)}
-															max={Number(esperado[key] || 0)}
+															value={totalCobrado}
+															max={totalEsperado}
 														/>
 													</TableCell>
 												</TableRow>
-											))}
-											<TableRow className="border-t-2 bg-muted/50 font-bold">
-												<TableCell>Total</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(totalCobrado)}
-												</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(totalEsperado)}
-												</TableCell>
-												<TableCell>
-													<ProgressBar value={totalCobrado} max={totalEsperado} />
-												</TableCell>
-											</TableRow>
-										</TableBody>
-									</Table>
-								);
-							})()}
+											</TableBody>
+										</Table>
+									);
+								})()}
 						</CardContent>
 					</Card>
 
@@ -1286,17 +1383,22 @@ function RouteComponent() {
 										Flujo de Cuotas de Inversiones
 									</CardTitle>
 									<CardDescription>
-										Cuotas esperadas hacia reinversión y hacia pago en efectivo, por período
+										Cuotas esperadas hacia reinversión y hacia pago en efectivo,
+										por período
 									</CardDescription>
 								</div>
 								<div className="flex items-center gap-2">
+									<SimularButton onClick={() => setScenarioOpen("flujo")} />
 									<Input
 										type="date"
 										aria-label="Fecha inicio"
 										className="w-40"
 										value={flujoCuotasRange.fechaInicio}
 										onChange={(e) =>
-											setFlujoCuotasRange((prev) => ({ ...prev, fechaInicio: e.target.value }))
+											setFlujoCuotasRange((prev) => ({
+												...prev,
+												fechaInicio: e.target.value,
+											}))
 										}
 									/>
 									<span className="text-muted-foreground text-sm">–</span>
@@ -1306,7 +1408,10 @@ function RouteComponent() {
 										className="w-40"
 										value={flujoCuotasRange.fechaFin}
 										onChange={(e) =>
-											setFlujoCuotasRange((prev) => ({ ...prev, fechaFin: e.target.value }))
+											setFlujoCuotasRange((prev) => ({
+												...prev,
+												fechaFin: e.target.value,
+											}))
 										}
 									/>
 								</div>
@@ -1314,181 +1419,307 @@ function RouteComponent() {
 						</CardHeader>
 						<CardContent className="space-y-6">
 							{flujoCuotasQuery.isPending && (
-								<div className="text-muted-foreground py-4 text-center text-sm">
+								<div className="py-4 text-center text-muted-foreground text-sm">
 									Cargando...
 								</div>
 							)}
 							{flujoCuotasQuery.isError && (
-								<div className="text-destructive py-4 text-center text-sm">
+								<div className="py-4 text-center text-destructive text-sm">
 									Error al cargar datos
 								</div>
 							)}
-							{flujoCuotasData && (() => {
-								const { reinversionPorTipo, cashParcialPorTipo, sinReinversion, pagosExtras } = flujoCuotasData;
-								const TIPO_LABELS: Record<string, string> = {
-									reinversion_capital: "Reinversión Capital",
-									reinversion_interes: "Reinversión Interés",
-									reinversion_total: "Reinversión Total",
-									reinversion_variable: "Reinversión Variable",
-									reinversion_excedente: "Reinversión Excedente",
-								};
-								type ReinvertidoResult =
-									| { esTotal: true; total: number }
-									| { esTotal: false; capital: number; interes: number; iva: number };
-								function getReinvertido(tipo: string, t: FlujoCuotasRubro & { monto_reinvertido?: string }): ReinvertidoResult {
-									if (tipo === "reinversion_variable" || tipo === "reinversion_excedente")
-										return { esTotal: true, total: Number(t.monto_reinvertido ?? 0) };
-									if (tipo === "reinversion_capital")
-										return { esTotal: false, capital: Number(t.capital), interes: 0, iva: 0 };
-									if (tipo === "reinversion_interes")
-										return { esTotal: false, capital: 0, interes: Number(t.interes), iva: Number(t.iva) };
-									return { esTotal: false, capital: Number(t.capital), interes: Number(t.interes), iva: Number(t.iva) };
-								}
-								const totalesReinv = reinversionPorTipo.reduce(
-									(a, t) => {
-										const r = getReinvertido(t.tipo, t);
-										const tot = r.esTotal ? r.total : r.capital + r.interes + r.iva;
+							{flujoCuotasData &&
+								(() => {
+									const {
+										reinversionPorTipo,
+										cashParcialPorTipo,
+										sinReinversion,
+										pagosExtras,
+									} = flujoCuotasData;
+									const TIPO_LABELS: Record<string, string> = {
+										reinversion_capital: "Reinversión Capital",
+										reinversion_interes: "Reinversión Interés",
+										reinversion_total: "Reinversión Total",
+										reinversion_variable: "Reinversión Variable",
+										reinversion_excedente: "Reinversión Excedente",
+									};
+									type ReinvertidoResult =
+										| { esTotal: true; total: number }
+										| {
+												esTotal: false;
+												capital: number;
+												interes: number;
+												iva: number;
+										  };
+									function getReinvertido(
+										tipo: string,
+										t: FlujoCuotasRubro & { monto_reinvertido?: string },
+									): ReinvertidoResult {
+										if (
+											tipo === "reinversion_variable" ||
+											tipo === "reinversion_excedente"
+										)
+											return {
+												esTotal: true,
+												total: Number(t.monto_reinvertido ?? 0),
+											};
+										if (tipo === "reinversion_capital")
+											return {
+												esTotal: false,
+												capital: Number(t.capital),
+												interes: 0,
+												iva: 0,
+											};
+										if (tipo === "reinversion_interes")
+											return {
+												esTotal: false,
+												capital: 0,
+												interes: Number(t.interes),
+												iva: Number(t.iva),
+											};
 										return {
-											total: a.total + tot,
-											capital: a.capital + (r.esTotal ? 0 : r.capital),
-											interes: a.interes + (r.esTotal ? 0 : r.interes),
-											iva: a.iva + (r.esTotal ? 0 : r.iva),
+											esTotal: false,
+											capital: Number(t.capital),
+											interes: Number(t.interes),
+											iva: Number(t.iva),
 										};
-									},
-									{ total: 0, capital: 0, interes: 0, iva: 0 },
-								);
-								const totalReinv = totalesReinv.total;
-								const cashParcialTotal = cashParcialPorTipo.reduce(
-									(a, t) => a + (t.monto_cash ? Number(t.monto_cash) : Number(t.capital) + Number(t.interes) + Number(t.iva)),
-									0,
-								);
-								const totalSinReinv = FLUJO_RUBROS.reduce((a, r) => a + Number(sinReinversion.totales[r.key] || 0), 0);
-								const totalExtras = Number(pagosExtras.abonos_capital) + Number(pagosExtras.cancelaciones);
-								return (
-									<>
-										{/* Sección 1: Hacia Reinversión por tipo */}
-										<div>
-											<p className="mb-2 text-sm font-semibold">Cuotas → Reinversión</p>
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Tipo de Reinversión</TableHead>
-														<TableHead className="text-right">Capital</TableHead>
-														<TableHead className="text-right">Interés</TableHead>
-														<TableHead className="text-right">IVA 12%</TableHead>
-														<TableHead className="text-right">Total</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{reinversionPorTipo.filter((t) => {
-														const r = getReinvertido(t.tipo, t);
-														const tot = r.esTotal ? r.total : r.capital + r.interes + r.iva;
-														return tot > 0;
-													}).map((t) => {
-														const r = getReinvertido(t.tipo, t);
-														const rowTotal = r.esTotal ? r.total : r.capital + r.interes + r.iva;
-														return (
-															<TableRow key={t.tipo}>
-																<TableCell>{TIPO_LABELS[t.tipo] ?? t.tipo}</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	{r.esTotal ? "—" : formatCurrency(r.capital)}
-																</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	{r.esTotal ? "—" : formatCurrency(r.interes)}
-																</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	{r.esTotal ? "—" : formatCurrency(r.iva)}
-																</TableCell>
-																<TableCell className="text-right">{formatCurrency(rowTotal)}</TableCell>
-															</TableRow>
-														);
-													})}
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalesReinv.capital)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalesReinv.interes)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalesReinv.iva)}
-														</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalReinv)}</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										</div>
-
-										{/* Sección 2: Cash (sin reinversión + porciones cash de reinversión parcial) */}
-										<div>
-											<p className="mb-2 text-sm font-semibold">Cuotas → Cash</p>
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Origen</TableHead>
-														<TableHead className="text-right">Capital</TableHead>
-														<TableHead className="text-right">Interés</TableHead>
-														<TableHead className="text-right">IVA 12%</TableHead>
-														<TableHead className="text-right">Total</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{/* Inversionistas sin reinversión */}
-													<TableRow>
-														<TableCell>Sin Reinversión</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.capital))}</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.interes))}</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.iva))}</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalSinReinv)}</TableCell>
-													</TableRow>
-													{/* Porciones cash de inversionistas con reinversión parcial — combinado */}
-													{cashParcialPorTipo.length > 0 && (
+									}
+									const totalesReinv = reinversionPorTipo.reduce(
+										(a, t) => {
+											const r = getReinvertido(t.tipo, t);
+											const tot = r.esTotal
+												? r.total
+												: r.capital + r.interes + r.iva;
+											return {
+												total: a.total + tot,
+												capital: a.capital + (r.esTotal ? 0 : r.capital),
+												interes: a.interes + (r.esTotal ? 0 : r.interes),
+												iva: a.iva + (r.esTotal ? 0 : r.iva),
+											};
+										},
+										{ total: 0, capital: 0, interes: 0, iva: 0 },
+									);
+									const totalReinv = totalesReinv.total;
+									const cashParcialTotal = cashParcialPorTipo.reduce(
+										(a, t) =>
+											a +
+											(t.monto_cash
+												? Number(t.monto_cash)
+												: Number(t.capital) +
+													Number(t.interes) +
+													Number(t.iva)),
+										0,
+									);
+									const totalSinReinv = FLUJO_RUBROS.reduce(
+										(a, r) => a + Number(sinReinversion.totales[r.key] || 0),
+										0,
+									);
+									const totalExtras =
+										Number(pagosExtras.abonos_capital) +
+										Number(pagosExtras.cancelaciones);
+									return (
+										<>
+											{/* Sección 1: Hacia Reinversión por tipo */}
+											<div>
+												<p className="mb-2 font-semibold text-sm">
+													Cuotas → Reinversión
+												</p>
+												<Table>
+													<TableHeader>
 														<TableRow>
-															<TableCell>Intereses y excedentes pagados a inversionistas</TableCell>
-															<TableCell colSpan={3} className="text-muted-foreground text-right text-sm">capital/interés/IVA según tipo</TableCell>
-															<TableCell className="text-right">{formatCurrency(cashParcialTotal)}</TableCell>
+															<TableHead>Tipo de Reinversión</TableHead>
+															<TableHead className="text-right">
+																Capital
+															</TableHead>
+															<TableHead className="text-right">
+																Interés
+															</TableHead>
+															<TableHead className="text-right">
+																IVA 12%
+															</TableHead>
+															<TableHead className="text-right">
+																Total
+															</TableHead>
 														</TableRow>
-													)}
-													{/* Total general cash */}
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total Cash</TableCell>
-														<TableCell colSpan={3} />
-														<TableCell className="text-right">{formatCurrency(totalSinReinv + cashParcialTotal)}</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										</div>
+													</TableHeader>
+													<TableBody>
+														{reinversionPorTipo
+															.filter((t) => {
+																const r = getReinvertido(t.tipo, t);
+																const tot = r.esTotal
+																	? r.total
+																	: r.capital + r.interes + r.iva;
+																return tot > 0;
+															})
+															.map((t) => {
+																const r = getReinvertido(t.tipo, t);
+																const rowTotal = r.esTotal
+																	? r.total
+																	: r.capital + r.interes + r.iva;
+																return (
+																	<TableRow key={t.tipo}>
+																		<TableCell>
+																			{TIPO_LABELS[t.tipo] ?? t.tipo}
+																		</TableCell>
+																		<TableCell className="text-right text-muted-foreground">
+																			{r.esTotal
+																				? "—"
+																				: formatCurrency(r.capital)}
+																		</TableCell>
+																		<TableCell className="text-right text-muted-foreground">
+																			{r.esTotal
+																				? "—"
+																				: formatCurrency(r.interes)}
+																		</TableCell>
+																		<TableCell className="text-right text-muted-foreground">
+																			{r.esTotal ? "—" : formatCurrency(r.iva)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(rowTotal)}
+																		</TableCell>
+																	</TableRow>
+																);
+															})}
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalesReinv.capital)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalesReinv.interes)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalesReinv.iva)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalReinv)}
+															</TableCell>
+														</TableRow>
+													</TableBody>
+												</Table>
+											</div>
 
-										{/* Sección 3: Pagos Extras Recibidos */}
-										<div>
-											<p className="mb-2 text-sm font-semibold">Pagos Extras Recibidos</p>
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Tipo</TableHead>
-														<TableHead className="text-right">Monto</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													<TableRow>
-														<TableCell>Abonos Extra a Capital</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(pagosExtras.abonos_capital))}</TableCell>
-													</TableRow>
-													<TableRow>
-														<TableCell>Cancelaciones</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(pagosExtras.cancelaciones))}</TableCell>
-													</TableRow>
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalExtras)}</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										</div>
-									</>
-								);
-							})()}
+											{/* Sección 2: Cash (sin reinversión + porciones cash de reinversión parcial) */}
+											<div>
+												<p className="mb-2 font-semibold text-sm">
+													Cuotas → Cash
+												</p>
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Origen</TableHead>
+															<TableHead className="text-right">
+																Capital
+															</TableHead>
+															<TableHead className="text-right">
+																Interés
+															</TableHead>
+															<TableHead className="text-right">
+																IVA 12%
+															</TableHead>
+															<TableHead className="text-right">
+																Total
+															</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														{/* Inversionistas sin reinversión */}
+														<TableRow>
+															<TableCell>Sin Reinversión</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(sinReinversion.totales.capital),
+																)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(sinReinversion.totales.interes),
+																)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(sinReinversion.totales.iva),
+																)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalSinReinv)}
+															</TableCell>
+														</TableRow>
+														{/* Porciones cash de inversionistas con reinversión parcial — combinado */}
+														{cashParcialPorTipo.length > 0 && (
+															<TableRow>
+																<TableCell>
+																	Intereses y excedentes pagados a
+																	inversionistas
+																</TableCell>
+																<TableCell
+																	colSpan={3}
+																	className="text-right text-muted-foreground text-sm"
+																>
+																	capital/interés/IVA según tipo
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(cashParcialTotal)}
+																</TableCell>
+															</TableRow>
+														)}
+														{/* Total general cash */}
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total Cash</TableCell>
+															<TableCell colSpan={3} />
+															<TableCell className="text-right">
+																{formatCurrency(
+																	totalSinReinv + cashParcialTotal,
+																)}
+															</TableCell>
+														</TableRow>
+													</TableBody>
+												</Table>
+											</div>
+
+											{/* Sección 3: Pagos Extras Recibidos */}
+											<div>
+												<p className="mb-2 font-semibold text-sm">
+													Pagos Extras Recibidos
+												</p>
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Tipo</TableHead>
+															<TableHead className="text-right">
+																Monto
+															</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														<TableRow>
+															<TableCell>Abonos Extra a Capital</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(pagosExtras.abonos_capital),
+																)}
+															</TableCell>
+														</TableRow>
+														<TableRow>
+															<TableCell>Cancelaciones</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(pagosExtras.cancelaciones),
+																)}
+															</TableCell>
+														</TableRow>
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalExtras)}
+															</TableCell>
+														</TableRow>
+													</TableBody>
+												</Table>
+											</div>
+										</>
+									);
+								})()}
 						</CardContent>
 					</Card>
 
@@ -1502,21 +1733,41 @@ function RouteComponent() {
 								</DialogTitle>
 							</DialogHeader>
 							<div className="flex items-center justify-center gap-3 pb-2">
-								<Button variant="outline" size="sm" onClick={() => setMetasAnio((y) => y - 1)}>‹</Button>
-								<span className="w-16 text-center font-semibold">{metasAnio}</span>
-								<Button variant="outline" size="sm" onClick={() => setMetasAnio((y) => y + 1)}>›</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setMetasAnio((y) => y - 1)}
+								>
+									‹
+								</Button>
+								<span className="w-16 text-center font-semibold">
+									{metasAnio}
+								</span>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setMetasAnio((y) => y + 1)}
+								>
+									›
+								</Button>
 							</div>
 							{metasQuery.isPending ? (
-								<p className="text-muted-foreground py-4 text-center text-sm">Cargando...</p>
+								<p className="py-4 text-center text-muted-foreground text-sm">
+									Cargando...
+								</p>
 							) : (
 								<div className="grid grid-cols-2 gap-x-10 gap-y-4">
 									{MESES.map((nombreMes, idx) => {
 										const mes = idx + 1;
 										return (
 											<div key={mes} className="flex items-center gap-3">
-												<span className="w-20 shrink-0 font-medium text-sm">{nombreMes}</span>
+												<span className="w-20 shrink-0 font-medium text-sm">
+													{nombreMes}
+												</span>
 												<div className="relative min-w-0 flex-1">
-													<span className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground text-sm font-medium">Q</span>
+													<span className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 font-medium text-muted-foreground text-sm">
+														Q
+													</span>
 													<Input
 														type="text"
 														inputMode="decimal"
@@ -1526,16 +1777,22 @@ function RouteComponent() {
 															focusedMes === mes
 																? (editMetas[mes] ?? "")
 																: editMetas[mes] && Number(editMetas[mes]) > 0
-																	? Number(editMetas[mes]).toLocaleString("es-GT", {
-																			minimumFractionDigits: 2,
-																			maximumFractionDigits: 2,
-																		})
+																	? Number(editMetas[mes]).toLocaleString(
+																			"es-GT",
+																			{
+																				minimumFractionDigits: 2,
+																				maximumFractionDigits: 2,
+																			},
+																		)
 																	: ""
 														}
 														onFocus={() => setFocusedMes(mes)}
 														onBlur={() => setFocusedMes(null)}
 														onChange={(e) => {
-															const raw = e.target.value.replace(/[^0-9.]/g, "");
+															const raw = e.target.value.replace(
+																/[^0-9.]/g,
+																"",
+															);
 															setEditMetas((prev) => ({ ...prev, [mes]: raw }));
 														}}
 													/>
@@ -1546,7 +1803,10 @@ function RouteComponent() {
 								</div>
 							)}
 							<div className="flex justify-end gap-2 pt-2">
-								<Button variant="outline" onClick={() => setMetasModalOpen(false)}>
+								<Button
+									variant="outline"
+									onClick={() => setMetasModalOpen(false)}
+								>
 									Cancelar
 								</Button>
 								<Button onClick={handleGuardarTodo} disabled={isSavingMetas}>
@@ -1559,6 +1819,38 @@ function RouteComponent() {
 						</DialogContent>
 					</Dialog>
 
+					{/* Modales de simulación de escenarios */}
+					<ScenarioModal
+						open={scenarioOpen === "monto"}
+						onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
+						config={montoACobrarConfig}
+						baseData={montoCobrarData?.data}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "facturacion"}
+						onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
+						config={facturacionConfig}
+						baseData={facturacionMesData}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "flujo"}
+						onOpenChange={(o) => setScenarioOpen(o ? "flujo" : null)}
+						config={flujoCuotasConfig}
+						baseData={flujoCuotasData}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "cobertura"}
+						onOpenChange={(o) => setScenarioOpen(o ? "cobertura" : null)}
+						config={coberturaConfig}
+						baseData={puntoEquilibrioData?.data}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "comparativo"}
+						onOpenChange={(o) => setScenarioOpen(o ? "comparativo" : null)}
+						config={comparativoConfig}
+						baseData={comparativoData?.data}
+					/>
+
 					{/* Cobertura de Colocación vs Meta */}
 					<Card>
 						<CardHeader>
@@ -1568,11 +1860,13 @@ function RouteComponent() {
 									<div>
 										<CardTitle>Cobertura de Colocación vs Meta</CardTitle>
 										<CardDescription>
-											Compara el capital colocado en cada período contra la meta mensual definida
+											Compara el capital colocado en cada período contra la meta
+											mensual definida
 										</CardDescription>
 									</div>
 								</div>
 								<div className="flex flex-wrap items-center gap-2">
+									<SimularButton onClick={() => setScenarioOpen("cobertura")} />
 									<Button
 										variant="outline"
 										size="sm"
@@ -1624,7 +1918,9 @@ function RouteComponent() {
 						</CardHeader>
 						<CardContent className="space-y-4">
 							{puntoEquilibrioQuery.isPending && (
-								<p className="text-muted-foreground text-sm">Cargando reporte...</p>
+								<p className="text-muted-foreground text-sm">
+									Cargando reporte...
+								</p>
 							)}
 							{puntoEquilibrioQuery.isError && (
 								<p className="text-destructive text-sm">
@@ -1636,259 +1932,380 @@ function RouteComponent() {
 									No hay datos de colocación para el rango seleccionado.
 								</p>
 							)}
-							{!!puntoEquilibrioData?.data.length && (() => {
-								const rows = puntoEquilibrioData.data;
-								const totalColocado = rows.reduce((acc, r) => acc + Number(r.colocado), 0);
-								const totalMeta = rows.reduce((acc, r) => acc + Number(r.meta), 0);
-								const totalCreditos = rows.reduce((acc, r) => acc + r.cantidad_creditos, 0);
-								const totalCobertura =
-									totalMeta > 0 ? ((totalColocado / totalMeta) * 100).toFixed(1) : null;
-								return (
-									<>
-										<ResponsiveContainer width="100%" height={300}>
-											<BarChart
-												data={rows.map((row) => ({
-													bucket: formatBucket(row.bucket, equilibrioPeriodo),
-													colocado: Number(row.colocado),
-													meta: Number(row.meta),
-												}))}
-											>
-												<CartesianGrid strokeDasharray="3 3" />
-												<XAxis dataKey="bucket" tick={{ fontSize: 11 }} interval={0} height={36} />
-												<YAxis tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`} />
-												<Tooltip
-													formatter={(value, name) => [
-														formatCurrency(Number(value)),
-														name === "colocado" ? "Colocado" : "Meta",
-													]}
-												/>
-												<Legend formatter={(v) => (v === "colocado" ? "Colocado" : "Meta")} />
-												<Bar dataKey="colocado" fill="#3b82f6" name="colocado" />
-												<Bar dataKey="meta" fill="#d1d5db" name="meta" />
-											</BarChart>
-										</ResponsiveContainer>
+							{!!puntoEquilibrioData?.data.length &&
+								(() => {
+									const rows = puntoEquilibrioData.data;
+									const totalColocado = rows.reduce(
+										(acc, r) => acc + Number(r.colocado),
+										0,
+									);
+									const totalMeta = rows.reduce(
+										(acc, r) => acc + Number(r.meta),
+										0,
+									);
+									const totalCreditos = rows.reduce(
+										(acc, r) => acc + r.cantidad_creditos,
+										0,
+									);
+									const totalCobertura =
+										totalMeta > 0
+											? ((totalColocado / totalMeta) * 100).toFixed(1)
+											: null;
+									return (
+										<>
+											<ResponsiveContainer width="100%" height={300}>
+												<BarChart
+													data={rows.map((row) => ({
+														bucket: formatBucket(row.bucket, equilibrioPeriodo),
+														colocado: Number(row.colocado),
+														meta: Number(row.meta),
+													}))}
+												>
+													<CartesianGrid strokeDasharray="3 3" />
+													<XAxis
+														dataKey="bucket"
+														tick={{ fontSize: 11 }}
+														interval={0}
+														height={36}
+													/>
+													<YAxis
+														tickFormatter={(v) =>
+															`Q${(Number(v) / 1000).toFixed(0)}k`
+														}
+													/>
+													<Tooltip
+														formatter={(value, name) => [
+															formatCurrency(Number(value)),
+															name === "colocado" ? "Colocado" : "Meta",
+														]}
+													/>
+													<Legend
+														formatter={(v) =>
+															v === "colocado" ? "Colocado" : "Meta"
+														}
+													/>
+													<Bar
+														dataKey="colocado"
+														fill="#3b82f6"
+														name="colocado"
+													/>
+													<Bar dataKey="meta" fill="#d1d5db" name="meta" />
+												</BarChart>
+											</ResponsiveContainer>
 
-										<div className="overflow-x-auto">
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Período</TableHead>
-														<TableHead className="text-right">Créditos</TableHead>
-														<TableHead className="text-right">Colocado</TableHead>
-														<TableHead className="text-right">Meta</TableHead>
-														<TableHead className="text-right">Cobertura</TableHead>
-														<TableHead className="text-right">Faltante</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{rows.map((row) => (
-														<TableRow key={row.bucket}>
-															<TableCell>{formatBucket(row.bucket, equilibrioPeriodo)}</TableCell>
-															<TableCell className="text-right">{row.cantidad_creditos}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.colocado)}</TableCell>
+											<div className="overflow-x-auto">
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Período</TableHead>
+															<TableHead className="text-right">
+																Créditos
+															</TableHead>
+															<TableHead className="text-right">
+																Colocado
+															</TableHead>
+															<TableHead className="text-right">Meta</TableHead>
+															<TableHead className="text-right">
+																Cobertura
+															</TableHead>
+															<TableHead className="text-right">
+																Faltante
+															</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														{rows.map((row) => (
+															<TableRow key={row.bucket}>
+																<TableCell>
+																	{formatBucket(row.bucket, equilibrioPeriodo)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.cantidad_creditos}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(row.colocado)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{Number(row.meta) > 0 ? (
+																		formatCurrency(row.meta)
+																	) : (
+																		<span className="text-muted-foreground">
+																			Sin meta
+																		</span>
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	<span
+																		className="font-semibold"
+																		style={{
+																			color: coberturaColor(row.cobertura),
+																		}}
+																	>
+																		{coberturaLabel(row.cobertura)}
+																	</span>
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.faltante
+																		? formatCurrency(row.faltante)
+																		: "—"}
+																</TableCell>
+															</TableRow>
+														))}
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total</TableCell>
 															<TableCell className="text-right">
-																{Number(row.meta) > 0 ? formatCurrency(row.meta) : <span className="text-muted-foreground">Sin meta</span>}
+																{totalCreditos}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalColocado)}
+															</TableCell>
+															<TableCell className="text-right">
+																{totalMeta > 0
+																	? formatCurrency(totalMeta)
+																	: "—"}
 															</TableCell>
 															<TableCell className="text-right">
 																<span
 																	className="font-semibold"
-																	style={{ color: coberturaColor(row.cobertura) }}
+																	style={{
+																		color: coberturaColor(totalCobertura),
+																	}}
 																>
-																	{coberturaLabel(row.cobertura)}
+																	{coberturaLabel(totalCobertura)}
 																</span>
 															</TableCell>
 															<TableCell className="text-right">
-																{row.faltante ? formatCurrency(row.faltante) : "—"}
+																{totalMeta > 0
+																	? formatCurrency(
+																			Math.max(0, totalMeta - totalColocado),
+																		)
+																	: "—"}
 															</TableCell>
 														</TableRow>
-													))}
+													</TableBody>
+												</Table>
+											</div>
+										</>
+									);
+								})()}
+						</CardContent>
+					</Card>
+
+					{/* ============================================================ */}
+					{/* REPORTE: COMPARATIVO HISTÓRICO MENSUAL                        */}
+					{/* ============================================================ */}
+					<Card>
+						<CardHeader>
+							<div className="flex items-center justify-between">
+								<CardTitle className="flex items-center gap-2">
+									<CalendarDays className="h-5 w-5" />
+									Comparativo Histórico Mensual
+								</CardTitle>
+								<div className="flex items-center gap-2">
+									<SimularButton
+										onClick={() => setScenarioOpen("comparativo")}
+									/>
+									<button
+										type="button"
+										className="rounded p-1 hover:bg-muted"
+										onClick={() => setComparativoAnio((y) => y - 1)}
+									>
+										<ChevronLeft className="h-4 w-4" />
+									</button>
+									<span className="w-12 text-center font-semibold text-sm">
+										{comparativoAnio}
+									</span>
+									<button
+										type="button"
+										className="rounded p-1 hover:bg-muted"
+										onClick={() =>
+											setComparativoAnio((y) =>
+												y < new Date().getFullYear() ? y + 1 : y,
+											)
+										}
+									>
+										<ChevronRight className="h-4 w-4" />
+									</button>
+								</div>
+							</div>
+						</CardHeader>
+						<CardContent>
+							{comparativoQuery.isPending && (
+								<p className="py-4 text-center text-muted-foreground text-sm">
+									Cargando...
+								</p>
+							)}
+							{comparativoQuery.isError && (
+								<p className="py-4 text-center text-red-500 text-sm">
+									Error al cargar comparativo histórico.
+								</p>
+							)}
+							{comparativoData &&
+								(() => {
+									const rows = comparativoData.data;
+									const sumColoc = rows.reduce(
+										(acc, r) =>
+											acc +
+											(r.colocacion_monto ? Number(r.colocacion_monto) : 0),
+										0,
+									);
+									const sumFacturacion = rows.reduce(
+										(acc, r) =>
+											acc + (r.facturacion ? Number(r.facturacion) : 0),
+										0,
+									);
+									const sumCreditosColoc = rows.reduce(
+										(acc, r) => acc + (r.colocacion_creditos ?? 0),
+										0,
+									);
+									return (
+										<div className="overflow-x-auto">
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Mes</TableHead>
+														<TableHead className="text-right">
+															Colocación (Q)
+														</TableHead>
+														<TableHead className="text-right"># Col.</TableHead>
+														<TableHead className="text-right">
+															Facturación (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Cartera Activa (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															# Activos
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 30 (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 60 (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 90 (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 120+ (Q)
+														</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{rows.map((row) => {
+														const esFuturo =
+															row.colocacion_monto === null &&
+															row.facturacion === null &&
+															row.cartera_activa === null;
+														return (
+															<TableRow
+																key={row.mes}
+																className={esFuturo ? "opacity-40" : undefined}
+															>
+																<TableCell className="font-medium">
+																	{MESES[row.mes - 1]}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.colocacion_monto
+																		? formatCurrency(
+																				Number(row.colocacion_monto),
+																			)
+																		: "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.colocacion_creditos ?? "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.facturacion
+																		? formatCurrency(Number(row.facturacion))
+																		: "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.cartera_activa
+																		? formatCurrency(Number(row.cartera_activa))
+																		: "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.creditos_activos ?? "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_30 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_30))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_30 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_60 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_60))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_60 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_90 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_90))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_90 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_120 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_120))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_120 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+															</TableRow>
+														);
+													})}
 													<TableRow className="border-t-2 bg-muted/50 font-bold">
 														<TableCell>Total</TableCell>
-														<TableCell className="text-right">{totalCreditos}</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalColocado)}</TableCell>
 														<TableCell className="text-right">
-															{totalMeta > 0 ? formatCurrency(totalMeta) : "—"}
+															{formatCurrency(sumColoc)}
 														</TableCell>
 														<TableCell className="text-right">
-															<span
-																className="font-semibold"
-																style={{ color: coberturaColor(totalCobertura) }}
-															>
-																{coberturaLabel(totalCobertura)}
-															</span>
+															{sumCreditosColoc}
 														</TableCell>
 														<TableCell className="text-right">
-															{totalMeta > 0
-																? formatCurrency(Math.max(0, totalMeta - totalColocado))
-																: "—"}
+															{formatCurrency(sumFacturacion)}
 														</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
 													</TableRow>
 												</TableBody>
 											</Table>
 										</div>
-									</>
-								);
-							})()}
+									);
+								})()}
 						</CardContent>
 					</Card>
-
-				{/* ============================================================ */}
-				{/* REPORTE: COMPARATIVO HISTÓRICO MENSUAL                        */}
-				{/* ============================================================ */}
-				<Card>
-					<CardHeader>
-						<div className="flex items-center justify-between">
-							<CardTitle className="flex items-center gap-2">
-								<CalendarDays className="h-5 w-5" />
-								Comparativo Histórico Mensual
-							</CardTitle>
-							<div className="flex items-center gap-2">
-								<button
-									type="button"
-									className="rounded p-1 hover:bg-muted"
-									onClick={() => setComparativoAnio((y) => y - 1)}
-								>
-									<ChevronLeft className="h-4 w-4" />
-								</button>
-								<span className="font-semibold text-sm w-12 text-center">
-									{comparativoAnio}
-								</span>
-								<button
-									type="button"
-									className="rounded p-1 hover:bg-muted"
-									onClick={() =>
-										setComparativoAnio((y) =>
-											y < new Date().getFullYear() ? y + 1 : y,
-										)
-									}
-								>
-									<ChevronRight className="h-4 w-4" />
-								</button>
-							</div>
-						</div>
-					</CardHeader>
-					<CardContent>
-						{comparativoQuery.isPending && (
-							<p className="text-sm text-muted-foreground py-4 text-center">
-								Cargando...
-							</p>
-						)}
-						{comparativoQuery.isError && (
-							<p className="text-sm text-red-500 py-4 text-center">
-								Error al cargar comparativo histórico.
-							</p>
-						)}
-						{comparativoData && (() => {
-							const rows = comparativoData.data;
-							const sumColoc = rows.reduce(
-								(acc, r) => acc + (r.colocacion_monto ? Number(r.colocacion_monto) : 0),
-								0,
-							);
-							const sumFacturacion = rows.reduce(
-								(acc, r) => acc + (r.facturacion ? Number(r.facturacion) : 0),
-								0,
-							);
-							const sumCreditosColoc = rows.reduce(
-								(acc, r) => acc + (r.colocacion_creditos ?? 0),
-								0,
-							);
-							return (
-								<div className="overflow-x-auto">
-									<Table>
-										<TableHeader>
-											<TableRow>
-												<TableHead>Mes</TableHead>
-												<TableHead className="text-right">Colocación (Q)</TableHead>
-												<TableHead className="text-right"># Col.</TableHead>
-												<TableHead className="text-right">Facturación (Q)</TableHead>
-												<TableHead className="text-right">Cartera Activa (Q)</TableHead>
-												<TableHead className="text-right"># Activos</TableHead>
-												<TableHead className="text-right">Mora 30 (Q)</TableHead>
-												<TableHead className="text-right">Mora 60 (Q)</TableHead>
-												<TableHead className="text-right">Mora 90 (Q)</TableHead>
-												<TableHead className="text-right">Mora 120+ (Q)</TableHead>
-											</TableRow>
-										</TableHeader>
-										<TableBody>
-											{rows.map((row) => {
-												const esFuturo =
-													row.colocacion_monto === null &&
-													row.facturacion === null &&
-													row.cartera_activa === null;
-												return (
-													<TableRow
-														key={row.mes}
-														className={esFuturo ? "opacity-40" : undefined}
-													>
-														<TableCell className="font-medium">
-															{MESES[row.mes - 1]}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.colocacion_monto
-																? formatCurrency(Number(row.colocacion_monto))
-																: "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.colocacion_creditos ?? "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.facturacion
-																? formatCurrency(Number(row.facturacion))
-																: "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.cartera_activa
-																? formatCurrency(Number(row.cartera_activa))
-																: "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.creditos_activos ?? "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_30 ? <span>{formatCurrency(Number(row.mora_30))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_30 ?? 0})</span></span> : "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_60 ? <span>{formatCurrency(Number(row.mora_60))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_60 ?? 0})</span></span> : "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_90 ? <span>{formatCurrency(Number(row.mora_90))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_90 ?? 0})</span></span> : "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_120 ? <span>{formatCurrency(Number(row.mora_120))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_120 ?? 0})</span></span> : "—"}
-														</TableCell>
-													</TableRow>
-												);
-											})}
-										</TableBody>
-										<TableBody>
-											<TableRow className="border-t-2 bg-muted/50 font-bold">
-												<TableCell>Total</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(sumColoc)}
-												</TableCell>
-												<TableCell className="text-right">
-													{sumCreditosColoc}
-												</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(sumFacturacion)}
-												</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-											</TableRow>
-										</TableBody>
-									</Table>
-								</div>
-							);
-						})()}
-					</CardContent>
-				</Card>
 				</>
 			)}
-
 		</div>
 	);
 }


### PR DESCRIPTION
## Qué

Agrega un botón **Simular** (✨) en cada uno de los 5 reportes de `/admin/reports`. Abre un modal con supuestos y muestra el resultado **simulado vs real**:

- **Colocar +X%** — escala la colocación
- **Bajar mora X%** — reduce la mora (acotado a 0–100%)
- **Subir efectividad X%** — cierra la brecha cobrado vs esperado
- **Método de cuota** (francés / fija) — cuota ilustrativa

Reportes cubiertos: Monto a Cobrarse, Facturado vs Esperado, Flujo de Cuotas de Inversiones, Cobertura vs Meta, Comparativo Histórico.

Todo el cálculo es **client-side** sobre los datos que el reporte ya carga. **No modifica datos reales** (resultados estimados, indicado en el modal). Si luego se requiere exactitud, se puede mover a backend.

## Archivos

- `lib/reports/scenario.ts` — motor puro de transformaciones + cuota ilustrativa (reusa amortización de `quoter-calculations`)
- `lib/reports/scenario-configs.ts` — config por reporte
- `components/reports/scenario-modal.tsx` — UI genérica (sliders/inputs + gráfica y tabla real vs escenario)
- `lib/reports/scenario.test.ts` — 11 tests
- `routes/admin/reports/index.tsx` — botón + modales

## Fixes incidentales en `admin/reports/index.tsx`

- `total_royalti` faltaba en la columna **Total** de "Monto a Cobrarse" (subestimaba el total)
- Dos `<TableBody>` hermanos en "Comparativo Histórico" (HTML inválido)
- Deduplica 6 tipos importándolos de `scenario.ts` (fuente única)

## Verificación

- `bun test` → 11 pass, 0 fail
- `biome` → limpio en archivos nuevos
- Sin conflictos con #871 (archivos disjuntos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)