### PR TITLE
feat(cartera): la gráfica de evolución de mora respeta el filtro de etapa

### DIFF
--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -137,7 +137,8 @@ export async function getMoraHistorialSnapshot(a: SnapshotArgs) {
 }
 
 // Timeline: total de mora reconstruido as-of para cada día del rango (evolución).
-export async function getMoraTimeline({ desde, hasta, asesor }: { desde: string; hasta: string; asesor?: string }) {
+// Respeta el filtro de etapa (Mora 30/60/90/120+) para poder comparar la curva por bucket.
+export async function getMoraTimeline({ desde, hasta, asesor, etapa }: { desde: string; hasta: string; asesor?: string; etapa?: string }) {
   // Filtro de asesor: limita a créditos del/los asesor(es).
   let asesorFilter = sql``;
   if (asesor) {
@@ -150,16 +151,32 @@ export async function getMoraTimeline({ desde, hasta, asesor }: { desde: string;
       )`;
     }
   }
+  // Filtro de etapa sobre las cuotas "vivas" (carry-forward) de cada crédito a esa fecha.
+  let etapaFilter = sql``;
+  if (etapa === "0-30") etapaFilter = sql` AND s.cuotas = 1`;
+  else if (etapa === "31-60") etapaFilter = sql` AND s.cuotas = 2`;
+  else if (etapa === "61-90") etapaFilter = sql` AND s.cuotas = 3`;
+  else if (etapa === "+90") etapaFilter = sql` AND s.cuotas >= 4`;
+
   const res = await db.execute<any>(sql`
     SELECT d::date AS fecha, (
       SELECT COALESCE(SUM(s.monto), 0)
       FROM (
-        SELECT DISTINCT ON (h.credito_id) h.monto_nuevo::numeric AS monto, h.tipo_evento
-        FROM cartera.moras_historial h
-        WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= d ${asesorFilter}
-        ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+        -- estado as-of por crédito: monto/tipo del último evento, cuotas con carry-forward
+        -- (último evento con cuotas>0) para clasificar la etapa igual que el snapshot.
+        SELECT credito_id, monto, tipo_evento, cuotas,
+          ROW_NUMBER() OVER (PARTITION BY credito_id ORDER BY fecha DESC, historial_id DESC) AS rn
+        FROM (
+          SELECT h.credito_id, h.monto_nuevo::numeric AS monto, h.tipo_evento, h.fecha, h.historial_id,
+            FIRST_VALUE(h.cuotas_atrasadas_nuevas) OVER (
+              PARTITION BY h.credito_id
+              ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
+            ) AS cuotas
+          FROM cartera.moras_historial h
+          WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= d ${asesorFilter}
+        ) hh
       ) s
-      WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0
+      WHERE s.rn = 1 AND s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0 ${etapaFilter}
     ) AS mora_total
     FROM generate_series(${desde}::date, ${hasta}::date, INTERVAL '1 day') d
     ORDER BY d

--- a/apps/cartera-back/src/routers/latefee.ts
+++ b/apps/cartera-back/src/routers/latefee.ts
@@ -259,13 +259,13 @@ export const morasRouter = new Elysia()
   .get("/moras/historial/timeline", async ({ query, set, user }: any) => {
     if (!requireMoraHistorialRole(user, set)) return NO_AUTORIZADO;
     try {
-      return await getMoraTimeline({ desde: query.desde, hasta: query.hasta || hoyGT(), asesor: query.asesor });
+      return await getMoraTimeline({ desde: query.desde, hasta: query.hasta || hoyGT(), asesor: query.asesor, etapa: query.etapa });
     } catch (err) {
       set.status = 500;
       return { success: false, message: "[ERROR] No se pudo obtener el timeline de mora", error: String(err) };
     }
   }, {
-    query: t.Object({ desde: t.String(), hasta: t.Optional(t.String()), asesor: t.Optional(t.String()) }),
+    query: t.Object({ desde: t.String(), hasta: t.Optional(t.String()), asesor: t.Optional(t.String()), etapa: t.Optional(t.String()) }),
   })
 
   // Excel del snapshot a la fecha de corte.

--- a/apps/carteraFront/src/private/cartera/components/MoraHistorial.tsx
+++ b/apps/carteraFront/src/private/cartera/components/MoraHistorial.tsx
@@ -33,6 +33,17 @@ const etapaBadge = (etapa: string) => {
   return map[etapa] ?? "bg-gray-100 text-gray-700";
 };
 
+// Etiqueta legible para el valor del filtro de etapa (mismo mapeo que el backend).
+const etapaLabel = (etapa: string) => {
+  const map: Record<string, string> = {
+    "0-30": "Mora 30",
+    "31-60": "Mora 60",
+    "61-90": "Mora 90",
+    "+90": "Mora 120+",
+  };
+  return map[etapa] ?? etapa;
+};
+
 export function MoraHistorial() {
   const { advisors } = useAdminData();
   const [fecha, setFecha] = useState(hoyISO());
@@ -64,8 +75,8 @@ export function MoraHistorial() {
   });
 
   const timelineQuery = useQuery({
-    queryKey: ["mora-timeline", fecha, asesorCsv],
-    queryFn: () => getMoraTimeline(menosDias(fecha, 45), fecha, asesorCsv),
+    queryKey: ["mora-timeline", fecha, asesorCsv, etapa],
+    queryFn: () => getMoraTimeline(menosDias(fecha, 45), fecha, asesorCsv, etapa || undefined),
     refetchOnWindowFocus: false,
   });
 
@@ -215,7 +226,7 @@ export function MoraHistorial() {
 
         {/* Timeline */}
         <div className="bg-white rounded-2xl shadow-lg border border-red-100 p-5 mb-6">
-          <h2 className="text-sm font-bold text-red-800 mb-3 uppercase tracking-wide flex items-center gap-2"><TrendingUp className="h-4 w-4" /> Evolución de la mora (últimos 45 días)</h2>
+          <h2 className="text-sm font-bold text-red-800 mb-3 uppercase tracking-wide flex items-center gap-2"><TrendingUp className="h-4 w-4" /> Evolución de la mora{etapa ? ` — ${etapaLabel(etapa)}` : ""} (últimos 45 días)</h2>
           {timelineQuery.isFetching ? (
             <div className="h-64 flex items-center justify-center text-red-300"><Loader2 className="h-6 w-6 animate-spin" /></div>
           ) : (

--- a/apps/carteraFront/src/private/cartera/services/moraHistorial.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/moraHistorial.services.ts
@@ -63,9 +63,10 @@ export const getMoraHistorialSnapshot = async (params: SnapshotParams): Promise<
 export const getMoraTimeline = async (
   desde: string,
   hasta: string,
-  asesor?: string
+  asesor?: string,
+  etapa?: string
 ): Promise<{ success: boolean; data: { fecha: string; mora_total: string }[] }> => {
-  const { data } = await api.get(`${API_URL}/moras/historial/timeline`, { params: { desde, hasta, asesor } });
+  const { data } = await api.get(`${API_URL}/moras/historial/timeline`, { params: { desde, hasta, asesor, etapa } });
   return data;
 };
 


### PR DESCRIPTION
## Qué

La gráfica **"Evolución de la mora"** del módulo Mora Histórica ahora respeta el filtro de **Etapa** (Mora 30 / 60 / 90 / 120+). Antes la curva siempre mostraba el total sin filtrar aunque seleccionaras una etapa, así que no se podía comparar la evolución por bucket.

Ahora, al elegir "Mora 30" (o cualquier etapa) la curva grafica solo el monto de esa etapa a lo largo del tiempo, y el título lo indica: *"Evolución de la mora — Mora 30 (últimos 45 días)"*.

## Cómo

- **`getMoraTimeline`** (controller): recibe `etapa` y reconstruye el estado as-of por día con window functions — `ROW_NUMBER()` para el último evento de cada crédito + `FIRST_VALUE(cuotas_atrasadas_nuevas)` con carry-forward (último evento con `cuotas>0`) para clasificar la etapa **igual que el snapshot**. El mapeo es idéntico al de `buildSnapshotWhere`: `0-30`→1 cuota, `31-60`→2, `61-90`→3, `+90`→≥4.
- **Ruta** `/moras/historial/timeline`: pasa `query.etapa` y lo agrega al `query` schema de Elysia (`t.Optional(t.String())`).
- **Front**: el service `getMoraTimeline` manda `etapa`; el `queryKey` del `timelineQuery` lo incluye (se refetch al cambiar el filtro); el título muestra la etapa activa.

## Verificación (read-only, contra restore de prod)

Al corte 2026-06-06, la curva por etapa coincide **exacto** con las cards del snapshot, y la suma de los 4 buckets == total sin filtro en cada día:

| | card (snapshot) | timeline | diff |
|---|---|---|---|
| Total | Q2,529,388.49 | Q2,529,388.49 | Q0.00 |
| Mora 30 | Q481,884.44 | Q481,884.44 | Q0.00 |
| Mora 60 | Q200,381.29 | Q200,381.29 | Q0.00 |
| Mora 90 | Q116,784.05 | Q116,784.05 | Q0.00 |
| Mora 120+ | Q1,730,338.71 | Q1,730,338.71 | Q0.00 |

- Timeline de 45 días: 46 puntos en **143ms** (sin regresión de performance).
- Typecheck back y front limpios. No se tocó prod.

## Notas
- Stack: nace sobre #894 (Mora Histórica), ya mergeado a develop, así que el diff es solo este cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)