### PR TITLE
fix(crm): mostrar solo oportunidades abiertas en análisis

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -2501,7 +2501,11 @@ export const crmRouter = {
 			}
 
 			// Build conditions
-			const conditions = [eq(opportunities.stageId, analysisStage[0].id)];
+			const conditions = [
+				eq(opportunities.stageId, analysisStage[0].id),
+				// Solo mostrar oportunidades abiertas (excluir perdidas, ganadas, etc.)
+				eq(opportunities.status, "open"),
+			];
 
 			// Search filter (name, license plate, opportunity ID)
 			if (search && search.trim() !== "") {


### PR DESCRIPTION
## Problema
La pantalla de **Análisis de Documentación** mostraba oportunidades perdidas (`lost`) junto con las abiertas. La query `getOpportunitiesForAnalysis` solo filtraba por la etapa de análisis (`stageId`), sin considerar el `status` de la oportunidad.

## Cambio
Se agrega el filtro `status = "open"` al `whereClause` de `getOpportunitiesForAnalysis`. Como ese `whereClause` se usa tanto en el conteo total como en la data paginada, el filtro aplica a ambos.

Resultado: la lista muestra **solo oportunidades abiertas**, excluyendo `lost`, `won`, `on_hold` y `migrate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)