### PR TITLE
feat(portal): ajustar calculadora pública de crédito

### DIFF
--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test:credit-calculator": "node scripts/credit-calculator.test.mjs",
     "preview": "vite preview",
     "push": "bash ./deploy.sh"
   },

--- a/apps/portal-web/scripts/credit-calculator.test.mjs
+++ b/apps/portal-web/scripts/credit-calculator.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { rmSync } from "node:fs";
+import { readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -58,5 +58,15 @@ assertClose(
   0.01,
   "Q200k / 20% / 48 meses",
 );
+
+const calculatorSource = readFileSync(
+  "src/features/Marketplace/Sections/CalculatorCredit.tsx",
+  "utf8",
+);
+const calculadoraRouteSource = readFileSync("src/routes/calculadora.tsx", "utf8");
+
+assert.match(calculatorSource, /standalone\?: boolean/);
+assert.match(calculatorSource, /standalone \? "mt-4 lg:mt-8" : "mt-12 lg:mt-64"/);
+assert.match(calculadoraRouteSource, /<CalculatorCredit standalone \/>/);
 
 console.log("Pruebas de calculadora de crédito OK");

--- a/apps/portal-web/scripts/credit-calculator.test.mjs
+++ b/apps/portal-web/scripts/credit-calculator.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const outDir = join(tmpdir(), "portal-web-credit-calculator-test");
+rmSync(outDir, { force: true, recursive: true });
+
+execFileSync(
+  "./node_modules/.bin/tsc",
+  [
+    "src/features/Marketplace/utils/creditCalculator.ts",
+    "--target",
+    "ES2022",
+    "--module",
+    "ES2022",
+    "--moduleResolution",
+    "bundler",
+    "--outDir",
+    outDir,
+    "--skipLibCheck",
+  ],
+  { stdio: "inherit" },
+);
+
+const {
+  calculatePublicCredit,
+  getPublicAdjustmentFactor,
+} = await import(`file://${outDir}/creditCalculator.js`);
+
+function assertClose(actual, expected, tolerance, label) {
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `${label}: esperado ${expected}, recibido ${actual}`,
+  );
+}
+
+assertClose(getPublicAdjustmentFactor(50_000, 20, 48), 0.3, 0.000001, "factor Q50k");
+assertClose(getPublicAdjustmentFactor(100_000, 20, 48), 0.205, 0.000001, "factor Q100k");
+assertClose(getPublicAdjustmentFactor(200_000, 20, 48), 0.155, 0.000001, "factor Q200k");
+
+assertClose(
+  calculatePublicCredit({ vehicleAmount: 50_000, downPaymentPct: 20, termMonths: 48 }).monthlyPayment,
+  1_586.82,
+  0.01,
+  "Q50k / 20% / 48 meses",
+);
+assertClose(
+  calculatePublicCredit({ vehicleAmount: 100_000, downPaymentPct: 20, termMonths: 48 }).monthlyPayment,
+  2_941.71,
+  0.01,
+  "Q100k / 20% / 48 meses",
+);
+assertClose(
+  calculatePublicCredit({ vehicleAmount: 200_000, downPaymentPct: 20, termMonths: 48 }).monthlyPayment,
+  5_639.30,
+  0.01,
+  "Q200k / 20% / 48 meses",
+);
+
+console.log("Pruebas de calculadora de crédito OK");

--- a/apps/portal-web/scripts/credit-calculator.test.mjs
+++ b/apps/portal-web/scripts/credit-calculator.test.mjs
@@ -59,6 +59,39 @@ assertClose(
   "Q200k / 20% / 48 meses",
 );
 
+const beforeBoundary = calculatePublicCredit({
+  vehicleAmount: 50_000,
+  downPaymentPct: 20,
+  termMonths: 48,
+}).monthlyPayment;
+const afterBoundary = calculatePublicCredit({
+  vehicleAmount: 50_001,
+  downPaymentPct: 20,
+  termMonths: 48,
+}).monthlyPayment;
+assert.ok(
+  afterBoundary >= beforeBoundary,
+  `La cuota no debe bajar al cruzar Q50k: ${beforeBoundary} -> ${afterBoundary}`,
+);
+
+for (const termMonths of [12, 24, 36, 48, 60]) {
+  for (const downPaymentPct of [10, 15, 20, 25, 30]) {
+    let previousPayment = 0;
+    for (let vehicleAmount = 25_000; vehicleAmount <= 500_000; vehicleAmount += 1_000) {
+      const { monthlyPayment } = calculatePublicCredit({
+        vehicleAmount,
+        downPaymentPct,
+        termMonths,
+      });
+      assert.ok(
+        monthlyPayment >= previousPayment,
+        `La cuota debe ser monotónica para Q${vehicleAmount}, ${downPaymentPct}%, ${termMonths} meses`,
+      );
+      previousPayment = monthlyPayment;
+    }
+  }
+}
+
 const calculatorSource = readFileSync(
   "src/features/Marketplace/Sections/CalculatorCredit.tsx",
   "utf8",

--- a/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
+++ b/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
@@ -1,6 +1,7 @@
 import { Select, Input, Button } from "@/components";
 import { useState } from "react";
 import { openWhatsApp, useIsMobile } from "@/hooks";
+import { calculatePublicCredit } from "../utils/creditCalculator";
 
 export const CalculatorCredit = () => {
   const IMAGE = import.meta.env.VITE_IMAGE_URL + "/calculator.jpg";
@@ -28,7 +29,6 @@ export const CalculatorCredit = () => {
     { value: "60", label: "60 meses" },
   ];
 
-  // Calcular resultados
   const calcularCredito = () => {
     const montoNumero = Number.parseFloat(monto);
     const engancheNumero = Number.parseFloat(enganche);
@@ -38,22 +38,15 @@ export const CalculatorCredit = () => {
       return { interes: 0, pagoMensual: 0 };
     }
 
-    // Calcular monto de enganche
-    const montoEnganche = (montoNumero * engancheNumero) / 100;
-    const montoFinanciar = montoNumero - montoEnganche;
-
-    // Tasa de interés mensual: 1.5% + IVA (12%)
-    const tasaMensual = 1.5 / 100;
-    const tasaEfectiva = tasaMensual * 1.12;
-
-    // Calcular pago mensual usando fórmula de amortización (incluye IVA sobre interés)
-    const pagoMensual =
-      (montoFinanciar * tasaEfectiva * Math.pow(1 + tasaEfectiva, tiempoNumero)) /
-      (Math.pow(1 + tasaEfectiva, tiempoNumero) - 1);
+    const credito = calculatePublicCredit({
+      vehicleAmount: montoNumero,
+      downPaymentPct: engancheNumero,
+      termMonths: tiempoNumero,
+    });
 
     return {
-      interes: 1.5,
-      pagoMensual: Number.isNaN(pagoMensual) ? 0 : pagoMensual,
+      interes: credito.interestPct,
+      pagoMensual: credito.monthlyPayment,
     };
   };
 
@@ -196,7 +189,7 @@ export const CalculatorCredit = () => {
                     </div>
                   </div>
                   <p className="text-xs text-white/40 mt-3 text-center">
-                    *Esta calculadora es solo una referencia estimada y no refleja las condiciones finales del crédito.
+                    *Esta calculadora es una estimación referencial y puede variar según la evaluación y las condiciones finales del crédito.
                   </p>
                 </div>
                 <div className="w-full flex justify-center mt-2 lg:mt-6">

--- a/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
+++ b/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
@@ -3,7 +3,11 @@ import { useState } from "react";
 import { openWhatsApp, useIsMobile } from "@/hooks";
 import { calculatePublicCredit } from "../utils/creditCalculator";
 
-export const CalculatorCredit = () => {
+type CalculatorCreditProps = {
+  standalone?: boolean;
+};
+
+export const CalculatorCredit = ({ standalone = false }: CalculatorCreditProps) => {
   const IMAGE = import.meta.env.VITE_IMAGE_URL + "/calculator.jpg";
 
   const [monto, setMonto] = useState<string>("");
@@ -51,9 +55,12 @@ export const CalculatorCredit = () => {
   };
 
   const resultado = calcularCredito();
+  const topMargin = standalone ? "mt-4 lg:mt-8" : "mt-12 lg:mt-64";
 
   return (
-    <section className="relative w-full mt-12 lg:mt-64 mb-16 lg:mb-30 flex px-8 lg:px-20">
+    <section
+      className={`relative w-full ${topMargin} mb-16 lg:mb-30 flex px-8 lg:px-20`}
+    >
       {/* Imagen a la izquierda */}
       <div className="relative w-[438px] shrink-0 hidden lg:block">
         <img

--- a/apps/portal-web/src/features/Marketplace/utils/creditCalculator.ts
+++ b/apps/portal-web/src/features/Marketplace/utils/creditCalculator.ts
@@ -14,21 +14,43 @@ export interface PublicCreditResult {
 const MONTHLY_INTEREST_PCT = 1.5;
 const IVA_FACTOR = 1.12;
 
+const BASE_ADJUSTMENT_POINTS = [
+  { vehicleAmount: 25_000, factor: 0.47 },
+  { vehicleAmount: 50_000, factor: 0.29 },
+  { vehicleAmount: 75_000, factor: 0.225 },
+  { vehicleAmount: 100_000, factor: 0.195 },
+  { vehicleAmount: 150_000, factor: 0.165 },
+  { vehicleAmount: 200_000, factor: 0.145 },
+  { vehicleAmount: 300_000, factor: 0.13 },
+  { vehicleAmount: 400_000, factor: 0.12 },
+  { vehicleAmount: 500_000, factor: 0.115 },
+] as const;
+
+function getInterpolatedBaseFactor(vehicleAmount: number) {
+  const firstPoint = BASE_ADJUSTMENT_POINTS[0];
+  const lastPoint = BASE_ADJUSTMENT_POINTS[BASE_ADJUSTMENT_POINTS.length - 1];
+
+  if (vehicleAmount <= firstPoint.vehicleAmount) return firstPoint.factor;
+  if (vehicleAmount >= lastPoint.vehicleAmount) return lastPoint.factor;
+
+  const upperIndex = BASE_ADJUSTMENT_POINTS.findIndex(
+    (point) => vehicleAmount <= point.vehicleAmount,
+  );
+  const lowerPoint = BASE_ADJUSTMENT_POINTS[upperIndex - 1];
+  const upperPoint = BASE_ADJUSTMENT_POINTS[upperIndex];
+  const progress =
+    (vehicleAmount - lowerPoint.vehicleAmount) /
+    (upperPoint.vehicleAmount - lowerPoint.vehicleAmount);
+
+  return lowerPoint.factor + (upperPoint.factor - lowerPoint.factor) * progress;
+}
+
 export function getPublicAdjustmentFactor(
   vehicleAmount: number,
   downPaymentPct: number,
   termMonths: number,
 ) {
-  let baseFactor: number;
-  if (vehicleAmount <= 25_000) baseFactor = 0.47;
-  else if (vehicleAmount <= 50_000) baseFactor = 0.29;
-  else if (vehicleAmount <= 75_000) baseFactor = 0.225;
-  else if (vehicleAmount <= 100_000) baseFactor = 0.195;
-  else if (vehicleAmount <= 150_000) baseFactor = 0.165;
-  else if (vehicleAmount <= 200_000) baseFactor = 0.145;
-  else if (vehicleAmount <= 300_000) baseFactor = 0.13;
-  else if (vehicleAmount <= 400_000) baseFactor = 0.12;
-  else baseFactor = 0.115;
+  const baseFactor = getInterpolatedBaseFactor(vehicleAmount);
 
   const termAdjustment =
     termMonths <= 12 ? -0.035 :

--- a/apps/portal-web/src/features/Marketplace/utils/creditCalculator.ts
+++ b/apps/portal-web/src/features/Marketplace/utils/creditCalculator.ts
@@ -1,0 +1,72 @@
+export interface PublicCreditInput {
+  vehicleAmount: number;
+  downPaymentPct: number;
+  termMonths: number;
+}
+
+export interface PublicCreditResult {
+  interestPct: number;
+  baseMonthlyPayment: number;
+  adjustmentFactor: number;
+  monthlyPayment: number;
+}
+
+const MONTHLY_INTEREST_PCT = 1.5;
+const IVA_FACTOR = 1.12;
+
+export function getPublicAdjustmentFactor(
+  vehicleAmount: number,
+  downPaymentPct: number,
+  termMonths: number,
+) {
+  let baseFactor: number;
+  if (vehicleAmount <= 25_000) baseFactor = 0.47;
+  else if (vehicleAmount <= 50_000) baseFactor = 0.29;
+  else if (vehicleAmount <= 75_000) baseFactor = 0.225;
+  else if (vehicleAmount <= 100_000) baseFactor = 0.195;
+  else if (vehicleAmount <= 150_000) baseFactor = 0.165;
+  else if (vehicleAmount <= 200_000) baseFactor = 0.145;
+  else if (vehicleAmount <= 300_000) baseFactor = 0.13;
+  else if (vehicleAmount <= 400_000) baseFactor = 0.12;
+  else baseFactor = 0.115;
+
+  const termAdjustment =
+    termMonths <= 12 ? -0.035 :
+    termMonths <= 24 ? -0.018 :
+    termMonths <= 36 ? 0 :
+    termMonths <= 48 ? 0.01 :
+    0.02;
+
+  const downPaymentAdjustment = (downPaymentPct - 20) / 1500;
+  return Math.min(0.50, Math.max(0.07, baseFactor + termAdjustment + downPaymentAdjustment));
+}
+
+export function calculatePublicCredit({
+  vehicleAmount,
+  downPaymentPct,
+  termMonths,
+}: PublicCreditInput): PublicCreditResult {
+  if (vehicleAmount <= 0 || downPaymentPct < 0 || termMonths <= 0) {
+    return {
+      interestPct: MONTHLY_INTEREST_PCT,
+      baseMonthlyPayment: 0,
+      adjustmentFactor: 0,
+      monthlyPayment: 0,
+    };
+  }
+
+  const amountToFinance = vehicleAmount - (vehicleAmount * downPaymentPct) / 100;
+  const monthlyRate = (MONTHLY_INTEREST_PCT / 100) * IVA_FACTOR;
+  const factor = (1 + monthlyRate) ** termMonths;
+  const baseMonthlyPayment = (amountToFinance * monthlyRate * factor) / (factor - 1);
+  const adjustmentFactor = getPublicAdjustmentFactor(vehicleAmount, downPaymentPct, termMonths);
+
+  return {
+    interestPct: MONTHLY_INTEREST_PCT,
+    baseMonthlyPayment: Number.isNaN(baseMonthlyPayment) ? 0 : baseMonthlyPayment,
+    adjustmentFactor,
+    monthlyPayment: Number.isNaN(baseMonthlyPayment)
+      ? 0
+      : baseMonthlyPayment * (1 + adjustmentFactor),
+  };
+}

--- a/apps/portal-web/src/routeTree.gen.ts
+++ b/apps/portal-web/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as InvestRouteImport } from './routes/invest'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as DocumentsRouteImport } from './routes/documents'
 import { Route as CreditRouteImport } from './routes/credit'
+import { Route as CalculadoraRouteImport } from './routes/calculadora'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as MarketplaceIndexRouteImport } from './routes/marketplace/index'
@@ -111,6 +112,11 @@ const CreditRoute = CreditRouteImport.update({
   path: '/credit',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CalculadoraRoute = CalculadoraRouteImport.update({
+  id: '/calculadora',
+  path: '/calculadora',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
@@ -140,6 +146,7 @@ const MarketplaceSearchIdRoute = MarketplaceSearchIdRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/calculadora': typeof CalculadoraRoute
   '/credit': typeof CreditRoute
   '/documents': typeof DocumentsRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -163,6 +170,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/calculadora': typeof CalculadoraRoute
   '/credit': typeof CreditRoute
   '/documents': typeof DocumentsRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -187,6 +195,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/calculadora': typeof CalculadoraRoute
   '/credit': typeof CreditRoute
   '/documents': typeof DocumentsRoute
   '/forgot-password': typeof ForgotPasswordRoute
@@ -212,6 +221,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/about'
+    | '/calculadora'
     | '/credit'
     | '/documents'
     | '/forgot-password'
@@ -235,6 +245,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/about'
+    | '/calculadora'
     | '/credit'
     | '/documents'
     | '/forgot-password'
@@ -258,6 +269,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/about'
+    | '/calculadora'
     | '/credit'
     | '/documents'
     | '/forgot-password'
@@ -282,6 +294,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  CalculadoraRoute: typeof CalculadoraRoute
   CreditRoute: typeof CreditRoute
   DocumentsRoute: typeof DocumentsRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
@@ -417,6 +430,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CreditRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/calculadora': {
+      id: '/calculadora'
+      path: '/calculadora'
+      fullPath: '/calculadora'
+      preLoaderRoute: typeof CalculadoraRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/about': {
       id: '/about'
       path: '/about'
@@ -458,6 +478,7 @@ declare module '@tanstack/react-router' {
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  CalculadoraRoute: CalculadoraRoute,
   CreditRoute: CreditRoute,
   DocumentsRoute: DocumentsRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,

--- a/apps/portal-web/src/routes/calculadora.tsx
+++ b/apps/portal-web/src/routes/calculadora.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { CalculatorCredit } from "@/features/Marketplace/Sections/CalculatorCredit";
+import { NavBar, Page } from "@/components";
+import { useSEO } from "@/lib/seo";
+
+export const Route = createFileRoute("/calculadora")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  useSEO({
+    title: "Calculadora de Crédito Vehicular",
+    description:
+      "Calcula una cuota mensual estimada para tu crédito vehicular en Club CashIn.",
+    canonical: "https://clubcashin.com/calculadora",
+  });
+
+  return (
+    <Page>
+      <NavBar />
+      <main className="pt-24 lg:pt-36">
+        <CalculatorCredit />
+      </main>
+    </Page>
+  );
+}

--- a/apps/portal-web/src/routes/calculadora.tsx
+++ b/apps/portal-web/src/routes/calculadora.tsx
@@ -19,7 +19,7 @@ function RouteComponent() {
     <Page>
       <NavBar />
       <main className="pt-24 lg:pt-36">
-        <CalculatorCredit />
+        <CalculatorCredit standalone />
       </main>
     </Page>
   );


### PR DESCRIPTION
## Resumen
- Agrega utilidad compartida para calcular la cuota pública con factor de ajuste comercial suave.
- Actualiza la calculadora existente para usar la nueva lógica sin exponer rubros internos.
- Agrega ruta pública `/calculadora` para mostrar solo la calculadora.
- Agrega prueba mínima reproducible para los casos calibrados de Q50k, Q100k y Q200k.

## Pruebas
- `npm run test:credit-calculator`
- `npm run build`

## Notas
- No se exponen seguro, GPS, administrativos ni otros rubros internos en UI.
- La cuota se mantiene como estimación referencial sujeta a evaluación y condiciones finales.