### PR TITLE
feat(cartera-front): Royalty y Otros editables completos + historial legible (hora GT)

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -111,17 +111,19 @@ const GRUPOS: Grupo[] = [
   },
 ];
 
-// ÚNICAS columnas editables: los 6 TOTALES de rubro. Todo lo demás (detalle por
-// producto, servicios/carros/inversionistas, metas, y los acumulados/tendencias)
-// es de solo lectura. `Facturación` se deriva de estos rubros en el backend y los
+// Editables: grupos ROYALTY y OTROS INGRESOS COMPLETOS (detalle por producto +
+// total + administrativos + otros_cobros). Capital, Interés, Membresía, Mora,
+// servicios/carros/inversionistas, metas y los acumulados/tendencias quedan
+// read-only. `Facturación` se deriva en el backend de los totales editados y los
 // acumulados se recalculan como suma corrida. Además solo se edita el día de HOY.
 const EDITABLES = new Set<string>([
-  "capital_total",
-  "interes_cube",
-  "membresia",
-  "otros_ingresos",
-  "mora_cube",
-  "royalty",
+  // Royalty (completo)
+  "roy_autocompras", "roy_sobre_vehiculo", "nuevo_roy_autocompras",
+  "roy_hipotecario", "roy_extra_financiamiento", "roy_reestructura", "royalty",
+  // Otros ingresos (completo, incl. administrativos y otros_cobros)
+  "oi_autocompras", "oi_sobre_vehiculo", "nuevo_oi_autocompras",
+  "oi_hipotecario", "oi_extra_financiamiento", "oi_reestructura",
+  "otros_ingresos", "administrativos", "otros_cobros",
 ]);
 
 export function FacturacionDiaria() {
@@ -515,7 +517,7 @@ export function FacturacionDiaria() {
               ) : (histQuery.data?.data ?? []).length === 0 ? (
                 <p className="text-center py-10 text-gray-400">Sin cambios registrados.</p>
               ) : (
-                <table className="w-full text-sm border-collapse">
+                <table className="w-full text-sm border-collapse text-gray-800">
                   <thead>
                     <tr className="bg-blue-50 text-blue-800 text-left">
                       <th className="px-3 py-2 font-semibold">Cuándo</th>
@@ -530,10 +532,10 @@ export function FacturacionDiaria() {
                   <tbody>
                     {(histQuery.data?.data ?? []).map((a: AuditoriaSnapshot) => (
                       <tr key={a.id} className="border-b border-gray-100">
+                        {/* created_at ya viene formateado en hora de Guatemala
+                            desde el backend (to_char en SQL) → se muestra tal cual. */}
                         <td className="px-3 py-2 whitespace-nowrap text-gray-500">
-                          {a.created_at
-                            ? new Date(a.created_at).toLocaleString("es-GT")
-                            : "—"}
+                          {a.created_at ?? "—"}
                         </td>
                         <td className="px-3 py-2 whitespace-nowrap">{a.fecha}</td>
                         <td className="px-3 py-2">


### PR DESCRIPTION
## Ajustes al front de celdas editables (sobre lo ya desplegado en #896)

Cambios después del despliegue de #896:

### 1. Editables = Royalty y Otros ingresos COMPLETOS
`EDITABLES` ahora = las 16 columnas de los grupos **Royalty** (detalle `roy_*` + total) y **Otros ingresos** (detalle `oi_*` + total + Administrativos + Otros cobros). Capital/Interés/Membresía/Mora → read-only. Sigue: solo **ADMIN**, solo el **día de hoy**.

### 2. Historial de cambios: legible + hora GT
- **Fix de visibilidad**: las columnas Día/Columna/Nuevo no tenían color de texto y heredaban un color claro (invisibles). Se forzó texto oscuro en la tabla → ahora se leen las 3.
- **Hora GT**: `created_at` se muestra tal cual (el backend ya lo devuelve formateado en hora de Guatemala — ver PR de back).

### Ejemplo
Modo edición (ADMIN) → editás Royalty/Otros ingresos del día de hoy → Guardar → el día queda 🔒 → "Historial de cambios" muestra `edit  royalty  42056.00 → 42057.00  email  16/06/2026 15:26:26`.

### Pruebas
typecheck del front: 0 errores. Probado contra back apuntando a clon de prod.

> ⚠️ **Depende del PR de back** (la hora GT del historial la formatea el backend). Mergear el back primero.
