### PR TITLE
🚀 Pase a Producción — Release develop → main

### DIFF
--- a/apps/cartera-back/drizzle/0013_desglose_facturas_genericas.sql
+++ b/apps/cartera-back/drizzle/0013_desglose_facturas_genericas.sql
@@ -1,0 +1,19 @@
+-- Desglose para FACTURAS GENÉRICAS (las que pasan por /facturar-generico, sin pago),
+-- para que el reporte diario capture lo facturado genérico (otros ingresos, royalty, etc.).
+--   1) ROYALTY como rubro (el royalty REALMENTE facturado; el snapshot lo prioriza
+--      sobre creditos.royalti, que queda solo de respaldo para días sin royalty facturado).
+--   2) pago_id nullable: las genéricas no tienen pago → se anclan por factura_id.
+--   3) categoria: se guarda la del receptor (resuelta por NIT) para poder ubicarlas en la
+--      columna de producto del reporte (las genéricas no tienen crédito para derivarla por JOIN).
+--   4) unicidad de genéricas por (factura_id, rubro) cuando pago_id IS NULL.
+--
+-- ADD VALUE IF NOT EXISTS es idempotente (PG10+). Correr/commitear ANTES de desplegar el código.
+ALTER TYPE cartera.rubro_facturacion ADD VALUE IF NOT EXISTS 'ROYALTY';
+
+ALTER TABLE cartera.facturacion_desglose ALTER COLUMN pago_id DROP NOT NULL;
+
+ALTER TABLE cartera.facturacion_desglose ADD COLUMN IF NOT EXISTS categoria varchar(100);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facturacion_desglose_factura_rubro
+  ON cartera.facturacion_desglose (factura_id, rubro)
+  WHERE pago_id IS NULL;

--- a/apps/cartera-back/schedule.ts
+++ b/apps/cartera-back/schedule.ts
@@ -7,7 +7,7 @@ import {
   verificarFacturasSat,
   reportarFacturasFallidasSat,
 } from './src/controllers/verificarFacturasSat';
-import { asegurarSnapshotDiario } from './src/controllers/facturacionSnapshot';
+import { generarSnapshotDiario } from './src/controllers/facturacionSnapshot';
 
 const TZ_GUATEMALA = 'America/Guatemala';
 
@@ -111,18 +111,21 @@ export function iniciarTareasProgramadas() {
     }
   });
 
-  // 📸 Snapshot diario de facturación - 01:00 hora Guatemala (respaldo).
-  //    Genera el snapshot del DÍA ANTERIOR SOLO si no se guardó ya manualmente.
+  // 📸 Snapshot diario de facturación - 01:00 hora Guatemala.
+  //    REGENERA (force) los últimos 3 días, NO "solo si falta": así captura
+  //    facturación que entró con fecha atrasada y refresca filas pre-creadas
+  //    (p. ej. del import del Excel hasta 2026-12-31) que de otro modo
+  //    quedarían congeladas en su valor viejo/0.
   schedule.scheduleJob({ rule: '0 1 * * *', tz: TZ_GUATEMALA }, async () => {
-    const fecha = getFechaGuatemalaISO(-1); // ayer en GT
-    console.log(`📸 Ejecutando asegurarSnapshotDiario para ${fecha} (01:00 Guatemala)...`);
-    try {
-      const res = await asegurarSnapshotDiario(fecha);
-      console.log(
-        `✅ snapshotDiario ${fecha}: ${res.created ? 'generado' : 'ya existía'}`,
-      );
-    } catch (error) {
-      console.error('❌ Error al ejecutar asegurarSnapshotDiario:', error);
+    for (const off of [-1, -2, -3]) {
+      const fecha = getFechaGuatemalaISO(off); // ayer, antier, trasantier (GT)
+      console.log(`📸 Regenerando snapshot diario ${fecha} (01:00 Guatemala)...`);
+      try {
+        await generarSnapshotDiario(fecha);
+        console.log(`✅ snapshotDiario ${fecha}: regenerado`);
+      } catch (error) {
+        console.error(`❌ Error regenerando snapshot ${fecha}:`, error);
+      }
     }
   });
 

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -342,6 +342,34 @@ export async function asegurarSnapshotDiario(fecha: string) {
   return { success: true, created: true, fecha };
 }
 
+// Regenera (force, upsert) el snapshot de CADA día en [fechaInicio, fechaFin].
+// A diferencia de asegurarSnapshotDiario, SIEMPRE recalcula aunque la fila ya
+// exista — útil para refrescar días pre-creados (p. ej. del import del Excel)
+// o capturar facturación que entró con fecha atrasada.
+export async function regenerarSnapshotRango(
+  fechaInicio: string,
+  fechaFin: string
+) {
+  const dias: string[] = [];
+  const d = new Date(`${fechaInicio}T00:00:00Z`);
+  const fin = new Date(`${fechaFin}T00:00:00Z`);
+  if (Number.isNaN(d.getTime()) || Number.isNaN(fin.getTime()) || d > fin) {
+    return { success: false, message: "Rango de fechas inválido" };
+  }
+  while (d <= fin) {
+    dias.push(d.toISOString().slice(0, 10));
+    d.setUTCDate(d.getUTCDate() + 1);
+    if (dias.length > 400) break; // tope defensivo
+  }
+  for (const f of dias) await generarSnapshotDiario(f);
+  return {
+    success: true,
+    regenerados: dias.length,
+    desde: dias[0],
+    hasta: dias[dias.length - 1],
+  };
+}
+
 // ============================================================================
 // 📥 EXPORTAR A EXCEL (diseño tipo Reuniones diarias, con logo y totales)
 // ============================================================================

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -78,6 +78,9 @@ export async function generarSnapshotDiario(fecha: string) {
     LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
     LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
     WHERE fd.fecha_aplicado_gt = ${fecha}::date
+      -- una fila de PAGO huérfana (credito/usuario borrado) no debe sumar al
+      -- total; las GENÉRICAS (pago_id NULL) sí entran.
+      AND (fd.pago_id IS NULL OR p.pago_id IS NOT NULL)
     GROUP BY COALESCE(u.categoria, fd.categoria), fd.rubro
   `);
   for (const r of (desg as any).rows ?? []) {
@@ -107,21 +110,29 @@ export async function generarSnapshotDiario(fecha: string) {
     add(colProducto(prefix, cat), total);
   }
 
-  // 2) Royalty del día: PRIORIDAD a lo REALMENTE facturado (rubro ROYALTY del
-  //    desglose, ya sumado en el bloque 1). Solo si ese día NO hubo royalty
-  //    facturado, se usa el RESPALDO de creditos.royalti por fecha_creacion (GT).
-  if (g("royalty").lte(0)) {
-    const roy = await db.execute(sql`
-      SELECT u.categoria AS categoria, COALESCE(SUM(c.royalti), 0) AS total
-      FROM cartera.creditos c
-      INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-      WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
-      GROUP BY u.categoria
-    `);
-    for (const r of (roy as any).rows ?? []) {
-      add("royalty", r.total);
-      add(colProducto("roy", r.categoria as string), r.total);
-    }
+  // 2) Royalty del día = lo facturado (rubro ROYALTY del desglose, ya sumado en
+  //    el bloque 1) + RESPALDO de creditos.royalti (por fecha_creacion), PERO solo
+  //    para créditos cuyo NIT NO tenga una factura genérica ROYALTY en el mes
+  //    (dedup por NIT: si su royalty ya se facturó genérico, no se vuelve a contar).
+  const roy = await db.execute(sql`
+    SELECT u.categoria AS categoria, COALESCE(SUM(c.royalti), 0) AS total
+    FROM cartera.creditos c
+    INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+    WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+      AND NOT EXISTS (
+        SELECT 1
+        FROM cartera.facturacion_desglose fdr
+        JOIN cartera.facturas_electronicas fe ON fe.factura_id = fdr.factura_id
+        WHERE fdr.rubro::text = 'ROYALTY' AND fdr.pago_id IS NULL
+          AND fdr.fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
+          AND regexp_replace(COALESCE(fe.receptor_nit, ''), '[^0-9A-Za-z]', '', 'g')
+            = regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g')
+      )
+    GROUP BY u.categoria
+  `);
+  for (const r of (roy as any).rows ?? []) {
+    add("royalty", r.total);
+    add(colProducto("roy", r.categoria as string), r.total);
   }
 
   // 3) Gastos administrativos del día
@@ -174,20 +185,27 @@ export async function generarSnapshotDiario(fecha: string) {
     WHERE fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
   // Royalty MTD: lo REALMENTE facturado (rubro ROYALTY del desglose) + RESPALDO de
-  // creditos.royalti SOLO para los días del mes SIN royalty facturado (mismo criterio
-  // que el día, pero acumulado).
+  // creditos.royalti, pero SOLO de créditos cuyo NIT NO tenga factura genérica
+  // ROYALTY en el mes (dedup por NIT, mismo criterio que el día → la suma de los
+  // días cuadra con el MTD y no hay doble conteo por fechas distintas).
   const royMtd = await db.execute(sql`
     SELECT
       COALESCE((SELECT SUM(monto_total) FROM cartera.facturacion_desglose
                 WHERE rubro::text = 'ROYALTY'
                   AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date), 0)
       +
-      COALESCE((SELECT SUM(c.royalti) FROM cartera.creditos c
+      COALESCE((SELECT SUM(c.royalti)
+                FROM cartera.creditos c
+                JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
                 WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
                   AND NOT EXISTS (
-                    SELECT 1 FROM cartera.facturacion_desglose fd
-                    WHERE fd.rubro::text = 'ROYALTY'
-                      AND fd.fecha_aplicado_gt = (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date
+                    SELECT 1
+                    FROM cartera.facturacion_desglose fdr
+                    JOIN cartera.facturas_electronicas fe ON fe.factura_id = fdr.factura_id
+                    WHERE fdr.rubro::text = 'ROYALTY' AND fdr.pago_id IS NULL
+                      AND fdr.fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
+                      AND regexp_replace(COALESCE(fe.receptor_nit, ''), '[^0-9A-Za-z]', '', 'g')
+                        = regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g')
                   )), 0) AS total
   `);
   const invMtd = await db.execute(sql`

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -58,7 +58,6 @@ export async function generarSnapshotDiario(fecha: string) {
   const [y, m, d] = fecha.split("-").map(Number);
   const monthStart = `${y}-${String(m).padStart(2, "0")}-01`;
   const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
-  const monthEnd = `${y}-${String(m).padStart(2, "0")}-${String(daysInMonth).padStart(2, "0")}`;
   const dayOfMonth = d;
 
   // Acumulador de columnas (Big.js)
@@ -111,32 +110,11 @@ export async function generarSnapshotDiario(fecha: string) {
     add(colProducto(prefix, cat), total);
   }
 
-  // 2) Royalty del día = lo facturado (rubro ROYALTY del desglose, ya sumado en
-  //    el bloque 1) + RESPALDO de creditos.royalti (por fecha_creacion), PERO solo
-  //    para créditos cuyo NIT NO tenga una factura genérica ROYALTY en el mes
-  //    (dedup por NIT: si su royalty ya se facturó genérico, no se vuelve a contar).
-  const roy = await db.execute(sql`
-    SELECT u.categoria AS categoria, COALESCE(SUM(c.royalti), 0) AS total
-    FROM cartera.creditos c
-    INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-    WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
-      AND NOT EXISTS (
-        SELECT 1
-        FROM cartera.facturacion_desglose fdr
-        JOIN cartera.facturas_electronicas fe ON fe.factura_id = fdr.factura_id
-        WHERE fdr.rubro::text = 'ROYALTY' AND fdr.pago_id IS NULL
-          -- mes COMPLETO (no solo hasta hoy): si la factura ROYALTY del NIT se
-          -- emite DESPUÉS en el mes, igual debe suprimir el respaldo al regenerar.
-          AND fdr.fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${monthEnd}::date
-          AND upper(regexp_replace(COALESCE(fe.receptor_nit, ''), '[^0-9A-Za-z]', '', 'g'))
-            = upper(regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g'))
-      )
-    GROUP BY u.categoria
-  `);
-  for (const r of (roy as any).rows ?? []) {
-    add("royalty", r.total);
-    add(colProducto("roy", r.categoria as string), r.total);
-  }
+  // 2) Royalty del día = SOLO lo REALMENTE facturado (rubro ROYALTY del desglose,
+  //    ya sumado en el bloque 1). Decisión de diseño: NO se usa creditos.royalti de
+  //    respaldo — lo facturado es la fuente correcta (creditos.royalti difería de
+  //    contabilidad) y el respaldo causaba doble conteo. Crédito sin royalty
+  //    facturado genérico → no suma royalty (0).
 
   // 3) Gastos administrativos del día
   const adm = await db.execute(sql`
@@ -187,29 +165,13 @@ export async function generarSnapshotDiario(fecha: string) {
     FROM cartera.facturacion_desglose
     WHERE fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
-  // Royalty MTD: lo REALMENTE facturado (rubro ROYALTY del desglose) + RESPALDO de
-  // creditos.royalti, pero SOLO de créditos cuyo NIT NO tenga factura genérica
-  // ROYALTY en el mes (dedup por NIT, mismo criterio que el día → la suma de los
-  // días cuadra con el MTD y no hay doble conteo por fechas distintas).
+  // Royalty MTD: SOLO lo facturado (rubro ROYALTY del desglose). Sin respaldo de
+  // creditos.royalti (misma decisión que el bloque 2).
   const royMtd = await db.execute(sql`
-    SELECT
-      COALESCE((SELECT SUM(monto_total) FROM cartera.facturacion_desglose
-                WHERE rubro::text = 'ROYALTY'
-                  AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date), 0)
-      +
-      COALESCE((SELECT SUM(c.royalti)
-                FROM cartera.creditos c
-                JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-                WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
-                  AND NOT EXISTS (
-                    SELECT 1
-                    FROM cartera.facturacion_desglose fdr
-                    JOIN cartera.facturas_electronicas fe ON fe.factura_id = fdr.factura_id
-                    WHERE fdr.rubro::text = 'ROYALTY' AND fdr.pago_id IS NULL
-                      AND fdr.fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
-                      AND regexp_replace(COALESCE(fe.receptor_nit, ''), '[^0-9A-Za-z]', '', 'g')
-                        = regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g')
-                  )), 0) AS total
+    SELECT COALESCE(SUM(monto_total), 0) AS total
+    FROM cartera.facturacion_desglose
+    WHERE rubro::text = 'ROYALTY'
+      AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
   const invMtd = await db.execute(sql`
     SELECT COALESCE(SUM(monto_total), 0) AS total

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -12,9 +12,9 @@ const LOGO_URL =
 // ============================================================================
 // 📸 SNAPSHOT DIARIO DE FACTURACIÓN (tipo Excel "Reuniones diarias")
 //    Calcula y CONGELA una fila por día con las columnas A→BK.
-//    Fuentes: facturacion_desglose (CUBE), creditos.royalti (royalty),
-//    gastos_administrativos, pagos_credito.reserva, pci (inversionistas),
-//    metas_facturacion. Upsert por fecha (regenerable).
+//    Fuentes: facturacion_desglose (CUBE + genéricas: otros, royalty facturado,
+//    inversionistas), gastos_administrativos, ingresos_carros,
+//    pagos_credito.reserva, metas_facturacion. Upsert por fecha (regenerable).
 // ============================================================================
 
 // Prefijo de columna por rubro (lo que factura CUBE).

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -24,6 +24,7 @@ const RUBRO_PREFIX: Record<string, string> = {
   MEMBRESIA: "mem",
   OTROS: "oi",
   MORA: "mora",
+  ROYALTY: "roy",
 };
 
 // categoría BD -> producto Excel (sufijo). "__NUEVO__" usa el patrón nuevo_<prefijo>_autocompras.
@@ -67,15 +68,17 @@ export async function generarSnapshotDiario(fecha: string) {
   };
   const g = (col: string) => C[col] ?? new Big(0);
 
-  // 1) Desglose CUBE del día: por categoría × rubro
+  // 1) Desglose del día: por categoría × rubro. LEFT JOIN para incluir también las
+  //    GENÉRICAS (pago_id NULL): para esas la categoría sale de la columna guardada
+  //    `fd.categoria` (resuelta por NIT al facturar); las de pago la derivan por JOIN.
   const desg = await db.execute(sql`
-    SELECT u.categoria AS categoria, fd.rubro AS rubro, SUM(fd.monto_total) AS total
+    SELECT COALESCE(u.categoria, fd.categoria) AS categoria, fd.rubro AS rubro, SUM(fd.monto_total) AS total
     FROM cartera.facturacion_desglose fd
-    INNER JOIN cartera.pagos_credito p ON p.pago_id   = fd.pago_id
-    INNER JOIN cartera.creditos      c ON c.credito_id = p.credito_id
-    INNER JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
+    LEFT JOIN cartera.pagos_credito p ON p.pago_id   = fd.pago_id
+    LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
+    LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
     WHERE fd.fecha_aplicado_gt = ${fecha}::date
-    GROUP BY u.categoria, fd.rubro
+    GROUP BY COALESCE(u.categoria, fd.categoria), fd.rubro
   `);
   for (const r of (desg as any).rows ?? []) {
     const cat = r.categoria as string;
@@ -97,22 +100,28 @@ export async function generarSnapshotDiario(fecha: string) {
         ? "membresia"
         : rubro === "OTROS"
         ? "otros_ingresos"
+        : rubro === "ROYALTY"
+        ? "royalty"
         : "mora_cube"; // MORA
     add(totalCol, total);
     add(colProducto(prefix, cat), total);
   }
 
-  // 2) Royalty del día: de creditos.royalti por fecha_creacion (GT) + categoría
-  const roy = await db.execute(sql`
-    SELECT u.categoria AS categoria, COALESCE(SUM(c.royalti), 0) AS total
-    FROM cartera.creditos c
-    INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-    WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
-    GROUP BY u.categoria
-  `);
-  for (const r of (roy as any).rows ?? []) {
-    add("royalty", r.total);
-    add(colProducto("roy", r.categoria as string), r.total);
+  // 2) Royalty del día: PRIORIDAD a lo REALMENTE facturado (rubro ROYALTY del
+  //    desglose, ya sumado en el bloque 1). Solo si ese día NO hubo royalty
+  //    facturado, se usa el RESPALDO de creditos.royalti por fecha_creacion (GT).
+  if (g("royalty").lte(0)) {
+    const roy = await db.execute(sql`
+      SELECT u.categoria AS categoria, COALESCE(SUM(c.royalti), 0) AS total
+      FROM cartera.creditos c
+      INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+      WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+      GROUP BY u.categoria
+    `);
+    for (const r of (roy as any).rows ?? []) {
+      add("royalty", r.total);
+      add(colProducto("roy", r.categoria as string), r.total);
+    }
   }
 
   // 3) Gastos administrativos del día
@@ -164,9 +173,22 @@ export async function generarSnapshotDiario(fecha: string) {
     FROM cartera.facturacion_desglose
     WHERE fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
+  // Royalty MTD: lo REALMENTE facturado (rubro ROYALTY del desglose) + RESPALDO de
+  // creditos.royalti SOLO para los días del mes SIN royalty facturado (mismo criterio
+  // que el día, pero acumulado).
   const royMtd = await db.execute(sql`
-    SELECT COALESCE(SUM(c.royalti), 0) AS total FROM cartera.creditos c
-    WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
+    SELECT
+      COALESCE((SELECT SUM(monto_total) FROM cartera.facturacion_desglose
+                WHERE rubro::text = 'ROYALTY'
+                  AND fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date), 0)
+      +
+      COALESCE((SELECT SUM(c.royalti) FROM cartera.creditos c
+                WHERE (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
+                  AND NOT EXISTS (
+                    SELECT 1 FROM cartera.facturacion_desglose fd
+                    WHERE fd.rubro::text = 'ROYALTY'
+                      AND fd.fecha_aplicado_gt = (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date
+                  )), 0) AS total
   `);
   const invMtd = await db.execute(sql`
     SELECT COALESCE(SUM(monto_total), 0) AS total

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -58,6 +58,7 @@ export async function generarSnapshotDiario(fecha: string) {
   const [y, m, d] = fecha.split("-").map(Number);
   const monthStart = `${y}-${String(m).padStart(2, "0")}-01`;
   const daysInMonth = new Date(Date.UTC(y, m, 0)).getUTCDate();
+  const monthEnd = `${y}-${String(m).padStart(2, "0")}-${String(daysInMonth).padStart(2, "0")}`;
   const dayOfMonth = d;
 
   // Acumulador de columnas (Big.js)
@@ -124,9 +125,11 @@ export async function generarSnapshotDiario(fecha: string) {
         FROM cartera.facturacion_desglose fdr
         JOIN cartera.facturas_electronicas fe ON fe.factura_id = fdr.factura_id
         WHERE fdr.rubro::text = 'ROYALTY' AND fdr.pago_id IS NULL
-          AND fdr.fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${fecha}::date
-          AND regexp_replace(COALESCE(fe.receptor_nit, ''), '[^0-9A-Za-z]', '', 'g')
-            = regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g')
+          -- mes COMPLETO (no solo hasta hoy): si la factura ROYALTY del NIT se
+          -- emite DESPUÉS en el mes, igual debe suprimir el respaldo al regenerar.
+          AND fdr.fecha_aplicado_gt BETWEEN ${monthStart}::date AND ${monthEnd}::date
+          AND upper(regexp_replace(COALESCE(fe.receptor_nit, ''), '[^0-9A-Za-z]', '', 'g'))
+            = upper(regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g'))
       )
     GROUP BY u.categoria
   `);

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -869,6 +869,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
       const comprasPendientesOrigen = await tx
         .select({
           monto_aportado: compras_credito_inversionista.monto_aportado,
+          tipo_reinversion: compras_credito_inversionista.tipo_reinversion,
         })
         .from(compras_credito_inversionista)
         .where(
@@ -889,6 +890,13 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
         (acc, r) => acc.plus(new Big(r.monto_aportado)),
         new Big(0),
       );
+
+      // tipo_reinversion de la operación pendiente del origen. Se conserva
+      // para que la fila nueva del destino (insert) no lo pierda (antes se
+      // guardaba en null).
+      const tipoReinversionOrigen =
+        comprasPendientesOrigen.find((c) => c.tipo_reinversion != null)
+          ?.tipo_reinversion ?? null;
 
       const montoPadreOrigen = new Big(invEnOrigen.monto_aportado);
       const montoEnOrigen = deltaPendienteOrigen.gt(0)
@@ -1199,7 +1207,7 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
           inversionista_id,
           monto_aportado: montoAsignar.toString(),
           tipo_operacion,
-          tipo_reinversion: null,
+          tipo_reinversion: tipoReinversionOrigen,
           status: statusEspejo,
         });
 

--- a/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
+++ b/apps/cartera-back/src/controllers/replaceInvestorCredit.ts
@@ -1183,6 +1183,13 @@ export const manualReassignInvestor = async ({ body, set }: any) => {
             | "pendiente_reinversion"
             | "pendiente_compra_cartera"
             | "completado",
+          // Estampar la modalidad en la fila del inversionista reasignado:
+          // sesiones pendientes y la aceptación de compra leen tipo_reinversion
+          // DEL ESPEJO, no de compras_credito_inversionista.
+          tipo_reinversion:
+            inv.inversionista_id === inversionista_id
+              ? tipoReinversionOrigen
+              : null,
           updated_at: new Date(),
         }));
 

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -65,6 +65,7 @@
     "MORA",
     "OTROS",
     "INTERES_INVERSIONISTAS",
+    "ROYALTY",
   ]);
   export const admins = customSchema.table("admins", {
     admin_id: serial("admin_id").primaryKey(),
@@ -1135,9 +1136,11 @@
     "facturacion_desglose",
     {
       id: serial("id").primaryKey(),
-      pago_id: integer("pago_id")
-        .notNull()
-        .references(() => pagos_credito.pago_id, { onDelete: "cascade" }),
+      // nullable: las facturas GENÉRICAS no tienen pago (se anclan por factura_id).
+      pago_id: integer("pago_id").references(
+        () => pagos_credito.pago_id,
+        { onDelete: "cascade" }
+      ),
       factura_id: integer("factura_id").references(
         () => facturas_electronicas.factura_id,
         { onDelete: "set null" }
@@ -1150,6 +1153,10 @@
         .notNull()
         .default("0"),
       fecha_aplicado_gt: date("fecha_aplicado_gt"),
+      // Categoría del receptor (resuelta por NIT) para las genéricas → columna de
+      // producto del reporte. En filas ligadas a un pago queda NULL y se deriva
+      // por JOIN pago→credito→usuario.
+      categoria: varchar("categoria", { length: 100 }),
       created_at: timestamp("created_at").defaultNow().notNull(),
     },
     (table) => ({

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -2441,6 +2441,21 @@ if (facturasExistentes.length > 0) {
 
       console.log('✅ Estado de factura actualizado en base de datos');
 
+      // 🧾 Si la factura tenía desglose GENÉRICO (para el reporte diario), borrarlo
+      //    para que no siga sumando en el snapshot tras la anulación. Solo toca las
+      //    filas genéricas (pago_id IS NULL); las ligadas a un pago no se tocan.
+      //    Best-effort: la factura ya quedó anulada, esto no debe romper la respuesta.
+      try {
+        await db.execute(
+          sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${facturaAnulada.factura_id} AND pago_id IS NULL`
+        );
+      } catch (limpiezaError) {
+        console.error(
+          '⚠️ No se pudo limpiar el desglose genérico de la factura anulada (NO afecta la anulación):',
+          (limpiezaError as Error).message
+        );
+      }
+
       // ============================================
       // 8️⃣ RESPUESTA EXITOSA
       // ============================================
@@ -3334,7 +3349,10 @@ if (facturasExistentes.length > 0) {
                     ${rubro}::cartera.rubro_facturacion,
                     ${montoBig.toFixed(2)},
                     ${iva.toFixed(2)},
-                    (SELECT (fecha_emision AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date
+                    -- fecha_emision YA se guarda en hora Guatemala (certificarFacturaHelper
+                    -- le resta 6h antes de persistir), así que se usa directo SIN volver a
+                    -- convertir de UTC→GT (eso shifteaba las genéricas de 00:00–05:59 al día anterior).
+                    (SELECT fecha_emision::date
                        FROM cartera.facturas_electronicas WHERE factura_id = ${resultado.factura_id}),
                     ${categoria}
                   )

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -3282,6 +3282,76 @@ if (facturasExistentes.length > 0) {
         console.log(`✅ Serie: ${resultado.serie}-${resultado.numero}`);
         console.log(`✅ UUID: ${resultado.uuid}`);
 
+        // 🧾 Desglose de la factura GENÉRICA para el reporte diario (best-effort,
+        //    NO afecta la facturación). Solo para items que traen `rubro_desglose`.
+        //    La categoría (columna de producto del reporte) se resuelve por el NIT
+        //    del receptor → usuario con créditos → usuarios.categoria.
+        try {
+          const RUBROS_VALIDOS = new Set([
+            "CAPITAL", "INTERES", "MEMBRESIA", "SEGURO", "GPS",
+            "MORA", "OTROS", "INTERES_INVERSIONISTAS", "ROYALTY",
+          ]);
+          const itemsConRubro = (itemsInput as any[]).filter(
+            (it) =>
+              it.rubro_desglose &&
+              RUBROS_VALIDOS.has(String(it.rubro_desglose).toUpperCase())
+          );
+          if (itemsConRubro.length > 0 && resultado.factura_id) {
+            // Categoría del receptor: usuario (con créditos) por NIT; el del crédito más reciente.
+            const catRes = await db.execute(sql`
+              SELECT u.categoria
+              FROM cartera.usuarios u
+              WHERE regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g') = ${nitNormalizado}
+                AND EXISTS (SELECT 1 FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id)
+              ORDER BY (SELECT MAX(c.fecha_creacion) FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id) DESC NULLS LAST
+              LIMIT 1
+            `);
+            const categoria = (catRes as any).rows?.[0]?.categoria ?? null;
+
+            // Agrupar por rubro (varios items pueden compartir rubro). monto = total con IVA.
+            const porRubro: Record<string, Big> = {};
+            for (const it of itemsConRubro) {
+              const k = String(it.rubro_desglose).toUpperCase();
+              porRubro[k] = (porRubro[k] ?? new Big(0)).plus(new Big(it.monto || 0));
+            }
+
+            await db.transaction(async (tx) => {
+              // Reemplazar para que re-facturar no duplique.
+              await tx.execute(
+                sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${resultado.factura_id} AND pago_id IS NULL`
+              );
+              for (const [rubro, montoBig] of Object.entries(porRubro)) {
+                if (montoBig.lte(0)) continue;
+                const iva = new Big(
+                  calcularIvaExacto(parseFloat(montoBig.toFixed(2))).montoImpuesto
+                );
+                await tx.execute(sql`
+                  INSERT INTO cartera.facturacion_desglose
+                    (pago_id, factura_id, rubro, monto_total, monto_iva, fecha_aplicado_gt, categoria)
+                  VALUES (
+                    NULL,
+                    ${resultado.factura_id},
+                    ${rubro}::cartera.rubro_facturacion,
+                    ${montoBig.toFixed(2)},
+                    ${iva.toFixed(2)},
+                    (SELECT (fecha_emision AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date
+                       FROM cartera.facturas_electronicas WHERE factura_id = ${resultado.factura_id}),
+                    ${categoria}
+                  )
+                `);
+              }
+            });
+            console.log(
+              `🧾 Desglose genérico guardado: ${Object.keys(porRubro).length} rubro(s) para factura ${resultado.factura_id} (categoria=${categoria ?? "—"})`
+            );
+          }
+        } catch (desgloseError: any) {
+          console.error(
+            `⚠️ No se pudo guardar el desglose genérico (NO afecta la facturación):`,
+            desgloseError?.message
+          );
+        }
+
         return {
           success: true,
           data: {
@@ -3320,6 +3390,10 @@ if (facturasExistentes.length > 0) {
           t.Object({
             monto: t.Number(),
             rubro: t.String(),
+            // Opcional: rubro del REPORTE (enum rubro_facturacion) para el desglose.
+            // Si viene, se guarda en facturacion_desglose y el snapshot lo suma.
+            // Si no viene, la factura no entra al reporte (mejor no contar que mal).
+            rubro_desglose: t.Optional(t.String()),
           })
         ),
         created_by: t.Optional(t.Number()),

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -3316,7 +3316,8 @@ if (facturasExistentes.length > 0) {
             const catRes = await db.execute(sql`
               SELECT u.categoria
               FROM cartera.usuarios u
-              WHERE regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g') = ${nitNormalizado}
+              WHERE regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g')
+                  = regexp_replace(${nitNormalizado}, '[^0-9A-Za-z]', '', 'g')
                 AND EXISTS (SELECT 1 FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id)
               ORDER BY (SELECT MAX(c.fecha_creacion) FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id) DESC NULLS LAST
               LIMIT 1

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -3316,8 +3316,8 @@ if (facturasExistentes.length > 0) {
             const catRes = await db.execute(sql`
               SELECT u.categoria
               FROM cartera.usuarios u
-              WHERE regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g')
-                  = regexp_replace(${nitNormalizado}, '[^0-9A-Za-z]', '', 'g')
+              WHERE upper(regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g'))
+                  = upper(regexp_replace(${nitNormalizado}, '[^0-9A-Za-z]', '', 'g'))
                 AND EXISTS (SELECT 1 FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id)
               ORDER BY (SELECT MAX(c.fecha_creacion) FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id) DESC NULLS LAST
               LIMIT 1

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -6,6 +6,7 @@ import {
   generarExcelFacturacionDiaria,
   generarSnapshotDiario,
   getSnapshotsDiarios,
+  regenerarSnapshotRango,
 } from "../controllers/facturacionSnapshot";
 
 export const facturacionSnapshotRouter = new Elysia({
@@ -33,6 +34,35 @@ export const facturacionSnapshotRouter = new Elysia({
     {
       body: t.Object({
         fecha: t.String(), // "YYYY-MM-DD"
+      }),
+    }
+  )
+
+  // POST - Regenerar (force) el snapshot de un RANGO de días. Recalcula aunque
+  //        la fila exista. { fechaInicio: "YYYY-MM-DD", fechaFin: "YYYY-MM-DD" }
+  .post(
+    "/regenerar-rango",
+    async ({ body, set }: any) => {
+      try {
+        const result = await regenerarSnapshotRango(
+          body.fechaInicio,
+          body.fechaFin
+        );
+        if (!result.success) set.status = 400;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Error regenerando rango de snapshots",
+          error: String(error),
+        };
+      }
+    },
+    {
+      body: t.Object({
+        fechaInicio: t.String(), // "YYYY-MM-DD"
+        fechaFin: t.String(), // "YYYY-MM-DD"
       }),
     }
   )

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -10,27 +10,27 @@ const TRADUCCIONES: Array<{
   patron: RegExp;
   traduccion: string | ((match: RegExpExecArray) => string);
 }> = [
-  { patron: /jwt expired/i, traduccion: "tu sesión expiró, vuelve a iniciar sesión" },
+  { patron: /jwt expired/i, traduccion: "Tu sesión expiró, vuelve a iniciar sesión" },
   {
     patron: /jwt|invalid signature|invalid token|token no proporcionado|token inválido/i,
-    traduccion: "tu sesión no es válida, vuelve a iniciar sesión",
+    traduccion: "Tu sesión no es válida, vuelve a iniciar sesión",
   },
   {
     patron: /^Expected /,
-    traduccion: (m) => `uno de los filtros o datos enviados no es válido (${m.input})`,
+    traduccion: (m) => `Uno de los filtros o datos enviados no es válido (${m.input})`,
   },
-  { patron: /payment\s+(\d+)\s+not found/i, traduccion: (m) => `no se encontró el pago ${m[1]}` },
-  { patron: /payment not found/i, traduccion: "no se encontró el pago" },
-  { patron: /credit not found or not active/i, traduccion: "no se encontró el crédito o no está activo" },
-  { patron: /credit not found/i, traduccion: "no se encontró el crédito" },
-  { patron: /user not found/i, traduccion: "no se encontró el usuario" },
+  { patron: /payment\s+(\d+)\s+not found/i, traduccion: (m) => `No se encontró el pago ${m[1]}` },
+  { patron: /payment not found/i, traduccion: "No se encontró el pago" },
+  { patron: /credit not found or not active/i, traduccion: "No se encontró el crédito o no está activo" },
+  { patron: /credit not found/i, traduccion: "No se encontró el crédito" },
+  { patron: /user not found/i, traduccion: "No se encontró el usuario" },
   {
     patron: /validation failed/i,
-    traduccion: "los datos enviados no son válidos, revisa los campos e intenta de nuevo",
+    traduccion: "Los datos enviados no son válidos, revisa los campos e intenta de nuevo",
   },
   {
     patron: /internal server error/i,
-    traduccion: "error interno del servidor, intenta de nuevo o contacta soporte",
+    traduccion: "Error interno del servidor, intenta de nuevo o contacta soporte",
   },
 ];
 
@@ -87,10 +87,10 @@ function esDetalleTecnicoCrudo(detail: string): boolean {
 export function getApiErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof AxiosError) {
     if (error.code === "ECONNABORTED") {
-      return `${fallback}: el servidor tardó demasiado en responder, intenta de nuevo`;
+      return `${fallback}: El servidor tardó demasiado en responder, intenta de nuevo`;
     }
     if (!error.response) {
-      return `${fallback}: sin conexión con el servidor`;
+      return `${fallback}: Sin conexión con el servidor`;
     }
     const { status, data } = error.response;
     let detail: unknown;
@@ -113,10 +113,10 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
       return `${fallback}: ${traducirDetalleTecnico(detail.trim())}`;
     }
     if (status === 401 || status === 403) {
-      return `${fallback}: tu sesión no es válida, vuelve a iniciar sesión`;
+      return `${fallback}: Tu sesión no es válida, vuelve a iniciar sesión`;
     }
     if (status >= 500) {
-      return `${fallback}: error interno del servidor (HTTP ${status})`;
+      return `${fallback}: Error interno del servidor (HTTP ${status})`;
     }
     return `${fallback} (HTTP ${status})`;
   }

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -50,12 +50,31 @@ function traducirDetalleTecnico(detail: string): string {
 
 /**
  * `message` genérico que no aporta información: si el endpoint también
- * manda en `error` un motivo de negocio conocido (con traducción en
- * TRADUCCIONES), se prefiere `error`. Si `error` es un crudo no reconocido
- * (stack de driver, excepción inesperada), NO se promueve: el usuario ve
- * el genérico y el crudo no se filtra a la UI.
+ * manda en `error` un motivo de negocio legible, se prefiere `error`.
+ * Los crudos técnicos (excepción inesperada, driver de DB, stack) se
+ * detectan con DETALLE_TECNICO y NO se promueven: el usuario ve el
+ * genérico y el crudo no se filtra a la UI.
  */
 const MENSAJE_SIN_INFORMACION = /^internal server error$/i;
+
+/**
+ * Firmas de errores técnicos que nunca deben mostrarse al usuario.
+ * Los throws de negocio del backend ("Payment not found", "No se encontró
+ * el pago con id 123") no calzan con ninguna de estas.
+ */
+const DETALLE_TECNICO = [
+  /^\s*\w*(Error|Exception)\s*:/, // "TypeError: ...", "PostgresError: ..."
+  /\bat\s+\S+\s+\(.+\)/, // frame de stack trace
+  /\b(ECONN\w+|ETIMEDOUT|ENOTFOUND|EPIPE|EAI_AGAIN)\b/,
+  /\b(undefined|null|NaN)\b/i,
+  /cannot read|is not a function|is not defined/i,
+  /\b(query|relation|column|constraint|duplicate key|violates|syntax)\b/i,
+  /fetch failed|socket|connection|timeout/i,
+];
+
+function esDetalleTecnicoCrudo(detail: string): boolean {
+  return DETALLE_TECNICO.some((patron) => patron.test(detail));
+}
 
 /**
  * Extrae el motivo real de un error de API para mostrarlo al usuario.
@@ -83,7 +102,9 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
         typeof detail === "string" &&
         MENSAJE_SIN_INFORMACION.test(detail.trim()) &&
         typeof data?.error === "string" &&
-        buscarTraduccion(data.error.trim()) !== null
+        data.error.trim() &&
+        (buscarTraduccion(data.error.trim()) !== null ||
+          !esDetalleTecnicoCrudo(data.error.trim()))
       ) {
         detail = data.error;
       }

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -34,19 +34,26 @@ const TRADUCCIONES: Array<{
   },
 ];
 
-function traducirDetalleTecnico(detail: string): string {
+function buscarTraduccion(detail: string): string | null {
   for (const { patron, traduccion } of TRADUCCIONES) {
     const match = patron.exec(detail);
     if (match) {
       return typeof traduccion === "function" ? traduccion(match) : traduccion;
     }
   }
-  return detail;
+  return null;
+}
+
+function traducirDetalleTecnico(detail: string): string {
+  return buscarTraduccion(detail) ?? detail;
 }
 
 /**
  * `message` genérico que no aporta información: si el endpoint también
- * manda `error` con el motivo real, se prefiere `error`.
+ * manda en `error` un motivo de negocio conocido (con traducción en
+ * TRADUCCIONES), se prefiere `error`. Si `error` es un crudo no reconocido
+ * (stack de driver, excepción inesperada), NO se promueve: el usuario ve
+ * el genérico y el crudo no se filtra a la UI.
  */
 const MENSAJE_SIN_INFORMACION = /^internal server error$/i;
 
@@ -76,7 +83,7 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
         typeof detail === "string" &&
         MENSAJE_SIN_INFORMACION.test(detail.trim()) &&
         typeof data?.error === "string" &&
-        data.error.trim()
+        buscarTraduccion(data.error.trim()) !== null
       ) {
         detail = data.error;
       }

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -1,34 +1,62 @@
 import { AxiosError } from "axios";
 
 /**
- * Traduce mensajes técnicos conocidos (jwt, validación de Elysia, etc.)
- * a texto entendible para el usuario final. Si el mensaje ya es legible
- * (el backend lo mandó en español), se devuelve tal cual.
+ * Traducciones de mensajes técnicos o en inglés conocidos. Se recorre en
+ * orden y gana la primera regla que matchea, así que las reglas específicas
+ * van antes que las generales (p. ej. "credit not found or not active"
+ * antes que "credit not found").
  */
+const TRADUCCIONES: Array<{
+  patron: RegExp;
+  traduccion: string | ((match: RegExpExecArray) => string);
+}> = [
+  { patron: /jwt expired/i, traduccion: "tu sesión expiró, vuelve a iniciar sesión" },
+  {
+    patron: /jwt|invalid signature|invalid token|token no proporcionado|token inválido/i,
+    traduccion: "tu sesión no es válida, vuelve a iniciar sesión",
+  },
+  {
+    patron: /^Expected /,
+    traduccion: (m) => `uno de los filtros o datos enviados no es válido (${m.input})`,
+  },
+  { patron: /payment\s+(\d+)\s+not found/i, traduccion: (m) => `no se encontró el pago ${m[1]}` },
+  { patron: /payment not found/i, traduccion: "no se encontró el pago" },
+  { patron: /credit not found or not active/i, traduccion: "no se encontró el crédito o no está activo" },
+  { patron: /credit not found/i, traduccion: "no se encontró el crédito" },
+  { patron: /user not found/i, traduccion: "no se encontró el usuario" },
+  {
+    patron: /validation failed/i,
+    traduccion: "los datos enviados no son válidos, revisa los campos e intenta de nuevo",
+  },
+  {
+    patron: /internal server error/i,
+    traduccion: "error interno del servidor, intenta de nuevo o contacta soporte",
+  },
+];
+
 function traducirDetalleTecnico(detail: string): string {
-  const d = detail.toLowerCase();
-  if (d.includes("jwt expired")) {
-    return "tu sesión expiró, vuelve a iniciar sesión";
-  }
-  if (
-    d.includes("jwt") ||
-    d.includes("invalid signature") ||
-    d.includes("invalid token") ||
-    d.includes("token no proporcionado") ||
-    d.includes("token inválido")
-  ) {
-    return "tu sesión no es válida, vuelve a iniciar sesión";
-  }
-  if (detail.startsWith("Expected ")) {
-    return `uno de los filtros o datos enviados no es válido (${detail})`;
+  for (const { patron, traduccion } of TRADUCCIONES) {
+    const match = patron.exec(detail);
+    if (match) {
+      return typeof traduccion === "function" ? traduccion(match) : traduccion;
+    }
   }
   return detail;
 }
 
 /**
+ * `message` genérico que no aporta información: si el endpoint también
+ * manda `error` con el motivo real, se prefiere `error`.
+ */
+const MENSAJE_SIN_INFORMACION = /^internal server error$/i;
+
+/**
  * Extrae el motivo real de un error de API para mostrarlo al usuario.
- * El backend devuelve el detalle en `error`, `message` o `mensaje`
- * según el endpoint, por lo que se revisan los tres campos.
+ *
+ * Prioridad de campos: `message` (texto curado de los endpoints) primero;
+ * `error` cuando no hay `message` o cuando este es un genérico sin
+ * información, porque hay endpoints donde los roles están invertidos
+ * (`message: "Internal server error"` y el motivo real en `error`).
  */
 export function getApiErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof AxiosError) {
@@ -39,10 +67,20 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
       return `${fallback}: sin conexión con el servidor`;
     }
     const { status, data } = error.response;
-    const detail =
-      typeof data === "string"
-        ? data
-        : (data?.error ?? data?.message ?? data?.mensaje);
+    let detail: unknown;
+    if (typeof data === "string") {
+      detail = data;
+    } else {
+      detail = data?.message ?? data?.error ?? data?.mensaje;
+      if (
+        typeof detail === "string" &&
+        MENSAJE_SIN_INFORMACION.test(detail.trim()) &&
+        typeof data?.error === "string" &&
+        data.error.trim()
+      ) {
+        detail = data.error;
+      }
+    }
     if (typeof detail === "string" && detail.trim()) {
       return `${fallback}: ${traducirDetalleTecnico(detail.trim())}`;
     }

--- a/apps/carteraFront/src/private/cartera/components/FacturasGenericas.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturasGenericas.tsx
@@ -182,7 +182,7 @@ export function FacturasGenericas() {
     initialValues: {
       nit: "",
       emisor: "" as EmisorKey | "",
-      items: [{ rubro: "", monto: 0 }],
+      items: [{ rubro: "", monto: 0, rubro_desglose: "" }],
     },
     validationSchema,
     onSubmit: (values, { resetForm }) => {
@@ -197,6 +197,7 @@ export function FacturasGenericas() {
           items: values.items.map((item) => ({
             rubro: item.rubro,
             monto: Number(item.monto),
+            rubro_desglose: item.rubro_desglose || undefined,
           })),
           created_by: user.id,
           emisor: values.emisor as EmisorKey,
@@ -835,6 +836,37 @@ export function FacturasGenericas() {
                                     </p>
                                   )}
                               </div>
+
+                              {/* Rubro del reporte (desglose) — opcional */}
+                              <div>
+                                <label className="block text-purple-800 text-sm font-medium mb-1">
+                                  Rubro del reporte{" "}
+                                  <span className="text-purple-400 font-normal">
+                                    (opcional)
+                                  </span>
+                                </label>
+                                <select
+                                  name={`items.${index}.rubro_desglose`}
+                                  value={item.rubro_desglose || ""}
+                                  onChange={formik.handleChange}
+                                  onBlur={formik.handleBlur}
+                                  className="w-full border-2 border-purple-300 rounded-lg px-3 py-2 text-sm text-gray-900 bg-white focus:border-purple-500 focus:ring-2 focus:ring-purple-500/20 transition [color-scheme:light]"
+                                >
+                                  <option value="">
+                                    — No clasificar (no entra al reporte) —
+                                  </option>
+                                  <option value="OTROS">Otros ingresos</option>
+                                  <option value="ROYALTY">Royalty</option>
+                                  <option value="INTERES">Interés</option>
+                                  <option value="MEMBRESIA">Membresía</option>
+                                  <option value="SEGURO">Seguro</option>
+                                  <option value="GPS">GPS</option>
+                                </select>
+                                <p className="text-purple-400 text-xs mt-1">
+                                  Define en qué rubro del reporte diario suma esta
+                                  factura.
+                                </p>
+                              </div>
                             </div>
                           </div>
                         ))}
@@ -842,7 +874,7 @@ export function FacturasGenericas() {
                         {/* Botón agregar item */}
                         <button
                           type="button"
-                          onClick={() => push({ rubro: "", monto: 0 })}
+                          onClick={() => push({ rubro: "", monto: 0, rubro_desglose: "" })}
                           className="w-full flex items-center justify-center gap-2 py-3 border-2 border-dashed border-purple-300 rounded-lg text-purple-600 font-semibold hover:bg-purple-50 hover:border-purple-400 transition"
                         >
                           <Plus className="w-5 h-5" />

--- a/apps/carteraFront/src/private/cartera/hooks/account.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/account.ts
@@ -3,6 +3,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
  
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { getCuentasEmpresaService, type ActualizarCuentaPagoRequest, actualizarCuentaPagoService } from "../services/services";
 
 // 📋 Hook para obtener todas las cuentas de empresa
@@ -38,7 +39,7 @@ export function useActualizarCuentaPago() {
 
     onError: (error) => {
       console.error("❌ Error al actualizar cuenta:", error);
-      toast.error("❌ Error al actualizar la cuenta del pago");
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar la cuenta del pago"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/advisor.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/advisor.ts
@@ -31,6 +31,7 @@ import {
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { PagoFormValues } from "./registerPayment";
 import { toast } from "sonner"; // 🔥 O tu librería de toast preferida
+import { getApiErrorMessage } from "@/lib/apiError";
 
 // ========== Hook ==========
 // 🚀 Administración de asesores, contadores, inversionistas, créditos y pagos
@@ -57,7 +58,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error creando asesor:", error);
-      toast.error(`❌ Error al crear asesor: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al crear asesor"));
     },
   });
 
@@ -71,7 +72,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando asesor:", error);
-      toast.error(`❌ Error al actualizar asesor: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar asesor"));
     },
   });
 
@@ -95,7 +96,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error creando contador:", error);
-      toast.error(`❌ Error al crear contador: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al crear contador"));
     },
   });
 
@@ -108,7 +109,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando contador:", error);
-      toast.error(`❌ Error al actualizar contador: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar contador"));
     },
   });
 
@@ -132,7 +133,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error con inversionista:", error);
-      toast.error(`❌ Error al procesar inversionista: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al procesar inversionista"));
     },
   });
 
@@ -144,7 +145,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando inversionista:", error);
-      toast.error(`❌ Error al actualizar inversionista: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar inversionista"));
     },
   });
 
@@ -157,7 +158,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error creando crédito:", error);
-      toast.error(`❌ Error al crear crédito: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al crear crédito"));
     },
   });
 
@@ -169,7 +170,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error actualizando crédito:", error);
-      toast.error(`❌ Error al actualizar crédito: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al actualizar crédito"));
     },
   });
 
@@ -197,7 +198,7 @@ export const useAdminData = () => {
     },
     onError: (error: any) => {
       console.error("Error registrando pago:", error);
-      toast.error(`❌ Error al registrar pago: ${error.message || "Error desconocido"}`);
+      toast.error(getApiErrorMessage(error, "❌ Error al registrar pago"));
     },
   });
 

--- a/apps/carteraFront/src/private/cartera/hooks/recalculateQuota.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/recalculateQuota.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { recalculateQuotaService, type RecalculateQuotaPayload } from "../services/services";
 
 export function useRecalculateQuota() {
@@ -10,8 +11,7 @@ export function useRecalculateQuota() {
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {
-      const msg = error?.response?.data?.message || "Error recalculando cuota";
-      toast.error(msg);
+      toast.error(getApiErrorMessage(error, "Error recalculando cuota"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -20,6 +20,7 @@ import {
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useResetCredit } from "./resetCredit";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { useAuth } from "@/Provider/authProvider";
 import { toast } from "sonner";
 export const pagoSchema = z.object({
@@ -207,9 +208,11 @@ const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
         setArchivosParaSubir([]);
         setResetBuscador(true);
       } catch (error: any) {
-        const backendMessage =
-          error?.response?.data?.message || "Error desconocido";
-        toast.error(`No se pudo registrar el pago: ${backendMessage}`);
+        const backendMessage = getApiErrorMessage(
+          error,
+          "No se pudo registrar el pago",
+        );
+        toast.error(backendMessage);
         setStatus({ success: false, error: backendMessage });
       } finally {
         setSubmitting(false);
@@ -596,7 +599,7 @@ const handleAbonoOtros = () => {
         }
       },
       onError: (err: any) => {
-        toast.error(err?.response?.data?.message || "Error al liquidar pagos");
+        toast.error(getApiErrorMessage(err, "Error al liquidar pagos"));
       },
     });
   }
@@ -608,7 +611,7 @@ const handleAbonoOtros = () => {
         toast.success("Pago reversado correctamente");
       },
       onError: (err: any) => {
-        toast.error("Error al reversar pago: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al reversar pago"));
       },
     });
   }
@@ -621,7 +624,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
-        toast.error("Error al reversar pago a pendiente: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al reversar pago a pendiente"));
       },
     });
   }
@@ -634,7 +637,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
-        toast.error("Error al revalidar pago: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al revalidar pago"));
       },
     });
   }
@@ -647,7 +650,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
       },
       onError: (err: any) => {
-        toast.error("Error al procesar inversionistas: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al procesar inversionistas"));
       },
     });
   }
@@ -668,7 +671,7 @@ const handleAbonoOtros = () => {
 
       // Aquí podrías hacer un refetch/queryClient.invalidateQueries para actualizar
     } catch (error) {
-      toast.error("Error al liquidar el pago");
+      toast.error(getApiErrorMessage(error, "Error al liquidar el pago"));
       console.error("Error liquidando pago:", error);
     }
   }
@@ -685,7 +688,7 @@ const handleAbonoOtros = () => {
         queryClient.invalidateQueries({ queryKey: ["pagosByCredito"] });
       },
       onError: (err: any) => {
-        toast.error("Error al recalcular pagos: " + (err?.response?.data?.message || "Error desconocido"));
+        toast.error(getApiErrorMessage(err, "Error al recalcular pagos"));
       },
     });
   }
@@ -770,7 +773,7 @@ async function handleResetCredito() {
         }
     },
     onError: (error) => {
-      toast.error("Error al reiniciar crédito: " + (error?.message || error));
+      toast.error(getApiErrorMessage(error, "Error al reiniciar crédito"));
     }
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/updateCredit.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/updateCredit.ts
@@ -1,5 +1,6 @@
 import { useMutation } from "@tanstack/react-query";
 import { toast } from "sonner"; // o donde uses tu toast
+import { getApiErrorMessage } from "@/lib/apiError";
 import { updateCreditService, type UpdateCreditBody } from "../services/services";
 
 export function useUpdateCredit() {
@@ -10,8 +11,7 @@ export function useUpdateCredit() {
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onError: (error: any) => {
-      const msg = error?.response?.data?.message || "Error actualizando crédito";
-      toast.error(msg);
+      toast.error(getApiErrorMessage(error, "Error actualizando crédito"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/useReciboPago.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useReciboPago.ts
@@ -1,6 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { generarReciboPago } from "../services/services";
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 
 export function useReciboPago() {
   return useMutation({
@@ -10,7 +11,7 @@ export function useReciboPago() {
       window.open(data.pdfUrl, "_blank");
     },
     onError: (err: any) => {
-      toast.error(err?.response?.data?.message || "Error al generar el recibo de pago");
+      toast.error(getApiErrorMessage(err, "Error al generar el recibo de pago"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3113,6 +3113,9 @@ export const getBoletas = async (filters?: GetBoletasFilters) => {
 export interface FacturarGenericoItem {
   monto: number;
   rubro: string;
+  /** Rubro del REPORTE (enum rubro_facturacion de cartera-back) para el desglose.
+   *  Opcional: si viene, cartera lo guarda en facturacion_desglose y el snapshot lo suma. */
+  rubro_desglose?: string;
 }
 
 export type EmisorKey = "CUBE" | "SE_PRESTA" | "AMJK" | "CREACION_IMAGEN" | "GRUPO_BATRO" | "AUTOCASH";

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -145,6 +145,43 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 	};
 }
 
+// Helper: Pagina getAllCreditos hasta traer la cartera completa que matchea
+// los filtros. Sin esto, un solo fetch trunca silenciosamente cuando la
+// cartera supera el perPage.
+async function obtenerTodasLasPaginasCreditos(
+	params: Omit<
+		Parameters<typeof obtenerTodosLosCreditosCarteraBack>[0],
+		"page" | "perPage"
+	>,
+) {
+	const perPage = 100;
+	// Tope duro: si cartera-back devolviera totalPages null/undefined y siempre
+	// exactamente `perPage` items, el loop no terminaría. 200 páginas = 20k
+	// créditos, muy por encima de la cartera real.
+	const MAX_PAGES = 200;
+	const data: Awaited<
+		ReturnType<typeof obtenerTodosLosCreditosCarteraBack>
+	>["data"] = [];
+	let page = 1;
+	while (page <= MAX_PAGES) {
+		const resp = await obtenerTodosLosCreditosCarteraBack({
+			...params,
+			page,
+			perPage,
+		});
+		data.push(...resp.data);
+		if (resp.data.length < perPage) break;
+		if (resp.totalPages != null && page >= resp.totalPages) break;
+		page += 1;
+	}
+	if (page > MAX_PAGES) {
+		console.warn(
+			`[obtenerTodasLasPaginasCreditos] Se alcanzó MAX_PAGES=${MAX_PAGES} (${data.length} créditos). Posible truncamiento — la cartera supera el tope.`,
+		);
+	}
+	return data;
+}
+
 /**
  * Verifica si la auto-creación de datos migrate está habilitada
  */
@@ -3877,6 +3914,376 @@ export const cobrosRouter = {
 				success: true,
 				mailingId,
 				casoCobroId: input.casoCobroId,
+			};
+		}),
+
+	// ========================================================================
+	// MORA POR ETAPA Y ASESOR
+	// ========================================================================
+
+	getMoraByEtapaYAsesor: cobrosSupervisorProcedure
+		.input(
+			z
+				.object({
+					emailCobrador: z.string().optional(),
+				})
+				.optional(),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			// Traer cartera completa (mes=0 = todos los créditos)
+			const creditos = await obtenerTodasLasPaginasCreditos({
+				mes: 0,
+				anio: new Date().getFullYear(),
+				estado: "ACTIVO",
+				email_cobrador: input?.emailCobrador,
+			});
+
+			type BucketAcc = {
+				cantidad: number;
+				sumaCapital: number;
+				sumaMora: number;
+			};
+			type BucketsAcc = {
+				mora_30: BucketAcc;
+				mora_60: BucketAcc;
+				mora_90: BucketAcc;
+				mora_120_plus: BucketAcc;
+			};
+			const emptyBuckets = (): BucketsAcc => ({
+				mora_30: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+				mora_60: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+				mora_90: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+				mora_120_plus: { cantidad: 0, sumaCapital: 0, sumaMora: 0 },
+			});
+
+			const serializeBuckets = (b: BucketsAcc) => {
+				const fmt = (v: number) => v.toFixed(2);
+				const totalCantidad =
+					b.mora_30.cantidad + b.mora_60.cantidad + b.mora_90.cantidad + b.mora_120_plus.cantidad;
+				const totalMora =
+					b.mora_30.sumaMora + b.mora_60.sumaMora + b.mora_90.sumaMora + b.mora_120_plus.sumaMora;
+				return {
+					mora_30: { cantidad: b.mora_30.cantidad, sumaCapital: fmt(b.mora_30.sumaCapital), sumaMora: fmt(b.mora_30.sumaMora) },
+					mora_60: { cantidad: b.mora_60.cantidad, sumaCapital: fmt(b.mora_60.sumaCapital), sumaMora: fmt(b.mora_60.sumaMora) },
+					mora_90: { cantidad: b.mora_90.cantidad, sumaCapital: fmt(b.mora_90.sumaCapital), sumaMora: fmt(b.mora_90.sumaMora) },
+					mora_120_plus: { cantidad: b.mora_120_plus.cantidad, sumaCapital: fmt(b.mora_120_plus.sumaCapital), sumaMora: fmt(b.mora_120_plus.sumaMora) },
+					totalEnMora: { cantidad: totalCantidad, sumaMora: fmt(totalMora) },
+				};
+			};
+
+			const acumuladoTotal = emptyBuckets();
+
+			type AsesorEntry = { asesorId: number; nombre: string; email: string; buckets: BucketsAcc };
+			const porAsesorMap = new Map<string, AsesorEntry>();
+
+			const addToBucket = (acc: BucketsAcc, cuotasAtrasadas: number, capital: number, mora: number) => {
+				const key =
+					cuotasAtrasadas >= 4 ? "mora_120_plus" :
+					cuotasAtrasadas === 3 ? "mora_90" :
+					cuotasAtrasadas === 2 ? "mora_60" :
+					"mora_30";
+				acc[key].cantidad += 1;
+				acc[key].sumaCapital += capital;
+				acc[key].sumaMora += mora;
+			};
+
+			for (const item of creditos) {
+				const cuotasAtrasadas = item.mora?.cuotas_atrasadas ?? 0;
+				if (cuotasAtrasadas < 1) continue;
+
+				const capital = parseFloat(item.creditos.capital as string || "0");
+				const montoMora = parseFloat(item.mora?.monto_mora ?? "0");
+
+				addToBucket(acumuladoTotal, cuotasAtrasadas, capital, montoMora);
+
+				// Agrupar por asesor usando emailCashIn del crédito mismo
+				const emailAsesor = item.asesores?.emailCashIn ?? "sin_asesor";
+				const nombreAsesor = item.asesores?.nombre ?? "Sin asesor";
+				const asesorId = item.asesores?.asesor_id ?? 0;
+
+				let entry = porAsesorMap.get(emailAsesor);
+				if (!entry) {
+					entry = { asesorId, nombre: nombreAsesor, email: emailAsesor, buckets: emptyBuckets() };
+					porAsesorMap.set(emailAsesor, entry);
+				}
+				addToBucket(entry.buckets, cuotasAtrasadas, capital, montoMora);
+			}
+
+			const porAsesor = Array.from(porAsesorMap.values())
+				.sort((a, b) => {
+					const totalA = a.buckets.mora_30.sumaMora + a.buckets.mora_60.sumaMora + a.buckets.mora_90.sumaMora + a.buckets.mora_120_plus.sumaMora;
+					const totalB = b.buckets.mora_30.sumaMora + b.buckets.mora_60.sumaMora + b.buckets.mora_90.sumaMora + b.buckets.mora_120_plus.sumaMora;
+					return totalB - totalA;
+				})
+				.map((e) => ({
+					asesorId: e.asesorId,
+					nombre: e.nombre,
+					email: e.email,
+					...serializeBuckets(e.buckets),
+				}));
+
+			return { totales: serializeBuckets(acumuladoTotal), porAsesor };
+		}),
+
+	// ========================================================================
+	// PAGOS ESPERADOS (COBROS)
+	// ========================================================================
+
+	getPagosEsperadosCobros: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				temporalidad: z.enum(["hoy", "semana", "quincena", "mes"]),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			const hoy = new Date();
+			const pad = (n: number) => n.toString().padStart(2, "0");
+			const toISO = (d: Date) =>
+				`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+			const fechaInicio = toISO(hoy);
+
+			const diasAdelanteMap: Record<typeof input.temporalidad, number> = {
+				hoy: 0,
+				semana: 6,
+				quincena: 14,
+				mes: 29,
+			};
+			const diasAdelante = diasAdelanteMap[input.temporalidad];
+
+			const fechaFinDate = new Date(hoy);
+			fechaFinDate.setDate(fechaFinDate.getDate() + diasAdelante);
+			const fechaFin = toISO(fechaFinDate);
+
+			const desglose = await carteraBackClient.getMontoACobrar({
+				periodo: "dia",
+				fechaInicio,
+				fechaFin,
+			});
+
+			// Ojo: en cartera-back `total_cuota` ES el capital de las cuotas
+			// (mismo criterio que el reporte de monto-a-cobrar existente, que lo
+			// etiqueta "Capital" y calcula el total sumando todos los rubros).
+			let totalCapital = 0;
+			let totalInteres = 0;
+			let totalIva = 0;
+			let totalSeguro = 0;
+			let totalGps = 0;
+			let totalMembresias = 0;
+			let totalRoyalti = 0;
+			let cantidadCuotas = 0;
+
+			for (const row of desglose) {
+				totalCapital += parseFloat(row.total_cuota);
+				totalInteres += parseFloat(row.total_interes);
+				totalIva += parseFloat(row.total_iva);
+				totalSeguro += parseFloat(row.total_seguro);
+				totalGps += parseFloat(row.total_gps);
+				totalMembresias += parseFloat(row.total_membresias);
+				totalRoyalti += parseFloat(row.total_royalti);
+				cantidadCuotas += row.cuotas_count;
+			}
+
+			const totalACobrar =
+				totalCapital +
+				totalInteres +
+				totalIva +
+				totalSeguro +
+				totalGps +
+				totalMembresias;
+
+			return {
+				fechaInicio,
+				fechaFin,
+				temporalidad: input.temporalidad,
+				desglose,
+				totales: {
+					capital: totalCapital.toFixed(2),
+					interes: totalInteres.toFixed(2),
+					iva: totalIva.toFixed(2),
+					seguro: totalSeguro.toFixed(2),
+					gps: totalGps.toFixed(2),
+					membresias: totalMembresias.toFixed(2),
+					royalti: totalRoyalti.toFixed(2),
+					totalCuota: totalACobrar.toFixed(2),
+					cantidadCuotas,
+				},
+			};
+		}),
+
+	// ========================================================================
+	// PAGOS NO RECIBIDOS
+	// ========================================================================
+
+	getPagosNoRecibidos: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				emailCobrador: z.string().optional(),
+				capitalMin: z.number().optional(),
+				capitalMax: z.number().optional(),
+				cuotasAtrasadasMin: z.number().min(1).optional(),
+				cuotasAtrasadasMax: z.number().min(1).optional(),
+				fechaDesde: z.string().optional(),
+				fechaHasta: z.string().optional(),
+				page: z.number().min(1).default(1),
+				pageSize: z.number().min(1).max(100).default(25),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			// mes=0 trae TODOS los créditos sin filtrar por mes (mismo criterio
+			// que getTodosLosCreditos); con el mes actual cartera-back devuelve
+			// solo el snapshot mensual y el listado sale vacío.
+			const creditos = await obtenerTodasLasPaginasCreditos({
+				mes: 0,
+				anio: new Date().getFullYear(),
+				estado: "ACTIVO",
+				email_cobrador: input.emailCobrador,
+				capital_min: input.capitalMin,
+				capital_max: input.capitalMax,
+				fecha_desde: input.fechaDesde,
+				fecha_hasta: input.fechaHasta,
+			});
+
+			const minCuotas = input.cuotasAtrasadasMin ?? 1;
+
+			const todosOverdue = creditos.filter((item) => {
+				const cuotasAtrasadas = item.mora?.cuotas_atrasadas ?? 0;
+				if (cuotasAtrasadas < minCuotas) return false;
+				if (
+					input.cuotasAtrasadasMax !== undefined &&
+					cuotasAtrasadas > input.cuotasAtrasadasMax
+				)
+					return false;
+				return true;
+			});
+
+			const total = todosOverdue.length;
+			const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
+			const start = (input.page - 1) * input.pageSize;
+			const pageData = todosOverdue.slice(start, start + input.pageSize);
+
+			const items = pageData.map((item) => ({
+				sifco: item.creditos.numero_credito_sifco,
+				clienteNombre: item.usuarios.nombre,
+				asesorNombre: item.asesores?.nombre ?? "Sin asesor",
+				cuotasAtrasadas: item.mora?.cuotas_atrasadas ?? 0,
+				montoMora: item.mora?.monto_mora ?? "0",
+				capital: item.proxima_cuota?.capital_restante ?? item.creditos.capital,
+				cuotaMensual: item.creditos.cuota,
+				proximaFechaVencimiento:
+					item.proxima_cuota?.fecha_vencimiento ?? null,
+				tipoCredito: item.creditos.tipoCredito ?? null,
+			}));
+
+			return {
+				data: items,
+				total,
+				page: input.page,
+				pageSize: input.pageSize,
+				totalPages,
+			};
+		}),
+
+	// ========================================================================
+	// DESCUENTOS / RUBROS POR CRÉDITO
+	// ========================================================================
+
+	getDescuentosCRM: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				page: z.number().min(1).default(1),
+				pageSize: z.number().min(1).max(100).default(25),
+				emailCobrador: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			const creditos = await obtenerTodasLasPaginasCreditos({
+				mes: 0,
+				anio: new Date().getFullYear(),
+				estado: "ACTIVO",
+				email_cobrador: input.emailCobrador,
+			});
+
+			type RubroItem = { nombre_rubro: string; monto: string | number };
+
+			const todos = creditos
+				.map((item) => {
+					const cred = item.creditos;
+					const gps = parseFloat(cred.gps || "0");
+					const seguro = parseFloat(cred.seguro_10_cuotas || "0");
+					const membresias = parseFloat(cred.membresias_pago || "0");
+					const otros = parseFloat(cred.otros || "0");
+
+					const rubros = (
+						(item.rubros as RubroItem[] | null) ?? []
+					).map((r) => ({
+						nombre: r.nombre_rubro,
+						monto: parseFloat(String(r.monto || "0")).toFixed(2),
+					}));
+					const rubrosTotal = rubros.reduce(
+						(s, r) => s + parseFloat(r.monto),
+						0,
+					);
+
+					const totalDescuentos = gps + seguro + membresias + otros + rubrosTotal;
+					if (totalDescuentos <= 0) return null;
+
+					return {
+						sifco: cred.numero_credito_sifco,
+						clienteNombre: item.usuarios.nombre,
+						asesorNombre: item.asesores?.nombre ?? "Sin asesor",
+						gps: gps.toFixed(2),
+						seguro: seguro.toFixed(2),
+						membresias: membresias.toFixed(2),
+						otros: otros.toFixed(2),
+						rubros,
+						rubrosTotal: rubrosTotal.toFixed(2),
+						totalDescuentos: totalDescuentos.toFixed(2),
+						capital: cred.capital,
+						tipoCredito: cred.tipoCredito ?? null,
+					};
+				})
+				.filter(
+					(
+						v,
+					): v is NonNullable<typeof v> => v !== null,
+				);
+
+			const total = todos.length;
+			const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
+			const start = (input.page - 1) * input.pageSize;
+			const pageData = todos.slice(start, start + input.pageSize);
+
+			return {
+				data: pageData,
+				total,
+				page: input.page,
+				pageSize: input.pageSize,
+				totalPages,
 			};
 		}),
 };

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -71,6 +71,7 @@ import {
 	getUltimasSincronizaciones,
 	sincronizarCasosCobros,
 } from "../services/sync-casos-cobros";
+import { toDateStrGT } from "../lib/guatemala-month-window";
 import type { CreditoDirectoResponse } from "../types/cartera-back";
 import { createNotification } from "./notifications";
 
@@ -4048,12 +4049,7 @@ export const cobrosRouter = {
 				});
 			}
 
-			const hoy = new Date();
 			const pad = (n: number) => n.toString().padStart(2, "0");
-			const toISO = (d: Date) =>
-				`${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
-
-			const fechaInicio = toISO(hoy);
 
 			const diasAdelanteMap: Record<typeof input.temporalidad, number> = {
 				hoy: 0,
@@ -4063,9 +4059,16 @@ export const cobrosRouter = {
 			};
 			const diasAdelante = diasAdelanteMap[input.temporalidad];
 
-			const fechaFinDate = new Date(hoy);
-			fechaFinDate.setDate(fechaFinDate.getDate() + diasAdelante);
-			const fechaFin = toISO(fechaFinDate);
+			// Las fechas de negocio son días calendario de Guatemala (UTC-6). Si el
+			// server corre en UTC, usar getFullYear/getMonth/getDate directo desplaza
+			// "hoy" un día entre las 00:00 y 05:59 UTC. Anclamos en la fecha GT y
+			// hacemos la aritmética de días sobre esos componentes en UTC puro.
+			const fechaInicio = toDateStrGT(new Date());
+			const [anioGT, mesGT, diaGT] = fechaInicio.split("-").map(Number);
+			const fechaFinUTC = new Date(
+				Date.UTC(anioGT, mesGT - 1, diaGT + diasAdelante),
+			);
+			const fechaFin = `${fechaFinUTC.getUTCFullYear()}-${pad(fechaFinUTC.getUTCMonth() + 1)}-${pad(fechaFinUTC.getUTCDate())}`;
 
 			const desglose = await carteraBackClient.getMontoACobrar({
 				periodo: "dia",

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -169,6 +169,12 @@ export const cobrosAppRouter = {
 	getMetasMoraAnual: cobrosRouter.getMetasMoraAnual,
 	upsertMetasMora: cobrosRouter.upsertMetasMora,
 
+	// CRM Cobros — nuevas vistas
+	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
+	getPagosEsperadosCobros: cobrosRouter.getPagosEsperadosCobros,
+	getPagosNoRecibidos: cobrosRouter.getPagosNoRecibidos,
+	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
+
 	// Seguimientos programados
 	createSeguimiento: seguimientosRouter.createSeguimiento,
 	getSeguimientosActivos: seguimientosRouter.getSeguimientosActivos,

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -511,6 +511,11 @@ export const vehiclesRouter = {
 						message: `Ya existe un vehículo con la placa "${input.licensePlate}"`,
 					});
 				}
+				if (isUniqueViolation(error, "vehicles_vin_number_unique")) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: `Ya existe un vehículo con el número de VIN "${input.vinNumber}"`,
+					});
+				}
 				throw error;
 			}
 		}),

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -456,6 +456,7 @@ function buildInvoices(
 				{
 					monto: royalti,
 					rubro: "Royalty",
+					rubro_desglose: "ROYALTY",
 				},
 			],
 		});
@@ -480,6 +481,7 @@ function buildInvoices(
 				{
 					monto: FACTURACION_TRASPASO_COSTO,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -497,6 +499,7 @@ function buildInvoices(
 				{
 					monto: leasingContractCost,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -514,6 +517,7 @@ function buildInvoices(
 				{
 					monto: FACTURACION_GARANTIA_MOBILIARIA_COSTO,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -533,12 +537,14 @@ function buildInvoices(
 			cuota0Items.push({
 				monto: interestCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "INTERES",
 			});
 		}
 		if (extraMembershipCost > 0) {
 			cuota0Items.push({
 				monto: extraMembershipCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "MEMBRESIA",
 			});
 		}
 		if (cuota0Items.length > 0) {
@@ -562,6 +568,7 @@ function buildInvoices(
 				{
 					monto: FACTURACION_NOMBRAMIENTO_COSTO,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -579,6 +586,7 @@ function buildInvoices(
 				{
 					monto: keyCopyDiffCost,
 					rubro: "Cargo por servicios",
+					rubro_desglose: "OTROS",
 				},
 			],
 		});
@@ -598,12 +606,14 @@ function buildInvoices(
 			seguroGastosItems.push({
 				monto: extraInsuranceCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "SEGURO",
 			});
 		}
 		if (extraAdminCost > 0) {
 			seguroGastosItems.push({
 				monto: extraAdminCost,
 				rubro: "Gastos varios",
+				rubro_desglose: "OTROS",
 			});
 		}
 		if (seguroGastosItems.length > 0) {

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -665,6 +665,9 @@ export interface GetStatsParams {
 export interface FacturaItem {
 	monto: number;
 	rubro: string;
+	/** Rubro del REPORTE (enum rubro_facturacion de cartera-back) para el desglose.
+	 *  Opcional: si viene, cartera lo guarda en facturacion_desglose y el snapshot lo suma. */
+	rubro_desglose?: string;
 }
 
 /** Input para facturación genérica */

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -272,6 +272,17 @@ export default function Header() {
 											</Link>
 										</DropdownMenuItem>
 									)}
+									{PERMISSIONS.canAssignCobros(userRole) && (
+										<>
+											<DropdownMenuSeparator />
+											<DropdownMenuItem asChild>
+												<Link to="/cobros/reportes" className="cursor-pointer">
+													<BarChart3 className="mr-2 h-4 w-4" />
+													Reportes
+												</Link>
+											</DropdownMenuItem>
+										</>
+									)}
 								</DropdownMenuContent>
 							</DropdownMenu>
 						)}

--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -28,13 +28,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "@/components/ui/select";
-import {
 	Table,
 	TableBody,
 	TableCell,
@@ -46,7 +39,6 @@ import {
 	cuotaIlustrativa,
 	DEFAULT_SCENARIO_PARAMS,
 	type LeverKey,
-	type MetodoCuota,
 	type ScenarioParams,
 } from "@/lib/reports/scenario";
 import type {
@@ -215,26 +207,11 @@ export function ScenarioModal<T>({
 
 							{config.usaMetodoCuota && (
 								<div className="space-y-2 border-t pt-3">
-									<Label className="text-sm">Método de cuota</Label>
-									<Select
-										value={params.metodoCuota}
-										onValueChange={(v) =>
-											setField("metodoCuota", v as MetodoCuota)
-										}
-									>
-										<SelectTrigger className="h-9">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="actual">Actual</SelectItem>
-											<SelectItem value="frances">
-												Francés (nivelada)
-											</SelectItem>
-											<SelectItem value="fija">
-												Cuota fija de capital
-											</SelectItem>
-										</SelectContent>
-									</Select>
+									<Label className="text-sm">Cuota mensual por método</Label>
+									<p className="text-muted-foreground text-xs">
+										Compara la cuota de un crédito promedio según el método de
+										amortización.
+									</p>
 									<div className="grid grid-cols-3 gap-2">
 										<div>
 											<Label className="text-muted-foreground text-xs">

--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -1,0 +1,380 @@
+/**
+ * Modal de simulación "qué pasaría si" para los reportes.
+ *
+ * Recibe los datos reales del reporte y su config, aplica los supuestos en el
+ * cliente y muestra el resultado simulado vs real. No modifica datos reales.
+ */
+
+import { Sparkles } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Legend,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import {
+	cuotaIlustrativa,
+	DEFAULT_SCENARIO_PARAMS,
+	type LeverKey,
+	type MetodoCuota,
+	type ScenarioParams,
+} from "@/lib/reports/scenario";
+import type {
+	ScenarioReportConfig,
+	SummaryRow,
+} from "@/lib/reports/scenario-configs";
+
+function formatQ(value: number): string {
+	return `Q${value.toLocaleString("es-GT", {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	})}`;
+}
+
+function deltaPct(real: number, escenario: number): string {
+	if (real === 0) return escenario === 0 ? "0%" : "—";
+	const pct = ((escenario - real) / Math.abs(real)) * 100;
+	const sign = pct > 0 ? "+" : "";
+	return `${sign}${pct.toFixed(1)}%`;
+}
+
+function deltaColor(real: number, escenario: number): string {
+	if (escenario > real) return "text-green-600";
+	if (escenario < real) return "text-red-600";
+	return "text-muted-foreground";
+}
+
+const LEVER_LABELS: Record<
+	Exclude<LeverKey, "metodo">,
+	{ label: string; hint: string; max: number }
+> = {
+	colocacion: {
+		label: "Colocar más (%)",
+		hint: "Aumenta el capital colocado",
+		max: 100,
+	},
+	mora: { label: "Bajar mora (%)", hint: "Reduce la mora", max: 100 },
+	efectividad: {
+		label: "Subir efectividad (%)",
+		hint: "Cierra la brecha contra lo esperado",
+		max: 100,
+	},
+};
+
+const LEVER_FIELD: Record<Exclude<LeverKey, "metodo">, keyof ScenarioParams> = {
+	colocacion: "colocacionDeltaPct",
+	mora: "moraReduccionPct",
+	efectividad: "efectividadDeltaPct",
+};
+
+function LeverSlider({
+	lever,
+	value,
+	onChange,
+}: {
+	lever: Exclude<LeverKey, "metodo">;
+	value: number;
+	onChange: (v: number) => void;
+}) {
+	const cfg = LEVER_LABELS[lever];
+	return (
+		<div className="space-y-1.5">
+			<div className="flex items-center justify-between">
+				<Label className="text-sm">{cfg.label}</Label>
+				<span className="text-muted-foreground text-xs">{cfg.hint}</span>
+			</div>
+			<div className="flex items-center gap-3">
+				<input
+					type="range"
+					min={0}
+					max={cfg.max}
+					step={1}
+					value={value}
+					onChange={(e) => onChange(Number(e.target.value))}
+					className="h-2 flex-1 cursor-pointer accent-purple-500"
+				/>
+				<div className="relative w-20 shrink-0">
+					<Input
+						type="number"
+						min={0}
+						max={cfg.max}
+						value={value}
+						onChange={(e) => onChange(Number(e.target.value) || 0)}
+						className="h-9 pr-6 text-right"
+					/>
+					<span className="pointer-events-none absolute top-1/2 right-2.5 -translate-y-1/2 text-muted-foreground text-sm">
+						%
+					</span>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+interface ScenarioModalProps<T> {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	config: ScenarioReportConfig<T>;
+	baseData: T | undefined;
+}
+
+export function ScenarioModal<T>({
+	open,
+	onOpenChange,
+	config,
+	baseData,
+}: ScenarioModalProps<T>) {
+	const [params, setParams] = useState<ScenarioParams>(DEFAULT_SCENARIO_PARAMS);
+
+	const setField = <K extends keyof ScenarioParams>(
+		key: K,
+		value: ScenarioParams[K],
+	) => setParams((prev) => ({ ...prev, [key]: value }));
+
+	const { realRows, simRows } = useMemo(() => {
+		if (!baseData) return { realRows: [], simRows: [] as SummaryRow[] };
+		const sim = config.transform(baseData, params);
+		return {
+			realRows: config.summarize(baseData),
+			simRows: config.summarize(sim),
+		};
+	}, [baseData, config, params]);
+
+	const chartData = useMemo(
+		() =>
+			realRows.map((row, i) => ({
+				concepto: row.concepto,
+				Real: row.valor,
+				Escenario: simRows[i]?.valor ?? 0,
+			})),
+		[realRows, simRows],
+	);
+
+	const cuota = config.usaMetodoCuota ? cuotaIlustrativa(params) : null;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[900px]">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2">
+						<Sparkles className="h-4 w-4 text-purple-500" />
+						Simular: {config.titulo}
+					</DialogTitle>
+					<DialogDescription>{config.descripcion}</DialogDescription>
+				</DialogHeader>
+
+				{!baseData ? (
+					<p className="py-8 text-center text-muted-foreground text-sm">
+						Carga primero el reporte para poder simular.
+					</p>
+				) : (
+					<div className="grid gap-6 md:grid-cols-[280px_1fr]">
+						{/* Supuestos */}
+						<div className="space-y-4">
+							<h4 className="font-semibold text-sm">Supuestos</h4>
+							{config.levers
+								.filter((l): l is Exclude<LeverKey, "metodo"> => l !== "metodo")
+								.map((lever) => (
+									<LeverSlider
+										key={lever}
+										lever={lever}
+										value={params[LEVER_FIELD[lever]] as number}
+										onChange={(v) => setField(LEVER_FIELD[lever], v)}
+									/>
+								))}
+
+							{config.usaMetodoCuota && (
+								<div className="space-y-2 border-t pt-3">
+									<Label className="text-sm">Método de cuota</Label>
+									<Select
+										value={params.metodoCuota}
+										onValueChange={(v) =>
+											setField("metodoCuota", v as MetodoCuota)
+										}
+									>
+										<SelectTrigger className="h-9">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="actual">Actual</SelectItem>
+											<SelectItem value="frances">
+												Francés (nivelada)
+											</SelectItem>
+											<SelectItem value="fija">
+												Cuota fija de capital
+											</SelectItem>
+										</SelectContent>
+									</Select>
+									<div className="grid grid-cols-3 gap-2">
+										<div>
+											<Label className="text-muted-foreground text-xs">
+												Capital
+											</Label>
+											<Input
+												type="number"
+												value={params.metodoCapital}
+												onChange={(e) =>
+													setField("metodoCapital", Number(e.target.value) || 0)
+												}
+												className="h-9"
+											/>
+										</div>
+										<div>
+											<Label className="text-muted-foreground text-xs">
+												Plazo
+											</Label>
+											<Input
+												type="number"
+												value={params.metodoPlazoMeses}
+												onChange={(e) =>
+													setField(
+														"metodoPlazoMeses",
+														Number(e.target.value) || 1,
+													)
+												}
+												className="h-9"
+											/>
+										</div>
+										<div>
+											<Label className="text-muted-foreground text-xs">
+												Tasa %
+											</Label>
+											<Input
+												type="number"
+												step="0.01"
+												value={params.metodoTasaMensual}
+												onChange={(e) =>
+													setField(
+														"metodoTasaMensual",
+														Number(e.target.value) || 0,
+													)
+												}
+												className="h-9"
+											/>
+										</div>
+									</div>
+									{cuota && (
+										<div className="rounded-md bg-muted/50 p-2 text-xs">
+											<div className="flex justify-between">
+												<span>Cuota francés:</span>
+												<span className="font-medium">
+													{formatQ(cuota.frances)}
+												</span>
+											</div>
+											<div className="flex justify-between">
+												<span>Cuota fija (1ª):</span>
+												<span className="font-medium">
+													{formatQ(cuota.fija)}
+												</span>
+											</div>
+										</div>
+									)}
+								</div>
+							)}
+
+							<Button
+								variant="outline"
+								size="sm"
+								className="w-full"
+								onClick={() => setParams(DEFAULT_SCENARIO_PARAMS)}
+							>
+								Restablecer
+							</Button>
+						</div>
+
+						{/* Resultado */}
+						<div className="space-y-4">
+							<ResponsiveContainer width="100%" height={240}>
+								<BarChart data={chartData}>
+									<CartesianGrid strokeDasharray="3 3" />
+									<XAxis dataKey="concepto" tick={{ fontSize: 11 }} />
+									<YAxis
+										tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`}
+										tick={{ fontSize: 11 }}
+									/>
+									<Tooltip formatter={(v) => formatQ(Number(v))} />
+									<Legend />
+									<Bar dataKey="Real" fill="#94a3b8" radius={[4, 4, 0, 0]} />
+									<Bar
+										dataKey="Escenario"
+										fill="#a855f7"
+										radius={[4, 4, 0, 0]}
+									/>
+								</BarChart>
+							</ResponsiveContainer>
+
+							<Table>
+								<TableHeader>
+									<TableRow>
+										<TableHead>Concepto</TableHead>
+										<TableHead className="text-right">Real</TableHead>
+										<TableHead className="text-right">Escenario</TableHead>
+										<TableHead className="text-right">Δ</TableHead>
+									</TableRow>
+								</TableHeader>
+								<TableBody>
+									{realRows.map((row, i) => {
+										const esc = simRows[i]?.valor ?? 0;
+										return (
+											<TableRow key={row.concepto}>
+												<TableCell className="font-medium">
+													{row.concepto}
+												</TableCell>
+												<TableCell className="text-right">
+													{formatQ(row.valor)}
+												</TableCell>
+												<TableCell className="text-right">
+													{formatQ(esc)}
+												</TableCell>
+												<TableCell
+													className={`text-right ${deltaColor(row.valor, esc)}`}
+												>
+													{deltaPct(row.valor, esc)}
+												</TableCell>
+											</TableRow>
+										);
+									})}
+								</TableBody>
+							</Table>
+
+							<p className="text-muted-foreground text-xs">
+								Resultados estimados a partir de los datos del reporte. No
+								modifican datos reales.
+							</p>
+						</div>
+					</div>
+				)}
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -90,18 +90,31 @@ export const flujoCuotasConfig: ScenarioReportConfig<FlujoCuotasInversionesRespo
 		usaMetodoCuota: true,
 		transform: transformFlujoCuotas,
 		summarize: (data) => {
-			const reinvCap = sumBy(data.reinversionPorTipo, (r) => num(r.capital));
-			const reinvInt = sumBy(data.reinversionPorTipo, (r) => num(r.interes));
-			const cash = sumBy(
-				data.cashParcialPorTipo,
-				(r) => num(r.capital) + num(r.interes),
+			// Réplica de la lógica de totales del reporte (admin/reports/index.tsx):
+			// variable/excedente son total-only (monto_reinvertido), interés incluye
+			// IVA, cash usa monto_cash si existe, y sin-reinversión suma capital+interés+IVA.
+			const reinversion = sumBy(data.reinversionPorTipo, (r) => {
+				if (
+					r.tipo === "reinversion_variable" ||
+					r.tipo === "reinversion_excedente"
+				)
+					return num(r.monto_reinvertido);
+				if (r.tipo === "reinversion_capital") return num(r.capital);
+				if (r.tipo === "reinversion_interes")
+					return num(r.interes) + num(r.iva);
+				return num(r.capital) + num(r.interes) + num(r.iva);
+			});
+			const cash = sumBy(data.cashParcialPorTipo, (r) =>
+				r.monto_cash
+					? num(r.monto_cash)
+					: num(r.capital) + num(r.interes) + num(r.iva),
 			);
 			const sinReinv =
 				num(data.sinReinversion.totales.capital) +
-				num(data.sinReinversion.totales.interes);
+				num(data.sinReinversion.totales.interes) +
+				num(data.sinReinversion.totales.iva);
 			return [
-				{ concepto: "Reinv. capital", valor: reinvCap },
-				{ concepto: "Reinv. interés", valor: reinvInt },
+				{ concepto: "Reinversión", valor: reinversion },
 				{ concepto: "Cash parcial", valor: cash },
 				{ concepto: "Sin reinversión", valor: sinReinv },
 				{

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -59,8 +59,12 @@ export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
 		},
 		{ concepto: "Royalti", valor: sumBy(rows, (r) => num(r.total_royalti)) },
 		{
+			// mora_promedio ya es un promedio por bucket; promediamos entre
+			// buckets para no inflar el valor con la cantidad de períodos.
 			concepto: "Mora prom.",
-			valor: sumBy(rows, (r) => num(r.mora_promedio)),
+			valor: rows.length
+				? sumBy(rows, (r) => num(r.mora_promedio)) / rows.length
+				: 0,
 		},
 	],
 };

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -1,0 +1,155 @@
+/**
+ * Config de escenarios por reporte: qué palancas aplican, cómo transformar los
+ * datos y cómo resumirlos para la comparación real vs escenario del modal.
+ */
+import {
+	type ComparativoHistoricoRow,
+	type FacturacionMesResponse,
+	type FlujoCuotasInversionesResponse,
+	type LeverKey,
+	type MontoACobrarRow,
+	type PuntoEquilibrioRow,
+	type ScenarioParams,
+	transformCobertura,
+	transformComparativo,
+	transformFacturacion,
+	transformFlujoCuotas,
+	transformMontoACobrar,
+} from "./scenario";
+
+export interface SummaryRow {
+	concepto: string;
+	valor: number;
+}
+
+export interface ScenarioReportConfig<T> {
+	titulo: string;
+	descripcion: string;
+	levers: LeverKey[];
+	/** Muestra controles de cuota ilustrativa (método de amortización). */
+	usaMetodoCuota: boolean;
+	transform: (base: T, p: ScenarioParams) => T;
+	summarize: (data: T) => SummaryRow[];
+}
+
+const num = (v: string | number | null | undefined): number => {
+	const x = Number(v);
+	return Number.isFinite(x) ? x : 0;
+};
+
+const sumBy = <T>(rows: T[], pick: (r: T) => number): number =>
+	rows.reduce((acc, r) => acc + pick(r), 0);
+
+export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
+	titulo: "Monto a Cobrarse por Período",
+	descripcion:
+		"Estima cómo cambian las cuotas a cobrar si crece la colocación o baja la mora.",
+	levers: ["colocacion", "mora", "metodo"],
+	usaMetodoCuota: true,
+	transform: transformMontoACobrar,
+	summarize: (rows) => [
+		{ concepto: "Capital", valor: sumBy(rows, (r) => num(r.total_cuota)) },
+		{ concepto: "Interés", valor: sumBy(rows, (r) => num(r.total_interes)) },
+		{ concepto: "IVA", valor: sumBy(rows, (r) => num(r.total_iva)) },
+		{ concepto: "Seguro", valor: sumBy(rows, (r) => num(r.total_seguro)) },
+		{ concepto: "GPS", valor: sumBy(rows, (r) => num(r.total_gps)) },
+		{
+			concepto: "Membresías",
+			valor: sumBy(rows, (r) => num(r.total_membresias)),
+		},
+		{ concepto: "Royalti", valor: sumBy(rows, (r) => num(r.total_royalti)) },
+		{
+			concepto: "Mora prom.",
+			valor: sumBy(rows, (r) => num(r.mora_promedio)),
+		},
+	],
+};
+
+export const facturacionConfig: ScenarioReportConfig<FacturacionMesResponse> = {
+	titulo: "Facturado del Mes vs Esperado",
+	descripcion:
+		"Estima cuánto más se cobraría al subir la efectividad o bajar la mora.",
+	levers: ["efectividad", "mora"],
+	usaMetodoCuota: false,
+	transform: transformFacturacion,
+	summarize: (data) => [
+		{ concepto: "Capital", valor: num(data.cobrado.capital) },
+		{ concepto: "Interés", valor: num(data.cobrado.interes) },
+		{ concepto: "IVA", valor: num(data.cobrado.iva) },
+		{ concepto: "Seguro", valor: num(data.cobrado.seguro) },
+		{ concepto: "GPS", valor: num(data.cobrado.gps) },
+		{ concepto: "Membresías", valor: num(data.cobrado.membresias) },
+	],
+};
+
+export const flujoCuotasConfig: ScenarioReportConfig<FlujoCuotasInversionesResponse> =
+	{
+		titulo: "Flujo de Cuotas de Inversiones",
+		descripcion: "Estima cómo escalan los flujos si crece la colocación.",
+		levers: ["colocacion", "metodo"],
+		usaMetodoCuota: true,
+		transform: transformFlujoCuotas,
+		summarize: (data) => {
+			const reinvCap = sumBy(data.reinversionPorTipo, (r) => num(r.capital));
+			const reinvInt = sumBy(data.reinversionPorTipo, (r) => num(r.interes));
+			const cash = sumBy(
+				data.cashParcialPorTipo,
+				(r) => num(r.capital) + num(r.interes),
+			);
+			const sinReinv =
+				num(data.sinReinversion.totales.capital) +
+				num(data.sinReinversion.totales.interes);
+			return [
+				{ concepto: "Reinv. capital", valor: reinvCap },
+				{ concepto: "Reinv. interés", valor: reinvInt },
+				{ concepto: "Cash parcial", valor: cash },
+				{ concepto: "Sin reinversión", valor: sinReinv },
+				{
+					concepto: "Abonos capital",
+					valor: num(data.pagosExtras.abonos_capital),
+				},
+				{
+					concepto: "Cancelaciones",
+					valor: num(data.pagosExtras.cancelaciones),
+				},
+			];
+		},
+	};
+
+export const coberturaConfig: ScenarioReportConfig<PuntoEquilibrioRow[]> = {
+	titulo: "Cobertura de Colocación vs Meta",
+	descripcion: "Estima la cobertura si se coloca más capital.",
+	levers: ["colocacion"],
+	usaMetodoCuota: false,
+	transform: transformCobertura,
+	summarize: (rows) => [
+		{ concepto: "Colocado", valor: sumBy(rows, (r) => num(r.colocado)) },
+		{ concepto: "Meta", valor: sumBy(rows, (r) => num(r.meta)) },
+		{ concepto: "Faltante", valor: sumBy(rows, (r) => num(r.faltante)) },
+	],
+};
+
+export const comparativoConfig: ScenarioReportConfig<
+	ComparativoHistoricoRow[]
+> = {
+	titulo: "Comparativo Histórico Mensual",
+	descripcion:
+		"Estima el año si crece la colocación, sube la efectividad o baja la mora.",
+	levers: ["colocacion", "efectividad", "mora"],
+	usaMetodoCuota: false,
+	transform: transformComparativo,
+	summarize: (rows) => [
+		{
+			concepto: "Colocación",
+			valor: sumBy(rows, (r) => num(r.colocacion_monto)),
+		},
+		{
+			concepto: "Facturación",
+			valor: sumBy(rows, (r) => num(r.facturacion)),
+		},
+		{ concepto: "Mora 30", valor: sumBy(rows, (r) => num(r.mora_30)) },
+		{ concepto: "Mora 60", valor: sumBy(rows, (r) => num(r.mora_60)) },
+		{ concepto: "Mora 90", valor: sumBy(rows, (r) => num(r.mora_90)) },
+		{ concepto: "Mora 120+", valor: sumBy(rows, (r) => num(r.mora_120)) },
+	],
+};

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -107,6 +107,18 @@ describe("transformFacturacion", () => {
 		);
 		expect(out.esperado.capital).toBe("1000");
 	});
+
+	test("rubro sobre-cobrado (cobrado > esperado) se preserva intacto", () => {
+		const over: FacturacionMesResponse = {
+			cobrado: { ...data.cobrado, interes: "150" },
+			esperado: { ...data.esperado, interes: "100" },
+		};
+		const out = transformFacturacion(
+			over,
+			params({ efectividadDeltaPct: 100 }),
+		);
+		expect(out.cobrado.interes).toBe("150.00");
+	});
 });
 
 describe("transformCobertura", () => {

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type ComparativoHistoricoRow,
+	cuotaIlustrativa,
+	DEFAULT_SCENARIO_PARAMS,
+	type FacturacionMesResponse,
+	type MontoACobrarRow,
+	type PuntoEquilibrioRow,
+	type ScenarioParams,
+	transformCobertura,
+	transformComparativo,
+	transformFacturacion,
+	transformMontoACobrar,
+} from "./scenario";
+
+const params = (overrides: Partial<ScenarioParams> = {}): ScenarioParams => ({
+	...DEFAULT_SCENARIO_PARAMS,
+	...overrides,
+});
+
+const montoRow = (over: Partial<MontoACobrarRow> = {}): MontoACobrarRow => ({
+	bucket: "2026-01-01",
+	cuotas_count: 10,
+	total_cuota: "1000",
+	total_interes: "200",
+	total_iva: "24",
+	total_seguro: "50",
+	total_gps: "30",
+	total_membresias: "40",
+	total_royalti: "10",
+	mora_promedio: "100",
+	...over,
+});
+
+describe("transformMontoACobrar", () => {
+	test("método actual sin cambios = identidad", () => {
+		const rows = [montoRow()];
+		const out = transformMontoACobrar(rows, params());
+		expect(out[0].total_cuota).toBe("1000.00");
+		expect(out[0].mora_promedio).toBe("100.00");
+		expect(out[0].cuotas_count).toBe(10);
+	});
+
+	test("bajar mora 10% reduce mora_promedio 10%", () => {
+		const out = transformMontoACobrar(
+			[montoRow()],
+			params({ moraReduccionPct: 10 }),
+		);
+		expect(out[0].mora_promedio).toBe("90.00");
+	});
+
+	test("bajar mora >100% se acota a 0 (sin mora negativa)", () => {
+		const out = transformMontoACobrar(
+			[montoRow()],
+			params({ moraReduccionPct: 120 }),
+		);
+		expect(out[0].mora_promedio).toBe("0.00");
+	});
+
+	test("colocar +20% escala los rubros", () => {
+		const out = transformMontoACobrar(
+			[montoRow()],
+			params({ colocacionDeltaPct: 20 }),
+		);
+		expect(out[0].total_cuota).toBe("1200.00");
+		expect(out[0].cuotas_count).toBe(12);
+	});
+});
+
+describe("transformFacturacion", () => {
+	const data: FacturacionMesResponse = {
+		cobrado: {
+			capital: "800",
+			interes: "100",
+			iva: "12",
+			seguro: "0",
+			gps: "0",
+			membresias: "0",
+		},
+		esperado: {
+			capital: "1000",
+			interes: "100",
+			iva: "12",
+			seguro: "0",
+			gps: "0",
+			membresias: "0",
+		},
+	};
+
+	test("efectividad +100% iguala cobrado a esperado", () => {
+		const out = transformFacturacion(
+			data,
+			params({ efectividadDeltaPct: 100 }),
+		);
+		expect(out.cobrado.capital).toBe("1000.00");
+	});
+
+	test("efectividad +50% cierra la mitad de la brecha", () => {
+		const out = transformFacturacion(data, params({ efectividadDeltaPct: 50 }));
+		expect(out.cobrado.capital).toBe("900.00");
+	});
+
+	test("esperado no cambia", () => {
+		const out = transformFacturacion(
+			data,
+			params({ efectividadDeltaPct: 100 }),
+		);
+		expect(out.esperado.capital).toBe("1000");
+	});
+});
+
+describe("transformCobertura", () => {
+	const rows: PuntoEquilibrioRow[] = [
+		{
+			bucket: "2026-01-01",
+			cantidad_creditos: 5,
+			colocado: "50000",
+			meta: "100000",
+			cobertura: "50.0",
+			faltante: "50000.00",
+		},
+	];
+
+	test("colocar +100% duplica colocado y recalcula cobertura/faltante", () => {
+		const out = transformCobertura(rows, params({ colocacionDeltaPct: 100 }));
+		expect(out[0].colocado).toBe("100000.00");
+		expect(out[0].cobertura).toBe("100.0");
+		expect(out[0].faltante).toBe("0.00");
+	});
+});
+
+describe("transformComparativo", () => {
+	const rows: ComparativoHistoricoRow[] = [
+		{
+			mes: 1,
+			colocacion_monto: "100000",
+			colocacion_creditos: 10,
+			facturacion: "50000",
+			cartera_activa: "200000",
+			creditos_activos: 30,
+			mora_30: "1000",
+			mora_60: "500",
+			mora_90: "200",
+			mora_120: "100",
+			creditos_30: 4,
+			creditos_60: 2,
+			creditos_90: 1,
+			creditos_120: 1,
+		},
+	];
+
+	test("bajar mora 50% reduce buckets de mora a la mitad", () => {
+		const out = transformComparativo(rows, params({ moraReduccionPct: 50 }));
+		expect(out[0].mora_30).toBe("500.00");
+		expect(out[0].mora_120).toBe("50.00");
+	});
+
+	test("colocar +10% escala colocación; nulos siguen nulos", () => {
+		const withNull = [{ ...rows[0], colocacion_monto: null }];
+		const out = transformComparativo(
+			withNull,
+			params({ colocacionDeltaPct: 10 }),
+		);
+		expect(out[0].colocacion_monto).toBeNull();
+		expect(out[0].cartera_activa).toBe("220000.00");
+	});
+});
+
+describe("cuotaIlustrativa", () => {
+	test("francés y fija son positivas y la fija (1ª) es mayor", () => {
+		const { frances, fija } = cuotaIlustrativa(
+			params({
+				metodoCapital: 50000,
+				metodoPlazoMeses: 12,
+				metodoTasaMensual: 1.78,
+			}),
+		);
+		expect(frances).toBeGreaterThan(0);
+		expect(fija).toBeGreaterThan(0);
+		expect(fija).toBeGreaterThan(frances);
+	});
+});

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -110,6 +110,16 @@ describe("transformFacturacion", () => {
 		expect(out.esperado.capital).toBe("1000");
 	});
 
+	test("efectividad negativa no cancela reducción de mora válida", () => {
+		// mora=100 debería cerrar el 100% de la brecha aunque efectividad=-100
+		const out = transformFacturacion(
+			data,
+			params({ moraReduccionPct: 100, efectividadDeltaPct: -100 }),
+		);
+		// capital: cobrado=800, esperado=1000, brecha=200, close=clamp01(0+1)=1 → 1000
+		expect(out.cobrado.capital).toBe("1000.00");
+	});
+
 	test("rubro sobre-cobrado (cobrado > esperado) se preserva intacto", () => {
 		const over: FacturacionMesResponse = {
 			cobrado: { ...data.cobrado, interes: "150" },

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -169,6 +169,14 @@ describe("transformComparativo", () => {
 		expect(out[0].mora_120).toBe("50.00");
 	});
 
+	test("efectividad negativa se acota a 0 (facturación no baja)", () => {
+		const out = transformComparativo(
+			rows,
+			params({ efectividadDeltaPct: -150 }),
+		);
+		expect(out[0].facturacion).toBe("50000.00");
+	});
+
 	test("colocar +10% escala colocación; nulos siguen nulos", () => {
 		const withNull = [{ ...rows[0], colocacion_monto: null }];
 		const out = transformComparativo(

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -4,6 +4,7 @@ import {
 	cuotaIlustrativa,
 	DEFAULT_SCENARIO_PARAMS,
 	type FacturacionMesResponse,
+	type FlujoCuotasInversionesResponse,
 	type MontoACobrarRow,
 	type PuntoEquilibrioRow,
 	type ScenarioParams,
@@ -12,6 +13,7 @@ import {
 	transformFacturacion,
 	transformMontoACobrar,
 } from "./scenario";
+import { flujoCuotasConfig, montoACobrarConfig } from "./scenario-configs";
 
 const params = (overrides: Partial<ScenarioParams> = {}): ScenarioParams => ({
 	...DEFAULT_SCENARIO_PARAMS,
@@ -175,6 +177,57 @@ describe("transformComparativo", () => {
 		);
 		expect(out[0].colocacion_monto).toBeNull();
 		expect(out[0].cartera_activa).toBe("220000.00");
+	});
+});
+
+describe("montoACobrarConfig.summarize", () => {
+	test("mora se promedia entre buckets, no se suma", () => {
+		const rows: MontoACobrarRow[] = [
+			montoRow({ mora_promedio: "100" }),
+			montoRow({ mora_promedio: "100" }),
+		];
+		const summary = montoACobrarConfig.summarize(rows);
+		const mora = summary.find((s) => s.concepto === "Mora prom.");
+		expect(mora?.valor).toBe(100);
+	});
+});
+
+describe("flujoCuotasConfig.summarize", () => {
+	const data: FlujoCuotasInversionesResponse = {
+		reinversionPorTipo: [
+			{
+				tipo: "reinversion_variable",
+				capital: "0",
+				interes: "0",
+				iva: "0",
+				monto_reinvertido: "5000",
+			},
+			{ tipo: "reinversion_interes", capital: "0", interes: "200", iva: "24" },
+		],
+		cashParcialPorTipo: [
+			{ tipo: "cash", capital: "0", interes: "0", iva: "0", monto_cash: "300" },
+		],
+		sinReinversion: {
+			totales: { capital: "100", interes: "50", iva: "6" },
+			porInversionista: [],
+		},
+		pagosExtras: { abonos_capital: "0", cancelaciones: "0" },
+	};
+
+	test("reinversión variable usa monto_reinvertido e interés incluye IVA", () => {
+		const summary = flujoCuotasConfig.summarize(data);
+		const reinv = summary.find((s) => s.concepto === "Reinversión");
+		// 5000 (variable total-only) + 200 + 24 (interés + IVA)
+		expect(reinv?.valor).toBe(5224);
+	});
+
+	test("cash usa monto_cash y sin-reinversión incluye IVA", () => {
+		const summary = flujoCuotasConfig.summarize(data);
+		expect(summary.find((s) => s.concepto === "Cash parcial")?.valor).toBe(300);
+		// 100 + 50 + 6
+		expect(summary.find((s) => s.concepto === "Sin reinversión")?.valor).toBe(
+			156,
+		);
 	});
 });
 

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -270,7 +270,8 @@ export function transformComparativo(
 ): ComparativoHistoricoRow[] {
 	const col = colocacionFactor(p);
 	const mora = moraFactor(p);
-	const fact = 1 + p.efectividadDeltaPct / 100;
+	// Acotado a ≥0: "subir efectividad" nunca debe reducir la facturación.
+	const fact = 1 + Math.max(0, p.efectividadDeltaPct) / 100;
 	const scale = (v: string | null, f: number) =>
 		v == null ? null : money(num(v) * f);
 	const scaleN = (v: number | null, f: number) =>

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -199,7 +199,10 @@ export function transformFacturacion(
 	for (const k of rubros) {
 		const c = num(data.cobrado[k]);
 		const e = num(data.esperado[k]);
-		cobrado[k] = money(c + (e - c) * close);
+		// Solo cerramos brechas positivas (esperado > cobrado). Si ya está
+		// sobre-cobrado (c >= e), se preserva el monto real intacto.
+		const gap = e - c;
+		cobrado[k] = money(gap > 0 ? c + gap * close : c);
 	}
 	return { cobrado, esperado: data.esperado };
 }

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -60,9 +60,13 @@ const colocacionFactor = (p: ScenarioParams) =>
 	1 + Math.max(0, p.colocacionDeltaPct) / 100;
 /** Reducción de mora acotada a [0, 100]% → factor en [0, 1]. */
 const moraFactor = (p: ScenarioParams) => 1 - clamp01(p.moraReduccionPct / 100);
-/** Fracción de la brecha cobrado→esperado que se cierra (efectividad + mora). */
+/** Fracción de la brecha cobrado→esperado que se cierra (efectividad + mora).
+ *  Cada palanca se acota individualmente a [0,1] antes de sumar para evitar
+ *  que valores negativos en una cancelen una reducción válida en la otra. */
 const gapClose = (p: ScenarioParams) =>
-	clamp01(p.efectividadDeltaPct / 100 + p.moraReduccionPct / 100);
+	clamp01(
+		clamp01(p.efectividadDeltaPct / 100) + clamp01(p.moraReduccionPct / 100),
+	);
 
 // ---------------------------------------------------------------------------
 // Tipos de fila de cada reporte (estructuralmente iguales a los de la ruta)

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -1,0 +1,325 @@
+/**
+ * Motor de escenarios "qué pasaría si" para los reportes.
+ *
+ * Funciones puras que toman los datos reales de un reporte + supuestos y
+ * devuelven una versión simulada del mismo tipo. Todo el cálculo ocurre en el
+ * cliente sobre los agregados que el reporte ya cargó, por lo que los
+ * resultados son ESTIMACIONES y no modifican datos reales.
+ */
+import {
+	calculateMonthlyPayment,
+	IVA_FACTOR,
+} from "@/utils/quoter-calculations";
+
+export type MetodoCuota = "actual" | "frances" | "fija";
+
+export type LeverKey = "colocacion" | "mora" | "efectividad" | "metodo";
+
+export interface ScenarioParams {
+	/** % extra de colocación (0 = sin cambio). */
+	colocacionDeltaPct: number;
+	/** Reduce la mora en X% (0 = sin cambio). */
+	moraReduccionPct: number;
+	/** Cierra la brecha cobrado vs esperado en X% (0 = sin cambio). */
+	efectividadDeltaPct: number;
+	/** Método de amortización para la cuota ilustrativa. */
+	metodoCuota: MetodoCuota;
+	/** Plazo promedio (meses) para la cuota ilustrativa. */
+	metodoPlazoMeses: number;
+	/** Tasa mensual (%) para la cuota ilustrativa. */
+	metodoTasaMensual: number;
+	/** Capital del crédito promedio para la cuota ilustrativa. */
+	metodoCapital: number;
+}
+
+export const DEFAULT_SCENARIO_PARAMS: ScenarioParams = {
+	colocacionDeltaPct: 0,
+	moraReduccionPct: 0,
+	efectividadDeltaPct: 0,
+	metodoCuota: "actual",
+	metodoPlazoMeses: 12,
+	metodoTasaMensual: 1.78,
+	metodoCapital: 50000,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Convierte string|null a número seguro. */
+function num(value: string | number | null | undefined): number {
+	const x = Number(value);
+	return Number.isFinite(x) ? x : 0;
+}
+
+/** Número a string con 2 decimales (formato de los reportes). */
+function money(value: number): string {
+	return value.toFixed(2);
+}
+
+function clamp01(value: number): number {
+	return Math.min(1, Math.max(0, value));
+}
+
+const colocacionFactor = (p: ScenarioParams) =>
+	1 + Math.max(0, p.colocacionDeltaPct) / 100;
+/** Reducción de mora acotada a [0, 100]% → factor en [0, 1]. */
+const moraFactor = (p: ScenarioParams) => 1 - clamp01(p.moraReduccionPct / 100);
+/** Fracción de la brecha cobrado→esperado que se cierra (efectividad + mora). */
+const gapClose = (p: ScenarioParams) =>
+	clamp01(p.efectividadDeltaPct / 100 + p.moraReduccionPct / 100);
+
+// ---------------------------------------------------------------------------
+// Tipos de fila de cada reporte (estructuralmente iguales a los de la ruta)
+// ---------------------------------------------------------------------------
+
+export type MontoACobrarRow = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	total_royalti: string;
+	mora_promedio: string;
+};
+
+export type FacturacionMesRubro = {
+	capital: string;
+	interes: string;
+	iva: string;
+	seguro: string;
+	gps: string;
+	membresias: string;
+};
+
+export type FacturacionMesResponse = {
+	cobrado: FacturacionMesRubro;
+	esperado: FacturacionMesRubro;
+};
+
+export type FlujoCuotasRubro = {
+	capital: string;
+	interes: string;
+	iva: string;
+};
+export type FlujoCuotasInversionesResponse = {
+	reinversionPorTipo: (FlujoCuotasRubro & {
+		tipo: string;
+		monto_reinvertido?: string;
+	})[];
+	cashParcialPorTipo: (FlujoCuotasRubro & {
+		tipo: string;
+		monto_cash?: string;
+	})[];
+	sinReinversion: {
+		totales: FlujoCuotasRubro;
+		porInversionista: (FlujoCuotasRubro & {
+			inversionista_id: number;
+			nombre: string;
+		})[];
+	};
+	pagosExtras: { abonos_capital: string; cancelaciones: string };
+};
+
+export type PuntoEquilibrioRow = {
+	bucket: string;
+	cantidad_creditos: number;
+	colocado: string;
+	meta: string;
+	cobertura: string | null;
+	faltante: string | null;
+};
+
+export type ComparativoHistoricoRow = {
+	mes: number;
+	colocacion_monto: string | null;
+	colocacion_creditos: number | null;
+	facturacion: string | null;
+	cartera_activa: string | null;
+	creditos_activos: number | null;
+	mora_30: string | null;
+	mora_60: string | null;
+	mora_90: string | null;
+	mora_120: string | null;
+	creditos_30: number | null;
+	creditos_60: number | null;
+	creditos_90: number | null;
+	creditos_120: number | null;
+};
+
+// ---------------------------------------------------------------------------
+// Transformaciones por reporte
+// ---------------------------------------------------------------------------
+
+/**
+ * Monto a Cobrar: colocación escala los rubros (más cartera ≈ más cuotas),
+ * la mora reduce el promedio de mora por bucket.
+ */
+export function transformMontoACobrar(
+	rows: MontoACobrarRow[],
+	p: ScenarioParams,
+): MontoACobrarRow[] {
+	const col = colocacionFactor(p);
+	const mora = moraFactor(p);
+	return rows.map((r) => ({
+		...r,
+		cuotas_count: Math.round(r.cuotas_count * col),
+		total_cuota: money(num(r.total_cuota) * col),
+		total_interes: money(num(r.total_interes) * col),
+		total_iva: money(num(r.total_iva) * col),
+		total_seguro: money(num(r.total_seguro) * col),
+		total_gps: money(num(r.total_gps) * col),
+		total_membresias: money(num(r.total_membresias) * col),
+		total_royalti: money(num(r.total_royalti) * col),
+		mora_promedio: money(num(r.mora_promedio) * mora),
+	}));
+}
+
+/**
+ * Facturado vs Esperado: efectividad y mora cierran la brecha entre lo
+ * cobrado y lo esperado por rubro. Lo esperado no cambia.
+ */
+export function transformFacturacion(
+	data: FacturacionMesResponse,
+	p: ScenarioParams,
+): FacturacionMesResponse {
+	const close = gapClose(p);
+	const rubros: (keyof FacturacionMesRubro)[] = [
+		"capital",
+		"interes",
+		"iva",
+		"seguro",
+		"gps",
+		"membresias",
+	];
+	const cobrado = { ...data.cobrado };
+	for (const k of rubros) {
+		const c = num(data.cobrado[k]);
+		const e = num(data.esperado[k]);
+		cobrado[k] = money(c + (e - c) * close);
+	}
+	return { cobrado, esperado: data.esperado };
+}
+
+/** Flujo de Cuotas de Inversiones: la colocación escala todos los flujos. */
+export function transformFlujoCuotas(
+	data: FlujoCuotasInversionesResponse,
+	p: ScenarioParams,
+): FlujoCuotasInversionesResponse {
+	const col = colocacionFactor(p);
+	const scaleRubro = <T extends FlujoCuotasRubro>(r: T): T => ({
+		...r,
+		capital: money(num(r.capital) * col),
+		interes: money(num(r.interes) * col),
+		iva: money(num(r.iva) * col),
+	});
+	return {
+		reinversionPorTipo: data.reinversionPorTipo.map((r) => ({
+			...scaleRubro(r),
+			monto_reinvertido:
+				r.monto_reinvertido != null
+					? money(num(r.monto_reinvertido) * col)
+					: r.monto_reinvertido,
+		})),
+		cashParcialPorTipo: data.cashParcialPorTipo.map((r) => ({
+			...scaleRubro(r),
+			monto_cash:
+				r.monto_cash != null ? money(num(r.monto_cash) * col) : r.monto_cash,
+		})),
+		sinReinversion: {
+			totales: scaleRubro(data.sinReinversion.totales),
+			porInversionista: data.sinReinversion.porInversionista.map(scaleRubro),
+		},
+		pagosExtras: {
+			abonos_capital: money(num(data.pagosExtras.abonos_capital) * col),
+			cancelaciones: money(num(data.pagosExtras.cancelaciones) * col),
+		},
+	};
+}
+
+/**
+ * Cobertura vs Meta: la colocación escala lo colocado; cobertura y faltante
+ * se recalculan con la misma fórmula del backend.
+ */
+export function transformCobertura(
+	rows: PuntoEquilibrioRow[],
+	p: ScenarioParams,
+): PuntoEquilibrioRow[] {
+	const col = colocacionFactor(p);
+	return rows.map((r) => {
+		const colocado = num(r.colocado) * col;
+		const meta = num(r.meta);
+		return {
+			...r,
+			cantidad_creditos: Math.round(r.cantidad_creditos * col),
+			colocado: money(colocado),
+			cobertura: meta > 0 ? ((colocado / meta) * 100).toFixed(1) : null,
+			faltante: meta > 0 ? money(Math.max(0, meta - colocado)) : null,
+		};
+	});
+}
+
+/**
+ * Comparativo Histórico: colocación escala colocación/cartera, efectividad
+ * sube la facturación y la mora reduce los buckets de mora.
+ */
+export function transformComparativo(
+	rows: ComparativoHistoricoRow[],
+	p: ScenarioParams,
+): ComparativoHistoricoRow[] {
+	const col = colocacionFactor(p);
+	const mora = moraFactor(p);
+	const fact = 1 + p.efectividadDeltaPct / 100;
+	const scale = (v: string | null, f: number) =>
+		v == null ? null : money(num(v) * f);
+	const scaleN = (v: number | null, f: number) =>
+		v == null ? null : Math.round(v * f);
+	return rows.map((r) => ({
+		...r,
+		colocacion_monto: scale(r.colocacion_monto, col),
+		colocacion_creditos: scaleN(r.colocacion_creditos, col),
+		cartera_activa: scale(r.cartera_activa, col),
+		creditos_activos: scaleN(r.creditos_activos, col),
+		facturacion: scale(r.facturacion, fact),
+		mora_30: scale(r.mora_30, mora),
+		mora_60: scale(r.mora_60, mora),
+		mora_90: scale(r.mora_90, mora),
+		mora_120: scale(r.mora_120, mora),
+		creditos_30: scaleN(r.creditos_30, mora),
+		creditos_60: scaleN(r.creditos_60, mora),
+		creditos_90: scaleN(r.creditos_90, mora),
+		creditos_120: scaleN(r.creditos_120, mora),
+	}));
+}
+
+// ---------------------------------------------------------------------------
+// Cuota ilustrativa por método de amortización
+// ---------------------------------------------------------------------------
+
+export interface CuotaIlustrativa {
+	frances: number;
+	fija: number;
+}
+
+/**
+ * Cuota mensual de un crédito promedio según método. Francés = cuota nivelada
+ * (reusa calculateMonthlyPayment). Fija = capital/plazo + interés sobre saldo
+ * (primera cuota, la más alta). Ambas con IVA sobre el interés.
+ */
+export function cuotaIlustrativa(p: ScenarioParams): CuotaIlustrativa {
+	const capital = p.metodoCapital;
+	const plazo = p.metodoPlazoMeses > 0 ? p.metodoPlazoMeses : 1;
+	const frances = calculateMonthlyPayment(
+		capital,
+		p.metodoTasaMensual,
+		plazo,
+		0,
+		0,
+	);
+	const r = (p.metodoTasaMensual / 100) * IVA_FACTOR;
+	const fija = Math.round((capital / plazo + capital * r) * 100) / 100;
+	return { frances, fija };
+}

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -11,8 +11,6 @@ import {
 	IVA_FACTOR,
 } from "@/utils/quoter-calculations";
 
-export type MetodoCuota = "actual" | "frances" | "fija";
-
 export type LeverKey = "colocacion" | "mora" | "efectividad" | "metodo";
 
 export interface ScenarioParams {
@@ -22,8 +20,6 @@ export interface ScenarioParams {
 	moraReduccionPct: number;
 	/** Cierra la brecha cobrado vs esperado en X% (0 = sin cambio). */
 	efectividadDeltaPct: number;
-	/** Método de amortización para la cuota ilustrativa. */
-	metodoCuota: MetodoCuota;
 	/** Plazo promedio (meses) para la cuota ilustrativa. */
 	metodoPlazoMeses: number;
 	/** Tasa mensual (%) para la cuota ilustrativa. */
@@ -36,7 +32,6 @@ export const DEFAULT_SCENARIO_PARAMS: ScenarioParams = {
 	colocacionDeltaPct: 0,
 	moraReduccionPct: 0,
 	efectividadDeltaPct: 0,
-	metodoCuota: "actual",
 	metodoPlazoMeses: 12,
 	metodoTasaMensual: 1.78,
 	metodoCapital: 50000,

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -31,6 +31,7 @@ import { Route as CrmOpportunitiesRouteImport } from './routes/crm/opportunities
 import { Route as CrmLeadsRouteImport } from './routes/crm/leads'
 import { Route as CrmCompaniesRouteImport } from './routes/crm/companies'
 import { Route as CrmClientsRouteImport } from './routes/crm/clients'
+import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
 import { Route as CobrosIdRouteImport } from './routes/cobros/$id'
 import { Route as AdminUsersRouteImport } from './routes/admin/users'
@@ -158,6 +159,11 @@ const CrmClientsRoute = CrmClientsRouteImport.update({
   path: '/crm/clients',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosReportesRoute = CobrosReportesRouteImport.update({
+  id: '/cobros/reportes',
+  path: '/cobros/reportes',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosMetasRoute = CobrosMetasRouteImport.update({
   id: '/cobros/metas',
   path: '/cobros/metas',
@@ -250,6 +256,7 @@ export interface FileRoutesByFullPath {
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
   '/crm/leads': typeof CrmLeadsRoute
@@ -289,6 +296,7 @@ export interface FileRoutesByTo {
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
   '/crm/leads': typeof CrmLeadsRoute
@@ -329,6 +337,7 @@ export interface FileRoutesById {
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
   '/crm/leads': typeof CrmLeadsRoute
@@ -370,6 +379,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/cobros/$id'
     | '/cobros/metas'
+    | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
     | '/crm/leads'
@@ -409,6 +419,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/cobros/$id'
     | '/cobros/metas'
+    | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
     | '/crm/leads'
@@ -448,6 +459,7 @@ export interface FileRouteTypes {
     | '/admin/users'
     | '/cobros/$id'
     | '/cobros/metas'
+    | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
     | '/crm/leads'
@@ -488,6 +500,7 @@ export interface RootRouteChildren {
   AdminUsersRoute: typeof AdminUsersRoute
   CobrosIdRoute: typeof CobrosIdRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
+  CobrosReportesRoute: typeof CobrosReportesRoute
   CrmClientsRoute: typeof CrmClientsRoute
   CrmCompaniesRoute: typeof CrmCompaniesRoute
   CrmLeadsRoute: typeof CrmLeadsRoute
@@ -673,6 +686,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CrmClientsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/reportes': {
+      id: '/cobros/reportes'
+      path: '/cobros/reportes'
+      fullPath: '/cobros/reportes'
+      preLoaderRoute: typeof CobrosReportesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/metas': {
       id: '/cobros/metas'
       path: '/cobros/metas'
@@ -792,6 +812,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminUsersRoute: AdminUsersRoute,
   CobrosIdRoute: CobrosIdRoute,
   CobrosMetasRoute: CobrosMetasRoute,
+  CobrosReportesRoute: CobrosReportesRoute,
   CrmClientsRoute: CrmClientsRoute,
   CrmCompaniesRoute: CrmCompaniesRoute,
   CrmLeadsRoute: CrmLeadsRoute,

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -9,6 +9,7 @@ import {
 	Download,
 	FileText,
 	Loader2,
+	Sparkles,
 	Target,
 	TrendingDown,
 	TrendingUp,
@@ -34,6 +35,7 @@ import {
 import { toast } from "sonner";
 import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { ReportCard } from "@/components/reports/report-card";
+import { ScenarioModal } from "@/components/reports/scenario-modal";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -43,13 +45,12 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import {
-	Table,
-	TableBody,
-	TableCell,
-	TableHead,
-	TableHeader,
-	TableRow,
-} from "@/components/ui/table";
+	Dialog,
+	DialogContent,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
 import {
 	Select,
 	SelectContent,
@@ -58,14 +59,31 @@ import {
 	SelectValue,
 } from "@/components/ui/select";
 import {
-	Dialog,
-	DialogContent,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
+import type {
+	ComparativoHistoricoRow,
+	FacturacionMesResponse,
+	FacturacionMesRubro,
+	FlujoCuotasInversionesResponse,
+	FlujoCuotasRubro,
+	MontoACobrarRow,
+	PuntoEquilibrioRow,
+} from "@/lib/reports/scenario";
+import {
+	coberturaConfig,
+	comparativoConfig,
+	facturacionConfig,
+	flujoCuotasConfig,
+	montoACobrarConfig,
+} from "@/lib/reports/scenario-configs";
 import { PERMISSIONS } from "@/lib/roles";
 import { client, orpc, queryClient } from "@/utils/orpc";
 
@@ -84,88 +102,41 @@ const COLORS = {
 	incobrable: "#7f1d1d",
 };
 
-type MontoACobrarRow = {
-	bucket: string;
-	cuotas_count: number;
-	total_cuota: string;
-	total_interes: string;
-	total_iva: string;
-	total_seguro: string;
-	total_gps: string;
-	total_membresias: string;
-	total_royalti: string;
-	mora_promedio: string;
-};
-
-type FacturacionMesRubro = {
-	capital: string;
-	interes: string;
-	iva: string;
-	seguro: string;
-	gps: string;
-	membresias: string;
-};
-
-type FacturacionMesResponse = {
-	cobrado: FacturacionMesRubro;
-	esperado: FacturacionMesRubro;
-};
-
-type FlujoCuotasRubro = { capital: string; interes: string; iva: string };
-type FlujoCuotasInversionista = FlujoCuotasRubro & { inversionista_id: number; nombre: string };
-type FlujoCuotasInversionesResponse = {
-	reinversionPorTipo: (FlujoCuotasRubro & { tipo: string; monto_reinvertido?: string })[];
-	cashParcialPorTipo: (FlujoCuotasRubro & { tipo: string; monto_cash?: string })[];
-	sinReinversion: { totales: FlujoCuotasRubro; porInversionista: FlujoCuotasInversionista[] };
-	pagosExtras: { abonos_capital: string; cancelaciones: string };
-};
-
 const FLUJO_RUBROS: { key: keyof FlujoCuotasRubro; label: string }[] = [
 	{ key: "capital", label: "Capital" },
 	{ key: "interes", label: "Interés" },
 	{ key: "iva", label: "IVA 12%" },
 ];
 
-function getDefaultFlujoCuotasRange(): { fechaInicio: string; fechaFin: string } {
+function getDefaultFlujoCuotasRange(): {
+	fechaInicio: string;
+	fechaFin: string;
+} {
 	const todayGt = formatDateInput(new Date());
 	const [year, month] = todayGt.split("-").map(Number);
 	const fechaInicio = `${year}-${String(month).padStart(2, "0")}-01`;
 	const nextM = month === 12 ? 1 : month + 1;
 	const nextY = month === 12 ? year + 1 : year;
-	const lastDay = new Date(`${nextY}-${String(nextM).padStart(2, "0")}-01T12:00:00`);
+	const lastDay = new Date(
+		`${nextY}-${String(nextM).padStart(2, "0")}-01T12:00:00`,
+	);
 	lastDay.setDate(lastDay.getDate() - 1);
 	return { fechaInicio, fechaFin: formatDateInput(lastDay) };
 }
 
-type ComparativoHistoricoRow = {
-	mes: number;
-	colocacion_monto: string | null;
-	colocacion_creditos: number | null;
-	facturacion: string | null;
-	cartera_activa: string | null;
-	creditos_activos: number | null;
-	mora_30: string | null;
-	mora_60: string | null;
-	mora_90: string | null;
-	mora_120: string | null;
-	creditos_30: number | null;
-	creditos_60: number | null;
-	creditos_90: number | null;
-	creditos_120: number | null;
-};
-
-type PuntoEquilibrioRow = {
-	bucket: string;
-	cantidad_creditos: number;
-	colocado: string;
-	meta: string;
-	cobertura: string | null;
-	faltante: string | null;
-};
-
 const MESES = [
-	"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
-	"Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+	"Enero",
+	"Febrero",
+	"Marzo",
+	"Abril",
+	"Mayo",
+	"Junio",
+	"Julio",
+	"Agosto",
+	"Septiembre",
+	"Octubre",
+	"Noviembre",
+	"Diciembre",
 ];
 
 function coberturaColor(cobertura: string | null): string {
@@ -181,14 +152,15 @@ function coberturaLabel(cobertura: string | null): string {
 	return `${cobertura}%`;
 }
 
-const FACTURACION_RUBROS: { key: keyof FacturacionMesRubro; label: string }[] = [
-	{ key: "capital", label: "Capital" },
-	{ key: "interes", label: "Interés" },
-	{ key: "iva", label: "IVA 12%" },
-	{ key: "seguro", label: "Seguro" },
-	{ key: "gps", label: "GPS" },
-	{ key: "membresias", label: "Membresías" },
-];
+const FACTURACION_RUBROS: { key: keyof FacturacionMesRubro; label: string }[] =
+	[
+		{ key: "capital", label: "Capital" },
+		{ key: "interes", label: "Interés" },
+		{ key: "iva", label: "IVA 12%" },
+		{ key: "seguro", label: "Seguro" },
+		{ key: "gps", label: "GPS" },
+		{ key: "membresias", label: "Membresías" },
+	];
 
 const MONTO_COBRAR_COLORS = {
 	total_cuota: "#3b82f6",
@@ -225,7 +197,10 @@ function dateFromInput(value: string) {
 	return new Date(`${value}T12:00:00`);
 }
 
-function getDefaultMontoCobrarRange(): { fechaInicio: string; fechaFin: string } {
+function getDefaultMontoCobrarRange(): {
+	fechaInicio: string;
+	fechaFin: string;
+} {
 	const today = formatDateInput(new Date());
 	const fin = new Date();
 	fin.setFullYear(fin.getFullYear() + 1);
@@ -235,7 +210,10 @@ function getDefaultMontoCobrarRange(): { fechaInicio: string; fechaFin: string }
 function formatBucket(bucket: string, periodo: string): string {
 	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
 	if (periodo === "dia") {
-		return new Intl.DateTimeFormat("es-GT", { day: "2-digit", month: "short" }).format(date);
+		return new Intl.DateTimeFormat("es-GT", {
+			day: "2-digit",
+			month: "short",
+		}).format(date);
 	}
 	if (periodo === "semana") {
 		return `Sem ${new Intl.DateTimeFormat("es-GT", { day: "2-digit", month: "short" }).format(date)}`;
@@ -247,7 +225,10 @@ function formatBucket(bucket: string, periodo: string): string {
 	if (periodo === "anio") {
 		return String(date.getFullYear());
 	}
-	return new Intl.DateTimeFormat("es-GT", { month: "short", year: "numeric" }).format(date);
+	return new Intl.DateTimeFormat("es-GT", {
+		month: "short",
+		year: "numeric",
+	}).format(date);
 }
 
 function getDefaultClosedCreditsRange(): DateRange {
@@ -286,6 +267,15 @@ function downloadCsv(filename: string, rows: (string | number | null)[][]) {
 	URL.revokeObjectURL(url);
 }
 
+function SimularButton({ onClick }: { onClick: () => void }) {
+	return (
+		<Button variant="outline" size="sm" className="gap-1.5" onClick={onClick}>
+			<Sparkles className="h-3.5 w-3.5 text-purple-500" />
+			Simular
+		</Button>
+	);
+}
+
 function ProgressBar({ value, max }: { value: number; max: number }) {
 	const pct = max > 0 ? Math.min((value / max) * 100, 100) : 0;
 	const color = pct >= 100 ? "#22c55e" : pct >= 80 ? "#eab308" : "#ef4444";
@@ -316,18 +306,25 @@ function RouteComponent() {
 	const [montoCobrarPeriodo, setMontoCobrarPeriodo] = useState<
 		"anio" | "trimestre" | "mes" | "semana" | "dia"
 	>("mes");
-	const [montoCobrarRange, setMontoCobrarRange] = useState(getDefaultMontoCobrarRange);
+	const [montoCobrarRange, setMontoCobrarRange] = useState(
+		getDefaultMontoCobrarRange,
+	);
 	const [facturacionMes, setFacturacionMes] = useState(() => ({
 		mes: new Date().getMonth() + 1,
 		anio: new Date().getFullYear(),
 	}));
-	const [flujoCuotasRange, setFlujoCuotasRange] = useState(getDefaultFlujoCuotasRange);
-	const [comparativoAnio, setComparativoAnio] = useState(
-		() => new Date().getFullYear(),
+	const [flujoCuotasRange, setFlujoCuotasRange] = useState(
+		getDefaultFlujoCuotasRange,
+	);
+	const [comparativoAnio, setComparativoAnio] = useState(() =>
+		new Date().getFullYear(),
 	);
 	const [metasAnio, setMetasAnio] = useState(new Date().getFullYear());
 	const [editMetas, setEditMetas] = useState<Record<number, string>>({});
 	const [metasModalOpen, setMetasModalOpen] = useState(false);
+	const [scenarioOpen, setScenarioOpen] = useState<
+		null | "monto" | "facturacion" | "flujo" | "cobertura" | "comparativo"
+	>(null);
 	const [isSavingMetas, setIsSavingMetas] = useState(false);
 	const [focusedMes, setFocusedMes] = useState<number | null>(null);
 	const [equilibrioPeriodo, setEquilibrioPeriodo] = useState<
@@ -393,11 +390,16 @@ function RouteComponent() {
 
 	const flujoCuotasQuery = useQuery({
 		...orpc.getFlujoCuotasInversiones.queryOptions({
-			input: { fechaInicio: flujoCuotasRange.fechaInicio, fechaFin: flujoCuotasRange.fechaFin },
+			input: {
+				fechaInicio: flujoCuotasRange.fechaInicio,
+				fechaFin: flujoCuotasRange.fechaFin,
+			},
 		}),
 		enabled: isAdmin,
 	});
-	const flujoCuotasData = flujoCuotasQuery.data as FlujoCuotasInversionesResponse | undefined;
+	const flujoCuotasData = flujoCuotasQuery.data as
+		| FlujoCuotasInversionesResponse
+		| undefined;
 
 	const comparativoQuery = useQuery({
 		...orpc.getComparativoHistorico.queryOptions({
@@ -425,7 +427,9 @@ function RouteComponent() {
 		}) => client.upsertMeta(vars),
 		onSuccess: () => {
 			queryClient.invalidateQueries(
-				orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
+				orpc.getMetas.queryOptions({
+					input: { anio: metasAnio, tipo: "colocacion" },
+				}),
 			);
 		},
 		onError: (error: Error) => {
@@ -466,7 +470,9 @@ function RouteComponent() {
 			await Promise.all(saves);
 			await Promise.all([
 				queryClient.invalidateQueries(
-					orpc.getMetas.queryOptions({ input: { anio: metasAnio, tipo: "colocacion" } }),
+					orpc.getMetas.queryOptions({
+						input: { anio: metasAnio, tipo: "colocacion" },
+					}),
 				),
 				queryClient.invalidateQueries(
 					orpc.getPuntoEquilibrio.queryOptions({
@@ -481,7 +487,9 @@ function RouteComponent() {
 			toast.success(`${saves.length} metas guardadas`);
 			setMetasModalOpen(false);
 		} catch (err) {
-			toast.error(err instanceof Error ? err.message : "Error al guardar metas");
+			toast.error(
+				err instanceof Error ? err.message : "Error al guardar metas",
+			);
 		} finally {
 			setIsSavingMetas(false);
 		}
@@ -496,7 +504,6 @@ function RouteComponent() {
 			setEditMetas(map);
 		}
 	}, [metasQuery.data]);
-
 
 	useEffect(() => {
 		if (shouldRedirectToLogin({ error: sessionError, isPending, session })) {
@@ -973,11 +980,13 @@ function RouteComponent() {
 									<div>
 										<CardTitle>Monto a Cobrarse por Período</CardTitle>
 										<CardDescription>
-											Cuotas pendientes desglosadas por rubro (capital, interés, seguro, etc.)
+											Cuotas pendientes desglosadas por rubro (capital, interés,
+											seguro, etc.)
 										</CardDescription>
 									</div>
 								</div>
 								<div className="flex flex-wrap items-center gap-2">
+									<SimularButton onClick={() => setScenarioOpen("monto")} />
 									<Select
 										value={montoCobrarPeriodo}
 										onValueChange={(v) =>
@@ -1035,33 +1044,52 @@ function RouteComponent() {
 									{/* Gráfica de barras apiladas */}
 									<ResponsiveContainer width="100%" height={350}>
 										<BarChart
-											data={montoCobrarData.data.map((row: MontoACobrarRow) => ({
-												bucket: formatBucket(row.bucket, montoCobrarPeriodo),
-												total_cuota: Number.parseFloat(row.total_cuota),
-												total_interes: Number.parseFloat(row.total_interes),
-												total_iva: Number.parseFloat(row.total_iva),
-												total_seguro: Number.parseFloat(row.total_seguro),
-												total_gps: Number.parseFloat(row.total_gps),
-												total_membresias: Number.parseFloat(row.total_membresias),
-												total_royalti: Number.parseFloat(row.total_royalti),
-											}))}
+											data={montoCobrarData.data.map(
+												(row: MontoACobrarRow) => ({
+													bucket: formatBucket(row.bucket, montoCobrarPeriodo),
+													total_cuota: Number.parseFloat(row.total_cuota),
+													total_interes: Number.parseFloat(row.total_interes),
+													total_iva: Number.parseFloat(row.total_iva),
+													total_seguro: Number.parseFloat(row.total_seguro),
+													total_gps: Number.parseFloat(row.total_gps),
+													total_membresias: Number.parseFloat(
+														row.total_membresias,
+													),
+													total_royalti: Number.parseFloat(row.total_royalti),
+												}),
+											)}
 										>
 											<CartesianGrid strokeDasharray="3 3" />
-											<XAxis dataKey="bucket" tick={{ fontSize: 11 }} interval={0} height={36} />
-											<YAxis tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`} />
+											<XAxis
+												dataKey="bucket"
+												tick={{ fontSize: 11 }}
+												interval={0}
+												height={36}
+											/>
+											<YAxis
+												tickFormatter={(v) =>
+													`Q${(Number(v) / 1000).toFixed(0)}k`
+												}
+											/>
 											<Tooltip
 												formatter={(value, name) => [
 													formatCurrency(Number(value)),
-													MONTO_COBRAR_LABELS[name as keyof typeof MONTO_COBRAR_LABELS] ?? name,
+													MONTO_COBRAR_LABELS[
+														name as keyof typeof MONTO_COBRAR_LABELS
+													] ?? name,
 												]}
 											/>
 											<Legend
 												formatter={(value) =>
-													MONTO_COBRAR_LABELS[value as keyof typeof MONTO_COBRAR_LABELS] ?? value
+													MONTO_COBRAR_LABELS[
+														value as keyof typeof MONTO_COBRAR_LABELS
+													] ?? value
 												}
 											/>
 											{(
-												Object.keys(MONTO_COBRAR_COLORS) as (keyof typeof MONTO_COBRAR_COLORS)[]
+												Object.keys(
+													MONTO_COBRAR_COLORS,
+												) as (keyof typeof MONTO_COBRAR_COLORS)[]
 											).map((key) => (
 												<Bar
 													key={key}
@@ -1085,10 +1113,16 @@ function RouteComponent() {
 													<TableHead className="text-right">IVA</TableHead>
 													<TableHead className="text-right">Seguro</TableHead>
 													<TableHead className="text-right">GPS</TableHead>
-													<TableHead className="text-right">Membresías</TableHead>
+													<TableHead className="text-right">
+														Membresías
+													</TableHead>
 													<TableHead className="text-right">Royalti</TableHead>
-													<TableHead className="text-right">Mora Prom.</TableHead>
-													<TableHead className="text-right font-bold">Total</TableHead>
+													<TableHead className="text-right">
+														Mora Prom.
+													</TableHead>
+													<TableHead className="text-right font-bold">
+														Total
+													</TableHead>
 												</TableRow>
 											</TableHeader>
 											<TableBody>
@@ -1099,30 +1133,55 @@ function RouteComponent() {
 														Number.parseFloat(row.total_iva) +
 														Number.parseFloat(row.total_seguro) +
 														Number.parseFloat(row.total_gps) +
-														Number.parseFloat(row.total_membresias);
+														Number.parseFloat(row.total_membresias) +
+														Number.parseFloat(row.total_royalti);
 													return (
 														<TableRow key={row.bucket}>
-															<TableCell>{formatBucket(row.bucket, montoCobrarPeriodo)}</TableCell>
-															<TableCell className="text-right">{row.cuotas_count}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_cuota)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_interes)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_iva)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_seguro)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_gps)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_membresias)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.total_royalti)}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.mora_promedio)}</TableCell>
-															<TableCell className="text-right font-bold">{formatCurrency(total)}</TableCell>
+															<TableCell>
+																{formatBucket(row.bucket, montoCobrarPeriodo)}
+															</TableCell>
+															<TableCell className="text-right">
+																{row.cuotas_count}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_cuota)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_interes)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_iva)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_seguro)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_gps)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_membresias)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.total_royalti)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(row.mora_promedio)}
+															</TableCell>
+															<TableCell className="text-right font-bold">
+																{formatCurrency(total)}
+															</TableCell>
 														</TableRow>
 													);
 												})}
 												{/* Fila de totales */}
 												{(() => {
-													const rows = montoCobrarData.data as MontoACobrarRow[];
+													const rows =
+														montoCobrarData.data as MontoACobrarRow[];
 													const sum = (key: keyof MontoACobrarRow) =>
 														rows.reduce(
 															(acc: number, r: MontoACobrarRow) =>
-																acc + Number.parseFloat((r[key] as string) || "0"),
+																acc +
+																Number.parseFloat((r[key] as string) || "0"),
 															0,
 														);
 													const grandTotal =
@@ -1131,22 +1190,42 @@ function RouteComponent() {
 														sum("total_iva") +
 														sum("total_seguro") +
 														sum("total_gps") +
-														sum("total_membresias");
+														sum("total_membresias") +
+														sum("total_royalti");
 													return (
 														<TableRow className="border-t-2 bg-muted/50 font-bold">
 															<TableCell>Total</TableCell>
 															<TableCell className="text-right">
-																{rows.reduce((acc, r) => acc + r.cuotas_count, 0)}
+																{rows.reduce(
+																	(acc, r) => acc + r.cuotas_count,
+																	0,
+																)}
 															</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_cuota"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_interes"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_iva"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_seguro"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_gps"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_membresias"))}</TableCell>
-															<TableCell className="text-right">{formatCurrency(sum("total_royalti"))}</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_cuota"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_interes"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_iva"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_seguro"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_gps"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_membresias"))}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(sum("total_royalti"))}
+															</TableCell>
 															<TableCell className="text-right">—</TableCell>
-															<TableCell className="text-right">{formatCurrency(grandTotal)}</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(grandTotal)}
+															</TableCell>
 														</TableRow>
 													);
 												})()}
@@ -1168,10 +1247,14 @@ function RouteComponent() {
 										Facturado del Mes vs Esperado
 									</CardTitle>
 									<CardDescription>
-										Compara lo cobrado en el mes contra lo esperado según fecha de vencimiento
+										Compara lo cobrado en el mes contra lo esperado según fecha
+										de vencimiento
 									</CardDescription>
 								</div>
 								<div className="flex items-center gap-2">
+									<SimularButton
+										onClick={() => setScenarioOpen("facturacion")}
+									/>
 									<Select
 										value={String(facturacionMes.mes)}
 										onValueChange={(v) =>
@@ -1183,8 +1266,18 @@ function RouteComponent() {
 										</SelectTrigger>
 										<SelectContent>
 											{[
-												"Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio",
-												"Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre",
+												"Enero",
+												"Febrero",
+												"Marzo",
+												"Abril",
+												"Mayo",
+												"Junio",
+												"Julio",
+												"Agosto",
+												"Septiembre",
+												"Octubre",
+												"Noviembre",
+												"Diciembre",
 											].map((label, i) => (
 												<SelectItem key={i + 1} value={String(i + 1)}>
 													{label}
@@ -1210,69 +1303,73 @@ function RouteComponent() {
 						</CardHeader>
 						<CardContent>
 							{facturacionMesQuery.isPending && (
-								<div className="text-muted-foreground py-4 text-center text-sm">
+								<div className="py-4 text-center text-muted-foreground text-sm">
 									Cargando...
 								</div>
 							)}
 							{facturacionMesQuery.isError && (
-								<div className="text-destructive py-4 text-center text-sm">
+								<div className="py-4 text-center text-destructive text-sm">
 									Error al cargar datos
 								</div>
 							)}
-							{facturacionMesData && (() => {
-								const { cobrado, esperado } = facturacionMesData;
-								const totalCobrado = FACTURACION_RUBROS.reduce(
-									(acc, r) => acc + Number(cobrado[r.key] || 0),
-									0,
-								);
-								const totalEsperado = FACTURACION_RUBROS.reduce(
-									(acc, r) => acc + Number(esperado[r.key] || 0),
-									0,
-								);
-								return (
-									<Table>
-										<TableHeader>
-											<TableRow>
-												<TableHead>Rubro</TableHead>
-												<TableHead className="text-right">Cobrado</TableHead>
-												<TableHead className="text-right">Esperado</TableHead>
-												<TableHead className="w-48">Progreso</TableHead>
-											</TableRow>
-										</TableHeader>
-										<TableBody>
-											{FACTURACION_RUBROS.map(({ key, label }) => (
-												<TableRow key={key}>
-													<TableCell>{label}</TableCell>
+							{facturacionMesData &&
+								(() => {
+									const { cobrado, esperado } = facturacionMesData;
+									const totalCobrado = FACTURACION_RUBROS.reduce(
+										(acc, r) => acc + Number(cobrado[r.key] || 0),
+										0,
+									);
+									const totalEsperado = FACTURACION_RUBROS.reduce(
+										(acc, r) => acc + Number(esperado[r.key] || 0),
+										0,
+									);
+									return (
+										<Table>
+											<TableHeader>
+												<TableRow>
+													<TableHead>Rubro</TableHead>
+													<TableHead className="text-right">Cobrado</TableHead>
+													<TableHead className="text-right">Esperado</TableHead>
+													<TableHead className="w-48">Progreso</TableHead>
+												</TableRow>
+											</TableHeader>
+											<TableBody>
+												{FACTURACION_RUBROS.map(({ key, label }) => (
+													<TableRow key={key}>
+														<TableCell>{label}</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(Number(cobrado[key] || 0))}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(Number(esperado[key] || 0))}
+														</TableCell>
+														<TableCell>
+															<ProgressBar
+																value={Number(cobrado[key] || 0)}
+																max={Number(esperado[key] || 0)}
+															/>
+														</TableCell>
+													</TableRow>
+												))}
+												<TableRow className="border-t-2 bg-muted/50 font-bold">
+													<TableCell>Total</TableCell>
 													<TableCell className="text-right">
-														{formatCurrency(Number(cobrado[key] || 0))}
+														{formatCurrency(totalCobrado)}
 													</TableCell>
 													<TableCell className="text-right">
-														{formatCurrency(Number(esperado[key] || 0))}
+														{formatCurrency(totalEsperado)}
 													</TableCell>
 													<TableCell>
 														<ProgressBar
-															value={Number(cobrado[key] || 0)}
-															max={Number(esperado[key] || 0)}
+															value={totalCobrado}
+															max={totalEsperado}
 														/>
 													</TableCell>
 												</TableRow>
-											))}
-											<TableRow className="border-t-2 bg-muted/50 font-bold">
-												<TableCell>Total</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(totalCobrado)}
-												</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(totalEsperado)}
-												</TableCell>
-												<TableCell>
-													<ProgressBar value={totalCobrado} max={totalEsperado} />
-												</TableCell>
-											</TableRow>
-										</TableBody>
-									</Table>
-								);
-							})()}
+											</TableBody>
+										</Table>
+									);
+								})()}
 						</CardContent>
 					</Card>
 
@@ -1286,17 +1383,22 @@ function RouteComponent() {
 										Flujo de Cuotas de Inversiones
 									</CardTitle>
 									<CardDescription>
-										Cuotas esperadas hacia reinversión y hacia pago en efectivo, por período
+										Cuotas esperadas hacia reinversión y hacia pago en efectivo,
+										por período
 									</CardDescription>
 								</div>
 								<div className="flex items-center gap-2">
+									<SimularButton onClick={() => setScenarioOpen("flujo")} />
 									<Input
 										type="date"
 										aria-label="Fecha inicio"
 										className="w-40"
 										value={flujoCuotasRange.fechaInicio}
 										onChange={(e) =>
-											setFlujoCuotasRange((prev) => ({ ...prev, fechaInicio: e.target.value }))
+											setFlujoCuotasRange((prev) => ({
+												...prev,
+												fechaInicio: e.target.value,
+											}))
 										}
 									/>
 									<span className="text-muted-foreground text-sm">–</span>
@@ -1306,7 +1408,10 @@ function RouteComponent() {
 										className="w-40"
 										value={flujoCuotasRange.fechaFin}
 										onChange={(e) =>
-											setFlujoCuotasRange((prev) => ({ ...prev, fechaFin: e.target.value }))
+											setFlujoCuotasRange((prev) => ({
+												...prev,
+												fechaFin: e.target.value,
+											}))
 										}
 									/>
 								</div>
@@ -1314,181 +1419,307 @@ function RouteComponent() {
 						</CardHeader>
 						<CardContent className="space-y-6">
 							{flujoCuotasQuery.isPending && (
-								<div className="text-muted-foreground py-4 text-center text-sm">
+								<div className="py-4 text-center text-muted-foreground text-sm">
 									Cargando...
 								</div>
 							)}
 							{flujoCuotasQuery.isError && (
-								<div className="text-destructive py-4 text-center text-sm">
+								<div className="py-4 text-center text-destructive text-sm">
 									Error al cargar datos
 								</div>
 							)}
-							{flujoCuotasData && (() => {
-								const { reinversionPorTipo, cashParcialPorTipo, sinReinversion, pagosExtras } = flujoCuotasData;
-								const TIPO_LABELS: Record<string, string> = {
-									reinversion_capital: "Reinversión Capital",
-									reinversion_interes: "Reinversión Interés",
-									reinversion_total: "Reinversión Total",
-									reinversion_variable: "Reinversión Variable",
-									reinversion_excedente: "Reinversión Excedente",
-								};
-								type ReinvertidoResult =
-									| { esTotal: true; total: number }
-									| { esTotal: false; capital: number; interes: number; iva: number };
-								function getReinvertido(tipo: string, t: FlujoCuotasRubro & { monto_reinvertido?: string }): ReinvertidoResult {
-									if (tipo === "reinversion_variable" || tipo === "reinversion_excedente")
-										return { esTotal: true, total: Number(t.monto_reinvertido ?? 0) };
-									if (tipo === "reinversion_capital")
-										return { esTotal: false, capital: Number(t.capital), interes: 0, iva: 0 };
-									if (tipo === "reinversion_interes")
-										return { esTotal: false, capital: 0, interes: Number(t.interes), iva: Number(t.iva) };
-									return { esTotal: false, capital: Number(t.capital), interes: Number(t.interes), iva: Number(t.iva) };
-								}
-								const totalesReinv = reinversionPorTipo.reduce(
-									(a, t) => {
-										const r = getReinvertido(t.tipo, t);
-										const tot = r.esTotal ? r.total : r.capital + r.interes + r.iva;
+							{flujoCuotasData &&
+								(() => {
+									const {
+										reinversionPorTipo,
+										cashParcialPorTipo,
+										sinReinversion,
+										pagosExtras,
+									} = flujoCuotasData;
+									const TIPO_LABELS: Record<string, string> = {
+										reinversion_capital: "Reinversión Capital",
+										reinversion_interes: "Reinversión Interés",
+										reinversion_total: "Reinversión Total",
+										reinversion_variable: "Reinversión Variable",
+										reinversion_excedente: "Reinversión Excedente",
+									};
+									type ReinvertidoResult =
+										| { esTotal: true; total: number }
+										| {
+												esTotal: false;
+												capital: number;
+												interes: number;
+												iva: number;
+										  };
+									function getReinvertido(
+										tipo: string,
+										t: FlujoCuotasRubro & { monto_reinvertido?: string },
+									): ReinvertidoResult {
+										if (
+											tipo === "reinversion_variable" ||
+											tipo === "reinversion_excedente"
+										)
+											return {
+												esTotal: true,
+												total: Number(t.monto_reinvertido ?? 0),
+											};
+										if (tipo === "reinversion_capital")
+											return {
+												esTotal: false,
+												capital: Number(t.capital),
+												interes: 0,
+												iva: 0,
+											};
+										if (tipo === "reinversion_interes")
+											return {
+												esTotal: false,
+												capital: 0,
+												interes: Number(t.interes),
+												iva: Number(t.iva),
+											};
 										return {
-											total: a.total + tot,
-											capital: a.capital + (r.esTotal ? 0 : r.capital),
-											interes: a.interes + (r.esTotal ? 0 : r.interes),
-											iva: a.iva + (r.esTotal ? 0 : r.iva),
+											esTotal: false,
+											capital: Number(t.capital),
+											interes: Number(t.interes),
+											iva: Number(t.iva),
 										};
-									},
-									{ total: 0, capital: 0, interes: 0, iva: 0 },
-								);
-								const totalReinv = totalesReinv.total;
-								const cashParcialTotal = cashParcialPorTipo.reduce(
-									(a, t) => a + (t.monto_cash ? Number(t.monto_cash) : Number(t.capital) + Number(t.interes) + Number(t.iva)),
-									0,
-								);
-								const totalSinReinv = FLUJO_RUBROS.reduce((a, r) => a + Number(sinReinversion.totales[r.key] || 0), 0);
-								const totalExtras = Number(pagosExtras.abonos_capital) + Number(pagosExtras.cancelaciones);
-								return (
-									<>
-										{/* Sección 1: Hacia Reinversión por tipo */}
-										<div>
-											<p className="mb-2 text-sm font-semibold">Cuotas → Reinversión</p>
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Tipo de Reinversión</TableHead>
-														<TableHead className="text-right">Capital</TableHead>
-														<TableHead className="text-right">Interés</TableHead>
-														<TableHead className="text-right">IVA 12%</TableHead>
-														<TableHead className="text-right">Total</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{reinversionPorTipo.filter((t) => {
-														const r = getReinvertido(t.tipo, t);
-														const tot = r.esTotal ? r.total : r.capital + r.interes + r.iva;
-														return tot > 0;
-													}).map((t) => {
-														const r = getReinvertido(t.tipo, t);
-														const rowTotal = r.esTotal ? r.total : r.capital + r.interes + r.iva;
-														return (
-															<TableRow key={t.tipo}>
-																<TableCell>{TIPO_LABELS[t.tipo] ?? t.tipo}</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	{r.esTotal ? "—" : formatCurrency(r.capital)}
-																</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	{r.esTotal ? "—" : formatCurrency(r.interes)}
-																</TableCell>
-																<TableCell className="text-right text-muted-foreground">
-																	{r.esTotal ? "—" : formatCurrency(r.iva)}
-																</TableCell>
-																<TableCell className="text-right">{formatCurrency(rowTotal)}</TableCell>
-															</TableRow>
-														);
-													})}
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalesReinv.capital)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalesReinv.interes)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalesReinv.iva)}
-														</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalReinv)}</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										</div>
-
-										{/* Sección 2: Cash (sin reinversión + porciones cash de reinversión parcial) */}
-										<div>
-											<p className="mb-2 text-sm font-semibold">Cuotas → Cash</p>
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Origen</TableHead>
-														<TableHead className="text-right">Capital</TableHead>
-														<TableHead className="text-right">Interés</TableHead>
-														<TableHead className="text-right">IVA 12%</TableHead>
-														<TableHead className="text-right">Total</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{/* Inversionistas sin reinversión */}
-													<TableRow>
-														<TableCell>Sin Reinversión</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.capital))}</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.interes))}</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(sinReinversion.totales.iva))}</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalSinReinv)}</TableCell>
-													</TableRow>
-													{/* Porciones cash de inversionistas con reinversión parcial — combinado */}
-													{cashParcialPorTipo.length > 0 && (
+									}
+									const totalesReinv = reinversionPorTipo.reduce(
+										(a, t) => {
+											const r = getReinvertido(t.tipo, t);
+											const tot = r.esTotal
+												? r.total
+												: r.capital + r.interes + r.iva;
+											return {
+												total: a.total + tot,
+												capital: a.capital + (r.esTotal ? 0 : r.capital),
+												interes: a.interes + (r.esTotal ? 0 : r.interes),
+												iva: a.iva + (r.esTotal ? 0 : r.iva),
+											};
+										},
+										{ total: 0, capital: 0, interes: 0, iva: 0 },
+									);
+									const totalReinv = totalesReinv.total;
+									const cashParcialTotal = cashParcialPorTipo.reduce(
+										(a, t) =>
+											a +
+											(t.monto_cash
+												? Number(t.monto_cash)
+												: Number(t.capital) +
+													Number(t.interes) +
+													Number(t.iva)),
+										0,
+									);
+									const totalSinReinv = FLUJO_RUBROS.reduce(
+										(a, r) => a + Number(sinReinversion.totales[r.key] || 0),
+										0,
+									);
+									const totalExtras =
+										Number(pagosExtras.abonos_capital) +
+										Number(pagosExtras.cancelaciones);
+									return (
+										<>
+											{/* Sección 1: Hacia Reinversión por tipo */}
+											<div>
+												<p className="mb-2 font-semibold text-sm">
+													Cuotas → Reinversión
+												</p>
+												<Table>
+													<TableHeader>
 														<TableRow>
-															<TableCell>Intereses y excedentes pagados a inversionistas</TableCell>
-															<TableCell colSpan={3} className="text-muted-foreground text-right text-sm">capital/interés/IVA según tipo</TableCell>
-															<TableCell className="text-right">{formatCurrency(cashParcialTotal)}</TableCell>
+															<TableHead>Tipo de Reinversión</TableHead>
+															<TableHead className="text-right">
+																Capital
+															</TableHead>
+															<TableHead className="text-right">
+																Interés
+															</TableHead>
+															<TableHead className="text-right">
+																IVA 12%
+															</TableHead>
+															<TableHead className="text-right">
+																Total
+															</TableHead>
 														</TableRow>
-													)}
-													{/* Total general cash */}
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total Cash</TableCell>
-														<TableCell colSpan={3} />
-														<TableCell className="text-right">{formatCurrency(totalSinReinv + cashParcialTotal)}</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										</div>
+													</TableHeader>
+													<TableBody>
+														{reinversionPorTipo
+															.filter((t) => {
+																const r = getReinvertido(t.tipo, t);
+																const tot = r.esTotal
+																	? r.total
+																	: r.capital + r.interes + r.iva;
+																return tot > 0;
+															})
+															.map((t) => {
+																const r = getReinvertido(t.tipo, t);
+																const rowTotal = r.esTotal
+																	? r.total
+																	: r.capital + r.interes + r.iva;
+																return (
+																	<TableRow key={t.tipo}>
+																		<TableCell>
+																			{TIPO_LABELS[t.tipo] ?? t.tipo}
+																		</TableCell>
+																		<TableCell className="text-right text-muted-foreground">
+																			{r.esTotal
+																				? "—"
+																				: formatCurrency(r.capital)}
+																		</TableCell>
+																		<TableCell className="text-right text-muted-foreground">
+																			{r.esTotal
+																				? "—"
+																				: formatCurrency(r.interes)}
+																		</TableCell>
+																		<TableCell className="text-right text-muted-foreground">
+																			{r.esTotal ? "—" : formatCurrency(r.iva)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(rowTotal)}
+																		</TableCell>
+																	</TableRow>
+																);
+															})}
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalesReinv.capital)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalesReinv.interes)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalesReinv.iva)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalReinv)}
+															</TableCell>
+														</TableRow>
+													</TableBody>
+												</Table>
+											</div>
 
-										{/* Sección 3: Pagos Extras Recibidos */}
-										<div>
-											<p className="mb-2 text-sm font-semibold">Pagos Extras Recibidos</p>
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Tipo</TableHead>
-														<TableHead className="text-right">Monto</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													<TableRow>
-														<TableCell>Abonos Extra a Capital</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(pagosExtras.abonos_capital))}</TableCell>
-													</TableRow>
-													<TableRow>
-														<TableCell>Cancelaciones</TableCell>
-														<TableCell className="text-right">{formatCurrency(Number(pagosExtras.cancelaciones))}</TableCell>
-													</TableRow>
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalExtras)}</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										</div>
-									</>
-								);
-							})()}
+											{/* Sección 2: Cash (sin reinversión + porciones cash de reinversión parcial) */}
+											<div>
+												<p className="mb-2 font-semibold text-sm">
+													Cuotas → Cash
+												</p>
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Origen</TableHead>
+															<TableHead className="text-right">
+																Capital
+															</TableHead>
+															<TableHead className="text-right">
+																Interés
+															</TableHead>
+															<TableHead className="text-right">
+																IVA 12%
+															</TableHead>
+															<TableHead className="text-right">
+																Total
+															</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														{/* Inversionistas sin reinversión */}
+														<TableRow>
+															<TableCell>Sin Reinversión</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(sinReinversion.totales.capital),
+																)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(sinReinversion.totales.interes),
+																)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(sinReinversion.totales.iva),
+																)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalSinReinv)}
+															</TableCell>
+														</TableRow>
+														{/* Porciones cash de inversionistas con reinversión parcial — combinado */}
+														{cashParcialPorTipo.length > 0 && (
+															<TableRow>
+																<TableCell>
+																	Intereses y excedentes pagados a
+																	inversionistas
+																</TableCell>
+																<TableCell
+																	colSpan={3}
+																	className="text-right text-muted-foreground text-sm"
+																>
+																	capital/interés/IVA según tipo
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(cashParcialTotal)}
+																</TableCell>
+															</TableRow>
+														)}
+														{/* Total general cash */}
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total Cash</TableCell>
+															<TableCell colSpan={3} />
+															<TableCell className="text-right">
+																{formatCurrency(
+																	totalSinReinv + cashParcialTotal,
+																)}
+															</TableCell>
+														</TableRow>
+													</TableBody>
+												</Table>
+											</div>
+
+											{/* Sección 3: Pagos Extras Recibidos */}
+											<div>
+												<p className="mb-2 font-semibold text-sm">
+													Pagos Extras Recibidos
+												</p>
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Tipo</TableHead>
+															<TableHead className="text-right">
+																Monto
+															</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														<TableRow>
+															<TableCell>Abonos Extra a Capital</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(pagosExtras.abonos_capital),
+																)}
+															</TableCell>
+														</TableRow>
+														<TableRow>
+															<TableCell>Cancelaciones</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(
+																	Number(pagosExtras.cancelaciones),
+																)}
+															</TableCell>
+														</TableRow>
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalExtras)}
+															</TableCell>
+														</TableRow>
+													</TableBody>
+												</Table>
+											</div>
+										</>
+									);
+								})()}
 						</CardContent>
 					</Card>
 
@@ -1502,21 +1733,41 @@ function RouteComponent() {
 								</DialogTitle>
 							</DialogHeader>
 							<div className="flex items-center justify-center gap-3 pb-2">
-								<Button variant="outline" size="sm" onClick={() => setMetasAnio((y) => y - 1)}>‹</Button>
-								<span className="w-16 text-center font-semibold">{metasAnio}</span>
-								<Button variant="outline" size="sm" onClick={() => setMetasAnio((y) => y + 1)}>›</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setMetasAnio((y) => y - 1)}
+								>
+									‹
+								</Button>
+								<span className="w-16 text-center font-semibold">
+									{metasAnio}
+								</span>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() => setMetasAnio((y) => y + 1)}
+								>
+									›
+								</Button>
 							</div>
 							{metasQuery.isPending ? (
-								<p className="text-muted-foreground py-4 text-center text-sm">Cargando...</p>
+								<p className="py-4 text-center text-muted-foreground text-sm">
+									Cargando...
+								</p>
 							) : (
 								<div className="grid grid-cols-2 gap-x-10 gap-y-4">
 									{MESES.map((nombreMes, idx) => {
 										const mes = idx + 1;
 										return (
 											<div key={mes} className="flex items-center gap-3">
-												<span className="w-20 shrink-0 font-medium text-sm">{nombreMes}</span>
+												<span className="w-20 shrink-0 font-medium text-sm">
+													{nombreMes}
+												</span>
 												<div className="relative min-w-0 flex-1">
-													<span className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground text-sm font-medium">Q</span>
+													<span className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 font-medium text-muted-foreground text-sm">
+														Q
+													</span>
 													<Input
 														type="text"
 														inputMode="decimal"
@@ -1526,16 +1777,22 @@ function RouteComponent() {
 															focusedMes === mes
 																? (editMetas[mes] ?? "")
 																: editMetas[mes] && Number(editMetas[mes]) > 0
-																	? Number(editMetas[mes]).toLocaleString("es-GT", {
-																			minimumFractionDigits: 2,
-																			maximumFractionDigits: 2,
-																		})
+																	? Number(editMetas[mes]).toLocaleString(
+																			"es-GT",
+																			{
+																				minimumFractionDigits: 2,
+																				maximumFractionDigits: 2,
+																			},
+																		)
 																	: ""
 														}
 														onFocus={() => setFocusedMes(mes)}
 														onBlur={() => setFocusedMes(null)}
 														onChange={(e) => {
-															const raw = e.target.value.replace(/[^0-9.]/g, "");
+															const raw = e.target.value.replace(
+																/[^0-9.]/g,
+																"",
+															);
 															setEditMetas((prev) => ({ ...prev, [mes]: raw }));
 														}}
 													/>
@@ -1546,7 +1803,10 @@ function RouteComponent() {
 								</div>
 							)}
 							<div className="flex justify-end gap-2 pt-2">
-								<Button variant="outline" onClick={() => setMetasModalOpen(false)}>
+								<Button
+									variant="outline"
+									onClick={() => setMetasModalOpen(false)}
+								>
 									Cancelar
 								</Button>
 								<Button onClick={handleGuardarTodo} disabled={isSavingMetas}>
@@ -1559,6 +1819,38 @@ function RouteComponent() {
 						</DialogContent>
 					</Dialog>
 
+					{/* Modales de simulación de escenarios */}
+					<ScenarioModal
+						open={scenarioOpen === "monto"}
+						onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
+						config={montoACobrarConfig}
+						baseData={montoCobrarData?.data}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "facturacion"}
+						onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
+						config={facturacionConfig}
+						baseData={facturacionMesData}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "flujo"}
+						onOpenChange={(o) => setScenarioOpen(o ? "flujo" : null)}
+						config={flujoCuotasConfig}
+						baseData={flujoCuotasData}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "cobertura"}
+						onOpenChange={(o) => setScenarioOpen(o ? "cobertura" : null)}
+						config={coberturaConfig}
+						baseData={puntoEquilibrioData?.data}
+					/>
+					<ScenarioModal
+						open={scenarioOpen === "comparativo"}
+						onOpenChange={(o) => setScenarioOpen(o ? "comparativo" : null)}
+						config={comparativoConfig}
+						baseData={comparativoData?.data}
+					/>
+
 					{/* Cobertura de Colocación vs Meta */}
 					<Card>
 						<CardHeader>
@@ -1568,11 +1860,13 @@ function RouteComponent() {
 									<div>
 										<CardTitle>Cobertura de Colocación vs Meta</CardTitle>
 										<CardDescription>
-											Compara el capital colocado en cada período contra la meta mensual definida
+											Compara el capital colocado en cada período contra la meta
+											mensual definida
 										</CardDescription>
 									</div>
 								</div>
 								<div className="flex flex-wrap items-center gap-2">
+									<SimularButton onClick={() => setScenarioOpen("cobertura")} />
 									<Button
 										variant="outline"
 										size="sm"
@@ -1624,7 +1918,9 @@ function RouteComponent() {
 						</CardHeader>
 						<CardContent className="space-y-4">
 							{puntoEquilibrioQuery.isPending && (
-								<p className="text-muted-foreground text-sm">Cargando reporte...</p>
+								<p className="text-muted-foreground text-sm">
+									Cargando reporte...
+								</p>
 							)}
 							{puntoEquilibrioQuery.isError && (
 								<p className="text-destructive text-sm">
@@ -1636,259 +1932,380 @@ function RouteComponent() {
 									No hay datos de colocación para el rango seleccionado.
 								</p>
 							)}
-							{!!puntoEquilibrioData?.data.length && (() => {
-								const rows = puntoEquilibrioData.data;
-								const totalColocado = rows.reduce((acc, r) => acc + Number(r.colocado), 0);
-								const totalMeta = rows.reduce((acc, r) => acc + Number(r.meta), 0);
-								const totalCreditos = rows.reduce((acc, r) => acc + r.cantidad_creditos, 0);
-								const totalCobertura =
-									totalMeta > 0 ? ((totalColocado / totalMeta) * 100).toFixed(1) : null;
-								return (
-									<>
-										<ResponsiveContainer width="100%" height={300}>
-											<BarChart
-												data={rows.map((row) => ({
-													bucket: formatBucket(row.bucket, equilibrioPeriodo),
-													colocado: Number(row.colocado),
-													meta: Number(row.meta),
-												}))}
-											>
-												<CartesianGrid strokeDasharray="3 3" />
-												<XAxis dataKey="bucket" tick={{ fontSize: 11 }} interval={0} height={36} />
-												<YAxis tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`} />
-												<Tooltip
-													formatter={(value, name) => [
-														formatCurrency(Number(value)),
-														name === "colocado" ? "Colocado" : "Meta",
-													]}
-												/>
-												<Legend formatter={(v) => (v === "colocado" ? "Colocado" : "Meta")} />
-												<Bar dataKey="colocado" fill="#3b82f6" name="colocado" />
-												<Bar dataKey="meta" fill="#d1d5db" name="meta" />
-											</BarChart>
-										</ResponsiveContainer>
+							{!!puntoEquilibrioData?.data.length &&
+								(() => {
+									const rows = puntoEquilibrioData.data;
+									const totalColocado = rows.reduce(
+										(acc, r) => acc + Number(r.colocado),
+										0,
+									);
+									const totalMeta = rows.reduce(
+										(acc, r) => acc + Number(r.meta),
+										0,
+									);
+									const totalCreditos = rows.reduce(
+										(acc, r) => acc + r.cantidad_creditos,
+										0,
+									);
+									const totalCobertura =
+										totalMeta > 0
+											? ((totalColocado / totalMeta) * 100).toFixed(1)
+											: null;
+									return (
+										<>
+											<ResponsiveContainer width="100%" height={300}>
+												<BarChart
+													data={rows.map((row) => ({
+														bucket: formatBucket(row.bucket, equilibrioPeriodo),
+														colocado: Number(row.colocado),
+														meta: Number(row.meta),
+													}))}
+												>
+													<CartesianGrid strokeDasharray="3 3" />
+													<XAxis
+														dataKey="bucket"
+														tick={{ fontSize: 11 }}
+														interval={0}
+														height={36}
+													/>
+													<YAxis
+														tickFormatter={(v) =>
+															`Q${(Number(v) / 1000).toFixed(0)}k`
+														}
+													/>
+													<Tooltip
+														formatter={(value, name) => [
+															formatCurrency(Number(value)),
+															name === "colocado" ? "Colocado" : "Meta",
+														]}
+													/>
+													<Legend
+														formatter={(v) =>
+															v === "colocado" ? "Colocado" : "Meta"
+														}
+													/>
+													<Bar
+														dataKey="colocado"
+														fill="#3b82f6"
+														name="colocado"
+													/>
+													<Bar dataKey="meta" fill="#d1d5db" name="meta" />
+												</BarChart>
+											</ResponsiveContainer>
 
-										<div className="overflow-x-auto">
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Período</TableHead>
-														<TableHead className="text-right">Créditos</TableHead>
-														<TableHead className="text-right">Colocado</TableHead>
-														<TableHead className="text-right">Meta</TableHead>
-														<TableHead className="text-right">Cobertura</TableHead>
-														<TableHead className="text-right">Faltante</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{rows.map((row) => (
-														<TableRow key={row.bucket}>
-															<TableCell>{formatBucket(row.bucket, equilibrioPeriodo)}</TableCell>
-															<TableCell className="text-right">{row.cantidad_creditos}</TableCell>
-															<TableCell className="text-right">{formatCurrency(row.colocado)}</TableCell>
+											<div className="overflow-x-auto">
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Período</TableHead>
+															<TableHead className="text-right">
+																Créditos
+															</TableHead>
+															<TableHead className="text-right">
+																Colocado
+															</TableHead>
+															<TableHead className="text-right">Meta</TableHead>
+															<TableHead className="text-right">
+																Cobertura
+															</TableHead>
+															<TableHead className="text-right">
+																Faltante
+															</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														{rows.map((row) => (
+															<TableRow key={row.bucket}>
+																<TableCell>
+																	{formatBucket(row.bucket, equilibrioPeriodo)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.cantidad_creditos}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(row.colocado)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{Number(row.meta) > 0 ? (
+																		formatCurrency(row.meta)
+																	) : (
+																		<span className="text-muted-foreground">
+																			Sin meta
+																		</span>
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	<span
+																		className="font-semibold"
+																		style={{
+																			color: coberturaColor(row.cobertura),
+																		}}
+																	>
+																		{coberturaLabel(row.cobertura)}
+																	</span>
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.faltante
+																		? formatCurrency(row.faltante)
+																		: "—"}
+																</TableCell>
+															</TableRow>
+														))}
+														<TableRow className="border-t-2 bg-muted/50 font-bold">
+															<TableCell>Total</TableCell>
 															<TableCell className="text-right">
-																{Number(row.meta) > 0 ? formatCurrency(row.meta) : <span className="text-muted-foreground">Sin meta</span>}
+																{totalCreditos}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(totalColocado)}
+															</TableCell>
+															<TableCell className="text-right">
+																{totalMeta > 0
+																	? formatCurrency(totalMeta)
+																	: "—"}
 															</TableCell>
 															<TableCell className="text-right">
 																<span
 																	className="font-semibold"
-																	style={{ color: coberturaColor(row.cobertura) }}
+																	style={{
+																		color: coberturaColor(totalCobertura),
+																	}}
 																>
-																	{coberturaLabel(row.cobertura)}
+																	{coberturaLabel(totalCobertura)}
 																</span>
 															</TableCell>
 															<TableCell className="text-right">
-																{row.faltante ? formatCurrency(row.faltante) : "—"}
+																{totalMeta > 0
+																	? formatCurrency(
+																			Math.max(0, totalMeta - totalColocado),
+																		)
+																	: "—"}
 															</TableCell>
 														</TableRow>
-													))}
+													</TableBody>
+												</Table>
+											</div>
+										</>
+									);
+								})()}
+						</CardContent>
+					</Card>
+
+					{/* ============================================================ */}
+					{/* REPORTE: COMPARATIVO HISTÓRICO MENSUAL                        */}
+					{/* ============================================================ */}
+					<Card>
+						<CardHeader>
+							<div className="flex items-center justify-between">
+								<CardTitle className="flex items-center gap-2">
+									<CalendarDays className="h-5 w-5" />
+									Comparativo Histórico Mensual
+								</CardTitle>
+								<div className="flex items-center gap-2">
+									<SimularButton
+										onClick={() => setScenarioOpen("comparativo")}
+									/>
+									<button
+										type="button"
+										className="rounded p-1 hover:bg-muted"
+										onClick={() => setComparativoAnio((y) => y - 1)}
+									>
+										<ChevronLeft className="h-4 w-4" />
+									</button>
+									<span className="w-12 text-center font-semibold text-sm">
+										{comparativoAnio}
+									</span>
+									<button
+										type="button"
+										className="rounded p-1 hover:bg-muted"
+										onClick={() =>
+											setComparativoAnio((y) =>
+												y < new Date().getFullYear() ? y + 1 : y,
+											)
+										}
+									>
+										<ChevronRight className="h-4 w-4" />
+									</button>
+								</div>
+							</div>
+						</CardHeader>
+						<CardContent>
+							{comparativoQuery.isPending && (
+								<p className="py-4 text-center text-muted-foreground text-sm">
+									Cargando...
+								</p>
+							)}
+							{comparativoQuery.isError && (
+								<p className="py-4 text-center text-red-500 text-sm">
+									Error al cargar comparativo histórico.
+								</p>
+							)}
+							{comparativoData &&
+								(() => {
+									const rows = comparativoData.data;
+									const sumColoc = rows.reduce(
+										(acc, r) =>
+											acc +
+											(r.colocacion_monto ? Number(r.colocacion_monto) : 0),
+										0,
+									);
+									const sumFacturacion = rows.reduce(
+										(acc, r) =>
+											acc + (r.facturacion ? Number(r.facturacion) : 0),
+										0,
+									);
+									const sumCreditosColoc = rows.reduce(
+										(acc, r) => acc + (r.colocacion_creditos ?? 0),
+										0,
+									);
+									return (
+										<div className="overflow-x-auto">
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Mes</TableHead>
+														<TableHead className="text-right">
+															Colocación (Q)
+														</TableHead>
+														<TableHead className="text-right"># Col.</TableHead>
+														<TableHead className="text-right">
+															Facturación (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Cartera Activa (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															# Activos
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 30 (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 60 (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 90 (Q)
+														</TableHead>
+														<TableHead className="text-right">
+															Mora 120+ (Q)
+														</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{rows.map((row) => {
+														const esFuturo =
+															row.colocacion_monto === null &&
+															row.facturacion === null &&
+															row.cartera_activa === null;
+														return (
+															<TableRow
+																key={row.mes}
+																className={esFuturo ? "opacity-40" : undefined}
+															>
+																<TableCell className="font-medium">
+																	{MESES[row.mes - 1]}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.colocacion_monto
+																		? formatCurrency(
+																				Number(row.colocacion_monto),
+																			)
+																		: "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.colocacion_creditos ?? "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.facturacion
+																		? formatCurrency(Number(row.facturacion))
+																		: "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.cartera_activa
+																		? formatCurrency(Number(row.cartera_activa))
+																		: "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.creditos_activos ?? "—"}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_30 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_30))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_30 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_60 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_60))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_60 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_90 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_90))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_90 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{row.mora_120 ? (
+																		<span>
+																			{formatCurrency(Number(row.mora_120))}
+																			<span className="ml-1 text-muted-foreground text-xs">
+																				({row.creditos_120 ?? 0})
+																			</span>
+																		</span>
+																	) : (
+																		"—"
+																	)}
+																</TableCell>
+															</TableRow>
+														);
+													})}
 													<TableRow className="border-t-2 bg-muted/50 font-bold">
 														<TableCell>Total</TableCell>
-														<TableCell className="text-right">{totalCreditos}</TableCell>
-														<TableCell className="text-right">{formatCurrency(totalColocado)}</TableCell>
 														<TableCell className="text-right">
-															{totalMeta > 0 ? formatCurrency(totalMeta) : "—"}
+															{formatCurrency(sumColoc)}
 														</TableCell>
 														<TableCell className="text-right">
-															<span
-																className="font-semibold"
-																style={{ color: coberturaColor(totalCobertura) }}
-															>
-																{coberturaLabel(totalCobertura)}
-															</span>
+															{sumCreditosColoc}
 														</TableCell>
 														<TableCell className="text-right">
-															{totalMeta > 0
-																? formatCurrency(Math.max(0, totalMeta - totalColocado))
-																: "—"}
+															{formatCurrency(sumFacturacion)}
 														</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
+														<TableCell className="text-right">—</TableCell>
 													</TableRow>
 												</TableBody>
 											</Table>
 										</div>
-									</>
-								);
-							})()}
+									);
+								})()}
 						</CardContent>
 					</Card>
-
-				{/* ============================================================ */}
-				{/* REPORTE: COMPARATIVO HISTÓRICO MENSUAL                        */}
-				{/* ============================================================ */}
-				<Card>
-					<CardHeader>
-						<div className="flex items-center justify-between">
-							<CardTitle className="flex items-center gap-2">
-								<CalendarDays className="h-5 w-5" />
-								Comparativo Histórico Mensual
-							</CardTitle>
-							<div className="flex items-center gap-2">
-								<button
-									type="button"
-									className="rounded p-1 hover:bg-muted"
-									onClick={() => setComparativoAnio((y) => y - 1)}
-								>
-									<ChevronLeft className="h-4 w-4" />
-								</button>
-								<span className="font-semibold text-sm w-12 text-center">
-									{comparativoAnio}
-								</span>
-								<button
-									type="button"
-									className="rounded p-1 hover:bg-muted"
-									onClick={() =>
-										setComparativoAnio((y) =>
-											y < new Date().getFullYear() ? y + 1 : y,
-										)
-									}
-								>
-									<ChevronRight className="h-4 w-4" />
-								</button>
-							</div>
-						</div>
-					</CardHeader>
-					<CardContent>
-						{comparativoQuery.isPending && (
-							<p className="text-sm text-muted-foreground py-4 text-center">
-								Cargando...
-							</p>
-						)}
-						{comparativoQuery.isError && (
-							<p className="text-sm text-red-500 py-4 text-center">
-								Error al cargar comparativo histórico.
-							</p>
-						)}
-						{comparativoData && (() => {
-							const rows = comparativoData.data;
-							const sumColoc = rows.reduce(
-								(acc, r) => acc + (r.colocacion_monto ? Number(r.colocacion_monto) : 0),
-								0,
-							);
-							const sumFacturacion = rows.reduce(
-								(acc, r) => acc + (r.facturacion ? Number(r.facturacion) : 0),
-								0,
-							);
-							const sumCreditosColoc = rows.reduce(
-								(acc, r) => acc + (r.colocacion_creditos ?? 0),
-								0,
-							);
-							return (
-								<div className="overflow-x-auto">
-									<Table>
-										<TableHeader>
-											<TableRow>
-												<TableHead>Mes</TableHead>
-												<TableHead className="text-right">Colocación (Q)</TableHead>
-												<TableHead className="text-right"># Col.</TableHead>
-												<TableHead className="text-right">Facturación (Q)</TableHead>
-												<TableHead className="text-right">Cartera Activa (Q)</TableHead>
-												<TableHead className="text-right"># Activos</TableHead>
-												<TableHead className="text-right">Mora 30 (Q)</TableHead>
-												<TableHead className="text-right">Mora 60 (Q)</TableHead>
-												<TableHead className="text-right">Mora 90 (Q)</TableHead>
-												<TableHead className="text-right">Mora 120+ (Q)</TableHead>
-											</TableRow>
-										</TableHeader>
-										<TableBody>
-											{rows.map((row) => {
-												const esFuturo =
-													row.colocacion_monto === null &&
-													row.facturacion === null &&
-													row.cartera_activa === null;
-												return (
-													<TableRow
-														key={row.mes}
-														className={esFuturo ? "opacity-40" : undefined}
-													>
-														<TableCell className="font-medium">
-															{MESES[row.mes - 1]}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.colocacion_monto
-																? formatCurrency(Number(row.colocacion_monto))
-																: "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.colocacion_creditos ?? "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.facturacion
-																? formatCurrency(Number(row.facturacion))
-																: "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.cartera_activa
-																? formatCurrency(Number(row.cartera_activa))
-																: "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.creditos_activos ?? "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_30 ? <span>{formatCurrency(Number(row.mora_30))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_30 ?? 0})</span></span> : "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_60 ? <span>{formatCurrency(Number(row.mora_60))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_60 ?? 0})</span></span> : "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_90 ? <span>{formatCurrency(Number(row.mora_90))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_90 ?? 0})</span></span> : "—"}
-														</TableCell>
-														<TableCell className="text-right">
-															{row.mora_120 ? <span>{formatCurrency(Number(row.mora_120))}<span className="text-muted-foreground text-xs ml-1">({row.creditos_120 ?? 0})</span></span> : "—"}
-														</TableCell>
-													</TableRow>
-												);
-											})}
-										</TableBody>
-										<TableBody>
-											<TableRow className="border-t-2 bg-muted/50 font-bold">
-												<TableCell>Total</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(sumColoc)}
-												</TableCell>
-												<TableCell className="text-right">
-													{sumCreditosColoc}
-												</TableCell>
-												<TableCell className="text-right">
-													{formatCurrency(sumFacturacion)}
-												</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-												<TableCell className="text-right">—</TableCell>
-											</TableRow>
-										</TableBody>
-									</Table>
-								</div>
-							);
-						})()}
-					</CardContent>
-				</Card>
 				</>
 			)}
-
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -329,7 +329,7 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 	});
 
 	const { data: asesoresData } = useQuery({
-		...orpc.getAsesores.queryOptions({ input: {} }),
+		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
 		enabled: !!session && canSeeAll,
 	});
 
@@ -563,7 +563,7 @@ function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof auth
 	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
 
 	const { data: asesoresData } = useQuery({
-		...orpc.getAsesores.queryOptions({ input: {} }),
+		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
 		enabled: !!session && canSeeAll,
 	});
 

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -1,0 +1,670 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
+import { BarChart3, CalendarClock, RefreshCw, TrendingDown } from "lucide-react";
+import { useState } from "react";
+import { CapitalRangeFilter } from "@/components/cobros/capital-range-filter";
+import { DataTable } from "@/components/data-table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { usePersistedState } from "@/hooks/usePersistedState";
+import { authClient } from "@/lib/auth-client";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/reportes")({
+	component: RouteComponent,
+});
+
+// ─── shared helpers ────────────────────────────────────────────────────────
+
+function fmtQ(v: string | number) {
+	const n = parseFloat(String(v));
+	return `Q${isNaN(n) ? "0.00" : n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function fmtTime(d: Date) {
+	return d.toLocaleTimeString("es-GT", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+// ─── Mora ──────────────────────────────────────────────────────────────────
+
+const ETAPAS = [
+	{ key: "mora_30" as const, label: "Mora 30", color: "bg-yellow-100 text-yellow-800" },
+	{ key: "mora_60" as const, label: "Mora 60", color: "bg-orange-100 text-orange-800" },
+	{ key: "mora_90" as const, label: "Mora 90", color: "bg-red-100 text-red-800" },
+	{ key: "mora_120_plus" as const, label: "Mora 120+", color: "bg-red-300 text-red-950" },
+];
+
+function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
+	const emailCobrador = canSeeAll ? undefined : (session?.user?.email ?? undefined);
+
+	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
+		...orpc.getMoraByEtapaYAsesor.queryOptions({ input: { emailCobrador } }),
+		enabled: !!session,
+		refetchInterval: 60_000,
+		refetchIntervalInBackground: false,
+	});
+
+	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<TrendingDown className="h-5 w-5 text-red-600" />
+					<h2 className="font-semibold text-xl">Análisis de Mora</h2>
+				</div>
+				<div className="flex items-center gap-3">
+					{ultimaAct && (
+						<span className="text-muted-foreground text-xs">Actualizado: {ultimaAct}</span>
+					)}
+					<Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
+						<RefreshCw className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+						Actualizar
+					</Button>
+				</div>
+			</div>
+
+			{isLoading ? (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{ETAPAS.map((e) => (
+						<Card key={e.key}><CardContent className="pt-6"><div className="h-12 animate-pulse rounded bg-muted" /></CardContent></Card>
+					))}
+				</div>
+			) : (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{ETAPAS.map((etapa) => {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const bucket = (data as any)?.totales?.[etapa.key];
+						return (
+							<Card key={etapa.key}>
+								<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+									<CardTitle className="font-medium text-sm">{etapa.label}</CardTitle>
+									<Badge className={etapa.color}>{bucket?.cantidad ?? 0}</Badge>
+								</CardHeader>
+								<CardContent>
+									<div className="font-bold text-2xl">{fmtQ(bucket?.sumaMora ?? "0")}</div>
+									<p className="text-muted-foreground text-xs">Capital: {fmtQ(bucket?.sumaCapital ?? "0")}</p>
+								</CardContent>
+							</Card>
+						);
+					})}
+				</div>
+			)}
+
+			{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+			{!!(data as any)?.totales?.totalEnMora && (
+				<Card className="border-red-200 bg-red-50">
+					<CardContent className="pt-4">
+						<div className="flex items-center justify-between">
+							<div>
+								<p className="font-semibold text-sm text-red-700">Total en Mora</p>
+								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+								<p className="font-bold text-3xl text-red-800">{fmtQ((data as any).totales.totalEnMora.sumaMora)}</p>
+							</div>
+							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+							<div className="text-right"><p className="text-muted-foreground text-sm">Créditos</p><p className="font-bold text-2xl">{(data as any).totales.totalEnMora.cantidad}</p></div>
+						</div>
+					</CardContent>
+				</Card>
+			)}
+
+			<div>
+				<h3 className="mb-3 font-semibold text-base">Desglose por Asesor</h3>
+				{isLoading ? (
+					<div className="h-32 animate-pulse rounded bg-muted" />
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				) : !(data as any)?.porAsesor?.length ? (
+					<p className="text-muted-foreground text-sm">No hay datos disponibles.</p>
+				) : (
+					<div className="overflow-x-auto rounded-lg border">
+						<table className="w-full text-sm">
+							<thead className="bg-muted/50">
+								<tr>
+									<th className="px-4 py-3 text-left font-semibold">Asesor</th>
+									{ETAPAS.map((e) => <th key={e.key} className="px-4 py-3 text-right font-semibold">{e.label}</th>)}
+									<th className="px-4 py-3 text-right font-semibold">Total en Mora</th>
+								</tr>
+							</thead>
+							<tbody>
+								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+								{(data as any).porAsesor.map((asesor: any) => (
+									<tr key={asesor.asesorId} className="border-t hover:bg-muted/30">
+										<td className="px-4 py-3 font-medium">{asesor.nombre}</td>
+										{ETAPAS.map((etapa) => {
+											const bucket = asesor[etapa.key];
+											return (
+												<td key={etapa.key} className="px-4 py-3 text-right">
+													{bucket?.cantidad > 0 ? (
+														<div>
+															<div className="font-medium">{fmtQ(bucket.sumaMora)}</div>
+															<div className="text-muted-foreground text-xs">{bucket.cantidad} créd.</div>
+														</div>
+													) : <span className="text-muted-foreground">—</span>}
+												</td>
+											);
+										})}
+										<td className="px-4 py-3 text-right">
+											<div className="font-semibold text-red-700">{fmtQ(asesor.totalEnMora?.sumaMora ?? "0")}</div>
+											<div className="text-muted-foreground text-xs">{asesor.totalEnMora?.cantidad ?? 0} créd.</div>
+										</td>
+									</tr>
+								))}
+							</tbody>
+							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+							{!!(data as any)?.totales && (
+								<tfoot className="border-t-2 bg-muted/50 font-semibold">
+									<tr>
+										<td className="px-4 py-3">TOTAL</td>
+										{ETAPAS.map((etapa) => {
+											// eslint-disable-next-line @typescript-eslint/no-explicit-any
+											const bucket = (data as any).totales[etapa.key];
+											return (
+												<td key={etapa.key} className="px-4 py-3 text-right">
+													<div>{fmtQ(bucket?.sumaMora ?? "0")}</div>
+													<div className="font-normal text-muted-foreground text-xs">{bucket?.cantidad ?? 0} créd.</div>
+												</td>
+											);
+										})}
+										<td className="px-4 py-3 text-right text-red-700">
+											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+											<div>{fmtQ((data as any).totales.totalEnMora?.sumaMora ?? "0")}</div>
+											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+											<div className="font-normal text-muted-foreground text-xs">{(data as any).totales.totalEnMora?.cantidad ?? 0} créd.</div>
+										</td>
+									</tr>
+								</tfoot>
+							)}
+						</table>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+// ─── Pagos Esperados ────────────────────────────────────────────────────────
+
+type Temporalidad = "hoy" | "semana" | "quincena" | "mes";
+
+const TEMPORALIDAD_LABELS: Record<Temporalidad, string> = {
+	hoy: "Hoy",
+	semana: "Esta Semana",
+	quincena: "Esta Quincena",
+	mes: "Este Mes",
+};
+
+const RUBROS = [
+	{ key: "totalCuota" as const, label: "Total a Cobrar", highlight: true },
+	{ key: "capital" as const, label: "Capital" },
+	{ key: "interes" as const, label: "Interés" },
+	{ key: "iva" as const, label: "IVA" },
+	{ key: "seguro" as const, label: "Seguro" },
+	{ key: "gps" as const, label: "GPS" },
+	{ key: "membresias" as const, label: "Membresías" },
+	{ key: "royalti" as const, label: "Royaltí" },
+];
+
+type DesgloseDia = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	total_royalti: string;
+};
+
+// Buckets date-only se parsean como mediodía local para evitar que el
+// offset de zona horaria los desplace al día anterior.
+function fmtBucketDia(bucket: string) {
+	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
+	return date.toLocaleDateString("es-GT", { weekday: "short", day: "2-digit", month: "short" });
+}
+
+// `total_cuota` de cartera-back es el capital; el total a cobrar de la fila
+// es la suma de rubros (mismo criterio que el reporte monto-a-cobrar).
+function totalDeFila(row: DesgloseDia) {
+	return (
+		parseFloat(row.total_cuota) +
+		parseFloat(row.total_interes) +
+		parseFloat(row.total_iva) +
+		parseFloat(row.total_seguro) +
+		parseFloat(row.total_gps) +
+		parseFloat(row.total_membresias)
+	);
+}
+
+type PagoNoRecibido = {
+	sifco: string;
+	clienteNombre: string;
+	asesorNombre: string;
+	cuotasAtrasadas: number;
+	montoMora: string;
+	capital: string;
+	cuotaMensual: string;
+	proximaFechaVencimiento: string | null;
+	tipoCredito: string | null;
+};
+
+function getMoraBadge(cuotas: number) {
+	if (cuotas >= 4) return <Badge className="bg-red-300 text-red-950">Mora 120+</Badge>;
+	if (cuotas === 3) return <Badge className="bg-red-100 text-red-800">Mora 90</Badge>;
+	if (cuotas === 2) return <Badge className="bg-orange-100 text-orange-800">Mora 60</Badge>;
+	return <Badge className="bg-yellow-100 text-yellow-800">Mora 30</Badge>;
+}
+
+const colsPagos: ColumnDef<PagoNoRecibido>[] = [
+	{
+		accessorKey: "sifco",
+		header: "Crédito",
+		cell: ({ row }) => (
+			<Link to="/cobros/$id" params={{ id: row.original.sifco }} search={{ tipo: "contrato" }} className="font-mono text-blue-600 text-xs hover:underline">
+				{row.original.sifco}
+			</Link>
+		),
+	},
+	{ accessorKey: "clienteNombre", header: "Cliente" },
+	{ accessorKey: "asesorNombre", header: "Asesor" },
+	{
+		accessorKey: "cuotasAtrasadas",
+		header: "Cuotas Atrasadas",
+		cell: ({ row }) => getMoraBadge(row.original.cuotasAtrasadas),
+	},
+	{
+		accessorKey: "montoMora",
+		header: "Monto Mora",
+		cell: ({ row }) => <span className="font-medium text-red-700">{fmtQ(row.original.montoMora)}</span>,
+	},
+	{ accessorKey: "capital", header: "Capital Restante", cell: ({ row }) => fmtQ(row.original.capital) },
+	{ accessorKey: "cuotaMensual", header: "Cuota Mensual", cell: ({ row }) => fmtQ(row.original.cuotaMensual) },
+	{
+		accessorKey: "proximaFechaVencimiento",
+		header: "Próx. Vencimiento",
+		cell: ({ row }) =>
+			row.original.proximaFechaVencimiento
+				? new Date(`${row.original.proximaFechaVencimiento}T00:00:00`).toLocaleDateString("es-GT")
+				: "—",
+	},
+];
+
+function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
+	const [temporalidad, setTemporalidad] = usePersistedState<Temporalidad>("cobros/reportes/temporalidad", "hoy");
+	const [emailAsesor, setEmailAsesor] = usePersistedState<string>("cobros/reportes/pagos/emailAsesor", "");
+	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>("cobros/reportes/pagos/capitalMin", undefined);
+	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>("cobros/reportes/pagos/capitalMax", undefined);
+	const [cuotasMin, setCuotasMin] = usePersistedState<string>("cobros/reportes/pagos/cuotasMin", "");
+	const [cuotasMax, setCuotasMax] = usePersistedState<string>("cobros/reportes/pagos/cuotasMax", "");
+	const [fechaDesde, setFechaDesde] = usePersistedState<string>("cobros/reportes/pagos/fechaDesde", "");
+	const [fechaHasta, setFechaHasta] = usePersistedState<string>("cobros/reportes/pagos/fechaHasta", "");
+	const [page, setPage] = usePersistedState<number>("cobros/reportes/pagos/page", 1);
+	const [pageSize] = usePersistedState<number>("cobros/reportes/pagos/pageSize", 25);
+
+	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
+
+	const { data: resumenData, isLoading: resumenLoading, dataUpdatedAt, refetch: refetchResumen, isFetching: resumenFetching } = useQuery({
+		...orpc.getPagosEsperadosCobros.queryOptions({ input: { temporalidad } }),
+		enabled: !!session,
+		staleTime: 5 * 60 * 1000,
+	});
+
+	const { data: asesoresData } = useQuery({
+		...orpc.getAsesores.queryOptions({ input: {} }),
+		enabled: !!session && canSeeAll,
+	});
+
+	const { data: noRecibidosData, isLoading: noRecibidosLoading } = useQuery({
+		...orpc.getPagosNoRecibidos.queryOptions({
+			input: {
+				emailCobrador,
+				capitalMin,
+				capitalMax,
+				cuotasAtrasadasMin: cuotasMin ? parseInt(cuotasMin, 10) : undefined,
+				cuotasAtrasadasMax: cuotasMax ? parseInt(cuotasMax, 10) : undefined,
+				fechaDesde: fechaDesde || undefined,
+				fechaHasta: fechaHasta || undefined,
+				page,
+				pageSize,
+			},
+		}),
+		enabled: !!session,
+		staleTime: 5 * 60 * 1000,
+	});
+
+	const ultimaAct = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleTimeString("es-GT", { hour: "2-digit", minute: "2-digit" }) : null;
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center gap-2">
+				<CalendarClock className="h-5 w-5 text-blue-600" />
+				<h2 className="font-semibold text-xl">Pagos Esperados</h2>
+			</div>
+
+			{/* Período selector */}
+			<div className="flex flex-wrap items-center gap-2">
+				<span className="font-medium text-sm">Período:</span>
+				{(Object.keys(TEMPORALIDAD_LABELS) as Temporalidad[]).map((t) => (
+					<Button key={t} variant={temporalidad === t ? "default" : "outline"} size="sm" onClick={() => setTemporalidad(t)}>
+						{TEMPORALIDAD_LABELS[t]}
+					</Button>
+				))}
+				<div className="ml-auto flex items-center gap-2">
+					{ultimaAct && <span className="text-muted-foreground text-xs">Actualizado: {ultimaAct}</span>}
+					<Button variant="outline" size="sm" onClick={() => refetchResumen()} disabled={resumenFetching}>
+						<RefreshCw className={`mr-2 h-4 w-4 ${resumenFetching ? "animate-spin" : ""}`} />
+						Actualizar
+					</Button>
+				</div>
+			</div>
+
+			{resumenLoading ? (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{RUBROS.map((r) => <Card key={r.key}><CardContent className="pt-6"><div className="h-10 animate-pulse rounded bg-muted" /></CardContent></Card>)}
+				</div>
+			) : (
+				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+					{RUBROS.map((r) => {
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const value = (resumenData as any)?.totales?.[r.key] as string | number | undefined;
+						return (
+							<Card key={r.key} className={r.highlight ? "border-blue-200 bg-blue-50" : ""}>
+								<CardHeader className="pb-2">
+									<CardTitle className={`font-medium text-sm ${r.highlight ? "text-blue-700" : ""}`}>{r.label}</CardTitle>
+								</CardHeader>
+								<CardContent>
+									<div className={`font-bold text-xl ${r.highlight ? "text-blue-800" : ""}`}>{fmtQ(String(value ?? "0"))}</div>
+								</CardContent>
+							</Card>
+						);
+					})}
+					<Card>
+						<CardHeader className="pb-2"><CardTitle className="font-medium text-sm">Cant. Cuotas</CardTitle></CardHeader>
+						{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+						<CardContent><div className="font-bold text-xl">{(resumenData as any)?.totales?.cantidadCuotas ?? 0}</div></CardContent>
+					</Card>
+				</div>
+			)}
+
+			{!!resumenData && (
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				<p className="text-muted-foreground text-xs">Período: {(resumenData as any).fechaInicio} → {(resumenData as any).fechaFin}</p>
+			)}
+
+			{(() => {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				const desglose = ((resumenData as any)?.desglose ?? []) as DesgloseDia[];
+				if (temporalidad === "hoy" || desglose.length <= 1) return null;
+				return (
+					<div>
+						<h3 className="mb-3 font-semibold text-base">Desglose por Día</h3>
+						<div className="overflow-x-auto rounded-lg border">
+							<table className="w-full text-sm">
+								<thead className="bg-muted/50">
+									<tr>
+										<th className="px-4 py-3 text-left font-semibold">Fecha</th>
+										<th className="px-4 py-3 text-right font-semibold">Cuotas</th>
+										<th className="px-4 py-3 text-right font-semibold">Capital</th>
+										<th className="px-4 py-3 text-right font-semibold">Interés</th>
+										<th className="px-4 py-3 text-right font-semibold">IVA</th>
+										<th className="px-4 py-3 text-right font-semibold">Total a Cobrar</th>
+									</tr>
+								</thead>
+								<tbody>
+									{desglose.map((row) => (
+										<tr key={row.bucket} className="border-t hover:bg-muted/30">
+											<td className="px-4 py-3 font-medium">{fmtBucketDia(row.bucket)}</td>
+											<td className="px-4 py-3 text-right">{row.cuotas_count}</td>
+											<td className="px-4 py-3 text-right">{fmtQ(row.total_cuota)}</td>
+											<td className="px-4 py-3 text-right">{fmtQ(row.total_interes)}</td>
+											<td className="px-4 py-3 text-right">{fmtQ(row.total_iva)}</td>
+											<td className="px-4 py-3 text-right font-medium">{fmtQ(totalDeFila(row))}</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+						</div>
+					</div>
+				);
+			})()}
+
+			<Separator />
+
+			<h3 className="font-semibold text-base">Pagos No Recibidos</h3>
+
+			<div className="flex flex-wrap items-end gap-4">
+				{canSeeAll && (
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Asesor</Label>
+						<Select value={emailAsesor} onValueChange={(v) => { setEmailAsesor(v === "todos" ? "" : v); setPage(1); }}>
+							<SelectTrigger className="w-52"><SelectValue placeholder="Todos los asesores" /></SelectTrigger>
+							<SelectContent>
+								<SelectItem value="todos">Todos</SelectItem>
+								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+								{(asesoresData as any)?.asesores?.map((a: any) => <SelectItem key={a.asesorId} value={a.email}>{a.nombre}</SelectItem>)}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+				<CapitalRangeFilter capitalMin={capitalMin} capitalMax={capitalMax} onCapitalRangeChange={(min, max) => { setCapitalMin(min); setCapitalMax(max); setPage(1); }} />
+				<div className="flex items-end gap-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Cuotas atrasadas mín.</Label>
+						<Input type="number" min={1} className="w-24" placeholder="1" value={cuotasMin} onChange={(e) => { setCuotasMin(e.target.value); setPage(1); }} />
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Cuotas atrasadas máx.</Label>
+						<Input type="number" min={1} className="w-24" placeholder="—" value={cuotasMax} onChange={(e) => { setCuotasMax(e.target.value); setPage(1); }} />
+					</div>
+				</div>
+				<div className="flex items-end gap-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Fecha pago desde</Label>
+						<Input type="date" className="w-40" value={fechaDesde} onChange={(e) => { setFechaDesde(e.target.value); setPage(1); }} />
+					</div>
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Fecha pago hasta</Label>
+						<Input type="date" className="w-40" value={fechaHasta} onChange={(e) => { setFechaHasta(e.target.value); setPage(1); }} />
+					</div>
+				</div>
+			</div>
+
+			<DataTable
+				columns={colsPagos}
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				data={(noRecibidosData as any)?.data ?? []}
+				isLoading={noRecibidosLoading}
+				hideSearch
+				serverPagination={
+					noRecibidosData
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						? { page: (noRecibidosData as any).page, pageSize: (noRecibidosData as any).pageSize, totalPages: (noRecibidosData as any).totalPages, totalItems: (noRecibidosData as any).total, onPageChange: setPage }
+						: undefined
+				}
+			/>
+		</div>
+	);
+}
+
+// ─── Descuentos ─────────────────────────────────────────────────────────────
+
+type DescuentoRow = {
+	sifco: string;
+	clienteNombre: string;
+	asesorNombre: string;
+	gps: string;
+	seguro: string;
+	membresias: string;
+	otros: string;
+	rubros: { nombre: string; monto: string }[];
+	rubrosTotal: string;
+	totalDescuentos: string;
+	capital: string;
+	tipoCredito: string | null;
+};
+
+const colsDescuentos: ColumnDef<DescuentoRow>[] = [
+	{
+		accessorKey: "sifco",
+		header: "Crédito",
+		cell: ({ row }) => (
+			<Link to="/cobros/$id" params={{ id: row.original.sifco }} search={{ tipo: "contrato" }} className="font-mono text-blue-600 text-xs hover:underline">
+				{row.original.sifco}
+			</Link>
+		),
+	},
+	{ accessorKey: "clienteNombre", header: "Cliente" },
+	{ accessorKey: "asesorNombre", header: "Asesor" },
+	{ accessorKey: "capital", header: "Capital", cell: ({ row }) => fmtQ(row.original.capital) },
+	{ accessorKey: "gps", header: "GPS", cell: ({ row }) => fmtQ(row.original.gps) },
+	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtQ(row.original.seguro) },
+	{ accessorKey: "membresias", header: "Membresías", cell: ({ row }) => fmtQ(row.original.membresias) },
+	{ accessorKey: "otros", header: "Otros", cell: ({ row }) => fmtQ(row.original.otros) },
+	{
+		accessorKey: "rubrosTotal",
+		header: "Rubros Extra",
+		cell: ({ row }) => {
+			const monto = fmtQ(row.original.rubrosTotal);
+			if (parseFloat(row.original.rubrosTotal) <= 0) return <span className="text-muted-foreground">—</span>;
+			return <div title={row.original.rubros.map((r) => `${r.nombre}: ${fmtQ(r.monto)}`).join("\n")}>{monto}</div>;
+		},
+	},
+	{
+		accessorKey: "totalDescuentos",
+		header: "Total Descuentos",
+		cell: ({ row }) => <span className="font-semibold">{fmtQ(row.original.totalDescuentos)}</span>,
+	},
+];
+
+function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
+	const [emailAsesor, setEmailAsesor] = usePersistedState<string>("cobros/reportes/desc/emailAsesor", "");
+	const [page, setPage] = usePersistedState<number>("cobros/reportes/desc/page", 1);
+	const [pageSize] = usePersistedState<number>("cobros/reportes/desc/pageSize", 25);
+
+	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
+
+	const { data: asesoresData } = useQuery({
+		...orpc.getAsesores.queryOptions({ input: {} }),
+		enabled: !!session && canSeeAll,
+	});
+
+	const { data, isLoading } = useQuery({
+		...orpc.getDescuentosCRM.queryOptions({ input: { page, pageSize, emailCobrador } }),
+		enabled: !!session,
+		staleTime: 5 * 60 * 1000,
+	});
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center gap-2">
+				<BarChart3 className="h-5 w-5 text-purple-600" />
+				<h2 className="font-semibold text-xl">Descuentos por Crédito</h2>
+			</div>
+
+			{canSeeAll && (
+				<div className="flex flex-col gap-1">
+					<Label className="text-xs">Asesor</Label>
+					<Select value={emailAsesor} onValueChange={(v) => { setEmailAsesor(v === "todos" ? "" : v); setPage(1); }}>
+						<SelectTrigger className="w-52"><SelectValue placeholder="Todos los asesores" /></SelectTrigger>
+						<SelectContent>
+							<SelectItem value="todos">Todos</SelectItem>
+							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+							{(asesoresData as any)?.asesores?.map((a: any) => <SelectItem key={a.asesorId} value={a.email}>{a.nombre}</SelectItem>)}
+						</SelectContent>
+					</Select>
+				</div>
+			)}
+
+			<DataTable
+				columns={colsDescuentos}
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				data={(data as any)?.data ?? []}
+				isLoading={isLoading}
+				hideSearch
+				serverPagination={
+					data
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						? { page: (data as any).page, pageSize: (data as any).pageSize, totalPages: (data as any).totalPages, totalItems: (data as any).total, onPageChange: setPage }
+						: undefined
+				}
+			/>
+		</div>
+	);
+}
+
+// ─── Root ───────────────────────────────────────────────────────────────────
+
+function RouteComponent() {
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user.role;
+	const canSeeAll = PERMISSIONS.canAssignCobros(userRole ?? "");
+	const [tab, setTab] = useState("mora");
+
+	// Reportes restringidos a admin/supervisor de cobros. Los endpoints ya
+	// devuelven 403 a otros roles; aquí evitamos renderizar la página rota.
+	if (session && !canSeeAll) {
+		return (
+			<div className="space-y-2 p-6">
+				<h1 className="font-bold text-2xl">Reportes de Cobros</h1>
+				<p className="text-muted-foreground">
+					No tienes permiso para ver estos reportes.
+				</p>
+			</div>
+		);
+	}
+
+	return (
+		<div className="space-y-6 p-6">
+			<div className="flex items-center gap-2">
+				<BarChart3 className="h-6 w-6 text-blue-600" />
+				<h1 className="font-bold text-2xl">Reportes de Cobros</h1>
+			</div>
+
+			<Tabs value={tab} onValueChange={setTab}>
+				<TabsList>
+					<TabsTrigger value="mora">
+						<TrendingDown className="mr-2 h-4 w-4" />
+						Análisis de Mora
+					</TabsTrigger>
+					<TabsTrigger value="pagos">
+						<CalendarClock className="mr-2 h-4 w-4" />
+						Pagos Esperados
+					</TabsTrigger>
+					<TabsTrigger value="descuentos">
+						<BarChart3 className="mr-2 h-4 w-4" />
+						Descuentos
+					</TabsTrigger>
+				</TabsList>
+
+				<TabsContent value="mora" className="mt-6">
+					<TabMora session={session} canSeeAll={canSeeAll} />
+				</TabsContent>
+				<TabsContent value="pagos" className="mt-6">
+					<TabPagos session={session} canSeeAll={canSeeAll} />
+				</TabsContent>
+				<TabsContent value="descuentos" className="mt-6">
+					<TabDescuentos session={session} canSeeAll={canSeeAll} />
+				</TabsContent>
+			</Tabs>
+		</div>
+	);
+}


### PR DESCRIPTION
# 🚀 Pase a Producción — `develop` → `main`

Release de los cambios acumulados en `develop`. Resumen general por área:

## 📊 Reportes
- Simulador de escenarios "qué pasaría si" en reportes admin
- Corrección en `gapClose`: clampear cada palanca antes de sumar

## 📈 Reportes de Cobros
- Nuevos reportes de cobros: mora, pagos esperados, no recibidos y descuentos
- Correcciones de cálculo atendiendo review

## 💳 Cartera
- Reasignación manual de inversionista conserva la modalidad (`tipo_reinversion`) tanto en compras como en el espejo destino
- Royalty calculado **solo sobre lo facturado**, con dedup por NIT, NIT normalizado / case-insensitive y ventana de mes completo
- Captura de facturas genéricas en el desglose para el reporte diario + clasificación de rubro
- Desglose genérico: fecha sin doble shift y limpieza al anular
- Cron regenera los últimos días del snapshot + endpoint `regenerar-rango`

## 👥 CRM
- Clasificación de las facturas del cierre con `rubro_desglose` para el reporte

## 🧯 Manejo de errores de API
- Mostrar el motivo real de los errores de API en la UI (varios hooks)
- Normalización, firmas técnicas de error y mejoras de traducción/capitalización

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
