### PR TITLE
feat(cartera): celdas editables del reporte Facturación Diaria (lock por fila + auditoría)

### DIFF
--- a/apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql
+++ b/apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql
@@ -1,0 +1,21 @@
+-- Lock por fila + auditoría para edición manual del snapshot diario.
+ALTER TABLE cartera.facturacion_snapshot_diario
+  ADD COLUMN IF NOT EXISTS bloqueado boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS bloqueado_por integer,
+  ADD COLUMN IF NOT EXISTS bloqueado_at timestamp;
+
+CREATE TABLE IF NOT EXISTS cartera.facturacion_snapshot_auditoria (
+  id serial PRIMARY KEY,
+  fecha date NOT NULL,
+  columna varchar(100) NOT NULL,
+  valor_anterior text,
+  valor_nuevo text,
+  accion varchar(20) NOT NULL,
+  usuario_id integer,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshot_auditoria_fecha
+  ON cartera.facturacion_snapshot_auditoria (fecha);
+CREATE INDEX IF NOT EXISTS idx_snapshot_auditoria_created
+  ON cartera.facturacion_snapshot_auditoria (created_at);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
@@ -37,3 +37,26 @@ describe("validarValores", () => {
     expect(r.invalidas).toContain("capital_total");
   });
 });
+
+const { calcularAcumuladosCorridos } = await import("./facturacionSnapshot");
+
+describe("calcularAcumuladosCorridos", () => {
+  it("suma corrida e ignora bloqueados para escribir, pero incluye sus diarias", () => {
+    const dias = [
+      { fecha: "2026-06-01", bloqueado: false, facturacion: "100", servicios_seguro_gps: "10", facturacion_inversionistas: "5", ingreso_carros: "0" },
+      { fecha: "2026-06-02", bloqueado: true,  facturacion: "200", servicios_seguro_gps: "20", facturacion_inversionistas: "5", ingreso_carros: "0" },
+      { fecha: "2026-06-03", bloqueado: false, facturacion: "300", servicios_seguro_gps: "30", facturacion_inversionistas: "5", ingreso_carros: "1" },
+    ];
+    const r = calcularAcumuladosCorridos(dias);
+    // El día 2 (bloqueado) NO genera update.
+    expect(r.map((u) => u.fecha)).toEqual(["2026-06-01", "2026-06-03"]);
+    // Día 1: fact_acum=100
+    expect(r[0].facturacion_acumulado).toBe("100.00");
+    // Día 3: incluye el día 2 bloqueado → 100+200+300 = 600
+    expect(r[1].facturacion_acumulado).toBe("600.00");
+    expect(r[1].acum_servicios_seguro_gps).toBe("60.00");
+    expect(r[1].acumulado_inversionistas).toBe("15.00");
+    // acumulado_total = fact_acum + serv_acum + carros_acum = 600+60+1 = 661
+    expect(r[1].acumulado_total).toBe("661.00");
+  });
+});

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// El controller importa ../database; lo mockeamos para poder importar los helpers puros.
+mock.module("../database", () => ({ db: {} }));
+
+const { esColumnaEditable, validarValores } = await import("./facturacionSnapshot");
+
+describe("esColumnaEditable", () => {
+  it("acepta columnas de valor", () => {
+    expect(esColumnaEditable("capital_total")).toBe(true);
+    expect(esColumnaEditable("facturacion_acumulado")).toBe(true);
+    expect(esColumnaEditable("roy_hipotecario")).toBe(true);
+  });
+  it("rechaza columnas no editables", () => {
+    expect(esColumnaEditable("id")).toBe(false);
+    expect(esColumnaEditable("fecha")).toBe(false);
+    expect(esColumnaEditable("anio")).toBe(false);
+    expect(esColumnaEditable("bloqueado")).toBe(false);
+    expect(esColumnaEditable("columna_inventada")).toBe(false);
+  });
+});
+
+describe("validarValores", () => {
+  it("ok con columnas válidas y números", () => {
+    const r = validarValores({ capital_total: "100.50", facturacion: "0" });
+    expect(r.ok).toBe(true);
+    expect(r.invalidas).toEqual([]);
+  });
+  it("marca columna no editable", () => {
+    const r = validarValores({ fecha: "2026-06-10" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("fecha");
+  });
+  it("marca valor no numérico", () => {
+    const r = validarValores({ capital_total: "abc" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("capital_total");
+  });
+});

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
@@ -6,16 +6,20 @@ mock.module("../database", () => ({ db: {} }));
 const { esColumnaEditable, validarValores } = await import("./facturacionSnapshot");
 
 describe("esColumnaEditable", () => {
-  it("acepta columnas de valor", () => {
+  it("acepta columnas de valor DIARIAS", () => {
     expect(esColumnaEditable("capital_total")).toBe(true);
-    expect(esColumnaEditable("facturacion_acumulado")).toBe(true);
+    expect(esColumnaEditable("facturacion")).toBe(true);
     expect(esColumnaEditable("roy_hipotecario")).toBe(true);
   });
-  it("rechaza columnas no editables", () => {
+  it("rechaza columnas no editables (incl. acumulados auto-calculados)", () => {
     expect(esColumnaEditable("id")).toBe(false);
     expect(esColumnaEditable("fecha")).toBe(false);
     expect(esColumnaEditable("anio")).toBe(false);
     expect(esColumnaEditable("bloqueado")).toBe(false);
+    // Acumulados/tendencias/% se auto-calculan → NO editables a mano.
+    expect(esColumnaEditable("facturacion_acumulado")).toBe(false);
+    expect(esColumnaEditable("acumulado_total")).toBe(false);
+    expect(esColumnaEditable("porcentaje_meta_mensual")).toBe(false);
     expect(esColumnaEditable("columna_inventada")).toBe(false);
   });
 });
@@ -41,22 +45,38 @@ describe("validarValores", () => {
 const { calcularAcumuladosCorridos } = await import("./facturacionSnapshot");
 
 describe("calcularAcumuladosCorridos", () => {
-  it("suma corrida e ignora bloqueados para escribir, pero incluye sus diarias", () => {
+  it("suma corrida para TODOS los días (incl. bloqueado) → acumulados siempre suman", () => {
     const dias = [
       { fecha: "2026-06-01", bloqueado: false, facturacion: "100", servicios_seguro_gps: "10", facturacion_inversionistas: "5", ingreso_carros: "0" },
       { fecha: "2026-06-02", bloqueado: true,  facturacion: "200", servicios_seguro_gps: "20", facturacion_inversionistas: "5", ingreso_carros: "0" },
       { fecha: "2026-06-03", bloqueado: false, facturacion: "300", servicios_seguro_gps: "30", facturacion_inversionistas: "5", ingreso_carros: "1" },
     ];
     const r = calcularAcumuladosCorridos(dias);
-    // El día 2 (bloqueado) NO genera update.
-    expect(r.map((u) => u.fecha)).toEqual(["2026-06-01", "2026-06-03"]);
-    // Día 1: fact_acum=100
+    // Todos los días emiten update (incl. el bloqueado) — sin discontinuidad.
+    expect(r.map((u) => u.fecha)).toEqual(["2026-06-01", "2026-06-02", "2026-06-03"]);
+    // Día 1: 100
     expect(r[0].facturacion_acumulado).toBe("100.00");
-    // Día 3: incluye el día 2 bloqueado → 100+200+300 = 600
-    expect(r[1].facturacion_acumulado).toBe("600.00");
-    expect(r[1].acum_servicios_seguro_gps).toBe("60.00");
-    expect(r[1].acumulado_inversionistas).toBe("15.00");
-    // acumulado_total = fact_acum + serv_acum + carros_acum = 600+60+1 = 661
-    expect(r[1].acumulado_total).toBe("661.00");
+    // Día 2 (bloqueado, pero su acumulado SÍ se calcula): 100+200 = 300
+    expect(r[1].facturacion_acumulado).toBe("300.00");
+    expect(r[1].acumulado_total).toBe("330.00"); // 300 + 30(serv) + 0(carros)
+    // Día 3: 100+200+300 = 600
+    expect(r[2].facturacion_acumulado).toBe("600.00");
+    expect(r[2].acum_servicios_seguro_gps).toBe("60.00");
+    expect(r[2].acumulado_inversionistas).toBe("15.00");
+    // acumulado_total = 600 + 60(serv) + 1(carros) = 661
+    expect(r[2].acumulado_total).toBe("661.00");
+  });
+});
+
+describe("validarValores numérico estricto", () => {
+  it("rechaza notación científica, hex y comas", () => {
+    expect(validarValores({ facturacion: "1e3" }).ok).toBe(false);
+    expect(validarValores({ facturacion: "0x10" }).ok).toBe(false);
+    expect(validarValores({ facturacion: "1,000" }).ok).toBe(false);
+  });
+  it("acepta decimal plano con espacios y signo", () => {
+    expect(validarValores({ facturacion: " 1000 " }).ok).toBe(true);
+    expect(validarValores({ facturacion: "-12.50" }).ok).toBe(true);
+    expect(validarValores({ facturacion: "0" }).ok).toBe(true);
   });
 });

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -9,6 +9,48 @@ const LOGO_URL =
   process.env.LOGO_URL ||
   "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
 
+// ── Edición manual: whitelist de columnas editables + validación ──────────────
+export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set([
+  // Capital
+  "cap_autocompras","cap_sobre_vehiculo","nuevo_cap_autocompras","cap_hipotecario","cap_extra_financiamiento","cap_reestructura","capital_total",
+  // Interés
+  "int_autocompras","int_sobre_vehiculo","nuevo_int_autocompras","int_hipotecario","int_extra_financiamiento","int_reestructura","interes_cube",
+  // Membresía
+  "mem_autocompras","mem_sobre_vehiculo","nuevo_mem_autocompras","mem_hipotecario","mem_extra_financiamiento","mem_reestructura","membresia",
+  // Otros ingresos
+  "oi_autocompras","oi_sobre_vehiculo","nuevo_oi_autocompras","oi_hipotecario","oi_extra_financiamiento","oi_reestructura","otros_ingresos","administrativos","otros_cobros",
+  // Mora
+  "mora_autocompras","mora_sobre_vehiculo","nuevo_mora_autocompras","mora_hipotecario","mora_extra_financiamiento","mora_reestructura","mora_cube",
+  // Royalty
+  "roy_autocompras","roy_sobre_vehiculo","nuevo_roy_autocompras","roy_hipotecario","roy_extra_financiamiento","roy_reestructura","royalty",
+  // Totales / acumulados / servicios
+  "facturacion","facturacion_acumulado","servicios_seguro_gps","acum_servicios_seguro_gps","facturacion_mas_servicios","acumulado_total","facturacion_inversionistas","acumulado_inversionistas","tendencia_fin_mes","tendencia_semanal","ingreso_carros","reserva_acumulada","semana",
+  // Metas
+  "meta_facturacion_mensual","meta_facturacion_semanal","meta_facturacion_diaria","porcentaje_meta_mensual","meta_diaria",
+]);
+
+export function esColumnaEditable(col: string): boolean {
+  return COLUMNAS_EDITABLES.has(col);
+}
+
+export function validarValores(valores: Record<string, unknown>): {
+  ok: boolean;
+  invalidas: string[];
+} {
+  const invalidas: string[] = [];
+  for (const [col, val] of Object.entries(valores)) {
+    if (!esColumnaEditable(col)) {
+      invalidas.push(col);
+      continue;
+    }
+    const n = Number(val);
+    if (val === null || val === "" || Number.isNaN(n) || !Number.isFinite(n)) {
+      invalidas.push(col);
+    }
+  }
+  return { ok: invalidas.length === 0, invalidas };
+}
+
 // ============================================================================
 // 📸 SNAPSHOT DIARIO DE FACTURACIÓN (tipo Excel "Reuniones diarias")
 //    Calcula y CONGELA una fila por día con las columnas A→BK.

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -51,6 +51,79 @@ export function validarValores(valores: Record<string, unknown>): {
   return { ok: invalidas.length === 0, invalidas };
 }
 
+export type DiaAcumulable = {
+  fecha: string;
+  bloqueado: boolean;
+  facturacion: string | number;
+  servicios_seguro_gps: string | number;
+  facturacion_inversionistas: string | number;
+  ingreso_carros: string | number;
+};
+
+export type UpdateAcumulado = {
+  fecha: string;
+  facturacion_acumulado: string;
+  acum_servicios_seguro_gps: string;
+  acumulado_inversionistas: string;
+  acumulado_total: string;
+};
+
+// Suma corrida sobre días YA ordenados por fecha. Acumula TODAS las diarias
+// (incluidas las de días bloqueados) pero solo emite update para los NO bloqueados.
+// No toca reserva_acumulada (es MTD desde pagos, sin columna diaria).
+export function calcularAcumuladosCorridos(
+  dias: DiaAcumulable[]
+): UpdateAcumulado[] {
+  let accFact = new Big(0);
+  let accServ = new Big(0);
+  let accInv = new Big(0);
+  let accCarros = new Big(0);
+  const updates: UpdateAcumulado[] = [];
+  for (const d of dias) {
+    accFact = accFact.plus(new Big(d.facturacion || 0));
+    accServ = accServ.plus(new Big(d.servicios_seguro_gps || 0));
+    accInv = accInv.plus(new Big(d.facturacion_inversionistas || 0));
+    accCarros = accCarros.plus(new Big(d.ingreso_carros || 0));
+    if (!d.bloqueado) {
+      updates.push({
+        fecha: d.fecha,
+        facturacion_acumulado: accFact.toFixed(2),
+        acum_servicios_seguro_gps: accServ.toFixed(2),
+        acumulado_inversionistas: accInv.toFixed(2),
+        acumulado_total: accFact.plus(accServ).plus(accCarros).toFixed(2),
+      });
+    }
+  }
+  return updates;
+}
+
+// Refresca SOLO las columnas de acumulado de los días no bloqueados del mes,
+// usando la suma corrida de las diarias guardadas. No lee la fuente ni toca
+// diarias → seguro para días históricos importados del Excel.
+export async function recomputarAcumuladosMes(anio: number, mes: number) {
+  const res = await db.execute(sql`
+    SELECT fecha::text AS fecha, bloqueado,
+           facturacion, servicios_seguro_gps, facturacion_inversionistas, ingreso_carros
+    FROM cartera.facturacion_snapshot_diario
+    WHERE anio = ${anio} AND mes = ${mes}
+    ORDER BY fecha
+  `);
+  const dias = ((res as any).rows ?? res) as DiaAcumulable[];
+  const updates = calcularAcumuladosCorridos(dias);
+  for (const u of updates) {
+    await db.execute(sql`
+      UPDATE cartera.facturacion_snapshot_diario SET
+        facturacion_acumulado = ${u.facturacion_acumulado},
+        acum_servicios_seguro_gps = ${u.acum_servicios_seguro_gps},
+        acumulado_inversionistas = ${u.acumulado_inversionistas},
+        acumulado_total = ${u.acumulado_total},
+        updated_at = now()
+      WHERE fecha = ${u.fecha}::date
+    `);
+  }
+  return { success: true, dias_actualizados: updates.length };
+}
+
 // ============================================================================
 // 📸 SNAPSHOT DIARIO DE FACTURACIÓN (tipo Excel "Reuniones diarias")
 //    Calcula y CONGELA una fila por día con las columnas A→BK.

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -23,10 +23,14 @@ export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set([
   "mora_autocompras","mora_sobre_vehiculo","nuevo_mora_autocompras","mora_hipotecario","mora_extra_financiamiento","mora_reestructura","mora_cube",
   // Royalty
   "roy_autocompras","roy_sobre_vehiculo","nuevo_roy_autocompras","roy_hipotecario","roy_extra_financiamiento","roy_reestructura","royalty",
-  // Totales / acumulados / servicios
-  "facturacion","facturacion_acumulado","servicios_seguro_gps","acum_servicios_seguro_gps","facturacion_mas_servicios","acumulado_total","facturacion_inversionistas","acumulado_inversionistas","tendencia_fin_mes","tendencia_semanal","ingreso_carros","reserva_acumulada","semana",
-  // Metas
-  "meta_facturacion_mensual","meta_facturacion_semanal","meta_facturacion_diaria","porcentaje_meta_mensual","meta_diaria",
+  // Totales / servicios DIARIOS (editables). Los ACUMULADOS y tendencias NO van
+  // aquí: se auto-calculan (suma corrida) y no se editan a mano —ver
+  // calcularAcumuladosCorridos. (facturacion_acumulado, acum_servicios_seguro_gps,
+  // acumulado_total, acumulado_inversionistas, tendencia_*, reserva_acumulada,
+  // porcentaje_meta_mensual quedan fuera a propósito.)
+  "facturacion","servicios_seguro_gps","facturacion_mas_servicios","facturacion_inversionistas","ingreso_carros","semana",
+  // Metas (editables; el % se deriva del acumulado, no se edita)
+  "meta_facturacion_mensual","meta_facturacion_semanal","meta_facturacion_diaria","meta_diaria",
 ]);
 
 export function esColumnaEditable(col: string): boolean {
@@ -43,8 +47,11 @@ export function validarValores(valores: Record<string, unknown>): {
       invalidas.push(col);
       continue;
     }
-    const n = Number(val);
-    if (val === null || val === "" || Number.isNaN(n) || !Number.isFinite(n)) {
+    // Solo decimal plano (opcional signo): "123", "-12.50", "0". Rechaza "", null,
+    // notación científica ("1e3"), hex ("0x10"), comas ("1,000") y basura — que
+    // Number() aceptaría pero romperían el cast a numeric en el INSERT/UPDATE.
+    const s = String(val ?? "").trim();
+    if (!/^-?\d+(\.\d+)?$/.test(s)) {
       invalidas.push(col);
     }
   }
@@ -68,9 +75,12 @@ export type UpdateAcumulado = {
   acumulado_total: string;
 };
 
-// Suma corrida sobre días YA ordenados por fecha. Acumula TODAS las diarias
-// (incluidas las de días bloqueados) pero solo emite update para los NO bloqueados.
-// No toca reserva_acumulada (es MTD desde pagos, sin columna diaria).
+// Suma corrida sobre días YA ordenados por fecha. Emite el acumulado para CADA
+// día (incluidos los bloqueados): los ACUMULADOS SIEMPRE SUMAN, no se congelan.
+// El lock protege los valores DIARIOS (los salta generarSnapshotDiario), pero el
+// acumulado de un día = suma corrida de las diarias hasta ese día. Así no hay
+// discontinuidad cuando se edita+bloquea un día. No toca reserva_acumulada
+// (es MTD desde pagos, sin columna diaria).
 export function calcularAcumuladosCorridos(
   dias: DiaAcumulable[]
 ): UpdateAcumulado[] {
@@ -84,15 +94,13 @@ export function calcularAcumuladosCorridos(
     accServ = accServ.plus(new Big(d.servicios_seguro_gps || 0));
     accInv = accInv.plus(new Big(d.facturacion_inversionistas || 0));
     accCarros = accCarros.plus(new Big(d.ingreso_carros || 0));
-    if (!d.bloqueado) {
-      updates.push({
-        fecha: d.fecha,
-        facturacion_acumulado: accFact.toFixed(2),
-        acum_servicios_seguro_gps: accServ.toFixed(2),
-        acumulado_inversionistas: accInv.toFixed(2),
-        acumulado_total: accFact.plus(accServ).plus(accCarros).toFixed(2),
-      });
-    }
+    updates.push({
+      fecha: d.fecha,
+      facturacion_acumulado: accFact.toFixed(2),
+      acum_servicios_seguro_gps: accServ.toFixed(2),
+      acumulado_inversionistas: accInv.toFixed(2),
+      acumulado_total: accFact.plus(accServ).plus(accCarros).toFixed(2),
+    });
   }
   return updates;
 }
@@ -101,11 +109,16 @@ export function calcularAcumuladosCorridos(
 // usando la suma corrida de las diarias guardadas. No lee la fuente ni toca
 // diarias → seguro para días históricos importados del Excel.
 export async function recomputarAcumuladosMes(anio: number, mes: number) {
+  // Filtramos por RANGO de fecha (no por anio/mes) porque esas columnas helper
+  // pueden venir NULL en filas importadas → quedarían fuera del SUM y romperían
+  // la continuidad del acumulado.
+  const inicioMes = `${anio}-${String(mes).padStart(2, "0")}-01`;
   const res = await db.execute(sql`
     SELECT fecha::text AS fecha, bloqueado,
            facturacion, servicios_seguro_gps, facturacion_inversionistas, ingreso_carros
     FROM cartera.facturacion_snapshot_diario
-    WHERE anio = ${anio} AND mes = ${mes}
+    WHERE fecha >= ${inicioMes}::date
+      AND fecha < (${inicioMes}::date + INTERVAL '1 month')
     ORDER BY fecha
   `);
   const dias = ((res as any).rows ?? res) as DiaAcumulable[];
@@ -426,6 +439,7 @@ export async function aplicarManualesEnSnapshotDia(fecha: string) {
           + COALESCE((SELECT SUM(monto) FROM cartera.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
         updated_at = now()
     WHERE s.fecha = ${fecha}::date
+      AND s.bloqueado = false
   `);
   return { success: true };
 }
@@ -448,6 +462,7 @@ export async function aplicarMetaEnSnapshotsMes(anio: number, mes: number) {
     WHERE m.anio = ${anio} AND m.mes = ${mes}
       AND s.fecha >= make_date(${anio}, ${mes}, 1)
       AND s.fecha < (make_date(${anio}, ${mes}, 1) + INTERVAL '1 month')
+      AND s.bloqueado = false
   `);
   return { success: true, actualizados: (res as any).rowCount ?? 0 };
 }
@@ -702,6 +717,9 @@ export async function getSnapshotsDiarios(opts: {
     "anio",
     "mes",
     "semana",
+    "bloqueado",
+    "bloqueado_por",
+    "bloqueado_at",
     "facturacion_acumulado",
     "acum_servicios_seguro_gps",
     "acumulado_total",
@@ -777,11 +795,11 @@ export async function guardarCeldasSnapshot(input: {
       const prev = ((prevRes as any).rows ?? prevRes)[0] ?? null;
 
       const cols = Object.keys(c.valores);
+      // Valor canónico (trim) — validarValores ya garantizó que es decimal plano.
+      const valOf = (col: string) => String(c.valores[col] ?? "").trim();
       // SET dinámico de las columnas tocadas. sql.raw para el nombre de columna
       // (YA validado contra el whitelist) y bind del valor.
-      const sets = cols.map(
-        (col) => sql`${sql.raw(col)} = ${String(c.valores[col])}`
-      );
+      const sets = cols.map((col) => sql`${sql.raw(col)} = ${valOf(col)}`);
 
       if (prev) {
         await tx.execute(sql`
@@ -804,7 +822,7 @@ export async function guardarCeldasSnapshot(input: {
           sql`${c.fecha}::date`,
           sql`${anio}`,
           sql`${mes}`,
-          ...cols.map((col) => sql`${String(c.valores[col])}`),
+          ...cols.map((col) => sql`${valOf(col)}`),
           sql`true`,
           sql`${usuarioId}`,
           sql`now()`,
@@ -825,7 +843,7 @@ export async function guardarCeldasSnapshot(input: {
           INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
           VALUES (${c.fecha}::date, ${col}, ${
           anterior === null ? null : String(anterior)
-        }, ${String(c.valores[col])}, 'edit', ${usuarioId})
+        }, ${valOf(col)}, 'edit', ${usuarioId})
         `);
       }
       // Auditoría de lock si no estaba bloqueado.

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -169,6 +169,16 @@ function colProducto(prefix: string, categoria: string): string | null {
 }
 
 export async function generarSnapshotDiario(fecha: string) {
+  // Si el día está bloqueado (editado a mano), NO se sobreescribe.
+  const lockRes = await db.execute(sql`
+    SELECT bloqueado FROM cartera.facturacion_snapshot_diario
+    WHERE fecha = ${fecha}::date
+  `);
+  const lockRow = ((lockRes as any).rows ?? lockRes)[0];
+  if (lockRow?.bloqueado === true) {
+    return { success: true, skipped: true, reason: "bloqueado", fecha };
+  }
+
   // "YYYY-MM-DD"
   const [y, m, d] = fecha.split("-").map(Number);
   const monthStart = `${y}-${String(m).padStart(2, "0")}-01`;
@@ -721,4 +731,140 @@ export async function getSnapshotsDiarios(opts: {
   }
 
   return { success: true, data: rows, totales };
+}
+
+// ============================================================================
+// ✏️ EDICIÓN MANUAL DE CELDAS (lock por fila + auditoría). Solo ADMIN (gate en router).
+// ============================================================================
+
+type CambioDia = { fecha: string; valores: Record<string, unknown> };
+
+// Guarda (upsert) las celdas tocadas por día, bloquea el día, audita cada cambio
+// y refresca los acumulados de los meses afectados. Solo columnas del whitelist.
+export async function guardarCeldasSnapshot(input: {
+  cambios: CambioDia[];
+  usuarioId: number | null;
+}) {
+  const { cambios, usuarioId } = input;
+  if (!Array.isArray(cambios) || cambios.length === 0) {
+    return { success: false, message: "Sin cambios" };
+  }
+  // Validar todo antes de escribir.
+  for (const c of cambios) {
+    const v = validarValores(c.valores);
+    if (!v.ok) {
+      return {
+        success: false,
+        message: `Columnas inválidas en ${c.fecha}`,
+        invalidas: v.invalidas,
+      };
+    }
+  }
+
+  const mesesAfectados = new Set<string>();
+
+  await db.transaction(async (tx) => {
+    for (const c of cambios) {
+      const [y, m] = c.fecha.split("-");
+      const anio = Number(y);
+      const mes = Number(m);
+      mesesAfectados.add(`${anio}-${mes}`);
+
+      // Fila actual (para valores viejos + saber si ya estaba bloqueado).
+      const prevRes = await tx.execute(sql`
+        SELECT * FROM cartera.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date
+      `);
+      const prev = ((prevRes as any).rows ?? prevRes)[0] ?? null;
+
+      const cols = Object.keys(c.valores);
+      // SET dinámico de las columnas tocadas. sql.raw para el nombre de columna
+      // (YA validado contra el whitelist) y bind del valor.
+      const sets = cols.map(
+        (col) => sql`${sql.raw(col)} = ${String(c.valores[col])}`
+      );
+
+      if (prev) {
+        await tx.execute(sql`
+          UPDATE cartera.facturacion_snapshot_diario
+          SET ${sql.join(sets, sql`, `)},
+              bloqueado = true, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
+          WHERE fecha = ${c.fecha}::date
+        `);
+      } else {
+        const insertCols = [
+          "fecha",
+          "anio",
+          "mes",
+          ...cols,
+          "bloqueado",
+          "bloqueado_por",
+          "bloqueado_at",
+        ];
+        const insertVals = [
+          sql`${c.fecha}::date`,
+          sql`${anio}`,
+          sql`${mes}`,
+          ...cols.map((col) => sql`${String(c.valores[col])}`),
+          sql`true`,
+          sql`${usuarioId}`,
+          sql`now()`,
+        ];
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_diario (${sql.join(
+            insertCols.map((x) => sql.raw(x)),
+            sql`, `
+          )})
+          VALUES (${sql.join(insertVals, sql`, `)})
+        `);
+      }
+
+      // Auditoría por celda.
+      for (const col of cols) {
+        const anterior = prev ? prev[col] ?? null : null;
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          VALUES (${c.fecha}::date, ${col}, ${
+          anterior === null ? null : String(anterior)
+        }, ${String(c.valores[col])}, 'edit', ${usuarioId})
+        `);
+      }
+      // Auditoría de lock si no estaba bloqueado.
+      if (!prev || prev.bloqueado !== true) {
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          VALUES (${c.fecha}::date, '*', NULL, NULL, 'lock', ${usuarioId})
+        `);
+      }
+    }
+  });
+
+  // Refrescar acumulados de cada mes afectado (recomputarAcumuladosMes hace sus updates).
+  for (const k of mesesAfectados) {
+    const [anio, mes] = k.split("-").map(Number);
+    await recomputarAcumuladosMes(anio, mes);
+  }
+
+  return { success: true, dias: cambios.length, meses: mesesAfectados.size };
+}
+
+export async function desbloquearDiaSnapshot(
+  fecha: string,
+  usuarioId: number | null
+) {
+  const [y, m] = fecha.split("-");
+  const anio = Number(y);
+  const mes = Number(m);
+  await db.execute(sql`
+    UPDATE cartera.facturacion_snapshot_diario
+    SET bloqueado = false, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
+    WHERE fecha = ${fecha}::date
+  `);
+  await db.execute(sql`
+    INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+    VALUES (${fecha}::date, '*', NULL, NULL, 'unlock', ${usuarioId})
+  `);
+  // Vuelve a valores del sistema y refresca acumulados.
+  await generarSnapshotDiario(fecha);
+  await recomputarAcumuladosMes(anio, mes);
+  return { success: true, fecha };
 }

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1346,10 +1346,28 @@
 
       created_at: timestamp("created_at").defaultNow().notNull(),
       updated_at: timestamp("updated_at").defaultNow().notNull(),
+
+      bloqueado: boolean("bloqueado").notNull().default(false),
+      bloqueado_por: integer("bloqueado_por"),
+      bloqueado_at: timestamp("bloqueado_at"),
     },
     (table) => ({
       uqFecha: uniqueIndex("uq_facturacion_snapshot_diario_fecha").on(table.fecha),
     })
+  );
+
+  export const facturacion_snapshot_auditoria = customSchema.table(
+    "facturacion_snapshot_auditoria",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(),
+      columna: varchar("columna", { length: 100 }).notNull(),
+      valor_anterior: text("valor_anterior"),
+      valor_nuevo: text("valor_nuevo"),
+      accion: varchar("accion", { length: 20 }).notNull(),
+      usuario_id: integer("usuario_id"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+    }
   );
 
   // ============================================

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -3,9 +3,11 @@ import { authMiddleware } from "./midleware";
 import {
   aplicarManualesEnSnapshotDia,
   aplicarMetaEnSnapshotsMes,
+  desbloquearDiaSnapshot,
   generarExcelFacturacionDiaria,
   generarSnapshotDiario,
   getSnapshotsDiarios,
+  guardarCeldasSnapshot,
   regenerarSnapshotRango,
 } from "../controllers/facturacionSnapshot";
 
@@ -124,6 +126,64 @@ export const facturacionSnapshotRouter = new Elysia({
         fechaFin: t.String(),
       }),
     }
+  )
+
+  // PUT - Guardar celdas editadas a mano (batch). Bloquea los días tocados. Solo ADMIN.
+  .put(
+    "/celdas",
+    async ({ body, user, set }: any) => {
+      if (user?.role !== "ADMIN") {
+        set.status = 403;
+        return { success: false, message: "Solo ADMIN puede editar el reporte" };
+      }
+      try {
+        const result = await guardarCeldasSnapshot({
+          cambios: body.cambios,
+          usuarioId: user?.id ?? null,
+        });
+        if (!result.success) set.status = 400;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Error guardando celdas",
+          error: String(error),
+        };
+      }
+    },
+    {
+      body: t.Object({
+        cambios: t.Array(
+          t.Object({
+            fecha: t.String(),
+            valores: t.Record(t.String(), t.Union([t.String(), t.Number()])),
+          })
+        ),
+      }),
+    }
+  )
+
+  // POST - Desbloquear un día (vuelve a automático). Solo ADMIN.
+  .post(
+    "/desbloquear-dia",
+    async ({ body, user, set }: any) => {
+      if (user?.role !== "ADMIN") {
+        set.status = 403;
+        return { success: false, message: "Solo ADMIN puede desbloquear" };
+      }
+      try {
+        return await desbloquearDiaSnapshot(body.fecha, user?.id ?? null);
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Error desbloqueando el día",
+          error: String(error),
+        };
+      }
+    },
+    { body: t.Object({ fecha: t.String() }) }
   )
 
   // GET - Leer snapshots. ?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD (opcionales).

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -132,7 +132,26 @@ export function FacturacionDiaria() {
   const [desbloquearTarget, setDesbloquearTarget] = useState<string | null>(null);
   // edits: { [fechaISO]: { [columna]: string } }
   const [edits, setEdits] = useState<Record<string, Record<string, string>>>({});
-  const hayCambios = Object.values(edits).some((c) => Object.keys(c).length > 0);
+  // Celdas con cambio real (ignora vacías, que no se envían).
+  const nCambios = Object.values(edits).reduce(
+    (acc, c) => acc + Object.values(c).filter((v) => String(v).trim() !== "").length,
+    0
+  );
+  const nDiasCambiados = Object.values(edits).filter((c) =>
+    Object.values(c).some((v) => String(v).trim() !== "")
+  ).length;
+  const hayCambios = nCambios > 0;
+
+  // Avisar si se intenta cerrar/recargar con cambios sin guardar.
+  useEffect(() => {
+    if (!hayCambios) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [hayCambios]);
   const [fechaInicio, setFechaInicio] = useState(inicioMesISO());
   const [fechaFin, setFechaFin] = useState(hoyISO());
   // rango "aplicado" (lo que de verdad consulta react-query)
@@ -286,14 +305,23 @@ export function FacturacionDiaria() {
                 {modoEdicion ? "Cancelar edición" : "Modo edición"}
               </button>
               {modoEdicion && (
-                <button
-                  disabled={!hayCambios || guardarMut.isPending}
-                  onClick={() => guardarMut.mutate()}
-                  className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-green-600 hover:bg-green-700 text-white font-semibold disabled:opacity-50"
-                >
-                  {guardarMut.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
-                  Guardar cambios
-                </button>
+                <>
+                  {hayCambios && (
+                    <span className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold rounded-full bg-amber-100 text-amber-800 border border-amber-300">
+                      <span className="h-2 w-2 rounded-full bg-amber-500 animate-pulse" />
+                      {nCambios} cambio{nCambios !== 1 ? "s" : ""} sin guardar
+                      {nDiasCambiados > 1 ? ` (${nDiasCambiados} días)` : ""}
+                    </span>
+                  )}
+                  <button
+                    disabled={!hayCambios || guardarMut.isPending}
+                    onClick={() => guardarMut.mutate()}
+                    className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-green-600 hover:bg-green-700 text-white font-semibold disabled:opacity-50"
+                  >
+                    {guardarMut.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                    Guardar cambios{hayCambios ? ` (${nCambios})` : ""}
+                  </button>
+                </>
               )}
             </div>
           )}

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -109,6 +109,20 @@ const GRUPOS: Grupo[] = [
   },
 ];
 
+// Columnas AUTO-calculadas (acumulados/tendencias/% meta): NO editables a mano —
+// se recalculan como suma corrida en el backend. En modo edición se ven de solo
+// lectura para no confundir (lo que escribas ahí lo pisa el recálculo).
+const ACUM_AUTO = new Set<string>([
+  "facturacion_acumulado",
+  "acum_servicios_seguro_gps",
+  "acumulado_total",
+  "acumulado_inversionistas",
+  "tendencia_fin_mes",
+  "tendencia_semanal",
+  "reserva_acumulada",
+  "porcentaje_meta_mensual",
+]);
+
 export function FacturacionDiaria() {
   const qc = useQueryClient();
   const { user } = useAuth();
@@ -160,9 +174,16 @@ export function FacturacionDiaria() {
 
   const guardarMut = useMutation({
     mutationFn: async () => {
+      // Por día, descartar celdas vacías (input limpiado) — el backend rechaza ""
+      // y abortaría todo el batch. Solo se mandan valores con contenido.
       const cambios = Object.entries(edits)
-        .filter(([, v]) => Object.keys(v).length > 0)
-        .map(([fecha, valores]) => ({ fecha, valores }));
+        .map(([fecha, valores]) => {
+          const limpios = Object.fromEntries(
+            Object.entries(valores).filter(([, val]) => String(val).trim() !== "")
+          );
+          return { fecha, valores: limpios };
+        })
+        .filter((c) => Object.keys(c.valores).length > 0);
       return guardarCeldasSnapshot(cambios);
     },
     onSuccess: () => {
@@ -379,7 +400,7 @@ export function FacturacionDiaria() {
                             c.k === g.total.k ? "bg-blue-50/60 font-semibold text-blue-900" : "text-gray-700"
                           }`}
                         >
-                          {modoEdicion && esAdmin ? (
+                          {modoEdicion && esAdmin && !ACUM_AUTO.has(c.k) ? (
                             <input
                               type="number"
                               step="0.01"

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -128,6 +128,8 @@ export function FacturacionDiaria() {
   const { user } = useAuth();
   const esAdmin = user?.role === "ADMIN";
   const [modoEdicion, setModoEdicion] = useState(false);
+  // día pendiente de confirmar desbloqueo (null = modal cerrado)
+  const [desbloquearTarget, setDesbloquearTarget] = useState<string | null>(null);
   // edits: { [fechaISO]: { [columna]: string } }
   const [edits, setEdits] = useState<Record<string, Record<string, string>>>({});
   const hayCambios = Object.values(edits).some((c) => Object.keys(c).length > 0);
@@ -378,14 +380,7 @@ export function FacturacionDiaria() {
                       {row.bloqueado && (
                         <button
                           title="Día manual (bloqueado). Click para desbloquear y volver a automático."
-                          onClick={() => {
-                            if (
-                              window.confirm(
-                                `¿Desbloquear ${row.fecha}? Volverá a calcularse desde el sistema (días históricos previos al 2026-06-10 pueden quedar en 0).`
-                              )
-                            )
-                              desbloquearMut.mutate(row.fecha);
-                          }}
+                          onClick={() => setDesbloquearTarget(row.fecha)}
                           className="ml-2 text-amber-600 hover:text-amber-800"
                         >
                           🔒
@@ -449,6 +444,48 @@ export function FacturacionDiaria() {
         {/* Secciones de registro */}
         <RegistrosManuales mes={Number(fechaFin.slice(5, 7))} anio={Number(fechaFin.slice(0, 4))} />
       </div>
+
+      {/* Modal de confirmación de desbloqueo */}
+      {desbloquearTarget && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-2xl shadow-xl border border-blue-100 w-full max-w-md p-6">
+            <h3 className="text-lg font-bold text-blue-900 mb-2">
+              Desbloquear {desbloquearTarget}
+            </h3>
+            <p className="text-sm text-gray-600 mb-1">
+              El día volverá a calcularse automáticamente desde el sistema y se
+              perderán los valores manuales.
+            </p>
+            <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 mb-5">
+              ⚠️ Si es un día histórico (anterior al 2026-06-10) puede quedar en 0,
+              porque no hay datos del sistema para esa fecha.
+            </p>
+            <div className="flex justify-end gap-3">
+              <button
+                onClick={() => setDesbloquearTarget(null)}
+                disabled={desbloquearMut.isPending}
+                className="px-4 py-2 text-sm rounded-lg bg-gray-100 text-gray-700 font-semibold hover:bg-gray-200 disabled:opacity-50"
+              >
+                Cancelar
+              </button>
+              <button
+                onClick={() =>
+                  desbloquearMut.mutate(desbloquearTarget!, {
+                    onSettled: () => setDesbloquearTarget(null),
+                  })
+                }
+                disabled={desbloquearMut.isPending}
+                className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-amber-600 hover:bg-amber-700 text-white font-semibold disabled:opacity-50"
+              >
+                {desbloquearMut.isPending ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : null}
+                Desbloquear
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -23,12 +23,15 @@ import {
   getIngresosCarros,
   getMetasFacturacion,
   getSnapshotsDiarios,
+  guardarCeldasSnapshot,
+  desbloquearDiaSnapshot,
   upsertMetaFacturacion,
   type GastoAdministrativo,
   type IngresoCarro,
   type MetaFacturacion,
   type SnapshotDiario,
 } from "../services/facturacionDiaria.services";
+import { useAuth } from "@/Provider/authProvider";
 
 // ───────────── helpers ─────────────
 // Fecha en hora Guatemala (no UTC), para no adelantarse de día por la noche.
@@ -108,6 +111,12 @@ const GRUPOS: Grupo[] = [
 
 export function FacturacionDiaria() {
   const qc = useQueryClient();
+  const { user } = useAuth();
+  const esAdmin = user?.role === "ADMIN";
+  const [modoEdicion, setModoEdicion] = useState(false);
+  // edits: { [fechaISO]: { [columna]: string } }
+  const [edits, setEdits] = useState<Record<string, Record<string, string>>>({});
+  const hayCambios = Object.values(edits).some((c) => Object.keys(c).length > 0);
   const [fechaInicio, setFechaInicio] = useState(inicioMesISO());
   const [fechaFin, setFechaFin] = useState(hoyISO());
   // rango "aplicado" (lo que de verdad consulta react-query)
@@ -143,6 +152,35 @@ export function FacturacionDiaria() {
       qc.invalidateQueries({ queryKey: [SNAP_KEY] });
     },
     onError: () => setMsg("❌ Error generando el snapshot"),
+  });
+
+  // ── Edición manual de celdas (solo ADMIN) ──
+  const setCell = (fecha: string, columna: string, valor: string) =>
+    setEdits((e) => ({ ...e, [fecha]: { ...(e[fecha] || {}), [columna]: valor } }));
+
+  const guardarMut = useMutation({
+    mutationFn: async () => {
+      const cambios = Object.entries(edits)
+        .filter(([, v]) => Object.keys(v).length > 0)
+        .map(([fecha, valores]) => ({ fecha, valores }));
+      return guardarCeldasSnapshot(cambios);
+    },
+    onSuccess: () => {
+      setEdits({});
+      setModoEdicion(false);
+      setMsg("✅ Cambios guardados (días bloqueados)");
+      qc.invalidateQueries({ queryKey: [SNAP_KEY] });
+    },
+    onError: () => setMsg("❌ Error guardando los cambios"),
+  });
+
+  const desbloquearMut = useMutation({
+    mutationFn: (fecha: string) => desbloquearDiaSnapshot(fecha),
+    onSuccess: (_d, fecha) => {
+      setMsg(`🔓 ${fecha} desbloqueado (vuelve a automático)`);
+      qc.invalidateQueries({ queryKey: [SNAP_KEY] });
+    },
+    onError: () => setMsg("❌ Error desbloqueando el día"),
   });
 
   const descargarExcel = async () => {
@@ -212,6 +250,30 @@ export function FacturacionDiaria() {
             {descargando ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
             Descargar Excel
           </button>
+
+          {esAdmin && (
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => {
+                  setModoEdicion((m) => !m);
+                  setEdits({});
+                }}
+                className="px-4 py-2 text-sm rounded-lg bg-blue-100 text-blue-800 font-semibold hover:bg-blue-200"
+              >
+                {modoEdicion ? "Cancelar edición" : "Modo edición"}
+              </button>
+              {modoEdicion && (
+                <button
+                  disabled={!hayCambios || guardarMut.isPending}
+                  onClick={() => guardarMut.mutate()}
+                  className="inline-flex items-center gap-2 px-4 py-2 text-sm rounded-lg bg-green-600 hover:bg-green-700 text-white font-semibold disabled:opacity-50"
+                >
+                  {guardarMut.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : null}
+                  Guardar cambios
+                </button>
+              )}
+            </div>
+          )}
 
           <div className="ml-auto flex items-end gap-2">
             <div>
@@ -290,8 +352,24 @@ export function FacturacionDiaria() {
               ) : (
                 snapshots.map((row) => (
                   <tr key={row.id} className="hover:bg-blue-50/50 border-b border-gray-100">
-                    <td className="sticky left-0 z-10 bg-white px-3 py-2 font-semibold text-blue-900 border-r border-gray-200 whitespace-nowrap">
+                    <td className={`sticky left-0 z-10 px-3 py-2 font-semibold text-blue-900 border-r border-gray-200 whitespace-nowrap ${row.bloqueado ? "bg-amber-50" : "bg-white"}`}>
                       {row.fecha}
+                      {row.bloqueado && (
+                        <button
+                          title="Día manual (bloqueado). Click para desbloquear y volver a automático."
+                          onClick={() => {
+                            if (
+                              window.confirm(
+                                `¿Desbloquear ${row.fecha}? Volverá a calcularse desde el sistema (días históricos previos al 2026-06-10 pueden quedar en 0).`
+                              )
+                            )
+                              desbloquearMut.mutate(row.fecha);
+                          }}
+                          className="ml-2 text-amber-600 hover:text-amber-800"
+                        >
+                          🔒
+                        </button>
+                      )}
                     </td>
                     {GRUPOS.flatMap((g) =>
                       colsDe(g).map((c) => (
@@ -301,7 +379,19 @@ export function FacturacionDiaria() {
                             c.k === g.total.k ? "bg-blue-50/60 font-semibold text-blue-900" : "text-gray-700"
                           }`}
                         >
-                          {c.k === "porcentaje_meta_mensual" ? (
+                          {modoEdicion && esAdmin ? (
+                            <input
+                              type="number"
+                              step="0.01"
+                              defaultValue={edits[row.fecha]?.[c.k] ?? (row[c.k] ?? "")}
+                              onChange={(e) => setCell(row.fecha, c.k, e.target.value)}
+                              className={`w-24 text-right border rounded px-1 py-0.5 text-xs [color-scheme:light] ${
+                                edits[row.fecha]?.[c.k] !== undefined
+                                  ? "bg-yellow-50 border-yellow-400"
+                                  : "bg-white border-gray-200"
+                              }`}
+                            />
+                          ) : c.k === "porcentaje_meta_mensual" ? (
                             Number(row[c.k] ?? 0) ? `${nf.format(Number(row[c.k]))}%` : <span className="text-gray-300">—</span>
                           ) : (
                             fmt(row[c.k])

--- a/apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts
@@ -9,6 +9,9 @@ export interface SnapshotDiario {
   anio: number;
   mes: number;
   semana: number;
+  bloqueado?: boolean;
+  bloqueado_por?: number | null;
+  bloqueado_at?: string | null;
   [k: string]: any;
 }
 
@@ -156,5 +159,23 @@ export const upsertMetaFacturacion = async (body: {
   deuda_diaria?: number | string | null;
 }) => {
   const { data } = await api.post(`${API_URL}/api/metas-facturacion`, body);
+  return data;
+};
+
+// ───────────── Edición manual de celdas (lock por fila) ─────────────
+export const guardarCeldasSnapshot = async (
+  cambios: { fecha: string; valores: Record<string, string | number> }[]
+) => {
+  const { data } = await api.put(`${API_URL}/api/facturacion-snapshot/celdas`, {
+    cambios,
+  });
+  return data;
+};
+
+export const desbloquearDiaSnapshot = async (fecha: string) => {
+  const { data } = await api.post(
+    `${API_URL}/api/facturacion-snapshot/desbloquear-dia`,
+    { fecha }
+  );
   return data;
 };

--- a/docs/superpowers/plans/2026-06-16-facturacion-diaria-celdas-editables.md
+++ b/docs/superpowers/plans/2026-06-16-facturacion-diaria-celdas-editables.md
@@ -1,0 +1,855 @@
+# Facturación Diaria — Celdas editables (lock por fila) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permitir editar a mano cualquier celda del reporte Facturación Diaria por día (con botón "Guardar cambios"), bloqueando el día editado para que la regeneración automática lo respete, con auditoría completa y solo para ADMIN.
+
+**Architecture:** Se extiende la tabla `facturacion_snapshot_diario` con un flag `bloqueado`; `generarSnapshotDiario` salta los días bloqueados; un endpoint `PUT /celdas` hace upsert de las celdas tocadas + bloquea + audita, y un helper liviano `recomputarAcumuladosMes` refresca solo los acumulados (sin tocar diarias ni leer la fuente, seguro para días históricos del Excel). El front agrega un "Modo edición" inline visible solo a ADMIN.
+
+**Tech Stack:** Bun, Elysia, Drizzle ORM, Postgres, `big.js`, React 19, TanStack Query, axios (`@/Provider/interceptor`), `bun:test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-16-facturacion-diaria-celdas-editables-design.md`
+
+---
+
+## File Structure
+
+- `apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql` — **crear** (migración idempotente)
+- `apps/cartera-back/src/database/db/schema.ts` — **modificar** (3 columnas + tabla auditoría)
+- `apps/cartera-back/src/controllers/facturacionSnapshot.ts` — **modificar** (helpers puros, lock guard, guardarCeldas, desbloquear, recomputarAcumuladosMes)
+- `apps/cartera-back/src/controllers/facturacionSnapshot.test.ts` — **crear** (tests de funciones puras)
+- `apps/cartera-back/src/routers/facturacionSnapshot.ts` — **modificar** (2 endpoints + gate ADMIN)
+- `apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts` — **modificar** (2 services + interface)
+- `apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx` — **modificar** (modo edición)
+
+---
+
+## Task 1: Migración + schema (lock + auditoría)
+
+**Files:**
+- Create: `apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql`
+- Modify: `apps/cartera-back/src/database/db/schema.ts` (tras `facturacion_snapshot_diario`, ~línea 1353)
+
+- [ ] **Step 1: Escribir la migración SQL**
+
+Crear `apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql`:
+
+```sql
+-- Lock por fila + auditoría para edición manual del snapshot diario.
+ALTER TABLE cartera.facturacion_snapshot_diario
+  ADD COLUMN IF NOT EXISTS bloqueado boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS bloqueado_por integer,
+  ADD COLUMN IF NOT EXISTS bloqueado_at timestamp;
+
+CREATE TABLE IF NOT EXISTS cartera.facturacion_snapshot_auditoria (
+  id serial PRIMARY KEY,
+  fecha date NOT NULL,
+  columna varchar(100) NOT NULL,
+  valor_anterior text,
+  valor_nuevo text,
+  accion varchar(20) NOT NULL,
+  usuario_id integer,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshot_auditoria_fecha
+  ON cartera.facturacion_snapshot_auditoria (fecha);
+CREATE INDEX IF NOT EXISTS idx_snapshot_auditoria_created
+  ON cartera.facturacion_snapshot_auditoria (created_at);
+```
+
+- [ ] **Step 2: Actualizar el schema Drizzle — columnas de lock**
+
+En `schema.ts`, dentro de `facturacion_snapshot_diario`, después de `updated_at` (antes del cierre del objeto de columnas, ~línea 1348):
+
+```ts
+      bloqueado: boolean("bloqueado").notNull().default(false),
+      bloqueado_por: integer("bloqueado_por"),
+      bloqueado_at: timestamp("bloqueado_at"),
+```
+
+Verificar que `boolean` esté importado de `drizzle-orm/pg-core` al inicio del archivo (si no, agregarlo al import existente).
+
+- [ ] **Step 3: Agregar la tabla de auditoría al schema Drizzle**
+
+En `schema.ts`, justo después del cierre de `facturacion_snapshot_diario` (después de la línea 1353):
+
+```ts
+  export const facturacion_snapshot_auditoria = customSchema.table(
+    "facturacion_snapshot_auditoria",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(),
+      columna: varchar("columna", { length: 100 }).notNull(),
+      valor_anterior: text("valor_anterior"),
+      valor_nuevo: text("valor_nuevo"),
+      accion: varchar("accion", { length: 20 }).notNull(),
+      usuario_id: integer("usuario_id"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+    }
+  );
+```
+
+Verificar que `text` y `varchar` estén importados (ya se usan en el archivo).
+
+- [ ] **Step 4: Typecheck del backend**
+
+Run: `cd apps/cartera-back && bun --bun tsc --noEmit 2>&1 | head -20`
+Expected: sin errores nuevos en `schema.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql apps/cartera-back/src/database/db/schema.ts
+git commit -m "feat(cartera): schema lock + auditoría para snapshot editable"
+```
+
+---
+
+## Task 2: Helpers puros — whitelist de columnas y validación
+
+**Files:**
+- Modify: `apps/cartera-back/src/controllers/facturacionSnapshot.ts` (agregar exports cerca del tope, tras los imports)
+- Test: `apps/cartera-back/src/controllers/facturacionSnapshot.test.ts` (crear)
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Crear `apps/cartera-back/src/controllers/facturacionSnapshot.test.ts`:
+
+```ts
+import { describe, expect, it, mock } from "bun:test";
+
+// El controller importa ../database; lo mockeamos para poder importar los helpers puros.
+mock.module("../database", () => ({ db: {} }));
+
+const { esColumnaEditable, validarValores } = await import("./facturacionSnapshot");
+
+describe("esColumnaEditable", () => {
+  it("acepta columnas de valor", () => {
+    expect(esColumnaEditable("capital_total")).toBe(true);
+    expect(esColumnaEditable("facturacion_acumulado")).toBe(true);
+    expect(esColumnaEditable("roy_hipotecario")).toBe(true);
+  });
+  it("rechaza columnas no editables", () => {
+    expect(esColumnaEditable("id")).toBe(false);
+    expect(esColumnaEditable("fecha")).toBe(false);
+    expect(esColumnaEditable("anio")).toBe(false);
+    expect(esColumnaEditable("bloqueado")).toBe(false);
+    expect(esColumnaEditable("columna_inventada")).toBe(false);
+  });
+});
+
+describe("validarValores", () => {
+  it("ok con columnas válidas y números", () => {
+    const r = validarValores({ capital_total: "100.50", facturacion: "0" });
+    expect(r.ok).toBe(true);
+    expect(r.invalidas).toEqual([]);
+  });
+  it("marca columna no editable", () => {
+    const r = validarValores({ fecha: "2026-06-10" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("fecha");
+  });
+  it("marca valor no numérico", () => {
+    const r = validarValores({ capital_total: "abc" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("capital_total");
+  });
+});
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+Run: `cd apps/cartera-back && bun test src/controllers/facturacionSnapshot.test.ts 2>&1 | head -30`
+Expected: FAIL — `esColumnaEditable is not a function` (aún no existe).
+
+- [ ] **Step 3: Implementar los helpers**
+
+En `facturacionSnapshot.ts`, tras los imports (antes de la primera función exportada), agregar:
+
+```ts
+// ── Edición manual: whitelist de columnas editables + validación ──────────────
+export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set([
+  // Capital
+  "cap_autocompras","cap_sobre_vehiculo","nuevo_cap_autocompras","cap_hipotecario","cap_extra_financiamiento","cap_reestructura","capital_total",
+  // Interés
+  "int_autocompras","int_sobre_vehiculo","nuevo_int_autocompras","int_hipotecario","int_extra_financiamiento","int_reestructura","interes_cube",
+  // Membresía
+  "mem_autocompras","mem_sobre_vehiculo","nuevo_mem_autocompras","mem_hipotecario","mem_extra_financiamiento","mem_reestructura","membresia",
+  // Otros ingresos
+  "oi_autocompras","oi_sobre_vehiculo","nuevo_oi_autocompras","oi_hipotecario","oi_extra_financiamiento","oi_reestructura","otros_ingresos","administrativos","otros_cobros",
+  // Mora
+  "mora_autocompras","mora_sobre_vehiculo","nuevo_mora_autocompras","mora_hipotecario","mora_extra_financiamiento","mora_reestructura","mora_cube",
+  // Royalty
+  "roy_autocompras","roy_sobre_vehiculo","nuevo_roy_autocompras","roy_hipotecario","roy_extra_financiamiento","roy_reestructura","royalty",
+  // Totales / acumulados / servicios
+  "facturacion","facturacion_acumulado","servicios_seguro_gps","acum_servicios_seguro_gps","facturacion_mas_servicios","acumulado_total","facturacion_inversionistas","acumulado_inversionistas","tendencia_fin_mes","tendencia_semanal","ingreso_carros","reserva_acumulada","semana",
+  // Metas
+  "meta_facturacion_mensual","meta_facturacion_semanal","meta_facturacion_diaria","porcentaje_meta_mensual","meta_diaria",
+]);
+
+export function esColumnaEditable(col: string): boolean {
+  return COLUMNAS_EDITABLES.has(col);
+}
+
+export function validarValores(valores: Record<string, unknown>): {
+  ok: boolean;
+  invalidas: string[];
+} {
+  const invalidas: string[] = [];
+  for (const [col, val] of Object.entries(valores)) {
+    if (!esColumnaEditable(col)) {
+      invalidas.push(col);
+      continue;
+    }
+    const n = Number(val);
+    if (val === null || val === "" || Number.isNaN(n) || !Number.isFinite(n)) {
+      invalidas.push(col);
+    }
+  }
+  return { ok: invalidas.length === 0, invalidas };
+}
+```
+
+- [ ] **Step 4: Correr el test para verificar que pasa**
+
+Run: `cd apps/cartera-back && bun test src/controllers/facturacionSnapshot.test.ts 2>&1 | head -30`
+Expected: PASS (3 describe, todos verdes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cartera-back/src/controllers/facturacionSnapshot.ts apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+git commit -m "feat(cartera): whitelist + validación de columnas editables del snapshot"
+```
+
+---
+
+## Task 3: Suma corrida pura + `recomputarAcumuladosMes`
+
+**Files:**
+- Modify: `apps/cartera-back/src/controllers/facturacionSnapshot.ts`
+- Test: `apps/cartera-back/src/controllers/facturacionSnapshot.test.ts`
+
+- [ ] **Step 1: Escribir el test que falla**
+
+Agregar a `facturacionSnapshot.test.ts`:
+
+```ts
+const { calcularAcumuladosCorridos } = await import("./facturacionSnapshot");
+
+describe("calcularAcumuladosCorridos", () => {
+  it("suma corrida e ignora bloqueados para escribir, pero incluye sus diarias", () => {
+    const dias = [
+      { fecha: "2026-06-01", bloqueado: false, facturacion: "100", servicios_seguro_gps: "10", facturacion_inversionistas: "5", ingreso_carros: "0" },
+      { fecha: "2026-06-02", bloqueado: true,  facturacion: "200", servicios_seguro_gps: "20", facturacion_inversionistas: "5", ingreso_carros: "0" },
+      { fecha: "2026-06-03", bloqueado: false, facturacion: "300", servicios_seguro_gps: "30", facturacion_inversionistas: "5", ingreso_carros: "1" },
+    ];
+    const r = calcularAcumuladosCorridos(dias);
+    // El día 2 (bloqueado) NO genera update.
+    expect(r.map((u) => u.fecha)).toEqual(["2026-06-01", "2026-06-03"]);
+    // Día 1: fact_acum=100
+    expect(r[0].facturacion_acumulado).toBe("100.00");
+    // Día 3: incluye el día 2 bloqueado → 100+200+300 = 600
+    expect(r[1].facturacion_acumulado).toBe("600.00");
+    expect(r[1].acum_servicios_seguro_gps).toBe("60.00");
+    expect(r[1].acumulado_inversionistas).toBe("15.00");
+    // acumulado_total = fact_acum + serv_acum + carros_acum = 600+60+1 = 661
+    expect(r[1].acumulado_total).toBe("661.00");
+  });
+});
+```
+
+- [ ] **Step 2: Correr el test para verificar que falla**
+
+Run: `cd apps/cartera-back && bun test src/controllers/facturacionSnapshot.test.ts 2>&1 | head -30`
+Expected: FAIL — `calcularAcumuladosCorridos is not a function`.
+
+- [ ] **Step 3: Implementar la función pura**
+
+En `facturacionSnapshot.ts` (cerca de los otros helpers). Asume que `Big` ya está importado (lo usa todo el controller):
+
+```ts
+export type DiaAcumulable = {
+  fecha: string;
+  bloqueado: boolean;
+  facturacion: string | number;
+  servicios_seguro_gps: string | number;
+  facturacion_inversionistas: string | number;
+  ingreso_carros: string | number;
+};
+
+export type UpdateAcumulado = {
+  fecha: string;
+  facturacion_acumulado: string;
+  acum_servicios_seguro_gps: string;
+  acumulado_inversionistas: string;
+  acumulado_total: string;
+};
+
+// Suma corrida sobre días YA ordenados por fecha. Acumula TODAS las diarias
+// (incluidas las de días bloqueados) pero solo emite update para los NO bloqueados.
+// No toca reserva_acumulada (es MTD desde pagos, sin columna diaria).
+export function calcularAcumuladosCorridos(
+  dias: DiaAcumulable[]
+): UpdateAcumulado[] {
+  let accFact = new Big(0);
+  let accServ = new Big(0);
+  let accInv = new Big(0);
+  let accCarros = new Big(0);
+  const updates: UpdateAcumulado[] = [];
+  for (const d of dias) {
+    accFact = accFact.plus(new Big(d.facturacion || 0));
+    accServ = accServ.plus(new Big(d.servicios_seguro_gps || 0));
+    accInv = accInv.plus(new Big(d.facturacion_inversionistas || 0));
+    accCarros = accCarros.plus(new Big(d.ingreso_carros || 0));
+    if (!d.bloqueado) {
+      updates.push({
+        fecha: d.fecha,
+        facturacion_acumulado: accFact.toFixed(2),
+        acum_servicios_seguro_gps: accServ.toFixed(2),
+        acumulado_inversionistas: accInv.toFixed(2),
+        acumulado_total: accFact.plus(accServ).plus(accCarros).toFixed(2),
+      });
+    }
+  }
+  return updates;
+}
+```
+
+- [ ] **Step 4: Correr el test para verificar que pasa**
+
+Run: `cd apps/cartera-back && bun test src/controllers/facturacionSnapshot.test.ts 2>&1 | head -30`
+Expected: PASS.
+
+- [ ] **Step 5: Implementar `recomputarAcumuladosMes` (wrapper con DB)**
+
+En `facturacionSnapshot.ts` agregar (usa `db`, `sql` ya importados):
+
+```ts
+// Refresca SOLO las columnas de acumulado de los días no bloqueados del mes,
+// usando la suma corrida de las diarias guardadas. No lee la fuente ni toca
+// diarias → seguro para días históricos importados del Excel.
+export async function recomputarAcumuladosMes(anio: number, mes: number) {
+  const inicio = `${anio}-${String(mes).padStart(2, "0")}-01`;
+  const res = await db.execute(sql`
+    SELECT fecha::text AS fecha, bloqueado,
+           facturacion, servicios_seguro_gps, facturacion_inversionistas, ingreso_carros
+    FROM cartera.facturacion_snapshot_diario
+    WHERE anio = ${anio} AND mes = ${mes}
+    ORDER BY fecha
+  `);
+  const dias = ((res as any).rows ?? res) as DiaAcumulable[];
+  const updates = calcularAcumuladosCorridos(dias);
+  for (const u of updates) {
+    await db.execute(sql`
+      UPDATE cartera.facturacion_snapshot_diario SET
+        facturacion_acumulado = ${u.facturacion_acumulado},
+        acum_servicios_seguro_gps = ${u.acum_servicios_seguro_gps},
+        acumulado_inversionistas = ${u.acumulado_inversionistas},
+        acumulado_total = ${u.acumulado_total},
+        updated_at = now()
+      WHERE fecha = ${u.fecha}::date
+    `);
+  }
+  return { success: true, dias_actualizados: updates.length };
+}
+```
+
+- [ ] **Step 6: Typecheck + commit**
+
+Run: `cd apps/cartera-back && bun --bun tsc --noEmit 2>&1 | head -20`
+Expected: sin errores nuevos.
+
+```bash
+git add apps/cartera-back/src/controllers/facturacionSnapshot.ts apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+git commit -m "feat(cartera): suma corrida pura + recomputarAcumuladosMes (no pisa histórico)"
+```
+
+---
+
+## Task 4: Lock guard en `generarSnapshotDiario`
+
+**Files:**
+- Modify: `apps/cartera-back/src/controllers/facturacionSnapshot.ts` (inicio de `generarSnapshotDiario`)
+
+- [ ] **Step 1: Leer el inicio de `generarSnapshotDiario`**
+
+Run: `cd apps/cartera-back && grep -n "export async function generarSnapshotDiario" src/controllers/facturacionSnapshot.ts`
+Abrir ~15 líneas tras esa firma para ver dónde se calcula `monthStart`/`fecha`.
+
+- [ ] **Step 2: Insertar el guard al inicio de la función**
+
+Inmediatamente después de la línea de apertura `export async function generarSnapshotDiario(fecha: string) {`, agregar:
+
+```ts
+  // Si el día está bloqueado (editado a mano), NO se sobreescribe.
+  const lockRes = await db.execute(sql`
+    SELECT bloqueado FROM cartera.facturacion_snapshot_diario
+    WHERE fecha = ${fecha}::date
+  `);
+  const lockRow = ((lockRes as any).rows ?? lockRes)[0];
+  if (lockRow?.bloqueado === true) {
+    return { success: true, skipped: true, reason: "bloqueado", fecha };
+  }
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd apps/cartera-back && bun --bun tsc --noEmit 2>&1 | head -20`
+Expected: sin errores nuevos.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/cartera-back/src/controllers/facturacionSnapshot.ts
+git commit -m "feat(cartera): generarSnapshotDiario respeta días bloqueados"
+```
+
+---
+
+## Task 5: Controladores `guardarCeldasSnapshot` y `desbloquearDiaSnapshot`
+
+**Files:**
+- Modify: `apps/cartera-back/src/controllers/facturacionSnapshot.ts`
+
+- [ ] **Step 1: Implementar `guardarCeldasSnapshot`**
+
+Agregar al final de `facturacionSnapshot.ts`:
+
+```ts
+type CambioDia = { fecha: string; valores: Record<string, unknown> };
+
+// Guarda (upsert) las celdas tocadas por día, bloquea el día, audita cada cambio
+// y refresca los acumulados de los meses afectados. Solo columnas del whitelist.
+export async function guardarCeldasSnapshot(input: {
+  cambios: CambioDia[];
+  usuarioId: number | null;
+}) {
+  const { cambios, usuarioId } = input;
+  if (!Array.isArray(cambios) || cambios.length === 0) {
+    return { success: false, message: "Sin cambios" };
+  }
+  // Validar todo antes de escribir.
+  for (const c of cambios) {
+    const v = validarValores(c.valores);
+    if (!v.ok) {
+      return { success: false, message: `Columnas inválidas en ${c.fecha}`, invalidas: v.invalidas };
+    }
+  }
+
+  const mesesAfectados = new Set<string>();
+
+  await db.transaction(async (tx) => {
+    for (const c of cambios) {
+      const [y, m] = c.fecha.split("-");
+      const anio = Number(y);
+      const mes = Number(m);
+      mesesAfectados.add(`${anio}-${mes}`);
+
+      // Fila actual (para valores viejos + saber si ya estaba bloqueado).
+      const prevRes = await tx.execute(sql`
+        SELECT * FROM cartera.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date
+      `);
+      const prev = ((prevRes as any).rows ?? prevRes)[0] ?? null;
+
+      const cols = Object.keys(c.valores);
+      // SET dinámico de las columnas tocadas. Usamos sql.raw para el nombre de
+      // columna (ya validado contra el whitelist) y bind del valor.
+      const sets = cols.map(
+        (col) => sql`${sql.raw(col)} = ${String(c.valores[col])}`
+      );
+
+      if (prev) {
+        await tx.execute(sql`
+          UPDATE cartera.facturacion_snapshot_diario
+          SET ${sql.join(sets, sql`, `)},
+              bloqueado = true, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
+          WHERE fecha = ${c.fecha}::date
+        `);
+      } else {
+        // Insert mínimo: fecha + anio + mes + columnas tocadas + lock.
+        const insertCols = ["fecha", "anio", "mes", ...cols, "bloqueado", "bloqueado_por", "bloqueado_at"];
+        const insertVals = [
+          sql`${c.fecha}::date`, sql`${anio}`, sql`${mes}`,
+          ...cols.map((col) => sql`${String(c.valores[col])}`),
+          sql`true`, sql`${usuarioId}`, sql`now()`,
+        ];
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_diario (${sql.join(insertCols.map((x) => sql.raw(x)), sql`, `)})
+          VALUES (${sql.join(insertVals, sql`, `)})
+        `);
+      }
+
+      // Auditoría por celda.
+      for (const col of cols) {
+        const anterior = prev ? (prev[col] ?? null) : null;
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          VALUES (${c.fecha}::date, ${col}, ${anterior === null ? null : String(anterior)}, ${String(c.valores[col])}, 'edit', ${usuarioId})
+        `);
+      }
+      // Auditoría de lock si no estaba bloqueado.
+      if (!prev || prev.bloqueado !== true) {
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          VALUES (${c.fecha}::date, '*', NULL, NULL, 'lock', ${usuarioId})
+        `);
+      }
+    }
+  });
+
+  // Refrescar acumulados de cada mes afectado (fuera de la transacción de escritura
+  // de celdas; recomputarAcumuladosMes hace sus propios updates).
+  for (const k of mesesAfectados) {
+    const [anio, mes] = k.split("-").map(Number);
+    await recomputarAcumuladosMes(anio, mes);
+  }
+
+  return { success: true, dias: cambios.length, meses: mesesAfectados.size };
+}
+```
+
+- [ ] **Step 2: Implementar `desbloquearDiaSnapshot`**
+
+Agregar a continuación:
+
+```ts
+export async function desbloquearDiaSnapshot(fecha: string, usuarioId: number | null) {
+  const [y, m] = fecha.split("-");
+  const anio = Number(y);
+  const mes = Number(m);
+  await db.execute(sql`
+    UPDATE cartera.facturacion_snapshot_diario
+    SET bloqueado = false, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
+    WHERE fecha = ${fecha}::date
+  `);
+  await db.execute(sql`
+    INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+    VALUES (${fecha}::date, '*', NULL, NULL, 'unlock', ${usuarioId})
+  `);
+  // Vuelve a valores del sistema y refresca acumulados.
+  await generarSnapshotDiario(fecha);
+  await recomputarAcumuladosMes(anio, mes);
+  return { success: true, fecha };
+}
+```
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd apps/cartera-back && bun --bun tsc --noEmit 2>&1 | head -20`
+Expected: sin errores nuevos. (Si `sql.join`/`sql.raw` no existieran en la versión de drizzle, ver nota al pie — pero drizzle-orm los expone.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/cartera-back/src/controllers/facturacionSnapshot.ts
+git commit -m "feat(cartera): guardarCeldas + desbloquearDia (upsert, lock, auditoría)"
+```
+
+---
+
+## Task 6: Endpoints router (PUT /celdas, POST /desbloquear-dia, gate ADMIN)
+
+**Files:**
+- Modify: `apps/cartera-back/src/routers/facturacionSnapshot.ts`
+
+- [ ] **Step 1: Importar los nuevos controladores**
+
+En el `import { ... } from "../controllers/facturacionSnapshot"` agregar:
+`guardarCeldasSnapshot,` y `desbloquearDiaSnapshot,`.
+
+- [ ] **Step 2: Agregar el endpoint `PUT /celdas` (antes del `GET /`)**
+
+```ts
+  // PUT - Guardar celdas editadas a mano (batch). Bloquea los días tocados. Solo ADMIN.
+  .put(
+    "/celdas",
+    async ({ body, user, set }: any) => {
+      if (user?.role !== "ADMIN") {
+        set.status = 403;
+        return { success: false, message: "Solo ADMIN puede editar el reporte" };
+      }
+      try {
+        const result = await guardarCeldasSnapshot({
+          cambios: body.cambios,
+          usuarioId: user?.id ?? null,
+        });
+        if (!result.success) set.status = 400;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error guardando celdas", error: String(error) };
+      }
+    },
+    {
+      body: t.Object({
+        cambios: t.Array(
+          t.Object({
+            fecha: t.String(),
+            valores: t.Record(t.String(), t.Union([t.String(), t.Number()])),
+          })
+        ),
+      }),
+    }
+  )
+
+  // POST - Desbloquear un día (vuelve a automático). Solo ADMIN.
+  .post(
+    "/desbloquear-dia",
+    async ({ body, user, set }: any) => {
+      if (user?.role !== "ADMIN") {
+        set.status = 403;
+        return { success: false, message: "Solo ADMIN puede desbloquear" };
+      }
+      try {
+        return await desbloquearDiaSnapshot(body.fecha, user?.id ?? null);
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error desbloqueando el día", error: String(error) };
+      }
+    },
+    { body: t.Object({ fecha: t.String() }) }
+  )
+```
+
+Nota: `user` viene del `authMiddleware` (`app.derive` → `{ user: decoded }`); el payload JWT trae `role` e `id` (mismo patrón que `payments.ts:1473`).
+
+- [ ] **Step 3: Typecheck**
+
+Run: `cd apps/cartera-back && bun --bun tsc --noEmit 2>&1 | head -20`
+Expected: sin errores nuevos.
+
+- [ ] **Step 4: Smoke test del server (arranca sin romper)**
+
+Run: `cd apps/cartera-back && timeout 12 bun run src/index.ts 2>&1 | head -20`
+Expected: el server levanta (mensaje de arranque), sin error de rutas.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/cartera-back/src/routers/facturacionSnapshot.ts
+git commit -m "feat(cartera): endpoints PUT /celdas y POST /desbloquear-dia (gate ADMIN)"
+```
+
+---
+
+## Task 7: Front — services
+
+**Files:**
+- Modify: `apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts`
+
+- [ ] **Step 1: Agregar `bloqueado` a la interface `SnapshotDiario`**
+
+En la interface `SnapshotDiario` (línea ~6) agregar campos opcionales:
+
+```ts
+  bloqueado?: boolean;
+  bloqueado_por?: number | null;
+  bloqueado_at?: string | null;
+```
+
+- [ ] **Step 2: Agregar los services**
+
+Al final del archivo:
+
+```ts
+export const guardarCeldasSnapshot = async (
+  cambios: { fecha: string; valores: Record<string, string | number> }[]
+) => {
+  const { data } = await api.put(`${API_URL}/api/facturacion-snapshot/celdas`, {
+    cambios,
+  });
+  return data;
+};
+
+export const desbloquearDiaSnapshot = async (fecha: string) => {
+  const { data } = await api.post(
+    `${API_URL}/api/facturacion-snapshot/desbloquear-dia`,
+    { fecha }
+  );
+  return data;
+};
+```
+
+- [ ] **Step 3: Typecheck del front**
+
+Run: `cd apps/carteraFront && bunx tsc --noEmit 2>&1 | head -20`
+Expected: sin errores nuevos en el services.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts
+git commit -m "feat(cartera-front): services guardarCeldas + desbloquearDia"
+```
+
+---
+
+## Task 8: Front — modo edición inline en `FacturacionDiaria.tsx`
+
+**Files:**
+- Modify: `apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx`
+
+- [ ] **Step 1: Imports y rol**
+
+Al inicio del componente `FacturacionDiaria`, agregar imports y leer el rol:
+
+```ts
+// imports (arriba del archivo)
+import { useAuth } from "@/Provider/authProvider";
+import { guardarCeldasSnapshot, desbloquearDiaSnapshot } from "../services/facturacionDiaria.services";
+```
+
+Dentro del componente (junto a `const qc = useQueryClient();`):
+
+```ts
+  const { user } = useAuth();
+  const esAdmin = user?.role === "ADMIN";
+  const [modoEdicion, setModoEdicion] = useState(false);
+  // edits: { [fechaISO]: { [columna]: string } }
+  const [edits, setEdits] = useState<Record<string, Record<string, string>>>({});
+  const hayCambios = Object.values(edits).some((c) => Object.keys(c).length > 0);
+```
+
+- [ ] **Step 2: Helpers de edición + mutaciones**
+
+Dentro del componente:
+
+```ts
+  const setCell = (fecha: string, columna: string, valor: string) =>
+    setEdits((e) => ({ ...e, [fecha]: { ...(e[fecha] || {}), [columna]: valor } }));
+
+  const guardarMut = useMutation({
+    mutationFn: async () => {
+      const cambios = Object.entries(edits)
+        .filter(([, v]) => Object.keys(v).length > 0)
+        .map(([fecha, valores]) => ({ fecha, valores }));
+      return guardarCeldasSnapshot(cambios);
+    },
+    onSuccess: () => {
+      setEdits({});
+      setModoEdicion(false);
+      qc.invalidateQueries({ queryKey: ["facturacion-snapshot"] });
+    },
+  });
+
+  const desbloquearMut = useMutation({
+    mutationFn: (fecha: string) => desbloquearDiaSnapshot(fecha),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["facturacion-snapshot"] }),
+  });
+```
+
+Nota: confirmar el `queryKey` real de la query de snapshots en este archivo (buscar `useQuery({ queryKey:`). Usar exactamente ese key en `invalidateQueries`.
+
+- [ ] **Step 3: Botones de barra (toggle + guardar) — solo ADMIN**
+
+En la barra de acciones (junto al botón de descargar Excel, ~línea 175-220), agregar:
+
+```tsx
+{esAdmin && (
+  <div className="flex items-center gap-2">
+    <button
+      onClick={() => { setModoEdicion((m) => !m); setEdits({}); }}
+      className="px-3 py-2 text-sm rounded bg-blue-100 text-blue-800 font-semibold"
+    >
+      {modoEdicion ? "Cancelar edición" : "Modo edición"}
+    </button>
+    {modoEdicion && (
+      <button
+        disabled={!hayCambios || guardarMut.isPending}
+        onClick={() => guardarMut.mutate()}
+        className="px-3 py-2 text-sm rounded bg-green-600 text-white font-semibold disabled:opacity-50"
+      >
+        {guardarMut.isPending ? "Guardando…" : "Guardar cambios"}
+      </button>
+    )}
+  </div>
+)}
+```
+
+- [ ] **Step 4: Celda editable**
+
+Localizar el render de cada celda de valor (donde se usa `fmt(row[col.k])`, ~líneas 240-300). Reemplazar el contenido de la celda por:
+
+```tsx
+{modoEdicion && esAdmin ? (
+  <input
+    type="number"
+    step="0.01"
+    defaultValue={edits[row.fecha]?.[col.k] ?? row[col.k] ?? ""}
+    onChange={(e) => setCell(row.fecha, col.k, e.target.value)}
+    className={`w-24 text-right border rounded px-1 py-0.5 text-xs ${
+      edits[row.fecha]?.[col.k] !== undefined ? "bg-yellow-50 border-yellow-400" : "border-gray-200"
+    }`}
+  />
+) : (
+  fmt(row[col.k])
+)}
+```
+
+(Aplica el mismo patrón tanto a la celda de `total` como a las de `detalle` de cada grupo.)
+
+- [ ] **Step 5: Indicador de fila bloqueada + desbloquear**
+
+En la celda de `Fecha` de cada fila, agregar junto a la fecha:
+
+```tsx
+{row.bloqueado && (
+  <button
+    title="Día manual (bloqueado). Click para desbloquear y volver a automático."
+    onClick={() => {
+      if (window.confirm(`¿Desbloquear ${row.fecha}? Volverá a calcularse desde el sistema (días históricos previos al 2026-06-10 pueden quedar en 0).`))
+        desbloquearMut.mutate(row.fecha);
+    }}
+    className="ml-2 text-amber-600"
+  >🔒</button>
+)}
+```
+
+- [ ] **Step 6: Typecheck + build del front**
+
+Run: `cd apps/carteraFront && bunx tsc --noEmit 2>&1 | head -30`
+Expected: sin errores nuevos.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+git commit -m "feat(cartera-front): modo edición inline + lock/unlock en Facturación Diaria"
+```
+
+---
+
+## Task 9: Aplicar migración + QA manual (DEV → prod)
+
+**Files:** ninguno (operación).
+
+- [ ] **Step 1: Aplicar la migración 0014 a DEV Neon**
+
+Script bun en `apps/cartera-back/` que conecta a la URL DEV Neon (la del `.env`, `neondb`), verifica que NO es prod (`current_database()='neondb'`), y corre el SQL de `drizzle/0014_snapshot_editable_lock.sql`. Verificar columnas creadas (`\d` equivalente vía information_schema).
+
+- [ ] **Step 2: QA funcional en DEV**
+
+Levantar el back contra DEV. Probar con un token ADMIN: `PUT /api/facturacion-snapshot/celdas` con un día → verificar `bloqueado=true`, fila de auditoría `edit`+`lock`, y que `generarSnapshotDiario` de ese día responde `skipped:true`. Editar día intermedio y verificar que los acumulados de días posteriores no bloqueados se refrescan. Probar `desbloquear-dia` → `unlock` en auditoría + recalculado. Probar token no-ADMIN → 403.
+
+- [ ] **Step 3: Aplicar la migración 0014 a PROD**
+
+Mismo script, apuntando al pooler Supabase 5432 (verificar `count(creditos)>1000` antes). Idempotente.
+
+- [ ] **Step 4: PR contra develop**
+
+```bash
+git push -u origin feat/cartera-snapshot-celdas-editables
+gh pr create --base develop --title "feat(cartera): celdas editables del reporte Facturación Diaria (lock por fila + auditoría)" --body-file <descripción detallada>
+```
+
+Atender comentarios de code review (Codex/reviewers) en el hilo del PR.
+
+---
+
+## Self-Review (del autor del plan)
+
+- **Cobertura del spec:** datos (T1) ✓, lock guard (T4) ✓, PUT/celdas + desbloquear (T5/T6) ✓, recompute liviano sin pisar histórico (T3) ✓, front edición + lock/unlock + gate ADMIN (T7/T8) ✓, auditoría (T5) ✓, permisos ADMIN (T6/T8) ✓, pruebas (T2/T3 unit + T9 manual) ✓, caveat desbloqueo histórico (T8 step 5 confirm) ✓.
+- **Consistencia de tipos:** `calcularAcumuladosCorridos`/`DiaAcumulable`/`UpdateAcumulado` usados igual en T3 y `recomputarAcumuladosMes`. `guardarCeldasSnapshot({cambios, usuarioId})` igual en T5 y T6. `esColumnaEditable`/`validarValores` igual en T2 y T5.
+- **Riesgo a vigilar:** `sql.raw` para nombres de columna — seguro porque las columnas pasan por `validarValores` (whitelist) antes de construir el SQL; nunca viene texto libre del usuario a `sql.raw`.

--- a/docs/superpowers/specs/2026-06-16-facturacion-diaria-celdas-editables-design.md
+++ b/docs/superpowers/specs/2026-06-16-facturacion-diaria-celdas-editables-design.md
@@ -1,0 +1,151 @@
+# Facturación Diaria — Celdas editables tipo Excel (con lock por fila)
+
+**Fecha:** 2026-06-16
+**Estado:** Diseño aprobado (pendiente revisión del spec por el usuario)
+**Módulo:** `apps/cartera-back` (Elysia/Drizzle) + `apps/carteraFront` (React)
+
+## Objetivo
+
+Que el reporte **Facturación Diaria** se comporte como el Excel "Reuniones diarias":
+permitir editar **a mano** los valores por día (cualquier celda, incluidos los
+acumulados), con un botón **"Guardar cambios"** (batch, no autosave). El sistema
+sigue generando los días automáticamente, pero un día editado a mano queda
+**bloqueado** y la regeneración automática lo respeta.
+
+## Decisiones (cerradas con el usuario)
+
+| Tema | Decisión |
+|---|---|
+| Qué se edita | **Todo libre** — cualquier celda numérica, incluidos totales y acumulados. Sin fórmulas forzadas (se aceptan incoherencias total ≠ suma). |
+| Manual vs automático | **Lock por fila** — al guardar, el día queda `bloqueado=true`; `generarSnapshotDiario`, `regenerarSnapshotRango` y el cron #872 lo **saltan**. Desbloquear lo devuelve a automático. |
+| Permisos | **Solo ADMIN** edita/bloquea/desbloquea. Ver: ADMIN y CONTA (sin cambio). |
+| Auditoría | **Bitácora completa** por celda: usuario, timestamp, columna, valor anterior → nuevo, acción. |
+| Enfoque | **A** — extender tabla y endpoints actuales + edición inline en el componente existente. (No grid externo, no overrides celda-por-celda.) |
+
+## Contexto del código actual
+
+- Tabla `cartera.facturacion_snapshot_diario`: 1 fila ancha por día (~68 columnas:
+  hojas rubro×producto, totales diarios, acumulados, tendencias, metas, helpers).
+  Único por `fecha`. Money = `numeric(18,2)`.
+- `controllers/facturacionSnapshot.ts`:
+  - `generarSnapshotDiario(fecha)` recomputa TODO el día desde fuentes (desglose,
+    pagos, gastos_administrativos, ingresos_carros, pci) y hace upsert.
+  - Acumulados = **suma corrida** de las columnas diarias del mes
+    (`SUM(columna WHERE fecha>=monthStart AND fecha<hoy) + valor de hoy`).
+  - `regenerarSnapshotRango(inicio, fin)` regenera en orden (force).
+  - `aplicarManualesEnSnapshotDia`, `aplicarMetaEnSnapshotsMes` = updates quirúrgicos.
+- `routers/facturacionSnapshot.ts`: `POST /generar`, `POST /regenerar-rango`,
+  `POST /aplicar-manuales-dia`, `POST /aplicar-meta-mes`, `GET /excel`, `GET /`.
+  Prefijo `/api/facturacion-snapshot`, `authMiddleware`.
+- Cron #872 (`schedule.ts`, 01:00 GT): regenera force los últimos 3 días.
+- Front: `components/FacturacionDiaria.tsx` + `services/facturacionDiaria.services.ts`.
+  Tabla colapsable por grupos (default solo totales), fila TOTALES, descarga Excel,
+  secciones carros/gastos/metas. Ruta `/facturacion-diaria` (ADMIN, CONTA).
+
+## Diseño
+
+### 1. Modelo de datos — migración `drizzle/0014_snapshot_editable_lock.sql` (idempotente)
+
+`facturacion_snapshot_diario` (+3 columnas):
+- `bloqueado boolean NOT NULL DEFAULT false`
+- `bloqueado_por integer` (id de usuario; sin FK estricta para no acoplar)
+- `bloqueado_at timestamp`
+
+Tabla nueva `cartera.facturacion_snapshot_auditoria`:
+- `id serial PK`
+- `fecha date NOT NULL` — día del snapshot editado
+- `columna varchar(100) NOT NULL`
+- `valor_anterior text` — representación textual (soporta money, %, int)
+- `valor_nuevo text`
+- `accion varchar(20) NOT NULL` — `'edit' | 'lock' | 'unlock'`
+- `usuario_id integer`
+- `created_at timestamp NOT NULL DEFAULT now()`
+- Índices: `(fecha)`, `(created_at)`
+
+Schema Drizzle (`database/db/schema.ts`) actualizado a la par. Aplicar a **DEV
+Neon** primero, luego prod (correr el SQL a mano, drizzle-kit no se usa).
+
+### 2. Backend — respeto del lock
+
+- `generarSnapshotDiario(fecha)`: al inicio, leer la fila; si existe y
+  `bloqueado=true` → **return temprano** `{ success:true, skipped:true,
+  reason:'bloqueado' }` sin sobreescribir nada.
+- `regenerarSnapshotRango` y el **cron #872** heredan el skip (llaman a
+  `generarSnapshotDiario`).
+- Invariante clave: el acumulado de un día auto se calcula con la **suma corrida
+  de las columnas diarias** de los días previos (incluidos los bloqueados con sus
+  valores manuales) → sigue cuadrando sin importar qué esté bloqueado. No requiere
+  cambios extra en el cálculo del acumulado.
+
+### 3. Backend — endpoints nuevos
+
+**`PUT /api/facturacion-snapshot/celdas`** — guardar cambios (batch):
+- Body: `{ cambios: [{ fecha: "YYYY-MM-DD", valores: { <columna>: <valor>, … } }, …] }`.
+  Usuario tomado del auth.
+- Pasos (en transacción):
+  1. **Gate ADMIN** (rechaza con 403 si no).
+  2. Validar columnas contra whitelist `COLUMNAS_EDITABLES` (las ~60 numéricas +
+     `semana`; nunca `id/fecha/anio/mes/created_at/updated_at/bloqueado*`).
+  3. Validar que cada valor sea numérico.
+  4. Por cada día: leer fila actual (valores viejos para auditoría); **upsert** de
+     las celdas tocadas + `bloqueado=true, bloqueado_por, bloqueado_at,
+     updated_at`. Si la fila no existía → insert (bloqueado).
+  5. Escribir **auditoría** por cada celda cambiada (`edit`, viejo→nuevo) + una fila
+     `lock` si el día no estaba bloqueado antes.
+  6. Tras guardar todos los días: `regenerarSnapshotRango(inicioMesAfectado, hoy)`
+     (que salta bloqueados) → refresca los acumulados de los días **no** bloqueados
+     del/los mes(es) afectado(s) para mantener la columna continua.
+- Respuesta: filas actualizadas + resumen (días bloqueados, celdas cambiadas).
+
+**`POST /api/facturacion-snapshot/desbloquear-dia`** — `{ fecha }`:
+- Gate ADMIN. `bloqueado=false`; auditoría `accion='unlock'`; `generarSnapshotDiario(fecha)`
+  (vuelve a valores del sistema); `regenerarSnapshotRango(inicioMes, hoy)` para
+  refrescar acumulados.
+
+`GET /` (existente) devuelve además `bloqueado`/`bloqueado_por`/`bloqueado_at` por fila.
+
+### 4. Front — edición inline (`FacturacionDiaria.tsx` + services)
+
+- Toggle **"Modo edición"** visible **solo si el usuario es ADMIN** (rol del auth context).
+- En modo edición: cada celda numérica → `<input>` controlado; estado de celdas
+  **sucias** (resaltadas); validación numérica en blur; funciona en vista colapsada
+  (totales) y expandida (hojas por producto).
+- Columna 🔒/🔓 por fila: indica si el día es manual. Click en 🔓 sobre un día
+  bloqueado → confirma y llama `desbloquear-dia`.
+- Botón **"Guardar cambios"** (deshabilitado sin cambios) → arma `PUT /celdas`
+  agrupando celdas sucias por día → al éxito invalida React Query, refetch, toast.
+- Filas bloqueadas con tinte/badge "manual".
+- Service nuevo: `guardarCeldas(cambios)`, `desbloquearDia(fecha)`.
+
+### 5. Casos borde / consistencia
+
+- Día sin fila → insert (bloqueado). No-ADMIN → 403. Columna fuera de whitelist /
+  valor no numérico → 400, no se aplica.
+- Placeholders futuros (del import Excel): editarlos los bloquea → el cron ya no
+  los toca.
+- **Incoherencia aceptada (por "todo libre")**: si se edita a mano el *acumulado*
+  de un día bloqueado, los días automáticos posteriores calculan su acumulado por
+  suma corrida de las **diarias** (no encadenan el acumulado manual). Documentado;
+  es el costo de permitir editar todo.
+- Concurrencia: last-write-wins; la auditoría deja rastro de ambos cambios.
+
+### 6. Pruebas
+
+- Backend: skip de bloqueados en `generar`/`regenerar`/cron; `PUT /celdas`
+  (upsert + auditoría + cascada de acumulados); gate ADMIN; whitelist de columnas;
+  `desbloquear-dia` regenera desde el sistema.
+- QA manual contra **DEV Neon** (clon de cartera, correos suprimidos) antes de prod.
+- Migración: DEV → prod (verificar a qué BD se pega antes de escribir).
+
+### 7. Entrega
+
+- Branch `feat/cartera-snapshot-celdas-editables` (vs `develop`).
+- Implementación back + front + migración siguiendo el plan (writing-plans).
+- Posible ejecución por agente en background sobre worktree; PR contra `develop`
+  con descripción detallada y atención a comentarios de code review.
+
+## Fuera de alcance (YAGNI)
+
+- Grid tipo Excel con navegación por flechas / copy-paste (enfoque C) — futura iteración.
+- Overrides celda-por-celda con recálculo parcial (enfoque B) — descartado por lock-por-fila.
+- Editar columnas helper (`anio/mes`) o `fecha`.

--- a/docs/superpowers/specs/2026-06-16-facturacion-diaria-celdas-editables-design.md
+++ b/docs/superpowers/specs/2026-06-16-facturacion-diaria-celdas-editables-design.md
@@ -76,6 +76,17 @@ Neon** primero, luego prod (correr el SQL a mano, drizzle-kit no se usa).
   de las columnas diarias** de los días previos (incluidos los bloqueados con sus
   valores manuales) → sigue cuadrando sin importar qué esté bloqueado. No requiere
   cambios extra en el cálculo del acumulado.
+- **Helper nuevo `recomputarAcumuladosMes(anio, mes)`** (para el refresco post-edición):
+  recorre los días del mes EN ORDEN y actualiza **solo las columnas de acumulado que
+  derivan de una columna diaria** (`facturacion_acumulado`, `acum_servicios_seguro_gps`,
+  `acumulado_inversionistas`, `acumulado_total`) como suma corrida de las diarias ya
+  guardadas. **No** toca `reserva_acumulada` (es MTD desde `pagos`, sin columna diaria;
+  solo `generarSnapshotDiario` la recalcula). **Nunca lee de la fuente ni toca las
+  columnas diarias** → seguro
+  para días históricos importados del Excel (no los pone en 0). **Salta** los días
+  bloqueados (no pisa su acumulado manual), pero **sí** incluye sus diarias en la
+  suma corrida de los días siguientes. Este helper, NO `regenerarSnapshotRango`, es
+  el que se usa tras guardar/desbloquear.
 
 ### 3. Backend — endpoints nuevos
 
@@ -92,15 +103,19 @@ Neon** primero, luego prod (correr el SQL a mano, drizzle-kit no se usa).
      updated_at`. Si la fila no existía → insert (bloqueado).
   5. Escribir **auditoría** por cada celda cambiada (`edit`, viejo→nuevo) + una fila
      `lock` si el día no estaba bloqueado antes.
-  6. Tras guardar todos los días: `regenerarSnapshotRango(inicioMesAfectado, hoy)`
-     (que salta bloqueados) → refresca los acumulados de los días **no** bloqueados
-     del/los mes(es) afectado(s) para mantener la columna continua.
+  6. Tras guardar: por cada **mes afectado** (un batch puede tocar varios),
+     `recomputarAcumuladosMes(anio, mes)` → refresca SOLO los acumulados de los días
+     no bloqueados del mes, sin tocar diarias ni leer fuente (seguro para histórico).
 - Respuesta: filas actualizadas + resumen (días bloqueados, celdas cambiadas).
 
 **`POST /api/facturacion-snapshot/desbloquear-dia`** — `{ fecha }`:
 - Gate ADMIN. `bloqueado=false`; auditoría `accion='unlock'`; `generarSnapshotDiario(fecha)`
-  (vuelve a valores del sistema); `regenerarSnapshotRango(inicioMes, hoy)` para
-  refrescar acumulados.
+  (vuelve a valores del sistema); `recomputarAcumuladosMes(anio, mes)` para refrescar
+  acumulados.
+- ⚠️ Caveat histórico: desbloquear un día **histórico importado del Excel** (sin
+  desglose en BD) lo recalcula a ~0, porque "automático" para esos días no tiene
+  fuente. El front debe **confirmar/advertir** antes de desbloquear días previos a la
+  ventana operativa del sistema (corte 06-10-2026).
 
 `GET /` (existente) devuelve además `bloqueado`/`bloqueado_por`/`bloqueado_at` por fila.
 
@@ -128,6 +143,11 @@ Neon** primero, luego prod (correr el SQL a mano, drizzle-kit no se usa).
   suma corrida de las **diarias** (no encadenan el acumulado manual). Documentado;
   es el costo de permitir editar todo.
 - Concurrencia: last-write-wins; la auditoría deja rastro de ambos cambios.
+- **Histórico vs sistema**: editar+bloquear preserva cualquier día (incluido el
+  histórico del Excel). Pero **desbloquear** un día histórico (< corte 06-10-2026)
+  lo manda a "automático" = ~0 (no hay fuente). El front advierte antes de
+  desbloquear esos días. El refresco de acumulados (`recomputarAcumuladosMes`) NUNCA
+  toca diarias, así que nunca borra un día del Excel por sí solo.
 
 ### 6. Pruebas
 


### PR DESCRIPTION
## Qué hace

Hace que el reporte **Facturación Diaria** se pueda editar a mano tipo Excel, con botón **"Guardar cambios"**, **solo para ADMIN**. Un día editado queda **bloqueado** y la regeneración automática (cron / `generarSnapshotDiario`) lo respeta. Los **acumulados siempre suman** (no se editan a mano; se recalculan como suma corrida).

## Decisiones de diseño

- **Lock por fila**: al guardar, el día queda `bloqueado=true` → el cron y la regeneración lo saltan. Desbloquear lo devuelve a automático (🔒/🔓 en la fila, con confirm que advierte sobre días históricos < 2026-06-10).
- **Valores DIARIOS** (rubros×producto, totales, servicios, carros, metas): editables libremente.
- **Acumulados / tendencias / % meta**: **auto-calculados** (suma corrida), read-only — así *siempre suman* sin discontinuidad. (Esto ajusta la idea inicial de "todo libre incl. acumulados": los acumulados se priorizó que cuadren.)
- **Auditoría completa**: tabla `facturacion_snapshot_auditoria` con usuario, fecha, columna, valor anterior→nuevo y acción (`edit`/`lock`/`unlock`).
- **Permisos**: solo ADMIN edita/bloquea/desbloquea (gate en el router).

## Cambios

**Back** (`apps/cartera-back`):
- Migración `drizzle/0014_snapshot_editable_lock.sql` (idempotente; **ya aplicada a PROD**: 3 columnas de lock + tabla auditoría, 0 días bloqueados).
- `facturacionSnapshot.ts`: whitelist `COLUMNAS_EDITABLES` + `validarValores` (numérico estricto), `calcularAcumuladosCorridos` (pura) + `recomputarAcumuladosMes` (solo acumulados, suma corrida, filtra por rango de fecha), lock guard en `generarSnapshotDiario` + `aplicarManualesEnSnapshotDia` + `aplicarMetaEnSnapshotsMes`, `guardarCeldasSnapshot` + `desbloquearDiaSnapshot`, `NO_SUMAR` incluye columnas de lock.
- Endpoints `PUT /api/facturacion-snapshot/celdas` y `POST /api/facturacion-snapshot/desbloquear-dia` (gate ADMIN).
- Tests `bun test` (helpers puros + suma corrida + validación).

**Front** (`apps/carteraFront`): modo edición inline en `FacturacionDiaria.tsx` (toggle ADMIN, celdas editables con dirty highlight, Guardar, 🔒/🔓, acumulados read-only, no envía celdas vacías) + services.

## Pruebas

- `bun test` backend: 8/8.
- **QA contra clon de PROD local** (dump→restore→migración): editar+bloquear, cascada de acumulados, lock respetado por generar/aplicarManuales, desbloqueo, validación. **Invariante verificado: `acumulado == suma corrida de las diarias` en los 30 días del mes, incluso tras editar+bloquear un día intermedio.**
- typecheck back (sin errores nuevos) y front (0 errores).

## Notas

- Rebasada sobre `develop` (incluye #888 suma corrida) → `generarSnapshotDiario` (sección 6) y `recomputarAcumuladosMes` usan el mismo algoritmo de suma corrida, sin divergencia.
- Migración 0014 ya está en prod, así que el código se puede desplegar sin el error "columna no existe".

Spec y plan: `docs/superpowers/specs/2026-06-16-...` y `docs/superpowers/plans/2026-06-16-...`.
