### PR TITLE
fix(cobros): botón de contacto rápido por estado del crédito + teléfonos con "/"

### DIFF
--- a/apps/crm/apps/server/src/lib/simpletech.ts
+++ b/apps/crm/apps/server/src/lib/simpletech.ts
@@ -89,11 +89,11 @@ export function getSimpletechClient(): SimpleTechClient | null {
 }
 
 export function normalizePhone(phone: string): string {
-	// Un mismo registro puede traer varios teléfonos separados por coma
-	// (p. ej. "49289881, 25099248, 31123811"). Antes de limpiar no-dígitos
-	// nos quedamos SOLO con el primero; de lo contrario las comas se borran
-	// y los números quedan concatenados en uno inválido.
-	const primero = (phone.split(",")[0] ?? phone).trim();
+	// Un mismo registro puede traer varios teléfonos separados por coma o "/"
+	// (p. ej. "49289881, 25099248" o "46904722 / 47926862"). Antes de limpiar
+	// no-dígitos nos quedamos SOLO con el primero; de lo contrario los
+	// separadores se borran y los números quedan concatenados en uno inválido.
+	const primero = (phone.split(/[,/]/)[0] ?? phone).trim();
 	const digits = primero.replaceAll(/\D/g, "");
 	// Si ya viene en formato internacional explícito (+<código>…, p. ej. "+1…"
 	// o "+01…"), respetamos ese código de país tal cual y NO anteponemos el 502.

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -114,9 +114,10 @@ function esVehiculoPlaceholder(marca: string, modelo: string): boolean {
 
 interface GetColumnsOptions {
 	/**
-	 * Etapa de mora actualmente filtrada en la tabla. Cuando coincide con un
-	 * estado de mora (mora_30/60/90/120+), se muestra el CTA de contacto rápido
-	 * en la primera columna.
+	 * Etapa de mora actualmente filtrada en la tabla. Si el filtro ya es un
+	 * estado de mora (mora_30/60/90/120+), el CTA de contacto rápido se muestra
+	 * en TODAS las filas (no hace falta revisar una por una). Si no, se decide
+	 * por fila según el estado de mora propio de cada crédito.
 	 */
 	filtroEtapa: string | null;
 }
@@ -124,7 +125,7 @@ interface GetColumnsOptions {
 export function getCobrosColumns({
 	filtroEtapa,
 }: GetColumnsOptions): ColumnDef<ContratoCobranza>[] {
-	const mostrarCtaContacto = !!filtroEtapa && ESTADOS_MORA_CTA.has(filtroEtapa);
+	const filtroEsMora = !!filtroEtapa && ESTADOS_MORA_CTA.has(filtroEtapa);
 
 	return [
 	{
@@ -144,6 +145,15 @@ export function getCobrosColumns({
 			const fecha = row.getValue("fechaProximoPago") as string | null;
 			const dias = row.original.diasHastaPago;
 			const numeroCredito = row.original.numeroCredito;
+
+			// Si el filtro ya es un estado de mora, el botón va en todas las filas
+			// (cortocircuita sin revisar la fila). Si no, se muestra solo en las
+			// filas cuyo propio estado (estadoMora) es de mora.
+			const mostrarCtaContacto =
+				filtroEsMora ||
+				(row.original.estadoContrato === "activo" &&
+					!!row.original.estadoMora &&
+					ESTADOS_MORA_CTA.has(row.original.estadoMora));
 
 			const fechaFormateada = fecha
 				? parseFechaLocal(fecha).toLocaleDateString("es-GT", {


### PR DESCRIPTION
## Qué cambia

### 1. El botón de contacto rápido (📞) ahora aparece por estado del crédito

Antes, el botón de acceso rápido para contactar al cliente solo aparecía si el **filtro** "Etapa de Mora" estaba puesto en mora (Mora 30/60/90/120+). Si estabas en **"Todas"**, un crédito que estaba en Mora 60 **no** mostraba el botón.

Ahora el botón se decide por el **estado real de cada crédito**:
- Si el filtro **ya es de mora** → se muestra en todas las filas (igual que antes, sin revisar una por una).
- Si el filtro es **"Todas"** (o cualquier otro) → se muestra solo en las filas cuyo crédito esté en mora.

La funcionalidad del botón es la misma; solo cambia **cuándo se muestra**.

### 2. El envío masivo lee bien los teléfonos con "/"

Algunos registros traen varios teléfonos separados con **"/"** (ej. `46904722 / 47926862`), además de coma. La normalización solo separaba por coma, así que con "/" pegaba los números en uno inválido. Ahora separa por **coma y "/"**, tomando siempre el primero. Esto corrige el **envío masivo de WhatsApp** (y cualquier envío que use esa normalización).

## Notas

- Cambio chico y aislado: no toca la lógica de envío ni de la tabla más allá de lo descrito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)