### PR TITLE
feat(cobros): módulo Buckets en cartera front + endpoint de cambios de asesor

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/asesorHistorial.ts
+++ b/apps/cartera-back/src/controllers/buckets/asesorHistorial.ts
@@ -1,0 +1,146 @@
+import { db } from "../../database";
+import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
+import { sql } from "drizzle-orm";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// COBROS-02 · Asesores — Bitácora de reasignaciones (append-only).
+// Lee `cartera.credito_asesor_historial` (la llena el motor al reasignar y los
+// scripts de siembra) con joins al crédito, cliente, ambos asesores y el bucket
+// snapshot. Endpoint de solo lectura, paginado y con filtros — espejo de
+// bucketsHistorial.ts a propósito (mismo patrón, misma validación en el router).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type AsesorHistorialArgs = {
+  desde?: string; // YYYY-MM-DD (corte por día GT, inclusive)
+  hasta?: string; // YYYY-MM-DD (corte por día GT, inclusive)
+  origen?: string; // PROCESO_AUTO | API_MANUAL
+  bucket?: string; // CSV de enteros (snapshot del bucket al momento del cambio)
+  asesor_nuevo?: string; // CSV de nombres, ILIKE
+  asesor_anterior?: string; // CSV de nombres, ILIKE
+  credito_id?: number;
+  numero_credito_sifco?: string; // ILIKE
+  nombre_usuario?: string; // cliente, ILIKE
+  page?: number;
+  pageSize?: number;
+};
+
+// CSV → lista limpia de strings.
+const csv = (v?: string) =>
+  (v ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+
+// CSV → lista de enteros válidos.
+const csvInts = (v?: string) =>
+  csv(v).map((s) => Number(s)).filter((n) => Number.isInteger(n));
+
+function buildWhere(a: AsesorHistorialArgs) {
+  const filters: any[] = [];
+
+  // Rango de fecha por DÍA Guatemala (fecha es timestamp UTC; el motor corre
+  // ~23:59 GT ≈ 06:00 UTC del día siguiente → comparar en GT evita el corrimiento).
+  const fechaGT = sql`(h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date`;
+  if (a.desde) filters.push(sql`${fechaGT} >= ${a.desde}::date`);
+  if (a.hasta) filters.push(sql`${fechaGT} <= ${a.hasta}::date`);
+
+  if (a.origen) filters.push(sql`h.origen = ${a.origen}`);
+
+  const bucketsSnap = csvInts(a.bucket);
+  if (bucketsSnap.length) {
+    filters.push(sql`h.bucket IN (${sql.join(bucketsSnap.map((n) => sql`${n}`), sql`, `)})`);
+  }
+
+  if (a.credito_id) filters.push(sql`h.credito_id = ${a.credito_id}`);
+  if (a.numero_credito_sifco) {
+    filters.push(sql`c.numero_credito_sifco ILIKE ${"%" + a.numero_credito_sifco + "%"}`);
+  }
+  if (a.nombre_usuario) filters.push(sql`u.nombre ILIKE ${"%" + a.nombre_usuario + "%"}`);
+
+  const nuevos = csv(a.asesor_nuevo);
+  if (nuevos.length) {
+    filters.push(
+      sql`(${sql.join(nuevos.map((n) => sql`an.nombre ILIKE ${"%" + n + "%"}`), sql` OR `)})`,
+    );
+  }
+  const anteriores = csv(a.asesor_anterior);
+  if (anteriores.length) {
+    filters.push(
+      sql`(${sql.join(anteriores.map((n) => sql`aa.nombre ILIKE ${"%" + n + "%"}`), sql` OR `)})`,
+    );
+  }
+
+  return filters.length ? sql.join(filters, sql` AND `) : sql`TRUE`;
+}
+
+// Joins compartidos entre el conteo y la data.
+// - creditos/usuarios: INNER (toda reasignación tiene su crédito y cliente).
+// - asesores aa/an: LEFT (asesor_anterior NULL = siembra; nuevo nullable a futuro).
+// - buckets b: LEFT contra el catálogo (nombre/prefijo del snapshot).
+// - platform_users pu: LEFT, quién hizo el cambio (solo API_MANUAL).
+const joins = sql`
+  FROM ${SQL_CARTERA_SCHEMA}.credito_asesor_historial h
+  INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = h.credito_id
+  INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores aa ON aa.asesor_id = h.asesor_anterior
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores an ON an.asesor_id = h.asesor_nuevo
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.buckets b ON b.numero = h.bucket
+  LEFT JOIN ${SQL_CARTERA_SCHEMA}.platform_users pu ON pu.id = h.usuario_id`;
+
+// Bitácora paginada de cambios de asesor, con filtros, joins y resumen.
+export async function getAsesorHistorial(a: AsesorHistorialArgs) {
+  // Clamp defensivo: floor PRIMERO y mínimo 1 DESPUÉS (mismo criterio que
+  // bucketsHistorial — page=0.5 → floor 0 → OFFSET negativo si no).
+  const pageFloor = Math.floor(Number(a.page));
+  const page = Number.isFinite(pageFloor) && pageFloor > 0 ? pageFloor : 1;
+  const sizeFloor = Math.floor(Number(a.pageSize));
+  const pageSize = Number.isFinite(sizeFloor) && sizeFloor > 0 ? Math.min(sizeFloor, 500) : 20;
+  const offset = (page - 1) * pageSize;
+  const where = buildWhere(a);
+
+  const [totRes, dataRes] = await Promise.all([
+    db.execute<any>(sql`
+      SELECT
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE h.origen = 'PROCESO_AUTO')::int AS automaticos,
+        COUNT(*) FILTER (WHERE h.origen = 'API_MANUAL')::int AS manuales,
+        COUNT(DISTINCT h.credito_id)::int AS creditos
+      ${joins}
+      WHERE ${where}
+    `),
+    db.execute<any>(sql`
+      SELECT
+        h.historial_id,
+        h.fecha,
+        h.credito_id,
+        c.numero_credito_sifco,
+        u.nombre AS cliente,
+        h.asesor_anterior AS asesor_anterior_id,
+        aa.nombre AS asesor_anterior,
+        h.asesor_nuevo AS asesor_nuevo_id,
+        an.nombre AS asesor_nuevo,
+        h.bucket,
+        b.prefijo AS bucket_prefijo,
+        b.nombre  AS bucket_nombre,
+        h.origen,
+        h.motivo,
+        pu.email AS usuario,
+        c."statusCredit" AS status_actual
+      ${joins}
+      WHERE ${where}
+      ORDER BY h.fecha DESC, h.historial_id DESC
+      LIMIT ${pageSize} OFFSET ${offset}
+    `),
+  ]);
+
+  const tot = totRes.rows[0] ?? {};
+  const total = Number(tot.total ?? 0);
+  return {
+    success: true,
+    data: dataRes.rows,
+    pagination: { page, pageSize, total, totalPages: Math.ceil(total / pageSize) },
+    resumen: {
+      total,
+      automaticos: Number(tot.automaticos ?? 0),
+      manuales: Number(tot.manuales ?? 0),
+      creditos: Number(tot.creditos ?? 0),
+    },
+  };
+}

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -5,6 +5,7 @@ import {
   getBucketsHistorial,
   getBucketsHistorialCredito,
 } from "../controllers/buckets/bucketsHistorial";
+import { getAsesorHistorial } from "../controllers/buckets/asesorHistorial";
 import { getCreditosWithUserByMesAnio } from "../controllers/credits";
 import { StatusCredit } from "../database/db/schema";
 
@@ -153,6 +154,77 @@ export const bucketsRouter = new Elysia()
         asesor: t.Optional(t.String()),
         status_credito: t.Optional(t.String()),
         pago_id: t.Optional(t.String()),
+        page: t.Optional(t.String()),
+        pageSize: t.Optional(t.String()),
+      }),
+    },
+  )
+
+  // Bitácora de cambios de asesor (credito_asesor_historial), paginada y con
+  // filtros + resumen. Misma validación estricta que /buckets/historial.
+  .get(
+    "/buckets/asesores-historial",
+    async ({ query, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        const creditoId = query.credito_id ? Number(query.credito_id) : undefined;
+        if (creditoId !== undefined && (!Number.isInteger(creditoId) || creditoId <= 0)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] credito_id inválido" };
+        }
+        if (query.desde && !esFecha(query.desde)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] desde inválida (formato YYYY-MM-DD)" };
+        }
+        if (query.hasta && !esFecha(query.hasta)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] hasta inválida (formato YYYY-MM-DD)" };
+        }
+        if (query.desde && query.hasta && query.desde > query.hasta) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] rango de fechas inválido (desde > hasta)" };
+        }
+        if (csvInvalido(query.bucket, esBucket)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] bucket inválido (CSV de enteros, ej. 0,1,5)" };
+        }
+        if (query.origen && !ORIGENES.includes(query.origen)) {
+          set.status = 400;
+          return { success: false, message: `[ERROR] origen inválido (valores: ${ORIGENES.join(", ")})` };
+        }
+        return await getAsesorHistorial({
+          desde: query.desde,
+          hasta: query.hasta,
+          origen: query.origen,
+          bucket: query.bucket,
+          asesor_nuevo: query.asesor_nuevo,
+          asesor_anterior: query.asesor_anterior,
+          credito_id: creditoId,
+          numero_credito_sifco: query.numero_credito_sifco,
+          nombre_usuario: query.nombre_usuario,
+          page: query.page ? Number(query.page) : 1,
+          pageSize: query.pageSize ? Number(query.pageSize) : 20,
+        });
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener el histórico de cambios de asesor",
+          error: String(err),
+        };
+      }
+    },
+    {
+      query: t.Object({
+        desde: t.Optional(t.String()),
+        hasta: t.Optional(t.String()),
+        origen: t.Optional(t.String()),
+        bucket: t.Optional(t.String()),
+        asesor_nuevo: t.Optional(t.String()),
+        asesor_anterior: t.Optional(t.String()),
+        credito_id: t.Optional(t.String()),
+        numero_credito_sifco: t.Optional(t.String()),
+        nombre_usuario: t.Optional(t.String()),
         page: t.Optional(t.String()),
         pageSize: t.Optional(t.String()),
       }),

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -23,6 +23,8 @@ import { RecibosGenericos } from "./private/recibos-genericos/components/Recibos
 import { FallenCredits } from "./private/cartera/components/FallenCredits";
 import { PagosPorVencimiento } from "./private/cartera/components/PagosPorVencimiento";
 import { MoraHistorial } from "./private/cartera/components/MoraHistorial";
+import { BucketsHistorial } from "./private/cartera/components/BucketsHistorial";
+import { BucketsCambiosAsesor } from "./private/cartera/components/BucketsCambiosAsesor";
 import { DevolucionCube } from "./private/cartera/components/DevolucionCube";
 import { CierreCartera } from "./private/cartera/components/CierreCartera";
 import { FacturacionDiaria } from "./private/cartera/components/FacturacionDiaria";
@@ -263,6 +265,25 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
               <MoraHistorial />
+            </RoleRoute>
+          }
+        />
+
+        {/* COBROS-02: módulos temporales de auditoría del motor de buckets */}
+        <Route
+          path="buckets-historial"
+          element={
+            <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
+              <BucketsHistorial />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="buckets-asesores"
+          element={
+            <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
+              <BucketsCambiosAsesor />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/BucketsCambiosAsesor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/BucketsCambiosAsesor.tsx
@@ -1,0 +1,255 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Search,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  ArrowRight,
+  UserCog,
+  Bot,
+  Hand,
+  Users,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getAsesorHistorial } from "../services/buckets.services";
+import {
+  useBucketsCatalogo,
+  BucketBadge,
+  fmtFechaEvento,
+  origenLabel,
+  origenBadgeClass,
+} from "./bucketsUi";
+
+export function BucketsCambiosAsesor() {
+  const { catalogo, porNumero } = useBucketsCatalogo();
+
+  const [desde, setDesde] = useState("");
+  const [hasta, setHasta] = useState("");
+  const [origen, setOrigen] = useState("");
+  const [bucket, setBucket] = useState("");
+  const [asesorInput, setAsesorInput] = useState("");
+  const [sifcoInput, setSifcoInput] = useState("");
+  const [nombreInput, setNombreInput] = useState("");
+  const [asesor, setAsesor] = useState("");
+  const [sifco, setSifco] = useState("");
+  const [nombre, setNombre] = useState("");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const query = useQuery({
+    queryKey: ["buckets-asesores-historial", desde, hasta, origen, bucket, asesor, sifco, nombre, page, pageSize],
+    queryFn: () =>
+      getAsesorHistorial({
+        desde: desde || undefined,
+        hasta: hasta || undefined,
+        origen: origen || undefined,
+        bucket: bucket || undefined,
+        asesor_nuevo: asesor || undefined,
+        numero_credito_sifco: sifco || undefined,
+        nombre_usuario: nombre || undefined,
+        page,
+        pageSize,
+      }),
+    refetchOnWindowFocus: false,
+  });
+
+  const rows = query.data?.data ?? [];
+  const resumen = query.data?.resumen;
+  const pagination = query.data?.pagination;
+
+  const aplicar = () => {
+    setAsesor(asesorInput.trim());
+    setSifco(sifcoInput.trim());
+    setNombre(nombreInput.trim());
+    setPage(1);
+  };
+  const limpiar = () => {
+    setDesde(""); setHasta(""); setOrigen(""); setBucket("");
+    setAsesorInput(""); setSifcoInput(""); setNombreInput("");
+    setAsesor(""); setSifco(""); setNombre("");
+    setPage(1);
+  };
+  const filtros =
+    (desde ? 1 : 0) + (hasta ? 1 : 0) + (origen ? 1 : 0) + (bucket ? 1 : 0) +
+    (asesor ? 1 : 0) + (sifco ? 1 : 0) + (nombre ? 1 : 0);
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 overflow-auto bg-gradient-to-br from-violet-50 to-white px-4 sm:px-6 lg:px-8 pt-8 pb-8">
+      <div className="w-full mx-auto">
+        <div className="flex flex-col items-center mb-6">
+          <h1 className="text-3xl font-extrabold text-violet-800 text-center flex items-center gap-2">
+            <UserCog className="h-7 w-7" /> Cambios de Asesor
+          </h1>
+          <p className="text-gray-600 mt-2 text-center">
+            Bitácora de reasignaciones de cartera: quién llevaba el crédito, quién lo lleva ahora y en qué bucket ocurrió el cambio.
+          </p>
+        </div>
+
+        {/* Filtros */}
+        <div className="bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-violet-100 p-5 mb-6">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="min-w-[145px]">
+              <label className="text-sm font-semibold text-violet-800 mb-1 block">Desde</label>
+              <Input type="date" value={desde} onChange={(e) => { setDesde(e.target.value); setPage(1); }} className="text-gray-900 border-violet-200 bg-violet-50 [color-scheme:light]" />
+            </div>
+            <div className="min-w-[145px]">
+              <label className="text-sm font-semibold text-violet-800 mb-1 block">Hasta</label>
+              <Input type="date" value={hasta} onChange={(e) => { setHasta(e.target.value); setPage(1); }} className="text-gray-900 border-violet-200 bg-violet-50 [color-scheme:light]" />
+            </div>
+            <div className="min-w-[140px]">
+              <label className="text-sm font-semibold text-violet-800 mb-1 block">Origen</label>
+              <select className="w-full border border-violet-200 rounded-lg px-3 py-2 text-sm text-violet-800 bg-violet-50 h-10" value={origen} onChange={(e) => { setOrigen(e.target.value); setPage(1); }}>
+                <option value="">Todos</option>
+                <option value="PROCESO_AUTO">Automático</option>
+                <option value="API_MANUAL">Manual</option>
+              </select>
+            </div>
+            <div className="min-w-[150px]">
+              <label className="text-sm font-semibold text-violet-800 mb-1 block">Bucket</label>
+              <select className="w-full border border-violet-200 rounded-lg px-3 py-2 text-sm text-violet-800 bg-violet-50 h-10" value={bucket} onChange={(e) => { setBucket(e.target.value); setPage(1); }}>
+                <option value="">Todos</option>
+                {catalogo.map((b) => (
+                  <option key={b.numero} value={String(b.numero)}>
+                    {b.prefijo} · {b.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1 min-w-[150px]">
+              <label className="text-sm font-semibold text-violet-800 mb-1 block">Asesor nuevo</label>
+              <Input placeholder="Buscar asesor..." value={asesorInput} onChange={(e) => setAsesorInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && aplicar()} className="text-gray-900 border-violet-200 bg-violet-50" />
+            </div>
+            <div className="flex-1 min-w-[150px]">
+              <label className="text-sm font-semibold text-violet-800 mb-1 block">No. SIFCO</label>
+              <Input placeholder="Buscar SIFCO..." value={sifcoInput} onChange={(e) => setSifcoInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && aplicar()} className="text-gray-900 border-violet-200 bg-violet-50" />
+            </div>
+            <div className="flex-1 min-w-[150px]">
+              <label className="text-sm font-semibold text-violet-800 mb-1 block">Cliente</label>
+              <Input placeholder="Buscar nombre..." value={nombreInput} onChange={(e) => setNombreInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && aplicar()} className="text-gray-900 border-violet-200 bg-violet-50" />
+            </div>
+
+            <Button variant="outline" size="sm" onClick={aplicar} className="text-violet-700 border-violet-300 hover:bg-violet-50">
+              <Search className="w-4 h-4 mr-1" /> Buscar
+            </Button>
+            {filtros > 0 && (
+              <Button variant="outline" size="sm" onClick={limpiar} className="text-gray-600 border-gray-300 hover:bg-gray-100">
+                <X className="w-4 h-4 mr-1" /> Limpiar <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">{filtros}</Badge>
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Resumen */}
+        {resumen && (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+            <div className="bg-white rounded-xl shadow border border-violet-200 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium">Cambios</p>
+              <p className="text-lg font-bold text-violet-700">{resumen.total.toLocaleString("es-GT")}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-slate-200 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium flex items-center justify-center gap-1"><Bot className="h-3 w-3" /> Automáticos</p>
+              <p className="text-lg font-bold text-slate-700">{resumen.automaticos.toLocaleString("es-GT")}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-amber-100 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium flex items-center justify-center gap-1"><Hand className="h-3 w-3" /> Manuales</p>
+              <p className="text-lg font-bold text-amber-700">{resumen.manuales.toLocaleString("es-GT")}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-blue-100 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium flex items-center justify-center gap-1"><Users className="h-3 w-3" /> Créditos afectados</p>
+              <p className="text-lg font-bold text-blue-600">{resumen.creditos.toLocaleString("es-GT")}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Tabla */}
+        {query.isLoading ? (
+          <div className="text-center py-16 text-violet-400 font-semibold">Cargando...</div>
+        ) : query.isError ? (
+          <div className="text-center py-16 text-red-500 font-semibold">Error al cargar los cambios de asesor</div>
+        ) : !rows.length ? (
+          <div className="text-center py-16 text-gray-400 font-semibold">No hay cambios para los filtros seleccionados</div>
+        ) : (
+          <>
+            <div className="bg-white rounded-2xl shadow-lg border border-violet-100 overflow-x-auto">
+              <Table className="w-full">
+                <TableHeader>
+                  <TableRow className="bg-gradient-to-r from-violet-50 to-violet-100">
+                    <TableHead className="font-bold text-violet-800">Fecha</TableHead>
+                    <TableHead className="font-bold text-violet-800">No. SIFCO</TableHead>
+                    <TableHead className="font-bold text-violet-800">Cliente</TableHead>
+                    <TableHead className="font-bold text-violet-800 text-center">Cambio de asesor</TableHead>
+                    <TableHead className="font-bold text-violet-800 text-center">Bucket</TableHead>
+                    <TableHead className="font-bold text-violet-800 text-center">Origen</TableHead>
+                    <TableHead className="font-bold text-violet-800">Motivo</TableHead>
+                    <TableHead className="font-bold text-violet-800">Usuario</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((r) => (
+                    <TableRow key={r.historial_id} className="hover:bg-violet-50/40">
+                      <TableCell className="text-xs text-gray-600 whitespace-nowrap">{fmtFechaEvento(r.fecha)}</TableCell>
+                      <TableCell className="font-semibold">
+                        <Link to={`/pagos/${r.numero_credito_sifco}`} className="text-violet-700 hover:underline" title="Ver pagos del crédito">
+                          {r.numero_credito_sifco}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-black">{r.cliente}</TableCell>
+                      <TableCell className="text-center">
+                        <span className="inline-flex items-center gap-1.5 text-xs">
+                          <span className={r.asesor_anterior ? "text-gray-500" : "text-gray-400 italic"}>
+                            {r.asesor_anterior ?? "Sin asesor"}
+                          </span>
+                          <ArrowRight className="h-3 w-3 text-gray-400 shrink-0" />
+                          <span className="font-semibold text-violet-700">{r.asesor_nuevo ?? "—"}</span>
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <BucketBadge numero={r.bucket} porNumero={porNumero} />
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-semibold ${origenBadgeClass(r.origen)}`}>
+                          {origenLabel(r.origen)}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-xs text-gray-600 max-w-[260px] truncate" title={r.motivo ?? undefined}>
+                        {r.motivo || "—"}
+                      </TableCell>
+                      <TableCell className="text-xs text-gray-500">{r.usuario || "sistema"}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between mt-5 gap-3">
+              <span className="text-sm text-gray-600">
+                Página {pagination?.page ?? 1} de {pagination?.totalPages ?? 1} ({pagination?.total ?? 0} cambios)
+              </span>
+              <div className="flex items-center gap-2">
+                <select className="border border-violet-200 rounded-lg px-3 py-2 text-sm text-violet-800 bg-violet-50" value={pageSize} onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}>
+                  {[20, 50, 100].map((n) => <option key={n} value={n}>{n} por página</option>)}
+                </select>
+                <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)} className="border-violet-200 text-violet-700"><ChevronLeft className="w-4 h-4" /></Button>
+                <Button variant="outline" size="sm" disabled={page >= (pagination?.totalPages ?? 1)} onClick={() => setPage((p) => p + 1)} className="border-violet-200 text-violet-700"><ChevronRight className="w-4 h-4" /></Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BucketsCambiosAsesor;

--- a/apps/carteraFront/src/private/cartera/components/BucketsHistorial.tsx
+++ b/apps/carteraFront/src/private/cartera/components/BucketsHistorial.tsx
@@ -203,7 +203,7 @@ export function BucketsHistorial() {
                     <TableHead className="font-bold text-indigo-800 text-center">Evento</TableHead>
                     <TableHead className="font-bold text-indigo-800 text-center">Transición</TableHead>
                     <TableHead className="font-bold text-indigo-800 text-center">Cuotas</TableHead>
-                    <TableHead className="font-bold text-indigo-800">Asesor</TableHead>
+                    <TableHead className="font-bold text-indigo-800">Asesor actual</TableHead>
                     <TableHead className="font-bold text-indigo-800 text-center">Origen</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -230,7 +230,19 @@ export function BucketsHistorial() {
                         </span>
                       </TableCell>
                       <TableCell className="text-center text-black">{r.cuotas_atrasadas_nuevas ?? "—"}</TableCell>
-                      <TableCell className="text-black text-xs">{r.asesor || "—"}</TableCell>
+                      {/* Dueño ACTUAL del crédito (review Codex: el join es vivo, cambia
+                          con cada reasignación). En BAJADAs se agrega la atribución
+                          inmutable del evento (h.asesor_id) cuando difiere del actual. */}
+                      <TableCell className="text-black text-xs">
+                        {r.asesor || "—"}
+                        {r.tipo_evento === "BAJADA" &&
+                          r.asesor_atribucion &&
+                          r.asesor_atribucion !== r.asesor && (
+                            <span className="block text-[10px] text-emerald-700">
+                              curó: {r.asesor_atribucion}
+                            </span>
+                          )}
+                      </TableCell>
                       <TableCell className="text-center">
                         <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-semibold ${origenBadgeClass(r.origen)}`} title={r.motivo ?? undefined}>
                           {origenLabel(r.origen)}

--- a/apps/carteraFront/src/private/cartera/components/BucketsHistorial.tsx
+++ b/apps/carteraFront/src/private/cartera/components/BucketsHistorial.tsx
@@ -1,0 +1,264 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import {
+  Search,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  ArrowRight,
+  Layers,
+  TrendingUp,
+  TrendingDown,
+  Sparkles,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { getBucketsHistorial } from "../services/buckets.services";
+import {
+  useBucketsCatalogo,
+  BucketBadge,
+  fmtFechaEvento,
+  origenLabel,
+  origenBadgeClass,
+} from "./bucketsUi";
+
+const eventoBadge = (tipo: string) => {
+  // SUBIDA = empeora (rojo), BAJADA = mejora (verde), INICIAL = siembra (azul).
+  const map: Record<string, string> = {
+    INICIAL: "bg-blue-100 text-blue-700",
+    SUBIDA: "bg-red-100 text-red-700",
+    BAJADA: "bg-emerald-100 text-emerald-700",
+  };
+  return map[tipo] ?? "bg-gray-100 text-gray-700";
+};
+
+const eventoIcon = (tipo: string) =>
+  tipo === "SUBIDA" ? (
+    <TrendingUp className="h-3 w-3" />
+  ) : tipo === "BAJADA" ? (
+    <TrendingDown className="h-3 w-3" />
+  ) : (
+    <Sparkles className="h-3 w-3" />
+  );
+
+export function BucketsHistorial() {
+  const { catalogo, porNumero } = useBucketsCatalogo();
+
+  const [desde, setDesde] = useState("");
+  const [hasta, setHasta] = useState("");
+  const [tipoEvento, setTipoEvento] = useState("");
+  const [bucketNuevo, setBucketNuevo] = useState("");
+  const [sifcoInput, setSifcoInput] = useState("");
+  const [nombreInput, setNombreInput] = useState("");
+  const [sifco, setSifco] = useState("");
+  const [nombre, setNombre] = useState("");
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(20);
+
+  const query = useQuery({
+    queryKey: ["buckets-historial", desde, hasta, tipoEvento, bucketNuevo, sifco, nombre, page, pageSize],
+    queryFn: () =>
+      getBucketsHistorial({
+        desde: desde || undefined,
+        hasta: hasta || undefined,
+        tipo_evento: tipoEvento || undefined,
+        bucket_nuevo: bucketNuevo || undefined,
+        numero_credito_sifco: sifco || undefined,
+        nombre_usuario: nombre || undefined,
+        page,
+        pageSize,
+      }),
+    refetchOnWindowFocus: false,
+  });
+
+  const rows = query.data?.data ?? [];
+  const resumen = query.data?.resumen;
+  const pagination = query.data?.pagination;
+
+  const aplicar = () => {
+    setSifco(sifcoInput.trim());
+    setNombre(nombreInput.trim());
+    setPage(1);
+  };
+  const limpiar = () => {
+    setDesde(""); setHasta(""); setTipoEvento(""); setBucketNuevo("");
+    setSifcoInput(""); setNombreInput(""); setSifco(""); setNombre("");
+    setPage(1);
+  };
+  const filtros =
+    (desde ? 1 : 0) + (hasta ? 1 : 0) + (tipoEvento ? 1 : 0) +
+    (bucketNuevo ? 1 : 0) + (sifco ? 1 : 0) + (nombre ? 1 : 0);
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 overflow-auto bg-gradient-to-br from-indigo-50 to-white px-4 sm:px-6 lg:px-8 pt-8 pb-8">
+      <div className="w-full mx-auto">
+        <div className="flex flex-col items-center mb-6">
+          <h1 className="text-3xl font-extrabold text-indigo-800 text-center flex items-center gap-2">
+            <Layers className="h-7 w-7" /> Historial de Buckets
+          </h1>
+          <p className="text-gray-600 mt-2 text-center">
+            Subidas y bajadas de bucket registradas por el motor de cobros. Cada movimiento queda con su evento, cuotas y asesor.
+          </p>
+        </div>
+
+        {/* Filtros */}
+        <div className="bg-white/80 backdrop-blur rounded-2xl shadow-lg border border-indigo-100 p-5 mb-6">
+          <div className="flex flex-wrap items-end gap-4">
+            <div className="min-w-[145px]">
+              <label className="text-sm font-semibold text-indigo-800 mb-1 block">Desde</label>
+              <Input type="date" value={desde} onChange={(e) => { setDesde(e.target.value); setPage(1); }} className="text-gray-900 border-indigo-200 bg-indigo-50 [color-scheme:light]" />
+            </div>
+            <div className="min-w-[145px]">
+              <label className="text-sm font-semibold text-indigo-800 mb-1 block">Hasta</label>
+              <Input type="date" value={hasta} onChange={(e) => { setHasta(e.target.value); setPage(1); }} className="text-gray-900 border-indigo-200 bg-indigo-50 [color-scheme:light]" />
+            </div>
+            <div className="min-w-[140px]">
+              <label className="text-sm font-semibold text-indigo-800 mb-1 block">Evento</label>
+              <select className="w-full border border-indigo-200 rounded-lg px-3 py-2 text-sm text-indigo-800 bg-indigo-50 h-10" value={tipoEvento} onChange={(e) => { setTipoEvento(e.target.value); setPage(1); }}>
+                <option value="">Todos</option>
+                <option value="SUBIDA">Subidas</option>
+                <option value="BAJADA">Bajadas</option>
+                <option value="INICIAL">Iniciales</option>
+              </select>
+            </div>
+            <div className="min-w-[150px]">
+              <label className="text-sm font-semibold text-indigo-800 mb-1 block">Bucket destino</label>
+              <select className="w-full border border-indigo-200 rounded-lg px-3 py-2 text-sm text-indigo-800 bg-indigo-50 h-10" value={bucketNuevo} onChange={(e) => { setBucketNuevo(e.target.value); setPage(1); }}>
+                <option value="">Todos</option>
+                {catalogo.map((b) => (
+                  <option key={b.numero} value={String(b.numero)}>
+                    {b.prefijo} · {b.nombre}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="flex-1 min-w-[150px]">
+              <label className="text-sm font-semibold text-indigo-800 mb-1 block">No. SIFCO</label>
+              <Input placeholder="Buscar SIFCO..." value={sifcoInput} onChange={(e) => setSifcoInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && aplicar()} className="text-gray-900 border-indigo-200 bg-indigo-50" />
+            </div>
+            <div className="flex-1 min-w-[150px]">
+              <label className="text-sm font-semibold text-indigo-800 mb-1 block">Cliente</label>
+              <Input placeholder="Buscar nombre..." value={nombreInput} onChange={(e) => setNombreInput(e.target.value)} onKeyDown={(e) => e.key === "Enter" && aplicar()} className="text-gray-900 border-indigo-200 bg-indigo-50" />
+            </div>
+
+            <Button variant="outline" size="sm" onClick={aplicar} className="text-indigo-700 border-indigo-300 hover:bg-indigo-50">
+              <Search className="w-4 h-4 mr-1" /> Buscar
+            </Button>
+            {filtros > 0 && (
+              <Button variant="outline" size="sm" onClick={limpiar} className="text-gray-600 border-gray-300 hover:bg-gray-100">
+                <X className="w-4 h-4 mr-1" /> Limpiar <Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">{filtros}</Badge>
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* Resumen */}
+        {resumen && (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+            <div className="bg-white rounded-xl shadow border border-indigo-200 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium">Eventos</p>
+              <p className="text-lg font-bold text-indigo-700">{resumen.total.toLocaleString("es-GT")}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-red-100 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium flex items-center justify-center gap-1"><TrendingUp className="h-3 w-3" /> Subidas</p>
+              <p className="text-lg font-bold text-red-600">{resumen.subidas.toLocaleString("es-GT")}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-emerald-100 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium flex items-center justify-center gap-1"><TrendingDown className="h-3 w-3" /> Bajadas</p>
+              <p className="text-lg font-bold text-emerald-600">{resumen.bajadas.toLocaleString("es-GT")}</p>
+            </div>
+            <div className="bg-white rounded-xl shadow border border-blue-100 p-4 text-center">
+              <p className="text-xs text-gray-500 font-medium flex items-center justify-center gap-1"><Sparkles className="h-3 w-3" /> Iniciales</p>
+              <p className="text-lg font-bold text-blue-600">{resumen.iniciales.toLocaleString("es-GT")}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Tabla */}
+        {query.isLoading ? (
+          <div className="text-center py-16 text-indigo-400 font-semibold">Cargando...</div>
+        ) : query.isError ? (
+          <div className="text-center py-16 text-red-500 font-semibold">Error al cargar el historial de buckets</div>
+        ) : !rows.length ? (
+          <div className="text-center py-16 text-gray-400 font-semibold">No hay eventos para los filtros seleccionados</div>
+        ) : (
+          <>
+            <div className="bg-white rounded-2xl shadow-lg border border-indigo-100 overflow-x-auto">
+              <Table className="w-full">
+                <TableHeader>
+                  <TableRow className="bg-gradient-to-r from-indigo-50 to-indigo-100">
+                    <TableHead className="font-bold text-indigo-800">Fecha</TableHead>
+                    <TableHead className="font-bold text-indigo-800">No. SIFCO</TableHead>
+                    <TableHead className="font-bold text-indigo-800">Cliente</TableHead>
+                    <TableHead className="font-bold text-indigo-800 text-center">Evento</TableHead>
+                    <TableHead className="font-bold text-indigo-800 text-center">Transición</TableHead>
+                    <TableHead className="font-bold text-indigo-800 text-center">Cuotas</TableHead>
+                    <TableHead className="font-bold text-indigo-800">Asesor</TableHead>
+                    <TableHead className="font-bold text-indigo-800 text-center">Origen</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((r) => (
+                    <TableRow key={r.historial_id} className="hover:bg-indigo-50/40">
+                      <TableCell className="text-xs text-gray-600 whitespace-nowrap">{fmtFechaEvento(r.fecha)}</TableCell>
+                      <TableCell className="font-semibold">
+                        <Link to={`/pagos/${r.numero_credito_sifco}`} className="text-indigo-700 hover:underline" title="Ver pagos del crédito">
+                          {r.numero_credito_sifco}
+                        </Link>
+                      </TableCell>
+                      <TableCell className="text-black">{r.cliente}</TableCell>
+                      <TableCell className="text-center">
+                        <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold ${eventoBadge(r.tipo_evento)}`}>
+                          {eventoIcon(r.tipo_evento)} {r.tipo_evento}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-center">
+                        <span className="inline-flex items-center gap-1.5">
+                          <BucketBadge numero={r.bucket_anterior} porNumero={porNumero} />
+                          <ArrowRight className="h-3 w-3 text-gray-400" />
+                          <BucketBadge numero={r.bucket_nuevo} porNumero={porNumero} />
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-center text-black">{r.cuotas_atrasadas_nuevas ?? "—"}</TableCell>
+                      <TableCell className="text-black text-xs">{r.asesor || "—"}</TableCell>
+                      <TableCell className="text-center">
+                        <span className={`inline-flex px-2 py-0.5 rounded-full text-[10px] font-semibold ${origenBadgeClass(r.origen)}`} title={r.motivo ?? undefined}>
+                          {origenLabel(r.origen)}
+                        </span>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            <div className="flex flex-wrap items-center justify-between mt-5 gap-3">
+              <span className="text-sm text-gray-600">
+                Página {pagination?.page ?? 1} de {pagination?.totalPages ?? 1} ({pagination?.total ?? 0} eventos)
+              </span>
+              <div className="flex items-center gap-2">
+                <select className="border border-indigo-200 rounded-lg px-3 py-2 text-sm text-indigo-800 bg-indigo-50" value={pageSize} onChange={(e) => { setPageSize(Number(e.target.value)); setPage(1); }}>
+                  {[20, 50, 100].map((n) => <option key={n} value={n}>{n} por página</option>)}
+                </select>
+                <Button variant="outline" size="sm" disabled={page <= 1} onClick={() => setPage((p) => p - 1)} className="border-indigo-200 text-indigo-700"><ChevronLeft className="w-4 h-4" /></Button>
+                <Button variant="outline" size="sm" disabled={page >= (pagination?.totalPages ?? 1)} onClick={() => setPage((p) => p + 1)} className="border-indigo-200 text-indigo-700"><ChevronRight className="w-4 h-4" /></Button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default BucketsHistorial;

--- a/apps/carteraFront/src/private/cartera/components/bucketsUi.tsx
+++ b/apps/carteraFront/src/private/cartera/components/bucketsUi.tsx
@@ -45,13 +45,22 @@ export function BucketBadge({
   );
 }
 
-// Fecha del evento: mismo criterio que el resto de la app (slice del string
-// que manda el back), con hora — el job corre a fin de día y la hora ubica.
+// Fecha del evento en día GUATEMALA (review Codex): los filtros desde/hasta de
+// estos endpoints cortan por día GT, y el job corre ~23:59 GT (~05:59 UTC del
+// día siguiente) — mostrar el slice UTC descuadraba la fecha visible contra el
+// filtro que incluyó el evento. en-CA da YYYY-MM-DD; si no parsea, slice crudo.
 export const fmtFechaEvento = (v: string) => {
   const s = String(v ?? "");
-  const fecha = s.slice(0, 10);
-  const hora = s.slice(11, 16);
-  return hora ? `${fecha} ${hora}` : fecha;
+  const d = new Date(s);
+  if (Number.isNaN(d.getTime())) return s.slice(0, 16).replace("T", " ");
+  const fecha = d.toLocaleDateString("en-CA", { timeZone: "America/Guatemala" });
+  const hora = d.toLocaleTimeString("es-GT", {
+    timeZone: "America/Guatemala",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  return `${fecha} ${hora}`;
 };
 
 export const origenLabel = (origen: string) =>

--- a/apps/carteraFront/src/private/cartera/components/bucketsUi.tsx
+++ b/apps/carteraFront/src/private/cartera/components/bucketsUi.tsx
@@ -1,0 +1,63 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getBucketsCatalogo,
+  type BucketCatalogo,
+} from "../services/buckets.services";
+
+// ─── COBROS-02 · piezas compartidas de los módulos de Buckets (temporales) ───
+
+// Catálogo B0-B5 cacheado: los badges pintan con el color REAL del catálogo.
+export function useBucketsCatalogo() {
+  const { data } = useQuery({
+    queryKey: ["buckets-catalogo"],
+    queryFn: getBucketsCatalogo,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+  const catalogo = data?.data ?? [];
+  const porNumero = new Map<number, BucketCatalogo>(
+    catalogo.map((b) => [b.numero, b])
+  );
+  return { catalogo, porNumero };
+}
+
+// Badge de bucket con el color del catálogo (fondo suave + texto del color).
+export function BucketBadge({
+  numero,
+  porNumero,
+}: {
+  numero: number | null;
+  porNumero: Map<number, BucketCatalogo>;
+}) {
+  if (numero === null || numero === undefined) {
+    return <span className="text-gray-400 text-xs">—</span>;
+  }
+  const b = porNumero.get(numero);
+  const color = b?.color || "#64748b";
+  return (
+    <span
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-bold whitespace-nowrap border"
+      style={{ color, borderColor: `${color}55`, backgroundColor: `${color}1A` }}
+      title={b ? `${b.prefijo} · ${b.nombre}` : `Bucket ${numero}`}
+    >
+      {b?.prefijo ?? `B${numero}`}
+    </span>
+  );
+}
+
+// Fecha del evento: mismo criterio que el resto de la app (slice del string
+// que manda el back), con hora — el job corre a fin de día y la hora ubica.
+export const fmtFechaEvento = (v: string) => {
+  const s = String(v ?? "");
+  const fecha = s.slice(0, 10);
+  const hora = s.slice(11, 16);
+  return hora ? `${fecha} ${hora}` : fecha;
+};
+
+export const origenLabel = (origen: string) =>
+  origen === "PROCESO_AUTO" ? "Automático" : origen === "API_MANUAL" ? "Manual" : origen;
+
+export const origenBadgeClass = (origen: string) =>
+  origen === "PROCESO_AUTO"
+    ? "bg-slate-100 text-slate-600"
+    : "bg-amber-100 text-amber-800";

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -20,6 +20,8 @@ import {
   Wallet,
   PiggyBank,
   Shield,
+  Layers,
+  UserCog,
 } from "lucide-react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useState, useRef, useEffect } from "react";
@@ -125,6 +127,28 @@ const menuSections: MenuSection[] = [
         icon: <Shield className="h-4 w-4" />,
         path: "/seguros",
         roles: ["ADMIN"],
+      },
+    ],
+  },
+  {
+    // COBROS-02: módulos temporales de auditoría del motor de buckets.
+    key: "buckets",
+    label: "Buckets",
+    icon: <Layers className="h-4 w-4" />,
+    items: [
+      {
+        key: "buckets-historial",
+        label: "Historial de Buckets",
+        icon: <Layers className="h-4 w-4" />,
+        path: "/buckets-historial",
+        roles: ["ADMIN", "CONTA"],
+      },
+      {
+        key: "buckets-asesores",
+        label: "Cambios de Asesor",
+        icon: <UserCog className="h-4 w-4" />,
+        path: "/buckets-asesores",
+        roles: ["ADMIN", "CONTA"],
       },
     ],
   },

--- a/apps/carteraFront/src/private/cartera/services/buckets.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/buckets.services.ts
@@ -1,0 +1,124 @@
+import api from "@/Provider/interceptor";
+
+const API_URL = import.meta.env.VITE_BACK_URL || "";
+
+// ─── COBROS-02 · Buckets (módulos temporales de auditoría del motor) ─────────
+
+export interface BucketCatalogo {
+  numero: number;
+  prefijo: string;
+  nombre: string;
+  descripcion: string | null;
+  cuotas_min: number | null;
+  cuotas_max: number | null;
+  color: string | null;
+}
+
+// Catálogo dinámico B0-B5 (fuente única: cartera-back). Los badges usan el
+// color REAL del catálogo, no un mapeo hardcodeado en el front.
+export const getBucketsCatalogo = async (): Promise<{
+  success: boolean;
+  data: BucketCatalogo[];
+}> => {
+  const { data } = await api.get(`${API_URL}/config/buckets`);
+  return data;
+};
+
+export interface BucketEventoRow {
+  historial_id: number;
+  fecha: string;
+  credito_id: number;
+  numero_credito_sifco: string;
+  cliente: string;
+  asesor_id: number | null;
+  asesor: string | null;
+  tipo_evento: "INICIAL" | "SUBIDA" | "BAJADA";
+  origen: string;
+  bucket_anterior: number | null;
+  bucket_anterior_prefijo: string | null;
+  bucket_anterior_nombre: string | null;
+  bucket_nuevo: number;
+  bucket_nuevo_prefijo: string | null;
+  bucket_nuevo_nombre: string | null;
+  cuotas_atrasadas_nuevas: number | null;
+  status_credito: string | null;
+  status_actual: string;
+  capital: string;
+  asesor_atribucion_id: number | null;
+  asesor_atribucion: string | null;
+  pago_id: number | null;
+  motivo: string | null;
+}
+
+export interface BucketsHistorialResponse {
+  success: boolean;
+  data: BucketEventoRow[];
+  pagination: { page: number; pageSize: number; total: number; totalPages: number };
+  resumen: { total: number; iniciales: number; subidas: number; bajadas: number };
+}
+
+export interface BucketsHistorialParams {
+  desde?: string;
+  hasta?: string;
+  tipo_evento?: string; // CSV: INICIAL,SUBIDA,BAJADA
+  origen?: string; // PROCESO_AUTO | API_MANUAL
+  bucket_nuevo?: string; // CSV de enteros
+  numero_credito_sifco?: string;
+  nombre_usuario?: string;
+  asesor?: string; // CSV de nombres
+  page?: number;
+  pageSize?: number;
+}
+
+export const getBucketsHistorial = async (
+  params: BucketsHistorialParams
+): Promise<BucketsHistorialResponse> => {
+  const { data } = await api.get(`${API_URL}/buckets/historial`, { params });
+  return data;
+};
+
+export interface AsesorCambioRow {
+  historial_id: number;
+  fecha: string;
+  credito_id: number;
+  numero_credito_sifco: string;
+  cliente: string;
+  asesor_anterior_id: number | null;
+  asesor_anterior: string | null;
+  asesor_nuevo_id: number | null;
+  asesor_nuevo: string | null;
+  bucket: number | null;
+  bucket_prefijo: string | null;
+  bucket_nombre: string | null;
+  origen: string;
+  motivo: string | null;
+  usuario: string | null;
+  status_actual: string;
+}
+
+export interface AsesorHistorialResponse {
+  success: boolean;
+  data: AsesorCambioRow[];
+  pagination: { page: number; pageSize: number; total: number; totalPages: number };
+  resumen: { total: number; automaticos: number; manuales: number; creditos: number };
+}
+
+export interface AsesorHistorialParams {
+  desde?: string;
+  hasta?: string;
+  origen?: string; // PROCESO_AUTO | API_MANUAL
+  bucket?: string; // CSV de enteros (snapshot)
+  asesor_nuevo?: string; // CSV de nombres
+  asesor_anterior?: string; // CSV de nombres
+  numero_credito_sifco?: string;
+  nombre_usuario?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export const getAsesorHistorial = async (
+  params: AsesorHistorialParams
+): Promise<AsesorHistorialResponse> => {
+  const { data } = await api.get(`${API_URL}/buckets/asesores-historial`, { params });
+  return data;
+};


### PR DESCRIPTION
## Qué hace

Agrega el módulo **Buckets** a la navbar de cartera front (temporal, para auditar el motor de COBROS-02 mientras se prueba) con dos submódulos, y el endpoint que faltaba en cartera-back.

### cartera-back
- **`GET /buckets/asesores-historial`** (nuevo): bitácora de `credito_asesor_historial` paginada — quién llevaba el crédito, quién lo lleva, bucket snapshot, origen, motivo y usuario (solo API_MANUAL). Filtros: `desde/hasta` (día GT), `origen`, `bucket` (CSV), `asesor_nuevo/anterior` (CSV ILIKE), SIFCO, cliente. Resumen: total / automáticos / manuales / créditos afectados.
- Controller [`asesorHistorial.ts`](../blob/feat/cobros02-buckets-front-modulos/apps/cartera-back/src/controllers/buckets/asesorHistorial.ts) espejo de `bucketsHistorial.ts`: mismos criterios (fecha por día Guatemala, clamp de paginación floor-primero) y misma validación estricta en el router (tokens inválidos → 400, nunca descartar en silencio).
- Gate server-side ADMIN/CONTA, igual que el resto de `/buckets/*`.

### carteraFront
- Navbar: sección **Buckets** (ADMIN/CONTA) con dos entradas.
- **`/buckets-historial`** — Historial de Buckets: subidas y bajadas del motor (consume `/buckets/historial` existente). Resumen (eventos/subidas/bajadas/iniciales), transición `B2 → B1` en badges, filtros por fecha/evento/bucket destino/SIFCO/cliente.
- **`/buckets-asesores`** — Cambios de Asesor: `asesor anterior → asesor nuevo`, bucket del cambio, origen (Automático/Manual), motivo y usuario. Resumen (cambios/automáticos/manuales/créditos afectados).
- Los badges de bucket usan el **color real del catálogo** (`GET /config/buckets`), no un mapeo hardcodeado ([`bucketsUi.tsx`](../blob/feat/cobros02-buckets-front-modulos/apps/carteraFront/src/private/cartera/components/bucketsUi.tsx) compartido).
- El No. SIFCO linkea a `/pagos/:numero_credito_sifco`.
- Ancho completo de pantalla; scroll horizontal solo como fallback.

## Cómo se probó
- SQL del endpoint nuevo validado directo contra la sandbox (`cartera_cobros2`): 1,213 cambios (1,193 de la carga inicial por script + 20 reasignaciones reales del motor), datos cuadran con lo que muestran los módulos.
- Probado en vivo en local contra la sandbox: filtros, paginación, links a pagos y colores del catálogo.
- `tsc --noEmit` limpio en los archivos nuevos de ambos apps (los errores restantes son preexistentes).

## Notas
- Módulos marcados como temporales (comentario en navbar y rutas): son la ventana de auditoría mientras el rediseño avanza.
- "Manuales" incluye la carga inicial por script (se insertó con `origen='API_MANUAL'` y motivo "Asignación inicial por bucket — carga COBROS-02 (SQL)"); las del motor van como Automático.

🤖 Generated with [Claude Code](https://claude.com/claude-code)