### PR TITLE
fix(cartera): evitar moras_credito activas duplicadas (cron en paralelo)

### DIFF
--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -1,5 +1,5 @@
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
-import { db } from "../database";
+import { client, db } from "../database";
 import { asesores, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, platform_users, usuarios } from "../database/db/schema";
 import Big from "big.js";
 import { toZonedTime } from "date-fns-tz";
@@ -490,10 +490,27 @@ export async function updateMora({
  *    - Update the credit status to "MOROSO".
  * 5. Log every step for debugging and monitoring.
  */
+// Clave fija para el advisory lock de procesarMoras (cualquier int estable sirve).
+const PROCESAR_MORAS_LOCK_KEY = 728193;
+
 export async function procesarMoras() {
   const zona = "America/Guatemala";
 
+  // 🔒 Lock entre instancias: con varias réplicas del back, todas agendan el cron
+  // (23:59 GT) y corrían EN PARALELO leyendo el mismo estado viejo → duplicaban
+  // eventos en moras_historial y, peor, filas activa=true en moras_credito.
+  // Tomamos un advisory lock en una conexión dedicada; si otra corrida ya lo tiene,
+  // se omite esta. (El índice único parcial moras_credito_uq_activa es el respaldo duro.)
+  const lockConn = await client.connect();
+  let lockHeld = false;
   try {
+    const _lk = await lockConn.query("SELECT pg_try_advisory_lock($1) AS ok", [PROCESAR_MORAS_LOCK_KEY]);
+    lockHeld = _lk.rows[0]?.ok === true;
+    if (!lockHeld) {
+      console.log("[MORA] ⏭️  Otra instancia ya está procesando moras; se omite esta corrida.");
+      return { skipped: true, creadas: 0, recalculadas: 0, sinCambios: 0, desactivadas: 0, sinCapital: 0 };
+    }
+
     const hoy = toZonedTime(new Date(), zona);
     hoy.setHours(0, 0, 0, 0);
 
@@ -622,16 +639,27 @@ export async function procesarMoras() {
 
       if (!moraActual) {
         // CREACION
-        const [insertada] = await db
-          .insert(moras_credito)
-          .values({
-            credito_id: creditoId,
-            monto_mora: moraNuevaStr,
-            cuotas_atrasadas: cuotasAtrasadas,
-            activa: true,
-            porcentaje_mora: "1.12",
-          })
-          .returning();
+        let insertada;
+        try {
+          [insertada] = await db
+            .insert(moras_credito)
+            .values({
+              credito_id: creditoId,
+              monto_mora: moraNuevaStr,
+              cuotas_atrasadas: cuotasAtrasadas,
+              activa: true,
+              porcentaje_mora: "1.12",
+            })
+            .returning();
+        } catch (e: any) {
+          // Índice único parcial moras_credito_uq_activa: otra corrida concurrente
+          // ya creó la mora activa de este crédito → omitir (no duplicar).
+          if (e?.code === "23505") {
+            console.log(`[SKIP] Credit #${creditoId} mora ya creada por otra instancia (índice único)`);
+            continue;
+          }
+          throw e;
+        }
 
         await db
           .update(creditos)
@@ -756,6 +784,15 @@ export async function procesarMoras() {
     console.error("[ERROR] Message:", error.message);
     console.error("[ERROR] Stack trace:", error.stack);
     throw error;
+  } finally {
+    if (lockHeld) {
+      try {
+        await lockConn.query("SELECT pg_advisory_unlock($1)", [PROCESAR_MORAS_LOCK_KEY]);
+      } catch {
+        /* el lock se libera solo al cerrar la sesión; no es crítico */
+      }
+    }
+    lockConn.release();
   }
 }
 

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -291,23 +291,34 @@
     })
   );
 
-  export const moras_credito = customSchema.table("moras_credito", {
-    mora_id: serial("mora_id").primaryKey(),
-    credito_id: integer("credito_id")
-      .notNull()
-      .references(() => creditos.credito_id, { onDelete: "cascade" }),
-    activa: boolean("activa").notNull().default(true),
-    porcentaje_mora: numeric("porcentaje_mora", { precision: 5, scale: 2 })
-      .notNull()
-      .default("1.12"),
-    monto_mora: numeric("monto_mora", { precision: 18, scale: 2 })
-      .notNull()
-      .default("0"),
-    cuotas_atrasadas: integer("cuotas_atrasadas").notNull().default(0),
+  export const moras_credito = customSchema.table(
+    "moras_credito",
+    {
+      mora_id: serial("mora_id").primaryKey(),
+      credito_id: integer("credito_id")
+        .notNull()
+        .references(() => creditos.credito_id, { onDelete: "cascade" }),
+      activa: boolean("activa").notNull().default(true),
+      porcentaje_mora: numeric("porcentaje_mora", { precision: 5, scale: 2 })
+        .notNull()
+        .default("1.12"),
+      monto_mora: numeric("monto_mora", { precision: 18, scale: 2 })
+        .notNull()
+        .default("0"),
+      cuotas_atrasadas: integer("cuotas_atrasadas").notNull().default(0),
 
-    created_at: timestamp("created_at").defaultNow(),
-    updated_at: timestamp("updated_at").defaultNow(),
-  });
+      created_at: timestamp("created_at").defaultNow(),
+      updated_at: timestamp("updated_at").defaultNow(),
+    },
+    (t) => [
+      // Garantiza UNA sola mora activa por crédito. Bloquea a nivel BD la
+      // condición de carrera de procesarMoras corriendo en paralelo (varias
+      // réplicas) que insertaba filas activa=true duplicadas e inflaba el total.
+      uniqueIndex("moras_credito_uq_activa")
+        .on(t.credito_id)
+        .where(sql`${t.activa} = true`),
+    ]
+  );
   export const moras_condonaciones = customSchema.table("moras_condonaciones", {
     condonacion_id: serial("condonacion_id").primaryKey(),
     credito_id: integer("credito_id")


### PR DESCRIPTION
## Problema
El módulo **Mora Histórica** no duplica en pantalla (reconstruye con `ROW_NUMBER() PARTITION BY credito_id WHERE rn=1`), pero la data cruda **sí** estaba duplicada:

- `procesarMoras` está agendado **1 sola vez** (23:59 GT) en `schedule.ts`, pero el back corre con **varias réplicas** (imagen a ECR); cada una agenda el cron y corrían **en paralelo** leyendo el mismo estado viejo (read-modify-write sin lock).
- Resultado en prod (verificado 2026-06-18): **1,884 filas extra** en `moras_historial` y, lo grave, **173 créditos con 2 filas `activa=true`** en `moras_credito` → inflaban el total de mora en **~Q193,502**. Por eso "sacar totales de `moras_credito` actual" daba más que la Mora Histórica.

## Cambios
- **schema**: índice único parcial `moras_credito_uq_activa (credito_id) WHERE activa=true` → imposible tener 2 moras activas por crédito (garantía dura, pooler-agnóstica).
- **`procesarMoras`**: `pg_try_advisory_lock` en conexión dedicada al inicio; si otra instancia ya lo tiene, omite la corrida (`unlock`+`release` en `finally`).
- **CREACION**: el `INSERT` se envuelve en try/catch; si choca con el índice (`23505`) se omite ese crédito en vez de tronar la corrida nocturna.

## Ya aplicado a prod (manual, con backup)
- Limpieza: por crédito duplicado se dejó 1 fila activa (orden `monto>0, updated_at, mora_id`), 173 desactivadas → **0 duplicados**. Backup completo en `cartera._bk_dup_moras_credito_20260618` (346 filas).
- Índice `moras_credito_uq_activa` creado a mano (probado: insert duplicado da `23505`).
- Por eso este PR **no** necesita migración; el `deploy.sh` solo construye/empuja imagen, no corre migraciones. El índice se agrega a `schema.ts` para que un `drizzle-kit push` futuro no lo borre.

## Notas
- El advisory lock es de sesión; bajo pgbouncer **transaction pooler (6543)** no serializaría bien — por eso el índice es la garantía real y el `INSERT` tolera el `23505`.
- Tras la limpieza, la diferencia que queda entre Mora Histórica (~Q2.39M) y `moras_credito` actual (~Q2.27M) es legítima: son ~51 créditos **condonados** (mora en cero en `moras_credito` pero viva en el historial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)