### PR TITLE
fix(crm): consolidate sales report metrics and presets

### DIFF
--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -3,6 +3,7 @@ import {
 	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
 	enforceClosedCreditReportLimit,
 	isClosedCreditReportCarteraStatusIncluded,
+	isPorcentajeEfectividadPeriodCloseIncluded,
 	isPorcentajeEfectividadOpportunityStatusIncluded,
 } from "./reports";
 
@@ -36,6 +37,38 @@ describe("isPorcentajeEfectividadOpportunityStatusIncluded", () => {
 		expect(isPorcentajeEfectividadOpportunityStatusIncluded("migrate")).toBe(
 			false,
 		);
+	});
+});
+
+describe("isPorcentajeEfectividadPeriodCloseIncluded", () => {
+	test("includes only first closes inside the selected period and excludes migrated opportunities", () => {
+		const start = new Date("2026-06-01T00:00:00.000-06:00");
+		const end = new Date("2026-06-30T23:59:59.999-06:00");
+
+		expect(
+			isPorcentajeEfectividadPeriodCloseIncluded(
+				"won",
+				new Date("2026-06-15T10:00:00.000-06:00"),
+				start,
+				end,
+			),
+		).toBe(true);
+		expect(
+			isPorcentajeEfectividadPeriodCloseIncluded(
+				"won",
+				new Date("2026-05-31T23:59:59.999-06:00"),
+				start,
+				end,
+			),
+		).toBe(false);
+		expect(
+			isPorcentajeEfectividadPeriodCloseIncluded(
+				"migrate",
+				new Date("2026-06-15T10:00:00.000-06:00"),
+				start,
+				end,
+			),
+		).toBe(false);
 	});
 });
 

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -3,6 +3,7 @@ import {
 	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
 	enforceClosedCreditReportLimit,
 	isClosedCreditReportCarteraStatusIncluded,
+	isPorcentajeEfectividadOpportunityStatusIncluded,
 } from "./reports";
 
 describe("isClosedCreditReportCarteraStatusIncluded", () => {
@@ -20,6 +21,20 @@ describe("CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE", () => {
 	test("keeps status lookups on the GET path because bulk POST requires estado", () => {
 		expect(CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE).toBeLessThanOrEqual(
 			50,
+		);
+	});
+});
+
+describe("isPorcentajeEfectividadOpportunityStatusIncluded", () => {
+	test("excludes migrated opportunities from effectiveness report totals", () => {
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("open")).toBe(true);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("won")).toBe(true);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("lost")).toBe(true);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("on_hold")).toBe(
+			true,
+		);
+		expect(isPorcentajeEfectividadOpportunityStatusIncluded("migrate")).toBe(
+			false,
 		);
 	});
 });

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -1,5 +1,5 @@
 import { ORPCError } from "@orpc/server";
-import { and, count, desc, eq, gte, lt, lte, sql, sum } from "drizzle-orm";
+import { and, count, desc, eq, gte, lt, lte, ne, sql, sum } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { auctionVehicles } from "../db/schema/auctionVehicles";
@@ -56,6 +56,7 @@ const CLOSED_CREDIT_REPORT_CARTERA_STATUSES: StatusCreditEnum[] = [
 	"MOROSO",
 	"EN_CONVENIO",
 ];
+const MIGRATED_OPPORTUNITY_STATUS = "migrate";
 export const CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE = 50;
 
 export function isClosedCreditReportCarteraStatusIncluded(
@@ -73,6 +74,12 @@ export function enforceClosedCreditReportLimit<T>(rows: T[]) {
 				"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
 		});
 	}
+}
+
+export function isPorcentajeEfectividadOpportunityStatusIncluded(
+	status: string | null,
+) {
+	return status !== MIGRATED_OPPORTUNITY_STATUS;
 }
 
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
@@ -546,6 +553,7 @@ export const getReportePorcentajeEfectividad =
 			const baseWhere = and(
 				gte(opportunities.createdAt, start),
 				lte(opportunities.createdAt, end),
+				ne(opportunities.status, MIGRATED_OPPORTUNITY_STATUS),
 			);
 
 			const totalCerradas = sql<number>`COUNT(${everClosed.opportunityId})`;

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -82,6 +82,19 @@ export function isPorcentajeEfectividadOpportunityStatusIncluded(
 	return status !== MIGRATED_OPPORTUNITY_STATUS;
 }
 
+export function isPorcentajeEfectividadPeriodCloseIncluded(
+	status: string | null,
+	firstClosedAt: Date,
+	start: Date,
+	end: Date,
+) {
+	return (
+		isPorcentajeEfectividadOpportunityStatusIncluded(status) &&
+		firstClosedAt >= start &&
+		firstClosedAt <= end
+	);
+}
+
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
 	const start = new Date(`${startDate}T00:00:00.000-06:00`);
 	const end = new Date(`${endDate}T23:59:59.999-06:00`);
@@ -550,6 +563,23 @@ export const getReportePorcentajeEfectividad =
 				.groupBy(opportunityStageHistory.opportunityId)
 				.as("ever_closed");
 
+			const firstClosedStageDates = db
+				.select({
+					opportunityId: opportunityStageHistory.opportunityId,
+					firstClosedStageAt:
+						sql<Date>`MIN(${opportunityStageHistory.changedAt})`.as(
+							"first_closed_stage_at",
+						),
+				})
+				.from(opportunityStageHistory)
+				.innerJoin(
+					salesStages,
+					eq(opportunityStageHistory.toStageId, salesStages.id),
+				)
+				.where(gte(salesStages.closurePercentage, CLOSED_STAGE_THRESHOLD))
+				.groupBy(opportunityStageHistory.opportunityId)
+				.as("first_closed_stage_dates");
+
 			const baseWhere = and(
 				gte(opportunities.createdAt, start),
 				lte(opportunities.createdAt, end),
@@ -559,50 +589,66 @@ export const getReportePorcentajeEfectividad =
 			const totalCerradas = sql<number>`COUNT(${everClosed.opportunityId})`;
 			const porcentaje = sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
 
-			const [totalRows, porFuente, registrosRaw] = await Promise.all([
-				db
-					.select({
-						totalOportunidades: count(opportunities.id),
-						totalCerradas,
-						porcentaje,
-					})
-					.from(opportunities)
-					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-					.where(baseWhere),
+			const [totalRows, periodCloseRows, porFuente, registrosRaw] =
+				await Promise.all([
+					db
+						.select({
+							totalOportunidades: count(opportunities.id),
+							totalCerradas,
+							porcentaje,
+						})
+						.from(opportunities)
+						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+						.where(baseWhere),
 
-				db
-					.select({
-						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-						totalOportunidades: count(opportunities.id),
-						totalCerradas,
-						porcentaje,
-					})
-					.from(opportunities)
-					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-					.where(baseWhere)
-					.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
-					.orderBy(desc(count(opportunities.id))),
+					db
+						.select({ totalCierresPeriodo: count(opportunities.id) })
+						.from(firstClosedStageDates)
+						.innerJoin(
+							opportunities,
+							eq(firstClosedStageDates.opportunityId, opportunities.id),
+						)
+						.where(
+							and(
+								gte(firstClosedStageDates.firstClosedStageAt, start),
+								lte(firstClosedStageDates.firstClosedStageAt, end),
+								ne(opportunities.status, MIGRATED_OPPORTUNITY_STATUS),
+							),
+						),
 
-				db
-					.select({
-						id: opportunities.id,
-						createdAt: opportunities.createdAt,
-						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-						nombre: sql<
-							string | null
-						>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
-						etapaNombre: salesStages.name,
-						etapaPorcentaje: salesStages.closurePercentage,
-						cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
-					})
-					.from(opportunities)
-					.leftJoin(leads, eq(opportunities.leadId, leads.id))
-					.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
-					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-					.where(baseWhere)
-					.orderBy(desc(opportunities.createdAt))
-					.limit(MAX_REPORT_ROWS + 1),
-			]);
+					db
+						.select({
+							source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
+							totalOportunidades: count(opportunities.id),
+							totalCerradas,
+							porcentaje,
+						})
+						.from(opportunities)
+						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+						.where(baseWhere)
+						.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
+						.orderBy(desc(count(opportunities.id))),
+
+					db
+						.select({
+							id: opportunities.id,
+							createdAt: opportunities.createdAt,
+							source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
+							nombre: sql<
+								string | null
+							>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
+							etapaNombre: salesStages.name,
+							etapaPorcentaje: salesStages.closurePercentage,
+							cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
+						})
+						.from(opportunities)
+						.leftJoin(leads, eq(opportunities.leadId, leads.id))
+						.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
+						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+						.where(baseWhere)
+						.orderBy(desc(opportunities.createdAt))
+						.limit(MAX_REPORT_ROWS + 1),
+				]);
 
 			if (registrosRaw.length > MAX_REPORT_ROWS) {
 				throw new ORPCError("BAD_REQUEST", {
@@ -615,6 +661,8 @@ export const getReportePorcentajeEfectividad =
 				total: {
 					totalOportunidades: totalRows[0]?.totalOportunidades ?? 0,
 					totalCerradas: totalRows[0]?.totalCerradas ?? 0,
+					totalCierresPeriodo:
+						periodCloseRows[0]?.totalCierresPeriodo ?? 0,
 					porcentaje: totalRows[0]?.porcentaje ?? 0,
 				},
 				porFuente: porFuente.map((row) => ({

--- a/apps/crm/apps/web/src/components/reports/range-preset-filter.test.ts
+++ b/apps/crm/apps/web/src/components/reports/range-preset-filter.test.ts
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, setSystemTime, test } from "bun:test";
+import { DEFAULT_PRESET, rangeForPreset } from "./range-preset-filter";
+
+describe("rangeForPreset", () => {
+	afterEach(() => setSystemTime());
+
+	test("lastMonth returns the previous calendar month in Guatemala time", () => {
+		setSystemTime(new Date("2026-07-15T12:00:00.000Z"));
+		const range = rangeForPreset("lastMonth");
+
+		expect(range.from?.toISOString()).toBe("2026-06-01T06:00:00.000Z");
+		expect(range.to?.toISOString()).toBe("2026-07-01T05:59:59.999Z");
+	});
+
+	test("keeps Este mes as the default preset", () => {
+		expect(DEFAULT_PRESET).toBe("month");
+	});
+});

--- a/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
+++ b/apps/crm/apps/web/src/components/reports/range-preset-filter.tsx
@@ -6,17 +6,18 @@ import { Button } from "@/components/ui/button";
 
 const GUATEMALA_TZ = "America/Guatemala";
 
-export type PresetKey = "month" | "3m" | "6m" | "ytd" | "custom";
+export type PresetKey = "month" | "lastMonth" | "3m" | "6m" | "ytd" | "custom";
 
 const RANGE_PRESETS: { key: PresetKey; label: string }[] = [
 	{ key: "month", label: "Este mes" },
+	{ key: "lastMonth", label: "Mes pasado" },
 	{ key: "3m", label: "Últimos 3 meses" },
 	{ key: "6m", label: "Últimos 6 meses" },
 	{ key: "ytd", label: "Este año" },
 	{ key: "custom", label: "Personalizado" },
 ];
 
-export const DEFAULT_PRESET: PresetKey = "3m";
+export const DEFAULT_PRESET: PresetKey = "month";
 
 /** Año/mes de hoy en zona Guatemala (evita corrimientos por la TZ del navegador). */
 function gtYearMonth(): { year: number; month: number } {
@@ -45,6 +46,13 @@ export function rangeForPreset(key: PresetKey): DateRange {
 			// para que coincida con la serialización en zona Guatemala del caller.
 			const { year, month } = gtYearMonth();
 			return { from: gtMidnight(year, month, 1), to: today };
+		}
+		case "lastMonth": {
+			const { year, month } = gtYearMonth();
+			const fromYear = month === 1 ? year - 1 : year;
+			const fromMonth = month === 1 ? 12 : month - 1;
+			const to = new Date(gtMidnight(year, month, 1).getTime() - 1);
+			return { from: gtMidnight(fromYear, fromMonth, 1), to };
 		}
 		case "6m":
 			return { from: subMonths(today, 6), to: today };

--- a/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
@@ -69,38 +69,35 @@ function RouteComponent() {
 
 	if (!canAny) return null;
 
-	const defaultTab = canTiempo
-		? "tiempo"
+	const defaultTab = canMeta
+		? "meta"
 		: canEfectividad
 			? "efectividad"
-			: "meta";
+			: "tiempo";
 
 	return (
 		<div className="container mx-auto space-y-6 p-6">
 			<div>
 				<h1 className="font-bold text-3xl tracking-tight">Reportes</h1>
 				<p className="mt-1 text-muted-foreground">
-					Reportes de ventas: tiempo de cierre, efectividad y meta de
-					colocación.
+					Reportes de ventas: colocación, efectividad y tiempo de cierre.
 				</p>
 			</div>
 
 			<Tabs defaultValue={defaultTab} className="space-y-6">
 				<TabsList>
-					{canTiempo && (
-						<TabsTrigger value="tiempo">Tiempo Cierre Crédito</TabsTrigger>
-					)}
+					{canMeta && <TabsTrigger value="meta">Colocación</TabsTrigger>}
 					{canEfectividad && (
-						<TabsTrigger value="efectividad">Porcentaje Efectividad</TabsTrigger>
+						<TabsTrigger value="efectividad">Efectividad</TabsTrigger>
 					)}
-					{canMeta && (
-						<TabsTrigger value="meta">Meta Colocación</TabsTrigger>
+					{canTiempo && (
+						<TabsTrigger value="tiempo">Tiempo de cierre</TabsTrigger>
 					)}
 				</TabsList>
 
-				{canTiempo && (
-					<TabsContent value="tiempo" className="space-y-6">
-						<TiempoCierreContent />
+				{canMeta && (
+					<TabsContent value="meta" className="space-y-6">
+						<MetaColocacionContent />
 					</TabsContent>
 				)}
 				{canEfectividad && (
@@ -108,9 +105,9 @@ function RouteComponent() {
 						<PorcentajeEfectividadContent />
 					</TabsContent>
 				)}
-				{canMeta && (
-					<TabsContent value="meta" className="space-y-6">
-						<MetaColocacionContent />
+				{canTiempo && (
+					<TabsContent value="tiempo" className="space-y-6">
+						<TiempoCierreContent />
 					</TabsContent>
 				)}
 			</Tabs>

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -260,8 +260,8 @@ export function PorcentajeEfectividadContent() {
 					Porcentaje Efectividad
 				</h1>
 				<p className="mt-1 text-muted-foreground">
-					Oportunidades creadas en el período y si alcanzaron cierre (90%+), con
-					resumen de conversión por fuente. Excluye oportunidades migradas.
+					Oportunidades creadas, cierres del período y conversión por fuente.
+					Excluye oportunidades migradas.
 				</p>
 			</div>
 
@@ -273,21 +273,21 @@ export function PorcentajeEfectividadContent() {
 			{/* ── Resumen estadístico ── */}
 			<div className="grid gap-4 md:grid-cols-3">
 				<ReportCard
-					title="Oportunidades Creadas"
+					title="Oportunidades abiertas"
 					value={isLoading ? "—" : (data?.total.totalOportunidades ?? 0)}
-					description="Total del período, sin migradas"
+					description="Creadas en el período, sin migradas"
 					icon={Activity}
 				/>
 				<ReportCard
-					title="Créditos Cerrados"
-					value={isLoading ? "—" : (data?.total.totalCerradas ?? 0)}
-					description="Oportunidades que alcanzaron etapa 90%+"
+					title="Cierres del período"
+					value={isLoading ? "—" : (data?.total.totalCierresPeriodo ?? 0)}
+					description="Primer cierre 90%+ en el rango"
 					icon={CheckCircle2}
 				/>
 				<ReportCard
 					title="Efectividad Global"
 					value={isLoading ? "—" : `${data?.total.porcentaje ?? 0}%`}
-					description="Tasa de conversión total del período"
+					description={`Cohorte creada: ${data?.total.totalCerradas ?? 0} cerradas`}
 					icon={Target}
 				/>
 			</div>

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -261,7 +261,7 @@ export function PorcentajeEfectividadContent() {
 				</h1>
 				<p className="mt-1 text-muted-foreground">
 					Oportunidades creadas en el período y si alcanzaron cierre (90%+), con
-					resumen de conversión por fuente.
+					resumen de conversión por fuente. Excluye oportunidades migradas.
 				</p>
 			</div>
 
@@ -275,7 +275,7 @@ export function PorcentajeEfectividadContent() {
 				<ReportCard
 					title="Oportunidades Creadas"
 					value={isLoading ? "—" : (data?.total.totalOportunidades ?? 0)}
-					description="Total en el período seleccionado"
+					description="Total del período, sin migradas"
 					icon={Activity}
 				/>
 				<ReportCard


### PR DESCRIPTION
## Summary
- Aligns `Porcentaje Efectividad` with the opportunities page by excluding migrated opportunities from totals, source breakdowns, and records.
- Splits the effectiveness summary into separate cards for:
  - `Oportunidades abiertas` / created in the selected period.
  - `Cierres del período` / first reached 90%+ in the selected period.
  - `Efectividad Global` / conversion for the created cohort.
- Keeps `Este mes` as the default report date preset.
- Adds a `Mes pasado` preset for previous calendar month in Guatemala time.
- Reorders sales report tabs to: `Colocación`, `Efectividad`, `Tiempo de cierre`.

## Why
Sales reports and the opportunities page were showing different totals because the effectiveness report included `status = "migrate"` while the opportunities page excludes them. Also, the UI was conflating two different metrics: opportunities created in the period vs. opportunities closed in the period.

For June 2026, this separates the concepts clearly:
- Created/opened in period, excluding migrated: `1687`
- Closed in period: `114`
- Created in period and eventually closed: `71`

## Verification
- [x] `bun test apps/server/src/routers/reports.test.ts apps/web/src/components/reports/range-preset-filter.test.ts`
- [x] `git diff --check`
- [x] Verified no `as any` added in the diff

## Notes
`bun run check-types` is still noisy in this repo due to existing unrelated type/dependency issues, so this PR includes focused regression coverage for the touched report/date helpers.
