### PR TITLE
fix(cartera): centralizar launch de Puppeteer con flags estables para contenedor

### DIFF
--- a/apps/cartera-back/src/controllers/recibosGenericos.ts
+++ b/apps/cartera-back/src/controllers/recibosGenericos.ts
@@ -4,7 +4,7 @@ import {
   recibos_genericos,
   recibo_generico_montos,
 } from "../database/db";
-import puppeteer from "puppeteer";
+import { launchBrowser } from "../utils/functions/browser";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 
 const LOGO_URL = process.env.LOGO_URL || "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
@@ -331,10 +331,7 @@ export async function generateReciboGenericoPDF(reciboId: number) {
   </html>`;
 
   // Generar PDF con Puppeteer
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   const pdfData = await page.pdf({

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1,11 +1,11 @@
 import ExcelJS from "exceljs";
-import puppeteer from "puppeteer";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getCreditosWithUserByMesAnio } from "./credits";
 import { getAllPagosWithCreditAndInversionistas, getPagosConInversionistas } from "./payments";
 import { esPagoAplicado } from "../utils/paymentStatus";
 import { fetchImageBase64 } from "../utils/functions/internReportCancelations";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
+import { launchBrowser } from "../utils/functions/browser";
 import { db } from "../database";
 import { sql } from "drizzle-orm";
 import Big from "big.js";
@@ -686,10 +686,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
   </html>`;
 
   // 3️⃣ Generar PDF con Puppeteer (landscape para que quepan las columnas)
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   const pdfData = await page.pdf({
@@ -1580,10 +1577,7 @@ export async function generateReciboPagoPDF(pagoId: number) {
   </html>`;
 
   // 3️⃣ Generar PDF con Puppeteer
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   const pdfData = await page.pdf({

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -4119,16 +4119,8 @@ const fechaHoraEmision = fechaEmision.toISOString().substring(0, 19);
     // ============================================
     console.log(`   🎨 Generando PDF...`);
 
-    const puppeteer = await import("puppeteer");
-    const browser = await puppeteer.default.launch({
-      headless: true,
-      args: [
-        "--no-sandbox",
-        "--disable-setuid-sandbox",
-        "--disable-dev-shm-usage",
-        "--disable-gpu",
-      ],
-    });
+    const { launchBrowser } = await import("../utils/functions/browser");
+    const browser = await launchBrowser();
 
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -15,7 +15,7 @@ import {
 import { getCuotasPorDiaYAsesor, upsertEfectividadAsesores, getEfectividadAsesores } from "../controllers/paymentsByAdvisor";
 import { z } from "zod";
 import { getCreditWithCancellationDetails } from "../controllers/cancelCredit";
-import puppeteer from "puppeteer";
+import { launchBrowser } from "../utils/functions/browser";
 import { promises as fs } from "fs";
 import {
   GetObjectCommand,
@@ -785,10 +785,7 @@ export const creditRouter = new Elysia()
     } else {
       const logoUrl = process.env.LOGO_URL || "";
       const html = renderCancelationHTML(data, logoUrl);
-      const browser = await puppeteer.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
-      });
+      const browser = await launchBrowser();
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
       const pdfData = await pagePDF.pdf({
@@ -890,10 +887,7 @@ export const creditRouter = new Elysia()
       const logoUrl = process.env.LOGO_URL || "";
       const html = renderCancelationHTMLDetailedGreen(data, logoUrl);
 
-      const browser = await puppeteer.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
-      });
+      const browser = await launchBrowser();
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
       const pdfData = await pagePDF.pdf({
@@ -994,10 +988,7 @@ export const creditRouter = new Elysia()
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     } else {
       const html = renderCostDetailHTMLPeach(data, process.env.LOGO_URL || "");
-      const browser = await puppeteer.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
-      });
+      const browser = await launchBrowser();
       const page = await browser.newPage();
       await page.setContent(html, { waitUntil: "networkidle0" });
       const pdfData = await page.pdf({

--- a/apps/cartera-back/src/utils/functions/browser.ts
+++ b/apps/cartera-back/src/utils/functions/browser.ts
@@ -1,0 +1,17 @@
+import puppeteer, { type Browser } from "puppeteer";
+
+// Flags únicos para correr Chromium dentro del contenedor (sin dbus, sin GPU,
+// /dev/shm limitado). Cualquier ajuste de flags se hace SOLO aquí.
+export const CHROMIUM_LAUNCH_ARGS = [
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+];
+
+export async function launchBrowser(): Promise<Browser> {
+  return puppeteer.launch({
+    headless: true,
+    args: CHROMIUM_LAUNCH_ARGS,
+  });
+}

--- a/apps/cartera-back/src/utils/functions/generalFunctions.ts
+++ b/apps/cartera-back/src/utils/functions/generalFunctions.ts
@@ -1,6 +1,6 @@
 import { generarHTMLReporte } from "../../controllers/investor";
 import { GetCreditDTO, InversionistaReporte } from "../interface";
-import puppeteer from "puppeteer";
+import { launchBrowser } from "./browser";
 import ExcelJS from "exceljs";
 import axios from "axios";
 import Big from "big.js";
@@ -68,15 +68,7 @@ export async function generarPDFBuffer(
   logoUrl: string = ""
 ): Promise<Buffer> {
   const html = generarHTMLReporte(inversionista, logoUrl);
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: [
-      "--no-sandbox",
-      "--disable-setuid-sandbox",
-      "--disable-dev-shm-usage",
-      "--disable-gpu",
-    ],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   
@@ -103,15 +95,7 @@ export async function generarYSubirPDFInversionista(
 ): Promise<{ url: string; pdfBuffer: Buffer }> {
   const html = generarHTMLReporte(inversionista, logoUrl);
 
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: [
-      "--no-sandbox",
-      "--disable-setuid-sandbox",
-      "--disable-dev-shm-usage",
-      "--disable-gpu",
-    ],
-  });
+  const browser = await launchBrowser();
 
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });


### PR DESCRIPTION
## Problema

`GET /paymentByCredit?excel=true` (estado de cuenta PDF) tronaba en DEV con:

```
Error: Failed to launch the browser process! Code: null
[ERROR:dbus/bus.cc] Failed to connect to the bus: /run/dbus/system_bus_socket ...
```

Chromium moría al arrancar dentro del contenedor porque ese call site (y otros 5) lanzaban Puppeteer solo con `--no-sandbox --disable-setuid-sandbox`, sin `--disable-dev-shm-usage` ni `--disable-gpu` — flags necesarios en contenedor (sin dbus, sin GPU, `/dev/shm` de 64MB). Los lanzamientos que sí funcionaban (reportes de inversionistas, cofidi) ya llevaban los 4 flags: la config estaba divergida.

## Fix

- Nuevo helper `launchBrowser()` en `src/utils/functions/browser.ts` — **único** punto de configuración de flags de Chromium.
- Se reemplazan los 9 call sites: `reports.ts` ×2, `credits.ts` ×3, `recibosGenericos.ts`, `generalFunctions.ts` ×2, `cofidi.ts`.
- Para los que ya funcionaban el comportamiento es idéntico (mismos 4 flags); los rotos ganan los 2 flags que les faltaban.

## Verificación

- `grep puppeteer` → cero referencias fuera del helper.
- `tsc --noEmit` → solo errores preexistentes (types de `pg`, `lockConn`), ninguno en archivos tocados.

> Nota: DEV no buildea de Git — para verlo en `devteamatcci.site` hay que re-build + push a ECR + redeploy en Coolify (`deploy-dev.sh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)