### PR TITLE
fix(crm): separate effectiveness and period closes

### DIFF
--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
+	buildPorcentajeEfectividadFuenteRows,
 	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
 	enforceClosedCreditReportLimit,
 	isClosedCreditReportCarteraStatusIncluded,
-	isPorcentajeEfectividadPeriodCloseIncluded,
 	isPorcentajeEfectividadOpportunityStatusIncluded,
+	isPorcentajeEfectividadPeriodCloseIncluded,
 } from "./reports";
 
 describe("isClosedCreditReportCarteraStatusIncluded", () => {
@@ -69,6 +70,55 @@ describe("isPorcentajeEfectividadPeriodCloseIncluded", () => {
 				end,
 			),
 		).toBe(false);
+	});
+});
+
+describe("buildPorcentajeEfectividadFuenteRows", () => {
+	test("keeps cohort closes and period closes as separate per-source metrics", () => {
+		const rows = buildPorcentajeEfectividadFuenteRows(
+			[
+				{
+					source: "agency",
+					totalOportunidades: 25,
+					totalCerradas: 0,
+					porcentaje: 0,
+				},
+				{
+					source: "meta",
+					totalOportunidades: 108,
+					totalCerradas: 0,
+					porcentaje: 0,
+				},
+			],
+			[
+				{ source: "agency", totalCierresPeriodo: 11 },
+				{ source: "website", totalCierresPeriodo: 3 },
+			],
+		);
+
+		expect(rows).toEqual([
+			{
+				source: "meta",
+				totalOportunidades: 108,
+				totalCerradas: 0,
+				totalCierresPeriodo: 0,
+				porcentaje: 0,
+			},
+			{
+				source: "agency",
+				totalOportunidades: 25,
+				totalCerradas: 0,
+				totalCierresPeriodo: 11,
+				porcentaje: 0,
+			},
+			{
+				source: "website",
+				totalOportunidades: 0,
+				totalCerradas: 0,
+				totalCierresPeriodo: 3,
+				porcentaje: 0,
+			},
+		]);
 	});
 });
 

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -537,6 +537,60 @@ export const getReporteInventario = protectedProcedure.handler(async () => {
 
 const CLOSED_STAGE_THRESHOLD = 90;
 const MAX_REPORT_ROWS = 10_000;
+
+type PorcentajeEfectividadFuenteBaseRow = {
+	source: string;
+	totalOportunidades: number;
+	totalCerradas: number;
+	porcentaje: number;
+};
+
+type PorcentajeEfectividadCierrePeriodoFuenteRow = {
+	source: string;
+	totalCierresPeriodo: number;
+};
+
+export function buildPorcentajeEfectividadFuenteRows(
+	cohortRows: PorcentajeEfectividadFuenteBaseRow[],
+	periodCloseRows: PorcentajeEfectividadCierrePeriodoFuenteRow[],
+) {
+	const bySource = new Map<
+		string,
+		PorcentajeEfectividadFuenteBaseRow & { totalCierresPeriodo: number }
+	>();
+
+	for (const row of cohortRows) {
+		bySource.set(row.source, {
+			source: row.source,
+			totalOportunidades: row.totalOportunidades,
+			totalCerradas: row.totalCerradas ?? 0,
+			totalCierresPeriodo: 0,
+			porcentaje: row.porcentaje ?? 0,
+		});
+	}
+
+	for (const row of periodCloseRows) {
+		const current = bySource.get(row.source) ?? {
+			source: row.source,
+			totalOportunidades: 0,
+			totalCerradas: 0,
+			totalCierresPeriodo: 0,
+			porcentaje: 0,
+		};
+		current.totalCierresPeriodo = row.totalCierresPeriodo ?? 0;
+		bySource.set(row.source, current);
+	}
+
+	return [...bySource.values()].sort((a, b) => {
+		if (b.totalOportunidades !== a.totalOportunidades) {
+			return b.totalOportunidades - a.totalOportunidades;
+		}
+		if (b.totalCierresPeriodo !== a.totalCierresPeriodo) {
+			return b.totalCierresPeriodo - a.totalCierresPeriodo;
+		}
+		return a.source.localeCompare(b.source);
+	});
+}
 /**
  * Reporte Porcentaje Efectividad
  * Tasa de conversión de oportunidades a créditos cerrados, por fuente.
@@ -589,66 +643,90 @@ export const getReportePorcentajeEfectividad =
 			const totalCerradas = sql<number>`COUNT(${everClosed.opportunityId})`;
 			const porcentaje = sql<number>`ROUND(COUNT(${everClosed.opportunityId}) * 100.0 / NULLIF(COUNT(${opportunities.id}), 0), 1)`;
 
-			const [totalRows, periodCloseRows, porFuente, registrosRaw] =
-				await Promise.all([
-					db
-						.select({
-							totalOportunidades: count(opportunities.id),
-							totalCerradas,
-							porcentaje,
-						})
-						.from(opportunities)
-						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-						.where(baseWhere),
+			const [
+				totalRows,
+				periodCloseRows,
+				porFuente,
+				cierresPeriodoPorFuente,
+				registrosRaw,
+			] = await Promise.all([
+				db
+					.select({
+						totalOportunidades: count(opportunities.id),
+						totalCerradas,
+						porcentaje,
+					})
+					.from(opportunities)
+					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+					.where(baseWhere),
 
-					db
-						.select({ totalCierresPeriodo: count(opportunities.id) })
-						.from(firstClosedStageDates)
-						.innerJoin(
-							opportunities,
-							eq(firstClosedStageDates.opportunityId, opportunities.id),
-						)
-						.where(
-							and(
-								gte(firstClosedStageDates.firstClosedStageAt, start),
-								lte(firstClosedStageDates.firstClosedStageAt, end),
-								ne(opportunities.status, MIGRATED_OPPORTUNITY_STATUS),
-							),
+				db
+					.select({ totalCierresPeriodo: count(opportunities.id) })
+					.from(firstClosedStageDates)
+					.innerJoin(
+						opportunities,
+						eq(firstClosedStageDates.opportunityId, opportunities.id),
+					)
+					.where(
+						and(
+							gte(firstClosedStageDates.firstClosedStageAt, start),
+							lte(firstClosedStageDates.firstClosedStageAt, end),
+							ne(opportunities.status, MIGRATED_OPPORTUNITY_STATUS),
 						),
+					),
 
-					db
-						.select({
-							source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-							totalOportunidades: count(opportunities.id),
-							totalCerradas,
-							porcentaje,
-						})
-						.from(opportunities)
-						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-						.where(baseWhere)
-						.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
-						.orderBy(desc(count(opportunities.id))),
+				db
+					.select({
+						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
+						totalOportunidades: count(opportunities.id),
+						totalCerradas,
+						porcentaje,
+					})
+					.from(opportunities)
+					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+					.where(baseWhere)
+					.groupBy(sql`COALESCE(${opportunities.source}, 'other')`)
+					.orderBy(desc(count(opportunities.id))),
 
-					db
-						.select({
-							id: opportunities.id,
-							createdAt: opportunities.createdAt,
-							source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
-							nombre: sql<
-								string | null
-							>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
-							etapaNombre: salesStages.name,
-							etapaPorcentaje: salesStages.closurePercentage,
-							cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
-						})
-						.from(opportunities)
-						.leftJoin(leads, eq(opportunities.leadId, leads.id))
-						.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
-						.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
-						.where(baseWhere)
-						.orderBy(desc(opportunities.createdAt))
-						.limit(MAX_REPORT_ROWS + 1),
-				]);
+				db
+					.select({
+						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
+						totalCierresPeriodo: count(opportunities.id),
+					})
+					.from(firstClosedStageDates)
+					.innerJoin(
+						opportunities,
+						eq(firstClosedStageDates.opportunityId, opportunities.id),
+					)
+					.where(
+						and(
+							gte(firstClosedStageDates.firstClosedStageAt, start),
+							lte(firstClosedStageDates.firstClosedStageAt, end),
+							ne(opportunities.status, MIGRATED_OPPORTUNITY_STATUS),
+						),
+					)
+					.groupBy(sql`COALESCE(${opportunities.source}, 'other')`),
+
+				db
+					.select({
+						id: opportunities.id,
+						createdAt: opportunities.createdAt,
+						source: sql<string>`COALESCE(${opportunities.source}, 'other')`,
+						nombre: sql<
+							string | null
+						>`NULLIF(TRIM(CONCAT_WS(' ', ${leads.firstName}, ${leads.lastName})), '')`,
+						etapaNombre: salesStages.name,
+						etapaPorcentaje: salesStages.closurePercentage,
+						cerro: sql<boolean>`(${everClosed.opportunityId} IS NOT NULL)`,
+					})
+					.from(opportunities)
+					.leftJoin(leads, eq(opportunities.leadId, leads.id))
+					.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
+					.leftJoin(everClosed, eq(opportunities.id, everClosed.opportunityId))
+					.where(baseWhere)
+					.orderBy(desc(opportunities.createdAt))
+					.limit(MAX_REPORT_ROWS + 1),
+			]);
 
 			if (registrosRaw.length > MAX_REPORT_ROWS) {
 				throw new ORPCError("BAD_REQUEST", {
@@ -661,16 +739,21 @@ export const getReportePorcentajeEfectividad =
 				total: {
 					totalOportunidades: totalRows[0]?.totalOportunidades ?? 0,
 					totalCerradas: totalRows[0]?.totalCerradas ?? 0,
-					totalCierresPeriodo:
-						periodCloseRows[0]?.totalCierresPeriodo ?? 0,
+					totalCierresPeriodo: periodCloseRows[0]?.totalCierresPeriodo ?? 0,
 					porcentaje: totalRows[0]?.porcentaje ?? 0,
 				},
-				porFuente: porFuente.map((row) => ({
-					source: row.source,
-					totalOportunidades: row.totalOportunidades,
-					totalCerradas: row.totalCerradas ?? 0,
-					porcentaje: row.porcentaje ?? 0,
-				})),
+				porFuente: buildPorcentajeEfectividadFuenteRows(
+					porFuente.map((row) => ({
+						source: row.source,
+						totalOportunidades: row.totalOportunidades,
+						totalCerradas: row.totalCerradas ?? 0,
+						porcentaje: row.porcentaje ?? 0,
+					})),
+					cierresPeriodoPorFuente.map((row) => ({
+						source: row.source,
+						totalCierresPeriodo: row.totalCierresPeriodo,
+					})),
+				),
 				registros: registrosRaw.map((row) => ({
 					id: row.id,
 					createdAt: row.createdAt,

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -248,6 +248,7 @@ export function PorcentajeEfectividadContent() {
 			porcentaje: row.porcentaje,
 			totalOportunidades: row.totalOportunidades,
 			totalCerradas: row.totalCerradas,
+			totalCierresPeriodo: row.totalCierresPeriodo,
 		}))
 		.sort((a, b) => b.porcentaje - a.porcentaje);
 
@@ -260,8 +261,7 @@ export function PorcentajeEfectividadContent() {
 					Porcentaje Efectividad
 				</h1>
 				<p className="mt-1 text-muted-foreground">
-					Oportunidades creadas, cierres del período y conversión por fuente.
-					Excluye oportunidades migradas.
+					Creadas en el rango y cierres del período por medio.
 				</p>
 			</div>
 
@@ -271,32 +271,38 @@ export function PorcentajeEfectividadContent() {
 			/>
 
 			{/* ── Resumen estadístico ── */}
-			<div className="grid gap-4 md:grid-cols-3">
+			<div className="grid gap-4 md:grid-cols-4">
 				<ReportCard
-					title="Oportunidades abiertas"
+					title="Oportunidades creadas"
 					value={isLoading ? "—" : (data?.total.totalOportunidades ?? 0)}
-					description="Creadas en el período, sin migradas"
+					description="En el rango"
 					icon={Activity}
+				/>
+				<ReportCard
+					title="Cerradas (creadas)"
+					value={isLoading ? "—" : (data?.total.totalCerradas ?? 0)}
+					description="Creadas en el rango"
+					icon={CheckCircle2}
 				/>
 				<ReportCard
 					title="Cierres del período"
 					value={isLoading ? "—" : (data?.total.totalCierresPeriodo ?? 0)}
-					description="Primer cierre 90%+ en el rango"
+					description="Primer 90%+ en el rango"
 					icon={CheckCircle2}
 				/>
 				<ReportCard
-					title="Efectividad Global"
+					title="Efectividad (creadas)"
 					value={isLoading ? "—" : `${data?.total.porcentaje ?? 0}%`}
-					description={`Cohorte creada: ${data?.total.totalCerradas ?? 0} cerradas`}
+					description="Cerradas / creadas"
 					icon={Target}
 				/>
 			</div>
 
 			<Card>
 				<CardHeader>
-					<CardTitle>Efectividad por fuente</CardTitle>
+					<CardTitle>Efectividad de creadas por fuente</CardTitle>
 					<CardDescription>
-						Ordenado de mayor a menor tasa de conversión
+						Cerradas de oportunidades creadas en el rango
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -354,8 +360,7 @@ export function PorcentajeEfectividadContent() {
 				<CardHeader>
 					<CardTitle>Detalle por fuente</CardTitle>
 					<CardDescription>
-						Oportunidades creadas, cerradas y tasa de conversión por canal de
-						origen
+						Creadas y cierres del rango por medio
 					</CardDescription>
 				</CardHeader>
 				<CardContent>
@@ -363,8 +368,9 @@ export function PorcentajeEfectividadContent() {
 						<TableHeader>
 							<TableRow>
 								<TableHead>Fuente</TableHead>
-								<TableHead className="text-right">Oportunidades</TableHead>
-								<TableHead className="text-right">Cerradas</TableHead>
+								<TableHead className="text-right">Creadas</TableHead>
+								<TableHead className="text-right">Cerradas (creadas)</TableHead>
+								<TableHead className="text-right">Cierres período</TableHead>
 								<TableHead className="text-right">Efectividad</TableHead>
 							</TableRow>
 						</TableHeader>
@@ -372,7 +378,7 @@ export function PorcentajeEfectividadContent() {
 							{isLoading ? (
 								<TableRow>
 									<TableCell
-										colSpan={4}
+										colSpan={5}
 										className="py-8 text-center text-muted-foreground"
 									>
 										Cargando...
@@ -381,7 +387,7 @@ export function PorcentajeEfectividadContent() {
 							) : chartData.length === 0 ? (
 								<TableRow>
 									<TableCell
-										colSpan={4}
+										colSpan={5}
 										className="py-8 text-center text-muted-foreground"
 									>
 										No hay datos para el período seleccionado
@@ -406,6 +412,9 @@ export function PorcentajeEfectividadContent() {
 										</TableCell>
 										<TableCell className="text-right">
 											{row.totalCerradas}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalCierresPeriodo}
 										</TableCell>
 										<TableCell className="text-right font-semibold">
 											{row.porcentaje}%


### PR DESCRIPTION
## Summary
- Separates created-opportunity effectiveness from period-close counts in CRM → Ventas → Reportes → Porcentaje Efectividad.
- Adds `totalCierresPeriodo` per source so the lower table can show both logics side by side.
- Updates the cards/copy to short functional labels: created opportunities, closed created opportunities, period closes, and effectiveness for created opportunities.

## Test Plan
- [x] `bun test apps/server/src/routers/reports.test.ts`
- [x] `node_modules/.bin/biome check apps/server/src/routers/reports.ts apps/server/src/routers/reports.test.ts apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx` exits 0; existing info-only hook dependency suggestion remains.
- [x] `git diff --check`

## Notes
- Server `check-types` still has existing unrelated repo errors in other files/dependencies, with no `reports.ts` errors.
- Web `check-types` still has existing ORPC/roles typing errors in this route and broader app; this PR does not add a new focused type error for the new field.
