### PR TITLE
feat(cartera): filtro por plazos restantes en assign-capital

### DIFF
--- a/apps/cartera-back/src/controllers/assignCapital.test.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { CreditCandidate } from "./assignCapital";
+
+/**
+ * Filtro por plazos restantes de getCreditCandidates.
+ *
+ * Se testean las dos funciones puras que sostienen la regla de negocio: el
+ * cálculo de plazos restantes y el filtro por plazo exacto. Ninguna toca la DB.
+ *
+ * El módulo `../database` se fakea ANTES de importar el controller (mismo patrón
+ * que latefee.test.ts): importarlo de verdad ejecuta `database/index.ts`, que
+ * tira `Error: DATABASE_URL environment variable not set` si falta la env var y
+ * abre un pool de conexiones que estos tests no necesitan.
+ */
+mock.module("../database", () => ({ db: {}, client: {} }));
+
+const { calcPlazosRestantes, seleccionarPorPlazo, CUBE_ID } = await import(
+  "./assignCapital"
+);
+
+// ── Helper: candidato mínimo ────────────────────────────────────────────────
+// Solo importan plazos_restantes, capital_evaluado y score; el resto es relleno
+// para satisfacer el tipo.
+let seq = 0;
+function mkCandidate(opts: {
+  plazos_restantes: number;
+  capital_evaluado?: number; // lo que Cube tiene en el crédito (lo vendible)
+  capital_activo?: number;
+  score?: number;
+  sifco?: string;
+}): CreditCandidate {
+  const capitalCube = opts.capital_evaluado ?? 10000;
+  const id = ++seq;
+  return {
+    credito_id: id,
+    numero_credito_sifco: opts.sifco ?? `C-${id}`,
+    capital: opts.capital_activo ?? capitalCube,
+    capital_activo: opts.capital_activo ?? capitalCube,
+    formato_credito: "Individual",
+    cuotas_pagadas: 1,
+    total_cuotas: 24,
+    plazos_restantes: opts.plazos_restantes,
+    inversionistas: [
+      {
+        inversionista_id: CUBE_ID,
+        nombre: "Cube Investments",
+        monto_aportado: capitalCube,
+        es_cube: true,
+      },
+    ],
+    score: opts.score ?? 1000,
+    score_breakdown: {
+      crm_bonus: 0,
+      formato: 0,
+      cuotas: 0,
+      proximidad: 0,
+      reinversion: 0,
+      vencimiento_dia_30: 0,
+      total: opts.score ?? 1000,
+    },
+    capital_evaluado: capitalCube,
+  };
+}
+
+const plazosDe = (cs: CreditCandidate[]) => cs.map((c) => c.plazos_restantes);
+
+// ============================================================================
+describe("calcPlazosRestantes", () => {
+  it("crédito nuevo (ninguna cuota pagada) → restantes = total", () => {
+    expect(calcPlazosRestantes(24, 0)).toBe(24);
+  });
+
+  it("a mitad de pago (última pagada 12 de 24) → 12", () => {
+    expect(calcPlazosRestantes(24, 12)).toBe(12);
+  });
+
+  it("con hueco: cuenta desde la MAYOR pagada, ignora las impagas de abajo", () => {
+    // Total 24. Pagadas 1, 2, 4 y 5 — la 3 quedó impaga. La mayor pagada es la 5.
+    // Restantes = 24 - 5 = 19. NO 20 (que sería total - cantidad_pagadas).
+    expect(calcPlazosRestantes(24, 5)).toBe(19);
+  });
+
+  it("última cuota pagada → 0 restantes", () => {
+    expect(calcPlazosRestantes(24, 24)).toBe(0);
+  });
+
+  it("crédito sin cuotas → 0 (nunca negativo)", () => {
+    expect(calcPlazosRestantes(0, 0)).toBe(0);
+  });
+});
+
+// ============================================================================
+describe("seleccionarPorPlazo — filtro estricto", () => {
+  it("devuelve solo los del plazo exacto, descarta los vecinos", () => {
+    const candidatos = [
+      mkCandidate({ plazos_restantes: 12 }),
+      mkCandidate({ plazos_restantes: 13 }),
+      mkCandidate({ plazos_restantes: 12 }),
+      mkCandidate({ plazos_restantes: 14 }),
+    ];
+
+    const result = seleccionarPorPlazo(candidatos, 12);
+
+    expect(plazosDe(result)).toEqual([12, 12]);
+  });
+
+  it("NO escala hacia arriba: sin créditos de 12, no toma los de 13 ni 14", () => {
+    const candidatos = [
+      mkCandidate({ plazos_restantes: 13 }),
+      mkCandidate({ plazos_restantes: 14 }),
+      mkCandidate({ plazos_restantes: 16 }),
+    ];
+
+    expect(seleccionarPorPlazo(candidatos, 12)).toEqual([]);
+  });
+
+  it("NO escala hacia abajo: un crédito de plazo 11 no entra con objetivo 12", () => {
+    const candidatos = [
+      mkCandidate({ plazos_restantes: 11 }),
+      mkCandidate({ plazos_restantes: 9 }),
+    ];
+
+    expect(seleccionarPorPlazo(candidatos, 12)).toEqual([]);
+  });
+
+  it("no alcanza a cubrir el monto → devuelve igual los que haya (no escala)", () => {
+    // Monto pedido Q300k. Los créditos de plazo 12 solo suman Q30k de Cube.
+    // Aun así se devuelven esos dos; el faltante queda sin asignar.
+    const candidatos = [
+      mkCandidate({ plazos_restantes: 12, capital_evaluado: 20_000 }),
+      mkCandidate({ plazos_restantes: 12, capital_evaluado: 10_000 }),
+      mkCandidate({ plazos_restantes: 13, capital_evaluado: 999_000 }),
+    ];
+
+    const result = seleccionarPorPlazo(candidatos, 12);
+
+    expect(plazosDe(result)).toEqual([12, 12]);
+    const capitalCube = result.reduce((acc, c) => acc + c.capital_evaluado, 0);
+    expect(capitalCube).toBe(30_000); // muy por debajo de los Q300k, y está bien
+  });
+
+  it("sin candidatos del plazo pedido → lista vacía", () => {
+    const candidatos = [
+      mkCandidate({ plazos_restantes: 20 }),
+      mkCandidate({ plazos_restantes: 30 }),
+    ];
+
+    expect(seleccionarPorPlazo(candidatos, 12)).toEqual([]);
+  });
+
+  it("conserva el orden de score de la lista de entrada", () => {
+    const candidatos = [
+      mkCandidate({ plazos_restantes: 12, score: 5_000, sifco: "A" }),
+      mkCandidate({ plazos_restantes: 13, score: 4_500, sifco: "DESCARTADO" }),
+      mkCandidate({ plazos_restantes: 12, score: 3_000, sifco: "B" }),
+      mkCandidate({ plazos_restantes: 12, score: 2_000, sifco: "C" }),
+    ];
+
+    const result = seleccionarPorPlazo(candidatos, 12);
+
+    expect(result.map((c) => c.numero_credito_sifco)).toEqual(["A", "B", "C"]);
+  });
+});

--- a/apps/cartera-back/src/controllers/assignCapital.ts
+++ b/apps/cartera-back/src/controllers/assignCapital.ts
@@ -57,6 +57,8 @@ export interface CreditCandidate {
   formato_credito: "Pool" | "Individual";
   cuotas_pagadas: number;
   total_cuotas: number;
+  // Cuotas que quedan por encima de la última cuota pagada. Ver calcPlazosRestantes.
+  plazos_restantes: number;
   inversionistas: InversionistaResult[];
   score: number;
   score_breakdown: ScoreBreakdown;
@@ -137,6 +139,48 @@ function calcCapitalProximityBonus(
 }
 
 // ============================================================
+// FUNCIONES DE PLAZOS RESTANTES
+// ============================================================
+
+/**
+ * Plazos (meses/cuotas) que le quedan al crédito.
+ *
+ * Se recorren las cuotas en orden DESCENDENTE y se busca la primera pagada;
+ * los plazos restantes son las cuotas que quedan POR ENCIMA de ella. Por eso
+ * basta con la cuota pagada de mayor número (`maxCuotaPagada`).
+ *
+ * Consecuencia deliberada: los huecos NO se cuentan. Si de 24 cuotas están
+ * pagadas la 1, 2, 4 y 5 (la 3 quedó impaga), la mayor pagada es la 5 y los
+ * restantes son 19 — no 20.
+ *
+ * Crédito sin ninguna cuota pagada (`maxCuotaPagada = 0`) → restantes = total.
+ */
+export function calcPlazosRestantes(
+  totalCuotas: number,
+  maxCuotaPagada: number
+): number {
+  if (totalCuotas <= 0) return 0;
+  return Math.max(0, totalCuotas - maxCuotaPagada);
+}
+
+/**
+ * Filtra los candidatos dejando SOLO los que tienen exactamente `plazoObjetivo`
+ * plazos restantes. Filtro estricto: no se escala a plazos vecinos.
+ *
+ * Si los créditos de ese plazo no alcanzan a cubrir el monto pedido, no importa:
+ * se devuelven los que haya (incluso ninguno). El caller ya reporta el faltante
+ * como monto sin asignar.
+ *
+ * Conserva el orden de score de la lista de entrada.
+ */
+export function seleccionarPorPlazo(
+  candidatos: CreditCandidate[],
+  plazoObjetivo: number
+): CreditCandidate[] {
+  return candidatos.filter((c) => c.plazos_restantes === plazoObjetivo);
+}
+
+// ============================================================
 // QUERY PRINCIPAL
 // ============================================================
 
@@ -144,10 +188,12 @@ export async function getCreditCandidates(
   monto?: number,
   limit?: number,
   inversionistaIdSolicitante?: number,
-  porcentaje?: number
+  porcentaje?: number,
+  plazoObjetivo?: number
 ): Promise<CreditCandidate[]> {
   console.log("\n🔍 ========== getCreditCandidates ==========");
   console.log(`   monto: ${monto ?? "no especificado"}`);
+  console.log(`   plazoObjetivo: ${plazoObjetivo ?? "no especificado"}`);
 
   // Para optimizar el rendimiento y aprovechar índices (sargable), calculamos la fecha
   // exacta de inicio de mes en UTC basándonos en la zona horaria de Guatemala.
@@ -386,12 +432,17 @@ export async function getCreditCandidates(
   }
 
   // ──────────────────────────────────────────────────────────
-  // 5. Cuotas pagadas por crédito (todas incluyendo cuota 0)
+  // 5. Cuotas pagadas por crédito: cuántas y cuál es la de mayor número.
+  //    El MAX equivale a recorrer las cuotas en orden descendente y quedarse
+  //    con la primera pagada; alimenta el cálculo de plazos restantes.
+  //    Un crédito sin cuotas pagadas no aparece en el resultado (GROUP BY no
+  //    emite grupos vacíos) y cae al `?? 0` de más abajo.
   // ──────────────────────────────────────────────────────────
   const cuotasPagadasRaw = await db
     .select({
       credito_id: cuotas_credito.credito_id,
       count: sql<number>`COUNT(*)::int`,
+      max_pagada: sql<number>`MAX(${cuotas_credito.numero_cuota})::int`,
     })
     .from(cuotas_credito)
     .where(
@@ -405,8 +456,10 @@ export async function getCreditCandidates(
     .groupBy(cuotas_credito.credito_id);
 
   const cuotasPagadasByCredito = new Map<number, number>();
+  const maxCuotaPagadaByCredito = new Map<number, number>();
   for (const row of cuotasPagadasRaw) {
     cuotasPagadasByCredito.set(row.credito_id, Number(row.count));
+    maxCuotaPagadaByCredito.set(row.credito_id, Number(row.max_pagada));
   }
 
   // ──────────────────────────────────────────────────────────
@@ -483,7 +536,7 @@ export async function getCreditCandidates(
   // ──────────────────────────────────────────────────────────
   // 7. Aplicar filtros hard y calcular score
   // ──────────────────────────────────────────────────────────
-  const candidates: CreditCandidate[] = [];
+  let candidates: CreditCandidate[] = [];
 
   for (const credito of baseCredits) {
     const { credito_id, numero_credito_sifco, capital, formato_credito } =
@@ -577,6 +630,8 @@ export async function getCreditCandidates(
     // Cuotas pagadas y totales
     const cuotasPagadas = cuotasPagadasByCredito.get(credito_id) ?? 0;
     const totalCuotas = totalCuotasByCredito.get(credito_id) ?? 0;
+    const maxCuotaPagada = maxCuotaPagadaByCredito.get(credito_id) ?? 0;
+    const plazosRestantes = calcPlazosRestantes(totalCuotas, maxCuotaPagada);
 
     // FILTRO CRÍTICO: Solo si es cuota 1 confirmada pa delante (se descarta si solo tiene cuota 0 o ninguna)
     if (cuotasPagadas === 0) {
@@ -636,6 +691,7 @@ export async function getCreditCandidates(
       formato_credito: actualFormadoCredito as "Pool" | "Individual",
       cuotas_pagadas: cuotasPagadas,
       total_cuotas: totalCuotas,
+      plazos_restantes: plazosRestantes,
       inversionistas: invs,
       score,
       score_breakdown: {
@@ -675,6 +731,21 @@ export async function getCreditCandidates(
     }
     return 0;
   });
+
+  // ──────────────────────────────────────────────────────────
+  // 7.5 Filtro estricto por plazos restantes
+  //     Va ANTES del limit: si recortáramos primero, podríamos tirar los únicos
+  //     candidatos del plazo pedido. Si no alcanzan a cubrir el monto, se
+  //     devuelven igual — el caller reporta el faltante como monto sin asignar.
+  // ──────────────────────────────────────────────────────────
+  if (plazoObjetivo !== undefined && plazoObjetivo !== null) {
+    const antes = candidates.length;
+    candidates = seleccionarPorPlazo(candidates, plazoObjetivo);
+    const capitalCube = candidates.reduce((acc, c) => acc + c.capital_evaluado, 0);
+    console.log(
+      `   📆 Filtro plazos restantes (exactamente ${plazoObjetivo}): ${antes} → ${candidates.length} candidato(s), capital Cube Q${capitalCube}`
+    );
+  }
 
   // Si se especificó un límite, cortar antes de las queries de relaciones
   if (limit !== undefined) {
@@ -801,10 +872,13 @@ export async function getCreditCandidateById(
     capital: Number(c.capital),
     // capital_activo / cuotas / score no se calculan en modo manual:
     // el flujo aguas abajo solo consume credito_completo.
+    // OJO: plazos_restantes = 0 acá es "no calculado", NO "crédito liquidado".
+    // No filtres por este campo sobre un candidato salido de esta función.
     capital_activo: 0,
     formato_credito: esIndividual ? "Individual" : "Pool",
     cuotas_pagadas: 0,
     total_cuotas: 0,
+    plazos_restantes: 0,
     inversionistas: inversionistasResult,
     score: 0,
     score_breakdown: {

--- a/apps/cartera-back/src/routers/assignCapital.ts
+++ b/apps/cartera-back/src/routers/assignCapital.ts
@@ -25,7 +25,20 @@ export const assignCapitalRouter = new Elysia()
    *      Devuelve los top N créditos por score.
    *      Para dar opciones sin filtrar tanto como solo_insertable.
    *
+   *  - plazo_objetivo  (opcional, entero positivo)
+   *      Filtro estricto: solo créditos con EXACTAMENTE esa cantidad de plazos
+   *      (cuotas) restantes. No escala a plazos vecinos.
+   *      Si los créditos de ese plazo no cubren el monto, se devuelven igual
+   *      los que haya (o ninguno); el faltante queda sin asignar.
+   *
    * Prioridad de modos: solo_insertable > minimo > default (todos)
+   * plazo_objetivo es ortogonal: filtra antes, y luego se aplica el modo.
+   *
+   * OJO con `total_sin_filtro` en la respuesta: cuenta los candidatos que
+   * devolvió el controller, o sea DESPUÉS del filtro de plazo_objetivo y antes
+   * del modo. Con plazo_objetivo=12 y 3 candidatos de 400, dice 3 — no 400.
+   * Si el front necesita el "3 de 400", ese total pre-filtro hoy no sale de
+   * getCreditCandidates y hay que exponerlo aparte.
    */
   .get("/assign-capital/candidates", async ({ query, set }) => {
     const {
@@ -34,6 +47,7 @@ export const assignCapitalRouter = new Elysia()
       minimo: minimoStr,
       inversionista_id: inversionistaIdStr,
       porcentaje: porcentajeStr,
+      plazo_objetivo: plazoObjetivoStr,
     } = query as Record<string, string | undefined>;
 
     // ── Validar monto ──────────────────────────────────────────
@@ -89,8 +103,19 @@ export const assignCapitalRouter = new Elysia()
       porcentaje = parsed;
     }
 
+    // ── Validar plazo_objetivo ─────────────────────────────────
+    let plazoObjetivo: number | undefined;
+    if (plazoObjetivoStr !== undefined && plazoObjetivoStr !== "") {
+      const parsed = Number(plazoObjetivoStr);
+      if (isNaN(parsed) || parsed < 1 || !Number.isInteger(parsed)) {
+        set.status = 400;
+        return { ok: false, message: "El parámetro 'plazo_objetivo' debe ser un entero positivo (ej: 12)." };
+      }
+      plazoObjetivo = parsed;
+    }
+
     try {
-      const allCandidates = await getCreditCandidates(monto, minimo, inversionista_id, porcentaje);
+      const allCandidates = await getCreditCandidates(monto, minimo, inversionista_id, porcentaje, plazoObjetivo);
 
       let result: CreditCandidate[];
 
@@ -114,10 +139,13 @@ export const assignCapitalRouter = new Elysia()
       return {
         ok: true,
         total: result.length,
+        // "sin filtro" = sin el modo (solo_insertable / minimo). El filtro de
+        // plazo_objetivo, si vino, YA se aplicó: no es el universo completo.
         total_sin_filtro: allCandidates.length,
         monto_buscado: monto ?? null,
         solo_insertable: soloInsertable,
         minimo: minimo ?? null,
+        plazo_objetivo: plazoObjetivo ?? null,
         capital_acumulado: soloInsertable
           ? result.reduce((acc, c) => acc + c.capital_activo, 0)
           : null,


### PR DESCRIPTION
## Qué hace

Agrega `plazoObjetivo` (opcional) a `getCreditCandidates` y lo expone como query param `plazo_objetivo` en `GET /assign-capital/candidates`.

**Filtro estricto:** solo entran créditos con **exactamente** esa cantidad de plazos restantes. No escala a plazos vecinos — si los créditos de ese plazo no alcanzan a cubrir el monto pedido, se devuelven igual los que haya (o ninguno), y el faltante queda sin asignar.

```
GET /assign-capital/candidates?monto=10000000&plazo_objetivo=52
→ 13 créditos, todos de plazo 52, sumando Q765k de los Q10M pedidos.
  No toca los plazos 51/53/54 aunque existan y tengan capital.
```

## Cálculo de plazos restantes

`total_cuotas − max(numero_cuota donde pagado)` — o sea, recorrer las cuotas en orden descendente hasta la primera pagada, y contar las que quedan por encima.

⚠️ **Los huecos no se cuentan.** Si un crédito tiene la cuota 3 impaga pero pagó la 5, la mayor pagada es la 5 y los restantes salen de ahí. En prod hay **2 créditos de 136** en esa situación (el 222 y el 43), donde este número difiere en 2 del "contar impagas reales". Es la regla de negocio pedida, pero vale tenerlo presente.

## Detalles de implementación

- El filtro corre **después del scoring y antes del `limit`**, para que `minimo=N` recorte la lista ya filtrada por plazo y no al revés. Verificado: un crédito en la posición #33 del ranking global sigue apareciendo con `minimo=3`.
- Nuevo campo `plazos_restantes` en `CreditCandidate` — se llena siempre, venga o no el parámetro.
- Se fusiona la query de `MAX(numero_cuota)` con la de `COUNT(*)` de cuotas pagadas: compartían `WHERE` y `GROUP BY`, así que era un round-trip de más a la DB.
- El parámetro es **opcional y va al final de la firma**: `addInvestorToCredit` sigue llamando con 4 args y su comportamiento no cambia. No se tocó el frontend.

## Verificación

**Tests:** 11 nuevos en `assignCapital.test.ts`, sin DB (mockea `../database` como ya hacen `latefee.test.ts` y `payments.test.ts`). Typecheck limpio.

**Contra la base de producción, solo lectura:**
- 136 candidatos verificados contra las cuotas crudas: **0 discrepancias** entre lo que devuelve el API y lo que dice la DB.
- Regresión: sin `plazo_objetivo` devuelve los mismos 136 candidatos que antes, con el campo en `null`.
- Filtro estricto confirmado: con monto de Q10M y `plazo_objetivo=52`, no escala a los vecinos.
- Validaciones: `abc`, `0`, `-5`, `12.5` → 400. Vacío → se ignora (sin filtro).

## Nota de negocio

**No existe ningún crédito con 12 plazos restantes**, ni en dev ni en prod. Los plazos reales van de 18 a 83, concentrados en 52-59 y 76-83. Si el flujo va a pedir 12, va a recibir lista vacía siempre — vale confirmar con negocio qué plazo se va a usar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)