### PR TITLE
🚀 Pase a Producción — Release develop → main

### DIFF
--- a/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.test.ts
@@ -6,20 +6,23 @@ mock.module("../database", () => ({ db: {} }));
 const { esColumnaEditable, validarValores } = await import("./facturacionSnapshot");
 
 describe("esColumnaEditable", () => {
-  it("acepta SOLO los 6 totales de rubro", () => {
-    expect(esColumnaEditable("capital_total")).toBe(true);
-    expect(esColumnaEditable("interes_cube")).toBe(true);
-    expect(esColumnaEditable("membresia")).toBe(true);
-    expect(esColumnaEditable("otros_ingresos")).toBe(true);
-    expect(esColumnaEditable("mora_cube")).toBe(true);
+  it("acepta TODO Royalty y TODO Otros ingresos (detalle + total)", () => {
     expect(esColumnaEditable("royalty")).toBe(true);
+    expect(esColumnaEditable("roy_hipotecario")).toBe(true);
+    expect(esColumnaEditable("nuevo_roy_autocompras")).toBe(true);
+    expect(esColumnaEditable("otros_ingresos")).toBe(true);
+    expect(esColumnaEditable("oi_autocompras")).toBe(true);
+    expect(esColumnaEditable("administrativos")).toBe(true);
+    expect(esColumnaEditable("otros_cobros")).toBe(true);
   });
-  it("rechaza detalle por producto, facturación, servicios, metas y acumulados", () => {
+  it("rechaza Capital/Interés/Membresía/Mora, servicios, metas y acumulados", () => {
     expect(esColumnaEditable("id")).toBe(false);
     expect(esColumnaEditable("fecha")).toBe(false);
     expect(esColumnaEditable("bloqueado")).toBe(false);
-    expect(esColumnaEditable("roy_hipotecario")).toBe(false); // detalle producto
-    expect(esColumnaEditable("administrativos")).toBe(false);
+    expect(esColumnaEditable("capital_total")).toBe(false);
+    expect(esColumnaEditable("interes_cube")).toBe(false);
+    expect(esColumnaEditable("membresia")).toBe(false);
+    expect(esColumnaEditable("mora_cube")).toBe(false);
     expect(esColumnaEditable("facturacion")).toBe(false); // se DERIVA de rubros
     expect(esColumnaEditable("servicios_seguro_gps")).toBe(false);
     expect(esColumnaEditable("ingreso_carros")).toBe(false);
@@ -33,19 +36,19 @@ describe("esColumnaEditable", () => {
 
 describe("validarValores", () => {
   it("ok con rubros editables y números", () => {
-    const r = validarValores({ capital_total: "100.50", royalty: "0" });
+    const r = validarValores({ royalty: "100.50", otros_ingresos: "0" });
     expect(r.ok).toBe(true);
     expect(r.invalidas).toEqual([]);
   });
   it("marca columna no editable", () => {
-    const r = validarValores({ fecha: "2026-06-10" });
-    expect(r.ok).toBe(false);
-    expect(r.invalidas).toContain("fecha");
-  });
-  it("marca valor no numérico", () => {
-    const r = validarValores({ capital_total: "abc" });
+    const r = validarValores({ capital_total: "100" });
     expect(r.ok).toBe(false);
     expect(r.invalidas).toContain("capital_total");
+  });
+  it("marca valor no numérico", () => {
+    const r = validarValores({ royalty: "abc" });
+    expect(r.ok).toBe(false);
+    expect(r.invalidas).toContain("royalty");
   });
 });
 

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -955,7 +955,12 @@ export async function listarAuditoriaSnapshot(opts: {
     : sql``;
   const res = await db.execute(sql`
     SELECT a.id, a.fecha::text AS fecha, a.columna, a.valor_anterior, a.valor_nuevo,
-           a.accion, a.usuario_id, u.email AS usuario_email, a.created_at
+           a.accion, a.usuario_id, u.email AS usuario_email,
+           -- created_at en hora de Guatemala, YA formateado (a prueba de la zona
+           -- horaria de node/navegador): el guardado se interpreta como UTC y se
+           -- convierte a America/Guatemala.
+           to_char((a.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'America/Guatemala',
+                   'DD/MM/YYYY HH24:MI:SS') AS created_at
     FROM cartera.facturacion_snapshot_auditoria a
     LEFT JOIN cartera.platform_users u ON u.id = a.usuario_id
     ${whereSql}

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -795,6 +795,23 @@ export async function guardarCeldasSnapshot(input: {
   if (!Array.isArray(cambios) || cambios.length === 0) {
     return { success: false, message: "Sin cambios" };
   }
+
+  // SOLO se puede editar el DÍA DE HOY (zona Guatemala). Se valida en el server
+  // además del front: un token ADMIN/script podría hacer PUT de una fecha vieja y
+  // bloquear una fila histórica, cambiando el mes reportado.
+  const hoyRes = await db.execute(
+    sql`SELECT (now() AT TIME ZONE 'America/Guatemala')::date::text AS hoy`
+  );
+  const hoyGT = ((hoyRes as any).rows ?? hoyRes)[0]?.hoy as string;
+  const fueraDeHoy = cambios.filter((c) => c.fecha !== hoyGT);
+  if (fueraDeHoy.length > 0) {
+    return {
+      success: false,
+      message: `Solo se puede editar el día de hoy (${hoyGT}).`,
+      fechas_invalidas: fueraDeHoy.map((c) => c.fecha),
+    };
+  }
+
   // Validar todo antes de escribir.
   for (const c of cambios) {
     const v = validarValores(c.valores);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -10,22 +10,18 @@ const LOGO_URL =
   "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
 
 // ── Edición manual: whitelist de columnas editables + validación ──────────────
-// SOLO los 6 TOTALES de rubro (los que se ven colapsados). El detalle por
-// producto, servicios/inversionistas/carros, metas, y los ACUMULADOS/tendencias
-// quedan fuera: read-only. `facturacion` (total del día) se DERIVA de los rubros
-// (interes+membresia+otros+mora+royalty) — ver recomputarTotalesDia. Los
-// acumulados se auto-calculan (suma corrida). El front además solo deja editar HOY.
-export const RUBROS_TOTALES_EDITABLES = [
-  "capital_total",
-  "interes_cube",
-  "membresia",
-  "otros_ingresos",
-  "mora_cube",
-  "royalty",
-] as const;
-export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set(
-  RUBROS_TOTALES_EDITABLES
-);
+// Editables SOLO los grupos ROYALTY y OTROS INGRESOS, COMPLETOS (detalle por
+// producto + total + administrativos + otros_cobros). Capital, Interés,
+// Membresía, Mora, servicios/inversionistas/carros, metas y los acumulados/
+// tendencias quedan read-only. `facturacion` se DERIVA (interes+membresia+
+// otros_ingresos+mora+royalty, usando los totales editados) y los acumulados se
+// auto-calculan (suma corrida). El front además solo deja editar HOY.
+export const COLUMNAS_EDITABLES: ReadonlySet<string> = new Set([
+  // Royalty (completo)
+  "roy_autocompras","roy_sobre_vehiculo","nuevo_roy_autocompras","roy_hipotecario","roy_extra_financiamiento","roy_reestructura","royalty",
+  // Otros ingresos (completo, incl. administrativos y otros_cobros)
+  "oi_autocompras","oi_sobre_vehiculo","nuevo_oi_autocompras","oi_hipotecario","oi_extra_financiamiento","oi_reestructura","otros_ingresos","administrativos","otros_cobros",
+]);
 
 export function esColumnaEditable(col: string): boolean {
   return COLUMNAS_EDITABLES.has(col);
@@ -110,9 +106,9 @@ export async function recomputarTotalesDia(fecha: string, exec: any = db) {
       facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty,
       facturacion_mas_servicios =
         interes_cube + membresia + otros_ingresos + mora_cube + royalty + servicios_seguro_gps,
-      -- otros_cobros = otros_ingresos − administrativos (igual que generarSnapshotDiario);
-      -- al editar otros_ingresos debe refrescarse o queda stale en el día bloqueado.
-      otros_cobros = otros_ingresos - administrativos,
+      -- NO se recalcula otros_cobros: ahora es columna EDITABLE (grupo Otros
+      -- ingresos), el usuario la maneja a mano. Si la quiere = otros_ingresos −
+      -- administrativos, la edita él (todo libre en ese grupo).
       updated_at = now()
     WHERE fecha = ${fecha}::date
   `);
@@ -442,9 +438,8 @@ export async function generarSnapshotDiario(fecha: string) {
 //    los montos importados). Si el día no tiene fila, la genera primero.
 //    - administrativos = SUM(gastos del día); otros_cobros = otros_ingresos − administrativos
 //    - ingreso_carros = SUM(carros del día); acumulado_total = fact_acum + acum_servicios + carros MTD
-//    NO lleva guard de bloqueado: ninguna de estas columnas es editable a mano (lo
-//    editable son los 6 totales de rubro) → deben refrescar también en días bloqueados.
-//    El lock solo lo respeta generarSnapshotDiario (que sí reescribe los rubros).
+//    SÍ respeta el lock: administrativos y otros_cobros son EDITABLES (grupo Otros
+//    ingresos), así que en un día bloqueado NO debe pisarlos → salta días bloqueados.
 export async function aplicarManualesEnSnapshotDia(fecha: string) {
   const existe = await db
     .select({ id: facturacion_snapshot_diario.id })
@@ -471,6 +466,7 @@ export async function aplicarManualesEnSnapshotDia(fecha: string) {
           + COALESCE((SELECT SUM(monto) FROM cartera.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
         updated_at = now()
     WHERE s.fecha = ${fecha}::date
+      AND s.bloqueado = false
   `);
   return { success: true };
 }

--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -137,7 +137,8 @@ export async function getMoraHistorialSnapshot(a: SnapshotArgs) {
 }
 
 // Timeline: total de mora reconstruido as-of para cada día del rango (evolución).
-export async function getMoraTimeline({ desde, hasta, asesor }: { desde: string; hasta: string; asesor?: string }) {
+// Respeta el filtro de etapa (Mora 30/60/90/120+) para poder comparar la curva por bucket.
+export async function getMoraTimeline({ desde, hasta, asesor, etapa }: { desde: string; hasta: string; asesor?: string; etapa?: string }) {
   // Filtro de asesor: limita a créditos del/los asesor(es).
   let asesorFilter = sql``;
   if (asesor) {
@@ -150,16 +151,32 @@ export async function getMoraTimeline({ desde, hasta, asesor }: { desde: string;
       )`;
     }
   }
+  // Filtro de etapa sobre las cuotas "vivas" (carry-forward) de cada crédito a esa fecha.
+  let etapaFilter = sql``;
+  if (etapa === "0-30") etapaFilter = sql` AND s.cuotas = 1`;
+  else if (etapa === "31-60") etapaFilter = sql` AND s.cuotas = 2`;
+  else if (etapa === "61-90") etapaFilter = sql` AND s.cuotas = 3`;
+  else if (etapa === "+90") etapaFilter = sql` AND s.cuotas >= 4`;
+
   const res = await db.execute<any>(sql`
     SELECT d::date AS fecha, (
       SELECT COALESCE(SUM(s.monto), 0)
       FROM (
-        SELECT DISTINCT ON (h.credito_id) h.monto_nuevo::numeric AS monto, h.tipo_evento
-        FROM cartera.moras_historial h
-        WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= d ${asesorFilter}
-        ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+        -- estado as-of por crédito: monto/tipo del último evento, cuotas con carry-forward
+        -- (último evento con cuotas>0) para clasificar la etapa igual que el snapshot.
+        SELECT credito_id, monto, tipo_evento, cuotas,
+          ROW_NUMBER() OVER (PARTITION BY credito_id ORDER BY fecha DESC, historial_id DESC) AS rn
+        FROM (
+          SELECT h.credito_id, h.monto_nuevo::numeric AS monto, h.tipo_evento, h.fecha, h.historial_id,
+            FIRST_VALUE(h.cuotas_atrasadas_nuevas) OVER (
+              PARTITION BY h.credito_id
+              ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
+            ) AS cuotas
+          FROM cartera.moras_historial h
+          WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= d ${asesorFilter}
+        ) hh
       ) s
-      WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0
+      WHERE s.rn = 1 AND s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0 ${etapaFilter}
     ) AS mora_total
     FROM generate_series(${desde}::date, ${hasta}::date, INTERVAL '1 day') d
     ORDER BY d

--- a/apps/cartera-back/src/routers/latefee.ts
+++ b/apps/cartera-back/src/routers/latefee.ts
@@ -259,13 +259,13 @@ export const morasRouter = new Elysia()
   .get("/moras/historial/timeline", async ({ query, set, user }: any) => {
     if (!requireMoraHistorialRole(user, set)) return NO_AUTORIZADO;
     try {
-      return await getMoraTimeline({ desde: query.desde, hasta: query.hasta || hoyGT(), asesor: query.asesor });
+      return await getMoraTimeline({ desde: query.desde, hasta: query.hasta || hoyGT(), asesor: query.asesor, etapa: query.etapa });
     } catch (err) {
       set.status = 500;
       return { success: false, message: "[ERROR] No se pudo obtener el timeline de mora", error: String(err) };
     }
   }, {
-    query: t.Object({ desde: t.String(), hasta: t.Optional(t.String()), asesor: t.Optional(t.String()) }),
+    query: t.Object({ desde: t.String(), hasta: t.Optional(t.String()), asesor: t.Optional(t.String()), etapa: t.Optional(t.String()) }),
   })
 
   // Excel del snapshot a la fecha de corte.

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -111,17 +111,19 @@ const GRUPOS: Grupo[] = [
   },
 ];
 
-// ÚNICAS columnas editables: los 6 TOTALES de rubro. Todo lo demás (detalle por
-// producto, servicios/carros/inversionistas, metas, y los acumulados/tendencias)
-// es de solo lectura. `Facturación` se deriva de estos rubros en el backend y los
+// Editables: grupos ROYALTY y OTROS INGRESOS COMPLETOS (detalle por producto +
+// total + administrativos + otros_cobros). Capital, Interés, Membresía, Mora,
+// servicios/carros/inversionistas, metas y los acumulados/tendencias quedan
+// read-only. `Facturación` se deriva en el backend de los totales editados y los
 // acumulados se recalculan como suma corrida. Además solo se edita el día de HOY.
 const EDITABLES = new Set<string>([
-  "capital_total",
-  "interes_cube",
-  "membresia",
-  "otros_ingresos",
-  "mora_cube",
-  "royalty",
+  // Royalty (completo)
+  "roy_autocompras", "roy_sobre_vehiculo", "nuevo_roy_autocompras",
+  "roy_hipotecario", "roy_extra_financiamiento", "roy_reestructura", "royalty",
+  // Otros ingresos (completo, incl. administrativos y otros_cobros)
+  "oi_autocompras", "oi_sobre_vehiculo", "nuevo_oi_autocompras",
+  "oi_hipotecario", "oi_extra_financiamiento", "oi_reestructura",
+  "otros_ingresos", "administrativos", "otros_cobros",
 ]);
 
 export function FacturacionDiaria() {
@@ -515,7 +517,7 @@ export function FacturacionDiaria() {
               ) : (histQuery.data?.data ?? []).length === 0 ? (
                 <p className="text-center py-10 text-gray-400">Sin cambios registrados.</p>
               ) : (
-                <table className="w-full text-sm border-collapse">
+                <table className="w-full text-sm border-collapse text-gray-800">
                   <thead>
                     <tr className="bg-blue-50 text-blue-800 text-left">
                       <th className="px-3 py-2 font-semibold">Cuándo</th>
@@ -530,10 +532,10 @@ export function FacturacionDiaria() {
                   <tbody>
                     {(histQuery.data?.data ?? []).map((a: AuditoriaSnapshot) => (
                       <tr key={a.id} className="border-b border-gray-100">
+                        {/* created_at ya viene formateado en hora de Guatemala
+                            desde el backend (to_char en SQL) → se muestra tal cual. */}
                         <td className="px-3 py-2 whitespace-nowrap text-gray-500">
-                          {a.created_at
-                            ? new Date(a.created_at).toLocaleString("es-GT")
-                            : "—"}
+                          {a.created_at ?? "—"}
                         </td>
                         <td className="px-3 py-2 whitespace-nowrap">{a.fecha}</td>
                         <td className="px-3 py-2">

--- a/apps/carteraFront/src/private/cartera/components/MoraHistorial.tsx
+++ b/apps/carteraFront/src/private/cartera/components/MoraHistorial.tsx
@@ -33,6 +33,17 @@ const etapaBadge = (etapa: string) => {
   return map[etapa] ?? "bg-gray-100 text-gray-700";
 };
 
+// Etiqueta legible para el valor del filtro de etapa (mismo mapeo que el backend).
+const etapaLabel = (etapa: string) => {
+  const map: Record<string, string> = {
+    "0-30": "Mora 30",
+    "31-60": "Mora 60",
+    "61-90": "Mora 90",
+    "+90": "Mora 120+",
+  };
+  return map[etapa] ?? etapa;
+};
+
 export function MoraHistorial() {
   const { advisors } = useAdminData();
   const [fecha, setFecha] = useState(hoyISO());
@@ -64,8 +75,8 @@ export function MoraHistorial() {
   });
 
   const timelineQuery = useQuery({
-    queryKey: ["mora-timeline", fecha, asesorCsv],
-    queryFn: () => getMoraTimeline(menosDias(fecha, 45), fecha, asesorCsv),
+    queryKey: ["mora-timeline", fecha, asesorCsv, etapa],
+    queryFn: () => getMoraTimeline(menosDias(fecha, 45), fecha, asesorCsv, etapa || undefined),
     refetchOnWindowFocus: false,
   });
 
@@ -215,7 +226,7 @@ export function MoraHistorial() {
 
         {/* Timeline */}
         <div className="bg-white rounded-2xl shadow-lg border border-red-100 p-5 mb-6">
-          <h2 className="text-sm font-bold text-red-800 mb-3 uppercase tracking-wide flex items-center gap-2"><TrendingUp className="h-4 w-4" /> Evolución de la mora (últimos 45 días)</h2>
+          <h2 className="text-sm font-bold text-red-800 mb-3 uppercase tracking-wide flex items-center gap-2"><TrendingUp className="h-4 w-4" /> Evolución de la mora{etapa ? ` — ${etapaLabel(etapa)}` : ""} (últimos 45 días)</h2>
           {timelineQuery.isFetching ? (
             <div className="h-64 flex items-center justify-center text-red-300"><Loader2 className="h-6 w-6 animate-spin" /></div>
           ) : (

--- a/apps/carteraFront/src/private/cartera/services/moraHistorial.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/moraHistorial.services.ts
@@ -63,9 +63,10 @@ export const getMoraHistorialSnapshot = async (params: SnapshotParams): Promise<
 export const getMoraTimeline = async (
   desde: string,
   hasta: string,
-  asesor?: string
+  asesor?: string,
+  etapa?: string
 ): Promise<{ success: boolean; data: { fecha: string; mora_total: string }[] }> => {
-  const { data } = await api.get(`${API_URL}/moras/historial/timeline`, { params: { desde, hasta, asesor } });
+  const { data } = await api.get(`${API_URL}/moras/historial/timeline`, { params: { desde, hasta, asesor, etapa } });
   return data;
 };
 

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -193,6 +193,33 @@ describe("buildCarteraMatchedClientRows", () => {
 
 		expect(row.totalClosedValue).toBe(1200);
 	});
+
+	test("includes all lead opportunities in each matched client detail row", () => {
+		const rows = buildCarteraMatchedClientRows({
+			lead,
+			leadOpportunities: [
+				{ id: "opp-1", numeroSifco: "SIFCO-1", value: "5000.00", isClosed: true },
+				{ id: "opp-2", numeroSifco: "SIFCO-2", value: "7000.00", isClosed: true },
+			],
+			creditAnalysis: null,
+			carteraCreditBySifco: new Map([
+				[
+					"SIFCO-1",
+					{ creditos: { numero_credito_sifco: "SIFCO-1", deudatotal: "1200.00" } },
+				],
+				[
+					"SIFCO-2",
+					{ creditos: { numero_credito_sifco: "SIFCO-2", deudatotal: "3400.00" } },
+				],
+			]),
+		});
+
+		expect(rows[0].carteraCredit?.numeroSifco).toBe("SIFCO-1");
+		expect(rows[0].opportunities.map((opp) => opp.id)).toEqual([
+			"opp-1",
+			"opp-2",
+		]);
+	});
 });
 
 describe("calculateCarteraClientStats", () => {

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -4,6 +4,7 @@ import {
 	buildCarteraMatchedClientRows,
 	buildCarteraOnlyClientRow,
 	calculateCarteraClientStats,
+	getCurrentClientCreditsFromCartera,
 	getClientCreditSifcosFromCartera,
 	getLeadsInputSchema,
 } from "./crm";
@@ -69,6 +70,39 @@ describe("getClientCreditSifcosFromCartera", () => {
 			"ACTIVO",
 			"MOROSO",
 			"EN_CONVENIO",
+		]);
+	});
+});
+
+describe("getCurrentClientCreditsFromCartera", () => {
+	test("requests active cartera credits without month/year filtering", async () => {
+		const calls: Array<{ mes: number; anio: number; estado: string }> = [];
+		const fetchCredits = async (params: {
+			mes: number;
+			anio: number;
+			estado: string;
+			page: number;
+			perPage: number;
+		}) => {
+			calls.push(params);
+
+			return {
+				data: [{ creditos: { numero_credito_sifco: `${params.estado}-1` } }],
+				totalPages: 1,
+			};
+		};
+
+		const credits = await getCurrentClientCreditsFromCartera(fetchCredits);
+
+		expect(credits.map((row) => row.creditos?.numero_credito_sifco)).toEqual([
+			"ACTIVO-1",
+			"MOROSO-1",
+			"EN_CONVENIO-1",
+		]);
+		expect(calls.map(({ mes, anio }) => ({ mes, anio }))).toEqual([
+			{ mes: 0, anio: 0 },
+			{ mes: 0, anio: 0 },
+			{ mes: 0, anio: 0 },
 		]);
 	});
 });

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -330,10 +330,10 @@ export function buildCarteraMatchedClientRows(params: {
 		rows.push({
 			...params.lead,
 			rowId: `${params.lead.id}-${sifco}`,
-			opportunities: matchingOpportunities,
+			opportunities: params.leadOpportunities,
 			creditAnalysis: params.creditAnalysis,
 			totalClosedValue: getCarteraCreditAmount(credit),
-			closedOpportunitiesCount: matchingOpportunities.filter(
+			closedOpportunitiesCount: params.leadOpportunities.filter(
 				(opp) => opp.isClosed,
 			).length,
 			crmMatchStatus: "matched",

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -62,7 +62,6 @@ import {
 import { buildDeletedOpportunitySnapshot } from "../lib/deleted-opportunity-audit";
 import {
 	getGuatemalaMonthWindow,
-	toDateStrGT,
 } from "../lib/guatemala-month-window";
 import {
 	formatMissingLeadFields,
@@ -194,11 +193,6 @@ function getCarteraCreditAmount(credit: CarteraClientCredit) {
 	);
 }
 
-function getCurrentCarteraMonthParams(now = new Date()) {
-	const [anio, mes] = toDateStrGT(now).split("-").map(Number);
-	return { mes, anio };
-}
-
 export async function getClientCreditSifcosFromCartera(
 	fetchCredits: ClientCreditFetcher,
 	params: { mes: number; anio: number },
@@ -241,10 +235,13 @@ async function getClientCreditsFromCartera(
 	return Array.from(creditsBySifco.values());
 }
 
-async function getCurrentClientCreditsFromCartera() {
+export async function getCurrentClientCreditsFromCartera(
+	fetchCredits: ClientCreditFetcher = (params) =>
+		carteraBackClient.getAllCreditos(params),
+) {
 	return getClientCreditsFromCartera(
-		(params) => carteraBackClient.getAllCreditos(params),
-		getCurrentCarteraMonthParams(),
+		fetchCredits,
+		{ mes: 0, anio: 0 },
 	);
 }
 

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -8,8 +8,12 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { carteraBackReferences } from "../db/schema/cartera-back";
-import { TIPOS_META, metasMensuales } from "../db/schema/metas";
 import { casosCobros } from "../db/schema/cobros";
+import { metasMensuales, TIPOS_META } from "../db/schema/metas";
+import {
+	getGuatemalaMonthWindow,
+	gtDateStrToDate,
+} from "../lib/guatemala-month-window";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
 import { adminProcedure } from "../lib/orpc";
 import {
@@ -410,8 +414,12 @@ export const reportesCarteraRouter = {
 				periodo: z
 					.enum(["anio", "trimestre", "mes", "semana", "dia"])
 					.default("mes"),
-				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
-				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaInicio: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaFin: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
 			}),
 		)
 		.handler(async ({ input }): Promise<{ data: MontoACobrarRow[] }> => {
@@ -457,30 +465,36 @@ export const reportesCarteraRouter = {
 	getFlujoCuotasInversiones: adminProcedure
 		.input(
 			z.object({
-				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
-				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaInicio: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaFin: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
 			}),
 		)
-		.handler(
-			async ({ input }): Promise<FlujoCuotasInversionesResponse> => {
-				if (!isCarteraBackEnabled()) {
-					throw new ORPCError("BAD_REQUEST", {
-						message: "Integración con cartera-back no está habilitada",
-					});
-				}
-
-				return carteraBackClient.getFlujoCuotasInversiones({
-					fechaInicio: input.fechaInicio,
-					fechaFin: input.fechaFin,
+		.handler(async ({ input }): Promise<FlujoCuotasInversionesResponse> => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
 				});
-			},
-		),
+			}
+
+			return carteraBackClient.getFlujoCuotasInversiones({
+				fechaInicio: input.fechaInicio,
+				fechaFin: input.fechaFin,
+			});
+		}),
 
 	getFlujoCuotasPorInversionista: adminProcedure
 		.input(
 			z.object({
-				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
-				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaInicio: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaFin: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
 			}),
 		)
 		.handler(
@@ -543,7 +557,11 @@ export const reportesCarteraRouter = {
 					updatedAt: new Date(),
 				})
 				.onConflictDoUpdate({
-					target: [metasMensuales.tipo, metasMensuales.anio, metasMensuales.mes],
+					target: [
+						metasMensuales.tipo,
+						metasMensuales.anio,
+						metasMensuales.mes,
+					],
 					set: { monto: input.monto, updatedAt: new Date() },
 				});
 			return { ok: true };
@@ -564,7 +582,9 @@ export const reportesCarteraRouter = {
 			}),
 		)
 		.handler(
-			async ({ input }): Promise<{
+			async ({
+				input,
+			}): Promise<{
 				data: {
 					bucket: string;
 					cantidad_creditos: number;
@@ -574,6 +594,12 @@ export const reportesCarteraRouter = {
 					faltante: string | null;
 				}[];
 			}> => {
+				const startDate = gtDateStrToDate(input.fechaInicio);
+				const endInclusive = new Date(`${input.fechaFin}T12:00:00Z`);
+				endInclusive.setUTCDate(endInclusive.getUTCDate() + 1);
+				const endDate = gtDateStrToDate(
+					endInclusive.toISOString().slice(0, 10),
+				);
 				const toPostgresPeriod: Record<string, string> = {
 					dia: "'day'",
 					semana: "'week'",
@@ -584,25 +610,29 @@ export const reportesCarteraRouter = {
 				const pg = sql.raw(toPostgresPeriod[input.periodo]);
 
 				const colocacionResult = await db.execute(sql`
-					WITH first_placed AS (
+					WITH placed_stage_ids AS (
+						SELECT id
+						FROM sales_stages
+						WHERE closure_percentage >= 90
+					), first_placed AS (
 						SELECT
 							osh.opportunity_id,
 							MIN(osh.changed_at) AS first_placed_at
 						FROM opportunity_stage_history osh
-						JOIN sales_stages ss ON ss.id = osh.to_stage_id
-						WHERE ss.closure_percentage >= 90
+						WHERE osh.to_stage_id IN (SELECT id FROM placed_stage_ids)
 						GROUP BY osh.opportunity_id
 					)
 					SELECT
-						DATE_TRUNC(${pg}, fp.first_placed_at AT TIME ZONE 'America/Guatemala') AS bucket,
+						DATE_TRUNC(${pg}, fp.first_placed_at - INTERVAL '6 hours') AS bucket,
 						COUNT(o.id)::int AS cantidad_creditos,
 						COALESCE(SUM(o.value::numeric), 0) AS total_colocacion
 					FROM first_placed fp
 					JOIN opportunities o ON o.id = fp.opportunity_id
 					WHERE o.status != 'migrate'
-						AND (fp.first_placed_at AT TIME ZONE 'America/Guatemala')::date >= ${input.fechaInicio}::date
-						AND (fp.first_placed_at AT TIME ZONE 'America/Guatemala')::date <= ${input.fechaFin}::date
-					GROUP BY DATE_TRUNC(${pg}, fp.first_placed_at AT TIME ZONE 'America/Guatemala')
+						AND o.stage_id IN (SELECT id FROM placed_stage_ids)
+						AND fp.first_placed_at >= ${startDate}
+						AND fp.first_placed_at < ${endDate}
+					GROUP BY DATE_TRUNC(${pg}, fp.first_placed_at - INTERVAL '6 hours')
 					ORDER BY bucket ASC
 				`);
 
@@ -612,9 +642,16 @@ export const reportesCarteraRouter = {
 					total_colocacion: string;
 				}[];
 
-				const startYear = new Date(`${input.fechaInicio}T12:00:00Z`).getUTCFullYear();
-				const endYear = new Date(`${input.fechaFin}T12:00:00Z`).getUTCFullYear();
-				const anios = Array.from({ length: endYear - startYear + 1 }, (_, i) => startYear + i);
+				const startYear = new Date(
+					`${input.fechaInicio}T12:00:00Z`,
+				).getUTCFullYear();
+				const endYear = new Date(
+					`${input.fechaFin}T12:00:00Z`,
+				).getUTCFullYear();
+				const anios = Array.from(
+					{ length: endYear - startYear + 1 },
+					(_, i) => startYear + i,
+				);
 
 				const metasRows = await db
 					.select()
@@ -632,13 +669,19 @@ export const reportesCarteraRouter = {
 					metasMap[r.anio][r.mes] = Number(r.monto);
 				}
 
-				// Indexar colocación por bucket — parsear como UTC explícito para evitar
-				// interpretación en zona local del servidor (#6)
-				const colocacionMap = new Map<string, { cantidad: number; total: number }>();
+				// Indexar colocación por bucket local GT — parsear como UTC explícito
+				// para evitar interpretación en zona local del servidor (#6)
+				const colocacionMap = new Map<
+					string,
+					{ cantidad: number; total: number }
+				>();
 				for (const row of colocacion) {
-					// row.bucket viene como timestamp string sin zona de DATE_TRUNC AT TIME ZONE
+					// row.bucket viene como timestamp string sin zona de DATE_TRUNC
 					// Forzar parseo UTC agregando Z
-					const raw = typeof row.bucket === "string" ? row.bucket : (row.bucket as Date).toISOString();
+					const raw =
+						typeof row.bucket === "string"
+							? row.bucket
+							: (row.bucket as Date).toISOString();
 					const key = (raw.endsWith("Z") ? raw : `${raw}Z`).slice(0, 10);
 					colocacionMap.set(key, {
 						cantidad: row.cantidad_creditos,
@@ -653,7 +696,9 @@ export const reportesCarteraRouter = {
 
 				const truncTz = (d: Date, periodo: string): Date => {
 					const gt = new Date(d.getTime() - 6 * 60 * 60 * 1000);
-					const y = gt.getUTCFullYear(), mo = gt.getUTCMonth(), day = gt.getUTCDate();
+					const y = gt.getUTCFullYear();
+					const mo = gt.getUTCMonth();
+					const day = gt.getUTCDate();
 					if (periodo === "dia") return new Date(Date.UTC(y, mo, day));
 					if (periodo === "semana") {
 						const dow = gt.getUTCDay();
@@ -661,7 +706,8 @@ export const reportesCarteraRouter = {
 						return new Date(Date.UTC(y, mo, day - ((dow + 6) % 7)));
 					}
 					if (periodo === "mes") return new Date(Date.UTC(y, mo, 1));
-					if (periodo === "trimestre") return new Date(Date.UTC(y, Math.floor(mo / 3) * 3, 1));
+					if (periodo === "trimestre")
+						return new Date(Date.UTC(y, Math.floor(mo / 3) * 3, 1));
 					return new Date(Date.UTC(y, 0, 1));
 				};
 
@@ -710,8 +756,10 @@ export const reportesCarteraRouter = {
 					}
 
 					const colocado = col?.total ?? 0;
-					const cobertura = metaBucket > 0 ? (colocado / metaBucket) * 100 : null;
-					const faltante = metaBucket > 0 ? Math.max(0, metaBucket - colocado) : null;
+					const cobertura =
+						metaBucket > 0 ? (colocado / metaBucket) * 100 : null;
+					const faltante =
+						metaBucket > 0 ? Math.max(0, metaBucket - colocado) : null;
 
 					return {
 						bucket: bucket.toISOString().slice(0, 10),
@@ -738,7 +786,9 @@ export const reportesCarteraRouter = {
 			}),
 		)
 		.handler(
-			async ({ input }): Promise<{
+			async ({
+				input,
+			}): Promise<{
 				data: {
 					mes: number;
 					colocacion_monto: string | null;
@@ -765,30 +815,46 @@ export const reportesCarteraRouter = {
 				const carteraData = await carteraBackClient.getComparativoHistorico(
 					input.anio,
 				);
+				const { startOfMonth: startOfYear } = getGuatemalaMonthWindow(
+					input.anio,
+					1,
+				);
+				const { startOfMonth: endOfYear } = getGuatemalaMonthWindow(
+					input.anio + 1,
+					1,
+				);
 
 				const colocacionResult = await db.execute(sql`
-					WITH first_placed AS (
+					WITH placed_stage_ids AS (
+						SELECT id
+						FROM sales_stages
+						WHERE closure_percentage >= 90
+					), first_placed AS (
 						SELECT
 							osh.opportunity_id,
 							MIN(osh.changed_at) AS first_placed_at
 						FROM opportunity_stage_history osh
-						JOIN sales_stages ss ON ss.id = osh.to_stage_id
-						WHERE ss.closure_percentage >= 90
+						WHERE osh.to_stage_id IN (SELECT id FROM placed_stage_ids)
 						GROUP BY osh.opportunity_id
 					)
 					SELECT
-						EXTRACT(MONTH FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala')::int AS mes,
+						EXTRACT(MONTH FROM fp.first_placed_at - INTERVAL '6 hours')::int AS mes,
 						COUNT(o.id)::int AS colocacion_creditos,
 						COALESCE(SUM(o.value::numeric), 0) AS colocacion_monto
 					FROM first_placed fp
 					JOIN opportunities o ON o.id = fp.opportunity_id
 					WHERE o.status != 'migrate'
-						AND EXTRACT(YEAR FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${input.anio}
+						AND o.stage_id IN (SELECT id FROM placed_stage_ids)
+						AND fp.first_placed_at >= ${startOfYear}
+						AND fp.first_placed_at < ${endOfYear}
 					GROUP BY 1
 					ORDER BY 1
 				`);
 
-				const colocacionMap = new Map<number, { monto: string; creditos: number }>();
+				const colocacionMap = new Map<
+					number,
+					{ monto: string; creditos: number }
+				>();
 				for (const row of colocacionResult.rows as {
 					mes: number;
 					colocacion_creditos: number;
@@ -808,7 +874,10 @@ export const reportesCarteraRouter = {
 					cobradoMap.set(Number(row.mes), Number(row.cobrado).toFixed(2));
 				}
 
-				const carteraMap = new Map<number, { capital: string; creditos: number }>();
+				const carteraMap = new Map<
+					number,
+					{ capital: string; creditos: number }
+				>();
 				for (const row of carteraData.cartera) {
 					carteraMap.set(mesDeDate(row.mes), {
 						capital: Number(row.cartera_activa).toFixed(2),
@@ -816,23 +885,58 @@ export const reportesCarteraRouter = {
 					});
 				}
 
-				type AgingBuckets = { mora_30: string | null; mora_60: string | null; mora_90: string | null; mora_120: string | null; creditos_30: number | null; creditos_60: number | null; creditos_90: number | null; creditos_120: number | null };
+				type AgingBuckets = {
+					mora_30: string | null;
+					mora_60: string | null;
+					mora_90: string | null;
+					mora_120: string | null;
+					creditos_30: number | null;
+					creditos_60: number | null;
+					creditos_90: number | null;
+					creditos_120: number | null;
+				};
 
 				const agingHistMap = new Map<number, AgingBuckets>();
 				for (const row of carteraData.agingHistorico) {
 					const m = mesDeDate(row.periodo);
-					if (!agingHistMap.has(m)) agingHistMap.set(m, { mora_30: null, mora_60: null, mora_90: null, mora_120: null, creditos_30: null, creditos_60: null, creditos_90: null, creditos_120: null });
+					if (!agingHistMap.has(m))
+						agingHistMap.set(m, {
+							mora_30: null,
+							mora_60: null,
+							mora_90: null,
+							mora_120: null,
+							creditos_30: null,
+							creditos_60: null,
+							creditos_90: null,
+							creditos_120: null,
+						});
 					const entry = agingHistMap.get(m)!;
 					const key = `mora_${row.bucket}` as keyof AgingBuckets;
 					const cKey = `creditos_${row.bucket}` as keyof AgingBuckets;
-					(entry as Record<string, string | number | null>)[key] = Number(row.monto_mora).toFixed(2);
-					(entry as Record<string, string | number | null>)[cKey] = row.cantidad_creditos;
+					(entry as Record<string, string | number | null>)[key] = Number(
+						row.monto_mora,
+					).toFixed(2);
+					(entry as Record<string, string | number | null>)[cKey] =
+						row.cantidad_creditos;
 				}
 
-				const agingActual: AgingBuckets = { mora_30: null, mora_60: null, mora_90: null, mora_120: null, creditos_30: null, creditos_60: null, creditos_90: null, creditos_120: null };
+				const agingActual: AgingBuckets = {
+					mora_30: null,
+					mora_60: null,
+					mora_90: null,
+					mora_120: null,
+					creditos_30: null,
+					creditos_60: null,
+					creditos_90: null,
+					creditos_120: null,
+				};
 				for (const row of carteraData.moraActual) {
-					(agingActual as Record<string, string | number | null>)[`mora_${row.bucket}`] = Number(row.monto_mora).toFixed(2);
-					(agingActual as Record<string, string | number | null>)[`creditos_${row.bucket}`] = row.cantidad_creditos;
+					(agingActual as Record<string, string | number | null>)[
+						`mora_${row.bucket}`
+					] = Number(row.monto_mora).toFixed(2);
+					(agingActual as Record<string, string | number | null>)[
+						`creditos_${row.bucket}`
+					] = row.cantidad_creditos;
 				}
 
 				const ahoraGt = new Date(Date.now() - 6 * 60 * 60 * 1000);
@@ -846,15 +950,34 @@ export const reportesCarteraRouter = {
 						(input.anio === anioActual && mes > mesActual);
 					const esMesActual = input.anio === anioActual && mes === mesActual;
 
-					const nullAging: AgingBuckets = { mora_30: null, mora_60: null, mora_90: null, mora_120: null, creditos_30: null, creditos_60: null, creditos_90: null, creditos_120: null };
+					const nullAging: AgingBuckets = {
+						mora_30: null,
+						mora_60: null,
+						mora_90: null,
+						mora_120: null,
+						creditos_30: null,
+						creditos_60: null,
+						creditos_90: null,
+						creditos_120: null,
+					};
 
 					if (esFuturo) {
-						return { mes, colocacion_monto: null, colocacion_creditos: null, facturacion: null, cartera_activa: null, creditos_activos: null, ...nullAging };
+						return {
+							mes,
+							colocacion_monto: null,
+							colocacion_creditos: null,
+							facturacion: null,
+							cartera_activa: null,
+							creditos_activos: null,
+							...nullAging,
+						};
 					}
 
 					const coloc = colocacionMap.get(mes);
 					const cart = carteraMap.get(mes);
-					const aging = esMesActual ? agingActual : (agingHistMap.get(mes) ?? nullAging);
+					const aging = esMesActual
+						? agingActual
+						: (agingHistMap.get(mes) ?? nullAging);
 
 					return {
 						mes,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -3,7 +3,6 @@ import { and, count, desc, eq, gte, lte, sql, sum } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { auctionVehicles } from "../db/schema/auctionVehicles";
-import { user } from "../db/schema/auth";
 import { carteraBackReferences } from "../db/schema/cartera-back";
 import {
 	casosCobros,
@@ -20,13 +19,16 @@ import {
 import { metasMensuales } from "../db/schema/metas";
 import { vehicleInspections, vehicles } from "../db/schema/vehicles";
 import {
+	getGuatemalaMonthWindow,
+	toDateStrGT,
+} from "../lib/guatemala-month-window";
+import {
 	closedCreditsReportProcedure,
 	metaColocacionReportProcedure,
 	porcentajeEfectividadReportProcedure,
 	protectedProcedure,
 	tiempoCierreReportProcedure,
 } from "../lib/orpc";
-import { toDateStrGT } from "../lib/guatemala-month-window";
 import { carteraBackClient } from "../services/cartera-back-client";
 import type { StatusCreditEnum } from "../types/cartera-back";
 
@@ -53,7 +55,9 @@ export const CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE = 50;
 export function isClosedCreditReportCarteraStatusIncluded(
 	status: StatusCreditEnum | null,
 ) {
-	return status ? CLOSED_CREDIT_REPORT_CARTERA_STATUSES.includes(status) : false;
+	return status
+		? CLOSED_CREDIT_REPORT_CARTERA_STATUSES.includes(status)
+		: false;
 }
 
 export function enforceClosedCreditReportLimit<T>(rows: T[]) {
@@ -740,6 +744,7 @@ export const getReporteMetaColocacion = metaColocacionReportProcedure
 	)
 	.handler(async ({ input }) => {
 		const { anio, mes } = input;
+		const { startOfMonth, endOfMonth } = getGuatemalaMonthWindow(anio, mes);
 
 		const [metaRow, porColaboradorRows] = await Promise.all([
 			db
@@ -755,29 +760,40 @@ export const getReporteMetaColocacion = metaColocacionReportProcedure
 				.limit(1),
 
 			db.execute(sql`
-				WITH first_placed AS (
+				WITH placed_stage_ids AS (
+					SELECT id
+					FROM sales_stages
+					WHERE closure_percentage >= 90
+				), moved_to_placed_this_month AS (
 					SELECT
-						osh.opportunity_id,
-						MIN(osh.changed_at) AS first_placed_at
+						DISTINCT osh.opportunity_id
 					FROM opportunity_stage_history osh
-					JOIN sales_stages ss ON ss.id = osh.to_stage_id
-					WHERE ss.closure_percentage >= 90
-					GROUP BY osh.opportunity_id
+					WHERE osh.to_stage_id IN (SELECT id FROM placed_stage_ids)
+						AND osh.changed_at >= ${startOfMonth}
+						AND osh.changed_at < ${endOfMonth}
+				), already_placed_before AS (
+					SELECT DISTINCT osh.opportunity_id
+					FROM opportunity_stage_history osh
+					WHERE osh.opportunity_id IN (
+						SELECT opportunity_id FROM moved_to_placed_this_month
+					)
+						AND osh.to_stage_id IN (SELECT id FROM placed_stage_ids)
+						AND osh.changed_at < ${startOfMonth}
+				), placed_this_month AS (
+					SELECT opportunity_id FROM moved_to_placed_this_month
+					EXCEPT
+					SELECT opportunity_id FROM already_placed_before
 				)
 				SELECT
 					o.assigned_to AS user_id,
 					u.name AS nombre,
 					COUNT(o.id)::int AS creditos,
 					COALESCE(SUM(o.value::numeric), 0) AS monto
-				FROM first_placed fp
-				JOIN opportunities o ON o.id = fp.opportunity_id
-				JOIN sales_stages ss_cur
-					ON ss_cur.id = o.stage_id
-					AND ss_cur.closure_percentage >= 90
+				FROM placed_this_month ptm
+				JOIN opportunities o ON o.id = ptm.opportunity_id
 				LEFT JOIN "user" u ON u.id = o.assigned_to
 				WHERE o.status != 'migrate'
-					AND EXTRACT(YEAR FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${anio}
-					AND EXTRACT(MONTH FROM fp.first_placed_at AT TIME ZONE 'America/Guatemala') = ${mes}
+					AND o.stage_id IN (SELECT id FROM placed_stage_ids)
 				GROUP BY o.assigned_to, u.name
 				ORDER BY monto DESC
 			`),


### PR DESCRIPTION
# 🚀 Pase a Producción — `develop` → `main`

Release de los cambios acumulados en `develop`. Resumen general por área:

## 💳 Cartera
- Editar Royalty y Otros ingresos de forma completa (detalle + total)
- `guardarCeldas` fuerza edición solo del día de hoy (validación server-side)
- Auditoría devuelve `created_at` en hora de Guatemala (formateado en SQL)

## 📊 Reportes
- La gráfica de evolución de mora respeta el filtro de etapa
- Alineación del criterio de cierre de la meta de colocación

## 👥 CRM
- Trae la totalidad de los créditos vigentes de cartera

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
