### PR TITLE
fix(reports): alinear Simular con reporte Cobrado del Mes vs Esperado

### DIFF
--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -5,7 +5,7 @@
  * cliente y muestra el resultado simulado vs real. No modifica datos reales.
  */
 
-import { Sparkles } from "lucide-react";
+import { AlertTriangle, Info, Sparkles } from "lucide-react";
 import { useMemo, useState } from "react";
 import {
 	Bar,
@@ -13,7 +13,7 @@ import {
 	CartesianGrid,
 	Legend,
 	ResponsiveContainer,
-	Tooltip,
+	Tooltip as RechartsTooltip,
 	XAxis,
 	YAxis,
 } from "recharts";
@@ -27,6 +27,12 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+	Tooltip,
+	TooltipContent,
+	TooltipProvider,
+	TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
 	Table,
 	TableBody,
@@ -93,17 +99,29 @@ function LeverSlider({
 	lever,
 	value,
 	onChange,
+	hintOverride,
 }: {
 	lever: Exclude<LeverKey, "metodo">;
 	value: number;
 	onChange: (v: number) => void;
+	hintOverride?: string;
 }) {
 	const cfg = LEVER_LABELS[lever];
+	const hint = hintOverride ?? cfg.hint;
 	return (
 		<div className="space-y-1.5">
-			<div className="flex items-center justify-between">
+			<div className="flex items-center gap-1.5">
 				<Label className="text-sm">{cfg.label}</Label>
-				<span className="text-muted-foreground text-xs">{cfg.hint}</span>
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground" />
+						</TooltipTrigger>
+						<TooltipContent className="max-w-56 text-xs">
+							{hint}
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
 			</div>
 			<div className="flex items-center gap-3">
 				<input
@@ -173,6 +191,7 @@ export function ScenarioModal<T>({
 	);
 
 	const cuota = config.usaMetodoCuota ? cuotaIlustrativa(params) : null;
+	const warning = baseData ? (config.getWarning?.(baseData) ?? null) : null;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -191,6 +210,12 @@ export function ScenarioModal<T>({
 					</p>
 				) : (
 					<div className="grid gap-6 md:grid-cols-[280px_1fr]">
+						{warning && (
+							<div className="col-span-full flex items-start gap-3 rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800">
+								<AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+								<span>{warning}</span>
+							</div>
+						)}
 						{/* Supuestos */}
 						<div className="space-y-4">
 							<h4 className="font-semibold text-sm">Supuestos</h4>
@@ -202,6 +227,7 @@ export function ScenarioModal<T>({
 										lever={lever}
 										value={params[LEVER_FIELD[lever]] as number}
 										onChange={(v) => setField(LEVER_FIELD[lever], v)}
+										hintOverride={config.leverDescriptions?.[lever]}
 									/>
 								))}
 
@@ -299,7 +325,7 @@ export function ScenarioModal<T>({
 										tickFormatter={(v) => `Q${(Number(v) / 1000).toFixed(0)}k`}
 										tick={{ fontSize: 11 }}
 									/>
-									<Tooltip formatter={(v) => formatQ(Number(v))} />
+									<RechartsTooltip formatter={(v) => formatQ(Number(v))} />
 									<Legend />
 									<Bar dataKey="Real" fill="#94a3b8" radius={[4, 4, 0, 0]} />
 									<Bar

--- a/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
+++ b/apps/crm/apps/web/src/components/reports/scenario-modal.tsx
@@ -114,8 +114,11 @@ function LeverSlider({
 				<Label className="text-sm">{cfg.label}</Label>
 				<TooltipProvider>
 					<Tooltip>
-						<TooltipTrigger asChild>
-							<Info className="h-3.5 w-3.5 cursor-pointer text-muted-foreground" />
+						<TooltipTrigger
+							aria-label={hint}
+							className="rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+						>
+							<Info className="h-3.5 w-3.5 text-muted-foreground" />
 						</TooltipTrigger>
 						<TooltipContent className="max-w-56 text-xs">
 							{hint}

--- a/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario-configs.ts
@@ -30,6 +30,10 @@ export interface ScenarioReportConfig<T> {
 	usaMetodoCuota: boolean;
 	transform: (base: T, p: ScenarioParams) => T;
 	summarize: (data: T) => SummaryRow[];
+	/** Aviso informativo cuando los datos limitan la simulación (ej: sin meta). */
+	getWarning?: (data: T) => string | null;
+	/** Override del hint por lever, específico para este reporte. */
+	leverDescriptions?: Partial<Record<Exclude<LeverKey, "metodo">, string>>;
 }
 
 const num = (v: string | number | null | undefined): number => {
@@ -65,20 +69,40 @@ export const montoACobrarConfig: ScenarioReportConfig<MontoACobrarRow[]> = {
 };
 
 export const facturacionConfig: ScenarioReportConfig<FacturacionMesResponse> = {
-	titulo: "Facturado del Mes vs Esperado",
+	titulo: "Cobrado del Mes vs Esperado",
 	descripcion:
 		"Estima cuánto más se cobraría al subir la efectividad o bajar la mora.",
 	levers: ["efectividad", "mora"],
 	usaMetodoCuota: false,
 	transform: transformFacturacion,
-	summarize: (data) => [
-		{ concepto: "Interés", valor: num(data.cobrado.interes) },
-		{ concepto: "Membresías", valor: num(data.cobrado.membresias) },
-		{ concepto: "Seguro + GPS", valor: num(data.cobrado.seguro_gps) },
-		{ concepto: "Royaltí", valor: num(data.cobrado.royalti) },
-		{ concepto: "Mora", valor: num(data.cobrado.mora) },
-		{ concepto: "Otros", valor: num(data.cobrado.otros) },
-	],
+	summarize: (data) => {
+		const totalCobrado =
+			num(data.cobrado.interes) +
+			num(data.cobrado.membresias) +
+			num(data.cobrado.seguro_gps) +
+			num(data.cobrado.royalti) +
+			num(data.cobrado.mora) +
+			num(data.cobrado.otros);
+		return [
+			{ concepto: "Interés", valor: num(data.cobrado.interes) },
+			{ concepto: "Membresías", valor: num(data.cobrado.membresias) },
+			{ concepto: "Seguro + GPS", valor: num(data.cobrado.seguro_gps) },
+			{ concepto: "Royaltí", valor: num(data.cobrado.royalti) },
+			{ concepto: "Mora", valor: num(data.cobrado.mora) },
+			{ concepto: "Otros", valor: num(data.cobrado.otros) },
+			{ concepto: "Total cobrado", valor: totalCobrado },
+			{ concepto: "Meta del mes", valor: num(data.esperado.meta_mensual) },
+		];
+	},
+	getWarning: (data) =>
+		num(data.esperado.meta_mensual) === 0
+			? "Sin meta del mes configurada, solo la palanca de mora tiene efecto. Configura la meta para simular efectividad de cobranza."
+			: null,
+	leverDescriptions: {
+		efectividad:
+			"Escala Interés, Membresías, Seguro+GPS, Royaltí y Otros para cerrar la brecha con la meta",
+		mora: "Reduce directamente los ingresos por mora, y también contribuye a cerrar la brecha en los demás rubros",
+	},
 };
 
 export const flujoCuotasConfig: ScenarioReportConfig<FlujoCuotasInversionesResponse> =


### PR DESCRIPTION
## Summary

- Corrige título del modal: "Facturado del Mes vs Esperado" → "Cobrado del Mes vs Esperado"
- Agrega filas **Total cobrado** y **Meta del mes** al summarize del modal para que el usuario vea la brecha que se está simulando
- Muestra banner de aviso cuando `meta_mensual = 0` — explica que solo la palanca de mora tiene efecto
- Reemplaza hint estático por **tooltip con ícono ⓘ** en cada lever, con descripción específica por reporte (via `leverDescriptions` en config)
- Renombra `Tooltip` de recharts a `RechartsTooltip` para evitar colisión con shadcn Tooltip

## Test plan

- [ ] Abrir reporte sin meta configurada → botón Simular → ver banner amarillo
- [ ] Mover slider de mora → valor de Mora baja, otros rubros sin cambio
- [ ] Configurar meta del mes → Simular → ambos sliders tienen efecto, tabla muestra Total + Meta como referencia
- [ ] Hover sobre ⓘ en cada lever → tooltip explica qué rubros afecta
- [ ] Efectividad 100% + mora 100% → Total escenario se aproxima a Meta del mes
- [ ] Verificar que los otros reportes (Monto a Cobrar, Cobertura, Comparativo) no se ven afectados

🤖 Generated with [Claude Code](https://claude.com/claude-code)