### PR TITLE
feat(carteraFront): mensajes de error descriptivos en cartera part3

### DIFF
--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -77,12 +77,49 @@ function esDetalleTecnicoCrudo(detail: string): boolean {
 }
 
 /**
+ * Decide qué texto del cuerpo del error se muestra al usuario, según la
+ * convención del backend de cartera:
+ *  - `message` / `mensaje`: texto curado (normalmente español), salvo cuando
+ *    es el genérico "Internal server error".
+ *  - `error`: por convención carga `error.message` crudo de la excepción
+ *    (`return { error: error.message }` en los catch), aunque algunos
+ *    endpoints meten ahí el motivo de negocio. Por eso `error` solo se
+ *    muestra si es traducible (negocio conocido) o no parece un crudo técnico
+ *    (stack, driver de DB, etc.). Esta regla aplica venga de donde venga el
+ *    `error`, no solo cuando los roles están invertidos.
+ */
+function extraerDetalle(data: unknown): string | undefined {
+  const cuerpo = (data ?? {}) as { message?: unknown; error?: unknown; mensaje?: unknown };
+  const message = typeof cuerpo.message === "string" ? cuerpo.message.trim() : "";
+  const mensaje = typeof cuerpo.mensaje === "string" ? cuerpo.mensaje.trim() : "";
+  const errorRaw = typeof cuerpo.error === "string" ? cuerpo.error.trim() : "";
+
+  const errorUtilizable =
+    !!errorRaw && (buscarTraduccion(errorRaw) !== null || !esDetalleTecnicoCrudo(errorRaw));
+
+  // `message` curado tiene prioridad, salvo que sea el genérico sin información.
+  if (message && !MENSAJE_SIN_INFORMACION.test(message)) {
+    return message;
+  }
+  // `error` solo si pasa el filtro de crudos.
+  if (errorUtilizable) {
+    return errorRaw;
+  }
+  // `message` genérico ("Internal server error") como último recurso textual.
+  if (message) {
+    return message;
+  }
+  if (mensaje) {
+    return mensaje;
+  }
+  return undefined;
+}
+
+/**
  * Extrae el motivo real de un error de API para mostrarlo al usuario.
  *
- * Prioridad de campos: `message` (texto curado de los endpoints) primero;
- * `error` cuando no hay `message` o cuando este es un genérico sin
- * información, porque hay endpoints donde los roles están invertidos
- * (`message: "Internal server error"` y el motivo real en `error`).
+ * El campo `error` (crudo por convención del backend) se filtra en
+ * `extraerDetalle`: nunca se muestra una excepción técnica al usuario.
  */
 export function getApiErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof AxiosError) {
@@ -93,22 +130,7 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
       return `${fallback}: Sin conexión con el servidor`;
     }
     const { status, data } = error.response;
-    let detail: unknown;
-    if (typeof data === "string") {
-      detail = data;
-    } else {
-      detail = data?.message ?? data?.error ?? data?.mensaje;
-      if (
-        typeof detail === "string" &&
-        MENSAJE_SIN_INFORMACION.test(detail.trim()) &&
-        typeof data?.error === "string" &&
-        data.error.trim() &&
-        (buscarTraduccion(data.error.trim()) !== null ||
-          !esDetalleTecnicoCrudo(data.error.trim()))
-      ) {
-        detail = data.error;
-      }
-    }
+    const detail = typeof data === "string" ? data : extraerDetalle(data);
     if (typeof detail === "string" && detail.trim()) {
       return `${fallback}: ${traducirDetalleTecnico(detail.trim())}`;
     }
@@ -121,7 +143,21 @@ export function getApiErrorMessage(error: unknown, fallback: string): string {
     return `${fallback} (HTTP ${status})`;
   }
   if (error instanceof Error && error.message) {
-    return `${fallback}: ${error.message}`;
+    const msg = error.message.trim();
+    // Algunos servicios relanzan `new Error(data.message || "<fallback>")`,
+    // por lo que `msg` puede ser ya el mismo fallback: no duplicar ("X: X").
+    if (!msg || msg === fallback) {
+      return fallback;
+    }
+    const traducido = buscarTraduccion(msg);
+    if (traducido) {
+      return `${fallback}: ${traducido}`;
+    }
+    // Mismo criterio que extraerDetalle: no filtrar crudos técnicos a la UI.
+    if (esDetalleTecnicoCrudo(msg)) {
+      return fallback;
+    }
+    return `${fallback}: ${msg}`;
   }
   return fallback;
 }

--- a/apps/carteraFront/src/private/cartera/hooks/cofidi.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/cofidi.ts
@@ -4,6 +4,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { toast } from 'sonner'; // o tu librería de toast
+import { getApiErrorMessage } from "@/lib/apiError";
 import {
   anularFactura,
   facturarPagoCompleto,
@@ -46,12 +47,8 @@ export const useFacturarPagoCompleto = () => {
       }
     },
     onError: (error: any) => {
-      const errorMsg = error?.response?.data?.error 
-        || error?.message 
-        || 'Error al generar facturas';
-      
-      toast.error(errorMsg);
-      
+      toast.error(getApiErrorMessage(error, 'Error al generar facturas'));
+
       // Log para debugging
       console.error('Error facturando pago completo:', error);
     }
@@ -87,7 +84,7 @@ export const useAnularFactura = () => {
       }
     },
     onError: (error: any) => {
-      toast.error(error?.response?.data?.error || 'Error al anular factura');
+      toast.error(getApiErrorMessage(error, 'Error al anular factura'));
     }
   });
 };
@@ -149,11 +146,7 @@ export const useFacturarGenerico = () => {
       }
     },
     onError: (error: any) => {
-      const errorMsg = error?.response?.data?.error
-        || error?.message
-        || 'Error al generar factura genérica';
-
-      toast.error(errorMsg);
+      toast.error(getApiErrorMessage(error, 'Error al generar factura genérica'));
 
       console.error('Error facturando genérico:', error);
     }
@@ -190,7 +183,7 @@ export const useExportFacturasExcel = () => {
       }
     },
     onError: (error: any) => {
-      toast.error(error?.message || 'Error al exportar Excel');
+      toast.error(getApiErrorMessage(error, 'Error al exportar Excel'));
     },
   });
 };

--- a/apps/carteraFront/src/private/cartera/hooks/paymentagreement.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/paymentagreement.ts
@@ -3,8 +3,9 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
  
 import { toast } from "sonner";
-import { 
-  type GetPaymentAgreementsFilters, 
+import { getApiErrorMessage } from "@/lib/apiError";
+import {
+  type GetPaymentAgreementsFilters,
   getPaymentAgreements, 
   type CreatePaymentAgreementInput, 
   createPaymentAgreement, 
@@ -44,7 +45,7 @@ export const useCreatePaymentAgreement = () => {
       toast.success("Convenio de pago creado exitosamente");
     },
     onError: (error: Error) => {
-      toast.error(error.message || "Error al crear el convenio de pago");
+      toast.error(getApiErrorMessage(error, "Error al crear el convenio de pago"));
     },
   });
 }; 
@@ -67,7 +68,7 @@ export const useTogglePaymentAgreementStatus = () => {
       toast.success(mensaje);
     },
     onError: (error: Error) => {
-      toast.error(error.message || "Error al actualizar el estado del convenio");
+      toast.error(getApiErrorMessage(error, "Error al actualizar el estado del convenio"));
     },
   });
 };

--- a/apps/carteraFront/src/private/cartera/hooks/registerCredit.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerCredit.ts
@@ -4,6 +4,7 @@ import { useFormik } from "formik";
 
 import { z } from "zod";
 import { createCredit } from "../services/services";
+import { getApiErrorMessage } from "@/lib/apiError";
 export const creditSchema = z.object({
   usuario: z.string().max(1000),
   numero_credito_sifco: z.string().max(1000),
@@ -131,9 +132,8 @@ export function useCreditForm(initialValues?: Partial<CreditFormValues>) {
         alert("¡Crédito creado correctamente!");
         setStatus({ success: true });
       } catch (error: any) {
-        const backendMessage =
-          error?.response?.data?.message || "Error desconocido";
-        alert(`No se pudo crear el crédito:\n${backendMessage}`);
+        const backendMessage = getApiErrorMessage(error, "No se pudo crear el crédito");
+        alert(backendMessage);
         setStatus({ success: false, error: backendMessage });
       } finally {
         setSubmitting(false);

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getApiErrorMessage } from "@/lib/apiError";
 import {
   getPagosConInversionistasService,
   pagosService,
@@ -68,7 +69,7 @@ export function useAplicarPago() {
     onError: (error) => {
       // ❌ Mostrar error
       console.error("Error al aplicar pago:", error);
-      alert(error.message || "Error al aplicar el pago al crédito");
+      alert(getApiErrorMessage(error, "Error al aplicar el pago al crédito"));
     },
   });
 }

--- a/apps/carteraFront/src/private/cartera/hooks/useBoletasInversionistas.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useBoletasInversionistas.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"; 
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 import { createBoleta, getBoletas, type CreateBoletaDTO, type GetBoletasFilters } from "../services/services";
 
 // ============================================
@@ -23,7 +24,7 @@ export const useCreateBoleta = () => {
     },
     onError: (error: Error) => {
       console.error("❌ Error creando boleta:", error);
-      toast.error(error.message || "Error al crear boleta");
+      toast.error(getApiErrorMessage(error, "Error al crear boleta"));
     },
   });
 };

--- a/apps/carteraFront/src/private/cartera/hooks/useLateFee.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/useLateFee.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+import { getApiErrorMessage } from "@/lib/apiError";
 import {
   condonarMoraService,
   createMoraService,
@@ -100,7 +101,7 @@ export const useMorasMasivo = () => {
       }
     },
     onError: (error: any) => {
-      toast.error(error?.response?.data?.message || 'Error en condonación masiva');
+      toast.error(getApiErrorMessage(error, 'Error en condonación masiva'));
     },
   });
 

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -2672,7 +2672,7 @@ export const createPaymentAgreement = async (
     return data;
   } catch (error: any) {
     console.error("Error creating payment agreement:", error);
-    throw new Error(error?.response?.data?.message || "Failed to create payment agreement");
+    throw error; // propaga el AxiosError para que el hook lo traduzca/filtre
   }
 };
 
@@ -2716,9 +2716,7 @@ export const togglePaymentAgreementStatus = async (
     return data;
   } catch (error: any) {
     console.error("Error toggling payment agreement status:", error);
-    throw new Error(
-      error?.response?.data?.message || "Failed to toggle payment agreement status"
-    );
+    throw error; // propaga el AxiosError para que el hook lo traduzca/filtre
   }
 };
 
@@ -3063,9 +3061,7 @@ export const createBoleta = async (data: CreateBoletaDTO) => {
     return response.data;
   } catch (error: any) {
     console.error("❌ Error creando boleta:", error);
-    throw new Error(
-      error.response?.data?.message || "Error al crear boleta"
-    );
+    throw error; // propaga el AxiosError para que el hook lo traduzca/filtre
   }
 };
 


### PR DESCRIPTION
## Contexto

Tercer lote de la migración a `getApiErrorMessage` (continúa #860 y #870). Extiende los mensajes de error descriptivos a 6 hooks más de cartera y cierra un hueco de raíz en `apiError.ts` detectado en el review de #870.

El objetivo de siempre: en vez de toasts inútiles (`Request failed with status code 500`), genéricos (`Error en condonación masiva`) o en inglés (`Failed to create payment agreement`), el usuario ve el motivo real en español.

---

### Cambio, camino de error 500

El código viejo de varios handlers leía `data.error` **directo**, y en el catch de error inesperado el backend devuelve el `error.message` crudo (en `facturar-pago-completo`, [hasta el stack trace](https://github.com/Engineering-Club-Cash-In/universe/blob/develop/apps/cartera-back/src/routers/cofidi.ts#L2022)). Esto es lo que veía el usuario antes vs. ahora:

| Hook | Fallo | Antes (crudo al usuario) | Ahora |
|---|---|---|---|
| `cofidi · facturarPagoCompleto` | Excepción no controlada | `Cannot read properties of undefined (reading 'monto_total')` | `Error al generar facturas: Error interno del servidor (HTTP 500)` |
| `cofidi · anularFactura` | BD caída | `connect ECONNREFUSED 10.0.0.5:5432` | `Error al anular factura: Error interno del servidor (HTTP 500)` |
| `cofidi · facturarGenerico` | Error SQL | `duplicate key value violates unique constraint "facturas_uuid_key"` | `Error al generar factura genérica: Error interno del servidor (HTTP 500)` |
| `cofidi · facturarPagoCompleto` | **Contra-prueba**: negocio legible | `Pago no encontrado` | `Error al generar facturas: Pago no encontrado` *(NO se filtra)* |

La contra-prueba es clave: un mensaje de negocio legible **se sigue mostrando**; solo se suprime el crudo técnico.

---

## Cambios

### `src/lib/apiError.ts` — el filtro de crudos ahora es central

En #870 el filtro de crudos solo protegía la rama de "roles invertidos" (`message: "Internal server error"`). Pero hay endpoints que devuelven **solo** `error` con el `error.message` crudo (ej. `/recalcular-pagos`, los catch de DTE). Se centralizó la extracción en `extraerDetalle`, que aplica el criterio a **cualquier** uso del campo `error`:

- El campo `error` solo se muestra si es **traducible** (negocio conocido) o **no parece un crudo técnico** (`DETALLE_TECNICO`: prefijos `TypeError:`/stack, `ECONN*`, `cannot read`, vocabulario SQL, etc.).
- La rama de `Error` plano usa el **mismo criterio** (traduce → suprime crudo → muestra) y deduplica el `"X: X"` cuando un servicio relanza `new Error(<mismo fallback>)`.

### 6 hooks migrados a `getApiErrorMessage`

`cofidi` (4 handlers), `paymentagreement` (2), `useBoletasInversionistas`, `registerCredit`, `reportPayments`, `useLateFee`.

### `src/private/cartera/services/services.ts` — propagar el AxiosError (3 servicios)

`createBoleta`, `createPaymentAgreement` y `togglePaymentAgreementStatus` **tragaban** el `AxiosError` y relanzaban `new Error(data.message || "Failed to...")`. En errores de validación el backend manda el motivo en el campo `error` (no `message`), así que el servicio caía a un fallback **en inglés** y el hook ya no podía recuperarlo. Ahora propagan el `AxiosError` (conservando el `console.error`) para que la traducción/filtrado del hook funcione de punta a punta.

> **Seguridad del cambio:** el único consumidor del error de esos 3 servicios es el `onError` de los hooks migrados. `investorPayment.tsx` usa `createBoleta.mutateAsync` en un `try/finally` sin `catch` que lea `error.message`, por lo que no se rompe ningún otro flujo.

---

## Validación

Script temporal (no incluido) contra el backend local, 15 escenarios (validación 422, not-found 404, y 500/crudo con la forma real del backend). Muestra del camino de validación:

| Hook | Antes | Ahora |
|---|---|---|
| `reportPayments · aplicarPago` | `Request failed with status code 404` | `…: No se encontró el pago con ID 99999999` |
| `registerCredit · createCredit` | `Validation failed` (inglés) | `…: Los datos enviados no son válidos, revisa los campos…` |
| `paymentagreement · createPaymentAgreement` | `Failed to create payment agreement` (inglés) | `…: El valor del campo "credit_id" no es válido…` |
| `useLateFee · condonarMorasMasivo` | `Error en condonación masiva` (genérico) | `…: El valor del campo "motivo" no es válido…` |

---

## Decisiones técnicas

- **`extraerDetalle(data: unknown)`**: se tipa con `unknown` + cast acotado para no introducir un `any` explícito (el archivo no tiene `eslint-disable`).
- **`getPaymentAgreements` (GET)** mantiene su `throw new Error(...)`: es un *query*, fuera del alcance de este lote.
- **Ramas `onSuccess` con `data.error`** (fallo de negocio en respuesta 200) no se migran: esos mensajes ya vienen curados por el endpoint; `getApiErrorMessage` es para errores lanzados. Mismo criterio que en #860/#870.