### PR TITLE
fix(crm): add no-reply guard to cobros WhatsApp templates

### DIFF
--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -3,6 +3,8 @@ import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+const CONFIRMATION_REQUEST_REGEX =
+	/confirme la recepción|confirmar recepción|confirme recepcion/i;
 
 describe("plantillas masivas de cobros", () => {
 	test("incluyen el aviso de no responder exactamente una vez", () => {
@@ -32,6 +34,16 @@ describe("plantillas masivas de cobros", () => {
 			expect(plantilla.cuerpo, plantilla.id).not.toMatch(
 				/por este medio|por este chat|comunicarse por este medio/i,
 			);
+		}
+	});
+
+	test("no piden confirmar recepcion cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			if (plantilla.cuerpo.includes(NO_REPLY_WARNING)) {
+				expect(plantilla.cuerpo, plantilla.id).not.toMatch(
+					CONFIRMATION_REQUEST_REGEX,
+				);
+			}
 		}
 	});
 

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -26,4 +26,26 @@ describe("plantillas masivas de cobros", () => {
 			}
 		}
 	});
+
+	test("no indican responder por este chat cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			expect(plantilla.cuerpo, plantilla.id).not.toMatch(
+				/por este medio|por este chat|comunicarse por este medio/i,
+			);
+		}
+	});
+
+	test("dirigen comprobantes y dudas al telefono del asesor", () => {
+		const bienvenida = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "bienvenida",
+		);
+		const preMora = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "pre_mora",
+		);
+
+		expect(bienvenida?.cuerpo).toMatch(
+			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
+		);
+		expect(preMora?.cuerpo).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
+
+const NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
+describe("plantillas masivas de cobros", () => {
+	test("incluyen el aviso de no responder exactamente una vez", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const matches = plantilla.cuerpo.matchAll(
+				/NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS/g,
+			);
+
+			expect(Array.from(matches).length, plantilla.id).toBe(1);
+			expect(plantilla.cuerpo, plantilla.id).toContain(NO_REPLY_WARNING);
+		}
+	});
+
+	test("colocan el aviso antes de la firma cuando existe", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const warningIndex = plantilla.cuerpo.indexOf(NO_REPLY_WARNING);
+			const signatureIndex = plantilla.cuerpo.indexOf("Atentamente");
+
+			if (signatureIndex !== -1) {
+				expect(warningIndex, plantilla.id).toBeLessThan(signatureIndex);
+			}
+		}
+	});
+});

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
+import {
+	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	PLANTILLAS_MENSAJES,
+	prepararTelefonoAsesorParaEnvio,
+} from "./cobros-plantillas";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
@@ -59,5 +63,25 @@ describe("plantillas masivas de cobros", () => {
 			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
 		);
 		expect(preMora?.cuerpo).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
+
+	test("descarta plantillas no-reply sin telefono de asesor", () => {
+		const cuerpo = PLANTILLAS_MENSAJES[0].cuerpo;
+
+		for (const telefono of [null, undefined, "", "   "]) {
+			expect(prepararTelefonoAsesorParaEnvio(cuerpo, telefono)).toEqual({
+				enviar: false,
+				motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+			});
+		}
+	});
+
+	test("recorta el telefono del asesor antes de interpolar", () => {
+		const cuerpo = PLANTILLAS_MENSAJES[0].cuerpo;
+
+		expect(prepararTelefonoAsesorParaEnvio(cuerpo, " 41286630 ")).toEqual({
+			enviar: true,
+			telefonoAsesor: "41286630",
+		});
 	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -88,7 +88,7 @@ Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplic
 
 ${COBROS_NO_REPLY_WARNING}
 
-Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
 		id: "al_dia",

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -37,6 +37,9 @@ export interface PlantillaMensaje {
 	cuerpo: string;
 }
 
+export const COBROS_NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
 function toCapitalCase(str: string): string {
 	return str
 		.toLowerCase()
@@ -76,12 +79,14 @@ export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
 		nombre: "Bienvenida",
 		etapa: "al_dia",
 		asunto: "Bienvenido/a a su plan de financiamiento",
-		// 4 bloques separados por línea en blanco → template `mensaje4parametros`.
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
 Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+
+${COBROS_NO_REPLY_WARNING}
 
 Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -90,8 +95,10 @@ Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} 
 		nombre: "Recordatorio de pago",
 		etapa: "al_dia",
 		asunto: "Recordatorio de pago - Vehículo {placa}",
-		// 2 bloques → template `mensaje2parametros`.
+		// 3 bloques → template `mensaje3parametros`.
 		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -100,12 +107,14 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",
 		asunto: "Aviso de atraso en pago - Vehículo {placa}",
-		// 4 bloques → template `mensaje4parametros`.
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
 Si tiene alguna duda por favor comunicarse por este medio.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -114,8 +123,10 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Mora 30 días",
 		etapa: "mora_30",
 		asunto: "URGENTE: Mora de 30 días - Vehículo {placa}",
-		// 2 bloques → template `mensaje2parametros`.
+		// 3 bloques → template `mensaje3parametros`.
 		cuerpo: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -124,10 +135,12 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Mora 60 días",
 		etapa: "mora_60",
 		asunto: "AVISO IMPORTANTE: Mora de 60 días - Vehículo {placa}",
-		// 3 bloques → template `mensaje3parametros`.
+		// 4 bloques → template `mensaje4parametros`.
 		cuerpo: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
 
 Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 	},
@@ -136,10 +149,12 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 		nombre: "Aviso jurídico",
 		etapa: "mora_90",
 		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
-		// 3 bloques → template `mensaje3parametros`.
+		// 4 bloques → template `mensaje4parametros`.
 		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
+
+${COBROS_NO_REPLY_WARNING}
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
 	},

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -39,6 +39,22 @@ export interface PlantillaMensaje {
 
 export const COBROS_NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+export const COBROS_MOTIVO_SIN_TELEFONO_ASESOR = "sin teléfono de asesor";
+
+export function prepararTelefonoAsesorParaEnvio(
+	cuerpo: string,
+	telefono: string | null | undefined,
+):
+	| { enviar: true; telefonoAsesor: string }
+	| { enviar: false; motivo: string } {
+	const telefonoAsesor = telefono?.trim() ?? "";
+
+	if (cuerpo.includes(COBROS_NO_REPLY_WARNING) && !telefonoAsesor) {
+		return { enviar: false, motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR };
+	}
+
+	return { enviar: true, telefonoAsesor };
+}
 
 function toCapitalCase(str: string): string {
 	return str

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -84,7 +84,7 @@ export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
-Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
 
 ${COBROS_NO_REPLY_WARNING}
 
@@ -110,7 +110,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
-Si tiene alguna duda por favor comunicarse por este medio.
+Si tiene alguna duda, por favor comuníquese al {telefonoAsesor}.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 
@@ -150,7 +150,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 		etapa: "mora_90",
 		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
 		// 4 bloques → template `mensaje4parametros`.
-		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+		cuerpo: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -40,11 +40,12 @@ import {
 } from "../db/schema/crm";
 import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
-import {
-	interpolar as interpolarPlantilla,
-	PLANTILLAS_MENSAJES,
-} from "../lib/cobros-plantillas";
 import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
+import {
+	PLANTILLAS_MENSAJES,
+	interpolar as interpolarPlantilla,
+	prepararTelefonoAsesorParaEnvio,
+} from "../lib/cobros-plantillas";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
 import { toDateStrGT } from "../lib/guatemala-month-window";
 import {
@@ -3583,6 +3584,19 @@ export const cobrosRouter = {
 				const cuerpoBase = input.cuerpoEditado?.trim()
 					? input.cuerpoEditado
 					: plantilla.cuerpo;
+				const telefonoAsesor = prepararTelefonoAsesorParaEnvio(
+					cuerpoBase,
+					asesor.telefono,
+				);
+
+				if (!telefonoAsesor.enviar) {
+					descartados.push({
+						numeroSifco: sifco,
+						clienteNombre,
+						motivo: telefonoAsesor.motivo,
+					});
+					continue;
+				}
 
 				// Día de pago: tomar el día del mes de la fecha de vencimiento de la
 				// próxima cuota que devuelve cartera (`proxima_cuota`). Es el mismo
@@ -3610,7 +3624,7 @@ export const cobrosRouter = {
 								})
 							: "",
 					cuotasAtraso: credito.mora?.cuotas_atrasadas ?? 0,
-					telefonoAsesor: asesor.telefono ?? "",
+					telefonoAsesor: telefonoAsesor.telefonoAsesor,
 					nombreAsesor: asesor.nombre ?? "",
 				});
 
@@ -3619,7 +3633,7 @@ export const cobrosRouter = {
 					telefono: testMode ? getTestPhone(candidatos.length) : telefono,
 					telefonoReal: telefono,
 					mensaje,
-					casoCobroId: sifco ? (casoIdPorSifco.get(sifco) ?? null) : null,
+					casoCobroId: sifco ? casoIdPorSifco.get(sifco) ?? null : null,
 					clienteNombre,
 				});
 			}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -51,6 +51,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
+	crearUrlWhatsappManual,
 	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
@@ -324,9 +325,11 @@ export function ContactoModal({
 				window.open(`tel:${tel}`);
 				break;
 			case "whatsapp-link": {
-				const url = mensajeEditado
-					? `https://wa.me/${telLimpio}?text=${encodeURIComponent(mensajeEditado)}`
-					: `https://wa.me/${telLimpio}`;
+				const url = crearUrlWhatsappManual(
+					telLimpio,
+					mensajeWhatsappEditado,
+					mensajeEditado,
+				);
 				window.open(url);
 				break;
 			}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
+	accionUsaCuerpoNoReply,
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
@@ -322,10 +323,7 @@ export function ContactoModal({
 			mensajeWhatsapp,
 			telefonoAsesorLimpio,
 		);
-		if (
-			(metodo === "whatsapp-link" || metodo === "whatsapp-api") &&
-			!telefonoAsesorNoReply.enviar
-		) {
+		if (accionUsaCuerpoNoReply(metodo) && !telefonoAsesorNoReply.enviar) {
 			toast.error(
 				"No se puede enviar esta plantilla no-reply porque el asesor no tiene teléfono registrado",
 			);

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -53,6 +53,7 @@ import {
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
+	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
@@ -312,6 +313,11 @@ export function ContactoModal({
 			mensajeEditado,
 			mensajeWhatsappEditado,
 		);
+		const mensajeSms = mensajeSmsEditable(
+			metodoInicial,
+			mensajeEditado,
+			mensajeWhatsappEditado,
+		);
 		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
 			mensajeWhatsapp,
 			telefonoAsesorLimpio,
@@ -380,13 +386,13 @@ export function ContactoModal({
 					toast.error("No hay teléfono para enviar SMS");
 					return;
 				}
-				if (!mensajeEditado.trim()) {
+				if (!mensajeSms.trim()) {
 					toast.error("No hay mensaje para enviar");
 					return;
 				}
 				smsApiMutation.mutate({
 					telefono: telLimpio,
-					mensaje: mensajeEditado,
+					mensaje: mensajeSms,
 				});
 				break;
 		}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -51,6 +51,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
+	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
 } from "@/lib/cobros/plantillas-mensajes";
@@ -131,6 +132,8 @@ export function ContactoModal({
 	const [mensajeWhatsappEditado, setMensajeWhatsappEditado] = useState("");
 	const [asuntoEditado, setAsuntoEditado] = useState("");
 
+	const telefonoAsesorLimpio = telefonoAsesor.trim();
+
 	const variables: VariablesPlantilla = useMemo(
 		() => ({
 			clienteNombre,
@@ -140,7 +143,7 @@ export function ContactoModal({
 			marcaLineaModelo,
 			montoAdeudado,
 			cuotasAtraso,
-			telefonoAsesor,
+			telefonoAsesor: telefonoAsesorLimpio,
 			nombreAsesor,
 		}),
 		[
@@ -151,7 +154,7 @@ export function ContactoModal({
 			marcaLineaModelo,
 			montoAdeudado,
 			cuotasAtraso,
-			telefonoAsesor,
+			telefonoAsesorLimpio,
 			nombreAsesor,
 		],
 	);
@@ -303,6 +306,19 @@ export function ContactoModal({
 		const tel = telefonoSeleccionado || telefonoPrincipal;
 		const telLimpio = tel.replace(/[^0-9]/g, "");
 		const mensajeWhatsapp = mensajeWhatsappEditado || mensajeEditado;
+		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
+			mensajeWhatsapp,
+			telefonoAsesorLimpio,
+		);
+		if (
+			(metodo === "whatsapp-link" || metodo === "whatsapp-api") &&
+			!telefonoAsesorNoReply.enviar
+		) {
+			toast.error(
+				"No se puede enviar esta plantilla no-reply porque el asesor no tiene teléfono registrado",
+			);
+			return;
+		}
 		switch (metodo) {
 			case "llamada":
 				window.open(`tel:${tel}`);

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -54,6 +54,7 @@ import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
+	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
@@ -320,6 +321,11 @@ export function ContactoModal({
 			mensajeEditado,
 			mensajeWhatsappEditado,
 		);
+		const mensajeEmail = mensajeEmailEditable(
+			metodoInicial,
+			mensajeEditado,
+			mensajeWhatsappEditado,
+		);
 		const cuerpoNoReply = cuerpoParaValidarNoReply(
 			metodo,
 			mensajeWhatsapp,
@@ -361,7 +367,7 @@ export function ContactoModal({
 			case "email-link": {
 				const params = new URLSearchParams();
 				if (asuntoEditado) params.set("subject", asuntoEditado);
-				if (mensajeEditado) params.set("body", mensajeEditado);
+				if (mensajeEmail) params.set("body", mensajeEmail);
 				const query = params.toString();
 				window.open(`mailto:${emailCliente || ""}${query ? `?${query}` : ""}`);
 				break;
@@ -375,14 +381,14 @@ export function ContactoModal({
 					toast.error("El asunto es requerido");
 					return;
 				}
-				if (!mensajeEditado.trim()) {
+				if (!mensajeEmail.trim()) {
 					toast.error("El mensaje es requerido");
 					return;
 				}
 				emailApiMutation.mutate({
 					destinatario: emailCliente,
 					asunto: asuntoEditado,
-					mensaje: mensajeEditado,
+					mensaje: mensajeEmail,
 				});
 				break;
 			case "sms-api":

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -52,6 +52,7 @@ import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
+	mensajePlantillaEditable,
 	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
@@ -306,7 +307,11 @@ export function ContactoModal({
 	const ejecutarAccion = (metodo: AccionContacto) => {
 		const tel = telefonoSeleccionado || telefonoPrincipal;
 		const telLimpio = tel.replace(/[^0-9]/g, "");
-		const mensajeWhatsapp = mensajeWhatsappEditado || mensajeEditado;
+		const mensajeWhatsapp = mensajePlantillaEditable(
+			"whatsapp",
+			mensajeEditado,
+			mensajeWhatsappEditado,
+		);
 		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
 			mensajeWhatsapp,
 			telefonoAsesorLimpio,
@@ -325,11 +330,7 @@ export function ContactoModal({
 				window.open(`tel:${tel}`);
 				break;
 			case "whatsapp-link": {
-				const url = crearUrlWhatsappManual(
-					telLimpio,
-					mensajeWhatsappEditado,
-					mensajeEditado,
-				);
+				const url = crearUrlWhatsappManual(telLimpio, mensajeWhatsapp);
 				window.open(url);
 				break;
 			}
@@ -393,6 +394,19 @@ export function ContactoModal({
 
 	const mostrarPlantillas =
 		metodoInicial === "whatsapp" || metodoInicial === "email";
+	const mensajeEditable = mensajePlantillaEditable(
+		metodoInicial,
+		mensajeEditado,
+		mensajeWhatsappEditado,
+	);
+	const handleMensajeEditableChange = (mensaje: string) => {
+		if (metodoInicial === "whatsapp") {
+			setMensajeWhatsappEditado(mensaje);
+			return;
+		}
+
+		setMensajeEditado(mensaje);
+	};
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -533,8 +547,10 @@ export function ContactoModal({
 										<Label>Mensaje (editable)</Label>
 										<Textarea
 											className="min-h-[150px] text-sm"
-											value={mensajeEditado}
-											onChange={(e) => setMensajeEditado(e.target.value)}
+											value={mensajeEditable}
+											onChange={(e) =>
+												handleMensajeEditableChange(e.target.value)
+											}
 										/>
 									</div>
 								)}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -50,6 +50,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import {
 	accionUsaCuerpoNoReply,
+	cuerpoParaValidarNoReply,
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
@@ -319,8 +320,13 @@ export function ContactoModal({
 			mensajeEditado,
 			mensajeWhatsappEditado,
 		);
-		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
+		const cuerpoNoReply = cuerpoParaValidarNoReply(
+			metodo,
 			mensajeWhatsapp,
+			mensajeSms,
+		);
+		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
+			cuerpoNoReply,
 			telefonoAsesorLimpio,
 		);
 		if (accionUsaCuerpoNoReply(metodo) && !telefonoAsesorNoReply.enviar) {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -5,6 +5,7 @@ import {
 	accionUsaCuerpoNoReply,
 	cuerpoParaValidarNoReply,
 	crearUrlWhatsappManual,
+	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
@@ -106,6 +107,16 @@ describe("plantillas web de cobros", () => {
 	test("envia por SMS el mensaje visible cuando se edita desde WhatsApp", () => {
 		expect(
 			mensajeSmsEditable(
+				"whatsapp",
+				"Mensaje email largo oculto",
+				"Mensaje visible editado",
+			),
+		).toBe("Mensaje visible editado");
+	});
+
+	test("envia por Email el mensaje visible cuando se edita desde WhatsApp", () => {
+		expect(
+			mensajeEmailEditable(
 				"whatsapp",
 				"Mensaje email largo oculto",
 				"Mensaje visible editado",

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
+import {
+	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	PLANTILLAS_MENSAJES,
+	prepararTelefonoAsesorParaEnvio,
+} from "./plantillas-mensajes";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
@@ -65,5 +69,27 @@ describe("plantillas web de cobros", () => {
 			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
 		);
 		expect(preMora?.cuerpoWhastapp).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
+
+	test("descarta plantillas no-reply sin telefono de asesor", () => {
+		const cuerpoWhatsapp =
+			PLANTILLAS_MENSAJES[0].cuerpoWhastapp ?? PLANTILLAS_MENSAJES[0].cuerpo;
+
+		for (const telefono of [null, undefined, "", "   "]) {
+			expect(prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, telefono)).toEqual({
+				enviar: false,
+				motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+			});
+		}
+	});
+
+	test("recorta el telefono del asesor antes de interpolar", () => {
+		const cuerpoWhatsapp =
+			PLANTILLAS_MENSAJES[0].cuerpoWhastapp ?? PLANTILLAS_MENSAJES[0].cuerpo;
+
+		expect(prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, " 41286630 ")).toEqual({
+			enviar: true,
+			telefonoAsesor: "41286630",
+		});
 	});
 });

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -3,6 +3,7 @@ import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
 	accionUsaCuerpoNoReply,
+	cuerpoParaValidarNoReply,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
@@ -117,6 +118,16 @@ describe("plantillas web de cobros", () => {
 		expect(accionUsaCuerpoNoReply("whatsapp-api")).toBe(true);
 		expect(accionUsaCuerpoNoReply("sms-api")).toBe(true);
 		expect(accionUsaCuerpoNoReply("email-api")).toBe(false);
+	});
+
+	test("valida no-reply contra el cuerpo real de SMS", () => {
+		expect(
+			cuerpoParaValidarNoReply(
+				"sms-api",
+				`Mensaje WhatsApp oculto ${NO_REPLY_WARNING}`,
+				"Mensaje SMS seguro",
+			),
+		).toBe("Mensaje SMS seguro");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -3,6 +3,7 @@ import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
+	mensajePlantillaEditable,
 	prepararTelefonoAsesorParaEnvio,
 } from "./plantillas-mensajes";
 
@@ -81,6 +82,22 @@ describe("plantillas web de cobros", () => {
 		const text = new URL(url).searchParams.get("text");
 
 		expect(text).toBe("Mensaje WhatsApp no-reply");
+	});
+
+	test("edita el cuerpo visible que usa WhatsApp", () => {
+		expect(
+			mensajePlantillaEditable(
+				"whatsapp",
+				"Mensaje email por este medio",
+				"Mensaje WhatsApp no-reply",
+			),
+		).toBe("Mensaje WhatsApp no-reply");
+	});
+
+	test("respeta mensajes de WhatsApp vacios editados manualmente", () => {
+		expect(
+			mensajePlantillaEditable("whatsapp", "Mensaje fallback", ""),
+		).toBe("");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
+
+const NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
+describe("plantillas web de cobros", () => {
+	test("incluyen el aviso de no responder en el cuerpo de WhatsApp", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+			const matches = cuerpoWhatsapp.matchAll(
+				/NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS/g,
+			);
+
+			expect(Array.from(matches).length, plantilla.id).toBe(1);
+			expect(cuerpoWhatsapp, plantilla.id).toContain(NO_REPLY_WARNING);
+		}
+	});
+
+	test("colocan el aviso antes de la firma cuando existe", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+			const warningIndex = cuerpoWhatsapp.indexOf(NO_REPLY_WARNING);
+			const signatureIndex = cuerpoWhatsapp.indexOf("Atentamente");
+
+			if (signatureIndex !== -1) {
+				expect(warningIndex, plantilla.id).toBeLessThan(signatureIndex);
+			}
+		}
+	});
+});

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -4,6 +4,7 @@ import {
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
+	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
 } from "./plantillas-mensajes";
 
@@ -98,6 +99,16 @@ describe("plantillas web de cobros", () => {
 		expect(
 			mensajePlantillaEditable("whatsapp", "Mensaje fallback", ""),
 		).toBe("");
+	});
+
+	test("envia por SMS el mensaje visible cuando se edita desde WhatsApp", () => {
+		expect(
+			mensajeSmsEditable(
+				"whatsapp",
+				"Mensaje email largo oculto",
+				"Mensaje visible editado",
+			),
+		).toBe("Mensaje visible editado");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -3,6 +3,8 @@ import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+const CONFIRMATION_REQUEST_REGEX =
+	/confirme la recepción|confirmar recepción|confirme recepcion/i;
 
 describe("plantillas web de cobros", () => {
 	test("incluyen el aviso de no responder en el cuerpo de WhatsApp", () => {
@@ -36,6 +38,18 @@ describe("plantillas web de cobros", () => {
 			expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
 				/por este medio|por este chat|comunicarse por este medio/i,
 			);
+		}
+	});
+
+	test("no piden confirmar recepcion cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+
+			if (cuerpoWhatsapp.includes(NO_REPLY_WARNING)) {
+				expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
+					CONFIRMATION_REQUEST_REGEX,
+				);
+			}
 		}
 	});
 

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -28,4 +28,28 @@ describe("plantillas web de cobros", () => {
 			}
 		}
 	});
+
+	test("no indican responder por este chat cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+
+			expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
+				/por este medio|por este chat|comunicarse por este medio/i,
+			);
+		}
+	});
+
+	test("dirigen comprobantes y dudas al telefono del asesor", () => {
+		const bienvenida = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "bienvenida",
+		);
+		const preMora = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "pre_mora",
+		);
+
+		expect(bienvenida?.cuerpoWhastapp).toMatch(
+			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
+		);
+		expect(preMora?.cuerpoWhastapp).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
 });

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
+	crearUrlWhatsappManual,
 	prepararTelefonoAsesorParaEnvio,
 } from "./plantillas-mensajes";
 
@@ -69,6 +70,17 @@ describe("plantillas web de cobros", () => {
 			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
 		);
 		expect(preMora?.cuerpoWhastapp).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
+
+	test("crea links manuales de WhatsApp con el cuerpo de WhatsApp", () => {
+		const url = crearUrlWhatsappManual(
+			"50241286630",
+			"Mensaje WhatsApp no-reply",
+			"Mensaje email por este medio",
+		);
+		const text = new URL(url).searchParams.get("text");
+
+		expect(text).toBe("Mensaje WhatsApp no-reply");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
+	accionUsaCuerpoNoReply,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
@@ -109,6 +110,13 @@ describe("plantillas web de cobros", () => {
 				"Mensaje visible editado",
 			),
 		).toBe("Mensaje visible editado");
+	});
+
+	test("bloquea todos los envios que usan cuerpo no-reply sin telefono de asesor", () => {
+		expect(accionUsaCuerpoNoReply("whatsapp-link")).toBe(true);
+		expect(accionUsaCuerpoNoReply("whatsapp-api")).toBe(true);
+		expect(accionUsaCuerpoNoReply("sms-api")).toBe(true);
+		expect(accionUsaCuerpoNoReply("email-api")).toBe(false);
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -60,6 +60,14 @@ export function crearUrlWhatsappManual(
     : `https://wa.me/${telefonoLimpio}`;
 }
 
+export function mensajePlantillaEditable(
+  metodoContacto: string,
+  mensajeEditado: string,
+  mensajeWhatsappEditado: string,
+): string {
+  return metodoContacto === "whatsapp" ? mensajeWhatsappEditado : mensajeEditado;
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -49,6 +49,17 @@ export function prepararTelefonoAsesorParaEnvio(
   return { enviar: true, telefonoAsesor };
 }
 
+export function crearUrlWhatsappManual(
+  telefonoLimpio: string,
+  mensajeWhatsapp: string,
+  mensajeFallback = "",
+): string {
+  const mensaje = mensajeWhatsapp || mensajeFallback;
+  return mensaje
+    ? `https://wa.me/${telefonoLimpio}?text=${encodeURIComponent(mensaje)}`
+    : `https://wa.me/${telefonoLimpio}`;
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -32,6 +32,22 @@ export interface PlantillaMensaje {
 
 export const COBROS_NO_REPLY_WARNING =
   "*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+export const COBROS_MOTIVO_SIN_TELEFONO_ASESOR = "sin teléfono de asesor";
+
+export function prepararTelefonoAsesorParaEnvio(
+  cuerpo: string,
+  telefono: string | null | undefined,
+):
+  | { enviar: true; telefonoAsesor: string }
+  | { enviar: false; motivo: string } {
+  const telefonoAsesor = telefono?.trim() ?? "";
+
+  if (cuerpo.includes(COBROS_NO_REPLY_WARNING) && !telefonoAsesor) {
+    return { enviar: false, motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR };
+  }
+
+  return { enviar: true, telefonoAsesor };
+}
 
 function toCapitalCase(str: string): string {
   return str

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -80,6 +80,18 @@ export function mensajeSmsEditable(
   );
 }
 
+export function mensajeEmailEditable(
+  metodoInicial: string,
+  mensajeEditado: string,
+  mensajeWhatsappEditado: string,
+): string {
+  return mensajePlantillaEditable(
+    metodoInicial,
+    mensajeEditado,
+    mensajeWhatsappEditado,
+  );
+}
+
 export function accionUsaCuerpoNoReply(metodo: string): boolean {
   return (
     metodo === "whatsapp-link" || metodo === "whatsapp-api" || metodo === "sms-api"

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -80,6 +80,12 @@ export function mensajeSmsEditable(
   );
 }
 
+export function accionUsaCuerpoNoReply(metodo: string): boolean {
+  return (
+    metodo === "whatsapp-link" || metodo === "whatsapp-api" || metodo === "sms-api"
+  );
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -102,7 +102,7 @@ Tel: {telefonoAsesor}.`,
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
-Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
 
 ${COBROS_NO_REPLY_WARNING}
 
@@ -140,7 +140,7 @@ Atentamente,
 Tel: {telefonoAsesor}.`,
     cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
-Si tiene alguna duda por favor comunicarse por este medio.
+Si tiene alguna duda, por favor comuníquese al {telefonoAsesor}.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 
@@ -196,7 +196,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-    cuerpoWhastapp: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+    cuerpoWhastapp: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -68,6 +68,18 @@ export function mensajePlantillaEditable(
   return metodoContacto === "whatsapp" ? mensajeWhatsappEditado : mensajeEditado;
 }
 
+export function mensajeSmsEditable(
+  metodoInicial: string,
+  mensajeEditado: string,
+  mensajeWhatsappEditado: string,
+): string {
+  return mensajePlantillaEditable(
+    metodoInicial,
+    mensajeEditado,
+    mensajeWhatsappEditado,
+  );
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -106,7 +106,7 @@ Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplic
 
 ${COBROS_NO_REPLY_WARNING}
 
-Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "al_dia",

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -86,6 +86,14 @@ export function accionUsaCuerpoNoReply(metodo: string): boolean {
   );
 }
 
+export function cuerpoParaValidarNoReply(
+  metodo: string,
+  mensajeWhatsapp: string,
+  mensajeSms: string,
+): string {
+  return metodo === "sms-api" ? mensajeSms : mensajeWhatsapp;
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -30,6 +30,9 @@ export interface PlantillaMensaje {
   cuerpoWhastapp?: string;
 }
 
+export const COBROS_NO_REPLY_WARNING =
+  "*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()
@@ -95,8 +98,15 @@ Agradecemos confirme la recepción de este mensaje.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.\n\nA continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL\n\nPor favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.\n\nAgradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
+
+A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
+
+Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+
+${COBROS_NO_REPLY_WARNING}
+
+Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "al_dia",
@@ -108,8 +118,11 @@ Tel: {telefonoAsesor}.`,
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "pre_mora",
@@ -125,8 +138,15 @@ SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.\n\nSi tiene alguna duda por favor comunicarse por este medio.\n\nSI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
+
+Si tiene alguna duda por favor comunicarse por este medio.
+
+SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "mora_30",
@@ -138,8 +158,11 @@ Tel: {telefonoAsesor}.`,
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "mora_60",
@@ -155,8 +178,13 @@ Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a to
 Atentamente,
 {nombreAsesor}
 Tel: {telefonoAsesor}`,
-    cuerpoWhastapp:
-      "Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.\n\nSi no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}",
+    cuerpoWhastapp: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
+
+Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
   },
   {
     id: "aviso_juridico",
@@ -168,8 +196,13 @@ Tel: {telefonoAsesor}`,
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-    cuerpoWhastapp:
-      "Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.\n\nPor lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.\n\nFavor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.",
+    cuerpoWhastapp: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+
+Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
+
+${COBROS_NO_REPLY_WARNING}
+
+Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Replaces closed PR #1062 without redoing the work from scratch.
- Adds Alejandro's no-reply warning to all cobros mass WhatsApp templates.
- Removes contradictory no-reply copy: receipts/questions now route to `{telefonoAsesor}`, and the bienvenida confirmation request is removed from no-reply bodies.
- Skips no-reply mass cobros rows when the assigned advisor has no usable phone, avoiding empty `Tel:` / `al .` messages.

## Test Plan
- [x] `bun test apps/crm/apps/server/src/lib/cobros-plantillas.test.ts apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts`
- [x] no-reply conflict + missing-phone smoke check
- [x] `git diff --check`

## Notes
- Old PR #1062 was closed due to noisy review iteration.
- This branch keeps the verified commits from #1062 and adds only the latest advisor-phone guard on top.
- No production writes/deploys.
