### PR TITLE
feat(reportes): Interés de CUBE en "Interés Neto" + columna "Interés Inv. (referencia)"

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -996,6 +996,8 @@ export async function getReinversionLiquidaciones({
       },
       cube: {
         interes: interesCube.toFixed(2),
+        iva: (interesCube * 0.12).toFixed(2),
+        neto: (interesCube * 1.12).toFixed(2),
       },
     },
     pagosExtras: {

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -297,10 +297,10 @@ export async function getMontoACobrarPeriodo({
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
     ),
-    -- Interés facturado a inversionistas: rubro INTERES_INVERSIONISTAS del desglose
-    -- (con IVA incluido), agrupado por fecha en que se aplicó (fecha_aplicado_gt).
-    -- Es facturado REAL —otra fuente que el esperado de las cuotas— por eso se muestra
-    -- aparte y NO se suma al Total de la fila.
+    -- Interés facturado a inversionistas: rubro INTERES_INVERSIONISTAS del desglose,
+    -- NETO (monto_total - monto_iva), agrupado por la fecha en que se aplicó
+    -- (fecha_aplicado_gt). Es facturado REAL —otra fuente que el esperado de las
+    -- cuotas— por eso se muestra aparte y NO se suma al Total de la fila.
     inv_por_bucket AS (
       SELECT
         DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)        AS inv_bucket,
@@ -313,7 +313,7 @@ export async function getMontoACobrarPeriodo({
       GROUP BY DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)
     )
     SELECT
-      bucket,
+      COALESCE(per_bucket_credit.bucket, ib.inv_bucket) AS bucket,
       COALESCE(SUM(cuotas_count), 0)::int                                                        AS cuotas_count,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
@@ -353,11 +353,14 @@ export async function getMontoACobrarPeriodo({
       -- en ese bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran
       -- total, igual que como la fila Total lee el acumulado de los demás rubros).
       COALESCE(MAX(ib.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
-      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY bucket), 0)   AS acum_total_interes_inversionista
+      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket)), 0)   AS acum_total_interes_inversionista
+    -- FULL JOIN: el resultado se arma desde la unión de buckets de ambas fuentes, para
+    -- que un período con facturación a inversionistas pero SIN cuotas pendientes
+    -- (posible en vista día/semana) no se pierda al subestimar la columna.
     FROM per_bucket_credit
-    LEFT JOIN inv_por_bucket ib ON ib.inv_bucket = bucket
-    GROUP BY bucket
-    ORDER BY bucket ASC
+    FULL JOIN inv_por_bucket ib ON ib.inv_bucket = per_bucket_credit.bucket
+    GROUP BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket)
+    ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket) ASC
   `);
 
   return result.rows;

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -296,6 +296,21 @@ export async function getMontoACobrarPeriodo({
         COUNT(*)::int                           AS cuotas_count
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
+    ),
+    -- Interés facturado a inversionistas: rubro INTERES_INVERSIONISTAS del desglose
+    -- (con IVA incluido), agrupado por fecha en que se aplicó (fecha_aplicado_gt).
+    -- Es facturado REAL —otra fuente que el esperado de las cuotas— por eso se muestra
+    -- aparte y NO se suma al Total de la fila.
+    inv_por_bucket AS (
+      SELECT
+        DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)        AS inv_bucket,
+        COALESCE(SUM(fd.monto_total::numeric - fd.monto_iva::numeric), 0) AS total_interes_inversionista
+      FROM cartera.facturacion_desglose fd
+      WHERE fd.rubro::text = 'INTERES_INVERSIONISTAS'
+        AND fd.fecha_aplicado_gt IS NOT NULL
+        AND fd.fecha_aplicado_gt >= ${fechaInicio}::date
+        AND fd.fecha_aplicado_gt <= ${fechaFin}::date
+      GROUP BY DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)
     )
     SELECT
       bucket,
@@ -333,8 +348,14 @@ export async function getMontoACobrarPeriodo({
       COALESCE(SUM(CASE
         WHEN excluido_mora     THEN 0
         WHEN cuotas_atrasadas > 0 THEN acum_mem
-        ELSE mem END), 0)                                                                         AS acum_total_membresias
+        ELSE mem END), 0)                                                                         AS acum_total_membresias,
+      -- Interés a inversionistas (facturado REAL, neto sin IVA). Por período: lo facturado
+      -- en ese bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran
+      -- total, igual que como la fila Total lee el acumulado de los demás rubros).
+      COALESCE(MAX(ib.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
+      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY bucket), 0)   AS acum_total_interes_inversionista
     FROM per_bucket_credit
+    LEFT JOIN inv_por_bucket ib ON ib.inv_bucket = bucket
     GROUP BY bucket
     ORDER BY bucket ASC
   `);

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -799,27 +799,48 @@ export async function getReinversionLiquidaciones({
 
   // Interés de CUBE: no se almacena en liquidaciones sino que se deriva de los
   // registros de inversionistas no-CUBE en pagos_credito_inversionistas_espejo.
-  // Por crédito+liquidación se agrupa la participación e interés de todos los
-  // inversionistas no-CUBE, y el interés de CUBE es:
   //   interes_cube = total_inv_interes × (100 - total_inv_pct) / total_inv_pct
+  // `porcentaje_participacion` es un split por inversionista guardado por fila de
+  // pago (snapshot del momento). Se agrupa a nivel de cuota en dos pasos:
+  //   1. (credito, liquidacion, cuota, inversionista): colapsa pagos PARCIALES de
+  //      la misma cuota tomando el porcentaje UNA sola vez (MAX) y sumando el
+  //      interés. Evita inflar el porcentaje (dos parciales al 80% darían 160% y
+  //      romperían el cálculo al caer en el filtro `< 100`).
+  //   2. (credito, liquidacion, cuota): suma la participación de los distintos
+  //      inversionistas no-CUBE dentro de la cuota. Agrupar por cuota (y no por
+  //      crédito) mantiene el cálculo correcto aun si la participación de un
+  //      inversionista cambia entre cuotas (reasignación): cada cuota usa su
+  //      propio porcentaje.
   const cubeRows = await db.execute(sql`
-    WITH por_credito_liq AS (
+    WITH por_inv_cuota AS (
       SELECT
         pe.credito_id,
         pe.liquidacion_id,
-        COALESCE(SUM(pe.abono_interes::numeric), 0)             AS total_inv_interes,
-        COALESCE(SUM(pe.porcentaje_participacion::numeric), 0)  AS total_inv_pct
+        pe.cuota,
+        pe.inversionista_id,
+        COALESCE(SUM(pe.abono_interes::numeric), 0)         AS inv_interes,
+        MAX(pe.porcentaje_participacion::numeric)           AS inv_pct
       FROM cartera.pagos_credito_inversionistas_espejo pe
       JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
       WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
         AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
         AND pe.porcentaje_participacion::numeric > 0
-      GROUP BY pe.credito_id, pe.liquidacion_id
+      GROUP BY pe.credito_id, pe.liquidacion_id, pe.cuota, pe.inversionista_id
+    ),
+    por_cuota AS (
+      SELECT
+        credito_id,
+        liquidacion_id,
+        cuota,
+        SUM(inv_interes) AS total_inv_interes,
+        SUM(inv_pct)     AS total_inv_pct
+      FROM por_inv_cuota
+      GROUP BY credito_id, liquidacion_id, cuota
     )
     SELECT COALESCE(SUM(
       total_inv_interes * (100 - total_inv_pct) / total_inv_pct
     ), 0) AS interes_cube
-    FROM por_credito_liq
+    FROM por_cuota
     WHERE total_inv_pct > 0 AND total_inv_pct < 100
   `);
   const interesCube = Number(

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -311,9 +311,25 @@ export async function getMontoACobrarPeriodo({
         AND fd.fecha_aplicado_gt >= ${fechaInicio}::date
         AND fd.fecha_aplicado_gt <= ${fechaFin}::date
       GROUP BY DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)
+    ),
+    -- ENFOQUE ALTERNATIVO (en evaluación A/B, NO reemplaza al anterior): interés a
+    -- inversionistas tomado de pagos_credito_inversionistas (interés + IVA), solo de
+    -- inversionistas externos (permite_distribucion = false → se ignoran los nuestros),
+    -- agrupado por fecha_pago en zona Guatemala.
+    inv_pagos_por_bucket AS (
+      SELECT
+        DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp) AS pagos_bucket,
+        COALESCE(SUM(pci.abono_interes::numeric + pci.abono_iva_12::numeric), 0)        AS total_interes_inversionista_pagos
+      FROM cartera.pagos_credito_inversionistas pci
+      WHERE pci.inversionista_id IN (
+        SELECT inversionista_id FROM cartera.inversionistas WHERE permite_distribucion = false
+      )
+        AND (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::date >= ${fechaInicio}::date
+        AND (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::date <= ${fechaFin}::date
+      GROUP BY DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp)
     )
     SELECT
-      COALESCE(per_bucket_credit.bucket, ib.inv_bucket) AS bucket,
+      COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket) AS bucket,
       COALESCE(SUM(cuotas_count), 0)::int                                                        AS cuotas_count,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
@@ -353,14 +369,19 @@ export async function getMontoACobrarPeriodo({
       -- en ese bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran
       -- total, igual que como la fila Total lee el acumulado de los demás rubros).
       COALESCE(MAX(ib.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
-      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket)), 0)   AS acum_total_interes_inversionista
-    -- FULL JOIN: el resultado se arma desde la unión de buckets de ambas fuentes, para
-    -- que un período con facturación a inversionistas pero SIN cuotas pendientes
-    -- (posible en vista día/semana) no se pierda al subestimar la columna.
+      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista,
+      -- ENFOQUE ALTERNATIVO (A/B): interés a inversionistas desde pagos_credito_inversionistas
+      -- (interés + IVA). Mismo tratamiento por período / acumulado que el enfoque anterior.
+      COALESCE(MAX(ip.total_interes_inversionista_pagos), 0)                                      AS total_interes_inversionista_pagos,
+      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista_pagos), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista_pagos
+    -- FULL JOIN: el resultado se arma desde la unión de buckets de las fuentes, para que un
+    -- período con facturación/pagos a inversionistas pero SIN cuotas pendientes (posible en
+    -- vista día/semana) no se pierda ni subestime las columnas.
     FROM per_bucket_credit
     FULL JOIN inv_por_bucket ib ON ib.inv_bucket = per_bucket_credit.bucket
-    GROUP BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket)
-    ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket) ASC
+    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = COALESCE(per_bucket_credit.bucket, ib.inv_bucket)
+    GROUP BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)
+    ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket) ASC
   `);
 
   return result.rows;

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -797,6 +797,35 @@ export async function getReinversionLiquidaciones({
     }
   }
 
+  // Interés de CUBE: no se almacena en liquidaciones sino que se deriva de los
+  // registros de inversionistas no-CUBE en pagos_credito_inversionistas_espejo.
+  // Por crédito+liquidación se agrupa la participación e interés de todos los
+  // inversionistas no-CUBE, y el interés de CUBE es:
+  //   interes_cube = total_inv_interes × (100 - total_inv_pct) / total_inv_pct
+  const cubeRows = await db.execute(sql`
+    WITH por_credito_liq AS (
+      SELECT
+        pe.credito_id,
+        pe.liquidacion_id,
+        COALESCE(SUM(pe.abono_interes::numeric), 0)             AS total_inv_interes,
+        COALESCE(SUM(pe.porcentaje_participacion::numeric), 0)  AS total_inv_pct
+      FROM cartera.pagos_credito_inversionistas_espejo pe
+      JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
+      WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+        AND pe.porcentaje_participacion::numeric > 0
+      GROUP BY pe.credito_id, pe.liquidacion_id
+    )
+    SELECT COALESCE(SUM(
+      total_inv_interes * (100 - total_inv_pct) / total_inv_pct
+    ), 0) AS interes_cube
+    FROM por_credito_liq
+    WHERE total_inv_pct > 0 AND total_inv_pct < 100
+  `);
+  const interesCube = Number(
+    (cubeRows.rows[0] as Record<string, unknown>)?.interes_cube ?? 0
+  );
+
   // Pagos extras recibidos (abonos a capital / cancelaciones) que fluyen desde
   // las liquidaciones del mes: liquidación → pago espejo → abono.
   // Cada abono se cuenta una sola vez (DISTINCT) aunque tenga varios pagos espejo.
@@ -962,6 +991,9 @@ export async function getReinversionLiquidaciones({
         interes: sinFactura.interes.toFixed(2),
         isr: sinFactura.isr.toFixed(2),
         neto: (sinFactura.interes - sinFactura.isr).toFixed(2),
+      },
+      cube: {
+        interes: interesCube.toFixed(2),
       },
     },
     pagosExtras: {

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -797,51 +797,32 @@ export async function getReinversionLiquidaciones({
     }
   }
 
-  // Interés de CUBE: no se almacena en liquidaciones sino que se deriva de los
-  // registros de inversionistas no-CUBE en pagos_credito_inversionistas_espejo.
-  //   interes_cube = total_inv_interes × (100 - total_inv_pct) / total_inv_pct
-  // `porcentaje_participacion` es un split por inversionista guardado por fila de
-  // pago (snapshot del momento). Se agrupa a nivel de cuota en dos pasos:
-  //   1. (credito, liquidacion, cuota, inversionista): colapsa pagos PARCIALES de
-  //      la misma cuota tomando el porcentaje UNA sola vez (MAX) y sumando el
-  //      interés. Evita inflar el porcentaje (dos parciales al 80% darían 160% y
-  //      romperían el cálculo al caer en el filtro `< 100`).
-  //   2. (credito, liquidacion, cuota): suma la participación de los distintos
-  //      inversionistas no-CUBE dentro de la cuota. Agrupar por cuota (y no por
-  //      crédito) mantiene el cálculo correcto aun si la participación de un
-  //      inversionista cambia entre cuotas (reasignación): cada cuota usa su
-  //      propio porcentaje.
+  // Interés de CUBE: no se almacena como tal sino que se deriva de las filas de
+  // los inversionistas no-CUBE en pagos_credito_inversionistas_espejo. Para una
+  // fila con interés `abono_interes` y participación `porcentaje_participacion`,
+  // el interés que le corresponde a CUBE (el complemento) es:
+  //   interes_cube = abono_interes × (100 - porcentaje_participacion) / porcentaje_participacion
+  // El cálculo se hace POR FILA, así
+  // que no hay que combinar inversionistas por cuota. Calcular por fila además:
+  //   - maneja pagos parciales (cada parcial aporta su complemento y se suman);
+  //   - usa el porcentaje del snapshot de cada fila, por lo que sigue siendo
+  //     correcto si la participación cambia entre cuotas (reasignación).
+  // Se excluye la propia CUBE (inversionista_id 86) para no contar sus filas como
+  // si fueran de un inversionista no-CUBE, y se omiten las filas al 100% (sin
+  // complemento) y al 0% (evita división por cero).
   const cubeRows = await db.execute(sql`
-    WITH por_inv_cuota AS (
-      SELECT
-        pe.credito_id,
-        pe.liquidacion_id,
-        pe.cuota,
-        pe.inversionista_id,
-        COALESCE(SUM(pe.abono_interes::numeric), 0)         AS inv_interes,
-        MAX(pe.porcentaje_participacion::numeric)           AS inv_pct
-      FROM cartera.pagos_credito_inversionistas_espejo pe
-      JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
-      WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
-        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
-        AND pe.porcentaje_participacion::numeric > 0
-      GROUP BY pe.credito_id, pe.liquidacion_id, pe.cuota, pe.inversionista_id
-    ),
-    por_cuota AS (
-      SELECT
-        credito_id,
-        liquidacion_id,
-        cuota,
-        SUM(inv_interes) AS total_inv_interes,
-        SUM(inv_pct)     AS total_inv_pct
-      FROM por_inv_cuota
-      GROUP BY credito_id, liquidacion_id, cuota
-    )
     SELECT COALESCE(SUM(
-      total_inv_interes * (100 - total_inv_pct) / total_inv_pct
+      pe.abono_interes::numeric
+        * (100 - pe.porcentaje_participacion::numeric)
+        / pe.porcentaje_participacion::numeric
     ), 0) AS interes_cube
-    FROM por_cuota
-    WHERE total_inv_pct > 0 AND total_inv_pct < 100
+    FROM cartera.pagos_credito_inversionistas_espejo pe
+    JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
+      AND pe.inversionista_id <> 86
+      AND pe.porcentaje_participacion::numeric > 0
+      AND pe.porcentaje_participacion::numeric < 100
   `);
   const interesCube = Number(
     (cubeRows.rows[0] as Record<string, unknown>)?.interes_cube ?? 0

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -256,6 +256,8 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_seguro: string;
 	acum_total_gps: string;
 	acum_total_membresias: string;
+	total_interes_inversionista: string;
+	acum_total_interes_inversionista: string;
 };
 
 export type FlujoCuotasRubro = {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -316,7 +316,7 @@ export type ReinversionLiquidacionesResponse = {
 	interesNeto: {
 		conFactura: { interes: string; iva: string; neto: string };
 		sinFactura: { interes: string; isr: string; neto: string };
-		cube: { interes: string };
+		cube: { interes: string; iva: string; neto: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
 	pagosExtras: { abonos_capital: string; cancelaciones: string };

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -258,6 +258,8 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
+	total_interes_inversionista_pagos: string;
+	acum_total_interes_inversionista_pagos: string;
 };
 
 export type FlujoCuotasRubro = {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -316,6 +316,7 @@ export type ReinversionLiquidacionesResponse = {
 	interesNeto: {
 		conFactura: { interes: string; iva: string; neto: string };
 		sinFactura: { interes: string; isr: string; neto: string };
+		cube: { interes: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
 	pagosExtras: { abonos_capital: string; cancelaciones: string };

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -105,6 +105,8 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
+	total_interes_inversionista_pagos: string;
+	acum_total_interes_inversionista_pagos: string;
 };
 
 export type FacturacionMesRubro = {

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -171,7 +171,7 @@ export type ReinversionLiquidacionesResponse = {
 	interesNeto: {
 		conFactura: { interes: string; iva: string; neto: string };
 		sinFactura: { interes: string; isr: string; neto: string };
-		cube: { interes: string };
+		cube: { interes: string; iva: string; neto: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
 	pagosExtras: { abonos_capital: string; cancelaciones: string };

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -103,6 +103,8 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_seguro: string;
 	acum_total_gps: string;
 	acum_total_membresias: string;
+	total_interes_inversionista: string;
+	acum_total_interes_inversionista: string;
 };
 
 export type FacturacionMesRubro = {

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -171,6 +171,7 @@ export type ReinversionLiquidacionesResponse = {
 	interesNeto: {
 		conFactura: { interes: string; iva: string; neto: string };
 		sinFactura: { interes: string; isr: string; neto: string };
+		cube: { interes: string };
 	};
 	/** Pagos extras recibidos del mes (vía liquidación → pago espejo → abono). */
 	pagosExtras: { abonos_capital: string; cancelaciones: string };

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -2079,7 +2079,7 @@ function RouteComponent() {
 														</TableHeader>
 														<TableBody>
 															<TableRow>
-																<TableCell>Con Factura</TableCell>
+																<TableCell>Inversionista Con Factura</TableCell>
 																<TableCell className="text-right">
 																	{dash(cf.interes)}
 																</TableCell>
@@ -2093,8 +2093,8 @@ function RouteComponent() {
 																	{dash(cf.neto)}
 																</TableCell>
 															</TableRow>
-															<TableRow>
-																<TableCell>Sin Factura</TableCell>
+															<TableRow>	
+																<TableCell>Inversionista Sin Factura</TableCell>
 																<TableCell className="text-right">
 																	{dash(sf.interes)}
 																</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -2132,7 +2132,7 @@ function RouteComponent() {
 															</TableRow>
 
 															<TableRow>
-																<TableCell>CUBE</TableCell>
+																<TableCell>Residuo CUBE</TableCell>
 																<TableCell className="text-right">{dash(cube.interes)}</TableCell>
 																<TableCell className="text-right">{dash(cube.iva)}</TableCell>
 																<TableCell className="text-right text-muted-foreground">—</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -379,6 +379,8 @@ function fillMissingPeriods(
 				acum_total_membresias: "0",
 				total_interes_inversionista: "0",
 				acum_total_interes_inversionista: "0",
+				total_interes_inversionista_pagos: "0",
+				acum_total_interes_inversionista_pagos: "0",
 			}
 		);
 	});
@@ -1472,10 +1474,9 @@ function RouteComponent() {
 															const membresias = a
 																? row.acum_total_membresias
 																: row.total_membresias;
-															// Facturado real a inversionistas (neto). Por período: lo
-															const interesInversionista = a
-																? row.acum_total_interes_inversionista
-																: row.total_interes_inversionista;
+															const interesInversionistaPagos = a
+																? row.acum_total_interes_inversionista_pagos
+																: row.total_interes_inversionista_pagos;
 															const total =
 																Number.parseFloat(cuota) +
 																Number.parseFloat(interes) +
@@ -1513,7 +1514,7 @@ function RouteComponent() {
 																		{formatCurrency(membresias)}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(interesInversionista)}
+																		{formatCurrency(interesInversionistaPagos)}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		<div>{formatCurrency(row.total_mora)}</div>
@@ -1627,8 +1628,8 @@ function RouteComponent() {
 																		{formatCurrency(
 																			val(
 																				a
-																					? "acum_total_interes_inversionista"
-																					: "total_interes_inversionista",
+																					? "acum_total_interes_inversionista_pagos"
+																					: "total_interes_inversionista_pagos",
 																			),
 																		)}
 																	</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -2051,9 +2051,10 @@ function RouteComponent() {
 											const cube = reinversionData.interesNeto.cube;
 											const totalInteres =
 												Number(cf.interes) + Number(sf.interes) + Number(cube.interes);
-											const totalIva = Number(cf.iva);
+											const totalIva = Number(cf.iva) + Number(cube.iva);
 											const totalIsr = Number(sf.isr);
-											const totalNeto = Number(cf.neto) + Number(sf.neto);
+											const totalNeto =
+												Number(cf.neto) + Number(sf.neto) + Number(cube.neto);
 											return (
 												<div className={SECCION_REPORTE_CLASS}>
 													<p className="mb-2 font-semibold text-sm">
@@ -2112,9 +2113,9 @@ function RouteComponent() {
 															<TableRow>
 																<TableCell>CUBE</TableCell>
 																<TableCell className="text-right">{dash(cube.interes)}</TableCell>
+																<TableCell className="text-right">{dash(cube.iva)}</TableCell>
 																<TableCell className="text-right text-muted-foreground">—</TableCell>
-																<TableCell className="text-right text-muted-foreground">—</TableCell>
-																<TableCell className="text-right text-muted-foreground">—</TableCell>
+																<TableCell className="text-right font-semibold">{dash(cube.neto)}</TableCell>
 															</TableRow>
 															<TableRow className="border-t-2 bg-muted/50 font-bold">
 																<TableCell>Total</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from "@tanstack/react-query";
+﻿import { useMutation, useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import {
 	Activity,
@@ -2048,8 +2048,9 @@ function RouteComponent() {
 										(() => {
 											const cf = reinversionData.interesNeto.conFactura;
 											const sf = reinversionData.interesNeto.sinFactura;
+											const cube = reinversionData.interesNeto.cube;
 											const totalInteres =
-												Number(cf.interes) + Number(sf.interes);
+												Number(cf.interes) + Number(sf.interes) + Number(cube.interes);
 											const totalIva = Number(cf.iva);
 											const totalIsr = Number(sf.isr);
 											const totalNeto = Number(cf.neto) + Number(sf.neto);
@@ -2106,6 +2107,14 @@ function RouteComponent() {
 																<TableCell className="text-right font-semibold">
 																	{dash(sf.neto)}
 																</TableCell>
+															</TableRow>
+
+															<TableRow>
+																<TableCell>CUBE</TableCell>
+																<TableCell className="text-right">{dash(cube.interes)}</TableCell>
+																<TableCell className="text-right text-muted-foreground">—</TableCell>
+																<TableCell className="text-right text-muted-foreground">—</TableCell>
+																<TableCell className="text-right text-muted-foreground">—</TableCell>
 															</TableRow>
 															<TableRow className="border-t-2 bg-muted/50 font-bold">
 																<TableCell>Total</TableCell>

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -377,6 +377,8 @@ function fillMissingPeriods(
 				acum_total_seguro: "0",
 				acum_total_gps: "0",
 				acum_total_membresias: "0",
+				total_interes_inversionista: "0",
+				acum_total_interes_inversionista: "0",
 			}
 		);
 	});
@@ -1434,6 +1436,9 @@ function RouteComponent() {
 																Membresías
 															</TableHead>
 															<TableHead className="text-right">
+																Interés Inv. (referencia)
+															</TableHead>
+															<TableHead className="text-right">
 																Total Mora
 															</TableHead>
 															<TableHead className="text-right font-bold">
@@ -1467,6 +1472,10 @@ function RouteComponent() {
 															const membresias = a
 																? row.acum_total_membresias
 																: row.total_membresias;
+															// Facturado real a inversionistas (neto). Por período: lo
+															const interesInversionista = a
+																? row.acum_total_interes_inversionista
+																: row.total_interes_inversionista;
 															const total =
 																Number.parseFloat(cuota) +
 																Number.parseFloat(interes) +
@@ -1502,6 +1511,9 @@ function RouteComponent() {
 																	</TableCell>
 																	<TableCell className="text-right">
 																		{formatCurrency(membresias)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(interesInversionista)}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		<div>{formatCurrency(row.total_mora)}</div>
@@ -1608,6 +1620,15 @@ function RouteComponent() {
 																				a
 																					? "acum_total_membresias"
 																					: "total_membresias",
+																			),
+																		)}
+																	</TableCell>
+																	<TableCell className="text-right">
+																		{formatCurrency(
+																			val(
+																				a
+																					? "acum_total_interes_inversionista"
+																					: "total_interes_inversionista",
 																			),
 																		)}
 																	</TableCell>


### PR DESCRIPTION
## Parte 1 — Separación del Interés de CUBE en la tabla "Interés Neto"

Se agrega una fila **CUBE** en la sección *Interés Neto* (tab Inversiones), debajo de
"Inversionista Sin Factura" y encima del Total.

### Contexto
CUBE INVESTMENTS se comporta como un inversionista con un mecanismo especial: su porción
**no** se almacena en liquidaciones, sino que fluye por el mecanismo de `cash_in`. Es un
interés real que el dashboard debe reflejar, por lo que se **deriva** a partir de las filas
de los inversionistas no-CUBE.

### Derivación de la fórmula
```
Paso 1: CAPITAL        = abono_interes / (porcentaje_interes% × porcentaje_participacion%)
Paso 2: INTERES_CUBE   = CAPITAL × porcentaje_interes% × (100 − porcentaje_participacion%)
```
Al sustituir, la tasa (`porcentaje_interes%`) se cancela y queda:
```
INTERES_CUBE = abono_interes × (100 − porcentaje_participacion%) / porcentaje_participacion%
```
La tasa del crédito desaparece: solo se necesita el interés del inversionista y su % de
participación.

**Ejemplo** (participación 80%, interés recibido Q400, crédito al 1.5%):
```
CAPITAL  = 400 / (0.015 × 0.80) = Q33,333.33
CUBE_int = 33,333.33 × 0.015 × 0.20 = Q100
Simplificado: 400 × (100 − 80) / 80 = Q100 ✓
```

### Cómo se calcula (implementación real)
El cálculo es **por fila** (sin agrupación), sumando el complemento de cada fila:
- Maneja **pagos parciales**: cada parcial aporta su complemento y se suman.
- Respeta **reasignación** de participación entre cuotas: cada fila usa el `porcentaje_participacion`
  de su propio snapshot.
- Excluye a la propia CUBE (`inversionista_id <> 86`) y omite filas al 100% (sin complemento)
  y al 0% (evita división por cero).

> **Invariante de negocio (importante):** ningún crédito tiene 2 o más inversionistas no-CUBE
> en toda la historia; cada crédito tiene a lo sumo **un** inversionista no-CUBE y CUBE es el
> complemento implícito. Por eso el cálculo por fila es correcto y **no** se agrupa por
> (crédito/cuota): agrupar requería una clave de installment confiable (no la hay: `pe.cuota`
> guarda el **monto**, no un id) y, sumar participaciones por fila, inflaba el % (p. ej. 2 filas
> al 80% → 160%, que el filtro `< 100` descartaba). El enfoque por fila evita ambos problemas.

### Alcance
- Se calcula y muestra el **Interés de CUBE**, su **IVA 12%** (`interés × 0.12`) y su
  **Interés Neto** (`interés × 1.12`).
- **ISR** no aplica a CUBE → se muestra como "—" en esa fila.
- El **Total** de la tabla incluye el interés, IVA y neto de CUBE.

<img width="1168" height="226" alt="image" src="https://github.com/user-attachments/assets/288efb96-42e3-4c12-879e-078030483dfc" />


### Archivos
- `apps/cartera-back/src/controllers/reportes.ts` — query que deriva `interes_cube` por fila
  desde `pagos_credito_inversionistas_espejo` (excluye id 86, filtra `0 < participación < 100`);
  retornado en `interesNeto.cube` con `interes`, `iva` y `neto`.
- `apps/crm/apps/server/src/services/cartera-back-client.ts` — tipo
  `ReinversionLiquidacionesResponse.interesNeto.cube: { interes, iva, neto }`.
- `apps/crm/apps/web/src/lib/reports/scenario.ts` — mismo campo en el tipo paralelo del simulador.
- `apps/crm/apps/web/src/routes/admin/reports/index.tsx` — fila CUBE en la tabla *Interés Neto*;
  el Total suma el interés/IVA/neto de CUBE.

---

## Parte 2 — Columna "Interés Inv. (referencia)" en "Monto a Cobrarse por Período"

Agrega una columna **"Interés Inv. (referencia)"** a la tabla *Monto a Cobrarse por Período*
(tab Cobranza), ubicada entre **Membresías** y **Total Mora**. Muestra el interés facturado a
inversionistas (rubro `INTERES_INVERSIONISTAS` de `cartera.facturacion_desglose`), **neto
(sin IVA)**, agrupado por período según `fecha_aplicado_gt`.

<img width="1197" height="759" alt="Captura de pantalla 2026-06-19 114141" src="https://github.com/user-attachments/assets/90018614-fa75-4514-ab35-3bc0932dc724" />

<img width="1385" height="668" alt="Captura de pantalla 2026-06-19 114122" src="https://github.com/user-attachments/assets/f304bdee-6473-4b33-9dd9-579464fa0eef" />


### Decisiones de diseño
- **Fuente de datos:** el reporte calcula el *esperado a cobrar* desde las cuotas; esta columna
  viene de `facturacion_desglose` (*facturado real*). Son ejes distintos a propósito; la columna
  se rotula **"(referencia)"** y es informativa.
- **No se suma al Total:** ni el `total` por fila ni el `grandTotal` incluyen esta columna
  (evita doble conteo, ya que sería un subconjunto del interés).
- **Neto, sin IVA:** se usa `monto_total − monto_iva` para alinear con las demás columnas de
  interés del reporte (el IVA tiene su propia columna).
- **Por período vs Acumulado:** "Por período" = facturado en ese bucket; "Acumulado" = saldo
  corrido (suma acumulada hasta el bucket). El último bucket = gran total, igual que como la fila
  Total lee el acumulado de los demás rubros. En rangos de un solo bucket (Mes/Trimestre/Año
  puntual) ambas vistas coinciden por definición.
- **FULL JOIN (unión de buckets):** el resultado se arma desde la unión de buckets de ambas
  fuentes, para que un período con facturación a inversionistas pero **sin cuotas pendientes**
  (posible en vista día/semana) no se pierda ni subestime la columna.

### Archivos
- `apps/cartera-back/src/controllers/reportes.ts` — CTE `inv_por_bucket` (neto, por
  `fecha_aplicado_gt`), `FULL JOIN` por bucket y columnas `total_interes_inversionista` /
  `acum_total_interes_inversionista`.
- `apps/crm/apps/server/src/services/cartera-back-client.ts` y
  `apps/crm/apps/web/src/lib/reports/scenario.ts` — ambos campos en `MontoACobrarPeriodoRow`.
- `apps/crm/apps/web/src/routes/admin/reports/index.tsx` — header, celda por fila, celda en la
  fila Total y defaults en `fillMissingPeriods`.

