### PR TITLE
fix(cobros): alinear monto y etapa de mora entre embudo, tabla y detalle

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -699,8 +699,18 @@ export async function getCreditosWithUserByMesAnio(
     }
 
     if (cuotas_atrasadas && cuotas_atrasadas > 0) {
-      console.log(`🔎 Filtrando por cuotas atrasadas >= ${cuotas_atrasadas}`);
-      conditions.push(eq(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
+      // Mora 120+ es un bucket ABIERTO: `cuotas_atrasadas = 4` significa "4 o más",
+      // igual que el embudo (getCreditStats usa `>= 4` para ese bucket). Para 1/2/3
+      // (mora_30/60/90) cada etapa es un conteo exacto. Antes se usaba `eq` para todos,
+      // así que un crédito con 5+ cuotas se contaba en el embudo pero NO salía al
+      // filtrar la tabla por mora_120.
+      if (cuotas_atrasadas >= 4) {
+        console.log(`🔎 Filtrando por cuotas atrasadas >= ${cuotas_atrasadas}`);
+        conditions.push(gte(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
+      } else {
+        console.log(`🔎 Filtrando por cuotas atrasadas = ${cuotas_atrasadas}`);
+        conditions.push(eq(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
+      }
     }
 
     if (is_vehiculo_propio) {

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1011,15 +1011,17 @@ export const cobrosRouter = {
 							// Acceder a los datos anidados correctamente
 							const statusCredit = credito.creditos.statusCredit;
 							const cuotasAtrasadas = credito.mora?.cuotas_atrasadas ?? 0;
-							const cuotaMensual = Number(credito.creditos.cuota ?? 0);
 
 							// NOTA: Usamos aproximación (30 días por cuota) porque /getAllCredits
 							// NO retorna las fechas de vencimiento de las cuotas individuales.
 							// Solo /credito retorna el array completo con fechas para cálculo exacto.
 							const diasMora = cuotasAtrasadas * 30;
 
-							// Calcular monto en mora como: cuota mensual * cuotas atrasadas
-							const montoEnMora = cuotaMensual * cuotasAtrasadas;
+							// Monto en mora REAL: usamos moras_credito.monto_mora (capital × 1.12% ×
+							// cuotas) que /getAllCredits ya trae en `mora`, para que coincida con el
+							// embudo (/stats) y la pantalla de detalle (/credito). Antes se aproximaba
+							// `cuota × cuotas`, dando un número distinto al del detalle para el mismo crédito.
+							const montoEnMora = Number(credito.mora?.monto_mora ?? 0);
 
 							// Determinar estado de mora según statusCredit y días de mora
 							let estadoMora: string | null = null;


### PR DESCRIPTION
## Qué arregla

Dos inconsistencias **de producción** en el módulo de Cobros, donde el mismo crédito mostraba números distintos según la pantalla. Ambas comparten la fuente de verdad `moras_credito`.

### 1. Mora 120+ no cuadra entre el embudo y la tabla
El filtro de `cuotas_atrasadas` en `getCreditosWithUserByMesAnio` (cartera-back) usaba **igualdad exacta** para todos los buckets. Como `mora_120` manda `cuotas_atrasadas = 4`, un crédito con **5+ cuotas atrasadas** se contaba en el embudo (`getCreditStats` usa `>= 4`) pero **desaparecía** al filtrar la tabla por Mora 120+.

**Fix:** el bucket 4 ahora filtra `>= 4` (igual que el embudo); `mora_30/60/90` siguen siendo conteo exacto.

### 2. Monto en mora estimado vs. real
La tabla de casos (`getTodosLosCreditos` → CRM) calculaba el monto en mora como `cuota mensual × cuotas`, mientras que el **embudo** (`/stats`) y la **página de detalle** (`/credito`) usan el valor real `moras_credito.monto_mora` (`capital × 1.12% × cuotas`). El mismo crédito mostraba un monto en la lista y otro al abrirlo.

**Fix:** la lista ahora lee el monto **real** que `/getAllCredits` ya devuelve en `mora`.

## Archivos
- `apps/cartera-back/src/controllers/credits.ts` — filtro `>= 4` para mora_120.
- `apps/crm/apps/server/src/routers/cobros.ts` — `montoEnMora` desde `mora.monto_mora`.

## Notas
- El punto 1 también afecta el Excel de reportes (`reports.ts`), que comparte el filtro — queda consistente (Mora 120+ = 4 o más en ambos).
- Los "días de mora" de la lista siguen siendo aproximados a propósito (fuera de alcance de este PR).
- `tsc --noEmit`: sin errores nuevos en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
