### PR TITLE
feat(GyT): seguro GyT vs Universales + flujo aseguradoras CRM→cartera

### DIFF
--- a/apps/cartera-back/drizzle/0015_add_aseguradoras.sql
+++ b/apps/cartera-back/drizzle/0015_add_aseguradoras.sql
@@ -1,0 +1,16 @@
+-- Catálogo de aseguradoras + enlace del crédito a su aseguradora.
+-- El CRM manda siempre 'GyT' o 'Universales'; cartera hace match y, si no
+-- existe, la crea (find-or-create). Columna nullable: créditos viejos quedan NULL.
+CREATE TABLE IF NOT EXISTS cartera.aseguradoras (
+  id serial PRIMARY KEY,
+  nombre varchar(100) NOT NULL UNIQUE,
+  created_at timestamp NOT NULL DEFAULT now()
+);
+
+ALTER TABLE cartera.creditos
+  ADD COLUMN IF NOT EXISTS aseguradora_id integer REFERENCES cartera.aseguradoras(id);
+
+-- Aseguradoras conocidas (idempotente).
+INSERT INTO cartera.aseguradoras (nombre)
+VALUES ('Universales'), ('GyT')
+ON CONFLICT (nombre) DO NOTHING;

--- a/apps/cartera-back/src/controllers/createCredit.test.ts
+++ b/apps/cartera-back/src/controllers/createCredit.test.ts
@@ -70,7 +70,9 @@ mock.module("@cci/email", () => ({
   sendNewCreditNotification: mock(() => Promise.resolve()),
 }));
 
-const { insertCredit } = await import("./createCredit");
+const { insertCredit, findOrCreateAseguradora } = await import("./createCredit");
+
+type Executor = Parameters<typeof findOrCreateAseguradora>[1];
 
 const validCreditBody = {
   usuario: "Cliente prueba",
@@ -119,5 +121,69 @@ describe("insertCredit", () => {
     expect(globalInsertCalls).toBe(0);
     expect(txInsertCalls).toBeGreaterThan(0);
     expect(set.status).toBe(500);
+  });
+});
+
+describe("findOrCreateAseguradora", () => {
+  it("devuelve el id existente sin insertar", async () => {
+    const executor = {
+      select: () => ({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([{ id: 7 }]) }),
+        }),
+      }),
+      insert: () => {
+        throw new Error("no debería insertar si ya existe");
+      },
+    } as unknown as Executor;
+
+    const id = await findOrCreateAseguradora("GyT", executor);
+    expect(id).toBe(7);
+  });
+
+  it("crea y devuelve el id nuevo cuando no existe", async () => {
+    const executor = {
+      select: () => ({
+        from: () => ({
+          where: () => ({ limit: () => Promise.resolve([]) }),
+        }),
+      }),
+      insert: () => ({
+        values: () => ({
+          onConflictDoNothing: () => ({
+            returning: () => Promise.resolve([{ id: 42 }]),
+          }),
+        }),
+      }),
+    } as unknown as Executor;
+
+    const id = await findOrCreateAseguradora("MAPFRE", executor);
+    expect(id).toBe(42);
+  });
+
+  it("re-busca cuando el insert choca por carrera (onConflictDoNothing)", async () => {
+    let selectCount = 0;
+    const executor = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => {
+              selectCount += 1;
+              return Promise.resolve(selectCount === 1 ? [] : [{ id: 99 }]);
+            },
+          }),
+        }),
+      }),
+      insert: () => ({
+        values: () => ({
+          onConflictDoNothing: () => ({
+            returning: () => Promise.resolve([]),
+          }),
+        }),
+      }),
+    } as unknown as Executor;
+
+    const id = await findOrCreateAseguradora("Universales", executor);
+    expect(id).toBe(99);
   });
 });

--- a/apps/cartera-back/src/controllers/createCredit.ts
+++ b/apps/cartera-back/src/controllers/createCredit.ts
@@ -2,6 +2,7 @@ import Big from "big.js";
 import z from "zod";
 import { db } from "../database";
 import {
+  aseguradoras,
   creditos,
   creditos_rubros_otros,
   creditos_inversionistas,
@@ -14,7 +15,7 @@ import {
 import { findOrCreateAdvisorByName, getAsesorConMenorCarga } from "./advisor";
 import { findOrCreateUserByName } from "./users";
 import { sendNewCreditNotification } from "@cci/email";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 
 // ========================================
 // TIPOS E INTERFACES
@@ -62,6 +63,7 @@ interface CreditDataForInsert {
   gps: string;
   observaciones: string;
   no_poliza: string;
+  aseguradora_id?: number;
   asesor_id: number;
   como_se_entero: string; 
   plazo: number;
@@ -167,7 +169,8 @@ const creditSchema = z.object({
   gps: z.number().min(0),
   observaciones: z.string().max(1000),
   no_poliza: z.string().max(1000),
-  como_se_entero: z.string().max(100), 
+  aseguradora: z.string().max(100).optional().nullable(),
+  como_se_entero: z.string().max(100),
   plazo: z.number().int().min(1).max(360),
   cuota: z.number().min(0),
   dia_pago_mensual: z.number().int().min(1).max(31),
@@ -267,6 +270,44 @@ const validateCreditData = (creditData: CreditData, set: SetContext): Validation
 // 2. INSERCIÓN DE CRÉDITO Y RELACIONADOS
 // ========================================
 
+/**
+ * Busca la aseguradora por nombre y, si no existe, la crea (find-or-create).
+ * El CRM manda 'GyT' o 'Universales'; queda extensible a más aseguradoras.
+ */
+export const findOrCreateAseguradora = async (
+  nombre: string,
+  executor: DbExecutor = db,
+): Promise<number> => {
+  const nombreLimpio = nombre.trim();
+
+  const [existing] = await executor
+    .select({ id: aseguradoras.id })
+    .from(aseguradoras)
+    .where(sql`lower(${aseguradoras.nombre}) = lower(${nombreLimpio})`)
+    .limit(1);
+  if (existing) return existing.id;
+
+  const [created] = await executor
+    .insert(aseguradoras)
+    .values({ nombre: nombreLimpio })
+    .onConflictDoNothing()
+    .returning({ id: aseguradoras.id });
+  if (created) return created.id;
+
+  // Otro proceso la insertó en paralelo: re-buscar.
+  const [row] = await executor
+    .select({ id: aseguradoras.id })
+    .from(aseguradoras)
+    .where(sql`lower(${aseguradoras.nombre}) = lower(${nombreLimpio})`)
+    .limit(1);
+  if (!row) {
+    throw new Error(
+      `No se pudo resolver la aseguradora "${nombreLimpio}" tras conflicto`,
+    );
+  }
+  return row.id;
+};
+
 const insertCreditAndRelated = async (creditData: CreditData, executor: DbExecutor = db): Promise<{
   newCredit: NewCredit;
   creditDataForInsert: CreditDataForInsert;
@@ -311,6 +352,15 @@ const insertCreditAndRelated = async (creditData: CreditData, executor: DbExecut
       (inv: Inversionista) => Number(inv.porcentaje_inversion) > 1
     ) ? "Pool" : "Individual";
 
+  // Aseguradora (find-or-create). Si el CRM no la manda, queda NULL.
+  let aseguradora_id: number | undefined;
+  if (creditData.aseguradora) {
+    aseguradora_id = await findOrCreateAseguradora(
+      creditData.aseguradora,
+      executor,
+    );
+  }
+
   const creditDataForInsert: CreditDataForInsert = {
     usuario_id: user.usuario_id,
     otros: creditData.otros?.toString() ?? "0",
@@ -324,6 +374,7 @@ const insertCreditAndRelated = async (creditData: CreditData, executor: DbExecut
     gps: creditData.gps.toString(),
     observaciones: creditData.observaciones ?? "0",
     no_poliza: creditData.no_poliza ?? "",
+    aseguradora_id,
     como_se_entero: creditData.como_se_entero ?? "",
     asesor_id: asesor_id,
     plazo: creditData.plazo,
@@ -931,6 +982,7 @@ export const insertCredit = async ({ body, set }: { body: unknown; set: SetConte
         vehiculoVin: creditData.vehiculo_vin ?? undefined,
         montoAsegurado: creditData.monto_asegurado ?? undefined,
         opportunityId: creditData.opportunity_id ?? undefined,
+        aseguradora: creditData.aseguradora ?? undefined,
       });
       console.log("[INSERT CREDIT] Email notification sent successfully");
     } catch (emailErr) {

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -136,6 +136,13 @@
   }
   // 2. Créditos
 
+  // Catálogo de aseguradoras (GyT, Universales, futuras). El crédito enlaza aquí.
+  export const aseguradoras = customSchema.table("aseguradoras", {
+    id: serial("id").primaryKey(),
+    nombre: varchar("nombre", { length: 100 }).notNull().unique(),
+    created_at: timestamp("created_at").notNull().defaultNow(),
+  });
+
   export const creditos = customSchema.table("creditos", {
     credito_id: serial("credito_id").primaryKey(),
     usuario_id: integer("usuario_id").notNull(),
@@ -165,6 +172,9 @@
     gps: numeric("gps", { precision: 18, scale: 2 }).notNull(),
     observaciones: text("observaciones").notNull(),
     no_poliza: varchar("no_poliza").notNull(),
+    aseguradora_id: integer("aseguradora_id").references(
+      () => aseguradoras.id,
+    ),
     como_se_entero: varchar("como_se_entero", { length: 100 }).notNull(),
     asesor_id: integer("asesor_id")
       .notNull()

--- a/apps/crm/apps/server/drizzle.config.ts
+++ b/apps/crm/apps/server/drizzle.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({

--- a/apps/crm/apps/server/package.json
+++ b/apps/crm/apps/server/package.json
@@ -42,6 +42,7 @@
 		"drizzle-orm": "^0.44.2",
 		"hono": "^4.8.2",
 		"pg": "^8.14.1",
+		"xlsx": "^0.18.5",
 		"zod": "^3.23.8"
 	},
 	"devDependencies": {

--- a/apps/crm/apps/server/src/db/migrations/0024_add_gyt_insurance.sql
+++ b/apps/crm/apps/server/src/db/migrations/0024_add_gyt_insurance.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS "gyt_insurance_costs" (
+	"price" integer PRIMARY KEY NOT NULL,
+	"current_automovil_camioneta" numeric(16, 8),
+	"automovil_camioneta" numeric(16, 8),
+	"current_microbus" numeric(16, 8),
+	"microbus" numeric(16, 8),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "gyt_insurance_costs"
+	ADD COLUMN IF NOT EXISTS "current_automovil_camioneta" numeric(16, 8),
+	ADD COLUMN IF NOT EXISTS "current_microbus" numeric(16, 8);
+
+ALTER TABLE "quotations"
+	ADD COLUMN IF NOT EXISTS "insurance_provider" text DEFAULT 'universales' NOT NULL,
+	ADD COLUMN IF NOT EXISTS "customer_insurance_cost" numeric(16, 8),
+	ADD COLUMN IF NOT EXISTS "internal_insurance_cost" numeric(16, 8),
+	ADD COLUMN IF NOT EXISTS "insurance_savings_to_membership" numeric(16, 8) DEFAULT '0' NOT NULL;
+
+ALTER TABLE "opportunities"
+	ADD COLUMN IF NOT EXISTS "insurance_provider" text DEFAULT 'universales' NOT NULL,
+	ADD COLUMN IF NOT EXISTS "customer_insurance_cost" numeric(16, 8),
+	ADD COLUMN IF NOT EXISTS "internal_insurance_cost" numeric(16, 8),
+	ADD COLUMN IF NOT EXISTS "insurance_savings_to_membership" numeric(16, 8) DEFAULT '0' NOT NULL;

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -61,10 +61,7 @@ export const creditTypeEnum = pgEnum("credit_type", [
 	"autocompra",
 	"sobre_vehiculo",
 ]);
-export const assignmentTypeEnum = pgEnum("assignment_type", [
-	"auto",
-	"manual",
-]);
+export const assignmentTypeEnum = pgEnum("assignment_type", ["auto", "manual"]);
 export const creditCategoryEnum = pgEnum("credit_category", [
 	"Contraseña",
 	"CV Vehículo",
@@ -325,6 +322,23 @@ export const opportunities = pgTable("opportunities", {
 	// Additional fields
 	seguro: decimal("seguro", { precision: 12, scale: 2 }), // Insurance amount
 	gps: decimal("gps", { precision: 12, scale: 2 }), // GPS amount
+	insuranceProvider: text("insurance_provider")
+		.notNull()
+		.default("universales"),
+	customerInsuranceCost: decimal("customer_insurance_cost", {
+		precision: 16,
+		scale: 8,
+	}),
+	internalInsuranceCost: decimal("internal_insurance_cost", {
+		precision: 16,
+		scale: 8,
+	}),
+	insuranceSavingsToMembership: decimal("insurance_savings_to_membership", {
+		precision: 16,
+		scale: 8,
+	})
+		.notNull()
+		.default("0"),
 	categoria: creditCategoryEnum("categoria"), // Credit category
 	nit: text("nit"), // Tax identification number
 	royalti: decimal("royalti", { precision: 12, scale: 2 }), // Royalty amount

--- a/apps/crm/apps/server/src/db/schema/insurance.ts
+++ b/apps/crm/apps/server/src/db/schema/insurance.ts
@@ -1,4 +1,4 @@
-import { decimal, integer, pgTable } from "drizzle-orm/pg-core";
+import { decimal, integer, pgTable, timestamp } from "drizzle-orm/pg-core";
 
 export const insuranceCosts = pgTable("insurance_costs", {
 	price: integer("price").primaryKey(),
@@ -12,4 +12,20 @@ export const insuranceCosts = pgTable("insurance_costs", {
 	busHasta20: decimal("bus_hasta_20", { precision: 16, scale: 8 }),
 	bus21a35: decimal("bus_21_a_35", { precision: 16, scale: 8 }),
 	busMas35: decimal("bus_mas_35", { precision: 16, scale: 8 }),
+});
+
+export const gytInsuranceCosts = pgTable("gyt_insurance_costs", {
+	price: integer("price").primaryKey(),
+	currentAutomovilCamioneta: decimal("current_automovil_camioneta", {
+		precision: 16,
+		scale: 8,
+	}),
+	automovilCamioneta: decimal("automovil_camioneta", {
+		precision: 16,
+		scale: 8,
+	}),
+	currentMicrobus: decimal("current_microbus", { precision: 16, scale: 8 }),
+	microbus: decimal("microbus", { precision: 16, scale: 8 }),
+	createdAt: timestamp("created_at").notNull().defaultNow(),
+	updatedAt: timestamp("updated_at").notNull().defaultNow(),
 });

--- a/apps/crm/apps/server/src/db/schema/quotations.ts
+++ b/apps/crm/apps/server/src/db/schema/quotations.ts
@@ -84,6 +84,23 @@ export const quotations = pgTable("quotations", {
 	membershipCost: decimal("membership_cost", { precision: 16, scale: 8 })
 		.notNull()
 		.default("0"),
+	insuranceProvider: text("insurance_provider")
+		.notNull()
+		.default("universales"),
+	customerInsuranceCost: decimal("customer_insurance_cost", {
+		precision: 16,
+		scale: 8,
+	}),
+	internalInsuranceCost: decimal("internal_insurance_cost", {
+		precision: 16,
+		scale: 8,
+	}),
+	insuranceSavingsToMembership: decimal("insurance_savings_to_membership", {
+		precision: 16,
+		scale: 8,
+	})
+		.notNull()
+		.default("0"),
 
 	// Comisiones - Free lance
 	freelanceCost: decimal("freelance_cost", { precision: 14, scale: 2 }).default(

--- a/apps/crm/apps/server/src/db/seed-gyt-insurance.ts
+++ b/apps/crm/apps/server/src/db/seed-gyt-insurance.ts
@@ -1,0 +1,107 @@
+import { sql } from "drizzle-orm";
+import * as XLSX from "xlsx";
+import { db } from "./index";
+import { gytInsuranceCosts } from "./schema";
+
+const DEFAULT_WORKBOOK_PATH =
+	"/home/lralda/Downloads/LISTADO DE PRECIOS Y COMPARATIVO - CASH IN - Junio 2026 Final.xlsx";
+
+type GytInsuranceRow = {
+	price: number;
+	currentAutomovilCamioneta?: string;
+	automovilCamioneta?: string;
+	currentMicrobus?: string;
+	microbus?: string;
+};
+
+function readGytRows(
+	workbook: XLSX.WorkBook,
+	sheetName: string,
+	field: "automovilCamioneta" | "microbus",
+): Map<number, GytInsuranceRow> {
+	const sheet = workbook.Sheets[sheetName];
+	if (!sheet) throw new Error(`No se encontró la hoja ${sheetName}`);
+
+	const rows = XLSX.utils.sheet_to_json<unknown[]>(sheet, {
+		header: 1,
+		blankrows: false,
+		defval: null,
+	});
+	const result = new Map<number, GytInsuranceRow>();
+	const currentField =
+		field === "automovilCamioneta"
+			? "currentAutomovilCamioneta"
+			: "currentMicrobus";
+
+	for (const row of rows) {
+		const price = row[1];
+		const currentCost = row[2];
+		const monthlyCost = row[9];
+
+		if (typeof price !== "number" || typeof monthlyCost !== "number") continue;
+
+		result.set(price, {
+			price,
+			...(typeof currentCost === "number" && {
+				[currentField]: currentCost.toFixed(8),
+			}),
+			[field]: monthlyCost.toFixed(8),
+		});
+	}
+
+	return result;
+}
+
+async function seedGytInsurance() {
+	const workbookPath =
+		process.env.GYT_INSURANCE_XLSX_PATH ?? DEFAULT_WORKBOOK_PATH;
+	const workbook = XLSX.readFile(workbookPath);
+	const automovilRows = readGytRows(
+		workbook,
+		"AUTOMOVIL - CAMIONETA",
+		"automovilCamioneta",
+	);
+	const microbusRows = readGytRows(workbook, "MICROBUS", "microbus");
+	const merged = new Map<number, GytInsuranceRow>();
+
+	for (const row of automovilRows.values()) merged.set(row.price, row);
+	for (const row of microbusRows.values()) {
+		const current = merged.get(row.price) ?? { price: row.price };
+		merged.set(row.price, { ...current, ...row });
+	}
+
+	const values = [...merged.values()].sort((a, b) => a.price - b.price);
+	let processed = 0;
+
+	for (const row of values) {
+		await db
+			.insert(gytInsuranceCosts)
+			.values({
+				price: row.price,
+				currentAutomovilCamioneta: row.currentAutomovilCamioneta,
+				automovilCamioneta: row.automovilCamioneta,
+				currentMicrobus: row.currentMicrobus,
+				microbus: row.microbus,
+			})
+			.onConflictDoUpdate({
+				target: gytInsuranceCosts.price,
+				set: {
+					currentAutomovilCamioneta: sql`COALESCE(EXCLUDED.current_automovil_camioneta, ${gytInsuranceCosts.currentAutomovilCamioneta})`,
+					automovilCamioneta: sql`COALESCE(EXCLUDED.automovil_camioneta, ${gytInsuranceCosts.automovilCamioneta})`,
+					currentMicrobus: sql`COALESCE(EXCLUDED.current_microbus, ${gytInsuranceCosts.currentMicrobus})`,
+					microbus: sql`COALESCE(EXCLUDED.microbus, ${gytInsuranceCosts.microbus})`,
+					updatedAt: new Date(),
+				},
+			});
+		processed++;
+	}
+
+	console.log(`Tarifas GyT cargadas: ${processed} filas desde ${workbookPath}`);
+}
+
+seedGytInsurance()
+	.then(() => process.exit(0))
+	.catch((error) => {
+		console.error("Error al cargar tarifas GyT:", error);
+		process.exit(1);
+	});

--- a/apps/crm/apps/server/src/db/seed-gyt-insurance.ts
+++ b/apps/crm/apps/server/src/db/seed-gyt-insurance.ts
@@ -1,10 +1,13 @@
 import { sql } from "drizzle-orm";
 import * as XLSX from "xlsx";
+import { getFileBuffer } from "../lib/storage";
 import { db } from "./index";
 import { gytInsuranceCosts } from "./schema";
 
-const DEFAULT_WORKBOOK_PATH =
-	"/home/lralda/Downloads/LISTADO DE PRECIOS Y COMPARATIVO - CASH IN - Junio 2026 Final.xlsx";
+// Key del Excel de tarifas GyT en R2 (bucket por defecto de storage).
+// Subir el archivo a R2 bajo esta key, o sobreescribir con GYT_INSURANCE_XLSX_KEY.
+const DEFAULT_WORKBOOK_KEY =
+	"Precios junio 2026 (valor Universales actualizado).xlsx";
 
 type GytInsuranceRow = {
 	price: number;
@@ -53,9 +56,10 @@ function readGytRows(
 }
 
 async function seedGytInsurance() {
-	const workbookPath =
-		process.env.GYT_INSURANCE_XLSX_PATH ?? DEFAULT_WORKBOOK_PATH;
-	const workbook = XLSX.readFile(workbookPath);
+	const workbookKey =
+		process.env.GYT_INSURANCE_XLSX_KEY ?? DEFAULT_WORKBOOK_KEY;
+	const buffer = await getFileBuffer(workbookKey);
+	const workbook = XLSX.read(buffer, { type: "buffer" });
 	const automovilRows = readGytRows(
 		workbook,
 		"AUTOMOVIL - CAMIONETA",
@@ -96,7 +100,9 @@ async function seedGytInsurance() {
 		processed++;
 	}
 
-	console.log(`Tarifas GyT cargadas: ${processed} filas desde ${workbookPath}`);
+	console.log(
+		`Tarifas GyT cargadas: ${processed} filas desde R2 (${workbookKey})`,
+	);
 }
 
 seedGytInsurance()

--- a/apps/crm/apps/server/src/lib/insurance-selection.test.ts
+++ b/apps/crm/apps/server/src/lib/insurance-selection.test.ts
@@ -123,7 +123,7 @@ describe("selectInsuranceProvider", () => {
 		expect(result.provider).toBe("universales");
 	});
 
-	test("uses GyT by approved range even when GyT is not cheaper", () => {
+	test("keeps Universales in the approved range when GyT is NOT cheaper", () => {
 		const result = selectInsuranceProvider({
 			insuredAmount: 189000,
 			vehicleType: "particular",
@@ -132,9 +132,9 @@ describe("selectInsuranceProvider", () => {
 			membershipCost: 100,
 		});
 
-		expect(result.provider).toBe("gyt");
+		expect(result.provider).toBe("universales");
 		expect(result.customerInsuranceCost).toBe(584);
-		expect(result.internalInsuranceCost).toBe(585);
+		expect(result.internalInsuranceCost).toBe(584);
 		expect(result.insuranceSavingsToMembership).toBe(0);
 	});
 });
@@ -194,7 +194,8 @@ describe("buildServerInsurancePersistence", () => {
 		expect(result.customerInsuranceCost).toBe("585.86");
 		expect(result.internalInsuranceCost).toBe("584.96");
 		expect(result.insuranceSavingsToMembership).toBe("0.90");
-		expect(result.membresiaPago).toBe("100.90");
+		// El server ya no re-suma el ahorro a la membresía (lo hace el front una vez).
+		expect(result.membresiaPago).toBe("100.00");
 	});
 
 	test("uses visible quoter insurance as customer amount when provided", () => {
@@ -202,7 +203,7 @@ describe("buildServerInsurancePersistence", () => {
 			insuredAmount: 189000,
 			vehicleType: "particular",
 			universalesCost: 550.1,
-			gytCost: 584.96,
+			gytCost: 540,
 			membershipCost: 403.32,
 			customerInsuranceCost: 953.42,
 		});
@@ -210,8 +211,30 @@ describe("buildServerInsurancePersistence", () => {
 		expect(result.insuranceProvider).toBe("gyt");
 		expect(result.seguro).toBe("953.42");
 		expect(result.customerInsuranceCost).toBe("953.42");
-		expect(result.internalInsuranceCost).toBe("584.96");
-		expect(result.insuranceSavingsToMembership).toBe("368.46");
-		expect(result.membresiaPago).toBe("771.78");
+		expect(result.internalInsuranceCost).toBe("540.00");
+		// ahorro limpio = universales - gyt = 550.10 - 540 = 10.10 (no del bundle)
+		expect(result.insuranceSavingsToMembership).toBe("10.10");
+		// membresía = la que mandó el front, sin re-sumar el ahorro
+		expect(result.membresiaPago).toBe("403.32");
+	});
+
+	test("computes savings from insurance prices and does not re-add them to membership", () => {
+		// El front ya metió el ahorro GyT en membershipCost (162) y armó el bundle
+		// base + membresía en customerInsuranceCost (762). El server NO debe calcular
+		// el ahorro del bundle (762-580) ni volver a sumarlo a la membresía.
+		const result = buildServerInsurancePersistence({
+			insuredAmount: 189000,
+			vehicleType: "particular",
+			universalesCost: 600,
+			gytCost: 580,
+			membershipCost: 162,
+			customerInsuranceCost: 762,
+		});
+
+		expect(result.insuranceProvider).toBe("gyt");
+		// ahorro = universales - gyt = 20  (NO 762 - 580 = 182)
+		expect(result.insuranceSavingsToMembership).toBe("20.00");
+		// membresía persistida = la que mandó el front, sin re-sumar el ahorro
+		expect(result.membresiaPago).toBe("162.00");
 	});
 });

--- a/apps/crm/apps/server/src/lib/insurance-selection.test.ts
+++ b/apps/crm/apps/server/src/lib/insurance-selection.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from "bun:test";
+import {
+	buildServerInsurancePersistence,
+	normalizeInsuranceBreakdown,
+	selectInsuranceProvider,
+} from "./insurance-selection";
+
+describe("selectInsuranceProvider", () => {
+	test("keeps Universales for particular below Q189,000", () => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 188000,
+			vehicleType: "particular",
+			universalesCost: 582.76,
+			gytCost: 583.3,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("universales");
+		expect(result.customerInsuranceCost).toBe(582.76);
+		expect(result.insuranceSavingsToMembership).toBe(0);
+	});
+
+	test("uses GyT for particular from Q189,000 when cheaper", () => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 189000,
+			vehicleType: "particular",
+			universalesCost: 585.86,
+			gytCost: 584.96,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("gyt");
+		expect(result.customerInsuranceCost).toBe(585.86);
+		expect(result.internalInsuranceCost).toBe(584.96);
+		expect(result.insuranceSavingsToMembership).toBeCloseTo(0.9, 2);
+		expect(result.effectiveMembershipCost).toBeCloseTo(100.9, 2);
+	});
+
+	test.each([
+		"particular",
+		"uber",
+		"nuevo",
+	])("uses GyT for %s from Q189,000 when cheaper", (vehicleType) => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 189000,
+			vehicleType,
+			universalesCost: 585.86,
+			gytCost: 584.96,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("gyt");
+	});
+
+	test("never uses GyT for pickup", () => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 300000,
+			vehicleType: "pickup",
+			universalesCost: 900,
+			gytCost: 700,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("universales");
+	});
+
+	test("keeps Universales for microbus below Q125,000", () => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 124000,
+			vehicleType: "microbus",
+			universalesCost: 776.51,
+			gytCost: 778.34,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("universales");
+	});
+
+	test("uses GyT for microbus from Q125,000 when cheaper", () => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 125000,
+			vehicleType: "microbus",
+			universalesCost: 782.78,
+			gytCost: 781.78,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("gyt");
+		expect(result.customerInsuranceCost).toBe(782.78);
+		expect(result.insuranceSavingsToMembership).toBeCloseTo(1, 2);
+	});
+
+	test.each([
+		"microbus",
+		"microbus_20",
+		"microbus_35",
+		"microbus_36plus",
+	])("uses GyT for %s from Q125,000 when cheaper", (vehicleType) => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 125000,
+			vehicleType,
+			universalesCost: 782.78,
+			gytCost: 781.78,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("gyt");
+	});
+
+	test.each([
+		"panel",
+		"camion",
+		"otro",
+	])("keeps Universales for non-approved type %s", (vehicleType) => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 300000,
+			vehicleType,
+			universalesCost: 900,
+			gytCost: 700,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("universales");
+	});
+
+	test("uses GyT by approved range even when GyT is not cheaper", () => {
+		const result = selectInsuranceProvider({
+			insuredAmount: 189000,
+			vehicleType: "particular",
+			universalesCost: 584,
+			gytCost: 585,
+			membershipCost: 100,
+		});
+
+		expect(result.provider).toBe("gyt");
+		expect(result.customerInsuranceCost).toBe(584);
+		expect(result.internalInsuranceCost).toBe(585);
+		expect(result.insuranceSavingsToMembership).toBe(0);
+	});
+});
+
+describe("normalizeInsuranceBreakdown", () => {
+	test("returns DB-safe values for GyT selection", () => {
+		const result = normalizeInsuranceBreakdown({
+			selection: selectInsuranceProvider({
+				insuredAmount: 189000,
+				vehicleType: "particular",
+				universalesCost: 585.86,
+				gytCost: 584.96,
+				membershipCost: 100,
+			}),
+		});
+
+		expect(result.insuranceProvider).toBe("gyt");
+		expect(result.seguro).toBe("585.86");
+		expect(result.membresiaPago).toBe("100.90");
+	});
+
+	test("returns DB-safe values for Universales selection", () => {
+		const result = normalizeInsuranceBreakdown({
+			selection: selectInsuranceProvider({
+				insuredAmount: 188000,
+				vehicleType: "particular",
+				universalesCost: 582.76,
+				gytCost: 583.3,
+				membershipCost: 100,
+			}),
+		});
+
+		expect(result.insuranceProvider).toBe("universales");
+		expect(result.seguro).toBe("582.76");
+		expect(result.membresiaPago).toBe("100.00");
+	});
+});
+
+describe("buildServerInsurancePersistence", () => {
+	test("ignores manipulated client breakdown and persists server-calculated values", () => {
+		const result = buildServerInsurancePersistence({
+			insuredAmount: 189000,
+			vehicleType: "particular",
+			universalesCost: 585.86,
+			gytCost: 584.96,
+			membershipCost: 100,
+			clientBreakdown: {
+				insuranceProvider: "universales",
+				customerInsuranceCost: 1,
+				internalInsuranceCost: 1,
+				insuranceSavingsToMembership: 999,
+			},
+		});
+
+		expect(result.insuranceProvider).toBe("gyt");
+		expect(result.seguro).toBe("585.86");
+		expect(result.customerInsuranceCost).toBe("585.86");
+		expect(result.internalInsuranceCost).toBe("584.96");
+		expect(result.insuranceSavingsToMembership).toBe("0.90");
+		expect(result.membresiaPago).toBe("100.90");
+	});
+
+	test("uses visible quoter insurance as customer amount when provided", () => {
+		const result = buildServerInsurancePersistence({
+			insuredAmount: 189000,
+			vehicleType: "particular",
+			universalesCost: 550.1,
+			gytCost: 584.96,
+			membershipCost: 403.32,
+			customerInsuranceCost: 953.42,
+		});
+
+		expect(result.insuranceProvider).toBe("gyt");
+		expect(result.seguro).toBe("953.42");
+		expect(result.customerInsuranceCost).toBe("953.42");
+		expect(result.internalInsuranceCost).toBe("584.96");
+		expect(result.insuranceSavingsToMembership).toBe("368.46");
+		expect(result.membresiaPago).toBe("771.78");
+	});
+});

--- a/apps/crm/apps/server/src/lib/insurance-selection.ts
+++ b/apps/crm/apps/server/src/lib/insurance-selection.ts
@@ -1,0 +1,136 @@
+export type InsuranceProvider = "universales" | "gyt";
+
+export interface InsuranceSelectionInput {
+	insuredAmount: number;
+	vehicleType: string;
+	universalesCost: number;
+	gytCost: number | null;
+	membershipCost: number;
+}
+
+export interface InsuranceSelectionResult {
+	provider: InsuranceProvider;
+	customerInsuranceCost: number;
+	internalInsuranceCost: number;
+	insuranceSavingsToMembership: number;
+	effectiveMembershipCost: number;
+}
+
+export interface InsurancePersistenceInput extends InsuranceSelectionInput {
+	customerInsuranceCost?: number;
+	clientBreakdown?: {
+		insuranceProvider?: string;
+		customerInsuranceCost?: number;
+		internalInsuranceCost?: number;
+		insuranceSavingsToMembership?: number;
+	};
+}
+
+export interface NormalizedInsuranceBreakdown {
+	insuranceProvider: InsuranceProvider;
+	seguro: string;
+	membresiaPago: string;
+	customerInsuranceCost: string;
+	internalInsuranceCost: string;
+	insuranceSavingsToMembership: string;
+}
+
+const VEHICLE_GYT_TYPES = new Set(["particular", "uber", "nuevo"]);
+const MICROBUS_GYT_TYPES = new Set([
+	"microbus",
+	"microbus_20",
+	"microbus_35",
+	"microbus_36plus",
+]);
+
+export function roundMoney(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+function toMoneyString(value: number): string {
+	return roundMoney(value).toFixed(2);
+}
+
+function normalizeVehicleType(vehicleType: string): string {
+	return vehicleType.trim().toLowerCase();
+}
+
+function qualifiesForGyt(insuredAmount: number, vehicleType: string): boolean {
+	const normalizedType = normalizeVehicleType(vehicleType);
+
+	if (VEHICLE_GYT_TYPES.has(normalizedType)) return insuredAmount >= 189000;
+	if (MICROBUS_GYT_TYPES.has(normalizedType)) return insuredAmount >= 125000;
+
+	return false;
+}
+
+export function selectInsuranceProvider(
+	input: InsuranceSelectionInput,
+): InsuranceSelectionResult {
+	const universalesCost = roundMoney(input.universalesCost);
+	const gytCost = input.gytCost == null ? null : roundMoney(input.gytCost);
+
+	if (
+		gytCost != null &&
+		qualifiesForGyt(input.insuredAmount, input.vehicleType)
+	) {
+		const savings = roundMoney(Math.max(universalesCost - gytCost, 0));
+
+		return {
+			provider: "gyt",
+			customerInsuranceCost: universalesCost,
+			internalInsuranceCost: gytCost,
+			insuranceSavingsToMembership: savings,
+			effectiveMembershipCost: roundMoney(input.membershipCost + savings),
+		};
+	}
+
+	return {
+		provider: "universales",
+		customerInsuranceCost: universalesCost,
+		internalInsuranceCost: universalesCost,
+		insuranceSavingsToMembership: 0,
+		effectiveMembershipCost: roundMoney(input.membershipCost),
+	};
+}
+
+export function normalizeInsuranceBreakdown({
+	selection,
+}: {
+	selection: InsuranceSelectionResult;
+}): NormalizedInsuranceBreakdown {
+	return {
+		insuranceProvider: selection.provider,
+		seguro: toMoneyString(selection.customerInsuranceCost),
+		membresiaPago: toMoneyString(selection.effectiveMembershipCost),
+		customerInsuranceCost: toMoneyString(selection.customerInsuranceCost),
+		internalInsuranceCost: toMoneyString(selection.internalInsuranceCost),
+		insuranceSavingsToMembership: toMoneyString(
+			selection.insuranceSavingsToMembership,
+		),
+	};
+}
+
+export function buildServerInsurancePersistence(
+	input: InsurancePersistenceInput,
+): NormalizedInsuranceBreakdown {
+	void input.clientBreakdown;
+	const selection = selectInsuranceProvider(input);
+	const customerInsuranceCost = roundMoney(
+		input.customerInsuranceCost ?? selection.customerInsuranceCost,
+	);
+	const internalInsuranceCost = selection.internalInsuranceCost;
+	const savings = roundMoney(
+		Math.max(customerInsuranceCost - internalInsuranceCost, 0),
+	);
+
+	return normalizeInsuranceBreakdown({
+		selection: {
+			provider: selection.provider,
+			customerInsuranceCost,
+			internalInsuranceCost,
+			insuranceSavingsToMembership: savings,
+			effectiveMembershipCost: roundMoney(input.membershipCost + savings),
+		},
+	});
+}

--- a/apps/crm/apps/server/src/lib/insurance-selection.ts
+++ b/apps/crm/apps/server/src/lib/insurance-selection.ts
@@ -72,6 +72,7 @@ export function selectInsuranceProvider(
 
 	if (
 		gytCost != null &&
+		gytCost < universalesCost &&
 		qualifiesForGyt(input.insuredAmount, input.vehicleType)
 	) {
 		const savings = roundMoney(Math.max(universalesCost - gytCost, 0));
@@ -119,18 +120,18 @@ export function buildServerInsurancePersistence(
 	const customerInsuranceCost = roundMoney(
 		input.customerInsuranceCost ?? selection.customerInsuranceCost,
 	);
-	const internalInsuranceCost = selection.internalInsuranceCost;
-	const savings = roundMoney(
-		Math.max(customerInsuranceCost - internalInsuranceCost, 0),
-	);
 
 	return normalizeInsuranceBreakdown({
 		selection: {
 			provider: selection.provider,
 			customerInsuranceCost,
-			internalInsuranceCost,
-			insuranceSavingsToMembership: savings,
-			effectiveMembershipCost: roundMoney(input.membershipCost + savings),
+			internalInsuranceCost: selection.internalInsuranceCost,
+			// El ahorro sale de los precios de seguro (universales - gyt), NO del
+			// monto bundle del cotizador (que ya incluye la membresía).
+			insuranceSavingsToMembership: selection.insuranceSavingsToMembership,
+			// La membresía ya trae el ahorro incorporado desde el front
+			// (getInsuranceCost). No lo volvemos a sumar para no contarlo dos veces.
+			effectiveMembershipCost: roundMoney(input.membershipCost),
 		},
 	});
 }

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -60,9 +60,7 @@ import {
 	updateChecklistForVehicleDocument,
 } from "../lib/checklist";
 import { buildDeletedOpportunitySnapshot } from "../lib/deleted-opportunity-audit";
-import {
-	getGuatemalaMonthWindow,
-} from "../lib/guatemala-month-window";
+import { getGuatemalaMonthWindow } from "../lib/guatemala-month-window";
 import {
 	formatMissingLeadFields,
 	getMissingLeadFieldsForContracts,
@@ -239,10 +237,7 @@ export async function getCurrentClientCreditsFromCartera(
 	fetchCredits: ClientCreditFetcher = (params) =>
 		carteraBackClient.getAllCreditos(params),
 ) {
-	return getClientCreditsFromCartera(
-		fetchCredits,
-		{ mes: 0, anio: 0 },
-	);
+	return getClientCreditsFromCartera(fetchCredits, { mes: 0, anio: 0 });
 }
 
 function splitFullName(fullName: string | null | undefined) {
@@ -1422,6 +1417,11 @@ export const crmRouter = {
 				// Additional credit fields
 				seguro: opportunities.seguro,
 				gps: opportunities.gps,
+				insuranceProvider: opportunities.insuranceProvider,
+				customerInsuranceCost: opportunities.customerInsuranceCost,
+				internalInsuranceCost: opportunities.internalInsuranceCost,
+				insuranceSavingsToMembership:
+					opportunities.insuranceSavingsToMembership,
 				categoria: opportunities.categoria,
 				nit: opportunities.nit,
 				royalti: opportunities.royalti,
@@ -2163,6 +2163,15 @@ export const crmRouter = {
 			const vehicleChanged =
 				input.vehicleId !== undefined &&
 				input.vehicleId !== currentOpportunity[0].vehicleId;
+			const insuranceFallback =
+				seguro !== undefined
+					? {
+							insuranceProvider: "universales",
+							customerInsuranceCost: String(seguro),
+							internalInsuranceCost: String(seguro),
+							insuranceSavingsToMembership: "0",
+						}
+					: {};
 
 			// Check if this is an override (sales moving from analysis stage)
 			let isOverride = false;
@@ -2215,6 +2224,7 @@ export const crmRouter = {
 					}),
 					// Convert numeric fields to strings for decimal columns
 					...(seguro !== undefined && { seguro: String(seguro) }),
+					...insuranceFallback,
 					...(gps !== undefined && { gps: String(gps) }),
 					...(royalti !== undefined && { royalti: String(royalti) }),
 					...(porcentajeRoyalti !== undefined && {

--- a/apps/crm/apps/server/src/routers/insurance.ts
+++ b/apps/crm/apps/server/src/routers/insurance.ts
@@ -1,7 +1,8 @@
 import { lte, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
-import { insuranceCosts } from "../db/schema";
+import { gytInsuranceCosts, insuranceCosts } from "../db/schema";
+import { selectInsuranceProvider } from "../lib/insurance-selection";
 import { publicProcedure } from "../lib/orpc";
 
 /** Tipos de bus RCDP */
@@ -33,13 +34,19 @@ function isBusType(vehicleType: string): boolean {
  * - Seguro base = panelCamionMicrobus + RCDP/3
  * - Membresía = membership × 1.1
  */
-async function getInsuranceCost(
+export async function getInsuranceCost(
 	insuredAmount: number,
 	vehicleType: string,
 ): Promise<{
 	baseInsuranceCost: number;
 	membershipCost: number;
 	rcdpCost: number;
+	provider: "universales" | "gyt";
+	customerInsuranceCost: number;
+	internalInsuranceCost: number;
+	insuranceSavingsToMembership: number;
+	effectiveMembershipCost: number;
+	excelCurrentInsuranceCost: number | null;
 }> {
 	// Buscar el registro más cercano (VLOOKUP con aproximación)
 	const [result] = await db
@@ -58,11 +65,38 @@ async function getInsuranceCost(
 			.limit(1);
 
 		if (!minResult)
-			return { baseInsuranceCost: 0, membershipCost: 0, rcdpCost: 0 };
-		return calculateCosts(minResult, vehicleType);
+			return {
+				baseInsuranceCost: 0,
+				membershipCost: 0,
+				rcdpCost: 0,
+				provider: "universales",
+				customerInsuranceCost: 0,
+				internalInsuranceCost: 0,
+				insuranceSavingsToMembership: 0,
+				effectiveMembershipCost: 0,
+				excelCurrentInsuranceCost: null,
+			};
+		return calculateCostsWithProvider(
+			minResult,
+			null,
+			insuredAmount,
+			vehicleType,
+		);
 	}
 
-	return calculateCosts(result, vehicleType);
+	const [gytResult] = await db
+		.select()
+		.from(gytInsuranceCosts)
+		.where(lte(gytInsuranceCosts.price, insuredAmount))
+		.orderBy(sql`${gytInsuranceCosts.price} DESC`)
+		.limit(1);
+
+	return calculateCostsWithProvider(
+		result,
+		gytResult ?? null,
+		insuredAmount,
+		vehicleType,
+	);
 }
 
 /** Calcular costos de seguro y membresía según tipo de vehículo */
@@ -111,6 +145,77 @@ function calculateCosts(
 		baseInsuranceCost: baseInsurance,
 		membershipCost: membershipCost,
 		rcdpCost: rcdpCost,
+	};
+}
+
+function getGytValues(
+	result: typeof gytInsuranceCosts.$inferSelect | null,
+	vehicleType: string,
+): { gytCost: number | null; excelCurrentCost: number | null } {
+	if (!result) return { gytCost: null, excelCurrentCost: null };
+
+	const normalizedType = vehicleType.toLowerCase();
+	if (["particular", "uber", "nuevo"].includes(normalizedType)) {
+		return {
+			gytCost:
+				result.automovilCamioneta == null
+					? null
+					: Number(result.automovilCamioneta),
+			excelCurrentCost:
+				result.currentAutomovilCamioneta == null
+					? null
+					: Number(result.currentAutomovilCamioneta),
+		};
+	}
+	if (
+		["microbus", "microbus_20", "microbus_35", "microbus_36plus"].includes(
+			normalizedType,
+		)
+	) {
+		return {
+			gytCost: result.microbus == null ? null : Number(result.microbus),
+			excelCurrentCost:
+				result.currentMicrobus == null ? null : Number(result.currentMicrobus),
+		};
+	}
+
+	return { gytCost: null, excelCurrentCost: null };
+}
+
+function calculateCostsWithProvider(
+	result: typeof insuranceCosts.$inferSelect,
+	gytResult: typeof gytInsuranceCosts.$inferSelect | null,
+	insuredAmount: number,
+	vehicleType: string,
+): {
+	baseInsuranceCost: number;
+	membershipCost: number;
+	rcdpCost: number;
+	provider: "universales" | "gyt";
+	customerInsuranceCost: number;
+	internalInsuranceCost: number;
+	insuranceSavingsToMembership: number;
+	effectiveMembershipCost: number;
+	excelCurrentInsuranceCost: number | null;
+} {
+	const costs = calculateCosts(result, vehicleType);
+	const gytValues = getGytValues(gytResult, vehicleType);
+	const selection = selectInsuranceProvider({
+		insuredAmount,
+		vehicleType,
+		universalesCost: costs.baseInsuranceCost,
+		gytCost: gytValues.gytCost,
+		membershipCost: costs.membershipCost,
+	});
+
+	return {
+		...costs,
+		provider: selection.provider,
+		customerInsuranceCost: selection.customerInsuranceCost,
+		internalInsuranceCost: selection.internalInsuranceCost,
+		insuranceSavingsToMembership: selection.insuranceSavingsToMembership,
+		effectiveMembershipCost: selection.effectiveMembershipCost,
+		excelCurrentInsuranceCost: gytValues.excelCurrentCost,
 	};
 }
 

--- a/apps/crm/apps/server/src/routers/quotations.ts
+++ b/apps/crm/apps/server/src/routers/quotations.ts
@@ -3,9 +3,13 @@ import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { quotations, vehicles } from "../db/schema";
+import { buildServerInsurancePersistence } from "../lib/insurance-selection";
 import { crmProcedure } from "../lib/orpc";
-import { canManageAnyQuotation, canManageQuotations } from "../lib/quotation-permissions";
-import { ROLES } from "../lib/roles";
+import {
+	canManageAnyQuotation,
+	canManageQuotations,
+} from "../lib/quotation-permissions";
+import { getInsuranceCost } from "./insurance";
 
 /**
  * Calcula la cuota mensual usando la fórmula PMT de Excel
@@ -193,6 +197,22 @@ export const quotationsRouter = {
 				}
 			}
 
+			const serverInsurance = await getInsuranceCost(
+				input.insuredAmount,
+				input.vehicleType,
+			);
+			const insurancePersistence = buildServerInsurancePersistence({
+				insuredAmount: input.insuredAmount,
+				vehicleType: input.vehicleType,
+				universalesCost: serverInsurance.baseInsuranceCost,
+				gytCost:
+					serverInsurance.provider === "gyt"
+						? serverInsurance.internalInsuranceCost
+						: null,
+				membershipCost: input.membershipCost,
+				customerInsuranceCost: input.insuranceCost,
+			});
+
 			// Calcular valores
 			const isSobreVehiculo = input.creditType === "sobre_vehiculo";
 			const downPaymentPercentage = isSobreVehiculo
@@ -224,7 +244,7 @@ export const quotationsRouter = {
 				totalFinanced,
 				input.interestRate,
 				input.termMonths,
-				input.insuranceCost,
+				Number(insurancePersistence.seguro),
 				input.gpsCost,
 			);
 
@@ -245,11 +265,16 @@ export const quotationsRouter = {
 					downPaymentPercentage: downPaymentPercentage.toString(),
 					termMonths: input.termMonths,
 					interestRate: input.interestRate.toString(),
-					insuranceCost: input.insuranceCost.toString(),
+					insuranceCost: insurancePersistence.seguro,
 					gpsCost: input.gpsCost.toString(),
 					transferCost: input.transferCost.toString(),
 					adminCost: input.adminCost.toString(),
-					membershipCost: input.membershipCost.toString(),
+					membershipCost: insurancePersistence.membresiaPago,
+					insuranceProvider: insurancePersistence.insuranceProvider,
+					customerInsuranceCost: insurancePersistence.customerInsuranceCost,
+					internalInsuranceCost: insurancePersistence.internalInsuranceCost,
+					insuranceSavingsToMembership:
+						insurancePersistence.insuranceSavingsToMembership,
 					// Gastos adicionales para detalle de crédito
 					freelanceCost: input.freelanceCost.toString(),
 					freelancePercentage: input.freelancePercentage?.toString() ?? null,
@@ -327,7 +352,10 @@ export const quotationsRouter = {
 
 			// Validar acceso
 			const userRole = context.userRole;
-			if (!canManageAnyQuotation(userRole) && quotation.salesUserId !== context.userId) {
+			if (
+				!canManageAnyQuotation(userRole) &&
+				quotation.salesUserId !== context.userId
+			) {
 				throw new ORPCError("FORBIDDEN", {
 					message: "No tienes permiso para ver esta cotización",
 				});

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -276,6 +276,7 @@ export const getReporteCreditosCerrados = closedCreditsReportProcedure
 				placa: vehicles.licensePlate,
 				chasis: vehicles.vinNumber,
 				cuotaSeguro: opportunities.seguro,
+				insuranceProvider: opportunities.insuranceProvider,
 				clienteNombre: sql<string>`COALESCE(NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.middleName}, ${leads.lastName}, ${leads.secondLastName})), ''), ${clients.contactPerson}, '')`,
 				numeroCredito: sql<string>`COALESCE(${latestCarteraReference.numeroCreditoSifco}, ${opportunities.numeroSifco}, '')`,
 				fecha90: firstClosedStageDates.firstClosedStageAt,

--- a/apps/crm/apps/server/src/services/cartera-back-integration.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-integration.ts
@@ -134,6 +134,7 @@ export interface CreateCreditoParams {
 	fecha_creacion?: string;
 	observaciones?: string;
 	no_poliza?: string;
+	aseguradora?: string;
 	// Nuevos campos adicionales
 	categoria?: string;
 	nit?: string;
@@ -195,6 +196,7 @@ export async function createCreditoInCarteraBack(
 			gps: params.gps ?? 0,
 			observaciones: params.observaciones,
 			no_poliza: params.no_poliza || "",
+			aseguradora: params.aseguradora,
 			direccion: params.direccion || "",
 			// Nuevos campos adicionales
 			categoria: params.categoria,

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -5,7 +5,7 @@
  */
 
 import crypto from "node:crypto";
-import { and, desc, eq } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import {
@@ -426,12 +426,7 @@ async function getLatestApprovedQuotation(
 				insuranceProvider: quotations.insuranceProvider,
 			})
 			.from(quotations)
-			.where(
-				and(
-					eq(quotations.opportunityId, opportunityId),
-					eq(quotations.status, "accepted"),
-				),
-			)
+			.where(eq(quotations.opportunityId, opportunityId))
 			.orderBy(desc(quotations.createdAt))
 			.limit(1);
 

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -185,6 +185,7 @@ interface QuotationDataForBilling {
 	insuredAmount: string | null; // Monto asegurado (para correo)
 	value: string | null; // Valor del vehículo (para correo)
 	monthlyPayment: string | null; // Cuota mensual (para asegurar el valor que es)
+	insuranceProvider: string | null; // Aseguradora elegida (gyt | universales)
 }
 
 /** Parámetros para generación de facturas en background */
@@ -397,6 +398,13 @@ async function logInvoiceSyncOperation(
 /**
  * Obtiene la última cotización aprobada de una oportunidad
  */
+/** Mapea el provider interno (gyt | universales) a la etiqueta de aseguradora. */
+function aseguradoraLabel(
+	provider: string | null | undefined,
+): "GyT" | "Universales" {
+	return provider === "gyt" ? "GyT" : "Universales";
+}
+
 async function getLatestApprovedQuotation(
 	opportunityId: string,
 ): Promise<QuotationDataForBilling | null> {
@@ -415,6 +423,7 @@ async function getLatestApprovedQuotation(
 				insuredAmount: quotations.insuredAmount,
 				value: quotations.vehicleValue,
 				monthlyPayment: quotations.monthlyPayment,
+				insuranceProvider: quotations.insuranceProvider,
 			})
 			.from(quotations)
 			.where(eq(quotations.opportunityId, opportunityId))
@@ -960,6 +969,7 @@ async function createCredit(
 			observaciones: `Crédito generado desde CRM - Oportunidad: ${opportunity.title}`,
 			seguro_10_cuotas: seguro,
 			gps: gps,
+			aseguradora: aseguradoraLabel(opportunity.insuranceProvider),
 			categoria: opportunity.categoria ?? undefined,
 			nit: cleanNit(opportunity.nit),
 			royalti: royalti,
@@ -1177,6 +1187,11 @@ export async function closeOpportunity(
 				diaPagoMensual: opportunities.diaPagoMensual,
 				seguro: opportunities.seguro,
 				gps: opportunities.gps,
+				insuranceProvider: opportunities.insuranceProvider,
+				customerInsuranceCost: opportunities.customerInsuranceCost,
+				internalInsuranceCost: opportunities.internalInsuranceCost,
+				insuranceSavingsToMembership:
+					opportunities.insuranceSavingsToMembership,
 				categoria: opportunities.categoria,
 				nit: opportunities.nit,
 				royalti: opportunities.royalti,
@@ -1345,6 +1360,20 @@ export async function closeOpportunity(
 		console.log(
 			`[CloseOpportunity] Latest quotation found: ${quotation ? "YES" : "NO"}`,
 		);
+
+		// Estampar la aseguradora elegida (fuente: cotización) en la oportunidad,
+		// para que viaje a cartera y quede consistente en el CRM.
+		const insuranceProvider =
+			quotation?.insuranceProvider ??
+			opportunity.insuranceProvider ??
+			"universales";
+		if (insuranceProvider !== opportunity.insuranceProvider) {
+			await db
+				.update(opportunities)
+				.set({ insuranceProvider })
+				.where(eq(opportunities.id, opportunityId));
+			opportunity.insuranceProvider = insuranceProvider;
+		}
 
 		//  Create credit in cartera-back
 		const creditResult = await createCredit({

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -5,7 +5,7 @@
  */
 
 import crypto from "node:crypto";
-import { desc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import {
@@ -426,7 +426,12 @@ async function getLatestApprovedQuotation(
 				insuranceProvider: quotations.insuranceProvider,
 			})
 			.from(quotations)
-			.where(eq(quotations.opportunityId, opportunityId))
+			.where(
+				and(
+					eq(quotations.opportunityId, opportunityId),
+					eq(quotations.status, "accepted"),
+				),
+			)
 			.orderBy(desc(quotations.createdAt))
 			.limit(1);
 

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -100,6 +100,10 @@ interface OpportunityData {
 	diaPagoMensual: number | null;
 	// Additional fields
 	seguro: string | null;
+	customerInsuranceCost?: string | null;
+	internalInsuranceCost?: string | null;
+	insuranceProvider?: string | null;
+	insuranceSavingsToMembership?: string | null;
 	gps: string | null;
 	categoria: string | null;
 	nit: string | null;
@@ -907,9 +911,9 @@ async function createCredit(
 		);
 
 		// Parse all values from opportunity
-		const seguro = opportunity.seguro
-			? Number.parseFloat(opportunity.seguro)
-			: undefined;
+		const seguroCliente =
+			opportunity.customerInsuranceCost ?? opportunity.seguro;
+		const seguro = seguroCliente ? Number.parseFloat(seguroCliente) : undefined;
 		const gps = opportunity.gps
 			? Number.parseFloat(opportunity.gps)
 			: undefined;
@@ -948,7 +952,9 @@ async function createCredit(
 			capital: Number.parseFloat(opportunity.value as string),
 			porcentaje_interes: Number.parseFloat(opportunity.tasaInteres as string),
 			plazo: opportunity.numeroCuotas as number,
-			cuota: params.cuotaMensual ? Number(params.cuotaMensual) : Number.parseFloat(opportunity.cuotaMensual as string),
+			cuota: params.cuotaMensual
+				? Number(params.cuotaMensual)
+				: Number.parseFloat(opportunity.cuotaMensual as string),
 			dia_pago_mensual: diaPagoMensual,
 			tipoCredito: opportunity.creditType || "autocompra",
 			observaciones: `Crédito generado desde CRM - Oportunidad: ${opportunity.title}`,
@@ -1291,9 +1297,7 @@ export async function closeOpportunity(
 		// Validate NIT against cartera-back before proceeding
 		if (opportunity.nit) {
 			const nitLimpio = opportunity.nit.replace(/[-\s]/g, "").toUpperCase();
-			console.log(
-				`[CloseOpportunity] Validating NIT: ${nitLimpio}`,
-			);
+			console.log(`[CloseOpportunity] Validating NIT: ${nitLimpio}`);
 
 			if (nitLimpio.length < 5 && nitLimpio !== "CF") {
 				return {
@@ -1326,7 +1330,8 @@ export async function closeOpportunity(
 				console.error("[CloseOpportunity] Error validating NIT:", error);
 				return {
 					success: false,
-					error: `No se pudo validar el NIT contra SAT. Intenta de nuevo o verifica la conexión con cartera.`,
+					error:
+						"No se pudo validar el NIT contra SAT. Intenta de nuevo o verifica la conexión con cartera.",
 				};
 			}
 		}
@@ -1334,7 +1339,6 @@ export async function closeOpportunity(
 		// Generate unique SIFCO credit number using UUID
 		const numeroSifco = generateNumeroSifco();
 		console.log(`[CloseOpportunity] Generated numero SIFCO: ${numeroSifco}`);
-
 
 		//  Get the latest quotation for invoicing (async - doesn't block)
 		const quotation = await getLatestApprovedQuotation(opportunityId);
@@ -1348,7 +1352,9 @@ export async function closeOpportunity(
 			lead,
 			numeroSifco,
 			userId,
-			cuotaMensual: quotation?.monthlyPayment ? String(quotation.monthlyPayment) : undefined,
+			cuotaMensual: quotation?.monthlyPayment
+				? String(quotation.monthlyPayment)
+				: undefined,
 			isVehicleOwned: vehicleData?.isOwned ?? false,
 			// Enviar info del vehículo para que llegue en el correo de cartera
 			vehiculo_marca: vehicleData?.make ?? undefined,
@@ -1356,7 +1362,11 @@ export async function closeOpportunity(
 			vehiculo_modelo: vehicleData?.year ? String(vehicleData.year) : undefined,
 			vehiculo_placa: vehicleData?.licensePlate ?? undefined,
 			vehiculo_vin: vehicleData?.vinNumber ?? undefined,
-			monto_asegurado: quotation?.insuredAmount ? Number(quotation.insuredAmount) : quotation?.value ? Number(quotation.value) : undefined,
+			monto_asegurado: quotation?.insuredAmount
+				? Number(quotation.insuredAmount)
+				: quotation?.value
+					? Number(quotation.value)
+					: undefined,
 		});
 
 		if (!creditResult.success) {
@@ -1366,7 +1376,6 @@ export async function closeOpportunity(
 					creditResult.error || "Error al crear el crédito en cartera-back",
 			};
 		}
-
 
 		// 3. Generate invoices in background (fire-and-forget)
 		// This runs asynchronously after the credit is created

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -111,6 +111,7 @@ export interface CreateCreditoInput {
 	fecha_creacion?: string;
 	observaciones?: string;
 	no_poliza?: string;
+	aseguradora?: string;
 	como_se_entero?: string;
 	dia_pago_mensual?: 15 | 30;
 	membresias_pago?: number;

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -971,6 +971,7 @@ function QuoterPage() {
 	const updateInsuranceCost = async (
 		insuredAmount: number,
 		vehicleType: string,
+		vehicleContext?: { isNew?: boolean; origin?: string | null },
 	) => {
 		if (insuredAmount <= 0) return;
 
@@ -987,12 +988,24 @@ function QuoterPage() {
 			const selectedVehicle = vehiclesQuery.data?.data?.find(
 				(vehicle) => vehicle.id === quoterForm.state.values.vehicleId,
 			);
+			const normalizedVehicleType = vehicleType.trim().toLowerCase();
+			const inferredNewType = [
+				"nuevo",
+				"camion",
+				"camión",
+				"microbus",
+				"microbus_20",
+				"microbus_35",
+				"microbus_36plus",
+				"panel",
+				"uber",
+			].includes(normalizedVehicleType);
 			const membershipAdjustment = getMembershipAdjustment({
 				creditType: quoterForm.state.values.creditType,
 				insuredAmount,
 				vehicleType,
-				isNew: selectedVehicle?.isNew ?? vehicleType === "nuevo",
-				origin: selectedVehicle?.origin,
+				isNew: vehicleContext?.isNew ?? selectedVehicle?.isNew ?? inferredNewType,
+				origin: vehicleContext?.origin ?? selectedVehicle?.origin,
 			});
 			const rawMembershipCost = applyMembershipAdjustment(
 				rawMembershipCostBeforeAdjustment,

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -89,6 +89,10 @@ export const Route = createFileRoute("/crm/quoter")({
 });
 
 import {
+	applyMembershipAdjustment,
+	getMembershipAdjustment,
+} from "@/utils/membership-adjustment";
+import {
 	calculateQuotation,
 	GARANTIA_MOBILIARIA_INTERNO,
 	GPS_COST,
@@ -128,6 +132,8 @@ interface QuotationFormValues {
 	transferCost: number;
 	adminCost: number;
 	membershipCost: number;
+	membershipAdjustmentCategory: string;
+	membershipAdjustmentPercentage: number;
 	freelanceCost: number;
 	freelancePercentage: number;
 	royalty: number;
@@ -843,6 +849,8 @@ function QuoterPage() {
 			transferCost: 545, // 395 + 150 según Excel
 			adminCost: 0,
 			membershipCost: 0,
+			membershipAdjustmentCategory: "",
+			membershipAdjustmentPercentage: 0,
 			// Gastos adicionales para detalle de crédito
 			freelanceCost: 0,
 			freelancePercentage: 0,
@@ -974,8 +982,30 @@ function QuoterPage() {
 
 			const baseInsuranceCost =
 				Math.round(result.baseInsuranceCost * 100) / 100;
-			const rawMembershipCost =
+			const rawMembershipCostBeforeAdjustment =
 				Math.round(result.effectiveMembershipCost * 100) / 100;
+			const selectedVehicle = vehiclesQuery.data?.data?.find(
+				(vehicle) => vehicle.id === quoterForm.state.values.vehicleId,
+			);
+			const membershipAdjustment = getMembershipAdjustment({
+				creditType: quoterForm.state.values.creditType,
+				insuredAmount,
+				vehicleType,
+				isNew: selectedVehicle?.isNew ?? vehicleType === "nuevo",
+				origin: selectedVehicle?.origin,
+			});
+			const rawMembershipCost = applyMembershipAdjustment(
+				rawMembershipCostBeforeAdjustment,
+				membershipAdjustment,
+			);
+			quoterForm.setFieldValue(
+				"membershipAdjustmentCategory",
+				membershipAdjustment.category,
+			);
+			quoterForm.setFieldValue(
+				"membershipAdjustmentPercentage",
+				membershipAdjustment.percentage,
+			);
 			quoterForm.setFieldValue("insuranceProvider", result.provider);
 			quoterForm.setFieldValue(
 				"customerInsuranceCost",
@@ -1947,6 +1977,15 @@ function QuoterPage() {
 											Seguro: Universales
 										</p>
 									)}
+									{quoterForm.state.values.membershipAdjustmentCategory ? (
+										<p className="text-muted-foreground text-xs">
+											Membresía: ajuste automático {""}
+											{quoterForm.state.values.membershipAdjustmentPercentage.toFixed(
+												2,
+											)}
+											% por {quoterForm.state.values.membershipAdjustmentCategory}.
+										</p>
+									) : null}
 
 									<quoterForm.Field name="gpsCost">
 										{(field) => (

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -119,6 +119,11 @@ interface QuotationFormValues {
 	termMonths: number;
 	interestRate: number;
 	insuranceCost: number;
+	insuranceProvider: "universales" | "gyt";
+	customerInsuranceCost: number;
+	internalInsuranceCost: number;
+	excelCurrentInsuranceCost: number;
+	insuranceSavingsToMembership: number;
 	gpsCost: number;
 	transferCost: number;
 	adminCost: number;
@@ -829,6 +834,11 @@ function QuoterPage() {
 			termMonths: 60,
 			interestRate: 1.5, // default autocompra; sobre_vehiculo usa 3
 			insuranceCost: 0,
+			insuranceProvider: "universales" as "universales" | "gyt",
+			customerInsuranceCost: 0,
+			internalInsuranceCost: 0,
+			excelCurrentInsuranceCost: 0,
+			insuranceSavingsToMembership: 0,
 			gpsCost: GPS_COST,
 			transferCost: 545, // 395 + 150 según Excel
 			adminCost: 0,
@@ -964,11 +974,30 @@ function QuoterPage() {
 
 			const baseInsuranceCost =
 				Math.round(result.baseInsuranceCost * 100) / 100;
-			const rawMembershipCost = Math.round(result.membershipCost * 100) / 100;
+			const rawMembershipCost =
+				Math.round(result.effectiveMembershipCost * 100) / 100;
+			quoterForm.setFieldValue("insuranceProvider", result.provider);
+			quoterForm.setFieldValue(
+				"customerInsuranceCost",
+				Math.round(result.customerInsuranceCost * 100) / 100,
+			);
+			quoterForm.setFieldValue(
+				"internalInsuranceCost",
+				Math.round(result.internalInsuranceCost * 100) / 100,
+			);
+			quoterForm.setFieldValue(
+				"excelCurrentInsuranceCost",
+				Math.round((result.excelCurrentInsuranceCost ?? 0) * 100) / 100,
+			);
+			quoterForm.setFieldValue(
+				"insuranceSavingsToMembership",
+				Math.round(result.insuranceSavingsToMembership * 100) / 100,
+			);
 
 			if (isInterno) {
 				// Crédito interno: solo seguro base, sin membresía ni GPS
 				quoterForm.setFieldValue("insuranceCost", baseInsuranceCost);
+				quoterForm.setFieldValue("customerInsuranceCost", baseInsuranceCost);
 				quoterForm.setFieldValue("membershipCost", 0);
 				quoterForm.setFieldValue("extraInsuranceCost", baseInsuranceCost);
 				quoterForm.setFieldValue("extraMembershipCost", 0);
@@ -980,6 +1009,7 @@ function QuoterPage() {
 					Math.round((baseInsuranceCost + netMembershipCost) * 100) / 100;
 
 				quoterForm.setFieldValue("insuranceCost", insuranceCost);
+				quoterForm.setFieldValue("customerInsuranceCost", insuranceCost);
 				quoterForm.setFieldValue("membershipCost", netMembershipCost);
 				quoterForm.setFieldValue("extraInsuranceCost", baseInsuranceCost);
 				quoterForm.setFieldValue("extraMembershipCost", rawMembershipCost);
@@ -1896,6 +1926,27 @@ function QuoterPage() {
 											</div>
 										)}
 									</quoterForm.Field>
+									{quoterForm.state.values.insuranceProvider === "gyt" ? (
+										<p className="text-muted-foreground text-xs">
+											Seguro: GyT. Actual Excel: Q
+											{quoterForm.state.values.excelCurrentInsuranceCost.toFixed(
+												2,
+											)}{" "}
+											/ CRM: Q
+											{quoterForm.state.values.customerInsuranceCost.toFixed(2)}{" "}
+											/ GyT: Q
+											{quoterForm.state.values.internalInsuranceCost.toFixed(2)}
+											. Diferencia a membresía: Q
+											{quoterForm.state.values.insuranceSavingsToMembership.toFixed(
+												2,
+											)}
+											.
+										</p>
+									) : (
+										<p className="text-muted-foreground text-xs">
+											Seguro: Universales
+										</p>
+									)}
 
 									<quoterForm.Field name="gpsCost">
 										{(field) => (
@@ -2104,16 +2155,32 @@ function QuoterPage() {
 																{row.period}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.initialBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+																Q
+																{row.initialBalance.toLocaleString("es-GT", {
+																	minimumFractionDigits: 2,
+																	maximumFractionDigits: 2,
+																})}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.interestPlusVAT.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+																Q
+																{row.interestPlusVAT.toLocaleString("es-GT", {
+																	minimumFractionDigits: 2,
+																	maximumFractionDigits: 2,
+																})}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.principal.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+																Q
+																{row.principal.toLocaleString("es-GT", {
+																	minimumFractionDigits: 2,
+																	maximumFractionDigits: 2,
+																})}
 															</TableCell>
 															<TableCell className="text-right">
-																Q{row.finalBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+																Q
+																{row.finalBalance.toLocaleString("es-GT", {
+																	minimumFractionDigits: 2,
+																	maximumFractionDigits: 2,
+																})}
 															</TableCell>
 														</TableRow>
 													))}
@@ -2422,10 +2489,34 @@ function QuotationDetailDialog({
 										.map((row: any) => (
 											<TableRow key={row.period}>
 												<TableCell>{row.period}</TableCell>
-												<TableCell>Q{row.initialBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
-												<TableCell>Q{row.interestPlusVAT.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
-												<TableCell>Q{row.principal.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
-												<TableCell>Q{row.finalBalance.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}</TableCell>
+												<TableCell>
+													Q
+													{row.initialBalance.toLocaleString("es-GT", {
+														minimumFractionDigits: 2,
+														maximumFractionDigits: 2,
+													})}
+												</TableCell>
+												<TableCell>
+													Q
+													{row.interestPlusVAT.toLocaleString("es-GT", {
+														minimumFractionDigits: 2,
+														maximumFractionDigits: 2,
+													})}
+												</TableCell>
+												<TableCell>
+													Q
+													{row.principal.toLocaleString("es-GT", {
+														minimumFractionDigits: 2,
+														maximumFractionDigits: 2,
+													})}
+												</TableCell>
+												<TableCell>
+													Q
+													{row.finalBalance.toLocaleString("es-GT", {
+														minimumFractionDigits: 2,
+														maximumFractionDigits: 2,
+													})}
+												</TableCell>
 											</TableRow>
 										))}
 								</TableBody>

--- a/apps/crm/apps/web/src/routes/crm/quoter.tsx
+++ b/apps/crm/apps/web/src/routes/crm/quoter.tsx
@@ -1196,12 +1196,16 @@ function QuoterPage() {
 					quoterForm.setFieldValue("downPayment", downPayment);
 				}
 
-				// Actualizar seguro y membresía
+				// Actualizar seguro y membresía. Pasamos isNew/origin del vehículo
+				// seleccionado explícitamente: el form state (vehicleId) que usa
+				// updateInsuranceCost para resolver el vehículo recién se seteó y
+				// puede estar stale, lo que clasificaría mal la membresía.
 				updateInsuranceCost(
 					isSobreVehiculo
 						? quoterForm.state.values.insuredAmount || numericValue
 						: numericValue,
 					quoterForm.state.values.vehicleType,
+					{ isNew: vehicle.isNew, origin: vehicle.origin },
 				);
 			}
 		}

--- a/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+import {
+	applyMembershipAdjustment,
+	getMembershipAdjustment,
+} from "./membership-adjustment";
+
+describe("getMembershipAdjustment", () => {
+	test.each([
+		[99999.99, 18.75],
+		[100000, 18.75],
+		[100000.01, 33.59],
+		[140000, 33.59],
+		[140000.01, 35],
+	])("uses new personal vehicle ranges for %s", (insuredAmount, percentage) => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount,
+			vehicleType: "particular",
+			isNew: true,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe("Nuevo (sedán, SUV, pickup)");
+		expect(result.percentage).toBe(percentage);
+	});
+
+	test("uses new commercial vehicle category", () => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount: 100000,
+			vehicleType: "microbus",
+			isNew: true,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe(
+			"Nuevo (camión, microbus, panel, uber o similar)",
+		);
+		expect(result.percentage).toBe(25);
+	});
+
+	test("uses used agency category from non-rodado origin", () => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount: 120000,
+			vehicleType: "particular",
+			isNew: false,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe("Usado agencia");
+		expect(result.percentage).toBe(55.47);
+	});
+
+	test.each(["rodado", "importado", "subasta"])(
+		"uses rodado category for origin %s",
+		(origin) => {
+			const result = getMembershipAdjustment({
+				creditType: "autocompra",
+				insuredAmount: 150000,
+				vehicleType: "particular",
+				isNew: false,
+				origin,
+			});
+
+			expect(result.category).toBe("Rodado");
+			expect(result.percentage).toBe(70);
+		},
+	);
+
+	test("uses sobre vehículo category before vehicle origin", () => {
+		const result = getMembershipAdjustment({
+			creditType: "sobre_vehiculo",
+			insuredAmount: 90000,
+			vehicleType: "microbus",
+			isNew: true,
+			origin: "agencia",
+		});
+
+		expect(result.category).toBe("Sobre vehículo (hasta 50%)");
+		expect(result.percentage).toBe(37.5);
+	});
+});
+
+describe("applyMembershipAdjustment", () => {
+	test("multiplies the current membership by the adjustment factor", () => {
+		const result = applyMembershipAdjustment(100, {
+			category: "Nuevo (sedán, SUV, pickup)",
+			percentage: 18.75,
+			factor: 1.1875,
+		});
+
+		expect(result).toBe(118.75);
+	});
+});

--- a/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.test.ts
@@ -39,6 +39,21 @@ describe("getMembershipAdjustment", () => {
 		expect(result.percentage).toBe(25);
 	});
 
+	test("manual microbus without selected vehicle is treated as new commercial", () => {
+		const result = getMembershipAdjustment({
+			creditType: "autocompra",
+			insuredAmount: 100000,
+			vehicleType: "microbus",
+			isNew: true,
+			origin: null,
+		});
+
+		expect(result.category).toBe(
+			"Nuevo (camión, microbus, panel, uber o similar)",
+		);
+		expect(result.percentage).toBe(25);
+	});
+
 	test("uses used agency category from non-rodado origin", () => {
 		const result = getMembershipAdjustment({
 			creditType: "autocompra",

--- a/apps/crm/apps/web/src/utils/membership-adjustment.ts
+++ b/apps/crm/apps/web/src/utils/membership-adjustment.ts
@@ -1,0 +1,98 @@
+export type MembershipAdjustmentCategory =
+	| "Nuevo (sedán, SUV, pickup)"
+	| "Nuevo (camión, microbus, panel, uber o similar)"
+	| "Usado agencia"
+	| "Rodado"
+	| "Sobre vehículo (hasta 50%)";
+
+export interface MembershipAdjustmentInput {
+	creditType: "autocompra" | "sobre_vehiculo";
+	insuredAmount: number;
+	vehicleType: string;
+	isNew: boolean;
+	origin?: string | null;
+}
+
+export interface MembershipAdjustment {
+	category: MembershipAdjustmentCategory;
+	percentage: number;
+	factor: number;
+}
+
+const RATES: Record<MembershipAdjustmentCategory, [number, number, number]> = {
+	"Nuevo (sedán, SUV, pickup)": [18.75, 33.59, 35],
+	"Nuevo (camión, microbus, panel, uber o similar)": [25, 44.53, 46.25],
+	"Usado agencia": [31.25, 55.47, 57.5],
+	Rodado: [37.5, 67.19, 70],
+	"Sobre vehículo (hasta 50%)": [37.5, 67.19, 70],
+};
+
+const NEW_PERSONAL_TYPES = new Set([
+	"particular",
+	"nuevo",
+	"sedan",
+	"sedán",
+	"suv",
+	"pickup",
+]);
+const NEW_COMMERCIAL_TYPES = new Set([
+	"camion",
+	"camión",
+	"microbus",
+	"microbus_20",
+	"microbus_35",
+	"microbus_36plus",
+	"panel",
+	"uber",
+]);
+const RODADO_ORIGINS = ["rodado", "importado", "subasta"];
+
+function normalize(value?: string | null): string {
+	return value?.trim().toLowerCase() ?? "";
+}
+
+function getRangeIndex(insuredAmount: number): 0 | 1 | 2 {
+	if (insuredAmount <= 100000) return 0;
+	if (insuredAmount <= 140000) return 1;
+	return 2;
+}
+
+function getCategory(input: MembershipAdjustmentInput): MembershipAdjustmentCategory {
+	if (input.creditType === "sobre_vehiculo") return "Sobre vehículo (hasta 50%)";
+
+	const vehicleType = normalize(input.vehicleType);
+	if (input.isNew) {
+		if (NEW_COMMERCIAL_TYPES.has(vehicleType)) {
+			return "Nuevo (camión, microbus, panel, uber o similar)";
+		}
+		if (NEW_PERSONAL_TYPES.has(vehicleType)) return "Nuevo (sedán, SUV, pickup)";
+		return "Nuevo (sedán, SUV, pickup)";
+	}
+
+	const origin = normalize(input.origin);
+	if (RODADO_ORIGINS.some((keyword) => origin.includes(keyword))) {
+		return "Rodado";
+	}
+
+	return "Usado agencia";
+}
+
+export function getMembershipAdjustment(
+	input: MembershipAdjustmentInput,
+): MembershipAdjustment {
+	const category = getCategory(input);
+	const percentage = RATES[category][getRangeIndex(input.insuredAmount)];
+
+	return {
+		category,
+		percentage,
+		factor: 1 + percentage / 100,
+	};
+}
+
+export function applyMembershipAdjustment(
+	membershipCost: number,
+	adjustment: MembershipAdjustment,
+): number {
+	return Math.round(membershipCost * adjustment.factor * 100) / 100;
+}

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -157,6 +157,7 @@ export interface SendNewCreditNotificationParams {
   vehiculoVin?: string;
   montoAsegurado?: number;
   opportunityId?: string;
+  aseguradora?: string;
 }
 
 export const sendNewCreditNotification = async ({
@@ -176,6 +177,7 @@ export const sendNewCreditNotification = async ({
   vehiculoVin,
   montoAsegurado,
   opportunityId,
+  aseguradora,
 }: SendNewCreditNotificationParams) => {
   try {
     const validEmails = to.filter((email) => {
@@ -207,6 +209,7 @@ export const sendNewCreditNotification = async ({
         vehiculoVin,
         montoAsegurado,
         opportunityId,
+        aseguradora,
       }),
     });
 

--- a/packages/email/src/templates/NewCreditTemplate.tsx
+++ b/packages/email/src/templates/NewCreditTemplate.tsx
@@ -28,6 +28,7 @@ interface NewCreditEmailProps {
   vehiculoVin?: string;
   montoAsegurado?: number;
   opportunityId?: string;
+  aseguradora?: string;
 }
 
 const main = {
@@ -146,6 +147,7 @@ export const NewCreditEmail = ({
   vehiculoVin,
   montoAsegurado,
   opportunityId,
+  aseguradora,
 }: NewCreditEmailProps) => {
   const hasVehicleInfo = vehiculoMarca || vehiculoLinea || vehiculoModelo || vehiculoPlaca || vehiculoVin;
   const oportunidadUrl = `https://crm.s3.devteamatcci.site/crm/opportunities?opportunityId=${opportunityId}&tab=create`;
@@ -172,6 +174,9 @@ export const NewCreditEmail = ({
             <Text style={detailItem}><strong>Plazo:</strong> {plazo} meses</Text>
             <Text style={detailItem}><strong>Cuota:</strong> {currencySymbol}{cuota}</Text>
             <Text style={detailItem}><strong>Tasa de Interés:</strong> {interestRate}%</Text>
+            {aseguradora && (
+              <Text style={detailItem}><strong>Aseguradora:</strong> {aseguradora}</Text>
+            )}
           </Section>
 
           {investors.length > 0 && (


### PR DESCRIPTION
## Qué
Lleva la **feature GyT completa** a develop (incluye #964 y #965 ya mergeados en esta rama):
- **Precios GyT vs Universales** en el cotizador: `selectInsuranceProvider` elige GyT solo si califica (≥189k auto/uber/nuevo, ≥125k microbús) **y es más barato**; tabla `gyt_insurance_costs` + seed desde R2.
- **Flujo aseguradoras CRM→cartera** (#965): estampa el provider al cerrar (última cotización) y manda 'GyT'/'Universales' a cartera; `findOrCreateAseguradora` enlaza el crédito + correo.
- Fixes de cálculo A1/A2, quoter isNew/origin, y reviews de Codex/Luis/Daniel.

## ⚠️ Solape con el módulo ya en develop (#968/#969)
El schema `cartera.aseguradoras` + `creditos.aseguradora_id` lo agregan **ambos** (este PR por #965, y #968 ya en develop). **Hay que resolver el conflicto al mergear**: dejar una sola definición en `schema.ts` + reconciliar migraciones (develop ya trae `0016_add_aseguradoras`; esta rama trae `0015_add_aseguradoras` — equivalentes). El `findOrCreateAseguradora` (lógica de createCredit) sí es único de este PR y se conserva.

## ⚠️ Para el pase a PROD (CRM)
- Correr migración `0024_add_gyt_insurance.sql` (crea `gyt_insurance_costs`) **antes** del código (el cotizador la consulta).
- Subir el Excel de tarifas a R2 + correr el seed (`GYT_INSURANCE_XLSX_KEY`). Sin Excel → degrada a Universales (no crashea, si la tabla existe).
- La parte cartera (`cartera.aseguradoras` + índice) **ya está aplicada en dev y prod**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)