### PR TITLE
fix(investment): objetivo anual Tradicional subcotizaba el capital (review Codex)

### DIFF
--- a/apps/investment-calculator/src/App.tsx
+++ b/apps/investment-calculator/src/App.tsx
@@ -1045,14 +1045,19 @@ export default function InvestmentCalculator() {
       capital = interest / monthlyInterestRate;
     } else if (inverseMode === "tradicionalAnual") {
       // Tradicional con frecuencia anual: el "monto deseado" es el INTERÉS que
-      // el inversionista quiere ganar por AÑO. Se lleva a interés mensual
-      // (÷12) y de ahí al capital, con la misma estructura que el modo mensual
-      // (grossup por participación y por IVA). El plazo no altera el capital
-      // (interés sobre el aporte), igual que en el modo mensual interest-only.
-      const monthlyDesired = D / 12;
-      const interestPlusVat = monthlyDesired / investorShare;
-      const interest = interestPlusVat / (1 + vatRate);
-      capital = interest / monthlyInterestRate;
+      // el inversionista quiere ganar en el PRIMER AÑO.
+      //
+      // Se resuelve invirtiendo el MISMO schedule que se despliega (amortización
+      // francesa), no con interés simple: en Tradicional el saldo baja cada mes,
+      // así que un cálculo interest-only subcotiza el capital (la Proyección
+      // Anual mostraría menos de lo pedido en el año 1).
+      // El schedule es lineal en el capital → basta escalar desde una referencia,
+      // sin iterar. En años siguientes el interés baja (propio del modelo).
+      const REF = 10000;
+      const refYear1 = generateAmortizationSchedule(REF)
+        .slice(0, 12)
+        .reduce((sum, row) => sum + row.interestVatPayment, 0);
+      capital = refYear1 > 0 ? (D * REF) / refYear1 : 0;
     } else {
       // lumpSum
       if (lumpSumType === "compound") {


### PR DESCRIPTION
## Bug

Codex lo detectó en el PR #1098 y es **válido**: en **Calcular Objetivo → "Anual (Tradicional)"** el capital se calculaba con matemática *interest-only* (interés sobre el capital completo los 12 meses), pero la UI cotiza el modelo **Tradicional**, que **amortiza capital cada mes**. Como el saldo baja, la Proyección Anual mostraba **menos de lo pedido**:

| | Antes |
|---|---|
| Pedido | Q1,000/año |
| Capital cotizado | Q7,086.17 |
| **Año 1 real en la tabla** | **Q943.06** ❌ (5.7% menos) |

O sea, el objetivo **subcotizaba** el capital requerido.

## Fix

El capital ahora se resuelve **invirtiendo el mismo schedule que se despliega** (amortización francesa), apuntando a que el **año 1** iguale el monto pedido. El schedule es lineal en el capital, así que se escala desde una referencia — exacto y sin iterar.

**Decisión de negocio**: en Tradicional el interés decae año a año (Q1,000 → Q850 → Q667 → Q443 → Q170 con los defaults); se apunta al **año 1** porque es lo que se cotiza al inversionista. El disclaimer del modelo ya advierte que los montos son estimaciones sujetas al ritmo real de amortización.

## Verificación

| | Después |
|---|---|
| Pedido | Q1,000/año |
| Capital cotizado | Q7,513.99 |
| **Año 1 real en la tabla** | **Q1,000.00** ✅ |

Verificado en navegador leyendo la fila real de la Proyección Anual. Typecheck limpio, **34/34 tests**, build OK.

## ⚠️ Importante

El PR #1105 (develop → main, *Pase a Producción*) está abierto e incluye la Calculadora. Este fix debería entrar a develop **antes** de ese release, si no el bug llega a producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)