### PR TITLE
fix(crm): calcular mora de cobros por capital

### DIFF
--- a/apps/crm/apps/server/src/lib/cobros-capital-percentages.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-capital-percentages.test.ts
@@ -68,5 +68,7 @@ describe("cobros capital percentages", () => {
 		expect(porcentaje("mora_90")).toBeCloseTo(2.69, 2);
 		expect(porcentaje("mora_120")).toBeCloseTo(8.24, 2);
 		expect(moraTotal).toBeCloseTo(44.39, 2);
+		expect(porcentaje("incobrable")).toBe(48.9);
+		expect(porcentaje("completado")).toBe(51.1);
 	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-capital-percentages.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-capital-percentages.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { recalculateCobrosCapitalPercentages } from "./cobros-capital-percentages";
+
+describe("cobros capital percentages", () => {
+	test("calculates active mora percentages from capital only", () => {
+		const stats = recalculateCobrosCapitalPercentages([
+			{
+				estadoMora: "al_dia",
+				totalCases: 795,
+				montoTotal: "0",
+				sumaCapital: "89438266.55",
+				porcentaje: "51.9",
+			},
+			{
+				estadoMora: "mora_30",
+				totalCases: 431,
+				montoTotal: "0",
+				sumaCapital: "40729880.38",
+				porcentaje: "28.1",
+			},
+			{
+				estadoMora: "mora_60",
+				totalCases: 139,
+				montoTotal: "0",
+				sumaCapital: "13087520.98",
+				porcentaje: "9.1",
+			},
+			{
+				estadoMora: "mora_90",
+				totalCases: 46,
+				montoTotal: "0",
+				sumaCapital: "4329427.08",
+				porcentaje: "3.0",
+			},
+			{
+				estadoMora: "mora_120",
+				totalCases: 120,
+				montoTotal: "0",
+				sumaCapital: "13250798.62",
+				porcentaje: "7.8",
+			},
+			{
+				estadoMora: "incobrable",
+				totalCases: 43,
+				montoTotal: "0",
+				sumaCapital: "2070165.08",
+				porcentaje: "48.9",
+			},
+			{
+				estadoMora: "completado",
+				totalCases: 45,
+				montoTotal: "0",
+				sumaCapital: "607799.01",
+				porcentaje: "51.1",
+			},
+		]);
+
+		const porcentaje = (estadoMora: string) =>
+			Number(stats.find((stat) => stat.estadoMora === estadoMora)?.porcentaje);
+		const moraTotal = ["mora_30", "mora_60", "mora_90", "mora_120"].reduce(
+			(sum, estadoMora) => sum + porcentaje(estadoMora),
+			0,
+		);
+
+		expect(porcentaje("al_dia")).toBeCloseTo(55.61, 2);
+		expect(porcentaje("mora_30")).toBeCloseTo(25.32, 2);
+		expect(porcentaje("mora_60")).toBeCloseTo(8.14, 2);
+		expect(porcentaje("mora_90")).toBeCloseTo(2.69, 2);
+		expect(porcentaje("mora_120")).toBeCloseTo(8.24, 2);
+		expect(moraTotal).toBeCloseTo(44.39, 2);
+	});
+});

--- a/apps/crm/apps/server/src/lib/cobros-capital-percentages.ts
+++ b/apps/crm/apps/server/src/lib/cobros-capital-percentages.ts
@@ -6,8 +6,6 @@ const ACTIVE_ESTADOS = new Set([
 	"mora_120",
 ]);
 
-const CLOSED_ESTADOS = new Set(["incobrable", "completado"]);
-
 export type CobrosCapitalStats = {
 	estadoMora: string;
 	sumaCapital: string;
@@ -29,17 +27,12 @@ export function recalculateCobrosCapitalPercentages<T extends CobrosCapitalStats
 	stats: readonly T[],
 ) {
 	const activeTotal = capitalTotal(stats, ACTIVE_ESTADOS);
-	const closedTotal = capitalTotal(stats, CLOSED_ESTADOS);
 
 	return stats.map((stat) => {
 		if (ACTIVE_ESTADOS.has(stat.estadoMora)) {
 			return { ...stat, porcentaje: percentage(stat.sumaCapital, activeTotal) };
 		}
 
-		if (CLOSED_ESTADOS.has(stat.estadoMora)) {
-			return { ...stat, porcentaje: percentage(stat.sumaCapital, closedTotal) };
-		}
-
-		return { ...stat, porcentaje: "0" };
+		return stat;
 	});
 }

--- a/apps/crm/apps/server/src/lib/cobros-capital-percentages.ts
+++ b/apps/crm/apps/server/src/lib/cobros-capital-percentages.ts
@@ -1,0 +1,45 @@
+const ACTIVE_ESTADOS = new Set([
+	"al_dia",
+	"mora_30",
+	"mora_60",
+	"mora_90",
+	"mora_120",
+]);
+
+const CLOSED_ESTADOS = new Set(["incobrable", "completado"]);
+
+export type CobrosCapitalStats = {
+	estadoMora: string;
+	sumaCapital: string;
+	porcentaje: string;
+};
+
+function capitalTotal(stats: readonly CobrosCapitalStats[], estados: Set<string>) {
+	return stats
+		.filter((stat) => estados.has(stat.estadoMora))
+		.reduce((sum, stat) => sum + Number(stat.sumaCapital || 0), 0);
+}
+
+function percentage(capital: string, total: number) {
+	if (total <= 0) return "0";
+	return ((Number(capital || 0) / total) * 100).toFixed(2);
+}
+
+export function recalculateCobrosCapitalPercentages<T extends CobrosCapitalStats>(
+	stats: readonly T[],
+) {
+	const activeTotal = capitalTotal(stats, ACTIVE_ESTADOS);
+	const closedTotal = capitalTotal(stats, CLOSED_ESTADOS);
+
+	return stats.map((stat) => {
+		if (ACTIVE_ESTADOS.has(stat.estadoMora)) {
+			return { ...stat, porcentaje: percentage(stat.sumaCapital, activeTotal) };
+		}
+
+		if (CLOSED_ESTADOS.has(stat.estadoMora)) {
+			return { ...stat, porcentaje: percentage(stat.sumaCapital, closedTotal) };
+		}
+
+		return { ...stat, porcentaje: "0" };
+	});
+}

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -44,6 +44,7 @@ import {
 	interpolar as interpolarPlantilla,
 	PLANTILLAS_MENSAJES,
 } from "../lib/cobros-plantillas";
+import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
 import { toDateStrGT } from "../lib/guatemala-month-window";
 import {
@@ -405,7 +406,7 @@ export const cobrosRouter = {
 					});
 
 					// Mapear cuotas atrasadas a estados de mora - usar datos exactos de cartera
-					const estatusStats = [
+					const estatusStats = recalculateCobrosCapitalPercentages([
 						{
 							estadoMora: "al_dia",
 							totalCases: statsResponse.porCuotasAtrasadas["0"]?.cantidad || 0,
@@ -472,7 +473,7 @@ export const cobrosRouter = {
 								statsResponse.porEstado.incobrable?.sumaCapital || "0",
 							porcentaje: statsResponse.porEstado.incobrable?.porcentaje || "0",
 						},
-					];
+					]);
 
 					console.log(
 						"[Cobros] Stats obtenidas desde endpoint /stats:",
@@ -630,10 +631,12 @@ export const cobrosRouter = {
 				);
 
 			return {
-				estatusStats: Object.entries(embudoStats).map(([estado, data]) => ({
-					estadoMora: estado,
-					...data,
-				})),
+				estatusStats: recalculateCobrosCapitalPercentages(
+					Object.entries(embudoStats).map(([estado, data]) => ({
+						estadoMora: estado,
+						...data,
+					})),
+				),
 				totalCasosAsignados: casosAsignados[0]?.count || 0,
 				efectividad: "0",
 				contactosHoy: contactosHoy[0]?.count || 0,

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -969,14 +969,15 @@ function RouteComponent() {
 										? Number.parseFloat(statReal.porcentaje)
 										: undefined;
 
-									// Para mora_total, sumar todas las moras
+									// Para mora_total, sumar sólo moras activas
 									const porcentajeMoraTotal =
 										meta.categoria === "mora_total"
 											? stats
 													.filter(
 														(s) =>
 															s.estadoMora !== "al_dia" &&
-															s.estadoMora !== "completado",
+															s.estadoMora !== "completado" &&
+															s.estadoMora !== "incobrable",
 													)
 													.reduce(
 														(sum, s) =>


### PR DESCRIPTION
## Summary
- Recalcula los porcentajes del dashboard de Cobros con base en `sumaCapital`, no en cantidad de créditos/casos.
- Excluye `incobrable` y `completado` del denominador de cartera activa para metas de mora.
- Corrige la card de `Metas de Mora` para que `Mora Total` sume solo moras activas (`mora_30`, `mora_60`, `mora_90`, `mora_120`).
- Agrega prueba con el caso reportado: `Mora Total ≈ 44.39%` por capital activo.

## Test Plan
- [x] `git diff --check origin/develop...HEAD`
- [x] `bun test apps/server/src/lib/cobros-capital-percentages.test.ts`

## Notes
- `bun run check-types` y `bun run build` siguen fallando por errores/dependencias preexistentes no relacionados en la rama base, por ejemplo `@atlaskit/pragmatic-drag-and-drop/element/adapter`, `@aws-sdk/client-rekognition`, `@cci/email`, `ai`, y errores de tipos existentes en varios módulos.
- El cambio se validó con prueba focal sobre el cálculo nuevo.