### PR TITLE
fix(crm): save bank analysis statements as attachments

### DIFF
--- a/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
+++ b/apps/crm/apps/server/src/lib/bank-statement-documents.test.ts
@@ -1,0 +1,82 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+	canAutoAttachBankStatementDocuments,
+	getBankStatementOpportunityDocumentType,
+} from "./bank-statement-documents";
+
+describe("bank statement opportunity documents", () => {
+	test("maps only the first three PDFs to estados_cuenta document types", () => {
+		expect(getBankStatementOpportunityDocumentType(0)).toBe("estados_cuenta_1");
+		expect(getBankStatementOpportunityDocumentType(1)).toBe("estados_cuenta_2");
+		expect(getBankStatementOpportunityDocumentType(2)).toBe("estados_cuenta_3");
+		expect(getBankStatementOpportunityDocumentType(3)).toBeUndefined();
+	});
+
+	test("allows auto-attachments only for upload roles and assigned sales users", () => {
+		expect(
+			canAutoAttachBankStatementDocuments({
+				userRole: "admin",
+				userId: "user-1",
+				opportunityAssignedTo: "user-2",
+			}),
+		).toBe(true);
+		expect(
+			canAutoAttachBankStatementDocuments({
+				userRole: "sales",
+				userId: "user-1",
+				opportunityAssignedTo: "user-1",
+			}),
+		).toBe(true);
+		expect(
+			canAutoAttachBankStatementDocuments({
+				userRole: "sales",
+				userId: "user-1",
+				opportunityAssignedTo: "user-2",
+			}),
+		).toBe(false);
+		expect(
+			canAutoAttachBankStatementDocuments({
+				userRole: "juridico",
+				userId: "user-1",
+				opportunityAssignedTo: "user-1",
+			}),
+		).toBe(false);
+	});
+
+	test("writes opportunity attachments only after AI analysis succeeds and is persisted", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/bank-analysis.ts"),
+			"utf8",
+		);
+		const successIndex = source.indexOf(
+			"const creditCapacity = calculateCreditCapacity",
+		);
+		const persistedAnalysisIndex = source.indexOf(
+			"fullAnalysis: JSON.stringify(analysis)",
+		);
+		const attachmentWriteIndex = source.indexOf(
+			"const { key } = await uploadFileToR2(",
+		);
+
+		expect(successIndex).toBeGreaterThan(-1);
+		expect(persistedAnalysisIndex).toBeGreaterThan(successIndex);
+		expect(attachmentWriteIndex).toBeGreaterThan(persistedAnalysisIndex);
+	});
+
+	test("keeps non-upload roles analyzing while skipping auto-attachments", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/bank-analysis.ts"),
+			"utf8",
+		);
+		const permissionCheckIndex = source.indexOf(
+			"canAutoAttachBankStatementDocuments({",
+		);
+		const enableAttachmentsIndex = source.indexOf("opportunityForDocuments = {");
+
+		expect(permissionCheckIndex).toBeGreaterThan(-1);
+		expect(enableAttachmentsIndex).toBeGreaterThan(permissionCheckIndex);
+		expect(source).not.toContain('message: "No tienes permiso para subir documentos"');
+	});
+});

--- a/apps/crm/apps/server/src/lib/bank-statement-documents.ts
+++ b/apps/crm/apps/server/src/lib/bank-statement-documents.ts
@@ -1,0 +1,30 @@
+export const BANK_STATEMENT_OPPORTUNITY_DOCUMENT_TYPES = [
+	"estados_cuenta_1",
+	"estados_cuenta_2",
+	"estados_cuenta_3",
+] as const;
+
+export type BankStatementOpportunityDocumentType =
+	(typeof BANK_STATEMENT_OPPORTUNITY_DOCUMENT_TYPES)[number];
+
+export function getBankStatementOpportunityDocumentType(
+	index: number,
+): BankStatementOpportunityDocumentType | undefined {
+	return BANK_STATEMENT_OPPORTUNITY_DOCUMENT_TYPES[index];
+}
+
+export function canAutoAttachBankStatementDocuments({
+	userRole,
+	userId,
+	opportunityAssignedTo,
+}: {
+	userRole: string;
+	userId: string;
+	opportunityAssignedTo: string;
+}) {
+	if (!["admin", "sales", "sales_supervisor", "analyst"].includes(userRole)) {
+		return false;
+	}
+
+	return userRole !== "sales" || opportunityAssignedTo === userId;
+}

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -4,17 +4,30 @@ import { generateObject } from "ai";
 import { and, eq, isNull, lt, sql } from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
-import { coDebtors, creditAnalysis, leads } from "../db/schema/crm";
+import { opportunityDocuments } from "../db/schema/documents";
+import {
+	coDebtors,
+	creditAnalysis,
+	leads,
+	opportunities,
+} from "../db/schema/crm";
 import {
 	BANK_ANALYSIS_PROMPT,
 	bankStatementAnalysisSchema,
 } from "../lib/bank-analysis-schema";
+import {
+	canAutoAttachBankStatementDocuments,
+	getBankStatementOpportunityDocumentType,
+} from "../lib/bank-statement-documents";
+import { updateChecklistForClientDocument } from "../lib/checklist";
 import { calculateCreditCapacity } from "../lib/financial-math";
 import { crmProcedure } from "../lib/orpc";
 import {
 	buildUploadPrefix,
 	deleteFileFromR2,
+	generateUniqueFilename,
 	getFileBuffer,
+	uploadFileToR2,
 	verifyUploadedDocumentInR2,
 } from "../lib/storage";
 
@@ -43,6 +56,7 @@ export const bankAnalysisRouter = {
 					termMonths: z.number().int().min(12).max(120).default(60),
 					maxDebtRatio: z.number().min(0).max(1).default(0.2),
 					maxVariableDebtRatio: z.number().min(0).max(1).default(0.2),
+					opportunityId: z.string().uuid().optional(),
 				})
 				.refine((data) => data.leadId || data.coDebtorId, {
 					message: "Debe proporcionar leadId o coDebtorId",
@@ -89,11 +103,58 @@ export const bankAnalysisRouter = {
 				}
 			}
 
+			let opportunityForDocuments:
+				| { id: string; vehicleId: string | null }
+				| undefined;
+
+			if (isForLead && input.opportunityId) {
+				const [opportunity] = await db
+					.select({
+						id: opportunities.id,
+						leadId: opportunities.leadId,
+						vehicleId: opportunities.vehicleId,
+						assignedTo: opportunities.assignedTo,
+					})
+					.from(opportunities)
+					.where(eq(opportunities.id, input.opportunityId))
+					.limit(1);
+
+				if (!opportunity) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "Oportunidad no encontrada",
+					});
+				}
+
+				if (opportunity.leadId !== input.leadId) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: "La oportunidad no pertenece al lead analizado",
+					});
+				}
+
+				if (
+					canAutoAttachBankStatementDocuments({
+						userRole: context.userRole,
+						userId: context.userId,
+						opportunityAssignedTo: opportunity.assignedTo,
+					})
+				) {
+					opportunityForDocuments = {
+						id: opportunity.id,
+						vehicleId: opportunity.vehicleId,
+					};
+				}
+			}
+
 			const uploadedKeys: string[] = [];
 
 			try {
 				// 2. Validar archivos: descargar de R2 y verificar formato PDF
-				const downloadedFiles: { name: string; buffer: Buffer }[] = [];
+				const downloadedFiles: {
+					name: string;
+					buffer: Buffer;
+					mimeType: string;
+					size: number;
+				}[] = [];
 				for (const file of input.files) {
 					const uploadedFile = await verifyUploadedDocumentInR2({
 						key: file.key,
@@ -115,7 +176,12 @@ export const bankAnalysisRouter = {
 						});
 					}
 
-					downloadedFiles.push({ name: file.name, buffer });
+					downloadedFiles.push({
+						name: file.name,
+						buffer,
+						mimeType: uploadedFile.mimeType,
+						size: uploadedFile.size,
+					});
 				}
 
 				// 3. Incremento atómico del contador para evitar race conditions
@@ -302,6 +368,86 @@ export const bankAnalysisRouter = {
 						updatedAt: new Date(),
 					})
 					.where(whereCondition);
+
+				if (opportunityForDocuments) {
+					const savedDocuments: { id: string; documentType: string }[] = [];
+					const savedKeys: string[] = [];
+
+					try {
+						for (const [index, file] of downloadedFiles.entries()) {
+							const documentType = getBankStatementOpportunityDocumentType(index);
+							if (!documentType) {
+								continue;
+							}
+
+							const uniqueFilename = generateUniqueFilename(file.name);
+							const { key } = await uploadFileToR2(
+								new Blob([new Uint8Array(file.buffer)], { type: file.mimeType }),
+								uniqueFilename,
+								opportunityForDocuments.id,
+							);
+							savedKeys.push(key);
+
+							const [newDocument] = await db
+								.insert(opportunityDocuments)
+								.values({
+									opportunityId: opportunityForDocuments.id,
+									filename: uniqueFilename,
+									originalName: file.name,
+									mimeType: file.mimeType,
+									size: file.size,
+									documentType,
+									description:
+										"Guardado automáticamente desde análisis de capacidad de pago",
+									uploadedBy: context.userId,
+									filePath: key,
+								})
+								.returning({ id: opportunityDocuments.id });
+
+							if (newDocument) {
+								savedDocuments.push({ id: newDocument.id, documentType });
+								await updateChecklistForClientDocument(
+									opportunityForDocuments.id,
+									documentType,
+									newDocument.id,
+									!!opportunityForDocuments.vehicleId,
+									opportunityForDocuments.vehicleId || undefined,
+								);
+							}
+						}
+					} catch (error) {
+						const cleanupResults = await Promise.allSettled([
+							...savedDocuments.map(({ id }) =>
+								db
+									.delete(opportunityDocuments)
+									.where(eq(opportunityDocuments.id, id)),
+							),
+							...savedKeys.map((key) => deleteFileFromR2(key)),
+						]);
+						const failedCleanups = cleanupResults.filter(
+							(result) => result.status === "rejected",
+						);
+						await Promise.allSettled(
+							savedDocuments.map(({ id, documentType }) =>
+								updateChecklistForClientDocument(
+									opportunityForDocuments.id,
+									documentType,
+									id,
+									!!opportunityForDocuments.vehicleId,
+									opportunityForDocuments.vehicleId || undefined,
+								),
+							),
+						);
+
+						console.error("Failed to save bank statement opportunity documents", {
+							opportunityId: opportunityForDocuments.id,
+							savedDocuments: savedDocuments.length,
+							savedFiles: savedKeys.length,
+							failedCleanups: failedCleanups.length,
+							error: error instanceof Error ? error.message : String(error),
+						});
+					}
+				}
 
 				// 8. Retornar resultados
 				return {

--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -34,12 +34,14 @@ function isPdfFile(file: File) {
 interface BankStatementAnalysisProps {
 	leadId?: string;
 	coDebtorId?: string;
+	opportunityId?: string;
 	onAnalysisComplete?: () => void;
 }
 
 export function BankStatementAnalysis({
 	leadId,
 	coDebtorId,
+	opportunityId,
 	onAnalysisComplete,
 }: BankStatementAnalysisProps) {
 	const [files, setFiles] = useState<File[]>([]);
@@ -113,6 +115,7 @@ export function BankStatementAnalysis({
 
 			return client.analyzeBankStatements({
 				...(leadId ? { leadId } : { coDebtorId: coDebtorId! }),
+				...(leadId && opportunityId ? { opportunityId } : {}),
 				files: filePayloads,
 				annualRate: Number.parseFloat(annualRate),
 				termMonths: Number.parseInt(termMonths),

--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -345,6 +345,7 @@ export function OpportunityDetailModal({
 												to="/crm/leads"
 												search={{
 													leadId: displayLead.id,
+													opportunityId: opportunity.id,
 												}}
 												className="font-medium text-primary hover:underline"
 												onClick={() => onOpenChange(false)}

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -108,6 +108,7 @@ export const Route = createFileRoute("/crm/leads")({
 	validateSearch: z.object({
 		companyId: z.string().optional(),
 		leadId: z.string().optional(),
+		opportunityId: z.string().optional(),
 	}).parse,
 });
 
@@ -291,6 +292,7 @@ function RouteComponent() {
 			: () => Promise.resolve([]),
 		enabled: !!selectedLead?.id && isDetailsDialogOpen,
 	});
+	const analysisOpportunityId = search.opportunityId;
 
 	// Query para obtener un lead específico por ID (desde URL)
 	const specificLeadQuery = useQuery({
@@ -2697,6 +2699,7 @@ function RouteComponent() {
 								{selectedLead?.id && (
 									<BankStatementAnalysis
 										leadId={selectedLead.id}
+										opportunityId={analysisOpportunityId}
 										onAnalysisComplete={() => creditAnalysisQuery.refetch()}
 									/>
 								)}

--- a/apps/crm/apps/web/src/routes/crm/opportunities.tsx
+++ b/apps/crm/apps/web/src/routes/crm/opportunities.tsx
@@ -2311,6 +2311,7 @@ function RouteComponent() {
 															to: "/crm/leads",
 															search: {
 																leadId: selectedOpportunity.lead?.id,
+																opportunityId: selectedOpportunity.id,
 															},
 														});
 													}}
@@ -2322,6 +2323,7 @@ function RouteComponent() {
 																to: "/crm/leads",
 																search: {
 																	leadId: selectedOpportunity.lead?.id,
+																	opportunityId: selectedOpportunity.id,
 																},
 															});
 														}


### PR DESCRIPTION
## Summary
- Replaces closed PR #1045 with a clean branch containing the bank-analysis attachment flow.
- Saves the first three successfully analyzed bank-statement PDFs as opportunity attachments `estados_cuenta_1..3` when there is an explicit valid `opportunityId`.
- Persists `creditAnalysis` before writing attachments/checklist, and skips auto-attachments for non-upload roles while allowing their analysis to continue.
- Passes opportunity context from opportunity→lead navigation so uploads from the capacity-analysis UI can populate opportunity attachments.

## Codex feedback addressed from #1045
- Attachment writes happen only after successful Gemini analysis.
- `creditAnalysis` is persisted before any opportunity attachment/checklist write.
- Auto-attachments use the same upload-role gate as manual document upload: `admin`, `sales`, `sales_supervisor`, `analyst`.
- `sales` auto-attachment still requires assignment to the opportunity.
- Roles that can analyze but cannot upload, e.g. juridico/cobros/accounting, no longer fail the whole analysis just because `opportunityId` is present; the server validates the opportunity and skips auto-attachment.

## Test plan
- [x] `PATH="$HOME/.bun/bin:$PATH" bun test apps/crm/apps/server/src/lib/bank-statement-documents.test.ts` — 4 pass, 0 fail
- [x] `git diff --check`
- [x] Checked diff for `as any` — none introduced in the PR diff
- [ ] `bunx biome check <changed files>` — blocked by existing incompatible `biome.json` keys (`includes`, `assist`, `info`, `fix`)
- [ ] `bun check-types` — fails on existing repo/dependency/generated-type issues; representative existing failures include missing `ai`, `@aws-sdk/client-rekognition`, `@repo/simpletech`, `@cci/email`, and broad web ORPC generated-type errors

Replaces #1045.