### PR TITLE
fix(cartera): keep installments consistent after revalidation

### DIFF
--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -17,7 +17,7 @@ import {
 import { desc, gte } from "drizzle-orm";
 import Big from "big.js";
 import { z } from "zod";
-import { and, eq, lt, sql, asc, lte, inArray, notInArray } from "drizzle-orm";
+import { and, eq, lt, sql, asc, lte, inArray } from "drizzle-orm";
 import { removeAccents } from "../utils/functions/generalFunctions";
 import {
   processAndReplaceCreditInvestors,
@@ -28,6 +28,19 @@ import { calcularAjusteCompras, obtenerSumaComprasMesAnterior, obtenerSumaCompra
 import { calcularFactoresProrrateoInteresV2 } from "../cofidi/prorrateoPciInteres";
 import { calcularSplitInteresPci } from "../cofidi/splitInteresPci";
 import { t } from "elysia";
+import { calcularResumenAbonosCuota } from "./registerPaymentPolicy";
+
+export const crearResumenAbonosCuota = (input: Parameters<
+  typeof calcularResumenAbonosCuota
+>[0]) => {
+  const resumen = calcularResumenAbonosCuota(input);
+  return {
+    cuota_cerrada: resumen.cuotaCerrada,
+    total_aplicado_cuota: resumen.totalAplicadoCuota,
+    saldo_pendiente: resumen.saldoPendiente,
+    tiene_abono_parcial: resumen.tieneAbonoParcial,
+  };
+};
 
 // ID del inversionista Cube. Fuente canónica: assignCapital.ts (export const CUBE_ID = 86).
 // Se redefine local (igual que investor.ts) para no acoplar la carga de este módulo
@@ -987,13 +1000,19 @@ export async function insertPagosCreditoInversionistas(
   return resolvedInserts;
 }
 
+type InvestorPaymentDb = Pick<
+  typeof db,
+  "query" | "select" | "insert" | "update"
+>;
+
 export async function insertPagosCreditoInversionistasV2(
   pago_id: number,
   credito_id: number,
   fechaPeriodo?: Date,
+  txOrDb: InvestorPaymentDb = db,
 ) {
   // 1. Obtener el pago
-  const currentPago = await db.query.pagos_credito.findFirst({
+  const currentPago = await txOrDb.query.pagos_credito.findFirst({
     where: (p, { eq }) => eq(p.pago_id, pago_id),
   });
 
@@ -1002,7 +1021,7 @@ export async function insertPagosCreditoInversionistasV2(
   }
 
   // 2. Obtener inversionistas del crédito
-  const inversionistasData = await db.query.creditos_inversionistas.findMany({
+  const inversionistasData = await txOrDb.query.creditos_inversionistas.findMany({
     where: (ci, { eq }) => eq(ci.credito_id, credito_id),
   });
 
@@ -1013,7 +1032,7 @@ export async function insertPagosCreditoInversionistasV2(
   // 3. Obtener nombres para identificar a Cube
   const inversionistasWithName = await Promise.all(
     inversionistasData.map(async (inv) => {
-      const [invRow] = await db
+      const [invRow] = await txOrDb
         .select({ nombre: inversionistas.nombre })
         .from(inversionistas)
         .where(eq(inversionistas.inversionista_id, inv.inversionista_id));
@@ -1045,7 +1064,7 @@ export async function insertPagosCreditoInversionistasV2(
   //    del mes de la compra se aplicaría a un mes que no corresponde. La facturación
   //    tiene el MISMO comportamiento, así que pci y la factura no divergen; cuando se
   //    decida cerrar este borde hay que hacerlo en AMBOS lados (cofidi.ts + acá).
-  const comprasPendientesFacturar = await db
+  const comprasPendientesFacturar = await txOrDb
     .select({
       inversionista_id: compras_credito_inversionista.inversionista_id,
       monto_aportado: compras_credito_inversionista.monto_aportado,
@@ -1070,7 +1089,7 @@ export async function insertPagosCreditoInversionistasV2(
     const compra = comprasPendientesFacturar[0];
 
     // Espejo: base (monto_aportado), status y fecha_inicio_participacion por inversionista.
-    const espejoRows = await db
+    const espejoRows = await txOrDb
       .select({
         inversionista_id: creditos_inversionistas_espejo.inversionista_id,
         monto_aportado: creditos_inversionistas_espejo.monto_aportado,
@@ -1185,7 +1204,9 @@ export async function insertPagosCreditoInversionistasV2(
         credito_id,
         abonoCapitalInv.toNumber(),
         false,
-        inv.inversionista_id
+        inv.inversionista_id,
+        false,
+        txOrDb
       );
     }
 
@@ -1205,7 +1226,7 @@ export async function insertPagosCreditoInversionistasV2(
   }
 
   // 7. Insertar/upsert en pagos_credito_inversionistas
-  await db
+  await txOrDb
     .insert(pagos_credito_inversionistas)
     .values(inserts)
     .onConflictDoUpdate({
@@ -3307,7 +3328,7 @@ export async function getAbonosPorCuota(
 ) {
   // 1. Buscar el crédito por SIFCO
   const [credito] = await db
-    .select({ credito_id: creditos.credito_id })
+    .select({ credito_id: creditos.credito_id, cuota: creditos.cuota })
     .from(creditos)
     .where(eq(creditos.numero_credito_sifco, numero_credito_sifco))
     .limit(1);
@@ -3321,7 +3342,10 @@ export async function getAbonosPorCuota(
   // credito (p. ej. tras regeneraciones de calendario). Se consideran todas para
   // no perder pagos vinculados al cuota_id "viejo".
   const cuotasMatch = await db
-    .select({ cuota_id: cuotas_credito.cuota_id })
+    .select({
+      cuota_id: cuotas_credito.cuota_id,
+      pagado: cuotas_credito.pagado,
+    })
     .from(cuotas_credito)
     .where(
       and(
@@ -3340,6 +3364,8 @@ export async function getAbonosPorCuota(
   const pagos = await db
     .select({
       pago_id: pagos_credito.pago_id,
+      validationStatus: pagos_credito.validationStatus,
+      paymentFalse: pagos_credito.paymentFalse,
       abono_capital: pagos_credito.abono_capital,
       abono_iva_12: pagos_credito.abono_iva_12,
       abono_interes: pagos_credito.abono_interes,
@@ -3353,11 +3379,10 @@ export async function getAbonosPorCuota(
       and(
         eq(pagos_credito.credito_id, credito.credito_id),
         inArray(pagos_credito.cuota_id, cuotaIds),
-        // Excluir abonos directos a capital (no son pago de cuota) y reversados.
-        // `capital` = sin aplicar, `capital_validated` = aplicado; ninguno es
-        // abono de la cuota, así que no deben aparecer en este desglose.
+        // El desglose y el resumen deben usar exactamente los mismos pagos vivos
+        // de cuota. Excluye reversados, placeholders, convenio y capital directo.
         eq(pagos_credito.paymentFalse, false),
-        notInArray(pagos_credito.validationStatus, ["capital", "capital_validated"])
+        inArray(pagos_credito.validationStatus, ["pending", "validated"])
       )
     );
 
@@ -3377,6 +3402,11 @@ export async function getAbonosPorCuota(
     total_abono_seguro = total_abono_seguro.plus(p.abono_seguro || "0");
     total_abono_gps = total_abono_gps.plus(p.abono_gps || "0");
   }
+  const resumen = crearResumenAbonosCuota({
+    montoCuota: credito.cuota ?? 0,
+    cuotaCerrada: cuotasMatch.some((cuota) => cuota.pagado === true),
+    pagos,
+  });
 
   return {
     success: true,
@@ -3389,5 +3419,6 @@ export async function getAbonosPorCuota(
     membresias_pago: total_membresias_pago.toFixed(2),
     abono_seguro: total_abono_seguro.toFixed(2),
     abono_gps: total_abono_gps.toFixed(2),
+    ...resumen,
   };
 }

--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -13,6 +13,7 @@ import {
   shouldRejectZeroAppliedNormalValidation,
   shouldMarkInstallmentPaymentPaid,
   sumarAplicadoACuota,
+  calcularCoberturaCuota,
 } from "./registerPaymentPolicy";
 
 describe("register payment", () => {
@@ -258,6 +259,32 @@ describe("sumarAplicadoACuota", () => {
         },
       ]).toFixed(2)
     ).toBe("0.00");
+  });
+});
+
+describe("calcularCoberturaCuota", () => {
+  it("cubre una cuota con pagos partidos vivos aunque uno siga pending", () => {
+    const cobertura = calcularCoberturaCuota({
+      montoCuota: "100.00",
+      incluirPendientes: true,
+      pagos: [
+        {
+          pago_id: 1,
+          validationStatus: "validated",
+          paymentFalse: false,
+          abono_capital: "40.00",
+        },
+        {
+          pago_id: 2,
+          validationStatus: "pending",
+          paymentFalse: false,
+          abono_capital: "59.99",
+        },
+      ],
+    });
+
+    expect(cobertura.cuotaCompleta).toBeTrue();
+    expect(cobertura.totalAplicado.toFixed(2)).toBe("99.99");
   });
 });
 

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -25,6 +25,7 @@ import {
   calcularSaldoNetoCuota,
   esDestinoSobrescribible,
   getCuotaIdForPaymentInsert,
+  getCoveredOpenInstallment,
   getRequestedInstallmentFloor,
   getSpecialPaymentInstallmentFields,
   getSpecialPaymentCuotaId,
@@ -35,15 +36,12 @@ import {
   shouldMarkInstallmentPaymentPaid,
   sumarAplicadoACuota,
 } from "./registerPaymentPolicy";
+import {
+  PAYMENT_ADVISORY_LOCK_NAMESPACE,
+  type PaymentAdvisoryLockConnection,
+} from "../utils/paymentAdvisoryLock";
 
-type LockConn = {
-  query: (text: string, values?: unknown[]) => Promise<unknown>;
-  release: () => void;
-};
-
-// Namespace para advisory locks de pagos (evita colisión con otros locks).
-// pg_advisory_lock(ns, credito_id) serializa pagos concurrentes del mismo crédito.
-const PAGO_LOCK_NS = 8765;
+const CUOTA_INTEGRITY_ERROR_PREFIX = "Inconsistencia de integridad:";
 
 // ========================================
 // TIPOS E INTERFACES
@@ -342,6 +340,36 @@ const obtenerInfoCompletaCredito = async (
         )
         .orderBy(cuotas_credito.numero_cuota),
     ]);
+
+    const cuotasParaValidar = new Map<
+      number,
+      {
+        cuotaId: number;
+        numeroCuota: number;
+        pagos: (typeof pagos_credito.$inferSelect)[];
+      }
+    >();
+    for (const item of cuotasPendientes) {
+      const cuotaId = item.cuotas_credito.cuota_id;
+      const cuota = cuotasParaValidar.get(cuotaId) ?? {
+        cuotaId,
+        numeroCuota: item.cuotas_credito.numero_cuota,
+        pagos: [],
+      };
+      cuota.pagos.push(item.pagos_credito);
+      cuotasParaValidar.set(cuotaId, cuota);
+    }
+    const cuotaInconsistente = getCoveredOpenInstallment({
+      montoCuota: info.credito.cuota ?? 0,
+      cuotas: [...cuotasParaValidar.values()],
+    });
+    if (cuotaInconsistente) {
+      set.status = 409;
+      throw new Error(
+        `${CUOTA_INTEGRITY_ERROR_PREFIX} la cuota ${cuotaInconsistente.numeroCuota} está abierta, pero sus pagos validados ya cubren el total. Revalide el pago antes de registrar uno nuevo.`
+      );
+    }
+
     console.log(cuotaApagar,"cuota a pagar");
     const cuotasPendientesUnicas = Array.from(
       new Map(
@@ -400,6 +428,13 @@ const obtenerInfoCompletaCredito = async (
       },
     };
   } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.startsWith(CUOTA_INTEGRITY_ERROR_PREFIX)
+    ) {
+      throw error;
+    }
+
     // 🔥 Preservar errores 404
     if (
       (error as any).message === "Credit not found" ||
@@ -509,7 +544,7 @@ const insertarBoletas = async (pago_id: number, urlCompletas: string[]) => {
 
 export const insertPayment = async ({ body, set }: any) => {
   // 🔒 Conexión dedicada para el advisory lock (se libera en finally).
-  let lockConn: LockConn | undefined;
+  let lockConn: PaymentAdvisoryLockConnection | undefined;
   let lockedCreditoId: number | undefined;
   try {
     // 1. Validar schema
@@ -551,7 +586,7 @@ export const insertPayment = async ({ body, set }: any) => {
     lockConn = await client.connect();
     lockedCreditoId = credito_id;
     await lockConn.query("SELECT pg_advisory_lock($1, $2)", [
-      PAGO_LOCK_NS,
+      PAYMENT_ADVISORY_LOCK_NAMESPACE,
       credito_id,
     ]);
 
@@ -1936,6 +1971,14 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
     }
   } catch (error) {
     console.error("[insertPayment] Error:", error);
+    if (
+      error instanceof Error &&
+      error.message.startsWith(CUOTA_INTEGRITY_ERROR_PREFIX)
+    ) {
+      set.status = 409;
+      return { success: false, message: error.message };
+    }
+
     set.status = 500;
     return {
       message: "Internal server error",
@@ -1947,7 +1990,7 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
       try {
         if (lockedCreditoId !== undefined) {
           await lockConn.query("SELECT pg_advisory_unlock($1, $2)", [
-            PAGO_LOCK_NS,
+            PAYMENT_ADVISORY_LOCK_NAMESPACE,
             lockedCreditoId,
           ]);
         }

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.test.ts
@@ -3,6 +3,213 @@ import {
   recomputeCreditAfterCapital,
   shouldIncobrableInstallmentBePaid,
 } from "./registerPaymentPolicy";
+import * as registerPaymentPolicy from "./registerPaymentPolicy";
+
+describe("registerPaymentPolicy - integridad de cuotas abiertas", () => {
+  it("detecta una cuota abierta que ya está cubierta por pagos validados vivos", () => {
+    const detectarInconsistencia = Reflect.get(
+      registerPaymentPolicy,
+      "getCoveredOpenInstallment",
+    );
+
+    expect(detectarInconsistencia).toBeFunction();
+    if (typeof detectarInconsistencia !== "function") return;
+
+    expect(
+      detectarInconsistencia({
+        montoCuota: "100.00",
+        cuotas: [
+          {
+            cuotaId: 20,
+            numeroCuota: 3,
+            pagos: [
+              {
+                pago_id: 30,
+                validationStatus: "validated",
+                paymentFalse: false,
+                abono_capital: "80.00",
+                abono_interes: "17.86",
+                abono_iva_12: "2.14",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({ cuotaId: 20, numeroCuota: 3 });
+  });
+
+  it("no bloquea varios pagos pending antes de validación", () => {
+    expect(
+      registerPaymentPolicy.getCoveredOpenInstallment({
+        montoCuota: "100.00",
+        cuotas: [
+          {
+            cuotaId: 20,
+            numeroCuota: 3,
+            pagos: [
+              {
+                validationStatus: "pending",
+                paymentFalse: false,
+                abono_capital: "60.00",
+              },
+              {
+                validationStatus: "pending",
+                paymentFalse: false,
+                abono_capital: "40.00",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  it("detecta cobertura repartida entre filas duplicadas de la misma cuota", () => {
+    expect(
+      registerPaymentPolicy.getCoveredOpenInstallment({
+        montoCuota: "100.00",
+        cuotas: [
+          {
+            cuotaId: 20,
+            numeroCuota: 3,
+            pagos: [
+              {
+                validationStatus: "validated",
+                paymentFalse: false,
+                abono_capital: "60.00",
+              },
+            ],
+          },
+          {
+            cuotaId: 21,
+            numeroCuota: 3,
+            pagos: [
+              {
+                validationStatus: "validated",
+                paymentFalse: false,
+                abono_capital: "40.00",
+              },
+            ],
+          },
+        ],
+      }),
+    ).toEqual({ cuotaId: 20, numeroCuota: 3 });
+  });
+});
+
+describe("registerPaymentPolicy - resumen de abonos de cuota", () => {
+  const resumir = (
+    input: Parameters<
+      typeof registerPaymentPolicy.calcularResumenAbonosCuota
+    >[0],
+  ) => {
+    const calcularResumen = Reflect.get(
+      registerPaymentPolicy,
+      "calcularResumenAbonosCuota",
+    );
+    expect(calcularResumen).toBeFunction();
+    if (typeof calcularResumen !== "function") return;
+    return calcularResumen(input);
+  };
+
+  it("un pago completo de una cuota cerrada no es abono parcial", () => {
+    expect(
+      resumir({
+        montoCuota: "100.00",
+        cuotaCerrada: true,
+        pagos: [
+          {
+            validationStatus: "validated",
+            paymentFalse: false,
+            abono_capital: "80.00",
+            abono_interes: "17.86",
+            abono_iva_12: "2.14",
+          },
+        ],
+      }),
+    ).toEqual({
+      cuotaCerrada: true,
+      totalAplicadoCuota: "100.00",
+      saldoPendiente: "0.00",
+      tieneAbonoParcial: false,
+    });
+  });
+
+  it("una cuota abierta parcialmente cubierta sí tiene abono parcial", () => {
+    expect(
+      resumir({
+        montoCuota: "100.00",
+        cuotaCerrada: false,
+        pagos: [
+          {
+            validationStatus: "pending",
+            paymentFalse: false,
+            abono_capital: "40.00",
+          },
+        ],
+      }),
+    ).toEqual({
+      cuotaCerrada: false,
+      totalAplicadoCuota: "40.00",
+      saldoPendiente: "60.00",
+      tieneAbonoParcial: true,
+    });
+  });
+
+  it("un placeholder en cero no es abono parcial", () => {
+    expect(
+      resumir({
+        montoCuota: "100.00",
+        cuotaCerrada: false,
+        pagos: [
+          {
+            validationStatus: "no_required",
+            paymentFalse: false,
+            abono_capital: "0",
+          },
+        ],
+      }),
+    ).toEqual({
+      cuotaCerrada: false,
+      totalAplicadoCuota: "0.00",
+      saldoPendiente: "100.00",
+      tieneAbonoParcial: false,
+    });
+  });
+
+  it("excluye mora, otros, convenio y abono directo a capital", () => {
+    expect(
+      resumir({
+        montoCuota: "100.00",
+        cuotaCerrada: false,
+        pagos: [
+          {
+            validationStatus: "validated",
+            paymentFalse: false,
+            abono_interes: "20.00",
+          },
+          {
+            validationStatus: "validated",
+            paymentFalse: false,
+            mora: "100.00",
+            otros: "200.00",
+            pagoConvenio: "300.00",
+          },
+          {
+            validationStatus: "capital_validated",
+            paymentFalse: false,
+            abono_capital: "500.00",
+          },
+        ],
+      }),
+    ).toEqual({
+      cuotaCerrada: false,
+      totalAplicadoCuota: "20.00",
+      saldoPendiente: "80.00",
+      tieneAbonoParcial: true,
+    });
+  });
+});
 
 describe("registerPaymentPolicy - shouldIncobrableInstallmentBePaid", () => {
   it("no aplica (null) cuando el crédito no es incobrable", () => {

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -233,6 +233,15 @@ export type RubrosCuotaRow = {
   membresias_pago?: BigInput | null;
 };
 
+export type PagoCoberturaCuota = RubrosCuotaRow & {
+  pago_id?: number;
+  validationStatus?: string | null;
+  paymentFalse?: boolean | null;
+  mora?: BigInput | null;
+  otros?: string | number | null;
+  pagoConvenio?: BigInput | null;
+};
+
 /**
  * Σ de lo que los pagos hermanos aplicaron a la CUOTA contractual
  * (`credito.cuota`): capital + interés + IVA + seguro + GPS + membresías.
@@ -261,6 +270,108 @@ export const sumarAplicadoACuota = (rows: RubrosCuotaRow[]): Big =>
         .plus(new Big(r.membresias_pago ?? 0)),
     new Big(0)
   );
+
+export const calcularCoberturaCuota = ({
+  montoCuota,
+  pagos,
+  pagoIdEnValidacion,
+  incluirPendientes = false,
+}: {
+  montoCuota: BigInput;
+  pagos: PagoCoberturaCuota[];
+  pagoIdEnValidacion?: number;
+  incluirPendientes?: boolean;
+}) => {
+  const monto = new Big(montoCuota);
+  const aplicados = pagos.filter(
+    (pago) =>
+      pago.paymentFalse === false &&
+      (pago.validationStatus === "validated" ||
+        (pago.validationStatus === "pending" &&
+          (incluirPendientes ||
+            (pagoIdEnValidacion !== undefined &&
+              pago.pago_id === pagoIdEnValidacion))))
+  );
+  const totalAplicado = sumarAplicadoACuota(aplicados);
+  const saldoPendiente = monto.minus(totalAplicado);
+  const cuotaCompleta =
+    monto.gt(0) && totalAplicado.gte(monto.minus(0.01));
+
+  return {
+    totalAplicado,
+    saldoPendiente: saldoPendiente.gt(0) ? saldoPendiente : new Big(0),
+    cuotaCompleta,
+    tieneAbonoParcial:
+      !cuotaCompleta && totalAplicado.gt(0) && totalAplicado.lt(monto),
+  };
+};
+
+export const getCoveredOpenInstallment = ({
+  montoCuota,
+  cuotas,
+}: {
+  montoCuota: BigInput;
+  cuotas: {
+    cuotaId: number;
+    numeroCuota: number;
+    pagos: PagoCoberturaCuota[];
+  }[];
+}) => {
+  const cuotasLogicas = new Map<number, (typeof cuotas)[number]>();
+  for (const cuota of cuotas) {
+    const existente = cuotasLogicas.get(cuota.numeroCuota);
+    cuotasLogicas.set(
+      cuota.numeroCuota,
+      existente
+        ? { ...existente, pagos: [...existente.pagos, ...cuota.pagos] }
+        : cuota
+    );
+  }
+
+  const inconsistente = [...cuotasLogicas.values()].find((cuota) =>
+    calcularCoberturaCuota({
+      montoCuota,
+      pagos: cuota.pagos,
+    }).cuotaCompleta
+  );
+
+  return inconsistente
+    ? {
+        cuotaId: inconsistente.cuotaId,
+        numeroCuota: inconsistente.numeroCuota,
+      }
+    : null;
+};
+
+export type ResumenAbonosCuota = {
+  cuotaCerrada: boolean;
+  totalAplicadoCuota: string;
+  saldoPendiente: string;
+  tieneAbonoParcial: boolean;
+};
+
+export const calcularResumenAbonosCuota = ({
+  montoCuota,
+  cuotaCerrada,
+  pagos,
+}: {
+  montoCuota: BigInput;
+  cuotaCerrada: boolean;
+  pagos: PagoCoberturaCuota[];
+}): ResumenAbonosCuota => {
+  const cobertura = calcularCoberturaCuota({
+    montoCuota,
+    pagos,
+    incluirPendientes: true,
+  });
+
+  return {
+    cuotaCerrada,
+    totalAplicadoCuota: cobertura.totalAplicado.toFixed(2),
+    saldoPendiente: cobertura.saldoPendiente.toFixed(2),
+    tieneAbonoParcial: !cuotaCerrada && cobertura.tieneAbonoParcial,
+  };
+};
 
 export type SaldoCuotaNeto = {
   saldoRealCuota: Big;

--- a/apps/cartera-back/src/controllers/revalidatePayment.test.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const updates: Record<string, unknown>[] = [];
+let selectResults: unknown[][] = [];
+const insertInvestors = mock(() => Promise.resolve());
+
+const tx = {
+  execute: mock(() => Promise.resolve()),
+  select: mock(() => ({
+    from: () => ({
+      where: () => {
+        const rows = selectResults.shift() ?? [];
+        return Object.assign(Promise.resolve(rows), {
+          limit: () => Promise.resolve(rows),
+        });
+      },
+    }),
+  })),
+  update: mock(() => ({
+    set: (values: Record<string, unknown>) => ({
+      where: () => {
+        updates.push(values);
+        return Object.assign(Promise.resolve(), {
+          returning: () => Promise.resolve([{ pago_id: 30 }]),
+        });
+      },
+    }),
+  })),
+};
+
+mock.module("../database", () => ({
+  db: {
+    transaction: mock(
+      (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx),
+    ),
+  },
+}));
+
+mock.module("../utils/withAuditContext", () => ({
+  setCapitalSource: mock(() => Promise.resolve()),
+}));
+
+mock.module("./payments", () => ({
+  insertPagosCreditoInversionistasV2: insertInvestors,
+}));
+
+const { revalidatePayment } = await import("./revalidatePayment");
+
+const pagoCompletoPendiente = {
+  pago_id: 30,
+  credito_id: 10,
+  cuota_id: 20,
+  validationStatus: "pending",
+  paymentFalse: false,
+  monto_aplicado: "100.00",
+  abono_capital: "80.00",
+  abono_interes: "17.86",
+  abono_iva_12: "2.14",
+  abono_seguro: "0",
+  abono_gps: "0",
+  membresias_pago: "0",
+  mora: "0",
+  otros: "0",
+  pagoConvenio: "0",
+};
+
+const credito = {
+  credito_id: 10,
+  numero_credito_sifco: "CRED-10",
+  capital: "1000.00",
+  cuota: "100.00",
+  porcentaje_interes: "1",
+  seguro_10_cuotas: "0",
+  gps: "0",
+  membresias_pago: "0",
+};
+
+describe("revalidatePayment", () => {
+  beforeEach(() => {
+    updates.length = 0;
+    selectResults = [[pagoCompletoPendiente], [credito], []];
+    tx.execute.mockClear();
+    insertInvestors.mockClear();
+  });
+
+  it("restaura la cuota cerrada al revalidar el pago completo reversado", async () => {
+    const set = { status: 0 };
+
+    await revalidatePayment({
+      body: { credito_id: 10, pago_id: 30 },
+      set,
+    });
+
+    expect(set.status).toBe(200);
+    expect(updates.some((values) => values.pagado === true)).toBeTrue();
+    expect(insertInvestors).toHaveBeenCalledWith(30, 10, undefined, tx);
+    expect(tx.execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("valida un pago parcial sin cerrar la cuota", async () => {
+    const pagoParcial = {
+      ...pagoCompletoPendiente,
+      monto_aplicado: "60.00",
+      abono_capital: "50.00",
+      abono_interes: "8.93",
+      abono_iva_12: "1.07",
+    };
+    selectResults = [
+      [pagoParcial],
+      [credito],
+      [pagoParcial],
+    ];
+    const set = { status: 0 };
+
+    await revalidatePayment({
+      body: { credito_id: 10, pago_id: 30 },
+      set,
+    });
+
+    expect(set.status).toBe(200);
+    expect(
+      updates.some((values) => values.validationStatus === "validated"),
+    ).toBeTrue();
+    expect(updates.some((values) => values.pagado === true)).toBeFalse();
+  });
+
+  it("no cuenta dos veces el pago actual devuelto por el query de la cuota", async () => {
+    const pagoParcial = {
+      ...pagoCompletoPendiente,
+      monto_aplicado: "60.00",
+      abono_capital: "50.00",
+      abono_interes: "8.93",
+      abono_iva_12: "1.07",
+    };
+    selectResults = [[pagoParcial], [credito], [pagoParcial]];
+    const set = { status: 0 };
+
+    await revalidatePayment({
+      body: { credito_id: 10, pago_id: 30 },
+      set,
+    });
+
+    expect(set.status).toBe(200);
+    expect(updates.some((values) => values.pagado === true)).toBeFalse();
+  });
+
+  it("cierra la cuota cuando el pago actual y un hermano validated cubren el monto", async () => {
+    const pagoParcial = {
+      ...pagoCompletoPendiente,
+      monto_aplicado: "40.00",
+      abono_capital: "30.00",
+      abono_interes: "8.93",
+      abono_iva_12: "1.07",
+    };
+    selectResults = [
+      [pagoParcial],
+      [credito],
+      [
+        {
+          ...pagoCompletoPendiente,
+          pago_id: 29,
+          validationStatus: "validated",
+          monto_aplicado: "60.00",
+          abono_capital: "50.00",
+          abono_interes: "8.93",
+          abono_iva_12: "1.07",
+        },
+      ],
+    ];
+    const set = { status: 0 };
+
+    await revalidatePayment({
+      body: { credito_id: 10, pago_id: 30 },
+      set,
+    });
+
+    expect(set.status).toBe(200);
+    expect(updates.some((values) => values.pagado === true)).toBeTrue();
+  });
+
+  it("no cierra la cuota contando un pago hermano que sigue pending", async () => {
+    const pagoActual = {
+      ...pagoCompletoPendiente,
+      monto_aplicado: "40.00",
+      abono_capital: "30.00",
+      abono_interes: "8.93",
+      abono_iva_12: "1.07",
+    };
+    selectResults = [[pagoActual], [credito], []];
+    const set = { status: 0 };
+
+    await revalidatePayment({
+      body: { credito_id: 10, pago_id: 30 },
+      set,
+    });
+
+    expect(set.status).toBe(200);
+    expect(updates.some((values) => values.pagado === true)).toBeFalse();
+  });
+
+  it("no vuelve a descontar del capital los pagos hermanos ya validados", async () => {
+    const pagoActual = {
+      ...pagoCompletoPendiente,
+      monto_aplicado: "40.00",
+      abono_capital: "30.00",
+      abono_interes: "8.93",
+      abono_iva_12: "1.07",
+    };
+    selectResults = [
+      [pagoActual],
+      [{ ...credito, capital: "950.00" }],
+      [
+        {
+          ...pagoCompletoPendiente,
+          pago_id: 29,
+          validationStatus: "validated",
+          monto_aplicado: "60.00",
+          abono_capital: "50.00",
+          abono_interes: "8.93",
+          abono_iva_12: "1.07",
+        },
+      ],
+    ];
+
+    await revalidatePayment({
+      body: { credito_id: 10, pago_id: 30 },
+      set: { status: 0 },
+    });
+
+    expect(updates.find((values) => values.capital)?.capital).toBe("920");
+  });
+});

--- a/apps/cartera-back/src/controllers/revalidatePayment.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.ts
@@ -1,12 +1,16 @@
 import { z } from "zod";
-import { eq, and } from "drizzle-orm";
+import { eq, and, ne, sql } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
 import { setCapitalSource } from "../utils/withAuditContext";
-import { pagos_credito, creditos } from "../database/db";
+import { pagos_credito, creditos, cuotas_credito } from "../database/db";
 import { insertPagosCreditoInversionistasV2 } from "./payments";
 import { esPagoAplicado } from "../utils/paymentStatus";
-import { shouldRejectZeroAppliedNormalValidation } from "./registerPaymentPolicy";
+import {
+  calcularCoberturaCuota,
+  shouldRejectZeroAppliedNormalValidation,
+} from "./registerPaymentPolicy";
+import { PAYMENT_ADVISORY_LOCK_NAMESPACE } from "../utils/paymentAdvisoryLock";
 
 // ============================================================================
 // SCHEMA DE VALIDACIÓN
@@ -38,6 +42,9 @@ export const revalidatePayment = async ({ body, set }: any) => {
 
     // 🔥 INICIAR TRANSACCIÓN ATÓMICA
     const result = await db.transaction(async (tx) => {
+      await tx.execute(
+        sql`SELECT pg_advisory_xact_lock(${PAYMENT_ADVISORY_LOCK_NAMESPACE}, ${credito_id})`
+      );
       // 2️⃣ OBTENER DATOS DEL PAGO
       const [pago] = await tx
         .select()
@@ -56,6 +63,9 @@ export const revalidatePayment = async ({ body, set }: any) => {
       
       if (esPagoAplicado(pago.validationStatus)) {
         throw new Error(`Payment ${pago_id} is already validated`);
+      }
+      if (pago.validationStatus !== "pending" || pago.paymentFalse !== false) {
+        throw new Error(`Payment ${pago_id} is not pending revalidation`);
       }
 
       if (
@@ -95,30 +105,43 @@ export const revalidatePayment = async ({ body, set }: any) => {
 
       // 4️⃣ CALCULAR NUEVO CAPITAL (restar el abono_capital del pago)
       const capital_actual = new Big(credito.capital ?? 0);
-      const todosPagosCuota = pago.cuota_id === null
+      const pagosVivosCuota = pago.cuota_id === null
         ? []
         : await tx
-            .select({ abono_capital: pagos_credito.abono_capital })
+            .select({
+              pago_id: pagos_credito.pago_id,
+              validationStatus: pagos_credito.validationStatus,
+              paymentFalse: pagos_credito.paymentFalse,
+              abono_capital: pagos_credito.abono_capital,
+              abono_interes: pagos_credito.abono_interes,
+              abono_iva_12: pagos_credito.abono_iva_12,
+              abono_seguro: pagos_credito.abono_seguro,
+              abono_gps: pagos_credito.abono_gps,
+              membresias_pago: pagos_credito.membresias_pago,
+            })
             .from(pagos_credito)
             .where(
               and(
                 eq(pagos_credito.cuota_id, pago.cuota_id),
-                eq(pagos_credito.validationStatus, "validated")
+                eq(pagos_credito.validationStatus, "validated"),
+                eq(pagos_credito.paymentFalse, false),
+                ne(pagos_credito.pago_id, pago_id)
               )
             );
+      const otrosPagosVivos = pagosVivosCuota.filter(
+        (otroPago) => otroPago.pago_id !== pago_id
+      );
 
-      let abono_capital_total = new Big(0);
-      for (const p of todosPagosCuota) {
-        abono_capital_total = abono_capital_total.plus(p.abono_capital ?? 0);
-      }
-
-      // Incluir el abono del pago actual (aún no está "validated")
-      abono_capital_total = abono_capital_total.plus(pago.abono_capital ?? 0);
-
-      const nuevo_capital = capital_actual.minus(abono_capital_total);
+      const abono_capital_actual = new Big(pago.abono_capital ?? 0);
+      const nuevo_capital = capital_actual.minus(abono_capital_actual);
+      const coberturaCuota = calcularCoberturaCuota({
+        montoCuota: credito.cuota ?? 0,
+        pagos: [...otrosPagosVivos, pago],
+        pagoIdEnValidacion: pago_id,
+      });
 
       console.log(`💰 Capital actual: ${capital_actual.toString()}`);
-      console.log(`💰 Abono capital total de cuota: ${abono_capital_total.toString()}`);
+      console.log(`💰 Abono capital del pago actual: ${abono_capital_actual.toString()}`);
       console.log(`💰 Nuevo capital: ${nuevo_capital.toString()}`);
 
       // 5️⃣ CALCULAR NUEVA DEUDA TOTAL
@@ -158,11 +181,35 @@ export const revalidatePayment = async ({ body, set }: any) => {
       }
 
       // 7️⃣ VALIDAR EL PAGO y registrar fecha de aplicación
-      await tx
+      const [validatedPayment] = await tx
         .update(pagos_credito)
         .set({ validationStatus: "validated", fecha_aplicado: new Date() })
-        .where(eq(pagos_credito.pago_id, pago_id));
+        .where(
+          and(
+            eq(pagos_credito.pago_id, pago_id),
+            eq(pagos_credito.validationStatus, "pending"),
+            eq(pagos_credito.paymentFalse, false)
+          )
+        )
+        .returning({ pago_id: pagos_credito.pago_id });
+      if (!validatedPayment) {
+        throw new Error(`Payment ${pago_id} changed during revalidation`);
+      }
       console.log("✅ Pago marcado como validado con fecha de aplicación");
+
+      if (pago.cuota_id !== null && coberturaCuota.cuotaCompleta) {
+        await tx
+          .update(cuotas_credito)
+          .set({ pagado: true })
+          .where(eq(cuotas_credito.cuota_id, pago.cuota_id));
+      }
+
+      await insertPagosCreditoInversionistasV2(
+        pago_id,
+        credito_id,
+        undefined,
+        tx
+      );
 
       return {
         pago_id,
@@ -178,13 +225,6 @@ export const revalidatePayment = async ({ body, set }: any) => {
       return result;
     }
 
-    // 8️⃣ EJECUTAR INVERSIONISTAS (fuera de la transacción para usar la función existente o asegurar que los registros se vean en la otra conexión)
-    // El insertPagosCreditoInversionistasV2 ya maneja su propia forma de inserción.
-    // Ojo: insertPagosCreditoInversionistasV2 puede requerir validaciones internas.
-    console.log("\n💼 ========== PROCESANDO INVERSIONISTAS ==========");
-    await insertPagosCreditoInversionistasV2(pago_id, credito_id);
-    console.log("✅ Pagos a inversionistas procesados correctamente");
-
     set.status = 200;
     return {
       message: "Payment revalidated successfully",
@@ -196,8 +236,12 @@ export const revalidatePayment = async ({ body, set }: any) => {
     
     if (error.message.includes("not found")) {
       set.status = 404;
-    } else if (error.message.includes("already validated")) {
-      set.status = 400;
+    } else if (
+      error.message.includes("already validated") ||
+      error.message.includes("not pending revalidation") ||
+      error.message.includes("changed during revalidation")
+    ) {
+      set.status = 409;
     } else {
       set.status = 500;
     }

--- a/apps/cartera-back/src/utils/paymentAdvisoryLock.ts
+++ b/apps/cartera-back/src/utils/paymentAdvisoryLock.ts
@@ -1,0 +1,6 @@
+export const PAYMENT_ADVISORY_LOCK_NAMESPACE = 8765;
+
+export type PaymentAdvisoryLockConnection = {
+  query: (text: string, values?: unknown[]) => Promise<unknown>;
+  release: () => void;
+};

--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -30,6 +30,7 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog"; 
 import {  DatePickerMUI } from "./calendar";
+import { getDisplayedPartialContribution } from "../services/installmentContribution";
 const fields = [
   {
     name: "monto_boleta",
@@ -90,6 +91,8 @@ export function PagoForm() {
   } = usePagoForm();
 
   const { bancos, loading: loadingBancos } = useBancos();
+  const displayedPartialContribution =
+    getDisplayedPartialContribution(abonosCuota);
 
   // Crédito preseleccionado vía URL (?sifco=...) desde el Historial de Pagos
   const [searchParams, setSearchParams] = useSearchParams();
@@ -297,14 +300,7 @@ export function PagoForm() {
 
         // 4 Cuota Normal (restando abonos ya realizados desde endpoint)
         const cuotaBase = Number(dataCredito?.credito?.cuota) || 0;
-        const abonosYaHechos = abonosCuota ? (
-          Number(abonosCuota.abono_capital || 0) +
-          Number(abonosCuota.abono_interes || 0) +
-          Number(abonosCuota.abono_iva_12 || 0) +
-          Number(abonosCuota.abono_seguro || 0) +
-          Number(abonosCuota.abono_gps || 0) +
-          Number(abonosCuota.membresias_pago || 0)
-        ) : 0;
+        const abonosYaHechos = displayedPartialContribution;
         const cuotaNormal = Math.max(0, cuotaBase - abonosYaHechos);
         if (cuotaNormal > 0 && montoRestante > 0) {
           const montoCuota = Math.min(montoRestante, cuotaNormal);
@@ -584,16 +580,24 @@ export function PagoForm() {
                 convenioActivoInfo={convenioActivoInfo}
                 cuotaMensualAPagar={dataCredito.cuotaMensualAPagar}
                 abonosParciales={(() => {
-                  if (!abonosCuota) return null;
+                  if (!abonosCuota || displayedPartialContribution === 0) {
+                    return null;
+                  }
                   const abono_capital = Number(abonosCuota.abono_capital || 0);
                   const abono_interes = Number(abonosCuota.abono_interes || 0);
                   const abono_iva_12 = Number(abonosCuota.abono_iva_12 || 0);
                   const abono_seguro = Number(abonosCuota.abono_seguro || 0);
                   const abono_gps = Number(abonosCuota.abono_gps || 0);
                   const abono_membresias = Number(abonosCuota.membresias_pago || 0);
-                  const total = abono_capital + abono_interes + abono_iva_12 + abono_seguro + abono_gps + abono_membresias;
-                  if (total === 0) return null;
-                  return { abono_capital, abono_interes, abono_iva_12, abono_seguro, abono_gps, abono_membresias, total };
+                  return {
+                    abono_capital,
+                    abono_interes,
+                    abono_iva_12,
+                    abono_seguro,
+                    abono_gps,
+                    abono_membresias,
+                    total: displayedPartialContribution,
+                  };
                 })()}
               />
             )

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -23,6 +23,7 @@ import { useResetCredit } from "./resetCredit";
 import { getApiErrorMessage } from "@/lib/apiError";
 import { useAuth } from "@/Provider/authProvider";
 import { toast } from "sonner";
+import { getDisplayedPartialContribution } from "../services/installmentContribution";
 export const pagoSchema = z.object({
   credito_id: z.number().int().positive({ message: "Debe seleccionar un crédito" }),
   usuario_id: z.number().int().positive({ message: "Usuario requerido" }),
@@ -445,14 +446,7 @@ console.log("Cuota a usar:", cuotaAPagar);
 const montoRedondeado = Math.round(montoBoletaReal * 100) / 100;
 
 // 🔥 Calcular abonos ya realizados en la cuota SELECCIONADA (desde endpoint)
-const abonosRealizados = abonosCuota ? (
-  Number(abonosCuota.abono_capital || 0) +
-  Number(abonosCuota.abono_interes || 0) +
-  Number(abonosCuota.abono_iva_12 || 0) +
-  Number(abonosCuota.abono_seguro || 0) +
-  Number(abonosCuota.abono_gps || 0) +
-  Number(abonosCuota.membresias_pago || 0)
-) : 0;
+const abonosRealizados = getDisplayedPartialContribution(abonosCuota);
 
 // 🔥 Cuota menos los abonos ya hechos = lo que falta por pagar
 const cuotaComparar = Math.max(0,cuota - abonosRealizados );

--- a/apps/carteraFront/src/private/cartera/services/installmentContribution.test.ts
+++ b/apps/carteraFront/src/private/cartera/services/installmentContribution.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import * as installmentContribution from "./installmentContribution";
+
+const getDisplayedContribution = () =>
+  Reflect.get(installmentContribution, "getDisplayedPartialContribution");
+
+describe("getDisplayedPartialContribution", () => {
+  it("resta únicamente un abono parcial real de una cuota abierta", () => {
+    const getContribution = getDisplayedContribution();
+    expect(getContribution).toBeFunction();
+    if (typeof getContribution !== "function") return;
+
+    expect(
+      getContribution({
+        cuota_cerrada: false,
+        total_aplicado_cuota: "40.00",
+        saldo_pendiente: "60.00",
+        tiene_abono_parcial: true,
+      }),
+    ).toBe(40);
+  });
+
+  it("devuelve cero para cuota cerrada, pago completo o placeholder", () => {
+    const getContribution = getDisplayedContribution();
+    expect(getContribution).toBeFunction();
+    if (typeof getContribution !== "function") return;
+
+    expect(
+      getContribution({
+        cuota_cerrada: true,
+        total_aplicado_cuota: "100.00",
+        saldo_pendiente: "0.00",
+        tiene_abono_parcial: false,
+      }),
+    ).toBe(0);
+    expect(
+      getContribution({
+        cuota_cerrada: false,
+        total_aplicado_cuota: "100.00",
+        saldo_pendiente: "0.00",
+        tiene_abono_parcial: false,
+      }),
+    ).toBe(0);
+    expect(
+      getContribution({
+        cuota_cerrada: false,
+        total_aplicado_cuota: "0.00",
+        saldo_pendiente: "100.00",
+        tiene_abono_parcial: false,
+      }),
+    ).toBe(0);
+  });
+});

--- a/apps/carteraFront/src/private/cartera/services/installmentContribution.ts
+++ b/apps/carteraFront/src/private/cartera/services/installmentContribution.ts
@@ -1,0 +1,22 @@
+export type InstallmentContributionSummary = {
+  cuota_cerrada: boolean;
+  total_aplicado_cuota: string;
+  saldo_pendiente: string;
+  tiene_abono_parcial: boolean;
+};
+
+export const getDisplayedPartialContribution = (
+  summary: InstallmentContributionSummary | null,
+) => {
+  if (
+    !summary ||
+    summary.cuota_cerrada ||
+    !summary.tiene_abono_parcial
+  ) {
+    return 0;
+  }
+
+  const applied = Number(summary.total_aplicado_cuota);
+  const pending = Number(summary.saldo_pendiente);
+  return Number.isFinite(applied) && applied > 0 && pending > 0 ? applied : 0;
+};

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -2,6 +2,7 @@
 import api from "@/Provider/interceptor";
 import type { PagoFormValues } from "../hooks/registerPayment";
 import type { ReactNode } from "react";
+import type { InstallmentContributionSummary } from "./installmentContribution";
 
 const API_URL = import.meta.env.VITE_BACK_URL  ||'https://qk4sw4kc4c088c8csos400wc.s3.devteamatcci.site'; ;
 
@@ -3478,7 +3479,7 @@ export const getEfectividadAsesores = async (params: {
 // ============================================
 // Abonos por cuota
 // ============================================
-export interface AbonosCuotaResponse {
+export interface AbonosCuotaResponse extends InstallmentContributionSummary {
   success: boolean;
   numero_credito_sifco: string;
   numero_cuota: number;


### PR DESCRIPTION
## Resumen

Corrige la inconsistencia que podía quedar después de `pago aplicado → reversión → revalidación`: el pago volvía a `validated`, pero `cuotas_credito.pagado` permanecía en `false`, permitiendo que el selector y el registro trataran una cuota completamente satisfecha como pendiente.

## Cambios

- Sincroniza `cuotas_credito.pagado=true` al revalidar cuando los pagos validados realmente cubren la cuota.
- Mantiene abierta una cuota parcial y no cuenta hermanos todavía `pending` para cerrarla.
- Serializa registro/revalidación por crédito con el mismo advisory lock y usa transición condicional `pending → validated`.
- Ejecuta capital, estado del pago, cuota y distribución a inversionistas dentro de la misma transacción.
- Hace que `newPayment` falle con `409` si detecta una cuota abierta ya cubierta por pagos validados, en vez de saltarla silenciosamente.
- Añade semántica explícita al endpoint de abonos: cuota cerrada, total aplicado, saldo pendiente y abono parcial real.
- Excluye reversados, placeholders, reset, convenio y capital directo del desglose de abonos.
- El frontend solo muestra/descuenta abonos parciales reales.

## Pruebas

- [x] Backend focal: 75/75
- [x] Frontend focal: 2/2
- [x] Build de producción de Cartera Front
- [x] `git diff --check`
- [x] Dos revisiones independientes sin P0/P1 pendientes

## Notas

- No incluye migraciones ni cambios de datos.
- La reparación puntual del registro afectado se manejó por separado.
- El typecheck/suite global conserva fallos preexistentes ajenos a este cambio en ExcelJS, `latefee`, reportes y dependencias de email; los archivos modificados no introducen errores TypeScript nuevos.
