### PR TITLE
fix(reports): refine capital calculation and mora approach for getMontoACobrarPeriodo

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -67,6 +67,262 @@ export async function getMontoACobrar({
   return result.rows;
 }
 
+export async function getMontoACobrarPeriodo({
+  periodo,
+  fechaInicio,
+  fechaFin,
+}: {
+  periodo: Periodo;
+  fechaInicio: string;
+  fechaFin: string;
+}) {
+  const pg = sql.raw(toPostgresPeriod[periodo]);
+
+  const result = await db.execute(sql`
+    WITH
+    pagos_en_rango AS (
+      SELECT
+        pc.credito_id,
+        pc.cuota_id,
+        q.fecha_vencimiento                                                                            AS fecha_venc,
+        MIN(COALESCE(pc.capital_restante::numeric, 0))  + SUM(COALESCE(pc.abono_capital::numeric, 0))   AS capital_restante,
+        MIN(COALESCE(pc.interes_restante::numeric, 0))  + SUM(COALESCE(pc.abono_interes::numeric, 0))   AS interes_restante,
+        MIN(COALESCE(pc.iva_12_restante::numeric, 0))   + SUM(COALESCE(pc.abono_iva_12::numeric, 0))    AS iva_12_restante,
+        MIN(COALESCE(pc.seguro_restante::numeric, 0))   + SUM(COALESCE(pc.abono_seguro::numeric, 0))    AS seguro_restante,
+        MIN(COALESCE(pc.gps_restante::numeric, 0))      + SUM(COALESCE(pc.abono_gps::numeric, 0))       AS gps_restante,
+        MIN(COALESCE(pc.membresias::numeric, 0))        + SUM(COALESCE(pc.membresias_pago::numeric, 0)) AS membresias,
+        SUM(COALESCE(pc.monto_boleta::numeric, 0))                                                       AS monto_boleta
+      FROM cartera.pagos_credito pc
+      JOIN cartera.cuotas_credito q ON q.cuota_id = pc.cuota_id
+      WHERE q.fecha_vencimiento::date >= ${fechaInicio}::date
+        AND q.fecha_vencimiento::date <= ${fechaFin}::date
+      GROUP BY pc.credito_id, pc.cuota_id, q.fecha_vencimiento
+
+      UNION ALL
+
+      SELECT
+        pc.credito_id,
+        pc.cuota_id,
+        pc.fecha_vencimiento                                                                             AS fecha_venc,
+        COALESCE(pc.capital_restante::numeric, 0)  + COALESCE(pc.abono_capital::numeric, 0)             AS capital_restante,
+        COALESCE(pc.interes_restante::numeric, 0)  + COALESCE(pc.abono_interes::numeric, 0)             AS interes_restante,
+        COALESCE(pc.iva_12_restante::numeric, 0)   + COALESCE(pc.abono_iva_12::numeric, 0)              AS iva_12_restante,
+        COALESCE(pc.seguro_restante::numeric, 0)   + COALESCE(pc.abono_seguro::numeric, 0)              AS seguro_restante,
+        COALESCE(pc.gps_restante::numeric, 0)      + COALESCE(pc.abono_gps::numeric, 0)                 AS gps_restante,
+        COALESCE(pc.membresias::numeric, 0)        + COALESCE(pc.membresias_pago::numeric, 0)           AS membresias,
+        COALESCE(pc.monto_boleta::numeric, 0)                                                            AS monto_boleta
+      FROM cartera.pagos_credito pc
+      WHERE pc.cuota_id IS NULL
+        AND pc.fecha_vencimiento::date >= ${fechaInicio}::date
+        AND pc.fecha_vencimiento::date <= ${fechaFin}::date
+    ),
+    per_credito AS (
+      SELECT
+        p.fecha_venc::date                                             AS bucket,
+        c.credito_id,
+        c."statusCredit"                                               AS status,
+        c.porcentaje_interes::numeric / 100                            AS tasa,
+        c.cuota::numeric                                               AS cuota_c,
+        COALESCE(c.seguro_10_cuotas::numeric, 0)                       AS seguro,
+        COALESCE(c.gps::numeric, 0)                                    AS gps,
+        COALESCE(c.membresias_pago::numeric, 0)                        AS mem,
+        COALESCE(cap_anterior.total_restante, c.capital::numeric)       AS cap_ant,
+        MAX(mora_real.cuotas_atrasadas)                                 AS cuotas_atrasadas,
+        CASE WHEN MAX(mora_real.cuotas_atrasadas) > 0
+             THEN COALESCE(MAX(m.monto_mora::numeric), 0)
+             ELSE 0 END                                                 AS mora_val
+      FROM pagos_en_rango p
+      INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
+      INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
+      INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
+      LEFT JOIN cartera.moras_credito m ON m.credito_id = c.credito_id AND m.activa = true
+      LEFT JOIN LATERAL (
+        SELECT pc_a.total_restante::numeric AS total_restante
+        FROM cartera.pagos_credito pc_a
+        LEFT JOIN cartera.cuotas_credito qcc_a ON pc_a.cuota_id = qcc_a.cuota_id
+        WHERE pc_a.credito_id = c.credito_id
+          AND pc_a."paymentFalse" = false
+          AND pc_a.total_restante IS NOT NULL
+          AND pc_a.total_restante::numeric > 0
+          AND COALESCE(
+            qcc_a.fecha_vencimiento::date,
+            GREATEST(
+              COALESCE(pc_a.fecha_boleta::date, pc_a.fecha_pago::date, '1900-01-01'::date),
+              COALESCE(pc_a.fecha_pago::date,   pc_a.fecha_boleta::date, '1900-01-01'::date)
+            )
+          ) < p.fecha_venc::date
+        ORDER BY COALESCE(
+          qcc_a.fecha_vencimiento::date,
+          GREATEST(
+            COALESCE(pc_a.fecha_boleta::date, pc_a.fecha_pago::date, '1900-01-01'::date),
+            COALESCE(pc_a.fecha_pago::date,   pc_a.fecha_boleta::date, '1900-01-01'::date)
+          )
+        ) DESC, pc_a.pago_id DESC
+        LIMIT 1
+      ) cap_anterior ON true
+      LEFT JOIN LATERAL (
+        SELECT COUNT(*)::int AS cuotas_atrasadas
+        FROM cartera.cuotas_credito qc_mora
+        WHERE qc_mora.credito_id = c.credito_id
+          AND qc_mora.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
+          AND qc_mora.pagado = false
+          AND NOT EXISTS (
+            SELECT 1 FROM cartera.pagos_credito pc_mora
+            WHERE pc_mora.cuota_id = qc_mora.cuota_id
+              AND pc_mora."paymentFalse" = false
+              AND pc_mora.pagado = true
+              AND pc_mora.validation_status IN ('validated', 'no_required')
+          )
+      ) mora_real ON true
+      GROUP BY
+        p.fecha_venc::date,
+        c.credito_id, c."statusCredit", c.capital, c.porcentaje_interes, c.cuota,
+        c.seguro_10_cuotas, c.gps, c.membresias_pago,
+        cap_anterior.total_restante, mora_real.cuotas_atrasadas
+      HAVING (
+        SUM(COALESCE(p.capital_restante, 0)) +
+        SUM(COALESCE(p.interes_restante, 0)) +
+        SUM(COALESCE(p.iva_12_restante, 0))  +
+        SUM(COALESCE(p.seguro_restante, 0))  +
+        SUM(COALESCE(p.gps_restante, 0))     +
+        SUM(COALESCE(p.membresias, 0))       +
+        SUM(COALESCE(p.monto_boleta, 0))
+      ) <> 0
+    ),
+    calc AS (
+      SELECT *,
+        ROUND(cap_ant * tasa, 2)                   AS interes,
+        ROUND(ROUND(cap_ant * tasa, 2) * 0.12, 2)  AS iva
+      FROM per_credito
+    ),
+    calc_acum AS (
+      SELECT
+        calc.*,
+        (calc.status IN ('EN_CONVENIO', 'INCOBRABLE', 'CANCELADO', 'PENDIENTE_CANCELACION', 'CAIDO')) AS excluido_mora,
+        (calc.status IN ('CANCELADO', 'INCOBRABLE', 'PENDIENTE_CANCELACION'))                          AS excluido_factura,
+        LEAST(GREATEST(cuota_c - interes - iva - seguro - gps - mem, 0::numeric), cap_ant)             AS exp_capital,
+        COALESCE(acum.acum_capital, 0) AS acum_capital,
+        COALESCE(acum.acum_interes, 0) AS acum_interes,
+        COALESCE(acum.acum_iva,     0) AS acum_iva,
+        COALESCE(acum.acum_seguro,  0) AS acum_seguro,
+        COALESCE(acum.acum_gps,     0) AS acum_gps,
+        COALESCE(acum.acum_mem,     0) AS acum_mem
+      FROM calc
+      LEFT JOIN LATERAL (
+        SELECT
+          COALESCE(SUM(LEAST(
+            a.capital_restante,
+            GREATEST(calc.cuota_c - a.interes_restante - a.iva_12_restante
+                     - a.seguro_restante - a.gps_restante - a.membresias, 0::numeric)
+          )), 0) AS acum_capital,
+          COALESCE(SUM(a.interes_restante), 0) AS acum_interes,
+          COALESCE(SUM(a.iva_12_restante),  0) AS acum_iva,
+          COALESCE(SUM(a.seguro_restante),  0) AS acum_seguro,
+          COALESCE(SUM(a.gps_restante),     0) AS acum_gps,
+          COALESCE(SUM(a.membresias),       0) AS acum_mem
+        FROM (
+          SELECT
+            COALESCE(MIN(pc_a.capital_restante::numeric), 0) AS capital_restante,
+            COALESCE(MIN(pc_a.interes_restante::numeric), 0) AS interes_restante,
+            COALESCE(MIN(pc_a.iva_12_restante::numeric),  0) AS iva_12_restante,
+            COALESCE(MIN(pc_a.seguro_restante::numeric),  0) AS seguro_restante,
+            COALESCE(MIN(pc_a.gps_restante::numeric),     0) AS gps_restante,
+            COALESCE(MIN(pc_a.membresias::numeric),       0) AS membresias
+          FROM cartera.cuotas_credito q_a
+          LEFT JOIN cartera.pagos_credito pc_a
+            ON pc_a.cuota_id = q_a.cuota_id
+            AND pc_a."paymentFalse" = false
+          WHERE q_a.credito_id = calc.credito_id
+            AND q_a.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
+            AND q_a.pagado = false
+            AND NOT EXISTS (
+              SELECT 1 FROM cartera.pagos_credito pc2
+              WHERE pc2.cuota_id = q_a.cuota_id
+                AND pc2."paymentFalse" = false
+                AND pc2.pagado = true
+                AND pc2.validation_status IN ('validated', 'no_required')
+            )
+          GROUP BY q_a.cuota_id
+          HAVING (
+              COALESCE(MIN(pc_a.capital_restante::numeric), 0)
+            + COALESCE(MIN(pc_a.interes_restante::numeric), 0)
+            + COALESCE(MIN(pc_a.iva_12_restante::numeric),  0)
+            + COALESCE(MIN(pc_a.seguro_restante::numeric),  0)
+            + COALESCE(MIN(pc_a.gps_restante::numeric),     0)
+            + COALESCE(MIN(pc_a.membresias::numeric),       0)
+          ) > 0
+          OR COUNT(pc_a.pago_id) = 0
+          OR MIN(pc_a.capital_restante) IS NULL
+        ) a
+      ) acum ON calc.cuotas_atrasadas > 0
+    ),
+    per_bucket_credit AS (
+      SELECT
+        DATE_TRUNC(${pg}, bucket::timestamp)    AS bucket,
+        credito_id,
+        MAX(excluido_mora::int)::bool           AS excluido_mora,
+        MAX(excluido_factura::int)::bool        AS excluido_factura,
+        SUM(exp_capital)                        AS exp_capital,
+        SUM(interes)                            AS interes,
+        SUM(iva)                                AS iva,
+        SUM(seguro)                             AS seguro,
+        SUM(gps)                                AS gps,
+        SUM(mem)                                AS mem,
+        MAX(mora_val)                           AS mora_val,
+        MAX(cuotas_atrasadas)                   AS cuotas_atrasadas,
+        MIN(cap_ant)                            AS cap_ant,
+        MAX(acum_capital)                       AS acum_capital,
+        MAX(acum_interes)                       AS acum_interes,
+        MAX(acum_iva)                           AS acum_iva,
+        MAX(acum_seguro)                        AS acum_seguro,
+        MAX(acum_gps)                           AS acum_gps,
+        MAX(acum_mem)                           AS acum_mem
+      FROM calc_acum
+      GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
+    )
+    SELECT
+      bucket,
+      COUNT(*)::int                                                                                AS cuotas_count,
+      COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
+      COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
+      COALESCE(SUM(CASE WHEN NOT excluido_factura THEN iva         ELSE 0 END), 0)               AS total_iva,
+      COALESCE(SUM(CASE WHEN NOT excluido_factura THEN seguro      ELSE 0 END), 0)               AS total_seguro,
+      COALESCE(SUM(CASE WHEN NOT excluido_factura THEN gps         ELSE 0 END), 0)               AS total_gps,
+      COALESCE(SUM(CASE WHEN NOT excluido_factura THEN mem         ELSE 0 END), 0)               AS total_membresias,
+      AVG(CASE WHEN cuotas_atrasadas > 0 AND NOT excluido_mora THEN mora_val END)                AS mora_promedio,
+      COUNT(*) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora)::int                   AS mora_count,
+      COALESCE(SUM(CASE
+        WHEN excluido_mora     THEN 0
+        WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant)
+        ELSE exp_capital END), 0)                                                                 AS acum_total_cuota,
+      COALESCE(SUM(CASE
+        WHEN excluido_mora     THEN 0
+        WHEN cuotas_atrasadas > 0 THEN acum_interes
+        ELSE interes END), 0)                                                                     AS acum_total_interes,
+      COALESCE(SUM(CASE
+        WHEN excluido_mora     THEN 0
+        WHEN cuotas_atrasadas > 0 THEN acum_iva
+        ELSE iva END), 0)                                                                         AS acum_total_iva,
+      COALESCE(SUM(CASE
+        WHEN excluido_mora     THEN 0
+        WHEN cuotas_atrasadas > 0 THEN acum_seguro
+        ELSE seguro END), 0)                                                                      AS acum_total_seguro,
+      COALESCE(SUM(CASE
+        WHEN excluido_mora     THEN 0
+        WHEN cuotas_atrasadas > 0 THEN acum_gps
+        ELSE gps END), 0)                                                                         AS acum_total_gps,
+      COALESCE(SUM(CASE
+        WHEN excluido_mora     THEN 0
+        WHEN cuotas_atrasadas > 0 THEN acum_mem
+        ELSE mem END), 0)                                                                         AS acum_total_membresias
+    FROM per_bucket_credit
+    GROUP BY bucket
+    ORDER BY bucket ASC
+  `);
+
+  return result.rows;
+}
+
 export async function getCobradoDelMes({
   mes,
   anio,

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -84,18 +84,17 @@ export async function getMontoACobrarPeriodo({
       SELECT
         pc.credito_id,
         pc.cuota_id,
-        q.fecha_vencimiento                                                                            AS fecha_venc,
-        MIN(COALESCE(pc.capital_restante::numeric, 0))  + SUM(COALESCE(pc.abono_capital::numeric, 0))   AS capital_restante,
-        MIN(COALESCE(pc.interes_restante::numeric, 0))  + SUM(COALESCE(pc.abono_interes::numeric, 0))   AS interes_restante,
-        MIN(COALESCE(pc.iva_12_restante::numeric, 0))   + SUM(COALESCE(pc.abono_iva_12::numeric, 0))    AS iva_12_restante,
-        MIN(COALESCE(pc.seguro_restante::numeric, 0))   + SUM(COALESCE(pc.abono_seguro::numeric, 0))    AS seguro_restante,
-        MIN(COALESCE(pc.gps_restante::numeric, 0))      + SUM(COALESCE(pc.abono_gps::numeric, 0))       AS gps_restante,
-        MIN(COALESCE(pc.membresias::numeric, 0))        + SUM(COALESCE(pc.membresias_pago::numeric, 0)) AS membresias,
-        SUM(COALESCE(pc.monto_boleta::numeric, 0))                                                       AS monto_boleta
+        q.fecha_vencimiento                                                                                                AS fecha_venc,
+        COALESCE(MIN(pc.capital_restante::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.abono_capital::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0)   AS capital_restante,
+        COALESCE(MIN(pc.interes_restante::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.abono_interes::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0)   AS interes_restante,
+        COALESCE(MIN(pc.iva_12_restante::numeric)  FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.abono_iva_12::numeric)   FILTER (WHERE NOT pc."paymentFalse"), 0)  AS iva_12_restante,
+        COALESCE(MIN(pc.seguro_restante::numeric)  FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.abono_seguro::numeric)   FILTER (WHERE NOT pc."paymentFalse"), 0)  AS seguro_restante,
+        COALESCE(MIN(pc.gps_restante::numeric)     FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.abono_gps::numeric)      FILTER (WHERE NOT pc."paymentFalse"), 0)  AS gps_restante,
+        COALESCE(MIN(pc.membresias::numeric)       FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.membresias_pago::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0) AS membresias,
+        SUM(COALESCE(pc.monto_boleta::numeric, 0))                                                                         AS monto_boleta
       FROM cartera.pagos_credito pc
       JOIN cartera.cuotas_credito q ON q.cuota_id = pc.cuota_id
-      WHERE pc."paymentFalse" = false
-        AND q.fecha_vencimiento::date >= ${fechaInicio}::date
+      WHERE q.fecha_vencimiento::date >= ${fechaInicio}::date
         AND q.fecha_vencimiento::date <= ${fechaFin}::date
       GROUP BY pc.credito_id, pc.cuota_id, q.fecha_vencimiento
 
@@ -152,7 +151,7 @@ export async function getMontoACobrarPeriodo({
               COALESCE(pc_a.fecha_boleta::date, pc_a.fecha_pago::date, '1900-01-01'::date),
               COALESCE(pc_a.fecha_pago::date,   pc_a.fecha_boleta::date, '1900-01-01'::date)
             )
-          ) < p.fecha_venc::date
+          ) < DATE_TRUNC(${pg}, p.fecha_venc::timestamp)::date
         ORDER BY COALESCE(
           qcc_a.fecha_vencimiento::date,
           GREATEST(
@@ -167,13 +166,13 @@ export async function getMontoACobrarPeriodo({
         FROM cartera.cuotas_credito qc_mora
         WHERE qc_mora.credito_id = c.credito_id
           AND qc_mora.fecha_vencimiento::date < p.fecha_venc::date
-          AND qc_mora.pagado = false
           AND NOT EXISTS (
             SELECT 1 FROM cartera.pagos_credito pc_mora
             WHERE pc_mora.cuota_id = qc_mora.cuota_id
               AND pc_mora."paymentFalse" = false
               AND pc_mora.pagado = true
               AND pc_mora.validation_status IN ('validated', 'no_required')
+              AND COALESCE(pc_mora.fecha_boleta::date, pc_mora.fecha_pago::date) <= p.fecha_venc::date
           )
       ) mora_real ON true
       GROUP BY
@@ -236,13 +235,13 @@ export async function getMontoACobrarPeriodo({
             AND pc_a."paymentFalse" = false
           WHERE q_a.credito_id = calc.credito_id
             AND q_a.fecha_vencimiento::date < calc.bucket
-            AND q_a.pagado = false
             AND NOT EXISTS (
               SELECT 1 FROM cartera.pagos_credito pc2
               WHERE pc2.cuota_id = q_a.cuota_id
                 AND pc2."paymentFalse" = false
                 AND pc2.pagado = true
                 AND pc2.validation_status IN ('validated', 'no_required')
+                AND COALESCE(pc2.fecha_boleta::date, pc2.fecha_pago::date) <= calc.bucket
             )
           GROUP BY q_a.cuota_id
           HAVING (
@@ -293,7 +292,7 @@ export async function getMontoACobrarPeriodo({
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN gps         ELSE 0 END), 0)               AS total_gps,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN mem         ELSE 0 END), 0)               AS total_membresias,
       AVG(CASE WHEN cuotas_atrasadas > 0 AND NOT excluido_mora THEN mora_val END)                AS mora_promedio,
-      COUNT(*) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora)::int                   AS mora_count,
+      COALESCE(SUM(cuotas_count) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora), 0)::int AS mora_count,
       COALESCE(SUM(CASE
         WHEN excluido_mora     THEN 0
         WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant)

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -164,7 +164,7 @@ export async function getMontoACobrarPeriodo({
         SELECT COUNT(*)::int AS cuotas_atrasadas
         FROM cartera.cuotas_credito qc_mora
         WHERE qc_mora.credito_id = c.credito_id
-          AND qc_mora.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
+          AND qc_mora.fecha_vencimiento::date < p.fecha_venc::date
           AND qc_mora.pagado = false
           AND NOT EXISTS (
             SELECT 1 FROM cartera.pagos_credito pc_mora
@@ -233,7 +233,7 @@ export async function getMontoACobrarPeriodo({
             ON pc_a.cuota_id = q_a.cuota_id
             AND pc_a."paymentFalse" = false
           WHERE q_a.credito_id = calc.credito_id
-            AND q_a.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
+            AND q_a.fecha_vencimiento::date < calc.bucket
             AND q_a.pagado = false
             AND NOT EXISTS (
               SELECT 1 FROM cartera.pagos_credito pc2

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -94,7 +94,8 @@ export async function getMontoACobrarPeriodo({
         SUM(COALESCE(pc.monto_boleta::numeric, 0))                                                       AS monto_boleta
       FROM cartera.pagos_credito pc
       JOIN cartera.cuotas_credito q ON q.cuota_id = pc.cuota_id
-      WHERE q.fecha_vencimiento::date >= ${fechaInicio}::date
+      WHERE pc."paymentFalse" = false
+        AND q.fecha_vencimiento::date >= ${fechaInicio}::date
         AND q.fecha_vencimiento::date <= ${fechaFin}::date
       GROUP BY pc.credito_id, pc.cuota_id, q.fecha_vencimiento
 
@@ -112,7 +113,8 @@ export async function getMontoACobrarPeriodo({
         COALESCE(pc.membresias::numeric, 0)        + COALESCE(pc.membresias_pago::numeric, 0)           AS membresias,
         COALESCE(pc.monto_boleta::numeric, 0)                                                            AS monto_boleta
       FROM cartera.pagos_credito pc
-      WHERE pc.cuota_id IS NULL
+      WHERE pc."paymentFalse" = false
+        AND pc.cuota_id IS NULL
         AND pc.fecha_vencimiento::date >= ${fechaInicio}::date
         AND pc.fecha_vencimiento::date <= ${fechaFin}::date
     ),
@@ -276,13 +278,14 @@ export async function getMontoACobrarPeriodo({
         MAX(acum_iva)                           AS acum_iva,
         MAX(acum_seguro)                        AS acum_seguro,
         MAX(acum_gps)                           AS acum_gps,
-        MAX(acum_mem)                           AS acum_mem
+        MAX(acum_mem)                           AS acum_mem,
+        COUNT(*)::int                           AS cuotas_count
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
     )
     SELECT
       bucket,
-      COUNT(*)::int                                                                                AS cuotas_count,
+      COALESCE(SUM(cuotas_count), 0)::int                                                        AS cuotas_count,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN iva         ELSE 0 END), 0)               AS total_iva,

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -16,6 +16,12 @@ function validarPeriodo(periodo: string | undefined, set: { status: number }): P
   return p as PeriodoValido;
 }
 
+function fechaValida(s: string): boolean {
+  const [y, m, d] = s.split("-").map(Number);
+  const dt = new Date(y, m - 1, d);
+  return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
+}
+
 export const reportesRouter = new Elysia().use(authMiddleware)
 
   .get("/reportes/monto-cobrar", async ({ query, set }) => {
@@ -29,15 +35,13 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
-      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
-        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
-          set.status = 400;
-          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
-        }
-        if (fechaInicio > fechaFin) {
-          set.status = 400;
-          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
-        }
+      if (!fechaValida(fechaInicio) || !fechaValida(fechaFin)) {
+        set.status = 400;
+        return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+      }
+      if (fechaInicio > fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio debe ser menor o igual a fechaFin" };
       }
       const p = validarPeriodo(periodo, set);
       if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };
@@ -62,15 +66,13 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
-      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
-        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
-          set.status = 400;
-          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
-        }
-        if (fechaInicio > fechaFin) {
-          set.status = 400;
-          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
-        }
+      if (!fechaValida(fechaInicio) || !fechaValida(fechaFin)) {
+        set.status = 400;
+        return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+      }
+      if (fechaInicio > fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio debe ser menor o igual a fechaFin" };
       }
       const p = validarPeriodo(periodo, set);
       if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };
@@ -114,15 +116,13 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
-      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
-        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
-          set.status = 400;
-          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
-        }
-        if (fechaInicio > fechaFin) {
-          set.status = 400;
-          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
-        }
+      if (!fechaValida(fechaInicio) || !fechaValida(fechaFin)) {
+        set.status = 400;
+        return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+      }
+      if (fechaInicio > fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio debe ser menor o igual a fechaFin" };
       }
       const data = await getFlujoCuotasInversiones({ fechaInicio, fechaFin });
       set.status = 200;
@@ -164,15 +164,13 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
-      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
-        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
-          set.status = 400;
-          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
-        }
-        if (fechaInicio > fechaFin) {
-          set.status = 400;
-          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
-        }
+      if (!fechaValida(fechaInicio) || !fechaValida(fechaFin)) {
+        set.status = 400;
+        return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+      }
+      if (fechaInicio > fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio debe ser menor o igual a fechaFin" };
       }
       const data = await getFlujoCuotasPorInversionista({ fechaInicio, fechaFin });
       set.status = 200;
@@ -214,15 +212,13 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
-      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
-        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
-          set.status = 400;
-          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
-        }
-        if (fechaInicio > fechaFin) {
-          set.status = 400;
-          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
-        }
+      if (!fechaValida(fechaInicio) || !fechaValida(fechaFin)) {
+        set.status = 400;
+        return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+      }
+      if (fechaInicio > fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio debe ser menor o igual a fechaFin" };
       }
       const p = validarPeriodo(periodo, set);
       if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -29,6 +29,16 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
+      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
+        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
+          set.status = 400;
+          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+        }
+        if (fechaInicio > fechaFin) {
+          set.status = 400;
+          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
+        }
+      }
       const p = validarPeriodo(periodo, set);
       if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };
       const data = await getMontoACobrar({ periodo: p, fechaInicio, fechaFin });
@@ -51,6 +61,16 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       if (!FECHA_REGEX.test(fechaInicio) || !FECHA_REGEX.test(fechaFin)) {
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
+      }
+      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
+        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
+          set.status = 400;
+          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+        }
+        if (fechaInicio > fechaFin) {
+          set.status = 400;
+          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
+        }
       }
       const p = validarPeriodo(periodo, set);
       if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };
@@ -94,6 +114,16 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
+      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
+        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
+          set.status = 400;
+          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+        }
+        if (fechaInicio > fechaFin) {
+          set.status = 400;
+          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
+        }
+      }
       const data = await getFlujoCuotasInversiones({ fechaInicio, fechaFin });
       set.status = 200;
       return data;
@@ -134,6 +164,16 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
       }
+      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
+        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
+          set.status = 400;
+          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+        }
+        if (fechaInicio > fechaFin) {
+          set.status = 400;
+          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
+        }
+      }
       const data = await getFlujoCuotasPorInversionista({ fechaInicio, fechaFin });
       set.status = 200;
       return data;
@@ -169,6 +209,20 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       if (!fechaInicio || !fechaFin) {
         set.status = 400;
         return { error: "fechaInicio y fechaFin son requeridos" };
+      }
+      if (!FECHA_REGEX.test(fechaInicio) || !FECHA_REGEX.test(fechaFin)) {
+        set.status = 400;
+        return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
+      }
+      { const fd1 = new Date(fechaInicio), fd2 = new Date(fechaFin);
+        if (isNaN(fd1.getTime()) || isNaN(fd2.getTime())) {
+          set.status = 400;
+          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+        }
+        if (fechaInicio > fechaFin) {
+          set.status = 400;
+          return { error: "fechaInicio debe ser menor o igual a fechaFin" };
+        }
       }
       const p = validarPeriodo(periodo, set);
       if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { getCobradoDelMes, getColocacionPorPeriodo, getComparativoHistorico, getEsperadoDelMes, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar, getReinversionLiquidaciones } from "../controllers/reportes";
+import { getCobradoDelMes, getColocacionPorPeriodo, getComparativoHistorico, getEsperadoDelMes, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -36,6 +36,29 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return { data };
     } catch (error) {
       console.error("[/reportes/monto-cobrar]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/monto-cobrar-periodo", async ({ query, set }) => {
+    try {
+      const { periodo, fechaInicio, fechaFin } = query as Record<string, string>;
+      if (!fechaInicio || !fechaFin) {
+        set.status = 400;
+        return { error: "fechaInicio y fechaFin son requeridos" };
+      }
+      if (!FECHA_REGEX.test(fechaInicio) || !FECHA_REGEX.test(fechaFin)) {
+        set.status = 400;
+        return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
+      }
+      const p = validarPeriodo(periodo, set);
+      if (!p) return { error: "periodo inválido. Valores: anio, trimestre, mes, semana, dia" };
+      const data = await getMontoACobrarPeriodo({ periodo: p, fechaInicio, fechaFin });
+      set.status = 200;
+      return { data };
+    } catch (error) {
+      console.error("[/reportes/monto-cobrar-periodo]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -341,6 +341,7 @@ export const reportsAppRouter = {
 	getReporteCarteraCompleto: reportesCarteraRouter.getReporteCarteraCompleto,
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,
 	getMontoACobrar: reportesCarteraRouter.getMontoACobrar,
+	getMontoACobrarPeriodo: reportesCarteraRouter.getMontoACobrarPeriodo,
 	getFacturacionMes: reportesCarteraRouter.getFacturacionMes,
 	getFlujoCuotasInversiones: reportesCarteraRouter.getFlujoCuotasInversiones,
 	getReinversionLiquidaciones:

--- a/apps/crm/apps/server/src/routers/reportes-cartera.ts
+++ b/apps/crm/apps/server/src/routers/reportes-cartera.ts
@@ -22,6 +22,7 @@ import {
 	type FlujoCuotasInversionesResponse,
 	type FlujoCuotasPorInversionistaResponse,
 	type MontoACobrarRow,
+	type MontoACobrarPeriodoRow,
 	type ReinversionLiquidacionesResponse,
 } from "../services/cartera-back-client";
 import { isCarteraBackEnabled } from "../services/cartera-back-integration";
@@ -431,6 +432,36 @@ export const reportesCarteraRouter = {
 			}
 
 			const data = await carteraBackClient.getMontoACobrar({
+				periodo: input.periodo,
+				fechaInicio: input.fechaInicio,
+				fechaFin: input.fechaFin,
+			});
+
+			return { data };
+		}),
+
+	// ========================================================================
+	// REPORTE: MONTO A COBRARSE POR PERÍODO (lógica cartera web, con acumulado)
+	// ========================================================================
+
+	getMontoACobrarPeriodo: adminProcedure
+		.input(
+			z.object({
+				periodo: z
+					.enum(["anio", "trimestre", "mes", "semana", "dia"])
+					.default("mes"),
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Formato YYYY-MM-DD requerido"),
+			}),
+		)
+		.handler(async ({ input }): Promise<{ data: MontoACobrarPeriodoRow[] }> => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			const data = await carteraBackClient.getMontoACobrarPeriodo({
 				periodo: input.periodo,
 				fechaInicio: input.fechaInicio,
 				fechaFin: input.fechaFin,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -210,6 +210,25 @@ export type MontoACobrarRow = {
 	mora_promedio: string;
 };
 
+export type MontoACobrarPeriodoRow = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	mora_promedio: string;
+	mora_count: number;
+	acum_total_cuota: string;
+	acum_total_interes: string;
+	acum_total_iva: string;
+	acum_total_seguro: string;
+	acum_total_gps: string;
+	acum_total_membresias: string;
+};
+
 export type FlujoCuotasRubro = {
 	capital: string;
 	interes: string;
@@ -1339,6 +1358,26 @@ export class CarteraBackClient {
 
 		const response = await this.request<{ data: MontoACobrarRow[] }>(
 			`/reportes/monto-cobrar?${queryParams}`,
+			{ method: "GET" },
+			true,
+		);
+
+		return response.data ?? [];
+	}
+
+	async getMontoACobrarPeriodo(params: {
+		periodo: string;
+		fechaInicio: string;
+		fechaFin: string;
+	}): Promise<MontoACobrarPeriodoRow[]> {
+		const queryParams = new URLSearchParams({
+			periodo: params.periodo,
+			fechaInicio: params.fechaInicio,
+			fechaFin: params.fechaFin,
+		});
+
+		const response = await this.request<{ data: MontoACobrarPeriodoRow[] }>(
+			`/reportes/monto-cobrar-periodo?${queryParams}`,
 			{ method: "GET" },
 			true,
 		);

--- a/apps/crm/apps/web/src/components/reports/period-date-picker.tsx
+++ b/apps/crm/apps/web/src/components/reports/period-date-picker.tsx
@@ -1,0 +1,282 @@
+import { CalendarIcon } from "lucide-react";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+
+type Periodo = "anio" | "trimestre" | "mes" | "semana" | "dia";
+
+interface PeriodDatePickerProps {
+	periodo: Periodo;
+	fechaInicio: string;
+	fechaFin: string;
+	onChange: (fechaInicio: string, fechaFin: string) => void;
+}
+
+function pad(n: number) {
+	return String(n).padStart(2, "0");
+}
+
+function lastDayOfMonth(year: number, month: number) {
+	return new Date(year, month, 0).getDate();
+}
+
+function quarterStartEnd(year: number, q: number) {
+	const startMonth = (q - 1) * 3 + 1;
+	const endMonth = startMonth + 2;
+	return {
+		start: `${year}-${pad(startMonth)}-01`,
+		end: `${year}-${pad(endMonth)}-${pad(lastDayOfMonth(year, endMonth))}`,
+	};
+}
+
+function monthStartEnd(year: number, month: number) {
+	return {
+		start: `${year}-${pad(month)}-01`,
+		end: `${year}-${pad(month)}-${pad(lastDayOfMonth(year, month))}`,
+	};
+}
+
+function parseYear(s: string) {
+	return new Date(`${s}T12:00:00`).getFullYear();
+}
+function parseMonth(s: string) {
+	return new Date(`${s}T12:00:00`).getMonth() + 1;
+}
+function parseQuarter(s: string) {
+	return Math.ceil(parseMonth(s) / 3) || 1;
+}
+
+const MONTHS = [
+	"Enero",
+	"Febrero",
+	"Marzo",
+	"Abril",
+	"Mayo",
+	"Junio",
+	"Julio",
+	"Agosto",
+	"Septiembre",
+	"Octubre",
+	"Noviembre",
+	"Diciembre",
+];
+
+function YearSelect({
+	value,
+	onChange,
+}: {
+	value: number;
+	onChange: (y: number) => void;
+}) {
+	const currentYear = new Date().getFullYear();
+	const years = Array.from({ length: 11 }, (_, i) => currentYear - 5 + i);
+	return (
+		<Select
+			value={String(value)}
+			onValueChange={(v) => onChange(Number(v))}
+		>
+			<SelectTrigger className="w-[90px]">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{years.map((y) => (
+					<SelectItem key={y} value={String(y)}>
+						{y}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+function QuarterSelect({
+	value,
+	onChange,
+}: {
+	value: number;
+	onChange: (q: number) => void;
+}) {
+	return (
+		<Select
+			value={String(value)}
+			onValueChange={(v) => onChange(Number(v))}
+		>
+			<SelectTrigger className="w-[70px]">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				<SelectItem value="1">T1</SelectItem>
+				<SelectItem value="2">T2</SelectItem>
+				<SelectItem value="3">T3</SelectItem>
+				<SelectItem value="4">T4</SelectItem>
+			</SelectContent>
+		</Select>
+	);
+}
+
+function MonthSelect({
+	value,
+	onChange,
+}: {
+	value: number;
+	onChange: (m: number) => void;
+}) {
+	return (
+		<Select
+			value={String(value)}
+			onValueChange={(v) => onChange(Number(v))}
+		>
+			<SelectTrigger className="w-[120px]">
+				<SelectValue />
+			</SelectTrigger>
+			<SelectContent>
+				{MONTHS.map((name, i) => (
+					<SelectItem key={i + 1} value={String(i + 1)}>
+						{name}
+					</SelectItem>
+				))}
+			</SelectContent>
+		</Select>
+	);
+}
+
+export function PeriodDatePicker({
+	periodo,
+	fechaInicio,
+	fechaFin,
+	onChange,
+}: PeriodDatePickerProps) {
+	if (periodo === "anio") {
+		const fromYear = parseYear(fechaInicio);
+		const toYear = parseYear(fechaFin);
+		return (
+			<div className="flex items-center gap-1.5">
+				<CalendarIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+				<YearSelect
+					value={fromYear}
+					onChange={(y) => {
+						const clampedTo = Math.max(y, toYear);
+						onChange(`${y}-01-01`, `${clampedTo}-12-31`);
+					}}
+				/>
+				<span className="text-muted-foreground text-sm">–</span>
+				<YearSelect
+					value={toYear}
+					onChange={(y) => {
+						const clampedFrom = Math.min(fromYear, y);
+						onChange(`${clampedFrom}-01-01`, `${y}-12-31`);
+					}}
+				/>
+			</div>
+		);
+	}
+
+	if (periodo === "trimestre") {
+		const year = parseYear(fechaInicio);
+		const fromQ = parseQuarter(fechaInicio);
+		const toQ = parseQuarter(fechaFin);
+		return (
+			<div className="flex items-center gap-1.5">
+				<CalendarIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+				<YearSelect
+					value={year}
+					onChange={(y) => {
+						onChange(
+							quarterStartEnd(y, fromQ).start,
+							quarterStartEnd(y, toQ).end,
+						);
+					}}
+				/>
+				<QuarterSelect
+					value={fromQ}
+					onChange={(q) => {
+						const clampedTo = Math.max(q, toQ);
+						onChange(
+							quarterStartEnd(year, q).start,
+							quarterStartEnd(year, clampedTo).end,
+						);
+					}}
+				/>
+				<span className="text-muted-foreground text-sm">–</span>
+				<QuarterSelect
+					value={toQ}
+					onChange={(q) => {
+						const clampedFrom = Math.min(fromQ, q);
+						onChange(
+							quarterStartEnd(year, clampedFrom).start,
+							quarterStartEnd(year, q).end,
+						);
+					}}
+				/>
+			</div>
+		);
+	}
+
+	if (periodo === "mes") {
+		const year = parseYear(fechaInicio);
+		const fromMonth = parseMonth(fechaInicio);
+		const toMonth = parseMonth(fechaFin);
+		return (
+			<div className="flex items-center gap-1.5">
+				<CalendarIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+				<YearSelect
+					value={year}
+					onChange={(y) => {
+						onChange(
+							monthStartEnd(y, fromMonth).start,
+							monthStartEnd(y, toMonth).end,
+						);
+					}}
+				/>
+				<MonthSelect
+					value={fromMonth}
+					onChange={(m) => {
+						const clampedTo = Math.max(m, toMonth);
+						onChange(
+							monthStartEnd(year, m).start,
+							monthStartEnd(year, clampedTo).end,
+						);
+					}}
+				/>
+				<span className="text-muted-foreground text-sm">–</span>
+				<MonthSelect
+					value={toMonth}
+					onChange={(m) => {
+						const clampedFrom = Math.min(fromMonth, m);
+						onChange(
+							monthStartEnd(year, clampedFrom).start,
+							monthStartEnd(year, m).end,
+						);
+					}}
+				/>
+			</div>
+		);
+	}
+
+	// semana / dia — single year + month
+	const year = parseYear(fechaInicio);
+	const month = parseMonth(fechaInicio);
+	return (
+		<div className="flex items-center gap-1.5">
+			<CalendarIcon className="h-4 w-4 text-muted-foreground shrink-0" />
+			<YearSelect
+				value={year}
+				onChange={(y) => {
+					const r = monthStartEnd(y, month);
+					onChange(r.start, r.end);
+				}}
+			/>
+			<MonthSelect
+				value={month}
+				onChange={(m) => {
+					const r = monthStartEnd(year, m);
+					onChange(r.start, r.end);
+				}}
+			/>
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -57,7 +57,6 @@ export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
 			concepto: "Membresías",
 			valor: sumBy(rows, (r) => num(r.total_membresias)),
 		},
-		{ concepto: "Royalti", valor: sumBy(rows, (r) => num(r.total_royalti)) },
 		{
 			// mora_promedio ya es un promedio por bucket; promediamos entre
 			// buckets para no inflar el valor con la cantidad de períodos.

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -29,7 +29,6 @@ const montoRow = (over: Partial<MontoACobrarRow> = {}): MontoACobrarRow => ({
 	total_seguro: "50",
 	total_gps: "30",
 	total_membresias: "40",
-	total_royalti: "10",
 	mora_promedio: "100",
 	...over,
 });

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -81,8 +81,26 @@ export type MontoACobrarRow = {
 	total_seguro: string;
 	total_gps: string;
 	total_membresias: string;
-	total_royalti: string;
 	mora_promedio: string;
+};
+
+export type MontoACobrarPeriodoRow = {
+	bucket: string;
+	cuotas_count: number;
+	total_cuota: string;
+	total_interes: string;
+	total_iva: string;
+	total_seguro: string;
+	total_gps: string;
+	total_membresias: string;
+	mora_promedio: string;
+	mora_count: number;
+	acum_total_cuota: string;
+	acum_total_interes: string;
+	acum_total_iva: string;
+	acum_total_seguro: string;
+	acum_total_gps: string;
+	acum_total_membresias: string;
 };
 
 export type FacturacionMesRubro = {
@@ -202,7 +220,6 @@ export function transformMontoACobrar(
 		total_seguro: money(num(r.total_seguro) * col),
 		total_gps: money(num(r.total_gps) * col),
 		total_membresias: money(num(r.total_membresias) * col),
-		total_royalti: money(num(r.total_royalti) * col),
 		mora_promedio: money(num(r.mora_promedio) * mora),
 	}));
 }

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1399,7 +1399,15 @@ function RouteComponent() {
 																			{formatCurrency(membresias)}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.mora_promedio)}
+																			<div>{formatCurrency(row.mora_promedio)}</div>
+																			<div
+																				className="text-xs text-muted-foreground cursor-help"
+																				title="% de cuotas del período con mora activa"
+																			>
+																				{row.cuotas_count > 0
+																					? ((row.mora_count / row.cuotas_count) * 100).toFixed(1)
+																					: "0.0"}%
+																			</div>
 																		</TableCell>
 																		<TableCell className="text-right font-bold">
 																			{formatCurrency(total)}
@@ -1457,7 +1465,13 @@ function RouteComponent() {
 																		{formatCurrency(sum(a ? "acum_total_membresias" : "total_membresias"))}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		—
+																		{(() => {
+																			const totalCred = rows.reduce((a, r) => a + r.cuotas_count, 0);
+																			const totalMora = rows.reduce((a, r) => a + r.mora_count, 0);
+																			return totalCred > 0
+																				? `${((totalMora / totalCred) * 100).toFixed(1)}%`
+																				: "—";
+																		})()} 
 																	</TableCell>
 																	<TableCell className="text-right">
 																		{formatCurrency(grandTotal)}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1416,8 +1416,8 @@ function RouteComponent() {
 																);
 															},
 														)}
-														{/* Fila de totales */}
-														{(() => {
+														{/* Fila de totales: oculta en modo acumulado (sumar snapshots = doble conteo) */}
+														{!montoCobrarAcumulado && (() => {
 															const rows =
 																montoCobrarData.data as MontoACobrarPeriodoRow[];
 															const a = montoCobrarAcumulado;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1193,16 +1193,16 @@ function RouteComponent() {
 											<SimularButton onClick={() => setScenarioOpen("monto")} />
 											<Select
 												value={montoCobrarPeriodo}
-												onValueChange={(v) =>
-													setMontoCobrarPeriodo(
-														v as
-															| "anio"
-															| "trimestre"
-															| "mes"
-															| "semana"
-															| "dia",
-													)
-												}
+												onValueChange={(v) => {
+													const p = v as
+														| "anio"
+														| "trimestre"
+														| "mes"
+														| "semana"
+														| "dia";
+													setMontoCobrarPeriodo(p);
+													setMontoCobrarRange(getDefaultRangeForPeriodo(p));
+												}}
 											>
 												<SelectTrigger className="w-[140px]">
 													<SelectValue placeholder="Período" />
@@ -1215,26 +1215,13 @@ function RouteComponent() {
 													<SelectItem value="anio">Año</SelectItem>
 												</SelectContent>
 											</Select>
-											<DateRangeFilter
-												dateRange={
-													montoCobrarRange.fechaInicio &&
-													montoCobrarRange.fechaFin
-														? {
-																from: dateFromInput(
-																	montoCobrarRange.fechaInicio,
-																),
-																to: dateFromInput(montoCobrarRange.fechaFin),
-															}
-														: undefined
+											<PeriodDatePicker
+												periodo={montoCobrarPeriodo}
+												fechaInicio={montoCobrarRange.fechaInicio}
+												fechaFin={montoCobrarRange.fechaFin}
+												onChange={(fechaInicio, fechaFin) =>
+													setMontoCobrarRange({ fechaInicio, fechaFin })
 												}
-												onDateRangeChange={(range) => {
-													if (range?.from && range?.to) {
-														setMontoCobrarRange({
-															fechaInicio: formatDateInput(range.from),
-															fechaFin: formatDateInput(range.to),
-														});
-													}
-												}}
 											/>
 										</div>
 									</div>
@@ -1256,8 +1243,13 @@ function RouteComponent() {
 											{/* Gráfica de barras apiladas */}
 											<ResponsiveContainer width="100%" height={350}>
 												<BarChart
-													data={montoCobrarData.data.map(
-														(row: MontoACobrarRow) => ({
+													data={fillMissingPeriods(
+														montoCobrarData.data,
+														montoCobrarPeriodo,
+														montoCobrarRange.fechaInicio,
+														montoCobrarRange.fechaFin,
+													).map(
+														(row: MontoACobrarPeriodoRow) => ({
 															bucket: formatBucket(
 																row.bucket,
 																montoCobrarPeriodo,
@@ -1271,9 +1263,6 @@ function RouteComponent() {
 															total_gps: Number.parseFloat(row.total_gps),
 															total_membresias: Number.parseFloat(
 																row.total_membresias,
-															),
-															total_royalti: Number.parseFloat(
-																row.total_royalti,
 															),
 														}),
 													)}
@@ -1344,9 +1333,6 @@ function RouteComponent() {
 																Membresías
 															</TableHead>
 															<TableHead className="text-right">
-																Royalti
-															</TableHead>
-															<TableHead className="text-right">
 																Mora Prom.
 															</TableHead>
 															<TableHead className="text-right font-bold">
@@ -1356,15 +1342,14 @@ function RouteComponent() {
 													</TableHeader>
 													<TableBody>
 														{montoCobrarData.data.map(
-															(row: MontoACobrarRow) => {
+															(row: MontoACobrarPeriodoRow) => {
 																const total =
 																	Number.parseFloat(row.total_cuota) +
 																	Number.parseFloat(row.total_interes) +
 																	Number.parseFloat(row.total_iva) +
 																	Number.parseFloat(row.total_seguro) +
 																	Number.parseFloat(row.total_gps) +
-																	Number.parseFloat(row.total_membresias) +
-																	Number.parseFloat(row.total_royalti);
+																	Number.parseFloat(row.total_membresias);
 																return (
 																	<TableRow key={row.bucket}>
 																		<TableCell>
@@ -1395,9 +1380,6 @@ function RouteComponent() {
 																			{formatCurrency(row.total_membresias)}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.total_royalti)}
-																		</TableCell>
-																		<TableCell className="text-right">
 																			{formatCurrency(row.mora_promedio)}
 																		</TableCell>
 																		<TableCell className="text-right font-bold">
@@ -1410,10 +1392,10 @@ function RouteComponent() {
 														{/* Fila de totales */}
 														{(() => {
 															const rows =
-																montoCobrarData.data as MontoACobrarRow[];
-															const sum = (key: keyof MontoACobrarRow) =>
+																montoCobrarData.data as MontoACobrarPeriodoRow[];
+															const sum = (key: keyof MontoACobrarPeriodoRow) =>
 																rows.reduce(
-																	(acc: number, r: MontoACobrarRow) =>
+																	(acc: number, r: MontoACobrarPeriodoRow) =>
 																		acc +
 																		Number.parseFloat(
 																			(r[key] as string) || "0",
@@ -1426,8 +1408,7 @@ function RouteComponent() {
 																sum("total_iva") +
 																sum("total_seguro") +
 																sum("total_gps") +
-																sum("total_membresias") +
-																sum("total_royalti");
+																sum("total_membresias");
 															return (
 																<TableRow className="border-t-2 bg-muted/50 font-bold">
 																	<TableCell>Total</TableCell>
@@ -1454,9 +1435,6 @@ function RouteComponent() {
 																	</TableCell>
 																	<TableCell className="text-right">
 																		{formatCurrency(sum("total_membresias"))}
-																	</TableCell>
-																	<TableCell className="text-right">
-																		{formatCurrency(sum("total_royalti"))}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		—

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1416,8 +1416,7 @@ function RouteComponent() {
 																);
 															},
 														)}
-														{/* Fila de totales: oculta en modo acumulado (sumar snapshots = doble conteo) */}
-														{!montoCobrarAcumulado && (() => {
+														{(() => {
 															const rows =
 																montoCobrarData.data as MontoACobrarPeriodoRow[];
 															const a = montoCobrarAcumulado;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -36,6 +36,7 @@ import {
 import { toast } from "sonner";
 import * as XLSX from "xlsx";
 import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import { PeriodDatePicker } from "@/components/reports/period-date-picker";
 import { ReportCard } from "@/components/reports/report-card";
 import { ScenarioModal } from "@/components/reports/scenario-modal";
 import { Button } from "@/components/ui/button";
@@ -76,6 +77,8 @@ import type {
 	FacturacionMesResponse,
 	FacturacionMesRubro,
 	FlujoCuotasInversionesResponse,
+	FlujoCuotasRubro,
+	MontoACobrarPeriodoRow,
 	MontoACobrarRow,
 	PuntoEquilibrioRow,
 	ReinversionLiquidacionesResponse,
@@ -205,7 +208,6 @@ const MONTO_COBRAR_COLORS = {
 	total_seguro: "#f97316",
 	total_gps: "#8b5cf6",
 	total_membresias: "#ec4899",
-	total_royalti: "#14b8a6",
 } as const;
 
 const MONTO_COBRAR_LABELS: Record<keyof typeof MONTO_COBRAR_COLORS, string> = {
@@ -215,7 +217,6 @@ const MONTO_COBRAR_LABELS: Record<keyof typeof MONTO_COBRAR_COLORS, string> = {
 	total_seguro: "Seguro",
 	total_gps: "GPS",
 	total_membresias: "Membresías",
-	total_royalti: "Royalti",
 };
 
 const GUATEMALA_TIME_ZONE = "America/Guatemala";
@@ -243,6 +244,32 @@ function getDefaultMontoCobrarRange(): {
 	return { fechaInicio: today, fechaFin: formatDateInput(fin) };
 }
 
+function getDefaultRangeForPeriodo(
+	periodo: "anio" | "trimestre" | "mes" | "semana" | "dia",
+): { fechaInicio: string; fechaFin: string } {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = now.getMonth() + 1;
+	const pad = (n: number) => String(n).padStart(2, "0");
+	const lastDay = (y: number, m: number) => new Date(y, m, 0).getDate();
+	if (periodo === "anio") {
+		return { fechaInicio: `${year}-01-01`, fechaFin: `${year}-12-31` };
+	}
+	if (periodo === "trimestre") {
+		const q = Math.ceil(month / 3);
+		const startMonth = (q - 1) * 3 + 1;
+		const endMonth = startMonth + 2;
+		return {
+			fechaInicio: `${year}-${pad(startMonth)}-01`,
+			fechaFin: `${year}-${pad(endMonth)}-${pad(lastDay(year, endMonth))}`,
+		};
+	}
+	return {
+		fechaInicio: `${year}-${pad(month)}-01`,
+		fechaFin: `${year}-${pad(month)}-${pad(lastDay(year, month))}`,
+	};
+}
+
 function formatBucket(bucket: string, periodo: string): string {
 	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
 	if (periodo === "dia") {
@@ -265,6 +292,67 @@ function formatBucket(bucket: string, periodo: string): string {
 		month: "short",
 		year: "numeric",
 	}).format(date);
+}
+
+function fillMissingPeriods(
+	data: MontoACobrarPeriodoRow[],
+	periodo: "anio" | "trimestre" | "mes" | "semana" | "dia",
+	fechaInicio: string,
+	fechaFin: string,
+): MontoACobrarPeriodoRow[] {
+	if (periodo !== "semana" && periodo !== "dia") return data;
+
+	const toKey = (d: Date) =>
+		`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+	const dataMap = new Map(
+		data.map((row) => [row.bucket.slice(0, 10), row]),
+	);
+
+	const dates: Date[] = [];
+	const start = new Date(`${fechaInicio}T12:00:00`);
+	const end = new Date(`${fechaFin}T12:00:00`);
+
+	if (periodo === "dia") {
+		const cur = new Date(start);
+		while (cur <= end) {
+			dates.push(new Date(cur));
+			cur.setDate(cur.getDate() + 1);
+		}
+	} else {
+		// ISO week: Monday start (matches PostgreSQL DATE_TRUNC('week'))
+		const cur = new Date(start);
+		const dow = cur.getDay();
+		cur.setDate(cur.getDate() + (dow === 0 ? -6 : 1 - dow));
+		while (cur <= end) {
+			dates.push(new Date(cur));
+			cur.setDate(cur.getDate() + 7);
+		}
+	}
+
+	return dates.map((d) => {
+		const key = toKey(d);
+		return (
+			dataMap.get(key) ?? {
+				bucket: key,
+				cuotas_count: 0,
+				total_cuota: "0",
+				total_interes: "0",
+				total_iva: "0",
+				total_seguro: "0",
+				total_gps: "0",
+				total_membresias: "0",
+				mora_promedio: "0",
+				mora_count: 0,
+				acum_total_cuota: "0",
+				acum_total_interes: "0",
+				acum_total_iva: "0",
+				acum_total_seguro: "0",
+				acum_total_gps: "0",
+				acum_total_membresias: "0",
+			}
+		);
+	});
 }
 
 function getDefaultClosedCreditsRange(): DateRange {
@@ -342,9 +430,10 @@ function RouteComponent() {
 	const [montoCobrarPeriodo, setMontoCobrarPeriodo] = useState<
 		"anio" | "trimestre" | "mes" | "semana" | "dia"
 	>("mes");
-	const [montoCobrarRange, setMontoCobrarRange] = useState(
-		getDefaultMontoCobrarRange,
+	const [montoCobrarRange, setMontoCobrarRange] = useState(() =>
+		getDefaultRangeForPeriodo("mes"),
 	);
+	const [montoCobrarAcumulado, setMontoCobrarAcumulado] = useState(false);
 	const [facturacionMes, setFacturacionMes] = useState(() => ({
 		mes: new Date().getMonth() + 1,
 		anio: new Date().getFullYear(),
@@ -426,7 +515,7 @@ function RouteComponent() {
 	});
 
 	const montoCobrarQuery = useQuery({
-		...orpc.getMontoACobrar.queryOptions({
+		...orpc.getMontoACobrarPeriodo.queryOptions({
 			input: {
 				periodo: montoCobrarPeriodo,
 				fechaInicio: montoCobrarRange.fechaInicio,
@@ -436,7 +525,7 @@ function RouteComponent() {
 		enabled: isAdmin,
 	});
 	const montoCobrarData = montoCobrarQuery.data as
-		| { data: MontoACobrarRow[] }
+		| { data: MontoACobrarPeriodoRow[] }
 		| undefined;
 
 	const facturacionMesQuery = useQuery({

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1223,6 +1223,20 @@ function RouteComponent() {
 													setMontoCobrarRange({ fechaInicio, fechaFin })
 												}
 											/>
+											<Select
+												value={montoCobrarAcumulado ? "acumulado" : "periodo"}
+												onValueChange={(v) =>
+													setMontoCobrarAcumulado(v === "acumulado")
+												}
+											>
+												<SelectTrigger className="w-[150px]">
+													<SelectValue />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="periodo">Por período</SelectItem>
+													<SelectItem value="acumulado">Acumulado</SelectItem>
+												</SelectContent>
+											</Select>
 										</div>
 									</div>
 								</CardHeader>
@@ -1249,22 +1263,18 @@ function RouteComponent() {
 														montoCobrarRange.fechaInicio,
 														montoCobrarRange.fechaFin,
 													).map(
-														(row: MontoACobrarPeriodoRow) => ({
-															bucket: formatBucket(
-																row.bucket,
-																montoCobrarPeriodo,
-															),
-															total_cuota: Number.parseFloat(row.total_cuota),
-															total_interes: Number.parseFloat(
-																row.total_interes,
-															),
-															total_iva: Number.parseFloat(row.total_iva),
-															total_seguro: Number.parseFloat(row.total_seguro),
-															total_gps: Number.parseFloat(row.total_gps),
-															total_membresias: Number.parseFloat(
-																row.total_membresias,
-															),
-														}),
+														(row: MontoACobrarPeriodoRow) => {
+															const a = montoCobrarAcumulado;
+															return {
+																bucket: formatBucket(row.bucket, montoCobrarPeriodo),
+																total_cuota: Number.parseFloat(a ? row.acum_total_cuota : row.total_cuota),
+																total_interes: Number.parseFloat(a ? row.acum_total_interes : row.total_interes),
+																total_iva: Number.parseFloat(a ? row.acum_total_iva : row.total_iva),
+																total_seguro: Number.parseFloat(a ? row.acum_total_seguro : row.total_seguro),
+																total_gps: Number.parseFloat(a ? row.acum_total_gps : row.total_gps),
+																total_membresias: Number.parseFloat(a ? row.acum_total_membresias : row.total_membresias),
+															};
+														},
 													)}
 												>
 													<CartesianGrid strokeDasharray="3 3" />
@@ -1341,43 +1351,52 @@ function RouteComponent() {
 														</TableRow>
 													</TableHeader>
 													<TableBody>
-														{montoCobrarData.data.map(
+														{fillMissingPeriods(
+															montoCobrarData.data,
+															montoCobrarPeriodo,
+															montoCobrarRange.fechaInicio,
+															montoCobrarRange.fechaFin,
+														).map(
 															(row: MontoACobrarPeriodoRow) => {
+																const a = montoCobrarAcumulado;
+																const cuota = a ? row.acum_total_cuota : row.total_cuota;
+																const interes = a ? row.acum_total_interes : row.total_interes;
+																const iva = a ? row.acum_total_iva : row.total_iva;
+																const seguro = a ? row.acum_total_seguro : row.total_seguro;
+																const gps = a ? row.acum_total_gps : row.total_gps;
+																const membresias = a ? row.acum_total_membresias : row.total_membresias;
 																const total =
-																	Number.parseFloat(row.total_cuota) +
-																	Number.parseFloat(row.total_interes) +
-																	Number.parseFloat(row.total_iva) +
-																	Number.parseFloat(row.total_seguro) +
-																	Number.parseFloat(row.total_gps) +
-																	Number.parseFloat(row.total_membresias);
+																	Number.parseFloat(cuota) +
+																	Number.parseFloat(interes) +
+																	Number.parseFloat(iva) +
+																	Number.parseFloat(seguro) +
+																	Number.parseFloat(gps) +
+																	Number.parseFloat(membresias);
 																return (
 																	<TableRow key={row.bucket}>
 																		<TableCell>
-																			{formatBucket(
-																				row.bucket,
-																				montoCobrarPeriodo,
-																			)}
+																			{formatBucket(row.bucket, montoCobrarPeriodo)}
 																		</TableCell>
 																		<TableCell className="text-right">
 																			{row.cuotas_count}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.total_cuota)}
+																			{formatCurrency(cuota)}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.total_interes)}
+																			{formatCurrency(interes)}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.total_iva)}
+																			{formatCurrency(iva)}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.total_seguro)}
+																			{formatCurrency(seguro)}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.total_gps)}
+																			{formatCurrency(gps)}
 																		</TableCell>
 																		<TableCell className="text-right">
-																			{formatCurrency(row.total_membresias)}
+																			{formatCurrency(membresias)}
 																		</TableCell>
 																		<TableCell className="text-right">
 																			{formatCurrency(row.mora_promedio)}
@@ -1393,6 +1412,7 @@ function RouteComponent() {
 														{(() => {
 															const rows =
 																montoCobrarData.data as MontoACobrarPeriodoRow[];
+															const a = montoCobrarAcumulado;
 															const sum = (key: keyof MontoACobrarPeriodoRow) =>
 																rows.reduce(
 																	(acc: number, r: MontoACobrarPeriodoRow) =>
@@ -1403,12 +1423,12 @@ function RouteComponent() {
 																	0,
 																);
 															const grandTotal =
-																sum("total_cuota") +
-																sum("total_interes") +
-																sum("total_iva") +
-																sum("total_seguro") +
-																sum("total_gps") +
-																sum("total_membresias");
+																sum(a ? "acum_total_cuota" : "total_cuota") +
+																sum(a ? "acum_total_interes" : "total_interes") +
+																sum(a ? "acum_total_iva" : "total_iva") +
+																sum(a ? "acum_total_seguro" : "total_seguro") +
+																sum(a ? "acum_total_gps" : "total_gps") +
+																sum(a ? "acum_total_membresias" : "total_membresias");
 															return (
 																<TableRow className="border-t-2 bg-muted/50 font-bold">
 																	<TableCell>Total</TableCell>
@@ -1419,22 +1439,22 @@ function RouteComponent() {
 																		)}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(sum("total_cuota"))}
+																		{formatCurrency(sum(a ? "acum_total_cuota" : "total_cuota"))}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(sum("total_interes"))}
+																		{formatCurrency(sum(a ? "acum_total_interes" : "total_interes"))}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(sum("total_iva"))}
+																		{formatCurrency(sum(a ? "acum_total_iva" : "total_iva"))}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(sum("total_seguro"))}
+																		{formatCurrency(sum(a ? "acum_total_seguro" : "total_seguro"))}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(sum("total_gps"))}
+																		{formatCurrency(sum(a ? "acum_total_gps" : "total_gps"))}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(sum("total_membresias"))}
+																		{formatCurrency(sum(a ? "acum_total_membresias" : "total_membresias"))}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		—


### PR DESCRIPTION
## Resumen

Este PR refina la función `getMontoACobrarPeriodo` en cartera-back para corregir diferencias de capital con Cartera Web, y ajusta el frontend CRM para mostrar totales en ambos modos (Por período y Acumulado).

---

## 1. `pagos_en_rango` branch 1 — Incluir pagos anulados correctamente

**Antes:** `WHERE pc."paymentFalse" = false` excluía filas con pagos anulados del JOIN, dejando fuera créditos que solo tenían un pago anulado registrado.

**Problema concreto:** Crédito 8860 (ACTIVO) con cuota de junio 2026 cuyo único `pagos_credito` tiene `paymentFalse=true` y `capital_restante=0`. Al filtrar en WHERE, la fila desaparecía del CTE y el crédito nunca llegaba al cálculo → diferencia de ~Q134 vs Cartera Web.

**Fix:** Se eliminó el WHERE y se movió la condición a `FILTER (WHERE NOT pc."paymentFalse")` dentro de cada agregación:

```sql
COALESCE(MIN(pc.capital_restante::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0)
  + COALESCE(SUM(pc.abono_capital::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0)
  AS capital_restante,
```

`monto_boleta` sigue sumando **todas** las filas (incluyendo anuladas) porque es el campo usado en la cláusula `HAVING` para determinar si la cuota tiene movimiento registrado — si se filtrara también, un crédito con solo pago anulado tampoco pasaría el HAVING.

---

## 2. `cap_anterior` — Cutoff en inicio del bucket

**Antes:** el ordenamiento del LATERAL `cap_anterior` usaba `< p.fecha_venc::date` como límite.

**Fix:** Cambiado a `< DATE_TRUNC(${pg}, p.fecha_venc::timestamp)::date` (inicio del bucket del período). Esto es semánticamente correcto: el capital anterior a un bucket mensual es el que cerró **antes del primer día del mes**, no antes del día exacto de vencimiento de la cuota dentro del mes.

---

## 3. `mora_real` LATERAL — Enfoque histórico con NOT EXISTS acotado

**Antes:** `AND qc_mora.pagado = false` determinaba mora por el campo booleano de la tabla, que puede cambiar si se paga después. Además no tenía límite de fecha para los pagos.

**Fix:**
- Removido `AND qc_mora.pagado = false`
- Agregado al NOT EXISTS: `AND COALESCE(pc_mora.fecha_boleta::date, pc_mora.fecha_pago::date) <= p.fecha_venc::date`

```sql
AND NOT EXISTS (
  SELECT 1 FROM cartera.pagos_credito pc_mora
  WHERE pc_mora.cuota_id = qc_mora.cuota_id
    AND pc_mora."paymentFalse" = false
    AND pc_mora.pagado = true
    AND pc_mora.validation_status IN ('validated', 'no_required')
    AND COALESCE(pc_mora.fecha_boleta::date, pc_mora.fecha_pago::date) <= p.fecha_venc::date
)
```

**Diferencia conceptual CRM vs Cartera Web:**

| | CRM (este código) | Cartera Web |
|---|---|---|
| Corte de tiempo | `<= p.fecha_venc::date` (fecha del bucket) | `<= NOW()` (ahora mismo) |
| ¿Qué mide? | Mora **como estaba** en ese período histórico | Mora **como está** actualmente |
| Mejor para | Análisis de tendencias, comparación entre períodos pasados | Vista operacional en tiempo real |

Ambos enfoques son correctos; sirven propósitos distintos. CRM usa el histórico porque permite ver cómo estaba la cartera **en ese momento**, independientemente de si después se pagó.

---

## 4. `acum` LATERAL — Mismo enfoque histórico

Idéntico razonamiento al punto anterior. Se removió `AND q_a.pagado = false` y se agregó el acote de fecha al NOT EXISTS:

```sql
AND COALESCE(pc2.fecha_boleta::date, pc2.fecha_pago::date) <= calc.bucket
```

Esto hace que el acumulado de mora de un bucket X refleje las cuotas que estaban vencidas y sin pago válido **a fecha X**, no las que siguen sin pagar hoy.

---

## 5. `mora_count` — Contar cuotas en mora, no créditos

**Antes:** `COUNT(*) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora)` contaba **cuantos créditos** tenían mora — si un crédito tenía 3 cuotas atrasadas, contaba como 1.

**Fix:** `COALESCE(SUM(cuotas_count) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora), 0)::int`

Ahora suma el campo `cuotas_count` (ya calculado como conteo de cuotas atrasadas por crédito), dando el total de **cuotas** en mora, que es el número más relevante operacionalmente.

---

## 6. Frontend — Totales visibles en modo Acumulado

**Antes:** La fila de totales al pie de la tabla tenía `{!montoCobrarAcumulado && (() => { ... })}`, ocultándola cuando el toggle estaba en "Acumulado".

**Fix:** Removida la condición. Los totales se muestran siempre en ambos modos. En modo Acumulado, el total de la última fila ya representa el snapshot acumulado más reciente del período consultado.

---

## Archivos modificados

| Archivo | Cambios |
|---|---|
| `apps/cartera-back/src/controllers/reportes.ts` | pagos_en_rango FILTER, cap_anterior cutoff, mora_real histórico, acum histórico, mora_count cuotas |
| `apps/crm/apps/web/src/routes/admin/reports/index.tsx` | Totals footer siempre visible |


<img width="1220" height="741" alt="image" src="https://github.com/user-attachments/assets/776a517e-9362-41cd-b8a5-d088e33449e7" />



## Plan de prueba

- [ ] Consultar período junio 2026 — capital debe coincidir con Cartera Web (diferencia de Q134 resuelta)
- [ ] Verificar que crédito 8860 (ACTIVO, pago anulado) aparece en el resultado
- [ ] Toggle Acumulado muestra fila de totales
- [ ] Consultar período histórico (ej. enero 2026) — mora refleja estado de ese mes, no el actual
- [ ] `mora_count` muestra suma de cuotas en mora (no conteo de créditos)