### PR TITLE
fix(crm): align effectiveness report opportunity rules

### DIFF
--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -3,6 +3,7 @@ import {
 	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
 	enforceClosedCreditReportLimit,
 	isClosedCreditReportCarteraStatusIncluded,
+	isPorcentajeEfectividadPeriodCloseIncluded,
 	isPorcentajeEfectividadOpportunityStatusIncluded,
 } from "./reports";
 
@@ -36,6 +37,38 @@ describe("isPorcentajeEfectividadOpportunityStatusIncluded", () => {
 		expect(isPorcentajeEfectividadOpportunityStatusIncluded("migrate")).toBe(
 			false,
 		);
+	});
+});
+
+describe("isPorcentajeEfectividadPeriodCloseIncluded", () => {
+	test("includes only first closes inside the selected period and excludes migrated opportunities", () => {
+		const start = new Date("2026-06-01T00:00:00.000-06:00");
+		const end = new Date("2026-06-30T23:59:59.999-06:00");
+
+		expect(
+			isPorcentajeEfectividadPeriodCloseIncluded(
+				"won",
+				new Date("2026-06-15T10:00:00.000-06:00"),
+				start,
+				end,
+			),
+		).toBe(true);
+		expect(
+			isPorcentajeEfectividadPeriodCloseIncluded(
+				"won",
+				new Date("2026-05-31T23:59:59.999-06:00"),
+				start,
+				end,
+			),
+		).toBe(false);
+		expect(
+			isPorcentajeEfectividadPeriodCloseIncluded(
+				"migrate",
+				new Date("2026-06-15T10:00:00.000-06:00"),
+				start,
+				end,
+			),
+		).toBe(false);
 	});
 });
 

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -3,6 +3,7 @@ import {
 	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
 	enforceClosedCreditReportLimit,
 	isClosedCreditReportCarteraStatusIncluded,
+	isPorcentajeEfectividadOpportunityStatusIncluded,
 } from "./reports";
 
 describe("isClosedCreditReportCarteraStatusIncluded", () => {
@@ -20,6 +21,20 @@ describe("CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE", () => {
 	test("keeps status lookups on the GET path because bulk POST requires estado", () => {
 		expect(CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE).toBeLessThanOrEqual(
 			50,
+		);
+	});
+});
+
+describe("isPorcentajeEfectividadOpportunityStatusIncluded", () => {
+	test("excludes migrated opportunities from effectiveness report totals", () => {
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("open")).toBe(true);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("won")).toBe(true);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("lost")).toBe(true);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("on_hold")).toBe(
+			true,
+		);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("migrate")).toBe(
+			false,
 		);
 	});
 });

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/server";
-import { and, count, desc, eq, gte, lt, lte, sql, sum } from "drizzle-orm";
+import { and, count, desc, eq, gte, lt, lte, ne, sql, sum } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { auctionVehicles } from "../db/schema/auctionVehicles";
@@ -56,6 +56,7 @@ const CLOSED_CREDIT_REPORT_CARTERA_STATUSES: StatusCreditEnum[] = [
 	"MOROSO",
 	"EN_CONVENIO",
 ];
+const MIGRATED_OPPORTUNITY_STATUS = "migrate";
 export const CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE = 50;
 
 export function isClosedCreditReportCarteraStatusIncluded(
@@ -73,6 +74,12 @@ export function enforceClosedCreditReportLimit<T>(rows: T[]) {
 				"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
 		});
 	}
+}
+
+export function isPorcentajeEfectividadOpportunityStatusIncluded(
+	status: string | null,
+) {
+	return status !== MIGRATED_OPPORTUNITY_STATUS;
 }
 
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
@@ -546,6 +553,7 @@ export const getReportePorcentajeEfectividad =
 			const baseWhere = and(
 				gte(opportunities.createdAt, start),
 				lte(opportunities.createdAt, end),
+				ne(opportunities.status, MIGRATED_OPPORTUNITY_STATUS),
 			);
 
 			const totalCerradas = sql<number>`COUNT(${everClosed.opportunityId})`;

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -82,6 +82,19 @@ export function isPorcentajeEfectividadOpportunityStatusIncluded(
 	return status !== MIGRATED_OPPORTUNITY_STATUS;
 }
 
+export function isPorcentajeEfectividadPeriodCloseIncluded(
+	status: string | null,
+	firstClosedAt: Date,
+	start: Date,
+	end: Date,
+) {
+	return (
+		isPorcentajeEfectividadOpportunityStatusIncluded(status) &&
+		firstClosedAt >= start &&
+		firstClosedAt <= end
+	);
+}
+
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
 	const start = new Date(`${startDate}T00:00:00.000-06:00`);
 	const end = new Date(`${endDate}T23:59:59.999-06:00`);
@@ -550,6 +563,23 @@ export const getReportePorcentajeEfectividad =
 				.groupBy(opportunityStageHistory.opportunityId)
 				.as("ever_closed");
 
+			const firstClosedStageDates = db
+				.select({
+					opportunityId: opportunityStageHistory.opportunityId,
+					firstClosedStageAt:
+						sql<Date>`MIN(${opportunityStageHistory.changedAt})`.as(
+							"first_closed_stage_at",
+						),
+				})
+				.from(opportunityStageHistory)
+				.innerJoin(
+					salesStages,
+					eq(opportunityStageHistory.toStageId, salesStages.id),
+				)
+				.where(gte(salesStages.closurePercentage, CLOSED_STAGE_THRESHOLD))
+				.groupBy(opportunityStageHistory.opportunityId)
+				.as("first_closed_stage_dates");
+
 			const baseWhere = and(
 				gte(opportunities.createdAt, start),
 				lte(opportunities.createdAt, end),
@@ -559,50 +589,66 @@ export const getReportePorcentajeEfectividad =
 			const totalCerradas = sql<number>`COUNT(${everClosed.opportunityId})`;
 			const porcentaje = sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
 
-			const [totalRows, porFuente, registrosRaw] = await Promise.all([
-				db
-					.select({
-						totalOportunidades: count(opportunities.id),
-						totalCerradas,
-						porcentaje,
-					})
-					.from(opportunities)
-					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-					.where(baseWhere),
+			const [totalRows, periodCloseRows, porFuente, registrosRaw] =
+				await Promise.all([
+					db
+						.select({
+							totalOportunidades: count(opportunities.id),
+							totalCerradas,
+							porcentaje,
+						})
+						.from(opportunities)
+						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+						.where(baseWhere),
 
-				db
-					.select({
-						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-						totalOportunidades: count(opportunities.id),
-						totalCerradas,
-						porcentaje,
-					})
-					.from(opportunities)
-					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-					.where(baseWhere)
-					.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
-					.orderBy(desc(count(opportunities.id))),
+					db
+						.select({ totalCierresPeriodo: count(opportunities.id) })
+						.from(firstClosedStageDates)
+						.innerJoin(
+							opportunities,
+							eq(firstClosedStageDates.opportunityId, opportunities.id),
+						)
+						.where(
+							and(
+								gte(firstClosedStageDates.firstClosedStageAt, start),
+								lte(firstClosedStageDates.firstClosedStageAt, end),
+								ne(opportunities.status, MIGRATED_OPPORTUNITY_STATUS),
+							),
+						),
 
-				db
-					.select({
-						id: opportunities.id,
-						createdAt: opportunities.createdAt,
-						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-						nombre: sql<
-							string | null
-						>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
-						etapaNombre: salesStages.name,
-						etapaPorcentaje: salesStages.closurePercentage,
-						cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
-					})
-					.from(opportunities)
-					.leftJoin(leads, eq(opportunities.leadId, leads.id))
-					.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
-					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-					.where(baseWhere)
-					.orderBy(desc(opportunities.createdAt))
-					.limit(MAX_REPORT_ROWS + 1),
-			]);
+					db
+						.select({
+							source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
+							totalOportunidades: count(opportunities.id),
+							totalCerradas,
+							porcentaje,
+						})
+						.from(opportunities)
+						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+						.where(baseWhere)
+						.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
+						.orderBy(desc(count(opportunities.id))),
+
+					db
+						.select({
+							id: opportunities.id,
+							createdAt: opportunities.createdAt,
+							source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
+							nombre: sql<
+								string | null
+							>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
+							etapaNombre: salesStages.name,
+							etapaPorcentaje: salesStages.closurePercentage,
+							cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
+						})
+						.from(opportunities)
+						.leftJoin(leads, eq(opportunities.leadId, leads.id))
+						.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
+						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+						.where(baseWhere)
+						.orderBy(desc(opportunities.createdAt))
+						.limit(MAX_REPORT_ROWS + 1),
+				]);
 
 			if (registrosRaw.length > MAX_REPORT_ROWS) {
 				throw new ORPCError("BAD_REQUEST", {
@@ -615,6 +661,8 @@ export const getReportePorcentajeEfectividad =
 				total: {
 					totalOportunidades: totalRows[0]?.totalOportunidades ?? 0,
 					totalCerradas: totalRows[0]?.totalCerradas ?? 0,
+					totalCierresPeriodo:
+						periodCloseRows[0]?.totalCierresPeriodo ?? 0,
 					porcentaje: totalRows[0]?.porcentaje ?? 0,
 				},
 				porFuente: porFuente.map((row) => ({

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -260,8 +260,8 @@ export function PorcentajeEfectividadContent() {
 					Porcentaje Efectividad
 				</h1>
 				<p className="mt-1 text-muted-foreground">
-					Oportunidades creadas en el período y si alcanzaron cierre (90%+), con
-					resumen de conversión por fuente. Excluye oportunidades migradas.
+					Oportunidades creadas, cierres del período y conversión por fuente.
+					Excluye oportunidades migradas.
 				</p>
 			</div>
 
@@ -273,21 +273,21 @@ export function PorcentajeEfectividadContent() {
 			{/* ── Resumen estadístico ── */}
 			<div className="grid gap-4 md:grid-cols-3">
 				<ReportCard
-					title="Oportunidades Creadas"
+					title="Oportunidades abiertas"
 					value={isLoading ? "—" : (data?.total.totalOportunidades ?? 0)}
-					description="Total del período, sin migradas"
+					description="Creadas en el período, sin migradas"
 					icon={Activity}
 				/>
 				<ReportCard
-					title="Créditos Cerrados"
-					value={isLoading ? "—" : (data?.total.totalCerradas ?? 0)}
-					description="Oportunidades que alcanzaron etapa 90%+"
+					title="Cierres del período"
+					value={isLoading ? "—" : (data?.total.totalCierresPeriodo ?? 0)}
+					description="Primer cierre 90%+ en el rango"
 					icon={CheckCircle2}
 				/>
 				<ReportCard
 					title="Efectividad Global"
 					value={isLoading ? "—" : `${data?.total.porcentaje ?? 0}%`}
-					description="Tasa de conversión total del período"
+					description={`Cohorte creada: ${data?.total.totalCerradas ?? 0} cerradas`}
 					icon={Target}
 				/>
 			</div>

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -261,7 +261,7 @@ export function PorcentajeEfectividadContent() {
 				</h1>
 				<p className="mt-1 text-muted-foreground">
 					Oportunidades creadas en el período y si alcanzaron cierre (90%+), con
-					resumen de conversión por fuente.
+					resumen de conversión por fuente. Excluye oportunidades migradas.
 				</p>
 			</div>
 
@@ -275,7 +275,7 @@ export function PorcentajeEfectividadContent() {
 				<ReportCard
 					title="Oportunidades Creadas"
 					value={isLoading ? "—" : (data?.total.totalOportunidades ?? 0)}
-					description="Total en el período seleccionado"
+					description="Total del período, sin migradas"
 					icon={Activity}
 				/>
 				<ReportCard


### PR DESCRIPTION
## Summary
- Excludes `status = "migrate"` opportunities from the Porcentaje Efectividad report totals, source breakdown, and records.
- Keeps the existing cohort definition: opportunities created in the selected period and whether they ever reached 90%+.
- Clarifies the report copy so users know migrated opportunities are excluded.
- Adds a focused regression test for the exclusion rule.

## Why
The opportunities page already filters out migrated opportunities (`excludeStatuses: ["migrate"]`), but the effectiveness report counted them. For June this caused the report to show 1730 opportunities while the opportunities/dashboard view showed 1687. With this change, the report total aligns with the opportunities page rule.

## Verification
- [x] `bun test apps/server/src/routers/reports.test.ts`
- [x] `git diff --check`
- [x] SQL sanity check against production data: June report total excluding migrate = 1687

## Notes
`bun run check-types` still fails on existing unrelated repo issues/dependencies (e.g. missing SDK packages and existing ORPC/web type errors). Biome script/config is also currently incompatible in this checkout; no formatting issues were detected by `git diff --check`.
