### PR TITLE
fix(cartera): guardar email_cash_in del asesor al crear y editar

### DIFF
--- a/apps/cartera-back/src/controllers/advisor.ts
+++ b/apps/cartera-back/src/controllers/advisor.ts
@@ -4,12 +4,9 @@ import { asesores, creditos, moras_credito, platform_users, usuarios } from '../
 import { and, eq, like, or, sql } from 'drizzle-orm';
 import bcrypt from "bcrypt";
 import Big from 'big.js';
-
 // 🔥 Mismo valor normalizado (trim + minúsculas) para asesores.email_cash_in y platform_users.email:
 // los filtros de cobro (reportes.ts, /stats) comparan por igualdad exacta contra el email de sesión.
-// Whitespace-only o no-string → undefined (se rechaza en create y se ignora en update).
-const normalizeEmail = (email: unknown): string | undefined =>
-  typeof email === "string" ? email.trim().toLowerCase() || undefined : undefined;
+import { normalizeEmail } from '../utils/functions/email';
 
 export const insertAdvisor = async ({ body, set }: any) => {
   try {

--- a/apps/cartera-back/src/controllers/advisor.ts
+++ b/apps/cartera-back/src/controllers/advisor.ts
@@ -4,9 +4,16 @@ import { asesores, creditos, moras_credito, platform_users, usuarios } from '../
 import { and, eq, like, or, sql } from 'drizzle-orm';
 import bcrypt from "bcrypt";
 import Big from 'big.js';
+
+// 🔥 Mismo valor normalizado (trim + minúsculas) para asesores.email_cash_in y platform_users.email:
+// los filtros de cobro (reportes.ts, /stats) comparan por igualdad exacta contra el email de sesión.
+// Whitespace-only o no-string → undefined (se rechaza en create y se ignora en update).
+const normalizeEmail = (email: unknown): string | undefined =>
+  typeof email === "string" ? email.trim().toLowerCase() || undefined : undefined;
+
 export const insertAdvisor = async ({ body, set }: any) => {
   try {
-    let asesoresToInsert = [];
+    let asesoresToInsert: any[] = [];
 
     // Permitir objeto único o array
     if (Array.isArray(body)) {
@@ -17,7 +24,7 @@ export const insertAdvisor = async ({ body, set }: any) => {
 
     // Validar que todos tengan nombre y correo
     const isValid = asesoresToInsert.every(
-      (a) => a.nombre && a.email && a.password
+      (a) => a.nombre && normalizeEmail(a.email) && a.password
     );
     if (!isValid || asesoresToInsert.length === 0) {
       set.status = 400;
@@ -26,36 +33,41 @@ export const insertAdvisor = async ({ body, set }: any) => {
       };
     }
 
-    // Insertar asesores
-    const insertedAdvisors = await db
-      .insert(asesores)
-      .values(
-        asesoresToInsert.map(({ nombre, activo, telefono, activo_para_creditos, email }) => ({ // 🔥 Agregado telefono
-          nombre,
-          telefono: telefono?.trim() || null, // 🔥 NUEVO: Limpia o pone null
-          // 🔥 Los reportes/correos de cobro leen asesores.email_cash_in, no platform_users.email
-          emailCashIn: email?.trim() || null,
-          activo: typeof activo !== "undefined" ? activo : true,
-          // 🔥 default true: el asesor entra al balanceo salvo que se indique lo contrario.
-          // Solo un boolean explícito lo cambia (null/otros tipos caen a true; la columna es NOT NULL).
-          activo_para_creditos: typeof activo_para_creditos === "boolean" ? activo_para_creditos : true,
-        }))
-      )
-      .returning();
+    // 🔥 Asesor + login en una sola transacción: sin ella, un fallo en platform_users
+    // (email duplicado UNIQUE) dejaba asesores huérfanos sin login que sí entraban al balanceo.
+    const insertedAdvisors = await db.transaction(async (tx) => {
+      const inserted = await tx
+        .insert(asesores)
+        .values(
+          asesoresToInsert.map(({ nombre, activo, telefono, activo_para_creditos, email }) => ({ // 🔥 Agregado telefono
+            nombre,
+            telefono: telefono?.trim() || null, // 🔥 NUEVO: Limpia o pone null
+            // 🔥 Los reportes/correos de cobro leen asesores.email_cash_in, no platform_users.email
+            emailCashIn: normalizeEmail(email) || null,
+            activo: typeof activo !== "undefined" ? activo : true,
+            // 🔥 default true: el asesor entra al balanceo salvo que se indique lo contrario.
+            // Solo un boolean explícito lo cambia (null/otros tipos caen a true; la columna es NOT NULL).
+            activo_para_creditos: typeof activo_para_creditos === "boolean" ? activo_para_creditos : true,
+          }))
+        )
+        .returning();
 
-    // Insertar en platform_users (uno por cada asesor)
-    for (let i = 0; i < insertedAdvisors.length; i++) {
-      const asesor = insertedAdvisors[i];
-      const { email, password } = asesoresToInsert[i];
+      // Insertar en platform_users (uno por cada asesor)
+      for (let i = 0; i < inserted.length; i++) {
+        const asesor = inserted[i];
+        const { email, password } = asesoresToInsert[i];
 
-      await db.insert(platform_users).values({
-        email,
-        password_hash: await bcrypt.hash(password, 10),
-        role: "ASESOR",
-        is_active: true,
-        asesor_id: asesor.asesor_id,
-      });
-    }
+        await tx.insert(platform_users).values({
+          email: normalizeEmail(email)!,
+          password_hash: await bcrypt.hash(password, 10),
+          role: "ASESOR",
+          is_active: true,
+          asesor_id: asesor.asesor_id,
+        });
+      }
+
+      return inserted;
+    });
 
     set.status = 201;
     return insertedAdvisors;
@@ -223,6 +235,8 @@ export const updateAdvisor = async ({ query, body, set }: any) => {
     }
 
     const { nombre, telefono, activo, email, password, activo_para_creditos } = body; // ✅ Ya tiene telefono
+    // 🔥 email normalizado UNA vez: el mismo valor va a asesores.email_cash_in y platform_users.email
+    const emailNorm = normalizeEmail(email);
 
     // 1. Buscar el usuario en platform_users
     const [user] = await db
@@ -239,35 +253,51 @@ export const updateAdvisor = async ({ query, body, set }: any) => {
       set.status = 400;
       return { message: "El usuario no tiene un asesor_id asociado." };
     }
+    const asesorId = user.asesor_id;
 
-    // 2. Actualizar tabla asesores usando el asesor_id
-    const updatedAdvisor = await db
-      .update(asesores)
-      .set({
-        ...(nombre !== undefined ? { nombre } : {}),
-        ...(telefono !== undefined ? { telefono } : {}), // ✅ Ya tiene telefono
-        // 🔥 Mantener email_cash_in en sync con platform_users.email (lo leen los reportes de cobro)
-        ...(email ? { emailCashIn: email.trim() } : {}),
-        ...(activo !== undefined ? { activo } : {}),
-        ...(activo_para_creditos !== undefined ? { activo_para_creditos } : {}), // 🔥 flag balanceo
-      })
-      .where(eq(asesores.asesor_id, user.asesor_id))
-      .returning();
+    // 2. Cambios para asesores
+    const advisorChanges = {
+      ...(nombre !== undefined ? { nombre } : {}),
+      ...(telefono !== undefined ? { telefono } : {}), // ✅ Ya tiene telefono
+      // 🔥 Mantener email_cash_in en sync con platform_users.email (lo leen los reportes de cobro)
+      ...(emailNorm ? { emailCashIn: emailNorm } : {}),
+      ...(activo !== undefined ? { activo } : {}),
+      ...(activo_para_creditos !== undefined ? { activo_para_creditos } : {}), // 🔥 flag balanceo
+    };
 
     // 3. Preparar update para platform_users
     const updateUser: any = {};
-    if (email) updateUser.email = email;
+    if (emailNorm) updateUser.email = emailNorm;
     if (password) {
       updateUser.password_hash = await bcrypt.hash(password, 10);
     }
     if (typeof activo !== "undefined") updateUser.is_active = activo;
 
-    if (Object.keys(updateUser).length > 0) {
-      await db
-        .update(platform_users)
-        .set(updateUser)
-        .where(eq(platform_users.id, Number(id)));
-    }
+    // 🔥 Ambas tablas en una sola transacción: sin ella, un fallo en platform_users
+    // (email UNIQUE) dejaba email_cash_in ya cambiado y el login con el email viejo.
+    const updatedAdvisor = await db.transaction(async (tx) => {
+      // .set({}) vacío tira "No values to set" (ej. body solo con password)
+      const updated =
+        Object.keys(advisorChanges).length > 0
+          ? await tx
+              .update(asesores)
+              .set(advisorChanges)
+              .where(eq(asesores.asesor_id, asesorId))
+              .returning()
+          : await tx
+              .select()
+              .from(asesores)
+              .where(eq(asesores.asesor_id, asesorId));
+
+      if (Object.keys(updateUser).length > 0) {
+        await tx
+          .update(platform_users)
+          .set(updateUser)
+          .where(eq(platform_users.id, Number(id)));
+      }
+
+      return updated;
+    });
 
     set.status = 200;
     return {

--- a/apps/cartera-back/src/controllers/advisor.ts
+++ b/apps/cartera-back/src/controllers/advisor.ts
@@ -30,9 +30,11 @@ export const insertAdvisor = async ({ body, set }: any) => {
     const insertedAdvisors = await db
       .insert(asesores)
       .values(
-        asesoresToInsert.map(({ nombre, activo, telefono, activo_para_creditos }) => ({ // 🔥 Agregado telefono
+        asesoresToInsert.map(({ nombre, activo, telefono, activo_para_creditos, email }) => ({ // 🔥 Agregado telefono
           nombre,
           telefono: telefono?.trim() || null, // 🔥 NUEVO: Limpia o pone null
+          // 🔥 Los reportes/correos de cobro leen asesores.email_cash_in, no platform_users.email
+          emailCashIn: email?.trim() || null,
           activo: typeof activo !== "undefined" ? activo : true,
           // 🔥 default true: el asesor entra al balanceo salvo que se indique lo contrario.
           // Solo un boolean explícito lo cambia (null/otros tipos caen a true; la columna es NOT NULL).
@@ -244,6 +246,8 @@ export const updateAdvisor = async ({ query, body, set }: any) => {
       .set({
         ...(nombre !== undefined ? { nombre } : {}),
         ...(telefono !== undefined ? { telefono } : {}), // ✅ Ya tiene telefono
+        // 🔥 Mantener email_cash_in en sync con platform_users.email (lo leen los reportes de cobro)
+        ...(email ? { emailCashIn: email.trim() } : {}),
         ...(activo !== undefined ? { activo } : {}),
         ...(activo_para_creditos !== undefined ? { activo_para_creditos } : {}), // 🔥 flag balanceo
       })

--- a/apps/cartera-back/src/controllers/auth.ts
+++ b/apps/cartera-back/src/controllers/auth.ts
@@ -1,5 +1,5 @@
  
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import bcrypt from "bcrypt";
 import { admins, asesores, conta_users, platform_users } from "../database/db";
 import { db } from "../database";
@@ -64,11 +64,12 @@ export async function createPlatformUserService(data: {
 const JWT_SECRET = process.env.JWT_SECRET || "supersecreto"; // ⚠️ ponelo en tu .env
 const JWT_REFRESH_SECRET = process.env.JWT_REFRESH_SECRET || "supersecreto";
 export async function loginService(email: string, password: string) {
-  // 1. Buscar usuario por email
+  // 1. Buscar usuario por email (case/espacios-insensible: los asesores nuevos
+  // se guardan normalizados a minúsculas, los registros viejos pueden no estarlo)
   const [user] = await db
     .select()
     .from(platform_users)
-    .where(eq(platform_users.email, email))
+    .where(sql`LOWER(${platform_users.email}) = ${email.trim().toLowerCase()}`)
     .limit(1);
 
   if (!user) {

--- a/apps/cartera-back/src/controllers/auth.ts
+++ b/apps/cartera-back/src/controllers/auth.ts
@@ -17,26 +17,28 @@ export async function createAdminService(data: {
   // 1. Hashear contraseña
   const passwordHash = await bcrypt.hash(data.password, 10);
 
-  // 2. Insertar admin
-  const [newAdmin] = await db
-    .insert(admins)
-    .values({
-      nombre: data.nombre,
-      apellido: data.apellido,
+  // 2+3. Admin + login en una sola transacción: un email duplicado en
+  // platform_users no debe dejar un admin huérfano sin login
+  return await db.transaction(async (tx) => {
+    const [newAdmin] = await tx
+      .insert(admins)
+      .values({
+        nombre: data.nombre,
+        apellido: data.apellido,
+        email: normalizeEmail(data.email)!,
+        telefono: data.telefono ?? null,
+      })
+      .returning();
+
+    await tx.insert(platform_users).values({
       email: normalizeEmail(data.email)!,
-      telefono: data.telefono ?? null,
-    })
-    .returning();
+      password_hash: passwordHash,
+      role: "ADMIN",
+      admin_id: newAdmin.admin_id,
+    });
 
-  // 3. Insertar en platform_users
-  await db.insert(platform_users).values({
-    email: normalizeEmail(data.email)!,
-    password_hash: passwordHash,
-    role: "ADMIN",
-    admin_id: newAdmin.admin_id,
+    return newAdmin;
   });
-
-  return newAdmin;
 }
 export async function createPlatformUserService(data: {
   email: string;

--- a/apps/cartera-back/src/controllers/auth.ts
+++ b/apps/cartera-back/src/controllers/auth.ts
@@ -4,6 +4,9 @@ import bcrypt from "bcrypt";
 import { admins, asesores, conta_users, platform_users } from "../database/db";
 import { db } from "../database";
 import jwt from "jsonwebtoken";
+// 🔥 platform_users.email se guarda SIEMPRE normalizado (trim+minúsculas) en todos los
+// writers, para que el login case-insensitive nunca encuentre duplicados por casing
+import { normalizeEmail } from "../utils/functions/email";
 export async function createAdminService(data: {
   nombre: string;
   apellido: string;
@@ -20,14 +23,14 @@ export async function createAdminService(data: {
     .values({
       nombre: data.nombre,
       apellido: data.apellido,
-      email: data.email,
+      email: normalizeEmail(data.email)!,
       telefono: data.telefono ?? null,
     })
     .returning();
 
   // 3. Insertar en platform_users
   await db.insert(platform_users).values({
-    email: data.email,
+    email: normalizeEmail(data.email)!,
     password_hash: passwordHash,
     role: "ADMIN",
     admin_id: newAdmin.admin_id,
@@ -49,7 +52,7 @@ export async function createPlatformUserService(data: {
   const [newUser] = await db
     .insert(platform_users)
     .values({
-      email: data.email,
+      email: normalizeEmail(data.email)!,
       password_hash: passwordHash,
       role: data.role,
       admin_id: data.admin_id ?? null,
@@ -198,8 +201,8 @@ export async function createContaService(data: {
       const [newConta] = await tx
         .insert(conta_users)
         .values({
-          nombre: data.nombre, 
-          email: data.email,
+          nombre: data.nombre,
+          email: normalizeEmail(data.email)!,
           telefono: data.telefono ?? null,
         })
         .returning();
@@ -214,7 +217,7 @@ export async function createContaService(data: {
       const [newUser] = await tx
         .insert(platform_users)
         .values({
-          email: data.email,
+          email: normalizeEmail(data.email)!,
           password_hash: passwordHash,
           role: "CONTA",
           conta_id: newConta.conta_id,
@@ -259,8 +262,9 @@ export async function updateContaUserService(
       console.log("🔎 Usuario encontrado en platform_users:", user);
 
       // 2. Actualizar platform_users
+      const emailNorm = normalizeEmail(updates.email);
       const userUpdates: any = {};
-      if (updates.email) userUpdates.email = updates.email;
+      if (emailNorm) userUpdates.email = emailNorm;
       if (updates.password)
         userUpdates.password_hash = await bcrypt.hash(updates.password, 10);
       if (typeof updates.is_active !== "undefined")
@@ -278,7 +282,7 @@ export async function updateContaUserService(
       // 3. Actualizar conta_users usando el conta_id que trae platform_users
       const contaUpdates: any = {};
       if (updates.nombre) contaUpdates.nombre = updates.nombre;
-      if (updates.email) contaUpdates.email = updates.email;
+      if (emailNorm) contaUpdates.email = emailNorm;
 
       if (Object.keys(contaUpdates).length > 0 && user.conta_id) {
         await tx

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -2819,7 +2819,8 @@ export const getCreditStats = async (email?: string): Promise<CreditStatsRespons
     const platformUser = await db
       .select({ asesor_id: asesores.asesor_id })
       .from(asesores)
-      .where(eq(asesores.emailCashIn, email))
+      // 🔥 case/espacios-insensible: el email de sesión del CRM puede venir con otro casing
+      .where(sql`LOWER(${asesores.emailCashIn}) = ${email.trim().toLowerCase()}`)
       .limit(1);
 
     if (platformUser.length > 0 && platformUser[0].asesor_id) {

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1226,7 +1226,7 @@ export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?:
     INNER JOIN cartera.creditos c ON c.credito_id = m.credito_id
     INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
     WHERE c."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
-      ${emailCobrador ? sql`AND a.email_cash_in = ${emailCobrador}` : sql``}
+      ${emailCobrador ? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))` : sql``}
     GROUP BY a.asesor_id, a.nombre, a.email_cash_in, bucket
   `);
 

--- a/apps/cartera-back/src/utils/functions/email.ts
+++ b/apps/cartera-back/src/utils/functions/email.ts
@@ -1,0 +1,7 @@
+// 🔥 Normalización canónica de emails (trim + minúsculas), compartida por TODOS los
+// writers de platform_users.email / asesores.email_cash_in y por los lookups de login.
+// Los filtros de cobro comparan por igualdad exacta contra el email de sesión, así que
+// cualquier writer que no normalice vuelve a desincronizar las columnas.
+// Whitespace-only o no-string → undefined (rechazar en creates, ignorar en updates).
+export const normalizeEmail = (email: unknown): string | undefined =>
+  typeof email === "string" ? email.trim().toLowerCase() || undefined : undefined;


### PR DESCRIPTION
## Problema

Los asesores creados desde la UI de cartera (Gestión de Usuarios) quedan con `asesores.email_cash_in` en NULL, aunque el formulario sí captura el email. Casos reales en prod: Octavio Rosales (id 8) y José Veliz (id 9).

**Causa:** `insertAdvisor` usa el email solo para crear el login en `platform_users` y nunca lo escribe en `asesores.email_cash_in`, que es la columna que leen los reportes/correos de cobro (`getMoraByEtapaYAsesor` filtra por `a.email_cash_in`, `cuotas-por-fecha` expone `asesor_email`). `updateAdvisor` tiene el mismo problema: al cambiar el email solo actualiza `platform_users`, así que ni editando se puede corregir desde la UI.

## Fix

- `insertAdvisor`: al insertar en `asesores` ahora también guarda `emailCashIn` (trim, o NULL).
- `updateAdvisor`: si viene `email` en el body, actualiza `email_cash_in` en `asesores` además de `platform_users.email`, manteniéndolos en sync.

## Datos existentes

Los 2 asesores ya afectados en prod se corrigen con backfill (aparte de este PR):

```sql
UPDATE cartera.asesores a
SET email_cash_in = pu.email
FROM cartera.platform_users pu
WHERE pu.asesor_id = a.asesor_id AND a.email_cash_in IS NULL;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)