### PR TITLE
feat(crm): ajuste automático de membresía

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0024_add_quotation_vehicle_context.sql
+++ b/apps/crm/apps/server/src/db/migrations/0024_add_quotation_vehicle_context.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "quotations"
+ADD COLUMN IF NOT EXISTS "vehicle_condition" text NOT NULL DEFAULT 'used';
+
+ALTER TABLE "quotations"
+ADD COLUMN IF NOT EXISTS "vehicle_origin" text NOT NULL DEFAULT 'agencia';

--- a/apps/crm/apps/server/src/db/schema/quotations.ts
+++ b/apps/crm/apps/server/src/db/schema/quotations.ts
@@ -53,6 +53,8 @@ export const quotations = pgTable("quotations", {
 	vehicleLine: text("vehicle_line"),
 	vehicleModel: text("vehicle_model"),
 	vehicleType: vehicleTypeEnum("vehicle_type").notNull().default("particular"),
+	vehicleCondition: text("vehicle_condition").notNull().default("used"),
+	vehicleOrigin: text("vehicle_origin").notNull().default("agencia"),
 	vehicleValue: decimal("vehicle_value", { precision: 14, scale: 2 }).notNull(),
 	insuredAmount: decimal("insured_amount", {
 		precision: 14,

--- a/apps/crm/apps/server/src/routers/quotations.ts
+++ b/apps/crm/apps/server/src/routers/quotations.ts
@@ -117,6 +117,10 @@ export const quotationsRouter = {
 						"microbus_36plus",
 					])
 					.default("particular"),
+				vehicleCondition: z.enum(["new", "used"]).default("used"),
+				vehicleOrigin: z
+					.enum(["agencia", "rodado", "importado", "subasta", "otro"])
+					.default("agencia"),
 				creditType: z
 					.enum(["autocompra", "sobre_vehiculo"])
 					.default("autocompra"),
@@ -239,6 +243,8 @@ export const quotationsRouter = {
 					vehicleLine: vehicleData.line || null,
 					vehicleModel: vehicleData.model || null,
 					vehicleType: input.vehicleType,
+					vehicleCondition: input.vehicleCondition,
+					vehicleOrigin: input.vehicleOrigin,
 					vehicleValue: input.vehicleValue.toString(),
 					insuredAmount: input.insuredAmount.toString(),
 					downPayment: input.downPayment.toString(),

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -773,6 +773,7 @@ function QuoterPage() {
 		value: string;
 		label: string;
 	} | null>(null);
+	const [vehicleConditionLocked, setVehicleConditionLocked] = useState(false);
 
 	// Estado del formulario
 	const [calculatedValues, setCalculatedValues] = useState({
@@ -976,11 +977,29 @@ function QuoterPage() {
 		return "otro";
 	};
 
+	const applyVehicleConditionAndOrigin = (vehicle?: {
+		isNew?: boolean | null;
+		origin?: string | null;
+	}) => {
+		if (!vehicle) return null;
+
+		const vehicleCondition: QuotationFormValues["vehicleCondition"] = vehicle.isNew
+			? "new"
+			: "used";
+		const vehicleOrigin = normalizeVehicleOrigin(vehicle.origin);
+		quoterForm.setFieldValue("vehicleCondition", vehicleCondition);
+		quoterForm.setFieldValue("vehicleOrigin", vehicleOrigin);
+		setVehicleConditionLocked(true);
+
+		return { condition: vehicleCondition, origin: vehicleOrigin };
+	};
+
 	// Obtener costo de seguro automáticamente
 	const updateInsuranceCost = async (
 		insuredAmount: number,
 		vehicleType: string,
 		vehicleContext?: {
+			creditType?: "autocompra" | "sobre_vehiculo";
 			condition?: "new" | "used";
 			origin?: string | null;
 		},
@@ -1010,7 +1029,8 @@ function QuoterPage() {
 				quoterForm.getFieldValue("vehicleOrigin") ??
 				"agencia";
 			const membershipAdjustment = getMembershipAdjustment({
-				creditType: quoterForm.state.values.creditType,
+				creditType:
+					vehicleContext?.creditType ?? quoterForm.state.values.creditType,
 				insuredAmount,
 				vehicleType,
 				isNew: condition === "new",
@@ -1131,10 +1151,7 @@ function QuoterPage() {
 			(vehicle.vehicleType as typeof quoterForm.state.values.vehicleType) ||
 			"particular";
 		quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
-		const vehicleCondition = vehicle.isNew ? "new" : "used";
-		const vehicleOrigin = normalizeVehicleOrigin(vehicle.origin);
-		quoterForm.setFieldValue("vehicleCondition", vehicleCondition);
-		quoterForm.setFieldValue("vehicleOrigin", vehicleOrigin);
+		const vehicleContext = applyVehicleConditionAndOrigin(vehicle);
 
 		// Obtener la inspección más reciente para el marketValue
 		try {
@@ -1162,7 +1179,7 @@ function QuoterPage() {
 						? quoterForm.state.values.insuredAmount || numericValue
 						: numericValue,
 					vehicleTypeToUse,
-					{ condition: vehicleCondition, origin: vehicleOrigin },
+					vehicleContext ?? undefined,
 				);
 			}
 		} catch (error) {
@@ -1178,10 +1195,7 @@ function QuoterPage() {
 			quoterForm.setFieldValue("vehicleBrand", vehicle.make);
 			quoterForm.setFieldValue("vehicleLine", vehicle.model);
 			quoterForm.setFieldValue("vehicleModel", vehicle.year.toString());
-			const vehicleCondition = vehicle.isNew ? "new" : "used";
-			const vehicleOrigin = normalizeVehicleOrigin(vehicle.origin);
-			quoterForm.setFieldValue("vehicleCondition", vehicleCondition);
-			quoterForm.setFieldValue("vehicleOrigin", vehicleOrigin);
+			const vehicleContext = applyVehicleConditionAndOrigin(vehicle);
 
 			// El marketValue está en la inspección más reciente
 			const latestInspection = vehicle.inspections?.[0];
@@ -1205,14 +1219,21 @@ function QuoterPage() {
 						? quoterForm.state.values.insuredAmount || numericValue
 						: numericValue,
 					quoterForm.state.values.vehicleType,
-					{ condition: vehicleCondition, origin: vehicleOrigin },
+					vehicleContext ?? undefined,
 				);
 			}
 		}
 	};
 
 	// Cargar cotización existente de una oportunidad
-	const loadExistingQuotation = async (opportunityId: string) => {
+	const loadExistingQuotation = async (
+		opportunityId: string,
+		fallbackVehicle?: {
+			id: string;
+			isNew?: boolean | null;
+			origin?: string | null;
+		},
+	) => {
 		try {
 			const quotations = await client.listQuotationsByOpportunity({
 				opportunityId,
@@ -1220,6 +1241,12 @@ function QuoterPage() {
 
 			if (quotations && quotations.length > 0) {
 				const q = quotations[0]; // La más reciente
+				const linkedVehicle = q.vehicleId
+					? (vehiclesQuery.data?.data?.find(
+							(vehicle) => vehicle.id === q.vehicleId,
+						) ??
+						(fallbackVehicle?.id === q.vehicleId ? fallbackVehicle : undefined))
+					: undefined;
 
 				// Cargar todos los campos de la cotización
 				quoterForm.setFieldValue("vehicleId", q.vehicleId || "");
@@ -1230,6 +1257,11 @@ function QuoterPage() {
 					(q.vehicleType as typeof quoterForm.state.values.vehicleType) ||
 					"particular";
 				quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
+				if (linkedVehicle) {
+					applyVehicleConditionAndOrigin(linkedVehicle);
+				} else {
+					setVehicleConditionLocked(false);
+				}
 				quoterForm.setFieldValue("vehicleValue", Number(q.vehicleValue) || 0);
 				quoterForm.setFieldValue("insuredAmount", Number(q.insuredAmount) || 0);
 				quoterForm.setFieldValue("downPayment", Number(q.downPayment) || 0);
@@ -1461,8 +1493,12 @@ function QuoterPage() {
 														);
 													}
 
-													// Intentar cargar cotización existente primero
-													await loadExistingQuotation(value);
+
+											// Intentar cargar cotización existente primero
+											await loadExistingQuotation(
+												value,
+												selectedOpp?.vehicle ?? undefined,
+											);
 
 													// Guardar vehículo de la oportunidad para el combobox
 													if (selectedOpp?.vehicle?.id) {
@@ -1471,10 +1507,11 @@ function QuoterPage() {
 															label: `${selectedOpp.vehicle.make} ${selectedOpp.vehicle.model} ${selectedOpp.vehicle.year} - ${selectedOpp.vehicle.licensePlate || ""}`,
 														});
 													}
-												} else {
-													// Limpiar vehículo de oportunidad cuando se deselecciona
-													setOpportunityVehicle(null);
-												}
+										} else {
+											// Limpiar vehículo de oportunidad cuando se deselecciona
+											setOpportunityVehicle(null);
+											setVehicleConditionLocked(false);
+										}
 											}}
 											onSearchChange={setOpportunitiesSearch}
 											isLoading={opportunitiesQuery.isFetching}
@@ -1525,9 +1562,25 @@ function QuoterPage() {
 															// En sobre vehículo no hay enganche, limpiar
 															quoterForm.setFieldValue("downPayment", 0);
 														}
-														// Recalcular después del cambio de tipo
-														setTimeout(() => recalculate(), 100);
-													}}
+												// Recalcular después del cambio de tipo
+												const insuredAmount =
+													quoterForm.getFieldValue("insuredAmount") ?? 0;
+												if (insuredAmount > 0) {
+													updateInsuranceCost(
+														insuredAmount,
+														quoterForm.state.values.vehicleType,
+														{
+															creditType: value as
+																| "autocompra"
+																| "sobre_vehiculo",
+															condition:
+																quoterForm.getFieldValue("vehicleCondition"),
+															origin: quoterForm.getFieldValue("vehicleOrigin"),
+														},
+													);
+												}
+												setTimeout(() => recalculate(), 100);
+											}}
 													disabled={isDisabled}
 												>
 													<SelectTrigger>
@@ -1754,17 +1807,13 @@ function QuoterPage() {
 									<div className="grid gap-4 sm:grid-cols-2">
 										<quoterForm.Field name="vehicleCondition">
 											{(field) => {
-												const hasSelectedVehicle = Boolean(
-													quoterForm.state.values.vehicleId,
-												);
-
 												return (
 													<div>
 														<Label htmlFor={field.name} className="mb-2">
 															Condición
 														</Label>
 														<Select
-															disabled={hasSelectedVehicle}
+															disabled={vehicleConditionLocked}
 															value={field.state.value}
 															onValueChange={(value) => {
 																const condition = value as "new" | "used";
@@ -1798,17 +1847,13 @@ function QuoterPage() {
 
 										<quoterForm.Field name="vehicleOrigin">
 											{(field) => {
-												const hasSelectedVehicle = Boolean(
-													quoterForm.state.values.vehicleId,
-												);
-
 												return (
 													<div>
 														<Label htmlFor={field.name} className="mb-2">
 															Origen
 														</Label>
 														<Select
-															disabled={hasSelectedVehicle}
+															disabled={vehicleConditionLocked}
 															value={field.state.value}
 															onValueChange={(value) => {
 																const origin =

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -793,13 +793,14 @@ function QuoterPage() {
 		mutationFn: async (values: any) => {
 			return await client.createQuotation(values);
 		},
-		onSuccess: () => {
-			toast.success("Cotización creada exitosamente");
-			queryClient.invalidateQueries(orpc.getQuotations.queryOptions());
-			quoterForm.reset();
-			setIsInterno(false);
-			setOpportunityVehicle(null);
-			setCalculatedValues({
+			onSuccess: () => {
+				toast.success("Cotización creada exitosamente");
+				queryClient.invalidateQueries(orpc.getQuotations.queryOptions());
+				quoterForm.reset();
+				setIsInterno(false);
+				setOpportunityVehicle(null);
+				setVehicleConditionLocked(false);
+				setCalculatedValues({
 				amountToFinance: 0,
 				totalFinanced: 0,
 				monthlyPayment: 0,
@@ -1197,6 +1198,10 @@ function QuoterPage() {
 			quoterForm.setFieldValue("vehicleBrand", vehicle.make);
 			quoterForm.setFieldValue("vehicleLine", vehicle.model);
 			quoterForm.setFieldValue("vehicleModel", vehicle.year.toString());
+			const vehicleTypeToUse =
+				(vehicle.vehicleType as typeof quoterForm.state.values.vehicleType) ||
+				"particular";
+			quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
 			const vehicleContext = applyVehicleConditionAndOrigin(vehicle);
 
 			// El marketValue está en la inspección más reciente
@@ -1220,7 +1225,7 @@ function QuoterPage() {
 					isSobreVehiculo
 						? quoterForm.state.values.insuredAmount || numericValue
 						: numericValue,
-					quoterForm.state.values.vehicleType,
+					vehicleTypeToUse,
 					vehicleContext ?? undefined,
 				);
 			}

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -117,6 +117,8 @@ interface QuotationFormValues {
 		| "microbus_20"
 		| "microbus_35"
 		| "microbus_36plus";
+	vehicleCondition: "new" | "used";
+	vehicleOrigin: "agencia" | "rodado" | "importado" | "subasta" | "otro";
 	vehicleValue: number;
 	insuredAmount: number;
 	downPayment: number;
@@ -126,6 +128,7 @@ interface QuotationFormValues {
 	gpsCost: number;
 	transferCost: number;
 	adminCost: number;
+	baseMembershipCost: number;
 	membershipCost: number;
 	membershipAdjustmentCategory: string;
 	membershipAdjustmentPercentage: number;
@@ -829,6 +832,8 @@ function QuoterPage() {
 			vehicleLine: "",
 			vehicleModel: "",
 			vehicleType: "particular" as const,
+			vehicleCondition: "used" as const,
+			vehicleOrigin: "agencia" as const,
 			vehicleValue: 0,
 			insuredAmount: 0,
 			downPayment: 0,
@@ -838,6 +843,7 @@ function QuoterPage() {
 			gpsCost: GPS_COST,
 			transferCost: 545, // 395 + 150 según Excel
 			adminCost: 0,
+			baseMembershipCost: 0,
 			membershipCost: 0,
 			membershipAdjustmentCategory: "",
 			membershipAdjustmentPercentage: 0,
@@ -957,11 +963,25 @@ function QuoterPage() {
 	// Tipos de bus RCDP (membresía ya incluida en la tarifa)
 	const BUS_TYPES = ["microbus_20", "microbus_35", "microbus_36plus"];
 
+	const normalizeVehicleOrigin = (
+		origin?: string | null,
+	): QuotationFormValues["vehicleOrigin"] => {
+		const normalized = (origin ?? "").trim().toLowerCase();
+		if (normalized.includes("rodado")) return "rodado";
+		if (normalized.includes("import")) return "importado";
+		if (normalized.includes("subasta")) return "subasta";
+		if (normalized.includes("agencia")) return "agencia";
+		return "otro";
+	};
+
 	// Obtener costo de seguro automáticamente
 	const updateInsuranceCost = async (
 		insuredAmount: number,
 		vehicleType: string,
-		vehicleContext?: { isNew?: boolean; origin?: string | null },
+		vehicleContext?: {
+			condition?: "new" | "used";
+			origin?: string | null;
+		},
 	) => {
 		if (insuredAmount <= 0) return;
 
@@ -971,29 +991,29 @@ function QuoterPage() {
 				vehicleType: vehicleType as any,
 			});
 
+			const baseInsuranceCost =
+				Math.round(result.baseInsuranceCost * 100) / 100;
 			const rawMembershipCostBeforeAdjustment =
 				Math.round(result.membershipCost * 100) / 100;
-			const selectedVehicle = vehiclesQuery.data?.data?.find(
-				(vehicle) => vehicle.id === quoterForm.state.values.vehicleId,
+			quoterForm.setFieldValue(
+				"baseMembershipCost",
+				rawMembershipCostBeforeAdjustment,
 			);
-			const normalizedVehicleType = vehicleType.trim().toLowerCase();
-			const inferredNewType = [
-				"nuevo",
-				"camion",
-				"camión",
-				"microbus",
-				"microbus_20",
-				"microbus_35",
-				"microbus_36plus",
-				"panel",
-				"uber",
-			].includes(normalizedVehicleType);
+			const condition =
+				vehicleContext?.condition ??
+				quoterForm.getFieldValue("vehicleCondition") ??
+				"used";
+			const origin =
+				vehicleContext?.origin ??
+				quoterForm.getFieldValue("vehicleOrigin") ??
+				"agencia";
 			const membershipAdjustment = getMembershipAdjustment({
 				creditType: quoterForm.state.values.creditType,
 				insuredAmount,
 				vehicleType,
-				isNew: vehicleContext?.isNew ?? selectedVehicle?.isNew ?? inferredNewType,
-				origin: vehicleContext?.origin ?? selectedVehicle?.origin,
+				isNew: condition === "new",
+				condition,
+				origin,
 			});
 			const rawMembershipCost = applyMembershipAdjustment(
 				rawMembershipCostBeforeAdjustment,
@@ -1011,6 +1031,7 @@ function QuoterPage() {
 			if (isInterno) {
 				// Crédito interno: solo seguro base, sin membresía ni GPS
 				quoterForm.setFieldValue("insuranceCost", baseInsuranceCost);
+				quoterForm.setFieldValue("baseMembershipCost", 0);
 				quoterForm.setFieldValue("membershipCost", 0);
 				quoterForm.setFieldValue("extraInsuranceCost", baseInsuranceCost);
 				quoterForm.setFieldValue("extraMembershipCost", 0);
@@ -1088,6 +1109,8 @@ function QuoterPage() {
 		year: number;
 		licensePlate: string | null;
 		vehicleType?: string | null;
+		isNew?: boolean | null;
+		origin?: string | null;
 	}) => {
 		// Guardar el vehículo para mostrarlo en el combobox
 		setOpportunityVehicle({
@@ -1106,6 +1129,10 @@ function QuoterPage() {
 			(vehicle.vehicleType as typeof quoterForm.state.values.vehicleType) ||
 			"particular";
 		quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
+		const vehicleCondition = vehicle.isNew ? "new" : "used";
+		const vehicleOrigin = normalizeVehicleOrigin(vehicle.origin);
+		quoterForm.setFieldValue("vehicleCondition", vehicleCondition);
+		quoterForm.setFieldValue("vehicleOrigin", vehicleOrigin);
 
 		// Obtener la inspección más reciente para el marketValue
 		try {
@@ -1133,6 +1160,7 @@ function QuoterPage() {
 						? quoterForm.state.values.insuredAmount || numericValue
 						: numericValue,
 					vehicleTypeToUse,
+					{ condition: vehicleCondition, origin: vehicleOrigin },
 				);
 			}
 		} catch (error) {
@@ -1148,6 +1176,10 @@ function QuoterPage() {
 			quoterForm.setFieldValue("vehicleBrand", vehicle.make);
 			quoterForm.setFieldValue("vehicleLine", vehicle.model);
 			quoterForm.setFieldValue("vehicleModel", vehicle.year.toString());
+			const vehicleCondition = vehicle.isNew ? "new" : "used";
+			const vehicleOrigin = normalizeVehicleOrigin(vehicle.origin);
+			quoterForm.setFieldValue("vehicleCondition", vehicleCondition);
+			quoterForm.setFieldValue("vehicleOrigin", vehicleOrigin);
 
 			// El marketValue está en la inspección más reciente
 			const latestInspection = vehicle.inspections?.[0];
@@ -1171,6 +1203,7 @@ function QuoterPage() {
 						? quoterForm.state.values.insuredAmount || numericValue
 						: numericValue,
 					quoterForm.state.values.vehicleType,
+					{ condition: vehicleCondition, origin: vehicleOrigin },
 				);
 			}
 		}
@@ -1716,6 +1749,101 @@ function QuoterPage() {
 										)}
 									</quoterForm.Field>
 
+									<div className="grid gap-4 sm:grid-cols-2">
+										<quoterForm.Field name="vehicleCondition">
+											{(field) => {
+												const hasSelectedVehicle = Boolean(
+													quoterForm.state.values.vehicleId,
+												);
+
+												return (
+													<div>
+														<Label htmlFor={field.name} className="mb-2">
+															Condición
+														</Label>
+														<Select
+															disabled={hasSelectedVehicle}
+															value={field.state.value}
+															onValueChange={(value) => {
+																const condition = value as "new" | "used";
+																field.handleChange(condition);
+																const insuredAmount =
+																	quoterForm.getFieldValue("insuredAmount") ?? 0;
+																if (insuredAmount > 0) {
+																	updateInsuranceCost(
+																		insuredAmount,
+																		quoterForm.state.values.vehicleType,
+																		{
+																			condition,
+																			origin: quoterForm.getFieldValue("vehicleOrigin"),
+																		},
+																	);
+																}
+															}}
+														>
+															<SelectTrigger>
+																<SelectValue placeholder="Seleccionar condición..." />
+															</SelectTrigger>
+															<SelectContent>
+																<SelectItem value="new">Nuevo</SelectItem>
+																<SelectItem value="used">Usado</SelectItem>
+															</SelectContent>
+														</Select>
+													</div>
+												);
+											}}
+										</quoterForm.Field>
+
+										<quoterForm.Field name="vehicleOrigin">
+											{(field) => {
+												const hasSelectedVehicle = Boolean(
+													quoterForm.state.values.vehicleId,
+												);
+
+												return (
+													<div>
+														<Label htmlFor={field.name} className="mb-2">
+															Origen
+														</Label>
+														<Select
+															disabled={hasSelectedVehicle}
+															value={field.state.value}
+															onValueChange={(value) => {
+																const origin =
+																	value as QuotationFormValues["vehicleOrigin"];
+																field.handleChange(origin);
+																const insuredAmount =
+																	quoterForm.getFieldValue("insuredAmount") ?? 0;
+																if (insuredAmount > 0) {
+																	updateInsuranceCost(
+																		insuredAmount,
+																		quoterForm.state.values.vehicleType,
+																		{
+																			condition:
+																				quoterForm.getFieldValue("vehicleCondition"),
+																			origin,
+																		},
+																	);
+																}
+															}}
+														>
+															<SelectTrigger>
+																<SelectValue placeholder="Seleccionar origen..." />
+															</SelectTrigger>
+															<SelectContent>
+																<SelectItem value="agencia">Agencia</SelectItem>
+																<SelectItem value="rodado">Rodado</SelectItem>
+																<SelectItem value="importado">Importado</SelectItem>
+																<SelectItem value="subasta">Subasta</SelectItem>
+																<SelectItem value="otro">Otro</SelectItem>
+															</SelectContent>
+														</Select>
+													</div>
+												);
+											}}
+										</quoterForm.Field>
+									</div>
+
 									<quoterForm.Field name="vehicleValue">
 										{(field) => (
 											<div>
@@ -1938,7 +2066,6 @@ function QuoterPage() {
 											</div>
 										)}
 									</quoterForm.Field>
-									<Badge variant="secondary">Seguro: Universales</Badge>
 									{quoterForm.state.values.membershipAdjustmentCategory ? (
 										<p className="text-muted-foreground text-xs">
 											Membresía: ajuste automático {""}
@@ -1946,6 +2073,10 @@ function QuoterPage() {
 												2,
 											)}
 											% por {quoterForm.state.values.membershipAdjustmentCategory}.
+											 Original: Q
+											{quoterForm.state.values.baseMembershipCost.toFixed(2)} /
+											 Inflada: Q
+											{quoterForm.state.values.extraMembershipCost.toFixed(2)}.
 										</p>
 									) : null}
 

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -887,6 +887,8 @@ function QuoterPage() {
 				vehicleLine: value.vehicleLine,
 				vehicleModel: value.vehicleModel,
 				vehicleType: value.vehicleType,
+				vehicleCondition: value.vehicleCondition,
+				vehicleOrigin: value.vehicleOrigin,
 				vehicleValue: Number(value.vehicleValue),
 				insuredAmount: Number(value.insuredAmount),
 				downPayment: Number(value.downPayment),
@@ -1241,6 +1243,10 @@ function QuoterPage() {
 
 			if (quotations && quotations.length > 0) {
 				const q = quotations[0]; // La más reciente
+				const savedVehicleContext = q as typeof q & {
+					vehicleCondition?: QuotationFormValues["vehicleCondition"] | null;
+					vehicleOrigin?: QuotationFormValues["vehicleOrigin"] | null;
+				};
 				const linkedVehicle = q.vehicleId
 					? (vehiclesQuery.data?.data?.find(
 							(vehicle) => vehicle.id === q.vehicleId,
@@ -1260,6 +1266,14 @@ function QuoterPage() {
 				if (linkedVehicle) {
 					applyVehicleConditionAndOrigin(linkedVehicle);
 				} else {
+					quoterForm.setFieldValue(
+						"vehicleCondition",
+						savedVehicleContext.vehicleCondition ?? "used",
+					);
+					quoterForm.setFieldValue(
+						"vehicleOrigin",
+						savedVehicleContext.vehicleOrigin ?? "agencia",
+					);
 					setVehicleConditionLocked(false);
 				}
 				quoterForm.setFieldValue("vehicleValue", Number(q.vehicleValue) || 0);

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -89,6 +89,10 @@ export const Route = createFileRoute("/crm/quoter")({
 });
 
 import {
+	applyMembershipAdjustment,
+	getMembershipAdjustment,
+} from "@/utils/membership-adjustment";
+import {
 	calculateQuotation,
 	GARANTIA_MOBILIARIA_INTERNO,
 	GPS_COST,
@@ -123,6 +127,8 @@ interface QuotationFormValues {
 	transferCost: number;
 	adminCost: number;
 	membershipCost: number;
+	membershipAdjustmentCategory: string;
+	membershipAdjustmentPercentage: number;
 	freelanceCost: number;
 	freelancePercentage: number;
 	royalty: number;
@@ -833,6 +839,8 @@ function QuoterPage() {
 			transferCost: 545, // 395 + 150 según Excel
 			adminCost: 0,
 			membershipCost: 0,
+			membershipAdjustmentCategory: "",
+			membershipAdjustmentPercentage: 0,
 			// Gastos adicionales para detalle de crédito
 			freelanceCost: 0,
 			freelancePercentage: 0,
@@ -962,9 +970,30 @@ function QuoterPage() {
 				vehicleType: vehicleType as any,
 			});
 
-			const baseInsuranceCost =
-				Math.round(result.baseInsuranceCost * 100) / 100;
-			const rawMembershipCost = Math.round(result.membershipCost * 100) / 100;
+			const rawMembershipCostBeforeAdjustment =
+				Math.round(result.membershipCost * 100) / 100;
+			const selectedVehicle = vehiclesQuery.data?.data?.find(
+				(vehicle) => vehicle.id === quoterForm.state.values.vehicleId,
+			);
+			const membershipAdjustment = getMembershipAdjustment({
+				creditType: quoterForm.state.values.creditType,
+				insuredAmount,
+				vehicleType,
+				isNew: selectedVehicle?.isNew ?? vehicleType === "nuevo",
+				origin: selectedVehicle?.origin,
+			});
+			const rawMembershipCost = applyMembershipAdjustment(
+				rawMembershipCostBeforeAdjustment,
+				membershipAdjustment,
+			);
+			quoterForm.setFieldValue(
+				"membershipAdjustmentCategory",
+				membershipAdjustment.category,
+			);
+			quoterForm.setFieldValue(
+				"membershipAdjustmentPercentage",
+				membershipAdjustment.percentage,
+			);
 
 			if (isInterno) {
 				// Crédito interno: solo seguro base, sin membresía ni GPS
@@ -1896,6 +1925,16 @@ function QuoterPage() {
 											</div>
 										)}
 									</quoterForm.Field>
+									<Badge variant="secondary">Seguro: Universales</Badge>
+									{quoterForm.state.values.membershipAdjustmentCategory ? (
+										<p className="text-muted-foreground text-xs">
+											Membresía: ajuste automático {""}
+											{quoterForm.state.values.membershipAdjustmentPercentage.toFixed(
+												2,
+											)}
+											% por {quoterForm.state.values.membershipAdjustmentCategory}.
+										</p>
+									) : null}
 
 									<quoterForm.Field name="gpsCost">
 										{(field) => (

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -980,6 +980,31 @@ function QuoterPage() {
 		return "otro";
 	};
 
+	const normalizeVehicleTypeForQuoter = (
+		vehicleType?: string | null,
+	): QuotationFormValues["vehicleType"] => {
+		const normalized = (vehicleType ?? "").trim().toLowerCase();
+
+		if (["particular", "sedan", "sedán", "suv"].includes(normalized)) {
+			return "particular";
+		}
+		if (["pickup", "pick up", "pick-up"].includes(normalized)) {
+			return "pickup";
+		}
+		if (normalized === "nuevo") return "nuevo";
+		if (normalized === "uber") return "uber";
+		if (normalized === "panel") return "panel";
+		if (normalized === "camion" || normalized === "camión") return "camion";
+		if (normalized === "microbus" || normalized === "microbús") {
+			return "microbus";
+		}
+		if (normalized === "microbus_20") return "microbus_20";
+		if (normalized === "microbus_35") return "microbus_35";
+		if (normalized === "microbus_36plus") return "microbus_36plus";
+
+		return "particular";
+	};
+
 	const applyVehicleConditionAndOrigin = (vehicle?: {
 		isNew?: boolean | null;
 		origin?: string | null;
@@ -1182,9 +1207,7 @@ function QuoterPage() {
 		quoterForm.setFieldValue("vehicleModel", vehicle.year.toString());
 
 		// Establecer el tipo de vehículo si viene de la oportunidad
-		const vehicleTypeToUse =
-			(vehicle.vehicleType as typeof quoterForm.state.values.vehicleType) ||
-			"particular";
+		const vehicleTypeToUse = normalizeVehicleTypeForQuoter(vehicle.vehicleType);
 		quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
 		const vehicleContext = applyVehicleConditionAndOrigin(vehicle);
 
@@ -1230,9 +1253,7 @@ function QuoterPage() {
 			quoterForm.setFieldValue("vehicleBrand", vehicle.make);
 			quoterForm.setFieldValue("vehicleLine", vehicle.model);
 			quoterForm.setFieldValue("vehicleModel", vehicle.year.toString());
-			const vehicleTypeToUse =
-				(vehicle.vehicleType as typeof quoterForm.state.values.vehicleType) ||
-				"particular";
+			const vehicleTypeToUse = normalizeVehicleTypeForQuoter(vehicle.vehicleType);
 			quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
 			const vehicleContext = applyVehicleConditionAndOrigin(vehicle);
 
@@ -1296,9 +1317,7 @@ function QuoterPage() {
 				quoterForm.setFieldValue("vehicleBrand", q.vehicleBrand || "");
 				quoterForm.setFieldValue("vehicleLine", q.vehicleLine || "");
 				quoterForm.setFieldValue("vehicleModel", q.vehicleModel || "");
-				const vehicleTypeToUse =
-					(q.vehicleType as typeof quoterForm.state.values.vehicleType) ||
-					"particular";
+				const vehicleTypeToUse = normalizeVehicleTypeForQuoter(q.vehicleType);
 				quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
 				if (linkedVehicle) {
 					applyVehicleConditionAndOrigin(linkedVehicle);

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -1077,8 +1077,40 @@ function QuoterPage() {
 			// Recalcular después de actualizar
 			setTimeout(() => recalculate(), 100);
 		} catch (error) {
-			console.error("Error al obtener costo de seguro:", error);
+		console.error("Error al obtener costo de seguro:", error);
+	}
+	};
+
+	const applyCreditTypeChange = async (
+		creditType: QuotationFormValues["creditType"],
+	) => {
+		quoterForm.setFieldValue("creditType", creditType);
+
+		if (creditType === "sobre_vehiculo") {
+			setIsInterno(false);
+			quoterForm.setFieldValue("appointmentCost", 0);
+			quoterForm.setFieldValue("interestRate", 3);
+			quoterForm.setFieldValue("downPayment", 0);
+		} else {
+			quoterForm.setFieldValue("addressVerificationCost", 395);
+			quoterForm.setFieldValue("appointmentCost", 150);
+			quoterForm.setFieldValue("interestRate", 1.5);
 		}
+
+		const insuredAmount = quoterForm.getFieldValue("insuredAmount") ?? 0;
+		if (insuredAmount > 0) {
+			await updateInsuranceCost(
+				insuredAmount,
+				quoterForm.getFieldValue("vehicleType"),
+				{
+					creditType,
+					condition: quoterForm.getFieldValue("vehicleCondition"),
+					origin: quoterForm.getFieldValue("vehicleOrigin"),
+				},
+			);
+		}
+
+		setTimeout(() => recalculate(), 100);
 	};
 
 	// Función para recalcular cuando cambian los valores (según Excel)
@@ -1240,7 +1272,7 @@ function QuoterPage() {
 			isNew?: boolean | null;
 			origin?: string | null;
 		},
-	) => {
+	): Promise<boolean> => {
 		try {
 			const quotations = await client.listQuotationsByOpportunity({
 				opportunityId,
@@ -1380,9 +1412,13 @@ function QuoterPage() {
 				setTimeout(() => recalculate(), 100);
 
 				toast.success("Cotización existente cargada");
+				return true;
 			}
+
+			return false;
 		} catch (error) {
 			console.error("Error al cargar cotización existente:", error);
+			return false;
 		}
 	};
 
@@ -1505,19 +1541,21 @@ function QuoterPage() {
 													const selectedOpp = opportunitiesQuery.data?.find(
 														(opp: any) => opp.id === value,
 													);
-													if (selectedOpp?.creditType) {
-														quoterForm.setFieldValue(
-															"creditType",
-															selectedOpp.creditType,
-														);
-													}
-
+											if (selectedOpp?.creditType) {
+												quoterForm.setFieldValue(
+													"creditType",
+													selectedOpp.creditType,
+												);
+											}
 
 											// Intentar cargar cotización existente primero
-											await loadExistingQuotation(
+											const loadedExistingQuotation = await loadExistingQuotation(
 												value,
 												selectedOpp?.vehicle ?? undefined,
 											);
+											if (!loadedExistingQuotation && selectedOpp?.creditType) {
+												await applyCreditTypeChange(selectedOpp.creditType);
+											}
 
 													// Guardar vehículo de la oportunidad para el combobox
 													if (selectedOpp?.vehicle?.id) {
@@ -1557,48 +1595,15 @@ function QuoterPage() {
 												<Label htmlFor={field.name} className="mb-2">
 													Tipo de Crédito
 												</Label>
-												<Select
-													value={field.state.value}
-													onValueChange={(value) => {
-														field.handleChange(
-															value as "autocompra" | "sobre_vehiculo",
-														);
-														// Resetear crédito interno al cambiar tipo
-														if (value === "sobre_vehiculo") {
-															setIsInterno(false);
-														}
-														// Actualizar campos específicos según tipo de crédito
-														if (value === "autocompra") {
-															quoterForm.setFieldValue(
-																"addressVerificationCost",
-																395,
-															);
-															quoterForm.setFieldValue("appointmentCost", 150);
-															quoterForm.setFieldValue("interestRate", 1.5);
-														} else {
-															quoterForm.setFieldValue("appointmentCost", 0);
-															quoterForm.setFieldValue("interestRate", 3);
-															// En sobre vehículo no hay enganche, limpiar
-															quoterForm.setFieldValue("downPayment", 0);
-														}
-												// Recalcular después del cambio de tipo
-												const insuredAmount =
-													quoterForm.getFieldValue("insuredAmount") ?? 0;
-												if (insuredAmount > 0) {
-													updateInsuranceCost(
-														insuredAmount,
-														quoterForm.state.values.vehicleType,
-														{
-															creditType: value as
-																| "autocompra"
-																| "sobre_vehiculo",
-															condition:
-																quoterForm.getFieldValue("vehicleCondition"),
-															origin: quoterForm.getFieldValue("vehicleOrigin"),
-														},
-													);
-												}
-												setTimeout(() => recalculate(), 100);
+										<Select
+											value={field.state.value}
+											onValueChange={(value) => {
+												field.handleChange(
+													value as QuotationFormValues["creditType"],
+												);
+												void applyCreditTypeChange(
+													value as QuotationFormValues["creditType"],
+												);
 											}}
 													disabled={isDisabled}
 												>

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -985,9 +985,24 @@ function QuoterPage() {
 	): QuotationFormValues["vehicleType"] => {
 		const normalized = (vehicleType ?? "").trim().toLowerCase();
 
-		if (["particular", "sedan", "sedán", "suv"].includes(normalized)) {
+		if (
+			[
+				"particular",
+				"sedan",
+				"sedán",
+				"hatchback",
+				"suv",
+				"minivan",
+				"deportivo",
+				"otro",
+			].includes(normalized)
+		) {
 			return "particular";
 		}
+		if (normalized === "bus hasta 20 pasajeros") return "microbus_20";
+		if (normalized === "bus 21-35 pasajeros") return "microbus_35";
+		if (normalized === "bus más de 35 pasajeros") return "microbus_36plus";
+		if (normalized === "bus mas de 35 pasajeros") return "microbus_36plus";
 		if (["pickup", "pick up", "pick-up"].includes(normalized)) {
 			return "pickup";
 		}

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -961,6 +961,7 @@ function QuoterPage() {
 	const updateInsuranceCost = async (
 		insuredAmount: number,
 		vehicleType: string,
+		vehicleContext?: { isNew?: boolean; origin?: string | null },
 	) => {
 		if (insuredAmount <= 0) return;
 
@@ -975,12 +976,24 @@ function QuoterPage() {
 			const selectedVehicle = vehiclesQuery.data?.data?.find(
 				(vehicle) => vehicle.id === quoterForm.state.values.vehicleId,
 			);
+			const normalizedVehicleType = vehicleType.trim().toLowerCase();
+			const inferredNewType = [
+				"nuevo",
+				"camion",
+				"camión",
+				"microbus",
+				"microbus_20",
+				"microbus_35",
+				"microbus_36plus",
+				"panel",
+				"uber",
+			].includes(normalizedVehicleType);
 			const membershipAdjustment = getMembershipAdjustment({
 				creditType: quoterForm.state.values.creditType,
 				insuredAmount,
 				vehicleType,
-				isNew: selectedVehicle?.isNew ?? vehicleType === "nuevo",
-				origin: selectedVehicle?.origin,
+				isNew: vehicleContext?.isNew ?? selectedVehicle?.isNew ?? inferredNewType,
+				origin: vehicleContext?.origin ?? selectedVehicle?.origin,
 			});
 			const rawMembershipCost = applyMembershipAdjustment(
 				rawMembershipCostBeforeAdjustment,

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -823,58 +823,60 @@ function QuoterPage() {
 	});
 
 	// Form
+	const defaultQuotationValues: QuotationFormValues = {
+		opportunityId: "",
+		vehicleId: "",
+		creditType: "autocompra" as "autocompra" | "sobre_vehiculo",
+		vehicleBrand: "",
+		vehicleLine: "",
+		vehicleModel: "",
+		vehicleType: "particular" as const,
+		vehicleCondition: "used" as const,
+		vehicleOrigin: "agencia" as const,
+		vehicleValue: 0,
+		insuredAmount: 0,
+		downPayment: 0,
+		termMonths: 60,
+		interestRate: 1.5, // default autocompra; sobre_vehiculo usa 3
+		insuranceCost: 0,
+		gpsCost: GPS_COST,
+		transferCost: 545, // 395 + 150 según Excel
+		adminCost: 0,
+		baseMembershipCost: 0,
+		membershipCost: 0,
+		membershipAdjustmentCategory: "",
+		membershipAdjustmentPercentage: 0,
+		// Gastos adicionales para detalle de crédito
+		freelanceCost: 0,
+		freelancePercentage: 0,
+		royalty: 0,
+		royaltyPercentage: 4.0,
+		inspectionCost: 0,
+		finesCost: 0,
+		keyCopyCost: 0,
+		keyCopyDiffCost: 0,
+		circulationTaxCost: 0,
+		vehicleTransferCost: 0,
+		mobileGuaranteeCost: 400,
+		licensePlatesCost: 0,
+		leasingContractCost: 400,
+		collectionAuthCost: 0,
+		legalCost: 0,
+		// Gastos específicos de Autocompras
+		appointmentCost: 150,
+		addressVerificationCost: 395,
+		// Interés calculado automáticamente
+		interestCost: 0,
+		// Gastos extra (separados de los principales)
+		extraGpsCost: 0,
+		extraInsuranceCost: 0,
+		extraMembershipCost: 0,
+		extraAdminCost: 600,
+		rcdpCost: 0,
+	};
+
 	const quoterForm = useForm({
-		defaultValues: {
-			opportunityId: "",
-			vehicleId: "",
-			creditType: "autocompra" as "autocompra" | "sobre_vehiculo",
-			vehicleBrand: "",
-			vehicleLine: "",
-			vehicleModel: "",
-			vehicleType: "particular" as const,
-			vehicleCondition: "used" as const,
-			vehicleOrigin: "agencia" as const,
-			vehicleValue: 0,
-			insuredAmount: 0,
-			downPayment: 0,
-			termMonths: 60,
-			interestRate: 1.5, // default autocompra; sobre_vehiculo usa 3
-			insuranceCost: 0,
-			gpsCost: GPS_COST,
-			transferCost: 545, // 395 + 150 según Excel
-			adminCost: 0,
-			baseMembershipCost: 0,
-			membershipCost: 0,
-			membershipAdjustmentCategory: "",
-			membershipAdjustmentPercentage: 0,
-			// Gastos adicionales para detalle de crédito
-			freelanceCost: 0,
-			freelancePercentage: 0,
-			royalty: 0,
-			royaltyPercentage: 4.0,
-			inspectionCost: 0,
-			finesCost: 0,
-			keyCopyCost: 0,
-			keyCopyDiffCost: 0,
-			circulationTaxCost: 0,
-			vehicleTransferCost: 0,
-			mobileGuaranteeCost: 400,
-			licensePlatesCost: 0,
-			leasingContractCost: 400,
-			collectionAuthCost: 0,
-			legalCost: 0,
-			// Gastos específicos de Autocompras
-			appointmentCost: 150,
-			addressVerificationCost: 395,
-			// Interés calculado automáticamente
-			interestCost: 0,
-			// Gastos extra (separados de los principales)
-			extraGpsCost: 0,
-			extraInsuranceCost: 0,
-			extraMembershipCost: 0,
-			extraAdminCost: 600,
-			rcdpCost: 0,
-		},
+		defaultValues: defaultQuotationValues,
 		onSubmit: async ({ value }) => {
 			createQuotationMutation.mutate({
 				opportunityId: value.opportunityId || undefined,

--- a/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+	applyMembershipAdjustment,
+	getMembershipAdjustment,
+} from "./membership-adjustment";
+
+describe("getMembershipAdjustment", () => {
+	test.each([
+		[99999.99, 18.75],
+		[100000, 18.75],
+		[100000.01, 33.59],
+		[140000, 33.59],
+		[140000.01, 35],
+	])("uses new personal vehicle ranges for %s", (insuredAmount, percentage) => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount,
+			vehicleType: "particular",
+			isNew: true,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe("Nuevo (sedán, SUV, pickup)");
+		expect(result.percentage).toBe(percentage);
+	});
+
+	test("uses new commercial vehicle category", () => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount: 100000,
+			vehicleType: "microbus",
+			isNew: true,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe(
+			"Nuevo (camión, microbus, panel, uber o similar)",
+		);
+		expect(result.percentage).toBe(25);
+	});
+
+	test("uses used agency category from non-rodado origin", () => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount: 120000,
+			vehicleType: "particular",
+			isNew: false,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe("Usado agencia");
+		expect(result.percentage).toBe(55.47);
+	});
+
+	test.each(["rodado", "importado", "subasta"])(
+		"uses rodado category for origin %s",
+		(origin) => {
+			const result = getMembershipAdjustment({
+				creditType: "autocompra",
+				insuredAmount: 150000,
+				vehicleType: "particular",
+				isNew: false,
+				origin,
+			});
+
+			expect(result.category).toBe("Rodado");
+			expect(result.percentage).toBe(70);
+		},
+	);
+
+	test("uses sobre vehículo category before vehicle origin", () => {
+		const result = getMembershipAdjustment({
+			creditType: "sobre_vehiculo",
+			insuredAmount: 90000,
+			vehicleType: "microbus",
+			isNew: true,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe("Sobre vehículo (hasta 50%)");
+		expect(result.percentage).toBe(37.5);
+	});
+});
+
+describe("applyMembershipAdjustment", () => {
+	test("multiplies the current membership by the adjustment factor", () => {
+		const result = applyMembershipAdjustment(100, {
+			category: "Nuevo (sedán, SUV, pickup)",
+			percentage: 18.75,
+			factor: 1.1875,
+		});
+
+		expect(result).toBe(118.75);
+	});
+});

--- a/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
@@ -39,6 +39,21 @@ describe("getMembershipAdjustment", () => {
 		expect(result.percentage).toBe(25);
 	});
 
+	test("manual microbus without selected vehicle is treated as new commercial", () => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount: 100000,
+			vehicleType: "microbus",
+			isNew: true,
+			origin: null,
+		});
+
+		expect(result.category).toBe(
+			"Nuevo (camión, microbus, panel, uber o similar)",
+		);
+		expect(result.percentage).toBe(25);
+	});
+
 	test("uses used agency category from non-rodado origin", () => {
 		const result = getMembershipAdjustment({
 			creditType: "autocompra",

--- a/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
@@ -44,7 +44,7 @@ describe("getMembershipAdjustment", () => {
 			creditType: "autocompra",
 			insuredAmount: 100000,
 			vehicleType: "microbus",
-			isNew: true,
+			condition: "new",
 			origin: null,
 		});
 
@@ -52,6 +52,19 @@ describe("getMembershipAdjustment", () => {
 			"Nuevo (camión, microbus, panel, uber o similar)",
 		);
 		expect(result.percentage).toBe(25);
+	});
+
+	test("manual used microbus can be simulated as used agency", () => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount: 100000,
+			vehicleType: "microbus",
+			condition: "used",
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe("Usado agencia");
+		expect(result.percentage).toBe(31.25);
 	});
 
 	test("uses used agency category from non-rodado origin", () => {

--- a/apps/crm/apps/web/src/utils/membership-adjustment.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.ts
@@ -1,0 +1,98 @@
+export type MembershipAdjustmentCategory =
+	| "Nuevo (sedán, SUV, pickup)"
+	| "Nuevo (camión, microbus, panel, uber o similar)"
+	| "Usado agencia"
+	| "Rodado"
+	| "Sobre vehículo (hasta 50%)";
+
+export interface MembershipAdjustmentInput {
+	creditType: "autocompra" | "sobre_vehiculo";
+	insuredAmount: number;
+	vehicleType: string;
+	isNew: boolean;
+	origin?: string | null;
+}
+
+export interface MembershipAdjustment {
+	category: MembershipAdjustmentCategory;
+	percentage: number;
+	factor: number;
+}
+
+const RATES: Record<MembershipAdjustmentCategory, [number, number, number]> = {
+	"Nuevo (sedán, SUV, pickup)": [18.75, 33.59, 35],
+	"Nuevo (camión, microbus, panel, uber o similar)": [25, 44.53, 46.25],
+	"Usado agencia": [31.25, 55.47, 57.5],
+	Rodado: [37.5, 67.19, 70],
+	"Sobre vehículo (hasta 50%)": [37.5, 67.19, 70],
+};
+
+const NEW_PERSONAL_TYPES = new Set([
+	"particular",
+	"nuevo",
+	"sedan",
+	"sedán",
+	"suv",
+	"pickup",
+]);
+const NEW_COMMERCIAL_TYPES = new Set([
+	"camion",
+	"camión",
+	"microbus",
+	"microbus_20",
+	"microbus_35",
+	"microbus_36plus",
+	"panel",
+	"uber",
+]);
+const RODADO_ORIGINS = ["rodado", "importado", "subasta"];
+
+function normalize(value?: string | null): string {
+	return value?.trim().toLowerCase() ?? "";
+}
+
+function getRangeIndex(insuredAmount: number): 0 | 1 | 2 {
+	if (insuredAmount <= 100000) return 0;
+	if (insuredAmount <= 140000) return 1;
+	return 2;
+}
+
+function getCategory(input: MembershipAdjustmentInput): MembershipAdjustmentCategory {
+	if (input.creditType === "sobre_vehiculo") return "Sobre vehículo (hasta 50%)";
+
+	const vehicleType = normalize(input.vehicleType);
+	if (input.isNew) {
+		if (NEW_COMMERCIAL_TYPES.has(vehicleType)) {
+			return "Nuevo (camión, microbus, panel, uber o similar)";
+		}
+		if (NEW_PERSONAL_TYPES.has(vehicleType)) return "Nuevo (sedán, SUV, pickup)";
+		return "Nuevo (sedán, SUV, pickup)";
+	}
+
+	const origin = normalize(input.origin);
+	if (RODADO_ORIGINS.some((keyword) => origin.includes(keyword))) {
+		return "Rodado";
+	}
+
+	return "Usado agencia";
+}
+
+export function getMembershipAdjustment(
+	input: MembershipAdjustmentInput,
+): MembershipAdjustment {
+	const category = getCategory(input);
+	const percentage = RATES[category][getRangeIndex(input.insuredAmount)];
+
+	return {
+		category,
+		percentage,
+		factor: 1 + percentage / 100,
+	};
+}
+
+export function applyMembershipAdjustment(
+	membershipCost: number,
+	adjustment: MembershipAdjustment,
+): number {
+	return Math.round(membershipCost * adjustment.factor * 100) / 100;
+}

--- a/apps/crm/apps/web/src/utils/membership-adjustment.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.ts
@@ -9,7 +9,8 @@ export interface MembershipAdjustmentInput {
 	creditType: "autocompra" | "sobre_vehiculo";
 	insuredAmount: number;
 	vehicleType: string;
-	isNew: boolean;
+	isNew?: boolean;
+	condition?: "new" | "used";
 	origin?: string | null;
 }
 
@@ -57,15 +58,20 @@ function getRangeIndex(insuredAmount: number): 0 | 1 | 2 {
 	return 2;
 }
 
-function getCategory(input: MembershipAdjustmentInput): MembershipAdjustmentCategory {
-	if (input.creditType === "sobre_vehiculo") return "Sobre vehículo (hasta 50%)";
+function getCategory(
+	input: MembershipAdjustmentInput,
+): MembershipAdjustmentCategory {
+	if (input.creditType === "sobre_vehiculo")
+		return "Sobre vehículo (hasta 50%)";
 
 	const vehicleType = normalize(input.vehicleType);
-	if (input.isNew) {
+	const isNew = input.condition ? input.condition === "new" : input.isNew;
+	if (isNew) {
 		if (NEW_COMMERCIAL_TYPES.has(vehicleType)) {
 			return "Nuevo (camión, microbus, panel, uber o similar)";
 		}
-		if (NEW_PERSONAL_TYPES.has(vehicleType)) return "Nuevo (sedán, SUV, pickup)";
+		if (NEW_PERSONAL_TYPES.has(vehicleType))
+			return "Nuevo (sedán, SUV, pickup)";
 		return "Nuevo (sedán, SUV, pickup)";
 	}
 


### PR DESCRIPTION
## Summary
- Agrega reglas automáticas de incremento de membresía por tipo de crédito, monto, condición y origen del vehículo.
- Permite simular condición/origen cuando no hay vehículo seleccionado y bloquea esos campos solo cuando el contexto viene de un vehículo real.
- Autocompleta tipo, condición y origen al seleccionar vehículo existente.
- Recalcula membresía al cambiar tipo de crédito cuando ya existe monto asegurado.
- Persiste condición/origen simulados en cotizaciones manuales para mantener la misma categoría al recargar.
- Muestra membresía original vs membresía inflada en el cotizador.

## Production migration
- Requiere aplicar la migración en producción: `apps/server/src/db/migrations/0024_add_quotation_vehicle_context.sql`.
- La migración agrega `vehicle_condition` y `vehicle_origin` a `quotations` con defaults seguros para cotizaciones existentes.

## Test Plan
- bun test apps/web/src/utils/membership-adjustment.test.ts
- bun run check-types
- bun run check-all

## Notes
- No incluye cambios de GyT ni comparativos de seguro.