### PR TITLE
feat(credit-analysis): fecha ideal de pago según los ingresos del cliente

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_day.sql
+++ b/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_day.sql
@@ -1,0 +1,4 @@
+-- Agrega la fecha ideal de pago sugerida por la IA al análisis de capacidad de pago.
+-- Día del mes (1-31) según cuándo recibe ingresos el solicitante. Dato informativo;
+-- el detalle (días detectados y justificación) vive en credit_analysis.full_analysis.
+ALTER TABLE "credit_analysis" ADD COLUMN IF NOT EXISTS "suggested_payment_day" integer;

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -275,6 +275,8 @@ export const creditAnalysis = pgTable("credit_analysis", {
 	maxPayment: decimal("max_payment", { precision: 12, scale: 2 }),
 	adjustedPayment: decimal("adjusted_payment", { precision: 12, scale: 2 }),
 	maxCreditAmount: decimal("max_credit_amount", { precision: 12, scale: 2 }),
+	// Fecha ideal de pago sugerida por la IA (día del mes 1-31, según cuándo recibe ingresos)
+	suggestedPaymentDay: integer("suggested_payment_day"),
 	// Control de intentos de análisis con IA (cada llamada a IA cuesta dinero)
 	attemptCount: integer("attempt_count").notNull().default(0), // Se incrementa al llamar a la IA
 	// Metadata

--- a/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
+++ b/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
@@ -30,6 +30,14 @@ export const bankStatementAnalysisSchema = z.object({
 		promedio_gastos_variables: z.number(),
 		disponibilidad_economica: z.number(),
 	}),
+	// Nullable e informativo: no debe tumbar el análisis core; días acotados a 1-31 enteros
+	analisis_fecha_pago: z
+		.object({
+			dias_ingreso_detectados: z.array(z.number().int().min(1).max(31)),
+			dia_pago_sugerido: z.number().int().min(1).max(31),
+			justificacion: z.string(),
+		})
+		.nullable(),
 });
 
 export type BankStatementAnalysis = z.infer<typeof bankStatementAnalysisSchema>;
@@ -64,6 +72,11 @@ Eres un analista de capacidad de pago para una financiera que otorga créditos p
    - promedio_gastos_variables: Promedio mensual de gastos variables.
    - disponibilidad_economica: Promedio de la diferencia entre créditos y débitos totales. Se calcula como: (promedio_creditos - promedio_debitos).
    **Nota**: El promedio de créditos es la suma de 'total_creditos' a lo largo de los meses analizados dividido por la cantidad de meses. El promedio de débitos es la suma de 'total_debitos' a lo largo de los meses analizados dividido por la cantidad de meses.
+
+4. **analisis_fecha_pago**: Determina la fecha ideal de pago según CUÁNDO recibe ingresos el solicitante, analizando las FECHAS de las transacciones de crédito (no solo los totales). Devuelve:
+   - dias_ingreso_detectados: Días del mes (1-31) en que se repiten sus ingresos recurrentes. Si es quincena, incluye ambos (ej. [15, 30]).
+   - dia_pago_sugerido: Día del mes (1-31) para la cuota, entre 1 y 5 días después de su ingreso recurrente de mayor monto, para no caer donde el dinero ya se gastó. En quincena, elige la que deje más liquidez. Devuelve el día real, no un valor fijo.
+   - justificacion: 1-2 frases justificando el día según el patrón detectado. Si el ingreso es irregular, elige el día más conservador y acláralo; no inventes precisión.
 
 ## IMPORTANTE: Múltiples cuentas bancarias del mismo titular
 

--- a/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
+++ b/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
@@ -30,14 +30,14 @@ export const bankStatementAnalysisSchema = z.object({
 		promedio_gastos_variables: z.number(),
 		disponibilidad_economica: z.number(),
 	}),
-	// Nullable e informativo: no debe tumbar el análisis core; días acotados a 1-31 enteros
+	// Nullish e informativo: la key puede faltar o venir null sin tumbar el análisis core; días acotados a 1-31 enteros
 	analisis_fecha_pago: z
 		.object({
 			dias_ingreso_detectados: z.array(z.number().int().min(1).max(31)),
 			dia_pago_sugerido: z.number().int().min(1).max(31),
 			justificacion: z.string(),
 		})
-		.nullable(),
+		.nullish(),
 });
 
 export type BankStatementAnalysis = z.infer<typeof bankStatementAnalysisSchema>;

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -364,6 +364,8 @@ export const bankAnalysisRouter = {
 							analysis.promedio_mensual.disponibilidad_economica.toString(),
 						maxPayment: creditCapacity.maxPayment.toString(),
 						maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
+						suggestedPaymentDay:
+							analysis.analisis_fecha_pago?.dia_pago_sugerido ?? null,
 						analyzedAt: new Date(),
 						updatedAt: new Date(),
 					})

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3631,6 +3631,7 @@ export const crmRouter = {
 								economicAvailability: creditAnalysis.economicAvailability,
 								maxPayment: creditAnalysis.maxPayment,
 								maxCreditAmount: creditAnalysis.maxCreditAmount,
+								suggestedPaymentDay: creditAnalysis.suggestedPaymentDay,
 								analyzedAt: creditAnalysis.analyzedAt,
 							})
 							.from(creditAnalysis)
@@ -6665,6 +6666,7 @@ export const crmRouter = {
 				economicAvailability: parseDecimal(leadAnalysis?.economicAvailability),
 				maxPayment: parseDecimal(leadAnalysis?.maxPayment),
 				maxCreditAmount: parseDecimal(leadAnalysis?.maxCreditAmount),
+				suggestedPaymentDay: leadAnalysis?.suggestedPaymentDay ?? null,
 				hasAnalysis: leadAnalysis?.analyzedAt != null,
 			};
 

--- a/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
+++ b/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
@@ -553,6 +553,18 @@ function CoDebtorCard({
 										</p>
 									</div>
 
+									{/* Fecha ideal de pago */}
+									{creditAnalysisQuery.data?.suggestedPaymentDay != null && (
+										<div className="flex items-center justify-between rounded border px-2 py-1 text-xs">
+											<span className="text-muted-foreground">
+												Fecha ideal de pago
+											</span>
+											<span className="font-semibold text-blue-600">
+												Día {creditAnalysisQuery.data.suggestedPaymentDay}
+											</span>
+										</div>
+									)}
+
 									{/* Capacidad de pago */}
 									<div className="grid grid-cols-2 gap-2 text-center text-xs">
 										<div className="rounded border p-2">

--- a/apps/crm/apps/web/src/components/credit/ConsolidatedCreditSummary.tsx
+++ b/apps/crm/apps/web/src/components/credit/ConsolidatedCreditSummary.tsx
@@ -116,6 +116,18 @@ export function ConsolidatedCreditSummary({
 				</div>
 			</div>
 
+			{/* Fecha ideal de pago sugerida (solo del deudor principal) */}
+			{lead.suggestedPaymentDay != null && (
+				<div className="rounded-md bg-white/80 p-2 text-center dark:bg-white/5">
+					<p className="text-muted-foreground text-xs">
+						Fecha ideal de pago
+					</p>
+					<p className="font-semibold text-blue-600 text-sm">
+						Día {lead.suggestedPaymentDay}
+					</p>
+				</div>
+			)}
+
 			{/* Desglose si hay co-firmantes */}
 			{coDebtorsCount > 0 && (
 				<div className="border-t pt-3">

--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -741,6 +741,18 @@ export function LeadDetailModal({
 								</div>
 							)}
 
+							{/* Suggested Payment Day */}
+							{creditAnalysisQuery.data.suggestedPaymentDay != null && (
+								<div className="flex items-center justify-between rounded-lg border px-3 py-2">
+									<span className="text-muted-foreground text-xs">
+										Fecha Ideal de Pago
+									</span>
+									<span className="font-bold text-blue-600 text-sm">
+										Día {creditAnalysisQuery.data.suggestedPaymentDay}
+									</span>
+								</div>
+							)}
+
 							{/* Payment Capacity */}
 							<div className="grid grid-cols-2 gap-4">
 								{creditAnalysisQuery.data.maxPayment && (

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -226,6 +226,7 @@ type CreditAnalysisData = {
 	economicAvailability: string | null;
 	maxPayment: string | null;
 	maxCreditAmount: string | null;
+	suggestedPaymentDay: number | null;
 	analyzedAt: Date;
 } | null;
 
@@ -1566,6 +1567,20 @@ function RouteComponent() {
 											</span>
 										</div>
 									</div>
+
+									{/* Fecha Ideal de Pago Sugerida */}
+									{selectedClient.creditAnalysis.suggestedPaymentDay !=
+										null && (
+										<div className="flex items-center justify-between rounded-lg border px-3 py-2">
+											<span className="text-muted-foreground text-xs">
+												Fecha Ideal de Pago
+											</span>
+											<span className="font-bold text-blue-600 text-sm">
+												Día{" "}
+												{selectedClient.creditAnalysis.suggestedPaymentDay}
+											</span>
+										</div>
+									)}
 
 									{/* Capacidad de Pago */}
 									<div className="grid grid-cols-2 gap-3">

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -3047,6 +3047,18 @@ function RouteComponent() {
 											<h4 className="font-medium text-base">
 												Capacidad de Pago
 											</h4>
+											{creditAnalysisQuery.data.suggestedPaymentDay !=
+												null && (
+												<div className="flex items-center justify-between rounded-lg border px-3 py-2">
+													<span className="text-muted-foreground text-xs">
+														Fecha Ideal de Pago
+													</span>
+													<span className="font-bold text-blue-600 text-sm">
+														Día{" "}
+														{creditAnalysisQuery.data.suggestedPaymentDay}
+													</span>
+												</div>
+											)}
 											<div className="grid grid-cols-2 gap-4">
 												<div className="rounded-lg border p-4 text-center">
 													<Label className="text-muted-foreground text-xs">

--- a/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
+++ b/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
@@ -180,12 +180,6 @@ export const CalculatorCredit = ({ standalone = false }: CalculatorCreditProps) 
                 <div className="rounded-lg mt-6 shadow-sm">
                   <div className="space-y-3">
                     <div className="flex justify-between items-center">
-                      <span className="text-white">Tasa de interés:</span>
-                      <span className="text-xl text-white font-semibold">
-                        {resultado.interes}%
-                      </span>
-                    </div>
-                    <div className="flex justify-between items-center">
                       <span className="text-primary">Pago mensual:</span>
                       <span className="text-xl text-primary font-semibold">
                         Q.
@@ -195,6 +189,9 @@ export const CalculatorCredit = ({ standalone = false }: CalculatorCreditProps) 
                       </span>
                     </div>
                   </div>
+                  <p className="text-xs text-white/40 mt-3 text-center">
+                    Seguro y GPS incluido en cuota, plazo: usado hasta 60 meses y nuevo hasta 84 meses.
+                  </p>
                   <p className="text-xs text-white/40 mt-3 text-center">
                     *Esta calculadora es una estimación referencial y puede variar según la evaluación y las condiciones finales del crédito.
                   </p>


### PR DESCRIPTION
## #1 Fecha ideal de pago según los ingresos del cliente
Agrega, dentro del análisis de capacidad de pago existente, el cálculo de la **fecha ideal de pago** del cliente a partir de los estados de cuenta que ya se suben. Es un dato **informativo** que ayuda al analista a estructurar el crédito según cuándo el cliente recibe liquidez. No modifica el `diaPagoMensual` del crédito ni ningún campo operativo.

## Qué hace
En la misma llamada a la IA que ya analiza los estados de cuenta, el modelo revisa las **fechas de las transacciones de ingreso** (no solo los totales), detecta los días en que el cliente recibe ingresos recurrentes (sueldo/quincena) y sugiere el mejor día del mes para la cuota: 1–5 días después de su ingreso recurrente de mayor monto, para que el dinero ya esté disponible cuando venza. En caso de quincena, elige la que deja más liquidez; si el ingreso es irregular, elige el día más conservador y lo explica.

## Cambios

**IA** — `bank-analysis-schema.ts`
- Nuevo bloque `analisis_fecha_pago` en el schema de respuesta (`dias_ingreso_detectados`, `dia_pago_sugerido`, `justificacion`) e instrucciones en el prompt. Se resuelve en la misma llamada a Gemini, sin costo ni intentos adicionales.
- El bloque es `.nullable()` y los días están acotados a enteros 1–31: al ser informativo, nunca puede tumbar el análisis financiero core ni persistir valores inválidos (la validación zod es a la vez el `responseSchema`, así que también restringe al modelo).

**Base de datos** — `crm.ts` (schema) + migración `0025`
- Nueva columna `suggested_payment_day` (integer, nullable) en `credit_analysis`. El detalle completo (días detectados + justificación) queda en `full_analysis`, sin desnormalizar de más.

**Backend** — `bank-analysis.ts` + `crm.ts` (router)
- Persiste `suggested_payment_day` al guardar el análisis exitoso.
- Lo expone en la lectura por lead, en el consolidado (solo el del **lead** — una fecha no es aditiva entre co-deudores como sí lo son los montos) y en la query de clientes.

**Frontend** — `leads.tsx`, `clients.tsx`, `lead-detail-modal.tsx`, `CoDebtorsView.tsx`, `ConsolidatedCreditSummary.tsx`
- Muestra la **Fecha Ideal de Pago** como dato informativo en las 5 vistas del análisis, con el mismo formato y estilo que Pago Máximo / Crédito Máximo. Solo se renderiza cuando hay dato; para análisis sin el campo, el componente no aparece.

## Decisión de diseño
El dato es **hacia adelante**: se calcula solo en análisis nuevos. Los registros previos al deploy no se re-analizan ni se backfillean (su `full_analysis` tampoco contiene el bloque), por lo que el campo simplemente no se muestra para ellos.

## Pruebas
Validado end-to-end con dos escenarios de 9 estados de cuenta cada uno (3 bancos × 3 meses, mismo titular):
- **Asalariado (sueldo mensual):** detecta el día del sueldo y sugiere la fecha justo después.
- **Quincena (día 15 y fin de mes):** detecta ambas quincenas y elige la de mayor monto.

En ambos, la IA consolidó los 3 bancos en 3 meses y **excluyó correctamente las transferencias entre cuentas propias** (no las contó como ingreso ni gasto).

## Migración
Aplicar `0025_add_suggested_payment_day.sql` en producción al desplegar (columna nullable, sin backfill).



## #2 Reemplazar tasa de interés por disclaimer de seguro/GPS en calculadora de crédito
commit: [f8df917](https://github.com/Engineering-Club-Cash-In/universe/pull/1107/commits/f8df917d722bfa56d21b4456cf3077d1ba5ba211) 
Se elimina la visualización de la "Tasa de interés" en la calculadora pública de crédito vehicular (/calculadora y /credit) y se reemplaza por un texto informativo requerido por el negocio:

- "Seguro y GPS incluido en cuota, plazo: usado hasta 60 meses y nuevo hasta 84 meses."
- apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx: se quita el bloque que mostraba Tasa de interés: X% y se agrega el nuevo disclaimer junto al ya existente sobre la estimación referencial.
- Alcance: solo afecta la calculadora pública de pre-venta (CalculatorCredit). 