### PR TITLE
feat(cobros): filtro 'Ocultar los que ya pagaron su cuota' (cartera + CRM)

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -616,7 +616,8 @@ export async function getCreditosWithUserByMesAnio(
   capital_min?: number,
   capital_max?: number,
   estados_credito?: StatusCredit[],
-  aseguradora_id?: number
+  aseguradora_id?: number,
+  excluir_pagados_mes?: boolean
 ): Promise<{
   data: CreditoConInfo[];
   page: number;
@@ -799,6 +800,32 @@ export async function getCreditosWithUserByMesAnio(
 
   if (aseguradora_id !== undefined) {
     conditions.push(eq(creditos.aseguradora_id, aseguradora_id));
+  }
+
+  if (excluir_pagados_mes) {
+    console.log(`🔎 Excluyendo créditos con su cuota actual ya pagada`);
+    // Cuota actual = primera cuota con fecha_vencimiento >= hoy (mismo
+    // concepto que proxima_cuota). Se excluye el crédito solo si esa cuota
+    // está pagada (todas sus filas, por si hay duplicadas) Y no tiene mora
+    // activa; sin cuotas futuras no se excluye. Subconsulta correlacionada
+    // en vez de join para no multiplicar filas (paginación) y para que el
+    // COUNT herede la condición.
+    conditions.push(sql`NOT (
+      ${moras_credito.credito_id} IS NULL
+      AND COALESCE((
+        SELECT bool_and(COALESCE(cc.pagado, false))
+        FROM ${cuotas_credito} cc
+        WHERE cc.credito_id = ${creditos.credito_id}
+          AND cc.numero_cuota > 0
+          AND cc.fecha_vencimiento = (
+            SELECT MIN(cc2.fecha_vencimiento)
+            FROM ${cuotas_credito} cc2
+            WHERE cc2.credito_id = ${creditos.credito_id}
+              AND cc2.numero_cuota > 0
+              AND cc2.fecha_vencimiento >= ${hoyStr}::date
+          )
+      ), false)
+    )`);
   }
 
   const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;

--- a/apps/cartera-back/src/controllers/excluirPagadosMes.test.ts
+++ b/apps/cartera-back/src/controllers/excluirPagadosMes.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "bun:test";
+
+// Test de integración: ejercita el filtro excluir_pagados_mes de
+// getCreditosWithUserByMesAnio contra la base configurada en SUPABASE_DB_URL
+// (clon DEV/local). Solo lecturas. Si no hay DB configurada, se salta.
+const hasDb = !!process.env.SUPABASE_DB_URL;
+
+if (!hasDb) {
+  describe("excluir_pagados_mes (integración)", () => {
+    it.skip("requiere SUPABASE_DB_URL apuntando al clon DEV/local", () => {});
+  });
+} else {
+  const { sql } = await import("drizzle-orm");
+  const { db } = await import("../database/index");
+  const { getCreditosWithUserByMesAnio } = await import("./credits");
+
+  const hoyGuatemala = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
+  );
+  const hoyStr = hoyGuatemala.toISOString().slice(0, 10);
+
+  const toRows = (r: any) => (Array.isArray(r) ? r : (r.rows ?? []));
+
+  // Mismo criterio que la implementación, expresado en SQL independiente.
+  const cuotaActualPagadaSql = (alias: string) => sql.raw(`
+    COALESCE((
+      SELECT bool_and(COALESCE(cc.pagado, false))
+      FROM cartera.cuotas_credito cc
+      WHERE cc.credito_id = ${alias}.credito_id AND cc.numero_cuota > 0
+        AND cc.fecha_vencimiento = (
+          SELECT MIN(cc2.fecha_vencimiento) FROM cartera.cuotas_credito cc2
+          WHERE cc2.credito_id = ${alias}.credito_id AND cc2.numero_cuota > 0
+            AND cc2.fecha_vencimiento >= '${hoyStr}'::date)
+    ), false)`);
+
+  const moraActivaSql = (alias: string) =>
+    sql.raw(`EXISTS (SELECT 1 FROM cartera.moras_credito m
+      WHERE m.credito_id = ${alias}.credito_id AND m.activa = true)`);
+
+  async function buscarEscenario(pagada: boolean, conMora: boolean) {
+    const rows = toRows(
+      await db.execute(sql`
+        SELECT c.numero_credito_sifco
+        FROM cartera.creditos c
+        JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+        JOIN cartera.asesores a ON a.asesor_id = c.asesor_id
+        WHERE c."statusCredit" IN ('ACTIVO','MOROSO','EN_CONVENIO')
+          AND ${cuotaActualPagadaSql("c")} = ${pagada}
+          AND ${moraActivaSql("c")} = ${conMora}
+        LIMIT 1
+      `)
+    );
+    return rows[0]?.numero_credito_sifco as string | undefined;
+  }
+
+  async function totalPorSifco(sifco: string, excluir?: boolean) {
+    const res = await getCreditosWithUserByMesAnio(
+      0, hoyGuatemala.getFullYear(), 1, 5, sifco, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, excluir
+    );
+    return res.totalCount;
+  }
+
+  describe(`excluir_pagados_mes (integración, hoy=${hoyStr})`, () => {
+    it("el totalCount con flag cuadra con un cross-check SQL independiente", async () => {
+      const off = await getCreditosWithUserByMesAnio(
+        0, hoyGuatemala.getFullYear(), 1, 1, undefined, "ACTIVO",
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined
+      );
+      const on = await getCreditosWithUserByMesAnio(
+        0, hoyGuatemala.getFullYear(), 1, 1, undefined, "ACTIVO",
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, undefined, undefined, undefined, undefined,
+        undefined, undefined, true
+      );
+      const [check] = toRows(
+        await db.execute(sql`
+          SELECT count(*) AS excluibles
+          FROM cartera.creditos c
+          JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+          JOIN cartera.asesores a ON a.asesor_id = c.asesor_id
+          WHERE c."statusCredit" IN ('ACTIVO','MOROSO','EN_CONVENIO')
+            AND ${cuotaActualPagadaSql("c")} = true
+            AND NOT ${moraActivaSql("c")}
+        `)
+      );
+      expect(off.totalCount - on.totalCount).toBe(Number(check.excluibles));
+      expect(on.totalCount).toBeLessThanOrEqual(off.totalCount);
+    });
+
+    it("crédito que YA pagó su cuota actual y sin mora → se excluye con el flag", async () => {
+      const sifco = await buscarEscenario(true, false);
+      if (!sifco) return console.warn("(sin escenario en la DB, se omite)");
+      expect(await totalPorSifco(sifco, undefined)).toBe(1); // sin flag sigue saliendo
+      expect(await totalPorSifco(sifco, true)).toBe(0); // con flag desaparece
+    });
+
+    it("moroso que pagó su cuota actual pero con mora activa → NO se excluye", async () => {
+      const sifco = await buscarEscenario(true, true);
+      if (!sifco) return console.warn("(sin escenario en la DB, se omite)");
+      expect(await totalPorSifco(sifco, true)).toBe(1);
+    });
+
+    it("crédito que NO ha pagado su cuota actual → NO se excluye", async () => {
+      const sifco = await buscarEscenario(false, false);
+      if (!sifco) return console.warn("(sin escenario en la DB, se omite)");
+      expect(await totalPorSifco(sifco, true)).toBe(1);
+    });
+  });
+}

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -219,6 +219,7 @@ export async function getCreditosWithUserByMesAnioExcel(
     is_vehiculo_propio?: boolean;
     inversionista_ids?: number[];
     aseguradora_id?: number;
+    excluir_pagados_mes?: boolean;
     excel?: boolean;
   }
 ) {
@@ -245,7 +246,8 @@ export async function getCreditosWithUserByMesAnioExcel(
     undefined, // capital_min
     undefined, // capital_max
     undefined, // estados_credito
-    rest.aseguradora_id
+    rest.aseguradora_id,
+    rest.excluir_pagados_mes
   );
 
   if (!excel) return result; // si no piden excel, devolvemos JSON normal

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -200,6 +200,7 @@ export const creditRouter = new Elysia()
     capital_max,
     estados_credito,
     aseguradora_id,      // 🆕 NUEVO
+    excluir_pagados_mes, // 🆕 NUEVO
   } = query as Record<string, string>;
 
   // Validar parámetros requeridos
@@ -334,6 +335,9 @@ export const creditRouter = new Elysia()
     return { message: "Parámetro 'aseguradora_id' debe ser un número válido." };
   }
 
+  // 🆕 Excluir créditos con su cuota actual ya pagada (default false)
+  const excluirPagadosMesParam = excluir_pagados_mes === "true" ? true : undefined;
+
   // Llamar servicio
   try {
     if (excel === "true") {
@@ -354,6 +358,7 @@ export const creditRouter = new Elysia()
         is_vehiculo_propio: isVehiculoPropioParam,
         inversionista_ids: inversionistaIdsArray,
         aseguradora_id: aseguradoraIdNum,
+        excluir_pagados_mes: excluirPagadosMesParam,
         excel: true,
       });
       set.status = 200;
@@ -380,7 +385,8 @@ export const creditRouter = new Elysia()
         capitalMinParam,
         capitalMaxParam,
         estadosCreditoParsed?.values,
-        aseguradoraIdNum
+        aseguradoraIdNum,
+        excluirPagadosMesParam
       );
       set.status = 200;
       return result;
@@ -425,6 +431,7 @@ export const creditRouter = new Elysia()
         capital_max,
         estados_credito,
         aseguradora_id,
+        excluir_pagados_mes,
       } = body;
 
       if (mes === undefined || anio === undefined || !estado) {
@@ -466,6 +473,7 @@ export const creditRouter = new Elysia()
             is_vehiculo_propio,
             inversionista_ids,
             aseguradora_id,
+            excluir_pagados_mes,
             excel: true,
           });
           set.status = 200;
@@ -492,7 +500,8 @@ export const creditRouter = new Elysia()
           capital_min,
           capital_max,
           estadosCreditoParsed?.values,
-          aseguradora_id
+          aseguradora_id,
+          excluir_pagados_mes
         );
         set.status = 200;
         return result;
@@ -540,6 +549,7 @@ export const creditRouter = new Elysia()
         capital_max: t.Optional(t.Number()),
         estados_credito: t.Optional(t.Array(t.String())),
         aseguradora_id: t.Optional(t.Number()),
+        excluir_pagados_mes: t.Optional(t.Boolean()),
       }),
     }
   )

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -100,6 +100,7 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 	fecha_hasta?: string;
 	capital_min?: number;
 	capital_max?: number;
+	excluir_pagados_mes?: boolean;
 }) {
 	const estado = params.estado || "ACTIVO";
 
@@ -145,6 +146,9 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 		}),
 		...(params.capital_max !== undefined && {
 			capital_max: params.capital_max,
+		}),
+		...(params.excluir_pagados_mes && {
+			excluir_pagados_mes: true,
 		}),
 	});
 
@@ -659,6 +663,7 @@ export const cobrosRouter = {
 				etiquetas: z.array(z.string()).optional(),
 				capitalMin: z.number().optional(),
 				capitalMax: z.number().optional(),
+				excluirPagadosMes: z.boolean().optional(),
 			}),
 		)
 		.handler(async ({ input }) => {
@@ -832,6 +837,7 @@ export const cobrosRouter = {
 									fecha_hasta: input.fechaHasta,
 									capital_min: input.capitalMin,
 									capital_max: input.capitalMax,
+									excluir_pagados_mes: input.excluirPagadosMes,
 								});
 							}
 						} else {
@@ -877,6 +883,7 @@ export const cobrosRouter = {
 									numeros_credito_sifco: sifcosFiltro,
 									capital_min: input.capitalMin,
 									capital_max: input.capitalMax,
+									excluir_pagados_mes: input.excluirPagadosMes,
 								});
 
 								const allCredits = [...firstPage.data];
@@ -896,6 +903,7 @@ export const cobrosRouter = {
 										numeros_credito_sifco: sifcosFiltro,
 										capital_min: input.capitalMin,
 										capital_max: input.capitalMax,
+										excluir_pagados_mes: input.excluirPagadosMes,
 									});
 									allCredits.push(...nextPage.data);
 								}
@@ -940,6 +948,7 @@ export const cobrosRouter = {
 								fecha_hasta: input.fechaHasta,
 								capital_min: input.capitalMin,
 								capital_max: input.capitalMax,
+								excluir_pagados_mes: input.excluirPagadosMes,
 							});
 						}
 					} else {
@@ -959,6 +968,7 @@ export const cobrosRouter = {
 							numeros_credito_sifco: sifcosPorEtiquetas,
 							capital_min: input.capitalMin,
 							capital_max: input.capitalMax,
+							excluir_pagados_mes: input.excluirPagadosMes,
 						});
 					}
 
@@ -3211,6 +3221,7 @@ export const cobrosRouter = {
 				etiquetas: z.array(z.string()).optional(),
 				fechaDesde: z.string().optional(),
 				fechaHasta: z.string().optional(),
+				excluirPagadosMes: z.boolean().optional(),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -3426,6 +3437,7 @@ export const cobrosRouter = {
 						numeros_credito_sifco: sifcosPorEtiquetas,
 						fecha_desde: input.fechaDesde,
 						fecha_hasta: input.fechaHasta,
+						excluir_pagados_mes: input.excluirPagadosMes,
 						page,
 						perPage,
 					});

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -736,6 +736,9 @@ export class CarteraBackClient {
 						...(params.capital_max !== undefined && {
 							capital_max: params.capital_max,
 						}),
+						...(params.excluir_pagados_mes && {
+							excluir_pagados_mes: true,
+						}),
 						excel: false,
 					}),
 				},
@@ -769,6 +772,9 @@ export class CarteraBackClient {
 				}),
 				...(params.capital_max !== undefined && {
 					capital_max: params.capital_max.toString(),
+				}),
+				...(params.excluir_pagados_mes && {
+					excluir_pagados_mes: "true",
 				}),
 				excel: "false",
 			});

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -575,6 +575,7 @@ export interface GetAllCreditsParams {
 	fecha_hasta?: string;
 	capital_min?: number;
 	capital_max?: number;
+	excluir_pagados_mes?: boolean;
 }
 
 export interface GetPaymentsParams {

--- a/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
@@ -97,6 +97,7 @@ interface MassWhatsappModalProps {
 		etiquetas?: string[];
 		fechaDesde?: string;
 		fechaHasta?: string;
+		excluirPagadosMes?: boolean;
 	};
 	etiquetaLabels?: Record<string, string>;
 	totalDestinatarios?: number;
@@ -187,6 +188,7 @@ export function MassWhatsappModal({
 						: undefined,
 				fechaDesde: filtros.fechaDesde,
 				fechaHasta: filtros.fechaHasta,
+				excluirPagadosMes: filtros.excluirPagadosMes,
 			}),
 		onSuccess: (res) => {
 			// `descartados` ya incluye los que fallaron en el proveedor, así que

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -311,6 +311,7 @@ function RouteComponent() {
 	const [fechaError, setFechaError] = useState<string | null>(null);
 	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>("cobros/capitalMin", undefined);
 	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>("cobros/capitalMax", undefined);
+	const [excluirPagados, setExcluirPagados] = usePersistedState<boolean>("cobros/excluirPagados", false);
 
 	const hasActiveFilters =
 		filtroTemporal !== "hoy" ||
@@ -320,7 +321,8 @@ function RouteComponent() {
 		sifcoFilterValue !== "" ||
 		capitalMin !== undefined ||
 		capitalMax !== undefined ||
-		dateRange !== undefined;
+		dateRange !== undefined ||
+		excluirPagados;
 	const resetFilters = () => {
 		setFiltroTemporal("hoy");
 		setFiltroEtapa(null);
@@ -329,6 +331,7 @@ function RouteComponent() {
 		setSifcoFilterValue("");
 		setCapitalMin(undefined);
 		setCapitalMax(undefined);
+		setExcluirPagados(false);
 		setDateRange(undefined);
 		setPickerRange(undefined);
 		setFechaError(null);
@@ -461,6 +464,7 @@ function RouteComponent() {
 				etiquetas: filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
 				capitalMin,
 				capitalMax,
+				excluirPagadosMes: excluirPagados || undefined,
 			},
 		}),
 		enabled: !!session,
@@ -1049,6 +1053,7 @@ function RouteComponent() {
 										filtroEtiquetas.length > 0 ? filtroEtiquetas : undefined,
 									fechaDesde,
 									fechaHasta,
+									excluirPagadosMes: excluirPagados || undefined,
 								}}
 								etiquetaLabels={ETIQUETA_LABELS_FILTRO}
 								totalDestinatarios={totalCreditos}
@@ -1177,6 +1182,25 @@ function RouteComponent() {
 									</div>
 								</div>
 
+								{/* Cuota actual */}
+								<div className="flex flex-col gap-2">
+									<span className="font-semibold text-muted-foreground text-xs uppercase tracking-wide">
+										Cuota actual
+									</span>
+									<div className="flex flex-wrap items-center gap-2">
+										<Button
+											variant={excluirPagados ? "default" : "outline"}
+											size="sm"
+											onClick={() => {
+												setExcluirPagados(!excluirPagados);
+												setPage(1);
+											}}
+										>
+											Ocultar los que ya pagaron su cuota
+										</Button>
+									</div>
+								</div>
+
 								{/* Etiquetas */}
 								<div className="flex flex-col gap-2">
 									<span className="font-semibold text-muted-foreground text-xs uppercase tracking-wide">
@@ -1237,7 +1261,7 @@ function RouteComponent() {
 											<X className="mr-1 h-3 w-3" />
 											Limpiar filtros
 											<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
-												{[filtroTemporal !== "hoy", filtroEtapa !== null, filtroEtiquetas.length > 0, filterValue !== "", sifcoFilterValue !== "", capitalMin !== undefined, capitalMax !== undefined, dateRange !== undefined].filter(Boolean).length}
+												{[filtroTemporal !== "hoy", filtroEtapa !== null, filtroEtiquetas.length > 0, filterValue !== "", sifcoFilterValue !== "", capitalMin !== undefined, capitalMax !== undefined, dateRange !== undefined, excluirPagados].filter(Boolean).length}
 											</Badge>
 										</Button>
 									</div>


### PR DESCRIPTION
## Qué hace

Nuevo filtro end-to-end para la pantalla de **Cobros**: un botón que oculta de la lista los créditos que **ya pagaron su cuota actual**.

> Continuación del PR #1021 (estos commits quedaron fuera porque se mergeó antes del push). El fix del bucket Mora 120+ que venía en la rama ya llegó a develop por otro lado, así que aquí no se repite.

## 1) cartera-back: parámetro `excluir_pagados_mes` en /getAllCredits

Booleano opcional (default `false`, GET query / POST body / variante Excel). Con `true` se excluye un crédito solo si:
- su **cuota actual** (primera cuota con `fecha_vencimiento >= hoy` GT, mismo concepto que `proxima_cuota` de la columna "Fecha de Pago") ya está **pagada**, y
- **no** tiene mora activa (los morosos nunca se ocultan; créditos sin cuotas futuras tampoco).

Implementado como **subconsulta correlacionada** en el WHERE — sin joins nuevos, no multiplica filas en la paginación y el `COUNT(DISTINCT)` hereda la condición. Sin el flag, comportamiento idéntico al actual.

**Ejemplo:** hoy 6-jul, cuota vence 30-jul → si pago hoy, desaparezco de la lista; si debo cuotas viejas (mora), sigo apareciendo.

## 2) CRM: botón en la pantalla de Cobros

Sección **"Cuota actual"** en el panel de filtros con toggle persistido (`cobros/excluirPagados`), integrado al contador de filtros activos y a "Limpiar filtros". Viaja por `getTodosLosCreditos` (los 5 caminos del handler) → `cartera-back-client` (GET y POST).

El **envío masivo de WhatsApp** respeta el mismo filtro: con el toggle activo no se le escribe a clientes que ya pagaron su cuota actual.

## Verificación

- Test de integración [excluirPagadosMes.test.ts](apps/cartera-back/src/controllers/excluirPagadosMes.test.ts) contra el clon DEV con la fecha del día: **4 pass** — cuadre de `totalCount` vs cross-check SQL independiente (1,532 sin flag vs 1,508 con flag, 24 excluidos 1:1), pagó-adelantado se excluye, no-pagado se queda. Se salta solo si no hay `SUPabase_DB_URL`.
- `tsc --noEmit`: cartera-back mantiene sus 6 errores preexistentes (0 nuevos), CRM server en 0.
- Biome limpio en los archivos tocados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)