### PR TITLE
feat(cartera): prorratear interés a inversionistas en pci cuando hay compra de cartera pendiente

### DIFF
--- a/apps/cartera-back/src/cofidi/prorrateoPciInteres.ts
+++ b/apps/cartera-back/src/cofidi/prorrateoPciInteres.ts
@@ -1,0 +1,110 @@
+import Big from "big.js";
+
+Big.DP = 20;
+Big.RM = Big.roundHalfUp;
+
+// 🆕 PRORRATEO DE INTERÉS POR COMPRA DE CARTERA (para insertPagosCreditoInversionistasV2)
+// ----------------------------------------------------------------------------------------
+// Calcula, por inversionista, el FACTOR (fracción del interés total del pago) que le toca
+// cuando el crédito tiene una compra de cartera pendiente. Replica el mismo cálculo de
+// ventanas antes/después de la facturación (ver ./prorratearIntereses.ts):
+//   • fracciónAntes  = díaCorte / díasDelMes      (cómo estaba el crédito ANTES de la compra)
+//   • fracciónDespués = 1 − fracciónAntes          (cómo está AHORA)
+// y en cada ventana reparte por base (monto_aportado del espejo) × el % propio de cada uno
+// (participación para los no-CUBE, cash_in propio para CUBE).
+//
+// Diferencia CLAVE vs la facturación: acá NO se redirige el cash_in de los no-CUBE a CUBE
+// (no hay residuo). Cada quien recibe SOLO lo suyo. El factor se aplica igual a
+// abono_interes y a abono_iva_12 (el reparto es lineal).
+//
+// ⚠️ TODO (cash_in residuo — DIFERIDO a futuro): como NO redirigimos el cash_in de los
+//    no-CUBE a CUBE, la suma de factores es < 1 (queda un hueco = Σ cash_in de los no-CUBE).
+//    Cuando se quiera que CUBE absorba ese residuo (y pci quede idéntico a la factura),
+//    sumarle a CUBE: residuoCube = 1 − Σ(factores) y agregarlo a su factor antes de retornar.
+export type InvProrrateoV2 = {
+  inversionista_id: number;
+  nombre: string;
+  porcentaje_participacion: string | number;
+  porcentaje_cash_in: string | number;
+  monto_aportado_espejo: string | number;
+  status_espejo?: string | null;
+};
+
+export function calcularFactoresProrrateoInteresV2(input: {
+  inversionistas: InvProrrateoV2[];
+  idComprador: number;
+  montoComprado: string | number;
+  fechaCorte: Date;
+  banderaReinversion?: boolean;
+}): Map<number, Big> {
+  const {
+    inversionistas: invs,
+    idComprador,
+    montoComprado,
+    fechaCorte,
+    banderaReinversion = false,
+  } = input;
+  const montoCompra = new Big(montoComprado);
+
+  // UTC: la columna fecha_inicio_participacion es `date` (sin hora); usar UTC evita
+  // que en TZ negativa (GT, UTC-6) "2026-06-01" se corra al día/mes anterior.
+  const diaCorte = fechaCorte.getUTCDate();
+  const ultimoDiaMes = new Date(
+    Date.UTC(fechaCorte.getUTCFullYear(), fechaCorte.getUTCMonth() + 1, 0)
+  ).getUTCDate();
+  const fraccionAntes = new Big(diaCorte).div(ultimoDiaMes);
+  const fraccionDespues = new Big(1).minus(fraccionAntes);
+
+  const cubeId =
+    invs.find((i) => i.nombre.trim().toUpperCase().includes("CUBE INVESTMENTS"))
+      ?.inversionista_id ?? null;
+
+  // Base ANTES (reconstruida): CUBE recupera lo vendido, el comprador queda en su monto
+  // previo (clamp a 0 si era nuevo), el resto igual. Base DESPUÉS = foto actual del espejo.
+  const baseAntes = (inv: InvProrrateoV2): Big => {
+    const m = new Big(inv.monto_aportado_espejo || 0);
+    if (inv.inversionista_id === cubeId) return m.plus(montoCompra);
+    if (inv.inversionista_id === idComprador) {
+      const a = m.minus(montoCompra);
+      return a.lt(0) ? new Big(0) : a;
+    }
+    return m;
+  };
+  const baseDespues = (inv: InvProrrateoV2): Big =>
+    new Big(inv.monto_aportado_espejo || 0);
+
+  const factor = new Map<number, Big>();
+  for (const inv of invs) factor.set(inv.inversionista_id, new Big(0));
+
+  const acumularVentana = (
+    getBase: (i: InvProrrateoV2) => Big,
+    fraccion: Big
+  ) => {
+    const bases = invs.map((inv) => ({ inv, base: getBase(inv) }));
+    const sumaBases = bases.reduce((s, b) => s.plus(b.base), new Big(0));
+    for (const { inv, base } of bases) {
+      // Redirección a CUBE por reinversión: hoy se DIFIERE (no se le asigna a nadie);
+      // entra en el mismo hueco/TODO del residuo de arriba.
+      const redirigirACube =
+        banderaReinversion &&
+        (inv.status_espejo === "pendiente_reinversion" ||
+          inv.status_espejo === "pendiente_compra_cartera");
+      if (redirigirACube) continue;
+
+      const participacion = sumaBases.gt(0) ? base.div(sumaBases) : new Big(0);
+      const esCube = inv.inversionista_id === cubeId;
+      // % propio: CUBE cobra por su cash_in; los demás por su participación.
+      const pctPropio = esCube
+        ? new Big(inv.porcentaje_cash_in || 0).div(100)
+        : new Big(inv.porcentaje_participacion || 0).div(100);
+      const aporte = fraccion.times(participacion).times(pctPropio);
+      factor.set(
+        inv.inversionista_id,
+        (factor.get(inv.inversionista_id) ?? new Big(0)).plus(aporte)
+      );
+    }
+  };
+  acumularVentana(baseAntes, fraccionAntes);
+  acumularVentana(baseDespues, fraccionDespues);
+  return factor;
+}

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -25,6 +25,7 @@ import {
 } from "./investor";
 import { updateMora } from "./latefee";
 import { calcularAjusteCompras, obtenerSumaComprasMesAnterior, obtenerSumaComprasPendientes, obtenerSumaComprasCompletadasMesActual } from "../utils/comprasAjuste";
+import { calcularFactoresProrrateoInteresV2 } from "../cofidi/prorrateoPciInteres";
 import { t } from "elysia";
 
 // ID del inversionista Cube. Fuente canónica: assignCapital.ts (export const CUBE_ID = 86).
@@ -1029,6 +1030,93 @@ export async function insertPagosCreditoInversionistasV2(
     throw new Error("La suma de montos aportados es 0, no se puede distribuir");
   }
 
+  // 4.5 🆕 ¿El crédito tiene una compra de cartera PENDIENTE de facturar?
+  //      Mismo disparador que la facturación (compras_credito_inversionista con
+  //      pendiente_facturar=true y tipo_operacion='compra_cartera'), SIN filtrar por mes.
+  //      Si la hay → el interés se reparte PRORRATEADO (ventanas antes/después).
+  //      Si NO la hay → factorInteresPorInv queda en null y TODO el reparto de abajo
+  //      sigue EXACTAMENTE igual que antes (flujo normal, cero cambios).
+  //
+  // ⚠️ TODO (gating de período — COMPARTIDO con la facturación): este flujo se activa
+  //    SOLO con pendiente_facturar (igual que cofidi.ts), sin verificar que el pago
+  //    pertenezca al mes de la compra. Si un pago de un mes POSTERIOR se distribuye
+  //    mientras la bandera sigue en true (la facturación es quien la limpia), el corte
+  //    del mes de la compra se aplicaría a un mes que no corresponde. La facturación
+  //    tiene el MISMO comportamiento, así que pci y la factura no divergen; cuando se
+  //    decida cerrar este borde hay que hacerlo en AMBOS lados (cofidi.ts + acá).
+  const comprasPendientesFacturar = await db
+    .select({
+      inversionista_id: compras_credito_inversionista.inversionista_id,
+      monto_aportado: compras_credito_inversionista.monto_aportado,
+    })
+    .from(compras_credito_inversionista)
+    .where(
+      and(
+        eq(compras_credito_inversionista.credito_id, credito_id),
+        eq(compras_credito_inversionista.pendiente_facturar, true),
+        eq(compras_credito_inversionista.tipo_operacion, "compra_cartera")
+      )
+    );
+
+  let factorInteresPorInv: Map<number, Big> | null = null;
+
+  if (comprasPendientesFacturar.length > 0) {
+    if (comprasPendientesFacturar.length > 1) {
+      console.warn(
+        `⚠️ [V2 prorrateo] Se esperaba 1 compra pendiente pero llegaron ${comprasPendientesFacturar.length} (crédito ${credito_id}). Se usa la primera.`
+      );
+    }
+    const compra = comprasPendientesFacturar[0];
+
+    // Espejo: base (monto_aportado), status y fecha_inicio_participacion por inversionista.
+    const espejoRows = await db
+      .select({
+        inversionista_id: creditos_inversionistas_espejo.inversionista_id,
+        monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+        status: creditos_inversionistas_espejo.status,
+        fecha_inicio_participacion:
+          creditos_inversionistas_espejo.fecha_inicio_participacion,
+      })
+      .from(creditos_inversionistas_espejo)
+      .where(eq(creditos_inversionistas_espejo.credito_id, credito_id));
+    const espejoPorInv = new Map(espejoRows.map((e) => [e.inversionista_id, e]));
+
+    const fechaCorteRaw = espejoPorInv.get(
+      compra.inversionista_id
+    )?.fecha_inicio_participacion;
+
+    if (!fechaCorteRaw) {
+      // Sin fecha de corte no se puede prorratear → caemos al flujo normal (no rompe el pago).
+      console.warn(
+        `⚠️ [V2 prorrateo] Comprador ${compra.inversionista_id} sin fecha_inicio_participacion en espejo (crédito ${credito_id}). Se usa reparto normal.`
+      );
+    } else {
+      factorInteresPorInv = calcularFactoresProrrateoInteresV2({
+        inversionistas: inversionistasWithName.map((inv) => ({
+          inversionista_id: inv.inversionista_id,
+          nombre: inv.nombre,
+          porcentaje_participacion: inv.porcentaje_participacion_inversionista ?? 0,
+          porcentaje_cash_in: inv.porcentaje_cash_in ?? 0,
+          // Para el prorrateo se usa la base del ESPEJO (refleja la compra); si por algún
+          // motivo el inv no estuviera en el espejo, se cae a su monto_aportado live.
+          monto_aportado_espejo:
+            espejoPorInv.get(inv.inversionista_id)?.monto_aportado ??
+            inv.monto_aportado ??
+            0,
+          status_espejo: espejoPorInv.get(inv.inversionista_id)?.status ?? null,
+        })),
+        idComprador: compra.inversionista_id,
+        montoComprado: compra.monto_aportado,
+        fechaCorte: new Date(fechaCorteRaw as unknown as string),
+        // compra_cartera normalmente no usa redirección por reinversión → false.
+        banderaReinversion: false,
+      });
+      console.log(
+        `🆕 [V2 prorrateo] Crédito ${credito_id}: interés PRORRATEADO por compra de cartera (comprador ${compra.inversionista_id}, corte ${String(fechaCorteRaw)}).`
+      );
+    }
+  }
+
   // 5. Abonos totales del pago
   const pagoAbonoCapital = new Big(currentPago.abono_capital ?? 0);
   const pagoAbonoInteres = new Big(currentPago.abono_interes ?? 0);
@@ -1050,10 +1138,23 @@ export async function insertPagosCreditoInversionistasV2(
       ? new Big(inv.porcentaje_cash_in ?? 0).div(100)
       : new Big(inv.porcentaje_participacion_inversionista ?? 0).div(100);
 
-    // Distribuir abonos: primero por participación, luego por porcentaje general
+    // Capital: SIEMPRE por porcentaje general (sin cambios respecto al flujo original).
     const abonoCapitalInv = pagoAbonoCapital.times(porcentajeGeneral);
-    const abonoInteresInv = pagoAbonoInteres.times(porcentajeParticipacion).times(porcentajeGeneral);
-    const abonoIvaInv = pagoAbonoIva.times(porcentajeParticipacion).times(porcentajeGeneral);
+
+    // Interés / IVA:
+    //   • Con compra de cartera pendiente (factorInteresPorInv != null) → PRORRATEADO
+    //     por ventanas antes/después (mismo criterio que la facturación, sin residuo a CUBE).
+    //   • Sin compra → fórmula de siempre: participación × porcentaje general.
+    let abonoInteresInv: Big;
+    let abonoIvaInv: Big;
+    if (factorInteresPorInv) {
+      const f = factorInteresPorInv.get(inv.inversionista_id) ?? new Big(0);
+      abonoInteresInv = pagoAbonoInteres.times(f);
+      abonoIvaInv = pagoAbonoIva.times(f);
+    } else {
+      abonoInteresInv = pagoAbonoInteres.times(porcentajeParticipacion).times(porcentajeGeneral);
+      abonoIvaInv = pagoAbonoIva.times(porcentajeParticipacion).times(porcentajeGeneral);
+    }
 
     // Solo actualizar monto_aportado si hubo abono a capital
     if (abonoCapitalInv.gt(0)) {

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1091,6 +1091,28 @@ export async function insertPagosCreditoInversionistasV2(
         `⚠️ [V2 prorrateo] Comprador ${compra.inversionista_id} sin fecha_inicio_participacion en espejo (crédito ${credito_id}). Se usa reparto normal.`
       );
     } else {
+      // 🆕 VENTA TOTAL DE CUBE: si la compra consumió toda la posición de CUBE,
+      //    addInvestorToCredit ELIMINA a CUBE de creditos_inversionistas (no lo deja en 0;
+      //    ver addInvestorToCredit.ts: "Si queda en 0, se elimina"), así que no viene en
+      //    inversionistasWithName. Sin CUBE, la ventana "antes" no tendría quién reciba lo
+      //    que CUBE poseía antes de vender → su interés pre-corte se perdería y NO se le
+      //    insertaría fila de pci. Lo sintetizamos en 0 SOLO acá (hay compra_cartera
+      //    pendiente, donde CUBE siempre es el vendedor): el helper le da baseAntes = 0 +
+      //    montoComprado, y el loop le inserta su fila de pci (capital 0 → porcentajeGeneral 0,
+      //    no llama a processAndReplaceCreditInvestors; interés = su factor "antes").
+      if (!inversionistasWithName.some((i) => i.inversionista_id === CUBE_ID)) {
+        inversionistasWithName.push({
+          inversionista_id: CUBE_ID,
+          nombre: "Cube Investments S.A.",
+          monto_aportado: "0",
+          porcentaje_cash_in: "100",
+          porcentaje_participacion_inversionista: "0",
+        } as any);
+        console.log(
+          `🆕 [V2 prorrateo] CUBE vendido a 0 (no está en creditos_inversionistas); se sintetiza en 0 para el prorrateo y su fila de pci (crédito ${credito_id}).`
+        );
+      }
+
       factorInteresPorInv = calcularFactoresProrrateoInteresV2({
         inversionistas: inversionistasWithName.map((inv) => ({
           inversionista_id: inv.inversionista_id,


### PR DESCRIPTION
## Qué

`insertPagosCreditoInversionistasV2` (distribución de pagos a inversionistas → tabla `pagos_credito_inversionistas`, base de la liquidación) ahora **prorratea el interés** igual que la facturación cuando el crédito tiene una **compra de cartera pendiente**.

- **Disparador:** existe fila en `compras_credito_inversionista` con `pendiente_facturar=true` y `tipo_operacion='compra_cartera'` (mismo criterio que la facturación).
- **Cálculo:** ventanas antes/después por la fecha de la compra (`fecha_inicio_participacion` del espejo), repartiendo el `abono_interes`/`abono_iva_12` **real** del pago. Cada no-CUBE recibe su participación; CUBE su parte propia.
- **Sin compra pendiente → flujo idéntico al actual** (guarda aditiva, cero cambios para pagos normales).
- **Capital:** sin cambios.

## Por qué

Antes, el reparto de pci a inversionistas no prorrateaba, así que ante una compra de cartera la liquidación no coincidía con lo facturado. Este cambio alinea el reparto del interés con la lógica de facturación.

## Cómo se probó (DEV / Neon)

- **14/14 pruebas de lógica** (8 configs reales de DEV + 6 casos de borde) cruzadas contra el oráculo independiente `src/cofidi/prorratearIntereses.ts`.
- **4/4 pruebas de la función viva end-to-end** corriendo `insertPagosCreditoInversionistasV2` real contra DEV (con snapshot/restore): disparó el prorrateo, el pci quedó exacto al esperado, y todo se restauró.

## TODOs documentados (no en este PR)

1. **Residuo de cash_in a CUBE (diferido):** hoy el cash_in de los no-CUBE no se redirige a CUBE, así que `Σ pci.interes < abono_interes` (hueco = Σ cash_in no-CUBE). Documentado en `prorrateoPciInteres.ts` con cómo activarlo.
2. **Gating de período (compartido con la facturación):** el flujo se activa solo con `pendiente_facturar`, sin verificar que el pago sea del mes de la compra. Mismo comportamiento que `cofidi.ts`, por lo que pci y la factura no divergen; si se cierra este borde, hay que hacerlo en ambos lados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)