### PR TITLE
release: liquidación devolución créditos VERIFICADO + mora cobrada por asesor

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4228,167 +4228,190 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
         }
 
         // ========================================
-        // FASE 5: SALIDA AUTOMÁTICA (pendiente_devolucion)
-        // Si el inversionista quedó marcado como `pendiente_devolucion`,
-        // se ejecuta exitInvestor sobre los créditos con pagos liquidados
-        // en esta corrida. exitInvestor traslada la participación a CUBE
-        // y marca al inversionista como `inactivo`. Como salvaguarda,
-        // forzamos el status a `inactivo` después.
+        // FASE 5: SALIDA AUTOMÁTICA — dos caminos MUTUAMENTE EXCLUYENTES:
+        //  RAMA 1 (inversionista pendiente_devolucion): salida total. exitInvestor
+        //    sobre TODOS los créditos con pagos, sin flag → correo + inactiva.
+        //  RAMA 2 (resto): devolución de créditos VERIFICADO individuales.
+        //    exitInvestor con skipStatusAndEmail (sin correo, no inactiva) y
+        //    validación de monto_aportado==0 en espejo antes de mover a CUBE.
+        // Al ser excluyentes, ningún crédito pasa por exitInvestor dos veces.
         // ========================================
         try {
-          // 5A) Salida automática por créditos con devolucion_cube=true
-          //     (independiente del status del inversionista)
           const creditoIdsConPagos = [
             ...new Set(pagosNoLiquidados.map((p) => p.credito_id)),
           ];
-          // Créditos excluidos de exitInvestor en 5A por monto_aportado pendiente
-          // en el espejo — 5C debe respetarlos y NO marcarlos COMPLETADO.
-          let creditoIdsConMontoPendiente: number[] = [];
 
           if (creditoIdsConPagos.length > 0) {
-            const creditosConDevolucion = await db
-              .select({ credito_id: creditos.credito_id })
-              .from(creditos)
-              .where(
-                and(
-                  inArray(creditos.credito_id, creditoIdsConPagos),
-                  eq(creditos.estado_devolucion, 'VERIFICADO')
-                )
-              );
+            const [invRow] = await db
+              .select({ status: inversionistas.status })
+              .from(inversionistas)
+              .where(eq(inversionistas.inversionista_id, inv_id))
+              .limit(1);
 
-            const creditoIdsDevolucion = creditosConDevolucion.map((c) => c.credito_id);
-
-            if (creditoIdsDevolucion.length > 0) {
+            if (invRow?.status === "pendiente_devolucion") {
+              // ── RAMA 1: SALIDA TOTAL DEL INVERSIONISTA ──
+              // Todo se devuelve a CUBE. exitInvestor SIN flag → manda correo
+              // e inactiva al inversionista. Sin validación de monto porque es
+              // una salida completa (no una devolución de crédito individual).
               console.log(
-                `  🚪 Inversionista ${inv_id} → exitInvestor por estado_devolucion=VERIFICADO en ${creditoIdsDevolucion.length} crédito(s)`
+                `  🚪 Inversionista ${inv_id} en pendiente_devolucion → exitInvestor (salida total) sobre ${creditoIdsConPagos.length} crédito(s)`
               );
 
-              // Validación previa: el monto_aportado del inversionista en el espejo
-              // debería estar en 0 en este punto (ya liquidado por el loop de pagos).
-              // Los créditos que no cumplan se skippean (no entran a exitInvestor,
-              // no se marcan COMPLETADO) para revisión manual.
-              const filasEspejoPrevias = await db
-                .select({
-                  credito_id: creditos_inversionistas_espejo.credito_id,
-                  monto_aportado: creditos_inversionistas_espejo.monto_aportado,
-                })
-                .from(creditos_inversionistas_espejo)
-                .where(
-                  and(
-                    inArray(creditos_inversionistas_espejo.credito_id, creditoIdsDevolucion),
-                    eq(creditos_inversionistas_espejo.inversionista_id, inv_id)
-                  )
-                );
-
-              creditoIdsConMontoPendiente = filasEspejoPrevias
-                .filter((f) => Number(f.monto_aportado) !== 0)
-                .map((f) => f.credito_id);
-
-              if (creditoIdsConMontoPendiente.length > 0) {
-                console.warn(
-                  `  ⚠️  monto_aportado en espejo != 0 antes de exitInvestor para inversionista ${inv_id} — se omiten:`,
-                  filasEspejoPrevias
-                    .filter((f) => creditoIdsConMontoPendiente.includes(f.credito_id))
-                    .map((f) => `credito_id=${f.credito_id} monto_aportado=${f.monto_aportado}`)
-                    .join(", ")
-                );
-              }
-
-              const creditoIdsDevolucionValidos = creditoIdsDevolucion.filter(
-                (id) => !creditoIdsConMontoPendiente.includes(id)
-              );
-
-              if (creditoIdsDevolucionValidos.length > 0) {
-                const exitResultDevolucion = await exitInvestor({
-                  body: {
-                    inversionista_id: inv_id,
-                    creditos: creditoIdsDevolucionValidos,
-                    skipStatusAndEmail: true,
-                  },
-                  set: { status: 200 },
-                  request: {} as any,
-                });
-
-                // Después de separar en exitInvestor, dejar estado_devolucion en COMPLETADO
-                await db
-                  .update(creditos)
-                  .set({ estado_devolucion: "COMPLETADO" })
-                  .where(inArray(creditos.credito_id, creditoIdsDevolucionValidos));
-
-                console.log(`  ✅ Salida por estado_devolucion=VERIFICADO ejecutada y créditos reseteados a COMPLETADO:`, exitResultDevolucion);
-              }
-            }
-          }
-
-          const [invRow] = await db
-            .select({ status: inversionistas.status })
-            .from(inversionistas)
-            .where(eq(inversionistas.inversionista_id, inv_id))
-            .limit(1);
-
-          if (invRow?.status === "pendiente_devolucion") {
-            const creditoIdsSalida = [
-              ...new Set(pagosNoLiquidados.map((p) => p.credito_id)),
-            ];
-
-            if (creditoIdsSalida.length > 0) {
-              console.log(
-                `  🚪 Inversionista ${inv_id} en pendiente_devolucion → exitInvestor sobre ${creditoIdsSalida.length} crédito(s)`
-              );
-
-              const exitResult = await exitInvestor({
+              const exitResult: any = await exitInvestor({
                 body: {
                   inversionista_id: inv_id,
-                  creditos: creditoIdsSalida,
+                  creditos: creditoIdsConPagos,
                 },
                 set: { status: 200 },
                 request: {} as any,
               });
 
-              console.log(`  ✅ Salida ejecutada:`, exitResult);
+              if (!exitResult?.success) {
+                // exitInvestor falló por completo: no se transfirió nada. No se
+                // marca inactivo ni COMPLETADO — todo queda como estaba para revisión.
+                console.error(
+                  `  ❌ exitInvestor (salida total) falló para inversionista ${inv_id} — no se marca inactivo ni COMPLETADO:`,
+                  exitResult?.message ?? exitResult
+                );
+              } else {
+                console.log(`  ✅ Salida total ejecutada:`, exitResult);
 
-              await db
-                .update(inversionistas)
-                .set({ status: "inactivo" })
-                .where(eq(inversionistas.inversionista_id, inv_id));
+                await db
+                  .update(inversionistas)
+                  .set({ status: "inactivo" })
+                  .where(eq(inversionistas.inversionista_id, inv_id));
 
-              console.log(`  ✅ Inversionista ${inv_id} marcado como inactivo`);
+                console.log(`  ✅ Inversionista ${inv_id} marcado como inactivo`);
+
+                // Solo los créditos realmente transferidos por exitInvestor y que
+                // estaban VERIFICADO pasan a COMPLETADO (no la lista de entrada).
+                const creditoIdsProcesados: number[] = (exitResult.creditos_procesados ?? []).map(
+                  (r: any) => r.credito_id
+                );
+
+                if (creditoIdsProcesados.length > 0) {
+                  await db
+                    .update(creditos)
+                    .set({ estado_devolucion: "COMPLETADO" })
+                    .where(
+                      and(
+                        inArray(creditos.credito_id, creditoIdsProcesados),
+                        eq(creditos.estado_devolucion, "VERIFICADO")
+                      )
+                    );
+
+                  console.log(
+                    `  ✅ Créditos VERIFICADO reseteados a COMPLETADO tras salida total del inversionista ${inv_id}`
+                  );
+                }
+
+                if (Array.isArray(exitResult.errores) && exitResult.errores.length > 0) {
+                  console.warn(
+                    `  ⚠️  exitInvestor (salida total) tuvo ${exitResult.errores.length} crédito(s) con error — no marcados COMPLETADO:`,
+                    exitResult.errores
+                  );
+                }
+              }
             } else {
-              console.warn(
-                `  ⚠️ Inversionista ${inv_id} pendiente_devolucion pero sin créditos con pagos en esta corrida; se omite exitInvestor`
-              );
-            }
-          }
-
-          // 5C) Regla de cierre: tras liquidar, cualquier estado de devolución
-          // del/los crédito(s) procesado(s) pasa a COMPLETADO (solo si ya estaba VERIFICADO).
-          // Se excluyen los créditos que 5A dejó fuera por monto_aportado pendiente
-          // en el espejo — deben seguir en VERIFICADO para revisión manual.
-          if (creditoIdsConPagos.length > 0) {
-            const creditoIdsParaCierre = creditoIdsConPagos.filter(
-              (id) => !creditoIdsConMontoPendiente.includes(id)
-            );
-
-            if (creditoIdsParaCierre.length > 0) {
-              await db
-                .update(creditos)
-                .set({ estado_devolucion: "COMPLETADO" })
+              // ── RAMA 2: DEVOLUCIÓN DE CRÉDITOS VERIFICADO INDIVIDUALES ──
+              // El inversionista NO sale por completo; solo los créditos marcados
+              // VERIFICADO se devuelven a CUBE. exitInvestor CON flag → no correo,
+              // no inactiva. Se valida que monto_aportado==0 en espejo antes de mover.
+              const creditosConDevolucion = await db
+                .select({ credito_id: creditos.credito_id })
+                .from(creditos)
                 .where(
                   and(
-                    inArray(creditos.credito_id, creditoIdsParaCierre),
-                    eq(creditos.estado_devolucion, "VERIFICADO")
+                    inArray(creditos.credito_id, creditoIdsConPagos),
+                    eq(creditos.estado_devolucion, 'VERIFICADO')
                   )
                 );
 
-              console.log(
-                `  ✅ Estado devolución actualizado a COMPLETADO en ${creditoIdsParaCierre.length} crédito(s) procesado(s) en liquidación`
-              );
-            }
+              const creditoIdsDevolucion = creditosConDevolucion.map((c) => c.credito_id);
 
-            if (creditoIdsConMontoPendiente.length > 0) {
-              console.warn(
-                `  ⚠️  ${creditoIdsConMontoPendiente.length} crédito(s) excluidos de COMPLETADO por monto_aportado pendiente en espejo: [${creditoIdsConMontoPendiente.join(", ")}]`
-              );
+              if (creditoIdsDevolucion.length > 0) {
+                console.log(
+                  `  🚪 Inversionista ${inv_id} → exitInvestor por estado_devolucion=VERIFICADO en ${creditoIdsDevolucion.length} crédito(s)`
+                );
+
+                // Validación previa: el monto_aportado del inversionista en el espejo
+                // debería estar en 0 en este punto (ya liquidado por el loop de pagos).
+                // Los créditos que no cumplan se skippean (no entran a exitInvestor,
+                // no se marcan COMPLETADO) para revisión manual.
+                const filasEspejoPrevias = await db
+                  .select({
+                    credito_id: creditos_inversionistas_espejo.credito_id,
+                    monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+                  })
+                  .from(creditos_inversionistas_espejo)
+                  .where(
+                    and(
+                      inArray(creditos_inversionistas_espejo.credito_id, creditoIdsDevolucion),
+                      eq(creditos_inversionistas_espejo.inversionista_id, inv_id)
+                    )
+                  );
+
+                const creditoIdsConMontoPendiente = filasEspejoPrevias
+                  .filter((f) => Number(f.monto_aportado) !== 0)
+                  .map((f) => f.credito_id);
+
+                if (creditoIdsConMontoPendiente.length > 0) {
+                  console.warn(
+                    `  ⚠️  monto_aportado en espejo != 0 antes de exitInvestor para inversionista ${inv_id} — se omiten:`,
+                    filasEspejoPrevias
+                      .filter((f) => creditoIdsConMontoPendiente.includes(f.credito_id))
+                      .map((f) => `credito_id=${f.credito_id} monto_aportado=${f.monto_aportado}`)
+                      .join(", ")
+                  );
+                }
+
+                const creditoIdsDevolucionValidos = creditoIdsDevolucion.filter(
+                  (id) => !creditoIdsConMontoPendiente.includes(id)
+                );
+
+                if (creditoIdsDevolucionValidos.length > 0) {
+                  const exitResultDevolucion: any = await exitInvestor({
+                    body: {
+                      inversionista_id: inv_id,
+                      creditos: creditoIdsDevolucionValidos,
+                      skipStatusAndEmail: true,
+                    },
+                    set: { status: 200 },
+                    request: {} as any,
+                  });
+
+                  if (!exitResultDevolucion?.success) {
+                    // exitInvestor falló por completo: no se transfirió nada. No se
+                    // marca COMPLETADO — los créditos quedan en VERIFICADO para revisión.
+                    console.error(
+                      `  ❌ exitInvestor (devolución VERIFICADO) falló para inversionista ${inv_id} — no se marca COMPLETADO:`,
+                      exitResultDevolucion?.message ?? exitResultDevolucion
+                    );
+                  } else {
+                    // Solo los créditos realmente transferidos por exitInvestor pasan
+                    // a COMPLETADO (no la lista de entrada).
+                    const creditoIdsProcesados: number[] = (exitResultDevolucion.creditos_procesados ?? []).map(
+                      (r: any) => r.credito_id
+                    );
+
+                    if (creditoIdsProcesados.length > 0) {
+                      await db
+                        .update(creditos)
+                        .set({ estado_devolucion: "COMPLETADO" })
+                        .where(inArray(creditos.credito_id, creditoIdsProcesados));
+
+                      console.log(`  ✅ Salida por estado_devolucion=VERIFICADO ejecutada y créditos reseteados a COMPLETADO:`, exitResultDevolucion);
+                    }
+
+                    if (Array.isArray(exitResultDevolucion.errores) && exitResultDevolucion.errores.length > 0) {
+                      console.warn(
+                        `  ⚠️  exitInvestor (devolución VERIFICADO) tuvo ${exitResultDevolucion.errores.length} crédito(s) con error — quedan en VERIFICADO:`,
+                        exitResultDevolucion.errores
+                      );
+                    }
+                  }
+                }
+              }
             }
           }
         } catch (exitError) {

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4351,34 +4351,53 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
                     )
                   );
 
-                const creditoIdsConMontoPendiente = filasEspejoPrevias
-                  .filter((f) => Number(f.monto_aportado) !== 0)
-                  .map((f) => f.credito_id);
+                // Un crédito solo es válido si tiene fila en el espejo para este
+                // inversionista Y su monto_aportado es 0. Se excluye tanto el que
+                // tiene monto != 0 como el que NO tiene fila espejo (estado anómalo:
+                // exitInvestor trataría la fila faltante como no-fatal y movería el
+                // padre igual, saltándose el safeguard). Los excluidos quedan en
+                // VERIFICADO para revisión manual.
+                const creditoIdsConEspejoEnCero = new Set(
+                  filasEspejoPrevias
+                    .filter((f) => Number(f.monto_aportado) === 0)
+                    .map((f) => f.credito_id)
+                );
+
+                const creditoIdsDevolucionValidos = creditoIdsDevolucion.filter((id) =>
+                  creditoIdsConEspejoEnCero.has(id)
+                );
+                const creditoIdsConMontoPendiente = creditoIdsDevolucion.filter(
+                  (id) => !creditoIdsConEspejoEnCero.has(id)
+                );
 
                 if (creditoIdsConMontoPendiente.length > 0) {
+                  const montoPorCredito = new Map(
+                    filasEspejoPrevias.map((f) => [f.credito_id, f.monto_aportado])
+                  );
                   console.warn(
-                    `  ⚠️  monto_aportado en espejo != 0 antes de exitInvestor para inversionista ${inv_id} — se omiten:`,
-                    filasEspejoPrevias
-                      .filter((f) => creditoIdsConMontoPendiente.includes(f.credito_id))
-                      .map((f) => `credito_id=${f.credito_id} monto_aportado=${f.monto_aportado}`)
+                    `  ⚠️  créditos con espejo inválido (monto != 0 o sin fila) antes de exitInvestor para inversionista ${inv_id} — se omiten:`,
+                    creditoIdsConMontoPendiente
+                      .map((id) =>
+                        montoPorCredito.has(id)
+                          ? `credito_id=${id} monto_aportado=${montoPorCredito.get(id)}`
+                          : `credito_id=${id} SIN_FILA_ESPEJO`
+                      )
                       .join(", ")
                   );
                 }
 
-                const creditoIdsDevolucionValidos = creditoIdsDevolucion.filter(
-                  (id) => !creditoIdsConMontoPendiente.includes(id)
-                );
-
                 if (creditoIdsDevolucionValidos.length > 0) {
-                  const exitResultDevolucion: any = await exitInvestor({
-                    body: {
-                      inversionista_id: inv_id,
-                      creditos: creditoIdsDevolucionValidos,
-                      skipStatusAndEmail: true,
+                  const exitResultDevolucion: any = await exitInvestor(
+                    {
+                      body: {
+                        inversionista_id: inv_id,
+                        creditos: creditoIdsDevolucionValidos,
+                      },
+                      set: { status: 200 },
+                      request: {} as any,
                     },
-                    set: { status: 200 },
-                    request: {} as any,
-                  });
+                    { skipStatusAndEmail: true }
+                  );
 
                   if (!exitResultDevolucion?.success) {
                     // exitInvestor falló por completo: no se transfirió nada. No se
@@ -5372,7 +5391,15 @@ const CUBE_INVESTMENT_ID = 86;
 // - 404: inversionista no encontrado.
 // - 500: error inesperado (la transacción hace rollback).
 // ============================================================================
-export const exitInvestor = async ({ body, set, request }: any) => {
+// El segundo argumento `opts` NO viene del body HTTP — solo lo pueden pasar
+// las llamadas internas (ver liquidateByInvestorId). El router pasa únicamente
+// el contexto de Elysia, así que un caller HTTP nunca puede setear
+// skipStatusAndEmail, sin importar props extra en el body.
+export const exitInvestor = async (
+  { body, set, request }: any,
+  opts: { skipStatusAndEmail?: boolean } = {}
+) => {
+  const skipStatusAndEmail = opts.skipStatusAndEmail === true;
   // ── Helper de logging con prefijo único por request ──
   // runId: 6 chars alfanuméricos en mayúsculas, para hilar logs de un
   // mismo request cuando hay múltiples corriendo en paralelo.
@@ -5392,13 +5419,7 @@ export const exitInvestor = async ({ body, set, request }: any) => {
     // ========================================================================
     // Se valida manualmente (Elysia ya valida el schema a nivel router, pero
     // acá defendemos por si se llama internamente sin pasar por el router).
-    //
-    // skipStatusAndEmail: SOLO para llamadas internas (ver liquidateByInvestorId).
-    // El schema del router (routers/investor.ts) NO declara este campo, así que
-    // Elysia lo descarta en /investor/exit — un caller HTTP no puede activarlo.
-    // Si algún día se agrega al schema del router, revisar que siga sin ser
-    // controlable por clientes externos.
-    const { inversionista_id, creditos: creditoIds, skipStatusAndEmail } = body ?? {};
+    const { inversionista_id, creditos: creditoIds } = body ?? {};
 
     if (typeof inversionista_id !== "number" || !Number.isFinite(inversionista_id)) {
       warn("❌ Validación falló: inversionista_id inválido →", inversionista_id);

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4241,6 +4241,9 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
           const creditoIdsConPagos = [
             ...new Set(pagosNoLiquidados.map((p) => p.credito_id)),
           ];
+          // Créditos excluidos de exitInvestor en 5A por monto_aportado pendiente
+          // en el espejo — 5C debe respetarlos y NO marcarlos COMPLETADO.
+          let creditoIdsConMontoPendiente: number[] = [];
 
           if (creditoIdsConPagos.length > 0) {
             const creditosConDevolucion = await db
@@ -4277,7 +4280,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
                   )
                 );
 
-              const creditoIdsConMontoPendiente = filasEspejoPrevias
+              creditoIdsConMontoPendiente = filasEspejoPrevias
                 .filter((f) => Number(f.monto_aportado) !== 0)
                 .map((f) => f.credito_id);
 
@@ -4359,20 +4362,34 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
 
           // 5C) Regla de cierre: tras liquidar, cualquier estado de devolución
           // del/los crédito(s) procesado(s) pasa a COMPLETADO (solo si ya estaba VERIFICADO).
+          // Se excluyen los créditos que 5A dejó fuera por monto_aportado pendiente
+          // en el espejo — deben seguir en VERIFICADO para revisión manual.
           if (creditoIdsConPagos.length > 0) {
-            await db
-              .update(creditos)
-              .set({ estado_devolucion: "COMPLETADO" })
-              .where(
-                and(
-                  inArray(creditos.credito_id, creditoIdsConPagos),
-                  eq(creditos.estado_devolucion, "VERIFICADO")
-                )
-              );
-
-            console.log(
-              `  ✅ Estado devolución actualizado a COMPLETADO en ${creditoIdsConPagos.length} crédito(s) procesado(s) en liquidación`
+            const creditoIdsParaCierre = creditoIdsConPagos.filter(
+              (id) => !creditoIdsConMontoPendiente.includes(id)
             );
+
+            if (creditoIdsParaCierre.length > 0) {
+              await db
+                .update(creditos)
+                .set({ estado_devolucion: "COMPLETADO" })
+                .where(
+                  and(
+                    inArray(creditos.credito_id, creditoIdsParaCierre),
+                    eq(creditos.estado_devolucion, "VERIFICADO")
+                  )
+                );
+
+              console.log(
+                `  ✅ Estado devolución actualizado a COMPLETADO en ${creditoIdsParaCierre.length} crédito(s) procesado(s) en liquidación`
+              );
+            }
+
+            if (creditoIdsConMontoPendiente.length > 0) {
+              console.warn(
+                `  ⚠️  ${creditoIdsConMontoPendiente.length} crédito(s) excluidos de COMPLETADO por monto_aportado pendiente en espejo: [${creditoIdsConMontoPendiente.join(", ")}]`
+              );
+            }
           }
         } catch (exitError) {
           console.error(

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -6086,8 +6086,13 @@ export const exitInvestor = async (
       log(`📧 Correos: enviados=${enviados}, fallidos=${fallidos}`);
     }
 
+    // Cuando skipStatusAndEmail=true no se cambió el status: el inversionista
+    // sigue con el que tenía (invRow.status). Solo pasó a "inactivo" en el
+    // camino normal.
+    const statusFinal = skipStatusAndEmail ? invRow.status : "inactivo";
+
     log(`⏱️  Duración total: ${Date.now() - t0}ms`);
-    log(`✅ DONE — inversionista ${invRow.inversionista_id} inactivado, ${resultados.length} crédito(s), Q${totalTransferido.toFixed(2)} a CUBE`);
+    log(`✅ DONE — inversionista ${invRow.inversionista_id} (status=${statusFinal}), ${resultados.length} crédito(s), Q${totalTransferido.toFixed(2)} a CUBE`);
     log("═══════════════════════════════════════════════════════════");
 
     // ========================================================================
@@ -6099,8 +6104,10 @@ export const exitInvestor = async (
     set.status = 200;
     return {
       success: true,
-      message: `Inversionista inactivado. ${resultados.length} crédito(s) transferido(s) a CUBE. Total: Q${totalTransferido.toFixed(2)}.`,
-      inversionista: { inversionista_id: invRow.inversionista_id, nombre: invRow.nombre, status: "inactivo" },
+      message: skipStatusAndEmail
+        ? `${resultados.length} crédito(s) transferido(s) a CUBE. Total: Q${totalTransferido.toFixed(2)}. (status del inversionista sin cambios)`
+        : `Inversionista inactivado. ${resultados.length} crédito(s) transferido(s) a CUBE. Total: Q${totalTransferido.toFixed(2)}.`,
+      inversionista: { inversionista_id: invRow.inversionista_id, nombre: invRow.nombre, status: statusFinal },
       total_transferido_a_cube: totalTransferido.toFixed(2),
       creditos_procesados: resultados,
       errores,

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4264,6 +4264,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
                 body: {
                   inversionista_id: inv_id,
                   creditos: creditoIdsDevolucion,
+                  skipStatusAndEmail: true,
                 },
                 set: { status: 200 },
                 request: {} as any,
@@ -4299,6 +4300,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
                 body: {
                   inversionista_id: inv_id,
                   creditos: creditoIdsSalida,
+                  skipStatusAndEmail: true,
                 },
                 set: { status: 200 },
                 request: {} as any,
@@ -5314,7 +5316,13 @@ export const exitInvestor = async ({ body, set, request }: any) => {
     // ========================================================================
     // Se valida manualmente (Elysia ya valida el schema a nivel router, pero
     // acá defendemos por si se llama internamente sin pasar por el router).
-    const { inversionista_id, creditos: creditoIds } = body ?? {};
+    //
+    // skipStatusAndEmail: SOLO para llamadas internas (ver liquidateByInvestorId).
+    // El schema del router (routers/investor.ts) NO declara este campo, así que
+    // Elysia lo descarta en /investor/exit — un caller HTTP no puede activarlo.
+    // Si algún día se agrega al schema del router, revisar que siga sin ser
+    // controlable por clientes externos.
+    const { inversionista_id, creditos: creditoIds, skipStatusAndEmail } = body ?? {};
 
     if (typeof inversionista_id !== "number" || !Number.isFinite(inversionista_id)) {
       warn("❌ Validación falló: inversionista_id inválido →", inversionista_id);
@@ -5822,7 +5830,9 @@ export const exitInvestor = async ({ body, set, request }: any) => {
       // el status — sería prematuro marcarlo como inactivo sin haberlo
       // sacado efectivamente de ningún crédito.
       // ──────────────────────────────────────────────────────────────────────
-      if (resultados.length > 0) {
+      if (skipStatusAndEmail) {
+        log(`⏭️  skipStatusAndEmail=true → NO se cambia status del inversionista`);
+      } else if (resultados.length > 0) {
         log(`🔻 Pasando inversionista ${inversionista_id} → status='inactivo'`);
         const resStatus = await tx
           .update(inversionistas)
@@ -5878,99 +5888,106 @@ export const exitInvestor = async ({ body, set, request }: any) => {
     // ========================================================================
     // PASO 7: ARMAR Y ENVIAR EL CORREO
     // ========================================================================
-    // Fecha en GT (zona horaria Guatemala) para mostrar el momento exacto
-    // del cambio sin depender de la zona del server.
-    const fechaGT = new Date().toLocaleString("es-GT", { timeZone: "America/Guatemala" });
-    const subject = `Inversionista INACTIVADO (cartera transferida a CUBE): ${invRow.nombre}`;
+    let enviados = 0;
+    let fallidos = 0;
 
-    // Una fila por crédito procesado, con SIFCO, ID interno, monto y
-    // leyenda de qué acción se tomó (swap vs merge).
-    const filasCreditos = resultados
-      .map(
-        (r) => `
-          <tr>
-            <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.numero_credito_sifco ?? "—"}</td>
-            <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.credito_id}</td>
-            <td style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">Q${r.monto_transferido}</td>
-            <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.accion === "merge" ? "Sumado a CUBE existente" : "CUBE tomó la posición"}</td>
-          </tr>
-        `,
-      )
-      .join("");
+    if (skipStatusAndEmail) {
+      log(`⏭️  skipStatusAndEmail=true → NO se envía correo de notificación`);
+    } else {
+      // Fecha en GT (zona horaria Guatemala) para mostrar el momento exacto
+      // del cambio sin depender de la zona del server.
+      const fechaGT = new Date().toLocaleString("es-GT", { timeZone: "America/Guatemala" });
+      const subject = `Inversionista INACTIVADO (cartera transferida a CUBE): ${invRow.nombre}`;
 
-    // Si hubo créditos saltados, se listan al final en rojo para que
-    // el equipo pueda revisarlos aparte.
-    const erroresHtml =
-      errores.length > 0
-        ? `
-          <h3 style="margin-top:16px; color:#b91c1c;">Créditos omitidos</h3>
-          <ul style="color:#b91c1c;">
-            ${errores.map((e) => `<li>Crédito ${e.credito_id}: ${e.razon}</li>`).join("")}
-          </ul>
-        `
-        : "";
-
-    const html = `
-      <div style="font-family: Arial, sans-serif; color:#111;">
-        <h2 style="margin-bottom: 8px;">Salida de inversionista — cartera transferida a CUBE</h2>
-        <p>
-          El inversionista <strong>${invRow.nombre}</strong> (ID: ${invRow.inversionista_id})
-          fue <strong style="color:#dc2626;">INACTIVADO</strong>.
-          Su participación en los créditos listados fue transferida a <strong>CUBE INVESTMENTS S.A.</strong>
-        </p>
-        <table style="border-collapse: collapse; margin-top: 8px;">
-          <tr><td style="padding:4px 8px;"><strong>Estado anterior:</strong></td><td style="padding:4px 8px;">${invRow.status}</td></tr>
-          <tr><td style="padding:4px 8px;"><strong>Estado nuevo:</strong></td><td style="padding:4px 8px; color:#dc2626;"><strong>inactivo</strong></td></tr>
-          <tr><td style="padding:4px 8px;"><strong>Fecha (GT):</strong></td><td style="padding:4px 8px;">${fechaGT}</td></tr>
-          ${usuarioNombre || usuarioEmail
-            ? `<tr><td style="padding:4px 8px;"><strong>Ejecutado por:</strong></td><td style="padding:4px 8px;">${[usuarioNombre, usuarioEmail].filter(Boolean).join(" — ")}</td></tr>`
-            : ""}
-          <tr><td style="padding:4px 8px;"><strong>Total transferido a CUBE:</strong></td><td style="padding:4px 8px;"><strong>Q${totalTransferido.toFixed(2)}</strong></td></tr>
-          <tr><td style="padding:4px 8px;"><strong>Créditos procesados:</strong></td><td style="padding:4px 8px;">${resultados.length}</td></tr>
-        </table>
-
-        <h3 style="margin-top:16px;">Créditos transferidos</h3>
-        <table style="border-collapse: collapse; margin-top: 4px; min-width: 520px;">
-          <thead>
-            <tr style="background:#f3f4f6;">
-              <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">SIFCO</th>
-              <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">Crédito ID</th>
-              <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">Monto a CUBE</th>
-              <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">Acción</th>
+      // Una fila por crédito procesado, con SIFCO, ID interno, monto y
+      // leyenda de qué acción se tomó (swap vs merge).
+      const filasCreditos = resultados
+        .map(
+          (r) => `
+            <tr>
+              <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.numero_credito_sifco ?? "—"}</td>
+              <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.credito_id}</td>
+              <td style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">Q${r.monto_transferido}</td>
+              <td style="padding:6px 10px; border:1px solid #e5e7eb;">${r.accion === "merge" ? "Sumado a CUBE existente" : "CUBE tomó la posición"}</td>
             </tr>
-          </thead>
-          <tbody>${filasCreditos}</tbody>
-        </table>
-        ${erroresHtml}
-        <p style="margin-top:16px; color:#555; font-size:12px;">Correo automático — Club Cash In / Cartera.</p>
-      </div>
-    `;
+          `,
+        )
+        .join("");
 
-    log(`📧 Enviando correo a ${INVESTOR_STATUS_CHANGE_RECIPIENTS.length} destinatario(s): [${INVESTOR_STATUS_CHANGE_RECIPIENTS.join(", ")}]`);
-    log(`📧 Asunto: "${subject}"`);
+      // Si hubo créditos saltados, se listan al final en rojo para que
+      // el equipo pueda revisarlos aparte.
+      const erroresHtml =
+        errores.length > 0
+          ? `
+            <h3 style="margin-top:16px; color:#b91c1c;">Créditos omitidos</h3>
+            <ul style="color:#b91c1c;">
+              ${errores.map((e) => `<li>Crédito ${e.credito_id}: ${e.razon}</li>`).join("")}
+            </ul>
+          `
+          : "";
 
-    // `allSettled` para que un destinatario que falle no tumbe el resto.
-    // Enviamos individualmente (sendPlainEmail acepta un solo `to`) en paralelo.
-    const mailResults = await Promise.allSettled(
-      INVESTOR_STATUS_CHANGE_RECIPIENTS.map((to) => sendPlainEmail(to, subject, html)),
-    );
+      const html = `
+        <div style="font-family: Arial, sans-serif; color:#111;">
+          <h2 style="margin-bottom: 8px;">Salida de inversionista — cartera transferida a CUBE</h2>
+          <p>
+            El inversionista <strong>${invRow.nombre}</strong> (ID: ${invRow.inversionista_id})
+            fue <strong style="color:#dc2626;">INACTIVADO</strong>.
+            Su participación en los créditos listados fue transferida a <strong>CUBE INVESTMENTS S.A.</strong>
+          </p>
+          <table style="border-collapse: collapse; margin-top: 8px;">
+            <tr><td style="padding:4px 8px;"><strong>Estado anterior:</strong></td><td style="padding:4px 8px;">${invRow.status}</td></tr>
+            <tr><td style="padding:4px 8px;"><strong>Estado nuevo:</strong></td><td style="padding:4px 8px; color:#dc2626;"><strong>inactivo</strong></td></tr>
+            <tr><td style="padding:4px 8px;"><strong>Fecha (GT):</strong></td><td style="padding:4px 8px;">${fechaGT}</td></tr>
+            ${usuarioNombre || usuarioEmail
+              ? `<tr><td style="padding:4px 8px;"><strong>Ejecutado por:</strong></td><td style="padding:4px 8px;">${[usuarioNombre, usuarioEmail].filter(Boolean).join(" — ")}</td></tr>`
+              : ""}
+            <tr><td style="padding:4px 8px;"><strong>Total transferido a CUBE:</strong></td><td style="padding:4px 8px;"><strong>Q${totalTransferido.toFixed(2)}</strong></td></tr>
+            <tr><td style="padding:4px 8px;"><strong>Créditos procesados:</strong></td><td style="padding:4px 8px;">${resultados.length}</td></tr>
+          </table>
 
-    mailResults.forEach((r, i) => {
-      const to = INVESTOR_STATUS_CHANGE_RECIPIENTS[i];
-      if (r.status === "fulfilled" && (r as any).value?.success) {
-        log(`   ✉️  OK → ${to} (id=${(r as any).value?.data?.id ?? "?"})`);
-      } else if (r.status === "fulfilled") {
-        warn(`   ✉️  FAIL → ${to}:`, (r as any).value?.error);
-      } else {
-        warn(`   ✉️  REJECTED → ${to}:`, r.reason);
-      }
-    });
+          <h3 style="margin-top:16px;">Créditos transferidos</h3>
+          <table style="border-collapse: collapse; margin-top: 4px; min-width: 520px;">
+            <thead>
+              <tr style="background:#f3f4f6;">
+                <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">SIFCO</th>
+                <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">Crédito ID</th>
+                <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:right;">Monto a CUBE</th>
+                <th style="padding:6px 10px; border:1px solid #e5e7eb; text-align:left;">Acción</th>
+              </tr>
+            </thead>
+            <tbody>${filasCreditos}</tbody>
+          </table>
+          ${erroresHtml}
+          <p style="margin-top:16px; color:#555; font-size:12px;">Correo automático — Club Cash In / Cartera.</p>
+        </div>
+      `;
 
-    const enviados = mailResults.filter(
-      (r) => r.status === "fulfilled" && (r as any).value?.success,
-    ).length;
-    const fallidos = INVESTOR_STATUS_CHANGE_RECIPIENTS.length - enviados;
-    log(`📧 Correos: enviados=${enviados}, fallidos=${fallidos}`);
+      log(`📧 Enviando correo a ${INVESTOR_STATUS_CHANGE_RECIPIENTS.length} destinatario(s): [${INVESTOR_STATUS_CHANGE_RECIPIENTS.join(", ")}]`);
+      log(`📧 Asunto: "${subject}"`);
+
+      // `allSettled` para que un destinatario que falle no tumbe el resto.
+      // Enviamos individualmente (sendPlainEmail acepta un solo `to`) en paralelo.
+      const mailResults = await Promise.allSettled(
+        INVESTOR_STATUS_CHANGE_RECIPIENTS.map((to) => sendPlainEmail(to, subject, html)),
+      );
+
+      mailResults.forEach((r, i) => {
+        const to = INVESTOR_STATUS_CHANGE_RECIPIENTS[i];
+        if (r.status === "fulfilled" && (r as any).value?.success) {
+          log(`   ✉️  OK → ${to} (id=${(r as any).value?.data?.id ?? "?"})`);
+        } else if (r.status === "fulfilled") {
+          warn(`   ✉️  FAIL → ${to}:`, (r as any).value?.error);
+        } else {
+          warn(`   ✉️  REJECTED → ${to}:`, r.reason);
+        }
+      });
+
+      enviados = mailResults.filter(
+        (r) => r.status === "fulfilled" && (r as any).value?.success,
+      ).length;
+      fallidos = INVESTOR_STATUS_CHANGE_RECIPIENTS.length - enviados;
+      log(`📧 Correos: enviados=${enviados}, fallidos=${fallidos}`);
+    }
 
     log(`⏱️  Duración total: ${Date.now() - t0}ms`);
     log(`✅ DONE — inversionista ${invRow.inversionista_id} inactivado, ${resultados.length} crédito(s), Q${totalTransferido.toFixed(2)} a CUBE`);

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4260,23 +4260,60 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
                 `  🚪 Inversionista ${inv_id} → exitInvestor por estado_devolucion=VERIFICADO en ${creditoIdsDevolucion.length} crédito(s)`
               );
 
-              const exitResultDevolucion = await exitInvestor({
-                body: {
-                  inversionista_id: inv_id,
-                  creditos: creditoIdsDevolucion,
-                  skipStatusAndEmail: true,
-                },
-                set: { status: 200 },
-                request: {} as any,
-              });
+              // Validación previa: el monto_aportado del inversionista en el espejo
+              // debería estar en 0 en este punto (ya liquidado por el loop de pagos).
+              // Los créditos que no cumplan se skippean (no entran a exitInvestor,
+              // no se marcan COMPLETADO) para revisión manual.
+              const filasEspejoPrevias = await db
+                .select({
+                  credito_id: creditos_inversionistas_espejo.credito_id,
+                  monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+                })
+                .from(creditos_inversionistas_espejo)
+                .where(
+                  and(
+                    inArray(creditos_inversionistas_espejo.credito_id, creditoIdsDevolucion),
+                    eq(creditos_inversionistas_espejo.inversionista_id, inv_id)
+                  )
+                );
 
-              // Después de separar en exitInvestor, dejar estado_devolucion en COMPLETADO
-              await db
-                .update(creditos)
-                .set({ estado_devolucion: "COMPLETADO" })
-                .where(inArray(creditos.credito_id, creditoIdsDevolucion));
+              const creditoIdsConMontoPendiente = filasEspejoPrevias
+                .filter((f) => Number(f.monto_aportado) !== 0)
+                .map((f) => f.credito_id);
 
-              console.log(`  ✅ Salida por estado_devolucion=VERIFICADO ejecutada y créditos reseteados a COMPLETADO:`, exitResultDevolucion);
+              if (creditoIdsConMontoPendiente.length > 0) {
+                console.warn(
+                  `  ⚠️  monto_aportado en espejo != 0 antes de exitInvestor para inversionista ${inv_id} — se omiten:`,
+                  filasEspejoPrevias
+                    .filter((f) => creditoIdsConMontoPendiente.includes(f.credito_id))
+                    .map((f) => `credito_id=${f.credito_id} monto_aportado=${f.monto_aportado}`)
+                    .join(", ")
+                );
+              }
+
+              const creditoIdsDevolucionValidos = creditoIdsDevolucion.filter(
+                (id) => !creditoIdsConMontoPendiente.includes(id)
+              );
+
+              if (creditoIdsDevolucionValidos.length > 0) {
+                const exitResultDevolucion = await exitInvestor({
+                  body: {
+                    inversionista_id: inv_id,
+                    creditos: creditoIdsDevolucionValidos,
+                    skipStatusAndEmail: true,
+                  },
+                  set: { status: 200 },
+                  request: {} as any,
+                });
+
+                // Después de separar en exitInvestor, dejar estado_devolucion en COMPLETADO
+                await db
+                  .update(creditos)
+                  .set({ estado_devolucion: "COMPLETADO" })
+                  .where(inArray(creditos.credito_id, creditoIdsDevolucionValidos));
+
+                console.log(`  ✅ Salida por estado_devolucion=VERIFICADO ejecutada y créditos reseteados a COMPLETADO:`, exitResultDevolucion);
+              }
             }
           }
 

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -4300,7 +4300,6 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
                 body: {
                   inversionista_id: inv_id,
                   creditos: creditoIdsSalida,
-                  skipStatusAndEmail: true,
                 },
                 set: { status: 200 },
                 request: {} as any,

--- a/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+
+// Integración: getMoraCobradaPorAsesor (mora cobrada por asesor en el período de
+// cierre de un mes) contra SUPABASE_DB_URL. Solo lecturas. Se salta si no hay DB.
+const hasDb = !!process.env.SUPABASE_DB_URL;
+
+if (!hasDb) {
+  describe("getMoraCobradaPorAsesor (integración)", () => {
+    it.skip("requiere SUPABASE_DB_URL", () => {});
+  });
+} else {
+  const { getMoraCobradaPorAsesor } = await import("./reportes");
+  const { db } = await import("../database/index");
+  const { sql } = await import("drizzle-orm");
+
+  describe("getMoraCobradaPorAsesor", () => {
+    it("período = [día 6 del mes, día 6 del mes siguiente)", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      expect(r.periodo.inicio).toBe("2026-06-06");
+      expect(r.periodo.fin).toBe("2026-07-06");
+    }, 20000);
+
+    it("diciembre rueda el año en el fin de período", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 12, anio: 2026 });
+      expect(r.periodo.inicio).toBe("2026-12-06");
+      expect(r.periodo.fin).toBe("2027-01-06");
+    }, 20000);
+
+    it("totalCobrado == suma de porAsesor y cuadra vs SUM independiente", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      const sumaPorAsesor = r.porAsesor.reduce((s, a) => s + Number(a.cobrado), 0);
+      expect(Number(r.totalCobrado)).toBeCloseTo(sumaPorAsesor, 2);
+
+      // Reconstrucción independiente del mismo total (misma ventana + paymentFalse=false).
+      const indep = await db.execute<{ total: string }>(sql`
+        SELECT COALESCE(SUM(pc.mora::numeric), 0) AS total
+        FROM cartera.pagos_credito pc
+        WHERE pc.fecha_pago >= '2026-06-06'::timestamp
+          AND pc.fecha_pago <  '2026-07-06'::timestamp
+          AND COALESCE(pc."paymentFalse", false) = false
+      `);
+      expect(Number(r.totalCobrado)).toBeCloseTo(Number(indep.rows[0].total), 2);
+    }, 20000);
+
+    it("filtro asesores limita a los IDs pedidos", async () => {
+      const full = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      const ids = full.porAsesor.slice(0, 1).map((a) => a.asesorId);
+      if (!ids.length) return;
+      const filt = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026, asesores: ids });
+      expect(filt.porAsesor.every((a) => ids.includes(a.asesorId))).toBe(true);
+    }, 20000);
+  });
+}

--- a/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts
@@ -49,5 +49,27 @@ if (!hasDb) {
       const filt = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026, asesores: ids });
       expect(filt.porAsesor.every((a) => ids.includes(a.asesorId))).toBe(true);
     }, 20000);
+
+    it("mes sin pagos (futuro lejano) → sin asesores y total 0.00", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 12, anio: 2035 });
+      expect(r.porAsesor).toEqual([]);
+      expect(r.totalCobrado).toBe("0.00");
+    }, 20000);
+
+    it("porAsesor viene ordenado de mayor a menor cobrado", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      const montos = r.porAsesor.map((a) => Number(a.cobrado));
+      const ordenado = [...montos].sort((x, y) => y - x);
+      expect(montos).toEqual(ordenado);
+    }, 20000);
+
+    it("totalCobrado y cobrado por asesor con formato de 2 decimales", async () => {
+      const r = await getMoraCobradaPorAsesor({ mes: 6, anio: 2026 });
+      expect(r.totalCobrado).toMatch(/^\d+\.\d{2}$/);
+      for (const a of r.porAsesor) {
+        expect(a.cobrado).toMatch(/^\d+\.\d{2}$/);
+        expect(Number(a.cobrado)).toBeGreaterThan(0);
+      }
+    }, 20000);
   });
 }

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -1317,6 +1317,59 @@ export async function getMoraByEtapaYAsesor({
   return { ...result, fecha, alcance: "historico" as const };
 }
 
+// Mora COBRADA por asesor en el período de cierre de un mes.
+// Período = [día 6 del mes, día 6 del mes siguiente) — alineado a que el cierre
+// corre el día 5. Suma cartera.pagos_credito.mora (lo efectivamente aplicado a
+// mora en cada pago), excluyendo pagos marcados como falsos.
+export async function getMoraCobradaPorAsesor({
+  mes,
+  anio,
+  asesores,
+  emailCobrador,
+}: {
+  mes: number;
+  anio: number;
+  asesores?: number[];
+  emailCobrador?: string;
+}) {
+  const mm = String(mes).padStart(2, "0");
+  const inicio = `${anio}-${mm}-06`;
+  const finMes = mes === 12 ? 1 : mes + 1;
+  const finAnio = mes === 12 ? anio + 1 : anio;
+  const fin = `${finAnio}-${String(finMes).padStart(2, "0")}-06`;
+
+  const emailFilter = emailCobrador
+    ? sql`AND LOWER(a.email_cash_in) = LOWER(TRIM(${emailCobrador}))`
+    : sql``;
+  const asesoresFilter = asesores && asesores.length
+    ? sql`AND a.asesor_id IN (${sql.join(asesores.map((id) => sql`${id}`), sql`, `)})`
+    : sql``;
+
+  const rows = await db.execute<{ asesor_id: number; nombre: string; cobrado: string }>(sql`
+    SELECT
+      a.asesor_id,
+      a.nombre,
+      COALESCE(SUM(pc.mora::numeric), 0) AS cobrado
+    FROM cartera.pagos_credito pc
+    INNER JOIN cartera.creditos c ON c.credito_id = pc.credito_id
+    INNER JOIN cartera.asesores a ON a.asesor_id  = c.asesor_id
+    WHERE pc.fecha_pago >= ${inicio}::timestamp
+      AND pc.fecha_pago <  ${fin}::timestamp
+      AND COALESCE(pc."paymentFalse", false) = false
+      ${emailFilter}
+      ${asesoresFilter}
+    GROUP BY a.asesor_id, a.nombre
+  `);
+
+  const porAsesor = rows.rows
+    .map((r) => ({ asesorId: r.asesor_id, nombre: r.nombre, cobrado: Number(r.cobrado).toFixed(2) }))
+    .filter((r) => Number(r.cobrado) !== 0)
+    .sort((x, y) => Number(y.cobrado) - Number(x.cobrado));
+  const totalCobrado = porAsesor.reduce((s, r) => s + Number(r.cobrado), 0).toFixed(2);
+
+  return { periodo: { inicio, fin }, porAsesor, totalCobrado };
+}
+
 export async function getCuotasPorFecha({
   fechaInicio,
   fechaFin,

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,5 @@
 import { Elysia } from "elysia";
-import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
+import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -290,6 +290,47 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return data;
     } catch (error) {
       console.error("[/reportes/mora-por-etapa-asesor]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/mora-cobrada-por-asesor", async ({ query, set }) => {
+    try {
+      const { mes, anio, asesores, email_cobrador } = query as Record<string, string>;
+      const mesNum = Number(mes);
+      const anioNum = Number(anio);
+      if (!Number.isInteger(mesNum) || mesNum < 1 || mesNum > 12) {
+        set.status = 400;
+        return { error: "Parámetro 'mes' inválido (1-12)" };
+      }
+      if (!Number.isInteger(anioNum) || anioNum < 2000 || anioNum > 2100) {
+        set.status = 400;
+        return { error: "Parámetro 'anio' inválido" };
+      }
+
+      let asesoresIds: number[] | undefined;
+      if (asesores) {
+        asesoresIds = asesores
+          .split(",")
+          .map((s) => Number(s.trim()))
+          .filter((n) => Number.isInteger(n) && n > 0);
+        if (!asesoresIds.length) {
+          set.status = 400;
+          return { error: "Parámetro 'asesores' inválido" };
+        }
+      }
+
+      const data = await getMoraCobradaPorAsesor({
+        mes: mesNum,
+        anio: anioNum,
+        asesores: asesoresIds,
+        emailCobrador: email_cobrador,
+      });
+      set.status = 200;
+      return data;
+    } catch (error) {
+      console.error("[/reportes/mora-cobrada-por-asesor]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -3,6 +3,8 @@ import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+const CONFIRMATION_REQUEST_REGEX =
+	/confirme la recepción|confirmar recepción|confirme recepcion/i;
 
 describe("plantillas masivas de cobros", () => {
 	test("incluyen el aviso de no responder exactamente una vez", () => {
@@ -32,6 +34,16 @@ describe("plantillas masivas de cobros", () => {
 			expect(plantilla.cuerpo, plantilla.id).not.toMatch(
 				/por este medio|por este chat|comunicarse por este medio/i,
 			);
+		}
+	});
+
+	test("no piden confirmar recepcion cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			if (plantilla.cuerpo.includes(NO_REPLY_WARNING)) {
+				expect(plantilla.cuerpo, plantilla.id).not.toMatch(
+					CONFIRMATION_REQUEST_REGEX,
+				);
+			}
 		}
 	});
 

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -26,4 +26,26 @@ describe("plantillas masivas de cobros", () => {
 			}
 		}
 	});
+
+	test("no indican responder por este chat cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			expect(plantilla.cuerpo, plantilla.id).not.toMatch(
+				/por este medio|por este chat|comunicarse por este medio/i,
+			);
+		}
+	});
+
+	test("dirigen comprobantes y dudas al telefono del asesor", () => {
+		const bienvenida = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "bienvenida",
+		);
+		const preMora = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "pre_mora",
+		);
+
+		expect(bienvenida?.cuerpo).toMatch(
+			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
+		);
+		expect(preMora?.cuerpo).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
+
+const NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
+describe("plantillas masivas de cobros", () => {
+	test("incluyen el aviso de no responder exactamente una vez", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const matches = plantilla.cuerpo.matchAll(
+				/NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS/g,
+			);
+
+			expect(Array.from(matches).length, plantilla.id).toBe(1);
+			expect(plantilla.cuerpo, plantilla.id).toContain(NO_REPLY_WARNING);
+		}
+	});
+
+	test("colocan el aviso antes de la firma cuando existe", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const warningIndex = plantilla.cuerpo.indexOf(NO_REPLY_WARNING);
+			const signatureIndex = plantilla.cuerpo.indexOf("Atentamente");
+
+			if (signatureIndex !== -1) {
+				expect(warningIndex, plantilla.id).toBeLessThan(signatureIndex);
+			}
+		}
+	});
+});

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { PLANTILLAS_MENSAJES } from "./cobros-plantillas";
+import {
+	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	PLANTILLAS_MENSAJES,
+	prepararTelefonoAsesorParaEnvio,
+} from "./cobros-plantillas";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
@@ -59,5 +63,25 @@ describe("plantillas masivas de cobros", () => {
 			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
 		);
 		expect(preMora?.cuerpo).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
+
+	test("descarta plantillas no-reply sin telefono de asesor", () => {
+		const cuerpo = PLANTILLAS_MENSAJES[0].cuerpo;
+
+		for (const telefono of [null, undefined, "", "   "]) {
+			expect(prepararTelefonoAsesorParaEnvio(cuerpo, telefono)).toEqual({
+				enviar: false,
+				motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+			});
+		}
+	});
+
+	test("recorta el telefono del asesor antes de interpolar", () => {
+		const cuerpo = PLANTILLAS_MENSAJES[0].cuerpo;
+
+		expect(prepararTelefonoAsesorParaEnvio(cuerpo, " 41286630 ")).toEqual({
+			enviar: true,
+			telefonoAsesor: "41286630",
+		});
 	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -88,7 +88,7 @@ Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplic
 
 ${COBROS_NO_REPLY_WARNING}
 
-Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
 		id: "al_dia",

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -37,6 +37,9 @@ export interface PlantillaMensaje {
 	cuerpo: string;
 }
 
+export const COBROS_NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
 function toCapitalCase(str: string): string {
 	return str
 		.toLowerCase()
@@ -76,12 +79,14 @@ export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
 		nombre: "Bienvenida",
 		etapa: "al_dia",
 		asunto: "Bienvenido/a a su plan de financiamiento",
-		// 4 bloques separados por línea en blanco → template `mensaje4parametros`.
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
 Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+
+${COBROS_NO_REPLY_WARNING}
 
 Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -90,8 +95,10 @@ Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} 
 		nombre: "Recordatorio de pago",
 		etapa: "al_dia",
 		asunto: "Recordatorio de pago - Vehículo {placa}",
-		// 2 bloques → template `mensaje2parametros`.
+		// 3 bloques → template `mensaje3parametros`.
 		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -100,12 +107,14 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",
 		asunto: "Aviso de atraso en pago - Vehículo {placa}",
-		// 4 bloques → template `mensaje4parametros`.
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
 Si tiene alguna duda por favor comunicarse por este medio.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -114,8 +123,10 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Mora 30 días",
 		etapa: "mora_30",
 		asunto: "URGENTE: Mora de 30 días - Vehículo {placa}",
-		// 2 bloques → template `mensaje2parametros`.
+		// 3 bloques → template `mensaje3parametros`.
 		cuerpo: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
@@ -124,10 +135,12 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		nombre: "Mora 60 días",
 		etapa: "mora_60",
 		asunto: "AVISO IMPORTANTE: Mora de 60 días - Vehículo {placa}",
-		// 3 bloques → template `mensaje3parametros`.
+		// 4 bloques → template `mensaje4parametros`.
 		cuerpo: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
 
 Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
+
+${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 	},
@@ -136,10 +149,12 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 		nombre: "Aviso jurídico",
 		etapa: "mora_90",
 		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
-		// 3 bloques → template `mensaje3parametros`.
+		// 4 bloques → template `mensaje4parametros`.
 		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
+
+${COBROS_NO_REPLY_WARNING}
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
 	},

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -39,6 +39,22 @@ export interface PlantillaMensaje {
 
 export const COBROS_NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+export const COBROS_MOTIVO_SIN_TELEFONO_ASESOR = "sin teléfono de asesor";
+
+export function prepararTelefonoAsesorParaEnvio(
+	cuerpo: string,
+	telefono: string | null | undefined,
+):
+	| { enviar: true; telefonoAsesor: string }
+	| { enviar: false; motivo: string } {
+	const telefonoAsesor = telefono?.trim() ?? "";
+
+	if (cuerpo.includes(COBROS_NO_REPLY_WARNING) && !telefonoAsesor) {
+		return { enviar: false, motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR };
+	}
+
+	return { enviar: true, telefonoAsesor };
+}
 
 function toCapitalCase(str: string): string {
 	return str

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -84,7 +84,7 @@ export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
-Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
 
 ${COBROS_NO_REPLY_WARNING}
 
@@ -110,7 +110,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
 		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
-Si tiene alguna duda por favor comunicarse por este medio.
+Si tiene alguna duda, por favor comuníquese al {telefonoAsesor}.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 
@@ -150,7 +150,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 		etapa: "mora_90",
 		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
 		// 4 bloques → template `mensaje4parametros`.
-		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+		cuerpo: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -40,11 +40,11 @@ import {
 } from "../db/schema/crm";
 import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
+import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
 import {
 	interpolar as interpolarPlantilla,
 	PLANTILLAS_MENSAJES,
 } from "../lib/cobros-plantillas";
-import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
 import { toDateStrGT } from "../lib/guatemala-month-window";
 import {
@@ -3976,6 +3976,30 @@ export const cobrosRouter = {
 				emailCobrador: input?.emailCobrador,
 				fecha: input?.fecha,
 				asesores: input?.asesores,
+			});
+		}),
+
+	getMoraCobradaPorAsesor: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				mes: z.number(),
+				anio: z.number(),
+				asesores: z.array(z.number()).optional(),
+				emailCobrador: z.string().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			return carteraBackClient.getMoraCobradaPorAsesor({
+				mes: input.mes,
+				anio: input.anio,
+				asesores: input.asesores,
+				emailCobrador: input.emailCobrador,
 			});
 		}),
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -40,11 +40,12 @@ import {
 } from "../db/schema/crm";
 import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
-import {
-	interpolar as interpolarPlantilla,
-	PLANTILLAS_MENSAJES,
-} from "../lib/cobros-plantillas";
 import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
+import {
+	PLANTILLAS_MENSAJES,
+	interpolar as interpolarPlantilla,
+	prepararTelefonoAsesorParaEnvio,
+} from "../lib/cobros-plantillas";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
 import { toDateStrGT } from "../lib/guatemala-month-window";
 import {
@@ -3583,6 +3584,19 @@ export const cobrosRouter = {
 				const cuerpoBase = input.cuerpoEditado?.trim()
 					? input.cuerpoEditado
 					: plantilla.cuerpo;
+				const telefonoAsesor = prepararTelefonoAsesorParaEnvio(
+					cuerpoBase,
+					asesor.telefono,
+				);
+
+				if (!telefonoAsesor.enviar) {
+					descartados.push({
+						numeroSifco: sifco,
+						clienteNombre,
+						motivo: telefonoAsesor.motivo,
+					});
+					continue;
+				}
 
 				// Día de pago: tomar el día del mes de la fecha de vencimiento de la
 				// próxima cuota que devuelve cartera (`proxima_cuota`). Es el mismo
@@ -3610,7 +3624,7 @@ export const cobrosRouter = {
 								})
 							: "",
 					cuotasAtraso: credito.mora?.cuotas_atrasadas ?? 0,
-					telefonoAsesor: asesor.telefono ?? "",
+					telefonoAsesor: telefonoAsesor.telefonoAsesor,
 					nombreAsesor: asesor.nombre ?? "",
 				});
 
@@ -3619,7 +3633,7 @@ export const cobrosRouter = {
 					telefono: testMode ? getTestPhone(candidatos.length) : telefono,
 					telefonoReal: telefono,
 					mensaje,
-					casoCobroId: sifco ? (casoIdPorSifco.get(sifco) ?? null) : null,
+					casoCobroId: sifco ? casoIdPorSifco.get(sifco) ?? null : null,
 					clienteNombre,
 				});
 			}

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -172,6 +172,7 @@ export const cobrosAppRouter = {
 
 	// CRM Cobros — nuevas vistas
 	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
+	getMoraCobradaPorAsesor: cobrosRouter.getMoraCobradaPorAsesor,
 	getCuotasPorFecha: cobrosRouter.getCuotasPorFecha,
 	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
 
@@ -438,7 +439,8 @@ export const manualVehicleRouter = {
 // Projection procedures exported separately to avoid TS7056 truncation
 export const proyeccionRouter = {
 	getInvestorsCartera: investorDocumentsRouter.getInvestorsCartera,
-	getSimulacionInversionista: investorDocumentsRouter.getSimulacionInversionista,
+	getSimulacionInversionista:
+		investorDocumentsRouter.getSimulacionInversionista,
 };
 
 // Merged AppRouter type to avoid serialization limit

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -425,10 +425,20 @@ export type MoraTotales = {
 
 export type MoraByEtapaYAsesorResponse = {
 	totales: MoraTotales;
-	porAsesor: ({ asesorId: number; nombre: string; email: string } & MoraTotales)[];
+	porAsesor: ({
+		asesorId: number;
+		nombre: string;
+		email: string;
+	} & MoraTotales)[];
 	fecha?: string;
 	alcance?: "live" | "historico";
 	dataDisponibleDesde?: string;
+};
+
+export type MoraCobradaPorAsesorResponse = {
+	periodo: { inicio: string; fin: string };
+	porAsesor: { asesorId: number; nombre: string; cobrado: string }[];
+	totalCobrado: string;
 };
 
 // ============================================================================
@@ -1548,7 +1558,10 @@ export class CarteraBackClient {
 			otros: cobradoResult.cobrado_otros ?? "0",
 		};
 
-		return { cobrado, esperado: { meta_mensual: esperadoResult.meta_mensual ?? "0" } };
+		return {
+			cobrado,
+			esperado: { meta_mensual: esperadoResult.meta_mensual ?? "0" },
+		};
 	}
 
 	async getFlujoCuotasInversiones(params: {
@@ -1609,12 +1622,34 @@ export class CarteraBackClient {
 		asesores?: number[];
 	}) {
 		const queryParams = new URLSearchParams();
-		if (params?.emailCobrador) queryParams.set("email_cobrador", params.emailCobrador);
+		if (params?.emailCobrador)
+			queryParams.set("email_cobrador", params.emailCobrador);
 		if (params?.fecha) queryParams.set("fecha", params.fecha);
-		if (params?.asesores?.length) queryParams.set("asesores", params.asesores.join(","));
+		if (params?.asesores?.length)
+			queryParams.set("asesores", params.asesores.join(","));
 		const qs = queryParams.size > 0 ? `?${queryParams}` : "";
 		return this.request<MoraByEtapaYAsesorResponse>(
 			`/reportes/mora-por-etapa-asesor${qs}`,
+			{ method: "GET" },
+			true,
+		);
+	}
+
+	async getMoraCobradaPorAsesor(params: {
+		mes: number;
+		anio: number;
+		asesores?: number[];
+		emailCobrador?: string;
+	}) {
+		const queryParams = new URLSearchParams();
+		queryParams.set("mes", String(params.mes));
+		queryParams.set("anio", String(params.anio));
+		if (params.asesores?.length)
+			queryParams.set("asesores", params.asesores.join(","));
+		if (params.emailCobrador)
+			queryParams.set("email_cobrador", params.emailCobrador);
+		return this.request<MoraCobradaPorAsesorResponse>(
+			`/reportes/mora-cobrada-por-asesor?${queryParams}`,
 			{ method: "GET" },
 			true,
 		);
@@ -1631,11 +1666,10 @@ export class CarteraBackClient {
 			...(params.asesorId ? { asesor_id: String(params.asesorId) } : {}),
 		});
 
-		const response = await this.request<{ ok: boolean; data: CuotaPorFechaRow[] }>(
-			`/reportes/cuotas-por-fecha?${qp}`,
-			{ method: "GET" },
-			false,
-		);
+		const response = await this.request<{
+			ok: boolean;
+			data: CuotaPorFechaRow[];
+		}>(`/reportes/cuotas-por-fecha?${qp}`, { method: "GET" }, false);
 
 		return response.data ?? [];
 	}

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1648,10 +1648,12 @@ export class CarteraBackClient {
 			queryParams.set("asesores", params.asesores.join(","));
 		if (params.emailCobrador)
 			queryParams.set("email_cobrador", params.emailCobrador);
+		// Sin caché: es un reporte de flujo (pagos del período). Con caché el
+		// "Actualizar" podría devolver un hit stale tras registrar/ajustar un pago.
 		return this.request<MoraCobradaPorAsesorResponse>(
 			`/reportes/mora-cobrada-por-asesor?${queryParams}`,
 			{ method: "GET" },
-			true,
+			false,
 		);
 	}
 

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -51,6 +51,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
+	crearUrlWhatsappManual,
 	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
@@ -324,9 +325,11 @@ export function ContactoModal({
 				window.open(`tel:${tel}`);
 				break;
 			case "whatsapp-link": {
-				const url = mensajeEditado
-					? `https://wa.me/${telLimpio}?text=${encodeURIComponent(mensajeEditado)}`
-					: `https://wa.me/${telLimpio}`;
+				const url = crearUrlWhatsappManual(
+					telLimpio,
+					mensajeWhatsappEditado,
+					mensajeEditado,
+				);
 				window.open(url);
 				break;
 			}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -27,6 +27,12 @@ import {
 	DialogTitle,
 	DialogTrigger,
 } from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -34,12 +40,6 @@ import {
 	PopoverContent,
 	PopoverTrigger,
 } from "@/components/ui/popover";
-import {
-	DropdownMenu,
-	DropdownMenuContent,
-	DropdownMenuItem,
-	DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import {
 	Select,
 	SelectContent,
@@ -50,13 +50,13 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import {
 	accionUsaCuerpoNoReply,
+	crearUrlWhatsappManual,
 	cuerpoParaValidarNoReply,
 	interpolar,
-	PLANTILLAS_MENSAJES,
-	crearUrlWhatsappManual,
 	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
+	PLANTILLAS_MENSAJES,
 	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
@@ -330,6 +330,7 @@ export function ContactoModal({
 			metodo,
 			mensajeWhatsapp,
 			mensajeSms,
+			mensajeEmail,
 		);
 		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
 			cuerpoNoReply,
@@ -667,7 +668,9 @@ export function ContactoModal({
 									<DropdownMenuItem onClick={() => ejecutarAccion("email-api")}>
 										Enviar Directo (Automático)
 									</DropdownMenuItem>
-									<DropdownMenuItem onClick={() => ejecutarAccion("email-link")}>
+									<DropdownMenuItem
+										onClick={() => ejecutarAccion("email-link")}
+									>
 										Abrir cliente de correo (Manual)
 									</DropdownMenuItem>
 								</DropdownMenuContent>

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -49,6 +49,7 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import {
+	accionUsaCuerpoNoReply,
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
@@ -322,10 +323,7 @@ export function ContactoModal({
 			mensajeWhatsapp,
 			telefonoAsesorLimpio,
 		);
-		if (
-			(metodo === "whatsapp-link" || metodo === "whatsapp-api") &&
-			!telefonoAsesorNoReply.enviar
-		) {
+		if (accionUsaCuerpoNoReply(metodo) && !telefonoAsesorNoReply.enviar) {
 			toast.error(
 				"No se puede enviar esta plantilla no-reply porque el asesor no tiene teléfono registrado",
 			);

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -53,6 +53,7 @@ import {
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
+	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
@@ -312,6 +313,11 @@ export function ContactoModal({
 			mensajeEditado,
 			mensajeWhatsappEditado,
 		);
+		const mensajeSms = mensajeSmsEditable(
+			metodoInicial,
+			mensajeEditado,
+			mensajeWhatsappEditado,
+		);
 		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
 			mensajeWhatsapp,
 			telefonoAsesorLimpio,
@@ -380,13 +386,13 @@ export function ContactoModal({
 					toast.error("No hay teléfono para enviar SMS");
 					return;
 				}
-				if (!mensajeEditado.trim()) {
+				if (!mensajeSms.trim()) {
 					toast.error("No hay mensaje para enviar");
 					return;
 				}
 				smsApiMutation.mutate({
 					telefono: telLimpio,
-					mensaje: mensajeEditado,
+					mensaje: mensajeSms,
 				});
 				break;
 		}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -51,6 +51,7 @@ import { Textarea } from "@/components/ui/textarea";
 import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
+	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
 } from "@/lib/cobros/plantillas-mensajes";
@@ -131,6 +132,8 @@ export function ContactoModal({
 	const [mensajeWhatsappEditado, setMensajeWhatsappEditado] = useState("");
 	const [asuntoEditado, setAsuntoEditado] = useState("");
 
+	const telefonoAsesorLimpio = telefonoAsesor.trim();
+
 	const variables: VariablesPlantilla = useMemo(
 		() => ({
 			clienteNombre,
@@ -140,7 +143,7 @@ export function ContactoModal({
 			marcaLineaModelo,
 			montoAdeudado,
 			cuotasAtraso,
-			telefonoAsesor,
+			telefonoAsesor: telefonoAsesorLimpio,
 			nombreAsesor,
 		}),
 		[
@@ -151,7 +154,7 @@ export function ContactoModal({
 			marcaLineaModelo,
 			montoAdeudado,
 			cuotasAtraso,
-			telefonoAsesor,
+			telefonoAsesorLimpio,
 			nombreAsesor,
 		],
 	);
@@ -303,6 +306,19 @@ export function ContactoModal({
 		const tel = telefonoSeleccionado || telefonoPrincipal;
 		const telLimpio = tel.replace(/[^0-9]/g, "");
 		const mensajeWhatsapp = mensajeWhatsappEditado || mensajeEditado;
+		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
+			mensajeWhatsapp,
+			telefonoAsesorLimpio,
+		);
+		if (
+			(metodo === "whatsapp-link" || metodo === "whatsapp-api") &&
+			!telefonoAsesorNoReply.enviar
+		) {
+			toast.error(
+				"No se puede enviar esta plantilla no-reply porque el asesor no tiene teléfono registrado",
+			);
+			return;
+		}
 		switch (metodo) {
 			case "llamada":
 				window.open(`tel:${tel}`);

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -54,6 +54,7 @@ import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
+	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
@@ -320,6 +321,11 @@ export function ContactoModal({
 			mensajeEditado,
 			mensajeWhatsappEditado,
 		);
+		const mensajeEmail = mensajeEmailEditable(
+			metodoInicial,
+			mensajeEditado,
+			mensajeWhatsappEditado,
+		);
 		const cuerpoNoReply = cuerpoParaValidarNoReply(
 			metodo,
 			mensajeWhatsapp,
@@ -361,7 +367,7 @@ export function ContactoModal({
 			case "email-link": {
 				const params = new URLSearchParams();
 				if (asuntoEditado) params.set("subject", asuntoEditado);
-				if (mensajeEditado) params.set("body", mensajeEditado);
+				if (mensajeEmail) params.set("body", mensajeEmail);
 				const query = params.toString();
 				window.open(`mailto:${emailCliente || ""}${query ? `?${query}` : ""}`);
 				break;
@@ -375,14 +381,14 @@ export function ContactoModal({
 					toast.error("El asunto es requerido");
 					return;
 				}
-				if (!mensajeEditado.trim()) {
+				if (!mensajeEmail.trim()) {
 					toast.error("El mensaje es requerido");
 					return;
 				}
 				emailApiMutation.mutate({
 					destinatario: emailCliente,
 					asunto: asuntoEditado,
-					mensaje: mensajeEditado,
+					mensaje: mensajeEmail,
 				});
 				break;
 			case "sms-api":

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -52,6 +52,7 @@ import {
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
+	mensajePlantillaEditable,
 	prepararTelefonoAsesorParaEnvio,
 	sugerirPlantilla,
 	type VariablesPlantilla,
@@ -306,7 +307,11 @@ export function ContactoModal({
 	const ejecutarAccion = (metodo: AccionContacto) => {
 		const tel = telefonoSeleccionado || telefonoPrincipal;
 		const telLimpio = tel.replace(/[^0-9]/g, "");
-		const mensajeWhatsapp = mensajeWhatsappEditado || mensajeEditado;
+		const mensajeWhatsapp = mensajePlantillaEditable(
+			"whatsapp",
+			mensajeEditado,
+			mensajeWhatsappEditado,
+		);
 		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
 			mensajeWhatsapp,
 			telefonoAsesorLimpio,
@@ -325,11 +330,7 @@ export function ContactoModal({
 				window.open(`tel:${tel}`);
 				break;
 			case "whatsapp-link": {
-				const url = crearUrlWhatsappManual(
-					telLimpio,
-					mensajeWhatsappEditado,
-					mensajeEditado,
-				);
+				const url = crearUrlWhatsappManual(telLimpio, mensajeWhatsapp);
 				window.open(url);
 				break;
 			}
@@ -393,6 +394,19 @@ export function ContactoModal({
 
 	const mostrarPlantillas =
 		metodoInicial === "whatsapp" || metodoInicial === "email";
+	const mensajeEditable = mensajePlantillaEditable(
+		metodoInicial,
+		mensajeEditado,
+		mensajeWhatsappEditado,
+	);
+	const handleMensajeEditableChange = (mensaje: string) => {
+		if (metodoInicial === "whatsapp") {
+			setMensajeWhatsappEditado(mensaje);
+			return;
+		}
+
+		setMensajeEditado(mensaje);
+	};
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -533,8 +547,10 @@ export function ContactoModal({
 										<Label>Mensaje (editable)</Label>
 										<Textarea
 											className="min-h-[150px] text-sm"
-											value={mensajeEditado}
-											onChange={(e) => setMensajeEditado(e.target.value)}
+											value={mensajeEditable}
+											onChange={(e) =>
+												handleMensajeEditableChange(e.target.value)
+											}
 										/>
 									</div>
 								)}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -50,6 +50,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import {
 	accionUsaCuerpoNoReply,
+	cuerpoParaValidarNoReply,
 	interpolar,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
@@ -319,8 +320,13 @@ export function ContactoModal({
 			mensajeEditado,
 			mensajeWhatsappEditado,
 		);
-		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
+		const cuerpoNoReply = cuerpoParaValidarNoReply(
+			metodo,
 			mensajeWhatsapp,
+			mensajeSms,
+		);
+		const telefonoAsesorNoReply = prepararTelefonoAsesorParaEnvio(
+			cuerpoNoReply,
 			telefonoAsesorLimpio,
 		);
 		if (accionUsaCuerpoNoReply(metodo) && !telefonoAsesorNoReply.enviar) {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -5,6 +5,7 @@ import {
 	accionUsaCuerpoNoReply,
 	cuerpoParaValidarNoReply,
 	crearUrlWhatsappManual,
+	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
@@ -106,6 +107,16 @@ describe("plantillas web de cobros", () => {
 	test("envia por SMS el mensaje visible cuando se edita desde WhatsApp", () => {
 		expect(
 			mensajeSmsEditable(
+				"whatsapp",
+				"Mensaje email largo oculto",
+				"Mensaje visible editado",
+			),
+		).toBe("Mensaje visible editado");
+	});
+
+	test("envia por Email el mensaje visible cuando se edita desde WhatsApp", () => {
+		expect(
+			mensajeEmailEditable(
 				"whatsapp",
 				"Mensaje email largo oculto",
 				"Mensaje visible editado",

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
+import {
+	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	PLANTILLAS_MENSAJES,
+	prepararTelefonoAsesorParaEnvio,
+} from "./plantillas-mensajes";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
@@ -65,5 +69,27 @@ describe("plantillas web de cobros", () => {
 			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
 		);
 		expect(preMora?.cuerpoWhastapp).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
+
+	test("descarta plantillas no-reply sin telefono de asesor", () => {
+		const cuerpoWhatsapp =
+			PLANTILLAS_MENSAJES[0].cuerpoWhastapp ?? PLANTILLAS_MENSAJES[0].cuerpo;
+
+		for (const telefono of [null, undefined, "", "   "]) {
+			expect(prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, telefono)).toEqual({
+				enviar: false,
+				motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+			});
+		}
+	});
+
+	test("recorta el telefono del asesor antes de interpolar", () => {
+		const cuerpoWhatsapp =
+			PLANTILLAS_MENSAJES[0].cuerpoWhastapp ?? PLANTILLAS_MENSAJES[0].cuerpo;
+
+		expect(prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, " 41286630 ")).toEqual({
+			enviar: true,
+			telefonoAsesor: "41286630",
+		});
 	});
 });

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -3,6 +3,7 @@ import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
 	accionUsaCuerpoNoReply,
+	cuerpoParaValidarNoReply,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
@@ -117,6 +118,16 @@ describe("plantillas web de cobros", () => {
 		expect(accionUsaCuerpoNoReply("whatsapp-api")).toBe(true);
 		expect(accionUsaCuerpoNoReply("sms-api")).toBe(true);
 		expect(accionUsaCuerpoNoReply("email-api")).toBe(false);
+	});
+
+	test("valida no-reply contra el cuerpo real de SMS", () => {
+		expect(
+			cuerpoParaValidarNoReply(
+				"sms-api",
+				`Mensaje WhatsApp oculto ${NO_REPLY_WARNING}`,
+				"Mensaje SMS seguro",
+			),
+		).toBe("Mensaje SMS seguro");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -3,6 +3,7 @@ import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
+	mensajePlantillaEditable,
 	prepararTelefonoAsesorParaEnvio,
 } from "./plantillas-mensajes";
 
@@ -81,6 +82,22 @@ describe("plantillas web de cobros", () => {
 		const text = new URL(url).searchParams.get("text");
 
 		expect(text).toBe("Mensaje WhatsApp no-reply");
+	});
+
+	test("edita el cuerpo visible que usa WhatsApp", () => {
+		expect(
+			mensajePlantillaEditable(
+				"whatsapp",
+				"Mensaje email por este medio",
+				"Mensaje WhatsApp no-reply",
+			),
+		).toBe("Mensaje WhatsApp no-reply");
+	});
+
+	test("respeta mensajes de WhatsApp vacios editados manualmente", () => {
+		expect(
+			mensajePlantillaEditable("whatsapp", "Mensaje fallback", ""),
+		).toBe("");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
+
+const NO_REPLY_WARNING =
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
+describe("plantillas web de cobros", () => {
+	test("incluyen el aviso de no responder en el cuerpo de WhatsApp", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+			const matches = cuerpoWhatsapp.matchAll(
+				/NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS/g,
+			);
+
+			expect(Array.from(matches).length, plantilla.id).toBe(1);
+			expect(cuerpoWhatsapp, plantilla.id).toContain(NO_REPLY_WARNING);
+		}
+	});
+
+	test("colocan el aviso antes de la firma cuando existe", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+			const warningIndex = cuerpoWhatsapp.indexOf(NO_REPLY_WARNING);
+			const signatureIndex = cuerpoWhatsapp.indexOf("Atentamente");
+
+			if (signatureIndex !== -1) {
+				expect(warningIndex, plantilla.id).toBeLessThan(signatureIndex);
+			}
+		}
+	});
+});

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -4,6 +4,7 @@ import {
 	PLANTILLAS_MENSAJES,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
+	mensajeSmsEditable,
 	prepararTelefonoAsesorParaEnvio,
 } from "./plantillas-mensajes";
 
@@ -98,6 +99,16 @@ describe("plantillas web de cobros", () => {
 		expect(
 			mensajePlantillaEditable("whatsapp", "Mensaje fallback", ""),
 		).toBe("");
+	});
+
+	test("envia por SMS el mensaje visible cuando se edita desde WhatsApp", () => {
+		expect(
+			mensajeSmsEditable(
+				"whatsapp",
+				"Mensaje email largo oculto",
+				"Mensaje visible editado",
+			),
+		).toBe("Mensaje visible editado");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -3,6 +3,8 @@ import { PLANTILLAS_MENSAJES } from "./plantillas-mensajes";
 
 const NO_REPLY_WARNING =
 	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+const CONFIRMATION_REQUEST_REGEX =
+	/confirme la recepción|confirmar recepción|confirme recepcion/i;
 
 describe("plantillas web de cobros", () => {
 	test("incluyen el aviso de no responder en el cuerpo de WhatsApp", () => {
@@ -36,6 +38,18 @@ describe("plantillas web de cobros", () => {
 			expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
 				/por este medio|por este chat|comunicarse por este medio/i,
 			);
+		}
+	});
+
+	test("no piden confirmar recepcion cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+
+			if (cuerpoWhatsapp.includes(NO_REPLY_WARNING)) {
+				expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
+					CONFIRMATION_REQUEST_REGEX,
+				);
+			}
 		}
 	});
 

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
-	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
-	PLANTILLAS_MENSAJES,
 	accionUsaCuerpoNoReply,
-	cuerpoParaValidarNoReply,
+	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	crearUrlWhatsappManual,
+	cuerpoParaValidarNoReply,
 	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
+	PLANTILLAS_MENSAJES,
 	prepararTelefonoAsesorParaEnvio,
 } from "./plantillas-mensajes";
 
@@ -99,9 +99,9 @@ describe("plantillas web de cobros", () => {
 	});
 
 	test("respeta mensajes de WhatsApp vacios editados manualmente", () => {
-		expect(
-			mensajePlantillaEditable("whatsapp", "Mensaje fallback", ""),
-		).toBe("");
+		expect(mensajePlantillaEditable("whatsapp", "Mensaje fallback", "")).toBe(
+			"",
+		);
 	});
 
 	test("envia por SMS el mensaje visible cuando se edita desde WhatsApp", () => {
@@ -128,7 +128,8 @@ describe("plantillas web de cobros", () => {
 		expect(accionUsaCuerpoNoReply("whatsapp-link")).toBe(true);
 		expect(accionUsaCuerpoNoReply("whatsapp-api")).toBe(true);
 		expect(accionUsaCuerpoNoReply("sms-api")).toBe(true);
-		expect(accionUsaCuerpoNoReply("email-api")).toBe(false);
+		expect(accionUsaCuerpoNoReply("email-link")).toBe(true);
+		expect(accionUsaCuerpoNoReply("email-api")).toBe(true);
 	});
 
 	test("valida no-reply contra el cuerpo real de SMS", () => {
@@ -141,15 +142,28 @@ describe("plantillas web de cobros", () => {
 		).toBe("Mensaje SMS seguro");
 	});
 
+	test("valida no-reply contra el cuerpo real de Email", () => {
+		expect(
+			cuerpoParaValidarNoReply(
+				"email-api",
+				`Mensaje WhatsApp oculto ${NO_REPLY_WARNING}`,
+				"Mensaje SMS seguro",
+				"Mensaje Email seguro",
+			),
+		).toBe("Mensaje Email seguro");
+	});
+
 	test("descarta plantillas no-reply sin telefono de asesor", () => {
 		const cuerpoWhatsapp =
 			PLANTILLAS_MENSAJES[0].cuerpoWhastapp ?? PLANTILLAS_MENSAJES[0].cuerpo;
 
 		for (const telefono of [null, undefined, "", "   "]) {
-			expect(prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, telefono)).toEqual({
-				enviar: false,
-				motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
-			});
+			expect(prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, telefono)).toEqual(
+				{
+					enviar: false,
+					motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+				},
+			);
 		}
 	});
 
@@ -157,7 +171,9 @@ describe("plantillas web de cobros", () => {
 		const cuerpoWhatsapp =
 			PLANTILLAS_MENSAJES[0].cuerpoWhastapp ?? PLANTILLAS_MENSAJES[0].cuerpo;
 
-		expect(prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, " 41286630 ")).toEqual({
+		expect(
+			prepararTelefonoAsesorParaEnvio(cuerpoWhatsapp, " 41286630 "),
+		).toEqual({
 			enviar: true,
 			telefonoAsesor: "41286630",
 		});

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -28,4 +28,28 @@ describe("plantillas web de cobros", () => {
 			}
 		}
 	});
+
+	test("no indican responder por este chat cuando tienen aviso de no responder", () => {
+		for (const plantilla of PLANTILLAS_MENSAJES) {
+			const cuerpoWhatsapp = plantilla.cuerpoWhastapp ?? plantilla.cuerpo;
+
+			expect(cuerpoWhatsapp, plantilla.id).not.toMatch(
+				/por este medio|por este chat|comunicarse por este medio/i,
+			);
+		}
+	});
+
+	test("dirigen comprobantes y dudas al telefono del asesor", () => {
+		const bienvenida = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "bienvenida",
+		);
+		const preMora = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "pre_mora",
+		);
+
+		expect(bienvenida?.cuerpoWhastapp).toMatch(
+			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
+		);
+		expect(preMora?.cuerpoWhastapp).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
 });

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
+	crearUrlWhatsappManual,
 	prepararTelefonoAsesorParaEnvio,
 } from "./plantillas-mensajes";
 
@@ -69,6 +70,17 @@ describe("plantillas web de cobros", () => {
 			/boleta o comprobante de pago[^.]*{telefonoAsesor}/i,
 		);
 		expect(preMora?.cuerpoWhastapp).toMatch(/duda[^.]*{telefonoAsesor}/i);
+	});
+
+	test("crea links manuales de WhatsApp con el cuerpo de WhatsApp", () => {
+		const url = crearUrlWhatsappManual(
+			"50241286630",
+			"Mensaje WhatsApp no-reply",
+			"Mensaje email por este medio",
+		);
+		const text = new URL(url).searchParams.get("text");
+
+		expect(text).toBe("Mensaje WhatsApp no-reply");
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
 	PLANTILLAS_MENSAJES,
+	accionUsaCuerpoNoReply,
 	crearUrlWhatsappManual,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
@@ -109,6 +110,13 @@ describe("plantillas web de cobros", () => {
 				"Mensaje visible editado",
 			),
 		).toBe("Mensaje visible editado");
+	});
+
+	test("bloquea todos los envios que usan cuerpo no-reply sin telefono de asesor", () => {
+		expect(accionUsaCuerpoNoReply("whatsapp-link")).toBe(true);
+		expect(accionUsaCuerpoNoReply("whatsapp-api")).toBe(true);
+		expect(accionUsaCuerpoNoReply("sms-api")).toBe(true);
+		expect(accionUsaCuerpoNoReply("email-api")).toBe(false);
 	});
 
 	test("descarta plantillas no-reply sin telefono de asesor", () => {

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -10,148 +10,156 @@
  */
 
 export interface VariablesPlantilla {
-  clienteNombre: string;
-  fechaPago: string;
-  cuotaMensual: string;
-  placa: string;
-  marcaLineaModelo: string;
-  montoAdeudado: string;
-  cuotasAtraso: number;
-  telefonoAsesor: string;
-  nombreAsesor: string;
+	clienteNombre: string;
+	fechaPago: string;
+	cuotaMensual: string;
+	placa: string;
+	marcaLineaModelo: string;
+	montoAdeudado: string;
+	cuotasAtraso: number;
+	telefonoAsesor: string;
+	nombreAsesor: string;
 }
 
 export interface PlantillaMensaje {
-  id: string;
-  nombre: string;
-  etapa: string;
-  asunto: string;
-  cuerpo: string;
-  cuerpoWhastapp?: string;
+	id: string;
+	nombre: string;
+	etapa: string;
+	asunto: string;
+	cuerpo: string;
+	cuerpoWhastapp?: string;
 }
 
 export const COBROS_NO_REPLY_WARNING =
-  "*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+	"*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
 export const COBROS_MOTIVO_SIN_TELEFONO_ASESOR = "sin teléfono de asesor";
 
 export function prepararTelefonoAsesorParaEnvio(
-  cuerpo: string,
-  telefono: string | null | undefined,
+	cuerpo: string,
+	telefono: string | null | undefined,
 ):
-  | { enviar: true; telefonoAsesor: string }
-  | { enviar: false; motivo: string } {
-  const telefonoAsesor = telefono?.trim() ?? "";
+	| { enviar: true; telefonoAsesor: string }
+	| { enviar: false; motivo: string } {
+	const telefonoAsesor = telefono?.trim() ?? "";
 
-  if (cuerpo.includes(COBROS_NO_REPLY_WARNING) && !telefonoAsesor) {
-    return { enviar: false, motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR };
-  }
+	if (cuerpo.includes(COBROS_NO_REPLY_WARNING) && !telefonoAsesor) {
+		return { enviar: false, motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR };
+	}
 
-  return { enviar: true, telefonoAsesor };
+	return { enviar: true, telefonoAsesor };
 }
 
 export function crearUrlWhatsappManual(
-  telefonoLimpio: string,
-  mensajeWhatsapp: string,
-  mensajeFallback = "",
+	telefonoLimpio: string,
+	mensajeWhatsapp: string,
+	mensajeFallback = "",
 ): string {
-  const mensaje = mensajeWhatsapp || mensajeFallback;
-  return mensaje
-    ? `https://wa.me/${telefonoLimpio}?text=${encodeURIComponent(mensaje)}`
-    : `https://wa.me/${telefonoLimpio}`;
+	const mensaje = mensajeWhatsapp || mensajeFallback;
+	return mensaje
+		? `https://wa.me/${telefonoLimpio}?text=${encodeURIComponent(mensaje)}`
+		: `https://wa.me/${telefonoLimpio}`;
 }
 
 export function mensajePlantillaEditable(
-  metodoContacto: string,
-  mensajeEditado: string,
-  mensajeWhatsappEditado: string,
+	metodoContacto: string,
+	mensajeEditado: string,
+	mensajeWhatsappEditado: string,
 ): string {
-  return metodoContacto === "whatsapp" ? mensajeWhatsappEditado : mensajeEditado;
+	return metodoContacto === "whatsapp"
+		? mensajeWhatsappEditado
+		: mensajeEditado;
 }
 
 export function mensajeSmsEditable(
-  metodoInicial: string,
-  mensajeEditado: string,
-  mensajeWhatsappEditado: string,
+	metodoInicial: string,
+	mensajeEditado: string,
+	mensajeWhatsappEditado: string,
 ): string {
-  return mensajePlantillaEditable(
-    metodoInicial,
-    mensajeEditado,
-    mensajeWhatsappEditado,
-  );
+	return mensajePlantillaEditable(
+		metodoInicial,
+		mensajeEditado,
+		mensajeWhatsappEditado,
+	);
 }
 
 export function mensajeEmailEditable(
-  metodoInicial: string,
-  mensajeEditado: string,
-  mensajeWhatsappEditado: string,
+	metodoInicial: string,
+	mensajeEditado: string,
+	mensajeWhatsappEditado: string,
 ): string {
-  return mensajePlantillaEditable(
-    metodoInicial,
-    mensajeEditado,
-    mensajeWhatsappEditado,
-  );
+	return mensajePlantillaEditable(
+		metodoInicial,
+		mensajeEditado,
+		mensajeWhatsappEditado,
+	);
 }
 
 export function accionUsaCuerpoNoReply(metodo: string): boolean {
-  return (
-    metodo === "whatsapp-link" || metodo === "whatsapp-api" || metodo === "sms-api"
-  );
+	return (
+		metodo === "whatsapp-link" ||
+		metodo === "whatsapp-api" ||
+		metodo === "sms-api" ||
+		metodo === "email-link" ||
+		metodo === "email-api"
+	);
 }
 
 export function cuerpoParaValidarNoReply(
-  metodo: string,
-  mensajeWhatsapp: string,
-  mensajeSms: string,
+	metodo: string,
+	mensajeWhatsapp: string,
+	mensajeSms: string,
+	mensajeEmail = mensajeWhatsapp,
 ): string {
-  return metodo === "sms-api" ? mensajeSms : mensajeWhatsapp;
+	if (metodo === "email-link" || metodo === "email-api") return mensajeEmail;
+	return metodo === "sms-api" ? mensajeSms : mensajeWhatsapp;
 }
 
 function toCapitalCase(str: string): string {
-  return str
-    .toLowerCase()
-    .split(" ")
-    .map((word) => (word ? word[0].toUpperCase() + word.slice(1) : ""))
-    .join(" ");
+	return str
+		.toLowerCase()
+		.split(" ")
+		.map((word) => (word ? word[0].toUpperCase() + word.slice(1) : ""))
+		.join(" ");
 }
 
 export function interpolar(
-  texto: string,
-  variables: VariablesPlantilla,
+	texto: string,
+	variables: VariablesPlantilla,
 ): string {
-  const v = (val: string | number, _placeholder: string) =>
-    val !== undefined && val !== null && val !== "" && val !== 0
-      ? String(val)
-      : "";
+	const v = (val: string | number, _placeholder: string) =>
+		val !== undefined && val !== null && val !== "" && val !== 0
+			? String(val)
+			: "";
 
-  const nombre = variables.clienteNombre
-    ? toCapitalCase(variables.clienteNombre)
-    : "";
+	const nombre = variables.clienteNombre
+		? toCapitalCase(variables.clienteNombre)
+		: "";
 
-  return texto
-    .replace(/{clienteNombre}/g, v(nombre, "nombre cliente"))
-    .replace(/{fechaPago}/g, v(variables.fechaPago, "fecha pago"))
-    .replace(/{cuotaMensual}/g, v(variables.cuotaMensual, "cuota mensual"))
-    .replace(/{placa}/g, v(variables.placa, "placa"))
-    .replace(
-      /{marcaLineaModelo}/g,
-      v(variables.marcaLineaModelo, "marca/modelo"),
-    )
-    .replace(/{montoAdeudado}/g, v(variables.montoAdeudado, "monto adeudado"))
-    .replace(/{cuotasAtraso}/g, v(variables.cuotasAtraso, "cuotas en atraso"))
-    .replace(
-      /{telefonoAsesor}/g,
-      v(variables.telefonoAsesor, "teléfono asesor"),
-    )
-    .replace(/{nombreAsesor}/g, v(variables.nombreAsesor, "nombre asesor"));
+	return texto
+		.replace(/{clienteNombre}/g, v(nombre, "nombre cliente"))
+		.replace(/{fechaPago}/g, v(variables.fechaPago, "fecha pago"))
+		.replace(/{cuotaMensual}/g, v(variables.cuotaMensual, "cuota mensual"))
+		.replace(/{placa}/g, v(variables.placa, "placa"))
+		.replace(
+			/{marcaLineaModelo}/g,
+			v(variables.marcaLineaModelo, "marca/modelo"),
+		)
+		.replace(/{montoAdeudado}/g, v(variables.montoAdeudado, "monto adeudado"))
+		.replace(/{cuotasAtraso}/g, v(variables.cuotasAtraso, "cuotas en atraso"))
+		.replace(
+			/{telefonoAsesor}/g,
+			v(variables.telefonoAsesor, "teléfono asesor"),
+		)
+		.replace(/{nombreAsesor}/g, v(variables.nombreAsesor, "nombre asesor"));
 }
 
 export const PLANTILLAS_MENSAJES: PlantillaMensaje[] = [
-  {
-    id: "bienvenida",
-    nombre: "Bienvenida",
-    etapa: "al_dia",
-    asunto: "Bienvenido/a a su plan de financiamiento",
-    cuerpo: `Hola {clienteNombre},
+	{
+		id: "bienvenida",
+		nombre: "Bienvenida",
+		etapa: "al_dia",
+		asunto: "Bienvenido/a a su plan de financiamiento",
+		cuerpo: `Hola {clienteNombre},
 
 Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
 
@@ -171,7 +179,7 @@ Agradecemos confirme la recepción de este mensaje.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
+		cuerpoWhastapp: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
@@ -180,29 +188,29 @@ Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplic
 ${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
-  },
-  {
-    id: "al_dia",
-    nombre: "Recordatorio de pago",
-    etapa: "al_dia",
-    asunto: "Recordatorio de pago - Vehículo {placa}",
-    cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+	},
+	{
+		id: "al_dia",
+		nombre: "Recordatorio de pago",
+		etapa: "al_dia",
+		asunto: "Recordatorio de pago - Vehículo {placa}",
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
 
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+		cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
 
 ${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
-  },
-  {
-    id: "pre_mora",
-    nombre: "Aviso de atraso",
-    etapa: "pre_mora",
-    asunto: "Aviso de atraso en pago - Vehículo {placa}",
-    cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
+	},
+	{
+		id: "pre_mora",
+		nombre: "Aviso de atraso",
+		etapa: "pre_mora",
+		asunto: "Aviso de atraso en pago - Vehículo {placa}",
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
 Si tiene alguna duda por favor comunicarse por este medio.
 
@@ -211,7 +219,7 @@ SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
+		cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
 Si tiene alguna duda, por favor comuníquese al {telefonoAsesor}.
 
@@ -220,29 +228,29 @@ SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 ${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
-  },
-  {
-    id: "mora_30",
-    nombre: "Mora 30 días",
-    etapa: "mora_30",
-    asunto: "URGENTE: Mora de 30 días - Vehículo {placa}",
-    cuerpo: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+	},
+	{
+		id: "mora_30",
+		nombre: "Mora 30 días",
+		etapa: "mora_30",
+		asunto: "URGENTE: Mora de 30 días - Vehículo {placa}",
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
 
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+		cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
 
 ${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
-  },
-  {
-    id: "mora_60",
-    nombre: "Mora 60 días",
-    etapa: "mora_60",
-    asunto: "AVISO IMPORTANTE: Mora de 60 días - Vehículo {placa}",
-    cuerpo: `Estimado/a {clienteNombre},
+	},
+	{
+		id: "mora_60",
+		nombre: "Mora 60 días",
+		etapa: "mora_60",
+		asunto: "AVISO IMPORTANTE: Mora de 60 días - Vehículo {placa}",
+		cuerpo: `Estimado/a {clienteNombre},
 
 Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
 
@@ -251,62 +259,62 @@ Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a to
 Atentamente,
 {nombreAsesor}
 Tel: {telefonoAsesor}`,
-    cuerpoWhastapp: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
+		cuerpoWhastapp: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
 
 Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
 
 ${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
-  },
-  {
-    id: "aviso_juridico",
-    nombre: "Aviso jurídico",
-    etapa: "mora_90",
-    asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
-    cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+	},
+	{
+		id: "aviso_juridico",
+		nombre: "Aviso jurídico",
+		etapa: "mora_90",
+		asunto: "ÚLTIMO AVISO: Proceso jurídico - Vehículo {placa}",
+		cuerpo: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-    cuerpoWhastapp: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+		cuerpoWhastapp: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 ${COBROS_NO_REPLY_WARNING}
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-  },
+	},
 ];
 
 /** Sugiere una plantilla según el estado de mora y antigüedad del caso */
 export function sugerirPlantilla(
-  estadoMora: string | undefined,
-  fechaInicio?: string | Date | null,
+	estadoMora: string | undefined,
+	fechaInicio?: string | Date | null,
 ): string {
-  const mapaMora: Record<string, string> = {
-    pre_mora: "pre_mora",
-    mora_30: "mora_30",
-    mora_60: "mora_60",
-    mora_90: "aviso_juridico",
-    incobrable: "aviso_juridico",
-  };
+	const mapaMora: Record<string, string> = {
+		pre_mora: "pre_mora",
+		mora_30: "mora_30",
+		mora_60: "mora_60",
+		mora_90: "aviso_juridico",
+		incobrable: "aviso_juridico",
+	};
 
-  // Si tiene mora, usar plantilla correspondiente
-  if (estadoMora && mapaMora[estadoMora]) {
-    return mapaMora[estadoMora];
-  }
+	// Si tiene mora, usar plantilla correspondiente
+	if (estadoMora && mapaMora[estadoMora]) {
+		return mapaMora[estadoMora];
+	}
 
-  // Si es cliente reciente (menos de 30 días), bienvenida
-  if (fechaInicio) {
-    const inicio = new Date(fechaInicio);
-    const diasDesdeInicio =
-      (Date.now() - inicio.getTime()) / (1000 * 60 * 60 * 24);
-    if (diasDesdeInicio <= 30) {
-      return "bienvenida";
-    }
-  }
+	// Si es cliente reciente (menos de 30 días), bienvenida
+	if (fechaInicio) {
+		const inicio = new Date(fechaInicio);
+		const diasDesdeInicio =
+			(Date.now() - inicio.getTime()) / (1000 * 60 * 60 * 24);
+		if (diasDesdeInicio <= 30) {
+			return "bienvenida";
+		}
+	}
 
-  // Fallback: recordatorio de pago
-  return "al_dia";
+	// Fallback: recordatorio de pago
+	return "al_dia";
 }

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -60,6 +60,14 @@ export function crearUrlWhatsappManual(
     : `https://wa.me/${telefonoLimpio}`;
 }
 
+export function mensajePlantillaEditable(
+  metodoContacto: string,
+  mensajeEditado: string,
+  mensajeWhatsappEditado: string,
+): string {
+  return metodoContacto === "whatsapp" ? mensajeWhatsappEditado : mensajeEditado;
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -49,6 +49,17 @@ export function prepararTelefonoAsesorParaEnvio(
   return { enviar: true, telefonoAsesor };
 }
 
+export function crearUrlWhatsappManual(
+  telefonoLimpio: string,
+  mensajeWhatsapp: string,
+  mensajeFallback = "",
+): string {
+  const mensaje = mensajeWhatsapp || mensajeFallback;
+  return mensaje
+    ? `https://wa.me/${telefonoLimpio}?text=${encodeURIComponent(mensaje)}`
+    : `https://wa.me/${telefonoLimpio}`;
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -32,6 +32,22 @@ export interface PlantillaMensaje {
 
 export const COBROS_NO_REPLY_WARNING =
   "*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+export const COBROS_MOTIVO_SIN_TELEFONO_ASESOR = "sin teléfono de asesor";
+
+export function prepararTelefonoAsesorParaEnvio(
+  cuerpo: string,
+  telefono: string | null | undefined,
+):
+  | { enviar: true; telefonoAsesor: string }
+  | { enviar: false; motivo: string } {
+  const telefonoAsesor = telefono?.trim() ?? "";
+
+  if (cuerpo.includes(COBROS_NO_REPLY_WARNING) && !telefonoAsesor) {
+    return { enviar: false, motivo: COBROS_MOTIVO_SIN_TELEFONO_ASESOR };
+  }
+
+  return { enviar: true, telefonoAsesor };
+}
 
 function toCapitalCase(str: string): string {
   return str

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -80,6 +80,18 @@ export function mensajeSmsEditable(
   );
 }
 
+export function mensajeEmailEditable(
+  metodoInicial: string,
+  mensajeEditado: string,
+  mensajeWhatsappEditado: string,
+): string {
+  return mensajePlantillaEditable(
+    metodoInicial,
+    mensajeEditado,
+    mensajeWhatsappEditado,
+  );
+}
+
 export function accionUsaCuerpoNoReply(metodo: string): boolean {
   return (
     metodo === "whatsapp-link" || metodo === "whatsapp-api" || metodo === "sms-api"

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -80,6 +80,12 @@ export function mensajeSmsEditable(
   );
 }
 
+export function accionUsaCuerpoNoReply(metodo: string): boolean {
+  return (
+    metodo === "whatsapp-link" || metodo === "whatsapp-api" || metodo === "sms-api"
+  );
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -102,7 +102,7 @@ Tel: {telefonoAsesor}.`,
 
 A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
 
-Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
 
 ${COBROS_NO_REPLY_WARNING}
 
@@ -140,7 +140,7 @@ Atentamente,
 Tel: {telefonoAsesor}.`,
     cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
 
-Si tiene alguna duda por favor comunicarse por este medio.
+Si tiene alguna duda, por favor comuníquese al {telefonoAsesor}.
 
 SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 
@@ -196,7 +196,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-    cuerpoWhastapp: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+    cuerpoWhastapp: `Señor(a) {clienteNombre}, le informamos que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
 
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -68,6 +68,18 @@ export function mensajePlantillaEditable(
   return metodoContacto === "whatsapp" ? mensajeWhatsappEditado : mensajeEditado;
 }
 
+export function mensajeSmsEditable(
+  metodoInicial: string,
+  mensajeEditado: string,
+  mensajeWhatsappEditado: string,
+): string {
+  return mensajePlantillaEditable(
+    metodoInicial,
+    mensajeEditado,
+    mensajeWhatsappEditado,
+  );
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -106,7 +106,7 @@ Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor} para aplic
 
 ${COBROS_NO_REPLY_WARNING}
 
-Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "al_dia",

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -86,6 +86,14 @@ export function accionUsaCuerpoNoReply(metodo: string): boolean {
   );
 }
 
+export function cuerpoParaValidarNoReply(
+  metodo: string,
+  mensajeWhatsapp: string,
+  mensajeSms: string,
+): string {
+  return metodo === "sms-api" ? mensajeSms : mensajeWhatsapp;
+}
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -30,6 +30,9 @@ export interface PlantillaMensaje {
   cuerpoWhastapp?: string;
 }
 
+export const COBROS_NO_REPLY_WARNING =
+  "*NO RESPONDER EN ESTE CHAT, CONTESTAR AL NUMERO DE SU ASESOR DE COBROS*";
+
 function toCapitalCase(str: string): string {
   return str
     .toLowerCase()
@@ -95,8 +98,15 @@ Agradecemos confirme la recepción de este mensaje.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.\n\nA continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL\n\nPor favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.\n\nAgradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Hola {clienteNombre}, Le saludamos cordialmente de Clubcashin.com para recordarle sobre el pago de su crédito, el cual debe realizarse el {fechaPago}. Sus cuotas son por un monto de Q{cuotaMensual}.
+
+A continuación, le compartimos los números de cuenta para realizar su depósito o transferencia: - CUBE INVESTMENTS, S.A. (monetaria) No. 5520029876 BANCO INDUSTRIAL (BI) / CUBE INVESTMENTS, S.A. (monetaria) No. 3020123033 BANCO AGROMERCANTIL (BAM) / CUBE INVESTMENTS, S.A. (monetaria) No. 01300039945 BANCO GyT CONTINENTAL / CUBE INVESTMENTS, S.A. (monetaria) No. 3394002346 BANRURAL
+
+Por favor, envíe su boleta o comprobante de pago por este medio para aplicarlo a su cuenta. Si tiene alguna duda o consulta, estamos a su disposición.
+
+${COBROS_NO_REPLY_WARNING}
+
+Agradecemos confirme la recepción de este mensaje. Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "al_dia",
@@ -108,8 +118,11 @@ Tel: {telefonoAsesor}.`,
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago de su crédito el día de hoy, quedamos a la espera de su comprobante de pago.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "pre_mora",
@@ -125,8 +138,15 @@ SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.\n\nSi tiene alguna duda por favor comunicarse por este medio.\n\nSI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Hola {clienteNombre}, le saludamos de Clubcashin recordándole que su cuota esta próxima a vencer. Su día de pago es el {fechaPago}. Ponemos a su disposición nuestros medios de pago en Banco Industrial, BANRURAL, Banco Agromercantil (BAM) y GyT.
+
+Si tiene alguna duda por favor comunicarse por este medio.
+
+SI YA REALIZO SU PAGO POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "mora_30",
@@ -138,8 +158,11 @@ Tel: {telefonoAsesor}.`,
 Atentamente, 
 {nombreAsesor} 
 Tel: {telefonoAsesor}.`,
-    cuerpoWhastapp:
-      "Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}.",
+    cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, el motivo de la notificación es porque tenemos 1 cuota en atraso, se solicita que su pago sea lo antes posible para poder solventar su situación, quedaremos a la espera de su boleta el día {fechaPago}.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
   },
   {
     id: "mora_60",
@@ -155,8 +178,13 @@ Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a to
 Atentamente,
 {nombreAsesor}
 Tel: {telefonoAsesor}`,
-    cuerpoWhastapp:
-      "Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.\n\nSi no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.\n\nAtentamente, {nombreAsesor} Tel: {telefonoAsesor}",
+    cuerpoWhastapp: `Estimado/a {clienteNombre}, Buen día. El motivo de la notificación es porque tenemos {cuotasAtraso} cuota(s) en atraso. Se solicita que su pago sea lo antes posible para poder solventar su situación. Quedaremos a la espera de su boleta el día {fechaPago}.
+
+Si no recibimos el pago dentro del plazo establecido, nos veremos obligados a tomar medidas adicionales para recuperar la deuda, incluida la posible ejecución del vehículo y el apagado de la unidad en movimiento o estacionado.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}`,
   },
   {
     id: "aviso_juridico",
@@ -168,8 +196,13 @@ Tel: {telefonoAsesor}`,
 Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
 
 Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
-    cuerpoWhastapp:
-      "Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.\n\nPor lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.\n\nFavor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.",
+    cuerpoWhastapp: `Señor(a) {clienteNombre}, por este medio hacemos de su conocimiento que su obligación adquirida por medio de la plataforma de inversión CLUB CASH IN por la compra del vehículo ({placa}) {marcaLineaModelo}, se encuentra con {cuotasAtraso} cuota(s) de atraso, por un monto de {montoAdeudado} incluyendo moras.
+
+Por lo que le solicitamos ponerse en contacto con nosotros para entregar la unidad en un plazo no mayor de 24 horas para solventar su situación. De no obtener respuesta en el plazo establecido, procederemos a presentar DEMANDA en su contra por denuncia de robo.
+
+${COBROS_NO_REPLY_WARNING}
+
+Favor de comunicarse a los siguientes números: {telefonoAsesor} y 2234-1333. Nuestro horario de atención es de lunes a viernes en horario de 8:00 a 17:00 hrs.`,
   },
 ];
 

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -160,6 +160,32 @@ function TabMora({
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const alcance = (data as any)?.alcance as "live" | "historico" | undefined;
 
+	// Cobrado (mora cobrada en el período del mes). Solo aplica en modo "mes".
+	const anioNum = Number(mesAnio.slice(0, 4));
+	const mesNum = Number(mesAnio.slice(5, 7));
+	const { data: cobradoData } = useQuery({
+		...orpc.getMoraCobradaPorAsesor.queryOptions({
+			input: {
+				mes: mesNum,
+				anio: anioNum,
+				asesores: asesoresSel ?? undefined,
+				emailCobrador,
+			},
+		}),
+		enabled: !!session && modo === "mes",
+	});
+	const cobradoMap = useMemo(() => {
+		const m = new Map<number, number>();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		for (const a of ((cobradoData as any)?.porAsesor ?? []) as any[]) {
+			m.set(a.asesorId, Number(a.cobrado));
+		}
+		return m;
+	}, [cobradoData]);
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const totalCobrado = Number((cobradoData as any)?.totalCobrado ?? 0);
+	const verCobrado = modo === "mes";
+
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
 	return (
@@ -296,7 +322,9 @@ function TabMora({
 			)}
 
 			{porAsesor.length > 0 && (
-				<div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+				<div
+					className={`grid grid-cols-1 gap-4 md:grid-cols-2 ${verCobrado ? "lg:grid-cols-3" : ""}`}
+				>
 					<Card className="border-red-200 bg-red-50">
 						<CardContent className="pt-4">
 							<p className="font-semibold text-red-700 text-sm">
@@ -323,6 +351,23 @@ function TabMora({
 							</p>
 						</CardContent>
 					</Card>
+					{verCobrado && (
+						<Card className="border-green-200 bg-green-50">
+							<CardContent className="pt-4">
+								<p className="font-semibold text-green-700 text-sm">
+									Mora Cobrada (en el mes)
+								</p>
+								<p className="font-bold text-3xl text-green-800">
+									{fmtQ(totalCobrado)}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{totalConGerencia > 0
+										? `${((totalCobrado / totalConGerencia) * 100).toFixed(1)}% de lo esperado`
+										: "—"}
+								</p>
+							</CardContent>
+						</Card>
+					)}
 				</div>
 			)}
 
@@ -352,6 +397,19 @@ function TabMora({
 									<th className="px-4 py-3 text-right font-semibold">
 										Total en Mora
 									</th>
+									{verCobrado && (
+										<>
+											<th className="px-4 py-3 text-right font-semibold">
+												Cobrado
+											</th>
+											<th className="px-4 py-3 text-right font-semibold">
+												% Cobrado
+											</th>
+											<th className="px-4 py-3 text-right font-semibold">
+												Pendiente
+											</th>
+										</>
+									)}
 								</tr>
 							</thead>
 							<tbody>
@@ -408,6 +466,33 @@ function TabMora({
 												) : null;
 											})()}
 										</td>
+										{verCobrado &&
+											(() => {
+												const esperado = Number.parseFloat(
+													asesor.totalEnMora?.sumaMora ?? "0",
+												);
+												const cobrado = cobradoMap.get(asesor.asesorId) ?? 0;
+												const pct =
+													esperado > 0 ? (cobrado / esperado) * 100 : 0;
+												const pendiente = esperado - cobrado;
+												return (
+													<>
+														<td className="px-4 py-3 text-right font-medium text-green-700">
+															{cobrado > 0 ? (
+																fmtQ(cobrado)
+															) : (
+																<span className="text-muted-foreground">—</span>
+															)}
+														</td>
+														<td className="px-4 py-3 text-right text-muted-foreground">
+															{esperado > 0 ? `${pct.toFixed(1)}%` : "—"}
+														</td>
+														<td className="px-4 py-3 text-right">
+															{fmtQ(pendiente)}
+														</td>
+													</>
+												);
+											})()}
 									</tr>
 								))}
 							</tbody>
@@ -440,6 +525,30 @@ function TabMora({
 												{(data as any).totales.totalEnMora?.cantidad ?? 0} créd.
 											</div>
 										</td>
+										{verCobrado &&
+											(() => {
+												// eslint-disable-next-line @typescript-eslint/no-explicit-any
+												const esperadoTot = Number.parseFloat(
+													(data as any).totales.totalEnMora?.sumaMora ?? "0",
+												);
+												const pctTot =
+													esperadoTot > 0
+														? (totalCobrado / esperadoTot) * 100
+														: 0;
+												return (
+													<>
+														<td className="px-4 py-3 text-right text-green-700">
+															{fmtQ(totalCobrado)}
+														</td>
+														<td className="px-4 py-3 text-right font-normal text-muted-foreground">
+															{esperadoTot > 0 ? `${pctTot.toFixed(1)}%` : "—"}
+														</td>
+														<td className="px-4 py-3 text-right">
+															{fmtQ(esperadoTot - totalCobrado)}
+														</td>
+													</>
+												);
+											})()}
 									</tr>
 								</tfoot>
 							)}
@@ -569,7 +678,7 @@ function RubroCelda({
 		<div className="space-y-0.5 text-right">
 			<div className="text-muted-foreground text-xs">{fmtQ(esperado)}</div>
 			<div
-				className={`text-xs font-medium ${pagadoNum > 0 ? "text-green-600" : "text-muted-foreground/40"}`}
+				className={`font-medium text-xs ${pagadoNum > 0 ? "text-green-600" : "text-muted-foreground/40"}`}
 			>
 				{pagadoNum > 0 ? fmtQ(pagado) : "—"}
 			</div>
@@ -747,18 +856,16 @@ function TabCuotasPorFecha({
 		enabled: !!session && canSeeAll,
 	});
 
-	const {
-		data,
-		isLoading,
-		dataUpdatedAt,
-		refetch,
-		isFetching,
-	} = useQuery({
+	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
 		...orpc.getCuotasPorFecha.queryOptions({
 			input: {
 				fechaInicio,
 				fechaFin,
-				asesorId: canSeeAll ? (asesorId ? Number(asesorId) : undefined) : undefined,
+				asesorId: canSeeAll
+					? asesorId
+						? Number(asesorId)
+						: undefined
+					: undefined,
 			},
 		}),
 		enabled: !!session && !!fechaInicio && !!fechaFin,
@@ -784,9 +891,10 @@ function TabCuotasPorFecha({
 		return "pendiente";
 	}
 
-	const filteredRows = filtroEstado === "todos"
-		? rows
-		: rows.filter((r) => getEstado(r) === filtroEstado);
+	const filteredRows =
+		filtroEstado === "todos"
+			? rows
+			: rows.filter((r) => getEstado(r) === filtroEstado);
 
 	return (
 		<div className="space-y-6">
@@ -918,7 +1026,7 @@ function TabCuotasPorFecha({
 			{/* Summary cards */}
 			<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
 				<Card className="gap-1 border-blue-200 bg-blue-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-blue-700 text-xs">
 							Total Esperado
 						</CardTitle>
@@ -930,7 +1038,7 @@ function TabCuotasPorFecha({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-green-200 bg-green-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-green-700 text-xs">
 							Total Pagado
 						</CardTitle>
@@ -942,19 +1050,19 @@ function TabCuotasPorFecha({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-red-200 bg-red-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-red-700 text-xs">
 							Total Pendiente
 						</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-red-700 text-lg">
+						<div className="font-bold text-lg text-red-700">
 							{fmtQ(totales?.totalPendiente ?? "0")}
 						</div>
 					</CardContent>
 				</Card>
 				<Card className="gap-1 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-xs">Cuotas</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">
@@ -979,7 +1087,7 @@ function TabCuotasPorFecha({
 					] as const
 				).map((c) => (
 					<Card key={c.key} className="gap-0.5 py-2.5">
-						<CardHeader className="px-3 pb-0 pt-0">
+						<CardHeader className="px-3 pt-0 pb-0">
 							<CardTitle className="font-medium text-muted-foreground text-xs">
 								{c.label}
 							</CardTitle>
@@ -994,7 +1102,11 @@ function TabCuotasPorFecha({
 			</div>
 
 			{/* Detail table */}
-			<DataTable columns={colsCuotas} data={filteredRows} isLoading={isLoading} />
+			<DataTable
+				columns={colsCuotas}
+				data={filteredRows}
+				isLoading={isLoading}
+			/>
 		</div>
 	);
 }
@@ -1054,28 +1166,98 @@ const colsDescuentos: ColumnDef<DescuentoRow>[] = [
 			</div>
 		),
 	},
-	{ accessorKey: "multas", header: "Multas", cell: ({ row }) => fmtDesc(row.original.multas) },
-	{ accessorKey: "copiaDeLlave", header: "Copia llave", cell: ({ row }) => fmtDesc(row.original.copiaDeLlave) },
-	{ accessorKey: "diferenciaCopia", header: "Dif. copia", cell: ({ row }) => fmtDesc(row.original.diferenciaCopia) },
-	{ accessorKey: "impuestoCirculacion", header: "Imp. circulación", cell: ({ row }) => fmtDesc(row.original.impuestoCirculacion) },
-	{ accessorKey: "garantiaMobiliaria", header: "Garantía mob.", cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria) },
-	{ accessorKey: "placas", header: "Placas", cell: ({ row }) => fmtDesc(row.original.placas) },
-	{ accessorKey: "contratoLeasing", header: "Cto. leasing", cell: ({ row }) => fmtDesc(row.original.contratoLeasing) },
-	{ accessorKey: "verificacionDireccion", header: "Verif. dirección", cell: ({ row }) => fmtDesc(row.original.verificacionDireccion) },
-	{ accessorKey: "traspasoVehiculo", header: "Traspaso", cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo) },
-	{ accessorKey: "intereses", header: "Intereses", cell: ({ row }) => fmtDesc(row.original.intereses) },
-	{ accessorKey: "rcdp", header: "RCDP", cell: ({ row }) => fmtDesc(row.original.rcdp) },
-	{ accessorKey: "gps", header: "GPS", cell: ({ row }) => fmtDesc(row.original.gps) },
-	{ accessorKey: "seguro", header: "Seguro", cell: ({ row }) => fmtDesc(row.original.seguro) },
-	{ accessorKey: "membresia", header: "Membresía", cell: ({ row }) => fmtDesc(row.original.membresia) },
-	{ accessorKey: "gastosAdmin", header: "Gastos admin", cell: ({ row }) => fmtDesc(row.original.gastosAdmin) },
-	{ accessorKey: "freelance", header: "Free Lance", cell: ({ row }) => fmtDesc(row.original.freelance) },
-	{ accessorKey: "royalty", header: "Royalty", cell: ({ row }) => fmtDesc(row.original.royalty) },
+	{
+		accessorKey: "multas",
+		header: "Multas",
+		cell: ({ row }) => fmtDesc(row.original.multas),
+	},
+	{
+		accessorKey: "copiaDeLlave",
+		header: "Copia llave",
+		cell: ({ row }) => fmtDesc(row.original.copiaDeLlave),
+	},
+	{
+		accessorKey: "diferenciaCopia",
+		header: "Dif. copia",
+		cell: ({ row }) => fmtDesc(row.original.diferenciaCopia),
+	},
+	{
+		accessorKey: "impuestoCirculacion",
+		header: "Imp. circulación",
+		cell: ({ row }) => fmtDesc(row.original.impuestoCirculacion),
+	},
+	{
+		accessorKey: "garantiaMobiliaria",
+		header: "Garantía mob.",
+		cell: ({ row }) => fmtDesc(row.original.garantiaMobiliaria),
+	},
+	{
+		accessorKey: "placas",
+		header: "Placas",
+		cell: ({ row }) => fmtDesc(row.original.placas),
+	},
+	{
+		accessorKey: "contratoLeasing",
+		header: "Cto. leasing",
+		cell: ({ row }) => fmtDesc(row.original.contratoLeasing),
+	},
+	{
+		accessorKey: "verificacionDireccion",
+		header: "Verif. dirección",
+		cell: ({ row }) => fmtDesc(row.original.verificacionDireccion),
+	},
+	{
+		accessorKey: "traspasoVehiculo",
+		header: "Traspaso",
+		cell: ({ row }) => fmtDesc(row.original.traspasoVehiculo),
+	},
+	{
+		accessorKey: "intereses",
+		header: "Intereses",
+		cell: ({ row }) => fmtDesc(row.original.intereses),
+	},
+	{
+		accessorKey: "rcdp",
+		header: "RCDP",
+		cell: ({ row }) => fmtDesc(row.original.rcdp),
+	},
+	{
+		accessorKey: "gps",
+		header: "GPS",
+		cell: ({ row }) => fmtDesc(row.original.gps),
+	},
+	{
+		accessorKey: "seguro",
+		header: "Seguro",
+		cell: ({ row }) => fmtDesc(row.original.seguro),
+	},
+	{
+		accessorKey: "membresia",
+		header: "Membresía",
+		cell: ({ row }) => fmtDesc(row.original.membresia),
+	},
+	{
+		accessorKey: "gastosAdmin",
+		header: "Gastos admin",
+		cell: ({ row }) => fmtDesc(row.original.gastosAdmin),
+	},
+	{
+		accessorKey: "freelance",
+		header: "Free Lance",
+		cell: ({ row }) => fmtDesc(row.original.freelance),
+	},
+	{
+		accessorKey: "royalty",
+		header: "Royalty",
+		cell: ({ row }) => fmtDesc(row.original.royalty),
+	},
 	{
 		accessorKey: "totalDescuentos",
 		header: "Total",
 		cell: ({ row }) => (
-			<span className="font-semibold">{fmtQ(row.original.totalDescuentos)}</span>
+			<span className="font-semibold">
+				{fmtQ(row.original.totalDescuentos)}
+			</span>
 		),
 	},
 ];
@@ -1140,18 +1322,18 @@ function TabDescuentos({
 				hideSearch
 				stickyFirstColumn
 				serverPagination={
-						data
-							? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-								{
-									page: (data as any).page,
-									pageSize: (data as any).pageSize,
-									totalPages: (data as any).totalPages,
-									totalItems: (data as any).total,
-									onPageChange: setPage,
-								}
-							: undefined
-					}
-				/>
+					data
+						? // eslint-disable-next-line @typescript-eslint/no-explicit-any
+							{
+								page: (data as any).page,
+								pageSize: (data as any).pageSize,
+								totalPages: (data as any).totalPages,
+								totalItems: (data as any).total,
+								onPageChange: setPage,
+							}
+						: undefined
+				}
+			/>
 		</div>
 	);
 }

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -163,7 +163,7 @@ function TabMora({
 	// Cobrado (mora cobrada en el período del mes). Solo aplica en modo "mes".
 	const anioNum = Number(mesAnio.slice(0, 4));
 	const mesNum = Number(mesAnio.slice(5, 7));
-	const { data: cobradoData } = useQuery({
+	const { data: cobradoData, refetch: refetchCobrado } = useQuery({
 		...orpc.getMoraCobradaPorAsesor.queryOptions({
 			input: {
 				mes: mesNum,
@@ -175,16 +175,31 @@ function TabMora({
 		enabled: !!session && modo === "mes",
 	});
 	const cobradoMap = useMemo(() => {
-		const m = new Map<number, number>();
+		const m = new Map<number, { cobrado: number; nombre: string }>();
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		for (const a of ((cobradoData as any)?.porAsesor ?? []) as any[]) {
-			m.set(a.asesorId, Number(a.cobrado));
+			m.set(a.asesorId, { cobrado: Number(a.cobrado), nombre: a.nombre });
 		}
 		return m;
 	}, [cobradoData]);
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	const totalCobrado = Number((cobradoData as any)?.totalCobrado ?? 0);
 	const verCobrado = modo === "mes";
+
+	// Filas del desglose = unión de asesores con mora esperada y/o cobrada. El
+	// total cobrado incluye pagos sobre créditos ya saldados / fuera del snapshot
+	// de mora activa, así que sin la unión las filas no sumarían el total.
+	const filasAsesor = useMemo(() => {
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const map = new Map<number, any>();
+		for (const a of porAsesor) map.set(a.asesorId, a);
+		if (verCobrado) {
+			for (const [id, c] of cobradoMap) {
+				if (!map.has(id)) map.set(id, { asesorId: id, nombre: c.nombre });
+			}
+		}
+		return [...map.values()];
+	}, [porAsesor, cobradoMap, verCobrado]);
 
 	const ultimaAct = dataUpdatedAt ? fmtTime(new Date(dataUpdatedAt)) : null;
 
@@ -204,7 +219,10 @@ function TabMora({
 					<Button
 						variant="outline"
 						size="sm"
-						onClick={() => refetch()}
+						onClick={() => {
+							refetch();
+							if (verCobrado) refetchCobrado();
+						}}
 						disabled={isFetching}
 					>
 						<RefreshCw
@@ -321,36 +339,40 @@ function TabMora({
 				</div>
 			)}
 
-			{porAsesor.length > 0 && (
+			{(porAsesor.length > 0 || (verCobrado && totalCobrado > 0)) && (
 				<div
 					className={`grid grid-cols-1 gap-4 md:grid-cols-2 ${verCobrado ? "lg:grid-cols-3" : ""}`}
 				>
-					<Card className="border-red-200 bg-red-50">
-						<CardContent className="pt-4">
-							<p className="font-semibold text-red-700 text-sm">
-								Total en Mora (con Gerencia)
-							</p>
-							<p className="font-bold text-3xl text-red-800">
-								{fmtQ(totalConGerencia)}
-							</p>
-							<p className="text-muted-foreground text-xs">
-								{credConGerencia} créditos
-							</p>
-						</CardContent>
-					</Card>
-					<Card className="border-orange-200 bg-orange-50">
-						<CardContent className="pt-4">
-							<p className="font-semibold text-orange-700 text-sm">
-								Total en Mora (sin Gerencia)
-							</p>
-							<p className="font-bold text-3xl text-orange-800">
-								{fmtQ(totalSinGerencia)}
-							</p>
-							<p className="text-muted-foreground text-xs">
-								{credSinGerencia} créditos
-							</p>
-						</CardContent>
-					</Card>
+					{porAsesor.length > 0 && (
+						<Card className="border-red-200 bg-red-50">
+							<CardContent className="pt-4">
+								<p className="font-semibold text-red-700 text-sm">
+									Total en Mora (con Gerencia)
+								</p>
+								<p className="font-bold text-3xl text-red-800">
+									{fmtQ(totalConGerencia)}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{credConGerencia} créditos
+								</p>
+							</CardContent>
+						</Card>
+					)}
+					{porAsesor.length > 0 && (
+						<Card className="border-orange-200 bg-orange-50">
+							<CardContent className="pt-4">
+								<p className="font-semibold text-orange-700 text-sm">
+									Total en Mora (sin Gerencia)
+								</p>
+								<p className="font-bold text-3xl text-orange-800">
+									{fmtQ(totalSinGerencia)}
+								</p>
+								<p className="text-muted-foreground text-xs">
+									{credSinGerencia} créditos
+								</p>
+							</CardContent>
+						</Card>
+					)}
 					{verCobrado && (
 						<Card className="border-green-200 bg-green-50">
 							<CardContent className="pt-4">
@@ -376,7 +398,7 @@ function TabMora({
 				{isLoading ? (
 					<div className="h-32 animate-pulse rounded bg-muted" />
 					// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				) : !(data as any)?.porAsesor?.length ? (
+				) : filasAsesor.length === 0 ? (
 					<p className="text-muted-foreground text-sm">
 						No hay datos disponibles.
 					</p>
@@ -414,7 +436,7 @@ function TabMora({
 							</thead>
 							<tbody>
 								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-								{(data as any).porAsesor.map((asesor: any) => (
+								{filasAsesor.map((asesor: any) => (
 									<tr
 										key={asesor.asesorId}
 										className="border-t hover:bg-muted/30"
@@ -471,10 +493,11 @@ function TabMora({
 												const esperado = Number.parseFloat(
 													asesor.totalEnMora?.sumaMora ?? "0",
 												);
-												const cobrado = cobradoMap.get(asesor.asesorId) ?? 0;
+												const cobrado =
+													cobradoMap.get(asesor.asesorId)?.cobrado ?? 0;
 												const pct =
 													esperado > 0 ? (cobrado / esperado) * 100 : 0;
-												const pendiente = esperado - cobrado;
+												const pendiente = Math.max(0, esperado - cobrado);
 												return (
 													<>
 														<td className="px-4 py-3 text-right font-medium text-green-700">
@@ -544,7 +567,7 @@ function TabMora({
 															{esperadoTot > 0 ? `${pctTot.toFixed(1)}%` : "—"}
 														</td>
 														<td className="px-4 py-3 text-right">
-															{fmtQ(esperadoTot - totalCobrado)}
+															{fmtQ(Math.max(0, esperadoTot - totalCobrado))}
 														</td>
 													</>
 												);


### PR DESCRIPTION
Release de `develop` → `main`. Agrupa dos líneas de trabajo independientes.

## 1. Cartera — devolución de créditos VERIFICADO en liquidación

Reestructura la Fase 5 (salida automática) de `liquidateByInvestorId` en `cartera-back/src/controllers/investor.ts`:

- **`skipStatusAndEmail` en `exitInvestor`**: cuando la liquidación devuelve a CUBE créditos con `estado_devolucion='VERIFICADO'` individuales, hace el SWAP/MERGE igual pero NO inactiva al inversionista ni envía correo (esos efectos solo aplican a salida total explícita). El flag es segundo argumento de función, no viene del body — un caller HTTP no puede activarlo.
- **Dos ramas mutuamente excluyentes**: rama `pendiente_devolucion` (salida total, con correo + inactiva) vs rama devolución de créditos VERIFICADO individuales. Elimina el doble envío a `exitInvestor`.
- **Validación de espejo**: un crédito solo se transfiere si tiene fila en `creditos_inversionistas_espejo` con `monto_aportado=0`; monto != 0 o sin fila se excluye y queda en `VERIFICADO` para revisión manual.
- **Chequeo de éxito**: se valida `exitResult.success` antes de marcar `COMPLETADO`/`inactivo`; solo se cierran los créditos realmente transferidos (`creditos_procesados`), no la lista de entrada.

Commits: `71abead2`, `5be9b381`, `bf58aa03`, `92dc67db`, `b7407d5e`, `001b4090`.

## 2. Cobros — mora cobrada por asesor

Nuevo desglose de mora cobrada por asesor (`pagos_credito.mora`) en el reporte de flujo:

- `getMoraCobradaPorAsesor` en `cartera-back` (`reportes.ts` + router), sin caché por ser reporte de flujo.
- Consumo desde CRM (`cobros.ts`, `cartera-back-client.ts`) y UI en `reportes.tsx`.
- Tests: `moraCobradaPorAsesor.test.ts` (mes vacío, orden, formato).

Commits: `d79dca4e`, `8400f643`, `3d1f8a31`, `21c34d71`.

## Archivos

```
apps/cartera-back/src/controllers/investor.ts               | 464 +-
apps/cartera-back/src/controllers/moraCobradaPorAsesor.test.ts |  75 +
apps/cartera-back/src/controllers/reportes.ts               |  53 +
apps/cartera-back/src/routers/reportes.ts                   |  43 +
apps/crm/apps/server/src/routers/cobros.ts                  |  26 +
apps/crm/apps/server/src/routers/index.ts                   |   4 +
apps/crm/apps/server/src/services/cartera-back-client.ts    |  54 +
apps/crm/apps/web/src/routes/cobros/reportes.tsx            | 365 +
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)