### PR TITLE
feat(cobros): reasignación manual de asesor por bucket (CB-017)

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/reasignarAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/reasignarAsesor.test.ts
@@ -1,0 +1,287 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+/**
+ * Tests del controller REAL reasignarAsesorManual/getAsesoresPorBucket con la
+ * DB (frontera del sistema) fakeada — mismo patrón que latefee.test.ts (motor
+ * automático de la misma carpeta): un fakeDb que despacha por identidad de
+ * tabla drizzle y graba inserts/updates/transacciones. Nada de lógica
+ * duplicada: se prueba el módulo tal cual corre en producción.
+ */
+
+type Fila = Record<string, any>;
+
+const estado = {
+  // Resultado configurable por test para cada select, por tabla drizzle.
+  selectsPorTabla: new Map<any, Fila[]>(),
+  // Resultado configurable para el db.execute() crudo (bucketActualDeCredito).
+  executeResult: { rows: [] as Fila[] },
+  inserts: [] as { tabla: any; filas: Fila[] }[],
+  updates: [] as { tabla: any; set: Fila }[],
+};
+
+function crearBuilderSelect() {
+  let tabla: any = null;
+  const b: any = {
+    from(t: any) {
+      tabla = t;
+      return b;
+    },
+    innerJoin() {
+      return b;
+    },
+    leftJoin() {
+      return b;
+    },
+    where() {
+      return b;
+    },
+    orderBy() {
+      return b;
+    },
+    limit() {
+      return b;
+    },
+    then(res: any, rej: any) {
+      return Promise.resolve(estado.selectsPorTabla.get(tabla) ?? []).then(res, rej);
+    },
+  };
+  return b;
+}
+
+function crearMutadores() {
+  return {
+    insert(tabla: any) {
+      return {
+        values(v: Fila | Fila[]) {
+          const filas = Array.isArray(v) ? v : [v];
+          estado.inserts.push({ tabla, filas });
+          return Promise.resolve(filas);
+        },
+      };
+    },
+    update(tabla: any) {
+      return {
+        set(s: Fila) {
+          estado.updates.push({ tabla, set: s });
+          return { where: () => Promise.resolve([]) };
+        },
+      };
+    },
+  };
+}
+
+const fakeDb: any = {
+  select: () => crearBuilderSelect(),
+  ...crearMutadores(),
+  execute: async () => estado.executeResult,
+  transaction: async (cb: any) => cb(crearMutadores()),
+};
+
+mock.module("../../database", () => ({ db: fakeDb }));
+
+const schema = await import("../../database/db/schema");
+const {
+  getAsesoresPorBucket,
+  reasignarAsesorManual,
+} = await import("./reasignarAsesor");
+
+// Helper: setea el resultado de bucketActualDeCredito (db.execute crudo).
+function setBucketActual(bucket: number | null, fuera = false) {
+  estado.executeResult = {
+    rows: [{ bucket, fuera }],
+  };
+}
+
+beforeEach(() => {
+  estado.selectsPorTabla.clear();
+  estado.executeResult = { rows: [] };
+  estado.inserts = [];
+  estado.updates = [];
+});
+
+describe("getAsesoresPorBucket", () => {
+  it("devuelve el pool tal cual lo da la query", async () => {
+    estado.selectsPorTabla.set(schema.asesor_bucket, [
+      { asesor_id: 2, nombre: "Samuel Gamboa" },
+      { asesor_id: 7, nombre: "Erik Rivas" },
+    ]);
+    const pool = await getAsesoresPorBucket(2);
+    expect(pool).toEqual([
+      { asesor_id: 2, nombre: "Samuel Gamboa" },
+      { asesor_id: 7, nombre: "Erik Rivas" },
+    ]);
+  });
+
+  it("pool vacío cuando el bucket no tiene asesores", async () => {
+    const pool = await getAsesoresPorBucket(3);
+    expect(pool).toEqual([]);
+  });
+});
+
+describe("reasignarAsesorManual — controller real con DB fakeada", () => {
+  it("reasigna correctamente: bitácora + UPDATE en una transacción", async () => {
+    estado.selectsPorTabla.set(schema.creditos, [{ asesor_id: 2 }]);
+    setBucketActual(1);
+    estado.selectsPorTabla.set(schema.asesor_bucket, [
+      { asesor_id: 2, nombre: "Samuel Gamboa" },
+      { asesor_id: 7, nombre: "Erik Rivas" },
+    ]);
+    estado.selectsPorTabla.set(schema.platform_users, [{ id: 55 }]);
+
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 7,
+      motivo: "Rotación por vacaciones",
+      usuario_email: "supervisor@clubcashin.com",
+    });
+
+    expect(r).toEqual({
+      success: true,
+      credito_id: 9116,
+      asesor_anterior: 2,
+      asesor_nuevo: 7,
+      bucket: 1,
+    });
+
+    // Bitácora: origen API_MANUAL, motivo, usuario_id resuelto, snapshot de bucket.
+    expect(estado.inserts).toHaveLength(1);
+    expect(estado.inserts[0].tabla).toBe(schema.credito_asesor_historial);
+    expect(estado.inserts[0].filas[0]).toMatchObject({
+      credito_id: 9116,
+      asesor_anterior: 2,
+      asesor_nuevo: 7,
+      bucket: 1,
+      origen: "API_MANUAL",
+      motivo: "Rotación por vacaciones",
+      usuario_id: 55,
+    });
+
+    // UPDATE: ÚNICAMENTE asesor_id (decisión de raíz, nada más del crédito).
+    expect(estado.updates).toHaveLength(1);
+    expect(estado.updates[0].tabla).toBe(schema.creditos);
+    expect(estado.updates[0].set).toEqual({ asesor_id: 7 });
+  });
+
+  it("rechaza motivo vacío sin tocar la DB de escritura (400)", async () => {
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 7,
+      motivo: "   ",
+    });
+    expect(r).toMatchObject({ success: false, status: 400 });
+    expect(estado.inserts).toHaveLength(0);
+    expect(estado.updates).toHaveLength(0);
+  });
+
+  it("404 cuando el crédito no existe", async () => {
+    // selectsPorTabla sin entrada para creditos → [] → no encontrado.
+    const r = await reasignarAsesorManual({
+      credito_id: 424242,
+      asesor_nuevo_id: 7,
+      motivo: "motivo válido",
+    });
+    expect(r).toMatchObject({ success: false, status: 404 });
+  });
+
+  it("rechaza crédito fuera del funnel operativo (bucket null, 400)", async () => {
+    estado.selectsPorTabla.set(schema.creditos, [{ asesor_id: 2 }]);
+    setBucketActual(null, true);
+
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 7,
+      motivo: "motivo válido",
+    });
+    expect(r).toMatchObject({ success: false, status: 400 });
+    expect((r as any).message).toContain("fuera del funnel");
+    expect(estado.inserts).toHaveLength(0);
+  });
+
+  it("rechaza asesor no elegible en el pool del bucket (400)", async () => {
+    estado.selectsPorTabla.set(schema.creditos, [{ asesor_id: 2 }]);
+    setBucketActual(1);
+    estado.selectsPorTabla.set(schema.asesor_bucket, [
+      { asesor_id: 2, nombre: "Samuel Gamboa" },
+    ]);
+
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 99,
+      motivo: "motivo válido",
+    });
+    expect(r).toMatchObject({ success: false, status: 400 });
+    expect((r as any).message).toContain("no es elegible");
+    expect(estado.inserts).toHaveLength(0);
+  });
+
+  it("rechaza no-op: reasignar al mismo asesor actual (400)", async () => {
+    estado.selectsPorTabla.set(schema.creditos, [{ asesor_id: 2 }]);
+    setBucketActual(1);
+    estado.selectsPorTabla.set(schema.asesor_bucket, [
+      { asesor_id: 2, nombre: "Samuel Gamboa" },
+    ]);
+
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 2,
+      motivo: "motivo válido",
+    });
+    expect(r).toMatchObject({ success: false, status: 400 });
+    expect((r as any).message).toContain("ya está asignado");
+    expect(estado.inserts).toHaveLength(0);
+  });
+
+  it("usuario_id queda null si el email no resuelve en platform_users (best-effort)", async () => {
+    estado.selectsPorTabla.set(schema.creditos, [{ asesor_id: 2 }]);
+    setBucketActual(1);
+    estado.selectsPorTabla.set(schema.asesor_bucket, [
+      { asesor_id: 2, nombre: "Samuel Gamboa" },
+      { asesor_id: 7, nombre: "Erik Rivas" },
+    ]);
+    // platform_users sin entrada → [] → no resuelve.
+
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 7,
+      motivo: "motivo válido",
+      usuario_email: "no-existe@clubcashin.com",
+    });
+
+    expect(r).toMatchObject({ success: true });
+    expect(estado.inserts[0].filas[0].usuario_id).toBeNull();
+  });
+
+  it("usuario_id null cuando no se envía usuario_email", async () => {
+    estado.selectsPorTabla.set(schema.creditos, [{ asesor_id: 2 }]);
+    setBucketActual(1);
+    estado.selectsPorTabla.set(schema.asesor_bucket, [
+      { asesor_id: 2, nombre: "Samuel Gamboa" },
+      { asesor_id: 7, nombre: "Erik Rivas" },
+    ]);
+
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 7,
+      motivo: "motivo válido",
+    });
+
+    expect(r).toMatchObject({ success: true });
+    expect(estado.inserts[0].filas[0].usuario_id).toBeNull();
+  });
+
+  it("permite reasignar un crédito sin asesor actual (asesor_id null)", async () => {
+    estado.selectsPorTabla.set(schema.creditos, [{ asesor_id: null }]);
+    setBucketActual(1);
+    estado.selectsPorTabla.set(schema.asesor_bucket, [
+      { asesor_id: 7, nombre: "Erik Rivas" },
+    ]);
+
+    const r = await reasignarAsesorManual({
+      credito_id: 9116,
+      asesor_nuevo_id: 7,
+      motivo: "motivo válido",
+    });
+
+    expect(r).toMatchObject({ success: true, asesor_anterior: null, asesor_nuevo: 7 });
+  });
+});

--- a/apps/cartera-back/src/controllers/buckets/reasignarAsesor.ts
+++ b/apps/cartera-back/src/controllers/buckets/reasignarAsesor.ts
@@ -1,0 +1,179 @@
+import { and, eq, sql } from "drizzle-orm";
+import { db } from "../../database";
+import {
+  asesor_bucket,
+  asesores,
+  credito_asesor_historial,
+  creditos,
+  platform_users,
+  SQL_CARTERA_SCHEMA,
+} from "../../database/db/schema";
+import { STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// COBROS-02 · Buckets — Reasignación MANUAL de asesor (supervisor/gerente).
+// Contraparte manual del motor automático (controllers/latefee.ts): mismo par
+// UPDATE creditos.asesor_id + INSERT credito_asesor_historial en una transacción
+// (decisión de raíz, schema.ts:527-549), pero con origen=API_MANUAL, el usuario_id
+// del que lo hizo y motivo OBLIGATORIO. Solo se permite reasignar a un asesor que
+// ya esté en el pool (asesor_bucket) del bucket ACTUAL del crédito.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type PoolAsesor = { asesor_id: number; nombre: string };
+
+/**
+ * Asesores elegibles (pool activo) de un bucket. Alimenta el dropdown del modal
+ * de reasignación en el CRM y es la misma fuente que valida el server-side.
+ */
+export async function getAsesoresPorBucket(bucket: number): Promise<PoolAsesor[]> {
+  const rows = await db
+    .select({ asesor_id: asesor_bucket.asesor_id, nombre: asesores.nombre })
+    .from(asesor_bucket)
+    .innerJoin(asesores, eq(asesores.asesor_id, asesor_bucket.asesor_id))
+    .where(and(eq(asesor_bucket.bucket, bucket), eq(asesor_bucket.activo, true)))
+    .orderBy(asesores.nombre);
+  return rows;
+}
+
+/**
+ * Bucket ACTUAL de un crédito — misma fuente que el listado /buckets/creditos
+ * (getCreditosWithUserByMesAnio): COALESCE(último de buckets_historial → estado
+ * que fuerza bucket vía estados_incluidos → rango de cuotas de la mora activa).
+ * Devuelve null si el crédito está fuera del funnel operativo (no se reasigna).
+ */
+async function bucketActualDeCredito(credito_id: number): Promise<number | null> {
+  const fueraSql = sql.join(STATUS_BUCKET_FUERA.map((s) => sql`${s}`), sql`, `);
+  const res = await db.execute<{ bucket: number | null; fuera: boolean }>(sql`
+    SELECT
+      (c."statusCredit" IN (${fueraSql})) AS fuera,
+      COALESCE(
+        (SELECT h.bucket_nuevo FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+          WHERE h.credito_id = c.credito_id
+          ORDER BY h.fecha DESC, h.historial_id DESC
+          LIMIT 1),
+        (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
+          WHERE b.activo = true
+            AND c."statusCredit" = ANY (b.estados_incluidos)
+          ORDER BY b.numero LIMIT 1),
+        (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
+          WHERE b.activo = true
+            AND COALESCE(m.cuotas_atrasadas, 0) >= b.cuotas_min
+            AND (b.cuotas_max IS NULL OR COALESCE(m.cuotas_atrasadas, 0) <= b.cuotas_max)
+          ORDER BY b.numero LIMIT 1)
+      ) AS bucket
+    FROM ${SQL_CARTERA_SCHEMA}.creditos c
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
+      ON m.credito_id = c.credito_id AND m.activa = true
+    WHERE c.credito_id = ${credito_id}
+    LIMIT 1
+  `);
+  const row = res.rows?.[0];
+  if (!row) return null;
+  if (row.fuera) return null;
+  return row.bucket === null || row.bucket === undefined ? null : Number(row.bucket);
+}
+
+export type ReasignarAsesorResultado =
+  | {
+      success: true;
+      credito_id: number;
+      asesor_anterior: number | null;
+      asesor_nuevo: number;
+      bucket: number;
+    }
+  | { success: false; message: string; status?: number };
+
+/**
+ * Reasigna MANUALMENTE el asesor de un crédito. Solo a un asesor del pool del
+ * bucket actual. Escribe la bitácora (origen=API_MANUAL, usuario_id, motivo) y
+ * actualiza creditos.asesor_id — ÚNICAMENTE ese campo — en una transacción.
+ */
+export async function reasignarAsesorManual(params: {
+  credito_id: number;
+  asesor_nuevo_id: number;
+  motivo: string;
+  usuario_email?: string;
+}): Promise<ReasignarAsesorResultado> {
+  const { credito_id, asesor_nuevo_id } = params;
+  const motivo = (params.motivo ?? "").trim();
+
+  // 1. Motivo obligatorio (auditoría).
+  if (!motivo) {
+    return { success: false, status: 400, message: "[ERROR] El motivo es obligatorio" };
+  }
+
+  // 2. Crédito + asesor actual.
+  const [credito] = await db
+    .select({ asesor_id: creditos.asesor_id })
+    .from(creditos)
+    .where(eq(creditos.credito_id, credito_id));
+  if (!credito) {
+    return { success: false, status: 404, message: `[ERROR] No se encontró crédito con credito_id=${credito_id}` };
+  }
+  const asesorActual = credito.asesor_id ?? null;
+
+  // 3. Bucket actual (misma derivación que el listado).
+  const bucket = await bucketActualDeCredito(credito_id);
+  if (bucket === null) {
+    return {
+      success: false,
+      status: 400,
+      message: "[ERROR] El crédito está fuera del funnel operativo (sin bucket): no se reasigna.",
+    };
+  }
+
+  // 4. Elegibilidad: el asesor destino debe estar en el pool del bucket actual.
+  const pool = await getAsesoresPorBucket(bucket);
+  if (!pool.some((a) => a.asesor_id === asesor_nuevo_id)) {
+    return {
+      success: false,
+      status: 400,
+      message: `[ERROR] El asesor ${asesor_nuevo_id} no es elegible en el bucket B${bucket} (no está en el pool activo).`,
+    };
+  }
+
+  // 5. No-op: ya es el dueño actual.
+  if (asesorActual === asesor_nuevo_id) {
+    return {
+      success: false,
+      status: 400,
+      message: "[ERROR] El crédito ya está asignado a ese asesor.",
+    };
+  }
+
+  // 6. Resolver identidad del supervisor por email → platform_users.id
+  //    (best-effort, patrón de createMora: no bloquea la operación si no resuelve).
+  let usuarioId: number | null = null;
+  if (params.usuario_email) {
+    const [u] = await db
+      .select({ id: platform_users.id })
+      .from(platform_users)
+      .where(eq(platform_users.email, params.usuario_email));
+    usuarioId = u?.id ?? null;
+  }
+
+  // 7. Transacción: bitácora PRIMERO, luego UPDATE (mismo par que el motor auto).
+  await db.transaction(async (tx) => {
+    await tx.insert(credito_asesor_historial).values({
+      credito_id,
+      asesor_anterior: asesorActual,
+      asesor_nuevo: asesor_nuevo_id,
+      bucket,
+      origen: "API_MANUAL",
+      motivo,
+      usuario_id: usuarioId,
+    });
+    await tx
+      .update(creditos)
+      .set({ asesor_id: asesor_nuevo_id })
+      .where(eq(creditos.credito_id, credito_id));
+  });
+
+  return {
+    success: true,
+    credito_id,
+    asesor_anterior: asesorActual,
+    asesor_nuevo: asesor_nuevo_id,
+    bucket,
+  };
+}

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -7,6 +7,10 @@ import {
 } from "../controllers/buckets/bucketsHistorial";
 import { getAsesorHistorial } from "../controllers/buckets/asesorHistorial";
 import { getCreditosWithUserByMesAnio } from "../controllers/credits";
+import {
+  getAsesoresPorBucket,
+  reasignarAsesorManual,
+} from "../controllers/buckets/reasignarAsesor";
 import { StatusCredit } from "../database/db/schema";
 
 // Estados DENTRO del funnel operativo (= enum de statusCredit menos
@@ -361,5 +365,76 @@ export const bucketsRouter = new Elysia()
           error: String(err),
         };
       }
+    },
+  )
+
+  // Pool de asesores elegibles de un bucket (alimenta el dropdown del modal de
+  // reasignación manual en el CRM). Misma fuente que valida el POST /reasignar.
+  .get(
+    "/buckets/pool/:bucket",
+    async ({ params, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        const bucket = Number(params.bucket);
+        if (!Number.isInteger(bucket) || bucket < 0) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] bucket inválido" };
+        }
+        const data = await getAsesoresPorBucket(bucket);
+        return { success: true, data };
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener el pool de asesores del bucket",
+          error: String(err),
+        };
+      }
+    },
+  )
+
+  // Reasignación MANUAL del asesor de un crédito (supervisor/gerente). Solo a un
+  // asesor del pool del bucket actual; motivo obligatorio; bitácora API_MANUAL.
+  .post(
+    "/buckets/creditos/:credito_id/reasignar",
+    async ({ params, body, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        const creditoId = Number(params.credito_id);
+        if (!Number.isInteger(creditoId) || creditoId <= 0) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] credito_id inválido" };
+        }
+        const asesorNuevoId = Number(body?.asesor_nuevo_id);
+        if (!Number.isInteger(asesorNuevoId) || asesorNuevoId <= 0) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] asesor_nuevo_id inválido" };
+        }
+        const result = await reasignarAsesorManual({
+          credito_id: creditoId,
+          asesor_nuevo_id: asesorNuevoId,
+          motivo: body?.motivo,
+          usuario_email: body?.usuario_email,
+        });
+        if (!result.success) {
+          set.status = result.status ?? 400;
+          return { success: false, message: result.message };
+        }
+        return result;
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo reasignar el asesor del crédito",
+          error: String(err),
+        };
+      }
+    },
+    {
+      body: t.Object({
+        asesor_nuevo_id: t.Union([t.Number(), t.String()]),
+        motivo: t.String(),
+        usuario_email: t.Optional(t.String()),
+      }),
     },
   );


### PR DESCRIPTION
## Resumen
- Endpoint para que supervisor/gerente reasigne manualmente el asesor de un crédito, solo a un elegible del pool (`asesor_bucket`) del bucket actual — motivo obligatorio, bitácora auditada.
- Mismo par `UPDATE creditos.asesor_id` + `INSERT credito_asesor_historial` (origen=`API_MANUAL`) que ya usa el motor automático (`latefee.ts`), en una transacción.
- `usuario_id` se resuelve por `usuario_email` → `platform_users.id` (best-effort, mismo patrón que `createMora`).

## Endpoints nuevos
- `POST /buckets/creditos/:credito_id/reasignar` — body `{ asesor_nuevo_id, motivo, usuario_email? }`. Gate `requireBucketsRole` (ADMIN/CONTA). Valida motivo no vacío, crédito existe, bucket dentro del funnel, asesor elegible en el pool, no-op (mismo asesor).
- `GET /buckets/pool/:bucket` — asesores elegibles (pool activo) de un bucket. Alimenta el dropdown del consumidor (CRM, PR aparte).

## Este PR es solo cartera-back
Es la Parte 1/3 de la feature CB-017. El consumidor (CRM server + web) va en PRs separados, encima de este, una vez mergeado.

## Test plan
- [x] `bunx tsc --noEmit` limpio
- [x] `bun test src/controllers/buckets/reasignarAsesor.test.ts` — 11 tests, 0 fail (DB fakeada, mismo patrón que `latefee.test.ts`)
- [ ] Probado manualmente en dev (`ep-green-tree`) — reasignación real verificada en `credito_asesor_historial`

🤖 Generated with [Claude Code](https://claude.com/claude-code)