### PR TITLE
feat(reportes): rework créditos cerrados, tabs de reportes de ventas, header responsive y jerarquía de filtros

### DIFF
--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -271,8 +271,6 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 				fechaCierre: opportunities.actualCloseDate,
 				// Día del mes en que paga (1-31), tomado de la oportunidad.
 				diaPago: opportunities.diaPagoMensual,
-				// Total de filas que cumplen el filtro (antes de LIMIT/OFFSET).
-				total: sql<number>`COUNT(*) OVER()`,
 			})
 			.from(opportunities)
 			.leftJoin(leads, eq(opportunities.leadId, leads.id))
@@ -300,14 +298,21 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 			.where(whereClause)
 			.orderBy(desc(opportunities.actualCloseDate));
 
-		const result = input.pageSize
+		const rows = input.pageSize
 			? await baseQuery
 					.limit(input.pageSize)
 					.offset(((input.page ?? 1) - 1) * input.pageSize)
 			: await baseQuery;
 
-		const total = Number(result[0]?.total ?? 0);
-		const rows = result.map(({ total: _total, ...row }) => row);
+		// Conteo total independiente de la página. Cada oportunidad produce
+		// exactamente una fila (los joins están deduplicados a rn=1), así que
+		// contar oportunidades que cumplen el filtro = total real. Con esto, una
+		// página fuera de rango (datos borrados o page stale) deja de reportar 0.
+		const totalResult = await db
+			.select({ total: count() })
+			.from(opportunities)
+			.where(whereClause);
+		const total = totalResult[0]?.total ?? 0;
 
 		// Solo la exportación (sin paginar) puede traer todo; ahí aplicamos el tope.
 		if (!input.pageSize) {

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/server";
-import { and, count, desc, eq, gte, lte, sql, sum } from "drizzle-orm";
+import { and, count, desc, eq, gte, lt, lte, sql, sum } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { auctionVehicles } from "../db/schema/auctionVehicles";
@@ -17,11 +17,9 @@ import {
 	salesStages,
 } from "../db/schema/crm";
 import { metasMensuales } from "../db/schema/metas";
+import { quotations } from "../db/schema/quotations";
 import { vehicleInspections, vehicles } from "../db/schema/vehicles";
-import {
-	getGuatemalaMonthWindow,
-	toDateStrGT,
-} from "../lib/guatemala-month-window";
+import { getGuatemalaMonthWindow } from "../lib/guatemala-month-window";
 import {
 	closedCreditsReportProcedure,
 	metaColocacionReportProcedure,
@@ -29,7 +27,6 @@ import {
 	protectedProcedure,
 	tiempoCierreReportProcedure,
 } from "../lib/orpc";
-import { carteraBackClient } from "../services/cartera-back-client";
 import type { StatusCreditEnum } from "../types/cartera-back";
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
@@ -43,6 +40,15 @@ const dateRangeSchema = z.object({
 const closedCreditsReportInputSchema = z.object({
 	startDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
 	endDate: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+});
+
+// Reporte "Créditos cerrados": filtro por mes + paginación del lado del servidor.
+// Sin `pageSize` se devuelven todas las filas del mes (usado por la exportación).
+const creditosCerradosInputSchema = z.object({
+	anio: z.number().int().min(2000).max(2100),
+	mes: z.number().int().min(1).max(12),
+	page: z.number().int().min(1).optional(),
+	pageSize: z.number().int().min(1).max(500).optional(),
 });
 
 const CLOSED_CREDIT_REPORT_CARTERA_STATUSES: StatusCreditEnum[] = [
@@ -67,39 +73,6 @@ export function enforceClosedCreditReportLimit<T>(rows: T[]) {
 				"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
 		});
 	}
-}
-
-async function getClosedCreditReportCarteraStatuses(sifcos: string[]) {
-	const uniqueSifcos = [...new Set(sifcos.filter(Boolean))];
-	const statuses = new Map<string, StatusCreditEnum>();
-	const [anio, mes] = toDateStrGT(new Date()).split("-").map(Number);
-
-	for (
-		let index = 0;
-		index < uniqueSifcos.length;
-		index += CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE
-	) {
-		const chunk = uniqueSifcos.slice(
-			index,
-			index + CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
-		);
-		const response = await carteraBackClient.getAllCreditos({
-			mes,
-			anio,
-			page: 1,
-			perPage: chunk.length,
-			numeros_credito_sifco: chunk,
-		});
-
-		for (const row of response.data) {
-			statuses.set(
-				row.creditos.numero_credito_sifco,
-				row.creditos.statusCredit,
-			);
-		}
-	}
-
-	return statuses;
 }
 
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
@@ -231,63 +204,85 @@ export const getDashboardExecutivo = protectedProcedure
 
 /**
  * Reporte de créditos cerrados
- * Créditos que llegaron por primera vez a una etapa 90%+.
+ * Oportunidades ganadas (status = 'won'), filtradas por la fecha en que se
+ * cerraron (actualCloseDate) dentro del mes seleccionado. Paginado del lado del
+ * servidor; sin `pageSize` se devuelven todas las filas del mes (exportación).
  */
 export const getReporteCreditosCerrados = closedCreditsReportProcedure
-	.input(closedCreditsReportInputSchema)
+	.input(creditosCerradosInputSchema)
 	.handler(async ({ input }) => {
-		const { start, end } = parseGuatemalaDateRange(
-			input.startDate,
-			input.endDate,
+		const { startOfMonth, endOfMonth } = getGuatemalaMonthWindow(
+			input.anio,
+			input.mes,
 		);
 
-		const firstClosedStageDates = db
+		// Cuota del crédito = monthlyPayment de la cotización enlazada a la
+		// oportunidad. Si hay varias, se prefiere la aceptada y luego la más reciente.
+		const latestQuotation = db
 			.select({
-				opportunityId: opportunityStageHistory.opportunityId,
-				firstClosedStageAt:
-					sql<Date>`MIN(${opportunityStageHistory.changedAt})`.as(
-						"first_closed_stage_at",
-					),
+				opportunityId: quotations.opportunityId,
+				monthlyPayment: quotations.monthlyPayment,
+				rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${quotations.opportunityId} ORDER BY (${quotations.status} = 'accepted') DESC, ${quotations.createdAt} DESC)`.as(
+					"rn_quot",
+				),
 			})
-			.from(opportunityStageHistory)
-			.innerJoin(
-				salesStages,
-				eq(opportunityStageHistory.toStageId, salesStages.id),
-			)
-			.where(gte(salesStages.closurePercentage, 90))
-			.groupBy(opportunityStageHistory.opportunityId)
-			.as("first_closed_stage_dates");
+			.from(quotations)
+			.as("latest_quotation");
 
+		// Número SIFCO: referencia de cartera más reciente; fallback al de la opp.
 		const latestCarteraReference = db
 			.select({
 				opportunityId: carteraBackReferences.opportunityId,
-				contratoFinanciamientoId:
-					carteraBackReferences.contratoFinanciamientoId,
 				numeroCreditoSifco: carteraBackReferences.numeroCreditoSifco,
 				rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${carteraBackReferences.opportunityId} ORDER BY ${carteraBackReferences.createdAt} DESC, ${carteraBackReferences.id} DESC)`.as(
-					"rn",
+					"rn_cart",
 				),
 			})
 			.from(carteraBackReferences)
 			.as("latest_cartera_reference");
 
-		const rows = await db
+		// Cliente por oportunidad (deduplicado) — solo para el nombre de respaldo.
+		// Garantiza una fila por oportunidad (evita multiplicar el conteo/paginado).
+		const latestClient = db
 			.select({
-				placa: vehicles.licensePlate,
-				chasis: vehicles.vinNumber,
-				cuotaSeguro: opportunities.seguro,
-				clienteNombre: sql<string>`COALESCE(NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.middleName}, ${leads.lastName}, ${leads.secondLastName})), ''), ${clients.contactPerson}, '')`,
-				numeroCredito: sql<string>`COALESCE(${latestCarteraReference.numeroCreditoSifco}, ${opportunities.numeroSifco}, '')`,
-				fecha90: firstClosedStageDates.firstClosedStageAt,
+				opportunityId: clients.opportunityId,
+				contactPerson: clients.contactPerson,
+				rn: sql<number>`ROW_NUMBER() OVER (PARTITION BY ${clients.opportunityId} ORDER BY ${clients.createdAt} DESC, ${clients.id} DESC)`.as(
+					"rn_cli",
+				),
 			})
-			.from(firstClosedStageDates)
-			.innerJoin(
-				opportunities,
-				eq(firstClosedStageDates.opportunityId, opportunities.id),
-			)
-			.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+			.from(clients)
+			.as("latest_client");
+
+		const whereClause = and(
+			eq(opportunities.status, "won"),
+			gte(opportunities.actualCloseDate, startOfMonth),
+			lt(opportunities.actualCloseDate, endOfMonth),
+		);
+
+		const baseQuery = db
+			.select({
+				id: opportunities.id,
+				clienteNombre: sql<string>`COALESCE(NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.middleName}, ${leads.lastName}, ${leads.secondLastName})), ''), ${latestClient.contactPerson}, '')`,
+				numeroSifco: sql<string>`COALESCE(${latestCarteraReference.numeroCreditoSifco}, ${opportunities.numeroSifco}, '')`,
+				cuotaSeguro: opportunities.seguro,
+				montoCredito: opportunities.value,
+				cuotaCredito: latestQuotation.monthlyPayment,
+				fechaCierre: opportunities.actualCloseDate,
+				// Día del mes en que paga (1-31), tomado de la oportunidad.
+				diaPago: opportunities.diaPagoMensual,
+				// Total de filas que cumplen el filtro (antes de LIMIT/OFFSET).
+				total: sql<number>`COUNT(*) OVER()`,
+			})
+			.from(opportunities)
 			.leftJoin(leads, eq(opportunities.leadId, leads.id))
-			.leftJoin(clients, eq(clients.opportunityId, opportunities.id))
+			.leftJoin(
+				latestClient,
+				and(
+					eq(latestClient.opportunityId, opportunities.id),
+					eq(latestClient.rn, 1),
+				),
+			)
 			.leftJoin(
 				latestCarteraReference,
 				and(
@@ -295,33 +290,36 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 					eq(latestCarteraReference.rn, 1),
 				),
 			)
-			.innerJoin(
-				contratosFinanciamiento,
-				eq(
-					latestCarteraReference.contratoFinanciamientoId,
-					contratosFinanciamiento.id,
-				),
-			)
-			.where(
+			.leftJoin(
+				latestQuotation,
 				and(
-					gte(firstClosedStageDates.firstClosedStageAt, start),
-					lte(firstClosedStageDates.firstClosedStageAt, end),
+					eq(latestQuotation.opportunityId, opportunities.id),
+					eq(latestQuotation.rn, 1),
 				),
 			)
-			.orderBy(desc(firstClosedStageDates.firstClosedStageAt));
+			.where(whereClause)
+			.orderBy(desc(opportunities.actualCloseDate));
 
-		const carteraStatuses = await getClosedCreditReportCarteraStatuses(
-			rows.map((row) => row.numeroCredito),
-		);
+		const result = input.pageSize
+			? await baseQuery
+					.limit(input.pageSize)
+					.offset(((input.page ?? 1) - 1) * input.pageSize)
+			: await baseQuery;
 
-		const activeRows = rows.filter((row) =>
-			isClosedCreditReportCarteraStatusIncluded(
-				carteraStatuses.get(row.numeroCredito) ?? null,
-			),
-		);
-		enforceClosedCreditReportLimit(activeRows);
+		const total = Number(result[0]?.total ?? 0);
+		const rows = result.map(({ total: _total, ...row }) => row);
 
-		return activeRows;
+		// Solo la exportación (sin paginar) puede traer todo; ahí aplicamos el tope.
+		if (!input.pageSize) {
+			enforceClosedCreditReportLimit(rows);
+		}
+
+		return {
+			rows,
+			total,
+			page: input.page ?? 1,
+			pageSize: input.pageSize ?? total,
+		};
 	});
 
 /**

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -513,7 +513,7 @@ function MobileNav({
 					<SheetHeader className="shrink-0 border-b">
 						<SheetTitle>Menú</SheetTitle>
 					</SheetHeader>
-					<nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-3">
+					<nav className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-3">
 						{!session && (
 							<Link to="/" className={MOBILE_LINK_CLASS}>
 								<LayoutDashboard />

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -9,15 +9,13 @@ import {
 	Calculator,
 	Car,
 	ChevronDown,
-	Clock,
 	Database,
 	FileText,
 	Gavel,
-	Key,
 	Landmark,
 	LayoutDashboard,
+	Menu,
 	MessageSquare,
-	Percent,
 	Scale,
 	Settings,
 	Target,
@@ -25,6 +23,7 @@ import {
 	UserCircle,
 	Users,
 } from "lucide-react";
+import { type ReactNode, useEffect, useState } from "react";
 import { logo } from "@/assets";
 import { authClient } from "@/lib/auth-client";
 import { PERMISSIONS } from "@/lib/roles";
@@ -39,6 +38,13 @@ import {
 	DropdownMenuSeparator,
 	DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
+import {
+	Sheet,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+} from "./ui/sheet";
 import UserMenu from "./user-menu";
 
 export default function Header() {
@@ -57,7 +63,10 @@ export default function Header() {
 	return (
 		<div className="border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
 			<div className="flex h-16 items-center px-6">
-				<div className="flex items-center gap-8">
+				<div className="flex items-center gap-3 md:gap-8">
+					{/* Mobile menu (hamburguesa) */}
+					<MobileNav session={!!session} userRole={userRole} />
+
 					{/* Logo */}
 					<Link
 						to="/"
@@ -69,8 +78,8 @@ export default function Header() {
 						</span>
 					</Link>
 
-					{/* Navigation */}
-					<nav className="flex items-center gap-1">
+					{/* Navigation (desktop) */}
+					<nav className="hidden items-center gap-1 md:flex">
 						{!session && (
 							<Button variant="ghost" size="sm" asChild>
 								<Link to="/">
@@ -152,48 +161,17 @@ export default function Header() {
 										</>
 									)}
 									{userRole &&
-										PERMISSIONS.canAccessTiempoCierreReport(userRole) && (
+										(PERMISSIONS.canAccessTiempoCierreReport(userRole) ||
+											PERMISSIONS.canAccessPorcentajeEfectividadReport(
+												userRole,
+											) ||
+											PERMISSIONS.canAccessMetaColocacionReport(userRole)) && (
 											<>
 												<DropdownMenuSeparator />
 												<DropdownMenuItem asChild>
-													<Link
-														to="/crm/reportes/tiempo-cierre"
-														className="cursor-pointer"
-													>
-														<Clock className="mr-2 h-4 w-4" />
-														Tiempo Cierre Crédito
-													</Link>
-												</DropdownMenuItem>
-											</>
-										)}
-									{userRole &&
-										PERMISSIONS.canAccessPorcentajeEfectividadReport(
-											userRole,
-										) && (
-											<>
-												<DropdownMenuSeparator />
-												<DropdownMenuItem asChild>
-													<Link
-														to="/crm/reportes/porcentaje-efectividad"
-														className="cursor-pointer"
-													>
-														<Percent className="mr-2 h-4 w-4" />
-														Porcentaje Efectividad
-													</Link>
-												</DropdownMenuItem>
-											</>
-										)}
-									{userRole &&
-										PERMISSIONS.canAccessMetaColocacionReport(userRole) && (
-											<>
-												<DropdownMenuSeparator />
-												<DropdownMenuItem asChild>
-													<Link
-														to="/crm/reportes/meta-colocacion"
-														className="cursor-pointer"
-													>
-														<Target className="mr-2 h-4 w-4" />
-														Meta Colocación
+													<Link to="/crm/reportes" className="cursor-pointer">
+														<FileText className="mr-2 h-4 w-4" />
+														Reportes
 													</Link>
 												</DropdownMenuItem>
 											</>
@@ -448,27 +426,12 @@ export default function Header() {
 														Usuarios
 													</Link>
 												</DropdownMenuItem>
-												<DropdownMenuItem asChild>
-													<Link to="/admin/import" className="cursor-pointer">
-														<Database className="mr-2 h-4 w-4" />
-														Importación
-													</Link>
-												</DropdownMenuItem>
-												<DropdownMenuItem asChild>
-													<Link
-														to="/crm/admin/miniagent"
-														className="cursor-pointer"
-													>
-														<Key className="mr-2 h-4 w-4" />
-														MiniAgent
-													</Link>
-												</DropdownMenuItem>
-												<DropdownMenuItem asChild>
-													<Link to="/admin/settings" className="cursor-pointer">
-														<Settings className="mr-2 h-4 w-4" />
-														Configuración
-													</Link>
-												</DropdownMenuItem>
+												{/* "Importación", "MiniAgent" y "Configuración"
+												    ocultos a propósito. Las rutas y páginas
+												    (/admin/import, /crm/admin/miniagent,
+												    /admin/settings) se conservan por si se quieren
+												    reutilizar; para volver a mostrarlas, reañadir
+												    aquí sus DropdownMenuItem. */}
 											</>
 										)}
 										<DropdownMenuItem asChild>
@@ -490,6 +453,249 @@ export default function Header() {
 					<UserMenu />
 				</div>
 			</div>
+		</div>
+	);
+}
+
+const MOBILE_LINK_CLASS =
+	"flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors hover:bg-accent [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0 [&_svg]:text-muted-foreground";
+
+function MobileSection({
+	label,
+	children,
+}: {
+	label: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className="mt-2 flex flex-col">
+			<p className="px-3 pt-2 pb-1 font-medium text-muted-foreground text-xs uppercase tracking-wider">
+				{label}
+			</p>
+			{children}
+		</div>
+	);
+}
+
+// Menú de navegación para mobile (hamburguesa + drawer). Mismas opciones y
+// permisos que el nav de escritorio, en lista vertical. Se cierra solo al navegar.
+function MobileNav({
+	session,
+	userRole,
+}: {
+	session: boolean;
+	userRole: string | undefined;
+}) {
+	const [open, setOpen] = useState(false);
+	const router = useRouterState();
+	const pathname = router.location.pathname;
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: cerrar el drawer cuando cambia la ruta
+	useEffect(() => {
+		setOpen(false);
+	}, [pathname]);
+
+	const ventasReports =
+		!!userRole &&
+		(PERMISSIONS.canAccessTiempoCierreReport(userRole) ||
+			PERMISSIONS.canAccessPorcentajeEfectividadReport(userRole) ||
+			PERMISSIONS.canAccessMetaColocacionReport(userRole));
+
+	return (
+		<div className="md:hidden">
+			<Sheet open={open} onOpenChange={setOpen}>
+				<SheetTrigger asChild>
+					<Button variant="ghost" size="icon" aria-label="Abrir menú">
+						<Menu className="h-5 w-5" />
+					</Button>
+				</SheetTrigger>
+				<SheetContent side="left" className="flex w-72 flex-col gap-0 p-0">
+					<SheetHeader className="shrink-0 border-b">
+						<SheetTitle>Menú</SheetTitle>
+					</SheetHeader>
+					<nav className="flex flex-1 flex-col gap-0.5 overflow-y-auto p-3">
+						{!session && (
+							<Link to="/" className={MOBILE_LINK_CLASS}>
+								<LayoutDashboard />
+								Inicio
+							</Link>
+						)}
+
+						{session && (
+							<>
+								<Link to="/dashboard" className={MOBILE_LINK_CLASS}>
+									<LayoutDashboard />
+									Tablero
+								</Link>
+
+								{userRole && PERMISSIONS.canAccessCRM(userRole) && (
+									<MobileSection label="Ventas">
+										<Link to="/crm/leads" className={MOBILE_LINK_CLASS}>
+											<UserCircle />
+											Prospectos
+										</Link>
+										<Link to="/crm/opportunities" className={MOBILE_LINK_CLASS}>
+											<TrendingUp />
+											Oportunidades
+										</Link>
+										<Link to="/crm/companies" className={MOBILE_LINK_CLASS}>
+											<Building2 />
+											Empresas
+										</Link>
+										<Link to="/crm/vendors" className={MOBILE_LINK_CLASS}>
+											<UserCircle />
+											Vendedores
+										</Link>
+										<Link to="/crm/quoter" className={MOBILE_LINK_CLASS}>
+											<Calculator />
+											Cotizador
+										</Link>
+										{PERMISSIONS.canAccessWhatsApp(userRole) && (
+											<Link to="/crm/whatsapp" className={MOBILE_LINK_CLASS}>
+												<MessageSquare />
+												WhatsApp
+											</Link>
+										)}
+										{ventasReports && (
+											<Link to="/crm/reportes" className={MOBILE_LINK_CLASS}>
+												<FileText />
+												Reportes
+											</Link>
+										)}
+									</MobileSection>
+								)}
+
+								{userRole && PERMISSIONS.canAccessClients(userRole) && (
+									<Link to="/crm/clients" className={MOBILE_LINK_CLASS}>
+										<Users />
+										Clientes
+									</Link>
+								)}
+
+								{userRole && PERMISSIONS.canAccessVehicles(userRole) && (
+									<MobileSection label="Vehículos">
+										<Link
+											to="/vehicles"
+											search={{
+												vehicleId: undefined,
+												inspectionId: undefined,
+												tab: undefined,
+											}}
+											className={MOBILE_LINK_CLASS}
+										>
+											<Car />
+											Inventario
+										</Link>
+										<Link
+											to="/vehicles/auction-vehicles"
+											className={MOBILE_LINK_CLASS}
+										>
+											<Gavel />
+											Carros en Remate
+										</Link>
+									</MobileSection>
+								)}
+
+								{userRole && PERMISSIONS.canAccessCobros(userRole) && (
+									<MobileSection label="Cobros">
+										<Link to="/cobros" className={MOBILE_LINK_CLASS}>
+											<Banknote />
+											Dashboard
+										</Link>
+										{PERMISSIONS.canAssignCobros(userRole) && (
+											<Link to="/cobros/metas" className={MOBILE_LINK_CLASS}>
+												<Target />
+												Metas de Mora
+											</Link>
+										)}
+										{PERMISSIONS.canAssignCobros(userRole) && (
+											<Link to="/cobros/reportes" className={MOBILE_LINK_CLASS}>
+												<BarChart3 />
+												Reportes
+											</Link>
+										)}
+									</MobileSection>
+								)}
+
+								{userRole && PERMISSIONS.canAccessAnalysis(userRole) && (
+									<Link to="/crm/analysis" className={MOBILE_LINK_CLASS}>
+										<BarChart3 />
+										Análisis
+									</Link>
+								)}
+
+								{userRole && PERMISSIONS.canAccessJuridico(userRole) && (
+									<MobileSection label="Jurídico">
+										<Link to="/juridico" className={MOBILE_LINK_CLASS}>
+											<Scale />
+											Gestión jurídica
+										</Link>
+										<Link
+											to="/juridico/dashboard"
+											className={MOBILE_LINK_CLASS}
+										>
+											<LayoutDashboard />
+											Dashboard
+										</Link>
+										<Link
+											to="/juridico/dashboard-data"
+											className={MOBILE_LINK_CLASS}
+										>
+											<Database />
+											Carga de datos
+										</Link>
+									</MobileSection>
+								)}
+
+								{userRole && PERMISSIONS.canAccessInvestments(userRole) && (
+									<MobileSection label="Inversiones">
+										<Link to="/inversiones" className={MOBILE_LINK_CLASS}>
+											<Target />
+											Leads
+										</Link>
+										<Link
+											to="/inversiones/liquidaciones"
+											className={MOBILE_LINK_CLASS}
+										>
+											<Landmark />
+											Inversionistas
+										</Link>
+									</MobileSection>
+								)}
+
+								{userRole && PERMISSIONS.canAccessAccounting(userRole) && (
+									<MobileSection label="Contabilidad">
+										<Link
+											to="/accounting/pay-investors"
+											className={MOBILE_LINK_CLASS}
+										>
+											<Banknote />
+											Pagar Inversionistas
+										</Link>
+									</MobileSection>
+								)}
+
+								{userRole &&
+									(PERMISSIONS.canAccessAdmin(userRole) ||
+										PERMISSIONS.canAccessClosedCreditsReport(userRole)) && (
+										<MobileSection label="Admin">
+											{PERMISSIONS.canAccessAdmin(userRole) && (
+												<Link to="/admin/users" className={MOBILE_LINK_CLASS}>
+													<Users />
+													Usuarios
+												</Link>
+											)}
+											<Link to="/admin/reports" className={MOBILE_LINK_CLASS}>
+												<FileText />
+												Reportes
+											</Link>
+										</MobileSection>
+									)}
+							</>
+						)}
+					</nav>
+				</SheetContent>
+			</Sheet>
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -509,11 +509,14 @@ function MobileNav({
 						<Menu className="h-5 w-5" />
 					</Button>
 				</SheetTrigger>
-				<SheetContent side="left" className="flex w-72 flex-col gap-0 p-0">
+				<SheetContent
+					side="left"
+					className="flex h-dvh max-h-dvh w-72 flex-col gap-0 overflow-hidden p-0"
+				>
 					<SheetHeader className="shrink-0 border-b">
 						<SheetTitle>Menú</SheetTitle>
 					</SheetHeader>
-					<nav className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto p-3">
+					<nav className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto overscroll-contain p-3">
 						{!session && (
 							<Link to="/" className={MOBILE_LINK_CLASS}>
 								<LayoutDashboard />

--- a/apps/crm/apps/web/src/components/ui/sheet.tsx
+++ b/apps/crm/apps/web/src/components/ui/sheet.tsx
@@ -58,9 +58,9 @@ function SheetContent({
 				className={cn(
 					"fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500",
 					side === "right" &&
-						"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+						"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-0 right-0 h-dvh max-h-dvh w-3/4 border-l sm:max-w-sm",
 					side === "left" &&
-						"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+						"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-0 left-0 h-dvh max-h-dvh w-3/4 border-r sm:max-w-sm",
 					side === "top" &&
 						"data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
 					side === "bottom" &&

--- a/apps/crm/apps/web/src/components/ui/sheet.tsx
+++ b/apps/crm/apps/web/src/components/ui/sheet.tsx
@@ -1,0 +1,115 @@
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { XIcon } from "lucide-react";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+	return <SheetPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger({
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+	return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose({
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+	return <SheetPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+function SheetPortal({
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+	return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />;
+}
+
+function SheetOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+	return (
+		<SheetPrimitive.Overlay
+			data-slot="sheet-overlay"
+			className={cn(
+				"data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=open]:animate-in",
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function SheetContent({
+	className,
+	children,
+	side = "right",
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+	side?: "top" | "right" | "bottom" | "left";
+}) {
+	return (
+		<SheetPortal>
+			<SheetOverlay />
+			<SheetPrimitive.Content
+				data-slot="sheet-content"
+				className={cn(
+					"fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:duration-300 data-[state=open]:duration-500",
+					side === "right" &&
+						"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right inset-y-0 right-0 h-full w-3/4 border-l sm:max-w-sm",
+					side === "left" &&
+						"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left inset-y-0 left-0 h-full w-3/4 border-r sm:max-w-sm",
+					side === "top" &&
+						"data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-0 h-auto border-b",
+					side === "bottom" &&
+						"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-0 h-auto border-t",
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				<SheetPrimitive.Close
+					data-slot="sheet-close"
+					className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
+				>
+					<XIcon className="h-5 w-5" />
+					<span className="sr-only">Cerrar</span>
+				</SheetPrimitive.Close>
+			</SheetPrimitive.Content>
+		</SheetPortal>
+	);
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+	return (
+		<div
+			data-slot="sheet-header"
+			className={cn("flex flex-col gap-1.5 p-4", className)}
+			{...props}
+		/>
+	);
+}
+
+function SheetTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+	return (
+		<SheetPrimitive.Title
+			data-slot="sheet-title"
+			className={cn("font-semibold text-foreground", className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Sheet,
+	SheetClose,
+	SheetContent,
+	SheetHeader,
+	SheetTitle,
+	SheetTrigger,
+};

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as AdminSettingsRouteImport } from './routes/admin/settings'
 import { Route as AdminImportRouteImport } from './routes/admin/import'
 import { Route as AccountingPayInvestorsRouteImport } from './routes/accounting/pay-investors'
 import { Route as InversionesLiquidacionesIndexRouteImport } from './routes/inversiones/liquidaciones.index'
+import { Route as CrmReportesIndexRouteImport } from './routes/crm/reportes/index'
 import { Route as CrmAnalysisIndexRouteImport } from './routes/crm/analysis/index'
 import { Route as AdminReportsIndexRouteImport } from './routes/admin/reports/index'
 import { Route as JuridicoGenerateOpportunityIdRouteImport } from './routes/juridico/generate.$opportunityId'
@@ -201,6 +202,11 @@ const InversionesLiquidacionesIndexRoute =
     path: '/inversiones/liquidaciones/',
     getParentRoute: () => rootRouteImport,
   } as any)
+const CrmReportesIndexRoute = CrmReportesIndexRouteImport.update({
+  id: '/crm/reportes/',
+  path: '/crm/reportes/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CrmAnalysisIndexRoute = CrmAnalysisIndexRouteImport.update({
   id: '/crm/analysis/',
   path: '/crm/analysis/',
@@ -291,6 +297,7 @@ export interface FileRoutesByFullPath {
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports/': typeof AdminReportsIndexRoute
   '/crm/analysis/': typeof CrmAnalysisIndexRoute
+  '/crm/reportes/': typeof CrmReportesIndexRoute
   '/inversiones/liquidaciones/': typeof InversionesLiquidacionesIndexRoute
 }
 export interface FileRoutesByTo {
@@ -332,6 +339,7 @@ export interface FileRoutesByTo {
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports': typeof AdminReportsIndexRoute
   '/crm/analysis': typeof CrmAnalysisIndexRoute
+  '/crm/reportes': typeof CrmReportesIndexRoute
   '/inversiones/liquidaciones': typeof InversionesLiquidacionesIndexRoute
 }
 export interface FileRoutesById {
@@ -374,6 +382,7 @@ export interface FileRoutesById {
   '/juridico/generate/$opportunityId': typeof JuridicoGenerateOpportunityIdRoute
   '/admin/reports/': typeof AdminReportsIndexRoute
   '/crm/analysis/': typeof CrmAnalysisIndexRoute
+  '/crm/reportes/': typeof CrmReportesIndexRoute
   '/inversiones/liquidaciones/': typeof InversionesLiquidacionesIndexRoute
 }
 export interface FileRouteTypes {
@@ -417,6 +426,7 @@ export interface FileRouteTypes {
     | '/juridico/generate/$opportunityId'
     | '/admin/reports/'
     | '/crm/analysis/'
+    | '/crm/reportes/'
     | '/inversiones/liquidaciones/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -458,6 +468,7 @@ export interface FileRouteTypes {
     | '/juridico/generate/$opportunityId'
     | '/admin/reports'
     | '/crm/analysis'
+    | '/crm/reportes'
     | '/inversiones/liquidaciones'
   id:
     | '__root__'
@@ -499,6 +510,7 @@ export interface FileRouteTypes {
     | '/juridico/generate/$opportunityId'
     | '/admin/reports/'
     | '/crm/analysis/'
+    | '/crm/reportes/'
     | '/inversiones/liquidaciones/'
   fileRoutesById: FileRoutesById
 }
@@ -541,6 +553,7 @@ export interface RootRouteChildren {
   JuridicoGenerateOpportunityIdRoute: typeof JuridicoGenerateOpportunityIdRoute
   AdminReportsIndexRoute: typeof AdminReportsIndexRoute
   CrmAnalysisIndexRoute: typeof CrmAnalysisIndexRoute
+  CrmReportesIndexRoute: typeof CrmReportesIndexRoute
   InversionesLiquidacionesIndexRoute: typeof InversionesLiquidacionesIndexRoute
 }
 
@@ -756,6 +769,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof InversionesLiquidacionesIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/crm/reportes/': {
+      id: '/crm/reportes/'
+      path: '/crm/reportes'
+      fullPath: '/crm/reportes/'
+      preLoaderRoute: typeof CrmReportesIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/crm/analysis/': {
       id: '/crm/analysis/'
       path: '/crm/analysis'
@@ -862,6 +882,7 @@ const rootRouteChildren: RootRouteChildren = {
   JuridicoGenerateOpportunityIdRoute: JuridicoGenerateOpportunityIdRoute,
   AdminReportsIndexRoute: AdminReportsIndexRoute,
   CrmAnalysisIndexRoute: CrmAnalysisIndexRoute,
+  CrmReportesIndexRoute: CrmReportesIndexRoute,
   InversionesLiquidacionesIndexRoute: InversionesLiquidacionesIndexRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -536,6 +536,17 @@ function RouteComponent() {
 		enabled: canAccessClosedCreditsReport,
 	});
 
+	// Si la página quedó fuera de rango (datos borrados / page stale), el total
+	// del server sigue siendo correcto: volvemos a la última página válida en vez
+	// de mostrar el mes vacío.
+	useEffect(() => {
+		const total = closedCreditsReport.data?.total ?? 0;
+		const totalPages = Math.max(1, Math.ceil(total / CLOSED_CREDITS_PAGE_SIZE));
+		if (closedCreditsPage > totalPages) {
+			setClosedCreditsPage(totalPages);
+		}
+	}, [closedCreditsReport.data?.total, closedCreditsPage]);
+
 	const montoCobrarQuery = useQuery({
 		...orpc.getMontoACobrarPeriodo.queryOptions({
 			input: {

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -15,7 +15,7 @@ import {
 	TrendingUp,
 	Wallet,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useState } from "react";
 import {
 	Bar,
 	BarChart,
@@ -395,6 +395,27 @@ function SimularButton({ onClick }: { onClick: () => void }) {
 			<Sparkles className="h-3.5 w-3.5 text-purple-500" />
 			Simular
 		</Button>
+	);
+}
+
+// Un control de filtro con su etiqueta encima. Da jerarquía a las barras de
+// filtros: cada control dice qué controla, agrupados visualmente.
+function FilterField({
+	label,
+	className,
+	children,
+}: {
+	label: string;
+	className?: string;
+	children: ReactNode;
+}) {
+	return (
+		<div className={`flex flex-col gap-1.5 ${className ?? ""}`}>
+			<span className="font-medium text-[11px] text-muted-foreground uppercase tracking-wide">
+				{label}
+			</span>
+			{children}
+		</div>
 	);
 }
 
@@ -1216,7 +1237,7 @@ function RouteComponent() {
 							{/* Reporte: Monto a Cobrarse por Período */}
 							<Card>
 								<CardHeader>
-									<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+									<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
 										<div className="flex items-center gap-2">
 											<CalendarDays className="h-5 w-5 text-blue-500" />
 											<div>
@@ -1227,8 +1248,11 @@ function RouteComponent() {
 												</CardDescription>
 											</div>
 										</div>
-										<div className="flex flex-wrap items-center gap-2">
-											<SimularButton onClick={() => setScenarioOpen("monto")} />
+										<SimularButton onClick={() => setScenarioOpen("monto")} />
+									</div>
+
+									<div className="mt-4 flex flex-wrap items-end gap-x-5 gap-y-3 rounded-lg border bg-muted/30 px-4 py-3">
+										<FilterField label="Período">
 											<Select
 												value={montoCobrarPeriodo}
 												onValueChange={(v) => {
@@ -1253,6 +1277,9 @@ function RouteComponent() {
 													<SelectItem value="anio">Año</SelectItem>
 												</SelectContent>
 											</Select>
+										</FilterField>
+
+										<FilterField label="Rango">
 											<PeriodDatePicker
 												periodo={montoCobrarPeriodo}
 												fechaInicio={montoCobrarRange.fechaInicio}
@@ -1261,6 +1288,9 @@ function RouteComponent() {
 													setMontoCobrarRange({ fechaInicio, fechaFin })
 												}
 											/>
+										</FilterField>
+
+										<FilterField label="Vista" className="sm:ml-auto">
 											<Select
 												value={montoCobrarAcumulado ? "acumulado" : "periodo"}
 												onValueChange={(v) =>
@@ -1275,7 +1305,7 @@ function RouteComponent() {
 													<SelectItem value="acumulado">Acumulado</SelectItem>
 												</SelectContent>
 											</Select>
-										</div>
+										</FilterField>
 									</div>
 								</CardHeader>
 								<CardContent className="space-y-6">
@@ -1468,17 +1498,20 @@ function RouteComponent() {
 																		{formatCurrency(membresias)}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		<div>
-																			{formatCurrency(row.total_mora)}
+																		<div>{formatCurrency(row.total_mora)}</div>
+																		<div
+																			className="text-muted-foreground text-xs"
+																			title="% de créditos del período con mora activa"
+																		>
+																			{row.total_credits > 0
+																				? (
+																						(row.credits_con_mora /
+																							row.total_credits) *
+																						100
+																					).toFixed(1)
+																				: "0.0"}
+																			%
 																		</div>
-																																																																								<div
-																																					className="text-muted-foreground text-xs"
-																																					title="% de créditos del período con mora activa"
-																																				>
-																																					{row.total_credits > 0
-																																						? ((row.credits_con_mora / row.total_credits) * 100).toFixed(1)
-																																						: "0.0"}%
-																																				</div>
 																	</TableCell>
 																	<TableCell className="text-right font-bold">
 																		{formatCurrency(total)}
@@ -1701,7 +1734,7 @@ function RouteComponent() {
 																		formatCurrency(totalEsperado)
 																	) : (
 																		<span className="text-base text-muted-foreground">
-																			Sin meta
+																			Por definir
 																		</span>
 																	)}
 																</p>
@@ -1711,14 +1744,22 @@ function RouteComponent() {
 																	Avance
 																</p>
 																<p className="font-bold text-2xl">
-																	{pct.toFixed(1)}%
+																	{totalEsperado > 0 ? (
+																		`${pct.toFixed(1)}%`
+																	) : (
+																		<span className="text-base text-muted-foreground">
+																			—
+																		</span>
+																	)}
 																</p>
 															</div>
 														</div>
-														<ProgressBar
-															value={totalCobrado}
-															max={totalEsperado}
-														/>
+														{totalEsperado > 0 && (
+															<ProgressBar
+																value={totalCobrado}
+																max={totalEsperado}
+															/>
+														)}
 													</div>
 
 													{/* Desglose por rubro */}
@@ -2515,7 +2556,7 @@ function RouteComponent() {
 							{/* Cobertura de Colocación vs Meta */}
 							<Card>
 								<CardHeader>
-									<div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+									<div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
 										<div className="flex items-center gap-2">
 											<TrendingUp className="h-5 w-5 text-green-500" />
 											<div>
@@ -2526,7 +2567,7 @@ function RouteComponent() {
 												</CardDescription>
 											</div>
 										</div>
-										<div className="flex flex-wrap items-center gap-2">
+										<div className="flex items-center gap-2">
 											<SimularButton
 												onClick={() => setScenarioOpen("cobertura")}
 											/>
@@ -2539,6 +2580,11 @@ function RouteComponent() {
 												<Target className="h-3.5 w-3.5" />
 												Configurar metas
 											</Button>
+										</div>
+									</div>
+
+									<div className="mt-4 flex flex-wrap items-end gap-x-5 gap-y-3 rounded-lg border bg-muted/30 px-4 py-3">
+										<FilterField label="Período">
 											<Select
 												value={equilibrioPeriodo}
 												onValueChange={(v) =>
@@ -2563,6 +2609,9 @@ function RouteComponent() {
 													<SelectItem value="anio">Año</SelectItem>
 												</SelectContent>
 											</Select>
+										</FilterField>
+
+										<FilterField label="Rango">
 											<DateRangeFilter
 												dateRange={
 													equilibrioRange.fechaInicio &&
@@ -2584,7 +2633,7 @@ function RouteComponent() {
 													}
 												}}
 											/>
-										</div>
+										</FilterField>
 									</div>
 								</CardHeader>
 								<CardContent className="space-y-4">

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -16,7 +16,6 @@ import {
 	Wallet,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import type { DateRange } from "react-day-picker";
 import {
 	Bar,
 	BarChart,
@@ -254,6 +253,18 @@ function dateFromInput(value: string) {
 	return new Date(`${value}T12:00:00`);
 }
 
+// Fecha legible en zona Guatemala, p.ej. "17 jun 2026".
+function formatFechaCorta(value: string | Date | null | undefined): string {
+	if (!value) return "-";
+	const date = typeof value === "string" ? new Date(value) : value;
+	return new Intl.DateTimeFormat("es-GT", {
+		timeZone: GUATEMALA_TIME_ZONE,
+		day: "2-digit",
+		month: "short",
+		year: "numeric",
+	}).format(date);
+}
+
 function getDefaultMontoCobrarRange(): {
 	fechaInicio: string;
 	fechaFin: string;
@@ -375,41 +386,8 @@ function fillMissingPeriods(
 	});
 }
 
-function getDefaultClosedCreditsRange(): DateRange {
-	const today = dateFromInput(formatDateInput(new Date()));
-	const start = new Date(today);
-	start.setDate(today.getDate() - 14);
-	return { from: start, to: today };
-}
-
-function buildClosedCreditsInput(dateRange: DateRange | undefined) {
-	if (!dateRange?.from || !dateRange?.to) return null;
-	return {
-		startDate: formatDateInput(dateRange.from),
-		endDate: formatDateInput(dateRange.to),
-	};
-}
-
-function escapeCsvValue(value: string | number | null | undefined) {
-	const raw = value == null ? "" : String(value);
-	if (/[",\n\r]/.test(raw)) {
-		return `"${raw.replaceAll('"', '""')}"`;
-	}
-	return raw;
-}
-
-function downloadCsv(filename: string, rows: (string | number | null)[][]) {
-	const csv = `\uFEFF${rows
-		.map((row) => row.map((value) => escapeCsvValue(value)).join(","))
-		.join("\n")}`;
-	const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
-	const url = URL.createObjectURL(blob);
-	const link = document.createElement("a");
-	link.href = url;
-	link.download = filename;
-	link.click();
-	URL.revokeObjectURL(url);
-}
+// Filas por página del reporte "Créditos cerrados" (paginado del lado servidor).
+const CLOSED_CREDITS_PAGE_SIZE = 25;
 
 function SimularButton({ onClick }: { onClick: () => void }) {
 	return (
@@ -443,10 +421,12 @@ function RouteComponent() {
 		isPending,
 	} = authClient.useSession();
 	const navigate = Route.useNavigate();
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(undefined);
-	const [closedCreditsRange, setClosedCreditsRange] = useState<
-		DateRange | undefined
-	>(getDefaultClosedCreditsRange);
+	const [closedCreditsMes, setClosedCreditsMes] = useState(() => ({
+		mes: new Date().getMonth() + 1,
+		anio: new Date().getFullYear(),
+	}));
+	const [closedCreditsPage, setClosedCreditsPage] = useState(1);
+	const [isExportingCerrados, setIsExportingCerrados] = useState(false);
 	const [montoCobrarPeriodo, setMontoCobrarPeriodo] = useState<
 		"anio" | "trimestre" | "mes" | "semana" | "dia"
 	>("mes");
@@ -515,23 +495,24 @@ function RouteComponent() {
 		? PERMISSIONS.canAccessClosedCreditsReport(userRole)
 		: false;
 	const canAccessReports = isAdmin || canAccessClosedCreditsReport;
-	const closedCreditsInput = buildClosedCreditsInput(closedCreditsRange);
 
 	const dashboardData = useQuery({
 		...orpc.getDashboardExecutivo.queryOptions({
-			input: {
-				startDate: dateRange?.from?.toISOString(),
-				endDate: dateRange?.to?.toISOString(),
-			},
+			input: {},
 		}),
 		enabled: isAdmin,
 	});
 
 	const closedCreditsReport = useQuery({
 		...orpc.getReporteCreditosCerrados.queryOptions({
-			input: closedCreditsInput ?? { startDate: "", endDate: "" },
+			input: {
+				anio: closedCreditsMes.anio,
+				mes: closedCreditsMes.mes,
+				page: closedCreditsPage,
+				pageSize: CLOSED_CREDITS_PAGE_SIZE,
+			},
 		}),
-		enabled: canAccessClosedCreditsReport && !!closedCreditsInput,
+		enabled: canAccessClosedCreditsReport,
 	});
 
 	const montoCobrarQuery = useQuery({
@@ -757,58 +738,56 @@ function RouteComponent() {
 		}),
 	);
 
-	const setClosedCreditsPreset = (preset: "week" | "last15" | "month") => {
-		const today = dateFromInput(formatDateInput(new Date()));
-
-		if (preset === "last15") {
-			const start = new Date(today);
-			start.setDate(today.getDate() - 14);
-			setClosedCreditsRange({ from: start, to: today });
-			return;
-		}
-
-		if (preset === "month") {
-			setClosedCreditsRange({
-				from: new Date(today.getFullYear(), today.getMonth(), 1),
-				to: new Date(today.getFullYear(), today.getMonth() + 1, 0),
+	// Exporta TODO el mes (sin paginar): se pide al server sin `pageSize`.
+	const exportClosedCreditsExcel = async () => {
+		setIsExportingCerrados(true);
+		try {
+			const res = await client.getReporteCreditosCerrados({
+				anio: closedCreditsMes.anio,
+				mes: closedCreditsMes.mes,
 			});
-			return;
+			const headers = [
+				"Fecha de Cierre",
+				"Nombre del Cliente",
+				"SIFCO",
+				"Cuota de Seguro",
+				"Monto del Crédito",
+				"Cuota del Crédito",
+				"Día de Pago",
+			];
+			const data = res.rows.map((row) => [
+				row.fechaCierre ? formatFechaCorta(row.fechaCierre) : "",
+				row.clienteNombre || "",
+				row.numeroSifco || "",
+				Number(row.cuotaSeguro ?? 0),
+				Number(row.montoCredito ?? 0),
+				Number(row.cuotaCredito ?? 0),
+				row.diaPago ?? "",
+			]);
+			const worksheet = XLSX.utils.aoa_to_sheet([headers, ...data]);
+			const workbook = XLSX.utils.book_new();
+			XLSX.utils.book_append_sheet(workbook, worksheet, "Créditos cerrados");
+			XLSX.writeFile(
+				workbook,
+				`creditos-cerrados-${closedCreditsMes.anio}-${String(
+					closedCreditsMes.mes,
+				).padStart(2, "0")}.xlsx`,
+			);
+		} catch (err) {
+			toast.error(
+				err instanceof Error ? err.message : "Error al exportar el reporte",
+			);
+		} finally {
+			setIsExportingCerrados(false);
 		}
-
-		const day = today.getDay();
-		const daysSinceMonday = day === 0 ? 6 : day - 1;
-		const start = new Date(today);
-		start.setDate(today.getDate() - daysSinceMonday);
-		const end = new Date(start);
-		end.setDate(start.getDate() + 6);
-		setClosedCreditsRange({ from: start, to: end });
 	};
 
-	const exportClosedCreditsCsv = () => {
-		if (!closedCreditsInput) return;
-		const rows = closedCreditsReport.data ?? [];
-		downloadCsv(
-			`creditos-cerrados-${closedCreditsInput.startDate}-a-${closedCreditsInput.endDate}.csv`,
-			[
-				[
-					"Placa",
-					"Chasis",
-					"Cuota de Seguro",
-					"Nombre del Cliente",
-					"Número de Crédito",
-					"Fecha 90%+",
-				],
-				...rows.map((row) => [
-					row.placa ?? "",
-					row.chasis ?? "",
-					row.cuotaSeguro ?? "",
-					row.clienteNombre ?? "",
-					row.numeroCredito ?? "",
-					row.fecha90 ? formatDateInput(new Date(row.fecha90)) : "",
-				]),
-			],
-		);
-	};
+	const closedCreditsRows = closedCreditsReport.data?.rows ?? [];
+	const closedCreditsTotal = closedCreditsReport.data?.total ?? 0;
+	const closedCreditsTotalPages = Math.max(
+		1,
+		Math.ceil(closedCreditsTotal / CLOSED_CREDITS_PAGE_SIZE),
+	);
 
 	const creditosCerradosCard = (
 		<Card>
@@ -817,42 +796,52 @@ function RouteComponent() {
 					<div>
 						<CardTitle>Créditos cerrados</CardTitle>
 						<CardDescription>
-							Créditos que llegaron por primera vez a una etapa 90%+.
+							Oportunidades ganadas, según el mes en que se cerraron.
 						</CardDescription>
 					</div>
 					<div className="flex flex-wrap items-center gap-2">
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => setClosedCreditsPreset("week")}
+						<Select
+							value={String(closedCreditsMes.mes)}
+							onValueChange={(v) => {
+								setClosedCreditsMes((prev) => ({ ...prev, mes: Number(v) }));
+								setClosedCreditsPage(1);
+							}}
 						>
-							Esta semana
-						</Button>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => setClosedCreditsPreset("last15")}
-						>
-							Últimos 15 días
-						</Button>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => setClosedCreditsPreset("month")}
-						>
-							Este mes
-						</Button>
-						<DateRangeFilter
-							dateRange={closedCreditsRange}
-							onDateRangeChange={setClosedCreditsRange}
-							required
+							<SelectTrigger className="w-36">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{MESES.map((label, i) => (
+									<SelectItem key={label} value={String(i + 1)}>
+										{label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						<Input
+							type="number"
+							className="w-24"
+							value={closedCreditsMes.anio}
+							min={2020}
+							max={2100}
+							onChange={(e) => {
+								setClosedCreditsMes((prev) => ({
+									...prev,
+									anio: Number(e.target.value),
+								}));
+								setClosedCreditsPage(1);
+							}}
 						/>
 						<Button
-							onClick={exportClosedCreditsCsv}
-							disabled={!closedCreditsReport.data?.length}
+							onClick={exportClosedCreditsExcel}
+							disabled={isExportingCerrados || closedCreditsTotal === 0}
 						>
-							<Download className="mr-2 h-4 w-4" />
-							Exportar CSV
+							{isExportingCerrados ? (
+								<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+							) : (
+								<Download className="mr-2 h-4 w-4" />
+							)}
+							Exportar Excel
 						</Button>
 					</div>
 				</div>
@@ -862,43 +851,95 @@ function RouteComponent() {
 				{closedCreditsReport.isError && (
 					<p className="text-destructive">Error al cargar el reporte.</p>
 				)}
-				{closedCreditsReport.data?.length === 0 && (
+				{closedCreditsReport.data && closedCreditsTotal === 0 && (
 					<p className="text-muted-foreground">
-						No hay créditos cerrados para el rango seleccionado.
+						No hay créditos cerrados para el mes seleccionado.
 					</p>
 				)}
-				{!!closedCreditsReport.data?.length && (
-					<div className="overflow-x-auto">
-						<Table>
-							<TableHeader>
-								<TableRow>
-									<TableHead>Placa</TableHead>
-									<TableHead>Chasis</TableHead>
-									<TableHead>Cuota de Seguro</TableHead>
-									<TableHead>Nombre del Cliente</TableHead>
-									<TableHead>Número de Crédito</TableHead>
-									<TableHead>Fecha 90%+</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{closedCreditsReport.data.map((row) => (
-									<TableRow
-										key={`${row.numeroCredito}-${row.fecha90}-${row.placa}-${row.chasis}`}
-									>
-										<TableCell>{row.placa || "-"}</TableCell>
-										<TableCell>{row.chasis || "-"}</TableCell>
-										<TableCell>{formatCurrency(row.cuotaSeguro)}</TableCell>
-										<TableCell>{row.clienteNombre || "-"}</TableCell>
-										<TableCell>{row.numeroCredito || "-"}</TableCell>
-										<TableCell>
-											{row.fecha90
-												? formatDateInput(new Date(row.fecha90))
-												: "-"}
-										</TableCell>
+				{closedCreditsRows.length > 0 && (
+					<div className="space-y-4">
+						<div className="overflow-x-auto [&_td]:px-5 [&_th]:px-5">
+							<Table className="tabular-nums">
+								<TableHeader>
+									<TableRow>
+										<TableHead>Fecha de Cierre</TableHead>
+										<TableHead>Cliente / SIFCO</TableHead>
+										<TableHead className="text-right">
+											Cuota de Seguro
+										</TableHead>
+										<TableHead className="text-right">
+											Monto del Crédito
+										</TableHead>
+										<TableHead className="text-right">
+											Cuota del Crédito
+										</TableHead>
+										<TableHead className="text-right">Día de Pago</TableHead>
 									</TableRow>
-								))}
-							</TableBody>
-						</Table>
+								</TableHeader>
+								<TableBody>
+									{closedCreditsRows.map((row) => (
+										<TableRow key={row.id}>
+											<TableCell>{formatFechaCorta(row.fechaCierre)}</TableCell>
+											<TableCell>
+												<div className="font-medium">
+													{row.clienteNombre || "-"}
+												</div>
+												<div className="text-muted-foreground text-xs">
+													{row.numeroSifco || "Sin SIFCO"}
+												</div>
+											</TableCell>
+											<TableCell className="text-right">
+												{formatCurrency(row.cuotaSeguro)}
+											</TableCell>
+											<TableCell className="text-right">
+												{formatCurrency(row.montoCredito)}
+											</TableCell>
+											<TableCell className="text-right">
+												{row.cuotaCredito
+													? formatCurrency(row.cuotaCredito)
+													: "-"}
+											</TableCell>
+											<TableCell className="text-right">
+												{row.diaPago ?? "-"}
+											</TableCell>
+										</TableRow>
+									))}
+								</TableBody>
+							</Table>
+						</div>
+						<div className="flex items-center justify-between">
+							<p className="text-muted-foreground text-sm">
+								{closedCreditsTotal}{" "}
+								{closedCreditsTotal === 1 ? "crédito" : "créditos"} · Página{" "}
+								{closedCreditsPage} de {closedCreditsTotalPages}
+							</p>
+							<div className="flex items-center gap-2">
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() =>
+										setClosedCreditsPage((p) => Math.max(1, p - 1))
+									}
+									disabled={closedCreditsPage <= 1}
+								>
+									<ChevronLeft className="h-4 w-4" />
+									Anterior
+								</Button>
+								<Button
+									variant="outline"
+									size="sm"
+									onClick={() =>
+										setClosedCreditsPage((p) =>
+											Math.min(closedCreditsTotalPages, p + 1),
+										)
+									}
+									disabled={closedCreditsPage >= closedCreditsTotalPages}
+								>
+									Siguiente
+									<ChevronRight className="h-4 w-4" />
+								</Button>
+							</div>
+						</div>
 					</div>
 				)}
 			</CardContent>
@@ -918,12 +959,6 @@ function RouteComponent() {
 							: "Reportes disponibles para el área de cobros"}
 					</p>
 				</div>
-				{isAdmin && (
-					<DateRangeFilter
-						dateRange={dateRange}
-						onDateRangeChange={setDateRange}
-					/>
-				)}
 			</div>
 
 			{!isAdmin && canAccessClosedCreditsReport && creditosCerradosCard}
@@ -931,15 +966,19 @@ function RouteComponent() {
 			{isAdmin && (
 				<>
 					<Tabs
-						defaultValue={canAccessClosedCreditsReport ? "creditos" : "resumen"}
+						defaultValue={
+							canAccessClosedCreditsReport ? "creditos" : "cobranza"
+						}
 						className="space-y-6"
 					>
 						<TabsList>
 							{canAccessClosedCreditsReport && (
 								<TabsTrigger value="creditos">Créditos cerrados</TabsTrigger>
 							)}
-							<TabsTrigger value="resumen">Resumen</TabsTrigger>
-							<TabsTrigger value="graficas">Gráficas</TabsTrigger>
+							{/* Tabs "Resumen" y "Gráficas" ocultos a propósito. Las
+							    secciones (TabsContent value="resumen" / "graficas") se
+							    conservan más abajo por si se quieren reutilizar; para
+							    volver a mostrarlas, reañadir aquí sus TabsTrigger. */}
 							<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
 							<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
 							<TabsTrigger value="colocacion">Colocación</TabsTrigger>

--- a/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
@@ -1,0 +1,119 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { useEffect } from "react";
+import { toast } from "sonner";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+import { MetaColocacionContent } from "./meta-colocacion";
+import { PorcentajeEfectividadContent } from "./porcentaje-efectividad";
+import { TiempoCierreContent } from "./tiempo-cierre";
+
+export const Route = createFileRoute("/crm/reportes/")({
+	component: RouteComponent,
+});
+
+function RouteComponent() {
+	const {
+		data: session,
+		error: sessionError,
+		isPending: sessionPending,
+	} = authClient.useSession();
+	const navigate = useNavigate();
+
+	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
+	const userRole = userProfile.data?.role;
+	const canTiempo = userRole
+		? PERMISSIONS.canAccessTiempoCierreReport(userRole)
+		: false;
+	const canEfectividad = userRole
+		? PERMISSIONS.canAccessPorcentajeEfectividadReport(userRole)
+		: false;
+	const canMeta = userRole
+		? PERMISSIONS.canAccessMetaColocacionReport(userRole)
+		: false;
+	const canAny = canTiempo || canEfectividad || canMeta;
+	const isPending = sessionPending || userProfile.isPending;
+
+	useEffect(() => {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
+			navigate({ to: "/login" });
+		} else if (session && !userProfile.isPending && !canAny) {
+			navigate({ to: "/dashboard" });
+			toast.error("Acceso denegado");
+		}
+	}, [
+		session,
+		sessionError,
+		sessionPending,
+		userProfile.isPending,
+		canAny,
+		navigate,
+	]);
+
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAny) return null;
+
+	const defaultTab = canTiempo
+		? "tiempo"
+		: canEfectividad
+			? "efectividad"
+			: "meta";
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<div>
+				<h1 className="font-bold text-3xl tracking-tight">Reportes</h1>
+				<p className="mt-1 text-muted-foreground">
+					Reportes de ventas: tiempo de cierre, efectividad y meta de
+					colocación.
+				</p>
+			</div>
+
+			<Tabs defaultValue={defaultTab} className="space-y-6">
+				<TabsList>
+					{canTiempo && (
+						<TabsTrigger value="tiempo">Tiempo Cierre Crédito</TabsTrigger>
+					)}
+					{canEfectividad && (
+						<TabsTrigger value="efectividad">Porcentaje Efectividad</TabsTrigger>
+					)}
+					{canMeta && (
+						<TabsTrigger value="meta">Meta Colocación</TabsTrigger>
+					)}
+				</TabsList>
+
+				{canTiempo && (
+					<TabsContent value="tiempo" className="space-y-6">
+						<TiempoCierreContent />
+					</TabsContent>
+				)}
+				{canEfectividad && (
+					<TabsContent value="efectividad" className="space-y-6">
+						<PorcentajeEfectividadContent />
+					</TabsContent>
+				)}
+				{canMeta && (
+					<TabsContent value="meta" className="space-y-6">
+						<MetaColocacionContent />
+					</TabsContent>
+				)}
+			</Tabs>
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
@@ -86,10 +86,6 @@ function RouteComponent() {
 	const isPending =
 		sessionPending || userProfile.isPending || (!session && !sessionError);
 
-	const now = nowGT();
-	const [mes, setMes] = useState<number>(now.getUTCMonth() + 1);
-	const [anio, setAnio] = useState<number>(now.getUTCFullYear());
-
 	useEffect(() => {
 		if (
 			shouldRedirectToLogin({
@@ -112,11 +108,6 @@ function RouteComponent() {
 		navigate,
 	]);
 
-	const reportQuery = useQuery({
-		...orpc.getReporteMetaColocacion.queryOptions({ input: { anio, mes } }),
-		enabled: canAccess,
-	});
-
 	if (isPending) {
 		return (
 			<div className="flex h-96 items-center justify-center text-muted-foreground">
@@ -126,6 +117,22 @@ function RouteComponent() {
 	}
 
 	if (!canAccess) return null;
+
+	return (
+		<div className="container mx-auto max-w-5xl space-y-6 p-6">
+			<MetaColocacionContent />
+		</div>
+	);
+}
+
+export function MetaColocacionContent() {
+	const now = nowGT();
+	const [mes, setMes] = useState<number>(now.getUTCMonth() + 1);
+	const [anio, setAnio] = useState<number>(now.getUTCFullYear());
+
+	const reportQuery = useQuery(
+		orpc.getReporteMetaColocacion.queryOptions({ input: { anio, mes } }),
+	);
 
 	const data = reportQuery.data;
 	const isLoading = reportQuery.isLoading;
@@ -139,7 +146,7 @@ function RouteComponent() {
 	const porColaborador = data?.porColaborador ?? [];
 
 	return (
-		<div className="container mx-auto max-w-5xl space-y-6 p-6">
+		<div className="space-y-6">
 			{/* Header */}
 			<div>
 				<h1 className="font-bold text-2xl">Meta de Colocación</h1>

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -109,12 +109,6 @@ function sanitizeCSVCell(value: string): string {
 }
 
 function RouteComponent() {
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(
-		getDefaultDateRange,
-	);
-	const [pageSize, setPageSize] = useState(25);
-	const [page, setPage] = useState(0);
-
 	const {
 		data: session,
 		error: sessionError,
@@ -151,6 +145,30 @@ function RouteComponent() {
 		navigate,
 	]);
 
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAccess) return null;
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<PorcentajeEfectividadContent />
+		</div>
+	);
+}
+
+export function PorcentajeEfectividadContent() {
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(
+		getDefaultDateRange,
+	);
+	const [pageSize, setPageSize] = useState(25);
+	const [page, setPage] = useState(0);
+
 	const input =
 		dateRange?.from && dateRange?.to
 			? {
@@ -163,23 +181,13 @@ function RouteComponent() {
 		...orpc.getReportePorcentajeEfectividad.queryOptions({
 			input: input ?? { startDate: "", endDate: "" },
 		}),
-		enabled: canAccess && !!input,
+		enabled: !!input,
 	});
 
 	// Reiniciar página al recibir datos nuevos
 	useEffect(() => {
 		setPage(0);
 	}, [reportQuery.data]);
-
-	if (isPending) {
-		return (
-			<div className="flex h-96 items-center justify-center text-muted-foreground">
-				Cargando...
-			</div>
-		);
-	}
-
-	if (!canAccess) return null;
 
 	const data = reportQuery.data;
 	const isLoading = reportQuery.isLoading;
@@ -236,7 +244,7 @@ function RouteComponent() {
 	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
 
 	return (
-		<div className="container mx-auto space-y-6 p-6">
+		<div className="space-y-6">
 			<div>
 				<h1 className="font-bold text-3xl tracking-tight">
 					Porcentaje Efectividad

--- a/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
@@ -106,6 +106,24 @@ function RouteComponent() {
 		}
 	}, [session, sessionError, sessionPending, userProfile.isPending, canAccess, navigate]);
 
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAccess) return null;
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<TiempoCierreContent />
+		</div>
+	);
+}
+
+export function TiempoCierreContent() {
 	const [dateRange, setDateRange] = useState<DateRange | undefined>(getDefaultDateRange);
 
 	const input =
@@ -117,18 +135,8 @@ function RouteComponent() {
 		...orpc.getReporteTiempoCierre.queryOptions({
 			input: input ?? { startDate: "", endDate: "" },
 		}),
-		enabled: canAccess && !!input,
+		enabled: !!input,
 	});
-
-	if (isPending) {
-		return (
-			<div className="flex h-96 items-center justify-center text-muted-foreground">
-				Cargando...
-			</div>
-		);
-	}
-
-	if (!canAccess) return null;
 
 	const data = reportQuery.data;
 	const isLoading = reportQuery.isLoading;
@@ -147,7 +155,7 @@ function RouteComponent() {
 	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
 
 	return (
-		<div className="container mx-auto space-y-6 p-6">
+		<div className="space-y-6">
 			<div>
 				<h1 className="font-bold text-3xl tracking-tight">
 					Tiempo Cierre Crédito


### PR DESCRIPTION
## Resumen

Cambios de reportes (admin y ventas) + navegación responsive.

### Reportes Admin (`/admin/reports`)
- **Créditos cerrados** reescrito: ahora son **oportunidades ganadas** filtradas por **fecha de cierre**, con **paginado del lado del servidor**, **export a Excel** (sin paginar) y columnas: Fecha de cierre, Cliente/SIFCO, Cuota de seguro, Monto del crédito, Cuota del crédito, Día de pago.
- Se ocultaron los tabs **Resumen** y **Gráficas** y el selector de fechas global (las secciones se conservan en código por si se reutilizan).
- **Jerarquía visual de filtros**: en *Monto a Cobrarse por Período* y *Cobertura de Colocación vs Meta* se separaron las acciones (Simular / Configurar metas) de los filtros, agrupados en una barra etiquetada (Período / Rango) — helper reutilizable `FilterField`.

### Reportes de Ventas (`/crm/reportes`)
- Nueva página con **tabs** (Tiempo Cierre Crédito, Porcentaje Efectividad, Meta Colocación) reutilizando el contenido de cada reporte.
- El menú **Ventas** pasa de 3 items separados a un solo **Reportes**.

### Menú Admin
- Se quitaron los items **Importación**, **MiniAgent** y **Configuración** (rutas/páginas conservadas).

### Header responsive
- Navegación con **drawer (Sheet)** en mobile (`< md`) y nav horizontal en `md+`. Nuevo componente `ui/sheet`.

## Notas
- Sin cambios de esquema de DB.
- `tsc` y Biome en verde (la deuda de lint preexistente del archivo de reportes no se tocó).

🤖 Generated with [Claude Code](https://claude.com/claude-code)