### PR TITLE
feat(cobros): CRM consume catálogo dinámico de buckets vía cartera-back

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -1360,6 +1360,28 @@ function MobileView({
                             : item.creditos.statusCredit}
             </span>
           </p>
+          <p className="text-sm text-gray-700 flex items-center gap-2">
+            <strong>Bucket:</strong>
+            {item.bucket ? (
+              <span
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold border"
+                style={{
+                  backgroundColor: item.bucket.color
+                    ? `${item.bucket.color}1A`
+                    : "rgba(100,116,139,0.1)",
+                  color: item.bucket.color || "#475569",
+                  borderColor: item.bucket.color
+                    ? `${item.bucket.color}40`
+                    : "rgba(100,116,139,0.25)",
+                }}
+                title={item.bucket.nombre}
+              >
+                {item.bucket.prefijo} · {item.bucket.nombre}
+              </span>
+            ) : (
+              <span className="text-gray-400 text-xs">—</span>
+            )}
+          </p>
 
           {/* Acciones */}
           <div className="flex justify-center flex-wrap gap-2 mt-3">
@@ -1596,6 +1618,9 @@ function DesktopView({
               Cuota
             </TableHead>
             <TableHead className="text-gray-900 font-bold text-center">
+              Bucket
+            </TableHead>
+            <TableHead className="text-gray-900 font-bold text-center">
               Fecha de Creación
             </TableHead>
             <TableHead className="text-gray-900 font-bold text-center">
@@ -1647,6 +1672,27 @@ function DesktopView({
                     maximumFractionDigits: 2,
                   })}
                 </TableCell>
+                <TableCell className="text-center">
+                  {item.bucket ? (
+                    <span
+                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold border"
+                      style={{
+                        backgroundColor: item.bucket.color
+                          ? `${item.bucket.color}1A`
+                          : "rgba(100,116,139,0.1)",
+                        color: item.bucket.color || "#475569",
+                        borderColor: item.bucket.color
+                          ? `${item.bucket.color}40`
+                          : "rgba(100,116,139,0.25)",
+                      }}
+                      title={item.bucket.nombre}
+                    >
+                      {item.bucket.prefijo} · {item.bucket.nombre}
+                    </span>
+                  ) : (
+                    <span className="text-gray-400 text-xs">—</span>
+                  )}
+                </TableCell>
                 <TableCell className="text-indigo-700 font-bold text-center">
                   {item.creditos?.fecha_creacion
                     ? new Date(item.creditos.fecha_creacion).toLocaleDateString(
@@ -1680,7 +1726,7 @@ function DesktopView({
               {/* Row expandida con acciones + detalles */}
               {expandedRow === idx && (
                 <TableRow>
-                  <TableCell colSpan={6} className="p-0 bg-blue-50 rounded-b-2xl">
+                  <TableCell colSpan={7} className="p-0 bg-blue-50 rounded-b-2xl">
                     {/* Botones de acción */}
                     <div className="flex flex-wrap justify-center gap-2 px-6 py-4 border-b border-blue-100">
                         {(user?.role === "ADMIN" || user?.role === "ASESOR") && (

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -393,6 +393,13 @@ export interface InversionistaEspejo {
   fecha_inicio_participacion?: string;
 }
 
+export interface CreditoBucket {
+  numero: number;
+  prefijo: string;
+  nombre: string;
+  color: string | null;
+}
+
 export interface CreditoUsuarioPago {
   creditos: Credito;
   usuarios: Usuario;
@@ -408,6 +415,8 @@ export interface CreditoUsuarioPago {
   rubros: Rubro[];
   mora: Mora | null;
   deuda_total_con_mora: string;
+  /** Bucket de cobros actual (B0-B5). null = fuera del funnel operativo. */
+  bucket?: CreditoBucket | null;
 }
 
 export interface Mora {

--- a/apps/crm/apps/server/src/lib/cobros-capital-percentages.ts
+++ b/apps/crm/apps/server/src/lib/cobros-capital-percentages.ts
@@ -1,4 +1,9 @@
-const ACTIVE_ESTADOS = new Set([
+// Default histórico (buckets B0-B5 fijos). Los callers que consumen el
+// catálogo dinámico de cartera-back deben pasar su propio `activeEstados`
+// (derivado del catálogo real) — si no, un bucket nuevo/renumerado queda
+// fuera del denominador y nunca recibe porcentaje, aunque sí aparezca en el
+// array de stats (ver moraBuckets.ts / cobros.ts para el caso dinámico).
+const ACTIVE_ESTADOS_DEFAULT = new Set([
 	"al_dia",
 	"mora_30",
 	"mora_60",
@@ -13,7 +18,7 @@ export type CobrosCapitalStats = {
 	porcentaje: string;
 };
 
-function capitalTotal(stats: readonly CobrosCapitalStats[], estados: Set<string>) {
+function capitalTotal(stats: readonly CobrosCapitalStats[], estados: ReadonlySet<string>) {
 	return stats
 		.filter((stat) => estados.has(stat.estadoMora))
 		.reduce((sum, stat) => sum + Number(stat.sumaCapital || 0), 0);
@@ -26,11 +31,12 @@ function percentage(capital: string, total: number) {
 
 export function recalculateCobrosCapitalPercentages<T extends CobrosCapitalStats>(
 	stats: readonly T[],
+	activeEstados: ReadonlySet<string> = ACTIVE_ESTADOS_DEFAULT,
 ) {
-	const activeTotal = capitalTotal(stats, ACTIVE_ESTADOS);
+	const activeTotal = capitalTotal(stats, activeEstados);
 
 	return stats.map((stat) => {
-		if (ACTIVE_ESTADOS.has(stat.estadoMora)) {
+		if (activeEstados.has(stat.estadoMora)) {
 			return { ...stat, porcentaje: percentage(stat.sumaCapital, activeTotal) };
 		}
 

--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -23,11 +23,17 @@ describe("estadoMoraPorCuotas", () => {
 		// puede "pasar" solo porque el cache ya quedó poblado por uno anterior,
 		// no porque su propia lógica sea correcta.
 		__resetMoraBucketsCacheForTests();
+		// Sin implementación por defecto acá a propósito: un mockRejectedValue
+		// global sería el resultado de CUALQUIER llamada al spy hasta que un
+		// test lo sobreescriba, incluida una llamada que ocurra ANTES de esa
+		// sobreescritura (ej. un refresh en background disparado por un test
+		// previo) — esa promesa rechazada nadie la espera y queda como
+		// unhandled rejection. Cada test configura su propio mock.
 		getBucketsCatalogoSpy = spyOn(carteraBackClient, "getBucketsCatalogo");
-		getBucketsCatalogoSpy.mockRejectedValue(new Error("cartera-back down"));
 	});
 
 	test("falls back to al_dia for 0 cuotas atrasadas when catalogo fetch fails", () => {
+		getBucketsCatalogoSpy.mockRejectedValue(new Error("cartera-back down"));
 		expect(estadoMoraPorCuotas(0)).toBe("al_dia");
 	});
 

--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, spyOn, test } from "bun:test";
+import { carteraBackClient } from "../services/cartera-back-client";
+import { estadoMoraPorCuotas, refreshMoraBucketsCache } from "./moraBuckets";
+
+describe("estadoMoraPorCuotas", () => {
+	beforeEach(() => {
+		spyOn(carteraBackClient, "getBucketsCatalogo").mockRejectedValue(
+			new Error("cartera-back down"),
+		);
+	});
+
+	test("falls back to al_dia for 0 cuotas atrasadas when catalogo fetch fails", () => {
+		expect(estadoMoraPorCuotas(0)).toBe("al_dia");
+	});
+
+	test("uses dynamic catalogo from cartera-back once cache is refreshed", async () => {
+		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue([
+			{
+				numero: 0,
+				prefijo: "B0",
+				nombre: "Cartera Sana Custom",
+				descripcion: null,
+				cuotas_min: 0,
+				cuotas_max: 0,
+				estados_incluidos: [],
+				es_operativo: true,
+				orden: 0,
+				color: null,
+				estado_mora: "al_dia_custom",
+			},
+		]);
+
+		await refreshMoraBucketsCache();
+
+		expect(estadoMoraPorCuotas(0)).toBe("al_dia_custom");
+	});
+});

--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -1,9 +1,18 @@
 import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { carteraBackClient } from "../services/cartera-back-client";
-import { estadoMoraPorCuotas, refreshMoraBucketsCache } from "./moraBuckets";
+import {
+	__resetMoraBucketsCacheForTests,
+	estadoMoraPorCuotas,
+	refreshMoraBucketsCache,
+} from "./moraBuckets";
 
 describe("estadoMoraPorCuotas", () => {
 	beforeEach(() => {
+		// El módulo es un singleton con estado global (cache + timestamp) que
+		// persiste entre tests si no se resetea — sin esto, un test posterior
+		// puede "pasar" solo porque el cache ya quedó poblado por uno anterior,
+		// no porque su propia lógica sea correcta.
+		__resetMoraBucketsCacheForTests();
 		spyOn(carteraBackClient, "getBucketsCatalogo").mockRejectedValue(
 			new Error("cartera-back down"),
 		);
@@ -14,24 +23,91 @@ describe("estadoMoraPorCuotas", () => {
 	});
 
 	test("uses dynamic catalogo from cartera-back once cache is refreshed", async () => {
+		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue(
+			buildCatalogoCompleto(),
+		);
+
+		await refreshMoraBucketsCache();
+
+		expect(estadoMoraPorCuotas(0)).toBe("al_dia");
+	});
+
+	test("rejects estado_mora values outside the CRM enum, falls back to homólogo por numero", async () => {
+		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue(
+			buildCatalogoCompleto({ 0: "al_dia_custom" }),
+		);
+
+		await refreshMoraBucketsCache();
+
+		// "al_dia_custom" no existe en el pgEnum del CRM (casos_cobros.estado_mora)
+		// — debe caer al fallback homólogo del bucket 0 ("al_dia"), nunca
+		// propagar el valor inválido (revienta el INSERT en sync-casos-cobros.ts).
+		expect(estadoMoraPorCuotas(0)).toBe("al_dia");
+	});
+
+	test("rejects a partial catalogo (fewer buckets than the fallback), keeps previous cache", async () => {
+		// Catálogo con solo B0-B3: sin esto, un crédito con 5 cuotas atrasadas
+		// perdería cobertura y estadoMoraPorCuotas(5) caería al "al_dia" final
+		// del loop en vez del bucket real (mora_120_plus).
+		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue(
+			buildCatalogoCompleto().filter((b) => b.numero <= 3),
+		);
+
+		await refreshMoraBucketsCache();
+
+		expect(estadoMoraPorCuotas(5)).toBe("mora_120_plus");
+	});
+
+	test("rejects a catalogo with a duplicate numero (same row count, missing coverage)", async () => {
+		// Mismo largo que el catálogo completo (6 filas) pero con B0 duplicado
+		// en vez de B5 — un guard que solo compara `length` colaría esto, y
+		// cuota-5 perdería cobertura igual que en el caso de catálogo parcial.
+		const catalogo = buildCatalogoCompleto().filter((b) => b.numero <= 4);
 		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue([
-			{
-				numero: 0,
-				prefijo: "B0",
-				nombre: "Cartera Sana Custom",
-				descripcion: null,
-				cuotas_min: 0,
-				cuotas_max: 0,
-				estados_incluidos: [],
-				es_operativo: true,
-				orden: 0,
-				color: null,
-				estado_mora: "al_dia_custom",
-			},
+			...catalogo,
+			{ ...catalogo[0] },
 		]);
 
 		await refreshMoraBucketsCache();
 
-		expect(estadoMoraPorCuotas(0)).toBe("al_dia_custom");
+		expect(estadoMoraPorCuotas(5)).toBe("mora_120_plus");
 	});
 });
+
+function buildCatalogoCompleto(
+	estadoMoraOverrides: Record<number, string> = {},
+): Array<{
+	numero: number;
+	prefijo: string;
+	nombre: string;
+	descripcion: string | null;
+	cuotas_min: number;
+	cuotas_max: number | null;
+	estados_incluidos: string[];
+	es_operativo: boolean;
+	orden: number;
+	color: string | null;
+	estado_mora: string | null;
+}> {
+	const buckets = [
+		{ numero: 0, nombre: "Cartera Sana", cuotas_min: 0, cuotas_max: 0, estadoMora: "al_dia" },
+		{ numero: 1, nombre: "Alerta Temprana", cuotas_min: 1, cuotas_max: 1, estadoMora: "mora_30" },
+		{ numero: 2, nombre: "Gestión Activa", cuotas_min: 2, cuotas_max: 2, estadoMora: "mora_60" },
+		{ numero: 3, nombre: "Rescate", cuotas_min: 3, cuotas_max: 3, estadoMora: "mora_90" },
+		{ numero: 4, nombre: "Última Instancia", cuotas_min: 4, cuotas_max: 4, estadoMora: "mora_120" },
+		{ numero: 5, nombre: "Jurídico", cuotas_min: 5, cuotas_max: null, estadoMora: "mora_120_plus" },
+	];
+	return buckets.map((b) => ({
+		numero: b.numero,
+		prefijo: `B${b.numero}`,
+		nombre: b.nombre,
+		descripcion: null,
+		cuotas_min: b.cuotas_min,
+		cuotas_max: b.cuotas_max,
+		estados_incluidos: [],
+		es_operativo: true,
+		orden: b.numero,
+		color: null,
+		estado_mora: estadoMoraOverrides[b.numero] ?? b.estadoMora,
+	}));
+}

--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -3,19 +3,28 @@ import { carteraBackClient } from "../services/cartera-back-client";
 import {
 	__resetMoraBucketsCacheForTests,
 	estadoMoraPorCuotas,
+	labelPorEstadoMora,
+	rangoCuotasPorEstadoMora,
 	refreshMoraBucketsCache,
 } from "./moraBuckets";
 
 describe("estadoMoraPorCuotas", () => {
+	// Un solo handle de spy, reusado en todos los tests: llamar `spyOn` de
+	// nuevo sobre el mismo método sin restaurar el anterior no está garantizado
+	// entre versiones de Bun (hoy re-envuelve limpio, pero es un detalle de
+	// implementación, no contrato documentado). Cambiar la implementación del
+	// MISMO handle (`mockResolvedValue`/`mockRejectedValue`) es el patrón
+	// correcto y no depende de ese detalle.
+	let getBucketsCatalogoSpy: ReturnType<typeof spyOn<typeof carteraBackClient, "getBucketsCatalogo">>;
+
 	beforeEach(() => {
 		// El módulo es un singleton con estado global (cache + timestamp) que
 		// persiste entre tests si no se resetea — sin esto, un test posterior
 		// puede "pasar" solo porque el cache ya quedó poblado por uno anterior,
 		// no porque su propia lógica sea correcta.
 		__resetMoraBucketsCacheForTests();
-		spyOn(carteraBackClient, "getBucketsCatalogo").mockRejectedValue(
-			new Error("cartera-back down"),
-		);
+		getBucketsCatalogoSpy = spyOn(carteraBackClient, "getBucketsCatalogo");
+		getBucketsCatalogoSpy.mockRejectedValue(new Error("cartera-back down"));
 	});
 
 	test("falls back to al_dia for 0 cuotas atrasadas when catalogo fetch fails", () => {
@@ -23,9 +32,7 @@ describe("estadoMoraPorCuotas", () => {
 	});
 
 	test("uses dynamic catalogo from cartera-back once cache is refreshed", async () => {
-		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue(
-			buildCatalogoCompleto(),
-		);
+		getBucketsCatalogoSpy.mockResolvedValue(buildCatalogoCompleto());
 
 		await refreshMoraBucketsCache();
 
@@ -33,7 +40,7 @@ describe("estadoMoraPorCuotas", () => {
 	});
 
 	test("rejects estado_mora values outside the CRM enum, falls back to homólogo por numero", async () => {
-		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue(
+		getBucketsCatalogoSpy.mockResolvedValue(
 			buildCatalogoCompleto({ 0: "al_dia_custom" }),
 		);
 
@@ -49,7 +56,7 @@ describe("estadoMoraPorCuotas", () => {
 		// Catálogo con solo B0-B3: sin esto, un crédito con 5 cuotas atrasadas
 		// perdería cobertura y estadoMoraPorCuotas(5) caería al "al_dia" final
 		// del loop en vez del bucket real (mora_120_plus).
-		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue(
+		getBucketsCatalogoSpy.mockResolvedValue(
 			buildCatalogoCompleto().filter((b) => b.numero <= 3),
 		);
 
@@ -63,14 +70,102 @@ describe("estadoMoraPorCuotas", () => {
 		// en vez de B5 — un guard que solo compara `length` colaría esto, y
 		// cuota-5 perdería cobertura igual que en el caso de catálogo parcial.
 		const catalogo = buildCatalogoCompleto().filter((b) => b.numero <= 4);
-		spyOn(carteraBackClient, "getBucketsCatalogo").mockResolvedValue([
-			...catalogo,
-			{ ...catalogo[0] },
-		]);
+		getBucketsCatalogoSpy.mockResolvedValue([...catalogo, { ...catalogo[0] }]);
 
 		await refreshMoraBucketsCache();
 
 		expect(estadoMoraPorCuotas(5)).toBe("mora_120_plus");
+	});
+
+	test("discards a new bucket (no homólogo conocido) whose estado_mora is null/invalid, instead of defaulting to al_dia", async () => {
+		// B6 no existe en MORA_BUCKETS — no hay homólogo al que caer, y su
+		// estado_mora es null. Antes del fix, esto se forzaba a "al_dia" y esa
+		// fila fantasma se incluía en el cache con `orden: -1` (primero que B0
+		// real) — como `labelPorEstadoMora`/`estadoMoraPorCuotas` hacen
+		// first-match, el B0 legítimo (rango 0-0, label "Cartera Sana") habría
+		// quedado ensombrecido por el B6 fantasma (label "Bucket nuevo sin
+		// estado") para CUALQUIER crédito al día, no solo para cuota 6 — el
+		// bug no se limitaba al rango del bucket nuevo. Con el fix, la fila se
+		// descarta antes de entrar al cache: el label de "al_dia" sigue siendo
+		// el de B0 real.
+		const catalogo = buildCatalogoCompleto();
+		getBucketsCatalogoSpy.mockResolvedValue([
+			{
+				numero: 6,
+				prefijo: "B6",
+				nombre: "Bucket nuevo sin estado",
+				descripcion: null,
+				cuotas_min: 6,
+				cuotas_max: null,
+				estados_incluidos: [],
+				es_operativo: true,
+				orden: -1,
+				color: null,
+				estado_mora: null,
+			},
+			...catalogo,
+		]);
+
+		await refreshMoraBucketsCache();
+
+		expect(labelPorEstadoMora("al_dia")).toBe("Cartera Sana");
+	});
+
+	test("discards a new bucket (no homólogo conocido) even with a VALID estado_mora", async () => {
+		// Variante más sutil del test anterior: B6 no existe en MORA_BUCKETS,
+		// pero esta vez su estado_mora ("mora_90") SÍ es válido en el enum — no
+		// lo filtra la whitelist. Sin el filtro por `numero` conocido, esta fila
+		// sobrevivía al mapeo entero y, con `orden: -1`, ensombrecía a B0 real
+		// (rango 0-0) para cualquier crédito al día, devolviendo "mora_90" en
+		// vez de "al_dia" — un crédito sin atraso persistido con etapa de mora.
+		const catalogo = buildCatalogoCompleto();
+		getBucketsCatalogoSpy.mockResolvedValue([
+			{
+				numero: 6,
+				prefijo: "B6",
+				nombre: "Bucket nuevo con estado válido",
+				descripcion: null,
+				cuotas_min: 0,
+				cuotas_max: 0,
+				estados_incluidos: [],
+				es_operativo: true,
+				orden: -1,
+				color: null,
+				estado_mora: "mora_90",
+			},
+			...catalogo,
+		]);
+
+		await refreshMoraBucketsCache();
+
+		expect(estadoMoraPorCuotas(0)).toBe("al_dia");
+	});
+
+	test("dedups a duplicated numero deterministically (lowest orden wins), not by iteration order", async () => {
+		// Catálogo completo + una segunda fila con numero:3 (rango y estado
+		// distintos al B3 real), con `orden` MÁS BAJO que el B3 legítimo — sin
+		// dedup explícito, ambas entradas convivirían en el cache y cuál "gana"
+		// el first-match dependería del orden de iteración, no de una regla.
+		const catalogo = buildCatalogoCompleto();
+		const b3Real = catalogo.find((b) => b.numero === 3);
+		if (!b3Real) throw new Error("fixture inválido: falta B3");
+		getBucketsCatalogoSpy.mockResolvedValue([
+			{
+				...b3Real,
+				cuotas_min: 10,
+				cuotas_max: 10,
+				estado_mora: "mora_120",
+				orden: -1,
+			},
+			...catalogo,
+		]);
+
+		await refreshMoraBucketsCache();
+
+		// Debe ganar la fila de `orden` más bajo (la duplicada, orden:-1) —
+		// comportamiento determinístico, documentado, no azar de iteración.
+		const rango = rangoCuotasPorEstadoMora("mora_120");
+		expect(rango).toEqual({ min: 10, max: 10 });
 	});
 });
 

--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -52,6 +52,22 @@ describe("estadoMoraPorCuotas", () => {
 		expect(estadoMoraPorCuotas(0)).toBe("al_dia");
 	});
 
+	test("rejects a status estado_mora (en_convenio/pagado/incobrable) on a bucket row, falls back to homólogo", async () => {
+		// "en_convenio" SÍ es válido en el pgEnum completo de 9 valores — pero
+		// es un estado de STATUS del crédito, no de aging por cuotas. Este
+		// bucket (B2, rango de 2 cuotas) no debería poder tener ese estado: si
+		// la whitelist usara ESTADOS_MORA_VALIDOS (los 9) en vez de
+		// ESTADOS_AGING_VALIDOS (los 6), esto pasaría sin filtro y un crédito
+		// con 2 cuotas atrasadas normales se clasificaría como "en_convenio".
+		getBucketsCatalogoSpy.mockResolvedValue(
+			buildCatalogoCompleto({ 2: "en_convenio" }),
+		);
+
+		await refreshMoraBucketsCache();
+
+		expect(estadoMoraPorCuotas(2)).toBe("mora_60");
+	});
+
 	test("rejects a partial catalogo (fewer buckets than the fallback), keeps previous cache", async () => {
 		// Catálogo con solo B0-B3: sin esto, un crédito con 5 cuotas atrasadas
 		// perdería cobertura y estadoMoraPorCuotas(5) caería al "al_dia" final

--- a/apps/crm/apps/server/src/lib/moraBuckets.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.ts
@@ -1,3 +1,5 @@
+import { carteraBackClient } from "../services/cartera-back-client";
+
 /**
  * Fuente única de verdad (lado CRM) de los buckets de aging de mora por cuotas
  * atrasadas. Espejo de `apps/cartera-back/src/config/moraBuckets.ts`: mantener
@@ -32,23 +34,57 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 	{ key: "5", estadoMora: "mora_120_plus", min: 5, max: null, label: "Jurídico" },
 ] as const;
 
+/**
+ * Cache en memoria de MORA_BUCKETS poblada desde el catálogo dinámico de
+ * cartera-back (tabla `cartera.buckets`). Arranca en `null` (usa el estático
+ * MORA_BUCKETS de arriba) hasta que `refreshMoraBucketsCache()` la puebla;
+ * si el fetch falla se mantiene el fallback estático, nunca lanza.
+ */
+let dynamicBucketsCache: readonly MoraBucket[] | null = null;
+
+function activeBuckets(): readonly MoraBucket[] {
+	return dynamicBucketsCache ?? MORA_BUCKETS;
+}
+
+/** Refresca la cache de buckets desde cartera-back. No lanza: si falla, conserva la cache/fallback previos. */
+export async function refreshMoraBucketsCache(): Promise<void> {
+	try {
+		const catalogo = await carteraBackClient.getBucketsCatalogo();
+		dynamicBucketsCache = catalogo
+			.filter((b) => b.estado_mora !== null)
+			.sort((a, b) => a.orden - b.orden)
+			.map((b) => ({
+				key: String(b.numero),
+				estadoMora: b.estado_mora as string,
+				min: b.cuotas_min,
+				max: b.cuotas_max,
+				label: b.nombre,
+			}));
+	} catch (err) {
+		console.error(
+			"[moraBuckets] Error refrescando catálogo de buckets, se mantiene fallback:",
+			err,
+		);
+	}
+}
+
 /** Rango { min, max } de cuotas atrasadas para una etapa. `undefined` si no aplica filtro por cuotas. */
 export function rangoCuotasPorEstadoMora(
 	estadoMora: string,
 ): { min: number; max: number | undefined } | undefined {
-	const b = MORA_BUCKETS.find((x) => x.estadoMora === estadoMora);
+	const b = activeBuckets().find((x) => x.estadoMora === estadoMora);
 	if (!b) return undefined;
 	return { min: b.min, max: b.max ?? undefined };
 }
 
 /** Nombre de negocio (label) de una etapa. `undefined` si no es bucket de aging. */
 export function labelPorEstadoMora(estadoMora: string): string | undefined {
-	return MORA_BUCKETS.find((b) => b.estadoMora === estadoMora)?.label;
+	return activeBuckets().find((b) => b.estadoMora === estadoMora)?.label;
 }
 
 /** Etapa de mora correspondiente a un número de cuotas atrasadas. */
 export function estadoMoraPorCuotas(cuotas: number): string {
-	for (const b of MORA_BUCKETS) {
+	for (const b of activeBuckets()) {
 		const dentro = b.max === null ? cuotas >= b.min : cuotas >= b.min && cuotas <= b.max;
 		if (dentro) return b.estadoMora;
 	}

--- a/apps/crm/apps/server/src/lib/moraBuckets.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.ts
@@ -89,19 +89,37 @@ export function __resetMoraBucketsCacheForTests(): void {
 export async function refreshMoraBucketsCache(): Promise<void> {
 	try {
 		const catalogo = await carteraBackClient.getBucketsCatalogo();
-		// No se descartan filas con `estado_mora` null/inválido: eso dejaría su
-		// rango de cuotas sin cobertura y `estadoMoraPorCuotas` caería al "al_dia"
-		// final del loop para créditos realmente atrasados (persistido como etapa
-		// del caso). En vez de eso, cada fila usa su propio `estado_mora` si es
-		// uno de los 9 valores del enum del CRM, o el del bucket homólogo de
-		// MORA_BUCKETS (mismo `numero`/`key`) si no — nunca se propaga un valor
-		// fuera del enum (revienta el INSERT/UPDATE en sync-casos-cobros.ts).
-		const mapped = catalogo
+		// Solo se aceptan `numero` conocidos en MORA_BUCKETS ("0".."5"). Un
+		// `numero` fuera de ese conjunto (bucket nuevo agregado al catálogo sin
+		// que el código sepa mapearlo) se descarta ENTERO, sin importar si su
+		// estado_mora es válido: aceptarlo permitiría que un bucket huérfano con
+		// `orden` bajo (ej. -1) gane el first-match de estadoMoraPorCuotas sobre
+		// el bucket real y ensombrezca su clasificación para CUALQUIER crédito
+		// en ese rango de cuotas — no solo el rango del bucket nuevo. Añadir un
+		// bucket nuevo real requiere agregar su homólogo a MORA_BUCKETS primero.
+		const catalogoConocido = catalogo.filter((b) =>
+			MORA_BUCKETS.some((f) => f.key === String(b.numero)),
+		);
+		// Dedup por `numero`: si el catálogo trae dos filas con el mismo numero
+		// (bug de query en cartera-back, o edición manual duplicada), quedarse
+		// con la de `orden` más bajo de forma determinística — sin este dedup,
+		// dos entradas con la misma key coexistirían en el cache y cuál gana el
+		// first-match de `estadoMoraPorCuotas`/`rangoCuotasPorEstadoMora`
+		// dependería del orden de iteración, no de una regla explícita.
+		const porNumero = new Map<number, (typeof catalogoConocido)[number]>();
+		for (const b of [...catalogoConocido].sort((a, b) => a.orden - b.orden)) {
+			if (!porNumero.has(b.numero)) porNumero.set(b.numero, b);
+		}
+		// `estado_mora` null/inválido: la fila SÍ se conserva (numero conocido,
+		// solo falta el estado) usando el homólogo de MORA_BUCKETS — nunca se
+		// propaga un valor fuera del enum (revienta el INSERT/UPDATE en
+		// sync-casos-cobros.ts).
+		const mapped = Array.from(porNumero.values())
 			.sort((a, b) => a.orden - b.orden)
 			.map((b) => {
-				const fallbackEstado =
-					MORA_BUCKETS.find((f) => f.key === String(b.numero))?.estadoMora ??
-					"al_dia";
+				const fallbackEstado = MORA_BUCKETS.find(
+					(f) => f.key === String(b.numero),
+				)?.estadoMora as string;
 				const estadoMora =
 					b.estado_mora && ESTADOS_MORA_VALIDOS.has(b.estado_mora)
 						? b.estado_mora
@@ -114,15 +132,11 @@ export async function refreshMoraBucketsCache(): Promise<void> {
 					label: b.nombre,
 				};
 			});
-		// Guard: catálogo vacío, o sin cubrir cada bucket del fallback conocido
-		// (siembra parcial, fila desactivada/borrada por error) — un catálogo
-		// incompleto reemplazando el cache dejaría rangos de cuotas sin cobertura
-		// (mismo síntoma que el guard de arriba, por otra puerta). Se cuentan
-		// `numero`/`key` DISTINTOS, no filas: un catálogo con una fila duplicada
-		// (mismo numero dos veces, otro numero ausente) tendría el mismo
-		// `mapped.length` que uno completo y colaría por un `length < length`
-		// simple. Todo-o-nada: o el catálogo cubre cada key del fallback, o no
-		// se usa y se conserva el cache/fallback previo.
+		// Guard: catálogo vacío, o sin cubrir cada bucket conocido (siembra
+		// parcial, fila desactivada/borrada por error) — un catálogo incompleto
+		// reemplazando el cache dejaría rangos de cuotas sin cobertura. Todo-o-
+		// nada: o el catálogo cubre cada key de MORA_BUCKETS, o no se usa y se
+		// conserva el cache/fallback previo.
 		const keysCubiertas = new Set(mapped.map((b) => b.key));
 		const faltantes = MORA_BUCKETS.filter((f) => !keysCubiertas.has(f.key));
 		if (faltantes.length > 0) {

--- a/apps/crm/apps/server/src/lib/moraBuckets.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.ts
@@ -34,6 +34,26 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 	{ key: "5", estadoMora: "mora_120_plus", min: 5, max: null, label: "Jurídico" },
 ] as const;
 
+// `casos_cobros.estado_mora` es un pgEnum de 9 valores fijos en el CRM (ver
+// db/schema/cobros.ts). El catálogo de cartera-back (`buckets.estado_mora`) es
+// varchar(24) editable a mano — un admin puede escribir cualquier texto ahí.
+// Sin esta whitelist, ese texto libre se castea `as EstadoMoraEnum` en
+// sync-casos-cobros.ts y el INSERT/UPDATE revienta en Postgres con "invalid
+// input value for enum" (silencioso: cae al catch por-crédito, el caso
+// simplemente no se sincroniza). Solo se acepta un estado_mora del catálogo si
+// es uno de estos 9; si no, se usa el fallback homólogo por número de bucket.
+export const ESTADOS_MORA_VALIDOS = new Set([
+	"al_dia",
+	"en_convenio",
+	"mora_30",
+	"mora_60",
+	"mora_90",
+	"mora_120",
+	"mora_120_plus",
+	"pagado",
+	"incobrable",
+]);
+
 /**
  * Cache en memoria de MORA_BUCKETS poblada desde el catálogo dinámico de
  * cartera-back (tabla `cartera.buckets`). Arranca en `null` (usa el estático
@@ -41,26 +61,84 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
  * si el fetch falla se mantiene el fallback estático, nunca lanza.
  */
 let dynamicBucketsCache: readonly MoraBucket[] | null = null;
+let cachedAt = 0;
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 min — el catálogo cambia poco (admin lo edita a mano)
 
 function activeBuckets(): readonly MoraBucket[] {
 	return dynamicBucketsCache ?? MORA_BUCKETS;
 }
 
-/** Refresca la cache de buckets desde cartera-back. No lanza: si falla, conserva la cache/fallback previos. */
+/**
+ * Resetea el cache en memoria a su estado inicial (sin poblar). Test-only:
+ * el módulo es un singleton con estado global (`dynamicBucketsCache`,
+ * `cachedAt`) que persiste entre tests si no se limpia explícitamente.
+ */
+export function __resetMoraBucketsCacheForTests(): void {
+	dynamicBucketsCache = null;
+	cachedAt = 0;
+	refreshInFlight = null;
+}
+
+/**
+ * Refresca la cache de buckets desde cartera-back. No lanza: si falla, conserva
+ * el cache/fallback previos. Uso normal es interno, vía `maybeRefreshInBackground`
+ * (lazy, disparado por las funciones exportadas de abajo) — se exporta para que
+ * los tests puedan poblar el cache de forma determinística sin esperar al TTL,
+ * y como warm-up manual opcional si algún caller quisiera precalentar el cache.
+ */
 export async function refreshMoraBucketsCache(): Promise<void> {
 	try {
 		const catalogo = await carteraBackClient.getBucketsCatalogo();
-		dynamicBucketsCache = catalogo
-			.filter((b) => b.estado_mora !== null)
+		// No se descartan filas con `estado_mora` null/inválido: eso dejaría su
+		// rango de cuotas sin cobertura y `estadoMoraPorCuotas` caería al "al_dia"
+		// final del loop para créditos realmente atrasados (persistido como etapa
+		// del caso). En vez de eso, cada fila usa su propio `estado_mora` si es
+		// uno de los 9 valores del enum del CRM, o el del bucket homólogo de
+		// MORA_BUCKETS (mismo `numero`/`key`) si no — nunca se propaga un valor
+		// fuera del enum (revienta el INSERT/UPDATE en sync-casos-cobros.ts).
+		const mapped = catalogo
 			.sort((a, b) => a.orden - b.orden)
-			.map((b) => ({
-				key: String(b.numero),
-				estadoMora: b.estado_mora as string,
-				min: b.cuotas_min,
-				max: b.cuotas_max,
-				label: b.nombre,
-			}));
+			.map((b) => {
+				const fallbackEstado =
+					MORA_BUCKETS.find((f) => f.key === String(b.numero))?.estadoMora ??
+					"al_dia";
+				const estadoMora =
+					b.estado_mora && ESTADOS_MORA_VALIDOS.has(b.estado_mora)
+						? b.estado_mora
+						: fallbackEstado;
+				return {
+					key: String(b.numero),
+					estadoMora,
+					min: b.cuotas_min,
+					max: b.cuotas_max,
+					label: b.nombre,
+				};
+			});
+		// Guard: catálogo vacío, o sin cubrir cada bucket del fallback conocido
+		// (siembra parcial, fila desactivada/borrada por error) — un catálogo
+		// incompleto reemplazando el cache dejaría rangos de cuotas sin cobertura
+		// (mismo síntoma que el guard de arriba, por otra puerta). Se cuentan
+		// `numero`/`key` DISTINTOS, no filas: un catálogo con una fila duplicada
+		// (mismo numero dos veces, otro numero ausente) tendría el mismo
+		// `mapped.length` que uno completo y colaría por un `length < length`
+		// simple. Todo-o-nada: o el catálogo cubre cada key del fallback, o no
+		// se usa y se conserva el cache/fallback previo.
+		const keysCubiertas = new Set(mapped.map((b) => b.key));
+		const faltantes = MORA_BUCKETS.filter((f) => !keysCubiertas.has(f.key));
+		if (faltantes.length > 0) {
+			console.error(
+				`[moraBuckets] Catálogo incompleto (faltan buckets: ${faltantes.map((f) => f.key).join(", ")}) — se mantiene fallback previo`,
+			);
+			return;
+		}
+		dynamicBucketsCache = mapped;
+		cachedAt = Date.now();
 	} catch (err) {
+		// Aunque falle, se respeta el TTL antes de reintentar — sin esto, con
+		// cachedAt sin tocar (0 al arranque), cada llamada síncrona siguiente
+		// (una por fila en tablas de cobros) dispararía un fetch nuevo mientras
+		// cartera-back esté caído, sin backoff.
+		cachedAt = Date.now();
 		console.error(
 			"[moraBuckets] Error refrescando catálogo de buckets, se mantiene fallback:",
 			err,
@@ -68,10 +146,27 @@ export async function refreshMoraBucketsCache(): Promise<void> {
 	}
 }
 
+let refreshInFlight: Promise<void> | null = null;
+
+/**
+ * Dispara un refresh en background si el cache expiró, sin bloquear la
+ * llamada actual. Deduplica: si ya hay un refresh en vuelo, no dispara otro
+ * (evita N fetches concurrentes cuando N filas de una tabla llaman a este
+ * módulo en el mismo tick con el cache recién expirado).
+ */
+function maybeRefreshInBackground(): void {
+	if (Date.now() - cachedAt > CACHE_TTL_MS && !refreshInFlight) {
+		refreshInFlight = refreshMoraBucketsCache().finally(() => {
+			refreshInFlight = null;
+		});
+	}
+}
+
 /** Rango { min, max } de cuotas atrasadas para una etapa. `undefined` si no aplica filtro por cuotas. */
 export function rangoCuotasPorEstadoMora(
 	estadoMora: string,
 ): { min: number; max: number | undefined } | undefined {
+	maybeRefreshInBackground();
 	const b = activeBuckets().find((x) => x.estadoMora === estadoMora);
 	if (!b) return undefined;
 	return { min: b.min, max: b.max ?? undefined };
@@ -79,11 +174,13 @@ export function rangoCuotasPorEstadoMora(
 
 /** Nombre de negocio (label) de una etapa. `undefined` si no es bucket de aging. */
 export function labelPorEstadoMora(estadoMora: string): string | undefined {
+	maybeRefreshInBackground();
 	return activeBuckets().find((b) => b.estadoMora === estadoMora)?.label;
 }
 
 /** Etapa de mora correspondiente a un número de cuotas atrasadas. */
 export function estadoMoraPorCuotas(cuotas: number): string {
+	maybeRefreshInBackground();
 	for (const b of activeBuckets()) {
 		const dentro = b.max === null ? cuotas >= b.min : cuotas >= b.min && cuotas <= b.max;
 		if (dentro) return b.estadoMora;

--- a/apps/crm/apps/server/src/lib/moraBuckets.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.ts
@@ -35,24 +35,18 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 ] as const;
 
 // `casos_cobros.estado_mora` es un pgEnum de 9 valores fijos en el CRM (ver
-// db/schema/cobros.ts). El catálogo de cartera-back (`buckets.estado_mora`) es
-// varchar(24) editable a mano — un admin puede escribir cualquier texto ahí.
-// Sin esta whitelist, ese texto libre se castea `as EstadoMoraEnum` en
-// sync-casos-cobros.ts y el INSERT/UPDATE revienta en Postgres con "invalid
-// input value for enum" (silencioso: cae al catch por-crédito, el caso
-// simplemente no se sincroniza). Solo se acepta un estado_mora del catálogo si
-// es uno de estos 9; si no, se usa el fallback homólogo por número de bucket.
-export const ESTADOS_MORA_VALIDOS = new Set([
-	"al_dia",
-	"en_convenio",
-	"mora_30",
-	"mora_60",
-	"mora_90",
-	"mora_120",
-	"mora_120_plus",
-	"pagado",
-	"incobrable",
-]);
+// db/schema/cobros.ts), pero el catálogo de cartera-back (`buckets.estado_mora`)
+// solo representa los 6 buckets de AGING (B0-B5) — `en_convenio`/`pagado`/
+// `incobrable` son estados de STATUS del crédito, resueltos aparte (ver
+// mapearEstadoMora en sync-casos-cobros.ts), nunca filas del catálogo de
+// buckets. Este set, derivado de MORA_BUCKETS en vez de repetir la lista a
+// mano, es la whitelist real para cualquier estado_mora que venga del
+// catálogo (varchar(24) editable a mano): aceptar un valor de status aquí
+// sería válido en el enum de Postgres pero semánticamente incorrecto — un
+// bucket de CUOTAS no debería poder tener un estado de status.
+export const ESTADOS_AGING_VALIDOS = new Set(
+	MORA_BUCKETS.map((b) => b.estadoMora),
+);
 
 /**
  * Cache en memoria de MORA_BUCKETS poblada desde el catálogo dinámico de
@@ -110,9 +104,12 @@ export async function refreshMoraBucketsCache(): Promise<void> {
 		for (const b of [...catalogoConocido].sort((a, b) => a.orden - b.orden)) {
 			if (!porNumero.has(b.numero)) porNumero.set(b.numero, b);
 		}
-		// `estado_mora` null/inválido: la fila SÍ se conserva (numero conocido,
-		// solo falta el estado) usando el homólogo de MORA_BUCKETS — nunca se
-		// propaga un valor fuera del enum (revienta el INSERT/UPDATE en
+		// `estado_mora` null/inválido/de-status: la fila SÍ se conserva (numero
+		// conocido, solo falta un estado de aging válido) usando el homólogo de
+		// MORA_BUCKETS — nunca se propaga un valor fuera de ESTADOS_AGING_VALIDOS
+		// (un valor de status como "en_convenio" sería válido en el pgEnum
+		// completo pero semánticamente incorrecto para un bucket de CUOTAS, y un
+		// valor fuera del enum entero revienta el INSERT/UPDATE en
 		// sync-casos-cobros.ts).
 		const mapped = Array.from(porNumero.values())
 			.sort((a, b) => a.orden - b.orden)
@@ -121,7 +118,7 @@ export async function refreshMoraBucketsCache(): Promise<void> {
 					(f) => f.key === String(b.numero),
 				)?.estadoMora as string;
 				const estadoMora =
-					b.estado_mora && ESTADOS_MORA_VALIDOS.has(b.estado_mora)
+					b.estado_mora && ESTADOS_AGING_VALIDOS.has(b.estado_mora)
 						? b.estado_mora
 						: fallbackEstado;
 				return {
@@ -140,6 +137,11 @@ export async function refreshMoraBucketsCache(): Promise<void> {
 		const keysCubiertas = new Set(mapped.map((b) => b.key));
 		const faltantes = MORA_BUCKETS.filter((f) => !keysCubiertas.has(f.key));
 		if (faltantes.length > 0) {
+			// Actualiza cachedAt igual que el catch de abajo: sin esto, con el
+			// catálogo incompleto persistiendo (migración a medias, fila borrada
+			// sin restaurar), cada llamada síncrona siguiente reintentaría el
+			// fetch sin respetar el TTL, machacando cartera-back fila por fila.
+			cachedAt = Date.now();
 			console.error(
 				`[moraBuckets] Catálogo incompleto (faltan buckets: ${faltantes.map((f) => f.key).join(", ")}) — se mantiene fallback previo`,
 			);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -54,7 +54,7 @@ import {
 } from "../lib/messaging-test-mode";
 import {
 	estadoMoraPorCuotas,
-	ESTADOS_MORA_VALIDOS,
+	ESTADOS_AGING_VALIDOS,
 	MORA_BUCKETS,
 	rangoCuotasPorEstadoMora,
 } from "../lib/moraBuckets";
@@ -433,11 +433,13 @@ export const cobrosRouter = {
 							MORA_BUCKETS.find((b) => b.key === key)?.estadoMora ?? "al_dia";
 						// `estadoMora` de /stats viene del mismo catálogo varchar(24)
 						// editable a mano que valida moraBuckets.ts — se aplica la misma
-						// whitelist aquí (no se persiste, es solo dashboard, pero un valor
-						// fuera del enum no debería llegar al embudo ni al denominador).
+						// whitelist de AGING aquí (no ESTADOS_MORA_VALIDOS completo): estos
+						// son buckets de CUOTAS, no filas de status — un "en_convenio"/
+						// "pagado"/"incobrable" colado aquí sería válido en el enum pero
+						// semánticamente incorrecto para un bucket de aging.
 						const estadoMora =
 							bucketStats?.estadoMora &&
-							ESTADOS_MORA_VALIDOS.has(bucketStats.estadoMora)
+							ESTADOS_AGING_VALIDOS.has(bucketStats.estadoMora)
 								? bucketStats.estadoMora
 								: fallbackEstado;
 						return {

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -413,68 +413,38 @@ export const cobrosRouter = {
 						email: input?.emailCobrador,
 					});
 
-					// Mapear cuotas atrasadas a estados de mora - usar datos exactos de cartera
+					// Mapear cuotas atrasadas a estados de mora - usar datos exactos de cartera.
+					// `estadoMora` viene del catálogo dinámico (cartera.buckets vía /stats
+					// enriquecido); el literal es solo fallback si el catálogo aún no lo trae.
+					// Se itera sobre las keys reales de `porCuotasAtrasadas` (no una lista
+					// fija "0".."5") para que un bucket nuevo o renumerado en el catálogo
+					// no quede excluido silenciosamente del embudo/porcentajes del CRM.
+					const FALLBACK_ESTADO_MORA_POR_KEY: Record<string, string> = {
+						"0": "al_dia",
+						"1": "mora_30",
+						"2": "mora_60",
+						"3": "mora_90",
+						"4": "mora_120",
+						"5": "mora_120_plus",
+					};
+					const cuotasKeys = Object.keys(
+						statsResponse.porCuotasAtrasadas,
+					).sort((a, b) => Number(a) - Number(b));
+
 					const estatusStats = recalculateCobrosCapitalPercentages([
-						{
-							estadoMora: "al_dia",
-							totalCases: statsResponse.porCuotasAtrasadas["0"]?.cantidad || 0,
-							montoTotal:
-								statsResponse.porCuotasAtrasadas["0"]?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porCuotasAtrasadas["0"]?.sumaCapital || "0",
-							porcentaje:
-								statsResponse.porCuotasAtrasadas["0"]?.porcentaje || "0",
-						},
-						{
-							estadoMora: "mora_30",
-							totalCases: statsResponse.porCuotasAtrasadas["1"]?.cantidad || 0,
-							montoTotal:
-								statsResponse.porCuotasAtrasadas["1"]?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porCuotasAtrasadas["1"]?.sumaCapital || "0",
-							porcentaje:
-								statsResponse.porCuotasAtrasadas["1"]?.porcentaje || "0",
-						},
-						{
-							estadoMora: "mora_60",
-							totalCases: statsResponse.porCuotasAtrasadas["2"]?.cantidad || 0,
-							montoTotal:
-								statsResponse.porCuotasAtrasadas["2"]?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porCuotasAtrasadas["2"]?.sumaCapital || "0",
-							porcentaje:
-								statsResponse.porCuotasAtrasadas["2"]?.porcentaje || "0",
-						},
-						{
-							estadoMora: "mora_90",
-							totalCases: statsResponse.porCuotasAtrasadas["3"]?.cantidad || 0,
-							montoTotal:
-								statsResponse.porCuotasAtrasadas["3"]?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porCuotasAtrasadas["3"]?.sumaCapital || "0",
-							porcentaje:
-								statsResponse.porCuotasAtrasadas["3"]?.porcentaje || "0",
-						},
-						{
-							estadoMora: "mora_120",
-							totalCases: statsResponse.porCuotasAtrasadas["4"]?.cantidad || 0,
-							montoTotal:
-								statsResponse.porCuotasAtrasadas["4"]?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porCuotasAtrasadas["4"]?.sumaCapital || "0",
-							porcentaje:
-								statsResponse.porCuotasAtrasadas["4"]?.porcentaje || "0",
-						},
-						{
-							estadoMora: "mora_120_plus",
-							totalCases: statsResponse.porCuotasAtrasadas["5"]?.cantidad || 0,
-							montoTotal:
-								statsResponse.porCuotasAtrasadas["5"]?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porCuotasAtrasadas["5"]?.sumaCapital || "0",
-							porcentaje:
-								statsResponse.porCuotasAtrasadas["5"]?.porcentaje || "0",
-						},
+						...cuotasKeys.map((key) => {
+							const bucketStats = statsResponse.porCuotasAtrasadas[key];
+							return {
+								estadoMora:
+									bucketStats?.estadoMora ??
+									FALLBACK_ESTADO_MORA_POR_KEY[key] ??
+									"al_dia",
+								totalCases: bucketStats?.cantidad || 0,
+								montoTotal: bucketStats?.sumaMora || "0",
+								sumaCapital: bucketStats?.sumaCapital || "0",
+								porcentaje: bucketStats?.porcentaje || "0",
+							};
+						}),
 						{
 							estadoMora: "completado",
 							totalCases: statsResponse.porEstado.cancelado?.cantidad || 0,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -54,6 +54,8 @@ import {
 } from "../lib/messaging-test-mode";
 import {
 	estadoMoraPorCuotas,
+	ESTADOS_MORA_VALIDOS,
+	MORA_BUCKETS,
 	rangoCuotasPorEstadoMora,
 } from "../lib/moraBuckets";
 import { calcularDiasMoraExactos } from "../lib/mora-utils";
@@ -415,53 +417,67 @@ export const cobrosRouter = {
 
 					// Mapear cuotas atrasadas a estados de mora - usar datos exactos de cartera.
 					// `estadoMora` viene del catálogo dinámico (cartera.buckets vía /stats
-					// enriquecido); el literal es solo fallback si el catálogo aún no lo trae.
+					// enriquecido); el fallback deriva de MORA_BUCKETS (no un objeto literal
+					// capado a "0".."5") para que un bucket nuevo/renumerado tenga fallback
+					// también en la ventana en la que /stats aún no lo enriquece.
 					// Se itera sobre las keys reales de `porCuotasAtrasadas` (no una lista
 					// fija "0".."5") para que un bucket nuevo o renumerado en el catálogo
 					// no quede excluido silenciosamente del embudo/porcentajes del CRM.
-					const FALLBACK_ESTADO_MORA_POR_KEY: Record<string, string> = {
-						"0": "al_dia",
-						"1": "mora_30",
-						"2": "mora_60",
-						"3": "mora_90",
-						"4": "mora_120",
-						"5": "mora_120_plus",
-					};
 					const cuotasKeys = Object.keys(
 						statsResponse.porCuotasAtrasadas,
 					).sort((a, b) => Number(a) - Number(b));
 
-					const estatusStats = recalculateCobrosCapitalPercentages([
-						...cuotasKeys.map((key) => {
-							const bucketStats = statsResponse.porCuotasAtrasadas[key];
-							return {
-								estadoMora:
-									bucketStats?.estadoMora ??
-									FALLBACK_ESTADO_MORA_POR_KEY[key] ??
-									"al_dia",
-								totalCases: bucketStats?.cantidad || 0,
-								montoTotal: bucketStats?.sumaMora || "0",
-								sumaCapital: bucketStats?.sumaCapital || "0",
-								porcentaje: bucketStats?.porcentaje || "0",
-							};
-						}),
-						{
-							estadoMora: "completado",
-							totalCases: statsResponse.porEstado.cancelado?.cantidad || 0,
-							montoTotal: statsResponse.porEstado.cancelado?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porEstado.cancelado?.sumaCapital || "0",
-							porcentaje: statsResponse.porEstado.cancelado?.porcentaje || "0",
-						},
-						{
-							estadoMora: "incobrable",
-							totalCases: statsResponse.porEstado.incobrable?.cantidad || 0,
-							montoTotal: statsResponse.porEstado.incobrable?.sumaMora || "0",
-							sumaCapital:
-								statsResponse.porEstado.incobrable?.sumaCapital || "0",
-							porcentaje: statsResponse.porEstado.incobrable?.porcentaje || "0",
-						},
-					]);
+					const bucketsFunnel = cuotasKeys.map((key) => {
+						const bucketStats = statsResponse.porCuotasAtrasadas[key];
+						const fallbackEstado =
+							MORA_BUCKETS.find((b) => b.key === key)?.estadoMora ?? "al_dia";
+						// `estadoMora` de /stats viene del mismo catálogo varchar(24)
+						// editable a mano que valida moraBuckets.ts — se aplica la misma
+						// whitelist aquí (no se persiste, es solo dashboard, pero un valor
+						// fuera del enum no debería llegar al embudo ni al denominador).
+						const estadoMora =
+							bucketStats?.estadoMora &&
+							ESTADOS_MORA_VALIDOS.has(bucketStats.estadoMora)
+								? bucketStats.estadoMora
+								: fallbackEstado;
+						return {
+							estadoMora,
+							totalCases: bucketStats?.cantidad || 0,
+							montoTotal: bucketStats?.sumaMora || "0",
+							sumaCapital: bucketStats?.sumaCapital || "0",
+							porcentaje: bucketStats?.porcentaje || "0",
+						};
+					});
+
+					// Denominador de porcentajes = los estados de aging que realmente
+					// llegaron en este funnel (derivado, no un Set fijo de 6) — sin esto,
+					// un bucket nuevo/renumerado se lista en el array pero su capital
+					// queda fuera del total y nunca recibe porcentaje (ver
+					// cobros-capital-percentages.ts).
+					const activeEstados = new Set(bucketsFunnel.map((b) => b.estadoMora));
+
+					const estatusStats = recalculateCobrosCapitalPercentages(
+						[
+							...bucketsFunnel,
+							{
+								estadoMora: "completado",
+								totalCases: statsResponse.porEstado.cancelado?.cantidad || 0,
+								montoTotal: statsResponse.porEstado.cancelado?.sumaMora || "0",
+								sumaCapital:
+									statsResponse.porEstado.cancelado?.sumaCapital || "0",
+								porcentaje: statsResponse.porEstado.cancelado?.porcentaje || "0",
+							},
+							{
+								estadoMora: "incobrable",
+								totalCases: statsResponse.porEstado.incobrable?.cantidad || 0,
+								montoTotal: statsResponse.porEstado.incobrable?.sumaMora || "0",
+								sumaCapital:
+									statsResponse.porEstado.incobrable?.sumaCapital || "0",
+								porcentaje: statsResponse.porEstado.incobrable?.porcentaje || "0",
+							},
+						],
+						activeEstados,
+					);
 
 					console.log(
 						"[Cobros] Stats obtenidas desde endpoint /stats:",

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -11,6 +11,7 @@ import type {
 	CarteraBackConnectionError,
 	CarteraBackError,
 	CarteraBackValidationError,
+	CarteraBucketCatalogo,
 	CarteraCredito,
 	CarteraInversionista,
 	CarteraPagoCredito,
@@ -926,6 +927,18 @@ export class CarteraBackClient {
 		const response = await this.request<{
 			data: { banco_id: number; nombre: string }[];
 		}>("/bancos", { method: "GET" }, true);
+		return response.data ?? [];
+	}
+
+	// ========================================================================
+	// BUCKETS DE MORA (catálogo dinámico B0-B5)
+	// ========================================================================
+
+	async getBucketsCatalogo(): Promise<CarteraBucketCatalogo[]> {
+		const response = await this.request<{
+			success: boolean;
+			data: CarteraBucketCatalogo[];
+		}>("/config/buckets", { method: "GET" }, true);
 		return response.data ?? [];
 	}
 

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -643,13 +643,18 @@ export interface CarteraStatsBucket {
 	porcentaje: string;
 	sumaCapital: string;
 	sumaMora: string;
+	/** Enriquecido desde el catálogo dinámico `cartera.buckets`. */
+	estadoMora?: string;
+	label?: string;
+	color?: string | null;
+	prefijo?: string;
 }
 
 export interface CarteraStatsResponse {
 	totalCreditos: number;
 	efectividad: string;
 	porCuotasAtrasadas: {
-		[key: string]: CarteraStatsBucket; // "0", "1", "2", "3", "4"+
+		[key: string]: CarteraStatsBucket; // "0".."5" y futuros
 	};
 	porEstado: {
 		cancelado?: CarteraStatsBucket;
@@ -659,6 +664,21 @@ export interface CarteraStatsResponse {
 
 export interface GetStatsParams {
 	email?: string; // Email del asesor para filtrar
+}
+
+/** Fila del catálogo dinámico `cartera.buckets` (B0-B5), expuesta vía GET /config/buckets. */
+export interface CarteraBucketCatalogo {
+	numero: number;
+	prefijo: string;
+	nombre: string;
+	descripcion: string | null;
+	cuotas_min: number;
+	cuotas_max: number | null;
+	estados_incluidos: string[];
+	es_operativo: boolean;
+	orden: number;
+	color: string | null;
+	estado_mora: string | null;
 }
 
 // ============================================================================

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -45,7 +45,6 @@ import { getCobrosColumns } from "@/lib/cobros/columns";
 import { getPaymentDateRangeFilter } from "@/lib/cobros/payment-date-range-filter";
 import { parseFechaLocal } from "@/lib/date-utils";
 import { PERMISSIONS, ROLES } from "@/lib/roles";
-import { labelPorEstadoMora } from "server/src/lib/moraBuckets";
 import { orpc } from "@/utils/orpc";
 
 // Función para calcular días restantes hasta la fecha de próximo pago
@@ -574,7 +573,7 @@ function RouteComponent() {
 	const filtrosEtapa = [
 		{
 			key: "al_dia",
-			label: labelPorEstadoMora("al_dia") ?? "Cartera Sana",
+			label: "Cartera Sana",
 			color: "bg-green-100 text-green-800",
 		},
 		{
@@ -584,27 +583,27 @@ function RouteComponent() {
 		},
 		{
 			key: "mora_30",
-			label: labelPorEstadoMora("mora_30") ?? "Alerta Temprana",
+			label: "Alerta Temprana",
 			color: "bg-yellow-100 text-yellow-800",
 		},
 		{
 			key: "mora_60",
-			label: labelPorEstadoMora("mora_60") ?? "Gestión Activa",
+			label: "Gestión Activa",
 			color: "bg-orange-100 text-orange-800",
 		},
 		{
 			key: "mora_90",
-			label: labelPorEstadoMora("mora_90") ?? "Rescate",
+			label: "Rescate",
 			color: "bg-red-100 text-red-800",
 		},
 		{
 			key: "mora_120",
-			label: labelPorEstadoMora("mora_120") ?? "Última Instancia / Pre Jurídico",
+			label: "Última Instancia / Pre Jurídico",
 			color: "bg-red-200 text-red-900",
 		},
 		{
 			key: "mora_120_plus",
-			label: labelPorEstadoMora("mora_120_plus") ?? "Jurídico",
+			label: "Jurídico",
 			color: "bg-red-300 text-red-900",
 		},
 		{
@@ -773,39 +772,37 @@ function RouteComponent() {
 							[
 								{
 									key: "al_dia",
-									label: labelPorEstadoMora("al_dia") ?? "Cartera Sana",
+									label: "Cartera Sana",
 									color: "bg-green-100 text-green-800",
 									barColor: "#22c55e",
 								},
 								{
 									key: "mora_30",
-									label: labelPorEstadoMora("mora_30") ?? "Alerta Temprana",
+									label: "Alerta Temprana",
 									color: "bg-yellow-100 text-yellow-800",
 									barColor: "#eab308",
 								},
 								{
 									key: "mora_60",
-									label: labelPorEstadoMora("mora_60") ?? "Gestión Activa",
+									label: "Gestión Activa",
 									color: "bg-orange-100 text-orange-800",
 									barColor: "#f97316",
 								},
 								{
 									key: "mora_90",
-									label: labelPorEstadoMora("mora_90") ?? "Rescate",
+									label: "Rescate",
 									color: "bg-red-100 text-red-800",
 									barColor: "#ef4444",
 								},
 								{
 									key: "mora_120",
-									label:
-										labelPorEstadoMora("mora_120") ??
-										"Última Instancia / Pre Jurídico",
+									label: "Última Instancia / Pre Jurídico",
 									color: "bg-red-200 text-red-900",
 									barColor: "#b91c1c",
 								},
 								{
 									key: "mora_120_plus",
-									label: labelPorEstadoMora("mora_120_plus") ?? "Jurídico",
+									label: "Jurídico",
 									color: "bg-red-300 text-red-900",
 									barColor: "#991b1b",
 								},


### PR DESCRIPTION
## Qué hace

Segunda mitad de la consolidación de buckets de mora (ver #1037, ya mergeado): el **CRM** deja de mantener su propio mapeo hardcodeado `numero↔estadoMora` y lo consume del catálogo dinámico `cartera.buckets` vía el endpoint `GET /config/buckets` (expuesto en cartera-back).

### Contexto

`crm/apps/server/src/lib/moraBuckets.ts` tenía el mismo mapeo duplicado que ya eliminamos en cartera-back (`config/moraBuckets.ts`). Con el endpoint ya disponible, este PR hace que el CRM lo consuma en vez de mantener su propia copia — pero como el catálogo es una tabla editable a mano por un admin (no un array de código versionado), este PR le dedica bastante superficie a blindar esa fuente de verdad nueva contra estados inconsistentes, incompletos o corruptos.

### Cambios

**1. `moraBuckets.ts` — de mapeo estático a cache dinámico con múltiples capas de defensa**

El módulo ya no es un array hardcodeado inmutable. La forma final:

- `refreshMoraBucketsCache()` hace fetch a `carteraBackClient.getBucketsCatalogo()` y construye el cache en memoria (`dynamicBucketsCache`) a partir del catálogo, aplicando en orden:
  1. **Filtro por `numero` conocido** — solo se aceptan buckets cuyo `numero` ya existe en el array estático `MORA_BUCKETS` ("0".."5"). Un bucket con `numero` fuera de ese rango (agregado al catálogo sin que el código lo sepa mapear) se descarta entero, sin importar si trae un `estado_mora` válido o no — aceptarlo permitiría que ese bucket huérfano, con un `orden` bajo, gane el first-match de `estadoMoraPorCuotas` sobre el bucket real y reclasifique cualquier crédito en ese rango de cuotas con un estado ajeno.
  2. **Dedup determinístico por `numero`** — si el catálogo trae dos filas con el mismo `numero` (bug de query en cartera-back, o edición manual duplicada), se queda con la de `orden` más bajo de forma explícita, en vez de dejar que la coexistencia de duplicados dependa del orden de iteración implícito.
  3. **Whitelist de `estado_mora` contra el pgEnum del CRM** (`ESTADOS_MORA_VALIDOS`, 9 valores exactos de `casos_cobros.estado_mora`) — el catálogo de cartera-back es `varchar(24)` editable a mano; un valor fuera del enum se reemplaza por el fallback homólogo del bucket conocido en `MORA_BUCKETS`, nunca se propaga sin validar (de lo contrario revienta el INSERT/UPDATE en `sync-casos-cobros.ts` con "invalid input value for enum", silenciosamente — cae al catch por-crédito y el caso simplemente no se sincroniza).
  4. **Guard de cobertura completa** — el catálogo resultante debe cubrir cada uno de los 6 buckets conocidos; si falta alguno (siembra parcial, fila desactivada por error), se descarta el refresh entero y se conserva el cache/fallback previo. Todo-o-nada: nunca se reemplaza el cache con una cobertura parcial de rangos de cuotas.
- `maybeRefreshInBackground()` dispara el refresh de forma perezosa (TTL 5 min) sin bloquear la llamada actual, con **dedup de fetches concurrentes** (`refreshInFlight`): si N filas de una tabla piden refresh en el mismo tick con el cache expirado, se dispara un solo fetch, no N.
- El catch de `refreshMoraBucketsCache()` también actualiza `cachedAt` — sin esto, con cartera-back caído, cada llamada síncrona reintentaría el fetch sin backoff (el TTL solo protege si se respeta también en el camino de error).
- `activeBuckets()` sigue siendo síncrono (`dynamicBucketsCache ?? MORA_BUCKETS`), para no meter latencia por-fila en `estadoMoraPorCuotas`/`rangoCuotasPorEstadoMora`/`labelPorEstadoMora` (se llaman fila por fila en tablas de cobros).
- `__resetMoraBucketsCacheForTests()` — helper exportado solo para tests, dado que el módulo es un singleton con estado global que persiste entre corridas si no se limpia explícitamente.
- 9 tests (`moraBuckets.test.ts`) cubren: fallback cuando el fetch falla, uso del catálogo dinámico tras refrescar, rechazo de `estado_mora` inválido (cae al homólogo), rechazo de catálogo parcial, rechazo de `numero` duplicado, descarte de bucket huérfano con estado inválido, descarte de bucket huérfano con estado válido, y dedup determinístico ante duplicados.

**2. Cliente HTTP + tipos**
- `crm/apps/server/src/services/cartera-back-client.ts` — nuevo método `getBucketsCatalogo()` (`GET /config/buckets`, reutiliza el cache HTTP existente del cliente).
- `crm/apps/server/src/types/cartera-back.ts` — nuevo tipo `CarteraBucketCatalogo` (shape completo del catálogo) + `CarteraStatsBucket` ampliado con `estadoMora`/`label`/`color`/`prefijo` opcionales (matching la respuesta ya ampliada de `/stats` en cartera-back).

**3. Funnel del dashboard de cobros — dinámico, no hardcoded**
- `crm/apps/server/src/routers/cobros.ts` (`getDashboardStats`) — el bloque que armaba el funnel leía 6 literales fijos `porCuotasAtrasadas["0"]`..`["5"]`. Ahora itera `Object.keys(statsResponse.porCuotasAtrasadas)` (ordenadas numéricamente), con fallback por `key` derivado de `MORA_BUCKETS` (no un objeto literal capado a 6) si `estadoMora` no viene enriquecido desde `/stats`.
- `crm/apps/server/src/lib/cobros-capital-percentages.ts` — `recalculateCobrosCapitalPercentages` ahora acepta un segundo parámetro opcional `activeEstados` (default = el mismo Set fijo de 6 estados de siempre, para no romper el otro call-site existente). El path del catálogo dinámico en `cobros.ts` deriva ese Set de los estados realmente presentes en el funnel — antes, un bucket nuevo o renumerado aparecía en el array de stats pero su capital quedaba fuera del denominador y nunca recibía `porcentaje` (el `Set` de estados activos era literal y fijo).
- El `estadoMora` que llega de `/stats` para el funnel también se valida contra `ESTADOS_MORA_VALIDOS` antes de usarse — mismo rigor que en `moraBuckets.ts`, ya que viene de la misma fuente (`varchar(24)` editable a mano).

**4. Frontend — badge de Bucket en la tabla de créditos**
- `carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx` — agrega el badge visual del bucket (prefijo + nombre) en `MobileView` y `DesktopView`; `colSpan` actualizado de 6 a 7 para la columna nueva.
- `carteraFront/src/private/cartera/services/services.ts` — tipo `CreditoBucket` alineado al shape que ya devuelve el backend (ver #1037).
- `crm/apps/web/src/routes/cobros/index.tsx` — se quitó el import cruzado `server/src/lib/moraBuckets` desde el paquete `web` (ese módulo ahora depende de `cartera-back-client`, un servicio server-only con auth/fetch que no debe bundlearse al navegador). Los call-sites de `labelPorEstadoMora("x") ?? "Literal"` se reemplazaron por el literal directo (mismo valor de fallback que ya existía, sin cambio de comportamiento).

## Fuera de alcance (documentado, no bloqueante)

- `moraBuckets.ts` no se refresca activamente al arrancar el server (sin hook en `index.ts`) — decisión explícita: la ventana de cold-start usa `MORA_BUCKETS` (fallback estático), que ya tiene los mismos rangos/labels que el seed real, así que no hay riesgo de dato incorrecto, solo un cache "frío" por unos segundos. Agregar el hook fue evaluado y descartado por no justificar tocar un archivo no relacionado para un caso cosmético y transitorio.
- Agregar un bucket nuevo *real* al catálogo (numero fuera de "0".."5") requiere primero agregar su homólogo a `MORA_BUCKETS` en código — el sistema actual no soporta buckets completamente dinámicos sin ese paso manual. Documentado como limitación conocida, no bug.
- Sin invariante que ate `orden` al rango de cuotas del bucket — el catálogo es editable a mano y nada impide que un admin configure `orden` inconsistente con `cuotas_min`/`cuotas_max` de forma que dos rangos se solapen. Preexistente en el diseño (el array estático original también dependía del orden de declaración); la fuente dinámica lo hace alcanzable por edición humana en vez de fijo en código. Riesgo documentado, no bloqueante — sería un follow-up de validación en cartera-back (CHECK o validación de no-solapamiento entre filas), no algo a resolver en este PR.
- Badge de bucket duplicado entre `MobileView`/`DesktopView` en `CreditsPaymentsData.tsx` (~25 líneas x2) — nit de frontend, no bloqueante; se puede extraer a un componente `<BucketBadge />` en una pasada de limpieza aparte.
- Divergencia entre el conteo de `/stats` (por rango de cuotas puro) y la clasificación por-fila (`bucketDeCredito`, que honra `estados_incluidos`/`STATUS_BUCKET_FUERA`) — preexistente en cartera-back, ya documentada en #1037, no introducida ni tocada por este PR.

## Verificación

- `bun run check-types` (crm: server + web) limpio.
- `bunx tsc --noEmit` (carteraFront) limpio.
- `bun test apps/server/src/lib/moraBuckets.test.ts apps/server/src/lib/cobros-capital-percentages.test.ts` — 9/9 pass.
- Cada guard de `moraBuckets.ts` fue verificado con sanity check manual (revertir temporalmente esa mitad del fix, confirmar que el test correspondiente falla, restaurar el fix) antes de darlo por cerrado.
- Rebase limpio sobre `COBROS-02` post-merge de #1037 (sin conflictos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
