### PR TITLE
🚀 Pase a Producción — Calculadora de Inversión (plazos anuales + Proyección Anual) y CRM (plantilla impuesto de circulación + rebalanceo de leads)

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -18,6 +18,7 @@ on:
       - "apps/backend-2/**"
       - "apps/legal-documents/**"
       - "apps/legal-docs-blueprints/**"
+      - "apps/investment-calculator/**"
       - "packages/**"
       - "package.json"
       - "bun.lock"
@@ -39,6 +40,7 @@ on:
           - backend-2
           - legal-documents
           - legal-docs-blueprints
+          - investment
 
 env:
   AWS_REGION: us-east-1
@@ -104,9 +106,11 @@ jobs:
               - 'apps/legal-documents/**'
             legal-docs-blueprints:
               - 'apps/legal-docs-blueprints/**'
+            investment:
+              - 'apps/investment-calculator/**'
       - id: pick
         run: |
-          ALL='["cartera-back","cartera-front","crm-api","crm-web","portal-web","auth-google","backend-2","legal-documents","legal-docs-blueprints"]'
+          ALL='["cartera-back","cartera-front","crm-api","crm-web","portal-web","auth-google","backend-2","legal-documents","legal-docs-blueprints","investment"]'
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${{ inputs.app }}" = "all" ]; then
               echo "apps=$ALL" >> "$GITHUB_OUTPUT"
@@ -163,6 +167,7 @@ jobs:
             auth-google)     CTX=.                    FILE=apps/auth-google/Dockerfile         IMAGE=cci/better-auth-api ;;
             backend-2)       CTX=.                    FILE=apps/backend-2/Dockerfile           IMAGE=cci/backend ;;
             legal-documents) CTX=apps/legal-documents FILE=apps/legal-documents/Dockerfile     IMAGE=cci/legal-documents ;;
+            investment)      CTX=apps/investment-calculator FILE=apps/investment-calculator/Dockerfile IMAGE=cci/investment ;;
             *) echo "App desconocida"; exit 1 ;;
           esac
           podman build -f "$FILE" "$CTX" \
@@ -188,6 +193,7 @@ jobs:
           WH_BACKEND_2: ${{ secrets.COOLIFY_WEBHOOK_BACKEND_2_PROD }}
           WH_LEGAL_DOCUMENTS: ${{ secrets.COOLIFY_WEBHOOK_LEGAL_DOCUMENTS_PROD }}
           WH_LEGAL_DOCS_BLUEPRINTS: ${{ secrets.COOLIFY_WEBHOOK_LEGAL_DOCS_BLUEPRINTS_PROD }}
+          WH_INVESTMENT: ${{ secrets.COOLIFY_WEBHOOK_INVESTMENT_PROD }}
         run: |
           case "${{ matrix.app }}" in
             cartera-back)    WEBHOOK="$WH_CARTERA_BACK" ;;
@@ -199,6 +205,7 @@ jobs:
             backend-2)       WEBHOOK="$WH_BACKEND_2" ;;
             legal-documents) WEBHOOK="$WH_LEGAL_DOCUMENTS" ;;
             legal-docs-blueprints) WEBHOOK="$WH_LEGAL_DOCS_BLUEPRINTS" ;;
+            investment)      WEBHOOK="$WH_INVESTMENT" ;;
           esac
           if [ -z "$WEBHOOK" ]; then
             echo "::notice::Sin webhook configurado para ${{ matrix.app }}; imagen pusheada pero sin redeploy automático."

--- a/apps/crm/apps/server/src/controllers/bot.ts
+++ b/apps/crm/apps/server/src/controllers/bot.ts
@@ -449,6 +449,10 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 				lastName: renapData.firstLastName,
 				maritalStatus: mapCivilStatusToEnum(renapData.civil_status),
 				assignedTo,
+				assignmentType:
+					assignedTo === existingLead[0].assignedTo
+						? existingLead[0].assignmentType
+						: "auto",
 				status: "new",
 				age: age ?? existingLead[0].age,
 				updatedAt: new Date(),

--- a/apps/crm/apps/server/src/controllers/bot.ts
+++ b/apps/crm/apps/server/src/controllers/bot.ts
@@ -12,12 +12,13 @@ import {
 } from "@/db/schema";
 import type { documentTypeEnum } from "@/db/schema/documents";
 import { getRenapData } from "@/functions/getRenapInfo";
+import { resolveExistingLeadAssigneeFromDatabase } from "@/lib/lead-assignment";
+import { getOpenOpportunityBySource } from "@/lib/lead-opportunity";
 import { generateUniqueFilename, uploadFileFromUrlToR2 } from "@/lib/storage";
 import { salesUser } from "@/utils/constants";
 import { db } from "../db";
 import { validarDpi } from "../utils/cui-validation";
 import { otpController } from "./otp";
-import { getOpenOpportunityBySource } from "./public-lead";
 
 // Type for document type enum
 type DocumentType = (typeof documentTypeEnum.enumValues)[number];
@@ -430,13 +431,24 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 		createdByUserId = salesUser;
 	} else {
 		console.log("[DEBUG] DPI found in leads. Updating existing lead.");
+		const assignedTo = await resolveExistingLeadAssigneeFromDatabase(
+			existingLead[0].assignedTo,
+		);
+
+		if (!assignedTo) {
+			return {
+				success: false,
+				message: "No sales user available to assign the reactivated lead",
+			};
+		}
+
 		await db
 			.update(leads)
 			.set({
 				firstName: renapData.firstName,
 				lastName: renapData.firstLastName,
 				maritalStatus: mapCivilStatusToEnum(renapData.civil_status),
-				assignedTo: existingLead[0].assignedTo,
+				assignedTo,
 				status: "new",
 				age: age ?? existingLead[0].age,
 				updatedAt: new Date(),
@@ -444,7 +456,7 @@ export const getRenapInfoController = async (dpi: string, phone: string) => {
 			})
 			.where(eq(leads.dpi, dpi));
 		leadId = existingLead[0].id;
-		assignedUserId = existingLead[0].assignedTo;
+		assignedUserId = assignedTo;
 		createdByUserId = existingLead[0].createdBy;
 	}
 

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -1,15 +1,19 @@
-import { and, asc, count, desc, eq, gte, or } from "drizzle-orm";
+import { and, asc, count, eq, or } from "drizzle-orm";
 import type { Context } from "hono";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import {
-	leadSourceEnum,
+	type leadSourceEnum,
 	leads,
 	opportunities,
 	salesStages,
 } from "../db/schema/crm";
-import { canReceiveAutoAssignedLead } from "../lib/lead-assignment";
+import {
+	findSalesUserWithLeastAutoAssignedLeads,
+	resolveExistingLeadAssigneeFromDatabase,
+} from "../lib/lead-assignment";
 import { getPublicLeadExistingOpportunityUpdates } from "../lib/lead-helpers";
+import { getOpenOpportunityBySource } from "../lib/lead-opportunity";
 import { validarDpi } from "../utils/cui-validation";
 import { getOnlyRenapInfoController } from "./bot";
 
@@ -30,7 +34,13 @@ export async function getSalesUserWithLeastOpportunities() {
 			role: user.role,
 		})
 		.from(user)
-		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true), eq(user.banned, false)));
+		.where(
+			and(
+				eq(user.role, "sales"),
+				eq(user.assignLeads, true),
+				eq(user.banned, false),
+			),
+		);
 
 	if (salesUsers.length === 0) {
 		return null;
@@ -69,68 +79,9 @@ export async function getSalesUserWithLeastOpportunities() {
 	return minUser;
 }
 
-/**
- * Encuentra al usuario de ventas con menos leads asignados.
- * Si hay empate, retorna el primero encontrado.
- * Si no hay usuarios de ventas, retorna null.
- */
-export async function getSalesUserWithLeastLeads() {
-	// Obtener todos los usuarios de ventas activos (no baneados)
-	const salesUsers = await db
-		.select({
-			id: user.id,
-			name: user.name,
-			email: user.email,
-			role: user.role,
-		})
-		.from(user)
-		.where(and(eq(user.role, "sales"), eq(user.assignLeads, true), eq(user.banned, false)));
-
-	if (salesUsers.length === 0) {
-		return null;
-	}
-
-	// Contar leads automáticos asignados hoy por usuario (hora Guatemala UTC-6)
-	const startOfToday = new Date(
-		new Date().toLocaleDateString("en-US", { timeZone: "America/Guatemala" }),
-	);
-
-	const leadCounts = await db
-		.select({
-			assignedTo: leads.assignedTo,
-			count: count(leads.id),
-		})
-		.from(leads)
-		.where(
-			and(
-				eq(leads.assignmentType, "auto"),
-				gte(leads.createdAt, startOfToday),
-			),
-		)
-		.groupBy(leads.assignedTo);
-
-	// Crear un mapa de conteos
-	const countMap = new Map<string, number>();
-	for (const lc of leadCounts) {
-		if (lc.assignedTo) {
-			countMap.set(lc.assignedTo, lc.count);
-		}
-	}
-
-	// Encontrar el usuario de ventas con menos leads
-	let minUser = salesUsers[0];
-	let minCount = countMap.get(minUser.id) ?? 0;
-
-	for (const salesUser of salesUsers) {
-		const userCount = countMap.get(salesUser.id) ?? 0;
-		if (userCount < minCount) {
-			minCount = userCount;
-			minUser = salesUser;
-		}
-	}
-
-	return minUser;
-}
+export {
+	findSalesUserWithLeastAutoAssignedLeads as getSalesUserWithLeastLeads,
+};
 
 /**
  * Crea una nueva oportunidad vinculada a un lead
@@ -180,57 +131,6 @@ export async function createOpportunityForLead(
 	return newOpportunity;
 }
 
-/**
- * Verifica si un lead ya tiene una oportunidad abierta con el mismo source.
- */
-export async function getOpenOpportunityBySource(
-	leadId: string,
-	source: LeadSource,
-) {
-	const [existing] = await db
-		.select({
-			id: opportunities.id,
-			source: opportunities.source,
-			campaign: opportunities.campaign,
-			creditType: opportunities.creditType,
-		})
-		.from(opportunities)
-		.where(
-			and(
-				eq(opportunities.leadId, leadId),
-				or(
-					eq(opportunities.status, "open"),
-					eq(opportunities.status, "on_hold"),
-				),
-			),
-		)
-		.orderBy(desc(opportunities.createdAt))
-		.limit(1);
-	return existing;
-}
-
-async function resolveLeadAssignee(existingAssignedTo?: string | null) {
-	if (existingAssignedTo) {
-		const [currentOwner] = await db
-			.select({
-				id: user.id,
-				role: user.role,
-				assignLeads: user.assignLeads,
-				banned: user.banned,
-			})
-			.from(user)
-			.where(eq(user.id, existingAssignedTo))
-			.limit(1);
-
-		if (canReceiveAutoAssignedLead(currentOwner)) {
-			return currentOwner.id;
-		}
-	}
-
-	const fallbackSalesUser = await getSalesUserWithLeastLeads();
-	return fallbackSalesUser?.id ?? null;
-}
-
 export async function createPublicLead(c: Context) {
 	try {
 		const body = await c.req.json();
@@ -257,10 +157,7 @@ export async function createPublicLead(c: Context) {
 		if (hasDpi) {
 			const resultadoDpi = validarDpi(body.dpi);
 			if (!resultadoDpi.valid) {
-				return c.json(
-					{ success: false, error: resultadoDpi.error },
-					400,
-				);
+				return c.json({ success: false, error: resultadoDpi.error }, 400);
 			}
 			body.dpi = resultadoDpi.dpiLimpio;
 		}
@@ -279,8 +176,7 @@ export async function createPublicLead(c: Context) {
 		// --- Lead existente ---
 		if (existingLead) {
 			const source = body.source || existingLead.source || "website";
-			const campaign =
-				body.campaign || existingLead.campaign || undefined;
+			const campaign = body.campaign || existingLead.campaign || undefined;
 			let leadData = existingLead;
 
 			if (body.isRegister) {
@@ -308,11 +204,13 @@ export async function createPublicLead(c: Context) {
 				source,
 			);
 			if (existingOpportunity) {
-				const opportunityUpdates =
-					getPublicLeadExistingOpportunityUpdates(existingOpportunity, {
+				const opportunityUpdates = getPublicLeadExistingOpportunityUpdates(
+					existingOpportunity,
+					{
 						campaign: body.campaign,
 						creditType,
-					});
+					},
+				);
 
 				if (Object.keys(opportunityUpdates).length > 0) {
 					await db
@@ -335,7 +233,9 @@ export async function createPublicLead(c: Context) {
 				);
 			}
 
-			const assignedTo = await resolveLeadAssignee(existingLead.assignedTo);
+			const assignedTo = await resolveExistingLeadAssigneeFromDatabase(
+				existingLead.assignedTo,
+			);
 
 			if (!assignedTo) {
 				return c.json(
@@ -410,7 +310,7 @@ export async function createPublicLead(c: Context) {
 		}
 
 		// --- Lead nuevo: mismo asesor para lead y oportunidad ---
-		const salesUserForLead = await getSalesUserWithLeastLeads();
+		const salesUserForLead = await findSalesUserWithLeastAutoAssignedLeads();
 
 		if (!salesUserForLead) {
 			return c.json(

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -252,6 +252,7 @@ export async function createPublicLead(c: Context) {
 					.update(leads)
 					.set({
 						assignedTo,
+						assignmentType: "auto",
 						updatedAt: new Date(),
 					})
 					.where(eq(leads.id, existingLead.id))

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	COBROS_NO_REPLY_WARNING,
+	interpolar,
 	PLANTILLAS_MENSAJES,
 	prepararTelefonoAsesorParaEnvio,
 } from "./cobros-plantillas";
@@ -83,5 +85,62 @@ describe("plantillas masivas de cobros", () => {
 			enviar: true,
 			telefonoAsesor: "41286630",
 		});
+	});
+
+	test("define el recordatorio de impuesto de circulación 2026", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+
+		expect(plantilla?.nombre).toBe("Impuesto de circulación 2026");
+		expect(
+			plantilla?.cuerpo,
+		).toBe(`Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`);
+	});
+
+	test("interpola el recordatorio de impuesto con los datos del cliente y asesor", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+		const mensaje = interpolar(plantilla?.cuerpo ?? "", {
+			clienteNombre: "MARIA LOPEZ",
+			fechaPago: "",
+			cuotaMensual: "",
+			placa: "",
+			marcaLineaModelo: "",
+			montoAdeudado: "",
+			cuotasAtraso: 0,
+			telefonoAsesor: "41286630",
+			nombreAsesor: "Carlos Pérez",
+		});
+
+		expect(mensaje).toContain("Estimado(a) Maria Lopez");
+		expect(mensaje).toContain("Atentamente,\nCarlos Pérez\nTel: 41286630");
+		expect(mensaje.match(/NO RESPONDER EN ESTE CHAT/g)?.length).toBe(1);
+	});
+
+	test("conserva los cinco párrafos del contrato SimpleTech para impuesto de circulación", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+		const paragraphs = (plantilla?.cuerpo ?? "")
+			.split(/\n\s*\n/g)
+			.map((paragraph) => paragraph.trim())
+			.filter(Boolean);
+
+		expect(paragraphs).toHaveLength(5);
+		expect(paragraphs.slice(3).join("\n\n")).toBe(
+			`${COBROS_NO_REPLY_WARNING}\n\nAtentamente,\n{nombreAsesor}\nTel: {telefonoAsesor}`,
+		);
 	});
 });

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -119,6 +119,24 @@ ${COBROS_NO_REPLY_WARNING}
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
+		id: "impuesto_circulacion_2026",
+		nombre: "Impuesto de circulación 2026",
+		etapa: "al_dia",
+		asunto: "Recordatorio de pago - Impuesto de circulación 2026",
+		// 5 bloques; SimpleTech colapsa los dos últimos en `mensaje4parametro`.
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
 		id: "pre_mora",
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",

--- a/apps/crm/apps/server/src/lib/lead-assignment.test.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { canReceiveAutoAssignedLead } from "./lead-assignment";
+import {
+	canReceiveAutoAssignedLead,
+	getSalesUserWithLeastAutoAssignedLeads,
+	resolveExistingLeadAssignee,
+} from "./lead-assignment";
 
 describe("lead assignment helpers", () => {
 	test("accepts active sales users that can receive leads", () => {
@@ -38,5 +42,70 @@ describe("lead assignment helpers", () => {
 			}),
 		).toBe(false);
 		expect(canReceiveAutoAssignedLead(null)).toBe(false);
+	});
+
+	test("keeps an eligible existing owner", () => {
+		expect(
+			resolveExistingLeadAssignee(
+				{ id: "current", role: "sales", assignLeads: true, banned: false },
+				{ id: "fallback", role: "sales", assignLeads: true, banned: false },
+			),
+		).toBe("current");
+	});
+
+	test("uses the balanced fallback for an ineligible existing owner", () => {
+		const fallback = {
+			id: "fallback",
+			role: "sales",
+			assignLeads: true,
+			banned: false,
+		};
+
+		for (const currentOwner of [
+			{ id: "disabled", role: "sales", assignLeads: false, banned: false },
+			{ id: "banned", role: "sales", assignLeads: true, banned: true },
+			{
+				id: "not-sales",
+				role: "sales_supervisor",
+				assignLeads: true,
+				banned: false,
+			},
+		]) {
+			expect(resolveExistingLeadAssignee(currentOwner, fallback)).toBe(
+				"fallback",
+			);
+		}
+	});
+
+	test("chooses the eligible advisor with the fewest automatic leads today", () => {
+		const selected = getSalesUserWithLeastAutoAssignedLeads(
+			[
+				{ id: "busy", role: "sales", assignLeads: true, banned: false },
+				{ id: "available", role: "sales", assignLeads: true, banned: false },
+			],
+			new Map([
+				["busy", 4],
+				["available", 1],
+			]),
+		);
+
+		expect(selected?.id).toBe("available");
+	});
+
+	test("returns no assignee when no eligible fallback exists", () => {
+		expect(
+			resolveExistingLeadAssignee(
+				{ id: "disabled", role: "sales", assignLeads: false, banned: false },
+				null,
+			),
+		).toBeNull();
+	});
+
+	test("keeps the WhatsApp controller out of the public-lead import cycle", async () => {
+		const botSource = await Bun.file(
+			new URL("../controllers/bot.ts", import.meta.url),
+		).text();
+
+		expect(botSource).not.toContain('from "./public-lead"');
 	});
 });

--- a/apps/crm/apps/server/src/lib/lead-assignment.test.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.test.ts
@@ -92,6 +92,19 @@ describe("lead assignment helpers", () => {
 		expect(selected?.id).toBe("available");
 	});
 
+	test("balances fallback assignments after reactivating an older lead", () => {
+		const selected = getSalesUserWithLeastAutoAssignedLeads(
+			[
+				{ id: "first", role: "sales", assignLeads: true, banned: false },
+				{ id: "second", role: "sales", assignLeads: true, banned: false },
+			],
+			new Map(),
+			new Map([["first", 1]]),
+		);
+
+		expect(selected?.id).toBe("second");
+	});
+
 	test("returns no assignee when no eligible fallback exists", () => {
 		expect(
 			resolveExistingLeadAssignee(

--- a/apps/crm/apps/server/src/lib/lead-assignment.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.ts
@@ -1,4 +1,4 @@
-import { and, count, eq, gte } from "drizzle-orm";
+import { and, count, eq, gte, lt } from "drizzle-orm";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
 import { leads } from "../db/schema/crm";
@@ -24,12 +24,18 @@ export function canReceiveAutoAssignedLead(
 export function getSalesUserWithLeastAutoAssignedLeads(
 	salesUsers: Array<LeadAssignableUser & { id: string }>,
 	leadCounts: ReadonlyMap<string, number>,
+	reactivatedLeadCounts: ReadonlyMap<string, number> = new Map(),
 ): (LeadAssignableUser & { id: string }) | null {
 	let selectedUser = salesUsers[0] ?? null;
-	let selectedCount = selectedUser ? (leadCounts.get(selectedUser.id) ?? 0) : 0;
+	let selectedCount = selectedUser
+		? (leadCounts.get(selectedUser.id) ?? 0) +
+			(reactivatedLeadCounts.get(selectedUser.id) ?? 0)
+		: 0;
 
 	for (const salesUser of salesUsers) {
-		const userCount = leadCounts.get(salesUser.id) ?? 0;
+		const userCount =
+			(leadCounts.get(salesUser.id) ?? 0) +
+			(reactivatedLeadCounts.get(salesUser.id) ?? 0);
 		if (selectedUser && userCount < selectedCount) {
 			selectedUser = salesUser;
 			selectedCount = userCount;
@@ -71,22 +77,48 @@ export async function findSalesUserWithLeastAutoAssignedLeads() {
 			timeZone: "America/Guatemala",
 		}),
 	);
-	const leadCounts = await db
-		.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
-		.from(leads)
-		.where(
-			and(eq(leads.assignmentType, "auto"), gte(leads.createdAt, startOfToday)),
-		)
-		.groupBy(leads.assignedTo);
+	const [leadCounts, reactivatedLeadCounts] = await Promise.all([
+		db
+			.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
+			.from(leads)
+			.where(
+				and(
+					eq(leads.assignmentType, "auto"),
+					gte(leads.createdAt, startOfToday),
+				),
+			)
+			.groupBy(leads.assignedTo),
+		db
+			.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
+			.from(leads)
+			.where(
+				and(
+					eq(leads.assignmentType, "auto"),
+					lt(leads.createdAt, startOfToday),
+					gte(leads.updatedAt, startOfToday),
+				),
+			)
+			.groupBy(leads.assignedTo),
+	]);
 	const countMap = new Map<string, number>();
+	const reactivatedCountMap = new Map<string, number>();
 
 	for (const leadCount of leadCounts) {
 		if (leadCount.assignedTo) {
 			countMap.set(leadCount.assignedTo, leadCount.count);
 		}
 	}
+	for (const leadCount of reactivatedLeadCounts) {
+		if (leadCount.assignedTo) {
+			reactivatedCountMap.set(leadCount.assignedTo, leadCount.count);
+		}
+	}
 
-	return getSalesUserWithLeastAutoAssignedLeads(salesUsers, countMap);
+	return getSalesUserWithLeastAutoAssignedLeads(
+		salesUsers,
+		countMap,
+		reactivatedCountMap,
+	);
 }
 
 export async function resolveExistingLeadAssigneeFromDatabase(

--- a/apps/crm/apps/server/src/lib/lead-assignment.ts
+++ b/apps/crm/apps/server/src/lib/lead-assignment.ts
@@ -1,6 +1,11 @@
+import { and, count, eq, gte } from "drizzle-orm";
+import { db } from "../db";
+import { user } from "../db/schema/auth";
+import { leads } from "../db/schema/crm";
 import { ROLES } from "./roles";
 
-type LeadAssignableUser = {
+export type LeadAssignableUser = {
+	id?: string;
 	role: string | null | undefined;
 	assignLeads: boolean | null | undefined;
 	banned: boolean | null | undefined;
@@ -13,5 +18,99 @@ export function canReceiveAutoAssignedLead(
 		user?.role === ROLES.SALES &&
 		user.assignLeads === true &&
 		user.banned !== true
+	);
+}
+
+export function getSalesUserWithLeastAutoAssignedLeads(
+	salesUsers: Array<LeadAssignableUser & { id: string }>,
+	leadCounts: ReadonlyMap<string, number>,
+): (LeadAssignableUser & { id: string }) | null {
+	let selectedUser = salesUsers[0] ?? null;
+	let selectedCount = selectedUser ? (leadCounts.get(selectedUser.id) ?? 0) : 0;
+
+	for (const salesUser of salesUsers) {
+		const userCount = leadCounts.get(salesUser.id) ?? 0;
+		if (selectedUser && userCount < selectedCount) {
+			selectedUser = salesUser;
+			selectedCount = userCount;
+		}
+	}
+
+	return selectedUser;
+}
+
+export function resolveExistingLeadAssignee(
+	currentOwner: LeadAssignableUser | null | undefined,
+	fallbackSalesUser: LeadAssignableUser | null,
+): string | null {
+	if (canReceiveAutoAssignedLead(currentOwner)) {
+		return currentOwner?.id ?? null;
+	}
+
+	return fallbackSalesUser?.id ?? null;
+}
+
+export async function findSalesUserWithLeastAutoAssignedLeads() {
+	const salesUsers = await db
+		.select({
+			id: user.id,
+			role: user.role,
+			assignLeads: user.assignLeads,
+			banned: user.banned,
+		})
+		.from(user)
+		.where(
+			and(
+				eq(user.role, ROLES.SALES),
+				eq(user.assignLeads, true),
+				eq(user.banned, false),
+			),
+		);
+	const startOfToday = new Date(
+		new Date().toLocaleDateString("en-US", {
+			timeZone: "America/Guatemala",
+		}),
+	);
+	const leadCounts = await db
+		.select({ assignedTo: leads.assignedTo, count: count(leads.id) })
+		.from(leads)
+		.where(
+			and(eq(leads.assignmentType, "auto"), gte(leads.createdAt, startOfToday)),
+		)
+		.groupBy(leads.assignedTo);
+	const countMap = new Map<string, number>();
+
+	for (const leadCount of leadCounts) {
+		if (leadCount.assignedTo) {
+			countMap.set(leadCount.assignedTo, leadCount.count);
+		}
+	}
+
+	return getSalesUserWithLeastAutoAssignedLeads(salesUsers, countMap);
+}
+
+export async function resolveExistingLeadAssigneeFromDatabase(
+	existingAssignedTo?: string | null,
+) {
+	const [currentOwner] = existingAssignedTo
+		? await db
+				.select({
+					id: user.id,
+					role: user.role,
+					assignLeads: user.assignLeads,
+					banned: user.banned,
+				})
+				.from(user)
+				.where(eq(user.id, existingAssignedTo))
+				.limit(1)
+		: [];
+
+	if (canReceiveAutoAssignedLead(currentOwner)) {
+		return currentOwner?.id ?? null;
+	}
+
+	return resolveExistingLeadAssignee(
+		null,
+		await findSalesUserWithLeastAutoAssignedLeads(),
 	);
 }

--- a/apps/crm/apps/server/src/lib/lead-opportunity.ts
+++ b/apps/crm/apps/server/src/lib/lead-opportunity.ts
@@ -1,0 +1,32 @@
+import { and, desc, eq, or } from "drizzle-orm";
+import { db } from "../db";
+import { type leadSourceEnum, opportunities } from "../db/schema/crm";
+
+type LeadSource = (typeof leadSourceEnum.enumValues)[number];
+
+export async function getOpenOpportunityBySource(
+	leadId: string,
+	_source: LeadSource,
+) {
+	const [existing] = await db
+		.select({
+			id: opportunities.id,
+			source: opportunities.source,
+			campaign: opportunities.campaign,
+			creditType: opportunities.creditType,
+		})
+		.from(opportunities)
+		.where(
+			and(
+				eq(opportunities.leadId, leadId),
+				or(
+					eq(opportunities.status, "open"),
+					eq(opportunities.status, "on_hold"),
+				),
+			),
+		)
+		.orderBy(desc(opportunities.createdAt))
+		.limit(1);
+
+	return existing;
+}

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test";
 import {
 	accionUsaCuerpoNoReply,
 	COBROS_MOTIVO_SIN_TELEFONO_ASESOR,
+	COBROS_NO_REPLY_WARNING,
 	crearUrlWhatsappManual,
 	cuerpoParaValidarNoReply,
+	interpolar,
 	mensajeEmailEditable,
 	mensajePlantillaEditable,
 	mensajeSmsEditable,
@@ -177,5 +179,29 @@ describe("plantillas web de cobros", () => {
 			enviar: true,
 			telefonoAsesor: "41286630",
 		});
+	});
+
+	test("muestra el recordatorio de impuesto de circulación 2026 con sus variables", () => {
+		const plantilla = PLANTILLAS_MENSAJES.find(
+			(plantilla) => plantilla.id === "impuesto_circulacion_2026",
+		);
+		const cuerpoWhatsapp = plantilla?.cuerpoWhastapp ?? plantilla?.cuerpo ?? "";
+		const mensaje = interpolar(cuerpoWhatsapp, {
+			clienteNombre: "MARIA LOPEZ",
+			fechaPago: "",
+			cuotaMensual: "",
+			placa: "",
+			marcaLineaModelo: "",
+			montoAdeudado: "",
+			cuotasAtraso: 0,
+			telefonoAsesor: "41286630",
+			nombreAsesor: "Carlos Pérez",
+		});
+
+		expect(plantilla?.nombre).toBe("Impuesto de circulación 2026");
+		expect(mensaje).toContain("Estimado(a) Maria Lopez");
+		expect(mensaje).toContain("Atentamente,\nCarlos Pérez\nTel: 41286630");
+		expect(mensaje.match(/NO RESPONDER EN ESTE CHAT/g)?.length).toBe(1);
+		expect(cuerpoWhatsapp).toContain(COBROS_NO_REPLY_WARNING);
 	});
 });

--- a/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
+++ b/apps/crm/apps/web/src/lib/cobros/plantillas-mensajes.ts
@@ -206,6 +206,34 @@ ${COBROS_NO_REPLY_WARNING}
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
 	{
+		id: "impuesto_circulacion_2026",
+		nombre: "Impuesto de circulación 2026",
+		etapa: "al_dia",
+		asunto: "Recordatorio de pago - Impuesto de circulación 2026",
+		cuerpo: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+		cuerpoWhastapp: `Estimado(a) {clienteNombre}, buen día, cordialmente le saludamos de Clubcashin para recordarle sobre el pago del impuesto de circulación del año 2026.
+
+Envíanos tu comprobante a tiempo para que podamos procesar y enviarte tus distintivos sin contratiempos.
+
+¡No lo dejes para última hora!
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente,
+{nombreAsesor}
+Tel: {telefonoAsesor}`,
+	},
+	{
 		id: "pre_mora",
 		nombre: "Aviso de atraso",
 		etapa: "pre_mora",

--- a/apps/investment-calculator/.dockerignore
+++ b/apps/investment-calculator/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+docs/
+*.md

--- a/apps/investment-calculator/Dockerfile
+++ b/apps/investment-calculator/Dockerfile
@@ -1,6 +1,21 @@
-FROM docker.io/library/nginx:latest
+# Etapa 1: Build (multi-stage para que CI construya sin dist/ previo,
+# mismo patrón que carteraFront)
+FROM docker.io/node:20-alpine AS build
 
-COPY dist /usr/share/nginx/html
+WORKDIR /app
+
+COPY . .
+
+RUN npm install --legacy-peer-deps
+
+RUN node node_modules/vite/bin/vite.js build
+
+# Etapa 2: Nginx
+FROM docker.io/library/nginx:alpine
+
+RUN rm -rf /usr/share/nginx/html/*
+
+COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 80
 

--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -532,8 +532,14 @@ export default function InvestmentCalculator() {
 
     // Proyección anual (solo modelo Tradicional): desglose por año de capital
     // devuelto e intereses, calculado sobre el capital activo de cada mes.
+    // Igual que en la UI, solo aplica en "Calcular Rendimiento" (en modo
+    // Objetivo el plazo es libre y Tradicional no es una opción).
     let annualSection: HTMLDivElement | null = null;
-    if (activeTab === "standard" && annualProjection.length > 0) {
+    if (
+      activeTab === "standard" &&
+      mainTab === "calculator" &&
+      annualProjection.length > 0
+    ) {
       annualSection = document.createElement("div");
 
       const annualTitle = document.createElement("h2");
@@ -1319,8 +1325,11 @@ export default function InvestmentCalculator() {
         </CardContent>
       </Card>
 
-      {/* Proyección Anual — solo modelo Tradicional (minuta Plazos Calculadora) */}
-      {activeTab === "standard" && (
+      {/* Proyección Anual — solo modelo Tradicional (minuta Plazos Calculadora).
+          Solo en "Calcular Rendimiento": en modo Objetivo el plazo es libre
+          (Tradicional no es una opción ahí) y renderizarla cotizaría un
+          Tradicional con plazo bloqueado. */}
+      {activeTab === "standard" && mainTab === "calculator" && (
         <Card>
           <CardHeader>
             <CardTitle>Proyección Anual</CardTitle>

--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -599,6 +599,33 @@ export default function InvestmentCalculator() {
         });
         annualBody.appendChild(tr);
       });
+
+      // Fila de totales (misma info que la fila de resumen de la tabla mensual)
+      const annualTotalsRow = document.createElement("tr");
+      annualTotalsRow.style.backgroundColor = "#f2f2f2";
+      annualTotalsRow.style.fontWeight = "bold";
+      const annualTotals: [string, number][] = [
+        [`Monto a Invertir: ${fmtQ(displayCapital)}`, 2],
+        [
+          `Total Intereses: ${fmtQ(investmentResult.grossProfit + investmentResult.vatPaid)}`,
+          1,
+        ],
+        [
+          `Total a Recibir: ${fmtQ(displayCapital + (investmentResult.grossProfit + investmentResult.vatPaid) / (1 + getVatRate()))}`,
+          2,
+        ],
+      ];
+      annualTotals.forEach(([text, span], i) => {
+        const td = document.createElement("td");
+        td.textContent = text;
+        td.colSpan = span;
+        td.style.padding = "8px";
+        td.style.border = "1px solid #ddd";
+        if (i > 0) td.style.textAlign = "right";
+        annualTotalsRow.appendChild(td);
+      });
+      annualBody.appendChild(annualTotalsRow);
+
       annualTable.appendChild(annualBody);
       annualSection.appendChild(annualTable);
 
@@ -772,10 +799,13 @@ export default function InvestmentCalculator() {
     printContent.appendChild(header);
     printContent.appendChild(summary);
     if (annualSection) {
+      // Tradicional: la Proyección Anual ES la tabla del resumen (la tabla
+      // mensual no se incluye, igual que en la UI).
       printContent.appendChild(annualSection);
+    } else {
+      printContent.appendChild(tableTitle);
+      printContent.appendChild(table);
     }
-    printContent.appendChild(tableTitle);
-    printContent.appendChild(table);
     printContent.appendChild(disclaimer);
 
     // Agregar el contenedor al documento
@@ -1325,78 +1355,26 @@ export default function InvestmentCalculator() {
         </CardContent>
       </Card>
 
-      {/* Proyección Anual — solo modelo Tradicional (minuta Plazos Calculadora).
-          Solo en "Calcular Rendimiento": en modo Objetivo el plazo es libre
-          (Tradicional no es una opción ahí) y renderizarla cotizaría un
-          Tradicional con plazo bloqueado. */}
-      {activeTab === "standard" && mainTab === "calculator" && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Proyección Anual</CardTitle>
+      {/* Amortization Schedule Table with Tabs.
+          Para Tradicional (en "Calcular Rendimiento") la tabla ES la
+          Proyección Anual (minuta Plazos Calculadora): devolución de capital
+          e intereses agrupados por año. Los otros modelos (y el modo
+          Objetivo, donde el plazo es libre y Tradicional no es una opción)
+          conservan la tabla mensual. */}
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {activeTab === "standard" && mainTab === "calculator"
+              ? "Proyección Anual"
+              : "Tabla de Amortización"}
+          </CardTitle>
+          {activeTab === "standard" && mainTab === "calculator" && (
             <CardDescription>
               Devolución estimada de capital e intereses ganados por año. La
               ganancia se calcula sobre el capital que permanece activo cada
               mes, no sobre el monto inicial.
             </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <Table containerClassname="">
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Año</TableHead>
-                  <TableHead className="text-right">Capital Devuelto</TableHead>
-                  <TableHead className="text-right">Intereses + IVA</TableHead>
-                  <TableHead className="text-right">Total a Recibir</TableHead>
-                  <TableHead className="text-right">Capital Activo al Cierre</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {annualProjection.map((y) => (
-                  <TableRow key={y.year}>
-                    <TableCell>Año {y.year}</TableCell>
-                    <TableCell className="text-right">
-                      Q{" "}
-                      {y.capitalDevuelto.toLocaleString("en-US", {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      Q{" "}
-                      {y.intereses.toLocaleString("en-US", {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      Q{" "}
-                      {y.totalRecibir.toLocaleString("en-US", {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      Q{" "}
-                      {y.saldoFinal.toLocaleString("en-US", {
-                        minimumFractionDigits: 2,
-                        maximumFractionDigits: 2,
-                      })}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-            <p className="mt-4 text-xs text-gray-500 italic">
-              {DISCLAIMER_TRADICIONAL}
-            </p>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Amortization Schedule Table with Tabs */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Tabla de Amortización</CardTitle>
+          )}
         </CardHeader>
         <CardContent>
           <Tabs value={activeTab} onValueChange={handleModeloChange}>
@@ -1406,6 +1384,82 @@ export default function InvestmentCalculator() {
               <TabsTrigger value="compound">Interés Compuesto</TabsTrigger>
             </TabsList>
             <TabsContent value="standard">
+              {activeTab === "standard" && mainTab === "calculator" ? (
+                <>
+                  <Table containerClassname="">
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>Año</TableHead>
+                        <TableHead className="text-right">Capital Devuelto</TableHead>
+                        <TableHead className="text-right">Intereses + IVA</TableHead>
+                        <TableHead className="text-right">Total a Recibir</TableHead>
+                        <TableHead className="text-right">Capital Activo al Cierre</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {annualProjection.map((y) => (
+                        <TableRow key={y.year}>
+                          <TableCell>Año {y.year}</TableCell>
+                          <TableCell className="text-right">
+                            Q{" "}
+                            {y.capitalDevuelto.toLocaleString("en-US", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            Q{" "}
+                            {y.intereses.toLocaleString("en-US", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            Q{" "}
+                            {y.totalRecibir.toLocaleString("en-US", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            Q{" "}
+                            {y.saldoFinal.toLocaleString("en-US", {
+                              minimumFractionDigits: 2,
+                              maximumFractionDigits: 2,
+                            })}
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                    <TableRow className="bg-gray-100 font-semibold">
+                      <TableCell colSpan={2}>
+                        Monto a Invertir: Q{" "}
+                        {displayCapital.toLocaleString("en-US", {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        Total Intereses: Q{" "}
+                        {(investmentResult.grossProfit + investmentResult.vatPaid).toLocaleString("en-US", {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}
+                      </TableCell>
+                      <TableCell colSpan={2} className="text-right">
+                        Total a Recibir: Q{" "}
+                        {(displayCapital + ((investmentResult.grossProfit + investmentResult.vatPaid) / (1 + getVatRate()))).toLocaleString("en-US", {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 2,
+                        })}
+                      </TableCell>
+                    </TableRow>
+                  </Table>
+                  <p className="mt-4 text-xs text-gray-500 italic">
+                    {DISCLAIMER_TRADICIONAL}
+                  </p>
+                </>
+              ) : (
               <ScrollArea className="h-[500px] rounded-md border">
                 <Table containerClassname="">
                   <TableHeader>
@@ -1491,6 +1545,7 @@ export default function InvestmentCalculator() {
                 </Table>
                 <ScrollBar orientation="horizontal" />
               </ScrollArea>
+              )}
             </TabsContent>
 
             <TabsContent value="interest-only">

--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -62,6 +62,18 @@ interface AmortizationRow {
 
 const DEFAULT_INVESTOR_PERCENTAGE = 70;
 
+// Plazos permitidos para el modelo Tradicional (acuerdo de la minuta
+// "Plazos Calculadora Inversión"): los plazos de 12 a 48 meses quedan
+// bloqueados por inviabilidad operativa; solo se cotiza a 60, 72 y 84 meses.
+const PLAZOS_TRADICIONAL = [60, 72, 84];
+
+// Textos legales/advertencia (BORRADOR pendiente de revisión del grupo).
+const DISCLAIMER_GENERAL =
+  "Los rendimientos y montos presentados en este cotizador son de carácter referencial y aproximados: pueden variar según la composición y el comportamiento de la cartera adquirida, el momento de adquisición de cada crédito, así como por el régimen fiscal aplicable al inversionista, retenciones, impuestos u otras disposiciones legales vigentes. Esta simulación no constituye una oferta vinculante, una promesa de rendimiento ni una garantía de resultados futuros.";
+
+const DISCLAIMER_TRADICIONAL =
+  "En el modelo Tradicional los intereses se calculan sobre el capital que permanece activo cada mes, por lo que la devolución de capital y los intereses proyectados son estimaciones sujetas al ritmo real de amortización de la cartera. Si el inversionista desea retirar su capital antes del plazo cotizado, Cash In realizará su mejor esfuerzo por vender la cartera correspondiente; dicha venta está sujeta a condiciones de mercado y no constituye una obligación contractual ni una garantía de salida inmediata.";
+
 const normalizeInvestorPercentage = (value: number) =>
   Math.min(Math.max(Number.isFinite(value) ? value : DEFAULT_INVESTOR_PERCENTAGE, 1), 100);
 
@@ -79,7 +91,8 @@ export default function InvestmentCalculator() {
   const [mainTab, setMainTab] = useState("calculator"); // 'calculator' or 'goal'
   const [capital, setCapital] = useState<string>("7591.11");
   const [interestRate, setInterestRate] = useState<number>(1.5);
-  const [term, setTerm] = useState<number>(1);
+  // El modelo por defecto es Tradicional → arranca en el plazo mínimo permitido (60 meses).
+  const [term, setTerm] = useState<number>(60);
   const [investorPercentage, setInvestorPercentage] = useState<number>(
     DEFAULT_INVESTOR_PERCENTAGE
   );
@@ -89,7 +102,7 @@ export default function InvestmentCalculator() {
   const [isDialogOpen, setIsDialogOpen] = useState(false);
 
   // New state for term unit
-  const [termUnit, setTermUnit] = useState<"months" | "years">("years");
+  const [termUnit, setTermUnit] = useState<"months" | "years">("months");
 
   // Small taxpayer state
   const [isSmallTaxpayer, setIsSmallTaxpayer] = useState<boolean>(false);
@@ -132,6 +145,20 @@ export default function InvestmentCalculator() {
   const getTermInMonths = useCallback(() => {
     return termUnit === "years" ? term * 12 : term;
   }, [termUnit, term]);
+
+  // Cambio de modelo de inversión: el modelo se elige ANTES que el plazo.
+  // Al entrar a Tradicional, si el plazo actual no es uno de los permitidos
+  // (60/72/84 meses), se ajusta al mínimo permitido.
+  const handleModeloChange = (modelo: string) => {
+    setActiveTab(modelo);
+    if (modelo === "standard") {
+      const meses = termUnit === "years" ? term * 12 : term;
+      if (!PLAZOS_TRADICIONAL.includes(meses)) {
+        setTerm(PLAZOS_TRADICIONAL[0]);
+        setTermUnit("months");
+      }
+    }
+  };
 
   // Helper function to get VAT rate
   const getVatRate = useCallback(() => {
@@ -270,10 +297,38 @@ export default function InvestmentCalculator() {
     [displayCapital, interestRate, term, termUnit, investorPercentage, isSmallTaxpayer]
   );
   
-  const compoundScheduleArr = useMemo(() => 
-    generateCompoundSchedule(displayCapital), 
+  const compoundScheduleArr = useMemo(() =>
+    generateCompoundSchedule(displayCapital),
     [displayCapital, interestRate, term, termUnit, investorPercentage, isSmallTaxpayer]
   );
+
+  // Proyección anual del modelo Tradicional (minuta "Plazos Calculadora
+  // Inversión"): desglose por año de la devolución estimada de capital y los
+  // intereses ganados. La ganancia se calcula sobre el capital ACTIVO de cada
+  // mes (la tabla mensual ya funciona sobre saldo); aquí solo se agrupa por año.
+  const annualProjection = useMemo(() => {
+    const years: {
+      year: number;
+      capitalDevuelto: number;
+      intereses: number;
+      totalRecibir: number;
+      saldoFinal: number;
+    }[] = [];
+    for (let i = 0; i < standardSchedule.length; i += 12) {
+      const chunk = standardSchedule.slice(i, i + 12);
+      years.push({
+        year: i / 12 + 1,
+        capitalDevuelto: chunk.reduce((s, r) => s + r.amortization, 0),
+        intereses: chunk.reduce((s, r) => s + r.interestVatPayment, 0),
+        totalRecibir: chunk.reduce(
+          (s, r) => s + r.amortization + r.interest * (investorPercentage / 100),
+          0
+        ),
+        saldoFinal: chunk[chunk.length - 1]?.finalBalance ?? 0,
+      });
+    }
+    return years;
+  }, [standardSchedule, investorPercentage]);
 
   // Calculate investment results using the backend functions
   const investmentParams: InvestmentParams = {
@@ -460,6 +515,81 @@ export default function InvestmentCalculator() {
       )
     );
 
+    // Proyección anual (solo modelo Tradicional): desglose por año de capital
+    // devuelto e intereses, calculado sobre el capital activo de cada mes.
+    let annualSection: HTMLDivElement | null = null;
+    if (activeTab === "standard" && annualProjection.length > 0) {
+      annualSection = document.createElement("div");
+
+      const annualTitle = document.createElement("h2");
+      annualTitle.textContent = "Proyección Anual";
+      annualTitle.style.fontSize = "22px";
+      annualTitle.style.marginTop = "20px";
+      annualTitle.style.marginBottom = "15px";
+      annualSection.appendChild(annualTitle);
+
+      const annualTable = document.createElement("table");
+      annualTable.style.width = "100%";
+      annualTable.style.borderCollapse = "collapse";
+      annualTable.style.marginBottom = "10px";
+      annualTable.style.fontSize = "13px";
+
+      const annualHead = document.createElement("thead");
+      const annualHeaderRow = document.createElement("tr");
+      [
+        "Año",
+        "Capital Devuelto",
+        "Intereses + IVA",
+        "Total a Recibir",
+        "Capital Activo al Cierre",
+      ].forEach((h) => {
+        const th = document.createElement("th");
+        th.textContent = h;
+        th.style.padding = "8px";
+        th.style.backgroundColor = "#f2f2f2";
+        th.style.border = "1px solid #ddd";
+        th.style.textAlign = "right";
+        annualHeaderRow.appendChild(th);
+      });
+      annualHead.appendChild(annualHeaderRow);
+      annualTable.appendChild(annualHead);
+
+      const annualBody = document.createElement("tbody");
+      const fmtQ = (v: number) =>
+        `Q ${v.toLocaleString("en-US", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        })}`;
+      annualProjection.forEach((y) => {
+        const tr = document.createElement("tr");
+        [
+          `Año ${y.year}`,
+          fmtQ(y.capitalDevuelto),
+          fmtQ(y.intereses),
+          fmtQ(y.totalRecibir),
+          fmtQ(y.saldoFinal),
+        ].forEach((text, i) => {
+          const td = document.createElement("td");
+          td.textContent = text;
+          td.style.padding = "8px";
+          td.style.border = "1px solid #ddd";
+          td.style.textAlign = i === 0 ? "center" : "right";
+          tr.appendChild(td);
+        });
+        annualBody.appendChild(tr);
+      });
+      annualTable.appendChild(annualBody);
+      annualSection.appendChild(annualTable);
+
+      const annualNote = document.createElement("p");
+      annualNote.textContent = DISCLAIMER_TRADICIONAL;
+      annualNote.style.fontSize = "10px";
+      annualNote.style.color = "#666666";
+      annualNote.style.fontStyle = "italic";
+      annualNote.style.lineHeight = "1.4";
+      annualSection.appendChild(annualNote);
+    }
+
     // Agregar la tabla de amortización
     const tableTitle = document.createElement("h2");
     tableTitle.textContent = "Tabla de Amortización";
@@ -615,11 +745,14 @@ export default function InvestmentCalculator() {
     disclaimer.style.border = "1px solid #ddd";
     disclaimer.style.borderRadius = "3px";
     disclaimer.style.backgroundColor = "#f9f9f9";
-    disclaimer.textContent = "Los rendimientos y montos presentados en este cotizador son de carácter referencial y pueden variar según el régimen fiscal aplicable al inversionista, así como por retenciones, impuestos u otras disposiciones legales vigentes. Esta simulación no constituye una oferta vinculante ni garantiza resultados futuros.";
+    disclaimer.textContent = DISCLAIMER_GENERAL;
 
     // Agregar todo al contenedor principal
     printContent.appendChild(header);
     printContent.appendChild(summary);
+    if (annualSection) {
+      printContent.appendChild(annualSection);
+    }
     printContent.appendChild(tableTitle);
     printContent.appendChild(table);
     printContent.appendChild(disclaimer);
@@ -858,7 +991,7 @@ export default function InvestmentCalculator() {
             *No hay penalización por cancelación anticipada de créditos
           </CardDescription>
           <CardDescription className="text-xs text-gray-500 mt-4 italic">
-            Los rendimientos y montos presentados en este cotizador son de carácter referencial y pueden variar según el régimen fiscal aplicable al inversionista, así como por retenciones, impuestos u otras disposiciones legales vigentes. Esta simulación no constituye una oferta vinculante ni garantiza resultados futuros.
+            {DISCLAIMER_GENERAL}
           </CardDescription>
         </CardHeader>
         <CardContent>
@@ -868,6 +1001,20 @@ export default function InvestmentCalculator() {
             <TabsTrigger value="goal">Calcular Objetivo</TabsTrigger>
             </TabsList>
             <TabsContent value="calculator">
+              {/* El modelo se elige PRIMERO: define qué plazos se pueden cotizar. */}
+              <div className="space-y-2 pt-4 md:max-w-xs">
+                <Label htmlFor="modelo">Modelo de Inversión</Label>
+                <Select value={activeTab} onValueChange={handleModeloChange}>
+                  <SelectTrigger id="modelo">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="standard">Tradicional</SelectItem>
+                    <SelectItem value="interest-only">Al vencimiento</SelectItem>
+                    <SelectItem value="compound">Interés Compuesto</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
               <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-5 pt-4">
                 <div className="space-y-2">
                   <Label htmlFor="capital">Monto a Invertir (Q)</Label>
@@ -890,30 +1037,53 @@ export default function InvestmentCalculator() {
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="term">Plazo</Label>
-                  <div className="flex gap-2">
-                    <Input
-                      id="term"
-                      type="number"
-                      value={term}
-                      onChange={(e) => setTerm(Number(e.target.value))}
-                      min="1"
-                      className="flex-1"
-                    />
+                  {activeTab === "standard" ? (
+                    // Tradicional: plazos de 12 a 48 meses bloqueados (minuta);
+                    // solo se cotiza a 60, 72 u 84 meses.
                     <Select
-                      value={termUnit}
-                      onValueChange={(value) =>
-                        setTermUnit(value as "months" | "years")
-                      }
+                      value={String(getTermInMonths())}
+                      onValueChange={(v) => {
+                        setTerm(Number(v));
+                        setTermUnit("months");
+                      }}
                     >
-                      <SelectTrigger className="w-24">
+                      <SelectTrigger id="term">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="months">Meses</SelectItem>
-                        <SelectItem value="years">Años</SelectItem>
+                        {PLAZOS_TRADICIONAL.map((meses) => (
+                          <SelectItem key={meses} value={String(meses)}>
+                            {meses / 12} años ({meses} meses)
+                          </SelectItem>
+                        ))}
                       </SelectContent>
                     </Select>
-                  </div>
+                  ) : (
+                    <div className="flex gap-2">
+                      <Input
+                        id="term"
+                        type="number"
+                        value={term}
+                        onChange={(e) => setTerm(Number(e.target.value))}
+                        min="1"
+                        className="flex-1"
+                      />
+                      <Select
+                        value={termUnit}
+                        onValueChange={(value) =>
+                          setTermUnit(value as "months" | "years")
+                        }
+                      >
+                        <SelectTrigger className="w-24">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="months">Meses</SelectItem>
+                          <SelectItem value="years">Años</SelectItem>
+                        </SelectContent>
+                      </Select>
+                    </div>
+                  )}
                 </div>
                 <div className="space-y-2">
                   <Label htmlFor="investorSplit">
@@ -1082,15 +1252,6 @@ export default function InvestmentCalculator() {
             </TabsContent>
           </Tabs>
 
-          {/* Summary Tabs for the summary cards */}
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
-            <TabsList className="my-4">
-              <TabsTrigger value="standard">Tradicional</TabsTrigger>
-              <TabsTrigger value="interest-only">Al vencimiento</TabsTrigger>
-              <TabsTrigger value="compound">Interés Compuesto</TabsTrigger>
-            </TabsList>
-          </Tabs>
-
           <div className="mt-6 grid gap-4 md:grid-cols-2 lg:grid-cols-3">
             <Card>
               <CardHeader>
@@ -1143,13 +1304,78 @@ export default function InvestmentCalculator() {
         </CardContent>
       </Card>
 
+      {/* Proyección Anual — solo modelo Tradicional (minuta Plazos Calculadora) */}
+      {activeTab === "standard" && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Proyección Anual</CardTitle>
+            <CardDescription>
+              Devolución estimada de capital e intereses ganados por año. La
+              ganancia se calcula sobre el capital que permanece activo cada
+              mes, no sobre el monto inicial.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table containerClassname="">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Año</TableHead>
+                  <TableHead className="text-right">Capital Devuelto</TableHead>
+                  <TableHead className="text-right">Intereses + IVA</TableHead>
+                  <TableHead className="text-right">Total a Recibir</TableHead>
+                  <TableHead className="text-right">Capital Activo al Cierre</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {annualProjection.map((y) => (
+                  <TableRow key={y.year}>
+                    <TableCell>Año {y.year}</TableCell>
+                    <TableCell className="text-right">
+                      Q{" "}
+                      {y.capitalDevuelto.toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      Q{" "}
+                      {y.intereses.toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      Q{" "}
+                      {y.totalRecibir.toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      Q{" "}
+                      {y.saldoFinal.toLocaleString("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      })}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+            <p className="mt-4 text-xs text-gray-500 italic">
+              {DISCLAIMER_TRADICIONAL}
+            </p>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Amortization Schedule Table with Tabs */}
       <Card>
         <CardHeader>
           <CardTitle>Tabla de Amortización</CardTitle>
         </CardHeader>
         <CardContent>
-          <Tabs value={activeTab} onValueChange={setActiveTab}>
+          <Tabs value={activeTab} onValueChange={handleModeloChange}>
             <TabsList className="mb-4">
               <TabsTrigger value="standard">Tradicional</TabsTrigger>
               <TabsTrigger value="interest-only">Al vencimiento</TabsTrigger>

--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -351,6 +351,19 @@ export default function InvestmentCalculator() {
     return years;
   }, [standardSchedule, investorPercentage]);
 
+  // Totales del footer de la Proyección Anual: se calculan sumando las filas
+  // por año para que SIEMPRE cuadren con lo mostrado. (No derivar de
+  // investmentResult dividiendo por 1+getVatRate(): con Pequeño Contribuyente
+  // el IVA de la tabla sigue siendo 12% mientras getVatRate() baja a 5%, y el
+  // total quedaría descuadrado respecto a la suma de las filas.)
+  const annualTotals = useMemo(
+    () => ({
+      intereses: annualProjection.reduce((s, y) => s + y.intereses, 0),
+      totalRecibir: annualProjection.reduce((s, y) => s + y.totalRecibir, 0),
+    }),
+    [annualProjection]
+  );
+
   // Calculate investment results using the backend functions
   const investmentParams: InvestmentParams = {
     capital: displayCapital,
@@ -610,18 +623,13 @@ export default function InvestmentCalculator() {
       const annualTotalsRow = document.createElement("tr");
       annualTotalsRow.style.backgroundColor = "#f2f2f2";
       annualTotalsRow.style.fontWeight = "bold";
-      const annualTotals: [string, number][] = [
+      // Mismos totales que la UI: sumados de las filas por año para que cuadren.
+      const annualTotalsRowData: [string, number][] = [
         [`Monto a Invertir: ${fmtQ(displayCapital)}`, 2],
-        [
-          `Total Intereses: ${fmtQ(investmentResult.grossProfit + investmentResult.vatPaid)}`,
-          1,
-        ],
-        [
-          `Total a Recibir: ${fmtQ(displayCapital + (investmentResult.grossProfit + investmentResult.vatPaid) / (1 + getVatRate()))}`,
-          2,
-        ],
+        [`Total Intereses: ${fmtQ(annualTotals.intereses)}`, 1],
+        [`Total a Recibir: ${fmtQ(annualTotals.totalRecibir)}`, 2],
       ];
-      annualTotals.forEach(([text, span], i) => {
+      annualTotalsRowData.forEach(([text, span], i) => {
         const td = document.createElement("td");
         td.textContent = text;
         td.colSpan = span;
@@ -1447,14 +1455,14 @@ export default function InvestmentCalculator() {
                       </TableCell>
                       <TableCell className="text-right">
                         Total Intereses: Q{" "}
-                        {(investmentResult.grossProfit + investmentResult.vatPaid).toLocaleString("en-US", {
+                        {annualTotals.intereses.toLocaleString("en-US", {
                           minimumFractionDigits: 2,
                           maximumFractionDigits: 2,
                         })}
                       </TableCell>
                       <TableCell colSpan={2} className="text-right">
                         Total a Recibir: Q{" "}
-                        {(displayCapital + ((investmentResult.grossProfit + investmentResult.vatPaid) / (1 + getVatRate()))).toLocaleString("en-US", {
+                        {annualTotals.totalRecibir.toLocaleString("en-US", {
                           minimumFractionDigits: 2,
                           maximumFractionDigits: 2,
                         })}

--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -148,8 +148,14 @@ export default function InvestmentCalculator() {
 
   // Ajusta el plazo al mínimo permitido de Tradicional cuando el valor
   // actual no es uno de los válidos (60/72/84 meses).
-  const clampTermToTradicional = (modelo: string) => {
-    if (modelo !== "standard") return;
+  //
+  // El clamp SOLO aplica en "Calcular Rendimiento": en "Calcular Objetivo" el
+  // plazo es libre y Tradicional no es una opción de cotización, así que
+  // pisar el plazo ahí reescribiría el objetivo del usuario y recalcularía el
+  // capital requerido. Como `mainTab` se actualiza de forma asíncrona, el
+  // llamador pasa el valor efectivo del modo (el destino, no el estado viejo).
+  const clampTermToTradicional = (modelo: string, effectiveMainTab: string) => {
+    if (effectiveMainTab !== "calculator" || modelo !== "standard") return;
     const meses = termUnit === "years" ? term * 12 : term;
     if (!PLAZOS_TRADICIONAL.includes(meses)) {
       setTerm(PLAZOS_TRADICIONAL[0]);
@@ -159,9 +165,11 @@ export default function InvestmentCalculator() {
 
   // Cambio de modelo de inversión: el modelo se elige ANTES que el plazo.
   // Al entrar a Tradicional, si el plazo actual no es permitido, se ajusta.
+  // Este handler también lo usa la tira de tabs de la tabla de amortización,
+  // que se renderiza en ambos modos; por eso el clamp respeta el `mainTab`.
   const handleModeloChange = (modelo: string) => {
     setActiveTab(modelo);
-    clampTermToTradicional(modelo);
+    clampTermToTradicional(modelo, mainTab);
   };
 
   // `term` es estado compartido con la pestaña "Calcular Objetivo", cuyo
@@ -170,9 +178,7 @@ export default function InvestmentCalculator() {
   // plazo queda con un valor inválido y la cotización usa un plazo bloqueado.
   const handleMainTabChange = (tab: string) => {
     setMainTab(tab);
-    if (tab === "calculator") {
-      clampTermToTradicional(activeTab);
-    }
+    clampTermToTradicional(activeTab, tab);
   };
 
   // Helper function to get VAT rate

--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -146,17 +146,32 @@ export default function InvestmentCalculator() {
     return termUnit === "years" ? term * 12 : term;
   }, [termUnit, term]);
 
+  // Ajusta el plazo al mínimo permitido de Tradicional cuando el valor
+  // actual no es uno de los válidos (60/72/84 meses).
+  const clampTermToTradicional = (modelo: string) => {
+    if (modelo !== "standard") return;
+    const meses = termUnit === "years" ? term * 12 : term;
+    if (!PLAZOS_TRADICIONAL.includes(meses)) {
+      setTerm(PLAZOS_TRADICIONAL[0]);
+      setTermUnit("months");
+    }
+  };
+
   // Cambio de modelo de inversión: el modelo se elige ANTES que el plazo.
-  // Al entrar a Tradicional, si el plazo actual no es uno de los permitidos
-  // (60/72/84 meses), se ajusta al mínimo permitido.
+  // Al entrar a Tradicional, si el plazo actual no es permitido, se ajusta.
   const handleModeloChange = (modelo: string) => {
     setActiveTab(modelo);
-    if (modelo === "standard") {
-      const meses = termUnit === "years" ? term * 12 : term;
-      if (!PLAZOS_TRADICIONAL.includes(meses)) {
-        setTerm(PLAZOS_TRADICIONAL[0]);
-        setTermUnit("months");
-      }
+    clampTermToTradicional(modelo);
+  };
+
+  // `term` es estado compartido con la pestaña "Calcular Objetivo", cuyo
+  // input libre acepta cualquier valor. Al volver a "Calcular Rendimiento"
+  // con Tradicional activo hay que re-aplicar el clamp, si no el select de
+  // plazo queda con un valor inválido y la cotización usa un plazo bloqueado.
+  const handleMainTabChange = (tab: string) => {
+    setMainTab(tab);
+    if (tab === "calculator") {
+      clampTermToTradicional(activeTab);
     }
   };
 
@@ -995,7 +1010,7 @@ export default function InvestmentCalculator() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <Tabs value={mainTab} onValueChange={setMainTab}>
+          <Tabs value={mainTab} onValueChange={handleMainTabChange}>
             <TabsList className="grid w-full grid-cols-2">
               <TabsTrigger value="calculator">Calcular Rendimiento</TabsTrigger>
             <TabsTrigger value="goal">Calcular Objetivo</TabsTrigger>


### PR DESCRIPTION
## 🚀 Pase a Producción — Release `develop` → `main`

Este PR agrupa los cambios acumulados en `develop` listos para pase a producción.

---

### 🧮 Calculadora de Inversión (investment-calculator)
- **Plazos anuales 60/72/84** en el modelo Tradicional, con sus textos de advertencia asociados.
- **Proyección Anual unificada** como LA tabla del modelo Tradicional (footer con totales que cuadran contra las filas).
- Correcciones de UX en el flujo **Calcular Objetivo**: no se renderiza la Proyección Anual en ese modo, no se clampa el plazo del objetivo al cambiar de tab, y se re-aplica el clamp de plazos de Tradicional al volver.
- **CI/CD:** se agrega `investment-calculator` al deploy de producción (workflow + Dockerfile + `.dockerignore`).

### 👥 CRM
- **Nueva plantilla de cobros:** impuesto de circulación (server + web, con tests).
- **Reasignación de leads reactivados por WhatsApp:** rebalanceo de leads y ajustes en la lógica de asignación (`lead-assignment`, `public-lead`, `bot`), incorporando el review de Codex.

---

### 📊 Resumen por área

| Área | Archivos | Detalle |
|------|----------|---------|
| Calculadora de Inversión | 6 | Plazos anuales, Proyección Anual unificada, fixes Calcular Objetivo, deploy prod |
| CRM | 9 | Plantilla impuesto de circulación + rebalanceo de leads por WhatsApp |
| CI/CD | 1 | `deploy-prod.yaml` |

**Total:** 16 archivos · +815 / −187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
