### PR TITLE
feat(aseguradoras): persistir aseguradora del crédito (CRM→cartera) + correo

### DIFF
--- a/apps/cartera-back/drizzle/0015_add_aseguradoras.sql
+++ b/apps/cartera-back/drizzle/0015_add_aseguradoras.sql
@@ -1,0 +1,16 @@
+-- Catálogo de aseguradoras + enlace del crédito a su aseguradora.
+-- El CRM manda siempre 'GyT' o 'Universales'; cartera hace match y, si no
+-- existe, la crea (find-or-create). Columna nullable: créditos viejos quedan NULL.
+CREATE TABLE IF NOT EXISTS cartera.aseguradoras (
+  id serial PRIMARY KEY,
+  nombre varchar(100) NOT NULL UNIQUE,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+ALTER TABLE cartera.creditos
+  ADD COLUMN IF NOT EXISTS aseguradora_id integer REFERENCES cartera.aseguradoras(id);
+
+-- Aseguradoras conocidas (idempotente).
+INSERT INTO cartera.aseguradoras (nombre)
+VALUES ('Universales'), ('GyT')
+ON CONFLICT (nombre) DO NOTHING;

--- a/apps/cartera-back/src/controllers/createCredit.test.ts
+++ b/apps/cartera-back/src/controllers/createCredit.test.ts
@@ -70,7 +70,9 @@ mock.module("@cci/email", () => ({
   sendNewCreditNotification: mock(() => Promise.resolve()),
 }));
 
-const { insertCredit } = await import("./createCredit");
+const { insertCredit, findOrCreateAseguradora } = await import("./createCredit");
+
+type Executor = Parameters<typeof findOrCreateAseguradora>[1];
 
 const validCreditBody = {
   usuario: "Cliente prueba",
@@ -119,5 +121,69 @@ describe("insertCredit", () => {
     expect(globalInsertCalls).toBe(0);
     expect(txInsertCalls).toBeGreaterThan(0);
     expect(set.status).toBe(500);
+  });
+});
+
+describe("findOrCreateAseguradora", () => {
+  it("devuelve el id existente sin insertar", async () => {
+    const executor = {
+      select: () => ({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([{ id: 7 }]) }),
+        }),
+      }),
+      insert: () => {
+        throw new Error("no debería insertar si ya existe");
+      },
+    } as unknown as Executor;
+
+    const id = await findOrCreateAseguradora("GyT", executor);
+    expect(id).toBe(7);
+  });
+
+  it("crea y devuelve el id nuevo cuando no existe", async () => {
+    const executor = {
+      select: () => ({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([]) }),
+        }),
+      }),
+      insert: () => ({
+        values: () => ({
+          onConflictDoNothing: () => ({
+            returning: () => Promise.resolve([{ id: 42 }]),
+          }),
+        }),
+      }),
+    } as unknown as Executor;
+
+    const id = await findOrCreateAseguradora("MAPFRE", executor);
+    expect(id).toBe(42);
+  });
+
+  it("re-busca cuando el insert choca por carrera (onConflictDoNothing)", async () => {
+    let selectCount = 0;
+    const executor = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => {
+              selectCount += 1;
+              return Promise.resolve(selectCount === 1 ? [] : [{ id: 99 }]);
+            },
+          }),
+        }),
+      }),
+      insert: () => ({
+        values: () => ({
+          onConflictDoNothing: () => ({
+            returning: () => Promise.resolve([]),
+          }),
+        }),
+      }),
+    } as unknown as Executor;
+
+    const id = await findOrCreateAseguradora("Universales", executor);
+    expect(id).toBe(99);
   });
 });

--- a/apps/cartera-back/src/controllers/createCredit.ts
+++ b/apps/cartera-back/src/controllers/createCredit.ts
@@ -2,6 +2,7 @@ import Big from "big.js";
 import z from "zod";
 import { db } from "../database";
 import {
+  aseguradoras,
   creditos,
   creditos_rubros_otros,
   creditos_inversionistas,
@@ -14,7 +15,7 @@ import {
 import { findOrCreateAdvisorByName, getAsesorConMenorCarga } from "./advisor";
 import { findOrCreateUserByName } from "./users";
 import { sendNewCreditNotification } from "@cci/email";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 
 // ========================================
 // TIPOS E INTERFACES
@@ -62,6 +63,7 @@ interface CreditDataForInsert {
   gps: string;
   observaciones: string;
   no_poliza: string;
+  aseguradora_id?: number;
   asesor_id: number;
   como_se_entero: string; 
   plazo: number;
@@ -167,7 +169,8 @@ const creditSchema = z.object({
   gps: z.number().min(0),
   observaciones: z.string().max(1000),
   no_poliza: z.string().max(1000),
-  como_se_entero: z.string().max(100), 
+  aseguradora: z.string().max(100).optional().nullable(),
+  como_se_entero: z.string().max(100),
   plazo: z.number().int().min(1).max(360),
   cuota: z.number().min(0),
   dia_pago_mensual: z.number().int().min(1).max(31),
@@ -267,6 +270,44 @@ const validateCreditData = (creditData: CreditData, set: SetContext): Validation
 // 2. INSERCIÓN DE CRÉDITO Y RELACIONADOS
 // ========================================
 
+/**
+ * Busca la aseguradora por nombre y, si no existe, la crea (find-or-create).
+ * El CRM manda 'GyT' o 'Universales'; queda extensible a más aseguradoras.
+ */
+export const findOrCreateAseguradora = async (
+  nombre: string,
+  executor: DbExecutor = db,
+): Promise<number> => {
+  const nombreLimpio = nombre.trim();
+
+  const [existing] = await executor
+    .select({ id: aseguradoras.id })
+    .from(aseguradoras)
+    .where(sql`lower(${aseguradoras.nombre}) = lower(${nombreLimpio})`)
+    .limit(1);
+  if (existing) return existing.id;
+
+  const [created] = await executor
+    .insert(aseguradoras)
+    .values({ nombre: nombreLimpio })
+    .onConflictDoNothing()
+    .returning({ id: aseguradoras.id });
+  if (created) return created.id;
+
+  // Otro proceso la insertó en paralelo: re-buscar.
+  const [row] = await executor
+    .select({ id: aseguradoras.id })
+    .from(aseguradoras)
+    .where(sql`lower(${aseguradoras.nombre}) = lower(${nombreLimpio})`)
+    .limit(1);
+  if (!row) {
+    throw new Error(
+      `No se pudo resolver la aseguradora "${nombreLimpio}" tras conflicto`,
+    );
+  }
+  return row.id;
+};
+
 const insertCreditAndRelated = async (creditData: CreditData, executor: DbExecutor = db): Promise<{
   newCredit: NewCredit;
   creditDataForInsert: CreditDataForInsert;
@@ -311,6 +352,15 @@ const insertCreditAndRelated = async (creditData: CreditData, executor: DbExecut
       (inv: Inversionista) => Number(inv.porcentaje_inversion) > 1
     ) ? "Pool" : "Individual";
 
+  // Aseguradora (find-or-create). Si el CRM no la manda, queda NULL.
+  let aseguradora_id: number | undefined;
+  if (creditData.aseguradora) {
+    aseguradora_id = await findOrCreateAseguradora(
+      creditData.aseguradora,
+      executor,
+    );
+  }
+
   const creditDataForInsert: CreditDataForInsert = {
     usuario_id: user.usuario_id,
     otros: creditData.otros?.toString() ?? "0",
@@ -324,6 +374,7 @@ const insertCreditAndRelated = async (creditData: CreditData, executor: DbExecut
     gps: creditData.gps.toString(),
     observaciones: creditData.observaciones ?? "0",
     no_poliza: creditData.no_poliza ?? "",
+    aseguradora_id,
     como_se_entero: creditData.como_se_entero ?? "",
     asesor_id: asesor_id,
     plazo: creditData.plazo,
@@ -931,6 +982,7 @@ export const insertCredit = async ({ body, set }: { body: unknown; set: SetConte
         vehiculoVin: creditData.vehiculo_vin ?? undefined,
         montoAsegurado: creditData.monto_asegurado ?? undefined,
         opportunityId: creditData.opportunity_id ?? undefined,
+        aseguradora: creditData.aseguradora ?? undefined,
       });
       console.log("[INSERT CREDIT] Email notification sent successfully");
     } catch (emailErr) {

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -136,6 +136,13 @@
   }
   // 2. Créditos
 
+  // Catálogo de aseguradoras (GyT, Universales, futuras). El crédito enlaza aquí.
+  export const aseguradoras = customSchema.table("aseguradoras", {
+    id: serial("id").primaryKey(),
+    nombre: varchar("nombre", { length: 100 }).notNull().unique(),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+  });
+
   export const creditos = customSchema.table("creditos", {
     credito_id: serial("credito_id").primaryKey(),
     usuario_id: integer("usuario_id").notNull(),
@@ -165,6 +172,9 @@
     gps: numeric("gps", { precision: 18, scale: 2 }).notNull(),
     observaciones: text("observaciones").notNull(),
     no_poliza: varchar("no_poliza").notNull(),
+    aseguradora_id: integer("aseguradora_id").references(
+      () => aseguradoras.id,
+    ),
     como_se_entero: varchar("como_se_entero", { length: 100 }).notNull(),
     asesor_id: integer("asesor_id")
       .notNull()

--- a/apps/crm/apps/server/src/services/cartera-back-integration.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-integration.ts
@@ -134,6 +134,7 @@ export interface CreateCreditoParams {
 	fecha_creacion?: string;
 	observaciones?: string;
 	no_poliza?: string;
+	aseguradora?: string;
 	// Nuevos campos adicionales
 	categoria?: string;
 	nit?: string;
@@ -195,6 +196,7 @@ export async function createCreditoInCarteraBack(
 			gps: params.gps ?? 0,
 			observaciones: params.observaciones,
 			no_poliza: params.no_poliza || "",
+			aseguradora: params.aseguradora,
 			direccion: params.direccion || "",
 			// Nuevos campos adicionales
 			categoria: params.categoria,

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -5,7 +5,7 @@
  */
 
 import crypto from "node:crypto";
-import { and, desc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import {
@@ -426,12 +426,7 @@ async function getLatestApprovedQuotation(
 				insuranceProvider: quotations.insuranceProvider,
 			})
 			.from(quotations)
-			.where(
-				and(
-					eq(quotations.opportunityId, opportunityId),
-					eq(quotations.status, "accepted"),
-				),
-			)
+			.where(eq(quotations.opportunityId, opportunityId))
 			.orderBy(desc(quotations.createdAt))
 			.limit(1);
 

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -185,6 +185,7 @@ interface QuotationDataForBilling {
 	insuredAmount: string | null; // Monto asegurado (para correo)
 	value: string | null; // Valor del vehículo (para correo)
 	monthlyPayment: string | null; // Cuota mensual (para asegurar el valor que es)
+	insuranceProvider: string | null; // Aseguradora elegida (gyt | universales)
 }
 
 /** Parámetros para generación de facturas en background */
@@ -397,6 +398,13 @@ async function logInvoiceSyncOperation(
 /**
  * Obtiene la última cotización aprobada de una oportunidad
  */
+/** Mapea el provider interno (gyt | universales) a la etiqueta de aseguradora. */
+function aseguradoraLabel(
+	provider: string | null | undefined,
+): "GyT" | "Universales" {
+	return provider === "gyt" ? "GyT" : "Universales";
+}
+
 async function getLatestApprovedQuotation(
 	opportunityId: string,
 ): Promise<QuotationDataForBilling | null> {
@@ -415,6 +423,7 @@ async function getLatestApprovedQuotation(
 				insuredAmount: quotations.insuredAmount,
 				value: quotations.vehicleValue,
 				monthlyPayment: quotations.monthlyPayment,
+				insuranceProvider: quotations.insuranceProvider,
 			})
 			.from(quotations)
 			.where(eq(quotations.opportunityId, opportunityId))
@@ -960,6 +969,7 @@ async function createCredit(
 			observaciones: `Crédito generado desde CRM - Oportunidad: ${opportunity.title}`,
 			seguro_10_cuotas: seguro,
 			gps: gps,
+			aseguradora: aseguradoraLabel(opportunity.insuranceProvider),
 			categoria: opportunity.categoria ?? undefined,
 			nit: cleanNit(opportunity.nit),
 			royalti: royalti,
@@ -1177,6 +1187,11 @@ export async function closeOpportunity(
 				diaPagoMensual: opportunities.diaPagoMensual,
 				seguro: opportunities.seguro,
 				gps: opportunities.gps,
+				insuranceProvider: opportunities.insuranceProvider,
+				customerInsuranceCost: opportunities.customerInsuranceCost,
+				internalInsuranceCost: opportunities.internalInsuranceCost,
+				insuranceSavingsToMembership:
+					opportunities.insuranceSavingsToMembership,
 				categoria: opportunities.categoria,
 				nit: opportunities.nit,
 				royalti: opportunities.royalti,
@@ -1345,6 +1360,20 @@ export async function closeOpportunity(
 		console.log(
 			`[CloseOpportunity] Latest quotation found: ${quotation ? "YES" : "NO"}`,
 		);
+
+		// Estampar la aseguradora elegida (fuente: cotización) en la oportunidad,
+		// para que viaje a cartera y quede consistente en el CRM.
+		const insuranceProvider =
+			quotation?.insuranceProvider ??
+			opportunity.insuranceProvider ??
+			"universales";
+		if (insuranceProvider !== opportunity.insuranceProvider) {
+			await db
+				.update(opportunities)
+				.set({ insuranceProvider })
+				.where(eq(opportunities.id, opportunityId));
+			opportunity.insuranceProvider = insuranceProvider;
+		}
 
 		//  Create credit in cartera-back
 		const creditResult = await createCredit({

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -5,7 +5,7 @@
  */
 
 import crypto from "node:crypto";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import {
@@ -426,7 +426,12 @@ async function getLatestApprovedQuotation(
 				insuranceProvider: quotations.insuranceProvider,
 			})
 			.from(quotations)
-			.where(eq(quotations.opportunityId, opportunityId))
+			.where(
+				and(
+					eq(quotations.opportunityId, opportunityId),
+					eq(quotations.status, "accepted"),
+				),
+			)
 			.orderBy(desc(quotations.createdAt))
 			.limit(1);
 

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -111,6 +111,7 @@ export interface CreateCreditoInput {
 	fecha_creacion?: string;
 	observaciones?: string;
 	no_poliza?: string;
+	aseguradora?: string;
 	como_se_entero?: string;
 	dia_pago_mensual?: 15 | 30;
 	membresias_pago?: number;

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -157,6 +157,7 @@ export interface SendNewCreditNotificationParams {
   vehiculoVin?: string;
   montoAsegurado?: number;
   opportunityId?: string;
+  aseguradora?: string;
 }
 
 export const sendNewCreditNotification = async ({
@@ -176,6 +177,7 @@ export const sendNewCreditNotification = async ({
   vehiculoVin,
   montoAsegurado,
   opportunityId,
+  aseguradora,
 }: SendNewCreditNotificationParams) => {
   try {
     const validEmails = to.filter((email) => {
@@ -207,6 +209,7 @@ export const sendNewCreditNotification = async ({
         vehiculoVin,
         montoAsegurado,
         opportunityId,
+        aseguradora,
       }),
     });
 

--- a/packages/email/src/templates/NewCreditTemplate.tsx
+++ b/packages/email/src/templates/NewCreditTemplate.tsx
@@ -28,6 +28,7 @@ interface NewCreditEmailProps {
   vehiculoVin?: string;
   montoAsegurado?: number;
   opportunityId?: string;
+  aseguradora?: string;
 }
 
 const main = {
@@ -146,6 +147,7 @@ export const NewCreditEmail = ({
   vehiculoVin,
   montoAsegurado,
   opportunityId,
+  aseguradora,
 }: NewCreditEmailProps) => {
   const hasVehicleInfo = vehiculoMarca || vehiculoLinea || vehiculoModelo || vehiculoPlaca || vehiculoVin;
   const oportunidadUrl = `https://crm.s3.devteamatcci.site/crm/opportunities?opportunityId=${opportunityId}&tab=create`;
@@ -172,6 +174,9 @@ export const NewCreditEmail = ({
             <Text style={detailItem}><strong>Plazo:</strong> {plazo} meses</Text>
             <Text style={detailItem}><strong>Cuota:</strong> {currencySymbol}{cuota}</Text>
             <Text style={detailItem}><strong>Tasa de Interés:</strong> {interestRate}%</Text>
+            {aseguradora && (
+              <Text style={detailItem}><strong>Aseguradora:</strong> {aseguradora}</Text>
+            )}
           </Section>
 
           {investors.length > 0 && (


### PR DESCRIPTION
## Qué
Persiste la **aseguradora** del crédito de punta a punta (CRM → cartera) y la muestra en el correo de creación.

### Flujo
Al **cerrar** la oportunidad, el CRM estampa el `insurance_provider` (de la cotización) y manda `'GyT'`/`'Universales'` a cartera. Cartera hace **find-or-create** en un catálogo `aseguradoras` y enlaza el crédito.

### CRM
- `close-opportunity`: estampar provider al cerrar + **seleccionar los campos de seguro** (antes no se seleccionaban → nunca llegaban a cartera) + mandar la aseguradora.

### Cartera-back
- Migración **0015**: tabla catálogo `aseguradoras` (nombre único) + FK `creditos.aseguradora_id` (nullable); pre-seed 'Universales'/'GyT'.
- `insertCredit`: **find-or-create** (case-insensitive) + enlace; campo **opcional** en el zod → degradación suave.
- Aseguradora en el correo de creación.

## Pruebas
`createCredit.test.ts` + 3 de `findOrCreateAseguradora`: **4/4**.

## ⚠️ Deploy
**Orden: cartera-back primero** (migración 0015 + `/newCredit` acepta el campo), luego CRM. La migración 0015 se aplica como SQL manual al schema `cartera` (cartera no usa drizzle-kit).

## Base
Sobre `feature/crm-gyt-seguro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)