### PR TITLE
feat(reportes): % mora, royaltí en totales y desglose por inversionista

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -245,6 +245,127 @@ export async function getFlujoCuotasInversiones({
 }
 
 
+export async function getFlujoCuotasPorInversionista({
+  fechaInicio,
+  fechaFin,
+}: {
+  fechaInicio: string;
+  fechaFin: string;
+}) {
+  const rows = await db.execute(sql`
+    SELECT
+      CASE
+        WHEN i.tipo_reinversion = 'reinversion_combinada'
+        THEN COALESCE(ce.tipo_reinversion::text, 'sin_reinversion')
+        ELSE i.tipo_reinversion::text
+      END AS tipo_reinv_efectivo,
+      i.inversionista_id,
+      i.nombre,
+      COALESCE(SUM(ci.cuota_inversionista::numeric), 0) AS total_capital,
+      COALESCE(SUM(ci.monto_inversionista::numeric), 0) AS total_interes,
+      COALESCE(SUM(ci.iva_inversionista::numeric), 0)   AS total_iva,
+      MAX(i.monto_reinversion::numeric)                  AS monto_reinversion_inv
+    FROM cartera.cuotas_credito c
+    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+    JOIN cartera.creditos_inversionistas ci ON cr.credito_id = ci.credito_id
+    JOIN cartera.inversionistas i ON ci.inversionista_id = i.inversionista_id
+    LEFT JOIN cartera.creditos_inversionistas_espejo ce
+      ON cr.credito_id = ce.credito_id AND ci.inversionista_id = ce.inversionista_id
+    WHERE c.pagado = false
+      AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
+      AND c.fecha_vencimiento >= ${fechaInicio}::date
+      AND c.fecha_vencimiento <= ${fechaFin}::date
+    GROUP BY tipo_reinv_efectivo, i.inversionista_id, i.nombre
+    ORDER BY i.nombre
+  `);
+
+  const fmt = (n: number) => n.toFixed(2);
+
+  type InvRow = {
+    inversionista_id: number;
+    nombre: string;
+    reinv_capital: number;
+    reinv_interes: number;
+    cash_capital: number;
+    cash_interes: number;
+  };
+
+  const porInv: Record<number, InvRow> = {};
+
+  for (const row of rows.rows as Record<string, unknown>[]) {
+    const id = Number(row.inversionista_id);
+    const nombre = String(row.nombre);
+    const capital = Number(row.total_capital);
+    const interes = Number(row.total_interes);
+    const iva = Number(row.total_iva);
+    const tipo = String(row.tipo_reinv_efectivo);
+    const montoReinvInv = Number(row.monto_reinversion_inv ?? 0);
+    const totalCuota = capital + interes + iva;
+
+    if (!porInv[id]) {
+      porInv[id] = { inversionista_id: id, nombre, reinv_capital: 0, reinv_interes: 0, cash_capital: 0, cash_interes: 0 };
+    }
+
+    const inv = porInv[id];
+
+    if (tipo === "sin_reinversion") {
+      inv.cash_capital += capital;
+      inv.cash_interes += interes + iva;
+    } else if (tipo === "reinversion_capital") {
+      inv.reinv_capital += capital;
+      inv.cash_interes += interes + iva;
+    } else if (tipo === "reinversion_interes") {
+      inv.reinv_interes += interes + iva;
+      inv.cash_capital += capital;
+    } else if (tipo === "reinversion_total") {
+      inv.reinv_capital += capital;
+      inv.reinv_interes += interes + iva;
+    } else if (tipo === "reinversion_variable") {
+      const reinvertido = Math.min(montoReinvInv, totalCuota);
+      const cash = Math.max(0, totalCuota - reinvertido);
+      inv.reinv_capital += reinvertido;
+      inv.cash_capital += cash;
+    } else if (tipo === "reinversion_excedente") {
+      const recibe = Math.min(montoReinvInv, totalCuota);
+      inv.cash_capital += recibe;
+      inv.reinv_capital += Math.max(0, totalCuota - recibe);
+    }
+  }
+
+  const lista = Object.values(porInv).sort((a, b) => a.nombre.localeCompare(b.nombre));
+
+  let totalReinv = 0;
+  let totalCash = 0;
+
+  for (const inv of lista) {
+    totalReinv += inv.reinv_capital + inv.reinv_interes;
+    totalCash += inv.cash_capital + inv.cash_interes;
+  }
+
+  return {
+    porInversionista: lista.map((inv) => {
+      const reinvTotal = inv.reinv_capital + inv.reinv_interes;
+      const cashTotal = inv.cash_capital + inv.cash_interes;
+      return {
+        inversionista_id: inv.inversionista_id,
+        nombre: inv.nombre,
+        reinversion_capital: fmt(inv.reinv_capital),
+        reinversion_interes: fmt(inv.reinv_interes),
+        reinversion_total: fmt(reinvTotal),
+        cash_capital: fmt(inv.cash_capital),
+        cash_interes: fmt(inv.cash_interes),
+        cash_total: fmt(cashTotal),
+        total: fmt(reinvTotal + cashTotal),
+      };
+    }),
+    totales: {
+      reinversion_total: fmt(totalReinv),
+      cash_total: fmt(totalCash),
+      total: fmt(totalReinv + totalCash),
+    },
+  };
+}
+
 export async function getEsperadoDelMes({
   mes,
   anio,

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { getCobradoDelMes, getColocacionPorPeriodo, getComparativoHistorico, getEsperadoDelMes, getFlujoCuotasInversiones, getMontoACobrar } from "../controllers/reportes";
+import { getCobradoDelMes, getColocacionPorPeriodo, getComparativoHistorico, getEsperadoDelMes, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar } from "../controllers/reportes";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -76,6 +76,27 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/flujo-cuotas-inversiones]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/flujo-cuotas-inversiones/por-inversionista", async ({ query, set }) => {
+    try {
+      const { fechaInicio, fechaFin } = query as Record<string, string>;
+      if (!fechaInicio || !fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio y fechaFin son requeridos" };
+      }
+      if (!FECHA_REGEX.test(fechaInicio) || !FECHA_REGEX.test(fechaFin)) {
+        set.status = 400;
+        return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
+      }
+      const data = await getFlujoCuotasPorInversionista({ fechaInicio, fechaFin });
+      set.status = 200;
+      return data;
+    } catch (error) {
+      console.error("[/reportes/flujo-cuotas-inversiones/por-inversionista]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -38,23 +38,24 @@ import {
 	salesStages,
 } from "../db/schema/crm";
 import { vehicles } from "../db/schema/vehicles";
-import { calcularDiasMoraExactos } from "../lib/mora-utils";
+import {
+	interpolar as interpolarPlantilla,
+	PLANTILLAS_MENSAJES,
+} from "../lib/cobros-plantillas";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
+import { toDateStrGT } from "../lib/guatemala-month-window";
+import {
+	getTestPhone,
+	isTestModeEnabled,
+	TEST_EMAIL,
+} from "../lib/messaging-test-mode";
+import { calcularDiasMoraExactos } from "../lib/mora-utils";
 import {
 	cobrosProcedure,
 	cobrosSupervisorProcedure,
 	crmCobrosOrInvestmentsProcedure,
 	crmOrCobrosProcedure,
 } from "../lib/orpc";
-import {
-	interpolar as interpolarPlantilla,
-	PLANTILLAS_MENSAJES,
-} from "../lib/cobros-plantillas";
-import {
-	getTestPhone,
-	isTestModeEnabled,
-	TEST_EMAIL,
-} from "../lib/messaging-test-mode";
 import { PERMISSIONS } from "../lib/roles";
 import {
 	sendWhatsappTemplate,
@@ -71,7 +72,6 @@ import {
 	getUltimasSincronizaciones,
 	sincronizarCasosCobros,
 } from "../services/sync-casos-cobros";
-import { toDateStrGT } from "../lib/guatemala-month-window";
 import type { CreditoDirectoResponse } from "../types/cartera-back";
 import { createNotification } from "./notifications";
 
@@ -131,10 +131,18 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 			params.email_cobrador !== "" && {
 				email_cobrador: params.email_cobrador,
 			}),
-			...(params.fecha_desde !== undefined && { fecha_desde: params.fecha_desde }),
-			...(params.fecha_hasta !== undefined && { fecha_hasta: params.fecha_hasta }),
-			...(params.capital_min !== undefined && { capital_min: params.capital_min }),
-			...(params.capital_max !== undefined && { capital_max: params.capital_max }),
+		...(params.fecha_desde !== undefined && {
+			fecha_desde: params.fecha_desde,
+		}),
+		...(params.fecha_hasta !== undefined && {
+			fecha_hasta: params.fecha_hasta,
+		}),
+		...(params.capital_min !== undefined && {
+			capital_min: params.capital_min,
+		}),
+		...(params.capital_max !== undefined && {
+			capital_max: params.capital_max,
+		}),
 	});
 
 	return {
@@ -732,9 +740,9 @@ export const cobrosRouter = {
 							.from(casosCobros)
 							.where(
 								sql`${casosCobros.etiquetas} && ARRAY[${sql.join(
-							input.etiquetas.map((e) => sql`${e}`),
-							sql`, `,
-						)}]::text[]`,
+									input.etiquetas.map((e) => sql`${e}`),
+									sql`, `,
+								)}]::text[]`,
 							);
 						sifcosPorEtiquetas = filas
 							.map((r) => r.numeroSifco)
@@ -982,9 +990,7 @@ export const cobrosRouter = {
 								etiquetas: casosCobros.etiquetas,
 							})
 							.from(casosCobros)
-							.where(
-								inArray(casosCobros.numeroCreditoSifco, sifcosPagina),
-							);
+							.where(inArray(casosCobros.numeroCreditoSifco, sifcosPagina));
 						for (const row of casosRows) {
 							if (!row.numeroSifco) continue;
 							casosPorSifco.set(row.numeroSifco, {
@@ -1824,7 +1830,8 @@ export const cobrosRouter = {
 
 				// 0. Si el creditoId es un UUID (viene de una notificación), resolverlo
 				//    al numeroCreditoSifco del caso de cobros antes de consultar cartera-back.
-				const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+				const UUID_REGEX =
+					/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 				if (UUID_REGEX.test(numeroSifco)) {
 					const [casoPorUUID] = await db
 						.select({ numeroCreditoSifco: casosCobros.numeroCreditoSifco })
@@ -2183,7 +2190,9 @@ export const cobrosRouter = {
 					? Number.parseInt(
 							cuotaParaDiaPago.fecha_vencimiento.substring(8, 10),
 							10,
-						) || oportunidadData?.diaPago || null
+						) ||
+						oportunidadData?.diaPago ||
+						null
 					: oportunidadData?.diaPago || null;
 
 				const statusCredit = creditoCompleto.credito.statusCredit;
@@ -2202,7 +2211,9 @@ export const cobrosRouter = {
 					diasMoraMaximo: diasMora,
 					cuotasVencidas: cuotasAtrasadas,
 					cuotaConvenio: tieneConvenioActivo
-						? Number(creditoCompleto.convenioActivo!.cuota_mensual ?? 0).toFixed(2)
+						? Number(
+								creditoCompleto.convenioActivo!.cuota_mensual ?? 0,
+							).toFixed(2)
 						: null,
 
 					// Datos de contacto (del caso de cobros primero, fallback al lead)
@@ -2216,7 +2227,10 @@ export const cobrosRouter = {
 					etiquetas: casoCobro?.etiquetas || [],
 
 					// Datos del contrato (cartera primero, fallback a nuestra BD)
-					montoFinanciado: creditoCompleto.credito.capital ?? creditoCompleto.credito.deudatotal ?? "0.00",
+					montoFinanciado:
+						creditoCompleto.credito.capital ??
+						creditoCompleto.credito.deudatotal ??
+						"0.00",
 					cuotaMensual:
 						creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual,
 					numeroCuotas: creditoCompleto.credito.plazo,
@@ -3124,7 +3138,9 @@ export const cobrosRouter = {
 			const result = await sendWhatsappTemplate({
 				phone: telefonoDestino,
 				message: input.mensaje,
-				logPrefix: testMode ? "[SimpleTech][cobros][TEST]" : "[SimpleTech][cobros]",
+				logPrefix: testMode
+					? "[SimpleTech][cobros][TEST]"
+					: "[SimpleTech][cobros]",
 			});
 
 			await persistCobrosSendLog({
@@ -3215,11 +3231,8 @@ export const cobrosRouter = {
 			// 1. Mapear estadoMora → params de cartera-back (mismo mapping que
 			// getTodosLosCreditos).
 			let cuotasAtrasadas: number | undefined;
-			let estadoCartera:
-				| "ACTIVO"
-				| "CANCELADO"
-				| "INCOBRABLE"
-				| undefined = "ACTIVO";
+			let estadoCartera: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | undefined =
+				"ACTIVO";
 			if (input.estadoMora) {
 				switch (input.estadoMora) {
 					case "al_dia":
@@ -3265,7 +3278,8 @@ export const cobrosRouter = {
 			const isNameSearch =
 				!numeroSifcoExacto && searchTerm.length > 0 && !hasNumber;
 
-			let numeroSifcoFiltro: string | undefined = numeroSifcoExacto || undefined;
+			let numeroSifcoFiltro: string | undefined =
+				numeroSifcoExacto || undefined;
 			let searchPorPlacaSinMatch = false;
 			const matchingSifcos = new Set<string>();
 			if (isPlateSearch) {
@@ -3398,8 +3412,7 @@ export const cobrosRouter = {
 						cuotasAtrasadas,
 						// Mismo criterio que getTodosLosCreditos: si hay rango de fechas
 						// custom, ignoramos el preset `time` para que no se pisen.
-						time:
-							input.fechaDesde || input.fechaHasta ? undefined : input.time,
+						time: input.fechaDesde || input.fechaHasta ? undefined : input.time,
 						email_cobrador: emailCobrador,
 						nombre_usuario: isNameSearch ? searchTerm : undefined,
 						numero_credito_sifco: numeroSifcoFiltro,
@@ -3510,15 +3523,27 @@ export const cobrosRouter = {
 				const clienteNombre = credito.usuarios.nombre ?? null;
 
 				if (!cuota || Number(cuota) === 0) {
-					descartados.push({ numeroSifco: sifco, clienteNombre, motivo: "sin cuota" });
+					descartados.push({
+						numeroSifco: sifco,
+						clienteNombre,
+						motivo: "sin cuota",
+					});
 					continue;
 				}
 				if (!telefono) {
-					descartados.push({ numeroSifco: sifco, clienteNombre, motivo: "sin teléfono" });
+					descartados.push({
+						numeroSifco: sifco,
+						clienteNombre,
+						motivo: "sin teléfono",
+					});
 					continue;
 				}
 				if (!asesor) {
-					descartados.push({ numeroSifco: sifco, clienteNombre, motivo: "sin asesor" });
+					descartados.push({
+						numeroSifco: sifco,
+						clienteNombre,
+						motivo: "sin asesor",
+					});
 					continue;
 				}
 
@@ -3534,8 +3559,7 @@ export const cobrosRouter = {
 				// Total a cobrar = monto en mora + cuota mensual (mismo criterio
 				// que se muestra en la pantalla de detalle del caso).
 				const montoMora = Number(credito.mora?.monto_mora ?? 0);
-				const totalACobrar =
-					montoMora > 0 ? montoMora + Number(cuota) : 0;
+				const totalACobrar = montoMora > 0 ? montoMora + Number(cuota) : 0;
 
 				const cuerpoBase = input.cuerpoEditado?.trim()
 					? input.cuerpoEditado
@@ -3670,9 +3694,7 @@ export const cobrosRouter = {
 							: {
 									success: false,
 									errorMessage:
-										res?.error ??
-										batch.transportError ??
-										"Error desconocido",
+										res?.error ?? batch.transportError ?? "Error desconocido",
 									providerResponse: {
 										...(batch.providerResponse ?? {}),
 										...(testMode
@@ -3758,11 +3780,7 @@ export const cobrosRouter = {
 			let sendError: string | null = null;
 			let emailId: string | undefined;
 			try {
-				const result = await sendPlainEmail(
-					emailDestino,
-					input.asunto,
-					html,
-				);
+				const result = await sendPlainEmail(emailDestino, input.asunto, html);
 
 				if (!result.success) {
 					sendError =
@@ -3773,8 +3791,7 @@ export const cobrosRouter = {
 					emailId = result.data?.id;
 				}
 			} catch (error) {
-				sendError =
-					error instanceof Error ? error.message : String(error);
+				sendError = error instanceof Error ? error.message : String(error);
 			}
 
 			await persistCobrosSendLog({
@@ -3869,15 +3886,12 @@ export const cobrosRouter = {
 
 				if (!result.success) {
 					sendError =
-						result.error?.hint ||
-						result.error?.message ||
-						"desconocido";
+						result.error?.hint || result.error?.message || "desconocido";
 				} else {
 					mailingId = result.mailingId;
 				}
 			} catch (error) {
-				sendError =
-					error instanceof Error ? error.message : String(error);
+				sendError = error instanceof Error ? error.message : String(error);
 			}
 
 			await persistCobrosSendLog({
@@ -3966,29 +3980,64 @@ export const cobrosRouter = {
 			const serializeBuckets = (b: BucketsAcc) => {
 				const fmt = (v: number) => v.toFixed(2);
 				const totalCantidad =
-					b.mora_30.cantidad + b.mora_60.cantidad + b.mora_90.cantidad + b.mora_120_plus.cantidad;
+					b.mora_30.cantidad +
+					b.mora_60.cantidad +
+					b.mora_90.cantidad +
+					b.mora_120_plus.cantidad;
 				const totalMora =
-					b.mora_30.sumaMora + b.mora_60.sumaMora + b.mora_90.sumaMora + b.mora_120_plus.sumaMora;
+					b.mora_30.sumaMora +
+					b.mora_60.sumaMora +
+					b.mora_90.sumaMora +
+					b.mora_120_plus.sumaMora;
 				return {
-					mora_30: { cantidad: b.mora_30.cantidad, sumaCapital: fmt(b.mora_30.sumaCapital), sumaMora: fmt(b.mora_30.sumaMora) },
-					mora_60: { cantidad: b.mora_60.cantidad, sumaCapital: fmt(b.mora_60.sumaCapital), sumaMora: fmt(b.mora_60.sumaMora) },
-					mora_90: { cantidad: b.mora_90.cantidad, sumaCapital: fmt(b.mora_90.sumaCapital), sumaMora: fmt(b.mora_90.sumaMora) },
-					mora_120_plus: { cantidad: b.mora_120_plus.cantidad, sumaCapital: fmt(b.mora_120_plus.sumaCapital), sumaMora: fmt(b.mora_120_plus.sumaMora) },
+					mora_30: {
+						cantidad: b.mora_30.cantidad,
+						sumaCapital: fmt(b.mora_30.sumaCapital),
+						sumaMora: fmt(b.mora_30.sumaMora),
+					},
+					mora_60: {
+						cantidad: b.mora_60.cantidad,
+						sumaCapital: fmt(b.mora_60.sumaCapital),
+						sumaMora: fmt(b.mora_60.sumaMora),
+					},
+					mora_90: {
+						cantidad: b.mora_90.cantidad,
+						sumaCapital: fmt(b.mora_90.sumaCapital),
+						sumaMora: fmt(b.mora_90.sumaMora),
+					},
+					mora_120_plus: {
+						cantidad: b.mora_120_plus.cantidad,
+						sumaCapital: fmt(b.mora_120_plus.sumaCapital),
+						sumaMora: fmt(b.mora_120_plus.sumaMora),
+					},
 					totalEnMora: { cantidad: totalCantidad, sumaMora: fmt(totalMora) },
 				};
 			};
 
 			const acumuladoTotal = emptyBuckets();
 
-			type AsesorEntry = { asesorId: number; nombre: string; email: string; buckets: BucketsAcc };
+			type AsesorEntry = {
+				asesorId: number;
+				nombre: string;
+				email: string;
+				buckets: BucketsAcc;
+			};
 			const porAsesorMap = new Map<string, AsesorEntry>();
 
-			const addToBucket = (acc: BucketsAcc, cuotasAtrasadas: number, capital: number, mora: number) => {
+			const addToBucket = (
+				acc: BucketsAcc,
+				cuotasAtrasadas: number,
+				capital: number,
+				mora: number,
+			) => {
 				const key =
-					cuotasAtrasadas >= 4 ? "mora_120_plus" :
-					cuotasAtrasadas === 3 ? "mora_90" :
-					cuotasAtrasadas === 2 ? "mora_60" :
-					"mora_30";
+					cuotasAtrasadas >= 4
+						? "mora_120_plus"
+						: cuotasAtrasadas === 3
+							? "mora_90"
+							: cuotasAtrasadas === 2
+								? "mora_60"
+								: "mora_30";
 				acc[key].cantidad += 1;
 				acc[key].sumaCapital += capital;
 				acc[key].sumaMora += mora;
@@ -3998,8 +4047,10 @@ export const cobrosRouter = {
 				const cuotasAtrasadas = item.mora?.cuotas_atrasadas ?? 0;
 				if (cuotasAtrasadas < 1) continue;
 
-				const capital = parseFloat(item.creditos.capital as string || "0");
-				const montoMora = parseFloat(item.mora?.monto_mora ?? "0");
+				const capital = Number.parseFloat(
+					(item.creditos.capital as string) || "0",
+				);
+				const montoMora = Number.parseFloat(item.mora?.monto_mora ?? "0");
 
 				addToBucket(acumuladoTotal, cuotasAtrasadas, capital, montoMora);
 
@@ -4010,7 +4061,12 @@ export const cobrosRouter = {
 
 				let entry = porAsesorMap.get(emailAsesor);
 				if (!entry) {
-					entry = { asesorId, nombre: nombreAsesor, email: emailAsesor, buckets: emptyBuckets() };
+					entry = {
+						asesorId,
+						nombre: nombreAsesor,
+						email: emailAsesor,
+						buckets: emptyBuckets(),
+					};
 					porAsesorMap.set(emailAsesor, entry);
 				}
 				addToBucket(entry.buckets, cuotasAtrasadas, capital, montoMora);
@@ -4018,8 +4074,16 @@ export const cobrosRouter = {
 
 			const porAsesor = Array.from(porAsesorMap.values())
 				.sort((a, b) => {
-					const totalA = a.buckets.mora_30.sumaMora + a.buckets.mora_60.sumaMora + a.buckets.mora_90.sumaMora + a.buckets.mora_120_plus.sumaMora;
-					const totalB = b.buckets.mora_30.sumaMora + b.buckets.mora_60.sumaMora + b.buckets.mora_90.sumaMora + b.buckets.mora_120_plus.sumaMora;
+					const totalA =
+						a.buckets.mora_30.sumaMora +
+						a.buckets.mora_60.sumaMora +
+						a.buckets.mora_90.sumaMora +
+						a.buckets.mora_120_plus.sumaMora;
+					const totalB =
+						b.buckets.mora_30.sumaMora +
+						b.buckets.mora_60.sumaMora +
+						b.buckets.mora_90.sumaMora +
+						b.buckets.mora_120_plus.sumaMora;
 					return totalB - totalA;
 				})
 				.map((e) => ({
@@ -4089,13 +4153,13 @@ export const cobrosRouter = {
 			let cantidadCuotas = 0;
 
 			for (const row of desglose) {
-				totalCapital += parseFloat(row.total_cuota);
-				totalInteres += parseFloat(row.total_interes);
-				totalIva += parseFloat(row.total_iva);
-				totalSeguro += parseFloat(row.total_seguro);
-				totalGps += parseFloat(row.total_gps);
-				totalMembresias += parseFloat(row.total_membresias);
-				totalRoyalti += parseFloat(row.total_royalti);
+				totalCapital += Number.parseFloat(row.total_cuota);
+				totalInteres += Number.parseFloat(row.total_interes);
+				totalIva += Number.parseFloat(row.total_iva);
+				totalSeguro += Number.parseFloat(row.total_seguro);
+				totalGps += Number.parseFloat(row.total_gps);
+				totalMembresias += Number.parseFloat(row.total_membresias);
+				totalRoyalti += Number.parseFloat(row.total_royalti);
 				cantidadCuotas += row.cuotas_count;
 			}
 
@@ -4105,7 +4169,8 @@ export const cobrosRouter = {
 				totalIva +
 				totalSeguro +
 				totalGps +
-				totalMembresias;
+				totalMembresias +
+				totalRoyalti;
 
 			return {
 				fechaInicio,
@@ -4191,8 +4256,7 @@ export const cobrosRouter = {
 				montoMora: item.mora?.monto_mora ?? "0",
 				capital: item.proxima_cuota?.capital_restante ?? item.creditos.capital,
 				cuotaMensual: item.creditos.cuota,
-				proximaFechaVencimiento:
-					item.proxima_cuota?.fecha_vencimiento ?? null,
+				proximaFechaVencimiento: item.proxima_cuota?.fecha_vencimiento ?? null,
 				tipoCredito: item.creditos.tipoCredito ?? null,
 			}));
 
@@ -4236,23 +4300,24 @@ export const cobrosRouter = {
 			const todos = creditos
 				.map((item) => {
 					const cred = item.creditos;
-					const gps = parseFloat(cred.gps || "0");
-					const seguro = parseFloat(cred.seguro_10_cuotas || "0");
-					const membresias = parseFloat(cred.membresias_pago || "0");
-					const otros = parseFloat(cred.otros || "0");
+					const gps = Number.parseFloat(cred.gps || "0");
+					const seguro = Number.parseFloat(cred.seguro_10_cuotas || "0");
+					const membresias = Number.parseFloat(cred.membresias_pago || "0");
+					const otros = Number.parseFloat(cred.otros || "0");
 
-					const rubros = (
-						(item.rubros as RubroItem[] | null) ?? []
-					).map((r) => ({
-						nombre: r.nombre_rubro,
-						monto: parseFloat(String(r.monto || "0")).toFixed(2),
-					}));
+					const rubros = ((item.rubros as RubroItem[] | null) ?? []).map(
+						(r) => ({
+							nombre: r.nombre_rubro,
+							monto: Number.parseFloat(String(r.monto || "0")).toFixed(2),
+						}),
+					);
 					const rubrosTotal = rubros.reduce(
-						(s, r) => s + parseFloat(r.monto),
+						(s, r) => s + Number.parseFloat(r.monto),
 						0,
 					);
 
-					const totalDescuentos = gps + seguro + membresias + otros + rubrosTotal;
+					const totalDescuentos =
+						gps + seguro + membresias + otros + rubrosTotal;
 					if (totalDescuentos <= 0) return null;
 
 					return {
@@ -4270,11 +4335,7 @@ export const cobrosRouter = {
 						tipoCredito: cred.tipoCredito ?? null,
 					};
 				})
-				.filter(
-					(
-						v,
-					): v is NonNullable<typeof v> => v !== null,
-				);
+				.filter((v): v is NonNullable<typeof v> => v !== null);
 
 			const total = todos.length;
 			const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
@@ -4323,7 +4384,11 @@ async function persistCobrosSendLog(params: {
 	createdBy: string;
 	result:
 		| { success: true; providerResponse?: Record<string, unknown> }
-		| { success: false; errorMessage?: string; providerResponse?: Record<string, unknown> };
+		| {
+				success: false;
+				errorMessage?: string;
+				providerResponse?: Record<string, unknown>;
+		  };
 }) {
 	try {
 		await db.insert(cobrosSendLogs).values({

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -342,6 +342,7 @@ export const reportsAppRouter = {
 	getMontoACobrar: reportesCarteraRouter.getMontoACobrar,
 	getFacturacionMes: reportesCarteraRouter.getFacturacionMes,
 	getFlujoCuotasInversiones: reportesCarteraRouter.getFlujoCuotasInversiones,
+	getFlujoCuotasPorInversionista: reportesCarteraRouter.getFlujoCuotasPorInversionista,
 	getComparativoHistorico: reportesCarteraRouter.getComparativoHistorico,
 	getMetas: reportesCarteraRouter.getMetas,
 	upsertMeta: reportesCarteraRouter.upsertMeta,

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -16,6 +16,7 @@ import {
 	carteraBackClient,
 	type FacturacionMesResponse,
 	type FlujoCuotasInversionesResponse,
+	type FlujoCuotasPorInversionistaResponse,
 	type MontoACobrarRow,
 } from "../services/cartera-back-client";
 import { isCarteraBackEnabled } from "../services/cartera-back-integration";
@@ -469,6 +470,28 @@ export const reportesCarteraRouter = {
 				}
 
 				return carteraBackClient.getFlujoCuotasInversiones({
+					fechaInicio: input.fechaInicio,
+					fechaFin: input.fechaFin,
+				});
+			},
+		),
+
+	getFlujoCuotasPorInversionista: adminProcedure
+		.input(
+			z.object({
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+			}),
+		)
+		.handler(
+			async ({ input }): Promise<FlujoCuotasPorInversionistaResponse> => {
+				if (!isCarteraBackEnabled()) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: "Integración con cartera-back no está habilitada",
+					});
+				}
+
+				return carteraBackClient.getFlujoCuotasPorInversionista({
 					fechaInicio: input.fechaInicio,
 					fechaFin: input.fechaFin,
 				});

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -234,6 +234,27 @@ export type FlujoCuotasInversionesResponse = {
 	};
 };
 
+export type FlujoPorInversionistaRow = {
+	inversionista_id: number;
+	nombre: string;
+	reinversion_capital: string;
+	reinversion_interes: string;
+	reinversion_total: string;
+	cash_capital: string;
+	cash_interes: string;
+	cash_total: string;
+	total: string;
+};
+
+export type FlujoCuotasPorInversionistaResponse = {
+	porInversionista: FlujoPorInversionistaRow[];
+	totales: {
+		reinversion_total: string;
+		cash_total: string;
+		total: string;
+	};
+};
+
 export type ColocacionPeriodoRow = {
 	bucket: string;
 	cantidad_creditos: number;
@@ -1358,6 +1379,21 @@ export class CarteraBackClient {
 		});
 		return this.request<FlujoCuotasInversionesResponse>(
 			`/reportes/flujo-cuotas-inversiones?${qp}`,
+			{ method: "GET" },
+			true,
+		);
+	}
+
+	async getFlujoCuotasPorInversionista(params: {
+		fechaInicio: string;
+		fechaFin: string;
+	}): Promise<FlujoCuotasPorInversionistaResponse> {
+		const qp = new URLSearchParams({
+			fechaInicio: params.fechaInicio,
+			fechaFin: params.fechaFin,
+		});
+		return this.request<FlujoCuotasPorInversionistaResponse>(
+			`/reportes/flujo-cuotas-inversiones/por-inversionista?${qp}`,
 			{ method: "GET" },
 			true,
 		);

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -5,6 +5,7 @@ import {
 	AlertTriangle,
 	CalendarDays,
 	ChevronLeft,
+	ChevronDown,
 	ChevronRight,
 	Download,
 	FileText,
@@ -33,6 +34,7 @@ import {
 	YAxis,
 } from "recharts";
 import { toast } from "sonner";
+import * as XLSX from "xlsx";
 import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { ReportCard } from "@/components/reports/report-card";
 import { ScenarioModal } from "@/components/reports/scenario-modal";
@@ -316,6 +318,8 @@ function RouteComponent() {
 	const [flujoCuotasRange, setFlujoCuotasRange] = useState(
 		getDefaultFlujoCuotasRange,
 	);
+	const [desgloseInversionistaOpen, setDesgloseInversionistaOpen] =
+		useState(false);
 	const [comparativoAnio, setComparativoAnio] = useState(() =>
 		new Date().getFullYear(),
 	);
@@ -400,6 +404,18 @@ function RouteComponent() {
 	const flujoCuotasData = flujoCuotasQuery.data as
 		| FlujoCuotasInversionesResponse
 		| undefined;
+
+	const flujoPorInversionistaQuery = useQuery({
+		...orpc.getFlujoCuotasPorInversionista.queryOptions({
+			input: {
+				fechaInicio: flujoCuotasRange.fechaInicio,
+				fechaFin: flujoCuotasRange.fechaFin,
+			},
+		}),
+		enabled: isAdmin,
+	});
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const flujoPorInversionistaData = flujoPorInversionistaQuery.data as any;
 
 	const comparativoQuery = useQuery({
 		...orpc.getComparativoHistorico.queryOptions({
@@ -1602,7 +1618,7 @@ function RouteComponent() {
 											{/* Sección 2: Cash (sin reinversión + porciones cash de reinversión parcial) */}
 											<div>
 												<p className="mb-2 font-semibold text-sm">
-													Cuotas → Cash
+													Cuotas → A Recibir
 												</p>
 												<Table>
 													<TableHeader>
@@ -1665,7 +1681,7 @@ function RouteComponent() {
 														)}
 														{/* Total general cash */}
 														<TableRow className="border-t-2 bg-muted/50 font-bold">
-															<TableCell>Total Cash</TableCell>
+															<TableCell>Total a Recibir</TableCell>
 															<TableCell colSpan={3} />
 															<TableCell className="text-right">
 																{formatCurrency(
@@ -1720,6 +1736,147 @@ function RouteComponent() {
 										</>
 									);
 								})()}
+
+							{/* Sección 4: Desglose por Inversionista */}
+							<div className="border-t pt-4">
+								<div className="mb-3 flex items-center justify-between">
+									<button
+										type="button"
+										className="flex items-center gap-1 font-semibold text-sm hover:text-foreground/70 transition-colors"
+										onClick={() =>
+											setDesgloseInversionistaOpen(
+												(o) => !o,
+											)
+										}
+									>
+										{desgloseInversionistaOpen ? (
+											<ChevronDown className="h-4 w-4" />
+										) : (
+											<ChevronRight className="h-4 w-4" />
+										)}
+										Desglose por Inversionista
+									</button>
+									{desgloseInversionistaOpen &&
+										(flujoPorInversionistaData?.porInversionista?.length ?? 0) > 0 && (
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={() => {
+												const rows = (
+													// eslint-disable-next-line @typescript-eslint/no-explicit-any
+													(flujoPorInversionistaData!.porInversionista as any[])
+												).map((r: any) => ({
+													Inversionista: r.nombre,
+													"Reinv. Capital": r.reinversion_capital,
+													"Reinv. Interés": r.reinversion_interes,
+													"Total Reinversión": r.reinversion_total,
+													"Capital a Recibir": r.cash_capital,
+													"Interés a Recibir": r.cash_interes,
+													"Total a Recibir": r.cash_total,
+													"Total General": r.total,
+												}));
+												const ws = XLSX.utils.json_to_sheet(rows);
+												ws["!cols"] = [
+													{ wch: 30 },
+													{ wch: 18 },
+													{ wch: 18 },
+													{ wch: 18 },
+													{ wch: 18 },
+													{ wch: 18 },
+													{ wch: 18 },
+													{ wch: 18 },
+												];
+												const wb = XLSX.utils.book_new();
+												XLSX.utils.book_append_sheet(
+													wb,
+													ws,
+													"Por Inversionista",
+												);
+												XLSX.writeFile(
+													wb,
+													`flujo-inversionistas-${flujoCuotasRange.fechaInicio}-${flujoCuotasRange.fechaFin}.xlsx`,
+												);
+											}}
+										>
+											<Download className="mr-2 h-4 w-4" />
+											Exportar Excel
+										</Button>
+									)}
+								</div>
+								{desgloseInversionistaOpen && (flujoPorInversionistaQuery.isPending ? (
+									<p className="py-4 text-center text-muted-foreground text-sm">
+										Cargando...
+									</p>
+								) : flujoPorInversionistaQuery.isError ? (
+									<p className="py-4 text-center text-destructive text-sm">
+										Error al cargar desglose por inversionista
+									</p>
+								) : !flujoPorInversionistaData?.porInversionista?.length ? (
+									<p className="py-4 text-center text-muted-foreground text-sm">
+										Sin datos para el período seleccionado
+									</p>
+								) : (
+									<Table>
+										<TableHeader>
+											<TableRow>
+												<TableHead>Inversionista</TableHead>
+												<TableHead className="text-right">
+													Reinversión
+												</TableHead>
+												<TableHead className="text-right">A Recibir</TableHead>
+												<TableHead className="text-right">Total</TableHead>
+											</TableRow>
+										</TableHeader>
+										<TableBody>
+											{(
+												flujoPorInversionistaData.porInversionista as any[]
+											).map((row: any) => (
+												<TableRow key={row.inversionista_id}>
+													<TableCell className="font-medium">
+														{row.nombre}
+													</TableCell>
+													<TableCell className="text-right">
+														{formatCurrency(Number(row.reinversion_total))}
+													</TableCell>
+													<TableCell className="text-right">
+														{formatCurrency(Number(row.cash_total))}
+													</TableCell>
+													<TableCell className="text-right font-semibold">
+														{formatCurrency(Number(row.total))}
+													</TableCell>
+												</TableRow>
+											))}
+										</TableBody>
+										{flujoPorInversionistaData?.totales && (
+											<tfoot>
+												<TableRow className="border-t-2 bg-muted/50 font-bold">
+													<TableCell>Total</TableCell>
+													<TableCell className="text-right">
+														{formatCurrency(
+															Number(
+																flujoPorInversionistaData.totales
+																	.reinversion_total,
+															),
+														)}
+													</TableCell>
+													<TableCell className="text-right">
+														{formatCurrency(
+															Number(
+																flujoPorInversionistaData.totales.cash_total,
+															),
+														)}
+													</TableCell>
+													<TableCell className="text-right">
+														{formatCurrency(
+															Number(flujoPorInversionistaData.totales.total),
+														)}
+													</TableCell>
+												</TableRow>
+											</tfoot>
+										)}
+									</Table>
+								))}
+							</div>
 						</CardContent>
 					</Card>
 

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -2197,6 +2197,15 @@ function RouteComponent() {
 															row.colocacion_monto === null &&
 															row.facturacion === null &&
 															row.cartera_activa === null;
+														const totalMoraFila =
+															Number(row.mora_30 ?? 0) +
+															Number(row.mora_60 ?? 0) +
+															Number(row.mora_90 ?? 0) +
+															Number(row.mora_120 ?? 0);
+														const pctMora = (val: string | null) =>
+															totalMoraFila > 0 && val
+																? ((Number(val) / totalMoraFila) * 100).toFixed(1)
+																: null;
 														return (
 															<TableRow
 																key={row.mes}
@@ -2230,48 +2239,76 @@ function RouteComponent() {
 																</TableCell>
 																<TableCell className="text-right">
 																	{row.mora_30 ? (
-																		<span>
-																			{formatCurrency(Number(row.mora_30))}
-																			<span className="ml-1 text-muted-foreground text-xs">
-																				({row.creditos_30 ?? 0})
+																		<div>
+																			<span>
+																				{formatCurrency(Number(row.mora_30))}
+																				<span className="ml-1 text-muted-foreground text-xs">
+																					({row.creditos_30 ?? 0})
+																				</span>
 																			</span>
-																		</span>
+																			{pctMora(row.mora_30) && (
+																				<div className="text-muted-foreground text-xs">
+																					{pctMora(row.mora_30)}%
+																				</div>
+																			)}
+																		</div>
 																	) : (
 																		"—"
 																	)}
 																</TableCell>
 																<TableCell className="text-right">
 																	{row.mora_60 ? (
-																		<span>
-																			{formatCurrency(Number(row.mora_60))}
-																			<span className="ml-1 text-muted-foreground text-xs">
-																				({row.creditos_60 ?? 0})
+																		<div>
+																			<span>
+																				{formatCurrency(Number(row.mora_60))}
+																				<span className="ml-1 text-muted-foreground text-xs">
+																					({row.creditos_60 ?? 0})
+																				</span>
 																			</span>
-																		</span>
+																			{pctMora(row.mora_60) && (
+																				<div className="text-muted-foreground text-xs">
+																					{pctMora(row.mora_60)}%
+																				</div>
+																			)}
+																		</div>
 																	) : (
 																		"—"
 																	)}
 																</TableCell>
 																<TableCell className="text-right">
 																	{row.mora_90 ? (
-																		<span>
-																			{formatCurrency(Number(row.mora_90))}
-																			<span className="ml-1 text-muted-foreground text-xs">
-																				({row.creditos_90 ?? 0})
+																		<div>
+																			<span>
+																				{formatCurrency(Number(row.mora_90))}
+																				<span className="ml-1 text-muted-foreground text-xs">
+																					({row.creditos_90 ?? 0})
+																				</span>
 																			</span>
-																		</span>
+																			{pctMora(row.mora_90) && (
+																				<div className="text-muted-foreground text-xs">
+																					{pctMora(row.mora_90)}%
+																				</div>
+																			)}
+																		</div>
 																	) : (
 																		"—"
 																	)}
 																</TableCell>
 																<TableCell className="text-right">
 																	{row.mora_120 ? (
-																		<span>
-																			{formatCurrency(Number(row.mora_120))}
-																			<span className="ml-1 text-muted-foreground text-xs">
-																				({row.creditos_120 ?? 0})
+																		<div>
+																			<span>
+																				{formatCurrency(Number(row.mora_120))}
+																				<span className="ml-1 text-muted-foreground text-xs">
+																					({row.creditos_120 ?? 0})
+																				</span>
 																			</span>
-																		</span>
+																			{pctMora(row.mora_120) && (
+																				<div className="text-muted-foreground text-xs">
+																					{pctMora(row.mora_120)}%
+																				</div>
+																			)}
+																		</div>
 																	) : (
 																		"—"
 																	)}

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -1,18 +1,18 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
-import { BarChart3, CalendarClock, RefreshCw, TrendingDown } from "lucide-react";
+import {
+	BarChart3,
+	CalendarClock,
+	RefreshCw,
+	TrendingDown,
+} from "lucide-react";
 import { useState } from "react";
 import { CapitalRangeFilter } from "@/components/cobros/capital-range-filter";
 import { DataTable } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-	Card,
-	CardContent,
-	CardHeader,
-	CardTitle,
-} from "@/components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -36,25 +36,53 @@ export const Route = createFileRoute("/cobros/reportes")({
 // ─── shared helpers ────────────────────────────────────────────────────────
 
 function fmtQ(v: string | number) {
-	const n = parseFloat(String(v));
+	const n = Number.parseFloat(String(v));
 	return `Q${isNaN(n) ? "0.00" : n.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 }
 
 function fmtTime(d: Date) {
-	return d.toLocaleTimeString("es-GT", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+	return d.toLocaleTimeString("es-GT", {
+		hour: "2-digit",
+		minute: "2-digit",
+		second: "2-digit",
+	});
 }
 
 // ─── Mora ──────────────────────────────────────────────────────────────────
 
 const ETAPAS = [
-	{ key: "mora_30" as const, label: "Mora 30", color: "bg-yellow-100 text-yellow-800" },
-	{ key: "mora_60" as const, label: "Mora 60", color: "bg-orange-100 text-orange-800" },
-	{ key: "mora_90" as const, label: "Mora 90", color: "bg-red-100 text-red-800" },
-	{ key: "mora_120_plus" as const, label: "Mora 120+", color: "bg-red-300 text-red-950" },
+	{
+		key: "mora_30" as const,
+		label: "Mora 30",
+		color: "bg-yellow-100 text-yellow-800",
+	},
+	{
+		key: "mora_60" as const,
+		label: "Mora 60",
+		color: "bg-orange-100 text-orange-800",
+	},
+	{
+		key: "mora_90" as const,
+		label: "Mora 90",
+		color: "bg-red-100 text-red-800",
+	},
+	{
+		key: "mora_120_plus" as const,
+		label: "Mora 120+",
+		color: "bg-red-300 text-red-950",
+	},
 ];
 
-function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
-	const emailCobrador = canSeeAll ? undefined : (session?.user?.email ?? undefined);
+function TabMora({
+	session,
+	canSeeAll,
+}: {
+	session: ReturnType<typeof authClient.useSession>["data"];
+	canSeeAll: boolean;
+}) {
+	const emailCobrador = canSeeAll
+		? undefined
+		: (session?.user?.email ?? undefined);
 
 	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
 		...orpc.getMoraByEtapaYAsesor.queryOptions({ input: { emailCobrador } }),
@@ -74,10 +102,19 @@ function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient
 				</div>
 				<div className="flex items-center gap-3">
 					{ultimaAct && (
-						<span className="text-muted-foreground text-xs">Actualizado: {ultimaAct}</span>
+						<span className="text-muted-foreground text-xs">
+							Actualizado: {ultimaAct}
+						</span>
 					)}
-					<Button variant="outline" size="sm" onClick={() => refetch()} disabled={isFetching}>
-						<RefreshCw className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`} />
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => refetch()}
+						disabled={isFetching}
+					>
+						<RefreshCw
+							className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+						/>
 						Actualizar
 					</Button>
 				</div>
@@ -86,7 +123,11 @@ function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient
 			{isLoading ? (
 				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
 					{ETAPAS.map((e) => (
-						<Card key={e.key}><CardContent className="pt-6"><div className="h-12 animate-pulse rounded bg-muted" /></CardContent></Card>
+						<Card key={e.key}>
+							<CardContent className="pt-6">
+								<div className="h-12 animate-pulse rounded bg-muted" />
+							</CardContent>
+						</Card>
 					))}
 				</div>
 			) : (
@@ -97,12 +138,18 @@ function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient
 						return (
 							<Card key={etapa.key}>
 								<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-									<CardTitle className="font-medium text-sm">{etapa.label}</CardTitle>
+									<CardTitle className="font-medium text-sm">
+										{etapa.label}
+									</CardTitle>
 									<Badge className={etapa.color}>{bucket?.cantidad ?? 0}</Badge>
 								</CardHeader>
 								<CardContent>
-									<div className="font-bold text-2xl">{fmtQ(bucket?.sumaMora ?? "0")}</div>
-									<p className="text-muted-foreground text-xs">Capital: {fmtQ(bucket?.sumaCapital ?? "0")}</p>
+									<div className="font-bold text-2xl">
+										{fmtQ(bucket?.sumaMora ?? "0")}
+									</div>
+									<p className="text-muted-foreground text-xs">
+										Capital: {fmtQ(bucket?.sumaCapital ?? "0")}
+									</p>
 								</CardContent>
 							</Card>
 						);
@@ -116,12 +163,21 @@ function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient
 					<CardContent className="pt-4">
 						<div className="flex items-center justify-between">
 							<div>
-								<p className="font-semibold text-sm text-red-700">Total en Mora</p>
+								<p className="font-semibold text-red-700 text-sm">
+									Total en Mora
+								</p>
 								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								<p className="font-bold text-3xl text-red-800">{fmtQ((data as any).totales.totalEnMora.sumaMora)}</p>
+								<p className="font-bold text-3xl text-red-800">
+									{fmtQ((data as any).totales.totalEnMora.sumaMora)}
+								</p>
 							</div>
 							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-							<div className="text-right"><p className="text-muted-foreground text-sm">Créditos</p><p className="font-bold text-2xl">{(data as any).totales.totalEnMora.cantidad}</p></div>
+							<div className="text-right">
+								<p className="text-muted-foreground text-sm">Créditos</p>
+								<p className="font-bold text-2xl">
+									{(data as any).totales.totalEnMora.cantidad}
+								</p>
+							</div>
 						</div>
 					</CardContent>
 				</Card>
@@ -131,23 +187,37 @@ function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient
 				<h3 className="mb-3 font-semibold text-base">Desglose por Asesor</h3>
 				{isLoading ? (
 					<div className="h-32 animate-pulse rounded bg-muted" />
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				) : !(data as any)?.porAsesor?.length ? (
-					<p className="text-muted-foreground text-sm">No hay datos disponibles.</p>
+					<p className="text-muted-foreground text-sm">
+						No hay datos disponibles.
+					</p>
 				) : (
 					<div className="overflow-x-auto rounded-lg border">
 						<table className="w-full text-sm">
 							<thead className="bg-muted/50">
 								<tr>
 									<th className="px-4 py-3 text-left font-semibold">Asesor</th>
-									{ETAPAS.map((e) => <th key={e.key} className="px-4 py-3 text-right font-semibold">{e.label}</th>)}
-									<th className="px-4 py-3 text-right font-semibold">Total en Mora</th>
+									{ETAPAS.map((e) => (
+										<th
+											key={e.key}
+											className="px-4 py-3 text-right font-semibold"
+										>
+											{e.label}
+										</th>
+									))}
+									<th className="px-4 py-3 text-right font-semibold">
+										Total en Mora
+									</th>
 								</tr>
 							</thead>
 							<tbody>
 								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 								{(data as any).porAsesor.map((asesor: any) => (
-									<tr key={asesor.asesorId} className="border-t hover:bg-muted/30">
+									<tr
+										key={asesor.asesorId}
+										className="border-t hover:bg-muted/30"
+									>
 										<td className="px-4 py-3 font-medium">{asesor.nombre}</td>
 										{ETAPAS.map((etapa) => {
 											const bucket = asesor[etapa.key];
@@ -155,16 +225,26 @@ function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient
 												<td key={etapa.key} className="px-4 py-3 text-right">
 													{bucket?.cantidad > 0 ? (
 														<div>
-															<div className="font-medium">{fmtQ(bucket.sumaMora)}</div>
-															<div className="text-muted-foreground text-xs">{bucket.cantidad} créd.</div>
+															<div className="font-medium">
+																{fmtQ(bucket.sumaMora)}
+															</div>
+															<div className="text-muted-foreground text-xs">
+																{bucket.cantidad} créd.
+															</div>
 														</div>
-													) : <span className="text-muted-foreground">—</span>}
+													) : (
+														<span className="text-muted-foreground">—</span>
+													)}
 												</td>
 											);
 										})}
 										<td className="px-4 py-3 text-right">
-											<div className="font-semibold text-red-700">{fmtQ(asesor.totalEnMora?.sumaMora ?? "0")}</div>
-											<div className="text-muted-foreground text-xs">{asesor.totalEnMora?.cantidad ?? 0} créd.</div>
+											<div className="font-semibold text-red-700">
+												{fmtQ(asesor.totalEnMora?.sumaMora ?? "0")}
+											</div>
+											<div className="text-muted-foreground text-xs">
+												{asesor.totalEnMora?.cantidad ?? 0} créd.
+											</div>
 										</td>
 									</tr>
 								))}
@@ -180,15 +260,23 @@ function TabMora({ session, canSeeAll }: { session: ReturnType<typeof authClient
 											return (
 												<td key={etapa.key} className="px-4 py-3 text-right">
 													<div>{fmtQ(bucket?.sumaMora ?? "0")}</div>
-													<div className="font-normal text-muted-foreground text-xs">{bucket?.cantidad ?? 0} créd.</div>
+													<div className="font-normal text-muted-foreground text-xs">
+														{bucket?.cantidad ?? 0} créd.
+													</div>
 												</td>
 											);
 										})}
 										<td className="px-4 py-3 text-right text-red-700">
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-											<div>{fmtQ((data as any).totales.totalEnMora?.sumaMora ?? "0")}</div>
+											<div>
+												{fmtQ(
+													(data as any).totales.totalEnMora?.sumaMora ?? "0",
+												)}
+											</div>
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-											<div className="font-normal text-muted-foreground text-xs">{(data as any).totales.totalEnMora?.cantidad ?? 0} créd.</div>
+											<div className="font-normal text-muted-foreground text-xs">
+												{(data as any).totales.totalEnMora?.cantidad ?? 0} créd.
+											</div>
 										</td>
 									</tr>
 								</tfoot>
@@ -239,19 +327,24 @@ type DesgloseDia = {
 // offset de zona horaria los desplace al día anterior.
 function fmtBucketDia(bucket: string) {
 	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
-	return date.toLocaleDateString("es-GT", { weekday: "short", day: "2-digit", month: "short" });
+	return date.toLocaleDateString("es-GT", {
+		weekday: "short",
+		day: "2-digit",
+		month: "short",
+	});
 }
 
 // `total_cuota` de cartera-back es el capital; el total a cobrar de la fila
 // es la suma de rubros (mismo criterio que el reporte monto-a-cobrar).
 function totalDeFila(row: DesgloseDia) {
 	return (
-		parseFloat(row.total_cuota) +
-		parseFloat(row.total_interes) +
-		parseFloat(row.total_iva) +
-		parseFloat(row.total_seguro) +
-		parseFloat(row.total_gps) +
-		parseFloat(row.total_membresias)
+		Number.parseFloat(row.total_cuota) +
+		Number.parseFloat(row.total_interes) +
+		Number.parseFloat(row.total_iva) +
+		Number.parseFloat(row.total_seguro) +
+		Number.parseFloat(row.total_gps) +
+		Number.parseFloat(row.total_membresias) +
+		Number.parseFloat(row.total_royalti)
 	);
 }
 
@@ -268,9 +361,12 @@ type PagoNoRecibido = {
 };
 
 function getMoraBadge(cuotas: number) {
-	if (cuotas >= 4) return <Badge className="bg-red-300 text-red-950">Mora 120+</Badge>;
-	if (cuotas === 3) return <Badge className="bg-red-100 text-red-800">Mora 90</Badge>;
-	if (cuotas === 2) return <Badge className="bg-orange-100 text-orange-800">Mora 60</Badge>;
+	if (cuotas >= 4)
+		return <Badge className="bg-red-300 text-red-950">Mora 120+</Badge>;
+	if (cuotas === 3)
+		return <Badge className="bg-red-100 text-red-800">Mora 90</Badge>;
+	if (cuotas === 2)
+		return <Badge className="bg-orange-100 text-orange-800">Mora 60</Badge>;
 	return <Badge className="bg-yellow-100 text-yellow-800">Mora 30</Badge>;
 }
 
@@ -279,7 +375,12 @@ const colsPagos: ColumnDef<PagoNoRecibido>[] = [
 		accessorKey: "sifco",
 		header: "Crédito",
 		cell: ({ row }) => (
-			<Link to="/cobros/$id" params={{ id: row.original.sifco }} search={{ tipo: "contrato" }} className="font-mono text-blue-600 text-xs hover:underline">
+			<Link
+				to="/cobros/$id"
+				params={{ id: row.original.sifco }}
+				search={{ tipo: "contrato" }}
+				className="font-mono text-blue-600 text-xs hover:underline"
+			>
 				{row.original.sifco}
 			</Link>
 		),
@@ -294,35 +395,93 @@ const colsPagos: ColumnDef<PagoNoRecibido>[] = [
 	{
 		accessorKey: "montoMora",
 		header: "Monto Mora",
-		cell: ({ row }) => <span className="font-medium text-red-700">{fmtQ(row.original.montoMora)}</span>,
+		cell: ({ row }) => (
+			<span className="font-medium text-red-700">
+				{fmtQ(row.original.montoMora)}
+			</span>
+		),
 	},
-	{ accessorKey: "capital", header: "Capital Restante", cell: ({ row }) => fmtQ(row.original.capital) },
-	{ accessorKey: "cuotaMensual", header: "Cuota Mensual", cell: ({ row }) => fmtQ(row.original.cuotaMensual) },
+	{
+		accessorKey: "capital",
+		header: "Capital Restante",
+		cell: ({ row }) => fmtQ(row.original.capital),
+	},
+	{
+		accessorKey: "cuotaMensual",
+		header: "Cuota Mensual",
+		cell: ({ row }) => fmtQ(row.original.cuotaMensual),
+	},
 	{
 		accessorKey: "proximaFechaVencimiento",
 		header: "Próx. Vencimiento",
 		cell: ({ row }) =>
 			row.original.proximaFechaVencimiento
-				? new Date(`${row.original.proximaFechaVencimiento}T00:00:00`).toLocaleDateString("es-GT")
+				? new Date(
+						`${row.original.proximaFechaVencimiento}T00:00:00`,
+					).toLocaleDateString("es-GT")
 				: "—",
 	},
 ];
 
-function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
-	const [temporalidad, setTemporalidad] = usePersistedState<Temporalidad>("cobros/reportes/temporalidad", "hoy");
-	const [emailAsesor, setEmailAsesor] = usePersistedState<string>("cobros/reportes/pagos/emailAsesor", "");
-	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>("cobros/reportes/pagos/capitalMin", undefined);
-	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>("cobros/reportes/pagos/capitalMax", undefined);
-	const [cuotasMin, setCuotasMin] = usePersistedState<string>("cobros/reportes/pagos/cuotasMin", "");
-	const [cuotasMax, setCuotasMax] = usePersistedState<string>("cobros/reportes/pagos/cuotasMax", "");
-	const [fechaDesde, setFechaDesde] = usePersistedState<string>("cobros/reportes/pagos/fechaDesde", "");
-	const [fechaHasta, setFechaHasta] = usePersistedState<string>("cobros/reportes/pagos/fechaHasta", "");
-	const [page, setPage] = usePersistedState<number>("cobros/reportes/pagos/page", 1);
-	const [pageSize] = usePersistedState<number>("cobros/reportes/pagos/pageSize", 25);
+function TabPagos({
+	session,
+	canSeeAll,
+}: {
+	session: ReturnType<typeof authClient.useSession>["data"];
+	canSeeAll: boolean;
+}) {
+	const [temporalidad, setTemporalidad] = usePersistedState<Temporalidad>(
+		"cobros/reportes/temporalidad",
+		"hoy",
+	);
+	const [emailAsesor, setEmailAsesor] = usePersistedState<string>(
+		"cobros/reportes/pagos/emailAsesor",
+		"",
+	);
+	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>(
+		"cobros/reportes/pagos/capitalMin",
+		undefined,
+	);
+	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>(
+		"cobros/reportes/pagos/capitalMax",
+		undefined,
+	);
+	const [cuotasMin, setCuotasMin] = usePersistedState<string>(
+		"cobros/reportes/pagos/cuotasMin",
+		"",
+	);
+	const [cuotasMax, setCuotasMax] = usePersistedState<string>(
+		"cobros/reportes/pagos/cuotasMax",
+		"",
+	);
+	const [fechaDesde, setFechaDesde] = usePersistedState<string>(
+		"cobros/reportes/pagos/fechaDesde",
+		"",
+	);
+	const [fechaHasta, setFechaHasta] = usePersistedState<string>(
+		"cobros/reportes/pagos/fechaHasta",
+		"",
+	);
+	const [page, setPage] = usePersistedState<number>(
+		"cobros/reportes/pagos/page",
+		1,
+	);
+	const [pageSize] = usePersistedState<number>(
+		"cobros/reportes/pagos/pageSize",
+		25,
+	);
 
-	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
+	const emailCobrador = canSeeAll
+		? emailAsesor || undefined
+		: (session?.user?.email ?? undefined);
 
-	const { data: resumenData, isLoading: resumenLoading, dataUpdatedAt, refetch: refetchResumen, isFetching: resumenFetching } = useQuery({
+	const {
+		data: resumenData,
+		isLoading: resumenLoading,
+		dataUpdatedAt,
+		refetch: refetchResumen,
+		isFetching: resumenFetching,
+	} = useQuery({
 		...orpc.getPagosEsperadosCobros.queryOptions({ input: { temporalidad } }),
 		enabled: !!session,
 		staleTime: 5 * 60 * 1000,
@@ -339,8 +498,12 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 				emailCobrador,
 				capitalMin,
 				capitalMax,
-				cuotasAtrasadasMin: cuotasMin ? parseInt(cuotasMin, 10) : undefined,
-				cuotasAtrasadasMax: cuotasMax ? parseInt(cuotasMax, 10) : undefined,
+				cuotasAtrasadasMin: cuotasMin
+					? Number.parseInt(cuotasMin, 10)
+					: undefined,
+				cuotasAtrasadasMax: cuotasMax
+					? Number.parseInt(cuotasMax, 10)
+					: undefined,
 				fechaDesde: fechaDesde || undefined,
 				fechaHasta: fechaHasta || undefined,
 				page,
@@ -351,7 +514,12 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 		staleTime: 5 * 60 * 1000,
 	});
 
-	const ultimaAct = dataUpdatedAt ? new Date(dataUpdatedAt).toLocaleTimeString("es-GT", { hour: "2-digit", minute: "2-digit" }) : null;
+	const ultimaAct = dataUpdatedAt
+		? new Date(dataUpdatedAt).toLocaleTimeString("es-GT", {
+				hour: "2-digit",
+				minute: "2-digit",
+			})
+		: null;
 
 	return (
 		<div className="space-y-6">
@@ -364,14 +532,30 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 			<div className="flex flex-wrap items-center gap-2">
 				<span className="font-medium text-sm">Período:</span>
 				{(Object.keys(TEMPORALIDAD_LABELS) as Temporalidad[]).map((t) => (
-					<Button key={t} variant={temporalidad === t ? "default" : "outline"} size="sm" onClick={() => setTemporalidad(t)}>
+					<Button
+						key={t}
+						variant={temporalidad === t ? "default" : "outline"}
+						size="sm"
+						onClick={() => setTemporalidad(t)}
+					>
 						{TEMPORALIDAD_LABELS[t]}
 					</Button>
 				))}
 				<div className="ml-auto flex items-center gap-2">
-					{ultimaAct && <span className="text-muted-foreground text-xs">Actualizado: {ultimaAct}</span>}
-					<Button variant="outline" size="sm" onClick={() => refetchResumen()} disabled={resumenFetching}>
-						<RefreshCw className={`mr-2 h-4 w-4 ${resumenFetching ? "animate-spin" : ""}`} />
+					{ultimaAct && (
+						<span className="text-muted-foreground text-xs">
+							Actualizado: {ultimaAct}
+						</span>
+					)}
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => refetchResumen()}
+						disabled={resumenFetching}
+					>
+						<RefreshCw
+							className={`mr-2 h-4 w-4 ${resumenFetching ? "animate-spin" : ""}`}
+						/>
 						Actualizar
 					</Button>
 				</div>
@@ -379,40 +563,72 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 
 			{resumenLoading ? (
 				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-					{RUBROS.map((r) => <Card key={r.key}><CardContent className="pt-6"><div className="h-10 animate-pulse rounded bg-muted" /></CardContent></Card>)}
+					{RUBROS.map((r) => (
+						<Card key={r.key}>
+							<CardContent className="pt-6">
+								<div className="h-10 animate-pulse rounded bg-muted" />
+							</CardContent>
+						</Card>
+					))}
 				</div>
 			) : (
 				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
 					{RUBROS.map((r) => {
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						const value = (resumenData as any)?.totales?.[r.key] as string | number | undefined;
+						const value = (resumenData as any)?.totales?.[r.key] as
+							| string
+							| number
+							| undefined;
 						return (
-							<Card key={r.key} className={r.highlight ? "border-blue-200 bg-blue-50" : ""}>
+							<Card
+								key={r.key}
+								className={r.highlight ? "border-blue-200 bg-blue-50" : ""}
+							>
 								<CardHeader className="pb-2">
-									<CardTitle className={`font-medium text-sm ${r.highlight ? "text-blue-700" : ""}`}>{r.label}</CardTitle>
+									<CardTitle
+										className={`font-medium text-sm ${r.highlight ? "text-blue-700" : ""}`}
+									>
+										{r.label}
+									</CardTitle>
 								</CardHeader>
 								<CardContent>
-									<div className={`font-bold text-xl ${r.highlight ? "text-blue-800" : ""}`}>{fmtQ(String(value ?? "0"))}</div>
+									<div
+										className={`font-bold text-xl ${r.highlight ? "text-blue-800" : ""}`}
+									>
+										{fmtQ(String(value ?? "0"))}
+									</div>
 								</CardContent>
 							</Card>
 						);
 					})}
 					<Card>
-						<CardHeader className="pb-2"><CardTitle className="font-medium text-sm">Cant. Cuotas</CardTitle></CardHeader>
+						<CardHeader className="pb-2">
+							<CardTitle className="font-medium text-sm">
+								Cant. Cuotas
+							</CardTitle>
+						</CardHeader>
 						{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-						<CardContent><div className="font-bold text-xl">{(resumenData as any)?.totales?.cantidadCuotas ?? 0}</div></CardContent>
+						<CardContent>
+							<div className="font-bold text-xl">
+								{(resumenData as any)?.totales?.cantidadCuotas ?? 0}
+							</div>
+						</CardContent>
 					</Card>
 				</div>
 			)}
 
 			{!!resumenData && (
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				<p className="text-muted-foreground text-xs">Período: {(resumenData as any).fechaInicio} → {(resumenData as any).fechaFin}</p>
+				<p className="text-muted-foreground text-xs">
+					Período: {(resumenData as any).fechaInicio} →{" "}
+					{(resumenData as any).fechaFin}
+				</p>
 			)}
 
 			{(() => {
 				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				const desglose = ((resumenData as any)?.desglose ?? []) as DesgloseDia[];
+				const desglose = ((resumenData as any)?.desglose ??
+					[]) as DesgloseDia[];
 				if (temporalidad === "hoy" || desglose.length <= 1) return null;
 				return (
 					<div>
@@ -422,22 +638,42 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 								<thead className="bg-muted/50">
 									<tr>
 										<th className="px-4 py-3 text-left font-semibold">Fecha</th>
-										<th className="px-4 py-3 text-right font-semibold">Cuotas</th>
-										<th className="px-4 py-3 text-right font-semibold">Capital</th>
-										<th className="px-4 py-3 text-right font-semibold">Interés</th>
+										<th className="px-4 py-3 text-right font-semibold">
+											Cuotas
+										</th>
+										<th className="px-4 py-3 text-right font-semibold">
+											Capital
+										</th>
+										<th className="px-4 py-3 text-right font-semibold">
+											Interés
+										</th>
 										<th className="px-4 py-3 text-right font-semibold">IVA</th>
-										<th className="px-4 py-3 text-right font-semibold">Total a Cobrar</th>
+										<th className="px-4 py-3 text-right font-semibold">
+											Total a Cobrar
+										</th>
 									</tr>
 								</thead>
 								<tbody>
 									{desglose.map((row) => (
 										<tr key={row.bucket} className="border-t hover:bg-muted/30">
-											<td className="px-4 py-3 font-medium">{fmtBucketDia(row.bucket)}</td>
-											<td className="px-4 py-3 text-right">{row.cuotas_count}</td>
-											<td className="px-4 py-3 text-right">{fmtQ(row.total_cuota)}</td>
-											<td className="px-4 py-3 text-right">{fmtQ(row.total_interes)}</td>
-											<td className="px-4 py-3 text-right">{fmtQ(row.total_iva)}</td>
-											<td className="px-4 py-3 text-right font-medium">{fmtQ(totalDeFila(row))}</td>
+											<td className="px-4 py-3 font-medium">
+												{fmtBucketDia(row.bucket)}
+											</td>
+											<td className="px-4 py-3 text-right">
+												{row.cuotas_count}
+											</td>
+											<td className="px-4 py-3 text-right">
+												{fmtQ(row.total_cuota)}
+											</td>
+											<td className="px-4 py-3 text-right">
+												{fmtQ(row.total_interes)}
+											</td>
+											<td className="px-4 py-3 text-right">
+												{fmtQ(row.total_iva)}
+											</td>
+											<td className="px-4 py-3 text-right font-medium">
+												{fmtQ(totalDeFila(row))}
+											</td>
 										</tr>
 									))}
 								</tbody>
@@ -455,35 +691,91 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 				{canSeeAll && (
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Asesor</Label>
-						<Select value={emailAsesor} onValueChange={(v) => { setEmailAsesor(v === "todos" ? "" : v); setPage(1); }}>
-							<SelectTrigger className="w-52"><SelectValue placeholder="Todos los asesores" /></SelectTrigger>
+						<Select
+							value={emailAsesor}
+							onValueChange={(v) => {
+								setEmailAsesor(v === "todos" ? "" : v);
+								setPage(1);
+							}}
+						>
+							<SelectTrigger className="w-52">
+								<SelectValue placeholder="Todos los asesores" />
+							</SelectTrigger>
 							<SelectContent>
 								<SelectItem value="todos">Todos</SelectItem>
 								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								{(asesoresData as any)?.asesores?.map((a: any) => <SelectItem key={a.asesorId} value={a.email}>{a.nombre}</SelectItem>)}
+								{(asesoresData as any)?.asesores?.map((a: any) => (
+									<SelectItem key={a.asesorId} value={a.email}>
+										{a.nombre}
+									</SelectItem>
+								))}
 							</SelectContent>
 						</Select>
 					</div>
 				)}
-				<CapitalRangeFilter capitalMin={capitalMin} capitalMax={capitalMax} onCapitalRangeChange={(min, max) => { setCapitalMin(min); setCapitalMax(max); setPage(1); }} />
+				<CapitalRangeFilter
+					capitalMin={capitalMin}
+					capitalMax={capitalMax}
+					onCapitalRangeChange={(min, max) => {
+						setCapitalMin(min);
+						setCapitalMax(max);
+						setPage(1);
+					}}
+				/>
 				<div className="flex items-end gap-2">
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Cuotas atrasadas mín.</Label>
-						<Input type="number" min={1} className="w-24" placeholder="1" value={cuotasMin} onChange={(e) => { setCuotasMin(e.target.value); setPage(1); }} />
+						<Input
+							type="number"
+							min={1}
+							className="w-24"
+							placeholder="1"
+							value={cuotasMin}
+							onChange={(e) => {
+								setCuotasMin(e.target.value);
+								setPage(1);
+							}}
+						/>
 					</div>
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Cuotas atrasadas máx.</Label>
-						<Input type="number" min={1} className="w-24" placeholder="—" value={cuotasMax} onChange={(e) => { setCuotasMax(e.target.value); setPage(1); }} />
+						<Input
+							type="number"
+							min={1}
+							className="w-24"
+							placeholder="—"
+							value={cuotasMax}
+							onChange={(e) => {
+								setCuotasMax(e.target.value);
+								setPage(1);
+							}}
+						/>
 					</div>
 				</div>
 				<div className="flex items-end gap-2">
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Fecha pago desde</Label>
-						<Input type="date" className="w-40" value={fechaDesde} onChange={(e) => { setFechaDesde(e.target.value); setPage(1); }} />
+						<Input
+							type="date"
+							className="w-40"
+							value={fechaDesde}
+							onChange={(e) => {
+								setFechaDesde(e.target.value);
+								setPage(1);
+							}}
+						/>
 					</div>
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Fecha pago hasta</Label>
-						<Input type="date" className="w-40" value={fechaHasta} onChange={(e) => { setFechaHasta(e.target.value); setPage(1); }} />
+						<Input
+							type="date"
+							className="w-40"
+							value={fechaHasta}
+							onChange={(e) => {
+								setFechaHasta(e.target.value);
+								setPage(1);
+							}}
+						/>
 					</div>
 				</div>
 			</div>
@@ -496,8 +788,14 @@ function TabPagos({ session, canSeeAll }: { session: ReturnType<typeof authClien
 				hideSearch
 				serverPagination={
 					noRecibidosData
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						? { page: (noRecibidosData as any).page, pageSize: (noRecibidosData as any).pageSize, totalPages: (noRecibidosData as any).totalPages, totalItems: (noRecibidosData as any).total, onPageChange: setPage }
+						? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+							{
+								page: (noRecibidosData as any).page,
+								pageSize: (noRecibidosData as any).pageSize,
+								totalPages: (noRecibidosData as any).totalPages,
+								totalItems: (noRecibidosData as any).total,
+								onPageChange: setPage,
+							}
 						: undefined
 				}
 			/>
@@ -527,40 +825,95 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 		accessorKey: "sifco",
 		header: "Crédito",
 		cell: ({ row }) => (
-			<Link to="/cobros/$id" params={{ id: row.original.sifco }} search={{ tipo: "contrato" }} className="font-mono text-blue-600 text-xs hover:underline">
+			<Link
+				to="/cobros/$id"
+				params={{ id: row.original.sifco }}
+				search={{ tipo: "contrato" }}
+				className="font-mono text-blue-600 text-xs hover:underline"
+			>
 				{row.original.sifco}
 			</Link>
 		),
 	},
 	{ accessorKey: "clienteNombre", header: "Cliente" },
 	{ accessorKey: "asesorNombre", header: "Asesor" },
-	{ accessorKey: "capital", header: "Capital", cell: ({ row }) => fmtQ(row.original.capital) },
-	{ accessorKey: "gps", header: "GPS", cell: ({ row }) => fmtQ(row.original.gps) },
-	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtQ(row.original.seguro) },
-	{ accessorKey: "membresias", header: "Membresías", cell: ({ row }) => fmtQ(row.original.membresias) },
-	{ accessorKey: "otros", header: "Otros", cell: ({ row }) => fmtQ(row.original.otros) },
+	{
+		accessorKey: "capital",
+		header: "Capital",
+		cell: ({ row }) => fmtQ(row.original.capital),
+	},
+	{
+		accessorKey: "gps",
+		header: "GPS",
+		cell: ({ row }) => fmtQ(row.original.gps),
+	},
+	{
+		accessorKey: "seguro",
+		header: "Seguro",
+		cell: ({ row }) => fmtQ(row.original.seguro),
+	},
+	{
+		accessorKey: "membresias",
+		header: "Membresías",
+		cell: ({ row }) => fmtQ(row.original.membresias),
+	},
+	{
+		accessorKey: "otros",
+		header: "Otros",
+		cell: ({ row }) => fmtQ(row.original.otros),
+	},
 	{
 		accessorKey: "rubrosTotal",
 		header: "Rubros Extra",
 		cell: ({ row }) => {
 			const monto = fmtQ(row.original.rubrosTotal);
-			if (parseFloat(row.original.rubrosTotal) <= 0) return <span className="text-muted-foreground">—</span>;
-			return <div title={row.original.rubros.map((r) => `${r.nombre}: ${fmtQ(r.monto)}`).join("\n")}>{monto}</div>;
+			if (Number.parseFloat(row.original.rubrosTotal) <= 0)
+				return <span className="text-muted-foreground">—</span>;
+			return (
+				<div
+					title={row.original.rubros
+						.map((r) => `${r.nombre}: ${fmtQ(r.monto)}`)
+						.join("\n")}
+				>
+					{monto}
+				</div>
+			);
 		},
 	},
 	{
 		accessorKey: "totalDescuentos",
 		header: "Total Descuentos",
-		cell: ({ row }) => <span className="font-semibold">{fmtQ(row.original.totalDescuentos)}</span>,
+		cell: ({ row }) => (
+			<span className="font-semibold">
+				{fmtQ(row.original.totalDescuentos)}
+			</span>
+		),
 	},
 ];
 
-function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof authClient.useSession>["data"]; canSeeAll: boolean }) {
-	const [emailAsesor, setEmailAsesor] = usePersistedState<string>("cobros/reportes/desc/emailAsesor", "");
-	const [page, setPage] = usePersistedState<number>("cobros/reportes/desc/page", 1);
-	const [pageSize] = usePersistedState<number>("cobros/reportes/desc/pageSize", 25);
+function TabDescuentos({
+	session,
+	canSeeAll,
+}: {
+	session: ReturnType<typeof authClient.useSession>["data"];
+	canSeeAll: boolean;
+}) {
+	const [emailAsesor, setEmailAsesor] = usePersistedState<string>(
+		"cobros/reportes/desc/emailAsesor",
+		"",
+	);
+	const [page, setPage] = usePersistedState<number>(
+		"cobros/reportes/desc/page",
+		1,
+	);
+	const [pageSize] = usePersistedState<number>(
+		"cobros/reportes/desc/pageSize",
+		25,
+	);
 
-	const emailCobrador = canSeeAll ? (emailAsesor || undefined) : (session?.user?.email ?? undefined);
+	const emailCobrador = canSeeAll
+		? emailAsesor || undefined
+		: (session?.user?.email ?? undefined);
 
 	const { data: asesoresData } = useQuery({
 		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
@@ -568,7 +921,9 @@ function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof auth
 	});
 
 	const { data, isLoading } = useQuery({
-		...orpc.getDescuentosCRM.queryOptions({ input: { page, pageSize, emailCobrador } }),
+		...orpc.getDescuentosCRM.queryOptions({
+			input: { page, pageSize, emailCobrador },
+		}),
 		enabled: !!session,
 		staleTime: 5 * 60 * 1000,
 	});
@@ -583,12 +938,24 @@ function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof auth
 			{canSeeAll && (
 				<div className="flex flex-col gap-1">
 					<Label className="text-xs">Asesor</Label>
-					<Select value={emailAsesor} onValueChange={(v) => { setEmailAsesor(v === "todos" ? "" : v); setPage(1); }}>
-						<SelectTrigger className="w-52"><SelectValue placeholder="Todos los asesores" /></SelectTrigger>
+					<Select
+						value={emailAsesor}
+						onValueChange={(v) => {
+							setEmailAsesor(v === "todos" ? "" : v);
+							setPage(1);
+						}}
+					>
+						<SelectTrigger className="w-52">
+							<SelectValue placeholder="Todos los asesores" />
+						</SelectTrigger>
 						<SelectContent>
 							<SelectItem value="todos">Todos</SelectItem>
 							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-							{(asesoresData as any)?.asesores?.map((a: any) => <SelectItem key={a.asesorId} value={a.email}>{a.nombre}</SelectItem>)}
+							{(asesoresData as any)?.asesores?.map((a: any) => (
+								<SelectItem key={a.asesorId} value={a.email}>
+									{a.nombre}
+								</SelectItem>
+							))}
 						</SelectContent>
 					</Select>
 				</div>
@@ -602,8 +969,14 @@ function TabDescuentos({ session, canSeeAll }: { session: ReturnType<typeof auth
 				hideSearch
 				serverPagination={
 					data
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						? { page: (data as any).page, pageSize: (data as any).pageSize, totalPages: (data as any).totalPages, totalItems: (data as any).total, onPageChange: setPage }
+						? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+							{
+								page: (data as any).page,
+								pageSize: (data as any).pageSize,
+								totalPages: (data as any).totalPages,
+								totalItems: (data as any).total,
+								onPageChange: setPage,
+							}
 						: undefined
 				}
 			/>

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -135,6 +135,9 @@ function TabMora({
 					{ETAPAS.map((etapa) => {
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						const bucket = (data as any)?.totales?.[etapa.key];
+						// eslint-disable-next-line @typescript-eslint/no-explicit-any
+						const totalMora = parseFloat((data as any)?.totales?.totalEnMora?.sumaMora ?? "0");
+						const pct = totalMora > 0 ? (parseFloat(bucket?.sumaMora ?? "0") / totalMora) * 100 : 0;
 						return (
 							<Card key={etapa.key}>
 								<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -149,6 +152,9 @@ function TabMora({
 									</div>
 									<p className="text-muted-foreground text-xs">
 										Capital: {fmtQ(bucket?.sumaCapital ?? "0")}
+									</p>
+									<p className="mt-1 font-medium text-xs text-muted-foreground">
+										{pct.toFixed(1)}% del total en mora
 									</p>
 								</CardContent>
 							</Card>
@@ -245,6 +251,16 @@ function TabMora({
 											<div className="text-muted-foreground text-xs">
 												{asesor.totalEnMora?.cantidad ?? 0} créd.
 											</div>
+											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+											{(() => {
+												const totalMora = parseFloat((data as any)?.totales?.totalEnMora?.sumaMora ?? "0");
+												const pct = totalMora > 0 ? (parseFloat(asesor.totalEnMora?.sumaMora ?? "0") / totalMora) * 100 : 0;
+												return pct > 0 ? (
+													<div className="font-medium text-muted-foreground text-xs">
+														{pct.toFixed(1)}%
+													</div>
+												) : null;
+											})()}
 										</td>
 									</tr>
 								))}


### PR DESCRIPTION
## Resumen

### fix: Royaltí incluido en totales
- **Server** (`routers/cobros.ts`): `totalACobrar` ahora suma `totalRoyalti`, que estaba excluido.
- **Web** (`routes/cobros/reportes.tsx`): `totalDeFila()` suma `total_royalti` para que el total de cada fila cuadre.

### feat: % del total en mora
- **Tab Mora** (`routes/cobros/reportes.tsx`): cada bucket de mora (30/60/90/120) muestra su % respecto al total en mora.
- **Comparativo Histórico Mensual** (`routes/admin/reports/index.tsx`): cada celda de mora muestra monto, conteo y % dentro del total de mora de esa fila mensual.

### feat: Desglose por Inversionista en Flujo de Cuotas
- **cartera-back** (`controllers/reportes.ts` + `routers/reportes.ts`): nuevo endpoint `GET /reportes/flujo-cuotas-inversiones/por-inversionista` que calcula reinversión vs monto a recibir por inversionista, respetando los tipos de reinversión (`sin_reinversion`, `reinversion_capital`, `reinversion_interes`, `reinversion_total`, `reinversion_variable`, `reinversion_excedente`).
- **CRM server** (`services/cartera-back-client.ts`, `routers/reportes-cartera.ts`, `routers/index.ts`): nuevo tipo `FlujoCuotasPorInversionistaResponse` + procedimiento `getFlujoCuotasPorInversionista`.
- **CRM web** (`routes/admin/reports/index.tsx`): sección colapsable "Desglose por Inversionista" dentro del card Flujo de Cuotas con tabla (Inversionista | Reinversión | A Recibir | Total) y botón "Exportar Excel". Columna renombrada de "Cash" a "A Recibir" para reflejar que es pago al inversionista.

## Test plan
- [ ] Verificar que el total a cobrar en cobros incluye royaltí
- [ ] Verificar % mora en tab Mora de cobros
- [ ] Verificar % mora en Comparativo Histórico Mensual
- [ ] Seleccionar rango en Flujo de Cuotas → expandir "Desglose por Inversionista" → confirmar todos los inversionistas (con y sin reinversión)
- [ ] Exportar Excel y verificar columnas "A Recibir" con montos correctos
- [ ] Reiniciar cartera-back para activar el nuevo endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)