### PR TITLE
fix(vehicles): keep provenance separate from quoter origin

### DIFF
--- a/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
 	QUOTER_VEHICLE_TYPE_OPTIONS,
 	VEHICLE_BODY_TYPE_OPTIONS,
-	VEHICLE_ORIGIN_OPTIONS,
+	QUOTER_VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_PROVENANCE_OPTIONS,
 	VEHICLE_USE_OPTIONS,
 } from "./vehicle-form-options";
 
@@ -11,7 +12,11 @@ describe("vehicle form options", () => {
 		expect(VEHICLE_BODY_TYPE_OPTIONS.map((option) => option.value)).toContain("Sedan");
 		expect(VEHICLE_BODY_TYPE_OPTIONS.map((option) => option.value)).toContain("SUV");
 		expect(QUOTER_VEHICLE_TYPE_OPTIONS.map((option) => option.value)).toContain("particular");
-		expect(VEHICLE_ORIGIN_OPTIONS.map((option) => option.value)).toEqual([
+		expect(VEHICLE_PROVENANCE_OPTIONS.map((option) => option.value)).toEqual([
+			"Nacional",
+			"Importado",
+		]);
+		expect(QUOTER_VEHICLE_ORIGIN_OPTIONS.map((option) => option.value)).toEqual([
 			"agencia",
 			"rodado",
 			"importado",

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.ts
@@ -25,7 +25,12 @@ export const QUOTER_VEHICLE_TYPE_OPTIONS = [
 	{ value: "microbus_36plus", label: "Bus más de 35 pasajeros (RCDP)" },
 ] as const;
 
-export const VEHICLE_ORIGIN_OPTIONS = [
+export const VEHICLE_PROVENANCE_OPTIONS = [
+	{ value: "Nacional", label: "Nacional" },
+	{ value: "Importado", label: "Importado" },
+] as const;
+
+export const QUOTER_VEHICLE_ORIGIN_OPTIONS = [
 	{ value: "agencia", label: "Agencia" },
 	{ value: "rodado", label: "Rodado" },
 	{ value: "importado", label: "Importado" },

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -67,8 +67,8 @@ import {
 } from "@/lib/generate-pdf";
 import { PERMISSIONS } from "@/lib/roles";
 import {
+	QUOTER_VEHICLE_ORIGIN_OPTIONS,
 	QUOTER_VEHICLE_TYPE_OPTIONS,
-	VEHICLE_ORIGIN_OPTIONS,
 } from "@/lib/vehicle-form-options";
 import { client, orpc } from "@/utils/orpc";
 
@@ -1940,7 +1940,7 @@ function QuoterPage() {
 																<SelectValue placeholder="Seleccionar origen..." />
 															</SelectTrigger>
 												<SelectContent>
-													{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+													{QUOTER_VEHICLE_ORIGIN_OPTIONS.map((option) => (
 														<SelectItem key={option.value} value={option.value}>
 															{option.label}
 														</SelectItem>

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -85,7 +85,7 @@ import { VehicleDocumentUpload } from "@/components/vehicles/VehicleDocumentUplo
 import { ROLES } from "@/lib/roles";
 import {
 	VEHICLE_BODY_TYPE_OPTIONS,
-	VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_PROVENANCE_OPTIONS,
 	VEHICLE_USE_OPTIONS,
 } from "@/lib/vehicle-form-options";
 import {
@@ -2124,7 +2124,7 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+											{VEHICLE_PROVENANCE_OPTIONS.map((option) => (
 												<SelectItem key={option.value} value={option.value}>
 													{option.label}
 												</SelectItem>
@@ -2620,7 +2620,7 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+											{VEHICLE_PROVENANCE_OPTIONS.map((option) => (
 												<SelectItem key={option.value} value={option.value}>
 													{option.label}
 												</SelectItem>


### PR DESCRIPTION
## Summary
- Keep Vehicles dashboard saving physical provenance in vehicles.origin as Nacional/Importado
- Keep quoter origin categories separate for insurance/quoter calculations
- Preserve contract data expectations for vehicle.origin

## Verification
- bun test apps/web/src/lib/vehicle-form-options.test.ts
- bun check-types