### PR TITLE
feat(cobros): mora cobrada por asesor (esperado vs cobrado en el desglose)

### DIFF
--- a/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+
+// Integración: getMoraCobradaPorAsesor (mora cobrada por asesor en el período de
+// cierre de un mes) contra SUPABASE_DB_URL. Solo lecturas. Se salta si no hay DB.
+const hasDb = !!process.env.SUPABASE_DB_URL;
+
+if (!hasDb) {
+  describe("getMoraCobradaPorAsesor (integración)", () => {
+    it.skip("requiere SUPABASE_DB_URL", () => {});
+  });
+} else {
+  const { getMoraCobradaPorAsesor } = await import("./reportes");
+  const { db } = await import("../database/index");
+  const { sql } = await import("drizzle-orm");
+
+  describe("getMoraCobradaPorAsesor", () => {
+    it("período = [día 6 del mes, día 6 del mes siguiente)", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      expect(r.periodo.inicio).toBe("2026-06-06");
+      expect(r.periodo.fin).toBe("2026-07-06");
+    }, 20000);
+
+    it("diciembre rueda el año en el fin de período", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 12, anio: 2026 });
+      expect(r.periodo.inicio).toBe("2026-12-06");
+      expect(r.periodo.fin).toBe("2027-01-06");
+    }, 20000);
+
+    it("totalCobrado == suma de porAsesor y cuadra vs SUM independiente", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      const sumaPorAsesor = r.porAsesor.reduce((s, a) => s + Number(a.cobrado), 0);
+      expect(Number(r.totalCobrado)).toBeCloseTo(sumaPorAsesor, 2);
+
+      // Reconstrucción independiente del mismo total (misma ventana + paymentFalse=false).
+      const indep = await db.execute<{ total: string }>(sql`
+        SELECT COALESCE(SUM(pc.mora::numeric), 0) AS total
+        FROM cartera.pagos_credito pc
+        WHERE pc.fecha_pago >= '2026-06-06'::timestamp
+          AND pc.fecha_pago <  '2026-07-06'::timestamp
+          AND COALESCE(pc."paymentFalse", false) = false
+      `);
+      expect(Number(r.totalCobrado)).toBeCloseTo(Number(indep.rows[0].total), 2);
+    }, 20000);
+
+    it("filtro asesores limita a los IDs pedidos", async () => {
+      const full = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      const ids = full.porAsesor.slice(0, 1).map((a) => a.asesorId);
+      if (!ids.length) return;
+      const filt = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026, asesores: ids });
+      expect(filt.porAsesor.every((a) => ids.includes(a.asesorId))).toBe(true);
+    }, 20000);
+  });
+}

--- a/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
@@ -49,5 +49,27 @@ if (!hasDb) {
       const filt = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026, asesores: ids });
       expect(filt.porAsesor.every((a) => ids.includes(a.asesorId))).toBe(true);
     }, 20000);
+
+    it("mes sin pagos (futuro lejano) → sin asesores y total 0.00", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 12, anio: 2035 });
+      expect(r.porAsesor).toEqual([]);
+      expect(r.totalCobrado).toBe("0.00");
+    }, 20000);
+
+    it("porAsesor viene ordenado de mayor a menor cobrado", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      const montos = r.porAsesor.map((a) => Number(a.cobrado));
+      const ordenado = [...montos].sort((x, y) => y - x);
+      expect(montos).toEqual(ordenado);
+    }, 20000);
+
+    it("totalCobrado y cobrado por asesor con formato de 2 decimales", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      expect(r.totalCobrado).toMatch(/^\d+\.\d{2}$/);
+      for (const a of r.porAsesor) {
+        expect(a.cobrado).toMatch(/^\d+\.\d{2}$/);
+        expect(Number(a.cobrado)).toBeGreaterThan(0);
+      }
+    }, 20000);
   });
 }

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1317,6 +1317,59 @@ export async function getMoraByEtapaYAsesor({
   return { ...result, fecha, alcance: "historico" as const };
 }
 
+// Mora COBRADA por asesor en el período de cierre de un mes.
+// Período = [día 6 del mes, día 6 del mes siguiente) — alineado a que el cierre
+// corre el día 5. Suma cartera.pagos_credito.mora (lo efectivamente aplicado a
+// mora en cada pago), excluyendo pagos marcados como falsos.
+export async function getMoraCobradaPorAsesor({
+  mes,
+  anio,
+  asesores,
+  emailCobrador,
+}: {
+  mes: number;
+  anio: number;
+  asesores?: number[];
+  emailCobrador?: string;
+}) {
+  const mm = String(mes).padStart(2, "0");
+  const inicio = `${anio}-${mm}-06`;
+  const finMes = mes === 12 ? 1 : mes + 1;
+  const finAnio = mes === 12 ? anio + 1 : anio;
+  const fin = `${finAnio}-${String(finMes).padStart(2, "0")}-06`;
+
+  const emailFilter = emailCobrador
+    ? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))`
+    : sql``;
+  const asesoresFilter = asesores && asesores.length
+    ? sql`AND a.asesor_id IN (${sql.join(asesores.map((id) => sql`${id}`), sql`, `)})`
+    : sql``;
+
+  const rows = await db.execute<{ asesor_id: number; nombre: string; cobrado: string }>(sql`
+    SELECT
+      a.asesor_id,
+      a.nombre,
+      COALESCE(SUM(pc.mora::numeric), 0) AS cobrado
+    FROM cartera.pagos_credito pc
+    INNER JOIN cartera.creditos c ON c.credito_id = pc.credito_id
+    INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
+    WHERE pc.fecha_pago >= ${inicio}::timestamp
+      AND pc.fecha_pago <  ${fin}::timestamp
+      AND COALESCE(pc."paymentFalse", false) = false
+      ${emailFilter}
+      ${asesoresFilter}
+    GROUP BY a.asesor_id, a.nombre
+  `);
+
+  const porAsesor = rows.rows
+    .map((r) => ({ asesorId: r.asesor_id, nombre: r.nombre, cobrado: Number(r.cobrado).toFixed(2) }))
+    .filter((r) => Number(r.cobrado) !== 0)
+    .sort((x, y) => Number(y.cobrado) - Number(x.cobrado));
+  const totalCobrado = porAsesor.reduce((s, r) => s + Number(r.cobrado), 0).toFixed(2);
+
+  return { periodo: { inicio, fin }, porAsesor, totalCobrado };
+}
+
 export async function getCuotasPorFecha({
   fechaInicio,
   fechaFin,

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
+import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -290,6 +290,47 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/mora-por-etapa-asesor]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/mora-cobrada-por-asesor", async ({ query, set }) => {
+    try {
+      const { mes, anio, asesores, email_cobrador } = query as Record<string, string>;
+      const mesNum = Number(mes);
+      const anioNum = Number(anio);
+      if (!Number.isInteger(mesNum) || mesNum < 1 || mesNum > 12) {
+        set.status = 400;
+        return { error: "Parámetro 'mes' inválido (1-12)" };
+      }
+      if (!Number.isInteger(anioNum) || anioNum < 2000 || anioNum > 2100) {
+        set.status = 400;
+        return { error: "Parámetro 'anio' inválido" };
+      }
+
+      let asesoresIds: number[] | undefined;
+      if (asesores) {
+        asesoresIds = asesores
+          .split(",")
+          .map((s) => Number(s.trim()))
+          .filter((n) => Number.isInteger(n) && n > 0);
+        if (!asesoresIds.length) {
+          set.status = 400;
+          return { error: "Parámetro 'asesores' inválido" };
+        }
+      }
+
+      const data = await getMoraCobradaPorAsesor({
+        mes: mesNum,
+        anio: anioNum,
+        asesores: asesoresIds,
+        emailCobrador: email_cobrador,
+      });
+      set.status = 200;
+      return data;
+    } catch (error) {
+      console.error("[/reportes/mora-cobrada-por-asesor]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -40,11 +40,11 @@ import {
 } from "../db/schema/crm";
 import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
+import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
 import {
 	interpolar as interpolarPlantilla,
 	PLANTILLAS_MENSAJES,
 } from "../lib/cobros-plantillas";
-import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
 import { toDateStrGT } from "../lib/guatemala-month-window";
 import {
@@ -3976,6 +3976,30 @@ export const cobrosRouter = {
 				emailCobrador: input?.emailCobrador,
 				fecha: input?.fecha,
 				asesores: input?.asesores,
+			});
+		}),
+
+	getMoraCobradaPorAsesor: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				mes: z.number(),
+				anio: z.number(),
+				asesores: z.array(z.number()).optional(),
+				emailCobrador: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			return carteraBackClient.getMoraCobradaPorAsesor({
+				mes: input.mes,
+				anio: input.anio,
+				asesores: input.asesores,
+				emailCobrador: input.emailCobrador,
 			});
 		}),
 

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -172,6 +172,7 @@ export const cobrosAppRouter = {
 
 	// CRM Cobros — nuevas vistas
 	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
+	getMoraCobradaPorAsesor: cobrosRouter.getMoraCobradaPorAsesor,
 	getCuotasPorFecha: cobrosRouter.getCuotasPorFecha,
 	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
 
@@ -438,7 +439,8 @@ export const manualVehicleRouter = {
 // Projection procedures exported separately to avoid TS7056 truncation
 export const proyeccionRouter = {
 	getInvestorsCartera: investorDocumentsRouter.getInvestorsCartera,
-	getSimulacionInversionista: investorDocumentsRouter.getSimulacionInversionista,
+	getSimulacionInversionista:
+		investorDocumentsRouter.getSimulacionInversionista,
 };
 
 // Merged AppRouter type to avoid serialization limit

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -425,10 +425,20 @@ export type MoraTotales = {
 
 export type MoraByEtapaYAsesorResponse = {
 	totales: MoraTotales;
-	porAsesor: ({ asesorId: number; nombre: string; email: string } & MoraTotales)[];
+	porAsesor: ({
+		asesorId: number;
+		nombre: string;
+		email: string;
+	} & MoraTotales)[];
 	fecha?: string;
 	alcance?: "live" | "historico";
 	dataDisponibleDesde?: string;
+};
+
+export type MoraCobradaPorAsesorResponse = {
+	periodo: { inicio: string; fin: string };
+	porAsesor: { asesorId: number; nombre: string; cobrado: string }[];
+	totalCobrado: string;
 };
 
 // ============================================================================
@@ -1548,7 +1558,10 @@ export class CarteraBackClient {
 			otros: cobradoResult.cobrado_otros ?? "0",
 		};
 
-		return { cobrado, esperado: { meta_mensual: esperadoResult.meta_mensual ?? "0" } };
+		return {
+			cobrado,
+			esperado: { meta_mensual: esperadoResult.meta_mensual ?? "0" },
+		};
 	}
 
 	async getFlujoCuotasInversiones(params: {
@@ -1609,12 +1622,34 @@ export class CarteraBackClient {
 		asesores?: number[];
 	}) {
 		const queryParams = new URLSearchParams();
-		if (params?.emailCobrador) queryParams.set("email_cobrador", params.emailCobrador);
+		if (params?.emailCobrador)
+			queryParams.set("email_cobrador", params.emailCobrador);
 		if (params?.fecha) queryParams.set("fecha", params.fecha);
-		if (params?.asesores?.length) queryParams.set("asesores", params.asesores.join(","));
+		if (params?.asesores?.length)
+			queryParams.set("asesores", params.asesores.join(","));
 		const qs = queryParams.size > 0 ? `?${queryParams}` : "";
 		return this.request<MoraByEtapaYAsesorResponse>(
 			`/reportes/mora-por-etapa-asesor${qs}`,
+			{ method: "GET" },
+			true,
+		);
+	}
+
+	async getMoraCobradaPorAsesor(params: {
+		mes: number;
+		anio: number;
+		asesores?: number[];
+		emailCobrador?: string;
+	}) {
+		const queryParams = new URLSearchParams();
+		queryParams.set("mes", String(params.mes));
+		queryParams.set("anio", String(params.anio));
+		if (params.asesores?.length)
+			queryParams.set("asesores", params.asesores.join(","));
+		if (params.emailCobrador)
+			queryParams.set("email_cobrador", params.emailCobrador);
+		return this.request<MoraCobradaPorAsesorResponse>(
+			`/reportes/mora-cobrada-por-asesor?${queryParams}`,
 			{ method: "GET" },
 			true,
 		);
@@ -1631,11 +1666,10 @@ export class CarteraBackClient {
 			...(params.asesorId ? { asesor_id: String(params.asesorId) } : {}),
 		});
 
-		const response = await this.request<{ ok: boolean; data: CuotaPorFechaRow[] }>(
-			`/reportes/cuotas-por-fecha?${qp}`,
-			{ method: "GET" },
-			false,
-		);
+		const response = await this.request<{
+			ok: boolean;
+			data: CuotaPorFechaRow[];
+		}>(`/reportes/cuotas-por-fecha?${qp}`, { method: "GET" }, false);
 
 		return response.data ?? [];
 	}

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1648,10 +1648,12 @@ export class CarteraBackClient {
 			queryParams.set("asesores", params.asesores.join(","));
 		if (params.emailCobrador)
 			queryParams.set("email_cobrador", params.emailCobrador);
+		// Sin caché: es un reporte de flujo (pagos del período). Con caché el
+		// "Actualizar" podría devolver un hit stale tras registrar/ajustar un pago.
 		return this.request<MoraCobradaPorAsesorResponse>(
 			`/reportes/mora-cobrada-por-asesor?${queryParams}`,
 			{ method: "GET" },
-			true,
+			false,
 		);
 	}
 

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -160,6 +160,32 @@ function TabMora({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const alcance = (data as any)?.alcance as "live" | "historico" | undefined;
 
+	// Cobrado (mora cobrada en el período del mes). Solo aplica en modo "mes".
+	const anioNum = Number(mesAnio.slice(0, 4));
+	const mesNum = Number(mesAnio.slice(5, 7));
+	const { data: cobradoData } = useQuery({
+		...orpc.getMoraCobradaPorAsesor.queryOptions({
+			input: {
+				mes: mesNum,
+				anio: anioNum,
+				asesores: asesoresSel ?? undefined,
+				emailCobrador,
+			},
+		}),
+		enabled: !!session && modo === "mes",
+	});
+	const cobradoMap = useMemo(() => {
+		const m = new Map<number, number>();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		for (const a of ((cobradoData as any)?.porAsesor ?? []) as any[]) {
+			m.set(a.asesorId, Number(a.cobrado));
+		}
+		return m;
+	}, [cobradoData]);
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const totalCobrado = Number((cobradoData as any)?.totalCobrado ?? 0);
+	const verCobrado = modo === "mes";
+
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
 	return (
@@ -296,7 +322,9 @@ function TabMora({
 			)}
 
 			{porAsesor.length > 0 && (
-				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+				<div
+					className={`grid grid-cols-1 gap-4 md:grid-cols-2 ${verCobrado ? "lg:grid-cols-3" : ""}`}
+				>
 					<Card className="border-red-200 bg-red-50">
 						<CardContent className="pt-4">
 							<p className="font-semibold text-red-700 text-sm">
@@ -323,6 +351,23 @@ function TabMora({
 							</p>
 						</CardContent>
 					</Card>
+					{verCobrado && (
+						<Card className="border-green-200 bg-green-50">
+							<CardContent className="pt-4">
+								<p className="font-semibold text-green-700 text-sm">
+									Mora Cobrada (en el mes)
+								</p>
+								<p className="font-bold text-3xl text-green-800">
+									{fmtQ(totalCobrado)}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{totalConGerencia > 0
+										? `${((totalCobrado / totalConGerencia) * 100).toFixed(1)}% de lo esperado`
+										: "—"}
+								</p>
+							</CardContent>
+						</Card>
+					)}
 				</div>
 			)}
 
@@ -352,6 +397,19 @@ function TabMora({
 									<th className="px-4 py-3 text-right font-semibold">
 										Total en Mora
 									</th>
+									{verCobrado && (
+										<>
+											<th className="px-4 py-3 text-right font-semibold">
+												Cobrado
+											</th>
+											<th className="px-4 py-3 text-right font-semibold">
+												% Cobrado
+											</th>
+											<th className="px-4 py-3 text-right font-semibold">
+												Pendiente
+											</th>
+										</>
+									)}
 								</tr>
 							</thead>
 							<tbody>
@@ -408,6 +466,33 @@ function TabMora({
 												) : null;
 											})()}
 										</td>
+										{verCobrado &&
+											(() => {
+												const esperado = Number.parseFloat(
+													asesor.totalEnMora?.sumaMora ?? "0",
+												);
+												const cobrado = cobradoMap.get(asesor.asesorId) ?? 0;
+												const pct =
+													esperado > 0 ? (cobrado / esperado) * 100 : 0;
+												const pendiente = esperado - cobrado;
+												return (
+													<>
+														<td className="px-4 py-3 text-right font-medium text-green-700">
+															{cobrado > 0 ? (
+																fmtQ(cobrado)
+															) : (
+																<span className="text-muted-foreground">—</span>
+															)}
+														</td>
+														<td className="px-4 py-3 text-right text-muted-foreground">
+															{esperado > 0 ? `${pct.toFixed(1)}%` : "—"}
+														</td>
+														<td className="px-4 py-3 text-right">
+															{fmtQ(pendiente)}
+														</td>
+													</>
+												);
+											})()}
 									</tr>
 								))}
 							</tbody>
@@ -440,6 +525,30 @@ function TabMora({
 												{(data as any).totales.totalEnMora?.cantidad ?? 0} créd.
 											</div>
 										</td>
+										{verCobrado &&
+											(() => {
+												// eslint-disable-next-line @typescript-eslint/no-explicit-any
+												const esperadoTot = Number.parseFloat(
+													(data as any).totales.totalEnMora?.sumaMora ?? "0",
+												);
+												const pctTot =
+													esperadoTot > 0
+														? (totalCobrado / esperadoTot) * 100
+														: 0;
+												return (
+													<>
+														<td className="px-4 py-3 text-right text-green-700">
+															{fmtQ(totalCobrado)}
+														</td>
+														<td className="px-4 py-3 text-right font-normal text-muted-foreground">
+															{esperadoTot > 0 ? `${pctTot.toFixed(1)}%` : "—"}
+														</td>
+														<td className="px-4 py-3 text-right">
+															{fmtQ(esperadoTot - totalCobrado)}
+														</td>
+													</>
+												);
+											})()}
 									</tr>
 								</tfoot>
 							)}
@@ -569,7 +678,7 @@ function RubroCelda({
 		<div className="space-y-0.5 text-right">
 			<div className="text-muted-foreground text-xs">{fmtQ(esperado)}</div>
 			<div
-				className={`text-xs font-medium ${pagadoNum > 0 ? "text-green-600" : "text-muted-foreground/40"}`}
+				className={`font-medium text-xs ${pagadoNum > 0 ? "text-green-600" : "text-muted-foreground/40"}`}
 			>
 				{pagadoNum > 0 ? fmtQ(pagado) : "—"}
 			</div>
@@ -747,18 +856,16 @@ function TabCuotasPorFecha({
 		enabled: !!session && canSeeAll,
 	});
 
-	const {
-		data,
-		isLoading,
-		dataUpdatedAt,
-		refetch,
-		isFetching,
-	} = useQuery({
+	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
 		...orpc.getCuotasPorFecha.queryOptions({
 			input: {
 				fechaInicio,
 				fechaFin,
-				asesorId: canSeeAll ? (asesorId ? Number(asesorId) : undefined) : undefined,
+				asesorId: canSeeAll
+					? asesorId
+						? Number(asesorId)
+						: undefined
+					: undefined,
 			},
 		}),
 		enabled: !!session && !!fechaInicio && !!fechaFin,
@@ -784,9 +891,10 @@ function TabCuotasPorFecha({
 		return "pendiente";
 	}
 
-	const filteredRows = filtroEstado === "todos"
-		? rows
-		: rows.filter((r) => getEstado(r) === filtroEstado);
+	const filteredRows =
+		filtroEstado === "todos"
+			? rows
+			: rows.filter((r) => getEstado(r) === filtroEstado);
 
 	return (
 		<div className="space-y-6">
@@ -918,7 +1026,7 @@ function TabCuotasPorFecha({
 			{/* Summary cards */}
 			<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
 				<Card className="gap-1 border-blue-200 bg-blue-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-blue-700 text-xs">
 							Total Esperado
 						</CardTitle>
@@ -930,7 +1038,7 @@ function TabCuotasPorFecha({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-green-200 bg-green-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-green-700 text-xs">
 							Total Pagado
 						</CardTitle>
@@ -942,19 +1050,19 @@ function TabCuotasPorFecha({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-red-200 bg-red-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-red-700 text-xs">
 							Total Pendiente
 						</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-red-700 text-lg">
+						<div className="font-bold text-lg text-red-700">
 							{fmtQ(totales?.totalPendiente ?? "0")}
 						</div>
 					</CardContent>
 				</Card>
 				<Card className="gap-1 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-xs">Cuotas</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">
@@ -979,7 +1087,7 @@ function TabCuotasPorFecha({
 					] as const
 				).map((c) => (
 					<Card key={c.key} className="gap-0.5 py-2.5">
-						<CardHeader className="px-3 pb-0 pt-0">
+						<CardHeader className="px-3 pt-0 pb-0">
 							<CardTitle className="font-medium text-muted-foreground text-xs">
 								{c.label}
 							</CardTitle>
@@ -994,7 +1102,11 @@ function TabCuotasPorFecha({
 			</div>
 
 			{/* Detail table */}
-			<DataTable columns={colsCuotas} data={filteredRows} isLoading={isLoading} />
+			<DataTable
+				columns={colsCuotas}
+				data={filteredRows}
+				isLoading={isLoading}
+			/>
 		</div>
 	);
 }
@@ -1054,28 +1166,98 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 			</div>
 		),
 	},
-	{ accessorKey: "multas", header: "Multas", cell: ({ row }) => fmtDesc(row.original.multas) },
-	{ accessorKey: "copiaDeLlave", header: "Copia llave", cell: ({ row }) => fmtDesc(row.original.copiaDeLlave) },
-	{ accessorKey: "diferenciaCopia", header: "Dif. copia", cell: ({ row }) => fmtDesc(row.original.diferenciaCopia) },
-	{ accessorKey: "impuestoCirculacion", header: "Imp. circulación", cell: ({ row }) => fmtDesc(row.original.impuestoCirculacion) },
-	{ accessorKey: "garantiaMobiliaria", header: "Garantía mob.", cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria) },
-	{ accessorKey: "placas", header: "Placas", cell: ({ row }) => fmtDesc(row.original.placas) },
-	{ accessorKey: "contratoLeasing", header: "Cto. leasing", cell: ({ row }) => fmtDesc(row.original.contratoLeasing) },
-	{ accessorKey: "verificacionDireccion", header: "Verif. dirección", cell: ({ row }) => fmtDesc(row.original.verificacionDireccion) },
-	{ accessorKey: "traspasoVehiculo", header: "Traspaso", cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo) },
-	{ accessorKey: "intereses", header: "Intereses", cell: ({ row }) => fmtDesc(row.original.intereses) },
-	{ accessorKey: "rcdp", header: "RCDP", cell: ({ row }) => fmtDesc(row.original.rcdp) },
-	{ accessorKey: "gps", header: "GPS", cell: ({ row }) => fmtDesc(row.original.gps) },
-	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtDesc(row.original.seguro) },
-	{ accessorKey: "membresia", header: "Membresía", cell: ({ row }) => fmtDesc(row.original.membresia) },
-	{ accessorKey: "gastosAdmin", header: "Gastos admin", cell: ({ row }) => fmtDesc(row.original.gastosAdmin) },
-	{ accessorKey: "freelance", header: "Free Lance", cell: ({ row }) => fmtDesc(row.original.freelance) },
-	{ accessorKey: "royalty", header: "Royalty", cell: ({ row }) => fmtDesc(row.original.royalty) },
+	{
+		accessorKey: "multas",
+		header: "Multas",
+		cell: ({ row }) => fmtDesc(row.original.multas),
+	},
+	{
+		accessorKey: "copiaDeLlave",
+		header: "Copia llave",
+		cell: ({ row }) => fmtDesc(row.original.copiaDeLlave),
+	},
+	{
+		accessorKey: "diferenciaCopia",
+		header: "Dif. copia",
+		cell: ({ row }) => fmtDesc(row.original.diferenciaCopia),
+	},
+	{
+		accessorKey: "impuestoCirculacion",
+		header: "Imp. circulación",
+		cell: ({ row }) => fmtDesc(row.original.impuestoCirculacion),
+	},
+	{
+		accessorKey: "garantiaMobiliaria",
+		header: "Garantía mob.",
+		cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria),
+	},
+	{
+		accessorKey: "placas",
+		header: "Placas",
+		cell: ({ row }) => fmtDesc(row.original.placas),
+	},
+	{
+		accessorKey: "contratoLeasing",
+		header: "Cto. leasing",
+		cell: ({ row }) => fmtDesc(row.original.contratoLeasing),
+	},
+	{
+		accessorKey: "verificacionDireccion",
+		header: "Verif. dirección",
+		cell: ({ row }) => fmtDesc(row.original.verificacionDireccion),
+	},
+	{
+		accessorKey: "traspasoVehiculo",
+		header: "Traspaso",
+		cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo),
+	},
+	{
+		accessorKey: "intereses",
+		header: "Intereses",
+		cell: ({ row }) => fmtDesc(row.original.intereses),
+	},
+	{
+		accessorKey: "rcdp",
+		header: "RCDP",
+		cell: ({ row }) => fmtDesc(row.original.rcdp),
+	},
+	{
+		accessorKey: "gps",
+		header: "GPS",
+		cell: ({ row }) => fmtDesc(row.original.gps),
+	},
+	{
+		accessorKey: "seguro",
+		header: "Seguro",
+		cell: ({ row }) => fmtDesc(row.original.seguro),
+	},
+	{
+		accessorKey: "membresia",
+		header: "Membresía",
+		cell: ({ row }) => fmtDesc(row.original.membresia),
+	},
+	{
+		accessorKey: "gastosAdmin",
+		header: "Gastos admin",
+		cell: ({ row }) => fmtDesc(row.original.gastosAdmin),
+	},
+	{
+		accessorKey: "freelance",
+		header: "Free Lance",
+		cell: ({ row }) => fmtDesc(row.original.freelance),
+	},
+	{
+		accessorKey: "royalty",
+		header: "Royalty",
+		cell: ({ row }) => fmtDesc(row.original.royalty),
+	},
 	{
 		accessorKey: "totalDescuentos",
 		header: "Total",
 		cell: ({ row }) => (
-			<span className="font-semibold">{fmtQ(row.original.totalDescuentos)}</span>
+			<span className="font-semibold">
+				{fmtQ(row.original.totalDescuentos)}
+			</span>
 		),
 	},
 ];
@@ -1140,18 +1322,18 @@ function TabDescuentos({
 				hideSearch
 				stickyFirstColumn
 				serverPagination={
-						data
-							? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-								{
-									page: (data as any).page,
-									pageSize: (data as any).pageSize,
-									totalPages: (data as any).totalPages,
-									totalItems: (data as any).total,
-									onPageChange: setPage,
-								}
-							: undefined
-					}
-				/>
+					data
+						? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+							{
+								page: (data as any).page,
+								pageSize: (data as any).pageSize,
+								totalPages: (data as any).totalPages,
+								totalItems: (data as any).total,
+								onPageChange: setPage,
+							}
+						: undefined
+				}
+			/>
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -163,7 +163,7 @@ function TabMora({
 	// Cobrado (mora cobrada en el período del mes). Solo aplica en modo "mes".
 	const anioNum = Number(mesAnio.slice(0, 4));
 	const mesNum = Number(mesAnio.slice(5, 7));
-	const { data: cobradoData } = useQuery({
+	const { data: cobradoData, refetch: refetchCobrado } = useQuery({
 		...orpc.getMoraCobradaPorAsesor.queryOptions({
 			input: {
 				mes: mesNum,
@@ -175,16 +175,31 @@ function TabMora({
 		enabled: !!session && modo === "mes",
 	});
 	const cobradoMap = useMemo(() => {
-		const m = new Map<number, number>();
+		const m = new Map<number, { cobrado: number; nombre: string }>();
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		for (const a of ((cobradoData as any)?.porAsesor ?? []) as any[]) {
-			m.set(a.asesorId, Number(a.cobrado));
+			m.set(a.asesorId, { cobrado: Number(a.cobrado), nombre: a.nombre });
 		}
 		return m;
 	}, [cobradoData]);
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const totalCobrado = Number((cobradoData as any)?.totalCobrado ?? 0);
 	const verCobrado = modo === "mes";
+
+	// Filas del desglose = unión de asesores con mora esperada y/o cobrada. El
+	// total cobrado incluye pagos sobre créditos ya saldados / fuera del snapshot
+	// de mora activa, así que sin la unión las filas no sumarían el total.
+	const filasAsesor = useMemo(() => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const map = new Map<number, any>();
+		for (const a of porAsesor) map.set(a.asesorId, a);
+		if (verCobrado) {
+			for (const [id, c] of cobradoMap) {
+				if (!map.has(id)) map.set(id, { asesorId: id, nombre: c.nombre });
+			}
+		}
+		return [...map.values()];
+	}, [porAsesor, cobradoMap, verCobrado]);
 
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
@@ -204,7 +219,10 @@ function TabMora({
 					<Button
 						variant="outline"
 						size="sm"
-						onClick={() => refetch()}
+						onClick={() => {
+							refetch();
+							if (verCobrado) refetchCobrado();
+						}}
 						disabled={isFetching}
 					>
 						<RefreshCw
@@ -321,36 +339,40 @@ function TabMora({
 				</div>
 			)}
 
-			{porAsesor.length > 0 && (
+			{(porAsesor.length > 0 || (verCobrado && totalCobrado > 0)) && (
 				<div
 					className={`grid grid-cols-1 gap-4 md:grid-cols-2 ${verCobrado ? "lg:grid-cols-3" : ""}`}
 				>
-					<Card className="border-red-200 bg-red-50">
-						<CardContent className="pt-4">
-							<p className="font-semibold text-red-700 text-sm">
-								Total en Mora (con Gerencia)
-							</p>
-							<p className="font-bold text-3xl text-red-800">
-								{fmtQ(totalConGerencia)}
-							</p>
-							<p className="text-muted-foreground text-xs">
-								{credConGerencia} créditos
-							</p>
-						</CardContent>
-					</Card>
-					<Card className="border-orange-200 bg-orange-50">
-						<CardContent className="pt-4">
-							<p className="font-semibold text-orange-700 text-sm">
-								Total en Mora (sin Gerencia)
-							</p>
-							<p className="font-bold text-3xl text-orange-800">
-								{fmtQ(totalSinGerencia)}
-							</p>
-							<p className="text-muted-foreground text-xs">
-								{credSinGerencia} créditos
-							</p>
-						</CardContent>
-					</Card>
+					{porAsesor.length > 0 && (
+						<Card className="border-red-200 bg-red-50">
+							<CardContent className="pt-4">
+								<p className="font-semibold text-red-700 text-sm">
+									Total en Mora (con Gerencia)
+								</p>
+								<p className="font-bold text-3xl text-red-800">
+									{fmtQ(totalConGerencia)}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{credConGerencia} créditos
+								</p>
+							</CardContent>
+						</Card>
+					)}
+					{porAsesor.length > 0 && (
+						<Card className="border-orange-200 bg-orange-50">
+							<CardContent className="pt-4">
+								<p className="font-semibold text-orange-700 text-sm">
+									Total en Mora (sin Gerencia)
+								</p>
+								<p className="font-bold text-3xl text-orange-800">
+									{fmtQ(totalSinGerencia)}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{credSinGerencia} créditos
+								</p>
+							</CardContent>
+						</Card>
+					)}
 					{verCobrado && (
 						<Card className="border-green-200 bg-green-50">
 							<CardContent className="pt-4">
@@ -376,7 +398,7 @@ function TabMora({
 				{isLoading ? (
 					<div className="h-32 animate-pulse rounded bg-muted" />
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				) : !(data as any)?.porAsesor?.length ? (
+				) : filasAsesor.length === 0 ? (
 					<p className="text-muted-foreground text-sm">
 						No hay datos disponibles.
 					</p>
@@ -414,7 +436,7 @@ function TabMora({
 							</thead>
 							<tbody>
 								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								{(data as any).porAsesor.map((asesor: any) => (
+								{filasAsesor.map((asesor: any) => (
 									<tr
 										key={asesor.asesorId}
 										className="border-t hover:bg-muted/30"
@@ -471,10 +493,11 @@ function TabMora({
 												const esperado = Number.parseFloat(
 													asesor.totalEnMora?.sumaMora ?? "0",
 												);
-												const cobrado = cobradoMap.get(asesor.asesorId) ?? 0;
+												const cobrado =
+													cobradoMap.get(asesor.asesorId)?.cobrado ?? 0;
 												const pct =
 													esperado > 0 ? (cobrado / esperado) * 100 : 0;
-												const pendiente = esperado - cobrado;
+												const pendiente = Math.max(0, esperado - cobrado);
 												return (
 													<>
 														<td className="px-4 py-3 text-right font-medium text-green-700">
@@ -544,7 +567,7 @@ function TabMora({
 															{esperadoTot > 0 ? `${pctTot.toFixed(1)}%` : "—"}
 														</td>
 														<td className="px-4 py-3 text-right">
-															{fmtQ(esperadoTot - totalCobrado)}
+															{fmtQ(Math.max(0, esperadoTot - totalCobrado))}
 														</td>
 													</>
 												);


### PR DESCRIPTION
## Qué hace

Continúa el reporte de mora por asesor (iteración 1 ya mergeada en #1058, PR merge `582bb204`) agregando **lo cobrado por cada asesor**. En la tab "Análisis de Mora", modo **Por mes**, el "Desglose por Asesor" ahora compara **esperado vs cobrado** por asesor.

## Cambios

**Backend (`cartera-back`)**
- Nuevo `getMoraCobradaPorAsesor({ mes, anio, asesores?, emailCobrador? })`: suma `cartera.pagos_credito.mora` (lo efectivamente aplicado a mora en cada pago) por asesor, en el **período de cierre** `[día 6 del mes, día 6 del mes siguiente)`, con `paymentFalse = false`. Devuelve `{ periodo, porAsesor:[{asesorId, nombre, cobrado}], totalCobrado }`.
- Nuevo endpoint `GET /reportes/mora-cobrada-por-asesor?mes=&anio=&asesores=&email_cobrador=` (valida mes 1-12, año, y CSV de asesores).

**CRM server** — proxea `getMoraCobradaPorAsesor` (ORPC type-safe) + tipos.

**Web (`reportes.tsx`)** — en modo **Por mes**:
- Tarjeta **"Mora Cobrada (en el mes)"** con total y % de lo esperado.
- En el desglose por asesor, columnas nuevas **Cobrado / % Cobrado / Pendiente** por fila (+ fila TOTAL).
- Solo en modo Por mes (el cobrado es un flujo del período; en "Hoy en vivo" no aplica).

## Validación (prod, solo lectura)

- **Junio 2026 = Q267,274.11**, cuadra al centavo contra un `SUM` independiente.
- Desglose por asesor: Caren Q117,426.30 · Samuel Q65,035.39 · Erik Q32,255.42 · Wilson Q23,074.43 · Jorge Q15,382.08 · Gerencia Q14,100.49.
- **7/7 tests de integración** (período, rollover de diciembre, cuadre vs SUM independiente, filtro de asesores, mes vacío, orden descendente, formato de 2 decimales).
- Backend tsc-clean; frontend sin errores de tipo nuevos; Biome limpio.

## Notas

- Stock vs flujo: `esperado` = saldo de mora al día 6; `cobrado` = flujo del mes → el `%` es "cuánto del saldo raspamos este mes", no efectividad de ciclo.
- Solo admin / cobros_supervisor (sin cambio de permisos), igual que iteración 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
