### PR TITLE
EXTRAIT-119: paginar Cartera de Clientes y export a Excel para marketing

### DIFF
--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -273,9 +273,10 @@ describe("buildCarteraMatchedClientRows", () => {
 });
 
 describe("getClientCreditsPageFromCartera", () => {
-	// Fetcher falso: cada estado tiene `counts[estado]` créditos y devuelve la
-	// página pedida + el totalCount, igual que cartera-back.
-	const buildFetcher = (counts: Record<string, number>) => {
+	// Fetcher falso de cartera-back: `estado: "ACTIVO"` ya devuelve todos los
+	// vigentes, así que el helper solo debe consultar ese estado. Devuelve la
+	// página pedida + el totalCount.
+	const buildFetcher = (total: number) => {
 		const calls: Array<{ estado: string; page: number; perPage: number }> = [];
 		const fetchCredits = async (params: {
 			estado: string;
@@ -287,18 +288,15 @@ describe("getClientCreditsPageFromCartera", () => {
 				page: params.page,
 				perPage: params.perPage,
 			});
-			const count = counts[params.estado] ?? 0;
 			const start = (params.page - 1) * params.perPage;
 			const data = [];
-			for (let i = start; i < Math.min(start + params.perPage, count); i++) {
-				data.push({
-					creditos: { numero_credito_sifco: `${params.estado}-${i}` },
-				});
+			for (let i = start; i < Math.min(start + params.perPage, total); i++) {
+				data.push({ creditos: { numero_credito_sifco: `SIFCO-${i}` } });
 			}
 			return {
 				data,
-				totalCount: count,
-				totalPages: Math.max(1, Math.ceil(count / params.perPage)),
+				totalCount: total,
+				totalPages: Math.max(1, Math.ceil(total / params.perPage)),
 			};
 		};
 		return { fetchCredits, calls };
@@ -308,41 +306,48 @@ describe("getClientCreditsPageFromCartera", () => {
 		credits: Array<{ creditos?: { numero_credito_sifco?: string | null } }>,
 	) => credits.map((c) => c.creditos?.numero_credito_sifco);
 
-	test("returns only the requested window within ACTIVO and totals all states", async () => {
-		const { fetchCredits, calls } = buildFetcher({
-			ACTIVO: 5,
-			MOROSO: 4,
-			EN_CONVENIO: 3,
-		});
+	test("returns only the requested window and consulta solo ACTIVO", async () => {
+		const { fetchCredits, calls } = buildFetcher(250);
 
 		const { credits, total } = await getClientCreditsPageFromCartera(
 			{ offset: 0, limit: 2 },
 			fetchCredits,
 		);
 
-		expect(sifcosDe(credits)).toEqual(["ACTIVO-0", "ACTIVO-1"]);
-		expect(total).toBe(12);
-		// ACTIVO se pide con página real; los demás solo se sondean (perPage=1).
-		const moroso = calls.find((c) => c.estado === "MOROSO");
-		const convenio = calls.find((c) => c.estado === "EN_CONVENIO");
-		expect(moroso?.perPage).toBe(1);
-		expect(convenio?.perPage).toBe(1);
+		expect(sifcosDe(credits)).toEqual(["SIFCO-0", "SIFCO-1"]);
+		expect(total).toBe(250);
+		// Nunca debe iterar MOROSO/EN_CONVENIO (cartera ya los incluye en ACTIVO).
+		expect(calls.every((c) => c.estado === "ACTIVO")).toBe(true);
 	});
 
-	test("stitches the window across the ACTIVO -> MOROSO boundary", async () => {
-		const { fetchCredits } = buildFetcher({
-			ACTIVO: 2,
-			MOROSO: 3,
-			EN_CONVENIO: 0,
-		});
+	test("paginates across cartera pages (perPage=100)", async () => {
+		const { fetchCredits, calls } = buildFetcher(250);
 
+		// Ventana 90..109 cruza el borde de página 1 (0-99) a página 2 (100-199).
 		const { credits, total } = await getClientCreditsPageFromCartera(
-			{ offset: 1, limit: 3 },
+			{ offset: 90, limit: 20 },
 			fetchCredits,
 		);
 
-		expect(sifcosDe(credits)).toEqual(["ACTIVO-1", "MOROSO-0", "MOROSO-1"]);
-		expect(total).toBe(5);
+		expect(total).toBe(250);
+		expect(credits).toHaveLength(20);
+		expect(sifcosDe(credits)[0]).toBe("SIFCO-90");
+		expect(sifcosDe(credits).at(-1)).toBe("SIFCO-109");
+		expect(calls.map((c) => c.page)).toEqual([1, 2]);
+	});
+
+	test("con limit<=0 solo cuenta (sonda), sin recolectar filas", async () => {
+		const { fetchCredits, calls } = buildFetcher(42);
+
+		const { credits, total } = await getClientCreditsPageFromCartera(
+			{ offset: 0, limit: 0 },
+			fetchCredits,
+		);
+
+		expect(credits).toEqual([]);
+		expect(total).toBe(42);
+		expect(calls).toHaveLength(1);
+		expect(calls[0].perPage).toBe(1);
 	});
 
 	test("passes filters through to the fetcher", async () => {

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -3,9 +3,9 @@ import { leadSourceEnum } from "../db/schema/crm";
 import {
 	buildCarteraMatchedClientRows,
 	buildCarteraOnlyClientRow,
-	calculateCarteraClientStats,
-	getCurrentClientCreditsFromCartera,
 	getClientCreditSifcosFromCartera,
+	getClientCreditsPageFromCartera,
+	getCurrentClientCreditsFromCartera,
 	getLeadsInputSchema,
 } from "./crm";
 
@@ -153,18 +153,38 @@ describe("buildCarteraMatchedClientRows", () => {
 		const rows = buildCarteraMatchedClientRows({
 			lead,
 			leadOpportunities: [
-				{ id: "opp-1", numeroSifco: "SIFCO-1", value: "5000.00", isClosed: true },
-				{ id: "opp-2", numeroSifco: "SIFCO-2", value: "7000.00", isClosed: true },
+				{
+					id: "opp-1",
+					numeroSifco: "SIFCO-1",
+					value: "5000.00",
+					isClosed: true,
+				},
+				{
+					id: "opp-2",
+					numeroSifco: "SIFCO-2",
+					value: "7000.00",
+					isClosed: true,
+				},
 			],
 			creditAnalysis: null,
 			carteraCreditBySifco: new Map([
 				[
 					"SIFCO-1",
-					{ creditos: { numero_credito_sifco: "SIFCO-1", deudatotal: "1200.00" } },
+					{
+						creditos: {
+							numero_credito_sifco: "SIFCO-1",
+							deudatotal: "1200.00",
+						},
+					},
 				],
 				[
 					"SIFCO-2",
-					{ creditos: { numero_credito_sifco: "SIFCO-2", deudatotal: "3400.00" } },
+					{
+						creditos: {
+							numero_credito_sifco: "SIFCO-2",
+							deudatotal: "3400.00",
+						},
+					},
 				],
 			]),
 		});
@@ -180,13 +200,23 @@ describe("buildCarteraMatchedClientRows", () => {
 		const [row] = buildCarteraMatchedClientRows({
 			lead,
 			leadOpportunities: [
-				{ id: "opp-1", numeroSifco: "SIFCO-1", value: "5000.00", isClosed: true },
+				{
+					id: "opp-1",
+					numeroSifco: "SIFCO-1",
+					value: "5000.00",
+					isClosed: true,
+				},
 			],
 			creditAnalysis: null,
 			carteraCreditBySifco: new Map([
 				[
 					"SIFCO-1",
-					{ creditos: { numero_credito_sifco: "SIFCO-1", deudatotal: "1200.00" } },
+					{
+						creditos: {
+							numero_credito_sifco: "SIFCO-1",
+							deudatotal: "1200.00",
+						},
+					},
 				],
 			]),
 		});
@@ -198,18 +228,38 @@ describe("buildCarteraMatchedClientRows", () => {
 		const rows = buildCarteraMatchedClientRows({
 			lead,
 			leadOpportunities: [
-				{ id: "opp-1", numeroSifco: "SIFCO-1", value: "5000.00", isClosed: true },
-				{ id: "opp-2", numeroSifco: "SIFCO-2", value: "7000.00", isClosed: true },
+				{
+					id: "opp-1",
+					numeroSifco: "SIFCO-1",
+					value: "5000.00",
+					isClosed: true,
+				},
+				{
+					id: "opp-2",
+					numeroSifco: "SIFCO-2",
+					value: "7000.00",
+					isClosed: true,
+				},
 			],
 			creditAnalysis: null,
 			carteraCreditBySifco: new Map([
 				[
 					"SIFCO-1",
-					{ creditos: { numero_credito_sifco: "SIFCO-1", deudatotal: "1200.00" } },
+					{
+						creditos: {
+							numero_credito_sifco: "SIFCO-1",
+							deudatotal: "1200.00",
+						},
+					},
 				],
 				[
 					"SIFCO-2",
-					{ creditos: { numero_credito_sifco: "SIFCO-2", deudatotal: "3400.00" } },
+					{
+						creditos: {
+							numero_credito_sifco: "SIFCO-2",
+							deudatotal: "3400.00",
+						},
+					},
 				],
 			]),
 		});
@@ -222,54 +272,101 @@ describe("buildCarteraMatchedClientRows", () => {
 	});
 });
 
-describe("calculateCarteraClientStats", () => {
-	test("scopes sales total value to matched assigned SIFCOs", () => {
-		const stats = calculateCarteraClientStats({
-			carteraCredits: [
-				{ creditos: { numero_credito_sifco: "A-1", deudatotal: "100.00" } },
-				{ creditos: { numero_credito_sifco: "B-1", deudatotal: "900.00" } },
-			],
-			matchedSifcos: new Set(["A-1"]),
-			uniqueLeadCount: 1,
-			scopedOpportunityCount: 1,
-			userRole: "sales",
+describe("getClientCreditsPageFromCartera", () => {
+	// Fetcher falso: cada estado tiene `counts[estado]` créditos y devuelve la
+	// página pedida + el totalCount, igual que cartera-back.
+	const buildFetcher = (counts: Record<string, number>) => {
+		const calls: Array<{ estado: string; page: number; perPage: number }> = [];
+		const fetchCredits = async (params: {
+			estado: string;
+			page: number;
+			perPage: number;
+		}) => {
+			calls.push({
+				estado: params.estado,
+				page: params.page,
+				perPage: params.perPage,
+			});
+			const count = counts[params.estado] ?? 0;
+			const start = (params.page - 1) * params.perPage;
+			const data = [];
+			for (let i = start; i < Math.min(start + params.perPage, count); i++) {
+				data.push({
+					creditos: { numero_credito_sifco: `${params.estado}-${i}` },
+				});
+			}
+			return {
+				data,
+				totalCount: count,
+				totalPages: Math.max(1, Math.ceil(count / params.perPage)),
+			};
+		};
+		return { fetchCredits, calls };
+	};
+
+	const sifcosDe = (
+		credits: Array<{ creditos?: { numero_credito_sifco?: string | null } }>,
+	) => credits.map((c) => c.creditos?.numero_credito_sifco);
+
+	test("returns only the requested window within ACTIVO and totals all states", async () => {
+		const { fetchCredits, calls } = buildFetcher({
+			ACTIVO: 5,
+			MOROSO: 4,
+			EN_CONVENIO: 3,
 		});
 
-		expect(stats.totalClients).toBe(1);
-		expect(stats.totalClosedOpportunities).toBe(1);
-		expect(stats.totalValue).toBe(100);
-		expect(stats.missingCrmCount).toBe(0);
+		const { credits, total } = await getClientCreditsPageFromCartera(
+			{ offset: 0, limit: 2 },
+			fetchCredits,
+		);
+
+		expect(sifcosDe(credits)).toEqual(["ACTIVO-0", "ACTIVO-1"]);
+		expect(total).toBe(12);
+		// ACTIVO se pide con página real; los demás solo se sondean (perPage=1).
+		const moroso = calls.find((c) => c.estado === "MOROSO");
+		const convenio = calls.find((c) => c.estado === "EN_CONVENIO");
+		expect(moroso?.perPage).toBe(1);
+		expect(convenio?.perPage).toBe(1);
 	});
 
-	test("counts sales clients by matched cartera credits", () => {
-		const stats = calculateCarteraClientStats({
-			carteraCredits: [
-				{ creditos: { numero_credito_sifco: "A-1", deudatotal: "100.00" } },
-				{ creditos: { numero_credito_sifco: "A-2", deudatotal: "200.00" } },
-			],
-			matchedSifcos: new Set(["A-1", "A-2"]),
-			uniqueLeadCount: 1,
-			scopedOpportunityCount: 2,
-			userRole: "sales",
+	test("stitches the window across the ACTIVO -> MOROSO boundary", async () => {
+		const { fetchCredits } = buildFetcher({
+			ACTIVO: 2,
+			MOROSO: 3,
+			EN_CONVENIO: 0,
 		});
 
-		expect(stats.totalClients).toBe(2);
+		const { credits, total } = await getClientCreditsPageFromCartera(
+			{ offset: 1, limit: 3 },
+			fetchCredits,
+		);
+
+		expect(sifcosDe(credits)).toEqual(["ACTIVO-1", "MOROSO-0", "MOROSO-1"]);
+		expect(total).toBe(5);
 	});
 
-	test("uses full cartera totals for non-sales users", () => {
-		const stats = calculateCarteraClientStats({
-			carteraCredits: [
-				{ creditos: { numero_credito_sifco: "A-1", deudatotal: "100.00" } },
-				{ creditos: { numero_credito_sifco: "B-1", capital: "900.00" } },
-			],
-			matchedSifcos: new Set(["A-1"]),
-			uniqueLeadCount: 1,
-			scopedOpportunityCount: 1,
-			userRole: "admin",
-		});
+	test("passes filters through to the fetcher", async () => {
+		const received: Array<{
+			nombre_usuario?: string;
+			numeros_credito_sifco?: string[];
+		}> = [];
+		const fetchCredits = async (params: {
+			estado: string;
+			page: number;
+			perPage: number;
+			nombre_usuario?: string;
+			numeros_credito_sifco?: string[];
+		}) => {
+			received.push(params);
+			return { data: [], totalCount: 0, totalPages: 1 };
+		};
 
-		expect(stats.totalClients).toBe(2);
-		expect(stats.totalValue).toBe(1000);
-		expect(stats.missingCrmCount).toBe(1);
+		await getClientCreditsPageFromCartera(
+			{ offset: 0, limit: 10, nombreUsuario: "Juan", sifcos: ["X-1", "X-2"] },
+			fetchCredits,
+		);
+
+		expect(received[0]?.nombre_usuario).toBe("Juan");
+		expect(received[0]?.numeros_credito_sifco).toEqual(["X-1", "X-2"]);
 	});
 });

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -259,13 +259,14 @@ export async function getCurrentClientCreditsFromCartera(
 const CARTERA_PAGE_FETCH_SIZE = 100;
 
 /**
- * Trae SOLO la ventana [offset, offset+limit) del portafolio vigente, tratando
- * los estados ACTIVO/MOROSO/EN_CONVENIO como una lista concatenada. Evita bajar
- * toda la cartera: pide a cartera-back únicamente las páginas que la ventana
- * toca y usa el `totalCount` que ya devuelve `getAllCreditos` para el total.
+ * Trae SOLO la ventana [offset, offset+limit) del portafolio vigente.
  *
- * Cuando la ventana ya está completa, los estados restantes se consultan con una
- * sonda mínima (perPage=1) solo para acumular el conteo total.
+ * En cartera-back, `estado: "ACTIVO"` SIN `cuotas_atrasadas` ya devuelve
+ * `statusCredit IN ('ACTIVO','MOROSO','EN_CONVENIO')` — es decir, todos los
+ * créditos vigentes en una sola consulta (ver apps/cartera-back credits.ts).
+ * Por eso NO se itera por estado: una sola corriente paginada, sin doble conteo
+ * ni filas duplicadas. Pide solo las páginas que la ventana toca y usa el
+ * `totalCount` que ya devuelve `getAllCreditos`.
  */
 export async function getClientCreditsPageFromCartera(
 	params: {
@@ -282,6 +283,8 @@ export async function getClientCreditsPageFromCartera(
 	const filtros = {
 		mes: 0,
 		anio: 0,
+		// ACTIVO (sin cuotas_atrasadas) = ACTIVO + MOROSO + EN_CONVENIO en origen.
+		estado: "ACTIVO" as ClientCreditCarteraStatus,
 		...(params.nombreUsuario ? { nombre_usuario: params.nombreUsuario } : {}),
 		...(params.sifcoExacto ? { numero_credito_sifco: params.sifcoExacto } : {}),
 		...(params.sifcos && params.sifcos.length > 0
@@ -289,56 +292,34 @@ export async function getClientCreditsPageFromCartera(
 			: {}),
 	};
 
+	// Solo se necesita el conteo (p. ej. para las stats): sonda mínima.
+	if (params.limit <= 0) {
+		const probe = await fetchCredits({ ...filtros, page: 1, perPage: 1 });
+		return { credits: [], total: probe.totalCount ?? probe.data.length };
+	}
+
 	const credits: CarteraClientCredit[] = [];
-	let total = 0;
-	let skip = Math.max(0, params.offset);
-	let need = Math.max(0, params.limit);
+	let need = params.limit;
+	let cursor = Math.max(0, params.offset);
+	let page = Math.floor(cursor / perPage) + 1;
+	let resp = await fetchCredits({ ...filtros, page, perPage });
+	const total = resp.totalCount ?? resp.data.length;
 
-	for (const estado of CLIENT_CREDIT_CARTERA_STATUSES) {
-		if (need <= 0) {
-			// La ventana ya está completa: solo necesitamos el conteo de este
-			// estado para el total.
-			const probe = await fetchCredits({
-				...filtros,
-				estado,
-				page: 1,
-				perPage: 1,
-			});
-			total += probe.totalCount ?? probe.data.length;
-			continue;
+	// Recolectar desde `cursor` hasta agotar `need` o el total.
+	while (need > 0 && cursor < total) {
+		const pageStart = (page - 1) * perPage;
+		const slice = resp.data.slice(
+			cursor - pageStart,
+			cursor - pageStart + need,
+		);
+		if (slice.length === 0) break;
+		credits.push(...slice);
+		need -= slice.length;
+		cursor += slice.length;
+		if (need > 0 && cursor < total) {
+			page += 1;
+			resp = await fetchCredits({ ...filtros, page, perPage });
 		}
-
-		// La ventana puede caer en este estado. Arrancamos en la página que
-		// contiene el índice local `skip`.
-		let localStart = skip;
-		let page = Math.floor(localStart / perPage) + 1;
-		let resp = await fetchCredits({ ...filtros, estado, page, perPage });
-		const count = resp.totalCount ?? resp.data.length;
-		total += count;
-
-		if (localStart >= count) {
-			// La ventana todavía no llega a este estado; lo saltamos completo.
-			skip = localStart - count;
-			continue;
-		}
-
-		// Recolectar desde `localStart` hasta agotar `need` o el estado.
-		while (need > 0 && localStart < count) {
-			const pageStart = (page - 1) * perPage;
-			const slice = resp.data.slice(
-				localStart - pageStart,
-				localStart - pageStart + need,
-			);
-			if (slice.length === 0) break;
-			credits.push(...slice);
-			need -= slice.length;
-			localStart += slice.length;
-			if (need > 0 && localStart < count) {
-				page += 1;
-				resp = await fetchCredits({ ...filtros, estado, page, perPage });
-			}
-		}
-		skip = 0;
 	}
 
 	return { credits, total };

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3422,6 +3422,19 @@ export const crmRouter = {
 				return { data: [], total: 0, limit, offset };
 			}
 
+			// Búsqueda por SIFCO exacto dentro de una vista acotada (sales/leadId):
+			// cartera-back prioriza la lista `numeros_credito_sifco` sobre el SIFCO
+			// único, así que NO se mandan ambos. Si el SIFCO buscado está en el
+			// alcance, se manda solo ese (sin la lista); si no, no hay resultado.
+			// La búsqueda por nombre sí va siempre a cartera junto al alcance (AND).
+			let effectiveSifcos = scopedSifcos;
+			if (sifcoExacto && scopedSifcos) {
+				if (!scopedSifcos.includes(sifcoExacto)) {
+					return { data: [], total: 0, limit, offset };
+				}
+				effectiveSifcos = undefined;
+			}
+
 			// Traer SOLO la ventana visible desde cartera. El nombre y el SIFCO se
 			// filtran en el origen (cartera); el alcance sales/leadId va por SIFCOs.
 			const { credits, total } = await getClientCreditsPageFromCartera({
@@ -3429,7 +3442,7 @@ export const crmRouter = {
 				limit,
 				nombreUsuario,
 				sifcoExacto,
-				sifcos: scopedSifcos,
+				sifcos: effectiveSifcos,
 			});
 
 			const pageSifcos = credits
@@ -3624,12 +3637,12 @@ export const crmRouter = {
 				.map((o) => o.numeroSifco)
 				.filter((s): s is string => Boolean(s));
 			if (scopedSifcos.length === 0) {
-				return { totalClients: 0, totalValue: 0 };
+				return { totalClients: 0, totalValue: null };
 			}
 		}
 
-		// Total de clientes vigentes: el helper con limit=0 solo suma los
-		// totalCount de los 3 estados (no recolecta filas).
+		// Total de clientes vigentes: el helper con limit=0 solo hace una sonda de
+		// conteo contra cartera (estado ACTIVO ya incluye los 3 vigentes).
 		const { total } = await getClientCreditsPageFromCartera({
 			offset: 0,
 			limit: 0,
@@ -3638,9 +3651,10 @@ export const crmRouter = {
 
 		// Valor total: stats agregadas de cartera (suma de capital de la cartera
 		// activa). Solo para vistas globales; para asesores no hay un agregado
-		// barato acotado, así que se omite.
-		let totalValue = 0;
+		// barato acotado, así que se devuelve null y el front oculta la tarjeta.
+		let totalValue: number | null = null;
 		if (context.userRole !== "sales") {
+			totalValue = 0;
 			try {
 				const stats = await carteraBackClient.getStats();
 				totalValue = Object.values(stats.porCuotasAtrasadas).reduce(

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -50,6 +50,7 @@ import {
 	opportunityDocuments,
 	VEHICLE_DOCUMENT_TYPES,
 } from "../db/schema/documents";
+import { quotations } from "../db/schema/quotations";
 import {
 	carryForwardAnalysisChecklistVerificationState,
 	hasStaleAnalysisChecklistDocumentState,
@@ -3672,6 +3673,81 @@ export const crmRouter = {
 		}
 
 		return { totalClients: total, totalValue };
+	}),
+
+	// Export para marketing (base lookalike): CRM-only, sin verificar cartera.
+	// Una fila por cliente (lead) que alguna vez cerró crédito (oportunidad con
+	// numeroSifco). Valor del vehículo = insured_amount de la cotización más
+	// reciente de su oportunidad más reciente; si no hay cotización, opp.value.
+	exportClientsForMarketing: crmProcedure.handler(async ({ context }) => {
+		if (!PERMISSIONS.canExportReports(context.userRole)) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "No tienes permiso para exportar la base de clientes",
+			});
+		}
+
+		// Oportunidades que se volvieron crédito (tienen numeroSifco), con su lead.
+		const rows = await db
+			.select({
+				oppId: opportunities.id,
+				leadId: opportunities.leadId,
+				value: opportunities.value,
+				createdAt: opportunities.createdAt,
+				firstName: leads.firstName,
+				middleName: leads.middleName,
+				lastName: leads.lastName,
+				secondLastName: leads.secondLastName,
+				phone: leads.phone,
+				email: leads.email,
+			})
+			.from(opportunities)
+			.innerJoin(leads, eq(opportunities.leadId, leads.id))
+			.where(isNotNull(opportunities.numeroSifco))
+			// Más reciente en cerrarse primero (fecha de cierre; createdAt si falta).
+			.orderBy(
+				sql`coalesce(${opportunities.actualCloseDate}, ${opportunities.createdAt}) desc`,
+			);
+
+		// Una fila por lead: su oportunidad más reciente en cerrarse (el stream ya
+		// viene ordenado por fecha de cierre desc, así que la primera gana).
+		const latestByLead = new Map<string, (typeof rows)[number]>();
+		for (const row of rows) {
+			if (row.leadId && !latestByLead.has(row.leadId)) {
+				latestByLead.set(row.leadId, row);
+			}
+		}
+		const selected = Array.from(latestByLead.values());
+
+		// Valor del vehículo: insured_amount de la cotización más reciente por opp.
+		const oppIds = selected.map((r) => r.oppId);
+		const insuredByOpp = new Map<string, string>();
+		if (oppIds.length > 0) {
+			const quotes = await db
+				.select({
+					opportunityId: quotations.opportunityId,
+					insuredAmount: quotations.insuredAmount,
+					createdAt: quotations.createdAt,
+				})
+				.from(quotations)
+				.where(inArray(quotations.opportunityId, oppIds))
+				.orderBy(desc(quotations.createdAt));
+			for (const q of quotes) {
+				if (q.opportunityId && !insuredByOpp.has(q.opportunityId)) {
+					insuredByOpp.set(q.opportunityId, q.insuredAmount);
+				}
+			}
+		}
+
+		const data = selected.map((r) => ({
+			nombre: [r.firstName, r.middleName, r.lastName, r.secondLastName]
+				.filter((p) => p?.trim())
+				.join(" "),
+			telefono: r.phone ?? "",
+			correo: r.email ?? "",
+			valorVehiculo: insuredByOpp.get(r.oppId) ?? r.value ?? "",
+		}));
+
+		return { data, total: data.length };
 	}),
 
 	createClient: crmProcedure

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3389,15 +3389,21 @@ export const crmRouter = {
 			//  - rol sales: solo los créditos de los leads asignados al asesor
 			let scopedSifcos: string[] | undefined;
 			if (input.leadId) {
+				// Un asesor solo puede abrir leads asignados a él: sin este check, un
+				// sales podría pasar ?idLead=<uuid ajeno> y ver datos de un cliente
+				// que no le corresponde. Admin/supervisor pueden ver cualquiera.
+				const leadConditions = [
+					eq(opportunities.leadId, input.leadId),
+					isNotNull(opportunities.numeroSifco),
+				];
+				if (context.userRole === "sales") {
+					leadConditions.push(eq(leads.assignedTo, context.userId));
+				}
 				const opps = await db
 					.select({ numeroSifco: opportunities.numeroSifco })
 					.from(opportunities)
-					.where(
-						and(
-							eq(opportunities.leadId, input.leadId),
-							isNotNull(opportunities.numeroSifco),
-						),
-					);
+					.leftJoin(leads, eq(opportunities.leadId, leads.id))
+					.where(and(...leadConditions));
 				scopedSifcos = opps
 					.map((o) => o.numeroSifco)
 					.filter((s): s is string => Boolean(s));

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -60,9 +60,7 @@ import {
 	updateChecklistForVehicleDocument,
 } from "../lib/checklist";
 import { buildDeletedOpportunitySnapshot } from "../lib/deleted-opportunity-audit";
-import {
-	getGuatemalaMonthWindow,
-} from "../lib/guatemala-month-window";
+import { getGuatemalaMonthWindow } from "../lib/guatemala-month-window";
 import {
 	formatMissingLeadFields,
 	getMissingLeadFieldsForContracts,
@@ -104,6 +102,21 @@ type ClientCreditFetcher = (params: {
 	perPage: number;
 }) => Promise<{
 	data: CarteraClientCredit[];
+	totalPages?: number | null;
+}>;
+
+type ClientCreditPageFetcher = (params: {
+	mes: number;
+	anio: number;
+	estado: ClientCreditCarteraStatus;
+	page: number;
+	perPage: number;
+	nombre_usuario?: string;
+	numero_credito_sifco?: string;
+	numeros_credito_sifco?: string[];
+}) => Promise<{
+	data: CarteraClientCredit[];
+	totalCount?: number | null;
 	totalPages?: number | null;
 }>;
 
@@ -239,10 +252,95 @@ export async function getCurrentClientCreditsFromCartera(
 	fetchCredits: ClientCreditFetcher = (params) =>
 		carteraBackClient.getAllCreditos(params),
 ) {
-	return getClientCreditsFromCartera(
-		fetchCredits,
-		{ mes: 0, anio: 0 },
-	);
+	return getClientCreditsFromCartera(fetchCredits, { mes: 0, anio: 0 });
+}
+
+const CARTERA_PAGE_FETCH_SIZE = 100;
+
+/**
+ * Trae SOLO la ventana [offset, offset+limit) del portafolio vigente, tratando
+ * los estados ACTIVO/MOROSO/EN_CONVENIO como una lista concatenada. Evita bajar
+ * toda la cartera: pide a cartera-back únicamente las páginas que la ventana
+ * toca y usa el `totalCount` que ya devuelve `getAllCreditos` para el total.
+ *
+ * Cuando la ventana ya está completa, los estados restantes se consultan con una
+ * sonda mínima (perPage=1) solo para acumular el conteo total.
+ */
+export async function getClientCreditsPageFromCartera(
+	params: {
+		offset: number;
+		limit: number;
+		nombreUsuario?: string;
+		sifcoExacto?: string;
+		sifcos?: string[];
+	},
+	fetchCredits: ClientCreditPageFetcher = (p) =>
+		carteraBackClient.getAllCreditos(p),
+): Promise<{ credits: CarteraClientCredit[]; total: number }> {
+	const perPage = CARTERA_PAGE_FETCH_SIZE;
+	const filtros = {
+		mes: 0,
+		anio: 0,
+		...(params.nombreUsuario ? { nombre_usuario: params.nombreUsuario } : {}),
+		...(params.sifcoExacto ? { numero_credito_sifco: params.sifcoExacto } : {}),
+		...(params.sifcos && params.sifcos.length > 0
+			? { numeros_credito_sifco: params.sifcos }
+			: {}),
+	};
+
+	const credits: CarteraClientCredit[] = [];
+	let total = 0;
+	let skip = Math.max(0, params.offset);
+	let need = Math.max(0, params.limit);
+
+	for (const estado of CLIENT_CREDIT_CARTERA_STATUSES) {
+		if (need <= 0) {
+			// La ventana ya está completa: solo necesitamos el conteo de este
+			// estado para el total.
+			const probe = await fetchCredits({
+				...filtros,
+				estado,
+				page: 1,
+				perPage: 1,
+			});
+			total += probe.totalCount ?? probe.data.length;
+			continue;
+		}
+
+		// La ventana puede caer en este estado. Arrancamos en la página que
+		// contiene el índice local `skip`.
+		let localStart = skip;
+		let page = Math.floor(localStart / perPage) + 1;
+		let resp = await fetchCredits({ ...filtros, estado, page, perPage });
+		const count = resp.totalCount ?? resp.data.length;
+		total += count;
+
+		if (localStart >= count) {
+			// La ventana todavía no llega a este estado; lo saltamos completo.
+			skip = localStart - count;
+			continue;
+		}
+
+		// Recolectar desde `localStart` hasta agotar `need` o el estado.
+		while (need > 0 && localStart < count) {
+			const pageStart = (page - 1) * perPage;
+			const slice = resp.data.slice(
+				localStart - pageStart,
+				localStart - pageStart + need,
+			);
+			if (slice.length === 0) break;
+			credits.push(...slice);
+			need -= slice.length;
+			localStart += slice.length;
+			if (need > 0 && localStart < count) {
+				page += 1;
+				resp = await fetchCredits({ ...filtros, estado, page, perPage });
+			}
+		}
+		skip = 0;
+	}
+
+	return { credits, total };
 }
 
 function splitFullName(fullName: string | null | undefined) {
@@ -342,38 +440,6 @@ export function buildCarteraMatchedClientRows(params: {
 	}
 
 	return rows;
-}
-
-export function calculateCarteraClientStats(params: {
-	carteraCredits: CarteraClientCredit[];
-	matchedSifcos: Set<string>;
-	uniqueLeadCount: number;
-	scopedOpportunityCount: number;
-	userRole: string | null | undefined;
-}) {
-	const visibleCredits =
-		params.userRole === "sales"
-			? params.carteraCredits.filter((credit) => {
-					const sifco = credit.creditos?.numero_credito_sifco?.trim();
-					return sifco ? params.matchedSifcos.has(sifco) : false;
-				})
-			: params.carteraCredits;
-
-	return {
-		totalClients:
-			params.userRole === "sales"
-				? params.matchedSifcos.size
-				: params.carteraCredits.length,
-		totalClosedOpportunities: params.scopedOpportunityCount,
-		totalValue: visibleCredits.reduce(
-			(sum, credit) => sum + getCarteraCreditAmount(credit),
-			0,
-		),
-		missingCrmCount:
-			params.userRole === "sales"
-				? 0
-				: Math.max(0, params.carteraCredits.length - params.matchedSifcos.size),
-	};
 }
 
 export const getLeadsInputSchema = z.object({
@@ -3321,117 +3387,141 @@ export const crmRouter = {
 			}),
 		)
 		.handler(async ({ input, context }) => {
-			const { limit, offset, search } = input;
+			const { limit, offset } = input;
+			const searchValue = input.search?.trim();
+			// Solo se busca por nombre o por No. SIFCO (no email ni teléfono). El
+			// filtro lo hace cartera: nombre vía nombre_usuario y, si el término es
+			// solo dígitos (largo), como SIFCO exacto.
+			const looksLikeSifco =
+				!!searchValue && /^\d{6,}$/.test(searchValue.replace(/\s/g, ""));
+			const nombreUsuario =
+				searchValue && !looksLikeSifco ? searchValue : undefined;
+			const sifcoExacto = looksLikeSifco
+				? searchValue?.replace(/\s/g, "")
+				: undefined;
 
-			const carteraCredits = await getCurrentClientCreditsFromCartera();
-			const clientCreditSifcos = carteraCredits
-				.map((row) => row.creditos?.numero_credito_sifco?.trim())
-				.filter((sifco): sifco is string => Boolean(sifco));
-			const carteraCreditBySifco = new Map(
-				carteraCredits
-					.map(
-						(row) => [row.creditos?.numero_credito_sifco?.trim(), row] as const,
-					)
-					.filter((entry): entry is readonly [string, CarteraClientCredit] =>
-						Boolean(entry[0]),
-					),
-			);
-
-			if (clientCreditSifcos.length === 0) {
-				return {
-					data: [],
-					total: 0,
-					limit,
-					offset,
-				};
-			}
-
-			// Find leads with at least one credit currently active, overdue, or in agreement in cartera.
-			const leadsWithClientCredits = await db
-				.selectDistinct({ leadId: opportunities.leadId })
-				.from(opportunities)
-				.where(
-					and(
-						isNotNull(opportunities.leadId),
-						inArray(opportunities.numeroSifco, clientCreditSifcos),
-					),
-				);
-
-			const clientLeadIds = leadsWithClientCredits
-				.map((r) => r.leadId)
-				.filter((id): id is string => id !== null);
-
-			// Build conditions for the main query
-			const conditions: any[] = [];
-			if (clientLeadIds.length > 0) {
-				conditions.push(
-					sql`${leads.id} IN (${sql.join(
-						clientLeadIds.map((id) => sql`${id}`),
-						sql`, `,
-					)})`,
-				);
-			} else {
-				conditions.push(sql`false`);
-			}
-
-			// Filter by user if not admin/sales_supervisor
-			if (context.userRole === "sales") {
-				conditions.push(eq(leads.assignedTo, context.userId));
-			}
-
-			// Filter by specific lead ID
+			// Vistas acotadas: en lugar de bajar toda la cartera, resolvemos en la
+			// DB local los SIFCOs relevantes y se los pasamos a cartera para que
+			// pagine solo ese subconjunto.
+			//  - leadId: solo los créditos de ese lead (modal de detalle)
+			//  - rol sales: solo los créditos de los leads asignados al asesor
+			let scopedSifcos: string[] | undefined;
 			if (input.leadId) {
-				conditions.push(eq(leads.id, input.leadId));
+				const opps = await db
+					.select({ numeroSifco: opportunities.numeroSifco })
+					.from(opportunities)
+					.where(
+						and(
+							eq(opportunities.leadId, input.leadId),
+							isNotNull(opportunities.numeroSifco),
+						),
+					);
+				scopedSifcos = opps
+					.map((o) => o.numeroSifco)
+					.filter((s): s is string => Boolean(s));
+			} else if (context.userRole === "sales") {
+				const opps = await db
+					.select({ numeroSifco: opportunities.numeroSifco })
+					.from(opportunities)
+					.leftJoin(leads, eq(opportunities.leadId, leads.id))
+					.where(
+						and(
+							eq(leads.assignedTo, context.userId),
+							isNotNull(opportunities.numeroSifco),
+						),
+					);
+				scopedSifcos = opps
+					.map((o) => o.numeroSifco)
+					.filter((s): s is string => Boolean(s));
 			}
 
-			const whereClause = and(...conditions);
+			// Vista acotada sin créditos => nada que mostrar (no consultar cartera).
+			if (scopedSifcos && scopedSifcos.length === 0) {
+				return { data: [], total: 0, limit, offset };
+			}
 
-			// Get paginated leads
-			const clientLeads = await db
-				.select({
-					id: leads.id,
-					firstName: leads.firstName,
-					middleName: leads.middleName,
-					lastName: leads.lastName,
-					secondLastName: leads.secondLastName,
-					email: leads.email,
-					phone: leads.phone,
-					dpi: leads.dpi,
-					nit: leads.nit,
-					age: leads.age,
-					clientType: leads.clientType,
-					maritalStatus: leads.maritalStatus,
-					dependents: leads.dependents,
-					monthlyIncome: leads.monthlyIncome,
-					loanAmount: leads.loanAmount,
-					occupation: leads.occupation,
-					workTime: leads.workTime,
-					ownsHome: leads.ownsHome,
-					ownsVehicle: leads.ownsVehicle,
-					hasCreditCard: leads.hasCreditCard,
-					jobTitle: leads.jobTitle,
-					direccion: leads.direccion,
-					departamento: leads.departamento,
-					municipio: leads.municipio,
-					zona: leads.zona,
-					assignedTo: leads.assignedTo,
-					createdAt: leads.createdAt,
-					updatedAt: leads.updatedAt,
-					assignedUser: {
-						id: user.id,
-						name: user.name,
-					},
-				})
-				.from(leads)
-				.leftJoin(user, eq(leads.assignedTo, user.id))
-				.where(whereClause)
-				.orderBy(desc(leads.createdAt));
+			// Traer SOLO la ventana visible desde cartera. El nombre y el SIFCO se
+			// filtran en el origen (cartera); el alcance sales/leadId va por SIFCOs.
+			const { credits, total } = await getClientCreditsPageFromCartera({
+				offset,
+				limit,
+				nombreUsuario,
+				sifcoExacto,
+				sifcos: scopedSifcos,
+			});
 
-			// Now get the opportunities for each lead
-			const leadIds = clientLeads.map((l) => l.id);
+			const pageSifcos = credits
+				.map((c) => c.creditos?.numero_credito_sifco?.trim())
+				.filter((s): s is string => Boolean(s));
 
+			// Enriquecer SOLO la página con datos del CRM.
+			// 1) Oportunidades cuyo numeroSifco está en la página -> sifco -> leadId
+			const matchingOpps =
+				pageSifcos.length > 0
+					? await db
+							.select({
+								numeroSifco: opportunities.numeroSifco,
+								leadId: opportunities.leadId,
+							})
+							.from(opportunities)
+							.where(inArray(opportunities.numeroSifco, pageSifcos))
+					: [];
+
+			const sifcoToLeadId = new Map<string, string>();
+			for (const o of matchingOpps) {
+				if (o.numeroSifco && o.leadId && !sifcoToLeadId.has(o.numeroSifco)) {
+					sifcoToLeadId.set(o.numeroSifco, o.leadId);
+				}
+			}
+			const matchedLeadIds = Array.from(new Set(sifcoToLeadId.values()));
+
+			// 2) Datos completos de esos leads
+			const leadsData =
+				matchedLeadIds.length > 0
+					? await db
+							.select({
+								id: leads.id,
+								firstName: leads.firstName,
+								middleName: leads.middleName,
+								lastName: leads.lastName,
+								secondLastName: leads.secondLastName,
+								email: leads.email,
+								phone: leads.phone,
+								dpi: leads.dpi,
+								nit: leads.nit,
+								age: leads.age,
+								clientType: leads.clientType,
+								maritalStatus: leads.maritalStatus,
+								dependents: leads.dependents,
+								monthlyIncome: leads.monthlyIncome,
+								loanAmount: leads.loanAmount,
+								occupation: leads.occupation,
+								workTime: leads.workTime,
+								ownsHome: leads.ownsHome,
+								ownsVehicle: leads.ownsVehicle,
+								hasCreditCard: leads.hasCreditCard,
+								jobTitle: leads.jobTitle,
+								direccion: leads.direccion,
+								departamento: leads.departamento,
+								municipio: leads.municipio,
+								zona: leads.zona,
+								assignedTo: leads.assignedTo,
+								createdAt: leads.createdAt,
+								updatedAt: leads.updatedAt,
+								assignedUser: {
+									id: user.id,
+									name: user.name,
+								},
+							})
+							.from(leads)
+							.leftJoin(user, eq(leads.assignedTo, user.id))
+							.where(inArray(leads.id, matchedLeadIds))
+					: [];
+			const leadById = new Map(leadsData.map((l) => [l.id, l]));
+
+			// 3) Todas las oportunidades de esos leads (para la lista del row)
 			const leadsOpportunities =
-				leadIds.length > 0
+				matchedLeadIds.length > 0
 					? await db
 							.select({
 								id: opportunities.id,
@@ -3451,16 +3541,10 @@ export const crmRouter = {
 							})
 							.from(opportunities)
 							.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
-							.where(
-								sql`${opportunities.leadId} IN (${sql.join(
-									leadIds.map((id) => sql`${id}`),
-									sql`, `,
-								)})`,
-							)
+							.where(inArray(opportunities.leadId, matchedLeadIds))
 							.orderBy(desc(opportunities.createdAt))
 					: [];
 
-			// Group opportunities by lead
 			const opportunitiesByLead = leadsOpportunities.reduce(
 				(acc, opp) => {
 					const leadId = opp.leadId;
@@ -3477,9 +3561,9 @@ export const crmRouter = {
 							status: opp.status,
 							createdAt: opp.createdAt,
 							stage: opp.stage,
-							isClosed:
-								opp.numeroSifco != null &&
-								clientCreditSifcos.includes(opp.numeroSifco),
+							// Una oportunidad cuenta como "colocada" cuando tiene número
+							// SIFCO (se generó al desembolsar el crédito en cartera).
+							isClosed: opp.numeroSifco != null,
 						});
 					}
 					return acc;
@@ -3487,9 +3571,9 @@ export const crmRouter = {
 				{} as Record<string, any[]>,
 			);
 
-			// Get credit analysis for each lead
+			// 4) Análisis de crédito de esos leads
 			const creditAnalysisByLead =
-				leadIds.length > 0
+				matchedLeadIds.length > 0
 					? await db
 							.select({
 								leadId: creditAnalysis.leadId,
@@ -3503,15 +3587,8 @@ export const crmRouter = {
 								analyzedAt: creditAnalysis.analyzedAt,
 							})
 							.from(creditAnalysis)
-							.where(
-								sql`${creditAnalysis.leadId} IN (${sql.join(
-									leadIds.map((id) => sql`${id}`),
-									sql`, `,
-								)})`,
-							)
+							.where(inArray(creditAnalysis.leadId, matchedLeadIds))
 					: [];
-
-			// Map credit analysis by lead ID
 			const creditAnalysisMap = creditAnalysisByLead.reduce(
 				(acc, ca) => {
 					if (ca.leadId) {
@@ -3522,127 +3599,79 @@ export const crmRouter = {
 				{} as Record<string, (typeof creditAnalysisByLead)[0]>,
 			);
 
-			// Combine leads with their opportunities and credit analysis
-			const crmRows = clientLeads.flatMap((lead) => {
-				const leadOpportunities = opportunitiesByLead[lead.id] || [];
-				return buildCarteraMatchedClientRows({
-					lead,
-					leadOpportunities,
-					creditAnalysis: creditAnalysisMap[lead.id] || null,
-					carteraCreditBySifco,
-				});
+			// 5) Construir filas en el orden en que cartera devolvió los créditos.
+			const data = credits.flatMap<
+				MatchedClientRow | ReturnType<typeof buildCarteraOnlyClientRow>
+			>((credit) => {
+				const sifco = credit.creditos?.numero_credito_sifco?.trim();
+				if (!sifco) return [];
+				const leadId = sifcoToLeadId.get(sifco);
+				const lead = leadId ? leadById.get(leadId) : undefined;
+				if (leadId && lead) {
+					return buildCarteraMatchedClientRows({
+						lead,
+						leadOpportunities: opportunitiesByLead[leadId] || [],
+						creditAnalysis: creditAnalysisMap[leadId] || null,
+						carteraCreditBySifco: new Map([[sifco, credit]]),
+					});
+				}
+				// Sin match CRM: las filas "sólo cartera" no aplican en vistas acotadas.
+				if (scopedSifcos) return [];
+				return [buildCarteraOnlyClientRow(credit)];
 			});
-			const matchedSifcos = new Set(
-				crmRows
-					.map((row) => row.carteraCredit?.numeroSifco)
-					.filter((sifco): sifco is string => Boolean(sifco)),
-			);
 
-			const carteraOnlyRows = carteraCredits
-				.filter((credit) => {
-					const sifco = credit.creditos?.numero_credito_sifco?.trim();
-					return sifco && !matchedSifcos.has(sifco);
-				})
-				.map(buildCarteraOnlyClientRow);
-
-			const searchValue = search?.trim().toLowerCase();
-			const fromDate = input.dateFrom ? new Date(input.dateFrom) : null;
-			const toDate = input.dateTo ? new Date(input.dateTo) : null;
-			if (toDate) toDate.setHours(23, 59, 59, 999);
-
-			const visibleCarteraOnlyRows =
-				input.leadId || context.userRole === "sales" ? [] : carteraOnlyRows;
-			const allRows = [...crmRows, ...visibleCarteraOnlyRows]
-				.filter((row) => {
-					if (!searchValue) return true;
-					return [
-						row.firstName,
-						(row as any).middleName,
-						row.lastName,
-						(row as any).secondLastName,
-						row.email,
-						row.phone,
-						row.dpi,
-						(row as any).nit,
-						(row as any).carteraCredit?.numeroSifco,
-					]
-						.filter(Boolean)
-						.some((value) => String(value).toLowerCase().includes(searchValue));
-				})
-				.filter((row) => {
-					if (fromDate && row.createdAt < fromDate) return false;
-					if (toDate && row.createdAt > toDate) return false;
-					return true;
-				})
-				.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
-
-			const data = allRows.slice(offset, offset + limit);
-
-			return {
-				data,
-				total: allRows.length,
-				limit,
-				offset,
-			};
+			return { data, total, limit, offset };
 		}),
 
-	// Estadísticas de leads como clientes (totales globales, no paginados)
+	// Estadísticas de clientes (baratas: no barren toda la cartera).
 	getLeadsAsClientsStats: crmProcedure.handler(async ({ context }) => {
-		const carteraCredits = await getCurrentClientCreditsFromCartera();
-		const clientCreditSifcos = carteraCredits
-			.map((row) => row.creditos?.numero_credito_sifco?.trim())
-			.filter((sifco): sifco is string => Boolean(sifco));
-
-		if (clientCreditSifcos.length === 0) {
-			return {
-				totalClients: 0,
-				totalClosedOpportunities: 0,
-				totalValue: 0,
-				missingCrmCount: 0,
-			};
+		// Para asesores la vista está acotada a sus créditos.
+		let scopedSifcos: string[] | undefined;
+		if (context.userRole === "sales") {
+			const opps = await db
+				.select({ numeroSifco: opportunities.numeroSifco })
+				.from(opportunities)
+				.leftJoin(leads, eq(opportunities.leadId, leads.id))
+				.where(
+					and(
+						eq(leads.assignedTo, context.userId),
+						isNotNull(opportunities.numeroSifco),
+					),
+				);
+			scopedSifcos = opps
+				.map((o) => o.numeroSifco)
+				.filter((s): s is string => Boolean(s));
+			if (scopedSifcos.length === 0) {
+				return { totalClients: 0, totalValue: 0 };
+			}
 		}
 
-		const clientCreditOpportunityCondition = and(
-			isNotNull(opportunities.leadId),
-			inArray(opportunities.numeroSifco, clientCreditSifcos),
-		);
-
-		const clientCreditOpportunitiesData = await db
-			.select({
-				leadId: opportunities.leadId,
-				numeroSifco: opportunities.numeroSifco,
-				value: opportunities.value,
-			})
-			.from(opportunities)
-			.leftJoin(leads, eq(opportunities.leadId, leads.id))
-			.where(
-				context.userRole === "sales"
-					? and(
-							clientCreditOpportunityCondition,
-							eq(leads.assignedTo, context.userId),
-						)
-					: clientCreditOpportunityCondition,
-			);
-
-		// Calculate stats
-		const uniqueLeadIds = new Set(
-			clientCreditOpportunitiesData
-				.map((o) => o.leadId)
-				.filter((id): id is string => id !== null),
-		);
-		const matchedSifcos = new Set(
-			clientCreditOpportunitiesData
-				.map((o: any) => o.numeroSifco)
-				.filter((sifco: unknown): sifco is string => typeof sifco === "string"),
-		);
-
-		return calculateCarteraClientStats({
-			carteraCredits,
-			matchedSifcos,
-			uniqueLeadCount: uniqueLeadIds.size,
-			scopedOpportunityCount: clientCreditOpportunitiesData.length,
-			userRole: context.userRole,
+		// Total de clientes vigentes: el helper con limit=0 solo suma los
+		// totalCount de los 3 estados (no recolecta filas).
+		const { total } = await getClientCreditsPageFromCartera({
+			offset: 0,
+			limit: 0,
+			sifcos: scopedSifcos,
 		});
+
+		// Valor total: stats agregadas de cartera (suma de capital de la cartera
+		// activa). Solo para vistas globales; para asesores no hay un agregado
+		// barato acotado, así que se omite.
+		let totalValue = 0;
+		if (context.userRole !== "sales") {
+			try {
+				const stats = await carteraBackClient.getStats();
+				totalValue = Object.values(stats.porCuotasAtrasadas).reduce(
+					(sum, bucket) =>
+						sum + (Number.parseFloat(bucket?.sumaCapital ?? "0") || 0),
+					0,
+				);
+			} catch (error) {
+				console.error("[getLeadsAsClientsStats] getStats falló:", error);
+			}
+		}
+
+		return { totalClients: total, totalValue };
 	}),
 
 	createClient: crmProcedure

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -83,6 +83,7 @@ export const crmAppRouter = {
 	getClientsStats: crmRouter.getClientsStats,
 	getLeadsAsClients: crmRouter.getLeadsAsClients,
 	getLeadsAsClientsStats: crmRouter.getLeadsAsClientsStats,
+	exportClientsForMarketing: crmRouter.exportClientsForMarketing,
 	createClient: crmRouter.createClient,
 	updateClient: crmRouter.updateClient,
 	getDashboardStats: crmRouter.getDashboardStats,

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -641,24 +641,28 @@ function RouteComponent() {
 						</p>
 					</CardContent>
 				</Card>
-				<Card>
-					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle className="font-medium text-sm">Valor Total</CardTitle>
-						<Banknote className="h-4 w-4 text-purple-500" />
-					</CardHeader>
-					<CardContent>
-						<div className="font-bold text-2xl">
-							Q
-							{(statsQuery.data?.totalValue ?? 0).toLocaleString("es-GT", {
-								minimumFractionDigits: 2,
-								maximumFractionDigits: 2,
-							})}
-						</div>
-						<p className="text-muted-foreground text-xs">
-							Deuda total en cartera vigente
-						</p>
-					</CardContent>
-				</Card>
+				{/* "Valor Total" es global; se oculta a los vendedores (no hay un
+				    agregado acotado a su cartera, mostraría Q0.00 engañoso). */}
+				{userProfile.data.role !== "sales" && (
+					<Card>
+						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+							<CardTitle className="font-medium text-sm">Valor Total</CardTitle>
+							<Banknote className="h-4 w-4 text-purple-500" />
+						</CardHeader>
+						<CardContent>
+							<div className="font-bold text-2xl">
+								Q
+								{(statsQuery.data?.totalValue ?? 0).toLocaleString("es-GT", {
+									minimumFractionDigits: 2,
+									maximumFractionDigits: 2,
+								})}
+							</div>
+							<p className="text-muted-foreground text-xs">
+								Deuda total en cartera vigente
+							</p>
+						</CardContent>
+					</Card>
+				)}
 			</div>
 
 			<Card>

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -641,12 +641,15 @@ function RouteComponent() {
 						</p>
 					</CardContent>
 				</Card>
-				{/* "Valor Total" es global; se oculta a los vendedores (no hay un
-				    agregado acotado a su cartera, mostraría Q0.00 engañoso). */}
+				{/* Capital de la cartera activa (suma de capital vía /stats). Es
+				    global; se oculta a los vendedores (no hay un agregado acotado a
+				    su cartera, mostraría Q0.00 engañoso). */}
 				{userProfile.data.role !== "sales" && (
 					<Card>
 						<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-							<CardTitle className="font-medium text-sm">Valor Total</CardTitle>
+							<CardTitle className="font-medium text-sm">
+								Capital en cartera
+							</CardTitle>
 							<Banknote className="h-4 w-4 text-purple-500" />
 						</CardHeader>
 						<CardContent>
@@ -658,7 +661,7 @@ function RouteComponent() {
 								})}
 							</div>
 							<p className="text-muted-foreground text-xs">
-								Deuda total en cartera vigente
+								Capital de créditos activos
 							</p>
 						</CardContent>
 					</Card>

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -32,7 +32,6 @@ import {
 	OpportunityDetailModal,
 	type OpportunityForModal,
 } from "@/components/opportunity-detail-modal";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -65,7 +64,6 @@ import {
 	TooltipProvider,
 	TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
@@ -259,17 +257,13 @@ function RouteComponent() {
 		"",
 	);
 	const [debouncedSearch, setDebouncedSearch] = useState(searchTerm);
-	const [dateRange, setDateRange] = usePersistedDateRange(
-		"crm/clients/dateRange",
-	);
 	const [page, setPage] = usePersistedState<number>("crm/clients/page", 0);
 	const pageSize = 20;
 
-	const hasActiveFilters = searchTerm !== "" || dateRange !== undefined;
+	const hasActiveFilters = searchTerm !== "";
 	const resetFilters = () => {
 		setSearchTerm("");
 		setDebouncedSearch("");
-		setDateRange(undefined);
 		setPage(0);
 	};
 
@@ -422,8 +416,6 @@ function RouteComponent() {
 				limit: pageSize,
 				offset: page * pageSize,
 				search: debouncedSearch || undefined,
-				dateFrom: dateRange?.from?.toISOString(),
-				dateTo: dateRange?.to?.toISOString(),
 			},
 		}),
 		enabled:
@@ -437,8 +429,6 @@ function RouteComponent() {
 			page,
 			pageSize,
 			debouncedSearch,
-			dateRange?.from?.toISOString(),
-			dateRange?.to?.toISOString(),
 		],
 	});
 
@@ -554,7 +544,7 @@ function RouteComponent() {
 			</div>
 
 			{/* Summary Stats */}
-			<div className="grid gap-4 md:grid-cols-3">
+			<div className="grid gap-4 md:grid-cols-2">
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="font-medium text-sm">
@@ -568,20 +558,6 @@ function RouteComponent() {
 						</div>
 						<p className="text-muted-foreground text-xs">
 							Créditos activos, morosos o en convenio
-						</p>
-					</CardContent>
-				</Card>
-				<Card>
-					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-						<CardTitle className="font-medium text-sm">Con CRM</CardTitle>
-						<CheckCircle2 className="h-4 w-4 text-green-500" />
-					</CardHeader>
-					<CardContent>
-						<div className="font-bold text-2xl">
-							{statsQuery.data?.totalClosedOpportunities ?? 0}
-						</div>
-						<p className="text-muted-foreground text-xs">
-							Créditos con oportunidad enlazada
 						</p>
 					</CardContent>
 				</Card>
@@ -623,19 +599,12 @@ function RouteComponent() {
 						<div className="relative max-w-md flex-1">
 							<Search className="absolute top-2.5 left-2 h-4 w-4 text-muted-foreground" />
 							<Input
-								placeholder="Buscar por nombre, NIT, SIFCO, email o teléfono..."
+								placeholder="Buscar por nombre o No. SIFCO..."
 								value={searchTerm}
 								onChange={(e) => setSearchTerm(e.target.value)}
 								className="pl-8"
 							/>
 						</div>
-						<DateRangeFilter
-							dateRange={dateRange}
-							onDateRangeChange={(range) => {
-								setDateRange(range);
-								setPage(0);
-							}}
-						/>
 						{hasActiveFilters && (
 							<Button
 								variant="ghost"
@@ -645,12 +614,6 @@ function RouteComponent() {
 							>
 								<X className="mr-1 h-3 w-3" />
 								Limpiar filtros
-								<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
-									{
-										[searchTerm !== "", dateRange !== undefined].filter(Boolean)
-											.length
-									}
-								</Badge>
 							</Button>
 						)}
 					</div>

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import * as XLSX from "xlsx";
 import { z } from "zod";
 import {
 	OpportunityDetailModal,
@@ -168,6 +169,52 @@ const getCarteraStatusClassName = (status?: string | null) => {
 			return "bg-muted text-muted-foreground";
 	}
 };
+
+// Genera y descarga un Excel (.xlsx) de la base de clientes para marketing
+function downloadClientsExcel(
+	rows: Array<{
+		nombre: string;
+		telefono: string;
+		correo: string;
+		valorVehiculo: string;
+	}>,
+) {
+	const headers = ["Nombre", "Teléfono", "Correo", "Valor del vehículo"];
+	const body = rows.map((r) => {
+		// El valor va como número para que Excel lo trate como tal (ordenar/sumar).
+		const num = Number(r.valorVehiculo);
+		const valor =
+			r.valorVehiculo && Number.isFinite(num) ? num : r.valorVehiculo;
+		return [r.nombre, r.telefono, r.correo, valor];
+	});
+	const matrix = [headers, ...body];
+	const worksheet = XLSX.utils.aoa_to_sheet(matrix);
+
+	// Ancho de cada columna según el contenido más largo (con piso y techo).
+	worksheet["!cols"] = headers.map((header, col) => {
+		const maxLen = matrix.reduce((max, row) => {
+			const cell = row[col];
+			return Math.max(max, cell == null ? 0 : String(cell).length);
+		}, header.length);
+		return { wch: Math.min(Math.max(maxLen + 2, 12), 60) };
+	});
+
+	// Formato de miles/decimales para la columna "Valor del vehículo" (D).
+	for (let i = 0; i < body.length; i++) {
+		const ref = XLSX.utils.encode_cell({ r: i + 1, c: 3 });
+		const cell = worksheet[ref];
+		if (cell && typeof cell.v === "number") {
+			cell.z = "#,##0.00";
+		}
+	}
+
+	const workbook = XLSX.utils.book_new();
+	XLSX.utils.book_append_sheet(workbook, worksheet, "Clientes");
+	XLSX.writeFile(
+		workbook,
+		`clientes-${new Date().toISOString().slice(0, 10)}.xlsx`,
+	);
+}
 
 // Type definition for credit analysis
 type CreditAnalysisData = {
@@ -491,6 +538,22 @@ function RouteComponent() {
 		},
 	});
 
+	// Export de la base de clientes (CRM) para marketing/lookalike
+	const exportMutation = useMutation({
+		mutationFn: () => client.exportClientsForMarketing(),
+		onSuccess: (result) => {
+			if (!result.data.length) {
+				toast.info("No hay clientes para exportar");
+				return;
+			}
+			downloadClientsExcel(result.data);
+			toast.success(`${result.total} clientes exportados`);
+		},
+		onError: (error: any) => {
+			toast.error(error.message || "Error al exportar la base");
+		},
+	});
+
 	const handleStartEditContact = () => {
 		if (!selectedClient) return;
 		setEditForm({
@@ -536,11 +599,28 @@ function RouteComponent() {
 
 	return (
 		<div className="container mx-auto space-y-6 p-6">
-			<div>
-				<h1 className="font-bold text-3xl">Cartera de Clientes</h1>
-				<p className="text-muted-foreground">
-					Créditos vigentes de cartera enriquecidos con CRM cuando existe match
-				</p>
+			<div className="flex flex-wrap items-start justify-between gap-4">
+				<div>
+					<h1 className="font-bold text-3xl">Cartera de Clientes</h1>
+					<p className="text-muted-foreground">
+						Créditos vigentes de cartera enriquecidos con CRM cuando existe
+						match
+					</p>
+				</div>
+				{PERMISSIONS.canExportReports(userProfile.data.role) && (
+					<Button
+						variant="outline"
+						onClick={() => exportMutation.mutate()}
+						disabled={exportMutation.isPending}
+					>
+						{exportMutation.isPending ? (
+							<Loader2 className="mr-2 h-4 w-4 animate-spin" />
+						) : (
+							<Download className="mr-2 h-4 w-4" />
+						)}
+						Descargar base de clientes
+					</Button>
+				)}
 			</div>
 
 			{/* Summary Stats */}
@@ -548,7 +628,7 @@ function RouteComponent() {
 				<Card>
 					<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 						<CardTitle className="font-medium text-sm">
-							Total de Clientes
+							Total de Créditos
 						</CardTitle>
 						<HandshakeIcon className="h-4 w-4 text-muted-foreground" />
 					</CardHeader>


### PR DESCRIPTION
Jira: [EXTRAIT-119](https://clubcashin.atlassian.net/browse/EXTRAIT-119)

> Reemplaza al PR #967 (se cerró por exceso de hilos de review). Incluye todo lo de aquel PR + las correcciones de los comentarios ya aplicadas.

## Contexto
La pantalla **Cartera de Clientes** (`/crm/clients`) bajaba **todo** el portafolio vigente de cartera-back en cada carga (y duplicado: lista + tarjetas), paginando en memoria → muy lenta. Además, Marketing pidió descargar la base de clientes de crédito (Nombre, Teléfono, Correo, valor del vehículo) para una audiencia *lookalike*.

## 1. Paginación contra cartera (perf)
- Helper `getClientCreditsPageFromCartera`: trae **solo la ventana visible** `[offset, offset+limit)`. En cartera-back, `estado: "ACTIVO"` sin `cuotas_atrasadas` ya devuelve `ACTIVO + MOROSO + EN_CONVENIO`, así que es **una sola consulta paginada** (sin doble conteo ni duplicados). La página visible se enriquece con datos del CRM por SIFCO.
- `getLeadsAsClientsStats`: stats baratos. Total = `totalCount` de cartera; "Capital en cartera" = suma de `sumaCapital` vía `/stats`. Se quitó la tarjeta "Con CRM".
- Búsqueda por **nombre** (`nombre_usuario`) o **No. SIFCO** exacto (sin email/teléfono).

## 2. Export a Excel (marketing / lookalike)
- Botón **"Descargar base"** (rol admin/analyst/supervisor) → `.xlsx` con **Nombre, Teléfono, Correo, Valor del vehículo**.
- `exportClientsForMarketing` (CRM-only): una fila por cliente que cerró crédito (oportunidad con `numeroSifco`), **ordenada por fecha de cierre (`actualCloseDate`) más reciente primero**.
- **Valor del vehículo** = `insured_amount` de la **cotización más reciente** de la opp; si no hay, `opportunities.value`.
- Excel con anchos de columna automáticos y formato numérico en el valor.

## Correcciones de review (de los comentarios del PR anterior)
- **Doble conteo/duplicados**: el pager hace una sola consulta `ACTIVO` (no itera los 3 estados).
- **SIFCO exacto en vista acotada**: no se mandan a cartera el SIFCO único y la lista de alcance juntos (cartera prioriza la lista); se valida pertenencia y se manda solo el SIFCO.
- **`Valor Total` Q0.00 para vendedores**: stats devuelve `null` para sales y el front oculta la tarjeta.
- **Rótulo de la tarjeta**: era "Deuda total" pero mostraba capital → renombrada a "Capital en cartera".
- **Seguridad (IDOR)**: el lookup por `leadId` exige `leads.assignedTo = userId` para sales, así un asesor no puede abrir clientes ajenos vía `?idLead`.

## Decisiones a confirmar
- **Una fila por cliente** (no por crédito): si tiene varios créditos, se usa el del cierre más reciente.
- Se incluyen **todos** los que cerraron crédito, aunque falte teléfono/correo (la base completa; marketing filtra).

## Verificación
- `bun check-types` server y web: en verde.
- `bun test` del router (incluye tests del helper de paginado).
- Biome sin errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EXTRAIT-119]: https://clubcashin.atlassian.net/browse/EXTRAIT-119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ