### PR TITLE
fix(crm): acotar y chunkear /info/vehicles-by-sifco (Codex P2)

### DIFF
--- a/apps/crm/apps/server/src/controllers/vehicles.ts
+++ b/apps/crm/apps/server/src/controllers/vehicles.ts
@@ -79,21 +79,31 @@ export const getVehiclesBySifcoController = async (numeroSifcos: string[]) => {
 	}
 
 	try {
-		const rows = await db
-			.select({
-				numeroSifco: opportunities.numeroSifco,
-				licensePlate: vehicles.licensePlate,
-				vinNumber: vehicles.vinNumber,
-			})
-			.from(opportunities)
-			.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
-			.where(
-				and(
-					inArray(opportunities.numeroSifco, uniqueSifcos),
-					inArray(opportunities.status, ["won", "migrate"]),
-				),
-			)
-			.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt));
+		const CHUNK_SIZE = 1000;
+		const rows: {
+			numeroSifco: string | null;
+			licensePlate: string | null;
+			vinNumber: string | null;
+		}[] = [];
+		for (let i = 0; i < uniqueSifcos.length; i += CHUNK_SIZE) {
+			const chunk = uniqueSifcos.slice(i, i + CHUNK_SIZE);
+			const part = await db
+				.select({
+					numeroSifco: opportunities.numeroSifco,
+					licensePlate: vehicles.licensePlate,
+					vinNumber: vehicles.vinNumber,
+				})
+				.from(opportunities)
+				.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
+				.where(
+					and(
+						inArray(opportunities.numeroSifco, chunk),
+						inArray(opportunities.status, ["won", "migrate"]),
+					),
+				)
+				.orderBy(desc(opportunities.updatedAt), desc(opportunities.createdAt));
+			rows.push(...part);
+		}
 
 		const seen = new Set<string>();
 		const matchedVehicles: VehicleBySifco[] = [];

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1103,6 +1103,18 @@ app.post("/info/vehicles-by-sifco", async (c) => {
 		const numeroSifcos = body.numero_sifcos
 			.map((value) => String(value ?? "").trim())
 			.filter(Boolean);
+
+		const MAX_SIFCOS = 50000;
+		if (numeroSifcos.length > MAX_SIFCOS) {
+			return c.json(
+				{
+					success: false,
+					message: `numero_sifcos excede el máximo permitido (${MAX_SIFCOS})`,
+				},
+				400,
+			);
+		}
+
 		const result = await getVehiclesBySifcoController(numeroSifcos);
 		return c.json(result, result.success ? 200 : 500);
 	} catch (err: any) {

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1100,12 +1100,10 @@ app.post("/info/vehicles-by-sifco", async (c) => {
 			);
 		}
 
-		const numeroSifcos = body.numero_sifcos
-			.map((value) => String(value ?? "").trim())
-			.filter(Boolean);
-
+		// Tope de abuso sobre el array CRUDO, antes de normalizar, para no recorrer
+		// un payload gigante (aunque normalice a vacío) en una ruta pública.
 		const MAX_SIFCOS = 50000;
-		if (numeroSifcos.length > MAX_SIFCOS) {
+		if (body.numero_sifcos.length > MAX_SIFCOS) {
 			return c.json(
 				{
 					success: false,
@@ -1114,6 +1112,10 @@ app.post("/info/vehicles-by-sifco", async (c) => {
 				400,
 			);
 		}
+
+		const numeroSifcos = body.numero_sifcos
+			.map((value) => String(value ?? "").trim())
+			.filter(Boolean);
 
 		const result = await getVehiclesBySifcoController(numeroSifcos);
 		return c.json(result, result.success ? 200 : 500);


### PR DESCRIPTION
## Qué arregla

Atiende el hallazgo **P2 de Codex** en `POST /info/vehicles-by-sifco` (CRM server): el endpoint aceptaba el array `numero_sifcos` **sin límite** y lo pasaba a una sola query `IN (...)`, con dos riesgos:
- Pegar contra el **límite de parámetros de Postgres** (~65,535) con un array grande.
- Escaneo lento / DoS con un payload malicioso.

## Cambios

1. **Tope de abuso en la ruta** (`index.ts`): rechaza con 400 si `numero_sifcos.length > 50000`. Es un techo muy por encima de cualquier portafolio real, y por debajo del límite de parámetros de Postgres.
2. **Chunkeo de la query** (`vehicles.ts::getVehiclesBySifcoController`): la query `IN(...)` se ejecuta en lotes de 1000 y se acumulan los resultados. Preserva la deduplicación existente (cada SIFCO vive en un solo chunk, así que el dedup por SIFCO sigue tomando la oportunidad más reciente).

## Por qué NO se agrega auth aquí

Codex también mencionó la falta de auth. **A propósito no se agrega** en este PR:
- `/info/*` es un grupo **público por diseño** (onboarding, OTP, leads, etc.).
- El **único caller** es `cartera-back` (`crm.service.ts` → reporte `/reportes/cartera-activa/excel`, ya protegido con rol `ADMIN|CONTA`) y **NO manda headers de auth**. Meter un check de sesión/token rompería producción.

## Follow-up (fuera de alcance, requiere coordinación entre servicios)

La exposición de placa/VIN sin auth sigue siendo una decisión de diseño de `/info/*`. Endurecerla (service token compartido + actualizar el caller, o restringir `/info/*` por red/origen a cartera-back) es un cambio coordinado entre CRM y cartera-back que se puede hacer aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
