### PR TITLE
fix(crm): allow editing vehicle condition

### DIFF
--- a/apps/crm/apps/server/src/routers/vehicles.test.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { createNewVehicleInputSchema } from "./vehicles";
+import {
+	createNewVehicleInputSchema,
+	isValidVehicleConditionOrigin,
+	mergeVehicleConditionOrigin,
+} from "./vehicles";
 
 const baseVehicleInput = {
 	make: "Toyota",
@@ -22,6 +26,36 @@ describe("createNewVehicleInputSchema", () => {
 				...baseVehicleInput,
 				vehicleIsNew: false,
 			}).vehicleIsNew,
+		).toBe(false);
+	});
+});
+
+describe("isValidVehicleConditionOrigin", () => {
+	test("allows used rodado vehicles but rejects new imported or rodado vehicles", () => {
+		expect(isValidVehicleConditionOrigin(false, "Rodado")).toBe(true);
+		expect(isValidVehicleConditionOrigin(true, "Rodado")).toBe(false);
+		expect(isValidVehicleConditionOrigin(true, "Importado")).toBe(false);
+		expect(isValidVehicleConditionOrigin(true, "Nacional")).toBe(true);
+	});
+});
+
+describe("mergeVehicleConditionOrigin", () => {
+	test("validates partial condition updates against stored values", () => {
+		const newRodado = mergeVehicleConditionOrigin(
+			{ isNew: false, origin: "Rodado" },
+			{ isNew: true },
+		);
+		const newImportado = mergeVehicleConditionOrigin(
+			{ isNew: true, origin: "Nacional" },
+			{ origin: "Importado" },
+		);
+
+		expect(newRodado).toEqual({ isNew: true, origin: "Rodado" });
+		expect(
+			isValidVehicleConditionOrigin(newRodado.isNew, newRodado.origin),
+		).toBe(false);
+		expect(
+			isValidVehicleConditionOrigin(newImportado.isNew, newImportado.origin),
 		).toBe(false);
 	});
 });

--- a/apps/crm/apps/server/src/routers/vehicles.test.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createNewVehicleInputSchema } from "./vehicles";
+
+const baseVehicleInput = {
+	make: "Toyota",
+	model: "Hilux",
+	year: 2026,
+	color: "Blanco",
+	vehicleType: "Pickup",
+};
+
+describe("createNewVehicleInputSchema", () => {
+	test("defaults omitted vehicleIsNew to true for legacy callers", () => {
+		expect(
+			createNewVehicleInputSchema.parse(baseVehicleInput).vehicleIsNew,
+		).toBe(true);
+	});
+
+	test("keeps explicitly used vehicles as false", () => {
+		expect(
+			createNewVehicleInputSchema.parse({
+				...baseVehicleInput,
+				vehicleIsNew: false,
+			}).vehicleIsNew,
+		).toBe(false);
+	});
+});

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -498,6 +498,14 @@ export const vehiclesRouter = {
 		.handler(async ({ input }) => {
 			try {
 				const { vehicleIsNew, ...vehicleInput } = input;
+				if (
+					vehicleIsNew &&
+					vehicleInput.origin?.trim().toLowerCase() === "importado"
+				) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: "Un vehículo nuevo de agencia no puede ser importado/rodado",
+					});
+				}
 				const [newVehicle] = await db
 					.insert(vehicles)
 					.values({
@@ -562,6 +570,14 @@ export const vehiclesRouter = {
 		)
 		.handler(async ({ input, context }) => {
 			try {
+				if (
+					input.data.isNew &&
+					input.data.origin?.trim().toLowerCase() === "importado"
+				) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: "Un vehículo nuevo de agencia no puede ser importado/rodado",
+					});
+				}
 				if (
 					input.data.status &&
 					!PERMISSIONS.canManageTallerVehicleStatus(context.userRole) &&

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -66,6 +66,26 @@ const ALLOWED_MIME_TYPES = [
 const MANUAL_VALUATION_COMMA_DECIMAL_PATTERN = /^\d+,\d+$/;
 const MANUAL_VALUATION_THOUSANDS_PATTERN = /^\d{1,3}(,\d{3})+(\.\d+)?$/;
 const MANUAL_VALUATION_PLAIN_NUMBER_PATTERN = /^\d+(\.\d+)?$/;
+const NEW_AGENCY_BLOCKED_ORIGINS = new Set(["importado", "rodado"]);
+
+export function isValidVehicleConditionOrigin(
+	isNew: boolean,
+	origin: string | null | undefined,
+) {
+	return !(
+		isNew && origin && NEW_AGENCY_BLOCKED_ORIGINS.has(origin.trim().toLowerCase())
+	);
+}
+
+export function mergeVehicleConditionOrigin(
+	current: { isNew: boolean; origin: string | null },
+	patch: { isNew?: boolean; origin?: string | null },
+) {
+	return {
+		isNew: patch.isNew ?? current.isNew,
+		origin: "origin" in patch ? patch.origin : current.origin,
+	};
+}
 
 const normalizeManualValuationAmount = (
 	value: string,
@@ -498,10 +518,7 @@ export const vehiclesRouter = {
 		.handler(async ({ input }) => {
 			try {
 				const { vehicleIsNew, ...vehicleInput } = input;
-				if (
-					vehicleIsNew &&
-					vehicleInput.origin?.trim().toLowerCase() === "importado"
-				) {
+				if (!isValidVehicleConditionOrigin(vehicleIsNew, vehicleInput.origin)) {
 					throw new ORPCError("BAD_REQUEST", {
 						message: "Un vehículo nuevo de agencia no puede ser importado/rodado",
 					});
@@ -570,13 +587,31 @@ export const vehiclesRouter = {
 		)
 		.handler(async ({ input, context }) => {
 			try {
-				if (
-					input.data.isNew &&
-					input.data.origin?.trim().toLowerCase() === "importado"
-				) {
-					throw new ORPCError("BAD_REQUEST", {
-						message: "Un vehículo nuevo de agencia no puede ser importado/rodado",
-					});
+				if (input.data.isNew !== undefined || input.data.origin !== undefined) {
+					const [currentVehicle] = await db
+						.select({ isNew: vehicles.isNew, origin: vehicles.origin })
+						.from(vehicles)
+						.where(eq(vehicles.id, input.id))
+						.limit(1);
+
+					if (currentVehicle) {
+						const conditionOrigin = mergeVehicleConditionOrigin(
+							currentVehicle,
+							input.data,
+						);
+
+						if (
+							!isValidVehicleConditionOrigin(
+								conditionOrigin.isNew,
+								conditionOrigin.origin,
+							)
+						) {
+							throw new ORPCError("BAD_REQUEST", {
+								message:
+									"Un vehículo nuevo de agencia no puede ser importado/rodado",
+							});
+						}
+					}
 				}
 				if (
 					input.data.status &&

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -98,6 +98,37 @@ const normalizeManualValuationAmount = (
 	return sanitized;
 };
 
+export const createNewVehicleInputSchema = z.object({
+	// Campos básicos requeridos (conocidos desde proforma)
+	make: z.string(),
+	model: z.string(),
+	year: z.number(),
+	color: z.string(),
+	vehicleType: z.string(),
+	// Campos opcionales (llegan después del dealer)
+	licensePlate: z.string().optional(),
+	vinNumber: z.string().optional(),
+	motorNumber: z.string().optional(),
+	milesMileage: z.number().nullable().optional(),
+	kmMileage: z.number().optional().default(0),
+	origin: z.string().optional(),
+	cylinders: z.string().optional(),
+	engineCC: z.string().optional(),
+	fuelType: z.string().optional(),
+	transmission: z.string().optional(),
+	companyId: z.string().nullable().optional(),
+	status: z.string().optional().default("pending"),
+	vehicleIsNew: z.boolean().optional().default(true),
+	isOwned: z.boolean().optional().default(false),
+	// Campos para contratos legales
+	seats: z.number().nullable().optional(),
+	doors: z.number().nullable().optional(),
+	axles: z.number().nullable().optional().default(2),
+	vehicleUse: z.string().nullable().optional(),
+	series: z.string().nullable().optional(),
+	iscvCode: z.string().nullable().optional(),
+});
+
 export const vehiclesRouter = {
 	// Get all vehicles with their latest inspection and photos
 	getAll: vehiclesProcedure
@@ -463,38 +494,7 @@ export const vehiclesRouter = {
 
 	// Create new vehicle (for brand new vehicles from dealer - minimal required fields)
 	createNewVehicle: protectedProcedure
-		.input(
-			z.object({
-				// Campos básicos requeridos (conocidos desde proforma)
-				make: z.string(),
-				model: z.string(),
-				year: z.number(),
-				color: z.string(),
-				vehicleType: z.string(),
-				// Campos opcionales (llegan después del dealer)
-				licensePlate: z.string().optional(),
-				vinNumber: z.string().optional(),
-				motorNumber: z.string().optional(),
-				milesMileage: z.number().nullable().optional(),
-				kmMileage: z.number().optional().default(0),
-				origin: z.string().optional(),
-				cylinders: z.string().optional(),
-				engineCC: z.string().optional(),
-				fuelType: z.string().optional(),
-				transmission: z.string().optional(),
-				companyId: z.string().nullable().optional(),
-				status: z.string().optional().default("pending"),
-				vehicleIsNew: z.boolean().optional().default(false),
-				isOwned: z.boolean().optional().default(false),
-				// Campos para contratos legales
-				seats: z.number().nullable().optional(),
-				doors: z.number().nullable().optional(),
-				axles: z.number().nullable().optional().default(2),
-				vehicleUse: z.string().nullable().optional(),
-				series: z.string().nullable().optional(),
-				iscvCode: z.string().nullable().optional(),
-			}),
-		)
+		.input(createNewVehicleInputSchema)
 		.handler(async ({ input }) => {
 			try {
 				const { vehicleIsNew, ...vehicleInput } = input;
@@ -1078,7 +1078,7 @@ export const vehiclesRouter = {
 						),
 					)
 					.limit(1);
-				
+
 				foundVehicle = existingWithPlate[0] || null;
 			}
 
@@ -1098,7 +1098,7 @@ export const vehiclesRouter = {
 						),
 					)
 					.limit(1);
-				
+
 				foundVehicle = existingWithVin[0] || null;
 			}
 
@@ -1312,7 +1312,7 @@ export const vehiclesRouter = {
 							})
 							.where(eq(vehicles.id, vehicleInputId))
 							.returning();
-						
+
 						if (updated) {
 							vehicleId = updated.id;
 						} else {

--- a/apps/crm/apps/server/src/routers/vehicles.ts
+++ b/apps/crm/apps/server/src/routers/vehicles.ts
@@ -484,6 +484,7 @@ export const vehiclesRouter = {
 				transmission: z.string().optional(),
 				companyId: z.string().nullable().optional(),
 				status: z.string().optional().default("pending"),
+				vehicleIsNew: z.boolean().optional().default(false),
 				isOwned: z.boolean().optional().default(false),
 				// Campos para contratos legales
 				seats: z.number().nullable().optional(),
@@ -496,12 +497,13 @@ export const vehiclesRouter = {
 		)
 		.handler(async ({ input }) => {
 			try {
+				const { vehicleIsNew, ...vehicleInput } = input;
 				const [newVehicle] = await db
 					.insert(vehicles)
 					.values({
-						...input,
-						isNew: true, // Siempre es vehículo nuevo
-						kmMileage: input.kmMileage ?? 0, // Default 0 para nuevos
+						...vehicleInput,
+						isNew: vehicleIsNew,
+						kmMileage: vehicleInput.kmMileage ?? 0, // Default 0 para nuevos
 					} as NewVehicle)
 					.returning();
 

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
@@ -35,10 +35,12 @@ describe("vehicle form options", () => {
 		]);
 	});
 
-	test("allows used national and imported vehicles but not new imported vehicles", () => {
+	test("allows used imported/rodado vehicles but rejects new imported/rodado vehicles", () => {
 		expect(isValidVehicleConditionOrigin(false, "Nacional")).toBe(true);
 		expect(isValidVehicleConditionOrigin(false, "Importado")).toBe(true);
+		expect(isValidVehicleConditionOrigin(false, "Rodado")).toBe(true);
 		expect(isValidVehicleConditionOrigin(true, "Nacional")).toBe(true);
 		expect(isValidVehicleConditionOrigin(true, "Importado")).toBe(false);
+		expect(isValidVehicleConditionOrigin(true, "Rodado")).toBe(false);
 	});
 });

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	QUOTER_VEHICLE_TYPE_OPTIONS,
 	VEHICLE_BODY_TYPE_OPTIONS,
+	VEHICLE_CONDITION_OPTIONS,
 	QUOTER_VEHICLE_ORIGIN_OPTIONS,
 	VEHICLE_PROVENANCE_OPTIONS,
 	VEHICLE_USE_OPTIONS,
@@ -26,6 +27,10 @@ describe("vehicle form options", () => {
 		expect(VEHICLE_USE_OPTIONS.map((option) => option.value)).toEqual([
 			"Particular",
 			"Comercial",
+		]);
+		expect(VEHICLE_CONDITION_OPTIONS).toEqual([
+			{ value: false, label: "Usado / rodado" },
+			{ value: true, label: "Nuevo de agencia" },
 		]);
 	});
 });

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.test.ts
@@ -6,6 +6,7 @@ import {
 	QUOTER_VEHICLE_ORIGIN_OPTIONS,
 	VEHICLE_PROVENANCE_OPTIONS,
 	VEHICLE_USE_OPTIONS,
+	isValidVehicleConditionOrigin,
 } from "./vehicle-form-options";
 
 describe("vehicle form options", () => {
@@ -29,8 +30,15 @@ describe("vehicle form options", () => {
 			"Comercial",
 		]);
 		expect(VEHICLE_CONDITION_OPTIONS).toEqual([
-			{ value: false, label: "Usado / rodado" },
+			{ value: false, label: "Usado" },
 			{ value: true, label: "Nuevo de agencia" },
 		]);
+	});
+
+	test("allows used national and imported vehicles but not new imported vehicles", () => {
+		expect(isValidVehicleConditionOrigin(false, "Nacional")).toBe(true);
+		expect(isValidVehicleConditionOrigin(false, "Importado")).toBe(true);
+		expect(isValidVehicleConditionOrigin(true, "Nacional")).toBe(true);
+		expect(isValidVehicleConditionOrigin(true, "Importado")).toBe(false);
 	});
 });

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.ts
@@ -35,8 +35,10 @@ export const VEHICLE_CONDITION_OPTIONS = [
 	{ value: true, label: "Nuevo de agencia" },
 ] as const;
 
+const NEW_AGENCY_BLOCKED_ORIGINS = new Set(["importado", "rodado"]);
+
 export function isValidVehicleConditionOrigin(isNew: boolean, origin: string) {
-	return !(isNew && origin.trim().toLowerCase() === "importado");
+	return !(isNew && NEW_AGENCY_BLOCKED_ORIGINS.has(origin.trim().toLowerCase()));
 }
 
 export const QUOTER_VEHICLE_ORIGIN_OPTIONS = [

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.ts
@@ -31,9 +31,13 @@ export const VEHICLE_PROVENANCE_OPTIONS = [
 ] as const;
 
 export const VEHICLE_CONDITION_OPTIONS = [
-	{ value: false, label: "Usado / rodado" },
+	{ value: false, label: "Usado" },
 	{ value: true, label: "Nuevo de agencia" },
 ] as const;
+
+export function isValidVehicleConditionOrigin(isNew: boolean, origin: string) {
+	return !(isNew && origin.trim().toLowerCase() === "importado");
+}
 
 export const QUOTER_VEHICLE_ORIGIN_OPTIONS = [
 	{ value: "agencia", label: "Agencia" },

--- a/apps/crm/apps/web/src/lib/vehicle-form-options.ts
+++ b/apps/crm/apps/web/src/lib/vehicle-form-options.ts
@@ -30,6 +30,11 @@ export const VEHICLE_PROVENANCE_OPTIONS = [
 	{ value: "Importado", label: "Importado" },
 ] as const;
 
+export const VEHICLE_CONDITION_OPTIONS = [
+	{ value: false, label: "Usado / rodado" },
+	{ value: true, label: "Nuevo de agencia" },
+] as const;
+
 export const QUOTER_VEHICLE_ORIGIN_OPTIONS = [
 	{ value: "agencia", label: "Agencia" },
 	{ value: "rodado", label: "Rodado" },

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -85,6 +85,7 @@ import { VehicleDocumentUpload } from "@/components/vehicles/VehicleDocumentUplo
 import { ROLES } from "@/lib/roles";
 import {
 	VEHICLE_BODY_TYPE_OPTIONS,
+	VEHICLE_CONDITION_OPTIONS,
 	VEHICLE_PROVENANCE_OPTIONS,
 	VEHICLE_USE_OPTIONS,
 } from "@/lib/vehicle-form-options";
@@ -311,6 +312,7 @@ function VehiclesDashboard() {
 		fuelType: "",
 		transmission: "",
 		kmMileage: 0,
+		isNew: false,
 		isOwned: false,
 		// Datos técnicos para contratos
 		seats: null as number | null,
@@ -359,6 +361,7 @@ function VehiclesDashboard() {
 				fuelType: data.fuelType || undefined,
 				transmission: data.transmission || undefined,
 				kmMileage: data.kmMileage ?? undefined,
+				vehicleIsNew: data.isNew,
 				isOwned: data.isOwned,
 				seats: data.seats ?? undefined,
 				doors: data.doors ?? undefined,
@@ -368,7 +371,7 @@ function VehiclesDashboard() {
 				iscvCode: data.iscvCode || undefined,
 			}),
 		onSuccess: () => {
-			toast.success("Vehículo nuevo creado exitosamente");
+			toast.success("Vehículo creado exitosamente");
 			queryClient.invalidateQueries({ queryKey: ["getVehicles"] });
 			queryClient.invalidateQueries({ queryKey: ["getVehicleStatistics"] });
 			setIsNewVehicleOpen(false);
@@ -385,6 +388,7 @@ function VehiclesDashboard() {
 				fuelType: "",
 				transmission: "",
 				kmMileage: 0,
+				isNew: false,
 				isOwned: false,
 				seats: null,
 				doors: null,
@@ -449,6 +453,7 @@ function VehiclesDashboard() {
 					fuelType: data.fuelType || null,
 					transmission: data.transmission || null,
 					kmMileage: data.kmMileage,
+					isNew: data.isNew,
 					isOwned: data.isOwned,
 					status: data.status,
 					// Campos para contratos legales
@@ -497,7 +502,7 @@ function VehiclesDashboard() {
 				<h1 className="font-bold text-4xl">Panel de Vehículos</h1>
 				<Button onClick={() => setIsNewVehicleOpen(true)}>
 					<Plus className="mr-2 h-4 w-4" />
-					Nuevo Vehículo
+					Registrar Vehículo
 				</Button>
 			</div>
 
@@ -1992,16 +1997,16 @@ function VehiclesDashboard() {
 				</DialogContent>
 			</Dialog>
 
-			{/* Dialog para crear vehículo nuevo */}
+			{/* Dialog para crear vehículo */}
 			<Dialog open={isNewVehicleOpen} onOpenChange={setIsNewVehicleOpen}>
 				<DialogContent className="max-h-[90vh] max-w-4xl overflow-y-auto">
 					<DialogHeader>
 						<DialogTitle className="flex items-center gap-2">
 							<Sparkles className="h-5 w-5 text-blue-500" />
-							Registrar Vehículo Nuevo
+							Registrar Vehículo
 						</DialogTitle>
 						<DialogDescription>
-							Los campos con * son requeridos. El resto puede completarse después.
+							Selecciona si es usado/rodado o nuevo de agencia. Los campos con * son requeridos.
 						</DialogDescription>
 					</DialogHeader>
 
@@ -2106,6 +2111,29 @@ function VehiclesDashboard() {
 										<SelectContent>
 											{VEHICLE_BODY_TYPE_OPTIONS.map((option) => (
 												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="vehicleCondition">Condición *</Label>
+									<Select
+										value={String(newVehicleForm.isNew)}
+										onValueChange={(value) =>
+											setNewVehicleForm({
+												...newVehicleForm,
+												isNew: value === "true",
+											})
+										}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="Seleccionar condición" />
+										</SelectTrigger>
+										<SelectContent>
+											{VEHICLE_CONDITION_OPTIONS.map((option) => (
+												<SelectItem key={String(option.value)} value={String(option.value)}>
 													{option.label}
 												</SelectItem>
 											))}
@@ -2602,6 +2630,29 @@ function VehiclesDashboard() {
 										<SelectContent>
 											{VEHICLE_BODY_TYPE_OPTIONS.map((option) => (
 												<SelectItem key={option.value} value={option.value}>
+													{option.label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="space-y-2">
+									<Label htmlFor="edit-vehicleCondition">Condición *</Label>
+									<Select
+										value={String(editVehicleForm.isNew)}
+										onValueChange={(value) =>
+											setEditVehicleForm({
+												...editVehicleForm,
+												isNew: value === "true",
+											})
+										}
+									>
+										<SelectTrigger>
+											<SelectValue placeholder="Seleccionar condición" />
+										</SelectTrigger>
+										<SelectContent>
+											{VEHICLE_CONDITION_OPTIONS.map((option) => (
+												<SelectItem key={String(option.value)} value={String(option.value)}>
 													{option.label}
 												</SelectItem>
 											))}

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -84,6 +84,7 @@ import { Inspection360View } from "@/components/vehicles/inspection-360-view";
 import { VehicleDocumentUpload } from "@/components/vehicles/VehicleDocumentUpload";
 import { ROLES } from "@/lib/roles";
 import {
+	isValidVehicleConditionOrigin,
 	VEHICLE_BODY_TYPE_OPTIONS,
 	VEHICLE_CONDITION_OPTIONS,
 	VEHICLE_PROVENANCE_OPTIONS,
@@ -2022,6 +2023,17 @@ function VehiclesDashboard() {
 								toast.error("Por favor completa todos los campos requeridos");
 								return;
 							}
+							if (
+								!isValidVehicleConditionOrigin(
+									newVehicleForm.isNew,
+									newVehicleForm.origin,
+								)
+							) {
+								toast.error(
+									"Un vehículo nuevo de agencia no puede ser importado/rodado",
+								);
+								return;
+							}
 							createNewVehicleMutation.mutate(newVehicleForm);
 						}}
 						className="space-y-5"
@@ -2453,6 +2465,17 @@ function VehiclesDashboard() {
 								!editVehicleForm.vehicleType
 							) {
 								toast.error("Por favor completa todos los campos requeridos");
+								return;
+							}
+							if (
+								!isValidVehicleConditionOrigin(
+									editVehicleForm.isNew,
+									editVehicleForm.origin,
+								)
+							) {
+								toast.error(
+									"Un vehículo nuevo de agencia no puede ser importado/rodado",
+								);
 								return;
 							}
 							updateVehicleMutation.mutate(editVehicleForm);


### PR DESCRIPTION
## Summary
- add vehicle condition selection when registering a vehicle
- allow editing whether a vehicle is used/rodado or new from agency
- stop forcing registered vehicles through this modal to be new

## Checks
- bun run check-all
- bun test apps/web/src/lib/vehicle-form-options.test.ts