### PR TITLE
fix(crm): add no-reply warning to cobros templates

### DIFF
--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -3,6 +3,8 @@ import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+const CONFIRMATION_REQUEST_REGEX =
+	/confirme la recepción|confirmar recepción|confirme recepcion/i;
 
 describe("plantillas masivas de cobros", () => {
 	test("incluyen el aviso de no responder exactamente una vez", () => {
@@ -32,6 +34,16 @@ describe("plantillas masivas de cobros", () => {
 			expect(plantilla.cuerpo, plantilla.id).not.toMatch(
 				/por este medio|por este chat|comunicarse por este medio/i,
 			);
+		}
+	});
+
+	test("no piden confirmar recepcion cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			if (plantilla.cuerpo.includes(NO_REPLY_WARNING)) {
+				expect(plantilla.cuerpo, plantilla.id).not.toMatch(
+					CONFIRMATION_REQUEST_REGEX,
+				);
+			}
 		}
 	});
 

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -26,4 +26,26 @@ describe("plantillas masivas de cobros", () => {
 			}
 		}
 	});
+
+	test("no indican responder por este chat cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			expect(plantilla.cuerpo, plantilla.id).not.toMatch(
+				/por este medio|por este chat|comunicarse por este medio/i,
+			);
+		}
+	});
+
+	test("dirigen comprobantes y dudas al telefono del asesor", () => {
+		const bienvenida = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "bienvenida",
+		);
+		const preMora = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "pre_mora",
+		);
+
+		expect(bienvenida?.cuerpo).toMatch(
+			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
+		);
+		expect(preMora?.cuerpo).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
+
+const NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
+describe("plantillas masivas de cobros", () => {
+	test("incluyen el aviso de no responder exactamente una vez", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const matches = plantilla.cuerpo.matchAll(
+				/NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS/g,
+			);
+
+			expect(Array.from(matches).length, plantilla.id).toBe(1);
+			expect(plantilla.cuerpo, plantilla.id).toContain(NO_REPLY_WARNING);
+		}
+	});
+
+	test("colocan el aviso antes de la firma cuando existe", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const warningIndex = plantilla.cuerpo.indexOf(NO_REPLY_WARNING);
+			const signatureIndex = plantilla.cuerpo.indexOf("Atentamente");
+
+			if (signatureIndex !== -1) {
+				expect(warningIndex, plantilla.id).toBeLessThan(signatureIndex);
+			}
+		}
+	});
+});

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -88,7 +88,7 @@ Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplic
 
 ${COBROS_NO_REPLY_WARNING}
 
-Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
 		id: "al_dia",

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -37,6 +37,9 @@ export interface PlantillaMensaje {
 	cuerpo: string;
 }
 
+export const COBROS_NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
 function toCapitalCase(str: string): string {
 	return str
 		.toLowerCase()
@@ -76,12 +79,14 @@ export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
 		nombre: "Bienvenida",
 		etapa: "al_dia",
 		asunto: "Bienvenido/a a su plan de financiamiento",
-		// 4 bloques separados por línea en blanco → template `mensaje4parametros`.
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
 Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+
+${COBROS_NO_REPLY_WARNING}
 
 Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -90,8 +95,10 @@ Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} 
 		nombre: "Recordatorio de pago",
 		etapa: "al_dia",
 		asunto: "Recordatorio de pago - Vehículo {placa}",
-		// 2 bloques → template `mensaje2parametros`.
+		// 3 bloques → template `mensaje3parametros`.
 		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -100,12 +107,14 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",
 		asunto: "Aviso de atraso en pago - Vehículo {placa}",
-		// 4 bloques → template `mensaje4parametros`.
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
 Si tiene alguna duda por favor comunicarse por este medio.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -114,8 +123,10 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Mora 30 días",
 		etapa: "mora_30",
 		asunto: "URGENTE: Mora de 30 días - Vehículo {placa}",
-		// 2 bloques → template `mensaje2parametros`.
+		// 3 bloques → template `mensaje3parametros`.
 		cuerpo: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -124,10 +135,12 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Mora 60 días",
 		etapa: "mora_60",
 		asunto: "AVISO IMPORTANTE: Mora de 60 días - Vehículo {placa}",
-		// 3 bloques → template `mensaje3parametros`.
+		// 4 bloques → template `mensaje4parametros`.
 		cuerpo: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
 
 Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 	},
@@ -136,10 +149,12 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 		nombre: "Aviso jurídico",
 		etapa: "mora_90",
 		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
-		// 3 bloques → template `mensaje3parametros`.
+		// 4 bloques → template `mensaje4parametros`.
 		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
+
+${COBROS_NO_REPLY_WARNING}
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
 	},

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -84,7 +84,7 @@ export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
-Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
 
 ${COBROS_NO_REPLY_WARNING}
 
@@ -110,7 +110,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
-Si tiene alguna duda por favor comunicarse por este medio.
+Si tiene alguna duda, por favor comuníquese al {telefonoAsesor}.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 
@@ -150,7 +150,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 		etapa: "mora_90",
 		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
 		// 4 bloques → template `mensaje4parametros`.
-		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+		cuerpo: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
+
+const NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
+describe("plantillas web de cobros", () => {
+	test("incluyen el aviso de no responder en el cuerpo de WhatsApp", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+			const matches = cuerpoWhatsapp.matchAll(
+				/NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS/g,
+			);
+
+			expect(Array.from(matches).length, plantilla.id).toBe(1);
+			expect(cuerpoWhatsapp, plantilla.id).toContain(NO_REPLY_WARNING);
+		}
+	});
+
+	test("colocan el aviso antes de la firma cuando existe", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+			const warningIndex = cuerpoWhatsapp.indexOf(NO_REPLY_WARNING);
+			const signatureIndex = cuerpoWhatsapp.indexOf("Atentamente");
+
+			if (signatureIndex !== -1) {
+				expect(warningIndex, plantilla.id).toBeLessThan(signatureIndex);
+			}
+		}
+	});
+});

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -3,6 +3,8 @@ import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+const CONFIRMATION_REQUEST_REGEX =
+	/confirme la recepción|confirmar recepción|confirme recepcion/i;
 
 describe("plantillas web de cobros", () => {
 	test("incluyen el aviso de no responder en el cuerpo de WhatsApp", () => {
@@ -36,6 +38,18 @@ describe("plantillas web de cobros", () => {
 			expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
 				/por este medio|por este chat|comunicarse por este medio/i,
 			);
+		}
+	});
+
+	test("no piden confirmar recepcion cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+
+			if (cuerpoWhatsapp.includes(NO_REPLY_WARNING)) {
+				expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
+					CONFIRMATION_REQUEST_REGEX,
+				);
+			}
 		}
 	});
 

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -28,4 +28,28 @@ describe("plantillas web de cobros", () => {
 			}
 		}
 	});
+
+	test("no indican responder por este chat cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+
+			expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
+				/por este medio|por este chat|comunicarse por este medio/i,
+			);
+		}
+	});
+
+	test("dirigen comprobantes y dudas al telefono del asesor", () => {
+		const bienvenida = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "bienvenida",
+		);
+		const preMora = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "pre_mora",
+		);
+
+		expect(bienvenida?.cuerpoWhastapp).toMatch(
+			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
+		);
+		expect(preMora?.cuerpoWhastapp).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
 });

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -102,7 +102,7 @@ Tel: {telefonoAsesor}.`,
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
-Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
 
 ${COBROS_NO_REPLY_WARNING}
 
@@ -140,7 +140,7 @@ Atentamente,
 Tel: {telefonoAsesor}.`,
     cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
-Si tiene alguna duda por favor comunicarse por este medio.
+Si tiene alguna duda, por favor comuníquese al {telefonoAsesor}.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 
@@ -196,7 +196,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-    cuerpoWhastapp: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+    cuerpoWhastapp: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -106,7 +106,7 @@ Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplic
 
 ${COBROS_NO_REPLY_WARNING}
 
-Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "al_dia",

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -30,6 +30,9 @@ export interface PlantillaMensaje {
   cuerpoWhastapp?: string;
 }
 
+export const COBROS_NO_REPLY_WARNING =
+  "*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()
@@ -95,8 +98,15 @@ Agradecemos confirme la recepción de este mensaje.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.\n\nA continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL\n\nPor favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.\n\nAgradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
+
+A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
+
+Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+
+${COBROS_NO_REPLY_WARNING}
+
+Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "al_dia",
@@ -108,8 +118,11 @@ Tel: {telefonoAsesor}.`,
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "pre_mora",
@@ -125,8 +138,15 @@ SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.\n\nSi tiene alguna duda por favor comunicarse por este medio.\n\nSI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
+
+Si tiene alguna duda por favor comunicarse por este medio.
+
+SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "mora_30",
@@ -138,8 +158,11 @@ Tel: {telefonoAsesor}.`,
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "mora_60",
@@ -155,8 +178,13 @@ Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a to
 Atentamente,
 {nombreAsesor}
 Tel: {telefonoAsesor}`,
-    cuerpoWhastapp:
-      "Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.\n\nSi no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}",
+    cuerpoWhastapp: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
+
+Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
   },
   {
     id: "aviso_juridico",
@@ -168,8 +196,13 @@ Tel: {telefonoAsesor}`,
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-    cuerpoWhastapp:
-      "Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.\n\nPor lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.\n\nFavor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.",
+    cuerpoWhastapp: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+
+Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
+
+${COBROS_NO_REPLY_WARNING}
+
+Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Adds the no-reply warning requested by Alejandro to all cobros mass WhatsApp templates.
- Keeps the warning in WhatsApp bold syntax: `*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*`.
- Updates both sources used by the flow:
  - server templates used by `enviarWhatsappMasivoCobros`
  - web templates used by the mass WhatsApp modal preview/default body
- Adds focused tests to ensure every template includes the warning exactly once and before the signature when present.

## Test Plan
- [x] `bun test apps/crm/apps/server/src/lib/cobros-plantillas.test.ts apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts`
- [x] `git diff --cached --check` before commit
- [x] Generated smoke check: 6 server templates + 6 web WhatsApp templates include the warning exactly once

## Notes
- `bun run check-types` still fails on existing unrelated CRM type/dependency issues (for example missing workspace modules/types and existing web ORPC unknown-type errors). No new type errors were identified in the focused files.
