### PR TITLE
fix(vehicles): align vehicle options with quoter

### DIFF
--- a/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+	VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_TYPE_OPTIONS,
+	VEHICLE_USE_OPTIONS,
+} from "./vehicle-form-options";
+
+describe("vehicle form options", () => {
+	test("matches quoter vehicle context values", () => {
+		expect(VEHICLE_TYPE_OPTIONS.map((option) => option.value)).toEqual([
+			"particular",
+			"uber",
+			"pickup",
+			"nuevo",
+			"panel",
+			"camion",
+			"microbus",
+			"microbus_20",
+			"microbus_35",
+			"microbus_36plus",
+		]);
+		expect(VEHICLE_ORIGIN_OPTIONS.map((option) => option.value)).toEqual([
+			"agencia",
+			"rodado",
+			"importado",
+			"subasta",
+			"otro",
+		]);
+		expect(VEHICLE_USE_OPTIONS.map((option) => option.value)).toEqual([
+			"Particular",
+			"Comercial",
+		]);
+	});
+});

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.ts
@@ -1,0 +1,25 @@
+export const VEHICLE_TYPE_OPTIONS = [
+	{ value: "particular", label: "Particular" },
+	{ value: "uber", label: "UBER" },
+	{ value: "pickup", label: "Pick Up" },
+	{ value: "nuevo", label: "Nuevo" },
+	{ value: "panel", label: "Panel" },
+	{ value: "camion", label: "Camión" },
+	{ value: "microbus", label: "Microbus" },
+	{ value: "microbus_20", label: "Bus hasta 20 pasajeros (RCDP)" },
+	{ value: "microbus_35", label: "Bus 21-35 pasajeros (RCDP)" },
+	{ value: "microbus_36plus", label: "Bus más de 35 pasajeros (RCDP)" },
+] as const;
+
+export const VEHICLE_ORIGIN_OPTIONS = [
+	{ value: "agencia", label: "Agencia" },
+	{ value: "rodado", label: "Rodado" },
+	{ value: "importado", label: "Importado" },
+	{ value: "subasta", label: "Subasta" },
+	{ value: "otro", label: "Otro" },
+] as const;
+
+export const VEHICLE_USE_OPTIONS = [
+	{ value: "Particular", label: "Particular" },
+	{ value: "Comercial", label: "Comercial" },
+] as const;

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -66,6 +66,10 @@ import {
 	generateQuotationPdf,
 } from "@/lib/generate-pdf";
 import { PERMISSIONS } from "@/lib/roles";
+import {
+	VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_TYPE_OPTIONS,
+} from "@/lib/vehicle-form-options";
 import { client, orpc } from "@/utils/orpc";
 
 const searchSchema = z.object({
@@ -1850,26 +1854,13 @@ function QuoterPage() {
 													<SelectTrigger>
 														<SelectValue placeholder="Seleccionar tipo..." />
 													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="particular">
-															Particular
-														</SelectItem>
-														<SelectItem value="uber">UBER</SelectItem>
-														<SelectItem value="pickup">Pick Up</SelectItem>
-														<SelectItem value="nuevo">Nuevo</SelectItem>
-														<SelectItem value="panel">Panel</SelectItem>
-														<SelectItem value="camion">Camión</SelectItem>
-														<SelectItem value="microbus">Microbus</SelectItem>
-														<SelectItem value="microbus_20">
-															Bus hasta 20 pasajeros (RCDP)
-														</SelectItem>
-														<SelectItem value="microbus_35">
-															Bus 21-35 pasajeros (RCDP)
-														</SelectItem>
-														<SelectItem value="microbus_36plus">
-															Bus más de 35 pasajeros (RCDP)
-														</SelectItem>
-													</SelectContent>
+											<SelectContent>
+												{VEHICLE_TYPE_OPTIONS.map((option) => (
+													<SelectItem key={option.value} value={option.value}>
+														{option.label}
+													</SelectItem>
+												))}
+											</SelectContent>
 												</Select>
 											</div>
 										)}
@@ -1948,13 +1939,13 @@ function QuoterPage() {
 															<SelectTrigger>
 																<SelectValue placeholder="Seleccionar origen..." />
 															</SelectTrigger>
-															<SelectContent>
-																<SelectItem value="agencia">Agencia</SelectItem>
-																<SelectItem value="rodado">Rodado</SelectItem>
-																<SelectItem value="importado">Importado</SelectItem>
-																<SelectItem value="subasta">Subasta</SelectItem>
-																<SelectItem value="otro">Otro</SelectItem>
-															</SelectContent>
+											<SelectContent>
+												{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+													<SelectItem key={option.value} value={option.value}>
+														{option.label}
+													</SelectItem>
+												))}
+											</SelectContent>
 														</Select>
 													</div>
 												);

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -84,6 +84,11 @@ import { Inspection360View } from "@/components/vehicles/inspection-360-view";
 import { VehicleDocumentUpload } from "@/components/vehicles/VehicleDocumentUpload";
 import { ROLES } from "@/lib/roles";
 import {
+	VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_TYPE_OPTIONS,
+	VEHICLE_USE_OPTIONS,
+} from "@/lib/vehicle-form-options";
+import {
 	renderInspectionStatusBadge,
 	renderNewVehicleBadges,
 } from "@/lib/vehicle-utils";
@@ -2099,23 +2104,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar tipo" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Sedan">Sedan</SelectItem>
-											<SelectItem value="Hatchback">Hatchback</SelectItem>
-											<SelectItem value="SUV">SUV</SelectItem>
-											<SelectItem value="Pickup">Pickup</SelectItem>
-											<SelectItem value="Minivan">Minivan</SelectItem>
-											<SelectItem value="Deportivo">Deportivo</SelectItem>
-											<SelectItem value="Microbus">Microbus</SelectItem>
-											<SelectItem value="Bus hasta 20 pasajeros">
-												Bus hasta 20 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus 21-35 pasajeros">
-												Bus 21-35 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus más de 35 pasajeros">
-												Bus más de 35 pasajeros
-											</SelectItem>
-											<SelectItem value="Otro">Otro</SelectItem>
+											{VEHICLE_TYPE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2131,8 +2124,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Nacional">Nacional</SelectItem>
-											<SelectItem value="Importado">Importado</SelectItem>
+											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2319,8 +2315,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Particular">Particular</SelectItem>
-											<SelectItem value="Comercial">Comercial</SelectItem>
+											{VEHICLE_USE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2601,23 +2600,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar tipo" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Sedan">Sedan</SelectItem>
-											<SelectItem value="Hatchback">Hatchback</SelectItem>
-											<SelectItem value="SUV">SUV</SelectItem>
-											<SelectItem value="Pickup">Pickup</SelectItem>
-											<SelectItem value="Minivan">Minivan</SelectItem>
-											<SelectItem value="Deportivo">Deportivo</SelectItem>
-											<SelectItem value="Microbus">Microbus</SelectItem>
-											<SelectItem value="Bus hasta 20 pasajeros">
-												Bus hasta 20 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus 21-35 pasajeros">
-												Bus 21-35 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus más de 35 pasajeros">
-												Bus más de 35 pasajeros
-											</SelectItem>
-											<SelectItem value="Otro">Otro</SelectItem>
+											{VEHICLE_TYPE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2633,8 +2620,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Nacional">Nacional</SelectItem>
-											<SelectItem value="Importado">Importado</SelectItem>
+											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2836,8 +2826,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar uso" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Particular">Particular</SelectItem>
-											<SelectItem value="Comercial">Comercial</SelectItem>
+											{VEHICLE_USE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>


### PR DESCRIPTION
## Summary
- Align vehicle create/edit options with quoter vehicle type and origin values
- Share vehicle option lists between vehicle panel and quoter
- Add a small test to prevent option drift

## Verification
- bun test apps/web/src/lib/vehicle-form-options.test.ts
- bun check-types