### PR TITLE
feat(reports): reemplazar Mora Promedio por Total Mora con datos históricos

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -148,7 +148,7 @@ export async function getMontoACobrarPeriodo({
         SELECT COALESCE(mh.monto_nuevo, 0) AS monto_mora
         FROM cartera.moras_historial mh
         WHERE mh.credito_id = c.credito_id
-          AND mh.fecha < DATE_TRUNC(${pg}, p.fecha_venc::timestamp) + ${pgInterval}
+          AND (mh.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala') < DATE_TRUNC(${pg}, p.fecha_venc::timestamp) + ${pgInterval}
         ORDER BY mh.fecha DESC
         LIMIT 1
       ) hist_mora ON true

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -77,6 +77,14 @@ export async function getMontoACobrarPeriodo({
   fechaFin: string;
 }) {
   const pg = sql.raw(toPostgresPeriod[periodo]);
+  const pgIntervalMap: Record<Periodo, string> = {
+    anio: "1 year",
+    trimestre: "3 months",
+    mes: "1 month",
+    semana: "1 week",
+    dia: "1 day",
+  };
+  const pgInterval = sql.raw(`interval '${pgIntervalMap[periodo]}'`);
 
   const result = await db.execute(sql`
     WITH
@@ -130,13 +138,20 @@ export async function getMontoACobrarPeriodo({
         COALESCE(cap_anterior.total_restante, c.capital::numeric)       AS cap_ant,
         MAX(mora_real.cuotas_atrasadas)                                 AS cuotas_atrasadas,
         CASE WHEN MAX(mora_real.cuotas_atrasadas) > 0
-             THEN COALESCE(MAX(m.monto_mora::numeric), 0)
+             THEN COALESCE(MAX(hist_mora.monto_mora), 0)
              ELSE 0 END                                                 AS mora_val
       FROM pagos_en_rango p
       INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
       INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
       INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
-      LEFT JOIN cartera.moras_credito m ON m.credito_id = c.credito_id AND m.activa = true
+      LEFT JOIN LATERAL (
+        SELECT COALESCE(mh.monto_nuevo, 0) AS monto_mora
+        FROM cartera.moras_historial mh
+        WHERE mh.credito_id = c.credito_id
+          AND mh.fecha < DATE_TRUNC(${pg}, p.fecha_venc::timestamp) + ${pgInterval}
+        ORDER BY mh.fecha DESC
+        LIMIT 1
+      ) hist_mora ON true
       LEFT JOIN LATERAL (
         SELECT pc_a.total_restante::numeric AS total_restante
         FROM cartera.pagos_credito pc_a
@@ -291,8 +306,10 @@ export async function getMontoACobrarPeriodo({
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN seguro      ELSE 0 END), 0)               AS total_seguro,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN gps         ELSE 0 END), 0)               AS total_gps,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN mem         ELSE 0 END), 0)               AS total_membresias,
-      AVG(CASE WHEN cuotas_atrasadas > 0 AND NOT excluido_mora THEN mora_val END)                AS mora_promedio,
+      COALESCE(SUM(mora_val) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora), 0)       AS total_mora,
       COALESCE(SUM(cuotas_atrasadas) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora), 0)::int AS mora_count,
+      COUNT(credito_id)::int                                                                    AS total_credits,
+      COUNT(credito_id) FILTER (WHERE cuotas_atrasadas > 0 AND NOT excluido_mora)::int          AS credits_con_mora,
       COALESCE(SUM(CASE
         WHEN excluido_mora     THEN 0
         WHEN cuotas_atrasadas > 0 THEN LEAST(acum_capital, cap_ant)

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -218,8 +218,10 @@ export type MontoACobrarPeriodoRow = {
 	total_seguro: string;
 	total_gps: string;
 	total_membresias: string;
-	mora_promedio: string;
+	total_mora: string;
 	mora_count: number;
+	total_credits: number;
+	credits_con_mora: number;
 	acum_total_cuota: string;
 	acum_total_interes: string;
 	acum_total_iva: string;

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -58,12 +58,8 @@ export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
 			valor: sumBy(rows, (r) => num(r.total_membresias)),
 		},
 		{
-			// mora_promedio ya es un promedio por bucket; promediamos entre
-			// buckets para no inflar el valor con la cantidad de períodos.
-			concepto: "Mora prom.",
-			valor: rows.length
-				? sumBy(rows, (r) => num(r.mora_promedio)) / rows.length
-				: 0,
+			concepto: "Total mora",
+			valor: sumBy(rows, (r) => num(r.total_mora)),
 		},
 	],
 };

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -29,7 +29,7 @@ const montoRow = (over: Partial<MontoACobrarRow> = {}): MontoACobrarRow => ({
 	total_seguro: "50",
 	total_gps: "30",
 	total_membresias: "40",
-	mora_promedio: "100",
+	total_mora: "100",
 	...over,
 });
 
@@ -38,16 +38,16 @@ describe("transformMontoACobrar", () => {
 		const rows = [montoRow()];
 		const out = transformMontoACobrar(rows, params());
 		expect(out[0].total_cuota).toBe("1000.00");
-		expect(out[0].mora_promedio).toBe("100.00");
+		expect(out[0].total_mora).toBe("100.00");
 		expect(out[0].cuotas_count).toBe(10);
 	});
 
-	test("bajar mora 10% reduce mora_promedio 10%", () => {
+	test("bajar mora 10% reduce total_mora 10%", () => {
 		const out = transformMontoACobrar(
 			[montoRow()],
 			params({ moraReduccionPct: 10 }),
 		);
-		expect(out[0].mora_promedio).toBe("90.00");
+		expect(out[0].total_mora).toBe("90.00");
 	});
 
 	test("bajar mora >100% se acota a 0 (sin mora negativa)", () => {
@@ -55,7 +55,7 @@ describe("transformMontoACobrar", () => {
 			[montoRow()],
 			params({ moraReduccionPct: 120 }),
 		);
-		expect(out[0].mora_promedio).toBe("0.00");
+		expect(out[0].total_mora).toBe("0.00");
 	});
 
 	test("colocar +20% escala los rubros", () => {
@@ -193,14 +193,14 @@ describe("transformComparativo", () => {
 });
 
 describe("montoACobrarConfig.summarize", () => {
-	test("mora se promedia entre buckets, no se suma", () => {
+	test("mora total se suma entre buckets", () => {
 		const rows: MontoACobrarRow[] = [
-			montoRow({ mora_promedio: "100" }),
-			montoRow({ mora_promedio: "100" }),
+			montoRow({ total_mora: "100" }),
+			montoRow({ total_mora: "100" }),
 		];
 		const summary = montoACobrarConfig.summarize(rows);
-		const mora = summary.find((s) => s.concepto === "Mora prom.");
-		expect(mora?.valor).toBe(100);
+		const mora = summary.find((s) => s.concepto === "Total mora");
+		expect(mora?.valor).toBe(200);
 	});
 });
 

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -81,7 +81,7 @@ export type MontoACobrarRow = {
 	total_seguro: string;
 	total_gps: string;
 	total_membresias: string;
-	mora_promedio: string;
+	total_mora: string;
 };
 
 export type MontoACobrarPeriodoRow = {
@@ -93,8 +93,10 @@ export type MontoACobrarPeriodoRow = {
 	total_seguro: string;
 	total_gps: string;
 	total_membresias: string;
-	mora_promedio: string;
+	total_mora: string;
 	mora_count: number;
+	total_credits: number;
+	credits_con_mora: number;
 	acum_total_cuota: string;
 	acum_total_interes: string;
 	acum_total_iva: string;
@@ -223,7 +225,7 @@ export function transformMontoACobrar(
 		total_seguro: money(num(r.total_seguro) * col),
 		total_gps: money(num(r.total_gps) * col),
 		total_membresias: money(num(r.total_membresias) * col),
-		mora_promedio: money(num(r.mora_promedio) * mora),
+		total_mora: money(num(r.total_mora) * mora),
 	}));
 }
 

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -337,8 +337,10 @@ function fillMissingPeriods(
 				total_seguro: "0",
 				total_gps: "0",
 				total_membresias: "0",
-				mora_promedio: "0",
+				total_mora: "0",
 				mora_count: 0,
+				total_credits: 0,
+				credits_con_mora: 0,
 				acum_total_cuota: "0",
 				acum_total_interes: "0",
 				acum_total_iva: "0",
@@ -1344,7 +1346,7 @@ function RouteComponent() {
 																Membresías
 															</TableHead>
 															<TableHead className="text-right">
-																Mora Promedio
+																Total Mora
 															</TableHead>
 															<TableHead className="text-right font-bold">
 																Total
@@ -1415,21 +1417,16 @@ function RouteComponent() {
 																	</TableCell>
 																	<TableCell className="text-right">
 																		<div>
-																			{formatCurrency(row.mora_promedio)}
+																			{formatCurrency(row.total_mora)}
 																		</div>
-																		<div
-																			className="cursor-help text-muted-foreground text-xs"
-																			title="% de cuotas del período con mora activa"
-																		>
-																			{row.cuotas_count > 0
-																				? (
-																						(row.mora_count /
-																							row.cuotas_count) *
-																						100
-																					).toFixed(1)
-																				: "0.0"}
-																			%
-																		</div>
+																																																																								<div
+																																					className="text-muted-foreground text-xs"
+																																					title="% de créditos del período con mora activa"
+																																				>
+																																					{row.total_credits > 0
+																																						? ((row.credits_con_mora / row.total_credits) * 100).toFixed(1)
+																																						: "0.0"}%
+																																				</div>
 																	</TableCell>
 																	<TableCell className="text-right font-bold">
 																		{formatCurrency(total)}
@@ -1471,13 +1468,6 @@ function RouteComponent() {
 																	? lastRow.cuotas_count
 																	: rows.reduce(
 																			(acc, r) => acc + r.cuotas_count,
-																			0,
-																		);
-															const totalMora =
-																a && lastRow
-																	? lastRow.mora_count
-																	: rows.reduce(
-																			(acc, r) => acc + r.mora_count,
 																			0,
 																		);
 															return (
@@ -1531,9 +1521,7 @@ function RouteComponent() {
 																		)}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{totalCred > 0
-																			? `${((totalMora / totalCred) * 100).toFixed(1)}%`
-																			: "—"}
+																		{formatCurrency(val("total_mora"))}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		{formatCurrency(grandTotal)}


### PR DESCRIPTION
## Resumen

Este PR reemplaza la columna **Mora Promedio** del reporte *Monto a Cobrarse por Período* con **Total Mora**, mostrando el monto total acumulado de mora para los créditos de cada bucket, con precisión histórica a través de `moras_historial`.

---

## ¿Qué cambió y por qué?

### Problema con la columna anterior
La columna `mora_promedio` mostraba el **promedio** del `monto_mora` de `moras_credito` (la tabla que solo guarda el estado **actual** de la mora). Esto causaba dos problemas:
1. Para períodos históricos (ej. enero 2025 consultado hoy), el valor reflejaba la mora de **hoy**, no la de enero — incorrecto.
2. El promedio no es útil como KPI operativo; el **total** es lo que importa para cobranza.

### Solución: `moras_historial` + SUM
La tabla `cartera.moras_historial` registra cada evento de mora (`CREACION`, `RECALCULO`, `INCREMENTO`, `DECREMENTO`, `CONDONACION`, `DESACTIVACION`) con `monto_nuevo` y `fecha`. Permite reconstruir el saldo de mora de cualquier crédito en cualquier punto del tiempo.

Para cada bucket del reporte, se obtiene el **último evento de `moras_historial` antes del fin del período** por crédito (via lateral subquery), y se suman todos los `monto_nuevo > 0` filtrados por créditos no excluidos (`excluido_mora`).

---

## Cambios por archivo

### `cartera-back/src/controllers/reportes.ts`
- Agrega `pgIntervalMap` para mapear el `periodo` (mes/trimestre/etc.) al intervalo PostgreSQL equivalente (`'1 month'`, `'3 months'`, etc.).
- **Reemplaza** `LEFT JOIN cartera.moras_credito m ON activa = true` con un `LEFT JOIN LATERAL` a `cartera.moras_historial` que toma el último `monto_nuevo` antes del fin del bucket.
- **Cambia** `AVG(...) AS mora_promedio` → `COALESCE(SUM(mora_val) FILTER (...), 0) AS total_mora` en el SELECT final.
- **Agrega** `COUNT(credito_id)::int AS total_credits` y `COUNT(credito_id) FILTER (...) AS credits_con_mora` para el cálculo de porcentaje de créditos morosos.

### `crm/apps/server/src/services/cartera-back-client.ts`
- Tipo `MontoACobrarPeriodoRow`: renombra `mora_promedio: string` → `total_mora: string`, agrega `total_credits: number` y `credits_con_mora: number`.

### `crm/apps/web/src/lib/reports/scenario.ts`
- Tipos `MontoACobrarRow` y `MontoACobrarPeriodoRow`: renombra `mora_promedio` → `total_mora`, agrega `total_credits` y `credits_con_mora` en `PeriodoRow`.
- `transformMontoACobrar()`: aplica `moraFactor` a `total_mora` en lugar de `mora_promedio`.

### `crm/apps/web/src/lib/reports/scenario-configs.ts`
- `montoACobrarConfig.summarize()`: cambia el concepto `"Mora prom."` → `"Total mora"` y reemplaza el promedio por una suma (`sumBy(rows, r => num(r.total_mora))`).

### `crm/apps/web/src/lib/reports/scenario.test.ts`
- Actualiza el helper `montoRow()` y todos los assertions para usar `total_mora` en lugar de `mora_promedio`.
- Actualiza el test de `summarize` para verificar que la mora se **suma** (no promedia): 100 + 100 = 200.

### `crm/apps/web/src/routes/admin/reports/index.tsx`
- Header de columna: `"Mora Promedio"` → `"Total Mora"`.
- Celda de datos: muestra `formatCurrency(row.total_mora)` + subtítulo con porcentaje `credits_con_mora / total_credits * 100` (siempre entre 0–100%, reemplaza el ratio `mora_count/cuotas_count` que podía superar el 100%).
- Footer: muestra `formatCurrency(val("total_mora"))` — suma acumulada o último bucket según toggle acumulado.
- Row fill de períodos vacíos: agrega `total_credits: 0` y `credits_con_mora: 0`.

---

## Limitación conocida

`moras_historial` solo tiene registros desde el **20 de mayo 2026** (fecha en que se empezó a poblar la tabla). Los buckets anteriores a esa fecha mostrarán `Q 0.00` en Total Mora — esto es correcto dado la ausencia de datos históricos, no un bug. A futuro los datos se irán acumulando correctamente.

---

## Plan de pruebas

- [ ] Reporte Ene–Jun 2026: columna "Total Mora" muestra Q values (Q 0 para ene–abr, valores reales para may–jun)
- [ ] Porcentaje de mora bajo la cifra es ≤ 100% en todos los períodos
- [ ] Tooltip del subtítulo dice "% de créditos del período con mora activa"
- [ ] Footer muestra suma currency (no porcentaje)
- [ ] Toggle "Acumulado" → footer muestra valor del último bucket
- [ ] Modal de simulación: slider "Reducción mora" escala `total_mora`
- [ ] `bun check-types` pasa sin errores
- [ ] `bun test` pasa: 17/17 tests en `scenario.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)