### PR TITLE
feat(cartera): desglose nuevo vs pago + seguro/GPS en snapshot diario

### DIFF
--- a/apps/cartera-back/drizzle/0015_snapshot_detalle_origen.sql
+++ b/apps/cartera-back/drizzle/0015_snapshot_detalle_origen.sql
@@ -1,0 +1,37 @@
+-- 0015 — Desglose por origen (crédito nuevo vs pago) + separación seguro/GPS
+-- Spec: docs/superpowers/specs/2026-06-18-facturacion-detalle-origen-design.md
+-- NO toca totales ni fórmulas existentes: solo agrega columnas/tabla nuevas.
+
+-- 1) Snapshot: seguro y GPS por categoría (el combinado sigue en servicios_seguro_gps)
+ALTER TABLE cartera.facturacion_snapshot_diario
+  ADD COLUMN IF NOT EXISTS seg_autocompras           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_sobre_vehiculo        numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS nuevo_seg_autocompras     numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_hipotecario           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_extra_financiamiento  numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_reestructura          numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seguro_total              numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_autocompras           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_sobre_vehiculo        numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS nuevo_gps_autocompras     numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_hipotecario           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_extra_financiamiento  numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_reestructura          numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_total                 numeric(18,2) NOT NULL DEFAULT 0;
+
+-- 2) Tabla intermedia: desglose por origen (nuevo vs pago), derivada de facturacion_desglose
+CREATE TABLE IF NOT EXISTS cartera.facturacion_snapshot_detalle (
+  id          serial PRIMARY KEY,
+  fecha       date NOT NULL,
+  rubro       cartera.rubro_facturacion NOT NULL,
+  producto    varchar(40) NOT NULL,   -- autocompras|sobre_vehiculo|nuevo_autocompras|hipotecario|extra_financiamiento|reestructura|sin_producto
+  origen      varchar(10) NOT NULL,   -- 'nuevo' (originación) | 'pago'
+  monto_total numeric(18,2) NOT NULL DEFAULT 0,
+  monto_iva   numeric(18,2) NOT NULL DEFAULT 0,
+  created_at  timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facturacion_snapshot_detalle
+  ON cartera.facturacion_snapshot_detalle (fecha, rubro, producto, origen);
+CREATE INDEX IF NOT EXISTS idx_facturacion_snapshot_detalle_fecha
+  ON cartera.facturacion_snapshot_detalle (fecha);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -880,11 +880,16 @@ export async function generarExcelFacturacionDiaria(
   //   Para conta: por cada día y rubro, el desglose por producto en crédito nuevo
   //   vs pago, RESPETANDO el orden del reporte y con filas en blanco entre rubros
   //   y días para que se lea cómodo. Fuente: facturacion_snapshot_detalle.
+  // Días BLOQUEADOS (editados a mano / forzados): el detalle viene del desglose y
+  //   NO reconcilia con el total forzado → se EXCLUYEN del Desglose (Codex P2 #933).
   const det = await db.execute(sql`
     SELECT fecha::text AS fecha, rubro::text AS rubro, producto, origen,
            monto_total::float8 AS monto
     FROM cartera.facturacion_snapshot_detalle
     WHERE fecha BETWEEN ${fechaInicio}::date AND ${fechaFin}::date
+      AND fecha NOT IN (
+        SELECT fecha FROM cartera.facturacion_snapshot_diario WHERE bloqueado = true
+      )
   `);
   const idx: Record<string, Record<string, Record<string, { nuevo: number; pago: number }>>> = {};
   for (const x of (det as any).rows ?? []) {

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -178,6 +178,10 @@ const RUBRO_PREFIX: Record<string, string> = {
   OTROS: "oi",
   MORA: "mora",
   ROYALTY: "roy",
+  // Seguro/GPS también van por categoría (además del combinado servicios_seguro_gps).
+  // En el loop del desglose se tratan aparte (no caen en el totalCol genérico).
+  SEGURO: "seg",
+  GPS: "gps",
 };
 
 // categoría BD -> producto Excel (sufijo). "__NUEVO__" usa el patrón nuevo_<prefijo>_autocompras.
@@ -241,9 +245,33 @@ export async function generarSnapshotDiario(fecha: string) {
     LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
     LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
     WHERE fd.fecha_aplicado_gt = ${fecha}::date
-      -- una fila de PAGO huérfana (credito/usuario borrado) no debe sumar al
-      -- total; las GENÉRICAS (pago_id NULL) sí entran.
-      AND (fd.pago_id IS NULL OR p.pago_id IS NOT NULL)
+      -- Filas de PAGO: el pago debe existir (no huérfano por credito/usuario
+      -- borrado) y, MISMO CRITERIO QUE EL EXCEL (getPagosConInversionistas que
+      -- llena "Reuniones diarias"): el crédito debe estar en un estado contable
+      -- (excluye CAIDO y demás) y el pago en un validation_status contable. Si no,
+      -- el desglose contaba pagos facturados sobre créditos caídos que el Excel
+      -- excluye → diferencia (p.ej. capital nuevo 06-16). Las GENÉRICAS (pago_id
+      -- NULL) no tienen crédito asociado → entran igual.
+      AND (
+        fd.pago_id IS NULL OR (
+          p.pago_id IS NOT NULL
+          AND c."statusCredit" IN
+            ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+          AND p.validation_status IN
+            ('validated','pending','reset','capital','capital_validated')
+        )
+      )
+      -- Las GENÉRICAS de ORIGINACIÓN (alta de crédito nuevo) SÍ alimentan sus rubros:
+      -- la cuota 0 de INTERÉS y MEMBRESÍA del vehículo nuevo DEBE SUMAR (decisión del
+      -- negocio), igual que otros/royalty/seguro. Solo se excluyen del desglose:
+      --   • CAPITAL → se calcula del pci (bloque 1.5), no del desglose.
+      --   • MORA → un crédito nuevo no genera mora genérica.
+      -- ⚠️ Con esto interés/membresía dejan de cuadrar con el Excel (que manda la
+      --    cuota 0 a administrativos) — decisión explícita: en el sistema la cuota 0 suma.
+      AND NOT (
+        fd.pago_id IS NULL
+        AND fd.rubro::text IN ('CAPITAL','MORA')
+      )
     GROUP BY COALESCE(u.categoria, fd.categoria), fd.rubro
   `);
   for (const r of (desg as any).rows ?? []) {
@@ -251,9 +279,19 @@ export async function generarSnapshotDiario(fecha: string) {
     const rubro = r.rubro as string;
     const total = r.total;
     if (rubro === "SEGURO" || rubro === "GPS") {
-      add("servicios_seguro_gps", total);
+      add("servicios_seguro_gps", total); // combinado, INTACTO para conta
+      // + segmentación por categoría (igual que membresía/interés)
+      const pfx = rubro === "SEGURO" ? "seg" : "gps";
+      add(rubro === "SEGURO" ? "seguro_total" : "gps_total", total);
+      add(colProducto(pfx, cat), total);
       continue;
     }
+    // 💰 CAPITAL NO se toma del desglose: se jala del pci (pagos aplicados) en el
+    //    bloque 1.5 de abajo. cofidi escribe la fila CAPITAL solo si el capital de
+    //    CUBE > 0 al FACTURAR; si entra al pci DESPUÉS de facturar, la fila no se
+    //    escribe y el desglose sub-cuenta capital (gap vs el Excel). Por eso el
+    //    capital se calcula desde los pagos aplicados, igual que "Reuniones diarias".
+    if (rubro === "CAPITAL") continue;
     const prefix = RUBRO_PREFIX[rubro];
     if (!prefix) continue;
     // total por rubro (columna *_cube / total)
@@ -271,6 +309,32 @@ export async function generarSnapshotDiario(fecha: string) {
         : "mora_cube"; // MORA
     add(totalCol, total);
     add(colProducto(prefix, cat), total);
+  }
+
+  // 1.5) 💰 CAPITAL del día = capital de CUBE desde pagos_credito_inversionistas
+  //      (pci) de los pagos APLICADOS hoy — MISMA fuente que el Excel "Reuniones
+  //      diarias" (getPagosConInversionistas). Se reparte por usuario.categoria
+  //      (igual que el resto). Resuelve el desfase pci↔facturación: el desglose
+  //      escribe la fila CAPITAL solo si el capital de CUBE existe al facturar, y a
+  //      veces el capital entra al pci después → la fila falta y el desglose
+  //      sub-cuenta. Tomándolo de los pagos aplicados cuadra al centavo con el Excel.
+  const capPci = await db.execute(sql`
+    SELECT u.categoria AS categoria, SUM(pci.abono_capital) AS cap
+    FROM cartera.pagos_credito p
+    JOIN cartera.creditos c ON c.credito_id = p.credito_id
+    JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+    JOIN cartera.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
+    JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+    WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+      AND p.validation_status IN ('validated','pending','reset','capital','capital_validated')
+      AND c."statusCredit" IN
+        ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+      AND UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
+    GROUP BY u.categoria
+  `);
+  for (const r of (capPci as any).rows ?? []) {
+    add("capital_total", r.cap);
+    add(colProducto("cap", r.categoria as string), r.cap);
   }
 
   // 2) Royalty del día = SOLO lo REALMENTE facturado (rubro ROYALTY del desglose,
@@ -392,6 +456,8 @@ export async function generarSnapshotDiario(fecha: string) {
     otros_cobros: f2(otros_cobros),
     mora_cube: f2(mora_cube),
     royalty: f2(royalty),
+    seguro_total: f2(g("seguro_total")),
+    gps_total: f2(g("gps_total")),
     facturacion: f2(facturacion),
     facturacion_acumulado: f2(facturacion_acumulado),
     servicios_seguro_gps: f2(servicios),
@@ -430,6 +496,78 @@ export async function generarSnapshotDiario(fecha: string) {
       set: setObj,
     })
     .returning();
+
+  // ───────────── tabla intermedia: detalle por ORIGEN (nuevo vs pago) ─────────────
+  //   Para que conta vea la diferencia que hoy hace a mano. Cubre TODOS los rubros.
+  //   - INTERÉS/MEMBRESÍA/SEGURO/GPS/OTROS/MORA/ROYALTY/INVERSIONISTAS: del desglose
+  //     (genérica = 'nuevo' originación; con pago = 'pago').
+  //   - CAPITAL: NO del desglose (el desglose sub-cuenta capital); se toma de pci de
+  //     CUBE por pago aplicado, MISMA fuente que la columna capital_total → reconcilia.
+  //     Capital siempre es 'pago' (no hay originación de capital).
+  //   trim() en la categoría para igualar colProducto (la data trae espacios/variantes).
+  //   Best-effort: si falla (p.ej. tabla aún no migrada, o race del índice único),
+  //   NO rompe el snapshot ya guardado. Días bloqueados retornan arriba (backfill aparte).
+  try {
+    await db.execute(sql`DELETE FROM cartera.facturacion_snapshot_detalle WHERE fecha = ${fecha}::date`);
+    await db.execute(sql`
+      INSERT INTO cartera.facturacion_snapshot_detalle
+        (fecha, rubro, producto, origen, monto_total, monto_iva)
+      SELECT ${fecha}::date, fd.rubro,
+        CASE lower(trim(COALESCE(u.categoria, fd.categoria)))
+          WHEN 'cv vehículo' THEN 'autocompras'
+          WHEN 'cv vehículo nuevo' THEN 'nuevo_autocompras'
+          WHEN 'vehículo' THEN 'sobre_vehiculo'
+          WHEN 'hipotecario' THEN 'hipotecario'
+          ELSE 'sin_producto'
+        END,
+        CASE WHEN fd.pago_id IS NULL THEN 'nuevo' ELSE 'pago' END,
+        SUM(fd.monto_total), SUM(fd.monto_iva)
+      FROM cartera.facturacion_desglose fd
+      LEFT JOIN cartera.pagos_credito p ON p.pago_id   = fd.pago_id
+      LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
+      LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
+      WHERE fd.fecha_aplicado_gt = ${fecha}::date
+        AND fd.rubro::text <> 'CAPITAL'
+        AND (
+          fd.pago_id IS NULL OR (
+            p.pago_id IS NOT NULL
+            AND c."statusCredit" IN
+              ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+            AND p.validation_status IN
+              ('validated','pending','reset','capital','capital_validated')
+          )
+        )
+      GROUP BY fd.rubro, 3, 4
+    `);
+    // CAPITAL desde pci de CUBE (igual que capital_total) → reconcilia con el snapshot
+    await db.execute(sql`
+      INSERT INTO cartera.facturacion_snapshot_detalle
+        (fecha, rubro, producto, origen, monto_total, monto_iva)
+      SELECT ${fecha}::date, 'CAPITAL'::cartera.rubro_facturacion,
+        CASE lower(trim(u.categoria))
+          WHEN 'cv vehículo' THEN 'autocompras'
+          WHEN 'cv vehículo nuevo' THEN 'nuevo_autocompras'
+          WHEN 'vehículo' THEN 'sobre_vehiculo'
+          WHEN 'hipotecario' THEN 'hipotecario'
+          ELSE 'sin_producto'
+        END,
+        'pago', SUM(pci.abono_capital), 0
+      FROM cartera.pagos_credito p
+      JOIN cartera.creditos c ON c.credito_id = p.credito_id
+      JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+      JOIN cartera.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
+      JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+      WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+        AND p.validation_status IN ('validated','pending','reset','capital','capital_validated')
+        AND c."statusCredit" IN
+          ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+        AND UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
+      GROUP BY 3
+      HAVING SUM(pci.abono_capital) <> 0
+    `);
+  } catch (e) {
+    console.error(`⚠️ detalle snapshot ${fecha} no se pudo poblar (best-effort):`, e);
+  }
 
   return { success: true, data: saved };
 }
@@ -538,6 +676,25 @@ export async function regenerarSnapshotRango(
 // ============================================================================
 // 📥 EXPORTAR A EXCEL (diseño tipo Reuniones diarias, con logo y totales)
 // ============================================================================
+// 📋 Detalle por ORIGEN (crédito nuevo vs pago) de un día — alimenta el modal del
+//    front y la hoja "Desglose" del Excel. Lee facturacion_snapshot_detalle.
+//    Opcional: filtrar por rubro (para el modal de un rubro puntual).
+export async function listarDetalleSnapshot(params: {
+  fecha: string;
+  rubro?: string;
+}) {
+  const { fecha, rubro } = params;
+  const res = await db.execute(sql`
+    SELECT rubro::text AS rubro, producto, origen,
+           monto_total::float8 AS monto_total, monto_iva::float8 AS monto_iva
+    FROM cartera.facturacion_snapshot_detalle
+    WHERE fecha = ${fecha}::date
+      ${rubro ? sql`AND rubro::text = ${rubro}` : sql``}
+    ORDER BY rubro, producto, origen
+  `);
+  return { success: true, data: (res as any).rows ?? [] };
+}
+
 const prodCols = (p: string) => [
   { k: `${p}_autocompras`, l: "Autocompras" },
   { k: `${p}_sobre_vehiculo`, l: "Sobre vehículo" },
@@ -558,6 +715,8 @@ const EXCEL_GRUPOS: { label: string; color: string; cols: { k: string; l: string
   },
   { label: "Mora", color: "FF1D4ED8", cols: [...prodCols("mora"), { k: "mora_cube", l: "Mora Cube" }] },
   { label: "Royalty", color: "FF2563EB", cols: [...prodCols("roy"), { k: "royalty", l: "Royalty" }] },
+  { label: "Seguro", color: "FF1D4ED8", cols: [...prodCols("seg"), { k: "seguro_total", l: "Seguro total" }] },
+  { label: "GPS", color: "FF2563EB", cols: [...prodCols("gps"), { k: "gps_total", l: "GPS total" }] },
   {
     label: "Totales / Acumulados",
     color: "FF0F766E",
@@ -716,6 +875,92 @@ export async function generarExcelFacturacionDiaria(
 
   ws.getRow(HEADER_GROUP_ROW).height = 22;
   ws.getRow(HEADER_COL_ROW).height = 30;
+
+  // ───────────── Hoja "Desglose nuevo vs pago" ─────────────
+  //   Para conta: por cada día y rubro, el desglose por producto en crédito nuevo
+  //   vs pago, RESPETANDO el orden del reporte y con filas en blanco entre rubros
+  //   y días para que se lea cómodo. Fuente: facturacion_snapshot_detalle.
+  const det = await db.execute(sql`
+    SELECT fecha::text AS fecha, rubro::text AS rubro, producto, origen,
+           monto_total::float8 AS monto
+    FROM cartera.facturacion_snapshot_detalle
+    WHERE fecha BETWEEN ${fechaInicio}::date AND ${fechaFin}::date
+  `);
+  const idx: Record<string, Record<string, Record<string, { nuevo: number; pago: number }>>> = {};
+  for (const x of (det as any).rows ?? []) {
+    const f = x.fecha as string, rb = x.rubro as string, p = x.producto as string;
+    (idx[f] ??= {});
+    (idx[f][rb] ??= {});
+    (idx[f][rb][p] ??= { nuevo: 0, pago: 0 });
+    if (x.origen === "nuevo") idx[f][rb][p].nuevo += Number(x.monto) || 0;
+    else idx[f][rb][p].pago += Number(x.monto) || 0;
+  }
+  const RUBRO_ORDER = ["CAPITAL", "INTERES", "MEMBRESIA", "OTROS", "MORA", "ROYALTY", "SEGURO", "GPS", "INTERES_INVERSIONISTAS"];
+  const RUBRO_LABEL: Record<string, string> = { CAPITAL: "Capital", INTERES: "Interés", MEMBRESIA: "Membresía", OTROS: "Otros ingresos", MORA: "Mora", ROYALTY: "Royalty", SEGURO: "Seguro", GPS: "GPS", INTERES_INVERSIONISTAS: "Inversionistas" };
+  const PROD_ORDER = ["autocompras", "sobre_vehiculo", "nuevo_autocompras", "hipotecario", "extra_financiamiento", "reestructura", "sin_producto"];
+  const PROD_LABEL: Record<string, string> = { autocompras: "Autocompras", sobre_vehiculo: "Sobre vehículo", nuevo_autocompras: "Nuevo Autocompras", hipotecario: "Hipotecario", extra_financiamiento: "Extra financ.", reestructura: "Reestructura", sin_producto: "Sin producto" };
+
+  const ds = wb.addWorksheet("Desglose nuevo vs pago");
+  ds.columns = [
+    { key: "fecha", width: 13 },
+    { key: "rubro", width: 16 },
+    { key: "producto", width: 20 },
+    { key: "nuevo", width: 16 },
+    { key: "pago", width: 16 },
+    { key: "total", width: 16 },
+  ];
+  ds.mergeCells(1, 1, 1, 6);
+  const dT = ds.getCell(1, 1);
+  dT.value = `Desglose crédito nuevo vs pago  ·  ${fechaInicio ?? "—"} a ${fechaFin ?? "—"}`;
+  dT.font = { bold: true, size: 14, color: { argb: "FF1E3A8A" } };
+  const dh = ds.getRow(3);
+  ["Fecha", "Rubro", "Producto", "Crédito nuevo", "Pago", "Total"].forEach((h, i) => {
+    const c = dh.getCell(i + 1);
+    c.value = h;
+    c.font = { bold: true, color: { argb: "FFFFFFFF" } };
+    c.alignment = { horizontal: i < 3 ? "left" : "right", vertical: "middle" };
+    c.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FF1E3A8A" } };
+    c.border = border;
+  });
+  dh.height = 22;
+
+  let dr = 4;
+  for (const f of Object.keys(idx).sort()) {
+    for (const rb of RUBRO_ORDER) {
+      const prods = idx[f]?.[rb];
+      if (!prods) continue;
+      const firstRow = dr;
+      let sn = 0, sp = 0;
+      for (const p of PROD_ORDER) {
+        const v = prods[p];
+        if (!v || (v.nuevo === 0 && v.pago === 0)) continue;
+        const row = ds.getRow(dr);
+        row.getCell(1).value = dr === firstRow ? f : "";
+        row.getCell(2).value = dr === firstRow ? (RUBRO_LABEL[rb] ?? rb) : "";
+        row.getCell(3).value = PROD_LABEL[p] ?? p;
+        row.getCell(4).value = v.nuevo;
+        row.getCell(5).value = v.pago;
+        row.getCell(6).value = v.nuevo + v.pago;
+        for (const cc of [4, 5, 6]) row.getCell(cc).numFmt = "#,##0.00";
+        sn += v.nuevo; sp += v.pago;
+        dr++;
+      }
+      if (dr === firstRow) continue; // rubro sin movimiento
+      const sub = ds.getRow(dr);
+      sub.getCell(3).value = `Subtotal ${RUBRO_LABEL[rb] ?? rb}`;
+      sub.getCell(4).value = sn;
+      sub.getCell(5).value = sp;
+      sub.getCell(6).value = sn + sp;
+      for (let cc = 1; cc <= 6; cc++) {
+        const c = sub.getCell(cc);
+        if (cc >= 4) c.numFmt = "#,##0.00";
+        c.font = { bold: true, color: { argb: "FF1E3A8A" } };
+        c.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFEFF6FF" } };
+      }
+      dr += 2; // subtotal + fila en blanco (espacio entre rubros)
+    }
+    dr++; // espacio extra entre días
+  }
 
   const buf = await wb.xlsx.writeBuffer();
   return Buffer.from(buf);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -527,9 +527,14 @@ export async function generarSnapshotDiario(fecha: string) {
       LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
       LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
       WHERE fd.fecha_aplicado_gt = ${fecha}::date
-        AND fd.rubro::text <> 'CAPITAL'
+        AND fd.rubro::text <> 'CAPITAL'                            -- capital se toma del pci (abajo)
+        AND NOT (fd.pago_id IS NULL AND fd.rubro::text = 'MORA')   -- mora genérica fuera (= snapshot)
         AND (
-          fd.pago_id IS NULL OR (
+          fd.pago_id IS NULL
+          -- INTERES_INVERSIONISTAS reconcilia con facturacion_inversionistas (bloque 4),
+          -- que suma el desglose SIN filtro de estado/validation → acá tampoco se filtra.
+          OR fd.rubro::text = 'INTERES_INVERSIONISTAS'
+          OR (
             p.pago_id IS NOT NULL
             AND c."statusCredit" IN
               ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1322,6 +1322,24 @@
       roy_reestructura: numeric("roy_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
       royalty: numeric("royalty", { precision: 18, scale: 2 }).notNull().default("0"),
 
+      // 🛡️ Seguro por categoría (segmentación; el COMBINADO sigue en servicios_seguro_gps)
+      seg_autocompras: numeric("seg_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_sobre_vehiculo: numeric("seg_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_seg_autocompras: numeric("nuevo_seg_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_hipotecario: numeric("seg_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_extra_financiamiento: numeric("seg_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_reestructura: numeric("seg_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      seguro_total: numeric("seguro_total", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 📍 GPS por categoría (segmentación; el COMBINADO sigue en servicios_seguro_gps)
+      gps_autocompras: numeric("gps_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_sobre_vehiculo: numeric("gps_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_gps_autocompras: numeric("nuevo_gps_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_hipotecario: numeric("gps_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_extra_financiamiento: numeric("gps_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_reestructura: numeric("gps_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_total: numeric("gps_total", { precision: 18, scale: 2 }).notNull().default("0"),
+
       // 📊 Totales / acumulados (AT–BE)
       facturacion: numeric("facturacion", { precision: 18, scale: 2 }).notNull().default("0"),
       facturacion_acumulado: numeric("facturacion_acumulado", { precision: 18, scale: 2 }).notNull().default("0"),
@@ -1353,6 +1371,37 @@
     },
     (table) => ({
       uqFecha: uniqueIndex("uq_facturacion_snapshot_diario_fecha").on(table.fecha),
+    })
+  );
+
+  // 🧾 TABLA: facturacion_snapshot_detalle
+  //    Desglose del snapshot por ORIGEN (crédito nuevo vs pago) para que conta vea
+  //    la diferencia que hoy calcula a mano. 1 fila por (fecha, rubro, producto,
+  //    origen). Se DERIVA de facturacion_desglose en generarSnapshotDiario
+  //    (origen = pago_id IS NULL → 'nuevo' [originación]; si no → 'pago').
+  //    NO afecta los totales del snapshot ni las fórmulas del Excel: es una vista
+  //    de control adicional (~60–70 filas/día).
+  export const facturacion_snapshot_detalle = customSchema.table(
+    "facturacion_snapshot_detalle",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(),
+      rubro: rubroFacturacionEnum("rubro").notNull(),
+      // producto: autocompras|sobre_vehiculo|nuevo_autocompras|hipotecario|extra_financiamiento|reestructura|sin_producto
+      producto: varchar("producto", { length: 40 }).notNull(),
+      origen: varchar("origen", { length: 10 }).notNull(), // 'nuevo' (originación) | 'pago'
+      monto_total: numeric("monto_total", { precision: 18, scale: 2 }).notNull().default("0"),
+      monto_iva: numeric("monto_iva", { precision: 18, scale: 2 }).notNull().default("0"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqDetalle: uniqueIndex("uq_facturacion_snapshot_detalle").on(
+        table.fecha,
+        table.rubro,
+        table.producto,
+        table.origen
+      ),
+      idxFecha: index("idx_facturacion_snapshot_detalle_fecha").on(table.fecha),
     })
   );
 

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -9,6 +9,7 @@ import {
   getSnapshotsDiarios,
   guardarCeldasSnapshot,
   listarAuditoriaSnapshot,
+  listarDetalleSnapshot,
   regenerarSnapshotRango,
 } from "../controllers/facturacionSnapshot";
 
@@ -212,6 +213,29 @@ export const facturacionSnapshotRouter = new Elysia({
         fechaInicio: t.Optional(t.String()),
         fechaFin: t.Optional(t.String()),
         limit: t.Optional(t.String()),
+      }),
+    }
+  )
+
+  // GET - Detalle por origen (crédito nuevo vs pago) de un día (para el modal).
+  //       ?fecha=YYYY-MM-DD&rubro=INTERES (rubro opcional)
+  .get(
+    "/detalle",
+    async ({ query, set }: any) => {
+      try {
+        return await listarDetalleSnapshot({
+          fecha: query.fecha,
+          rubro: query.rubro,
+        });
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error obteniendo el detalle", error: String(error) };
+      }
+    },
+    {
+      query: t.Object({
+        fecha: t.String(),
+        rubro: t.Optional(t.String()),
       }),
     }
   )

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -466,15 +466,15 @@ export function FacturacionDiaria() {
                         <td
                           key={`${row.id}-${c.k}`}
                           onClick={
-                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) && !row.bloqueado
                               ? () => setDetalleTarget({ fecha: row.fecha, rubro: g.rubro as string, label: g.label })
                               : undefined
                           }
-                          title={c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) ? "Ver desglose crédito nuevo vs pago" : undefined}
+                          title={c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) && !row.bloqueado ? "Ver desglose crédito nuevo vs pago" : undefined}
                           className={`px-3 py-2 text-right tabular-nums border-r border-gray-50 whitespace-nowrap ${
                             c.k === g.total.k ? "bg-blue-50/60 font-semibold text-blue-900" : "text-gray-700"
                           }${
-                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) && !row.bloqueado
                               ? " cursor-pointer hover:bg-blue-100 underline decoration-dotted underline-offset-2"
                               : ""
                           }`}

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -26,12 +26,14 @@ import {
   guardarCeldasSnapshot,
   desbloquearDiaSnapshot,
   getAuditoriaSnapshot,
+  getDetalleSnapshot,
   upsertMetaFacturacion,
   type GastoAdministrativo,
   type IngresoCarro,
   type MetaFacturacion,
   type SnapshotDiario,
   type AuditoriaSnapshot,
+  type DetalleSnapshotRow,
 } from "../services/facturacionDiaria.services";
 import { useAuth } from "@/Provider/authProvider";
 
@@ -62,7 +64,9 @@ const SNAP_KEY = "facturacion-snapshots";
 
 // ───────────── grupos de columnas (colapsables) ─────────────
 type Col = { k: string; l: string };
-type Grupo = { key: string; label: string; total: Col; detalle: Col[] };
+// rubro: si está, el TOTAL del grupo es clickeable y abre el modal de desglose
+// (crédito nuevo vs pago) de ese rubro/día. Capital/Mora no llevan (son solo pago).
+type Grupo = { key: string; label: string; total: Col; detalle: Col[]; rubro?: string };
 
 const productos = (prefix: string): Col[] => [
   { k: `${prefix}_autocompras`, l: "Autocompras" },
@@ -75,16 +79,19 @@ const productos = (prefix: string): Col[] => [
 
 const GRUPOS: Grupo[] = [
   { key: "capital", label: "Capital", total: { k: "capital_total", l: "Capital total" }, detalle: productos("cap") },
-  { key: "interes", label: "Interés", total: { k: "interes_cube", l: "Interés Cube" }, detalle: productos("int") },
-  { key: "membresia", label: "Membresía", total: { k: "membresia", l: "Membresía" }, detalle: productos("mem") },
+  { key: "interes", label: "Interés", rubro: "INTERES", total: { k: "interes_cube", l: "Interés Cube" }, detalle: productos("int") },
+  { key: "membresia", label: "Membresía", rubro: "MEMBRESIA", total: { k: "membresia", l: "Membresía" }, detalle: productos("mem") },
   {
     key: "otros",
     label: "Otros ingresos",
+    rubro: "OTROS",
     total: { k: "otros_ingresos", l: "Otros ingresos" },
     detalle: [...productos("oi"), { k: "administrativos", l: "Administrativos" }, { k: "otros_cobros", l: "Otros cobros" }],
   },
   { key: "mora", label: "Mora", total: { k: "mora_cube", l: "Mora Cube" }, detalle: productos("mora") },
-  { key: "royalty", label: "Royalty", total: { k: "royalty", l: "Royalty" }, detalle: productos("roy") },
+  { key: "royalty", label: "Royalty", rubro: "ROYALTY", total: { k: "royalty", l: "Royalty" }, detalle: productos("roy") },
+  { key: "seguro", label: "Seguro", rubro: "SEGURO", total: { k: "seguro_total", l: "Seguro total" }, detalle: productos("seg") },
+  { key: "gps", label: "GPS", rubro: "GPS", total: { k: "gps_total", l: "GPS total" }, detalle: productos("gps") },
   {
     key: "totales",
     label: "Totales / Acumulados",
@@ -135,6 +142,22 @@ export function FacturacionDiaria() {
   const [desbloquearTarget, setDesbloquearTarget] = useState<string | null>(null);
   // modal de historial de cambios (auditoría)
   const [historialOpen, setHistorialOpen] = useState(false);
+  // modal de desglose por origen (crédito nuevo vs pago): {fecha, rubro, label} | null
+  const [detalleTarget, setDetalleTarget] = useState<{ fecha: string; rubro: string; label: string } | null>(null);
+  const [detalleRows, setDetalleRows] = useState<DetalleSnapshotRow[]>([]);
+  const [detalleLoading, setDetalleLoading] = useState(false);
+
+  useEffect(() => {
+    if (!detalleTarget) return;
+    let ignore = false; // evita que una respuesta vieja pise a una más nueva
+    setDetalleLoading(true);
+    setDetalleRows([]);
+    getDetalleSnapshot(detalleTarget.fecha, detalleTarget.rubro)
+      .then((r) => { if (!ignore) setDetalleRows(r.data ?? []); })
+      .catch(() => { if (!ignore) setDetalleRows([]); })
+      .finally(() => { if (!ignore) setDetalleLoading(false); });
+    return () => { ignore = true; };
+  }, [detalleTarget]);
   const histQuery = useQuery({
     queryKey: ["facturacion-auditoria"],
     queryFn: () => getAuditoriaSnapshot({ limit: 300 }),
@@ -442,8 +465,18 @@ export function FacturacionDiaria() {
                       colsDe(g).map((c) => (
                         <td
                           key={`${row.id}-${c.k}`}
+                          onClick={
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                              ? () => setDetalleTarget({ fecha: row.fecha, rubro: g.rubro as string, label: g.label })
+                              : undefined
+                          }
+                          title={c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) ? "Ver desglose crédito nuevo vs pago" : undefined}
                           className={`px-3 py-2 text-right tabular-nums border-r border-gray-50 whitespace-nowrap ${
                             c.k === g.total.k ? "bg-blue-50/60 font-semibold text-blue-900" : "text-gray-700"
+                          }${
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                              ? " cursor-pointer hover:bg-blue-100 underline decoration-dotted underline-offset-2"
+                              : ""
                           }`}
                         >
                           {esCeldaEditable(row.fecha, c.k) ? (
@@ -495,6 +528,94 @@ export function FacturacionDiaria() {
         {/* Secciones de registro */}
         <RegistrosManuales mes={Number(fechaFin.slice(5, 7))} anio={Number(fechaFin.slice(0, 4))} />
       </div>
+
+      {/* Modal de desglose por origen (crédito nuevo vs pago) */}
+      {detalleTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setDetalleTarget(null)}
+        >
+          <div
+            className="bg-white rounded-xl shadow-xl w-full max-w-lg max-h-[80vh] overflow-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-5 py-3 border-b border-gray-200 bg-blue-50 rounded-t-xl">
+              <div>
+                <h3 className="text-base font-bold text-blue-900">Desglose · {detalleTarget.label}</h3>
+                <p className="text-xs text-gray-600">Crédito nuevo vs pago · {detalleTarget.fecha}</p>
+              </div>
+              <button
+                onClick={() => setDetalleTarget(null)}
+                className="text-gray-500 hover:text-gray-800 text-xl leading-none"
+                aria-label="Cerrar"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="p-4 bg-white">
+              {detalleLoading ? (
+                <div className="text-center py-8 text-gray-500">
+                  <Loader2 className="h-6 w-6 animate-spin inline" />
+                </div>
+              ) : detalleRows.length === 0 ? (
+                <div className="text-center py-8 text-gray-500">Sin datos para este día</div>
+              ) : (
+                (() => {
+                  const PROD_LABEL: Record<string, string> = {
+                    autocompras: "Autocompras",
+                    sobre_vehiculo: "Sobre vehículo",
+                    nuevo_autocompras: "Nuevo Autocompras",
+                    hipotecario: "Hipotecario",
+                    extra_financiamiento: "Extra financ.",
+                    reestructura: "Reestructura",
+                    sin_producto: "Sin producto",
+                  };
+                  const ORDER = ["autocompras", "sobre_vehiculo", "nuevo_autocompras", "hipotecario", "extra_financiamiento", "reestructura", "sin_producto"];
+                  const piv: Record<string, { nuevo: number; pago: number }> = {};
+                  for (const r of detalleRows) {
+                    (piv[r.producto] ??= { nuevo: 0, pago: 0 });
+                    if (r.origen === "nuevo") piv[r.producto].nuevo += Number(r.monto_total) || 0;
+                    else piv[r.producto].pago += Number(r.monto_total) || 0;
+                  }
+                  const prods = ORDER.filter((p) => piv[p] && (piv[p].nuevo || piv[p].pago));
+                  const tn = prods.reduce((s, p) => s + piv[p].nuevo, 0);
+                  const tp = prods.reduce((s, p) => s + piv[p].pago, 0);
+                  return (
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="bg-blue-50 text-blue-900">
+                          <th className="text-left font-semibold py-2 px-2 rounded-l">Producto</th>
+                          <th className="text-right font-semibold py-2 px-2">Crédito nuevo</th>
+                          <th className="text-right font-semibold py-2 px-2">Pago</th>
+                          <th className="text-right font-semibold py-2 px-2 rounded-r">Total</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {prods.map((p) => (
+                          <tr key={p} className="border-b border-gray-100 hover:bg-gray-50">
+                            <td className="py-2 px-2 text-gray-800">{PROD_LABEL[p] ?? p}</td>
+                            <td className="text-right tabular-nums py-2 px-2 text-emerald-700">{nf.format(piv[p].nuevo)}</td>
+                            <td className="text-right tabular-nums py-2 px-2 text-slate-600">{nf.format(piv[p].pago)}</td>
+                            <td className="text-right tabular-nums py-2 px-2 font-semibold text-blue-900">{nf.format(piv[p].nuevo + piv[p].pago)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                      <tfoot>
+                        <tr className="font-bold text-blue-900 border-t-2 border-blue-200 bg-blue-50/60">
+                          <td className="py-2 px-2">TOTAL</td>
+                          <td className="text-right tabular-nums py-2 px-2 text-emerald-800">{nf.format(tn)}</td>
+                          <td className="text-right tabular-nums py-2 px-2 text-slate-700">{nf.format(tp)}</td>
+                          <td className="text-right tabular-nums py-2 px-2">{nf.format(tn + tp)}</td>
+                        </tr>
+                      </tfoot>
+                    </table>
+                  );
+                })()
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Modal de historial de cambios (auditoría) */}
       {historialOpen && (

--- a/apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts
@@ -203,3 +203,24 @@ export const getAuditoriaSnapshot = async (params?: {
   );
   return data;
 };
+
+// ───────────── Detalle por origen (crédito nuevo vs pago) ─────────────
+export interface DetalleSnapshotRow {
+  rubro: string;
+  producto: string; // autocompras | nuevo_autocompras | sobre_vehiculo | hipotecario | ...
+  origen: "nuevo" | "pago";
+  monto_total: number;
+  monto_iva: number;
+}
+
+// Trae el desglose nuevo/pago de un día (opcionalmente de un rubro) para el modal.
+export const getDetalleSnapshot = async (
+  fecha: string,
+  rubro?: string
+): Promise<{ success: boolean; data: DetalleSnapshotRow[] }> => {
+  const { data } = await api.get(
+    `${API_URL}/api/facturacion-snapshot/detalle`,
+    { params: { fecha, rubro } }
+  );
+  return data;
+};


### PR DESCRIPTION
## Qué hace
Agrega al **snapshot de Facturación Diaria** el desglose por **ORIGEN (crédito nuevo vs pago)** por rubro — para que conta vea la diferencia que hoy calcula a mano — y separa **seguro** y **GPS** por categoría. **No toca los totales ni las fórmulas existentes** que usa conta.

## Cambios
**Back**
- `schema.ts` + migración `0015`: columnas `seg_*`/`gps_*` + `seguro_total`/`gps_total` en `facturacion_snapshot_diario` (el combinado `servicios_seguro_gps` queda intacto); nueva tabla `facturacion_snapshot_detalle (fecha, rubro, producto, origen, monto_total, monto_iva)`.
- `generarSnapshotDiario`: separa seguro/gps por categoría + puebla la tabla detalle desde `facturacion_desglose` (origen = genérica→`nuevo` / con pago→`pago`). **CAPITAL del detalle desde `pci`** (= `capital_total`) para reconciliar. Best-effort (try/catch).
- Excel: grupos Seguro/GPS en la hoja principal + nueva hoja **"Desglose nuevo vs pago"** (orden de rubros, subtotales, espacios).
- Endpoint `GET /api/facturacion-snapshot/detalle?fecha=&rubro=` + `listarDetalleSnapshot`.
- También: capital desde `pci` aplicados + filtro `statusCredit`/`validation_status` (criterio del Excel) para que capital/membresía cuadren.

**Front** (`FacturacionDiaria.tsx` + service)
- Columnas Seguro/GPS en la tabla.
- Modal de desglose nuevo/pago al clic en el TOTAL de interés/membresía/otros/royalty/seguro/gps (no capital). Diseño claro, texto legible.

## Migración / datos
- `0015` es **aditiva** (ADD COLUMN / CREATE TABLE IF NOT EXISTS) → compatible con el código viejo.
- **Aplicada a PROD** + backfill de junio + regeneración de días recientes.
- ⚠️ **Aplicar la migración antes de desplegar** (el cron llama a `generarSnapshotDiario`, que escribe en la tabla nueva).

## Verificación
- Typecheck back + front: **0 errores**.
- Reconciliación **snapshot ⟷ detalle** (días sistema): **exacta en TODOS los rubros** (capital/int/mem/otros/mora/royalty/seguro/gps/inversionistas).
- `servicios = seguro_total + gps_total`; fórmula de facturación: OK.
- Endpoint + hoja Excel "Desglose": verificados end-to-end.
- Días **bloqueados** (forzados al Excel) e **importados** difieren por diseño (no son del feature).

## Code review
Pasó revisión multi-agente. Fixes aplicados: capital del detalle desde `pci` (reconcilia), `trim()` en categoría, `try/catch` best-effort (deploy-antes-de-migrar + race del índice único), front (guard de celda editable + race del fetch del modal).

Diferidos (no bloquean): duplicación del CASE/labels (refactor a helper), `seg_extra_financiamiento/reestructura` siempre 0 (patrón pre-existente de todos los rubros), modal sin Esc-to-close.

Spec: `docs/superpowers/specs/2026-06-18-facturacion-detalle-origen-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)