### PR TITLE
fix(cartera): serie de DTE guardada como 'Infinity' (parseo numérico del XML de COFIDI)

### DIFF
--- a/apps/cartera-back/src/cofidi/satClientService.test.ts
+++ b/apps/cartera-back/src/cofidi/satClientService.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import { SATClientService } from "./satClientService";
+
+const svc = new SATClientService(
+  { requestor: "req", user: "user", userName: "userName", entity: "123456" },
+  "https://example.invalid/ws"
+);
+
+// Acceso al parser privado: no queremos pegarle a COFIDI en un unit test
+const parsear = (soap: string) =>
+  (svc as any).parsearRespuestaCertificacion(soap);
+
+const soapCertificacion = (batch: string, serial: string, guid: string) => `<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <RequestTransactionResponse xmlns="http://www.fact.com.mx/schema/ws">
+      <RequestTransactionResult>
+        <Response>
+          <Result>true</Result>
+          <Code>1</Code>
+          <Description>OK</Description>
+          <Hint></Hint>
+          <Identifier>
+            <Batch>${batch}</Batch>
+            <Serial>${serial}</Serial>
+            <DocumentGUID>${guid}</DocumentGUID>
+          </Identifier>
+        </Response>
+        <ResponseData>
+          <ResponseData1>UEsDBA==</ResponseData1>
+        </ResponseData>
+      </RequestTransactionResult>
+    </RequestTransactionResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+describe("parsearRespuestaCertificacion — serie/numero como strings", () => {
+  it("no convierte a Infinity una serie hex con forma de notación científica (3E722147)", () => {
+    // Caso real: serie 3E722147 → Number('3E722147') = 3×10^722147 = Infinity
+    const r = parsear(
+      soapCertificacion("3E722147", "1103581021", "3E722147-41C7-4F5D-81B9-7C8C222257EC")
+    );
+    expect(r.batch).toBe("3E722147");
+    expect(r.serial).toBe("1103581021");
+    expect(r.documentGUID).toBe("3E722147-41C7-4F5D-81B9-7C8C222257EC");
+  });
+
+  it("no expande una serie tipo 476589E6 a 476589000000", () => {
+    const r = parsear(
+      soapCertificacion("476589E6", "999", "476589E6-0000-4000-8000-000000000000")
+    );
+    expect(r.batch).toBe("476589E6");
+  });
+
+  it("no pierde el cero inicial de una serie numérica (09302093)", () => {
+    const r = parsear(
+      soapCertificacion("09302093", "888", "09302093-0000-4000-8000-000000000000")
+    );
+    expect(r.batch).toBe("09302093");
+  });
+
+  it("sigue reportando el error cuando la certificación falla", () => {
+    const soapError = soapCertificacion("X", "Y", "Z").replace(
+      "<Result>true</Result>",
+      "<Result>false</Result>"
+    );
+    expect(() => parsear(soapError)).toThrow(/Certificación falló/);
+  });
+});

--- a/apps/cartera-back/src/cofidi/satClientService.ts
+++ b/apps/cartera-back/src/cofidi/satClientService.ts
@@ -48,7 +48,10 @@ export class SATClientService {
   constructor(credentials: SATCredentials, endpointUrl: string) {
     this.credentials = credentials;
     this.endpointUrl = endpointUrl.trim();
-    this.xmlParser = new XMLParser();
+    // parseTagValue: false — la serie de SAT son 8 hex (ej. "3E722147") y el
+    // parseo numérico por defecto la interpreta como notación científica:
+    // Number("3E722147") = Infinity, que era lo que quedaba guardado en la BD.
+    this.xmlParser = new XMLParser({ parseTagValue: false });
   }
 
   // 🔥 POST_DOCUMENT_SAT - Certificar documento
@@ -183,9 +186,9 @@ export class SATClientService {
       });
 
       return {
-        batch,
-        serial,
-        documentGUID,
+        batch: String(batch),
+        serial: String(serial),
+        documentGUID: String(documentGUID),
         xmlCertificado: xmlBase64
       };
 


### PR DESCRIPTION
## Problema

El Excel de `GET /dte/facturas-genericas?excel=true` muestra **Infinity** en la columna Serie (reporte de Juan, 2026-07-07). El valor viene así desde la BD: `facturas_electronicas.serie = 'Infinity'`.

## Causa raíz

En `SATClientService` la respuesta SOAP de certificación se parsea con `new XMLParser()` — y fast-xml-parser trae `parseTagValue: true` por defecto, que convierte los valores de texto a número.

La serie FEL son 8 caracteres hexadecimales. Cuando la serie cae en forma `dígitos + E + dígitos`, JavaScript la lee como notación científica:

```js
Number("3E722147") // 3×10^722147 = Infinity
```

Ese `Infinity` se guardaba en `serie`, en el nombre del PDF (`factura_Infinity_….pdf`) y salía en el Excel. El mismo parseo produce otras 3 variantes:

| Serie real (SAT) | Guardada en BD |
|---|---|
| `3E722147` | `Infinity` |
| `476589E6` | `476589000000` |
| `38693E50` | `3.8693e+54` |
| `09302093` | `9302093` (pierde el 0 inicial) |

En **prod hay 125 filas afectadas** (12 Infinity + 34 float científico + 38 expandidas + 41 con dígitos alterados), auditadas comparando `serie` contra el primer segmento del UUID (en FEL la serie **es** el primer segmento del número de autorización). El `numero` está intacto (cuadra con los segmentos 2-3 del UUID en hex). El repair de datos va aparte: `serie = split_part(uuid,'-',1)`.

## Fix

- `parseTagValue: false` en el `XMLParser` del `SATClientService` — Batch/Serial/DocumentGUID y los `ResponseData` (base64) quedan siempre como string. Todos los consumidores ya comparaban contra strings (`=== 'true'`), no cambia ningún otro comportamiento.
- `String(...)` en el retorno de `parsearRespuestaCertificacion` como defensa extra.
- Test unitario con la respuesta SOAP real de COFIDI que reproduce los 3 modos de corrupción (rojo antes del fix, 4/4 verde después).

🤖 Generated with [Claude Code](https://claude.com/claude-code)