### PR TITLE
feat(crm): tab Proyección Liquidaciones en Dashboard Ejecutivo

### DIFF
--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -376,6 +376,9 @@ export const reportsAppRouter = {
 	editarInversionista: investorDocumentsRouter.editarInversionista,
 	cambiarStatusInversionista:
 		investorDocumentsRouter.cambiarStatusInversionista,
+	getInvestorsCartera: investorDocumentsRouter.getInvestorsCartera,
+	getSimulacionInversionista:
+		investorDocumentsRouter.getSimulacionInversionista,
 
 	// Accounting routes (Contabilidad)
 	getResumenGlobalInversionistas:
@@ -430,6 +433,12 @@ export const disbursementRouter = {
 
 export const manualVehicleRouter = {
 	upsertManualVehicleValuation: vehiclesRouter.upsertManualValuation,
+};
+
+// Projection procedures exported separately to avoid TS7056 truncation
+export const proyeccionRouter = {
+	getInvestorsCartera: investorDocumentsRouter.getInvestorsCartera,
+	getSimulacionInversionista: investorDocumentsRouter.getSimulacionInversionista,
 };
 
 // Merged AppRouter type to avoid serialization limit

--- a/apps/crm/apps/server/src/routers/investor-documents.ts
+++ b/apps/crm/apps/server/src/routers/investor-documents.ts
@@ -7,7 +7,10 @@ import {
 	investmentManagerProcedure,
 } from "../lib/orpc";
 import { PERMISSIONS } from "../lib/roles";
-import { carteraBackClient } from "../services/cartera-back-client";
+import {
+	carteraBackClient,
+	type SimulacionInversionistaResult,
+} from "../services/cartera-back-client";
 
 export const investorDocumentsRouter = {
 	getInvestorRendimiento: crmCobrosOrInvestmentsProcedure
@@ -381,6 +384,26 @@ export const investorDocumentsRouter = {
 			});
 
 			return result;
+		}),
+
+	getInvestorsCartera: investmentManagerProcedure.handler(async () => {
+		const result = await carteraBackClient.getInvestors();
+		return result.data ?? [];
+	}),
+
+	getSimulacionInversionista: investmentManagerProcedure
+		.input(
+			z.object({
+				inversionistaId: z.number().int().positive(),
+				mes: z.number().int().min(1).max(12).optional(),
+				anio: z.number().int().min(1900).max(2100).optional(),
+			}),
+		)
+		.handler(async ({ input }): Promise<SimulacionInversionistaResult> => {
+			return carteraBackClient.getSimulacionInversionista(
+				input.inversionistaId,
+				{ mes: input.mes, anio: input.anio },
+			);
 		}),
 
 	// Solo manager/admin pueden ver el historial de actividad

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1652,7 +1652,7 @@ export class CarteraBackClient {
 		return this.request<SimulacionInversionistaResult>(
 			`/inversionistas/${inversionistaId}/simulacion${qs}`,
 			{ method: "GET" },
-			true,
+			false,
 		);
 	}
 }

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -43,6 +43,37 @@ import {
 } from "./cartera-auth.service";
 
 // ============================================================================
+// TIPOS SIMULACIÓN INVERSIONISTA
+// ============================================================================
+
+export interface SimulacionInversionistaResult {
+	success: boolean;
+	data: {
+		inversionista_id: number;
+		nombre: string;
+		tipo_reinversion: string | null;
+		moneda: string | null;
+		emite_factura: boolean;
+		monto_reinversion_mensual: number;
+		total_monto_aportado: number;
+		total_capital_actual: number;
+		capital_restante_global: number;
+		desglose_acumulado: {
+			total_creditos: number;
+			total_reinversion: number;
+			total_acumulado: number;
+			meses: Array<{
+				mes: string;
+				total_sin_reinversion: number;
+				total_con_reinversion: number;
+				total_reinversion: number;
+				total_capital_restante: number;
+			}>;
+		};
+	};
+}
+
+// ============================================================================
 // CONFIGURATION
 // ============================================================================
 
@@ -1604,6 +1635,25 @@ export class CarteraBackClient {
 
 	invalidateCache(pattern?: string): void {
 		this.cache.invalidate(pattern);
+	}
+
+	// ========================================================================
+	// SIMULACIÓN INVERSIONISTA
+	// ========================================================================
+
+	async getSimulacionInversionista(
+		inversionistaId: number,
+		params?: { mes?: number; anio?: number },
+	): Promise<SimulacionInversionistaResult> {
+		const query = new URLSearchParams();
+		if (params?.mes !== undefined) query.set("mes", String(params.mes));
+		if (params?.anio !== undefined) query.set("anio", String(params.anio));
+		const qs = query.toString() ? `?${query}` : "";
+		return this.request<SimulacionInversionistaResult>(
+			`/inversionistas/${inversionistaId}/simulacion${qs}`,
+			{ method: "GET" },
+			true,
+		);
 	}
 }
 

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -3301,6 +3301,15 @@ function RouteComponent() {
 								const meses = sim.desglose_acumulado.meses.filter(
 									(m) => m.mes <= limitKey,
 								);
+
+								if (meses.length === 0) {
+									return (
+										<p className="text-sm text-muted-foreground py-4 text-center">
+											No hay meses proyectados para el período seleccionado.
+										</p>
+									);
+								}
+
 								const ultimoMes = meses.at(-1);
 								const totales = meses.reduce(
 									(acc, m) => ({

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -3267,7 +3267,13 @@ function RouteComponent() {
 									</Select>
 								</div>
 								<Button
-									onClick={() => setProyeccionEnabled(true)}
+									onClick={() => {
+										if (proyeccionEnabled) {
+											simulacionQuery.refetch();
+										} else {
+											setProyeccionEnabled(true);
+										}
+									}}
 									disabled={!proyeccionInvId || simulacionQuery.isFetching}
 								>
 									{simulacionQuery.isFetching ? "Generando..." : "Generar proyección"}
@@ -3282,6 +3288,13 @@ function RouteComponent() {
 
 							{(simulacionQuery.data as SimulacionInversionistaResult | undefined)?.data && (() => {
 								const sim = (simulacionQuery.data as SimulacionInversionistaResult).data;
+								const fmtProyeccion = (v: number) =>
+									new Intl.NumberFormat("es-GT", {
+										style: "currency",
+										currency: sim.moneda === "dolares" ? "USD" : "GTQ",
+										minimumFractionDigits: 2,
+										maximumFractionDigits: 2,
+									}).format(v);
 								const limitKey = proyeccionMes
 									? `${proyeccionAnio}-${String(proyeccionMes).padStart(2, "0")}`
 									: `${proyeccionAnio}-12`;
@@ -3310,7 +3323,7 @@ function RouteComponent() {
 												</CardHeader>
 												<CardContent>
 													<p className="text-xl font-bold font-mono">
-														{formatCurrency(totales.sin_reinversion)}
+														{fmtProyeccion(totales.sin_reinversion)}
 													</p>
 												</CardContent>
 											</Card>
@@ -3322,7 +3335,7 @@ function RouteComponent() {
 												</CardHeader>
 												<CardContent>
 													<p className="text-xl font-bold font-mono text-amber-600">
-														{formatCurrency(totales.reinversion)}
+														{fmtProyeccion(totales.reinversion)}
 													</p>
 												</CardContent>
 											</Card>
@@ -3334,7 +3347,7 @@ function RouteComponent() {
 												</CardHeader>
 												<CardContent>
 													<p className="text-xl font-bold font-mono">
-														{formatCurrency(totales.con_reinversion)}
+														{fmtProyeccion(totales.con_reinversion)}
 													</p>
 												</CardContent>
 											</Card>
@@ -3346,7 +3359,7 @@ function RouteComponent() {
 												</CardHeader>
 												<CardContent>
 													<p className="text-xl font-bold font-mono">
-														{formatCurrency(ultimoMes?.total_capital_restante ?? 0)}
+														{fmtProyeccion(ultimoMes?.total_capital_restante ?? 0)}
 													</p>
 												</CardContent>
 											</Card>
@@ -3380,16 +3393,16 @@ function RouteComponent() {
 																<tr key={m.mes} className="border-b last:border-0 hover:bg-muted/30">
 																	<td className="px-4 py-2 capitalize">{label}</td>
 																	<td className="px-4 py-2 text-right font-mono">
-																		{formatCurrency(m.total_sin_reinversion)}
+																		{fmtProyeccion(m.total_sin_reinversion)}
 																	</td>
 																	<td className="px-4 py-2 text-right font-mono text-amber-600">
-																		{formatCurrency(m.total_reinversion)}
+																		{fmtProyeccion(m.total_reinversion)}
 																	</td>
 																	<td className="px-4 py-2 text-right font-mono">
-																		{formatCurrency(m.total_con_reinversion)}
+																		{fmtProyeccion(m.total_con_reinversion)}
 																	</td>
 																	<td className="px-4 py-2 text-right font-mono">
-																		{formatCurrency(m.total_capital_restante)}
+																		{fmtProyeccion(m.total_capital_restante)}
 																	</td>
 																</tr>
 															);

--- a/apps/crm/apps/web/src/routes/admin/reports/index.tsx
+++ b/apps/crm/apps/web/src/routes/admin/reports/index.tsx
@@ -85,7 +85,36 @@ import {
 	montoACobrarConfig,
 } from "@/lib/reports/scenario-configs";
 import { PERMISSIONS } from "@/lib/roles";
+import { Combobox } from "@/components/ui/combobox";
 import { client, orpc, queryClient } from "@/utils/orpc";
+type SimulacionInversionistaResult = {
+	success: boolean;
+	data: {
+		inversionista_id: number;
+		nombre: string;
+		tipo_reinversion: string | null;
+		moneda: string | null;
+		emite_factura: boolean;
+		monto_reinversion_mensual: number;
+		total_monto_aportado: number;
+		total_capital_actual: number;
+		capital_restante_global: number;
+		desglose_acumulado: {
+			total_creditos: number;
+			total_reinversion: number;
+			total_acumulado: number;
+			meses: Array<{
+				mes: string;
+				total_sin_reinversion: number;
+				total_con_reinversion: number;
+				total_reinversion: number;
+				total_capital_restante: number;
+			}>;
+		};
+	};
+};
+
+type InversionistaItem = { inversionista_id: number; nombre: string };
 
 export const Route = createFileRoute("/admin/reports/")({
 	component: RouteComponent,
@@ -511,6 +540,13 @@ function RouteComponent() {
 		getDefaultRangeForPeriodo("mes"),
 	);
 
+	const [proyeccionInvId, setProyeccionInvId] = useState<number | null>(null);
+	const [proyeccionAnio, setProyeccionAnio] = useState<number>(
+		new Date().getFullYear(),
+	);
+	const [proyeccionMes, setProyeccionMes] = useState<number | null>(null);
+	const [proyeccionEnabled, setProyeccionEnabled] = useState(false);
+
 	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
 	const userRole = userProfile.data?.role;
 	const isAdmin = userRole ? PERMISSIONS.canAccessAdmin(userRole) : false;
@@ -583,6 +619,21 @@ function RouteComponent() {
 	const reinversionData = reinversionLiquidacionesQuery.data as
 		| ReinversionLiquidacionesResponse
 		| undefined;
+
+	const investorsCarteraQuery = useQuery({
+		...orpc.getInvestorsCartera.queryOptions({ input: {} }),
+		enabled: isAdmin,
+		staleTime: 1000 * 60 * 10,
+	});
+
+	const simulacionQuery = useQuery({
+		...orpc.getSimulacionInversionista.queryOptions({
+			input: { inversionistaId: proyeccionInvId ?? 0, anio: proyeccionAnio },
+		}),
+		enabled: isAdmin && proyeccionEnabled && proyeccionInvId !== null,
+		staleTime: 1000 * 60 * 10,
+		placeholderData: undefined,
+	});
 
 	const comparativoQuery = useQuery({
 		...orpc.getComparativoHistorico.queryOptions({
@@ -1016,6 +1067,9 @@ function RouteComponent() {
 							<TabsTrigger value="cobranza">Cobranza</TabsTrigger>
 							<TabsTrigger value="inversiones">Inversiones</TabsTrigger>
 							<TabsTrigger value="colocacion">Colocación</TabsTrigger>
+							<TabsTrigger value="proyeccion-liquidaciones">
+								Proyección Liquidaciones
+							</TabsTrigger>
 						</TabsList>
 						{canAccessClosedCreditsReport && (
 							<TabsContent value="creditos" className="space-y-6">
@@ -3139,6 +3193,214 @@ function RouteComponent() {
 										})()}
 								</CardContent>
 							</Card>
+						</TabsContent>
+
+						{/* ── PROYECCIÓN LIQUIDACIONES ── */}
+						<TabsContent value="proyeccion-liquidaciones" className="space-y-6">
+							<div className="flex flex-wrap items-end gap-3">
+								<div className="flex flex-col gap-1">
+									<label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+										Inversionista
+									</label>
+									<Combobox
+										width="288px"
+										placeholder="Buscar inversionista..."
+										value={proyeccionInvId ? String(proyeccionInvId) : null}
+										options={((investorsCarteraQuery.data ?? []) as InversionistaItem[]).map(
+											(inv) => ({
+												value: String(inv.inversionista_id),
+												label: inv.nombre,
+											}),
+										)}
+										onChange={(v) => {
+											setProyeccionInvId(v ? Number(v) : null);
+											setProyeccionEnabled(false);
+										}}
+										isLoading={investorsCarteraQuery.isPending}
+									/>
+								</div>
+								<div className="flex flex-col gap-1">
+									<label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+										Hasta mes
+									</label>
+									<Select
+										value={proyeccionMes ? String(proyeccionMes) : "todos"}
+										onValueChange={(v) => {
+											setProyeccionMes(v === "todos" ? null : Number(v));
+											setProyeccionEnabled(false);
+										}}
+									>
+										<SelectTrigger className="w-36">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											<SelectItem value="todos">Todos los meses</SelectItem>
+											{MESES.map((label, i) => (
+												<SelectItem key={label} value={String(i + 1)}>
+													{label}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<div className="flex flex-col gap-1">
+									<label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+										Año
+									</label>
+									<Select
+										value={String(proyeccionAnio)}
+										onValueChange={(v) => {
+											setProyeccionAnio(Number(v));
+											setProyeccionEnabled(false);
+										}}
+									>
+										<SelectTrigger className="w-28">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{Array.from({ length: 7 }, (_, i) => new Date().getFullYear() - 1 + i).map((y) => (
+												<SelectItem key={y} value={String(y)}>
+													{y}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+								<Button
+									onClick={() => setProyeccionEnabled(true)}
+									disabled={!proyeccionInvId || simulacionQuery.isFetching}
+								>
+									{simulacionQuery.isFetching ? "Generando..." : "Generar proyección"}
+								</Button>
+							</div>
+
+							{simulacionQuery.isError && (
+								<p className="text-sm text-destructive">
+									Error al cargar la proyección. Intenta de nuevo.
+								</p>
+							)}
+
+							{(simulacionQuery.data as SimulacionInversionistaResult | undefined)?.data && (() => {
+								const sim = (simulacionQuery.data as SimulacionInversionistaResult).data;
+								const limitKey = proyeccionMes
+									? `${proyeccionAnio}-${String(proyeccionMes).padStart(2, "0")}`
+									: `${proyeccionAnio}-12`;
+								const meses = sim.desglose_acumulado.meses.filter(
+									(m) => m.mes <= limitKey,
+								);
+								const ultimoMes = meses.at(-1);
+								const totales = meses.reduce(
+									(acc, m) => ({
+										sin_reinversion: acc.sin_reinversion + Number(m.total_sin_reinversion),
+										con_reinversion: acc.con_reinversion + Number(m.total_con_reinversion),
+										reinversion: acc.reinversion + Number(m.total_reinversion),
+									}),
+									{ sin_reinversion: 0, con_reinversion: 0, reinversion: 0 },
+								);
+
+								return (
+									<div className="space-y-6">
+										{/* Tarjetas resumen */}
+										<div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+											<Card>
+												<CardHeader className="pb-2">
+													<CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+														Cuota Sin Reinversión
+													</CardTitle>
+												</CardHeader>
+												<CardContent>
+													<p className="text-xl font-bold font-mono">
+														{formatCurrency(totales.sin_reinversion)}
+													</p>
+												</CardContent>
+											</Card>
+											<Card>
+												<CardHeader className="pb-2">
+													<CardTitle className="text-xs font-medium text-amber-600 uppercase tracking-wide">
+														Reinversión
+													</CardTitle>
+												</CardHeader>
+												<CardContent>
+													<p className="text-xl font-bold font-mono text-amber-600">
+														{formatCurrency(totales.reinversion)}
+													</p>
+												</CardContent>
+											</Card>
+											<Card>
+												<CardHeader className="pb-2">
+													<CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+														Cuota Con Reinversión
+													</CardTitle>
+												</CardHeader>
+												<CardContent>
+													<p className="text-xl font-bold font-mono">
+														{formatCurrency(totales.con_reinversion)}
+													</p>
+												</CardContent>
+											</Card>
+											<Card>
+												<CardHeader className="pb-2">
+													<CardTitle className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+														Capital Restante
+													</CardTitle>
+												</CardHeader>
+												<CardContent>
+													<p className="text-xl font-bold font-mono">
+														{formatCurrency(ultimoMes?.total_capital_restante ?? 0)}
+													</p>
+												</CardContent>
+											</Card>
+										</div>
+
+										{/* Tabla por mes */}
+										<Card>
+											<CardHeader>
+												<CardTitle className="text-sm">Desglose mensual</CardTitle>
+											</CardHeader>
+											<CardContent className="p-0">
+												<table className="w-full text-sm">
+													<thead>
+														<tr className="border-b bg-muted/50 text-xs text-muted-foreground uppercase tracking-wide">
+															<th className="px-4 py-2 text-left">Mes</th>
+															<th className="px-4 py-2 text-right">Sin reinversión</th>
+															<th className="px-4 py-2 text-right text-amber-600">Reinversión</th>
+															<th className="px-4 py-2 text-right">Con reinversión</th>
+															<th className="px-4 py-2 text-right">Capital restante</th>
+														</tr>
+													</thead>
+													<tbody>
+														{meses.map((m) => {
+															const fecha = new Date(`${m.mes}-01T00:00:00Z`);
+															const label = fecha.toLocaleDateString("es-GT", {
+																month: "long",
+																year: "numeric",
+																timeZone: "UTC",
+															});
+															return (
+																<tr key={m.mes} className="border-b last:border-0 hover:bg-muted/30">
+																	<td className="px-4 py-2 capitalize">{label}</td>
+																	<td className="px-4 py-2 text-right font-mono">
+																		{formatCurrency(m.total_sin_reinversion)}
+																	</td>
+																	<td className="px-4 py-2 text-right font-mono text-amber-600">
+																		{formatCurrency(m.total_reinversion)}
+																	</td>
+																	<td className="px-4 py-2 text-right font-mono">
+																		{formatCurrency(m.total_con_reinversion)}
+																	</td>
+																	<td className="px-4 py-2 text-right font-mono">
+																		{formatCurrency(m.total_capital_restante)}
+																	</td>
+																</tr>
+															);
+														})}
+													</tbody>
+												</table>
+											</CardContent>
+										</Card>
+									</div>
+								);
+							})()}
 						</TabsContent>
 					</Tabs>
 				</>

--- a/apps/crm/apps/web/src/utils/orpc.ts
+++ b/apps/crm/apps/web/src/utils/orpc.ts
@@ -9,6 +9,7 @@ import type {
 	AppRouter,
 	disbursementRouter,
 	manualVehicleRouter,
+	proyeccionRouter,
 } from "../../../server/src/routers/index";
 
 type InvestmentsRouter =
@@ -76,7 +77,8 @@ export const link = new RPCLink({
 type MergedRouter = AppRouter &
 	typeof manualVehicleRouter &
 	InvestmentsRouter &
-	typeof disbursementRouter;
+	typeof disbursementRouter &
+	typeof proyeccionRouter;
 
 export const client: RouterClient<MergedRouter> = createORPCClient(link);
 


### PR DESCRIPTION
## Resumen

Agrega una nueva pestaña **"Proyección Liquidaciones"** en el Dashboard Ejecutivo del CRM (`/admin/reports`), que consume el mismo endpoint de cartera-back (`GET /inversionistas/:id/simulacion`) que ya utiliza carteraFront, pero mostrando únicamente totales — sin desglose por crédito — con el estilo visual del CRM.

---

## Cambios por capa

### `apps/crm/apps/server/src/services/cartera-back-client.ts`
- Agrega interfaz exportada `SimulacionInversionistaResult` con la forma completa de la respuesta del endpoint.
- Agrega método `getSimulacionInversionista(inversionistaId, { mes?, anio? })` que llama a `GET /inversionistas/:id/simulacion` con autenticación y caché de 5 min.
- **Fix review**: checks de `params.mes` / `params.anio` cambiados de falsy (`if (params?.x)`) a `!== undefined` para evitar que valores `0` se silencien.

### `apps/crm/apps/server/src/routers/investor-documents.ts`
- Agrega procedure `getInvestorsCartera` — lista de inversionistas desde cartera-back para el selector del CRM. Retorna `result.data ?? []` con null-guard.
- Agrega procedure `getSimulacionInversionista` con validación Zod: `inversionistaId` (positive int), `mes` (1–12), `anio` (int, min 1900 max 2100).
- **Fix review**: `anio` tenía `.int().optional()` sin bounds — ahora tiene `.min(1900).max(2100)`.

### `apps/crm/apps/server/src/routers/index.ts`
- Incluye `getInvestorsCartera` y `getSimulacionInversionista` en `reportsAppRouter` (runtime).
- Exporta `proyeccionRouter` separado con los mismos dos procedures — necesario para evitar el error TS7056 ("type exceeds maximum length") que trunca `AppRouter` al hacer declaration emit.

### `apps/crm/apps/web/src/utils/orpc.ts`
- Importa `proyeccionRouter` y lo agrega al tipo `MergedRouter` para que el cliente ORPC en el web tenga acceso tipado a los dos nuevos procedures sin que TS truncue el tipo.

### `apps/crm/apps/web/src/routes/admin/reports/index.tsx`
- Agrega tipo inline `SimulacionInversionistaResult` e `InversionistaItem` (import directo del server falla por resolución de módulos en el web).
- Agrega estados: `proyeccionInvId`, `proyeccionAnio`, `proyeccionMes`, `proyeccionEnabled`.
- Agrega query `investorsCarteraQuery` (staleTime 10 min) para poblar el selector.
- Agrega query `simulacionQuery` con `enabled: isAdmin && proyeccionEnabled && proyeccionInvId !== null`, `staleTime: 10 min`, `placeholderData: undefined` para evitar datos stale de inversionista anterior.
- Agrega `TabsTrigger` y `TabsContent` para la pestaña "Proyección Liquidaciones":
  - **Selector de inversionista**: usa `Combobox` (componente existente con búsqueda por texto).
  - **Selector de mes**: "Todos los meses" o mes específico (1–12).
  - **Selector de año**: año actual ± rango, misma lógica que otros tabs.
  - **Botón "Generar proyección"**: activa la query; deshabilitado si no hay inversionista seleccionado.
  - **4 tarjetas de resumen** (nombres idénticos a carteraFront): Cuota Sin Reinversión, Reinversión, Cuota Con Reinversión, Capital Restante (último mes filtrado).
  - **Tabla mensual**: columnas mes / sin reinversión / reinversión / con reinversión / capital restante, con filas filtradas hasta el mes/año seleccionado.

---

## Comportamiento del filtro de meses

Igual que carteraFront:
- Si se selecciona "Todos los meses" → corta en diciembre del año seleccionado (`${anio}-12`).
- Si se selecciona un mes específico → corta en ese mes (`${anio}-MM`).
- Capital Restante siempre muestra el del **último mes filtrado**.

---

## Fixes de code review aplicados

| # | Problema | Fix |
|---|----------|-----|
| 1/3 | `if (params?.mes)` / `if (params?.anio)` silencia valores `0` | Cambiado a `!== undefined` |
| 2 | Zod `anio` sin bounds — acepta años negativos/extremos | Agregado `.min(1900).max(2100)` |
| 5 | `simulacionQuery.data` stale al cambiar inversionista/año | `placeholderData: undefined` |
| 6 | `simulacionQuery` sin `staleTime` — refetch en window focus | `staleTime: 1000 * 60 * 10` |
| 8 | `getInvestorsCartera` sin null-guard — crash si cartera-back responde mal | `result.data ?? []` |

## Plan de prueba

- [ ] Abrir Dashboard Ejecutivo CRM → pestaña "Proyección Liquidaciones" visible
- [ ] Escribir nombre en el selector de inversionista → búsqueda funciona
- [ ] Seleccionar inversionista → botón "Generar proyección" se habilita
- [ ] Generar proyección → 4 tarjetas y tabla mensual se muestran con datos correctos
- [ ] Cambiar año → datos filtran correctamente al diciembre del año seleccionado
- [ ] Seleccionar mes específico → datos cortan en ese mes, Capital Restante = último mes
- [ ] Cambiar inversionista → no muestra datos del anterior (placeholderData: undefined)
- [ ] `bun check-types` → 0 errores nuevos en archivos tocados

🤖 Generated with [Claude Code](https://claude.com/claude-code)