### PR TITLE
hotfix(legal-docs): timeouts en fetch de Documenso y CRM para evitar cuelgues

### DIFF
--- a/apps/legal-docs-blueprints/services/CrmApiService.ts
+++ b/apps/legal-docs-blueprints/services/CrmApiService.ts
@@ -60,6 +60,8 @@ export class CrmApiService {
           email: this.serviceAccountEmail,
           password: this.serviceAccountPassword,
         }),
+        // Sin timeout, un stall de red deja el request colgado para siempre
+        signal: AbortSignal.timeout(30_000),
       });
 
       if (!response.ok) {
@@ -115,6 +117,7 @@ export class CrmApiService {
           'Cookie': `better-auth.session_token=${this.sessionToken}`,
         },
         body: JSON.stringify(payload),
+        signal: AbortSignal.timeout(30_000),
       });
 
       // 3. Si falla por auth (401/403), re-autenticar e intentar de nuevo
@@ -136,6 +139,7 @@ export class CrmApiService {
             'Cookie': `better-auth.session_token=${this.sessionToken}`,
           },
           body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(30_000),
         });
 
         if (!retryResponse.ok) {

--- a/apps/legal-docs-blueprints/services/DocumensoService.ts
+++ b/apps/legal-docs-blueprints/services/DocumensoService.ts
@@ -341,6 +341,8 @@ export class DocumensoService {
         headers: {
           'Content-Type': 'application/pdf',
         },
+        // Sin timeout, un stall a media subida deja el request colgado para siempre
+        signal: AbortSignal.timeout(60_000),
       });
 
       if (!uploadResponse.ok) {
@@ -403,6 +405,7 @@ export class DocumensoService {
             headers: {
               'Content-Type': 'application/pdf',
             },
+            signal: AbortSignal.timeout(60_000),
           });
 
           if (!uploadResponse.ok) {
@@ -612,6 +615,7 @@ export class DocumensoService {
       const response = await fetch(signingUrl, {
         method: 'HEAD',
         redirect: 'manual',
+        signal: AbortSignal.timeout(30_000),
       });
 
       // Si hay redirect a /complete, el documento está firmado


### PR DESCRIPTION
## Problema

legal-docs-blueprints se cuelga esporádicamente en prod: no crashea ni loguea error, simplemente deja de responder y hay que redeployar en Coolify.

## Causa raíz

`fetch()` en Node/Bun **no tiene timeout por defecto**. Había 6 llamadas sin timeout en la cadena de generación:

- `DocumensoService`: el `PUT` que sube el PDF a la URL prefirmada (x2) y el `HEAD` que verifica estado de firma
- `CrmApiService`: login de la cuenta de servicio y `POST /api/contracts/external` (+ retry)

Si el otro lado se estanca (stall TCP, proxy, storage lento), ese `await` queda colgado **para siempre**. Como `/contracts/batch` procesa los contratos en secuencia, un solo stall congela el batch entero; los reintentos del CRM apilan más requests colgados con buffers en memoria. El proceso sigue vivo y `/health` responde (solo chequea Gotenberg, con timeout propio), así que Coolify lo ve sano y nunca lo reinicia — solo el redeploy mata los sockets colgados.

Nota: Gotenberg (60s + `finally` que libera el slot) y WeeTrust (axios 30s) ya estaban protegidos; el hueco era solo Documenso y CRM.

## Fix

`signal: AbortSignal.timeout(...)` en los 6 fetch: **60s** para las subidas de PDF, **30s** para el resto. El timeout se convierte en error que cae en los `try/catch` existentes (el batch continúa con el siguiente contrato, el guardado en CRM devuelve `null` como ya hacía en otros errores).

## Pendiente post-merge

- Backport a `develop`
- (Opcional, aparte) limpieza de `output/`: los docx/pdf que no se suben a R2 quedan acumulándose en el disco del contenedor

🤖 Generated with [Claude Code](https://claude.com/claude-code)