### PR TITLE
feat(cartera): excluir creditos en devolucion Cube del assignCapital

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -529,6 +529,24 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
         const montoSolicitado =
           montoManualPorCredito.get(candidato.credito_id) ?? new Big(0);
 
+        // ── Guard 0: crédito sin proceso de devolución a Cube ──
+        // getCreditCandidates filtra por estado_devolucion = NO_APLICA. En
+        // manual saltamos ese filtro, así que lo replicamos: un crédito en
+        // PENDIENTE_AUTORIZACION / VERIFICADO / RECHAZADO se está devolviendo a
+        // Cube; asignarle un inversionista genera la doble asignación que
+        // liquidación (exitInvestor) provocaría después.
+        const estadoDevolucion =
+          candidato.credito_completo?.credito?.estado_devolucion;
+        if (estadoDevolucion && estadoDevolucion !== "NO_APLICA") {
+          violaciones.push({
+            credito_id: candidato.credito_id,
+            numero_credito_sifco: candidato.numero_credito_sifco,
+            razon: `El crédito está en proceso de devolución a Cube (estado ${estadoDevolucion}); no se puede reasignar manualmente`,
+            monto_solicitado: montoSolicitado.toString(),
+          });
+          continue;
+        }
+
         // ── Guard 1: espejo sin operación en curso ──
         // Un crédito pasa solo si TODAS sus filas de espejo están en
         // "completado" (o no tiene filas de espejo). Si alguna está en
@@ -581,7 +599,7 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
         return {
           success: false,
           message:
-            "No se pudo crear la asignación manual: uno o más créditos no son elegibles (espejo con operación en curso, sin CUBE, o monto sobre el tope de CUBE)",
+            "No se pudo crear la asignación manual: uno o más créditos no son elegibles (en devolución a Cube, espejo con operación en curso, sin CUBE, o monto sobre el tope de CUBE)",
           violaciones,
         };
       }

--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -182,8 +182,9 @@ export async function getCreditCandidates(
       eq(creditos.statusCredit, "ACTIVO"),
       sql`LOWER(${usuarios.categoria}) LIKE '%cv veh_culo%'`,
       lt(creditos.fecha_creacion, inicioMesGuateUTC),
-      // Excluir créditos con devolución a Cube pendiente o rechazada
-      notInArray(creditos.estado_devolucion, ["PENDIENTE_AUTORIZACION", "RECHAZADO"] as any)
+      // Solo créditos sin proceso de devolución a Cube (NO_APLICA).
+      // PENDIENTE_AUTORIZACION / VERIFICADO / RECHAZADO están en flujo de devolución.
+      eq(creditos.estado_devolucion, "NO_APLICA")
     ));
 
   console.log(`   - Créditos ACTIVOS en total: ${totalActivos}`);
@@ -216,9 +217,10 @@ export async function getCreditCandidates(
         gt(creditos.porcentaje_interes, "0"),
         // Excluir créditos creados en el mes actual (fecha pre-calculada y optimizada)
         lt(creditos.fecha_creacion, inicioMesGuateUTC),
-        // Excluir créditos con devolución a Cube pendiente o rechazada:
-        // no deben ofrecerse a inversionistas.
-        notInArray(creditos.estado_devolucion, ["PENDIENTE_AUTORIZACION", "RECHAZADO"] as any)
+        // Solo créditos sin proceso de devolución a Cube.
+        // PENDIENTE_AUTORIZACION / VERIFICADO / RECHAZADO están en flujo de
+        // devolución a Cube; no deben ofrecerse a inversionistas.
+        eq(creditos.estado_devolucion, "NO_APLICA")
       )
     );
 

--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -181,7 +181,9 @@ export async function getCreditCandidates(
     .where(and(
       eq(creditos.statusCredit, "ACTIVO"),
       sql`LOWER(${usuarios.categoria}) LIKE '%cv veh_culo%'`,
-      lt(creditos.fecha_creacion, inicioMesGuateUTC)
+      lt(creditos.fecha_creacion, inicioMesGuateUTC),
+      // Excluir créditos con devolución a Cube pendiente o rechazada
+      notInArray(creditos.estado_devolucion, ["PENDIENTE_AUTORIZACION", "RECHAZADO"] as any)
     ));
 
   console.log(`   - Créditos ACTIVOS en total: ${totalActivos}`);
@@ -213,7 +215,10 @@ export async function getCreditCandidates(
         // Descartar créditos sin interés (0%)
         gt(creditos.porcentaje_interes, "0"),
         // Excluir créditos creados en el mes actual (fecha pre-calculada y optimizada)
-        lt(creditos.fecha_creacion, inicioMesGuateUTC)
+        lt(creditos.fecha_creacion, inicioMesGuateUTC),
+        // Excluir créditos con devolución a Cube pendiente o rechazada:
+        // no deben ofrecerse a inversionistas.
+        notInArray(creditos.estado_devolucion, ["PENDIENTE_AUTORIZACION", "RECHAZADO"] as any)
       )
     );
 


### PR DESCRIPTION
## Contexto

El modulo **assignCapital** (`cartera-back/src/controllers/assignCapital.ts`) recomienda creditos de Cube para reasignar/vender a inversionistas.

Los creditos con un proceso de devolucion a Cube en curso (visibles en la pagina **Devolucion Cube**) NO deben ofrecerse ni asignarse a inversionistas: se van a devolver a Cube, no a un inversionista. Ofrecerlos crea doble asignacion / conflicto.

## Cambio

Se excluyen del pool de candidatos y del path manual los creditos con `estado_devolucion` distinto de `NO_APLICA`, es decir:
- `PENDIENTE_AUTORIZACION` — solicitud de devolucion en curso
- `VERIFICADO` — devolucion aceptada pero aun no liquidada (payments.ts la trata como reembolso total a Cube; investor.ts corre exitInvestor y recien ahi resetea a NO_APLICA)
- `RECHAZADO` — devolucion rechazada (por decision de negocio tampoco se reasigna)

Solo `NO_APLICA` (credito sin proceso de devolucion) queda elegible.

**Puntos tocados:**
1. `assignCapital.ts` — filtro `estado_devolucion = NO_APLICA` en el WHERE de la query base `baseCredits` y en la de diagnostico. Sargable, corta antes de las queries batch.
2. `addInvestorToCredit.ts` — Guard 0 en la asignacion **manual** (que salta getCreditCandidates via getCreditCandidateById): rechaza cualquier credito con `estado_devolucion != NO_APLICA`, cerrando el mismo invariante por el path manual.

## Verificacion

- `bunx tsc --noEmit` limpio.
- Pendiente prueba end-to-end: poner credito en devolucion, confirmar que desaparece de `GET /assign-capital/candidates` y que la asignacion manual lo rechaza con 409.

## Follow-ups (no bloqueantes, fuera de este PR)

Levantados en review de @jalvaradoatcci, anotados para un PR aparte:
1. `replaceInvestorCredit.ts` (`/reemplazar-inversionista-credito`) tampoco valida `estado_devolucion` en el destino.
2. Check-then-act: re-chequear el guard dentro de la transaccion para cerrar la ventana de una devolucion concurrente.
3. Query de diagnostico `totalCandidatosBase` esta muerta (nunca se logea) y driftio — borrarla o logearla.
4. El criterio de elegibilidad se repite a mano en dos WHERE — extraer a un fragmento `and(...)` compartido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
