### PR TITLE
fix(cartera): el cierre de cuota no sobreescribe un pago real

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -3,6 +3,7 @@ import Big from "big.js";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
+  esDestinoSobrescribible,
   getCuotaIdForPaymentInsert,
   getRequestedInstallmentFloor,
   getSpecialPaymentCuotaId,
@@ -303,6 +304,246 @@ describe("regresión: mora/otros no debe colapsar el saldo de la cuota", () => {
       hermanosIva: 0,
     });
     expect(saldo.saldoRealCuota.toFixed(2)).toBe("1000.00");
+  });
+});
+
+// Bug crédito 217 / cuota #8: el placeholder `no_required` de la cuota YA fue
+// consumido por un parcial anterior (esa fila pasó a `validated` con
+// `abono_interes` real, ya facturado). Al llegar el pago que CIERRA la cuota,
+// `pagoOriginal` (no_required) es undefined y `existingPago` cae al fallback
+// `allExistingPagos[0]` = la fila REAL más vieja. El cierre hacía UPDATE sobre
+// esa fila, BORRANDO un pago de interés validado/facturado. El fix: el cierre
+// solo puede UPDATE-ar un destino realmente desechable; si no, INSERTA fila nueva.
+describe("esDestinoSobrescribible", () => {
+  it("el placeholder no_required SIEMPRE es sobrescribible (aunque trajera saldos)", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "no_required",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+      })
+    ).toBe(true);
+  });
+
+  it("una fila vacía (monto_aplicado≈0 y todos los abono_* ≈0) es sobrescribible", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+        abono_iva_12: "0",
+        abono_seguro: "0",
+        abono_gps: "0",
+        membresias_pago: "0",
+      })
+    ).toBe(true);
+  });
+
+  it("tolera centavos de ruido al medir 'vacío'", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "0.00",
+        abono_capital: "0.005",
+        abono_interes: "0",
+      })
+    ).toBe(true);
+  });
+
+  it("un pago REAL (con abono_interes validado) NO es sobrescribible", () => {
+    // Caso crédito 217: fila validated con interés real ya facturado.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "1151.00",
+        abono_capital: "0",
+        abono_interes: "1027.68",
+        abono_iva_12: "123.32",
+        abono_seguro: "0",
+        abono_gps: "0",
+        membresias_pago: "0",
+      })
+    ).toBe(false);
+  });
+
+  it("una fila con monto_aplicado real pero rubros en 0 NO es sobrescribible", () => {
+    // p.ej. fila solo-mora/otros con plata aplicada: no la queremos pisar.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "200.00",
+        abono_capital: "0",
+        abono_interes: "0",
+      })
+    ).toBe(false);
+  });
+
+  it("una fila con solo abono_capital real NO es sobrescribible", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_capital: "500.00",
+        abono_interes: "0",
+      })
+    ).toBe(false);
+  });
+});
+
+// Réplica pura del árbol de decisión insert-vs-update del cierre en
+// `insertPayment` (registerPayment.ts ~1378): NO toca DB; modela exactamente la
+// rama elegida y el conjunto de filas resultante de la cuota, para asegurar que
+// (a) la fila real preexistente nunca se sobrescribe, (b) se INSERTA una fila de
+// cierre, y (c) no se pierde ni se duplica plata en la cuota.
+type FilaCuota = {
+  pago_id: number;
+  validationStatus: string;
+  monto_aplicado: string;
+  abono_capital: string;
+  abono_interes: string;
+  abono_iva_12: string;
+};
+
+const sumaRubrosCuota = (filas: FilaCuota[]) =>
+  filas
+    .reduce(
+      (acc, f) =>
+        acc
+          .plus(new Big(f.abono_capital))
+          .plus(new Big(f.abono_interes))
+          .plus(new Big(f.abono_iva_12)),
+      new Big(0)
+    )
+    .toFixed(2);
+
+/**
+ * Aplica la decisión de cierre tal como lo hace el controlador:
+ *  - pagado && destinoSobrescribible → UPDATE sobre existingPago.
+ *  - pagado && !destinoSobrescribible → INSERT fila de cierre nueva.
+ *  - !pagado → INSERT parcial.
+ * Devuelve el nuevo set de filas de la cuota.
+ */
+const aplicarDecisionCierre = (
+  filas: FilaCuota[],
+  existingPagoId: number,
+  pagoData: {
+    pagado: boolean;
+    abono_capital: string;
+    abono_interes: string;
+    abono_iva_12: string;
+    monto_aplicado: string;
+  }
+): FilaCuota[] => {
+  const existing = filas.find((f) => f.pago_id === existingPagoId)!;
+  const sobrescribible = esDestinoSobrescribible(existing);
+  const nuevaFila: FilaCuota = {
+    pago_id: Math.max(...filas.map((f) => f.pago_id)) + 1,
+    validationStatus: "pending",
+    monto_aplicado: pagoData.monto_aplicado,
+    abono_capital: pagoData.abono_capital,
+    abono_interes: pagoData.abono_interes,
+    abono_iva_12: pagoData.abono_iva_12,
+  };
+
+  if (pagoData.pagado && sobrescribible) {
+    return filas.map((f) =>
+      f.pago_id === existingPagoId
+        ? {
+            ...f,
+            validationStatus: "pending",
+            monto_aplicado: pagoData.monto_aplicado,
+            abono_capital: pagoData.abono_capital,
+            abono_interes: pagoData.abono_interes,
+            abono_iva_12: pagoData.abono_iva_12,
+          }
+        : f
+    );
+  }
+  // INSERT (cierre-nuevo o parcial): se preservan todas las filas previas.
+  return [...filas, nuevaFila];
+};
+
+describe("cierre de cuota: no sobrescribe un pago real cuando el no_required ya fue consumido", () => {
+  it("INSERTA una fila de cierre y conserva la fila validated preexistente (crédito 217 / cuota 8)", () => {
+    // Estado: el placeholder no_required YA fue consumido por un parcial → no
+    // existe fila no_required; queda una fila `validated` con interés real
+    // (Q1151 ya facturado) y la cuota aún tiene capital pendiente.
+    const filasPrevias: FilaCuota[] = [
+      {
+        pago_id: 5001, // fila REAL (parcial validado de interés, ya facturado)
+        validationStatus: "validated",
+        monto_aplicado: "1151.00",
+        abono_capital: "0",
+        abono_interes: "1027.68",
+        abono_iva_12: "123.32",
+      },
+    ];
+    // existingPago cae al fallback allExistingPagos[0] = la fila real 5001.
+    const existingPagoId = 5001;
+    expect(esDestinoSobrescribible(filasPrevias[0])).toBe(false);
+
+    // Pago que CIERRA la cuota: cubre el capital faltante (cuota = 2151).
+    const pagoData = {
+      pagado: true,
+      abono_capital: "1000.00",
+      abono_interes: "0",
+      abono_iva_12: "0",
+      monto_aplicado: "1000.00",
+    };
+
+    const resultado = aplicarDecisionCierre(
+      filasPrevias,
+      existingPagoId,
+      pagoData
+    );
+
+    // (a) la fila validated preexistente NO se modificó.
+    const filaPreexistente = resultado.find((f) => f.pago_id === 5001)!;
+    expect(filaPreexistente.validationStatus).toBe("validated");
+    expect(filaPreexistente.abono_interes).toBe("1027.68");
+    expect(filaPreexistente.monto_aplicado).toBe("1151.00");
+
+    // (b) se INSERTÓ una fila nueva de cierre.
+    expect(resultado).toHaveLength(2);
+    const filaCierre = resultado.find((f) => f.pago_id !== 5001)!;
+    expect(filaCierre.abono_capital).toBe("1000.00");
+
+    // (c) Σ de rubros de la cuota = composición real (1151 previo + 1000 cierre
+    //     = 2151), sin perder ni duplicar plata.
+    expect(sumaRubrosCuota(resultado)).toBe("2151.00");
+  });
+
+  it("comportamiento intacto: con placeholder no_required vivo el cierre hace UPDATE (no inserta)", () => {
+    // Caso normal: existe el placeholder no_required (sin rubros). El cierre lo
+    // sobrescribe (UPDATE) → NO crece el número de filas.
+    const filasPrevias: FilaCuota[] = [
+      {
+        pago_id: 7001, // placeholder no_required (pago_id == cuota_id típicamente)
+        validationStatus: "no_required",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+        abono_iva_12: "0",
+      },
+    ];
+    const pagoData = {
+      pagado: true,
+      abono_capital: "1900.00",
+      abono_interes: "224.11",
+      abono_iva_12: "26.89",
+      monto_aplicado: "2151.00",
+    };
+
+    const resultado = aplicarDecisionCierre(filasPrevias, 7001, pagoData);
+
+    // UPDATE: misma cantidad de filas, el placeholder ahora trae el cierre.
+    expect(resultado).toHaveLength(1);
+    expect(resultado[0].pago_id).toBe(7001);
+    expect(resultado[0].validationStatus).toBe("pending");
+    expect(resultado[0].abono_capital).toBe("1900.00");
+    expect(sumaRubrosCuota(resultado)).toBe("2151.00");
   });
 });
 

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -407,6 +407,41 @@ describe("esDestinoSobrescribible", () => {
       })
     ).toBe(false);
   });
+
+  it("un pago de solo MORA (monto_aplicado/abono_* en 0) NO es sobrescribible", () => {
+    // Codex P2: insertarPago crea filas mora/otros con monto_aplicado:0 y
+    // abono_* en 0 pero plata en mora. No debe tratarse como vacío.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+        mora: "150.00",
+      })
+    ).toBe(false);
+  });
+
+  it("un pago de solo OTROS (TEXT con monto) NO es sobrescribible", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_interes: "0",
+        otros: "300.00",
+      })
+    ).toBe(false);
+  });
+
+  it("una fila con `otros` vacío/no-numérico SÍ puede ser vacía", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "no_required",
+        monto_aplicado: "0",
+        otros: "",
+      })
+    ).toBe(true);
+  });
 });
 
 // Réplica pura del árbol de decisión insert-vs-update del cierre en

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -352,6 +352,23 @@ describe("esDestinoSobrescribible", () => {
     ).toBe(true);
   });
 
+  it("un pago real de EXACTAMENTE Q0.01 NO es sobrescribible (numeric(2) es exacto)", () => {
+    // Codex P2: con `lte(0.01)` un parcial de un centavo se trataba como vacío
+    // y el cierre lo machacaba. Debe contar como pago real.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "0.01",
+        abono_capital: "0",
+        abono_interes: "0.01",
+        abono_iva_12: "0",
+        abono_seguro: "0",
+        abono_gps: "0",
+        membresias_pago: "0",
+      })
+    ).toBe(false);
+  });
+
   it("un pago REAL (con abono_interes validado) NO es sobrescribible", () => {
     // Caso crédito 217: fila validated con interés real ya facturado.
     expect(

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -22,6 +22,7 @@ import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
+  esDestinoSobrescribible,
   getCuotaIdForPaymentInsert,
   getRequestedInstallmentFloor,
   getSpecialPaymentInstallmentFields,
@@ -911,7 +912,20 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
         // normal del loop. `aplicadoPrevioCuota`/`interesPrevioCuota` los
         // reusa la red de seguridad de más abajo.
         const TOLERANCIA_CENTAVO = new Big(0.01);
-        const pagoIdEnVuelo = existingPago?.pago.pago_id ?? -1;
+        // ¿`existingPago` es una fila desechable que el cierre puede SOBRESCRIBIR
+        // (placeholder `no_required` o fila vacía), o es un pago REAL que cayó al
+        // fallback `allExistingPagos[0]` porque el `no_required` ya fue consumido?
+        // De esto depende todo: si NO es sobrescribible, el cierre INSERTA una
+        // fila nueva (no la pisa) y, por lo mismo, `existingPago` es un hermano
+        // REAL que SÍ debe contarse. Solo lo excluimos del set de hermanos cuando
+        // realmente lo vamos a UPDATE-ar (i.e. cuando es sobrescribible); si no,
+        // contar sus rubros evita re-aplicar interés/IVA/etc.
+        const destinoSobrescribible = existingPago
+          ? esDestinoSobrescribible(existingPago.pago)
+          : false;
+        const pagoIdEnVuelo = destinoSobrescribible
+          ? existingPago!.pago.pago_id
+          : -1;
         const pagosHermanos = await db
           .select({
             pago_id: pagos_credito.pago_id,
@@ -1362,7 +1376,11 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           console.log("cuota_id:", cuota);
           console.log("pagoInsertado:", pagoData);
           if (pagoData) {
-            if (pagoData.pagado) {
+            if (pagoData.pagado && destinoSobrescribible) {
+              // ── CIERRE sobre fila DESECHABLE (UPDATE) ──────────────────────
+              // `existingPago` es el placeholder `no_required` o una fila vacía:
+              // pisarla con el pago de cierre no destruye plata. Comportamiento
+              // histórico para el caso normal.
               cuotas_completas++;
               console.log(
                 `✅ Cuota ${cuota.cuotas_credito.numero_cuota} PAGADA COMPLETAMENTE`
@@ -1402,7 +1420,133 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
                 );
               }
 
-             
+
+            } else if (pagoData.pagado) {
+              // ── CIERRE sin fila desechable (INSERT de fila de cierre) ──────
+              // El placeholder `no_required` ya fue consumido por un parcial
+              // previo, así que `existingPago` cayó al fallback = una fila REAL
+              // (con interés/IVA ya validado, posiblemente facturado).
+              // Sobrescribirla destruiría ese pago (caso crédito 217 / cuota 8).
+              // En su lugar INSERTAMOS una fila nueva de cierre (igual que un
+              // parcial pero `pagado: true` y restantes en 0). El UPDATE masivo
+              // de abajo marca toda la cuota como pagada.
+              cuotas_completas++;
+              console.log(
+                `✅ Cuota ${cuota.cuotas_credito.numero_cuota} PAGADA COMPLETAMENTE (fila de cierre NUEVA: el destino existente es un pago real y no se sobrescribe)`
+              );
+
+              const guatemalaTimeString = new Date().toLocaleString("en-US", {
+                timeZone: "America/Guatemala",
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+                hour: "2-digit",
+                minute: "2-digit",
+                second: "2-digit",
+                hour12: false,
+              });
+              const [datePart, timePart] = guatemalaTimeString.split(", ");
+              const [month, day, year] = datePart.split("/");
+              const fechaGuatemala = new Date(
+                `${year}-${month}-${day}T${timePart}`
+              );
+
+              [pagoInsertado] = await db
+                .insert(pagos_credito)
+                .values({
+                  // Campos requeridos del input
+                  cuota_id: cuota.cuotas_credito.cuota_id,
+                  renuevo_o_nuevo: pagoData.renuevo_o_nuevo,
+                  credito_id: pagoData.credito_id,
+                  // Campos que vienen del crédito/cuota
+                  cuota: credito.cuota,
+                  cuota_interes: credito.cuota_interes,
+                  fecha_pago: fechaGuatemala,
+                  fecha_vencimiento: cuota.cuotas_credito.fecha_vencimiento
+                    ? new Date(
+                        cuota.cuotas_credito.fecha_vencimiento
+                      ).toISOString()
+                    : undefined,
+
+                  // Abonos (calculados según lógica de distribución)
+                  abono_capital: pagoData.abono_capital,
+                  abono_interes: pagoData.abono_interes,
+                  abono_iva_12: pagoData.abono_iva_12,
+                  abono_interes_ci: pagoData.abono_interes_ci,
+                  abono_iva_ci: pagoData.abono_iva_ci,
+                  abono_seguro: pagoData.abono_seguro,
+                  abono_gps: pagoData.abono_gps,
+                  pago_del_mes: pagoData.pago_del_mes,
+
+                  // Restantes en 0: esta fila cierra la cuota.
+                  capital_restante: "0",
+                  interes_restante: "0",
+                  iva_12_restante: "0",
+                  seguro_restante: "0",
+                  gps_restante: "0",
+                  total_restante:
+                    pagoSaldoVigente?.pago.total_restante ??
+                    credito.capital ??
+                    "0",
+
+                  // Membresías
+                  membresias: "0",
+                  membresias_pago: pagoData.membresias_pago,
+                  membresias_mes: pagoData.membresias_mes,
+
+                  // Campos adicionales del input
+                  llamada: pagoData.llamada || "",
+                  otros: pagoData.otros,
+                  mora: pagoData.mora,
+                  monto_boleta_cuota: montoBoleta.toString(),
+                  monto_boleta: montoBoleta.toString(),
+                  observaciones: pagoData.observaciones,
+
+                  // Seguros y GPS
+                  seguro_total: pagoData.seguro_total,
+                  seguro_facturado: pagoData.seguro_facturado,
+                  gps_facturado: pagoData.gps_facturado,
+                  reserva: pagoData.reserva,
+
+                  // Campos de estado: fila de cierre (pagado:true, pending hasta
+                  // que contabilidad valida).
+                  pagado: true,
+                  facturacion: pagoData.facturacion || "si",
+                  mes_pagado: pagoData.mes_pagado,
+                  paymentFalse: pagoData.paymentFalse || false,
+                  validationStatus: "pending",
+                  banco_id: pagoData.banco_id || null,
+                  numeroAutorizacion: pagoData.numeroAutorizacion || null,
+                  registerBy: pagoData.registerBy,
+                  pagoConvenio: montoConvenio.toString() || "0",
+                  fecha_boleta: pagoData.fecha_boleta,
+                  monto_aplicado: pagoData.monto_aplicado,
+                  // Paridad con la rama UPDATE de cierre (que persiste pagoData
+                  // completo): conservar el origen del pago en la fila de cierre.
+                  origen_pago: pagoData.origen_pago,
+                })
+                .returning();
+
+              // Marcar TODA la cuota como pagada (igual que la rama UPDATE).
+              await db
+                .update(pagos_credito)
+                .set({ pagado: true })
+                .where(
+                  eq(pagos_credito.cuota_id, cuota.cuotas_credito.cuota_id)
+                );
+
+              if (
+                pagoInsertado?.pago_id &&
+                urlCompletas &&
+                urlCompletas.length > 0
+              ) {
+                await db.insert(boletas).values(
+                  urlCompletas.map((url) => ({
+                    pago_id: pagoInsertado!.pago_id,
+                    url_boleta: url,
+                  }))
+                );
+              }
             } else {
               disponible_para_cuotasPosteriores =
                 disponible_para_cuotasPosteriores.plus(disponible);

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -67,6 +67,59 @@ export const getSpecialPaymentInstallmentFields = () => ({
   pagado: true,
 });
 
+// Tolerancia de un centavo al comparar montos de pago contra cero.
+export const DESTINO_SOBRESCRIBIBLE_TOLERANCE = 0.01;
+
+/** Subconjunto de una fila de pago necesario para decidir si es sobrescribible. */
+export type DestinoSobrescribibleRow = {
+  validationStatus?: string | null;
+  monto_aplicado?: BigInput | null;
+  abono_capital?: BigInput | null;
+  abono_interes?: BigInput | null;
+  abono_iva_12?: BigInput | null;
+  abono_seguro?: BigInput | null;
+  abono_gps?: BigInput | null;
+  membresias_pago?: BigInput | null;
+};
+
+/**
+ * ¿La fila de pago elegida como `existingPago` se puede SOBRESCRIBIR (UPDATE) al
+ * cerrar la cuota, sin destruir plata real?
+ *
+ * El cierre de una cuota hace `UPDATE pagos_credito SET <pagoData> WHERE
+ * pago_id = existingPago`. Eso es seguro SOLO si la fila destino es desechable:
+ *
+ *  - El placeholder `no_required` importado de SIFCO (su único propósito es
+ *    portar los `*_restante`; no representa plata aplicada), o
+ *  - Una fila "vacía": `monto_aplicado ≈ 0` Y todos los `abono_*` ≈ 0 (p.ej. una
+ *    fila estructural sin rubros de cuota).
+ *
+ * Cuando el placeholder `no_required` ya fue consumido por un parcial previo,
+ * `existingPago` cae al fallback `allExistingPagos[0]` = la fila REAL más vieja
+ * (con `abono_interes` validado, posiblemente ya facturado). Sobrescribirla
+ * borraría ese pago. En ese caso esta función devuelve `false` y el caller debe
+ * INSERTAR una fila de cierre nueva en vez de hacer UPDATE.
+ */
+export const esDestinoSobrescribible = (
+  pago: DestinoSobrescribibleRow
+): boolean => {
+  if (pago.validationStatus === "no_required") return true;
+
+  const tol = new Big(DESTINO_SOBRESCRIBIBLE_TOLERANCE);
+  const casiCero = (v: BigInput | null | undefined) =>
+    new Big(v ?? 0).abs().lte(tol);
+
+  return (
+    casiCero(pago.monto_aplicado) &&
+    casiCero(pago.abono_capital) &&
+    casiCero(pago.abono_interes) &&
+    casiCero(pago.abono_iva_12) &&
+    casiCero(pago.abono_seguro) &&
+    casiCero(pago.abono_gps) &&
+    casiCero(pago.membresias_pago)
+  );
+};
+
 export type SaldoCuotaInput = {
   /** Monto total de la cuota (credito.cuota). */
   montoCuota: BigInput;

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -85,6 +85,14 @@ export type DestinoSobrescribibleRow = {
   abono_seguro?: BigInput | null;
   abono_gps?: BigInput | null;
   membresias_pago?: BigInput | null;
+  abono_interes_ci?: BigInput | null;
+  abono_iva_ci?: BigInput | null;
+  // Buckets de plata que un pago de solo mora/otros/convenio (insertarPago /
+  // getSpecialPaymentInstallmentFields) lleva con `monto_aplicado` y `abono_*`
+  // en 0 — hay que contarlos o el cierre los machacaría. `otros` es TEXT.
+  mora?: BigInput | null;
+  pagoConvenio?: BigInput | null;
+  otros?: string | number | null;
 };
 
 /**
@@ -96,8 +104,10 @@ export type DestinoSobrescribibleRow = {
  *
  *  - El placeholder `no_required` importado de SIFCO (su único propósito es
  *    portar los `*_restante`; no representa plata aplicada), o
- *  - Una fila "vacía": `monto_aplicado ≈ 0` Y todos los `abono_*` ≈ 0 (p.ej. una
- *    fila estructural sin rubros de cuota).
+ *  - Una fila "vacía": SIN plata en NINGÚN bucket — `monto_aplicado`, todos los
+ *    `abono_*`, y también `mora`, `pagoConvenio` y `otros` ≈ 0. (Un pago de solo
+ *    mora/otros/convenio lleva `monto_aplicado`/`abono_*` en 0 pero plata en
+ *    esos otros campos; si no se contaran, el cierre lo machacaría.)
  *
  * Cuando el placeholder `no_required` ya fue consumido por un parcial previo,
  * `existingPago` cae al fallback `allExistingPagos[0]` = la fila REAL más vieja
@@ -114,6 +124,13 @@ export const esDestinoSobrescribible = (
   // Estricto (`lt`, no `lte`): un Q0.01 exacto es un pago real, no "vacío".
   const casiCero = (v: BigInput | null | undefined) =>
     new Big(v ?? 0).abs().lt(tol);
+  // `otros` es TEXT y puede venir null/''/no-numérico → parsear con guard.
+  const otrosCasiCero = (v: string | number | null | undefined) => {
+    if (v == null) return true;
+    const s = String(v).trim();
+    if (s === "" || !/^-?\d+(\.\d+)?$/.test(s)) return true;
+    return new Big(s).abs().lt(tol);
+  };
 
   return (
     casiCero(pago.monto_aplicado) &&
@@ -122,7 +139,13 @@ export const esDestinoSobrescribible = (
     casiCero(pago.abono_iva_12) &&
     casiCero(pago.abono_seguro) &&
     casiCero(pago.abono_gps) &&
-    casiCero(pago.membresias_pago)
+    casiCero(pago.membresias_pago) &&
+    casiCero(pago.abono_interes_ci) &&
+    casiCero(pago.abono_iva_ci) &&
+    // Plata real fuera de los abono_* de cuota: mora, convenio y otros.
+    casiCero(pago.mora) &&
+    casiCero(pago.pagoConvenio) &&
+    otrosCasiCero(pago.otros)
   );
 };
 

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -67,7 +67,12 @@ export const getSpecialPaymentInstallmentFields = () => ({
   pagado: true,
 });
 
-// Tolerancia de un centavo al comparar montos de pago contra cero.
+// Umbral para considerar un monto "cero". Las columnas monetarias son
+// numeric(2), así que el mínimo pago real representable es Q0.01: una fila se
+// considera vacía solo si cada monto es ESTRICTAMENTE menor a un centavo (i.e.
+// 0.00). Un Q0.01 es un pago real y NO debe tratarse como sobrescribible (con
+// `lte` el cierre lo machacaría, reintroduciendo la pérdida para parciales de
+// un centavo).
 export const DESTINO_SOBRESCRIBIBLE_TOLERANCE = 0.01;
 
 /** Subconjunto de una fila de pago necesario para decidir si es sobrescribible. */
@@ -106,8 +111,9 @@ export const esDestinoSobrescribible = (
   if (pago.validationStatus === "no_required") return true;
 
   const tol = new Big(DESTINO_SOBRESCRIBIBLE_TOLERANCE);
+  // Estricto (`lt`, no `lte`): un Q0.01 exacto es un pago real, no "vacío".
   const casiCero = (v: BigInput | null | undefined) =>
-    new Big(v ?? 0).abs().lte(tol);
+    new Big(v ?? 0).abs().lt(tol);
 
   return (
     casiCero(pago.monto_aplicado) &&


### PR DESCRIPTION
## Problema
Al **cerrar** una cuota, `insertPayment` hacía `UPDATE pagos_credito SET <pagoData> WHERE pago_id = existingPago`, donde `existingPago = pagoOriginal ?? allExistingPagos[0]`. Cuando el placeholder `no_required` de la cuota **ya fue consumido** por un parcial previo (esa fila pasó a `validated`), `pagoOriginal` es `undefined` y `existingPago` cae al fallback `allExistingPagos[0]` = **la fila REAL más vieja**. El cierre la **sobreescribía**, destruyendo un pago genuino.

**Caso real (crédito 217, cuota 8):** un pago de **Q1151 de interés** (registrado 2-jun, validado 8-jun, ya facturado en DTEs ACTIVA) fue borrado por el cierre del pago del 17-jun → el interés de la cuota cayó de 1467.54 a 316.54 pero la cuota quedó marcada como pagada (faltante oculto).

## Fix
- Nuevo helper puro `esDestinoSobrescribible(pago)` en `registerPaymentPolicy.ts`: `true` solo si la fila es `no_required` o está vacía (`monto_aplicado` y todos los `abono_*` ≈ 0).
- El cierre ahora ramifica:
  - destino **sobrescribible** → `UPDATE` (comportamiento histórico, caso normal intacto).
  - destino **NO sobrescribible** (pago real) → **INSERT de fila de cierre nueva** (`pagado:true`, restantes 0) — no pisa el pago real.
- `pagoIdEnVuelo` excluye `existingPago` del set de hermanos **solo** cuando es sobrescribible; si no, se cuenta como hermano real (evita re-aplicar interés/IVA).

## Validación
- **Tests** `registerPayment.test.ts`: 22 → **30 pass / 0 fail** (incluye el caso de regresión 217).
- **A/B en vivo contra DB local** (import directo de `insertPayment`, crédito 890 cuota 13 con el escenario montado): código viejo **machaca** la fila real (1 fila, interés 0); código nuevo **inserta** fila de cierre y **preserva** la validada (2 filas, total cuadra 3400.95).

## Datos en prod
La víctima (crédito 217 cuota 8) **ya fue reparada quirúrgicamente en prod** (split de la fila 87589, backup en `cartera._bk_repair_217_c8`). Este PR es el **fix de código** para que el patrón no se repita.

## Limitaciones / follow-up
- **Edge angosto** (del code review): si `existingPago` es a la vez `pagoSaldoVigente` con `*_restante` **stale**, el cierre podría doble-contar interés — pero **falla ruidoso** (la red anti-sobreaplicación lanza error, no corrompe) y depende de staleness pre-existente. No se tocó la distribución para no arriesgar regresiones.
- Pendiente: **detector read-only** en prod de otras víctimas del mismo patrón.
- `disponible_para_cuotasPosteriores` quedó como **código muerto** (pre-existente); candidato a limpieza aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
