### PR TITLE
fix(crm+cartera): fechas de cuotas en detalle de cobros + port de hotfixes Puppeteer a develop

### DIFF
--- a/.github/workflows/deploy-cartera-dev.yaml
+++ b/.github/workflows/deploy-cartera-dev.yaml
@@ -80,6 +80,8 @@ jobs:
           podman build -f apps/cartera-back/Dockerfile . \
             -t $ECR_REGISTRY/cartera-back-dev:latest \
             -t $ECR_REGISTRY/cartera-back-dev:${{ github.sha }}
+          echo "Running cartera-back Puppeteer smoke test inside the built image"
+          podman run --rm $ECR_REGISTRY/cartera-back-dev:${{ github.sha }} bun run smoke:puppeteer
           podman push $ECR_REGISTRY/cartera-back-dev:latest
           podman push $ECR_REGISTRY/cartera-back-dev:${{ github.sha }}
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -145,6 +145,12 @@ jobs:
           podman build -f "$FILE" "$CTX" \
             -t "$ECR_REGISTRY/$IMAGE:latest" \
             -t "$ECR_REGISTRY/$IMAGE:${{ github.sha }}"
+
+          if [ "${{ matrix.app }}" = "cartera-back" ]; then
+            echo "Running cartera-back Puppeteer smoke test inside the built image"
+            podman run --rm "$ECR_REGISTRY/$IMAGE:${{ github.sha }}" bun run smoke:puppeteer
+          fi
+
           podman push "$ECR_REGISTRY/$IMAGE:latest"
           podman push "$ECR_REGISTRY/$IMAGE:${{ github.sha }}"
 

--- a/apps/cartera-back/Dockerfile
+++ b/apps/cartera-back/Dockerfile
@@ -1,31 +1,62 @@
-FROM docker.io/oven/bun:latest
+FROM docker.io/oven/bun:1.3.14
 
-# 1. Instalar dependencias de Chromium (Sencillo)
-RUN apt update && apt install -y \
+# Chromium/Chrome runtime dependencies only. Do not install Debian's `chromium`
+# package here: GitHub Actions fresh builds can pick a newer browser than local
+# cached builds, and Chromium 150 crashed in production containers with
+# `Trace/breakpoint trap` / Puppeteer `Failed to launch the browser process`.
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    chromium \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgbm1 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxkbcommon0 \
+    libxrandr2 \
+    xdg-utils \
     && rm -rf /var/lib/apt/lists/*
 
-# 2. Configuración de Puppeteer y Usuario
+# 1. Configuración de Puppeteer y Usuario
 RUN groupadd -r appuser && useradd -r -g appuser -G audio,video appuser \
     && mkdir -p /home/appuser/Downloads \
     && chown -R appuser:appuser /home/appuser
 
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
-    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_CACHE_DIR=/usr/src/app/.cache/puppeteer \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chrome-for-testing
 
-# 3. Preparar el Monorepo
+ARG PUPPETEER_CHROME_VERSION=148.0.7778.97
+
+# 2. Preparar el Monorepo
 WORKDIR /usr/src/app
 
 # Copiar archivos de configuración de la raíz para que Bun reconozca el monorepo
-COPY package.json bun.lockb* ./
+COPY package.json bun.lock* ./
 
 # Copiar el paquete compartido y la app
 COPY packages/email ./packages/email
 COPY apps/cartera-back ./apps/cartera-back
 
-# Instalamos desde la raíz para que resuelva los workspaces correctamente
-RUN bun install
+# Instalamos desde la raíz para que resuelva los workspaces correctamente.
+# Luego instalamos el browser soportado por Puppeteer y creamos un symlink
+# estable para producción.
+RUN bun install \
+    && mkdir -p "$PUPPETEER_CACHE_DIR" \
+    && cd apps/cartera-back \
+    && bunx puppeteer browsers install "chrome@${PUPPETEER_CHROME_VERSION}" \
+    && CHROME_BIN="$(find "$PUPPETEER_CACHE_DIR" -path '*/chrome-linux64/chrome' -type f | sort | tail -n 1)" \
+    && test -n "$CHROME_BIN" \
+    && ln -sf "$CHROME_BIN" /usr/bin/chrome-for-testing \
+    && /usr/bin/chrome-for-testing --version
 
 # --- EL TRUCO DEL CRM ---
 # Nos aseguramos de que el link en node_modules sea el código real físicamente
@@ -34,8 +65,8 @@ RUN rm -rf node_modules/@cci/email && \
     mkdir -p node_modules/@cci && \
     cp -r /usr/src/app/packages/email node_modules/@cci/email
 
-# 4. Finalizar
-RUN chown -R appuser:appuser /usr/src/app/apps/cartera-back
+# 3. Finalizar
+RUN chown -R appuser:appuser /usr/src/app/apps/cartera-back "$PUPPETEER_CACHE_DIR"
 USER appuser
 
 EXPOSE 9000

--- a/apps/cartera-back/package.json
+++ b/apps/cartera-back/package.json
@@ -8,7 +8,8 @@
     "generate": "bunx drizzle-kit generate",
     "migrate": "NODE_ENV=LOCAL bunx drizzle-kit push",
     "push": "bash ./deploy.sh",
-    "push:dev": "bash ./deploy-dev.sh"
+    "push:dev": "bash ./deploy-dev.sh",
+    "smoke:puppeteer": "bun scripts/puppeteer-smoke.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.896.0",

--- a/apps/cartera-back/scripts/puppeteer-smoke.mjs
+++ b/apps/cartera-back/scripts/puppeteer-smoke.mjs
@@ -1,0 +1,35 @@
+import puppeteer from "puppeteer";
+
+const launchArgs = [
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+];
+
+try {
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: launchArgs,
+  });
+  const page = await browser.newPage();
+  await page.setContent("<html><body><h1>Puppeteer OK</h1></body></html>", {
+    waitUntil: "networkidle0",
+  });
+  const pdf = await page.pdf({ format: "letter" });
+  await browser.close();
+
+  if (!pdf || pdf.length < 1000) {
+    throw new Error(`PDF smoke produced an unexpectedly small PDF: ${pdf?.length ?? 0} bytes`);
+  }
+
+  console.log(JSON.stringify({ ok: true, pdfBytes: pdf.length }));
+} catch (error) {
+  console.error(
+    JSON.stringify({
+      ok: false,
+      message: error instanceof Error ? error.message : String(error),
+    })
+  );
+  process.exit(1);
+}

--- a/apps/cartera-back/src/controllers/recibosGenericos.ts
+++ b/apps/cartera-back/src/controllers/recibosGenericos.ts
@@ -4,7 +4,7 @@ import {
   recibos_genericos,
   recibo_generico_montos,
 } from "../database/db";
-import puppeteer from "puppeteer";
+import { launchBrowser } from "../utils/functions/browser";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 
 const LOGO_URL = process.env.LOGO_URL || "https://pub-8081c8d6e5e743f9adfc9e0db92e5a88.r2.dev/reports/logo-cashin.png";
@@ -331,10 +331,7 @@ export async function generateReciboGenericoPDF(reciboId: number) {
   </html>`;
 
   // Generar PDF con Puppeteer
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   const pdfData = await page.pdf({

--- a/apps/cartera-back/src/controllers/recibosGenericos.ts
+++ b/apps/cartera-back/src/controllers/recibosGenericos.ts
@@ -333,7 +333,7 @@ export async function generateReciboGenericoPDF(reciboId: number) {
   // Generar PDF con Puppeteer
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -688,7 +688,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
   // 3️⃣ Generar PDF con Puppeteer (landscape para que quepan las columnas)
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
@@ -1582,7 +1582,7 @@ export async function generateReciboPagoPDF(pagoId: number) {
   // 3️⃣ Generar PDF con Puppeteer
   const browser = await puppeteer.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
   });
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1,11 +1,11 @@
 import ExcelJS from "exceljs";
-import puppeteer from "puppeteer";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getCreditosWithUserByMesAnio } from "./credits";
 import { getAllPagosWithCreditAndInversionistas, getPagosConInversionistas } from "./payments";
 import { esPagoAplicado } from "../utils/paymentStatus";
 import { fetchImageBase64 } from "../utils/functions/internReportCancelations";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
+import { launchBrowser } from "../utils/functions/browser";
 import { db } from "../database";
 import { sql } from "drizzle-orm";
 import Big from "big.js";
@@ -686,10 +686,7 @@ export async function exportPagosToExcel(credito_sifco: string) {
   </html>`;
 
   // 3️⃣ Generar PDF con Puppeteer (landscape para que quepan las columnas)
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   const pdfData = await page.pdf({
@@ -1580,10 +1577,7 @@ export async function generateReciboPagoPDF(pagoId: number) {
   </html>`;
 
   // 3️⃣ Generar PDF con Puppeteer
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   const pdfData = await page.pdf({

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -4119,16 +4119,8 @@ const fechaHoraEmision = fechaEmision.toISOString().substring(0, 19);
     // ============================================
     console.log(`   🎨 Generando PDF...`);
 
-    const puppeteer = await import("puppeteer");
-    const browser = await puppeteer.default.launch({
-      headless: true,
-      args: [
-        "--no-sandbox",
-        "--disable-setuid-sandbox",
-        "--disable-dev-shm-usage",
-        "--disable-gpu",
-      ],
-    });
+    const { launchBrowser } = await import("../utils/functions/browser");
+    const browser = await launchBrowser();
 
     const page = await browser.newPage();
     await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -787,7 +787,7 @@ export const creditRouter = new Elysia()
       const html = renderCancelationHTML(data, logoUrl);
       const browser = await puppeteer.launch({
         headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
       });
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
@@ -892,7 +892,7 @@ export const creditRouter = new Elysia()
 
       const browser = await puppeteer.launch({
         headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
       });
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
@@ -996,7 +996,7 @@ export const creditRouter = new Elysia()
       const html = renderCostDetailHTMLPeach(data, process.env.LOGO_URL || "");
       const browser = await puppeteer.launch({
         headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
       });
       const page = await browser.newPage();
       await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -15,7 +15,7 @@ import {
 import { getCuotasPorDiaYAsesor, upsertEfectividadAsesores, getEfectividadAsesores } from "../controllers/paymentsByAdvisor";
 import { z } from "zod";
 import { getCreditWithCancellationDetails } from "../controllers/cancelCredit";
-import puppeteer from "puppeteer";
+import { launchBrowser } from "../utils/functions/browser";
 import { promises as fs } from "fs";
 import {
   GetObjectCommand,
@@ -785,10 +785,7 @@ export const creditRouter = new Elysia()
     } else {
       const logoUrl = process.env.LOGO_URL || "";
       const html = renderCancelationHTML(data, logoUrl);
-      const browser = await puppeteer.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-      });
+      const browser = await launchBrowser();
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
       const pdfData = await pagePDF.pdf({
@@ -890,10 +887,7 @@ export const creditRouter = new Elysia()
       const logoUrl = process.env.LOGO_URL || "";
       const html = renderCancelationHTMLDetailedGreen(data, logoUrl);
 
-      const browser = await puppeteer.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-      });
+      const browser = await launchBrowser();
       const pagePDF = await browser.newPage();
       await pagePDF.setContent(html, { waitUntil: "networkidle0" });
       const pdfData = await pagePDF.pdf({
@@ -994,10 +988,7 @@ export const creditRouter = new Elysia()
         "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
     } else {
       const html = renderCostDetailHTMLPeach(data, process.env.LOGO_URL || "");
-      const browser = await puppeteer.launch({
-        headless: true,
-        args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage", "--disable-gpu"],
-      });
+      const browser = await launchBrowser();
       const page = await browser.newPage();
       await page.setContent(html, { waitUntil: "networkidle0" });
       const pdfData = await page.pdf({

--- a/apps/cartera-back/src/utils/functions/browser.ts
+++ b/apps/cartera-back/src/utils/functions/browser.ts
@@ -1,0 +1,17 @@
+import puppeteer, { type Browser } from "puppeteer";
+
+// Flags únicos para correr Chromium dentro del contenedor (sin dbus, sin GPU,
+// /dev/shm limitado). Cualquier ajuste de flags se hace SOLO aquí.
+export const CHROMIUM_LAUNCH_ARGS = [
+  "--no-sandbox",
+  "--disable-setuid-sandbox",
+  "--disable-dev-shm-usage",
+  "--disable-gpu",
+];
+
+export async function launchBrowser(): Promise<Browser> {
+  return puppeteer.launch({
+    headless: true,
+    args: CHROMIUM_LAUNCH_ARGS,
+  });
+}

--- a/apps/cartera-back/src/utils/functions/generalFunctions.ts
+++ b/apps/cartera-back/src/utils/functions/generalFunctions.ts
@@ -1,6 +1,6 @@
 import { generarHTMLReporte } from "../../controllers/investor";
 import { GetCreditDTO, InversionistaReporte } from "../interface";
-import puppeteer from "puppeteer";
+import { launchBrowser } from "./browser";
 import ExcelJS from "exceljs";
 import axios from "axios";
 import Big from "big.js";
@@ -68,15 +68,7 @@ export async function generarPDFBuffer(
   logoUrl: string = ""
 ): Promise<Buffer> {
   const html = generarHTMLReporte(inversionista, logoUrl);
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: [
-      "--no-sandbox",
-      "--disable-setuid-sandbox",
-      "--disable-dev-shm-usage",
-      "--disable-gpu",
-    ],
-  });
+  const browser = await launchBrowser();
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });
   
@@ -103,15 +95,7 @@ export async function generarYSubirPDFInversionista(
 ): Promise<{ url: string; pdfBuffer: Buffer }> {
   const html = generarHTMLReporte(inversionista, logoUrl);
 
-  const browser = await puppeteer.launch({
-    headless: true,
-    args: [
-      "--no-sandbox",
-      "--disable-setuid-sandbox",
-      "--disable-dev-shm-usage",
-      "--disable-gpu",
-    ],
-  });
+  const browser = await launchBrowser();
 
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: "networkidle0" });

--- a/apps/crm/apps/web/src/lib/date-utils.ts
+++ b/apps/crm/apps/web/src/lib/date-utils.ts
@@ -6,3 +6,14 @@ export function parseFechaLocal(fecha: string): Date {
 	const [year, month, day] = fecha.split("-").map(Number);
 	return new Date(year, month - 1, day);
 }
+
+/**
+ * Formatea una fecha para mostrar en es-GT. Si el string es solo fecha
+ * ("YYYY-MM-DD") la parsea como local para evitar el desfase de un día;
+ * si trae hora (timestamp ISO) usa el parseo normal.
+ */
+export function formatFechaLocal(fecha: string): string {
+	const esSoloFecha = /^\d{4}-\d{2}-\d{2}$/.test(fecha);
+	const d = esSoloFecha ? parseFechaLocal(fecha) : new Date(fecha);
+	return d.toLocaleDateString("es-GT");
+}

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
+import { formatFechaLocal } from "@/lib/date-utils";
 import { ROLES } from "@/lib/roles";
 import { client, orpc } from "@/utils/orpc";
 
@@ -1529,18 +1530,14 @@ function RouteComponent() {
 																	Vencimiento:
 																</span>
 																<br />
-																{new Date(
-																	cuota.fechaVencimiento,
-																).toLocaleDateString("es-GT")}
+																{formatFechaLocal(cuota.fechaVencimiento)}
 															</div>
 															{esPagada ? (
 																<div>
 																	<span className="font-medium">Pagado:</span>
 																	<br />
 																	{cuota.fechaPago
-																		? new Date(
-																				cuota.fechaPago,
-																			).toLocaleDateString("es-GT")
+																		? formatFechaLocal(cuota.fechaPago)
 																		: "Sin fecha"}
 																	<br />
 																	<span className="font-medium text-green-600">
@@ -1798,9 +1795,7 @@ function RouteComponent() {
 								<p className="text-muted-foreground text-sm">Fecha de Inicio</p>
 								<p className="font-medium">
 									{caso.fechaInicioCuota0
-										? new Date(caso.fechaInicioCuota0).toLocaleDateString(
-												"es-GT",
-											)
+										? formatFechaLocal(caso.fechaInicioCuota0)
 										: caso.fechaInicio
 											? new Date(caso.fechaInicio).toLocaleDateString("es-GT")
 											: "Sin fecha"}


### PR DESCRIPTION
## 1) CRM: desfase de un día en fechas de cuotas (Detalles del Caso)

**Problema:** en Cobros → Detalles del Caso → Historial de Cuotas, *Vencimiento*, *Pagado* y *Fecha de Inicio* se mostraban un día antes (ej: vence el 6, mostraba 5/11/2023). El listado sí estaba bien.

**Causa:** `fecha_vencimiento` es columna `date` y llega como string `"YYYY-MM-DD"`; `new Date()` la interpreta como medianoche UTC y `toLocaleDateString("es-GT")` (UTC-6) la rueda al día anterior. El listado usa `parseFechaLocal` (creado para esto); el detalle nunca lo adoptó.

**Cambio:** nuevo `formatFechaLocal()` en `date-utils.ts` (solo-fecha → parseo local; timestamps ISO → `new Date` normal) aplicado a los 3 campos afectados.

**Verificación** con `TZ=America/Guatemala`: `2023-11-06` → `6/11/2023` ✅ (antes `5/11/2023`); timestamps intactos.

## 2) Cartera: port a develop de los hotfixes de Puppeteer (#1017/#1018/#1019)

**Problema:** DEV (que se construye desde `develop`) quedó tirando `Failed to launch the browser process` en `/paymentByCredit?excel=true` (estado de cuenta PDF) tras el redeploy de hoy 21:25, porque `develop` no tiene los hotfixes que ya viven en `main`: el Dockerfile instala el `chromium` flotante de Debian (150, que crashea) y el código usa `puppeteer.launch` crudo.

**Cambio:** cherry-pick de los 3 commits de main:
- `94aaccfb` (#1018) — flags `--disable-dev-shm-usage`/`--disable-gpu` en PDFs de estado de cuenta
- `fa8abd45` (#1017) — `launchBrowser()` centralizado en `utils/functions/browser.ts` (único punto de flags)
- `5f305ccd` (#1019) — Dockerfile pinnea Chrome for Testing 148.0.7778.97 + `smoke:puppeteer` + guard en deploy prod

Extra: el workflow **deploy-cartera-dev.yaml** ahora corre el mismo smoke test de Puppeteer antes de publicar la imagen dev (el guard solo existía en prod).

**Verificación:** cero `puppeteer.launch` crudos restantes en cartera-back (`grep`), `tsc --noEmit` con los mismos 6 errores preexistentes que develop (0 nuevos).

Al mergear, DEV se redespliega automáticamente y queda arreglado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 3) Cartera: bucket "Mora 120+" abierto en el filtro de /getAllCredits

**Problema:** el embudo del CRM (`/stats`) agrupa el bucket 4 con `cuotas_atrasadas >= 4`, pero el filtro de `/getAllCredits` usaba **igualdad exacta** — al filtrar la tabla por "Mora 120+" los créditos con 5+ cuotas atrasadas no aparecían (el conteo del embudo y la tabla no cuadraban).

**Cambio:** en `getCreditosWithUserByMesAnio`, buckets 1-3 siguen exactos y el 4 pasa a `gte` (abierto), espejo de `getCreditStats` y del reporte por `rango_mora` que ya usan `>= 4`. La variante Excel delega al mismo controller, así que queda cubierta.

## 4) Cartera: nuevo filtro `excluir_pagados_mes` en /getAllCredits

Booleano opcional (default `false`, GET query / POST body) para que la lista de cobros pueda **ocultar los créditos que ya pagaron su cuota actual**.

**Definición:** cuota actual = primera cuota con `fecha_vencimiento >= hoy` (fecha GT), mismo concepto que la `proxima_cuota` de la columna "Fecha de Pago". Con el flag en true se excluye un crédito solo si esa cuota ya está pagada **y** no tiene mora activa (los morosos nunca se ocultan; créditos sin cuotas futuras tampoco).

**Implementación:** subconsulta correlacionada en el WHERE — sin joins nuevos, no multiplica filas en la paginación y el `COUNT(DISTINCT)` hereda la condición. Variante Excel y POST cubiertos por passthrough. Sin el flag el comportamiento es idéntico al actual.

**Verificación (read-only, clon DEV):** totalCount 1,532 sin flag vs 1,508 con flag; los 24 excluidos cuadran 1:1 con un cross-check SQL independiente; muestreo confirma próxima cuota pagada + sin mora (ej: crédito 4955, cuota del 30-jul pagada por adelantado → excluido).

## 5) CRM: botón "Ocultar los que ya pagaron su cuota" en Cobros

Cablea el filtro del punto 4 de punta a punta: nueva sección **"Cuota actual"** en el panel de filtros de la pantalla de Cobros con un toggle persistido (`cobros/excluirPagados`), integrado al contador de filtros activos y a "Limpiar filtros". El valor viaja por `getTodosLosCreditos` → `cartera-back-client` (GET y POST) → `/getAllCredits?excluir_pagados_mes=true`.

El **envío masivo de WhatsApp** (`enviarWhatsappMasivoCobros`) respeta el mismo filtro — con el toggle activo no se le escribe a clientes que ya pagaron su cuota actual.

Sin el toggle, cero cambios de comportamiento. Tests: `bun test excluirPagadosMes.test.ts` (4 pass, integración contra clon DEV con la fecha del día); tsc del server CRM en 0 errores; los del web son los 1,043 preexistentes del entorno.
