### PR TITLE
feat(cartera-back): celdas editables del reporte Facturación Diaria (6 totales, lock, auditoría)

### DIFF
--- a/apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql
+++ b/apps/cartera-back/drizzle/0014_snapshot_editable_lock.sql
@@ -1,0 +1,21 @@
+-- Lock por fila + auditoría para edición manual del snapshot diario.
+ALTER TABLE cartera.facturacion_snapshot_diario
+  ADD COLUMN IF NOT EXISTS bloqueado boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS bloqueado_por integer,
+  ADD COLUMN IF NOT EXISTS bloqueado_at timestamp;
+
+CREATE TABLE IF NOT EXISTS cartera.facturacion_snapshot_auditoria (
+  id serial PRIMARY KEY,
+  fecha date NOT NULL,
+  columna varchar(100) NOT NULL,
+  valor_anterior text,
+  valor_nuevo text,
+  accion varchar(20) NOT NULL,
+  usuario_id integer,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshot_auditoria_fecha
+  ON cartera.facturacion_snapshot_auditoria (fecha);
+CREATE INDEX IF NOT EXISTS idx_snapshot_auditoria_created
+  ON cartera.facturacion_snapshot_auditoria (created_at);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
@@ -6,17 +6,24 @@ mock.module("../database", () => ({ db: {} }));
 const { esColumnaEditable, validarValores } = await import("./facturacionSnapshot");
 
 describe("esColumnaEditable", () => {
-  it("acepta columnas de valor DIARIAS", () => {
+  it("acepta SOLO los 6 totales de rubro", () => {
     expect(esColumnaEditable("capital_total")).toBe(true);
-    expect(esColumnaEditable("facturacion")).toBe(true);
-    expect(esColumnaEditable("roy_hipotecario")).toBe(true);
+    expect(esColumnaEditable("interes_cube")).toBe(true);
+    expect(esColumnaEditable("membresia")).toBe(true);
+    expect(esColumnaEditable("otros_ingresos")).toBe(true);
+    expect(esColumnaEditable("mora_cube")).toBe(true);
+    expect(esColumnaEditable("royalty")).toBe(true);
   });
-  it("rechaza columnas no editables (incl. acumulados auto-calculados)", () => {
+  it("rechaza detalle por producto, facturación, servicios, metas y acumulados", () => {
     expect(esColumnaEditable("id")).toBe(false);
     expect(esColumnaEditable("fecha")).toBe(false);
-    expect(esColumnaEditable("anio")).toBe(false);
     expect(esColumnaEditable("bloqueado")).toBe(false);
-    // Acumulados/tendencias/% se auto-calculan → NO editables a mano.
+    expect(esColumnaEditable("roy_hipotecario")).toBe(false); // detalle producto
+    expect(esColumnaEditable("administrativos")).toBe(false);
+    expect(esColumnaEditable("facturacion")).toBe(false); // se DERIVA de rubros
+    expect(esColumnaEditable("servicios_seguro_gps")).toBe(false);
+    expect(esColumnaEditable("ingreso_carros")).toBe(false);
+    expect(esColumnaEditable("meta_facturacion_diaria")).toBe(false);
     expect(esColumnaEditable("facturacion_acumulado")).toBe(false);
     expect(esColumnaEditable("acumulado_total")).toBe(false);
     expect(esColumnaEditable("porcentaje_meta_mensual")).toBe(false);
@@ -25,8 +32,8 @@ describe("esColumnaEditable", () => {
 });
 
 describe("validarValores", () => {
-  it("ok con columnas válidas y números", () => {
-    const r = validarValores({ capital_total: "100.50", facturacion: "0" });
+  it("ok con rubros editables y números", () => {
+    const r = validarValores({ capital_total: "100.50", royalty: "0" });
     expect(r.ok).toBe(true);
     expect(r.invalidas).toEqual([]);
   });
@@ -70,13 +77,13 @@ describe("calcularAcumuladosCorridos", () => {
 
 describe("validarValores numérico estricto", () => {
   it("rechaza notación científica, hex y comas", () => {
-    expect(validarValores({ facturacion: "1e3" }).ok).toBe(false);
-    expect(validarValores({ facturacion: "0x10" }).ok).toBe(false);
-    expect(validarValores({ facturacion: "1,000" }).ok).toBe(false);
+    expect(validarValores({ royalty: "1e3" }).ok).toBe(false);
+    expect(validarValores({ royalty: "0x10" }).ok).toBe(false);
+    expect(validarValores({ royalty: "1,000" }).ok).toBe(false);
   });
   it("acepta decimal plano con espacios y signo", () => {
-    expect(validarValores({ facturacion: " 1000 " }).ok).toBe(true);
-    expect(validarValores({ facturacion: "-12.50" }).ok).toBe(true);
-    expect(validarValores({ facturacion: "0" }).ok).toBe(true);
+    expect(validarValores({ royalty: " 1000 " }).ok).toBe(true);
+    expect(validarValores({ royalty: "-12.50" }).ok).toBe(true);
+    expect(validarValores({ royalty: "0" }).ok).toBe(true);
   });
 });

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, mock } from "bun:test";
+
+// El controller importa ../database; lo mockeamos para poder importar los helpers puros.
+mock.module("../database", () => ({ db: {} }));
+
+const { esColumnaEditable, validarValores } = await import("./facturacionSnapshot");
+
+describe("esColumnaEditable", () => {
+  it("acepta columnas de valor DIARIAS", () => {
+    expect(esColumnaEditable("capital_total")).toBe(true);
+    expect(esColumnaEditable("facturacion")).toBe(true);
+    expect(esColumnaEditable("roy_hipotecario")).toBe(true);
+  });
+  it("rechaza columnas no editables (incl. acumulados auto-calculados)", () => {
+    expect(esColumnaEditable("id")).toBe(false);
+    expect(esColumnaEditable("fecha")).toBe(false);
+    expect(esColumnaEditable("anio")).toBe(false);
+    expect(esColumnaEditable("bloqueado")).toBe(false);
+    // Acumulados/tendencias/% se auto-calculan → NO editables a mano.
+    expect(esColumnaEditable("facturacion_acumulado")).toBe(false);
+    expect(esColumnaEditable("acumulado_total")).toBe(false);
+    expect(esColumnaEditable("porcentaje_meta_mensual")).toBe(false);
+    expect(esColumnaEditable("columna_inventada")).toBe(false);
+  });
+});
+
+describe("validarValores", () => {
+  it("ok con columnas válidas y números", () => {
+    const r = validarValores({ capital_total: "100.50", facturacion: "0" });
+    expect(r.ok).toBe(true);
+    expect(r.invalidas).toEqual([]);
+  });
+  it("marca columna no editable", () => {
+    const r = validarValores({ fecha: "2026-06-10" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("fecha");
+  });
+  it("marca valor no numérico", () => {
+    const r = validarValores({ capital_total: "abc" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("capital_total");
+  });
+});
+
+const { calcularAcumuladosCorridos } = await import("./facturacionSnapshot");
+
+describe("calcularAcumuladosCorridos", () => {
+  it("suma corrida para TODOS los días (incl. bloqueado) → acumulados siempre suman", () => {
+    const dias = [
+      { fecha: "2026-06-01", bloqueado: false, facturacion: "100", servicios_seguro_gps: "10", facturacion_inversionistas: "5", ingreso_carros: "0" },
+      { fecha: "2026-06-02", bloqueado: true,  facturacion: "200", servicios_seguro_gps: "20", facturacion_inversionistas: "5", ingreso_carros: "0" },
+      { fecha: "2026-06-03", bloqueado: false, facturacion: "300", servicios_seguro_gps: "30", facturacion_inversionistas: "5", ingreso_carros: "1" },
+    ];
+    const r = calcularAcumuladosCorridos(dias);
+    // Todos los días emiten update (incl. el bloqueado) — sin discontinuidad.
+    expect(r.map((u) => u.fecha)).toEqual(["2026-06-01", "2026-06-02", "2026-06-03"]);
+    // Día 1: 100
+    expect(r[0].facturacion_acumulado).toBe("100.00");
+    // Día 2 (bloqueado, pero su acumulado SÍ se calcula): 100+200 = 300
+    expect(r[1].facturacion_acumulado).toBe("300.00");
+    expect(r[1].acumulado_total).toBe("330.00"); // 300 + 30(serv) + 0(carros)
+    // Día 3: 100+200+300 = 600
+    expect(r[2].facturacion_acumulado).toBe("600.00");
+    expect(r[2].acum_servicios_seguro_gps).toBe("60.00");
+    expect(r[2].acumulado_inversionistas).toBe("15.00");
+    // acumulado_total = 600 + 60(serv) + 1(carros) = 661
+    expect(r[2].acumulado_total).toBe("661.00");
+  });
+});
+
+describe("validarValores numérico estricto", () => {
+  it("rechaza notación científica, hex y comas", () => {
+    expect(validarValores({ facturacion: "1e3" }).ok).toBe(false);
+    expect(validarValores({ facturacion: "0x10" }).ok).toBe(false);
+    expect(validarValores({ facturacion: "1,000" }).ok).toBe(false);
+  });
+  it("acepta decimal plano con espacios y signo", () => {
+    expect(validarValores({ facturacion: " 1000 " }).ok).toBe(true);
+    expect(validarValores({ facturacion: "-12.50" }).ok).toBe(true);
+    expect(validarValores({ facturacion: "0" }).ok).toBe(true);
+  });
+});

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -104,8 +104,8 @@ export function calcularAcumuladosCorridos(
 //   facturacion_mas_servicios = facturacion + servicios_seguro_gps
 // (capital_total NO entra en facturacion.) Se usa tras editar rubros para que el
 // total del día y los acumulados cuadren con lo que el usuario tipeó.
-export async function recomputarTotalesDia(fecha: string) {
-  await db.execute(sql`
+export async function recomputarTotalesDia(fecha: string, exec: any = db) {
+  await exec.execute(sql`
     UPDATE cartera.facturacion_snapshot_diario SET
       facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty,
       facturacion_mas_servicios =
@@ -115,15 +115,20 @@ export async function recomputarTotalesDia(fecha: string) {
   `);
 }
 
-// Refresca SOLO las columnas de acumulado de los días no bloqueados del mes,
-// usando la suma corrida de las diarias guardadas. No lee la fuente ni toca
-// diarias → seguro para días históricos importados del Excel.
-export async function recomputarAcumuladosMes(anio: number, mes: number) {
+// Refresca las columnas de acumulado de TODOS los días del mes (incluidos los
+// bloqueados: sus acumulados también suman, ver calcularAcumuladosCorridos),
+// como suma corrida de las diarias guardadas. No lee la fuente ni toca diarias
+// → seguro para días históricos importados del Excel.
+export async function recomputarAcumuladosMes(
+  anio: number,
+  mes: number,
+  exec: any = db
+) {
   // Filtramos por RANGO de fecha (no por anio/mes) porque esas columnas helper
   // pueden venir NULL en filas importadas → quedarían fuera del SUM y romperían
   // la continuidad del acumulado.
   const inicioMes = `${anio}-${String(mes).padStart(2, "0")}-01`;
-  const res = await db.execute(sql`
+  const res = await exec.execute(sql`
     SELECT fecha::text AS fecha, bloqueado,
            facturacion, servicios_seguro_gps, facturacion_inversionistas, ingreso_carros
     FROM cartera.facturacion_snapshot_diario
@@ -134,7 +139,7 @@ export async function recomputarAcumuladosMes(anio: number, mes: number) {
   const dias = ((res as any).rows ?? res) as DiaAcumulable[];
   const updates = calcularAcumuladosCorridos(dias);
   for (const u of updates) {
-    await db.execute(sql`
+    await exec.execute(sql`
       UPDATE cartera.facturacion_snapshot_diario SET
         facturacion_acumulado = ${u.facturacion_acumulado},
         acum_servicios_seguro_gps = ${u.acum_servicios_seguro_gps},
@@ -865,18 +870,22 @@ export async function guardarCeldasSnapshot(input: {
           VALUES (${c.fecha}::date, '*', NULL, NULL, 'lock', ${usuarioId})
         `);
       }
+
+      // Recomputes DENTRO de la transacción (con tx) para que la edición, la
+      // re-derivación del total y los acumulados sean atómicos: si algo falla,
+      // rollback completo (nada de día bloqueado con totales/acumulados stale).
+    }
+
+    // 1) Re-derivar el total del día (facturacion + fact_mas_servicios) desde
+    //    los rubros editados, en cada día tocado.
+    for (const f of diasAfectados) await recomputarTotalesDia(f, tx);
+
+    // 2) Refrescar acumulados de cada mes afectado (suma corrida).
+    for (const k of mesesAfectados) {
+      const [anio, mes] = k.split("-").map(Number);
+      await recomputarAcumuladosMes(anio, mes, tx);
     }
   });
-
-  // 1) Re-derivar el total del día (facturacion + fact_mas_servicios) desde los
-  //    rubros editados, en cada día tocado.
-  for (const f of diasAfectados) await recomputarTotalesDia(f);
-
-  // 2) Refrescar acumulados de cada mes afectado (suma corrida).
-  for (const k of mesesAfectados) {
-    const [anio, mes] = k.split("-").map(Number);
-    await recomputarAcumuladosMes(anio, mes);
-  }
 
   return { success: true, dias: cambios.length, meses: mesesAfectados.size };
 }
@@ -910,7 +919,8 @@ export async function listarAuditoriaSnapshot(opts: {
   fechaFin?: string;
   limit?: number;
 }) {
-  const lim = Math.min(Math.max(opts.limit ?? 200, 1), 1000);
+  const n = Number(opts.limit);
+  const lim = Number.isFinite(n) ? Math.min(Math.max(n, 1), 1000) : 200;
   const conds: any[] = [];
   if (opts.fechaInicio) conds.push(sql`a.fecha >= ${opts.fechaInicio}::date`);
   if (opts.fechaFin) conds.push(sql`a.fecha <= ${opts.fechaFin}::date`);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -110,6 +110,9 @@ export async function recomputarTotalesDia(fecha: string, exec: any = db) {
       facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty,
       facturacion_mas_servicios =
         interes_cube + membresia + otros_ingresos + mora_cube + royalty + servicios_seguro_gps,
+      -- otros_cobros = otros_ingresos − administrativos (igual que generarSnapshotDiario);
+      -- al editar otros_ingresos debe refrescarse o queda stale en el día bloqueado.
+      otros_cobros = otros_ingresos - administrativos,
       updated_at = now()
     WHERE fecha = ${fecha}::date
   `);
@@ -145,6 +148,17 @@ export async function recomputarAcumuladosMes(
         acum_servicios_seguro_gps = ${u.acum_servicios_seguro_gps},
         acumulado_inversionistas = ${u.acumulado_inversionistas},
         acumulado_total = ${u.acumulado_total},
+        -- Proyecciones y % meta derivan del acumulado → refrescar o quedan stale.
+        tendencia_fin_mes = CASE WHEN EXTRACT(DAY FROM fecha) > 0
+          THEN ${u.facturacion_acumulado}::numeric / EXTRACT(DAY FROM fecha)
+               * EXTRACT(DAY FROM (date_trunc('month', fecha) + INTERVAL '1 month - 1 day'))
+          ELSE 0 END,
+        tendencia_semanal = CASE WHEN EXTRACT(DAY FROM fecha) > 0
+          THEN ${u.facturacion_acumulado}::numeric / EXTRACT(DAY FROM fecha) * 5
+          ELSE 0 END,
+        porcentaje_meta_mensual = CASE WHEN meta_facturacion_mensual > 0
+          THEN ROUND(${u.facturacion_acumulado}::numeric / meta_facturacion_mensual * 100, 4)
+          ELSE 0 END,
         updated_at = now()
       WHERE fecha = ${u.fecha}::date
     `);
@@ -428,6 +442,9 @@ export async function generarSnapshotDiario(fecha: string) {
 //    los montos importados). Si el día no tiene fila, la genera primero.
 //    - administrativos = SUM(gastos del día); otros_cobros = otros_ingresos − administrativos
 //    - ingreso_carros = SUM(carros del día); acumulado_total = fact_acum + acum_servicios + carros MTD
+//    NO lleva guard de bloqueado: ninguna de estas columnas es editable a mano (lo
+//    editable son los 6 totales de rubro) → deben refrescar también en días bloqueados.
+//    El lock solo lo respeta generarSnapshotDiario (que sí reescribe los rubros).
 export async function aplicarManualesEnSnapshotDia(fecha: string) {
   const existe = await db
     .select({ id: facturacion_snapshot_diario.id })
@@ -454,13 +471,14 @@ export async function aplicarManualesEnSnapshotDia(fecha: string) {
           + COALESCE((SELECT SUM(monto) FROM cartera.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
         updated_at = now()
     WHERE s.fecha = ${fecha}::date
-      AND s.bloqueado = false
   `);
   return { success: true };
 }
 
 // ✅ Aplica SOLO las columnas de meta a los snapshots del mes (sin recalcular
 //    los montos importados). Recalcula el % meta con el acumulado existente.
+//    NO lleva guard de bloqueado: las columnas de meta no son editables a mano →
+//    deben refrescar también en días bloqueados (el lock vive en generarSnapshotDiario).
 export async function aplicarMetaEnSnapshotsMes(anio: number, mes: number) {
   const res = await db.execute(sql`
     UPDATE cartera.facturacion_snapshot_diario s
@@ -477,7 +495,6 @@ export async function aplicarMetaEnSnapshotsMes(anio: number, mes: number) {
     WHERE m.anio = ${anio} AND m.mes = ${mes}
       AND s.fecha >= make_date(${anio}, ${mes}, 1)
       AND s.fecha < (make_date(${anio}, ${mes}, 1) + INTERVAL '1 month')
-      AND s.bloqueado = false
   `);
   return { success: true, actualizados: (res as any).rowCount ?? 0 };
 }

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -9,6 +9,134 @@ const LOGO_URL =
   process.env.LOGO_URL ||
   "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
 
+// ── Edición manual: whitelist de columnas editables + validación ──────────────
+export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set([
+  // Capital
+  "cap_autocompras","cap_sobre_vehiculo","nuevo_cap_autocompras","cap_hipotecario","cap_extra_financiamiento","cap_reestructura","capital_total",
+  // Interés
+  "int_autocompras","int_sobre_vehiculo","nuevo_int_autocompras","int_hipotecario","int_extra_financiamiento","int_reestructura","interes_cube",
+  // Membresía
+  "mem_autocompras","mem_sobre_vehiculo","nuevo_mem_autocompras","mem_hipotecario","mem_extra_financiamiento","mem_reestructura","membresia",
+  // Otros ingresos
+  "oi_autocompras","oi_sobre_vehiculo","nuevo_oi_autocompras","oi_hipotecario","oi_extra_financiamiento","oi_reestructura","otros_ingresos","administrativos","otros_cobros",
+  // Mora
+  "mora_autocompras","mora_sobre_vehiculo","nuevo_mora_autocompras","mora_hipotecario","mora_extra_financiamiento","mora_reestructura","mora_cube",
+  // Royalty
+  "roy_autocompras","roy_sobre_vehiculo","nuevo_roy_autocompras","roy_hipotecario","roy_extra_financiamiento","roy_reestructura","royalty",
+  // Totales / servicios DIARIOS (editables). Los ACUMULADOS y tendencias NO van
+  // aquí: se auto-calculan (suma corrida) y no se editan a mano —ver
+  // calcularAcumuladosCorridos. (facturacion_acumulado, acum_servicios_seguro_gps,
+  // acumulado_total, acumulado_inversionistas, tendencia_*, reserva_acumulada,
+  // porcentaje_meta_mensual quedan fuera a propósito.)
+  "facturacion","servicios_seguro_gps","facturacion_mas_servicios","facturacion_inversionistas","ingreso_carros","semana",
+  // Metas (editables; el % se deriva del acumulado, no se edita)
+  "meta_facturacion_mensual","meta_facturacion_semanal","meta_facturacion_diaria","meta_diaria",
+]);
+
+export function esColumnaEditable(col: string): boolean {
+  return COLUMNAS_EDITABLES.has(col);
+}
+
+export function validarValores(valores: Record<string, unknown>): {
+  ok: boolean;
+  invalidas: string[];
+} {
+  const invalidas: string[] = [];
+  for (const [col, val] of Object.entries(valores)) {
+    if (!esColumnaEditable(col)) {
+      invalidas.push(col);
+      continue;
+    }
+    // Solo decimal plano (opcional signo): "123", "-12.50", "0". Rechaza "", null,
+    // notación científica ("1e3"), hex ("0x10"), comas ("1,000") y basura — que
+    // Number() aceptaría pero romperían el cast a numeric en el INSERT/UPDATE.
+    const s = String(val ?? "").trim();
+    if (!/^-?\d+(\.\d+)?$/.test(s)) {
+      invalidas.push(col);
+    }
+  }
+  return { ok: invalidas.length === 0, invalidas };
+}
+
+export type DiaAcumulable = {
+  fecha: string;
+  bloqueado: boolean;
+  facturacion: string | number;
+  servicios_seguro_gps: string | number;
+  facturacion_inversionistas: string | number;
+  ingreso_carros: string | number;
+};
+
+export type UpdateAcumulado = {
+  fecha: string;
+  facturacion_acumulado: string;
+  acum_servicios_seguro_gps: string;
+  acumulado_inversionistas: string;
+  acumulado_total: string;
+};
+
+// Suma corrida sobre días YA ordenados por fecha. Emite el acumulado para CADA
+// día (incluidos los bloqueados): los ACUMULADOS SIEMPRE SUMAN, no se congelan.
+// El lock protege los valores DIARIOS (los salta generarSnapshotDiario), pero el
+// acumulado de un día = suma corrida de las diarias hasta ese día. Así no hay
+// discontinuidad cuando se edita+bloquea un día. No toca reserva_acumulada
+// (es MTD desde pagos, sin columna diaria).
+export function calcularAcumuladosCorridos(
+  dias: DiaAcumulable[]
+): UpdateAcumulado[] {
+  let accFact = new Big(0);
+  let accServ = new Big(0);
+  let accInv = new Big(0);
+  let accCarros = new Big(0);
+  const updates: UpdateAcumulado[] = [];
+  for (const d of dias) {
+    accFact = accFact.plus(new Big(d.facturacion || 0));
+    accServ = accServ.plus(new Big(d.servicios_seguro_gps || 0));
+    accInv = accInv.plus(new Big(d.facturacion_inversionistas || 0));
+    accCarros = accCarros.plus(new Big(d.ingreso_carros || 0));
+    updates.push({
+      fecha: d.fecha,
+      facturacion_acumulado: accFact.toFixed(2),
+      acum_servicios_seguro_gps: accServ.toFixed(2),
+      acumulado_inversionistas: accInv.toFixed(2),
+      acumulado_total: accFact.plus(accServ).plus(accCarros).toFixed(2),
+    });
+  }
+  return updates;
+}
+
+// Refresca SOLO las columnas de acumulado de los días no bloqueados del mes,
+// usando la suma corrida de las diarias guardadas. No lee la fuente ni toca
+// diarias → seguro para días históricos importados del Excel.
+export async function recomputarAcumuladosMes(anio: number, mes: number) {
+  // Filtramos por RANGO de fecha (no por anio/mes) porque esas columnas helper
+  // pueden venir NULL en filas importadas → quedarían fuera del SUM y romperían
+  // la continuidad del acumulado.
+  const inicioMes = `${anio}-${String(mes).padStart(2, "0")}-01`;
+  const res = await db.execute(sql`
+    SELECT fecha::text AS fecha, bloqueado,
+           facturacion, servicios_seguro_gps, facturacion_inversionistas, ingreso_carros
+    FROM cartera.facturacion_snapshot_diario
+    WHERE fecha >= ${inicioMes}::date
+      AND fecha < (${inicioMes}::date + INTERVAL '1 month')
+    ORDER BY fecha
+  `);
+  const dias = ((res as any).rows ?? res) as DiaAcumulable[];
+  const updates = calcularAcumuladosCorridos(dias);
+  for (const u of updates) {
+    await db.execute(sql`
+      UPDATE cartera.facturacion_snapshot_diario SET
+        facturacion_acumulado = ${u.facturacion_acumulado},
+        acum_servicios_seguro_gps = ${u.acum_servicios_seguro_gps},
+        acumulado_inversionistas = ${u.acumulado_inversionistas},
+        acumulado_total = ${u.acumulado_total},
+        updated_at = now()
+      WHERE fecha = ${u.fecha}::date
+    `);
+  }
+  return { success: true, dias_actualizados: updates.length };
+}
+
 // ============================================================================
 // 📸 SNAPSHOT DIARIO DE FACTURACIÓN (tipo Excel "Reuniones diarias")
 //    Calcula y CONGELA una fila por día con las columnas A→BK.
@@ -54,6 +182,16 @@ function colProducto(prefix: string, categoria: string): string | null {
 }
 
 export async function generarSnapshotDiario(fecha: string) {
+  // Si el día está bloqueado (editado a mano), NO se sobreescribe.
+  const lockRes = await db.execute(sql`
+    SELECT bloqueado FROM cartera.facturacion_snapshot_diario
+    WHERE fecha = ${fecha}::date
+  `);
+  const lockRow = ((lockRes as any).rows ?? lockRes)[0];
+  if (lockRow?.bloqueado === true) {
+    return { success: true, skipped: true, reason: "bloqueado", fecha };
+  }
+
   // "YYYY-MM-DD"
   const [y, m, d] = fecha.split("-").map(Number);
   const monthStart = `${y}-${String(m).padStart(2, "0")}-01`;
@@ -301,6 +439,7 @@ export async function aplicarManualesEnSnapshotDia(fecha: string) {
           + COALESCE((SELECT SUM(monto) FROM cartera.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
         updated_at = now()
     WHERE s.fecha = ${fecha}::date
+      AND s.bloqueado = false
   `);
   return { success: true };
 }
@@ -323,6 +462,7 @@ export async function aplicarMetaEnSnapshotsMes(anio: number, mes: number) {
     WHERE m.anio = ${anio} AND m.mes = ${mes}
       AND s.fecha >= make_date(${anio}, ${mes}, 1)
       AND s.fecha < (make_date(${anio}, ${mes}, 1) + INTERVAL '1 month')
+      AND s.bloqueado = false
   `);
   return { success: true, actualizados: (res as any).rowCount ?? 0 };
 }
@@ -577,6 +717,9 @@ export async function getSnapshotsDiarios(opts: {
     "anio",
     "mes",
     "semana",
+    "bloqueado",
+    "bloqueado_por",
+    "bloqueado_at",
     "facturacion_acumulado",
     "acum_servicios_seguro_gps",
     "acumulado_total",
@@ -606,4 +749,140 @@ export async function getSnapshotsDiarios(opts: {
   }
 
   return { success: true, data: rows, totales };
+}
+
+// ============================================================================
+// ✏️ EDICIÓN MANUAL DE CELDAS (lock por fila + auditoría). Solo ADMIN (gate en router).
+// ============================================================================
+
+type CambioDia = { fecha: string; valores: Record<string, unknown> };
+
+// Guarda (upsert) las celdas tocadas por día, bloquea el día, audita cada cambio
+// y refresca los acumulados de los meses afectados. Solo columnas del whitelist.
+export async function guardarCeldasSnapshot(input: {
+  cambios: CambioDia[];
+  usuarioId: number | null;
+}) {
+  const { cambios, usuarioId } = input;
+  if (!Array.isArray(cambios) || cambios.length === 0) {
+    return { success: false, message: "Sin cambios" };
+  }
+  // Validar todo antes de escribir.
+  for (const c of cambios) {
+    const v = validarValores(c.valores);
+    if (!v.ok) {
+      return {
+        success: false,
+        message: `Columnas inválidas en ${c.fecha}`,
+        invalidas: v.invalidas,
+      };
+    }
+  }
+
+  const mesesAfectados = new Set<string>();
+
+  await db.transaction(async (tx) => {
+    for (const c of cambios) {
+      const [y, m] = c.fecha.split("-");
+      const anio = Number(y);
+      const mes = Number(m);
+      mesesAfectados.add(`${anio}-${mes}`);
+
+      // Fila actual (para valores viejos + saber si ya estaba bloqueado).
+      const prevRes = await tx.execute(sql`
+        SELECT * FROM cartera.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date
+      `);
+      const prev = ((prevRes as any).rows ?? prevRes)[0] ?? null;
+
+      const cols = Object.keys(c.valores);
+      // Valor canónico (trim) — validarValores ya garantizó que es decimal plano.
+      const valOf = (col: string) => String(c.valores[col] ?? "").trim();
+      // SET dinámico de las columnas tocadas. sql.raw para el nombre de columna
+      // (YA validado contra el whitelist) y bind del valor.
+      const sets = cols.map((col) => sql`${sql.raw(col)} = ${valOf(col)}`);
+
+      if (prev) {
+        await tx.execute(sql`
+          UPDATE cartera.facturacion_snapshot_diario
+          SET ${sql.join(sets, sql`, `)},
+              bloqueado = true, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
+          WHERE fecha = ${c.fecha}::date
+        `);
+      } else {
+        const insertCols = [
+          "fecha",
+          "anio",
+          "mes",
+          ...cols,
+          "bloqueado",
+          "bloqueado_por",
+          "bloqueado_at",
+        ];
+        const insertVals = [
+          sql`${c.fecha}::date`,
+          sql`${anio}`,
+          sql`${mes}`,
+          ...cols.map((col) => sql`${valOf(col)}`),
+          sql`true`,
+          sql`${usuarioId}`,
+          sql`now()`,
+        ];
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_diario (${sql.join(
+            insertCols.map((x) => sql.raw(x)),
+            sql`, `
+          )})
+          VALUES (${sql.join(insertVals, sql`, `)})
+        `);
+      }
+
+      // Auditoría por celda.
+      for (const col of cols) {
+        const anterior = prev ? prev[col] ?? null : null;
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          VALUES (${c.fecha}::date, ${col}, ${
+          anterior === null ? null : String(anterior)
+        }, ${valOf(col)}, 'edit', ${usuarioId})
+        `);
+      }
+      // Auditoría de lock si no estaba bloqueado.
+      if (!prev || prev.bloqueado !== true) {
+        await tx.execute(sql`
+          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          VALUES (${c.fecha}::date, '*', NULL, NULL, 'lock', ${usuarioId})
+        `);
+      }
+    }
+  });
+
+  // Refrescar acumulados de cada mes afectado (recomputarAcumuladosMes hace sus updates).
+  for (const k of mesesAfectados) {
+    const [anio, mes] = k.split("-").map(Number);
+    await recomputarAcumuladosMes(anio, mes);
+  }
+
+  return { success: true, dias: cambios.length, meses: mesesAfectados.size };
+}
+
+export async function desbloquearDiaSnapshot(
+  fecha: string,
+  usuarioId: number | null
+) {
+  const [y, m] = fecha.split("-");
+  const anio = Number(y);
+  const mes = Number(m);
+  await db.execute(sql`
+    UPDATE cartera.facturacion_snapshot_diario
+    SET bloqueado = false, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
+    WHERE fecha = ${fecha}::date
+  `);
+  await db.execute(sql`
+    INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+    VALUES (${fecha}::date, '*', NULL, NULL, 'unlock', ${usuarioId})
+  `);
+  // Vuelve a valores del sistema y refresca acumulados.
+  await generarSnapshotDiario(fecha);
+  await recomputarAcumuladosMes(anio, mes);
+  return { success: true, fecha };
 }

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -811,6 +811,19 @@ export async function guardarCeldasSnapshot(input: {
     }
   }
 
+  // Si un día NO tiene fila aún, generarlo COMPLETO primero (columnas source:
+  // detalle por producto, servicios, inversionistas, metas, reserva, semana) y
+  // LUEGO editar+bloquear. Si no, quedaría una fila sparse en 0 y el cron no la
+  // llenaría (la salta por bloqueado). Mismo patrón que aplicarManualesEnSnapshotDia.
+  for (const c of cambios) {
+    const ex = await db.execute(sql`
+      SELECT 1 FROM cartera.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date LIMIT 1
+    `);
+    if ((((ex as any).rows ?? ex) as any[]).length === 0) {
+      await generarSnapshotDiario(c.fecha);
+    }
+  }
+
   const mesesAfectados = new Set<string>();
   const diasAfectados = new Set<string>();
 

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -10,28 +10,22 @@ const LOGO_URL =
   "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
 
 // ── Edición manual: whitelist de columnas editables + validación ──────────────
-export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set([
-  // Capital
-  "cap_autocompras","cap_sobre_vehiculo","nuevo_cap_autocompras","cap_hipotecario","cap_extra_financiamiento","cap_reestructura","capital_total",
-  // Interés
-  "int_autocompras","int_sobre_vehiculo","nuevo_int_autocompras","int_hipotecario","int_extra_financiamiento","int_reestructura","interes_cube",
-  // Membresía
-  "mem_autocompras","mem_sobre_vehiculo","nuevo_mem_autocompras","mem_hipotecario","mem_extra_financiamiento","mem_reestructura","membresia",
-  // Otros ingresos
-  "oi_autocompras","oi_sobre_vehiculo","nuevo_oi_autocompras","oi_hipotecario","oi_extra_financiamiento","oi_reestructura","otros_ingresos","administrativos","otros_cobros",
-  // Mora
-  "mora_autocompras","mora_sobre_vehiculo","nuevo_mora_autocompras","mora_hipotecario","mora_extra_financiamiento","mora_reestructura","mora_cube",
-  // Royalty
-  "roy_autocompras","roy_sobre_vehiculo","nuevo_roy_autocompras","roy_hipotecario","roy_extra_financiamiento","roy_reestructura","royalty",
-  // Totales / servicios DIARIOS (editables). Los ACUMULADOS y tendencias NO van
-  // aquí: se auto-calculan (suma corrida) y no se editan a mano —ver
-  // calcularAcumuladosCorridos. (facturacion_acumulado, acum_servicios_seguro_gps,
-  // acumulado_total, acumulado_inversionistas, tendencia_*, reserva_acumulada,
-  // porcentaje_meta_mensual quedan fuera a propósito.)
-  "facturacion","servicios_seguro_gps","facturacion_mas_servicios","facturacion_inversionistas","ingreso_carros","semana",
-  // Metas (editables; el % se deriva del acumulado, no se edita)
-  "meta_facturacion_mensual","meta_facturacion_semanal","meta_facturacion_diaria","meta_diaria",
-]);
+// SOLO los 6 TOTALES de rubro (los que se ven colapsados). El detalle por
+// producto, servicios/inversionistas/carros, metas, y los ACUMULADOS/tendencias
+// quedan fuera: read-only. `facturacion` (total del día) se DERIVA de los rubros
+// (interes+membresia+otros+mora+royalty) — ver recomputarTotalesDia. Los
+// acumulados se auto-calculan (suma corrida). El front además solo deja editar HOY.
+export const RUBROS_TOTALES_EDITABLES = [
+  "capital_total",
+  "interes_cube",
+  "membresia",
+  "otros_ingresos",
+  "mora_cube",
+  "royalty",
+] as const;
+export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set(
+  RUBROS_TOTALES_EDITABLES
+);
 
 export function esColumnaEditable(col: string): boolean {
   return COLUMNAS_EDITABLES.has(col);
@@ -103,6 +97,22 @@ export function calcularAcumuladosCorridos(
     });
   }
   return updates;
+}
+
+// Re-deriva los totales DEL DÍA desde los rubros editados a mano:
+//   facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty
+//   facturacion_mas_servicios = facturacion + servicios_seguro_gps
+// (capital_total NO entra en facturacion.) Se usa tras editar rubros para que el
+// total del día y los acumulados cuadren con lo que el usuario tipeó.
+export async function recomputarTotalesDia(fecha: string) {
+  await db.execute(sql`
+    UPDATE cartera.facturacion_snapshot_diario SET
+      facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty,
+      facturacion_mas_servicios =
+        interes_cube + membresia + otros_ingresos + mora_cube + royalty + servicios_seguro_gps,
+      updated_at = now()
+    WHERE fecha = ${fecha}::date
+  `);
 }
 
 // Refresca SOLO las columnas de acumulado de los días no bloqueados del mes,
@@ -780,6 +790,7 @@ export async function guardarCeldasSnapshot(input: {
   }
 
   const mesesAfectados = new Set<string>();
+  const diasAfectados = new Set<string>();
 
   await db.transaction(async (tx) => {
     for (const c of cambios) {
@@ -787,6 +798,7 @@ export async function guardarCeldasSnapshot(input: {
       const anio = Number(y);
       const mes = Number(m);
       mesesAfectados.add(`${anio}-${mes}`);
+      diasAfectados.add(c.fecha);
 
       // Fila actual (para valores viejos + saber si ya estaba bloqueado).
       const prevRes = await tx.execute(sql`
@@ -856,7 +868,11 @@ export async function guardarCeldasSnapshot(input: {
     }
   });
 
-  // Refrescar acumulados de cada mes afectado (recomputarAcumuladosMes hace sus updates).
+  // 1) Re-derivar el total del día (facturacion + fact_mas_servicios) desde los
+  //    rubros editados, en cada día tocado.
+  for (const f of diasAfectados) await recomputarTotalesDia(f);
+
+  // 2) Refrescar acumulados de cada mes afectado (suma corrida).
   for (const k of mesesAfectados) {
     const [anio, mes] = k.split("-").map(Number);
     await recomputarAcumuladosMes(anio, mes);
@@ -885,4 +901,30 @@ export async function desbloquearDiaSnapshot(
   await generarSnapshotDiario(fecha);
   await recomputarAcumuladosMes(anio, mes);
   return { success: true, fecha };
+}
+
+// Historial de cambios manuales (tabla de auditoría), más reciente primero.
+// Une al usuario del sistema (platform_users) para mostrar el email de quién editó.
+export async function listarAuditoriaSnapshot(opts: {
+  fechaInicio?: string;
+  fechaFin?: string;
+  limit?: number;
+}) {
+  const lim = Math.min(Math.max(opts.limit ?? 200, 1), 1000);
+  const conds: any[] = [];
+  if (opts.fechaInicio) conds.push(sql`a.fecha >= ${opts.fechaInicio}::date`);
+  if (opts.fechaFin) conds.push(sql`a.fecha <= ${opts.fechaFin}::date`);
+  const whereSql = conds.length
+    ? sql`WHERE ${sql.join(conds, sql` AND `)}`
+    : sql``;
+  const res = await db.execute(sql`
+    SELECT a.id, a.fecha::text AS fecha, a.columna, a.valor_anterior, a.valor_nuevo,
+           a.accion, a.usuario_id, u.email AS usuario_email, a.created_at
+    FROM cartera.facturacion_snapshot_auditoria a
+    LEFT JOIN cartera.platform_users u ON u.id = a.usuario_id
+    ${whereSql}
+    ORDER BY a.created_at DESC
+    LIMIT ${lim}
+  `);
+  return { success: true, data: (res as any).rows ?? res };
 }

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1346,10 +1346,28 @@
 
       created_at: timestamp("created_at").defaultNow().notNull(),
       updated_at: timestamp("updated_at").defaultNow().notNull(),
+
+      bloqueado: boolean("bloqueado").notNull().default(false),
+      bloqueado_por: integer("bloqueado_por"),
+      bloqueado_at: timestamp("bloqueado_at"),
     },
     (table) => ({
       uqFecha: uniqueIndex("uq_facturacion_snapshot_diario_fecha").on(table.fecha),
     })
+  );
+
+  export const facturacion_snapshot_auditoria = customSchema.table(
+    "facturacion_snapshot_auditoria",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(),
+      columna: varchar("columna", { length: 100 }).notNull(),
+      valor_anterior: text("valor_anterior"),
+      valor_nuevo: text("valor_nuevo"),
+      accion: varchar("accion", { length: 20 }).notNull(),
+      usuario_id: integer("usuario_id"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+    }
   );
 
   // ============================================

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -3,9 +3,11 @@ import { authMiddleware } from "./midleware";
 import {
   aplicarManualesEnSnapshotDia,
   aplicarMetaEnSnapshotsMes,
+  desbloquearDiaSnapshot,
   generarExcelFacturacionDiaria,
   generarSnapshotDiario,
   getSnapshotsDiarios,
+  guardarCeldasSnapshot,
   regenerarSnapshotRango,
 } from "../controllers/facturacionSnapshot";
 
@@ -124,6 +126,64 @@ export const facturacionSnapshotRouter = new Elysia({
         fechaFin: t.String(),
       }),
     }
+  )
+
+  // PUT - Guardar celdas editadas a mano (batch). Bloquea los días tocados. Solo ADMIN.
+  .put(
+    "/celdas",
+    async ({ body, user, set }: any) => {
+      if (user?.role !== "ADMIN") {
+        set.status = 403;
+        return { success: false, message: "Solo ADMIN puede editar el reporte" };
+      }
+      try {
+        const result = await guardarCeldasSnapshot({
+          cambios: body.cambios,
+          usuarioId: user?.id ?? null,
+        });
+        if (!result.success) set.status = 400;
+        return result;
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Error guardando celdas",
+          error: String(error),
+        };
+      }
+    },
+    {
+      body: t.Object({
+        cambios: t.Array(
+          t.Object({
+            fecha: t.String(),
+            valores: t.Record(t.String(), t.Union([t.String(), t.Number()])),
+          })
+        ),
+      }),
+    }
+  )
+
+  // POST - Desbloquear un día (vuelve a automático). Solo ADMIN.
+  .post(
+    "/desbloquear-dia",
+    async ({ body, user, set }: any) => {
+      if (user?.role !== "ADMIN") {
+        set.status = 403;
+        return { success: false, message: "Solo ADMIN puede desbloquear" };
+      }
+      try {
+        return await desbloquearDiaSnapshot(body.fecha, user?.id ?? null);
+      } catch (error) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "Error desbloqueando el día",
+          error: String(error),
+        };
+      }
+    },
+    { body: t.Object({ fecha: t.String() }) }
   )
 
   // GET - Leer snapshots. ?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD (opcionales).

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -8,6 +8,7 @@ import {
   generarSnapshotDiario,
   getSnapshotsDiarios,
   guardarCeldasSnapshot,
+  listarAuditoriaSnapshot,
   regenerarSnapshotRango,
 } from "../controllers/facturacionSnapshot";
 
@@ -184,6 +185,35 @@ export const facturacionSnapshotRouter = new Elysia({
       }
     },
     { body: t.Object({ fecha: t.String() }) }
+  )
+
+  // GET - Historial de cambios manuales (auditoría). Solo ADMIN.
+  //       ?fechaInicio=&fechaFin=&limit= (opcionales)
+  .get(
+    "/auditoria",
+    async ({ query, user, set }: any) => {
+      if (user?.role !== "ADMIN") {
+        set.status = 403;
+        return { success: false, message: "Solo ADMIN" };
+      }
+      try {
+        return await listarAuditoriaSnapshot({
+          fechaInicio: query.fechaInicio,
+          fechaFin: query.fechaFin,
+          limit: query.limit ? Number(query.limit) : undefined,
+        });
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error obteniendo auditoría", error: String(error) };
+      }
+    },
+    {
+      query: t.Object({
+        fechaInicio: t.Optional(t.String()),
+        fechaFin: t.Optional(t.String()),
+        limit: t.Optional(t.String()),
+      }),
+    }
   )
 
   // GET - Leer snapshots. ?fechaInicio=YYYY-MM-DD&fechaFin=YYYY-MM-DD (opcionales).


### PR DESCRIPTION
## Backend — celdas editables del reporte Facturación Diaria

Permite que **ADMIN** edite a mano el snapshot diario y que la regeneración automática respete esos cambios. **Solo se pueden editar los 6 totales de rubro** (el front además solo deja editar el día de hoy).

### Qué se puede editar
`capital_total, interes_cube, membresia, otros_ingresos, mora_cube, royalty` (whitelist `COLUMNAS_EDITABLES`). Todo lo demás (detalle por producto, servicios/carros/inversionistas, metas, acumulados, tendencias) es **read-only**: se deriva o se auto-calcula.

### Cómo cuadra todo al editar
Al guardar un rubro, **dentro de una transacción**:
1. upsert de las celdas + `bloqueado=true` + auditoría.
2. `recomputarTotalesDia`: `facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty` (capital NO entra) y `facturacion_mas_servicios`.
3. `recomputarAcumuladosMes`: suma corrida de los acumulados del mes.

Ejemplo: editás `otros_ingresos` de hoy de `13,472.51` → `15,000` → la fila queda bloqueada, `facturacion` se re-deriva con el nuevo valor y `facturacion_acumulado`/`acumulado_total` del mes se recalculan. Todo atómico (si algo falla, rollback).

### Lock por fila
`generarSnapshotDiario`, el cron #872, `aplicarManualesEnSnapshotDia` y `aplicarMetaEnSnapshotsMes` **saltan** los días `bloqueado=true`. Desbloquear (`POST /desbloquear-dia`) lo devuelve a automático.

### Endpoints (gate ADMIN)
- `PUT /api/facturacion-snapshot/celdas` — body: `{ cambios: [{ fecha, valores: { <rubro>: <valor> } }] }`
- `POST /api/facturacion-snapshot/desbloquear-dia` — `{ fecha }`
- `GET /api/facturacion-snapshot/auditoria?limit=` — historial de cambios (join `platform_users` → email)

### Datos / migración
Migración `drizzle/0014`: `bloqueado/bloqueado_por/bloqueado_at` + tabla `facturacion_snapshot_auditoria`. **Ya aplicada a PROD** (idempotente, 0 días bloqueados, cero impacto).

### Pruebas
- `bun test` (whitelist, validación numérica estricta, suma corrida) → 8/8.
- QA contra **clon de prod local**: invariante `acumulado == suma corrida` en los 30 días incl. tras editar+bloquear; flujo inversionistas (con IVA) desglose→snapshot.

### Validación / seguridad
`validarValores` exige decimal plano (rechaza `1e3`/`0x10`/comas); `sql.raw(columna)` solo tras pasar el whitelist; gate ADMIN en los 3 endpoints.

> Va de la mano con el PR de front (la UI). Este backend se puede mergear primero (la migración ya está en prod).
