### PR TITLE
refactor(reportes): consolidar Interés Inv. en enfoque de pagos y eliminar código muerto

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -297,29 +297,14 @@ export async function getMontoACobrarPeriodo({
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
     ),
-    -- Interés facturado a inversionistas: rubro INTERES_INVERSIONISTAS del desglose,
-    -- NETO (monto_total - monto_iva), agrupado por la fecha en que se aplicó
-    -- (fecha_aplicado_gt). Es facturado REAL —otra fuente que el esperado de las
-    -- cuotas— por eso se muestra aparte y NO se suma al Total de la fila.
-    inv_por_bucket AS (
-      SELECT
-        DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)        AS inv_bucket,
-        COALESCE(SUM(fd.monto_total::numeric - fd.monto_iva::numeric), 0) AS total_interes_inversionista
-      FROM cartera.facturacion_desglose fd
-      WHERE fd.rubro::text = 'INTERES_INVERSIONISTAS'
-        AND fd.fecha_aplicado_gt IS NOT NULL
-        AND fd.fecha_aplicado_gt >= ${fechaInicio}::date
-        AND fd.fecha_aplicado_gt <= ${fechaFin}::date
-      GROUP BY DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)
-    ),
-    -- ENFOQUE ALTERNATIVO (en evaluación A/B, NO reemplaza al anterior): interés a
-    -- inversionistas tomado de pagos_credito_inversionistas (interés + IVA), solo de
-    -- inversionistas externos (permite_distribucion = false → se ignoran los nuestros),
-    -- agrupado por fecha_pago en zona Guatemala.
+    -- Interés a inversionistas: lo efectivamente distribuido a inversionistas EXTERNOS
+    -- (inversionistas.permite_distribucion = false → se ignoran los nuestros), tomado de
+    -- pagos_credito_inversionistas como interés + IVA (abono_interes + abono_iva_12),
+    -- agrupado por fecha_pago en zona Guatemala. Informativo: NO se suma al Total.
     inv_pagos_por_bucket AS (
       SELECT
         DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp) AS pagos_bucket,
-        COALESCE(SUM(pci.abono_interes::numeric + pci.abono_iva_12::numeric), 0)        AS total_interes_inversionista_pagos
+        COALESCE(SUM(pci.abono_interes::numeric + pci.abono_iva_12::numeric), 0)        AS total_interes_inversionista
       FROM cartera.pagos_credito_inversionistas pci
       WHERE pci.inversionista_id IN (
         SELECT inversionista_id FROM cartera.inversionistas WHERE permite_distribucion = false
@@ -329,7 +314,7 @@ export async function getMontoACobrarPeriodo({
       GROUP BY DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp)
     )
     SELECT
-      COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket) AS bucket,
+      COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) AS bucket,
       COALESCE(SUM(cuotas_count), 0)::int                                                        AS cuotas_count,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
@@ -365,23 +350,17 @@ export async function getMontoACobrarPeriodo({
         WHEN excluido_mora     THEN 0
         WHEN cuotas_atrasadas > 0 THEN acum_mem
         ELSE mem END), 0)                                                                         AS acum_total_membresias,
-      -- Interés a inversionistas (facturado REAL, neto sin IVA). Por período: lo facturado
-      -- en ese bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran
-      -- total, igual que como la fila Total lee el acumulado de los demás rubros).
-      COALESCE(MAX(ib.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
-      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista,
-      -- ENFOQUE ALTERNATIVO (A/B): interés a inversionistas desde pagos_credito_inversionistas
-      -- (interés + IVA). Mismo tratamiento por período / acumulado que el enfoque anterior.
-      COALESCE(MAX(ip.total_interes_inversionista_pagos), 0)                                      AS total_interes_inversionista_pagos,
-      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista_pagos), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista_pagos
-    -- FULL JOIN: el resultado se arma desde la unión de buckets de las fuentes, para que un
-    -- período con facturación/pagos a inversionistas pero SIN cuotas pendientes (posible en
-    -- vista día/semana) no se pierda ni subestime las columnas.
+      -- Interés a inversionistas (lo distribuido a externos). Por período: lo pagado en ese
+      -- bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran total).
+      COALESCE(MAX(ip.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
+      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista
+    -- FULL JOIN: el resultado se arma desde la unión de buckets de ambas fuentes, para que un
+    -- período con pagos a inversionistas pero SIN cuotas pendientes (posible en vista
+    -- día/semana) no se pierda ni subestime la columna.
     FROM per_bucket_credit
-    FULL JOIN inv_por_bucket ib ON ib.inv_bucket = per_bucket_credit.bucket
-    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = COALESCE(per_bucket_credit.bucket, ib.inv_bucket)
-    GROUP BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)
-    ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket) ASC
+    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = per_bucket_credit.bucket
+    GROUP BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)
+    ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) ASC
   `);
 
   return result.rows;

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -258,8 +258,6 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
-	total_interes_inversionista_pagos: string;
-	acum_total_interes_inversionista_pagos: string;
 };
 
 export type FlujoCuotasRubro = {

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -105,8 +105,6 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
-	total_interes_inversionista_pagos: string;
-	acum_total_interes_inversionista_pagos: string;
 };
 
 export type FacturacionMesRubro = {

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -379,8 +379,6 @@ function fillMissingPeriods(
 				acum_total_membresias: "0",
 				total_interes_inversionista: "0",
 				acum_total_interes_inversionista: "0",
-				total_interes_inversionista_pagos: "0",
-				acum_total_interes_inversionista_pagos: "0",
 			}
 		);
 	});
@@ -1474,9 +1472,9 @@ function RouteComponent() {
 															const membresias = a
 																? row.acum_total_membresias
 																: row.total_membresias;
-															const interesInversionistaPagos = a
-																? row.acum_total_interes_inversionista_pagos
-																: row.total_interes_inversionista_pagos;
+															const interesInversionista = a
+																? row.acum_total_interes_inversionista
+																: row.total_interes_inversionista;
 															const total =
 																Number.parseFloat(cuota) +
 																Number.parseFloat(interes) +
@@ -1514,7 +1512,7 @@ function RouteComponent() {
 																		{formatCurrency(membresias)}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(interesInversionistaPagos)}
+																		{formatCurrency(interesInversionista)}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		<div>{formatCurrency(row.total_mora)}</div>
@@ -1628,8 +1626,8 @@ function RouteComponent() {
 																		{formatCurrency(
 																			val(
 																				a
-																					? "acum_total_interes_inversionista_pagos"
-																					: "total_interes_inversionista_pagos",
+																					? "acum_total_interes_inversionista"
+																					: "total_interes_inversionista",
 																			),
 																		)}
 																	</TableCell>


### PR DESCRIPTION
## Resumen

Tras evaluar los dos enfoques para la columna **"Interés Inv. (referencia)"** de la tabla *Monto a Cobrarse por Período* (tab Cobranza), se eligió el enfoque basado en **pagos a inversionistas**. Este PR **consolida ese enfoque** y **elimina el anterior** (`facturacion_desglose`), que quedaba como código muerto.

> Nota: la columna como tal ya se introdujo en un PR previo (ya mergeado). Este PR es el **refactor de consolidación/limpieza** sobre la misma rama.

## Enfoque elegido (el que queda)

La columna muestra el interés efectivamente distribuido a los inversionistas externos:

1. **Universo de inversionistas:** de `cartera.inversionistas` se toman únicamente los que tienen `permite_distribucion = false`, es decir los inversionistas **externos** — se excluyen los inversionistas propios/internos de la operación.
2. **Monto:** para esos inversionistas se suma, desde `cartera.pagos_credito_inversionistas`, el **interés con su IVA** (`abono_interes + abono_iva_12`).
3. **Período:** se agrupa y filtra por `fecha_pago` convertida a zona horaria de Guatemala (`America/Guatemala`), para que cada monto caiga en el bucket (día/semana/mes/trimestre/año) correcto según la fecha local del pago.

Comportamiento de la columna:
- Es **informativa**: no se suma al **Total** de la fila ni al gran total (evita doble conteo).
- **Por período** muestra lo pagado a inversionistas en ese bucket; **Acumulado** muestra el saldo corrido hasta ese bucket (el último bucket = gran total).
- El resultado se arma con `FULL JOIN` sobre la unión de buckets, por lo que un período con pagos a inversionistas pero **sin cuotas pendientes** (posible en vista día/semana) igual aparece, sin subestimar la columna.

## Qué se eliminó (código muerto)

- **SQL** (`apps/cartera-back/src/controllers/reportes.ts`): se eliminó el CTE `inv_por_bucket` (que sumaba el rubro `INTERES_INVERSIONISTAS` de `facturacion_desglose`, neto), su `FULL JOIN` y sus columnas de salida. El `COALESCE` de buckets se simplificó a dos fuentes (cuotas + pagos).
- **Tipos** (`apps/crm/apps/server/src/services/cartera-back-client.ts` y `apps/crm/apps/web/src/lib/reports/scenario.ts`): se eliminaron los campos `*_pagos`.
- **UI** (`apps/crm/apps/web/src/routes/admin/reports/index.tsx`): se eliminaron los defaults `*_pagos` de `fillMissingPeriods` y los bindings duplicados.

## Renombre a nombre canónico

Como el enfoque de pagos pasó a ser el único, se quitó el sufijo `_pagos`: los campos quedan como `total_interes_inversionista` / `acum_total_interes_inversionista` (en SQL, tipos y UI). **Sin cambio funcional** en el valor mostrado.

> `facturacion_desglose` sigue usándose en otras partes legítimas (p. ej. `facturacionSnapshot.ts` y el cálculo de CUBE); solo se quitó su uso muerto dentro de `getMontoACobrarPeriodo`.

