### PR TITLE
Fix: Add unique VIN number validation to vehicle creation

### DIFF
--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -511,6 +511,11 @@ export const vehiclesRouter = {
 						message: `Ya existe un vehículo con la placa "${input.licensePlate}"`,
 					});
 				}
+				if (isUniqueViolation(error, "vehicles_vin_number_unique")) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: `Ya existe un vehículo con el número de VIN "${input.vinNumber}"`,
+					});
+				}
 				throw error;
 			}
 		}),


### PR DESCRIPTION
**Vehicles.ts**
En /vehicles, al crear un vehículo nuevo con un VIN duplicado salía "Internal Server Error" en vez del mensaje descriptivo (con placa duplicada sí funcionaba bien).

Causa: El front usa el endpoint createNewVehicle, cuyo bloque catch solo capturaba la violación de unicidad de la placa (vehicles_license_plate_unique), pero no la del VIN (vehicles_vin_number_unique). El error del VIN se relanzaba crudo → ORPC respondía genérico.

Se agregó:
```
if (isUniqueViolation(error, "vehicles_vin_number_unique")) {
    throw new ORPCError("BAD_REQUEST", {
        message: `Ya existe un vehículo con el número de VIN "${input.vinNumber}"`,
    });
}
```