### PR TITLE
fix(crm): rebalancear leads reactivados por WhatsApp

### DIFF
--- a/apps/crm/apps/server/src/controllers/bot.ts
+++ b/apps/crm/apps/server/src/controllers/bot.ts
@@ -449,6 +449,10 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 				lastName: renapData.firstLastName,
 				maritalStatus: mapCivilStatusToEnum(renapData.civil_status),
 				assignedTo,
+				assignmentType:
+					assignedTo === existingLead[0].assignedTo
+						? existingLead[0].assignmentType
+						: "auto",
 				status: "new",
 				age: age ?? existingLead[0].age,
 				updatedAt: new Date(),

--- a/apps/crm/apps/server/src/controllers/bot.ts
+++ b/apps/crm/apps/server/src/controllers/bot.ts
@@ -12,12 +12,13 @@ import {
 } from "@/db/schema";
 import type { documentTypeEnum } from "@/db/schema/documents";
 import { getRenapData } from "@/functions/getRenapInfo";
+import { resolveExistingLeadAssigneeFromDatabase } from "@/lib/lead-assignment";
+import { getOpenOpportunityBySource } from "@/lib/lead-opportunity";
 import { generateUniqueFilename, uploadFileFromUrlToR2 } from "@/lib/storage";
 import { salesUser } from "@/utils/constants";
 import { db } from "../db";
 import { validarDpi } from "../utils/cui-validation";
 import { otpController } from "./otp";
-import { getOpenOpportunityBySource } from "./public-lead";
 
 // Type for document type enum
 type DocumentType = (typeof documentTypeEnum.enumValues)[number];
@@ -430,13 +431,24 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 		createdByUserId = salesUser;
 	} else {
 		console.log("[DEBUG] DPI found in leads. Updating existing lead.");
+		const assignedTo = await resolveExistingLeadAssigneeFromDatabase(
+			existingLead[0].assignedTo,
+		);
+
+		if (!assignedTo) {
+			return {
+				success: false,
+				message: "No sales user available to assign the reactivated lead",
+			};
+		}
+
 		await db
 			.update(leads)
 			.set({
 				firstName: renapData.firstName,
 				lastName: renapData.firstLastName,
 				maritalStatus: mapCivilStatusToEnum(renapData.civil_status),
-				assignedTo: existingLead[0].assignedTo,
+				assignedTo,
 				status: "new",
 				age: age ?? existingLead[0].age,
 				updatedAt: new Date(),
@@ -444,7 +456,7 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 			})
 			.where(eq(leads.dpi, dpi));
 		leadId = existingLead[0].id;
-		assignedUserId = existingLead[0].assignedTo;
+		assignedUserId = assignedTo;
 		createdByUserId = existingLead[0].createdBy;
 	}
 

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -1,15 +1,19 @@
-import { and, asc, count, desc, eq, gte, or } from "drizzle-orm";
+import { and, asc, count, eq, or } from "drizzle-orm";
 import type { Context } from "hono";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import {
-	leadSourceEnum,
+	type leadSourceEnum,
 	leads,
 	opportunities,
 	salesStages,
 } from "../db/schema/crm";
-import { canReceiveAutoAssignedLead } from "../lib/lead-assignment";
+import {
+	findSalesUserWithLeastAutoAssignedLeads,
+	resolveExistingLeadAssigneeFromDatabase,
+} from "../lib/lead-assignment";
 import { getPublicLeadExistingOpportunityUpdates } from "../lib/lead-helpers";
+import { getOpenOpportunityBySource } from "../lib/lead-opportunity";
 import { validarDpi } from "../utils/cui-validation";
 import { getOnlyRenapInfoController } from "./bot";
 
@@ -30,7 +34,13 @@ export async function getSalesUserWithLeastOpportunities() {
 			role: user.role,
 		})
 		.from(user)
-		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true), eq(user.banned, false)));
+		.where(
+			and(
+				eq(user.role, "sales"),
+				eq(user.assignLeads, true),
+				eq(user.banned, false),
+			),
+		);
 
 	if (salesUsers.length === 0) {
 		return null;
@@ -69,68 +79,9 @@ export async function getSalesUserWithLeastOpportunities() {
 	return minUser;
 }
 
-/**
- * Encuentra al usuario de ventas con menos leads asignados.
- * Si hay empate, retorna el primero encontrado.
- * Si no hay usuarios de ventas, retorna null.
- */
-export async function getSalesUserWithLeastLeads() {
-	// Obtener todos los usuarios de ventas activos (no baneados)
-	const salesUsers = await db
-		.select({
-			id: user.id,
-			name: user.name,
-			email: user.email,
-			role: user.role,
-		})
-		.from(user)
-		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true), eq(user.banned, false)));
-
-	if (salesUsers.length === 0) {
-		return null;
-	}
-
-	// Contar leads automáticos asignados hoy por usuario (hora Guatemala UTC-6)
-	const startOfToday = new Date(
-		new Date().toLocaleDateString("en-US", { timeZone: "America/Guatemala" }),
-	);
-
-	const leadCounts = await db
-		.select({
-			assignedTo: leads.assignedTo,
-			count: count(leads.id),
-		})
-		.from(leads)
-		.where(
-			and(
-				eq(leads.assignmentType, "auto"),
-				gte(leads.createdAt, startOfToday),
-			),
-		)
-		.groupBy(leads.assignedTo);
-
-	// Crear un mapa de conteos
-	const countMap = new Map<string, number>();
-	for (const lc of leadCounts) {
-		if (lc.assignedTo) {
-			countMap.set(lc.assignedTo, lc.count);
-		}
-	}
-
-	// Encontrar el usuario de ventas con menos leads
-	let minUser = salesUsers[0];
-	let minCount = countMap.get(minUser.id) ?? 0;
-
-	for (const salesUser of salesUsers) {
-		const userCount = countMap.get(salesUser.id) ?? 0;
-		if (userCount < minCount) {
-			minCount = userCount;
-			minUser = salesUser;
-		}
-	}
-
-	return minUser;
-}
+export {
+	findSalesUserWithLeastAutoAssignedLeads as getSalesUserWithLeastLeads,
+};
 
 /**
  * Crea una nueva oportunidad vinculada a un lead
@@ -180,57 +131,6 @@ export async function createOpportunityForLead(
 	return newOpportunity;
 }
 
-/**
- * Verifica si un lead ya tiene una oportunidad abierta con el mismo source.
- */
-export async function getOpenOpportunityBySource(
-	leadId: string,
-	source: LeadSource,
-) {
-	const [existing] = await db
-		.select({
-			id: opportunities.id,
-			source: opportunities.source,
-			campaign: opportunities.campaign,
-			creditType: opportunities.creditType,
-		})
-		.from(opportunities)
-		.where(
-			and(
-				eq(opportunities.leadId, leadId),
-				or(
-					eq(opportunities.status, "open"),
-					eq(opportunities.status, "on_hold"),
-				),
-			),
-		)
-		.orderBy(desc(opportunities.createdAt))
-		.limit(1);
-	return existing;
-}
-
-async function resolveLeadAssignee(existingAssignedTo?: string | null) {
-	if (existingAssignedTo) {
-		const [currentOwner] = await db
-			.select({
-				id: user.id,
-				role: user.role,
-				assignLeads: user.assignLeads,
-				banned: user.banned,
-			})
-			.from(user)
-			.where(eq(user.id, existingAssignedTo))
-			.limit(1);
-
-		if (canReceiveAutoAssignedLead(currentOwner)) {
-			return currentOwner.id;
-		}
-	}
-
-	const fallbackSalesUser = await getSalesUserWithLeastLeads();
-	return fallbackSalesUser?.id ?? null;
-}
-
 export async function createPublicLead(c: Context) {
 	try {
 		const body = await c.req.json();
@@ -257,10 +157,7 @@ export async function createPublicLead(c: Context) {
 		if (hasDpi) {
 			const resultadoDpi = validarDpi(body.dpi);
 			if (!resultadoDpi.valid) {
-				return c.json(
-					{ success: false, error: resultadoDpi.error },
-					400,
-				);
+				return c.json({ success: false, error: resultadoDpi.error }, 400);
 			}
 			body.dpi = resultadoDpi.dpiLimpio;
 		}
@@ -279,8 +176,7 @@ export async function createPublicLead(c: Context) {
 		// --- Lead existente ---
 		if (existingLead) {
 			const source = body.source || existingLead.source || "website";
-			const campaign =
-				body.campaign || existingLead.campaign || undefined;
+			const campaign = body.campaign || existingLead.campaign || undefined;
 			let leadData = existingLead;
 
 			if (body.isRegister) {
@@ -308,11 +204,13 @@ export async function createPublicLead(c: Context) {
 				source,
 			);
 			if (existingOpportunity) {
-				const opportunityUpdates =
-					getPublicLeadExistingOpportunityUpdates(existingOpportunity, {
+				const opportunityUpdates = getPublicLeadExistingOpportunityUpdates(
+					existingOpportunity,
+					{
 						campaign: body.campaign,
 						creditType,
-					});
+					},
+				);
 
 				if (Object.keys(opportunityUpdates).length > 0) {
 					await db
@@ -335,7 +233,9 @@ export async function createPublicLead(c: Context) {
 				);
 			}
 
-			const assignedTo = await resolveLeadAssignee(existingLead.assignedTo);
+			const assignedTo = await resolveExistingLeadAssigneeFromDatabase(
+				existingLead.assignedTo,
+			);
 
 			if (!assignedTo) {
 				return c.json(
@@ -410,7 +310,7 @@ export async function createPublicLead(c: Context) {
 		}
 
 		// --- Lead nuevo: mismo asesor para lead y oportunidad ---
-		const salesUserForLead = await getSalesUserWithLeastLeads();
+		const salesUserForLead = await findSalesUserWithLeastAutoAssignedLeads();
 
 		if (!salesUserForLead) {
 			return c.json(

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -252,6 +252,7 @@ export async function createPublicLead(c: Context) {
 					.update(leads)
 					.set({
 						assignedTo,
+						assignmentType: "auto",
 						updatedAt: new Date(),
 					})
 					.where(eq(leads.id, existingLead.id))

--- a/apps/crm/apps/server/src/lib/lead-assignment.test.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { canReceiveAutoAssignedLead } from "./lead-assignment";
+import {
+	canReceiveAutoAssignedLead,
+	getSalesUserWithLeastAutoAssignedLeads,
+	resolveExistingLeadAssignee,
+} from "./lead-assignment";
 
 describe("lead assignment helpers", () => {
 	test("accepts active sales users that can receive leads", () => {
@@ -38,5 +42,70 @@ describe("lead assignment helpers", () => {
 			}),
 		).toBe(false);
 		expect(canReceiveAutoAssignedLead(null)).toBe(false);
+	});
+
+	test("keeps an eligible existing owner", () => {
+		expect(
+			resolveExistingLeadAssignee(
+				{ id: "current", role: "sales", assignLeads: true, banned: false },
+				{ id: "fallback", role: "sales", assignLeads: true, banned: false },
+			),
+		).toBe("current");
+	});
+
+	test("uses the balanced fallback for an ineligible existing owner", () => {
+		const fallback = {
+			id: "fallback",
+			role: "sales",
+			assignLeads: true,
+			banned: false,
+		};
+
+		for (const currentOwner of [
+			{ id: "disabled", role: "sales", assignLeads: false, banned: false },
+			{ id: "banned", role: "sales", assignLeads: true, banned: true },
+			{
+				id: "not-sales",
+				role: "sales_supervisor",
+				assignLeads: true,
+				banned: false,
+			},
+		]) {
+			expect(resolveExistingLeadAssignee(currentOwner, fallback)).toBe(
+				"fallback",
+			);
+		}
+	});
+
+	test("chooses the eligible advisor with the fewest automatic leads today", () => {
+		const selected = getSalesUserWithLeastAutoAssignedLeads(
+			[
+				{ id: "busy", role: "sales", assignLeads: true, banned: false },
+				{ id: "available", role: "sales", assignLeads: true, banned: false },
+			],
+			new Map([
+				["busy", 4],
+				["available", 1],
+			]),
+		);
+
+		expect(selected?.id).toBe("available");
+	});
+
+	test("returns no assignee when no eligible fallback exists", () => {
+		expect(
+			resolveExistingLeadAssignee(
+				{ id: "disabled", role: "sales", assignLeads: false, banned: false },
+				null,
+			),
+		).toBeNull();
+	});
+
+	test("keeps the WhatsApp controller out of the public-lead import cycle", async () => {
+		const botSource = await Bun.file(
+			new URL("../controllers/bot.ts", import.meta.url),
+		).text();
+
+		expect(botSource).not.toContain('from "./public-lead"');
 	});
 });

--- a/apps/crm/apps/server/src/lib/lead-assignment.test.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.test.ts
@@ -92,6 +92,19 @@ describe("lead assignment helpers", () => {
 		expect(selected?.id).toBe("available");
 	});
 
+	test("balances fallback assignments after reactivating an older lead", () => {
+		const selected = getSalesUserWithLeastAutoAssignedLeads(
+			[
+				{ id: "first", role: "sales", assignLeads: true, banned: false },
+				{ id: "second", role: "sales", assignLeads: true, banned: false },
+			],
+			new Map(),
+			new Map([["first", 1]]),
+		);
+
+		expect(selected?.id).toBe("second");
+	});
+
 	test("returns no assignee when no eligible fallback exists", () => {
 		expect(
 			resolveExistingLeadAssignee(

--- a/apps/crm/apps/server/src/lib/lead-assignment.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, gte } from "drizzle-orm";
+import { and, count, eq, gte, lt } from "drizzle-orm";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { leads } from "../db/schema/crm";
@@ -24,12 +24,18 @@ export function canReceiveAutoAssignedLead(
 export function getSalesUserWithLeastAutoAssignedLeads(
 	salesUsers: Array<LeadAssignableUser & { id: string }>,
 	leadCounts: ReadonlyMap<string, number>,
+	reactivatedLeadCounts: ReadonlyMap<string, number> = new Map(),
 ): (LeadAssignableUser & { id: string }) | null {
 	let selectedUser = salesUsers[0] ?? null;
-	let selectedCount = selectedUser ? (leadCounts.get(selectedUser.id) ?? 0) : 0;
+	let selectedCount = selectedUser
+		? (leadCounts.get(selectedUser.id) ?? 0) +
+			(reactivatedLeadCounts.get(selectedUser.id) ?? 0)
+		: 0;
 
 	for (const salesUser of salesUsers) {
-		const userCount = leadCounts.get(salesUser.id) ?? 0;
+		const userCount =
+			(leadCounts.get(salesUser.id) ?? 0) +
+			(reactivatedLeadCounts.get(salesUser.id) ?? 0);
 		if (selectedUser && userCount < selectedCount) {
 			selectedUser = salesUser;
 			selectedCount = userCount;
@@ -71,22 +77,48 @@ export async function findSalesUserWithLeastAutoAssignedLeads() {
 			timeZone: "America/Guatemala",
 		}),
 	);
-	const leadCounts = await db
-		.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
-		.from(leads)
-		.where(
-			and(eq(leads.assignmentType, "auto"), gte(leads.createdAt, startOfToday)),
-		)
-		.groupBy(leads.assignedTo);
+	const [leadCounts, reactivatedLeadCounts] = await Promise.all([
+		db
+			.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
+			.from(leads)
+			.where(
+				and(
+					eq(leads.assignmentType, "auto"),
+					gte(leads.createdAt, startOfToday),
+				),
+			)
+			.groupBy(leads.assignedTo),
+		db
+			.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
+			.from(leads)
+			.where(
+				and(
+					eq(leads.assignmentType, "auto"),
+					lt(leads.createdAt, startOfToday),
+					gte(leads.updatedAt, startOfToday),
+				),
+			)
+			.groupBy(leads.assignedTo),
+	]);
 	const countMap = new Map<string, number>();
+	const reactivatedCountMap = new Map<string, number>();
 
 	for (const leadCount of leadCounts) {
 		if (leadCount.assignedTo) {
 			countMap.set(leadCount.assignedTo, leadCount.count);
 		}
 	}
+	for (const leadCount of reactivatedLeadCounts) {
+		if (leadCount.assignedTo) {
+			reactivatedCountMap.set(leadCount.assignedTo, leadCount.count);
+		}
+	}
 
-	return getSalesUserWithLeastAutoAssignedLeads(salesUsers, countMap);
+	return getSalesUserWithLeastAutoAssignedLeads(
+		salesUsers,
+		countMap,
+		reactivatedCountMap,
+	);
 }
 
 export async function resolveExistingLeadAssigneeFromDatabase(

--- a/apps/crm/apps/server/src/lib/lead-assignment.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.ts
@@ -1,6 +1,11 @@
+import { and, count, eq, gte } from "drizzle-orm";
+import { db } from "../db";
+import { user } from "../db/schema/auth";
+import { leads } from "../db/schema/crm";
 import { ROLES } from "./roles";
 
-type LeadAssignableUser = {
+export type LeadAssignableUser = {
+	id?: string;
 	role: string | null | undefined;
 	assignLeads: boolean | null | undefined;
 	banned: boolean | null | undefined;
@@ -13,5 +18,99 @@ export function canReceiveAutoAssignedLead(
 		user?.role === ROLES.SALES &&
 		user.assignLeads === true &&
 		user.banned !== true
+	);
+}
+
+export function getSalesUserWithLeastAutoAssignedLeads(
+	salesUsers: Array<LeadAssignableUser & { id: string }>,
+	leadCounts: ReadonlyMap<string, number>,
+): (LeadAssignableUser & { id: string }) | null {
+	let selectedUser = salesUsers[0] ?? null;
+	let selectedCount = selectedUser ? (leadCounts.get(selectedUser.id) ?? 0) : 0;
+
+	for (const salesUser of salesUsers) {
+		const userCount = leadCounts.get(salesUser.id) ?? 0;
+		if (selectedUser && userCount < selectedCount) {
+			selectedUser = salesUser;
+			selectedCount = userCount;
+		}
+	}
+
+	return selectedUser;
+}
+
+export function resolveExistingLeadAssignee(
+	currentOwner: LeadAssignableUser | null | undefined,
+	fallbackSalesUser: LeadAssignableUser | null,
+): string | null {
+	if (canReceiveAutoAssignedLead(currentOwner)) {
+		return currentOwner?.id ?? null;
+	}
+
+	return fallbackSalesUser?.id ?? null;
+}
+
+export async function findSalesUserWithLeastAutoAssignedLeads() {
+	const salesUsers = await db
+		.select({
+			id: user.id,
+			role: user.role,
+			assignLeads: user.assignLeads,
+			banned: user.banned,
+		})
+		.from(user)
+		.where(
+			and(
+				eq(user.role, ROLES.SALES),
+				eq(user.assignLeads, true),
+				eq(user.banned, false),
+			),
+		);
+	const startOfToday = new Date(
+		new Date().toLocaleDateString("en-US", {
+			timeZone: "America/Guatemala",
+		}),
+	);
+	const leadCounts = await db
+		.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
+		.from(leads)
+		.where(
+			and(eq(leads.assignmentType, "auto"), gte(leads.createdAt, startOfToday)),
+		)
+		.groupBy(leads.assignedTo);
+	const countMap = new Map<string, number>();
+
+	for (const leadCount of leadCounts) {
+		if (leadCount.assignedTo) {
+			countMap.set(leadCount.assignedTo, leadCount.count);
+		}
+	}
+
+	return getSalesUserWithLeastAutoAssignedLeads(salesUsers, countMap);
+}
+
+export async function resolveExistingLeadAssigneeFromDatabase(
+	existingAssignedTo?: string | null,
+) {
+	const [currentOwner] = existingAssignedTo
+		? await db
+				.select({
+					id: user.id,
+					role: user.role,
+					assignLeads: user.assignLeads,
+					banned: user.banned,
+				})
+				.from(user)
+				.where(eq(user.id, existingAssignedTo))
+				.limit(1)
+		: [];
+
+	if (canReceiveAutoAssignedLead(currentOwner)) {
+		return currentOwner?.id ?? null;
+	}
+
+	return resolveExistingLeadAssignee(
+		null,
+		await findSalesUserWithLeastAutoAssignedLeads(),
 	);
 }

--- a/apps/crm/apps/server/src/lib/lead-opportunity.ts
+++ b/apps/crm/apps/server/src/lib/lead-opportunity.ts
@@ -1,0 +1,32 @@
+import { and, desc, eq, or } from "drizzle-orm";
+import { db } from "../db";
+import { type leadSourceEnum, opportunities } from "../db/schema/crm";
+
+type LeadSource = (typeof leadSourceEnum.enumValues)[number];
+
+export async function getOpenOpportunityBySource(
+	leadId: string,
+	_source: LeadSource,
+) {
+	const [existing] = await db
+		.select({
+			id: opportunities.id,
+			source: opportunities.source,
+			campaign: opportunities.campaign,
+			creditType: opportunities.creditType,
+		})
+		.from(opportunities)
+		.where(
+			and(
+				eq(opportunities.leadId, leadId),
+				or(
+					eq(opportunities.status, "open"),
+					eq(opportunities.status, "on_hold"),
+				),
+			),
+		)
+		.orderBy(desc(opportunities.createdAt))
+		.limit(1);
+
+	return existing;
+}


### PR DESCRIPTION
## Resumen
- revalida que el asesor actual de un lead reactivado siga siendo `sales`, tenga `assign_leads=true` y no esté baneado
- cuando el dueño ya no es elegible, selecciona al asesor habilitado con menos leads automáticos del día
- asigna el mismo asesor resuelto al lead y a la nueva oportunidad WhatsApp
- conserva al dueño actual cuando sigue siendo elegible y no reasigna oportunidades abiertas existentes
- extrae utilidades compartidas para evitar el ciclo `bot.ts -> public-lead.ts -> bot.ts`

## Causa raíz
`getRenapInfoController` reutilizaba `existingLead.assignedTo` sin revalidar elegibilidad, por lo que una reactivación podía crear una oportunidad nueva para un asesor con asignación automática desactivada.

## Pruebas
- `bun test src/lib/lead-assignment.test.ts` — 8 pass, 0 fail
- Biome 2.3.14 sobre los cinco archivos modificados — sin errores; quedan advertencias preexistentes en controladores
- `git diff --check` — limpio

## Límites
- no modifica schema ni migraciones
- no toca producción
- preserva el comportamiento existente para oportunidades abiertas