### PR TITLE
feat(cartera-back): Royalty y Otros ingresos editables completos + hora GT en historial

### DIFF
--- a/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
@@ -6,20 +6,23 @@ mock.module("../database", () => ({ db: {} }));
 const { esColumnaEditable, validarValores } = await import("./facturacionSnapshot");
 
 describe("esColumnaEditable", () => {
-  it("acepta SOLO los 6 totales de rubro", () => {
-    expect(esColumnaEditable("capital_total")).toBe(true);
-    expect(esColumnaEditable("interes_cube")).toBe(true);
-    expect(esColumnaEditable("membresia")).toBe(true);
-    expect(esColumnaEditable("otros_ingresos")).toBe(true);
-    expect(esColumnaEditable("mora_cube")).toBe(true);
+  it("acepta TODO Royalty y TODO Otros ingresos (detalle + total)", () => {
     expect(esColumnaEditable("royalty")).toBe(true);
+    expect(esColumnaEditable("roy_hipotecario")).toBe(true);
+    expect(esColumnaEditable("nuevo_roy_autocompras")).toBe(true);
+    expect(esColumnaEditable("otros_ingresos")).toBe(true);
+    expect(esColumnaEditable("oi_autocompras")).toBe(true);
+    expect(esColumnaEditable("administrativos")).toBe(true);
+    expect(esColumnaEditable("otros_cobros")).toBe(true);
   });
-  it("rechaza detalle por producto, facturación, servicios, metas y acumulados", () => {
+  it("rechaza Capital/Interés/Membresía/Mora, servicios, metas y acumulados", () => {
     expect(esColumnaEditable("id")).toBe(false);
     expect(esColumnaEditable("fecha")).toBe(false);
     expect(esColumnaEditable("bloqueado")).toBe(false);
-    expect(esColumnaEditable("roy_hipotecario")).toBe(false); // detalle producto
-    expect(esColumnaEditable("administrativos")).toBe(false);
+    expect(esColumnaEditable("capital_total")).toBe(false);
+    expect(esColumnaEditable("interes_cube")).toBe(false);
+    expect(esColumnaEditable("membresia")).toBe(false);
+    expect(esColumnaEditable("mora_cube")).toBe(false);
     expect(esColumnaEditable("facturacion")).toBe(false); // se DERIVA de rubros
     expect(esColumnaEditable("servicios_seguro_gps")).toBe(false);
     expect(esColumnaEditable("ingreso_carros")).toBe(false);
@@ -33,19 +36,19 @@ describe("esColumnaEditable", () => {
 
 describe("validarValores", () => {
   it("ok con rubros editables y números", () => {
-    const r = validarValores({ capital_total: "100.50", royalty: "0" });
+    const r = validarValores({ royalty: "100.50", otros_ingresos: "0" });
     expect(r.ok).toBe(true);
     expect(r.invalidas).toEqual([]);
   });
   it("marca columna no editable", () => {
-    const r = validarValores({ fecha: "2026-06-10" });
-    expect(r.ok).toBe(false);
-    expect(r.invalidas).toContain("fecha");
-  });
-  it("marca valor no numérico", () => {
-    const r = validarValores({ capital_total: "abc" });
+    const r = validarValores({ capital_total: "100" });
     expect(r.ok).toBe(false);
     expect(r.invalidas).toContain("capital_total");
+  });
+  it("marca valor no numérico", () => {
+    const r = validarValores({ royalty: "abc" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("royalty");
   });
 });
 

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -955,7 +955,12 @@ export async function listarAuditoriaSnapshot(opts: {
     : sql``;
   const res = await db.execute(sql`
     SELECT a.id, a.fecha::text AS fecha, a.columna, a.valor_anterior, a.valor_nuevo,
-           a.accion, a.usuario_id, u.email AS usuario_email, a.created_at
+           a.accion, a.usuario_id, u.email AS usuario_email,
+           -- created_at en hora de Guatemala, YA formateado (a prueba de la zona
+           -- horaria de node/navegador): el guardado se interpreta como UTC y se
+           -- convierte a America/Guatemala.
+           to_char((a.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'America/Guatemala',
+                   'DD/MM/YYYY HH24:MI:SS') AS created_at
     FROM cartera.facturacion_snapshot_auditoria a
     LEFT JOIN cartera.platform_users u ON u.id = a.usuario_id
     ${whereSql}

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -795,6 +795,23 @@ export async function guardarCeldasSnapshot(input: {
   if (!Array.isArray(cambios) || cambios.length === 0) {
     return { success: false, message: "Sin cambios" };
   }
+
+  // SOLO se puede editar el DÍA DE HOY (zona Guatemala). Se valida en el server
+  // además del front: un token ADMIN/script podría hacer PUT de una fecha vieja y
+  // bloquear una fila histórica, cambiando el mes reportado.
+  const hoyRes = await db.execute(
+    sql`SELECT (now() AT TIME ZONE 'America/Guatemala')::date::text AS hoy`
+  );
+  const hoyGT = ((hoyRes as any).rows ?? hoyRes)[0]?.hoy as string;
+  const fueraDeHoy = cambios.filter((c) => c.fecha !== hoyGT);
+  if (fueraDeHoy.length > 0) {
+    return {
+      success: false,
+      message: `Solo se puede editar el día de hoy (${hoyGT}).`,
+      fechas_invalidas: fueraDeHoy.map((c) => c.fecha),
+    };
+  }
+
   // Validar todo antes de escribir.
   for (const c of cambios) {
     const v = validarValores(c.valores);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -10,22 +10,18 @@ const LOGO_URL =
   "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
 
 // ── Edición manual: whitelist de columnas editables + validación ──────────────
-// SOLO los 6 TOTALES de rubro (los que se ven colapsados). El detalle por
-// producto, servicios/inversionistas/carros, metas, y los ACUMULADOS/tendencias
-// quedan fuera: read-only. `facturacion` (total del día) se DERIVA de los rubros
-// (interes+membresia+otros+mora+royalty) — ver recomputarTotalesDia. Los
-// acumulados se auto-calculan (suma corrida). El front además solo deja editar HOY.
-export const RUBROS_TOTALES_EDITABLES = [
-  "capital_total",
-  "interes_cube",
-  "membresia",
-  "otros_ingresos",
-  "mora_cube",
-  "royalty",
-] as const;
-export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set(
-  RUBROS_TOTALES_EDITABLES
-);
+// Editables SOLO los grupos ROYALTY y OTROS INGRESOS, COMPLETOS (detalle por
+// producto + total + administrativos + otros_cobros). Capital, Interés,
+// Membresía, Mora, servicios/inversionistas/carros, metas y los acumulados/
+// tendencias quedan read-only. `facturacion` se DERIVA (interes+membresia+
+// otros_ingresos+mora+royalty, usando los totales editados) y los acumulados se
+// auto-calculan (suma corrida). El front además solo deja editar HOY.
+export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set([
+  // Royalty (completo)
+  "roy_autocompras","roy_sobre_vehiculo","nuevo_roy_autocompras","roy_hipotecario","roy_extra_financiamiento","roy_reestructura","royalty",
+  // Otros ingresos (completo, incl. administrativos y otros_cobros)
+  "oi_autocompras","oi_sobre_vehiculo","nuevo_oi_autocompras","oi_hipotecario","oi_extra_financiamiento","oi_reestructura","otros_ingresos","administrativos","otros_cobros",
+]);
 
 export function esColumnaEditable(col: string): boolean {
   return COLUMNAS_EDITABLES.has(col);
@@ -110,9 +106,9 @@ export async function recomputarTotalesDia(fecha: string, exec: any = db) {
       facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty,
       facturacion_mas_servicios =
         interes_cube + membresia + otros_ingresos + mora_cube + royalty + servicios_seguro_gps,
-      -- otros_cobros = otros_ingresos − administrativos (igual que generarSnapshotDiario);
-      -- al editar otros_ingresos debe refrescarse o queda stale en el día bloqueado.
-      otros_cobros = otros_ingresos - administrativos,
+      -- NO se recalcula otros_cobros: ahora es columna EDITABLE (grupo Otros
+      -- ingresos), el usuario la maneja a mano. Si la quiere = otros_ingresos −
+      -- administrativos, la edita él (todo libre en ese grupo).
       updated_at = now()
     WHERE fecha = ${fecha}::date
   `);
@@ -442,9 +438,8 @@ export async function generarSnapshotDiario(fecha: string) {
 //    los montos importados). Si el día no tiene fila, la genera primero.
 //    - administrativos = SUM(gastos del día); otros_cobros = otros_ingresos − administrativos
 //    - ingreso_carros = SUM(carros del día); acumulado_total = fact_acum + acum_servicios + carros MTD
-//    NO lleva guard de bloqueado: ninguna de estas columnas es editable a mano (lo
-//    editable son los 6 totales de rubro) → deben refrescar también en días bloqueados.
-//    El lock solo lo respeta generarSnapshotDiario (que sí reescribe los rubros).
+//    SÍ respeta el lock: administrativos y otros_cobros son EDITABLES (grupo Otros
+//    ingresos), así que en un día bloqueado NO debe pisarlos → salta días bloqueados.
 export async function aplicarManualesEnSnapshotDia(fecha: string) {
   const existe = await db
     .select({ id: facturacion_snapshot_diario.id })
@@ -471,6 +466,7 @@ export async function aplicarManualesEnSnapshotDia(fecha: string) {
           + COALESCE((SELECT SUM(monto) FROM cartera.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
         updated_at = now()
     WHERE s.fecha = ${fecha}::date
+      AND s.bloqueado = false
   `);
   return { success: true };
 }


### PR DESCRIPTION
## Ajustes al backend de celdas editables (sobre lo ya desplegado en #895)

Cambios después del despliegue de #895:

### 1. Editables = Royalty y Otros ingresos COMPLETOS
`COLUMNAS_EDITABLES` ahora incluye **todo** el grupo Royalty (`roy_*` + `royalty`) y **todo** Otros ingresos (`oi_*` + `otros_ingresos` + `administrativos` + `otros_cobros`). Capital/Interés/Membresía/Mora → read-only. (Antes eran solo los 6 totales de rubro.)

- `recomputarTotalesDia` **ya no deriva** `otros_cobros` (ahora es editable a mano). Sigue derivando `facturacion = interes+membresia+otros_ingresos+mora+royalty` y `facturacion_mas_servicios` desde los **totales**.
- `aplicarManualesEnSnapshotDia` **vuelve a saltar días bloqueados** (`AND s.bloqueado=false`): como `administrativos`/`otros_cobros` ahora son editables, no debe pisarlos.

### 2. Historial de cambios en hora de Guatemala
`GET /auditoria` devuelve `created_at` ya formateado en hora GT vía SQL (a prueba de la zona horaria de node/navegador):
```sql
to_char((a.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'America/Guatemala', 'DD/MM/YYYY HH24:MI:SS')
```
Verificado: prod tz=UTC → `21:26 UTC → 15:26 GT (3:26 p.m.)` ✓.

### Ejemplo
ADMIN edita `royalty` u `oi_hipotecario` de hoy → se guarda y bloquea el día; `facturacion` se re-deriva del total `royalty`/`otros_ingresos`; acumulados recalculan (suma corrida). El historial muestra la edición con hora GT.

### Pruebas
`bun test` 8/8; typecheck limpio; QA contra clon de prod.

### Trade-offs aceptados ("todo libre" en esos 2 grupos)
- Editar el **detalle** sin tocar el **total** los deja inconsistentes (el total/facturación/acumulados solo cambian si editás el total). Es intencional.
- Un día **bloqueado** no refresca `ingreso_carros`/`administrativos` vía `aplicarManuales` (caso borde: agregar un carro a un día ya editado a mano).

> ⚠️ **Mergear ANTES que el PR de front** (el front muestra `created_at` crudo asumiendo que este endpoint ya lo devuelve en GT).
