### PR TITLE
fix(cobros): pagar solo la mora ya no descuenta la cuota atrasada (BAJADA falsa de bucket)

### DIFF
--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -293,7 +293,8 @@ export async function createMora({
         AND NOT EXISTS (
           SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
           WHERE pc.cuota_id = cu.cuota_id AND pc."paymentFalse" = false AND pc.pagado = true
-            AND pc.validation_status IN ('validated', 'no_required'))`);
+            AND pc.validation_status IN ('validated', 'no_required')
+            AND COALESCE(pc.monto_aplicado, 0) > 0)`);
     const cuotasReales = Number(ovRes.rows?.[0]?.n ?? 0);
 
     // Si el cuotas_atrasadas enviado NO coincide con las cuotas vencidas reales, exigir override
@@ -751,6 +752,13 @@ export async function procesarMoras() {
         statusCredit: creditos.statusCredit,
         capital: creditos.capital,
         asesor_id: creditos.asesor_id, // FASE 3: dueño actual (para reasignar por bucket)
+        // Una fila de pago "vouchea" la cuota solo si aplicó plata REAL a la
+        // cuota (monto_aplicado > 0). Los pagos especiales de solo mora/otros/
+        // convenio se insertan colgados de la primera cuota pendiente con
+        // pagado=true y monto_aplicado=0 (getSpecialPaymentInstallmentFields):
+        // ese `pagado` significa "fila completa", NO "cuota cubierta" — sin
+        // este AND, pagar SOLO la mora sacaba la cuota del conteo al validar
+        // (cuotas 2→1 → BAJADA falsa de bucket y mora recalculada de menos).
         hasPaidPayment: sql<boolean>`EXISTS (
           SELECT 1
           FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
@@ -758,6 +766,7 @@ export async function procesarMoras() {
             AND pc."paymentFalse" = false
             AND pc.pagado = true
             AND pc.validation_status IN ('validated', 'no_required')
+            AND COALESCE(pc.monto_aplicado, 0) > 0
         )`,
       })
       .from(cuotas_credito)


### PR DESCRIPTION
## El bug (real, reproducido en pruebas con el sandbox)

Crédito en B2 (2 cuotas atrasadas). Se paga **solo la mora** de una cuota, CONTA valida, corre el job → el crédito baja a B1 **aunque la cuota sigue sin pagarse**. También afecta la mora del sistema viejo: `cuotas_atrasadas` baja 2→1 y el monto se recalcula de menos.

## Causa raíz

1. Un pago de **solo mora/otros/convenio** se inserta colgado de la primera cuota pendiente con `pagado: true` y `monto_aplicado: 0` (`getSpecialPaymentInstallmentFields` — ese `pagado` significa "fila de pago completa", no "cuota cubierta").
2. Al validar, la cuota correctamente NO se marca pagada (suma aplicada 0 < cuota), pero la fila conserva `pagado=true` y pasa a `validated`.
3. El `hasPaidPayment` del job (`EXISTS pagado=true AND validated/no_required`) la toma como cuota cubierta → la cuota desaparece del conteo → BAJADA falsa + mora sub-calculada.

## El fix

`AND COALESCE(pc.monto_aplicado, 0) > 0` en el EXISTS — una fila solo "vouchea" la cuota si aplicó plata real. En dos lugares para que no se contradigan:
- `procesarMoras` (el job) — `hasPaidPayment`
- `createMora` — guard de `cuotasReales` (misma lógica documentada "Misma lógica que procesarMoras")

## Radio de impacto (medido en dev/sandbox con SELECTs)

- 16 cuotas vencidas hoy excluidas del conteo por el EXISTS.
- **Solo 3 se re-incorporan** con el fix (2 solo-mora + 1 solo-otros — exactamente el bug).
- Las otras 13 tienen pago real validado que cerró la cuota con el flag desincronizado → siguen contando como pagadas (para eso existe el EXISTS; sin regresión).

## Letra chica

- Filas solo-mora **legacy** guardaban `monto_aplicado = mora+otros` (>0) → siguen comportándose como hoy (no distinguibles de plata real con seguridad).
- Hay EXISTS con el mismo patrón en `reports.ts` / `reportes.ts` / `paymentAgreement.ts` (conteos de reportes y convenios): **no se tocan aquí** (fuera del alcance pedido), pero queda anotado que pueden mostrar conteos distintos al job en estos 3 casos borde.

## Pruebas

- `bun test latefee.test.ts`: 17/17 pass (incluye los E2E del motor con DB fake).
- `tsc --noEmit` sin errores nuevos.
- Verificación manual del escenario en el sandbox pendiente de re-correr el ciclo (pago solo mora → validar → job → debe seguir B2 con 2 cuotas).

**Nota:** este error existe en prod (sistema viejo de moras, sin buckets) — sigue un hotfix aparte con base `main` con el mismo cambio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)