### PR TITLE
Broadens latest opportunity quote search

### DIFF
--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -428,8 +428,7 @@ async function getLatestApprovedQuotation(
 			.from(quotations)
 			.where(
 				and(
-					eq(quotations.opportunityId, opportunityId),
-					eq(quotations.status, "accepted"),
+					eq(quotations.opportunityId, opportunityId)
 				),
 			)
 			.orderBy(desc(quotations.createdAt))


### PR DESCRIPTION
Previously, the `getLatestApprovedQuotation` service function only considered quotations with an 'accepted' status. This update removes the status filter from the query. The change ensures the function accurately retrieves the absolute latest quotation for an opportunity based on its creation date, irrespective of its current status, addressing cases where the true latest quotation might not be 'accepted'.