### PR TITLE
Feat: Extract first and last name from fullName if firstName is missing

### DIFF
--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -235,6 +235,12 @@ export async function createPublicLead(c: Context) {
 	try {
 		const body = await c.req.json();
 
+		if (!body.firstName && body.fullName) {
+			const parts = (body.fullName as string).trim().split(/\s+/);
+			body.firstName = parts[0] ?? "";
+			body.lastName = parts.slice(1).join(" ") || parts[0] || "";
+		}
+
 		if (!body.firstName || !body.lastName || !body.email) {
 			return c.json(
 				{


### PR DESCRIPTION
### **fullName en endpoint público de leads**
Se configuró Make para capturar leads automáticamente desde los formularios nativos de Facebook Lead Ads y google ads y enviarlos al CRM vía POST /api/public/lead. Make entrega el nombre del lead como un único campo full_name — no permite hacer el split en firstName/lastName dentro del body JSON sin errores de sintaxis en su motor de plantillas (IML).

Cambio
controllers/public-lead.ts

Se agrega el campo opcional fullName. Si el caller no envía firstName pero sí envía fullName, el controlador lo divide por espacios: la primera palabra va a firstName y el resto a lastName. Si el nombre tiene una sola palabra, se usa en ambos campos.

El cambio es completamente backward compatible — el bloque solo se ejecuta cuando firstName está ausente y fullName está presente, por lo que ningún caller existente se ve afectado.