### PR TITLE
fix(vehicles): restringir escrituras de inspección

### DIFF
--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -734,7 +734,7 @@ export const vehiclesRouter = {
 		}),
 
 	// Create vehicle inspection
-	createInspection: vehiclesProcedure
+	createInspection: tallerOrCrmProcedure
 		.input(
 			z.object({
 				vehicleId: z.string(),
@@ -1130,7 +1130,7 @@ export const vehiclesRouter = {
 	}),
 
 	// Create full inspection with all data (vehicle + inspection + checklist)
-	createFullInspection: vehiclesProcedure
+	createFullInspection: tallerOrCrmProcedure
 		.input(
 			z.object({
 				// Vehicle data


### PR DESCRIPTION
## Summary
- Restringe createInspection con tallerOrCrmProcedure nuevamente.
- Restringe createFullInspection con tallerOrCrmProcedure nuevamente.
- Mantiene vehiclesProcedure para acceso general a Vehiculos, pero no para escrituras sensibles de inspeccion.

## Review comments addressed
- PR #883 comment: Restrict inspection creation to inspection roles
- PR #883 comment: Gate full inspection writes by inspection permissions

## Test Plan
- [x] bun run build en apps/crm/apps/server
- [x] bun test src/lib/roles.test.ts en apps/crm/apps/server

## Notes
Estos endpoints pueden crear inspecciones y cambiar estado del vehiculo, por eso no deben quedar abiertos a todos los roles con canAccessVehicles.