### PR TITLE
feat(cobros): asignación inicial asesor↔bucket — scripts SQL (Fase 2 sandbox)

### DIFF
--- a/apps/cartera-back/drizzle/cobros-02/README.md
+++ b/apps/cartera-back/drizzle/cobros-02/README.md
@@ -18,6 +18,24 @@ para que se sepa que se aplican como bloque cuando salga esa versión.
 | `0002_credito_asesor.sql` | Bitácora de reasignaciones `credito_asesor_historial` + enum `credito_asesor_origen`. **La asignación vive en `creditos.asesor_id`** (no hay tabla de estado): en cartera el asesor del crédito ES el cobrador (el vendedor vive en el CRM). Reasignar (futuro) = `UPDATE creditos SET asesor_id` (solo ese campo) + INSERT en la bitácora. |
 | `0003_buckets_estado_mora.sql` | Agrega `buckets.estado_mora` (puente numero↔estadoMora: al_dia..mora_120_plus) + seed. Retira la duplicación con `config/moraBuckets.ts` (cartera-back) y el mirror en CRM. |
 
+## Asignación inicial (`asignacion/`) — carga de datos, NO schema
+
+Scripts **set-based** (nada de ir crédito por crédito) para poblar el modelo
+una vez aplicadas las migraciones 0000→0003. Pensados para el **sandbox de
+pruebas** (`cartera_cobros2`, copia del schema `cartera` en dev): cada archivo
+abre con `SET LOCAL search_path TO cartera_cobros2;` — cambiar esa línea a
+`cartera` cuando toque el ambiente real. Correr en orden; los 3 son
+idempotentes y revientan (no siguen a medias) si falta un prerequisito.
+
+| Archivo | Qué hace |
+|---|---|
+| `asignacion/01_pool_asesor_bucket.sql` | Crea el asesor de prueba de B1 y puebla el pool `asesor_bucket` por NOMBRE: B0 Caren Rivera · B1 Diego Gomez + Asesor Prueba B1 · B2 Samuel Gamboa · B3 Jorge Sente · B4 Erik Rivas · B5 Gerencia. |
+| `asignacion/02_asignar_asesores_creditos.sql` | Deriva el bucket de cada crédito (mismas reglas del motor: fuera del funnel no se toca; `estados_incluidos` manda; si no, `cuotas_atrasadas` de la mora activa vs rangos del catálogo) y asigna asesor: 1 asesor → directo, N asesores → round-robin determinístico (parejo). Bitácora en `credito_asesor_historial` PRIMERO, luego `UPDATE creditos SET asesor_id` — **únicamente ese campo**. |
+| `asignacion/03_linea_base_historial.sql` | Siembra el evento `INICIAL` en `buckets_historial` (solo créditos sin ningún registro), espejo de lo que haría el motor — así `procesarMoras` no re-siembra y solo registra SUBIDAs/BAJADAs reales. |
+
+Dry-run contra dev (2026-07-08): B0 437 · B1 597 (→ 299/298) · B2 219 ·
+B3 55 · B4 30 · B5 148 · FUERA 142 (no se tocan) — 1,193 créditos cambian de dueño.
+
 ## Decisiones de modelo (revisadas 2026-07-07, panel + confirmación de Daniel)
 
 - **Asignación = `creditos.asesor_id`** (decisión de raíz): los reportes por asesor

--- a/apps/cartera-back/drizzle/cobros-02/asignacion/01_pool_asesor_bucket.sql
+++ b/apps/cartera-back/drizzle/cobros-02/asignacion/01_pool_asesor_bucket.sql
@@ -1,0 +1,76 @@
+-- =====================================================================
+-- COBROS-02 · Asignación inicial — PASO 1/3: pool asesor ↔ bucket
+-- =====================================================================
+-- Corre DESPUÉS de las migraciones 0000→0003 (necesita `buckets` y
+-- `asesor_bucket`). Idempotente: se puede re-correr sin duplicar.
+--
+-- Distribución acordada (2026-07-08, Daniel):
+--   B0 Cartera Sana                  → Caren Rivera
+--   B1 Alerta Temprana               → Diego Gomez + Asesor Prueba B1 (nuevo,
+--                                      para probar bucket con >1 asesor)
+--   B2 Gestión Activa                → Samuel Gamboa
+--   B3 Rescate                       → Jorge Sente
+--   B4 Última Instancia/Pre Jurídico → Erik Rivas
+--   B5 Jurídico                      → Gerencia
+--
+-- El mapeo va POR NOMBRE (no por id) para que sirva igual en el sandbox,
+-- en dev o en prod; si un nombre no existe, el script REVIENTA (no asigna
+-- a medias en silencio).
+-- =====================================================================
+
+BEGIN;
+
+-- ⇦ Sandbox de pruebas. Cambiar a `cartera` cuando toque el ambiente real.
+SET LOCAL search_path TO cartera_cobros2;
+
+-- 1) Asesor nuevo de prueba para B1. activo_para_creditos = false para que
+--    NO entre al balanceo viejo de ORIGINACIÓN (getAsesorConMenorCarga);
+--    el reparto de COBROS lo maneja asesor_bucket, no ese flag.
+INSERT INTO asesores (nombre, activo, activo_para_creditos)
+SELECT 'Asesor Prueba B1', true, false
+WHERE NOT EXISTS (
+  SELECT 1 FROM asesores WHERE nombre = 'Asesor Prueba B1'
+);
+
+-- 2) Guard: todos los nombres del mapeo deben existir antes de armar el pool.
+DO $$
+DECLARE faltan text;
+BEGIN
+  SELECT string_agg(m.nombre, ', ') INTO faltan
+  FROM (VALUES
+    ('Caren Rivera'), ('Diego Gomez'), ('Asesor Prueba B1'),
+    ('Samuel Gamboa'), ('Jorge Sente'), ('Erik Rivas'), ('Gerencia')
+  ) AS m(nombre)
+  LEFT JOIN asesores a ON a.nombre = m.nombre
+  WHERE a.asesor_id IS NULL;
+
+  IF faltan IS NOT NULL THEN
+    RAISE EXCEPTION 'Asesores no encontrados en cartera.asesores: %', faltan;
+  END IF;
+END $$;
+
+-- 3) Pool: elegibilidad asesor↔bucket (NO es la asignación del crédito;
+--    esa vive en creditos.asesor_id y la hace el paso 2).
+INSERT INTO asesor_bucket (asesor_id, bucket)
+SELECT a.asesor_id, m.bucket
+FROM (VALUES
+  ('Caren Rivera',     0),
+  ('Diego Gomez',      1),
+  ('Asesor Prueba B1', 1),
+  ('Samuel Gamboa',    2),
+  ('Jorge Sente',      3),
+  ('Erik Rivas',       4),
+  ('Gerencia',         5)
+) AS m(nombre, bucket)
+JOIN asesores a ON a.nombre = m.nombre
+ON CONFLICT (asesor_id, bucket) DO NOTHING;
+
+-- Resumen: pool resultante
+SELECT ab.bucket, b.prefijo, b.nombre AS bucket_nombre,
+       a.nombre AS asesor, ab.activo
+FROM asesor_bucket ab
+JOIN buckets b  ON b.numero = ab.bucket
+JOIN asesores a ON a.asesor_id = ab.asesor_id
+ORDER BY ab.bucket, a.nombre;
+
+COMMIT;

--- a/apps/cartera-back/drizzle/cobros-02/asignacion/02_asignar_asesores_creditos.sql
+++ b/apps/cartera-back/drizzle/cobros-02/asignacion/02_asignar_asesores_creditos.sql
@@ -1,0 +1,115 @@
+-- =====================================================================
+-- COBROS-02 · Asignación inicial — PASO 2/3: crédito → asesor de su bucket
+-- =====================================================================
+-- Requiere el PASO 1 (pool en asesor_bucket). Todo SET-BASED: se deriva el
+-- bucket de cada crédito con las MISMAS reglas del motor (bucketDeCredito
+-- en latefee.ts) usando la mora activa, y se reparte por bucket:
+--   · bucket con 1 asesor  → asignación directa
+--   · bucket con N asesores → round-robin determinístico (parejo, ordenado
+--     por credito_id, asesores ordenados por asesor_id)
+--
+-- Reglas de derivación (idénticas al motor):
+--   1. statusCredit fuera del funnel (CANCELADO, PENDIENTE_CANCELACION,
+--      EN_CONVENIO, CAIDO) → NO se toca el crédito.
+--   2. statusCredit en buckets.estados_incluidos (INCOBRABLE → B5) manda.
+--   3. Si no, cuotas_atrasadas de la mora ACTIVA contra los rangos del
+--      catálogo (sin mora activa = 0 → B0; cuotas_max NULL = abierto).
+--
+-- ⚠️ DECISIÓN DE RAÍZ: el UPDATE toca ÚNICAMENTE creditos.asesor_id.
+--    Nada más del crédito se modifica. Bitácora SIEMPRE (append-only).
+-- Idempotente: re-correrlo con la misma data no duplica bitácora ni
+-- re-actualiza (el round-robin es determinístico y los no-cambios se filtran).
+-- =====================================================================
+
+BEGIN;
+
+-- ⇦ Sandbox de pruebas. Cambiar a `cartera` cuando toque el ambiente real.
+SET LOCAL search_path TO cartera_cobros2;
+
+-- 1) Derivar bucket por crédito (misma derivación que 03_linea_base).
+CREATE TEMP TABLE tmp_bucket ON COMMIT DROP AS
+SELECT
+  c.credito_id,
+  c.asesor_id AS asesor_actual,
+  COALESCE(
+    -- prioridad 1: estados incluidos explícitos del catálogo (INCOBRABLE → B5)
+    (SELECT b.numero FROM buckets b
+      WHERE b.activo AND c."statusCredit" = ANY (b.estados_incluidos)
+      ORDER BY b.numero LIMIT 1),
+    -- prioridad 2: rango de cuotas atrasadas del catálogo
+    (SELECT b.numero FROM buckets b
+      WHERE b.activo
+        AND COALESCE(m.cuotas_atrasadas, 0) >= b.cuotas_min
+        AND (b.cuotas_max IS NULL OR COALESCE(m.cuotas_atrasadas, 0) <= b.cuotas_max)
+      ORDER BY b.numero LIMIT 1)
+  ) AS bucket
+FROM creditos c
+LEFT JOIN moras_credito m ON m.credito_id = c.credito_id AND m.activa = true
+WHERE c."statusCredit" NOT IN
+  ('CANCELADO', 'PENDIENTE_CANCELACION', 'EN_CONVENIO', 'CAIDO');
+
+-- 2) Guard: ningún bucket con créditos puede quedarse sin asesores en el pool
+--    (mejor reventar que dejar créditos sin dueño en silencio).
+DO $$
+DECLARE sin_pool text;
+BEGIN
+  SELECT string_agg(DISTINCT t.bucket::text, ', ') INTO sin_pool
+  FROM tmp_bucket t
+  WHERE t.bucket IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM asesor_bucket ab
+      WHERE ab.activo AND ab.bucket = t.bucket
+    );
+
+  IF sin_pool IS NOT NULL THEN
+    RAISE EXCEPTION 'Buckets con créditos pero sin asesor en el pool: % — correr 01_pool_asesor_bucket.sql primero', sin_pool;
+  END IF;
+END $$;
+
+-- 3) Repartir: round-robin sobre el pool del bucket (con 1 asesor queda
+--    directo; con N queda parejo).
+CREATE TEMP TABLE tmp_asignacion ON COMMIT DROP AS
+SELECT
+  t.credito_id,
+  t.asesor_actual,
+  t.bucket,
+  p.asesores[1 + ((row_number() OVER (PARTITION BY t.bucket ORDER BY t.credito_id) - 1)
+                  % array_length(p.asesores, 1))::int] AS asesor_nuevo
+FROM tmp_bucket t
+JOIN (
+  SELECT bucket, array_agg(asesor_id ORDER BY asesor_id) AS asesores
+  FROM asesor_bucket WHERE activo
+  GROUP BY bucket
+) p ON p.bucket = t.bucket
+WHERE t.bucket IS NOT NULL;
+
+-- 4) Bitácora PRIMERO (captura el asesor_anterior antes del UPDATE).
+--    usuario_id NULL: es una carga masiva por script, no un supervisor.
+INSERT INTO credito_asesor_historial
+  (credito_id, asesor_anterior, asesor_nuevo, bucket, origen, motivo)
+SELECT credito_id, asesor_actual, asesor_nuevo, bucket, 'API_MANUAL',
+       'Asignación inicial por bucket — carga COBROS-02 (SQL)'
+FROM tmp_asignacion
+WHERE asesor_actual IS DISTINCT FROM asesor_nuevo;
+
+-- 5) UPDATE: ÚNICAMENTE asesor_id (decisión de raíz — nada más del crédito).
+UPDATE creditos c
+SET asesor_id = t.asesor_nuevo
+FROM tmp_asignacion t
+WHERE c.credito_id = t.credito_id
+  AND c.asesor_id IS DISTINCT FROM t.asesor_nuevo;
+
+-- Resumen: distribución final por bucket y asesor (B1 debe quedar ~50/50)
+SELECT t.bucket, b.prefijo, a.nombre AS asesor, count(*) AS creditos
+FROM tmp_asignacion t
+JOIN buckets b  ON b.numero = t.bucket
+JOIN asesores a ON a.asesor_id = t.asesor_nuevo
+GROUP BY t.bucket, b.prefijo, a.nombre
+ORDER BY t.bucket, a.nombre;
+
+-- Resumen: cuántos créditos cambiaron de dueño
+SELECT count(*) AS reasignados
+FROM tmp_asignacion
+WHERE asesor_actual IS DISTINCT FROM asesor_nuevo;
+
+COMMIT;

--- a/apps/cartera-back/drizzle/cobros-02/asignacion/03_linea_base_historial.sql
+++ b/apps/cartera-back/drizzle/cobros-02/asignacion/03_linea_base_historial.sql
@@ -1,0 +1,66 @@
+-- =====================================================================
+-- COBROS-02 · Asignación inicial — PASO 3/3: línea base en buckets_historial
+-- =====================================================================
+-- Siembra el evento INICIAL (1 por crédito) para los créditos que aún no
+-- tienen NINGÚN registro en buckets_historial, con el bucket derivado con
+-- las mismas reglas del motor (idéntico al PASO 2). Así el historial del
+-- sandbox tiene línea base sin necesidad de correr la app, y cuando el
+-- motor (procesarMoras) corra después, ya no re-siembra: solo registrará
+-- SUBIDAs/BAJADAs reales.
+--
+-- Campos, espejo de lo que insertaría el motor:
+--   · bucket_anterior NULL + tipo_evento INICIAL (el CHECK de coherencia lo exige)
+--   · asesor_id NULL: la atribución es para BAJADAs (quién curó la cuenta);
+--     el dueño del crédito se ve por creditos.asesor_id / su bitácora.
+--   · origen API_MANUAL: lo sembró este script, no el job.
+-- Idempotente: el NOT EXISTS (y el unique parcial buckets_historial_uq_inicial)
+-- impiden duplicar.
+-- =====================================================================
+
+BEGIN;
+
+-- ⇦ Sandbox de pruebas. Cambiar a `cartera` cuando toque el ambiente real.
+SET LOCAL search_path TO cartera_cobros2;
+
+INSERT INTO buckets_historial
+  (credito_id, bucket_nuevo, tipo_evento, origen,
+   cuotas_atrasadas_nuevas, status_credito, motivo)
+SELECT
+  d.credito_id, d.bucket, 'INICIAL', 'API_MANUAL',
+  d.cuotas, d.status,
+  'Línea base — carga inicial COBROS-02 (SQL, previo al primer procesarMoras)'
+FROM (
+  -- misma derivación que 02_asignar_asesores_creditos.sql
+  SELECT
+    c.credito_id,
+    c."statusCredit" AS status,
+    COALESCE(m.cuotas_atrasadas, 0) AS cuotas,
+    COALESCE(
+      (SELECT b.numero FROM buckets b
+        WHERE b.activo AND c."statusCredit" = ANY (b.estados_incluidos)
+        ORDER BY b.numero LIMIT 1),
+      (SELECT b.numero FROM buckets b
+        WHERE b.activo
+          AND COALESCE(m.cuotas_atrasadas, 0) >= b.cuotas_min
+          AND (b.cuotas_max IS NULL OR COALESCE(m.cuotas_atrasadas, 0) <= b.cuotas_max)
+        ORDER BY b.numero LIMIT 1)
+    ) AS bucket
+  FROM creditos c
+  LEFT JOIN moras_credito m ON m.credito_id = c.credito_id AND m.activa = true
+  WHERE c."statusCredit" NOT IN
+    ('CANCELADO', 'PENDIENTE_CANCELACION', 'EN_CONVENIO', 'CAIDO')
+) d
+WHERE d.bucket IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM buckets_historial h WHERE h.credito_id = d.credito_id
+  );
+
+-- Resumen: línea base por bucket
+SELECT h.bucket_nuevo, b.prefijo, count(*) AS creditos
+FROM buckets_historial h
+JOIN buckets b ON b.numero = h.bucket_nuevo
+WHERE h.tipo_evento = 'INICIAL'
+GROUP BY h.bucket_nuevo, b.prefijo
+ORDER BY h.bucket_nuevo;
+
+COMMIT;


### PR DESCRIPTION
## Qué es

Los scripts de **carga inicial** del modelo de asignación (Fase 2 del plan de pruebas): poblar el pool asesor↔bucket, asignar cada crédito al asesor de su bucket y dejar la línea base en los dos historiales. Corren **después** de las migraciones `0000→0003`, sobre el **sandbox `cartera_cobros2`** (copia del schema `cartera` en dev — Fase 1, la arma otro compañero).

Todo **set-based** (WHEREs sobre `cuotas_atrasadas`, nada de ir crédito por crédito), **idempotente** (re-correr no duplica) y con guards que **revientan** en vez de asignar a medias (nombre de asesor inexistente, bucket con créditos pero sin pool).

## Los 3 scripts (`drizzle/cobros-02/asignacion/`, correr en orden)

| Script | Qué hace |
|---|---|
| `01_pool_asesor_bucket.sql` | Crea el asesor de prueba de B1 (`activo_para_creditos=false`, no entra al balanceo viejo de originación) y puebla `asesor_bucket` **por nombre**: B0 Caren Rivera · B1 Diego Gomez + Asesor Prueba B1 · B2 Samuel Gamboa · B3 Jorge Sente · B4 Erik Rivas · B5 Gerencia. |
| `02_asignar_asesores_creditos.sql` | Deriva el bucket de cada crédito con las **mismas reglas del motor** (fuera del funnel no se toca; `estados_incluidos` manda → INCOBRABLE a B5; si no, cuotas de la mora activa vs rangos del catálogo) y asigna: **1 asesor = directo, N = round-robin determinístico** (parejo). Bitácora `credito_asesor_historial` PRIMERO, luego `UPDATE creditos SET asesor_id` — **únicamente ese campo** (decisión de raíz). |
| `03_linea_base_historial.sql` | Siembra el evento `INICIAL` en `buckets_historial` (solo créditos sin ningún registro), espejo de lo que haría el motor → `procesarMoras` ya no re-siembra, solo registra SUBIDAs/BAJADAs reales. |

Cada archivo abre con `SET LOCAL search_path TO cartera_cobros2;` — para el ambiente real solo se cambia esa línea a `cartera`.

## Dry-run contra dev (solo lectura, 2026-07-08)

| Bucket | Asesor | Créditos |
|---|---|---|
| B0 | Caren Rivera | 437 |
| B1 | Diego Gomez / Asesor Prueba B1 | **299 / 298** (reparto parejo) |
| B2 | Samuel Gamboa | 219 |
| B3 | Jorge Sente | 55 |
| B4 | Erik Rivas | 30 |
| B5 | Gerencia | 148 = 103 por >=5 cuotas + **45 INCOBRABLES** (todos con cuotas=0 — sin la regla de `estados_incluidos` caerían a B0) |
| FUERA | no se tocan | 142 (50 EN_CONVENIO, 42 CANCELADO, 28 CAIDO, 22 PENDIENTE_CANCELACION) |

**1,193 créditos cambian de dueño** en la primera corrida. B1 con 2 asesores es la prueba viva del bucket multi-asesor.

## Siguiente (no en este PR)

**Fase 3** — lógica de asignación en el motor: al cambiar de bucket → directo (1 asesor) o equitativo por carga (N), `UPDATE` solo de `asesor_id` + bitácora `PROCESO_AUTO`.

Modelo visual: https://claude.ai/code/artifact/b4f20ce1-1a4c-40d4-8300-7c89df056e37

🤖 Generated with [Claude Code](https://claude.com/claude-code)