### PR TITLE
fix(convenios): permitir convenio en cuotas con pago solo de mora

### DIFF
--- a/apps/cartera-back/src/controllers/paymentAgreement.ts
+++ b/apps/cartera-back/src/controllers/paymentAgreement.ts
@@ -135,8 +135,16 @@ export async function createPaymentAgreement(
     // ⚠️ VALIDAR QUE LOS PAGOS NO ESTÉN PAGADOS
     // ============================================
     console.log("✅ Paso 5: Validando que los pagos NO estén marcados como pagados...");
-    
-    const pagosPagados = pagos.filter((item) => item.pago.pagado === true);
+
+    // Un pago `pagado=true` con `monto_aplicado = 0` es un pago SOLO DE MORA:
+    // no abonó nada a la cuota (capital/interés), así que la cuota sigue impaga
+    // y DEBE poder entrar a un convenio. Solo bloquea si de verdad se aplicó
+    // monto a la cuota. La cuota totalmente pagada la cubre el Paso 6 (cuota.pagado).
+    const pagosPagados = pagos.filter(
+      (item) =>
+        item.pago.pagado === true &&
+        Number(item.pago.monto_aplicado ?? 0) > 0
+    );
 
     if (pagosPagados.length > 0) {
       console.error("❌ Pagos pagados detectados:", pagosPagados.length);


### PR DESCRIPTION
## Problema
Al crear un convenio de pago (`/convenios`), si una cuota tenía un **pago solo de mora** (ej. crédito 865, cuota 22: `mora=400`, `monto_aplicado=0`, sin abono a capital/interés), el backend fallaba con:

> Error al crear el convenio de pago: Los siguientes pagos ya están marcados como pagados: Cuota #22

## Causa
El **Paso 5** de `createPaymentAgreement` rechazaba cualquier pago con `pago.pagado === true`. Pero un pago solo de mora queda con `pagado=true` aunque **no abonó nada a la cuota** — la cuota sigue impaga (`cuota.pagado=false`). El front manda *todos* los `pago_ids` de la cuota (incluido el mora-only), disparando el falso positivo.

## Fix
El Paso 5 ahora solo bloquea cuando el pago realmente aplicó monto a la cuota (`monto_aplicado > 0`). La cuota totalmente pagada la sigue cubriendo el **Paso 6** (`cuota.pagado`).

```ts
const pagosPagados = pagos.filter(
  (item) => item.pago.pagado === true && Number(item.pago.monto_aplicado ?? 0) > 0
);
```

## Verificación
Probado contra copia de prod-data en local. El convenio del crédito 865 (cuota 22 con mora-only) ahora pasa las validaciones. Confirmado funcionando por el usuario.

**Alcance:** habilita convenios sobre cuotas con mora-only. Los pagos parciales reales (`monto_aplicado>0`, cuota aún impaga) siguen bloqueando, sin cambios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)