### PR TITLE
fix(cartera): pin Chrome for Puppeteer receipts

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -145,6 +145,12 @@ jobs:
           podman build -f "$FILE" "$CTX" \
             -t "$ECR_REGISTRY/$IMAGE:latest" \
             -t "$ECR_REGISTRY/$IMAGE:${{ github.sha }}"
+
+          if [ "${{ matrix.app }}" = "cartera-back" ]; then
+            echo "Running cartera-back Puppeteer smoke test inside the built image"
+            podman run --rm "$ECR_REGISTRY/$IMAGE:${{ github.sha }}" bun run smoke:puppeteer
+          fi
+
           podman push "$ECR_REGISTRY/$IMAGE:latest"
           podman push "$ECR_REGISTRY/$IMAGE:${{ github.sha }}"
 

--- a/apps/cartera-back/Dockerfile
+++ b/apps/cartera-back/Dockerfile
@@ -1,31 +1,62 @@
-FROM docker.io/oven/bun:latest
+FROM docker.io/oven/bun:1.3.14
 
-# 1. Instalar dependencias de Chromium (Sencillo)
-RUN apt update && apt install -y \
+# Chromium/Chrome runtime dependencies only. Do not install Debian's `chromium`
+# package here: GitHub Actions fresh builds can pick a newer browser than local
+# cached builds, and Chromium 150 crashed in production containers with
+# `Trace/breakpoint trap` / Puppeteer `Failed to launch the browser process`.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    chromium \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Configuración de Puppeteer y Usuario
+# 1. Configuración de Puppeteer y Usuario
 RUN groupadd -r appuser && useradd -r -g appuser -G audio,video appuser \
     && mkdir -p /home/appuser/Downloads \
     && chown -R appuser:appuser /home/appuser
 
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_CACHE_DIR=/usr/src/app/.cache/puppeteer \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chrome-for-testing
 
-# 3. Preparar el Monorepo
+ARG PUPPETEER_CHROME_VERSION=148.0.7778.97
+
+# 2. Preparar el Monorepo
 WORKDIR /usr/src/app
 
 # Copiar archivos de configuración de la raíz para que Bun reconozca el monorepo
-COPY package.json bun.lockb* ./
+COPY package.json bun.lock* ./
 
 # Copiar el paquete compartido y la app
 COPY packages/email ./packages/email
 COPY apps/cartera-back ./apps/cartera-back
 
-# Instalamos desde la raíz para que resuelva los workspaces correctamente
-RUN bun install
+# Instalamos desde la raíz para que resuelva los workspaces correctamente.
+# Luego instalamos el browser soportado por Puppeteer y creamos un symlink
+# estable para producción.
+RUN bun install \
+    && mkdir -p "$PUPPETEER_CACHE_DIR" \
+    && cd apps/cartera-back \
+    && bunx puppeteer browsers install "chrome@${PUPPETEER_CHROME_VERSION}" \
+    && CHROME_BIN="$(find "$PUPPETEER_CACHE_DIR" -path '*/chrome-linux64/chrome' -type f | sort | tail -n 1)" \
+    && test -n "$CHROME_BIN" \
+    && ln -sf "$CHROME_BIN" /usr/bin/chrome-for-testing \
+    && /usr/bin/chrome-for-testing --version
 
 # --- EL TRUCO DEL CRM ---
 # Nos aseguramos de que el link en node_modules sea el código real físicamente
@@ -34,8 +65,8 @@ RUN rm -rf node_modules/@cci/email && \
     mkdir -p node_modules/@cci && \
     cp -r /usr/src/app/packages/email node_modules/@cci/email
 
-# 4. Finalizar
-RUN chown -R appuser:appuser /usr/src/app/apps/cartera-back
+# 3. Finalizar
+RUN chown -R appuser:appuser /usr/src/app/apps/cartera-back "$PUPPETEER_CACHE_DIR"
 USER appuser
 
 EXPOSE 9000

--- a/apps/cartera-back/package.json
+++ b/apps/cartera-back/package.json
@@ -8,7 +8,8 @@
     "generate": "bunx drizzle-kit generate",
     "migrate": "NODE_ENV=LOCAL bunx drizzle-kit push",
     "push": "bash ./deploy.sh",
-    "push:dev": "bash ./deploy-dev.sh"
+    "push:dev": "bash ./deploy-dev.sh",
+    "smoke:puppeteer": "bun scripts/puppeteer-smoke.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.896.0",

--- a/apps/cartera-back/scripts/puppeteer-smoke.mjs
+++ b/apps/cartera-back/scripts/puppeteer-smoke.mjs
@@ -1,0 +1,35 @@
+import puppeteer from "puppeteer";
+
+const launchArgs = [
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+];
+
+try {
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: launchArgs,
+  });
+  const page = await browser.newPage();
+  await page.setContent("<html><body><h1>Puppeteer OK</h1></body></html>", {
+    waitUntil: "networkidle0",
+  });
+  const pdf = await page.pdf({ format: "letter" });
+  await browser.close();
+
+  if (!pdf || pdf.length < 1000) {
+    throw new Error(`PDF smoke produced an unexpectedly small PDF: ${pdf?.length ?? 0} bytes`);
+  }
+
+  console.log(JSON.stringify({ ok: true, pdfBytes: pdf.length }));
+} catch (error) {
+  console.error(
+    JSON.stringify({
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    })
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Stop installing Debian's floating `chromium` package in `apps/cartera-back/Dockerfile`.
- Pin the runtime base image and install a known-working Chrome for Testing (`148.0.7778.97`) through Puppeteer into a stable `PUPPETEER_EXECUTABLE_PATH`.
- Add `smoke:puppeteer` and run it inside the built `cartera-back` image during the production deploy workflow before pushing/redeploying.

## Why
Remote ECR smoke tests showed GitHub Actions images used Debian Chromium 150 and crashed with `Trace/breakpoint trap` / Puppeteer `Failed to launch the browser process`, while the locally-built `latest` image used Chromium 148 and generated PDFs successfully.

## Verification
- `podman build -f apps/cartera-back/Dockerfile . -t cartera-back:puppeteer-deterministic-final`
- `podman run --rm cartera-back:puppeteer-deterministic-final bash -lc 'whoami; bun --version; /usr/bin/chrome-for-testing --version; bun run smoke:puppeteer'`
  - output included `Google Chrome for Testing 148.0.7778.97`
  - output included `{"ok":true,"pdfBytes":7316}`
- `bun test src/controllers/registerPayment.test.ts src/controllers/registerPaymentPolicy.test.ts`
  - `48 pass`, `0 fail`
- `git diff --check`

## Notes
- PRs #1017/#1018 added the right launch flags, but those images still failed when built by GitHub Actions because the browser binary itself crashed. This PR makes the browser binary deterministic and adds a build-time smoke guard.