### PR TITLE
feat(reportes): columna "Interés Inv. (referencia)" en Monto a Cobrarse por Período

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -296,6 +296,21 @@ export async function getMontoACobrarPeriodo({
         COUNT(*)::int                           AS cuotas_count
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
+    ),
+    -- Interés facturado a inversionistas: rubro INTERES_INVERSIONISTAS del desglose
+    -- (con IVA incluido), agrupado por fecha en que se aplicó (fecha_aplicado_gt).
+    -- Es facturado REAL —otra fuente que el esperado de las cuotas— por eso se muestra
+    -- aparte y NO se suma al Total de la fila.
+    inv_por_bucket AS (
+      SELECT
+        DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)        AS inv_bucket,
+        COALESCE(SUM(fd.monto_total::numeric - fd.monto_iva::numeric), 0) AS total_interes_inversionista
+      FROM cartera.facturacion_desglose fd
+      WHERE fd.rubro::text = 'INTERES_INVERSIONISTAS'
+        AND fd.fecha_aplicado_gt IS NOT NULL
+        AND fd.fecha_aplicado_gt >= ${fechaInicio}::date
+        AND fd.fecha_aplicado_gt <= ${fechaFin}::date
+      GROUP BY DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)
     )
     SELECT
       bucket,
@@ -333,8 +348,14 @@ export async function getMontoACobrarPeriodo({
       COALESCE(SUM(CASE
         WHEN excluido_mora     THEN 0
         WHEN cuotas_atrasadas > 0 THEN acum_mem
-        ELSE mem END), 0)                                                                         AS acum_total_membresias
+        ELSE mem END), 0)                                                                         AS acum_total_membresias,
+      -- Interés a inversionistas (facturado REAL, neto sin IVA). Por período: lo facturado
+      -- en ese bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran
+      -- total, igual que como la fila Total lee el acumulado de los demás rubros).
+      COALESCE(MAX(ib.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
+      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY bucket), 0)   AS acum_total_interes_inversionista
     FROM per_bucket_credit
+    LEFT JOIN inv_por_bucket ib ON ib.inv_bucket = bucket
     GROUP BY bucket
     ORDER BY bucket ASC
   `);

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -256,6 +256,8 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_seguro: string;
 	acum_total_gps: string;
 	acum_total_membresias: string;
+	total_interes_inversionista: string;
+	acum_total_interes_inversionista: string;
 };
 
 export type FlujoCuotasRubro = {

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -103,6 +103,8 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_seguro: string;
 	acum_total_gps: string;
 	acum_total_membresias: string;
+	total_interes_inversionista: string;
+	acum_total_interes_inversionista: string;
 };
 
 export type FacturacionMesRubro = {

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -377,6 +377,8 @@ function fillMissingPeriods(
 				acum_total_seguro: "0",
 				acum_total_gps: "0",
 				acum_total_membresias: "0",
+				total_interes_inversionista: "0",
+				acum_total_interes_inversionista: "0",
 			}
 		);
 	});
@@ -1434,6 +1436,9 @@ function RouteComponent() {
 																Membresías
 															</TableHead>
 															<TableHead className="text-right">
+																Interés Inv. (referencia)
+															</TableHead>
+															<TableHead className="text-right">
 																Total Mora
 															</TableHead>
 															<TableHead className="text-right font-bold">
@@ -1467,6 +1472,10 @@ function RouteComponent() {
 															const membresias = a
 																? row.acum_total_membresias
 																: row.total_membresias;
+															// Facturado real a inversionistas (neto). Por período: lo
+															const interesInversionista = a
+																? row.acum_total_interes_inversionista
+																: row.total_interes_inversionista;
 															const total =
 																Number.parseFloat(cuota) +
 																Number.parseFloat(interes) +
@@ -1502,6 +1511,9 @@ function RouteComponent() {
 																	</TableCell>
 																	<TableCell className="text-right">
 																		{formatCurrency(membresias)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(interesInversionista)}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		<div>{formatCurrency(row.total_mora)}</div>
@@ -1608,6 +1620,15 @@ function RouteComponent() {
 																				a
 																					? "acum_total_membresias"
 																					: "total_membresias",
+																			),
+																		)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(
+																			val(
+																				a
+																					? "acum_total_interes_inversionista"
+																					: "total_interes_inversionista",
 																			),
 																		)}
 																	</TableCell>


### PR DESCRIPTION
### columna "Interés Inv. (referencia)"

Agrega una nueva columna **"Interés Inv. (referencia)"** a la tabla **Monto a Cobrarse por Período**
(pestaña *Cobranza* del Dashboard Ejecutivo), ubicada entre **Membresías** y **Total Mora**.

La columna muestra el interés facturado a inversionistas, tomado del rubro
`INTERES_INVERSIONISTAS` de `cartera.facturacion_desglose`, **neto (sin IVA)**, agrupado por
período según `fecha_aplicado_gt`.

### Cambios

| Capa | Archivo | Cambio |
|------|---------|--------|
| cartera-back (SQL) | `apps/cartera-back/src/controllers/reportes.ts` | Nuevo CTE `inv_por_bucket` que agrega `INTERES_INVERSIONISTAS` por bucket (`fecha_aplicado_gt`), neto = `monto_total - monto_iva`. `LEFT JOIN` por bucket y dos columnas: `total_interes_inversionista` (por período) y `acum_total_interes_inversionista` (saldo corrido). |
| CRM server (tipo) | `apps/crm/apps/server/src/services/cartera-back-client.ts` | Agrega los 2 campos a `MontoACobrarPeriodoRow`. |
| CRM web (tipo) | `apps/crm/apps/web/src/lib/reports/scenario.ts` | Agrega los 2 campos a `MontoACobrarPeriodoRow`. |
| CRM web (UI) | `apps/crm/apps/web/src/routes/admin/reports/index.tsx` | Header, celda por fila, celda en la fila Total, y defaults en `fillMissingPeriods`. |

### Decisiones de diseño

- **Fuente de datos:** el reporte calcula el *esperado a cobrar* desde las cuotas; esta columna
  viene de `facturacion_desglose` (*facturado real*). Son ejes distintos a propósito; la columna
  se rotula **"(referencia)"** y se trata como informativa.
- **No se suma al Total:** ni el `total` por fila ni el `grandTotal` incluyen esta columna
  (evita doble conteo, ya que sería un subconjunto del interés).
- **Neto, sin IVA:** se usa `monto_total - monto_iva` para alinear con las demás columnas de
  interés del reporte (el IVA tiene su propia columna).
- **Por período vs Acumulado:** "Por período" = facturado en ese bucket; "Acumulado" = saldo
  corrido (suma acumulada hasta el bucket, vía `SUM(...) OVER (ORDER BY bucket)`). El último
  bucket = gran total, igual que como la fila Total lee el acumulado de los demás rubros. En
  rangos de un solo bucket (Mes/Trimestre/Año puntual) ambas vistas coinciden por definición.

<img width="1197" height="759" alt="Captura de pantalla 2026-06-19 114141" src="https://github.com/user-attachments/assets/3c8c4be2-6a4e-49f2-a8a5-19c3b4f0fc50" />

<img width="1385" height="668" alt="Captura de pantalla 2026-06-19 114122" src="https://github.com/user-attachments/assets/27e65214-c02b-4eff-8e22-808d06825de3" />

