### PR TITLE
🚀 Pase a Producción — Release develop → main

### DIFF
--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -1,5 +1,5 @@
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
-import { db } from "../database";
+import { client, db } from "../database";
 import { asesores, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, platform_users, usuarios } from "../database/db/schema";
 import Big from "big.js";
 import { toZonedTime } from "date-fns-tz";
@@ -490,10 +490,27 @@ export async function updateMora({
  *    - Update the credit status to "MOROSO".
  * 5. Log every step for debugging and monitoring.
  */
+// Clave fija para el advisory lock de procesarMoras (cualquier int estable sirve).
+const PROCESAR_MORAS_LOCK_KEY = 728193;
+
 export async function procesarMoras() {
   const zona = "America/Guatemala";
 
+  // 🔒 Lock entre instancias: con varias réplicas del back, todas agendan el cron
+  // (23:59 GT) y corrían EN PARALELO leyendo el mismo estado viejo → duplicaban
+  // eventos en moras_historial y, peor, filas activa=true en moras_credito.
+  // Tomamos un advisory lock en una conexión dedicada; si otra corrida ya lo tiene,
+  // se omite esta. (El índice único parcial moras_credito_uq_activa es el respaldo duro.)
+  const lockConn = await client.connect();
+  let lockHeld = false;
   try {
+    const _lk = await lockConn.query("SELECT pg_try_advisory_lock($1) AS ok", [PROCESAR_MORAS_LOCK_KEY]);
+    lockHeld = _lk.rows[0]?.ok === true;
+    if (!lockHeld) {
+      console.log("[MORA] ⏭️  Otra instancia ya está procesando moras; se omite esta corrida.");
+      return { skipped: true, creadas: 0, recalculadas: 0, sinCambios: 0, desactivadas: 0, sinCapital: 0 };
+    }
+
     const hoy = toZonedTime(new Date(), zona);
     hoy.setHours(0, 0, 0, 0);
 
@@ -622,16 +639,27 @@ export async function procesarMoras() {
 
       if (!moraActual) {
         // CREACION
-        const [insertada] = await db
-          .insert(moras_credito)
-          .values({
-            credito_id: creditoId,
-            monto_mora: moraNuevaStr,
-            cuotas_atrasadas: cuotasAtrasadas,
-            activa: true,
-            porcentaje_mora: "1.12",
-          })
-          .returning();
+        let insertada;
+        try {
+          [insertada] = await db
+            .insert(moras_credito)
+            .values({
+              credito_id: creditoId,
+              monto_mora: moraNuevaStr,
+              cuotas_atrasadas: cuotasAtrasadas,
+              activa: true,
+              porcentaje_mora: "1.12",
+            })
+            .returning();
+        } catch (e: any) {
+          // Índice único parcial moras_credito_uq_activa: otra corrida concurrente
+          // ya creó la mora activa de este crédito → omitir (no duplicar).
+          if (e?.code === "23505") {
+            console.log(`[SKIP] Credit #${creditoId} mora ya creada por otra instancia (índice único)`);
+            continue;
+          }
+          throw e;
+        }
 
         await db
           .update(creditos)
@@ -756,6 +784,15 @@ export async function procesarMoras() {
     console.error("[ERROR] Message:", error.message);
     console.error("[ERROR] Stack trace:", error.stack);
     throw error;
+  } finally {
+    if (lockHeld) {
+      try {
+        await lockConn.query("SELECT pg_advisory_unlock($1)", [PROCESAR_MORAS_LOCK_KEY]);
+      } catch {
+        /* el lock se libera solo al cerrar la sesión; no es crítico */
+      }
+    }
+    lockConn.release();
   }
 }
 

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -3,6 +3,7 @@ import Big from "big.js";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
+  esDestinoSobrescribible,
   getCuotaIdForPaymentInsert,
   getRequestedInstallmentFloor,
   getSpecialPaymentCuotaId,
@@ -303,6 +304,246 @@ describe("regresión: mora/otros no debe colapsar el saldo de la cuota", () => {
       hermanosIva: 0,
     });
     expect(saldo.saldoRealCuota.toFixed(2)).toBe("1000.00");
+  });
+});
+
+// Bug crédito 217 / cuota #8: el placeholder `no_required` de la cuota YA fue
+// consumido por un parcial anterior (esa fila pasó a `validated` con
+// `abono_interes` real, ya facturado). Al llegar el pago que CIERRA la cuota,
+// `pagoOriginal` (no_required) es undefined y `existingPago` cae al fallback
+// `allExistingPagos[0]` = la fila REAL más vieja. El cierre hacía UPDATE sobre
+// esa fila, BORRANDO un pago de interés validado/facturado. El fix: el cierre
+// solo puede UPDATE-ar un destino realmente desechable; si no, INSERTA fila nueva.
+describe("esDestinoSobrescribible", () => {
+  it("el placeholder no_required SIEMPRE es sobrescribible (aunque trajera saldos)", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "no_required",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+      })
+    ).toBe(true);
+  });
+
+  it("una fila vacía (monto_aplicado≈0 y todos los abono_* ≈0) es sobrescribible", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+        abono_iva_12: "0",
+        abono_seguro: "0",
+        abono_gps: "0",
+        membresias_pago: "0",
+      })
+    ).toBe(true);
+  });
+
+  it("tolera centavos de ruido al medir 'vacío'", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "0.00",
+        abono_capital: "0.005",
+        abono_interes: "0",
+      })
+    ).toBe(true);
+  });
+
+  it("un pago REAL (con abono_interes validado) NO es sobrescribible", () => {
+    // Caso crédito 217: fila validated con interés real ya facturado.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "1151.00",
+        abono_capital: "0",
+        abono_interes: "1027.68",
+        abono_iva_12: "123.32",
+        abono_seguro: "0",
+        abono_gps: "0",
+        membresias_pago: "0",
+      })
+    ).toBe(false);
+  });
+
+  it("una fila con monto_aplicado real pero rubros en 0 NO es sobrescribible", () => {
+    // p.ej. fila solo-mora/otros con plata aplicada: no la queremos pisar.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "200.00",
+        abono_capital: "0",
+        abono_interes: "0",
+      })
+    ).toBe(false);
+  });
+
+  it("una fila con solo abono_capital real NO es sobrescribible", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_capital: "500.00",
+        abono_interes: "0",
+      })
+    ).toBe(false);
+  });
+});
+
+// Réplica pura del árbol de decisión insert-vs-update del cierre en
+// `insertPayment` (registerPayment.ts ~1378): NO toca DB; modela exactamente la
+// rama elegida y el conjunto de filas resultante de la cuota, para asegurar que
+// (a) la fila real preexistente nunca se sobrescribe, (b) se INSERTA una fila de
+// cierre, y (c) no se pierde ni se duplica plata en la cuota.
+type FilaCuota = {
+  pago_id: number;
+  validationStatus: string;
+  monto_aplicado: string;
+  abono_capital: string;
+  abono_interes: string;
+  abono_iva_12: string;
+};
+
+const sumaRubrosCuota = (filas: FilaCuota[]) =>
+  filas
+    .reduce(
+      (acc, f) =>
+        acc
+          .plus(new Big(f.abono_capital))
+          .plus(new Big(f.abono_interes))
+          .plus(new Big(f.abono_iva_12)),
+      new Big(0)
+    )
+    .toFixed(2);
+
+/**
+ * Aplica la decisión de cierre tal como lo hace el controlador:
+ *  - pagado && destinoSobrescribible → UPDATE sobre existingPago.
+ *  - pagado && !destinoSobrescribible → INSERT fila de cierre nueva.
+ *  - !pagado → INSERT parcial.
+ * Devuelve el nuevo set de filas de la cuota.
+ */
+const aplicarDecisionCierre = (
+  filas: FilaCuota[],
+  existingPagoId: number,
+  pagoData: {
+    pagado: boolean;
+    abono_capital: string;
+    abono_interes: string;
+    abono_iva_12: string;
+    monto_aplicado: string;
+  }
+): FilaCuota[] => {
+  const existing = filas.find((f) => f.pago_id === existingPagoId)!;
+  const sobrescribible = esDestinoSobrescribible(existing);
+  const nuevaFila: FilaCuota = {
+    pago_id: Math.max(...filas.map((f) => f.pago_id)) + 1,
+    validationStatus: "pending",
+    monto_aplicado: pagoData.monto_aplicado,
+    abono_capital: pagoData.abono_capital,
+    abono_interes: pagoData.abono_interes,
+    abono_iva_12: pagoData.abono_iva_12,
+  };
+
+  if (pagoData.pagado && sobrescribible) {
+    return filas.map((f) =>
+      f.pago_id === existingPagoId
+        ? {
+            ...f,
+            validationStatus: "pending",
+            monto_aplicado: pagoData.monto_aplicado,
+            abono_capital: pagoData.abono_capital,
+            abono_interes: pagoData.abono_interes,
+            abono_iva_12: pagoData.abono_iva_12,
+          }
+        : f
+    );
+  }
+  // INSERT (cierre-nuevo o parcial): se preservan todas las filas previas.
+  return [...filas, nuevaFila];
+};
+
+describe("cierre de cuota: no sobrescribe un pago real cuando el no_required ya fue consumido", () => {
+  it("INSERTA una fila de cierre y conserva la fila validated preexistente (crédito 217 / cuota 8)", () => {
+    // Estado: el placeholder no_required YA fue consumido por un parcial → no
+    // existe fila no_required; queda una fila `validated` con interés real
+    // (Q1151 ya facturado) y la cuota aún tiene capital pendiente.
+    const filasPrevias: FilaCuota[] = [
+      {
+        pago_id: 5001, // fila REAL (parcial validado de interés, ya facturado)
+        validationStatus: "validated",
+        monto_aplicado: "1151.00",
+        abono_capital: "0",
+        abono_interes: "1027.68",
+        abono_iva_12: "123.32",
+      },
+    ];
+    // existingPago cae al fallback allExistingPagos[0] = la fila real 5001.
+    const existingPagoId = 5001;
+    expect(esDestinoSobrescribible(filasPrevias[0])).toBe(false);
+
+    // Pago que CIERRA la cuota: cubre el capital faltante (cuota = 2151).
+    const pagoData = {
+      pagado: true,
+      abono_capital: "1000.00",
+      abono_interes: "0",
+      abono_iva_12: "0",
+      monto_aplicado: "1000.00",
+    };
+
+    const resultado = aplicarDecisionCierre(
+      filasPrevias,
+      existingPagoId,
+      pagoData
+    );
+
+    // (a) la fila validated preexistente NO se modificó.
+    const filaPreexistente = resultado.find((f) => f.pago_id === 5001)!;
+    expect(filaPreexistente.validationStatus).toBe("validated");
+    expect(filaPreexistente.abono_interes).toBe("1027.68");
+    expect(filaPreexistente.monto_aplicado).toBe("1151.00");
+
+    // (b) se INSERTÓ una fila nueva de cierre.
+    expect(resultado).toHaveLength(2);
+    const filaCierre = resultado.find((f) => f.pago_id !== 5001)!;
+    expect(filaCierre.abono_capital).toBe("1000.00");
+
+    // (c) Σ de rubros de la cuota = composición real (1151 previo + 1000 cierre
+    //     = 2151), sin perder ni duplicar plata.
+    expect(sumaRubrosCuota(resultado)).toBe("2151.00");
+  });
+
+  it("comportamiento intacto: con placeholder no_required vivo el cierre hace UPDATE (no inserta)", () => {
+    // Caso normal: existe el placeholder no_required (sin rubros). El cierre lo
+    // sobrescribe (UPDATE) → NO crece el número de filas.
+    const filasPrevias: FilaCuota[] = [
+      {
+        pago_id: 7001, // placeholder no_required (pago_id == cuota_id típicamente)
+        validationStatus: "no_required",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+        abono_iva_12: "0",
+      },
+    ];
+    const pagoData = {
+      pagado: true,
+      abono_capital: "1900.00",
+      abono_interes: "224.11",
+      abono_iva_12: "26.89",
+      monto_aplicado: "2151.00",
+    };
+
+    const resultado = aplicarDecisionCierre(filasPrevias, 7001, pagoData);
+
+    // UPDATE: misma cantidad de filas, el placeholder ahora trae el cierre.
+    expect(resultado).toHaveLength(1);
+    expect(resultado[0].pago_id).toBe(7001);
+    expect(resultado[0].validationStatus).toBe("pending");
+    expect(resultado[0].abono_capital).toBe("1900.00");
+    expect(sumaRubrosCuota(resultado)).toBe("2151.00");
   });
 });
 

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -407,6 +407,41 @@ describe("esDestinoSobrescribible", () => {
       })
     ).toBe(false);
   });
+
+  it("un pago de solo MORA (monto_aplicado/abono_* en 0) NO es sobrescribible", () => {
+    // Codex P2: insertarPago crea filas mora/otros con monto_aplicado:0 y
+    // abono_* en 0 pero plata en mora. No debe tratarse como vacío.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+        mora: "150.00",
+      })
+    ).toBe(false);
+  });
+
+  it("un pago de solo OTROS (TEXT con monto) NO es sobrescribible", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "pending",
+        monto_aplicado: "0",
+        abono_interes: "0",
+        otros: "300.00",
+      })
+    ).toBe(false);
+  });
+
+  it("una fila con `otros` vacío/no-numérico SÍ puede ser vacía", () => {
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "no_required",
+        monto_aplicado: "0",
+        otros: "",
+      })
+    ).toBe(true);
+  });
 });
 
 // Réplica pura del árbol de decisión insert-vs-update del cierre en

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -352,6 +352,23 @@ describe("esDestinoSobrescribible", () => {
     ).toBe(true);
   });
 
+  it("un pago real de EXACTAMENTE Q0.01 NO es sobrescribible (numeric(2) es exacto)", () => {
+    // Codex P2: con `lte(0.01)` un parcial de un centavo se trataba como vacío
+    // y el cierre lo machacaba. Debe contar como pago real.
+    expect(
+      esDestinoSobrescribible({
+        validationStatus: "validated",
+        monto_aplicado: "0.01",
+        abono_capital: "0",
+        abono_interes: "0.01",
+        abono_iva_12: "0",
+        abono_seguro: "0",
+        abono_gps: "0",
+        membresias_pago: "0",
+      })
+    ).toBe(false);
+  });
+
   it("un pago REAL (con abono_interes validado) NO es sobrescribible", () => {
     // Caso crédito 217: fila validated con interés real ya facturado.
     expect(

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -22,6 +22,7 @@ import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
+  esDestinoSobrescribible,
   getCuotaIdForPaymentInsert,
   getRequestedInstallmentFloor,
   getSpecialPaymentInstallmentFields,
@@ -911,7 +912,20 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
         // normal del loop. `aplicadoPrevioCuota`/`interesPrevioCuota` los
         // reusa la red de seguridad de más abajo.
         const TOLERANCIA_CENTAVO = new Big(0.01);
-        const pagoIdEnVuelo = existingPago?.pago.pago_id ?? -1;
+        // ¿`existingPago` es una fila desechable que el cierre puede SOBRESCRIBIR
+        // (placeholder `no_required` o fila vacía), o es un pago REAL que cayó al
+        // fallback `allExistingPagos[0]` porque el `no_required` ya fue consumido?
+        // De esto depende todo: si NO es sobrescribible, el cierre INSERTA una
+        // fila nueva (no la pisa) y, por lo mismo, `existingPago` es un hermano
+        // REAL que SÍ debe contarse. Solo lo excluimos del set de hermanos cuando
+        // realmente lo vamos a UPDATE-ar (i.e. cuando es sobrescribible); si no,
+        // contar sus rubros evita re-aplicar interés/IVA/etc.
+        const destinoSobrescribible = existingPago
+          ? esDestinoSobrescribible(existingPago.pago)
+          : false;
+        const pagoIdEnVuelo = destinoSobrescribible
+          ? existingPago!.pago.pago_id
+          : -1;
         const pagosHermanos = await db
           .select({
             pago_id: pagos_credito.pago_id,
@@ -1362,7 +1376,11 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
           console.log("cuota_id:", cuota);
           console.log("pagoInsertado:", pagoData);
           if (pagoData) {
-            if (pagoData.pagado) {
+            if (pagoData.pagado && destinoSobrescribible) {
+              // ── CIERRE sobre fila DESECHABLE (UPDATE) ──────────────────────
+              // `existingPago` es el placeholder `no_required` o una fila vacía:
+              // pisarla con el pago de cierre no destruye plata. Comportamiento
+              // histórico para el caso normal.
               cuotas_completas++;
               console.log(
                 `✅ Cuota ${cuota.cuotas_credito.numero_cuota} PAGADA COMPLETAMENTE`
@@ -1402,7 +1420,133 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
                 );
               }
 
-             
+
+            } else if (pagoData.pagado) {
+              // ── CIERRE sin fila desechable (INSERT de fila de cierre) ──────
+              // El placeholder `no_required` ya fue consumido por un parcial
+              // previo, así que `existingPago` cayó al fallback = una fila REAL
+              // (con interés/IVA ya validado, posiblemente facturado).
+              // Sobrescribirla destruiría ese pago (caso crédito 217 / cuota 8).
+              // En su lugar INSERTAMOS una fila nueva de cierre (igual que un
+              // parcial pero `pagado: true` y restantes en 0). El UPDATE masivo
+              // de abajo marca toda la cuota como pagada.
+              cuotas_completas++;
+              console.log(
+                `✅ Cuota ${cuota.cuotas_credito.numero_cuota} PAGADA COMPLETAMENTE (fila de cierre NUEVA: el destino existente es un pago real y no se sobrescribe)`
+              );
+
+              const guatemalaTimeString = new Date().toLocaleString("en-US", {
+                timeZone: "America/Guatemala",
+                year: "numeric",
+                month: "2-digit",
+                day: "2-digit",
+                hour: "2-digit",
+                minute: "2-digit",
+                second: "2-digit",
+                hour12: false,
+              });
+              const [datePart, timePart] = guatemalaTimeString.split(", ");
+              const [month, day, year] = datePart.split("/");
+              const fechaGuatemala = new Date(
+                `${year}-${month}-${day}T${timePart}`
+              );
+
+              [pagoInsertado] = await db
+                .insert(pagos_credito)
+                .values({
+                  // Campos requeridos del input
+                  cuota_id: cuota.cuotas_credito.cuota_id,
+                  renuevo_o_nuevo: pagoData.renuevo_o_nuevo,
+                  credito_id: pagoData.credito_id,
+                  // Campos que vienen del crédito/cuota
+                  cuota: credito.cuota,
+                  cuota_interes: credito.cuota_interes,
+                  fecha_pago: fechaGuatemala,
+                  fecha_vencimiento: cuota.cuotas_credito.fecha_vencimiento
+                    ? new Date(
+                        cuota.cuotas_credito.fecha_vencimiento
+                      ).toISOString()
+                    : undefined,
+
+                  // Abonos (calculados según lógica de distribución)
+                  abono_capital: pagoData.abono_capital,
+                  abono_interes: pagoData.abono_interes,
+                  abono_iva_12: pagoData.abono_iva_12,
+                  abono_interes_ci: pagoData.abono_interes_ci,
+                  abono_iva_ci: pagoData.abono_iva_ci,
+                  abono_seguro: pagoData.abono_seguro,
+                  abono_gps: pagoData.abono_gps,
+                  pago_del_mes: pagoData.pago_del_mes,
+
+                  // Restantes en 0: esta fila cierra la cuota.
+                  capital_restante: "0",
+                  interes_restante: "0",
+                  iva_12_restante: "0",
+                  seguro_restante: "0",
+                  gps_restante: "0",
+                  total_restante:
+                    pagoSaldoVigente?.pago.total_restante ??
+                    credito.capital ??
+                    "0",
+
+                  // Membresías
+                  membresias: "0",
+                  membresias_pago: pagoData.membresias_pago,
+                  membresias_mes: pagoData.membresias_mes,
+
+                  // Campos adicionales del input
+                  llamada: pagoData.llamada || "",
+                  otros: pagoData.otros,
+                  mora: pagoData.mora,
+                  monto_boleta_cuota: montoBoleta.toString(),
+                  monto_boleta: montoBoleta.toString(),
+                  observaciones: pagoData.observaciones,
+
+                  // Seguros y GPS
+                  seguro_total: pagoData.seguro_total,
+                  seguro_facturado: pagoData.seguro_facturado,
+                  gps_facturado: pagoData.gps_facturado,
+                  reserva: pagoData.reserva,
+
+                  // Campos de estado: fila de cierre (pagado:true, pending hasta
+                  // que contabilidad valida).
+                  pagado: true,
+                  facturacion: pagoData.facturacion || "si",
+                  mes_pagado: pagoData.mes_pagado,
+                  paymentFalse: pagoData.paymentFalse || false,
+                  validationStatus: "pending",
+                  banco_id: pagoData.banco_id || null,
+                  numeroAutorizacion: pagoData.numeroAutorizacion || null,
+                  registerBy: pagoData.registerBy,
+                  pagoConvenio: montoConvenio.toString() || "0",
+                  fecha_boleta: pagoData.fecha_boleta,
+                  monto_aplicado: pagoData.monto_aplicado,
+                  // Paridad con la rama UPDATE de cierre (que persiste pagoData
+                  // completo): conservar el origen del pago en la fila de cierre.
+                  origen_pago: pagoData.origen_pago,
+                })
+                .returning();
+
+              // Marcar TODA la cuota como pagada (igual que la rama UPDATE).
+              await db
+                .update(pagos_credito)
+                .set({ pagado: true })
+                .where(
+                  eq(pagos_credito.cuota_id, cuota.cuotas_credito.cuota_id)
+                );
+
+              if (
+                pagoInsertado?.pago_id &&
+                urlCompletas &&
+                urlCompletas.length > 0
+              ) {
+                await db.insert(boletas).values(
+                  urlCompletas.map((url) => ({
+                    pago_id: pagoInsertado!.pago_id,
+                    url_boleta: url,
+                  }))
+                );
+              }
             } else {
               disponible_para_cuotasPosteriores =
                 disponible_para_cuotasPosteriores.plus(disponible);

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -67,6 +67,59 @@ export const getSpecialPaymentInstallmentFields = () => ({
   pagado: true,
 });
 
+// Tolerancia de un centavo al comparar montos de pago contra cero.
+export const DESTINO_SOBRESCRIBIBLE_TOLERANCE = 0.01;
+
+/** Subconjunto de una fila de pago necesario para decidir si es sobrescribible. */
+export type DestinoSobrescribibleRow = {
+  validationStatus?: string | null;
+  monto_aplicado?: BigInput | null;
+  abono_capital?: BigInput | null;
+  abono_interes?: BigInput | null;
+  abono_iva_12?: BigInput | null;
+  abono_seguro?: BigInput | null;
+  abono_gps?: BigInput | null;
+  membresias_pago?: BigInput | null;
+};
+
+/**
+ * ¿La fila de pago elegida como `existingPago` se puede SOBRESCRIBIR (UPDATE) al
+ * cerrar la cuota, sin destruir plata real?
+ *
+ * El cierre de una cuota hace `UPDATE pagos_credito SET <pagoData> WHERE
+ * pago_id = existingPago`. Eso es seguro SOLO si la fila destino es desechable:
+ *
+ *  - El placeholder `no_required` importado de SIFCO (su único propósito es
+ *    portar los `*_restante`; no representa plata aplicada), o
+ *  - Una fila "vacía": `monto_aplicado ≈ 0` Y todos los `abono_*` ≈ 0 (p.ej. una
+ *    fila estructural sin rubros de cuota).
+ *
+ * Cuando el placeholder `no_required` ya fue consumido por un parcial previo,
+ * `existingPago` cae al fallback `allExistingPagos[0]` = la fila REAL más vieja
+ * (con `abono_interes` validado, posiblemente ya facturado). Sobrescribirla
+ * borraría ese pago. En ese caso esta función devuelve `false` y el caller debe
+ * INSERTAR una fila de cierre nueva en vez de hacer UPDATE.
+ */
+export const esDestinoSobrescribible = (
+  pago: DestinoSobrescribibleRow
+): boolean => {
+  if (pago.validationStatus === "no_required") return true;
+
+  const tol = new Big(DESTINO_SOBRESCRIBIBLE_TOLERANCE);
+  const casiCero = (v: BigInput | null | undefined) =>
+    new Big(v ?? 0).abs().lte(tol);
+
+  return (
+    casiCero(pago.monto_aplicado) &&
+    casiCero(pago.abono_capital) &&
+    casiCero(pago.abono_interes) &&
+    casiCero(pago.abono_iva_12) &&
+    casiCero(pago.abono_seguro) &&
+    casiCero(pago.abono_gps) &&
+    casiCero(pago.membresias_pago)
+  );
+};
+
 export type SaldoCuotaInput = {
   /** Monto total de la cuota (credito.cuota). */
   montoCuota: BigInput;

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -85,6 +85,14 @@ export type DestinoSobrescribibleRow = {
   abono_seguro?: BigInput | null;
   abono_gps?: BigInput | null;
   membresias_pago?: BigInput | null;
+  abono_interes_ci?: BigInput | null;
+  abono_iva_ci?: BigInput | null;
+  // Buckets de plata que un pago de solo mora/otros/convenio (insertarPago /
+  // getSpecialPaymentInstallmentFields) lleva con `monto_aplicado` y `abono_*`
+  // en 0 — hay que contarlos o el cierre los machacaría. `otros` es TEXT.
+  mora?: BigInput | null;
+  pagoConvenio?: BigInput | null;
+  otros?: string | number | null;
 };
 
 /**
@@ -96,8 +104,10 @@ export type DestinoSobrescribibleRow = {
  *
  *  - El placeholder `no_required` importado de SIFCO (su único propósito es
  *    portar los `*_restante`; no representa plata aplicada), o
- *  - Una fila "vacía": `monto_aplicado ≈ 0` Y todos los `abono_*` ≈ 0 (p.ej. una
- *    fila estructural sin rubros de cuota).
+ *  - Una fila "vacía": SIN plata en NINGÚN bucket — `monto_aplicado`, todos los
+ *    `abono_*`, y también `mora`, `pagoConvenio` y `otros` ≈ 0. (Un pago de solo
+ *    mora/otros/convenio lleva `monto_aplicado`/`abono_*` en 0 pero plata en
+ *    esos otros campos; si no se contaran, el cierre lo machacaría.)
  *
  * Cuando el placeholder `no_required` ya fue consumido por un parcial previo,
  * `existingPago` cae al fallback `allExistingPagos[0]` = la fila REAL más vieja
@@ -114,6 +124,13 @@ export const esDestinoSobrescribible = (
   // Estricto (`lt`, no `lte`): un Q0.01 exacto es un pago real, no "vacío".
   const casiCero = (v: BigInput | null | undefined) =>
     new Big(v ?? 0).abs().lt(tol);
+  // `otros` es TEXT y puede venir null/''/no-numérico → parsear con guard.
+  const otrosCasiCero = (v: string | number | null | undefined) => {
+    if (v == null) return true;
+    const s = String(v).trim();
+    if (s === "" || !/^-?\d+(\.\d+)?$/.test(s)) return true;
+    return new Big(s).abs().lt(tol);
+  };
 
   return (
     casiCero(pago.monto_aplicado) &&
@@ -122,7 +139,13 @@ export const esDestinoSobrescribible = (
     casiCero(pago.abono_iva_12) &&
     casiCero(pago.abono_seguro) &&
     casiCero(pago.abono_gps) &&
-    casiCero(pago.membresias_pago)
+    casiCero(pago.membresias_pago) &&
+    casiCero(pago.abono_interes_ci) &&
+    casiCero(pago.abono_iva_ci) &&
+    // Plata real fuera de los abono_* de cuota: mora, convenio y otros.
+    casiCero(pago.mora) &&
+    casiCero(pago.pagoConvenio) &&
+    otrosCasiCero(pago.otros)
   );
 };
 

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -67,7 +67,12 @@ export const getSpecialPaymentInstallmentFields = () => ({
   pagado: true,
 });
 
-// Tolerancia de un centavo al comparar montos de pago contra cero.
+// Umbral para considerar un monto "cero". Las columnas monetarias son
+// numeric(2), así que el mínimo pago real representable es Q0.01: una fila se
+// considera vacía solo si cada monto es ESTRICTAMENTE menor a un centavo (i.e.
+// 0.00). Un Q0.01 es un pago real y NO debe tratarse como sobrescribible (con
+// `lte` el cierre lo machacaría, reintroduciendo la pérdida para parciales de
+// un centavo).
 export const DESTINO_SOBRESCRIBIBLE_TOLERANCE = 0.01;
 
 /** Subconjunto de una fila de pago necesario para decidir si es sobrescribible. */
@@ -106,8 +111,9 @@ export const esDestinoSobrescribible = (
   if (pago.validationStatus === "no_required") return true;
 
   const tol = new Big(DESTINO_SOBRESCRIBIBLE_TOLERANCE);
+  // Estricto (`lt`, no `lte`): un Q0.01 exacto es un pago real, no "vacío".
   const casiCero = (v: BigInput | null | undefined) =>
-    new Big(v ?? 0).abs().lte(tol);
+    new Big(v ?? 0).abs().lt(tol);
 
   return (
     casiCero(pago.monto_aplicado) &&

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1200,3 +1200,111 @@ export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?:
 
   return { totales: serializeBuckets(totalAcc), porAsesor };
 }
+
+export async function getCuotasPorFecha({
+  fechaInicio,
+  fechaFin,
+  emailAsesor,
+}: {
+  fechaInicio: string;
+  fechaFin: string;
+  emailAsesor?: string;
+}) {
+  const asesorFilter = emailAsesor
+    ? sql`AND a.email_cash_in = ${emailAsesor}`
+    : sql``;
+
+  const result = await db.execute(sql`
+    SELECT
+      c.cuota_id,
+      c.numero_cuota,
+      c.fecha_vencimiento,
+      c.pagado,
+      cr.credito_id,
+      cr.numero_credito_sifco,
+      u.nombre            AS cliente_nombre,
+      a.nombre            AS asesor_nombre,
+      a.email_cash_in     AS asesor_email,
+      cr."statusCredit",
+      -- Capital from amortization: prev cuota total_restante - current cuota total_restante
+      CASE
+        WHEN prev_pag.total_restante IS NOT NULL AND curr_pag.total_restante IS NOT NULL
+        THEN prev_pag.total_restante - curr_pag.total_restante
+        ELSE COALESCE(cr.cuota::numeric
+          - cr.cuota_interes::numeric
+          - cr.iva_12::numeric
+          - COALESCE(cr.seguro_10_cuotas::numeric, 0)
+          - COALESCE(cr.gps::numeric, 0)
+          - COALESCE(cr.membresias_pago::numeric, 0), 0)
+      END AS capital_esperado,
+      -- Interes from amortization: (cuota - capital - seguro - gps - membresias) * 100/112
+      CASE
+        WHEN prev_pag.total_restante IS NOT NULL AND curr_pag.total_restante IS NOT NULL
+        THEN GREATEST(0, (
+          cr.cuota::numeric
+          - (prev_pag.total_restante - curr_pag.total_restante)
+          - COALESCE(cr.seguro_10_cuotas::numeric, 0)
+          - COALESCE(cr.gps::numeric, 0)
+          - COALESCE(cr.membresias_pago::numeric, 0)
+        ) * 100.0 / 112.0)
+        ELSE COALESCE(cr.cuota_interes::numeric, 0)
+      END AS interes_esperado,
+      -- IVA from amortization: (cuota - capital - seguro - gps - membresias) * 12/112
+      CASE
+        WHEN prev_pag.total_restante IS NOT NULL AND curr_pag.total_restante IS NOT NULL
+        THEN GREATEST(0, (
+          cr.cuota::numeric
+          - (prev_pag.total_restante - curr_pag.total_restante)
+          - COALESCE(cr.seguro_10_cuotas::numeric, 0)
+          - COALESCE(cr.gps::numeric, 0)
+          - COALESCE(cr.membresias_pago::numeric, 0)
+        ) * 12.0 / 112.0)
+        ELSE COALESCE(cr.iva_12::numeric, 0)
+      END AS iva_esperado,
+      COALESCE(cr.seguro_10_cuotas::numeric, 0)       AS seguro_esperado,
+      COALESCE(cr.gps::numeric, 0)                    AS gps_esperado,
+      COALESCE(cr.membresias_pago::numeric, 0)        AS membresias_esperado,
+      COALESCE(cr.cuota::numeric, 0)                  AS total_esperado,
+      COALESCE(pag.abono_capital, 0)                  AS capital_pagado,
+      COALESCE(pag.abono_interes, 0)                  AS interes_pagado,
+      COALESCE(pag.abono_iva, 0)                      AS iva_pagado,
+      COALESCE(pag.abono_seguro, 0)                   AS seguro_pagado,
+      COALESCE(pag.abono_gps, 0)                      AS gps_pagado,
+      COALESCE(pag.total_pagado, 0)                   AS total_pagado
+    FROM cartera.cuotas_credito c
+    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+    JOIN cartera.usuarios u  ON cr.usuario_id = u.usuario_id
+    LEFT JOIN cartera.asesores a ON cr.asesor_id = a.asesor_id
+    LEFT JOIN LATERAL (
+      SELECT MAX(pc_prev.total_restante::numeric) AS total_restante
+      FROM cartera.pagos_credito pc_prev
+      JOIN cartera.cuotas_credito qc_prev ON pc_prev.cuota_id = qc_prev.cuota_id
+      WHERE qc_prev.credito_id = c.credito_id
+        AND qc_prev.numero_cuota = c.numero_cuota - 1
+    ) prev_pag ON true
+    LEFT JOIN LATERAL (
+      SELECT MAX(pc_curr.total_restante::numeric) AS total_restante
+      FROM cartera.pagos_credito pc_curr
+      WHERE pc_curr.cuota_id = c.cuota_id
+    ) curr_pag ON true
+    LEFT JOIN LATERAL (
+      SELECT
+        SUM(pc.abono_capital::numeric)  AS abono_capital,
+        SUM(pc.abono_interes::numeric)  AS abono_interes,
+        SUM(pc.abono_iva_12::numeric)   AS abono_iva,
+        SUM(pc.abono_seguro::numeric)   AS abono_seguro,
+        SUM(pc.abono_gps::numeric)      AS abono_gps,
+        SUM(pc.monto_aplicado::numeric) AS total_pagado
+      FROM cartera.pagos_credito pc
+      WHERE pc.cuota_id = c.cuota_id
+        AND pc."paymentFalse" = false
+    ) pag ON true
+    WHERE c.fecha_vencimiento::date >= ${fechaInicio}::date
+      AND c.fecha_vencimiento::date <= ${fechaFin}::date
+      AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
+      ${asesorFilter}
+    ORDER BY c.fecha_vencimiento ASC, cr.numero_credito_sifco ASC
+  `);
+
+  return result.rows;
+}

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1204,14 +1204,14 @@ export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?:
 export async function getCuotasPorFecha({
   fechaInicio,
   fechaFin,
-  emailAsesor,
+  asesorId,
 }: {
   fechaInicio: string;
   fechaFin: string;
-  emailAsesor?: string;
+  asesorId?: number;
 }) {
-  const asesorFilter = emailAsesor
-    ? sql`AND a.email_cash_in = ${emailAsesor}`
+  const asesorFilter = asesorId
+    ? sql`AND cr.asesor_id = ${asesorId}`
     : sql``;
 
   const result = await db.execute(sql`
@@ -1270,6 +1270,7 @@ export async function getCuotasPorFecha({
       COALESCE(pag.abono_iva, 0)                      AS iva_pagado,
       COALESCE(pag.abono_seguro, 0)                   AS seguro_pagado,
       COALESCE(pag.abono_gps, 0)                      AS gps_pagado,
+      COALESCE(pag.membresias_pagada, 0)              AS membresias_pagado,
       COALESCE(pag.total_pagado, 0)                   AS total_pagado
     FROM cartera.cuotas_credito c
     JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
@@ -1281,26 +1282,30 @@ export async function getCuotasPorFecha({
       JOIN cartera.cuotas_credito qc_prev ON pc_prev.cuota_id = qc_prev.cuota_id
       WHERE qc_prev.credito_id = c.credito_id
         AND qc_prev.numero_cuota = c.numero_cuota - 1
+        AND pc_prev."paymentFalse" = false
     ) prev_pag ON true
     LEFT JOIN LATERAL (
       SELECT MAX(pc_curr.total_restante::numeric) AS total_restante
       FROM cartera.pagos_credito pc_curr
       WHERE pc_curr.cuota_id = c.cuota_id
+        AND pc_curr."paymentFalse" = false
     ) curr_pag ON true
     LEFT JOIN LATERAL (
       SELECT
-        SUM(pc.abono_capital::numeric)  AS abono_capital,
-        SUM(pc.abono_interes::numeric)  AS abono_interes,
-        SUM(pc.abono_iva_12::numeric)   AS abono_iva,
-        SUM(pc.abono_seguro::numeric)   AS abono_seguro,
-        SUM(pc.abono_gps::numeric)      AS abono_gps,
-        SUM(pc.monto_aplicado::numeric) AS total_pagado
+        SUM(pc.abono_capital::numeric)    AS abono_capital,
+        SUM(pc.abono_interes::numeric)    AS abono_interes,
+        SUM(pc.abono_iva_12::numeric)     AS abono_iva,
+        SUM(pc.abono_seguro::numeric)     AS abono_seguro,
+        SUM(pc.abono_gps::numeric)        AS abono_gps,
+        SUM(pc.membresias_pago::numeric)  AS membresias_pagada,
+        SUM(pc.monto_aplicado::numeric)   AS total_pagado
       FROM cartera.pagos_credito pc
       WHERE pc.cuota_id = c.cuota_id
         AND pc."paymentFalse" = false
     ) pag ON true
     WHERE c.fecha_vencimiento::date >= ${fechaInicio}::date
       AND c.fecha_vencimiento::date <= ${fechaFin}::date
+      AND c.numero_cuota > 0
       AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
       ${asesorFilter}
     ORDER BY c.fecha_vencimiento ASC, cr.numero_credito_sifco ASC

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -390,11 +390,12 @@ export async function getCobradoDelMesSnapshot({
   const inicioMes = `${anio}-${String(mes).padStart(2, "0")}-01`;
   const result = await db.execute(sql`
     SELECT
-      COALESCE(SUM(capital_total::numeric), 0)          AS cobrado_capital,
       COALESCE(SUM(interes_cube::numeric), 0)           AS cobrado_interes,
       COALESCE(SUM(membresia::numeric), 0)              AS cobrado_membresias,
       COALESCE(SUM(servicios_seguro_gps::numeric), 0)   AS cobrado_seguro_gps,
-      COALESCE(SUM(royalty::numeric), 0)                AS cobrado_royalti
+      COALESCE(SUM(royalty::numeric), 0)                AS cobrado_royalti,
+      COALESCE(SUM(mora_cube::numeric), 0)              AS cobrado_mora,
+      COALESCE(SUM(otros_ingresos::numeric), 0)         AS cobrado_otros
     FROM cartera.facturacion_snapshot_diario
     WHERE fecha >= ${inicioMes}::date
       AND fecha < (${inicioMes}::date + INTERVAL '1 month')
@@ -402,11 +403,12 @@ export async function getCobradoDelMesSnapshot({
 
   const row = result.rows[0] as Record<string, unknown> | undefined;
   return {
-    cobrado_capital: String(row?.cobrado_capital ?? "0"),
     cobrado_interes: String(row?.cobrado_interes ?? "0"),
     cobrado_membresias: String(row?.cobrado_membresias ?? "0"),
     cobrado_seguro_gps: String(row?.cobrado_seguro_gps ?? "0"),
     cobrado_royalti: String(row?.cobrado_royalti ?? "0"),
+    cobrado_mora: String(row?.cobrado_mora ?? "0"),
+    cobrado_otros: String(row?.cobrado_otros ?? "0"),
   };
 }
 

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1282,6 +1282,7 @@ export async function getCuotasPorFecha({
       JOIN cartera.cuotas_credito qc_prev ON pc_prev.cuota_id = qc_prev.cuota_id
       WHERE qc_prev.credito_id = c.credito_id
         AND qc_prev.numero_cuota = c.numero_cuota - 1
+        AND qc_prev.numero_cuota > 0
         AND pc_prev."paymentFalse" = false
     ) prev_pag ON true
     LEFT JOIN LATERAL (
@@ -1298,7 +1299,14 @@ export async function getCuotasPorFecha({
         SUM(pc.abono_seguro::numeric)     AS abono_seguro,
         SUM(pc.abono_gps::numeric)        AS abono_gps,
         SUM(pc.membresias_pago::numeric)  AS membresias_pagada,
-        SUM(pc.monto_aplicado::numeric)   AS total_pagado
+        SUM(
+          COALESCE(pc.abono_capital::numeric, 0)
+          + COALESCE(pc.abono_interes::numeric, 0)
+          + COALESCE(pc.abono_iva_12::numeric, 0)
+          + COALESCE(pc.abono_seguro::numeric, 0)
+          + COALESCE(pc.abono_gps::numeric, 0)
+          + COALESCE(pc.membresias_pago::numeric, 0)
+        ) AS total_pagado
       FROM cartera.pagos_credito pc
       WHERE pc.cuota_id = c.cuota_id
         AND pc."paymentFalse" = false

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -291,23 +291,34 @@
     })
   );
 
-  export const moras_credito = customSchema.table("moras_credito", {
-    mora_id: serial("mora_id").primaryKey(),
-    credito_id: integer("credito_id")
-      .notNull()
-      .references(() => creditos.credito_id, { onDelete: "cascade" }),
-    activa: boolean("activa").notNull().default(true),
-    porcentaje_mora: numeric("porcentaje_mora", { precision: 5, scale: 2 })
-      .notNull()
-      .default("1.12"),
-    monto_mora: numeric("monto_mora", { precision: 18, scale: 2 })
-      .notNull()
-      .default("0"),
-    cuotas_atrasadas: integer("cuotas_atrasadas").notNull().default(0),
+  export const moras_credito = customSchema.table(
+    "moras_credito",
+    {
+      mora_id: serial("mora_id").primaryKey(),
+      credito_id: integer("credito_id")
+        .notNull()
+        .references(() => creditos.credito_id, { onDelete: "cascade" }),
+      activa: boolean("activa").notNull().default(true),
+      porcentaje_mora: numeric("porcentaje_mora", { precision: 5, scale: 2 })
+        .notNull()
+        .default("1.12"),
+      monto_mora: numeric("monto_mora", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      cuotas_atrasadas: integer("cuotas_atrasadas").notNull().default(0),
 
-    created_at: timestamp("created_at").defaultNow(),
-    updated_at: timestamp("updated_at").defaultNow(),
-  });
+      created_at: timestamp("created_at").defaultNow(),
+      updated_at: timestamp("updated_at").defaultNow(),
+    },
+    (t) => [
+      // Garantiza UNA sola mora activa por crédito. Bloquea a nivel BD la
+      // condición de carrera de procesarMoras corriendo en paralelo (varias
+      // réplicas) que insertaba filas activa=true duplicadas e inflaba el total.
+      uniqueIndex("moras_credito_uq_activa")
+        .on(t.credito_id)
+        .where(sql`${t.activa} = true`),
+    ]
+  );
   export const moras_condonaciones = customSchema.table("moras_condonaciones", {
     condonacion_id: serial("condonacion_id").primaryKey(),
     credito_id: integer("credito_id")

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
+import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -257,6 +257,31 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/mora-por-etapa-asesor]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/cuotas-por-fecha", async ({ query, set }) => {
+    try {
+      const { fecha_inicio, fecha_fin, email_asesor } = query as Record<string, string>;
+      if (!fecha_inicio || !fecha_fin) {
+        set.status = 400;
+        return { error: "fecha_inicio y fecha_fin son requeridos" };
+      }
+      if (!FECHA_REGEX.test(fecha_inicio) || !FECHA_REGEX.test(fecha_fin)) {
+        set.status = 400;
+        return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
+      }
+      const data = await getCuotasPorFecha({
+        fechaInicio: fecha_inicio,
+        fechaFin: fecha_fin,
+        emailAsesor: email_asesor,
+      });
+      set.status = 200;
+      return { ok: true, data };
+    } catch (error) {
+      console.error("[/reportes/cuotas-por-fecha]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -264,7 +264,7 @@ export const reportesRouter = new Elysia().use(authMiddleware)
 
   .get("/reportes/cuotas-por-fecha", async ({ query, set }) => {
     try {
-      const { fecha_inicio, fecha_fin, email_asesor } = query as Record<string, string>;
+      const { fecha_inicio, fecha_fin, asesor_id } = query as Record<string, string>;
       if (!fecha_inicio || !fecha_fin) {
         set.status = 400;
         return { error: "fecha_inicio y fecha_fin son requeridos" };
@@ -276,7 +276,7 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       const data = await getCuotasPorFecha({
         fechaInicio: fecha_inicio,
         fechaFin: fecha_fin,
-        emailAsesor: email_asesor,
+        asesorId: asesor_id ? Number(asesor_id) : undefined,
       });
       set.status = 200;
       return { ok: true, data };

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3957,175 +3957,82 @@ export const cobrosRouter = {
 		}),
 
 	// ========================================================================
-	// PAGOS ESPERADOS (COBROS)
+	// CUOTAS POR FECHA (reemplaza Pagos Esperados + Pagos No Recibidos)
 	// ========================================================================
 
-	getPagosEsperadosCobros: cobrosSupervisorProcedure
+	getCuotasPorFecha: cobrosSupervisorProcedure
 		.input(
 			z.object({
-				temporalidad: z.enum(["hoy", "semana", "quincena", "mes"]),
+				fechaInicio: z.string(),
+				fechaFin: z.string(),
+				emailAsesor: z.string().optional(),
 			}),
 		)
-		.handler(async ({ input }) => {
+		.handler(async ({ input, context }) => {
 			if (!isCarteraBackEnabled()) {
 				throw new ORPCError("BAD_REQUEST", {
 					message: "Integración con cartera-back no está habilitada",
 				});
 			}
 
-			const pad = (n: number) => n.toString().padStart(2, "0");
+			// Supervisores/admins pueden filtrar por asesor; el resto queda
+			// restringido a sus propios créditos.
+			const emailAsesor = PERMISSIONS.canAssignCobros(context.userRole)
+				? input.emailAsesor
+				: context.user?.email;
 
-			const diasAdelanteMap: Record<typeof input.temporalidad, number> = {
-				hoy: 0,
-				semana: 6,
-				quincena: 14,
-				mes: 29,
-			};
-			const diasAdelante = diasAdelanteMap[input.temporalidad];
-
-			// Las fechas de negocio son días calendario de Guatemala (UTC-6). Si el
-			// server corre en UTC, usar getFullYear/getMonth/getDate directo desplaza
-			// "hoy" un día entre las 00:00 y 05:59 UTC. Anclamos en la fecha GT y
-			// hacemos la aritmética de días sobre esos componentes en UTC puro.
-			const fechaInicio = toDateStrGT(new Date());
-			const [anioGT, mesGT, diaGT] = fechaInicio.split("-").map(Number);
-			const fechaFinUTC = new Date(
-				Date.UTC(anioGT, mesGT - 1, diaGT + diasAdelante),
-			);
-			const fechaFin = `${fechaFinUTC.getUTCFullYear()}-${pad(fechaFinUTC.getUTCMonth() + 1)}-${pad(fechaFinUTC.getUTCDate())}`;
-
-			const desglose = await carteraBackClient.getMontoACobrar({
-				periodo: "dia",
-				fechaInicio,
-				fechaFin,
+			const rows = await carteraBackClient.getCuotasPorFecha({
+				fechaInicio: input.fechaInicio,
+				fechaFin: input.fechaFin,
+				emailAsesor,
 			});
 
-			// Ojo: en cartera-back `total_cuota` ES el capital de las cuotas
-			// (mismo criterio que el reporte de monto-a-cobrar existente, que lo
-			// etiqueta "Capital" y calcula el total sumando todos los rubros).
-			let totalCapital = 0;
-			let totalInteres = 0;
-			let totalIva = 0;
-			let totalSeguro = 0;
-			let totalGps = 0;
-			let totalMembresias = 0;
-			let totalRoyalti = 0;
-			let cantidadCuotas = 0;
-
-			for (const row of desglose) {
-				totalCapital += Number.parseFloat(row.total_cuota);
-				totalInteres += Number.parseFloat(row.total_interes);
-				totalIva += Number.parseFloat(row.total_iva);
-				totalSeguro += Number.parseFloat(row.total_seguro);
-				totalGps += Number.parseFloat(row.total_gps);
-				totalMembresias += Number.parseFloat(row.total_membresias);
-				totalRoyalti += Number.parseFloat(row.total_royalti);
-				cantidadCuotas += row.cuotas_count;
-			}
-
-			const totalACobrar =
-				totalCapital +
-				totalInteres +
-				totalIva +
-				totalSeguro +
-				totalGps +
-				totalMembresias +
-				totalRoyalti;
-
-			return {
-				fechaInicio,
-				fechaFin,
-				temporalidad: input.temporalidad,
-				desglose,
-				totales: {
-					capital: totalCapital.toFixed(2),
-					interes: totalInteres.toFixed(2),
-					iva: totalIva.toFixed(2),
-					seguro: totalSeguro.toFixed(2),
-					gps: totalGps.toFixed(2),
-					membresias: totalMembresias.toFixed(2),
-					royalti: totalRoyalti.toFixed(2),
-					totalCuota: totalACobrar.toFixed(2),
-					cantidadCuotas,
-				},
-			};
-		}),
-
-	// ========================================================================
-	// PAGOS NO RECIBIDOS
-	// ========================================================================
-
-	getPagosNoRecibidos: cobrosSupervisorProcedure
-		.input(
-			z.object({
-				emailCobrador: z.string().optional(),
-				capitalMin: z.number().optional(),
-				capitalMax: z.number().optional(),
-				cuotasAtrasadasMin: z.number().min(1).optional(),
-				cuotasAtrasadasMax: z.number().min(1).optional(),
-				fechaDesde: z.string().optional(),
-				fechaHasta: z.string().optional(),
-				page: z.number().min(1).default(1),
-				pageSize: z.number().min(1).max(100).default(25),
-			}),
-		)
-		.handler(async ({ input }) => {
-			if (!isCarteraBackEnabled()) {
-				throw new ORPCError("BAD_REQUEST", {
-					message: "Integración con cartera-back no está habilitada",
-				});
-			}
-
-			// mes=0 trae TODOS los créditos sin filtrar por mes (mismo criterio
-			// que getTodosLosCreditos); con el mes actual cartera-back devuelve
-			// solo el snapshot mensual y el listado sale vacío.
-			const creditos = await obtenerTodasLasPaginasCreditos({
-				mes: 0,
-				anio: new Date().getFullYear(),
-				estado: "ACTIVO",
-				email_cobrador: input.emailCobrador,
-				capital_min: input.capitalMin,
-				capital_max: input.capitalMax,
-				fecha_desde: input.fechaDesde,
-				fecha_hasta: input.fechaHasta,
-			});
-
-			const minCuotas = input.cuotasAtrasadasMin ?? 1;
-
-			const todosOverdue = creditos.filter((item) => {
-				const cuotasAtrasadas = item.mora?.cuotas_atrasadas ?? 0;
-				if (cuotasAtrasadas < minCuotas) return false;
-				if (
-					input.cuotasAtrasadasMax !== undefined &&
-					cuotasAtrasadas > input.cuotasAtrasadasMax
-				)
-					return false;
-				return true;
-			});
-
-			const total = todosOverdue.length;
-			const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
-			const start = (input.page - 1) * input.pageSize;
-			const pageData = todosOverdue.slice(start, start + input.pageSize);
-
-			const items = pageData.map((item) => ({
-				sifco: item.creditos.numero_credito_sifco,
-				clienteNombre: item.usuarios.nombre,
-				asesorNombre: item.asesores?.nombre ?? "Sin asesor",
-				cuotasAtrasadas: item.mora?.cuotas_atrasadas ?? 0,
-				montoMora: item.mora?.monto_mora ?? "0",
-				capital: item.proxima_cuota?.capital_restante ?? item.creditos.capital,
-				cuotaMensual: item.creditos.cuota,
-				proximaFechaVencimiento: item.proxima_cuota?.fecha_vencimiento ?? null,
-				tipoCredito: item.creditos.tipoCredito ?? null,
+			const rowsMapped = rows.map((r) => ({
+				...r,
+				// Membresías no tiene abono propio: si la cuota está pagada se toma
+				// el monto esperado; de lo contrario se reporta como Q0.
+				membresias_pagado: r.pagado ? r.membresias_esperado : "0",
 			}));
 
+			let capitalEsp = 0;
+			let interesEsp = 0;
+			let ivaEsp = 0;
+			let seguroEsp = 0;
+			let gpsEsp = 0;
+			let membresiasEsp = 0;
+			let totalEsp = 0;
+			let totalPag = 0;
+			let cuotasTotal = 0;
+			let cuotasPagadas = 0;
+
+			for (const r of rowsMapped) {
+				capitalEsp += Number(r.capital_esperado);
+				interesEsp += Number(r.interes_esperado);
+				ivaEsp += Number(r.iva_esperado);
+				seguroEsp += Number(r.seguro_esperado);
+				gpsEsp += Number(r.gps_esperado);
+				membresiasEsp += Number(r.membresias_esperado);
+				totalEsp += Number(r.total_esperado);
+				totalPag += Number(r.total_pagado);
+				cuotasTotal++;
+				if (r.pagado) cuotasPagadas++;
+			}
+
 			return {
-				data: items,
-				total,
-				page: input.page,
-				pageSize: input.pageSize,
-				totalPages,
+				rows: rowsMapped,
+				totales: {
+					capitalEsp: capitalEsp.toFixed(2),
+					interesEsp: interesEsp.toFixed(2),
+					ivaEsp: ivaEsp.toFixed(2),
+					seguroEsp: seguroEsp.toFixed(2),
+					gpsEsp: gpsEsp.toFixed(2),
+					membresiasEsp: membresiasEsp.toFixed(2),
+					totalEsp: totalEsp.toFixed(2),
+					totalPag: totalPag.toFixed(2),
+					totalPendiente: (totalEsp - totalPag).toFixed(2),
+					cuotasTotal,
+					cuotasPagadas,
+				},
 			};
 		}),
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3965,34 +3965,23 @@ export const cobrosRouter = {
 			z.object({
 				fechaInicio: z.string(),
 				fechaFin: z.string(),
-				emailAsesor: z.string().optional(),
+				asesorId: z.number().optional(),
 			}),
 		)
-		.handler(async ({ input, context }) => {
+		.handler(async ({ input }) => {
 			if (!isCarteraBackEnabled()) {
 				throw new ORPCError("BAD_REQUEST", {
 					message: "Integración con cartera-back no está habilitada",
 				});
 			}
 
-			// Supervisores/admins pueden filtrar por asesor; el resto queda
-			// restringido a sus propios créditos.
-			const emailAsesor = PERMISSIONS.canAssignCobros(context.userRole)
-				? input.emailAsesor
-				: context.user?.email;
-
 			const rows = await carteraBackClient.getCuotasPorFecha({
 				fechaInicio: input.fechaInicio,
 				fechaFin: input.fechaFin,
-				emailAsesor,
+				asesorId: input.asesorId,
 			});
 
-			const rowsMapped = rows.map((r) => ({
-				...r,
-				// Membresías no tiene abono propio: si la cuota está pagada se toma
-				// el monto esperado; de lo contrario se reporta como Q0.
-				membresias_pagado: r.pagado ? r.membresias_esperado : "0",
-			}));
+			const rowsMapped = rows.map((r) => ({ ...r }));
 
 			let capitalEsp = 0;
 			let interesEsp = 0;

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -171,8 +171,7 @@ export const cobrosAppRouter = {
 
 	// CRM Cobros — nuevas vistas
 	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
-	getPagosEsperadosCobros: cobrosRouter.getPagosEsperadosCobros,
-	getPagosNoRecibidos: cobrosRouter.getPagosNoRecibidos,
+	getCuotasPorFecha: cobrosRouter.getCuotasPorFecha,
 	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
 
 	// Seguimientos programados

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -267,7 +267,12 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 				numeroSifco: sql<string>`COALESCE(${latestCarteraReference.numeroCreditoSifco}, ${opportunities.numeroSifco}, '')`,
 				cuotaSeguro: opportunities.seguro,
 				montoCredito: opportunities.value,
-				cuotaCredito: latestQuotation.monthlyPayment,
+				// Cuota de la cotización; si no hay cotización enlazada, se usa la
+				// cuota mensual guardada en la oportunidad (el flujo de cierre usa
+				// esa cuando no encuentra cotización).
+				cuotaCredito: sql<
+					string | null
+				>`COALESCE(${latestQuotation.monthlyPayment}, ${opportunities.cuotaMensual})`,
 				fechaCierre: opportunities.actualCloseDate,
 				// Día del mes en que paga (1-31), tomado de la oportunidad.
 				diaPago: opportunities.diaPagoMensual,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -209,6 +209,32 @@ export type MontoACobrarRow = {
 	mora_promedio: string;
 };
 
+export type CuotaPorFechaRow = {
+	cuota_id: number;
+	numero_cuota: number;
+	fecha_vencimiento: string;
+	pagado: boolean;
+	credito_id: number;
+	numero_credito_sifco: string;
+	cliente_nombre: string;
+	asesor_nombre: string | null;
+	asesor_email: string | null;
+	statusCredit: string;
+	capital_esperado: string;
+	interes_esperado: string;
+	iva_esperado: string;
+	seguro_esperado: string;
+	gps_esperado: string;
+	membresias_esperado: string;
+	total_esperado: string;
+	capital_pagado: string;
+	interes_pagado: string;
+	iva_pagado: string;
+	seguro_pagado: string;
+	gps_pagado: string;
+	total_pagado: string;
+};
+
 export type MontoACobrarPeriodoRow = {
 	bucket: string;
 	cuotas_count: number;
@@ -1539,6 +1565,26 @@ export class CarteraBackClient {
 			{ method: "GET" },
 			true,
 		);
+	}
+
+	async getCuotasPorFecha(params: {
+		fechaInicio: string;
+		fechaFin: string;
+		emailAsesor?: string;
+	}): Promise<CuotaPorFechaRow[]> {
+		const qp = new URLSearchParams({
+			fecha_inicio: params.fechaInicio,
+			fecha_fin: params.fechaFin,
+			...(params.emailAsesor ? { email_asesor: params.emailAsesor } : {}),
+		});
+
+		const response = await this.request<{ ok: boolean; data: CuotaPorFechaRow[] }>(
+			`/reportes/cuotas-por-fecha?${qp}`,
+			{ method: "GET" },
+			false,
+		);
+
+		return response.data ?? [];
 	}
 
 	// ========================================================================

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -232,6 +232,7 @@ export type CuotaPorFechaRow = {
 	iva_pagado: string;
 	seguro_pagado: string;
 	gps_pagado: string;
+	membresias_pagado: string;
 	total_pagado: string;
 };
 
@@ -1570,12 +1571,12 @@ export class CarteraBackClient {
 	async getCuotasPorFecha(params: {
 		fechaInicio: string;
 		fechaFin: string;
-		emailAsesor?: string;
+		asesorId?: number;
 	}): Promise<CuotaPorFechaRow[]> {
 		const qp = new URLSearchParams({
 			fecha_inicio: params.fechaInicio,
 			fecha_fin: params.fechaFin,
-			...(params.emailAsesor ? { email_asesor: params.emailAsesor } : {}),
+			...(params.asesorId ? { asesor_id: String(params.asesorId) } : {}),
 		});
 
 		const response = await this.request<{ ok: boolean; data: CuotaPorFechaRow[] }>(

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -184,11 +184,12 @@ class SimpleCache {
 // ============================================================================
 
 export type FacturacionMesRubro = {
-	capital: string;
 	interes: string;
 	membresias: string;
 	seguro_gps: string;
 	royalti: string;
+	mora: string;
+	otros: string;
 };
 
 export type FacturacionMesResponse = {
@@ -1483,11 +1484,12 @@ export class CarteraBackClient {
 
 		const [cobradoResult, esperadoResult] = await Promise.all([
 			this.request<{
-				cobrado_capital?: string;
 				cobrado_interes?: string;
 				cobrado_membresias?: string;
 				cobrado_seguro_gps?: string;
 				cobrado_royalti?: string;
+				cobrado_mora?: string;
+				cobrado_otros?: string;
 			}>(`/reportes/facturacion-mes-cobrado?${qp}`, { method: "GET" }, true),
 			this.request<{
 				meta_mensual?: string;
@@ -1495,11 +1497,12 @@ export class CarteraBackClient {
 		]);
 
 		const cobrado: FacturacionMesRubro = {
-			capital: cobradoResult.cobrado_capital ?? "0",
 			interes: cobradoResult.cobrado_interes ?? "0",
 			membresias: cobradoResult.cobrado_membresias ?? "0",
 			seguro_gps: cobradoResult.cobrado_seguro_gps ?? "0",
 			royalti: cobradoResult.cobrado_royalti ?? "0",
+			mora: cobradoResult.cobrado_mora ?? "0",
+			otros: cobradoResult.cobrado_otros ?? "0",
 		};
 
 		return { cobrado, esperado: { meta_mensual: esperadoResult.meta_mensual ?? "0" } };

--- a/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
+++ b/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
@@ -18,19 +18,40 @@ const RANGE_PRESETS: { key: PresetKey; label: string }[] = [
 
 export const DEFAULT_PRESET: PresetKey = "3m";
 
+/** Año/mes de hoy en zona Guatemala (evita corrimientos por la TZ del navegador). */
+function gtYearMonth(): { year: number; month: number } {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone: GUATEMALA_TZ,
+		year: "numeric",
+		month: "2-digit",
+	}).formatToParts(new Date());
+	const num = (type: string) =>
+		Number(parts.find((p) => p.type === type)?.value);
+	return { year: num("year"), month: num("month") };
+}
+
+/** Instante de medianoche en Guatemala (UTC-6) para el Y-M-D dado. */
+function gtMidnight(year: number, month: number, day: number): Date {
+	const pad = (n: number) => String(n).padStart(2, "0");
+	return new Date(`${year}-${pad(month)}-${pad(day)}T06:00:00.000Z`);
+}
+
 /** Rango [desde, hasta] correspondiente a un preset (hoy como fin). */
 export function rangeForPreset(key: PresetKey): DateRange {
 	const today = new Date();
 	switch (key) {
-		case "month":
-			return {
-				from: new Date(today.getFullYear(), today.getMonth(), 1),
-				to: today,
-			};
+		case "month": {
+			// Inicio = 1° del mes actual EN GUATEMALA (no en la TZ del navegador),
+			// para que coincida con la serialización en zona Guatemala del caller.
+			const { year, month } = gtYearMonth();
+			return { from: gtMidnight(year, month, 1), to: today };
+		}
 		case "6m":
 			return { from: subMonths(today, 6), to: today };
-		case "ytd":
-			return { from: new Date(today.getFullYear(), 0, 1), to: today };
+		case "ytd": {
+			const { year } = gtYearMonth();
+			return { from: gtMidnight(year, 1, 1), to: today };
+		}
 		default:
 			// "3m"
 			return { from: subMonths(today, 3), to: today };

--- a/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
+++ b/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
@@ -1,0 +1,103 @@
+import { subMonths } from "date-fns";
+import { useState } from "react";
+import type { DateRange } from "react-day-picker";
+import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import { Button } from "@/components/ui/button";
+
+const GUATEMALA_TZ = "America/Guatemala";
+
+export type PresetKey = "month" | "3m" | "6m" | "ytd" | "custom";
+
+const RANGE_PRESETS: { key: PresetKey; label: string }[] = [
+	{ key: "month", label: "Este mes" },
+	{ key: "3m", label: "Últimos 3 meses" },
+	{ key: "6m", label: "Últimos 6 meses" },
+	{ key: "ytd", label: "Este año" },
+	{ key: "custom", label: "Personalizado" },
+];
+
+export const DEFAULT_PRESET: PresetKey = "3m";
+
+/** Rango [desde, hasta] correspondiente a un preset (hoy como fin). */
+export function rangeForPreset(key: PresetKey): DateRange {
+	const today = new Date();
+	switch (key) {
+		case "month":
+			return {
+				from: new Date(today.getFullYear(), today.getMonth(), 1),
+				to: today,
+			};
+		case "6m":
+			return { from: subMonths(today, 6), to: today };
+		case "ytd":
+			return { from: new Date(today.getFullYear(), 0, 1), to: today };
+		default:
+			// "3m"
+			return { from: subMonths(today, 3), to: today };
+	}
+}
+
+function formatRangeLabel(range: DateRange | undefined): string {
+	if (!range?.from || !range?.to) return "";
+	const fmt = (d: Date) =>
+		new Intl.DateTimeFormat("es-GT", {
+			timeZone: GUATEMALA_TZ,
+			day: "2-digit",
+			month: "short",
+			year: "numeric",
+		}).format(d);
+	return `${fmt(range.from)} – ${fmt(range.to)}`;
+}
+
+/**
+ * Filtro de fechas por presets (Este mes / Últimos 3-6 meses / Este año) más
+ * una opción "Personalizado" que abre el calendario de rango libre. El rango
+ * vive en el padre; este componente solo recuerda qué preset está activo.
+ */
+export function RangePresetFilter({
+	dateRange,
+	onDateRangeChange,
+	defaultPreset = DEFAULT_PRESET,
+}: {
+	dateRange: DateRange | undefined;
+	onDateRangeChange: (range: DateRange | undefined) => void;
+	defaultPreset?: PresetKey;
+}) {
+	const [preset, setPreset] = useState<PresetKey>(defaultPreset);
+
+	const handlePreset = (key: PresetKey) => {
+		setPreset(key);
+		if (key !== "custom") {
+			onDateRangeChange(rangeForPreset(key));
+		}
+	};
+
+	return (
+		<div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+			<div className="inline-flex flex-wrap items-center gap-1 rounded-lg border bg-muted/30 p-1">
+				{RANGE_PRESETS.map((p) => (
+					<Button
+						key={p.key}
+						type="button"
+						size="sm"
+						variant={preset === p.key ? "secondary" : "ghost"}
+						className="h-8"
+						onClick={() => handlePreset(p.key)}
+					>
+						{p.label}
+					</Button>
+				))}
+			</div>
+			{preset === "custom" ? (
+				<DateRangeFilter
+					dateRange={dateRange}
+					onDateRangeChange={onDateRangeChange}
+				/>
+			) : (
+				<span className="text-muted-foreground text-sm">
+					{formatRangeLabel(dateRange)}
+				</span>
+			)}
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -5,7 +5,7 @@
  * cliente y muestra el resultado simulado vs real. No modifica datos reales.
  */
 
-import { Sparkles } from "lucide-react";
+import { AlertTriangle, Info, Sparkles } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
 	Bar,
@@ -13,7 +13,7 @@ import {
 	CartesianGrid,
 	Legend,
 	ResponsiveContainer,
-	Tooltip,
+	Tooltip as RechartsTooltip,
 	XAxis,
 	YAxis,
 } from "recharts";
@@ -27,6 +27,12 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
 	Table,
 	TableBody,
@@ -93,17 +99,29 @@ function LeverSlider({
 	lever,
 	value,
 	onChange,
+	hintOverride,
 }: {
 	lever: Exclude<LeverKey, "metodo">;
 	value: number;
 	onChange: (v: number) => void;
+	hintOverride?: string;
 }) {
 	const cfg = LEVER_LABELS[lever];
+	const hint = hintOverride ?? cfg.hint;
 	return (
 		<div className="space-y-1.5">
-			<div className="flex items-center justify-between">
+			<div className="flex items-center gap-1.5">
 				<Label className="text-sm">{cfg.label}</Label>
-				<span className="text-muted-foreground text-xs">{cfg.hint}</span>
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground" />
+						</TooltipTrigger>
+						<TooltipContent className="max-w-56 text-xs">
+							{hint}
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
 			</div>
 			<div className="flex items-center gap-3">
 				<input
@@ -173,6 +191,7 @@ export function ScenarioModal<T>({
 	);
 
 	const cuota = config.usaMetodoCuota ? cuotaIlustrativa(params) : null;
+	const warning = baseData ? (config.getWarning?.(baseData) ?? null) : null;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -191,6 +210,12 @@ export function ScenarioModal<T>({
 					</p>
 				) : (
 					<div className="grid gap-6 md:grid-cols-[280px_1fr]">
+						{warning && (
+							<div className="col-span-full flex items-start gap-3 rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+								<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+								<span>{warning}</span>
+							</div>
+						)}
 						{/* Supuestos */}
 						<div className="space-y-4">
 							<h4 className="font-semibold text-sm">Supuestos</h4>
@@ -202,6 +227,7 @@ export function ScenarioModal<T>({
 										lever={lever}
 										value={params[LEVER_FIELD[lever]] as number}
 										onChange={(v) => setField(LEVER_FIELD[lever], v)}
+										hintOverride={config.leverDescriptions?.[lever]}
 									/>
 								))}
 
@@ -299,7 +325,7 @@ export function ScenarioModal<T>({
 										tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`}
 										tick={{ fontSize: 11 }}
 									/>
-									<Tooltip formatter={(v) => formatQ(Number(v))} />
+									<RechartsTooltip formatter={(v) => formatQ(Number(v))} />
 									<Legend />
 									<Bar dataKey="Real" fill="#94a3b8" radius={[4, 4, 0, 0]} />
 									<Bar

--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -114,8 +114,11 @@ function LeverSlider({
 				<Label className="text-sm">{cfg.label}</Label>
 				<TooltipProvider>
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground" />
+						<TooltipTrigger
+							aria-label={hint}
+							className="rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							<Info className="h-3.5 w-3.5 text-muted-foreground" />
 						</TooltipTrigger>
 						<TooltipContent className="max-w-56 text-xs">
 							{hint}

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -30,6 +30,10 @@ export interface ScenarioReportConfig<T> {
 	usaMetodoCuota: boolean;
 	transform: (base: T, p: ScenarioParams) => T;
 	summarize: (data: T) => SummaryRow[];
+	/** Aviso informativo cuando los datos limitan la simulación (ej: sin meta). */
+	getWarning?: (data: T) => string | null;
+	/** Override del hint por lever, específico para este reporte. */
+	leverDescriptions?: Partial<Record<Exclude<LeverKey, "metodo">, string>>;
 }
 
 const num = (v: string | number | null | undefined): number => {
@@ -65,20 +69,40 @@ export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
 };
 
 export const facturacionConfig: ScenarioReportConfig<FacturacionMesResponse> = {
-	titulo: "Facturado del Mes vs Esperado",
+	titulo: "Cobrado del Mes vs Esperado",
 	descripcion:
 		"Estima cuánto más se cobraría al subir la efectividad o bajar la mora.",
 	levers: ["efectividad", "mora"],
 	usaMetodoCuota: false,
 	transform: transformFacturacion,
-	summarize: (data) => [
-		{ concepto: "Interés", valor: num(data.cobrado.interes) },
-		{ concepto: "Membresías", valor: num(data.cobrado.membresias) },
-		{ concepto: "Seguro + GPS", valor: num(data.cobrado.seguro_gps) },
-		{ concepto: "Royaltí", valor: num(data.cobrado.royalti) },
-		{ concepto: "Mora", valor: num(data.cobrado.mora) },
-		{ concepto: "Otros", valor: num(data.cobrado.otros) },
-	],
+	summarize: (data) => {
+		const totalCobrado =
+			num(data.cobrado.interes) +
+			num(data.cobrado.membresias) +
+			num(data.cobrado.seguro_gps) +
+			num(data.cobrado.royalti) +
+			num(data.cobrado.mora) +
+			num(data.cobrado.otros);
+		return [
+			{ concepto: "Interés", valor: num(data.cobrado.interes) },
+			{ concepto: "Membresías", valor: num(data.cobrado.membresias) },
+			{ concepto: "Seguro + GPS", valor: num(data.cobrado.seguro_gps) },
+			{ concepto: "Royaltí", valor: num(data.cobrado.royalti) },
+			{ concepto: "Mora", valor: num(data.cobrado.mora) },
+			{ concepto: "Otros", valor: num(data.cobrado.otros) },
+			{ concepto: "Total cobrado", valor: totalCobrado },
+			{ concepto: "Meta del mes", valor: num(data.esperado.meta_mensual) },
+		];
+	},
+	getWarning: (data) =>
+		num(data.esperado.meta_mensual) === 0
+			? "Sin meta del mes configurada, solo la palanca de mora tiene efecto. Configura la meta para simular efectividad de cobranza."
+			: null,
+	leverDescriptions: {
+		efectividad:
+			"Escala Interés, Membresías, Seguro+GPS, Royaltí y Otros para cerrar la brecha con la meta",
+		mora: "Reduce directamente los ingresos por mora, y también contribuye a cerrar la brecha en los demás rubros",
+	},
 };
 
 export const flujoCuotasConfig: ScenarioReportConfig<FlujoCuotasInversionesResponse> =

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -72,11 +72,12 @@ export const facturacionConfig: ScenarioReportConfig<FacturacionMesResponse> = {
 	usaMetodoCuota: false,
 	transform: transformFacturacion,
 	summarize: (data) => [
-		{ concepto: "Capital", valor: num(data.cobrado.capital) },
 		{ concepto: "Interés", valor: num(data.cobrado.interes) },
 		{ concepto: "Membresías", valor: num(data.cobrado.membresias) },
 		{ concepto: "Seguro + GPS", valor: num(data.cobrado.seguro_gps) },
 		{ concepto: "Royaltí", valor: num(data.cobrado.royalti) },
+		{ concepto: "Mora", valor: num(data.cobrado.mora) },
+		{ concepto: "Otros", valor: num(data.cobrado.otros) },
 	],
 };
 

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -84,13 +84,14 @@ describe("transformFacturacion", () => {
 		esperado: { meta_mensual: "1000" },
 	};
 
-	test("efectividad +100% escala todos los rubros proporcionalmente", () => {
+	test("efectividad +100% escala rubros de ingreso proporcionalmente, mora sin cambio", () => {
 		const out = transformFacturacion(
 			data,
 			params({ efectividadDeltaPct: 100 }),
 		);
 		expect(out.cobrado.interes).toBe("800.00");
-		expect(out.cobrado.mora).toBe("200.00");
+		// mora no sube — moraReduccionPct=0 → moraFactor=1 → sin cambio
+		expect(out.cobrado.mora).toBe("100.00");
 	});
 
 	test("efectividad +50% aplica la mitad del factor", () => {
@@ -106,25 +107,30 @@ describe("transformFacturacion", () => {
 		expect(out.esperado.meta_mensual).toBe("1000");
 	});
 
-	test("efectividad negativa no cancela reducción de mora válida", () => {
+	test("bajar mora 100% reduce mora a 0 y sube rubros de ingreso", () => {
 		const out = transformFacturacion(
 			data,
 			params({ moraReduccionPct: 100, efectividadDeltaPct: -100 }),
 		);
-		// close=clamp01(0+1)=1 → factor=2 → interes=800
+		// mora baja a 0 (moraFactor=0)
+		expect(out.cobrado.mora).toBe("0.00");
+		// close=clamp01(0+1)=1 → factor=2 → interes sube
 		expect(out.cobrado.interes).toBe("800.00");
 	});
 
-	test("total cobrado > meta (gap<=0) devuelve datos sin modificar", () => {
+	test("total cobrado > meta (gap<=0) aún aplica moraFactor a mora", () => {
 		const over: FacturacionMesResponse = {
-			cobrado: { interes: "1100", membresias: "0", seguro_gps: "0", royalti: "0", mora: "0", otros: "0" },
+			cobrado: { interes: "1100", membresias: "0", seguro_gps: "0", royalti: "0", mora: "100", otros: "0" },
 			esperado: { meta_mensual: "1000" },
 		};
 		const out = transformFacturacion(
 			over,
-			params({ efectividadDeltaPct: 100 }),
+			params({ moraReduccionPct: 50 }),
 		);
+		// gap<=0 → interes sin escalar
 		expect(out.cobrado.interes).toBe("1100");
+		// mora sí se reduce (moraFactor=0.5)
+		expect(out.cobrado.mora).toBe("50.00");
 	});
 });
 

--- a/apps/crm/apps/web/src/lib/reports/scenario.test.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.test.ts
@@ -69,16 +69,17 @@ describe("transformMontoACobrar", () => {
 });
 
 describe("transformFacturacion", () => {
-	// totalCobrado=500 (400+100), meta_mensual=1000, gap=500
+	// totalCobrado=500 (interes=400, mora=100), meta_mensual=1000, gap=500
 	// factor con close=1: 1 + 500/500 = 2
 	// factor con close=0.5: 1 + 250/500 = 1.5
 	const data: FacturacionMesResponse = {
 		cobrado: {
-			capital: "400",
-			interes: "100",
+			interes: "400",
 			membresias: "0",
 			seguro_gps: "0",
 			royalti: "0",
+			mora: "100",
+			otros: "0",
 		},
 		esperado: { meta_mensual: "1000" },
 	};
@@ -88,13 +89,13 @@ describe("transformFacturacion", () => {
 			data,
 			params({ efectividadDeltaPct: 100 }),
 		);
-		expect(out.cobrado.capital).toBe("800.00");
-		expect(out.cobrado.interes).toBe("200.00");
+		expect(out.cobrado.interes).toBe("800.00");
+		expect(out.cobrado.mora).toBe("200.00");
 	});
 
 	test("efectividad +50% aplica la mitad del factor", () => {
 		const out = transformFacturacion(data, params({ efectividadDeltaPct: 50 }));
-		expect(out.cobrado.capital).toBe("600.00");
+		expect(out.cobrado.interes).toBe("600.00");
 	});
 
 	test("esperado no cambia", () => {
@@ -110,20 +111,20 @@ describe("transformFacturacion", () => {
 			data,
 			params({ moraReduccionPct: 100, efectividadDeltaPct: -100 }),
 		);
-		// close=clamp01(0+1)=1 → factor=2 → capital=800
-		expect(out.cobrado.capital).toBe("800.00");
+		// close=clamp01(0+1)=1 → factor=2 → interes=800
+		expect(out.cobrado.interes).toBe("800.00");
 	});
 
 	test("total cobrado > meta (gap<=0) devuelve datos sin modificar", () => {
 		const over: FacturacionMesResponse = {
-			cobrado: { capital: "1100", interes: "100", membresias: "0", seguro_gps: "0", royalti: "0" },
+			cobrado: { interes: "1100", membresias: "0", seguro_gps: "0", royalti: "0", mora: "0", otros: "0" },
 			esperado: { meta_mensual: "1000" },
 		};
 		const out = transformFacturacion(
 			over,
 			params({ efectividadDeltaPct: 100 }),
 		);
-		expect(out.cobrado.capital).toBe("1100");
+		expect(out.cobrado.interes).toBe("1100");
 	});
 });
 

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -106,11 +106,12 @@ export type MontoACobrarPeriodoRow = {
 };
 
 export type FacturacionMesRubro = {
-	capital: string;
 	interes: string;
 	membresias: string;
 	seguro_gps: string;
 	royalti: string;
+	mora: string;
+	otros: string;
 };
 
 export type FacturacionMesResponse = {
@@ -252,11 +253,12 @@ export function transformFacturacion(
 ): FacturacionMesResponse {
 	const close = gapClose(p);
 	const rubros: (keyof FacturacionMesRubro)[] = [
-		"capital",
 		"interes",
 		"membresias",
 		"seguro_gps",
 		"royalti",
+		"mora",
+		"otros",
 	];
 	const totalCobrado = rubros.reduce((acc, k) => acc + num(data.cobrado[k]), 0);
 	const totalEsperado = num(data.esperado.meta_mensual);

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -252,23 +252,28 @@ export function transformFacturacion(
 	p: ScenarioParams,
 ): FacturacionMesResponse {
 	const close = gapClose(p);
+	// mora se excluye del upscale proporcional: menos morosidad → menos ingreso
+	// por mora, por lo que sigue moraFactor (dirección opuesta a los otros rubros).
 	const rubros: (keyof FacturacionMesRubro)[] = [
 		"interes",
 		"membresias",
 		"seguro_gps",
 		"royalti",
-		"mora",
 		"otros",
 	];
-	const totalCobrado = rubros.reduce((acc, k) => acc + num(data.cobrado[k]), 0);
+	const totalCobrado =
+		rubros.reduce((acc, k) => acc + num(data.cobrado[k]), 0) +
+		num(data.cobrado.mora);
 	const totalEsperado = num(data.esperado.meta_mensual);
 	const gap = totalEsperado - totalCobrado;
-	if (gap <= 0 || totalCobrado === 0) {
-		return data;
-	}
-	// Distribuir el cierre de brecha proporcionalmente a cada rubro
-	const factor = 1 + (gap * close) / totalCobrado;
 	const cobrado = { ...data.cobrado };
+	// mora siempre baja con moraFactor, independientemente del gap
+	cobrado.mora = money(num(data.cobrado.mora) * moraFactor(p));
+	if (gap <= 0 || totalCobrado === 0) {
+		return { cobrado, esperado: data.esperado };
+	}
+	// Distribuir el cierre de brecha proporcionalmente entre los rubros de ingreso
+	const factor = 1 + (gap * close) / totalCobrado;
 	for (const k of rubros) {
 		cobrado[k] = money(num(data.cobrado[k]) * factor);
 	}

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -213,11 +213,12 @@ function coberturaLabel(cobertura: string | null): string {
 
 const FACTURACION_RUBROS: { key: keyof FacturacionMesRubro; label: string }[] =
 	[
-		{ key: "capital", label: "Capital" },
 		{ key: "interes", label: "Interés" },
 		{ key: "membresias", label: "Membresías" },
 		{ key: "seguro_gps", label: "Seguro + GPS" },
 		{ key: "royalti", label: "Royaltí" },
+		{ key: "mora", label: "Mora" },
+		{ key: "otros", label: "Otros" },
 	];
 
 const MONTO_COBRAR_COLORS = {

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -496,13 +496,12 @@ function RouteComponent() {
 	const [equilibrioPeriodo, setEquilibrioPeriodo] = useState<
 		"anio" | "trimestre" | "mes" | "semana" | "dia"
 	>("mes");
-	const [equilibrioRange, setEquilibrioRange] = useState(() => {
-		const today = formatDateInput(new Date());
-		const start = new Date();
-		start.setMonth(start.getMonth() - 5);
-		start.setDate(1);
-		return { fechaInicio: formatDateInput(start), fechaFin: today };
-	});
+	// Alineado al período por defecto ("mes") y a un solo año: el PeriodDatePicker
+	// en modo mes tiene un único selector de año, así que un rango que cruce de año
+	// (p.ej. "últimos 6 meses" en enero) se renderizaría/editaría mal.
+	const [equilibrioRange, setEquilibrioRange] = useState(() =>
+		getDefaultRangeForPeriodo("mes"),
+	);
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const userRole = userProfile.data?.role;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -33,7 +33,6 @@ import {
 } from "recharts";
 import { toast } from "sonner";
 import * as XLSX from "xlsx";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { PeriodDatePicker } from "@/components/reports/period-date-picker";
 import { ReportCard } from "@/components/reports/report-card";
 import { ScenarioModal } from "@/components/reports/scenario-modal";
@@ -247,10 +246,6 @@ function formatDateInput(date: Date) {
 		month: "2-digit",
 		day: "2-digit",
 	}).format(date);
-}
-
-function dateFromInput(value: string) {
-	return new Date(`${value}T12:00:00`);
 }
 
 // Fecha legible en zona Guatemala, p.ej. "17 jun 2026".
@@ -2598,16 +2593,16 @@ function RouteComponent() {
 										<FilterField label="Período">
 											<Select
 												value={equilibrioPeriodo}
-												onValueChange={(v) =>
-													setEquilibrioPeriodo(
-														v as
-															| "anio"
-															| "trimestre"
-															| "mes"
-															| "semana"
-															| "dia",
-													)
-												}
+												onValueChange={(v) => {
+													const p = v as
+														| "anio"
+														| "trimestre"
+														| "mes"
+														| "semana"
+														| "dia";
+													setEquilibrioPeriodo(p);
+													setEquilibrioRange(getDefaultRangeForPeriodo(p));
+												}}
 											>
 												<SelectTrigger className="w-[140px]">
 													<SelectValue placeholder="Período" />
@@ -2623,26 +2618,13 @@ function RouteComponent() {
 										</FilterField>
 
 										<FilterField label="Rango">
-											<DateRangeFilter
-												dateRange={
-													equilibrioRange.fechaInicio &&
-													equilibrioRange.fechaFin
-														? {
-																from: dateFromInput(
-																	equilibrioRange.fechaInicio,
-																),
-																to: dateFromInput(equilibrioRange.fechaFin),
-															}
-														: undefined
+											<PeriodDatePicker
+												periodo={equilibrioPeriodo}
+												fechaInicio={equilibrioRange.fechaInicio}
+												fechaFin={equilibrioRange.fechaFin}
+												onChange={(fechaInicio, fechaFin) =>
+													setEquilibrioRange({ fechaInicio, fechaFin })
 												}
-												onDateRangeChange={(range) => {
-													if (range?.from && range?.to) {
-														setEquilibrioRange({
-															fechaInicio: formatDateInput(range.from),
-															fechaFin: formatDateInput(range.to),
-														});
-													}
-												}}
 											/>
 										</FilterField>
 									</div>

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -8,7 +8,6 @@ import {
 	TrendingDown,
 } from "lucide-react";
 import { useState } from "react";
-import { CapitalRangeFilter } from "@/components/cobros/capital-range-filter";
 import { DataTable } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -22,7 +21,6 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
-import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
@@ -305,228 +303,260 @@ function TabMora({
 	);
 }
 
-// ─── Pagos Esperados ────────────────────────────────────────────────────────
+// ─── Cuotas por Fecha (Pagos Esperados) ─────────────────────────────────────
 
-type Temporalidad = "hoy" | "semana" | "quincena" | "mes";
+type QuickPeriod = "hoy" | "semana" | "quincena" | "mes";
 
-const TEMPORALIDAD_LABELS: Record<Temporalidad, string> = {
+const QUICK_LABELS: Record<QuickPeriod, string> = {
 	hoy: "Hoy",
 	semana: "Esta Semana",
 	quincena: "Esta Quincena",
 	mes: "Este Mes",
 };
 
-const RUBROS = [
-	{ key: "totalCuota" as const, label: "Total a Cobrar", highlight: true },
-	{ key: "capital" as const, label: "Capital" },
-	{ key: "interes" as const, label: "Interés" },
-	{ key: "iva" as const, label: "IVA" },
-	{ key: "seguro" as const, label: "Seguro" },
-	{ key: "gps" as const, label: "GPS" },
-	{ key: "membresias" as const, label: "Membresías" },
-	{ key: "royalti" as const, label: "Royaltí" },
-];
-
-type DesgloseDia = {
-	bucket: string;
-	cuotas_count: number;
-	total_cuota: string;
-	total_interes: string;
-	total_iva: string;
-	total_seguro: string;
-	total_gps: string;
-	total_membresias: string;
-	total_royalti: string;
-};
-
-// Buckets date-only se parsean como mediodía local para evitar que el
-// offset de zona horaria los desplace al día anterior.
-function fmtBucketDia(bucket: string) {
-	const date = new Date(bucket.length === 10 ? `${bucket}T12:00:00` : bucket);
-	return date.toLocaleDateString("es-GT", {
-		weekday: "short",
-		day: "2-digit",
-		month: "short",
-	});
+function todayGT(): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: "America/Guatemala",
+	}).format(new Date());
 }
 
-// `total_cuota` de cartera-back es el capital; el total a cobrar de la fila
-// es la suma de rubros (mismo criterio que el reporte monto-a-cobrar).
-function totalDeFila(row: DesgloseDia) {
+function addDaysGT(dateStr: string, n: number): string {
+	const [y, m, d] = dateStr.split("-").map(Number);
+	const dt = new Date(Date.UTC(y, m - 1, d + n));
+	return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-${String(dt.getUTCDate()).padStart(2, "0")}`;
+}
+
+function fmtDate(dt: Date): string {
+	return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-${String(dt.getUTCDate()).padStart(2, "0")}`;
+}
+
+function weekRangeGT(): { start: string; end: string } {
+	const h = todayGT();
+	const [y, m, d] = h.split("-").map(Number);
+	const dt = new Date(Date.UTC(y, m - 1, d));
+	const dow = dt.getUTCDay(); // 0=Dom, 1=Lun ... 6=Sab
+	const daysFromMon = dow === 0 ? 6 : dow - 1;
+	const monday = new Date(Date.UTC(y, m - 1, d - daysFromMon));
+	const sunday = new Date(Date.UTC(y, m - 1, d - daysFromMon + 6));
+	return { start: fmtDate(monday), end: fmtDate(sunday) };
+}
+
+function monthRangeGT(): { start: string; end: string } {
+	const h = todayGT();
+	const [y, m] = h.split("-").map(Number);
+	const start = `${y}-${String(m).padStart(2, "0")}-01`;
+	const lastDay = new Date(Date.UTC(y, m, 0));
+	return { start, end: fmtDate(lastDay) };
+}
+
+type CuotaFila = {
+	cuota_id: number;
+	fecha_vencimiento: string;
+	pagado: boolean;
+	numero_credito_sifco: string;
+	cliente_nombre: string;
+	asesor_nombre: string | null;
+	statusCredit: string;
+	capital_esperado: string;
+	interes_esperado: string;
+	iva_esperado: string;
+	seguro_esperado: string;
+	gps_esperado: string;
+	membresias_esperado: string;
+	total_esperado: string;
+	capital_pagado: string;
+	interes_pagado: string;
+	iva_pagado: string;
+	seguro_pagado: string;
+	gps_pagado: string;
+	total_pagado: string;
+	membresias_pagado: string;
+};
+
+function RubroCelda({
+	esperado,
+	pagado,
+}: {
+	esperado: string;
+	pagado: string;
+}) {
+	const pagadoNum = Number(pagado);
 	return (
-		Number.parseFloat(row.total_cuota) +
-		Number.parseFloat(row.total_interes) +
-		Number.parseFloat(row.total_iva) +
-		Number.parseFloat(row.total_seguro) +
-		Number.parseFloat(row.total_gps) +
-		Number.parseFloat(row.total_membresias) +
-		Number.parseFloat(row.total_royalti)
+		<div className="space-y-0.5 text-right">
+			<div className="text-muted-foreground text-xs">{fmtQ(esperado)}</div>
+			<div
+				className={`text-xs font-medium ${pagadoNum > 0 ? "text-green-600" : "text-muted-foreground/40"}`}
+			>
+				{pagadoNum > 0 ? fmtQ(pagado) : "—"}
+			</div>
+		</div>
 	);
 }
 
-type PagoNoRecibido = {
-	sifco: string;
-	clienteNombre: string;
-	asesorNombre: string;
-	cuotasAtrasadas: number;
-	montoMora: string;
-	capital: string;
-	cuotaMensual: string;
-	proximaFechaVencimiento: string | null;
-	tipoCredito: string | null;
-};
-
-function getMoraBadge(cuotas: number) {
-	if (cuotas >= 4)
-		return <Badge className="bg-red-300 text-red-950">Mora 120+</Badge>;
-	if (cuotas === 3)
-		return <Badge className="bg-red-100 text-red-800">Mora 90</Badge>;
-	if (cuotas === 2)
-		return <Badge className="bg-orange-100 text-orange-800">Mora 60</Badge>;
-	return <Badge className="bg-yellow-100 text-yellow-800">Mora 30</Badge>;
+function EstadoBadge({ row }: { row: CuotaFila }) {
+	if (row.pagado)
+		return <Badge className="bg-green-100 text-green-800">Pagado</Badge>;
+	if (Number(row.total_pagado) > 0)
+		return <Badge className="bg-yellow-100 text-yellow-800">Parcial</Badge>;
+	return <Badge className="bg-red-100 text-red-800">Pendiente</Badge>;
 }
 
-const colsPagos: ColumnDef<PagoNoRecibido>[] = [
+const colsCuotas: ColumnDef<CuotaFila>[] = [
 	{
-		accessorKey: "sifco",
-		header: "Crédito",
+		accessorKey: "numero_credito_sifco",
+		header: "Crédito / Cliente",
 		cell: ({ row }) => (
-			<Link
-				to="/cobros/$id"
-				params={{ id: row.original.sifco }}
-				search={{ tipo: "contrato" }}
-				className="font-mono text-blue-600 text-xs hover:underline"
-			>
-				{row.original.sifco}
-			</Link>
-		),
-	},
-	{ accessorKey: "clienteNombre", header: "Cliente" },
-	{ accessorKey: "asesorNombre", header: "Asesor" },
-	{
-		accessorKey: "cuotasAtrasadas",
-		header: "Cuotas Atrasadas",
-		cell: ({ row }) => getMoraBadge(row.original.cuotasAtrasadas),
-	},
-	{
-		accessorKey: "montoMora",
-		header: "Monto Mora",
-		cell: ({ row }) => (
-			<span className="font-medium text-red-700">
-				{fmtQ(row.original.montoMora)}
-			</span>
+			<div className="flex flex-col gap-0.5">
+				<Link
+					to="/cobros/$id"
+					params={{ id: row.original.numero_credito_sifco }}
+					search={{ tipo: "contrato" }}
+					className="font-mono text-blue-600 text-xs hover:underline"
+				>
+					{row.original.numero_credito_sifco}
+				</Link>
+				<span className="text-muted-foreground text-xs">
+					{row.original.cliente_nombre}
+				</span>
+			</div>
 		),
 	},
 	{
-		accessorKey: "capital",
-		header: "Capital Restante",
-		cell: ({ row }) => fmtQ(row.original.capital),
+		accessorKey: "asesor_nombre",
+		header: "Asesor",
+		cell: ({ row }) => row.original.asesor_nombre ?? "—",
 	},
 	{
-		accessorKey: "cuotaMensual",
-		header: "Cuota Mensual",
-		cell: ({ row }) => fmtQ(row.original.cuotaMensual),
-	},
-	{
-		accessorKey: "proximaFechaVencimiento",
-		header: "Próx. Vencimiento",
+		accessorKey: "fecha_vencimiento",
+		header: "Fecha Venc.",
 		cell: ({ row }) =>
-			row.original.proximaFechaVencimiento
-				? new Date(
-						`${row.original.proximaFechaVencimiento}T00:00:00`,
-					).toLocaleDateString("es-GT")
-				: "—",
+			new Date(`${row.original.fecha_vencimiento}T12:00:00`).toLocaleDateString(
+				"es-GT",
+			),
+	},
+	{
+		accessorKey: "capital_esperado",
+		header: "Capital",
+		cell: ({ row }) => (
+			<RubroCelda
+				esperado={row.original.capital_esperado}
+				pagado={row.original.capital_pagado}
+			/>
+		),
+	},
+	{
+		accessorKey: "interes_esperado",
+		header: "Interés",
+		cell: ({ row }) => (
+			<RubroCelda
+				esperado={row.original.interes_esperado}
+				pagado={row.original.interes_pagado}
+			/>
+		),
+	},
+	{
+		accessorKey: "iva_esperado",
+		header: "IVA 12%",
+		cell: ({ row }) => (
+			<RubroCelda
+				esperado={row.original.iva_esperado}
+				pagado={row.original.iva_pagado}
+			/>
+		),
+	},
+	{
+		accessorKey: "seguro_esperado",
+		header: "Seguro",
+		cell: ({ row }) => (
+			<RubroCelda
+				esperado={row.original.seguro_esperado}
+				pagado={row.original.seguro_pagado}
+			/>
+		),
+	},
+	{
+		accessorKey: "gps_esperado",
+		header: "GPS",
+		cell: ({ row }) => (
+			<RubroCelda
+				esperado={row.original.gps_esperado}
+				pagado={row.original.gps_pagado}
+			/>
+		),
+	},
+	{
+		accessorKey: "membresias_esperado",
+		header: "Membresías",
+		cell: ({ row }) => (
+			<RubroCelda
+				esperado={row.original.membresias_esperado}
+				pagado={row.original.membresias_pagado}
+			/>
+		),
+	},
+	{
+		accessorKey: "total_esperado",
+		header: "Total",
+		cell: ({ row }) => (
+			<RubroCelda
+				esperado={row.original.total_esperado}
+				pagado={row.original.total_pagado}
+			/>
+		),
+	},
+	{
+		id: "estado",
+		header: "Estado",
+		cell: ({ row }) => <EstadoBadge row={row.original} />,
 	},
 ];
 
-function TabPagos({
+function TabCuotasPorFecha({
 	session,
 	canSeeAll,
 }: {
 	session: ReturnType<typeof authClient.useSession>["data"];
 	canSeeAll: boolean;
 }) {
-	const [temporalidad, setTemporalidad] = usePersistedState<Temporalidad>(
-		"cobros/reportes/temporalidad",
-		"hoy",
+	const hoyInit = todayGT();
+
+	const [fechaInicio, setFechaInicio] = usePersistedState<string>(
+		"cobros/reportes/cuotas/fechaInicio",
+		hoyInit,
+	);
+	const [fechaFin, setFechaFin] = usePersistedState<string>(
+		"cobros/reportes/cuotas/fechaFin",
+		hoyInit,
 	);
 	const [emailAsesor, setEmailAsesor] = usePersistedState<string>(
-		"cobros/reportes/pagos/emailAsesor",
+		"cobros/reportes/cuotas/emailAsesor",
 		"",
 	);
-	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>(
-		"cobros/reportes/pagos/capitalMin",
-		undefined,
+	const [filtroEstado, setFiltroEstado] = usePersistedState<string>(
+		"cobros/reportes/cuotas/filtroEstado",
+		"todos",
 	);
-	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>(
-		"cobros/reportes/pagos/capitalMax",
-		undefined,
-	);
-	const [cuotasMin, setCuotasMin] = usePersistedState<string>(
-		"cobros/reportes/pagos/cuotasMin",
-		"",
-	);
-	const [cuotasMax, setCuotasMax] = usePersistedState<string>(
-		"cobros/reportes/pagos/cuotasMax",
-		"",
-	);
-	const [fechaDesde, setFechaDesde] = usePersistedState<string>(
-		"cobros/reportes/pagos/fechaDesde",
-		"",
-	);
-	const [fechaHasta, setFechaHasta] = usePersistedState<string>(
-		"cobros/reportes/pagos/fechaHasta",
-		"",
-	);
-	const [page, setPage] = usePersistedState<number>(
-		"cobros/reportes/pagos/page",
-		1,
-	);
-	const [pageSize] = usePersistedState<number>(
-		"cobros/reportes/pagos/pageSize",
-		25,
-	);
-
-	const emailCobrador = canSeeAll
-		? emailAsesor || undefined
-		: (session?.user?.email ?? undefined);
-
-	const {
-		data: resumenData,
-		isLoading: resumenLoading,
-		dataUpdatedAt,
-		refetch: refetchResumen,
-		isFetching: resumenFetching,
-	} = useQuery({
-		...orpc.getPagosEsperadosCobros.queryOptions({ input: { temporalidad } }),
-		enabled: !!session,
-		staleTime: 5 * 60 * 1000,
-	});
 
 	const { data: asesoresData } = useQuery({
 		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
 		enabled: !!session && canSeeAll,
 	});
 
-	const { data: noRecibidosData, isLoading: noRecibidosLoading } = useQuery({
-		...orpc.getPagosNoRecibidos.queryOptions({
+	const {
+		data,
+		isLoading,
+		dataUpdatedAt,
+		refetch,
+		isFetching,
+	} = useQuery({
+		...orpc.getCuotasPorFecha.queryOptions({
 			input: {
-				emailCobrador,
-				capitalMin,
-				capitalMax,
-				cuotasAtrasadasMin: cuotasMin
-					? Number.parseInt(cuotasMin, 10)
-					: undefined,
-				cuotasAtrasadasMax: cuotasMax
-					? Number.parseInt(cuotasMax, 10)
-					: undefined,
-				fechaDesde: fechaDesde || undefined,
-				fechaHasta: fechaHasta || undefined,
-				page,
-				pageSize,
+				fechaInicio,
+				fechaFin,
+				emailAsesor: canSeeAll ? (emailAsesor || undefined) : undefined,
 			},
 		}),
-		enabled: !!session,
+		enabled: !!session && !!fechaInicio && !!fechaFin,
 		staleTime: 5 * 60 * 1000,
 	});
 
@@ -537,6 +567,53 @@ function TabPagos({
 			})
 		: null;
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const totales = (data as any)?.totales;
+	const rows: CuotaFila[] =
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(data as any)?.rows ?? [];
+
+	const hoy = todayGT();
+	const activeQuick: QuickPeriod | null = (() => {
+		if (fechaInicio === hoy && fechaFin === hoy) return "hoy";
+		const { start: ws, end: we } = weekRangeGT();
+		if (fechaInicio === ws && fechaFin === we) return "semana";
+		if (fechaInicio === hoy && fechaFin === addDaysGT(hoy, 14)) return "quincena";
+		const { start: ms, end: me } = monthRangeGT();
+		if (fechaInicio === ms && fechaFin === me) return "mes";
+		return null;
+	})();
+
+	function applyQuick(period: QuickPeriod) {
+		if (period === "hoy") {
+			const h = todayGT();
+			setFechaInicio(h);
+			setFechaFin(h);
+		} else if (period === "semana") {
+			const { start, end } = weekRangeGT();
+			setFechaInicio(start);
+			setFechaFin(end);
+		} else if (period === "quincena") {
+			const h = todayGT();
+			setFechaInicio(h);
+			setFechaFin(addDaysGT(h, 14));
+		} else if (period === "mes") {
+			const { start, end } = monthRangeGT();
+			setFechaInicio(start);
+			setFechaFin(end);
+		}
+	}
+
+	function getEstado(row: CuotaFila): "pagado" | "parcial" | "pendiente" {
+		if (row.pagado) return "pagado";
+		if (Number(row.total_pagado) > 0) return "parcial";
+		return "pendiente";
+	}
+
+	const filteredRows = filtroEstado === "todos"
+		? rows
+		: rows.filter((r) => getEstado(r) === filtroEstado);
+
 	return (
 		<div className="space-y-6">
 			<div className="flex items-center gap-2">
@@ -544,177 +621,50 @@ function TabPagos({
 				<h2 className="font-semibold text-xl">Pagos Esperados</h2>
 			</div>
 
-			{/* Período selector */}
-			<div className="flex flex-wrap items-center gap-2">
-				<span className="font-medium text-sm">Período:</span>
-				{(Object.keys(TEMPORALIDAD_LABELS) as Temporalidad[]).map((t) => (
-					<Button
-						key={t}
-						variant={temporalidad === t ? "default" : "outline"}
-						size="sm"
-						onClick={() => setTemporalidad(t)}
-					>
-						{TEMPORALIDAD_LABELS[t]}
-					</Button>
-				))}
-				<div className="ml-auto flex items-center gap-2">
-					{ultimaAct && (
-						<span className="text-muted-foreground text-xs">
-							Actualizado: {ultimaAct}
-						</span>
-					)}
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() => refetchResumen()}
-						disabled={resumenFetching}
-					>
-						<RefreshCw
-							className={`mr-2 h-4 w-4 ${resumenFetching ? "animate-spin" : ""}`}
-						/>
-						Actualizar
-					</Button>
-				</div>
-			</div>
-
-			{resumenLoading ? (
-				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-					{RUBROS.map((r) => (
-						<Card key={r.key}>
-							<CardContent className="pt-6">
-								<div className="h-10 animate-pulse rounded bg-muted" />
-							</CardContent>
-						</Card>
+			{/* Filtros */}
+			<div className="flex flex-wrap items-end gap-3">
+				<div className="flex items-center gap-2">
+					{(Object.keys(QUICK_LABELS) as QuickPeriod[]).map((p) => (
+						<Button
+							key={p}
+							variant={activeQuick === p ? "default" : "outline"}
+							size="sm"
+							onClick={() => applyQuick(p)}
+						>
+							{QUICK_LABELS[p]}
+						</Button>
 					))}
 				</div>
-			) : (
-				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-					{RUBROS.map((r) => {
-						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						const value = (resumenData as any)?.totales?.[r.key] as
-							| string
-							| number
-							| undefined;
-						return (
-							<Card
-								key={r.key}
-								className={r.highlight ? "border-blue-200 bg-blue-50" : ""}
-							>
-								<CardHeader className="pb-2">
-									<CardTitle
-										className={`font-medium text-sm ${r.highlight ? "text-blue-700" : ""}`}
-									>
-										{r.label}
-									</CardTitle>
-								</CardHeader>
-								<CardContent>
-									<div
-										className={`font-bold text-xl ${r.highlight ? "text-blue-800" : ""}`}
-									>
-										{fmtQ(String(value ?? "0"))}
-									</div>
-								</CardContent>
-							</Card>
-						);
-					})}
-					<Card>
-						<CardHeader className="pb-2">
-							<CardTitle className="font-medium text-sm">
-								Cant. Cuotas
-							</CardTitle>
-						</CardHeader>
-						{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-						<CardContent>
-							<div className="font-bold text-xl">
-								{(resumenData as any)?.totales?.cantidadCuotas ?? 0}
-							</div>
-						</CardContent>
-					</Card>
-				</div>
-			)}
 
-			{!!resumenData && (
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				<p className="text-muted-foreground text-xs">
-					Período: {(resumenData as any).fechaInicio} →{" "}
-					{(resumenData as any).fechaFin}
-				</p>
-			)}
-
-			{(() => {
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				const desglose = ((resumenData as any)?.desglose ??
-					[]) as DesgloseDia[];
-				if (temporalidad === "hoy" || desglose.length <= 1) return null;
-				return (
-					<div>
-						<h3 className="mb-3 font-semibold text-base">Desglose por Día</h3>
-						<div className="overflow-x-auto rounded-lg border">
-							<table className="w-full text-sm">
-								<thead className="bg-muted/50">
-									<tr>
-										<th className="px-4 py-3 text-left font-semibold">Fecha</th>
-										<th className="px-4 py-3 text-right font-semibold">
-											Cuotas
-										</th>
-										<th className="px-4 py-3 text-right font-semibold">
-											Capital
-										</th>
-										<th className="px-4 py-3 text-right font-semibold">
-											Interés
-										</th>
-										<th className="px-4 py-3 text-right font-semibold">IVA</th>
-										<th className="px-4 py-3 text-right font-semibold">
-											Total a Cobrar
-										</th>
-									</tr>
-								</thead>
-								<tbody>
-									{desglose.map((row) => (
-										<tr key={row.bucket} className="border-t hover:bg-muted/30">
-											<td className="px-4 py-3 font-medium">
-												{fmtBucketDia(row.bucket)}
-											</td>
-											<td className="px-4 py-3 text-right">
-												{row.cuotas_count}
-											</td>
-											<td className="px-4 py-3 text-right">
-												{fmtQ(row.total_cuota)}
-											</td>
-											<td className="px-4 py-3 text-right">
-												{fmtQ(row.total_interes)}
-											</td>
-											<td className="px-4 py-3 text-right">
-												{fmtQ(row.total_iva)}
-											</td>
-											<td className="px-4 py-3 text-right font-medium">
-												{fmtQ(totalDeFila(row))}
-											</td>
-										</tr>
-									))}
-								</tbody>
-							</table>
-						</div>
+				<div className="flex items-end gap-2">
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Desde</Label>
+						<Input
+							type="date"
+							className="w-36"
+							value={fechaInicio}
+							onChange={(e) => setFechaInicio(e.target.value)}
+						/>
 					</div>
-				);
-			})()}
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Hasta</Label>
+						<Input
+							type="date"
+							className="w-36"
+							value={fechaFin}
+							onChange={(e) => setFechaFin(e.target.value)}
+						/>
+					</div>
+				</div>
 
-			<Separator />
-
-			<h3 className="font-semibold text-base">Pagos No Recibidos</h3>
-
-			<div className="flex flex-wrap items-end gap-4">
 				{canSeeAll && (
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Asesor</Label>
 						<Select
 							value={emailAsesor}
-							onValueChange={(v) => {
-								setEmailAsesor(v === "todos" ? "" : v);
-								setPage(1);
-							}}
+							onValueChange={(v) => setEmailAsesor(v === "todos" ? "" : v)}
 						>
-							<SelectTrigger className="w-52">
+							<SelectTrigger className="w-48">
 								<SelectValue placeholder="Todos los asesores" />
 							</SelectTrigger>
 							<SelectContent>
@@ -729,92 +679,122 @@ function TabPagos({
 						</Select>
 					</div>
 				)}
-				<CapitalRangeFilter
-					capitalMin={capitalMin}
-					capitalMax={capitalMax}
-					onCapitalRangeChange={(min, max) => {
-						setCapitalMin(min);
-						setCapitalMax(max);
-						setPage(1);
-					}}
-				/>
-				<div className="flex items-end gap-2">
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Cuotas atrasadas mín.</Label>
-						<Input
-							type="number"
-							min={1}
-							className="w-24"
-							placeholder="1"
-							value={cuotasMin}
-							onChange={(e) => {
-								setCuotasMin(e.target.value);
-								setPage(1);
-							}}
-						/>
-					</div>
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Cuotas atrasadas máx.</Label>
-						<Input
-							type="number"
-							min={1}
-							className="w-24"
-							placeholder="—"
-							value={cuotasMax}
-							onChange={(e) => {
-								setCuotasMax(e.target.value);
-								setPage(1);
-							}}
-						/>
-					</div>
+
+				<div className="flex flex-col gap-1">
+					<Label className="text-xs">Estado</Label>
+					<Select value={filtroEstado} onValueChange={setFiltroEstado}>
+						<SelectTrigger className="w-36">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="todos">Todos</SelectItem>
+							<SelectItem value="pagado">Pagado</SelectItem>
+							<SelectItem value="parcial">Parcial</SelectItem>
+							<SelectItem value="pendiente">Pendiente</SelectItem>
+						</SelectContent>
+					</Select>
 				</div>
-				<div className="flex items-end gap-2">
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Fecha pago desde</Label>
-						<Input
-							type="date"
-							className="w-40"
-							value={fechaDesde}
-							onChange={(e) => {
-								setFechaDesde(e.target.value);
-								setPage(1);
-							}}
+
+				<div className="ml-auto flex items-center gap-2">
+					{ultimaAct && (
+						<span className="text-muted-foreground text-xs">
+							Actualizado: {ultimaAct}
+						</span>
+					)}
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => refetch()}
+						disabled={isFetching}
+					>
+						<RefreshCw
+							className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
 						/>
-					</div>
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Fecha pago hasta</Label>
-						<Input
-							type="date"
-							className="w-40"
-							value={fechaHasta}
-							onChange={(e) => {
-								setFechaHasta(e.target.value);
-								setPage(1);
-							}}
-						/>
-					</div>
+						Actualizar
+					</Button>
 				</div>
 			</div>
 
-			<DataTable
-				columns={colsPagos}
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				data={(noRecibidosData as any)?.data ?? []}
-				isLoading={noRecibidosLoading}
-				hideSearch
-				serverPagination={
-					noRecibidosData
-						? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-							{
-								page: (noRecibidosData as any).page,
-								pageSize: (noRecibidosData as any).pageSize,
-								totalPages: (noRecibidosData as any).totalPages,
-								totalItems: (noRecibidosData as any).total,
-								onPageChange: setPage,
-							}
-						: undefined
-				}
-			/>
+			{/* Summary cards */}
+			<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+				<Card className="border-blue-200 bg-blue-50">
+					<CardHeader className="pb-2">
+						<CardTitle className="font-medium text-blue-700 text-sm">
+							Total Esperado
+						</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<div className="font-bold text-blue-800 text-xl">
+							{fmtQ(totales?.totalEsp ?? "0")}
+						</div>
+					</CardContent>
+				</Card>
+				<Card className="border-green-200 bg-green-50">
+					<CardHeader className="pb-2">
+						<CardTitle className="font-medium text-green-700 text-sm">
+							Total Pagado
+						</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<div className="font-bold text-green-700 text-xl">
+							{fmtQ(totales?.totalPag ?? "0")}
+						</div>
+					</CardContent>
+				</Card>
+				<Card className="border-red-200 bg-red-50">
+					<CardHeader className="pb-2">
+						<CardTitle className="font-medium text-red-700 text-sm">
+							Total Pendiente
+						</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<div className="font-bold text-red-700 text-xl">
+							{fmtQ(totales?.totalPendiente ?? "0")}
+						</div>
+					</CardContent>
+				</Card>
+				<Card>
+					<CardHeader className="pb-2">
+						<CardTitle className="font-medium text-sm">Cuotas</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<div className="font-bold text-xl">
+							{totales?.cuotasPagadas ?? 0} / {totales?.cuotasTotal ?? 0}
+						</div>
+						<p className="text-muted-foreground text-xs">pagadas / total</p>
+					</CardContent>
+				</Card>
+			</div>
+
+			{/* Rubro breakdown cards */}
+			<div className="grid grid-cols-3 gap-3 md:grid-cols-6">
+				{(
+					[
+						{ key: "capitalEsp", label: "Capital" },
+						{ key: "interesEsp", label: "Interés" },
+						{ key: "ivaEsp", label: "IVA 12%" },
+						{ key: "seguroEsp", label: "Seguro" },
+						{ key: "gpsEsp", label: "GPS" },
+						{ key: "membresiasEsp", label: "Membresías" },
+					] as const
+				).map((c) => (
+					<Card key={c.key} className="py-3">
+						<CardHeader className="px-4 pb-1 pt-0">
+							<CardTitle className="font-medium text-muted-foreground text-xs">
+								{c.label}
+							</CardTitle>
+						</CardHeader>
+						<CardContent className="px-4 pb-0">
+							<div className="font-semibold text-sm">
+								{fmtQ(totales?.[c.key] ?? "0")}
+							</div>
+						</CardContent>
+					</Card>
+				))}
+			</div>
+
+			{/* Detail table */}
+			<DataTable columns={colsCuotas} data={filteredRows} isLoading={isLoading} />
 		</div>
 	);
 }
@@ -1048,7 +1028,7 @@ function RouteComponent() {
 					<TabMora session={session} canSeeAll={canSeeAll} />
 				</TabsContent>
 				<TabsContent value="pagos" className="mt-6">
-					<TabPagos session={session} canSeeAll={canSeeAll} />
+					<TabCuotasPorFecha session={session} canSeeAll={canSeeAll} />
 				</TabsContent>
 				<TabsContent value="descuentos" className="mt-6">
 					<TabDescuentos session={session} canSeeAll={canSeeAll} />

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -528,8 +528,8 @@ function TabCuotasPorFecha({
 		"cobros/reportes/cuotas/fechaFin",
 		hoyInit,
 	);
-	const [emailAsesor, setEmailAsesor] = usePersistedState<string>(
-		"cobros/reportes/cuotas/emailAsesor",
+	const [asesorId, setAsesorId] = usePersistedState<string>(
+		"cobros/reportes/cuotas/asesorId",
 		"",
 	);
 	const [filtroEstado, setFiltroEstado] = usePersistedState<string>(
@@ -553,7 +553,7 @@ function TabCuotasPorFecha({
 			input: {
 				fechaInicio,
 				fechaFin,
-				emailAsesor: canSeeAll ? (emailAsesor || undefined) : undefined,
+				asesorId: canSeeAll ? (asesorId ? Number(asesorId) : undefined) : undefined,
 			},
 		}),
 		enabled: !!session && !!fechaInicio && !!fechaFin,
@@ -661,8 +661,8 @@ function TabCuotasPorFecha({
 					<div className="flex flex-col gap-1">
 						<Label className="text-xs">Asesor</Label>
 						<Select
-							value={emailAsesor}
-							onValueChange={(v) => setEmailAsesor(v === "todos" ? "" : v)}
+							value={asesorId}
+							onValueChange={(v) => setAsesorId(v === "todos" ? "" : v)}
 						>
 							<SelectTrigger className="w-48">
 								<SelectValue placeholder="Todos los asesores" />
@@ -671,7 +671,7 @@ function TabCuotasPorFecha({
 								<SelectItem value="todos">Todos</SelectItem>
 								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 								{(asesoresData as any)?.asesores?.map((a: any) => (
-									<SelectItem key={a.asesorId} value={a.email}>
+									<SelectItem key={a.asesorId} value={String(a.asesorId)}>
 										{a.nombre}
 									</SelectItem>
 								))}

--- a/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/meta-colocacion.tsx
@@ -12,6 +12,13 @@ import {
 	CardTitle,
 } from "@/components/ui/card";
 import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
 	Table,
 	TableBody,
 	TableCell,
@@ -158,28 +165,30 @@ export function MetaColocacionContent() {
 
 			{/* Selector mes/año */}
 			<div className="flex items-center gap-3">
-				<select
-					value={mes}
-					onChange={(e) => setMes(Number(e.target.value))}
-					className="rounded-md border bg-background px-3 py-1.5 text-sm"
-				>
-					{MESES.map((label, i) => (
-						<option key={label} value={i + 1}>
-							{label}
-						</option>
-					))}
-				</select>
-				<select
-					value={anio}
-					onChange={(e) => setAnio(Number(e.target.value))}
-					className="rounded-md border bg-background px-3 py-1.5 text-sm"
-				>
-					{anios.map((a) => (
-						<option key={a} value={a}>
-							{a}
-						</option>
-					))}
-				</select>
+				<Select value={String(mes)} onValueChange={(v) => setMes(Number(v))}>
+					<SelectTrigger className="w-36">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{MESES.map((label, i) => (
+							<SelectItem key={label} value={String(i + 1)}>
+								{label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+				<Select value={String(anio)} onValueChange={(v) => setAnio(Number(v))}>
+					<SelectTrigger className="w-24">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{anios.map((a) => (
+							<SelectItem key={a} value={String(a)}>
+								{a}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
 			</div>
 
 			{/* KPI Cards */}
@@ -290,7 +299,9 @@ export function MetaColocacionContent() {
 							</div>
 							<p className="text-muted-foreground text-xs">
 								Faltante:{" "}
-								{formatCurrency(Math.max(0, Number(meta) - Number(realMonto ?? 0)))}
+								{formatCurrency(
+									Math.max(0, Number(meta) - Number(realMonto ?? 0)),
+								)}
 							</p>
 						</div>
 					</CardContent>

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -1,7 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { subMonths } from "date-fns";
-import { Activity, CheckCircle2, Download, Target, XCircle } from "lucide-react";
+import {
+	Activity,
+	CheckCircle2,
+	Download,
+	Target,
+	XCircle,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import type { DateRange } from "react-day-picker";
 import {
@@ -15,7 +20,11 @@ import {
 	YAxis,
 } from "recharts";
 import { toast } from "sonner";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import {
+	DEFAULT_PRESET,
+	RangePresetFilter,
+	rangeForPreset,
+} from "@/components/reports/range-preset-filter";
 import { ReportCard } from "@/components/reports/report-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -98,11 +107,6 @@ function formatDisplayDate(date: Date | string | null): string {
 	}).format(new Date(date));
 }
 
-function getDefaultDateRange(): DateRange {
-	const today = new Date();
-	return { from: subMonths(today, 1), to: today };
-}
-
 // Prefija celdas que empiecen con operadores de fórmula para evitar CSV injection
 function sanitizeCSVCell(value: string): string {
 	return /^[=+\-@]/.test(value) ? `'${value}` : value;
@@ -163,8 +167,8 @@ function RouteComponent() {
 }
 
 export function PorcentajeEfectividadContent() {
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(
-		getDefaultDateRange,
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(() =>
+		rangeForPreset(DEFAULT_PRESET),
 	);
 	const [pageSize, setPageSize] = useState(25);
 	const [page, setPage] = useState(0);
@@ -201,7 +205,14 @@ export function PorcentajeEfectividadContent() {
 
 	// exportCSV cierra sobre allRegistros para que el tipo sea inferido por oRPC
 	function exportCSV() {
-		const headers = ["Fecha", "Prospecto", "Fuente", "Etapa", "% Etapa", "¿Cerró?"];
+		const headers = [
+			"Fecha",
+			"Prospecto",
+			"Fuente",
+			"Etapa",
+			"% Etapa",
+			"¿Cerró?",
+		];
 		const rows = allRegistros.map((row) => [
 			formatDisplayDate(row.createdAt),
 			row.nombre || "Sin nombre",
@@ -214,8 +225,7 @@ export function PorcentajeEfectividadContent() {
 			.map((row) =>
 				row
 					.map(
-						(cell) =>
-							`"${sanitizeCSVCell(String(cell)).replace(/"/g, '""')}"`,
+						(cell) => `"${sanitizeCSVCell(String(cell)).replace(/"/g, '""')}"`,
 					)
 					.join(","),
 			)
@@ -250,186 +260,15 @@ export function PorcentajeEfectividadContent() {
 					Porcentaje Efectividad
 				</h1>
 				<p className="mt-1 text-muted-foreground">
-					Oportunidades creadas en el período y si alcanzaron cierre (90%+),
-					con resumen de conversión por fuente.
+					Oportunidades creadas en el período y si alcanzaron cierre (90%+), con
+					resumen de conversión por fuente.
 				</p>
 			</div>
 
-			<DateRangeFilter
+			<RangePresetFilter
 				dateRange={dateRange}
 				onDateRangeChange={setDateRange}
 			/>
-
-			{/* ── Registros individuales (prioridad) ── */}
-			<Card>
-				<CardHeader>
-					<div className="flex items-start justify-between gap-4">
-						<div>
-							<CardTitle>Oportunidades del período</CardTitle>
-							<CardDescription className="mt-1">
-								Todas las oportunidades creadas en el rango seleccionado y su
-								estado de conversión
-							</CardDescription>
-						</div>
-						{allRegistros.length > 0 && (
-							<Button
-								variant="outline"
-								size="sm"
-								className="shrink-0"
-								onClick={exportCSV}
-							>
-								<Download className="mr-2 h-4 w-4" />
-								Exportar CSV
-							</Button>
-						)}
-					</div>
-				</CardHeader>
-				<CardContent className="space-y-3">
-					<div className="max-h-[600px] overflow-y-auto rounded-md border">
-						<Table>
-							<TableHeader className="sticky top-0 z-10 bg-background">
-								<TableRow>
-									<TableHead>Fecha</TableHead>
-									<TableHead>Prospecto</TableHead>
-									<TableHead>Fuente</TableHead>
-									<TableHead>Etapa actual</TableHead>
-									<TableHead className="text-center">¿Cerró?</TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{isLoading ? (
-									<TableRow>
-										<TableCell
-											colSpan={5}
-											className="py-8 text-center text-muted-foreground"
-										>
-											Cargando...
-										</TableCell>
-									</TableRow>
-								) : visibleRegistros.length === 0 ? (
-									<TableRow>
-										<TableCell
-											colSpan={5}
-											className="py-8 text-center text-muted-foreground"
-										>
-											No hay datos para el período seleccionado
-										</TableCell>
-									</TableRow>
-								) : (
-									visibleRegistros.map((row) => (
-										<TableRow key={row.id}>
-											<TableCell className="whitespace-nowrap text-muted-foreground text-sm">
-												{formatDisplayDate(row.createdAt)}
-											</TableCell>
-											<TableCell className="font-medium">
-												{row.nombre || (
-													<span className="italic text-muted-foreground">
-														Sin nombre
-													</span>
-												)}
-											</TableCell>
-											<TableCell>
-												<div className="flex items-center gap-2">
-													<span
-														className="h-2 w-2 shrink-0 rounded-full"
-														style={{
-															backgroundColor: getSourceColor(row.source),
-														}}
-													/>
-													{getSourceLabel(row.source)}
-												</div>
-											</TableCell>
-											<TableCell>
-												{row.etapaNombre ? (
-													<span className="text-sm">
-														{row.etapaNombre}{" "}
-														<span className="text-muted-foreground">
-															({row.etapaPorcentaje}%)
-														</span>
-													</span>
-												) : (
-													<span className="italic text-muted-foreground text-sm">
-														Sin etapa
-													</span>
-												)}
-											</TableCell>
-											<TableCell className="text-center">
-												{row.cerro ? (
-													<Badge className="gap-1 bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-900/30 dark:text-green-400">
-														<CheckCircle2 className="h-3 w-3" />
-														Sí
-													</Badge>
-												) : (
-													<Badge
-														variant="outline"
-														className="gap-1 text-muted-foreground"
-													>
-														<XCircle className="h-3 w-3" />
-														No
-													</Badge>
-												)}
-											</TableCell>
-										</TableRow>
-									))
-								)}
-							</TableBody>
-						</Table>
-					</div>
-
-					{/* Footer: paginación + selector de page size */}
-					{!isLoading && allRegistros.length > 0 && (
-						<div className="flex items-center justify-between text-sm text-muted-foreground">
-							<span>
-								{`Mostrando ${page * pageSize + 1}–${Math.min((page + 1) * pageSize, allRegistros.length)} de ${allRegistros.length} registros`}
-							</span>
-							<div className="flex items-center gap-3">
-								<div className="flex items-center gap-2">
-									<span>Mostrar</span>
-									<Select
-										value={String(pageSize)}
-										onValueChange={(v) => {
-											setPageSize(Number(v));
-											setPage(0);
-										}}
-									>
-										<SelectTrigger className="h-7 w-16 text-xs">
-											<SelectValue />
-										</SelectTrigger>
-										<SelectContent>
-											<SelectItem value="25">25</SelectItem>
-											<SelectItem value="50">50</SelectItem>
-											<SelectItem value="100">100</SelectItem>
-										</SelectContent>
-									</Select>
-								</div>
-								<div className="flex items-center gap-1">
-									<Button
-										variant="outline"
-										size="sm"
-										className="h-7 px-2 text-xs"
-										disabled={page === 0}
-										onClick={() => setPage((p) => p - 1)}
-									>
-										Anterior
-									</Button>
-									<span className="px-2">
-										{page + 1} / {totalPages}
-									</span>
-									<Button
-										variant="outline"
-										size="sm"
-										className="h-7 px-2 text-xs"
-										disabled={page + 1 >= totalPages}
-										onClick={() => setPage((p) => p + 1)}
-									>
-										Siguiente
-									</Button>
-								</div>
-							</div>
-						</div>
-					)}
-				</CardContent>
-			</Card>
 
 			{/* ── Resumen estadístico ── */}
 			<div className="grid gap-4 md:grid-cols-3">
@@ -576,6 +415,177 @@ export function PorcentajeEfectividadContent() {
 							)}
 						</TableBody>
 					</Table>
+				</CardContent>
+			</Card>
+
+			{/* ── Registros individuales (detalle) ── */}
+			<Card>
+				<CardHeader>
+					<div className="flex items-start justify-between gap-4">
+						<div>
+							<CardTitle>Oportunidades del período</CardTitle>
+							<CardDescription className="mt-1">
+								Todas las oportunidades creadas en el rango seleccionado y su
+								estado de conversión
+							</CardDescription>
+						</div>
+						{allRegistros.length > 0 && (
+							<Button
+								variant="outline"
+								size="sm"
+								className="shrink-0"
+								onClick={exportCSV}
+							>
+								<Download className="mr-2 h-4 w-4" />
+								Exportar CSV
+							</Button>
+						)}
+					</div>
+				</CardHeader>
+				<CardContent className="space-y-3">
+					<div className="max-h-[600px] overflow-y-auto rounded-md border">
+						<Table>
+							<TableHeader className="sticky top-0 z-10 bg-background">
+								<TableRow>
+									<TableHead>Fecha</TableHead>
+									<TableHead>Prospecto</TableHead>
+									<TableHead>Fuente</TableHead>
+									<TableHead>Etapa actual</TableHead>
+									<TableHead className="text-center">¿Cerró?</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{isLoading ? (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className="py-8 text-center text-muted-foreground"
+										>
+											Cargando...
+										</TableCell>
+									</TableRow>
+								) : visibleRegistros.length === 0 ? (
+									<TableRow>
+										<TableCell
+											colSpan={5}
+											className="py-8 text-center text-muted-foreground"
+										>
+											No hay datos para el período seleccionado
+										</TableCell>
+									</TableRow>
+								) : (
+									visibleRegistros.map((row) => (
+										<TableRow key={row.id}>
+											<TableCell className="whitespace-nowrap text-muted-foreground text-sm">
+												{formatDisplayDate(row.createdAt)}
+											</TableCell>
+											<TableCell className="font-medium">
+												{row.nombre || (
+													<span className="text-muted-foreground italic">
+														Sin nombre
+													</span>
+												)}
+											</TableCell>
+											<TableCell>
+												<div className="flex items-center gap-2">
+													<span
+														className="h-2 w-2 shrink-0 rounded-full"
+														style={{
+															backgroundColor: getSourceColor(row.source),
+														}}
+													/>
+													{getSourceLabel(row.source)}
+												</div>
+											</TableCell>
+											<TableCell>
+												{row.etapaNombre ? (
+													<span className="text-sm">
+														{row.etapaNombre}{" "}
+														<span className="text-muted-foreground">
+															({row.etapaPorcentaje}%)
+														</span>
+													</span>
+												) : (
+													<span className="text-muted-foreground text-sm italic">
+														Sin etapa
+													</span>
+												)}
+											</TableCell>
+											<TableCell className="text-center">
+												{row.cerro ? (
+													<Badge className="gap-1 bg-green-100 text-green-700 hover:bg-green-100 dark:bg-green-900/30 dark:text-green-400">
+														<CheckCircle2 className="h-3 w-3" />
+														Sí
+													</Badge>
+												) : (
+													<Badge
+														variant="outline"
+														className="gap-1 text-muted-foreground"
+													>
+														<XCircle className="h-3 w-3" />
+														No
+													</Badge>
+												)}
+											</TableCell>
+										</TableRow>
+									))
+								)}
+							</TableBody>
+						</Table>
+					</div>
+
+					{/* Footer: paginación + selector de page size */}
+					{!isLoading && allRegistros.length > 0 && (
+						<div className="flex items-center justify-between text-muted-foreground text-sm">
+							<span>
+								{`Mostrando ${page * pageSize + 1}–${Math.min((page + 1) * pageSize, allRegistros.length)} de ${allRegistros.length} registros`}
+							</span>
+							<div className="flex items-center gap-3">
+								<div className="flex items-center gap-2">
+									<span>Mostrar</span>
+									<Select
+										value={String(pageSize)}
+										onValueChange={(v) => {
+											setPageSize(Number(v));
+											setPage(0);
+										}}
+									>
+										<SelectTrigger className="h-7 w-16 text-xs">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="25">25</SelectItem>
+											<SelectItem value="50">50</SelectItem>
+											<SelectItem value="100">100</SelectItem>
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="flex items-center gap-1">
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-7 px-2 text-xs"
+										disabled={page === 0}
+										onClick={() => setPage((p) => p - 1)}
+									>
+										Anterior
+									</Button>
+									<span className="px-2">
+										{page + 1} / {totalPages}
+									</span>
+									<Button
+										variant="outline"
+										size="sm"
+										className="h-7 px-2 text-xs"
+										disabled={page + 1 >= totalPages}
+										onClick={() => setPage((p) => p + 1)}
+									>
+										Siguiente
+									</Button>
+								</div>
+							</div>
+						</div>
+					)}
 				</CardContent>
 			</Card>
 		</div>

--- a/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { subMonths } from "date-fns";
 import { Activity, Clock, TrendingDown, TrendingUp } from "lucide-react";
 import { useEffect, useState } from "react";
 import type { DateRange } from "react-day-picker";
@@ -15,7 +14,11 @@ import {
 	YAxis,
 } from "recharts";
 import { toast } from "sonner";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
+import {
+	DEFAULT_PRESET,
+	RangePresetFilter,
+	rangeForPreset,
+} from "@/components/reports/range-preset-filter";
 import { ReportCard } from "@/components/reports/report-card";
 import {
 	Card,
@@ -79,11 +82,6 @@ function formatDateInput(date: Date): string {
 	}).format(date);
 }
 
-function getDefaultDateRange(): DateRange {
-	const today = new Date();
-	return { from: subMonths(today, 1), to: today };
-}
-
 function RouteComponent() {
 	const {
 		data: session,
@@ -94,17 +92,32 @@ function RouteComponent() {
 
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const userRole = userProfile.data?.role;
-	const canAccess = userRole ? PERMISSIONS.canAccessTiempoCierreReport(userRole) : false;
+	const canAccess = userRole
+		? PERMISSIONS.canAccessTiempoCierreReport(userRole)
+		: false;
 	const isPending = sessionPending || userProfile.isPending;
 
 	useEffect(() => {
-		if (shouldRedirectToLogin({ error: sessionError, isPending: sessionPending, session })) {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
 			navigate({ to: "/login" });
 		} else if (session && !userProfile.isPending && !canAccess) {
 			navigate({ to: "/dashboard" });
 			toast.error("Acceso denegado");
 		}
-	}, [session, sessionError, sessionPending, userProfile.isPending, canAccess, navigate]);
+	}, [
+		session,
+		sessionError,
+		sessionPending,
+		userProfile.isPending,
+		canAccess,
+		navigate,
+	]);
 
 	if (isPending) {
 		return (
@@ -124,11 +137,16 @@ function RouteComponent() {
 }
 
 export function TiempoCierreContent() {
-	const [dateRange, setDateRange] = useState<DateRange | undefined>(getDefaultDateRange);
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(() =>
+		rangeForPreset(DEFAULT_PRESET),
+	);
 
 	const input =
 		dateRange?.from && dateRange?.to
-			? { startDate: formatDateInput(dateRange.from), endDate: formatDateInput(dateRange.to) }
+			? {
+					startDate: formatDateInput(dateRange.from),
+					endDate: formatDateInput(dateRange.to),
+				}
 			: null;
 
 	const reportQuery = useQuery({
@@ -166,7 +184,7 @@ export function TiempoCierreContent() {
 				</p>
 			</div>
 
-			<DateRangeFilter
+			<RangePresetFilter
 				dateRange={dateRange}
 				onDateRangeChange={setDateRange}
 			/>
@@ -237,7 +255,11 @@ export function TiempoCierreContent() {
 									formatter={(value) => [`${value} días`, "Promedio"]}
 									labelFormatter={(label) => `Fuente: ${label}`}
 								/>
-								<Bar dataKey="avgDias" name="Días promedio" radius={[0, 4, 4, 0]}>
+								<Bar
+									dataKey="avgDias"
+									name="Días promedio"
+									radius={[0, 4, 4, 0]}
+								>
 									{chartData.map((entry) => (
 										<Cell
 											key={entry.rawSource}
@@ -295,7 +317,9 @@ export function TiempoCierreContent() {
 											<div className="flex items-center gap-2">
 												<span
 													className="h-2.5 w-2.5 shrink-0 rounded-full"
-													style={{ backgroundColor: getSourceColor(row.rawSource) }}
+													style={{
+														backgroundColor: getSourceColor(row.rawSource),
+													}}
 												/>
 												{row.source}
 											</div>


### PR DESCRIPTION
# 🚀 Pase a Producción — `develop` → `main`

Release de los cambios acumulados en `develop`. Resumen general por área:

## 📊 Reportes (CRM)
- **Filtro por presets reutilizable**: nuevo control de rango (Este mes / Últimos 3 meses / Últimos 6 meses / Este año / Personalizado) en Tiempo de Cierre y Porcentaje de Efectividad, con las fronteras calculadas en hora de Guatemala
- **Cuotas por Fecha**: nuevo reporte que reemplaza la pestaña "Pagos Esperados", con cuotas filtradas por asesor
- **Facturado del Mes**: nuevos rubros (mora del cubo y otros ingresos), se quita capital del cobrado y se agrega palanca de mora en el simulador de escenarios
- **Cobertura de Colocación**: filtro de rango por período, consistente con Cobranza y acotado a un solo año por defecto
- **Créditos cerrados**: la cuota del crédito cae a la cuota mensual de la oportunidad cuando no hay cotización enlazada
- **UI**: tabla de registros movida al final en Efectividad y selects de shadcn en Meta de Colocación
- Correcciones de cálculo: capital de la primera cuota y total pagado desglosado por rubros

## 💳 Cartera
- El cierre de cuota ya no sobreescribe un pago real registrado
- `esDestinoSobrescribible` con umbral estricto y considerando mora / otros / convenio (correcciones Codex P2)
- Política de registro de pagos extraída a su propio módulo y cubierta con tests

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
