### PR TITLE
fix(crm): preserve cartera credit rows

### DIFF
--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { leadSourceEnum } from "../db/schema/crm";
 import {
+	buildCarteraMatchedClientRows,
 	buildCarteraOnlyClientRow,
 	calculateCarteraClientStats,
 	getClientCreditSifcosFromCartera,
@@ -99,6 +100,64 @@ describe("buildCarteraOnlyClientRow", () => {
 		expect(row.opportunities).toEqual([]);
 		expect(row.closedOpportunitiesCount).toBe(0);
 		expect(row.totalClosedValue).toBe(12500);
+	});
+});
+
+describe("buildCarteraMatchedClientRows", () => {
+	const lead = {
+		id: "lead-1",
+		firstName: "Ana",
+		lastName: "Pérez",
+		email: "ana@example.com",
+		phone: "5555-0000",
+		dpi: "1234567890101",
+		createdAt: new Date("2026-01-01T00:00:00.000Z"),
+		updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+	};
+
+	test("builds one matched row per current cartera credit for the same lead", () => {
+		const rows = buildCarteraMatchedClientRows({
+			lead,
+			leadOpportunities: [
+				{ id: "opp-1", numeroSifco: "SIFCO-1", value: "5000.00", isClosed: true },
+				{ id: "opp-2", numeroSifco: "SIFCO-2", value: "7000.00", isClosed: true },
+			],
+			creditAnalysis: null,
+			carteraCreditBySifco: new Map([
+				[
+					"SIFCO-1",
+					{ creditos: { numero_credito_sifco: "SIFCO-1", deudatotal: "1200.00" } },
+				],
+				[
+					"SIFCO-2",
+					{ creditos: { numero_credito_sifco: "SIFCO-2", deudatotal: "3400.00" } },
+				],
+			]),
+		});
+
+		expect(rows).toHaveLength(2);
+		expect(rows.map((row) => row.carteraCredit?.numeroSifco)).toEqual([
+			"SIFCO-1",
+			"SIFCO-2",
+		]);
+	});
+
+	test("uses cartera debt instead of opportunity value for matched rows", () => {
+		const [row] = buildCarteraMatchedClientRows({
+			lead,
+			leadOpportunities: [
+				{ id: "opp-1", numeroSifco: "SIFCO-1", value: "5000.00", isClosed: true },
+			],
+			creditAnalysis: null,
+			carteraCreditBySifco: new Map([
+				[
+					"SIFCO-1",
+					{ creditos: { numero_credito_sifco: "SIFCO-1", deudatotal: "1200.00" } },
+				],
+			]),
+		});
+
+		expect(row.totalClosedValue).toBe(1200);
 	});
 });
 

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -180,6 +180,21 @@ describe("calculateCarteraClientStats", () => {
 		expect(stats.missingCrmCount).toBe(0);
 	});
 
+	test("counts sales clients by matched cartera credits", () => {
+		const stats = calculateCarteraClientStats({
+			carteraCredits: [
+				{ creditos: { numero_credito_sifco: "A-1", deudatotal: "100.00" } },
+				{ creditos: { numero_credito_sifco: "A-2", deudatotal: "200.00" } },
+			],
+			matchedSifcos: new Set(["A-1", "A-2"]),
+			uniqueLeadCount: 1,
+			scopedOpportunityCount: 2,
+			userRole: "sales",
+		});
+
+		expect(stats.totalClients).toBe(2);
+	});
+
 	test("uses full cartera totals for non-sales users", () => {
 		const stats = calculateCarteraClientStats({
 			carteraCredits: [

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -127,6 +127,73 @@ type CarteraClientCredit = {
 	} | null;
 };
 
+type ClientRowOpportunity = {
+	id: string;
+	title?: string;
+	value?: string | null;
+	creditType?: string | null;
+	numeroSifco: string | null;
+	status?: string;
+	createdAt?: Date;
+	stage?: {
+		id: string;
+		name: string;
+		closurePercentage: number;
+		color: string | null;
+	} | null;
+	isClosed: boolean;
+};
+
+type MatchedClientLead = {
+	id: string;
+	firstName: string;
+	middleName?: string | null;
+	lastName: string;
+	secondLastName?: string | null;
+	email: string | null;
+	phone: string | null;
+	dpi: string | null;
+	nit?: string | null;
+	age?: number | null;
+	clientType?: string | null;
+	maritalStatus?: string | null;
+	dependents?: number | null;
+	monthlyIncome?: string | null;
+	loanAmount?: string | null;
+	occupation?: string | null;
+	workTime?: string | null;
+	ownsHome?: boolean | null;
+	ownsVehicle?: boolean | null;
+	hasCreditCard?: boolean | null;
+	jobTitle?: string | null;
+	direccion?: string | null;
+	departamento?: string | null;
+	municipio?: string | null;
+	zona?: string | null;
+	assignedTo?: string | null;
+	createdAt: Date;
+	updatedAt: Date;
+	assignedUser?: { id: string | null; name: string | null } | null;
+};
+
+type MatchedClientRow = MatchedClientLead & {
+	rowId: string;
+	opportunities: ClientRowOpportunity[];
+	creditAnalysis: unknown;
+	totalClosedValue: number;
+	closedOpportunitiesCount: number;
+	crmMatchStatus: "matched";
+	carteraCredit: ReturnType<typeof buildCarteraOnlyClientRow>["carteraCredit"];
+};
+
+function getCarteraCreditAmount(credit: CarteraClientCredit) {
+	return (
+		Number.parseFloat(
+			credit.creditos?.deudatotal || credit.creditos?.capital || "0",
+		) || 0
+	);
+}
+
 function getCurrentCarteraMonthParams(now = new Date()) {
 	const [anio, mes] = toDateStrGT(now).split("-").map(Number);
 	return { mes, anio };
@@ -201,13 +268,11 @@ export function buildCarteraOnlyClientRow(credit: CarteraClientCredit) {
 	const createdAt = credit.creditos?.fecha_creacion
 		? new Date(credit.creditos.fecha_creacion)
 		: new Date();
-	const totalValue =
-		Number.parseFloat(
-			credit.creditos?.deudatotal || credit.creditos?.capital || "0",
-		) || 0;
+	const totalValue = getCarteraCreditAmount(credit);
 
 	return {
 		id: `cartera-${sifco}`,
+		rowId: `cartera-${sifco}`,
 		...name,
 		email: "",
 		phone: null,
@@ -251,6 +316,37 @@ export function buildCarteraOnlyClientRow(credit: CarteraClientCredit) {
 	};
 }
 
+export function buildCarteraMatchedClientRows(params: {
+	lead: MatchedClientLead;
+	leadOpportunities: ClientRowOpportunity[];
+	creditAnalysis: unknown;
+	carteraCreditBySifco: Map<string, CarteraClientCredit>;
+}): MatchedClientRow[] {
+	const rows: MatchedClientRow[] = [];
+
+	for (const [sifco, credit] of params.carteraCreditBySifco) {
+		const matchingOpportunities = params.leadOpportunities.filter(
+			(opp) => opp.numeroSifco === sifco,
+		);
+		if (matchingOpportunities.length === 0) continue;
+
+		rows.push({
+			...params.lead,
+			rowId: `${params.lead.id}-${sifco}`,
+			opportunities: matchingOpportunities,
+			creditAnalysis: params.creditAnalysis,
+			totalClosedValue: getCarteraCreditAmount(credit),
+			closedOpportunitiesCount: matchingOpportunities.filter(
+				(opp) => opp.isClosed,
+			).length,
+			crmMatchStatus: "matched",
+			carteraCredit: buildCarteraOnlyClientRow(credit).carteraCredit,
+		});
+	}
+
+	return rows;
+}
+
 export function calculateCarteraClientStats(params: {
 	carteraCredits: CarteraClientCredit[];
 	matchedSifcos: Set<string>;
@@ -273,11 +369,7 @@ export function calculateCarteraClientStats(params: {
 				: params.carteraCredits.length,
 		totalClosedOpportunities: params.scopedOpportunityCount,
 		totalValue: visibleCredits.reduce(
-			(sum, credit) =>
-				sum +
-				(Number.parseFloat(
-					credit.creditos?.deudatotal || credit.creditos?.capital || "0",
-				) || 0),
+			(sum, credit) => sum + getCarteraCreditAmount(credit),
 			0,
 		),
 		missingCrmCount:
@@ -3434,41 +3526,20 @@ export const crmRouter = {
 			);
 
 			// Combine leads with their opportunities and credit analysis
-			const matchedSifcos = new Set<string>();
-			const crmRows = clientLeads.map((lead) => {
+			const crmRows = clientLeads.flatMap((lead) => {
 				const leadOpportunities = opportunitiesByLead[lead.id] || [];
-				for (const opp of leadOpportunities) {
-					if (opp.numeroSifco && clientCreditSifcos.includes(opp.numeroSifco)) {
-						matchedSifcos.add(opp.numeroSifco);
-					}
-				}
-
-				const primaryCredit = leadOpportunities
-					.map((opp: any) =>
-						opp.numeroSifco ? carteraCreditBySifco.get(opp.numeroSifco) : null,
-					)
-					.find(Boolean);
-
-				return {
-					...lead,
-					opportunities: leadOpportunities,
+				return buildCarteraMatchedClientRows({
+					lead,
+					leadOpportunities,
 					creditAnalysis: creditAnalysisMap[lead.id] || null,
-					totalClosedValue: leadOpportunities
-						.filter((opp: any) => opp.isClosed)
-						.reduce(
-							(sum: number, opp: any) =>
-								sum + (Number.parseFloat(opp.value || "0") || 0),
-							0,
-						),
-					closedOpportunitiesCount: leadOpportunities.filter(
-						(opp: any) => opp.isClosed,
-					).length,
-					crmMatchStatus: "matched" as const,
-					carteraCredit: primaryCredit
-						? buildCarteraOnlyClientRow(primaryCredit).carteraCredit
-						: null,
-				};
+					carteraCreditBySifco,
+				});
 			});
+			const matchedSifcos = new Set(
+				crmRows
+					.map((row) => row.carteraCredit?.numeroSifco)
+					.filter((sifco): sifco is string => Boolean(sifco)),
+			);
 
 			const carteraOnlyRows = carteraCredits
 				.filter((credit) => {

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -365,7 +365,7 @@ export function calculateCarteraClientStats(params: {
 	return {
 		totalClients:
 			params.userRole === "sales"
-				? params.uniqueLeadCount
+				? params.matchedSifcos.size
 				: params.carteraCredits.length,
 		totalClosedOpportunities: params.scopedOpportunityCount,
 		totalValue: visibleCredits.reduce(

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { isClosedCreditReportCarteraStatusIncluded } from "./reports";
+import {
+	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
+	isClosedCreditReportCarteraStatusIncluded,
+} from "./reports";
 
 describe("isClosedCreditReportCarteraStatusIncluded", () => {
 	test("only includes currently active cartera credit states", () => {
@@ -9,5 +12,13 @@ describe("isClosedCreditReportCarteraStatusIncluded", () => {
 		expect(isClosedCreditReportCarteraStatusIncluded("CANCELADO")).toBe(false);
 		expect(isClosedCreditReportCarteraStatusIncluded("INCOBRABLE")).toBe(false);
 		expect(isClosedCreditReportCarteraStatusIncluded(null)).toBe(false);
+	});
+});
+
+describe("CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE", () => {
+	test("keeps status lookups on the GET path because bulk POST requires estado", () => {
+		expect(CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE).toBeLessThanOrEqual(
+			50,
+		);
 	});
 });

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { isClosedCreditReportContractStateIncluded } from "./reports";
+import { isClosedCreditReportCarteraStatusIncluded } from "./reports";
 
-describe("isClosedCreditReportContractStateIncluded", () => {
-	test("only includes credits with an active contract state", () => {
-		expect(isClosedCreditReportContractStateIncluded("activo")).toBe(true);
-		expect(isClosedCreditReportContractStateIncluded("completado")).toBe(false);
-		expect(isClosedCreditReportContractStateIncluded("incobrable")).toBe(false);
-		expect(isClosedCreditReportContractStateIncluded("recuperado")).toBe(false);
-		expect(isClosedCreditReportContractStateIncluded(null)).toBe(false);
+describe("isClosedCreditReportCarteraStatusIncluded", () => {
+	test("only includes currently active cartera credit states", () => {
+		expect(isClosedCreditReportCarteraStatusIncluded("ACTIVO")).toBe(true);
+		expect(isClosedCreditReportCarteraStatusIncluded("MOROSO")).toBe(true);
+		expect(isClosedCreditReportCarteraStatusIncluded("EN_CONVENIO")).toBe(true);
+		expect(isClosedCreditReportCarteraStatusIncluded("CANCELADO")).toBe(false);
+		expect(isClosedCreditReportCarteraStatusIncluded("INCOBRABLE")).toBe(false);
+		expect(isClosedCreditReportCarteraStatusIncluded(null)).toBe(false);
 	});
 });

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
 	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
+	enforceClosedCreditReportLimit,
 	isClosedCreditReportCarteraStatusIncluded,
 } from "./reports";
 
@@ -19,6 +20,26 @@ describe("CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE", () => {
 	test("keeps status lookups on the GET path because bulk POST requires estado", () => {
 		expect(CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE).toBeLessThanOrEqual(
 			50,
+		);
+	});
+});
+
+describe("enforceClosedCreditReportLimit", () => {
+	test("allows candidate ranges over 10000 when filtered rows are within the limit", () => {
+		const filteredRows = Array.from({ length: 10_000 }, (_, index) => ({
+			id: index,
+		}));
+
+		expect(() => enforceClosedCreditReportLimit(filteredRows)).not.toThrow();
+	});
+
+	test("rejects filtered report rows over the export limit", () => {
+		const filteredRows = Array.from({ length: 10_001 }, (_, index) => ({
+			id: index,
+		}));
+
+		expect(() => enforceClosedCreditReportLimit(filteredRows)).toThrow(
+			"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
 		);
 	});
 });

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -48,6 +48,7 @@ const CLOSED_CREDIT_REPORT_CARTERA_STATUSES: StatusCreditEnum[] = [
 	"MOROSO",
 	"EN_CONVENIO",
 ];
+export const CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE = 50;
 
 export function isClosedCreditReportCarteraStatusIncluded(
 	status: StatusCreditEnum | null,
@@ -59,10 +60,16 @@ async function getClosedCreditReportCarteraStatuses(sifcos: string[]) {
 	const uniqueSifcos = [...new Set(sifcos.filter(Boolean))];
 	const statuses = new Map<string, StatusCreditEnum>();
 	const [anio, mes] = toDateStrGT(new Date()).split("-").map(Number);
-	const chunkSize = 100;
 
-	for (let index = 0; index < uniqueSifcos.length; index += chunkSize) {
-		const chunk = uniqueSifcos.slice(index, index + chunkSize);
+	for (
+		let index = 0;
+		index < uniqueSifcos.length;
+		index += CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE
+	) {
+		const chunk = uniqueSifcos.slice(
+			index,
+			index + CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
+		);
 		const response = await carteraBackClient.getAllCreditos({
 			mes,
 			anio,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -26,6 +26,9 @@ import {
 	protectedProcedure,
 	tiempoCierreReportProcedure,
 } from "../lib/orpc";
+import { toDateStrGT } from "../lib/guatemala-month-window";
+import { carteraBackClient } from "../services/cartera-back-client";
+import type { StatusCreditEnum } from "../types/cartera-back";
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
 
@@ -40,10 +43,43 @@ const closedCreditsReportInputSchema = z.object({
 	endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 });
 
-export function isClosedCreditReportContractStateIncluded(
-	estado: string | null,
+const CLOSED_CREDIT_REPORT_CARTERA_STATUSES: StatusCreditEnum[] = [
+	"ACTIVO",
+	"MOROSO",
+	"EN_CONVENIO",
+];
+
+export function isClosedCreditReportCarteraStatusIncluded(
+	status: StatusCreditEnum | null,
 ) {
-	return estado === "activo";
+	return status ? CLOSED_CREDIT_REPORT_CARTERA_STATUSES.includes(status) : false;
+}
+
+async function getClosedCreditReportCarteraStatuses(sifcos: string[]) {
+	const uniqueSifcos = [...new Set(sifcos.filter(Boolean))];
+	const statuses = new Map<string, StatusCreditEnum>();
+	const [anio, mes] = toDateStrGT(new Date()).split("-").map(Number);
+	const chunkSize = 100;
+
+	for (let index = 0; index < uniqueSifcos.length; index += chunkSize) {
+		const chunk = uniqueSifcos.slice(index, index + chunkSize);
+		const response = await carteraBackClient.getAllCreditos({
+			mes,
+			anio,
+			page: 1,
+			perPage: chunk.length,
+			numeros_credito_sifco: chunk,
+		});
+
+		for (const row of response.data) {
+			statuses.set(
+				row.creditos.numero_credito_sifco,
+				row.creditos.statusCredit,
+			);
+		}
+	}
+
+	return statuses;
 }
 
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
@@ -250,7 +286,6 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 				and(
 					gte(firstClosedStageDates.firstClosedStageAt, start),
 					lte(firstClosedStageDates.firstClosedStageAt, end),
-					eq(contratosFinanciamiento.estado, "activo"),
 				),
 			)
 			.orderBy(desc(firstClosedStageDates.firstClosedStageAt))
@@ -263,7 +298,15 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 			});
 		}
 
-		return rows;
+		const carteraStatuses = await getClosedCreditReportCarteraStatuses(
+			rows.map((row) => row.numeroCredito),
+		);
+
+		return rows.filter((row) =>
+			isClosedCreditReportCarteraStatusIncluded(
+				carteraStatuses.get(row.numeroCredito) ?? null,
+			),
+		);
 	});
 
 /**

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -56,6 +56,15 @@ export function isClosedCreditReportCarteraStatusIncluded(
 	return status ? CLOSED_CREDIT_REPORT_CARTERA_STATUSES.includes(status) : false;
 }
 
+export function enforceClosedCreditReportLimit<T>(rows: T[]) {
+	if (rows.length > 10_000) {
+		throw new ORPCError("BAD_REQUEST", {
+			message:
+				"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
+		});
+	}
+}
+
 async function getClosedCreditReportCarteraStatuses(sifcos: string[]) {
 	const uniqueSifcos = [...new Set(sifcos.filter(Boolean))];
 	const statuses = new Map<string, StatusCreditEnum>();
@@ -295,25 +304,20 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 					lte(firstClosedStageDates.firstClosedStageAt, end),
 				),
 			)
-			.orderBy(desc(firstClosedStageDates.firstClosedStageAt))
-			.limit(10_001);
-
-		if (rows.length > 10_000) {
-			throw new ORPCError("BAD_REQUEST", {
-				message:
-					"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
-			});
-		}
+			.orderBy(desc(firstClosedStageDates.firstClosedStageAt));
 
 		const carteraStatuses = await getClosedCreditReportCarteraStatuses(
 			rows.map((row) => row.numeroCredito),
 		);
 
-		return rows.filter((row) =>
+		const activeRows = rows.filter((row) =>
 			isClosedCreditReportCarteraStatusIncluded(
 				carteraStatuses.get(row.numeroCredito) ?? null,
 			),
 		);
+		enforceClosedCreditReportLimit(activeRows);
+
+		return activeRows;
 	});
 
 /**

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -187,6 +187,7 @@ type CreditAnalysisData = {
 // Type definition for client data
 type ClientData = {
 	id: string;
+	rowId?: string;
 	firstName: string;
 	middleName?: string | null;
 	lastName: string;
@@ -688,7 +689,7 @@ function RouteComponent() {
 								<TableBody>
 									{clients.map((clientData) => (
 										<TableRow
-											key={clientData.id}
+											key={clientData.rowId ?? clientData.id}
 											className="cursor-pointer hover:bg-muted/50"
 											onClick={() => handleViewDetails(clientData)}
 										>


### PR DESCRIPTION
## Resumen
- Genera una fila por cada crédito vigente de cartera asociado al mismo lead, evitando ocultar créditos adicionales.
- Usa la deuda actual de cartera (`deudatotal`/`capital`) para los totales de filas con match CRM.
- Filtra el reporte de créditos cerrados por el estado actual en cartera (`ACTIVO`, `MOROSO`, `EN_CONVENIO`) en lugar del estado local del contrato.
- Limita la consulta de estados de cartera a chunks de 50 SIFCOs para mantenerse en el path GET; el POST bulk de cartera-back exige `estado` y aquí necesitamos consultar todos los estados.

## Verificación
- `bun test apps/server/src/routers/crm-get-leads-input.test.ts`
- `bun test apps/server/src/routers/reports.test.ts`
- `bun run check-all`

Follow-up de #892, que fue mergeado antes de incluir estos fixes de review.
