### PR TITLE
fix(vehicles): permitir acceso de cobros

### DIFF
--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -194,7 +194,7 @@ app.get("/", (c) => {
 // Vehicle photo upload endpoint
 app.post("/api/upload-vehicle-photo", async (c) => {
 	try {
-		// Get the context and require authenticated taller/CRM access.
+		// Get the context and require authenticated vehicle access.
 		const context = await createContext({ context: c });
 		const userRole = context.session?.user?.role;
 
@@ -202,11 +202,7 @@ app.post("/api/upload-vehicle-photo", async (c) => {
 			return c.json({ error: "No autorizado" }, 401);
 		}
 
-		if (
-			!userRole ||
-			(!PERMISSIONS.canAccessTaller(userRole) &&
-				!PERMISSIONS.canAccessCRM(userRole))
-		) {
+		if (!userRole || !PERMISSIONS.canAccessVehicles(userRole)) {
 			return c.json({ error: "No tienes permiso para subir fotos" }, 403);
 		}
 

--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -445,6 +445,35 @@ const requireTallerOrCrm = o.middleware(async ({ context, next }) => {
 	});
 });
 
+const requireVehicleAccess = o.middleware(async ({ context, next }) => {
+	if (!context.session?.user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	const userId = context.session.user.id;
+	const userData = await db
+		.select()
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+	const userRole = userData[0]?.role;
+
+	if (!userRole || !PERMISSIONS.canAccessVehicles(userRole)) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Se requiere acceso a vehículos",
+		});
+	}
+
+	return next({
+		context: {
+			...context,
+			user: userData[0],
+			userId,
+			userRole,
+		},
+	});
+});
+
 const requireInvestmentAccess = o.middleware(async ({ context, next }) => {
 	if (!context.session?.user) {
 		throw new ORPCError("UNAUTHORIZED");
@@ -528,6 +557,7 @@ export const viewOpportunityContractsProcedure = publicProcedure.use(
 export const juridicoProcedure = publicProcedure.use(requireJuridico);
 export const tallerProcedure = publicProcedure.use(requireTallerAccess);
 export const tallerOrCrmProcedure = publicProcedure.use(requireTallerOrCrm);
+export const vehiclesProcedure = publicProcedure.use(requireVehicleAccess);
 export const investmentProcedure = publicProcedure.use(requireInvestmentAccess);
 export const investmentManagerProcedure = publicProcedure.use(
 	requireInvestmentManager,

--- a/apps/crm/apps/server/src/lib/roles.test.ts
+++ b/apps/crm/apps/server/src/lib/roles.test.ts
@@ -17,7 +17,8 @@ describe("taller role permissions", () => {
 		expect(PERMISSIONS.canAccessVehicles(ROLES.ADMIN)).toBe(true);
 		expect(PERMISSIONS.canAccessVehicles(ROLES.SALES)).toBe(true);
 		expect(PERMISSIONS.canAccessVehicles(ROLES.ANALYST)).toBe(true);
-		expect(PERMISSIONS.canAccessVehicles(ROLES.COBROS)).toBe(false);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.COBROS)).toBe(true);
+		expect(PERMISSIONS.canAccessVehicles(ROLES.COBROS_SUPERVISOR)).toBe(true);
 		expect(PERMISSIONS.canAccessVehicles(ROLES.ACCOUNTING)).toBe(false);
 		expect(PERMISSIONS.canAccessVehicles(ROLES.INVESTMENT_MANAGER)).toBe(false);
 	});

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -247,7 +247,10 @@ export const PERMISSIONS = {
 
 	// Vehicles Module Access
 	canAccessVehicles: (role: UserRole | string): boolean =>
-		PERMISSIONS.canAccessCRM(role) || PERMISSIONS.canAccessTaller(role),
+		PERMISSIONS.canAccessCRM(role) ||
+		PERMISSIONS.canAccessTaller(role) ||
+		role === ROLES.COBROS ||
+		role === ROLES.COBROS_SUPERVISOR,
 
 	// Taller Module Access
 	canAccessTaller: (role: UserRole | string): boolean =>

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -33,6 +33,7 @@ import {
 	protectedProcedure,
 	publicProcedure,
 	tallerOrCrmProcedure,
+	vehiclesProcedure,
 } from "../lib/orpc";
 import { PERMISSIONS, ROLES } from "../lib/roles";
 import {
@@ -99,7 +100,7 @@ const normalizeManualValuationAmount = (
 
 export const vehiclesRouter = {
 	// Get all vehicles with their latest inspection and photos
-	getAll: tallerOrCrmProcedure
+	getAll: vehiclesProcedure
 		.input(
 			z
 				.object({
@@ -332,7 +333,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Get vehicle by ID with all related data
-	getById: tallerOrCrmProcedure
+	getById: vehiclesProcedure
 		.input(z.object({ id: z.string() }))
 		.handler(async ({ input }) => {
 			const [vehicle] = await db
@@ -521,7 +522,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Update vehicle
-	update: tallerOrCrmProcedure
+	update: vehiclesProcedure
 		.input(
 			z.object({
 				id: z.string(),
@@ -660,7 +661,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Search ONLY vehicles with recorded inspections
-	searchWithInspections: tallerOrCrmProcedure
+	searchWithInspections: vehiclesProcedure
 		.input(
 			z.object({
 				query: z.string().optional(),
@@ -733,7 +734,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Create vehicle inspection
-	createInspection: tallerOrCrmProcedure
+	createInspection: vehiclesProcedure
 		.input(
 			z.object({
 				vehicleId: z.string(),
@@ -930,7 +931,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Upload vehicle photo
-	uploadPhoto: tallerOrCrmProcedure
+	uploadPhoto: vehiclesProcedure
 		.input(
 			z.object({
 				vehicleId: z.string(),
@@ -1097,7 +1098,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Get statistics
-	getStatistics: tallerOrCrmProcedure.handler(async () => {
+	getStatistics: vehiclesProcedure.handler(async () => {
 		const allVehicles = await db.select().from(vehicles);
 		const allInspections = await db.select().from(vehicleInspections);
 
@@ -1129,7 +1130,7 @@ export const vehiclesRouter = {
 	}),
 
 	// Create full inspection with all data (vehicle + inspection + checklist)
-	createFullInspection: tallerOrCrmProcedure
+	createFullInspection: vehiclesProcedure
 		.input(
 			z.object({
 				// Vehicle data
@@ -1511,7 +1512,7 @@ export const vehiclesRouter = {
 		}),
 
 	// OCR endpoint for vehicle registration card (tarjeta de circulación)
-	processVehicleRegistrationOCR: tallerOrCrmProcedure
+	processVehicleRegistrationOCR: vehiclesProcedure
 		.input(
 			z.object({
 				imageBase64: z
@@ -1642,7 +1643,7 @@ REGLAS IMPORTANTES:
 		}),
 
 	// AI Vehicle Valuation endpoint
-	getAIVehicleValuation: tallerOrCrmProcedure
+	getAIVehicleValuation: vehiclesProcedure
 		.input(
 			z.object({
 				vehicleData: z.any().describe("Complete vehicle data from inspection"),


### PR DESCRIPTION
## Summary
- Agrega un guard vehiclesProcedure basado en PERMISSIONS.canAccessVehicles.
- Permite a cobros y supervisor de cobros acceder al modulo de Vehiculos sin tratarlos como CRM o Taller.
- Cambia endpoints de vehiculos/inspeccion/fotos/OCR/AI/statistics para usar vehiclesProcedure.
- Ajusta /api/upload-vehicle-photo para usar canAccessVehicles.

## Root cause
El PR #862 reemplazo endpoints publicos/protegidos por tallerOrCrmProcedure. Eso cerro el acceso publico, pero tambien bloqueo a usuarios de cobros porque cobros no pertenece a canAccessCRM ni canAccessTaller.

## Test Plan
- [x] bun test src/lib/roles.test.ts en apps/crm/apps/server
- [x] bun run build en apps/crm/apps/server
- [x] bun run build en apps/crm/apps/web

## Notes
- Cobros recupera acceso a Vehiculos.
- Las validaciones internas siguen restringiendo cambios sensibles como estado de vehiculo e inspecciones cuando aplica.