### PR TITLE
feat(cartera): historial de cambios de capital de un crédito

### DIFF
--- a/apps/cartera-back/drizzle/0014_add_historial_capital_credito.sql
+++ b/apps/cartera-back/drizzle/0014_add_historial_capital_credito.sql
@@ -10,6 +10,13 @@
 --
 -- Si no viene fuente: INSERT => 'CREACION', UPDATE => 'SISTEMA'. Nunca se pierde
 -- un cambio aunque el write site no esté instrumentado.
+--
+-- ⚠️ APLICAR MANUALMENTE (mismo patrón que 0004 y demás triggers del repo):
+-- `drizzle-kit push` (script `migrate`) sincroniza SOLO el schema de schema.ts
+-- (crea la TABLA) pero NO ejecuta este .sql, así que la FUNCIÓN y el TRIGGER hay
+-- que aplicarlos a mano en cada base. Todo el archivo es idempotente
+-- (CREATE ... IF NOT EXISTS / CREATE OR REPLACE / DROP TRIGGER IF EXISTS), así que
+-- se puede re-correr sin riesgo. Ya aplicado en PROD y DEV.
 
 -- 1. Tabla de historial
 CREATE TABLE IF NOT EXISTS cartera.historial_capital_credito (

--- a/apps/cartera-back/drizzle/0014_add_historial_capital_credito.sql
+++ b/apps/cartera-back/drizzle/0014_add_historial_capital_credito.sql
@@ -1,0 +1,92 @@
+-- Historial de cambios del capital de un crédito.
+-- Un trigger sobre cartera.creditos captura TODO cambio de `capital` (venga de
+-- ajuste manual, pago, reverso, castigo, merge, import...). La app decora cada
+-- cambio con fuente/usuario/motivo vía GUCs de sesión (SET LOCAL), igual que el
+-- patrón de historico_monto_aportado_espejo (0004).
+--
+--   SET LOCAL app.current_user_id = '<id>'
+--   SET LOCAL app.capital_source  = 'AJUSTE_MANUAL' | 'PAGO' | 'REVERSO' | 'CASTIGO' | 'MERGE'
+--   SET LOCAL app.capital_motivo  = '<texto libre>'
+--
+-- Si no viene fuente: INSERT => 'CREACION', UPDATE => 'SISTEMA'. Nunca se pierde
+-- un cambio aunque el write site no esté instrumentado.
+
+-- 1. Tabla de historial
+CREATE TABLE IF NOT EXISTS cartera.historial_capital_credito (
+  id                BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  txid              BIGINT        NOT NULL,
+  operacion         TEXT          NOT NULL,                 -- INSERT | UPDATE
+  credito_id        INT           NOT NULL REFERENCES cartera.creditos(credito_id) ON DELETE CASCADE,
+  capital_anterior  NUMERIC(18,2),
+  capital_nuevo     NUMERIC(18,2),
+  fuente            TEXT          NOT NULL DEFAULT 'SISTEMA',
+  motivo            TEXT,
+  platform_user_id  INT           REFERENCES cartera.platform_users(id) ON DELETE SET NULL,
+  user_email        VARCHAR(200),
+  fecha             TIMESTAMPTZ   NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS ix_hist_cap_cred   ON cartera.historial_capital_credito (credito_id, fecha DESC);
+CREATE INDEX IF NOT EXISTS ix_hist_cap_fecha  ON cartera.historial_capital_credito (fecha);
+CREATE INDEX IF NOT EXISTS ix_hist_cap_fuente ON cartera.historial_capital_credito (fuente);
+
+-- 2. Función trigger
+CREATE OR REPLACE FUNCTION cartera.historial_capital_credito_fn()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_user_setting TEXT;
+  v_user_id      INT;
+  v_email        VARCHAR(200);
+  v_source       TEXT;
+  v_motivo       TEXT;
+BEGIN
+  -- En UPDATE, solo registrar si el capital realmente cambió.
+  IF TG_OP = 'UPDATE' AND NEW.capital IS NOT DISTINCT FROM OLD.capital THEN
+    RETURN NEW;
+  END IF;
+
+  -- Fuente: GUC de la app, o default según operación.
+  v_source := NULLIF(current_setting('app.capital_source', true), '');
+  IF v_source IS NULL THEN
+    v_source := CASE WHEN TG_OP = 'INSERT' THEN 'CREACION' ELSE 'SISTEMA' END;
+  END IF;
+
+  -- Motivo (texto libre del modal), opcional.
+  v_motivo := NULLIF(current_setting('app.capital_motivo', true), '');
+
+  -- Usuario: resolver contra platform_users; si no existe, dejar NULL
+  -- (evita que un id inválido en el GUC rompa el UPDATE del crédito por FK).
+  v_user_setting := NULLIF(current_setting('app.current_user_id', true), '');
+  IF v_user_setting IS NOT NULL THEN
+    SELECT id, email INTO v_user_id, v_email
+      FROM cartera.platform_users
+     WHERE id = v_user_setting::INT;
+  END IF;
+
+  INSERT INTO cartera.historial_capital_credito
+    (txid, operacion, credito_id, capital_anterior, capital_nuevo,
+     fuente, motivo, platform_user_id, user_email)
+  VALUES (
+    txid_current(),
+    TG_OP,
+    COALESCE(NEW.credito_id, OLD.credito_id),
+    CASE WHEN TG_OP = 'INSERT' THEN NULL ELSE OLD.capital END,
+    NEW.capital,
+    v_source,
+    v_motivo,
+    v_user_id,
+    v_email
+  );
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 3. Trigger. `UPDATE OF capital` => solo dispara cuando el UPDATE toca la
+-- columna capital (los edits de teléfono/dirección no pagan overhead).
+DROP TRIGGER IF EXISTS trg_historial_capital_credito ON cartera.creditos;
+
+CREATE TRIGGER trg_historial_capital_credito
+AFTER INSERT OR UPDATE OF capital ON cartera.creditos
+FOR EACH ROW
+EXECUTE FUNCTION cartera.historial_capital_credito_fn();

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -1,4 +1,5 @@
 import { db } from "../database/index";
+import { withCapitalContext, setCapitalSource } from "../utils/withAuditContext";
 import {
   aseguradoras,
   asesores,
@@ -1600,6 +1601,7 @@ export async function actualizarEstadoCredito(input: AccionCreditoParams) {
         .returning({ cuota_id: cuotas_credito.cuota_id });
 
       // e) Actualizar crédito: INCOBRABLE, plazo 1, cuota = capital completo
+      await setCapitalSource(tx, "CASTIGO");
       await tx
         .update(creditos)
         .set({
@@ -1756,24 +1758,26 @@ export async function reiniciarCredito(
   creditId: number,
   montoIncobrable?: number
 ) {
-  await db
-    .update(creditos)
-    .set({
-      capital: "0",
-      deudatotal: montoIncobrable !== undefined ? String(montoIncobrable) : "0",
-      cuota_interes: "0",
-      cuota: "0",
-      iva_12: "0",
-      seguro_10_cuotas: "0",
-      gps: "0",
-      membresias_pago: "0",
-      membresias: "0",
-      porcentaje_royalti: "0",
-      royalti: "0",
-      otros: "0",
-      statusCredit: "ACTIVO",
-    })
-    .where(eq(creditos.credito_id, creditId));
+  await withCapitalContext(null, "REINICIO", null, (tx) =>
+    tx
+      .update(creditos)
+      .set({
+        capital: "0",
+        deudatotal: montoIncobrable !== undefined ? String(montoIncobrable) : "0",
+        cuota_interes: "0",
+        cuota: "0",
+        iva_12: "0",
+        seguro_10_cuotas: "0",
+        gps: "0",
+        membresias_pago: "0",
+        membresias: "0",
+        porcentaje_royalti: "0",
+        royalti: "0",
+        otros: "0",
+        statusCredit: "ACTIVO",
+      })
+      .where(eq(creditos.credito_id, creditId))
+  );
 }
 
 function construirUrlBoletas(url_boletas: string[], r2BaseUrl: string) {
@@ -2063,25 +2067,27 @@ export async function resetCredit({
       const capitalIncobrable = new Big(montoIncobrable!);
 
       // 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
-      await db
-        .update(creditos)
-        .set({
-          capital: capitalIncobrable.toString(),
-          deudatotal: capitalIncobrable.toString(),
-          cuota_interes: "0",
-          cuota: capitalIncobrable.toString(),
-          iva_12: "0",
-          seguro_10_cuotas: "0",
-          gps: "0",
-          membresias_pago: "0",
-          membresias: "0",
-          porcentaje_royalti: "0",
-          royalti: "0",
-          otros: "0",
-          plazo: 1,
-          statusCredit: "INCOBRABLE",
-        })
-        .where(eq(creditos.credito_id, creditId));
+      await withCapitalContext(null, "CASTIGO", null, (tx) =>
+        tx
+          .update(creditos)
+          .set({
+            capital: capitalIncobrable.toString(),
+            deudatotal: capitalIncobrable.toString(),
+            cuota_interes: "0",
+            cuota: capitalIncobrable.toString(),
+            iva_12: "0",
+            seguro_10_cuotas: "0",
+            gps: "0",
+            membresias_pago: "0",
+            membresias: "0",
+            porcentaje_royalti: "0",
+            royalti: "0",
+            otros: "0",
+            plazo: 1,
+            statusCredit: "INCOBRABLE",
+          })
+          .where(eq(creditos.credito_id, creditId))
+      );
 
       // 16b. Crear cuota pendiente para el monto incobrable (correlativa)
       const [maxCuotaRowInc] = await db
@@ -2144,24 +2150,26 @@ export async function resetCredit({
       });
     } else {
       // CANCELADO: zerear todo (preservamos porcentaje_interes)
-      await db
-        .update(creditos)
-        .set({
-          capital: "0",
-          deudatotal: "0",
-          cuota_interes: "0",
-          cuota: "0",
-          iva_12: "0",
-          seguro_10_cuotas: "0",
-          gps: "0",
-          membresias_pago: "0",
-          membresias: "0",
-          porcentaje_royalti: "0",
-          royalti: "0",
-          otros: "0",
-          statusCredit: "CANCELADO",
-        })
-        .where(eq(creditos.credito_id, creditId));
+      await withCapitalContext(null, "CANCELACION", null, (tx) =>
+        tx
+          .update(creditos)
+          .set({
+            capital: "0",
+            deudatotal: "0",
+            cuota_interes: "0",
+            cuota: "0",
+            iva_12: "0",
+            seguro_10_cuotas: "0",
+            gps: "0",
+            membresias_pago: "0",
+            membresias: "0",
+            porcentaje_royalti: "0",
+            royalti: "0",
+            otros: "0",
+            statusCredit: "CANCELADO",
+          })
+          .where(eq(creditos.credito_id, creditId))
+      );
     }
 
     // 17. Retorno OK
@@ -2647,22 +2655,24 @@ export const mergeCreditosAndUpdate = async ({
       "💾 PASO 3: Actualizando crédito destino con valores consolidados..."
     );
 
-    const [creditoActualizado] = await db
-      .update(creditos)
-      .set({
-        capital: capitalTotal.toString(),
-        cuota: cuota_total.toString(),
-        cuota_interes: cuota_interes.toString(),
-        iva_12: iva_12.toString(),
-        deudatotal: deudatotal.toString(),
-        seguro_10_cuotas: seguro_total.toString(),
-        gps: gps_total.toString(),
-        membresias_pago: membresias_total.toString(),
-        membresias: membresias_total.toString(),
-        otros: otros_total.toString(),
-      })
-      .where(eq(creditos.credito_id, creditoDestino.credito_id))
-      .returning();
+    const [creditoActualizado] = await withCapitalContext(null, "MERGE", null, (tx) =>
+      tx
+        .update(creditos)
+        .set({
+          capital: capitalTotal.toString(),
+          cuota: cuota_total.toString(),
+          cuota_interes: cuota_interes.toString(),
+          iva_12: iva_12.toString(),
+          deudatotal: deudatotal.toString(),
+          seguro_10_cuotas: seguro_total.toString(),
+          gps: gps_total.toString(),
+          membresias_pago: membresias_total.toString(),
+          membresias: membresias_total.toString(),
+          otros: otros_total.toString(),
+        })
+        .where(eq(creditos.credito_id, creditoDestino.credito_id))
+        .returning()
+    );
 
     console.log(
       `   ✅ Crédito ${creditoDestino.numero_credito_sifco} actualizado exitosamente`

--- a/apps/cartera-back/src/controllers/historialCapital.ts
+++ b/apps/cartera-back/src/controllers/historialCapital.ts
@@ -1,0 +1,60 @@
+import { desc, eq } from "drizzle-orm";
+import { db } from "../database";
+import { creditos, historial_capital_credito } from "../database/db";
+
+/**
+ * Historial de cambios del capital de un crédito (tabla historial_capital_credito,
+ * poblada por el trigger trg_historial_capital_credito). Devuelve los cambios más
+ * recientes primero, con fuente/motivo/usuario para la vista del front.
+ */
+export const getHistorialCapital = async ({
+  numero_credito_sifco,
+  set,
+}: {
+  numero_credito_sifco: string;
+  set: { status: number };
+}) => {
+  try {
+    if (!numero_credito_sifco) {
+      set.status = 400;
+      return { success: false, message: "Falta numero_credito_sifco" };
+    }
+
+    const [creditoDb] = await db
+      .select({ credito_id: creditos.credito_id })
+      .from(creditos)
+      .where(eq(creditos.numero_credito_sifco, numero_credito_sifco))
+      .limit(1);
+
+    if (!creditoDb) {
+      set.status = 404;
+      return { success: false, message: "Crédito no encontrado" };
+    }
+
+    const historial = await db
+      .select({
+        id: historial_capital_credito.id,
+        operacion: historial_capital_credito.operacion,
+        capital_anterior: historial_capital_credito.capital_anterior,
+        capital_nuevo: historial_capital_credito.capital_nuevo,
+        fuente: historial_capital_credito.fuente,
+        motivo: historial_capital_credito.motivo,
+        platform_user_id: historial_capital_credito.platform_user_id,
+        user_email: historial_capital_credito.user_email,
+        fecha: historial_capital_credito.fecha,
+      })
+      .from(historial_capital_credito)
+      .where(eq(historial_capital_credito.credito_id, creditoDb.credito_id))
+      .orderBy(desc(historial_capital_credito.fecha), desc(historial_capital_credito.id));
+
+    return { success: true, historial };
+  } catch (error) {
+    console.error("Error en getHistorialCapital:", error);
+    set.status = 500;
+    return {
+      success: false,
+      message: "Error interno del servidor",
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+};

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -1,6 +1,7 @@
 import Big from "big.js";
 import z from "zod";
 import { db, client } from "../database";
+import { withCapitalContext } from "../utils/withAuditContext";
 import {
   creditos,
   usuarios,
@@ -2354,15 +2355,17 @@ export async function aplicarPagoAlCredito(pago_id: number) {
         });
         const nuevoCapitalParc = recomputedParc.capital;
 
-        await db
-          .update(creditos)
-          .set({
-            capital: nuevoCapitalParc.toString(),
-            deudatotal: recomputedParc.deudaTotal.toString(),
-            iva_12: recomputedParc.iva.toString(),
-            cuota_interes: recomputedParc.cuotaInteres.toString(),
-          })
-          .where(eq(creditos.credito_id, pago.credito_id));
+        await withCapitalContext(null, "PAGO", null, (tx) =>
+          tx
+            .update(creditos)
+            .set({
+              capital: nuevoCapitalParc.toString(),
+              deudatotal: recomputedParc.deudaTotal.toString(),
+              iva_12: recomputedParc.iva.toString(),
+              cuota_interes: recomputedParc.cuotaInteres.toString(),
+            })
+            .where(eq(creditos.credito_id, pago.credito_id!))
+        );
 
         console.log("💰 Nuevo capital:", nuevoCapitalParc.toString());
         console.log("✅ Capital aplicado al crédito (cuota aún abierta)");
@@ -2426,15 +2429,17 @@ export async function aplicarPagoAlCredito(pago_id: number) {
     console.log("📊 Nueva deuda total:", nueva_deuda_total.toString());
 
     // 6. ACTUALIZAR EL CRÉDITO
-    await db
-      .update(creditos)
-      .set({
-        capital: nuevo_capital.toString(),
-        deudatotal: nueva_deuda_total.toString(),
-        iva_12: iva_12.toString(),
-        cuota_interes: cuota_interes.toString(),
-      })
-      .where(eq(creditos.credito_id, pago.credito_id));
+    await withCapitalContext(null, "PAGO", null, (tx) =>
+      tx
+        .update(creditos)
+        .set({
+          capital: nuevo_capital.toString(),
+          deudatotal: nueva_deuda_total.toString(),
+          iva_12: iva_12.toString(),
+          cuota_interes: cuota_interes.toString(),
+        })
+        .where(eq(creditos.credito_id, pago.credito_id!))
+    );
 
     // 7. VALIDAR EL PAGO y registrar fecha de aplicación
     await db
@@ -2832,15 +2837,17 @@ export async function aplicarAbonoCapitalInversionistas(
   console.log(`📊 Nueva Deuda Total: Q${deudatotal.toString()}`);
 
   // 1️⃣.2 Actualizar el crédito
-  await db
-    .update(creditos)
-    .set({
-      capital: nuevoCapital.toString(),
-      deudatotal: deudatotal.toString(),
-      cuota_interes: cuota_interes.toString(),
-      iva_12: iva_12.toString(),
-    })
-    .where(eq(creditos.credito_id, credito_id));
+  await withCapitalContext(null, "PAGO", null, (tx) =>
+    tx
+      .update(creditos)
+      .set({
+        capital: nuevoCapital.toString(),
+        deudatotal: deudatotal.toString(),
+        cuota_interes: cuota_interes.toString(),
+        iva_12: iva_12.toString(),
+      })
+      .where(eq(creditos.credito_id, credito_id))
+  );
 
   console.log(`✅ Crédito actualizado`);
 

--- a/apps/cartera-back/src/controllers/revalidatePayment.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { eq, and } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
+import { setCapitalSource } from "../utils/withAuditContext";
 import { pagos_credito, creditos } from "../database/db";
 import { insertPagosCreditoInversionistasV2 } from "./payments";
 import { esPagoAplicado } from "../utils/paymentStatus";
@@ -143,6 +144,7 @@ export const revalidatePayment = async ({ body, set }: any) => {
 
       // 6️⃣ ACTUALIZAR EL CRÉDITO
       if (pago.credito_id !== null) {
+        await setCapitalSource(tx, "PAGO");
         await tx
           .update(creditos)
           .set({

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { eq, and, not, inArray, sql } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
+import { setCapitalSource } from "../utils/withAuditContext";
 import {
   pagos_credito,
   creditos,
@@ -227,6 +228,7 @@ export const reversePayment = async ({ body, set }: any) => {
       // 7️⃣ ACTUALIZAR EL CRÉDITO CON LOS NUEVOS VALORES
       // ======================================================================
       if (pagoValidado) {
+        await setCapitalSource(tx, "REVERSO");
         await tx
           .update(creditos)
           .set({

--- a/apps/cartera-back/src/controllers/revertPaymentToPending.ts
+++ b/apps/cartera-back/src/controllers/revertPaymentToPending.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { eq, and, or } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
+import { setCapitalSource } from "../utils/withAuditContext";
 import {
   pagos_credito,
   creditos,
@@ -142,6 +143,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
 
         console.log(`💳 Nueva deuda total: ${deudatotal.toString()}`);
 
+        await setCapitalSource(tx, "REVERSO");
         await tx
           .update(creditos)
           .set({

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -14,7 +14,7 @@ import {
 import z from "zod";
 import type { WSCrEstadoCuentaResponse } from "../services/sifco.interface";
 import { consultarEstadoCuentaPrestamo } from "../services/sifcoIntegrations";
-import { withAuditContext } from "../utils/withAuditContext";
+import { withAuditContext, withCapitalContext } from "../utils/withAuditContext";
 
 interface UpdateInstallmentsParams {
   numero_credito_sifco: string;
@@ -453,6 +453,8 @@ const creditUpdateSchema = z.object({
   estado_devolucion: z.enum(['NO_APLICA', 'PENDIENTE_AUTORIZACION', 'VERIFICADO', 'RECHAZADO']).optional(),
   motivo_devolucion: z.string().optional(),
   bandera_reinversion: z.boolean().optional(),
+  // Motivo del ajuste manual de capital (se registra en historial_capital_credito).
+  motivo_ajuste_capital: z.string().max(500).optional(),
 });
 
 type CreditUpdateData = z.infer<typeof creditUpdateSchema>;
@@ -1007,6 +1009,7 @@ export const updateCredit = async ({ body, set, request }: any) => {
       estado_devolucion,
       motivo_devolucion,
       bandera_reinversion,
+      motivo_ajuste_capital,
       ...fieldsToUpdate
     } = parseResult.data;
 
@@ -1215,12 +1218,34 @@ export const updateCredit = async ({ body, set, request }: any) => {
     updateFields.membresias =
       fieldsToUpdate.membresias_pago ?? current.membresias_pago;
 
-    // 8. Actualizar el crédito
-    const [updatedCredit] = await db
-      .update(creditos)
-      .set(updateFields)
-      .where(eq(creditos.credito_id, credito_id))
-      .returning();
+    // 8. Actualizar el crédito.
+    // Si el capital cambia, envolvemos el UPDATE en withCapitalContext para que
+    // el trigger trg_historial_capital_credito registre el ajuste manual con
+    // usuario + motivo (fuente = 'AJUSTE_MANUAL'). Si no cambia, el trigger no
+    // dispara (guard IS DISTINCT) y hacemos el UPDATE normal.
+    const capitalCambia =
+      fieldsToUpdate.capital !== undefined &&
+      !new Big(fieldsToUpdate.capital).eq(new Big(current.capital || 0));
+
+    const ejecutarUpdateCredito = (dbInstance: typeof db) =>
+      dbInstance
+        .update(creditos)
+        .set(updateFields)
+        .where(eq(creditos.credito_id, credito_id))
+        .returning();
+
+    let updatedCredit;
+    if (capitalCambia) {
+      const ajusteUserId = extractUserId(request);
+      [updatedCredit] = await withCapitalContext(
+        ajusteUserId,
+        "AJUSTE_MANUAL",
+        motivo_ajuste_capital,
+        ejecutarUpdateCredito,
+      );
+    } else {
+      [updatedCredit] = await ejecutarUpdateCredito(db);
+    }
 
     // 8.1 Si la cuota cambió, sincronizar cuotas pendientes y recalcular
     // cuotas de inversionistas (solo si NO vinieron en el body — si vinieron,

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1762,6 +1762,30 @@
     })
   );
 
+  // ── Historial de cambios del capital de un crédito ──
+  // Poblado por el trigger trg_historial_capital_credito (ver drizzle/0014).
+  export const historial_capital_credito = customSchema.table(
+    "historial_capital_credito",
+    {
+      id: bigint("id", { mode: "number" }).primaryKey().generatedAlwaysAsIdentity(),
+      txid: bigint("txid", { mode: "number" }).notNull(),
+      operacion: text("operacion").notNull(),
+      credito_id: integer("credito_id").notNull().references(() => creditos.credito_id, { onDelete: "cascade" }),
+      capital_anterior: numeric("capital_anterior", { precision: 18, scale: 2 }),
+      capital_nuevo: numeric("capital_nuevo", { precision: 18, scale: 2 }),
+      fuente: text("fuente").notNull().default("SISTEMA"),
+      motivo: text("motivo"),
+      platform_user_id: integer("platform_user_id").references(() => platform_users.id, { onDelete: "set null" }),
+      user_email: varchar("user_email", { length: 200 }),
+      fecha: timestamp("fecha", { withTimezone: true }).notNull().defaultNow(),
+    },
+    (t) => ({
+      ixCred:   index("ix_hist_cap_cred").on(t.credito_id, t.fecha),
+      ixFecha:  index("ix_hist_cap_fecha").on(t.fecha),
+      ixFuente: index("ix_hist_cap_fuente").on(t.fuente),
+    })
+  );
+
   // ── Audit logs ──
   export const audit_logs = customSchema.table("audit_logs", {
     id: serial("id").primaryKey(),

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -46,6 +46,7 @@ import {
 } from "../controllers/bulkInsoluto";
 import {  updateAllInstallments, updateCredit, recalculateQuota, recalcularPagosCredito, calculateInvestorQuotas, repararTotalRestante } from "../controllers/updateCredit";
 import { updateDueDates, updateSingleDueDate, fixCreditosWithoutFebruary, updateDueDatesFromJson, cambiarFechaInicio, getHistorialCambioFecha } from "../controllers/updateDueDate";
+import { getHistorialCapital } from "../controllers/historialCapital";
 import { creditos, cuotas_credito } from "../database/db";
 import { and, desc, eq } from "drizzle-orm";
 import { db } from "../database"; 
@@ -1681,6 +1682,24 @@ export const creditRouter = new Elysia()
       detail: {
         tags: ["Créditos"],
         summary: "Obtener historial de cambios de fecha de inicio",
+      },
+    }
+  )
+  // ========================================
+  // ENDPOINT: HISTORIAL DE CAPITAL
+  // ========================================
+  .get(
+    "/historial-capital/:numero_credito_sifco",
+    async ({ params, set }) => {
+      return getHistorialCapital({
+        numero_credito_sifco: params.numero_credito_sifco,
+        set,
+      });
+    },
+    {
+      detail: {
+        tags: ["Créditos"],
+        summary: "Obtener historial de cambios del capital de un crédito",
       },
     }
   )

--- a/apps/cartera-back/src/utils/withAuditContext.ts
+++ b/apps/cartera-back/src/utils/withAuditContext.ts
@@ -12,3 +12,53 @@ export async function withAuditContext<T>(
     return fn(tx as unknown as DbOrTx);
   });
 }
+
+/**
+ * Contexto para el trigger trg_historial_capital_credito (ver drizzle/0014).
+ * Setea, dentro de una transacción, las GUCs que el trigger lee para etiquetar
+ * un cambio de creditos.capital: usuario, fuente y motivo. Usa set_config con
+ * parámetros ligados (no interpolación) para que el `motivo` de texto libre sea
+ * seguro ante inyección. Ejecuta `fn` con la MISMA transacción para que el
+ * UPDATE dispare el trigger con las GUCs ya seteadas.
+ */
+export async function withCapitalContext<T>(
+  userId: number | null | undefined,
+  source: string,
+  motivo: string | null | undefined,
+  fn: (tx: DbOrTx) => Promise<T>
+): Promise<T> {
+  return db.transaction(async (tx) => {
+    await setCapitalSource(tx, source, userId, motivo);
+    return fn(tx as unknown as DbOrTx);
+  });
+}
+
+/**
+ * Setea las GUCs del historial de capital sobre una transacción YA existente
+ * (para write sites que corren dentro de su propio db.transaction). Debe
+ * llamarse ANTES del UPDATE a creditos, dentro de la misma tx, para que el
+ * trigger lea la fuente/usuario/motivo. Usa set_config con params ligados.
+ * withCapitalContext delega aquí para no duplicar la lógica.
+ */
+// Ejecutor mínimo que cubre tanto `db` como una transacción `tx` (PgTransaction).
+type SqlExecutor = { execute: (query: any) => Promise<unknown> };
+
+export async function setCapitalSource(
+  tx: SqlExecutor,
+  source: string,
+  userId?: number | null,
+  motivo?: string | null
+): Promise<void> {
+  // Solo seteamos el usuario si es un entero finito: el trigger castea
+  // app.current_user_id::INT, y un valor como 'NaN' abortaría el UPDATE del
+  // crédito (rollback). Un id no numérico simplemente deja la atribución en NULL.
+  if (userId != null && Number.isInteger(Number(userId))) {
+    await tx.execute(
+      sql`select set_config('app.current_user_id', ${String(Number(userId))}, true)`
+    );
+  }
+  await tx.execute(sql`select set_config('app.capital_source', ${source}, true)`);
+  if (motivo != null && motivo !== "") {
+    await tx.execute(sql`select set_config('app.capital_motivo', ${motivo}, true)`);
+  }
+}

--- a/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalEditCredit.tsx
@@ -175,6 +175,7 @@ export function ModalEditCredit({
       ...safeInitialValues,
       estado_devolucion: safeInitialValues.estado_devolucion ?? "NO_APLICA",
       motivo_devolucion: "",
+      motivo_ajuste_capital: "",
       investors: parsedInvestors,
       investorsMirror: parsedInvestorsMirror, // 🆕 Campo para espejo
     },
@@ -256,6 +257,11 @@ export function ModalEditCredit({
         motivo_devolucion:
           values.estado_devolucion === "PENDIENTE_AUTORIZACION"
             ? values.motivo_devolucion?.trim() || ""
+            : undefined,
+        // Motivo del ajuste manual de capital: solo si el capital realmente cambió
+        motivo_ajuste_capital:
+          Number(values.capital) !== Number(safeInitialValues.capital ?? 0)
+            ? values.motivo_ajuste_capital?.trim() || undefined
             : undefined,
 
         // Lista Principal
@@ -567,6 +573,35 @@ export function ModalEditCredit({
                   );
                 })}
               </div>
+
+              {/* Motivo del ajuste de capital: aparece solo cuando el capital cambió */}
+              {Number(formik.values.capital ?? 0) !==
+                Number(safeInitialValues.capital ?? 0) && (
+                <div className="mt-3 p-3 rounded-lg border border-amber-200 bg-amber-50">
+                  <Label className="text-amber-800 font-medium">
+                    Motivo del ajuste de capital
+                  </Label>
+                  <Input
+                    type="text"
+                    name="motivo_ajuste_capital"
+                    value={formik.values.motivo_ajuste_capital || ""}
+                    onChange={formik.handleChange}
+                    onBlur={formik.handleBlur}
+                    placeholder="¿Por qué se está ajustando el capital? (queda en el historial)"
+                    className="mt-1 border-amber-300 bg-white"
+                  />
+                  <p className="text-xs text-amber-700 mt-1">
+                    Capital: Q
+                    {Number(safeInitialValues.capital ?? 0).toLocaleString("es-GT", {
+                      minimumFractionDigits: 2,
+                    })}{" "}
+                    → Q
+                    {Number(formik.values.capital ?? 0).toLocaleString("es-GT", {
+                      minimumFractionDigits: 2,
+                    })}
+                  </p>
+                </div>
+              )}
             </div>
 
             {/* Opciones del crédito */}

--- a/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PaymentsCredits.tsx
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useParams, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
-import { getPagosByCredito, getHistorialCambioFecha, type HistorialCambioFecha } from "../services/services";
+import { getPagosByCredito, getHistorialCambioFecha, type HistorialCambioFecha, getHistorialCapital, type HistorialCapital } from "../services/services";
 import {
   Table,
   TableBody,
@@ -46,7 +46,7 @@ import { editPaymentService, type EditPaymentParams } from "../services/services
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Input } from "@/components/ui/input";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { DollarSign, Pencil } from "lucide-react";
+import { DollarSign, Pencil, History } from "lucide-react";
 import { toast } from "sonner";
 // Iconos y colores por atributo
 const iconMap: Record<string, { icon: React.ReactNode; color: string }> = {
@@ -398,6 +398,26 @@ function colorEstado(estado: string) {
   return "bg-red-100 text-red-700 border-red-200";
 }
 
+// Estilos del badge por fuente del cambio de capital
+function colorFuenteCapital(fuente: string) {
+  switch (fuente) {
+    case "AJUSTE_MANUAL":
+      return "bg-amber-100 text-amber-800 border-amber-300";
+    case "CREACION":
+      return "bg-indigo-100 text-indigo-700 border-indigo-300";
+    case "PAGO":
+      return "bg-green-100 text-green-700 border-green-200";
+    case "REVERSO":
+      return "bg-orange-100 text-orange-700 border-orange-200";
+    case "CASTIGO":
+      return "bg-red-100 text-red-700 border-red-200";
+    case "MERGE":
+      return "bg-purple-100 text-purple-700 border-purple-200";
+    default:
+      return "bg-gray-100 text-gray-600 border-gray-300";
+  }
+}
+
 export function PaymentsCredits() {
   const [showInversionistas, setShowInversionistas] = useState(false);
   const [collapseInv, setCollapseInv] = useState<{ [key: number]: boolean }>(
@@ -418,6 +438,8 @@ export function PaymentsCredits() {
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [pagoParaEditar, setPagoParaEditar] = useState<any | null>(null);
   const [historialFecha, setHistorialFecha] = useState<HistorialCambioFecha[]>([]);
+  const [historialCapital, setHistorialCapital] = useState<HistorialCapital[]>([]);
+  const [showHistorialCapital, setShowHistorialCapital] = useState(false);
 
   React.useEffect(() => {
     if (!numero_credito_sifco) return;
@@ -438,6 +460,16 @@ export function PaymentsCredits() {
     queryFn: () => getPagosByCredito(numero_credito_sifco!,false),
     enabled: !!numero_credito_sifco,
   });
+
+  React.useEffect(() => {
+    if (!numero_credito_sifco) return;
+    getHistorialCapital(numero_credito_sifco)
+      .then((res) => setHistorialCapital(Array.isArray(res) ? res : []))
+      .catch((err) => {
+        console.error("Error al cargar historial de capital:", err);
+        setHistorialCapital([]);
+      });
+  }, [numero_credito_sifco]);
 const handleDownloadExcel = async () => {
   if (!numero_credito_sifco || descargandoExcel) return;
 
@@ -575,6 +607,69 @@ const handleDownloadExcel = async () => {
                   <span className="text-gray-400 text-xs ml-1">({new Date(h.created_at).toLocaleDateString("es-GT")})</span>
                 </span>
               ))}
+            </div>
+          )}
+
+          {/* Historial de capital */}
+          {historialCapital.length > 0 && (
+            <div className="w-full max-w-3xl mx-auto mt-3">
+              <button
+                type="button"
+                onClick={() => setShowHistorialCapital((v) => !v)}
+                className="w-full flex items-center justify-between gap-2 bg-amber-50 border-2 border-amber-200 rounded-xl px-4 py-2.5 shadow-sm hover:bg-amber-100/70 transition-colors"
+              >
+                <span className="flex items-center gap-2 text-amber-800 font-semibold text-sm">
+                  <History className="w-4 h-4 shrink-0" />
+                  Historial de capital ({historialCapital.length})
+                </span>
+                {showHistorialCapital ? (
+                  <ChevronUp className="w-4 h-4 text-amber-700" />
+                ) : (
+                  <ChevronDown className="w-4 h-4 text-amber-700" />
+                )}
+              </button>
+
+              {showHistorialCapital && (
+                <div className="mt-2 border border-amber-100 rounded-xl overflow-hidden divide-y divide-amber-50">
+                  {historialCapital.map((h) => (
+                    <div key={h.id} className="flex flex-col gap-1 bg-white px-4 py-2.5">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span
+                          className={`inline-flex items-center rounded-md border px-2 py-0.5 text-xs font-bold ${colorFuenteCapital(
+                            h.fuente
+                          )}`}
+                        >
+                          {h.fuente}
+                        </span>
+                        <span className="text-gray-400 line-through text-sm">
+                          {h.capital_anterior === null
+                            ? "—"
+                            : formatCurrency(h.capital_anterior)}
+                        </span>
+                        <span className="text-gray-400">&rarr;</span>
+                        <span className="font-semibold text-gray-800 text-sm">
+                          {h.capital_nuevo === null
+                            ? "—"
+                            : formatCurrency(h.capital_nuevo)}
+                        </span>
+                        <span className="text-gray-400 text-xs ml-auto">
+                          {formatDateTime(h.fecha)}
+                        </span>
+                      </div>
+                      {(h.motivo || h.user_email) && (
+                        <div className="flex items-center gap-2 text-xs text-gray-500 flex-wrap">
+                          {h.motivo && (
+                            <span className="italic">“{h.motivo}”</span>
+                          )}
+                          {h.user_email && (
+                            <span className="ml-auto">{h.user_email}</span>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
           )}
 

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -759,6 +759,10 @@ export interface UpdateCreditBody {
   permite_abono_capital?: boolean;
   no_amortiza_capital?: boolean;
   estado_devolucion?: 'NO_APLICA' | 'PENDIENTE_AUTORIZACION' | 'VERIFICADO' | 'RECHAZADO';
+  motivo_devolucion?: string;
+
+  // Motivo del ajuste manual de capital (se registra en el historial de capital)
+  motivo_ajuste_capital?: string;
 
   // Inversionistas nuevos
   inversionistas?: InversionistaPayload[];
@@ -3533,6 +3537,24 @@ export interface HistorialCambioFecha {
 
 export async function getHistorialCambioFecha(numeroCreditoSifco: string): Promise<HistorialCambioFecha[]> {
   const { data } = await api.get(`/historial-cambio-fecha/${numeroCreditoSifco}`);
+  return data.historial ?? [];
+}
+
+// Historial de cambios del capital de un crédito
+export interface HistorialCapital {
+  id: number;
+  operacion: string;               // INSERT | UPDATE
+  capital_anterior: string | null; // numeric → string
+  capital_nuevo: string | null;
+  fuente: string;                  // AJUSTE_MANUAL | PAGO | REVERSO | CASTIGO | MERGE | CREACION | SISTEMA
+  motivo: string | null;
+  platform_user_id: number | null;
+  user_email: string | null;
+  fecha: string;
+}
+
+export async function getHistorialCapital(numeroCreditoSifco: string): Promise<HistorialCapital[]> {
+  const { data } = await api.get(`/historial-capital/${numeroCreditoSifco}`);
   return data.historial ?? [];
 }
 


### PR DESCRIPTION
## Qué

Mini-módulo para llevar el **historial de cambios del capital** de un crédito, con foco en los **ajustes manuales** desde el modal de editar crédito.

## Cómo

Un **trigger de Postgres** (`trg_historial_capital_credito`) sobre `cartera.creditos` inserta en la tabla nueva `cartera.historial_capital_credito` cada vez que cambia `capital` (dispara en `INSERT` y en `UPDATE OF capital`, con guard `IS DISTINCT FROM`). La app decora cada cambio con **fuente / usuario / motivo** vía GUCs de sesión (`set_config(..., is_local=true)`), mismo patrón que el audit del espejo de inversionistas (`0004`).

- Ajuste manual (`updateCredit`) → fuente `AJUSTE_MANUAL` + `motivo` (del modal) + usuario del JWT.
- `INSERT` de crédito → `CREACION` automático.
- Cualquier otro cambio no instrumentado → `SISTEMA` (nunca se pierde un cambio). El etiquetado fino de pago/reverso/castigo/merge va en el **PR apilado** (fuentes).

## Incluye

- **Migración 0014** (tabla + función + trigger). ⚠️ **Ya aplicada en PROD y DEV** (verificada con transacción + rollback); este PR la versiona.
- `withCapitalContext` / `setCapitalSource` en `withAuditContext.ts` (params ligados → `motivo` seguro ante inyección; solo setea usuario si es entero finito para no romper el UPDATE por cast).
- `updateCredit`: envuelve el `UPDATE` de capital **solo cuando el capital cambia**.
- Endpoint `GET /historial-capital/:numero_credito_sifco` + controlador.
- **Front**: campo "Motivo del ajuste" en el modal (aparece al cambiar capital) + panel colapsable de historial con badges por fuente en el detalle del crédito.

## Notas

- Sin desplegar aún: hasta el deploy, prod registra los cambios como `SISTEMA`/`CREACION` (el trigger ya corre); el etiquetado `AJUSTE_MANUAL` + motivo + la vista aplican al desplegar cartera-back y carteraFront.
- Code review propio (multi-ángulo) aplicado: endpoint por `numero_credito_sifco` (evita depender de que el crédito tenga pagos), guard de `NaN` en el user id, dedup de `withCapitalContext`→`setCapitalSource`.
- `tsc`: 0 errores nuevos (backend y front).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
