### PR TITLE
fix(cobros): correcciones del code review de excluir_pagados_mes (#1024)

### DIFF
--- a/apps/cartera-back/drizzle/0018_idx_cuotas_credito_credito_fecha.sql
+++ b/apps/cartera-back/drizzle/0018_idx_cuotas_credito_credito_fecha.sql
@@ -1,0 +1,12 @@
+-- 0018 — Índice compuesto para cuotas_credito.
+-- Soporta las subconsultas correlacionadas por (credito_id, fecha_vencimiento):
+-- el filtro excluir_pagados_mes de /getAllCredits y los lookups de próximas
+-- cuotas. Sin esto cada evaluación cae a seq scan de la tabla completa.
+--
+-- Nota para aplicar EN PROD a mano: preferir CONCURRENTLY (fuera de
+-- transacción) para no bloquear escrituras:
+--   CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_cuotas_credito_credito_fecha
+--     ON cartera.cuotas_credito (credito_id, fecha_vencimiento);
+
+CREATE INDEX IF NOT EXISTS idx_cuotas_credito_credito_fecha
+  ON cartera.cuotas_credito (credito_id, fecha_vencimiento);

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -632,11 +632,19 @@ export async function getCreditosWithUserByMesAnio(
   const offset = (page - 1) * perPage;
   const conditions: any[] = [];
 
-  // 🇬🇹 Fecha actual en Guatemala
-  const hoyGuatemala = new Date(
-    new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
-  );
-  const hoyStr = hoyGuatemala.toISOString().slice(0, 10);
+  // 🇬🇹 Fecha actual en Guatemala. sv-SE da directamente YYYY-MM-DD y no
+  // depende del TZ del proceso (el patrón anterior new Date(toLocaleString)
+  // + toISOString solo era correcto con el server en UTC).
+  const hoyStr = new Date().toLocaleDateString("sv-SE", {
+    timeZone: "America/Guatemala",
+  });
+  // Aritmética de días en espacio UTC puro (independiente del TZ del server).
+  const hoyUTC = new Date(`${hoyStr}T00:00:00Z`);
+  const sumarDiasStr = (dias: number) => {
+    const d = new Date(hoyUTC);
+    d.setUTCDate(d.getUTCDate() + dias);
+    return d.toISOString().slice(0, 10);
+  };
 
   try {
     // 📌 Filtros
@@ -735,40 +743,26 @@ export async function getCreditosWithUserByMesAnio(
   if (proximidad_pago) {
     console.log(`🔎 Filtrando por proximidad de pago: ${proximidad_pago}`);
 
-    // Calcular rangos de fecha según proximidad
-    const hoy = new Date(hoyGuatemala);
-    hoy.setHours(0, 0, 0, 0);
-
+    // Calcular rangos de fecha según proximidad (derivados de hoyStr para no
+    // depender del TZ del proceso)
     if (proximidad_pago === "TODAY") {
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date = ${hoyStr}::date`);
     } else if (proximidad_pago === "WEEK") {
-      const fin = new Date(hoy);
-      fin.setDate(fin.getDate() + 7);
-      const finStr = fin.toISOString().slice(0, 10);
+      const finStr = sumarDiasStr(7);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date > ${hoyStr}::date`);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
     } else if (proximidad_pago === "TWO_WEEKS") {
-      const inicio = new Date(hoy);
-      inicio.setDate(inicio.getDate() + 8);
-      const inicioStr = inicio.toISOString().slice(0, 10);
-      const fin = new Date(hoy);
-      fin.setDate(fin.getDate() + 14);
-      const finStr = fin.toISOString().slice(0, 10);
+      const inicioStr = sumarDiasStr(8);
+      const finStr = sumarDiasStr(14);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
     } else if (proximidad_pago === "MONTH") {
-      const inicio = new Date(hoy);
-      inicio.setDate(inicio.getDate() + 15);
-      const inicioStr = inicio.toISOString().slice(0, 10);
-      const fin = new Date(hoy);
-      fin.setDate(fin.getDate() + 30);
-      const finStr = fin.toISOString().slice(0, 10);
+      const inicioStr = sumarDiasStr(15);
+      const finStr = sumarDiasStr(30);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
     } else if (proximidad_pago === "DUEMONTH") {
-      const inicio = new Date(hoy);
-      inicio.setDate(inicio.getDate() + 31);
-      const inicioStr = inicio.toISOString().slice(0, 10);
+      const inicioStr = sumarDiasStr(31);
       conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
     }
 
@@ -804,12 +798,15 @@ export async function getCreditosWithUserByMesAnio(
 
   if (excluir_pagados_mes) {
     console.log(`🔎 Excluyendo créditos con su cuota actual ya pagada`);
-    // Cuota actual = primera cuota con fecha_vencimiento >= hoy (mismo
-    // concepto que proxima_cuota). Se excluye el crédito solo si esa cuota
-    // está pagada (todas sus filas, por si hay duplicadas) Y no tiene mora
-    // activa; sin cuotas futuras no se excluye. Subconsulta correlacionada
-    // en vez de join para no multiplicar filas (paginación) y para que el
-    // COUNT herede la condición.
+    // Cuota actual = la MISMA cuota que la tabla muestra como Fecha de Pago
+    // (proximasCuotasMap): primera cuota con fecha_vencimiento >= (fecha_desde
+    // ?? hoy), con tope fecha_hasta si hay rango — si las anclas divergen, un
+    // crédito con cuota impaga visible podría ocultarse. Se excluye el crédito
+    // solo si esa cuota está pagada (todas sus filas, por si hay duplicadas)
+    // Y no tiene mora activa; sin cuotas en el rango no se excluye.
+    // Subconsulta correlacionada en vez de join para no multiplicar filas
+    // (paginación) y para que el COUNT herede la condición.
+    const anclaDesde = fecha_desde ?? hoyStr;
     conditions.push(sql`NOT (
       ${moras_credito.credito_id} IS NULL
       AND COALESCE((
@@ -822,7 +819,8 @@ export async function getCreditosWithUserByMesAnio(
             FROM ${cuotas_credito} cc2
             WHERE cc2.credito_id = ${creditos.credito_id}
               AND cc2.numero_cuota > 0
-              AND cc2.fecha_vencimiento >= ${hoyStr}::date
+              AND cc2.fecha_vencimiento >= ${anclaDesde}::date
+              ${fecha_hasta ? sql`AND cc2.fecha_vencimiento <= ${fecha_hasta}::date` : sql``}
           )
       ), false)
     )`);

--- a/apps/cartera-back/src/controllers/excluirPagadosMes.test.ts
+++ b/apps/cartera-back/src/controllers/excluirPagadosMes.test.ts
@@ -14,10 +14,12 @@ if (!hasDb) {
   const { db } = await import("../database/index");
   const { getCreditosWithUserByMesAnio } = await import("./credits");
 
-  const hoyGuatemala = new Date(
-    new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
-  );
-  const hoyStr = hoyGuatemala.toISOString().slice(0, 10);
+  // sv-SE da YYYY-MM-DD directo y no depende del TZ del proceso (mismo
+  // cálculo canónico que usa el controller).
+  const hoyStr = new Date().toLocaleDateString("sv-SE", {
+    timeZone: "America/Guatemala",
+  });
+  const anioActual = Number(hoyStr.slice(0, 4));
 
   const toRows = (r: any) => (Array.isArray(r) ? r : (r.rows ?? []));
 
@@ -55,7 +57,7 @@ if (!hasDb) {
 
   async function totalPorSifco(sifco: string, excluir?: boolean) {
     const res = await getCreditosWithUserByMesAnio(
-      0, hoyGuatemala.getFullYear(), 1, 5, sifco, undefined,
+      0, anioActual, 1, 5, sifco, undefined,
       undefined, undefined, undefined, undefined, undefined, undefined,
       undefined, undefined, undefined, undefined, undefined, undefined,
       undefined, undefined, excluir
@@ -66,13 +68,13 @@ if (!hasDb) {
   describe(`excluir_pagados_mes (integración, hoy=${hoyStr})`, () => {
     it("el totalCount con flag cuadra con un cross-check SQL independiente", async () => {
       const off = await getCreditosWithUserByMesAnio(
-        0, hoyGuatemala.getFullYear(), 1, 1, undefined, "ACTIVO",
+        0, anioActual, 1, 1, undefined, "ACTIVO",
         undefined, undefined, undefined, undefined, undefined, undefined,
         undefined, undefined, undefined, undefined, undefined, undefined,
         undefined, undefined, undefined
       );
       const on = await getCreditosWithUserByMesAnio(
-        0, hoyGuatemala.getFullYear(), 1, 1, undefined, "ACTIVO",
+        0, anioActual, 1, 1, undefined, "ACTIVO",
         undefined, undefined, undefined, undefined, undefined, undefined,
         undefined, undefined, undefined, undefined, undefined, undefined,
         undefined, undefined, true

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -246,7 +246,14 @@
     fecha_liquidacion_inversionistas: timestamp("fecha_liquidacion_inversionistas"), // 👈 Cuándo se liquidó
 
     createdAt: timestamp("createdat").defaultNow(),
-  });
+  }, (table) => ({
+    // Soporta las subconsultas correlacionadas por crédito/fecha (filtro
+    // excluir_pagados_mes, próximas cuotas) sin seq scan por fila.
+    idxCreditoFecha: index("idx_cuotas_credito_credito_fecha").on(
+      table.credito_id,
+      table.fecha_vencimiento,
+    ),
+  }));
   // 📊 Cierre mensual de cartera — foto del estado por cada statusCredit.
   //    El job corre el día 5 de cada mes y `periodo` apunta al mes anterior (el que se cierra).
   //    `capital_total` = suma del campo capital (monto colocado) de los créditos en ese estado.

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -730,6 +730,14 @@ export class CarteraBackClient {
 						...(params.email_cobrador && {
 							email_asesor: params.email_cobrador,
 						}),
+						// Sin esto el rango de fechas se perdía solo en la ruta POST
+						// (>50 SIFCOs) mientras el GET sí lo mandaba.
+						...(params.fecha_desde && {
+							fecha_desde: params.fecha_desde,
+						}),
+						...(params.fecha_hasta && {
+							fecha_hasta: params.fecha_hasta,
+						}),
 						...(params.capital_min !== undefined && {
 							capital_min: params.capital_min,
 						}),


### PR DESCRIPTION
Follow-up del code review post-merge del PR #1024 (filtro "Ocultar los que ya pagaron su cuota"). Tres correcciones quirúrgicas:

## 1) CRM: la rama bulk-POST de getAllCreditos perdía el rango de fechas
La ruta POST (>50 SIFCOs, usada con filtros de etiquetas grandes) omitía `fecha_desde`/`fecha_hasta` que el GET sí manda — la tabla y el **WhatsApp masivo** ignoraban la ventana de fechas en ese camino (defecto preexistente de abril, verificado con `git blame`; cartera-back ya aceptaba los campos). Se agregan al body.

## 2) Cartera: la exclusión ahora ancla en la MISMA cuota que muestra la tabla
La "cuota actual" del filtro anclaba siempre en *hoy*, mientras la columna Fecha de Pago (proximasCuotasMap) ancla en `fecha_desde ?? hoy` con tope `fecha_hasta`. Con un rango activo, un crédito con la cuota de hoy pagada por adelantado se ocultaba aunque su cuota visible en la ventana estuviera impaga — **2 casos reales en DEV** para una ventana de agosto. Ahora ambas usan la misma ancla; sin rango, comportamiento idéntico.

**Bonus TZ:** `hoyStr` pasa a `toLocaleDateString("sv-SE", {timeZone:"America/Guatemala"})`. El patrón anterior (`new Date(toLocaleString(...)).toISOString()`) corre la fecha +1 día si el proceso no corre en UTC (demostrado empíricamente con `TZ=America/Guatemala`; hoy el contenedor es UTC, era latente). Los rangos de proximidad (WEEK/TWO_WEEKS/MONTH/DUEMONTH) se derivan ahora con aritmética UTC pura — mismos resultados en UTC, robustos en cualquier TZ.

## 3) Perf: índice compuesto en cuotas_credito
`cuotas_credito` solo tenía la PK; las subconsultas correlacionadas del filtro (que corren en la query de datos **y** en el COUNT) caían a seq scan por evaluación. Migración `0018` + schema:
- **Ya aplicado en DEV** (neondb): plan verificado con `EXPLAIN` → `Index Scan using idx_cuotas_credito_credito_fecha`, costo 4.4.
- **Prod:** aplicar a mano con `CREATE INDEX CONCURRENTLY` (nota incluida en la migración).

## Verificación
- `tsc --noEmit`: cartera-back con sus 6 errores preexistentes (0 nuevos), CRM server en 0.
- Validación SQL read-only en DEV del nuevo anclaje (detecta y corrige los 2 divergentes).
- Test de integración actualizado al cálculo canónico de fecha. Nota: correrlo contra Neon DEV requiere aplicar antes la migración 0017 (`activo_para_creditos`) que le falta a ese clon — pendiente aparte, hoy corre contra el clon Docker local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)