### PR TITLE
fix(crm): save bank analysis statements as attachments

### DIFF
--- a/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
+++ b/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "bun:test";
+import { getBankStatementOpportunityDocumentType } from "./bank-statement-documents";
+
+describe("bank statement opportunity documents", () => {
+	test("maps only the first three PDFs to estados_cuenta document types", () => {
+		expect(getBankStatementOpportunityDocumentType(0)).toBe("estados_cuenta_1");
+		expect(getBankStatementOpportunityDocumentType(1)).toBe("estados_cuenta_2");
+		expect(getBankStatementOpportunityDocumentType(2)).toBe("estados_cuenta_3");
+		expect(getBankStatementOpportunityDocumentType(3)).toBeUndefined();
+	});
+});

--- a/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
+++ b/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
@@ -26,4 +26,18 @@ describe("bank statement opportunity documents", () => {
 		expect(successIndex).toBeGreaterThan(-1);
 		expect(attachmentWriteIndex).toBeGreaterThan(successIndex);
 	});
+
+	test("requires upload role before enabling opportunity attachments", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/bank-analysis.ts"),
+			"utf8",
+		);
+		const roleGateIndex = source.indexOf(
+			'!["admin", "sales", "sales_supervisor", "analyst"].includes(',
+		);
+		const enableAttachmentsIndex = source.indexOf("opportunityForDocuments = {");
+
+		expect(roleGateIndex).toBeGreaterThan(-1);
+		expect(enableAttachmentsIndex).toBeGreaterThan(roleGateIndex);
+	});
 });

--- a/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
+++ b/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 import { getBankStatementOpportunityDocumentType } from "./bank-statement-documents";
 
@@ -7,5 +9,21 @@ describe("bank statement opportunity documents", () => {
 		expect(getBankStatementOpportunityDocumentType(1)).toBe("estados_cuenta_2");
 		expect(getBankStatementOpportunityDocumentType(2)).toBe("estados_cuenta_3");
 		expect(getBankStatementOpportunityDocumentType(3)).toBeUndefined();
+	});
+
+	test("persists opportunity attachments only after analysis succeeds", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/bank-analysis.ts"),
+			"utf8",
+		);
+		const successIndex = source.indexOf(
+			"const creditCapacity = calculateCreditCapacity",
+		);
+		const attachmentWriteIndex = source.indexOf(
+			"const { key } = await uploadFileToR2(",
+		);
+
+		expect(successIndex).toBeGreaterThan(-1);
+		expect(attachmentWriteIndex).toBeGreaterThan(successIndex);
 	});
 });

--- a/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
+++ b/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
@@ -27,6 +27,22 @@ describe("bank statement opportunity documents", () => {
 		expect(attachmentWriteIndex).toBeGreaterThan(successIndex);
 	});
 
+	test("persists opportunity attachments only after saving credit analysis", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/bank-analysis.ts"),
+			"utf8",
+		);
+		const persistedAnalysisIndex = source.indexOf(
+			"fullAnalysis: JSON.stringify(analysis)",
+		);
+		const attachmentWriteIndex = source.indexOf(
+			"const { key } = await uploadFileToR2(",
+		);
+
+		expect(persistedAnalysisIndex).toBeGreaterThan(-1);
+		expect(attachmentWriteIndex).toBeGreaterThan(persistedAnalysisIndex);
+	});
+
 	test("requires upload role before enabling opportunity attachments", () => {
 		const source = readFileSync(
 			join(import.meta.dir, "../routers/bank-analysis.ts"),

--- a/apps/crm/apps/server/src/lib/bank-statement-documents.ts
+++ b/apps/crm/apps/server/src/lib/bank-statement-documents.ts
@@ -1,0 +1,14 @@
+export const BANK_STATEMENT_OPPORTUNITY_DOCUMENT_TYPES = [
+	"estados_cuenta_1",
+	"estados_cuenta_2",
+	"estados_cuenta_3",
+] as const;
+
+export type BankStatementOpportunityDocumentType =
+	(typeof BANK_STATEMENT_OPPORTUNITY_DOCUMENT_TYPES)[number];
+
+export function getBankStatementOpportunityDocumentType(
+	index: number,
+): BankStatementOpportunityDocumentType | undefined {
+	return BANK_STATEMENT_OPPORTUNITY_DOCUMENT_TYPES[index];
+}

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -4,17 +4,29 @@ import { generateObject } from "ai";
 import { and, eq, isNull, lt, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
-import { coDebtors, creditAnalysis, leads } from "../db/schema/crm";
+import {
+	coDebtors,
+	creditAnalysis,
+	leads,
+	opportunities,
+} from "../db/schema/crm";
+import { opportunityDocuments } from "../db/schema/documents";
 import {
 	BANK_ANALYSIS_PROMPT,
 	bankStatementAnalysisSchema,
 } from "../lib/bank-analysis-schema";
+import {
+	getBankStatementOpportunityDocumentType,
+} from "../lib/bank-statement-documents";
+import { updateChecklistForClientDocument } from "../lib/checklist";
 import { calculateCreditCapacity } from "../lib/financial-math";
 import { crmProcedure } from "../lib/orpc";
 import {
 	buildUploadPrefix,
 	deleteFileFromR2,
+	generateUniqueFilename,
 	getFileBuffer,
+	uploadFileToR2,
 	verifyUploadedDocumentInR2,
 } from "../lib/storage";
 
@@ -43,6 +55,7 @@ export const bankAnalysisRouter = {
 					termMonths: z.number().int().min(12).max(120).default(60),
 					maxDebtRatio: z.number().min(0).max(1).default(0.2),
 					maxVariableDebtRatio: z.number().min(0).max(1).default(0.2),
+					opportunityId: z.string().uuid().optional(),
 				})
 				.refine((data) => data.leadId || data.coDebtorId, {
 					message: "Debe proporcionar leadId o coDebtorId",
@@ -89,11 +102,60 @@ export const bankAnalysisRouter = {
 				}
 			}
 
+			let opportunityForDocuments:
+				| { id: string; vehicleId: string | null }
+				| undefined;
+
+			if (isForLead && input.opportunityId) {
+				const [opportunity] = await db
+					.select({
+						id: opportunities.id,
+						leadId: opportunities.leadId,
+						vehicleId: opportunities.vehicleId,
+						assignedTo: opportunities.assignedTo,
+					})
+					.from(opportunities)
+					.where(eq(opportunities.id, input.opportunityId))
+					.limit(1);
+
+				if (!opportunity) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "Oportunidad no encontrada",
+					});
+				}
+
+				if (opportunity.leadId !== input.leadId) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: "La oportunidad no pertenece al lead analizado",
+					});
+				}
+
+				if (
+					context.userRole === "sales" &&
+					opportunity.assignedTo !== context.userId
+				) {
+					throw new ORPCError("FORBIDDEN", {
+						message:
+							"No tienes permiso para adjuntar documentos a esta oportunidad",
+					});
+				}
+
+				opportunityForDocuments = {
+					id: opportunity.id,
+					vehicleId: opportunity.vehicleId,
+				};
+			}
+
 			const uploadedKeys: string[] = [];
 
 			try {
 				// 2. Validar archivos: descargar de R2 y verificar formato PDF
-				const downloadedFiles: { name: string; buffer: Buffer }[] = [];
+				const downloadedFiles: {
+					name: string;
+					buffer: Buffer;
+					mimeType: string;
+					size: number;
+				}[] = [];
 				for (const file of input.files) {
 					const uploadedFile = await verifyUploadedDocumentInR2({
 						key: file.key,
@@ -115,7 +177,12 @@ export const bankAnalysisRouter = {
 						});
 					}
 
-					downloadedFiles.push({ name: file.name, buffer });
+					downloadedFiles.push({
+						name: file.name,
+						buffer,
+						mimeType: uploadedFile.mimeType,
+						size: uploadedFile.size,
+					});
 				}
 
 				// 3. Incremento atómico del contador para evitar race conditions
@@ -210,6 +277,48 @@ export const bankAnalysisRouter = {
 						throw new ORPCError("PRECONDITION_FAILED", {
 							message: `Se alcanzó el límite de ${MAX_AI_ATTEMPTS} intentos de análisis. Contacte al administrador.`,
 						});
+					}
+				}
+
+				if (opportunityForDocuments) {
+					for (const [index, file] of downloadedFiles.entries()) {
+						const documentType = getBankStatementOpportunityDocumentType(index);
+						if (!documentType) {
+							continue;
+						}
+
+						const uniqueFilename = generateUniqueFilename(file.name);
+						const { key } = await uploadFileToR2(
+							new Blob([new Uint8Array(file.buffer)], { type: file.mimeType }),
+							uniqueFilename,
+							opportunityForDocuments.id,
+						);
+
+						const [newDocument] = await db
+							.insert(opportunityDocuments)
+							.values({
+								opportunityId: opportunityForDocuments.id,
+								filename: uniqueFilename,
+								originalName: file.name,
+								mimeType: file.mimeType,
+								size: file.size,
+								documentType,
+								description:
+									"Guardado automáticamente desde análisis de capacidad de pago",
+								uploadedBy: context.userId,
+								filePath: key,
+							})
+							.returning({ id: opportunityDocuments.id });
+
+						if (newDocument) {
+							await updateChecklistForClientDocument(
+								opportunityForDocuments.id,
+								documentType,
+								newDocument.id,
+								!!opportunityForDocuments.vehicleId,
+								opportunityForDocuments.vehicleId || undefined,
+							);
+						}
 					}
 				}
 

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -280,48 +280,6 @@ export const bankAnalysisRouter = {
 					}
 				}
 
-				if (opportunityForDocuments) {
-					for (const [index, file] of downloadedFiles.entries()) {
-						const documentType = getBankStatementOpportunityDocumentType(index);
-						if (!documentType) {
-							continue;
-						}
-
-						const uniqueFilename = generateUniqueFilename(file.name);
-						const { key } = await uploadFileToR2(
-							new Blob([new Uint8Array(file.buffer)], { type: file.mimeType }),
-							uniqueFilename,
-							opportunityForDocuments.id,
-						);
-
-						const [newDocument] = await db
-							.insert(opportunityDocuments)
-							.values({
-								opportunityId: opportunityForDocuments.id,
-								filename: uniqueFilename,
-								originalName: file.name,
-								mimeType: file.mimeType,
-								size: file.size,
-								documentType,
-								description:
-									"Guardado automáticamente desde análisis de capacidad de pago",
-								uploadedBy: context.userId,
-								filePath: key,
-							})
-							.returning({ id: opportunityDocuments.id });
-
-						if (newDocument) {
-							await updateChecklistForClientDocument(
-								opportunityForDocuments.id,
-								documentType,
-								newDocument.id,
-								!!opportunityForDocuments.vehicleId,
-								opportunityForDocuments.vehicleId || undefined,
-							);
-						}
-					}
-				}
-
 				// 4. Construir content parts con los PDFs descargados de R2
 				const fileParts = downloadedFiles.map((file) => ({
 					type: "file" as const,
@@ -389,6 +347,87 @@ export const bankAnalysisRouter = {
 					maxDebtRatio: input.maxDebtRatio,
 					maxVariableDebtRatio: input.maxVariableDebtRatio,
 				});
+
+				if (opportunityForDocuments) {
+					const savedDocuments: { id: string; documentType: string }[] = [];
+					const savedKeys: string[] = [];
+
+					try {
+						for (const [index, file] of downloadedFiles.entries()) {
+							const documentType = getBankStatementOpportunityDocumentType(index);
+							if (!documentType) {
+								continue;
+							}
+
+							const uniqueFilename = generateUniqueFilename(file.name);
+							const { key } = await uploadFileToR2(
+								new Blob([new Uint8Array(file.buffer)], { type: file.mimeType }),
+								uniqueFilename,
+								opportunityForDocuments.id,
+							);
+							savedKeys.push(key);
+
+							const [newDocument] = await db
+								.insert(opportunityDocuments)
+								.values({
+									opportunityId: opportunityForDocuments.id,
+									filename: uniqueFilename,
+									originalName: file.name,
+									mimeType: file.mimeType,
+									size: file.size,
+									documentType,
+									description:
+										"Guardado automáticamente desde análisis de capacidad de pago",
+									uploadedBy: context.userId,
+									filePath: key,
+								})
+								.returning({ id: opportunityDocuments.id });
+
+							if (newDocument) {
+								savedDocuments.push({ id: newDocument.id, documentType });
+								await updateChecklistForClientDocument(
+									opportunityForDocuments.id,
+									documentType,
+									newDocument.id,
+									!!opportunityForDocuments.vehicleId,
+									opportunityForDocuments.vehicleId || undefined,
+								);
+							}
+						}
+					} catch (error) {
+						// Do not turn a completed AI analysis into a spent failed attempt.
+						const cleanupResults = await Promise.allSettled([
+							...savedDocuments.map(({ id }) =>
+								db
+									.delete(opportunityDocuments)
+									.where(eq(opportunityDocuments.id, id)),
+							),
+							...savedKeys.map((key) => deleteFileFromR2(key)),
+						]);
+						const failedCleanups = cleanupResults.filter(
+							(result) => result.status === "rejected",
+						);
+						await Promise.allSettled(
+							savedDocuments.map(({ id, documentType }) =>
+								updateChecklistForClientDocument(
+									opportunityForDocuments.id,
+									documentType,
+									id,
+									!!opportunityForDocuments.vehicleId,
+									opportunityForDocuments.vehicleId || undefined,
+								),
+							),
+						);
+
+						console.error("Failed to save bank statement opportunity documents", {
+							opportunityId: opportunityForDocuments.id,
+							savedDocuments: savedDocuments.length,
+							savedFiles: savedKeys.length,
+							failedCleanups: failedCleanups.length,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+				}
 
 				// 7. Actualizar con los resultados del análisis exitoso
 				await db

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -131,6 +131,16 @@ export const bankAnalysisRouter = {
 				}
 
 				if (
+					!["admin", "sales", "sales_supervisor", "analyst"].includes(
+						context.userRole,
+					)
+				) {
+					throw new ORPCError("FORBIDDEN", {
+						message: "No tienes permiso para subir documentos",
+					});
+				}
+
+				if (
 					context.userRole === "sales" &&
 					opportunity.assignedTo !== context.userId
 				) {

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -358,6 +358,28 @@ export const bankAnalysisRouter = {
 					maxVariableDebtRatio: input.maxVariableDebtRatio,
 				});
 
+				// 7. Actualizar con los resultados del análisis exitoso
+				await db
+					.update(creditAnalysis)
+					.set({
+						fullAnalysis: JSON.stringify(analysis),
+						monthlyFixedIncome:
+							analysis.promedio_mensual.promedio_ingresos_fijos.toString(),
+						monthlyVariableIncome:
+							analysis.promedio_mensual.promedio_ingresos_variables.toString(),
+						monthlyFixedExpenses:
+							analysis.promedio_mensual.promedio_gastos_fijos.toString(),
+						monthlyVariableExpenses:
+							analysis.promedio_mensual.promedio_gastos_variables.toString(),
+						economicAvailability:
+							analysis.promedio_mensual.disponibilidad_economica.toString(),
+						maxPayment: creditCapacity.maxPayment.toString(),
+						maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
+						analyzedAt: new Date(),
+						updatedAt: new Date(),
+					})
+					.where(whereCondition);
+
 				if (opportunityForDocuments) {
 					const savedDocuments: { id: string; documentType: string }[] = [];
 					const savedKeys: string[] = [];
@@ -438,28 +460,6 @@ export const bankAnalysisRouter = {
 						});
 					}
 				}
-
-				// 7. Actualizar con los resultados del análisis exitoso
-				await db
-					.update(creditAnalysis)
-					.set({
-						fullAnalysis: JSON.stringify(analysis),
-						monthlyFixedIncome:
-							analysis.promedio_mensual.promedio_ingresos_fijos.toString(),
-						monthlyVariableIncome:
-							analysis.promedio_mensual.promedio_ingresos_variables.toString(),
-						monthlyFixedExpenses:
-							analysis.promedio_mensual.promedio_gastos_fijos.toString(),
-						monthlyVariableExpenses:
-							analysis.promedio_mensual.promedio_gastos_variables.toString(),
-						economicAvailability:
-							analysis.promedio_mensual.disponibilidad_economica.toString(),
-						maxPayment: creditCapacity.maxPayment.toString(),
-						maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
-						analyzedAt: new Date(),
-						updatedAt: new Date(),
-					})
-					.where(whereCondition);
 
 				// 8. Retornar resultados
 				return {

--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -34,12 +34,14 @@ function isPdfFile(file: File) {
 interface BankStatementAnalysisProps {
 	leadId?: string;
 	coDebtorId?: string;
+	opportunityId?: string;
 	onAnalysisComplete?: () => void;
 }
 
 export function BankStatementAnalysis({
 	leadId,
 	coDebtorId,
+	opportunityId,
 	onAnalysisComplete,
 }: BankStatementAnalysisProps) {
 	const [files, setFiles] = useState<File[]>([]);
@@ -113,6 +115,7 @@ export function BankStatementAnalysis({
 
 			return client.analyzeBankStatements({
 				...(leadId ? { leadId } : { coDebtorId: coDebtorId! }),
+				...(leadId && opportunityId ? { opportunityId } : {}),
 				files: filePayloads,
 				annualRate: Number.parseFloat(annualRate),
 				termMonths: Number.parseInt(termMonths),

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -345,6 +345,7 @@ export function OpportunityDetailModal({
 												to="/crm/leads"
 												search={{
 													leadId: displayLead.id,
+													opportunityId: opportunity.id,
 												}}
 												className="font-medium text-primary hover:underline"
 												onClick={() => onOpenChange(false)}

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -108,6 +108,7 @@ export const Route = createFileRoute("/crm/leads")({
 	validateSearch: z.object({
 		companyId: z.string().optional(),
 		leadId: z.string().optional(),
+		opportunityId: z.string().optional(),
 	}).parse,
 });
 
@@ -291,6 +292,7 @@ function RouteComponent() {
 			: () => Promise.resolve([]),
 		enabled: !!selectedLead?.id && isDetailsDialogOpen,
 	});
+	const analysisOpportunityId = search.opportunityId;
 
 	// Query para obtener un lead específico por ID (desde URL)
 	const specificLeadQuery = useQuery({
@@ -2697,6 +2699,7 @@ function RouteComponent() {
 								{selectedLead?.id && (
 									<BankStatementAnalysis
 										leadId={selectedLead.id}
+										opportunityId={analysisOpportunityId}
 										onAnalysisComplete={() => creditAnalysisQuery.refetch()}
 									/>
 								)}

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -2305,27 +2305,29 @@ function RouteComponent() {
 													className="cursor-pointer font-medium text-primary hover:underline"
 													role="button"
 													tabIndex={0}
-													onClick={() => {
+												onClick={() => {
+													setIsDetailsDialogOpen(false);
+													navigate({
+														to: "/crm/leads",
+														search: {
+															leadId: selectedOpportunity.lead?.id,
+															opportunityId: selectedOpportunity.id,
+														},
+													});
+												}}
+												onKeyDown={(e) => {
+													if (e.key === "Enter" || e.key === " ") {
+														e.preventDefault();
 														setIsDetailsDialogOpen(false);
 														navigate({
 															to: "/crm/leads",
 															search: {
 																leadId: selectedOpportunity.lead?.id,
+																opportunityId: selectedOpportunity.id,
 															},
 														});
-													}}
-													onKeyDown={(e) => {
-														if (e.key === "Enter" || e.key === " ") {
-															e.preventDefault();
-															setIsDetailsDialogOpen(false);
-															navigate({
-																to: "/crm/leads",
-																search: {
-																	leadId: selectedOpportunity.lead?.id,
-																},
-															});
-														}
-													}}
+													}
+												}}
 												>
 													{formatLeadFullName(selectedOpportunity.lead)}
 												</span>


### PR DESCRIPTION
## Summary
- Passes opportunity context into bank statement analysis from opportunity/detail flows.
- Auto-saves the first three PDFs uploaded for capacity/payment analysis as opportunity attachments: `estados_cuenta_1`, `estados_cuenta_2`, `estados_cuenta_3`.
- Updates the opportunity document checklist when those statements are saved automatically.

## Notes
- The auto-save only happens when the analysis request has an explicit `opportunityId`; it does not guess the first opportunity for a lead, to avoid attaching statements to the wrong opportunity.
- PDFs beyond the first three are still analyzed, but are not saved as attachments because the current document types only include `estados_cuenta_1..3`.

## Verification
- [x] `bun test apps/crm/apps/server/src/lib/bank-statement-documents.test.ts`
- [x] `git diff --check`
- [ ] Full repo typecheck — existing repo/dependency/type errors remain unrelated to this change.
