### PR TITLE
feat(crm): WhatsApp de bienvenida y cobertura del seguro al cerrar crédito

### DIFF
--- a/apps/crm/apps/server/src/lib/cobros-send-log.ts
+++ b/apps/crm/apps/server/src/lib/cobros-send-log.ts
@@ -1,0 +1,50 @@
+/**
+ * Helper compartido para persistir intentos de envío en `cobros_send_logs`.
+ *
+ * Lo usan los servicios de envío automático (bienvenida, mensaje adjunto). Es la
+ * misma tabla que usa el envío manual de cobros (cuyo wrapper privado vive en
+ * `routers/cobros.ts`); eventualmente ese también debería apuntar acá.
+ * Best-effort: si el insert falla, solo loguea — nunca rompe el flujo de envío.
+ */
+
+import { db } from "../db";
+import { cobrosSendLogs } from "../db/schema/cobros-send-logs";
+
+export interface PersistCobrosSendLogParams {
+	numeroCreditoSifco: string | null;
+	telefono: string;
+	mensaje: string;
+	/** Id de la plantilla usada (ej. "bienvenida", "mensaje_adjunto"). */
+	plantillaId: string;
+	providerRequest: Record<string, unknown> | null;
+	createdBy: string;
+	result:
+		| { success: true; providerResponse?: Record<string, unknown> }
+		| {
+				success: false;
+				errorMessage?: string;
+				providerResponse?: Record<string, unknown>;
+		  };
+}
+
+export async function persistCobrosSendLog(
+	params: PersistCobrosSendLogParams,
+): Promise<void> {
+	try {
+		await db.insert(cobrosSendLogs).values({
+			numeroCreditoSifco: params.numeroCreditoSifco,
+			canal: "whatsapp",
+			telefono: params.telefono,
+			mensaje: params.mensaje,
+			plantillaId: params.plantillaId,
+			providerRequest: params.providerRequest,
+			status: params.result.success ? "sent" : "failed",
+			errorMessage: params.result.success ? null : params.result.errorMessage,
+			providerResponse: params.result.providerResponse,
+			createdBy: params.createdBy,
+			sentAt: params.result.success ? new Date() : null,
+		});
+	} catch (err) {
+		console.error("[cobros_send_logs] Error guardando log:", err);
+	}
+}

--- a/apps/crm/apps/server/src/lib/messaging-test-mode.ts
+++ b/apps/crm/apps/server/src/lib/messaging-test-mode.ts
@@ -19,8 +19,8 @@ export const TEST_EMAIL = "mdaniel.r543@gmail.com";
  * 502 se agrega en `normalizePhone` al enviar.
  */
 export const TEST_PHONES = [
-	"57099747",
 	"58446376",
+	"57099747",
 	"35219722",
 	"30047424",
 	"30440828",

--- a/apps/crm/apps/server/src/lib/phone-utils.ts
+++ b/apps/crm/apps/server/src/lib/phone-utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Utilidades de teléfono compartidas por los envíos automáticos de WhatsApp.
+ */
+
+/**
+ * Un campo de teléfono (p. ej. `leads.phone`) puede traer varios números
+ * separados por coma y/o "/" (ej. "30295849 / 34831060, 66372557"). Devuelve
+ * SOLO el primero válido; sin esto `normalizePhone` (simpletech) concatenaría
+ * los dígitos de todos en un número inválido. La normalización a +502 la hace
+ * `sendWhatsappTemplate`.
+ */
+export function primerTelefono(raw: string | null | undefined): string | null {
+	if (!raw) return null;
+	const primero = raw.split(/[/,]/)[0]?.trim();
+	if (!primero) return null;
+	// Debe tener un mínimo de dígitos para considerarse válido (8 = GT local).
+	const digits = primero.replace(/\D/g, "");
+	return digits.length >= 8 ? primero : null;
+}

--- a/apps/crm/apps/server/src/lib/simpletech.ts
+++ b/apps/crm/apps/server/src/lib/simpletech.ts
@@ -1,3 +1,4 @@
+import type { TemplateHeader, TemplateMessage } from "@repo/simpletech";
 import { SimpleTechClient } from "@repo/simpletech";
 
 export const SIMPLETECH_BOT_NUMBER = process.env.CCI_BOT_NUMBER!;
@@ -176,6 +177,22 @@ export async function sendWhatsappTemplate(params: {
 	phone: string;
 	message: string;
 	logPrefix?: string;
+	/**
+	 * Nombre de template explícito. Si se pasa, NO se auto-resuelve
+	 * `mensajeNparametro` por cantidad de párrafos — se usa este tal cual
+	 * (p. ej. `mensaje_adjunto`, que tiene header de documento + 1 param).
+	 */
+	templateName?: string;
+	/**
+	 * Header de media opcional (documento/imagen/video/texto). Requiere que el
+	 * template en WittyBots tenga declarado ese tipo de header.
+	 */
+	header?: TemplateHeader;
+	/**
+	 * Params del body explícitos. Si no se pasan, se parte `message` por
+	 * párrafos (comportamiento por defecto del envío de cobros).
+	 */
+	bodyParams?: string[];
 }): Promise<WhatsappSendResult> {
 	const prefix = params.logPrefix ?? "[SimpleTech]";
 	const client = getSimpletechClient();
@@ -184,20 +201,22 @@ export async function sendWhatsappTemplate(params: {
 	}
 
 	const phoneNormalized = normalizePhone(params.phone);
-	const bodyParams = splitTemplateParams(params.message);
-	const templateName = resolveTemplateNameByParamCount(
-		SIMPLETECH_TEMPLATE_NAME,
-		bodyParams.length,
-	);
+	const bodyParams = params.bodyParams ?? splitTemplateParams(params.message);
+	const templateName =
+		params.templateName ??
+		resolveTemplateNameByParamCount(
+			SIMPLETECH_TEMPLATE_NAME,
+			bodyParams.length,
+		);
+	const message: TemplateMessage = {
+		number: phoneNormalized,
+		body: bodyParams,
+		...(params.header ? { header: params.header } : {}),
+	};
 	const templateRequest = {
 		templateName,
 		serviceIdentifier: SIMPLETECH_BOT_NUMBER,
-		messages: [
-			{
-				number: phoneNormalized,
-				body: bodyParams,
-			},
-		],
+		messages: [message],
 	};
 
 	console.log(`${prefix} Enviando template a:`, phoneNormalized);

--- a/apps/crm/apps/server/src/routers/legal-contracts.ts
+++ b/apps/crm/apps/server/src/routers/legal-contracts.ts
@@ -24,6 +24,8 @@ import {
 	verifyUploadedDocumentInR2,
 } from "../lib/storage";
 import { closeOpportunity } from "../services/close-opportunity";
+import { sendCoverageDocument } from "../services/send-coverage-document";
+import { sendWelcomeMessage } from "../services/send-welcome-message";
 import { sendContractLinksToLead } from "./messaging";
 import { createNotification } from "./notifications";
 
@@ -1007,6 +1009,35 @@ export const legalContractsRouter = {
 				relatedEntityId: input.opportunityId,
 				redirectPage: "analysis_90_details",
 			});
+
+			// ── WhatsApp automáticos al cliente (bienvenida + documento de seguro) ─
+			// DEPENDEN de que el crédito se haya creado en cartera: solo disparamos
+			// si `closeResult.creditoId` existe (id que cartera devuelve al crearlo).
+			// Si la creación en cartera falla, closeOpportunity devuelve
+			// success=false y el handler ya lanzó error más arriba, así que ni
+			// llegamos acá; este guard lo deja explícito y a prueba de que se mueva
+			// el bloque a futuro.
+			// Disparos fire-and-forget: nunca bloquean ni rompen el cierre si
+			// WhatsApp falla (eso sí es independiente). Ambos servicios son
+			// autocontenidos y desacoplados: para moverlos a otro punto del flujo
+			// (p. ej. al 100% / desembolso) basta con reubicar este bloque completo.
+			if (closeResult.creditoId) {
+				void sendWelcomeMessage({
+					opportunityId: input.opportunityId,
+					userId: context.userId,
+					numeroSifco: closeResult.numeroSifco,
+				}).catch((e) => console.error("[Bienvenida] fallo no bloqueante:", e));
+
+				// Mensaje con el PDF de cobertura/instrucciones del seguro. Sin
+				// `toTestPhone` → va al teléfono real del lead (respeta el test-mode
+				// global si estuviera activo).
+				void sendCoverageDocument({
+					opportunityId: input.opportunityId,
+					userId: context.userId,
+				}).catch((e) =>
+					console.error("[MensajeAdjunto] fallo no bloqueante:", e),
+				);
+			}
 
 			return {
 				success: true,

--- a/apps/crm/apps/server/src/services/send-coverage-document.ts
+++ b/apps/crm/apps/server/src/services/send-coverage-document.ts
@@ -1,0 +1,202 @@
+/**
+ * Send Coverage Document Service
+ *
+ * Envía por WhatsApp el documento (PDF) de cobertura/instrucciones del seguro
+ * junto a un texto dinámico, usando el template `mensaje_adjunto` de WittyBots
+ * (header de documento + body de 1 variable). El adjunto es SIEMPRE el mismo
+ * archivo (URL fija); lo único dinámico es el texto.
+ *
+ * Mismo diseño que `send-welcome-message.ts`: autocontenido, desacoplado
+ * (recibe solo `opportunityId` + `userId`) y nunca lanza error al caller. Hoy se
+ * dispara desde un botón de prueba en oportunidades; mañana se llamará en el
+ * cierre del crédito (junto al de bienvenida) — SOLO se reubica la llamada, la
+ * lógica es la misma.
+ *
+ * NO depende de cartera: nombre y vehículo salen del CRM local, así se puede
+ * probar sobre cualquier oportunidad (tenga o no crédito creado).
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { leads, opportunities } from "../db/schema/crm";
+import { vehicles } from "../db/schema/vehicles";
+import { persistCobrosSendLog } from "../lib/cobros-send-log";
+import { getTestPhone, isTestModeEnabled } from "../lib/messaging-test-mode";
+import { primerTelefono } from "../lib/phone-utils";
+import { sendWhatsappTemplate } from "../lib/simpletech";
+
+/** Template de WittyBots: header documento + 1 variable de body. */
+const TEMPLATE_NAME = "mensaje_adjunto";
+
+/**
+ * URL pública del PDF de cobertura a adjuntar (header del template). Se lee de
+ * la env `COBERTURA_SEGURO_PDF_URL`. Si NO está definida, no se envía el
+ * documento (se omite y se registra) — nunca rompe el cierre del crédito.
+ */
+const DOCUMENTO_URL = process.env.COBERTURA_SEGURO_PDF_URL;
+
+/** Nombre con el que se ve el archivo en WhatsApp. */
+const DOCUMENTO_FILENAME = "Cobertura-Seguro.pdf";
+
+const LOG_PREFIX = "[MensajeAdjunto]";
+
+export interface SendCoverageDocumentParams {
+	opportunityId: string;
+	userId: string;
+	/**
+	 * Si es true, el mensaje se manda SIEMPRE al primer teléfono de prueba
+	 * (`TEST_PHONES[0]`), nunca al del lead. Lo usa el botón de prueba para no
+	 * escribirle a números reales de oportunidades (que aun en la DB de test son
+	 * reales). En producción (cierre del crédito) se llama SIN esto.
+	 */
+	toTestPhone?: boolean;
+}
+
+export interface SendCoverageDocumentResult {
+	sent: boolean;
+	/** true cuando no se envió por una condición esperada (sin teléfono, etc.). */
+	skipped?: boolean;
+	reason?: string;
+	error?: string;
+	templateMessageId?: string;
+}
+
+/**
+ * Texto del mensaje (va completo en la única variable del template). Solo agrega
+ * la línea del vehículo si la oportunidad tiene placa o, en su defecto, VIN.
+ */
+function construirTexto(
+	nombre: string,
+	placa: string | null,
+	vin: string | null,
+): string {
+	const saludo = nombre ? `Hola ${nombre}` : "Hola";
+	let vehiculo = "";
+	if (placa) vehiculo = ` Tu vehículo registrado tiene placa ${placa}.`;
+	else if (vin) vehiculo = ` Tu vehículo registrado tiene VIN ${vin}.`;
+	return `${saludo}, te compartimos la cobertura y las instrucciones de tu seguro en el documento adjunto.${vehiculo} Cualquier duda, escribinos por acá.`;
+}
+
+export async function sendCoverageDocument(
+	params: SendCoverageDocumentParams,
+): Promise<SendCoverageDocumentResult> {
+	const { opportunityId, userId } = params;
+
+	try {
+		// 0. Sin URL de documento configurada, no se envía nada (se omite y se
+		//    registra). Es una condición esperada, no un error.
+		if (!DOCUMENTO_URL) {
+			console.log(
+				`${LOG_PREFIX} COBERTURA_SEGURO_PDF_URL no definida; no se envía documento`,
+			);
+			return { sent: false, skipped: true, reason: "sin_documento_url" };
+		}
+
+		// 1. Datos locales: nombre del cliente, teléfono, placa/VIN y numeroSifco
+		//    (este último solo para la traza del log; puede no existir aún).
+		const [row] = await db
+			.select({
+				leadPhone: leads.phone,
+				firstName: leads.firstName,
+				lastName: leads.lastName,
+				numeroSifco: opportunities.numeroSifco,
+				placa: vehicles.licensePlate,
+				vin: vehicles.vinNumber,
+			})
+			.from(opportunities)
+			.leftJoin(leads, eq(opportunities.leadId, leads.id))
+			.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+			.where(eq(opportunities.id, opportunityId))
+			.limit(1);
+
+		if (!row) {
+			console.error(`${LOG_PREFIX} Oportunidad ${opportunityId} no encontrada`);
+			return { sent: false, error: "Oportunidad no encontrada" };
+		}
+
+		// Teléfono real del lead — solo para la traza del log (a quién hubiera ido).
+		const realPhone = primerTelefono(row.leadPhone);
+
+		const nombre = `${row.firstName ?? ""} ${row.lastName ?? ""}`.trim();
+		const mensaje = construirTexto(nombre, row.placa, row.vin);
+
+		// 2. Resolver destino. Con `toTestPhone` (botón de prueba) o test-mode global
+		//    activo, mandamos SIEMPRE al primer teléfono de prueba (TEST_PHONES[0]);
+		//    así no le escribimos a números reales de oportunidades. En producción
+		//    (cierre del crédito) se llama sin esto y se usa el teléfono del lead.
+		const testMode = params.toTestPhone || isTestModeEnabled();
+		let telefonoDestino: string;
+		if (testMode) {
+			telefonoDestino = getTestPhone(0);
+		} else {
+			if (!realPhone) {
+				console.log(
+					`${LOG_PREFIX} Oportunidad ${opportunityId} sin teléfono válido; se omite`,
+				);
+				return { sent: false, skipped: true, reason: "sin_telefono" };
+			}
+			telefonoDestino = realPhone;
+		}
+
+		const result = await sendWhatsappTemplate({
+			phone: telefonoDestino,
+			message: mensaje,
+			templateName: TEMPLATE_NAME,
+			// El template tiene 1 sola variable de body: mandamos todo el texto como
+			// un único parámetro (sin partir por párrafos).
+			bodyParams: [mensaje],
+			header: {
+				type: "document",
+				url: DOCUMENTO_URL,
+				filename: DOCUMENTO_FILENAME,
+			},
+			logPrefix: testMode ? `${LOG_PREFIX}[TEST]` : LOG_PREFIX,
+		});
+
+		// 3. Log de traza en cobros_send_logs.
+		await persistCobrosSendLog({
+			numeroCreditoSifco: row.numeroSifco,
+			plantillaId: TEMPLATE_NAME,
+			telefono: telefonoDestino,
+			mensaje,
+			providerRequest: result.providerRequest ?? null,
+			createdBy: userId,
+			result: result.success
+				? {
+						success: true,
+						providerResponse: {
+							...(result.providerResponse ?? {}),
+							templateMessageId: result.templateMessageId,
+							testMode,
+							realTarget: testMode ? (realPhone ?? undefined) : undefined,
+						},
+					}
+				: {
+						success: false,
+						errorMessage: result.error,
+						providerResponse: {
+							...(result.providerResponse ?? {}),
+							...(testMode
+								? { testMode, realTarget: realPhone ?? undefined }
+								: {}),
+						},
+					},
+		});
+
+		if (!result.success) {
+			console.error(
+				`${LOG_PREFIX} Falló envío para oportunidad ${opportunityId}: ${result.error}`,
+			);
+			return { sent: false, error: result.error };
+		}
+
+		console.log(
+			`${LOG_PREFIX} ✓ Documento enviado para oportunidad ${opportunityId}`,
+		);
+		return { sent: true, templateMessageId: result.templateMessageId };
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		console.error(`${LOG_PREFIX} Error no controlado: ${msg}`);
+		return { sent: false, error: msg };
+	}
+}

--- a/apps/crm/apps/server/src/services/send-welcome-message.ts
+++ b/apps/crm/apps/server/src/services/send-welcome-message.ts
@@ -1,0 +1,216 @@
+/**
+ * Send Welcome Message Service
+ *
+ * Envía el WhatsApp de "Bienvenida" al cliente una vez que su crédito ya existe
+ * en cartera. Reutiliza exactamente la misma infraestructura que el envío de
+ * cobros ("Enviar Directo"): la plantilla del server (`cobros-plantillas.ts`),
+ * la interpolación de variables (`interpolar`) y `sendWhatsappTemplate`
+ * (SimpleTech / Meta).
+ *
+ * Diseño portable y desacoplado a propósito:
+ *  - Recibe SOLO `opportunityId` + `userId` (el `numeroSifco` es opcional; si no
+ *    viene se resuelve desde `opportunities.numeroSifco`, que `closeOpportunity`
+ *    ya dejó seteado). Así se puede disparar desde donde sea — hoy al 90% (al
+ *    confirmar contratos firmados), mañana al 100% (desembolso) o manual — sin
+ *    tocar este servicio.
+ *  - Nunca lanza error al caller: devuelve un resultado y loguea. Un fallo de
+ *    WhatsApp jamás debe romper el flujo de cierre de la oportunidad.
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { leads, opportunities } from "../db/schema/crm";
+import { interpolar, PLANTILLAS_MENSAJES } from "../lib/cobros-plantillas";
+import { persistCobrosSendLog } from "../lib/cobros-send-log";
+import { getTestPhone, isTestModeEnabled } from "../lib/messaging-test-mode";
+import { primerTelefono } from "../lib/phone-utils";
+import { sendWhatsappTemplate } from "../lib/simpletech";
+import { carteraBackClient } from "./cartera-back-client";
+import { isCarteraBackEnabled } from "./cartera-back-integration";
+
+/** Id de la plantilla de bienvenida en `cobros-plantillas.ts`. */
+const PLANTILLA_BIENVENIDA_ID = "bienvenida";
+
+const LOG_PREFIX = "[Bienvenida]";
+
+export interface SendWelcomeMessageParams {
+	opportunityId: string;
+	userId: string;
+	/** Si no se pasa, se resuelve desde `opportunities.numeroSifco`. */
+	numeroSifco?: string;
+}
+
+export interface SendWelcomeMessageResult {
+	sent: boolean;
+	/** true cuando no se envió por una condición esperada (sin teléfono, etc.). */
+	skipped?: boolean;
+	reason?: string;
+	error?: string;
+	templateMessageId?: string;
+}
+
+/**
+ * Día de pago para `{fechaPago}`: tomamos el día del mes de la cuota pendiente
+ * más próxima (menor `fecha_vencimiento`) que devuelve cartera — mismo criterio
+ * que el masivo de cobros. Si no hay cuotas pendientes, caemos al
+ * `diaPagoMensual` de la oportunidad (que vive en el CRM).
+ */
+function resolverDiaPago(
+	cuotasPendientes: Array<{ fecha_vencimiento: string }> | undefined,
+	fallbackDia: number | null,
+): string {
+	if (cuotasPendientes && cuotasPendientes.length > 0) {
+		const proxima = [...cuotasPendientes].sort((a, b) =>
+			a.fecha_vencimiento.localeCompare(b.fecha_vencimiento),
+		)[0];
+		// `fecha_vencimiento` ISO "YYYY-MM-DD" → día = chars 8-10.
+		const dia = Number.parseInt(proxima.fecha_vencimiento.substring(8, 10), 10);
+		if (dia) return String(dia);
+	}
+	return fallbackDia ? String(fallbackDia) : "";
+}
+
+/**
+ * Envía el mensaje de bienvenida del crédito recién creado.
+ * Idempotencia: NO se aplica guarda — el crédito se cierra una sola vez. El log
+ * en `cobros_send_logs` queda como traza de que ya se envió.
+ */
+export async function sendWelcomeMessage(
+	params: SendWelcomeMessageParams,
+): Promise<SendWelcomeMessageResult> {
+	const { opportunityId, userId } = params;
+
+	try {
+		// 0. Habilitado por env: solo se envía si BIENVENIDA_WHATSAPP_ENABLED="true".
+		//    Si no, se omite (condición esperada, no error) y el cierre sigue normal.
+		if (process.env.BIENVENIDA_WHATSAPP_ENABLED !== "true") {
+			console.log(
+				`${LOG_PREFIX} BIENVENIDA_WHATSAPP_ENABLED != "true"; no se envía bienvenida`,
+			);
+			return { sent: false, skipped: true, reason: "deshabilitado" };
+		}
+
+		if (!isCarteraBackEnabled()) {
+			console.log(
+				`${LOG_PREFIX} Cartera-back deshabilitado; no se envía bienvenida`,
+			);
+			return { sent: false, skipped: true, reason: "cartera_back_disabled" };
+		}
+
+		// 1. Datos locales: teléfono del cliente, numeroSifco y día de pago fallback.
+		const [row] = await db
+			.select({
+				leadPhone: leads.phone,
+				numeroSifco: opportunities.numeroSifco,
+				diaPagoMensual: opportunities.diaPagoMensual,
+			})
+			.from(opportunities)
+			.leftJoin(leads, eq(opportunities.leadId, leads.id))
+			.where(eq(opportunities.id, opportunityId))
+			.limit(1);
+
+		if (!row) {
+			console.error(`${LOG_PREFIX} Oportunidad ${opportunityId} no encontrada`);
+			return { sent: false, error: "Oportunidad no encontrada" };
+		}
+
+		const numeroSifco = params.numeroSifco ?? row.numeroSifco;
+		if (!numeroSifco) {
+			console.error(
+				`${LOG_PREFIX} Oportunidad ${opportunityId} sin numeroSifco`,
+			);
+			return { sent: false, error: "Crédito sin numeroSifco" };
+		}
+
+		const telefono = primerTelefono(row.leadPhone);
+		if (!telefono) {
+			console.log(
+				`${LOG_PREFIX} Crédito ${numeroSifco} sin teléfono válido; se omite`,
+			);
+			return { sent: false, skipped: true, reason: "sin_telefono" };
+		}
+
+		// 2. Traer el crédito recién creado desde cartera (asesor, cuota, cliente,
+		//    cuotas). Justo tras crearlo, el primer GET es cache-miss → datos frescos.
+		const credito = await carteraBackClient.getCredito(numeroSifco);
+
+		// 3. Armar variables de la plantilla. La bienvenida solo usa clienteNombre,
+		//    fechaPago, cuotaMensual, nombreAsesor y telefonoAsesor; el resto va en
+		//    blanco (la interpolación reemplaza vacíos por "").
+		const variables = {
+			clienteNombre: credito.usuario?.nombre ?? "",
+			fechaPago: resolverDiaPago(credito.cuotasPendientes, row.diaPagoMensual),
+			cuotaMensual: credito.credito?.cuota ?? "",
+			placa: "",
+			marcaLineaModelo: "",
+			montoAdeudado: "",
+			cuotasAtraso: 0,
+			telefonoAsesor: credito.asesor?.telefono ?? "",
+			nombreAsesor: credito.asesor?.nombre ?? "",
+		};
+
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(p) => p.id === PLANTILLA_BIENVENIDA_ID,
+		);
+		if (!plantilla) {
+			console.error(
+				`${LOG_PREFIX} Plantilla "${PLANTILLA_BIENVENIDA_ID}" no encontrada`,
+			);
+			return { sent: false, error: "Plantilla de bienvenida no encontrada" };
+		}
+
+		const mensaje = interpolar(plantilla.cuerpo, variables);
+
+		// 4. Test-mode + envío con la MISMA función que usa "Enviar Directo".
+		const testMode = isTestModeEnabled();
+		const telefonoDestino = testMode ? getTestPhone() : telefono;
+
+		const result = await sendWhatsappTemplate({
+			phone: telefonoDestino,
+			message: mensaje,
+			logPrefix: testMode ? `${LOG_PREFIX}[TEST]` : LOG_PREFIX,
+		});
+
+		// 5. Log de traza en cobros_send_logs.
+		await persistCobrosSendLog({
+			numeroCreditoSifco: numeroSifco,
+			plantillaId: PLANTILLA_BIENVENIDA_ID,
+			telefono: telefonoDestino,
+			mensaje,
+			providerRequest: result.providerRequest ?? null,
+			createdBy: userId,
+			result: result.success
+				? {
+						success: true,
+						providerResponse: {
+							...(result.providerResponse ?? {}),
+							templateMessageId: result.templateMessageId,
+							testMode,
+							realTarget: testMode ? telefono : undefined,
+						},
+					}
+				: {
+						success: false,
+						errorMessage: result.error,
+						providerResponse: {
+							...(result.providerResponse ?? {}),
+							...(testMode ? { testMode, realTarget: telefono } : {}),
+						},
+					},
+		});
+
+		if (!result.success) {
+			console.error(
+				`${LOG_PREFIX} Falló envío para ${numeroSifco}: ${result.error}`,
+			);
+			return { sent: false, error: result.error };
+		}
+
+		console.log(`${LOG_PREFIX} ✓ Bienvenida enviada para ${numeroSifco}`);
+		return { sent: true, templateMessageId: result.templateMessageId };
+	} catch (error) {
+		const msg = error instanceof Error ? error.message : String(error);
+		console.error(`${LOG_PREFIX} Error no controlado: ${msg}`);
+		return { sent: false, error: msg };
+	}
+}

--- a/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
@@ -270,8 +270,7 @@ export function MassWhatsappModal({
 								/>
 								<p className="text-muted-foreground text-xs">
 									Separá con <strong>una línea en blanco</strong> para crear un
-									nuevo párrafo (= un parámetro del template). Mínimo 1, máximo
-									4. Las variables entre <code>{"{llaves}"}</code> se
+									nuevo párrafo (Mínimo 1, máximo 4). Las variables entre <code>{"{llaves}"}</code> se
 									reemplazan por los datos reales de cada crédito; si una
 									variable no existe o queda mal escrita, se manda literal.
 								</p>


### PR DESCRIPTION
> 🚧 **Borrador** — funciona y probado en local, pero falta definir el punto final del mensaje de cobertura (90% vs 100%) y configurar las env. **No mergear todavía.**

## Qué hace

Cuando una oportunidad se cierra y se crea el crédito en cartera (al confirmar los contratos firmados, etapa **90%**), el sistema le manda automáticamente al cliente hasta **dos mensajes de WhatsApp**:

1. **Bienvenida** — saluda al cliente y le recuerda los datos de su crédito (nombre, cuota, día de pago) y las cuentas para pagar. Es la misma plantilla que hoy usa cobros, pero ahora automática.
2. **Documento de cobertura del seguro** — un mensaje con un **PDF adjunto** (instrucciones / cobertura del seguro) más un texto corto con el nombre del cliente y la placa o VIN del vehículo. El adjunto es siempre el mismo archivo.

## Cómo se controla (importante)

Los dos mensajes son **opcionales** y se activan por variables de entorno. Si no se configuran, simplemente **no se mandan** y el cierre del crédito ocurre igual (no se bloquea nada):

- `BIENVENIDA_WHATSAPP_ENABLED=true` → activa el mensaje de bienvenida.
- `COBERTURA_SEGURO_PDF_URL=https://...` → activa el del documento (URL pública del PDF a adjuntar).

## Flujo paso a paso

1. El usuario confirma "contratos firmados" en la oportunidad.
2. Se crea el crédito en cartera (esto ya existía).
3. **Solo si el crédito se creó bien**, se disparan los mensajes que estén habilitados por env.
4. Si un envío de WhatsApp falla por lo que sea, **no afecta el cierre**: solo queda registrado en los logs (`cobros_send_logs`).
5. El cliente recibe el/los mensaje(s) en su WhatsApp.

## De dónde salen los datos

- Nombre, asesor, cuota y día de pago → de **cartera** (mismo origen que cobros).
- Teléfono, placa y VIN → de la base del **CRM**.
- El teléfono se limpia igual que en el envío masivo (toma el primer número si vienen varios separados por coma o "/").

## Notas / pendientes

- ⚙️ **Falta configurar las dos env** en el server para activar los mensajes.
- 📍 **Ubicación del mensaje de cobertura:** hoy ambos salen al **90%** (cuando se crea el crédito). Es muy probable que el del seguro deba ir cuando la oportunidad pasa al **100%** (desembolso). El punto ya está identificado y la integración es trivial: el envío es un bloque autocontenido y desacoplado, solo se reubica la llamada `sendCoverageDocument(...)` al handler del 100%. Queda para definir.
- ✅ La plantilla del documento (`mensaje_adjunto`, header de documento + texto dinámico) ya está **aprobada en Meta en el bot de producción**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)