### PR TITLE
fix(cartera): switch "Permite Abono a Capital" arrancaba apagado al editar crédito

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -217,6 +217,8 @@ export function ListaCreditosPagos() {
       gps: credit.gps ?? 0,
       asesor_id: credit.asesor_id,
       formato_credito: credit.formato_credito ?? "",
+      permite_abono_capital: !!credit.permite_abono_capital,
+      no_amortiza_capital: !!credit.no_amortiza_capital,
       estado_devolucion: credit.estado_devolucion ?? "NO_APLICA",
       nombre: usuario?.nombre ?? (usuario?.nombres ? `${usuario.nombres} ${usuario.apellidos ?? ""}`.trim() : ""),
       nit: usuario?.nit ?? "",


### PR DESCRIPTION
## Problema

En el modal de edición de crédito, el switch **"Permite Abono a Capital"** aparecía apagado aunque en DB el crédito tuviera `permite_abono_capital: true`.

## Causa

En `handleOpenEdit` ([CreditsPaymentsData.tsx](apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx)), el objeto `creditToEdit` se arma campo por campo y **no copiaba** `permite_abono_capital` (ni `no_amortiza_capital`). Llegaba `undefined` a formik → el switch se inicializaba apagado. El guardado ya enviaba el campo correctamente; solo fallaba la lectura inicial.

## Cambio

Se copian ambos campos al abrir el modal:

```ts
permite_abono_capital: !!credit.permite_abono_capital,
no_amortiza_capital: !!credit.no_amortiza_capital,
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)