### PR TITLE
feat(cobros): Fase 3 — reasignación automática de asesor por bucket + listado por bucket

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -39,7 +39,7 @@ import {
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
-import { bucketDeCredito, BucketCatalogo, getBucketsCatalogo } from "./latefee";
+import { bucketDeCredito, BucketCatalogo, getBucketsCatalogo, STATUS_BUCKET_FUERA } from "./latefee";
 
 // Fallback B0-B5 — usado si el catálogo dinámico `cartera.buckets` no
 // responde (DB caída, migración pendiente). Incluye `estados_incluidos` en B5
@@ -653,7 +653,10 @@ export async function getCreditosWithUserByMesAnio(
   // `cuotas_atrasadas` (que sólo hacía `= N`). Si se envían, tienen prioridad.
   // `cuotas_max` undefined = sin tope (>= cuotas_min).
   cuotas_min?: number,
-  cuotas_max?: number
+  cuotas_max?: number,
+  // 🪣 COBROS-02: filtro por BUCKET derivado (números del catálogo, ej. [1] o
+  // [4,5]). Usa las MISMAS reglas que la columna `bucket` de esta respuesta.
+  buckets_numeros?: number[]
 ): Promise<{
   data: CreditoConInfo[];
   page: number;
@@ -853,6 +856,41 @@ export async function getCreditosWithUserByMesAnio(
 
   if (aseguradora_id !== undefined) {
     conditions.push(eq(creditos.aseguradora_id, aseguradora_id));
+  }
+
+  // 🪣 COBROS-02: filtro por BUCKET (B0-B5) derivado con las MISMAS reglas que
+  // la columna `bucket` de esta respuesta (bucketDeCredito): fuera del funnel
+  // queda excluido SIEMPRE; un estado en `buckets.estados_incluidos` fuerza su
+  // bucket (INCOBRABLE→B5, aunque su mora esté apagada) con prioridad sobre el
+  // rango de cuotas de la mora ACTIVA; sin mora activa cuenta 0 cuotas (B0).
+  // Así lo que se filtra es exactamente lo que se muestra.
+  if (buckets_numeros && buckets_numeros.length > 0) {
+    console.log(`🔎 Filtrando por bucket(s): ${buckets_numeros.join(", ")}`);
+    const numerosSql = sql.join(buckets_numeros.map((n) => sql`${n}`), sql`, `);
+    const fueraSql = sql.join(STATUS_BUCKET_FUERA.map((s) => sql`${s}`), sql`, `);
+    conditions.push(sql`${creditos.statusCredit} NOT IN (${fueraSql})`);
+    conditions.push(sql`(
+      EXISTS (
+        SELECT 1 FROM cartera.buckets b
+         WHERE b.activo = true
+           AND ${creditos.statusCredit} = ANY (b.estados_incluidos)
+           AND b.numero IN (${numerosSql})
+      )
+      OR (
+        NOT EXISTS (
+          SELECT 1 FROM cartera.buckets b
+           WHERE b.activo = true
+             AND ${creditos.statusCredit} = ANY (b.estados_incluidos)
+        )
+        AND EXISTS (
+          SELECT 1 FROM cartera.buckets b
+           WHERE b.activo = true
+             AND b.numero IN (${numerosSql})
+             AND COALESCE(${moras_credito.cuotas_atrasadas}, 0) >= b.cuotas_min
+             AND (b.cuotas_max IS NULL OR COALESCE(${moras_credito.cuotas_atrasadas}, 0) <= b.cuotas_max)
+        )
+      )
+    )`);
   }
 
   const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;

--- a/apps/cartera-back/src/controllers/latefee.test.ts
+++ b/apps/cartera-back/src/controllers/latefee.test.ts
@@ -2,9 +2,10 @@ import { describe, expect, it, mock } from "bun:test";
 
 mock.module("../database", () => ({
   db: {},
+  client: {},
 }));
 
-const { isOverdueInstallmentForMora } = await import("./latefee");
+const { isOverdueInstallmentForMora, elegirAsesorParaBucket } = await import("./latefee");
 
 describe("isOverdueInstallmentForMora", () => {
   it("no cuenta como vencida una cuota con pago asociado ya pagado", () => {
@@ -47,5 +48,50 @@ describe("isOverdueInstallmentForMora", () => {
     );
 
     expect(result).toBe(false);
+  });
+});
+
+// FASE 3 (COBROS-02) — reparto de asesor al entrar a un bucket
+describe("elegirAsesorParaBucket", () => {
+  it("pool vacío → null (el crédito conserva su asesor)", () => {
+    expect(elegirAsesorParaBucket([], new Map(), 7)).toBeNull();
+  });
+
+  it("bucket con 1 solo asesor → asignación directa", () => {
+    expect(elegirAsesorParaBucket([4], new Map(), 7)).toBe(4);
+  });
+
+  it("el asesor actual ya es elegible en el destino → se queda (sin churn)", () => {
+    const carga = new Map([
+      [3, 50],
+      [9, 0],
+    ]);
+    // aunque el 9 tenga menos carga, el 3 ya lleva el crédito y es elegible
+    expect(elegirAsesorParaBucket([3, 9], carga, 3)).toBe(3);
+  });
+
+  it("N asesores → gana el de MENOR carga (equitativo)", () => {
+    const carga = new Map([
+      [3, 10],
+      [9, 4],
+    ]);
+    expect(elegirAsesorParaBucket([3, 9], carga, 7)).toBe(9);
+  });
+
+  it("empate de carga → gana el menor asesor_id (determinístico)", () => {
+    const carga = new Map([
+      [9, 5],
+      [3, 5],
+    ]);
+    expect(elegirAsesorParaBucket([9, 3], carga, 7)).toBe(3);
+  });
+
+  it("sin mapa de carga → todos cuentan 0 y gana el menor asesor_id", () => {
+    expect(elegirAsesorParaBucket([9, 3], undefined, null)).toBe(3);
+  });
+
+  it("asesor sin entrada en el mapa de carga cuenta como 0", () => {
+    const carga = new Map([[3, 2]]); // el 9 no aparece → carga 0
+    expect(elegirAsesorParaBucket([3, 9], carga, null)).toBe(9);
   });
 });

--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { client, db } from "../database";
-import { asesores, buckets, buckets_historial, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, pagos_credito, platform_users, usuarios } from "../database/db/schema";
+import { asesor_bucket, asesores, buckets, buckets_historial, credito_asesor_historial, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, pagos_credito, platform_users, usuarios } from "../database/db/schema";
 import Big from "big.js";
 import { toZonedTime } from "date-fns-tz";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
@@ -150,6 +150,33 @@ export function bucketDeCredito(
     (b) => cuotas >= b.cuotas_min && (b.cuotas_max == null || cuotas <= b.cuotas_max),
   );
   return porRango ? porRango.numero : null;
+}
+
+/**
+ * FASE 3 — elige el asesor para un crédito que ENTRA a un bucket:
+ *  · pool vacío → null (no hay elegibles; el crédito conserva su asesor)
+ *  · el asesor actual ya es elegible en el bucket destino → se queda (sin churn)
+ *  · si no → el elegible con MENOR carga en ese bucket (asignación equitativa
+ *    cuando hay N asesores; con 1 solo, queda directa); empate → menor asesor_id.
+ * Pura a propósito (sin DB) para poder testearla aislada.
+ */
+export function elegirAsesorParaBucket(
+  pool: number[],
+  cargaBucket: Map<number, number> | undefined,
+  asesorActual: number | null,
+): number | null {
+  if (pool.length === 0) return null;
+  if (asesorActual !== null && pool.includes(asesorActual)) return asesorActual;
+  let elegido: number | null = null;
+  let menorCarga = Infinity;
+  for (const asesorId of pool) {
+    const carga = cargaBucket?.get(asesorId) ?? 0;
+    if (carga < menorCarga || (carga === menorCarga && elegido !== null && asesorId < elegido)) {
+      menorCarga = carga;
+      elegido = asesorId;
+    }
+  }
+  return elegido;
 }
 
 /**
@@ -738,6 +765,7 @@ export async function procesarMoras() {
         pagado: cuotas_credito.pagado,
         statusCredit: creditos.statusCredit,
         capital: creditos.capital,
+        asesor_id: creditos.asesor_id, // FASE 3: dueño actual (para reasignar por bucket)
         hasPaidPayment: sql<boolean>`EXISTS (
           SELECT 1
           FROM cartera.pagos_credito pc
@@ -982,6 +1010,14 @@ export async function procesarMoras() {
     // Paso ADITIVO: no toca el cálculo de mora. Detecta cambios de bucket
     // (derivado de estado + cuotas) y los registra en `buckets_historial`.
     // Si algo falla aquí, NO debe romper el proceso de mora (operación crítica).
+    // Se devuelve en el resultado del job (útil para pruebas vía POST /moras/procesar).
+    const bucketsResumen = {
+      iniciales: 0,
+      subidas: 0,
+      bajadas: 0,
+      reasignados: 0,
+      sinPoolDestino: 0,
+    };
     try {
       // Catálogo de buckets (config dinámica: nombres/rangos/estados). ~6 filas.
       const catalogoBuckets: BucketCatalogo[] = await db
@@ -1000,11 +1036,13 @@ export async function procesarMoras() {
           "[BUCKETS] ⚠️ Catálogo `cartera.buckets` vacío (¿migración/seed sin aplicar?) — se omite el registro de transiciones.",
         );
       } else {
-      // status por crédito — ya viene en `cuotas` (el job lo cargó con JOIN)
+      // status y asesor por crédito — ya vienen en `cuotas` (el job los cargó con JOIN)
       const statusPorCredito = new Map<number, string>();
+      const asesorPorCredito = new Map<number, number>();
       for (const c of cuotas) {
         if (!statusPorCredito.has(c.credito_id)) {
           statusPorCredito.set(c.credito_id, c.statusCredit);
+          asesorPorCredito.set(c.credito_id, c.asesor_id);
         }
       }
 
@@ -1019,8 +1057,48 @@ export async function procesarMoras() {
         ultimoBucket.set(Number(row.credito_id), Number(row.bucket_nuevo));
       }
 
+      // 🎯 FASE 3 — pool de elegibles por bucket (asesor_bucket). Si está vacío
+      // (script 01 sin correr en este ambiente), el motor sigue registrando
+      // transiciones pero NO reasigna: cada crédito conserva su asesor.
+      const poolPorBucket = new Map<number, number[]>();
+      const poolRows = await db
+        .select({ asesor_id: asesor_bucket.asesor_id, bucket: asesor_bucket.bucket })
+        .from(asesor_bucket)
+        .where(eq(asesor_bucket.activo, true))
+        .orderBy(asesor_bucket.bucket, asesor_bucket.asesor_id);
+      for (const r of poolRows) {
+        const lista = poolPorBucket.get(r.bucket) ?? [];
+        lista.push(r.asesor_id);
+        poolPorBucket.set(r.bucket, lista);
+      }
+
+      // Carga = créditos que cada asesor del pool lleva HOY en cada bucket
+      // (según el último bucket registrado). Se mantiene VIVA durante el loop
+      // para que varias transiciones al mismo bucket en una misma corrida se
+      // repartan parejo entre N asesores (asignación equitativa).
+      const cargaPorBucket = new Map<number, Map<number, number>>();
+      const ajustarCarga = (
+        bucket: number | undefined,
+        asesor: number | null | undefined,
+        delta: number,
+      ) => {
+        if (bucket === undefined || asesor == null) return;
+        if (!poolPorBucket.get(bucket)?.includes(asesor)) return; // solo cuenta el pool
+        let porAsesor = cargaPorBucket.get(bucket);
+        if (!porAsesor) {
+          porAsesor = new Map();
+          cargaPorBucket.set(bucket, porAsesor);
+        }
+        porAsesor.set(asesor, Math.max(0, (porAsesor.get(asesor) ?? 0) + delta));
+      };
+      for (const [creditoId] of statusPorCredito) {
+        ajustarCarga(ultimoBucket.get(creditoId), asesorPorCredito.get(creditoId), 1);
+      }
+
       let bucketsSubidas = 0;
       let bucketsBajadas = 0;
+      let bucketsReasignados = 0;
+      let bucketsSinPoolDestino = 0;
       // Las líneas base se acumulan y se insertan en LOTE al final (la 1a
       // corrida siembra ~todos los créditos del funnel: fila por fila serían
       // miles de INSERTs secuenciales dentro del job).
@@ -1047,6 +1125,9 @@ export async function procesarMoras() {
             motivo: "Línea base — primer registro en el motor de buckets",
           });
           ultimoBucket.set(creditoId, bucketNuevo);
+          // La línea base NO reasigna (eso lo hace la carga inicial SQL);
+          // solo se registra la carga para que el reparto posterior sea justo.
+          ajustarCarga(bucketNuevo, asesorPorCredito.get(creditoId), 1);
           continue;
         }
 
@@ -1091,6 +1172,43 @@ export async function procesarMoras() {
           pago_id: pagoId,
         });
 
+        // 🎯 FASE 3 — reasignación automática: el crédito cambió de bucket →
+        // si su asesor actual NO es elegible en el destino, pasa al elegible
+        // con menor carga (1 asesor = directo; N = equitativo). El UPDATE toca
+        // ÚNICAMENTE creditos.asesor_id (decisión de raíz) + bitácora
+        // OBLIGATORIA en credito_asesor_historial, ambos en una transacción.
+        const asesorActual = asesorPorCredito.get(creditoId) ?? null;
+        const asesorElegido = elegirAsesorParaBucket(
+          poolPorBucket.get(bucketNuevo) ?? [],
+          cargaPorBucket.get(bucketNuevo),
+          asesorActual,
+        );
+        if (asesorElegido !== null && asesorElegido !== asesorActual) {
+          await db.transaction(async (tx) => {
+            await tx.insert(credito_asesor_historial).values({
+              credito_id: creditoId,
+              asesor_anterior: asesorActual,
+              asesor_nuevo: asesorElegido,
+              bucket: bucketNuevo,
+              origen: "PROCESO_AUTO",
+              motivo: `Reasignación automática por cambio de bucket B${bucketAnterior}→B${bucketNuevo}`,
+              usuario_id: null,
+            });
+            await tx
+              .update(creditos)
+              .set({ asesor_id: asesorElegido })
+              .where(eq(creditos.credito_id, creditoId));
+          });
+          asesorPorCredito.set(creditoId, asesorElegido);
+          bucketsReasignados++;
+        } else if (asesorElegido === null) {
+          bucketsSinPoolDestino++;
+        }
+        // Carga: el crédito sale del bucket anterior y entra al nuevo con su
+        // asesor final (el elegido, o el actual si se quedó).
+        ajustarCarga(bucketAnterior, asesorActual, -1);
+        ajustarCarga(bucketNuevo, asesorPorCredito.get(creditoId), 1);
+
         ultimoBucket.set(creditoId, bucketNuevo);
         if (esSubida) bucketsSubidas++;
         else bucketsBajadas++;
@@ -1107,8 +1225,14 @@ export async function procesarMoras() {
           .onConflictDoNothing();
       }
 
+      bucketsResumen.iniciales = filasIniciales.length;
+      bucketsResumen.subidas = bucketsSubidas;
+      bucketsResumen.bajadas = bucketsBajadas;
+      bucketsResumen.reasignados = bucketsReasignados;
+      bucketsResumen.sinPoolDestino = bucketsSinPoolDestino;
+
       console.log(
-        `[BUCKETS] Registros — iniciales: ${filasIniciales.length}, subidas: ${bucketsSubidas}, bajadas: ${bucketsBajadas}`,
+        `[BUCKETS] Registros — iniciales: ${filasIniciales.length}, subidas: ${bucketsSubidas}, bajadas: ${bucketsBajadas}, reasignados: ${bucketsReasignados}${bucketsSinPoolDestino > 0 ? ` ⚠️ sin pool destino: ${bucketsSinPoolDestino}` : ""}`,
       );
       } // fin else (catálogo no vacío)
     } catch (bucketErr) {
@@ -1127,7 +1251,7 @@ export async function procesarMoras() {
     console.log(`║   Sin capital (omitidas): ${sinCapital}`);
     console.log("╚════════════════════════════════════════════════════════════\n");
 
-    return { creadas, recalculadas, sinCambios, desactivadas, sinCapital };
+    return { creadas, recalculadas, sinCambios, desactivadas, sinCapital, buckets: bucketsResumen };
 
   } catch (error: any) {
     console.error("\n╔════════════════════════════════════════════════════════════");

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -1,10 +1,23 @@
-// routes/buckets.ts — COBROS-02 · endpoints del motor de buckets (histórico).
+// routes/buckets.ts — COBROS-02 · endpoints del motor de buckets (histórico + listado).
 import { Elysia, t } from "elysia";
 import { authMiddleware } from "./midleware";
 import {
   getBucketsHistorial,
   getBucketsHistorialCredito,
 } from "../controllers/buckets/bucketsHistorial";
+import { getCreditosWithUserByMesAnio } from "../controllers/credits";
+import { StatusCredit } from "../database/db/schema";
+
+// Estados DENTRO del funnel operativo (= enum de statusCredit menos
+// STATUS_BUCKET_FUERA): ACTIVO/MOROSO clasifican por cuotas de la mora activa;
+// INCOBRABLE entra a B5 vía `buckets.estados_incluidos`. Se pasa como
+// whitelist al listado para que "sin filtro de bucket" = todo el funnel
+// (nunca CANCELADO/PENDIENTE_CANCELACION/EN_CONVENIO/CAIDO).
+const STATUS_FUNNEL: StatusCredit[] = [
+  StatusCredit.ACTIVO,
+  StatusCredit.MOROSO,
+  StatusCredit.INCOBRABLE,
+];
 
 // Gate de rol server-side: el histórico expone data de TODOS los créditos
 // (igual criterio que el historial de mora). authMiddleware solo autentica.
@@ -142,6 +155,113 @@ export const bucketsRouter = new Elysia()
         pago_id: t.Optional(t.String()),
         page: t.Optional(t.String()),
         pageSize: t.Optional(t.String()),
+      }),
+    },
+  )
+
+  // Listado de créditos POR BUCKET — gemelo de /getAllCredits (misma data por
+  // crédito, misma paginación) pero el eje es el bucket derivado (B0-B5) en
+  // vez de las cuotas atrasadas crudas. Cubre lo que el aging por cuotas no
+  // puede: INCOBRABLE cae en B5 aunque su mora esté apagada, y los estados
+  // fuera del funnel quedan excluidos siempre.
+  .get(
+    "/buckets/creditos",
+    async ({ query, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        // bucket: CSV de números del catálogo (ej. "1" o "4,5"). Sin él =
+        // todo el funnel. Tokens inválidos → 400 (no descartar en silencio).
+        if (csvInvalido(query.bucket, esBucket)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] bucket inválido (CSV de enteros, ej. 0,1,5)" };
+        }
+        const bucketsNumeros = query.bucket
+          ? [...new Set(
+              String(query.bucket)
+                .split(",")
+                .map((s: string) => Number(s.trim()))
+                .filter((n: number) => Number.isInteger(n)),
+            )]
+          : undefined;
+
+        // mes/anio de creación: opcionales, van JUNTOS (0/0 = sin filtro,
+        // igual que /getAllCredits). Validar antes de castear.
+        const mes = query.mes !== undefined ? Number(query.mes) : 0;
+        const anio = query.anio !== undefined ? Number(query.anio) : 0;
+        if (!Number.isInteger(mes) || mes < 0 || mes > 12) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] mes inválido (1-12)" };
+        }
+        if (!Number.isInteger(anio) || anio < 0) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] anio inválido" };
+        }
+        if ((mes === 0) !== (anio === 0)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] mes y anio van juntos (ambos o ninguno)" };
+        }
+
+        const asesorId = query.asesor_id ? Number(query.asesor_id) : undefined;
+        if (asesorId !== undefined && (!Number.isInteger(asesorId) || asesorId <= 0)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] asesor_id inválido" };
+        }
+
+        // Paginación: floor ANTES de clamp (page=0.5 → 1, no OFFSET negativo).
+        const pageFloor = Math.floor(Number(query.page ?? 1));
+        const page = Number.isFinite(pageFloor) && pageFloor > 0 ? pageFloor : 1;
+        const perPageFloor = Math.floor(Number(query.perPage ?? 10));
+        const perPage =
+          Number.isFinite(perPageFloor) && perPageFloor > 0
+            ? Math.min(perPageFloor, 500)
+            : 10;
+
+        const result = await getCreditosWithUserByMesAnio(
+          mes,
+          anio,
+          page,
+          perPage,
+          query.numero_credito_sifco?.trim() || undefined,
+          undefined, // estado: el bucket ya encapsula el estado
+          asesorId,
+          query.nombre_usuario,
+          query.email_asesor,
+          undefined, // cuotas_atrasadas (escalar viejo): aquí el eje es el bucket
+          undefined, // proximidad_pago
+          undefined, // is_vehiculo_propio
+          undefined, // inversionista_ids
+          undefined, // fecha_desde
+          undefined, // fecha_hasta
+          undefined, // numeros_credito_sifco
+          undefined, // capital_min
+          undefined, // capital_max
+          STATUS_FUNNEL, // solo créditos del funnel (B0-B5)
+          undefined, // aseguradora_id
+          undefined, // cuotas_min
+          undefined, // cuotas_max
+          bucketsNumeros,
+        );
+        return { success: true, ...result };
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener los créditos por bucket",
+          error: String(err),
+        };
+      }
+    },
+    {
+      query: t.Object({
+        bucket: t.Optional(t.String()),
+        mes: t.Optional(t.String()),
+        anio: t.Optional(t.String()),
+        numero_credito_sifco: t.Optional(t.String()),
+        nombre_usuario: t.Optional(t.String()),
+        asesor_id: t.Optional(t.String()),
+        email_asesor: t.Optional(t.String()),
+        page: t.Optional(t.String()),
+        perPage: t.Optional(t.String()),
       }),
     },
   )


### PR DESCRIPTION
## Qué es

La **Fase 3** del motor de buckets: cuando un crédito **cambia de bucket, cambia de asesor solo** — y el endpoint gemelo de `/getAllCredits` pero con eje en el bucket. Con esto **ya se puede correr el flujo completo de pruebas** en el sandbox (ver plan abajo).

## 1) Reasignación automática (motor, `latefee.ts`)

En cada SUBIDA/BAJADA que registra `procesarMoras`:

- **1 asesor elegible en el bucket destino → directa** · **N elegibles → equitativa** (el de menor carga en ese bucket; la carga se actualiza en vivo durante la corrida para que varias entradas al mismo bucket queden parejas; empate → menor `asesor_id`).
- Si el asesor actual **ya es elegible** en el destino → se queda (sin rebotes).
- Pool sin poblar (script `asignacion/01` sin correr) → solo se registra la transición, nadie pierde su asesor (contador `sinPoolDestino`).
- El par va en **una transacción**: INSERT en `credito_asesor_historial` (origen `PROCESO_AUTO`, motivo con la transición Bx→By) + `UPDATE creditos SET asesor_id` — **únicamente ese campo** (decisión de raíz).
- El evento `INICIAL` NO reasigna (la asignación inicial es de los scripts SQL de #1042).

Helper puro `elegirAsesorParaBucket()` con **7 tests unitarios** (`bun test`: 10/10).

## 2) `GET /buckets/creditos` — el getAllCredits por bucket

`getCreditosWithUserByMesAnio` ya devolvía la columna `bucket` por crédito (PR #1041); este PR le agrega el **filtro** con la MISMA derivación → lo que se filtra es exactamente lo que se muestra. Misma data, joins, paginación y conteo del original.

- `?bucket=1` · `?bucket=4,5` · sin `bucket` = todo el funnel (nunca CANCELADO/EN_CONVENIO/etc.)
- Cubre lo que el aging por cuotas no puede: **INCOBRABLE cae en B5 aunque su mora esté apagada** (45 casos reales en dev con cuotas=0).
- Filtros: `mes`/`anio` (juntos, 0/0 = sin filtro), `numero_credito_sifco`, `nombre_usuario`, `asesor_id`, `email_asesor`, `page`/`perPage` — todos validados → 400.
- Gate ADMIN/CONTA (mismo criterio que `/buckets/historial`).
- WHERE validado read-only contra dev (catálogo simulado): distribución **exacta** al dry-run — B0 437 · B1 597 · B2 219 · B3 55 · B4 30 · B5 148.

## 3) 🧪 El job se corre a mano — flujo de pruebas habilitado

**`POST /moras/procesar`** (ya existía, con token) ahora devuelve el resumen del motor:

```json
{ "result": { "creadas": ..., "buckets": { "iniciales": N, "subidas": N, "bajadas": N, "reasignados": N, "sinPoolDestino": N } } }
```

Plan de pruebas en el sandbox (post migraciones + `asignacion/01→03`):

| # | Escenario | Esperado tras `POST /moras/procesar` |
|---|---|---|
| 1 | Crédito B2 paga 1 cuota y **CONTA valida** | BAJADA B2→B1 + reasignado al asesor de B1 + ambas bitácoras |
| 2 | Pago hecho pero **sin validar** | Sigue en B2, sin eventos (la cuota sigue contando) |
| 3 | Se pone al día | BAJADA →B0 + pasa a Caren |
| 4 | Cae a >=5 cuotas o INCOBRABLE | SUBIDA →B5 + pasa a Gerencia |
| 5 | Varios créditos entran a B1 | Reparto parejo Diego / Asesor Prueba B1 |

Verificar con `GET /buckets/historial`, `GET /buckets/creditos?bucket=N` y `credito_asesor_historial`.

## Verificación

- `bun test`: 10/10 · `tsc`: 0 errores nuevos (solo los 6 pre-existentes de pg/scripts).
- Cambio a `getCreditosWithUserByMesAnio` es **aditivo** (param opcional): consumidores actuales intactos.

Modelo visual: https://claude.ai/code/artifact/b4f20ce1-1a4c-40d4-8300-7c89df056e37

🤖 Generated with [Claude Code](https://claude.com/claude-code)