### PR TITLE
fix(portal): recalibrar calculadora para rodado usado

### DIFF
--- a/apps/portal-web/scripts/credit-calculator.test.mjs
+++ b/apps/portal-web/scripts/credit-calculator.test.mjs
@@ -106,6 +106,7 @@ const calculatorSource = readFileSync(
 const calculadoraRouteSource = readFileSync("src/routes/calculadora.tsx", "utf8");
 
 assert.match(calculatorSource, /standalone\?: boolean/);
+assert.match(calculatorSource, /useState<string>\("60"\)/);
 assert.match(calculatorSource, /standalone \? "mt-4 lg:mt-8" : "mt-12 lg:mt-64"/);
 assert.match(calculadoraRouteSource, /<CalculatorCredit standalone \/>/);
 

--- a/apps/portal-web/scripts/credit-calculator.test.mjs
+++ b/apps/portal-web/scripts/credit-calculator.test.mjs
@@ -36,27 +36,34 @@ function assertClose(actual, expected, tolerance, label) {
   );
 }
 
-assertClose(getPublicAdjustmentFactor(50_000, 20, 48), 0.3, 0.000001, "factor Q50k");
-assertClose(getPublicAdjustmentFactor(100_000, 20, 48), 0.205, 0.000001, "factor Q100k");
-assertClose(getPublicAdjustmentFactor(200_000, 20, 48), 0.155, 0.000001, "factor Q200k");
+assertClose(getPublicAdjustmentFactor(50_000, 20, 48), 0.562737, 0.000001, "factor Q50k");
+assertClose(getPublicAdjustmentFactor(100_000, 20, 48), 0.474328, 0.000001, "factor Q100k");
+assertClose(getPublicAdjustmentFactor(200_000, 20, 48), 0.430124, 0.000001, "factor Q200k");
 
 assertClose(
   calculatePublicCredit({ vehicleAmount: 50_000, downPaymentPct: 20, termMonths: 48 }).monthlyPayment,
-  1_586.82,
+  1_907.52,
   0.01,
   "Q50k / 20% / 48 meses",
 );
 assertClose(
   calculatePublicCredit({ vehicleAmount: 100_000, downPaymentPct: 20, termMonths: 48 }).monthlyPayment,
-  2_941.71,
+  3_599.21,
   0.01,
   "Q100k / 20% / 48 meses",
 );
 assertClose(
   calculatePublicCredit({ vehicleAmount: 200_000, downPaymentPct: 20, termMonths: 48 }).monthlyPayment,
-  5_639.30,
+  6_982.59,
   0.01,
   "Q200k / 20% / 48 meses",
+);
+
+assertClose(
+  calculatePublicCredit({ vehicleAmount: 150_000, downPaymentPct: 10, termMonths: 60 }).monthlyPayment,
+  5_199.94,
+  0.01,
+  "Q150k / 10% / 60 meses usado rodado particular",
 );
 
 const beforeBoundary = calculatePublicCredit({

--- a/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
+++ b/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
@@ -12,7 +12,7 @@ export const CalculatorCredit = ({ standalone = false }: CalculatorCreditProps) 
 
   const [monto, setMonto] = useState<string>("");
   const [enganche, setEnganche] = useState<string>("10");
-  const [tiempo, setTiempo] = useState<string>("12");
+  const [tiempo, setTiempo] = useState<string>("60");
   const isMobile = useIsMobile();
 
   // Opciones de enganche (porcentajes)

--- a/apps/portal-web/src/features/Marketplace/utils/creditCalculator.ts
+++ b/apps/portal-web/src/features/Marketplace/utils/creditCalculator.ts
@@ -14,35 +14,80 @@ export interface PublicCreditResult {
 const MONTHLY_INTEREST_PCT = 1.5;
 const IVA_FACTOR = 1.12;
 
-const BASE_ADJUSTMENT_POINTS = [
-  { vehicleAmount: 25_000, factor: 0.47 },
-  { vehicleAmount: 50_000, factor: 0.29 },
-  { vehicleAmount: 75_000, factor: 0.225 },
-  { vehicleAmount: 100_000, factor: 0.195 },
-  { vehicleAmount: 150_000, factor: 0.165 },
-  { vehicleAmount: 200_000, factor: 0.145 },
-  { vehicleAmount: 300_000, factor: 0.13 },
-  { vehicleAmount: 400_000, factor: 0.12 },
-  { vehicleAmount: 500_000, factor: 0.115 },
-] as const;
+const REFERENCE_USED_IMPORTED_PRIVATE_COSTS = {
+  monthlyInsuranceAndMembershipPct: 0.00776,
+  monthlyGpsCost: 148.2,
+  transferCost: 545,
+  mobileGuaranteeCost: 400,
+  leasingContractCost: 400,
+  fixedAdminCost: 600,
+  royaltyPct: 4,
+  upfrontInterestPct: 1.78,
+} as const;
 
-function getInterpolatedBaseFactor(vehicleAmount: number) {
-  const firstPoint = BASE_ADJUSTMENT_POINTS[0];
-  const lastPoint = BASE_ADJUSTMENT_POINTS[BASE_ADJUSTMENT_POINTS.length - 1];
+function calculateLevelPayment(
+  principal: number,
+  monthlyRate: number,
+  termMonths: number,
+) {
+  if (monthlyRate === 0) return principal / termMonths;
 
-  if (vehicleAmount <= firstPoint.vehicleAmount) return firstPoint.factor;
-  if (vehicleAmount >= lastPoint.vehicleAmount) return lastPoint.factor;
+  const factor = (1 + monthlyRate) ** termMonths;
+  return (principal * monthlyRate * factor) / (factor - 1);
+}
 
-  const upperIndex = BASE_ADJUSTMENT_POINTS.findIndex(
-    (point) => vehicleAmount <= point.vehicleAmount,
+function calculateBaseMonthlyPayment(
+  vehicleAmount: number,
+  downPaymentPct: number,
+  termMonths: number,
+) {
+  const amountToFinance = vehicleAmount - (vehicleAmount * downPaymentPct) / 100;
+  const monthlyRate = (MONTHLY_INTEREST_PCT / 100) * IVA_FACTOR;
+
+  return calculateLevelPayment(amountToFinance, monthlyRate, termMonths);
+}
+
+function calculateUsedImportedPrivateReferencePayment(
+  vehicleAmount: number,
+  downPaymentPct: number,
+  termMonths: number,
+) {
+  const costs = REFERENCE_USED_IMPORTED_PRIVATE_COSTS;
+  const amountToFinance = vehicleAmount - (vehicleAmount * downPaymentPct) / 100;
+  const monthlyInsuranceAndMembership =
+    vehicleAmount * costs.monthlyInsuranceAndMembershipPct;
+
+  const intermediateBase =
+    amountToFinance +
+    costs.transferCost +
+    costs.mobileGuaranteeCost +
+    costs.leasingContractCost +
+    costs.fixedAdminCost +
+    costs.monthlyGpsCost +
+    monthlyInsuranceAndMembership;
+
+  const royalty = Math.ceil(intermediateBase * (costs.royaltyPct / 100));
+  const upfrontInterest = Math.ceil(
+    intermediateBase * (costs.upfrontInterestPct / 100),
   );
-  const lowerPoint = BASE_ADJUSTMENT_POINTS[upperIndex - 1];
-  const upperPoint = BASE_ADJUSTMENT_POINTS[upperIndex];
-  const progress =
-    (vehicleAmount - lowerPoint.vehicleAmount) /
-    (upperPoint.vehicleAmount - lowerPoint.vehicleAmount);
 
-  return lowerPoint.factor + (upperPoint.factor - lowerPoint.factor) * progress;
+  const adminCost =
+    costs.mobileGuaranteeCost +
+    royalty +
+    costs.leasingContractCost +
+    costs.fixedAdminCost +
+    upfrontInterest +
+    costs.monthlyGpsCost +
+    monthlyInsuranceAndMembership;
+
+  const totalFinanced = amountToFinance + costs.transferCost + adminCost;
+  const monthlyRate = (MONTHLY_INTEREST_PCT / 100) * IVA_FACTOR;
+
+  return (
+    calculateLevelPayment(totalFinanced, monthlyRate, termMonths) +
+    monthlyInsuranceAndMembership +
+    costs.monthlyGpsCost
+  );
 }
 
 export function getPublicAdjustmentFactor(
@@ -50,17 +95,21 @@ export function getPublicAdjustmentFactor(
   downPaymentPct: number,
   termMonths: number,
 ) {
-  const baseFactor = getInterpolatedBaseFactor(vehicleAmount);
+  const baseMonthlyPayment = calculateBaseMonthlyPayment(
+    vehicleAmount,
+    downPaymentPct,
+    termMonths,
+  );
 
-  const termAdjustment =
-    termMonths <= 12 ? -0.035 :
-    termMonths <= 24 ? -0.018 :
-    termMonths <= 36 ? 0 :
-    termMonths <= 48 ? 0.01 :
-    0.02;
+  if (!Number.isFinite(baseMonthlyPayment) || baseMonthlyPayment <= 0) return 0;
 
-  const downPaymentAdjustment = (downPaymentPct - 20) / 1500;
-  return Math.min(0.50, Math.max(0.07, baseFactor + termAdjustment + downPaymentAdjustment));
+  const referenceMonthlyPayment = calculateUsedImportedPrivateReferencePayment(
+    vehicleAmount,
+    downPaymentPct,
+    termMonths,
+  );
+
+  return referenceMonthlyPayment / baseMonthlyPayment - 1;
 }
 
 export function calculatePublicCredit({
@@ -77,11 +126,16 @@ export function calculatePublicCredit({
     };
   }
 
-  const amountToFinance = vehicleAmount - (vehicleAmount * downPaymentPct) / 100;
-  const monthlyRate = (MONTHLY_INTEREST_PCT / 100) * IVA_FACTOR;
-  const factor = (1 + monthlyRate) ** termMonths;
-  const baseMonthlyPayment = (amountToFinance * monthlyRate * factor) / (factor - 1);
-  const adjustmentFactor = getPublicAdjustmentFactor(vehicleAmount, downPaymentPct, termMonths);
+  const baseMonthlyPayment = calculateBaseMonthlyPayment(
+    vehicleAmount,
+    downPaymentPct,
+    termMonths,
+  );
+  const adjustmentFactor = getPublicAdjustmentFactor(
+    vehicleAmount,
+    downPaymentPct,
+    termMonths,
+  );
 
   return {
     interestPct: MONTHLY_INTEREST_PCT,


### PR DESCRIPTION
## Summary
- Recalibra la calculadora pública del portal para asumir por defecto un escenario conservador de vehículo usado, rodado/importado y particular.
- Sustituye la curva genérica anterior por una referencia tipo CRM que incluye seguro/membresía estimada, GPS, traspaso, garantía, leasing, admin, royalty e interés anticipado.
- Agrega regresión para Q150,000 / 10% / 60 meses ≈ Q5,199.94.

## Test plan
- [x] `node scripts/credit-calculator.test.mjs`
- [x] `./node_modules/.bin/tsc -b`
- [x] `node ./node_modules/vite/bin/vite.js build`

## Notes
- No incluye deploy.
- No incluye los scripts de calibración no trackeados ni el documento local de OpenCode.