### PR TITLE
feat(cartera): plazo_inversionista en compra de cartera (guardado + escalada por rondas opcional)

### DIFF
--- a/apps/cartera-back/drizzle/0019_add_plazo_inversionista.sql
+++ b/apps/cartera-back/drizzle/0019_add_plazo_inversionista.sql
@@ -1,0 +1,15 @@
+-- Plazo propio del inversionista (en meses): en cuánto tiempo saca su inversión.
+-- Hoy el abono a capital se deriva del plazo del crédito; esta columna guarda el
+-- plazo que el inversionista define al hacer la compra de cartera / reinversión.
+-- Por ahora SOLO se persiste (front -> backend -> insert); la lógica de cálculo
+-- que lo use vendrá después.
+--
+-- Nullable a propósito: los registros históricos no tienen plazo propio y la
+-- lógica actual (plazo del crédito) sigue aplicando cuando es NULL.
+-- Cartera aplica el SQL a mano (no drizzle-kit).
+
+ALTER TABLE cartera.creditos_inversionistas_espejo
+  ADD COLUMN IF NOT EXISTS plazo_inversionista integer;
+
+ALTER TABLE cartera.compras_credito_inversionista
+  ADD COLUMN IF NOT EXISTS plazo_inversionista integer;

--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -81,6 +81,17 @@ const addInvestorToCreditSchema = z.object({
   // Se sigue aceptando por compatibilidad, pero YA NO se usa para actualizar
   // la fecha de las filas (ni del inversionista nuevo ni del existente).
   fecha_inicio_participacion: z.string().optional(),
+  // Plazo propio del inversionista en meses (en cuánto tiempo saca su
+  // inversión). Siempre se persiste en espejo y compras. NULL = usa el
+  // plazo del crédito.
+  plazo_inversionista: z.number().int().positive().optional(),
+  // VARIANTE 1 vs 2 del plazo:
+  //   true / ausente → el plazo también FILTRA candidatos (escalada por
+  //                    rondas de cuotas pendientes).
+  //   false          → el plazo SOLO se guarda; los candidatos se eligen
+  //                    con el flujo normal (variante 2: no importa qué
+  //                    crédito cede, solo dejar definido el plazo).
+  usar_plazo_en_candidatos: z.boolean().optional(),
   // Nuevos campos para el buscador de capital
   minimo: z.number().int().positive().optional(),
   // MODO MANUAL: arreglo de { credito_id, monto }. Si viene (y no vacío) se
@@ -335,6 +346,8 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
       tipo_reinversion,
       // NOTA: fecha_inicio_participacion se sigue aceptando en el body pero
       // ya NO se desestructura ni se usa: no actualiza la fecha de las filas.
+      plazo_inversionista,
+      usar_plazo_en_candidatos,
       minimo,
       manual,
     } = parseResult.data;
@@ -499,6 +512,139 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
           message:
             "No se encontraron créditos candidatos compatibles (todos tienen alguna modalidad ya asignada)",
           descartados: filtradosPorTipoReinversion,
+        };
+      }
+    }
+
+    // ================================================================
+    // ESCALADA POR PLAZO (solo modo AUTOMÁTICO con plazo_inversionista)
+    // El inversionista define en cuántos meses saca su inversión. La compra
+    // se llena POR RONDAS: primero créditos con cuotas pendientes == plazo;
+    // si el CUBE disponible no cubre el monto, se escala a plazo+1, plazo+2,
+    // ... hasta cubrir el monto o agotar la cartera elegible (no hay créditos
+    // con más cuotas pendientes). Si aun así no alcanza, la compra queda
+    // PARCIAL como siempre (monto_sin_asignar > 0).
+    // El orden de rondas se respeta en la distribución: un crédito que cumple
+    // el plazo SIEMPRE se llena antes que uno de plazo mayor, sin importar
+    // el score (dentro de cada ronda sí manda el score).
+    //
+    // ⚠️ SIMULACIÓN DEL GET POR PLAZO: getCreditCandidates aún NO recibe
+    // `plazo` (lo está trabajando el equipo del buscador). Mientras tanto se
+    // pide la lista completa UNA vez (arriba) y cada ronda se simula en
+    // memoria con total_cuotas - cuotas_pagadas, que el candidato ya trae.
+    // Cuando el GET soporte plazo (filtro cuotas pendientes == plazo), cada
+    // ronda se reemplaza por una llamada real:
+    //   await getCreditCandidates(monto_aportado, minimo, inversionista_id,
+    //     porcentaje_inversion, plazoActual)
+    // y se elimina rondaPorPlazo/maxPendientes (el corte de "cartera agotada"
+    // pasa a ser N rondas seguidas sin resultados).
+    // ================================================================
+    let escaladaPlazoInfo:
+      | {
+          plazo_solicitado: number;
+          plazo_final: number;
+          capacidad_cube: string;
+          rondas: {
+            plazo: number;
+            creditos: number;
+            capacidad_acumulada: string;
+          }[];
+        }
+      | undefined;
+
+    // usar_plazo_en_candidatos === false → VARIANTE 2: el plazo solo se
+    // guarda (espejo + compras); la selección de candidatos es la normal.
+    if (
+      !esManual &&
+      plazo_inversionista !== undefined &&
+      usar_plazo_en_candidatos !== false
+    ) {
+      // Capacidad real de un candidato = monto de CUBE en el PADRE, que es el
+      // tope que la distribución puede tomar de ese crédito (ver PASO 3b).
+      const capacidadCube = (c: CreditCandidate): Big => {
+        const cube = (c.credito_completo?.inversionistas_detalle ?? []).find(
+          (inv: any) => inv.inversionista_id === CUBE_INVESTMENT_ID,
+        );
+        return cube ? new Big(cube.monto_aportado) : new Big(0);
+      };
+
+      const cuotasPendientes = (c: CreditCandidate) =>
+        c.total_cuotas - c.cuotas_pagadas;
+
+      // SIMULACIÓN: una "llamada" al GET con plazo == N. Mantiene el orden
+      // por score que ya trae la lista y replica el corte por `minimo` que el
+      // GET real aplicaría por llamada.
+      const rondaPorPlazo = (plazo: number): CreditCandidate[] => {
+        const ronda = candidatos.filter((c) => cuotasPendientes(c) === plazo);
+        if (minimo !== undefined) ronda.splice(minimo);
+        return ronda;
+      };
+
+      // Techo de escalada: no existe crédito con más cuotas pendientes que
+      // esto, así que iterar más allá nunca agrega candidatos.
+      const maxPendientes = candidatos.reduce(
+        (max, c) => Math.max(max, cuotasPendientes(c)),
+        0,
+      );
+
+      const objetivo = new Big(monto_aportado);
+      const seleccionados: CreditCandidate[] = [];
+      const rondasLog: {
+        plazo: number;
+        creditos: number;
+        capacidad_acumulada: string;
+      }[] = [];
+      let capacidad = new Big(0);
+      let plazoActual = plazo_inversionista;
+      let plazoFinal = plazo_inversionista;
+
+      console.log("================================================================");
+      console.log(
+        `[addInvestorToCredit] ESCALADA POR PLAZO: objetivo Q${objetivo}, plazo solicitado ${plazo_inversionista}, techo ${maxPendientes} cuotas pendientes`,
+      );
+
+      while (capacidad.lt(objetivo) && plazoActual <= maxPendientes) {
+        const ronda = rondaPorPlazo(plazoActual);
+        for (const c of ronda) {
+          seleccionados.push(c);
+          capacidad = capacidad.plus(capacidadCube(c));
+        }
+        if (ronda.length > 0) {
+          plazoFinal = plazoActual;
+          rondasLog.push({
+            plazo: plazoActual,
+            creditos: ronda.length,
+            capacidad_acumulada: capacidad.toString(),
+          });
+          console.log(
+            ` - Ronda plazo ${plazoActual}: ${ronda.length} crédito(s), capacidad CUBE acumulada Q${capacidad}`,
+          );
+        }
+        plazoActual++;
+      }
+
+      if (capacidad.lt(objetivo)) {
+        console.log(
+          `⚠️ Cartera agotada en plazo ${plazoFinal}: capacidad Q${capacidad} < objetivo Q${objetivo}. La compra quedará PARCIAL.`,
+        );
+      }
+      console.log("================================================================");
+
+      candidatos = seleccionados;
+
+      escaladaPlazoInfo = {
+        plazo_solicitado: plazo_inversionista,
+        plazo_final: plazoFinal,
+        capacidad_cube: capacidad.toString(),
+        rondas: rondasLog,
+      };
+
+      if (candidatos.length === 0) {
+        set.status = 404;
+        return {
+          success: false,
+          message: `No se encontraron créditos candidatos con ${plazo_inversionista} o más cuotas pendientes`,
+          escalada_plazo: escaladaPlazoInfo,
         };
       }
     }
@@ -761,6 +907,16 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
           (espejoActual ?? []).map((e: any) => [
             e.inversionista_id as number,
             e.tipo_reinversion ?? null,
+          ]),
+        );
+
+        // ── Mapa de plazo_inversionista actual por inversionista en el espejo ──
+        // Mismo patrón que tipo_reinversion: el nuke & rebuild del espejo
+        // borraría el plazo de los OTROS inversionistas si no lo preservamos.
+        const plazoActualPorInv = new Map<number, number | null>(
+          (espejoActual ?? []).map((e: any) => [
+            e.inversionista_id as number,
+            e.plazo_inversionista ?? null,
           ]),
         );
 
@@ -1061,6 +1217,16 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
                 tipoReinvActualPorInv.get(inv.inversionista_id) ??
                 null
               : tipoReinvActualPorInv.get(inv.inversionista_id) ?? null,
+          // plazo_inversionista (misma lógica de preservación que tipo_reinversion):
+          //   - target: si viene en el request lo usa; si no, preserva el
+          //     valor previo del espejo.
+          //   - resto: preserva el valor existente del espejo.
+          plazo_inversionista:
+            inv.inversionista_id === inversionista_id
+              ? plazo_inversionista ??
+                plazoActualPorInv.get(inv.inversionista_id) ??
+                null
+              : plazoActualPorInv.get(inv.inversionista_id) ?? null,
           updated_at: new Date(),
         }));
 
@@ -1097,6 +1263,9 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
             tipo_reinversion ??
             tipoReinvActualPorInv.get(inversionista_id) ??
             null,
+          // Plazo propio del inversionista para ESTA operación (solo lo que
+          // vino en el request; el registro histórico no se hereda del espejo).
+          plazo_inversionista: plazo_inversionista ?? null,
           status: statusEspejo,
         });
 
@@ -1228,6 +1397,9 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
       monto_sin_asignar: montoRestante.toString(),
       resultados,
       errores,
+      // Presente solo cuando la compra automática vino con plazo_inversionista:
+      // detalle de las rondas de escalada (plazo → créditos → capacidad CUBE).
+      ...(escaladaPlazoInfo && { escalada_plazo: escaladaPlazoInfo }),
     };
   } catch (error) {
     console.error("[addInvestorToCredit] Error:", error);

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -549,6 +549,8 @@
       aceptada_at: timestamp("aceptada_at", { withTimezone: true }),
       aceptada_por: text("aceptada_por"),
       compra_cartera_extendida_at: timestamp("compra_cartera_extendida_at", { withTimezone: true }),
+      // Plazo propio del inversionista en meses (NULL = usa el plazo del crédito).
+      plazo_inversionista: integer("plazo_inversionista"),
     },
     (t) => ({
       uxCreditoInvEspejo: uniqueIndex("ux_credito_inversionista_espejo").on(t.credito_id, t.inversionista_id),
@@ -582,6 +584,8 @@
       fecha: timestamp("fecha", { withTimezone: true }).notNull().$default(() => new Date()),
       created_at: timestamp("created_at", { withTimezone: true }).notNull().$default(() => new Date()),
       updated_at: timestamp("updated_at", { withTimezone: true }),
+      // Plazo propio del inversionista en meses (NULL = usa el plazo del crédito).
+      plazo_inversionista: integer("plazo_inversionista"),
     },
     (t) => ({
       ixStatus: index("ix_compras_credito_inv_status").on(t.status),

--- a/apps/cartera-back/src/routers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/routers/addInvestorToCredit.ts
@@ -31,6 +31,12 @@ export const addInvestorToCreditRouter = new Elysia()
         ]),
       ),
       fecha_inicio_participacion: t.Optional(t.String()),
+      // Plazo propio del inversionista en meses (en cuánto tiempo saca su
+      // inversión). Siempre se persiste en espejo y compras.
+      plazo_inversionista: t.Optional(t.Integer({ minimum: 1 })),
+      // true/ausente → el plazo también filtra candidatos (escalada por rondas).
+      // false → variante 2: el plazo solo se guarda; candidatos con flujo normal.
+      usar_plazo_en_candidatos: t.Optional(t.Boolean()),
       minimo: t.Optional(t.Number({ minimum: 1 })),
       // MODO MANUAL: arreglo de { credito_id, monto }. Si viene, se ignora el
       // buscador de candidatos y se opera SOLO sobre estos créditos. La suma

--- a/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
+++ b/apps/carteraFront/src/private/cartera/components/tableInvestors.tsx
@@ -334,6 +334,14 @@ export function TableInvestors() {
   const [compraCarteraOpen, setCompraCarteraOpen] = useState(false);
   const [compraCarteraInvId, setCompraCarteraInvId] = useState<number | null>(null);
   const [compraCarteraMonto, setCompraCarteraMonto] = useState("");
+  // Plazo propio del inversionista en meses (en cuánto tiempo saca su
+  // inversión). Opcional: vacío = usa el plazo del crédito. Siempre se
+  // guarda (espejo y compras).
+  const [compraCarteraPlazo, setCompraCarteraPlazo] = useState("");
+  // true → el plazo también filtra los créditos candidatos (variante 1:
+  // escalada por rondas de cuotas pendientes). false → variante 2: el plazo
+  // solo se guarda y los créditos se eligen con el flujo normal.
+  const [compraCarteraUsarPlazo, setCompraCarteraUsarPlazo] = useState(true);
   const [compraCarteraPctInv, setCompraCarteraPctInv] = useState("70");
   const [compraCarteraPctCashIn, setCompraCarteraPctCashIn] = useState("30");
   const [compraCarteraTipoReinversion, setCompraCarteraTipoReinversion] =
@@ -562,6 +570,8 @@ export function TableInvestors() {
   const handleAbrirCompraCartera = (inv: any) => {
     setCompraCarteraInvId(inv.inversionista_id);
     setCompraCarteraMonto("");
+    setCompraCarteraPlazo("");
+    setCompraCarteraUsarPlazo(true);
     setCompraCarteraManual(false);
     setCompraCarteraManualList([]);
     setCompraCarteraTipoReinversion("sin_reinversion");
@@ -2754,6 +2764,44 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                 />
               </div>
             )}
+            <div>
+              <label htmlFor="compra-plazo" className="text-sm font-medium text-gray-700">
+                Plazo del inversionista (meses)
+              </label>
+              <Input
+                id="compra-plazo"
+                type="number"
+                min={1}
+                step="1"
+                placeholder="Vacío = plazo del crédito"
+                value={compraCarteraPlazo}
+                onChange={(e) => setCompraCarteraPlazo(e.target.value)}
+                className="mt-1 !bg-white !border-gray-300 !text-gray-900 placeholder:text-gray-400 focus:!border-emerald-500 focus:!ring-emerald-500/30"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                En cuánto tiempo el inversionista saca su inversión.
+              </p>
+            </div>
+            {/* Solo aplica si se ingresó un plazo: define si el plazo además
+                filtra los créditos candidatos (variante 1) o solo se guarda
+                (variante 2). */}
+            {compraCarteraPlazo && Number(compraCarteraPlazo) > 0 && !compraCarteraManual && (
+              <div className="flex items-center justify-between rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5">
+                <div className="pr-3">
+                  <label htmlFor="compra-usar-plazo" className="text-sm font-medium text-gray-700 cursor-pointer">
+                    Usar plazo para elegir créditos
+                  </label>
+                  <p className="text-xs text-gray-500">
+                    Apagado: el plazo solo se guarda y los créditos se eligen como siempre.
+                  </p>
+                </div>
+                <Switch
+                  id="compra-usar-plazo"
+                  checked={compraCarteraUsarPlazo}
+                  onCheckedChange={setCompraCarteraUsarPlazo}
+                />
+              </div>
+            )}
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <label htmlFor="compra-pct-inv" className="text-sm font-medium text-gray-700">
@@ -2837,6 +2885,13 @@ const tieneBoletaPendiente = inv.tieneBoletaPendiente ?? false;
                     tipo_reinversion: compraCarteraTipoReinversion,
                     porcentaje_inversion: Number(compraCarteraPctInv),
                     porcentaje_cash_in: Number(compraCarteraPctCashIn),
+                    ...(compraCarteraPlazo &&
+                      Number(compraCarteraPlazo) > 0 && {
+                        plazo_inversionista: Math.round(
+                          Number(compraCarteraPlazo),
+                        ),
+                        usar_plazo_en_candidatos: compraCarteraUsarPlazo,
+                      }),
                     ...(compraCarteraManual && {
                       manual: compraCarteraManualList.map((c) => ({
                         credito_id: c.credito_id,

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -3992,6 +3992,14 @@ export interface AgregarInversionistaCreditoPayload {
   fecha_inicio_participacion?: string;
   porcentaje_cash_in?: number;
   porcentaje_inversion?: number;
+  // Plazo propio del inversionista en meses (en cuánto tiempo saca su
+  // inversión). Opcional: si no viene, aplica el plazo del crédito. Siempre
+  // se persiste en espejo y compras.
+  plazo_inversionista?: number;
+  // true/ausente → el plazo también filtra los créditos candidatos (escalada
+  // por rondas de cuotas pendientes). false → variante 2: el plazo solo se
+  // guarda y los créditos se eligen con el flujo normal.
+  usar_plazo_en_candidatos?: boolean;
   // MODO MANUAL: créditos específicos con su monto. Si viene, el backend
   // ignora el buscador de candidatos y opera solo sobre estos. La suma de los
   // montos debe igualar monto_aportado.


### PR DESCRIPTION
## Qué hace

Los inversionistas pueden definir en cuántos meses sacan su inversión (`plazo_inversionista`, en meses). Este PR agrega el guardado del dato de punta a punta y la primera versión de la selección de candidatos por plazo, con switch para activarla o no.

### DB (migración `0019_add_plazo_inversionista.sql` — se aplica a mano, aún NO corrida en dev/prod)
- Columna `plazo_inversionista integer` (nullable) en `cartera.creditos_inversionistas_espejo` y `cartera.compras_credito_inversionista`. `NULL` = aplica el plazo del crédito (registros históricos intactos).

### Front (modal Compra de Cartera)
- Campo opcional **"Plazo del inversionista (meses)"** (modo normal y manual).
- Switch **"Usar plazo para elegir créditos"** (aparece solo si hay plazo, default encendido).

### Backend (`/agregar-inversionista-credito`)
- El plazo **siempre se persiste** en espejo y compras. En el nuke&rebuild del espejo se preserva el plazo de los demás inversionistas (mismo patrón que `tipo_reinversion`).
- **Variante 1** (`usar_plazo_en_candidatos` true/ausente): escalada POR RONDAS — primero créditos con cuotas pendientes == plazo; si el CUBE disponible no cubre el monto, escala a plazo+1, +2… hasta cubrirlo o agotar la cartera elegible; si no alcanza, compra parcial como siempre. Un crédito que cumple el plazo siempre se llena antes que uno de plazo mayor. La respuesta incluye `escalada_plazo` con el detalle de rondas.
- **Variante 2** (`usar_plazo_en_candidatos: false`): el plazo solo se guarda; los candidatos salen del flujo normal por score.

### Nota de integración
El filtro por plazo dentro del GET de candidatos se **simula en memoria** (`total_cuotas - cuotas_pagadas`, bloque marcado ⚠️ SIMULACIÓN en el controller). Con el filtro real de assign-capital ya mergeado en esta rama (#1092), el siguiente paso es reemplazar `rondaPorPlazo` por la llamada real por ronda.

## Pruebas (copia de prod restaurada en local)
- Compra Q150k plazo 6: escaló rondas 18 → 27 → 28 → 32, se detuvo al cubrir el monto y llenó respetando el orden de rondas; las 4 operaciones quedaron con plazo 6 en ambas tablas.
- Variante 2 (flag off): candidato elegido por score puro, sin `escalada_plazo`, y el plazo igual quedó guardado.
- Preservación: una compra posterior de otro inversionista no borra el plazo existente del primero.
- Regresión: compra sin plazo = flujo idéntico al actual. `tsc` limpio en cartera-back y carteraFront.

🤖 Generated with [Claude Code](https://claude.com/claude-code)