### PR TITLE
feat(cartera): dia_vencimiento opcional en /ajustar-credito

### DIFF
--- a/apps/cartera-back/src/controllers/migratePayments.ts
+++ b/apps/cartera-back/src/controllers/migratePayments.ts
@@ -10,13 +10,15 @@ interface AjustarCuotasConSIFCOParams {
   cuota_esperada: number; // 20  → cuota cuya fecha conocemos
   fecha_cuota: string;    // "2025-12-28" → fecha de esa cuota
   plazo_completo: number; // 60  → plazo total objetivo
+  dia_vencimiento?: number; // 1-31 → si viene, se respeta este día exacto (no aplica la regla día 1 → 30)
 }
- 
+
 export const ajustarCuotasConSIFCO = async ({
   numero_credito_sifco,
   cuota_esperada,
   fecha_cuota,
   plazo_completo,
+  dia_vencimiento,
 }: AjustarCuotasConSIFCOParams): Promise<void> => {
   console.log(`\n🔧 Ajustando crédito ${numero_credito_sifco} - SOLO FECHAS Y PLAZO`);
   console.log(`   📊 Cuota esperada: ${cuota_esperada} (fecha: ${fecha_cuota})`);
@@ -59,7 +61,13 @@ export const ajustarCuotasConSIFCO = async ({
   let diaVencimiento: number;
   const fechaBase = new Date(fechaEsperada);
 
-  if (diaEsperado === 1) {
+  if (dia_vencimiento != null) {
+    // Día explícito (ej. créditos que pagan el 1): se respeta tal cual
+    diaVencimiento = dia_vencimiento;
+    const ultimoDia = new Date(fechaBase.getFullYear(), fechaBase.getMonth() + 1, 0).getDate();
+    fechaBase.setDate(Math.min(diaVencimiento, ultimoDia));
+    console.log(`   📌 Día de vencimiento explícito: ${diaVencimiento}`);
+  } else if (diaEsperado === 1) {
     // Día 1 = SIFCO manda el mes correcto, día 30 del mismo mes
     diaVencimiento = 30;
     const ultimoDia = new Date(fechaBase.getFullYear(), fechaBase.getMonth() + 1, 0).getDate();

--- a/apps/cartera-back/src/routers/payments.ts
+++ b/apps/cartera-back/src/routers/payments.ts
@@ -717,6 +717,7 @@ export const paymentRouter = new Elysia()
         cuota_esperada,
         fecha_cuota,
         plazo_completo,
+        dia_vencimiento,
       } = body;
 
       if (!fecha_cuota || fecha_cuota.trim() === "") {
@@ -733,6 +734,7 @@ export const paymentRouter = new Elysia()
           cuota_esperada,
           fecha_cuota,
           plazo_completo,
+          dia_vencimiento,
         });
 
         return {
@@ -757,12 +759,13 @@ export const paymentRouter = new Elysia()
         plazo_completo: t.Number(),
         plazo_encontrado: t.Number(),
         cuotas_por_crear: t.Number(),
+        dia_vencimiento: t.Optional(t.Number({ minimum: 1, maximum: 31 })),
       }),
       detail: {
         tags: ["SIFCO Pagos"],
         summary: "Ajustar fechas y plazo de un crédito",
         description:
-          "Ajusta fecha_vencimiento de cuotas y crea/borra cuotas según plazo_completo. NO modifica el estado pagado de cuotas existentes ni los abonos.",
+          "Ajusta fecha_vencimiento de cuotas y crea/borra cuotas según plazo_completo. NO modifica el estado pagado de cuotas existentes ni los abonos. Si se envía dia_vencimiento, se respeta ese día exacto; si no, aplica la regla histórica (día 1 → día 30).",
       },
     }
   )  .post("/procesar-desde-archivo", async () => {


### PR DESCRIPTION
## Contexto

Cobros pidió corregir la fecha de vencimiento del crédito `01010214106590` (Luis Alberto Guay Molina): la cuota 32 debía quedar el **1/05/2026**. El método existente para esto (`POST /ajustar-credito` → `ajustarCuotasConSIFCO`) corrigió bien el mes pero dejó todo al día 30, porque tiene una regla que convierte cualquier `fecha_cuota` con día 1 a vencimiento día 30 del mismo mes (pensada para imports de SIFCO donde el día 1 es placeholder).

El Excel de cartera (fuente de verdad, columna `Pago` de las hojas mensuales) confirma que este crédito paga el **día 1**, así que no había forma de generar el calendario correcto con el método tal como estaba.

## Cambio

Se agrega `dia_vencimiento` (1–31, **opcional**) al body de `/ajustar-credito` y a `ajustarCuotasConSIFCO`:

- **Si viene**: se respeta ese día exacto para todo el calendario (permite conservar día 1).
- **Si no viene**: comportamiento idéntico al actual (regla día 1 → 30). Los flujos existentes que usan el método (`/procesar-discrepancias`) no se ven afectados.

## Pruebas

Probado en **dev** (Neon) y luego aplicado en **prod** para el crédito `01010214106590`:

- Regresión sin el parámetro: resultado idéntico al comportamiento previo (día 30) ✓
- Con `dia_vencimiento: 1`: las 60 cuotas quedaron al día 1 calcando la columna `Pago` del Excel, cuota 32 = `2026-05-01` ✓
- `pagos_credito.fecha_vencimiento` 100% sincronizado (0 discrepancias) ✓
- Flags `pagado`, montos y abonos intactos ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)