### PR TITLE
fix(quoter): load saved vehicle context

### DIFF
--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -1339,7 +1339,7 @@ function QuoterPage() {
 				quoterForm.setFieldValue("vehicleModel", q.vehicleModel || "");
 				const vehicleTypeToUse = normalizeVehicleTypeForQuoter(q.vehicleType);
 				quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
-				const contextMigrationCutoff = new Date("2026-06-18T18:28:53.000Z");
+				const contextMigrationCutoff = new Date("2026-06-18T16:46:51.000Z");
 				const isMigratedDefaultContext =
 					!!linkedVehicle &&
 					new Date(q.createdAt) < contextMigrationCutoff &&

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -1339,13 +1339,16 @@ function QuoterPage() {
 				quoterForm.setFieldValue("vehicleModel", q.vehicleModel || "");
 				const vehicleTypeToUse = normalizeVehicleTypeForQuoter(q.vehicleType);
 				quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
-				const hasNonDefaultSavedContext =
-					savedVehicleContext.vehicleCondition === "new" ||
-					savedVehicleContext.vehicleOrigin !== "agencia";
-				if (
-					hasNonDefaultSavedContext ||
-					(savedVehicleContext.vehicleCondition && !linkedVehicle)
-				) {
+				const contextMigrationCutoff = new Date("2026-06-18T18:28:53.000Z");
+				const isMigratedDefaultContext =
+					!!linkedVehicle &&
+					new Date(q.createdAt) < contextMigrationCutoff &&
+					savedVehicleContext.vehicleCondition === "used" &&
+					savedVehicleContext.vehicleOrigin === "agencia";
+				const hasSavedContext =
+					!!savedVehicleContext.vehicleCondition ||
+					!!savedVehicleContext.vehicleOrigin;
+				if (hasSavedContext && !isMigratedDefaultContext) {
 					quoterForm.setFieldValue(
 						"vehicleCondition",
 						savedVehicleContext.vehicleCondition ?? "used",

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -1339,9 +1339,13 @@ function QuoterPage() {
 				quoterForm.setFieldValue("vehicleModel", q.vehicleModel || "");
 				const vehicleTypeToUse = normalizeVehicleTypeForQuoter(q.vehicleType);
 				quoterForm.setFieldValue("vehicleType", vehicleTypeToUse);
-				if (linkedVehicle) {
-					applyVehicleConditionAndOrigin(linkedVehicle);
-				} else {
+				const hasNonDefaultSavedContext =
+					savedVehicleContext.vehicleCondition === "new" ||
+					savedVehicleContext.vehicleOrigin !== "agencia";
+				if (
+					hasNonDefaultSavedContext ||
+					(savedVehicleContext.vehicleCondition && !linkedVehicle)
+				) {
 					quoterForm.setFieldValue(
 						"vehicleCondition",
 						savedVehicleContext.vehicleCondition ?? "used",
@@ -1350,6 +1354,11 @@ function QuoterPage() {
 						"vehicleOrigin",
 						savedVehicleContext.vehicleOrigin ?? "agencia",
 					);
+				} else if (linkedVehicle) {
+					applyVehicleConditionAndOrigin(linkedVehicle);
+				} else {
+					quoterForm.setFieldValue("vehicleCondition", "used");
+					quoterForm.setFieldValue("vehicleOrigin", "agencia");
 				}
 				quoterForm.setFieldValue("vehicleValue", Number(q.vehicleValue) || 0);
 				quoterForm.setFieldValue("insuredAmount", Number(q.insuredAmount) || 0);


### PR DESCRIPTION
## Summary
- Prefer saved quotation vehicleCondition and vehicleOrigin when loading an existing quote
- Use linked vehicle data only as fallback when saved context is missing
- Prevent reloading linked-vehicle quotes from overwriting quoter-only context

## Verification
- bun check-types