### PR TITLE
hotfix(cartera): resumen global no restaba el sobrante del excedente en reinversión combinada

### DIFF
--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -6722,6 +6722,40 @@ async function consultarResumenGlobalPorEstadoPago(
     condicionesJoinPagos.push(sql`EXTRACT(YEAR FROM ${pe.fecha_pago}) = ${anio}`);
   }
 
+  // ── Combinada con excedente/variable ────────────────────────────────────
+  // Dentro de una combinada, los créditos excedente/variable no se resuelven
+  // per-pago: se suman en un pool y se les aplica el monto_reinversion del
+  // inversionista (igual que las modalidades "crudas").
+  //   - Excedente: RECIBE el monto fijo; el sobrante del pool se reinvierte.
+  //   - Variable : REINVIERTE el monto fijo; el resto del pool lo recibe.
+  const cuotaCompleta = sql`
+    ${pe.abono_capital}
+    + ${pe.abono_interes}
+    + CASE
+        WHEN ${inversionistas.emite_factura}
+          THEN ${pe.abono_iva_12}
+        ELSE -ROUND(${pe.abono_interes} * 0.07, 2)
+      END`;
+
+  const montoReinv = sql`COALESCE(${inversionistas.monto_reinversion}, 0)::numeric`;
+
+  const poolExcedente = sql`COALESCE(SUM(
+    CASE WHEN ${ce.tipo_reinversion} = 'reinversion_excedente' THEN (${cuotaCompleta}) ELSE 0 END
+  ), 0)`;
+  const poolVariable = sql`COALESCE(SUM(
+    CASE WHEN ${ce.tipo_reinversion} = 'reinversion_variable' THEN (${cuotaCompleta}) ELSE 0 END
+  ), 0)`;
+
+  // Lo que se REINVIERTE de los pools (0 si el pool está vacío).
+  const reinvPools = sql`
+    GREATEST((${poolExcedente}) - (${montoReinv}), 0)
+    + LEAST((${montoReinv}), (${poolVariable}))`;
+
+  // Lo que el inversionista RECIBE de los pools (el inverso).
+  const recibePools = sql`
+    LEAST((${montoReinv}), (${poolExcedente}))
+    + ((${poolVariable}) - LEAST((${montoReinv}), (${poolVariable})))`;
+
   const selectObj: Record<string, any> = {
     inversionista_id: inversionistas.inversionista_id,
     nombre: inversionistas.nombre,
@@ -6781,6 +6815,7 @@ async function consultarResumenGlobalPorEstadoPago(
             ELSE 0
           END
         ), 0)
+        + (${reinvPools})
         WHEN 'reinversion_variable' THEN LEAST(
           COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
           COALESCE(SUM(
@@ -6839,6 +6874,7 @@ async function consultarResumenGlobalPorEstadoPago(
                 ELSE 0
               END
             ), 0)
+            + (${reinvPools})
             WHEN 'reinversion_variable' THEN LEAST(
               COALESCE(${inversionistas.monto_reinversion}, 0)::numeric,
               COALESCE(SUM(
@@ -6902,11 +6938,14 @@ async function consultarResumenGlobalPorEstadoPago(
             WHEN 'reinversion_interes' THEN (
               ${pe.abono_capital} + CASE WHEN ${inversionistas.emite_factura} THEN ${pe.abono_iva_12} ELSE -ROUND(${pe.abono_interes} * 0.07, 2) END
             )
+            WHEN 'reinversion_excedente' THEN 0
+            WHEN 'reinversion_variable' THEN 0
             ELSE (
                ${pe.abono_capital} + ${pe.abono_interes} + CASE WHEN ${inversionistas.emite_factura} THEN ${pe.abono_iva_12} ELSE -ROUND(${pe.abono_interes} * 0.07, 2) END
             )
           END
         ), 0)
+        + (${recibePools})
         WHEN 'reinversion_variable' THEN
           COALESCE(SUM(
             ${pe.abono_capital}


### PR DESCRIPTION
## Problema

El endpoint que consume el CRM (`getResumenGlobalInversionistas` → `GET /resumen-global-liquidaciones`) devolvía una **cuota a recibir inflada** para inversionistas con **reinversión combinada** que tienen créditos en modalidad **excedente**.

Caso real (Boris Gilberto Lemus Villatoro, `inversionista_id: 11`):

| | CRM (antes) | Reporte Excel (correcto) |
|---|---|---|
| `total_reinversion` | Q1,071.75 | **Q6,041.88** |
| `total_a_recibir_con_reinversion` | Q7,644.69 | **Q2,674.56** |

La diferencia es exactamente el **sobrante del excedente: Q4,970.13**.

## Causa

En `consultarResumenGlobalPorEstadoPago` (`apps/cartera-back/src/controllers/investor.ts`), el SQL resolvía la combinada **per-crédito** solo para `capital` / `interes` / `total`. Los créditos marcados como `reinversion_excedente` o `reinversion_variable`:

- caían en el `ELSE 0` de `total_reinversion` → **no aportaban nada a la reinversión**;
- caían en el `ELSE` de `total_cuota` → **recibían la cuota completa**.

Esas dos modalidades no se resuelven per-pago: se suman en un **pool** al que se le aplica el `monto_reinversion` del inversionista (tal como ya lo hacen las modalidades "crudas" `reinversion_excedente` / `reinversion_variable`).

## Solución

Se replica la lógica del crudo dentro de la rama combinada:

- **Excedente** → el inversionista **RECIBE** el monto fijo; el **sobrante** del pool se reinvierte.
- **Variable** → **REINVIERTE** el monto fijo; el resto del pool lo recibe.

Corrige los tres campos afectados: `total_reinversion`, `total_a_recibir_con_reinversion` y `total_cuota`.

Arregla de una vez **`/resumen-global`** y **`/resumen-global-liquidaciones`** (ambos usan la misma función), y por lo tanto el Excel del resumen global.

## Alcance / seguridad

- Cambio **puramente aditivo** (39 inserciones, 0 líneas modificadas), **solo dentro de** `WHEN 'reinversion_combinada'`.
- Si la combinada **no tiene** créditos excedente/variable, los pools quedan en 0 y los términos nuevos se anulan solos (`GREATEST(0 − monto, 0) = 0`, `LEAST(monto, 0) = 0`) → **resultado idéntico al anterior**.
- Las demás modalidades (`sin_reinversion`, `capital`, `interes`, `total`, y los crudos `excedente`/`variable`) **no se tocan**.

## Verificación (Boris)

- `poolExcedente` = 6,851.73 · `monto_reinversion` = 1,881.60
- sobrante = `GREATEST(6851.73 − 1881.60, 0)` = **4,970.13** ✓
- `total_reinversion` = 1,071.75 + 4,970.13 = **6,041.88** ✓
- `total_a_recibir_con_reinversion` = 8,716.44 − 6,041.88 = **2,674.56** ✓
- Por el otro camino: `total_cuota` = 792.96 + 1,881.60 = **2,674.56** ✓ (los dos cuadran)

Typecheck OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)