### PR TITLE
feat(cartera): reporte Flujo de Cuotas de Inversiones desde liquidaciones

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -366,6 +366,118 @@ export async function getFlujoCuotasPorInversionista({
   };
 }
 
+/**
+ * Liquidaciones del mes agrupadas por modalidad de reinversión del inversionista
+ * (`inversionistas.tipo_reinversion`). Por cada modalidad devuelve los campos
+ * crudos de la liquidación (sumas, sin derivar ni restar nada):
+ *   - `reinversion_total` → sección "Cuotas → Reinversión".
+ *   - `total_capital` / `total_interes` / `total_iva` / `total_isr` / `total_cuota`
+ *     → sección "Cuotas → A Recibir". (`total_iva` ya es el 12% del interés.)
+ * Se filtra por `fecha_liquidacion` dentro del mes en zona America/Guatemala.
+ * El etiquetado/omisión de modalidades se maneja en el front.
+ */
+export async function getReinversionLiquidaciones({
+  mes,
+  anio,
+}: {
+  mes: number;
+  anio: number;
+}) {
+  const inicioMes = `${anio}-${String(mes).padStart(2, "0")}-01`;
+  const nextMonth = mes === 12 ? 1 : mes + 1;
+  const nextYear = mes === 12 ? anio + 1 : anio;
+  const inicioMesSiguiente = `${nextYear}-${String(nextMonth).padStart(2, "0")}-01`;
+
+  const result = await db.execute(sql`
+    SELECT
+      COALESCE(i.tipo_reinversion::text, 'sin_reinversion') AS tipo,
+      COALESCE(SUM(l.reinversion_total::numeric), 0)        AS reinversion_total,
+      COALESCE(SUM(l.total_capital::numeric), 0)            AS total_capital,
+      COALESCE(SUM(l.total_interes::numeric), 0)            AS total_interes,
+      COALESCE(SUM(l.total_iva::numeric), 0)                AS total_iva,
+      COALESCE(SUM(l.total_isr::numeric), 0)                AS total_isr,
+      COALESCE(SUM(l.total_cuota::numeric), 0)              AS total_cuota,
+      COUNT(*)::int                                          AS cantidad
+    FROM cartera.liquidaciones l
+    JOIN cartera.inversionistas i ON l.inversionista_id = i.inversionista_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+    GROUP BY i.tipo_reinversion
+  `);
+
+  const porTipo: Record<
+    string,
+    {
+      reinversion_total: string;
+      total_capital: string;
+      total_interes: string;
+      total_iva: string;
+      total_isr: string;
+      total_cuota: string;
+    }
+  > = {};
+  let cantidad = 0;
+
+  for (const r of result.rows as Record<string, unknown>[]) {
+    const tipo = String(r.tipo ?? "sin_reinversion");
+    porTipo[tipo] = {
+      reinversion_total: Number(r.reinversion_total ?? 0).toFixed(2),
+      total_capital: Number(r.total_capital ?? 0).toFixed(2),
+      total_interes: Number(r.total_interes ?? 0).toFixed(2),
+      total_iva: Number(r.total_iva ?? 0).toFixed(2),
+      total_isr: Number(r.total_isr ?? 0).toFixed(2),
+      total_cuota: Number(r.total_cuota ?? 0).toFixed(2),
+    };
+    cantidad += Number(r.cantidad ?? 0);
+  }
+
+  // Interés neto, agrupado por si el inversionista emite factura o no:
+  //   - Con factura:  neto = interés + IVA
+  //   - Sin factura:  neto = interés − ISR
+  const facturaRows = await db.execute(sql`
+    SELECT
+      i.emite_factura                              AS emite_factura,
+      COALESCE(SUM(l.total_interes::numeric), 0)   AS total_interes,
+      COALESCE(SUM(l.total_iva::numeric), 0)       AS total_iva,
+      COALESCE(SUM(l.total_isr::numeric), 0)       AS total_isr
+    FROM cartera.liquidaciones l
+    JOIN cartera.inversionistas i ON l.inversionista_id = i.inversionista_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+    GROUP BY i.emite_factura
+  `);
+
+  const conFactura = { interes: 0, iva: 0 };
+  const sinFactura = { interes: 0, isr: 0 };
+  for (const r of facturaRows.rows as Record<string, unknown>[]) {
+    const interes = Number(r.total_interes ?? 0);
+    if (r.emite_factura === true) {
+      conFactura.interes += interes;
+      conFactura.iva += Number(r.total_iva ?? 0);
+    } else {
+      sinFactura.interes += interes;
+      sinFactura.isr += Number(r.total_isr ?? 0);
+    }
+  }
+
+  return {
+    porTipo,
+    interesNeto: {
+      conFactura: {
+        interes: conFactura.interes.toFixed(2),
+        iva: conFactura.iva.toFixed(2),
+        neto: (conFactura.interes + conFactura.iva).toFixed(2),
+      },
+      sinFactura: {
+        interes: sinFactura.interes.toFixed(2),
+        isr: sinFactura.isr.toFixed(2),
+        neto: (sinFactura.interes - sinFactura.isr).toFixed(2),
+      },
+    },
+    cantidad_liquidaciones: cantidad,
+  };
+}
+
 export async function getEsperadoDelMes({
   mes,
   anio,

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -431,32 +431,34 @@ export async function getReinversionLiquidaciones({
     cantidad += Number(r.cantidad ?? 0);
   }
 
-  // Interés neto, agrupado por si el inversionista emite factura o no:
+  // Interés neto, agrupado según el tratamiento fiscal *guardado en la propia
+  // liquidación* (no según el flag actual del inversionista, que puede cambiar
+  // y reclasificaría meses históricos). Una liquidación sin factura es la que
+  // tiene ISR retenido (`total_isr > 0`); las con factura tienen IVA y sin ISR.
   //   - Con factura:  neto = interés + IVA
   //   - Sin factura:  neto = interés − ISR
   const facturaRows = await db.execute(sql`
     SELECT
-      i.emite_factura                              AS emite_factura,
+      (l.total_isr::numeric > 0)                   AS sin_factura,
       COALESCE(SUM(l.total_interes::numeric), 0)   AS total_interes,
       COALESCE(SUM(l.total_iva::numeric), 0)       AS total_iva,
       COALESCE(SUM(l.total_isr::numeric), 0)       AS total_isr
     FROM cartera.liquidaciones l
-    JOIN cartera.inversionistas i ON l.inversionista_id = i.inversionista_id
     WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
       AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
-    GROUP BY i.emite_factura
+    GROUP BY (l.total_isr::numeric > 0)
   `);
 
   const conFactura = { interes: 0, iva: 0 };
   const sinFactura = { interes: 0, isr: 0 };
   for (const r of facturaRows.rows as Record<string, unknown>[]) {
     const interes = Number(r.total_interes ?? 0);
-    if (r.emite_factura === true) {
-      conFactura.interes += interes;
-      conFactura.iva += Number(r.total_iva ?? 0);
-    } else {
+    if (r.sin_factura === true) {
       sinFactura.interes += interes;
       sinFactura.isr += Number(r.total_isr ?? 0);
+    } else {
+      conFactura.interes += interes;
+      conFactura.iva += Number(r.total_iva ?? 0);
     }
   }
 

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { getCobradoDelMes, getColocacionPorPeriodo, getComparativoHistorico, getEsperadoDelMes, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar } from "../controllers/reportes";
+import { getCobradoDelMes, getColocacionPorPeriodo, getComparativoHistorico, getEsperadoDelMes, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar, getReinversionLiquidaciones } from "../controllers/reportes";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -76,6 +76,25 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/flujo-cuotas-inversiones]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/reinversion-liquidaciones", async ({ query, set }) => {
+    try {
+      const { mes, anio } = query as Record<string, string>;
+      const m = Number(mes);
+      const a = Number(anio);
+      if (!m || !a || m < 1 || m > 12 || a < 2020) {
+        set.status = 400;
+        return { error: "mes y anio son requeridos y deben ser válidos" };
+      }
+      const data = await getReinversionLiquidaciones({ mes: m, anio: a });
+      set.status = 200;
+      return data;
+    } catch (error) {
+      console.error("[/reportes/reinversion-liquidaciones]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -343,7 +343,10 @@ export const reportsAppRouter = {
 	getMontoACobrar: reportesCarteraRouter.getMontoACobrar,
 	getFacturacionMes: reportesCarteraRouter.getFacturacionMes,
 	getFlujoCuotasInversiones: reportesCarteraRouter.getFlujoCuotasInversiones,
-	getFlujoCuotasPorInversionista: reportesCarteraRouter.getFlujoCuotasPorInversionista,
+	getReinversionLiquidaciones:
+		reportesCarteraRouter.getReinversionLiquidaciones,
+	getFlujoCuotasPorInversionista:
+		reportesCarteraRouter.getFlujoCuotasPorInversionista,
 	getComparativoHistorico: reportesCarteraRouter.getComparativoHistorico,
 	getMetas: reportesCarteraRouter.getMetas,
 	upsertMeta: reportesCarteraRouter.upsertMeta,

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -22,6 +22,7 @@ import {
 	type FlujoCuotasInversionesResponse,
 	type FlujoCuotasPorInversionistaResponse,
 	type MontoACobrarRow,
+	type ReinversionLiquidacionesResponse,
 } from "../services/cartera-back-client";
 import { isCarteraBackEnabled } from "../services/cartera-back-integration";
 
@@ -483,6 +484,26 @@ export const reportesCarteraRouter = {
 			return carteraBackClient.getFlujoCuotasInversiones({
 				fechaInicio: input.fechaInicio,
 				fechaFin: input.fechaFin,
+			});
+		}),
+
+	getReinversionLiquidaciones: adminProcedure
+		.input(
+			z.object({
+				mes: z.number().min(1).max(12),
+				anio: z.number().min(2020),
+			}),
+		)
+		.handler(async ({ input }): Promise<ReinversionLiquidacionesResponse> => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			return carteraBackClient.getReinversionLiquidaciones({
+				mes: input.mes,
+				anio: input.anio,
 			});
 		}),
 

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1441,10 +1441,13 @@ export class CarteraBackClient {
 			mes: String(params.mes),
 			anio: String(params.anio),
 		});
+		// Sin cache: el reporte debe reflejar liquidaciones recién creadas/ajustadas.
+		// Con cache activo, tras crear liquidaciones el mes podía seguir devolviendo
+		// los totales previos hasta expirar el TTL.
 		return this.request<ReinversionLiquidacionesResponse>(
 			`/reportes/reinversion-liquidaciones?${qp}`,
 			{ method: "GET" },
-			true,
+			false,
 		);
 	}
 

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -3,10 +3,6 @@
  * Type-safe HTTP client with retry logic, circuit breaker, and caching
  */
 
-import {
-	getCarteraAccessToken,
-	invalidateAndReauth,
-} from "./cartera-auth.service";
 import type {
 	BoletaPagoInversionista,
 	CarteraAsesor,
@@ -41,6 +37,10 @@ import type {
 	ReversePagoInput,
 	UpdateCreditoInput,
 } from "../types/cartera-back";
+import {
+	getCarteraAccessToken,
+	invalidateAndReauth,
+} from "./cartera-auth.service";
 
 // ============================================================================
 // CONFIGURATION
@@ -222,8 +222,14 @@ export type FlujoCuotasInversionista = FlujoCuotasRubro & {
 };
 
 export type FlujoCuotasInversionesResponse = {
-	reinversionPorTipo: (FlujoCuotasRubro & { tipo: string; monto_reinvertido?: string })[];
-	cashParcialPorTipo: (FlujoCuotasRubro & { tipo: string; monto_cash?: string })[];
+	reinversionPorTipo: (FlujoCuotasRubro & {
+		tipo: string;
+		monto_reinvertido?: string;
+	})[];
+	cashParcialPorTipo: (FlujoCuotasRubro & {
+		tipo: string;
+		monto_cash?: string;
+	})[];
 	sinReinversion: {
 		totales: FlujoCuotasRubro;
 		porInversionista: FlujoCuotasInversionista[];
@@ -232,6 +238,36 @@ export type FlujoCuotasInversionesResponse = {
 		abonos_capital: string;
 		cancelaciones: string;
 	};
+};
+
+export type ReinversionLiquidacionesResponse = {
+	/**
+	 * Por modalidad (`tipo_reinversion`), campos crudos de la liquidación:
+	 * - `reinversion_total` → sección "Cuotas → Reinversión".
+	 * - `total_capital` / `total_interes` / `total_iva` / `total_isr` / `total_cuota`
+	 *   → sección "Cuotas → A Recibir".
+	 */
+	porTipo: Record<
+		string,
+		{
+			reinversion_total: string;
+			total_capital: string;
+			total_interes: string;
+			total_iva: string;
+			total_isr: string;
+			total_cuota: string;
+		}
+	>;
+	/**
+	 * Interés neto agrupado por si el inversionista emite factura:
+	 * - `conFactura`: neto = interés + IVA.
+	 * - `sinFactura`: neto = interés − ISR.
+	 */
+	interesNeto: {
+		conFactura: { interes: string; iva: string; neto: string };
+		sinFactura: { interes: string; isr: string; neto: string };
+	};
+	cantidad_liquidaciones: number;
 };
 
 export type FlujoPorInversionistaRow = {
@@ -551,7 +587,7 @@ export class CarteraBackClient {
 				`[CarteraBackClient] getAllCreditos: usando POST (${params.numeros_credito_sifco?.length} SIFCOs en lista)`,
 			);
 			response = await this.request<PaginatedResponse<CreditoDetailResponse>>(
-				`/getAllCredits`,
+				"/getAllCredits",
 				{
 					method: "POST",
 					body: JSON.stringify({
@@ -576,8 +612,12 @@ export class CarteraBackClient {
 						...(params.email_cobrador && {
 							email_asesor: params.email_cobrador,
 						}),
-						...(params.capital_min !== undefined && { capital_min: params.capital_min }),
-						...(params.capital_max !== undefined && { capital_max: params.capital_max }),
+						...(params.capital_min !== undefined && {
+							capital_min: params.capital_min,
+						}),
+						...(params.capital_max !== undefined && {
+							capital_max: params.capital_max,
+						}),
 						excel: false,
 					}),
 				},
@@ -606,8 +646,12 @@ export class CarteraBackClient {
 				...(params.email_cobrador && { email_asesor: params.email_cobrador }),
 				...(params.fecha_desde && { fecha_desde: params.fecha_desde }),
 				...(params.fecha_hasta && { fecha_hasta: params.fecha_hasta }),
-				...(params.capital_min !== undefined && { capital_min: params.capital_min.toString() }),
-				...(params.capital_max !== undefined && { capital_max: params.capital_max.toString() }),
+				...(params.capital_min !== undefined && {
+					capital_min: params.capital_min.toString(),
+				}),
+				...(params.capital_max !== undefined && {
+					capital_max: params.capital_max.toString(),
+				}),
 				excel: "false",
 			});
 
@@ -733,9 +777,11 @@ export class CarteraBackClient {
 	// NIT VALIDATION
 	// ========================================================================
 
-	async consultarNit(
-		nit: string,
-	): Promise<{ success: boolean; data?: { nit: string; nombre: string | null }; mensaje: string }> {
+	async consultarNit(nit: string): Promise<{
+		success: boolean;
+		data?: { nit: string; nombre: string | null };
+		mensaje: string;
+	}> {
 		return this.request("/api/dte/consultarNit", {
 			method: "POST",
 			body: JSON.stringify({ nit }),
@@ -781,9 +827,7 @@ export class CarteraBackClient {
 		};
 	}
 
-	async getInvestorRendimiento(
-		email: string,
-	): Promise<{
+	async getInvestorRendimiento(email: string): Promise<{
 		success: boolean;
 		data: {
 			inversionista_id: number;
@@ -1169,9 +1213,7 @@ export class CarteraBackClient {
 		return response;
 	}
 
-	async deleteInvestorDocument(
-		documentoId: number,
-	): Promise<{
+	async deleteInvestorDocument(documentoId: number): Promise<{
 		success: boolean;
 		message: string;
 		data?: Record<string, any>;
@@ -1204,14 +1246,19 @@ export class CarteraBackClient {
 		tipo_reinversion?: string | null;
 		monto_reinversion?: number | null;
 		moneda?: string;
-	}): Promise<{ message: string; data: { inversionista_id: number; nombre: string; [key: string]: any }[] }> {
+	}): Promise<{
+		message: string;
+		data: { inversionista_id: number; nombre: string; [key: string]: any }[];
+	}> {
 		const response = await this.request<{
 			message: string;
 			data: { inversionista_id: number; nombre: string; [key: string]: any }[];
 		}>("/investor", {
 			method: "POST",
 			body: JSON.stringify({
-				...(input.inversionista_id && { inversionista_id: input.inversionista_id }),
+				...(input.inversionista_id && {
+					inversionista_id: input.inversionista_id,
+				}),
 				...(input.operation && { operation: input.operation }),
 				nombre: input.nombre,
 				dpi: input.dpi ?? null,
@@ -1312,7 +1359,9 @@ export class CarteraBackClient {
 		);
 	}
 
-	async getComparativoHistorico(anio: number): Promise<ComparativoHistoricoResponse> {
+	async getComparativoHistorico(
+		anio: number,
+	): Promise<ComparativoHistoricoResponse> {
 		return this.request<ComparativoHistoricoResponse>(
 			`/reportes/comparativo-historico?anio=${anio}`,
 			{ method: "GET" },
@@ -1379,6 +1428,21 @@ export class CarteraBackClient {
 		});
 		return this.request<FlujoCuotasInversionesResponse>(
 			`/reportes/flujo-cuotas-inversiones?${qp}`,
+			{ method: "GET" },
+			true,
+		);
+	}
+
+	async getReinversionLiquidaciones(params: {
+		mes: number;
+		anio: number;
+	}): Promise<ReinversionLiquidacionesResponse> {
+		const qp = new URLSearchParams({
+			mes: String(params.mes),
+			anio: String(params.anio),
+		});
+		return this.request<ReinversionLiquidacionesResponse>(
+			`/reportes/reinversion-liquidaciones?${qp}`,
 			{ method: "GET" },
 			true,
 		);

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -123,6 +123,36 @@ export type FlujoCuotasInversionesResponse = {
 	pagosExtras: { abonos_capital: string; cancelaciones: string };
 };
 
+export type ReinversionLiquidacionesResponse = {
+	/**
+	 * Por modalidad (`tipo_reinversion`), campos crudos de la liquidación:
+	 * - `reinversion_total` → sección "Cuotas → Reinversión".
+	 * - `total_capital` / `total_interes` / `total_iva` / `total_isr` / `total_cuota`
+	 *   → sección "Cuotas → A Recibir".
+	 */
+	porTipo: Record<
+		string,
+		{
+			reinversion_total: string;
+			total_capital: string;
+			total_interes: string;
+			total_iva: string;
+			total_isr: string;
+			total_cuota: string;
+		}
+	>;
+	/**
+	 * Interés neto agrupado por si el inversionista emite factura:
+	 * - `conFactura`: neto = interés + IVA.
+	 * - `sinFactura`: neto = interés − ISR.
+	 */
+	interesNeto: {
+		conFactura: { interes: string; iva: string; neto: string };
+		sinFactura: { interes: string; isr: string; neto: string };
+	};
+	cantidad_liquidaciones: number;
+};
+
 export type PuntoEquilibrioRow = {
 	bucket: string;
 	cantidad_creditos: number;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -68,6 +68,7 @@ import {
 	TableHeader,
 	TableRow,
 } from "@/components/ui/table";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import type {
@@ -840,1365 +841,341 @@ function RouteComponent() {
 
 			{isAdmin && (
 				<>
-					{/* Enlaces a otros reportes - TODO: Implementar rutas */}
-					<div className="grid gap-4 md:grid-cols-4">
-						<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
-							<div className="flex items-center gap-2">
-								<AlertTriangle className="h-5 w-5 text-orange-500" />
-								<span className="font-semibold">Cobranza</span>
-							</div>
-							<p className="mt-1 text-muted-foreground text-sm">
-								Gestión de mora y recuperación (Próximamente)
-							</p>
-						</div>
-						<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
-							<div className="flex items-center gap-2">
-								<Wallet className="h-5 w-5 text-blue-500" />
-								<span className="font-semibold">Cartera</span>
-							</div>
-							<p className="mt-1 text-muted-foreground text-sm">
-								Análisis de créditos activos (Próximamente)
-							</p>
-						</div>
-						<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
-							<div className="flex items-center gap-2">
-								<Activity className="h-5 w-5 text-green-500" />
-								<span className="font-semibold">Inventario</span>
-							</div>
-							<p className="mt-1 text-muted-foreground text-sm">
-								Estado de vehículos (Próximamente)
-							</p>
-						</div>
-						<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
-							<div className="flex items-center gap-2">
-								<TrendingDown className="h-5 w-5 text-red-500" />
-								<span className="font-semibold">Subastas</span>
-							</div>
-							<p className="mt-1 text-muted-foreground text-sm">
-								Análisis de pérdidas (Próximamente)
-							</p>
-						</div>
-					</div>
-
-					{/* KPIs principales */}
-					<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-						<ReportCard
-							title="Cartera Activa"
-							value={formatCurrency(
-								dashboardData.data?.carteraActiva.montoTotal || 0,
-							)}
-							description={`${dashboardData.data?.carteraActiva.totalContratos || 0} contratos activos`}
-							icon={Wallet}
-						/>
-						<ReportCard
-							title="Total en Mora"
-							value={formatCurrency(totalEnMora)}
-							description="Cuotas pendientes de pago"
-							icon={AlertTriangle}
-							className="border-orange-200 dark:border-orange-900"
-						/>
-						<ReportCard
-							title="Total Recuperado"
-							value={formatCurrency(totalPagado)}
-							description="Cuotas pagadas"
-							icon={TrendingUp}
-							className="border-green-200 dark:border-green-900"
-						/>
-						<ReportCard
-							title="Casos Activos"
-							value={
-								dashboardData.data?.casosActivos.reduce(
-									(acc, c) => acc + c.totalCasos,
-									0,
-								) || 0
-							}
-							description="Casos en gestión de cobros"
-							icon={FileText}
-						/>
-					</div>
-
-					{/* Gráficas */}
-					<div className="grid gap-6 md:grid-cols-2">
-						<Card>
-							<CardHeader>
-								<CardTitle>Distribución de Cuotas por Estado</CardTitle>
-								<CardDescription>
-									Análisis del estado de pago de las cuotas
-								</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<ResponsiveContainer width="100%" height={300}>
-									<PieChart>
-										<Pie
-											data={pieData}
-											dataKey="value"
-											nameKey="name"
-											cx="50%"
-											cy="50%"
-											outerRadius={100}
-											label
-										>
-											{pieData.map((entry, index) => (
-												<Cell
-													key={entry.name}
-													fill={
-														COLORS[
-															moraData[index]?.estadoMora as keyof typeof COLORS
-														]
-													}
-												/>
-											))}
-										</Pie>
-										<Tooltip
-											formatter={(value) => formatCurrency(Number(value))}
-										/>
-									</PieChart>
-								</ResponsiveContainer>
-							</CardContent>
-						</Card>
-
-						<Card>
-							<CardHeader>
-								<CardTitle>Pipeline de Ventas</CardTitle>
-								<CardDescription>
-									Oportunidades por etapa del proceso
-								</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<ResponsiveContainer width="100%" height={300}>
-									<BarChart data={pipelineData}>
-										<CartesianGrid strokeDasharray="3 3" />
-										<XAxis
-											dataKey="etapa"
-											angle={-45}
-											textAnchor="end"
-											height={100}
-										/>
-										<YAxis />
-										<Tooltip />
-										<Legend />
-										<Bar
-											dataKey="oportunidades"
-											fill="#3b82f6"
-											name="Oportunidades"
-										/>
-									</BarChart>
-								</ResponsiveContainer>
-							</CardContent>
-						</Card>
-
-						<Card className="md:col-span-2">
-							<CardHeader>
-								<CardTitle>Tendencia de Nuevos Contratos</CardTitle>
-								<CardDescription>Últimos 6 meses de actividad</CardDescription>
-							</CardHeader>
-							<CardContent>
-								<ResponsiveContainer width="100%" height={300}>
-									<LineChart data={contratosData}>
-										<CartesianGrid strokeDasharray="3 3" />
-										<XAxis dataKey="mes" />
-										<YAxis yAxisId="left" />
-										<YAxis yAxisId="right" orientation="right" />
-										<Tooltip
-											formatter={(value, name) =>
-												name === "monto" ? formatCurrency(Number(value)) : value
-											}
-										/>
-										<Legend />
-										<Line
-											yAxisId="left"
-											type="monotone"
-											dataKey="contratos"
-											stroke="#3b82f6"
-											name="Contratos"
-										/>
-										<Line
-											yAxisId="right"
-											type="monotone"
-											dataKey="monto"
-											stroke="#10b981"
-											name="Capital Activo"
-										/>
-									</LineChart>
-								</ResponsiveContainer>
-							</CardContent>
-						</Card>
-					</div>
-
-					{/* Estadísticas de Leads */}
-					<Card>
-						<CardHeader>
-							<CardTitle>Conversión de Leads</CardTitle>
-							<CardDescription>
-								Estado de los prospectos en el sistema
-							</CardDescription>
-						</CardHeader>
-						<CardContent>
-							<div className="grid gap-4 md:grid-cols-5">
-								{dashboardData.data?.leadsStats.map((stat) => (
-									<div key={stat.status} className="rounded-lg border p-4">
-										<div className="text-muted-foreground text-sm">
-											{stat.status === "new"
-												? "Nuevos"
-												: stat.status === "contacted"
-													? "Contactados"
-													: stat.status === "qualified"
-														? "Calificados"
-														: stat.status === "unqualified"
-															? "No calificados"
-															: "Convertidos"}
-										</div>
-										<div className="mt-1 font-bold text-2xl">{stat.total}</div>
+					<Tabs defaultValue="resumen" className="space-y-6">
+						<TabsList>
+							<TabsTrigger value="resumen">Resumen</TabsTrigger>
+							<TabsTrigger value="graficas">Gráficas</TabsTrigger>
+							<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
+							<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
+							<TabsTrigger value="colocacion">Colocación</TabsTrigger>
+						</TabsList>
+						<TabsContent value="resumen" className="space-y-6">
+							{/* Enlaces a otros reportes - TODO: Implementar rutas */}
+							<div className="grid gap-4 md:grid-cols-4">
+								<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
+									<div className="flex items-center gap-2">
+										<AlertTriangle className="h-5 w-5 text-orange-500" />
+										<span className="font-semibold">Cobranza</span>
 									</div>
-								))}
-							</div>
-						</CardContent>
-					</Card>
-
-					{/* Reporte: Monto a Cobrarse por Período */}
-					<Card>
-						<CardHeader>
-							<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-								<div className="flex items-center gap-2">
-									<CalendarDays className="h-5 w-5 text-blue-500" />
-									<div>
-										<CardTitle>Monto a Cobrarse por Período</CardTitle>
-										<CardDescription>
-											Cuotas pendientes desglosadas por rubro (capital, interés,
-											seguro, etc.)
-										</CardDescription>
-									</div>
+									<p className="mt-1 text-muted-foreground text-sm">
+										Gestión de mora y recuperación (Próximamente)
+									</p>
 								</div>
-								<div className="flex flex-wrap items-center gap-2">
-									<SimularButton onClick={() => setScenarioOpen("monto")} />
-									<Select
-										value={montoCobrarPeriodo}
-										onValueChange={(v) =>
-											setMontoCobrarPeriodo(
-												v as "anio" | "trimestre" | "mes" | "semana" | "dia",
-											)
-										}
-									>
-										<SelectTrigger className="w-[140px]">
-											<SelectValue placeholder="Período" />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="dia">Día</SelectItem>
-											<SelectItem value="semana">Semana</SelectItem>
-											<SelectItem value="mes">Mes</SelectItem>
-											<SelectItem value="trimestre">Trimestre</SelectItem>
-											<SelectItem value="anio">Año</SelectItem>
-										</SelectContent>
-									</Select>
-									<DateRangeFilter
-										dateRange={
-											montoCobrarRange.fechaInicio && montoCobrarRange.fechaFin
-												? {
-														from: dateFromInput(montoCobrarRange.fechaInicio),
-														to: dateFromInput(montoCobrarRange.fechaFin),
-													}
-												: undefined
-										}
-										onDateRangeChange={(range) => {
-											if (range?.from && range?.to) {
-												setMontoCobrarRange({
-													fechaInicio: formatDateInput(range.from),
-													fechaFin: formatDateInput(range.to),
-												});
-											}
-										}}
-									/>
+								<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
+									<div className="flex items-center gap-2">
+										<Wallet className="h-5 w-5 text-blue-500" />
+										<span className="font-semibold">Cartera</span>
+									</div>
+									<p className="mt-1 text-muted-foreground text-sm">
+										Análisis de créditos activos (Próximamente)
+									</p>
+								</div>
+								<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
+									<div className="flex items-center gap-2">
+										<Activity className="h-5 w-5 text-green-500" />
+										<span className="font-semibold">Inventario</span>
+									</div>
+									<p className="mt-1 text-muted-foreground text-sm">
+										Estado de vehículos (Próximamente)
+									</p>
+								</div>
+								<div className="rounded-lg border bg-card p-4 text-card-foreground opacity-50 shadow-sm">
+									<div className="flex items-center gap-2">
+										<TrendingDown className="h-5 w-5 text-red-500" />
+										<span className="font-semibold">Subastas</span>
+									</div>
+									<p className="mt-1 text-muted-foreground text-sm">
+										Análisis de pérdidas (Próximamente)
+									</p>
 								</div>
 							</div>
-						</CardHeader>
-						<CardContent className="space-y-6">
-							{montoCobrarQuery.isPending && <p>Cargando reporte...</p>}
-							{montoCobrarQuery.isError && (
-								<p className="text-destructive">
-									Error al cargar el reporte de monto a cobrarse.
-								</p>
-							)}
-							{montoCobrarData && montoCobrarData.data.length === 0 && (
-								<p className="text-muted-foreground">
-									No hay cuotas pendientes para el rango seleccionado.
-								</p>
-							)}
-							{!!montoCobrarData?.data.length && (
-								<>
-									{/* Gráfica de barras apiladas */}
-									<ResponsiveContainer width="100%" height={350}>
-										<BarChart
-											data={montoCobrarData.data.map(
-												(row: MontoACobrarRow) => ({
-													bucket: formatBucket(row.bucket, montoCobrarPeriodo),
-													total_cuota: Number.parseFloat(row.total_cuota),
-													total_interes: Number.parseFloat(row.total_interes),
-													total_iva: Number.parseFloat(row.total_iva),
-													total_seguro: Number.parseFloat(row.total_seguro),
-													total_gps: Number.parseFloat(row.total_gps),
-													total_membresias: Number.parseFloat(
-														row.total_membresias,
-													),
-													total_royalti: Number.parseFloat(row.total_royalti),
-												}),
-											)}
-										>
-											<CartesianGrid strokeDasharray="3 3" />
-											<XAxis
-												dataKey="bucket"
-												tick={{ fontSize: 11 }}
-												interval={0}
-												height={36}
-											/>
-											<YAxis
-												tickFormatter={(v) =>
-													`Q${(Number(v) / 1000).toFixed(0)}k`
-												}
-											/>
-											<Tooltip
-												formatter={(value, name) => [
-													formatCurrency(Number(value)),
-													MONTO_COBRAR_LABELS[
-														name as keyof typeof MONTO_COBRAR_LABELS
-													] ?? name,
-												]}
-											/>
-											<Legend
-												formatter={(value) =>
-													MONTO_COBRAR_LABELS[
-														value as keyof typeof MONTO_COBRAR_LABELS
-													] ?? value
-												}
-											/>
-											{(
-												Object.keys(
-													MONTO_COBRAR_COLORS,
-												) as (keyof typeof MONTO_COBRAR_COLORS)[]
-											).map((key) => (
-												<Bar
-													key={key}
-													dataKey={key}
-													stackId="a"
-													fill={MONTO_COBRAR_COLORS[key]}
-												/>
-											))}
-										</BarChart>
-									</ResponsiveContainer>
 
-									{/* Tabla detallada */}
-									<div className="overflow-x-auto">
-										<Table>
-											<TableHeader>
-												<TableRow>
-													<TableHead>Período</TableHead>
-													<TableHead className="text-right">Cuotas</TableHead>
-													<TableHead className="text-right">Capital</TableHead>
-													<TableHead className="text-right">Interés</TableHead>
-													<TableHead className="text-right">IVA</TableHead>
-													<TableHead className="text-right">Seguro</TableHead>
-													<TableHead className="text-right">GPS</TableHead>
-													<TableHead className="text-right">
-														Membresías
-													</TableHead>
-													<TableHead className="text-right">Royalti</TableHead>
-													<TableHead className="text-right">
-														Mora Prom.
-													</TableHead>
-													<TableHead className="text-right font-bold">
-														Total
-													</TableHead>
-												</TableRow>
-											</TableHeader>
-											<TableBody>
-												{montoCobrarData.data.map((row: MontoACobrarRow) => {
-													const total =
-														Number.parseFloat(row.total_cuota) +
-														Number.parseFloat(row.total_interes) +
-														Number.parseFloat(row.total_iva) +
-														Number.parseFloat(row.total_seguro) +
-														Number.parseFloat(row.total_gps) +
-														Number.parseFloat(row.total_membresias) +
-														Number.parseFloat(row.total_royalti);
-													return (
-														<TableRow key={row.bucket}>
-															<TableCell>
-																{formatBucket(row.bucket, montoCobrarPeriodo)}
-															</TableCell>
-															<TableCell className="text-right">
-																{row.cuotas_count}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.total_cuota)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.total_interes)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.total_iva)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.total_seguro)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.total_gps)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.total_membresias)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.total_royalti)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(row.mora_promedio)}
-															</TableCell>
-															<TableCell className="text-right font-bold">
-																{formatCurrency(total)}
-															</TableCell>
-														</TableRow>
-													);
-												})}
-												{/* Fila de totales */}
-												{(() => {
-													const rows =
-														montoCobrarData.data as MontoACobrarRow[];
-													const sum = (key: keyof MontoACobrarRow) =>
-														rows.reduce(
-															(acc: number, r: MontoACobrarRow) =>
-																acc +
-																Number.parseFloat((r[key] as string) || "0"),
-															0,
-														);
-													const grandTotal =
-														sum("total_cuota") +
-														sum("total_interes") +
-														sum("total_iva") +
-														sum("total_seguro") +
-														sum("total_gps") +
-														sum("total_membresias") +
-														sum("total_royalti");
-													return (
-														<TableRow className="border-t-2 bg-muted/50 font-bold">
-															<TableCell>Total</TableCell>
-															<TableCell className="text-right">
-																{rows.reduce(
-																	(acc, r) => acc + r.cuotas_count,
-																	0,
-																)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(sum("total_cuota"))}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(sum("total_interes"))}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(sum("total_iva"))}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(sum("total_seguro"))}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(sum("total_gps"))}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(sum("total_membresias"))}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(sum("total_royalti"))}
-															</TableCell>
-															<TableCell className="text-right">—</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(grandTotal)}
-															</TableCell>
-														</TableRow>
-													);
-												})()}
-											</TableBody>
-										</Table>
-									</div>
-								</>
-							)}
-						</CardContent>
-					</Card>
-
-					{/* Reporte: Facturado del Mes vs Esperado */}
-					<Card>
-						<CardHeader>
-							<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-								<div>
-									<CardTitle className="flex items-center gap-2">
-										<CalendarDays className="h-5 w-5" />
-										Facturado del Mes vs Esperado
-									</CardTitle>
-									<CardDescription>
-										Compara lo cobrado en el mes contra lo esperado según fecha
-										de vencimiento
-									</CardDescription>
-								</div>
-								<div className="flex items-center gap-2">
-									<SimularButton
-										onClick={() => setScenarioOpen("facturacion")}
-									/>
-									<Select
-										value={String(facturacionMes.mes)}
-										onValueChange={(v) =>
-											setFacturacionMes((prev) => ({ ...prev, mes: Number(v) }))
-										}
-									>
-										<SelectTrigger className="w-36">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{[
-												"Enero",
-												"Febrero",
-												"Marzo",
-												"Abril",
-												"Mayo",
-												"Junio",
-												"Julio",
-												"Agosto",
-												"Septiembre",
-												"Octubre",
-												"Noviembre",
-												"Diciembre",
-											].map((label, i) => (
-												<SelectItem key={i + 1} value={String(i + 1)}>
-													{label}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									<Input
-										type="number"
-										className="w-24"
-										value={facturacionMes.anio}
-										min={2020}
-										max={2100}
-										onChange={(e) =>
-											setFacturacionMes((prev) => ({
-												...prev,
-												anio: Number(e.target.value),
-											}))
-										}
-									/>
-								</div>
-							</div>
-						</CardHeader>
-						<CardContent>
-							{facturacionMesQuery.isPending && (
-								<div className="py-4 text-center text-muted-foreground text-sm">
-									Cargando...
-								</div>
-							)}
-							{facturacionMesQuery.isError && (
-								<div className="py-4 text-center text-destructive text-sm">
-									Error al cargar datos
-								</div>
-							)}
-							{facturacionMesData &&
-								(() => {
-									const { cobrado, esperado } = facturacionMesData;
-									const totalCobrado = FACTURACION_RUBROS.reduce(
-										(acc, r) => acc + Number(cobrado[r.key] || 0),
-										0,
-									);
-									const totalEsperado = FACTURACION_RUBROS.reduce(
-										(acc, r) => acc + Number(esperado[r.key] || 0),
-										0,
-									);
-									return (
-										<Table>
-											<TableHeader>
-												<TableRow>
-													<TableHead>Rubro</TableHead>
-													<TableHead className="text-right">Cobrado</TableHead>
-													<TableHead className="text-right">Esperado</TableHead>
-													<TableHead className="w-48">Progreso</TableHead>
-												</TableRow>
-											</TableHeader>
-											<TableBody>
-												{FACTURACION_RUBROS.map(({ key, label }) => (
-													<TableRow key={key}>
-														<TableCell>{label}</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(Number(cobrado[key] || 0))}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(Number(esperado[key] || 0))}
-														</TableCell>
-														<TableCell>
-															<ProgressBar
-																value={Number(cobrado[key] || 0)}
-																max={Number(esperado[key] || 0)}
-															/>
-														</TableCell>
-													</TableRow>
-												))}
-												<TableRow className="border-t-2 bg-muted/50 font-bold">
-													<TableCell>Total</TableCell>
-													<TableCell className="text-right">
-														{formatCurrency(totalCobrado)}
-													</TableCell>
-													<TableCell className="text-right">
-														{formatCurrency(totalEsperado)}
-													</TableCell>
-													<TableCell>
-														<ProgressBar
-															value={totalCobrado}
-															max={totalEsperado}
-														/>
-													</TableCell>
-												</TableRow>
-											</TableBody>
-										</Table>
-									);
-								})()}
-						</CardContent>
-					</Card>
-
-					{/* Reporte: Flujo de Cuotas de Inversiones */}
-					<Card>
-						<CardHeader>
-							<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-								<div>
-									<CardTitle className="flex items-center gap-2">
-										<TrendingUp className="h-5 w-5" />
-										Flujo de Cuotas de Inversiones
-									</CardTitle>
-									<CardDescription>
-										Cuotas esperadas hacia reinversión y hacia pago en efectivo,
-										por período
-									</CardDescription>
-								</div>
-								<div className="flex items-center gap-2">
-									<SimularButton onClick={() => setScenarioOpen("flujo")} />
-									<Select
-										value={String(flujoMesNum)}
-										onValueChange={(v) =>
-											setFlujoMesAnio(flujoAnioNum, Number(v))
-										}
-									>
-										<SelectTrigger className="w-36" aria-label="Mes">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{mesesDisponibles.map((m) => (
-												<SelectItem key={m.num} value={String(m.num)}>
-													{m.nombre}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-									<Select
-										value={String(flujoAnioNum)}
-										onValueChange={(v) =>
-											setFlujoMesAnio(Number(v), flujoMesNum)
-										}
-									>
-										<SelectTrigger className="w-24" aria-label="Año">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											{aniosDisponibles.map((a) => (
-												<SelectItem key={a} value={String(a)}>
-													{a}
-												</SelectItem>
-											))}
-										</SelectContent>
-									</Select>
-								</div>
-							</div>
-						</CardHeader>
-						<CardContent className="space-y-8">
-							{/* Sección 1: Cuotas → Reinversión (desde liquidaciones) */}
-							<div className={SECCION_REPORTE_CLASS}>
-								<p className="mb-2 font-semibold text-sm">
-									Cuotas → Reinversión
-								</p>
-								{reinversionLiquidacionesQuery.isPending ? (
-									<div className="py-4 text-center text-muted-foreground text-sm">
-										Cargando...
-									</div>
-								) : reinversionLiquidacionesQuery.isError ? (
-									<div className="py-4 text-center text-destructive text-sm">
-										Error al cargar datos
-									</div>
-								) : reinversionData ? (
-									(() => {
-										const filas = REINVERSION_MODALIDADES.map((m) => ({
-											...m,
-											monto: Number(
-												reinversionData.porTipo[m.tipo]?.reinversion_total ?? 0,
-											),
-										})).filter((f) => f.monto !== 0);
-										const totalMostrado = filas.reduce(
-											(a, f) => a + f.monto,
+							{/* KPIs principales */}
+							<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+								<ReportCard
+									title="Cartera Activa"
+									value={formatCurrency(
+										dashboardData.data?.carteraActiva.montoTotal || 0,
+									)}
+									description={`${dashboardData.data?.carteraActiva.totalContratos || 0} contratos activos`}
+									icon={Wallet}
+								/>
+								<ReportCard
+									title="Total en Mora"
+									value={formatCurrency(totalEnMora)}
+									description="Cuotas pendientes de pago"
+									icon={AlertTriangle}
+									className="border-orange-200 dark:border-orange-900"
+								/>
+								<ReportCard
+									title="Total Recuperado"
+									value={formatCurrency(totalPagado)}
+									description="Cuotas pagadas"
+									icon={TrendingUp}
+									className="border-green-200 dark:border-green-900"
+								/>
+								<ReportCard
+									title="Casos Activos"
+									value={
+										dashboardData.data?.casosActivos.reduce(
+											(acc, c) => acc + c.totalCasos,
 											0,
-										);
-										return (
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Modalidad de Reinversión</TableHead>
-														<TableHead className="text-right">
-															Reinversión Total
-														</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{filas.map((f) => (
-														<TableRow key={f.tipo}>
-															<TableCell>{f.label}</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(f.monto)}
-															</TableCell>
-														</TableRow>
+										) || 0
+									}
+									description="Casos en gestión de cobros"
+									icon={FileText}
+								/>
+							</div>
+						</TabsContent>
+						<TabsContent value="graficas" className="space-y-6">
+							{/* Gráficas */}
+							<div className="grid gap-6 md:grid-cols-2">
+								<Card>
+									<CardHeader>
+										<CardTitle>Distribución de Cuotas por Estado</CardTitle>
+										<CardDescription>
+											Análisis del estado de pago de las cuotas
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<ResponsiveContainer width="100%" height={300}>
+											<PieChart>
+												<Pie
+													data={pieData}
+													dataKey="value"
+													nameKey="name"
+													cx="50%"
+													cy="50%"
+													outerRadius={100}
+													label
+												>
+													{pieData.map((entry, index) => (
+														<Cell
+															key={entry.name}
+															fill={
+																COLORS[
+																	moraData[index]
+																		?.estadoMora as keyof typeof COLORS
+																]
+															}
+														/>
 													))}
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total Reinvertido</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalMostrado)}
-														</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										);
-									})()
-								) : null}
+												</Pie>
+												<Tooltip
+													formatter={(value) => formatCurrency(Number(value))}
+												/>
+											</PieChart>
+										</ResponsiveContainer>
+									</CardContent>
+								</Card>
+
+								<Card>
+									<CardHeader>
+										<CardTitle>Pipeline de Ventas</CardTitle>
+										<CardDescription>
+											Oportunidades por etapa del proceso
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<ResponsiveContainer width="100%" height={300}>
+											<BarChart data={pipelineData}>
+												<CartesianGrid strokeDasharray="3 3" />
+												<XAxis
+													dataKey="etapa"
+													angle={-45}
+													textAnchor="end"
+													height={100}
+												/>
+												<YAxis />
+												<Tooltip />
+												<Legend />
+												<Bar
+													dataKey="oportunidades"
+													fill="#3b82f6"
+													name="Oportunidades"
+												/>
+											</BarChart>
+										</ResponsiveContainer>
+									</CardContent>
+								</Card>
+
+								<Card className="md:col-span-2">
+									<CardHeader>
+										<CardTitle>Tendencia de Nuevos Contratos</CardTitle>
+										<CardDescription>
+											Últimos 6 meses de actividad
+										</CardDescription>
+									</CardHeader>
+									<CardContent>
+										<ResponsiveContainer width="100%" height={300}>
+											<LineChart data={contratosData}>
+												<CartesianGrid strokeDasharray="3 3" />
+												<XAxis dataKey="mes" />
+												<YAxis yAxisId="left" />
+												<YAxis yAxisId="right" orientation="right" />
+												<Tooltip
+													formatter={(value, name) =>
+														name === "monto"
+															? formatCurrency(Number(value))
+															: value
+													}
+												/>
+												<Legend />
+												<Line
+													yAxisId="left"
+													type="monotone"
+													dataKey="contratos"
+													stroke="#3b82f6"
+													name="Contratos"
+												/>
+												<Line
+													yAxisId="right"
+													type="monotone"
+													dataKey="monto"
+													stroke="#10b981"
+													name="Capital Activo"
+												/>
+											</LineChart>
+										</ResponsiveContainer>
+									</CardContent>
+								</Card>
 							</div>
 
-							{/* Sección 2: Cuotas → A Recibir (efectivo neto = total_cuota) */}
-							<div className={SECCION_REPORTE_CLASS}>
-								<p className="mb-2 font-semibold text-sm">Cuotas → A Recibir</p>
-								{reinversionLiquidacionesQuery.isPending ? (
-									<div className="py-4 text-center text-muted-foreground text-sm">
-										Cargando...
-									</div>
-								) : reinversionLiquidacionesQuery.isError ? (
-									<div className="py-4 text-center text-destructive text-sm">
-										Error al cargar datos
-									</div>
-								) : reinversionData ? (
-									(() => {
-										const filas = A_RECIBIR_MODALIDADES.map((m) => {
-											const d = reinversionData.porTipo[m.tipo];
-											return {
-												...m,
-												capital: Number(d?.total_capital ?? 0),
-												interes: Number(d?.total_interes ?? 0),
-												iva: Number(d?.total_iva ?? 0),
-												isr: Number(d?.total_isr ?? 0),
-												total: Number(d?.total_cuota ?? 0),
-											};
-										}).filter(
-											(f) =>
-												f.capital !== 0 ||
-												f.interes !== 0 ||
-												f.iva !== 0 ||
-												f.isr !== 0 ||
-												f.total !== 0,
-										);
-										const totales = filas.reduce(
-											(a, f) => ({
-												capital: a.capital + f.capital,
-												interes: a.interes + f.interes,
-												iva: a.iva + f.iva,
-												isr: a.isr + f.isr,
-												total: a.total + f.total,
-											}),
-											{ capital: 0, interes: 0, iva: 0, isr: 0, total: 0 },
-										);
-										return (
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Modalidad de Reinversión</TableHead>
-														<TableHead className="text-right">
-															Capital
-														</TableHead>
-														<TableHead className="text-right">
-															Interés
-														</TableHead>
-														<TableHead className="text-right">
-															IVA 12%
-														</TableHead>
-														<TableHead className="text-right">ISR</TableHead>
-														<TableHead className="text-right">
-															Total a Recibir
-														</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{filas.map((f) => (
-														<TableRow key={f.tipo}>
-															<TableCell>{f.label}</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(f.capital)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(f.interes)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(f.iva)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(f.isr)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(f.total)}
-															</TableCell>
-														</TableRow>
-													))}
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total a Recibir</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totales.capital)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totales.interes)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totales.iva)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totales.isr)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totales.total)}
-														</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										);
-									})()
-								) : null}
-							</div>
-
-							{/* Sección: Interés Neto (agrupado por si el inversionista emite factura) */}
-							{reinversionData &&
-								(() => {
-									const cf = reinversionData.interesNeto.conFactura;
-									const sf = reinversionData.interesNeto.sinFactura;
-									const totalInteres = Number(cf.interes) + Number(sf.interes);
-									const totalIva = Number(cf.iva);
-									const totalIsr = Number(sf.isr);
-									const totalNeto = Number(cf.neto) + Number(sf.neto);
-									return (
-										<div className={SECCION_REPORTE_CLASS}>
-											<p className="mb-2 font-semibold text-sm">Interés Neto</p>
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Grupo</TableHead>
-														<TableHead className="text-right">
-															Interés
-														</TableHead>
-														<TableHead className="text-right">
-															IVA 12%
-														</TableHead>
-														<TableHead className="text-right">ISR</TableHead>
-														<TableHead className="text-right">
-															Interés Neto
-														</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													<TableRow>
-														<TableCell>Con Factura</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(cf.interes)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(cf.iva)}
-														</TableCell>
-														<TableCell className="text-right text-muted-foreground">
-															—
-														</TableCell>
-														<TableCell className="text-right font-semibold">
-															{formatCurrency(cf.neto)}
-														</TableCell>
-													</TableRow>
-													<TableRow>
-														<TableCell>Sin Factura</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(sf.interes)}
-														</TableCell>
-														<TableCell className="text-right text-muted-foreground">
-															—
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(sf.isr)}
-														</TableCell>
-														<TableCell className="text-right font-semibold">
-															{formatCurrency(sf.neto)}
-														</TableCell>
-													</TableRow>
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalInteres)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalIva)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalIsr)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(totalNeto)}
-														</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
-										</div>
-									);
-								})()}
-
-							{flujoCuotasQuery.isPending && (
-								<div className="py-4 text-center text-muted-foreground text-sm">
-									Cargando...
-								</div>
-							)}
-							{flujoCuotasQuery.isError && (
-								<div className="py-4 text-center text-destructive text-sm">
-									Error al cargar datos
-								</div>
-							)}
-							{flujoCuotasData &&
-								(() => {
-									const { pagosExtras } = flujoCuotasData;
-									const totalExtras =
-										Number(pagosExtras.abonos_capital) +
-										Number(pagosExtras.cancelaciones);
-									return (
-										<>
-											{/* Sección 3: Pagos Extras Recibidos */}
-											<div className={SECCION_REPORTE_CLASS}>
-												<p className="mb-2 font-semibold text-sm">
-													Pagos Extras Recibidos
-												</p>
-												<Table>
-													<TableHeader>
-														<TableRow>
-															<TableHead>Tipo</TableHead>
-															<TableHead className="text-right">
-																Monto
-															</TableHead>
-														</TableRow>
-													</TableHeader>
-													<TableBody>
-														<TableRow>
-															<TableCell>Abonos Extra a Capital</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(
-																	Number(pagosExtras.abonos_capital),
-																)}
-															</TableCell>
-														</TableRow>
-														<TableRow>
-															<TableCell>Cancelaciones</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(
-																	Number(pagosExtras.cancelaciones),
-																)}
-															</TableCell>
-														</TableRow>
-														<TableRow className="border-t-2 bg-muted/50 font-bold">
-															<TableCell>Total</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(totalExtras)}
-															</TableCell>
-														</TableRow>
-													</TableBody>
-												</Table>
-											</div>
-										</>
-									);
-								})()}
-
-							{/* Sección 4: Desglose por Inversionista */}
-							<div className="border-t pt-4">
-								<div className="mb-3 flex items-center justify-between">
-									<button
-										type="button"
-										className="flex items-center gap-1 font-semibold text-sm transition-colors hover:text-foreground/70"
-										onClick={() => setDesgloseInversionistaOpen((o) => !o)}
-									>
-										{desgloseInversionistaOpen ? (
-											<ChevronDown className="h-4 w-4" />
-										) : (
-											<ChevronRight className="h-4 w-4" />
-										)}
-										Desglose por Inversionista
-									</button>
-									{desgloseInversionistaOpen &&
-										(flujoPorInversionistaData?.porInversionista?.length ?? 0) >
-											0 && (
-											<Button
-												variant="outline"
-												size="sm"
-												onClick={() => {
-													const rows =
-														// eslint-disable-next-line @typescript-eslint/no-explicit-any
-														(
-															flujoPorInversionistaData!
-																.porInversionista as any[]
-														).map((r: any) => ({
-															Inversionista: r.nombre,
-															"Reinv. Capital": r.reinversion_capital,
-															"Reinv. Interés": r.reinversion_interes,
-															"Total Reinversión": r.reinversion_total,
-															"Capital a Recibir": r.cash_capital,
-															"Interés a Recibir": r.cash_interes,
-															"Total a Recibir": r.cash_total,
-															"Total General": r.total,
-														}));
-													const ws = XLSX.utils.json_to_sheet(rows);
-													ws["!cols"] = [
-														{ wch: 30 },
-														{ wch: 18 },
-														{ wch: 18 },
-														{ wch: 18 },
-														{ wch: 18 },
-														{ wch: 18 },
-														{ wch: 18 },
-														{ wch: 18 },
-													];
-													const wb = XLSX.utils.book_new();
-													XLSX.utils.book_append_sheet(
-														wb,
-														ws,
-														"Por Inversionista",
-													);
-													XLSX.writeFile(
-														wb,
-														`flujo-inversionistas-${flujoCuotasRange.fechaInicio}-${flujoCuotasRange.fechaFin}.xlsx`,
-													);
-												}}
-											>
-												<Download className="mr-2 h-4 w-4" />
-												Exportar Excel
-											</Button>
-										)}
-								</div>
-								{desgloseInversionistaOpen &&
-									(flujoPorInversionistaQuery.isPending ? (
-										<p className="py-4 text-center text-muted-foreground text-sm">
-											Cargando...
-										</p>
-									) : flujoPorInversionistaQuery.isError ? (
-										<p className="py-4 text-center text-destructive text-sm">
-											Error al cargar desglose por inversionista
-										</p>
-									) : !flujoPorInversionistaData?.porInversionista?.length ? (
-										<p className="py-4 text-center text-muted-foreground text-sm">
-											Sin datos para el período seleccionado
-										</p>
-									) : (
-										<Table>
-											<TableHeader>
-												<TableRow>
-													<TableHead>Inversionista</TableHead>
-													<TableHead className="text-right">
-														Reinversión
-													</TableHead>
-													<TableHead className="text-right">
-														A Recibir
-													</TableHead>
-													<TableHead className="text-right">Total</TableHead>
-												</TableRow>
-											</TableHeader>
-											<TableBody>
-												{(
-													flujoPorInversionistaData.porInversionista as any[]
-												).map((row: any) => (
-													<TableRow key={row.inversionista_id}>
-														<TableCell className="font-medium">
-															{row.nombre}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(Number(row.reinversion_total))}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(Number(row.cash_total))}
-														</TableCell>
-														<TableCell className="text-right font-semibold">
-															{formatCurrency(Number(row.total))}
-														</TableCell>
-													</TableRow>
-												))}
-											</TableBody>
-											{flujoPorInversionistaData?.totales && (
-												<tfoot>
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(
-																Number(
-																	flujoPorInversionistaData.totales
-																		.reinversion_total,
-																),
-															)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(
-																Number(
-																	flujoPorInversionistaData.totales.cash_total,
-																),
-															)}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(
-																Number(flujoPorInversionistaData.totales.total),
-															)}
-														</TableCell>
-													</TableRow>
-												</tfoot>
-											)}
-										</Table>
-									))}
-							</div>
-						</CardContent>
-					</Card>
-
-					{/* Modal: Metas Mensuales */}
-					<Dialog open={metasModalOpen} onOpenChange={setMetasModalOpen}>
-						<DialogContent className="sm:max-w-[860px]">
-							<DialogHeader>
-								<DialogTitle className="flex items-center gap-2">
-									<Target className="h-4 w-4 text-purple-500" />
-									Metas de Colocación
-								</DialogTitle>
-							</DialogHeader>
-							<div className="flex items-center justify-center gap-3 pb-2">
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setMetasAnio((y) => y - 1)}
-								>
-									‹
-								</Button>
-								<span className="w-16 text-center font-semibold">
-									{metasAnio}
-								</span>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setMetasAnio((y) => y + 1)}
-								>
-									›
-								</Button>
-							</div>
-							{metasQuery.isPending ? (
-								<p className="py-4 text-center text-muted-foreground text-sm">
-									Cargando...
-								</p>
-							) : (
-								<div className="grid grid-cols-2 gap-x-10 gap-y-4">
-									{MESES.map((nombreMes, idx) => {
-										const mes = idx + 1;
-										return (
-											<div key={mes} className="flex items-center gap-3">
-												<span className="w-20 shrink-0 font-medium text-sm">
-													{nombreMes}
-												</span>
-												<div className="relative min-w-0 flex-1">
-													<span className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 font-medium text-muted-foreground text-sm">
-														Q
-													</span>
-													<Input
-														type="text"
-														inputMode="decimal"
-														className="h-10 pl-7 text-right text-base"
-														placeholder="0"
-														value={
-															focusedMes === mes
-																? (editMetas[mes] ?? "")
-																: editMetas[mes] && Number(editMetas[mes]) > 0
-																	? Number(editMetas[mes]).toLocaleString(
-																			"es-GT",
-																			{
-																				minimumFractionDigits: 2,
-																				maximumFractionDigits: 2,
-																			},
-																		)
-																	: ""
-														}
-														onFocus={() => setFocusedMes(mes)}
-														onBlur={() => setFocusedMes(null)}
-														onChange={(e) => {
-															const raw = e.target.value.replace(
-																/[^0-9.]/g,
-																"",
-															);
-															setEditMetas((prev) => ({ ...prev, [mes]: raw }));
-														}}
-													/>
+							{/* Estadísticas de Leads */}
+							<Card>
+								<CardHeader>
+									<CardTitle>Conversión de Leads</CardTitle>
+									<CardDescription>
+										Estado de los prospectos en el sistema
+									</CardDescription>
+								</CardHeader>
+								<CardContent>
+									<div className="grid gap-4 md:grid-cols-5">
+										{dashboardData.data?.leadsStats.map((stat) => (
+											<div key={stat.status} className="rounded-lg border p-4">
+												<div className="text-muted-foreground text-sm">
+													{stat.status === "new"
+														? "Nuevos"
+														: stat.status === "contacted"
+															? "Contactados"
+															: stat.status === "qualified"
+																? "Calificados"
+																: stat.status === "unqualified"
+																	? "No calificados"
+																	: "Convertidos"}
+												</div>
+												<div className="mt-1 font-bold text-2xl">
+													{stat.total}
 												</div>
 											</div>
-										);
-									})}
-								</div>
-							)}
-							<div className="flex justify-end gap-2 pt-2">
-								<Button
-									variant="outline"
-									onClick={() => setMetasModalOpen(false)}
-								>
-									Cancelar
-								</Button>
-								<Button onClick={handleGuardarTodo} disabled={isSavingMetas}>
-									{isSavingMetas && (
-										<Loader2 className="mr-2 h-4 w-4 animate-spin" />
-									)}
-									Guardar todo
-								</Button>
-							</div>
-						</DialogContent>
-					</Dialog>
-
-					{/* Modales de simulación de escenarios */}
-					<ScenarioModal
-						open={scenarioOpen === "monto"}
-						onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
-						config={montoACobrarConfig}
-						baseData={montoCobrarData?.data}
-					/>
-					<ScenarioModal
-						open={scenarioOpen === "facturacion"}
-						onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
-						config={facturacionConfig}
-						baseData={facturacionMesData}
-					/>
-					<ScenarioModal
-						open={scenarioOpen === "flujo"}
-						onOpenChange={(o) => setScenarioOpen(o ? "flujo" : null)}
-						config={flujoCuotasConfig}
-						baseData={flujoCuotasData}
-					/>
-					<ScenarioModal
-						open={scenarioOpen === "cobertura"}
-						onOpenChange={(o) => setScenarioOpen(o ? "cobertura" : null)}
-						config={coberturaConfig}
-						baseData={puntoEquilibrioData?.data}
-					/>
-					<ScenarioModal
-						open={scenarioOpen === "comparativo"}
-						onOpenChange={(o) => setScenarioOpen(o ? "comparativo" : null)}
-						config={comparativoConfig}
-						baseData={comparativoData?.data}
-					/>
-
-					{/* Cobertura de Colocación vs Meta */}
-					<Card>
-						<CardHeader>
-							<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-								<div className="flex items-center gap-2">
-									<TrendingUp className="h-5 w-5 text-green-500" />
-									<div>
-										<CardTitle>Cobertura de Colocación vs Meta</CardTitle>
-										<CardDescription>
-											Compara el capital colocado en cada período contra la meta
-											mensual definida
-										</CardDescription>
+										))}
 									</div>
-								</div>
-								<div className="flex flex-wrap items-center gap-2">
-									<SimularButton onClick={() => setScenarioOpen("cobertura")} />
-									<Button
-										variant="outline"
-										size="sm"
-										className="gap-1.5"
-										onClick={() => setMetasModalOpen(true)}
-									>
-										<Target className="h-3.5 w-3.5" />
-										Configurar metas
-									</Button>
-									<Select
-										value={equilibrioPeriodo}
-										onValueChange={(v) =>
-											setEquilibrioPeriodo(
-												v as "anio" | "trimestre" | "mes" | "semana" | "dia",
-											)
-										}
-									>
-										<SelectTrigger className="w-[140px]">
-											<SelectValue placeholder="Período" />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="dia">Día</SelectItem>
-											<SelectItem value="semana">Semana</SelectItem>
-											<SelectItem value="mes">Mes</SelectItem>
-											<SelectItem value="trimestre">Trimestre</SelectItem>
-											<SelectItem value="anio">Año</SelectItem>
-										</SelectContent>
-									</Select>
-									<DateRangeFilter
-										dateRange={
-											equilibrioRange.fechaInicio && equilibrioRange.fechaFin
-												? {
-														from: dateFromInput(equilibrioRange.fechaInicio),
-														to: dateFromInput(equilibrioRange.fechaFin),
+								</CardContent>
+							</Card>
+						</TabsContent>
+						<TabsContent value="cobranza" className="space-y-6">
+							{/* Reporte: Monto a Cobrarse por Período */}
+							<Card>
+								<CardHeader>
+									<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+										<div className="flex items-center gap-2">
+											<CalendarDays className="h-5 w-5 text-blue-500" />
+											<div>
+												<CardTitle>Monto a Cobrarse por Período</CardTitle>
+												<CardDescription>
+													Cuotas pendientes desglosadas por rubro (capital,
+													interés, seguro, etc.)
+												</CardDescription>
+											</div>
+										</div>
+										<div className="flex flex-wrap items-center gap-2">
+											<SimularButton onClick={() => setScenarioOpen("monto")} />
+											<Select
+												value={montoCobrarPeriodo}
+												onValueChange={(v) =>
+													setMontoCobrarPeriodo(
+														v as
+															| "anio"
+															| "trimestre"
+															| "mes"
+															| "semana"
+															| "dia",
+													)
+												}
+											>
+												<SelectTrigger className="w-[140px]">
+													<SelectValue placeholder="Período" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="dia">Día</SelectItem>
+													<SelectItem value="semana">Semana</SelectItem>
+													<SelectItem value="mes">Mes</SelectItem>
+													<SelectItem value="trimestre">Trimestre</SelectItem>
+													<SelectItem value="anio">Año</SelectItem>
+												</SelectContent>
+											</Select>
+											<DateRangeFilter
+												dateRange={
+													montoCobrarRange.fechaInicio &&
+													montoCobrarRange.fechaFin
+														? {
+																from: dateFromInput(
+																	montoCobrarRange.fechaInicio,
+																),
+																to: dateFromInput(montoCobrarRange.fechaFin),
+															}
+														: undefined
+												}
+												onDateRangeChange={(range) => {
+													if (range?.from && range?.to) {
+														setMontoCobrarRange({
+															fechaInicio: formatDateInput(range.from),
+															fechaFin: formatDateInput(range.to),
+														});
 													}
-												: undefined
-										}
-										onDateRangeChange={(range) => {
-											if (range?.from && range?.to) {
-												setEquilibrioRange({
-													fechaInicio: formatDateInput(range.from),
-													fechaFin: formatDateInput(range.to),
-												});
-											}
-										}}
-									/>
-								</div>
-							</div>
-						</CardHeader>
-						<CardContent className="space-y-4">
-							{puntoEquilibrioQuery.isPending && (
-								<p className="text-muted-foreground text-sm">
-									Cargando reporte...
-								</p>
-							)}
-							{puntoEquilibrioQuery.isError && (
-								<p className="text-destructive text-sm">
-									Error al cargar reporte de cobertura.
-								</p>
-							)}
-							{puntoEquilibrioData && puntoEquilibrioData.data.length === 0 && (
-								<p className="text-muted-foreground text-sm">
-									No hay datos de colocación para el rango seleccionado.
-								</p>
-							)}
-							{!!puntoEquilibrioData?.data.length &&
-								(() => {
-									const rows = puntoEquilibrioData.data;
-									const totalColocado = rows.reduce(
-										(acc, r) => acc + Number(r.colocado),
-										0,
-									);
-									const totalMeta = rows.reduce(
-										(acc, r) => acc + Number(r.meta),
-										0,
-									);
-									const totalCreditos = rows.reduce(
-										(acc, r) => acc + r.cantidad_creditos,
-										0,
-									);
-									const totalCobertura =
-										totalMeta > 0
-											? ((totalColocado / totalMeta) * 100).toFixed(1)
-											: null;
-									return (
+												}}
+											/>
+										</div>
+									</div>
+								</CardHeader>
+								<CardContent className="space-y-6">
+									{montoCobrarQuery.isPending && <p>Cargando reporte...</p>}
+									{montoCobrarQuery.isError && (
+										<p className="text-destructive">
+											Error al cargar el reporte de monto a cobrarse.
+										</p>
+									)}
+									{montoCobrarData && montoCobrarData.data.length === 0 && (
+										<p className="text-muted-foreground">
+											No hay cuotas pendientes para el rango seleccionado.
+										</p>
+									)}
+									{!!montoCobrarData?.data.length && (
 										<>
-											<ResponsiveContainer width="100%" height={300}>
+											{/* Gráfica de barras apiladas */}
+											<ResponsiveContainer width="100%" height={350}>
 												<BarChart
-													data={rows.map((row) => ({
-														bucket: formatBucket(row.bucket, equilibrioPeriodo),
-														colocado: Number(row.colocado),
-														meta: Number(row.meta),
-													}))}
+													data={montoCobrarData.data.map(
+														(row: MontoACobrarRow) => ({
+															bucket: formatBucket(
+																row.bucket,
+																montoCobrarPeriodo,
+															),
+															total_cuota: Number.parseFloat(row.total_cuota),
+															total_interes: Number.parseFloat(
+																row.total_interes,
+															),
+															total_iva: Number.parseFloat(row.total_iva),
+															total_seguro: Number.parseFloat(row.total_seguro),
+															total_gps: Number.parseFloat(row.total_gps),
+															total_membresias: Number.parseFloat(
+																row.total_membresias,
+															),
+															total_royalti: Number.parseFloat(
+																row.total_royalti,
+															),
+														}),
+													)}
 												>
 													<CartesianGrid strokeDasharray="3 3" />
 													<XAxis
@@ -2215,373 +1192,1520 @@ function RouteComponent() {
 													<Tooltip
 														formatter={(value, name) => [
 															formatCurrency(Number(value)),
-															name === "colocado" ? "Colocado" : "Meta",
+															MONTO_COBRAR_LABELS[
+																name as keyof typeof MONTO_COBRAR_LABELS
+															] ?? name,
 														]}
 													/>
 													<Legend
-														formatter={(v) =>
-															v === "colocado" ? "Colocado" : "Meta"
+														formatter={(value) =>
+															MONTO_COBRAR_LABELS[
+																value as keyof typeof MONTO_COBRAR_LABELS
+															] ?? value
 														}
 													/>
-													<Bar
-														dataKey="colocado"
-														fill="#3b82f6"
-														name="colocado"
-													/>
-													<Bar dataKey="meta" fill="#d1d5db" name="meta" />
+													{(
+														Object.keys(
+															MONTO_COBRAR_COLORS,
+														) as (keyof typeof MONTO_COBRAR_COLORS)[]
+													).map((key) => (
+														<Bar
+															key={key}
+															dataKey={key}
+															stackId="a"
+															fill={MONTO_COBRAR_COLORS[key]}
+														/>
+													))}
 												</BarChart>
 											</ResponsiveContainer>
 
+											{/* Tabla detallada */}
 											<div className="overflow-x-auto">
 												<Table>
 													<TableHeader>
 														<TableRow>
 															<TableHead>Período</TableHead>
 															<TableHead className="text-right">
-																Créditos
+																Cuotas
 															</TableHead>
 															<TableHead className="text-right">
-																Colocado
-															</TableHead>
-															<TableHead className="text-right">Meta</TableHead>
-															<TableHead className="text-right">
-																Cobertura
+																Capital
 															</TableHead>
 															<TableHead className="text-right">
-																Faltante
+																Interés
+															</TableHead>
+															<TableHead className="text-right">IVA</TableHead>
+															<TableHead className="text-right">
+																Seguro
+															</TableHead>
+															<TableHead className="text-right">GPS</TableHead>
+															<TableHead className="text-right">
+																Membresías
+															</TableHead>
+															<TableHead className="text-right">
+																Royalti
+															</TableHead>
+															<TableHead className="text-right">
+																Mora Prom.
+															</TableHead>
+															<TableHead className="text-right font-bold">
+																Total
 															</TableHead>
 														</TableRow>
 													</TableHeader>
 													<TableBody>
-														{rows.map((row) => (
-															<TableRow key={row.bucket}>
+														{montoCobrarData.data.map(
+															(row: MontoACobrarRow) => {
+																const total =
+																	Number.parseFloat(row.total_cuota) +
+																	Number.parseFloat(row.total_interes) +
+																	Number.parseFloat(row.total_iva) +
+																	Number.parseFloat(row.total_seguro) +
+																	Number.parseFloat(row.total_gps) +
+																	Number.parseFloat(row.total_membresias) +
+																	Number.parseFloat(row.total_royalti);
+																return (
+																	<TableRow key={row.bucket}>
+																		<TableCell>
+																			{formatBucket(
+																				row.bucket,
+																				montoCobrarPeriodo,
+																			)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.cuotas_count}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.total_cuota)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.total_interes)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.total_iva)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.total_seguro)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.total_gps)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.total_membresias)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.total_royalti)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.mora_promedio)}
+																		</TableCell>
+																		<TableCell className="text-right font-bold">
+																			{formatCurrency(total)}
+																		</TableCell>
+																	</TableRow>
+																);
+															},
+														)}
+														{/* Fila de totales */}
+														{(() => {
+															const rows =
+																montoCobrarData.data as MontoACobrarRow[];
+															const sum = (key: keyof MontoACobrarRow) =>
+																rows.reduce(
+																	(acc: number, r: MontoACobrarRow) =>
+																		acc +
+																		Number.parseFloat(
+																			(r[key] as string) || "0",
+																		),
+																	0,
+																);
+															const grandTotal =
+																sum("total_cuota") +
+																sum("total_interes") +
+																sum("total_iva") +
+																sum("total_seguro") +
+																sum("total_gps") +
+																sum("total_membresias") +
+																sum("total_royalti");
+															return (
+																<TableRow className="border-t-2 bg-muted/50 font-bold">
+																	<TableCell>Total</TableCell>
+																	<TableCell className="text-right">
+																		{rows.reduce(
+																			(acc, r) => acc + r.cuotas_count,
+																			0,
+																		)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(sum("total_cuota"))}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(sum("total_interes"))}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(sum("total_iva"))}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(sum("total_seguro"))}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(sum("total_gps"))}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(sum("total_membresias"))}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(sum("total_royalti"))}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		—
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(grandTotal)}
+																	</TableCell>
+																</TableRow>
+															);
+														})()}
+													</TableBody>
+												</Table>
+											</div>
+										</>
+									)}
+								</CardContent>
+							</Card>
+
+							{/* Reporte: Facturado del Mes vs Esperado */}
+							<Card>
+								<CardHeader>
+									<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+										<div>
+											<CardTitle className="flex items-center gap-2">
+												<CalendarDays className="h-5 w-5" />
+												Facturado del Mes vs Esperado
+											</CardTitle>
+											<CardDescription>
+												Compara lo cobrado en el mes contra lo esperado según
+												fecha de vencimiento
+											</CardDescription>
+										</div>
+										<div className="flex items-center gap-2">
+											<SimularButton
+												onClick={() => setScenarioOpen("facturacion")}
+											/>
+											<Select
+												value={String(facturacionMes.mes)}
+												onValueChange={(v) =>
+													setFacturacionMes((prev) => ({
+														...prev,
+														mes: Number(v),
+													}))
+												}
+											>
+												<SelectTrigger className="w-36">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{[
+														"Enero",
+														"Febrero",
+														"Marzo",
+														"Abril",
+														"Mayo",
+														"Junio",
+														"Julio",
+														"Agosto",
+														"Septiembre",
+														"Octubre",
+														"Noviembre",
+														"Diciembre",
+													].map((label, i) => (
+														<SelectItem key={i + 1} value={String(i + 1)}>
+															{label}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+											<Input
+												type="number"
+												className="w-24"
+												value={facturacionMes.anio}
+												min={2020}
+												max={2100}
+												onChange={(e) =>
+													setFacturacionMes((prev) => ({
+														...prev,
+														anio: Number(e.target.value),
+													}))
+												}
+											/>
+										</div>
+									</div>
+								</CardHeader>
+								<CardContent>
+									{facturacionMesQuery.isPending && (
+										<div className="py-4 text-center text-muted-foreground text-sm">
+											Cargando...
+										</div>
+									)}
+									{facturacionMesQuery.isError && (
+										<div className="py-4 text-center text-destructive text-sm">
+											Error al cargar datos
+										</div>
+									)}
+									{facturacionMesData &&
+										(() => {
+											const { cobrado, esperado } = facturacionMesData;
+											const totalCobrado = FACTURACION_RUBROS.reduce(
+												(acc, r) => acc + Number(cobrado[r.key] || 0),
+												0,
+											);
+											const totalEsperado = FACTURACION_RUBROS.reduce(
+												(acc, r) => acc + Number(esperado[r.key] || 0),
+												0,
+											);
+											return (
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Rubro</TableHead>
+															<TableHead className="text-right">
+																Cobrado
+															</TableHead>
+															<TableHead className="text-right">
+																Esperado
+															</TableHead>
+															<TableHead className="w-48">Progreso</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														{FACTURACION_RUBROS.map(({ key, label }) => (
+															<TableRow key={key}>
+																<TableCell>{label}</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(Number(cobrado[key] || 0))}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(Number(esperado[key] || 0))}
+																</TableCell>
 																<TableCell>
-																	{formatBucket(row.bucket, equilibrioPeriodo)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{row.cantidad_creditos}
-																</TableCell>
-																<TableCell className="text-right">
-																	{formatCurrency(row.colocado)}
-																</TableCell>
-																<TableCell className="text-right">
-																	{Number(row.meta) > 0 ? (
-																		formatCurrency(row.meta)
-																	) : (
-																		<span className="text-muted-foreground">
-																			Sin meta
-																		</span>
-																	)}
-																</TableCell>
-																<TableCell className="text-right">
-																	<span
-																		className="font-semibold"
-																		style={{
-																			color: coberturaColor(row.cobertura),
-																		}}
-																	>
-																		{coberturaLabel(row.cobertura)}
-																	</span>
-																</TableCell>
-																<TableCell className="text-right">
-																	{row.faltante
-																		? formatCurrency(row.faltante)
-																		: "—"}
+																	<ProgressBar
+																		value={Number(cobrado[key] || 0)}
+																		max={Number(esperado[key] || 0)}
+																	/>
 																</TableCell>
 															</TableRow>
 														))}
 														<TableRow className="border-t-2 bg-muted/50 font-bold">
 															<TableCell>Total</TableCell>
 															<TableCell className="text-right">
-																{totalCreditos}
+																{formatCurrency(totalCobrado)}
 															</TableCell>
 															<TableCell className="text-right">
-																{formatCurrency(totalColocado)}
+																{formatCurrency(totalEsperado)}
 															</TableCell>
-															<TableCell className="text-right">
-																{totalMeta > 0
-																	? formatCurrency(totalMeta)
-																	: "—"}
-															</TableCell>
-															<TableCell className="text-right">
-																<span
-																	className="font-semibold"
-																	style={{
-																		color: coberturaColor(totalCobertura),
-																	}}
-																>
-																	{coberturaLabel(totalCobertura)}
-																</span>
-															</TableCell>
-															<TableCell className="text-right">
-																{totalMeta > 0
-																	? formatCurrency(
-																			Math.max(0, totalMeta - totalColocado),
-																		)
-																	: "—"}
+															<TableCell>
+																<ProgressBar
+																	value={totalCobrado}
+																	max={totalEsperado}
+																/>
 															</TableCell>
 														</TableRow>
 													</TableBody>
 												</Table>
+											);
+										})()}
+								</CardContent>
+							</Card>
+						</TabsContent>
+						<TabsContent value="inversiones" className="space-y-6">
+							{/* Reporte: Flujo de Cuotas de Inversiones */}
+							<Card>
+								<CardHeader>
+									<div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+										<div>
+											<CardTitle className="flex items-center gap-2">
+												<TrendingUp className="h-5 w-5" />
+												Flujo de Cuotas de Inversiones
+											</CardTitle>
+											<CardDescription>
+												Cuotas esperadas hacia reinversión y hacia pago en
+												efectivo, por período
+											</CardDescription>
+										</div>
+										<div className="flex items-center gap-2">
+											<SimularButton onClick={() => setScenarioOpen("flujo")} />
+											<Select
+												value={String(flujoMesNum)}
+												onValueChange={(v) =>
+													setFlujoMesAnio(flujoAnioNum, Number(v))
+												}
+											>
+												<SelectTrigger className="w-36" aria-label="Mes">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{mesesDisponibles.map((m) => (
+														<SelectItem key={m.num} value={String(m.num)}>
+															{m.nombre}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+											<Select
+												value={String(flujoAnioNum)}
+												onValueChange={(v) =>
+													setFlujoMesAnio(Number(v), flujoMesNum)
+												}
+											>
+												<SelectTrigger className="w-24" aria-label="Año">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													{aniosDisponibles.map((a) => (
+														<SelectItem key={a} value={String(a)}>
+															{a}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</div>
+									</div>
+								</CardHeader>
+								<CardContent className="space-y-8">
+									{/* Sección 1: Cuotas → Reinversión (desde liquidaciones) */}
+									<div className={SECCION_REPORTE_CLASS}>
+										<p className="mb-2 font-semibold text-sm">
+											Cuotas → Reinversión
+										</p>
+										{reinversionLiquidacionesQuery.isPending ? (
+											<div className="py-4 text-center text-muted-foreground text-sm">
+												Cargando...
 											</div>
-										</>
-									);
-								})()}
-						</CardContent>
-					</Card>
+										) : reinversionLiquidacionesQuery.isError ? (
+											<div className="py-4 text-center text-destructive text-sm">
+												Error al cargar datos
+											</div>
+										) : reinversionData ? (
+											(() => {
+												const filas = REINVERSION_MODALIDADES.map((m) => ({
+													...m,
+													monto: Number(
+														reinversionData.porTipo[m.tipo]
+															?.reinversion_total ?? 0,
+													),
+												})).filter((f) => f.monto !== 0);
+												const totalMostrado = filas.reduce(
+													(a, f) => a + f.monto,
+													0,
+												);
+												return (
+													<Table>
+														<TableHeader>
+															<TableRow>
+																<TableHead>Modalidad de Reinversión</TableHead>
+																<TableHead className="text-right">
+																	Reinversión Total
+																</TableHead>
+															</TableRow>
+														</TableHeader>
+														<TableBody>
+															{filas.map((f) => (
+																<TableRow key={f.tipo}>
+																	<TableCell>{f.label}</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(f.monto)}
+																	</TableCell>
+																</TableRow>
+															))}
+															<TableRow className="border-t-2 bg-muted/50 font-bold">
+																<TableCell>Total Reinvertido</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totalMostrado)}
+																</TableCell>
+															</TableRow>
+														</TableBody>
+													</Table>
+												);
+											})()
+										) : null}
+									</div>
 
-					{/* ============================================================ */}
-					{/* REPORTE: COMPARATIVO HISTÓRICO MENSUAL                        */}
-					{/* ============================================================ */}
-					<Card>
-						<CardHeader>
-							<div className="flex items-center justify-between">
-								<CardTitle className="flex items-center gap-2">
-									<CalendarDays className="h-5 w-5" />
-									Comparativo Histórico Mensual
-								</CardTitle>
-								<div className="flex items-center gap-2">
-									<SimularButton
-										onClick={() => setScenarioOpen("comparativo")}
-									/>
-									<button
-										type="button"
-										className="rounded p-1 hover:bg-muted"
-										onClick={() => setComparativoAnio((y) => y - 1)}
-									>
-										<ChevronLeft className="h-4 w-4" />
-									</button>
-									<span className="w-12 text-center font-semibold text-sm">
-										{comparativoAnio}
-									</span>
-									<button
-										type="button"
-										className="rounded p-1 hover:bg-muted"
-										onClick={() =>
-											setComparativoAnio((y) =>
-												y < new Date().getFullYear() ? y + 1 : y,
-											)
-										}
-									>
-										<ChevronRight className="h-4 w-4" />
-									</button>
-								</div>
-							</div>
-						</CardHeader>
-						<CardContent>
-							{comparativoQuery.isPending && (
-								<p className="py-4 text-center text-muted-foreground text-sm">
-									Cargando...
-								</p>
-							)}
-							{comparativoQuery.isError && (
-								<p className="py-4 text-center text-red-500 text-sm">
-									Error al cargar comparativo histórico.
-								</p>
-							)}
-							{comparativoData &&
-								(() => {
-									const rows = comparativoData.data;
-									const sumColoc = rows.reduce(
-										(acc, r) =>
-											acc +
-											(r.colocacion_monto ? Number(r.colocacion_monto) : 0),
-										0,
-									);
-									const sumFacturacion = rows.reduce(
-										(acc, r) =>
-											acc + (r.facturacion ? Number(r.facturacion) : 0),
-										0,
-									);
-									const sumCreditosColoc = rows.reduce(
-										(acc, r) => acc + (r.colocacion_creditos ?? 0),
-										0,
-									);
-									return (
-										<div className="overflow-x-auto">
-											<Table>
-												<TableHeader>
-													<TableRow>
-														<TableHead>Mes</TableHead>
-														<TableHead className="text-right">
-															Colocación (Q)
-														</TableHead>
-														<TableHead className="text-right"># Col.</TableHead>
-														<TableHead className="text-right">
-															Facturación (Q)
-														</TableHead>
-														<TableHead className="text-right">
-															Cartera Activa (Q)
-														</TableHead>
-														<TableHead className="text-right">
-															# Activos
-														</TableHead>
-														<TableHead className="text-right">
-															Mora 30 (Q)
-														</TableHead>
-														<TableHead className="text-right">
-															Mora 60 (Q)
-														</TableHead>
-														<TableHead className="text-right">
-															Mora 90 (Q)
-														</TableHead>
-														<TableHead className="text-right">
-															Mora 120+ (Q)
-														</TableHead>
-													</TableRow>
-												</TableHeader>
-												<TableBody>
-													{rows.map((row) => {
-														const esFuturo =
-															row.colocacion_monto === null &&
-															row.facturacion === null &&
-															row.cartera_activa === null;
-														const totalMoraFila =
-															Number(row.mora_30 ?? 0) +
-															Number(row.mora_60 ?? 0) +
-															Number(row.mora_90 ?? 0) +
-															Number(row.mora_120 ?? 0);
-														const pctMora = (val: string | null) =>
-															totalMoraFila > 0 && val
-																? ((Number(val) / totalMoraFila) * 100).toFixed(
-																		1,
-																	)
-																: null;
-														return (
-															<TableRow
-																key={row.mes}
-																className={esFuturo ? "opacity-40" : undefined}
-															>
+									{/* Sección 2: Cuotas → A Recibir (efectivo neto = total_cuota) */}
+									<div className={SECCION_REPORTE_CLASS}>
+										<p className="mb-2 font-semibold text-sm">
+											Cuotas → A Recibir
+										</p>
+										{reinversionLiquidacionesQuery.isPending ? (
+											<div className="py-4 text-center text-muted-foreground text-sm">
+												Cargando...
+											</div>
+										) : reinversionLiquidacionesQuery.isError ? (
+											<div className="py-4 text-center text-destructive text-sm">
+												Error al cargar datos
+											</div>
+										) : reinversionData ? (
+											(() => {
+												const filas = A_RECIBIR_MODALIDADES.map((m) => {
+													const d = reinversionData.porTipo[m.tipo];
+													return {
+														...m,
+														capital: Number(d?.total_capital ?? 0),
+														interes: Number(d?.total_interes ?? 0),
+														iva: Number(d?.total_iva ?? 0),
+														isr: Number(d?.total_isr ?? 0),
+														total: Number(d?.total_cuota ?? 0),
+													};
+												}).filter(
+													(f) =>
+														f.capital !== 0 ||
+														f.interes !== 0 ||
+														f.iva !== 0 ||
+														f.isr !== 0 ||
+														f.total !== 0,
+												);
+												const totales = filas.reduce(
+													(a, f) => ({
+														capital: a.capital + f.capital,
+														interes: a.interes + f.interes,
+														iva: a.iva + f.iva,
+														isr: a.isr + f.isr,
+														total: a.total + f.total,
+													}),
+													{ capital: 0, interes: 0, iva: 0, isr: 0, total: 0 },
+												);
+												return (
+													<Table>
+														<TableHeader>
+															<TableRow>
+																<TableHead>Modalidad de Reinversión</TableHead>
+																<TableHead className="text-right">
+																	Capital
+																</TableHead>
+																<TableHead className="text-right">
+																	Interés
+																</TableHead>
+																<TableHead className="text-right">
+																	IVA 12%
+																</TableHead>
+																<TableHead className="text-right">
+																	ISR
+																</TableHead>
+																<TableHead className="text-right">
+																	Total a Recibir
+																</TableHead>
+															</TableRow>
+														</TableHeader>
+														<TableBody>
+															{filas.map((f) => (
+																<TableRow key={f.tipo}>
+																	<TableCell>{f.label}</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(f.capital)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(f.interes)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(f.iva)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(f.isr)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(f.total)}
+																	</TableCell>
+																</TableRow>
+															))}
+															<TableRow className="border-t-2 bg-muted/50 font-bold">
+																<TableCell>Total a Recibir</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totales.capital)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totales.interes)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totales.iva)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totales.isr)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totales.total)}
+																</TableCell>
+															</TableRow>
+														</TableBody>
+													</Table>
+												);
+											})()
+										) : null}
+									</div>
+
+									{/* Sección: Interés Neto (agrupado por si el inversionista emite factura) */}
+									{reinversionData &&
+										(() => {
+											const cf = reinversionData.interesNeto.conFactura;
+											const sf = reinversionData.interesNeto.sinFactura;
+											const totalInteres =
+												Number(cf.interes) + Number(sf.interes);
+											const totalIva = Number(cf.iva);
+											const totalIsr = Number(sf.isr);
+											const totalNeto = Number(cf.neto) + Number(sf.neto);
+											return (
+												<div className={SECCION_REPORTE_CLASS}>
+													<p className="mb-2 font-semibold text-sm">
+														Interés Neto
+													</p>
+													<Table>
+														<TableHeader>
+															<TableRow>
+																<TableHead>Grupo</TableHead>
+																<TableHead className="text-right">
+																	Interés
+																</TableHead>
+																<TableHead className="text-right">
+																	IVA 12%
+																</TableHead>
+																<TableHead className="text-right">
+																	ISR
+																</TableHead>
+																<TableHead className="text-right">
+																	Interés Neto
+																</TableHead>
+															</TableRow>
+														</TableHeader>
+														<TableBody>
+															<TableRow>
+																<TableCell>Con Factura</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(cf.interes)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(cf.iva)}
+																</TableCell>
+																<TableCell className="text-right text-muted-foreground">
+																	—
+																</TableCell>
+																<TableCell className="text-right font-semibold">
+																	{formatCurrency(cf.neto)}
+																</TableCell>
+															</TableRow>
+															<TableRow>
+																<TableCell>Sin Factura</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(sf.interes)}
+																</TableCell>
+																<TableCell className="text-right text-muted-foreground">
+																	—
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(sf.isr)}
+																</TableCell>
+																<TableCell className="text-right font-semibold">
+																	{formatCurrency(sf.neto)}
+																</TableCell>
+															</TableRow>
+															<TableRow className="border-t-2 bg-muted/50 font-bold">
+																<TableCell>Total</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totalInteres)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totalIva)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totalIsr)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(totalNeto)}
+																</TableCell>
+															</TableRow>
+														</TableBody>
+													</Table>
+												</div>
+											);
+										})()}
+
+									{flujoCuotasQuery.isPending && (
+										<div className="py-4 text-center text-muted-foreground text-sm">
+											Cargando...
+										</div>
+									)}
+									{flujoCuotasQuery.isError && (
+										<div className="py-4 text-center text-destructive text-sm">
+											Error al cargar datos
+										</div>
+									)}
+									{flujoCuotasData &&
+										(() => {
+											const { pagosExtras } = flujoCuotasData;
+											const totalExtras =
+												Number(pagosExtras.abonos_capital) +
+												Number(pagosExtras.cancelaciones);
+											return (
+												<>
+													{/* Sección 3: Pagos Extras Recibidos */}
+													<div className={SECCION_REPORTE_CLASS}>
+														<p className="mb-2 font-semibold text-sm">
+															Pagos Extras Recibidos
+														</p>
+														<Table>
+															<TableHeader>
+																<TableRow>
+																	<TableHead>Tipo</TableHead>
+																	<TableHead className="text-right">
+																		Monto
+																	</TableHead>
+																</TableRow>
+															</TableHeader>
+															<TableBody>
+																<TableRow>
+																	<TableCell>Abonos Extra a Capital</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(
+																			Number(pagosExtras.abonos_capital),
+																		)}
+																	</TableCell>
+																</TableRow>
+																<TableRow>
+																	<TableCell>Cancelaciones</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(
+																			Number(pagosExtras.cancelaciones),
+																		)}
+																	</TableCell>
+																</TableRow>
+																<TableRow className="border-t-2 bg-muted/50 font-bold">
+																	<TableCell>Total</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(totalExtras)}
+																	</TableCell>
+																</TableRow>
+															</TableBody>
+														</Table>
+													</div>
+												</>
+											);
+										})()}
+
+									{/* Sección 4: Desglose por Inversionista */}
+									<div className="border-t pt-4">
+										<div className="mb-3 flex items-center justify-between">
+											<button
+												type="button"
+												className="flex items-center gap-1 font-semibold text-sm transition-colors hover:text-foreground/70"
+												onClick={() => setDesgloseInversionistaOpen((o) => !o)}
+											>
+												{desgloseInversionistaOpen ? (
+													<ChevronDown className="h-4 w-4" />
+												) : (
+													<ChevronRight className="h-4 w-4" />
+												)}
+												Desglose por Inversionista
+											</button>
+											{desgloseInversionistaOpen &&
+												(flujoPorInversionistaData?.porInversionista?.length ??
+													0) > 0 && (
+													<Button
+														variant="outline"
+														size="sm"
+														onClick={() => {
+															const rows =
+																// eslint-disable-next-line @typescript-eslint/no-explicit-any
+																(
+																	flujoPorInversionistaData!
+																		.porInversionista as any[]
+																).map((r: any) => ({
+																	Inversionista: r.nombre,
+																	"Reinv. Capital": r.reinversion_capital,
+																	"Reinv. Interés": r.reinversion_interes,
+																	"Total Reinversión": r.reinversion_total,
+																	"Capital a Recibir": r.cash_capital,
+																	"Interés a Recibir": r.cash_interes,
+																	"Total a Recibir": r.cash_total,
+																	"Total General": r.total,
+																}));
+															const ws = XLSX.utils.json_to_sheet(rows);
+															ws["!cols"] = [
+																{ wch: 30 },
+																{ wch: 18 },
+																{ wch: 18 },
+																{ wch: 18 },
+																{ wch: 18 },
+																{ wch: 18 },
+																{ wch: 18 },
+																{ wch: 18 },
+															];
+															const wb = XLSX.utils.book_new();
+															XLSX.utils.book_append_sheet(
+																wb,
+																ws,
+																"Por Inversionista",
+															);
+															XLSX.writeFile(
+																wb,
+																`flujo-inversionistas-${flujoCuotasRange.fechaInicio}-${flujoCuotasRange.fechaFin}.xlsx`,
+															);
+														}}
+													>
+														<Download className="mr-2 h-4 w-4" />
+														Exportar Excel
+													</Button>
+												)}
+										</div>
+										{desgloseInversionistaOpen &&
+											(flujoPorInversionistaQuery.isPending ? (
+												<p className="py-4 text-center text-muted-foreground text-sm">
+													Cargando...
+												</p>
+											) : flujoPorInversionistaQuery.isError ? (
+												<p className="py-4 text-center text-destructive text-sm">
+													Error al cargar desglose por inversionista
+												</p>
+											) : !flujoPorInversionistaData?.porInversionista
+													?.length ? (
+												<p className="py-4 text-center text-muted-foreground text-sm">
+													Sin datos para el período seleccionado
+												</p>
+											) : (
+												<Table>
+													<TableHeader>
+														<TableRow>
+															<TableHead>Inversionista</TableHead>
+															<TableHead className="text-right">
+																Reinversión
+															</TableHead>
+															<TableHead className="text-right">
+																A Recibir
+															</TableHead>
+															<TableHead className="text-right">
+																Total
+															</TableHead>
+														</TableRow>
+													</TableHeader>
+													<TableBody>
+														{(
+															flujoPorInversionistaData.porInversionista as any[]
+														).map((row: any) => (
+															<TableRow key={row.inversionista_id}>
 																<TableCell className="font-medium">
-																	{MESES[row.mes - 1]}
+																	{row.nombre}
 																</TableCell>
 																<TableCell className="text-right">
-																	{row.colocacion_monto
-																		? formatCurrency(
-																				Number(row.colocacion_monto),
-																			)
-																		: "—"}
-																</TableCell>
-																<TableCell className="text-right">
-																	{row.colocacion_creditos ?? "—"}
-																</TableCell>
-																<TableCell className="text-right">
-																	{row.facturacion
-																		? formatCurrency(Number(row.facturacion))
-																		: "—"}
-																</TableCell>
-																<TableCell className="text-right">
-																	{row.cartera_activa
-																		? formatCurrency(Number(row.cartera_activa))
-																		: "—"}
-																</TableCell>
-																<TableCell className="text-right">
-																	{row.creditos_activos ?? "—"}
-																</TableCell>
-																<TableCell className="text-right">
-																	{row.mora_30 ? (
-																		<div>
-																			<span>
-																				{formatCurrency(Number(row.mora_30))}
-																				<span className="ml-1 text-muted-foreground text-xs">
-																					({row.creditos_30 ?? 0})
-																				</span>
-																			</span>
-																			{pctMora(row.mora_30) && (
-																				<div className="text-muted-foreground text-xs">
-																					{pctMora(row.mora_30)}%
-																				</div>
-																			)}
-																		</div>
-																	) : (
-																		"—"
+																	{formatCurrency(
+																		Number(row.reinversion_total),
 																	)}
 																</TableCell>
 																<TableCell className="text-right">
-																	{row.mora_60 ? (
-																		<div>
-																			<span>
-																				{formatCurrency(Number(row.mora_60))}
-																				<span className="ml-1 text-muted-foreground text-xs">
-																					({row.creditos_60 ?? 0})
-																				</span>
-																			</span>
-																			{pctMora(row.mora_60) && (
-																				<div className="text-muted-foreground text-xs">
-																					{pctMora(row.mora_60)}%
-																				</div>
-																			)}
-																		</div>
-																	) : (
-																		"—"
+																	{formatCurrency(Number(row.cash_total))}
+																</TableCell>
+																<TableCell className="text-right font-semibold">
+																	{formatCurrency(Number(row.total))}
+																</TableCell>
+															</TableRow>
+														))}
+													</TableBody>
+													{flujoPorInversionistaData?.totales && (
+														<tfoot>
+															<TableRow className="border-t-2 bg-muted/50 font-bold">
+																<TableCell>Total</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(
+																		Number(
+																			flujoPorInversionistaData.totales
+																				.reinversion_total,
+																		),
 																	)}
 																</TableCell>
 																<TableCell className="text-right">
-																	{row.mora_90 ? (
-																		<div>
-																			<span>
-																				{formatCurrency(Number(row.mora_90))}
-																				<span className="ml-1 text-muted-foreground text-xs">
-																					({row.creditos_90 ?? 0})
-																				</span>
-																			</span>
-																			{pctMora(row.mora_90) && (
-																				<div className="text-muted-foreground text-xs">
-																					{pctMora(row.mora_90)}%
-																				</div>
-																			)}
-																		</div>
-																	) : (
-																		"—"
+																	{formatCurrency(
+																		Number(
+																			flujoPorInversionistaData.totales
+																				.cash_total,
+																		),
 																	)}
 																</TableCell>
 																<TableCell className="text-right">
-																	{row.mora_120 ? (
-																		<div>
-																			<span>
-																				{formatCurrency(Number(row.mora_120))}
-																				<span className="ml-1 text-muted-foreground text-xs">
-																					({row.creditos_120 ?? 0})
-																				</span>
-																			</span>
-																			{pctMora(row.mora_120) && (
-																				<div className="text-muted-foreground text-xs">
-																					{pctMora(row.mora_120)}%
-																				</div>
-																			)}
-																		</div>
-																	) : (
-																		"—"
+																	{formatCurrency(
+																		Number(
+																			flujoPorInversionistaData.totales.total,
+																		),
 																	)}
 																</TableCell>
 															</TableRow>
-														);
-													})}
-													<TableRow className="border-t-2 bg-muted/50 font-bold">
-														<TableCell>Total</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(sumColoc)}
-														</TableCell>
-														<TableCell className="text-right">
-															{sumCreditosColoc}
-														</TableCell>
-														<TableCell className="text-right">
-															{formatCurrency(sumFacturacion)}
-														</TableCell>
-														<TableCell className="text-right">—</TableCell>
-														<TableCell className="text-right">—</TableCell>
-														<TableCell className="text-right">—</TableCell>
-														<TableCell className="text-right">—</TableCell>
-														<TableCell className="text-right">—</TableCell>
-														<TableCell className="text-right">—</TableCell>
-													</TableRow>
-												</TableBody>
-											</Table>
+														</tfoot>
+													)}
+												</Table>
+											))}
+									</div>
+								</CardContent>
+							</Card>
+						</TabsContent>
+						{/* Modal: Metas Mensuales */}
+						<Dialog open={metasModalOpen} onOpenChange={setMetasModalOpen}>
+							<DialogContent className="sm:max-w-[860px]">
+								<DialogHeader>
+									<DialogTitle className="flex items-center gap-2">
+										<Target className="h-4 w-4 text-purple-500" />
+										Metas de Colocación
+									</DialogTitle>
+								</DialogHeader>
+								<div className="flex items-center justify-center gap-3 pb-2">
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={() => setMetasAnio((y) => y - 1)}
+									>
+										‹
+									</Button>
+									<span className="w-16 text-center font-semibold">
+										{metasAnio}
+									</span>
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={() => setMetasAnio((y) => y + 1)}
+									>
+										›
+									</Button>
+								</div>
+								{metasQuery.isPending ? (
+									<p className="py-4 text-center text-muted-foreground text-sm">
+										Cargando...
+									</p>
+								) : (
+									<div className="grid grid-cols-2 gap-x-10 gap-y-4">
+										{MESES.map((nombreMes, idx) => {
+											const mes = idx + 1;
+											return (
+												<div key={mes} className="flex items-center gap-3">
+													<span className="w-20 shrink-0 font-medium text-sm">
+														{nombreMes}
+													</span>
+													<div className="relative min-w-0 flex-1">
+														<span className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 font-medium text-muted-foreground text-sm">
+															Q
+														</span>
+														<Input
+															type="text"
+															inputMode="decimal"
+															className="h-10 pl-7 text-right text-base"
+															placeholder="0"
+															value={
+																focusedMes === mes
+																	? (editMetas[mes] ?? "")
+																	: editMetas[mes] && Number(editMetas[mes]) > 0
+																		? Number(editMetas[mes]).toLocaleString(
+																				"es-GT",
+																				{
+																					minimumFractionDigits: 2,
+																					maximumFractionDigits: 2,
+																				},
+																			)
+																		: ""
+															}
+															onFocus={() => setFocusedMes(mes)}
+															onBlur={() => setFocusedMes(null)}
+															onChange={(e) => {
+																const raw = e.target.value.replace(
+																	/[^0-9.]/g,
+																	"",
+																);
+																setEditMetas((prev) => ({
+																	...prev,
+																	[mes]: raw,
+																}));
+															}}
+														/>
+													</div>
+												</div>
+											);
+										})}
+									</div>
+								)}
+								<div className="flex justify-end gap-2 pt-2">
+									<Button
+										variant="outline"
+										onClick={() => setMetasModalOpen(false)}
+									>
+										Cancelar
+									</Button>
+									<Button onClick={handleGuardarTodo} disabled={isSavingMetas}>
+										{isSavingMetas && (
+											<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+										)}
+										Guardar todo
+									</Button>
+								</div>
+							</DialogContent>
+						</Dialog>
+
+						{/* Modales de simulación de escenarios */}
+						<ScenarioModal
+							open={scenarioOpen === "monto"}
+							onOpenChange={(o) => setScenarioOpen(o ? "monto" : null)}
+							config={montoACobrarConfig}
+							baseData={montoCobrarData?.data}
+						/>
+						<ScenarioModal
+							open={scenarioOpen === "facturacion"}
+							onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
+							config={facturacionConfig}
+							baseData={facturacionMesData}
+						/>
+						<ScenarioModal
+							open={scenarioOpen === "flujo"}
+							onOpenChange={(o) => setScenarioOpen(o ? "flujo" : null)}
+							config={flujoCuotasConfig}
+							baseData={flujoCuotasData}
+						/>
+						<ScenarioModal
+							open={scenarioOpen === "cobertura"}
+							onOpenChange={(o) => setScenarioOpen(o ? "cobertura" : null)}
+							config={coberturaConfig}
+							baseData={puntoEquilibrioData?.data}
+						/>
+						<ScenarioModal
+							open={scenarioOpen === "comparativo"}
+							onOpenChange={(o) => setScenarioOpen(o ? "comparativo" : null)}
+							config={comparativoConfig}
+							baseData={comparativoData?.data}
+						/>
+
+						<TabsContent value="colocacion" className="space-y-6">
+							{/* Cobertura de Colocación vs Meta */}
+							<Card>
+								<CardHeader>
+									<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+										<div className="flex items-center gap-2">
+											<TrendingUp className="h-5 w-5 text-green-500" />
+											<div>
+												<CardTitle>Cobertura de Colocación vs Meta</CardTitle>
+												<CardDescription>
+													Compara el capital colocado en cada período contra la
+													meta mensual definida
+												</CardDescription>
+											</div>
 										</div>
-									);
-								})()}
-						</CardContent>
-					</Card>
+										<div className="flex flex-wrap items-center gap-2">
+											<SimularButton
+												onClick={() => setScenarioOpen("cobertura")}
+											/>
+											<Button
+												variant="outline"
+												size="sm"
+												className="gap-1.5"
+												onClick={() => setMetasModalOpen(true)}
+											>
+												<Target className="h-3.5 w-3.5" />
+												Configurar metas
+											</Button>
+											<Select
+												value={equilibrioPeriodo}
+												onValueChange={(v) =>
+													setEquilibrioPeriodo(
+														v as
+															| "anio"
+															| "trimestre"
+															| "mes"
+															| "semana"
+															| "dia",
+													)
+												}
+											>
+												<SelectTrigger className="w-[140px]">
+													<SelectValue placeholder="Período" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="dia">Día</SelectItem>
+													<SelectItem value="semana">Semana</SelectItem>
+													<SelectItem value="mes">Mes</SelectItem>
+													<SelectItem value="trimestre">Trimestre</SelectItem>
+													<SelectItem value="anio">Año</SelectItem>
+												</SelectContent>
+											</Select>
+											<DateRangeFilter
+												dateRange={
+													equilibrioRange.fechaInicio &&
+													equilibrioRange.fechaFin
+														? {
+																from: dateFromInput(
+																	equilibrioRange.fechaInicio,
+																),
+																to: dateFromInput(equilibrioRange.fechaFin),
+															}
+														: undefined
+												}
+												onDateRangeChange={(range) => {
+													if (range?.from && range?.to) {
+														setEquilibrioRange({
+															fechaInicio: formatDateInput(range.from),
+															fechaFin: formatDateInput(range.to),
+														});
+													}
+												}}
+											/>
+										</div>
+									</div>
+								</CardHeader>
+								<CardContent className="space-y-4">
+									{puntoEquilibrioQuery.isPending && (
+										<p className="text-muted-foreground text-sm">
+											Cargando reporte...
+										</p>
+									)}
+									{puntoEquilibrioQuery.isError && (
+										<p className="text-destructive text-sm">
+											Error al cargar reporte de cobertura.
+										</p>
+									)}
+									{puntoEquilibrioData &&
+										puntoEquilibrioData.data.length === 0 && (
+											<p className="text-muted-foreground text-sm">
+												No hay datos de colocación para el rango seleccionado.
+											</p>
+										)}
+									{!!puntoEquilibrioData?.data.length &&
+										(() => {
+											const rows = puntoEquilibrioData.data;
+											const totalColocado = rows.reduce(
+												(acc, r) => acc + Number(r.colocado),
+												0,
+											);
+											const totalMeta = rows.reduce(
+												(acc, r) => acc + Number(r.meta),
+												0,
+											);
+											const totalCreditos = rows.reduce(
+												(acc, r) => acc + r.cantidad_creditos,
+												0,
+											);
+											const totalCobertura =
+												totalMeta > 0
+													? ((totalColocado / totalMeta) * 100).toFixed(1)
+													: null;
+											return (
+												<>
+													<ResponsiveContainer width="100%" height={300}>
+														<BarChart
+															data={rows.map((row) => ({
+																bucket: formatBucket(
+																	row.bucket,
+																	equilibrioPeriodo,
+																),
+																colocado: Number(row.colocado),
+																meta: Number(row.meta),
+															}))}
+														>
+															<CartesianGrid strokeDasharray="3 3" />
+															<XAxis
+																dataKey="bucket"
+																tick={{ fontSize: 11 }}
+																interval={0}
+																height={36}
+															/>
+															<YAxis
+																tickFormatter={(v) =>
+																	`Q${(Number(v) / 1000).toFixed(0)}k`
+																}
+															/>
+															<Tooltip
+																formatter={(value, name) => [
+																	formatCurrency(Number(value)),
+																	name === "colocado" ? "Colocado" : "Meta",
+																]}
+															/>
+															<Legend
+																formatter={(v) =>
+																	v === "colocado" ? "Colocado" : "Meta"
+																}
+															/>
+															<Bar
+																dataKey="colocado"
+																fill="#3b82f6"
+																name="colocado"
+															/>
+															<Bar dataKey="meta" fill="#d1d5db" name="meta" />
+														</BarChart>
+													</ResponsiveContainer>
+
+													<div className="overflow-x-auto">
+														<Table>
+															<TableHeader>
+																<TableRow>
+																	<TableHead>Período</TableHead>
+																	<TableHead className="text-right">
+																		Créditos
+																	</TableHead>
+																	<TableHead className="text-right">
+																		Colocado
+																	</TableHead>
+																	<TableHead className="text-right">
+																		Meta
+																	</TableHead>
+																	<TableHead className="text-right">
+																		Cobertura
+																	</TableHead>
+																	<TableHead className="text-right">
+																		Faltante
+																	</TableHead>
+																</TableRow>
+															</TableHeader>
+															<TableBody>
+																{rows.map((row) => (
+																	<TableRow key={row.bucket}>
+																		<TableCell>
+																			{formatBucket(
+																				row.bucket,
+																				equilibrioPeriodo,
+																			)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.cantidad_creditos}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{formatCurrency(row.colocado)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{Number(row.meta) > 0 ? (
+																				formatCurrency(row.meta)
+																			) : (
+																				<span className="text-muted-foreground">
+																					Sin meta
+																				</span>
+																			)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			<span
+																				className="font-semibold"
+																				style={{
+																					color: coberturaColor(row.cobertura),
+																				}}
+																			>
+																				{coberturaLabel(row.cobertura)}
+																			</span>
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.faltante
+																				? formatCurrency(row.faltante)
+																				: "—"}
+																		</TableCell>
+																	</TableRow>
+																))}
+																<TableRow className="border-t-2 bg-muted/50 font-bold">
+																	<TableCell>Total</TableCell>
+																	<TableCell className="text-right">
+																		{totalCreditos}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(totalColocado)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{totalMeta > 0
+																			? formatCurrency(totalMeta)
+																			: "—"}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		<span
+																			className="font-semibold"
+																			style={{
+																				color: coberturaColor(totalCobertura),
+																			}}
+																		>
+																			{coberturaLabel(totalCobertura)}
+																		</span>
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{totalMeta > 0
+																			? formatCurrency(
+																					Math.max(
+																						0,
+																						totalMeta - totalColocado,
+																					),
+																				)
+																			: "—"}
+																	</TableCell>
+																</TableRow>
+															</TableBody>
+														</Table>
+													</div>
+												</>
+											);
+										})()}
+								</CardContent>
+							</Card>
+
+							{/* ============================================================ */}
+							{/* REPORTE: COMPARATIVO HISTÓRICO MENSUAL                        */}
+							{/* ============================================================ */}
+							<Card>
+								<CardHeader>
+									<div className="flex items-center justify-between">
+										<CardTitle className="flex items-center gap-2">
+											<CalendarDays className="h-5 w-5" />
+											Comparativo Histórico Mensual
+										</CardTitle>
+										<div className="flex items-center gap-2">
+											<SimularButton
+												onClick={() => setScenarioOpen("comparativo")}
+											/>
+											<button
+												type="button"
+												className="rounded p-1 hover:bg-muted"
+												onClick={() => setComparativoAnio((y) => y - 1)}
+											>
+												<ChevronLeft className="h-4 w-4" />
+											</button>
+											<span className="w-12 text-center font-semibold text-sm">
+												{comparativoAnio}
+											</span>
+											<button
+												type="button"
+												className="rounded p-1 hover:bg-muted"
+												onClick={() =>
+													setComparativoAnio((y) =>
+														y < new Date().getFullYear() ? y + 1 : y,
+													)
+												}
+											>
+												<ChevronRight className="h-4 w-4" />
+											</button>
+										</div>
+									</div>
+								</CardHeader>
+								<CardContent>
+									{comparativoQuery.isPending && (
+										<p className="py-4 text-center text-muted-foreground text-sm">
+											Cargando...
+										</p>
+									)}
+									{comparativoQuery.isError && (
+										<p className="py-4 text-center text-red-500 text-sm">
+											Error al cargar comparativo histórico.
+										</p>
+									)}
+									{comparativoData &&
+										(() => {
+											const rows = comparativoData.data;
+											const sumColoc = rows.reduce(
+												(acc, r) =>
+													acc +
+													(r.colocacion_monto ? Number(r.colocacion_monto) : 0),
+												0,
+											);
+											const sumFacturacion = rows.reduce(
+												(acc, r) =>
+													acc + (r.facturacion ? Number(r.facturacion) : 0),
+												0,
+											);
+											const sumCreditosColoc = rows.reduce(
+												(acc, r) => acc + (r.colocacion_creditos ?? 0),
+												0,
+											);
+											return (
+												<div className="overflow-x-auto">
+													<Table>
+														<TableHeader>
+															<TableRow>
+																<TableHead>Mes</TableHead>
+																<TableHead className="text-right">
+																	Colocación (Q)
+																</TableHead>
+																<TableHead className="text-right">
+																	# Col.
+																</TableHead>
+																<TableHead className="text-right">
+																	Facturación (Q)
+																</TableHead>
+																<TableHead className="text-right">
+																	Cartera Activa (Q)
+																</TableHead>
+																<TableHead className="text-right">
+																	# Activos
+																</TableHead>
+																<TableHead className="text-right">
+																	Mora 30 (Q)
+																</TableHead>
+																<TableHead className="text-right">
+																	Mora 60 (Q)
+																</TableHead>
+																<TableHead className="text-right">
+																	Mora 90 (Q)
+																</TableHead>
+																<TableHead className="text-right">
+																	Mora 120+ (Q)
+																</TableHead>
+															</TableRow>
+														</TableHeader>
+														<TableBody>
+															{rows.map((row) => {
+																const esFuturo =
+																	row.colocacion_monto === null &&
+																	row.facturacion === null &&
+																	row.cartera_activa === null;
+																const totalMoraFila =
+																	Number(row.mora_30 ?? 0) +
+																	Number(row.mora_60 ?? 0) +
+																	Number(row.mora_90 ?? 0) +
+																	Number(row.mora_120 ?? 0);
+																const pctMora = (val: string | null) =>
+																	totalMoraFila > 0 && val
+																		? (
+																				(Number(val) / totalMoraFila) *
+																				100
+																			).toFixed(1)
+																		: null;
+																return (
+																	<TableRow
+																		key={row.mes}
+																		className={
+																			esFuturo ? "opacity-40" : undefined
+																		}
+																	>
+																		<TableCell className="font-medium">
+																			{MESES[row.mes - 1]}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.colocacion_monto
+																				? formatCurrency(
+																						Number(row.colocacion_monto),
+																					)
+																				: "—"}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.colocacion_creditos ?? "—"}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.facturacion
+																				? formatCurrency(
+																						Number(row.facturacion),
+																					)
+																				: "—"}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.cartera_activa
+																				? formatCurrency(
+																						Number(row.cartera_activa),
+																					)
+																				: "—"}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.creditos_activos ?? "—"}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.mora_30 ? (
+																				<div>
+																					<span>
+																						{formatCurrency(
+																							Number(row.mora_30),
+																						)}
+																						<span className="ml-1 text-muted-foreground text-xs">
+																							({row.creditos_30 ?? 0})
+																						</span>
+																					</span>
+																					{pctMora(row.mora_30) && (
+																						<div className="text-muted-foreground text-xs">
+																							{pctMora(row.mora_30)}%
+																						</div>
+																					)}
+																				</div>
+																			) : (
+																				"—"
+																			)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.mora_60 ? (
+																				<div>
+																					<span>
+																						{formatCurrency(
+																							Number(row.mora_60),
+																						)}
+																						<span className="ml-1 text-muted-foreground text-xs">
+																							({row.creditos_60 ?? 0})
+																						</span>
+																					</span>
+																					{pctMora(row.mora_60) && (
+																						<div className="text-muted-foreground text-xs">
+																							{pctMora(row.mora_60)}%
+																						</div>
+																					)}
+																				</div>
+																			) : (
+																				"—"
+																			)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.mora_90 ? (
+																				<div>
+																					<span>
+																						{formatCurrency(
+																							Number(row.mora_90),
+																						)}
+																						<span className="ml-1 text-muted-foreground text-xs">
+																							({row.creditos_90 ?? 0})
+																						</span>
+																					</span>
+																					{pctMora(row.mora_90) && (
+																						<div className="text-muted-foreground text-xs">
+																							{pctMora(row.mora_90)}%
+																						</div>
+																					)}
+																				</div>
+																			) : (
+																				"—"
+																			)}
+																		</TableCell>
+																		<TableCell className="text-right">
+																			{row.mora_120 ? (
+																				<div>
+																					<span>
+																						{formatCurrency(
+																							Number(row.mora_120),
+																						)}
+																						<span className="ml-1 text-muted-foreground text-xs">
+																							({row.creditos_120 ?? 0})
+																						</span>
+																					</span>
+																					{pctMora(row.mora_120) && (
+																						<div className="text-muted-foreground text-xs">
+																							{pctMora(row.mora_120)}%
+																						</div>
+																					)}
+																				</div>
+																			) : (
+																				"—"
+																			)}
+																		</TableCell>
+																	</TableRow>
+																);
+															})}
+															<TableRow className="border-t-2 bg-muted/50 font-bold">
+																<TableCell>Total</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(sumColoc)}
+																</TableCell>
+																<TableCell className="text-right">
+																	{sumCreditosColoc}
+																</TableCell>
+																<TableCell className="text-right">
+																	{formatCurrency(sumFacturacion)}
+																</TableCell>
+																<TableCell className="text-right">—</TableCell>
+																<TableCell className="text-right">—</TableCell>
+																<TableCell className="text-right">—</TableCell>
+																<TableCell className="text-right">—</TableCell>
+																<TableCell className="text-right">—</TableCell>
+																<TableCell className="text-right">—</TableCell>
+															</TableRow>
+														</TableBody>
+													</Table>
+												</div>
+											);
+										})()}
+								</CardContent>
+							</Card>
+						</TabsContent>
+					</Tabs>
 				</>
 			)}
 		</div>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -4,8 +4,8 @@ import {
 	Activity,
 	AlertTriangle,
 	CalendarDays,
-	ChevronLeft,
 	ChevronDown,
+	ChevronLeft,
 	ChevronRight,
 	Download,
 	FileText,
@@ -75,9 +75,9 @@ import type {
 	FacturacionMesResponse,
 	FacturacionMesRubro,
 	FlujoCuotasInversionesResponse,
-	FlujoCuotasRubro,
 	MontoACobrarRow,
 	PuntoEquilibrioRow,
+	ReinversionLiquidacionesResponse,
 } from "@/lib/reports/scenario";
 import {
 	coberturaConfig,
@@ -104,18 +104,43 @@ const COLORS = {
 	incobrable: "#7f1d1d",
 };
 
-const FLUJO_RUBROS: { key: keyof FlujoCuotasRubro; label: string }[] = [
-	{ key: "capital", label: "Capital" },
-	{ key: "interes", label: "Interés" },
-	{ key: "iva", label: "IVA 12%" },
+// Modalidades de reinversión a mostrar en "Cuotas → Reinversión".
+// El monto de cada una es la suma de `liquidaciones.reinversion_total`.
+// Se omiten `reinversion_interes` ("solo interés", no se usa) y `sin_reinversion`.
+const REINVERSION_MODALIDADES: { tipo: string; label: string }[] = [
+	{ tipo: "reinversion_capital", label: "Reinversión de Capital" },
+	{ tipo: "reinversion_total", label: "Interés compuesto" },
+	{ tipo: "reinversion_variable", label: "Reinversión Variable" },
+	{
+		tipo: "reinversion_excedente",
+		label: "Reinversión Excedente (monto fijo a recibir)",
+	},
+	{
+		tipo: "reinversion_combinada",
+		label: "Reinversión Combinada (combinaciones de modalidades)",
+	},
 ];
 
-function getDefaultFlujoCuotasRange(): {
+// Modalidades a mostrar en "Cuotas → A Recibir" (efectivo neto = total_cuota).
+// Incluye `sin_reinversion`; sigue omitiendo `reinversion_interes`.
+const A_RECIBIR_MODALIDADES: { tipo: string; label: string }[] = [
+	{ tipo: "sin_reinversion", label: "Sin Reinversión" },
+	...REINVERSION_MODALIDADES,
+];
+
+/** Mes por defecto (actual) en formato "YYYY-MM" para el <input type="month">. */
+function getDefaultFlujoMes(): string {
+	const todayGt = formatDateInput(new Date());
+	const [year, month] = todayGt.split("-");
+	return `${year}-${month}`;
+}
+
+/** Convierte "YYYY-MM" al rango de fechas [primer día, último día] del mes. */
+function mesToRange(mesStr: string): {
 	fechaInicio: string;
 	fechaFin: string;
 } {
-	const todayGt = formatDateInput(new Date());
-	const [year, month] = todayGt.split("-").map(Number);
+	const [year, month] = mesStr.split("-").map(Number);
 	const fechaInicio = `${year}-${String(month).padStart(2, "0")}-01`;
 	const nextM = month === 12 ? 1 : month + 1;
 	const nextY = month === 12 ? year + 1 : year;
@@ -315,9 +340,13 @@ function RouteComponent() {
 		mes: new Date().getMonth() + 1,
 		anio: new Date().getFullYear(),
 	}));
-	const [flujoCuotasRange, setFlujoCuotasRange] = useState(
-		getDefaultFlujoCuotasRange,
-	);
+	const [flujoMes, setFlujoMes] = useState(getDefaultFlujoMes);
+	// Rango derivado (primer/último día del mes) para los reportes que aún
+	// consumen el endpoint por rango de fechas (secciones 2 y 3).
+	const flujoCuotasRange = mesToRange(flujoMes);
+	const [flujoAnioStr, flujoMesStr] = flujoMes.split("-");
+	const flujoMesNum = Number(flujoMesStr);
+	const flujoAnioNum = Number(flujoAnioStr);
 	const [desgloseInversionistaOpen, setDesgloseInversionistaOpen] =
 		useState(false);
 	const [comparativoAnio, setComparativoAnio] = useState(() =>
@@ -403,6 +432,17 @@ function RouteComponent() {
 	});
 	const flujoCuotasData = flujoCuotasQuery.data as
 		| FlujoCuotasInversionesResponse
+		| undefined;
+
+	// Sección "Cuotas → Reinversión": se calcula desde la tabla de liquidaciones.
+	const reinversionLiquidacionesQuery = useQuery({
+		...orpc.getReinversionLiquidaciones.queryOptions({
+			input: { mes: flujoMesNum, anio: flujoAnioNum },
+		}),
+		enabled: isAdmin,
+	});
+	const reinversionData = reinversionLiquidacionesQuery.data as
+		| ReinversionLiquidacionesResponse
 		| undefined;
 
 	const flujoPorInversionistaQuery = useQuery({
@@ -1406,34 +1446,253 @@ function RouteComponent() {
 								<div className="flex items-center gap-2">
 									<SimularButton onClick={() => setScenarioOpen("flujo")} />
 									<Input
-										type="date"
-										aria-label="Fecha inicio"
-										className="w-40"
-										value={flujoCuotasRange.fechaInicio}
-										onChange={(e) =>
-											setFlujoCuotasRange((prev) => ({
-												...prev,
-												fechaInicio: e.target.value,
-											}))
-										}
-									/>
-									<span className="text-muted-foreground text-sm">–</span>
-									<Input
-										type="date"
-										aria-label="Fecha fin"
-										className="w-40"
-										value={flujoCuotasRange.fechaFin}
-										onChange={(e) =>
-											setFlujoCuotasRange((prev) => ({
-												...prev,
-												fechaFin: e.target.value,
-											}))
-										}
+										type="month"
+										aria-label="Mes"
+										className="w-44"
+										value={flujoMes}
+										onChange={(e) => setFlujoMes(e.target.value)}
 									/>
 								</div>
 							</div>
 						</CardHeader>
 						<CardContent className="space-y-6">
+							{/* Sección 1: Cuotas → Reinversión (desde liquidaciones) */}
+							<div>
+								<p className="mb-2 font-semibold text-sm">
+									Cuotas → Reinversión
+								</p>
+								{reinversionLiquidacionesQuery.isPending ? (
+									<div className="py-4 text-center text-muted-foreground text-sm">
+										Cargando...
+									</div>
+								) : reinversionLiquidacionesQuery.isError ? (
+									<div className="py-4 text-center text-destructive text-sm">
+										Error al cargar datos
+									</div>
+								) : reinversionData ? (
+									(() => {
+										const filas = REINVERSION_MODALIDADES.map((m) => ({
+											...m,
+											monto: Number(
+												reinversionData.porTipo[m.tipo]?.reinversion_total ?? 0,
+											),
+										}));
+										const totalMostrado = filas.reduce(
+											(a, f) => a + f.monto,
+											0,
+										);
+										return (
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Modalidad de Reinversión</TableHead>
+														<TableHead className="text-right">
+															Reinversión Total
+														</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{filas.map((f) => (
+														<TableRow key={f.tipo}>
+															<TableCell>{f.label}</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(f.monto)}
+															</TableCell>
+														</TableRow>
+													))}
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total Reinvertido</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalMostrado)}
+														</TableCell>
+													</TableRow>
+												</TableBody>
+											</Table>
+										);
+									})()
+								) : null}
+							</div>
+
+							{/* Sección 2: Cuotas → A Recibir (efectivo neto = total_cuota) */}
+							<div>
+								<p className="mb-2 font-semibold text-sm">Cuotas → A Recibir</p>
+								{reinversionLiquidacionesQuery.isPending ? (
+									<div className="py-4 text-center text-muted-foreground text-sm">
+										Cargando...
+									</div>
+								) : reinversionLiquidacionesQuery.isError ? (
+									<div className="py-4 text-center text-destructive text-sm">
+										Error al cargar datos
+									</div>
+								) : reinversionData ? (
+									(() => {
+										const filas = A_RECIBIR_MODALIDADES.map((m) => {
+											const d = reinversionData.porTipo[m.tipo];
+											return {
+												...m,
+												capital: Number(d?.total_capital ?? 0),
+												interes: Number(d?.total_interes ?? 0),
+												iva: Number(d?.total_iva ?? 0),
+												isr: Number(d?.total_isr ?? 0),
+												total: Number(d?.total_cuota ?? 0),
+											};
+										});
+										const totales = filas.reduce(
+											(a, f) => ({
+												capital: a.capital + f.capital,
+												interes: a.interes + f.interes,
+												iva: a.iva + f.iva,
+												isr: a.isr + f.isr,
+												total: a.total + f.total,
+											}),
+											{ capital: 0, interes: 0, iva: 0, isr: 0, total: 0 },
+										);
+										return (
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Modalidad de Reinversión</TableHead>
+														<TableHead className="text-right">
+															Capital
+														</TableHead>
+														<TableHead className="text-right">
+															Interés
+														</TableHead>
+														<TableHead className="text-right">
+															IVA 12%
+														</TableHead>
+														<TableHead className="text-right">ISR</TableHead>
+														<TableHead className="text-right">
+															Total a Recibir
+														</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													{filas.map((f) => (
+														<TableRow key={f.tipo}>
+															<TableCell>{f.label}</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(f.capital)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(f.interes)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(f.iva)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(f.isr)}
+															</TableCell>
+															<TableCell className="text-right">
+																{formatCurrency(f.total)}
+															</TableCell>
+														</TableRow>
+													))}
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total a Recibir</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totales.capital)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totales.interes)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totales.iva)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totales.isr)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totales.total)}
+														</TableCell>
+													</TableRow>
+												</TableBody>
+											</Table>
+										);
+									})()
+								) : null}
+							</div>
+
+							{/* Sección: Interés Neto (agrupado por si el inversionista emite factura) */}
+							{reinversionData &&
+								(() => {
+									const cf = reinversionData.interesNeto.conFactura;
+									const sf = reinversionData.interesNeto.sinFactura;
+									const totalInteres = Number(cf.interes) + Number(sf.interes);
+									const totalIva = Number(cf.iva);
+									const totalIsr = Number(sf.isr);
+									const totalNeto = Number(cf.neto) + Number(sf.neto);
+									return (
+										<div>
+											<p className="mb-2 font-semibold text-sm">Interés Neto</p>
+											<Table>
+												<TableHeader>
+													<TableRow>
+														<TableHead>Grupo</TableHead>
+														<TableHead className="text-right">
+															Interés
+														</TableHead>
+														<TableHead className="text-right">
+															IVA 12%
+														</TableHead>
+														<TableHead className="text-right">ISR</TableHead>
+														<TableHead className="text-right">
+															Interés Neto
+														</TableHead>
+													</TableRow>
+												</TableHeader>
+												<TableBody>
+													<TableRow>
+														<TableCell>Con Factura</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(cf.interes)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(cf.iva)}
+														</TableCell>
+														<TableCell className="text-right text-muted-foreground">
+															—
+														</TableCell>
+														<TableCell className="text-right font-semibold">
+															{formatCurrency(cf.neto)}
+														</TableCell>
+													</TableRow>
+													<TableRow>
+														<TableCell>Sin Factura</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(sf.interes)}
+														</TableCell>
+														<TableCell className="text-right text-muted-foreground">
+															—
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(sf.isr)}
+														</TableCell>
+														<TableCell className="text-right font-semibold">
+															{formatCurrency(sf.neto)}
+														</TableCell>
+													</TableRow>
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalInteres)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalIva)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalIsr)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(totalNeto)}
+														</TableCell>
+													</TableRow>
+												</TableBody>
+											</Table>
+										</div>
+									);
+								})()}
+
 							{flujoCuotasQuery.isPending && (
 								<div className="py-4 text-center text-muted-foreground text-sm">
 									Cargando...
@@ -1446,253 +1705,12 @@ function RouteComponent() {
 							)}
 							{flujoCuotasData &&
 								(() => {
-									const {
-										reinversionPorTipo,
-										cashParcialPorTipo,
-										sinReinversion,
-										pagosExtras,
-									} = flujoCuotasData;
-									const TIPO_LABELS: Record<string, string> = {
-										reinversion_capital: "Reinversión Capital",
-										reinversion_interes: "Reinversión Interés",
-										reinversion_total: "Reinversión Total",
-										reinversion_variable: "Reinversión Variable",
-										reinversion_excedente: "Reinversión Excedente",
-									};
-									type ReinvertidoResult =
-										| { esTotal: true; total: number }
-										| {
-												esTotal: false;
-												capital: number;
-												interes: number;
-												iva: number;
-										  };
-									function getReinvertido(
-										tipo: string,
-										t: FlujoCuotasRubro & { monto_reinvertido?: string },
-									): ReinvertidoResult {
-										if (
-											tipo === "reinversion_variable" ||
-											tipo === "reinversion_excedente"
-										)
-											return {
-												esTotal: true,
-												total: Number(t.monto_reinvertido ?? 0),
-											};
-										if (tipo === "reinversion_capital")
-											return {
-												esTotal: false,
-												capital: Number(t.capital),
-												interes: 0,
-												iva: 0,
-											};
-										if (tipo === "reinversion_interes")
-											return {
-												esTotal: false,
-												capital: 0,
-												interes: Number(t.interes),
-												iva: Number(t.iva),
-											};
-										return {
-											esTotal: false,
-											capital: Number(t.capital),
-											interes: Number(t.interes),
-											iva: Number(t.iva),
-										};
-									}
-									const totalesReinv = reinversionPorTipo.reduce(
-										(a, t) => {
-											const r = getReinvertido(t.tipo, t);
-											const tot = r.esTotal
-												? r.total
-												: r.capital + r.interes + r.iva;
-											return {
-												total: a.total + tot,
-												capital: a.capital + (r.esTotal ? 0 : r.capital),
-												interes: a.interes + (r.esTotal ? 0 : r.interes),
-												iva: a.iva + (r.esTotal ? 0 : r.iva),
-											};
-										},
-										{ total: 0, capital: 0, interes: 0, iva: 0 },
-									);
-									const totalReinv = totalesReinv.total;
-									const cashParcialTotal = cashParcialPorTipo.reduce(
-										(a, t) =>
-											a +
-											(t.monto_cash
-												? Number(t.monto_cash)
-												: Number(t.capital) +
-													Number(t.interes) +
-													Number(t.iva)),
-										0,
-									);
-									const totalSinReinv = FLUJO_RUBROS.reduce(
-										(a, r) => a + Number(sinReinversion.totales[r.key] || 0),
-										0,
-									);
+									const { pagosExtras } = flujoCuotasData;
 									const totalExtras =
 										Number(pagosExtras.abonos_capital) +
 										Number(pagosExtras.cancelaciones);
 									return (
 										<>
-											{/* Sección 1: Hacia Reinversión por tipo */}
-											<div>
-												<p className="mb-2 font-semibold text-sm">
-													Cuotas → Reinversión
-												</p>
-												<Table>
-													<TableHeader>
-														<TableRow>
-															<TableHead>Tipo de Reinversión</TableHead>
-															<TableHead className="text-right">
-																Capital
-															</TableHead>
-															<TableHead className="text-right">
-																Interés
-															</TableHead>
-															<TableHead className="text-right">
-																IVA 12%
-															</TableHead>
-															<TableHead className="text-right">
-																Total
-															</TableHead>
-														</TableRow>
-													</TableHeader>
-													<TableBody>
-														{reinversionPorTipo
-															.filter((t) => {
-																const r = getReinvertido(t.tipo, t);
-																const tot = r.esTotal
-																	? r.total
-																	: r.capital + r.interes + r.iva;
-																return tot > 0;
-															})
-															.map((t) => {
-																const r = getReinvertido(t.tipo, t);
-																const rowTotal = r.esTotal
-																	? r.total
-																	: r.capital + r.interes + r.iva;
-																return (
-																	<TableRow key={t.tipo}>
-																		<TableCell>
-																			{TIPO_LABELS[t.tipo] ?? t.tipo}
-																		</TableCell>
-																		<TableCell className="text-right text-muted-foreground">
-																			{r.esTotal
-																				? "—"
-																				: formatCurrency(r.capital)}
-																		</TableCell>
-																		<TableCell className="text-right text-muted-foreground">
-																			{r.esTotal
-																				? "—"
-																				: formatCurrency(r.interes)}
-																		</TableCell>
-																		<TableCell className="text-right text-muted-foreground">
-																			{r.esTotal ? "—" : formatCurrency(r.iva)}
-																		</TableCell>
-																		<TableCell className="text-right">
-																			{formatCurrency(rowTotal)}
-																		</TableCell>
-																	</TableRow>
-																);
-															})}
-														<TableRow className="border-t-2 bg-muted/50 font-bold">
-															<TableCell>Total</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(totalesReinv.capital)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(totalesReinv.interes)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(totalesReinv.iva)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(totalReinv)}
-															</TableCell>
-														</TableRow>
-													</TableBody>
-												</Table>
-											</div>
-
-											{/* Sección 2: Cash (sin reinversión + porciones cash de reinversión parcial) */}
-											<div>
-												<p className="mb-2 font-semibold text-sm">
-													Cuotas → A Recibir
-												</p>
-												<Table>
-													<TableHeader>
-														<TableRow>
-															<TableHead>Origen</TableHead>
-															<TableHead className="text-right">
-																Capital
-															</TableHead>
-															<TableHead className="text-right">
-																Interés
-															</TableHead>
-															<TableHead className="text-right">
-																IVA 12%
-															</TableHead>
-															<TableHead className="text-right">
-																Total
-															</TableHead>
-														</TableRow>
-													</TableHeader>
-													<TableBody>
-														{/* Inversionistas sin reinversión */}
-														<TableRow>
-															<TableCell>Sin Reinversión</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(
-																	Number(sinReinversion.totales.capital),
-																)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(
-																	Number(sinReinversion.totales.interes),
-																)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(
-																	Number(sinReinversion.totales.iva),
-																)}
-															</TableCell>
-															<TableCell className="text-right">
-																{formatCurrency(totalSinReinv)}
-															</TableCell>
-														</TableRow>
-														{/* Porciones cash de inversionistas con reinversión parcial — combinado */}
-														{cashParcialPorTipo.length > 0 && (
-															<TableRow>
-																<TableCell>
-																	Intereses y excedentes pagados a
-																	inversionistas
-																</TableCell>
-																<TableCell
-																	colSpan={3}
-																	className="text-right text-muted-foreground text-sm"
-																>
-																	capital/interés/IVA según tipo
-																</TableCell>
-																<TableCell className="text-right">
-																	{formatCurrency(cashParcialTotal)}
-																</TableCell>
-															</TableRow>
-														)}
-														{/* Total general cash */}
-														<TableRow className="border-t-2 bg-muted/50 font-bold">
-															<TableCell>Total a Recibir</TableCell>
-															<TableCell colSpan={3} />
-															<TableCell className="text-right">
-																{formatCurrency(
-																	totalSinReinv + cashParcialTotal,
-																)}
-															</TableCell>
-														</TableRow>
-													</TableBody>
-												</Table>
-											</div>
-
 											{/* Sección 3: Pagos Extras Recibidos */}
 											<div>
 												<p className="mb-2 font-semibold text-sm">
@@ -1742,12 +1760,8 @@ function RouteComponent() {
 								<div className="mb-3 flex items-center justify-between">
 									<button
 										type="button"
-										className="flex items-center gap-1 font-semibold text-sm hover:text-foreground/70 transition-colors"
-										onClick={() =>
-											setDesgloseInversionistaOpen(
-												(o) => !o,
-											)
-										}
+										className="flex items-center gap-1 font-semibold text-sm transition-colors hover:text-foreground/70"
+										onClick={() => setDesgloseInversionistaOpen((o) => !o)}
 									>
 										{desgloseInversionistaOpen ? (
 											<ChevronDown className="h-4 w-4" />
@@ -1757,125 +1771,131 @@ function RouteComponent() {
 										Desglose por Inversionista
 									</button>
 									{desgloseInversionistaOpen &&
-										(flujoPorInversionistaData?.porInversionista?.length ?? 0) > 0 && (
-										<Button
-											variant="outline"
-											size="sm"
-											onClick={() => {
-												const rows = (
-													// eslint-disable-next-line @typescript-eslint/no-explicit-any
-													(flujoPorInversionistaData!.porInversionista as any[])
-												).map((r: any) => ({
-													Inversionista: r.nombre,
-													"Reinv. Capital": r.reinversion_capital,
-													"Reinv. Interés": r.reinversion_interes,
-													"Total Reinversión": r.reinversion_total,
-													"Capital a Recibir": r.cash_capital,
-													"Interés a Recibir": r.cash_interes,
-													"Total a Recibir": r.cash_total,
-													"Total General": r.total,
-												}));
-												const ws = XLSX.utils.json_to_sheet(rows);
-												ws["!cols"] = [
-													{ wch: 30 },
-													{ wch: 18 },
-													{ wch: 18 },
-													{ wch: 18 },
-													{ wch: 18 },
-													{ wch: 18 },
-													{ wch: 18 },
-													{ wch: 18 },
-												];
-												const wb = XLSX.utils.book_new();
-												XLSX.utils.book_append_sheet(
-													wb,
-													ws,
-													"Por Inversionista",
-												);
-												XLSX.writeFile(
-													wb,
-													`flujo-inversionistas-${flujoCuotasRange.fechaInicio}-${flujoCuotasRange.fechaFin}.xlsx`,
-												);
-											}}
-										>
-											<Download className="mr-2 h-4 w-4" />
-											Exportar Excel
-										</Button>
-									)}
-								</div>
-								{desgloseInversionistaOpen && (flujoPorInversionistaQuery.isPending ? (
-									<p className="py-4 text-center text-muted-foreground text-sm">
-										Cargando...
-									</p>
-								) : flujoPorInversionistaQuery.isError ? (
-									<p className="py-4 text-center text-destructive text-sm">
-										Error al cargar desglose por inversionista
-									</p>
-								) : !flujoPorInversionistaData?.porInversionista?.length ? (
-									<p className="py-4 text-center text-muted-foreground text-sm">
-										Sin datos para el período seleccionado
-									</p>
-								) : (
-									<Table>
-										<TableHeader>
-											<TableRow>
-												<TableHead>Inversionista</TableHead>
-												<TableHead className="text-right">
-													Reinversión
-												</TableHead>
-												<TableHead className="text-right">A Recibir</TableHead>
-												<TableHead className="text-right">Total</TableHead>
-											</TableRow>
-										</TableHeader>
-										<TableBody>
-											{(
-												flujoPorInversionistaData.porInversionista as any[]
-											).map((row: any) => (
-												<TableRow key={row.inversionista_id}>
-													<TableCell className="font-medium">
-														{row.nombre}
-													</TableCell>
-													<TableCell className="text-right">
-														{formatCurrency(Number(row.reinversion_total))}
-													</TableCell>
-													<TableCell className="text-right">
-														{formatCurrency(Number(row.cash_total))}
-													</TableCell>
-													<TableCell className="text-right font-semibold">
-														{formatCurrency(Number(row.total))}
-													</TableCell>
-												</TableRow>
-											))}
-										</TableBody>
-										{flujoPorInversionistaData?.totales && (
-											<tfoot>
-												<TableRow className="border-t-2 bg-muted/50 font-bold">
-													<TableCell>Total</TableCell>
-													<TableCell className="text-right">
-														{formatCurrency(
-															Number(
-																flujoPorInversionistaData.totales
-																	.reinversion_total,
-															),
-														)}
-													</TableCell>
-													<TableCell className="text-right">
-														{formatCurrency(
-															Number(
-																flujoPorInversionistaData.totales.cash_total,
-															),
-														)}
-													</TableCell>
-													<TableCell className="text-right">
-														{formatCurrency(
-															Number(flujoPorInversionistaData.totales.total),
-														)}
-													</TableCell>
-												</TableRow>
-											</tfoot>
+										(flujoPorInversionistaData?.porInversionista?.length ?? 0) >
+											0 && (
+											<Button
+												variant="outline"
+												size="sm"
+												onClick={() => {
+													const rows =
+														// eslint-disable-next-line @typescript-eslint/no-explicit-any
+														(
+															flujoPorInversionistaData!
+																.porInversionista as any[]
+														).map((r: any) => ({
+															Inversionista: r.nombre,
+															"Reinv. Capital": r.reinversion_capital,
+															"Reinv. Interés": r.reinversion_interes,
+															"Total Reinversión": r.reinversion_total,
+															"Capital a Recibir": r.cash_capital,
+															"Interés a Recibir": r.cash_interes,
+															"Total a Recibir": r.cash_total,
+															"Total General": r.total,
+														}));
+													const ws = XLSX.utils.json_to_sheet(rows);
+													ws["!cols"] = [
+														{ wch: 30 },
+														{ wch: 18 },
+														{ wch: 18 },
+														{ wch: 18 },
+														{ wch: 18 },
+														{ wch: 18 },
+														{ wch: 18 },
+														{ wch: 18 },
+													];
+													const wb = XLSX.utils.book_new();
+													XLSX.utils.book_append_sheet(
+														wb,
+														ws,
+														"Por Inversionista",
+													);
+													XLSX.writeFile(
+														wb,
+														`flujo-inversionistas-${flujoCuotasRange.fechaInicio}-${flujoCuotasRange.fechaFin}.xlsx`,
+													);
+												}}
+											>
+												<Download className="mr-2 h-4 w-4" />
+												Exportar Excel
+											</Button>
 										)}
-									</Table>
-								))}
+								</div>
+								{desgloseInversionistaOpen &&
+									(flujoPorInversionistaQuery.isPending ? (
+										<p className="py-4 text-center text-muted-foreground text-sm">
+											Cargando...
+										</p>
+									) : flujoPorInversionistaQuery.isError ? (
+										<p className="py-4 text-center text-destructive text-sm">
+											Error al cargar desglose por inversionista
+										</p>
+									) : !flujoPorInversionistaData?.porInversionista?.length ? (
+										<p className="py-4 text-center text-muted-foreground text-sm">
+											Sin datos para el período seleccionado
+										</p>
+									) : (
+										<Table>
+											<TableHeader>
+												<TableRow>
+													<TableHead>Inversionista</TableHead>
+													<TableHead className="text-right">
+														Reinversión
+													</TableHead>
+													<TableHead className="text-right">
+														A Recibir
+													</TableHead>
+													<TableHead className="text-right">Total</TableHead>
+												</TableRow>
+											</TableHeader>
+											<TableBody>
+												{(
+													flujoPorInversionistaData.porInversionista as any[]
+												).map((row: any) => (
+													<TableRow key={row.inversionista_id}>
+														<TableCell className="font-medium">
+															{row.nombre}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(Number(row.reinversion_total))}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(Number(row.cash_total))}
+														</TableCell>
+														<TableCell className="text-right font-semibold">
+															{formatCurrency(Number(row.total))}
+														</TableCell>
+													</TableRow>
+												))}
+											</TableBody>
+											{flujoPorInversionistaData?.totales && (
+												<tfoot>
+													<TableRow className="border-t-2 bg-muted/50 font-bold">
+														<TableCell>Total</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(
+																Number(
+																	flujoPorInversionistaData.totales
+																		.reinversion_total,
+																),
+															)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(
+																Number(
+																	flujoPorInversionistaData.totales.cash_total,
+																),
+															)}
+														</TableCell>
+														<TableCell className="text-right">
+															{formatCurrency(
+																Number(flujoPorInversionistaData.totales.total),
+															)}
+														</TableCell>
+													</TableRow>
+												</tfoot>
+											)}
+										</Table>
+									))}
 							</div>
 						</CardContent>
 					</Card>
@@ -2361,7 +2381,9 @@ function RouteComponent() {
 															Number(row.mora_120 ?? 0);
 														const pctMora = (val: string | null) =>
 															totalMoraFila > 0 && val
-																? ((Number(val) / totalMoraFila) * 100).toFixed(1)
+																? ((Number(val) / totalMoraFila) * 100).toFixed(
+																		1,
+																	)
 																: null;
 														return (
 															<TableRow

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -84,7 +84,6 @@ import {
 	coberturaConfig,
 	comparativoConfig,
 	facturacionConfig,
-	flujoCuotasConfig,
 	montoACobrarConfig,
 } from "@/lib/reports/scenario-configs";
 import { PERMISSIONS } from "@/lib/roles";
@@ -1546,7 +1545,6 @@ function RouteComponent() {
 											</CardDescription>
 										</div>
 										<div className="flex items-center gap-2">
-											<SimularButton onClick={() => setScenarioOpen("flujo")} />
 											<Select
 												value={String(flujoMesNum)}
 												onValueChange={(v) =>
@@ -2165,12 +2163,6 @@ function RouteComponent() {
 							onOpenChange={(o) => setScenarioOpen(o ? "facturacion" : null)}
 							config={facturacionConfig}
 							baseData={facturacionMesData}
-						/>
-						<ScenarioModal
-							open={scenarioOpen === "flujo"}
-							onOpenChange={(o) => setScenarioOpen(o ? "flujo" : null)}
-							config={flujoCuotasConfig}
-							baseData={flujoCuotasData}
 						/>
 						<ScenarioModal
 							open={scenarioOpen === "cobertura"}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -128,6 +128,15 @@ const A_RECIBIR_MODALIDADES: { tipo: string; label: string }[] = [
 	...REINVERSION_MODALIDADES,
 ];
 
+// Estilo compartido para cada sub-sección del reporte de Flujo de Cuotas:
+// panel enmarcado, título con divisor y encabezados de tabla refinados
+// (mayúsculas, muted, números tabulares para alinear montos).
+const SECCION_REPORTE_CLASS =
+	"rounded-xl border bg-card p-4 shadow-sm " +
+	"[&>p:first-child]:border-b [&>p:first-child]:pb-2.5 [&>p:first-child]:text-foreground " +
+	"[&_thead_th]:h-9 [&_thead_th]:text-[11px] [&_thead_th]:font-semibold [&_thead_th]:uppercase [&_thead_th]:tracking-wider [&_thead_th]:text-muted-foreground " +
+	"[&_table]:tabular-nums";
+
 /** Mes por defecto (actual) en formato "YYYY-MM" para el <input type="month">. */
 function getDefaultFlujoMes(): string {
 	const todayGt = formatDateInput(new Date());
@@ -347,6 +356,25 @@ function RouteComponent() {
 	const [flujoAnioStr, flujoMesStr] = flujoMes.split("-");
 	const flujoMesNum = Number(flujoMesStr);
 	const flujoAnioNum = Number(flujoAnioStr);
+	// Selectores de mes/año: últimos 3 años y sin meses a futuro.
+	const flujoHoy = new Date();
+	const flujoAnioActual = flujoHoy.getFullYear();
+	const flujoMesActual = flujoHoy.getMonth() + 1;
+	const aniosDisponibles = [
+		flujoAnioActual,
+		flujoAnioActual - 1,
+		flujoAnioActual - 2,
+	];
+	const mesesDisponibles = MESES.map((nombre, i) => ({
+		num: i + 1,
+		nombre,
+	})).filter((m) => flujoAnioNum < flujoAnioActual || m.num <= flujoMesActual);
+	const setFlujoMesAnio = (anio: number, mes: number) => {
+		// No permitir meses a futuro en el año actual.
+		const m =
+			anio === flujoAnioActual && mes > flujoMesActual ? flujoMesActual : mes;
+		setFlujoMes(`${anio}-${String(m).padStart(2, "0")}`);
+	};
 	const [desgloseInversionistaOpen, setDesgloseInversionistaOpen] =
 		useState(false);
 	const [comparativoAnio, setComparativoAnio] = useState(() =>
@@ -1445,19 +1473,46 @@ function RouteComponent() {
 								</div>
 								<div className="flex items-center gap-2">
 									<SimularButton onClick={() => setScenarioOpen("flujo")} />
-									<Input
-										type="month"
-										aria-label="Mes"
-										className="w-44"
-										value={flujoMes}
-										onChange={(e) => setFlujoMes(e.target.value)}
-									/>
+									<Select
+										value={String(flujoMesNum)}
+										onValueChange={(v) =>
+											setFlujoMesAnio(flujoAnioNum, Number(v))
+										}
+									>
+										<SelectTrigger className="w-36" aria-label="Mes">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{mesesDisponibles.map((m) => (
+												<SelectItem key={m.num} value={String(m.num)}>
+													{m.nombre}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+									<Select
+										value={String(flujoAnioNum)}
+										onValueChange={(v) =>
+											setFlujoMesAnio(Number(v), flujoMesNum)
+										}
+									>
+										<SelectTrigger className="w-24" aria-label="Año">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{aniosDisponibles.map((a) => (
+												<SelectItem key={a} value={String(a)}>
+													{a}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
 								</div>
 							</div>
 						</CardHeader>
-						<CardContent className="space-y-6">
+						<CardContent className="space-y-8">
 							{/* Sección 1: Cuotas → Reinversión (desde liquidaciones) */}
-							<div>
+							<div className={SECCION_REPORTE_CLASS}>
 								<p className="mb-2 font-semibold text-sm">
 									Cuotas → Reinversión
 								</p>
@@ -1476,7 +1531,7 @@ function RouteComponent() {
 											monto: Number(
 												reinversionData.porTipo[m.tipo]?.reinversion_total ?? 0,
 											),
-										}));
+										})).filter((f) => f.monto !== 0);
 										const totalMostrado = filas.reduce(
 											(a, f) => a + f.monto,
 											0,
@@ -1514,7 +1569,7 @@ function RouteComponent() {
 							</div>
 
 							{/* Sección 2: Cuotas → A Recibir (efectivo neto = total_cuota) */}
-							<div>
+							<div className={SECCION_REPORTE_CLASS}>
 								<p className="mb-2 font-semibold text-sm">Cuotas → A Recibir</p>
 								{reinversionLiquidacionesQuery.isPending ? (
 									<div className="py-4 text-center text-muted-foreground text-sm">
@@ -1536,7 +1591,14 @@ function RouteComponent() {
 												isr: Number(d?.total_isr ?? 0),
 												total: Number(d?.total_cuota ?? 0),
 											};
-										});
+										}).filter(
+											(f) =>
+												f.capital !== 0 ||
+												f.interes !== 0 ||
+												f.iva !== 0 ||
+												f.isr !== 0 ||
+												f.total !== 0,
+										);
 										const totales = filas.reduce(
 											(a, f) => ({
 												capital: a.capital + f.capital,
@@ -1623,7 +1685,7 @@ function RouteComponent() {
 									const totalIsr = Number(sf.isr);
 									const totalNeto = Number(cf.neto) + Number(sf.neto);
 									return (
-										<div>
+										<div className={SECCION_REPORTE_CLASS}>
 											<p className="mb-2 font-semibold text-sm">Interés Neto</p>
 											<Table>
 												<TableHeader>
@@ -1712,7 +1774,7 @@ function RouteComponent() {
 									return (
 										<>
 											{/* Sección 3: Pagos Extras Recibidos */}
-											<div>
+											<div className={SECCION_REPORTE_CLASS}>
 												<p className="mb-2 font-semibold text-sm">
 													Pagos Extras Recibidos
 												</p>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -723,6 +723,101 @@ function RouteComponent() {
 		);
 	};
 
+	const creditosCerradosCard = (
+		<Card>
+			<CardHeader>
+				<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+					<div>
+						<CardTitle>Créditos cerrados</CardTitle>
+						<CardDescription>
+							Créditos que llegaron por primera vez a una etapa 90%+.
+						</CardDescription>
+					</div>
+					<div className="flex flex-wrap items-center gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setClosedCreditsPreset("week")}
+						>
+							Esta semana
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setClosedCreditsPreset("last15")}
+						>
+							Últimos 15 días
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => setClosedCreditsPreset("month")}
+						>
+							Este mes
+						</Button>
+						<DateRangeFilter
+							dateRange={closedCreditsRange}
+							onDateRangeChange={setClosedCreditsRange}
+							required
+						/>
+						<Button
+							onClick={exportClosedCreditsCsv}
+							disabled={!closedCreditsReport.data?.length}
+						>
+							<Download className="mr-2 h-4 w-4" />
+							Exportar CSV
+						</Button>
+					</div>
+				</div>
+			</CardHeader>
+			<CardContent>
+				{closedCreditsReport.isPending && <p>Cargando reporte...</p>}
+				{closedCreditsReport.isError && (
+					<p className="text-destructive">Error al cargar el reporte.</p>
+				)}
+				{closedCreditsReport.data?.length === 0 && (
+					<p className="text-muted-foreground">
+						No hay créditos cerrados para el rango seleccionado.
+					</p>
+				)}
+				{!!closedCreditsReport.data?.length && (
+					<div className="overflow-x-auto">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Placa</TableHead>
+									<TableHead>Chasis</TableHead>
+									<TableHead>Cuota Seguro</TableHead>
+									<TableHead>Nombre del Cliente</TableHead>
+									<TableHead>Número de Crédito</TableHead>
+									<TableHead>Fecha 90%+</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{closedCreditsReport.data.map((row) => (
+									<TableRow
+										key={`${row.numeroCredito}-${row.fecha90}-${row.placa}-${row.chasis}`}
+									>
+										<TableCell>{row.placa || "-"}</TableCell>
+										<TableCell>{row.chasis || "-"}</TableCell>
+										<TableCell>{formatCurrency(row.cuotaSeguro)}</TableCell>
+										<TableCell>{row.clienteNombre || "-"}</TableCell>
+										<TableCell>{row.numeroCredito || "-"}</TableCell>
+										<TableCell>
+											{row.fecha90
+												? formatDateInput(new Date(row.fecha90))
+												: "-"}
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				)}
+			</CardContent>
+		</Card>
+	);
+
 	return (
 		<div className="container mx-auto space-y-6 p-6">
 			<div className="flex items-center justify-between">
@@ -744,111 +839,29 @@ function RouteComponent() {
 				)}
 			</div>
 
-			{canAccessClosedCreditsReport && (
-				<Card>
-					<CardHeader>
-						<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
-							<div>
-								<CardTitle>Créditos cerrados</CardTitle>
-								<CardDescription>
-									Créditos que llegaron por primera vez a una etapa 90%+.
-								</CardDescription>
-							</div>
-							<div className="flex flex-wrap items-center gap-2">
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setClosedCreditsPreset("week")}
-								>
-									Esta semana
-								</Button>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setClosedCreditsPreset("last15")}
-								>
-									Últimos 15 días
-								</Button>
-								<Button
-									variant="outline"
-									size="sm"
-									onClick={() => setClosedCreditsPreset("month")}
-								>
-									Este mes
-								</Button>
-								<DateRangeFilter
-									dateRange={closedCreditsRange}
-									onDateRangeChange={setClosedCreditsRange}
-									required
-								/>
-								<Button
-									onClick={exportClosedCreditsCsv}
-									disabled={!closedCreditsReport.data?.length}
-								>
-									<Download className="mr-2 h-4 w-4" />
-									Exportar CSV
-								</Button>
-							</div>
-						</div>
-					</CardHeader>
-					<CardContent>
-						{closedCreditsReport.isPending && <p>Cargando reporte...</p>}
-						{closedCreditsReport.isError && (
-							<p className="text-destructive">Error al cargar el reporte.</p>
-						)}
-						{closedCreditsReport.data?.length === 0 && (
-							<p className="text-muted-foreground">
-								No hay créditos cerrados para el rango seleccionado.
-							</p>
-						)}
-						{!!closedCreditsReport.data?.length && (
-							<div className="overflow-x-auto">
-								<Table>
-									<TableHeader>
-										<TableRow>
-											<TableHead>Placa</TableHead>
-											<TableHead>Chasis</TableHead>
-											<TableHead>Cuota Seguro</TableHead>
-											<TableHead>Nombre del Cliente</TableHead>
-											<TableHead>Número de Crédito</TableHead>
-											<TableHead>Fecha 90%+</TableHead>
-										</TableRow>
-									</TableHeader>
-									<TableBody>
-										{closedCreditsReport.data.map((row) => (
-											<TableRow
-												key={`${row.numeroCredito}-${row.fecha90}-${row.placa}-${row.chasis}`}
-											>
-												<TableCell>{row.placa || "-"}</TableCell>
-												<TableCell>{row.chasis || "-"}</TableCell>
-												<TableCell>{formatCurrency(row.cuotaSeguro)}</TableCell>
-												<TableCell>{row.clienteNombre || "-"}</TableCell>
-												<TableCell>{row.numeroCredito || "-"}</TableCell>
-												<TableCell>
-													{row.fecha90
-														? formatDateInput(new Date(row.fecha90))
-														: "-"}
-												</TableCell>
-											</TableRow>
-										))}
-									</TableBody>
-								</Table>
-							</div>
-						)}
-					</CardContent>
-				</Card>
-			)}
+			{!isAdmin && canAccessClosedCreditsReport && creditosCerradosCard}
 
 			{isAdmin && (
 				<>
-					<Tabs defaultValue="resumen" className="space-y-6">
+					<Tabs
+						defaultValue={canAccessClosedCreditsReport ? "creditos" : "resumen"}
+						className="space-y-6"
+					>
 						<TabsList>
+							{canAccessClosedCreditsReport && (
+								<TabsTrigger value="creditos">Créditos cerrados</TabsTrigger>
+							)}
 							<TabsTrigger value="resumen">Resumen</TabsTrigger>
 							<TabsTrigger value="graficas">Gráficas</TabsTrigger>
 							<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
 							<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
 							<TabsTrigger value="colocacion">Colocación</TabsTrigger>
 						</TabsList>
+						{canAccessClosedCreditsReport && (
+							<TabsContent value="creditos" className="space-y-6">
+								{creditosCerradosCard}
+							</TabsContent>
+						)}
 						<TabsContent value="resumen" className="space-y-6">
 							{/* Enlaces a otros reportes - TODO: Implementar rutas */}
 							<div className="grid gap-4 md:grid-cols-4">


### PR DESCRIPTION
## Resumen

Reestructura el reporte **Flujo de Cuotas de Inversiones** (`/admin/reports`) para que sus cálculos salgan de la tabla `cartera.liquidaciones`, con filtro **por mes**.

Cadena: UI (`reports/index.tsx`) → ORPC `getReinversionLiquidaciones` → server CRM (`reportes-cartera.ts`) → `carteraBackClient` → cartera-back `GET /reportes/reinversion-liquidaciones?mes&anio`.

## Cambios

- **Filtro por mes**: selector de mes (`<input type="month">`) en vez de rango de días.
- **Nuevo endpoint** `GET /reportes/reinversion-liquidaciones` (cartera-back) agrupado por `inversionistas.tipo_reinversion`, filtrando `fecha_liquidacion` dentro del mes (zona America/Guatemala).
- **Sección "Cuotas → Reinversión"**: `reinversion_total` por modalidad. Se omite "solo interés" (`reinversion_interes`) y `sin_reinversion`; `reinversion_total` se etiqueta **"Interés compuesto"**. Excedente/combinada etiquetadas según pedido.
- **Sección "Cuotas → A Recibir"**: datos **crudos** por modalidad (Capital, Interés, IVA 12%, ISR, Total a Recibir = `total_cuota`). Incluye `sin_reinversion`.
- **Nueva sección "Interés Neto"** agrupada por `emite_factura`:
  - Con factura → neto = **interés + IVA**
  - Sin factura → neto = **interés − ISR**

## ⚠️ Pendiente (revisar despacio)

La sección **"Pagos Extras Recibidos"** (Abonos Extra a Capital / Cancelaciones) **aún NO está migrada**: sigue consumiendo el endpoint viejo (`getFlujoCuotasInversiones`). Falta pasarla a `liquidaciones` y revisarla con calma antes de darla por buena.

## Notas

- "A Recibir" muestra valores crudos: las columnas no necesariamente suman al Total (`total_cuota` ya viene neto de reinversión/IVA/ISR).
- ISR solo aparece en inversionistas que **no emiten factura**.
- El botón "Simular" sigue operando sobre el endpoint viejo para la parte aún no migrada.
- No hay cambios de schema/migraciones (solo lectura sobre `liquidaciones`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)