### PR TITLE
feat(crm): agregar plantilla de impuesto de circulación 2026

### DIFF
--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	COBROS_NO_REPLY_WARNING,
+	interpolar,
 	PLANTILLAS_MENSAJES,
 	prepararTelefonoAsesorParaEnvio,
 } from "./cobros-plantillas";
@@ -83,5 +85,62 @@ describe("plantillas masivas de cobros", () => {
 			enviar: true,
 			telefonoAsesor: "41286630",
 		});
+	});
+
+	test("define el recordatorio de impuesto de circulación 2026", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+
+		expect(plantilla?.nombre).toBe("Impuesto de circulación 2026");
+		expect(
+			plantilla?.cuerpo,
+		).toBe(`Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`);
+	});
+
+	test("interpola el recordatorio de impuesto con los datos del cliente y asesor", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+		const mensaje = interpolar(plantilla?.cuerpo ?? "", {
+			clienteNombre: "MARIA LOPEZ",
+			fechaPago: "",
+			cuotaMensual: "",
+			placa: "",
+			marcaLineaModelo: "",
+			montoAdeudado: "",
+			cuotasAtraso: 0,
+			telefonoAsesor: "41286630",
+			nombreAsesor: "Carlos Pérez",
+		});
+
+		expect(mensaje).toContain("Estimado(a) Maria Lopez");
+		expect(mensaje).toContain("Atentamente,\nCarlos Pérez\nTel: 41286630");
+		expect(mensaje.match(/NO RESPONDER EN ESTE CHAT/g)?.length).toBe(1);
+	});
+
+	test("conserva los cinco párrafos del contrato SimpleTech para impuesto de circulación", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+		const paragraphs = (plantilla?.cuerpo ?? "")
+			.split(/\n\s*\n/g)
+			.map((paragraph) => paragraph.trim())
+			.filter(Boolean);
+
+		expect(paragraphs).toHaveLength(5);
+		expect(paragraphs.slice(3).join("\n\n")).toBe(
+			`${COBROS_NO_REPLY_WARNING}\n\nAtentamente,\n{nombreAsesor}\nTel: {telefonoAsesor}`,
+		);
 	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -119,6 +119,24 @@ ${COBROS_NO_REPLY_WARNING}
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
+		id: "impuesto_circulacion_2026",
+		nombre: "Impuesto de circulación 2026",
+		etapa: "al_dia",
+		asunto: "Recordatorio de pago - Impuesto de circulación 2026",
+		// 5 bloques; SimpleTech colapsa los dos últimos en `mensaje4parametro`.
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
 		id: "pre_mora",
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
 	accionUsaCuerpoNoReply,
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	COBROS_NO_REPLY_WARNING,
 	crearUrlWhatsappManual,
 	cuerpoParaValidarNoReply,
+	interpolar,
 	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
@@ -177,5 +179,29 @@ describe("plantillas web de cobros", () => {
 			enviar: true,
 			telefonoAsesor: "41286630",
 		});
+	});
+
+	test("muestra el recordatorio de impuesto de circulación 2026 con sus variables", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+		const cuerpoWhatsapp = plantilla?.cuerpoWhastapp ?? plantilla?.cuerpo ?? "";
+		const mensaje = interpolar(cuerpoWhatsapp, {
+			clienteNombre: "MARIA LOPEZ",
+			fechaPago: "",
+			cuotaMensual: "",
+			placa: "",
+			marcaLineaModelo: "",
+			montoAdeudado: "",
+			cuotasAtraso: 0,
+			telefonoAsesor: "41286630",
+			nombreAsesor: "Carlos Pérez",
+		});
+
+		expect(plantilla?.nombre).toBe("Impuesto de circulación 2026");
+		expect(mensaje).toContain("Estimado(a) Maria Lopez");
+		expect(mensaje).toContain("Atentamente,\nCarlos Pérez\nTel: 41286630");
+		expect(mensaje.match(/NO RESPONDER EN ESTE CHAT/g)?.length).toBe(1);
+		expect(cuerpoWhatsapp).toContain(COBROS_NO_REPLY_WARNING);
 	});
 });

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -206,6 +206,34 @@ ${COBROS_NO_REPLY_WARNING}
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
+		id: "impuesto_circulacion_2026",
+		nombre: "Impuesto de circulación 2026",
+		etapa: "al_dia",
+		asunto: "Recordatorio de pago - Impuesto de circulación 2026",
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+		cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
 		id: "pre_mora",
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",


### PR DESCRIPTION
## Resumen
- agrega la plantilla **Impuesto de circulación 2026** solicitada por Alejandro para mensajes masivos de Cobros
- incorpora el texto en las fuentes server-side y web/selector
- interpola nombre del cliente, nombre del asesor y teléfono del asesor
- mantiene el aviso de no responder exactamente una vez
- conserva cinco bloques, compactados por SimpleTech a cuatro parámetros mediante `mensaje4parametro`

## Fuente del requerimiento
Correo de Alejandro Salvatierra del 8 de julio de 2026: **Solicitud de plantilla para mensajes masivos - Cobros**.

## Pruebas
- `bun test apps/server/src/lib/cobros-plantillas.test.ts apps/web/src/lib/cobros/plantillas-mensajes.test.ts` — 26 pass, 0 fail
- Biome 2.3.14 sobre los cuatro archivos modificados — limpio
- `git diff --check` — limpio

## Pendiente externo
Confirmar en SimpleTech/Meta que `mensaje4parametro` esté aprobado y acepte estos cuatro parámetros en el orden esperado. No se usaron credenciales ni APIs externas y este PR no realiza el registro/aprobación de la plantilla en el proveedor.

## Límites
- sin cambios de schema o migraciones
- sin cambios de producción