### PR TITLE
feat(reportes): filtro por presets reutilizable, ajustes de UI en reportes de ventas

### DIFF
--- a/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
+++ b/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
@@ -18,19 +18,40 @@ const RANGE_PRESETS: { key: PresetKey; label: string }[] = [
 
 export const DEFAULT_PRESET: PresetKey = "3m";
 
+/** Año/mes de hoy en zona Guatemala (evita corrimientos por la TZ del navegador). */
+function gtYearMonth(): { year: number; month: number } {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone: GUATEMALA_TZ,
+		year: "numeric",
+		month: "2-digit",
+	}).formatToParts(new Date());
+	const num = (type: string) =>
+		Number(parts.find((p) => p.type === type)?.value);
+	return { year: num("year"), month: num("month") };
+}
+
+/** Instante de medianoche en Guatemala (UTC-6) para el Y-M-D dado. */
+function gtMidnight(year: number, month: number, day: number): Date {
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return new Date(`${year}-${pad(month)}-${pad(day)}T06:00:00.000Z`);
+}
+
 /** Rango [desde, hasta] correspondiente a un preset (hoy como fin). */
 export function rangeForPreset(key: PresetKey): DateRange {
 	const today = new Date();
 	switch (key) {
-		case "month":
-			return {
-				from: new Date(today.getFullYear(), today.getMonth(), 1),
-				to: today,
-			};
+		case "month": {
+			// Inicio = 1° del mes actual EN GUATEMALA (no en la TZ del navegador),
+			// para que coincida con la serialización en zona Guatemala del caller.
+			const { year, month } = gtYearMonth();
+			return { from: gtMidnight(year, month, 1), to: today };
+		}
 		case "6m":
 			return { from: subMonths(today, 6), to: today };
-		case "ytd":
-			return { from: new Date(today.getFullYear(), 0, 1), to: today };
+		case "ytd": {
+			const { year } = gtYearMonth();
+			return { from: gtMidnight(year, 1, 1), to: today };
+		}
 		default:
 			// "3m"
 			return { from: subMonths(today, 3), to: today };

--- a/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
+++ b/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
@@ -1,0 +1,103 @@
+import { subMonths } from "date-fns";
+import { useState } from "react";
+import type { DateRange } from "react-day-picker";
+import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import { Button } from "@/components/ui/button";
+
+const GUATEMALA_TZ = "America/Guatemala";
+
+export type PresetKey = "month" | "3m" | "6m" | "ytd" | "custom";
+
+const RANGE_PRESETS: { key: PresetKey; label: string }[] = [
+	{ key: "month", label: "Este mes" },
+	{ key: "3m", label: "Últimos 3 meses" },
+	{ key: "6m", label: "Últimos 6 meses" },
+	{ key: "ytd", label: "Este año" },
+	{ key: "custom", label: "Personalizado" },
+];
+
+export const DEFAULT_PRESET: PresetKey = "3m";
+
+/** Rango [desde, hasta] correspondiente a un preset (hoy como fin). */
+export function rangeForPreset(key: PresetKey): DateRange {
+	const today = new Date();
+	switch (key) {
+		case "month":
+			return {
+				from: new Date(today.getFullYear(), today.getMonth(), 1),
+				to: today,
+			};
+		case "6m":
+			return { from: subMonths(today, 6), to: today };
+		case "ytd":
+			return { from: new Date(today.getFullYear(), 0, 1), to: today };
+		default:
+			// "3m"
+			return { from: subMonths(today, 3), to: today };
+	}
+}
+
+function formatRangeLabel(range: DateRange | undefined): string {
+	if (!range?.from || !range?.to) return "";
+	const fmt = (d: Date) =>
+		new Intl.DateTimeFormat("es-GT", {
+			timeZone: GUATEMALA_TZ,
+			day: "2-digit",
+			month: "short",
+			year: "numeric",
+		}).format(d);
+	return `${fmt(range.from)} – ${fmt(range.to)}`;
+}
+
+/**
+ * Filtro de fechas por presets (Este mes / Últimos 3-6 meses / Este año) más
+ * una opción "Personalizado" que abre el calendario de rango libre. El rango
+ * vive en el padre; este componente solo recuerda qué preset está activo.
+ */
+export function RangePresetFilter({
+	dateRange,
+	onDateRangeChange,
+	defaultPreset = DEFAULT_PRESET,
+}: {
+	dateRange: DateRange | undefined;
+	onDateRangeChange: (range: DateRange | undefined) => void;
+	defaultPreset?: PresetKey;
+}) {
+	const [preset, setPreset] = useState<PresetKey>(defaultPreset);
+
+	const handlePreset = (key: PresetKey) => {
+		setPreset(key);
+		if (key !== "custom") {
+			onDateRangeChange(rangeForPreset(key));
+		}
+	};
+
+	return (
+		<div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+			<div className="inline-flex flex-wrap items-center gap-1 rounded-lg border bg-muted/30 p-1">
+				{RANGE_PRESETS.map((p) => (
+					<Button
+						key={p.key}
+						type="button"
+						size="sm"
+						variant={preset === p.key ? "secondary" : "ghost"}
+						className="h-8"
+						onClick={() => handlePreset(p.key)}
+					>
+						{p.label}
+					</Button>
+				))}
+			</div>
+			{preset === "custom" ? (
+				<DateRangeFilter
+					dateRange={dateRange}
+					onDateRangeChange={onDateRangeChange}
+				/>
+			) : (
+				<span className="text-muted-foreground text-sm">
+					{formatRangeLabel(dateRange)}
+				</span>
+			)}
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -496,13 +496,12 @@ function RouteComponent() {
 	const [equilibrioPeriodo, setEquilibrioPeriodo] = useState<
 		"anio" | "trimestre" | "mes" | "semana" | "dia"
 	>("mes");
-	const [equilibrioRange, setEquilibrioRange] = useState(() => {
-		const today = formatDateInput(new Date());
-		const start = new Date();
-		start.setMonth(start.getMonth() - 5);
-		start.setDate(1);
-		return { fechaInicio: formatDateInput(start), fechaFin: today };
-	});
+	// Alineado al período por defecto ("mes") y a un solo año: el PeriodDatePicker
+	// en modo mes tiene un único selector de año, así que un rango que cruce de año
+	// (p.ej. "últimos 6 meses" en enero) se renderizaría/editaría mal.
+	const [equilibrioRange, setEquilibrioRange] = useState(() =>
+		getDefaultRangeForPeriodo("mes"),
+	);
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const userRole = userProfile.data?.role;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -33,7 +33,6 @@ import {
 } from "recharts";
 import { toast } from "sonner";
 import * as XLSX from "xlsx";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { PeriodDatePicker } from "@/components/reports/period-date-picker";
 import { ReportCard } from "@/components/reports/report-card";
 import { ScenarioModal } from "@/components/reports/scenario-modal";
@@ -247,10 +246,6 @@ function formatDateInput(date: Date) {
 		month: "2-digit",
 		day: "2-digit",
 	}).format(date);
-}
-
-function dateFromInput(value: string) {
-	return new Date(`${value}T12:00:00`);
 }
 
 // Fecha legible en zona Guatemala, p.ej. "17 jun 2026".
@@ -2598,16 +2593,16 @@ function RouteComponent() {
 										<FilterField label="Período">
 											<Select
 												value={equilibrioPeriodo}
-												onValueChange={(v) =>
-													setEquilibrioPeriodo(
-														v as
-															| "anio"
-															| "trimestre"
-															| "mes"
-															| "semana"
-															| "dia",
-													)
-												}
+												onValueChange={(v) => {
+													const p = v as
+														| "anio"
+														| "trimestre"
+														| "mes"
+														| "semana"
+														| "dia";
+													setEquilibrioPeriodo(p);
+													setEquilibrioRange(getDefaultRangeForPeriodo(p));
+												}}
 											>
 												<SelectTrigger className="w-[140px]">
 													<SelectValue placeholder="Período" />
@@ -2623,26 +2618,13 @@ function RouteComponent() {
 										</FilterField>
 
 										<FilterField label="Rango">
-											<DateRangeFilter
-												dateRange={
-													equilibrioRange.fechaInicio &&
-													equilibrioRange.fechaFin
-														? {
-																from: dateFromInput(
-																	equilibrioRange.fechaInicio,
-																),
-																to: dateFromInput(equilibrioRange.fechaFin),
-															}
-														: undefined
+											<PeriodDatePicker
+												periodo={equilibrioPeriodo}
+												fechaInicio={equilibrioRange.fechaInicio}
+												fechaFin={equilibrioRange.fechaFin}
+												onChange={(fechaInicio, fechaFin) =>
+													setEquilibrioRange({ fechaInicio, fechaFin })
 												}
-												onDateRangeChange={(range) => {
-													if (range?.from && range?.to) {
-														setEquilibrioRange({
-															fechaInicio: formatDateInput(range.from),
-															fechaFin: formatDateInput(range.to),
-														});
-													}
-												}}
 											/>
 										</FilterField>
 									</div>

--- a/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
@@ -12,6 +12,13 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
 	Table,
 	TableBody,
 	TableCell,
@@ -158,28 +165,30 @@ export function MetaColocacionContent() {
 
 			{/* Selector mes/año */}
 			<div className="flex items-center gap-3">
-				<select
-					value={mes}
-					onChange={(e) => setMes(Number(e.target.value))}
-					className="rounded-md border bg-background px-3 py-1.5 text-sm"
-				>
-					{MESES.map((label, i) => (
-						<option key={label} value={i + 1}>
-							{label}
-						</option>
-					))}
-				</select>
-				<select
-					value={anio}
-					onChange={(e) => setAnio(Number(e.target.value))}
-					className="rounded-md border bg-background px-3 py-1.5 text-sm"
-				>
-					{anios.map((a) => (
-						<option key={a} value={a}>
-							{a}
-						</option>
-					))}
-				</select>
+				<Select value={String(mes)} onValueChange={(v) => setMes(Number(v))}>
+					<SelectTrigger className="w-36">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{MESES.map((label, i) => (
+							<SelectItem key={label} value={String(i + 1)}>
+								{label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<Select value={String(anio)} onValueChange={(v) => setAnio(Number(v))}>
+					<SelectTrigger className="w-24">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{anios.map((a) => (
+							<SelectItem key={a} value={String(a)}>
+								{a}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
 			</div>
 
 			{/* KPI Cards */}
@@ -290,7 +299,9 @@ export function MetaColocacionContent() {
 							</div>
 							<p className="text-muted-foreground text-xs">
 								Faltante:{" "}
-								{formatCurrency(Math.max(0, Number(meta) - Number(realMonto ?? 0)))}
+								{formatCurrency(
+									Math.max(0, Number(meta) - Number(realMonto ?? 0)),
+								)}
 							</p>
 						</div>
 					</CardContent>

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -1,7 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { subMonths } from "date-fns";
-import { Activity, CheckCircle2, Download, Target, XCircle } from "lucide-react";
+import {
+	Activity,
+	CheckCircle2,
+	Download,
+	Target,
+	XCircle,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import type { DateRange } from "react-day-picker";
 import {
@@ -15,7 +20,11 @@ import {
 	YAxis,
 } from "recharts";
 import { toast } from "sonner";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import {
+	DEFAULT_PRESET,
+	RangePresetFilter,
+	rangeForPreset,
+} from "@/components/reports/range-preset-filter";
 import { ReportCard } from "@/components/reports/report-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -98,11 +107,6 @@ function formatDisplayDate(date: Date | string | null): string {
 	}).format(new Date(date));
 }
 
-function getDefaultDateRange(): DateRange {
-	const today = new Date();
-	return { from: subMonths(today, 1), to: today };
-}
-
 // Prefija celdas que empiecen con operadores de fórmula para evitar CSV injection
 function sanitizeCSVCell(value: string): string {
 	return /^[=+\-@]/.test(value) ? `'${value}` : value;
@@ -163,8 +167,8 @@ function RouteComponent() {
 }
 
 export function PorcentajeEfectividadContent() {
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(
-		getDefaultDateRange,
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(() =>
+		rangeForPreset(DEFAULT_PRESET),
 	);
 	const [pageSize, setPageSize] = useState(25);
 	const [page, setPage] = useState(0);
@@ -201,7 +205,14 @@ export function PorcentajeEfectividadContent() {
 
 	// exportCSV cierra sobre allRegistros para que el tipo sea inferido por oRPC
 	function exportCSV() {
-		const headers = ["Fecha", "Prospecto", "Fuente", "Etapa", "% Etapa", "¿Cerró?"];
+		const headers = [
+			"Fecha",
+			"Prospecto",
+			"Fuente",
+			"Etapa",
+			"% Etapa",
+			"¿Cerró?",
+		];
 		const rows = allRegistros.map((row) => [
 			formatDisplayDate(row.createdAt),
 			row.nombre || "Sin nombre",
@@ -214,8 +225,7 @@ export function PorcentajeEfectividadContent() {
 			.map((row) =>
 				row
 					.map(
-						(cell) =>
-							`"${sanitizeCSVCell(String(cell)).replace(/"/g, '""')}"`,
+						(cell) => `"${sanitizeCSVCell(String(cell)).replace(/"/g, '""')}"`,
 					)
 					.join(","),
 			)
@@ -250,186 +260,15 @@ export function PorcentajeEfectividadContent() {
 					Porcentaje Efectividad
 				</h1>
 				<p className="mt-1 text-muted-foreground">
-					Oportunidades creadas en el período y si alcanzaron cierre (90%+),
-					con resumen de conversión por fuente.
+					Oportunidades creadas en el período y si alcanzaron cierre (90%+), con
+					resumen de conversión por fuente.
 				</p>
 			</div>
 
-			<DateRangeFilter
+			<RangePresetFilter
 				dateRange={dateRange}
 				onDateRangeChange={setDateRange}
 			/>
-
-			{/* ── Registros individuales (prioridad) ── */}
-			<Card>
-				<CardHeader>
-					<div className="flex items-start justify-between gap-4">
-						<div>
-							<CardTitle>Oportunidades del período</CardTitle>
-							<CardDescription className="mt-1">
-								Todas las oportunidades creadas en el rango seleccionado y su
-								estado de conversión
-							</CardDescription>
-						</div>
-						{allRegistros.length > 0 && (
-							<Button
-								variant="outline"
-								size="sm"
-								className="shrink-0"
-								onClick={exportCSV}
-							>
-								<Download className="mr-2 h-4 w-4" />
-								Exportar CSV
-							</Button>
-						)}
-					</div>
-				</CardHeader>
-				<CardContent className="space-y-3">
-					<div className="max-h-[600px] overflow-y-auto rounded-md border">
-						<Table>
-							<TableHeader className="sticky top-0 z-10 bg-background">
-								<TableRow>
-									<TableHead>Fecha</TableHead>
-									<TableHead>Prospecto</TableHead>
-									<TableHead>Fuente</TableHead>
-									<TableHead>Etapa actual</TableHead>
-									<TableHead className="text-center">¿Cerró?</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{isLoading ? (
-									<TableRow>
-										<TableCell
-											colSpan={5}
-											className="py-8 text-center text-muted-foreground"
-										>
-											Cargando...
-										</TableCell>
-									</TableRow>
-								) : visibleRegistros.length === 0 ? (
-									<TableRow>
-										<TableCell
-											colSpan={5}
-											className="py-8 text-center text-muted-foreground"
-										>
-											No hay datos para el período seleccionado
-										</TableCell>
-									</TableRow>
-								) : (
-									visibleRegistros.map((row) => (
-										<TableRow key={row.id}>
-											<TableCell className="whitespace-nowrap text-muted-foreground text-sm">
-												{formatDisplayDate(row.createdAt)}
-											</TableCell>
-											<TableCell className="font-medium">
-												{row.nombre || (
-													<span className="italic text-muted-foreground">
-														Sin nombre
-													</span>
-												)}
-											</TableCell>
-											<TableCell>
-												<div className="flex items-center gap-2">
-													<span
-														className="h-2 w-2 shrink-0 rounded-full"
-														style={{
-															backgroundColor: getSourceColor(row.source),
-														}}
-													/>
-													{getSourceLabel(row.source)}
-												</div>
-											</TableCell>
-											<TableCell>
-												{row.etapaNombre ? (
-													<span className="text-sm">
-														{row.etapaNombre}{" "}
-														<span className="text-muted-foreground">
-															({row.etapaPorcentaje}%)
-														</span>
-													</span>
-												) : (
-													<span className="italic text-muted-foreground text-sm">
-														Sin etapa
-													</span>
-												)}
-											</TableCell>
-											<TableCell className="text-center">
-												{row.cerro ? (
-													<Badge className="gap-1 bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-900/30 dark:text-green-400">
-														<CheckCircle2 className="h-3 w-3" />
-														Sí
-													</Badge>
-												) : (
-													<Badge
-														variant="outline"
-														className="gap-1 text-muted-foreground"
-													>
-														<XCircle className="h-3 w-3" />
-														No
-													</Badge>
-												)}
-											</TableCell>
-										</TableRow>
-									))
-								)}
-							</TableBody>
-						</Table>
-					</div>
-
-					{/* Footer: paginación + selector de page size */}
-					{!isLoading && allRegistros.length > 0 && (
-						<div className="flex items-center justify-between text-sm text-muted-foreground">
-							<span>
-								{`Mostrando ${page * pageSize + 1}–${Math.min((page + 1) * pageSize, allRegistros.length)} de ${allRegistros.length} registros`}
-							</span>
-							<div className="flex items-center gap-3">
-								<div className="flex items-center gap-2">
-									<span>Mostrar</span>
-									<Select
-										value={String(pageSize)}
-										onValueChange={(v) => {
-											setPageSize(Number(v));
-											setPage(0);
-										}}
-									>
-										<SelectTrigger className="h-7 w-16 text-xs">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="25">25</SelectItem>
-											<SelectItem value="50">50</SelectItem>
-											<SelectItem value="100">100</SelectItem>
-										</SelectContent>
-									</Select>
-								</div>
-								<div className="flex items-center gap-1">
-									<Button
-										variant="outline"
-										size="sm"
-										className="h-7 px-2 text-xs"
-										disabled={page === 0}
-										onClick={() => setPage((p) => p - 1)}
-									>
-										Anterior
-									</Button>
-									<span className="px-2">
-										{page + 1} / {totalPages}
-									</span>
-									<Button
-										variant="outline"
-										size="sm"
-										className="h-7 px-2 text-xs"
-										disabled={page + 1 >= totalPages}
-										onClick={() => setPage((p) => p + 1)}
-									>
-										Siguiente
-									</Button>
-								</div>
-							</div>
-						</div>
-					)}
-				</CardContent>
-			</Card>
 
 			{/* ── Resumen estadístico ── */}
 			<div className="grid gap-4 md:grid-cols-3">
@@ -576,6 +415,177 @@ export function PorcentajeEfectividadContent() {
 							)}
 						</TableBody>
 					</Table>
+				</CardContent>
+			</Card>
+
+			{/* ── Registros individuales (detalle) ── */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-start justify-between gap-4">
+						<div>
+							<CardTitle>Oportunidades del período</CardTitle>
+							<CardDescription className="mt-1">
+								Todas las oportunidades creadas en el rango seleccionado y su
+								estado de conversión
+							</CardDescription>
+						</div>
+						{allRegistros.length > 0 && (
+							<Button
+								variant="outline"
+								size="sm"
+								className="shrink-0"
+								onClick={exportCSV}
+							>
+								<Download className="mr-2 h-4 w-4" />
+								Exportar CSV
+							</Button>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					<div className="max-h-[600px] overflow-y-auto rounded-md border">
+						<Table>
+							<TableHeader className="sticky top-0 z-10 bg-background">
+								<TableRow>
+									<TableHead>Fecha</TableHead>
+									<TableHead>Prospecto</TableHead>
+									<TableHead>Fuente</TableHead>
+									<TableHead>Etapa actual</TableHead>
+									<TableHead className="text-center">¿Cerró?</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{isLoading ? (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className="py-8 text-center text-muted-foreground"
+										>
+											Cargando...
+										</TableCell>
+									</TableRow>
+								) : visibleRegistros.length === 0 ? (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className="py-8 text-center text-muted-foreground"
+										>
+											No hay datos para el período seleccionado
+										</TableCell>
+									</TableRow>
+								) : (
+									visibleRegistros.map((row) => (
+										<TableRow key={row.id}>
+											<TableCell className="whitespace-nowrap text-muted-foreground text-sm">
+												{formatDisplayDate(row.createdAt)}
+											</TableCell>
+											<TableCell className="font-medium">
+												{row.nombre || (
+													<span className="text-muted-foreground italic">
+														Sin nombre
+													</span>
+												)}
+											</TableCell>
+											<TableCell>
+												<div className="flex items-center gap-2">
+													<span
+														className="h-2 w-2 shrink-0 rounded-full"
+														style={{
+															backgroundColor: getSourceColor(row.source),
+														}}
+													/>
+													{getSourceLabel(row.source)}
+												</div>
+											</TableCell>
+											<TableCell>
+												{row.etapaNombre ? (
+													<span className="text-sm">
+														{row.etapaNombre}{" "}
+														<span className="text-muted-foreground">
+															({row.etapaPorcentaje}%)
+														</span>
+													</span>
+												) : (
+													<span className="text-muted-foreground text-sm italic">
+														Sin etapa
+													</span>
+												)}
+											</TableCell>
+											<TableCell className="text-center">
+												{row.cerro ? (
+													<Badge className="gap-1 bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-900/30 dark:text-green-400">
+														<CheckCircle2 className="h-3 w-3" />
+														Sí
+													</Badge>
+												) : (
+													<Badge
+														variant="outline"
+														className="gap-1 text-muted-foreground"
+													>
+														<XCircle className="h-3 w-3" />
+														No
+													</Badge>
+												)}
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
+
+					{/* Footer: paginación + selector de page size */}
+					{!isLoading && allRegistros.length > 0 && (
+						<div className="flex items-center justify-between text-muted-foreground text-sm">
+							<span>
+								{`Mostrando ${page * pageSize + 1}–${Math.min((page + 1) * pageSize, allRegistros.length)} de ${allRegistros.length} registros`}
+							</span>
+							<div className="flex items-center gap-3">
+								<div className="flex items-center gap-2">
+									<span>Mostrar</span>
+									<Select
+										value={String(pageSize)}
+										onValueChange={(v) => {
+											setPageSize(Number(v));
+											setPage(0);
+										}}
+									>
+										<SelectTrigger className="h-7 w-16 text-xs">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="25">25</SelectItem>
+											<SelectItem value="50">50</SelectItem>
+											<SelectItem value="100">100</SelectItem>
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="flex items-center gap-1">
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-7 px-2 text-xs"
+										disabled={page === 0}
+										onClick={() => setPage((p) => p - 1)}
+									>
+										Anterior
+									</Button>
+									<span className="px-2">
+										{page + 1} / {totalPages}
+									</span>
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-7 px-2 text-xs"
+										disabled={page + 1 >= totalPages}
+										onClick={() => setPage((p) => p + 1)}
+									>
+										Siguiente
+									</Button>
+								</div>
+							</div>
+						</div>
+					)}
 				</CardContent>
 			</Card>
 		</div>

--- a/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { subMonths } from "date-fns";
 import { Activity, Clock, TrendingDown, TrendingUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { DateRange } from "react-day-picker";
@@ -15,7 +14,11 @@ import {
 	YAxis,
 } from "recharts";
 import { toast } from "sonner";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import {
+	DEFAULT_PRESET,
+	RangePresetFilter,
+	rangeForPreset,
+} from "@/components/reports/range-preset-filter";
 import { ReportCard } from "@/components/reports/report-card";
 import {
 	Card,
@@ -79,11 +82,6 @@ function formatDateInput(date: Date): string {
 	}).format(date);
 }
 
-function getDefaultDateRange(): DateRange {
-	const today = new Date();
-	return { from: subMonths(today, 1), to: today };
-}
-
 function RouteComponent() {
 	const {
 		data: session,
@@ -94,17 +92,32 @@ function RouteComponent() {
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const userRole = userProfile.data?.role;
-	const canAccess = userRole ? PERMISSIONS.canAccessTiempoCierreReport(userRole) : false;
+	const canAccess = userRole
+		? PERMISSIONS.canAccessTiempoCierreReport(userRole)
+		: false;
 	const isPending = sessionPending || userProfile.isPending;
 
 	useEffect(() => {
-		if (shouldRedirectToLogin({ error: sessionError, isPending: sessionPending, session })) {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
 			navigate({ to: "/login" });
 		} else if (session && !userProfile.isPending && !canAccess) {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado");
 		}
-	}, [session, sessionError, sessionPending, userProfile.isPending, canAccess, navigate]);
+	}, [
+		session,
+		sessionError,
+		sessionPending,
+		userProfile.isPending,
+		canAccess,
+		navigate,
+	]);
 
 	if (isPending) {
 		return (
@@ -124,11 +137,16 @@ function RouteComponent() {
 }
 
 export function TiempoCierreContent() {
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(getDefaultDateRange);
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(() =>
+		rangeForPreset(DEFAULT_PRESET),
+	);
 
 	const input =
 		dateRange?.from && dateRange?.to
-			? { startDate: formatDateInput(dateRange.from), endDate: formatDateInput(dateRange.to) }
+			? {
+					startDate: formatDateInput(dateRange.from),
+					endDate: formatDateInput(dateRange.to),
+				}
 			: null;
 
 	const reportQuery = useQuery({
@@ -166,7 +184,7 @@ export function TiempoCierreContent() {
 				</p>
 			</div>
 
-			<DateRangeFilter
+			<RangePresetFilter
 				dateRange={dateRange}
 				onDateRangeChange={setDateRange}
 			/>
@@ -237,7 +255,11 @@ export function TiempoCierreContent() {
 									formatter={(value) => [`${value} días`, "Promedio"]}
 									labelFormatter={(label) => `Fuente: ${label}`}
 								/>
-								<Bar dataKey="avgDias" name="Días promedio" radius={[0, 4, 4, 0]}>
+								<Bar
+									dataKey="avgDias"
+									name="Días promedio"
+									radius={[0, 4, 4, 0]}
+								>
 									{chartData.map((entry) => (
 										<Cell
 											key={entry.rawSource}
@@ -295,7 +317,9 @@ export function TiempoCierreContent() {
 											<div className="flex items-center gap-2">
 												<span
 													className="h-2.5 w-2.5 shrink-0 rounded-full"
-													style={{ backgroundColor: getSourceColor(row.rawSource) }}
+													style={{
+														backgroundColor: getSourceColor(row.rawSource),
+													}}
 												/>
 												{row.source}
 											</div>


### PR DESCRIPTION
## Resumen

Mejoras de filtros y UI en reportes (ventas + admin). Todo frontend.

### Nuevo componente
- **`RangePresetFilter`**: filtro de fechas por **presets** (Este mes · Últimos 3 meses · Últimos 6 meses · Este año · Personalizado) con etiqueta del rango resuelto. La opción *Personalizado* abre el calendario de rango libre.

### Reportes de Ventas (`/crm/reportes`)
- **Tiempo Cierre Crédito** y **Porcentaje Efectividad**: usan `RangePresetFilter` en lugar del calendario de rango libre (el `PeriodDatePicker` de admin no aplica porque son rangos libres, no por período).
- **Porcentaje Efectividad**: la tabla de **registros individuales** se movió del inicio al **final** del reporte (queda: resumen → efectividad por fuente → detalle por fuente → registros).
- **Meta de Colocación**: los `<select>` nativos de mes/año se reemplazaron por el componente **`Select`** de shadcn.

### Reportes Admin (`/admin/reports`)
- **Cobertura de Colocación vs Meta**: el control de **RANGO** ahora usa `PeriodDatePicker` (año + meses) para ser consistente con el reporte de **Cobranza**, en vez del calendario de rango libre.

## Verificación
- `tsc` (web) y Biome en verde. Sin cambios de backend ni de esquema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)