### PR TITLE
hotfix(investment): declarar @babel/runtime como dep directa (arregla build CI)

### DIFF
--- a/apps/investment-calculator/package.json
+++ b/apps/investment-calculator/package.json
@@ -15,6 +15,7 @@
     "push": "./deploy.sh"
   },
   "dependencies": {
+    "@babel/runtime": "^7.28.4",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-scroll-area": "^1.2.3",

--- a/bun.lock
+++ b/bun.lock
@@ -291,6 +291,7 @@
       "name": "@repo/investment-calculator",
       "version": "0.0.0",
       "dependencies": {
+        "@babel/runtime": "^7.28.4",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-scroll-area": "^1.2.3",


### PR DESCRIPTION
## Hotfix a main

El deploy de producción de **investment** murió en el paso de build:

```
[vite]: Rollup failed to resolve import "@babel/runtime/helpers/typeof" from ".../jspdf/dist/jspdf.es.min.js"
```

### Causa
El Dockerfile hace `npm install --legacy-peer-deps` aislado (sin lockfile). `@babel/runtime` es dependencia **transitiva** de jspdf, pero sin lockfile el hoisting al top-level no es determinista y a veces no queda resoluble para rollup. El build local (bun, con el `node_modules` hoisted del monorepo) nunca lo pegaba — por eso pasaba en dev y murió solo en CI.

### Fix
Declarar `@babel/runtime` (`^7.28.4`, igual que jspdf) como dependencia **directa** de la app: npm siempre hoistea las directas al top-level, eliminando la no-determinancia.

### Verificación
- Reproducido el fallo exacto en install aislado (quitando `@babel/runtime` del node_modules → mismo error de rollup).
- Con la dep directa: install aislado + `vite build` pasa.
- **podman build completo** (ruta idéntica a CI) → `✓ built`, imagen OK.
- Build local con bun sigue verde.

Va directo a main porque el pipeline de producción está roto; el mismo fix está incluido en el PR #1094 (→ develop) para que no haya drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)