### PR TITLE
feat(crm): group sales reports by channel type

### DIFF
--- a/apps/crm/apps/server/src/lib/lead-sources.test.ts
+++ b/apps/crm/apps/server/src/lib/lead-sources.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import { leadSourceEnum } from "../db/schema/crm";
 import {
 	getLeadSourceBadgeClass,
+	getLeadSourceChannelType,
 	getLeadSourceLabel,
 	LEAD_SOURCE_BADGE_CLASSES,
+	LEAD_SOURCE_CHANNEL_TYPES,
 	LEAD_SOURCE_LABELS,
 	LEAD_SOURCE_OPTIONS,
 } from "./lead-sources";
@@ -32,5 +34,42 @@ describe("lead source labels", () => {
 		expect(getLeadSourceBadgeClass("property")).toBe(
 			"bg-amber-100 text-amber-800",
 		);
+	});
+});
+
+describe("lead source channels", () => {
+	test("explicitly maps every CRM source and keeps unknown values in Otros", () => {
+		expect(Object.keys(LEAD_SOURCE_CHANNEL_TYPES).sort()).toEqual(
+			[...leadSourceEnum.enumValues].sort(),
+		);
+		expect(
+			Object.fromEntries(
+				leadSourceEnum.enumValues.map((source) => [
+					source,
+					getLeadSourceChannelType(source),
+				]),
+			),
+		).toEqual({
+			website: "Orgánico Digital",
+			referral: "Otros",
+			cold_call: "Físico",
+			email: "Orgánico Digital",
+			social_media: "Orgánico Digital",
+			event: "Físico",
+			other: "Otros",
+			facebook: "Pauta Digital",
+			instagram: "Pauta Digital",
+			google: "Pauta Digital",
+			meta: "Pauta Digital",
+			linkedin: "Pauta Digital",
+			Whatsapp: "Pauta Digital",
+			agency: "Físico",
+			property: "Físico",
+			recurrent: "Otros",
+			recurrent_active: "Otros",
+		});
+		expect(getLeadSourceChannelType("unexpected")).toBe("Otros");
+		expect(getLeadSourceChannelType("toString")).toBe("Otros");
+		expect(getLeadSourceChannelType(null)).toBe("Otros");
 	});
 });

--- a/apps/crm/apps/server/src/lib/lead-sources.ts
+++ b/apps/crm/apps/server/src/lib/lead-sources.ts
@@ -19,6 +19,27 @@ export const LEAD_SOURCE_LABELS = {
 } as const satisfies Record<string, string>;
 
 export type LeadSource = keyof typeof LEAD_SOURCE_LABELS;
+export type LeadSourceChannelType =
+	| "Físico"
+	| "Pauta Digital"
+	| "Orgánico Digital"
+	| "Otros";
+
+const LEAD_SOURCE_CHANNEL_TYPES = {
+	property: "Físico",
+	agency: "Físico",
+	google: "Pauta Digital",
+	meta: "Pauta Digital",
+	facebook: "Pauta Digital",
+	instagram: "Pauta Digital",
+	Whatsapp: "Pauta Digital",
+	website: "Orgánico Digital",
+	social_media: "Orgánico Digital",
+	recurrent: "Otros",
+	recurrent_active: "Otros",
+	other: "Otros",
+	referral: "Otros",
+} as const satisfies Partial<Record<LeadSource, LeadSourceChannelType>>;
 
 export const LEAD_SOURCE_OPTIONS = Object.entries(LEAD_SOURCE_LABELS).map(
 	([value, label]) => ({
@@ -51,6 +72,17 @@ export function getLeadSourceLabel(source: string | null | undefined): string {
 	if (!source) return "Sin fuente";
 	return (
 		LEAD_SOURCE_LABELS[source as keyof typeof LEAD_SOURCE_LABELS] ?? source
+	);
+}
+
+export function getLeadSourceChannelType(
+	source: string | null | undefined,
+): LeadSourceChannelType {
+	if (!source) return "Otros";
+	return (
+		LEAD_SOURCE_CHANNEL_TYPES[
+			source as keyof typeof LEAD_SOURCE_CHANNEL_TYPES
+		] ?? "Otros"
 	);
 }
 

--- a/apps/crm/apps/server/src/lib/lead-sources.ts
+++ b/apps/crm/apps/server/src/lib/lead-sources.ts
@@ -1,3 +1,6 @@
+export type LeadSource =
+	typeof import("../db/schema/crm").leadSourceEnum.enumValues[number];
+
 export const LEAD_SOURCE_LABELS = {
 	website: "Sitio Web",
 	referral: "Referencia",
@@ -16,30 +19,33 @@ export const LEAD_SOURCE_LABELS = {
 	property: "Predio",
 	recurrent: "Recurrente",
 	recurrent_active: "Recurrente Activo",
-} as const satisfies Record<string, string>;
+} as const satisfies Record<LeadSource, string>;
 
-export type LeadSource = keyof typeof LEAD_SOURCE_LABELS;
 export type LeadSourceChannelType =
 	| "Físico"
 	| "Pauta Digital"
 	| "Orgánico Digital"
 	| "Otros";
 
-const LEAD_SOURCE_CHANNEL_TYPES = {
+export const LEAD_SOURCE_CHANNEL_TYPES = {
 	property: "Físico",
 	agency: "Físico",
+	cold_call: "Físico",
+	event: "Físico",
 	google: "Pauta Digital",
 	meta: "Pauta Digital",
 	facebook: "Pauta Digital",
 	instagram: "Pauta Digital",
 	Whatsapp: "Pauta Digital",
+	linkedin: "Pauta Digital",
 	website: "Orgánico Digital",
 	social_media: "Orgánico Digital",
+	email: "Orgánico Digital",
 	recurrent: "Otros",
 	recurrent_active: "Otros",
 	other: "Otros",
 	referral: "Otros",
-} as const satisfies Partial<Record<LeadSource, LeadSourceChannelType>>;
+} as const satisfies Record<LeadSource, LeadSourceChannelType>;
 
 export const LEAD_SOURCE_OPTIONS = Object.entries(LEAD_SOURCE_LABELS).map(
 	([value, label]) => ({
@@ -79,11 +85,10 @@ export function getLeadSourceChannelType(
 	source: string | null | undefined,
 ): LeadSourceChannelType {
 	if (!source) return "Otros";
-	return (
-		LEAD_SOURCE_CHANNEL_TYPES[
-			source as keyof typeof LEAD_SOURCE_CHANNEL_TYPES
-		] ?? "Otros"
-	);
+	if (Object.hasOwn(LEAD_SOURCE_CHANNEL_TYPES, source)) {
+		return LEAD_SOURCE_CHANNEL_TYPES[source as LeadSource];
+	}
+	return "Otros";
 }
 
 export function getLeadSourceBadgeClass(source: string): string {

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -374,4 +374,27 @@ describe("aggregateTiempoCierrePorTipoCanal", () => {
 			},
 		]);
 	});
+
+	test("coerces raw min and max days before returning channel subtotals", () => {
+		expect(
+			aggregateTiempoCierrePorTipoCanal([
+				{
+					source: "property",
+					totalCreditos: 1,
+					avgDias: 3.5,
+					totalDias: "3.5",
+					minDias: "3.5",
+					maxDias: "3.5",
+				},
+			]),
+		).toEqual([
+			{
+				tipoCanal: "Físico",
+				totalCreditos: 1,
+				avgDias: 3.5,
+				minDias: 3.5,
+				maxDias: 3.5,
+			},
+		]);
+	});
 });

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -199,18 +199,21 @@ describe("aggregateEfectividadPorTipoCanal", () => {
 				tipoCanal: "Pauta Digital",
 				totalOportunidades: 10,
 				totalCerradas: 5,
+				totalCierresPeriodo: 0,
 				porcentaje: 50,
 			},
 			{
 				tipoCanal: "Orgánico Digital",
 				totalOportunidades: 5,
 				totalCerradas: 2,
+				totalCierresPeriodo: 0,
 				porcentaje: 40,
 			},
 			{
 				tipoCanal: "Otros",
 				totalOportunidades: 2,
 				totalCerradas: 1,
+				totalCierresPeriodo: 0,
 				porcentaje: 50,
 			},
 		]);
@@ -237,7 +240,30 @@ describe("aggregateEfectividadPorTipoCanal", () => {
 				tipoCanal: "Pauta Digital",
 				totalOportunidades: 10,
 				totalCerradas: 5,
+				totalCierresPeriodo: 0,
 				porcentaje: 50,
+			},
+		]);
+	});
+
+	test("keeps period-only closes in channel subtotals", () => {
+		expect(
+			aggregateEfectividadPorTipoCanal([
+				{
+					source: "event",
+					totalOportunidades: 0,
+					totalCerradas: 0,
+					totalCierresPeriodo: "3",
+					porcentaje: 0,
+				},
+			]),
+		).toEqual([
+			{
+				tipoCanal: "Físico",
+				totalOportunidades: 0,
+				totalCerradas: 0,
+				totalCierresPeriodo: 3,
+				porcentaje: 0,
 			},
 		]);
 	});

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -215,6 +215,32 @@ describe("aggregateEfectividadPorTipoCanal", () => {
 			},
 		]);
 	});
+
+	test("coerces raw closed counts before summing channel totals", () => {
+		expect(
+			aggregateEfectividadPorTipoCanal([
+				{
+					source: "google",
+					totalOportunidades: 3,
+					totalCerradas: "1",
+					porcentaje: 33.3,
+				},
+				{
+					source: "meta",
+					totalOportunidades: 7,
+					totalCerradas: "4",
+					porcentaje: 57.1,
+				},
+			]),
+		).toEqual([
+			{
+				tipoCanal: "Pauta Digital",
+				totalOportunidades: 10,
+				totalCerradas: 5,
+				porcentaje: 50,
+			},
+		]);
+	});
 });
 
 describe("aggregateTiempoCierrePorTipoCanal", () => {
@@ -277,6 +303,37 @@ describe("aggregateTiempoCierrePorTipoCanal", () => {
 					totalCreditos: 1,
 					avgDias: 1.2,
 					totalDias: 1.24,
+					minDias: 1,
+					maxDias: 2,
+				},
+			]),
+		).toEqual([
+			{
+				tipoCanal: "Físico",
+				totalCreditos: 3,
+				avgDias: 1.2,
+				minDias: 1,
+				maxDias: 2,
+			},
+		]);
+	});
+
+	test("coerces raw day totals before averaging channel totals", () => {
+		expect(
+			aggregateTiempoCierrePorTipoCanal([
+				{
+					source: "property",
+					totalCreditos: 2,
+					avgDias: 1.3,
+					totalDias: "2.5",
+					minDias: 1,
+					maxDias: 2,
+				},
+				{
+					source: "agency",
+					totalCreditos: 1,
+					avgDias: 1.2,
+					totalDias: "1.24",
 					minDias: 1,
 					maxDias: 2,
 				},

--- a/apps/crm/apps/server/src/routers/reports.test.ts
+++ b/apps/crm/apps/server/src/routers/reports.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import { getLeadSourceChannelType } from "../lib/lead-sources";
 import {
+	aggregateEfectividadPorTipoCanal,
+	aggregateTiempoCierrePorTipoCanal,
 	buildPorcentajeEfectividadFuenteRows,
 	CLOSED_CREDIT_REPORT_CARTERA_STATUS_CHUNK_SIZE,
 	enforceClosedCreditReportLimit,
@@ -139,5 +142,153 @@ describe("enforceClosedCreditReportLimit", () => {
 		expect(() => enforceClosedCreditReportLimit(filteredRows)).toThrow(
 			"El rango seleccionado devuelve demasiados registros. Reduce el rango de fechas.",
 		);
+	});
+});
+
+describe("getLeadSourceChannelType", () => {
+	test("groups known and unknown lead sources by channel type", () => {
+		expect(getLeadSourceChannelType("property")).toBe("Físico");
+		expect(getLeadSourceChannelType("agency")).toBe("Físico");
+		expect(getLeadSourceChannelType("google")).toBe("Pauta Digital");
+		expect(getLeadSourceChannelType("meta")).toBe("Pauta Digital");
+		expect(getLeadSourceChannelType("facebook")).toBe("Pauta Digital");
+		expect(getLeadSourceChannelType("instagram")).toBe("Pauta Digital");
+		expect(getLeadSourceChannelType("Whatsapp")).toBe("Pauta Digital");
+		expect(getLeadSourceChannelType("website")).toBe("Orgánico Digital");
+		expect(getLeadSourceChannelType("social_media")).toBe("Orgánico Digital");
+		expect(getLeadSourceChannelType("recurrent")).toBe("Otros");
+		expect(getLeadSourceChannelType("recurrent_active")).toBe("Otros");
+		expect(getLeadSourceChannelType("other")).toBe("Otros");
+		expect(getLeadSourceChannelType("referral")).toBe("Otros");
+		expect(getLeadSourceChannelType(null)).toBe("Otros");
+		expect(getLeadSourceChannelType("unknown_source")).toBe("Otros");
+	});
+});
+
+describe("aggregateEfectividadPorTipoCanal", () => {
+	test("subtotals opportunities and closed counts by channel type", () => {
+		expect(
+			aggregateEfectividadPorTipoCanal([
+				{
+					source: "google",
+					totalOportunidades: 3,
+					totalCerradas: 1,
+					porcentaje: 33.3,
+				},
+				{
+					source: "meta",
+					totalOportunidades: 7,
+					totalCerradas: 4,
+					porcentaje: 57.1,
+				},
+				{
+					source: "website",
+					totalOportunidades: 5,
+					totalCerradas: 2,
+					porcentaje: 40,
+				},
+				{
+					source: "untracked",
+					totalOportunidades: 2,
+					totalCerradas: 1,
+					porcentaje: 50,
+				},
+			]),
+		).toEqual([
+			{
+				tipoCanal: "Pauta Digital",
+				totalOportunidades: 10,
+				totalCerradas: 5,
+				porcentaje: 50,
+			},
+			{
+				tipoCanal: "Orgánico Digital",
+				totalOportunidades: 5,
+				totalCerradas: 2,
+				porcentaje: 40,
+			},
+			{
+				tipoCanal: "Otros",
+				totalOportunidades: 2,
+				totalCerradas: 1,
+				porcentaje: 50,
+			},
+		]);
+	});
+});
+
+describe("aggregateTiempoCierrePorTipoCanal", () => {
+	test("subtotals close-time stats by channel type", () => {
+		expect(
+			aggregateTiempoCierrePorTipoCanal([
+				{
+					source: "property",
+					totalCreditos: 2,
+					avgDias: 5,
+					minDias: 3,
+					maxDias: 7,
+				},
+				{
+					source: "agency",
+					totalCreditos: 1,
+					avgDias: 11,
+					minDias: 11,
+					maxDias: 11,
+				},
+				{
+					source: "social_media",
+					totalCreditos: 4,
+					avgDias: 8,
+					minDias: 4,
+					maxDias: 14,
+				},
+			]),
+		).toEqual([
+			{
+				tipoCanal: "Físico",
+				totalCreditos: 3,
+				avgDias: 7,
+				minDias: 3,
+				maxDias: 11,
+			},
+			{
+				tipoCanal: "Orgánico Digital",
+				totalCreditos: 4,
+				avgDias: 8,
+				minDias: 4,
+				maxDias: 14,
+			},
+		]);
+	});
+
+	test("uses raw day totals when available to avoid rounding per-source averages twice", () => {
+		expect(
+			aggregateTiempoCierrePorTipoCanal([
+				{
+					source: "property",
+					totalCreditos: 2,
+					avgDias: 1.3,
+					totalDias: 2.5,
+					minDias: 1,
+					maxDias: 2,
+				},
+				{
+					source: "agency",
+					totalCreditos: 1,
+					avgDias: 1.2,
+					totalDias: 1.24,
+					minDias: 1,
+					maxDias: 2,
+				},
+			]),
+		).toEqual([
+			{
+				tipoCanal: "Físico",
+				totalCreditos: 3,
+				avgDias: 1.2,
+				minDias: 1,
+				maxDias: 2,
+			},
+		]);
 	});
 });

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -109,13 +109,18 @@ type EfectividadFuenteRow = {
 	source: string | null;
 	totalOportunidades: number;
 	totalCerradas: number | `${number}`;
+	totalCierresPeriodo?: number | `${number}`;
 	porcentaje: number;
 };
 
 export function aggregateEfectividadPorTipoCanal(rows: EfectividadFuenteRow[]) {
 	const totals = new Map<
 		LeadSourceChannelType,
-		{ totalOportunidades: number; totalCerradas: number }
+		{
+			totalOportunidades: number;
+			totalCerradas: number;
+			totalCierresPeriodo: number;
+		}
 	>();
 
 	for (const row of rows) {
@@ -123,9 +128,11 @@ export function aggregateEfectividadPorTipoCanal(rows: EfectividadFuenteRow[]) {
 		const total = totals.get(tipoCanal) ?? {
 			totalOportunidades: 0,
 			totalCerradas: 0,
+			totalCierresPeriodo: 0,
 		};
 		total.totalOportunidades += row.totalOportunidades;
 		total.totalCerradas += Number(row.totalCerradas);
+		total.totalCierresPeriodo += Number(row.totalCierresPeriodo ?? 0);
 		totals.set(tipoCanal, total);
 	}
 
@@ -137,6 +144,7 @@ export function aggregateEfectividadPorTipoCanal(rows: EfectividadFuenteRow[]) {
 				tipoCanal,
 				totalOportunidades: total.totalOportunidades,
 				totalCerradas: total.totalCerradas,
+				totalCierresPeriodo: total.totalCierresPeriodo,
 				porcentaje:
 					total.totalOportunidades > 0
 						? Math.round(

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -21,6 +21,10 @@ import { quotations } from "../db/schema/quotations";
 import { vehicleInspections, vehicles } from "../db/schema/vehicles";
 import { getGuatemalaMonthWindow } from "../lib/guatemala-month-window";
 import {
+	getLeadSourceChannelType,
+	type LeadSourceChannelType,
+} from "../lib/lead-sources";
+import {
 	closedCreditsReportProcedure,
 	metaColocacionReportProcedure,
 	porcentajeEfectividadReportProcedure,
@@ -30,6 +34,12 @@ import {
 import type { StatusCreditEnum } from "../types/cartera-back";
 
 const SECONDS_PER_DAY = 60 * 60 * 24;
+const CHANNEL_TYPE_ORDER: LeadSourceChannelType[] = [
+	"Físico",
+	"Pauta Digital",
+	"Orgánico Digital",
+	"Otros",
+];
 
 // Schema para filtros de fecha
 const dateRangeSchema = z.object({
@@ -93,6 +103,110 @@ export function isPorcentajeEfectividadPeriodCloseIncluded(
 		firstClosedAt >= start &&
 		firstClosedAt <= end
 	);
+}
+
+type EfectividadFuenteRow = {
+	source: string | null;
+	totalOportunidades: number;
+	totalCerradas: number;
+	porcentaje: number;
+};
+
+export function aggregateEfectividadPorTipoCanal(rows: EfectividadFuenteRow[]) {
+	const totals = new Map<
+		LeadSourceChannelType,
+		{ totalOportunidades: number; totalCerradas: number }
+	>();
+
+	for (const row of rows) {
+		const tipoCanal = getLeadSourceChannelType(row.source);
+		const total = totals.get(tipoCanal) ?? {
+			totalOportunidades: 0,
+			totalCerradas: 0,
+		};
+		total.totalOportunidades += row.totalOportunidades;
+		total.totalCerradas += row.totalCerradas;
+		totals.set(tipoCanal, total);
+	}
+
+	return CHANNEL_TYPE_ORDER.flatMap((tipoCanal) => {
+		const total = totals.get(tipoCanal);
+		if (!total) return [];
+		return [
+			{
+				tipoCanal,
+				totalOportunidades: total.totalOportunidades,
+				totalCerradas: total.totalCerradas,
+				porcentaje:
+					total.totalOportunidades > 0
+						? Math.round(
+								(total.totalCerradas * 1000) / total.totalOportunidades,
+							) / 10
+						: 0,
+			},
+		];
+	});
+}
+
+type TiempoCierreFuenteRow = {
+	source: string | null;
+	totalCreditos: number;
+	avgDias: number;
+	totalDias?: number;
+	minDias: number;
+	maxDias: number;
+};
+
+export function aggregateTiempoCierrePorTipoCanal(
+	rows: TiempoCierreFuenteRow[],
+) {
+	const totals = new Map<
+		LeadSourceChannelType,
+		{
+			totalCreditos: number;
+			totalDias: number;
+			minDias: number | null;
+			maxDias: number | null;
+		}
+	>();
+
+	for (const row of rows) {
+		const tipoCanal = getLeadSourceChannelType(row.source);
+		const total = totals.get(tipoCanal) ?? {
+			totalCreditos: 0,
+			totalDias: 0,
+			minDias: null,
+			maxDias: null,
+		};
+		total.totalCreditos += row.totalCreditos;
+		total.totalDias += row.totalDias ?? row.avgDias * row.totalCreditos;
+		total.minDias =
+			total.minDias === null
+				? row.minDias
+				: Math.min(total.minDias, row.minDias);
+		total.maxDias =
+			total.maxDias === null
+				? row.maxDias
+				: Math.max(total.maxDias, row.maxDias);
+		totals.set(tipoCanal, total);
+	}
+
+	return CHANNEL_TYPE_ORDER.flatMap((tipoCanal) => {
+		const total = totals.get(tipoCanal);
+		if (!total) return [];
+		return [
+			{
+				tipoCanal,
+				totalCreditos: total.totalCreditos,
+				avgDias:
+					total.totalCreditos > 0
+						? Math.round((total.totalDias * 10) / total.totalCreditos) / 10
+						: 0,
+				minDias: total.minDias ?? 0,
+				maxDias: total.maxDias ?? 0,
+			},
+		];
+	});
 }
 
 function parseGuatemalaDateRange(startDate: string, endDate: string) {
@@ -735,6 +849,19 @@ export const getReportePorcentajeEfectividad =
 				});
 			}
 
+			const porFuenteRows = buildPorcentajeEfectividadFuenteRows(
+				porFuente.map((row) => ({
+					source: row.source,
+					totalOportunidades: row.totalOportunidades,
+					totalCerradas: row.totalCerradas ?? 0,
+					porcentaje: row.porcentaje ?? 0,
+				})),
+				cierresPeriodoPorFuente.map((row) => ({
+					source: row.source,
+					totalCierresPeriodo: row.totalCierresPeriodo,
+				})),
+			);
+
 			return {
 				total: {
 					totalOportunidades: totalRows[0]?.totalOportunidades ?? 0,
@@ -742,18 +869,8 @@ export const getReportePorcentajeEfectividad =
 					totalCierresPeriodo: periodCloseRows[0]?.totalCierresPeriodo ?? 0,
 					porcentaje: totalRows[0]?.porcentaje ?? 0,
 				},
-				porFuente: buildPorcentajeEfectividadFuenteRows(
-					porFuente.map((row) => ({
-						source: row.source,
-						totalOportunidades: row.totalOportunidades,
-						totalCerradas: row.totalCerradas ?? 0,
-						porcentaje: row.porcentaje ?? 0,
-					})),
-					cierresPeriodoPorFuente.map((row) => ({
-						source: row.source,
-						totalCierresPeriodo: row.totalCierresPeriodo,
-					})),
-				),
+				porFuente: porFuenteRows,
+				porTipoCanal: aggregateEfectividadPorTipoCanal(porFuenteRows),
 				registros: registrosRaw.map((row) => ({
 					id: row.id,
 					createdAt: row.createdAt,
@@ -798,8 +915,9 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 
 		// Fallback a opportunities.createdAt cuando leadId es null (oportunidades
 		// vinculadas directamente a empresa sin prospecto previo).
+		const diasDesdeCreacionBase = sql<number>`EXTRACT(EPOCH FROM (${firstClosedStageDates.firstClosedStageAt} - COALESCE(${leads.createdAt}, ${opportunities.createdAt}))) / ${SECONDS_PER_DAY}`;
 		const diasDesdeCreacion = (fn: "AVG" | "MIN" | "MAX") =>
-			sql<number>`ROUND(${sql.raw(fn)}(EXTRACT(EPOCH FROM (${firstClosedStageDates.firstClosedStageAt} - COALESCE(${leads.createdAt}, ${opportunities.createdAt}))) / ${SECONDS_PER_DAY}), 1)`;
+			sql<number>`ROUND(${sql.raw(fn)}(${diasDesdeCreacionBase}), 1)`;
 
 		const baseWhere = and(
 			gte(firstClosedStageDates.firstClosedStageAt, start),
@@ -828,6 +946,7 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 					avgDias: diasDesdeCreacion("AVG"),
 					minDias: diasDesdeCreacion("MIN"),
 					maxDias: diasDesdeCreacion("MAX"),
+					totalDias: sql<number>`SUM(${diasDesdeCreacionBase})`,
 				})
 				.from(firstClosedStageDates)
 				.innerJoin(
@@ -840,6 +959,15 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 				.orderBy(desc(count())),
 		]);
 
+		const porFuenteRows = porFuente.map((row) => ({
+			source: row.source,
+			totalCreditos: row.totalCreditos,
+			avgDias: row.avgDias ?? 0,
+			totalDias: row.totalDias ?? 0,
+			minDias: row.minDias ?? 0,
+			maxDias: row.maxDias ?? 0,
+		}));
+
 		return {
 			total: {
 				totalCreditos: totalRows[0]?.totalCreditos ?? 0,
@@ -847,13 +975,8 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 				minDias: totalRows[0]?.minDias ?? 0,
 				maxDias: totalRows[0]?.maxDias ?? 0,
 			},
-			porFuente: porFuente.map((row) => ({
-				source: row.source,
-				totalCreditos: row.totalCreditos,
-				avgDias: row.avgDias ?? 0,
-				minDias: row.minDias ?? 0,
-				maxDias: row.maxDias ?? 0,
-			})),
+			porFuente: porFuenteRows,
+			porTipoCanal: aggregateTiempoCierrePorTipoCanal(porFuenteRows),
 		};
 	});
 

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -108,7 +108,7 @@ export function isPorcentajeEfectividadPeriodCloseIncluded(
 type EfectividadFuenteRow = {
 	source: string | null;
 	totalOportunidades: number;
-	totalCerradas: number;
+	totalCerradas: number | `${number}`;
 	porcentaje: number;
 };
 
@@ -125,7 +125,7 @@ export function aggregateEfectividadPorTipoCanal(rows: EfectividadFuenteRow[]) {
 			totalCerradas: 0,
 		};
 		total.totalOportunidades += row.totalOportunidades;
-		total.totalCerradas += row.totalCerradas;
+		total.totalCerradas += Number(row.totalCerradas);
 		totals.set(tipoCanal, total);
 	}
 
@@ -152,7 +152,7 @@ type TiempoCierreFuenteRow = {
 	source: string | null;
 	totalCreditos: number;
 	avgDias: number;
-	totalDias?: number;
+	totalDias?: number | `${number}`;
 	minDias: number;
 	maxDias: number;
 };
@@ -179,7 +179,7 @@ export function aggregateTiempoCierrePorTipoCanal(
 			maxDias: null,
 		};
 		total.totalCreditos += row.totalCreditos;
-		total.totalDias += row.totalDias ?? row.avgDias * row.totalCreditos;
+		total.totalDias += Number(row.totalDias ?? row.avgDias * row.totalCreditos);
 		total.minDias =
 			total.minDias === null
 				? row.minDias

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -161,8 +161,8 @@ type TiempoCierreFuenteRow = {
 	totalCreditos: number;
 	avgDias: number;
 	totalDias?: number | `${number}`;
-	minDias: number;
-	maxDias: number;
+	minDias: number | `${number}`;
+	maxDias: number | `${number}`;
 };
 
 export function aggregateTiempoCierrePorTipoCanal(
@@ -180,6 +180,8 @@ export function aggregateTiempoCierrePorTipoCanal(
 
 	for (const row of rows) {
 		const tipoCanal = getLeadSourceChannelType(row.source);
+		const minDias = Number(row.minDias);
+		const maxDias = Number(row.maxDias);
 		const total = totals.get(tipoCanal) ?? {
 			totalCreditos: 0,
 			totalDias: 0,
@@ -189,13 +191,9 @@ export function aggregateTiempoCierrePorTipoCanal(
 		total.totalCreditos += row.totalCreditos;
 		total.totalDias += Number(row.totalDias ?? row.avgDias * row.totalCreditos);
 		total.minDias =
-			total.minDias === null
-				? row.minDias
-				: Math.min(total.minDias, row.minDias);
+			total.minDias === null ? minDias : Math.min(total.minDias, minDias);
 		total.maxDias =
-			total.maxDias === null
-				? row.maxDias
-				: Math.max(total.maxDias, row.maxDias);
+			total.maxDias === null ? maxDias : Math.max(total.maxDias, maxDias);
 		totals.set(tipoCanal, total);
 	}
 

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -253,6 +253,7 @@ export function PorcentajeEfectividadContent() {
 		.sort((a, b) => b.porcentaje - a.porcentaje);
 
 	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
+	const channelTypeData = data?.porTipoCanal ?? [];
 
 	return (
 		<div className="space-y-6">
@@ -353,6 +354,65 @@ export function PorcentajeEfectividadContent() {
 							</BarChart>
 						</ResponsiveContainer>
 					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Subtotales por tipo de canal</CardTitle>
+					<CardDescription>
+						Agrupación de fuentes para comparar efectividad por esfuerzo
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Tipo de canal</TableHead>
+								<TableHead className="text-right">Oportunidades</TableHead>
+								<TableHead className="text-right">Cerradas</TableHead>
+								<TableHead className="text-right">Efectividad</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={4}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : channelTypeData.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={4}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								channelTypeData.map((row) => (
+									<TableRow key={row.tipoCanal}>
+										<TableCell className="font-medium">
+											{row.tipoCanal}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalOportunidades}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalCerradas}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.porcentaje}%
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
 				</CardContent>
 			</Card>
 

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -370,8 +370,10 @@ export function PorcentajeEfectividadContent() {
 							<TableRow>
 								<TableHead>Tipo de canal</TableHead>
 								<TableHead className="text-right">Oportunidades</TableHead>
-								<TableHead className="text-right">Cerradas</TableHead>
-								<TableHead className="text-right">Cierres período</TableHead>
+								<TableHead className="text-right">Cerradas (creadas)</TableHead>
+								<TableHead className="text-right">
+									Cierres del período
+								</TableHead>
 								<TableHead className="text-right">Efectividad</TableHead>
 							</TableRow>
 						</TableHeader>
@@ -434,7 +436,9 @@ export function PorcentajeEfectividadContent() {
 								<TableHead>Fuente</TableHead>
 								<TableHead className="text-right">Creadas</TableHead>
 								<TableHead className="text-right">Cerradas (creadas)</TableHead>
-								<TableHead className="text-right">Cierres período</TableHead>
+								<TableHead className="text-right">
+									Cierres del período
+								</TableHead>
 								<TableHead className="text-right">Efectividad</TableHead>
 							</TableRow>
 						</TableHeader>

--- a/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx
@@ -187,13 +187,13 @@ export function PorcentajeEfectividadContent() {
 		}),
 		enabled: !!input,
 	});
+	const data = reportQuery.data;
 
 	// Reiniciar página al recibir datos nuevos
 	useEffect(() => {
-		setPage(0);
-	}, [reportQuery.data]);
+		if (data) setPage(0);
+	}, [data]);
 
-	const data = reportQuery.data;
 	const isLoading = reportQuery.isLoading;
 
 	const allRegistros = data?.registros ?? [];
@@ -371,6 +371,7 @@ export function PorcentajeEfectividadContent() {
 								<TableHead>Tipo de canal</TableHead>
 								<TableHead className="text-right">Oportunidades</TableHead>
 								<TableHead className="text-right">Cerradas</TableHead>
+								<TableHead className="text-right">Cierres período</TableHead>
 								<TableHead className="text-right">Efectividad</TableHead>
 							</TableRow>
 						</TableHeader>
@@ -378,7 +379,7 @@ export function PorcentajeEfectividadContent() {
 							{isLoading ? (
 								<TableRow>
 									<TableCell
-										colSpan={4}
+										colSpan={5}
 										className="py-8 text-center text-muted-foreground"
 									>
 										Cargando...
@@ -387,7 +388,7 @@ export function PorcentajeEfectividadContent() {
 							) : channelTypeData.length === 0 ? (
 								<TableRow>
 									<TableCell
-										colSpan={4}
+										colSpan={5}
 										className="py-8 text-center text-muted-foreground"
 									>
 										No hay datos para el período seleccionado
@@ -404,6 +405,9 @@ export function PorcentajeEfectividadContent() {
 										</TableCell>
 										<TableCell className="text-right">
 											{row.totalCerradas}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalCierresPeriodo}
 										</TableCell>
 										<TableCell className="text-right font-semibold">
 											{row.porcentaje}%

--- a/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
@@ -171,6 +171,7 @@ export function TiempoCierreContent() {
 		.sort((a, b) => a.avgDias - b.avgDias);
 
 	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
+	const channelTypeData = data?.porTipoCanal ?? [];
 
 	return (
 		<div className="space-y-6">
@@ -270,6 +271,69 @@ export function TiempoCierreContent() {
 							</BarChart>
 						</ResponsiveContainer>
 					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Subtotales por tipo de canal</CardTitle>
+					<CardDescription>
+						Agrupación de fuentes para comparar tiempos de cierre por esfuerzo
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Tipo de canal</TableHead>
+								<TableHead className="text-right">Créditos</TableHead>
+								<TableHead className="text-right">Promedio (días)</TableHead>
+								<TableHead className="text-right">Mínimo (días)</TableHead>
+								<TableHead className="text-right">Máximo (días)</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={5}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : channelTypeData.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={5}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								channelTypeData.map((row) => (
+									<TableRow key={row.tipoCanal}>
+										<TableCell className="font-medium">
+											{row.tipoCanal}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.totalCreditos}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.avgDias}
+										</TableCell>
+										<TableCell className="text-right text-green-600 dark:text-green-400">
+											{row.minDias}
+										</TableCell>
+										<TableCell className="text-right text-orange-600 dark:text-orange-400">
+											{row.maxDias}
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
 				</CardContent>
 			</Card>
 


### PR DESCRIPTION
## Summary
- Implements Leonardo point 3 by adding channel-type subtotals to CRM sales reports while preserving source-detail tables.
- Adds channel subtotals by type for Porcentaje Efectividad and Tiempo Cierre Crédito.
- Keeps CRM effectiveness semantics separate in cards, source detail, and the new channel subtotals: Cerradas (creadas) remains the created-in-range cohort, and Cierres del período remains closures occurring in the selected period.

## Requested fixes handled
- Leonardo point 3: channel subtotals by type.
- Codex fix: coerces raw closed counts before summing channels.
- Codex fix: coerces raw day totals before averaging channels.
- Codex fix: coerces raw min/max day values before channel subtotals.
- Codex fix: exhaustive CRM lead-source mapping, including cold_call, email, event, and linkedin.
- Codex fix: includes and displays both Cerradas (creadas) and Cierres del período totals in effectiveness channel subtotals.

## Verification
- bun test apps/server/src/lib/lead-sources.test.ts apps/server/src/routers/reports.test.ts
- node_modules/.bin/biome check apps/server/src/lib/lead-sources.ts apps/server/src/lib/lead-sources.test.ts apps/server/src/routers/reports.ts apps/server/src/routers/reports.test.ts apps/web/src/routes/crm/reportes/porcentaje-efectividad.tsx apps/web/src/routes/crm/reportes/tiempo-cierre.tsx
- git diff --check

Supersedes #1029.