### PR TITLE
fix(carteraFront): fila de Estado a ancho completo en filtros de Créditos

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -515,7 +515,7 @@ export function ListaCreditosPagos() {
         </label>
 
         {/* Filtro por Estado */}
-        <div className="flex flex-wrap items-center gap-2 sm:col-span-2">
+        <div className="flex flex-wrap items-center gap-2 col-span-full">
           <AlertCircle className="w-4 h-4 text-blue-700" />
           <span className="text-sm font-semibold text-blue-800 mr-1">Estado:</span>
           {estados.map((est) => (


### PR DESCRIPTION
## 🎯 Qué cambia

Arregla el espacio en blanco de la caja de filtros en la página de **Créditos** (carteraFront).

El grid de filtros es de 4 columnas en pantallas `lg`. La fila de **Estado** estaba con `sm:col-span-2` (media fila), por lo que en pantallas grandes:
- Los chips de estado se amontonaban y wrappeaban (`En Convenio` / `Caído` caían a una segunda línea).
- La mitad derecha de esa fila quedaba en blanco.

## ✅ Fix

`sm:col-span-2` → `col-span-full` en el contenedor de la fila de Estado. Ahora los chips se reparten a todo lo ancho en una sola línea y desaparece el hueco vacío.

Cambio de **1 línea**, solo layout — no toca lógica, estados ni queries.

| Fila | Contenido |
|---|---|
| 1 | No. Crédito SIFCO · Buscar por nombre |
| 2 | Asesores · Aseguradoras |
| 3 | **Estado** (chips a todo lo ancho) |
| 4 | Inversionistas · por página · toggle · Descargar Excel |

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
