### PR TITLE
feat(crm): source clients from cartera

### DIFF
--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { leadSourceEnum } from "../db/schema/crm";
-import { getLeadsInputSchema } from "./crm";
+import {
+	buildCarteraOnlyClientRow,
+	getClientCreditSifcosFromCartera,
+	getLeadsInputSchema,
+} from "./crm";
 
 describe("getLeadsInputSchema", () => {
 	test("accepts every configured lead source as a filter", () => {
@@ -13,5 +17,86 @@ describe("getLeadsInputSchema", () => {
 		expect(() =>
 			getLeadsInputSchema.parse({ source: "unknown-source" }),
 		).toThrow();
+	});
+});
+
+describe("getClientCreditSifcosFromCartera", () => {
+	test("returns unique SIFCOs from active, overdue, and agreement credits", async () => {
+		const calls: Array<{ estado?: string; page?: number; perPage?: number }> =
+			[];
+		const fetchCredits = async (params: {
+			estado?: string;
+			page?: number;
+			perPage?: number;
+		}) => {
+			calls.push(params);
+
+			if (params.estado === "ACTIVO") {
+				return {
+					data: [
+						{ creditos: { numero_credito_sifco: "A-1" } },
+						{ creditos: { numero_credito_sifco: "DUP" } },
+					],
+					totalPages: 1,
+				};
+			}
+
+			if (params.estado === "MOROSO") {
+				return {
+					data: [{ creditos: { numero_credito_sifco: "M-1" } }],
+					totalPages: 1,
+				};
+			}
+
+			return {
+				data: [
+					{ creditos: { numero_credito_sifco: "C-1" } },
+					{ creditos: { numero_credito_sifco: "DUP" } },
+				],
+				totalPages: 1,
+			};
+		};
+
+		const sifcos = await getClientCreditSifcosFromCartera(fetchCredits, {
+			mes: 6,
+			anio: 2026,
+		});
+
+		expect(sifcos).toEqual(["A-1", "DUP", "M-1", "C-1"]);
+		expect(calls.map((call) => call.estado)).toEqual([
+			"ACTIVO",
+			"MOROSO",
+			"EN_CONVENIO",
+		]);
+	});
+});
+
+describe("buildCarteraOnlyClientRow", () => {
+	test("builds a client row for a cartera credit without CRM match", () => {
+		const row = buildCarteraOnlyClientRow({
+			creditos: {
+				numero_credito_sifco: "01010101001170",
+				statusCredit: "MOROSO",
+				capital: "10000.00",
+				deudatotal: "12500.00",
+				cuota: "950.00",
+				fecha_creacion: "2026-01-15T00:00:00.000Z",
+				tipoCredito: "Sobre Vehículo",
+			},
+			usuarios: {
+				nombre: "María López",
+				nit: "1234567-8",
+			},
+			asesores: { nombre: "Asesor Cartera" },
+		});
+
+		expect(row.id).toBe("cartera-01010101001170");
+		expect(row.firstName).toBe("María");
+		expect(row.lastName).toBe("López");
+		expect(row.crmMatchStatus).toBe("missing");
+		expect(row.carteraCredit?.statusCredit).toBe("MOROSO");
+		expect(row.opportunities).toEqual([]);
+		expect(row.closedOpportunitiesCount).toBe(0);
+		expect(row.totalClosedValue).toBe(12500);
 	});
 });

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { leadSourceEnum } from "../db/schema/crm";
 import {
 	buildCarteraOnlyClientRow,
+	calculateCarteraClientStats,
 	getClientCreditSifcosFromCartera,
 	getLeadsInputSchema,
 } from "./crm";
@@ -98,5 +99,42 @@ describe("buildCarteraOnlyClientRow", () => {
 		expect(row.opportunities).toEqual([]);
 		expect(row.closedOpportunitiesCount).toBe(0);
 		expect(row.totalClosedValue).toBe(12500);
+	});
+});
+
+describe("calculateCarteraClientStats", () => {
+	test("scopes sales total value to matched assigned SIFCOs", () => {
+		const stats = calculateCarteraClientStats({
+			carteraCredits: [
+				{ creditos: { numero_credito_sifco: "A-1", deudatotal: "100.00" } },
+				{ creditos: { numero_credito_sifco: "B-1", deudatotal: "900.00" } },
+			],
+			matchedSifcos: new Set(["A-1"]),
+			uniqueLeadCount: 1,
+			scopedOpportunityCount: 1,
+			userRole: "sales",
+		});
+
+		expect(stats.totalClients).toBe(1);
+		expect(stats.totalClosedOpportunities).toBe(1);
+		expect(stats.totalValue).toBe(100);
+		expect(stats.missingCrmCount).toBe(0);
+	});
+
+	test("uses full cartera totals for non-sales users", () => {
+		const stats = calculateCarteraClientStats({
+			carteraCredits: [
+				{ creditos: { numero_credito_sifco: "A-1", deudatotal: "100.00" } },
+				{ creditos: { numero_credito_sifco: "B-1", capital: "900.00" } },
+			],
+			matchedSifcos: new Set(["A-1"]),
+			uniqueLeadCount: 1,
+			scopedOpportunityCount: 1,
+			userRole: "admin",
+		});
+
+		expect(stats.totalClients).toBe(2);
+		expect(stats.totalValue).toBe(1000);
+		expect(stats.missingCrmCount).toBe(1);
 	});
 });

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -60,7 +60,10 @@ import {
 	updateChecklistForVehicleDocument,
 } from "../lib/checklist";
 import { buildDeletedOpportunitySnapshot } from "../lib/deleted-opportunity-audit";
-import { getGuatemalaMonthWindow } from "../lib/guatemala-month-window";
+import {
+	getGuatemalaMonthWindow,
+	toDateStrGT,
+} from "../lib/guatemala-month-window";
 import {
 	formatMissingLeadFields,
 	getMissingLeadFieldsForContracts,
@@ -79,9 +82,174 @@ import {
 	getMissingFieldsForCompletion,
 	getMissingFieldsForContracts,
 } from "../lib/vehicle-helpers";
+import { carteraBackClient } from "../services/cartera-back-client";
 import { scoreLead } from "../services/lead-scoring";
+import type { StatusCreditEnum } from "../types/cartera-back";
 import { validarDpi } from "../utils/cui-validation";
 import { createNotification } from "./notifications";
+
+const CLIENT_CREDIT_CARTERA_STATUSES = [
+	"ACTIVO",
+	"MOROSO",
+	"EN_CONVENIO",
+] as const satisfies readonly StatusCreditEnum[];
+
+type ClientCreditCarteraStatus =
+	(typeof CLIENT_CREDIT_CARTERA_STATUSES)[number];
+
+type ClientCreditFetcher = (params: {
+	mes: number;
+	anio: number;
+	estado: ClientCreditCarteraStatus;
+	page: number;
+	perPage: number;
+}) => Promise<{
+	data: CarteraClientCredit[];
+	totalPages?: number | null;
+}>;
+
+type CarteraClientCredit = {
+	creditos?: {
+		numero_credito_sifco?: string | null;
+		statusCredit?: StatusCreditEnum | null;
+		capital?: string | null;
+		deudatotal?: string | null;
+		cuota?: string | null;
+		fecha_creacion?: string | null;
+		tipoCredito?: string | null;
+	};
+	usuarios?: {
+		nombre?: string | null;
+		nit?: string | null;
+	};
+	asesores?: {
+		nombre?: string | null;
+	} | null;
+};
+
+function getCurrentCarteraMonthParams(now = new Date()) {
+	const [anio, mes] = toDateStrGT(now).split("-").map(Number);
+	return { mes, anio };
+}
+
+export async function getClientCreditSifcosFromCartera(
+	fetchCredits: ClientCreditFetcher,
+	params: { mes: number; anio: number },
+) {
+	const credits = await getClientCreditsFromCartera(fetchCredits, params);
+	return credits
+		.map((row) => row.creditos?.numero_credito_sifco?.trim())
+		.filter((sifco): sifco is string => Boolean(sifco));
+}
+
+async function getClientCreditsFromCartera(
+	fetchCredits: ClientCreditFetcher,
+	params: { mes: number; anio: number },
+) {
+	const perPage = 100;
+	const maxPages = 200;
+	const creditsBySifco = new Map<string, CarteraClientCredit>();
+
+	for (const estado of CLIENT_CREDIT_CARTERA_STATUSES) {
+		let page = 1;
+		while (page <= maxPages) {
+			const response = await fetchCredits({
+				...params,
+				estado,
+				page,
+				perPage,
+			});
+
+			for (const row of response.data) {
+				const sifco = row.creditos?.numero_credito_sifco?.trim();
+				if (sifco && !creditsBySifco.has(sifco)) creditsBySifco.set(sifco, row);
+			}
+
+			if (response.data.length < perPage) break;
+			if (response.totalPages != null && page >= response.totalPages) break;
+			page += 1;
+		}
+	}
+
+	return Array.from(creditsBySifco.values());
+}
+
+async function getCurrentClientCreditsFromCartera() {
+	return getClientCreditsFromCartera(
+		(params) => carteraBackClient.getAllCreditos(params),
+		getCurrentCarteraMonthParams(),
+	);
+}
+
+function splitFullName(fullName: string | null | undefined) {
+	const parts = (fullName || "Cliente sin nombre")
+		.trim()
+		.split(/\s+/)
+		.filter(Boolean);
+	return {
+		firstName: parts[0] || "Cliente",
+		middleName: parts.length > 3 ? parts[1] : null,
+		lastName:
+			parts.length > 1 ? parts[parts.length > 2 ? parts.length - 2 : 1] : "",
+		secondLastName: parts.length > 2 ? parts[parts.length - 1] : null,
+	};
+}
+
+export function buildCarteraOnlyClientRow(credit: CarteraClientCredit) {
+	const sifco = credit.creditos?.numero_credito_sifco?.trim() || "sin-sifco";
+	const name = splitFullName(credit.usuarios?.nombre);
+	const createdAt = credit.creditos?.fecha_creacion
+		? new Date(credit.creditos.fecha_creacion)
+		: new Date();
+	const totalValue =
+		Number.parseFloat(
+			credit.creditos?.deudatotal || credit.creditos?.capital || "0",
+		) || 0;
+
+	return {
+		id: `cartera-${sifco}`,
+		...name,
+		email: "",
+		phone: null,
+		dpi: null,
+		nit: credit.usuarios?.nit || null,
+		age: null,
+		clientType: "individual",
+		maritalStatus: null,
+		dependents: null,
+		monthlyIncome: null,
+		loanAmount: credit.creditos?.capital || null,
+		occupation: null,
+		workTime: null,
+		ownsHome: null,
+		ownsVehicle: null,
+		hasCreditCard: null,
+		jobTitle: null,
+		direccion: null,
+		departamento: null,
+		municipio: null,
+		zona: null,
+		assignedTo: "",
+		createdAt,
+		updatedAt: createdAt,
+		assignedUser: credit.asesores?.nombre
+			? { id: "cartera", name: credit.asesores.nombre }
+			: null,
+		opportunities: [],
+		creditAnalysis: null,
+		totalClosedValue: totalValue,
+		closedOpportunitiesCount: 0,
+		crmMatchStatus: "missing" as const,
+		carteraCredit: {
+			numeroSifco: sifco,
+			statusCredit: credit.creditos?.statusCredit || null,
+			capital: credit.creditos?.capital || null,
+			deudaTotal: credit.creditos?.deudatotal || null,
+			cuota: credit.creditos?.cuota || null,
+			tipoCredito: credit.creditos?.tipoCredito || null,
+		},
+	};
+}
 
 export const getLeadsInputSchema = z.object({
 	limit: z.number().min(1).max(100).default(20),
@@ -758,7 +926,10 @@ export const crmRouter = {
 					.where(eq(opportunities.leadId, id));
 			}
 
-			if (updateData.source !== undefined || updateData.campaign !== undefined) {
+			if (
+				updateData.source !== undefined ||
+				updateData.campaign !== undefined
+			) {
 				const [activeOpportunity] = await db
 					.select({ id: opportunities.id })
 					.from(opportunities)
@@ -774,15 +945,15 @@ export const crmRouter = {
 				if (activeOpportunity) {
 					await db
 						.update(opportunities)
-					.set({
-						...(updateData.source !== undefined
-							? { source: updateData.source }
-							: {}),
-						...(updateData.campaign !== undefined
-							? { campaign: updateData.campaign }
-							: {}),
-						updatedAt: new Date(),
-					})
+						.set({
+							...(updateData.source !== undefined
+								? { source: updateData.source }
+								: {}),
+							...(updateData.campaign !== undefined
+								? { campaign: updateData.campaign }
+								: {}),
+							updatedAt: new Date(),
+						})
 						.where(eq(opportunities.id, activeOpportunity.id));
 				}
 			}
@@ -1093,8 +1264,7 @@ export const crmRouter = {
 				.groupBy(opportunityStageHistory.opportunityId)
 				.as("latest_stage_history");
 
-			const closedAtExpression =
-				sql<Date | null>`coalesce(${firstClosedStageDates.firstClosedStageAt}, ${opportunities.actualCloseDate})`;
+			const closedAtExpression = sql<Date | null>`coalesce(${firstClosedStageDates.firstClosedStageAt}, ${opportunities.actualCloseDate})`;
 
 			const selectFields = {
 				id: opportunities.id,
@@ -1892,7 +2062,11 @@ export const crmRouter = {
 			}
 
 			// If lead is being changed (not just preserved) and no explicit source provided, copy source from new lead
-			if (input.leadId && input.leadId !== currentOpportunity[0].leadId && !updateData.source) {
+			if (
+				input.leadId &&
+				input.leadId !== currentOpportunity[0].leadId &&
+				!updateData.source
+			) {
 				const newLead = await db
 					.select({ source: leads.source })
 					.from(leads)
@@ -3024,19 +3198,21 @@ export const crmRouter = {
 		.handler(async ({ input, context }) => {
 			const { limit, offset, search } = input;
 
-			// Build subquery to find leads with at least one won opportunity
-			const leadsWithClosedOpportunities = await db
-				.selectDistinct({ leadId: opportunities.leadId })
-				.from(opportunities)
-				.where(
-					and(isNotNull(opportunities.leadId), eq(opportunities.status, "won")),
-				);
+			const carteraCredits = await getCurrentClientCreditsFromCartera();
+			const clientCreditSifcos = carteraCredits
+				.map((row) => row.creditos?.numero_credito_sifco?.trim())
+				.filter((sifco): sifco is string => Boolean(sifco));
+			const carteraCreditBySifco = new Map(
+				carteraCredits
+					.map(
+						(row) => [row.creditos?.numero_credito_sifco?.trim(), row] as const,
+					)
+					.filter((entry): entry is readonly [string, CarteraClientCredit] =>
+						Boolean(entry[0]),
+					),
+			);
 
-			const clientLeadIds = leadsWithClosedOpportunities
-				.map((r) => r.leadId)
-				.filter((id): id is string => id !== null);
-
-			if (clientLeadIds.length === 0) {
+			if (clientCreditSifcos.length === 0) {
 				return {
 					data: [],
 					total: 0,
@@ -3045,13 +3221,33 @@ export const crmRouter = {
 				};
 			}
 
+			// Find leads with at least one credit currently active, overdue, or in agreement in cartera.
+			const leadsWithClientCredits = await db
+				.selectDistinct({ leadId: opportunities.leadId })
+				.from(opportunities)
+				.where(
+					and(
+						isNotNull(opportunities.leadId),
+						inArray(opportunities.numeroSifco, clientCreditSifcos),
+					),
+				);
+
+			const clientLeadIds = leadsWithClientCredits
+				.map((r) => r.leadId)
+				.filter((id): id is string => id !== null);
+
 			// Build conditions for the main query
-			const conditions: any[] = [
-				sql`${leads.id} IN (${sql.join(
-					clientLeadIds.map((id) => sql`${id}`),
-					sql`, `,
-				)})`,
-			];
+			const conditions: any[] = [];
+			if (clientLeadIds.length > 0) {
+				conditions.push(
+					sql`${leads.id} IN (${sql.join(
+						clientLeadIds.map((id) => sql`${id}`),
+						sql`, `,
+					)})`,
+				);
+			} else {
+				conditions.push(sql`false`);
+			}
 
 			// Filter by user if not admin/sales_supervisor
 			if (context.userRole === "sales") {
@@ -3063,41 +3259,7 @@ export const crmRouter = {
 				conditions.push(eq(leads.id, input.leadId));
 			}
 
-			// Search filter
-			if (search && search.trim() !== "") {
-				const searchPattern = `%${search.trim()}%`;
-				conditions.push(
-					or(
-						ilike(leads.firstName, searchPattern),
-						ilike(leads.middleName, searchPattern),
-						ilike(leads.lastName, searchPattern),
-						ilike(leads.secondLastName, searchPattern),
-						ilike(leads.email, searchPattern),
-						ilike(leads.phone, searchPattern),
-						ilike(leads.dpi, searchPattern),
-					),
-				);
-			}
-
-			// Date range filter on createdAt
-			if (input.dateFrom) {
-				conditions.push(gte(leads.createdAt, new Date(input.dateFrom)));
-			}
-			if (input.dateTo) {
-				const toDate = new Date(input.dateTo);
-				toDate.setHours(23, 59, 59, 999);
-				conditions.push(lte(leads.createdAt, toDate));
-			}
-
 			const whereClause = and(...conditions);
-
-			// Get total count
-			const countResult = await db
-				.select({ count: sql<number>`count(*)` })
-				.from(leads)
-				.where(whereClause);
-
-			const total = Number(countResult[0]?.count || 0);
 
 			// Get paginated leads
 			const clientLeads = await db
@@ -3138,9 +3300,7 @@ export const crmRouter = {
 				.from(leads)
 				.leftJoin(user, eq(leads.assignedTo, user.id))
 				.where(whereClause)
-				.orderBy(desc(leads.createdAt))
-				.limit(limit)
-				.offset(offset);
+				.orderBy(desc(leads.createdAt));
 
 			// Now get the opportunities for each lead
 			const leadIds = clientLeads.map((l) => l.id);
@@ -3193,8 +3353,8 @@ export const crmRouter = {
 							createdAt: opp.createdAt,
 							stage: opp.stage,
 							isClosed:
-								opp.numeroSifco !== null ||
-								(opp.stage?.closurePercentage ?? 0) >= 100,
+								opp.numeroSifco != null &&
+								clientCreditSifcos.includes(opp.numeroSifco),
 						});
 					}
 					return acc;
@@ -3238,27 +3398,85 @@ export const crmRouter = {
 			);
 
 			// Combine leads with their opportunities and credit analysis
-			const data = clientLeads.map((lead) => ({
-				...lead,
-				opportunities: opportunitiesByLead[lead.id] || [],
-				creditAnalysis: creditAnalysisMap[lead.id] || null,
-				// Calculate total value from closed opportunities
-				totalClosedValue: (opportunitiesByLead[lead.id] || [])
-					.filter((opp: any) => opp.isClosed)
-					.reduce(
-						(sum: number, opp: any) =>
-							sum + (Number.parseFloat(opp.value || "0") || 0),
-						0,
-					),
-				// Count of closed opportunities
-				closedOpportunitiesCount: (opportunitiesByLead[lead.id] || []).filter(
-					(opp: any) => opp.isClosed,
-				).length,
-			}));
+			const matchedSifcos = new Set<string>();
+			const crmRows = clientLeads.map((lead) => {
+				const leadOpportunities = opportunitiesByLead[lead.id] || [];
+				for (const opp of leadOpportunities) {
+					if (opp.numeroSifco && clientCreditSifcos.includes(opp.numeroSifco)) {
+						matchedSifcos.add(opp.numeroSifco);
+					}
+				}
+
+				const primaryCredit = leadOpportunities
+					.map((opp: any) =>
+						opp.numeroSifco ? carteraCreditBySifco.get(opp.numeroSifco) : null,
+					)
+					.find(Boolean);
+
+				return {
+					...lead,
+					opportunities: leadOpportunities,
+					creditAnalysis: creditAnalysisMap[lead.id] || null,
+					totalClosedValue: leadOpportunities
+						.filter((opp: any) => opp.isClosed)
+						.reduce(
+							(sum: number, opp: any) =>
+								sum + (Number.parseFloat(opp.value || "0") || 0),
+							0,
+						),
+					closedOpportunitiesCount: leadOpportunities.filter(
+						(opp: any) => opp.isClosed,
+					).length,
+					crmMatchStatus: "matched" as const,
+					carteraCredit: primaryCredit
+						? buildCarteraOnlyClientRow(primaryCredit).carteraCredit
+						: null,
+				};
+			});
+
+			const carteraOnlyRows = carteraCredits
+				.filter((credit) => {
+					const sifco = credit.creditos?.numero_credito_sifco?.trim();
+					return sifco && !matchedSifcos.has(sifco);
+				})
+				.map(buildCarteraOnlyClientRow);
+
+			const searchValue = search?.trim().toLowerCase();
+			const fromDate = input.dateFrom ? new Date(input.dateFrom) : null;
+			const toDate = input.dateTo ? new Date(input.dateTo) : null;
+			if (toDate) toDate.setHours(23, 59, 59, 999);
+
+			const visibleCarteraOnlyRows =
+				input.leadId || context.userRole === "sales" ? [] : carteraOnlyRows;
+			const allRows = [...crmRows, ...visibleCarteraOnlyRows]
+				.filter((row) => {
+					if (!searchValue) return true;
+					return [
+						row.firstName,
+						(row as any).middleName,
+						row.lastName,
+						(row as any).secondLastName,
+						row.email,
+						row.phone,
+						row.dpi,
+						(row as any).nit,
+						(row as any).carteraCredit?.numeroSifco,
+					]
+						.filter(Boolean)
+						.some((value) => String(value).toLowerCase().includes(searchValue));
+				})
+				.filter((row) => {
+					if (fromDate && row.createdAt < fromDate) return false;
+					if (toDate && row.createdAt > toDate) return false;
+					return true;
+				})
+				.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+
+			const data = allRows.slice(offset, offset + limit);
 
 			return {
 				data,
-				total,
+				total: allRows.length,
 				limit,
 				offset,
 			};
@@ -3266,32 +3484,29 @@ export const crmRouter = {
 
 	// Estadísticas de leads como clientes (totales globales, no paginados)
 	getLeadsAsClientsStats: crmProcedure.handler(async ({ context }) => {
-		// Get all stages with 100% closure
-		const closedStages = await db
-			.select({ id: salesStages.id })
-			.from(salesStages)
-			.where(gte(salesStages.closurePercentage, 100));
+		const carteraCredits = await getCurrentClientCreditsFromCartera();
+		const clientCreditSifcos = carteraCredits
+			.map((row) => row.creditos?.numero_credito_sifco?.trim())
+			.filter((sifco): sifco is string => Boolean(sifco));
 
-		const closedStageIds = closedStages.map((s) => s.id);
+		if (clientCreditSifcos.length === 0) {
+			return {
+				totalClients: 0,
+				totalClosedOpportunities: 0,
+				totalValue: 0,
+				missingCrmCount: 0,
+			};
+		}
 
-		// Build condition for closed opportunities
-		const closedOpportunityCondition = and(
+		const clientCreditOpportunityCondition = and(
 			isNotNull(opportunities.leadId),
-			or(
-				isNotNull(opportunities.numeroSifco),
-				closedStageIds.length > 0
-					? sql`${opportunities.stageId} IN (${sql.join(
-							closedStageIds.map((id) => sql`${id}`),
-							sql`, `,
-						)})`
-					: sql`false`,
-			),
+			inArray(opportunities.numeroSifco, clientCreditSifcos),
 		);
 
-		// Get all closed opportunities with their values
-		const closedOpportunitiesData = await db
+		const clientCreditOpportunitiesData = await db
 			.select({
 				leadId: opportunities.leadId,
+				numeroSifco: opportunities.numeroSifco,
 				value: opportunities.value,
 			})
 			.from(opportunities)
@@ -3299,23 +3514,33 @@ export const crmRouter = {
 			.where(
 				context.userRole === "sales"
 					? and(
-							closedOpportunityCondition,
+							clientCreditOpportunityCondition,
 							eq(leads.assignedTo, context.userId),
 						)
-					: closedOpportunityCondition,
+					: clientCreditOpportunityCondition,
 			);
 
 		// Calculate stats
 		const uniqueLeadIds = new Set(
-			closedOpportunitiesData
+			clientCreditOpportunitiesData
 				.map((o) => o.leadId)
 				.filter((id): id is string => id !== null),
 		);
+		const matchedSifcos = new Set(
+			clientCreditOpportunitiesData
+				.map((o: any) => o.numeroSifco)
+				.filter((sifco: unknown): sifco is string => typeof sifco === "string"),
+		);
 
-		const totalClients = uniqueLeadIds.size;
-		const totalClosedOpportunities = closedOpportunitiesData.length;
-		const totalValue = closedOpportunitiesData.reduce(
-			(sum, opp) => sum + (Number.parseFloat(opp.value || "0") || 0),
+		const totalClients =
+			context.userRole === "sales" ? uniqueLeadIds.size : carteraCredits.length;
+		const totalClosedOpportunities = clientCreditOpportunitiesData.length;
+		const totalValue = carteraCredits.reduce(
+			(sum, credit) =>
+				sum +
+				(Number.parseFloat(
+					credit.creditos?.deudatotal || credit.creditos?.capital || "0",
+				) || 0),
 			0,
 		);
 
@@ -3323,6 +3548,10 @@ export const crmRouter = {
 			totalClients,
 			totalClosedOpportunities,
 			totalValue,
+			missingCrmCount:
+				context.userRole === "sales"
+					? 0
+					: Math.max(0, carteraCredits.length - matchedSifcos.size),
 		};
 	}),
 
@@ -4807,9 +5036,7 @@ export const crmRouter = {
 			const [checklist] = await db
 				.select({ notes: disbursementChecklists.notes })
 				.from(disbursementChecklists)
-				.where(
-					eq(disbursementChecklists.opportunityId, input.opportunityId),
-				)
+				.where(eq(disbursementChecklists.opportunityId, input.opportunityId))
 				.limit(1);
 
 			return { notes: checklist?.notes ?? null };

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -251,6 +251,42 @@ export function buildCarteraOnlyClientRow(credit: CarteraClientCredit) {
 	};
 }
 
+export function calculateCarteraClientStats(params: {
+	carteraCredits: CarteraClientCredit[];
+	matchedSifcos: Set<string>;
+	uniqueLeadCount: number;
+	scopedOpportunityCount: number;
+	userRole: string | null | undefined;
+}) {
+	const visibleCredits =
+		params.userRole === "sales"
+			? params.carteraCredits.filter((credit) => {
+					const sifco = credit.creditos?.numero_credito_sifco?.trim();
+					return sifco ? params.matchedSifcos.has(sifco) : false;
+				})
+			: params.carteraCredits;
+
+	return {
+		totalClients:
+			params.userRole === "sales"
+				? params.uniqueLeadCount
+				: params.carteraCredits.length,
+		totalClosedOpportunities: params.scopedOpportunityCount,
+		totalValue: visibleCredits.reduce(
+			(sum, credit) =>
+				sum +
+				(Number.parseFloat(
+					credit.creditos?.deudatotal || credit.creditos?.capital || "0",
+				) || 0),
+			0,
+		),
+		missingCrmCount:
+			params.userRole === "sales"
+				? 0
+				: Math.max(0, params.carteraCredits.length - params.matchedSifcos.size),
+	};
+}
+
 export const getLeadsInputSchema = z.object({
 	limit: z.number().min(1).max(100).default(20),
 	offset: z.number().min(0).default(0),
@@ -3532,27 +3568,13 @@ export const crmRouter = {
 				.filter((sifco: unknown): sifco is string => typeof sifco === "string"),
 		);
 
-		const totalClients =
-			context.userRole === "sales" ? uniqueLeadIds.size : carteraCredits.length;
-		const totalClosedOpportunities = clientCreditOpportunitiesData.length;
-		const totalValue = carteraCredits.reduce(
-			(sum, credit) =>
-				sum +
-				(Number.parseFloat(
-					credit.creditos?.deudatotal || credit.creditos?.capital || "0",
-				) || 0),
-			0,
-		);
-
-		return {
-			totalClients,
-			totalClosedOpportunities,
-			totalValue,
-			missingCrmCount:
-				context.userRole === "sales"
-					? 0
-					: Math.max(0, carteraCredits.length - matchedSifcos.size),
-		};
+		return calculateCarteraClientStats({
+			carteraCredits,
+			matchedSifcos,
+			uniqueLeadCount: uniqueLeadIds.size,
+			scopedOpportunityCount: clientCreditOpportunitiesData.length,
+			userRole: context.userRole,
+		});
 	}),
 
 	createClient: crmProcedure

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { isClosedCreditReportContractStateIncluded } from "./reports";
+
+describe("isClosedCreditReportContractStateIncluded", () => {
+	test("only includes credits with an active contract state", () => {
+		expect(isClosedCreditReportContractStateIncluded("activo")).toBe(true);
+		expect(isClosedCreditReportContractStateIncluded("completado")).toBe(false);
+		expect(isClosedCreditReportContractStateIncluded("incobrable")).toBe(false);
+		expect(isClosedCreditReportContractStateIncluded("recuperado")).toBe(false);
+		expect(isClosedCreditReportContractStateIncluded(null)).toBe(false);
+	});
+});

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -19,9 +19,9 @@ import {
 import { vehicleInspections, vehicles } from "../db/schema/vehicles";
 import {
 	closedCreditsReportProcedure,
+	porcentajeEfectividadReportProcedure,
 	protectedProcedure,
 	tiempoCierreReportProcedure,
-  porcentajeEfectividadReportProcedure,
 } from "../lib/orpc";
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
@@ -36,6 +36,12 @@ const closedCreditsReportInputSchema = z.object({
 	startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 	endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
+
+export function isClosedCreditReportContractStateIncluded(
+	estado: string | null,
+) {
+	return estado === "activo";
+}
 
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
 	const start = new Date(`${startDate}T00:00:00.000-06:00`);
@@ -196,6 +202,8 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 		const latestCarteraReference = db
 			.select({
 				opportunityId: carteraBackReferences.opportunityId,
+				contratoFinanciamientoId:
+					carteraBackReferences.contratoFinanciamientoId,
 				numeroCreditoSifco: carteraBackReferences.numeroCreditoSifco,
 				rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${carteraBackReferences.opportunityId} ORDER BY ${carteraBackReferences.createdAt} DESC, ${carteraBackReferences.id} DESC)`.as(
 					"rn",
@@ -228,10 +236,18 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 					eq(latestCarteraReference.rn, 1),
 				),
 			)
+			.innerJoin(
+				contratosFinanciamiento,
+				eq(
+					latestCarteraReference.contratoFinanciamientoId,
+					contratosFinanciamiento.id,
+				),
+			)
 			.where(
 				and(
 					gte(firstClosedStageDates.firstClosedStageAt, start),
 					lte(firstClosedStageDates.firstClosedStageAt, end),
+					eq(contratosFinanciamiento.estado, "activo"),
 				),
 			)
 			.orderBy(desc(firstClosedStageDates.firstClosedStageAt))
@@ -462,10 +478,8 @@ export const getReportePorcentajeEfectividad =
 				lte(opportunities.createdAt, end),
 			);
 
-			const totalCerradas =
-				sql<number>`COUNT(${everClosed.opportunityId})`;
-			const porcentaje =
-				sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
+			const totalCerradas = sql<number>`COUNT(${everClosed.opportunityId})`;
+			const porcentaje = sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
 
 			const [totalRows, porFuente, registrosRaw] = await Promise.all([
 				db
@@ -496,7 +510,9 @@ export const getReportePorcentajeEfectividad =
 						id: opportunities.id,
 						createdAt: opportunities.createdAt,
 						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-						nombre: sql<string | null>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
+						nombre: sql<
+							string | null
+						>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
 						etapaNombre: salesStages.name,
 						etapaPorcentaje: salesStages.closurePercentage,
 						cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
+	AlertTriangle,
 	Banknote,
 	Briefcase,
 	Calendar,
@@ -13,7 +14,6 @@ import {
 	Eye,
 	FileText,
 	HandshakeIcon,
-	Home,
 	Loader2,
 	Mail,
 	MapPin,
@@ -26,7 +26,6 @@ import {
 	X,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import type { DateRange } from "react-day-picker";
 import { toast } from "sonner";
 import { z } from "zod";
 import {
@@ -66,12 +65,12 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { formatGuatemalaDate } from "@/lib/crm-formatters";
 import { PERMISSIONS } from "@/lib/roles";
-import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
-import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc } from "@/utils/orpc";
 
 export const Route = createFileRoute("/crm/clients")({
@@ -92,22 +91,9 @@ function formatLeadFullName(lead: {
 	secondLastName?: string | null;
 }) {
 	return [lead.firstName, lead.middleName, lead.lastName, lead.secondLastName]
-		.filter((part): part is string => Boolean(part && part.trim()))
+		.filter((part): part is string => Boolean(part?.trim()))
 		.join(" ");
 }
-
-const getClientTypeLabel = (type: string) => {
-	switch (type) {
-		case "individual":
-			return "Individual";
-		case "comerciante":
-			return "Comerciante";
-		case "empresa":
-			return "Empresa";
-		default:
-			return type;
-	}
-};
 
 const getMaritalStatusLabel = (status: string | null) => {
 	if (!status) return "No especificado";
@@ -159,6 +145,32 @@ const formatCurrency = (value: string | number | null) => {
 	return `Q${num.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
 };
 
+const getCarteraStatusLabel = (status?: string | null) => {
+	switch (status) {
+		case "ACTIVO":
+			return "Activo";
+		case "MOROSO":
+			return "Moroso";
+		case "EN_CONVENIO":
+			return "En convenio";
+		default:
+			return "Cartera";
+	}
+};
+
+const getCarteraStatusClassName = (status?: string | null) => {
+	switch (status) {
+		case "ACTIVO":
+			return "bg-green-100 text-green-800";
+		case "MOROSO":
+			return "bg-red-100 text-red-800";
+		case "EN_CONVENIO":
+			return "bg-blue-100 text-blue-800";
+		default:
+			return "bg-muted text-muted-foreground";
+	}
+};
+
 // Type definition for credit analysis
 type CreditAnalysisData = {
 	leadId: string;
@@ -176,10 +188,13 @@ type CreditAnalysisData = {
 type ClientData = {
 	id: string;
 	firstName: string;
+	middleName?: string | null;
 	lastName: string;
+	secondLastName?: string | null;
 	email: string;
 	phone: string | null;
 	dpi: string | null;
+	nit?: string | null;
 	age: number | null;
 	clientType: string;
 	maritalStatus: string | null;
@@ -219,6 +234,15 @@ type ClientData = {
 	creditAnalysis: CreditAnalysisData;
 	totalClosedValue: number;
 	closedOpportunitiesCount: number;
+	crmMatchStatus?: "matched" | "missing";
+	carteraCredit?: {
+		numeroSifco: string;
+		statusCredit: string | null;
+		capital: string | null;
+		deudaTotal: string | null;
+		cuota: string | null;
+		tipoCredito: string | null;
+	} | null;
 };
 
 function RouteComponent() {
@@ -229,9 +253,14 @@ function RouteComponent() {
 	} = authClient.useSession();
 	const navigate = Route.useNavigate();
 	const search = Route.useSearch();
-	const [searchTerm, setSearchTerm] = usePersistedState<string>("crm/clients/searchTerm", "");
+	const [searchTerm, setSearchTerm] = usePersistedState<string>(
+		"crm/clients/searchTerm",
+		"",
+	);
 	const [debouncedSearch, setDebouncedSearch] = useState(searchTerm);
-	const [dateRange, setDateRange] = usePersistedDateRange("crm/clients/dateRange");
+	const [dateRange, setDateRange] = usePersistedDateRange(
+		"crm/clients/dateRange",
+	);
 	const [page, setPage] = usePersistedState<number>("crm/clients/page", 0);
 	const pageSize = 20;
 
@@ -519,7 +548,7 @@ function RouteComponent() {
 			<div>
 				<h1 className="font-bold text-3xl">Cartera de Clientes</h1>
 				<p className="text-muted-foreground">
-					Leads con oportunidades cerradas
+					Créditos vigentes de cartera enriquecidos con CRM cuando existe match
 				</p>
 			</div>
 
@@ -537,15 +566,13 @@ function RouteComponent() {
 							{statsQuery.data?.totalClients ?? 0}
 						</div>
 						<p className="text-muted-foreground text-xs">
-							Leads con créditos cerrados
+							Créditos activos, morosos o en convenio
 						</p>
 					</CardContent>
 				</Card>
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle className="font-medium text-sm">
-							Oportunidades Cerradas
-						</CardTitle>
+						<CardTitle className="font-medium text-sm">Con CRM</CardTitle>
 						<CheckCircle2 className="h-4 w-4 text-green-500" />
 					</CardHeader>
 					<CardContent>
@@ -553,7 +580,7 @@ function RouteComponent() {
 							{statsQuery.data?.totalClosedOpportunities ?? 0}
 						</div>
 						<p className="text-muted-foreground text-xs">
-							Total de créditos activos
+							Créditos con oportunidad enlazada
 						</p>
 					</CardContent>
 				</Card>
@@ -571,7 +598,7 @@ function RouteComponent() {
 							})}
 						</div>
 						<p className="text-muted-foreground text-xs">
-							En créditos cerrados
+							Deuda total en cartera vigente
 						</p>
 					</CardContent>
 				</Card>
@@ -583,7 +610,8 @@ function RouteComponent() {
 						<div>
 							<CardTitle>Directorio de Clientes</CardTitle>
 							<CardDescription>
-								Leads que tienen al menos una oportunidad cerrada
+								Clientes de cartera; CRM se muestra cuando hay oportunidad
+								enlazada
 							</CardDescription>
 						</div>
 					</div>
@@ -594,7 +622,7 @@ function RouteComponent() {
 						<div className="relative max-w-md flex-1">
 							<Search className="absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
 							<Input
-								placeholder="Buscar por nombre, email, teléfono o DPI..."
+								placeholder="Buscar por nombre, NIT, SIFCO, email o teléfono..."
 								value={searchTerm}
 								onChange={(e) => setSearchTerm(e.target.value)}
 								className="pl-8"
@@ -608,11 +636,19 @@ function RouteComponent() {
 							}}
 						/>
 						{hasActiveFilters && (
-							<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+							<Button
+								variant="ghost"
+								size="sm"
+								onClick={resetFilters}
+								className="shrink-0 text-muted-foreground"
+							>
 								<X className="mr-1 h-3 w-3" />
 								Limpiar filtros
 								<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
-									{[searchTerm !== "", dateRange !== undefined].filter(Boolean).length}
+									{
+										[searchTerm !== "", dateRange !== undefined].filter(Boolean)
+											.length
+									}
 								</Badge>
 							</Button>
 						)}
@@ -631,8 +667,8 @@ function RouteComponent() {
 							<HandshakeIcon className="mb-4 h-12 w-12 text-muted-foreground" />
 							<h3 className="font-medium text-lg">No hay clientes aún</h3>
 							<p className="max-w-md text-muted-foreground text-sm">
-								Los clientes aparecerán aquí cuando los leads tengan
-								oportunidades en etapa al 100%
+								Los clientes aparecerán aquí cuando cartera tenga créditos
+								activos, morosos o en convenio.
 							</p>
 						</div>
 					) : (
@@ -642,9 +678,9 @@ function RouteComponent() {
 									<TableRow>
 										<TableHead>Cliente</TableHead>
 										<TableHead>Contacto</TableHead>
-										<TableHead>Tipo</TableHead>
-										<TableHead>Oportunidades Cerradas</TableHead>
-										<TableHead>Valor Total</TableHead>
+										<TableHead>Estado cartera</TableHead>
+										<TableHead>CRM</TableHead>
+										<TableHead>Deuda / valor</TableHead>
 										<TableHead>Desde</TableHead>
 										<TableHead className="text-right">Acciones</TableHead>
 									</TableRow>
@@ -663,9 +699,19 @@ function RouteComponent() {
 														<div className="font-medium">
 															{formatLeadFullName(clientData)}
 														</div>
+														{clientData.carteraCredit?.numeroSifco && (
+															<div className="text-muted-foreground text-xs">
+																SIFCO: {clientData.carteraCredit.numeroSifco}
+															</div>
+														)}
 														{clientData.dpi && (
 															<div className="text-muted-foreground text-xs">
 																DPI: {clientData.dpi}
+															</div>
+														)}
+														{!clientData.dpi && clientData.nit && (
+															<div className="text-muted-foreground text-xs">
+																NIT: {clientData.nit}
 															</div>
 														)}
 													</div>
@@ -685,53 +731,67 @@ function RouteComponent() {
 												</div>
 											</TableCell>
 											<TableCell>
-												<Badge variant="outline" className="capitalize">
-													{getClientTypeLabel(clientData.clientType)}
-												</Badge>
+												<div className="space-y-1">
+													<Badge
+														className={getCarteraStatusClassName(
+															clientData.carteraCredit?.statusCredit,
+														)}
+													>
+														{getCarteraStatusLabel(
+															clientData.carteraCredit?.statusCredit,
+														)}
+													</Badge>
+													{clientData.carteraCredit?.cuota && (
+														<div className="text-muted-foreground text-xs">
+															Cuota:{" "}
+															{formatCurrency(clientData.carteraCredit.cuota)}
+														</div>
+													)}
+												</div>
 											</TableCell>
 											<TableCell>
-												<TooltipProvider>
-													<Tooltip>
-														<TooltipTrigger asChild>
-															<div className="flex items-center gap-2">
+												{clientData.crmMatchStatus === "missing" ? (
+													<Badge
+														variant="outline"
+														className="border-amber-300 text-amber-700"
+													>
+														<AlertTriangle className="mr-1 h-3 w-3" />
+														Sin oportunidad CRM
+													</Badge>
+												) : (
+													<TooltipProvider>
+														<Tooltip>
+															<TooltipTrigger asChild>
 																<Badge
 																	variant="secondary"
 																	className="bg-green-100 text-green-800"
 																>
 																	{clientData.closedOpportunitiesCount}{" "}
-																	cerrada(s)
+																	enlazada(s)
 																</Badge>
-																{clientData.opportunities.length >
-																	clientData.closedOpportunitiesCount && (
-																	<Badge variant="outline">
-																		+
-																		{clientData.opportunities.length -
-																			clientData.closedOpportunitiesCount}{" "}
-																		abierta(s)
-																	</Badge>
-																)}
-															</div>
-														</TooltipTrigger>
-														<TooltipContent side="bottom" className="max-w-sm">
-															<div className="space-y-2">
-																<p className="font-medium">Oportunidades:</p>
-																{clientData.opportunities.map((opp) => (
-																	<div
-																		key={opp.id}
-																		className="flex items-center gap-2 text-sm"
-																	>
-																		{opp.isClosed ? (
+															</TooltipTrigger>
+															<TooltipContent
+																side="bottom"
+																className="max-w-sm"
+															>
+																<div className="space-y-2">
+																	<p className="font-medium">
+																		Oportunidades CRM:
+																	</p>
+																	{clientData.opportunities.map((opp) => (
+																		<div
+																			key={opp.id}
+																			className="flex items-center gap-2 text-sm"
+																		>
 																			<CheckCircle2 className="h-3 w-3 text-green-500" />
-																		) : (
-																			<FileText className="h-3 w-3 text-muted-foreground" />
-																		)}
-																		<span>{opp.title}</span>
-																	</div>
-																))}
-															</div>
-														</TooltipContent>
-													</Tooltip>
-												</TooltipProvider>
+																			<span>{opp.title}</span>
+																		</div>
+																	))}
+																</div>
+															</TooltipContent>
+														</Tooltip>
+													</TooltipProvider>
+												)}
 											</TableCell>
 											<TableCell>
 												<div className="flex items-center gap-1 font-medium text-green-600">
@@ -833,12 +893,27 @@ function RouteComponent() {
 										<h3 className="truncate font-semibold text-xl">
 											{formatLeadFullName(selectedClient)}
 										</h3>
-										<Badge variant="outline" className="shrink-0 text-xs">
-											{getClientTypeLabel(selectedClient.clientType)}
+										<Badge
+											className={`shrink-0 text-xs ${getCarteraStatusClassName(
+												selectedClient.carteraCredit?.statusCredit,
+											)}`}
+										>
+											{getCarteraStatusLabel(
+												selectedClient.carteraCredit?.statusCredit,
+											)}
 										</Badge>
-										<Badge className="shrink-0 bg-green-500 text-xs hover:bg-green-600">
-											Activo
-										</Badge>
+										{selectedClient.crmMatchStatus === "missing" ? (
+											<Badge
+												variant="outline"
+												className="shrink-0 border-amber-300 text-amber-700 text-xs"
+											>
+												Sin oportunidad CRM
+											</Badge>
+										) : (
+											<Badge variant="outline" className="shrink-0 text-xs">
+												CRM enlazado
+											</Badge>
+										)}
 									</div>
 									<div className="mt-1 flex items-center gap-4 text-muted-foreground text-sm">
 										{selectedClient.email && (
@@ -851,6 +926,12 @@ function RouteComponent() {
 											<span className="flex items-center gap-1">
 												<Phone className="h-3.5 w-3.5" />
 												{selectedClient.phone}
+											</span>
+										)}
+										{selectedClient.carteraCredit?.numeroSifco && (
+											<span className="flex items-center gap-1">
+												<CreditCard className="h-3.5 w-3.5" />
+												SIFCO: {selectedClient.carteraCredit.numeroSifco}
 											</span>
 										)}
 										{selectedClient.dpi && (
@@ -866,9 +947,7 @@ function RouteComponent() {
 										<p className="font-bold text-green-600 text-xl">
 											{selectedClient.closedOpportunitiesCount}
 										</p>
-										<p className="text-[11px] text-muted-foreground">
-											Cerradas
-										</p>
+										<p className="text-[11px] text-muted-foreground">CRM</p>
 									</div>
 									<div className="h-8 w-px bg-border" />
 									<div className="text-center">
@@ -883,7 +962,7 @@ function RouteComponent() {
 											{formatCurrency(selectedClient.totalClosedValue)}
 										</p>
 										<p className="text-[11px] text-muted-foreground">
-											Valor cerrado
+											Deuda / valor
 										</p>
 									</div>
 								</div>
@@ -893,12 +972,30 @@ function RouteComponent() {
 							<div className="space-y-3">
 								<h3 className="flex items-center gap-2 font-semibold text-base">
 									<HandshakeIcon className="h-4 w-4" />
-									Oportunidades
+									Oportunidad CRM
 									<Badge variant="secondary" className="ml-1 text-xs">
 										{selectedClient.opportunities.length}
 									</Badge>
 								</h3>
 								<div className="space-y-2">
+									{selectedClient.opportunities.length === 0 && (
+										<div className="rounded-lg border border-amber-200 bg-amber-50 p-4 text-amber-900 dark:border-amber-900 dark:bg-amber-950/30 dark:text-amber-100">
+											<div className="flex items-start gap-3">
+												<AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+												<div>
+													<p className="font-medium">
+														Sin oportunidad CRM enlazada
+													</p>
+													<p className="mt-1 text-sm">
+														Este crédito existe en cartera, pero no hay una
+														oportunidad CRM con el mismo número SIFCO. Los datos
+														de etapa, vehículo, documentos, análisis e historial
+														CRM no están disponibles.
+													</p>
+												</div>
+											</div>
+										</div>
+									)}
 									{selectedClient.opportunities.map((opp) => (
 										<div
 											key={opp.id}
@@ -1112,7 +1209,7 @@ function RouteComponent() {
 														Guardar
 													</Button>
 												</div>
-											) : (
+											) : selectedClient.crmMatchStatus !== "missing" ? (
 												<Button
 													variant="ghost"
 													size="sm"
@@ -1122,7 +1219,7 @@ function RouteComponent() {
 													<Pencil className="mr-1 h-3 w-3" />
 													Editar
 												</Button>
-											)}
+											) : null}
 										</div>
 										{isEditingContact ? (
 											<div className="space-y-3">


### PR DESCRIPTION
## Summary
- Source CRM clients from cartera credits in ACTIVO, MOROSO, and EN_CONVENIO states
- Keep existing CRM details when a cartera credit matches an opportunity by SIFCO
- Show cartera-only rows with a clear missing CRM opportunity state
- Filter closed credits report to active local contracts

## Verification
- bun test apps/server/src/routers/crm-get-leads-input.test.ts
- bun test apps/server/src/routers/reports.test.ts
- bun run --filter server check-types
- bun run --filter web check-types