### PR TITLE
fix: resolve problems in quota

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -424,7 +424,7 @@ export function PagoForm() {
       )}
     </div>
 
-    {permiteAbonoCapital && cuotaActualInfo?.pagada && !(cuotasAtrasadasInfo && cuotasAtrasadasInfo.total > 0) && (
+    {permiteAbonoCapital  && !(cuotasAtrasadasInfo && cuotasAtrasadasInfo.total > 0) && (
       <div className="bg-gradient-to-r from-green-50 to-emerald-50 rounded-xl p-4 border-2 border-green-200 mt-2">
         <div className="flex items-center gap-2 mb-2">
           <DollarSign className="w-5 h-5 text-green-600" />


### PR DESCRIPTION
## 🚀 Pase a Producción — Hotfix `hotfix-cuota` → `main`

Hotfix puntual en el formulario de registro de pago: se corrige la visibilidad del botón **"Abonar todo a Capital"** en el modal de confirmación de pago.

### 📞 Cartera — Registro de Pago (carteraFront)
- El botón **"Abonar todo a Capital"** ahora se muestra cuando el crédito permite abono a capital y **no** hay cuotas atrasadas, **sin exigir que la cuota actual ya esté pagada**.
- Antes se ocultaba si la cuota actual seguía pendiente (condición `cuotaActualInfo?.pagada`), lo que impedía abonar directo a capital en casos válidos.

---

### 📦 Resumen de cambios
| Área | Detalle |
|------|---------|
| carteraFront · PagoForm | Se quita la condición `cuotaActualInfo?.pagada` del gate del botón "Abonar todo a Capital" |

**Total:** 1 archivo · +1 / −1
