### PR TITLE
feat(cobros-02): catálogo dinámico de buckets + evento INICIAL

### DIFF
--- a/apps/cartera-back/drizzle/cobros-02/0000_motor_buckets.sql
+++ b/apps/cartera-back/drizzle/cobros-02/0000_motor_buckets.sql
@@ -13,16 +13,20 @@
 -- ============================================================================
 
 -- Enums ----------------------------------------------------------------------
--- Dirección de la transición de bucket.
+-- Tipo de evento: INICIAL = línea base (primer registro del crédito, punto de
+-- partida); SUBIDA = empeora; BAJADA = mejora/cura.
 DO $$
 BEGIN
   IF NOT EXISTS (
     SELECT 1 FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
     WHERE t.typname = 'bucket_evento_tipo' AND n.nspname = 'cartera'
   ) THEN
-    CREATE TYPE cartera.bucket_evento_tipo AS ENUM ('SUBIDA', 'BAJADA');
+    CREATE TYPE cartera.bucket_evento_tipo AS ENUM ('INICIAL', 'SUBIDA', 'BAJADA');
   END IF;
 END$$;
+--> statement-breakpoint
+-- Por si el tipo ya existía sin 'INICIAL' (aplicado en una versión previa).
+ALTER TYPE cartera.bucket_evento_tipo ADD VALUE IF NOT EXISTS 'INICIAL';
 --> statement-breakpoint
 
 -- Origen del evento (hoy siempre PROCESO_AUTO; API_MANUAL para ajustes futuros).

--- a/apps/cartera-back/drizzle/cobros-02/0001_buckets_catalogo.sql
+++ b/apps/cartera-back/drizzle/cobros-02/0001_buckets_catalogo.sql
@@ -1,0 +1,89 @@
+-- ============================================================================
+-- COBROS-02 · Motor de Buckets — 0001_buckets_catalogo
+-- ============================================================================
+-- Convierte el "bucket" (antes int suelto 0-5) en un CATÁLOGO dinámico:
+-- nombres, prefijos, rangos de cuotas y estados configurables → filtros full
+-- dinámicos sin tocar código. Deriva así:
+--   (1) estado fuera del funnel (CANCELADO/EN_CONVENIO/... → lista en código) = sin bucket
+--   (2) estado que fuerza un bucket (INCOBRABLE → B5 vía estados_incluidos)
+--   (3) rango de cuotas atrasadas (cuotas_min..cuotas_max, max NULL = abierto)
+--
+-- Además ata las FK de asesor_bucket.bucket y buckets_historial.bucket_(nuevo|anterior)
+-- al catálogo. B4 = exactamente 4 cuotas (mora 120); B5 = 5..∞ o INCOBRABLE.
+--
+-- NOTA: Cartera aplica el SQL a mano (no drizzle-kit). Idempotente. Pendiente de
+-- aplicar en dev/prod. Corresponde al schema en src/database/db/schema.ts.
+-- Se aplica DESPUÉS de 0000_motor_buckets.sql.
+-- ============================================================================
+
+-- Catálogo de buckets --------------------------------------------------------
+CREATE TABLE IF NOT EXISTS cartera.buckets (
+  numero             integer PRIMARY KEY,                 -- 0-5, clave estable que produce el job
+  prefijo            varchar(8)  NOT NULL,                -- "B0".."B5"
+  nombre             varchar(64) NOT NULL,                -- "Al día", "Mora 30"...
+  descripcion        text,
+  cuotas_min         integer NOT NULL,                    -- umbral inferior (inclusive)
+  cuotas_max         integer,                             -- superior (inclusive); NULL = abierto (B5)
+  estados_incluidos  text[] NOT NULL DEFAULT ARRAY[]::text[],  -- estados que FUERZAN este bucket (INCOBRABLE→B5)
+  es_operativo       boolean NOT NULL DEFAULT true,       -- false = fuera del funnel (B5 jurídico)
+  orden              integer NOT NULL DEFAULT 0,
+  color              varchar(16),
+  activo             boolean NOT NULL DEFAULT true,
+  created_at         timestamp DEFAULT now(),
+  updated_at         timestamp DEFAULT now()
+);
+--> statement-breakpoint
+
+-- Seed de los 6 buckets (idempotente). B4 = 4 exacto; B5 = 5..∞ o INCOBRABLE.
+-- Nombre + descripción (= "Filosofía") según el doc "2. Estructura de Buckets".
+-- Los "días de atraso" del doc (0 / 1-30 / 31-60 / 61-90 / 91-120 / 120+) son la
+-- etiqueta de negocio; el sistema los mide en CUOTAS (1 cuota ≈ 30 días).
+INSERT INTO cartera.buckets
+  (numero, prefijo, nombre,                            descripcion,                                                  cuotas_min, cuotas_max, estados_incluidos,          es_operativo, orden, color)
+VALUES
+  (0, 'B0', 'Cartera Sana',                    'Mantener relación activa; recordatorios preventivos.',       0, 0,    ARRAY[]::text[],            true,  0, '#16a34a'),
+  (1, 'B1', 'Alerta Temprana',                 'El cliente quiere pagar; el problema suele ser logístico.',  1, 1,    ARRAY[]::text[],            true,  1, '#84cc16'),
+  (2, 'B2', 'Gestión Activa',                  'Diagnosticar causa raíz; proponer plan de pago.',            2, 2,    ARRAY[]::text[],            true,  2, '#eab308'),
+  (3, 'B3', 'Rescate',                         'Presión + solución estructurada antes de escalar.',          3, 3,    ARRAY[]::text[],            true,  3, '#f97316'),
+  (4, 'B4', 'Última Instancia / Pre Jurídico', 'Acuerdo final o inicio de recuperación del activo.',         4, 4,    ARRAY[]::text[],            true,  4, '#ef4444'),
+  (5, 'B5', 'Jurídico',                        'Proceso legal de recuperación vehicular.',                   5, NULL, ARRAY['INCOBRABLE']::text[], false, 5, '#7f1d1d')
+ON CONFLICT (numero) DO NOTHING;
+--> statement-breakpoint
+
+-- FK: asesor_bucket.bucket → buckets.numero -----------------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'asesor_bucket_bucket_fk'
+  ) THEN
+    ALTER TABLE cartera.asesor_bucket
+      ADD CONSTRAINT asesor_bucket_bucket_fk
+      FOREIGN KEY (bucket) REFERENCES cartera.buckets (numero);
+  END IF;
+END$$;
+--> statement-breakpoint
+
+-- FK: buckets_historial.bucket_nuevo → buckets.numero -------------------------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'buckets_historial_bucket_nuevo_fk'
+  ) THEN
+    ALTER TABLE cartera.buckets_historial
+      ADD CONSTRAINT buckets_historial_bucket_nuevo_fk
+      FOREIGN KEY (bucket_nuevo) REFERENCES cartera.buckets (numero);
+  END IF;
+END$$;
+--> statement-breakpoint
+
+-- FK: buckets_historial.bucket_anterior → buckets.numero (nullable) -----------
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'buckets_historial_bucket_anterior_fk'
+  ) THEN
+    ALTER TABLE cartera.buckets_historial
+      ADD CONSTRAINT buckets_historial_bucket_anterior_fk
+      FOREIGN KEY (bucket_anterior) REFERENCES cartera.buckets (numero);
+  END IF;
+END$$;

--- a/apps/cartera-back/drizzle/cobros-02/README.md
+++ b/apps/cartera-back/drizzle/cobros-02/README.md
@@ -14,3 +14,4 @@ para que se sepa que se aplican como bloque cuando salga esa versión.
 | Archivo | Qué crea |
 |---|---|
 | `0000_motor_buckets.sql` | Motor de buckets: enums `bucket_evento_tipo`/`bucket_evento_origen`, tabla `buckets_historial` (transiciones) y `asesor_bucket` (asignación pool). |
+| `0001_buckets_catalogo.sql` | Catálogo dinámico `buckets` (nombre/prefijo/rangos/estados/color) + seed B0-B5 + FKs de `asesor_bucket.bucket` y `buckets_historial.bucket_(nuevo\|anterior)` al catálogo. |

--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { client, db } from "../database";
-import { asesores, buckets_historial, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, pagos_credito, platform_users, usuarios } from "../database/db/schema";
+import { asesores, buckets, buckets_historial, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, pagos_credito, platform_users, usuarios } from "../database/db/schema";
 import Big from "big.js";
 import { toZonedTime } from "date-fns-tz";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
@@ -49,9 +49,10 @@ export function isOverdueInstallmentForMora(
 // ============================================================
 // 🪣 MOTOR DE BUCKETS (COBROS-02) — bucket derivado por estado + cuotas
 // ============================================================
-// B5 (Jurídico) y los estados fuera del funnel operativo se determinan por
-// statusCredit, NO por conteo de cuotas (esos créditos ya no llevan mora).
-export const STATUS_BUCKET_B5 = ["INCOBRABLE"]; // legal / jurídico
+// El bucket se DERIVA del catálogo dinámico `cartera.buckets` (nombres, rangos y
+// estados configurables → filtros full dinámicos). Lo único que queda en código
+// es la lista de estados FUERA del funnel operativo (Opción A): esos créditos ya
+// no llevan mora ni se trackean como bucket.
 export const STATUS_BUCKET_FUERA = [
   "CANCELADO",
   "PENDIENTE_CANCELACION",
@@ -59,19 +60,38 @@ export const STATUS_BUCKET_FUERA = [
   "CAIDO",
 ];
 
+// Fila del catálogo de buckets relevante para la derivación.
+export type BucketCatalogo = {
+  numero: number;
+  cuotas_min: number;
+  cuotas_max: number | null; // null = abierto (B5 = 5..∞)
+  estados_incluidos: string[];
+};
+
 /**
- * Bucket de un crédito (0-5) según su estado y cuotas atrasadas.
+ * Bucket de un crédito (0-5) resuelto contra el catálogo dinámico `catalogo`.
+ * Orden: (1) estado fuera del funnel → null; (2) estado que fuerza un bucket
+ * (p.ej. INCOBRABLE → B5 vía `estados_incluidos`); (3) rango de cuotas atrasadas.
  * Devuelve `null` si el crédito está fuera del funnel operativo (no se trackea).
- * B0=0, B1=1, B2=2, B3=3, B4=4, B5=>=5 (o INCOBRABLE/legal).
  */
 export function bucketDeCredito(
   status: string | null | undefined,
   cuotasAtrasadas: number,
+  catalogo: BucketCatalogo[],
 ): number | null {
-  if (status && STATUS_BUCKET_B5.includes(status)) return 5;
+  // (1) Fuera del funnel operativo (lista en código, Opción A).
   if (status && STATUS_BUCKET_FUERA.includes(status)) return null;
-  // ACTIVO / MOROSO → por cuotas
-  return Math.min(Math.max(cuotasAtrasadas, 0), 5);
+  // (2) Estado que fuerza un bucket (p.ej. INCOBRABLE → B5).
+  if (status) {
+    const porEstado = catalogo.find((b) => b.estados_incluidos.includes(status));
+    if (porEstado) return porEstado.numero;
+  }
+  // (3) Por rango de cuotas atrasadas (max null = abierto).
+  const cuotas = Math.max(cuotasAtrasadas, 0);
+  const porRango = catalogo.find(
+    (b) => cuotas >= b.cuotas_min && (b.cuotas_max == null || cuotas <= b.cuotas_max),
+  );
+  return porRango ? porRango.numero : null;
 }
 
 /**
@@ -905,6 +925,23 @@ export async function procesarMoras() {
     // (derivado de estado + cuotas) y los registra en `buckets_historial`.
     // Si algo falla aquí, NO debe romper el proceso de mora (operación crítica).
     try {
+      // Catálogo de buckets (config dinámica: nombres/rangos/estados). ~6 filas.
+      const catalogoBuckets: BucketCatalogo[] = await db
+        .select({
+          numero: buckets.numero,
+          cuotas_min: buckets.cuotas_min,
+          cuotas_max: buckets.cuotas_max,
+          estados_incluidos: buckets.estados_incluidos,
+        })
+        .from(buckets)
+        .where(eq(buckets.activo, true))
+        .orderBy(buckets.orden);
+
+      if (catalogoBuckets.length === 0) {
+        console.warn(
+          "[BUCKETS] ⚠️ Catálogo `cartera.buckets` vacío (¿migración/seed sin aplicar?) — se omite el registro de transiciones.",
+        );
+      } else {
       // status por crédito — ya viene en `cuotas` (el job lo cargó con JOIN)
       const statusPorCredito = new Map<number, string>();
       for (const c of cuotas) {
@@ -924,15 +961,35 @@ export async function procesarMoras() {
         ultimoBucket.set(Number(row.credito_id), Number(row.bucket_nuevo));
       }
 
+      let bucketsIniciales = 0;
       let bucketsSubidas = 0;
       let bucketsBajadas = 0;
 
       for (const [creditoId, status] of statusPorCredito) {
         const cuotasAtrasadas = moraPorCredito[creditoId] ?? 0;
-        const bucketNuevo = bucketDeCredito(status, cuotasAtrasadas);
+        const bucketNuevo = bucketDeCredito(status, cuotasAtrasadas, catalogoBuckets);
         if (bucketNuevo === null) continue; // fuera del funnel operativo
 
-        const tieneHistorial = ultimoBucket.has(creditoId);
+        // Primera vez que vemos el crédito → sembrar la LÍNEA BASE (incluye B0).
+        // `INICIAL` marca el punto de partida real; la salud la dice bucket_nuevo.
+        if (!ultimoBucket.has(creditoId)) {
+          await db.insert(buckets_historial).values({
+            credito_id: creditoId,
+            bucket_anterior: null,
+            bucket_nuevo: bucketNuevo,
+            tipo_evento: "INICIAL",
+            origen: "PROCESO_AUTO",
+            cuotas_atrasadas_nuevas: cuotasAtrasadas,
+            status_credito: status,
+            asesor_id: null,
+            pago_id: null,
+            motivo: "Línea base — primer registro en el motor de buckets",
+          });
+          ultimoBucket.set(creditoId, bucketNuevo);
+          bucketsIniciales++;
+          continue;
+        }
+
         const bucketAnterior = ultimoBucket.get(creditoId) ?? 0;
         if (bucketNuevo === bucketAnterior) continue; // sin cambio de bucket
 
@@ -964,7 +1021,7 @@ export async function procesarMoras() {
 
         await db.insert(buckets_historial).values({
           credito_id: creditoId,
-          bucket_anterior: tieneHistorial ? bucketAnterior : null,
+          bucket_anterior: bucketAnterior,
           bucket_nuevo: bucketNuevo,
           tipo_evento: esSubida ? "SUBIDA" : "BAJADA",
           origen: "PROCESO_AUTO",
@@ -980,8 +1037,9 @@ export async function procesarMoras() {
       }
 
       console.log(
-        `[BUCKETS] Transiciones registradas — subidas: ${bucketsSubidas}, bajadas: ${bucketsBajadas}`,
+        `[BUCKETS] Registros — iniciales: ${bucketsIniciales}, subidas: ${bucketsSubidas}, bajadas: ${bucketsBajadas}`,
       );
+      } // fin else (catálogo no vacío)
     } catch (bucketErr) {
       console.error(
         "[BUCKETS] ⚠️ Error registrando transiciones de bucket (el proceso de mora no se ve afectado):",

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -403,6 +403,7 @@
   // Solo se persiste el HISTORIAL de transiciones + la asignación asesor↔bucket.
 
   export const bucketEventoTipoEnum = customSchema.enum("bucket_evento_tipo", [
+    "INICIAL", // línea base: primer registro del crédito (punto de partida)
     "SUBIDA",
     "BAJADA",
   ]);
@@ -411,6 +412,30 @@
     "bucket_evento_origen",
     ["PROCESO_AUTO", "API_MANUAL"]
   );
+
+  // Catálogo de buckets (config dinámica). El "bucket actual" se DERIVA de aquí:
+  // (1) estados fuera del funnel → sin bucket; (2) estado que fuerza un bucket
+  // (INCOBRABLE → B5 vía `estados_incluidos`); (3) rango de cuotas atrasadas
+  // (`cuotas_min`..`cuotas_max`, max null = abierto → B5). Los nombres, prefijos,
+  // rangos, estados y colores se editan sin tocar código → filtros full dinámicos.
+  export const buckets = customSchema.table("buckets", {
+    numero: integer("numero").primaryKey(), // 0-5, clave estable que produce el job
+    prefijo: varchar("prefijo", { length: 8 }).notNull(), // "B0".."B5"
+    nombre: varchar("nombre", { length: 64 }).notNull(), // "Cartera Sana", "Alerta Temprana"...
+    descripcion: text("descripcion"),
+    cuotas_min: integer("cuotas_min").notNull(),
+    cuotas_max: integer("cuotas_max"), // null = abierto (B5 = 5..∞)
+    estados_incluidos: text("estados_incluidos")
+      .array()
+      .notNull()
+      .default(sql`ARRAY[]::text[]`), // estados que FUERZAN este bucket (INCOBRABLE→B5)
+    es_operativo: boolean("es_operativo").notNull().default(true), // false = fuera del funnel (B5 jurídico)
+    orden: integer("orden").notNull().default(0),
+    color: varchar("color", { length: 16 }),
+    activo: boolean("activo").notNull().default(true),
+    created_at: timestamp("created_at").defaultNow(),
+    updated_at: timestamp("updated_at").defaultNow(),
+  });
 
   // Asignación asesor ↔ bucket (modelo POOL, muchos-a-muchos): un bucket con
   // varios asesores y un asesor en varios buckets.
@@ -421,7 +446,9 @@
       asesor_id: integer("asesor_id")
         .notNull()
         .references(() => asesores.asesor_id, { onDelete: "cascade" }),
-      bucket: integer("bucket").notNull(), // 0-5
+      bucket: integer("bucket")
+        .notNull()
+        .references(() => buckets.numero), // 0-5 (FK al catálogo)
       activo: boolean("activo").notNull().default(true),
       created_at: timestamp("created_at").defaultNow(),
       updated_at: timestamp("updated_at").defaultNow(),
@@ -433,7 +460,8 @@
   );
 
   // Bitácora de transiciones de bucket (append-only). El bucket actual se deriva;
-  // aquí solo se registra CUÁNDO cambia (SUBIDA = empeora, BAJADA = mejora/cura).
+  // aquí se registra el arranque (INICIAL = línea base, 1 por crédito la 1a vez)
+  // y CUÁNDO cambia (SUBIDA = empeora, BAJADA = mejora/cura).
   export const buckets_historial = customSchema.table(
     "buckets_historial",
     {
@@ -441,8 +469,12 @@
       credito_id: integer("credito_id")
         .notNull()
         .references(() => creditos.credito_id, { onDelete: "cascade" }),
-      bucket_anterior: integer("bucket_anterior"), // null en el primer registro
-      bucket_nuevo: integer("bucket_nuevo").notNull(),
+      bucket_anterior: integer("bucket_anterior").references(
+        () => buckets.numero
+      ), // null en el primer registro
+      bucket_nuevo: integer("bucket_nuevo")
+        .notNull()
+        .references(() => buckets.numero),
       tipo_evento: bucketEventoTipoEnum("tipo_evento").notNull(),
       origen: bucketEventoOrigenEnum("origen").notNull().default("PROCESO_AUTO"),
       cuotas_atrasadas_nuevas: integer("cuotas_atrasadas_nuevas")


### PR DESCRIPTION
## Qué hace
Incremento sobre el motor de buckets (PR #1023, ya merged). Dos cosas:

### 1. Catálogo dinámico `cartera.buckets`
El `bucket` deja de ser un `int` suelto y pasa a ser un **catálogo configurable** → filtros full dinámicos sin tocar código.

- Nueva tabla con `numero` (PK 0-5), `prefijo`, `nombre`, `descripcion`, `cuotas_min`/`cuotas_max` (null = abierto), `estados_incluidos` (text[]), `es_operativo`, `orden`, `color`, `activo`.
- `asesor_bucket.bucket` y `buckets_historial.bucket_(nuevo|anterior)` ahora son **FK al catálogo**.
- `bucketDeCredito(status, cuotas, catalogo)` deriva contra la tabla: (1) estado fuera del funnel → `null`; (2) estado que fuerza un bucket (INCOBRABLE → B5 vía `estados_incluidos`); (3) rango de cuotas.
- `STATUS_BUCKET_FUERA` (CANCELADO/PENDIENTE_CANCELACION/EN_CONVENIO/CAIDO) **se queda en código** (Opción A).
- Seed B0-B5 con nombres/filosofía del doc *"2. Estructura de Buckets"*. **B4 = 4 cuotas exacto**, **B5 = 5..∞ o INCOBRABLE** (`es_operativo=false`).

### 2. Evento `INICIAL` (línea base)
Resuelve el comentario **P2 de codex-connector** en el PR #1023: los créditos sanos (B0) sin historial se saltaban y perdían su punto de partida.

- Nuevo valor de enum `bucket_evento_tipo` → `INICIAL`.
- La 1ª vez que el motor ve un crédito, siembra **1 fila `INICIAL`** (incluye B0) con `bucket_anterior = null`.
- `INICIAL` = el momento (arranque); la salud la dice `bucket_nuevo`. Un crédito siempre-B0 = una sola fila `INICIAL → B0`.

## Migraciones (las corre el equipo a mano, agrupadas en `drizzle/cobros-02/`)
- `0000_motor_buckets.sql` — actualizada: enum nace con `INICIAL` + `ALTER TYPE ... ADD VALUE IF NOT EXISTS` por si ya se aplicó.
- `0001_buckets_catalogo.sql` — nueva: tabla `buckets` + seed B0-B5 + 3 FKs (guardadas por `pg_constraint`). Idempotente.

## Notas
- ⚠️ La **1ª corrida** del job crea 1 fila `INICIAL` por cada crédito del funnel (siembra masiva, una sola vez).
- `tsc` limpio (0 errores).
- Aditivo: no toca el cálculo de mora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)