### PR TITLE
feat(reportes): reporte de meta de colocación por asesor

### DIFF
--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -319,6 +319,34 @@ const requirePorcentajeEfectividadReport = o.middleware(
 		});
 	},
 );
+const requireMetaColocacionReport = o.middleware(async ({ context, next }) => {
+	if (!context.session?.user) {
+		throw new ORPCError("UNAUTHORIZED");
+	}
+
+	const userId = context.session.user.id;
+	const userData = await db
+		.select()
+		.from(user)
+		.where(eq(user.id, userId))
+		.limit(1);
+	const userRole = userData[0]?.role;
+
+	if (!PERMISSIONS.canAccessMetaColocacionReport(userRole)) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Meta colocación report access required",
+		});
+	}
+
+	return next({
+		context: {
+			session: context.session,
+			user: userData[0],
+			userId,
+			userRole,
+		},
+	});
+});
 
 const requireViewOpportunityContracts = o.middleware(
 	async ({ context, next }) => {
@@ -547,9 +575,12 @@ export const closedCreditsReportProcedure = publicProcedure.use(
 );
 export const tiempoCierreReportProcedure = publicProcedure.use(
 	requireTiempoCierreReport,
-  );
+);
 export const porcentajeEfectividadReportProcedure = publicProcedure.use(
 	requirePorcentajeEfectividadReport,
+);
+export const metaColocacionReportProcedure = publicProcedure.use(
+	requireMetaColocacionReport,
 );
 export const viewOpportunityContractsProcedure = publicProcedure.use(
 	requireViewOpportunityContracts,

--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -325,12 +325,7 @@ const requireMetaColocacionReport = o.middleware(async ({ context, next }) => {
 	}
 
 	const userId = context.session.user.id;
-	const userData = await db
-		.select()
-		.from(user)
-		.where(eq(user.id, userId))
-		.limit(1);
-	const userRole = userData[0]?.role;
+	const userRole = context.session.user.role ?? "";
 
 	if (!PERMISSIONS.canAccessMetaColocacionReport(userRole)) {
 		throw new ORPCError("FORBIDDEN", {
@@ -341,7 +336,6 @@ const requireMetaColocacionReport = o.middleware(async ({ context, next }) => {
 	return next({
 		context: {
 			session: context.session,
-			user: userData[0],
 			userId,
 			userRole,
 		},

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -163,9 +163,12 @@ export const PERMISSIONS = {
 		role === ROLES.ADMIN || role === ROLES.COBROS_SUPERVISOR,
 
 	canAccessTiempoCierreReport: (role: UserRole | string): boolean =>
-  role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
-  
+		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
+
 	canAccessPorcentajeEfectividadReport: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
+
+	canAccessMetaColocacionReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
 
 	// Credit Detail Approval (40% → 50%)

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -336,6 +336,7 @@ export const reportsAppRouter = {
 	getReporteTiempoCierre: reportsRouter.getReporteTiempoCierre,
 	getReportePorcentajeEfectividad:
 		reportsRouter.getReportePorcentajeEfectividad,
+	getReporteMetaColocacion: reportsRouter.getReporteMetaColocacion,
 	// Reportes unificados (cartera-back + CRM)
 	getReporteCarteraCompleto: reportesCarteraRouter.getReporteCarteraCompleto,
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -692,8 +692,6 @@ export const getReporteMetaColocacion = metaColocacionReportProcedure
 					FROM opportunity_stage_history osh
 					JOIN sales_stages ss ON ss.id = osh.to_stage_id
 					WHERE ss.closure_percentage >= 90
-						AND EXTRACT(YEAR FROM osh.changed_at AT TIME ZONE 'America/Guatemala') = ${anio}
-						AND EXTRACT(MONTH FROM osh.changed_at AT TIME ZONE 'America/Guatemala') = ${mes}
 					GROUP BY osh.opportunity_id
 				)
 				SELECT
@@ -703,8 +701,13 @@ export const getReporteMetaColocacion = metaColocacionReportProcedure
 					COALESCE(SUM(o.value::numeric), 0) AS monto
 				FROM first_placed fp
 				JOIN opportunities o ON o.id = fp.opportunity_id
+				JOIN sales_stages ss_cur
+					ON ss_cur.id = o.stage_id
+					AND ss_cur.closure_percentage >= 90
 				LEFT JOIN "user" u ON u.id = o.assigned_to
 				WHERE o.status != 'migrate'
+					AND EXTRACT(YEAR FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${anio}
+					AND EXTRACT(MONTH FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${mes}
 				GROUP BY o.assigned_to, u.name
 				ORDER BY monto DESC
 			`),

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -3,6 +3,7 @@ import { and, count, desc, eq, gte, lte, sql, sum } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { auctionVehicles } from "../db/schema/auctionVehicles";
+import { user } from "../db/schema/auth";
 import { carteraBackReferences } from "../db/schema/cartera-back";
 import {
 	casosCobros,
@@ -16,12 +17,14 @@ import {
 	opportunityStageHistory,
 	salesStages,
 } from "../db/schema/crm";
+import { metasMensuales } from "../db/schema/metas";
 import { vehicleInspections, vehicles } from "../db/schema/vehicles";
 import {
 	closedCreditsReportProcedure,
+	metaColocacionReportProcedure,
+	porcentajeEfectividadReportProcedure,
 	protectedProcedure,
 	tiempoCierreReportProcedure,
-  porcentajeEfectividadReportProcedure,
 } from "../lib/orpc";
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
@@ -462,10 +465,8 @@ export const getReportePorcentajeEfectividad =
 				lte(opportunities.createdAt, end),
 			);
 
-			const totalCerradas =
-				sql<number>`COUNT(${everClosed.opportunityId})`;
-			const porcentaje =
-				sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
+			const totalCerradas = sql<number>`COUNT(${everClosed.opportunityId})`;
+			const porcentaje = sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
 
 			const [totalRows, porFuente, registrosRaw] = await Promise.all([
 				db
@@ -496,7 +497,9 @@ export const getReportePorcentajeEfectividad =
 						id: opportunities.id,
 						createdAt: opportunities.createdAt,
 						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-						nombre: sql<string | null>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
+						nombre: sql<
+							string | null
+						>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
 						etapaNombre: salesStages.name,
 						etapaPorcentaje: salesStages.closurePercentage,
 						cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
@@ -652,3 +655,109 @@ export const getReporteSubastas = protectedProcedure.handler(async () => {
 		resumenSubastas,
 	};
 });
+
+/**
+ * Reporte de Meta de Colocación vs Real
+ * Compara la meta mensual de colocación con lo efectivamente colocado,
+ * desglosado por colaborador (assigned_to del opportunity).
+ */
+export const getReporteMetaColocacion = metaColocacionReportProcedure
+	.input(
+		z.object({
+			anio: z.number().min(2024).max(2100),
+			mes: z.number().min(1).max(12),
+		}),
+	)
+	.handler(async ({ input }) => {
+		const { anio, mes } = input;
+
+		const [metaRow, porColaboradorRows, totalesRow] = await Promise.all([
+			db
+				.select({ monto: metasMensuales.monto })
+				.from(metasMensuales)
+				.where(
+					and(
+						eq(metasMensuales.tipo, "colocacion"),
+						eq(metasMensuales.anio, anio),
+						eq(metasMensuales.mes, mes),
+					),
+				)
+				.limit(1),
+
+			db.execute(sql`
+				WITH first_placed AS (
+					SELECT
+						osh.opportunity_id,
+						MIN(osh.changed_at) AS first_placed_at
+					FROM opportunity_stage_history osh
+					JOIN sales_stages ss ON ss.id = osh.to_stage_id
+					WHERE ss.closure_percentage >= 90
+					GROUP BY osh.opportunity_id
+				)
+				SELECT
+					o.assigned_to AS user_id,
+					u.name AS nombre,
+					COUNT(o.id)::int AS creditos,
+					COALESCE(SUM(o.value::numeric), 0) AS monto
+				FROM first_placed fp
+				JOIN opportunities o ON o.id = fp.opportunity_id
+				LEFT JOIN "user" u ON u.id = o.assigned_to
+				WHERE o.status != 'migrate'
+					AND EXTRACT(YEAR FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${anio}
+					AND EXTRACT(MONTH FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${mes}
+				GROUP BY o.assigned_to, u.name
+				ORDER BY monto DESC
+			`),
+
+			db.execute(sql`
+				WITH first_placed AS (
+					SELECT
+						osh.opportunity_id,
+						MIN(osh.changed_at) AS first_placed_at
+					FROM opportunity_stage_history osh
+					JOIN sales_stages ss ON ss.id = osh.to_stage_id
+					WHERE ss.closure_percentage >= 90
+					GROUP BY osh.opportunity_id
+				)
+				SELECT
+					COUNT(o.id)::int AS creditos,
+					COALESCE(SUM(o.value::numeric), 0) AS monto
+				FROM first_placed fp
+				JOIN opportunities o ON o.id = fp.opportunity_id
+				WHERE o.status != 'migrate'
+					AND EXTRACT(YEAR FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${anio}
+					AND EXTRACT(MONTH FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${mes}
+			`),
+		]);
+
+		const meta = Number(metaRow[0]?.monto ?? 0);
+		const totalRow = totalesRow.rows[0] as
+			| { creditos: number; monto: string }
+			| undefined;
+		const realMonto = Number(totalRow?.monto ?? 0);
+		const realCreditos = Number(totalRow?.creditos ?? 0);
+		const cobertura = meta > 0 ? (realMonto / meta) * 100 : null;
+
+		const porColaborador = (
+			porColaboradorRows.rows as {
+				user_id: string | null;
+				nombre: string | null;
+				creditos: number;
+				monto: string;
+			}[]
+		).map((r) => ({
+			userId: r.user_id,
+			nombre: r.nombre ?? "Sin asignar",
+			creditos: r.creditos,
+			monto: Number(r.monto).toFixed(2),
+			pctDelTotal: realMonto > 0 ? (Number(r.monto) / realMonto) * 100 : 0,
+		}));
+
+		return {
+			meta: meta.toFixed(2),
+			realMonto: realMonto.toFixed(2),
+			realCreditos,
+			cobertura: cobertura !== null ? Number(cobertura.toFixed(1)) : null,
+			porColaborador,
+		};
+	});

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -671,7 +671,7 @@ export const getReporteMetaColocacion = metaColocacionReportProcedure
 	.handler(async ({ input }) => {
 		const { anio, mes } = input;
 
-		const [metaRow, porColaboradorRows, totalesRow] = await Promise.all([
+		const [metaRow, porColaboradorRows] = await Promise.all([
 			db
 				.select({ monto: metasMensuales.monto })
 				.from(metasMensuales)
@@ -692,6 +692,8 @@ export const getReporteMetaColocacion = metaColocacionReportProcedure
 					FROM opportunity_stage_history osh
 					JOIN sales_stages ss ON ss.id = osh.to_stage_id
 					WHERE ss.closure_percentage >= 90
+						AND EXTRACT(YEAR FROM osh.changed_at AT TIME ZONE 'America/Guatemala') = ${anio}
+						AND EXTRACT(MONTH FROM osh.changed_at AT TIME ZONE 'America/Guatemala') = ${mes}
 					GROUP BY osh.opportunity_id
 				)
 				SELECT
@@ -703,49 +705,23 @@ export const getReporteMetaColocacion = metaColocacionReportProcedure
 				JOIN opportunities o ON o.id = fp.opportunity_id
 				LEFT JOIN "user" u ON u.id = o.assigned_to
 				WHERE o.status != 'migrate'
-					AND EXTRACT(YEAR FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${anio}
-					AND EXTRACT(MONTH FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${mes}
 				GROUP BY o.assigned_to, u.name
 				ORDER BY monto DESC
-			`),
-
-			db.execute(sql`
-				WITH first_placed AS (
-					SELECT
-						osh.opportunity_id,
-						MIN(osh.changed_at) AS first_placed_at
-					FROM opportunity_stage_history osh
-					JOIN sales_stages ss ON ss.id = osh.to_stage_id
-					WHERE ss.closure_percentage >= 90
-					GROUP BY osh.opportunity_id
-				)
-				SELECT
-					COUNT(o.id)::int AS creditos,
-					COALESCE(SUM(o.value::numeric), 0) AS monto
-				FROM first_placed fp
-				JOIN opportunities o ON o.id = fp.opportunity_id
-				WHERE o.status != 'migrate'
-					AND EXTRACT(YEAR FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${anio}
-					AND EXTRACT(MONTH FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${mes}
 			`),
 		]);
 
 		const meta = Number(metaRow[0]?.monto ?? 0);
-		const totalRow = totalesRow.rows[0] as
-			| { creditos: number; monto: string }
-			| undefined;
-		const realMonto = Number(totalRow?.monto ?? 0);
-		const realCreditos = Number(totalRow?.creditos ?? 0);
+		const rawRows = porColaboradorRows.rows as {
+			user_id: string | null;
+			nombre: string | null;
+			creditos: number;
+			monto: string;
+		}[];
+		const realMonto = rawRows.reduce((acc, r) => acc + Number(r.monto), 0);
+		const realCreditos = rawRows.reduce((acc, r) => acc + r.creditos, 0);
 		const cobertura = meta > 0 ? (realMonto / meta) * 100 : null;
 
-		const porColaborador = (
-			porColaboradorRows.rows as {
-				user_id: string | null;
-				nombre: string | null;
-				creditos: number;
-				monto: string;
-			}[]
-		).map((r) => ({
+		const porColaborador = rawRows.map((r) => ({
 			userId: r.user_id,
 			nombre: r.nombre ?? "Sin asignar",
 			creditos: r.creditos,

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -166,11 +166,11 @@ export default function Header() {
 												</DropdownMenuItem>
 											</>
 										)}
-                  {userRole &&
+									{userRole &&
 										PERMISSIONS.canAccessPorcentajeEfectividadReport(
 											userRole,
 										) && (
-                    <>
+											<>
 												<DropdownMenuSeparator />
 												<DropdownMenuItem asChild>
 													<Link
@@ -179,6 +179,21 @@ export default function Header() {
 													>
 														<Percent className="mr-2 h-4 w-4" />
 														Porcentaje Efectividad
+													</Link>
+												</DropdownMenuItem>
+											</>
+										)}
+									{userRole &&
+										PERMISSIONS.canAccessMetaColocacionReport(userRole) && (
+											<>
+												<DropdownMenuSeparator />
+												<DropdownMenuItem asChild>
+													<Link
+														to="/crm/reportes/meta-colocacion"
+														className="cursor-pointer"
+													>
+														<Target className="mr-2 h-4 w-4" />
+														Meta Colocación
 													</Link>
 												</DropdownMenuItem>
 											</>

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -45,6 +45,7 @@ import { Route as JuridicoGenerateOpportunityIdRouteImport } from './routes/juri
 import { Route as InversionesLiquidacionesInversionistaIdRouteImport } from './routes/inversiones/liquidaciones.$inversionistaId'
 import { Route as CrmReportesTiempoCierreRouteImport } from './routes/crm/reportes/tiempo-cierre'
 import { Route as CrmReportesPorcentajeEfectividadRouteImport } from './routes/crm/reportes/porcentaje-efectividad'
+import { Route as CrmReportesMetaColocacionRouteImport } from './routes/crm/reportes/meta-colocacion'
 import { Route as CrmAnalysisOpportunityIdRouteImport } from './routes/crm/analysis/$opportunityId'
 import { Route as CrmAdminMiniagentRouteImport } from './routes/crm/admin/miniagent'
 
@@ -233,6 +234,12 @@ const CrmReportesPorcentajeEfectividadRoute =
     path: '/crm/reportes/porcentaje-efectividad',
     getParentRoute: () => rootRouteImport,
   } as any)
+const CrmReportesMetaColocacionRoute =
+  CrmReportesMetaColocacionRouteImport.update({
+    id: '/crm/reportes/meta-colocacion',
+    path: '/crm/reportes/meta-colocacion',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CrmAnalysisOpportunityIdRoute =
   CrmAnalysisOpportunityIdRouteImport.update({
     id: '/crm/analysis/$opportunityId',
@@ -277,6 +284,7 @@ export interface FileRoutesByFullPath {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
@@ -317,6 +325,7 @@ export interface FileRoutesByTo {
   '/vehicles': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
@@ -358,6 +367,7 @@ export interface FileRoutesById {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
   '/inversiones/liquidaciones/$inversionistaId': typeof InversionesLiquidacionesInversionistaIdRoute
@@ -400,6 +410,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
     | '/inversiones/liquidaciones/$inversionistaId'
@@ -440,6 +451,7 @@ export interface FileRouteTypes {
     | '/vehicles'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
     | '/inversiones/liquidaciones/$inversionistaId'
@@ -480,6 +492,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
     | '/inversiones/liquidaciones/$inversionistaId'
@@ -521,6 +534,7 @@ export interface RootRouteChildren {
   VehiclesIndexRoute: typeof VehiclesIndexRoute
   CrmAdminMiniagentRoute: typeof CrmAdminMiniagentRoute
   CrmAnalysisOpportunityIdRoute: typeof CrmAnalysisOpportunityIdRoute
+  CrmReportesMetaColocacionRoute: typeof CrmReportesMetaColocacionRoute
   CrmReportesPorcentajeEfectividadRoute: typeof CrmReportesPorcentajeEfectividadRoute
   CrmReportesTiempoCierreRoute: typeof CrmReportesTiempoCierreRoute
   InversionesLiquidacionesInversionistaIdRoute: typeof InversionesLiquidacionesInversionistaIdRoute
@@ -784,6 +798,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CrmReportesPorcentajeEfectividadRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/crm/reportes/meta-colocacion': {
+      id: '/crm/reportes/meta-colocacion'
+      path: '/crm/reportes/meta-colocacion'
+      fullPath: '/crm/reportes/meta-colocacion'
+      preLoaderRoute: typeof CrmReportesMetaColocacionRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/crm/analysis/$opportunityId': {
       id: '/crm/analysis/$opportunityId'
       path: '/crm/analysis/$opportunityId'
@@ -833,6 +854,7 @@ const rootRouteChildren: RootRouteChildren = {
   VehiclesIndexRoute: VehiclesIndexRoute,
   CrmAdminMiniagentRoute: CrmAdminMiniagentRoute,
   CrmAnalysisOpportunityIdRoute: CrmAnalysisOpportunityIdRoute,
+  CrmReportesMetaColocacionRoute: CrmReportesMetaColocacionRoute,
   CrmReportesPorcentajeEfectividadRoute: CrmReportesPorcentajeEfectividadRoute,
   CrmReportesTiempoCierreRoute: CrmReportesTiempoCierreRoute,
   InversionesLiquidacionesInversionistaIdRoute:

--- a/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { formatCurrency } from "@/lib/crm-formatters";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
@@ -54,13 +55,6 @@ function nowGT(): Date {
 			day: "2-digit",
 		}).format(new Date()) + "T12:00:00Z",
 	);
-}
-
-function formatQ(value: string | number): string {
-	return `Q${Number(value).toLocaleString("es-GT", {
-		minimumFractionDigits: 2,
-		maximumFractionDigits: 2,
-	})}`;
 }
 
 function coberturaColor(pct: number | null): string {
@@ -138,25 +132,11 @@ function RouteComponent() {
 
 	const anios = Array.from({ length: 5 }, (_, i) => now.getUTCFullYear() - i);
 
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const meta = (data as any)?.meta as string | undefined;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const realMonto = (data as any)?.realMonto as string | undefined;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const realCreditos = (data as any)?.realCreditos as number | undefined;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const cobertura = (data as any)?.cobertura as number | null | undefined;
-	const porColaborador =
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		((data as any)?.porColaborador as
-			| {
-					userId: string | null;
-					nombre: string;
-					creditos: number;
-					monto: string;
-					pctDelTotal: number;
-			  }[]
-			| undefined) ?? [];
+	const meta = data?.meta;
+	const realMonto = data?.realMonto;
+	const realCreditos = data?.realCreditos;
+	const cobertura = data?.cobertura;
+	const porColaborador = data?.porColaborador ?? [];
 
 	return (
 		<div className="container mx-auto max-w-5xl space-y-6 p-6">
@@ -199,12 +179,12 @@ function RouteComponent() {
 			<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
 				<ReportCard
 					title="Meta"
-					value={isLoading ? "—" : formatQ(meta ?? 0)}
+					value={isLoading ? "—" : formatCurrency(meta ?? 0)}
 					icon={Target}
 				/>
 				<ReportCard
 					title="Real Colocado"
-					value={isLoading ? "—" : formatQ(realMonto ?? 0)}
+					value={isLoading ? "—" : formatCurrency(realMonto ?? 0)}
 					icon={TrendingUp}
 				/>
 				<ReportCard
@@ -252,7 +232,7 @@ function RouteComponent() {
 										<TableCell className="font-medium">{row.nombre}</TableCell>
 										<TableCell className="text-right">{row.creditos}</TableCell>
 										<TableCell className="text-right">
-											{formatQ(row.monto)}
+											{formatCurrency(row.monto)}
 										</TableCell>
 										<TableCell className="text-right text-muted-foreground">
 											{row.pctDelTotal.toFixed(1)}%
@@ -265,7 +245,7 @@ function RouteComponent() {
 										{realCreditos ?? 0}
 									</TableCell>
 									<TableCell className="text-right">
-										{formatQ(realMonto ?? 0)}
+										{formatCurrency(realMonto ?? 0)}
 									</TableCell>
 									<TableCell className="text-right">100%</TableCell>
 								</TableRow>
@@ -285,7 +265,7 @@ function RouteComponent() {
 						<div className="space-y-2">
 							<div className="flex justify-between text-sm">
 								<span className="text-muted-foreground">
-									{formatQ(realMonto ?? 0)} de {formatQ(meta)}
+									{formatCurrency(realMonto ?? 0)} de {formatCurrency(meta)}
 								</span>
 								<span
 									className={`font-semibold ${coberturaColor(cobertura ?? null)}`}
@@ -303,7 +283,7 @@ function RouteComponent() {
 							</div>
 							<p className="text-muted-foreground text-xs">
 								Faltante:{" "}
-								{formatQ(Math.max(0, Number(meta) - Number(realMonto ?? 0)))}
+								{formatCurrency(Math.max(0, Number(meta) - Number(realMonto ?? 0)))}
 							</p>
 						</div>
 					</CardContent>

--- a/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
@@ -1,0 +1,314 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Target, TrendingUp, Users } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ReportCard } from "@/components/reports/report-card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/crm/reportes/meta-colocacion")({
+	component: RouteComponent,
+});
+
+const GUATEMALA_TZ = "America/Guatemala";
+
+const MESES = [
+	"Enero",
+	"Febrero",
+	"Marzo",
+	"Abril",
+	"Mayo",
+	"Junio",
+	"Julio",
+	"Agosto",
+	"Septiembre",
+	"Octubre",
+	"Noviembre",
+	"Diciembre",
+];
+
+function nowGT(): Date {
+	return new Date(
+		new Intl.DateTimeFormat("en-CA", {
+			timeZone: GUATEMALA_TZ,
+			year: "numeric",
+			month: "2-digit",
+			day: "2-digit",
+		}).format(new Date()) + "T12:00:00Z",
+	);
+}
+
+function formatQ(value: string | number): string {
+	return `Q${Number(value).toLocaleString("es-GT", {
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 2,
+	})}`;
+}
+
+function coberturaColor(pct: number | null): string {
+	if (pct === null) return "text-muted-foreground";
+	if (pct >= 100) return "text-green-600";
+	if (pct >= 75) return "text-yellow-600";
+	return "text-red-600";
+}
+
+function coberturaLabel(pct: number | null): string {
+	if (pct === null) return "Sin meta";
+	return `${pct.toFixed(1)}%`;
+}
+
+function RouteComponent() {
+	const navigate = useNavigate();
+	const {
+		data: session,
+		isPending: sessionPending,
+		error: sessionError,
+	} = authClient.useSession();
+	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const userRole = (userProfile.data as any)?.role as string | undefined;
+	const canAccess = userRole
+		? PERMISSIONS.canAccessMetaColocacionReport(userRole)
+		: false;
+
+	const isPending =
+		sessionPending || userProfile.isPending || (!session && !sessionError);
+
+	const now = nowGT();
+	const [mes, setMes] = useState<number>(now.getUTCMonth() + 1);
+	const [anio, setAnio] = useState<number>(now.getUTCFullYear());
+
+	useEffect(() => {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
+			navigate({ to: "/login" });
+		} else if (session && !userProfile.isPending && !canAccess) {
+			navigate({ to: "/dashboard" });
+			toast.error("Acceso denegado");
+		}
+	}, [
+		session,
+		sessionError,
+		sessionPending,
+		userProfile.isPending,
+		canAccess,
+		navigate,
+	]);
+
+	const reportQuery = useQuery({
+		...orpc.getReporteMetaColocacion.queryOptions({ input: { anio, mes } }),
+		enabled: canAccess,
+	});
+
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAccess) return null;
+
+	const data = reportQuery.data;
+	const isLoading = reportQuery.isLoading;
+
+	const anios = Array.from({ length: 5 }, (_, i) => now.getUTCFullYear() - i);
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const meta = (data as any)?.meta as string | undefined;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const realMonto = (data as any)?.realMonto as string | undefined;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const realCreditos = (data as any)?.realCreditos as number | undefined;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const cobertura = (data as any)?.cobertura as number | null | undefined;
+	const porColaborador =
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		((data as any)?.porColaborador as
+			| {
+					userId: string | null;
+					nombre: string;
+					creditos: number;
+					monto: string;
+					pctDelTotal: number;
+			  }[]
+			| undefined) ?? [];
+
+	return (
+		<div className="container mx-auto max-w-5xl space-y-6 p-6">
+			{/* Header */}
+			<div>
+				<h1 className="font-bold text-2xl">Meta de Colocación</h1>
+				<p className="mt-1 text-muted-foreground text-sm">
+					Compara la meta mensual de colocación con lo efectivamente colocado,
+					total y por colaborador.
+				</p>
+			</div>
+
+			{/* Selector mes/año */}
+			<div className="flex items-center gap-3">
+				<select
+					value={mes}
+					onChange={(e) => setMes(Number(e.target.value))}
+					className="rounded-md border bg-background px-3 py-1.5 text-sm"
+				>
+					{MESES.map((label, i) => (
+						<option key={label} value={i + 1}>
+							{label}
+						</option>
+					))}
+				</select>
+				<select
+					value={anio}
+					onChange={(e) => setAnio(Number(e.target.value))}
+					className="rounded-md border bg-background px-3 py-1.5 text-sm"
+				>
+					{anios.map((a) => (
+						<option key={a} value={a}>
+							{a}
+						</option>
+					))}
+				</select>
+			</div>
+
+			{/* KPI Cards */}
+			<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+				<ReportCard
+					title="Meta"
+					value={isLoading ? "—" : formatQ(meta ?? 0)}
+					icon={Target}
+				/>
+				<ReportCard
+					title="Real Colocado"
+					value={isLoading ? "—" : formatQ(realMonto ?? 0)}
+					icon={TrendingUp}
+				/>
+				<ReportCard
+					title="Cobertura"
+					value={isLoading ? "—" : coberturaLabel(cobertura ?? null)}
+					icon={Target}
+				/>
+				<ReportCard
+					title="Créditos"
+					value={isLoading ? "—" : String(realCreditos ?? 0)}
+					icon={Users}
+				/>
+			</div>
+
+			{/* Tabla por colaborador */}
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-base">Desglose por Colaborador</CardTitle>
+					<CardDescription>
+						Créditos y monto colocado por asesor en {MESES[mes - 1]} {anio}
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{isLoading ? (
+						<p className="py-8 text-center text-muted-foreground text-sm">
+							Cargando...
+						</p>
+					) : porColaborador.length === 0 ? (
+						<p className="py-8 text-center text-muted-foreground text-sm">
+							No hay colocaciones para este período.
+						</p>
+					) : (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Colaborador</TableHead>
+									<TableHead className="text-right"># Créditos</TableHead>
+									<TableHead className="text-right">Monto</TableHead>
+									<TableHead className="text-right">% del Total</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{porColaborador.map((row) => (
+									<TableRow key={row.userId ?? row.nombre}>
+										<TableCell className="font-medium">{row.nombre}</TableCell>
+										<TableCell className="text-right">{row.creditos}</TableCell>
+										<TableCell className="text-right">
+											{formatQ(row.monto)}
+										</TableCell>
+										<TableCell className="text-right text-muted-foreground">
+											{row.pctDelTotal.toFixed(1)}%
+										</TableCell>
+									</TableRow>
+								))}
+								<TableRow className="border-t-2 font-semibold">
+									<TableCell>Total</TableCell>
+									<TableCell className="text-right">
+										{realCreditos ?? 0}
+									</TableCell>
+									<TableCell className="text-right">
+										{formatQ(realMonto ?? 0)}
+									</TableCell>
+									<TableCell className="text-right">100%</TableCell>
+								</TableRow>
+							</TableBody>
+						</Table>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* Progreso vs Meta */}
+			{meta && Number(meta) > 0 && (
+				<Card>
+					<CardHeader>
+						<CardTitle className="text-base">Progreso vs Meta</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<div className="space-y-2">
+							<div className="flex justify-between text-sm">
+								<span className="text-muted-foreground">
+									{formatQ(realMonto ?? 0)} de {formatQ(meta)}
+								</span>
+								<span
+									className={`font-semibold ${coberturaColor(cobertura ?? null)}`}
+								>
+									{coberturaLabel(cobertura ?? null)}
+								</span>
+							</div>
+							<div className="h-3 w-full overflow-hidden rounded-full bg-muted">
+								<div
+									className="h-full rounded-full bg-purple-500 transition-all"
+									style={{
+										width: `${Math.min(100, cobertura ?? 0)}%`,
+									}}
+								/>
+							</div>
+							<p className="text-muted-foreground text-xs">
+								Faltante:{" "}
+								{formatQ(Math.max(0, Number(meta) - Number(realMonto ?? 0)))}
+							</p>
+						</div>
+					</CardContent>
+				</Card>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Resumen

- Nuevo reporte **Meta de Colocación** en `/crm/reportes/meta-colocacion`
- Compara la meta mensual de colocación contra lo efectivamente colocado, con desglose por asesor
- Acceso restringido a roles `admin` y `sales_supervisor`

## Cambios

### Backend

- **`roles.ts`**: nuevo permiso `canAccessMetaColocacionReport` (admin + sales_supervisor)
- **`orpc.ts`**: middleware `requireMetaColocacionReport` usando `context.session.user.role` directamente (sin DB lookup adicional)
- **`reports.ts`**: handler `getReporteMetaColocacion`
  - Consulta meta mensual desde `metasMensuales` por tipo `colocacion`
  - CTE `first_placed` con `MIN(changed_at)` histórico absoluto (sin fecha en CTE para correcta semántica de "primera vez colocado")
  - JOIN en etapa actual (`sales_stages.closure_percentage >= 90`) para alinear con lógica de `getDashboardStats`
  - Totales derivados en JS desde las filas por colaborador (evita segunda consulta duplicada)
- **`index.ts`**: expone `getReporteMetaColocacion`

### Frontend

- **`meta-colocacion.tsx`**: página completa con selector mes/año, 4 KPIs (Meta, Real Colocado, Cobertura, Créditos), tabla por colaborador y barra de progreso vs meta
- **`header.tsx`**: enlace de navegación bajo permiso `canAccessMetaColocacionReport`
- **`routeTree.gen.ts`**: ruta auto-generada `/crm/reportes/meta-colocacion`

## Test plan

- [ ] Acceder como admin a `/crm/reportes/meta-colocacion`
- [ ] Verificar que los números (créditos y monto) coinciden con "Créditos Colocados" y "Monto Colocado" del Panel de Control para el mismo mes/año
- [ ] Verificar que un usuario sin rol admin/sales_supervisor recibe FORBIDDEN
- [ ] Cambiar mes/año y confirmar que los datos se actualizan correctamente
- [ ] Verificar barra de progreso y porcentaje de cobertura


<img width="1304" height="873" alt="image" src="https://github.com/user-attachments/assets/d889cd2f-04d1-4660-affb-d5cf7c90e79c" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)