### PR TITLE
feat(cartera): add active portfolio excel report

### DIFF
--- a/apps/cartera-back/src/controllers/activePortfolioReport.test.ts
+++ b/apps/cartera-back/src/controllers/activePortfolioReport.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import ExcelJS from "exceljs";
+
+import {
+  ACTIVE_PORTFOLIO_STATUSES,
+  buildActivePortfolioRows,
+  buildActivePortfolioWorkbook,
+} from "./activePortfolioReport";
+
+describe("active portfolio report", () => {
+  it("uses all live cartera statuses", () => {
+    expect(ACTIVE_PORTFOLIO_STATUSES).toEqual(["ACTIVO", "MOROSO", "EN_CONVENIO"]);
+  });
+
+  it("maps report rows with vehicle fallback and preserves SIFCO order", () => {
+    const rows = buildActivePortfolioRows(
+      [
+        {
+          numero_credito_sifco: "1002",
+          seguro_10_cuotas: "1200.50",
+          cliente_nombre: "Cliente B",
+        },
+        {
+          numero_credito_sifco: "1001",
+          seguro_10_cuotas: "980",
+          cliente_nombre: "Cliente A",
+        },
+      ],
+      new Map([
+        ["1001", { licensePlate: "P123ABC", vinNumber: "VIN123" }],
+      ]),
+    );
+
+    expect(rows).toEqual([
+      {
+        placa: "P123ABC",
+        chasis: "VIN123",
+        cuotaInterna: 980,
+        clienteNombre: "Cliente A",
+        numeroCredito: "1001",
+      },
+      {
+        placa: "-",
+        chasis: "-",
+        cuotaInterna: 1200.5,
+        clienteNombre: "Cliente B",
+        numeroCredito: "1002",
+      },
+    ]);
+  });
+
+  it("builds the expected Excel worksheet", async () => {
+    const buffer = await buildActivePortfolioWorkbook([
+      {
+        placa: "P123ABC",
+        chasis: "VIN123",
+        cuotaInterna: 980,
+        clienteNombre: "Cliente A",
+        numeroCredito: "1001",
+      },
+    ]);
+
+    const workbook = new ExcelJS.Workbook();
+    const workbookPayload = buffer as unknown as Parameters<typeof workbook.xlsx.load>[0];
+    await workbook.xlsx.load(workbookPayload);
+    const worksheet = workbook.getWorksheet("Cartera Activa");
+
+    expect(worksheet?.getRow(1).values).toEqual([
+      undefined,
+      "Placa",
+      "Chasis",
+      "Cuota Interna",
+      "Nombre del Cliente",
+      "Número de Crédito",
+    ]);
+    expect(worksheet?.rowCount).toBe(2);
+    expect(worksheet?.getRow(2).values).toEqual([
+      undefined,
+      "P123ABC",
+      "VIN123",
+      980,
+      "Cliente A",
+      "1001",
+    ]);
+  });
+});

--- a/apps/cartera-back/src/controllers/activePortfolioReport.ts
+++ b/apps/cartera-back/src/controllers/activePortfolioReport.ts
@@ -1,0 +1,98 @@
+import ExcelJS from "exceljs";
+import { sql, type SQL } from "drizzle-orm";
+import { creditos, usuarios } from "../database/db/schema";
+
+export const ACTIVE_PORTFOLIO_STATUSES = ["ACTIVO", "MOROSO", "EN_CONVENIO"] as const;
+
+export type ActivePortfolioCredit = {
+  numero_credito_sifco: string;
+  seguro_10_cuotas: string | number;
+  cliente_nombre: string;
+};
+
+export type ActivePortfolioVehicle = {
+  licensePlate?: string | null;
+  vinNumber?: string | null;
+};
+
+export type ActivePortfolioRow = {
+  placa: string;
+  chasis: string;
+  cuotaInterna: number;
+  clienteNombre: string;
+  numeroCredito: string;
+};
+
+type DbExecutor = {
+  execute(query: SQL): Promise<{ rows: Record<string, unknown>[] }>;
+};
+
+function toText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function toNumber(value: unknown): number {
+  const numeric = Number(value ?? 0);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+export function buildActivePortfolioRows(
+  credits: ActivePortfolioCredit[],
+  vehiclesBySifco: Map<string, ActivePortfolioVehicle>,
+): ActivePortfolioRow[] {
+  return [...credits]
+    .sort((a, b) => a.numero_credito_sifco.localeCompare(b.numero_credito_sifco))
+    .map((credit) => {
+      const vehicle = vehiclesBySifco.get(credit.numero_credito_sifco);
+      return {
+        placa: vehicle?.licensePlate || "-",
+        chasis: vehicle?.vinNumber || "-",
+        cuotaInterna: toNumber(credit.seguro_10_cuotas),
+        clienteNombre: credit.cliente_nombre,
+        numeroCredito: credit.numero_credito_sifco,
+      };
+    });
+}
+
+export async function getActivePortfolioCredits(executor: DbExecutor): Promise<ActivePortfolioCredit[]> {
+  const activeStatusSql = sql.join(ACTIVE_PORTFOLIO_STATUSES.map((status) => sql`${status}`), sql`, `);
+  const result = await executor.execute(sql`
+    SELECT
+      c.numero_credito_sifco,
+      c.seguro_10_cuotas,
+      u.nombre AS cliente_nombre
+    FROM ${creditos} c
+    JOIN ${usuarios} u ON u.usuario_id = c.usuario_id
+    WHERE c."statusCredit" IN (${activeStatusSql})
+    ORDER BY c.numero_credito_sifco
+  `);
+  return result.rows.map((row) => ({
+    numero_credito_sifco: toText(row.numero_credito_sifco),
+    seguro_10_cuotas: toNumber(row.seguro_10_cuotas),
+    cliente_nombre: toText(row.cliente_nombre),
+  }));
+}
+
+export async function buildActivePortfolioWorkbook(rows: ActivePortfolioRow[]): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet("Cartera Activa");
+
+  ws.columns = [
+    { header: "Placa", key: "placa", width: 16 },
+    { header: "Chasis", key: "chasis", width: 26 },
+    { header: "Cuota Interna", key: "cuotaInterna", width: 16 },
+    { header: "Nombre del Cliente", key: "clienteNombre", width: 34 },
+    { header: "Número de Crédito", key: "numeroCredito", width: 22 },
+  ];
+  ws.getRow(1).font = { bold: true };
+  ws.views = [{ state: "frozen", ySplit: 1 }];
+  ws.autoFilter = "A1:E1";
+
+  for (const row of rows) {
+    ws.addRow(row);
+  }
+  ws.getColumn("cuotaInterna").numFmt = "#,##0.00";
+
+  const buf = await wb.xlsx.writeBuffer();
+  return Buffer.from(buf);
+}

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,8 @@
 import { Elysia } from "elysia";
+import { db } from "../database";
+import { buildActivePortfolioRows, buildActivePortfolioWorkbook, getActivePortfolioCredits } from "../controllers/activePortfolioReport";
 import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
+import { getVehiclesBySifcoMap } from "../services/crm.service";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -22,7 +25,34 @@ function fechaValida(s: string): boolean {
   return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
 }
 
+function puedeDescargarCarteraActiva(user: { role?: string } | undefined): boolean {
+  return user?.role === "ADMIN" || user?.role === "CONTA";
+}
+
 export const reportesRouter = new Elysia().use(authMiddleware)
+
+  .get("/reportes/cartera-activa/excel", async ({ set, user }) => {
+    if (!puedeDescargarCarteraActiva(user)) {
+      set.status = 403;
+      return { error: "No autorizado" };
+    }
+
+    try {
+      const credits = await getActivePortfolioCredits(db);
+      const vehicles = await getVehiclesBySifcoMap(credits.map((credit) => credit.numero_credito_sifco));
+      const buf = await buildActivePortfolioWorkbook(buildActivePortfolioRows(credits, vehicles));
+      return new Response(new Uint8Array(buf), {
+        headers: {
+          "content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "content-disposition": 'attachment; filename="reporte-cartera-activa.xlsx"',
+        },
+      });
+    } catch (error) {
+      console.error("[/reportes/cartera-activa/excel]", error);
+      set.status = 500;
+      return { error: "Error generando reporte de cartera activa" };
+    }
+  })
 
   .get("/reportes/monto-cobrar", async ({ query, set }) => {
     try {

--- a/apps/cartera-back/src/services/crm.service.ts
+++ b/apps/cartera-back/src/services/crm.service.ts
@@ -71,7 +71,7 @@ export async function notifyPayInvestors(
 }
 
 // ============================================
-// Obtener detalles de vehículo por número SIFCO
+// Obtener placa/chasis por número SIFCO
 // ============================================
 export interface VehicleDetails {
   id: string;
@@ -103,6 +103,21 @@ export interface VehicleDetailsResponse {
   error?: string;
 }
 
+export type VehicleReportDetails = Pick<VehicleDetails, "licensePlate" | "vinNumber">;
+
+type VehiclesBySifcoApiResponse = {
+  success: boolean;
+  data?: {
+    vehicles?: Array<{
+      numeroSifco: string;
+      licensePlate: string | null;
+      vinNumber: string | null;
+    }>;
+  };
+  message?: string;
+  error?: string;
+};
+
 export async function getVehicleDetailsBySifco(
   numeroSifco: string,
 ): Promise<VehicleDetailsResponse> {
@@ -110,14 +125,16 @@ export async function getVehicleDetailsBySifco(
     const { data } = await crmApi.get("/info/vehicle-details", {
       params: { numero_sifco: numeroSifco },
     });
-    if (!data) { return { success: false, message: "Sin respuesta del CRM" }}
+    if (!data) {
+      return { success: false, message: "Sin respuesta del CRM" };
+    }
 
     const vehicle = data?.data?.vehicle;
-    if (!vehicle) { 
-      console.error(`No contiene datos del vechículo para número ${numeroSifco}`);
-      return { success: false, message: "Vehículo no encontrado en CRM" }; 
+    if (!vehicle) {
+      console.error(`No contiene datos del vehículo para número ${numeroSifco}`);
+      return { success: false, message: "Vehículo no encontrado en CRM" };
     }
-    
+
     console.log("Consultado detalles del vehículo exitosamente");
     return {
       success: true,
@@ -133,4 +150,29 @@ export async function getVehicleDetailsBySifco(
       error: msg,
     };
   }
+}
+
+export async function getVehiclesBySifcoMap(
+  sifcos: string[],
+): Promise<Map<string, VehicleReportDetails>> {
+  const uniqueSifcos = [...new Set(sifcos.map((sifco) => sifco.trim()).filter(Boolean))];
+  const vehicles = new Map<string, VehicleReportDetails>();
+  if (uniqueSifcos.length === 0) return vehicles;
+
+  const { data } = await crmApi.post<VehiclesBySifcoApiResponse>("/info/vehicles-by-sifco", {
+    numero_sifcos: uniqueSifcos,
+  });
+
+  if (!data.success) {
+    throw new Error(data.message || data.error || "Error obteniendo vehículos del CRM");
+  }
+
+  for (const vehicle of data.data?.vehicles ?? []) {
+    vehicles.set(vehicle.numeroSifco, {
+      licensePlate: vehicle.licensePlate ?? "",
+      vinNumber: vehicle.vinNumber ?? "",
+    });
+  }
+
+  return vehicles;
 }

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -29,6 +29,7 @@ import { FacturacionDiaria } from "./private/cartera/components/FacturacionDiari
 import { CapitalInversionistas } from "./private/cartera/components/CapitalInversionistas";
 import { Seguros } from "./private/cartera/components/Seguros";
 import { ProyeccionInversionistas } from "./private/cartera/components/ProyeccionInversionistas";
+import { ActivePortfolioReport } from "./private/cartera/components/ActivePortfolioReport";
 
 // 🔒 Rutas privadas
 function PrivateRoute({ children }: { children: JSX.Element }) {
@@ -290,6 +291,15 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
               <FacturacionDiaria />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="reporte-cartera-activa"
+          element={
+            <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
+              <ActivePortfolioReport />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/ActivePortfolioReport.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ActivePortfolioReport.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Download, FileSpreadsheet } from "lucide-react";
+import { toast } from "sonner";
+import { descargarReporteCarteraActiva } from "../services/activePortfolioReport.services";
+
+function errMsg(e: unknown, fallback: string): string {
+  if (e instanceof Error) return e.message || fallback;
+  return fallback;
+}
+
+export function ActivePortfolioReport() {
+  const [loading, setLoading] = useState(false);
+
+  const descargar = async () => {
+    try {
+      setLoading(true);
+      const blob = await descargarReporteCarteraActiva();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "reporte-cartera-activa.xlsx";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast.success("Reporte descargado");
+    } catch (e: unknown) {
+      toast.error(errMsg(e, "Error descargando reporte"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 overflow-auto bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 pt-8 pb-8">
+      <div className="w-full max-w-3xl mx-auto">
+        <div className="flex flex-col items-center mb-6">
+          <h1 className="text-3xl font-extrabold text-blue-700 text-center">Reporte cartera activa</h1>
+          <p className="text-gray-600 mt-2 text-center">
+            Descarga la cartera activa actual con placa, chasis, cuota interna, cliente y número de crédito.
+          </p>
+        </div>
+
+        <Card className="border-blue-100 shadow-lg bg-white/90">
+          <CardContent className="p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="flex items-start gap-3">
+              <div className="rounded-xl bg-blue-100 p-3 text-blue-700">
+                <FileSpreadsheet className="h-6 w-6" />
+              </div>
+              <div>
+                <h2 className="font-semibold text-gray-900">Cartera activa a la fecha</h2>
+                <p className="text-sm text-gray-600 mt-1">Incluye créditos ACTIVO, MOROSO y EN_CONVENIO.</p>
+              </div>
+            </div>
+            <Button onClick={descargar} disabled={loading} className="gap-2">
+              <Download className="h-4 w-4" />
+              {loading ? "Generando..." : "Descargar Excel"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -267,6 +267,13 @@ const menuSections: MenuSection[] = [
         roles: ["ADMIN", "CONTA"],
       },
       {
+        key: "reporte-cartera-activa",
+        label: "Cartera Activa",
+        icon: <FileText className="h-4 w-4" />,
+        path: "/reporte-cartera-activa",
+        roles: ["ADMIN", "CONTA"],
+      },
+      {
         key: "capital-inversionistas",
         label: "Capital Inversionistas",
         icon: <TrendingUp className="h-4 w-4" />,

--- a/apps/carteraFront/src/private/cartera/services/activePortfolioReport.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/activePortfolioReport.services.ts
@@ -1,0 +1,10 @@
+import api from "@/Provider/interceptor";
+
+const API_URL = import.meta.env.VITE_BACK_URL || "";
+
+export const descargarReporteCarteraActiva = async (): Promise<Blob> => {
+  const res = await api.get(`${API_URL}/reportes/cartera-activa/excel`, {
+    responseType: "blob",
+  });
+  return res.data as Blob;
+};

--- a/apps/crm/apps/server/src/controllers/vehicles.ts
+++ b/apps/crm/apps/server/src/controllers/vehicles.ts
@@ -36,10 +36,12 @@ export const getVehicleByCodigoController = async (numero_sifco: string) => {
 			.from(opportunities)
 			.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 			.where(
-				and(eq(opportunities.numeroSifco, numero_sifco), 
-				inArray(opportunities.status, ["won", "migrate"]),),
+				and(
+					eq(opportunities.numeroSifco, numero_sifco),
+					inArray(opportunities.status, ["won", "migrate"]),
+				),
 			)
-			.orderBy(desc(opportunities.updatedAt))
+			.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt))
 			.limit(1)
 			.then((rows) => rows[0] || null);
 
@@ -56,6 +58,53 @@ export const getVehicleByCodigoController = async (numero_sifco: string) => {
 		};
 	} catch (err: any) {
 		console.error("[ERROR] getVehicleByCodigoController:", err);
+		return {
+			success: false,
+			message: err.message || "Internal server error",
+		};
+	}
+};
+
+export type VehicleBySifco = {
+	numeroSifco: string;
+	licensePlate: string | null;
+	vinNumber: string | null;
+};
+
+export const getVehiclesBySifcoController = async (numeroSifcos: string[]) => {
+	const uniqueSifcos = [...new Set(numeroSifcos.map((value) => value.trim()).filter(Boolean))];
+
+	if (uniqueSifcos.length === 0) {
+		return { success: true, data: { vehicles: [] as VehicleBySifco[] } };
+	}
+
+	try {
+		const rows = await db
+			.select({
+				numeroSifco: opportunities.numeroSifco,
+				licensePlate: vehicles.licensePlate,
+				vinNumber: vehicles.vinNumber,
+			})
+			.from(opportunities)
+			.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+			.where(inArray(opportunities.numeroSifco, uniqueSifcos))
+			.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt));
+
+		const seen = new Set<string>();
+		const matchedVehicles: VehicleBySifco[] = [];
+		for (const row of rows) {
+			if (!row.numeroSifco || seen.has(row.numeroSifco)) continue;
+			seen.add(row.numeroSifco);
+			matchedVehicles.push({
+				numeroSifco: row.numeroSifco,
+				licensePlate: row.licensePlate,
+				vinNumber: row.vinNumber,
+			});
+		}
+
+		return { success: true, data: { vehicles: matchedVehicles } };
+	} catch (err: any) {
+		console.error("[ERROR] getVehiclesBySifcoController:", err);
 		return {
 			success: false,
 			message: err.message || "Internal server error",

--- a/apps/crm/apps/server/src/controllers/vehicles.ts
+++ b/apps/crm/apps/server/src/controllers/vehicles.ts
@@ -86,8 +86,13 @@ export const getVehiclesBySifcoController = async (numeroSifcos: string[]) => {
 				vinNumber: vehicles.vinNumber,
 			})
 			.from(opportunities)
-			.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
-			.where(inArray(opportunities.numeroSifco, uniqueSifcos))
+			.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+			.where(
+				and(
+					inArray(opportunities.numeroSifco, uniqueSifcos),
+					inArray(opportunities.status, ["won", "migrate"]),
+				),
+			)
 			.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt));
 
 		const seen = new Set<string>();

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -26,7 +26,10 @@ import {
 	validatePortalToken,
 } from "./controllers/portal-lead";
 import { createPublicLead } from "./controllers/public-lead";
-import { getVehicleByCodigoController } from "./controllers/vehicles";
+import {
+	getVehicleByCodigoController,
+	getVehiclesBySifcoController,
+} from "./controllers/vehicles";
 import type { db } from "./db";
 import { otps } from "./db/schema/otp";
 import {
@@ -1084,6 +1087,31 @@ app.get("/info/vehicle-details", async (c) => {
 
 	const result = await getVehicleByCodigoController(numero_sifco);
 	return c.json(result, result.success ? 200 : 404);
+});
+
+// Endpoint batch para reportes de cartera: placa/chasis por números SIFCO.
+app.post("/info/vehicles-by-sifco", async (c) => {
+	try {
+		const body = await c.req.json<{ numero_sifcos?: unknown }>();
+		if (!Array.isArray(body.numero_sifcos)) {
+			return c.json(
+				{ success: false, message: "numero_sifcos must be an array" },
+				400,
+			);
+		}
+
+		const numeroSifcos = body.numero_sifcos
+			.map((value) => String(value ?? "").trim())
+			.filter(Boolean);
+		const result = await getVehiclesBySifcoController(numeroSifcos);
+		return c.json(result, result.success ? 200 : 500);
+	} catch (err: any) {
+		console.error("[ERROR] /info/vehicles-by-sifco:", err);
+		return c.json(
+			{ success: false, message: err.message || "Internal server error" },
+			500,
+		);
+	}
 });
 
 // Job periódico de notificaciones de cobros (cada hora)


### PR DESCRIPTION
## Summary
- Adds a Cartera backend Excel export for the active portfolio report.
- Adds a Cartera frontend route/menu card to download the report.
- Adds a CRM batch vehicle lookup endpoint so placa/chasis are fetched in one request instead of per credit.

## Report shape
Excel sheet: `Cartera Activa`

Columns:
- Placa
- Chasis
- Cuota Interna
- Nombre del Cliente
- Número de Crédito

Active cartera statuses included:
- `ACTIVO`
- `MOROSO`
- `EN_CONVENIO`

## Notes
- `Cuota Interna` comes from `cartera.creditos.seguro_10_cuotas`.
- Vehicle data is matched by `numero_sifco`; missing placa/chasis falls back to `-`.
- No generated `.xlsx` files are committed.

## Verification
- [x] `bun test apps/cartera-back/src/controllers/activePortfolioReport.test.ts`
- [x] `cd apps/carteraFront && bunx tsc --noEmit --pretty false`
- [x] `git diff --check origin/develop...HEAD`

## Known pre-existing check failures
- `cd apps/cartera-back && bunx tsc --noEmit --pretty false` still fails on existing unrelated issues:
  - `moraPorEtapaAsesor.test.ts` expects `dataDisponibleDesde` on a live result variant.
  - `@react-email/components` types/modules missing for email templates.
- `cd apps/crm && bun check-types` fails on existing unrelated missing deps/type debt across CRM server/web.
