### PR TITLE
fix(cobros): topar capital al saldo de la cuota + restante 0 en pagadas (follow-up #1076, Codex)

### DIFF
--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.test.ts
@@ -13,7 +13,7 @@ describe("getCobranzaDiaria", () => {
 		const exec = makeExec([
 			{ rows: [ // query A: 1 crédito, asesor 10
 				{ credito_id: 1, numero_credito_sifco: "X1", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
-				  cap_rest: "100", int_rest: "683.82", iva_rest: "82.06", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				  cap_rest_raw: "50000", cuota: "865.88", int_rest: "683.82", iva_rest: "82.06", seg_rest: "0", gps_rest: "0", mem_rest: "0",
 				  cap_cob: "0", int_cob: "0", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" },
 			] },
 			{ rows: [ // query B: Brenda 70/30 + CUBE
@@ -34,13 +34,50 @@ describe("getCobranzaDiaria", () => {
 	});
 });
 
+// Cuota no pagada (cuota Q1000 = Q900 capital + Q100 interés), cap_rest_raw trae el principal
+// remanente del préstamo (Q18268), no el capital de la cuota. El tope debe restar lo cobrado
+// para que un abono parcial no devuelva ese monto al capital (Codex P2 en #1079).
+describe("construirFilasCredito: tope de capital con abonos parciales", () => {
+	it("abono en interés no infla capital ni programado", async () => {
+		const exec = makeExec([
+			{ rows: [ { credito_id: 1, numero_credito_sifco: "P1", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
+				cap_rest_raw: "18268", cuota: "1000", int_rest: "0", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				cap_cob: "0", int_cob: "100", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" } ] },
+			{ rows: [] }, // sin inversionistas → CUBE 0
+		]);
+		const { asesores } = await getCobranzaDiaria({ anio: 2026, mes: 7, dia: 8, executor: exec as any });
+		// capital de la cuota = (1000 − 100 cobrado) − 0 restantes = 900 (NO 1000)
+		expect(asesores[0].restante.capital).toBe("900.00");
+		expect(asesores[0].total_esperado).toBe("900.00");
+		expect(asesores[0].total_cobrado).toBe("100.00");
+		// programado = cobrado + esperado se mantiene en la cuota (1000), no se infla a 1100
+		expect(asesores[0].programado).toBe("1000.00");
+		expect(asesores[0].efectividad).toBe(0.1);
+	});
+
+	it("abono parcial en capital descuenta lo ya cobrado del restante", async () => {
+		const exec = makeExec([
+			{ rows: [ { credito_id: 1, numero_credito_sifco: "P2", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
+				cap_rest_raw: "18268", cuota: "1000", int_rest: "100", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				cap_cob: "50", int_cob: "0", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" } ] },
+			{ rows: [] },
+		]);
+		const { asesores } = await getCobranzaDiaria({ anio: 2026, mes: 7, dia: 8, executor: exec as any });
+		// capital de la cuota = (1000 − 50 cobrado) − 100 int_rest = 850 (900 − 50 ya cobrado)
+		expect(asesores[0].restante.capital).toBe("850.00");
+		expect(asesores[0].total_esperado).toBe("950.00");
+		expect(asesores[0].total_cobrado).toBe("50.00");
+		expect(asesores[0].programado).toBe("1000.00");
+	});
+});
+
 const { getCobranzaDiariaDetalle } = await import("./cobranzaDiariaReporte");
 
 describe("getCobranzaDiariaDetalle", () => {
 	it("pagina y reporta hasMore usando el count", async () => {
 		const exec = makeExec([
 			{ rows: [ { credito_id: 1, numero_credito_sifco: "X1", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
-				cap_rest: "100", int_rest: "0", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				cap_rest_raw: "50000", cuota: "100", int_rest: "0", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
 				cap_cob: "0", int_cob: "0", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" } ] }, // qA
 			{ rows: [] }, // qB inversionistas
 			{ rows: [{ total: "23" }] }, // count
@@ -54,7 +91,7 @@ describe("getCobranzaDiariaDetalle", () => {
 	it("hasMore es false cuando offset + creditos.length >= total (última página)", async () => {
 		const exec = makeExec([
 			{ rows: [ { credito_id: 1, numero_credito_sifco: "X1", cliente_nombre: "Cli", asesor_id: 10, asesor_nombre: "Sam",
-				cap_rest: "100", int_rest: "0", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
+				cap_rest_raw: "50000", cuota: "100", int_rest: "0", iva_rest: "0", seg_rest: "0", gps_rest: "0", mem_rest: "0",
 				cap_cob: "0", int_cob: "0", iva_cob: "0", seg_cob: "0", gps_cob: "0", mem_cob: "0", mora_cob: "0" } ] }, // qA
 			{ rows: [] }, // qB inversionistas
 			{ rows: [{ total: "1" }] }, // count

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
@@ -19,12 +19,20 @@ export async function construirFilasCredito(
 	const qA = await exec.execute(sql`
 		SELECT cr.credito_id, cr.numero_credito_sifco, u.nombre AS cliente_nombre,
 			cr.asesor_id, a.nombre AS asesor_nombre,
-			COALESCE(prog.capital_restante,0) AS cap_rest, COALESCE(prog.interes_restante,0) AS int_rest,
-			COALESCE(prog.iva_12_restante,0) AS iva_rest, COALESCE(prog.seguro_restante,0) AS seg_rest,
-			COALESCE(prog.gps_restante,0) AS gps_rest,
-			-- Migrados SIFCO no ponen membresias=0 al pagar (a diferencia de los otros
-			-- *_restante), dejando una membresía fantasma en cuotas ya pagadas. Se fuerza a 0
-			-- cuando la cuota está pagada, para quedar consistente con los demás rubros.
+			-- Restantes por rubro. Una cuota PAGADA no debe nada → se fuerza a 0 (los migrados
+			-- SIFCO no siempre ponen capital_restante/membresias en 0 al pagar, dejando un
+			-- restante fantasma). En NO pagadas, el capital se topa al saldo de la cuota
+			-- (cuota − otros rubros): en filas schedule/no_required, capital_restante trae el
+			-- principal remanente del préstamo, no el capital de esta cuota (igual que getAcumuladoPorCredito).
+			CASE WHEN c.pagado THEN 0 ELSE LEAST(
+				COALESCE(prog.capital_restante,0),
+				GREATEST(cr.cuota::numeric - COALESCE(prog.interes_restante,0) - COALESCE(prog.iva_12_restante,0)
+					- COALESCE(prog.seguro_restante,0) - COALESCE(prog.gps_restante,0) - COALESCE(prog.membresias,0), 0)
+			) END AS cap_rest,
+			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.interes_restante,0) END AS int_rest,
+			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.iva_12_restante,0) END AS iva_rest,
+			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.seguro_restante,0) END AS seg_rest,
+			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.gps_restante,0) END AS gps_rest,
 			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.membresias,0) END AS mem_rest,
 			COALESCE(pag.abono_capital,0) AS cap_cob, COALESCE(pag.abono_interes,0) AS int_cob,
 			COALESCE(pag.abono_iva,0) AS iva_cob, COALESCE(pag.abono_seguro,0) AS seg_cob,

--- a/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
+++ b/apps/cartera-back/src/controllers/cobranzaDiariaReporte.ts
@@ -21,14 +21,12 @@ export async function construirFilasCredito(
 			cr.asesor_id, a.nombre AS asesor_nombre,
 			-- Restantes por rubro. Una cuota PAGADA no debe nada → se fuerza a 0 (los migrados
 			-- SIFCO no siempre ponen capital_restante/membresias en 0 al pagar, dejando un
-			-- restante fantasma). En NO pagadas, el capital se topa al saldo de la cuota
-			-- (cuota − otros rubros): en filas schedule/no_required, capital_restante trae el
-			-- principal remanente del préstamo, no el capital de esta cuota (igual que getAcumuladoPorCredito).
-			CASE WHEN c.pagado THEN 0 ELSE LEAST(
-				COALESCE(prog.capital_restante,0),
-				GREATEST(cr.cuota::numeric - COALESCE(prog.interes_restante,0) - COALESCE(prog.iva_12_restante,0)
-					- COALESCE(prog.seguro_restante,0) - COALESCE(prog.gps_restante,0) - COALESCE(prog.membresias,0), 0)
-			) END AS cap_rest,
+			-- restante fantasma). En filas schedule/no_required, capital_restante trae el principal
+			-- remanente del préstamo, no el capital de esta cuota, así que se topa al saldo real de
+			-- la cuota en JS (ver construirFilasCredito), restando lo cobrado para no inflar el
+			-- capital cuando hay abonos parciales en otros rubros.
+			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.capital_restante,0) END AS cap_rest_raw,
+			cr.cuota::numeric AS cuota,
 			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.interes_restante,0) END AS int_rest,
 			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.iva_12_restante,0) END AS iva_rest,
 			CASE WHEN c.pagado THEN 0 ELSE COALESCE(prog.seguro_restante,0) END AS seg_rest,
@@ -92,8 +90,22 @@ export async function construirFilasCredito(
 		const invs = invPorCredito.get(Number(f.credito_id)) ?? [];
 		const cubeEsp = interesCubeResidual(new Big(f.int_rest ?? 0), invs);
 		const cubeCob = interesCubeResidual(new Big(f.int_cob ?? 0), invs);
-		const restante = { capital: f.cap_rest, interes: f.int_rest, iva: f.iva_rest, seguro: f.seg_rest, gps: f.gps_rest, membresia: f.mem_rest };
 		const cobrado = { capital: f.cap_cob, interes: f.int_cob, iva: f.iva_cob, seguro: f.seg_cob, gps: f.gps_cob, membresia: f.mem_cob };
+		// Capital de ESTA cuota topado: cap_rest_raw trae el principal remanente del préstamo
+		// (filas schedule/no_required), no el capital de la cuota. El tope = saldo real de la
+		// cuota (cuota − todo lo cobrado) − lo que aún falta de los otros rubros. Restar lo
+		// cobrado evita que un abono parcial en otro rubro devuelva ese monto ya cobrado al
+		// capital e infle programado/esperado (Codex P2). Cuota pagada: cap_rest_raw ya es 0.
+		const otrosRest = new Big(f.int_rest ?? 0).plus(f.iva_rest ?? 0).plus(f.seg_rest ?? 0)
+			.plus(f.gps_rest ?? 0).plus(f.mem_rest ?? 0);
+		const cuotaRest = new Big(f.cuota ?? 0)
+			.minus(f.cap_cob ?? 0).minus(f.int_cob ?? 0).minus(f.iva_cob ?? 0)
+			.minus(f.seg_cob ?? 0).minus(f.gps_cob ?? 0).minus(f.mem_cob ?? 0);
+		let capTope = cuotaRest.minus(otrosRest);
+		if (capTope.lt(0)) capTope = new Big(0);
+		const capRestRaw = new Big(f.cap_rest_raw ?? 0);
+		const capRest = capRestRaw.lt(capTope) ? capRestRaw : capTope; // LEAST(crudo, tope)
+		const restante = { capital: capRest.toString(), interes: f.int_rest, iva: f.iva_rest, seguro: f.seg_rest, gps: f.gps_rest, membresia: f.mem_rest };
 		const sum = (o: Record<string, string>) =>
 			Object.values(o).reduce((a, v) => a.plus(v ?? 0), new Big(0));
 		return {


### PR DESCRIPTION
## Follow-up de #1076 — topar capital al saldo de la cuota

El módulo "Cobrado vs Esperado" (#1076) ya se mergeó a develop, pero un comentario P2 de Codex llegó **después del merge** y este PR lo atiende.

### Problema (Codex, verificado contra prod)
En filas `schedule`/`no_required`, `pagos_credito.capital_restante` trae el **principal remanente del préstamo**, no el capital de esa cuota. Reportarlo crudo inflaba `total_esperado`/`programado` y bajaba la efectividad.

Ejemplo prod (jul): crédito `…117420` (cuota **pagada**) → `capital_restante = Q18,268` vs cuota de solo Q1,894. **Capital esperado del mes: Q2,177,862 → Q2,087,011 (−Q85k de fantasma).**

### Fix
En `construirFilasCredito`:
- Capital topado con `LEAST(capital_restante, GREATEST(cuota − int − iva − seg − gps − mem, 0))` — mismo patrón que `getAcumuladoPorCredito`.
- **Todos** los rubros restantes se fuerzan a `0` cuando `c.pagado` (una cuota pagada no debe nada; los migrados SIFCO no siempre ponen capital/membresías en 0 al pagar).

### Validación
- 13/13 tests, tsc limpio.
- QA read-only prod: capital jul 2,177,862 → 2,087,011; cobrado por rubro sigue reconciliando al centavo (no se toca el lado cobrado).

Contexto: hilo de Codex en #1076 (comment sobre `cobranzaDiariaReporte.ts`). También cerró en #1076 el fix de membresía fantasma (mismo patrón, ya mergeado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
