### PR TITLE
fix(cartera-back): evitar crash de Chromium al generar PDFs (Estado de Cuenta)

### DIFF
--- a/apps/cartera-back/src/controllers/recibosGenericos.ts
+++ b/apps/cartera-back/src/controllers/recibosGenericos.ts
@@ -333,7 +333,7 @@ export async function generateReciboGenericoPDF(reciboId: number) {
   // Generar PDF con Puppeteer
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -688,7 +688,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
   // 3️⃣ Generar PDF con Puppeteer (landscape para que quepan las columnas)
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
@@ -1582,7 +1582,7 @@ export async function generateReciboPagoPDF(pagoId: number) {
   // 3️⃣ Generar PDF con Puppeteer
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -787,7 +787,7 @@ export const creditRouter = new Elysia()
       const html = renderCancelationHTML(data, logoUrl);
       const browser = await puppeteer.launch({
         headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
       });
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
@@ -892,7 +892,7 @@ export const creditRouter = new Elysia()
 
       const browser = await puppeteer.launch({
         headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
       });
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
@@ -996,7 +996,7 @@ export const creditRouter = new Elysia()
       const html = renderCostDetailHTMLPeach(data, process.env.LOGO_URL || "");
       const browser = await puppeteer.launch({
         headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
       });
       const page = await browser.newPage();
       await page.setContent(html, { waitUntil: "networkidle0" });


### PR DESCRIPTION
## Problema

El botón **Descargar Estado de Cuenta** fallaba con:

```
Error consultando pagos
Error: Failed to launch the browser process: Code: null
... Failed to connect to the bus / scaling_cur_freq: No such file or directory
```

El endpoint `GET /paymentByCredit?excel=true` → `exportPagosToExcel()` genera un **PDF con Puppeteer/Chromium** y lo sube a R2. Dentro del contenedor Docker, Chromium se cae al arrancar (`Code: null` = proceso muerto) porque el `/dev/shm` por defecto del contenedor (~64MB) se agota. Los mensajes de `dbus` y `cpufreq` del stderr son ruido no-fatal, no la causa.

## Fix

Agregar `--disable-dev-shm-usage` (usa `/tmp` en vez de `/dev/shm`) y `--disable-gpu` a los `puppeteer.launch` que aún no los tenían. Es exactamente la config que `generalFunctions.ts` ya usa y funciona.

Sitios corregidos:
- `reports.ts` — `exportPagosToExcel` (el botón) y recibo de pago PDF
- `recibosGenericos.ts` — recibos genéricos
- `credits.ts` — 3 PDFs de créditos (mismo bug latente)

## Notas

- Requiere **redeploy del contenedor de cartera-back** para tomar efecto.
- Alternativa infra complementaria: `--shm-size=1g` en el contenedor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)