### PR TITLE
feat(cartera-back): schema parametrizable por env — el back ya apunta al sandbox cartera_cobros2

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/bucketsHistorial.ts
+++ b/apps/cartera-back/src/controllers/buckets/bucketsHistorial.ts
@@ -1,4 +1,5 @@
 import { db } from "../../database";
+import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
 import { sql } from "drizzle-orm";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -82,13 +83,13 @@ function buildWhere(a: BucketsHistorialArgs) {
 // - buckets bn/ba: LEFT contra el catálogo (nombre/prefijo); ba puede ser null.
 // - asesores aa: LEFT, asesor de ATRIBUCIÓN del evento (h.asesor_id, la BAJADA curada).
 const joins = sql`
-  FROM cartera.buckets_historial h
-  INNER JOIN cartera.creditos c ON c.credito_id = h.credito_id
-  INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-  LEFT JOIN cartera.asesores a ON a.asesor_id = c.asesor_id
-  LEFT JOIN cartera.buckets bn ON bn.numero = h.bucket_nuevo
-  LEFT JOIN cartera.buckets ba ON ba.numero = h.bucket_anterior
-  LEFT JOIN cartera.asesores aa ON aa.asesor_id = h.asesor_id`;
+  FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+  INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = h.credito_id
+  INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets bn ON bn.numero = h.bucket_nuevo
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets ba ON ba.numero = h.bucket_anterior
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores aa ON aa.asesor_id = h.asesor_id`;
 
 // Histórico paginado de transiciones de bucket, con filtros, joins y resumen.
 export async function getBucketsHistorial(a: BucketsHistorialArgs) {
@@ -179,10 +180,10 @@ export async function getBucketsHistorialCredito({ credito_id }: { credito_id: n
       aa.nombre AS asesor_atribucion,
       h.pago_id,
       h.motivo
-    FROM cartera.buckets_historial h
-    LEFT JOIN cartera.buckets bn ON bn.numero = h.bucket_nuevo
-    LEFT JOIN cartera.buckets ba ON ba.numero = h.bucket_anterior
-    LEFT JOIN cartera.asesores aa ON aa.asesor_id = h.asesor_id
+    FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets bn ON bn.numero = h.bucket_nuevo
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets ba ON ba.numero = h.bucket_anterior
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores aa ON aa.asesor_id = h.asesor_id
     WHERE h.credito_id = ${credito_id}
     ORDER BY h.fecha DESC, h.historial_id DESC
   `);

--- a/apps/cartera-back/src/controllers/creditosNuevosConAbonos.ts
+++ b/apps/cartera-back/src/controllers/creditosNuevosConAbonos.ts
@@ -1,4 +1,5 @@
 import { db } from "../database/index";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import {
   creditos,
   pagos_credito,
@@ -35,7 +36,7 @@ export interface CreditoNuevoConAbono {
 export async function diagnosticoCreditosAbonos() {
   // Total de créditos en la BD
   const totalCreditosResult = await db.execute<{ total: string }>(
-    sql`SELECT COUNT(*) as total FROM cartera.creditos`
+    sql`SELECT COUNT(*) as total FROM ${SQL_CARTERA_SCHEMA}.creditos`
   );
 
   // Rango de fechas de los créditos
@@ -46,7 +47,7 @@ export async function diagnosticoCreditosAbonos() {
     sql`SELECT 
           MIN(fecha_creacion AT TIME ZONE 'America/Guatemala')::date::text as fecha_min,
           MAX(fecha_creacion AT TIME ZONE 'America/Guatemala')::date::text as fecha_max
-        FROM cartera.creditos`
+        FROM ${SQL_CARTERA_SCHEMA}.creditos`
   );
 
   // Créditos agrupados por mes/año para ver la distribución real
@@ -57,7 +58,7 @@ export async function diagnosticoCreditosAbonos() {
     sql`SELECT 
           TO_CHAR(fecha_creacion AT TIME ZONE 'America/Guatemala', 'YYYY-MM') as mes,
           COUNT(*) as total
-        FROM cartera.creditos
+        FROM ${SQL_CARTERA_SCHEMA}.creditos
         GROUP BY TO_CHAR(fecha_creacion AT TIME ZONE 'America/Guatemala', 'YYYY-MM')
         ORDER BY mes DESC
         LIMIT 12`
@@ -71,7 +72,7 @@ export async function diagnosticoCreditosAbonos() {
     sql`SELECT
           COUNT(*) as total_pagos,
           COUNT(*) FILTER (WHERE CAST(abono_capital AS NUMERIC) > 0) as con_abono_capital
-        FROM cartera.pagos_credito`
+        FROM ${SQL_CARTERA_SCHEMA}.pagos_credito`
   );
 
   // ====================================================================
@@ -100,7 +101,7 @@ export async function diagnosticoCreditosAbonos() {
           -- Cuántas cuotas reales (numero_cuota > 0) están pagadas
           (
             SELECT COUNT(*) 
-            FROM cartera.cuotas_credito cc 
+            FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cc 
             WHERE cc.credito_id = c.credito_id 
               AND cc.numero_cuota > 0 
               AND cc.pagado = true
@@ -116,9 +117,9 @@ export async function diagnosticoCreditosAbonos() {
           -- Suma total
           COALESCE(SUM(CAST(COALESCE(p.membresias_mes, '0') AS NUMERIC)), 0)::text as suma_membresias_mes,
           COALESCE(SUM(CAST(COALESCE(p.membresias_pago, '0') AS NUMERIC)), 0)::text as suma_membresias_pago
-        FROM cartera.creditos c
-        INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-        LEFT JOIN cartera.pagos_credito p ON p.credito_id = c.credito_id
+        FROM ${SQL_CARTERA_SCHEMA}.creditos c
+        INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+        LEFT JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito p ON p.credito_id = c.credito_id
         WHERE 
           (c.fecha_creacion AT TIME ZONE 'America/Guatemala')::date >= '2026-03-01'
         GROUP BY c.credito_id, c.numero_credito_sifco, c.fecha_creacion, u.nombre, c.capital
@@ -131,7 +132,7 @@ export async function diagnosticoCreditosAbonos() {
           -- Y que NO tenga cuotas reales pagadas (o sea, el cliente aún no ha pagado nada)
           AND (
             SELECT COUNT(*) 
-            FROM cartera.cuotas_credito cc 
+            FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cc 
             WHERE cc.credito_id = c.credito_id 
               AND cc.numero_cuota > 0 
               AND cc.pagado = true

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -1,4 +1,5 @@
 import { db } from "../database/index";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import {
   aseguradoras,
   asesores,
@@ -228,7 +229,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           lt(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
           sql`NOT EXISTS (
             SELECT 1
-            FROM cartera.pagos_credito p_pending
+            FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p_pending
             WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
               AND p_pending.validation_status = 'pending'
               AND p_pending.pagado = true
@@ -282,7 +283,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           eq(cuotas_credito.pagado, false),
           sql`NOT EXISTS (
             SELECT 1
-            FROM cartera.pagos_credito p_pending
+            FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p_pending
             WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
               AND p_pending.validation_status = 'pending'
           )`
@@ -871,19 +872,19 @@ export async function getCreditosWithUserByMesAnio(
     conditions.push(sql`${creditos.statusCredit} NOT IN (${fueraSql})`);
     conditions.push(sql`(
       EXISTS (
-        SELECT 1 FROM cartera.buckets b
+        SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.buckets b
          WHERE b.activo = true
            AND ${creditos.statusCredit} = ANY (b.estados_incluidos)
            AND b.numero IN (${numerosSql})
       )
       OR (
         NOT EXISTS (
-          SELECT 1 FROM cartera.buckets b
+          SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.buckets b
            WHERE b.activo = true
              AND ${creditos.statusCredit} = ANY (b.estados_incluidos)
         )
         AND EXISTS (
-          SELECT 1 FROM cartera.buckets b
+          SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.buckets b
            WHERE b.activo = true
              AND b.numero IN (${numerosSql})
              AND COALESCE(${moras_credito.cuotas_atrasadas}, 0) >= b.cuotas_min

--- a/apps/cartera-back/src/controllers/devolucion.ts
+++ b/apps/cartera-back/src/controllers/devolucion.ts
@@ -1,4 +1,5 @@
 import { db } from "../database";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import { creditos, historial_devolucion_credito, usuarios } from "../database/db/schema";
 import { eq, desc, sql, and, or, ilike, inArray } from "drizzle-orm";
 
@@ -53,7 +54,7 @@ export async function listPendingDevolucion({ query, set }: any) {
         estado_devolucion: creditos.estado_devolucion,
         motivo_contextual: sql<string | null>`(
           SELECT h.motivo
-          FROM cartera.historial_devolucion_credito h
+          FROM ${SQL_CARTERA_SCHEMA}.historial_devolucion_credito h
           WHERE h.credito_id = ${creditos.credito_id}
             AND h.estado_nuevo = ${creditos.estado_devolucion}
           ORDER BY h.created_at DESC

--- a/apps/cartera-back/src/controllers/facturacionSnapshot.ts
+++ b/apps/cartera-back/src/controllers/facturacionSnapshot.ts
@@ -1,4 +1,5 @@
 import Big from "big.js";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import ExcelJS from "exceljs";
 import { and, desc, eq, gte, lte, sql } from "drizzle-orm";
 import { db } from "../database";
@@ -102,7 +103,7 @@ export function calcularAcumuladosCorridos(
 // total del día y los acumulados cuadren con lo que el usuario tipeó.
 export async function recomputarTotalesDia(fecha: string, exec: any = db) {
   await exec.execute(sql`
-    UPDATE cartera.facturacion_snapshot_diario SET
+    UPDATE ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario SET
       facturacion = interes_cube + membresia + otros_ingresos + mora_cube + royalty,
       facturacion_mas_servicios =
         interes_cube + membresia + otros_ingresos + mora_cube + royalty + servicios_seguro_gps,
@@ -130,7 +131,7 @@ export async function recomputarAcumuladosMes(
   const res = await exec.execute(sql`
     SELECT fecha::text AS fecha, bloqueado,
            facturacion, servicios_seguro_gps, facturacion_inversionistas, ingreso_carros
-    FROM cartera.facturacion_snapshot_diario
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario
     WHERE fecha >= ${inicioMes}::date
       AND fecha < (${inicioMes}::date + INTERVAL '1 month')
     ORDER BY fecha
@@ -139,7 +140,7 @@ export async function recomputarAcumuladosMes(
   const updates = calcularAcumuladosCorridos(dias);
   for (const u of updates) {
     await exec.execute(sql`
-      UPDATE cartera.facturacion_snapshot_diario SET
+      UPDATE ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario SET
         facturacion_acumulado = ${u.facturacion_acumulado},
         acum_servicios_seguro_gps = ${u.acum_servicios_seguro_gps},
         acumulado_inversionistas = ${u.acumulado_inversionistas},
@@ -213,7 +214,7 @@ function colProducto(prefix: string, categoria: string): string | null {
 export async function generarSnapshotDiario(fecha: string) {
   // Si el día está bloqueado (editado a mano), NO se sobreescribe.
   const lockRes = await db.execute(sql`
-    SELECT bloqueado FROM cartera.facturacion_snapshot_diario
+    SELECT bloqueado FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario
     WHERE fecha = ${fecha}::date
   `);
   const lockRow = ((lockRes as any).rows ?? lockRes)[0];
@@ -240,10 +241,10 @@ export async function generarSnapshotDiario(fecha: string) {
   //    `fd.categoria` (resuelta por NIT al facturar); las de pago la derivan por JOIN.
   const desg = await db.execute(sql`
     SELECT COALESCE(u.categoria, fd.categoria) AS categoria, fd.rubro AS rubro, SUM(fd.monto_total) AS total
-    FROM cartera.facturacion_desglose fd
-    LEFT JOIN cartera.pagos_credito p ON p.pago_id   = fd.pago_id
-    LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
-    LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito p ON p.pago_id   = fd.pago_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos      c ON c.credito_id = p.credito_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.usuarios      u ON u.usuario_id = c.usuario_id
     WHERE fd.fecha_aplicado_gt = ${fecha}::date
       -- Filas de PAGO: el pago debe existir (no huérfano por credito/usuario
       -- borrado) y, MISMO CRITERIO QUE EL EXCEL (getPagosConInversionistas que
@@ -323,11 +324,11 @@ export async function generarSnapshotDiario(fecha: string) {
   //      sub-cuenta. Tomándolo de los pagos aplicados cuadra al centavo con el Excel.
   const capPci = await db.execute(sql`
     SELECT u.categoria AS categoria, SUM(pci.abono_capital) AS cap
-    FROM cartera.pagos_credito p
-    JOIN cartera.creditos c ON c.credito_id = p.credito_id
-    JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-    JOIN cartera.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
-    JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+    FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = p.credito_id
+    JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+    JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
+    JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
     WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
       AND p.validation_status IN ('validated','pending','reset','capital','capital_validated')
       AND c."statusCredit" IN
@@ -350,7 +351,7 @@ export async function generarSnapshotDiario(fecha: string) {
   //      La categoría de las genéricas vive en fd.categoria (resuelta por NIT al facturar).
   const oiNuevo = await db.execute(sql`
     SELECT fd.categoria AS categoria, SUM(fd.monto_total) AS total
-    FROM cartera.facturacion_desglose fd
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd
     WHERE fd.fecha_aplicado_gt = ${fecha}::date
       AND fd.pago_id IS NULL
       AND fd.rubro::text IN ('INTERES','MEMBRESIA','SEGURO','GPS','OTROS')
@@ -378,7 +379,7 @@ export async function generarSnapshotDiario(fecha: string) {
   //    desglose). Verificado: gastos_administrativos solo tenía cargos del CRM (sin manuales).
   const adm = await db.execute(sql`
     SELECT COALESCE(SUM(monto_total), 0) AS total
-    FROM cartera.facturacion_desglose
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose
     WHERE fecha_aplicado_gt = ${fecha}::date AND pago_id IS NULL
       AND rubro::text IN ('INTERES','MEMBRESIA','SEGURO','GPS','OTROS')
   `);
@@ -387,7 +388,7 @@ export async function generarSnapshotDiario(fecha: string) {
   // 3.1) Ingresos por carros del día
   const carr = await db.execute(sql`
     SELECT COALESCE(SUM(monto), 0) AS total
-    FROM cartera.ingresos_carros WHERE fecha = ${fecha}::date
+    FROM ${SQL_CARTERA_SCHEMA}.ingresos_carros WHERE fecha = ${fecha}::date
   `);
   const ingresoCarros = new Big((carr as any).rows?.[0]?.total || 0);
 
@@ -397,7 +398,7 @@ export async function generarSnapshotDiario(fecha: string) {
   //    sola fuente y la misma fecha (COALESCE fecha_aplicado/fecha_pago).
   const inv = await db.execute(sql`
     SELECT COALESCE(SUM(monto_total), 0) AS total
-    FROM cartera.facturacion_desglose
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose
     WHERE rubro::text = 'INTERES_INVERSIONISTAS'
       AND fecha_aplicado_gt = ${fecha}::date
   `);
@@ -436,7 +437,7 @@ export async function generarSnapshotDiario(fecha: string) {
       COALESCE(SUM(servicios_seguro_gps), 0)       AS serv,
       COALESCE(SUM(facturacion_inversionistas), 0) AS inv,
       COALESCE(SUM(ingreso_carros), 0)             AS carros
-    FROM cartera.facturacion_snapshot_diario
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario
     WHERE fecha >= ${monthStart}::date AND fecha < ${fecha}::date
   `);
   const P = (prev as any).rows?.[0] ?? {};
@@ -450,7 +451,7 @@ export async function generarSnapshotDiario(fecha: string) {
     .plus(ingresoCarrosMtd);
   // Reserva acumulada (MTD) desde pagos_credito.reserva (pagos tiene histórico → sin corte).
   const reservaMtd = await db.execute(sql`
-    SELECT COALESCE(SUM(reserva), 0) AS total FROM cartera.pagos_credito
+    SELECT COALESCE(SUM(reserva), 0) AS total FROM ${SQL_CARTERA_SCHEMA}.pagos_credito
     WHERE (fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date BETWEEN ${monthStart}::date AND ${fecha}::date
   `);
   const reserva_acumulada = new Big((reservaMtd as any).rows[0].total);
@@ -465,7 +466,7 @@ export async function generarSnapshotDiario(fecha: string) {
 
   // 8) Metas del mes
   const meta = await db.execute(sql`
-    SELECT * FROM cartera.metas_facturacion WHERE anio = ${y} AND mes = ${m} LIMIT 1
+    SELECT * FROM ${SQL_CARTERA_SCHEMA}.metas_facturacion WHERE anio = ${y} AND mes = ${m} LIMIT 1
   `);
   const M = (meta as any).rows?.[0] || {};
   const meta_mensual = new Big(M.meta_mensual || 0);
@@ -548,9 +549,9 @@ export async function generarSnapshotDiario(fecha: string) {
   //   Best-effort: si falla (p.ej. tabla aún no migrada, o race del índice único),
   //   NO rompe el snapshot ya guardado. Días bloqueados retornan arriba (backfill aparte).
   try {
-    await db.execute(sql`DELETE FROM cartera.facturacion_snapshot_detalle WHERE fecha = ${fecha}::date`);
+    await db.execute(sql`DELETE FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_detalle WHERE fecha = ${fecha}::date`);
     await db.execute(sql`
-      INSERT INTO cartera.facturacion_snapshot_detalle
+      INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_detalle
         (fecha, rubro, producto, origen, monto_total, monto_iva)
       SELECT ${fecha}::date, fd.rubro,
         CASE lower(trim(COALESCE(u.categoria, fd.categoria)))
@@ -562,10 +563,10 @@ export async function generarSnapshotDiario(fecha: string) {
         END,
         CASE WHEN fd.pago_id IS NULL THEN 'nuevo' ELSE 'pago' END,
         SUM(fd.monto_total), SUM(fd.monto_iva)
-      FROM cartera.facturacion_desglose fd
-      LEFT JOIN cartera.pagos_credito p ON p.pago_id   = fd.pago_id
-      LEFT JOIN cartera.creditos      c ON c.credito_id = p.credito_id
-      LEFT JOIN cartera.usuarios      u ON u.usuario_id = c.usuario_id
+      FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito p ON p.pago_id   = fd.pago_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos      c ON c.credito_id = p.credito_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.usuarios      u ON u.usuario_id = c.usuario_id
       WHERE fd.fecha_aplicado_gt = ${fecha}::date
         AND fd.rubro::text <> 'CAPITAL'                            -- capital se toma del pci (abajo)
         AND NOT (fd.pago_id IS NULL AND fd.rubro::text = 'MORA')   -- mora genérica fuera (= snapshot)
@@ -586,9 +587,9 @@ export async function generarSnapshotDiario(fecha: string) {
     `);
     // CAPITAL desde pci de CUBE (igual que capital_total) → reconcilia con el snapshot
     await db.execute(sql`
-      INSERT INTO cartera.facturacion_snapshot_detalle
+      INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_detalle
         (fecha, rubro, producto, origen, monto_total, monto_iva)
-      SELECT ${fecha}::date, 'CAPITAL'::cartera.rubro_facturacion,
+      SELECT ${fecha}::date, 'CAPITAL'::${SQL_CARTERA_SCHEMA}.rubro_facturacion,
         CASE lower(trim(u.categoria))
           WHEN 'cv vehículo' THEN 'autocompras'
           WHEN 'cv vehículo nuevo' THEN 'nuevo_autocompras'
@@ -597,11 +598,11 @@ export async function generarSnapshotDiario(fecha: string) {
           ELSE 'sin_producto'
         END,
         'pago', SUM(pci.abono_capital), 0
-      FROM cartera.pagos_credito p
-      JOIN cartera.creditos c ON c.credito_id = p.credito_id
-      JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-      JOIN cartera.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
-      JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p
+      JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = p.credito_id
+      JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+      JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci ON pci.pago_id = p.pago_id
+      JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
       WHERE (p.fecha_aplicado AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date = ${fecha}::date
         AND p.validation_status IN ('validated','pending','reset','capital','capital_validated')
         AND c."statusCredit" IN
@@ -629,7 +630,7 @@ export async function generarSnapshotDiario(fecha: string) {
 export async function aplicarManualesEnSnapshotDia(fecha: string) {
   const [y, m] = fecha.split("-").map(Number);
   const hayDesglose = await db.execute(sql`
-    SELECT 1 FROM cartera.facturacion_desglose WHERE fecha_aplicado_gt = ${fecha}::date LIMIT 1
+    SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose WHERE fecha_aplicado_gt = ${fecha}::date LIMIT 1
   `);
   if (((hayDesglose as any).rows ?? []).length > 0) {
     // Día del sistema: rubros + administrativos + oi_* + otros + capital derivan del
@@ -651,9 +652,9 @@ export async function aplicarManualesEnSnapshotDia(fecha: string) {
     return { success: true };
   }
   await db.execute(sql`
-    UPDATE cartera.facturacion_snapshot_diario SET
+    UPDATE ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario SET
       ingreso_carros = COALESCE((
-        SELECT SUM(monto) FROM cartera.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
+        SELECT SUM(monto) FROM ${SQL_CARTERA_SCHEMA}.ingresos_carros c WHERE c.fecha = ${fecha}::date), 0),
       updated_at = now()
     WHERE fecha = ${fecha}::date AND bloqueado = false
   `);
@@ -667,7 +668,7 @@ export async function aplicarManualesEnSnapshotDia(fecha: string) {
 //    deben refrescar también en días bloqueados (el lock vive en generarSnapshotDiario).
 export async function aplicarMetaEnSnapshotsMes(anio: number, mes: number) {
   const res = await db.execute(sql`
-    UPDATE cartera.facturacion_snapshot_diario s
+    UPDATE ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario s
     SET meta_facturacion_mensual = m.meta_mensual,
         meta_facturacion_semanal = m.meta_semanal,
         meta_facturacion_diaria  = m.meta_diaria,
@@ -677,7 +678,7 @@ export async function aplicarMetaEnSnapshotsMes(anio: number, mes: number) {
           THEN ROUND(s.facturacion_acumulado / m.meta_mensual * 100, 4)
           ELSE 0 END,
         updated_at = now()
-    FROM cartera.metas_facturacion m
+    FROM ${SQL_CARTERA_SCHEMA}.metas_facturacion m
     WHERE m.anio = ${anio} AND m.mes = ${mes}
       AND s.fecha >= make_date(${anio}, ${mes}, 1)
       AND s.fecha < (make_date(${anio}, ${mes}, 1) + INTERVAL '1 month')
@@ -739,7 +740,7 @@ export async function listarDetalleSnapshot(params: {
   const res = await db.execute(sql`
     SELECT rubro::text AS rubro, producto, origen,
            monto_total::float8 AS monto_total, monto_iva::float8 AS monto_iva
-    FROM cartera.facturacion_snapshot_detalle
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_detalle
     WHERE fecha = ${fecha}::date
       ${rubro ? sql`AND rubro::text = ${rubro}` : sql``}
     ORDER BY rubro, producto, origen
@@ -937,10 +938,10 @@ export async function generarExcelFacturacionDiaria(
   const det = await db.execute(sql`
     SELECT fecha::text AS fecha, rubro::text AS rubro, producto, origen,
            monto_total::float8 AS monto
-    FROM cartera.facturacion_snapshot_detalle
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_detalle
     WHERE fecha BETWEEN ${fechaInicio}::date AND ${fechaFin}::date
       AND fecha NOT IN (
-        SELECT fecha FROM cartera.facturacion_snapshot_diario WHERE bloqueado = true
+        SELECT fecha FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario WHERE bloqueado = true
       )
   `);
   const idx: Record<string, Record<string, Record<string, { nuevo: number; pago: number }>>> = {};
@@ -1132,7 +1133,7 @@ export async function guardarCeldasSnapshot(input: {
   // llenaría (la salta por bloqueado). Mismo patrón que aplicarManualesEnSnapshotDia.
   for (const c of cambios) {
     const ex = await db.execute(sql`
-      SELECT 1 FROM cartera.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date LIMIT 1
+      SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date LIMIT 1
     `);
     if ((((ex as any).rows ?? ex) as any[]).length === 0) {
       await generarSnapshotDiario(c.fecha);
@@ -1152,7 +1153,7 @@ export async function guardarCeldasSnapshot(input: {
 
       // Fila actual (para valores viejos + saber si ya estaba bloqueado).
       const prevRes = await tx.execute(sql`
-        SELECT * FROM cartera.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date
+        SELECT * FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario WHERE fecha = ${c.fecha}::date
       `);
       const prev = ((prevRes as any).rows ?? prevRes)[0] ?? null;
 
@@ -1165,7 +1166,7 @@ export async function guardarCeldasSnapshot(input: {
 
       if (prev) {
         await tx.execute(sql`
-          UPDATE cartera.facturacion_snapshot_diario
+          UPDATE ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario
           SET ${sql.join(sets, sql`, `)},
               bloqueado = true, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
           WHERE fecha = ${c.fecha}::date
@@ -1190,7 +1191,7 @@ export async function guardarCeldasSnapshot(input: {
           sql`now()`,
         ];
         await tx.execute(sql`
-          INSERT INTO cartera.facturacion_snapshot_diario (${sql.join(
+          INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario (${sql.join(
             insertCols.map((x) => sql.raw(x)),
             sql`, `
           )})
@@ -1202,7 +1203,7 @@ export async function guardarCeldasSnapshot(input: {
       for (const col of cols) {
         const anterior = prev ? prev[col] ?? null : null;
         await tx.execute(sql`
-          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
           VALUES (${c.fecha}::date, ${col}, ${
           anterior === null ? null : String(anterior)
         }, ${valOf(col)}, 'edit', ${usuarioId})
@@ -1211,7 +1212,7 @@ export async function guardarCeldasSnapshot(input: {
       // Auditoría de lock si no estaba bloqueado.
       if (!prev || prev.bloqueado !== true) {
         await tx.execute(sql`
-          INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+          INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
           VALUES (${c.fecha}::date, '*', NULL, NULL, 'lock', ${usuarioId})
         `);
       }
@@ -1243,12 +1244,12 @@ export async function desbloquearDiaSnapshot(
   const anio = Number(y);
   const mes = Number(m);
   await db.execute(sql`
-    UPDATE cartera.facturacion_snapshot_diario
+    UPDATE ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario
     SET bloqueado = false, bloqueado_por = ${usuarioId}, bloqueado_at = now(), updated_at = now()
     WHERE fecha = ${fecha}::date
   `);
   await db.execute(sql`
-    INSERT INTO cartera.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
+    INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_auditoria (fecha, columna, valor_anterior, valor_nuevo, accion, usuario_id)
     VALUES (${fecha}::date, '*', NULL, NULL, 'unlock', ${usuarioId})
   `);
   // Vuelve a valores del sistema y refresca acumulados.
@@ -1280,8 +1281,8 @@ export async function listarAuditoriaSnapshot(opts: {
            -- convierte a America/Guatemala.
            to_char((a.created_at AT TIME ZONE 'UTC') AT TIME ZONE 'America/Guatemala',
                    'DD/MM/YYYY HH24:MI:SS') AS created_at
-    FROM cartera.facturacion_snapshot_auditoria a
-    LEFT JOIN cartera.platform_users u ON u.id = a.usuario_id
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_auditoria a
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.platform_users u ON u.id = a.usuario_id
     ${whereSql}
     ORDER BY a.created_at DESC
     LIMIT ${lim}

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -1,4 +1,5 @@
 // app.ts (o donde declares tus rutas Elysia)
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import { z } from "zod";
 import { formatToUSD } from "../utils/functions/currencyConverter";
 import { USD_EXCHANGE_RATE } from "../utils/functions/const";
@@ -1281,9 +1282,9 @@ export async function resumeInvestor(
    tiene_boleta_pendiente: sql<boolean>`
       EXISTS (
         SELECT 1
-        FROM cartera.boletas_pago_inversionista
-        WHERE cartera.boletas_pago_inversionista.inversionista_id = ${inversionistas.inversionista_id}
-        AND cartera.boletas_pago_inversionista.estado = 'PENDIENTE'
+        FROM ${SQL_CARTERA_SCHEMA}.boletas_pago_inversionista
+        WHERE ${SQL_CARTERA_SCHEMA}.boletas_pago_inversionista.inversionista_id = ${inversionistas.inversionista_id}
+        AND ${SQL_CARTERA_SCHEMA}.boletas_pago_inversionista.estado = 'PENDIENTE'
       )
     `.as('tiene_boleta_pendiente'),
     })

--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, gte, inArray, lte, sql } from "drizzle-orm";
 import { client, db } from "../database";
-import { asesor_bucket, asesores, buckets, buckets_historial, credito_asesor_historial, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, pagos_credito, platform_users, usuarios } from "../database/db/schema";
+import { asesor_bucket, asesores, buckets, buckets_historial, CARTERA_SCHEMA, credito_asesor_historial, creditos, cuotas_credito, moras_condonaciones, moras_credito, moras_historial, pagos_credito, platform_users, SQL_CARTERA_SCHEMA, usuarios } from "../database/db/schema";
 import Big from "big.js";
 import { toZonedTime } from "date-fns-tz";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
@@ -301,12 +301,12 @@ export async function createMora({
     // 10× la fórmula de 7 cuotas. Misma lógica que procesarMoras (isOverdueInstallmentForMora).
     const ovRes = await db.execute<any>(sql`
       SELECT COUNT(*)::int AS n
-      FROM cartera.cuotas_credito cu
+      FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
       WHERE cu.credito_id = ${credito_id}
         AND cu.fecha_vencimiento::date < (now() AT TIME ZONE 'America/Guatemala')::date
         AND cu.pagado = false
         AND NOT EXISTS (
-          SELECT 1 FROM cartera.pagos_credito pc
+          SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
           WHERE pc.cuota_id = cu.cuota_id AND pc."paymentFalse" = false AND pc.pagado = true
             AND pc.validation_status IN ('validated', 'no_required'))`);
     const cuotasReales = Number(ovRes.rows?.[0]?.n ?? 0);
@@ -768,7 +768,7 @@ export async function procesarMoras() {
         asesor_id: creditos.asesor_id, // FASE 3: dueño actual (para reasignar por bucket)
         hasPaidPayment: sql<boolean>`EXISTS (
           SELECT 1
-          FROM cartera.pagos_credito pc
+          FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
           WHERE pc.cuota_id = ${cuotas_credito.cuota_id}
             AND pc."paymentFalse" = false
             AND pc.pagado = true
@@ -1033,7 +1033,7 @@ export async function procesarMoras() {
 
       if (catalogoBuckets.length === 0) {
         console.warn(
-          "[BUCKETS] ⚠️ Catálogo `cartera.buckets` vacío (¿migración/seed sin aplicar?) — se omite el registro de transiciones.",
+          `[BUCKETS] ⚠️ Catálogo \`${CARTERA_SCHEMA}.buckets\` vacío (¿migración/seed sin aplicar?) — se omite el registro de transiciones.`,
         );
       } else {
       // status y asesor por crédito — ya vienen en `cuotas` (el job los cargó con JOIN)
@@ -1050,7 +1050,7 @@ export async function procesarMoras() {
       const ultimoBucket = new Map<number, number>();
       const ultimosRes = await lockConn.query(
         `SELECT DISTINCT ON (credito_id) credito_id, bucket_nuevo
-           FROM cartera.buckets_historial
+           FROM ${CARTERA_SCHEMA}.buckets_historial
           ORDER BY credito_id, fecha DESC, historial_id DESC`,
       );
       for (const row of ultimosRes.rows) {

--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -1,4 +1,5 @@
 import { db } from "../database";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import { sql } from "drizzle-orm";
 import ExcelJS from "exceljs";
 
@@ -34,7 +35,7 @@ const snapCte = (fecha: string) => sql`
         PARTITION BY h.credito_id
         ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
       ) AS cuotas
-    FROM cartera.moras_historial h
+    FROM ${SQL_CARTERA_SCHEMA}.moras_historial h
     -- Corte por DÍA Guatemala: fecha es timestamp UTC (defaultNow, session UTC) y el cron
     -- corre ~23:59 GT (≈06:00 UTC del día siguiente); comparar en GT evita correr esos
     -- eventos al día siguiente.
@@ -72,9 +73,9 @@ function buildSnapshotWhere(a: SnapshotArgs) {
 
 const snapFromJoins = sql`
   FROM snap s
-  INNER JOIN cartera.creditos c ON c.credito_id = s.credito_id
-  INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-  INNER JOIN cartera.asesores a ON a.asesor_id = c.asesor_id`;
+  INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = s.credito_id
+  INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+  INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id`;
 
 // Snapshot por crédito de la mora a una fecha, con totales y filtros.
 export async function getMoraHistorialSnapshot(a: SnapshotArgs) {
@@ -145,8 +146,8 @@ export async function getMoraTimeline({ desde, hasta, asesor, etapa }: { desde: 
     const names = asesor.split(",").map((n) => n.trim()).filter(Boolean);
     if (names.length) {
       asesorFilter = sql` AND h.credito_id IN (
-        SELECT c.credito_id FROM cartera.creditos c
-        INNER JOIN cartera.asesores a ON a.asesor_id = c.asesor_id
+        SELECT c.credito_id FROM ${SQL_CARTERA_SCHEMA}.creditos c
+        INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
         WHERE (${sql.join(names.map((n) => sql`a.nombre ILIKE ${"%" + n + "%"}`), sql` OR `)})
       )`;
     }
@@ -172,7 +173,7 @@ export async function getMoraTimeline({ desde, hasta, asesor, etapa }: { desde: 
               PARTITION BY h.credito_id
               ORDER BY (h.cuotas_atrasadas_nuevas > 0) DESC, h.fecha DESC, h.historial_id DESC
             ) AS cuotas
-          FROM cartera.moras_historial h
+          FROM ${SQL_CARTERA_SCHEMA}.moras_historial h
           WHERE (h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date <= d ${asesorFilter}
         ) hh
       ) s
@@ -201,8 +202,8 @@ export async function getMoraHistorialCredito({ credito_id }: { credito_id: numb
       h.cuotas_atrasadas_nuevas,
       h.motivo,
       pu.email AS usuario
-    FROM cartera.moras_historial h
-    LEFT JOIN cartera.platform_users pu ON pu.id = h.usuario_id
+    FROM ${SQL_CARTERA_SCHEMA}.moras_historial h
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.platform_users pu ON pu.id = h.usuario_id
     WHERE h.credito_id = ${credito_id}
     ORDER BY h.fecha DESC, h.historial_id DESC
   `);

--- a/apps/cartera-back/src/controllers/paymentAgreement.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement.ts
@@ -1,4 +1,5 @@
 import { and, eq, gte, inArray, isNull, lte, sql, sum } from "drizzle-orm";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import { db } from "../database";
 import {
   pagos_credito,
@@ -1436,12 +1437,12 @@ export const updateConvenioStatus = async (
       // coincida con el que recalcula createMora y no lo rechace por mismatch.
       const ovRes = await db.execute<any>(sql`
         SELECT COUNT(*)::int AS n
-        FROM cartera.cuotas_credito cu
+        FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
         WHERE cu.credito_id = ${creditoId}
           AND cu.fecha_vencimiento::date < (now() AT TIME ZONE 'America/Guatemala')::date
           AND cu.pagado = false
           AND NOT EXISTS (
-            SELECT 1 FROM cartera.pagos_credito pc
+            SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
             WHERE pc.cuota_id = cu.cuota_id AND pc."paymentFalse" = false AND pc.pagado = true
               AND pc.validation_status IN ('validated', 'no_required'))`);
       const numCuotasAtrasadas = Number(ovRes.rows?.[0]?.n ?? 0);

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1,4 +1,5 @@
 import { db } from "../database/index";
+import { CARTERA_SCHEMA, SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import {
   creditos,
   pagos_credito,
@@ -1850,13 +1851,13 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
         whereClauses.push(`(
           EXISTS (
             SELECT 1
-            FROM cartera.pagos_credito_inversionistas pci2
+            FROM ${CARTERA_SCHEMA}.pagos_credito_inversionistas pci2
             WHERE pci2.pago_id = p.pago_id
             AND pci2.inversionista_id = '${inversionistaId}'
           )
           OR EXISTS (
             SELECT 1
-            FROM cartera.facturacion_desglose fd_cube
+            FROM ${CARTERA_SCHEMA}.facturacion_desglose fd_cube
             WHERE fd_cube.pago_id = p.pago_id
             AND fd_cube.rubro::text = 'INTERES'
           )
@@ -1865,7 +1866,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
         whereClauses.push(`
           EXISTS (
             SELECT 1
-            FROM cartera.pagos_credito_inversionistas pci2
+            FROM ${CARTERA_SCHEMA}.pagos_credito_inversionistas pci2
             WHERE pci2.pago_id = p.pago_id
             AND pci2.inversionista_id = '${inversionistaId}'
           )
@@ -1913,9 +1914,9 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
     // 🔢 Query para contar el total de registros (SIN LIMIT)
     const countQuery = sql`
       SELECT COUNT(*) as total
-      FROM cartera.pagos_credito p
-      LEFT JOIN cartera.creditos c ON c.credito_id = p.credito_id
-      LEFT JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = p.credito_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
       ${sql.raw(whereSQL)}
     `;
 
@@ -1990,7 +1991,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
         --    (pendiente_facturar=true + tipo_operacion='compra_cartera').
         EXISTS (
           SELECT 1
-          FROM cartera.compras_credito_inversionista cci
+          FROM ${SQL_CARTERA_SCHEMA}.compras_credito_inversionista cci
           WHERE cci.credito_id = p.credito_id
             AND cci.pendiente_facturar = true
             AND cci.tipo_operacion = 'compra_cartera'
@@ -2003,7 +2004,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
             'numeroCuota', cq.numero_cuota,
             'fechaVencimiento', cq.fecha_vencimiento
           )
-          FROM cartera.cuotas_credito cq
+          FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cq
           WHERE cq.cuota_id = p.cuota_id
           LIMIT 1
         ) AS "cuota",
@@ -2032,9 +2033,9 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
               'porcentajeParticipacion', ci.porcentaje_participacion_inversionista
             )
           )
-          FROM cartera.pagos_credito_inversionistas pci
-          LEFT JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
-          LEFT JOIN cartera.creditos_inversionistas ci
+          FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci
+          LEFT JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
+          LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos_inversionistas ci
             ON ci.credito_id = pci.credito_id
             AND ci.inversionista_id = pci.inversionista_id
           WHERE pci.pago_id = p.pago_id
@@ -2048,7 +2049,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
               'urlBoleta', bol.url_boleta
             )
           )
-          FROM cartera.boletas bol
+          FROM ${SQL_CARTERA_SCHEMA}.boletas bol
           WHERE bol.pago_id = p.pago_id
         ), '[]'::json) AS "boletas",
 
@@ -2072,22 +2073,22 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
                   'monto', ma.monto
                 )
               )
-              FROM cartera.montos_adicionales ma
+              FROM ${SQL_CARTERA_SCHEMA}.montos_adicionales ma
               WHERE ma.credit_id = cc.credit_id
             ), '[]'::json)
           )
-          FROM cartera.credit_cancelations cc
+          FROM ${SQL_CARTERA_SCHEMA}.credit_cancelations cc
           WHERE cc.credit_id = p.credito_id
           ORDER BY cc.id DESC
           LIMIT 1
         ) ELSE NULL END AS "cancelacion"
 
-      FROM cartera.pagos_credito p
-      LEFT JOIN cartera.creditos c ON c.credito_id = p.credito_id
-      LEFT JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-      LEFT JOIN cartera.bancos b ON b.banco_id = p.banco_id
-      LEFT JOIN cartera.cuentas_empresa ce ON ce.cuenta_id = p.cuenta_empresa_id
-      LEFT JOIN cartera.asesores ase ON ase.asesor_id = c.asesor_id
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = p.credito_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.bancos b ON b.banco_id = p.banco_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.cuentas_empresa ce ON ce.cuenta_id = p.cuenta_empresa_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores ase ON ase.asesor_id = c.asesor_id
       ${sql.raw(whereSQL)}
       ORDER BY p.fecha_pago DESC
       LIMIT ${pageSize} OFFSET ${offset};
@@ -2110,7 +2111,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
     try {
       const cubeRow = await db.execute(sql`
         SELECT i.inversionista_id AS "id"
-        FROM cartera.inversionistas i
+        FROM ${SQL_CARTERA_SCHEMA}.inversionistas i
         WHERE UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
         ORDER BY i.inversionista_id ASC
         LIMIT 1
@@ -2141,8 +2142,8 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           ci.porcentaje_participacion_inversionista AS "porcentajeParticipacion",
           ci.porcentaje_cash_in AS "porcentajeCashIn",
           ci.monto_aportado AS "montoAportado"
-        FROM cartera.creditos_inversionistas ci
-        INNER JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+        FROM ${SQL_CARTERA_SCHEMA}.creditos_inversionistas ci
+        INNER JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = ci.inversionista_id
         WHERE ci.credito_id = ANY(${"{" + creditoIds.join(",") + "}"}::bigint[])
       `);
       for (const row of ciResult.rows as any[]) {
@@ -2170,7 +2171,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
         SELECT fd.pago_id AS "pagoId",
                SUM(fd.monto_total)::numeric AS "total",
                SUM(fd.monto_iva)::numeric   AS "iva"
-        FROM cartera.facturacion_desglose fd
+        FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd
         WHERE fd.pago_id = ANY(${"{" + pagoIds.join(",") + "}"}::bigint[])
           AND fd.rubro::text = 'INTERES'
         GROUP BY fd.pago_id
@@ -2356,12 +2357,12 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
         COALESCE(SUM(pci.abono_iva_12::numeric), 0) AS "totalAbonoIva",
         ROUND(COALESCE(SUM(pci.abono_interes::numeric), 0) * 0.05, 2) AS "totalIsr",
         COALESCE(SUM(ci.monto_aportado::numeric), 0) AS "totalMontoAportado"
-      FROM cartera.pagos_credito_inversionistas pci
-      INNER JOIN cartera.pagos_credito p ON p.pago_id = pci.pago_id
-      INNER JOIN cartera.creditos c ON c.credito_id = pci.credito_id
-      INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-      INNER JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
-      LEFT JOIN cartera.creditos_inversionistas ci
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito p ON p.pago_id = pci.pago_id
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = pci.credito_id
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos_inversionistas ci
         ON ci.credito_id = pci.credito_id
         AND ci.inversionista_id = pci.inversionista_id
       ${sql.raw(whereSQL)}
@@ -2399,32 +2400,32 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       const cubeInteres = await db.execute(sql`
         WITH pf AS (
           SELECT p.pago_id
-          FROM cartera.pagos_credito p
-          INNER JOIN cartera.creditos c ON c.credito_id = p.credito_id
-          INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+          FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p
+          INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = p.credito_id
+          INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
           ${sql.raw(whereSQL)}
         )
         SELECT
           COALESCE((SELECT SUM(fd.monto_total - fd.monto_iva)
-                    FROM cartera.facturacion_desglose fd
+                    FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd
                     WHERE fd.rubro::text='INTERES' AND fd.pago_id IN (SELECT pago_id FROM pf)), 0)
           + COALESCE((SELECT SUM(pci.abono_interes::numeric)
-                      FROM cartera.pagos_credito_inversionistas pci
-                      JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+                      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci
+                      JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
                       WHERE (UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%' OR i.inversionista_id = ${CUBE_ID})
                         AND pci.pago_id IN (SELECT pago_id FROM pf)
-                        AND NOT EXISTS (SELECT 1 FROM cartera.facturacion_desglose fd2
+                        AND NOT EXISTS (SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd2
                                          WHERE fd2.pago_id = pci.pago_id AND fd2.rubro::text='INTERES')), 0)
           AS "net",
           COALESCE((SELECT SUM(fd.monto_iva)
-                    FROM cartera.facturacion_desglose fd
+                    FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd
                     WHERE fd.rubro::text='INTERES' AND fd.pago_id IN (SELECT pago_id FROM pf)), 0)
           + COALESCE((SELECT SUM(pci.abono_iva_12::numeric)
-                      FROM cartera.pagos_credito_inversionistas pci
-                      JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+                      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci
+                      JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
                       WHERE (UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%' OR i.inversionista_id = ${CUBE_ID})
                         AND pci.pago_id IN (SELECT pago_id FROM pf)
-                        AND NOT EXISTS (SELECT 1 FROM cartera.facturacion_desglose fd2
+                        AND NOT EXISTS (SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose fd2
                                          WHERE fd2.pago_id = pci.pago_id AND fd2.rubro::text='INTERES')), 0)
           AS "iva"
       `);

--- a/apps/cartera-back/src/controllers/paymentsByAdvisor.ts
+++ b/apps/cartera-back/src/controllers/paymentsByAdvisor.ts
@@ -1,4 +1,5 @@
 import { db } from "../database/index";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import {
   asesores,
   convenio_cuotas,
@@ -64,10 +65,10 @@ export const getCuotasPorDiaYAsesor = async (
         pagado: sql<boolean>`
           CASE
             WHEN EXISTS (
-              SELECT 1 FROM cartera.pagos_credito pc
+              SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
               WHERE pc.cuota_id = ${cuotas_credito.cuota_id}
             ) AND NOT EXISTS (
-              SELECT 1 FROM cartera.pagos_credito pc
+              SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
               WHERE pc.cuota_id = ${cuotas_credito.cuota_id}
               AND pc.pagado = false
             ) THEN true

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1,4 +1,5 @@
 import { sql } from "drizzle-orm";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import { db } from "../database";
 
 type Periodo = "anio" | "trimestre" | "mes" | "semana" | "dia";
@@ -27,8 +28,8 @@ export async function getMontoACobrar({
       SELECT DISTINCT
         DATE_TRUNC(${pg}, c.fecha_vencimiento::timestamp) AS bucket,
         cr.credito_id
-      FROM cartera.cuotas_credito c
-      JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+      FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito c
+      JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON c.credito_id = cr.credito_id
       WHERE c.pagado = false
         AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
         AND c.fecha_vencimiento >= ${fechaInicio}::date
@@ -39,7 +40,7 @@ export async function getMontoACobrar({
         bc.bucket,
         AVG(COALESCE(m.monto_mora::numeric, 0)) AS mora_promedio
       FROM bucket_creditos bc
-      LEFT JOIN cartera.moras_credito m ON m.credito_id = bc.credito_id AND m.activa = true
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m ON m.credito_id = bc.credito_id AND m.activa = true
       GROUP BY bc.bucket
     )
     SELECT
@@ -53,8 +54,8 @@ export async function getMontoACobrar({
       COALESCE(SUM(cr.membresias_pago::numeric), 0) AS total_membresias,
       COALESCE(SUM(cr.royalti::numeric / NULLIF(cr.plazo::numeric, 0)), 0) AS total_royalti,
       COALESCE(mpb.mora_promedio, 0) AS mora_promedio
-    FROM cartera.cuotas_credito c
-    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+    FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito c
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON c.credito_id = cr.credito_id
     JOIN mora_por_bucket mpb ON mpb.bucket = DATE_TRUNC(${pg}, c.fecha_vencimiento::timestamp)
     WHERE c.pagado = false
       AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
@@ -100,8 +101,8 @@ export async function getMontoACobrarPeriodo({
         COALESCE(MIN(pc.gps_restante::numeric)     FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.abono_gps::numeric)      FILTER (WHERE NOT pc."paymentFalse"), 0)  AS gps_restante,
         COALESCE(MIN(pc.membresias::numeric)       FILTER (WHERE NOT pc."paymentFalse"), 0) + COALESCE(SUM(pc.membresias_pago::numeric) FILTER (WHERE NOT pc."paymentFalse"), 0) AS membresias,
         SUM(COALESCE(pc.monto_boleta::numeric, 0))                                                                         AS monto_boleta
-      FROM cartera.pagos_credito pc
-      JOIN cartera.cuotas_credito q ON q.cuota_id = pc.cuota_id
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
+      JOIN ${SQL_CARTERA_SCHEMA}.cuotas_credito q ON q.cuota_id = pc.cuota_id
       WHERE q.fecha_vencimiento::date >= ${fechaInicio}::date
         AND q.fecha_vencimiento::date <= ${fechaFin}::date
       GROUP BY pc.credito_id, pc.cuota_id, q.fecha_vencimiento
@@ -119,7 +120,7 @@ export async function getMontoACobrarPeriodo({
         COALESCE(pc.gps_restante::numeric, 0)      + COALESCE(pc.abono_gps::numeric, 0)                 AS gps_restante,
         COALESCE(pc.membresias::numeric, 0)        + COALESCE(pc.membresias_pago::numeric, 0)           AS membresias,
         COALESCE(pc.monto_boleta::numeric, 0)                                                            AS monto_boleta
-      FROM cartera.pagos_credito pc
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
       WHERE pc."paymentFalse" = false
         AND pc.cuota_id IS NULL
         AND pc.fecha_vencimiento::date >= ${fechaInicio}::date
@@ -141,12 +142,12 @@ export async function getMontoACobrarPeriodo({
              THEN COALESCE(MAX(hist_mora.monto_mora), 0)
              ELSE 0 END                                                 AS mora_val
       FROM pagos_en_rango p
-      INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
-      INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
-      INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON p.credito_id = c.credito_id
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON c.usuario_id = u.usuario_id
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON c.asesor_id = a.asesor_id
       LEFT JOIN LATERAL (
         SELECT COALESCE(mh.monto_nuevo, 0) AS monto_mora
-        FROM cartera.moras_historial mh
+        FROM ${SQL_CARTERA_SCHEMA}.moras_historial mh
         WHERE mh.credito_id = c.credito_id
           AND (mh.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala') < DATE_TRUNC(${pg}, p.fecha_venc::timestamp) + ${pgInterval}
         ORDER BY mh.fecha DESC
@@ -154,8 +155,8 @@ export async function getMontoACobrarPeriodo({
       ) hist_mora ON true
       LEFT JOIN LATERAL (
         SELECT pc_a.total_restante::numeric AS total_restante
-        FROM cartera.pagos_credito pc_a
-        LEFT JOIN cartera.cuotas_credito qcc_a ON pc_a.cuota_id = qcc_a.cuota_id
+        FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc_a
+        LEFT JOIN ${SQL_CARTERA_SCHEMA}.cuotas_credito qcc_a ON pc_a.cuota_id = qcc_a.cuota_id
         WHERE pc_a.credito_id = c.credito_id
           AND pc_a."paymentFalse" = false
           AND pc_a.total_restante IS NOT NULL
@@ -178,11 +179,11 @@ export async function getMontoACobrarPeriodo({
       ) cap_anterior ON true
       LEFT JOIN LATERAL (
         SELECT COUNT(*)::int AS cuotas_atrasadas
-        FROM cartera.cuotas_credito qc_mora
+        FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito qc_mora
         WHERE qc_mora.credito_id = c.credito_id
           AND qc_mora.fecha_vencimiento::date < p.fecha_venc::date
           AND NOT EXISTS (
-            SELECT 1 FROM cartera.pagos_credito pc_mora
+            SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc_mora
             WHERE pc_mora.cuota_id = qc_mora.cuota_id
               AND pc_mora."paymentFalse" = false
               AND pc_mora.pagado = true
@@ -244,14 +245,14 @@ export async function getMontoACobrarPeriodo({
             COALESCE(MIN(pc_a.seguro_restante::numeric),  0) AS seguro_restante,
             COALESCE(MIN(pc_a.gps_restante::numeric),     0) AS gps_restante,
             COALESCE(MIN(pc_a.membresias::numeric),       0) AS membresias
-          FROM cartera.cuotas_credito q_a
-          LEFT JOIN cartera.pagos_credito pc_a
+          FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito q_a
+          LEFT JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito pc_a
             ON pc_a.cuota_id = q_a.cuota_id
             AND pc_a."paymentFalse" = false
           WHERE q_a.credito_id = calc.credito_id
             AND q_a.fecha_vencimiento::date < calc.bucket
             AND NOT EXISTS (
-              SELECT 1 FROM cartera.pagos_credito pc2
+              SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc2
               WHERE pc2.cuota_id = q_a.cuota_id
                 AND pc2."paymentFalse" = false
                 AND pc2.pagado = true
@@ -305,9 +306,9 @@ export async function getMontoACobrarPeriodo({
       SELECT
         DATE_TRUNC(${pg}, (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::timestamp) AS pagos_bucket,
         COALESCE(SUM(pci.abono_interes::numeric + pci.abono_iva_12::numeric), 0)        AS total_interes_inversionista
-      FROM cartera.pagos_credito_inversionistas pci
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci
       WHERE pci.inversionista_id IN (
-        SELECT inversionista_id FROM cartera.inversionistas WHERE permite_distribucion = false
+        SELECT inversionista_id FROM ${SQL_CARTERA_SCHEMA}.inversionistas WHERE permite_distribucion = false
       )
         AND (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::date >= ${fechaInicio}::date
         AND (pci.fecha_pago AT TIME ZONE 'America/Guatemala')::date <= ${fechaFin}::date
@@ -384,8 +385,8 @@ export async function getCobradoDelMes({
       COALESCE(SUM(p.abono_seguro::numeric), 0) AS cobrado_seguro,
       COALESCE(SUM(p.abono_gps::numeric), 0) AS cobrado_gps,
       COALESCE(SUM(p.membresias_pago::numeric), 0) AS cobrado_membresias
-    FROM cartera.pagos_credito p
-    JOIN cartera.creditos cr ON p.credito_id = cr.credito_id
+    FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON p.credito_id = cr.credito_id
     WHERE p.fecha_pago >= ${inicioMesUtc.toISOString()}::timestamptz
       AND p.fecha_pago < ${inicioMesSiguienteUtc.toISOString()}::timestamptz
       AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO', 'CANCELADO')
@@ -420,7 +421,7 @@ export async function getCobradoDelMesSnapshot({
       COALESCE(SUM(royalty::numeric), 0)                AS cobrado_royalti,
       COALESCE(SUM(mora_cube::numeric), 0)              AS cobrado_mora,
       COALESCE(SUM(otros_ingresos::numeric), 0)         AS cobrado_otros
-    FROM cartera.facturacion_snapshot_diario
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario
     WHERE fecha >= ${inicioMes}::date
       AND fecha < (${inicioMes}::date + INTERVAL '1 month')
   `);
@@ -445,7 +446,7 @@ export async function getEsperadoDelMesMeta({
 }) {
   const result = await db.execute(sql`
     SELECT meta_mensual
-    FROM cartera.metas_facturacion
+    FROM ${SQL_CARTERA_SCHEMA}.metas_facturacion
     WHERE anio = ${anio} AND mes = ${mes}
     LIMIT 1
   `);
@@ -476,11 +477,11 @@ export async function getFlujoCuotasInversiones({
       COALESCE(SUM(ci.monto_inversionista::numeric), 0) AS total_interes,
       COALESCE(SUM(ci.iva_inversionista::numeric), 0)   AS total_iva,
       MAX(i.monto_reinversion::numeric)                  AS monto_reinversion_inv
-    FROM cartera.cuotas_credito c
-    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
-    JOIN cartera.creditos_inversionistas ci ON cr.credito_id = ci.credito_id
-    JOIN cartera.inversionistas i ON ci.inversionista_id = i.inversionista_id
-    LEFT JOIN cartera.creditos_inversionistas_espejo ce
+    FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito c
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON c.credito_id = cr.credito_id
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos_inversionistas ci ON cr.credito_id = ci.credito_id
+    JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON ci.inversionista_id = i.inversionista_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos_inversionistas_espejo ce
       ON cr.credito_id = ce.credito_id AND ci.inversionista_id = ce.inversionista_id
     WHERE c.pagado = false
       AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
@@ -492,7 +493,7 @@ export async function getFlujoCuotasInversiones({
 
   const extrasRows = await db.execute(sql`
     SELECT tipo, COALESCE(SUM(monto::numeric), 0) AS total
-    FROM cartera.abonos_capital
+    FROM ${SQL_CARTERA_SCHEMA}.abonos_capital
     WHERE created_at::date >= ${fechaInicio}::date
       AND created_at::date <= ${fechaFin}::date
     GROUP BY tipo
@@ -618,11 +619,11 @@ export async function getFlujoCuotasPorInversionista({
       COALESCE(SUM(ci.monto_inversionista::numeric), 0) AS total_interes,
       COALESCE(SUM(ci.iva_inversionista::numeric), 0)   AS total_iva,
       MAX(i.monto_reinversion::numeric)                  AS monto_reinversion_inv
-    FROM cartera.cuotas_credito c
-    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
-    JOIN cartera.creditos_inversionistas ci ON cr.credito_id = ci.credito_id
-    JOIN cartera.inversionistas i ON ci.inversionista_id = i.inversionista_id
-    LEFT JOIN cartera.creditos_inversionistas_espejo ce
+    FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito c
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON c.credito_id = cr.credito_id
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos_inversionistas ci ON cr.credito_id = ci.credito_id
+    JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON ci.inversionista_id = i.inversionista_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos_inversionistas_espejo ce
       ON cr.credito_id = ce.credito_id AND ci.inversionista_id = ce.inversionista_id
     WHERE c.pagado = false
       AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
@@ -753,8 +754,8 @@ export async function getReinversionLiquidaciones({
       COALESCE(SUM(l.total_isr::numeric), 0)                AS total_isr,
       COALESCE(SUM(l.total_cuota::numeric), 0)              AS total_cuota,
       COUNT(*)::int                                          AS cantidad
-    FROM cartera.liquidaciones l
-    JOIN cartera.inversionistas i ON l.inversionista_id = i.inversionista_id
+    FROM ${SQL_CARTERA_SCHEMA}.liquidaciones l
+    JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON l.inversionista_id = i.inversionista_id
     WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
       AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
     GROUP BY i.tipo_reinversion
@@ -802,7 +803,7 @@ export async function getReinversionLiquidaciones({
       COALESCE(SUM(l.total_interes::numeric), 0)   AS total_interes,
       COALESCE(SUM(l.total_iva::numeric), 0)       AS total_iva,
       COALESCE(SUM(l.total_isr::numeric), 0)       AS total_isr
-    FROM cartera.liquidaciones l
+    FROM ${SQL_CARTERA_SCHEMA}.liquidaciones l
     WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
       AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
     GROUP BY (l.total_isr::numeric > 0)
@@ -840,8 +841,8 @@ export async function getReinversionLiquidaciones({
         * (100 - pe.porcentaje_participacion::numeric)
         / pe.porcentaje_participacion::numeric
     ), 0) AS interes_cube
-    FROM cartera.pagos_credito_inversionistas_espejo pe
-    JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
+    FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas_espejo pe
+    JOIN ${SQL_CARTERA_SCHEMA}.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
     WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
       AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
       AND pe.inversionista_id <> 86
@@ -857,11 +858,11 @@ export async function getReinversionLiquidaciones({
   // Cada abono se cuenta una sola vez (DISTINCT) aunque tenga varios pagos espejo.
   const extrasRows = await db.execute(sql`
     SELECT a.tipo, COALESCE(SUM(a.monto::numeric), 0) AS total
-    FROM cartera.abonos_capital a
+    FROM ${SQL_CARTERA_SCHEMA}.abonos_capital a
     WHERE a.abono_id IN (
       SELECT DISTINCT e.abono_capital_id
-      FROM cartera.pagos_credito_inversionistas_espejo e
-      JOIN cartera.liquidaciones l ON l.liquidacion_id = e.liquidacion_id
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas_espejo e
+      JOIN ${SQL_CARTERA_SCHEMA}.liquidaciones l ON l.liquidacion_id = e.liquidacion_id
       WHERE e.abono_capital_id IS NOT NULL
         AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
         AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
@@ -889,10 +890,10 @@ export async function getReinversionLiquidaciones({
         SUM(pe.abono_capital::numeric)                 AS abono,
         COALESCE(MAX(ce.monto_aportado::numeric), 0)   AS monto_aportado,
         bool_and(ce.id IS NULL)                        AS sin_fila
-      FROM cartera.pagos_credito_inversionistas_espejo pe
-      JOIN cartera.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
-      JOIN cartera.creditos cr ON cr.credito_id = pe.credito_id
-      LEFT JOIN cartera.creditos_inversionistas_espejo ce
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas_espejo pe
+      JOIN ${SQL_CARTERA_SCHEMA}.liquidaciones l ON l.liquidacion_id = pe.liquidacion_id
+      JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON cr.credito_id = pe.credito_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.creditos_inversionistas_espejo ce
         ON ce.credito_id = pe.credito_id
        AND ce.inversionista_id = pe.inversionista_id
       WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
@@ -921,8 +922,8 @@ export async function getReinversionLiquidaciones({
       COALESCE(SUM(l.reinversion_interes::numeric), 0) AS reinversion_interes,
       COALESCE(SUM(l.reinversion_total::numeric), 0)   AS reinversion,
       COALESCE(SUM(l.total_cuota::numeric), 0)         AS a_recibir
-    FROM cartera.liquidaciones l
-    JOIN cartera.inversionistas i ON l.inversionista_id = i.inversionista_id
+    FROM ${SQL_CARTERA_SCHEMA}.liquidaciones l
+    JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON l.inversionista_id = i.inversionista_id
     WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
       AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
     GROUP BY l.inversionista_id, i.nombre, i.tipo_reinversion
@@ -937,8 +938,8 @@ export async function getReinversionLiquidaciones({
     SELECT
       h.inversionista_id,
       COALESCE(SUM(h.monto_aportado::numeric), 0) AS monto_aportado
-    FROM cartera.historico_liquidaciones_espejo h
-    JOIN cartera.liquidaciones l ON l.liquidacion_id = h.liquidacion_id
+    FROM ${SQL_CARTERA_SCHEMA}.historico_liquidaciones_espejo h
+    JOIN ${SQL_CARTERA_SCHEMA}.liquidaciones l ON l.liquidacion_id = h.liquidacion_id
     WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
       AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
     GROUP BY h.inversionista_id
@@ -987,7 +988,7 @@ export async function getReinversionLiquidaciones({
       COALESCE(c.tipo_reinversion::text, 'sin_reinversion') AS tipo,
       COUNT(DISTINCT (c.inversionista_id, ${fechaCompra}))::int AS cantidad,
       COALESCE(SUM(c.monto_aportado::numeric), 0) AS monto
-    FROM cartera.compras_credito_inversionista c
+    FROM ${SQL_CARTERA_SCHEMA}.compras_credito_inversionista c
     WHERE c.tipo_operacion = 'compra_cartera'
       AND c.status = 'completado'
       AND (${fechaCompra} AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
@@ -1052,8 +1053,8 @@ export async function getEsperadoDelMes({
       COALESCE(SUM(cr.seguro_10_cuotas::numeric), 0) AS esperado_seguro,
       COALESCE(SUM(cr.gps::numeric), 0) AS esperado_gps,
       COALESCE(SUM(cr.membresias_pago::numeric), 0) AS esperado_membresias
-    FROM cartera.cuotas_credito c
-    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+    FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito c
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON c.credito_id = cr.credito_id
     WHERE c.fecha_vencimiento >= ${inicioMes}::date
       AND c.fecha_vencimiento < ${inicioMesSiguiente}::date
       AND cr."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
@@ -1086,7 +1087,7 @@ export async function getColocacionPorPeriodo({
       DATE_TRUNC(${pg}, (cr.fecha_creacion AT TIME ZONE 'America/Guatemala')::timestamp) AS bucket,
       COUNT(cr.credito_id)::int AS cantidad_creditos,
       COALESCE(SUM(cr.capital::numeric), 0) AS total_colocacion
-    FROM cartera.creditos cr
+    FROM ${SQL_CARTERA_SCHEMA}.creditos cr
     WHERE (cr.fecha_creacion AT TIME ZONE 'America/Guatemala')::date >= ${fechaInicio}::date
       AND (cr.fecha_creacion AT TIME ZONE 'America/Guatemala')::date <= ${fechaFin}::date
     GROUP BY DATE_TRUNC(${pg}, (cr.fecha_creacion AT TIME ZONE 'America/Guatemala')::timestamp)
@@ -1107,7 +1108,7 @@ export async function getComparativoHistorico({ anio }: { anio: number }) {
     SELECT DISTINCT ON (mes)
       mes,
       acumulado_total AS cobrado
-    FROM cartera.facturacion_snapshot_diario
+    FROM ${SQL_CARTERA_SCHEMA}.facturacion_snapshot_diario
     WHERE anio = ${anio}
     ORDER BY mes, fecha DESC
   `);
@@ -1119,7 +1120,7 @@ export async function getComparativoHistorico({ anio }: { anio: number }) {
       periodo AS mes,
       COALESCE(SUM(cantidad_creditos), 0)::int AS creditos_activos,
       COALESCE(SUM(capital_total::numeric), 0) AS cartera_activa
-    FROM cartera.cierre_mensual
+    FROM ${SQL_CARTERA_SCHEMA}.cierre_mensual
     WHERE periodo >= make_date(${anio}, 1, 1)
       AND periodo < make_date(${anio + 1}, 1, 1)
       AND status_credit IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
@@ -1138,7 +1139,7 @@ export async function getComparativoHistorico({ anio }: { anio: number }) {
       END AS bucket,
       COUNT(DISTINCT m.credito_id)::int AS cantidad_creditos,
       COALESCE(SUM(m.monto_mora::numeric), 0) AS monto_mora
-    FROM cartera.moras_credito m
+    FROM ${SQL_CARTERA_SCHEMA}.moras_credito m
     WHERE m.activa = true
     GROUP BY 1
   `);
@@ -1150,7 +1151,7 @@ export async function getComparativoHistorico({ anio }: { anio: number }) {
       bucket,
       cantidad_creditos,
       monto_mora
-    FROM cartera.cierre_mora_aging
+    FROM ${SQL_CARTERA_SCHEMA}.cierre_mora_aging
     WHERE periodo >= make_date(${anio}, 1, 1)
       AND periodo < make_date(${anio + 1}, 1, 1)
     ORDER BY periodo, bucket
@@ -1206,7 +1207,7 @@ export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?:
         credito_id,
         cuotas_atrasadas,
         monto_mora
-      FROM cartera.moras_credito
+      FROM ${SQL_CARTERA_SCHEMA}.moras_credito
       WHERE activa           = true
         AND cuotas_atrasadas > 0
       ORDER BY credito_id, mora_id DESC
@@ -1226,8 +1227,8 @@ export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?:
       COALESCE(SUM(c.capital::numeric), 0)    AS suma_capital,
       COALESCE(SUM(m.monto_mora::numeric), 0) AS suma_mora
     FROM mora_activa m
-    INNER JOIN cartera.creditos c ON c.credito_id = m.credito_id
-    INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = m.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id  = c.asesor_id
     WHERE c."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
       ${emailCobrador ? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))` : sql``}
     GROUP BY a.asesor_id, a.nombre, a.email_cash_in, bucket
@@ -1337,14 +1338,14 @@ export async function getCuotasPorFecha({
       COALESCE(pag.abono_gps, 0)                      AS gps_pagado,
       COALESCE(pag.membresias_pagada, 0)              AS membresias_pagado,
       COALESCE(pag.total_pagado, 0)                   AS total_pagado
-    FROM cartera.cuotas_credito c
-    JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
-    JOIN cartera.usuarios u  ON cr.usuario_id = u.usuario_id
-    LEFT JOIN cartera.asesores a ON cr.asesor_id = a.asesor_id
+    FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito c
+    JOIN ${SQL_CARTERA_SCHEMA}.creditos cr ON c.credito_id = cr.credito_id
+    JOIN ${SQL_CARTERA_SCHEMA}.usuarios u  ON cr.usuario_id = u.usuario_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON cr.asesor_id = a.asesor_id
     LEFT JOIN LATERAL (
       SELECT MAX(pc_prev.total_restante::numeric) AS total_restante
-      FROM cartera.pagos_credito pc_prev
-      JOIN cartera.cuotas_credito qc_prev ON pc_prev.cuota_id = qc_prev.cuota_id
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc_prev
+      JOIN ${SQL_CARTERA_SCHEMA}.cuotas_credito qc_prev ON pc_prev.cuota_id = qc_prev.cuota_id
       WHERE qc_prev.credito_id = c.credito_id
         AND qc_prev.numero_cuota = c.numero_cuota - 1
         AND qc_prev.numero_cuota > 0
@@ -1354,7 +1355,7 @@ export async function getCuotasPorFecha({
     ) prev_pag ON true
     LEFT JOIN LATERAL (
       SELECT MAX(pc_curr.total_restante::numeric) AS total_restante
-      FROM cartera.pagos_credito pc_curr
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc_curr
       WHERE pc_curr.cuota_id = c.cuota_id
         AND pc_curr."paymentFalse" = false
         AND pc_curr.monto_aplicado IS NOT NULL
@@ -1376,7 +1377,7 @@ export async function getCuotasPorFecha({
           + COALESCE(pc.abono_gps::numeric, 0)
           + COALESCE(pc.membresias_pago::numeric, 0)
         ) AS total_pagado
-      FROM cartera.pagos_credito pc
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
       WHERE pc.cuota_id = c.cuota_id
         AND pc."paymentFalse" = false
     ) pag ON true

--- a/apps/cartera-back/src/controllers/reports.ts
+++ b/apps/cartera-back/src/controllers/reports.ts
@@ -1,4 +1,5 @@
 import ExcelJS from "exceljs";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import { getCreditosWithUserByMesAnio } from "./credits";
 import { getAllPagosWithCreditAndInversionistas, getPagosConInversionistas } from "./payments";
@@ -1342,10 +1343,10 @@ export async function generateReciboPagoPDF(pagoId: number) {
       u.nombre AS usuario_nombre,
       u.nit AS usuario_nit,
       cq.numero_cuota
-    FROM cartera.pagos_credito p
-    INNER JOIN cartera.creditos c ON c.credito_id = p.credito_id
-    INNER JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
-    LEFT JOIN cartera.cuotas_credito cq ON cq.cuota_id = p.cuota_id
+    FROM ${SQL_CARTERA_SCHEMA}.pagos_credito p
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = p.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.cuotas_credito cq ON cq.cuota_id = p.cuota_id
     WHERE p.pago_id = ${pagoId}
   `);
 
@@ -1703,7 +1704,7 @@ export async function getPagosByVencimiento({
                          ELSE ci_all.porcentaje_cash_in::numeric END) / 100.0
               ELSE 0
             END
-          FROM cartera.creditos_inversionistas ci_all
+          FROM ${SQL_CARTERA_SCHEMA}.creditos_inversionistas ci_all
           WHERE ci_all.credito_id = p.credito_id
         ), 0) AS cash_in_pct
     ) cube_data ON true
@@ -1729,11 +1730,11 @@ export async function getPagosByVencimiento({
         SUM(COALESCE(pc.monto_aplicado::numeric, 0)) AS monto_aplicado,
         MIN(pc.fecha_vencimiento) AS fecha_vencimiento,
         BOOL_OR(pc.pagado) AS pagado
-      FROM cartera.pagos_credito pc
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
       WHERE pc.cuota_id IS NOT NULL
         AND pc.cuota_id IN (
           SELECT cuota_id 
-          FROM cartera.cuotas_credito 
+          FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito 
           WHERE fecha_vencimiento::date >= ${fechaInicio}::date 
             AND fecha_vencimiento::date <= ${fechaFin}::date
         )
@@ -1754,7 +1755,7 @@ export async function getPagosByVencimiento({
         COALESCE(pc.monto_aplicado::numeric, 0) AS monto_aplicado,
         pc.fecha_vencimiento,
         pc.pagado
-      FROM cartera.pagos_credito pc
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
       WHERE pc.cuota_id IS NULL
         AND pc.fecha_vencimiento::date >= ${fechaInicio}::date
         AND pc.fecha_vencimiento::date <= ${fechaFin}::date
@@ -1777,8 +1778,8 @@ export async function getPagosByVencimiento({
   const lateralCapAnterior = sql`
     LEFT JOIN LATERAL (
       SELECT pc_a.total_restante::numeric AS total_restante
-      FROM cartera.pagos_credito pc_a
-      LEFT JOIN cartera.cuotas_credito qcc_a ON pc_a.cuota_id = qcc_a.cuota_id
+      FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc_a
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.cuotas_credito qcc_a ON pc_a.cuota_id = qcc_a.cuota_id
       WHERE pc_a.credito_id = c.credito_id
         AND pc_a."paymentFalse" = false
         AND pc_a.total_restante IS NOT NULL
@@ -1801,20 +1802,20 @@ export async function getPagosByVencimiento({
 
   const commonFromJoins = sql`
     FROM ${pagosDeduped}
-    INNER JOIN cartera.creditos c ON p.credito_id = c.credito_id
-    INNER JOIN cartera.usuarios u ON c.usuario_id = u.usuario_id
-    INNER JOIN cartera.asesores a ON c.asesor_id = a.asesor_id
-    LEFT JOIN cartera.cuotas_credito q ON p.cuota_id = q.cuota_id
-    LEFT JOIN cartera.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON p.credito_id = c.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON c.usuario_id = u.usuario_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON c.asesor_id = a.asesor_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.cuotas_credito q ON p.cuota_id = q.cuota_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m ON c.credito_id = m.credito_id AND m.activa = true
     LEFT JOIN LATERAL (
       SELECT COUNT(*)::int AS cuotas_atrasadas
-      FROM cartera.cuotas_credito qc_mora
+      FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito qc_mora
       WHERE qc_mora.credito_id = c.credito_id
         AND qc_mora.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
         AND qc_mora.pagado = false
         AND NOT EXISTS (
           SELECT 1
-          FROM cartera.pagos_credito pc_mora
+          FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc_mora
           WHERE pc_mora.cuota_id = qc_mora.cuota_id
             AND pc_mora."paymentFalse" = false
             AND pc_mora.pagado = true
@@ -2053,13 +2054,13 @@ export async function getPagosByVencimiento({
           TO_CHAR(fecha_boleta, 'YYYY-MM-DD') AS fecha_boleta,
           TO_CHAR(fecha_pago AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala', 'YYYY-MM-DD HH24:MI:SS') AS fecha_pago,
           numeroautorizacion AS numero_boleta
-        FROM cartera.pagos_credito
+        FROM ${SQL_CARTERA_SCHEMA}.pagos_credito
         WHERE credito_id = ANY(ARRAY[${sql.raw(creditoIds.join(","))}]::int[])
           AND validation_status IN ('validated', 'capital_validated')
           AND "paymentFalse" = false
           AND (
             (cuota_id IS NOT NULL AND cuota_id IN (
-              SELECT cuota_id FROM cartera.cuotas_credito
+              SELECT cuota_id FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito
               WHERE fecha_vencimiento::date >= ${fechaInicio}::date
                 AND fecha_vencimiento::date <= ${fechaFin}::date
             ))
@@ -2251,15 +2252,15 @@ export async function getPagosByVencimiento({
               COALESCE(MIN(pc_a.seguro_restante::numeric),  0) AS seguro_restante,
               COALESCE(MIN(pc_a.gps_restante::numeric),     0) AS gps_restante,
               COALESCE(MIN(pc_a.membresias::numeric),       0) AS membresias
-            FROM cartera.cuotas_credito q_a
-            LEFT JOIN cartera.pagos_credito pc_a
+            FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito q_a
+            LEFT JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito pc_a
               ON pc_a.cuota_id = q_a.cuota_id
               AND pc_a."paymentFalse" = false
             WHERE q_a.credito_id = calc.credito_id
               AND q_a.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
               AND q_a.pagado = false
               AND NOT EXISTS (
-                SELECT 1 FROM cartera.pagos_credito pc2
+                SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc2
                 WHERE pc2.cuota_id = q_a.cuota_id
                   AND pc2."paymentFalse" = false
                   AND pc2.pagado = true
@@ -2385,13 +2386,13 @@ export async function getAbonosDelMesPorCredito({
       TO_CHAR(fecha_boleta, 'YYYY-MM-DD') AS fecha_boleta,
       TO_CHAR(fecha_pago AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala', 'YYYY-MM-DD HH24:MI:SS') AS fecha_pago,
       numeroautorizacion AS numero_boleta
-    FROM cartera.pagos_credito
+    FROM ${SQL_CARTERA_SCHEMA}.pagos_credito
     WHERE credito_id = ${credito_id}
       AND validation_status IN ('validated', 'capital_validated')
       AND "paymentFalse" = false
       AND (
         (cuota_id IS NOT NULL AND cuota_id IN (
-          SELECT cuota_id FROM cartera.cuotas_credito
+          SELECT cuota_id FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito
           WHERE fecha_vencimiento::date >= ${fechaInicio}::date
             AND fecha_vencimiento::date <= ${fechaFin}::date
         ))
@@ -2422,9 +2423,9 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
         COALESCE(MIN(pc.membresias::numeric),        0) AS mem_r,
         MIN(c.cuota::numeric) AS cuota_c,
         ROUND(COALESCE(MIN(pc.interes_restante::numeric), 0) * COALESCE(AVG(cube_data.cash_in_pct), 0), 2) AS interes_cube
-      FROM cartera.cuotas_credito q
-      INNER JOIN cartera.creditos c ON c.credito_id = q.credito_id
-      LEFT JOIN cartera.pagos_credito pc
+      FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito q
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = q.credito_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.pagos_credito pc
         ON pc.cuota_id = q.cuota_id
         AND pc."paymentFalse" = false
       LEFT JOIN LATERAL (
@@ -2446,7 +2447,7 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
                            ELSE ci_all.porcentaje_cash_in::numeric END) / 100.0
                 ELSE 0
               END
-            FROM cartera.creditos_inversionistas ci_all
+            FROM ${SQL_CARTERA_SCHEMA}.creditos_inversionistas ci_all
             WHERE ci_all.credito_id = q.credito_id
           ), 0) AS cash_in_pct
       ) cube_data ON true
@@ -2455,7 +2456,7 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
         AND q.fecha_vencimiento::date < (NOW() AT TIME ZONE 'America/Guatemala')::date
         AND q.pagado = false
         AND NOT EXISTS (
-          SELECT 1 FROM cartera.pagos_credito pc2
+          SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc2
           WHERE pc2.cuota_id = q.cuota_id
             AND pc2."paymentFalse" = false
             AND pc2.pagado = true
@@ -2495,10 +2496,10 @@ export async function getAcumuladoPorCredito({ credito_id }: { credito_id: numbe
   const principal = Number(
     (await db.execute<any>(sql`
       SELECT GREATEST(c.capital::numeric - COALESCE((
-        SELECT SUM(abono_capital::numeric) FROM cartera.pagos_credito
+        SELECT SUM(abono_capital::numeric) FROM ${SQL_CARTERA_SCHEMA}.pagos_credito
         WHERE credito_id = ${credito_id} AND "paymentFalse" = false
       ), 0), 0) AS principal
-      FROM cartera.creditos c WHERE c.credito_id = ${credito_id}
+      FROM ${SQL_CARTERA_SCHEMA}.creditos c WHERE c.credito_id = ${credito_id}
     `)).rows[0]?.principal ?? 0
   );
 
@@ -2557,8 +2558,8 @@ export async function getCapitalInversionistas({
         WHEN bool_or(e.status <> 'completado') THEN 'compra de cartera pendiente'
         ELSE ''
       END AS comentario
-    FROM cartera.creditos_inversionistas_espejo e
-    JOIN cartera.inversionistas i
+    FROM ${SQL_CARTERA_SCHEMA}.creditos_inversionistas_espejo e
+    JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i
       ON i.inversionista_id = e.inversionista_id
     ${whereClause}
     GROUP BY i.inversionista_id, i.nombre, i.tipo_reinversion

--- a/apps/cartera-back/src/controllers/updateDueDate.ts
+++ b/apps/cartera-back/src/controllers/updateDueDate.ts
@@ -1,4 +1,5 @@
 import { eq, and, asc, desc } from "drizzle-orm";
+import { CARTERA_SCHEMA } from "../database/db/schema";
 import { db } from "../database";
 import { creditos, cuotas_credito, pagos_credito, historial_cambio_fecha } from "../database/db";
 import z from "zod";
@@ -313,16 +314,16 @@ export const fixCreditosWithoutFebruary = async ({
       numero_credito_sifco: string;
     }>(
       `SELECT c.credito_id, c.numero_credito_sifco
-       FROM cartera.creditos c
+       FROM ${CARTERA_SCHEMA}.creditos c
        WHERE c."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
          AND c.credito_id NOT IN (
            SELECT DISTINCT cc.credito_id
-           FROM cartera.cuotas_credito cc
+           FROM ${CARTERA_SCHEMA}.cuotas_credito cc
            WHERE EXTRACT(MONTH FROM cc.fecha_vencimiento::date) = 2
              AND EXTRACT(YEAR FROM cc.fecha_vencimiento::date) = ${anio}
          )
          AND EXISTS (
-           SELECT 1 FROM cartera.cuotas_credito cc2
+           SELECT 1 FROM ${CARTERA_SCHEMA}.cuotas_credito cc2
            WHERE cc2.credito_id = c.credito_id
              AND cc2.pagado = false
              AND EXTRACT(YEAR FROM cc2.fecha_vencimiento::date) >= ${anio}
@@ -700,14 +701,14 @@ export const updateDueDatesFromJson = async ({
 
       // 3a. UPDATE cuotas_credito: solo cambiar el día de fecha_vencimiento
       const cuotasResult = await db.execute(
-        `UPDATE cartera.cuotas_credito cc
+        `UPDATE ${CARTERA_SCHEMA}.cuotas_credito cc
          SET fecha_vencimiento = MAKE_DATE(
              EXTRACT(YEAR FROM cc.fecha_vencimiento)::int,
              EXTRACT(MONTH FROM cc.fecha_vencimiento)::int,
              LEAST(${diaPago}, ${ultimoDia("cc.fecha_vencimiento")})
            )
          WHERE cc.credito_id IN (
-           SELECT credito_id FROM cartera.creditos
+           SELECT credito_id FROM ${CARTERA_SCHEMA}.creditos
            WHERE numero_credito_sifco IN (${inClause})
          )
          AND cc.numero_cuota > 0`
@@ -716,7 +717,7 @@ export const updateDueDatesFromJson = async ({
       // 3b. UPDATE pagos_credito: fecha_vencimiento siempre,
       //     fecha_pago + fecha_boleta SOLO donde fecha_pago ya tiene valor
       const pagosResult = await db.execute(
-        `UPDATE cartera.pagos_credito pc
+        `UPDATE ${CARTERA_SCHEMA}.pagos_credito pc
          SET
            fecha_vencimiento = MAKE_DATE(
                EXTRACT(YEAR FROM pc.fecha_vencimiento)::int,
@@ -738,8 +739,8 @@ export const updateDueDatesFromJson = async ({
                )
              ELSE pc.fecha_boleta END
          WHERE pc.cuota_id IN (
-           SELECT cc.cuota_id FROM cartera.cuotas_credito cc
-           INNER JOIN cartera.creditos c ON cc.credito_id = c.credito_id
+           SELECT cc.cuota_id FROM ${CARTERA_SCHEMA}.cuotas_credito cc
+           INNER JOIN ${CARTERA_SCHEMA}.creditos c ON cc.credito_id = c.credito_id
            WHERE c.numero_credito_sifco IN (${inClause})
              AND cc.numero_cuota > 0
          )`

--- a/apps/cartera-back/src/controllers/verificarFacturasSat.ts
+++ b/apps/cartera-back/src/controllers/verificarFacturasSat.ts
@@ -1,4 +1,5 @@
 // ============================================================
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 // Monitoreo de facturas no certificadas en SAT
 // ------------------------------------------------------------
 // - verificarFacturasSat(): job cada 15 min. Revisa las facturas
@@ -104,9 +105,9 @@ async function verificarEnSat(
 // la BD (así deja de aparecer en el reporte). Devuelve cuántas resolvió.
 async function resolverFallidasAnuladas(): Promise<number> {
   const r: any = await db.execute(sql`
-    UPDATE cartera.facturas_fallidas_sat AS ff
+    UPDATE ${SQL_CARTERA_SCHEMA}.facturas_fallidas_sat AS ff
     SET status = 'RESUELTA', resuelta_at = now(), updated_at = now()
-    FROM cartera.facturas_electronicas AS fe
+    FROM ${SQL_CARTERA_SCHEMA}.facturas_electronicas AS fe
     WHERE ff.factura_id = fe.factura_id
       AND ff.status = 'PENDIENTE'
       AND fe.status = 'ANULADA'

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -23,7 +23,17 @@
     CV_VEHICULO = "CV Vehículo",
   }
   export const userRoleEnum = pgEnum("user_role", ["ADMIN", "ASESOR","CONTA"]);
-  export const customSchema = pgSchema("cartera");
+
+  // 🪣 COBROS-02: el schema de Postgres es parametrizable por env para poder
+  // apuntar TODO el back a un schema espejo (p.ej. el sandbox de pruebas
+  // `cartera_cobros2`, copia de `cartera` en dev) SIN tocar código.
+  // Sin la variable = "cartera" (comportamiento normal / producción).
+  //  - CARTERA_SCHEMA: string, para SQL crudo en template strings planos.
+  //  - SQL_CARTERA_SCHEMA: sql.raw(...), para SQL crudo dentro de sql`...`
+  //    de drizzle (un string ahí se volvería parámetro $n y rompería el query).
+  export const CARTERA_SCHEMA = process.env.CARTERA_SCHEMA ?? "cartera";
+  export const SQL_CARTERA_SCHEMA = sql.raw(CARTERA_SCHEMA);
+  export const customSchema = pgSchema(CARTERA_SCHEMA);
 
   export const statusCreditoInversionistaEspejoEnum = customSchema.enum("status_credito_inversionista_espejo", [
     "pendiente_reinversion",
@@ -1155,7 +1165,7 @@
   // ===== Funciones + triggers de cuentas_empresa (hora Guatemala) =====
   // Aplica un movimiento al saldo_actual de la cuenta y guarda saldo_post.
   export const aplicarMovimientoCuentaEmpresaFn = sql`
-    CREATE OR REPLACE FUNCTION cartera.aplicar_movimiento_cuenta_empresa()
+    CREATE OR REPLACE FUNCTION ${SQL_CARTERA_SCHEMA}.aplicar_movimiento_cuenta_empresa()
     RETURNS TRIGGER AS $$
     DECLARE
       v_delta numeric(18,2);
@@ -1163,7 +1173,7 @@
     BEGIN
       v_delta := CASE NEW.tipo WHEN 'ingreso' THEN NEW.monto ELSE -NEW.monto END;
 
-      UPDATE cartera.cuentas_empresa
+      UPDATE ${SQL_CARTERA_SCHEMA}.cuentas_empresa
          SET saldo_actual = saldo_actual + v_delta
        WHERE cuenta_id = NEW.cuenta_id
        RETURNING saldo_actual INTO v_nuevo_saldo;
@@ -1179,16 +1189,16 @@
   `;
 
   export const aplicarMovimientoCuentaEmpresaTrigger = sql`
-    DROP TRIGGER IF EXISTS trg_cuentas_empresa_mov_aplicar ON cartera.cuentas_empresa_movimientos;
+    DROP TRIGGER IF EXISTS trg_cuentas_empresa_mov_aplicar ON ${SQL_CARTERA_SCHEMA}.cuentas_empresa_movimientos;
     CREATE TRIGGER trg_cuentas_empresa_mov_aplicar
-    BEFORE INSERT ON cartera.cuentas_empresa_movimientos
+    BEFORE INSERT ON ${SQL_CARTERA_SCHEMA}.cuentas_empresa_movimientos
     FOR EACH ROW
-    EXECUTE FUNCTION cartera.aplicar_movimiento_cuenta_empresa();
+    EXECUTE FUNCTION ${SQL_CARTERA_SCHEMA}.aplicar_movimiento_cuenta_empresa();
   `;
 
   // Auto-actualiza fecha_actualizacion en cualquier UPDATE.
   export const setFechaActualizacionFn = sql`
-    CREATE OR REPLACE FUNCTION cartera.set_fecha_actualizacion()
+    CREATE OR REPLACE FUNCTION ${SQL_CARTERA_SCHEMA}.set_fecha_actualizacion()
     RETURNS TRIGGER AS $$
     BEGIN
       NEW.fecha_actualizacion = NOW() AT TIME ZONE 'America/Guatemala';
@@ -1198,11 +1208,11 @@
   `;
 
   export const cuentasEmpresaSetFechaTrigger = sql`
-    DROP TRIGGER IF EXISTS trg_cuentas_empresa_set_fecha_actualizacion ON cartera.cuentas_empresa;
+    DROP TRIGGER IF EXISTS trg_cuentas_empresa_set_fecha_actualizacion ON ${SQL_CARTERA_SCHEMA}.cuentas_empresa;
     CREATE TRIGGER trg_cuentas_empresa_set_fecha_actualizacion
-    BEFORE UPDATE ON cartera.cuentas_empresa
+    BEFORE UPDATE ON ${SQL_CARTERA_SCHEMA}.cuentas_empresa
     FOR EACH ROW
-    EXECUTE FUNCTION cartera.set_fecha_actualizacion();
+    EXECUTE FUNCTION ${SQL_CARTERA_SCHEMA}.set_fecha_actualizacion();
   `;
 
 

--- a/apps/cartera-back/src/routers/cofidi.ts
+++ b/apps/cartera-back/src/routers/cofidi.ts
@@ -1,4 +1,5 @@
 // src/controllers/dte.controller.ts
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
 
 import { Elysia, t } from "elysia";
 import jwt from "jsonwebtoken";
@@ -1915,8 +1916,8 @@ if (facturasExistentes.length > 0) {
         //    reparte y se guarda por inversionista). Solo guardamos lo de CUBE.
         const capCubeRes = await db.execute(sql`
           SELECT COALESCE(SUM(pci.abono_capital), 0) AS capital_cube
-          FROM cartera.pagos_credito_inversionistas pci
-          JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+          FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci
+          JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
           WHERE pci.pago_id = ${pago_id}
             AND UPPER(TRIM(i.nombre)) LIKE '%CUBE INVESTMENTS%'
         `);
@@ -1931,8 +1932,8 @@ if (facturasExistentes.length > 0) {
         const invFacturadoRes = await db.execute(sql`
           SELECT COALESCE(SUM(pci.abono_interes + pci.abono_iva_12), 0) AS total,
                  COALESCE(SUM(pci.abono_iva_12), 0) AS iva
-          FROM cartera.pagos_credito_inversionistas pci
-          JOIN cartera.inversionistas i ON i.inversionista_id = pci.inversionista_id
+          FROM ${SQL_CARTERA_SCHEMA}.pagos_credito_inversionistas pci
+          JOIN ${SQL_CARTERA_SCHEMA}.inversionistas i ON i.inversionista_id = pci.inversionista_id
           WHERE pci.pago_id = ${pago_id}
             AND UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
             AND i.emite_factura = false
@@ -1946,7 +1947,7 @@ if (facturasExistentes.length > 0) {
             AND NOT (
               ${pagoData.bandera_reinversion === true}
               AND EXISTS (
-                SELECT 1 FROM cartera.creditos_inversionistas_espejo esp
+                SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.creditos_inversionistas_espejo esp
                 WHERE esp.credito_id = ${pagoData.credito_id}
                   AND esp.inversionista_id = pci.inversionista_id
                   AND esp.status IN ('pendiente_reinversion', 'pendiente_compra_cartera')
@@ -1985,20 +1986,20 @@ if (facturasExistentes.length > 0) {
         await db.transaction(async (tx) => {
           // Reemplazar para que re-facturar no duplique ni deje rubros viejos.
           await tx.execute(
-            sql`DELETE FROM cartera.facturacion_desglose WHERE pago_id = ${pago_id}`
+            sql`DELETE FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose WHERE pago_id = ${pago_id}`
           );
           for (const r of rubrosDesglose) {
             await tx.execute(sql`
-              INSERT INTO cartera.facturacion_desglose
+              INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_desglose
                 (pago_id, factura_id, rubro, monto_total, monto_iva, fecha_aplicado_gt)
               VALUES (
                 ${pago_id},
                 NULL,
-                ${r.rubro}::cartera.rubro_facturacion,
+                ${r.rubro}::${SQL_CARTERA_SCHEMA}.rubro_facturacion,
                 ${r.monto_total},
                 ${r.monto_iva},
                 (SELECT (COALESCE(pc.fecha_aplicado, pc.fecha_pago) AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date
-                   FROM cartera.pagos_credito pc WHERE pc.pago_id = ${pago_id})
+                   FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc WHERE pc.pago_id = ${pago_id})
               )
             `);
           }
@@ -2483,7 +2484,7 @@ if (facturasExistentes.length > 0) {
       //    Best-effort: la factura ya quedó anulada, esto no debe romper la respuesta.
       try {
         await db.execute(
-          sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${facturaAnulada.factura_id} AND pago_id IS NULL`
+          sql`DELETE FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose WHERE factura_id = ${facturaAnulada.factura_id} AND pago_id IS NULL`
         );
       } catch (limpiezaError) {
         console.error(
@@ -3351,11 +3352,11 @@ if (facturasExistentes.length > 0) {
             // Categoría del receptor: usuario (con créditos) por NIT; el del crédito más reciente.
             const catRes = await db.execute(sql`
               SELECT u.categoria
-              FROM cartera.usuarios u
+              FROM ${SQL_CARTERA_SCHEMA}.usuarios u
               WHERE upper(regexp_replace(COALESCE(u.nit, ''), '[^0-9A-Za-z]', '', 'g'))
                   = upper(regexp_replace(${nitNormalizado}, '[^0-9A-Za-z]', '', 'g'))
-                AND EXISTS (SELECT 1 FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id)
-              ORDER BY (SELECT MAX(c.fecha_creacion) FROM cartera.creditos c WHERE c.usuario_id = u.usuario_id) DESC NULLS LAST
+                AND EXISTS (SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.creditos c WHERE c.usuario_id = u.usuario_id)
+              ORDER BY (SELECT MAX(c.fecha_creacion) FROM ${SQL_CARTERA_SCHEMA}.creditos c WHERE c.usuario_id = u.usuario_id) DESC NULLS LAST
               LIMIT 1
             `);
             const categoria = (catRes as any).rows?.[0]?.categoria ?? null;
@@ -3370,7 +3371,7 @@ if (facturasExistentes.length > 0) {
             await db.transaction(async (tx) => {
               // Reemplazar para que re-facturar no duplique.
               await tx.execute(
-                sql`DELETE FROM cartera.facturacion_desglose WHERE factura_id = ${resultado.factura_id} AND pago_id IS NULL`
+                sql`DELETE FROM ${SQL_CARTERA_SCHEMA}.facturacion_desglose WHERE factura_id = ${resultado.factura_id} AND pago_id IS NULL`
               );
               for (const [rubro, montoBig] of Object.entries(porRubro)) {
                 if (montoBig.lte(0)) continue;
@@ -3378,19 +3379,19 @@ if (facturasExistentes.length > 0) {
                   calcularIvaExacto(parseFloat(montoBig.toFixed(2))).montoImpuesto
                 );
                 await tx.execute(sql`
-                  INSERT INTO cartera.facturacion_desglose
+                  INSERT INTO ${SQL_CARTERA_SCHEMA}.facturacion_desglose
                     (pago_id, factura_id, rubro, monto_total, monto_iva, fecha_aplicado_gt, categoria)
                   VALUES (
                     NULL,
                     ${resultado.factura_id},
-                    ${rubro}::cartera.rubro_facturacion,
+                    ${rubro}::${SQL_CARTERA_SCHEMA}.rubro_facturacion,
                     ${montoBig.toFixed(2)},
                     ${iva.toFixed(2)},
                     -- fecha_emision YA se guarda en hora Guatemala (certificarFacturaHelper
                     -- le resta 6h antes de persistir), así que se usa directo SIN volver a
                     -- convertir de UTC→GT (eso shifteaba las genéricas de 00:00–05:59 al día anterior).
                     (SELECT fecha_emision::date
-                       FROM cartera.facturas_electronicas WHERE factura_id = ${resultado.factura_id}),
+                       FROM ${SQL_CARTERA_SCHEMA}.facturas_electronicas WHERE factura_id = ${resultado.factura_id}),
                     ${categoria}
                   )
                 `);


### PR DESCRIPTION
## Qué es

Se **des-quema el schema `cartera`** de todo cartera-back: ahora es parametrizable con la env var **`CARTERA_SCHEMA`**. Sin la variable, default `"cartera"` → **cero cambio de comportamiento** (prod intacto). Con `CARTERA_SCHEMA=cartera_cobros2` en el `.env`, TODO el back (drizzle + SQL crudo) apunta al **sandbox de pruebas** que ya quedó montado en dev.

## Cómo

- `schema.ts` exporta dos tokens:
  - `CARTERA_SCHEMA` (string) → para SQL crudo en template strings planos (`client.query`, `db.execute(\`...\`)`).
  - `SQL_CARTERA_SCHEMA` (`sql.raw(...)`) → para SQL crudo dentro de `` sql`...` `` de drizzle (un string ahí se volvería parámetro `$n` y rompería el query).
  - `customSchema = pgSchema(CARTERA_SCHEMA)` → todas las tablas drizzle siguen solas.
- ~270 referencias `cartera.` reemplazadas en 17 archivos (controllers + routers). `src/scripts/` (herramientas one-off) se dejó tal cual a propósito.

## ✅ Verificado END-TO-END contra el sandbox

El compañero dejó `cartera_cobros2` completo (copia exacta: 1,628 créditos, 100,996 cuotas · migraciones 0000→0003 · scripts de asignación 01→03: pool 7 asesores, 1,193 en bitácora, 1,486 INICIALs). Con el server local apuntando ahí:

| Prueba | Resultado |
|---|---|
| `POST /moras/procesar` | ✅ `{subidas: 19, bajadas: 0, reasignados: 19, iniciales: 0}` — **19 SUBIDAs reales y las 19 reasignadas de asesor** (bitácora `PROCESO_AUTO` + `creditos.asesor_id` actualizado en los 19); no re-sembró INICIALs (respetó la línea base del script) |
| `GET /buckets/creditos?bucket=N` | ✅ distribución exacta: B0 437 · B1 597 · B2 219 · B3 55 · B4 30 · B5 148 |
| `GET /buckets/historial?tipo_evento=SUBIDA` | ✅ ej.: crédito 574 B0→B1, ya asignado a **Asesor Prueba B1** (el nuevo del pool) |
| `/moras/historial` y `/getAllCredits` (SQL crudo viejo) | ✅ funcionan igual (columna `bucket` con color del catálogo) |
| Schema `cartera` real | ✅ **intacto** — conteos idénticos pre/post, cero tablas nuevas |
| `tsc` / `bun test` | ✅ 0 errores nuevos / mismos resultados que COBROS-02 limpio (los 19 fails de payments/reports espejo ya estaban en la base) |

Ejemplo real del flujo completo en el sandbox (crédito 380): script lo asignó a Caren (B0) → hoy amaneció con 4 cuotas → job: SUBIDA B0→B4 → **pasó solo a Erik Rivas** (asesor de B4). 🎯

## 🧪 Para probar (ya se puede)

```bash
# apps/cartera-back/.env
CARTERA_SCHEMA=cartera_cobros2
```
Levantar el back y seguir el plan del PR #1044: pago validado → BAJADA + reasignación · pago sin validar → sin cambios · varios a B1 → reparto parejo Diego/Prueba B1. Quitar la variable = volver a `cartera` normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)