### PR TITLE
feat(cartera): etiquetar fuentes de cambio de capital (pago/reverso/castigo/merge)

### DIFF
--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -1,4 +1,5 @@
 import { db } from "../database/index";
+import { withCapitalContext, setCapitalSource } from "../utils/withAuditContext";
 import {
   aseguradoras,
   asesores,
@@ -1600,6 +1601,7 @@ export async function actualizarEstadoCredito(input: AccionCreditoParams) {
         .returning({ cuota_id: cuotas_credito.cuota_id });
 
       // e) Actualizar crédito: INCOBRABLE, plazo 1, cuota = capital completo
+      await setCapitalSource(tx, "CASTIGO");
       await tx
         .update(creditos)
         .set({
@@ -1756,24 +1758,26 @@ export async function reiniciarCredito(
   creditId: number,
   montoIncobrable?: number
 ) {
-  await db
-    .update(creditos)
-    .set({
-      capital: "0",
-      deudatotal: montoIncobrable !== undefined ? String(montoIncobrable) : "0",
-      cuota_interes: "0",
-      cuota: "0",
-      iva_12: "0",
-      seguro_10_cuotas: "0",
-      gps: "0",
-      membresias_pago: "0",
-      membresias: "0",
-      porcentaje_royalti: "0",
-      royalti: "0",
-      otros: "0",
-      statusCredit: "ACTIVO",
-    })
-    .where(eq(creditos.credito_id, creditId));
+  await withCapitalContext(null, "REINICIO", null, (tx) =>
+    tx
+      .update(creditos)
+      .set({
+        capital: "0",
+        deudatotal: montoIncobrable !== undefined ? String(montoIncobrable) : "0",
+        cuota_interes: "0",
+        cuota: "0",
+        iva_12: "0",
+        seguro_10_cuotas: "0",
+        gps: "0",
+        membresias_pago: "0",
+        membresias: "0",
+        porcentaje_royalti: "0",
+        royalti: "0",
+        otros: "0",
+        statusCredit: "ACTIVO",
+      })
+      .where(eq(creditos.credito_id, creditId))
+  );
 }
 
 function construirUrlBoletas(url_boletas: string[], r2BaseUrl: string) {
@@ -2063,25 +2067,27 @@ export async function resetCredit({
       const capitalIncobrable = new Big(montoIncobrable!);
 
       // 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
-      await db
-        .update(creditos)
-        .set({
-          capital: capitalIncobrable.toString(),
-          deudatotal: capitalIncobrable.toString(),
-          cuota_interes: "0",
-          cuota: capitalIncobrable.toString(),
-          iva_12: "0",
-          seguro_10_cuotas: "0",
-          gps: "0",
-          membresias_pago: "0",
-          membresias: "0",
-          porcentaje_royalti: "0",
-          royalti: "0",
-          otros: "0",
-          plazo: 1,
-          statusCredit: "INCOBRABLE",
-        })
-        .where(eq(creditos.credito_id, creditId));
+      await withCapitalContext(null, "CASTIGO", null, (tx) =>
+        tx
+          .update(creditos)
+          .set({
+            capital: capitalIncobrable.toString(),
+            deudatotal: capitalIncobrable.toString(),
+            cuota_interes: "0",
+            cuota: capitalIncobrable.toString(),
+            iva_12: "0",
+            seguro_10_cuotas: "0",
+            gps: "0",
+            membresias_pago: "0",
+            membresias: "0",
+            porcentaje_royalti: "0",
+            royalti: "0",
+            otros: "0",
+            plazo: 1,
+            statusCredit: "INCOBRABLE",
+          })
+          .where(eq(creditos.credito_id, creditId))
+      );
 
       // 16b. Crear cuota pendiente para el monto incobrable (correlativa)
       const [maxCuotaRowInc] = await db
@@ -2144,24 +2150,26 @@ export async function resetCredit({
       });
     } else {
       // CANCELADO: zerear todo (preservamos porcentaje_interes)
-      await db
-        .update(creditos)
-        .set({
-          capital: "0",
-          deudatotal: "0",
-          cuota_interes: "0",
-          cuota: "0",
-          iva_12: "0",
-          seguro_10_cuotas: "0",
-          gps: "0",
-          membresias_pago: "0",
-          membresias: "0",
-          porcentaje_royalti: "0",
-          royalti: "0",
-          otros: "0",
-          statusCredit: "CANCELADO",
-        })
-        .where(eq(creditos.credito_id, creditId));
+      await withCapitalContext(null, "CANCELACION", null, (tx) =>
+        tx
+          .update(creditos)
+          .set({
+            capital: "0",
+            deudatotal: "0",
+            cuota_interes: "0",
+            cuota: "0",
+            iva_12: "0",
+            seguro_10_cuotas: "0",
+            gps: "0",
+            membresias_pago: "0",
+            membresias: "0",
+            porcentaje_royalti: "0",
+            royalti: "0",
+            otros: "0",
+            statusCredit: "CANCELADO",
+          })
+          .where(eq(creditos.credito_id, creditId))
+      );
     }
 
     // 17. Retorno OK
@@ -2647,22 +2655,24 @@ export const mergeCreditosAndUpdate = async ({
       "💾 PASO 3: Actualizando crédito destino con valores consolidados..."
     );
 
-    const [creditoActualizado] = await db
-      .update(creditos)
-      .set({
-        capital: capitalTotal.toString(),
-        cuota: cuota_total.toString(),
-        cuota_interes: cuota_interes.toString(),
-        iva_12: iva_12.toString(),
-        deudatotal: deudatotal.toString(),
-        seguro_10_cuotas: seguro_total.toString(),
-        gps: gps_total.toString(),
-        membresias_pago: membresias_total.toString(),
-        membresias: membresias_total.toString(),
-        otros: otros_total.toString(),
-      })
-      .where(eq(creditos.credito_id, creditoDestino.credito_id))
-      .returning();
+    const [creditoActualizado] = await withCapitalContext(null, "MERGE", null, (tx) =>
+      tx
+        .update(creditos)
+        .set({
+          capital: capitalTotal.toString(),
+          cuota: cuota_total.toString(),
+          cuota_interes: cuota_interes.toString(),
+          iva_12: iva_12.toString(),
+          deudatotal: deudatotal.toString(),
+          seguro_10_cuotas: seguro_total.toString(),
+          gps: gps_total.toString(),
+          membresias_pago: membresias_total.toString(),
+          membresias: membresias_total.toString(),
+          otros: otros_total.toString(),
+        })
+        .where(eq(creditos.credito_id, creditoDestino.credito_id))
+        .returning()
+    );
 
     console.log(
       `   ✅ Crédito ${creditoDestino.numero_credito_sifco} actualizado exitosamente`

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -1,6 +1,7 @@
 import Big from "big.js";
 import z from "zod";
 import { db, client } from "../database";
+import { withCapitalContext } from "../utils/withAuditContext";
 import {
   creditos,
   usuarios,
@@ -2354,15 +2355,17 @@ export async function aplicarPagoAlCredito(pago_id: number) {
         });
         const nuevoCapitalParc = recomputedParc.capital;
 
-        await db
-          .update(creditos)
-          .set({
-            capital: nuevoCapitalParc.toString(),
-            deudatotal: recomputedParc.deudaTotal.toString(),
-            iva_12: recomputedParc.iva.toString(),
-            cuota_interes: recomputedParc.cuotaInteres.toString(),
-          })
-          .where(eq(creditos.credito_id, pago.credito_id));
+        await withCapitalContext(null, "PAGO", null, (tx) =>
+          tx
+            .update(creditos)
+            .set({
+              capital: nuevoCapitalParc.toString(),
+              deudatotal: recomputedParc.deudaTotal.toString(),
+              iva_12: recomputedParc.iva.toString(),
+              cuota_interes: recomputedParc.cuotaInteres.toString(),
+            })
+            .where(eq(creditos.credito_id, pago.credito_id!))
+        );
 
         console.log("💰 Nuevo capital:", nuevoCapitalParc.toString());
         console.log("✅ Capital aplicado al crédito (cuota aún abierta)");
@@ -2426,15 +2429,17 @@ export async function aplicarPagoAlCredito(pago_id: number) {
     console.log("📊 Nueva deuda total:", nueva_deuda_total.toString());
 
     // 6. ACTUALIZAR EL CRÉDITO
-    await db
-      .update(creditos)
-      .set({
-        capital: nuevo_capital.toString(),
-        deudatotal: nueva_deuda_total.toString(),
-        iva_12: iva_12.toString(),
-        cuota_interes: cuota_interes.toString(),
-      })
-      .where(eq(creditos.credito_id, pago.credito_id));
+    await withCapitalContext(null, "PAGO", null, (tx) =>
+      tx
+        .update(creditos)
+        .set({
+          capital: nuevo_capital.toString(),
+          deudatotal: nueva_deuda_total.toString(),
+          iva_12: iva_12.toString(),
+          cuota_interes: cuota_interes.toString(),
+        })
+        .where(eq(creditos.credito_id, pago.credito_id!))
+    );
 
     // 7. VALIDAR EL PAGO y registrar fecha de aplicación
     await db
@@ -2832,15 +2837,17 @@ export async function aplicarAbonoCapitalInversionistas(
   console.log(`📊 Nueva Deuda Total: Q${deudatotal.toString()}`);
 
   // 1️⃣.2 Actualizar el crédito
-  await db
-    .update(creditos)
-    .set({
-      capital: nuevoCapital.toString(),
-      deudatotal: deudatotal.toString(),
-      cuota_interes: cuota_interes.toString(),
-      iva_12: iva_12.toString(),
-    })
-    .where(eq(creditos.credito_id, credito_id));
+  await withCapitalContext(null, "PAGO", null, (tx) =>
+    tx
+      .update(creditos)
+      .set({
+        capital: nuevoCapital.toString(),
+        deudatotal: deudatotal.toString(),
+        cuota_interes: cuota_interes.toString(),
+        iva_12: iva_12.toString(),
+      })
+      .where(eq(creditos.credito_id, credito_id))
+  );
 
   console.log(`✅ Crédito actualizado`);
 

--- a/apps/cartera-back/src/controllers/revalidatePayment.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { eq, and } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
+import { setCapitalSource } from "../utils/withAuditContext";
 import { pagos_credito, creditos } from "../database/db";
 import { insertPagosCreditoInversionistasV2 } from "./payments";
 import { esPagoAplicado } from "../utils/paymentStatus";
@@ -143,6 +144,7 @@ export const revalidatePayment = async ({ body, set }: any) => {
 
       // 6️⃣ ACTUALIZAR EL CRÉDITO
       if (pago.credito_id !== null) {
+        await setCapitalSource(tx, "PAGO");
         await tx
           .update(creditos)
           .set({

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import { eq, and, not, inArray, sql } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
+import { setCapitalSource } from "../utils/withAuditContext";
 import {
   pagos_credito,
   creditos,
@@ -227,6 +228,7 @@ export const reversePayment = async ({ body, set }: any) => {
       // 7️⃣ ACTUALIZAR EL CRÉDITO CON LOS NUEVOS VALORES
       // ======================================================================
       if (pagoValidado) {
+        await setCapitalSource(tx, "REVERSO");
         await tx
           .update(creditos)
           .set({

--- a/apps/cartera-back/src/controllers/revertPaymentToPending.ts
+++ b/apps/cartera-back/src/controllers/revertPaymentToPending.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { eq, and, or } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
+import { setCapitalSource } from "../utils/withAuditContext";
 import {
   pagos_credito,
   creditos,
@@ -142,6 +143,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
 
         console.log(`💳 Nueva deuda total: ${deudatotal.toString()}`);
 
+        await setCapitalSource(tx, "REVERSO");
         await tx
           .update(creditos)
           .set({


### PR DESCRIPTION
## Qué

Etiqueta la **fuente** de los cambios de `creditos.capital` en los write sites restantes, para que el historial (PR #1047) los registre con fuente precisa en vez de `SISTEMA`.

> ⛓️ **Apilado sobre #1047** (base = `feat/cartera-historial-capital`). Mergear #1047 primero; luego este se retargetea a `develop`. Depende de `withCapitalContext`/`setCapitalSource` introducidos ahí.

## Sitios instrumentados

| Fuente | Dónde |
|---|---|
| `PAGO` | `registerPayment` (parcial / cierre / abono a capital), `revalidatePayment` |
| `REVERSO` | `reversePayment`, `revertPaymentToPending` |
| `CASTIGO` | `credits.ts` incobrable (`actualizarEstadoCredito`, `resetCredit`) |
| `CANCELACION` | `credits.ts` reset a CANCELADO |
| `REINICIO` | `reiniciarCredito` |
| `MERGE` | `mergeCreditosAndUpdate` |

## Cómo

- Sitios que ya corren dentro de un `db.transaction` → `await setCapitalSource(tx, "FUENTE")` **antes** del `UPDATE` (misma tx, mismo connection).
- Sitios que hacían `db.update(...)` en autocommit → envueltos en `withCapitalContext(null, "FUENTE", null, (tx) => tx.update(...))`. Todos corren fuera de cualquier transacción externa (verificado), así que no se introducen transacciones anidadas.

## Notas

- `actualizarCapitalCredito` (registerPayment) es código muerto (definido, nunca llamado) → no se instrumenta.
- `tsc`: 0 errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
