### PR TITLE
feat(crm): pantalla oficial Historial de Buckets en Cobros (CB-006)

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -45,8 +45,8 @@ import {
 	recalculateCobrosPercentagesWithFallback,
 } from "../lib/cobros-capital-percentages";
 import {
-	PLANTILLAS_MENSAJES,
 	interpolar as interpolarPlantilla,
+	PLANTILLAS_MENSAJES,
 	prepararTelefonoAsesorParaEnvio,
 } from "../lib/cobros-plantillas";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
@@ -487,9 +487,7 @@ export const cobrosRouter = {
 
 					const estatusStats = recalculateCobrosPercentagesWithFallback(
 						[
-							...bucketsFunnel.map(
-								({ sumaCapitalCruda, ...bucket }) => bucket,
-							),
+							...bucketsFunnel.map(({ sumaCapitalCruda, ...bucket }) => bucket),
 							{
 								estadoMora: "completado",
 								totalCases: statsResponse.porEstado.cancelado?.cantidad || 0,
@@ -1562,6 +1560,67 @@ export const cobrosRouter = {
 	getBucketsCatalogo: cobrosProcedure.handler(async () => {
 		return getBucketsParaUIAsync();
 	}),
+
+	// CB-006: histórico de migraciones de bucket (motor COBROS-02) desde
+	// cartera-back (/buckets/historial). Solo admin/cobros_supervisor: expone
+	// movimientos de TODA la cartera, no la porción del asesor.
+	getBucketsHistorial: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				desde: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/)
+					.optional(),
+				hasta: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/)
+					.optional(),
+				tipoEvento: z.enum(["INICIAL", "SUBIDA", "BAJADA"]).optional(),
+				bucketNuevo: z.number().int().min(0).max(5).optional(),
+				numeroCreditoSifco: z.string().max(100).optional(),
+				nombreUsuario: z.string().max(200).optional(),
+				page: z.number().int().min(1).default(1),
+				pageSize: z.number().int().min(1).max(100).default(20),
+			}),
+		)
+		.handler(async ({ input }) => {
+			try {
+				return await carteraBackClient.getBucketsHistorial({
+					desde: input.desde,
+					hasta: input.hasta,
+					tipo_evento: input.tipoEvento,
+					bucket_nuevo:
+						input.bucketNuevo !== undefined
+							? String(input.bucketNuevo)
+							: undefined,
+					numero_credito_sifco: input.numeroCreditoSifco || undefined,
+					nombre_usuario: input.nombreUsuario || undefined,
+					page: input.page,
+					pageSize: input.pageSize,
+				});
+			} catch (error) {
+				console.error("[getBucketsHistorial] Error:", error);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "No se pudo obtener el historial de buckets",
+				});
+			}
+		}),
+
+	// CB-006: ficha por cuenta — historial completo de migraciones de UN crédito.
+	getBucketsHistorialCredito: cobrosSupervisorProcedure
+		.input(z.object({ creditoId: z.number().int().positive() }))
+		.handler(async ({ input }) => {
+			try {
+				return await carteraBackClient.getBucketsHistorialCredito(
+					input.creditoId,
+				);
+			} catch (error) {
+				console.error("[getBucketsHistorialCredito] Error:", error);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "No se pudo obtener el historial del crédito",
+				});
+			}
+		}),
 
 	// Obtener usuarios con rol de cobros para asignación
 	getUsuariosCobros: cobrosSupervisorProcedure.handler(async () => {
@@ -3660,7 +3719,7 @@ export const cobrosRouter = {
 					telefono: testMode ? getTestPhone(candidatos.length) : telefono,
 					telefonoReal: telefono,
 					mensaje,
-					casoCobroId: sifco ? casoIdPorSifco.get(sifco) ?? null : null,
+					casoCobroId: sifco ? (casoIdPorSifco.get(sifco) ?? null) : null,
 					clienteNombre,
 				});
 			}

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -141,6 +141,8 @@ export const cobrosAppRouter = {
 	asignarResponsableCobros: cobrosRouter.asignarResponsableCobros,
 	getUsuariosCobros: cobrosRouter.getUsuariosCobros,
 	getBucketsCatalogo: cobrosRouter.getBucketsCatalogo,
+	getBucketsHistorial: cobrosRouter.getBucketsHistorial,
+	getBucketsHistorialCredito: cobrosRouter.getBucketsHistorialCredito,
 	getHistorialPagos: cobrosRouter.getHistorialPagos,
 	getRecuperacionVehiculo: cobrosRouter.getRecuperacionVehiculo,
 	getTodosLosCreditos: cobrosRouter.getTodosLosCreditos,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -12,6 +12,8 @@ import type {
 	CarteraBackError,
 	CarteraBackValidationError,
 	CarteraBucketCatalogo,
+	CarteraBucketHistorialEvento,
+	CarteraBucketsHistorialResponse,
 	CarteraCredito,
 	CarteraInversionista,
 	CarteraPagoCredito,
@@ -28,6 +30,7 @@ import type {
 	FacturarGenericoResponse,
 	GetAdvisorsParams,
 	GetAllCreditsParams,
+	GetBucketsHistorialParams,
 	GetInvestorReportParams,
 	GetInvestorsParams,
 	GetPaymentsParams,
@@ -966,6 +969,43 @@ export class CarteraBackClient {
 			success: boolean;
 			data: CarteraBucketCatalogo[];
 		}>("/config/buckets", { method: "GET" }, true);
+		return response.data ?? [];
+	}
+
+	/**
+	 * Histórico de migraciones de bucket (motor COBROS-02), paginado con
+	 * filtros y resumen. Sin cache: el job puede correrse manual y la vista
+	 * de auditoría debe reflejarlo al instante.
+	 */
+	async getBucketsHistorial(
+		params: GetBucketsHistorialParams = {},
+	): Promise<CarteraBucketsHistorialResponse> {
+		const queryParams = new URLSearchParams({
+			...(params.desde && { desde: params.desde }),
+			...(params.hasta && { hasta: params.hasta }),
+			...(params.tipo_evento && { tipo_evento: params.tipo_evento }),
+			...(params.bucket_nuevo && { bucket_nuevo: params.bucket_nuevo }),
+			...(params.numero_credito_sifco && {
+				numero_credito_sifco: params.numero_credito_sifco,
+			}),
+			...(params.nombre_usuario && { nombre_usuario: params.nombre_usuario }),
+			...(params.page && { page: params.page.toString() }),
+			...(params.pageSize && { pageSize: params.pageSize.toString() }),
+		});
+		return this.request<CarteraBucketsHistorialResponse>(
+			`/buckets/historial?${queryParams}`,
+			{ method: "GET" },
+		);
+	}
+
+	/** Drill-down: historial completo de migraciones de UN crédito (la "ficha"). */
+	async getBucketsHistorialCredito(
+		creditoId: number,
+	): Promise<CarteraBucketHistorialEvento[]> {
+		const response = await this.request<{
+			success: boolean;
+			data: CarteraBucketHistorialEvento[];
+		}>(`/buckets/historial/credito/${creditoId}`, { method: "GET" });
 		return response.data ?? [];
 	}
 

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -683,6 +683,85 @@ export interface CarteraBucketCatalogo {
 }
 
 // ============================================================================
+// HISTORIAL DE BUCKETS (motor COBROS-02, GET /buckets/historial)
+// ============================================================================
+
+/** Fila del histórico de migraciones de bucket (`cartera.buckets_historial` + joins). */
+export interface CarteraBucketHistorialRow {
+	historial_id: number;
+	fecha: string;
+	credito_id: number;
+	numero_credito_sifco: string;
+	cliente: string;
+	asesor_id: number | null;
+	asesor: string | null;
+	tipo_evento: "INICIAL" | "SUBIDA" | "BAJADA";
+	origen: string;
+	bucket_anterior: number | null;
+	bucket_anterior_prefijo: string | null;
+	bucket_anterior_nombre: string | null;
+	bucket_nuevo: number;
+	bucket_nuevo_prefijo: string | null;
+	bucket_nuevo_nombre: string | null;
+	cuotas_atrasadas_nuevas: number | null;
+	status_credito: string | null;
+	status_actual: string;
+	capital: string;
+	asesor_atribucion_id: number | null;
+	asesor_atribucion: string | null;
+	pago_id: number | null;
+	motivo: string | null;
+}
+
+export interface CarteraBucketsHistorialResponse {
+	success: boolean;
+	data: CarteraBucketHistorialRow[];
+	pagination: {
+		page: number;
+		pageSize: number;
+		total: number;
+		totalPages: number;
+	};
+	resumen: {
+		total: number;
+		iniciales: number;
+		subidas: number;
+		bajadas: number;
+	};
+}
+
+export interface GetBucketsHistorialParams {
+	desde?: string; // YYYY-MM-DD (corte por día GT, inclusive)
+	hasta?: string; // YYYY-MM-DD
+	tipo_evento?: string; // CSV: INICIAL,SUBIDA,BAJADA
+	bucket_nuevo?: string; // CSV de enteros 0-5
+	numero_credito_sifco?: string; // ILIKE
+	nombre_usuario?: string; // cliente, ILIKE
+	page?: number;
+	pageSize?: number;
+}
+
+/** Evento del drill-down por crédito (GET /buckets/historial/credito/:id). */
+export interface CarteraBucketHistorialEvento {
+	historial_id: number;
+	fecha: string;
+	tipo_evento: "INICIAL" | "SUBIDA" | "BAJADA";
+	origen: string;
+	bucket_anterior: number | null;
+	bucket_anterior_prefijo: string | null;
+	bucket_anterior_nombre: string | null;
+	bucket_nuevo: number;
+	bucket_nuevo_prefijo: string | null;
+	bucket_nuevo_nombre: string | null;
+	cuotas_atrasadas_nuevas: number | null;
+	status_credito: string | null;
+	asesor_atribucion_id: number | null;
+	asesor_atribucion: string | null;
+	pago_id: number | null;
+	motivo: string | null;
+}
+
+// ============================================================================
 // FACTURACIÓN
 // ============================================================================
 

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -13,6 +13,7 @@ import {
 	FileText,
 	Gavel,
 	Landmark,
+	Layers,
 	LayoutDashboard,
 	Menu,
 	MessageSquare,
@@ -262,6 +263,14 @@ export default function Header() {
 											<Link to="/cobros/metas" className="cursor-pointer">
 												<Target className="mr-2 h-4 w-4" />
 												Metas de Mora
+											</Link>
+										</DropdownMenuItem>
+									)}
+									{PERMISSIONS.canAssignCobros(userRole) && (
+										<DropdownMenuItem asChild>
+											<Link to="/cobros/buckets" className="cursor-pointer">
+												<Layers className="mr-2 h-4 w-4" />
+												Historial de Buckets
 											</Link>
 										</DropdownMenuItem>
 									)}
@@ -609,6 +618,12 @@ function MobileNav({
 											<Link to="/cobros/metas" className={MOBILE_LINK_CLASS}>
 												<Target />
 												Metas de Mora
+											</Link>
+										)}
+										{PERMISSIONS.canAssignCobros(userRole) && (
+											<Link to="/cobros/buckets" className={MOBILE_LINK_CLASS}>
+												<Layers />
+												Historial de Buckets
 											</Link>
 										)}
 										{PERMISSIONS.canAssignCobros(userRole) && (

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as CrmCompaniesRouteImport } from './routes/crm/companies'
 import { Route as CrmClientsRouteImport } from './routes/crm/clients'
 import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
+import { Route as CobrosBucketsRouteImport } from './routes/cobros/buckets'
 import { Route as CobrosIdRouteImport } from './routes/cobros/$id'
 import { Route as AdminUsersRouteImport } from './routes/admin/users'
 import { Route as AdminSettingsRouteImport } from './routes/admin/settings'
@@ -171,6 +172,11 @@ const CobrosMetasRoute = CobrosMetasRouteImport.update({
   path: '/cobros/metas',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosBucketsRoute = CobrosBucketsRouteImport.update({
+  id: '/cobros/buckets',
+  path: '/cobros/buckets',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosIdRoute = CobrosIdRouteImport.update({
   id: '/cobros/$id',
   path: '/cobros/$id',
@@ -268,6 +274,7 @@ export interface FileRoutesByFullPath {
   '/admin/settings': typeof AdminSettingsRoute
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
+  '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
@@ -310,6 +317,7 @@ export interface FileRoutesByTo {
   '/admin/settings': typeof AdminSettingsRoute
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
+  '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
@@ -353,6 +361,7 @@ export interface FileRoutesById {
   '/admin/settings': typeof AdminSettingsRoute
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
+  '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
@@ -397,6 +406,7 @@ export interface FileRouteTypes {
     | '/admin/settings'
     | '/admin/users'
     | '/cobros/$id'
+    | '/cobros/buckets'
     | '/cobros/metas'
     | '/cobros/reportes'
     | '/crm/clients'
@@ -439,6 +449,7 @@ export interface FileRouteTypes {
     | '/admin/settings'
     | '/admin/users'
     | '/cobros/$id'
+    | '/cobros/buckets'
     | '/cobros/metas'
     | '/cobros/reportes'
     | '/crm/clients'
@@ -481,6 +492,7 @@ export interface FileRouteTypes {
     | '/admin/settings'
     | '/admin/users'
     | '/cobros/$id'
+    | '/cobros/buckets'
     | '/cobros/metas'
     | '/cobros/reportes'
     | '/crm/clients'
@@ -524,6 +536,7 @@ export interface RootRouteChildren {
   AdminSettingsRoute: typeof AdminSettingsRoute
   AdminUsersRoute: typeof AdminUsersRoute
   CobrosIdRoute: typeof CobrosIdRoute
+  CobrosBucketsRoute: typeof CobrosBucketsRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
   CobrosReportesRoute: typeof CobrosReportesRoute
   CrmClientsRoute: typeof CrmClientsRoute
@@ -727,6 +740,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CobrosMetasRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/buckets': {
+      id: '/cobros/buckets'
+      path: '/cobros/buckets'
+      fullPath: '/cobros/buckets'
+      preLoaderRoute: typeof CobrosBucketsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/$id': {
       id: '/cobros/$id'
       path: '/cobros/$id'
@@ -852,6 +872,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminSettingsRoute: AdminSettingsRoute,
   AdminUsersRoute: AdminUsersRoute,
   CobrosIdRoute: CobrosIdRoute,
+  CobrosBucketsRoute: CobrosBucketsRoute,
   CobrosMetasRoute: CobrosMetasRoute,
   CobrosReportesRoute: CobrosReportesRoute,
   CrmClientsRoute: CrmClientsRoute,

--- a/apps/crm/apps/web/src/routes/cobros/buckets.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/buckets.tsx
@@ -1,0 +1,687 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+	ArrowRight,
+	ChevronDown,
+	ChevronLeft,
+	ChevronRight,
+	Layers,
+	Loader2,
+	Search,
+	Sparkles,
+	TrendingDown,
+	TrendingUp,
+	X,
+} from "lucide-react";
+import { Fragment, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import {
+	type BucketsCatalogoQueryData,
+	bucketDeEstado,
+	estiloBucket,
+	useBucketsCatalogo,
+} from "@/lib/cobros/buckets-catalogo";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/buckets")({
+	component: BucketsHistorialPage,
+});
+
+/**
+ * Bucket numérico del motor (0-5) → key de estadoMora del catálogo de UI.
+ * Mismo puente numero↔estadoMora que usa cartera-back en /stats.
+ */
+const KEY_POR_NUMERO = [
+	"al_dia",
+	"mora_30",
+	"mora_60",
+	"mora_90",
+	"mora_120",
+	"mora_120_plus",
+] as const;
+
+const EVENTO_BADGE: Record<string, string> = {
+	// SUBIDA = empeora (rojo), BAJADA = cura (verde), INICIAL = línea base (azul).
+	SUBIDA: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+	BAJADA:
+		"bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+	INICIAL: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+};
+
+function EventoBadge({ tipo }: { tipo: string }) {
+	const icon =
+		tipo === "SUBIDA" ? (
+			<TrendingUp className="h-3 w-3" />
+		) : tipo === "BAJADA" ? (
+			<TrendingDown className="h-3 w-3" />
+		) : (
+			<Sparkles className="h-3 w-3" />
+		);
+	return (
+		<Badge
+			variant="outline"
+			className={`gap-1 border-transparent text-[10px] ${EVENTO_BADGE[tipo] ?? ""}`}
+		>
+			{icon}
+			{tipo}
+		</Badge>
+	);
+}
+
+/** Badge de bucket con label/color del catálogo dinámico (fuente única de la UI). */
+function BucketBadge({
+	numero,
+	catalogo,
+}: {
+	numero: number | null;
+	catalogo: BucketsCatalogoQueryData | undefined;
+}) {
+	if (numero === null || numero === undefined) {
+		return <span className="text-muted-foreground text-xs">—</span>;
+	}
+	const ui = bucketDeEstado(KEY_POR_NUMERO[numero], catalogo);
+	return (
+		<Badge
+			variant="outline"
+			className="whitespace-nowrap text-[10px]"
+			style={estiloBucket(ui.colorHex)}
+			title={ui.label}
+		>
+			B{numero}
+		</Badge>
+	);
+}
+
+/** Transición Bx → By del evento (INICIAL no tiene anterior). */
+function Transicion({
+	anterior,
+	nuevo,
+	catalogo,
+}: {
+	anterior: number | null;
+	nuevo: number;
+	catalogo: BucketsCatalogoQueryData | undefined;
+}) {
+	return (
+		<span className="inline-flex items-center gap-1.5">
+			<BucketBadge numero={anterior} catalogo={catalogo} />
+			<ArrowRight className="h-3 w-3 text-muted-foreground" />
+			<BucketBadge numero={nuevo} catalogo={catalogo} />
+		</span>
+	);
+}
+
+/**
+ * Fecha del evento en día GUATEMALA: los filtros desde/hasta del endpoint
+ * cortan por día GT y el job corre ~23:59 GT (~05:59 UTC del día siguiente) —
+ * mostrar el string UTC crudo descuadraría la fecha visible contra el filtro.
+ */
+function fechaEventoGT(v: string) {
+	const d = new Date(v);
+	if (Number.isNaN(d.getTime())) return String(v ?? "").slice(0, 16);
+	const fecha = d.toLocaleDateString("es-GT", {
+		timeZone: "America/Guatemala",
+		day: "2-digit",
+		month: "2-digit",
+		year: "numeric",
+	});
+	const hora = d.toLocaleTimeString("es-GT", {
+		timeZone: "America/Guatemala",
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
+	return `${fecha} ${hora}`;
+}
+
+/** Cuotas atrasadas + su etiqueta de negocio en días (1 cuota ≈ 30 días). */
+function AtrasoCell({ cuotas }: { cuotas: number | null }) {
+	if (cuotas === null || cuotas === undefined) {
+		return <span className="text-muted-foreground">—</span>;
+	}
+	return (
+		<div className="text-center">
+			<p className="font-medium">
+				{cuotas} {cuotas === 1 ? "cuota" : "cuotas"}
+			</p>
+			<p className="text-muted-foreground text-xs">≈ {cuotas * 30} días</p>
+		</div>
+	);
+}
+
+/** Ficha por cuenta (CB-006): historial completo de migraciones del crédito. */
+function FichaCredito({
+	creditoId,
+	catalogo,
+}: {
+	creditoId: number;
+	catalogo: BucketsCatalogoQueryData | undefined;
+}) {
+	const fichaQuery = useQuery(
+		orpc.getBucketsHistorialCredito.queryOptions({
+			input: { creditoId },
+		}),
+	);
+
+	if (fichaQuery.isLoading) {
+		return (
+			<div className="flex items-center justify-center gap-2 py-4 text-muted-foreground text-sm">
+				<Loader2 className="h-4 w-4 animate-spin" />
+				Cargando ficha del crédito...
+			</div>
+		);
+	}
+	if (fichaQuery.isError) {
+		return (
+			<p className="py-4 text-center text-destructive text-sm">
+				Error al cargar la ficha del crédito
+			</p>
+		);
+	}
+	const eventos = fichaQuery.data ?? [];
+	if (eventos.length === 0) {
+		return (
+			<p className="py-4 text-center text-muted-foreground text-sm italic">
+				Sin migraciones registradas para este crédito.
+			</p>
+		);
+	}
+
+	return (
+		<div className="space-y-2 py-2">
+			<p className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+				Ficha del crédito — {eventos.length}{" "}
+				{eventos.length === 1 ? "evento" : "eventos"}
+			</p>
+			<table className="w-full text-xs">
+				<thead>
+					<tr className="border-b text-left text-muted-foreground">
+						<th className="px-2 py-1.5 font-medium">Fecha</th>
+						<th className="px-2 py-1.5 font-medium">Evento</th>
+						<th className="px-2 py-1.5 font-medium">Transición</th>
+						<th className="px-2 py-1.5 text-center font-medium">Atraso</th>
+						<th className="px-2 py-1.5 font-medium">Atribución</th>
+						<th className="px-2 py-1.5 font-medium">Motivo</th>
+					</tr>
+				</thead>
+				<tbody>
+					{eventos.map((ev) => (
+						<tr key={ev.historial_id} className="border-b last:border-0">
+							<td className="whitespace-nowrap px-2 py-1.5">
+								{fechaEventoGT(ev.fecha)}
+							</td>
+							<td className="px-2 py-1.5">
+								<EventoBadge tipo={ev.tipo_evento} />
+							</td>
+							<td className="px-2 py-1.5">
+								<Transicion
+									anterior={ev.bucket_anterior}
+									nuevo={ev.bucket_nuevo}
+									catalogo={catalogo}
+								/>
+							</td>
+							<td className="px-2 py-1.5 text-center">
+								{ev.cuotas_atrasadas_nuevas ?? "—"}
+							</td>
+							<td className="px-2 py-1.5 text-muted-foreground">
+								{ev.asesor_atribucion ??
+									(ev.pago_id ? `Pago #${ev.pago_id}` : "—")}
+							</td>
+							<td
+								className="max-w-[280px] truncate px-2 py-1.5 text-muted-foreground"
+								title={ev.motivo ?? undefined}
+							>
+								{ev.motivo ?? "—"}
+							</td>
+						</tr>
+					))}
+				</tbody>
+			</table>
+		</div>
+	);
+}
+
+const PAGE_SIZES = [20, 50, 100] as const;
+
+function BucketsHistorialPage() {
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user?.role;
+
+	const [desde, setDesde] = useState("");
+	const [hasta, setHasta] = useState("");
+	const [tipoEvento, setTipoEvento] = useState("todos");
+	const [bucketNuevo, setBucketNuevo] = useState("todos");
+	const [sifcoInput, setSifcoInput] = useState("");
+	const [clienteInput, setClienteInput] = useState("");
+	const [sifco, setSifco] = useState("");
+	const [cliente, setCliente] = useState("");
+	const [page, setPage] = useState(1);
+	const [pageSize, setPageSize] = useState<number>(20);
+	const [expandedCreditoId, setExpandedCreditoId] = useState<number | null>(
+		null,
+	);
+
+	const catalogoQuery = useBucketsCatalogo();
+	const catalogo = catalogoQuery.data;
+
+	const historialQuery = useQuery({
+		...orpc.getBucketsHistorial.queryOptions({
+			input: {
+				desde: desde || undefined,
+				hasta: hasta || undefined,
+				tipoEvento:
+					tipoEvento === "todos"
+						? undefined
+						: (tipoEvento as "INICIAL" | "SUBIDA" | "BAJADA"),
+				bucketNuevo: bucketNuevo === "todos" ? undefined : Number(bucketNuevo),
+				numeroCreditoSifco: sifco || undefined,
+				nombreUsuario: cliente || undefined,
+				page,
+				pageSize,
+			},
+		}),
+		enabled: !!session,
+	});
+
+	const aplicarBusqueda = () => {
+		setSifco(sifcoInput.trim());
+		setCliente(clienteInput.trim());
+		setPage(1);
+	};
+
+	const limpiarFiltros = () => {
+		setDesde("");
+		setHasta("");
+		setTipoEvento("todos");
+		setBucketNuevo("todos");
+		setSifcoInput("");
+		setClienteInput("");
+		setSifco("");
+		setCliente("");
+		setPage(1);
+	};
+
+	const filtrosActivos =
+		(desde ? 1 : 0) +
+		(hasta ? 1 : 0) +
+		(tipoEvento !== "todos" ? 1 : 0) +
+		(bucketNuevo !== "todos" ? 1 : 0) +
+		(sifco ? 1 : 0) +
+		(cliente ? 1 : 0);
+
+	if (!userRole || !PERMISSIONS.canAssignCobros(userRole)) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<div className="text-center">
+					<h1 className="mb-4 font-bold text-2xl text-gray-800">
+						Acceso Denegado
+					</h1>
+					<p className="text-gray-600">
+						Solo supervisores y administradores pueden ver el historial de
+						buckets.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const rows = historialQuery.data?.data ?? [];
+	const resumen = historialQuery.data?.resumen;
+	const pagination = historialQuery.data?.pagination;
+	const totalPages = pagination?.totalPages ?? 1;
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<div>
+				<h1 className="flex items-center gap-2 font-bold text-3xl">
+					<Layers className="h-7 w-7" />
+					Historial de Buckets
+				</h1>
+				<p className="text-muted-foreground">
+					Migraciones de bucket por cuenta registradas por el motor de cobros —
+					cada movimiento queda con su evento, atraso y transición.
+				</p>
+			</div>
+
+			{/* Filtros */}
+			<Card>
+				<CardContent className="pt-6">
+					<div className="flex flex-wrap items-end gap-3">
+						<div className="space-y-1">
+							<p className="font-medium text-muted-foreground text-xs">Desde</p>
+							<Input
+								type="date"
+								value={desde}
+								onChange={(e) => {
+									setDesde(e.target.value);
+									setPage(1);
+								}}
+								className="w-[150px]"
+							/>
+						</div>
+						<div className="space-y-1">
+							<p className="font-medium text-muted-foreground text-xs">Hasta</p>
+							<Input
+								type="date"
+								value={hasta}
+								onChange={(e) => {
+									setHasta(e.target.value);
+									setPage(1);
+								}}
+								className="w-[150px]"
+							/>
+						</div>
+						<div className="space-y-1">
+							<p className="font-medium text-muted-foreground text-xs">
+								Evento
+							</p>
+							<Select
+								value={tipoEvento}
+								onValueChange={(v) => {
+									setTipoEvento(v);
+									setPage(1);
+								}}
+							>
+								<SelectTrigger className="w-[140px]">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="todos">Todos</SelectItem>
+									<SelectItem value="SUBIDA">Subidas</SelectItem>
+									<SelectItem value="BAJADA">Bajadas</SelectItem>
+									<SelectItem value="INICIAL">Iniciales</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="space-y-1">
+							<p className="font-medium text-muted-foreground text-xs">
+								Bucket destino
+							</p>
+							<Select
+								value={bucketNuevo}
+								onValueChange={(v) => {
+									setBucketNuevo(v);
+									setPage(1);
+								}}
+							>
+								<SelectTrigger className="w-[210px]">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="todos">Todos</SelectItem>
+									{KEY_POR_NUMERO.map((key, numero) => {
+										const ui = bucketDeEstado(key, catalogo);
+										return (
+											<SelectItem key={key} value={String(numero)}>
+												B{numero} · {ui.label}
+											</SelectItem>
+										);
+									})}
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="min-w-[160px] flex-1 space-y-1">
+							<p className="font-medium text-muted-foreground text-xs">
+								No. SIFCO
+							</p>
+							<Input
+								placeholder="Buscar SIFCO..."
+								value={sifcoInput}
+								onChange={(e) => setSifcoInput(e.target.value)}
+								onKeyDown={(e) => e.key === "Enter" && aplicarBusqueda()}
+							/>
+						</div>
+						<div className="min-w-[160px] flex-1 space-y-1">
+							<p className="font-medium text-muted-foreground text-xs">
+								Cliente
+							</p>
+							<Input
+								placeholder="Buscar nombre..."
+								value={clienteInput}
+								onChange={(e) => setClienteInput(e.target.value)}
+								onKeyDown={(e) => e.key === "Enter" && aplicarBusqueda()}
+							/>
+						</div>
+						<Button variant="outline" size="sm" onClick={aplicarBusqueda}>
+							<Search className="mr-1 h-4 w-4" />
+							Buscar
+						</Button>
+						{filtrosActivos > 0 ? (
+							<Button variant="ghost" size="sm" onClick={limpiarFiltros}>
+								<X className="mr-1 h-4 w-4" />
+								Limpiar ({filtrosActivos})
+							</Button>
+						) : null}
+					</div>
+				</CardContent>
+			</Card>
+
+			{/* Resumen */}
+			{resumen ? (
+				<div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+					<Card>
+						<CardContent className="pt-6 text-center">
+							<p className="text-muted-foreground text-xs">Eventos</p>
+							<p className="font-bold text-2xl">
+								{resumen.total.toLocaleString("es-GT")}
+							</p>
+						</CardContent>
+					</Card>
+					<Card>
+						<CardContent className="pt-6 text-center">
+							<p className="flex items-center justify-center gap-1 text-muted-foreground text-xs">
+								<TrendingUp className="h-3 w-3" /> Subidas
+							</p>
+							<p className="font-bold text-2xl text-red-600 dark:text-red-400">
+								{resumen.subidas.toLocaleString("es-GT")}
+							</p>
+						</CardContent>
+					</Card>
+					<Card>
+						<CardContent className="pt-6 text-center">
+							<p className="flex items-center justify-center gap-1 text-muted-foreground text-xs">
+								<TrendingDown className="h-3 w-3" /> Bajadas (curadas)
+							</p>
+							<p className="font-bold text-2xl text-emerald-600 dark:text-emerald-400">
+								{resumen.bajadas.toLocaleString("es-GT")}
+							</p>
+						</CardContent>
+					</Card>
+					<Card>
+						<CardContent className="pt-6 text-center">
+							<p className="flex items-center justify-center gap-1 text-muted-foreground text-xs">
+								<Sparkles className="h-3 w-3" /> Iniciales
+							</p>
+							<p className="font-bold text-2xl text-blue-600 dark:text-blue-400">
+								{resumen.iniciales.toLocaleString("es-GT")}
+							</p>
+						</CardContent>
+					</Card>
+				</div>
+			) : null}
+
+			{/* Tabla */}
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-lg">Migraciones</CardTitle>
+					<CardDescription>
+						Haz clic en una fila para ver la ficha completa del crédito; el No.
+						SIFCO abre el detalle del caso.
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{historialQuery.isLoading ? (
+						<div className="flex items-center justify-center py-12">
+							<Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+						</div>
+					) : historialQuery.isError ? (
+						<p className="py-12 text-center text-destructive">
+							Error al cargar el historial de buckets
+						</p>
+					) : rows.length === 0 ? (
+						<p className="py-12 text-center text-muted-foreground">
+							No hay migraciones para los filtros seleccionados
+						</p>
+					) : (
+						<>
+							<div className="overflow-x-auto">
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead className="w-8" />
+											<TableHead>Fecha</TableHead>
+											<TableHead>No. SIFCO</TableHead>
+											<TableHead>Cliente</TableHead>
+											<TableHead className="text-center">Evento</TableHead>
+											<TableHead className="text-center">Transición</TableHead>
+											<TableHead className="text-center">
+												Días de atraso
+											</TableHead>
+											<TableHead>Asesor actual</TableHead>
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{rows.map((r) => {
+											const expanded = expandedCreditoId === r.credito_id;
+											return (
+												<Fragment key={r.historial_id}>
+													<TableRow
+														className="cursor-pointer"
+														onClick={() =>
+															setExpandedCreditoId(
+																expanded ? null : r.credito_id,
+															)
+														}
+													>
+														<TableCell>
+															<ChevronDown
+																className={`h-4 w-4 text-muted-foreground transition-transform ${
+																	expanded ? "" : "-rotate-90"
+																}`}
+															/>
+														</TableCell>
+														<TableCell className="whitespace-nowrap text-muted-foreground text-xs">
+															{fechaEventoGT(r.fecha)}
+														</TableCell>
+														<TableCell>
+															<Link
+																to="/cobros/$id"
+																params={{ id: r.numero_credito_sifco }}
+																search={{ tipo: "caso" }}
+																className="font-medium text-primary hover:underline"
+																onClick={(e) => e.stopPropagation()}
+															>
+																{r.numero_credito_sifco}
+															</Link>
+														</TableCell>
+														<TableCell>{r.cliente}</TableCell>
+														<TableCell className="text-center">
+															<EventoBadge tipo={r.tipo_evento} />
+														</TableCell>
+														<TableCell className="text-center">
+															<Transicion
+																anterior={r.bucket_anterior}
+																nuevo={r.bucket_nuevo}
+																catalogo={catalogo}
+															/>
+														</TableCell>
+														<TableCell>
+															<AtrasoCell cuotas={r.cuotas_atrasadas_nuevas} />
+														</TableCell>
+														<TableCell className="text-sm">
+															{r.asesor ?? "—"}
+														</TableCell>
+													</TableRow>
+													{expanded ? (
+														<TableRow className="bg-muted/40 hover:bg-muted/40">
+															<TableCell colSpan={8} className="px-6">
+																<FichaCredito
+																	creditoId={r.credito_id}
+																	catalogo={catalogo}
+																/>
+															</TableCell>
+														</TableRow>
+													) : null}
+												</Fragment>
+											);
+										})}
+									</TableBody>
+								</Table>
+							</div>
+
+							{/* Paginación */}
+							<div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+								<p className="text-muted-foreground text-sm">
+									Página {pagination?.page ?? 1} de {totalPages} (
+									{(pagination?.total ?? 0).toLocaleString("es-GT")} eventos)
+								</p>
+								<div className="flex items-center gap-2">
+									<Select
+										value={String(pageSize)}
+										onValueChange={(v) => {
+											setPageSize(Number(v));
+											setPage(1);
+										}}
+									>
+										<SelectTrigger className="w-[130px]">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{PAGE_SIZES.map((n) => (
+												<SelectItem key={n} value={String(n)}>
+													{n} por página
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+									<Button
+										variant="outline"
+										size="sm"
+										disabled={page <= 1}
+										onClick={() => setPage((p) => p - 1)}
+									>
+										<ChevronLeft className="h-4 w-4" />
+									</Button>
+									<Button
+										variant="outline"
+										size="sm"
+										disabled={page >= totalPages}
+										onClick={() => setPage((p) => p + 1)}
+									>
+										<ChevronRight className="h-4 w-4" />
+									</Button>
+								</div>
+							</div>
+						</>
+					)}
+				</CardContent>
+			</Card>
+		</div>
+	);
+}


### PR DESCRIPTION
## Historia

**[CB-006]** _Como gerente, quiero ver historial de migración de bucket por cuenta para analizar comportamiento de pago._ (Épica: Motor de buckets y mora · Sprint 14)

El módulo temporal de cartera front (PR #1069) se gradúa al CRM como pantalla oficial, consumiendo **el mismo endpoint** del motor (`GET /buckets/historial` de cartera-back).

## Criterios de aceptación

> La ficha muestra bucket anterior, bucket nuevo, fecha, días de atraso, cuota vencida y evento relacionado.

- **Bucket anterior → nuevo**: transición en badges con el label/color del **catálogo dinámico** (`lib/cobros/buckets-catalogo.ts` — fuente única de la UI, nada hardcodeado).
- **Fecha**: en día/hora Guatemala (los filtros del endpoint cortan por día GT; mostrar el UTC crudo descuadraría fecha visible vs filtro).
- **Días de atraso / cuota vencida**: cuotas atrasadas del evento + su etiqueta de negocio en días (1 cuota ≈ 30 días).
- **Evento relacionado**: SUBIDA / BAJADA / INICIAL, y en la ficha la atribución (asesor de la cura o pago) y el motivo.
- **Por cuenta**: cada fila expande la **ficha completa del crédito** (drill-down `/buckets/historial/credito/:id`) y el No. SIFCO abre el detalle del caso (`/cobros/$id`).
- Alimenta visualmente **Bucket Migration Rate** y **Cuentas Curadas**: cards de resumen con subidas vs bajadas (curadas) del período filtrado.

## Permisos

Solo **admin** y **cobros_supervisor**, en las tres capas: procedure con `cobrosSupervisorProcedure` (server), guard de página (patrón de metas.tsx) e item de navbar con `canAssignCobros`. El rol `cobros` no lo ve ni puede llamar el endpoint.

## Detalle técnico

- **Server**: tipos en `types/cartera-back.ts`, métodos en `cartera-back-client.ts` (sin cache — si corren el job manual, la auditoría lo refleja al instante), procedures en `routers/cobros.ts`, registro en `routers/index.ts`.
- **Web**: ruta `routes/cobros/buckets.tsx` 100% con componentes existentes del CRM (shadcn Card/Table/Select/Badge, dark mode); filtros: fechas, evento, bucket destino (catálogo), SIFCO, cliente; paginación 20/50/100. Header con el item nuevo (desktop + mobile). routeTree regenerado.

## Verificación

- Biome limpio en los archivos del PR (el error de `cobros.ts:810` es preexistente).
- `tsc` del server: solo el error preexistente de `auth.ts` (zod). **Nota:** el `check-types` del web está roto de base (1,009 errores preexistentes — `orpc.ts:12` importa `proyeccionRouter` y la inferencia de todo el appRouter muere; todas las rutas lo padecen). Este PR no agrega errores netos, pero vale la pena arreglar ese import en un PR aparte para revivir el typecheck del front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)