### PR TITLE
🚀 Pase a Producción — Cobros, Vehículos/Cotizador y Reportes

### DIFF
--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -297,29 +297,14 @@ export async function getMontoACobrarPeriodo({
       FROM calc_acum
       GROUP BY DATE_TRUNC(${pg}, bucket::timestamp), credito_id
     ),
-    -- Interés facturado a inversionistas: rubro INTERES_INVERSIONISTAS del desglose,
-    -- NETO (monto_total - monto_iva), agrupado por la fecha en que se aplicó
-    -- (fecha_aplicado_gt). Es facturado REAL —otra fuente que el esperado de las
-    -- cuotas— por eso se muestra aparte y NO se suma al Total de la fila.
-    inv_por_bucket AS (
-      SELECT
-        DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)        AS inv_bucket,
-        COALESCE(SUM(fd.monto_total::numeric - fd.monto_iva::numeric), 0) AS total_interes_inversionista
-      FROM cartera.facturacion_desglose fd
-      WHERE fd.rubro::text = 'INTERES_INVERSIONISTAS'
-        AND fd.fecha_aplicado_gt IS NOT NULL
-        AND fd.fecha_aplicado_gt >= ${fechaInicio}::date
-        AND fd.fecha_aplicado_gt <= ${fechaFin}::date
-      GROUP BY DATE_TRUNC(${pg}, fd.fecha_aplicado_gt::timestamp)
-    ),
-    -- ENFOQUE ALTERNATIVO (en evaluación A/B, NO reemplaza al anterior): interés a
-    -- inversionistas tomado de pagos_credito_inversionistas (interés + IVA), solo de
-    -- inversionistas externos (permite_distribucion = false → se ignoran los nuestros),
-    -- agrupado por fecha_pago en zona Guatemala.
+    -- Interés a inversionistas: lo efectivamente distribuido a inversionistas EXTERNOS
+    -- (inversionistas.permite_distribucion = false → se ignoran los nuestros), tomado de
+    -- pagos_credito_inversionistas como interés + IVA (abono_interes + abono_iva_12),
+    -- agrupado por fecha_pago en zona Guatemala. Informativo: NO se suma al Total.
     inv_pagos_por_bucket AS (
       SELECT
         DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp) AS pagos_bucket,
-        COALESCE(SUM(pci.abono_interes::numeric + pci.abono_iva_12::numeric), 0)        AS total_interes_inversionista_pagos
+        COALESCE(SUM(pci.abono_interes::numeric + pci.abono_iva_12::numeric), 0)        AS total_interes_inversionista
       FROM cartera.pagos_credito_inversionistas pci
       WHERE pci.inversionista_id IN (
         SELECT inversionista_id FROM cartera.inversionistas WHERE permite_distribucion = false
@@ -329,7 +314,7 @@ export async function getMontoACobrarPeriodo({
       GROUP BY DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp)
     )
     SELECT
-      COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket) AS bucket,
+      COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) AS bucket,
       COALESCE(SUM(cuotas_count), 0)::int                                                        AS cuotas_count,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN exp_capital ELSE 0 END), 0)               AS total_cuota,
       COALESCE(SUM(CASE WHEN NOT excluido_factura THEN interes     ELSE 0 END), 0)               AS total_interes,
@@ -365,23 +350,17 @@ export async function getMontoACobrarPeriodo({
         WHEN excluido_mora     THEN 0
         WHEN cuotas_atrasadas > 0 THEN acum_mem
         ELSE mem END), 0)                                                                         AS acum_total_membresias,
-      -- Interés a inversionistas (facturado REAL, neto sin IVA). Por período: lo facturado
-      -- en ese bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran
-      -- total, igual que como la fila Total lee el acumulado de los demás rubros).
-      COALESCE(MAX(ib.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
-      COALESCE(SUM(COALESCE(MAX(ib.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista,
-      -- ENFOQUE ALTERNATIVO (A/B): interés a inversionistas desde pagos_credito_inversionistas
-      -- (interés + IVA). Mismo tratamiento por período / acumulado que el enfoque anterior.
-      COALESCE(MAX(ip.total_interes_inversionista_pagos), 0)                                      AS total_interes_inversionista_pagos,
-      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista_pagos), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista_pagos
-    -- FULL JOIN: el resultado se arma desde la unión de buckets de las fuentes, para que un
-    -- período con facturación/pagos a inversionistas pero SIN cuotas pendientes (posible en
-    -- vista día/semana) no se pierda ni subestime las columnas.
+      -- Interés a inversionistas (lo distribuido a externos). Por período: lo pagado en ese
+      -- bucket. Acumulado: suma corrida hasta el bucket (el último bucket = gran total).
+      COALESCE(MAX(ip.total_interes_inversionista), 0)                                            AS total_interes_inversionista,
+      COALESCE(SUM(COALESCE(MAX(ip.total_interes_inversionista), 0)) OVER (ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)), 0)   AS acum_total_interes_inversionista
+    -- FULL JOIN: el resultado se arma desde la unión de buckets de ambas fuentes, para que un
+    -- período con pagos a inversionistas pero SIN cuotas pendientes (posible en vista
+    -- día/semana) no se pierda ni subestime la columna.
     FROM per_bucket_credit
-    FULL JOIN inv_por_bucket ib ON ib.inv_bucket = per_bucket_credit.bucket
-    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = COALESCE(per_bucket_credit.bucket, ib.inv_bucket)
-    GROUP BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket)
-    ORDER BY COALESCE(per_bucket_credit.bucket, ib.inv_bucket, ip.pagos_bucket) ASC
+    FULL JOIN inv_pagos_por_bucket ip ON ip.pagos_bucket = per_bucket_credit.bucket
+    GROUP BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket)
+    ORDER BY COALESCE(per_bucket_credit.bucket, ip.pagos_bucket) ASC
   `);
 
   return result.rows;

--- a/apps/crm/apps/server/src/lib/simpletech.ts
+++ b/apps/crm/apps/server/src/lib/simpletech.ts
@@ -89,11 +89,11 @@ export function getSimpletechClient(): SimpleTechClient | null {
 }
 
 export function normalizePhone(phone: string): string {
-	// Un mismo registro puede traer varios teléfonos separados por coma
-	// (p. ej. "49289881, 25099248, 31123811"). Antes de limpiar no-dígitos
-	// nos quedamos SOLO con el primero; de lo contrario las comas se borran
-	// y los números quedan concatenados en uno inválido.
-	const primero = (phone.split(",")[0] ?? phone).trim();
+	// Un mismo registro puede traer varios teléfonos separados por coma o "/"
+	// (p. ej. "49289881, 25099248" o "46904722 / 47926862"). Antes de limpiar
+	// no-dígitos nos quedamos SOLO con el primero; de lo contrario los
+	// separadores se borran y los números quedan concatenados en uno inválido.
+	const primero = (phone.split(/[,/]/)[0] ?? phone).trim();
 	const digits = primero.replaceAll(/\D/g, "");
 	// Si ya viene en formato internacional explícito (+<código>…, p. ej. "+1…"
 	// o "+01…"), respetamos ese código de país tal cual y NO anteponemos el 502.

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -258,8 +258,6 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
-	total_interes_inversionista_pagos: string;
-	acum_total_interes_inversionista_pagos: string;
 };
 
 export type FlujoCuotasRubro = {

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -114,9 +114,10 @@ function esVehiculoPlaceholder(marca: string, modelo: string): boolean {
 
 interface GetColumnsOptions {
 	/**
-	 * Etapa de mora actualmente filtrada en la tabla. Cuando coincide con un
-	 * estado de mora (mora_30/60/90/120+), se muestra el CTA de contacto rápido
-	 * en la primera columna.
+	 * Etapa de mora actualmente filtrada en la tabla. Si el filtro ya es un
+	 * estado de mora (mora_30/60/90/120+), el CTA de contacto rápido se muestra
+	 * en TODAS las filas (no hace falta revisar una por una). Si no, se decide
+	 * por fila según el estado de mora propio de cada crédito.
 	 */
 	filtroEtapa: string | null;
 }
@@ -124,7 +125,7 @@ interface GetColumnsOptions {
 export function getCobrosColumns({
 	filtroEtapa,
 }: GetColumnsOptions): ColumnDef<ContratoCobranza>[] {
-	const mostrarCtaContacto = !!filtroEtapa && ESTADOS_MORA_CTA.has(filtroEtapa);
+	const filtroEsMora = !!filtroEtapa && ESTADOS_MORA_CTA.has(filtroEtapa);
 
 	return [
 	{
@@ -144,6 +145,15 @@ export function getCobrosColumns({
 			const fecha = row.getValue("fechaProximoPago") as string | null;
 			const dias = row.original.diasHastaPago;
 			const numeroCredito = row.original.numeroCredito;
+
+			// Si el filtro ya es un estado de mora, el botón va en todas las filas
+			// (cortocircuita sin revisar la fila). Si no, se muestra solo en las
+			// filas cuyo propio estado (estadoMora) es de mora.
+			const mostrarCtaContacto =
+				filtroEsMora ||
+				(row.original.estadoContrato === "activo" &&
+					!!row.original.estadoMora &&
+					ESTADOS_MORA_CTA.has(row.original.estadoMora));
 
 			const fechaFormateada = fecha
 				? parseFechaLocal(fecha).toLocaleDateString("es-GT", {

--- a/apps/crm/apps/web/src/lib/reports/scenario.ts
+++ b/apps/crm/apps/web/src/lib/reports/scenario.ts
@@ -105,8 +105,6 @@ export type MontoACobrarPeriodoRow = {
 	acum_total_membresias: string;
 	total_interes_inversionista: string;
 	acum_total_interes_inversionista: string;
-	total_interes_inversionista_pagos: string;
-	acum_total_interes_inversionista_pagos: string;
 };
 
 export type FacturacionMesRubro = {

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import {
+	QUOTER_VEHICLE_TYPE_OPTIONS,
+	VEHICLE_BODY_TYPE_OPTIONS,
+	VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_USE_OPTIONS,
+} from "./vehicle-form-options";
+
+describe("vehicle form options", () => {
+	test("keeps vehicle body types separate from quoter categories", () => {
+		expect(VEHICLE_BODY_TYPE_OPTIONS.map((option) => option.value)).toContain("Sedan");
+		expect(VEHICLE_BODY_TYPE_OPTIONS.map((option) => option.value)).toContain("SUV");
+		expect(QUOTER_VEHICLE_TYPE_OPTIONS.map((option) => option.value)).toContain("particular");
+		expect(VEHICLE_ORIGIN_OPTIONS.map((option) => option.value)).toEqual([
+			"agencia",
+			"rodado",
+			"importado",
+			"subasta",
+			"otro",
+		]);
+		expect(VEHICLE_USE_OPTIONS.map((option) => option.value)).toEqual([
+			"Particular",
+			"Comercial",
+		]);
+	});
+});

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import {
 	QUOTER_VEHICLE_TYPE_OPTIONS,
 	VEHICLE_BODY_TYPE_OPTIONS,
-	VEHICLE_ORIGIN_OPTIONS,
+	QUOTER_VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_PROVENANCE_OPTIONS,
 	VEHICLE_USE_OPTIONS,
 } from "./vehicle-form-options";
 
@@ -11,7 +12,11 @@ describe("vehicle form options", () => {
 		expect(VEHICLE_BODY_TYPE_OPTIONS.map((option) => option.value)).toContain("Sedan");
 		expect(VEHICLE_BODY_TYPE_OPTIONS.map((option) => option.value)).toContain("SUV");
 		expect(QUOTER_VEHICLE_TYPE_OPTIONS.map((option) => option.value)).toContain("particular");
-		expect(VEHICLE_ORIGIN_OPTIONS.map((option) => option.value)).toEqual([
+		expect(VEHICLE_PROVENANCE_OPTIONS.map((option) => option.value)).toEqual([
+			"Nacional",
+			"Importado",
+		]);
+		expect(QUOTER_VEHICLE_ORIGIN_OPTIONS.map((option) => option.value)).toEqual([
 			"agencia",
 			"rodado",
 			"importado",

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.ts
@@ -25,7 +25,12 @@ export const QUOTER_VEHICLE_TYPE_OPTIONS = [
 	{ value: "microbus_36plus", label: "Bus más de 35 pasajeros (RCDP)" },
 ] as const;
 
-export const VEHICLE_ORIGIN_OPTIONS = [
+export const VEHICLE_PROVENANCE_OPTIONS = [
+	{ value: "Nacional", label: "Nacional" },
+	{ value: "Importado", label: "Importado" },
+] as const;
+
+export const QUOTER_VEHICLE_ORIGIN_OPTIONS = [
 	{ value: "agencia", label: "Agencia" },
 	{ value: "rodado", label: "Rodado" },
 	{ value: "importado", label: "Importado" },

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.ts
@@ -1,0 +1,39 @@
+export const VEHICLE_BODY_TYPE_OPTIONS = [
+	{ value: "Sedan", label: "Sedan" },
+	{ value: "Hatchback", label: "Hatchback" },
+	{ value: "SUV", label: "SUV" },
+	{ value: "Pickup", label: "Pickup" },
+	{ value: "Minivan", label: "Minivan" },
+	{ value: "Deportivo", label: "Deportivo" },
+	{ value: "Microbus", label: "Microbus" },
+	{ value: "Bus hasta 20 pasajeros", label: "Bus hasta 20 pasajeros" },
+	{ value: "Bus 21-35 pasajeros", label: "Bus 21-35 pasajeros" },
+	{ value: "Bus más de 35 pasajeros", label: "Bus más de 35 pasajeros" },
+	{ value: "Otro", label: "Otro" },
+] as const;
+
+export const QUOTER_VEHICLE_TYPE_OPTIONS = [
+	{ value: "particular", label: "Particular" },
+	{ value: "uber", label: "UBER" },
+	{ value: "pickup", label: "Pick Up" },
+	{ value: "nuevo", label: "Nuevo" },
+	{ value: "panel", label: "Panel" },
+	{ value: "camion", label: "Camión" },
+	{ value: "microbus", label: "Microbus" },
+	{ value: "microbus_20", label: "Bus hasta 20 pasajeros (RCDP)" },
+	{ value: "microbus_35", label: "Bus 21-35 pasajeros (RCDP)" },
+	{ value: "microbus_36plus", label: "Bus más de 35 pasajeros (RCDP)" },
+] as const;
+
+export const VEHICLE_ORIGIN_OPTIONS = [
+	{ value: "agencia", label: "Agencia" },
+	{ value: "rodado", label: "Rodado" },
+	{ value: "importado", label: "Importado" },
+	{ value: "subasta", label: "Subasta" },
+	{ value: "otro", label: "Otro" },
+] as const;
+
+export const VEHICLE_USE_OPTIONS = [
+	{ value: "Particular", label: "Particular" },
+	{ value: "Comercial", label: "Comercial" },
+] as const;

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -379,8 +379,6 @@ function fillMissingPeriods(
 				acum_total_membresias: "0",
 				total_interes_inversionista: "0",
 				acum_total_interes_inversionista: "0",
-				total_interes_inversionista_pagos: "0",
-				acum_total_interes_inversionista_pagos: "0",
 			}
 		);
 	});
@@ -1474,9 +1472,9 @@ function RouteComponent() {
 															const membresias = a
 																? row.acum_total_membresias
 																: row.total_membresias;
-															const interesInversionistaPagos = a
-																? row.acum_total_interes_inversionista_pagos
-																: row.total_interes_inversionista_pagos;
+															const interesInversionista = a
+																? row.acum_total_interes_inversionista
+																: row.total_interes_inversionista;
 															const total =
 																Number.parseFloat(cuota) +
 																Number.parseFloat(interes) +
@@ -1514,7 +1512,7 @@ function RouteComponent() {
 																		{formatCurrency(membresias)}
 																	</TableCell>
 																	<TableCell className="text-right">
-																		{formatCurrency(interesInversionistaPagos)}
+																		{formatCurrency(interesInversionista)}
 																	</TableCell>
 																	<TableCell className="text-right">
 																		<div>{formatCurrency(row.total_mora)}</div>
@@ -1628,8 +1626,8 @@ function RouteComponent() {
 																		{formatCurrency(
 																			val(
 																				a
-																					? "acum_total_interes_inversionista_pagos"
-																					: "total_interes_inversionista_pagos",
+																					? "acum_total_interes_inversionista"
+																					: "total_interes_inversionista",
 																			),
 																		)}
 																	</TableCell>

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -67,8 +67,8 @@ import {
 } from "@/lib/generate-pdf";
 import { PERMISSIONS } from "@/lib/roles";
 import {
+	QUOTER_VEHICLE_ORIGIN_OPTIONS,
 	QUOTER_VEHICLE_TYPE_OPTIONS,
-	VEHICLE_ORIGIN_OPTIONS,
 } from "@/lib/vehicle-form-options";
 import { client, orpc } from "@/utils/orpc";
 
@@ -1940,7 +1940,7 @@ function QuoterPage() {
 																<SelectValue placeholder="Seleccionar origen..." />
 															</SelectTrigger>
 												<SelectContent>
-													{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+													{QUOTER_VEHICLE_ORIGIN_OPTIONS.map((option) => (
 														<SelectItem key={option.value} value={option.value}>
 															{option.label}
 														</SelectItem>

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -66,6 +66,10 @@ import {
 	generateQuotationPdf,
 } from "@/lib/generate-pdf";
 import { PERMISSIONS } from "@/lib/roles";
+import {
+	QUOTER_VEHICLE_TYPE_OPTIONS,
+	VEHICLE_ORIGIN_OPTIONS,
+} from "@/lib/vehicle-form-options";
 import { client, orpc } from "@/utils/orpc";
 
 const searchSchema = z.object({
@@ -1850,26 +1854,13 @@ function QuoterPage() {
 													<SelectTrigger>
 														<SelectValue placeholder="Seleccionar tipo..." />
 													</SelectTrigger>
-													<SelectContent>
-														<SelectItem value="particular">
-															Particular
-														</SelectItem>
-														<SelectItem value="uber">UBER</SelectItem>
-														<SelectItem value="pickup">Pick Up</SelectItem>
-														<SelectItem value="nuevo">Nuevo</SelectItem>
-														<SelectItem value="panel">Panel</SelectItem>
-														<SelectItem value="camion">Camión</SelectItem>
-														<SelectItem value="microbus">Microbus</SelectItem>
-														<SelectItem value="microbus_20">
-															Bus hasta 20 pasajeros (RCDP)
-														</SelectItem>
-														<SelectItem value="microbus_35">
-															Bus 21-35 pasajeros (RCDP)
-														</SelectItem>
-														<SelectItem value="microbus_36plus">
-															Bus más de 35 pasajeros (RCDP)
-														</SelectItem>
-													</SelectContent>
+											<SelectContent>
+												{QUOTER_VEHICLE_TYPE_OPTIONS.map((option) => (
+													<SelectItem key={option.value} value={option.value}>
+														{option.label}
+													</SelectItem>
+												))}
+											</SelectContent>
 												</Select>
 											</div>
 										)}
@@ -1948,13 +1939,13 @@ function QuoterPage() {
 															<SelectTrigger>
 																<SelectValue placeholder="Seleccionar origen..." />
 															</SelectTrigger>
-															<SelectContent>
-																<SelectItem value="agencia">Agencia</SelectItem>
-																<SelectItem value="rodado">Rodado</SelectItem>
-																<SelectItem value="importado">Importado</SelectItem>
-																<SelectItem value="subasta">Subasta</SelectItem>
-																<SelectItem value="otro">Otro</SelectItem>
-															</SelectContent>
+												<SelectContent>
+													{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+														<SelectItem key={option.value} value={option.value}>
+															{option.label}
+														</SelectItem>
+													))}
+												</SelectContent>
 														</Select>
 													</div>
 												);

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -85,7 +85,7 @@ import { VehicleDocumentUpload } from "@/components/vehicles/VehicleDocumentUplo
 import { ROLES } from "@/lib/roles";
 import {
 	VEHICLE_BODY_TYPE_OPTIONS,
-	VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_PROVENANCE_OPTIONS,
 	VEHICLE_USE_OPTIONS,
 } from "@/lib/vehicle-form-options";
 import {
@@ -2124,7 +2124,7 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+											{VEHICLE_PROVENANCE_OPTIONS.map((option) => (
 												<SelectItem key={option.value} value={option.value}>
 													{option.label}
 												</SelectItem>
@@ -2620,7 +2620,7 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+											{VEHICLE_PROVENANCE_OPTIONS.map((option) => (
 												<SelectItem key={option.value} value={option.value}>
 													{option.label}
 												</SelectItem>

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -84,6 +84,11 @@ import { Inspection360View } from "@/components/vehicles/inspection-360-view";
 import { VehicleDocumentUpload } from "@/components/vehicles/VehicleDocumentUpload";
 import { ROLES } from "@/lib/roles";
 import {
+	VEHICLE_BODY_TYPE_OPTIONS,
+	VEHICLE_ORIGIN_OPTIONS,
+	VEHICLE_USE_OPTIONS,
+} from "@/lib/vehicle-form-options";
+import {
 	renderInspectionStatusBadge,
 	renderNewVehicleBadges,
 } from "@/lib/vehicle-utils";
@@ -2099,23 +2104,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar tipo" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Sedan">Sedan</SelectItem>
-											<SelectItem value="Hatchback">Hatchback</SelectItem>
-											<SelectItem value="SUV">SUV</SelectItem>
-											<SelectItem value="Pickup">Pickup</SelectItem>
-											<SelectItem value="Minivan">Minivan</SelectItem>
-											<SelectItem value="Deportivo">Deportivo</SelectItem>
-											<SelectItem value="Microbus">Microbus</SelectItem>
-											<SelectItem value="Bus hasta 20 pasajeros">
-												Bus hasta 20 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus 21-35 pasajeros">
-												Bus 21-35 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus más de 35 pasajeros">
-												Bus más de 35 pasajeros
-											</SelectItem>
-											<SelectItem value="Otro">Otro</SelectItem>
+											{VEHICLE_BODY_TYPE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2131,8 +2124,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Nacional">Nacional</SelectItem>
-											<SelectItem value="Importado">Importado</SelectItem>
+											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2319,8 +2315,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Particular">Particular</SelectItem>
-											<SelectItem value="Comercial">Comercial</SelectItem>
+											{VEHICLE_USE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2601,23 +2600,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar tipo" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Sedan">Sedan</SelectItem>
-											<SelectItem value="Hatchback">Hatchback</SelectItem>
-											<SelectItem value="SUV">SUV</SelectItem>
-											<SelectItem value="Pickup">Pickup</SelectItem>
-											<SelectItem value="Minivan">Minivan</SelectItem>
-											<SelectItem value="Deportivo">Deportivo</SelectItem>
-											<SelectItem value="Microbus">Microbus</SelectItem>
-											<SelectItem value="Bus hasta 20 pasajeros">
-												Bus hasta 20 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus 21-35 pasajeros">
-												Bus 21-35 pasajeros
-											</SelectItem>
-											<SelectItem value="Bus más de 35 pasajeros">
-												Bus más de 35 pasajeros
-											</SelectItem>
-											<SelectItem value="Otro">Otro</SelectItem>
+											{VEHICLE_BODY_TYPE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2633,8 +2620,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar origen" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Nacional">Nacional</SelectItem>
-											<SelectItem value="Importado">Importado</SelectItem>
+											{VEHICLE_ORIGIN_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>
@@ -2836,8 +2826,11 @@ function VehiclesDashboard() {
 											<SelectValue placeholder="Seleccionar uso" />
 										</SelectTrigger>
 										<SelectContent>
-											<SelectItem value="Particular">Particular</SelectItem>
-											<SelectItem value="Comercial">Comercial</SelectItem>
+											{VEHICLE_USE_OPTIONS.map((option) => (
+												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
 										</SelectContent>
 									</Select>
 								</div>


### PR DESCRIPTION
## 🚀 Pase a Producción — Release `develop` → `main`

Release con correcciones de Cobros, Vehículos/Cotizador y Reportes.

### 📞 Cobros (CRM)
- Botón de contacto rápido en cobros ahora depende del **estado del crédito**.
- Manejo correcto de teléfonos que vienen separados con `/`.

### 🚗 Vehículos / Cotizador
- El **tipo de carrocería** (body type) se mantiene separado del cotizador, evitando que se mezclen los datos.
- Se agregan opciones de formulario de vehículo con su test correspondiente.

### 📊 Reportes
- Se eliminan los campos `total_interes_inversionista_pagos` y se actualizan los cálculos relacionados en cartera-back y en el front de reportes admin.

---

### 📦 Resumen de cambios
| Área | Detalle |
|------|---------|
| Cobros (CRM) | Contacto rápido por estado del crédito + teléfonos con `/` |
| Vehículos / Cotizador | Body type separado del cotizador + opciones de formulario |
| Reportes | Remoción de `total_interes_inversionista_pagos` y recálculo |

**Total:** 10 archivos · +159 / −127
