### PR TITLE
feat(cartera): módulo Mora Histórica (reconstrucción as-of desde moras_historial)

### DIFF
--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -1,0 +1,211 @@
+import { db } from "../database";
+import { sql } from "drizzle-orm";
+import ExcelJS from "exceljs";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Módulo Mora Histórica: reconstruye la mora a cualquier fecha desde
+// `moras_historial` (independiente del cron / de la tabla moras_credito actual,
+// que puede estar condonada). Ver controllers/latefee.ts (procesarMoras).
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Etapa de mora a partir de cuotas atrasadas (igual criterio que el reporte Pagos x Venc).
+const ETAPA_SQL = sql`CASE
+  WHEN s.cuotas = 1 THEN 'Mora 30'
+  WHEN s.cuotas = 2 THEN 'Mora 60'
+  WHEN s.cuotas = 3 THEN 'Mora 90'
+  WHEN s.cuotas >= 4 THEN 'Mora 120+'
+  ELSE 'Al día' END`;
+
+// CTE: último evento de mora por crédito con fecha <= `fecha` (estado "as-of").
+const snapCte = (fecha: string) => sql`
+  snap AS (
+    SELECT DISTINCT ON (h.credito_id)
+      h.credito_id,
+      h.tipo_evento,
+      h.monto_nuevo::numeric        AS monto,
+      h.cuotas_atrasadas_nuevas     AS cuotas,
+      h.fecha
+    FROM cartera.moras_historial h
+    WHERE h.fecha < (${fecha}::date + INTERVAL '1 day')
+    ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+  )`;
+
+type SnapshotArgs = {
+  fecha: string; // YYYY-MM-DD (corte "al" día)
+  asesor?: string; // CSV de nombres
+  etapa?: string; // '0-30' | '31-60' | '61-90' | '+90'
+  numero_credito_sifco?: string;
+  nombre_usuario?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+function buildSnapshotWhere(a: SnapshotArgs) {
+  // Solo créditos con mora viva a la fecha (último evento no es desactivación y monto > 0).
+  const filters: any[] = [sql`s.tipo_evento <> 'DESACTIVACION'`, sql`s.monto > 0`];
+  if (a.etapa === "0-30") filters.push(sql`s.cuotas = 1`);
+  else if (a.etapa === "31-60") filters.push(sql`s.cuotas = 2`);
+  else if (a.etapa === "61-90") filters.push(sql`s.cuotas = 3`);
+  else if (a.etapa === "+90") filters.push(sql`s.cuotas >= 4`);
+  if (a.numero_credito_sifco) filters.push(sql`c.numero_credito_sifco ILIKE ${"%" + a.numero_credito_sifco + "%"}`);
+  if (a.nombre_usuario) filters.push(sql`u.nombre ILIKE ${"%" + a.nombre_usuario + "%"}`);
+  if (a.asesor) {
+    const names = a.asesor.split(",").map((n) => n.trim()).filter(Boolean);
+    if (names.length) filters.push(sql`(${sql.join(names.map((n) => sql`a.nombre ILIKE ${"%" + n + "%"}`), sql` OR `)})`);
+  }
+  return sql.join(filters, sql` AND `);
+}
+
+const snapFromJoins = sql`
+  FROM snap s
+  INNER JOIN cartera.creditos c ON c.credito_id = s.credito_id
+  INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+  INNER JOIN cartera.asesores a ON a.asesor_id = c.asesor_id`;
+
+// Snapshot por crédito de la mora a una fecha, con totales y filtros.
+export async function getMoraHistorialSnapshot(a: SnapshotArgs) {
+  const fecha = a.fecha;
+  // Clamp defensivo: evita OFFSET negativo / NaN si llega page/pageSize inválido.
+  const page = Number.isFinite(a.page) && (a.page as number) > 0 ? Math.floor(a.page as number) : 1;
+  const pageSize = Number.isFinite(a.pageSize) && (a.pageSize as number) > 0 ? Math.min(Math.floor(a.pageSize as number), 500) : 20;
+  const offset = (page - 1) * pageSize;
+  const where = buildSnapshotWhere(a);
+
+  const [totRes, dataRes] = await Promise.all([
+    db.execute<any>(sql`
+      WITH ${snapCte(fecha)}
+      SELECT
+        COUNT(*)::int AS total,
+        COALESCE(SUM(s.monto), 0) AS mora_total,
+        COALESCE(SUM(CASE WHEN s.cuotas = 1 THEN s.monto ELSE 0 END), 0) AS mora_30,
+        COALESCE(SUM(CASE WHEN s.cuotas = 2 THEN s.monto ELSE 0 END), 0) AS mora_60,
+        COALESCE(SUM(CASE WHEN s.cuotas = 3 THEN s.monto ELSE 0 END), 0) AS mora_90,
+        COALESCE(SUM(CASE WHEN s.cuotas >= 4 THEN s.monto ELSE 0 END), 0) AS mora_120
+      ${snapFromJoins}
+      WHERE ${where}
+    `),
+    db.execute<any>(sql`
+      WITH ${snapCte(fecha)}
+      SELECT
+        c.credito_id,
+        c.numero_credito_sifco,
+        u.nombre AS cliente,
+        a.nombre AS asesor,
+        c."statusCredit" AS status,
+        s.cuotas AS cuotas_atrasadas,
+        ${ETAPA_SQL} AS etapa,
+        ROUND(s.monto, 2) AS mora,
+        ROUND(c.capital::numeric, 2) AS capital,
+        s.fecha AS actualizado
+      ${snapFromJoins}
+      WHERE ${where}
+      ORDER BY s.monto DESC
+      LIMIT ${pageSize} OFFSET ${offset}
+    `),
+  ]);
+
+  const tot = totRes.rows[0] ?? {};
+  const total = Number(tot.total ?? 0);
+  return {
+    success: true,
+    fecha,
+    data: dataRes.rows,
+    pagination: { page, pageSize, total, totalPages: Math.ceil(total / pageSize) },
+    totales: {
+      mora_total: Number(tot.mora_total ?? 0).toFixed(2),
+      mora_30: Number(tot.mora_30 ?? 0).toFixed(2),
+      mora_60: Number(tot.mora_60 ?? 0).toFixed(2),
+      mora_90: Number(tot.mora_90 ?? 0).toFixed(2),
+      mora_120: Number(tot.mora_120 ?? 0).toFixed(2),
+      creditos: total,
+    },
+  };
+}
+
+// Timeline: total de mora reconstruido as-of para cada día del rango (evolución).
+export async function getMoraTimeline({ desde, hasta, asesor }: { desde: string; hasta: string; asesor?: string }) {
+  // Filtro de asesor: limita a créditos del/los asesor(es).
+  let asesorFilter = sql``;
+  if (asesor) {
+    const names = asesor.split(",").map((n) => n.trim()).filter(Boolean);
+    if (names.length) {
+      asesorFilter = sql` AND h.credito_id IN (
+        SELECT c.credito_id FROM cartera.creditos c
+        INNER JOIN cartera.asesores a ON a.asesor_id = c.asesor_id
+        WHERE (${sql.join(names.map((n) => sql`a.nombre ILIKE ${"%" + n + "%"}`), sql` OR `)})
+      )`;
+    }
+  }
+  const res = await db.execute<any>(sql`
+    SELECT d::date AS fecha, (
+      SELECT COALESCE(SUM(s.monto), 0)
+      FROM (
+        SELECT DISTINCT ON (h.credito_id) h.monto_nuevo::numeric AS monto, h.tipo_evento
+        FROM cartera.moras_historial h
+        WHERE h.fecha < (d + INTERVAL '1 day') ${asesorFilter}
+        ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+      ) s
+      WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0
+    ) AS mora_total
+    FROM generate_series(${desde}::date, ${hasta}::date, INTERVAL '1 day') d
+    ORDER BY d
+  `);
+  return {
+    success: true,
+    data: res.rows.map((r) => ({ fecha: r.fecha, mora_total: Number(r.mora_total).toFixed(2) })),
+  };
+}
+
+// Historial de eventos de mora de un crédito (drill-down).
+export async function getMoraHistorialCredito({ credito_id }: { credito_id: number }) {
+  const res = await db.execute<any>(sql`
+    SELECT
+      h.historial_id,
+      h.fecha,
+      h.tipo_evento,
+      h.origen,
+      ROUND(h.monto_anterior::numeric, 2) AS monto_anterior,
+      ROUND(h.monto_nuevo::numeric, 2) AS monto_nuevo,
+      h.cuotas_atrasadas_anterior,
+      h.cuotas_atrasadas_nuevas,
+      h.motivo,
+      pu.email AS usuario
+    FROM cartera.moras_historial h
+    LEFT JOIN cartera.platform_users pu ON pu.id = h.usuario_id
+    WHERE h.credito_id = ${credito_id}
+    ORDER BY h.fecha DESC, h.historial_id DESC
+  `);
+  return { success: true, data: res.rows };
+}
+
+// Excel del snapshot (todas las filas, sin paginar).
+export async function getMoraHistorialExcel(a: SnapshotArgs): Promise<Buffer> {
+  const where = buildSnapshotWhere(a);
+  const res = await db.execute<any>(sql`
+    WITH ${snapCte(a.fecha)}
+    SELECT c.numero_credito_sifco, u.nombre AS cliente, a.nombre AS asesor, c."statusCredit" AS status,
+      s.cuotas AS cuotas_atrasadas, ${ETAPA_SQL} AS etapa, ROUND(s.monto, 2) AS mora, ROUND(c.capital::numeric, 2) AS capital
+    ${snapFromJoins}
+    WHERE ${where}
+    ORDER BY s.monto DESC
+  `);
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet(`Mora al ${a.fecha}`);
+  ws.columns = [
+    { header: "No. SIFCO", key: "numero_credito_sifco", width: 18 },
+    { header: "Cliente", key: "cliente", width: 32 },
+    { header: "Asesor", key: "asesor", width: 24 },
+    { header: "Status", key: "status", width: 16 },
+    { header: "Cuotas atrasadas", key: "cuotas_atrasadas", width: 16 },
+    { header: "Etapa", key: "etapa", width: 12 },
+    { header: "Capital", key: "capital", width: 16 },
+    { header: "Mora", key: "mora", width: 16 },
+  ];
+  ws.getRow(1).font = { bold: true };
+  let totalMora = 0;
+  for (const r of res.rows) { ws.addRow(r); totalMora += Number(r.mora); }
+  const totalRow = ws.addRow({ asesor: "TOTAL", mora: Number(totalMora.toFixed(2)) });
+  totalRow.font = { bold: true };
+  const buf = await wb.xlsx.writeBuffer();
+  return Buffer.from(buf);
+}

--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -16,21 +16,32 @@ const ETAPA_SQL = sql`CASE
   WHEN s.cuotas >= 4 THEN 'Mora 120+'
   ELSE 'Al día' END`;
 
-// CTE: último evento de mora por crédito con fecha <= `fecha` (estado "as-of").
+// CTE: estado de mora por crédito "as-of" `fecha`.
+// monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
 const snapCte = (fecha: string) => sql`
-  snap AS (
-    SELECT DISTINCT ON (h.credito_id)
+  snap_raw AS (
+    SELECT
       h.credito_id,
       h.tipo_evento,
-      h.monto_nuevo::numeric        AS monto,
-      h.cuotas_atrasadas_nuevas     AS cuotas,
-      h.fecha
+      h.monto_nuevo::numeric AS monto,
+      h.fecha,
+      ROW_NUMBER() OVER (PARTITION BY h.credito_id ORDER BY h.fecha DESC, h.historial_id DESC) AS rn,
+      -- cuotas "vivas": cuotas del evento más reciente con cuotas>0. Los eventos payment-only
+      -- (updateMora sin cuotas, p.ej. reversa de pago en reversePayment.ts) registran
+      -- cuotas_atrasadas_nuevas=0; sin carry-forward un crédito con mora>0 cuyo último evento
+      -- sea payment-only caería a "Al día" y se saldría de los buckets 30/60/90/120 (review Codex).
+      FIRST_VALUE(h.cuotas_atrasadas_nuevas) OVER (
+        PARTITION BY h.credito_id
+        ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
+      ) AS cuotas
     FROM cartera.moras_historial h
     -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
     -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
     -- eventos al día siguiente.
     WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
-    ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+  ),
+  snap AS (
+    SELECT credito_id, tipo_evento, monto, cuotas, fecha FROM snap_raw WHERE rn = 1
   )`;
 
 type SnapshotArgs = {

--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -26,7 +26,10 @@ const snapCte = (fecha: string) => sql`
       h.cuotas_atrasadas_nuevas     AS cuotas,
       h.fecha
     FROM cartera.moras_historial h
-    WHERE h.fecha < (${fecha}::date + INTERVAL '1 day')
+    -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
+    -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
+    -- eventos al día siguiente.
+    WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= ${fecha}::date
     ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
   )`;
 
@@ -142,7 +145,7 @@ export async function getMoraTimeline({ desde, hasta, asesor }: { desde: string;
       FROM (
         SELECT DISTINCT ON (h.credito_id) h.monto_nuevo::numeric AS monto, h.tipo_evento
         FROM cartera.moras_historial h
-        WHERE h.fecha < (d + INTERVAL '1 day') ${asesorFilter}
+        WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= d ${asesorFilter}
         ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
       ) s
       WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0

--- a/apps/cartera-back/src/routers/latefee.ts
+++ b/apps/cartera-back/src/routers/latefee.ts
@@ -4,6 +4,13 @@ import { Elysia, t } from "elysia";
  
 import { authMiddleware } from "./midleware";
 import { createMora, updateMora, procesarMoras, condonarMora, getCreditosWithMoras, getCondonacionesMora, condonarTodasLasMoras } from "../controllers/latefee";
+import { getMoraHistorialSnapshot, getMoraTimeline, getMoraHistorialCredito, getMoraHistorialExcel } from "../controllers/moraHistorial";
+
+// Fecha de hoy en zona Guatemala (YYYY-MM-DD), para el corte por defecto del historial.
+const hoyGT = () => {
+  const d = new Date(new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" }));
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+};
 
 export const morasRouter = new Elysia()
   .use(authMiddleware)
@@ -205,4 +212,85 @@ export const morasRouter = new Elysia()
         description: "Procesa todas las cuotas vencidas y genera/actualiza los registros de mora para los créditos correspondientes"
       }
     }
-  );
+  )
+
+  // ───────────── Mora Histórica (reconstruida desde moras_historial) ─────────────
+  // Snapshot de la mora por crédito a una fecha de corte (con totales + filtros).
+  .get("/moras/historial", async ({ query, set }: any) => {
+    try {
+      return await getMoraHistorialSnapshot({
+        fecha: query.fecha || hoyGT(),
+        asesor: query.asesor,
+        etapa: query.etapa,
+        numero_credito_sifco: query.numero_credito_sifco,
+        nombre_usuario: query.nombre_usuario,
+        page: query.page ? Number(query.page) : 1,
+        pageSize: query.pageSize ? Number(query.pageSize) : 20,
+      });
+    } catch (err) {
+      set.status = 500;
+      return { success: false, message: "[ERROR] No se pudo obtener el historial de mora", error: String(err) };
+    }
+  }, {
+    query: t.Object({
+      fecha: t.Optional(t.String()),
+      asesor: t.Optional(t.String()),
+      etapa: t.Optional(t.String()),
+      numero_credito_sifco: t.Optional(t.String()),
+      nombre_usuario: t.Optional(t.String()),
+      page: t.Optional(t.String()),
+      pageSize: t.Optional(t.String()),
+    }),
+  })
+
+  // Evolución (timeline) del total de mora día a día en un rango.
+  .get("/moras/historial/timeline", async ({ query, set }: any) => {
+    try {
+      return await getMoraTimeline({ desde: query.desde, hasta: query.hasta || hoyGT(), asesor: query.asesor });
+    } catch (err) {
+      set.status = 500;
+      return { success: false, message: "[ERROR] No se pudo obtener el timeline de mora", error: String(err) };
+    }
+  }, {
+    query: t.Object({ desde: t.String(), hasta: t.Optional(t.String()), asesor: t.Optional(t.String()) }),
+  })
+
+  // Excel del snapshot a la fecha de corte.
+  .get("/moras/historial/excel", async ({ query, set }: any) => {
+    try {
+      const fecha = query.fecha || hoyGT();
+      const buf = await getMoraHistorialExcel({
+        fecha, asesor: query.asesor, etapa: query.etapa,
+        numero_credito_sifco: query.numero_credito_sifco, nombre_usuario: query.nombre_usuario,
+      });
+      return new Response(new Uint8Array(buf), {
+        headers: {
+          "content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "content-disposition": `attachment; filename="mora-${fecha}.xlsx"`,
+        },
+      });
+    } catch (err) {
+      set.status = 500;
+      return { success: false, message: "[ERROR] No se pudo generar el Excel de mora", error: String(err) };
+    }
+  }, {
+    query: t.Object({
+      fecha: t.Optional(t.String()), asesor: t.Optional(t.String()), etapa: t.Optional(t.String()),
+      numero_credito_sifco: t.Optional(t.String()), nombre_usuario: t.Optional(t.String()),
+    }),
+  })
+
+  // Historial completo de eventos de mora de un crédito (drill-down).
+  .get("/moras/historial/credito/:credito_id", async ({ params, set }: any) => {
+    try {
+      const creditoId = Number(params.credito_id);
+      if (!Number.isInteger(creditoId) || creditoId <= 0) {
+        set.status = 400;
+        return { success: false, message: "[ERROR] credito_id inválido" };
+      }
+      return await getMoraHistorialCredito({ credito_id: creditoId });
+    } catch (err) {
+      set.status = 500;
+      return { success: false, message: "[ERROR] No se pudo obtener el historial del crédito", error: String(err) };
+    }
+  });

--- a/apps/cartera-back/src/routers/latefee.ts
+++ b/apps/cartera-back/src/routers/latefee.ts
@@ -12,6 +12,17 @@ const hoyGT = () => {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 };
 
+// Gate de rol server-side para el historial de mora (expone data de TODOS los clientes).
+// authMiddleware solo autentica; aquí exigimos ADMIN/CONTA (igual que el front).
+const requireMoraHistorialRole = (user: any, set: any): boolean => {
+  if (!user || !["ADMIN", "CONTA"].includes(user.role)) {
+    set.status = 403;
+    return false;
+  }
+  return true;
+};
+const NO_AUTORIZADO = { success: false, message: "[ERROR] No autorizado (requiere ADMIN o CONTA)" };
+
 export const morasRouter = new Elysia()
   .use(authMiddleware)
 
@@ -216,7 +227,8 @@ export const morasRouter = new Elysia()
 
   // ───────────── Mora Histórica (reconstruida desde moras_historial) ─────────────
   // Snapshot de la mora por crédito a una fecha de corte (con totales + filtros).
-  .get("/moras/historial", async ({ query, set }: any) => {
+  .get("/moras/historial", async ({ query, set, user }: any) => {
+    if (!requireMoraHistorialRole(user, set)) return NO_AUTORIZADO;
     try {
       return await getMoraHistorialSnapshot({
         fecha: query.fecha || hoyGT(),
@@ -244,7 +256,8 @@ export const morasRouter = new Elysia()
   })
 
   // Evolución (timeline) del total de mora día a día en un rango.
-  .get("/moras/historial/timeline", async ({ query, set }: any) => {
+  .get("/moras/historial/timeline", async ({ query, set, user }: any) => {
+    if (!requireMoraHistorialRole(user, set)) return NO_AUTORIZADO;
     try {
       return await getMoraTimeline({ desde: query.desde, hasta: query.hasta || hoyGT(), asesor: query.asesor });
     } catch (err) {
@@ -256,7 +269,8 @@ export const morasRouter = new Elysia()
   })
 
   // Excel del snapshot a la fecha de corte.
-  .get("/moras/historial/excel", async ({ query, set }: any) => {
+  .get("/moras/historial/excel", async ({ query, set, user }: any) => {
+    if (!requireMoraHistorialRole(user, set)) return NO_AUTORIZADO;
     try {
       const fecha = query.fecha || hoyGT();
       const buf = await getMoraHistorialExcel({
@@ -281,7 +295,8 @@ export const morasRouter = new Elysia()
   })
 
   // Historial completo de eventos de mora de un crédito (drill-down).
-  .get("/moras/historial/credito/:credito_id", async ({ params, set }: any) => {
+  .get("/moras/historial/credito/:credito_id", async ({ params, set, user }: any) => {
+    if (!requireMoraHistorialRole(user, set)) return NO_AUTORIZADO;
     try {
       const creditoId = Number(params.credito_id);
       if (!Number.isInteger(creditoId) || creditoId <= 0) {

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -22,6 +22,7 @@ import { SesionesPendientes } from "./private/cartera/components/SesionesPendien
 import { RecibosGenericos } from "./private/recibos-genericos/components/RecibosGenericos";
 import { FallenCredits } from "./private/cartera/components/FallenCredits";
 import { PagosPorVencimiento } from "./private/cartera/components/PagosPorVencimiento";
+import { MoraHistorial } from "./private/cartera/components/MoraHistorial";
 import { DevolucionCube } from "./private/cartera/components/DevolucionCube";
 import { CierreCartera } from "./private/cartera/components/CierreCartera";
 import { FacturacionDiaria } from "./private/cartera/components/FacturacionDiaria";
@@ -251,6 +252,15 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN"]}>
               <PagosPorVencimiento />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="mora-historial"
+          element={
+            <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
+              <MoraHistorial />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/MoraHistorial.tsx
+++ b/apps/carteraFront/src/private/cartera/components/MoraHistorial.tsx
@@ -1,0 +1,334 @@
+import { useState, useRef, Fragment } from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from "recharts";
+import { Search, X, ChevronLeft, ChevronRight, Check, ChevronsUpDown, FileDown, Loader2, Calendar, TrendingUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/components/ui/command";
+import { useAdminData } from "../hooks/advisor";
+import type { Advisor } from "../services/services";
+import {
+  getMoraHistorialSnapshot, getMoraTimeline, getMoraHistorialCredito, descargarMoraExcel,
+  type MoraEvento,
+} from "../services/moraHistorial.services";
+
+const fechaGT = () => new Date(new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" }));
+const isoDe = (d: Date) => `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+const hoyISO = () => isoDe(fechaGT());
+const menosDias = (iso: string, n: number) => { const d = new Date(iso + "T12:00:00"); d.setDate(d.getDate() - n); return isoDe(d); };
+const fmtQ = (v: any) => `Q ${Number(v ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+
+const etapaBadge = (etapa: string) => {
+  const map: Record<string, string> = {
+    "Mora 30": "bg-yellow-100 text-yellow-800",
+    "Mora 60": "bg-orange-100 text-orange-800",
+    "Mora 90": "bg-red-100 text-red-700",
+    "Mora 120+": "bg-red-200 text-red-900",
+  };
+  return map[etapa] ?? "bg-gray-100 text-gray-700";
+};
+
+export function MoraHistorial() {
+  const { advisors } = useAdminData();
+  const [fecha, setFecha] = useState(hoyISO());
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+  const [asesores, setAsesores] = useState<string[]>([]);
+  const [etapa, setEtapa] = useState("");
+  const [sifcoInput, setSifcoInput] = useState("");
+  const [nombreInput, setNombreInput] = useState("");
+  const [sifco, setSifco] = useState("");
+  const [nombre, setNombre] = useState("");
+  const [advisorOpen, setAdvisorOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [eventos, setEventos] = useState<MoraEvento[]>([]);
+  const [loadingEv, setLoadingEv] = useState(false);
+  const pendingRef = useRef<number | null>(null); // token anti-race del drill-down
+
+  const asesorCsv = asesores.join(",") || undefined;
+
+  const snapQuery = useQuery({
+    queryKey: ["mora-historial", fecha, asesorCsv, etapa, sifco, nombre, page, pageSize],
+    queryFn: () => getMoraHistorialSnapshot({
+      fecha, asesor: asesorCsv, etapa: etapa || undefined,
+      numero_credito_sifco: sifco || undefined, nombre_usuario: nombre || undefined, page, pageSize,
+    }),
+    refetchOnWindowFocus: false,
+  });
+
+  const timelineQuery = useQuery({
+    queryKey: ["mora-timeline", fecha, asesorCsv],
+    queryFn: () => getMoraTimeline(menosDias(fecha, 45), fecha, asesorCsv),
+    refetchOnWindowFocus: false,
+  });
+
+  const rows = snapQuery.data?.data ?? [];
+  const totales = snapQuery.data?.totales;
+  const pagination = snapQuery.data?.pagination;
+  const timeline = (timelineQuery.data?.data ?? []).map((d) => ({
+    fecha: String(d.fecha).slice(5, 10),
+    mora: Number(d.mora_total),
+  }));
+
+  const aplicar = () => { setSifco(sifcoInput.trim()); setNombre(nombreInput.trim()); setPage(1); };
+  const limpiar = () => { setAsesores([]); setEtapa(""); setSifcoInput(""); setNombreInput(""); setSifco(""); setNombre(""); setPage(1); };
+
+  const toggleRow = async (creditoId: number) => {
+    if (expanded === creditoId) { setExpanded(null); setEventos([]); pendingRef.current = null; return; }
+    setExpanded(creditoId); setEventos([]); setLoadingEv(true);
+    pendingRef.current = creditoId;
+    try {
+      const r = await getMoraHistorialCredito(creditoId);
+      if (pendingRef.current !== creditoId) return; // otra fila se expandió mientras tanto
+      if (r.success) setEventos(r.data);
+    } finally {
+      if (pendingRef.current === creditoId) setLoadingEv(false);
+    }
+  };
+
+  const descargar = async () => {
+    setExporting(true);
+    try {
+      const blob = await descargarMoraExcel({ fecha, asesor: asesorCsv, etapa: etapa || undefined, numero_credito_sifco: sifco || undefined, nombre_usuario: nombre || undefined });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a"); a.href = url; a.download = `mora-${fecha}.xlsx`;
+      document.body.appendChild(a); a.click(); a.remove(); URL.revokeObjectURL(url);
+    } finally { setExporting(false); }
+  };
+
+  const filtros = asesores.length + (etapa ? 1 : 0) + (sifco ? 1 : 0) + (nombre ? 1 : 0);
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 overflow-auto bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 pt-8 pb-8">
+      <div className="w-full max-w-[1400px] mx-auto">
+        <div className="flex flex-col items-center mb-6">
+          <h1 className="text-3xl font-extrabold text-red-700 text-center">Mora Histórica</h1>
+          <p className="text-gray-600 mt-2 text-center">Mora reconstruida a cualquier fecha de corte (desde el historial). Expande un crédito para ver sus eventos.</p>
+        </div>
+
+        {/* Filtros */}
+        <div className="bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-red-100 p-5 mb-6">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="min-w-[150px]">
+              <label className="text-sm font-semibold text-red-800 mb-1 block">Mora al día</label>
+              <Input type="date" value={fecha} onChange={(e) => { setFecha(e.target.value); setPage(1); }} className="text-gray-900 border-red-200 bg-red-50 [color-scheme:light]" />
+            </div>
+
+            <div className="flex-1 min-w-[230px]">
+              <label className="text-sm font-semibold text-red-800 mb-1 block">Asesores</label>
+              <Popover open={advisorOpen} onOpenChange={setAdvisorOpen}>
+                <PopoverTrigger asChild>
+                  <div role="button" tabIndex={0} className="w-full flex items-center justify-between border border-red-200 rounded-lg px-3 py-2 bg-red-50 text-red-800 text-sm h-10 overflow-hidden cursor-pointer">
+                    <span className="flex flex-wrap gap-1 flex-1 items-center overflow-hidden">
+                      {asesores.length === 0 ? <span className="text-gray-400">Todos</span>
+                        : asesores.length > 2 ? <Badge variant="secondary" className="text-xs bg-red-100 text-red-700">{asesores.length} asesores</Badge>
+                        : asesores.map((n) => <Badge key={n} variant="secondary" className="text-xs bg-red-100 text-red-700">{n}</Badge>)}
+                    </span>
+                    <ChevronsUpDown className="w-4 h-4 shrink-0 opacity-50 ml-2" />
+                  </div>
+                </PopoverTrigger>
+                <PopoverContent className="w-[--radix-popover-trigger-width] p-0 bg-white border border-red-200 shadow-lg" align="start">
+                  <Command className="bg-white text-gray-900">
+                    <CommandInput placeholder="Buscar asesor..." />
+                    <CommandList className="max-h-[250px]">
+                      <CommandEmpty>Sin resultados.</CommandEmpty>
+                      <CommandGroup>
+                        {advisors?.map((adv: Advisor) => {
+                          const sel = asesores.includes(adv.nombre);
+                          return (
+                            <CommandItem key={adv.asesor_id} value={adv.nombre}
+                              onSelect={() => { setAsesores(sel ? asesores.filter((v) => v !== adv.nombre) : [...asesores, adv.nombre]); setPage(1); }}
+                              className="text-gray-800 hover:bg-red-50 cursor-pointer">
+                              <Check className={`w-4 h-4 mr-2 ${sel ? "opacity-100 text-red-600" : "opacity-0"}`} />
+                              {adv.nombre}
+                            </CommandItem>
+                          );
+                        })}
+                      </CommandGroup>
+                    </CommandList>
+                  </Command>
+                </PopoverContent>
+              </Popover>
+            </div>
+
+            <div className="min-w-[150px]">
+              <label className="text-sm font-semibold text-red-800 mb-1 block">Etapa de Mora</label>
+              <select className="w-full border border-red-200 rounded-lg px-3 py-2 text-sm text-red-800 bg-red-50" value={etapa} onChange={(e) => { setEtapa(e.target.value); setPage(1); }}>
+                <option value="">Todas</option>
+                <option value="0-30">Mora 30</option>
+                <option value="31-60">Mora 60</option>
+                <option value="61-90">Mora 90</option>
+                <option value="+90">Mora 120+</option>
+              </select>
+            </div>
+
+            <div className="flex-1 min-w-[150px]">
+              <label className="text-sm font-semibold text-red-800 mb-1 block">No. SIFCO</label>
+              <Input placeholder="Buscar SIFCO..." value={sifcoInput} onChange={(e) => setSifcoInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && aplicar()} className="text-gray-900 border-red-200 bg-red-50" />
+            </div>
+            <div className="flex-1 min-w-[150px]">
+              <label className="text-sm font-semibold text-red-800 mb-1 block">Cliente</label>
+              <Input placeholder="Buscar nombre..." value={nombreInput} onChange={(e) => setNombreInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && aplicar()} className="text-gray-900 border-red-200 bg-red-50" />
+            </div>
+
+            <Button variant="outline" size="sm" onClick={aplicar} className="text-red-700 border-red-300 hover:bg-red-50">
+              <Search className="w-4 h-4 mr-1" /> Buscar
+            </Button>
+            <Button variant="default" size="sm" onClick={descargar} disabled={exporting || !rows.length} className="bg-green-600 hover:bg-green-700 text-white border-none">
+              {exporting ? <Loader2 className="w-4 h-4 mr-1 animate-spin" /> : <FileDown className="w-4 h-4 mr-1" />}
+              {exporting ? "Generando..." : "Excel"}
+            </Button>
+            {filtros > 0 && (
+              <Button variant="outline" size="sm" onClick={limpiar} className="text-gray-600 border-gray-300 hover:bg-gray-100">
+                <X className="w-4 h-4 mr-1" /> Limpiar <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">{filtros}</Badge>
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Totales por etapa */}
+        {totales && (
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-3 mb-6">
+            <div className="bg-white rounded-xl shadow border border-red-200 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium flex items-center justify-center gap-1"><Calendar className="h-3 w-3" /> Mora total al {fecha}</p>
+              <p className="text-lg font-bold text-red-700">{fmtQ(totales.mora_total)}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-blue-100 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium">Créditos</p>
+              <p className="text-lg font-bold text-blue-700">{totales.creditos}</p>
+            </div>
+            {[["Mora 30", totales.mora_30], ["Mora 60", totales.mora_60], ["Mora 90", totales.mora_90], ["Mora 120+", totales.mora_120]].map(([l, v]) => (
+              <div key={l} className="bg-white rounded-xl shadow border border-gray-100 p-4 text-center">
+                <p className="text-xs text-gray-500 font-medium">{l}</p>
+                <p className="text-sm font-bold text-gray-800">{fmtQ(v)}</p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Timeline */}
+        <div className="bg-white rounded-2xl shadow-lg border border-red-100 p-5 mb-6">
+          <h2 className="text-sm font-bold text-red-800 mb-3 uppercase tracking-wide flex items-center gap-2"><TrendingUp className="h-4 w-4" /> Evolución de la mora (últimos 45 días)</h2>
+          {timelineQuery.isFetching ? (
+            <div className="h-64 flex items-center justify-center text-red-300"><Loader2 className="h-6 w-6 animate-spin" /></div>
+          ) : (
+            <ResponsiveContainer width="100%" height={260}>
+              <LineChart data={timeline} margin={{ top: 5, right: 20, left: 10, bottom: 5 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#fee2e2" />
+                <XAxis dataKey="fecha" tick={{ fontSize: 11 }} />
+                <YAxis tick={{ fontSize: 11 }} tickFormatter={(v) => `${(v / 1000).toFixed(0)}k`} />
+                <Tooltip formatter={(v: any) => fmtQ(v)} />
+                <Line type="monotone" dataKey="mora" stroke="#dc2626" strokeWidth={2} dot={{ r: 2 }} name="Mora total" />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        {/* Tabla */}
+        {snapQuery.isLoading ? (
+          <div className="text-center py-16 text-red-400 font-semibold">Cargando...</div>
+        ) : snapQuery.isError ? (
+          <div className="text-center py-16 text-red-500 font-semibold">Error al cargar la mora</div>
+        ) : !rows.length ? (
+          <div className="text-center py-16 text-gray-400 font-semibold">No hay mora para los filtros seleccionados</div>
+        ) : (
+          <>
+            <div className="bg-white rounded-2xl shadow-lg border border-red-100 overflow-x-auto">
+              <Table className="w-full">
+                <TableHeader>
+                  <TableRow className="bg-gradient-to-r from-red-50 to-red-100">
+                    <TableHead className="font-bold text-red-800">No. SIFCO</TableHead>
+                    <TableHead className="font-bold text-red-800">Cliente</TableHead>
+                    <TableHead className="font-bold text-red-800">Asesor</TableHead>
+                    <TableHead className="font-bold text-red-800 text-center">Status</TableHead>
+                    <TableHead className="font-bold text-red-800 text-center">Cuotas</TableHead>
+                    <TableHead className="font-bold text-red-800 text-center">Etapa</TableHead>
+                    <TableHead className="font-bold text-red-800 text-right">Capital</TableHead>
+                    <TableHead className="font-bold text-red-800 text-right">Mora</TableHead>
+                    <TableHead className="font-bold text-red-800 text-center">Actualizado</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((r) => (
+                    <Fragment key={r.credito_id}>
+                      <TableRow className="hover:bg-red-50/40 cursor-pointer" onClick={() => toggleRow(r.credito_id)}>
+                        <TableCell className="font-semibold text-red-700">{r.numero_credito_sifco}</TableCell>
+                        <TableCell className="text-black">{r.cliente}</TableCell>
+                        <TableCell className="text-black text-xs">{r.asesor || "--"}</TableCell>
+                        <TableCell className="text-center text-xs text-gray-600">{r.status}</TableCell>
+                        <TableCell className="text-center text-black">{r.cuotas_atrasadas}</TableCell>
+                        <TableCell className="text-center">
+                          <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-bold ${etapaBadge(r.etapa)}`}>{r.etapa}</span>
+                        </TableCell>
+                        <TableCell className="text-right text-gray-700">{fmtQ(r.capital)}</TableCell>
+                        <TableCell className="text-right font-bold text-red-700">{fmtQ(r.mora)}</TableCell>
+                        <TableCell className="text-center text-xs text-gray-500">{r.actualizado ? String(r.actualizado).slice(0, 10) : "--"}</TableCell>
+                      </TableRow>
+                      {expanded === r.credito_id && (
+                        <TableRow className="bg-slate-50/60">
+                          <TableCell colSpan={9} className="p-4">
+                            {loadingEv ? (
+                              <div className="flex items-center gap-2 text-xs text-red-500 py-3 justify-center"><Loader2 className="h-4 w-4 animate-spin" /> Cargando historial...</div>
+                            ) : eventos.length === 0 ? (
+                              <p className="text-xs text-gray-500 italic text-center py-2">Sin eventos de mora registrados.</p>
+                            ) : (
+                              <div>
+                                <p className="text-xs font-bold text-red-700 mb-2">Historial de mora del crédito</p>
+                                <table className="w-full text-[11px]">
+                                  <thead>
+                                    <tr className="text-left text-red-800 border-b border-red-100">
+                                      <th className="py-1 px-2">Fecha</th><th className="py-1 px-2">Evento</th><th className="py-1 px-2">Origen</th>
+                                      <th className="py-1 px-2 text-right">Antes</th><th className="py-1 px-2 text-right">Después</th>
+                                      <th className="py-1 px-2 text-center">Cuotas</th><th className="py-1 px-2">Usuario</th>
+                                    </tr>
+                                  </thead>
+                                  <tbody>
+                                    {eventos.map((ev) => (
+                                      <tr key={ev.historial_id} className="border-b border-gray-50">
+                                        <td className="py-1 px-2 whitespace-nowrap">{String(ev.fecha).slice(0, 10)}</td>
+                                        <td className="py-1 px-2">{ev.tipo_evento}</td>
+                                        <td className="py-1 px-2 text-gray-500">{ev.origen}</td>
+                                        <td className="py-1 px-2 text-right">{fmtQ(ev.monto_anterior)}</td>
+                                        <td className="py-1 px-2 text-right font-semibold">{fmtQ(ev.monto_nuevo)}</td>
+                                        <td className="py-1 px-2 text-center">{ev.cuotas_atrasadas_nuevas}</td>
+                                        <td className="py-1 px-2 text-gray-600">{ev.usuario || "sistema"}</td>
+                                      </tr>
+                                    ))}
+                                  </tbody>
+                                </table>
+                              </div>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      )}
+                    </Fragment>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between mt-5 gap-3">
+              <span className="text-sm text-gray-600">Página {pagination?.page ?? 1} de {pagination?.totalPages ?? 1} ({pagination?.total ?? 0} créditos)</span>
+              <div className="flex items-center gap-2">
+                <select className="border border-red-200 rounded-lg px-3 py-2 text-sm text-red-800 bg-red-50" value={pageSize} onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}>
+                  {[20, 50, 100].map((n) => <option key={n} value={n}>{n} por página</option>)}
+                </select>
+                <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)} className="border-red-200 text-red-700"><ChevronLeft className="w-4 h-4" /></Button>
+                <Button variant="outline" size="sm" disabled={page >= (pagination?.totalPages ?? 1)} onClick={() => setPage((p) => p + 1)} className="border-red-200 text-red-700"><ChevronRight className="w-4 h-4" /></Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default MoraHistorial;

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -230,6 +230,13 @@ const menuSections: MenuSection[] = [
         roles: ["ADMIN"],
       },
       {
+        key: "mora-historial",
+        label: "Mora Histórica",
+        icon: <TrendingDown className="h-4 w-4" />,
+        path: "/mora-historial",
+        roles: ["ADMIN", "CONTA"],
+      },
+      {
         key: "cierre-cartera",
         label: "Cierre de Cartera",
         icon: <PiggyBank className="h-4 w-4" />,

--- a/apps/carteraFront/src/private/cartera/services/moraHistorial.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/moraHistorial.services.ts
@@ -1,0 +1,82 @@
+import api from "@/Provider/interceptor";
+
+const API_URL = import.meta.env.VITE_BACK_URL || "";
+
+export interface MoraHistorialRow {
+  credito_id: number;
+  numero_credito_sifco: string;
+  cliente: string;
+  asesor: string;
+  status: string;
+  cuotas_atrasadas: number;
+  etapa: string;
+  mora: string;
+  capital: string;
+  actualizado: string;
+}
+
+export interface MoraTotales {
+  mora_total: string;
+  mora_30: string;
+  mora_60: string;
+  mora_90: string;
+  mora_120: string;
+  creditos: number;
+}
+
+export interface MoraEvento {
+  historial_id: number;
+  fecha: string;
+  tipo_evento: string;
+  origen: string;
+  monto_anterior: string;
+  monto_nuevo: string;
+  cuotas_atrasadas_anterior: number;
+  cuotas_atrasadas_nuevas: number;
+  motivo: string | null;
+  usuario: string | null;
+}
+
+export interface MoraSnapshotResponse {
+  success: boolean;
+  fecha: string;
+  data: MoraHistorialRow[];
+  pagination: { page: number; pageSize: number; total: number; totalPages: number };
+  totales: MoraTotales;
+}
+
+export interface SnapshotParams {
+  fecha: string;
+  asesor?: string;
+  etapa?: string;
+  numero_credito_sifco?: string;
+  nombre_usuario?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export const getMoraHistorialSnapshot = async (params: SnapshotParams): Promise<MoraSnapshotResponse> => {
+  const { data } = await api.get(`${API_URL}/moras/historial`, { params });
+  return data;
+};
+
+export const getMoraTimeline = async (
+  desde: string,
+  hasta: string,
+  asesor?: string
+): Promise<{ success: boolean; data: { fecha: string; mora_total: string }[] }> => {
+  const { data } = await api.get(`${API_URL}/moras/historial/timeline`, { params: { desde, hasta, asesor } });
+  return data;
+};
+
+export const getMoraHistorialCredito = async (
+  credito_id: number
+): Promise<{ success: boolean; data: MoraEvento[] }> => {
+  const { data } = await api.get(`${API_URL}/moras/historial/credito/${credito_id}`);
+  return data;
+};
+
+export const descargarMoraExcel = async (params: Omit<SnapshotParams, "page" | "pageSize">): Promise<Blob> => {
+  const res = await api.get(`${API_URL}/moras/historial/excel`, { params, responseType: "blob" });
+  return res.data as Blob;
+};


### PR DESCRIPTION
## Qué agrega

Un **módulo nuevo de Mora Histórica** en cartera (back + front): permite ver la mora **a cualquier fecha de corte**, con timeline de evolución, filtros, drill-down por crédito y export a Excel.

## Por qué

La tabla `moras_credito` refleja solo el **estado actual** y se puede quedar en cero (p. ej. tras una condonación masiva), perdiendo la foto histórica. Este módulo reconstruye la mora desde **`cartera.moras_historial`** (el log de eventos del cron/ajustes), así que:
- Muestra la mora **as-of** cualquier día (ej. al 6-jun) aunque hoy esté condonada.
- El **drill-down** hace visible *qué* le pasó a la mora de cada crédito (recálculos, condonaciones individuales/masivas, **y qué usuario las hizo**).

## Cómo funciona

Por crédito, el estado de mora "al día X" = **último evento con `fecha <= X`** (DISTINCT ON credito_id), excluyendo si el último evento fue una desactivación. Sobre eso se arman el snapshot, los totales por etapa y el timeline.

## Detalle técnico

**Backend** (`apps/cartera-back`)
- `controllers/moraHistorial.ts` (nuevo): `getMoraHistorialSnapshot` (snapshot as-of por crédito + totales por etapa 30/60/90/120+ + filtros + paginación), `getMoraTimeline` (total de mora día a día), `getMoraHistorialCredito` (eventos de un crédito), `getMoraHistorialExcel` (xlsx).
- `routers/latefee.ts`: 4 rutas GET en `morasRouter` — `/moras/historial`, `/moras/historial/timeline`, `/moras/historial/excel`, `/moras/historial/credito/:credito_id`.

**Frontend** (`apps/carteraFront`)
- `components/MoraHistorial.tsx` (nuevo): selector de fecha (aplica al instante), **timeline (recharts)** de los últimos 45 días, cards de totales por etapa, filtros (asesor multi-select, etapa, SIFCO/cliente), tabla con **drill-down** del historial de eventos por crédito, y botón Excel.
- `services/moraHistorial.services.ts` (nuevo).
- `App.tsx` + `dashBoard.tsx`: ruta `/mora-historial` + ítem de menú "Mora Histórica" (roles ADMIN, CONTA).

## Pruebas / verificación (read-only contra prod)

- Snapshot **al 06-06 = 702 créditos / Q2,529,970.84**, idéntico a un recálculo independiente desde `moras_historial`.
- Filtros (etapa + asesor), timeline y drill-down verificados; el drill-down muestra correctamente la condonación masiva y el usuario que la ejecutó.
- Router carga (12 rutas), **typecheck back + front limpio**.

## Code review aplicado

Se corrieron agentes de review y se arreglaron: guard anti-race en el drill-down (`pendingRef`), la fecha aplica de forma instantánea, **clamp de paginación** (page/pageSize inválido → defaults, sin 500), **try/catch en la ruta de Excel**, y validación de `:credito_id`. Falsos positivos descartados (probados): route-shadowing en Elysia (gana el segmento estático) y SQL injection (todo parametrizado).

## Notas / deuda técnica (no bloqueante)

- Duplicación con reportes existentes: mapeo de etapas (vs `reports.ts`), multi-select de asesor (vs `PagosPorVencimiento`), helpers `fmtQ`/`hoyGT` — candidatos a extraer a compartido más adelante.
- El timeline reconstruye día a día (1 query/día en el rango); OK con el volumen actual, a vigilar si crece `moras_historial`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
