### PR TITLE
fix(cartera): block invalid zero payment validation

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -9,7 +9,6 @@ import {
   getSpecialPaymentCuotaId,
   getSpecialPaymentInstallmentFields,
   shouldApplyStaleZeroRestanteAdjustment,
-  shouldRejectMismatchedInstallmentSelection,
   shouldRejectZeroAppliedNormalValidation,
   shouldMarkInstallmentPaymentPaid,
   sumarAplicadoACuota,
@@ -98,22 +97,6 @@ describe("register payment", () => {
         nextValidationStatus: "validated",
         montoAplicado: "0.00",
         mora: "25.00",
-      })
-    ).toBe(false);
-  });
-
-  it("rechaza request con cuotaApagar distinta al objeto numero_cuota enviado", () => {
-    expect(
-      shouldRejectMismatchedInstallmentSelection({
-        requestedInstallment: 5,
-        selectedInstallment: 10,
-      })
-    ).toBe(true);
-
-    expect(
-      shouldRejectMismatchedInstallmentSelection({
-        requestedInstallment: 5,
-        selectedInstallment: 5,
       })
     ).toBe(false);
   });

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -9,6 +9,8 @@ import {
   getSpecialPaymentCuotaId,
   getSpecialPaymentInstallmentFields,
   shouldApplyStaleZeroRestanteAdjustment,
+  shouldRejectMismatchedInstallmentSelection,
+  shouldRejectZeroAppliedNormalValidation,
   shouldMarkInstallmentPaymentPaid,
   sumarAplicadoACuota,
 } from "./registerPaymentPolicy";
@@ -66,6 +68,54 @@ describe("register payment", () => {
         installmentAmountApplied: 100,
       })
     ).toBe(true);
+  });
+
+  it("rechaza validar un pago normal sin monto aplicado", () => {
+    expect(
+      shouldRejectZeroAppliedNormalValidation({
+        validationStatus: "pending",
+        nextValidationStatus: "validated",
+        montoAplicado: "0.00",
+        mora: "0.00",
+        otros: "0",
+        pagoConvenio: "0",
+      })
+    ).toBe(true);
+  });
+
+  it("permite validar filas especiales sin monto aplicado", () => {
+    expect(
+      shouldRejectZeroAppliedNormalValidation({
+        validationStatus: "reset",
+        nextValidationStatus: "validated",
+        montoAplicado: "0.00",
+      })
+    ).toBe(false);
+
+    expect(
+      shouldRejectZeroAppliedNormalValidation({
+        validationStatus: "pending",
+        nextValidationStatus: "validated",
+        montoAplicado: "0.00",
+        mora: "25.00",
+      })
+    ).toBe(false);
+  });
+
+  it("rechaza request con cuotaApagar distinta al objeto numero_cuota enviado", () => {
+    expect(
+      shouldRejectMismatchedInstallmentSelection({
+        requestedInstallment: 5,
+        selectedInstallment: 10,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldRejectMismatchedInstallmentSelection({
+        requestedInstallment: 5,
+        selectedInstallment: 5,
+      })
+    ).toBe(false);
   });
 
   it("aplica el ajuste de restantes en cero a la primera cuota procesada aunque el request venga adelantado", () => {

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -4,6 +4,7 @@ import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
   esDestinoSobrescribible,
+  getApplyPaymentHttpStatus,
   getCuotaIdForPaymentInsert,
   getRequestedInstallmentFloor,
   getSpecialPaymentCuotaId,
@@ -99,6 +100,11 @@ describe("register payment", () => {
         mora: "25.00",
       })
     ).toBe(false);
+  });
+
+  it("mapea rechazos de regla de negocio de aplicar pago a HTTP 400", () => {
+    expect(getApplyPaymentHttpStatus({ success: false })).toBe(400);
+    expect(getApplyPaymentHttpStatus({ success: true })).toBe(200);
   });
 
   it("aplica el ajuste de restantes en cero a la primera cuota procesada aunque el request venga adelantado", () => {

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -83,6 +83,19 @@ describe("register payment", () => {
     ).toBe(true);
   });
 
+  it("rechaza revalidar un pago normal sin monto aplicado", () => {
+    expect(
+      shouldRejectZeroAppliedNormalValidation({
+        validationStatus: "pending",
+        nextValidationStatus: "validated",
+        montoAplicado: "0",
+        mora: "0",
+        otros: "0",
+        pagoConvenio: "0",
+      })
+    ).toBe(true);
+  });
+
   it("permite validar filas especiales sin monto aplicado", () => {
     expect(
       shouldRejectZeroAppliedNormalValidation({

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -29,6 +29,8 @@ import {
   getSpecialPaymentCuotaId,
   recomputeCreditAfterCapital,
   shouldApplyStaleZeroRestanteAdjustment,
+  shouldRejectMismatchedInstallmentSelection,
+  shouldRejectZeroAppliedNormalValidation,
   shouldIncobrableInstallmentBePaid,
   shouldMarkInstallmentPaymentPaid,
   sumarAplicadoACuota,
@@ -537,6 +539,25 @@ export const insertPayment = async ({ body, set }: any) => {
       fecha_boleta,
       origen_pago,
     } = parseResult.data;
+
+    const selectedInstallment = body?.numero_cuota?.numero_cuota;
+    if (
+      shouldRejectMismatchedInstallmentSelection({
+        requestedInstallment: cuotaApagar,
+        selectedInstallment:
+          typeof selectedInstallment === "number" ? selectedInstallment : null,
+      })
+    ) {
+      set.status = 400;
+      return {
+        message: "Validation failed",
+        errors: {
+          cuotaApagar: [
+            `La cuota solicitada (${cuotaApagar}) no coincide con la cuota seleccionada (${selectedInstallment})`,
+          ],
+        },
+      };
+    }
 
     // 🔒 LOCK PESIMISTA POR CRÉDITO
     // Serializa los pagos concurrentes del MISMO crédito. Sin esto, dos pagos
@@ -2216,6 +2237,21 @@ export async function aplicarPagoAlCredito(pago_id: number) {
       };
     }
 
+    if (
+      shouldRejectZeroAppliedNormalValidation({
+        validationStatus: pago.validationStatus,
+        nextValidationStatus: "validated",
+        montoAplicado: pago.monto_aplicado,
+        mora: pago.mora,
+        otros: pago.otros,
+        pagoConvenio: pago.pagoConvenio,
+      })
+    ) {
+      throw new Error(
+        `No se puede validar el pago ${pago_id}: monto_aplicado es 0.00`
+      );
+    }
+
     // 2. CARGAR EL CRÉDITO
     // (lo necesitamos tanto para evaluar si la cuota cierra como para
     // actualizar capital/deuda en ambas ramas).
@@ -3043,6 +3079,22 @@ export async function aplicarMontoAPago(pago_id: number, monto: number, fecha_pa
 
     if (!pago) {
       return { success: false, message: `Pago ${pago_id} no encontrado` };
+    }
+
+    if (
+      shouldRejectZeroAppliedNormalValidation({
+        validationStatus: pago.validationStatus,
+        nextValidationStatus: validationStatus,
+        montoAplicado: monto,
+        mora: pago.mora,
+        otros: pago.otros,
+        pagoConvenio: pago.pagoConvenio,
+      })
+    ) {
+      return {
+        success: false,
+        message: `No se puede validar el pago ${pago_id}: monto_aplicado es 0.00`,
+      };
     }
 
     // 2. Obtener restantes del pago

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2227,9 +2227,11 @@ export async function aplicarPagoAlCredito(pago_id: number) {
         pagoConvenio: pago.pagoConvenio,
       })
     ) {
-      throw new Error(
-        `No se puede validar el pago ${pago_id}: monto_aplicado es 0.00`
-      );
+      return {
+        success: false,
+        applied: false,
+        message: `No se puede validar el pago ${pago_id}: monto_aplicado es 0.00`,
+      };
     }
 
     // 2. CARGAR EL CRÉDITO

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -29,7 +29,6 @@ import {
   getSpecialPaymentCuotaId,
   recomputeCreditAfterCapital,
   shouldApplyStaleZeroRestanteAdjustment,
-  shouldRejectMismatchedInstallmentSelection,
   shouldRejectZeroAppliedNormalValidation,
   shouldIncobrableInstallmentBePaid,
   shouldMarkInstallmentPaymentPaid,
@@ -539,25 +538,6 @@ export const insertPayment = async ({ body, set }: any) => {
       fecha_boleta,
       origen_pago,
     } = parseResult.data;
-
-    const selectedInstallment = body?.numero_cuota?.numero_cuota;
-    if (
-      shouldRejectMismatchedInstallmentSelection({
-        requestedInstallment: cuotaApagar,
-        selectedInstallment:
-          typeof selectedInstallment === "number" ? selectedInstallment : null,
-      })
-    ) {
-      set.status = 400;
-      return {
-        message: "Validation failed",
-        errors: {
-          cuotaApagar: [
-            `La cuota solicitada (${cuotaApagar}) no coincide con la cuota seleccionada (${selectedInstallment})`,
-          ],
-        },
-      };
-    }
 
     // 🔒 LOCK PESIMISTA POR CRÉDITO
     // Serializa los pagos concurrentes del MISMO crédito. Sin esto, dos pagos

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3061,22 +3061,6 @@ export async function aplicarMontoAPago(pago_id: number, monto: number, fecha_pa
       return { success: false, message: `Pago ${pago_id} no encontrado` };
     }
 
-    if (
-      shouldRejectZeroAppliedNormalValidation({
-        validationStatus: pago.validationStatus,
-        nextValidationStatus: validationStatus,
-        montoAplicado: monto,
-        mora: pago.mora,
-        otros: pago.otros,
-        pagoConvenio: pago.pagoConvenio,
-      })
-    ) {
-      return {
-        success: false,
-        message: `No se puede validar el pago ${pago_id}: monto_aplicado es 0.00`,
-      };
-    }
-
     // 2. Obtener restantes del pago
     const interes_restante = new Big(pago.interes_restante ?? 0);
     const iva_restante = new Big(pago.iva_12_restante ?? 0);
@@ -3163,6 +3147,22 @@ export async function aplicarMontoAPago(pago_id: number, monto: number, fecha_pa
 
     const nuevo_monto_aplicado = totalPagado;
     const nuevo_monto_boleta = new Big(monto);
+
+    if (
+      shouldRejectZeroAppliedNormalValidation({
+        validationStatus: pago.validationStatus,
+        nextValidationStatus: validationStatus,
+        montoAplicado: nuevo_monto_aplicado,
+        mora: pago.mora,
+        otros: pago.otros,
+        pagoConvenio: pago.pagoConvenio,
+      })
+    ) {
+      return {
+        success: false,
+        message: `No se puede validar el pago ${pago_id}: monto_aplicado es 0.00`,
+      };
+    }
 
     // Fecha de pago: si viene, usarla; sino, fecha actual en hora Guatemala
     let fechaPago: Date;

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -55,17 +55,6 @@ export const shouldRejectZeroAppliedNormalValidation = ({
   );
 };
 
-export const shouldRejectMismatchedInstallmentSelection = ({
-  requestedInstallment,
-  selectedInstallment,
-}: {
-  requestedInstallment?: number | null;
-  selectedInstallment?: number | null;
-}) =>
-  selectedInstallment != null &&
-  requestedInstallment != null &&
-  selectedInstallment !== requestedInstallment;
-
 export const shouldApplyStaleZeroRestanteAdjustment = ({
   hasExistingPayment,
   isFirstProcessedInstallment,

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -55,6 +55,9 @@ export const shouldRejectZeroAppliedNormalValidation = ({
   );
 };
 
+export const getApplyPaymentHttpStatus = (result: { success?: boolean }) =>
+  result.success === false ? 400 : 200;
+
 export const shouldApplyStaleZeroRestanteAdjustment = ({
   hasExistingPayment,
   isFirstProcessedInstallment,

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -21,6 +21,51 @@ export const shouldMarkInstallmentPaymentPaid = ({
   hasExistingInstallmentPayment &&
   Number(installmentAmountApplied) > 0;
 
+export const shouldRejectZeroAppliedNormalValidation = ({
+  validationStatus,
+  nextValidationStatus,
+  montoAplicado,
+  mora = 0,
+  otros = 0,
+  pagoConvenio = 0,
+}: {
+  validationStatus?: string | null;
+  nextValidationStatus?: string | null;
+  montoAplicado?: BigInput | null;
+  mora?: BigInput | null;
+  otros?: string | number | null;
+  pagoConvenio?: BigInput | null;
+}) => {
+  if (nextValidationStatus !== "validated") return false;
+  if (["capital", "capital_validated", "reset"].includes(validationStatus ?? "")) {
+    return false;
+  }
+
+  const numericText = (v: string | number | null | undefined) => {
+    if (v == null) return "0";
+    const s = String(v).trim();
+    return /^-?\d+(\.\d+)?$/.test(s) ? s : "0";
+  };
+
+  return (
+    new Big(montoAplicado ?? 0).eq(0) &&
+    new Big(mora ?? 0).eq(0) &&
+    new Big(numericText(otros)).eq(0) &&
+    new Big(pagoConvenio ?? 0).eq(0)
+  );
+};
+
+export const shouldRejectMismatchedInstallmentSelection = ({
+  requestedInstallment,
+  selectedInstallment,
+}: {
+  requestedInstallment?: number | null;
+  selectedInstallment?: number | null;
+}) =>
+  selectedInstallment != null &&
+  requestedInstallment != null &&
+  selectedInstallment !== requestedInstallment;
+
 export const shouldApplyStaleZeroRestanteAdjustment = ({
   hasExistingPayment,
   isFirstProcessedInstallment,

--- a/apps/cartera-back/src/controllers/revalidatePayment.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.ts
@@ -5,6 +5,7 @@ import { db } from "../database";
 import { pagos_credito, creditos } from "../database/db";
 import { insertPagosCreditoInversionistasV2 } from "./payments";
 import { esPagoAplicado } from "../utils/paymentStatus";
+import { shouldRejectZeroAppliedNormalValidation } from "./registerPaymentPolicy";
 
 // ============================================================================
 // SCHEMA DE VALIDACIÓN
@@ -54,6 +55,22 @@ export const revalidatePayment = async ({ body, set }: any) => {
       
       if (esPagoAplicado(pago.validationStatus)) {
         throw new Error(`Payment ${pago_id} is already validated`);
+      }
+
+      if (
+        shouldRejectZeroAppliedNormalValidation({
+          validationStatus: pago.validationStatus,
+          nextValidationStatus: "validated",
+          montoAplicado: pago.monto_aplicado,
+          mora: pago.mora,
+          otros: pago.otros,
+          pagoConvenio: pago.pagoConvenio,
+        })
+      ) {
+        return {
+          success: false,
+          message: `No se puede revalidar el pago ${pago_id}: monto_aplicado es 0.00`,
+        };
       }
 
       console.log(`✅ Pago encontrado (Pendiente)`);
@@ -153,6 +170,11 @@ export const revalidatePayment = async ({ body, set }: any) => {
         cuota: credito.cuota
       };
     });
+
+    if ("success" in result && result.success === false) {
+      set.status = 400;
+      return result;
+    }
 
     // 8️⃣ EJECUTAR INVERSIONISTAS (fuera de la transacción para usar la función existente o asegurar que los registros se vean en la otra conexión)
     // El insertPagosCreditoInversionistasV2 ya maneja su propia forma de inserción.

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -24,6 +24,7 @@ import { processInvestors } from "../controllers/processInvestors";
 import { ajustarCuotasConSIFCO, marcarCuotasPagadasHastaNumero, procesarPagosSIFCODesdeJSON } from "../controllers/migratePayments";
 import { updateInstallments, updateAllInstallments } from "../controllers/updateCredit";
 import { esPagoAplicado } from "../utils/paymentStatus";
+import { getApplyPaymentHttpStatus } from "../controllers/registerPaymentPolicy";
 
 export const liquidatePaymentsSchema = z.object({
   pago_id: z.number().int().positive(),
@@ -537,7 +538,7 @@ export const paymentRouter = new Elysia()
       // Aplicar el pago
       const resultado = await aplicarPagoAlCredito(pagoId);
 
-      set.status = 200;
+      set.status = getApplyPaymentHttpStatus(resultado);
       return resultado;
 
     } catch (error) {


### PR DESCRIPTION
## Summary
- Blocks normal payment validation when monto_aplicado is 0.00 and there is no mora/otros/convenio amount.
- Rejects new payment requests when cuotaApagar conflicts with the selected numero_cuota payload.
- Adds regression coverage for zero-applied validation and mismatched installment selection.

## Test Plan
- [x] bun test src/controllers/registerPayment.test.ts
- [x] bunx tsc --noEmit

## Notes
- Full bun test still has pre-existing unrelated failures in latefee/reports exports.