### PR TITLE
fix(cartera): estado_devolucion pasa a COMPLETADO tras liquidacion

### DIFF
--- a/apps/cartera-back/drizzle/0018_add_completado_estado_devolucion.sql
+++ b/apps/cartera-back/drizzle/0018_add_completado_estado_devolucion.sql
@@ -1,0 +1,6 @@
+-- Agregar 'COMPLETADO' al enum de estado_devolucion en el esquema cartera.
+--
+-- Representa que el proceso de devolución ha finalizado y el crédito 
+-- ahora pertenece a CUBE de manera normal.
+--
+ALTER TYPE cartera.estado_devolucion ADD VALUE IF NOT EXISTS 'COMPLETADO';

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4320,7 +4320,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
           }
 
           // 5C) Regla de cierre: tras liquidar, cualquier estado de devolución
-          // del/los crédito(s) procesado(s) pasa a COMPLETADO.
+          // del/los crédito(s) procesado(s) pasa a COMPLETADO (solo si ya estaba VERIFICADO).
           if (creditoIdsConPagos.length > 0) {
             await db
               .update(creditos)
@@ -4328,7 +4328,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
               .where(
                 and(
                   inArray(creditos.credito_id, creditoIdsConPagos),
-                  ne(creditos.estado_devolucion, "NO_APLICA")
+                  eq(creditos.estado_devolucion, "VERIFICADO")
                 )
               );
 

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4269,13 +4269,13 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
                 request: {} as any,
               });
 
-              // Después de separar en exitInvestor, dejar estado_devolucion en NO_APLICA
+              // Después de separar en exitInvestor, dejar estado_devolucion en COMPLETADO
               await db
                 .update(creditos)
-                .set({ estado_devolucion: "NO_APLICA" })
+                .set({ estado_devolucion: "COMPLETADO" })
                 .where(inArray(creditos.credito_id, creditoIdsDevolucion));
 
-              console.log(`  ✅ Salida por estado_devolucion=VERIFICADO ejecutada y créditos reseteados a NO_APLICA:`, exitResultDevolucion);
+              console.log(`  ✅ Salida por estado_devolucion=VERIFICADO ejecutada y créditos reseteados a COMPLETADO:`, exitResultDevolucion);
             }
           }
 
@@ -4320,11 +4320,11 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
           }
 
           // 5C) Regla de cierre: tras liquidar, cualquier estado de devolución
-          // del/los crédito(s) procesado(s) vuelve a NO_APLICA.
+          // del/los crédito(s) procesado(s) pasa a COMPLETADO.
           if (creditoIdsConPagos.length > 0) {
             await db
               .update(creditos)
-              .set({ estado_devolucion: "NO_APLICA" })
+              .set({ estado_devolucion: "COMPLETADO" })
               .where(
                 and(
                   inArray(creditos.credito_id, creditoIdsConPagos),
@@ -4333,7 +4333,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
               );
 
             console.log(
-              `  ✅ Estado devolución reseteado a NO_APLICA en ${creditoIdsConPagos.length} crédito(s) procesado(s) en liquidación`
+              `  ✅ Estado devolución actualizado a COMPLETADO en ${creditoIdsConPagos.length} crédito(s) procesado(s) en liquidación`
             );
           }
         } catch (exitError) {

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -450,7 +450,7 @@ const creditUpdateSchema = z.object({
   formato_credito: z.string().max(50).optional(),
   permite_abono_capital: z.boolean().optional(),
   no_amortiza_capital: z.boolean().optional(),
-  estado_devolucion: z.enum(['NO_APLICA', 'PENDIENTE_AUTORIZACION', 'VERIFICADO', 'RECHAZADO']).optional(),
+  estado_devolucion: z.enum(['NO_APLICA', 'PENDIENTE_AUTORIZACION', 'VERIFICADO', 'RECHAZADO', 'COMPLETADO']).optional(),
   motivo_devolucion: z.string().optional(),
   bandera_reinversion: z.boolean().optional(),
 });

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -52,7 +52,8 @@
     "NO_APLICA",
     "PENDIENTE_AUTORIZACION",
     "VERIFICADO",
-    "RECHAZADO"
+    "RECHAZADO",
+    "COMPLETADO"
   ]);
 
   // 🧾 Rubros del desglose de facturación (lo que factura CUBE) para el reporte diario.


### PR DESCRIPTION
## Summary
- Agrega `COMPLETADO` al enum `estado_devolucion` en schema.ts y en el schema de validación de updateCredit
- Tras liquidación/salida de inversionista, `estado_devolucion` se marca como `COMPLETADO` en vez de resetear a `NO_APLICA`, para distinguir créditos que completaron su devolución de los que nunca aplicaron

Cherry-pick de c835ca0f (rama jalvarez) para llevar el fix directo a main.

## Test plan
- [ ] Verificar migración de enum en DB (agregar valor COMPLETADO)
- [ ] Probar liquidación de inversionista con crédito en estado VERIFICADO/devolución y confirmar que queda en COMPLETADO
- [ ] Confirmar que updateCredit acepta COMPLETADO como valor válido

🤖 Generated with [Claude Code](https://claude.com/claude-code)