### PR TITLE
fix(crm): quitar cache del GET resumen-global-liquidaciones (pagar inversionistas)

### DIFF
--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1177,10 +1177,13 @@ export class CarteraBackClient {
 			queryParams.set("anio", String(filters.anio));
 		}
 
+		// Sin cache: el estado de liquidación debe verse fresco siempre. Con cache
+		// en memoria + varias instancias, el invalidate del POST liquidar no llega
+		// a las demás instancias y la UI muestra "pendiente" hasta 5 min después.
 		const response = await this.request<ResumenGlobalInversionista[]>(
 			`/resumen-global-liquidaciones?${queryParams.toString()}`,
 			{ method: "GET" },
-			true,
+			false,
 		);
 		return response;
 	}


### PR DESCRIPTION
## Problema

En **Pagar inversionistas**, después de liquidar exitosamente a un inversionista, la UI seguía mostrándolo como *pendiente*. Contabilidad volvía a presionar el botón y se generaba una cadena de 422 (`No se pudo liquidar al inversionista 30, updatedCount: 0`) — hoy se registraron ~10 reintentos en ~3 minutos tras una liquidación que sí fue exitosa (`updatedCount: 12` a las 10:58:12).

## Causa

El GET `/resumen-global-liquidaciones` (vía `carteraBackClient.getResumenGlobalInversionistas`) se servía desde el cache en memoria del server del CRM (TTL 5 min). El `cache.invalidate()` que dispara el POST de liquidar solo aplica en la instancia que atendió ese POST; las demás instancias siguen sirviendo la lista vieja hasta que expira el TTL.

## Fix

Ese GET ya no usa cache (`useCache: false`): la lista de liquidaciones siempre se consulta fresca a cartera-back. Es estado demasiado delicado para servirlo cacheado. Los `invalidate()` de los POSTs quedan como estaban.

Un solo archivo, un solo flag: `apps/crm/apps/server/src/services/cartera-back-client.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)