### PR TITLE
fix(crm): show all client opportunities in detail

### DIFF
--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -193,6 +193,33 @@ describe("buildCarteraMatchedClientRows", () => {
 
 		expect(row.totalClosedValue).toBe(1200);
 	});
+
+	test("includes all lead opportunities in each matched client detail row", () => {
+		const rows = buildCarteraMatchedClientRows({
+			lead,
+			leadOpportunities: [
+				{ id: "opp-1", numeroSifco: "SIFCO-1", value: "5000.00", isClosed: true },
+				{ id: "opp-2", numeroSifco: "SIFCO-2", value: "7000.00", isClosed: true },
+			],
+			creditAnalysis: null,
+			carteraCreditBySifco: new Map([
+				[
+					"SIFCO-1",
+					{ creditos: { numero_credito_sifco: "SIFCO-1", deudatotal: "1200.00" } },
+				],
+				[
+					"SIFCO-2",
+					{ creditos: { numero_credito_sifco: "SIFCO-2", deudatotal: "3400.00" } },
+				],
+			]),
+		});
+
+		expect(rows[0].carteraCredit?.numeroSifco).toBe("SIFCO-1");
+		expect(rows[0].opportunities.map((opp) => opp.id)).toEqual([
+			"opp-1",
+			"opp-2",
+		]);
+	});
 });
 
 describe("calculateCarteraClientStats", () => {

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -330,10 +330,10 @@ export function buildCarteraMatchedClientRows(params: {
 		rows.push({
 			...params.lead,
 			rowId: `${params.lead.id}-${sifco}`,
-			opportunities: matchingOpportunities,
+			opportunities: params.leadOpportunities,
 			creditAnalysis: params.creditAnalysis,
 			totalClosedValue: getCarteraCreditAmount(credit),
-			closedOpportunitiesCount: matchingOpportunities.filter(
+			closedOpportunitiesCount: params.leadOpportunities.filter(
 				(opp) => opp.isClosed,
 			).length,
 			crmMatchStatus: "matched",


### PR DESCRIPTION
## Summary
- Show all CRM opportunities for a lead in the client detail modal instead of only the opportunity matching the selected cartera SIFCO row.
- Keep row-level cartera totals tied to the selected cartera credit.
- Add regression coverage for multi-credit lead detail rows.

## Test Plan
- bun test apps/server/src/routers/crm-get-leads-input.test.ts
- bun check-types