### PR TITLE
feat(cobros): mora por asesor a una fecha (snapshot histórico) + filtro de asesores

### DIFF
--- a/apps/cartera-back/src/controllers/moraHistorial.ts
+++ b/apps/cartera-back/src/controllers/moraHistorial.ts
@@ -18,7 +18,7 @@ const ETAPA_SQL = sql`CASE
 
 // CTE: estado de mora por crédito "as-of" `fecha`.
 // monto/tipo = último evento; cuotas = último evento CON cuotas>0 (carry-forward).
-const snapCte = (fecha: string) => sql`
+export const snapCte = (fecha: string) => sql`
   snap_raw AS (
     SELECT
       h.credito_id,

--- a/apps/cartera-back/src/controllers/moraPorEtapaAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/moraPorEtapaAsesor.test.ts
@@ -50,5 +50,22 @@ if (!hasDb) {
       const filt = await getMoraByEtapaYAsesor({ asesores: ids });
       expect(filt.porAsesor.every((a: any) => ids.includes(a.asesorId))).toBe(true);
     });
+
+    it("mapea cuotas → bucket con los umbrales exactos", async () => {
+      const { bucketCaseSql } = await import("./reportes");
+      const { db } = await import("../database");
+      const { sql } = await import("drizzle-orm");
+      const r = await db.execute<{ n: number; bucket: string }>(sql`
+        SELECT v.n, ${bucketCaseSql(sql`v.n`)} AS bucket
+        FROM (VALUES (1),(2),(3),(4),(5)) AS v(n)
+        ORDER BY v.n
+      `);
+      const map = Object.fromEntries(r.rows.map((x) => [x.n, x.bucket]));
+      expect(map[1]).toBe("mora_30");
+      expect(map[2]).toBe("mora_60");
+      expect(map[3]).toBe("mora_90");
+      expect(map[4]).toBe("mora_120_plus");
+      expect(map[5]).toBe("mora_120_plus");
+    });
   });
 }

--- a/apps/cartera-back/src/controllers/moraPorEtapaAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/moraPorEtapaAsesor.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+
+// Integración: ejercita getMoraByEtapaYAsesor (live + histórico) contra la base
+// de SUPABASE_DB_URL (clon DEV/local). Solo lecturas. Se salta si no hay DB.
+const hasDb = !!process.env.SUPABASE_DB_URL;
+
+if (!hasDb) {
+  describe("getMoraByEtapaYAsesor (integración)", () => {
+    it.skip("requiere SUPABASE_DB_URL apuntando al clon DEV/local", () => {});
+  });
+} else {
+  const { getMoraByEtapaYAsesor } = await import("./reportes");
+
+  const sumaTotal = (r: any) => Number(r.totales.totalEnMora.sumaMora);
+  const buckets = ["mora_30", "mora_60", "mora_90", "mora_120_plus"] as const;
+
+  describe("getMoraByEtapaYAsesor", () => {
+    it("live: totales = suma de buckets y de porAsesor", async () => {
+      const r = await getMoraByEtapaYAsesor();
+      expect(r.alcance).toBe("live");
+      const porBuckets = buckets.reduce((s, b) => s + Number(r.totales[b].sumaMora), 0);
+      expect(porBuckets).toBeCloseTo(sumaTotal(r), 2);
+      const porAsesor = r.porAsesor.reduce(
+        (s: number, a: any) => s + Number(a.totalEnMora.sumaMora), 0);
+      expect(porAsesor).toBeCloseTo(sumaTotal(r), 2);
+    });
+
+    it("histórico(hoy-1) devuelve alcance historico y forma válida", async () => {
+      const ayer = new Date(Date.now() - 86400000).toLocaleDateString("sv-SE", {
+        timeZone: "America/Guatemala",
+      });
+      const r = await getMoraByEtapaYAsesor({ fecha: ayer });
+      expect(r.alcance).toBe("historico");
+      expect(r.fecha).toBe(ayer);
+      const porBuckets = buckets.reduce((s, b) => s + Number(r.totales[b].sumaMora), 0);
+      expect(porBuckets).toBeCloseTo(sumaTotal(r), 2);
+    });
+
+    it("fecha anterior a la cobertura → vacío + dataDisponibleDesde", async () => {
+      const r = await getMoraByEtapaYAsesor({ fecha: "2000-01-01" });
+      expect(r.porAsesor.length).toBe(0);
+      expect(sumaTotal(r)).toBe(0);
+      expect(typeof r.dataDisponibleDesde).toBe("string");
+    });
+
+    it("filtro asesores limita porAsesor a los IDs pedidos", async () => {
+      const full = await getMoraByEtapaYAsesor();
+      const ids = full.porAsesor.slice(0, 1).map((a: any) => a.asesorId);
+      if (!ids.length) return;
+      const filt = await getMoraByEtapaYAsesor({ asesores: ids });
+      expect(filt.porAsesor.every((a: any) => ids.includes(a.asesorId))).toBe(true);
+    });
+  });
+}

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1233,6 +1233,18 @@ function hoyGTStr(): string {
   return new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
 }
 
+// Fragmento CASE compartido: clasifica cuotas atrasadas en el bucket de mora.
+// Umbral global (NO tocar sin revisar ambos call sites): >=4 → mora_120_plus,
+// =3 → mora_90, =2 → mora_60, resto → mora_30. Recibe la expresión de columna
+// (m.cuotas_atrasadas en el live path, s.cuotas en el histórico) para que
+// ambas queries compartan una única definición.
+export const bucketCaseSql = (col: ReturnType<typeof sql>) => sql`CASE
+  WHEN ${col} >= 4 THEN 'mora_120_plus'
+  WHEN ${col} = 3  THEN 'mora_90'
+  WHEN ${col} = 2  THEN 'mora_60'
+  ELSE                  'mora_30'
+END`;
+
 export async function getMoraByEtapaYAsesor({
   emailCobrador,
   fecha,
@@ -1259,12 +1271,7 @@ export async function getMoraByEtapaYAsesor({
       )
       SELECT
         a.asesor_id, a.nombre, a.email_cash_in AS email_asesor,
-        CASE
-          WHEN m.cuotas_atrasadas >= 4 THEN 'mora_120_plus'
-          WHEN m.cuotas_atrasadas = 3  THEN 'mora_90'
-          WHEN m.cuotas_atrasadas = 2  THEN 'mora_60'
-          ELSE                              'mora_30'
-        END AS bucket,
+        ${bucketCaseSql(sql`m.cuotas_atrasadas`)} AS bucket,
         COUNT(*)::int AS cantidad,
         COALESCE(SUM(c.capital::numeric), 0) AS suma_capital,
         COALESCE(SUM(m.monto_mora::numeric), 0) AS suma_mora
@@ -1283,12 +1290,7 @@ export async function getMoraByEtapaYAsesor({
     WITH ${snapCte(fecha!)}
     SELECT
       a.asesor_id, a.nombre, a.email_cash_in AS email_asesor,
-      CASE
-        WHEN s.cuotas >= 4 THEN 'mora_120_plus'
-        WHEN s.cuotas = 3  THEN 'mora_90'
-        WHEN s.cuotas = 2  THEN 'mora_60'
-        ELSE                    'mora_30'
-      END AS bucket,
+      ${bucketCaseSql(sql`s.cuotas`)} AS bucket,
       COUNT(*)::int AS cantidad,
       COALESCE(SUM(c.capital::numeric), 0) AS suma_capital,
       COALESCE(SUM(s.monto), 0) AS suma_mora

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1,5 +1,6 @@
 import { sql } from "drizzle-orm";
 import { db } from "../database";
+import { snapCte } from "./moraHistorial";
 
 type Periodo = "anio" | "trimestre" | "mes" | "semana" | "dia";
 
@@ -1189,60 +1190,27 @@ function serializeBuckets(b: BucketsAcc) {
   };
 }
 
-export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?: string } = {}) {
-  const rows = await db.execute<{
-    asesor_id: number;
-    nombre: string;
-    email_asesor: string | null;
-    bucket: keyof BucketsAcc;
-    cantidad: number;
-    suma_capital: string;
-    suma_mora: string;
-  }>(sql`
-    WITH mora_activa AS (
-      SELECT DISTINCT ON (credito_id)
-        credito_id,
-        cuotas_atrasadas,
-        monto_mora
-      FROM cartera.moras_credito
-      WHERE activa           = true
-        AND cuotas_atrasadas > 0
-      ORDER BY credito_id, mora_id DESC
-    )
-    SELECT
-      a.asesor_id,
-      a.nombre,
-      a.email_cash_in         AS email_asesor,
-      CASE
-        WHEN m.cuotas_atrasadas >= 4 THEN 'mora_120_plus'
-        WHEN m.cuotas_atrasadas = 3  THEN 'mora_90'
-        WHEN m.cuotas_atrasadas = 2  THEN 'mora_60'
-        ELSE                              'mora_30'
-      END                             AS bucket,
-      COUNT(*)::int                   AS cantidad,
-      COALESCE(SUM(c.capital::numeric), 0)    AS suma_capital,
-      COALESCE(SUM(m.monto_mora::numeric), 0) AS suma_mora
-    FROM mora_activa m
-    INNER JOIN cartera.creditos c ON c.credito_id = m.credito_id
-    INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
-    WHERE c."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
-      ${emailCobrador ? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))` : sql``}
-    GROUP BY a.asesor_id, a.nombre, a.email_cash_in, bucket
-  `);
+type MoraRow = {
+  asesor_id: number;
+  nombre: string;
+  email_asesor: string | null;
+  bucket: keyof BucketsAcc;
+  cantidad: number;
+  suma_capital: string;
+  suma_mora: string;
+};
 
+function acumularBuckets(rows: MoraRow[]) {
   const totalAcc = emptyBuckets();
   const asesorMap = new Map<number, { asesorId: number; nombre: string; email: string; acc: BucketsAcc }>();
-
-  for (const row of rows.rows) {
+  for (const row of rows) {
     const bucket = row.bucket;
     const cantidad = row.cantidad;
     const sumaCapital = Number(row.suma_capital);
     const sumaMora = Number(row.suma_mora);
-
     totalAcc[bucket].cantidad += cantidad;
     totalAcc[bucket].sumaCapital += sumaCapital;
     totalAcc[bucket].sumaMora += sumaMora;
-
     if (!asesorMap.has(row.asesor_id)) {
       asesorMap.set(row.asesor_id, { asesorId: row.asesor_id, nombre: row.nombre, email: row.email_asesor ?? "", acc: emptyBuckets() });
     }
@@ -1251,7 +1219,6 @@ export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?:
     entry.acc[bucket].sumaCapital += sumaCapital;
     entry.acc[bucket].sumaMora += sumaMora;
   }
-
   const porAsesor = Array.from(asesorMap.values())
     .sort((a, b) => {
       const tA = a.acc.mora_30.sumaMora + a.acc.mora_60.sumaMora + a.acc.mora_90.sumaMora + a.acc.mora_120_plus.sumaMora;
@@ -1259,8 +1226,93 @@ export async function getMoraByEtapaYAsesor({ emailCobrador }: { emailCobrador?:
       return tB - tA;
     })
     .map((e) => ({ asesorId: e.asesorId, nombre: e.nombre, email: e.email, ...serializeBuckets(e.acc) }));
-
   return { totales: serializeBuckets(totalAcc), porAsesor };
+}
+
+function hoyGTStr(): string {
+  return new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+}
+
+export async function getMoraByEtapaYAsesor({
+  emailCobrador,
+  fecha,
+  asesores,
+}: { emailCobrador?: string; fecha?: string; asesores?: number[] } = {}) {
+  const hoy = hoyGTStr();
+  const usarHistorico = !!fecha && fecha < hoy;
+
+  const emailFilter = emailCobrador
+    ? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))`
+    : sql``;
+  const asesoresFilter = asesores && asesores.length
+    ? sql`AND a.asesor_id IN (${sql.join(asesores.map((id) => sql`${id}`), sql`, `)})`
+    : sql``;
+
+  if (!usarHistorico) {
+    const rows = await db.execute<MoraRow>(sql`
+      WITH mora_activa AS (
+        SELECT DISTINCT ON (credito_id)
+          credito_id, cuotas_atrasadas, monto_mora
+        FROM cartera.moras_credito
+        WHERE activa = true AND cuotas_atrasadas > 0
+        ORDER BY credito_id, mora_id DESC
+      )
+      SELECT
+        a.asesor_id, a.nombre, a.email_cash_in AS email_asesor,
+        CASE
+          WHEN m.cuotas_atrasadas >= 4 THEN 'mora_120_plus'
+          WHEN m.cuotas_atrasadas = 3  THEN 'mora_90'
+          WHEN m.cuotas_atrasadas = 2  THEN 'mora_60'
+          ELSE                              'mora_30'
+        END AS bucket,
+        COUNT(*)::int AS cantidad,
+        COALESCE(SUM(c.capital::numeric), 0) AS suma_capital,
+        COALESCE(SUM(m.monto_mora::numeric), 0) AS suma_mora
+      FROM mora_activa m
+      INNER JOIN cartera.creditos c ON c.credito_id = m.credito_id
+      INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
+      WHERE c."statusCredit" IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')
+        ${emailFilter}
+        ${asesoresFilter}
+      GROUP BY a.asesor_id, a.nombre, a.email_cash_in, bucket
+    `);
+    return { ...acumularBuckets(rows.rows), fecha: hoy, alcance: "live" as const };
+  }
+
+  const rows = await db.execute<MoraRow>(sql`
+    WITH ${snapCte(fecha!)}
+    SELECT
+      a.asesor_id, a.nombre, a.email_cash_in AS email_asesor,
+      CASE
+        WHEN s.cuotas >= 4 THEN 'mora_120_plus'
+        WHEN s.cuotas = 3  THEN 'mora_90'
+        WHEN s.cuotas = 2  THEN 'mora_60'
+        ELSE                    'mora_30'
+      END AS bucket,
+      COUNT(*)::int AS cantidad,
+      COALESCE(SUM(c.capital::numeric), 0) AS suma_capital,
+      COALESCE(SUM(s.monto), 0) AS suma_mora
+    FROM snap s
+    INNER JOIN cartera.creditos c ON c.credito_id = s.credito_id
+    INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
+    WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0
+      ${emailFilter}
+      ${asesoresFilter}
+    GROUP BY a.asesor_id, a.nombre, a.email_cash_in, bucket
+  `);
+
+  const result = acumularBuckets(rows.rows);
+  if (!result.porAsesor.length) {
+    const minRes = await db.execute<{ min_fecha: string | null }>(sql`
+      SELECT MIN((fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date)::text AS min_fecha
+      FROM cartera.moras_historial
+    `);
+    const minFecha = minRes.rows[0]?.min_fecha ?? null;
+    if (minFecha && fecha! < minFecha) {
+      return { ...result, fecha, alcance: "historico" as const, dataDisponibleDesde: minFecha };
+    }
+  }
+  return { ...result, fecha, alcance: "historico" as const };
 }
 
 export async function getCuotasPorFecha({

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1297,7 +1297,7 @@ export async function getMoraByEtapaYAsesor({
     FROM snap s
     INNER JOIN cartera.creditos c ON c.credito_id = s.credito_id
     INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
-    WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0
+    WHERE s.tipo_evento <> 'DESACTIVACION' AND s.monto > 0 AND s.cuotas > 0
       ${emailFilter}
       ${asesoresFilter}
     GROUP BY a.asesor_id, a.nombre, a.email_cash_in, bucket

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -251,8 +251,37 @@ export const reportesRouter = new Elysia().use(authMiddleware)
 
   .get("/reportes/mora-por-etapa-asesor", async ({ query, set }) => {
     try {
-      const { email_cobrador } = query as Record<string, string>;
-      const data = await getMoraByEtapaYAsesor({ emailCobrador: email_cobrador });
+      const { email_cobrador, fecha, asesores } = query as Record<string, string>;
+
+      if (fecha) {
+        if (!FECHA_REGEX.test(fecha)) {
+          set.status = 400;
+          return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
+        }
+        const hoy = new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+        if (fecha > hoy) {
+          set.status = 400;
+          return { error: "La fecha no puede ser futura" };
+        }
+      }
+
+      let asesoresIds: number[] | undefined;
+      if (asesores) {
+        asesoresIds = asesores
+          .split(",")
+          .map((s) => Number(s.trim()))
+          .filter((n) => Number.isInteger(n) && n > 0);
+        if (!asesoresIds.length) {
+          set.status = 400;
+          return { error: "Parámetro 'asesores' inválido" };
+        }
+      }
+
+      const data = await getMoraByEtapaYAsesor({
+        emailCobrador: email_cobrador,
+        fecha: fecha || undefined,
+        asesores: asesoresIds,
+      });
       set.status = 200;
       return data;
     } catch (error) {

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -258,6 +258,10 @@ export const reportesRouter = new Elysia().use(authMiddleware)
           set.status = 400;
           return { error: "Formato de fecha inválido. Use YYYY-MM-DD" };
         }
+        if (!fechaValida(fecha)) {
+          set.status = 400;
+          return { error: "Fecha inválida. Verifique que el día exista en el mes." };
+        }
         const hoy = new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
         if (fecha > hoy) {
           set.status = 400;

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3960,6 +3960,8 @@ export const cobrosRouter = {
 			z
 				.object({
 					emailCobrador: z.string().optional(),
+					fecha: z.string().optional(),
+					asesores: z.array(z.number()).optional(),
 				})
 				.optional(),
 		)
@@ -3972,6 +3974,8 @@ export const cobrosRouter = {
 
 			return carteraBackClient.getMoraByEtapaYAsesor({
 				emailCobrador: input?.emailCobrador,
+				fecha: input?.fecha,
+				asesores: input?.asesores,
 			});
 		}),
 

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -426,6 +426,9 @@ export type MoraTotales = {
 export type MoraByEtapaYAsesorResponse = {
 	totales: MoraTotales;
 	porAsesor: ({ asesorId: number; nombre: string; email: string } & MoraTotales)[];
+	fecha?: string;
+	alcance?: "live" | "historico";
+	dataDisponibleDesde?: string;
 };
 
 // ============================================================================
@@ -1600,9 +1603,15 @@ export class CarteraBackClient {
 	// REPORTES
 	// ========================================================================
 
-	async getMoraByEtapaYAsesor(params?: { emailCobrador?: string }) {
+	async getMoraByEtapaYAsesor(params?: {
+		emailCobrador?: string;
+		fecha?: string;
+		asesores?: number[];
+	}) {
 		const queryParams = new URLSearchParams();
 		if (params?.emailCobrador) queryParams.set("email_cobrador", params.emailCobrador);
+		if (params?.fecha) queryParams.set("fecha", params.fecha);
+		if (params?.asesores?.length) queryParams.set("asesores", params.asesores.join(","));
 		const qs = queryParams.size > 0 ? `?${queryParams}` : "";
 		return this.request<MoraByEtapaYAsesorResponse>(
 			`/reportes/mora-por-etapa-asesor${qs}`,

--- a/apps/crm/apps/web/src/components/cobros/asesor-multi-select.tsx
+++ b/apps/crm/apps/web/src/components/cobros/asesor-multi-select.tsx
@@ -1,0 +1,84 @@
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Command,
+	CommandGroup,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+
+type Asesor = { asesorId: number; nombre: string };
+
+export function AsesorMultiSelect({
+	asesores,
+	value,
+	onChange,
+}: {
+	asesores: Asesor[];
+	value: number[] | null;
+	onChange: (ids: number[] | null) => void;
+}) {
+	const allIds = asesores.map((a) => a.asesorId);
+	const selected = value === null ? allIds : value;
+	const isAll = value === null || selected.length === allIds.length;
+
+	function toggle(id: number) {
+		const base = value === null ? allIds : value;
+		const next = base.includes(id)
+			? base.filter((x) => x !== id)
+			: [...base, id];
+		if (next.length === 0) return; // mínimo 1
+		onChange(next.length === allIds.length ? null : next);
+	}
+
+	const label = isAll
+		? "Todos los asesores"
+		: selected.length === 1
+			? (asesores.find((a) => a.asesorId === selected[0])?.nombre ?? "1 asesor")
+			: `${selected.length} asesores`;
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button variant="outline" className="w-56 justify-between">
+					<span className="truncate">{label}</span>
+					<ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-56 p-0" align="start">
+				<Command>
+					<CommandList>
+						<CommandGroup>
+							<CommandItem
+								onSelect={() => onChange(null)}
+								className="font-medium"
+							>
+								Seleccionar todos
+							</CommandItem>
+							{asesores.map((a) => {
+								const checked = selected.includes(a.asesorId);
+								const isLast = checked && selected.length === 1;
+								return (
+									<CommandItem
+										key={a.asesorId}
+										disabled={isLast}
+										onSelect={() => !isLast && toggle(a.asesorId)}
+									>
+										<Checkbox checked={checked} className="mr-2" />
+										<span className="truncate">{a.nombre}</span>
+									</CommandItem>
+								);
+							})}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -7,7 +7,8 @@ import {
 	RefreshCw,
 	TrendingDown,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { AsesorMultiSelect } from "@/components/cobros/asesor-multi-select";
 import { DataTable } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -71,6 +72,15 @@ const ETAPAS = [
 	},
 ];
 
+function todayGTISO() {
+	return new Date().toLocaleDateString("sv-SE", {
+		timeZone: "America/Guatemala",
+	});
+}
+function currentMonthGT() {
+	return todayGTISO().slice(0, 7); // YYYY-MM
+}
+
 function TabMora({
 	session,
 	canSeeAll,
@@ -82,12 +92,73 @@ function TabMora({
 		? undefined
 		: (session?.user?.email ?? undefined);
 
+	const [modo, setModo] = usePersistedState<"hoy" | "mes">(
+		"cobros.mora.modo",
+		"hoy",
+	);
+	const [mesAnio, setMesAnio] = usePersistedState<string>(
+		"cobros.mora.mes",
+		currentMonthGT(),
+	);
+	const [asesoresSel, setAsesoresSel] = usePersistedState<number[] | null>(
+		"cobros.mora.asesores",
+		null,
+	);
+
+	// Fecha snapshot = día 6 del mes elegido, clamp a hoy (nunca futura).
+	const hoy = todayGTISO();
+	const fechaSnapshot = useMemo(() => {
+		if (modo === "hoy") return undefined;
+		const dia6 = `${mesAnio}-06`;
+		return dia6 > hoy ? hoy : dia6;
+	}, [modo, mesAnio, hoy]);
+
+	const { data: asesoresData } = useQuery({
+		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
+		enabled: !!session && canSeeAll,
+	});
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const asesores: { asesorId: number; nombre: string }[] =
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(asesoresData as any)?.asesores ?? [];
+
 	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
-		...orpc.getMoraByEtapaYAsesor.queryOptions({ input: { emailCobrador } }),
+		...orpc.getMoraByEtapaYAsesor.queryOptions({
+			input: {
+				emailCobrador,
+				fecha: fechaSnapshot,
+				asesores: asesoresSel ?? undefined,
+			},
+		}),
 		enabled: !!session,
-		refetchInterval: 60_000,
+		refetchInterval: modo === "hoy" ? 60_000 : false,
 		refetchIntervalInBackground: false,
 	});
+
+	// Totales con / sin Gerencia (cliente, sobre porAsesor).
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const porAsesor: any[] = (data as any)?.porAsesor ?? [];
+	const totalConGerencia = porAsesor.reduce(
+		(s, a) => s + Number(a.totalEnMora?.sumaMora ?? 0),
+		0,
+	);
+	const totalSinGerencia = porAsesor
+		.filter((a) => a.nombre !== "Gerencia")
+		.reduce((s, a) => s + Number(a.totalEnMora?.sumaMora ?? 0), 0);
+	const credConGerencia = porAsesor.reduce(
+		(s, a) => s + Number(a.totalEnMora?.cantidad ?? 0),
+		0,
+	);
+	const credSinGerencia = porAsesor
+		.filter((a) => a.nombre !== "Gerencia")
+		.reduce((s, a) => s + Number(a.totalEnMora?.cantidad ?? 0), 0);
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const dataDisponibleDesde = (data as any)?.dataDisponibleDesde as
+		| string
+		| undefined;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const alcance = (data as any)?.alcance as "live" | "historico" | undefined;
 
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
@@ -118,6 +189,64 @@ function TabMora({
 				</div>
 			</div>
 
+			{/* Filtros */}
+			<div className="flex flex-wrap items-end gap-3 rounded-lg border bg-muted/30 p-3">
+				<div className="flex flex-col gap-1.5">
+					<Label className="font-semibold text-xs">Momento</Label>
+					<div className="flex items-center gap-1.5">
+						<Button
+							variant={modo === "hoy" ? "default" : "outline"}
+							size="sm"
+							onClick={() => setModo("hoy")}
+						>
+							Hoy (en vivo)
+						</Button>
+						<Button
+							variant={modo === "mes" ? "default" : "outline"}
+							size="sm"
+							onClick={() => setModo("mes")}
+						>
+							Por mes
+						</Button>
+					</div>
+				</div>
+
+				<div className="flex flex-col gap-1">
+					<Label className="text-muted-foreground text-xs">Mes</Label>
+					<Input
+						type="month"
+						className="w-40"
+						value={mesAnio}
+						max={currentMonthGT()}
+						disabled={modo !== "mes"}
+						onChange={(e) => setMesAnio(e.target.value)}
+					/>
+				</div>
+
+				{canSeeAll && asesores.length > 0 && (
+					<div className="flex flex-col gap-1">
+						<Label className="text-muted-foreground text-xs">Asesores</Label>
+						<AsesorMultiSelect
+							asesores={asesores}
+							value={asesoresSel}
+							onChange={setAsesoresSel}
+						/>
+					</div>
+				)}
+
+				<p className="pb-2 text-muted-foreground text-xs">
+					{modo === "hoy"
+						? "Mora actual en vivo"
+						: `Mora al ${fechaSnapshot ?? hoy}${alcance === "historico" ? " (histórico)" : ""}`}
+				</p>
+			</div>
+
+			{dataDisponibleDesde && (
+				<div className="rounded-lg border border-amber-200 bg-amber-50 px-4 py-2 text-amber-800 text-sm">
+					No hay datos de mora antes del {dataDisponibleDesde}.
+				</div>
+			)}
+
 			{isLoading ? (
 				<div className="grid grid-cols-2 gap-4 md:grid-cols-4">
 					{ETAPAS.map((e) => (
@@ -134,8 +263,13 @@ function TabMora({
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						const bucket = (data as any)?.totales?.[etapa.key];
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						const totalMora = parseFloat((data as any)?.totales?.totalEnMora?.sumaMora ?? "0");
-						const pct = totalMora > 0 ? (parseFloat(bucket?.sumaMora ?? "0") / totalMora) * 100 : 0;
+						const totalMora = Number.parseFloat(
+							(data as any)?.totales?.totalEnMora?.sumaMora ?? "0",
+						);
+						const pct =
+							totalMora > 0
+								? (Number.parseFloat(bucket?.sumaMora ?? "0") / totalMora) * 100
+								: 0;
 						return (
 							<Card key={etapa.key}>
 								<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -151,7 +285,7 @@ function TabMora({
 									<p className="text-muted-foreground text-xs">
 										Capital: {fmtQ(bucket?.sumaCapital ?? "0")}
 									</p>
-									<p className="mt-1 font-medium text-xs text-muted-foreground">
+									<p className="mt-1 font-medium text-muted-foreground text-xs">
 										{pct.toFixed(1)}% del total en mora
 									</p>
 								</CardContent>
@@ -161,30 +295,35 @@ function TabMora({
 				</div>
 			)}
 
-			{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-			{!!(data as any)?.totales?.totalEnMora && (
-				<Card className="border-red-200 bg-red-50">
-					<CardContent className="pt-4">
-						<div className="flex items-center justify-between">
-							<div>
-								<p className="font-semibold text-red-700 text-sm">
-									Total en Mora
-								</p>
-								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								<p className="font-bold text-3xl text-red-800">
-									{fmtQ((data as any).totales.totalEnMora.sumaMora)}
-								</p>
-							</div>
-							{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-							<div className="text-right">
-								<p className="text-muted-foreground text-sm">Créditos</p>
-								<p className="font-bold text-2xl">
-									{(data as any).totales.totalEnMora.cantidad}
-								</p>
-							</div>
-						</div>
-					</CardContent>
-				</Card>
+			{porAsesor.length > 0 && (
+				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+					<Card className="border-red-200 bg-red-50">
+						<CardContent className="pt-4">
+							<p className="font-semibold text-red-700 text-sm">
+								Total en Mora (con Gerencia)
+							</p>
+							<p className="font-bold text-3xl text-red-800">
+								{fmtQ(totalConGerencia)}
+							</p>
+							<p className="text-muted-foreground text-xs">
+								{credConGerencia} créditos
+							</p>
+						</CardContent>
+					</Card>
+					<Card className="border-orange-200 bg-orange-50">
+						<CardContent className="pt-4">
+							<p className="font-semibold text-orange-700 text-sm">
+								Total en Mora (sin Gerencia)
+							</p>
+							<p className="font-bold text-3xl text-orange-800">
+								{fmtQ(totalSinGerencia)}
+							</p>
+							<p className="text-muted-foreground text-xs">
+								{credSinGerencia} créditos
+							</p>
+						</CardContent>
+					</Card>
+				</div>
 			)}
 
 			<div>
@@ -251,8 +390,17 @@ function TabMora({
 											</div>
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 											{(() => {
-												const totalMora = parseFloat((data as any)?.totales?.totalEnMora?.sumaMora ?? "0");
-												const pct = totalMora > 0 ? (parseFloat(asesor.totalEnMora?.sumaMora ?? "0") / totalMora) * 100 : 0;
+												const totalMora = Number.parseFloat(
+													(data as any)?.totales?.totalEnMora?.sumaMora ?? "0",
+												);
+												const pct =
+													totalMora > 0
+														? (Number.parseFloat(
+																asesor.totalEnMora?.sumaMora ?? "0",
+															) /
+																totalMora) *
+															100
+														: 0;
 												return pct > 0 ? (
 													<div className="font-medium text-muted-foreground text-xs">
 														{pct.toFixed(1)}%


### PR DESCRIPTION
## Qué hace

Permite ver la **mora por asesor a una fecha pasada** en "Reportes de Cobros → Análisis de Mora", reconstruyendo el estado desde `cartera.moras_historial`, con filtro de asesores y totales con/sin Gerencia. Sin fecha = comportamiento **live actual sin cambios** (regresión cero).

## Cambios

**Backend (`cartera-back`)**
- `getMoraByEtapaYAsesor` acepta `fecha` (opcional) y `asesores` (opcional).
  - Sin `fecha` / `fecha === hoy` → camino LIVE actual (`moras_credito`), intacto.
  - `fecha` pasada → reconstruye el snapshot desde `moras_historial` reusando el CTE `snapCte` (mismo que el módulo Mora Histórica). Criterio "mora viva" = `tipo_evento <> 'DESACTIVACION' AND monto > 0 AND cuotas > 0`; sin filtro de `statusCredit` (decisión de producto: el status actual no refleja el de la fecha pasada).
  - `fecha` < inicio de cobertura → buckets en cero + `dataDisponibleDesde`.
- Se extrajo el `CASE WHEN` de bucket a un fragmento compartido `bucketCaseSql(col)` usado por el camino live y el histórico (evita divergencia).
- Router `/reportes/mora-por-etapa-asesor`: valida `fecha` (formato + `fechaValida` calendario + no futura) y `asesores` (CSV de enteros >0) → 400 en caso inválido.

**CRM server** — proxea `fecha` y `asesores` (ORPC type-safe); la respuesta expone `fecha`/`alcance`/`dataDisponibleDesde` (opcionales).

**Web** — la tab de mora gana: selector **Hoy (live) / Por mes** (snapshot al día 6, clamp a hoy), multi-select de asesores (`AsesorMultiSelect`, mínimo 1), y tarjetas de total **con / sin Gerencia**. Solo admin/cobros_supervisor (sin cambio de permisos).

## Validación (prod, solo lectura)

- Tests de integración: **5/5** (live, histórico, filtro asesores, `dataDisponibleDesde`, umbrales de bucket).
- End-to-end contra prod:
  - Histórico **2026-06-06 = Q2,529,388.49 / 702 créditos**, **cuadra al centavo (Δ=Q0.00)** contra el módulo independiente `getMoraHistorialSnapshot`.
  - `2026-07-06` da un total distinto (la fecha sí cambia el resultado); filtro de asesores acota correctamente; fecha pre-cobertura devuelve vacío + `dataDisponibleDesde`.
  - Con/sin Gerencia: Q2.53M / Q1.32M.

## Notas / follow-ups menores (no bloquean)

- `dataDisponibleDesde` usa el mínimo **global** de `moras_historial`; al filtrar por asesor no considera la cobertura propia de ese asesor.
- `AsesorMultiSelect`: `Checkbox` anidado dentro de `CommandItem` (fragilidad a11y por teclado/lector); "Seleccionar todos" sin indicador visual.
- `getAsesores` limitado a `perPage: 100` (suficiente hoy).
- Iteración 1: **solo el snapshot de mora esperada**. La comparación "cobrado vs esperado" (usando `pagos_credito.mora`) queda pospuesta para una iteración futura (ya validada como factible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
