### PR TITLE
fix(reportes): cuota del crédito usa cuotaMensual de la oportunidad como fallback

### DIFF
--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -267,7 +267,12 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 				numeroSifco: sql<string>`COALESCE(${latestCarteraReference.numeroCreditoSifco}, ${opportunities.numeroSifco}, '')`,
 				cuotaSeguro: opportunities.seguro,
 				montoCredito: opportunities.value,
-				cuotaCredito: latestQuotation.monthlyPayment,
+				// Cuota de la cotización; si no hay cotización enlazada, se usa la
+				// cuota mensual guardada en la oportunidad (el flujo de cierre usa
+				// esa cuando no encuentra cotización).
+				cuotaCredito: sql<
+					string | null
+				>`COALESCE(${latestQuotation.monthlyPayment}, ${opportunities.cuotaMensual})`,
 				fechaCierre: opportunities.actualCloseDate,
 				// Día del mes en que paga (1-31), tomado de la oportunidad.
 				diaPago: opportunities.diaPagoMensual,


### PR DESCRIPTION
## Qué

En el reporte **Créditos cerrados**, la columna **Cuota del Crédito** (y el Excel) usaba solo `latestQuotation.monthlyPayment`. Los créditos ganados **sin cotización enlazada** —cerrados desde los términos de crédito de la oportunidad— mostraban `-`/`0`, aunque la cuota está guardada en `opportunities.cuotaMensual` (la que usa el flujo de cierre cuando no encuentra cotización).

## Fix

```sql
COALESCE(latestQuotation.monthlyPayment, opportunities.cuotaMensual)
```

Así esos créditos conservan su monto de cuota en el reporte.

Aborda el comentario de review de `chatgpt-codex-connector` (P2) sobre el PR #922.

## Verificación
- `tsc` (server y web), Biome y tests de `reports.test.ts` en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)