### PR TITLE
feat(cobros-02): motor de buckets — historial de transiciones + asignación pool

### DIFF
--- a/apps/cartera-back/drizzle/cobros-02/0000_motor_buckets.sql
+++ b/apps/cartera-back/drizzle/cobros-02/0000_motor_buckets.sql
@@ -1,0 +1,90 @@
+-- ============================================================================
+-- COBROS-02 · Motor de Buckets — 0000_motor_buckets
+-- ============================================================================
+-- Rediseño de cobros (release COBROS-02, aislado, sale en meses). Este archivo
+-- crea el MOTOR de buckets: el historial de transiciones + la asignación
+-- asesor↔bucket (pool). El "bucket actual" NO se materializa: es derivado de
+-- las cuotas atrasadas / estado del crédito (lo calcula el job procesarMoras).
+--
+-- Buckets: B0=0 cuotas · B1=1 · B2=2 · B3=3 · B4=4 · B5=>=5 (o INCOBRABLE/legal).
+--
+-- NOTA: Cartera aplica el SQL a mano (no drizzle-kit). Idempotente. Pendiente de
+-- aplicar en dev/prod. Corresponde al schema en src/database/db/schema.ts.
+-- ============================================================================
+
+-- Enums ----------------------------------------------------------------------
+-- Dirección de la transición de bucket.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'bucket_evento_tipo' AND n.nspname = 'cartera'
+  ) THEN
+    CREATE TYPE cartera.bucket_evento_tipo AS ENUM ('SUBIDA', 'BAJADA');
+  END IF;
+END$$;
+--> statement-breakpoint
+
+-- Origen del evento (hoy siempre PROCESO_AUTO; API_MANUAL para ajustes futuros).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE t.typname = 'bucket_evento_origen' AND n.nspname = 'cartera'
+  ) THEN
+    CREATE TYPE cartera.bucket_evento_origen AS ENUM ('PROCESO_AUTO', 'API_MANUAL');
+  END IF;
+END$$;
+--> statement-breakpoint
+
+-- Asignación asesor ↔ bucket (modelo POOL, muchos-a-muchos) -------------------
+-- Un bucket con varios asesores y un asesor en varios buckets.
+CREATE TABLE IF NOT EXISTS cartera.asesor_bucket (
+  id          serial PRIMARY KEY,
+  asesor_id   integer NOT NULL REFERENCES cartera.asesores (asesor_id) ON DELETE CASCADE,
+  bucket      integer NOT NULL,                    -- 0-5
+  activo      boolean NOT NULL DEFAULT true,
+  created_at  timestamp DEFAULT now(),
+  updated_at  timestamp DEFAULT now()
+);
+--> statement-breakpoint
+
+CREATE UNIQUE INDEX IF NOT EXISTS asesor_bucket_uq
+  ON cartera.asesor_bucket (asesor_id, bucket);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS asesor_bucket_bucket_idx
+  ON cartera.asesor_bucket (bucket);
+--> statement-breakpoint
+
+-- Historial de transiciones de bucket (append-only) --------------------------
+-- Solo se registra CUÁNDO cambia el bucket (SUBIDA = empeora, BAJADA = mejora/cura).
+-- asesor_id/pago_id = atribución para métricas (sobre todo la BAJADA = cuenta
+-- curada). asesor_id se llena cuando el nuevo flujo de pago capture al asesor.
+CREATE TABLE IF NOT EXISTS cartera.buckets_historial (
+  historial_id             serial PRIMARY KEY,
+  credito_id               integer NOT NULL REFERENCES cartera.creditos (credito_id) ON DELETE CASCADE,
+  bucket_anterior          integer,                              -- null en el primer registro
+  bucket_nuevo             integer NOT NULL,
+  tipo_evento              cartera.bucket_evento_tipo NOT NULL,
+  origen                   cartera.bucket_evento_origen NOT NULL DEFAULT 'PROCESO_AUTO',
+  cuotas_atrasadas_nuevas  integer NOT NULL DEFAULT 0,
+  status_credito           text,                                 -- status al momento (traza B5/legal)
+  asesor_id                integer REFERENCES cartera.asesores (asesor_id) ON DELETE SET NULL,
+  pago_id                  integer REFERENCES cartera.pagos_credito (pago_id) ON DELETE SET NULL,
+  motivo                   text,
+  fecha                    timestamp NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS buckets_historial_credito_idx
+  ON cartera.buckets_historial (credito_id);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS buckets_historial_fecha_idx
+  ON cartera.buckets_historial (fecha);
+--> statement-breakpoint
+-- Soporta el "último bucket por crédito" (DISTINCT ON credito_id ORDER BY fecha DESC).
+CREATE INDEX IF NOT EXISTS buckets_historial_credito_fecha_idx
+  ON cartera.buckets_historial (credito_id, fecha);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS buckets_historial_asesor_idx
+  ON cartera.buckets_historial (asesor_id);

--- a/apps/cartera-back/drizzle/cobros-02/README.md
+++ b/apps/cartera-back/drizzle/cobros-02/README.md
@@ -1,0 +1,16 @@
+# Migraciones COBROS-02 (rediseño de cobros)
+
+Estas migraciones están **agrupadas aparte** a propósito: pertenecen al rediseño
+de cobros (**release COBROS-02**), una versión aislada que sale en meses y que
+**NO pasa por develop**. Se separan de las migraciones normales de `drizzle/`
+para que se sepa que se aplican como bloque cuando salga esa versión.
+
+- **Se aplican a mano** (Cartera no usa `drizzle-kit` para esto). SQL idempotente.
+- Corresponden al schema en `src/database/db/schema.ts`.
+- Orden de aplicación = por número de archivo (`0000_...`, `0001_...`, ...).
+
+## Contenido
+
+| Archivo | Qué crea |
+|---|---|
+| `0000_motor_buckets.sql` | Motor de buckets: enums `bucket_evento_tipo`/`bucket_evento_origen`, tabla `buckets_historial` (transiciones) y `asesor_bucket` (asignación pool). |

--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { client, db } from "../database";
-import { asesores, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, platform_users, usuarios } from "../database/db/schema";
+import { asesores, buckets_historial, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, pagos_credito, platform_users, usuarios } from "../database/db/schema";
 import Big from "big.js";
 import { toZonedTime } from "date-fns-tz";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
@@ -44,6 +44,34 @@ export function isOverdueInstallmentForMora(
   const isEligible = !STATUS_EXCLUIDOS_MORA.includes(cuota.statusCredit ?? "");
 
   return isOverdue && isUnpaid && isEligible;
+}
+
+// ============================================================
+// 🪣 MOTOR DE BUCKETS (COBROS-02) — bucket derivado por estado + cuotas
+// ============================================================
+// B5 (Jurídico) y los estados fuera del funnel operativo se determinan por
+// statusCredit, NO por conteo de cuotas (esos créditos ya no llevan mora).
+export const STATUS_BUCKET_B5 = ["INCOBRABLE"]; // legal / jurídico
+export const STATUS_BUCKET_FUERA = [
+  "CANCELADO",
+  "PENDIENTE_CANCELACION",
+  "EN_CONVENIO",
+  "CAIDO",
+];
+
+/**
+ * Bucket de un crédito (0-5) según su estado y cuotas atrasadas.
+ * Devuelve `null` si el crédito está fuera del funnel operativo (no se trackea).
+ * B0=0, B1=1, B2=2, B3=3, B4=4, B5=>=5 (o INCOBRABLE/legal).
+ */
+export function bucketDeCredito(
+  status: string | null | undefined,
+  cuotasAtrasadas: number,
+): number | null {
+  if (status && STATUS_BUCKET_B5.includes(status)) return 5;
+  if (status && STATUS_BUCKET_FUERA.includes(status)) return null;
+  // ACTIVO / MOROSO → por cuotas
+  return Math.min(Math.max(cuotasAtrasadas, 0), 5);
 }
 
 /**
@@ -868,6 +896,97 @@ export async function procesarMoras() {
 
       desactivadas++;
       console.log(`[DEACTIVATE] Credit #${mora.credito_id} se puso al día → mora desactivada`);
+    }
+
+    // ============================================================
+    // 🪣 MOTOR DE BUCKETS (COBROS-02) — registrar transiciones de bucket
+    // ============================================================
+    // Paso ADITIVO: no toca el cálculo de mora. Detecta cambios de bucket
+    // (derivado de estado + cuotas) y los registra en `buckets_historial`.
+    // Si algo falla aquí, NO debe romper el proceso de mora (operación crítica).
+    try {
+      // status por crédito — ya viene en `cuotas` (el job lo cargó con JOIN)
+      const statusPorCredito = new Map<number, string>();
+      for (const c of cuotas) {
+        if (!statusPorCredito.has(c.credito_id)) {
+          statusPorCredito.set(c.credito_id, c.statusCredit);
+        }
+      }
+
+      // Último bucket registrado por crédito (para detectar el cambio).
+      const ultimoBucket = new Map<number, number>();
+      const ultimosRes = await lockConn.query(
+        `SELECT DISTINCT ON (credito_id) credito_id, bucket_nuevo
+           FROM cartera.buckets_historial
+          ORDER BY credito_id, fecha DESC`,
+      );
+      for (const row of ultimosRes.rows) {
+        ultimoBucket.set(Number(row.credito_id), Number(row.bucket_nuevo));
+      }
+
+      let bucketsSubidas = 0;
+      let bucketsBajadas = 0;
+
+      for (const [creditoId, status] of statusPorCredito) {
+        const cuotasAtrasadas = moraPorCredito[creditoId] ?? 0;
+        const bucketNuevo = bucketDeCredito(status, cuotasAtrasadas);
+        if (bucketNuevo === null) continue; // fuera del funnel operativo
+
+        const tieneHistorial = ultimoBucket.has(creditoId);
+        const bucketAnterior = ultimoBucket.get(creditoId) ?? 0;
+        if (bucketNuevo === bucketAnterior) continue; // sin cambio de bucket
+
+        const esSubida = bucketNuevo > bucketAnterior;
+
+        // Atribución (Opción B): en la BAJADA (cuenta curada) trazamos el pago
+        // que la mejoró (best-effort: último pago validado del crédito). El
+        // `asesor_id` se llenará cuando el NUEVO flujo de pago capture al asesor
+        // de forma estructurada (hoy pagos_credito.registerBy es texto libre).
+        let pagoId: number | null = null;
+        if (!esSubida) {
+          const [pago] = await db
+            .select({ pago_id: pagos_credito.pago_id })
+            .from(pagos_credito)
+            .where(
+              and(
+                eq(pagos_credito.credito_id, creditoId),
+                eq(pagos_credito.paymentFalse, false),
+                inArray(pagos_credito.validationStatus, [
+                  "validated",
+                  "no_required",
+                ]),
+              ),
+            )
+            .orderBy(desc(pagos_credito.pago_id))
+            .limit(1);
+          pagoId = pago?.pago_id ?? null;
+        }
+
+        await db.insert(buckets_historial).values({
+          credito_id: creditoId,
+          bucket_anterior: tieneHistorial ? bucketAnterior : null,
+          bucket_nuevo: bucketNuevo,
+          tipo_evento: esSubida ? "SUBIDA" : "BAJADA",
+          origen: "PROCESO_AUTO",
+          cuotas_atrasadas_nuevas: cuotasAtrasadas,
+          status_credito: status,
+          asesor_id: null, // Opción B: se llena con el nuevo flujo de pago
+          pago_id: pagoId,
+        });
+
+        ultimoBucket.set(creditoId, bucketNuevo);
+        if (esSubida) bucketsSubidas++;
+        else bucketsBajadas++;
+      }
+
+      console.log(
+        `[BUCKETS] Transiciones registradas — subidas: ${bucketsSubidas}, bajadas: ${bucketsBajadas}`,
+      );
+    } catch (bucketErr) {
+      console.error(
+        "[BUCKETS] ⚠️ Error registrando transiciones de bucket (el proceso de mora no se ve afectado):",
+        bucketErr,
+      );
     }
 
     console.log("\n╔════════════════════════════════════════════════════════════");

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -393,6 +393,82 @@
     index("moras_historial_fecha_idx").on(table.fecha),
   ]);
 
+  // ============================================================
+  // 🪣 MOTOR DE BUCKETS (COBROS-02) — clasificación por etapa de mora
+  // ============================================================
+  // El bucket de un crédito es DERIVADO de sus cuotas atrasadas (no se
+  // materializa una fila por crédito): B0=0, B1=1, B2=2, B3=3, B4=4, B5=>=5.
+  // Los estados fuera del funnel operativo (INCOBRABLE/legal = B5, CANCELADO,
+  // EN_CONVENIO, etc.) se determinan por statusCredit, no por conteo de cuotas.
+  // Solo se persiste el HISTORIAL de transiciones + la asignación asesor↔bucket.
+
+  export const bucketEventoTipoEnum = customSchema.enum("bucket_evento_tipo", [
+    "SUBIDA",
+    "BAJADA",
+  ]);
+
+  export const bucketEventoOrigenEnum = customSchema.enum(
+    "bucket_evento_origen",
+    ["PROCESO_AUTO", "API_MANUAL"]
+  );
+
+  // Asignación asesor ↔ bucket (modelo POOL, muchos-a-muchos): un bucket con
+  // varios asesores y un asesor en varios buckets.
+  export const asesor_bucket = customSchema.table(
+    "asesor_bucket",
+    {
+      id: serial("id").primaryKey(),
+      asesor_id: integer("asesor_id")
+        .notNull()
+        .references(() => asesores.asesor_id, { onDelete: "cascade" }),
+      bucket: integer("bucket").notNull(), // 0-5
+      activo: boolean("activo").notNull().default(true),
+      created_at: timestamp("created_at").defaultNow(),
+      updated_at: timestamp("updated_at").defaultNow(),
+    },
+    (t) => [
+      uniqueIndex("asesor_bucket_uq").on(t.asesor_id, t.bucket),
+      index("asesor_bucket_bucket_idx").on(t.bucket),
+    ]
+  );
+
+  // Bitácora de transiciones de bucket (append-only). El bucket actual se deriva;
+  // aquí solo se registra CUÁNDO cambia (SUBIDA = empeora, BAJADA = mejora/cura).
+  export const buckets_historial = customSchema.table(
+    "buckets_historial",
+    {
+      historial_id: serial("historial_id").primaryKey(),
+      credito_id: integer("credito_id")
+        .notNull()
+        .references(() => creditos.credito_id, { onDelete: "cascade" }),
+      bucket_anterior: integer("bucket_anterior"), // null en el primer registro
+      bucket_nuevo: integer("bucket_nuevo").notNull(),
+      tipo_evento: bucketEventoTipoEnum("tipo_evento").notNull(),
+      origen: bucketEventoOrigenEnum("origen").notNull().default("PROCESO_AUTO"),
+      cuotas_atrasadas_nuevas: integer("cuotas_atrasadas_nuevas")
+        .notNull()
+        .default(0),
+      status_credito: text("status_credito"), // status al momento (traza B5/legal)
+      // 🎯 Atribución para métricas: qué asesor gatilló la transición. Sobre todo
+      // en la BAJADA (cuenta curada) = el asesor que registró el pago, para que le
+      // cuente en su métrica. null en SUBIDA o mientras no se pueda resolver.
+      asesor_id: integer("asesor_id").references(() => asesores.asesor_id, {
+        onDelete: "set null",
+      }),
+      pago_id: integer("pago_id").references(() => pagos_credito.pago_id, {
+        onDelete: "set null",
+      }),
+      motivo: text("motivo"),
+      fecha: timestamp("fecha").defaultNow().notNull(),
+    },
+    (t) => [
+      index("buckets_historial_credito_idx").on(t.credito_id),
+      index("buckets_historial_fecha_idx").on(t.fecha),
+      index("buckets_historial_credito_fecha_idx").on(t.credito_id, t.fecha),
+      index("buckets_historial_asesor_idx").on(t.asesor_id),
+    ]
+  );
+
   export const creditos_rubros_otros = customSchema.table("creditos_rubros_otros", {
     id: serial("id").primaryKey(),
     credito_id: integer("credito_id")


### PR DESCRIPTION
## Qué agrega

Primera feature del rediseño de cobros (**COBROS-02**): el **motor de buckets**.

Un crédito "está en" un bucket según sus cuotas atrasadas (B0=0 … B4=4, B5=≥5 o legal). El bucket es **derivado** (no se materializa por crédito); solo se persiste el **historial de transiciones** + la **asignación asesor↔bucket** (pool).

### Tablas nuevas (`schema.ts` + SQL en `drizzle/cobros-02/`)
- `buckets_historial` — transiciones append-only (`SUBIDA`/`BAJADA`), con `asesor_id`/`pago_id` para atribución de métricas.
- `asesor_bucket` — asignación asesor↔bucket (muchos-a-muchos, modelo pool).
- enums `bucket_evento_tipo`, `bucket_evento_origen`.

### Job (`procesarMoras`)
- Helper `bucketDeCredito(status, cuotas)` que **respeta el estado**: `INCOBRABLE`/legal → B5; `CANCELADO`/`EN_CONVENIO`/etc → fuera del funnel; `ACTIVO`/`MOROSO` → `min(cuotas,5)`.
- **Pass aditivo** al final del job: compara el bucket derivado contra el último registrado (`DISTINCT ON`) y escribe la transición. **No toca el cálculo de mora** (envuelto en try/catch).

### Atribución (Opción B)
En la BAJADA (cuenta curada) se traza `pago_id` (último pago validado del crédito). `asesor_id` queda listo para llenarse cuando el nuevo flujo de pago capture al asesor de forma estructurada (hoy `pagos_credito.registerBy` es texto libre).

## Migración
`drizzle/cobros-02/0000_motor_buckets.sql` — SQL **idempotente**, se aplica **a mano** (Cartera no usa drizzle-kit), agrupado aparte para el release COBROS-02.

## Notas / a revisar
- Primera corrida = **siembra** el bucket actual de cada crédito (registro inicial con `bucket_anterior = null`).
- `EN_CONVENIO` queda **fuera del funnel** de buckets (a confirmar).
- `tsc --noEmit`: sin errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
