### PR TITLE
feat(seguros): ícono de aseguradora en el badge de Créditos

### DIFF
--- a/apps/carteraFront/public/aseguradoras/README.md
+++ b/apps/carteraFront/public/aseguradoras/README.md
@@ -1,9 +1,0 @@
-# Logos de aseguradoras
-
-Coloca aquí los logos (PNG o SVG, fondo transparente idealmente):
-- `gyt.png`         → logo de G&T Continental (aseguradora "GyT")
-- `universales.png` → logo de Universales
-
-Se referencian desde el badge de aseguradora en CreditsPaymentsData.tsx
-vía `/aseguradoras/<archivo>` (helper `aseguradoraLogo`). Si falta el archivo,
-el badge muestra solo el nombre (con 🛡️ de fallback).

--- a/apps/carteraFront/public/aseguradoras/README.md
+++ b/apps/carteraFront/public/aseguradoras/README.md
@@ -1,0 +1,9 @@
+# Logos de aseguradoras
+
+Coloca aquí los logos (PNG o SVG, fondo transparente idealmente):
+- `gyt.png`         → logo de G&T Continental (aseguradora "GyT")
+- `universales.png` → logo de Universales
+
+Se referencian desde el badge de aseguradora en CreditsPaymentsData.tsx
+vía `/aseguradoras/<archivo>` (helper `aseguradoraLogo`). Si falta el archivo,
+el badge muestra solo el nombre (con 🛡️ de fallback).

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -15,7 +15,7 @@ import {
 import { useCreditosPaginadosWithFilters } from "../hooks/credits";
 import { getApiErrorMessage } from "@/lib/apiError";
 import { Button } from "@/components/ui/button";
-import { Eye, Pencil, XCircle, FileCheck, CheckCircle2, DollarSign } from "lucide-react";
+import { Eye, Pencil, XCircle, FileCheck, CheckCircle2, DollarSign, ShieldCheck } from "lucide-react";
 
 import {
   Table,
@@ -51,16 +51,6 @@ import { Switch } from "@/components/ui/switch";
 import { usePaymentAgreements,useTogglePaymentAgreementStatus } from "../hooks/paymentagreement";
 import { toast } from "sonner";
 import { ModalCaidoCredit } from "./ModalCaidoCredit";
-
-// Logos de aseguradoras (archivos en public/aseguradoras/). Key = nombre en minúsculas.
-const ASEGURADORA_LOGOS: Record<string, string> = {
-  gyt: "/aseguradoras/gyt.png",
-  universales: "/aseguradoras/universales.png",
-};
-function aseguradoraLogo(nombre?: string | null): string | undefined {
-  if (!nombre) return undefined;
-  return ASEGURADORA_LOGOS[nombre.trim().toLowerCase()];
-}
 
 export function ListaCreditosPagos() {
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
@@ -1312,16 +1302,8 @@ function MobileView({
               </span>
             )}
             {item.aseguradora && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-white text-slate-700 border border-slate-200">
-                {aseguradoraLogo(item.aseguradora) ? (
-                  <img
-                    src={aseguradoraLogo(item.aseguradora)}
-                    alt={item.aseguradora}
-                    className="h-4 w-auto max-w-[44px] object-contain rounded-sm"
-                  />
-                ) : (
-                  <span>🛡️</span>
-                )}
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-slate-100 text-slate-700 border border-slate-200">
+                <ShieldCheck className="h-3.5 w-3.5 text-slate-500" />
                 {item.aseguradora}
               </span>
             )}
@@ -1642,16 +1624,8 @@ function DesktopView({
                       </span>
                     )}
                     {item.aseguradora && (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-white text-slate-700 border border-slate-200">
-                        {aseguradoraLogo(item.aseguradora) ? (
-                          <img
-                            src={aseguradoraLogo(item.aseguradora)}
-                            alt={item.aseguradora}
-                            className="h-4 w-auto max-w-[44px] object-contain rounded-sm"
-                          />
-                        ) : (
-                          <span>🛡️</span>
-                        )}
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-slate-100 text-slate-700 border border-slate-200">
+                        <ShieldCheck className="h-3.5 w-3.5 text-slate-500" />
                         {item.aseguradora}
                       </span>
                     )}

--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -52,6 +52,16 @@ import { usePaymentAgreements,useTogglePaymentAgreementStatus } from "../hooks/p
 import { toast } from "sonner";
 import { ModalCaidoCredit } from "./ModalCaidoCredit";
 
+// Logos de aseguradoras (archivos en public/aseguradoras/). Key = nombre en minúsculas.
+const ASEGURADORA_LOGOS: Record<string, string> = {
+  gyt: "/aseguradoras/gyt.png",
+  universales: "/aseguradoras/universales.png",
+};
+function aseguradoraLogo(nombre?: string | null): string | undefined {
+  if (!nombre) return undefined;
+  return ASEGURADORA_LOGOS[nombre.trim().toLowerCase()];
+}
+
 export function ListaCreditosPagos() {
   const [expandedRow, setExpandedRow] = useState<number | null>(null);
   const [isDownloadingExcel, setIsDownloadingExcel] = useState(false);
@@ -1302,8 +1312,17 @@ function MobileView({
               </span>
             )}
             {item.aseguradora && (
-              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold" style={{ backgroundColor: 'rgba(22,163,74,0.1)', color: '#15803d', border: '1px solid rgba(22,163,74,0.25)' }}>
-                🛡️ {item.aseguradora}
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-white text-slate-700 border border-slate-200">
+                {aseguradoraLogo(item.aseguradora) ? (
+                  <img
+                    src={aseguradoraLogo(item.aseguradora)}
+                    alt={item.aseguradora}
+                    className="h-4 w-auto max-w-[44px] object-contain rounded-sm"
+                  />
+                ) : (
+                  <span>🛡️</span>
+                )}
+                {item.aseguradora}
               </span>
             )}
           </p>
@@ -1623,8 +1642,17 @@ function DesktopView({
                       </span>
                     )}
                     {item.aseguradora && (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold" style={{ backgroundColor: 'rgba(22,163,74,0.1)', color: '#15803d', border: '1px solid rgba(22,163,74,0.25)' }}>
-                        🛡️ {item.aseguradora}
+                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold bg-white text-slate-700 border border-slate-200">
+                        {aseguradoraLogo(item.aseguradora) ? (
+                          <img
+                            src={aseguradoraLogo(item.aseguradora)}
+                            alt={item.aseguradora}
+                            className="h-4 w-auto max-w-[44px] object-contain rounded-sm"
+                          />
+                        ) : (
+                          <span>🛡️</span>
+                        )}
+                        {item.aseguradora}
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
## Qué
En la página de **Créditos**, el badge de aseguradora ahora muestra un **ícono `ShieldCheck` (lucide) + el nombre** (en vez del emoji 🛡️), en desktop y móvil.

- Chip neutro (slate) + ícono + nombre.
- Sin assets/imágenes (se descartó la idea de logos reales por simplicidad).

## Pruebas
typecheck del front: 0 errores en CreditsPaymentsData.

🤖 Generated with [Claude Code](https://claude.com/claude-code)