### PR TITLE
feat(cartera): fecha de participación manual al confirmar compra de cartera

### DIFF
--- a/apps/cartera-back/src/controllers/completeEspejo.ts
+++ b/apps/cartera-back/src/controllers/completeEspejo.ts
@@ -29,6 +29,13 @@ const completeEspejoSchema = z.object({
   // en lugar del usuario del JWT / "Contabilidad". Útil cuando el flujo
   // se dispara desde el portal del inversionista.
   aceptada_por_inversionista: z.boolean().optional(),
+  // Fecha de inicio de participación (YYYY-MM-DD) elegida manualmente al
+  // confirmar una compra de cartera. Si se omite, se usa la fecha de hoy.
+  // Solo afecta al camino de compra (idsOtros); la reinversión la ignora.
+  fecha_participacion: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "fecha_participacion debe tener formato YYYY-MM-DD")
+    .optional(),
 });
 
 // ========================================
@@ -50,6 +57,7 @@ export const completeEspejo = async ({ body, set, request }: any) => {
       creditos: creditosInput,
       inversionista_id,
       aceptada_por_inversionista,
+      fecha_participacion,
     } = parseResult.data;
 
     // Normalizar a array
@@ -94,6 +102,11 @@ export const completeEspejo = async ({ body, set, request }: any) => {
           .toISOString()
           .split("T")[0];
 
+        // Fecha de participación para el camino de compra (idsOtros): la que
+        // el operador eligió manualmente en el modal de confirmar, o hoy si no
+        // se envió ninguna. La reinversión nunca usa esta fecha.
+        const fechaParticipacionCompra = fecha_participacion ?? fechaHoy;
+
         // ── Particionar inversionistas por status previo ──
         const idsReinversion = previos
           .filter((p) => p.status === "pendiente_reinversion")
@@ -135,7 +148,7 @@ export const completeEspejo = async ({ body, set, request }: any) => {
                 .update(creditos_inversionistas_espejo)
                 .set({
                   status: "completado",
-                  fecha_inicio_participacion: fechaHoy,
+                  fecha_inicio_participacion: fechaParticipacionCompra,
                   updated_at: new Date(),
                 })
                 .where(
@@ -165,7 +178,7 @@ export const completeEspejo = async ({ body, set, request }: any) => {
         if (idsOtros.length > 0) {
           await tx
             .update(creditos_inversionistas)
-            .set({ fecha_inicio_participacion: fechaHoy })
+            .set({ fecha_inicio_participacion: fechaParticipacionCompra })
             .where(
               and(
                 eq(creditos_inversionistas.credito_id, credito_id),

--- a/apps/cartera-back/src/routers/completeEspejo.ts
+++ b/apps/cartera-back/src/routers/completeEspejo.ts
@@ -15,6 +15,10 @@ export const completeEspejoRouter = new Elysia()
       ]),
       inversionista_id: t.Optional(t.Number({ minimum: 1 })),
       aceptada_por_inversionista: t.Optional(t.Boolean()),
+      // Fecha de inicio de participación (YYYY-MM-DD) elegida manualmente al
+      // confirmar una compra de cartera. Solo aplica al camino de compra; la
+      // reinversión la ignora.
+      fecha_participacion: t.Optional(t.String()),
     }),
     detail: {
       summary: "Marcar créditos espejo como completado",

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -23,6 +23,7 @@ import {
   AlertCircle,
   Clock,
   Plus,
+  CalendarDays,
 } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -74,18 +75,36 @@ const ACCION_CONFIG: Record<AccionTipo, {
   },
 };
 
+// Fecha de hoy en hora local (YYYY-MM-DD), evitando el corrimiento de UTC
+// que provoca toISOString() a partir de las 18:00 en Guatemala.
+function todayLocalISO(): string {
+  const d = new Date();
+  const off = d.getTimezoneOffset();
+  return new Date(d.getTime() - off * 60000).toISOString().split("T")[0];
+}
+
 function ModalConfirmAccion({
   open, onClose, onConfirm, tipo, creditos, isPending,
 }: {
   open: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: (fechaParticipacion?: string) => void;
   tipo: AccionTipo;
   creditos: CreditoEspejoPendiente[];
   isPending: boolean;
 }) {
   const cfg = ACCION_CONFIG[tipo];
   const totalMonto = creditos.reduce((s, c) => s + Number(c.monto_aportado_nuevo ?? c.monto_aportado), 0);
+
+  // Solo la confirmación de compra de cartera deja elegir la fecha de
+  // participación manualmente. Default: hoy. La reinversión no entra aquí.
+  const requiereFecha = tipo === "confirmar";
+  const [fechaParticipacion, setFechaParticipacion] = useState<string>(todayLocalISO);
+
+  // Reiniciar a hoy cada vez que se abre el modal.
+  useEffect(() => {
+    if (open) setFechaParticipacion(todayLocalISO());
+  }, [open]);
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
@@ -115,6 +134,27 @@ function ModalConfirmAccion({
           ))}
         </div>
 
+        {/* Fecha de participación (solo confirmar compra de cartera) */}
+        {requiereFecha && (
+          <div className="mb-5 rounded-lg border border-amber-200 bg-amber-50/50 px-3 py-3">
+            <label htmlFor="fecha-participacion" className="flex items-center gap-1.5 text-xs font-semibold text-amber-800 mb-2">
+              <CalendarDays className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+              Fecha de inicio de participación
+            </label>
+            <Input
+              id="fecha-participacion"
+              type="date"
+              value={fechaParticipacion}
+              onChange={(e) => setFechaParticipacion(e.target.value)}
+              disabled={isPending}
+              className="h-9 text-xs text-gray-900 bg-white"
+            />
+            <p className="text-[10px] text-amber-700/80 mt-1.5">
+              Se aplicará a la participación de la compra. Por defecto, hoy.
+            </p>
+          </div>
+        )}
+
         {/* Acciones */}
         <div className="flex items-center justify-between gap-3">
           <span className="text-xs text-gray-400">
@@ -124,7 +164,12 @@ function ModalConfirmAccion({
             <Button size="sm" variant="outline" onClick={onClose} disabled={isPending} className="h-8 text-xs px-4 border-gray-300 text-gray-700 hover:bg-gray-100">
               No
             </Button>
-            <Button size="sm" className={`h-8 text-xs px-4 gap-1.5 ${cfg.btnClass}`} onClick={onConfirm} disabled={isPending}>
+            <Button
+              size="sm"
+              className={`h-8 text-xs px-4 gap-1.5 ${cfg.btnClass}`}
+              onClick={() => onConfirm(requiereFecha ? fechaParticipacion : undefined)}
+              disabled={isPending || (requiereFecha && !fechaParticipacion)}
+            >
               {isPending && <Loader2 className="w-3 h-3 animate-spin" />}
               {cfg.btnLabel}
             </Button>
@@ -750,7 +795,7 @@ function InvestorCard({
   const [idsToCancel, setIdsToCancel] = useState<number[] | null>(null);
   const [cancelLabelOverride, setCancelLabelOverride] = useState<string>("");
   const [confirmingCancel, setConfirmingCancel] = useState(false);
-  const [pendingAction, setPendingAction] = useState<{ tipo: AccionTipo; creditos: CreditoEspejoPendiente[]; handler: () => void } | null>(null);
+  const [pendingAction, setPendingAction] = useState<{ tipo: AccionTipo; creditos: CreditoEspejoPendiente[]; handler: (fechaParticipacion?: string) => void } | null>(null);
   const reemplazar = useReemplazarInversionistaCredito();
   const completarEspejo = useCompletarEspejo();
   const devolverPendientes = useDevolverPendientesACube();
@@ -946,13 +991,14 @@ function InvestorCard({
     });
   }, [allReinversionKey]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleConfirmCompraCartera = useCallback(() => {
+  const handleConfirmCompraCartera = useCallback((fechaParticipacion?: string) => {
     if (selectedConfirmarIds.length === 0) return;
 
     completarEspejo.mutate(
       {
         creditos: selectedConfirmarIds,
         inversionista_id: investor.inversionista_id,
+        fecha_participacion: fechaParticipacion,
       },
       {
         onSuccess: () => {
@@ -1409,7 +1455,7 @@ function InvestorCard({
       <ModalConfirmAccion
         open={!!pendingAction}
         onClose={() => setPendingAction(null)}
-        onConfirm={() => { pendingAction?.handler(); setPendingAction(null); }}
+        onConfirm={(fecha) => { pendingAction?.handler(fecha); setPendingAction(null); }}
         tipo={pendingAction?.tipo ?? "aceptar"}
         creditos={pendingAction?.creditos ?? []}
         isPending={aceptarCompra.isPending || completarEspejo.isPending || devolverPendientes.isPending || extenderCompra.isPending}

--- a/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
+++ b/apps/carteraFront/src/private/cartera/components/SesionesPendientes.tsx
@@ -75,12 +75,18 @@ const ACCION_CONFIG: Record<AccionTipo, {
   },
 };
 
-// Fecha de hoy en hora local (YYYY-MM-DD), evitando el corrimiento de UTC
-// que provoca toISOString() a partir de las 18:00 en Guatemala.
-function todayLocalISO(): string {
-  const d = new Date();
-  const off = d.getTimezoneOffset();
-  return new Date(d.getTime() - off * 60000).toISOString().split("T")[0];
+// Fecha de hoy (YYYY-MM-DD) en el calendario de Guatemala, sin importar la
+// zona horaria configurada en el navegador del operador. Usamos un formateo
+// explícito con timeZone en lugar de getTimezoneOffset() para no corrernos
+// de día cuando el cliente no está en America/Guatemala.
+function todayGuatemalaISO(): string {
+  // El locale en-CA produce el formato YYYY-MM-DD.
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone: "America/Guatemala",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date());
 }
 
 function ModalConfirmAccion({
@@ -99,11 +105,11 @@ function ModalConfirmAccion({
   // Solo la confirmación de compra de cartera deja elegir la fecha de
   // participación manualmente. Default: hoy. La reinversión no entra aquí.
   const requiereFecha = tipo === "confirmar";
-  const [fechaParticipacion, setFechaParticipacion] = useState<string>(todayLocalISO);
+  const [fechaParticipacion, setFechaParticipacion] = useState<string>(todayGuatemalaISO);
 
   // Reiniciar a hoy cada vez que se abre el modal.
   useEffect(() => {
-    if (open) setFechaParticipacion(todayLocalISO());
+    if (open) setFechaParticipacion(todayGuatemalaISO());
   }, [open]);
 
   return (

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3920,6 +3920,10 @@ export async function agregarInversionistaCreditoService(
 export interface CompletarEspejoPayload {
   creditos: number[];
   inversionista_id: number;
+  // Fecha de inicio de participación (YYYY-MM-DD) elegida manualmente al
+  // confirmar una compra de cartera. Solo se envía en el flujo de compra;
+  // la reinversión la omite.
+  fecha_participacion?: string;
 }
 
 export interface CompletarEspejoResponse {


### PR DESCRIPTION
## Qué hace

Al **confirmar una compra de cartera** (paso 2, status `pendiente_revision`), el modal ahora muestra un selector de **fecha de inicio de participación** con default **hoy**. La fecha elegida se aplica como `fecha_inicio_participacion` al completar el espejo.

La **aceptación** (paso 1) y la **reinversión** quedan exactamente igual: no muestran el selector ni envían fecha.

## Cambios

**Backend** (`apps/cartera-back`)
- `routers/completeEspejo.ts`: nuevo campo opcional `fecha_participacion` en el body.
- `controllers/completeEspejo.ts`: valida `fecha_participacion` (`YYYY-MM-DD`) y la usa como `fecha_inicio_participacion` **solo en el camino de compra** (`idsOtros`), en el espejo y en la tabla padre `creditos_inversionistas`. Si se omite, se usa hoy. El camino de reinversión no se toca.

**Frontend** (`apps/carteraFront`)
- `services/services.ts`: `fecha_participacion?: string` en `CompletarEspejoPayload`.
- `components/SesionesPendientes.tsx`: el modal de confirmar compra renderiza un `<input type="date">` (default hoy, se resetea al abrir) y lo envía en el mutation. Helper `todayLocalISO()` para usar la fecha **local** de Guatemala y evitar el corrimiento de UTC de `toISOString()` después de las 18:00.

## Notas
- Solo afecta el flujo de compra; la reinversión no envía la fecha y el backend la ignoraría aunque llegara.

🤖 Generated with [Claude Code](https://claude.com/claude-code)