### PR TITLE
fix(cartera): exitInvestor reporta status real cuando skipStatusAndEmail

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -6086,8 +6086,13 @@ export const exitInvestor = async (
       log(`📧 Correos: enviados=${enviados}, fallidos=${fallidos}`);
     }
 
+    // Cuando skipStatusAndEmail=true no se cambió el status: el inversionista
+    // sigue con el que tenía (invRow.status). Solo pasó a "inactivo" en el
+    // camino normal.
+    const statusFinal = skipStatusAndEmail ? invRow.status : "inactivo";
+
     log(`⏱️  Duración total: ${Date.now() - t0}ms`);
-    log(`✅ DONE — inversionista ${invRow.inversionista_id} inactivado, ${resultados.length} crédito(s), Q${totalTransferido.toFixed(2)} a CUBE`);
+    log(`✅ DONE — inversionista ${invRow.inversionista_id} (status=${statusFinal}), ${resultados.length} crédito(s), Q${totalTransferido.toFixed(2)} a CUBE`);
     log("═══════════════════════════════════════════════════════════");
 
     // ========================================================================
@@ -6099,8 +6104,10 @@ export const exitInvestor = async (
     set.status = 200;
     return {
       success: true,
-      message: `Inversionista inactivado. ${resultados.length} crédito(s) transferido(s) a CUBE. Total: Q${totalTransferido.toFixed(2)}.`,
-      inversionista: { inversionista_id: invRow.inversionista_id, nombre: invRow.nombre, status: "inactivo" },
+      message: skipStatusAndEmail
+        ? `${resultados.length} crédito(s) transferido(s) a CUBE. Total: Q${totalTransferido.toFixed(2)}. (status del inversionista sin cambios)`
+        : `Inversionista inactivado. ${resultados.length} crédito(s) transferido(s) a CUBE. Total: Q${totalTransferido.toFixed(2)}.`,
+      inversionista: { inversionista_id: invRow.inversionista_id, nombre: invRow.nombre, status: statusFinal },
       total_transferido_a_cube: totalTransferido.toFixed(2),
       creditos_procesados: resultados,
       errores,


### PR DESCRIPTION
## Resumen

Cuando `exitInvestor` se llama con `skipStatusAndEmail=true` (devolución de créditos VERIFICADO individuales desde liquidación), el inversionista **no** se inactiva — pero el response y el log `DONE` reportaban `message` y `inversionista.status` con `"inactivo"` fijo, informando un estado que no ocurrió.

## Cambio

Se calcula `statusFinal = skipStatusAndEmail ? invRow.status : "inactivo"` (el status original leído al inicio cuando se salta la inactivación) y se usa en:
- `inversionista.status` del response (PASO 8)
- el `message` del response (variante que aclara "status del inversionista sin cambios")
- el log `✅ DONE`

No cambia lógica interna — los call-sites internos solo consumen `success`/`creditos_procesados`/`errores`. Corrige el reporte para cualquier log o consumidor que lea el status/message.

## Contexto

Finding P2 de Codex sobre el PR #1070 (develop→main): el camino sin correo devolvía la respuesta de inactivación normal en vez de una específica del skip.

## Test plan

- [x] `bun x tsc --noEmit` limpio en `cartera-back`.
- [ ] Devolución de crédito VERIFICADO individual (skip) → confirmar que el response trae `inversionista.status` = status previo (no `inactivo`) y `message` con la nota de "sin cambios".
- [ ] Salida total (`pendiente_devolucion`, sin flag) → response sigue con `status: "inactivo"` y message normal (sin regresión).

🤖 Generated with [Claude Code](https://claude.com/claude-code)