### PR TITLE
fix(cartera): mostrar abono directo a capital solo si la cuota actual ya está pagada

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -424,7 +424,7 @@ export function PagoForm() {
       )}
     </div>
 
-    {permiteAbonoCapital && !cuotaActualInfo?.pagada && !(cuotasAtrasadasInfo && cuotasAtrasadasInfo.total > 0) && (
+    {permiteAbonoCapital && cuotaActualInfo?.pagada && !(cuotasAtrasadasInfo && cuotasAtrasadasInfo.total > 0) && (
       <div className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl p-4 border-2 border-green-200 mt-2">
         <div className="flex items-center gap-2 mb-2">
           <DollarSign className="w-5 h-5 text-green-600" />


### PR DESCRIPTION
## Contexto

En el modal de confirmación de pago (`PagoForm.tsx`), el bloque verde **"Abonar todo a Capital"** se mostraba cuando la **cuota actual NO estaba pagada**:

```jsx
permiteAbonoCapital && !cuotaActualInfo?.pagada && !(cuotasAtrasadasInfo?.total > 0)
```

Esto ofrecía mandar toda la boleta a capital **salteándose la cuota del mes** (interés / IVA / seguro / membresía). Para un crédito con `permite_abono_capital`, un **abono voluntario a capital** debe hacerse cuando la cuota del mes **ya está cubierta**, no en lugar de pagarla.

> Esto también explicaba la diferencia "dev sí muestra el bloque / prod no" en el crédito 9055 — en prod la cuota de junio ya estaba pagada, en dev no.

## Cambio

Se invierte la condición en [PagoForm.tsx:427](apps/carteraFront/src/private/cartera/components/PagoForm.tsx#L427):

```diff
- permiteAbonoCapital && !cuotaActualInfo?.pagada && !(cuotasAtrasadasInfo?.total > 0)
+ permiteAbonoCapital && cuotaActualInfo?.pagada && !(cuotasAtrasadasInfo?.total > 0)
```

- Se mantiene el filtro de **sin atrasos** (no ofrecer abono voluntario si hay mora pendiente).
- El caso "cuota pagada + monto extra → excedente a capital" ya estaba cubierto por el modal de exceso en modo `pagada` (`handleAbonoCapital`); este cambio alinea el bloque verde con esa misma intención.

## Comportamiento esperado

| Estado cuota del mes | Antes | Después |
|---|---|---|
| Pendiente (sin pagar) | Bloque visible | Bloque oculto |
| Ya pagada (sin atrasos) | Bloque oculto | **Bloque visible** |
| Con atrasos | Oculto | Oculto |

> El mismo cambio va a `develop` en el PR #991.

🤖 Generated with [Claude Code](https://claude.com/claude-code)