### PR TITLE
🚀 Pase a Producción — Reporte de cartera activa y correcciones en CRM

### DIFF
--- a/apps/cartera-back/src/controllers/activePortfolioReport.test.ts
+++ b/apps/cartera-back/src/controllers/activePortfolioReport.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test";
+import ExcelJS from "exceljs";
+
+import {
+  ACTIVE_PORTFOLIO_STATUSES,
+  buildActivePortfolioRows,
+  buildActivePortfolioWorkbook,
+} from "./activePortfolioReport";
+
+describe("active portfolio report", () => {
+  it("uses all live cartera statuses", () => {
+    expect(ACTIVE_PORTFOLIO_STATUSES).toEqual(["ACTIVO", "MOROSO", "EN_CONVENIO"]);
+  });
+
+  it("maps report rows with vehicle fallback and preserves SIFCO order", () => {
+    const rows = buildActivePortfolioRows(
+      [
+        {
+          numero_credito_sifco: "1002",
+          seguro_10_cuotas: "1200.50",
+          cliente_nombre: "Cliente B",
+        },
+        {
+          numero_credito_sifco: "1001",
+          seguro_10_cuotas: "980",
+          cliente_nombre: "Cliente A",
+        },
+      ],
+      new Map([
+        ["1001", { licensePlate: "P123ABC", vinNumber: "VIN123" }],
+      ]),
+    );
+
+    expect(rows).toEqual([
+      {
+        placa: "P123ABC",
+        chasis: "VIN123",
+        cuotaInterna: 980,
+        clienteNombre: "Cliente A",
+        numeroCredito: "1001",
+      },
+      {
+        placa: "-",
+        chasis: "-",
+        cuotaInterna: 1200.5,
+        clienteNombre: "Cliente B",
+        numeroCredito: "1002",
+      },
+    ]);
+  });
+
+  it("builds the expected Excel worksheet", async () => {
+    const buffer = await buildActivePortfolioWorkbook([
+      {
+        placa: "P123ABC",
+        chasis: "VIN123",
+        cuotaInterna: 980,
+        clienteNombre: "Cliente A",
+        numeroCredito: "1001",
+      },
+    ]);
+
+    const workbook = new ExcelJS.Workbook();
+    const workbookPayload = buffer as unknown as Parameters<typeof workbook.xlsx.load>[0];
+    await workbook.xlsx.load(workbookPayload);
+    const worksheet = workbook.getWorksheet("Cartera Activa");
+
+    expect(worksheet?.getRow(1).values).toEqual([
+      undefined,
+      "Placa",
+      "Chasis",
+      "Cuota Interna",
+      "Nombre del Cliente",
+      "Número de Crédito",
+    ]);
+    expect(worksheet?.rowCount).toBe(2);
+    expect(worksheet?.getRow(2).values).toEqual([
+      undefined,
+      "P123ABC",
+      "VIN123",
+      980,
+      "Cliente A",
+      "1001",
+    ]);
+  });
+});

--- a/apps/cartera-back/src/controllers/activePortfolioReport.ts
+++ b/apps/cartera-back/src/controllers/activePortfolioReport.ts
@@ -1,0 +1,98 @@
+import ExcelJS from "exceljs";
+import { sql, type SQL } from "drizzle-orm";
+import { creditos, usuarios } from "../database/db/schema";
+
+export const ACTIVE_PORTFOLIO_STATUSES = ["ACTIVO", "MOROSO", "EN_CONVENIO"] as const;
+
+export type ActivePortfolioCredit = {
+  numero_credito_sifco: string;
+  seguro_10_cuotas: string | number;
+  cliente_nombre: string;
+};
+
+export type ActivePortfolioVehicle = {
+  licensePlate?: string | null;
+  vinNumber?: string | null;
+};
+
+export type ActivePortfolioRow = {
+  placa: string;
+  chasis: string;
+  cuotaInterna: number;
+  clienteNombre: string;
+  numeroCredito: string;
+};
+
+type DbExecutor = {
+  execute(query: SQL): Promise<{ rows: Record<string, unknown>[] }>;
+};
+
+function toText(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function toNumber(value: unknown): number {
+  const numeric = Number(value ?? 0);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+export function buildActivePortfolioRows(
+  credits: ActivePortfolioCredit[],
+  vehiclesBySifco: Map<string, ActivePortfolioVehicle>,
+): ActivePortfolioRow[] {
+  return [...credits]
+    .sort((a, b) => a.numero_credito_sifco.localeCompare(b.numero_credito_sifco))
+    .map((credit) => {
+      const vehicle = vehiclesBySifco.get(credit.numero_credito_sifco);
+      return {
+        placa: vehicle?.licensePlate || "-",
+        chasis: vehicle?.vinNumber || "-",
+        cuotaInterna: toNumber(credit.seguro_10_cuotas),
+        clienteNombre: credit.cliente_nombre,
+        numeroCredito: credit.numero_credito_sifco,
+      };
+    });
+}
+
+export async function getActivePortfolioCredits(executor: DbExecutor): Promise<ActivePortfolioCredit[]> {
+  const activeStatusSql = sql.join(ACTIVE_PORTFOLIO_STATUSES.map((status) => sql`${status}`), sql`, `);
+  const result = await executor.execute(sql`
+    SELECT
+      c.numero_credito_sifco,
+      c.seguro_10_cuotas,
+      u.nombre AS cliente_nombre
+    FROM ${creditos} c
+    JOIN ${usuarios} u ON u.usuario_id = c.usuario_id
+    WHERE c."statusCredit" IN (${activeStatusSql})
+    ORDER BY c.numero_credito_sifco
+  `);
+  return result.rows.map((row) => ({
+    numero_credito_sifco: toText(row.numero_credito_sifco),
+    seguro_10_cuotas: toNumber(row.seguro_10_cuotas),
+    cliente_nombre: toText(row.cliente_nombre),
+  }));
+}
+
+export async function buildActivePortfolioWorkbook(rows: ActivePortfolioRow[]): Promise<Buffer> {
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet("Cartera Activa");
+
+  ws.columns = [
+    { header: "Placa", key: "placa", width: 16 },
+    { header: "Chasis", key: "chasis", width: 26 },
+    { header: "Cuota Interna", key: "cuotaInterna", width: 16 },
+    { header: "Nombre del Cliente", key: "clienteNombre", width: 34 },
+    { header: "Número de Crédito", key: "numeroCredito", width: 22 },
+  ];
+  ws.getRow(1).font = { bold: true };
+  ws.views = [{ state: "frozen", ySplit: 1 }];
+  ws.autoFilter = "A1:E1";
+
+  for (const row of rows) {
+    ws.addRow(row);
+  }
+  ws.getColumn("cuotaInterna").numFmt = "#,##0.00";
+
+  const buf = await wb.xlsx.writeBuffer();
+  return Buffer.from(buf);
+}

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import Big from "big.js";
+import { interesCubeResidual } from "./cobranzaDiaria";
+
+const round2 = (b: Big) => Number(b.round(2).toString());
+
+describe("interesCubeResidual", () => {
+  it("CUBE = total - Σ(parte de inversionistas no-CUBE); caso Brenda 70/30 + CUBE", () => {
+    const cube = interesCubeResidual(new Big("683.82"), [
+      { inversionista_id: 1, nombre: "Brenda", porcentaje_participacion_inversionista: 70, porcentaje_cash_in: 30, monto_aportado: "25324.90" },
+      { inversionista_id: 86, nombre: "Cube Investments S.A.", porcentaje_participacion_inversionista: 0, porcentaje_cash_in: 100, monto_aportado: "20108.92" },
+    ]);
+    // Brenda se queda 266.80 → CUBE (residuo) = 683.82 - 266.80 = 417.02
+    expect(round2(cube)).toBeCloseTo(417.02, 1);
+  });
+
+  it("un solo inversionista real 100/0 → CUBE = 0", () => {
+    const cube = interesCubeResidual(new Big("500"), [
+      { inversionista_id: 7, nombre: "Ana", porcentaje_participacion_inversionista: 100, porcentaje_cash_in: 0, monto_aportado: "1000" },
+    ]);
+    expect(round2(cube)).toBe(0);
+  });
+
+  it("sin inversionistas → CUBE = 0", () => {
+    expect(round2(interesCubeResidual(new Big("500"), []))).toBe(0);
+  });
+
+  it("solo CUBE (id 86) → CUBE = total", () => {
+    const cube = interesCubeResidual(new Big("500"), [
+      { inversionista_id: 86, nombre: "Cube Investments S.A.", porcentaje_participacion_inversionista: 0, porcentaje_cash_in: 100, monto_aportado: "1000" },
+    ]);
+    expect(round2(cube)).toBeCloseTo(500, 1);
+  });
+});

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import Big from "big.js";
-import { interesCubeResidual, efectividadPct } from "./cobranzaDiaria";
+import { interesCubeResidual, efectividadPct, agruparPorAsesor, type CobranzaCreditoRow } from "./cobranzaDiaria";
 
 const round2 = (b: Big) => Number(b.round(2).toString());
 
@@ -42,5 +42,56 @@ describe("efectividadPct", () => {
   });
   it("cobrado completo → 1", () => {
     expect(efectividadPct(new Big("500"), new Big("500"))).toBe(1);
+  });
+});
+
+const rubro = (v: string): import("./cobranzaDiaria").RubroMontos => ({
+  capital: v,
+  interes: v,
+  iva: "0",
+  seguro: "0",
+  gps: "0",
+  membresia: "0",
+});
+
+const credito = (over: Partial<CobranzaCreditoRow>): CobranzaCreditoRow => ({
+  credito_id: 1,
+  numero_credito_sifco: "X",
+  cliente_nombre: "C",
+  asesor_id: 10,
+  asesor_nombre: "Sam",
+  cobrado: rubro("0"),
+  restante: rubro("0"),
+  cube: { esperado: "0", cobrado: "0" },
+  mora_cobrada: "0",
+  total_cobrado: "0",
+  total_esperado: "0",
+  ...over,
+});
+
+describe("agruparPorAsesor", () => {
+  it("suma dos créditos del mismo asesor y calcula efectividad", () => {
+    const { asesores, totalGeneral } = agruparPorAsesor([
+      credito({ credito_id: 1, total_cobrado: "600", total_esperado: "400" }),
+      credito({ credito_id: 2, total_cobrado: "300", total_esperado: "700" }),
+    ]);
+    expect(asesores).toHaveLength(1);
+    expect(asesores[0].cuotas).toBe(2);
+    expect(asesores[0].total_cobrado).toBe("900.00");
+    expect(asesores[0].total_esperado).toBe("1100.00");
+    expect(asesores[0].programado).toBe("2000.00");
+    expect(asesores[0].efectividad).toBeCloseTo(0.45, 4);
+    expect(totalGeneral.total_cobrado).toBe("900.00");
+  });
+
+  it("separa por asesor y el total general suma todos", () => {
+    const { asesores, totalGeneral } = agruparPorAsesor([
+      credito({ credito_id: 1, asesor_id: 10, asesor_nombre: "Sam", total_cobrado: "100", total_esperado: "0" }),
+      credito({ credito_id: 2, asesor_id: 20, asesor_nombre: "Wil", total_cobrado: "50", total_esperado: "50" }),
+    ]);
+    expect(asesores).toHaveLength(2);
+    expect(totalGeneral.total_cobrado).toBe("150.00");
+    expect(totalGeneral.total_esperado).toBe("50.00");
+    expect(totalGeneral.cuotas).toBe(2);
   });
 });

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import Big from "big.js";
-import { interesCubeResidual } from "./cobranzaDiaria";
+import { interesCubeResidual, efectividadPct } from "./cobranzaDiaria";
 
 const round2 = (b: Big) => Number(b.round(2).toString());
 
@@ -30,5 +30,17 @@ describe("interesCubeResidual", () => {
       { inversionista_id: 86, nombre: "Cube Investments S.A.", porcentaje_participacion_inversionista: 0, porcentaje_cash_in: 100, monto_aportado: "1000" },
     ]);
     expect(round2(cube)).toBeCloseTo(500, 1);
+  });
+});
+
+describe("efectividadPct", () => {
+  it("cobrado/programado", () => {
+    expect(efectividadPct(new Big("9900"), new Big("12400"))).toBeCloseTo(0.7984, 4);
+  });
+  it("programado 0 → 0 (sin división por cero)", () => {
+    expect(efectividadPct(new Big("0"), new Big("0"))).toBe(0);
+  });
+  it("cobrado completo → 1", () => {
+    expect(efectividadPct(new Big("500"), new Big("500"))).toBe(1);
   });
 });

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.test.ts
@@ -94,4 +94,28 @@ describe("agruparPorAsesor", () => {
     expect(totalGeneral.total_esperado).toBe("50.00");
     expect(totalGeneral.cuotas).toBe(2);
   });
+
+  it("agrupa asesor_id null como 'Sin asesor' y suma en totalGeneral", () => {
+    const { asesores, totalGeneral } = agruparPorAsesor([
+      credito({ credito_id: 1, asesor_id: null, asesor_nombre: null, total_cobrado: "75", total_esperado: "100" }),
+      credito({ credito_id: 2, asesor_id: 10, asesor_nombre: "Sam", total_cobrado: "150", total_esperado: "200" }),
+    ]);
+    expect(asesores).toHaveLength(2);
+    // El crédito sin asesor debe formar su propio grupo
+    const sinAsesor = asesores.find((a) => a.asesor_id === null);
+    expect(sinAsesor).toBeDefined();
+    expect(sinAsesor?.asesor_nombre).toBe("Sin asesor");
+    expect(sinAsesor?.total_cobrado).toBe("75.00");
+    expect(sinAsesor?.total_esperado).toBe("100.00");
+    expect(sinAsesor?.cuotas).toBe(1);
+    // El crédito con asesor está en su grupo
+    const conAsesor = asesores.find((a) => a.asesor_id === 10);
+    expect(conAsesor?.asesor_nombre).toBe("Sam");
+    expect(conAsesor?.total_cobrado).toBe("150.00");
+    expect(conAsesor?.total_esperado).toBe("200.00");
+    // totalGeneral suma ambos
+    expect(totalGeneral.total_cobrado).toBe("225.00");
+    expect(totalGeneral.total_esperado).toBe("300.00");
+    expect(totalGeneral.cuotas).toBe(2);
+  });
 });

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.ts
@@ -1,0 +1,62 @@
+import Big from "big.js";
+import { calcularSplitInteresPci, type InvSplitInput } from "../cofidi/splitInteresPci";
+import { CUBE_INVESTMENT_ID } from "./absorberEnCube";
+
+Big.DP = 20;
+Big.RM = Big.roundHalfUp;
+
+export type RubroMontos = {
+  capital: string;
+  interes: string;
+  iva: string;
+  seguro: string;
+  gps: string;
+  membresia: string;
+};
+
+export type CobranzaCreditoRow = {
+  credito_id: number;
+  numero_credito_sifco: string;
+  cliente_nombre: string;
+  asesor_id: number | null;
+  asesor_nombre: string | null;
+  cobrado: RubroMontos;
+  restante: RubroMontos;
+  cube: { esperado: string; cobrado: string };
+  mora_cobrada: string;
+  total_cobrado: string;
+  total_esperado: string;
+};
+
+export type CobranzaAsesorRow = {
+  asesor_id: number | null;
+  asesor_nombre: string;
+  cuotas: number;
+  cobrado: RubroMontos;
+  restante: RubroMontos;
+  cube: { esperado: string; cobrado: string };
+  mora_cobrada: string;
+  total_cobrado: string;
+  total_esperado: string;
+  programado: string;
+  efectividad: number;
+};
+
+/**
+ * Interés de CUBE como RESIDUO (igual que COFIDI): total menos la parte que se
+ * quedan los inversionistas REALES (no-CUBE). Reusa calcularSplitInteresPci para
+ * la distribución por inversionista y suma los que NO son id 86.
+ */
+export function interesCubeResidual(totalInteres: Big, inversionistas: InvSplitInput[]): Big {
+  if (inversionistas.length === 0 || totalInteres.lte(0)) return new Big(0);
+  const split = calcularSplitInteresPci({
+    inversionistas,
+    pagoAbonoInteres: totalInteres,
+    pagoAbonoIva: new Big(0),
+  });
+  const sumaNoCube = split
+    .filter((r) => r.inversionista_id !== CUBE_INVESTMENT_ID)
+    .reduce((acc, r) => acc.plus(r.abono_interes), new Big(0));
+  const cube = totalInteres.minus(sumaNoCube);
+  return cube.lt(0) ? new Big(0) : cube;
+}

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.ts
@@ -1,6 +1,9 @@
 import Big from "big.js";
 import { calcularSplitInteresPci, type InvSplitInput } from "../cofidi/splitInteresPci";
-import { CUBE_INVESTMENT_ID } from "./absorberEnCube";
+
+// Inversionista CUBE (id 86). Se define local para no acoplar este módulo a
+// absorberEnCube (que no vive en develop); es el mismo valor que CUBE_INVESTMENT_ID.
+const CUBE_INVESTMENT_ID = 86;
 
 Big.DP = 20;
 Big.RM = Big.roundHalfUp;

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.ts
@@ -60,3 +60,8 @@ export function interesCubeResidual(totalInteres: Big, inversionistas: InvSplitI
   const cube = totalInteres.minus(sumaNoCube);
   return cube.lt(0) ? new Big(0) : cube;
 }
+
+export function efectividadPct(cobrado: Big, programado: Big): number {
+  if (programado.lte(0)) return 0;
+  return Number(cobrado.div(programado).round(4).toString());
+}

--- a/apps/cartera-back/src/controllers/cobranzaDiaria.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiaria.ts
@@ -65,3 +65,80 @@ export function efectividadPct(cobrado: Big, programado: Big): number {
   if (programado.lte(0)) return 0;
   return Number(cobrado.div(programado).round(4).toString());
 }
+
+const RUBROS = ["capital", "interes", "iva", "seguro", "gps", "membresia"] as const;
+
+function nuevoAcc() {
+  return {
+    cuotas: 0,
+    cobrado: { capital: new Big(0), interes: new Big(0), iva: new Big(0), seguro: new Big(0), gps: new Big(0), membresia: new Big(0) },
+    restante: { capital: new Big(0), interes: new Big(0), iva: new Big(0), seguro: new Big(0), gps: new Big(0), membresia: new Big(0) },
+    cubeEsp: new Big(0),
+    cubeCob: new Big(0),
+    mora: new Big(0),
+    totalCob: new Big(0),
+    totalEsp: new Big(0),
+  };
+}
+type Acc = ReturnType<typeof nuevoAcc>;
+
+function sumar(acc: Acc, r: CobranzaCreditoRow) {
+  acc.cuotas += 1;
+  for (const k of RUBROS) {
+    acc.cobrado[k] = acc.cobrado[k].plus(r.cobrado[k]);
+    acc.restante[k] = acc.restante[k].plus(r.restante[k]);
+  }
+  acc.cubeEsp = acc.cubeEsp.plus(r.cube.esperado);
+  acc.cubeCob = acc.cubeCob.plus(r.cube.cobrado);
+  acc.mora = acc.mora.plus(r.mora_cobrada);
+  acc.totalCob = acc.totalCob.plus(r.total_cobrado);
+  acc.totalEsp = acc.totalEsp.plus(r.total_esperado);
+}
+
+function materializar(asesor_id: number | null, asesor_nombre: string, acc: Acc): CobranzaAsesorRow {
+  const money = (b: Big) => b.round(2).toFixed(2);
+  const rubro = (o: Acc["cobrado"]): RubroMontos => ({
+    capital: money(o.capital),
+    interes: money(o.interes),
+    iva: money(o.iva),
+    seguro: money(o.seguro),
+    gps: money(o.gps),
+    membresia: money(o.membresia),
+  });
+  const programado = acc.totalCob.plus(acc.totalEsp);
+  return {
+    asesor_id,
+    asesor_nombre,
+    cuotas: acc.cuotas,
+    cobrado: rubro(acc.cobrado),
+    restante: rubro(acc.restante),
+    cube: { esperado: money(acc.cubeEsp), cobrado: money(acc.cubeCob) },
+    mora_cobrada: money(acc.mora),
+    total_cobrado: money(acc.totalCob),
+    total_esperado: money(acc.totalEsp),
+    programado: money(programado),
+    efectividad: efectividadPct(acc.totalCob, programado),
+  };
+}
+
+/**
+ * Agrupa las filas por crédito en filas por asesor (suma de cada rubro cobrado/restante,
+ * CUBE, mora y totales) más un renglón `totalGeneral` con la suma de todos los asesores.
+ */
+export function agruparPorAsesor(rows: CobranzaCreditoRow[]): {
+  asesores: CobranzaAsesorRow[];
+  totalGeneral: CobranzaAsesorRow;
+} {
+  const porAsesor = new Map<number | null, { nombre: string; acc: Acc }>();
+  const general = nuevoAcc();
+  for (const r of rows) {
+    const key = r.asesor_id;
+    if (!porAsesor.has(key)) porAsesor.set(key, { nombre: r.asesor_nombre ?? "Sin asesor", acc: nuevoAcc() });
+    sumar(porAsesor.get(key)!.acc, r);
+    sumar(general, r);
+  }
+  const asesores = [...porAsesor.entries()]
+    .map(([id, { nombre, acc }]) => materializar(id, nombre, acc))
+    .sort((a, b) => Number(b.total_esperado) - Number(a.total_esperado));
+  return { asesores, totalGeneral: materializar(null, "TOTAL", general) };
+}

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, mock } from "bun:test";
+mock.module("../database", () => ({ db: {} }));
+const { getCobranzaDiaria } = await import("./cobranzaDiariaReporte");
+
+// Cola: 1ª execute = query A (créditos), 2ª = query B (inversionistas)
+const makeExec = (responses: Array<{ rows: any[] }>) => {
+	let i = 0;
+	return { execute: (_q?: unknown) => Promise.resolve(responses[i++] ?? { rows: [] }) };
+};
+
+describe("getCobranzaDiaria", () => {
+	it("arma asesores + totalGeneral con CUBE residuo por crédito", async () => {
+		const exec = makeExec([
+			{ rows: [ // query A: 1 crédito, asesor 10
+				{ credito_id: 1, numero_credito_sifco: "X1", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
+				  cap_rest: "100", int_rest: "683.82", iva_rest: "82.06", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				  cap_cob: "0", int_cob: "0", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" },
+			] },
+			{ rows: [ // query B: Brenda 70/30 + CUBE
+				{ credito_id: 1, inversionista_id: 1, nombre: "Brenda", porcentaje_participacion_inversionista: "70", porcentaje_cash_in: "30", monto_aportado: "25324.90" },
+				{ credito_id: 1, inversionista_id: 86, nombre: "Cube Investments S.A.", porcentaje_participacion_inversionista: "0", porcentaje_cash_in: "100", monto_aportado: "20108.92" },
+			] },
+		]);
+		const { asesores, totalGeneral } = await getCobranzaDiaria({ anio: 2026, mes: 7, dia: 8, executor: exec as any });
+		expect(asesores).toHaveLength(1);
+		expect(asesores[0].asesor_nombre).toBe("Sam");
+		expect(asesores[0].cuotas).toBe(1);
+		// esperado interés 683.82 → CUBE esperado ≈ 417.02
+		expect(Number(asesores[0].cube.esperado)).toBeCloseTo(417.02, 0);
+		// nada cobrado → efectividad 0, restante = total esperado
+		expect(asesores[0].total_cobrado).toBe("0.00");
+		expect(asesores[0].efectividad).toBe(0);
+		expect(totalGeneral.asesor_nombre).toBe("TOTAL");
+	});
+});

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
@@ -50,4 +50,18 @@ describe("getCobranzaDiariaDetalle", () => {
 		expect(res.total).toBe(23);
 		expect(res.hasMore).toBe(true);
 	});
+
+	it("hasMore es false cuando offset + creditos.length >= total (última página)", async () => {
+		const exec = makeExec([
+			{ rows: [ { credito_id: 1, numero_credito_sifco: "X1", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
+				cap_rest: "100", int_rest: "0", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				cap_cob: "0", int_cob: "0", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" } ] }, // qA
+			{ rows: [] }, // qB inversionistas
+			{ rows: [{ total: "1" }] }, // count
+		]);
+		const res = await getCobranzaDiariaDetalle({ anio: 2026, mes: 7, dia: 8, asesorId: 10, limit: 10, offset: 0, executor: exec as any });
+		expect(res.creditos).toHaveLength(1);
+		expect(res.total).toBe(1);
+		expect(res.hasMore).toBe(false);
+	});
 });

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
@@ -33,3 +33,21 @@ describe("getCobranzaDiaria", () => {
 		expect(totalGeneral.asesor_nombre).toBe("TOTAL");
 	});
 });
+
+const { getCobranzaDiariaDetalle } = await import("./cobranzaDiariaReporte");
+
+describe("getCobranzaDiariaDetalle", () => {
+	it("pagina y reporta hasMore usando el count", async () => {
+		const exec = makeExec([
+			{ rows: [ { credito_id: 1, numero_credito_sifco: "X1", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
+				cap_rest: "100", int_rest: "0", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				cap_cob: "0", int_cob: "0", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" } ] }, // qA
+			{ rows: [] }, // qB inversionistas
+			{ rows: [{ total: "23" }] }, // count
+		]);
+		const res = await getCobranzaDiariaDetalle({ anio: 2026, mes: 7, dia: 8, asesorId: 10, limit: 10, offset: 0, executor: exec as any });
+		expect(res.creditos).toHaveLength(1);
+		expect(res.total).toBe(23);
+		expect(res.hasMore).toBe(true);
+	});
+});

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
@@ -13,7 +13,7 @@ export async function construirFilasCredito(
 	p: { anio: number; mes: number; dia: number; asesorId?: number; limit?: number; offset?: number },
 	exec: Exec,
 ): Promise<CobranzaCreditoRow[]> {
-	const asesorFilter = p.asesorId ? sql`AND cr.asesor_id = ${p.asesorId}` : sql``;
+	const asesorFilter = p.asesorId != null ? sql`AND cr.asesor_id = ${p.asesorId}` : sql``;
 	const pageFilter = p.limit != null ? sql`LIMIT ${p.limit} OFFSET ${p.offset ?? 0}` : sql``;
 
 	const qA = await exec.execute(sql`
@@ -123,6 +123,7 @@ export async function getCobranzaDiariaDetalle(p: {
 		SELECT COUNT(*)::int AS total
 		FROM cartera.cuotas_credito c
 		JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+		JOIN cartera.usuarios u ON cr.usuario_id = u.usuario_id
 		WHERE c.fecha_vencimiento::date = make_date(${p.anio}, ${p.mes}, ${p.dia})
 			AND c.numero_cuota > 0
 			AND cr."statusCredit" IN ('ACTIVO','MOROSO','EN_CONVENIO')

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
@@ -21,7 +21,11 @@ export async function construirFilasCredito(
 			cr.asesor_id, a.nombre AS asesor_nombre,
 			COALESCE(prog.capital_restante,0) AS cap_rest, COALESCE(prog.interes_restante,0) AS int_rest,
 			COALESCE(prog.iva_12_restante,0) AS iva_rest, COALESCE(prog.seguro_restante,0) AS seg_rest,
-			COALESCE(prog.gps_restante,0) AS gps_rest, COALESCE(prog.membresias,0) AS mem_rest,
+			COALESCE(prog.gps_restante,0) AS gps_rest,
+			-- Migrados SIFCO no ponen membresias=0 al pagar (a diferencia de los otros
+			-- *_restante), dejando una membresía fantasma en cuotas ya pagadas. Se fuerza a 0
+			-- cuando la cuota está pagada, para quedar consistente con los demás rubros.
+			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.membresias,0) END AS mem_rest,
 			COALESCE(pag.abono_capital,0) AS cap_cob, COALESCE(pag.abono_interes,0) AS int_cob,
 			COALESCE(pag.abono_iva,0) AS iva_cob, COALESCE(pag.abono_seguro,0) AS seg_cob,
 			COALESCE(pag.abono_gps,0) AS gps_cob, COALESCE(pag.membresias_pagada,0) AS mem_cob,

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
@@ -110,3 +110,24 @@ export async function getCobranzaDiaria(p: {
 	const rows = await construirFilasCredito(p, p.executor ?? db);
 	return agruparPorAsesor(rows);
 }
+
+export async function getCobranzaDiariaDetalle(p: {
+	anio: number; mes: number; dia: number; asesorId: number;
+	limit?: number; offset?: number; executor?: Exec;
+}): Promise<{ creditos: CobranzaCreditoRow[]; total: number; hasMore: boolean }> {
+	const exec = p.executor ?? db;
+	const limit = p.limit ?? 10;
+	const offset = p.offset ?? 0;
+	const creditos = await construirFilasCredito({ ...p, limit, offset }, exec);
+	const countRes = await exec.execute(sql`
+		SELECT COUNT(*)::int AS total
+		FROM cartera.cuotas_credito c
+		JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+		WHERE c.fecha_vencimiento::date = make_date(${p.anio}, ${p.mes}, ${p.dia})
+			AND c.numero_cuota > 0
+			AND cr."statusCredit" IN ('ACTIVO','MOROSO','EN_CONVENIO')
+			AND cr.asesor_id = ${p.asesorId}
+	`);
+	const total = Number((countRes.rows[0] as any)?.total ?? 0);
+	return { creditos, total, hasMore: offset + creditos.length < total };
+}

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
@@ -1,0 +1,112 @@
+import { sql } from "drizzle-orm";
+import Big from "big.js";
+import { db } from "../database";
+import type { InvSplitInput } from "../cofidi/splitInteresPci";
+import {
+	agruparPorAsesor, interesCubeResidual,
+	type CobranzaAsesorRow, type CobranzaCreditoRow,
+} from "./cobranzaDiaria";
+
+type Exec = Pick<typeof db, "execute">;
+
+export async function construirFilasCredito(
+	p: { anio: number; mes: number; dia: number; asesorId?: number; limit?: number; offset?: number },
+	exec: Exec,
+): Promise<CobranzaCreditoRow[]> {
+	const asesorFilter = p.asesorId ? sql`AND cr.asesor_id = ${p.asesorId}` : sql``;
+	const pageFilter = p.limit != null ? sql`LIMIT ${p.limit} OFFSET ${p.offset ?? 0}` : sql``;
+
+	const qA = await exec.execute(sql`
+		SELECT cr.credito_id, cr.numero_credito_sifco, u.nombre AS cliente_nombre,
+			cr.asesor_id, a.nombre AS asesor_nombre,
+			COALESCE(prog.capital_restante,0) AS cap_rest, COALESCE(prog.interes_restante,0) AS int_rest,
+			COALESCE(prog.iva_12_restante,0) AS iva_rest, COALESCE(prog.seguro_restante,0) AS seg_rest,
+			COALESCE(prog.gps_restante,0) AS gps_rest, COALESCE(prog.membresias,0) AS mem_rest,
+			COALESCE(pag.abono_capital,0) AS cap_cob, COALESCE(pag.abono_interes,0) AS int_cob,
+			COALESCE(pag.abono_iva,0) AS iva_cob, COALESCE(pag.abono_seguro,0) AS seg_cob,
+			COALESCE(pag.abono_gps,0) AS gps_cob, COALESCE(pag.membresias_pagada,0) AS mem_cob,
+			COALESCE(pag.mora,0) AS mora_cob
+		FROM cartera.cuotas_credito c
+		JOIN cartera.creditos cr ON c.credito_id = cr.credito_id
+		JOIN cartera.usuarios u ON cr.usuario_id = u.usuario_id
+		LEFT JOIN cartera.asesores a ON cr.asesor_id = a.asesor_id
+		LEFT JOIN LATERAL (
+			SELECT pc.capital_restante::numeric AS capital_restante, pc.interes_restante::numeric AS interes_restante,
+				pc.iva_12_restante::numeric AS iva_12_restante, pc.seguro_restante::numeric AS seguro_restante,
+				pc.gps_restante::numeric AS gps_restante, pc.membresias::numeric AS membresias
+			FROM cartera.pagos_credito pc
+			WHERE pc.cuota_id = c.cuota_id AND pc."paymentFalse" = false
+			ORDER BY pc.total_restante::numeric DESC NULLS LAST, pc.pago_id ASC LIMIT 1
+		) prog ON true
+		LEFT JOIN LATERAL (
+			SELECT SUM(pc.abono_capital::numeric) AS abono_capital, SUM(pc.abono_interes::numeric) AS abono_interes,
+				SUM(pc.abono_iva_12::numeric) AS abono_iva, SUM(pc.abono_seguro::numeric) AS abono_seguro,
+				SUM(pc.abono_gps::numeric) AS abono_gps, SUM(pc.membresias_pago::numeric) AS membresias_pagada,
+				SUM(pc.mora::numeric) AS mora
+			FROM cartera.pagos_credito pc
+			WHERE pc.cuota_id = c.cuota_id AND pc."paymentFalse" = false
+		) pag ON true
+		WHERE c.fecha_vencimiento::date = make_date(${p.anio}, ${p.mes}, ${p.dia})
+			AND c.numero_cuota > 0
+			AND cr."statusCredit" IN ('ACTIVO','MOROSO','EN_CONVENIO')
+			${asesorFilter}
+		ORDER BY cr.asesor_id, cr.numero_credito_sifco
+		${pageFilter}
+	`);
+	const filas = qA.rows as any[];
+	if (filas.length === 0) return [];
+
+	const ids = filas.map((f) => Number(f.credito_id));
+	const qB = await exec.execute(sql`
+		SELECT ci.credito_id, ci.inversionista_id, i.nombre,
+			ci.porcentaje_participacion_inversionista, ci.porcentaje_cash_in, ci.monto_aportado
+		FROM cartera.creditos_inversionistas ci
+		JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+		WHERE ci.credito_id IN (${sql.join(ids.map((id) => sql`${id}`), sql`, `)})
+	`);
+	const invPorCredito = new Map<number, InvSplitInput[]>();
+	for (const r of qB.rows as any[]) {
+		const arr = invPorCredito.get(Number(r.credito_id)) ?? [];
+		arr.push({
+			inversionista_id: Number(r.inversionista_id), nombre: r.nombre,
+			porcentaje_participacion_inversionista: r.porcentaje_participacion_inversionista,
+			porcentaje_cash_in: r.porcentaje_cash_in, monto_aportado: r.monto_aportado,
+		});
+		invPorCredito.set(Number(r.credito_id), arr);
+	}
+
+	const money = (b: Big) => b.round(2).toFixed(2);
+	return filas.map((f) => {
+		const invs = invPorCredito.get(Number(f.credito_id)) ?? [];
+		const cubeEsp = interesCubeResidual(new Big(f.int_rest ?? 0), invs);
+		const cubeCob = interesCubeResidual(new Big(f.int_cob ?? 0), invs);
+		const restante = { capital: f.cap_rest, interes: f.int_rest, iva: f.iva_rest, seguro: f.seg_rest, gps: f.gps_rest, membresia: f.mem_rest };
+		const cobrado = { capital: f.cap_cob, interes: f.int_cob, iva: f.iva_cob, seguro: f.seg_cob, gps: f.gps_cob, membresia: f.mem_cob };
+		const sum = (o: Record<string, string>) =>
+			Object.values(o).reduce((a, v) => a.plus(v ?? 0), new Big(0));
+		return {
+			credito_id: Number(f.credito_id), numero_credito_sifco: f.numero_credito_sifco,
+			cliente_nombre: f.cliente_nombre, asesor_id: f.asesor_id == null ? null : Number(f.asesor_id),
+			asesor_nombre: f.asesor_nombre ?? null,
+			cobrado: mapMoney(cobrado, money), restante: mapMoney(restante, money),
+			cube: { esperado: money(cubeEsp), cobrado: money(cubeCob) },
+			mora_cobrada: money(new Big(f.mora_cob ?? 0)),
+			total_cobrado: money(sum(cobrado)), total_esperado: money(sum(restante)),
+		} satisfies CobranzaCreditoRow;
+	});
+}
+
+function mapMoney(o: Record<string, string>, money: (b: Big) => string) {
+	return {
+		capital: money(new Big(o.capital ?? 0)), interes: money(new Big(o.interes ?? 0)),
+		iva: money(new Big(o.iva ?? 0)), seguro: money(new Big(o.seguro ?? 0)),
+		gps: money(new Big(o.gps ?? 0)), membresia: money(new Big(o.membresia ?? 0)),
+	};
+}
+
+export async function getCobranzaDiaria(p: {
+	anio: number; mes: number; dia: number; asesorId?: number; executor?: Exec;
+}): Promise<{ asesores: CobranzaAsesorRow[]; totalGeneral: CobranzaAsesorRow }> {
+	const rows = await construirFilasCredito(p, p.executor ?? db);
+	return agruparPorAsesor(rows);
+}

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -399,11 +399,19 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "anio, mes y dia son requeridos" };
       }
+      const a = Number(anio);
+      const m = Number(mes);
+      const d = Number(dia);
+      const asesorId = asesor_id ? Number(asesor_id) : undefined;
+      if (Number.isNaN(a) || Number.isNaN(m) || Number.isNaN(d) || (asesorId !== undefined && Number.isNaN(asesorId))) {
+        set.status = 400;
+        return { error: "anio, mes, dia y asesor_id deben ser numéricos válidos" };
+      }
       const data = await getCobranzaDiaria({
-        anio: Number(anio),
-        mes: Number(mes),
-        dia: Number(dia),
-        asesorId: asesor_id ? Number(asesor_id) : undefined,
+        anio: a,
+        mes: m,
+        dia: d,
+        asesorId,
       });
       set.status = 200;
       return { ok: true, data };
@@ -421,11 +429,19 @@ export const reportesRouter = new Elysia().use(authMiddleware)
         set.status = 400;
         return { error: "anio, mes, dia y asesor_id son requeridos" };
       }
+      const a = Number(anio);
+      const m = Number(mes);
+      const d = Number(dia);
+      const asesorId = Number(asesor_id);
+      if (Number.isNaN(a) || Number.isNaN(m) || Number.isNaN(d) || Number.isNaN(asesorId)) {
+        set.status = 400;
+        return { error: "anio, mes, dia y asesor_id deben ser numéricos válidos" };
+      }
       const data = await getCobranzaDiariaDetalle({
-        anio: Number(anio),
-        mes: Number(mes),
-        dia: Number(dia),
-        asesorId: Number(asesor_id),
+        anio: a,
+        mes: m,
+        dia: d,
+        asesorId,
         limit: limit ? Number(limit) : undefined,
         offset: offset ? Number(offset) : undefined,
       });

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -3,6 +3,7 @@ import { db } from "../database";
 import { buildActivePortfolioRows, buildActivePortfolioWorkbook, getActivePortfolioCredits } from "../controllers/activePortfolioReport";
 import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
 import { getVehiclesBySifcoMap } from "../services/crm.service";
+import { getCobranzaDiaria, getCobranzaDiariaDetalle } from "../controllers/cobranzaDiariaReporte";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -386,6 +387,52 @@ export const reportesRouter = new Elysia().use(authMiddleware)
       return { ok: true, data };
     } catch (error) {
       console.error("[/reportes/cuotas-por-fecha]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/cobranza-diaria", async ({ query, set }) => {
+    try {
+      const { anio, mes, dia, asesor_id } = query as Record<string, string>;
+      if (!anio || !mes || !dia) {
+        set.status = 400;
+        return { error: "anio, mes y dia son requeridos" };
+      }
+      const data = await getCobranzaDiaria({
+        anio: Number(anio),
+        mes: Number(mes),
+        dia: Number(dia),
+        asesorId: asesor_id ? Number(asesor_id) : undefined,
+      });
+      set.status = 200;
+      return { ok: true, data };
+    } catch (error) {
+      console.error("[/reportes/cobranza-diaria]", error);
+      set.status = 500;
+      return { error: "Error interno del servidor" };
+    }
+  })
+
+  .get("/reportes/cobranza-diaria/detalle", async ({ query, set }) => {
+    try {
+      const { anio, mes, dia, asesor_id, limit, offset } = query as Record<string, string>;
+      if (!anio || !mes || !dia || !asesor_id) {
+        set.status = 400;
+        return { error: "anio, mes, dia y asesor_id son requeridos" };
+      }
+      const data = await getCobranzaDiariaDetalle({
+        anio: Number(anio),
+        mes: Number(mes),
+        dia: Number(dia),
+        asesorId: Number(asesor_id),
+        limit: limit ? Number(limit) : undefined,
+        offset: offset ? Number(offset) : undefined,
+      });
+      set.status = 200;
+      return { ok: true, data };
+    } catch (error) {
+      console.error("[/reportes/cobranza-diaria/detalle]", error);
       set.status = 500;
       return { error: "Error interno del servidor" };
     }

--- a/apps/cartera-back/src/routers/reportes.ts
+++ b/apps/cartera-back/src/routers/reportes.ts
@@ -1,5 +1,8 @@
 import { Elysia } from "elysia";
+import { db } from "../database";
+import { buildActivePortfolioRows, buildActivePortfolioWorkbook, getActivePortfolioCredits } from "../controllers/activePortfolioReport";
 import { getCobradoDelMesSnapshot, getColocacionPorPeriodo, getComparativoHistorico, getCuotasPorFecha, getEsperadoDelMesMeta, getFlujoCuotasInversiones, getFlujoCuotasPorInversionista, getMoraByEtapaYAsesor, getMoraCobradaPorAsesor, getMontoACobrar, getMontoACobrarPeriodo, getReinversionLiquidaciones } from "../controllers/reportes";
+import { getVehiclesBySifcoMap } from "../services/crm.service";
 import { authMiddleware } from "./midleware";
 
 const PERIODOS_VALIDOS = ["anio", "trimestre", "mes", "semana", "dia"] as const;
@@ -22,7 +25,34 @@ function fechaValida(s: string): boolean {
   return dt.getFullYear() === y && dt.getMonth() === m - 1 && dt.getDate() === d;
 }
 
+function puedeDescargarCarteraActiva(user: { role?: string } | undefined): boolean {
+  return user?.role === "ADMIN" || user?.role === "CONTA";
+}
+
 export const reportesRouter = new Elysia().use(authMiddleware)
+
+  .get("/reportes/cartera-activa/excel", async ({ set, user }) => {
+    if (!puedeDescargarCarteraActiva(user)) {
+      set.status = 403;
+      return { error: "No autorizado" };
+    }
+
+    try {
+      const credits = await getActivePortfolioCredits(db);
+      const vehicles = await getVehiclesBySifcoMap(credits.map((credit) => credit.numero_credito_sifco));
+      const buf = await buildActivePortfolioWorkbook(buildActivePortfolioRows(credits, vehicles));
+      return new Response(new Uint8Array(buf), {
+        headers: {
+          "content-type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          "content-disposition": 'attachment; filename="reporte-cartera-activa.xlsx"',
+        },
+      });
+    } catch (error) {
+      console.error("[/reportes/cartera-activa/excel]", error);
+      set.status = 500;
+      return { error: "Error generando reporte de cartera activa" };
+    }
+  })
 
   .get("/reportes/monto-cobrar", async ({ query, set }) => {
     try {

--- a/apps/cartera-back/src/services/crm.service.ts
+++ b/apps/cartera-back/src/services/crm.service.ts
@@ -71,7 +71,7 @@ export async function notifyPayInvestors(
 }
 
 // ============================================
-// Obtener detalles de vehículo por número SIFCO
+// Obtener placa/chasis por número SIFCO
 // ============================================
 export interface VehicleDetails {
   id: string;
@@ -103,6 +103,21 @@ export interface VehicleDetailsResponse {
   error?: string;
 }
 
+export type VehicleReportDetails = Pick<VehicleDetails, "licensePlate" | "vinNumber">;
+
+type VehiclesBySifcoApiResponse = {
+  success: boolean;
+  data?: {
+    vehicles?: Array<{
+      numeroSifco: string;
+      licensePlate: string | null;
+      vinNumber: string | null;
+    }>;
+  };
+  message?: string;
+  error?: string;
+};
+
 export async function getVehicleDetailsBySifco(
   numeroSifco: string,
 ): Promise<VehicleDetailsResponse> {
@@ -110,14 +125,16 @@ export async function getVehicleDetailsBySifco(
     const { data } = await crmApi.get("/info/vehicle-details", {
       params: { numero_sifco: numeroSifco },
     });
-    if (!data) { return { success: false, message: "Sin respuesta del CRM" }}
+    if (!data) {
+      return { success: false, message: "Sin respuesta del CRM" };
+    }
 
     const vehicle = data?.data?.vehicle;
-    if (!vehicle) { 
-      console.error(`No contiene datos del vechículo para número ${numeroSifco}`);
-      return { success: false, message: "Vehículo no encontrado en CRM" }; 
+    if (!vehicle) {
+      console.error(`No contiene datos del vehículo para número ${numeroSifco}`);
+      return { success: false, message: "Vehículo no encontrado en CRM" };
     }
-    
+
     console.log("Consultado detalles del vehículo exitosamente");
     return {
       success: true,
@@ -133,4 +150,29 @@ export async function getVehicleDetailsBySifco(
       error: msg,
     };
   }
+}
+
+export async function getVehiclesBySifcoMap(
+  sifcos: string[],
+): Promise<Map<string, VehicleReportDetails>> {
+  const uniqueSifcos = [...new Set(sifcos.map((sifco) => sifco.trim()).filter(Boolean))];
+  const vehicles = new Map<string, VehicleReportDetails>();
+  if (uniqueSifcos.length === 0) return vehicles;
+
+  const { data } = await crmApi.post<VehiclesBySifcoApiResponse>("/info/vehicles-by-sifco", {
+    numero_sifcos: uniqueSifcos,
+  });
+
+  if (!data.success) {
+    throw new Error(data.message || data.error || "Error obteniendo vehículos del CRM");
+  }
+
+  for (const vehicle of data.data?.vehicles ?? []) {
+    vehicles.set(vehicle.numeroSifco, {
+      licensePlate: vehicle.licensePlate ?? "",
+      vinNumber: vehicle.vinNumber ?? "",
+    });
+  }
+
+  return vehicles;
 }

--- a/apps/carteraFront/src/App.tsx
+++ b/apps/carteraFront/src/App.tsx
@@ -29,6 +29,7 @@ import { FacturacionDiaria } from "./private/cartera/components/FacturacionDiari
 import { CapitalInversionistas } from "./private/cartera/components/CapitalInversionistas";
 import { Seguros } from "./private/cartera/components/Seguros";
 import { ProyeccionInversionistas } from "./private/cartera/components/ProyeccionInversionistas";
+import { ActivePortfolioReport } from "./private/cartera/components/ActivePortfolioReport";
 
 // 🔒 Rutas privadas
 function PrivateRoute({ children }: { children: JSX.Element }) {
@@ -290,6 +291,15 @@ function App() {
           element={
             <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
               <FacturacionDiaria />
+            </RoleRoute>
+          }
+        />
+
+        <Route
+          path="reporte-cartera-activa"
+          element={
+            <RoleRoute allowedRoles={["ADMIN", "CONTA"]}>
+              <ActivePortfolioReport />
             </RoleRoute>
           }
         />

--- a/apps/carteraFront/src/private/cartera/components/ActivePortfolioReport.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ActivePortfolioReport.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Download, FileSpreadsheet } from "lucide-react";
+import { toast } from "sonner";
+import { descargarReporteCarteraActiva } from "../services/activePortfolioReport.services";
+
+function errMsg(e: unknown, fallback: string): string {
+  if (e instanceof Error) return e.message || fallback;
+  return fallback;
+}
+
+export function ActivePortfolioReport() {
+  const [loading, setLoading] = useState(false);
+
+  const descargar = async () => {
+    try {
+      setLoading(true);
+      const blob = await descargarReporteCarteraActiva();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "reporte-cartera-activa.xlsx";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+      toast.success("Reporte descargado");
+    } catch (e: unknown) {
+      toast.error(errMsg(e, "Error descargando reporte"));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-x-0 top-16 xl:top-20 bottom-0 overflow-auto bg-gradient-to-br from-blue-50 to-white px-4 sm:px-6 lg:px-8 pt-8 pb-8">
+      <div className="w-full max-w-3xl mx-auto">
+        <div className="flex flex-col items-center mb-6">
+          <h1 className="text-3xl font-extrabold text-blue-700 text-center">Reporte cartera activa</h1>
+          <p className="text-gray-600 mt-2 text-center">
+            Descarga la cartera activa actual con placa, chasis, cuota interna, cliente y número de crédito.
+          </p>
+        </div>
+
+        <Card className="border-blue-100 shadow-lg bg-white/90">
+          <CardContent className="p-6 flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+            <div className="flex items-start gap-3">
+              <div className="rounded-xl bg-blue-100 p-3 text-blue-700">
+                <FileSpreadsheet className="h-6 w-6" />
+              </div>
+              <div>
+                <h2 className="font-semibold text-gray-900">Cartera activa a la fecha</h2>
+                <p className="text-sm text-gray-600 mt-1">Incluye créditos ACTIVO, MOROSO y EN_CONVENIO.</p>
+              </div>
+            </div>
+            <Button onClick={descargar} disabled={loading} className="gap-2">
+              <Download className="h-4 w-4" />
+              {loading ? "Generando..." : "Descargar Excel"}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
+++ b/apps/carteraFront/src/private/cartera/components/dashBoard.tsx
@@ -267,6 +267,13 @@ const menuSections: MenuSection[] = [
         roles: ["ADMIN", "CONTA"],
       },
       {
+        key: "reporte-cartera-activa",
+        label: "Cartera Activa",
+        icon: <FileText className="h-4 w-4" />,
+        path: "/reporte-cartera-activa",
+        roles: ["ADMIN", "CONTA"],
+      },
+      {
         key: "capital-inversionistas",
         label: "Capital Inversionistas",
         icon: <TrendingUp className="h-4 w-4" />,

--- a/apps/carteraFront/src/private/cartera/services/activePortfolioReport.services.ts
+++ b/apps/carteraFront/src/private/cartera/services/activePortfolioReport.services.ts
@@ -1,0 +1,10 @@
+import api from "@/Provider/interceptor";
+
+const API_URL = import.meta.env.VITE_BACK_URL || "";
+
+export const descargarReporteCarteraActiva = async (): Promise<Blob> => {
+  const res = await api.get(`${API_URL}/reportes/cartera-activa/excel`, {
+    responseType: "blob",
+  });
+  return res.data as Blob;
+};

--- a/apps/crm/apps/server/src/controllers/vehicles.ts
+++ b/apps/crm/apps/server/src/controllers/vehicles.ts
@@ -36,10 +36,12 @@ export const getVehicleByCodigoController = async (numero_sifco: string) => {
 			.from(opportunities)
 			.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 			.where(
-				and(eq(opportunities.numeroSifco, numero_sifco), 
-				inArray(opportunities.status, ["won", "migrate"]),),
+				and(
+					eq(opportunities.numeroSifco, numero_sifco),
+					inArray(opportunities.status, ["won", "migrate"]),
+				),
 			)
-			.orderBy(desc(opportunities.updatedAt))
+			.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt))
 			.limit(1)
 			.then((rows) => rows[0] || null);
 
@@ -56,6 +58,53 @@ export const getVehicleByCodigoController = async (numero_sifco: string) => {
 		};
 	} catch (err: any) {
 		console.error("[ERROR] getVehicleByCodigoController:", err);
+		return {
+			success: false,
+			message: err.message || "Internal server error",
+		};
+	}
+};
+
+export type VehicleBySifco = {
+	numeroSifco: string;
+	licensePlate: string | null;
+	vinNumber: string | null;
+};
+
+export const getVehiclesBySifcoController = async (numeroSifcos: string[]) => {
+	const uniqueSifcos = [...new Set(numeroSifcos.map((value) => value.trim()).filter(Boolean))];
+
+	if (uniqueSifcos.length === 0) {
+		return { success: true, data: { vehicles: [] as VehicleBySifco[] } };
+	}
+
+	try {
+		const rows = await db
+			.select({
+				numeroSifco: opportunities.numeroSifco,
+				licensePlate: vehicles.licensePlate,
+				vinNumber: vehicles.vinNumber,
+			})
+			.from(opportunities)
+			.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+			.where(inArray(opportunities.numeroSifco, uniqueSifcos))
+			.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt));
+
+		const seen = new Set<string>();
+		const matchedVehicles: VehicleBySifco[] = [];
+		for (const row of rows) {
+			if (!row.numeroSifco || seen.has(row.numeroSifco)) continue;
+			seen.add(row.numeroSifco);
+			matchedVehicles.push({
+				numeroSifco: row.numeroSifco,
+				licensePlate: row.licensePlate,
+				vinNumber: row.vinNumber,
+			});
+		}
+
+		return { success: true, data: { vehicles: matchedVehicles } };
+	} catch (err: any) {
+		console.error("[ERROR] getVehiclesBySifcoController:", err);
 		return {
 			success: false,
 			message: err.message || "Internal server error",

--- a/apps/crm/apps/server/src/controllers/vehicles.ts
+++ b/apps/crm/apps/server/src/controllers/vehicles.ts
@@ -86,8 +86,13 @@ export const getVehiclesBySifcoController = async (numeroSifcos: string[]) => {
 				vinNumber: vehicles.vinNumber,
 			})
 			.from(opportunities)
-			.leftJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
-			.where(inArray(opportunities.numeroSifco, uniqueSifcos))
+			.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+			.where(
+				and(
+					inArray(opportunities.numeroSifco, uniqueSifcos),
+					inArray(opportunities.status, ["won", "migrate"]),
+				),
+			)
 			.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt));
 
 		const seen = new Set<string>();

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -26,7 +26,10 @@ import {
 	validatePortalToken,
 } from "./controllers/portal-lead";
 import { createPublicLead } from "./controllers/public-lead";
-import { getVehicleByCodigoController } from "./controllers/vehicles";
+import {
+	getVehicleByCodigoController,
+	getVehiclesBySifcoController,
+} from "./controllers/vehicles";
 import type { db } from "./db";
 import { otps } from "./db/schema/otp";
 import {
@@ -1084,6 +1087,31 @@ app.get("/info/vehicle-details", async (c) => {
 
 	const result = await getVehicleByCodigoController(numero_sifco);
 	return c.json(result, result.success ? 200 : 404);
+});
+
+// Endpoint batch para reportes de cartera: placa/chasis por números SIFCO.
+app.post("/info/vehicles-by-sifco", async (c) => {
+	try {
+		const body = await c.req.json<{ numero_sifcos?: unknown }>();
+		if (!Array.isArray(body.numero_sifcos)) {
+			return c.json(
+				{ success: false, message: "numero_sifcos must be an array" },
+				400,
+			);
+		}
+
+		const numeroSifcos = body.numero_sifcos
+			.map((value) => String(value ?? "").trim())
+			.filter(Boolean);
+		const result = await getVehiclesBySifcoController(numeroSifcos);
+		return c.json(result, result.success ? 200 : 500);
+	} catch (err: any) {
+		console.error("[ERROR] /info/vehicles-by-sifco:", err);
+		return c.json(
+			{ success: false, message: err.message || "Internal server error" },
+			500,
+		);
+	}
 });
 
 // Job periódico de notificaciones de cobros (cada hora)

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4087,6 +4087,50 @@ export const cobrosRouter = {
 		}),
 
 	// ========================================================================
+	// COBRANZA DIARIA (Cobrado vs Esperado)
+	// ========================================================================
+
+	getCobranzaDiaria: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				anio: z.number(),
+				mes: z.number(),
+				dia: z.number(),
+				asesorId: z.number().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			return carteraBackClient.getCobranzaDiaria(input);
+		}),
+
+	getCobranzaDiariaDetalle: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				anio: z.number(),
+				mes: z.number(),
+				dia: z.number(),
+				asesorId: z.number(),
+				limit: z.number().optional(),
+				offset: z.number().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+
+			return carteraBackClient.getCobranzaDiariaDetalle(input);
+		}),
+
+	// ========================================================================
 	// DESCUENTOS / RUBROS POR CRÉDITO
 	// ========================================================================
 

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -174,6 +174,8 @@ export const cobrosAppRouter = {
 	getMoraByEtapaYAsesor: cobrosRouter.getMoraByEtapaYAsesor,
 	getMoraCobradaPorAsesor: cobrosRouter.getMoraCobradaPorAsesor,
 	getCuotasPorFecha: cobrosRouter.getCuotasPorFecha,
+	getCobranzaDiaria: cobrosRouter.getCobranzaDiaria,
+	getCobranzaDiariaDetalle: cobrosRouter.getCobranzaDiariaDetalle,
 	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
 
 	// Seguimientos programados

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1684,6 +1684,54 @@ export class CarteraBackClient {
 		return response.data ?? [];
 	}
 
+	async getCobranzaDiaria(params: {
+		anio: number;
+		mes: number;
+		dia: number;
+		asesorId?: number;
+	}): Promise<any> {
+		const qp = new URLSearchParams({
+			anio: String(params.anio),
+			mes: String(params.mes),
+			dia: String(params.dia),
+			...(params.asesorId ? { asesor_id: String(params.asesorId) } : {}),
+		});
+
+		const res = await this.request<{ ok: boolean; data: any }>(
+			`/reportes/cobranza-diaria?${qp}`,
+			{ method: "GET" },
+			false,
+		);
+
+		return res.data ?? { asesores: [], totalGeneral: null };
+	}
+
+	async getCobranzaDiariaDetalle(params: {
+		anio: number;
+		mes: number;
+		dia: number;
+		asesorId: number;
+		limit?: number;
+		offset?: number;
+	}): Promise<any> {
+		const qp = new URLSearchParams({
+			anio: String(params.anio),
+			mes: String(params.mes),
+			dia: String(params.dia),
+			asesor_id: String(params.asesorId),
+			limit: String(params.limit ?? 10),
+			offset: String(params.offset ?? 0),
+		});
+
+		const res = await this.request<{ ok: boolean; data: any }>(
+			`/reportes/cobranza-diaria/detalle?${qp}`,
+			{ method: "GET" },
+			false,
+		);
+
+		return res.data ?? { creditos: [], total: 0, hasMore: false };
+	}
+
 	// ========================================================================
 	// CACHE MANAGEMENT
 	// ========================================================================

--- a/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
+++ b/apps/crm/apps/web/src/routes/accounting/pay-investors.tsx
@@ -374,7 +374,11 @@ function SubirBoletaDialog({
 			await upload({
 				file: toUpload,
 				inversionista_id: inv.inversionista_id,
-				monto_boleta: String(inv.total_a_recibir_con_reinversion),
+				// La boleta se emite por la cuota real a transferir (mismo campo que
+				// usan la fila y los archivos ACH/Terceros).
+				monto_boleta: String(
+					inv.total_cuota ?? inv.total_a_recibir_con_reinversion,
+				),
 				notas: notas.trim() || undefined,
 			});
 			toast.success("Boleta subida correctamente");
@@ -403,7 +407,11 @@ function SubirBoletaDialog({
 				<DialogHeader>
 					<DialogTitle>Subir Boleta</DialogTitle>
 					<DialogDescription>
-						{inv.nombre} — {formatCurrency(inv.total_a_recibir_con_reinversion, inv.currencySymbol)}
+						{inv.nombre} —{" "}
+						{formatCurrency(
+							inv.total_cuota ?? inv.total_a_recibir_con_reinversion,
+							inv.currencySymbol,
+						)}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -1066,11 +1074,18 @@ function PagarInversionistas() {
 		);
 	}
 
+	// Suma la cuota real a transferir, igual que la fila, la boleta y los archivos
+	// ACH/Terceros. No sirve `total_a_recibir_con_reinversion`: para los créditos en
+	// interés compuesto de inversionistas que emiten factura arrastra el IVA, que no
+	// se transfiere, e infla el total.
 	const totalPendienteLiquidar = inversionistas
 		.filter((inv) => inv.estado_liquidacion_resumen !== "liquidated")
 		.reduce(
 			(acc, inv) =>
-				acc + Number.parseFloat(inv.total_a_recibir_con_reinversion || "0"),
+				acc +
+				Number.parseFloat(
+					(inv.total_cuota ?? inv.total_a_recibir_con_reinversion) || "0",
+				),
 			0,
 		);
 	return (

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -590,111 +590,13 @@ function TabMora({
 	);
 }
 
-// ─── Cuotas por Fecha (Pagos Esperados) ─────────────────────────────────────
-
-type QuickPeriod = "hoy" | "semana" | "quincena" | "mes";
-type FechaMode = QuickPeriod | "personalizado";
-
-const QUICK_LABELS: Record<QuickPeriod, string> = {
-	hoy: "Hoy",
-	semana: "Esta Semana",
-	quincena: "Esta Quincena",
-	mes: "Este Mes",
-};
+// ─── shared helpers (fecha) ───────────────────────────────────────────────
 
 function todayGT(): string {
 	return new Intl.DateTimeFormat("en-CA", {
 		timeZone: "America/Guatemala",
 	}).format(new Date());
 }
-
-function addDaysGT(dateStr: string, n: number): string {
-	const [y, m, d] = dateStr.split("-").map(Number);
-	const dt = new Date(Date.UTC(y, m - 1, d + n));
-	return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-${String(dt.getUTCDate()).padStart(2, "0")}`;
-}
-
-function fmtDate(dt: Date): string {
-	return `${dt.getUTCFullYear()}-${String(dt.getUTCMonth() + 1).padStart(2, "0")}-${String(dt.getUTCDate()).padStart(2, "0")}`;
-}
-
-function weekRangeGT(): { start: string; end: string } {
-	const h = todayGT();
-	const [y, m, d] = h.split("-").map(Number);
-	const dt = new Date(Date.UTC(y, m - 1, d));
-	const dow = dt.getUTCDay(); // 0=Dom, 1=Lun ... 6=Sab
-	const daysFromMon = dow === 0 ? 6 : dow - 1;
-	const monday = new Date(Date.UTC(y, m - 1, d - daysFromMon));
-	const sunday = new Date(Date.UTC(y, m - 1, d - daysFromMon + 6));
-	return { start: fmtDate(monday), end: fmtDate(sunday) };
-}
-
-function monthRangeGT(): { start: string; end: string } {
-	const h = todayGT();
-	const [y, m] = h.split("-").map(Number);
-	const start = `${y}-${String(m).padStart(2, "0")}-01`;
-	const lastDay = new Date(Date.UTC(y, m, 0));
-	return { start, end: fmtDate(lastDay) };
-}
-
-// Rango calculado para un preset. Se recalcula en cada render, así "Hoy" /
-// "Esta Semana" siguen frescos aunque el usuario vuelva otro día.
-function rangeForPreset(p: QuickPeriod): { start: string; end: string } {
-	if (p === "hoy") {
-		const h = todayGT();
-		return { start: h, end: h };
-	}
-	if (p === "semana") return weekRangeGT();
-	if (p === "quincena") {
-		const h = todayGT();
-		return { start: h, end: addDaysGT(h, 14) };
-	}
-	return monthRangeGT();
-}
-
-// Modo inicial para sesiones previas a `modoFecha`: si las fechas guardadas
-// coinciden con un preset, se restaura ese preset; si son un rango propio, se
-// abre en "personalizado" para no perder el filtro del usuario.
-function inferModoFechaInicial(): FechaMode {
-	try {
-		const fiRaw = sessionStorage.getItem("cobros/reportes/cuotas/fechaInicio");
-		const ffRaw = sessionStorage.getItem("cobros/reportes/cuotas/fechaFin");
-		if (!fiRaw || !ffRaw) return "hoy";
-		const fi = JSON.parse(fiRaw) as string;
-		const ff = JSON.parse(ffRaw) as string;
-		for (const p of Object.keys(QUICK_LABELS) as QuickPeriod[]) {
-			const r = rangeForPreset(p);
-			if (fi === r.start && ff === r.end) return p;
-		}
-		return "personalizado";
-	} catch {
-		return "hoy";
-	}
-}
-
-type CuotaFila = {
-	cuota_id: number;
-	fecha_vencimiento: string;
-	pagado: boolean;
-	numero_credito_sifco: string;
-	cliente_nombre: string;
-	asesor_nombre: string | null;
-	statusCredit: string;
-	capital_esperado: string;
-	interes_esperado: string;
-	iva_esperado: string;
-	seguro_esperado: string;
-	gps_esperado: string;
-	membresias_esperado: string;
-	total_esperado: string;
-	capital_pagado: string;
-	interes_pagado: string;
-	iva_pagado: string;
-	seguro_pagado: string;
-	gps_pagado: string;
-	total_pagado: string;
-	membresias_pagado: string;
-};
 
 function RubroCelda({
 	esperado,
@@ -712,431 +614,6 @@ function RubroCelda({
 			>
 				{pagadoNum > 0 ? fmtQ(pagado) : "—"}
 			</div>
-		</div>
-	);
-}
-
-function EstadoBadge({ row }: { row: CuotaFila }) {
-	if (row.pagado)
-		return <Badge className="bg-green-100 text-green-800">Pagado</Badge>;
-	if (Number(row.total_pagado) > 0)
-		return <Badge className="bg-yellow-100 text-yellow-800">Parcial</Badge>;
-	return <Badge className="bg-red-100 text-red-800">Pendiente</Badge>;
-}
-
-const colsCuotas: ColumnDef<CuotaFila>[] = [
-	{
-		accessorKey: "numero_credito_sifco",
-		header: "Crédito / Cliente",
-		cell: ({ row }) => (
-			<div className="flex flex-col gap-0.5">
-				<Link
-					to="/cobros/$id"
-					params={{ id: row.original.numero_credito_sifco }}
-					search={{ tipo: "contrato" }}
-					className="font-mono text-blue-600 text-xs hover:underline"
-				>
-					{row.original.numero_credito_sifco}
-				</Link>
-				<span className="text-muted-foreground text-xs">
-					{row.original.cliente_nombre}
-				</span>
-			</div>
-		),
-	},
-	{
-		accessorKey: "asesor_nombre",
-		header: "Asesor",
-		cell: ({ row }) => row.original.asesor_nombre ?? "—",
-	},
-	{
-		accessorKey: "fecha_vencimiento",
-		header: "Fecha Venc.",
-		cell: ({ row }) =>
-			new Date(`${row.original.fecha_vencimiento}T12:00:00`).toLocaleDateString(
-				"es-GT",
-			),
-	},
-	{
-		accessorKey: "capital_esperado",
-		header: "Capital",
-		cell: ({ row }) => (
-			<RubroCelda
-				esperado={row.original.capital_esperado}
-				pagado={row.original.capital_pagado}
-			/>
-		),
-	},
-	{
-		accessorKey: "interes_esperado",
-		header: "Interés",
-		cell: ({ row }) => (
-			<RubroCelda
-				esperado={row.original.interes_esperado}
-				pagado={row.original.interes_pagado}
-			/>
-		),
-	},
-	{
-		accessorKey: "iva_esperado",
-		header: "IVA 12%",
-		cell: ({ row }) => (
-			<RubroCelda
-				esperado={row.original.iva_esperado}
-				pagado={row.original.iva_pagado}
-			/>
-		),
-	},
-	{
-		accessorKey: "seguro_esperado",
-		header: "Seguro",
-		cell: ({ row }) => (
-			<RubroCelda
-				esperado={row.original.seguro_esperado}
-				pagado={row.original.seguro_pagado}
-			/>
-		),
-	},
-	{
-		accessorKey: "gps_esperado",
-		header: "GPS",
-		cell: ({ row }) => (
-			<RubroCelda
-				esperado={row.original.gps_esperado}
-				pagado={row.original.gps_pagado}
-			/>
-		),
-	},
-	{
-		accessorKey: "membresias_esperado",
-		header: "Membresías",
-		cell: ({ row }) => (
-			<RubroCelda
-				esperado={row.original.membresias_esperado}
-				pagado={row.original.membresias_pagado}
-			/>
-		),
-	},
-	{
-		accessorKey: "total_esperado",
-		header: "Total",
-		cell: ({ row }) => (
-			<RubroCelda
-				esperado={row.original.total_esperado}
-				pagado={row.original.total_pagado}
-			/>
-		),
-	},
-	{
-		id: "estado",
-		header: "Estado",
-		cell: ({ row }) => <EstadoBadge row={row.original} />,
-	},
-];
-
-function TabCuotasPorFecha({
-	session,
-	canSeeAll,
-}: {
-	session: ReturnType<typeof authClient.useSession>["data"];
-	canSeeAll: boolean;
-}) {
-	const hoyInit = todayGT();
-
-	// El modo manda: si es un preset, las fechas se calculan al vuelo. Solo en
-	// "personalizado" se usan (y editan) las fechas guardadas.
-	const [modoFecha, setModoFecha] = usePersistedState<FechaMode>(
-		"cobros/reportes/cuotas/modoFecha",
-		inferModoFechaInicial(),
-	);
-	const [fechaInicioCustom, setFechaInicioCustom] = usePersistedState<string>(
-		"cobros/reportes/cuotas/fechaInicio",
-		hoyInit,
-	);
-	const [fechaFinCustom, setFechaFinCustom] = usePersistedState<string>(
-		"cobros/reportes/cuotas/fechaFin",
-		hoyInit,
-	);
-	const [asesorId, setAsesorId] = usePersistedState<string>(
-		"cobros/reportes/cuotas/asesorId",
-		"",
-	);
-	const [filtroEstado, setFiltroEstado] = usePersistedState<string>(
-		"cobros/reportes/cuotas/filtroEstado",
-		"todos",
-	);
-
-	const esPersonalizado = modoFecha === "personalizado";
-	const { start: fechaInicio, end: fechaFin } = esPersonalizado
-		? { start: fechaInicioCustom, end: fechaFinCustom }
-		: rangeForPreset(modoFecha);
-
-	function activarPersonalizado() {
-		// Sembrar las fechas editables con el rango del preset actual.
-		if (!esPersonalizado) {
-			const r = rangeForPreset(modoFecha);
-			setFechaInicioCustom(r.start);
-			setFechaFinCustom(r.end);
-		}
-		setModoFecha("personalizado");
-	}
-
-	const { data: asesoresData } = useQuery({
-		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
-		enabled: !!session && canSeeAll,
-	});
-
-	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
-		...orpc.getCuotasPorFecha.queryOptions({
-			input: {
-				fechaInicio,
-				fechaFin,
-				asesorId: canSeeAll
-					? asesorId
-						? Number(asesorId)
-						: undefined
-					: undefined,
-			},
-		}),
-		enabled: !!session && !!fechaInicio && !!fechaFin,
-		staleTime: 5 * 60 * 1000,
-	});
-
-	const ultimaAct = dataUpdatedAt
-		? new Date(dataUpdatedAt).toLocaleTimeString("es-GT", {
-				hour: "2-digit",
-				minute: "2-digit",
-			})
-		: null;
-
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const totales = (data as any)?.totales;
-	const rows: CuotaFila[] =
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		(data as any)?.rows ?? [];
-
-	function getEstado(row: CuotaFila): "pagado" | "parcial" | "pendiente" {
-		if (row.pagado) return "pagado";
-		if (Number(row.total_pagado) > 0) return "parcial";
-		return "pendiente";
-	}
-
-	const filteredRows =
-		filtroEstado === "todos"
-			? rows
-			: rows.filter((r) => getEstado(r) === filtroEstado);
-
-	return (
-		<div className="space-y-6">
-			<div className="flex items-center gap-2">
-				<CalendarClock className="h-5 w-5 text-blue-600" />
-				<h2 className="font-semibold text-xl">Pagos Esperados</h2>
-			</div>
-
-			{/* Filtros */}
-			<div className="space-y-3">
-				{/* Período — filtro principal */}
-				<div className="rounded-lg border bg-muted/30 p-3">
-					<div className="flex flex-wrap items-end gap-x-4 gap-y-3">
-						<div className="flex flex-col gap-1.5">
-							<Label className="font-semibold text-xs">Período</Label>
-							<div className="flex flex-wrap items-center gap-1.5">
-								{(Object.keys(QUICK_LABELS) as QuickPeriod[]).map((p) => (
-									<Button
-										key={p}
-										variant={modoFecha === p ? "default" : "outline"}
-										size="sm"
-										onClick={() => setModoFecha(p)}
-									>
-										{QUICK_LABELS[p]}
-									</Button>
-								))}
-								<Button
-									variant={esPersonalizado ? "default" : "outline"}
-									size="sm"
-									onClick={activarPersonalizado}
-								>
-									Personalizado
-								</Button>
-							</div>
-						</div>
-
-						<div className="flex items-end gap-2">
-							<div className="flex flex-col gap-1">
-								<Label className="text-muted-foreground text-xs">Desde</Label>
-								<Input
-									type="date"
-									className="w-36"
-									value={fechaInicio}
-									disabled={!esPersonalizado}
-									onChange={(e) => setFechaInicioCustom(e.target.value)}
-								/>
-							</div>
-							<div className="flex flex-col gap-1">
-								<Label className="text-muted-foreground text-xs">Hasta</Label>
-								<Input
-									type="date"
-									className="w-36"
-									value={fechaFin}
-									disabled={!esPersonalizado}
-									onChange={(e) => setFechaFinCustom(e.target.value)}
-								/>
-							</div>
-						</div>
-
-						{!esPersonalizado && (
-							<p className="pb-2 text-muted-foreground text-xs">
-								Selecciona «Personalizado» para elegir fechas.
-							</p>
-						)}
-					</div>
-				</div>
-
-				{/* Filtros secundarios */}
-				<div className="flex flex-wrap items-end gap-3">
-					{canSeeAll && (
-						<div className="flex flex-col gap-1">
-							<Label className="text-xs">Asesor</Label>
-							<Select
-								value={asesorId}
-								onValueChange={(v) => setAsesorId(v === "todos" ? "" : v)}
-							>
-								<SelectTrigger className="w-48">
-									<SelectValue placeholder="Todos los asesores" />
-								</SelectTrigger>
-								<SelectContent>
-									<SelectItem value="todos">Todos</SelectItem>
-									{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-									{(asesoresData as any)?.asesores?.map((a: any) => (
-										<SelectItem key={a.asesorId} value={String(a.asesorId)}>
-											{a.nombre}
-										</SelectItem>
-									))}
-								</SelectContent>
-							</Select>
-						</div>
-					)}
-
-					<div className="flex flex-col gap-1">
-						<Label className="text-xs">Estado</Label>
-						<Select value={filtroEstado} onValueChange={setFiltroEstado}>
-							<SelectTrigger className="w-36">
-								<SelectValue />
-							</SelectTrigger>
-							<SelectContent>
-								<SelectItem value="todos">Todos</SelectItem>
-								<SelectItem value="pagado">Pagado</SelectItem>
-								<SelectItem value="parcial">Parcial</SelectItem>
-								<SelectItem value="pendiente">Pendiente</SelectItem>
-							</SelectContent>
-						</Select>
-					</div>
-
-					<div className="ml-auto flex items-center gap-2">
-						{ultimaAct && (
-							<span className="text-muted-foreground text-xs">
-								Actualizado: {ultimaAct}
-							</span>
-						)}
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={() => refetch()}
-							disabled={isFetching}
-						>
-							<RefreshCw
-								className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
-							/>
-							Actualizar
-						</Button>
-					</div>
-				</div>
-			</div>
-
-			{/* Summary cards */}
-			<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-				<Card className="gap-1 border-blue-200 bg-blue-50 py-3">
-					<CardHeader className="px-4 pt-0 pb-0">
-						<CardTitle className="font-medium text-blue-700 text-xs">
-							Total Esperado
-						</CardTitle>
-					</CardHeader>
-					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-blue-800 text-lg">
-							{fmtQ(totales?.totalEsp ?? "0")}
-						</div>
-					</CardContent>
-				</Card>
-				<Card className="gap-1 border-green-200 bg-green-50 py-3">
-					<CardHeader className="px-4 pt-0 pb-0">
-						<CardTitle className="font-medium text-green-700 text-xs">
-							Total Pagado
-						</CardTitle>
-					</CardHeader>
-					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-green-700 text-lg">
-							{fmtQ(totales?.totalPag ?? "0")}
-						</div>
-					</CardContent>
-				</Card>
-				<Card className="gap-1 border-red-200 bg-red-50 py-3">
-					<CardHeader className="px-4 pt-0 pb-0">
-						<CardTitle className="font-medium text-red-700 text-xs">
-							Total Pendiente
-						</CardTitle>
-					</CardHeader>
-					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-lg text-red-700">
-							{fmtQ(totales?.totalPendiente ?? "0")}
-						</div>
-					</CardContent>
-				</Card>
-				<Card className="gap-1 py-3">
-					<CardHeader className="px-4 pt-0 pb-0">
-						<CardTitle className="font-medium text-xs">Cuotas</CardTitle>
-					</CardHeader>
-					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-lg">
-							{totales?.cuotasPagadas ?? 0} / {totales?.cuotasTotal ?? 0}
-						</div>
-						<p className="text-muted-foreground text-xs">pagadas / total</p>
-					</CardContent>
-				</Card>
-			</div>
-
-			{/* Rubro breakdown cards */}
-			<div className="grid grid-cols-3 gap-3 md:grid-cols-6">
-				{(
-					[
-						{ key: "capitalEsp", label: "Capital" },
-						{ key: "interesEsp", label: "Interés" },
-						{ key: "ivaEsp", label: "IVA 12%" },
-						{ key: "seguroEsp", label: "Seguro" },
-						{ key: "gpsEsp", label: "GPS" },
-						{ key: "membresiasEsp", label: "Membresías" },
-					] as const
-				).map((c) => (
-					<Card key={c.key} className="gap-0.5 py-2.5">
-						<CardHeader className="px-3 pt-0 pb-0">
-							<CardTitle className="font-medium text-muted-foreground text-xs">
-								{c.label}
-							</CardTitle>
-						</CardHeader>
-						<CardContent className="px-3 pb-0">
-							<div className="font-semibold text-sm">
-								{fmtQ(totales?.[c.key] ?? "0")}
-							</div>
-						</CardContent>
-					</Card>
-				))}
-			</div>
-
-			{/* Detail table */}
-			<DataTable
-				columns={colsCuotas}
-				data={filteredRows}
-				isLoading={isLoading}
-			/>
 		</div>
 	);
 }
@@ -1323,7 +800,9 @@ function AsesorRow({
 												/>
 											</td>
 											<td className="px-3 text-right text-green-600 text-xs">
-												{Number(c.mora_cobrada) > 0 ? fmtQ(c.mora_cobrada) : "—"}
+												{Number(c.mora_cobrada) > 0
+													? fmtQ(c.mora_cobrada)
+													: "—"}
 											</td>
 											<td className="px-3">
 												<RubroCelda
@@ -1342,8 +821,8 @@ function AsesorRow({
 										size="sm"
 										onClick={() => setLimit((l) => l + 10)}
 									>
-										Mostrar más (
-										{detalleData.total - (creditos.length ?? 0)} restantes)
+										Mostrar más ({detalleData.total - (creditos.length ?? 0)}{" "}
+										restantes)
 									</Button>
 								</div>
 							)}
@@ -1362,9 +841,11 @@ function TabCobradoVsEsperado({
 	session: ReturnType<typeof authClient.useSession>["data"];
 	canSeeAll: boolean;
 }) {
-	const [anioHoy, mesHoy, diaHoy] = todayGT()
-		.split("-")
-		.map(Number) as [number, number, number];
+	const [anioHoy, mesHoy, diaHoy] = todayGT().split("-").map(Number) as [
+		number,
+		number,
+		number,
+	];
 
 	const [anio, setAnio] = usePersistedState<number>(
 		"cobros/reportes/cobranza/anio",
@@ -1526,7 +1007,7 @@ function TabCobradoVsEsperado({
 			{/* Summary cards */}
 			<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
 				<Card className="gap-1 border-blue-200 bg-blue-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-blue-700 text-xs">
 							A Cobrar
 						</CardTitle>
@@ -1538,7 +1019,7 @@ function TabCobradoVsEsperado({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-green-200 bg-green-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-green-700 text-xs">
 							Cobrado
 						</CardTitle>
@@ -1550,19 +1031,19 @@ function TabCobradoVsEsperado({
 					</CardContent>
 				</Card>
 				<Card className="gap-1 border-red-200 bg-red-50 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-red-700 text-xs">
 							Restante
 						</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">
-						<div className="font-bold text-red-700 text-lg">
+						<div className="font-bold text-lg text-red-700">
 							{fmtQ(totalGeneral?.total_esperado ?? "0")}
 						</div>
 					</CardContent>
 				</Card>
 				<Card className="gap-1 py-3">
-					<CardHeader className="px-4 pb-0 pt-0">
+					<CardHeader className="px-4 pt-0 pb-0">
 						<CardTitle className="font-medium text-xs">Efectividad</CardTitle>
 					</CardHeader>
 					<CardContent className="px-4 pb-0">

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -680,6 +680,10 @@ function AsesorRow({
 	const [isOpen, setIsOpen] = useState(false);
 	const [limit, setLimit] = useState(10);
 
+	// El grupo "Sin asesor" (asesor_id null) no se puede expandir: el endpoint de
+	// detalle exige un asesorId, así que la fila queda como total no desglosable.
+	const expandable = asesor.asesor_id != null;
+
 	const detalle = useQuery({
 		...orpc.getCobranzaDiariaDetalle.queryOptions({
 			input: {
@@ -700,12 +704,13 @@ function AsesorRow({
 		<Collapsible
 			open={isOpen}
 			onOpenChange={setIsOpen}
+			disabled={!expandable}
 			className="rounded-lg border border-border"
 		>
 			<CollapsibleTrigger asChild>
 				<button
 					type="button"
-					className="group flex w-full cursor-pointer items-center gap-3 p-3 text-left hover:bg-muted/50"
+					className="group flex w-full items-center gap-3 p-3 text-left hover:bg-muted/50 enabled:cursor-pointer disabled:cursor-default disabled:hover:bg-transparent data-[state=open]:cursor-pointer"
 				>
 					<span className="min-w-40 font-medium">{asesor.asesor_nombre}</span>
 					<span className="text-muted-foreground text-xs">
@@ -717,9 +722,11 @@ function AsesorRow({
 					<Badge variant="outline">
 						{(asesor.efectividad * 100).toFixed(1)}%
 					</Badge>
-					<ChevronDown
-						className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
-					/>
+					{expandable && (
+						<ChevronDown
+							className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+						/>
+					)}
 				</button>
 			</CollapsibleTrigger>
 			<CollapsibleContent>
@@ -869,7 +876,11 @@ function TabCobradoVsEsperado({
 		enabled: !!session && canSeeAll,
 	});
 
-	const filtro = { anio, mes, dia };
+	// Días válidos del mes seleccionado (evita Feb 31 → make_date inválido → 500).
+	const diasEnMes = new Date(anio, mes, 0).getDate();
+	const diaValido = Math.min(dia, diasEnMes);
+
+	const filtro = { anio, mes, dia: diaValido };
 
 	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
 		...orpc.getCobranzaDiaria.queryOptions({
@@ -899,7 +910,7 @@ function TabCobradoVsEsperado({
 
 	const anios = [anioHoy, anioHoy - 1, anioHoy - 2];
 	const meses = Array.from({ length: 12 }, (_, i) => i + 1);
-	const dias = Array.from({ length: 31 }, (_, i) => i + 1);
+	const dias = Array.from({ length: diasEnMes }, (_, i) => i + 1);
 
 	return (
 		<div className="space-y-6">
@@ -947,7 +958,10 @@ function TabCobradoVsEsperado({
 
 				<div className="flex flex-col gap-1">
 					<Label className="text-xs">Día</Label>
-					<Select value={String(dia)} onValueChange={(v) => setDia(Number(v))}>
+					<Select
+						value={String(diaValido)}
+						onValueChange={(v) => setDia(Number(v))}
+					>
 						<SelectTrigger className="w-20">
 							<SelectValue />
 						</SelectTrigger>

--- a/apps/crm/apps/web/src/routes/cobros/reportes.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reportes.tsx
@@ -4,6 +4,8 @@ import type { ColumnDef } from "@tanstack/react-table";
 import {
 	BarChart3,
 	CalendarClock,
+	ChevronDown,
+	Loader2,
 	RefreshCw,
 	TrendingDown,
 } from "lucide-react";
@@ -13,6 +15,11 @@ import { DataTable } from "@/components/data-table";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Collapsible,
+	CollapsibleContent,
+	CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
@@ -1134,6 +1141,478 @@ function TabCuotasPorFecha({
 	);
 }
 
+// ─── Cobrado vs Esperado (Cobranza Diaria) ──────────────────────────────────
+
+type RubroMontos = {
+	capital: string;
+	interes: string;
+	iva: string;
+	seguro: string;
+	gps: string;
+	membresia: string;
+};
+
+type CobranzaAsesorRow = {
+	asesor_id: number | null;
+	asesor_nombre: string;
+	cuotas: number;
+	cobrado: RubroMontos;
+	restante: RubroMontos;
+	cube: { esperado: string; cobrado: string };
+	mora_cobrada: string;
+	total_cobrado: string;
+	total_esperado: string;
+	programado: string;
+	efectividad: number;
+};
+
+type CobranzaCreditoRow = {
+	credito_id: number;
+	numero_credito_sifco: string;
+	cliente_nombre: string;
+	asesor_id: number | null;
+	asesor_nombre: string | null;
+	cobrado: RubroMontos;
+	restante: RubroMontos;
+	cube: { esperado: string; cobrado: string };
+	mora_cobrada: string;
+	total_cobrado: string;
+	total_esperado: string;
+};
+
+const DETALLE_COBRANZA_COLS = [
+	"Crédito / Cliente",
+	"Capital",
+	"Interés",
+	"Int. CUBE",
+	"IVA",
+	"Seguro",
+	"GPS",
+	"Membresía",
+	"Mora",
+	"Total",
+];
+
+function AsesorRow({
+	asesor,
+	filtro,
+}: {
+	asesor: CobranzaAsesorRow;
+	filtro: { anio: number; mes: number; dia: number };
+}) {
+	const [isOpen, setIsOpen] = useState(false);
+	const [limit, setLimit] = useState(10);
+
+	const detalle = useQuery({
+		...orpc.getCobranzaDiariaDetalle.queryOptions({
+			input: {
+				...filtro,
+				asesorId: asesor.asesor_id as number,
+				limit,
+				offset: 0,
+			},
+		}),
+		enabled: isOpen && asesor.asesor_id != null,
+	});
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const detalleData = detalle.data as any;
+	const creditos: CobranzaCreditoRow[] = detalleData?.creditos ?? [];
+
+	return (
+		<Collapsible
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			className="rounded-lg border border-border"
+		>
+			<CollapsibleTrigger asChild>
+				<button
+					type="button"
+					className="group flex w-full cursor-pointer items-center gap-3 p-3 text-left hover:bg-muted/50"
+				>
+					<span className="min-w-40 font-medium">{asesor.asesor_nombre}</span>
+					<span className="text-muted-foreground text-xs">
+						{asesor.cuotas} cuotas
+					</span>
+					<span className="ml-auto text-right text-sm">
+						{fmtQ(asesor.total_cobrado)} / {fmtQ(asesor.total_esperado)}
+					</span>
+					<Badge variant="outline">
+						{(asesor.efectividad * 100).toFixed(1)}%
+					</Badge>
+					<ChevronDown
+						className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+					/>
+				</button>
+			</CollapsibleTrigger>
+			<CollapsibleContent>
+				<div className="overflow-x-auto border-t bg-card">
+					{detalle.isLoading ? (
+						<div className="flex items-center gap-2 p-3 text-muted-foreground text-sm">
+							<Loader2 className="h-4 w-4 animate-spin" /> Cargando detalle…
+						</div>
+					) : (
+						<>
+							<table className="w-full text-sm">
+								<thead className="bg-muted/50">
+									<tr>
+										{DETALLE_COBRANZA_COLS.map((h) => (
+											<th
+												key={h}
+												className="px-3 py-2 text-left font-medium text-muted-foreground text-xs"
+											>
+												{h}
+											</th>
+										))}
+									</tr>
+								</thead>
+								<tbody>
+									{creditos.map((c) => (
+										<tr
+											key={c.credito_id}
+											className="border-t hover:bg-muted/30"
+										>
+											<td className="px-3 py-1.5">
+												<div className="font-mono text-blue-600 text-xs">
+													{c.numero_credito_sifco}
+												</div>
+												<div className="text-muted-foreground text-xs">
+													{c.cliente_nombre}
+												</div>
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.restante.capital}
+													pagado={c.cobrado.capital}
+												/>
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.restante.interes}
+													pagado={c.cobrado.interes}
+												/>
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.cube.esperado}
+													pagado={c.cube.cobrado}
+												/>
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.restante.iva}
+													pagado={c.cobrado.iva}
+												/>
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.restante.seguro}
+													pagado={c.cobrado.seguro}
+												/>
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.restante.gps}
+													pagado={c.cobrado.gps}
+												/>
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.restante.membresia}
+													pagado={c.cobrado.membresia}
+												/>
+											</td>
+											<td className="px-3 text-right text-green-600 text-xs">
+												{Number(c.mora_cobrada) > 0 ? fmtQ(c.mora_cobrada) : "—"}
+											</td>
+											<td className="px-3">
+												<RubroCelda
+													esperado={c.total_esperado}
+													pagado={c.total_cobrado}
+												/>
+											</td>
+										</tr>
+									))}
+								</tbody>
+							</table>
+							{detalleData?.hasMore && (
+								<div className="border-t px-3 py-2 text-center">
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => setLimit((l) => l + 10)}
+									>
+										Mostrar más (
+										{detalleData.total - (creditos.length ?? 0)} restantes)
+									</Button>
+								</div>
+							)}
+						</>
+					)}
+				</div>
+			</CollapsibleContent>
+		</Collapsible>
+	);
+}
+
+function TabCobradoVsEsperado({
+	session,
+	canSeeAll,
+}: {
+	session: ReturnType<typeof authClient.useSession>["data"];
+	canSeeAll: boolean;
+}) {
+	const [anioHoy, mesHoy, diaHoy] = todayGT()
+		.split("-")
+		.map(Number) as [number, number, number];
+
+	const [anio, setAnio] = usePersistedState<number>(
+		"cobros/reportes/cobranza/anio",
+		anioHoy,
+	);
+	const [mes, setMes] = usePersistedState<number>(
+		"cobros/reportes/cobranza/mes",
+		mesHoy,
+	);
+	const [dia, setDia] = usePersistedState<number>(
+		"cobros/reportes/cobranza/dia",
+		diaHoy,
+	);
+	const [asesorId, setAsesorId] = usePersistedState<string>(
+		"cobros/reportes/cobranza/asesorId",
+		"",
+	);
+
+	const { data: asesoresData } = useQuery({
+		...orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
+		enabled: !!session && canSeeAll,
+	});
+
+	const filtro = { anio, mes, dia };
+
+	const { data, isLoading, dataUpdatedAt, refetch, isFetching } = useQuery({
+		...orpc.getCobranzaDiaria.queryOptions({
+			input: {
+				...filtro,
+				asesorId: canSeeAll
+					? asesorId
+						? Number(asesorId)
+						: undefined
+					: undefined,
+			},
+		}),
+		enabled: !!session,
+	});
+
+	const ultimaAct = dataUpdatedAt
+		? new Date(dataUpdatedAt).toLocaleTimeString("es-GT", {
+				hour: "2-digit",
+				minute: "2-digit",
+			})
+		: null;
+
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const resultado = data as any;
+	const asesores: CobranzaAsesorRow[] = resultado?.asesores ?? [];
+	const totalGeneral: CobranzaAsesorRow | undefined = resultado?.totalGeneral;
+
+	const anios = [anioHoy, anioHoy - 1, anioHoy - 2];
+	const meses = Array.from({ length: 12 }, (_, i) => i + 1);
+	const dias = Array.from({ length: 31 }, (_, i) => i + 1);
+
+	return (
+		<div className="space-y-6">
+			<div className="flex items-center gap-2">
+				<CalendarClock className="h-5 w-5 text-blue-600" />
+				<h2 className="font-semibold text-xl">Cobrado vs Esperado</h2>
+			</div>
+
+			{/* Filtros */}
+			<div className="flex flex-wrap items-end gap-3 rounded-lg border bg-muted/30 p-3">
+				<div className="flex flex-col gap-1">
+					<Label className="text-xs">Año</Label>
+					<Select
+						value={String(anio)}
+						onValueChange={(v) => setAnio(Number(v))}
+					>
+						<SelectTrigger className="w-24">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{anios.map((a) => (
+								<SelectItem key={a} value={String(a)}>
+									{a}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="flex flex-col gap-1">
+					<Label className="text-xs">Mes</Label>
+					<Select value={String(mes)} onValueChange={(v) => setMes(Number(v))}>
+						<SelectTrigger className="w-20">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{meses.map((m) => (
+								<SelectItem key={m} value={String(m)}>
+									{m}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				<div className="flex flex-col gap-1">
+					<Label className="text-xs">Día</Label>
+					<Select value={String(dia)} onValueChange={(v) => setDia(Number(v))}>
+						<SelectTrigger className="w-20">
+							<SelectValue />
+						</SelectTrigger>
+						<SelectContent>
+							{dias.map((d) => (
+								<SelectItem key={d} value={String(d)}>
+									{d}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				</div>
+
+				{canSeeAll && (
+					<div className="flex flex-col gap-1">
+						<Label className="text-xs">Asesor</Label>
+						<Select
+							value={asesorId}
+							onValueChange={(v) => setAsesorId(v === "todos" ? "" : v)}
+						>
+							<SelectTrigger className="w-48">
+								<SelectValue placeholder="Todos los asesores" />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="todos">Todos</SelectItem>
+								{/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+								{(asesoresData as any)?.asesores?.map((a: any) => (
+									<SelectItem key={a.asesorId} value={String(a.asesorId)}>
+										{a.nombre}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				)}
+
+				<div className="ml-auto flex items-center gap-2">
+					{ultimaAct && (
+						<span className="text-muted-foreground text-xs">
+							Actualizado: {ultimaAct}
+						</span>
+					)}
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => refetch()}
+						disabled={isFetching}
+					>
+						<RefreshCw
+							className={`mr-2 h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+						/>
+						Actualizar
+					</Button>
+				</div>
+			</div>
+
+			{/* Summary cards */}
+			<div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+				<Card className="gap-1 border-blue-200 bg-blue-50 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-blue-700 text-xs">
+							A Cobrar
+						</CardTitle>
+					</CardHeader>
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-blue-800 text-lg">
+							{fmtQ(totalGeneral?.programado ?? "0")}
+						</div>
+					</CardContent>
+				</Card>
+				<Card className="gap-1 border-green-200 bg-green-50 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-green-700 text-xs">
+							Cobrado
+						</CardTitle>
+					</CardHeader>
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-green-700 text-lg">
+							{fmtQ(totalGeneral?.total_cobrado ?? "0")}
+						</div>
+					</CardContent>
+				</Card>
+				<Card className="gap-1 border-red-200 bg-red-50 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-red-700 text-xs">
+							Restante
+						</CardTitle>
+					</CardHeader>
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-red-700 text-lg">
+							{fmtQ(totalGeneral?.total_esperado ?? "0")}
+						</div>
+					</CardContent>
+				</Card>
+				<Card className="gap-1 py-3">
+					<CardHeader className="px-4 pb-0 pt-0">
+						<CardTitle className="font-medium text-xs">Efectividad</CardTitle>
+					</CardHeader>
+					<CardContent className="px-4 pb-0">
+						<div className="font-bold text-lg">
+							{((totalGeneral?.efectividad ?? 0) * 100).toFixed(1)}%
+						</div>
+						<p className="text-muted-foreground text-xs">
+							{totalGeneral?.cuotas ?? 0} cuotas
+						</p>
+					</CardContent>
+				</Card>
+			</div>
+
+			{/* Por asesor */}
+			{isLoading ? (
+				<div className="h-32 animate-pulse rounded bg-muted" />
+			) : asesores.length === 0 ? (
+				<p className="text-muted-foreground text-sm">
+					No hay datos disponibles para la fecha seleccionada.
+				</p>
+			) : (
+				<div className="space-y-2">
+					{asesores.map((a) => (
+						<AsesorRow
+							key={a.asesor_id ?? "sin-asesor"}
+							asesor={a}
+							filtro={filtro}
+						/>
+					))}
+					{totalGeneral && (
+						<div className="flex items-center gap-3 rounded-lg border border-border bg-muted/50 p-3 font-semibold">
+							<span className="min-w-40">TOTAL</span>
+							<span className="text-muted-foreground text-xs">
+								{totalGeneral.cuotas} cuotas
+							</span>
+							<span className="ml-auto text-right text-sm">
+								{fmtQ(totalGeneral.total_cobrado)} /{" "}
+								{fmtQ(totalGeneral.total_esperado)}
+							</span>
+							<Badge variant="outline">
+								{(totalGeneral.efectividad * 100).toFixed(1)}%
+							</Badge>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
 // ─── Descuentos ─────────────────────────────────────────────────────────────
 
 type DescuentoRow = {
@@ -1397,7 +1876,7 @@ function RouteComponent() {
 					</TabsTrigger>
 					<TabsTrigger value="pagos">
 						<CalendarClock className="mr-2 h-4 w-4" />
-						Pagos Esperados
+						Cobrado vs Esperado
 					</TabsTrigger>
 					<TabsTrigger value="descuentos">
 						<BarChart3 className="mr-2 h-4 w-4" />
@@ -1409,7 +1888,7 @@ function RouteComponent() {
 					<TabMora session={session} canSeeAll={canSeeAll} />
 				</TabsContent>
 				<TabsContent value="pagos" className="mt-6">
-					<TabCuotasPorFecha session={session} canSeeAll={canSeeAll} />
+					<TabCobradoVsEsperado session={session} canSeeAll={canSeeAll} />
 				</TabsContent>
 				<TabsContent value="descuentos" className="mt-6">
 					<TabDescuentos session={session} />


### PR DESCRIPTION
# 🚀 Pase a Producción — Release `develop` → `main`

Release con un reporte nuevo de cartera y dos correcciones en el CRM, una de ellas sobre montos de pago a inversionistas.

---

## 📊 Reportes — Cartera Activa

- Se agrega un **nuevo reporte Excel de cartera activa**, con su endpoint dedicado en `cartera-back` y cobertura de tests.
- Se expone desde el **dashboard de carteraFront** con su propia pantalla y servicio.
- Para enriquecer el reporte, el CRM expone un **endpoint batch** que devuelve placa y chasis a partir de una lista de números SIFCO, consumido desde cartera.

## 💸 Pagos a Inversionistas — CRM

- El **"Total pendiente de liquidar"**, el **monto de la boleta** y el monto mostrado en el diálogo ahora usan la **cuota real a transferir**, quedando alineados con los archivos de **transferencia ACH / Terceros**.
- Antes usaban un campo que arrastraba el **IVA de los créditos en interés compuesto** (IVA que nunca se transfiere), lo que **inflaba el total** y hacía que la boleta se emitiera por un monto distinto al que efectivamente se paga.
- Con esto, el card, la fila, la boleta y los archivos de transferencia muestran y pagan **el mismo monto**.

## 🚗 Vehículos — CRM

- La **consulta batch de vehículos por número SIFCO** ahora exige que la oportunidad tenga vehículo asociado y considera únicamente oportunidades en estado **ganada** o **migrada**.
- Evita cruces incorrectos que traían registros que no correspondían a los reportes de cartera.

---

## 📦 Resumen

| Área | Archivos |
|---|---|
| `apps/cartera-back` | 4 |
| `apps/carteraFront` | 4 |
| `apps/crm` | 3 |
| **Total** | **11 archivos · +459 / −13** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
