### PR TITLE
fix(cartera): Fact. Inversionistas solo de los que CUBE factura (excluye autofactura)

### DIFF
--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -1936,6 +1936,22 @@ if (facturasExistentes.length > 0) {
           WHERE pci.pago_id = ${pago_id}
             AND UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
             AND i.emite_factura = false
+            -- ⚠️ Excluir inversionistas REDIRIGIDOS A CUBE: si el crédito tiene
+            --    bandera_reinversion=true y el espejo del inversionista está
+            --    pendiente (pendiente_reinversion / pendiente_compra_cartera), el
+            --    loop de interés (PASO 1) redirige su interés a CUBE → ya está en
+            --    interesCubeConIva (rubro INTERES). Contarlo también acá lo
+            --    duplicaría en el snapshot. Misma condición que el redirigirACube.
+            --    NOT EXISTS (no JOIN) para no multiplicar filas ni romper con NULL.
+            AND NOT (
+              ${pagoData.bandera_reinversion === true}
+              AND EXISTS (
+                SELECT 1 FROM cartera.creditos_inversionistas_espejo esp
+                WHERE esp.credito_id = ${pagoData.credito_id}
+                  AND esp.inversionista_id = pci.inversionista_id
+                  AND esp.status IN ('pendiente_reinversion', 'pendiente_compra_cartera')
+              )
+            )
         `);
         const invFacturadoTotal = new Big(
           (invFacturadoRes as any).rows?.[0]?.total || 0

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -1922,15 +1922,27 @@ if (facturasExistentes.length > 0) {
         `);
         const capitalCube = (capCubeRes as any).rows?.[0]?.capital_cube ?? 0;
 
-        // 🆕 Interés que se factura a inversionistas (no-CUBE) = interés total
-        //    del pago − lo que factura CUBE, CON IVA. Un solo registro agregado
-        //    por pago (sin importar cuántos inversionistas se lo repartan).
-        //    factura_id NULL: no es factura de CUBE, es el residuo de los inv.
-        const interesTotalConIvaPago = new Big(pagoData.abono_interes || 0).plus(
-          new Big(pagoData.abono_iva_12 || 0)
+        // 🆕 Interés que CUBE/el sistema factura a inversionistas = SOLO los
+        //    no-CUBE que NO emiten su propia factura (emite_factura=false). Los
+        //    que se autofacturan NO van acá (ese pedazo lo factura el inversionista,
+        //    no CUBE) → si no, el reporte sobre-cuenta. Se toma de pci (interés +
+        //    IVA por inversionista), mismo criterio que el backfill histórico.
+        //    factura_id NULL: es el residuo de los inversionistas, no factura CUBE.
+        const invFacturadoRes = await db.execute(sql`
+          SELECT COALESCE(SUM(pci.abono_interes + pci.abono_iva_12), 0) AS total,
+                 COALESCE(SUM(pci.abono_iva_12), 0) AS iva
+          FROM cartera.pagos_credito_inversionistas pci
+          JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+          WHERE pci.pago_id = ${pago_id}
+            AND UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
+            AND i.emite_factura = false
+        `);
+        const invFacturadoTotal = new Big(
+          (invFacturadoRes as any).rows?.[0]?.total || 0
         );
-        const interesInversionistasConIva =
-          interesTotalConIvaPago.minus(interesCubeConIva);
+        const invFacturadoIva = new Big(
+          (invFacturadoRes as any).rows?.[0]?.iva || 0
+        );
 
         pushRubro("CAPITAL", capitalCube, false); // solo capital de CUBE (de pci), sin IVA
         // Solo si el flujo de interés se calculó OK (no abortó). Si abortó,
@@ -1938,7 +1950,15 @@ if (facturasExistentes.length > 0) {
         // INTERES_INVERSIONISTAS → dejamos ambos rubros sin escribir.
         if (interesFlujoOk) {
           pushRubro("INTERES", interesCubeConIva, true); // residuo CUBE, ya con IVA
-          pushRubro("INTERES_INVERSIONISTAS", interesInversionistasConIva, true); // residuo no-CUBE, con IVA
+          // INTERES_INVERSIONISTAS: monto + IVA directo de pci (no recalcular el
+          // IVA) para que coincida con el reparto real. Solo si hay monto.
+          if (invFacturadoTotal.gt(0)) {
+            rubrosDesglose.push({
+              rubro: "INTERES_INVERSIONISTAS",
+              monto_total: invFacturadoTotal.toFixed(2),
+              monto_iva: invFacturadoIva.toFixed(2),
+            });
+          }
         }
         pushRubro("MEMBRESIA", pagoData.membresias_pago, true);
         pushRubro("SEGURO", pagoData.abono_seguro, true);


### PR DESCRIPTION
## Fix: Fact. Inversionistas contaba a los que se autofacturan

### El bug
En `facturar-pago-completo`, el rubro `INTERES_INVERSIONISTAS` del desglose se guardaba como **todo el residuo no-CUBE** (`interés total − lo de CUBE`), incluyendo a inversionistas que **emiten su propia factura**. Como CUBE NO factura ese pedazo, el reporte diario **sobre-contaba** la facturación de inversionistas.

Ejemplo (06-16): sistema **108,503.93** vs Excel **15,167.94** → diferencia de 93,336 = justo lo de los que se autofacturan.

### El fix
`INTERES_INVERSIONISTAS` ahora = interés (con IVA) de inversionistas **no-CUBE con `emite_factura=false`** (lo que CUBE/el sistema sí factura), tomado de `pagos_credito_inversionistas` (monto + IVA reales del reparto). Si un inversionista se autofactura, NO entra.

```sql
SELECT SUM(pci.abono_interes + pci.abono_iva_12), SUM(pci.abono_iva_12)
FROM pagos_credito_inversionistas pci
JOIN inversionistas i ON i.inversionista_id = pci.inversionista_id
WHERE pci.pago_id = :pago AND UPPER(i.nombre) NOT LIKE '%CUBE INVESTMENTS%' AND i.emite_factura = false
```

### Validación
- 06-16 con el fix = **15,167.94** = Excel exacto. 06-15 también cuadra (4,275.76).
- **Histórico ya corregido en PROD** (backfill: recompute de las filas `INTERES_INVERSIONISTAS` existentes con el mismo criterio + recompute de acumulados de junio; todos los días cuadran dif=0). Este PR es el fix **going-forward** para que las facturas nuevas guarden el valor correcto.

### Nota
Se decidió **excluir** también las entidades de la empresa con config propia (SE PRESTA, AMJK, etc.) — emiten su propia factura, así que no cuentan como facturación de CUBE (coincide con el criterio del Excel).
