### PR TITLE
feat(cobros): CRM consume catálogo dinámico de buckets vía cartera-back

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
+++ b/apps/carteraFront/src/private/cartera/components/CreditsPaymentsData.tsx
@@ -1376,7 +1376,7 @@ function MobileView({
                 }}
                 title={item.bucket.nombre}
               >
-                {item.bucket.prefijo} · {item.bucket.nombre}
+                {item.bucket.nombre}
               </span>
             ) : (
               <span className="text-gray-400 text-xs">—</span>
@@ -1687,7 +1687,7 @@ function DesktopView({
                       }}
                       title={item.bucket.nombre}
                     >
-                      {item.bucket.prefijo} · {item.bucket.nombre}
+                      {item.bucket.nombre}
                     </span>
                   ) : (
                     <span className="text-gray-400 text-xs">—</span>

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
@@ -1,4 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
+import type { CSSProperties } from "react";
 import { orpc } from "@/utils/orpc";
 
 /**
@@ -170,4 +171,19 @@ export function bucketsParaRender(
 	return keys
 		.map((key) => bucketDeEstado(key, catalogo))
 		.sort((a, b) => a.orden - b.orden);
+}
+
+/**
+ * Estilo inline (fondo tenue + texto + borde) a partir de `colorHex` —
+ * `colorClass` es una clase Tailwind estática (el default hardcoded);
+ * Tailwind no puede generar clases para un hex arbitrario del catálogo
+ * dinámico, así que el color REAL solo llega vía estilo inline. Mismo
+ * patrón de opacidad ya usado en carteraFront/CreditsPaymentsData.tsx.
+ */
+export function estiloBucket(colorHex: string): CSSProperties {
+	return {
+		backgroundColor: `${colorHex}1A`,
+		color: colorHex,
+		borderColor: `${colorHex}40`,
+	};
 }

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
@@ -1,0 +1,173 @@
+import { useQuery } from "@tanstack/react-query";
+import { orpc } from "@/utils/orpc";
+
+/**
+ * Fuente única de labels/colores/orden de buckets para la UI. Antes cada
+ * ruta (embudo, filtros, tabla, detalle, reportes) mantenía su propia copia
+ * hardcodeada — 4 copias divergentes, desalineadas entre sí y frente al
+ * catálogo dinámico (`cartera.buckets`) que ya vive en cartera-back.
+ *
+ * `DEFAULT_BUCKETS` cubre TODOS los estados usados en la UI: los 6 buckets
+ * de aging (B0-B5, `estadoMora` "al_dia".."mora_120_plus") que sí vienen del
+ * catálogo dinámico, más los estados de STATUS del crédito (`en_convenio`,
+ * `incobrable`, `completado`, `pagado`, `pre_mora`) que NUNCA son filas del
+ * catálogo de buckets — esos siempre usan el default.
+ *
+ * `useBucketsCatalogo()` trae el catálogo dinámico vía ORPC; los helpers
+ * combinan catálogo (si cargó y trae el estado) con el default (label/color
+ * de respaldo, y única fuente para estados de status).
+ */
+export interface BucketUI {
+	key: string;
+	label: string;
+	/** Clase Tailwind bg+text, usada cuando no hay color dinámico (hex). */
+	colorClass: string;
+	/** Color hex de referencia (embudo, barras) — respaldo si el catálogo no trae color. */
+	colorHex: string;
+	orden: number;
+}
+
+export const DEFAULT_BUCKETS: readonly BucketUI[] = [
+	{
+		key: "al_dia",
+		label: "Cartera Sana",
+		colorClass: "bg-green-100 text-green-800",
+		colorHex: "#22c55e",
+		orden: 0,
+	},
+	{
+		key: "en_convenio",
+		label: "En Convenio",
+		colorClass: "bg-green-100 text-green-800",
+		colorHex: "#22c55e",
+		orden: 0.5,
+	},
+	{
+		key: "pre_mora",
+		label: "Próximo a Vencer",
+		colorClass: "bg-yellow-50 text-yellow-700 border-yellow-200",
+		colorHex: "#fef9c3",
+		orden: 0.8,
+	},
+	{
+		key: "mora_30",
+		label: "Alerta Temprana",
+		colorClass: "bg-yellow-100 text-yellow-800",
+		colorHex: "#eab308",
+		orden: 1,
+	},
+	{
+		key: "mora_60",
+		label: "Gestión Activa",
+		colorClass: "bg-orange-100 text-orange-800",
+		colorHex: "#f97316",
+		orden: 2,
+	},
+	{
+		key: "mora_90",
+		label: "Rescate",
+		colorClass: "bg-red-100 text-red-800",
+		colorHex: "#ef4444",
+		orden: 3,
+	},
+	{
+		key: "mora_120",
+		label: "Última Instancia / Pre Jurídico",
+		colorClass: "bg-red-200 text-red-900",
+		colorHex: "#b91c1c",
+		orden: 4,
+	},
+	{
+		key: "mora_120_plus",
+		label: "Jurídico",
+		colorClass: "bg-red-300 text-red-900",
+		colorHex: "#991b1b",
+		orden: 5,
+	},
+	{
+		key: "pagado",
+		label: "Pagado",
+		colorClass: "bg-green-100 text-green-800",
+		colorHex: "#22c55e",
+		orden: 6,
+	},
+	{
+		key: "incobrable",
+		label: "Incobrable",
+		colorClass: "bg-gray-100 text-gray-800",
+		colorHex: "#6b7280",
+		orden: 7,
+	},
+	{
+		key: "completado",
+		label: "Completado",
+		colorClass: "bg-blue-100 text-blue-800",
+		colorHex: "#3b82f6",
+		orden: 8,
+	},
+];
+
+/**
+ * Bucket neutro para un `estadoMora` que no matchea ninguna key conocida
+ * (dato faltante/corrupto, o un estado nuevo agregado en cartera-back sin
+ * homólogo acá todavía). Deliberadamente NO reusa "incobrable": esa key
+ * carga significado real de negocio (cartera impagable) y pintar un crédito
+ * desconocido con ese label es más engañoso que útil.
+ */
+const BUCKET_DESCONOCIDO: BucketUI = {
+	key: "desconocido",
+	label: "—",
+	colorClass: "bg-gray-100 text-gray-500",
+	colorHex: "#9ca3af",
+	orden: Number.POSITIVE_INFINITY,
+};
+
+const DEFAULT_POR_KEY = new Map(DEFAULT_BUCKETS.map((b) => [b.key, b]));
+
+export type BucketsCatalogoQueryData = {
+	estadoMora: string;
+	label: string;
+	prefijo: string | null;
+	color: string | null;
+	orden: number;
+}[];
+
+/** Catálogo dinámico de buckets de aging (B0-B5), vía ORPC. Cachea 5 min en el server. */
+export function useBucketsCatalogo() {
+	return useQuery(orpc.getBucketsCatalogo.queryOptions());
+}
+
+/**
+ * Bucket combinado: catálogo dinámico (si trae el estado) sobreescribe
+ * label/color; estados de status (no-aging) o catálogo aún no cargado caen
+ * al default. Nunca retorna undefined — un estado sin match cae a
+ * BUCKET_DESCONOCIDO (neutro), no revienta el render ni aparenta ser un
+ * estado de negocio real.
+ */
+export function bucketDeEstado(
+	estadoMora: string | null | undefined,
+	catalogo: BucketsCatalogoQueryData | undefined,
+): BucketUI {
+	const key = estadoMora ?? "";
+	const base = DEFAULT_POR_KEY.get(key) ?? BUCKET_DESCONOCIDO;
+	const dinamico = catalogo?.find((b) => b.estadoMora === key);
+	if (!dinamico) return base;
+
+	return {
+		key,
+		label: dinamico.label || base.label,
+		colorClass: base.colorClass,
+		colorHex: dinamico.color || base.colorHex,
+		orden: dinamico.orden,
+	};
+}
+
+/** Lista de buckets para render (embudo, filtros), en el orden del catálogo dinámico si cargó, si no el default. */
+export function bucketsParaRender(
+	catalogo: BucketsCatalogoQueryData | undefined,
+	keys: readonly string[],
+): BucketUI[] {
+	return keys
+		.map((key) => bucketDeEstado(key, catalogo))
+		.sort((a, b) => a.orden - b.orden);
+}

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -1,8 +1,12 @@
 import type { ColumnDef } from "@tanstack/react-table";
 import { ArrowUpDown } from "lucide-react";
+import { ContactoQuickAction } from "@/components/cobros/contacto-quick-action";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ContactoQuickAction } from "@/components/cobros/contacto-quick-action";
+import {
+	type BucketsCatalogoQueryData,
+	bucketDeEstado,
+} from "@/lib/cobros/buckets-catalogo";
 import { parseFechaLocal } from "@/lib/date-utils";
 
 const ESTADOS_MORA_CTA = new Set([
@@ -35,36 +39,12 @@ export type ContratoCobranza = {
 	montoFinanciado: string;
 };
 
-function getEstadoBadge(estado: string) {
-	const colors: Record<string, string> = {
-		al_dia: "bg-green-100 text-green-800",
-		pre_mora: "bg-yellow-50 text-yellow-700 border-yellow-200",
-		mora_30: "bg-yellow-100 text-yellow-800",
-		mora_60: "bg-orange-100 text-orange-800",
-		mora_90: "bg-red-100 text-red-800",
-		mora_120: "bg-red-200 text-red-900",
-		mora_120_plus: "bg-red-300 text-red-950",
-		incobrable: "bg-gray-100 text-gray-800",
-		completado: "bg-blue-100 text-blue-800",
-	};
-
-	const labels: Record<string, string> = {
-		al_dia: "Al Día",
-		pre_mora: "Próximo a Vencer",
-		mora_30: "Mora 30",
-		mora_60: "Mora 60",
-		mora_90: "Mora 90",
-		mora_120: "Mora 120+",
-		mora_120_plus: "Mora 120+",
-		incobrable: "Incobrable",
-		completado: "Completado",
-	};
-
-	return (
-		<Badge className={colors[estado] || colors.al_dia}>
-			{labels[estado] || estado}
-		</Badge>
-	);
+function getEstadoBadge(
+	estado: string,
+	catalogo: BucketsCatalogoQueryData | undefined,
+) {
+	const bucket = bucketDeEstado(estado, catalogo);
+	return <Badge className={bucket.colorClass}>{bucket.label}</Badge>;
 }
 
 const ETIQUETA_LABELS: Record<string, string> = {
@@ -120,304 +100,312 @@ interface GetColumnsOptions {
 	 * por fila según el estado de mora propio de cada crédito.
 	 */
 	filtroEtapa: string | null;
+	/** Catálogo dinámico de buckets (labels/colores) — undefined mientras carga, cae al default. */
+	catalogo?: BucketsCatalogoQueryData;
 }
 
 export function getCobrosColumns({
 	filtroEtapa,
+	catalogo,
 }: GetColumnsOptions): ColumnDef<ContratoCobranza>[] {
 	const filtroEsMora = !!filtroEtapa && ESTADOS_MORA_CTA.has(filtroEtapa);
 
 	return [
-	{
-		accessorKey: "fechaProximoPago",
-		header: ({ column }) => {
-			return (
-				<Button
-					variant="ghost"
-					onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-				>
-					Fecha de Pago
-					<ArrowUpDown className="ml-2 h-4 w-4" />
-				</Button>
-			);
-		},
-		cell: ({ row }) => {
-			const fecha = row.getValue("fechaProximoPago") as string | null;
-			const dias = row.original.diasHastaPago;
-			const numeroCredito = row.original.numeroCredito;
-
-			// Si el filtro ya es un estado de mora, el botón va en todas las filas
-			// (cortocircuita sin revisar la fila). Si no, se muestra solo en las
-			// filas cuyo propio estado (estadoMora) es de mora.
-			const mostrarCtaContacto =
-				filtroEsMora ||
-				(row.original.estadoContrato === "activo" &&
-					!!row.original.estadoMora &&
-					ESTADOS_MORA_CTA.has(row.original.estadoMora));
-
-			const fechaFormateada = fecha
-				? parseFechaLocal(fecha).toLocaleDateString("es-GT", {
-						day: "2-digit",
-						month: "short",
-						year: "numeric",
-					})
-				: null;
-
-			let diasClassName = "text-xs mt-0.5";
-			let diasText = "";
-
-			if (dias === null) {
-				// sin texto secundario
-			} else if (dias === 0) {
-				diasClassName += " text-red-600 font-semibold";
-				diasText = "¡Hoy!";
-			} else if (dias < 0) {
-				diasClassName += " text-red-700 font-semibold";
-				diasText = `${Math.abs(dias)} días vencido`;
-			} else if (dias <= 3) {
-				diasClassName += " text-orange-600";
-				diasText = `en ${dias} días`;
-			} else if (dias <= 7) {
-				diasClassName += " text-yellow-600";
-				diasText = `en ${dias} días`;
-			} else {
-				diasClassName += " text-muted-foreground";
-				diasText = `en ${dias} días`;
-			}
-
-			return (
-				<div className="flex items-center gap-2">
-					<div className="font-medium">
-						{fechaFormateada ? (
-							<div>{fechaFormateada}</div>
-						) : (
-							<div className="text-gray-500">Sin fecha definida</div>
-						)}
-						{diasText && <div className={diasClassName}>{diasText}</div>}
-					</div>
-					{mostrarCtaContacto && numeroCredito && (
-						<ContactoQuickAction numeroCredito={numeroCredito} />
-					)}
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: "clienteNombre",
-		header: ({ column }) => {
-			return (
-				<Button
-					variant="ghost"
-					onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-				>
-					Cliente / Crédito
-					<ArrowUpDown className="ml-2 h-4 w-4" />
-				</Button>
-			);
-		},
-		cell: ({ row }) => {
-			const nombre = row.getValue("clienteNombre") as string;
-			const numero = row.original.numeroCredito;
-			const isPool = row.original.isPool;
-			return (
-				<div className="flex min-w-0 max-w-[320px] flex-col gap-0.5">
-					<div className="flex items-center gap-2">
-						<span className="truncate font-medium">{nombre}</span>
-						{isPool && (
-							<Badge
-								variant="secondary"
-								className="shrink-0 bg-indigo-100 text-indigo-800 text-xs"
-							>
-								Pool
-							</Badge>
-						)}
-					</div>
-					<span
-						className="truncate font-mono text-muted-foreground text-xs"
-						title={numero || undefined}
-					>
-						{numero ? truncarCredito(numero) : "—"}
-					</span>
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: "responsableCobros",
-		header: ({ column }) => (
-			<Button
-				variant="ghost"
-				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-			>
-				Asesor
-				<ArrowUpDown className="ml-2 h-4 w-4" />
-			</Button>
-		),
-		cell: ({ row }) => {
-			const asesor = row.getValue("responsableCobros") as string | null;
-			if (!asesor)
+		{
+			accessorKey: "fechaProximoPago",
+			header: ({ column }) => {
 				return (
-					<span className="text-muted-foreground text-xs">Sin asignar</span>
+					<Button
+						variant="ghost"
+						onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+					>
+						Fecha de Pago
+						<ArrowUpDown className="ml-2 h-4 w-4" />
+					</Button>
 				);
-			return <span className="font-medium text-sm">{asesor}</span>;
-		},
-	},
-	{
-		id: "vehiculo",
-		accessorFn: (row) =>
-			`${row.vehiculoMarca} ${row.vehiculoModelo} ${row.vehiculoYear} ${row.vehiculoPlaca}`,
-		header: "Vehículo",
-		cell: ({ row }) => {
-			const { vehiculoMarca, vehiculoModelo, vehiculoYear, vehiculoPlaca } =
-				row.original;
-			const esPlaceholder = esVehiculoPlaceholder(
-				vehiculoMarca,
-				vehiculoModelo,
-			);
-			const placaLimpia = vehiculoPlaca?.trim();
-			const tienePlaca = placaLimpia && placaLimpia !== "-" && placaLimpia !== "";
+			},
+			cell: ({ row }) => {
+				const fecha = row.getValue("fechaProximoPago") as string | null;
+				const dias = row.original.diasHastaPago;
+				const numeroCredito = row.original.numeroCredito;
 
-			if (esPlaceholder && !tienePlaca) {
-				return <span className="text-muted-foreground">—</span>;
-			}
+				// Si el filtro ya es un estado de mora, el botón va en todas las filas
+				// (cortocircuita sin revisar la fila). Si no, se muestra solo en las
+				// filas cuyo propio estado (estadoMora) es de mora.
+				const mostrarCtaContacto =
+					filtroEsMora ||
+					(row.original.estadoContrato === "activo" &&
+						!!row.original.estadoMora &&
+						ESTADOS_MORA_CTA.has(row.original.estadoMora));
 
-			return (
-				<div className="flex min-w-0 max-w-[180px] flex-col gap-0.5">
-					<span className="whitespace-normal break-words font-medium text-sm leading-tight">
-						{esPlaceholder
-							? "Sin datos"
-							: `${vehiculoMarca} ${vehiculoModelo} ${vehiculoYear ?? ""}`.trim()}
-					</span>
-					{tienePlaca && (
-						<span className="font-mono text-muted-foreground text-xs">
-							{placaLimpia}
-						</span>
-					)}
-				</div>
-			);
+				const fechaFormateada = fecha
+					? parseFechaLocal(fecha).toLocaleDateString("es-GT", {
+							day: "2-digit",
+							month: "short",
+							year: "numeric",
+						})
+					: null;
+
+				let diasClassName = "text-xs mt-0.5";
+				let diasText = "";
+
+				if (dias === null) {
+					// sin texto secundario
+				} else if (dias === 0) {
+					diasClassName += " text-red-600 font-semibold";
+					diasText = "¡Hoy!";
+				} else if (dias < 0) {
+					diasClassName += " text-red-700 font-semibold";
+					diasText = `${Math.abs(dias)} días vencido`;
+				} else if (dias <= 3) {
+					diasClassName += " text-orange-600";
+					diasText = `en ${dias} días`;
+				} else if (dias <= 7) {
+					diasClassName += " text-yellow-600";
+					diasText = `en ${dias} días`;
+				} else {
+					diasClassName += " text-muted-foreground";
+					diasText = `en ${dias} días`;
+				}
+
+				return (
+					<div className="flex items-center gap-2">
+						<div className="font-medium">
+							{fechaFormateada ? (
+								<div>{fechaFormateada}</div>
+							) : (
+								<div className="text-gray-500">Sin fecha definida</div>
+							)}
+							{diasText && <div className={diasClassName}>{diasText}</div>}
+						</div>
+						{mostrarCtaContacto && numeroCredito && (
+							<ContactoQuickAction numeroCredito={numeroCredito} />
+						)}
+					</div>
+				);
+			},
 		},
-	},
-	{
-		accessorKey: "montoEnMora",
-		header: ({ column }) => {
-			return (
-				<div className="text-right">
+		{
+			accessorKey: "clienteNombre",
+			header: ({ column }) => {
+				return (
 					<Button
 						variant="ghost"
 						onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
 					>
-						Monto en Mora
+						Cliente / Crédito
 						<ArrowUpDown className="ml-2 h-4 w-4" />
 					</Button>
-				</div>
-			);
-		},
-		cell: ({ row }) => {
-			const monto = Number.parseFloat(row.getValue("montoEnMora"));
-			const formatted = new Intl.NumberFormat("es-GT", {
-				style: "currency",
-				currency: "GTQ",
-				minimumFractionDigits: 2,
-				maximumFractionDigits: 2,
-			}).format(monto);
-
-			return (
-				<div
-					className={`font-medium tabular-nums ${monto > 0 ? "text-right" : "text-center"}`}
-				>
-					{monto > 0 ? formatted : "-"}
-				</div>
-			);
-		},
-	},
-	{
-		accessorKey: "montoFinanciado",
-		header: ({ column }) => {
-			return (
-				<div className="text-right">
-					<Button
-						variant="ghost"
-						onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-					>
-						Capital
-						<ArrowUpDown className="ml-2 h-4 w-4" />
-					</Button>
-				</div>
-			);
-		},
-		cell: ({ row }) => {
-			const monto = Number.parseFloat(row.getValue("montoFinanciado"));
-			const formatted = new Intl.NumberFormat("es-GT", {
-				style: "currency",
-				currency: "GTQ",
-				minimumFractionDigits: 2,
-				maximumFractionDigits: 2,
-			}).format(monto);
-
-			return (
-				<div
-					className={`font-medium tabular-nums ${monto > 0 ? "text-right" : "text-center"}`}
-				>
-					{monto > 0 ? formatted : "-"}
-				</div>
-			);
-		},
-		sortingFn: (rowA, rowB) => {
-			const a = Number.parseFloat(rowA.getValue("montoFinanciado"));
-			const b = Number.parseFloat(rowB.getValue("montoFinanciado"));
-			return a - b;
-		},
-	},
-	{
-		id: "etiquetas",
-		accessorKey: "etiquetas",
-		header: ({ column }) => (
-			<Button
-				variant="ghost"
-				onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-			>
-				Etiquetas
-				<ArrowUpDown className="ml-2 h-4 w-4" />
-			</Button>
-		),
-		cell: ({ row }) => {
-			const etiquetas = row.original.etiquetas;
-			if (!etiquetas || etiquetas.length === 0)
-				return <span className="text-muted-foreground text-xs">—</span>;
-			return (
-				<div className="flex flex-wrap gap-1">
-					{etiquetas.map((etiqueta) => (
-						<Badge
-							key={etiqueta}
-							className={`text-xs ${ETIQUETA_COLORS[etiqueta] || "bg-gray-100 text-gray-800"}`}
+				);
+			},
+			cell: ({ row }) => {
+				const nombre = row.getValue("clienteNombre") as string;
+				const numero = row.original.numeroCredito;
+				const isPool = row.original.isPool;
+				return (
+					<div className="flex min-w-0 max-w-[320px] flex-col gap-0.5">
+						<div className="flex items-center gap-2">
+							<span className="truncate font-medium">{nombre}</span>
+							{isPool && (
+								<Badge
+									variant="secondary"
+									className="shrink-0 bg-indigo-100 text-indigo-800 text-xs"
+								>
+									Pool
+								</Badge>
+							)}
+						</div>
+						<span
+							className="truncate font-mono text-muted-foreground text-xs"
+							title={numero || undefined}
 						>
-							{ETIQUETA_LABELS[etiqueta] || etiqueta}
-						</Badge>
-					))}
-				</div>
-			);
+							{numero ? truncarCredito(numero) : "—"}
+						</span>
+					</div>
+				);
+			},
 		},
-		sortingFn: (rowA, rowB) => {
-			const a = rowA.original.etiquetas?.length ?? 0;
-			const b = rowB.original.etiquetas?.length ?? 0;
-			return a - b;
+		{
+			accessorKey: "responsableCobros",
+			header: ({ column }) => (
+				<Button
+					variant="ghost"
+					onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				>
+					Asesor
+					<ArrowUpDown className="ml-2 h-4 w-4" />
+				</Button>
+			),
+			cell: ({ row }) => {
+				const asesor = row.getValue("responsableCobros") as string | null;
+				if (!asesor)
+					return (
+						<span className="text-muted-foreground text-xs">Sin asignar</span>
+					);
+				return <span className="font-medium text-sm">{asesor}</span>;
+			},
 		},
-	},
-	{
-		id: "estado",
-		accessorFn: (row) =>
-			row.estadoContrato === "activo"
-				? row.estadoMora || "al_dia"
-				: row.estadoContrato,
-		header: "Estado",
-		cell: ({ row }) => {
-			const estadoVisual =
-				row.original.estadoContrato === "activo"
-					? row.original.estadoMora || "al_dia"
-					: row.original.estadoContrato;
-			return getEstadoBadge(estadoVisual);
+		{
+			id: "vehiculo",
+			accessorFn: (row) =>
+				`${row.vehiculoMarca} ${row.vehiculoModelo} ${row.vehiculoYear} ${row.vehiculoPlaca}`,
+			header: "Vehículo",
+			cell: ({ row }) => {
+				const { vehiculoMarca, vehiculoModelo, vehiculoYear, vehiculoPlaca } =
+					row.original;
+				const esPlaceholder = esVehiculoPlaceholder(
+					vehiculoMarca,
+					vehiculoModelo,
+				);
+				const placaLimpia = vehiculoPlaca?.trim();
+				const tienePlaca =
+					placaLimpia && placaLimpia !== "-" && placaLimpia !== "";
+
+				if (esPlaceholder && !tienePlaca) {
+					return <span className="text-muted-foreground">—</span>;
+				}
+
+				return (
+					<div className="flex min-w-0 max-w-[180px] flex-col gap-0.5">
+						<span className="whitespace-normal break-words font-medium text-sm leading-tight">
+							{esPlaceholder
+								? "Sin datos"
+								: `${vehiculoMarca} ${vehiculoModelo} ${vehiculoYear ?? ""}`.trim()}
+						</span>
+						{tienePlaca && (
+							<span className="font-mono text-muted-foreground text-xs">
+								{placaLimpia}
+							</span>
+						)}
+					</div>
+				);
+			},
 		},
-	},
+		{
+			accessorKey: "montoEnMora",
+			header: ({ column }) => {
+				return (
+					<div className="text-right">
+						<Button
+							variant="ghost"
+							onClick={() =>
+								column.toggleSorting(column.getIsSorted() === "asc")
+							}
+						>
+							Monto en Mora
+							<ArrowUpDown className="ml-2 h-4 w-4" />
+						</Button>
+					</div>
+				);
+			},
+			cell: ({ row }) => {
+				const monto = Number.parseFloat(row.getValue("montoEnMora"));
+				const formatted = new Intl.NumberFormat("es-GT", {
+					style: "currency",
+					currency: "GTQ",
+					minimumFractionDigits: 2,
+					maximumFractionDigits: 2,
+				}).format(monto);
+
+				return (
+					<div
+						className={`font-medium tabular-nums ${monto > 0 ? "text-right" : "text-center"}`}
+					>
+						{monto > 0 ? formatted : "-"}
+					</div>
+				);
+			},
+		},
+		{
+			accessorKey: "montoFinanciado",
+			header: ({ column }) => {
+				return (
+					<div className="text-right">
+						<Button
+							variant="ghost"
+							onClick={() =>
+								column.toggleSorting(column.getIsSorted() === "asc")
+							}
+						>
+							Capital
+							<ArrowUpDown className="ml-2 h-4 w-4" />
+						</Button>
+					</div>
+				);
+			},
+			cell: ({ row }) => {
+				const monto = Number.parseFloat(row.getValue("montoFinanciado"));
+				const formatted = new Intl.NumberFormat("es-GT", {
+					style: "currency",
+					currency: "GTQ",
+					minimumFractionDigits: 2,
+					maximumFractionDigits: 2,
+				}).format(monto);
+
+				return (
+					<div
+						className={`font-medium tabular-nums ${monto > 0 ? "text-right" : "text-center"}`}
+					>
+						{monto > 0 ? formatted : "-"}
+					</div>
+				);
+			},
+			sortingFn: (rowA, rowB) => {
+				const a = Number.parseFloat(rowA.getValue("montoFinanciado"));
+				const b = Number.parseFloat(rowB.getValue("montoFinanciado"));
+				return a - b;
+			},
+		},
+		{
+			id: "etiquetas",
+			accessorKey: "etiquetas",
+			header: ({ column }) => (
+				<Button
+					variant="ghost"
+					onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+				>
+					Etiquetas
+					<ArrowUpDown className="ml-2 h-4 w-4" />
+				</Button>
+			),
+			cell: ({ row }) => {
+				const etiquetas = row.original.etiquetas;
+				if (!etiquetas || etiquetas.length === 0)
+					return <span className="text-muted-foreground text-xs">—</span>;
+				return (
+					<div className="flex flex-wrap gap-1">
+						{etiquetas.map((etiqueta) => (
+							<Badge
+								key={etiqueta}
+								className={`text-xs ${ETIQUETA_COLORS[etiqueta] || "bg-gray-100 text-gray-800"}`}
+							>
+								{ETIQUETA_LABELS[etiqueta] || etiqueta}
+							</Badge>
+						))}
+					</div>
+				);
+			},
+			sortingFn: (rowA, rowB) => {
+				const a = rowA.original.etiquetas?.length ?? 0;
+				const b = rowB.original.etiquetas?.length ?? 0;
+				return a - b;
+			},
+		},
+		{
+			id: "estado",
+			accessorFn: (row) =>
+				row.estadoContrato === "activo"
+					? row.estadoMora || "al_dia"
+					: row.estadoContrato,
+			header: "Estado",
+			cell: ({ row }) => {
+				const estadoVisual =
+					row.original.estadoContrato === "activo"
+						? row.original.estadoMora || "al_dia"
+						: row.original.estadoContrato;
+				return getEstadoBadge(estadoVisual, catalogo);
+			},
+		},
 	];
 }
 

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import {
 	type BucketsCatalogoQueryData,
 	bucketDeEstado,
+	estiloBucket,
 } from "@/lib/cobros/buckets-catalogo";
 import { parseFechaLocal } from "@/lib/date-utils";
 
@@ -44,7 +45,11 @@ function getEstadoBadge(
 	catalogo: BucketsCatalogoQueryData | undefined,
 ) {
 	const bucket = bucketDeEstado(estado, catalogo);
-	return <Badge className={bucket.colorClass}>{bucket.label}</Badge>;
+	return (
+		<Badge variant="outline" style={estiloBucket(bucket.colorHex)}>
+			{bucket.label}
+		</Badge>
+	);
 }
 
 const ETIQUETA_LABELS: Record<string, string> = {

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -63,6 +63,10 @@ import {
 } from "@/components/ui/popover";
 import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
+import {
+	bucketDeEstado,
+	useBucketsCatalogo,
+} from "@/lib/cobros/buckets-catalogo";
 import { formatFechaLocal } from "@/lib/date-utils";
 import { ROLES } from "@/lib/roles";
 import { client, orpc } from "@/utils/orpc";
@@ -203,6 +207,8 @@ function RouteComponent() {
 	const [isSeguimientoModalOpen, setIsSeguimientoModalOpen] = useState(false);
 
 	const queryClient = useQueryClient();
+
+	const bucketsCatalogo = useBucketsCatalogo();
 
 	// Obtener detalles del contrato/caso
 	// Si es ID numérico, usar endpoint de Cartera-Back, si es UUID usar el del CRM
@@ -470,20 +476,11 @@ function RouteComponent() {
 		setIsEditingVehicle(true);
 	};
 
-	const getEstadoBadge = (estado: string | null | undefined) => {
-		const colors: Record<string, string> = {
-			en_convenio: "bg-green-100 text-green-800",
-			mora_30: "bg-yellow-100 text-yellow-800",
-			mora_60: "bg-orange-100 text-orange-800",
-			mora_90: "bg-red-100 text-red-800",
-			mora_120: "bg-red-200 text-red-900",
-			pagado: "bg-green-100 text-green-800",
-			incobrable: "bg-gray-100 text-gray-800",
-		};
-		return estado
-			? (colors[estado] ?? "bg-gray-100 text-gray-800")
-			: "bg-gray-100 text-gray-800";
-	};
+	const getEstadoBadge = (estado: string | null | undefined) =>
+		bucketDeEstado(estado, bucketsCatalogo.data).colorClass;
+
+	const getEstadoLabel = (estado: string | null | undefined) =>
+		bucketDeEstado(estado, bucketsCatalogo.data).label;
 
 	const getMetodoIcon = (metodo: string) => {
 		switch (metodo) {
@@ -547,7 +544,7 @@ function RouteComponent() {
 					</div>
 				</div>
 				<Badge className={getEstadoBadge(caso.estadoMora || "")}>
-					{caso.estadoMora?.replace("_", " ")?.toUpperCase()}
+					{getEstadoLabel(caso.estadoMora || "")}
 				</Badge>
 			</div>
 
@@ -652,10 +649,11 @@ function RouteComponent() {
 									</div>
 									<p className="font-bold text-lg text-orange-600">
 										Q
-										{(
-											caso.cuotaConvenio != null
-												? Number(caso.cuotaConvenio) + Number(caso.cuotaMensual || 0)
-												: Number(caso.montoEnMora) + Number(caso.cuotaMensual || 0)
+										{(caso.cuotaConvenio != null
+											? Number(caso.cuotaConvenio) +
+												Number(caso.cuotaMensual || 0)
+											: Number(caso.montoEnMora) +
+												Number(caso.cuotaMensual || 0)
 										).toLocaleString()}
 									</p>
 								</div>
@@ -751,10 +749,13 @@ function RouteComponent() {
 													Convenio:{" "}
 													<strong>
 														Q
-														{Number(caso.cuotaConvenio ?? 0).toLocaleString("es-GT", {
-															minimumFractionDigits: 2,
-															maximumFractionDigits: 2,
-														})}
+														{Number(caso.cuotaConvenio ?? 0).toLocaleString(
+															"es-GT",
+															{
+																minimumFractionDigits: 2,
+																maximumFractionDigits: 2,
+															},
+														)}
 													</strong>
 												</span>
 												<span>+</span>
@@ -762,10 +763,13 @@ function RouteComponent() {
 													Cuota:{" "}
 													<strong>
 														Q
-														{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", {
-															minimumFractionDigits: 2,
-															maximumFractionDigits: 2,
-														})}
+														{Number(caso.cuotaMensual || 0).toLocaleString(
+															"es-GT",
+															{
+																minimumFractionDigits: 2,
+																maximumFractionDigits: 2,
+															},
+														)}
 													</strong>
 												</span>
 											</div>
@@ -1463,8 +1467,17 @@ function RouteComponent() {
 												cuotasPage * ITEMS_PER_PAGE,
 											)
 											.map((cuota) => {
-												const estadoBadge = getEstadoBadge(cuota.estadoMora);
+												// cuota.estadoMora es "pagado"/"pendiente" — estado de
+												// CUOTA, no el estadoMora de aging/status del crédito
+												// (al_dia/mora_30/.../en_convenio/incobrable). No pasa
+												// por bucketDeEstado: mezclar ambos dominios en
+												// DEFAULT_BUCKETS haría de ese catálogo un cajón de
+												// sastre, y "pendiente" caería en BUCKET_DESCONOCIDO.
 												const esPagada = cuota.estadoMora === "pagado";
+												const estadoBadge = esPagada
+													? "bg-green-100 text-green-800"
+													: "bg-yellow-100 text-yellow-800";
+												const estadoLabel = esPagada ? "Pagado" : "Pendiente";
 												const tieneMora = Number(cuota.montoMora) > 0;
 												const pagoConMora = esPagada && tieneMora; // Pagado pero con mora
 
@@ -1479,9 +1492,7 @@ function RouteComponent() {
 																	Cuota #{cuota.numeroCuota}
 																</span>
 																<Badge className={estadoBadge}>
-																	{cuota.estadoMora
-																		?.replace("_", " ")
-																		?.toUpperCase()}
+																	{estadoLabel}
 																</Badge>
 																{pagoConMora && (
 																	<Badge className="bg-orange-100 text-orange-800 text-xs dark:bg-orange-950/40 dark:text-orange-300">

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -65,6 +65,7 @@ import { Separator } from "@/components/ui/separator";
 import { authClient } from "@/lib/auth-client";
 import {
 	bucketDeEstado,
+	estiloBucket,
 	useBucketsCatalogo,
 } from "@/lib/cobros/buckets-catalogo";
 import { formatFechaLocal } from "@/lib/date-utils";
@@ -477,7 +478,7 @@ function RouteComponent() {
 	};
 
 	const getEstadoBadge = (estado: string | null | undefined) =>
-		bucketDeEstado(estado, bucketsCatalogo.data).colorClass;
+		estiloBucket(bucketDeEstado(estado, bucketsCatalogo.data).colorHex);
 
 	const getEstadoLabel = (estado: string | null | undefined) =>
 		bucketDeEstado(estado, bucketsCatalogo.data).label;
@@ -543,7 +544,7 @@ function RouteComponent() {
 						</p>
 					</div>
 				</div>
-				<Badge className={getEstadoBadge(caso.estadoMora || "")}>
+				<Badge variant="outline" style={getEstadoBadge(caso.estadoMora || "")}>
 					{getEstadoLabel(caso.estadoMora || "")}
 				</Badge>
 			</div>

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -44,6 +44,7 @@ import { authClient } from "@/lib/auth-client";
 import {
 	type BucketUI,
 	bucketsParaRender,
+	estiloBucket,
 	useBucketsCatalogo,
 } from "@/lib/cobros/buckets-catalogo";
 import { getCobrosColumns } from "@/lib/cobros/columns";
@@ -124,7 +125,11 @@ function EmbudoRow({
 					className="group flex w-full cursor-pointer items-center gap-3 p-3 text-left transition-all hover:bg-muted/50"
 				>
 					<div className="flex w-32 shrink-0 items-center gap-2">
-						<Badge className={`${estado.colorClass} whitespace-nowrap text-xs`}>
+						<Badge
+							variant="outline"
+							className="whitespace-nowrap text-xs"
+							style={estiloBucket(estado.colorHex)}
+						>
 							{estado.label}
 						</Badge>
 					</div>
@@ -1191,7 +1196,13 @@ function RouteComponent() {
 										{filtrosEtapa.map((filtro) => (
 											<Badge
 												key={filtro.key}
-												className={`cursor-pointer ${filtroEtapa === filtro.key ? filtro.colorClass : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+												variant="outline"
+												className={`cursor-pointer ${filtroEtapa === filtro.key ? "" : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+												style={
+													filtroEtapa === filtro.key
+														? estiloBucket(filtro.colorHex)
+														: undefined
+												}
 												onClick={() => {
 													setFiltroEtapa(
 														filtroEtapa === filtro.key ? null : filtro.key,

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -16,17 +16,14 @@ import {
 	Users,
 	X,
 } from "lucide-react";
-import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
-import { usePersistedState } from "@/hooks/usePersistedState";
 import { useEffect, useMemo, useState } from "react";
 import type { DateRange } from "react-day-picker";
-import { MassWhatsappModal } from "@/components/cobros/mass-whatsapp-modal";
-import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { CapitalRangeFilter } from "@/components/cobros/capital-range-filter";
+import { MassWhatsappModal } from "@/components/cobros/mass-whatsapp-modal";
 import { DataTable } from "@/components/data-table";
+import { DateRangeFilter } from "@/components/reports/date-range-filter";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
 	Card,
 	CardContent,
@@ -39,8 +36,16 @@ import {
 	CollapsibleContent,
 	CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
+import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
+import {
+	type BucketUI,
+	bucketsParaRender,
+	useBucketsCatalogo,
+} from "@/lib/cobros/buckets-catalogo";
 import { getCobrosColumns } from "@/lib/cobros/columns";
 import { getPaymentDateRangeFilter } from "@/lib/cobros/payment-date-range-filter";
 import { parseFechaLocal } from "@/lib/date-utils";
@@ -65,13 +70,6 @@ function calcularDiasHastaPago(fechaProximoPago: string | null) {
 
 type FiltroTemporal = "hoy" | "semana" | "quincena" | "mes" | "todos";
 
-interface EmbudoEstado {
-	key: string;
-	label: string;
-	color: string;
-	barColor: string;
-}
-
 interface EmbudoStats {
 	totalCases: number;
 	montoTotal: string;
@@ -86,7 +84,7 @@ function EmbudoRow({
 	emailCobrador,
 	onNavigate,
 }: {
-	estado: EmbudoEstado;
+	estado: BucketUI;
 	estadoStats: EmbudoStats;
 	maxCasos: number;
 	emailCobrador: string | undefined;
@@ -126,7 +124,7 @@ function EmbudoRow({
 					className="group flex w-full cursor-pointer items-center gap-3 p-3 text-left transition-all hover:bg-muted/50"
 				>
 					<div className="flex w-32 shrink-0 items-center gap-2">
-						<Badge className={`${estado.color} whitespace-nowrap text-xs`}>
+						<Badge className={`${estado.colorClass} whitespace-nowrap text-xs`}>
 							{estado.label}
 						</Badge>
 					</div>
@@ -137,7 +135,7 @@ function EmbudoRow({
 									className="flex h-full items-center justify-between px-3 transition-all duration-300 group-hover:opacity-80"
 									style={{
 										width: `${porcentaje}%`,
-										backgroundColor: estado.barColor,
+										backgroundColor: estado.colorHex,
 									}}
 								>
 									<span
@@ -159,7 +157,7 @@ function EmbudoRow({
 										className="h-full transition-all duration-300 group-hover:opacity-80"
 										style={{
 											width: `${Math.max(porcentaje, 3)}%`,
-											backgroundColor: estado.barColor,
+											backgroundColor: estado.colorHex,
 										}}
 									/>
 									<span className="ml-2 whitespace-nowrap font-semibold text-muted-foreground text-sm">
@@ -177,13 +175,21 @@ function EmbudoRow({
 						<div className="flex items-center justify-end gap-2">
 							<span className="text-muted-foreground text-xs">Mora:</span>
 							<span className="font-medium">
-								Q{Number(estadoStats.montoTotal || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+								Q
+								{Number(estadoStats.montoTotal || 0).toLocaleString("es-GT", {
+									minimumFractionDigits: 2,
+									maximumFractionDigits: 2,
+								})}
 							</span>
 						</div>
 						<div className="flex items-center justify-end gap-2">
 							<span className="text-muted-foreground text-xs">Capital:</span>
 							<span className="font-medium">
-								Q{Number(estadoStats.sumaCapital || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+								Q
+								{Number(estadoStats.sumaCapital || 0).toLocaleString("es-GT", {
+									minimumFractionDigits: 2,
+									maximumFractionDigits: 2,
+								})}
 							</span>
 						</div>
 					</div>
@@ -244,7 +250,11 @@ function EmbudoRow({
 											{caso.numeroCredito || "-"}
 										</td>
 										<td className="py-2 text-right tabular-nums">
-											Q{Number(caso.montoFinanciado || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+											Q
+											{Number(caso.montoFinanciado || 0).toLocaleString(
+												"es-GT",
+												{ minimumFractionDigits: 2, maximumFractionDigits: 2 },
+											)}
 										</td>
 										<td className="py-2 text-right text-red-600 tabular-nums">
 											{Number(caso.montoEnMora || 0) > 0
@@ -252,7 +262,11 @@ function EmbudoRow({
 												: "-"}
 										</td>
 										<td className="py-2 pr-3 text-right tabular-nums">
-											Q{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+											Q
+											{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", {
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											})}
 										</td>
 									</tr>
 								))}
@@ -289,28 +303,60 @@ const ETIQUETA_LABELS_FILTRO: Record<string, string> = {
 	reclamo: "Reclamo",
 };
 
-
 function RouteComponent() {
 	const { data: session } = authClient.useSession();
 	const navigate = useNavigate();
-	const [filtroTemporal, setFiltroTemporal] = usePersistedState<FiltroTemporal>("cobros/filtroTemporal", "hoy");
+	const [filtroTemporal, setFiltroTemporal] = usePersistedState<FiltroTemporal>(
+		"cobros/filtroTemporal",
+		"hoy",
+	);
 	const [mostrarCompletadosIncobrables, setMostrarCompletadosIncobrables] =
 		useState(false);
-	const [filtroEtapa, setFiltroEtapa] = usePersistedState<string | null>("cobros/filtroEtapa", null);
-	const [filtroEtiquetas, setFiltroEtiquetas] = usePersistedState<string[]>("cobros/filtroEtiquetas", []);
+	const [filtroEtapa, setFiltroEtapa] = usePersistedState<string | null>(
+		"cobros/filtroEtapa",
+		null,
+	);
+	const [filtroEtiquetas, setFiltroEtiquetas] = usePersistedState<string[]>(
+		"cobros/filtroEtiquetas",
+		[],
+	);
 	const [page, setPage] = usePersistedState<number>("cobros/page", 1);
-	const [filterValue, setFilterValue] = usePersistedState<string>("cobros/filterValue", "");
+	const [filterValue, setFilterValue] = usePersistedState<string>(
+		"cobros/filterValue",
+		"",
+	);
 	const [debouncedFilterValue, setDebouncedFilterValue] = useState(filterValue);
-	const [sifcoFilterValue, setSifcoFilterValue] = usePersistedState<string>("cobros/sifcoFilterValue", "");
-	const [debouncedSifcoFilterValue, setDebouncedSifcoFilterValue] = useState(sifcoFilterValue);
-	const [pageSize, setPageSize] = usePersistedState<number>("cobros/pageSize", 25);
+	const [sifcoFilterValue, setSifcoFilterValue] = usePersistedState<string>(
+		"cobros/sifcoFilterValue",
+		"",
+	);
+	const [debouncedSifcoFilterValue, setDebouncedSifcoFilterValue] =
+		useState(sifcoFilterValue);
+	const [pageSize, setPageSize] = usePersistedState<number>(
+		"cobros/pageSize",
+		25,
+	);
 	const [dateRange, setDateRange] = usePersistedDateRange("cobros/dateRange");
-	const [pickerRange, setPickerRange] = useState<DateRange | undefined>(dateRange);
-	const fechaDesde = dateRange?.from && dateRange?.to ? dateRange.from.toISOString().slice(0, 10) : undefined;
-	const fechaHasta = dateRange?.from && dateRange?.to ? dateRange.to.toISOString().slice(0, 10) : undefined;
+	const [pickerRange, setPickerRange] = useState<DateRange | undefined>(
+		dateRange,
+	);
+	const fechaDesde =
+		dateRange?.from && dateRange?.to
+			? dateRange.from.toISOString().slice(0, 10)
+			: undefined;
+	const fechaHasta =
+		dateRange?.from && dateRange?.to
+			? dateRange.to.toISOString().slice(0, 10)
+			: undefined;
 	const [fechaError, setFechaError] = useState<string | null>(null);
-	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>("cobros/capitalMin", undefined);
-	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>("cobros/capitalMax", undefined);
+	const [capitalMin, setCapitalMin] = usePersistedState<number | undefined>(
+		"cobros/capitalMin",
+		undefined,
+	);
+	const [capitalMax, setCapitalMax] = usePersistedState<number | undefined>(
+		"cobros/capitalMax",
+		undefined,
+	);
 
 	const hasActiveFilters =
 		filtroTemporal !== "hoy" ||
@@ -356,6 +402,8 @@ function RouteComponent() {
 	}, [sifcoFilterValue]);
 
 	const userRole = session?.user.role;
+
+	const bucketsCatalogo = useBucketsCatalogo();
 
 	const dashboardStats = useQuery({
 		...orpc.getCobrosDashboardStats.queryOptions({
@@ -475,8 +523,8 @@ function RouteComponent() {
 	// Recalcular columnas cuando cambia el filtro de etapa: el CTA de contacto
 	// rápido sólo aparece para estados de mora activa.
 	const columns = useMemo(
-		() => getCobrosColumns({ filtroEtapa }),
-		[filtroEtapa],
+		() => getCobrosColumns({ filtroEtapa, catalogo: bucketsCatalogo.data }),
+		[filtroEtapa, bucketsCatalogo.data],
 	);
 
 	// Procesar creditos y calcular días hasta pago
@@ -544,7 +592,13 @@ function RouteComponent() {
 			// Incluir casos en mora (días negativos) y casos próximos a vencer
 			return c?.diasHastaPago !== null && c?.diasHastaPago <= limite;
 		});
-	}, [creditosConDias, filtroTemporal, mostrarCompletadosIncobrables, filtroEtiquetas, filtroEtapa]);
+	}, [
+		creditosConDias,
+		filtroTemporal,
+		mostrarCompletadosIncobrables,
+		filtroEtiquetas,
+		filtroEtapa,
+	]);
 
 	// Check permissions after all hooks
 	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {
@@ -570,53 +624,17 @@ function RouteComponent() {
 		{ key: "todos" as const, label: "Todos", icon: Users },
 	];
 
-	const filtrosEtapa = [
-		{
-			key: "al_dia",
-			label: "Cartera Sana",
-			color: "bg-green-100 text-green-800",
-		},
-		{
-			key: "en_convenio",
-			label: "En Convenio",
-			color: "bg-green-100 text-green-800",
-		},
-		{
-			key: "mora_30",
-			label: "Alerta Temprana",
-			color: "bg-yellow-100 text-yellow-800",
-		},
-		{
-			key: "mora_60",
-			label: "Gestión Activa",
-			color: "bg-orange-100 text-orange-800",
-		},
-		{
-			key: "mora_90",
-			label: "Rescate",
-			color: "bg-red-100 text-red-800",
-		},
-		{
-			key: "mora_120",
-			label: "Última Instancia / Pre Jurídico",
-			color: "bg-red-200 text-red-900",
-		},
-		{
-			key: "mora_120_plus",
-			label: "Jurídico",
-			color: "bg-red-300 text-red-900",
-		},
-		{
-			key: "incobrable",
-			label: "Incobrable",
-			color: "bg-gray-100 text-gray-800",
-		},
-		{
-			key: "completado",
-			label: "Completado",
-			color: "bg-blue-100 text-blue-800",
-		},
-	];
+	const filtrosEtapa = bucketsParaRender(bucketsCatalogo.data, [
+		"al_dia",
+		"en_convenio",
+		"mora_30",
+		"mora_60",
+		"mora_90",
+		"mora_120",
+		"mora_120_plus",
+		"incobrable",
+		"completado",
+	]);
 
 	if (dashboardStats.isLoading) {
 		return (
@@ -708,7 +726,10 @@ function RouteComponent() {
 							Q
 							{stats
 								.reduce((sum, s) => sum + Number(s.montoTotal || 0), 0)
-								.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+								.toLocaleString("es-GT", {
+									minimumFractionDigits: 2,
+									maximumFractionDigits: 2,
+								})}
 						</div>
 						<p className="text-muted-foreground text-xs">
 							Suma de todos los montos en mora
@@ -728,7 +749,10 @@ function RouteComponent() {
 							Q
 							{stats
 								.reduce((sum, s) => sum + Number(s.sumaCapital || 0), 0)
-								.toLocaleString("es-GT", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+								.toLocaleString("es-GT", {
+									minimumFractionDigits: 2,
+									maximumFractionDigits: 2,
+								})}
 						</div>
 						<p className="text-muted-foreground text-xs">
 							Suma de todos los capitales
@@ -768,58 +792,16 @@ function RouteComponent() {
 				</CardHeader>
 				<CardContent>
 					<div className="space-y-1">
-						{(
-							[
-								{
-									key: "al_dia",
-									label: "Cartera Sana",
-									color: "bg-green-100 text-green-800",
-									barColor: "#22c55e",
-								},
-								{
-									key: "mora_30",
-									label: "Alerta Temprana",
-									color: "bg-yellow-100 text-yellow-800",
-									barColor: "#eab308",
-								},
-								{
-									key: "mora_60",
-									label: "Gestión Activa",
-									color: "bg-orange-100 text-orange-800",
-									barColor: "#f97316",
-								},
-								{
-									key: "mora_90",
-									label: "Rescate",
-									color: "bg-red-100 text-red-800",
-									barColor: "#ef4444",
-								},
-								{
-									key: "mora_120",
-									label: "Última Instancia / Pre Jurídico",
-									color: "bg-red-200 text-red-900",
-									barColor: "#b91c1c",
-								},
-								{
-									key: "mora_120_plus",
-									label: "Jurídico",
-									color: "bg-red-300 text-red-900",
-									barColor: "#991b1b",
-								},
-								{
-									key: "incobrable",
-									label: "Incobrable",
-									color: "bg-gray-100 text-gray-800",
-									barColor: "#6b7280",
-								},
-								{
-									key: "completado",
-									label: "Completado",
-									color: "bg-blue-100 text-blue-800",
-									barColor: "#3b82f6",
-								},
-							] satisfies EmbudoEstado[]
-						).map((estado) => {
+						{bucketsParaRender(bucketsCatalogo.data, [
+							"al_dia",
+							"mora_30",
+							"mora_60",
+							"mora_90",
+							"mora_120",
+							"mora_120_plus",
+							"incobrable",
+							"completado",
+						]).map((estado) => {
 							const estadoStat = stats.find(
 								(s) => s.estadoMora === estado.key,
 							) || {
@@ -1001,7 +983,8 @@ function RouteComponent() {
 										);
 										porcentajeReal = buckets120.length
 											? buckets120.reduce(
-													(sum, s) => sum + Number.parseFloat(s.porcentaje || "0"),
+													(sum, s) =>
+														sum + Number.parseFloat(s.porcentaje || "0"),
 													0,
 												)
 											: undefined;
@@ -1174,8 +1157,8 @@ function RouteComponent() {
 													return;
 												}
 												setFechaError(null);
-												setDateRange(range);    // persiste y afecta la query
-												setPickerRange(range);  // actualiza display
+												setDateRange(range); // persiste y afecta la query
+												setPickerRange(range); // actualiza display
 												if (!range.from || !range.to) return;
 												setFiltroTemporal("todos");
 												setPage(1);
@@ -1208,7 +1191,7 @@ function RouteComponent() {
 										{filtrosEtapa.map((filtro) => (
 											<Badge
 												key={filtro.key}
-												className={`cursor-pointer ${filtroEtapa === filtro.key ? filtro.color : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
+												className={`cursor-pointer ${filtroEtapa === filtro.key ? filtro.colorClass : "bg-gray-50 text-gray-600 hover:bg-gray-100"}`}
 												onClick={() => {
 													setFiltroEtapa(
 														filtroEtapa === filtro.key ? null : filtro.key,
@@ -1278,11 +1261,30 @@ function RouteComponent() {
 								</div>
 								{hasActiveFilters && (
 									<div className="border-t pt-2">
-										<Button variant="ghost" size="sm" onClick={resetFilters} className="w-full text-muted-foreground">
+										<Button
+											variant="ghost"
+											size="sm"
+											onClick={resetFilters}
+											className="w-full text-muted-foreground"
+										>
 											<X className="mr-1 h-3 w-3" />
 											Limpiar filtros
-											<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
-												{[filtroTemporal !== "hoy", filtroEtapa !== null, filtroEtiquetas.length > 0, filterValue !== "", sifcoFilterValue !== "", capitalMin !== undefined, capitalMax !== undefined, dateRange !== undefined].filter(Boolean).length}
+											<Badge
+												variant="secondary"
+												className="ml-1 h-4 px-1 text-xs"
+											>
+												{
+													[
+														filtroTemporal !== "hoy",
+														filtroEtapa !== null,
+														filtroEtiquetas.length > 0,
+														filterValue !== "",
+														sifcoFilterValue !== "",
+														capitalMin !== undefined,
+														capitalMax !== undefined,
+														dateRange !== undefined,
+													].filter(Boolean).length
+												}
 											</Badge>
 										</Button>
 									</div>

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -26,6 +26,7 @@ import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import {
 	bucketsParaRender,
+	estiloBucket,
 	useBucketsCatalogo,
 } from "@/lib/cobros/buckets-catalogo";
 import { PERMISSIONS } from "@/lib/roles";
@@ -139,7 +140,7 @@ function TabMora({
 									<CardTitle className="font-medium text-sm">
 										{etapa.label}
 									</CardTitle>
-									<Badge className={etapa.colorClass}>
+									<Badge variant="outline" style={estiloBucket(etapa.colorHex)}>
 										{bucket?.cantidad ?? 0}
 									</Badge>
 								</CardHeader>

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -24,6 +24,10 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
+import {
+	bucketsParaRender,
+	useBucketsCatalogo,
+} from "@/lib/cobros/buckets-catalogo";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
@@ -48,33 +52,13 @@ function fmtTime(d: Date) {
 
 // ─── Mora ──────────────────────────────────────────────────────────────────
 
-const ETAPAS = [
-	{
-		key: "mora_30" as const,
-		label: "Mora 30",
-		color: "bg-yellow-100 text-yellow-800",
-	},
-	{
-		key: "mora_60" as const,
-		label: "Mora 60",
-		color: "bg-orange-100 text-orange-800",
-	},
-	{
-		key: "mora_90" as const,
-		label: "Mora 90",
-		color: "bg-red-100 text-red-800",
-	},
-	{
-		key: "mora_120" as const,
-		label: "Mora 120",
-		color: "bg-red-200 text-red-900",
-	},
-	{
-		key: "mora_120_plus" as const,
-		label: "Mora 120+",
-		color: "bg-red-300 text-red-950",
-	},
-];
+const ETAPAS_MORA_KEYS = [
+	"mora_30",
+	"mora_60",
+	"mora_90",
+	"mora_120",
+	"mora_120_plus",
+] as const;
 
 function TabMora({
 	session,
@@ -86,6 +70,9 @@ function TabMora({
 	const emailCobrador = canSeeAll
 		? undefined
 		: (session?.user?.email ?? undefined);
+
+	const bucketsCatalogo = useBucketsCatalogo();
+	const ETAPAS = bucketsParaRender(bucketsCatalogo.data, ETAPAS_MORA_KEYS);
 
 	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
 		...orpc.getMoraByEtapaYAsesor.queryOptions({ input: { emailCobrador } }),
@@ -139,15 +126,22 @@ function TabMora({
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
 						const bucket = (data as any)?.totales?.[etapa.key];
 						// eslint-disable-next-line @typescript-eslint/no-explicit-any
-						const totalMora = parseFloat((data as any)?.totales?.totalEnMora?.sumaMora ?? "0");
-						const pct = totalMora > 0 ? (parseFloat(bucket?.sumaMora ?? "0") / totalMora) * 100 : 0;
+						const totalMora = Number.parseFloat(
+							(data as any)?.totales?.totalEnMora?.sumaMora ?? "0",
+						);
+						const pct =
+							totalMora > 0
+								? (Number.parseFloat(bucket?.sumaMora ?? "0") / totalMora) * 100
+								: 0;
 						return (
 							<Card key={etapa.key}>
 								<CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
 									<CardTitle className="font-medium text-sm">
 										{etapa.label}
 									</CardTitle>
-									<Badge className={etapa.color}>{bucket?.cantidad ?? 0}</Badge>
+									<Badge className={etapa.colorClass}>
+										{bucket?.cantidad ?? 0}
+									</Badge>
 								</CardHeader>
 								<CardContent>
 									<div className="font-bold text-2xl">
@@ -156,7 +150,7 @@ function TabMora({
 									<p className="text-muted-foreground text-xs">
 										Capital: {fmtQ(bucket?.sumaCapital ?? "0")}
 									</p>
-									<p className="mt-1 font-medium text-xs text-muted-foreground">
+									<p className="mt-1 font-medium text-muted-foreground text-xs">
 										{pct.toFixed(1)}% del total en mora
 									</p>
 								</CardContent>
@@ -256,8 +250,17 @@ function TabMora({
 											</div>
 											{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
 											{(() => {
-												const totalMora = parseFloat((data as any)?.totales?.totalEnMora?.sumaMora ?? "0");
-												const pct = totalMora > 0 ? (parseFloat(asesor.totalEnMora?.sumaMora ?? "0") / totalMora) * 100 : 0;
+												const totalMora = Number.parseFloat(
+													(data as any)?.totales?.totalEnMora?.sumaMora ?? "0",
+												);
+												const pct =
+													totalMora > 0
+														? (Number.parseFloat(
+																asesor.totalEnMora?.sumaMora ?? "0",
+															) /
+																totalMora) *
+															100
+														: 0;
 												return pct > 0 ? (
 													<div className="font-medium text-muted-foreground text-xs">
 														{pct.toFixed(1)}%
@@ -426,7 +429,7 @@ function RubroCelda({
 		<div className="space-y-0.5 text-right">
 			<div className="text-muted-foreground text-xs">{fmtQ(esperado)}</div>
 			<div
-				className={`text-xs font-medium ${pagadoNum > 0 ? "text-green-600" : "text-muted-foreground/40"}`}
+				className={`font-medium text-xs ${pagadoNum > 0 ? "text-green-600" : "text-muted-foreground/40"}`}
 			>
 				{pagadoNum > 0 ? fmtQ(pagado) : "—"}
 			</div>
@@ -604,18 +607,16 @@ function TabCuotasPorFecha({
 		enabled: !!session && canSeeAll,
 	});
 
-	const {
-		data,
-		isLoading,
-		dataUpdatedAt,
-		refetch,
-		isFetching,
-	} = useQuery({
+	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
 		...orpc.getCuotasPorFecha.queryOptions({
 			input: {
 				fechaInicio,
 				fechaFin,
-				asesorId: canSeeAll ? (asesorId ? Number(asesorId) : undefined) : undefined,
+				asesorId: canSeeAll
+					? asesorId
+						? Number(asesorId)
+						: undefined
+					: undefined,
 			},
 		}),
 		enabled: !!session && !!fechaInicio && !!fechaFin,
@@ -641,9 +642,10 @@ function TabCuotasPorFecha({
 		return "pendiente";
 	}
 
-	const filteredRows = filtroEstado === "todos"
-		? rows
-		: rows.filter((r) => getEstado(r) === filtroEstado);
+	const filteredRows =
+		filtroEstado === "todos"
+			? rows
+			: rows.filter((r) => getEstado(r) === filtroEstado);
 
 	return (
 		<div className="space-y-6">
@@ -775,7 +777,7 @@ function TabCuotasPorFecha({
 			{/* Summary cards */}
 			<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
 				<Card className="gap-1 border-blue-200 bg-blue-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-blue-700 text-xs">
 							Total Esperado
 						</CardTitle>
@@ -787,7 +789,7 @@ function TabCuotasPorFecha({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-green-200 bg-green-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-green-700 text-xs">
 							Total Pagado
 						</CardTitle>
@@ -799,19 +801,19 @@ function TabCuotasPorFecha({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-red-200 bg-red-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-red-700 text-xs">
 							Total Pendiente
 						</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-red-700 text-lg">
+						<div className="font-bold text-lg text-red-700">
 							{fmtQ(totales?.totalPendiente ?? "0")}
 						</div>
 					</CardContent>
 				</Card>
 				<Card className="gap-1 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-xs">Cuotas</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">
@@ -836,7 +838,7 @@ function TabCuotasPorFecha({
 					] as const
 				).map((c) => (
 					<Card key={c.key} className="gap-0.5 py-2.5">
-						<CardHeader className="px-3 pb-0 pt-0">
+						<CardHeader className="px-3 pt-0 pb-0">
 							<CardTitle className="font-medium text-muted-foreground text-xs">
 								{c.label}
 							</CardTitle>
@@ -851,7 +853,11 @@ function TabCuotasPorFecha({
 			</div>
 
 			{/* Detail table */}
-			<DataTable columns={colsCuotas} data={filteredRows} isLoading={isLoading} />
+			<DataTable
+				columns={colsCuotas}
+				data={filteredRows}
+				isLoading={isLoading}
+			/>
 		</div>
 	);
 }
@@ -911,28 +917,98 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 			</div>
 		),
 	},
-	{ accessorKey: "multas", header: "Multas", cell: ({ row }) => fmtDesc(row.original.multas) },
-	{ accessorKey: "copiaDeLlave", header: "Copia llave", cell: ({ row }) => fmtDesc(row.original.copiaDeLlave) },
-	{ accessorKey: "diferenciaCopia", header: "Dif. copia", cell: ({ row }) => fmtDesc(row.original.diferenciaCopia) },
-	{ accessorKey: "impuestoCirculacion", header: "Imp. circulación", cell: ({ row }) => fmtDesc(row.original.impuestoCirculacion) },
-	{ accessorKey: "garantiaMobiliaria", header: "Garantía mob.", cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria) },
-	{ accessorKey: "placas", header: "Placas", cell: ({ row }) => fmtDesc(row.original.placas) },
-	{ accessorKey: "contratoLeasing", header: "Cto. leasing", cell: ({ row }) => fmtDesc(row.original.contratoLeasing) },
-	{ accessorKey: "verificacionDireccion", header: "Verif. dirección", cell: ({ row }) => fmtDesc(row.original.verificacionDireccion) },
-	{ accessorKey: "traspasoVehiculo", header: "Traspaso", cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo) },
-	{ accessorKey: "intereses", header: "Intereses", cell: ({ row }) => fmtDesc(row.original.intereses) },
-	{ accessorKey: "rcdp", header: "RCDP", cell: ({ row }) => fmtDesc(row.original.rcdp) },
-	{ accessorKey: "gps", header: "GPS", cell: ({ row }) => fmtDesc(row.original.gps) },
-	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtDesc(row.original.seguro) },
-	{ accessorKey: "membresia", header: "Membresía", cell: ({ row }) => fmtDesc(row.original.membresia) },
-	{ accessorKey: "gastosAdmin", header: "Gastos admin", cell: ({ row }) => fmtDesc(row.original.gastosAdmin) },
-	{ accessorKey: "freelance", header: "Free Lance", cell: ({ row }) => fmtDesc(row.original.freelance) },
-	{ accessorKey: "royalty", header: "Royalty", cell: ({ row }) => fmtDesc(row.original.royalty) },
+	{
+		accessorKey: "multas",
+		header: "Multas",
+		cell: ({ row }) => fmtDesc(row.original.multas),
+	},
+	{
+		accessorKey: "copiaDeLlave",
+		header: "Copia llave",
+		cell: ({ row }) => fmtDesc(row.original.copiaDeLlave),
+	},
+	{
+		accessorKey: "diferenciaCopia",
+		header: "Dif. copia",
+		cell: ({ row }) => fmtDesc(row.original.diferenciaCopia),
+	},
+	{
+		accessorKey: "impuestoCirculacion",
+		header: "Imp. circulación",
+		cell: ({ row }) => fmtDesc(row.original.impuestoCirculacion),
+	},
+	{
+		accessorKey: "garantiaMobiliaria",
+		header: "Garantía mob.",
+		cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria),
+	},
+	{
+		accessorKey: "placas",
+		header: "Placas",
+		cell: ({ row }) => fmtDesc(row.original.placas),
+	},
+	{
+		accessorKey: "contratoLeasing",
+		header: "Cto. leasing",
+		cell: ({ row }) => fmtDesc(row.original.contratoLeasing),
+	},
+	{
+		accessorKey: "verificacionDireccion",
+		header: "Verif. dirección",
+		cell: ({ row }) => fmtDesc(row.original.verificacionDireccion),
+	},
+	{
+		accessorKey: "traspasoVehiculo",
+		header: "Traspaso",
+		cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo),
+	},
+	{
+		accessorKey: "intereses",
+		header: "Intereses",
+		cell: ({ row }) => fmtDesc(row.original.intereses),
+	},
+	{
+		accessorKey: "rcdp",
+		header: "RCDP",
+		cell: ({ row }) => fmtDesc(row.original.rcdp),
+	},
+	{
+		accessorKey: "gps",
+		header: "GPS",
+		cell: ({ row }) => fmtDesc(row.original.gps),
+	},
+	{
+		accessorKey: "seguro",
+		header: "Seguro",
+		cell: ({ row }) => fmtDesc(row.original.seguro),
+	},
+	{
+		accessorKey: "membresia",
+		header: "Membresía",
+		cell: ({ row }) => fmtDesc(row.original.membresia),
+	},
+	{
+		accessorKey: "gastosAdmin",
+		header: "Gastos admin",
+		cell: ({ row }) => fmtDesc(row.original.gastosAdmin),
+	},
+	{
+		accessorKey: "freelance",
+		header: "Free Lance",
+		cell: ({ row }) => fmtDesc(row.original.freelance),
+	},
+	{
+		accessorKey: "royalty",
+		header: "Royalty",
+		cell: ({ row }) => fmtDesc(row.original.royalty),
+	},
 	{
 		accessorKey: "totalDescuentos",
 		header: "Total",
 		cell: ({ row }) => (
-			<span className="font-semibold">{fmtQ(row.original.totalDescuentos)}</span>
+			<span className="font-semibold">
+				{fmtQ(row.original.totalDescuentos)}
+			</span>
 		),
 	},
 ];
@@ -997,18 +1073,18 @@ function TabDescuentos({
 				hideSearch
 				stickyFirstColumn
 				serverPagination={
-						data
-							? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-								{
-									page: (data as any).page,
-									pageSize: (data as any).pageSize,
-									totalPages: (data as any).totalPages,
-									totalItems: (data as any).total,
-									onPageChange: setPage,
-								}
-							: undefined
-					}
-				/>
+					data
+						? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+							{
+								page: (data as any).page,
+								pageSize: (data as any).pageSize,
+								totalPages: (data as any).totalPages,
+								totalItems: (data as any).total,
+								onPageChange: setPage,
+							}
+						: undefined
+				}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Contexto

Concern #3 del issue #1043 (revisión de Luis Ralda sobre COBROS-02):

> Hay partes de la UI que todavía parecen depender de labels/colores/buckets hardcodeados. Riesgo: si cambia el catálogo real, la UI puede quedar desalineada con backend/cartera.

#1052 validó el catálogo en cartera-back. #1053 lo expuso al CRM server vía ORPC (`getBucketsCatalogo`). Este PR cierra el ciclo: el **frontend** consume ese catálogo en vez de mantener 4 copias hardcodeadas y divergentes de labels/colores/orden.

## Qué cambia

**`lib/cobros/buckets-catalogo.ts`** (nuevo) — módulo compartido, única fuente de verdad para la UI:
- `DEFAULT_BUCKETS`: fallback visual mientras el catálogo dinámico no cargó, y única fuente para estados de **status** del crédito (`en_convenio`, `incobrable`, `completado`, `pagado`, `pre_mora`) — esos nunca son filas del catálogo de aging, así que siempre usan el default.
- `useBucketsCatalogo()`: hook ORPC sobre `getBucketsCatalogo`.
- `bucketDeEstado(estadoMora, catalogo)`: combina catálogo dinámico (si trae el estado) con el default (label/color de respaldo). Nunca retorna `undefined` — un estado sin match cae a un bucket neutro `"—"` gris, no reusa "incobrable" (evita que un dato corrupto se vea como cartera impagable).
- `bucketsParaRender(catalogo, keys)`: lista ordenada por `orden`, para embudo/filtros.

**`routes/cobros/index.tsx`** — embudo y `filtrosEtapa` usan `bucketsParaRender` en vez de arrays literales hardcodeados (label/color/barColor repetidos 2 veces en el archivo).

**`lib/cobros/columns.tsx`** — `getEstadoBadge` (columna "Estado" de la tabla) usa `bucketDeEstado` en vez de sus propios mapas `colors`/`labels`.

**`routes/cobros/$id.tsx`**:
- Labels de estado del CRÉDITO ahora vienen del catálogo — antes `estadoMora.replace("_"," ").toUpperCase()` mostraba "MORA 30" en esta pantalla mientras el resto de la UI (embudo, tabla, reportes) mostraba "Alerta Temprana": el mismo drift que el issue pedía eliminar. Bonus: se resuelve gratis el bug preexistente de `"mora_120_plus".replace("_"," ")` → "MORA 120_PLUS" (solo reemplazaba el primer guion).
- La tabla de **cuotas** queda aparte a propósito: `cuota.estadoMora` es `"pagado"/"pendiente"` — un campo de nivel-CUOTA (ver `cobros.ts:1637`), no el aging/status del crédito. Mezclarlo con el catálogo de buckets habría hecho que "pendiente" cayera al bucket neutro "—" en vez de mostrar "Pendiente" (regresión detectada y corregida en desarrollo, antes de este PR). Queda con badge/label local propio.

**`routes/cobros/reportes.tsx`** — `ETAPAS` (antes array fijo con label/color hardcodeado, repetido) se deriva de `bucketsParaRender` dentro de `TabMora`.

**`carteraFront/CreditsPaymentsData.tsx`** — quita el prefijo `"B0 · "` del badge de bucket en la vista de créditos, deja solo el nombre de negocio ("Cartera Sana" en vez de "B0 · Cartera Sana"). Cosmético, pedido en revisión visual.

## Qué NO cambia (a propósito)

- Umbrales de negocio (split B4/B5, meta 120+ agregando ambos) — son reglas, no presentación.
- `ESTADOS_MORA_CTA` en `columns.tsx` — lógica de visibilidad de CTA, no label/color.
- `pagado`/`incobrable`/`en_convenio` siguen en el `DEFAULT_BUCKETS` de la UI — son estados de STATUS, nunca vienen del catálogo de aging.

## Verificación

- `bun check-types` (server + web) — limpio.
- Probado en `bun dev` local: colores reales del catálogo dinámico (hex del seed, ej. `#16a34a` para "Cartera Sana") se ven correctamente en el listado de créditos tras apuntar al schema correcto (`CARTERA_SCHEMA`).

## Depende de

- #1052 (cartera-back: validación del catálogo) — mergeado.
- #1053 (CRM server: expone el catálogo vía ORPC) — mergeado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)