### PR TITLE
fix(crm): GyT solo si es más barato + sin doble conteo del ahorro; seed desde R2

### DIFF
--- a/apps/crm/apps/server/src/db/seed-gyt-insurance.ts
+++ b/apps/crm/apps/server/src/db/seed-gyt-insurance.ts
@@ -1,10 +1,13 @@
 import { sql } from "drizzle-orm";
 import * as XLSX from "xlsx";
+import { getFileBuffer } from "../lib/storage";
 import { db } from "./index";
 import { gytInsuranceCosts } from "./schema";
 
-const DEFAULT_WORKBOOK_PATH =
-	"/home/lralda/Downloads/LISTADO DE PRECIOS Y COMPARATIVO - CASH IN - Junio 2026 Final.xlsx";
+// Key del Excel de tarifas GyT en R2 (bucket por defecto de storage).
+// Subir el archivo a R2 bajo esta key, o sobreescribir con GYT_INSURANCE_XLSX_KEY.
+const DEFAULT_WORKBOOK_KEY =
+	"Precios junio 2026 (valor Universales actualizado).xlsx";
 
 type GytInsuranceRow = {
 	price: number;
@@ -53,9 +56,10 @@ function readGytRows(
 }
 
 async function seedGytInsurance() {
-	const workbookPath =
-		process.env.GYT_INSURANCE_XLSX_PATH ?? DEFAULT_WORKBOOK_PATH;
-	const workbook = XLSX.readFile(workbookPath);
+	const workbookKey =
+		process.env.GYT_INSURANCE_XLSX_KEY ?? DEFAULT_WORKBOOK_KEY;
+	const buffer = await getFileBuffer(workbookKey);
+	const workbook = XLSX.read(buffer, { type: "buffer" });
 	const automovilRows = readGytRows(
 		workbook,
 		"AUTOMOVIL - CAMIONETA",
@@ -96,7 +100,9 @@ async function seedGytInsurance() {
 		processed++;
 	}
 
-	console.log(`Tarifas GyT cargadas: ${processed} filas desde ${workbookPath}`);
+	console.log(
+		`Tarifas GyT cargadas: ${processed} filas desde R2 (${workbookKey})`,
+	);
 }
 
 seedGytInsurance()

--- a/apps/crm/apps/server/src/lib/insurance-selection.test.ts
+++ b/apps/crm/apps/server/src/lib/insurance-selection.test.ts
@@ -123,7 +123,7 @@ describe("selectInsuranceProvider", () => {
 		expect(result.provider).toBe("universales");
 	});
 
-	test("uses GyT by approved range even when GyT is not cheaper", () => {
+	test("keeps Universales in the approved range when GyT is NOT cheaper", () => {
 		const result = selectInsuranceProvider({
 			insuredAmount: 189000,
 			vehicleType: "particular",
@@ -132,9 +132,9 @@ describe("selectInsuranceProvider", () => {
 			membershipCost: 100,
 		});
 
-		expect(result.provider).toBe("gyt");
+		expect(result.provider).toBe("universales");
 		expect(result.customerInsuranceCost).toBe(584);
-		expect(result.internalInsuranceCost).toBe(585);
+		expect(result.internalInsuranceCost).toBe(584);
 		expect(result.insuranceSavingsToMembership).toBe(0);
 	});
 });
@@ -194,7 +194,8 @@ describe("buildServerInsurancePersistence", () => {
 		expect(result.customerInsuranceCost).toBe("585.86");
 		expect(result.internalInsuranceCost).toBe("584.96");
 		expect(result.insuranceSavingsToMembership).toBe("0.90");
-		expect(result.membresiaPago).toBe("100.90");
+		// El server ya no re-suma el ahorro a la membresía (lo hace el front una vez).
+		expect(result.membresiaPago).toBe("100.00");
 	});
 
 	test("uses visible quoter insurance as customer amount when provided", () => {
@@ -202,7 +203,7 @@ describe("buildServerInsurancePersistence", () => {
 			insuredAmount: 189000,
 			vehicleType: "particular",
 			universalesCost: 550.1,
-			gytCost: 584.96,
+			gytCost: 540,
 			membershipCost: 403.32,
 			customerInsuranceCost: 953.42,
 		});
@@ -210,8 +211,30 @@ describe("buildServerInsurancePersistence", () => {
 		expect(result.insuranceProvider).toBe("gyt");
 		expect(result.seguro).toBe("953.42");
 		expect(result.customerInsuranceCost).toBe("953.42");
-		expect(result.internalInsuranceCost).toBe("584.96");
-		expect(result.insuranceSavingsToMembership).toBe("368.46");
-		expect(result.membresiaPago).toBe("771.78");
+		expect(result.internalInsuranceCost).toBe("540.00");
+		// ahorro limpio = universales - gyt = 550.10 - 540 = 10.10 (no del bundle)
+		expect(result.insuranceSavingsToMembership).toBe("10.10");
+		// membresía = la que mandó el front, sin re-sumar el ahorro
+		expect(result.membresiaPago).toBe("403.32");
+	});
+
+	test("computes savings from insurance prices and does not re-add them to membership", () => {
+		// El front ya metió el ahorro GyT en membershipCost (162) y armó el bundle
+		// base + membresía en customerInsuranceCost (762). El server NO debe calcular
+		// el ahorro del bundle (762-580) ni volver a sumarlo a la membresía.
+		const result = buildServerInsurancePersistence({
+			insuredAmount: 189000,
+			vehicleType: "particular",
+			universalesCost: 600,
+			gytCost: 580,
+			membershipCost: 162,
+			customerInsuranceCost: 762,
+		});
+
+		expect(result.insuranceProvider).toBe("gyt");
+		// ahorro = universales - gyt = 20  (NO 762 - 580 = 182)
+		expect(result.insuranceSavingsToMembership).toBe("20.00");
+		// membresía persistida = la que mandó el front, sin re-sumar el ahorro
+		expect(result.membresiaPago).toBe("162.00");
 	});
 });

--- a/apps/crm/apps/server/src/lib/insurance-selection.ts
+++ b/apps/crm/apps/server/src/lib/insurance-selection.ts
@@ -72,6 +72,7 @@ export function selectInsuranceProvider(
 
 	if (
 		gytCost != null &&
+		gytCost < universalesCost &&
 		qualifiesForGyt(input.insuredAmount, input.vehicleType)
 	) {
 		const savings = roundMoney(Math.max(universalesCost - gytCost, 0));
@@ -119,18 +120,18 @@ export function buildServerInsurancePersistence(
 	const customerInsuranceCost = roundMoney(
 		input.customerInsuranceCost ?? selection.customerInsuranceCost,
 	);
-	const internalInsuranceCost = selection.internalInsuranceCost;
-	const savings = roundMoney(
-		Math.max(customerInsuranceCost - internalInsuranceCost, 0),
-	);
 
 	return normalizeInsuranceBreakdown({
 		selection: {
 			provider: selection.provider,
 			customerInsuranceCost,
-			internalInsuranceCost,
-			insuranceSavingsToMembership: savings,
-			effectiveMembershipCost: roundMoney(input.membershipCost + savings),
+			internalInsuranceCost: selection.internalInsuranceCost,
+			// El ahorro sale de los precios de seguro (universales - gyt), NO del
+			// monto bundle del cotizador (que ya incluye la membresía).
+			insuranceSavingsToMembership: selection.insuranceSavingsToMembership,
+			// La membresía ya trae el ahorro incorporado desde el front
+			// (getInsuranceCost). No lo volvemos a sumar para no contarlo dos veces.
+			effectiveMembershipCost: roundMoney(input.membershipCost),
 		},
 	});
 }

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -1196,12 +1196,16 @@ function QuoterPage() {
 					quoterForm.setFieldValue("downPayment", downPayment);
 				}
 
-				// Actualizar seguro y membresía
+				// Actualizar seguro y membresía. Pasamos isNew/origin del vehículo
+				// seleccionado explícitamente: el form state (vehicleId) que usa
+				// updateInsuranceCost para resolver el vehículo recién se seteó y
+				// puede estar stale, lo que clasificaría mal la membresía.
 				updateInsuranceCost(
 					isSobreVehiculo
 						? quoterForm.state.values.insuredAmount || numericValue
 						: numericValue,
 					quoterForm.state.values.vehicleType,
+					{ isNew: vehicle.isNew, origin: vehicle.origin },
 				);
 			}
 		}


### PR DESCRIPTION
## Qué
Arregla 2 bugs de **cálculo** de la feature GyT + el seed.

### Dinero
- **A2** — `selectInsuranceProvider` elige GyT **solo si es más barato** (`gytCost < universalesCost`). Antes lo elegía por rango aunque GyT fuera más caro.
- **A1** — `buildServerInsurancePersistence` calcula el ahorro de los precios de seguro (universales−gyt), **no del bundle** del cotizador, y **no re-suma** el ahorro a la membresía (el front ya lo incorpora una vez). Antes se inflaba lo persistido (membresía/cuota).

### Seed
- `seed-gyt-insurance` lee el Excel de tarifas desde **R2** (`getFileBuffer`) en vez de una ruta local hardcodeada. Env: `GYT_INSURANCE_XLSX_KEY`.

## Pruebas
`insurance-selection.test.ts`: **21/21** (con casos nuevos de A1/A2).

## Base
Sobre `feature/crm-gyt-seguro` (depende de esa feature, aún sin mergear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)