### PR TITLE
hotfix(cartera): pagar solo la mora ya no descuenta la cuota atrasada del conteo de mora

### DIFF
--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -175,7 +175,8 @@ export async function createMora({
         AND NOT EXISTS (
           SELECT 1 FROM cartera.pagos_credito pc
           WHERE pc.cuota_id = cu.cuota_id AND pc."paymentFalse" = false AND pc.pagado = true
-            AND pc.validation_status IN ('validated', 'no_required'))`);
+            AND pc.validation_status IN ('validated', 'no_required')
+            AND COALESCE(pc.monto_aplicado, 0) > 0)`);
     const cuotasReales = Number(ovRes.rows?.[0]?.n ?? 0);
 
     // Si el cuotas_atrasadas enviado NO coincide con las cuotas vencidas reales, exigir override
@@ -632,6 +633,13 @@ export async function procesarMoras() {
         pagado: cuotas_credito.pagado,
         statusCredit: creditos.statusCredit,
         capital: creditos.capital,
+        // Una fila de pago "vouchea" la cuota solo si aplicó plata REAL a la
+        // cuota (monto_aplicado > 0). Los pagos especiales de solo mora/otros/
+        // convenio se insertan colgados de la primera cuota pendiente con
+        // pagado=true y monto_aplicado=0 (getSpecialPaymentInstallmentFields):
+        // ese `pagado` significa "fila completa", NO "cuota cubierta" — sin
+        // este AND, pagar SOLO la mora sacaba la cuota del conteo al validar
+        // (cuotas_atrasadas 2→1 → mora recalculada de menos y etapa incorrecta).
         hasPaidPayment: sql<boolean>`EXISTS (
           SELECT 1
           FROM cartera.pagos_credito pc
@@ -639,6 +647,7 @@ export async function procesarMoras() {
             AND pc."paymentFalse" = false
             AND pc.pagado = true
             AND pc.validation_status IN ('validated', 'no_required')
+            AND COALESCE(pc.monto_aplicado, 0) > 0
         )`,
       })
       .from(cuotas_credito)

--- a/apps/cartera-back/src/controllers/paymentAgreement.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement.ts
@@ -1432,8 +1432,9 @@ export const updateConvenioStatus = async (
       }
 
       // Contar cuotas vencidas con la MISMA lógica que createMora/procesarMoras
-      // (< hoy GT, impaga, sin pago cubriente validated/no_required) para que el conteo
-      // coincida con el que recalcula createMora y no lo rechace por mismatch.
+      // (< hoy GT, impaga, sin pago cubriente validated/no_required CON plata real
+      // aplicada — monto_aplicado > 0, igual que el guard cuotasReales) para que el
+      // conteo coincida con el que recalcula createMora y no lo rechace por mismatch.
       const ovRes = await db.execute<any>(sql`
         SELECT COUNT(*)::int AS n
         FROM cartera.cuotas_credito cu
@@ -1443,7 +1444,8 @@ export const updateConvenioStatus = async (
           AND NOT EXISTS (
             SELECT 1 FROM cartera.pagos_credito pc
             WHERE pc.cuota_id = cu.cuota_id AND pc."paymentFalse" = false AND pc.pagado = true
-              AND pc.validation_status IN ('validated', 'no_required'))`);
+              AND pc.validation_status IN ('validated', 'no_required')
+              AND COALESCE(pc.monto_aplicado, 0) > 0)`);
       const numCuotasAtrasadas = Number(ovRes.rows?.[0]?.n ?? 0);
 
       console.log(`📊 Cuotas atrasadas encontradas: ${numCuotasAtrasadas}`);


### PR DESCRIPTION
## El bug (activo en prod)

Crédito con 2 cuotas atrasadas. El cliente paga **solo la mora**, CONTA valida, corre el job de moras → `cuotas_atrasadas` baja 2→1 **aunque la cuota sigue sin pagarse**: el monto de mora se recalcula de menos y la etapa (Mora 30/60/90/120) queda incorrecta.

Detectado probando el rediseño de cobros (COBROS-02), pero el error vive en el job actual de prod — este hotfix es el mismo cambio ya aplicado en la rama del rediseño (PR #1074).

## Causa raíz

1. Un pago de **solo mora/otros/convenio** se inserta colgado de la primera cuota pendiente con `pagado: true` y `monto_aplicado: 0` (`getSpecialPaymentInstallmentFields` — ese `pagado` significa "fila de pago completa", no "cuota cubierta").
2. Al validar, la cuota correctamente NO se marca pagada (suma aplicada 0 < cuota), pero la fila conserva `pagado=true` y pasa a `validated`.
3. El `hasPaidPayment` del job (`EXISTS pagado=true AND validated/no_required`) la toma como cuota cubierta → la cuota desaparece del conteo.

## El fix

`AND COALESCE(pc.monto_aplicado, 0) > 0` en el EXISTS — una fila de pago solo "da fe" de la cuota si aplicó plata real. En dos lugares para que no se contradigan:
- `procesarMoras` (el job) — `hasPaidPayment`
- `createMora` — guard de `cuotasReales` (documentado como "misma lógica que procesarMoras")

La válvula para cuotas pagadas con plata real pero flag desincronizado se conserva (13 casos vivos medidos en dev siguen contando como pagadas); solo re-entran al conteo las cuotas perdonadas por filas de cero aplicado (3 casos medidos en dev: 2 solo-mora + 1 solo-otros).

## Pruebas

- Reproducido y verificado el mecanismo completo en dev (sandbox COBROS-02): registro solo-mora → validación → job.
- `tsc --noEmit` sin errores nuevos. `latefee.test.ts` en main tiene un error preexistente de mocks de bun (falla igual en main limpio, verificado con stash); en COBROS-02, donde ese quirk ya está resuelto, los 17 tests del motor pasan con este mismo cambio.

## Letra chica

- Filas solo-mora **legacy** guardaban `monto_aplicado = mora+otros` (>0) → siguen comportándose como hoy.
- Hay EXISTS con el mismo patrón en `reports.ts` / `reportes.ts` / `paymentAgreement.ts` (conteos de reportes/convenios): no se tocan aquí; pueden mostrar conteos distintos al job en estos casos borde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)