### PR TITLE
🚀 Pase a Producción — Release develop → main

### DIFF
--- a/apps/cartera-back/drizzle/0015_snapshot_detalle_origen.sql
+++ b/apps/cartera-back/drizzle/0015_snapshot_detalle_origen.sql
@@ -1,0 +1,37 @@
+-- 0015 — Desglose por origen (crédito nuevo vs pago) + separación seguro/GPS
+-- Spec: docs/superpowers/specs/2026-06-18-facturacion-detalle-origen-design.md
+-- NO toca totales ni fórmulas existentes: solo agrega columnas/tabla nuevas.
+
+-- 1) Snapshot: seguro y GPS por categoría (el combinado sigue en servicios_seguro_gps)
+ALTER TABLE cartera.facturacion_snapshot_diario
+  ADD COLUMN IF NOT EXISTS seg_autocompras           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_sobre_vehiculo        numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS nuevo_seg_autocompras     numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_hipotecario           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_extra_financiamiento  numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seg_reestructura          numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS seguro_total              numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_autocompras           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_sobre_vehiculo        numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS nuevo_gps_autocompras     numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_hipotecario           numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_extra_financiamiento  numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_reestructura          numeric(18,2) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS gps_total                 numeric(18,2) NOT NULL DEFAULT 0;
+
+-- 2) Tabla intermedia: desglose por origen (nuevo vs pago), derivada de facturacion_desglose
+CREATE TABLE IF NOT EXISTS cartera.facturacion_snapshot_detalle (
+  id          serial PRIMARY KEY,
+  fecha       date NOT NULL,
+  rubro       cartera.rubro_facturacion NOT NULL,
+  producto    varchar(40) NOT NULL,   -- autocompras|sobre_vehiculo|nuevo_autocompras|hipotecario|extra_financiamiento|reestructura|sin_producto
+  origen      varchar(10) NOT NULL,   -- 'nuevo' (originación) | 'pago'
+  monto_total numeric(18,2) NOT NULL DEFAULT 0,
+  monto_iva   numeric(18,2) NOT NULL DEFAULT 0,
+  created_at  timestamp NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_facturacion_snapshot_detalle
+  ON cartera.facturacion_snapshot_detalle (fecha, rubro, producto, origen);
+CREATE INDEX IF NOT EXISTS idx_facturacion_snapshot_detalle_fecha
+  ON cartera.facturacion_snapshot_detalle (fecha);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -880,11 +880,16 @@ export async function generarExcelFacturacionDiaria(
   //   Para conta: por cada día y rubro, el desglose por producto en crédito nuevo
   //   vs pago, RESPETANDO el orden del reporte y con filas en blanco entre rubros
   //   y días para que se lea cómodo. Fuente: facturacion_snapshot_detalle.
+  // Días BLOQUEADOS (editados a mano / forzados): el detalle viene del desglose y
+  //   NO reconcilia con el total forzado → se EXCLUYEN del Desglose (Codex P2 #933).
   const det = await db.execute(sql`
     SELECT fecha::text AS fecha, rubro::text AS rubro, producto, origen,
            monto_total::float8 AS monto
     FROM cartera.facturacion_snapshot_detalle
     WHERE fecha BETWEEN ${fechaInicio}::date AND ${fechaFin}::date
+      AND fecha NOT IN (
+        SELECT fecha FROM cartera.facturacion_snapshot_diario WHERE bloqueado = true
+      )
   `);
   const idx: Record<string, Record<string, Record<string, { nuevo: number; pago: number }>>> = {};
   for (const x of (det as any).rows ?? []) {

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -178,6 +178,10 @@ const RUBRO_PREFIX: Record<string, string> = {
   OTROS: "oi",
   MORA: "mora",
   ROYALTY: "roy",
+  // Seguro/GPS también van por categoría (además del combinado servicios_seguro_gps).
+  // En el loop del desglose se tratan aparte (no caen en el totalCol genérico).
+  SEGURO: "seg",
+  GPS: "gps",
 };
 
 // categoría BD -> producto Excel (sufijo). "__NUEVO__" usa el patrón nuevo_<prefijo>_autocompras.
@@ -241,9 +245,33 @@ export async function generarSnapshotDiario(fecha: string) {
     LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
     LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
     WHERE fd.fecha_aplicado_gt = ${fecha}::date
-      -- una fila de PAGO huérfana (credito/usuario borrado) no debe sumar al
-      -- total; las GENÉRICAS (pago_id NULL) sí entran.
-      AND (fd.pago_id IS NULL OR p.pago_id IS NOT NULL)
+      -- Filas de PAGO: el pago debe existir (no huérfano por credito/usuario
+      -- borrado) y, MISMO CRITERIO QUE EL EXCEL (getPagosConInversionistas que
+      -- llena "Reuniones diarias"): el crédito debe estar en un estado contable
+      -- (excluye CAIDO y demás) y el pago en un validation_status contable. Si no,
+      -- el desglose contaba pagos facturados sobre créditos caídos que el Excel
+      -- excluye → diferencia (p.ej. capital nuevo 06-16). Las GENÉRICAS (pago_id
+      -- NULL) no tienen crédito asociado → entran igual.
+      AND (
+        fd.pago_id IS NULL OR (
+          p.pago_id IS NOT NULL
+          AND c."statusCredit" IN
+            ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+          AND p.validation_status IN
+            ('validated','pending','reset','capital','capital_validated')
+        )
+      )
+      -- Las GENÉRICAS de ORIGINACIÓN (alta de crédito nuevo) SÍ alimentan sus rubros:
+      -- la cuota 0 de INTERÉS y MEMBRESÍA del vehículo nuevo DEBE SUMAR (decisión del
+      -- negocio), igual que otros/royalty/seguro. Solo se excluyen del desglose:
+      --   • CAPITAL → se calcula del pci (bloque 1.5), no del desglose.
+      --   • MORA → un crédito nuevo no genera mora genérica.
+      -- ⚠️ Con esto interés/membresía dejan de cuadrar con el Excel (que manda la
+      --    cuota 0 a administrativos) — decisión explícita: en el sistema la cuota 0 suma.
+      AND NOT (
+        fd.pago_id IS NULL
+        AND fd.rubro::text IN ('CAPITAL','MORA')
+      )
     GROUP BY COALESCE(u.categoria, fd.categoria), fd.rubro
   `);
   for (const r of (desg as any).rows ?? []) {
@@ -251,9 +279,19 @@ export async function generarSnapshotDiario(fecha: string) {
     const rubro = r.rubro as string;
     const total = r.total;
     if (rubro === "SEGURO" || rubro === "GPS") {
-      add("servicios_seguro_gps", total);
+      add("servicios_seguro_gps", total); // combinado, INTACTO para conta
+      // + segmentación por categoría (igual que membresía/interés)
+      const pfx = rubro === "SEGURO" ? "seg" : "gps";
+      add(rubro === "SEGURO" ? "seguro_total" : "gps_total", total);
+      add(colProducto(pfx, cat), total);
       continue;
     }
+    // 💰 CAPITAL NO se toma del desglose: se jala del pci (pagos aplicados) en el
+    //    bloque 1.5 de abajo. cofidi escribe la fila CAPITAL solo si el capital de
+    //    CUBE > 0 al FACTURAR; si entra al pci DESPUÉS de facturar, la fila no se
+    //    escribe y el desglose sub-cuenta capital (gap vs el Excel). Por eso el
+    //    capital se calcula desde los pagos aplicados, igual que "Reuniones diarias".
+    if (rubro === "CAPITAL") continue;
     const prefix = RUBRO_PREFIX[rubro];
     if (!prefix) continue;
     // total por rubro (columna *_cube / total)
@@ -271,6 +309,32 @@ export async function generarSnapshotDiario(fecha: string) {
         : "mora_cube"; // MORA
     add(totalCol, total);
     add(colProducto(prefix, cat), total);
+  }
+
+  // 1.5) 💰 CAPITAL del día = capital de CUBE desde pagos_credito_inversionistas
+  //      (pci) de los pagos APLICADOS hoy — MISMA fuente que el Excel "Reuniones
+  //      diarias" (getPagosConInversionistas). Se reparte por usuario.categoria
+  //      (igual que el resto). Resuelve el desfase pci↔facturación: el desglose
+  //      escribe la fila CAPITAL solo si el capital de CUBE existe al facturar, y a
+  //      veces el capital entra al pci después → la fila falta y el desglose
+  //      sub-cuenta. Tomándolo de los pagos aplicados cuadra al centavo con el Excel.
+  const capPci = await db.execute(sql`
+    SELECT u.categoria AS categoria, SUM(pci.abono_capital) AS cap
+    FROM cartera.pagos_credito p
+    JOIN cartera.creditos c ON c.credito_id = p.credito_id
+    JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+    JOIN cartera.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
+    JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+    WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+      AND p.validation_status IN ('validated','pending','reset','capital','capital_validated')
+      AND c."statusCredit" IN
+        ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+      AND UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
+    GROUP BY u.categoria
+  `);
+  for (const r of (capPci as any).rows ?? []) {
+    add("capital_total", r.cap);
+    add(colProducto("cap", r.categoria as string), r.cap);
   }
 
   // 2) Royalty del día = SOLO lo REALMENTE facturado (rubro ROYALTY del desglose,
@@ -392,6 +456,8 @@ export async function generarSnapshotDiario(fecha: string) {
     otros_cobros: f2(otros_cobros),
     mora_cube: f2(mora_cube),
     royalty: f2(royalty),
+    seguro_total: f2(g("seguro_total")),
+    gps_total: f2(g("gps_total")),
     facturacion: f2(facturacion),
     facturacion_acumulado: f2(facturacion_acumulado),
     servicios_seguro_gps: f2(servicios),
@@ -430,6 +496,78 @@ export async function generarSnapshotDiario(fecha: string) {
       set: setObj,
     })
     .returning();
+
+  // ───────────── tabla intermedia: detalle por ORIGEN (nuevo vs pago) ─────────────
+  //   Para que conta vea la diferencia que hoy hace a mano. Cubre TODOS los rubros.
+  //   - INTERÉS/MEMBRESÍA/SEGURO/GPS/OTROS/MORA/ROYALTY/INVERSIONISTAS: del desglose
+  //     (genérica = 'nuevo' originación; con pago = 'pago').
+  //   - CAPITAL: NO del desglose (el desglose sub-cuenta capital); se toma de pci de
+  //     CUBE por pago aplicado, MISMA fuente que la columna capital_total → reconcilia.
+  //     Capital siempre es 'pago' (no hay originación de capital).
+  //   trim() en la categoría para igualar colProducto (la data trae espacios/variantes).
+  //   Best-effort: si falla (p.ej. tabla aún no migrada, o race del índice único),
+  //   NO rompe el snapshot ya guardado. Días bloqueados retornan arriba (backfill aparte).
+  try {
+    await db.execute(sql`DELETE FROM cartera.facturacion_snapshot_detalle WHERE fecha = ${fecha}::date`);
+    await db.execute(sql`
+      INSERT INTO cartera.facturacion_snapshot_detalle
+        (fecha, rubro, producto, origen, monto_total, monto_iva)
+      SELECT ${fecha}::date, fd.rubro,
+        CASE lower(trim(COALESCE(u.categoria, fd.categoria)))
+          WHEN 'cv vehículo' THEN 'autocompras'
+          WHEN 'cv vehículo nuevo' THEN 'nuevo_autocompras'
+          WHEN 'vehículo' THEN 'sobre_vehiculo'
+          WHEN 'hipotecario' THEN 'hipotecario'
+          ELSE 'sin_producto'
+        END,
+        CASE WHEN fd.pago_id IS NULL THEN 'nuevo' ELSE 'pago' END,
+        SUM(fd.monto_total), SUM(fd.monto_iva)
+      FROM cartera.facturacion_desglose fd
+      LEFT JOIN cartera.pagos_credito p ON p.pago_id   = fd.pago_id
+      LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
+      LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
+      WHERE fd.fecha_aplicado_gt = ${fecha}::date
+        AND fd.rubro::text <> 'CAPITAL'
+        AND (
+          fd.pago_id IS NULL OR (
+            p.pago_id IS NOT NULL
+            AND c."statusCredit" IN
+              ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+            AND p.validation_status IN
+              ('validated','pending','reset','capital','capital_validated')
+          )
+        )
+      GROUP BY fd.rubro, 3, 4
+    `);
+    // CAPITAL desde pci de CUBE (igual que capital_total) → reconcilia con el snapshot
+    await db.execute(sql`
+      INSERT INTO cartera.facturacion_snapshot_detalle
+        (fecha, rubro, producto, origen, monto_total, monto_iva)
+      SELECT ${fecha}::date, 'CAPITAL'::cartera.rubro_facturacion,
+        CASE lower(trim(u.categoria))
+          WHEN 'cv vehículo' THEN 'autocompras'
+          WHEN 'cv vehículo nuevo' THEN 'nuevo_autocompras'
+          WHEN 'vehículo' THEN 'sobre_vehiculo'
+          WHEN 'hipotecario' THEN 'hipotecario'
+          ELSE 'sin_producto'
+        END,
+        'pago', SUM(pci.abono_capital), 0
+      FROM cartera.pagos_credito p
+      JOIN cartera.creditos c ON c.credito_id = p.credito_id
+      JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+      JOIN cartera.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
+      JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+      WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
+        AND p.validation_status IN ('validated','pending','reset','capital','capital_validated')
+        AND c."statusCredit" IN
+          ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')
+        AND UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
+      GROUP BY 3
+      HAVING SUM(pci.abono_capital) <> 0
+    `);
+  } catch (e) {
+    console.error(`⚠️ detalle snapshot ${fecha} no se pudo poblar (best-effort):`, e);
+  }
 
   return { success: true, data: saved };
 }
@@ -538,6 +676,25 @@ export async function regenerarSnapshotRango(
 // ============================================================================
 // 📥 EXPORTAR A EXCEL (diseño tipo Reuniones diarias, con logo y totales)
 // ============================================================================
+// 📋 Detalle por ORIGEN (crédito nuevo vs pago) de un día — alimenta el modal del
+//    front y la hoja "Desglose" del Excel. Lee facturacion_snapshot_detalle.
+//    Opcional: filtrar por rubro (para el modal de un rubro puntual).
+export async function listarDetalleSnapshot(params: {
+  fecha: string;
+  rubro?: string;
+}) {
+  const { fecha, rubro } = params;
+  const res = await db.execute(sql`
+    SELECT rubro::text AS rubro, producto, origen,
+           monto_total::float8 AS monto_total, monto_iva::float8 AS monto_iva
+    FROM cartera.facturacion_snapshot_detalle
+    WHERE fecha = ${fecha}::date
+      ${rubro ? sql`AND rubro::text = ${rubro}` : sql``}
+    ORDER BY rubro, producto, origen
+  `);
+  return { success: true, data: (res as any).rows ?? [] };
+}
+
 const prodCols = (p: string) => [
   { k: `${p}_autocompras`, l: "Autocompras" },
   { k: `${p}_sobre_vehiculo`, l: "Sobre vehículo" },
@@ -558,6 +715,8 @@ const EXCEL_GRUPOS: { label: string; color: string; cols: { k: string; l: string
   },
   { label: "Mora", color: "FF1D4ED8", cols: [...prodCols("mora"), { k: "mora_cube", l: "Mora Cube" }] },
   { label: "Royalty", color: "FF2563EB", cols: [...prodCols("roy"), { k: "royalty", l: "Royalty" }] },
+  { label: "Seguro", color: "FF1D4ED8", cols: [...prodCols("seg"), { k: "seguro_total", l: "Seguro total" }] },
+  { label: "GPS", color: "FF2563EB", cols: [...prodCols("gps"), { k: "gps_total", l: "GPS total" }] },
   {
     label: "Totales / Acumulados",
     color: "FF0F766E",
@@ -716,6 +875,92 @@ export async function generarExcelFacturacionDiaria(
 
   ws.getRow(HEADER_GROUP_ROW).height = 22;
   ws.getRow(HEADER_COL_ROW).height = 30;
+
+  // ───────────── Hoja "Desglose nuevo vs pago" ─────────────
+  //   Para conta: por cada día y rubro, el desglose por producto en crédito nuevo
+  //   vs pago, RESPETANDO el orden del reporte y con filas en blanco entre rubros
+  //   y días para que se lea cómodo. Fuente: facturacion_snapshot_detalle.
+  const det = await db.execute(sql`
+    SELECT fecha::text AS fecha, rubro::text AS rubro, producto, origen,
+           monto_total::float8 AS monto
+    FROM cartera.facturacion_snapshot_detalle
+    WHERE fecha BETWEEN ${fechaInicio}::date AND ${fechaFin}::date
+  `);
+  const idx: Record<string, Record<string, Record<string, { nuevo: number; pago: number }>>> = {};
+  for (const x of (det as any).rows ?? []) {
+    const f = x.fecha as string, rb = x.rubro as string, p = x.producto as string;
+    (idx[f] ??= {});
+    (idx[f][rb] ??= {});
+    (idx[f][rb][p] ??= { nuevo: 0, pago: 0 });
+    if (x.origen === "nuevo") idx[f][rb][p].nuevo += Number(x.monto) || 0;
+    else idx[f][rb][p].pago += Number(x.monto) || 0;
+  }
+  const RUBRO_ORDER = ["CAPITAL", "INTERES", "MEMBRESIA", "OTROS", "MORA", "ROYALTY", "SEGURO", "GPS", "INTERES_INVERSIONISTAS"];
+  const RUBRO_LABEL: Record<string, string> = { CAPITAL: "Capital", INTERES: "Interés", MEMBRESIA: "Membresía", OTROS: "Otros ingresos", MORA: "Mora", ROYALTY: "Royalty", SEGURO: "Seguro", GPS: "GPS", INTERES_INVERSIONISTAS: "Inversionistas" };
+  const PROD_ORDER = ["autocompras", "sobre_vehiculo", "nuevo_autocompras", "hipotecario", "extra_financiamiento", "reestructura", "sin_producto"];
+  const PROD_LABEL: Record<string, string> = { autocompras: "Autocompras", sobre_vehiculo: "Sobre vehículo", nuevo_autocompras: "Nuevo Autocompras", hipotecario: "Hipotecario", extra_financiamiento: "Extra financ.", reestructura: "Reestructura", sin_producto: "Sin producto" };
+
+  const ds = wb.addWorksheet("Desglose nuevo vs pago");
+  ds.columns = [
+    { key: "fecha", width: 13 },
+    { key: "rubro", width: 16 },
+    { key: "producto", width: 20 },
+    { key: "nuevo", width: 16 },
+    { key: "pago", width: 16 },
+    { key: "total", width: 16 },
+  ];
+  ds.mergeCells(1, 1, 1, 6);
+  const dT = ds.getCell(1, 1);
+  dT.value = `Desglose crédito nuevo vs pago  ·  ${fechaInicio ?? "—"} a ${fechaFin ?? "—"}`;
+  dT.font = { bold: true, size: 14, color: { argb: "FF1E3A8A" } };
+  const dh = ds.getRow(3);
+  ["Fecha", "Rubro", "Producto", "Crédito nuevo", "Pago", "Total"].forEach((h, i) => {
+    const c = dh.getCell(i + 1);
+    c.value = h;
+    c.font = { bold: true, color: { argb: "FFFFFFFF" } };
+    c.alignment = { horizontal: i < 3 ? "left" : "right", vertical: "middle" };
+    c.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FF1E3A8A" } };
+    c.border = border;
+  });
+  dh.height = 22;
+
+  let dr = 4;
+  for (const f of Object.keys(idx).sort()) {
+    for (const rb of RUBRO_ORDER) {
+      const prods = idx[f]?.[rb];
+      if (!prods) continue;
+      const firstRow = dr;
+      let sn = 0, sp = 0;
+      for (const p of PROD_ORDER) {
+        const v = prods[p];
+        if (!v || (v.nuevo === 0 && v.pago === 0)) continue;
+        const row = ds.getRow(dr);
+        row.getCell(1).value = dr === firstRow ? f : "";
+        row.getCell(2).value = dr === firstRow ? (RUBRO_LABEL[rb] ?? rb) : "";
+        row.getCell(3).value = PROD_LABEL[p] ?? p;
+        row.getCell(4).value = v.nuevo;
+        row.getCell(5).value = v.pago;
+        row.getCell(6).value = v.nuevo + v.pago;
+        for (const cc of [4, 5, 6]) row.getCell(cc).numFmt = "#,##0.00";
+        sn += v.nuevo; sp += v.pago;
+        dr++;
+      }
+      if (dr === firstRow) continue; // rubro sin movimiento
+      const sub = ds.getRow(dr);
+      sub.getCell(3).value = `Subtotal ${RUBRO_LABEL[rb] ?? rb}`;
+      sub.getCell(4).value = sn;
+      sub.getCell(5).value = sp;
+      sub.getCell(6).value = sn + sp;
+      for (let cc = 1; cc <= 6; cc++) {
+        const c = sub.getCell(cc);
+        if (cc >= 4) c.numFmt = "#,##0.00";
+        c.font = { bold: true, color: { argb: "FF1E3A8A" } };
+        c.fill = { type: "pattern", pattern: "solid", fgColor: { argb: "FFEFF6FF" } };
+      }
+      dr += 2; // subtotal + fila en blanco (espacio entre rubros)
+    }
+    dr++; // espacio extra entre días
+  }
 
   const buf = await wb.xlsx.writeBuffer();
   return Buffer.from(buf);

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -527,9 +527,14 @@ export async function generarSnapshotDiario(fecha: string) {
       LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
       LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
       WHERE fd.fecha_aplicado_gt = ${fecha}::date
-        AND fd.rubro::text <> 'CAPITAL'
+        AND fd.rubro::text <> 'CAPITAL'                            -- capital se toma del pci (abajo)
+        AND NOT (fd.pago_id IS NULL AND fd.rubro::text = 'MORA')   -- mora genérica fuera (= snapshot)
         AND (
-          fd.pago_id IS NULL OR (
+          fd.pago_id IS NULL
+          -- INTERES_INVERSIONISTAS reconcilia con facturacion_inversionistas (bloque 4),
+          -- que suma el desglose SIN filtro de estado/validation → acá tampoco se filtra.
+          OR fd.rubro::text = 'INTERES_INVERSIONISTAS'
+          OR (
             p.pago_id IS NOT NULL
             AND c."statusCredit" IN
               ('ACTIVO','MOROSO','PENDIENTE_CANCELACION','EN_CONVENIO','CANCELADO','INCOBRABLE')

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1286,12 +1286,16 @@ export async function getCuotasPorFecha({
         AND qc_prev.numero_cuota = c.numero_cuota - 1
         AND qc_prev.numero_cuota > 0
         AND pc_prev."paymentFalse" = false
+        AND pc_prev.monto_aplicado IS NOT NULL
+        AND pc_prev.monto_aplicado::numeric > 0
     ) prev_pag ON true
     LEFT JOIN LATERAL (
       SELECT MAX(pc_curr.total_restante::numeric) AS total_restante
       FROM cartera.pagos_credito pc_curr
       WHERE pc_curr.cuota_id = c.cuota_id
         AND pc_curr."paymentFalse" = false
+        AND pc_curr.monto_aplicado IS NOT NULL
+        AND pc_curr.monto_aplicado::numeric > 0
     ) curr_pag ON true
     LEFT JOIN LATERAL (
       SELECT

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1322,6 +1322,24 @@
       roy_reestructura: numeric("roy_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
       royalty: numeric("royalty", { precision: 18, scale: 2 }).notNull().default("0"),
 
+      // 🛡️ Seguro por categoría (segmentación; el COMBINADO sigue en servicios_seguro_gps)
+      seg_autocompras: numeric("seg_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_sobre_vehiculo: numeric("seg_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_seg_autocompras: numeric("nuevo_seg_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_hipotecario: numeric("seg_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_extra_financiamiento: numeric("seg_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      seg_reestructura: numeric("seg_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      seguro_total: numeric("seguro_total", { precision: 18, scale: 2 }).notNull().default("0"),
+
+      // 📍 GPS por categoría (segmentación; el COMBINADO sigue en servicios_seguro_gps)
+      gps_autocompras: numeric("gps_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_sobre_vehiculo: numeric("gps_sobre_vehiculo", { precision: 18, scale: 2 }).notNull().default("0"),
+      nuevo_gps_autocompras: numeric("nuevo_gps_autocompras", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_hipotecario: numeric("gps_hipotecario", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_extra_financiamiento: numeric("gps_extra_financiamiento", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_reestructura: numeric("gps_reestructura", { precision: 18, scale: 2 }).notNull().default("0"),
+      gps_total: numeric("gps_total", { precision: 18, scale: 2 }).notNull().default("0"),
+
       // 📊 Totales / acumulados (AT–BE)
       facturacion: numeric("facturacion", { precision: 18, scale: 2 }).notNull().default("0"),
       facturacion_acumulado: numeric("facturacion_acumulado", { precision: 18, scale: 2 }).notNull().default("0"),
@@ -1353,6 +1371,37 @@
     },
     (table) => ({
       uqFecha: uniqueIndex("uq_facturacion_snapshot_diario_fecha").on(table.fecha),
+    })
+  );
+
+  // 🧾 TABLA: facturacion_snapshot_detalle
+  //    Desglose del snapshot por ORIGEN (crédito nuevo vs pago) para que conta vea
+  //    la diferencia que hoy calcula a mano. 1 fila por (fecha, rubro, producto,
+  //    origen). Se DERIVA de facturacion_desglose en generarSnapshotDiario
+  //    (origen = pago_id IS NULL → 'nuevo' [originación]; si no → 'pago').
+  //    NO afecta los totales del snapshot ni las fórmulas del Excel: es una vista
+  //    de control adicional (~60–70 filas/día).
+  export const facturacion_snapshot_detalle = customSchema.table(
+    "facturacion_snapshot_detalle",
+    {
+      id: serial("id").primaryKey(),
+      fecha: date("fecha").notNull(),
+      rubro: rubroFacturacionEnum("rubro").notNull(),
+      // producto: autocompras|sobre_vehiculo|nuevo_autocompras|hipotecario|extra_financiamiento|reestructura|sin_producto
+      producto: varchar("producto", { length: 40 }).notNull(),
+      origen: varchar("origen", { length: 10 }).notNull(), // 'nuevo' (originación) | 'pago'
+      monto_total: numeric("monto_total", { precision: 18, scale: 2 }).notNull().default("0"),
+      monto_iva: numeric("monto_iva", { precision: 18, scale: 2 }).notNull().default("0"),
+      created_at: timestamp("created_at").defaultNow().notNull(),
+    },
+    (table) => ({
+      uqDetalle: uniqueIndex("uq_facturacion_snapshot_detalle").on(
+        table.fecha,
+        table.rubro,
+        table.producto,
+        table.origen
+      ),
+      idxFecha: index("idx_facturacion_snapshot_detalle_fecha").on(table.fecha),
     })
   );
 

--- a/apps/cartera-back/src/routers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/routers/facturacionSnapshot.ts
@@ -9,6 +9,7 @@ import {
   getSnapshotsDiarios,
   guardarCeldasSnapshot,
   listarAuditoriaSnapshot,
+  listarDetalleSnapshot,
   regenerarSnapshotRango,
 } from "../controllers/facturacionSnapshot";
 
@@ -212,6 +213,29 @@ export const facturacionSnapshotRouter = new Elysia({
         fechaInicio: t.Optional(t.String()),
         fechaFin: t.Optional(t.String()),
         limit: t.Optional(t.String()),
+      }),
+    }
+  )
+
+  // GET - Detalle por origen (crédito nuevo vs pago) de un día (para el modal).
+  //       ?fecha=YYYY-MM-DD&rubro=INTERES (rubro opcional)
+  .get(
+    "/detalle",
+    async ({ query, set }: any) => {
+      try {
+        return await listarDetalleSnapshot({
+          fecha: query.fecha,
+          rubro: query.rubro,
+        });
+      } catch (error) {
+        set.status = 500;
+        return { success: false, message: "Error obteniendo el detalle", error: String(error) };
+      }
+    },
+    {
+      query: t.Object({
+        fecha: t.String(),
+        rubro: t.Optional(t.String()),
       }),
     }
   )

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -466,15 +466,15 @@ export function FacturacionDiaria() {
                         <td
                           key={`${row.id}-${c.k}`}
                           onClick={
-                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) && !row.bloqueado
                               ? () => setDetalleTarget({ fecha: row.fecha, rubro: g.rubro as string, label: g.label })
                               : undefined
                           }
-                          title={c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) ? "Ver desglose crédito nuevo vs pago" : undefined}
+                          title={c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) && !row.bloqueado ? "Ver desglose crédito nuevo vs pago" : undefined}
                           className={`px-3 py-2 text-right tabular-nums border-r border-gray-50 whitespace-nowrap ${
                             c.k === g.total.k ? "bg-blue-50/60 font-semibold text-blue-900" : "text-gray-700"
                           }${
-                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) && !row.bloqueado
                               ? " cursor-pointer hover:bg-blue-100 underline decoration-dotted underline-offset-2"
                               : ""
                           }`}

--- a/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
+++ b/apps/carteraFront/src/private/cartera/components/FacturacionDiaria.tsx
@@ -26,12 +26,14 @@ import {
   guardarCeldasSnapshot,
   desbloquearDiaSnapshot,
   getAuditoriaSnapshot,
+  getDetalleSnapshot,
   upsertMetaFacturacion,
   type GastoAdministrativo,
   type IngresoCarro,
   type MetaFacturacion,
   type SnapshotDiario,
   type AuditoriaSnapshot,
+  type DetalleSnapshotRow,
 } from "../services/facturacionDiaria.services";
 import { useAuth } from "@/Provider/authProvider";
 
@@ -62,7 +64,9 @@ const SNAP_KEY = "facturacion-snapshots";
 
 // ───────────── grupos de columnas (colapsables) ─────────────
 type Col = { k: string; l: string };
-type Grupo = { key: string; label: string; total: Col; detalle: Col[] };
+// rubro: si está, el TOTAL del grupo es clickeable y abre el modal de desglose
+// (crédito nuevo vs pago) de ese rubro/día. Capital/Mora no llevan (son solo pago).
+type Grupo = { key: string; label: string; total: Col; detalle: Col[]; rubro?: string };
 
 const productos = (prefix: string): Col[] => [
   { k: `${prefix}_autocompras`, l: "Autocompras" },
@@ -75,16 +79,19 @@ const productos = (prefix: string): Col[] => [
 
 const GRUPOS: Grupo[] = [
   { key: "capital", label: "Capital", total: { k: "capital_total", l: "Capital total" }, detalle: productos("cap") },
-  { key: "interes", label: "Interés", total: { k: "interes_cube", l: "Interés Cube" }, detalle: productos("int") },
-  { key: "membresia", label: "Membresía", total: { k: "membresia", l: "Membresía" }, detalle: productos("mem") },
+  { key: "interes", label: "Interés", rubro: "INTERES", total: { k: "interes_cube", l: "Interés Cube" }, detalle: productos("int") },
+  { key: "membresia", label: "Membresía", rubro: "MEMBRESIA", total: { k: "membresia", l: "Membresía" }, detalle: productos("mem") },
   {
     key: "otros",
     label: "Otros ingresos",
+    rubro: "OTROS",
     total: { k: "otros_ingresos", l: "Otros ingresos" },
     detalle: [...productos("oi"), { k: "administrativos", l: "Administrativos" }, { k: "otros_cobros", l: "Otros cobros" }],
   },
   { key: "mora", label: "Mora", total: { k: "mora_cube", l: "Mora Cube" }, detalle: productos("mora") },
-  { key: "royalty", label: "Royalty", total: { k: "royalty", l: "Royalty" }, detalle: productos("roy") },
+  { key: "royalty", label: "Royalty", rubro: "ROYALTY", total: { k: "royalty", l: "Royalty" }, detalle: productos("roy") },
+  { key: "seguro", label: "Seguro", rubro: "SEGURO", total: { k: "seguro_total", l: "Seguro total" }, detalle: productos("seg") },
+  { key: "gps", label: "GPS", rubro: "GPS", total: { k: "gps_total", l: "GPS total" }, detalle: productos("gps") },
   {
     key: "totales",
     label: "Totales / Acumulados",
@@ -135,6 +142,22 @@ export function FacturacionDiaria() {
   const [desbloquearTarget, setDesbloquearTarget] = useState<string | null>(null);
   // modal de historial de cambios (auditoría)
   const [historialOpen, setHistorialOpen] = useState(false);
+  // modal de desglose por origen (crédito nuevo vs pago): {fecha, rubro, label} | null
+  const [detalleTarget, setDetalleTarget] = useState<{ fecha: string; rubro: string; label: string } | null>(null);
+  const [detalleRows, setDetalleRows] = useState<DetalleSnapshotRow[]>([]);
+  const [detalleLoading, setDetalleLoading] = useState(false);
+
+  useEffect(() => {
+    if (!detalleTarget) return;
+    let ignore = false; // evita que una respuesta vieja pise a una más nueva
+    setDetalleLoading(true);
+    setDetalleRows([]);
+    getDetalleSnapshot(detalleTarget.fecha, detalleTarget.rubro)
+      .then((r) => { if (!ignore) setDetalleRows(r.data ?? []); })
+      .catch(() => { if (!ignore) setDetalleRows([]); })
+      .finally(() => { if (!ignore) setDetalleLoading(false); });
+    return () => { ignore = true; };
+  }, [detalleTarget]);
   const histQuery = useQuery({
     queryKey: ["facturacion-auditoria"],
     queryFn: () => getAuditoriaSnapshot({ limit: 300 }),
@@ -442,8 +465,18 @@ export function FacturacionDiaria() {
                       colsDe(g).map((c) => (
                         <td
                           key={`${row.id}-${c.k}`}
+                          onClick={
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                              ? () => setDetalleTarget({ fecha: row.fecha, rubro: g.rubro as string, label: g.label })
+                              : undefined
+                          }
+                          title={c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k) ? "Ver desglose crédito nuevo vs pago" : undefined}
                           className={`px-3 py-2 text-right tabular-nums border-r border-gray-50 whitespace-nowrap ${
                             c.k === g.total.k ? "bg-blue-50/60 font-semibold text-blue-900" : "text-gray-700"
+                          }${
+                            c.k === g.total.k && g.rubro && !esCeldaEditable(row.fecha, c.k)
+                              ? " cursor-pointer hover:bg-blue-100 underline decoration-dotted underline-offset-2"
+                              : ""
                           }`}
                         >
                           {esCeldaEditable(row.fecha, c.k) ? (
@@ -495,6 +528,94 @@ export function FacturacionDiaria() {
         {/* Secciones de registro */}
         <RegistrosManuales mes={Number(fechaFin.slice(5, 7))} anio={Number(fechaFin.slice(0, 4))} />
       </div>
+
+      {/* Modal de desglose por origen (crédito nuevo vs pago) */}
+      {detalleTarget && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+          onClick={() => setDetalleTarget(null)}
+        >
+          <div
+            className="bg-white rounded-xl shadow-xl w-full max-w-lg max-h-[80vh] overflow-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between px-5 py-3 border-b border-gray-200 bg-blue-50 rounded-t-xl">
+              <div>
+                <h3 className="text-base font-bold text-blue-900">Desglose · {detalleTarget.label}</h3>
+                <p className="text-xs text-gray-600">Crédito nuevo vs pago · {detalleTarget.fecha}</p>
+              </div>
+              <button
+                onClick={() => setDetalleTarget(null)}
+                className="text-gray-500 hover:text-gray-800 text-xl leading-none"
+                aria-label="Cerrar"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="p-4 bg-white">
+              {detalleLoading ? (
+                <div className="text-center py-8 text-gray-500">
+                  <Loader2 className="h-6 w-6 animate-spin inline" />
+                </div>
+              ) : detalleRows.length === 0 ? (
+                <div className="text-center py-8 text-gray-500">Sin datos para este día</div>
+              ) : (
+                (() => {
+                  const PROD_LABEL: Record<string, string> = {
+                    autocompras: "Autocompras",
+                    sobre_vehiculo: "Sobre vehículo",
+                    nuevo_autocompras: "Nuevo Autocompras",
+                    hipotecario: "Hipotecario",
+                    extra_financiamiento: "Extra financ.",
+                    reestructura: "Reestructura",
+                    sin_producto: "Sin producto",
+                  };
+                  const ORDER = ["autocompras", "sobre_vehiculo", "nuevo_autocompras", "hipotecario", "extra_financiamiento", "reestructura", "sin_producto"];
+                  const piv: Record<string, { nuevo: number; pago: number }> = {};
+                  for (const r of detalleRows) {
+                    (piv[r.producto] ??= { nuevo: 0, pago: 0 });
+                    if (r.origen === "nuevo") piv[r.producto].nuevo += Number(r.monto_total) || 0;
+                    else piv[r.producto].pago += Number(r.monto_total) || 0;
+                  }
+                  const prods = ORDER.filter((p) => piv[p] && (piv[p].nuevo || piv[p].pago));
+                  const tn = prods.reduce((s, p) => s + piv[p].nuevo, 0);
+                  const tp = prods.reduce((s, p) => s + piv[p].pago, 0);
+                  return (
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="bg-blue-50 text-blue-900">
+                          <th className="text-left font-semibold py-2 px-2 rounded-l">Producto</th>
+                          <th className="text-right font-semibold py-2 px-2">Crédito nuevo</th>
+                          <th className="text-right font-semibold py-2 px-2">Pago</th>
+                          <th className="text-right font-semibold py-2 px-2 rounded-r">Total</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {prods.map((p) => (
+                          <tr key={p} className="border-b border-gray-100 hover:bg-gray-50">
+                            <td className="py-2 px-2 text-gray-800">{PROD_LABEL[p] ?? p}</td>
+                            <td className="text-right tabular-nums py-2 px-2 text-emerald-700">{nf.format(piv[p].nuevo)}</td>
+                            <td className="text-right tabular-nums py-2 px-2 text-slate-600">{nf.format(piv[p].pago)}</td>
+                            <td className="text-right tabular-nums py-2 px-2 font-semibold text-blue-900">{nf.format(piv[p].nuevo + piv[p].pago)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                      <tfoot>
+                        <tr className="font-bold text-blue-900 border-t-2 border-blue-200 bg-blue-50/60">
+                          <td className="py-2 px-2">TOTAL</td>
+                          <td className="text-right tabular-nums py-2 px-2 text-emerald-800">{nf.format(tn)}</td>
+                          <td className="text-right tabular-nums py-2 px-2 text-slate-700">{nf.format(tp)}</td>
+                          <td className="text-right tabular-nums py-2 px-2">{nf.format(tn + tp)}</td>
+                        </tr>
+                      </tfoot>
+                    </table>
+                  );
+                })()
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Modal de historial de cambios (auditoría) */}
       {historialOpen && (

--- a/apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/facturacionDiaria.services.ts
@@ -203,3 +203,24 @@ export const getAuditoriaSnapshot = async (params?: {
   );
   return data;
 };
+
+// ───────────── Detalle por origen (crédito nuevo vs pago) ─────────────
+export interface DetalleSnapshotRow {
+  rubro: string;
+  producto: string; // autocompras | nuevo_autocompras | sobre_vehiculo | hipotecario | ...
+  origen: "nuevo" | "pago";
+  monto_total: number;
+  monto_iva: number;
+}
+
+// Trae el desglose nuevo/pago de un día (opcionalmente de un rubro) para el modal.
+export const getDetalleSnapshot = async (
+  fecha: string,
+  rubro?: string
+): Promise<{ success: boolean; data: DetalleSnapshotRow[] }> => {
+  const { data } = await api.get(
+    `${API_URL}/api/facturacion-snapshot/detalle`,
+    { params: { fecha, rubro } }
+  );
+  return data;
+};

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4062,6 +4062,10 @@ export const cobrosRouter = {
 					extraInsuranceCost: quotations.extraInsuranceCost,
 					extraMembershipCost: quotations.extraMembershipCost,
 					extraAdminCost: quotations.extraAdminCost,
+					freelanceCost: quotations.freelanceCost,
+					royalty: quotations.royalty,
+					inspectionCost: quotations.inspectionCost,
+					legalCost: quotations.legalCost,
 				})
 				.from(quotations)
 				.where(isNotNull(quotations.opportunityId))
@@ -4096,7 +4100,11 @@ export const cobrosRouter = {
 				COALESCE(${latestQuotations.extraGpsCost}::numeric, 0) +
 				COALESCE(${latestQuotations.extraInsuranceCost}::numeric, 0) +
 				COALESCE(${latestQuotations.extraMembershipCost}::numeric, 0) +
-				COALESCE(${latestQuotations.extraAdminCost}::numeric, 0)
+				COALESCE(${latestQuotations.extraAdminCost}::numeric, 0) +
+				COALESCE(${latestQuotations.freelanceCost}::numeric, 0) +
+				COALESCE(${latestQuotations.royalty}::numeric, 0) +
+				COALESCE(${latestQuotations.inspectionCost}::numeric, 0) +
+				COALESCE(${latestQuotations.legalCost}::numeric, 0)
 			)`;
 
 			const baseQuery = db
@@ -4121,6 +4129,10 @@ export const cobrosRouter = {
 					extraInsuranceCost: latestQuotations.extraInsuranceCost,
 					extraMembershipCost: latestQuotations.extraMembershipCost,
 					extraAdminCost: latestQuotations.extraAdminCost,
+					freelanceCost: latestQuotations.freelanceCost,
+					royalty: latestQuotations.royalty,
+					inspectionCost: latestQuotations.inspectionCost,
+					legalCost: latestQuotations.legalCost,
 					totalDescuentos: totalSql,
 				})
 				.from(latestQuotations)
@@ -4176,6 +4188,10 @@ export const cobrosRouter = {
 					seguro: fmt(row.extraInsuranceCost),
 					membresia: fmt(row.extraMembershipCost),
 					gastosAdmin: fmt(row.extraAdminCost),
+					freelance: fmt(row.freelanceCost),
+					royalty: fmt(row.royalty),
+					inspeccion: fmt(row.inspectionCost),
+					gastosLegales: fmt(row.legalCost),
 					totalDescuentos: Number(row.totalDescuentos).toFixed(2),
 				};
 			});

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4069,11 +4069,7 @@ export const cobrosRouter = {
 				})
 				.from(quotations)
 				.where(isNotNull(quotations.opportunityId))
-				.orderBy(
-					quotations.opportunityId,
-					sql`CASE WHEN ${quotations.status} = 'accepted' THEN 0 ELSE 1 END`,
-					desc(quotations.createdAt),
-				)
+				.orderBy(quotations.opportunityId, desc(quotations.createdAt))
 				.as("lq");
 
 			const conditions = [isNotNull(opportunities.numeroSifco)];

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -10,6 +10,7 @@ import {
 	gte,
 	ilike,
 	inArray,
+	isNotNull,
 	or,
 	sql,
 } from "drizzle-orm";
@@ -37,6 +38,7 @@ import {
 	referenciasLead,
 	salesStages,
 } from "../db/schema/crm";
+import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
 import {
 	interpolar as interpolarPlantilla,
@@ -4034,61 +4036,140 @@ export const cobrosRouter = {
 			z.object({
 				page: z.number().min(1).default(1),
 				pageSize: z.number().min(1).max(100).default(25),
-				emailCobrador: z.string().optional(),
+				search: z.string().optional(),
 			}),
 		)
 		.handler(async ({ input }) => {
-			if (!isCarteraBackEnabled()) {
-				throw new ORPCError("BAD_REQUEST", {
-					message: "Integración con cartera-back no está habilitada",
-				});
+			const asesorUser = user;
+
+			const latestQuotations = db
+				.selectDistinctOn([quotations.opportunityId], {
+					opportunityId: quotations.opportunityId,
+					finesCost: quotations.finesCost,
+					keyCopyCost: quotations.keyCopyCost,
+					keyCopyDiffCost: quotations.keyCopyDiffCost,
+					circulationTaxCost: quotations.circulationTaxCost,
+					mobileGuaranteeCost: quotations.mobileGuaranteeCost,
+					licensePlatesCost: quotations.licensePlatesCost,
+					leasingContractCost: quotations.leasingContractCost,
+					collectionAuthCost: quotations.collectionAuthCost,
+					appointmentCost: quotations.appointmentCost,
+					addressVerificationCost: quotations.addressVerificationCost,
+					vehicleTransferCost: quotations.vehicleTransferCost,
+					interestCost: quotations.interestCost,
+					rcdpCost: quotations.rcdpCost,
+					extraGpsCost: quotations.extraGpsCost,
+					extraInsuranceCost: quotations.extraInsuranceCost,
+					extraMembershipCost: quotations.extraMembershipCost,
+					extraAdminCost: quotations.extraAdminCost,
+				})
+				.from(quotations)
+				.where(isNotNull(quotations.opportunityId))
+				.orderBy(quotations.opportunityId, desc(quotations.createdAt))
+				.as("lq");
+
+			const conditions = [isNotNull(opportunities.numeroSifco)];
+			if (input.search) {
+				const term = `%${input.search}%`;
+				const searchCond = or(
+					ilike(opportunities.numeroSifco, term),
+					ilike(leads.firstName, term),
+					ilike(leads.lastName, term),
+				);
+				if (searchCond) conditions.push(searchCond);
 			}
 
-			const creditos = await obtenerTodasLasPaginasCreditos({
-				mes: 0,
-				anio: new Date().getFullYear(),
-				estado: "ACTIVO",
-				email_cobrador: input.emailCobrador,
-			});
+			const rows = await db
+				.select({
+					sifco: opportunities.numeroSifco,
+					leadFirstName: leads.firstName,
+					leadLastName: leads.lastName,
+					asesorNombre: asesorUser.name,
+					finesCost: latestQuotations.finesCost,
+					keyCopyCost: latestQuotations.keyCopyCost,
+					keyCopyDiffCost: latestQuotations.keyCopyDiffCost,
+					circulationTaxCost: latestQuotations.circulationTaxCost,
+					mobileGuaranteeCost: latestQuotations.mobileGuaranteeCost,
+					licensePlatesCost: latestQuotations.licensePlatesCost,
+					leasingContractCost: latestQuotations.leasingContractCost,
+					collectionAuthCost: latestQuotations.collectionAuthCost,
+					appointmentCost: latestQuotations.appointmentCost,
+					addressVerificationCost: latestQuotations.addressVerificationCost,
+					vehicleTransferCost: latestQuotations.vehicleTransferCost,
+					interestCost: latestQuotations.interestCost,
+					rcdpCost: latestQuotations.rcdpCost,
+					extraGpsCost: latestQuotations.extraGpsCost,
+					extraInsuranceCost: latestQuotations.extraInsuranceCost,
+					extraMembershipCost: latestQuotations.extraMembershipCost,
+					extraAdminCost: latestQuotations.extraAdminCost,
+				})
+				.from(latestQuotations)
+				.innerJoin(
+					opportunities,
+					eq(latestQuotations.opportunityId, opportunities.id),
+				)
+				.innerJoin(asesorUser, eq(opportunities.assignedTo, asesorUser.id))
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.where(and(...conditions));
 
-			type RubroItem = { nombre_rubro: string; monto: string | number };
+			const n = (v: string | null | undefined) =>
+				Number.parseFloat(v || "0") || 0;
+			const fmt = (v: number) => v.toFixed(2);
 
-			const todos = creditos
-				.map((item) => {
-					const cred = item.creditos;
-					const gps = Number.parseFloat(cred.gps || "0");
-					const seguro = Number.parseFloat(cred.seguro_10_cuotas || "0");
-					const membresias = Number.parseFloat(cred.membresias_pago || "0");
-					const otros = Number.parseFloat(cred.otros || "0");
-
-					const rubros = ((item.rubros as RubroItem[] | null) ?? []).map(
-						(r) => ({
-							nombre: r.nombre_rubro,
-							monto: Number.parseFloat(String(r.monto || "0")).toFixed(2),
-						}),
-					);
-					const rubrosTotal = rubros.reduce(
-						(s, r) => s + Number.parseFloat(r.monto),
-						0,
-					);
+			const todos = rows
+				.map((row) => {
+					const multas = n(row.finesCost);
+					const copiaDeLlave = n(row.keyCopyCost);
+					const diferenciaCopia = n(row.keyCopyDiffCost);
+					const impuestoCirculacion = n(row.circulationTaxCost);
+					const garantiaMobiliaria = n(row.mobileGuaranteeCost);
+					const placas = n(row.licensePlatesCost);
+					const contratoLeasing = n(row.leasingContractCost);
+					const autenticaCobranza = n(row.collectionAuthCost);
+					const nombramiento = n(row.appointmentCost);
+					const verificacionDireccion = n(row.addressVerificationCost);
+					const traspasoVehiculo = n(row.vehicleTransferCost);
+					const intereses = n(row.interestCost);
+					const rcdp = n(row.rcdpCost);
+					const gps = n(row.extraGpsCost);
+					const seguro = n(row.extraInsuranceCost);
+					const membresia = n(row.extraMembershipCost);
+					const gastosAdmin = n(row.extraAdminCost);
 
 					const totalDescuentos =
-						gps + seguro + membresias + otros + rubrosTotal;
+						multas + copiaDeLlave + diferenciaCopia + impuestoCirculacion +
+						garantiaMobiliaria + placas + contratoLeasing + autenticaCobranza +
+						nombramiento + verificacionDireccion + traspasoVehiculo +
+						intereses + rcdp + gps + seguro + membresia + gastosAdmin;
+
 					if (totalDescuentos <= 0) return null;
 
+					const clienteNombre =
+						[row.leadFirstName, row.leadLastName].filter(Boolean).join(" ") ||
+						"Sin cliente";
+
 					return {
-						sifco: cred.numero_credito_sifco,
-						clienteNombre: item.usuarios.nombre,
-						asesorNombre: item.asesores?.nombre ?? "Sin asesor",
-						gps: gps.toFixed(2),
-						seguro: seguro.toFixed(2),
-						membresias: membresias.toFixed(2),
-						otros: otros.toFixed(2),
-						rubros,
-						rubrosTotal: rubrosTotal.toFixed(2),
-						totalDescuentos: totalDescuentos.toFixed(2),
-						capital: cred.capital,
-						tipoCredito: cred.tipoCredito ?? null,
+						sifco: row.sifco ?? "",
+						clienteNombre,
+						asesorNombre: row.asesorNombre ?? "Sin asesor",
+						multas: fmt(multas),
+						copiaDeLlave: fmt(copiaDeLlave),
+						diferenciaCopia: fmt(diferenciaCopia),
+						impuestoCirculacion: fmt(impuestoCirculacion),
+						garantiaMobiliaria: fmt(garantiaMobiliaria),
+						placas: fmt(placas),
+						contratoLeasing: fmt(contratoLeasing),
+						autenticaCobranza: fmt(autenticaCobranza),
+						nombramiento: fmt(nombramiento),
+						verificacionDireccion: fmt(verificacionDireccion),
+						traspasoVehiculo: fmt(traspasoVehiculo),
+						intereses: fmt(intereses),
+						rcdp: fmt(rcdp),
+						gps: fmt(gps),
+						seguro: fmt(seguro),
+						membresia: fmt(membresia),
+						gastosAdmin: fmt(gastosAdmin),
+						totalDescuentos: fmt(totalDescuentos),
 					};
 				})
 				.filter((v): v is NonNullable<typeof v> => v !== null);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4079,12 +4079,31 @@ export const cobrosRouter = {
 				if (searchCond) conditions.push(searchCond);
 			}
 
-			const rows = await db
+			const totalSql = sql<number>`(
+				COALESCE(${latestQuotations.finesCost}::numeric, 0) +
+				COALESCE(${latestQuotations.keyCopyCost}::numeric, 0) +
+				COALESCE(${latestQuotations.keyCopyDiffCost}::numeric, 0) +
+				COALESCE(${latestQuotations.circulationTaxCost}::numeric, 0) +
+				COALESCE(${latestQuotations.mobileGuaranteeCost}::numeric, 0) +
+				COALESCE(${latestQuotations.licensePlatesCost}::numeric, 0) +
+				COALESCE(${latestQuotations.leasingContractCost}::numeric, 0) +
+				COALESCE(${latestQuotations.collectionAuthCost}::numeric, 0) +
+				COALESCE(${latestQuotations.appointmentCost}::numeric, 0) +
+				COALESCE(${latestQuotations.addressVerificationCost}::numeric, 0) +
+				COALESCE(${latestQuotations.vehicleTransferCost}::numeric, 0) +
+				COALESCE(${latestQuotations.interestCost}::numeric, 0) +
+				COALESCE(${latestQuotations.rcdpCost}::numeric, 0) +
+				COALESCE(${latestQuotations.extraGpsCost}::numeric, 0) +
+				COALESCE(${latestQuotations.extraInsuranceCost}::numeric, 0) +
+				COALESCE(${latestQuotations.extraMembershipCost}::numeric, 0) +
+				COALESCE(${latestQuotations.extraAdminCost}::numeric, 0)
+			)`;
+
+			const baseQuery = db
 				.select({
 					sifco: opportunities.numeroSifco,
 					leadFirstName: leads.firstName,
 					leadLastName: leads.lastName,
-					asesorNombre: asesorUser.name,
 					finesCost: latestQuotations.finesCost,
 					keyCopyCost: latestQuotations.keyCopyCost,
 					keyCopyDiffCost: latestQuotations.keyCopyDiffCost,
@@ -4102,6 +4121,7 @@ export const cobrosRouter = {
 					extraInsuranceCost: latestQuotations.extraInsuranceCost,
 					extraMembershipCost: latestQuotations.extraMembershipCost,
 					extraAdminCost: latestQuotations.extraAdminCost,
+					totalDescuentos: totalSql,
 				})
 				.from(latestQuotations)
 				.innerJoin(
@@ -4110,74 +4130,57 @@ export const cobrosRouter = {
 				)
 				.innerJoin(asesorUser, eq(opportunities.assignedTo, asesorUser.id))
 				.leftJoin(leads, eq(opportunities.leadId, leads.id))
-				.where(and(...conditions));
+				.where(and(...conditions, sql`${totalSql} > 0`));
 
-			const n = (v: string | null | undefined) =>
-				Number.parseFloat(v || "0") || 0;
-			const fmt = (v: number) => v.toFixed(2);
+			const [[{ total }], rows] = await Promise.all([
+				db
+					.select({ total: count() })
+					.from(latestQuotations)
+					.innerJoin(
+						opportunities,
+						eq(latestQuotations.opportunityId, opportunities.id),
+					)
+					.innerJoin(asesorUser, eq(opportunities.assignedTo, asesorUser.id))
+					.leftJoin(leads, eq(opportunities.leadId, leads.id))
+					.where(and(...conditions, sql`${totalSql} > 0`)),
+				baseQuery
+					.orderBy(desc(opportunities.createdAt))
+					.limit(input.pageSize)
+					.offset((input.page - 1) * input.pageSize),
+			]);
 
-			const todos = rows
-				.map((row) => {
-					const multas = n(row.finesCost);
-					const copiaDeLlave = n(row.keyCopyCost);
-					const diferenciaCopia = n(row.keyCopyDiffCost);
-					const impuestoCirculacion = n(row.circulationTaxCost);
-					const garantiaMobiliaria = n(row.mobileGuaranteeCost);
-					const placas = n(row.licensePlatesCost);
-					const contratoLeasing = n(row.leasingContractCost);
-					const autenticaCobranza = n(row.collectionAuthCost);
-					const nombramiento = n(row.appointmentCost);
-					const verificacionDireccion = n(row.addressVerificationCost);
-					const traspasoVehiculo = n(row.vehicleTransferCost);
-					const intereses = n(row.interestCost);
-					const rcdp = n(row.rcdpCost);
-					const gps = n(row.extraGpsCost);
-					const seguro = n(row.extraInsuranceCost);
-					const membresia = n(row.extraMembershipCost);
-					const gastosAdmin = n(row.extraAdminCost);
+			const fmt = (v: string | null | undefined) =>
+				Number.parseFloat(v || "0").toFixed(2);
 
-					const totalDescuentos =
-						multas + copiaDeLlave + diferenciaCopia + impuestoCirculacion +
-						garantiaMobiliaria + placas + contratoLeasing + autenticaCobranza +
-						nombramiento + verificacionDireccion + traspasoVehiculo +
-						intereses + rcdp + gps + seguro + membresia + gastosAdmin;
+			const pageData = rows.map((row) => {
+				const clienteNombre =
+					[row.leadFirstName, row.leadLastName].filter(Boolean).join(" ") ||
+					"Sin cliente";
+				return {
+					sifco: row.sifco ?? "",
+					clienteNombre,
+					multas: fmt(row.finesCost),
+					copiaDeLlave: fmt(row.keyCopyCost),
+					diferenciaCopia: fmt(row.keyCopyDiffCost),
+					impuestoCirculacion: fmt(row.circulationTaxCost),
+					garantiaMobiliaria: fmt(row.mobileGuaranteeCost),
+					placas: fmt(row.licensePlatesCost),
+					contratoLeasing: fmt(row.leasingContractCost),
+					autenticaCobranza: fmt(row.collectionAuthCost),
+					nombramiento: fmt(row.appointmentCost),
+					verificacionDireccion: fmt(row.addressVerificationCost),
+					traspasoVehiculo: fmt(row.vehicleTransferCost),
+					intereses: fmt(row.interestCost),
+					rcdp: fmt(row.rcdpCost),
+					gps: fmt(row.extraGpsCost),
+					seguro: fmt(row.extraInsuranceCost),
+					membresia: fmt(row.extraMembershipCost),
+					gastosAdmin: fmt(row.extraAdminCost),
+					totalDescuentos: Number(row.totalDescuentos).toFixed(2),
+				};
+			});
 
-					if (totalDescuentos <= 0) return null;
-
-					const clienteNombre =
-						[row.leadFirstName, row.leadLastName].filter(Boolean).join(" ") ||
-						"Sin cliente";
-
-					return {
-						sifco: row.sifco ?? "",
-						clienteNombre,
-						asesorNombre: row.asesorNombre ?? "Sin asesor",
-						multas: fmt(multas),
-						copiaDeLlave: fmt(copiaDeLlave),
-						diferenciaCopia: fmt(diferenciaCopia),
-						impuestoCirculacion: fmt(impuestoCirculacion),
-						garantiaMobiliaria: fmt(garantiaMobiliaria),
-						placas: fmt(placas),
-						contratoLeasing: fmt(contratoLeasing),
-						autenticaCobranza: fmt(autenticaCobranza),
-						nombramiento: fmt(nombramiento),
-						verificacionDireccion: fmt(verificacionDireccion),
-						traspasoVehiculo: fmt(traspasoVehiculo),
-						intereses: fmt(intereses),
-						rcdp: fmt(rcdp),
-						gps: fmt(gps),
-						seguro: fmt(seguro),
-						membresia: fmt(membresia),
-						gastosAdmin: fmt(gastosAdmin),
-						totalDescuentos: fmt(totalDescuentos),
-					};
-				})
-				.filter((v): v is NonNullable<typeof v> => v !== null);
-
-			const total = todos.length;
 			const totalPages = Math.max(1, Math.ceil(total / input.pageSize));
-			const start = (input.page - 1) * input.pageSize;
-			const pageData = todos.slice(start, start + input.pageSize);
 
 			return {
 				data: pageData,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4069,7 +4069,11 @@ export const cobrosRouter = {
 				})
 				.from(quotations)
 				.where(isNotNull(quotations.opportunityId))
-				.orderBy(quotations.opportunityId, desc(quotations.createdAt))
+				.orderBy(
+					quotations.opportunityId,
+					sql`CASE WHEN ${quotations.status} = 'accepted' THEN 0 ELSE 1 END`,
+					desc(quotations.createdAt),
+				)
 				.as("lq");
 
 			const conditions = [isNotNull(opportunities.numeroSifco)];

--- a/apps/crm/apps/web/src/components/data-table.tsx
+++ b/apps/crm/apps/web/src/components/data-table.tsx
@@ -47,6 +47,8 @@ interface DataTableProps<TData, TValue> {
 	hideSearch?: boolean;
 	pageSizeOptions?: number[];
 	tableContainerClass?: string;
+	stickyFirstColumn?: boolean;
+	stickyHeader?: boolean;
 }
 
 export function DataTable<TData, TValue>({
@@ -63,6 +65,8 @@ export function DataTable<TData, TValue>({
 	hideSearch,
 	pageSizeOptions = [10, 20, 30, 40, 50],
 	tableContainerClass,
+	stickyFirstColumn,
+	stickyHeader,
 }: DataTableProps<TData, TValue>) {
 	const [sorting, setSorting] = useState<SortingState>([]);
 	const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -107,7 +111,7 @@ export function DataTable<TData, TValue>({
 	});
 
 	return (
-		<div className="space-y-4">
+		<div className="w-full min-w-0 space-y-4">
 			{(!hideSearch || filterContent || extraSearch) && (
 				<div className="flex flex-col gap-4">
 					{(!hideSearch || extraSearch) && (
@@ -134,14 +138,17 @@ export function DataTable<TData, TValue>({
 				</div>
 			)}
 
-			<div className={`overflow-hidden rounded-md border${tableContainerClass ? ` ${tableContainerClass}` : ""}`}>
+			<div className={`w-full overflow-x-auto rounded-md border${tableContainerClass ? ` ${tableContainerClass}` : ""}`}>
 				<Table>
 					<TableHeader>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>
-								{headerGroup.headers.map((header) => {
+								{headerGroup.headers.map((header, idx) => {
 									return (
-										<TableHead key={header.id}>
+										<TableHead
+											key={header.id}
+											className={stickyFirstColumn && idx === 0 ? "sticky left-0 z-20 bg-background shadow-[1px_0_0_0_hsl(var(--border))]" : ""}
+										>
 											{header.isPlaceholder
 												? null
 												: flexRender(
@@ -179,8 +186,11 @@ export function DataTable<TData, TValue>({
 									}
 									onClick={() => onRowClick?.(row.original)}
 								>
-									{row.getVisibleCells().map((cell) => (
-										<TableCell key={cell.id}>
+									{row.getVisibleCells().map((cell, idx) => (
+										<TableCell
+											key={cell.id}
+											className={stickyFirstColumn && idx === 0 ? "sticky left-0 z-10 bg-background shadow-[1px_0_0_0_hsl(var(--border))]" : ""}
+										>
 											{flexRender(
 												cell.column.columnDef.cell,
 												cell.getContext(),

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -365,6 +365,26 @@ function rangeForPreset(p: QuickPeriod): { start: string; end: string } {
 	return monthRangeGT();
 }
 
+// Modo inicial para sesiones previas a `modoFecha`: si las fechas guardadas
+// coinciden con un preset, se restaura ese preset; si son un rango propio, se
+// abre en "personalizado" para no perder el filtro del usuario.
+function inferModoFechaInicial(): FechaMode {
+	try {
+		const fiRaw = sessionStorage.getItem("cobros/reportes/cuotas/fechaInicio");
+		const ffRaw = sessionStorage.getItem("cobros/reportes/cuotas/fechaFin");
+		if (!fiRaw || !ffRaw) return "hoy";
+		const fi = JSON.parse(fiRaw) as string;
+		const ff = JSON.parse(ffRaw) as string;
+		for (const p of Object.keys(QUICK_LABELS) as QuickPeriod[]) {
+			const r = rangeForPreset(p);
+			if (fi === r.start && ff === r.end) return p;
+		}
+		return "personalizado";
+	} catch {
+		return "hoy";
+	}
+}
+
 type CuotaFila = {
 	cuota_id: number;
 	fecha_vencimiento: string;
@@ -540,7 +560,7 @@ function TabCuotasPorFecha({
 	// "personalizado" se usan (y editan) las fechas guardadas.
 	const [modoFecha, setModoFecha] = usePersistedState<FechaMode>(
 		"cobros/reportes/cuotas/modoFecha",
-		"hoy",
+		inferModoFechaInicial(),
 	);
 	const [fechaInicioCustom, setFechaInicioCustom] = usePersistedState<string>(
 		"cobros/reportes/cuotas/fechaInicio",

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -306,6 +306,7 @@ function TabMora({
 // ─── Cuotas por Fecha (Pagos Esperados) ─────────────────────────────────────
 
 type QuickPeriod = "hoy" | "semana" | "quincena" | "mes";
+type FechaMode = QuickPeriod | "personalizado";
 
 const QUICK_LABELS: Record<QuickPeriod, string> = {
 	hoy: "Hoy",
@@ -347,6 +348,21 @@ function monthRangeGT(): { start: string; end: string } {
 	const start = `${y}-${String(m).padStart(2, "0")}-01`;
 	const lastDay = new Date(Date.UTC(y, m, 0));
 	return { start, end: fmtDate(lastDay) };
+}
+
+// Rango calculado para un preset. Se recalcula en cada render, así "Hoy" /
+// "Esta Semana" siguen frescos aunque el usuario vuelva otro día.
+function rangeForPreset(p: QuickPeriod): { start: string; end: string } {
+	if (p === "hoy") {
+		const h = todayGT();
+		return { start: h, end: h };
+	}
+	if (p === "semana") return weekRangeGT();
+	if (p === "quincena") {
+		const h = todayGT();
+		return { start: h, end: addDaysGT(h, 14) };
+	}
+	return monthRangeGT();
 }
 
 type CuotaFila = {
@@ -520,11 +536,17 @@ function TabCuotasPorFecha({
 }) {
 	const hoyInit = todayGT();
 
-	const [fechaInicio, setFechaInicio] = usePersistedState<string>(
+	// El modo manda: si es un preset, las fechas se calculan al vuelo. Solo en
+	// "personalizado" se usan (y editan) las fechas guardadas.
+	const [modoFecha, setModoFecha] = usePersistedState<FechaMode>(
+		"cobros/reportes/cuotas/modoFecha",
+		"hoy",
+	);
+	const [fechaInicioCustom, setFechaInicioCustom] = usePersistedState<string>(
 		"cobros/reportes/cuotas/fechaInicio",
 		hoyInit,
 	);
-	const [fechaFin, setFechaFin] = usePersistedState<string>(
+	const [fechaFinCustom, setFechaFinCustom] = usePersistedState<string>(
 		"cobros/reportes/cuotas/fechaFin",
 		hoyInit,
 	);
@@ -536,6 +558,21 @@ function TabCuotasPorFecha({
 		"cobros/reportes/cuotas/filtroEstado",
 		"todos",
 	);
+
+	const esPersonalizado = modoFecha === "personalizado";
+	const { start: fechaInicio, end: fechaFin } = esPersonalizado
+		? { start: fechaInicioCustom, end: fechaFinCustom }
+		: rangeForPreset(modoFecha);
+
+	function activarPersonalizado() {
+		// Sembrar las fechas editables con el rango del preset actual.
+		if (!esPersonalizado) {
+			const r = rangeForPreset(modoFecha);
+			setFechaInicioCustom(r.start);
+			setFechaFinCustom(r.end);
+		}
+		setModoFecha("personalizado");
+	}
 
 	const { data: asesoresData } = useQuery({
 		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
@@ -573,37 +610,6 @@ function TabCuotasPorFecha({
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		(data as any)?.rows ?? [];
 
-	const hoy = todayGT();
-	const activeQuick: QuickPeriod | null = (() => {
-		if (fechaInicio === hoy && fechaFin === hoy) return "hoy";
-		const { start: ws, end: we } = weekRangeGT();
-		if (fechaInicio === ws && fechaFin === we) return "semana";
-		if (fechaInicio === hoy && fechaFin === addDaysGT(hoy, 14)) return "quincena";
-		const { start: ms, end: me } = monthRangeGT();
-		if (fechaInicio === ms && fechaFin === me) return "mes";
-		return null;
-	})();
-
-	function applyQuick(period: QuickPeriod) {
-		if (period === "hoy") {
-			const h = todayGT();
-			setFechaInicio(h);
-			setFechaFin(h);
-		} else if (period === "semana") {
-			const { start, end } = weekRangeGT();
-			setFechaInicio(start);
-			setFechaFin(end);
-		} else if (period === "quincena") {
-			const h = todayGT();
-			setFechaInicio(h);
-			setFechaFin(addDaysGT(h, 14));
-		} else if (period === "mes") {
-			const { start, end } = monthRangeGT();
-			setFechaInicio(start);
-			setFechaFin(end);
-		}
-	}
-
 	function getEstado(row: CuotaFila): "pagado" | "parcial" | "pendiente" {
 		if (row.pagado) return "pagado";
 		if (Number(row.total_pagado) > 0) return "parcial";
@@ -622,96 +628,122 @@ function TabCuotasPorFecha({
 			</div>
 
 			{/* Filtros */}
-			<div className="flex flex-wrap items-end gap-3">
-				<div className="flex items-center gap-2">
-					{(Object.keys(QUICK_LABELS) as QuickPeriod[]).map((p) => (
-						<Button
-							key={p}
-							variant={activeQuick === p ? "default" : "outline"}
-							size="sm"
-							onClick={() => applyQuick(p)}
-						>
-							{QUICK_LABELS[p]}
-						</Button>
-					))}
+			<div className="space-y-3">
+				{/* Período — filtro principal */}
+				<div className="rounded-lg border bg-muted/30 p-3">
+					<div className="flex flex-wrap items-end gap-x-4 gap-y-3">
+						<div className="flex flex-col gap-1.5">
+							<Label className="font-semibold text-xs">Período</Label>
+							<div className="flex flex-wrap items-center gap-1.5">
+								{(Object.keys(QUICK_LABELS) as QuickPeriod[]).map((p) => (
+									<Button
+										key={p}
+										variant={modoFecha === p ? "default" : "outline"}
+										size="sm"
+										onClick={() => setModoFecha(p)}
+									>
+										{QUICK_LABELS[p]}
+									</Button>
+								))}
+								<Button
+									variant={esPersonalizado ? "default" : "outline"}
+									size="sm"
+									onClick={activarPersonalizado}
+								>
+									Personalizado
+								</Button>
+							</div>
+						</div>
+
+						<div className="flex items-end gap-2">
+							<div className="flex flex-col gap-1">
+								<Label className="text-muted-foreground text-xs">Desde</Label>
+								<Input
+									type="date"
+									className="w-36"
+									value={fechaInicio}
+									disabled={!esPersonalizado}
+									onChange={(e) => setFechaInicioCustom(e.target.value)}
+								/>
+							</div>
+							<div className="flex flex-col gap-1">
+								<Label className="text-muted-foreground text-xs">Hasta</Label>
+								<Input
+									type="date"
+									className="w-36"
+									value={fechaFin}
+									disabled={!esPersonalizado}
+									onChange={(e) => setFechaFinCustom(e.target.value)}
+								/>
+							</div>
+						</div>
+
+						{!esPersonalizado && (
+							<p className="pb-2 text-muted-foreground text-xs">
+								Selecciona «Personalizado» para elegir fechas.
+							</p>
+						)}
+					</div>
 				</div>
 
-				<div className="flex items-end gap-2">
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Desde</Label>
-						<Input
-							type="date"
-							className="w-36"
-							value={fechaInicio}
-							onChange={(e) => setFechaInicio(e.target.value)}
-						/>
-					</div>
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Hasta</Label>
-						<Input
-							type="date"
-							className="w-36"
-							value={fechaFin}
-							onChange={(e) => setFechaFin(e.target.value)}
-						/>
-					</div>
-				</div>
+				{/* Filtros secundarios */}
+				<div className="flex flex-wrap items-end gap-3">
+					{canSeeAll && (
+						<div className="flex flex-col gap-1">
+							<Label className="text-xs">Asesor</Label>
+							<Select
+								value={asesorId}
+								onValueChange={(v) => setAsesorId(v === "todos" ? "" : v)}
+							>
+								<SelectTrigger className="w-48">
+									<SelectValue placeholder="Todos los asesores" />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="todos">Todos</SelectItem>
+									{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+									{(asesoresData as any)?.asesores?.map((a: any) => (
+										<SelectItem key={a.asesorId} value={String(a.asesorId)}>
+											{a.nombre}
+										</SelectItem>
+									))}
+								</SelectContent>
+							</Select>
+						</div>
+					)}
 
-				{canSeeAll && (
 					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Asesor</Label>
-						<Select
-							value={asesorId}
-							onValueChange={(v) => setAsesorId(v === "todos" ? "" : v)}
-						>
-							<SelectTrigger className="w-48">
-								<SelectValue placeholder="Todos los asesores" />
+						<Label className="text-xs">Estado</Label>
+						<Select value={filtroEstado} onValueChange={setFiltroEstado}>
+							<SelectTrigger className="w-36">
+								<SelectValue />
 							</SelectTrigger>
 							<SelectContent>
 								<SelectItem value="todos">Todos</SelectItem>
-								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								{(asesoresData as any)?.asesores?.map((a: any) => (
-									<SelectItem key={a.asesorId} value={String(a.asesorId)}>
-										{a.nombre}
-									</SelectItem>
-								))}
+								<SelectItem value="pagado">Pagado</SelectItem>
+								<SelectItem value="parcial">Parcial</SelectItem>
+								<SelectItem value="pendiente">Pendiente</SelectItem>
 							</SelectContent>
 						</Select>
 					</div>
-				)}
 
-				<div className="flex flex-col gap-1">
-					<Label className="text-xs">Estado</Label>
-					<Select value={filtroEstado} onValueChange={setFiltroEstado}>
-						<SelectTrigger className="w-36">
-							<SelectValue />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="todos">Todos</SelectItem>
-							<SelectItem value="pagado">Pagado</SelectItem>
-							<SelectItem value="parcial">Parcial</SelectItem>
-							<SelectItem value="pendiente">Pendiente</SelectItem>
-						</SelectContent>
-					</Select>
-				</div>
-
-				<div className="ml-auto flex items-center gap-2">
-					{ultimaAct && (
-						<span className="text-muted-foreground text-xs">
-							Actualizado: {ultimaAct}
-						</span>
-					)}
-					<Button
-						variant="outline"
-						size="sm"
-						onClick={() => refetch()}
-						disabled={isFetching}
-					>
-						<RefreshCw
-							className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
-						/>
-						Actualizar
-					</Button>
+					<div className="ml-auto flex items-center gap-2">
+						{ultimaAct && (
+							<span className="text-muted-foreground text-xs">
+								Actualizado: {ultimaAct}
+							</span>
+						)}
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={() => refetch()}
+							disabled={isFetching}
+						>
+							<RefreshCw
+								className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+							/>
+							Actualizar
+						</Button>
+					</div>
 				</div>
 			</div>
 

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -805,84 +805,74 @@ type DescuentoRow = {
 	sifco: string;
 	clienteNombre: string;
 	asesorNombre: string;
+	multas: string;
+	copiaDeLlave: string;
+	diferenciaCopia: string;
+	impuestoCirculacion: string;
+	garantiaMobiliaria: string;
+	placas: string;
+	contratoLeasing: string;
+	autenticaCobranza: string;
+	nombramiento: string;
+	verificacionDireccion: string;
+	traspasoVehiculo: string;
+	intereses: string;
+	rcdp: string;
 	gps: string;
 	seguro: string;
-	membresias: string;
-	otros: string;
-	rubros: { nombre: string; monto: string }[];
-	rubrosTotal: string;
+	membresia: string;
+	gastosAdmin: string;
 	totalDescuentos: string;
-	capital: string;
-	tipoCredito: string | null;
 };
+
+function fmtDesc(v: string) {
+	const n = Number.parseFloat(v);
+	if (!n || n <= 0) return <span className="text-muted-foreground">—</span>;
+	return <span>{fmtQ(n)}</span>;
+}
 
 const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 	{
-		accessorKey: "sifco",
-		header: "Crédito",
+		id: "creditoCliente",
+		header: "Crédito / Cliente",
 		cell: ({ row }) => (
-			<Link
-				to="/cobros/$id"
-				params={{ id: row.original.sifco }}
-				search={{ tipo: "contrato" }}
-				className="font-mono text-blue-600 text-xs hover:underline"
-			>
-				{row.original.sifco}
-			</Link>
+			<div className="flex flex-col gap-0.5">
+				<Link
+					to="/cobros/$id"
+					params={{ id: row.original.sifco }}
+					search={{ tipo: "contrato" }}
+					className="font-mono text-blue-600 text-xs hover:underline"
+				>
+					{row.original.sifco}
+				</Link>
+				<span className="text-muted-foreground text-xs">
+					{row.original.clienteNombre}
+				</span>
+			</div>
 		),
 	},
-	{ accessorKey: "clienteNombre", header: "Cliente" },
-	{ accessorKey: "asesorNombre", header: "Asesor" },
-	{
-		accessorKey: "capital",
-		header: "Capital",
-		cell: ({ row }) => fmtQ(row.original.capital),
-	},
-	{
-		accessorKey: "gps",
-		header: "GPS",
-		cell: ({ row }) => fmtQ(row.original.gps),
-	},
-	{
-		accessorKey: "seguro",
-		header: "Seguro",
-		cell: ({ row }) => fmtQ(row.original.seguro),
-	},
-	{
-		accessorKey: "membresias",
-		header: "Membresías",
-		cell: ({ row }) => fmtQ(row.original.membresias),
-	},
-	{
-		accessorKey: "otros",
-		header: "Otros",
-		cell: ({ row }) => fmtQ(row.original.otros),
-	},
-	{
-		accessorKey: "rubrosTotal",
-		header: "Rubros Extra",
-		cell: ({ row }) => {
-			const monto = fmtQ(row.original.rubrosTotal);
-			if (Number.parseFloat(row.original.rubrosTotal) <= 0)
-				return <span className="text-muted-foreground">—</span>;
-			return (
-				<div
-					title={row.original.rubros
-						.map((r) => `${r.nombre}: ${fmtQ(r.monto)}`)
-						.join("\n")}
-				>
-					{monto}
-				</div>
-			);
-		},
-	},
+	{ accessorKey: "multas", header: "Multas", cell: ({ row }) => fmtDesc(row.original.multas) },
+	{ accessorKey: "copiaDeLlave", header: "Copia llave", cell: ({ row }) => fmtDesc(row.original.copiaDeLlave) },
+	{ accessorKey: "diferenciaCopia", header: "Dif. copia", cell: ({ row }) => fmtDesc(row.original.diferenciaCopia) },
+	{ accessorKey: "impuestoCirculacion", header: "Imp. circulación", cell: ({ row }) => fmtDesc(row.original.impuestoCirculacion) },
+	{ accessorKey: "garantiaMobiliaria", header: "Garantía mob.", cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria) },
+	{ accessorKey: "placas", header: "Placas", cell: ({ row }) => fmtDesc(row.original.placas) },
+	{ accessorKey: "contratoLeasing", header: "Cto. leasing", cell: ({ row }) => fmtDesc(row.original.contratoLeasing) },
+	{ accessorKey: "autenticaCobranza", header: "Auténtica", cell: ({ row }) => fmtDesc(row.original.autenticaCobranza) },
+	{ accessorKey: "nombramiento", header: "Nombramiento", cell: ({ row }) => fmtDesc(row.original.nombramiento) },
+	{ accessorKey: "verificacionDireccion", header: "Verif. dirección", cell: ({ row }) => fmtDesc(row.original.verificacionDireccion) },
+	{ accessorKey: "traspasoVehiculo", header: "Traspaso", cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo) },
+	{ accessorKey: "intereses", header: "Intereses", cell: ({ row }) => fmtDesc(row.original.intereses) },
+	{ accessorKey: "rcdp", header: "RCDP", cell: ({ row }) => fmtDesc(row.original.rcdp) },
+	{ accessorKey: "gps", header: "GPS", cell: ({ row }) => fmtDesc(row.original.gps) },
+	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtDesc(row.original.seguro) },
+	{ accessorKey: "membresia", header: "Membresía", cell: ({ row }) => fmtDesc(row.original.membresia) },
+	{ accessorKey: "gastosAdmin", header: "Gastos admin", cell: ({ row }) => fmtDesc(row.original.gastosAdmin) },
 	{
 		accessorKey: "totalDescuentos",
-		header: "Total Descuentos",
+		header: "Total",
 		cell: ({ row }) => (
-			<span className="font-semibold">
-				{fmtQ(row.original.totalDescuentos)}
-			</span>
+			<span className="font-semibold">{fmtQ(row.original.totalDescuentos)}</span>
 		),
 	},
 ];
@@ -894,10 +884,11 @@ function TabDescuentos({
 	session: ReturnType<typeof authClient.useSession>["data"];
 	canSeeAll: boolean;
 }) {
-	const [emailAsesor, setEmailAsesor] = usePersistedState<string>(
-		"cobros/reportes/desc/emailAsesor",
+	const [search, setSearch] = usePersistedState<string>(
+		"cobros/reportes/desc/search",
 		"",
 	);
+	const [debouncedSearch, setDebouncedSearch] = useState(search);
 	const [page, setPage] = usePersistedState<number>(
 		"cobros/reportes/desc/page",
 		1,
@@ -907,18 +898,9 @@ function TabDescuentos({
 		25,
 	);
 
-	const emailCobrador = canSeeAll
-		? emailAsesor || undefined
-		: (session?.user?.email ?? undefined);
-
-	const { data: asesoresData } = useQuery({
-		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
-		enabled: !!session && canSeeAll,
-	});
-
 	const { data, isLoading } = useQuery({
 		...orpc.getDescuentosCRM.queryOptions({
-			input: { page, pageSize, emailCobrador },
+			input: { page, pageSize, search: debouncedSearch || undefined },
 		}),
 		enabled: !!session,
 		staleTime: 5 * 60 * 1000,
@@ -931,51 +913,45 @@ function TabDescuentos({
 				<h2 className="font-semibold text-xl">Descuentos por Crédito</h2>
 			</div>
 
-			{canSeeAll && (
-				<div className="flex flex-col gap-1">
-					<Label className="text-xs">Asesor</Label>
-					<Select
-						value={emailAsesor}
-						onValueChange={(v) => {
-							setEmailAsesor(v === "todos" ? "" : v);
-							setPage(1);
-						}}
-					>
-						<SelectTrigger className="w-52">
-							<SelectValue placeholder="Todos los asesores" />
-						</SelectTrigger>
-						<SelectContent>
-							<SelectItem value="todos">Todos</SelectItem>
-							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-							{(asesoresData as any)?.asesores?.map((a: any) => (
-								<SelectItem key={a.asesorId} value={a.email}>
-									{a.nombre}
-								</SelectItem>
-							))}
-						</SelectContent>
-					</Select>
-				</div>
-			)}
+			<div className="flex flex-col gap-1">
+				<Label className="text-xs">Buscar por crédito o cliente</Label>
+				<Input
+					className="max-w-sm"
+					placeholder="CRM-... o nombre del cliente"
+					value={search}
+					onChange={(e) => {
+						setSearch(e.target.value);
+						setPage(1);
+						clearTimeout((window as any)._descSearch);
+						(window as any)._descSearch = setTimeout(
+							() => setDebouncedSearch(e.target.value),
+							400,
+						);
+					}}
+				/>
+			</div>
 
-			<DataTable
-				columns={colsDescuentos}
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				data={(data as any)?.data ?? []}
-				isLoading={isLoading}
-				hideSearch
-				serverPagination={
-					data
-						? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-							{
-								page: (data as any).page,
-								pageSize: (data as any).pageSize,
-								totalPages: (data as any).totalPages,
-								totalItems: (data as any).total,
-								onPageChange: setPage,
-							}
-						: undefined
-				}
-			/>
+			<div className="w-full overflow-x-auto">
+				<DataTable
+					columns={colsDescuentos}
+					// eslint-disable-next-line @typescript-eslint/no-explicit-any
+					data={(data as any)?.data ?? []}
+					isLoading={isLoading}
+					hideSearch
+					serverPagination={
+						data
+							? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+								{
+									page: (data as any).page,
+									pageSize: (data as any).pageSize,
+									totalPages: (data as any).totalPages,
+									totalItems: (data as any).total,
+									onPageChange: setPage,
+								}
+							: undefined
+					}
+				/>
+			</div>
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -913,8 +913,6 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 	{ accessorKey: "garantiaMobiliaria", header: "Garantía mob.", cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria) },
 	{ accessorKey: "placas", header: "Placas", cell: ({ row }) => fmtDesc(row.original.placas) },
 	{ accessorKey: "contratoLeasing", header: "Cto. leasing", cell: ({ row }) => fmtDesc(row.original.contratoLeasing) },
-	{ accessorKey: "autenticaCobranza", header: "Auténtica", cell: ({ row }) => fmtDesc(row.original.autenticaCobranza) },
-	{ accessorKey: "nombramiento", header: "Nombramiento", cell: ({ row }) => fmtDesc(row.original.nombramiento) },
 	{ accessorKey: "verificacionDireccion", header: "Verif. dirección", cell: ({ row }) => fmtDesc(row.original.verificacionDireccion) },
 	{ accessorKey: "traspasoVehiculo", header: "Traspaso", cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo) },
 	{ accessorKey: "intereses", header: "Intereses", cell: ({ row }) => fmtDesc(row.original.intereses) },
@@ -925,8 +923,6 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 	{ accessorKey: "gastosAdmin", header: "Gastos admin", cell: ({ row }) => fmtDesc(row.original.gastosAdmin) },
 	{ accessorKey: "freelance", header: "Free Lance", cell: ({ row }) => fmtDesc(row.original.freelance) },
 	{ accessorKey: "royalty", header: "Royalty", cell: ({ row }) => fmtDesc(row.original.royalty) },
-	{ accessorKey: "inspeccion", header: "Inspección", cell: ({ row }) => fmtDesc(row.original.inspeccion) },
-	{ accessorKey: "gastosLegales", header: "Gastos legales", cell: ({ row }) => fmtDesc(row.original.gastosLegales) },
 	{
 		accessorKey: "totalDescuentos",
 		header: "Total",
@@ -938,10 +934,8 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 
 function TabDescuentos({
 	session,
-	canSeeAll,
 }: {
 	session: ReturnType<typeof authClient.useSession>["data"];
-	canSeeAll: boolean;
 }) {
 	const [search, setSearch] = usePersistedState<string>(
 		"cobros/reportes/desc/search",
@@ -990,14 +984,14 @@ function TabDescuentos({
 				/>
 			</div>
 
-			<div className="w-full overflow-x-auto">
-				<DataTable
-					columns={colsDescuentos}
-					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-					data={(data as any)?.data ?? []}
-					isLoading={isLoading}
-					hideSearch
-					serverPagination={
+			<DataTable
+				columns={colsDescuentos}
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				data={(data as any)?.data ?? []}
+				isLoading={isLoading}
+				hideSearch
+				stickyFirstColumn
+				serverPagination={
 						data
 							? // eslint-disable-next-line @typescript-eslint/no-explicit-any
 								{
@@ -1010,7 +1004,6 @@ function TabDescuentos({
 							: undefined
 					}
 				/>
-			</div>
 		</div>
 	);
 }
@@ -1037,7 +1030,7 @@ function RouteComponent() {
 	}
 
 	return (
-		<div className="space-y-6 p-6">
+		<div className="min-w-0 space-y-6 p-6">
 			<div className="flex items-center gap-2">
 				<BarChart3 className="h-6 w-6 text-blue-600" />
 				<h1 className="font-bold text-2xl">Reportes de Cobros</h1>
@@ -1066,7 +1059,7 @@ function RouteComponent() {
 					<TabCuotasPorFecha session={session} canSeeAll={canSeeAll} />
 				</TabsContent>
 				<TabsContent value="descuentos" className="mt-6">
-					<TabDescuentos session={session} canSeeAll={canSeeAll} />
+					<TabDescuentos session={session} />
 				</TabsContent>
 			</Tabs>
 		</div>

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -804,7 +804,6 @@ function TabCuotasPorFecha({
 type DescuentoRow = {
 	sifco: string;
 	clienteNombre: string;
-	asesorNombre: string;
 	multas: string;
 	copiaDeLlave: string;
 	diferenciaCopia: string;
@@ -822,6 +821,10 @@ type DescuentoRow = {
 	seguro: string;
 	membresia: string;
 	gastosAdmin: string;
+	freelance: string;
+	royalty: string;
+	inspeccion: string;
+	gastosLegales: string;
 	totalDescuentos: string;
 };
 
@@ -868,6 +871,10 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtDesc(row.original.seguro) },
 	{ accessorKey: "membresia", header: "Membresía", cell: ({ row }) => fmtDesc(row.original.membresia) },
 	{ accessorKey: "gastosAdmin", header: "Gastos admin", cell: ({ row }) => fmtDesc(row.original.gastosAdmin) },
+	{ accessorKey: "freelance", header: "Free Lance", cell: ({ row }) => fmtDesc(row.original.freelance) },
+	{ accessorKey: "royalty", header: "Royalty", cell: ({ row }) => fmtDesc(row.original.royalty) },
+	{ accessorKey: "inspeccion", header: "Inspección", cell: ({ row }) => fmtDesc(row.original.inspeccion) },
+	{ accessorKey: "gastosLegales", header: "Gastos legales", cell: ({ row }) => fmtDesc(row.original.gastosLegales) },
 	{
 		accessorKey: "totalDescuentos",
 		header: "Total",

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -748,49 +748,49 @@ function TabCuotasPorFecha({
 			</div>
 
 			{/* Summary cards */}
-			<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-				<Card className="border-blue-200 bg-blue-50">
-					<CardHeader className="pb-2">
-						<CardTitle className="font-medium text-blue-700 text-sm">
+			<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+				<Card className="gap-1 border-blue-200 bg-blue-50 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-blue-700 text-xs">
 							Total Esperado
 						</CardTitle>
 					</CardHeader>
-					<CardContent>
-						<div className="font-bold text-blue-800 text-xl">
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-blue-800 text-lg">
 							{fmtQ(totales?.totalEsp ?? "0")}
 						</div>
 					</CardContent>
 				</Card>
-				<Card className="border-green-200 bg-green-50">
-					<CardHeader className="pb-2">
-						<CardTitle className="font-medium text-green-700 text-sm">
+				<Card className="gap-1 border-green-200 bg-green-50 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-green-700 text-xs">
 							Total Pagado
 						</CardTitle>
 					</CardHeader>
-					<CardContent>
-						<div className="font-bold text-green-700 text-xl">
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-green-700 text-lg">
 							{fmtQ(totales?.totalPag ?? "0")}
 						</div>
 					</CardContent>
 				</Card>
-				<Card className="border-red-200 bg-red-50">
-					<CardHeader className="pb-2">
-						<CardTitle className="font-medium text-red-700 text-sm">
+				<Card className="gap-1 border-red-200 bg-red-50 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-red-700 text-xs">
 							Total Pendiente
 						</CardTitle>
 					</CardHeader>
-					<CardContent>
-						<div className="font-bold text-red-700 text-xl">
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-red-700 text-lg">
 							{fmtQ(totales?.totalPendiente ?? "0")}
 						</div>
 					</CardContent>
 				</Card>
-				<Card>
-					<CardHeader className="pb-2">
-						<CardTitle className="font-medium text-sm">Cuotas</CardTitle>
+				<Card className="gap-1 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-xs">Cuotas</CardTitle>
 					</CardHeader>
-					<CardContent>
-						<div className="font-bold text-xl">
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-lg">
 							{totales?.cuotasPagadas ?? 0} / {totales?.cuotasTotal ?? 0}
 						</div>
 						<p className="text-muted-foreground text-xs">pagadas / total</p>
@@ -810,13 +810,13 @@ function TabCuotasPorFecha({
 						{ key: "membresiasEsp", label: "Membresías" },
 					] as const
 				).map((c) => (
-					<Card key={c.key} className="py-3">
-						<CardHeader className="px-4 pb-1 pt-0">
+					<Card key={c.key} className="gap-0.5 py-2.5">
+						<CardHeader className="px-3 pb-0 pt-0">
 							<CardTitle className="font-medium text-muted-foreground text-xs">
 								{c.label}
 							</CardTitle>
 						</CardHeader>
-						<CardContent className="px-4 pb-0">
+						<CardContent className="px-3 pb-0">
 							<div className="font-semibold text-sm">
 								{fmtQ(totales?.[c.key] ?? "0")}
 							</div>


### PR DESCRIPTION
# 🚀 Pase a Producción — `develop` → `main`

Release de los cambios acumulados en `develop`. Resumen general por área:

## 📊 Reportes

**Pagos Esperados (Cobros)**
- Jerarquía en el filtro de período: botón **Personalizado** que controla las fechas; con un preset activo (Hoy / Semana / Quincena / Mes) los campos Desde/Hasta quedan bloqueados y el rango se recalcula al vuelo
- Cards de totales y rubros más compactas
- Se preserva el filtro de fecha guardado de sesiones previas (no cae a "hoy" tras el deploy)

**Descuentos por Crédito (CRM)**
- Reporte de descuentos por crédito rehecho desde CRM
- Paginación server-side real
- Incluye rubros de freelance, royalty, inspección y gastos legales
- Prioriza la cotización aceptada al calcular descuentos

## 💳 Cartera
- Snapshot diario: desglose nuevo vs pago + seguro/GPS por categoría
- Detalle reconcilia `mora_cube` e inversionistas (Codex P2 #933)
- Se oculta el desglose nuevo/pago en días bloqueados (Codex P2 #933)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
