### PR TITLE
feat(cobros): CRM web — reasignación manual de asesor por bucket (CB-017)

### DIFF
--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -22,6 +22,7 @@ import {
 	Target,
 	TrendingUp,
 	UserCircle,
+	UserCog,
 	Users,
 } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
@@ -271,6 +272,17 @@ export default function Header() {
 											<Link to="/cobros/buckets" className="cursor-pointer">
 												<Layers className="mr-2 h-4 w-4" />
 												Historial de Buckets
+											</Link>
+										</DropdownMenuItem>
+									)}
+									{PERMISSIONS.canAssignCobros(userRole) && (
+										<DropdownMenuItem asChild>
+											<Link
+												to="/cobros/reasignaciones"
+												className="cursor-pointer"
+											>
+												<UserCog className="mr-2 h-4 w-4" />
+												Reasignar Cuentas
 											</Link>
 										</DropdownMenuItem>
 									)}
@@ -624,6 +636,15 @@ function MobileNav({
 											<Link to="/cobros/buckets" className={MOBILE_LINK_CLASS}>
 												<Layers />
 												Historial de Buckets
+											</Link>
+										)}
+										{PERMISSIONS.canAssignCobros(userRole) && (
+											<Link
+												to="/cobros/reasignaciones"
+												className={MOBILE_LINK_CLASS}
+											>
+												<UserCog />
+												Reasignar Cuentas
 											</Link>
 										)}
 										{PERMISSIONS.canAssignCobros(userRole) && (

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -32,6 +32,7 @@ import { Route as CrmLeadsRouteImport } from './routes/crm/leads'
 import { Route as CrmCompaniesRouteImport } from './routes/crm/companies'
 import { Route as CrmClientsRouteImport } from './routes/crm/clients'
 import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
+import { Route as CobrosReasignacionesRouteImport } from './routes/cobros/reasignaciones'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
 import { Route as CobrosBucketsRouteImport } from './routes/cobros/buckets'
 import { Route as CobrosIdRouteImport } from './routes/cobros/$id'
@@ -167,6 +168,11 @@ const CobrosReportesRoute = CobrosReportesRouteImport.update({
   path: '/cobros/reportes',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosReasignacionesRoute = CobrosReasignacionesRouteImport.update({
+  id: '/cobros/reasignaciones',
+  path: '/cobros/reasignaciones',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosMetasRoute = CobrosMetasRouteImport.update({
   id: '/cobros/metas',
   path: '/cobros/metas',
@@ -276,6 +282,7 @@ export interface FileRoutesByFullPath {
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
@@ -319,6 +326,7 @@ export interface FileRoutesByTo {
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
@@ -363,6 +371,7 @@ export interface FileRoutesById {
   '/cobros/$id': typeof CobrosIdRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/metas': typeof CobrosMetasRoute
+  '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reportes': typeof CobrosReportesRoute
   '/crm/clients': typeof CrmClientsRoute
   '/crm/companies': typeof CrmCompaniesRoute
@@ -408,6 +417,7 @@ export interface FileRouteTypes {
     | '/cobros/$id'
     | '/cobros/buckets'
     | '/cobros/metas'
+    | '/cobros/reasignaciones'
     | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
@@ -451,6 +461,7 @@ export interface FileRouteTypes {
     | '/cobros/$id'
     | '/cobros/buckets'
     | '/cobros/metas'
+    | '/cobros/reasignaciones'
     | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
@@ -494,6 +505,7 @@ export interface FileRouteTypes {
     | '/cobros/$id'
     | '/cobros/buckets'
     | '/cobros/metas'
+    | '/cobros/reasignaciones'
     | '/cobros/reportes'
     | '/crm/clients'
     | '/crm/companies'
@@ -538,6 +550,7 @@ export interface RootRouteChildren {
   CobrosIdRoute: typeof CobrosIdRoute
   CobrosBucketsRoute: typeof CobrosBucketsRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
+  CobrosReasignacionesRoute: typeof CobrosReasignacionesRoute
   CobrosReportesRoute: typeof CobrosReportesRoute
   CrmClientsRoute: typeof CrmClientsRoute
   CrmCompaniesRoute: typeof CrmCompaniesRoute
@@ -733,6 +746,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CobrosReportesRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/reasignaciones': {
+      id: '/cobros/reasignaciones'
+      path: '/cobros/reasignaciones'
+      fullPath: '/cobros/reasignaciones'
+      preLoaderRoute: typeof CobrosReasignacionesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/metas': {
       id: '/cobros/metas'
       path: '/cobros/metas'
@@ -874,6 +894,7 @@ const rootRouteChildren: RootRouteChildren = {
   CobrosIdRoute: CobrosIdRoute,
   CobrosBucketsRoute: CobrosBucketsRoute,
   CobrosMetasRoute: CobrosMetasRoute,
+  CobrosReasignacionesRoute: CobrosReasignacionesRoute,
   CobrosReportesRoute: CobrosReportesRoute,
   CrmClientsRoute: CrmClientsRoute,
   CrmCompaniesRoute: CrmCompaniesRoute,

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -257,6 +257,10 @@ function ReasignarModal({
 						</p>
 						{histQuery.isLoading ? (
 							<p className="text-muted-foreground text-xs">Cargando...</p>
+						) : histQuery.isError ? (
+							<p className="text-destructive text-xs">
+								No se pudo cargar el historial de este crédito.
+							</p>
 						) : historial.length === 0 ? (
 							<p className="text-muted-foreground text-xs italic">
 								Esta cuenta no ha sido reasignada manualmente antes.

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -126,10 +126,16 @@ function ReasignarModal({
 			},
 		}),
 	);
-	// Solo reasignaciones hechas por un usuario REAL (supervisor). La siembra
-	// inicial de COBROS-02 quedó marcada API_MANUAL pero sin usuario (usuario_id
-	// null → "sistema"): no es una decisión humana, se excluye del modal.
-	const historial = (histQuery.data?.data ?? []).filter((h) => h.usuario);
+	// Excluir SOLO la siembra inicial de COBROS-02 (motivo fijo del script SQL
+	// 02_asignar_asesores_creditos.sql) — quedó marcada API_MANUAL pero no es
+	// una decisión humana. Filtrar por `usuario` en vez de este motivo exacto
+	// escondía también reasignaciones manuales REALES cuyo supervisor no
+	// resolvió en platform_users (usuario_id null, best-effort) — review Codex.
+	const MOTIVO_SIEMBRA_INICIAL =
+		"Asignación inicial por bucket — carga COBROS-02 (SQL)";
+	const historial = (histQuery.data?.data ?? []).filter(
+		(h) => h.motivo !== MOTIVO_SIEMBRA_INICIAL,
+	);
 
 	const mutation = useMutation({
 		mutationFn: () =>
@@ -264,7 +270,7 @@ function ReasignarModal({
 									>
 										<div className="mb-1 flex items-center justify-between text-muted-foreground">
 											<span className="font-medium">{fmtFecha(h.fecha)}</span>
-											<span>{h.usuario}</span>
+											<span>{h.usuario || "sistema"}</span>
 										</div>
 										<div className="flex items-center gap-1.5">
 											<span className="text-muted-foreground">
@@ -443,6 +449,10 @@ function HistorialReasignaciones() {
 				{query.isLoading ? (
 					<div className="py-10 text-center text-muted-foreground">
 						Cargando...
+					</div>
+				) : query.isError ? (
+					<div className="py-10 text-center text-destructive">
+						Error al cargar el historial de reasignaciones
 					</div>
 				) : rows.length === 0 ? (
 					<div className="py-10 text-center text-muted-foreground">

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -158,16 +158,24 @@ function ReasignarModal({
 	const elegibles = pool.filter((a) => a.asesor_id !== credito.asesorId);
 	// El pool NO está vacío pero el único elegible es el asesor actual: no hay a
 	// quién reasignar dentro del bucket (mensaje distinto a "pool sin asesores").
+	// isError se distingue de poolVacio: un fetch fallido NO es lo mismo que un
+	// pool realmente vacío (mensaje distinto — review Codex).
 	const soloElAsesorActual =
-		!poolQuery.isLoading && pool.length > 0 && elegibles.length === 0;
-	const poolVacio = !poolQuery.isLoading && pool.length === 0;
+		!poolQuery.isLoading &&
+		!poolQuery.isError &&
+		pool.length > 0 &&
+		elegibles.length === 0;
+	const poolVacio =
+		!poolQuery.isLoading && !poolQuery.isError && pool.length === 0;
 	const placeholderAsesor = poolQuery.isLoading
 		? "Cargando..."
-		: soloElAsesorActual
-			? "No hay otros asesores en este bucket"
-			: poolVacio
-				? "El bucket no tiene asesores en su pool"
-				: "Selecciona un asesor";
+		: poolQuery.isError
+			? "Error al cargar asesores"
+			: soloElAsesorActual
+				? "No hay otros asesores en este bucket"
+				: poolVacio
+					? "El bucket no tiene asesores en su pool"
+					: "Selecciona un asesor";
 	const motivoValido = motivo.trim().length > 0;
 	const puedeGuardar = !!asesorNuevoId && motivoValido && !mutation.isPending;
 
@@ -212,7 +220,13 @@ function ReasignarModal({
 								))}
 							</SelectContent>
 						</Select>
-						{(soloElAsesorActual || poolVacio) && (
+						{poolQuery.isError && (
+							<p className="text-destructive text-xs">
+								No se pudo cargar el pool de asesores de este bucket. Intenta de
+								nuevo.
+							</p>
+						)}
+						{!poolQuery.isError && (soloElAsesorActual || poolVacio) && (
 							<p className="text-muted-foreground text-xs">
 								{soloElAsesorActual
 									? "Este bucket solo tiene un asesor en su pool. Agrega otro asesor al pool del bucket para poder reasignar."
@@ -330,7 +344,7 @@ function HistorialReasignaciones() {
 
 	const rows = query.data?.data ?? [];
 	const resumen = query.data?.resumen;
-	const totalPages = query.data?.pagination.totalPages ?? 1;
+	const totalPages = query.data?.pagination?.totalPages ?? 1;
 
 	const aplicar = () => {
 		setAsesor(asesorInput.trim());

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -1,0 +1,723 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { Search, UserCog } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { authClient } from "@/lib/auth-client";
+import { estiloBucket } from "@/lib/cobros/buckets-catalogo";
+import { PERMISSIONS } from "@/lib/roles";
+import { client, orpc, queryClient } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/reasignaciones")({
+	component: RouteComponent,
+});
+
+// Buckets del funnel operativo B0-B5 (clave estable del motor). El label real
+// por fila viene del objeto `bucket` que trae cada crédito; esto solo alimenta
+// el selector de filtro.
+const BUCKETS_FILTRO: { numero: number; label: string }[] = [
+	{ numero: 0, label: "B0 · Cartera Sana" },
+	{ numero: 1, label: "B1 · Alerta Temprana" },
+	{ numero: 2, label: "B2 · Gestión Activa" },
+	{ numero: 3, label: "B3 · Rescate" },
+	{ numero: 4, label: "B4 · Última Instancia / Pre Jurídico" },
+	{ numero: 5, label: "B5 · Jurídico" },
+];
+
+type CreditoFila = {
+	creditoId: number;
+	numeroCreditoSifco: string;
+	cliente: string;
+	asesorId: number | null;
+	asesorNombre: string | null;
+	bucket: {
+		numero: number;
+		prefijo: string;
+		nombre: string;
+		color: string | null;
+	} | null;
+};
+
+const fmtFecha = (v: string) => {
+	const d = new Date(v);
+	if (Number.isNaN(d.getTime())) return v;
+	return d.toLocaleString("es-GT", {
+		timeZone: "America/Guatemala",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+		hour: "2-digit",
+		minute: "2-digit",
+		hour12: false,
+	});
+};
+
+function BucketBadge({ bucket }: { bucket: CreditoFila["bucket"] }) {
+	if (!bucket) return <span className="text-muted-foreground text-xs">—</span>;
+	const color = bucket.color || "#64748b";
+	return (
+		<Badge
+			variant="outline"
+			className="whitespace-nowrap font-semibold"
+			style={estiloBucket(color)}
+			title={`${bucket.prefijo} · ${bucket.nombre}`}
+		>
+			{bucket.prefijo}
+		</Badge>
+	);
+}
+
+function ReasignarModal({
+	credito,
+	onClose,
+}: {
+	credito: CreditoFila;
+	onClose: () => void;
+}) {
+	const [asesorNuevoId, setAsesorNuevoId] = useState<string>("");
+	const [motivo, setMotivo] = useState("");
+
+	const bucketNumero = credito.bucket?.numero ?? null;
+
+	const poolQuery = useQuery({
+		...orpc.getPoolAsesoresPorBucket.queryOptions({
+			input: { bucket: bucketNumero ?? -1 },
+		}),
+		enabled: bucketNumero !== null,
+	});
+
+	// Historial de reasignaciones MANUALES previas de ESTE crédito (contexto:
+	// ¿ya movieron esta cuenta antes?). Solo API_MANUAL para no meter el ruido
+	// de las reasignaciones automáticas del motor.
+	const histQuery = useQuery(
+		orpc.getHistorialReasignaciones.queryOptions({
+			input: {
+				creditoId: credito.creditoId,
+				origen: "API_MANUAL",
+				pageSize: 10,
+			},
+		}),
+	);
+	// Solo reasignaciones hechas por un usuario REAL (supervisor). La siembra
+	// inicial de COBROS-02 quedó marcada API_MANUAL pero sin usuario (usuario_id
+	// null → "sistema"): no es una decisión humana, se excluye del modal.
+	const historial = (histQuery.data?.data ?? []).filter((h) => h.usuario);
+
+	const mutation = useMutation({
+		mutationFn: () =>
+			client.reasignarAsesorCredito({
+				creditoId: credito.creditoId,
+				asesorNuevoId: Number(asesorNuevoId),
+				motivo: motivo.trim(),
+			}),
+		onSuccess: () => {
+			toast.success("Crédito reasignado");
+			// key() (sin input) = prefijo del path → invalida TODAS las variantes
+			// de la query (cualquier bucket/página/filtro), no solo input:{}. Con
+			// queryKey({input:{}}) la tabla activa (input lleno) quedaba stale.
+			queryClient.invalidateQueries({
+				queryKey: orpc.getCreditosPorBucket.key(),
+			});
+			queryClient.invalidateQueries({
+				queryKey: orpc.getHistorialReasignaciones.key(),
+			});
+			onClose();
+		},
+		onError: (err: Error) => toast.error(err.message),
+	});
+
+	const pool = poolQuery.data ?? [];
+	const elegibles = pool.filter((a) => a.asesor_id !== credito.asesorId);
+	// El pool NO está vacío pero el único elegible es el asesor actual: no hay a
+	// quién reasignar dentro del bucket (mensaje distinto a "pool sin asesores").
+	const soloElAsesorActual =
+		!poolQuery.isLoading && pool.length > 0 && elegibles.length === 0;
+	const poolVacio = !poolQuery.isLoading && pool.length === 0;
+	const placeholderAsesor = poolQuery.isLoading
+		? "Cargando..."
+		: soloElAsesorActual
+			? "No hay otros asesores en este bucket"
+			: poolVacio
+				? "El bucket no tiene asesores en su pool"
+				: "Selecciona un asesor";
+	const motivoValido = motivo.trim().length > 0;
+	const puedeGuardar = !!asesorNuevoId && motivoValido && !mutation.isPending;
+
+	return (
+		<Dialog open onOpenChange={(o) => !o && onClose()}>
+			<DialogContent>
+				<DialogHeader>
+					<DialogTitle>Reasignar asesor</DialogTitle>
+				</DialogHeader>
+
+				<dl className="space-y-1.5 rounded-md border bg-muted/40 p-3 text-sm">
+					<div className="flex justify-between gap-4">
+						<dt className="text-muted-foreground">Crédito</dt>
+						<dd className="text-right font-medium">
+							{credito.numeroCreditoSifco}
+						</dd>
+					</div>
+					<div className="flex justify-between gap-4">
+						<dt className="text-muted-foreground">Cliente</dt>
+						<dd className="text-right font-medium">{credito.cliente}</dd>
+					</div>
+					<div className="flex justify-between gap-4">
+						<dt className="text-muted-foreground">Asesor actual</dt>
+						<dd className="text-right font-medium">
+							{credito.asesorNombre ?? "Sin asesor"}
+						</dd>
+					</div>
+				</dl>
+
+				<div className="space-y-4 py-2">
+					<div className="space-y-2">
+						<Label>Nuevo asesor (elegibles del bucket)</Label>
+						<Select value={asesorNuevoId} onValueChange={setAsesorNuevoId}>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder={placeholderAsesor} />
+							</SelectTrigger>
+							<SelectContent className="w-(--radix-select-trigger-width)">
+								{elegibles.map((a) => (
+									<SelectItem key={a.asesor_id} value={String(a.asesor_id)}>
+										{a.nombre}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+						{(soloElAsesorActual || poolVacio) && (
+							<p className="text-muted-foreground text-xs">
+								{soloElAsesorActual
+									? "Este bucket solo tiene un asesor en su pool. Agrega otro asesor al pool del bucket para poder reasignar."
+									: "Este bucket no tiene asesores configurados en su pool."}
+							</p>
+						)}
+					</div>
+
+					<div className="space-y-2">
+						<Label>Motivo (obligatorio)</Label>
+						<Textarea
+							value={motivo}
+							onChange={(e) => setMotivo(e.target.value)}
+							placeholder="Explica por qué se reasigna este crédito..."
+							rows={3}
+						/>
+					</div>
+
+					<div className="space-y-2 border-t pt-3">
+						<p className="font-semibold text-muted-foreground text-xs uppercase tracking-wide">
+							Reasignaciones manuales previas
+						</p>
+						{histQuery.isLoading ? (
+							<p className="text-muted-foreground text-xs">Cargando...</p>
+						) : historial.length === 0 ? (
+							<p className="text-muted-foreground text-xs italic">
+								Esta cuenta no ha sido reasignada manualmente antes.
+							</p>
+						) : (
+							<ul className="max-h-48 space-y-2 overflow-y-auto">
+								{historial.map((h) => (
+									<li
+										key={h.historial_id}
+										className="rounded-md border bg-muted/40 p-2.5 text-xs"
+									>
+										<div className="mb-1 flex items-center justify-between text-muted-foreground">
+											<span className="font-medium">{fmtFecha(h.fecha)}</span>
+											<span>{h.usuario}</span>
+										</div>
+										<div className="flex items-center gap-1.5">
+											<span className="text-muted-foreground">
+												{h.asesor_anterior ?? "Sin asesor"}
+											</span>
+											<span className="text-muted-foreground">→</span>
+											<span className="font-semibold text-foreground">
+												{h.asesor_nuevo ?? "—"}
+											</span>
+										</div>
+										{h.motivo ? (
+											<p className="mt-1 text-muted-foreground italic">
+												“{h.motivo}”
+											</p>
+										) : null}
+									</li>
+								))}
+							</ul>
+						)}
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button variant="outline" onClick={onClose}>
+						Cancelar
+					</Button>
+					<Button disabled={!puedeGuardar} onClick={() => mutation.mutate()}>
+						{mutation.isPending ? "Reasignando..." : "Reasignar"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function OrigenBadge({ origen }: { origen: string }) {
+	const esManual = origen === "API_MANUAL";
+	return (
+		<Badge
+			variant="outline"
+			className={
+				esManual
+					? "border-amber-300 bg-amber-50 text-amber-700"
+					: "border-slate-300 bg-slate-50 text-slate-600"
+			}
+		>
+			{esManual ? "Manual" : "Automático"}
+		</Badge>
+	);
+}
+
+function HistorialReasignaciones() {
+	const [origen, setOrigen] = useState<string>("todos");
+	const [bucket, setBucket] = useState<string>("todos");
+	const [asesorInput, setAsesorInput] = useState("");
+	const [sifcoInput, setSifcoInput] = useState("");
+	const [asesor, setAsesor] = useState("");
+	const [sifco, setSifco] = useState("");
+	const [page, setPage] = useState(1);
+	const pageSize = 20;
+
+	const query = useQuery(
+		orpc.getHistorialReasignaciones.queryOptions({
+			input: {
+				origen:
+					origen === "todos"
+						? undefined
+						: (origen as "PROCESO_AUTO" | "API_MANUAL"),
+				bucket: bucket === "todos" ? undefined : Number(bucket),
+				asesor: asesor || undefined,
+				numeroCredito: sifco || undefined,
+				page,
+				pageSize,
+			},
+		}),
+	);
+
+	const rows = query.data?.data ?? [];
+	const resumen = query.data?.resumen;
+	const totalPages = query.data?.pagination.totalPages ?? 1;
+
+	const aplicar = () => {
+		setAsesor(asesorInput.trim());
+		setSifco(sifcoInput.trim());
+		setPage(1);
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<CardTitle className="text-base">Historial de reasignaciones</CardTitle>
+			</CardHeader>
+			<CardContent className="space-y-4">
+				<div className="flex flex-wrap items-end gap-4">
+					<div className="space-y-2">
+						<Label>Origen</Label>
+						<Select
+							value={origen}
+							onValueChange={(v) => {
+								setOrigen(v);
+								setPage(1);
+							}}
+						>
+							<SelectTrigger className="w-[160px]">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="todos">Todos</SelectItem>
+								<SelectItem value="API_MANUAL">Manual</SelectItem>
+								<SelectItem value="PROCESO_AUTO">Automático</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="space-y-2">
+						<Label>Bucket</Label>
+						<Select
+							value={bucket}
+							onValueChange={(v) => {
+								setBucket(v);
+								setPage(1);
+							}}
+						>
+							<SelectTrigger className="w-[200px]">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="todos">Todos</SelectItem>
+								{BUCKETS_FILTRO.map((b) => (
+									<SelectItem key={b.numero} value={String(b.numero)}>
+										{b.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="space-y-2">
+						<Label>Asesor nuevo</Label>
+						<Input
+							placeholder="Buscar asesor..."
+							value={asesorInput}
+							onChange={(e) => setAsesorInput(e.target.value)}
+							onKeyDown={(e) => e.key === "Enter" && aplicar()}
+							className="w-[180px]"
+						/>
+					</div>
+					<div className="space-y-2">
+						<Label>No. SIFCO</Label>
+						<Input
+							placeholder="Buscar SIFCO..."
+							value={sifcoInput}
+							onChange={(e) => setSifcoInput(e.target.value)}
+							onKeyDown={(e) => e.key === "Enter" && aplicar()}
+							className="w-[180px]"
+						/>
+					</div>
+					<Button variant="outline" onClick={aplicar}>
+						<Search className="mr-1 h-4 w-4" /> Buscar
+					</Button>
+				</div>
+
+				{resumen && (
+					<div className="flex flex-wrap gap-4 text-sm">
+						<span className="text-muted-foreground">
+							Total: <b className="text-foreground">{resumen.total}</b>
+						</span>
+						<span className="text-muted-foreground">
+							Manuales: <b className="text-amber-700">{resumen.manuales}</b>
+						</span>
+						<span className="text-muted-foreground">
+							Automáticos:{" "}
+							<b className="text-slate-700">{resumen.automaticos}</b>
+						</span>
+					</div>
+				)}
+
+				{query.isLoading ? (
+					<div className="py-10 text-center text-muted-foreground">
+						Cargando...
+					</div>
+				) : rows.length === 0 ? (
+					<div className="py-10 text-center text-muted-foreground">
+						No hay reasignaciones para los filtros seleccionados
+					</div>
+				) : (
+					<div className="overflow-x-auto">
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>Fecha</TableHead>
+									<TableHead>No. SIFCO</TableHead>
+									<TableHead>Cliente</TableHead>
+									<TableHead>Cambio de asesor</TableHead>
+									<TableHead className="text-center">Bucket</TableHead>
+									<TableHead className="text-center">Origen</TableHead>
+									<TableHead>Motivo</TableHead>
+									<TableHead>Usuario</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{rows.map((r) => (
+									<TableRow key={r.historial_id}>
+										<TableCell className="whitespace-nowrap text-muted-foreground text-xs">
+											{fmtFecha(r.fecha)}
+										</TableCell>
+										<TableCell className="font-medium text-xs">
+											{r.numero_credito_sifco}
+										</TableCell>
+										<TableCell>{r.cliente}</TableCell>
+										<TableCell className="text-xs">
+											<span className="text-muted-foreground">
+												{r.asesor_anterior ?? "Sin asesor"}
+											</span>{" "}
+											→{" "}
+											<span className="font-semibold">
+												{r.asesor_nuevo ?? "—"}
+											</span>
+										</TableCell>
+										<TableCell className="text-center">
+											<BucketBadge
+												bucket={
+													r.bucket !== null
+														? {
+																numero: r.bucket,
+																prefijo: r.bucket_prefijo ?? `B${r.bucket}`,
+																nombre: r.bucket_nombre ?? "",
+																color: null,
+															}
+														: null
+												}
+											/>
+										</TableCell>
+										<TableCell className="text-center">
+											<OrigenBadge origen={r.origen} />
+										</TableCell>
+										<TableCell
+											className="max-w-[240px] truncate text-muted-foreground text-xs"
+											title={r.motivo ?? undefined}
+										>
+											{r.motivo || "—"}
+										</TableCell>
+										<TableCell className="text-muted-foreground text-xs">
+											{r.usuario || "sistema"}
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					</div>
+				)}
+
+				<div className="flex items-center justify-between">
+					<span className="text-muted-foreground text-sm">
+						Página {page} de {totalPages}
+					</span>
+					<div className="flex gap-2">
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={page <= 1}
+							onClick={() => setPage((p) => p - 1)}
+						>
+							Anterior
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							disabled={page >= totalPages}
+							onClick={() => setPage((p) => p + 1)}
+						>
+							Siguiente
+						</Button>
+					</div>
+				</div>
+			</CardContent>
+		</Card>
+	);
+}
+
+function RouteComponent() {
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user.role;
+
+	const [bucket, setBucket] = useState<string>("todos");
+	const [buscarInput, setBuscarInput] = useState("");
+	const [buscar, setBuscar] = useState("");
+	const [page, setPage] = useState(1);
+	const [seleccionado, setSeleccionado] = useState<CreditoFila | null>(null);
+	const perPage = 20;
+
+	const bucketNumero = bucket === "todos" ? undefined : Number(bucket);
+
+	const query = useQuery({
+		...orpc.getCreditosPorBucket.queryOptions({
+			input: {
+				bucket: bucketNumero,
+				page,
+				perPage,
+				numeroCredito: buscar || undefined,
+			},
+		}),
+		enabled: !!session,
+	});
+
+	if (!userRole || !PERMISSIONS.canAssignCobros(userRole)) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<div className="text-center text-muted-foreground">
+					No tienes permiso para acceder a esta página.
+				</div>
+			</div>
+		);
+	}
+
+	const filas = (query.data?.data ?? []) as CreditoFila[];
+	const totalPages = query.data?.totalPages ?? 1;
+
+	const aplicarBusqueda = () => {
+		setBuscar(buscarInput.trim());
+		setPage(1);
+	};
+
+	return (
+		<div className="container mx-auto space-y-6 p-4 md:p-8">
+			<div className="flex items-center gap-2">
+				<UserCog className="h-6 w-6" />
+				<h1 className="font-bold text-2xl">
+					Buckets — Reasignación de cuentas
+				</h1>
+			</div>
+			<p className="text-muted-foreground text-sm">
+				Créditos por bucket. Reasigna manualmente el asesor a un elegible del
+				pool del bucket (motivo obligatorio, queda auditado).
+			</p>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="text-base">Filtros</CardTitle>
+				</CardHeader>
+				<CardContent className="flex flex-wrap items-end gap-4">
+					<div className="space-y-2">
+						<Label>Bucket</Label>
+						<Select
+							value={bucket}
+							onValueChange={(v) => {
+								setBucket(v);
+								setPage(1);
+							}}
+						>
+							<SelectTrigger className="w-[220px]">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="todos">Todos</SelectItem>
+								{BUCKETS_FILTRO.map((b) => (
+									<SelectItem key={b.numero} value={String(b.numero)}>
+										{b.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+					<div className="min-w-[200px] flex-1 space-y-2">
+						<Label>No. SIFCO</Label>
+						<Input
+							placeholder="Buscar por número de crédito..."
+							value={buscarInput}
+							onChange={(e) => setBuscarInput(e.target.value)}
+							onKeyDown={(e) => e.key === "Enter" && aplicarBusqueda()}
+						/>
+					</div>
+					<Button variant="outline" onClick={aplicarBusqueda}>
+						<Search className="mr-1 h-4 w-4" /> Buscar
+					</Button>
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardContent className="p-0">
+					{query.isLoading ? (
+						<div className="py-16 text-center text-muted-foreground">
+							Cargando...
+						</div>
+					) : query.isError ? (
+						<div className="py-16 text-center text-destructive">
+							Error al cargar los créditos
+						</div>
+					) : filas.length === 0 ? (
+						<div className="py-16 text-center text-muted-foreground">
+							No hay créditos para los filtros seleccionados
+						</div>
+					) : (
+						<Table>
+							<TableHeader>
+								<TableRow>
+									<TableHead>No. SIFCO</TableHead>
+									<TableHead>Cliente</TableHead>
+									<TableHead>Asesor actual</TableHead>
+									<TableHead className="text-center">Bucket</TableHead>
+									<TableHead className="text-right">Acción</TableHead>
+								</TableRow>
+							</TableHeader>
+							<TableBody>
+								{filas.map((c) => (
+									<TableRow key={c.creditoId}>
+										<TableCell className="font-medium">
+											{c.numeroCreditoSifco}
+										</TableCell>
+										<TableCell>{c.cliente}</TableCell>
+										<TableCell>
+											{c.asesorNombre ?? (
+												<span className="text-muted-foreground italic">
+													Sin asesor
+												</span>
+											)}
+										</TableCell>
+										<TableCell className="text-center">
+											<BucketBadge bucket={c.bucket} />
+										</TableCell>
+										<TableCell className="text-right">
+											<Button
+												size="sm"
+												variant="outline"
+												onClick={() => setSeleccionado(c)}
+											>
+												Reasignar
+											</Button>
+										</TableCell>
+									</TableRow>
+								))}
+							</TableBody>
+						</Table>
+					)}
+				</CardContent>
+			</Card>
+
+			<div className="flex items-center justify-between">
+				<span className="text-muted-foreground text-sm">
+					Página {page} de {totalPages}
+				</span>
+				<div className="flex gap-2">
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={page <= 1}
+						onClick={() => setPage((p) => p - 1)}
+					>
+						Anterior
+					</Button>
+					<Button
+						variant="outline"
+						size="sm"
+						disabled={page >= totalPages}
+						onClick={() => setPage((p) => p + 1)}
+					>
+						Siguiente
+					</Button>
+				</div>
+			</div>
+
+			<HistorialReasignaciones />
+
+			{seleccionado && (
+				<ReasignarModal
+					credito={seleccionado}
+					onClose={() => setSeleccionado(null)}
+				/>
+			)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Resumen
Parte 3/3 de CB-017 (backend #1100, CRM server #1102, ambos ya mergeados). Página nueva `/cobros/reasignaciones` en el CRM: tabla de créditos por bucket con acción de reasignar asesor, modal con dropdown de elegibles del pool + motivo obligatorio + mini-historial de reasignaciones manuales previas del crédito, y una sección de historial global con filtros.

## Nota de ruta
La ruta `/cobros/buckets` ya la usa CB-006 (Historial de Buckets, #1099, ya mergeada) — esta feature usa **`/cobros/reasignaciones`** para no chocar. Item de nav "Reasignar Cuentas" agregado al lado de "Historial de Buckets" en el menú Cobros (desktop + mobile), mismo gate `canAssignCobros`.

## Cambios
- `routes/cobros/reasignaciones.tsx` (nuevo): tabla + filtros (bucket, SIFCO) + modal de reasignación + historial global.
- `components/header.tsx`: nav item nuevo, desktop y mobile.
- `routeTree.gen.ts`: auto-generado.

## Fixes aplicados de code review (Codex + revisión manual)
- Invalidación de cache con `.key()` (prefijo del path) en vez de `queryKey({input:{}})` — la tabla activa con filtros quedaba stale tras reasignar.
- `poolQuery.isError` distinguido de "pool vacío": un fetch fallido ya no muestra el mensaje engañoso de "bucket sin asesores configurados".
- `totalPages` con optional chain completo (`data?.pagination?.totalPages`), consistente con el resto del archivo.

## Test plan
- [x] `bunx tsc --noEmit` limpio (server + web)
- [x] `vite build` completo sin errores
- [ ] Probar el flujo end-to-end en dev: reasignar un crédito, ver el toast, la tabla actualizada sin refrescar, y el historial (modal + global) reflejando el cambio
- [ ] Confirmar que `/cobros/buckets` (CB-006) sigue funcionando sin conflicto de ruta

🤖 Generated with [Claude Code](https://claude.com/claude-code)