### PR TITLE
feat(cartera): soporte excedente/variable en reinversión combinada (end-to-end)

### DIFF
--- a/.github/workflows/notify-prod-pr-email.yml
+++ b/.github/workflows/notify-prod-pr-email.yml
@@ -82,30 +82,16 @@ jobs:
                   lines.append('- … %d commits más (ver el PR)' % (len(commits) - 30))
               return '\n'.join(lines)
 
-          # Marcadores de la plantilla pase-a-produccion.md. Si alguno sigue presente,
-          # el autor abrió el PR con la plantilla pero NO la completó.
-          TEMPLATE_PLACEHOLDERS = [
-              '[breve descripción de las áreas tocadas]',
-              '[Área / Módulo]',
-              '[Otra área]',
-              '[Qué cambió, en una línea]',
-          ]
-
           def strip_comments(b):
-              # quita los comentarios guía <!-- ... --> de la plantilla
+              # quita sólo los comentarios guía <!-- ... --> de la plantilla,
+              # para que no se cuelen en el correo. Nada más se toca del body.
               return re.sub(r'<!--.*?-->', '', b, flags=re.DOTALL).strip()
 
-          def is_unfilled_template(b):
-              cleaned = strip_comments(b)
-              return any(ph in cleaned for ph in TEMPLATE_PLACEHOLDERS)
-
-          # El correo usa la descripción del PR tal cual; cae al resumen de commits
-          # si está vacía o si es la plantilla sin completar.
-          if body and is_unfilled_template(body):
-              summary_md = fallback_summary()
-              source_label = 'automáticamente desde los commits (la plantilla del PR quedó sin completar)'
-          elif body:
-              summary_md = strip_comments(body)
+          # Mostramos SIEMPRE la descripción del PR tal cual. Sólo si el PR viene
+          # sin descripción armamos un resumen mínimo desde los commits.
+          body_clean = strip_comments(body)
+          if body_clean:
+              summary_md = body_clean
               source_label = 'a partir de la descripción del PR'
           else:
               summary_md = fallback_summary()

--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -641,9 +641,12 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
           X !== "reinversion_combinada" && X !== Y;
 
         if (debeEscalar) {
-          // ── Backfill: si X era "variable", usamos Y; sino, X ──
-          const valorBackfill =
-            X === "reinversion_variable" ? Y : X;
+          // ── Backfill: preservar SIEMPRE la modalidad previa (X) del
+          //    inversionista. variable/excedente ya son modalidades válidas
+          //    por-crédito dentro de una combinada, así que estampar los
+          //    créditos existentes con la modalidad nueva (Y) les cambiaría el
+          //    cálculo de reinversión. ──
+          const valorBackfill = X;
 
           // ── Global del inversionista → combinada ──
           await tx

--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -71,6 +71,11 @@ const addInvestorToCreditSchema = z.object({
       "reinversion_capital",
       "reinversion_interes",
       "reinversion_total",
+      // Modalidades que solo aplican cuando el inversionista es combinada: el
+      // sobrante del excedente / el monto del variable se reinvierten en un
+      // crédito nuevo con esa misma modalidad.
+      "reinversion_excedente",
+      "reinversion_variable",
     ])
     .optional(),
   // Se sigue aceptando por compatibilidad, pero YA NO se usa para actualizar

--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -598,6 +598,47 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
     let montoRestante = new Big(monto_aportado);
 
     // ================================================================
+    // GUARD: exclusividad excedente/variable (solo compra_cartera).
+    // La escalada a combinada backfillea los créditos existentes con la
+    // modalidad previa (X) e inserta los nuevos con la solicitada (Y). Si X y Y
+    // son las dos modalidades de monto fijo opuestas, quedaría un inversionista
+    // combinada con excedente Y variable a la vez, y getInvestorTotalsGlobales
+    // aplicaría el monto_reinversion único a ambos pools con sentidos opuestos.
+    // Se rechaza antes de tocar nada (misma regla que el modal y /asignar-reinversion).
+    // ================================================================
+    if (tipo_operacion === "compra_cartera" && tipo_reinversion) {
+      const [invActual] = await db
+        .select({ tipo_reinversion: inversionistas.tipo_reinversion })
+        .from(inversionistas)
+        .where(eq(inversionistas.inversionista_id, inversionista_id));
+      const X = invActual?.tipo_reinversion ?? null;
+      const Y = tipo_reinversion;
+      const debeEscalar = X !== "reinversion_combinada" && X !== Y;
+
+      const espejosExistentes = await db
+        .select({ tipo_reinversion: creditos_inversionistas_espejo.tipo_reinversion })
+        .from(creditos_inversionistas_espejo)
+        .where(eq(creditos_inversionistas_espejo.inversionista_id, inversionista_id));
+
+      // Modalidades por-crédito resultantes: existentes (NULL→backfill si escala)
+      // + la de los créditos nuevos (Y).
+      const modalidadesFinales = new Set<string | null>();
+      for (const e of espejosExistentes) {
+        modalidadesFinales.add(e.tipo_reinversion === null && debeEscalar ? X : e.tipo_reinversion);
+      }
+      modalidadesFinales.add(Y);
+
+      if (modalidadesFinales.has("reinversion_excedente") && modalidadesFinales.has("reinversion_variable")) {
+        set.status = 409;
+        return {
+          success: false,
+          message:
+            "No se puede mezclar Excedente y Variable en el mismo inversionista: el monto de reinversión es único (una modalidad recibe un monto fijo y la otra reinvierte un monto fijo).",
+        };
+      }
+    }
+
+    // ================================================================
     // PASO 3: ITERAR CRÉDITOS Y DISTRIBUIR MONTO
     // Todo dentro de una transacción para que si algo falla,
     // se haga rollback de TODOS los cambios.

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -174,6 +174,14 @@ async function consultarPagosInversionista(
       abono_capital: tabla.abono_capital,
       abono_interes: tabla.abono_interes,
       abono_iva_12: tabla.abono_iva_12,
+      // Desglose del interés cuando hubo compras en el mes (interés "partido").
+      // Solo existe en la tabla espejo; para original devolvemos null.
+      abono_interes_sin_compras: config.origen === "espejo"
+        ? (tabla as any).abono_interes_sin_compras
+        : sql<string | null>`null`,
+      abono_interes_con_compras: config.origen === "espejo"
+        ? (tabla as any).abono_interes_con_compras
+        : sql<string | null>`null`,
       fecha_pago: tabla.fecha_pago,
       porcentaje_participacion: tabla.porcentaje_participacion,
       abonoGeneralInteres: pagos_credito.abono_interes,
@@ -1377,6 +1385,10 @@ export async function resumeInvestor(
         total_reinv_tipo_capital: new Big(0),
         total_reinv_tipo_interes: new Big(0),
         total_reinv_tipo_total: new Big(0),
+        // Pools para combinada: cuota completa de los créditos que dentro de una
+        // combinada son excedente/variable (el ajuste global se aplica después).
+        total_cuota_excedente_combinada: new Big(0),
+        total_cuota_variable_combinada: new Big(0),
       };
 
       const formatValue = (val: string | number | null | undefined) =>
@@ -1494,7 +1506,7 @@ export async function resumeInvestor(
               const abono_interes = new Big(pago.abono_interes ?? 0);
               const abono_iva = new Big(pago.abono_iva_12 ?? 0);
               const isr = abono_interes.times(0.07);
-              const cuota = pago.cuota ?? 0;
+              const cuota = pago.cuota ?? 1;
               let cuota_inversor;
               let abonoGeneralInteres;
               let reinvCapital = new Big((pago as any).reinv_capital ?? 0);
@@ -1627,6 +1639,11 @@ export async function resumeInvestor(
                 abono_capital_detalle: (pago as any).abono_capital_id
                   ? abonosMap.get((pago as any).abono_capital_id) ?? null
                   : null,
+                // Interés "partido": hubo compras en el mes y el interés se
+                // calculó en dos partes (sin_compras + con_compras).
+                interes_partido:
+                  (pago as any).abono_interes_sin_compras != null ||
+                  (pago as any).abono_interes_con_compras != null,
               };
             });
 
@@ -1657,6 +1674,16 @@ export async function resumeInvestor(
           subtotal.total_reinv_tipo_capital = subtotal.total_reinv_tipo_capital.plus(total_reinv_tipo_capital);
           subtotal.total_reinv_tipo_interes = subtotal.total_reinv_tipo_interes.plus(total_reinv_tipo_interes);
           subtotal.total_reinv_tipo_total = subtotal.total_reinv_tipo_total.plus(total_reinv_tipo_total);
+
+          // Combinada: acumular la cuota completa de este crédito en su pool si es
+          // excedente/variable (su tipo es constante en todos sus pagos).
+          if (inv.reinversion === "reinversion_combinada") {
+            if (c.tipo_reinversion === "reinversion_excedente") {
+              subtotal.total_cuota_excedente_combinada = subtotal.total_cuota_excedente_combinada.plus(total_cuota);
+            } else if (c.tipo_reinversion === "reinversion_variable") {
+              subtotal.total_cuota_variable_combinada = subtotal.total_cuota_variable_combinada.plus(total_cuota);
+            }
+          }
 
           return {
             credito_id: c.credito_id,
@@ -1710,6 +1737,31 @@ export async function resumeInvestor(
         const recibe = montoRecibe.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoRecibe;
         subtotal.total_reinversion = subtotal.total_cuota.minus(recibe);
         subtotal.total_cuota = recibe;
+      }
+
+      // Combinada: aplicar excedente/variable sobre el pool de cada modalidad, con el
+      // mismo monto_reinversion. Es lo mismo que el crudo, solo que sumando únicamente
+      // los créditos que están en esa modalidad. La salida usa total_reinversion
+      // (total_cuota_con_reinversion = sin_reinversion − reinversion).
+      if (inv.reinversion === "reinversion_combinada") {
+        const monto = new Big(inv.monto_reinversion ?? 0);
+
+        // Excedente: el monto es lo que RECIBE del pool; el sobrante se reinvierte.
+        const poolExcedente = subtotal.total_cuota_excedente_combinada;
+        if (poolExcedente.gt(0)) {
+          const recibe = monto.gt(poolExcedente) ? poolExcedente : monto;
+          const sobrante = poolExcedente.minus(recibe);
+          subtotal.total_cuota = subtotal.total_cuota.minus(sobrante);
+          subtotal.total_reinversion = subtotal.total_reinversion.plus(sobrante);
+        }
+
+        // Variable: el monto es lo que se REINVIERTE del pool.
+        const poolVariable = subtotal.total_cuota_variable_combinada;
+        if (poolVariable.gt(0)) {
+          const reinv = monto.gt(poolVariable) ? poolVariable : monto;
+          subtotal.total_cuota = subtotal.total_cuota.minus(reinv);
+          subtotal.total_reinversion = subtotal.total_reinversion.plus(reinv);
+        }
       }
 
       // 🔹 Retornar estructura del inversionista
@@ -1954,6 +2006,16 @@ export async function getInvestorTotalsGlobales(
     total_reinv_tipo_capital: new Big(0),
     total_reinv_tipo_interes: new Big(0),
     total_reinv_tipo_total: new Big(0),
+    // Montos reinvertidos por excedente/variable dentro de una combinada (el
+    // sobrante del excedente y lo reinvertido del variable). Se despliegan como
+    // créditos nuevos con esa misma modalidad en la liquidación.
+    total_reinv_tipo_excedente: new Big(0),
+    total_reinv_tipo_variable: new Big(0),
+    // Pools para combinada: suma de la cuota completa de los créditos que dentro
+    // de una combinada son excedente/variable. El ajuste global (usando el
+    // monto_reinversion del inversionista) se aplica después del loop.
+    total_cuota_excedente_combinada: new Big(0),
+    total_cuota_variable_combinada: new Big(0),
   };
 
   // 7. Procesar TODOS los créditos del inversionista (sin queries adicionales)
@@ -2061,6 +2123,17 @@ export async function getInvestorTotalsGlobales(
       } else if (reinversionActual === "reinversion_total") {
         subtotal.total_reinv_tipo_total = subtotal.total_reinv_tipo_total.plus(montoReinvNetoPago);
       }
+
+      // Combinada: acumular la cuota completa de los créditos excedente/variable
+      // en su pool. Per-pago se calcularon como completos (cuota_inversor); el
+      // ajuste con monto_reinversion se hace después del loop.
+      if (inv.reinversion === "reinversion_combinada") {
+        if (reinversionActual === "reinversion_excedente") {
+          subtotal.total_cuota_excedente_combinada = subtotal.total_cuota_excedente_combinada.plus(cuota_inversor);
+        } else if (reinversionActual === "reinversion_variable") {
+          subtotal.total_cuota_variable_combinada = subtotal.total_cuota_variable_combinada.plus(cuota_inversor);
+        }
+      }
     }
 
     subtotal.total_monto_aportado = subtotal.total_monto_aportado.plus(new Big(c.monto_aportado ?? 0));
@@ -2082,6 +2155,32 @@ export async function getInvestorTotalsGlobales(
     const recibe = montoRecibe.gt(subtotal.total_cuota) ? subtotal.total_cuota : montoRecibe;
     subtotal.total_reinversion = subtotal.total_cuota.minus(recibe);
     subtotal.total_cuota = recibe;
+  }
+
+  // Combinada: aplicar excedente/variable sobre el pool de cada modalidad, con el
+  // mismo monto_reinversion del inversionista. Es lo mismo que el crudo, solo que
+  // sumando únicamente los créditos que están en esa modalidad.
+  if (inv.reinversion === "reinversion_combinada") {
+    const monto = new Big(inv.monto_reinversion ?? 0);
+
+    // Excedente: el monto es lo que RECIBE del pool; el sobrante se reinvierte.
+    const poolExcedente = subtotal.total_cuota_excedente_combinada;
+    if (poolExcedente.gt(0)) {
+      const recibe = monto.gt(poolExcedente) ? poolExcedente : monto;
+      const sobrante = poolExcedente.minus(recibe);
+      subtotal.total_cuota = subtotal.total_cuota.minus(sobrante);
+      subtotal.total_reinversion = subtotal.total_reinversion.plus(sobrante);
+      subtotal.total_reinv_tipo_excedente = sobrante;
+    }
+
+    // Variable: el monto es lo que se REINVIERTE del pool.
+    const poolVariable = subtotal.total_cuota_variable_combinada;
+    if (poolVariable.gt(0)) {
+      const reinv = monto.gt(poolVariable) ? poolVariable : monto;
+      subtotal.total_cuota = subtotal.total_cuota.minus(reinv);
+      subtotal.total_reinversion = subtotal.total_reinversion.plus(reinv);
+      subtotal.total_reinv_tipo_variable = reinv;
+    }
   }
 
   // 7. Upsert en reinversiones
@@ -2137,6 +2236,8 @@ export async function getInvestorTotalsGlobales(
       total_reinv_tipo_capital: formatValue(subtotal.total_reinv_tipo_capital.round(2).toString()),
       total_reinv_tipo_interes: formatValue(subtotal.total_reinv_tipo_interes.round(2).toString()),
       total_reinv_tipo_total: formatValue(subtotal.total_reinv_tipo_total.round(2).toString()),
+      total_reinv_tipo_excedente: formatValue(subtotal.total_reinv_tipo_excedente.round(2).toString()),
+      total_reinv_tipo_variable: formatValue(subtotal.total_reinv_tipo_variable.round(2).toString()),
     },
   };
 }
@@ -3353,6 +3454,10 @@ export async function getInvestorMirrorSummary(
     total_reinversion_interes: new Big(0),
     total_reinversion:         new Big(0),
     total_cuota_sin_reinversion: new Big(0),
+    // Pools para combinada (ver getInvestorTotalsGlobales): cuota completa de los
+    // créditos que dentro de una combinada son excedente/variable.
+    total_cuota_excedente_combinada: new Big(0),
+    total_cuota_variable_combinada: new Big(0),
   };
 
   for (const credito of creditosEspejo) {
@@ -3436,6 +3541,16 @@ export async function getInvestorMirrorSummary(
       sg.total_reinversion         = sg.total_reinversion.plus(netReinvMirror);
       sg.total_reinversion_capital = sg.total_reinversion_capital.plus(reinvCapital);
       sg.total_reinversion_interes = sg.total_reinversion_interes.plus(netReinvIntMirror);
+
+      // Combinada: acumular la cuota completa de los créditos excedente/variable
+      // en su pool; el ajuste con monto_reinversion se hace después del loop.
+      if (inv.reinversion === "reinversion_combinada") {
+        if (reinversionActual === "reinversion_excedente") {
+          sg.total_cuota_excedente_combinada = sg.total_cuota_excedente_combinada.plus(cuota_inversor);
+        } else if (reinversionActual === "reinversion_variable") {
+          sg.total_cuota_variable_combinada = sg.total_cuota_variable_combinada.plus(cuota_inversor);
+        }
+      }
     }
 
     // 🔑 Saldo actual = monto_aportado_base - SUM(abono_capital de pagos espejo)
@@ -3458,6 +3573,30 @@ export async function getInvestorMirrorSummary(
     const recibe = montoRecibe.gt(sg.total_cuota) ? sg.total_cuota : montoRecibe;
     sg.total_reinversion = sg.total_cuota.minus(recibe);
     sg.total_cuota = recibe;
+  }
+
+  // Combinada: aplicar excedente/variable sobre el pool de cada modalidad, con el
+  // mismo monto_reinversion. Es lo mismo que el crudo, solo que sumando únicamente
+  // los créditos que están en esa modalidad.
+  if (inv.reinversion === "reinversion_combinada") {
+    const monto = new Big(inv.monto_reinversion ?? 0);
+
+    // Excedente: el monto es lo que RECIBE del pool; el sobrante se reinvierte.
+    const poolExcedente = sg.total_cuota_excedente_combinada;
+    if (poolExcedente.gt(0)) {
+      const recibe = monto.gt(poolExcedente) ? poolExcedente : monto;
+      const sobrante = poolExcedente.minus(recibe);
+      sg.total_cuota = sg.total_cuota.minus(sobrante);
+      sg.total_reinversion = sg.total_reinversion.plus(sobrante);
+    }
+
+    // Variable: el monto es lo que se REINVIERTE del pool.
+    const poolVariable = sg.total_cuota_variable_combinada;
+    if (poolVariable.gt(0)) {
+      const reinv = monto.gt(poolVariable) ? poolVariable : monto;
+      sg.total_cuota = sg.total_cuota.minus(reinv);
+      sg.total_reinversion = sg.total_reinversion.plus(reinv);
+    }
   }
 
   // ── PASO 5: Retornar datos del inversionista + subtotales globales ─────────
@@ -4034,19 +4173,30 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
             console.log(`  📊 Moda porcentaje inversión: ${modaInversion}%, cash in: ${modaCashIn}%`);
 
             // Cuando la modalidad global es combinada, cada crédito reinvierte bajo su
-            // propia modalidad y el monto se reparte en hasta 3 llamadas (capital /
-            // interés / total). Si una llamada no encuentra candidatos compatibles,
-            // se aborta el resto (las anteriores ya quedaron committed).
-            type Modalidad = "reinversion_capital" | "reinversion_interes" | "reinversion_total";
+            // propia modalidad y el monto se reparte en hasta 5 llamadas (capital /
+            // interés / total / excedente / variable). El sobrante del excedente y el
+            // monto del variable van a créditos nuevos con esa misma modalidad. Si una
+            // llamada no encuentra candidatos compatibles, se aborta el resto (las
+            // anteriores ya quedaron committed).
+            type Modalidad =
+              | "reinversion_capital"
+              | "reinversion_interes"
+              | "reinversion_total"
+              | "reinversion_excedente"
+              | "reinversion_variable";
             const llamadasReinversion: { monto: number; tipo_reinversion?: Modalidad; etiqueta: string }[] = [];
 
             if (totalesResult.reinversion === "reinversion_combinada") {
               const montoCapital = Number(totales.total_reinv_tipo_capital ?? 0);
               const montoInteres = Number(totales.total_reinv_tipo_interes ?? 0);
               const montoTotal = Number(totales.total_reinv_tipo_total ?? 0);
+              const montoExcedente = Number(totales.total_reinv_tipo_excedente ?? 0);
+              const montoVariable = Number(totales.total_reinv_tipo_variable ?? 0);
               if (montoCapital > 0) llamadasReinversion.push({ monto: montoCapital, tipo_reinversion: "reinversion_capital", etiqueta: "capital" });
               if (montoInteres > 0) llamadasReinversion.push({ monto: montoInteres, tipo_reinversion: "reinversion_interes", etiqueta: "interés" });
               if (montoTotal > 0) llamadasReinversion.push({ monto: montoTotal, tipo_reinversion: "reinversion_total", etiqueta: "total" });
+              if (montoExcedente > 0) llamadasReinversion.push({ monto: montoExcedente, tipo_reinversion: "reinversion_excedente", etiqueta: "excedente" });
+              if (montoVariable > 0) llamadasReinversion.push({ monto: montoVariable, tipo_reinversion: "reinversion_variable", etiqueta: "variable" });
               console.log(`  📊 Modalidad combinada → ${llamadasReinversion.length} reinversión(es): ${llamadasReinversion.map(l => `${l.etiqueta}=Q${l.monto.toFixed(2)}`).join(", ")}`);
             } else {
               llamadasReinversion.push({ monto: Number(liquidacion.reinversion_total ?? 0), etiqueta: "global" });

--- a/apps/cartera-back/src/controllers/mirrorInvestor.ts
+++ b/apps/cartera-back/src/controllers/mirrorInvestor.ts
@@ -672,6 +672,21 @@ export const asignarReinversionEspejo = async ({ body, set }: any) => {
       return { success: false, message: "Falta el inversionista_id" };
     }
 
+    // No permitir mezclar Excedente y Variable en el mismo inversionista: el
+    // monto_reinversion es único y significaría dos cosas opuestas a la vez
+    // (recibir un monto fijo vs reinvertir un monto fijo). Los créditos que no
+    // vienen en el payload quedan sin_reinversion, así que basta revisar los
+    // enviados. Se valida acá además del modal para cubrir callers directos/bulk.
+    const tieneExcedente = Array.isArray(asignaciones) && asignaciones.some((a: any) => a.tipo_reinversion === "reinversion_excedente");
+    const tieneVariable = Array.isArray(asignaciones) && asignaciones.some((a: any) => a.tipo_reinversion === "reinversion_variable");
+    if (tieneExcedente && tieneVariable) {
+      set.status = 400;
+      return {
+        success: false,
+        message: "No se puede mezclar Excedente y Variable en el mismo inversionista. El monto de reinversión es único; usá solo una de las dos modalidades.",
+      };
+    }
+
     const resultados: any[] = [];
     const omitidos: any[] = [];
     let idsActuales: number[] = [];

--- a/apps/cartera-back/src/routers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/routers/addInvestorToCredit.ts
@@ -24,6 +24,10 @@ export const addInvestorToCreditRouter = new Elysia()
           t.Literal("reinversion_capital"),
           t.Literal("reinversion_total"),
           t.Literal("sin_reinversion"),
+          // En sync con el enum del controller: excedente/variable se despliegan
+          // como créditos nuevos con esa modalidad al reinvertir en combinada.
+          t.Literal("reinversion_excedente"),
+          t.Literal("reinversion_variable"),
         ]),
       ),
       fecha_inicio_participacion: t.Optional(t.String()),

--- a/apps/cartera-back/src/routers/investor.ts
+++ b/apps/cartera-back/src/routers/investor.ts
@@ -642,6 +642,18 @@ export const inversionistasRouter = new Elysia()
 
     const inversionista = result.inversionistas[0];
 
+    // El reporte PDF (generarHTMLReporte) NO agrupa las modalidades excedente/
+    // variable de una reinversión combinada, así que dejaría esos créditos fuera
+    // del reporte. Está deprecado (el reporte vigente es el Excel), por eso se
+    // rechaza explícitamente para combinada en vez de generar un PDF incompleto.
+    if (inversionista.reinversion === "reinversion_combinada") {
+      set.status = 410;
+      return {
+        message:
+          "El reporte PDF no está disponible para inversionistas con reinversión combinada. Usá el reporte Excel.",
+      };
+    }
+
     // Totales desde getInvestorTotalsGlobales (espejos, no liquidados)
     const totales = await getInvestorTotalsGlobales(
       Number(id),

--- a/apps/cartera-back/src/utils/functions/generalFunctions.ts
+++ b/apps/cartera-back/src/utils/functions/generalFunctions.ts
@@ -770,7 +770,14 @@ export async function buildInversionistaWorkbook(
   // En excedente/variable se incluye el monto fijo definido para el inversionista
   // (lo que recibe / lo que se reinvierte, según la modalidad).
   const simboloMoneda = inv.moneda === "dolares" ? "$" : "Q";
-  const montoReinvFmt = `${simboloMoneda}${toN(inv.monto_reinversion).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  // El cap (monto_reinversion) viene crudo de la DB en quetzales, pero los pagos
+  // que arman los pools ya vienen convertidos por resumeInvestor. Para dólares hay
+  // que convertir el cap con el mismo helper; si no, se compara Q contra USD.
+  const { formatToUSD: convMonedaCap } = await import("./currencyConverter");
+  const montoReinvNum = inv.moneda === "dolares"
+    ? convMonedaCap(inv.monto_reinversion ?? 0, inv.inversionista_id)
+    : toN(inv.monto_reinversion);
+  const montoReinvFmt = `${simboloMoneda}${montoReinvNum.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
   const descMapR: Record<string, string> = {
     reinversion_capital:   "El inversionista recibe solo el interés; el capital abonado se reinvierte.",
     reinversion_interes:   "El inversionista recibe el capital; el interés se reinvierte.",
@@ -1136,7 +1143,7 @@ export async function buildInversionistaWorkbook(
 
     // Excedente: el inversionista RECIBE el monto fijo; el sobrante del pool se reinvierte.
     // Variable: el monto fijo es lo que se REINVIERTE del pool.
-    const montoReinv = new Big(toN(inv.monto_reinversion));
+    const montoReinv = new Big(montoReinvNum);
     const reinvExcedente = poolExcedente.gt(0)
       ? poolExcedente.minus(montoReinv.gt(poolExcedente) ? poolExcedente : montoReinv)
       : new Big(0);

--- a/apps/cartera-back/src/utils/functions/generalFunctions.ts
+++ b/apps/cartera-back/src/utils/functions/generalFunctions.ts
@@ -694,6 +694,8 @@ export async function buildInversionistaWorkbook(
     zebra: "FFF9FBFF",
     total: "FFF0F9FF",
     gray:  "FF8C98B5",
+    // Resalte para filas con interés "partido" (cálculo dividido por compras)
+    partido: "FFFEF3C7",
   };
 
   const esDolares = inv.moneda === "dolares";
@@ -752,14 +754,16 @@ export async function buildInversionistaWorkbook(
   // ── tablas de datos
   const esCombinada = inv.reinversion === "reinversion_combinada";
   const labelMapR: Record<string, string> = {
-    reinversion_capital: "Reinversión Capital",
-    reinversion_interes: "Reinversión Interés",
-    reinversion_total:   "Interés Compuesto",
-    sin_reinversion:     "Tradicional",
+    reinversion_capital:   "Reinversión Capital",
+    reinversion_interes:   "Reinversión Interés",
+    reinversion_total:     "Interés Compuesto",
+    reinversion_excedente: "Reinversión Excedente",
+    reinversion_variable:  "Reinversión Variable",
+    sin_reinversion:       "Tradicional",
   };
 
   const grupos = esCombinada
-    ? ["reinversion_capital", "reinversion_interes", "reinversion_total", "sin_reinversion"]
+    ? ["reinversion_capital", "reinversion_interes", "reinversion_total", "reinversion_excedente", "reinversion_variable", "sin_reinversion"]
     : ["all"];
 
   let row = 5;
@@ -928,7 +932,13 @@ export async function buildInversionistaWorkbook(
         rr.getCell(13 + offset).alignment = { horizontal: "right" };
         rr.getCell(15 + offset).alignment = { horizontal: "right" };
 
-        if (rowIdx % 2 === 0) {
+        // Resaltar en amarillo las filas cuyo interés se calculó partido por
+        // compras del mes; prevalece sobre el zebra.
+        if (pago.interes_partido) {
+          for (let c = 1; c <= totalCols; c++) {
+            rr.getCell(c).fill = { type: "pattern", pattern: "solid", fgColor: { argb: CINV.partido } };
+          }
+        } else if (rowIdx % 2 === 0) {
           for (let c = 1; c <= totalCols; c++) {
             rr.getCell(c).fill = { type: "pattern", pattern: "solid", fgColor: { argb: CINV.zebra } };
           }
@@ -1049,6 +1059,10 @@ export async function buildInversionistaWorkbook(
     let reinvTot_cap = new Big(0);
     let reinvTot_int = new Big(0);
     let reinvInt_int = new Big(0);
+    // Pools de excedente/variable: cuota completa (cap + interés neto) de sus créditos.
+    // El monto reinvertido se calcula después con el monto_reinversion (igual que el backend).
+    let poolExcedente = new Big(0);
+    let poolVariable  = new Big(0);
 
     for (const cr of inv.creditos) {
       const tipo = cr.tipo_reinversion || "sin_reinversion";
@@ -1057,9 +1071,9 @@ export async function buildInversionistaWorkbook(
         const int = new Big(pago.abono_interes || 0);
         const iva = new Big(pago.abono_iva || 0);
         const isr = new Big(pago.isr || 0);
-        
-        const abonoGeneralInteres = inv.emite_factura 
-          ? int.plus(iva) 
+
+        const abonoGeneralInteres = inv.emite_factura
+          ? int.plus(iva)
           : int.minus(isr);
 
         if (tipo === "reinversion_capital") {
@@ -1072,9 +1086,23 @@ export async function buildInversionistaWorkbook(
         } else if (tipo === "reinversion_interes") {
           // `abonoGeneralInteres` YA es el interés neto; no re-descontar ISR.
           reinvInt_int = reinvInt_int.plus(abonoGeneralInteres);
+        } else if (tipo === "reinversion_excedente") {
+          poolExcedente = poolExcedente.plus(cap.plus(abonoGeneralInteres));
+        } else if (tipo === "reinversion_variable") {
+          poolVariable = poolVariable.plus(cap.plus(abonoGeneralInteres));
         }
       }
     }
+
+    // Excedente: el inversionista RECIBE el monto fijo; el sobrante del pool se reinvierte.
+    // Variable: el monto fijo es lo que se REINVIERTE del pool.
+    const montoReinv = new Big(toN(inv.monto_reinversion));
+    const reinvExcedente = poolExcedente.gt(0)
+      ? poolExcedente.minus(montoReinv.gt(poolExcedente) ? poolExcedente : montoReinv)
+      : new Big(0);
+    const reinvVariable = poolVariable.gt(0)
+      ? (montoReinv.gt(poolVariable) ? poolVariable : montoReinv)
+      : new Big(0);
 
     if (reinvCap_cap.gt(0)) {
       reinv.push(["Reinversión Capital (Abono Capital)", reinvCap_cap.toNumber()]);
@@ -1087,6 +1115,12 @@ export async function buildInversionistaWorkbook(
     }
     if (reinvInt_int.gt(0)) {
       reinv.push(["Reinversión Interés (Interés Neto)", reinvInt_int.toNumber()]);
+    }
+    if (reinvExcedente.gt(0)) {
+      reinv.push(["Reinversión Excedente (Sobrante)", reinvExcedente.toNumber()]);
+    }
+    if (reinvVariable.gt(0)) {
+      reinv.push(["Reinversión Variable", reinvVariable.toNumber()]);
     }
     reinv.push(["Total Reinversión", toN(sub.total_reinversion)]);
   } else {

--- a/apps/cartera-back/src/utils/functions/generalFunctions.ts
+++ b/apps/cartera-back/src/utils/functions/generalFunctions.ts
@@ -766,6 +766,20 @@ export async function buildInversionistaWorkbook(
     ? ["reinversion_capital", "reinversion_interes", "reinversion_total", "reinversion_excedente", "reinversion_variable", "sin_reinversion"]
     : ["all"];
 
+  // Descripción de cada modalidad para mostrarla al lado del título del grupo.
+  // En excedente/variable se incluye el monto fijo definido para el inversionista
+  // (lo que recibe / lo que se reinvierte, según la modalidad).
+  const simboloMoneda = inv.moneda === "dolares" ? "$" : "Q";
+  const montoReinvFmt = `${simboloMoneda}${toN(inv.monto_reinversion).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  const descMapR: Record<string, string> = {
+    reinversion_capital:   "El inversionista recibe solo el interés; el capital abonado se reinvierte.",
+    reinversion_interes:   "El inversionista recibe el capital; el interés se reinvierte.",
+    reinversion_total:     "Se reinvierte todo (capital + interés): interés compuesto.",
+    reinversion_excedente: `El inversionista recibe ${montoReinvFmt} fijo; el sobrante se reinvierte.`,
+    reinversion_variable:  `Se reinvierte ${montoReinvFmt}; el resto lo recibe el inversionista.`,
+    sin_reinversion:       "El inversionista recibe capital + interés; no se reinvierte nada.",
+  };
+
   let row = 5;
   const groupTotalRows: number[] = [];
 
@@ -786,6 +800,18 @@ export async function buildInversionistaWorkbook(
       titleRow.getCell(2).value = labelMapR[grupo ?? ""] ?? "Sin tipo definido";
       titleRow.getCell(2).font = { bold: true, size: 11, color: { argb: CINV.white } };
       titleRow.getCell(2).fill = { type: "pattern", pattern: "solid", fgColor: { argb: CINV.blue } };
+
+      // Descripción de la modalidad al lado del título (con el monto en
+      // excedente/variable, para saber cuánto está definido que recibe/reinvierte).
+      const descGrupo = descMapR[grupo ?? ""] ?? "";
+      if (descGrupo) {
+        const descCell = titleRow.getCell(4);
+        descCell.value = descGrupo;
+        descCell.font = { italic: true, size: 10, color: { argb: CINV.slate } };
+        descCell.alignment = { horizontal: "left", vertical: "middle" };
+        ws.mergeCells(row, 4, row, Math.min(totalCols, 13));
+      }
+
       row += 1; // header va una fila debajo del título
     } else {
       row += 1; // en modo normal el header es directo en fila 6
@@ -1050,7 +1076,21 @@ export async function buildInversionistaWorkbook(
   const titleRow = ws.getRow(row);
   titleRow.getCell(1).value = "Totales de Reinversión";
   titleRow.getCell(1).font = { bold: true, size: 12, color: { argb: CINV.navy } };
-  
+
+  // Descripción de la modalidad del inversionista. En combinada la descripción
+  // va al lado de cada grupo; cuando NO es combinada, va aquí (con el monto en
+  // excedente/variable, para saber cuánto recibe/reinvierte).
+  if (!esCombinada) {
+    const descInv = descMapR[inv.reinversion] ?? "";
+    if (descInv) {
+      const descRow = ws.getRow(row + 1);
+      descRow.getCell(1).value = `${labelMapR[inv.reinversion] ?? ""}: ${descInv}`;
+      descRow.getCell(1).font = { italic: true, size: 10, color: { argb: CINV.slate } };
+      descRow.getCell(1).alignment = { horizontal: "left", vertical: "middle" };
+      ws.mergeCells(row + 1, 1, row + 1, Math.min(totalCols, 10));
+    }
+  }
+
   row += 2;
   const reinv: [string, number][] = [];
 

--- a/apps/cartera-back/src/utils/interface.ts
+++ b/apps/cartera-back/src/utils/interface.ts
@@ -16,6 +16,9 @@ export interface PagoDetalle {
   tasaInteresInvesor: number;
   cuota: number;
   estado_liquidacion?: "LIQUIDADO" | "NO_LIQUIDADO";
+  // true cuando el interés del pago se calculó partido por compras del mes
+  // (abono_interes_sin_compras / _con_compras no nulos). Se resalta en el Excel.
+  interes_partido?: boolean;
 }
 
 export interface CreditoData {
@@ -70,6 +73,7 @@ export interface InversionistaReporte {
   nombre_inversionista: string;
   email: string | null;
   reinversion: string;
+  monto_reinversion?: string | number | null;
   banco: string | null;
   tipo_cuenta: string | null;
   numero_cuenta: string | null;

--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -14,10 +14,20 @@ interface ModalReinversionCombinadaProps {
   onSaved?: () => void;
 }
 
-const TIPOS_REINVERSION: { value: TipoReinversionEspejo; label: string; color: string }[] = [
-  { value: "sin_reinversion", label: "Sin Reinversión", color: "bg-gray-100 text-gray-700" },
-  { value: "reinversion_capital", label: "Capital", color: "bg-green-100 text-green-700" },
-  { value: "reinversion_total", label: "Interés Compuesto", color: "bg-purple-100 text-purple-700" },
+const TIPOS_REINVERSION: {
+  value: TipoReinversionEspejo;
+  label: string;
+  cardColor: string;
+  selectColor: string;
+  // Modalidades que solo se habilitan si el inversionista ya tiene monto de
+  // reinversión en DB (o algún crédito ya viene marcado con ese tipo).
+  extra?: boolean;
+}[] = [
+  { value: "sin_reinversion", label: "Sin Reinversión", cardColor: "bg-gray-100 text-gray-700", selectColor: "border-gray-300 bg-gray-50 text-gray-600" },
+  { value: "reinversion_capital", label: "Capital", cardColor: "bg-green-100 text-green-700", selectColor: "border-green-300 bg-green-50 text-green-700" },
+  { value: "reinversion_total", label: "Interés Compuesto", cardColor: "bg-purple-100 text-purple-700", selectColor: "border-purple-300 bg-purple-50 text-purple-700" },
+  { value: "reinversion_excedente", label: "Excedente", cardColor: "bg-blue-100 text-blue-700", selectColor: "border-blue-300 bg-blue-50 text-blue-700", extra: true },
+  { value: "reinversion_variable", label: "Variable", cardColor: "bg-amber-100 text-amber-700", selectColor: "border-amber-300 bg-amber-50 text-amber-700", extra: true },
 ];
 
 const ALL_CREDITS_PER_PAGE = 500;
@@ -55,12 +65,35 @@ export function ModalReinversionCombinada({
 
   const { mutate: asignarReinversion, isPending: isSaving } = useAsignarReinversion();
 
+  // Inversionista actual (para leer monto_reinversion y sus créditos)
+  const inversionista = useMemo(
+    () => data?.inversionistas?.find((i) => i.inversionista_id === inversionistaId) ?? null,
+    [data, inversionistaId]
+  );
+
   // Todos los créditos del inversionista actual
-  const allCreditos: CreditoInversionistaData[] = useMemo(() => {
-    if (!data?.inversionistas?.length) return [];
-    const inv = data.inversionistas.find((i) => i.inversionista_id === inversionistaId);
-    return inv?.creditos ?? [];
-  }, [data, inversionistaId]);
+  const allCreditos: CreditoInversionistaData[] = useMemo(
+    () => inversionista?.creditos ?? [],
+    [inversionista]
+  );
+
+  // Excedente y Variable son modalidades que normalmente no se usan. Solo se
+  // habilitan en la modal si el inversionista ya tiene monto de reinversión
+  // registrado en DB, o si algún crédito ya viene marcado con esos tipos.
+  const habilitarExtras = useMemo(() => {
+    if (Number(inversionista?.monto_reinversion ?? 0) > 0) return true;
+    return allCreditos.some(
+      (c) =>
+        c.tipo_reinversion === "reinversion_excedente" ||
+        c.tipo_reinversion === "reinversion_variable"
+    );
+  }, [inversionista, allCreditos]);
+
+  // Tipos que se muestran en el resumen y en el select según habilitación.
+  const tiposDisponibles = useMemo(
+    () => TIPOS_REINVERSION.filter((t) => !t.extra || habilitarExtras),
+    [habilitarExtras]
+  );
 
   // Filtro visual por búsqueda (no afecta totales)
   const creditosFiltrados = useMemo(() => {
@@ -81,11 +114,10 @@ export function ModalReinversionCombinada({
 
   // Resumen: contar por tipo y sumar montos — siempre sobre TODOS los créditos
   const resumen = useMemo(() => {
-    const counts: Record<string, { cantidad: number; monto: number }> = {
-      reinversion_capital: { cantidad: 0, monto: 0 },
-      reinversion_total: { cantidad: 0, monto: 0 },
-      sin_reinversion: { cantidad: 0, monto: 0 },
-    };
+    const counts: Record<string, { cantidad: number; monto: number }> = {};
+    TIPOS_REINVERSION.forEach((t) => {
+      counts[t.value] = { cantidad: 0, monto: 0 };
+    });
 
     allCreditos.forEach((cred) => {
       const espejoId = cred.credito_inversionista_espejo_id;
@@ -168,15 +200,18 @@ export function ModalReinversionCombinada({
 
         {/* Resumen por tipo */}
         <div className="px-6 py-3 border-b bg-gray-50">
-          <div className="grid grid-cols-3 gap-3">
-            {TIPOS_REINVERSION.map((tipo) => {
-              const data = resumen[tipo.value];
+          <div
+            className="grid gap-3"
+            style={{ gridTemplateColumns: `repeat(${tiposDisponibles.length}, minmax(0, 1fr))` }}
+          >
+            {tiposDisponibles.map((tipo) => {
+              const stat = resumen[tipo.value];
               return (
-                <div key={tipo.value} className={`rounded-lg px-3 py-2 ${tipo.color}`}>
+                <div key={tipo.value} className={`rounded-lg px-3 py-2 ${tipo.cardColor}`}>
                   <div className="text-xs font-medium opacity-75">{tipo.label}</div>
-                  <div className="text-lg font-bold">{data?.cantidad ?? 0} créditos</div>
+                  <div className="text-lg font-bold">{stat?.cantidad ?? 0} créditos</div>
                   <div className="text-xs">
-                    Q {(data?.monto ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
+                    Q {(stat?.monto ?? 0).toLocaleString("es-GT", { minimumFractionDigits: 2 })}
                   </div>
                 </div>
               );
@@ -218,6 +253,17 @@ export function ModalReinversionCombinada({
                 const espejoId = cred.credito_inversionista_espejo_id!;
                 const tipoOriginal = cred.tipo_reinversion ?? "sin_reinversion";
                 const tipoActual = asignaciones[espejoId] ?? tipoOriginal;
+                // Opciones del select: las disponibles + la actual si por algún
+                // motivo no estuviera (para no perder el valor del crédito).
+                const opcionesCredito = tiposDisponibles.some((t) => t.value === tipoActual)
+                  ? tiposDisponibles
+                  : [
+                      ...tiposDisponibles,
+                      ...TIPOS_REINVERSION.filter((t) => t.value === tipoActual),
+                    ];
+                const colorActual =
+                  (TIPOS_REINVERSION.find((t) => t.value === tipoActual) ?? TIPOS_REINVERSION[0])
+                    .selectColor;
                 return (
                   <div
                     key={espejoId}
@@ -252,17 +298,13 @@ export function ModalReinversionCombinada({
                       onChange={(e) =>
                         handleTipoChange(espejoId, e.target.value as TipoReinversionEspejo, tipoOriginal)
                       }
-                      className={`text-sm border rounded-lg px-3 py-1.5 font-medium transition ${
-                        tipoActual === "sin_reinversion"
-                          ? "border-gray-300 bg-gray-50 text-gray-600"
-                          : tipoActual === "reinversion_capital"
-                          ? "border-green-300 bg-green-50 text-green-700"
-                          : "border-purple-300 bg-purple-50 text-purple-700"
-                      }`}
+                      className={`text-sm border rounded-lg px-3 py-1.5 font-medium transition ${colorActual}`}
                     >
-                      <option value="sin_reinversion">Sin Reinversión</option>
-                      <option value="reinversion_capital">Capital</option>
-                      <option value="reinversion_total">Interés Compuesto</option>
+                      {opcionesCredito.map((t) => (
+                        <option key={t.value} value={t.value}>
+                          {t.label}
+                        </option>
+                      ))}
                     </select>
                   </div>
                 );

--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -165,6 +165,18 @@ export function ModalReinversionCombinada({
       return;
     }
 
+    // No permitir mezclar Excedente y Variable en el mismo inversionista: el
+    // monto_reinversion es único y significaría dos cosas opuestas a la vez
+    // (recibir un monto fijo vs reinvertir un monto fijo). Debe usarse solo una.
+    const tieneExcedente = todos.some((t) => t.tipo_reinversion === "reinversion_excedente");
+    const tieneVariable = todos.some((t) => t.tipo_reinversion === "reinversion_variable");
+    if (tieneExcedente && tieneVariable) {
+      toast.error(
+        "No se puede mezclar Excedente y Variable en el mismo inversionista. El monto de reinversión es único; usá solo una de las dos modalidades."
+      );
+      return;
+    }
+
     asignarReinversion(
       { inversionista_id: inversionistaId, asignaciones: todos },
       {

--- a/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalReinversionCombinada.tsx
@@ -11,6 +11,10 @@ interface ModalReinversionCombinadaProps {
   onClose: () => void;
   inversionistaId: number;
   inversionistaNombre: string;
+  // Monto de reinversión actual del form del inversionista (puede no estar
+  // guardado aún). Permite habilitar Excedente/Variable en el setup por primera
+  // vez, antes de persistir el monto en DB.
+  montoReinversion?: number;
   onSaved?: () => void;
 }
 
@@ -38,6 +42,7 @@ export function ModalReinversionCombinada({
   onClose,
   inversionistaId,
   inversionistaNombre,
+  montoReinversion,
   onSaved,
 }: ModalReinversionCombinadaProps) {
   const [page, setPage] = useState(1);
@@ -77,17 +82,19 @@ export function ModalReinversionCombinada({
     [inversionista]
   );
 
-  // Excedente y Variable son modalidades que normalmente no se usan. Solo se
-  // habilitan en la modal si el inversionista ya tiene monto de reinversión
-  // registrado en DB, o si algún crédito ya viene marcado con esos tipos.
+  // Excedente y Variable son modalidades que normalmente no se usan. Se habilitan
+  // si hay monto de reinversión: el del form actual (aunque no esté guardado, para
+  // el setup por primera vez) o el persistido en DB, o si algún crédito ya viene
+  // marcado con esos tipos.
   const habilitarExtras = useMemo(() => {
+    if (Number(montoReinversion ?? 0) > 0) return true;
     if (Number(inversionista?.monto_reinversion ?? 0) > 0) return true;
     return allCreditos.some(
       (c) =>
         c.tipo_reinversion === "reinversion_excedente" ||
         c.tipo_reinversion === "reinversion_variable"
     );
-  }, [inversionista, allCreditos]);
+  }, [montoReinversion, inversionista, allCreditos]);
 
   // Tipos que se muestran en el resumen y en el select según habilitación.
   const tiposDisponibles = useMemo(

--- a/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
@@ -345,6 +345,9 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
           }}
           inversionistaId={initialData.inversionista_id}
           inversionistaNombre={initialData.nombre}
+          // Monto del form (posiblemente sin guardar) para habilitar
+          // Excedente/Variable en el setup por primera vez.
+          montoReinversion={Number(watch("monto_reinversion") ?? 0)}
           onSaved={() => {
             // Guardar el inversionista con reinversion_combinada y cerrar todo
             const currentFormData = watch();

--- a/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalInvestor.tsx
@@ -108,6 +108,14 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
     });
   };
 
+  // El monto de reinversión es editable en variable, excedente y combinada
+  // (en combinada puede que haya que ajustar ese monto manualmente).
+  const tipoReinversion = watch("tipo_reinversion");
+  const montoEditable =
+    tipoReinversion === "reinversion_variable" ||
+    tipoReinversion === "reinversion_excedente" ||
+    tipoReinversion === "reinversion_combinada";
+
   if (!open) return null;
 
   return createPortal(
@@ -210,7 +218,11 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
                     onChange: (e) => {
                       const prev = watch("tipo_reinversion") ?? "sin_reinversion";
                       const val = e.target.value;
-                      if (val !== "reinversion_variable" && val !== "reinversion_excedente") {
+                      if (
+                        val !== "reinversion_variable" &&
+                        val !== "reinversion_excedente" &&
+                        val !== "reinversion_combinada"
+                      ) {
                         setValue("monto_reinversion", 0);
                       }
                       if (val === "reinversion_combinada") {
@@ -243,7 +255,7 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
             {/* Monto Reinversión */}
             <div>
               <label className="block text-sm text-blue-800 mb-1">
-                {watch("tipo_reinversion") === "reinversion_excedente"
+                {tipoReinversion === "reinversion_excedente"
                   ? "Monto a Recibir"
                   : "Monto Reinversión"}
               </label>
@@ -252,19 +264,15 @@ export function InvestorModal({ open, onClose, mode, initialData }: InvestorModa
                 type="number"
                 step="any"
                 min={0}
-                disabled={
-                  watch("tipo_reinversion") !== "reinversion_variable" &&
-                  watch("tipo_reinversion") !== "reinversion_excedente"
-                }
+                disabled={!montoEditable}
                 className={`border border-gray-300 rounded-lg px-4 py-2 w-full focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition ${
-                  watch("tipo_reinversion") !== "reinversion_variable" &&
-                  watch("tipo_reinversion") !== "reinversion_excedente"
+                  !montoEditable
                     ? "bg-gray-100 text-gray-400 cursor-not-allowed"
                     : "bg-white text-blue-900 placeholder-gray-400"
                 }`}
                 placeholder="0.00"
               />
-              {watch("tipo_reinversion") === "reinversion_excedente" && (
+              {tipoReinversion === "reinversion_excedente" && (
                 <p className="mt-1 text-xs text-blue-600">
                   El inversionista recibe este monto fijo; el sobrante de su cuota se reinvierte.
                 </p>

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -8,7 +8,6 @@ import {
   Download,
   Edit,
   Bell,
-  FileDown,
   FileSpreadsheet,
   Loader2,
   MoreVertical,
@@ -36,7 +35,6 @@ import {
   type InvestorPayload,
 } from "../services/services";
 import { useLiquidateByInvestor } from "../hooks/liquidateAllInvestor";
-import { useDownloadInvestorPDF } from "../hooks/downloadInvestorReport";
 import { useDownloadReporteNoLiquidados } from "../hooks/downloadReporteNoLiquidados";
 import { InvestorModal } from "./modalInvestor";
 import { useFalsePayments } from "../hooks/falsePayments";
@@ -449,7 +447,6 @@ export function TableInvestors() {
 
 
   const liquidateMutation = useLiquidateByInvestor();
-  const downloadPDF = useDownloadInvestorPDF();
   const downloadNoLiquidados = useDownloadReporteNoLiquidados();
   const [query, setQuery] = useState("");
 
@@ -1302,28 +1299,6 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
               </DropdownMenuTrigger>
 
               <DropdownMenuContent align="end" className="w-56 rounded-xl shadow-lg border border-gray-200 p-1 bg-white">
-                {/* Descargar PDF */}
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    downloadPDF.mutate({
-                      id: inv.inversionista_id,
-                      page: 1,
-                      perPage: perPage,
-                    });
-                  }}
-                  disabled={downloadPDF.isPending}
-                  className="cursor-pointer rounded-lg px-3 py-2.5 focus:bg-blue-50"
-                >
-                  {downloadPDF.isPending ? (
-                    <><Loader2 className="mr-2.5 h-4 w-4 animate-spin text-blue-500" /><span className="text-sm font-medium text-blue-600">Descargando…</span></>
-                  ) : (
-                    <><FileDown className="mr-2.5 h-4 w-4 text-blue-500" /><span className="text-sm font-medium text-gray-700">Descargar PDF</span></>
-                  )}
-                </DropdownMenuItem>
-
-                <DropdownMenuSeparator className="my-1" />
-
                 {/* Paso 1: Calcular Pagos */}
                 <DropdownMenuItem
                   onClick={(e) => {
@@ -1940,31 +1915,6 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
 
       {/* BOTONES CON VALIDACIONES */}
       <div className="flex flex-wrap gap-2 mb-2">
-        {/* Descargar PDF */}
-        <button
-          className="px-3 py-2 rounded-lg bg-blue-600 text-white text-xs font-semibold hover:bg-blue-700 active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2 shadow-sm"
-          disabled={Number(inv.subtotal?.total_cuota_sin_reinversion ?? 0) <= 0 || downloadPDF.isPending}
-          onClick={() =>
-            downloadPDF.mutate({
-              id: inv.inversionista_id,
-              page: 1,
-              perPage: perPage,
-            })
-          }
-        >
-          {downloadPDF.isPending ? (
-            <>
-              <Loader2 className="w-4 h-4 animate-spin" />
-              <span>PDF...</span>
-            </>
-          ) : (
-            <>
-              <FileDown className="w-4 h-4" />
-              <span>PDF</span>
-            </>
-          )}
-        </button>
-
         {/* 🔥 PASO 1: Generar Pagos - SIEMPRE DISPONIBLE */}
         <button
           className="px-3 py-2 rounded-lg bg-purple-600 text-white text-xs font-semibold hover:bg-purple-700 active:scale-95 transition-all disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2 shadow-sm"

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -242,6 +242,8 @@ export interface SendInvestorAddedToCreditsNotificationParams {
       | "reinversion_capital"
       | "reinversion_interes"
       | "reinversion_total"
+      | "reinversion_excedente"
+      | "reinversion_variable"
       | null;
   }>;
   currencySymbol?: string;
@@ -279,6 +281,8 @@ export const sendInvestorAddedToCreditsNotification = async ({
       reinversion_capital: "Reinversión Capital",
       reinversion_interes: "Reinversión de Interés",
       reinversion_total: "Interés Compuesto",
+      reinversion_excedente: "Reinversión Excedente",
+      reinversion_variable: "Reinversión Variable",
     };
 
     const filas = creditos


### PR DESCRIPTION
## Resumen

Habilita las modalidades **excedente** y **variable** dentro de una **reinversión combinada**, de punta a punta: UI → cálculo de pagos → reportes → liquidación. No afecta a otras modalidades ni a combinadas sin excedente/variable (mismo resultado que antes).

Reemplaza al PR #1004 (misma rama), consolidando aquí todas las observaciones de review ya atendidas.

## Cambios por área

### Frontend (carteraFront)
- **ModalReinversionCombinada**: muestra Excedente/Variable solo si el inversionista ya tiene `monto_reinversion` en DB (o algún crédito ya lo tiene). El resumen cuenta los 5 tipos y el select refleja el valor correcto por crédito.
- **modalInvestor**: habilita el campo Monto Reinversión también en combinada (sin resetearlo a 0).
- Se **quita el botón "Descargar PDF"** de tableInvestors (reporte deprecado; ver observaciones).

### Cálculo de pagos (cartera-back)
- `getInvestorTotalsGlobales`, `getInvestorMirrorSummary`, `resumeInvestor`: en combinada se acumula la cuota de los créditos excedente/variable en un pool y se aplica el mismo ajuste que el crudo (excedente recibe monto fijo y reinvierte el sobrante; variable reinvierte el monto). `total_cuota_sin_reinversion` queda intacto.

### Reportes (Excel)
- Grupos excedente/variable + desglose del sobrante en "Totales de Reinversión" (cuadra con el total).
- Descripción de cada modalidad al lado del título (combinada) y en "Totales de Reinversión" (no-combinada), con el monto en excedente/variable.
- Resalte amarillo de filas con interés "partido" por compras del mes.

### Liquidación
- Despliega el sobrante en créditos nuevos con su misma modalidad (excedente→excedente, variable→variable); `addInvestorToCredit` acepta esas modalidades. Reparto de hasta 5 llamadas.

### Otros
- `@cci/email` acepta/etiqueta excedente/variable.
- Reporte: `numero_cuota` nulo se muestra como 1.

## Observaciones de review atendidas

1. **Backfill al escalar a combinada (compra_cartera)** — se preserva siempre la modalidad previa (`valorBackfill = X`) para no perder variable/excedente. (`ef8de31a`)
2. **Modal sin `reinversion_interes`** — NO se agrega, a propósito: es una modalidad muerta, sin créditos/inversionistas usándola (pendiente de eliminar).
3. **Moneda del cap en Excel (USD)** — `monto_reinversion` se convierte con `formatToUSD` antes de compararlo con los pools (que ya vienen convertidos). Afectaba solo a dólares. (`b557f441`)
4. **PDF combinado incompleto** — el reporte PDF (`generarHTMLReporte` / `POST /investor/pdf`) no agrupa excedente/variable. Como está deprecado, se **rechaza (410) para combinada** y se quitó el botón del front. (`b557f441`, `c537e7b5`)
5. **Mezcla excedente + variable** — el modal ahora **bloquea** tener ambas modalidades en el mismo inversionista (el `monto_reinversion` es único y sería ambiguo). (`c537e7b5`)

## Notas / decisiones
- El registro `liquidaciones` guarda `reinversion_capital/interes/total`; el sobrante del excedente queda dentro de `reinversion_total` (el total es correcto).
- El endpoint `/investor/pdf` + `generarHTMLReporte` quedan sin uso (código muerto); no se borraron para acotar el cambio.
- Typecheck OK en los archivos tocados (los errores preexistentes de `pg`/`registerPayment` son ajenos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)