### PR TITLE
feat(reports): separar interés de inversiones y CUBE en tabla Interés Neto

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -797,27 +797,48 @@ export async function getReinversionLiquidaciones({
 
   // Interés de CUBE: no se almacena en liquidaciones sino que se deriva de los
   // registros de inversionistas no-CUBE en pagos_credito_inversionistas_espejo.
-  // Por crédito+liquidación se agrupa la participación e interés de todos los
-  // inversionistas no-CUBE, y el interés de CUBE es:
   //   interes_cube = total_inv_interes × (100 - total_inv_pct) / total_inv_pct
+  // `porcentaje_participacion` es un split por inversionista guardado por fila de
+  // pago (snapshot del momento). Se agrupa a nivel de cuota en dos pasos:
+  //   1. (credito, liquidacion, cuota, inversionista): colapsa pagos PARCIALES de
+  //      la misma cuota tomando el porcentaje UNA sola vez (MAX) y sumando el
+  //      interés. Evita inflar el porcentaje (dos parciales al 80% darían 160% y
+  //      romperían el cálculo al caer en el filtro `< 100`).
+  //   2. (credito, liquidacion, cuota): suma la participación de los distintos
+  //      inversionistas no-CUBE dentro de la cuota. Agrupar por cuota (y no por
+  //      crédito) mantiene el cálculo correcto aun si la participación de un
+  //      inversionista cambia entre cuotas (reasignación): cada cuota usa su
+  //      propio porcentaje.
   const cubeRows = await db.execute(sql`
-    WITH por_credito_liq AS (
+    WITH por_inv_cuota AS (
       SELECT
         pe.credito_id,
         pe.liquidacion_id,
-        COALESCE(SUM(pe.abono_interes::numeric), 0)             AS total_inv_interes,
-        COALESCE(SUM(pe.porcentaje_participacion::numeric), 0)  AS total_inv_pct
+        pe.cuota,
+        pe.inversionista_id,
+        COALESCE(SUM(pe.abono_interes::numeric), 0)         AS inv_interes,
+        MAX(pe.porcentaje_participacion::numeric)           AS inv_pct
       FROM cartera.pagos_credito_inversionistas_espejo pe
       JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
       WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
         AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
         AND pe.porcentaje_participacion::numeric > 0
-      GROUP BY pe.credito_id, pe.liquidacion_id
+      GROUP BY pe.credito_id, pe.liquidacion_id, pe.cuota, pe.inversionista_id
+    ),
+    por_cuota AS (
+      SELECT
+        credito_id,
+        liquidacion_id,
+        cuota,
+        SUM(inv_interes) AS total_inv_interes,
+        SUM(inv_pct)     AS total_inv_pct
+      FROM por_inv_cuota
+      GROUP BY credito_id, liquidacion_id, cuota
     )
     SELECT COALESCE(SUM(
       total_inv_interes * (100 - total_inv_pct) / total_inv_pct
     ), 0) AS interes_cube
-    FROM por_credito_liq
+    FROM por_cuota
     WHERE total_inv_pct > 0 AND total_inv_pct < 100
   `);
   const interesCube = Number(

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -795,51 +795,32 @@ export async function getReinversionLiquidaciones({
     }
   }
 
-  // Interés de CUBE: no se almacena en liquidaciones sino que se deriva de los
-  // registros de inversionistas no-CUBE en pagos_credito_inversionistas_espejo.
-  //   interes_cube = total_inv_interes × (100 - total_inv_pct) / total_inv_pct
-  // `porcentaje_participacion` es un split por inversionista guardado por fila de
-  // pago (snapshot del momento). Se agrupa a nivel de cuota en dos pasos:
-  //   1. (credito, liquidacion, cuota, inversionista): colapsa pagos PARCIALES de
-  //      la misma cuota tomando el porcentaje UNA sola vez (MAX) y sumando el
-  //      interés. Evita inflar el porcentaje (dos parciales al 80% darían 160% y
-  //      romperían el cálculo al caer en el filtro `< 100`).
-  //   2. (credito, liquidacion, cuota): suma la participación de los distintos
-  //      inversionistas no-CUBE dentro de la cuota. Agrupar por cuota (y no por
-  //      crédito) mantiene el cálculo correcto aun si la participación de un
-  //      inversionista cambia entre cuotas (reasignación): cada cuota usa su
-  //      propio porcentaje.
+  // Interés de CUBE: no se almacena como tal sino que se deriva de las filas de
+  // los inversionistas no-CUBE en pagos_credito_inversionistas_espejo. Para una
+  // fila con interés `abono_interes` y participación `porcentaje_participacion`,
+  // el interés que le corresponde a CUBE (el complemento) es:
+  //   interes_cube = abono_interes × (100 - porcentaje_participacion) / porcentaje_participacion
+  // El cálculo se hace POR FILA, así
+  // que no hay que combinar inversionistas por cuota. Calcular por fila además:
+  //   - maneja pagos parciales (cada parcial aporta su complemento y se suman);
+  //   - usa el porcentaje del snapshot de cada fila, por lo que sigue siendo
+  //     correcto si la participación cambia entre cuotas (reasignación).
+  // Se excluye la propia CUBE (inversionista_id 86) para no contar sus filas como
+  // si fueran de un inversionista no-CUBE, y se omiten las filas al 100% (sin
+  // complemento) y al 0% (evita división por cero).
   const cubeRows = await db.execute(sql`
-    WITH por_inv_cuota AS (
-      SELECT
-        pe.credito_id,
-        pe.liquidacion_id,
-        pe.cuota,
-        pe.inversionista_id,
-        COALESCE(SUM(pe.abono_interes::numeric), 0)         AS inv_interes,
-        MAX(pe.porcentaje_participacion::numeric)           AS inv_pct
-      FROM cartera.pagos_credito_inversionistas_espejo pe
-      JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
-      WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
-        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
-        AND pe.porcentaje_participacion::numeric > 0
-      GROUP BY pe.credito_id, pe.liquidacion_id, pe.cuota, pe.inversionista_id
-    ),
-    por_cuota AS (
-      SELECT
-        credito_id,
-        liquidacion_id,
-        cuota,
-        SUM(inv_interes) AS total_inv_interes,
-        SUM(inv_pct)     AS total_inv_pct
-      FROM por_inv_cuota
-      GROUP BY credito_id, liquidacion_id, cuota
-    )
     SELECT COALESCE(SUM(
-      total_inv_interes * (100 - total_inv_pct) / total_inv_pct
+      pe.abono_interes::numeric
+        * (100 - pe.porcentaje_participacion::numeric)
+        / pe.porcentaje_participacion::numeric
     ), 0) AS interes_cube
-    FROM por_cuota
-    WHERE total_inv_pct > 0 AND total_inv_pct < 100
+    FROM cartera.pagos_credito_inversionistas_espejo pe
+    JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+      AND pe.inversionista_id <> 86
+      AND pe.porcentaje_participacion::numeric > 0
+      AND pe.porcentaje_participacion::numeric < 100
   `);
   const interesCube = Number(
     (cubeRows.rows[0] as Record<string, unknown>)?.interes_cube ?? 0

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -795,6 +795,35 @@ export async function getReinversionLiquidaciones({
     }
   }
 
+  // Interés de CUBE: no se almacena en liquidaciones sino que se deriva de los
+  // registros de inversionistas no-CUBE en pagos_credito_inversionistas_espejo.
+  // Por crédito+liquidación se agrupa la participación e interés de todos los
+  // inversionistas no-CUBE, y el interés de CUBE es:
+  //   interes_cube = total_inv_interes × (100 - total_inv_pct) / total_inv_pct
+  const cubeRows = await db.execute(sql`
+    WITH por_credito_liq AS (
+      SELECT
+        pe.credito_id,
+        pe.liquidacion_id,
+        COALESCE(SUM(pe.abono_interes::numeric), 0)             AS total_inv_interes,
+        COALESCE(SUM(pe.porcentaje_participacion::numeric), 0)  AS total_inv_pct
+      FROM cartera.pagos_credito_inversionistas_espejo pe
+      JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
+      WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+        AND pe.porcentaje_participacion::numeric > 0
+      GROUP BY pe.credito_id, pe.liquidacion_id
+    )
+    SELECT COALESCE(SUM(
+      total_inv_interes * (100 - total_inv_pct) / total_inv_pct
+    ), 0) AS interes_cube
+    FROM por_credito_liq
+    WHERE total_inv_pct > 0 AND total_inv_pct < 100
+  `);
+  const interesCube = Number(
+    (cubeRows.rows[0] as Record<string, unknown>)?.interes_cube ?? 0
+  );
+
   // Pagos extras recibidos (abonos a capital / cancelaciones) que fluyen desde
   // las liquidaciones del mes: liquidación → pago espejo → abono.
   // Cada abono se cuenta una sola vez (DISTINCT) aunque tenga varios pagos espejo.
@@ -960,6 +989,9 @@ export async function getReinversionLiquidaciones({
         interes: sinFactura.interes.toFixed(2),
         isr: sinFactura.isr.toFixed(2),
         neto: (sinFactura.interes - sinFactura.isr).toFixed(2),
+      },
+      cube: {
+        interes: interesCube.toFixed(2),
       },
     },
     pagosExtras: {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -288,6 +288,7 @@ export type ReinversionLiquidacionesResponse = {
 	interesNeto: {
 		conFactura: { interes: string; iva: string; neto: string };
 		sinFactura: { interes: string; isr: string; neto: string };
+		cube: { interes: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
 	pagosExtras: { abonos_capital: string; cancelaciones: string };

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -170,6 +170,7 @@ export type ReinversionLiquidacionesResponse = {
 	interesNeto: {
 		conFactura: { interes: string; iva: string; neto: string };
 		sinFactura: { interes: string; isr: string; neto: string };
+		cube: { interes: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
 	pagosExtras: { abonos_capital: string; cancelaciones: string };

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+﻿import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
 	Activity,
@@ -1962,8 +1962,9 @@ function RouteComponent() {
 										(() => {
 											const cf = reinversionData.interesNeto.conFactura;
 											const sf = reinversionData.interesNeto.sinFactura;
+											const cube = reinversionData.interesNeto.cube;
 											const totalInteres =
-												Number(cf.interes) + Number(sf.interes);
+												Number(cf.interes) + Number(sf.interes) + Number(cube.interes);
 											const totalIva = Number(cf.iva);
 											const totalIsr = Number(sf.isr);
 											const totalNeto = Number(cf.neto) + Number(sf.neto);
@@ -2020,6 +2021,14 @@ function RouteComponent() {
 																<TableCell className="text-right font-semibold">
 																	{dash(sf.neto)}
 																</TableCell>
+															</TableRow>
+
+															<TableRow>
+																<TableCell>CUBE</TableCell>
+																<TableCell className="text-right">{dash(cube.interes)}</TableCell>
+																<TableCell className="text-right text-muted-foreground">—</TableCell>
+																<TableCell className="text-right text-muted-foreground">—</TableCell>
+																<TableCell className="text-right text-muted-foreground">—</TableCell>
 															</TableRow>
 															<TableRow className="border-t-2 bg-muted/50 font-bold">
 																<TableCell>Total</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1993,7 +1993,7 @@ function RouteComponent() {
 														</TableHeader>
 														<TableBody>
 															<TableRow>
-																<TableCell>Con Factura</TableCell>
+																<TableCell>Inversionista Con Factura</TableCell>
 																<TableCell className="text-right">
 																	{dash(cf.interes)}
 																</TableCell>
@@ -2007,8 +2007,8 @@ function RouteComponent() {
 																	{dash(cf.neto)}
 																</TableCell>
 															</TableRow>
-															<TableRow>
-																<TableCell>Sin Factura</TableCell>
+															<TableRow>	
+																<TableCell>Inversionista Sin Factura</TableCell>
 																<TableCell className="text-right">
 																	{dash(sf.interes)}
 																</TableCell>


### PR DESCRIPTION
## Separación de Interés de CUBE en tabla Interés Neto

Se agrega una fila **CUBE** en la sección "Interés Neto" del tab Inversiones, debajo de "Sin Factura" y encima del Total.

**Contexto**

CUBE INVESTMENTS se debe de tomar como un inversionista con un mecanismo especial de distribución de interés: su porción no se almacena en `liquidaciones` sino que fluye a través del mecanismo de `cash_in`. CUBE representa un interés real que el dashboard debe reflejar.

**Derivación de la fórmula:**

\`\`\`
Paso 1: CAPITAL = abono_interes / (porcentaje_interes% × porcentaje_participacion%)

Paso 2: INTERES_CUBE = CAPITAL × porcentaje_interes% × (100 - porcentaje_participacion%)
\`\`\`

Sustituyendo Paso 1 en Paso 2, el `porcentaje_interes%` aparece en numerador y denominador y se cancela:

\`\`\`
INTERES_CUBE = abono_interes × (100 - porcentaje_participacion%) / porcentaje_participacion%
\`\`\`

La tasa de interés del crédito desaparece — solo se necesita el interés del inversionista y su porcentaje de participación.

**Ejemplo con tasa 1.5%:**
- Inversionista: 80% participación, recibió Q400 de interés, crédito al 1.5%
- CAPITAL = 400 / (0.015 × 0.80) = Q33,333.33
- CUBE_int = 33,333.33 × 0.015 × 0.20 = **Q100**
- Simplificado: 400 × (100 − 80) / 80 = 400 × 20/80 = **Q100** ✓

**Para créditos con múltiples inversionistas no-CUBE**, se agrupa primero por `(credito_id, liquidacion_id)` y se suman intereses y participaciones antes de aplicar la fórmula, evitando doble conteo.

**Alcance de esta entrega**

Por el momento únicamente se calcula y muestra el **Interés** de CUBE. El cálculo de IVA e Interés Neto para CUBE queda pendiente para una siguiente iteración, por lo que las columnas IVA 12%, ISR e Interés Neto aparecen como `—` en la fila de CUBE.

**Archivos modificados:**
- `apps/cartera-back/src/controllers/reportes.ts` — query SQL con CTE `por_credito_liq` que agrupa por `(credito_id, liquidacion_id)`, filtra filas con `porcentaje_participacion > 0` (excluye CUBE), y calcula `interes_cube`. Retornado en `interesNeto.cube`.
- `apps/crm/apps/server/src/services/cartera-back-client.ts` — tipo `ReinversionLiquidacionesResponse.interesNeto` actualizado con `cube: { interes: string }`.
- `apps/crm/apps/web/src/lib/reports/scenario.ts` — mismo campo agregado al tipo paralelo usado por el simulador de escenarios.
- `apps/crm/apps/web/src/routes/admin/reports/index.tsx` — fila CUBE renderizada en la tabla Interés Neto; el Total incluye el interés de CUBE.

<img width="1311" height="248" alt="image" src="https://github.com/user-attachments/assets/b066370a-806c-4c96-ba05-7eef51b8480c" />
