### PR TITLE
fix(cartera): omitir updateInstallments al reversar incobrables (Codex P1 #890)

### DIFF
--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -694,13 +694,23 @@ export const reversePayment = async ({ body, set }: any) => {
       };
     });
 try {
-  await updateInstallments({
-    numero_credito_sifco: result.creditData.creditos.numero_credito_sifco, 
-    nueva_cuota: Number(result.creditData.creditos.cuota),  
-    all: true
-  });
-  
-  console.log("✅ UPDATE ALL STATEMENT ejecutado correctamente");
+  // En un INCOBRABLE NO se refrescan las cuotas: updateInstallments recalcula
+  // interes_restante/iva_12_restante de cada fila con `porcentaje_interes`
+  // (preservado en el castigo) y revivirían interés/IVA sobre un calendario
+  // que debe ser capital-only, corrompiendo el castigo tras la reversa.
+  if (result.creditData.creditos.statusCredit === "INCOBRABLE") {
+    console.log(
+      "⏭️ INCOBRABLE: se omite updateInstallments (cuota capital-only, no se recalcula interés)"
+    );
+  } else {
+    await updateInstallments({
+      numero_credito_sifco: result.creditData.creditos.numero_credito_sifco,
+      nueva_cuota: Number(result.creditData.creditos.cuota),
+      all: true,
+    });
+
+    console.log("✅ UPDATE ALL STATEMENT ejecutado correctamente");
+  }
 } catch (updateError: any) {
   console.error("⚠️ Error en UPDATE ALL STATEMENT:", updateError.message);
   // NO hacer throw aquí porque la transacción ya se completó


### PR DESCRIPTION
## Contexto
Codex marcó un **P1** en el release [#890](https://github.com/Engineering-Club-Cash-In/universe/pull/890) sobre el trabajo de incobrables ya mergeado en develop (PR #887): *"Skip installment refresh for incobrable reversals"*.

## Problema
`reversePayment.ts` ejecuta, fuera de la transacción, `updateInstallments({ all: true })`. Esa función ([updateCredit.ts:92-121](apps/cartera-back/src/controllers/updateCredit.ts#L92-L121)) recalcula por cada cuota:

```
interesMes = capital × porcentaje_interes
ivaMes     = interesMes × 0.12
→ interes_restante, iva_12_restante
```

Al habilitar el reverse para `INCOBRABLE`, una reversa de recuperación válida pasa por ahí y **revive interés/IVA** sobre las filas de cuota del castigo, que `porcentaje_interes` sigue preservando — aunque la deuda del incobrable debe ser **capital-only**. Esto **corrompe el calendario del castigo** después de la reversa.

Era el **tercer punto** de revivir interés; los otros dos (recálculo de capital/deuda del crédito en reverse y RAMA A/B) ya se cerraron en #887 con `recomputeCreditAfterCapital`.

## Fix
Se **omite `updateInstallments`** cuando `statusCredit === "INCOBRABLE"` (la cuota del castigo no tiene interés que recalcular). El resto de estados se comporta igual que antes.

## Pruebas
- `tsc --noEmit` limpio en `reversePayment.ts`.
- Cambio quirúrgico de un solo `if` en el bloque post-transacción.

⚠️ Conviene incluir este fix en el release #890 (develop→main) antes del pase a prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)