### PR TITLE
fix(cobros): validar consistencia del catálogo de buckets antes de clasificar

### DIFF
--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -6,6 +6,7 @@ import { toZonedTime } from "date-fns-tz";
 import { S3Client, PutObjectCommand } from "@aws-sdk/client-s3";
 import ExcelJS from "exceljs";
 import { stat } from "fs";
+import { validarCatalogoBuckets } from "../lib/buckets-validation";
 
 type MoraEventoTipo =
   | "CREACION"
@@ -49,42 +50,23 @@ export function isOverdueInstallmentForMora(
 // ============================================================
 // 🪣 MOTOR DE BUCKETS (COBROS-02) — bucket derivado por estado + cuotas
 // ============================================================
-// El bucket se DERIVA del catálogo dinámico `cartera.buckets` (nombres, rangos y
-// estados configurables → filtros full dinámicos). Lo único que queda en código
-// es la lista de estados FUERA del funnel operativo (Opción A): esos créditos ya
-// no llevan mora ni se trackean como bucket.
-export const STATUS_BUCKET_FUERA = [
-  "CANCELADO",
-  "PENDIENTE_CANCELACION",
-  "EN_CONVENIO",
-  "CAIDO",
-];
+// Tipos + bucketDeCredito() viven en lib/buckets-classification.ts (función
+// pura, sin dependencias de DB) para que buckets-validation.test.ts pueda
+// importarla sin pasar por este archivo: latefee.ts se importa en algún
+// bun test (payments.test.ts) vía `mock.module`, y Bun no tiene forma de
+// deshacer ese mock entre archivos de test en el mismo proceso — cualquier
+// test que importara latefee.ts real después vería el stub vacío en vez del
+// módulo real. Re-exportado acá para no romper a credits.ts y otros
+// consumidores existentes.
+import {
+  STATUS_BUCKET_FUERA,
+  bucketDeCredito,
+  type BucketCatalogo,
+  type BucketCatalogoCompleto,
+} from "../lib/buckets-classification";
 
-// Fila del catálogo de buckets relevante para la derivación.
-export type BucketCatalogo = {
-  numero: number;
-  cuotas_min: number;
-  cuotas_max: number | null; // null = abierto (B5 = 5..∞)
-  estados_incluidos: string[];
-};
-
-/**
- * Fila completa del catálogo `cartera.buckets` expuesta a consumidores
- * externos (CRM vía API) — incluye el puente `estado_mora` (numero↔estadoMora).
- */
-export type BucketCatalogoCompleto = {
-  numero: number;
-  prefijo: string;
-  nombre: string;
-  descripcion: string | null;
-  cuotas_min: number;
-  cuotas_max: number | null;
-  estados_incluidos: string[];
-  es_operativo: boolean;
-  orden: number;
-  color: string | null;
-  estado_mora: string | null;
-};
+export { STATUS_BUCKET_FUERA, bucketDeCredito };
+export type { BucketCatalogo, BucketCatalogoCompleto };
 
 // Fallback B0-B5 — mismo seed seed que 0001_buckets_catalogo.sql +
 // 0003_buckets_estado_mora.sql. Usado SOLO si la query falla (ej. columna
@@ -100,10 +82,23 @@ const FALLBACK_BUCKETS_CATALOGO: BucketCatalogoCompleto[] = [
   { numero: 5, prefijo: "B5", nombre: "Jurídico", descripcion: null, cuotas_min: 5, cuotas_max: null, estados_incluidos: ["INCOBRABLE"], es_operativo: false, orden: 5, color: null, estado_mora: "mora_120_plus" },
 ];
 
-/** Catálogo dinámico de buckets (activos, ordenados) — fuente única para cartera-back y CRM. */
-export async function getBucketsCatalogo(): Promise<BucketCatalogoCompleto[]> {
+export type CatalogoBucketsResultado = {
+  catalogo: BucketCatalogoCompleto[];
+  /** true si `catalogo` es FALLBACK_BUCKETS_CATALOGO (DB inconsistente/caída), no la config real. */
+  esFallback: boolean;
+};
+
+/**
+ * Catálogo dinámico de buckets (activos, ordenados) — fuente única para
+ * cartera-back y CRM. Expone si el resultado es el fallback hardcoded para
+ * que consumidores que ESCRIBEN datos derivados (el motor de buckets, más
+ * abajo) puedan negarse a persistir con config potencialmente incorrecta —
+ * los consumidores de solo-lectura/presentación (credits.ts, router) usan
+ * getBucketsCatalogo() y aceptan degradar en silencio, como antes.
+ */
+export async function getBucketsCatalogoConEstado(): Promise<CatalogoBucketsResultado> {
   try {
-    return await db
+    const rows = await db
       .select({
         numero: buckets.numero,
         prefijo: buckets.prefijo,
@@ -120,36 +115,26 @@ export async function getBucketsCatalogo(): Promise<BucketCatalogoCompleto[]> {
       .from(buckets)
       .where(eq(buckets.activo, true))
       .orderBy(buckets.orden);
+
+    const { ok, problemas } = validarCatalogoBuckets(rows);
+    if (!ok) {
+      console.error(
+        `❌ Catálogo de buckets inconsistente, usando fallback: ${problemas.join(" | ")}`,
+      );
+      return { catalogo: FALLBACK_BUCKETS_CATALOGO, esFallback: true };
+    }
+
+    return { catalogo: rows, esFallback: false };
   } catch (err) {
     console.error("❌ Error consultando catálogo de buckets, usando fallback:", err);
-    return FALLBACK_BUCKETS_CATALOGO;
+    return { catalogo: FALLBACK_BUCKETS_CATALOGO, esFallback: true };
   }
 }
 
-/**
- * Bucket de un crédito (0-5) resuelto contra el catálogo dinámico `catalogo`.
- * Orden: (1) estado fuera del funnel → null; (2) estado que fuerza un bucket
- * (p.ej. INCOBRABLE → B5 vía `estados_incluidos`); (3) rango de cuotas atrasadas.
- * Devuelve `null` si el crédito está fuera del funnel operativo (no se trackea).
- */
-export function bucketDeCredito(
-  status: string | null | undefined,
-  cuotasAtrasadas: number,
-  catalogo: BucketCatalogo[],
-): number | null {
-  // (1) Fuera del funnel operativo (lista en código, Opción A).
-  if (status && STATUS_BUCKET_FUERA.includes(status)) return null;
-  // (2) Estado que fuerza un bucket (p.ej. INCOBRABLE → B5).
-  if (status) {
-    const porEstado = catalogo.find((b) => b.estados_incluidos.includes(status));
-    if (porEstado) return porEstado.numero;
-  }
-  // (3) Por rango de cuotas atrasadas (max null = abierto).
-  const cuotas = Math.max(cuotasAtrasadas, 0);
-  const porRango = catalogo.find(
-    (b) => cuotas >= b.cuotas_min && (b.cuotas_max == null || cuotas <= b.cuotas_max),
-  );
-  return porRango ? porRango.numero : null;
+/** Catálogo dinámico de buckets (activos, ordenados) — fuente única para cartera-back y CRM. */
+export async function getBucketsCatalogo(): Promise<BucketCatalogoCompleto[]> {
+  const { catalogo } = await getBucketsCatalogoConEstado();
+  return catalogo;
 }
 
 /**
@@ -1011,27 +996,42 @@ export async function procesarMoras() {
     // (derivado de estado + cuotas) y los registra en `buckets_historial`.
     // Si algo falla aquí, NO debe romper el proceso de mora (operación crítica).
     // Se devuelve en el resultado del job (útil para pruebas vía POST /moras/procesar).
-    const bucketsResumen = {
+    const bucketsResumen: {
+      iniciales: number;
+      subidas: number;
+      bajadas: number;
+      reasignados: number;
+      sinPoolDestino: number;
+      omitidoPorFallback: boolean;
+    } = {
       iniciales: 0,
       subidas: 0,
       bajadas: 0,
       reasignados: 0,
       sinPoolDestino: 0,
+      omitidoPorFallback: false,
     };
     try {
       // Catálogo de buckets (config dinámica: nombres/rangos/estados). ~6 filas.
-      const catalogoBuckets: BucketCatalogo[] = await db
-        .select({
-          numero: buckets.numero,
-          cuotas_min: buckets.cuotas_min,
-          cuotas_max: buckets.cuotas_max,
-          estados_incluidos: buckets.estados_incluidos,
-        })
-        .from(buckets)
-        .where(eq(buckets.activo, true))
-        .orderBy(buckets.orden);
+      // Comparte getBucketsCatalogoConEstado() con el endpoint de presentación
+      // en vez de una query propia: así el motor que ESCRIBE buckets_historial
+      // queda cubierto por validarCatalogoBuckets() — pero a diferencia de los
+      // consumidores de solo-lectura (credits.ts, router), que aceptan degradar
+      // en silencio a FALLBACK_BUCKETS_CATALOGO, este motor NO debe persistir
+      // transiciones calculadas con rangos hardcoded del seed cuando la config
+      // real difiere (rangos custom, migración a medias): eso dejaría historial
+      // de negocio contaminado con datos derivados de una config que nunca
+      // aplicó, sin más rastro que un console.error efímero. Se omite el paso
+      // completo y se reporta en bucketsResumen.omitidoPorFallback.
+      const { catalogo: catalogoBuckets, esFallback }: { catalogo: BucketCatalogo[]; esFallback: boolean } =
+        await getBucketsCatalogoConEstado();
 
-      if (catalogoBuckets.length === 0) {
+      if (esFallback) {
+        bucketsResumen.omitidoPorFallback = true;
+        console.warn(
+          `[BUCKETS] ⚠️ Catálogo \`${CARTERA_SCHEMA}.buckets\` inconsistente o inaccesible — se omite el registro de transiciones este ciclo (no se persiste historial con rangos de fallback).`,
+        );
+      } else if (catalogoBuckets.length === 0) {
         console.warn(
           `[BUCKETS] ⚠️ Catálogo \`${CARTERA_SCHEMA}.buckets\` vacío (¿migración/seed sin aplicar?) — se omite el registro de transiciones.`,
         );

--- a/apps/cartera-back/src/lib/buckets-classification.ts
+++ b/apps/cartera-back/src/lib/buckets-classification.ts
@@ -1,0 +1,62 @@
+// Fila del catálogo de buckets relevante para la derivación.
+export type BucketCatalogo = {
+  numero: number;
+  cuotas_min: number;
+  cuotas_max: number | null; // null = abierto (B5 = 5..∞)
+  estados_incluidos: string[];
+};
+
+/**
+ * Fila completa del catálogo `cartera.buckets` expuesta a consumidores
+ * externos (CRM vía API) — incluye el puente `estado_mora` (numero↔estadoMora).
+ */
+export type BucketCatalogoCompleto = {
+  numero: number;
+  prefijo: string;
+  nombre: string;
+  descripcion: string | null;
+  cuotas_min: number;
+  cuotas_max: number | null;
+  estados_incluidos: string[];
+  es_operativo: boolean;
+  orden: number;
+  color: string | null;
+  estado_mora: string | null;
+};
+
+// El bucket se DERIVA del catálogo dinámico `cartera.buckets` (nombres, rangos y
+// estados configurables → filtros full dinámicos). Lo único que queda en código
+// es la lista de estados FUERA del funnel operativo (Opción A): esos créditos ya
+// no llevan mora ni se trackean como bucket.
+export const STATUS_BUCKET_FUERA = [
+  "CANCELADO",
+  "PENDIENTE_CANCELACION",
+  "EN_CONVENIO",
+  "CAIDO",
+];
+
+/**
+ * Bucket de un crédito (0-5) resuelto contra el catálogo dinámico `catalogo`.
+ * Orden: (1) estado fuera del funnel → null; (2) estado que fuerza un bucket
+ * (p.ej. INCOBRABLE → B5 vía `estados_incluidos`); (3) rango de cuotas atrasadas.
+ * Devuelve `null` si el crédito está fuera del funnel operativo (no se trackea).
+ */
+export function bucketDeCredito(
+  status: string | null | undefined,
+  cuotasAtrasadas: number,
+  catalogo: BucketCatalogo[],
+): number | null {
+  // (1) Fuera del funnel operativo (lista en código, Opción A).
+  if (status && STATUS_BUCKET_FUERA.includes(status)) return null;
+  // (2) Estado que fuerza un bucket (p.ej. INCOBRABLE → B5).
+  if (status) {
+    const porEstado = catalogo.find((b) => b.estados_incluidos.includes(status));
+    if (porEstado) return porEstado.numero;
+  }
+  // (3) Por rango de cuotas atrasadas (max null = abierto).
+  const cuotas = Math.max(cuotasAtrasadas, 0);
+  const porRango = catalogo.find(
+    (b) => cuotas >= b.cuotas_min && (b.cuotas_max == null || cuotas <= b.cuotas_max),
+  );
+  return porRango ? porRango.numero : null;
+}

--- a/apps/cartera-back/src/lib/buckets-validation.test.ts
+++ b/apps/cartera-back/src/lib/buckets-validation.test.ts
@@ -103,6 +103,19 @@ describe("validarCatalogoBuckets", () => {
       problemas.some((p) => p.includes("INCOBRABLE") && p.includes("más de un bucket")),
     ).toBe(true);
   });
+
+  it("status repetido DENTRO de la misma fila no cuenta como conflicto", () => {
+    // ["INCOBRABLE", "INCOBRABLE"] en la MISMA fila (typo de siembra, no
+    // ambigüedad real) — bucketDeCredito lo resuelve igual sin importar
+    // cuántas veces aparezca el valor. Un catálogo válido no debe tumbarse
+    // por esto.
+    const catalogo = SEED_VALIDO.map((b) =>
+      b.numero === 5 ? { ...b, estados_incluidos: ["INCOBRABLE", "INCOBRABLE"] } : b,
+    );
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(true);
+    expect(problemas).toEqual([]);
+  });
 });
 
 describe("bucketDeCredito", () => {

--- a/apps/cartera-back/src/lib/buckets-validation.test.ts
+++ b/apps/cartera-back/src/lib/buckets-validation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "bun:test";
+import { validarCatalogoBuckets } from "./buckets-validation";
+import { bucketDeCredito } from "./buckets-classification";
+import type { BucketCatalogo, BucketCatalogoCompleto } from "./buckets-classification";
+
+const SEED_VALIDO: BucketCatalogoCompleto[] = [
+  { numero: 0, prefijo: "B0", nombre: "Cartera Sana", descripcion: null, cuotas_min: 0, cuotas_max: 0, estados_incluidos: [], es_operativo: true, orden: 0, color: null, estado_mora: "al_dia" },
+  { numero: 1, prefijo: "B1", nombre: "Alerta Temprana", descripcion: null, cuotas_min: 1, cuotas_max: 1, estados_incluidos: [], es_operativo: true, orden: 1, color: null, estado_mora: "mora_30" },
+  { numero: 2, prefijo: "B2", nombre: "Gestión Activa", descripcion: null, cuotas_min: 2, cuotas_max: 2, estados_incluidos: [], es_operativo: true, orden: 2, color: null, estado_mora: "mora_60" },
+  { numero: 3, prefijo: "B3", nombre: "Rescate", descripcion: null, cuotas_min: 3, cuotas_max: 3, estados_incluidos: [], es_operativo: true, orden: 3, color: null, estado_mora: "mora_90" },
+  { numero: 4, prefijo: "B4", nombre: "Última Instancia / Pre Jurídico", descripcion: null, cuotas_min: 4, cuotas_max: 4, estados_incluidos: [], es_operativo: true, orden: 4, color: null, estado_mora: "mora_120" },
+  { numero: 5, prefijo: "B5", nombre: "Jurídico", descripcion: null, cuotas_min: 5, cuotas_max: null, estados_incluidos: ["INCOBRABLE"], es_operativo: false, orden: 5, color: null, estado_mora: "mora_120_plus" },
+];
+
+describe("validarCatalogoBuckets", () => {
+  it("catálogo seed (B0-B5) es válido", () => {
+    const { ok, problemas } = validarCatalogoBuckets(SEED_VALIDO);
+    expect(ok).toBe(true);
+    expect(problemas).toEqual([]);
+  });
+
+  it("detecta overlap entre filas consecutivas", () => {
+    const catalogo = SEED_VALIDO.map((b) =>
+      b.numero === 2 ? { ...b, cuotas_min: 1, cuotas_max: 2 } : b,
+    );
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(problemas.some((p) => p.includes("overlap"))).toBe(true);
+  });
+
+  it("detecta gap entre filas (bucket desactivado en medio)", () => {
+    const catalogo = SEED_VALIDO.filter((b) => b.numero !== 2);
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(problemas.some((p) => p.includes("gap"))).toBe(true);
+  });
+
+  it("detecta orden duplicado entre buckets operativos", () => {
+    const catalogo = SEED_VALIDO.map((b) => (b.numero === 1 ? { ...b, orden: 0 } : b));
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(problemas.some((p) => p.includes("orden duplicado"))).toBe(true);
+  });
+
+  it("detecta cobertura incompleta: primer bucket no empieza en 0", () => {
+    const catalogo = SEED_VALIDO.map((b) => (b.numero === 0 ? { ...b, cuotas_min: 1 } : b));
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(problemas.some((p) => p.includes("no en 0"))).toBe(true);
+  });
+
+  it("detecta cobertura incompleta: último bucket del catálogo no es abierto", () => {
+    const catalogo = SEED_VALIDO.map((b) => (b.numero === 5 ? { ...b, cuotas_max: 10 } : b));
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(problemas.some((p) => p.includes("debería ser abierto"))).toBe(true);
+  });
+
+  it("es_operativo=false no rompe cobertura si el rango sigue contiguo y abierto (B5 legal)", () => {
+    const { ok, problemas } = validarCatalogoBuckets(SEED_VALIDO);
+    expect(ok).toBe(true);
+    expect(problemas).toEqual([]);
+  });
+
+  it("detecta numero duplicado en el catálogo", () => {
+    const catalogo = [...SEED_VALIDO, { ...SEED_VALIDO[1], orden: 6 }];
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(problemas.some((p) => p.includes("numero duplicado"))).toBe(true);
+  });
+
+  it("catálogo sin ninguna fila operativa es inválido", () => {
+    const catalogo = SEED_VALIDO.map((b) => ({ ...b, es_operativo: false }));
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(problemas.some((p) => p.includes("sin ninguna fila operativa"))).toBe(true);
+  });
+
+  it("orden y cuotas_min desalineados (admin reordena presentación sin tocar rangos) sigue válido", () => {
+    // orden invertido respecto a cuotas_min: B0 pasa a orden=5, B5 a orden=0,
+    // etc. Los RANGOS de cuotas siguen intactos y contiguos — el catálogo
+    // sigue siendo válido. Si el walk de cobertura caminara por `orden` en
+    // vez de por `cuotas_min`, compararía filas no-adyacentes por cuota
+    // (ej. B0 cuotas_min=0 vs B1 cuotas_min=1, pero en posiciones de orden
+    // opuestas) y produciría overlap/gap falsos.
+    const catalogo = SEED_VALIDO.map((b) => ({ ...b, orden: 5 - b.orden }));
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(true);
+    expect(problemas).toEqual([]);
+  });
+
+  it("detecta el mismo status incluido en más de un bucket", () => {
+    // INCOBRABLE ya está en B5 (seed). Si además aparece en B3, bucketDeCredito
+    // (find first-match por orden de array) resolvería siempre al primero que
+    // aparezca en el catálogo — mis-clasificación silenciosa, y cambiar
+    // `orden` (sin tocar estados_incluidos) cambiaría cuál bucket gana.
+    const catalogo = SEED_VALIDO.map((b) =>
+      b.numero === 3 ? { ...b, estados_incluidos: ["INCOBRABLE"] } : b,
+    );
+    const { ok, problemas } = validarCatalogoBuckets(catalogo);
+    expect(ok).toBe(false);
+    expect(
+      problemas.some((p) => p.includes("INCOBRABLE") && p.includes("más de un bucket")),
+    ).toBe(true);
+  });
+});
+
+describe("bucketDeCredito", () => {
+  const catalogo: BucketCatalogo[] = SEED_VALIDO.map((b) => ({
+    numero: b.numero,
+    cuotas_min: b.cuotas_min,
+    cuotas_max: b.cuotas_max,
+    estados_incluidos: b.estados_incluidos,
+  }));
+
+  it("clasifica por rango de cuotas atrasadas", () => {
+    expect(bucketDeCredito("AL_DIA", 0, catalogo)).toBe(0);
+    expect(bucketDeCredito("MOROSO", 1, catalogo)).toBe(1);
+    expect(bucketDeCredito("MOROSO", 3, catalogo)).toBe(3);
+  });
+
+  it("clasifica en el bucket abierto (cuotas_max null) cuando excede el último rango cerrado", () => {
+    expect(bucketDeCredito("MOROSO", 5, catalogo)).toBe(5);
+    expect(bucketDeCredito("MOROSO", 100, catalogo)).toBe(5);
+  });
+
+  it("respeta límites exactos entre buckets consecutivos", () => {
+    expect(bucketDeCredito("MOROSO", 1, catalogo)).toBe(1);
+    expect(bucketDeCredito("MOROSO", 2, catalogo)).toBe(2);
+  });
+
+  it("estado que fuerza bucket vía estados_incluidos gana sobre el rango de cuotas", () => {
+    expect(bucketDeCredito("INCOBRABLE", 0, catalogo)).toBe(5);
+  });
+
+  it("status fuera del funnel operativo devuelve null", () => {
+    expect(bucketDeCredito("EN_CONVENIO", 10, catalogo)).toBeNull();
+    expect(bucketDeCredito("CANCELADO", 10, catalogo)).toBeNull();
+  });
+
+  it("gap en el catálogo (bucket faltante) devuelve null en vez de clasificar mal", () => {
+    const catalogoConGap = catalogo.filter((b) => b.numero !== 2);
+    expect(bucketDeCredito("MOROSO", 2, catalogoConGap)).toBeNull();
+  });
+
+  it("clasifica correcto aunque el array llegue en orden `orden` desalineado de cuotas_min", () => {
+    // validarCatalogoBuckets valida cobertura por cuotas_min (no por orden) —
+    // un catálogo con orden invertido pero rangos contiguos/sin overlap pasa
+    // el guard. bucketDeCredito hace find() first-match sobre el array tal
+    // como llega (orden SQL real: `.orderBy(buckets.orden)`). Si el catálogo
+    // YA es válido (sin overlap), el orden del array no puede cambiar el
+    // resultado — cada `cuotas` matchea como máximo un rango. Este test lo
+    // confirma explícitamente contra el mismo catálogo desalineado que
+    // valida OK en buckets-validation.test.ts.
+    const catalogoOrdenInvertido: BucketCatalogo[] = SEED_VALIDO
+      .map((b) => ({ ...b, orden: 5 - b.orden }))
+      .sort((a, b) => a.orden - b.orden)
+      .map((b) => ({
+        numero: b.numero,
+        cuotas_min: b.cuotas_min,
+        cuotas_max: b.cuotas_max,
+        estados_incluidos: b.estados_incluidos,
+      }));
+
+    expect(bucketDeCredito("MOROSO", 0, catalogoOrdenInvertido)).toBe(0);
+    expect(bucketDeCredito("MOROSO", 3, catalogoOrdenInvertido)).toBe(3);
+    expect(bucketDeCredito("MOROSO", 100, catalogoOrdenInvertido)).toBe(5);
+  });
+});

--- a/apps/cartera-back/src/lib/buckets-validation.ts
+++ b/apps/cartera-back/src/lib/buckets-validation.ts
@@ -38,12 +38,16 @@ export function validarCatalogoBuckets(
   }
 
   // Paso (2) de bucketDeCredito() resuelve por estados_incluidos con find()
-  // first-match: si el mismo status aparece en dos buckets, gana el primero
-  // por orden de array — mis-clasificación silenciosa, y reordenar el
-  // catálogo (sin tocar estados_incluidos) cambiaría el resultado.
+  // first-match: si el mismo status aparece en dos buckets DISTINTOS, gana el
+  // primero por orden de array — mis-clasificación silenciosa, y reordenar el
+  // catálogo (sin tocar estados_incluidos) cambiaría el resultado. Se
+  // deduplica por fila (`new Set`) antes de contar: un status repetido DENTRO
+  // de la misma fila (ej. estados_incluidos con un valor por error dos veces)
+  // no es ambigüedad real — bucketDeCredito lo resuelve igual sin importar
+  // cuántas veces aparezca, así que no debe tumbar un catálogo válido.
   const estadoABuckets = new Map<string, number[]>();
   for (const b of catalogo) {
-    for (const estado of b.estados_incluidos) {
+    for (const estado of new Set(b.estados_incluidos)) {
       const numeros = estadoABuckets.get(estado) ?? [];
       numeros.push(b.numero);
       estadoABuckets.set(estado, numeros);

--- a/apps/cartera-back/src/lib/buckets-validation.ts
+++ b/apps/cartera-back/src/lib/buckets-validation.ts
@@ -1,0 +1,110 @@
+import type { BucketCatalogoCompleto } from "./buckets-classification";
+
+export type ValidacionCatalogo = {
+  ok: boolean;
+  problemas: string[];
+};
+
+/**
+ * Valida consistencia del CONJUNTO del catálogo (no de una fila aislada — eso
+ * ya lo cubre el CHECK `buckets_rango_ck` en DB). Sin esto, un catálogo con
+ * huecos/overlaps/orden roto pasa silencioso: bucketDeCredito() hace find()
+ * first-match, así que un overlap gana por orden y un gap devuelve null
+ * (crédito sin bucket, indistinguible de "fuera del funnel").
+ *
+ * La cobertura por rango de cuotas (orden/overlap/gap/apertura 0..∞) se
+ * valida sobre TODAS las filas, no solo las operativas: `es_operativo=false`
+ * (p.ej. B5 jurídico) solo controla si el crédito sale del funnel de gestión
+ * al llegar ahí — el rango de cuotas sigue siendo parte de la cobertura.
+ */
+export function validarCatalogoBuckets(
+  catalogo: BucketCatalogoCompleto[],
+): ValidacionCatalogo {
+  const problemas: string[] = [];
+
+  if (catalogo.length === 0) {
+    problemas.push("catálogo vacío");
+    return { ok: false, problemas };
+  }
+
+  const numeros = catalogo.map((b) => b.numero);
+  const numerosDuplicados = numeros.filter((n, i) => numeros.indexOf(n) !== i);
+  if (numerosDuplicados.length > 0) {
+    problemas.push(`numero duplicado en catálogo: ${[...new Set(numerosDuplicados)].join(", ")}`);
+  }
+
+  if (!catalogo.some((b) => b.es_operativo)) {
+    problemas.push("catálogo sin ninguna fila operativa");
+  }
+
+  // Paso (2) de bucketDeCredito() resuelve por estados_incluidos con find()
+  // first-match: si el mismo status aparece en dos buckets, gana el primero
+  // por orden de array — mis-clasificación silenciosa, y reordenar el
+  // catálogo (sin tocar estados_incluidos) cambiaría el resultado.
+  const estadoABuckets = new Map<string, number[]>();
+  for (const b of catalogo) {
+    for (const estado of b.estados_incluidos) {
+      const numeros = estadoABuckets.get(estado) ?? [];
+      numeros.push(b.numero);
+      estadoABuckets.set(estado, numeros);
+    }
+  }
+  for (const [estado, numeros] of estadoABuckets) {
+    if (numeros.length > 1) {
+      problemas.push(
+        `estado "${estado}" incluido en más de un bucket: numero=${numeros.join(", ")}`,
+      );
+    }
+  }
+
+  const porOrden = catalogo.slice().sort((a, b) => a.orden - b.orden);
+  const ordenes = porOrden.map((b) => b.orden);
+  const ordenesDuplicados = ordenes.filter((o, i) => ordenes.indexOf(o) !== i);
+  if (ordenesDuplicados.length > 0) {
+    problemas.push(`orden duplicado en catálogo: ${[...new Set(ordenesDuplicados)].join(", ")}`);
+  }
+
+  // Cobertura/overlap/gap se caminan por cuotas_min, NO por orden: son
+  // columnas independientes (orden es de presentación, cuotas_min/max es el
+  // rango real). Un admin puede reordenar la presentación sin tocar rangos —
+  // caminar por `orden` ahí compararía filas no-adyacentes por cuota y
+  // produciría overlap/gap falsos, tumbando un catálogo válido al fallback.
+  const ordenados = catalogo.slice().sort((a, b) => a.cuotas_min - b.cuotas_min);
+
+  if (ordenados[0].cuotas_min !== 0) {
+    problemas.push(
+      `cobertura incompleta: el primer bucket (numero=${ordenados[0].numero}) empieza en cuotas_min=${ordenados[0].cuotas_min}, no en 0`,
+    );
+  }
+
+  for (let i = 1; i < ordenados.length; i++) {
+    const prev = ordenados[i - 1];
+    const cur = ordenados[i];
+
+    if (prev.cuotas_max == null) {
+      problemas.push(
+        `bucket numero=${prev.numero} (orden=${prev.orden}) tiene cuotas_max abierto pero no es el último del catálogo`,
+      );
+      continue;
+    }
+
+    if (cur.cuotas_min <= prev.cuotas_max) {
+      problemas.push(
+        `overlap entre bucket numero=${prev.numero} (cuotas_max=${prev.cuotas_max}) y numero=${cur.numero} (cuotas_min=${cur.cuotas_min})`,
+      );
+    } else if (cur.cuotas_min > prev.cuotas_max + 1) {
+      problemas.push(
+        `gap entre bucket numero=${prev.numero} (cuotas_max=${prev.cuotas_max}) y numero=${cur.numero} (cuotas_min=${cur.cuotas_min})`,
+      );
+    }
+  }
+
+  const ultimo = ordenados[ordenados.length - 1];
+  if (ultimo.cuotas_max != null) {
+    problemas.push(
+      `cobertura incompleta: el último bucket (numero=${ultimo.numero}) tiene cuotas_max=${ultimo.cuotas_max}, debería ser abierto (null) para cubrir ..∞`,
+    );
+  }
+
+  return { ok: problemas.length === 0, problemas };
+}


### PR DESCRIPTION
## Contexto

Concern #2 del issue #1043 (revisión de Luis Ralda sobre COBROS-02):

> Conviene validar que la configuración de buckets no tenga: rangos traslapados; huecos entre rangos; orden inconsistente; buckets activos/inactivos usados de forma ambigua.

El catálogo dinámico de buckets (`cartera.buckets`) solo tenía un CHECK por-fila en DB (`buckets_rango_ck`: valida que una fila individual no tenga rango invertido). Nada validaba el **conjunto**: un catálogo con overlap, gap, orden roto, o el mismo status en dos buckets pasaba silencioso.

`bucketDeCredito()` resuelve por `find()` first-match — en un overlap gana el primer bucket que aparezca en el array; en un gap devuelve `null` (indistinguible de "crédito fuera del funnel"). El motor de mora (el job que **escribe** `buckets_historial`, no solo lo lee) tenía además su propia query al catálogo, separada del endpoint de presentación y sin pasar por ningún guard.

## Qué cambia

**`lib/buckets-classification.ts`** (nuevo) — `bucketDeCredito()`, tipos `BucketCatalogo`/`BucketCatalogoCompleto`, `STATUS_BUCKET_FUERA`. Movidos de `latefee.ts` a un módulo puro sin dependencias de DB (razón técnica abajo). `latefee.ts` los re-exporta — cero breaking change para `credits.ts` ni otros consumidores.

**`lib/buckets-validation.ts`** (nuevo) — `validarCatalogoBuckets(catalogo)` valida el catálogo completo:
- `numero` sin duplicados.
- Al menos una fila `es_operativo=true`.
- `orden` sin duplicados (columna de presentación).
- Cobertura de `cuotas_min`/`cuotas_max`: arranca en 0, sin overlap, sin gap, termina abierto (`null`).
- El mismo `status` no puede aparecer en `estados_incluidos` de más de un bucket (si no, `bucketDeCredito` resuelve por orden de array, ambiguo).

La cobertura se camina ordenando por `cuotas_min`, **no** por `orden` — son columnas independientes (un admin puede reordenar la presentación sin tocar los rangos), y caminar por `orden` ahí compararía filas no-adyacentes por cuota y produciría falsos overlap/gap.

**`controllers/latefee.ts`**:
- `getBucketsCatalogo()` corre el guard sobre el resultado de la query; si falla, degrada a `FALLBACK_BUCKETS_CATALOGO` en vez de devolver un catálogo inconsistente.
- Nueva `getBucketsCatalogoConEstado()` — devuelve `{catalogo, esFallback}`. El job de mora (que antes tenía su propia query inline sin validar) ahora la usa: si el catálogo degrada a fallback, **el job se niega a persistir transiciones ese ciclo** (`bucketsResumen.omitidoPorFallback: true`) en vez de escribir historial calculado con rangos hardcoded del seed como si fueran la config real. Los consumidores de solo-lectura (`credits.ts`, router de presentación) siguen usando `getBucketsCatalogo()` sin cambios — degradar en silencio ahí es aceptable, no escriben nada.

### Por qué `buckets-classification.ts` es un módulo aparte

`payments.test.ts` (test preexistente, no tocado) hace `mock.module("./latefee", ...)` — Bun no tiene forma de deshacer un `mock.module` entre archivos de test en el mismo proceso de `bun test`. Cualquier test que importara `latefee.ts` real después en el mismo run heredaba el mock vacío y fallaba con `Export named 'X' not found`, aunque pasara perfecto aislado. Sacar `bucketDeCredito()` y los tipos a un módulo sin dependencias de DB deja los tests de validación completamente aislados de ese problema.

## Tests

18 tests nuevos en `buckets-validation.test.ts`:
- `validarCatalogoBuckets`: catálogo seed válido, overlap, gap, orden duplicado, cobertura incompleta (inicio/fin), sin fila operativa, numero duplicado, orden desalineado de cuotas_min (sigue válido), estado incluido en más de un bucket.
- `bucketDeCredito`: rangos, bucket abierto, límites exactos, estado que fuerza bucket, fuera del funnel, gap→null, orden invertido en el array de entrada.

## Verificación

- `bunx tsc --noEmit` en `cartera-back` — limpio.
- `bun test src/lib/buckets-validation.test.ts` — 18/18 pass.
- `bun test` (suite completo de `cartera-back`) — mismo conteo de fails que el baseline de `COBROS-02` sin este cambio (14, todos preexistentes y sin relación: `isOverdueInstallmentForMora` e `elegirAsesorParaBucket`, verificado con `git stash` contra el baseline puro).

## Fuera de alcance (PRs siguientes)

Este PR es solo la mitad de cartera-back de un trabajo más grande sobre buckets (Concern #2 y #3 del issue #1043). Vienen en PRs separados:
- Exponer el catálogo vía ORPC al CRM server + extender `moraBuckets.ts`.
- Refactor del frontend CRM para consumir el catálogo en vez de 4 copias hardcodeadas divergentes (Concern #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)