### PR TITLE
fix(abonos-capital): revertir el abono cuando se revierte el pago

### DIFF
--- a/apps/cartera-back/drizzle/0019_abonos_capital_pago_id.sql
+++ b/apps/cartera-back/drizzle/0019_abonos_capital_pago_id.sql
@@ -1,0 +1,36 @@
+-- Enlaza cada abono a capital con el pago que lo generó.
+--
+-- Contexto: hasta ahora `abonos_capital` era un ACUMULADO — una fila por par
+-- (credito_id, inversionista_id) sobre la que cada pago sumaba su monto. Por eso
+-- al revertir un pago no se podía saber qué parte de la fila era suya, y el
+-- monto quedaba sumado para siempre (abono huérfano).
+--
+-- Ahora cada pago inserta su propia fila con su `pago_id`, y revertir el pago
+-- borra exactamente esas filas.
+--
+-- NULLABLE a propósito:
+--   * las filas que ya existen (no se puede reconstruir qué pagos las formaron:
+--     esa información nunca se guardó),
+--   * las CANCELACION de devolución/reset, que no nacen de un pago,
+--   * el alta manual por POST /api/abonos-capital.
+--
+-- ON DELETE CASCADE: reversePayment borra los pagos parciales; sin el cascade su
+-- abono quedaría huérfano apuntando a un pago inexistente.
+
+ALTER TABLE "cartera"."abonos_capital"
+  ADD COLUMN IF NOT EXISTS "pago_id" integer;
+
+DO $$ BEGIN
+  ALTER TABLE "cartera"."abonos_capital"
+    ADD CONSTRAINT "abonos_capital_pago_id_pagos_credito_pago_id_fk"
+    FOREIGN KEY ("pago_id") REFERENCES "cartera"."pagos_credito"("pago_id")
+    ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_pago_id"
+  ON "cartera"."abonos_capital" ("pago_id");
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_cred_inv"
+  ON "cartera"."abonos_capital" ("credito_id", "inversionista_id");

--- a/apps/cartera-back/drizzle/0020_abonos_capital_liquidacion_id.sql
+++ b/apps/cartera-back/drizzle/0020_abonos_capital_liquidacion_id.sql
@@ -1,0 +1,45 @@
+-- Anota en cada abono a capital en qué liquidación se cerró.
+--
+-- Contexto: el reporte /reportes/reinversion-liquidaciones llegaba al abono por
+-- `pagos_credito_inversionistas_espejo.abono_capital_id`. Esa columna es una sola
+-- casilla: apunta a UN abono. Mientras hubo una fila por par (crédito,
+-- inversionista) daba igual — ese uno era todo. Con una fila por pago (ver
+-- 0019), ir por el link solo agarra la primera y el reporte subcuenta.
+--
+-- Con `liquidacion_id` seteado al cerrar el abono, el reporte suma directo y no
+-- necesita el link ni el DISTINCT.
+--
+-- El backfill hace UNA vez el mismo rodeo que el reporte hacía en cada consulta,
+-- y es exacto para lo viejo: en el modelo anterior había una sola fila abierta
+-- por par y era justo la linkeada.
+
+ALTER TABLE "cartera"."abonos_capital"
+  ADD COLUMN IF NOT EXISTS "liquidacion_id" integer;
+
+DO $$ BEGIN
+  ALTER TABLE "cartera"."abonos_capital"
+    ADD CONSTRAINT "abonos_capital_liquidacion_id_liquidaciones_liquidacion_id_fk"
+    FOREIGN KEY ("liquidacion_id") REFERENCES "cartera"."liquidaciones"("liquidacion_id")
+    ON DELETE SET NULL ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_liquidacion_id"
+  ON "cartera"."abonos_capital" ("liquidacion_id");
+
+-- Backfill del histórico: se recorre el link una sola vez y se guarda.
+-- MIN() por determinismo: si un abono estuviera linkeado desde espejos de más de
+-- una liquidación, se le atribuye la primera (la que efectivamente lo pagó).
+UPDATE "cartera"."abonos_capital" a
+   SET "liquidacion_id" = sub.liquidacion_id
+  FROM (
+    SELECT e."abono_capital_id" AS abono_id,
+           MIN(e."liquidacion_id") AS liquidacion_id
+      FROM "cartera"."pagos_credito_inversionistas_espejo" e
+     WHERE e."abono_capital_id" IS NOT NULL
+       AND e."liquidacion_id" IS NOT NULL
+     GROUP BY e."abono_capital_id"
+  ) sub
+ WHERE a."abono_id" = sub.abono_id
+   AND a."liquidacion_id" IS NULL;

--- a/apps/cartera-back/drizzle/0021_abonos_capital_pago_espejo_id.sql
+++ b/apps/cartera-back/drizzle/0021_abonos_capital_pago_espejo_id.sql
@@ -1,0 +1,43 @@
+-- Marca qué fila de espejo consumió cada abono a capital.
+--
+-- Por qué: el espejo CONGELA el monto a pagar cuando se genera, y no se regenera
+-- mientras haya uno sin liquidar. La liquidación paga esa foto
+-- (`espejo.abono_capital`). Un abono que nace DESPUÉS de la foto NO está en ese
+-- monto: no se pagó. Cerrarlo igual lo daría por cobrado y el inversionista
+-- nunca vería esa plata.
+--
+-- Con `pago_espejo_id` la liquidación cierra exactamente los abonos que la foto
+-- incluyó. Los que nacieron después quedan sin marca → abiertos → los toma el
+-- siguiente calcular pagos, que es como debe funcionar.
+--
+-- Se setea en insertPagosCreditoInversionistas (payments.ts) al generar el espejo.
+
+ALTER TABLE "cartera"."abonos_capital"
+  ADD COLUMN IF NOT EXISTS "pago_espejo_id" integer;
+
+DO $$ BEGIN
+  ALTER TABLE "cartera"."abonos_capital"
+    ADD CONSTRAINT "abonos_capital_pago_espejo_id_pagos_credito_inversionistas_espejo_id_fk"
+    FOREIGN KEY ("pago_espejo_id") REFERENCES "cartera"."pagos_credito_inversionistas_espejo"("id")
+    ON DELETE SET NULL ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_pago_espejo_id"
+  ON "cartera"."abonos_capital" ("pago_espejo_id");
+
+-- Backfill. CRÍTICO para los abonos ABIERTOS que ya están dentro de un espejo
+-- NO_LIQUIDADO: si quedaran sin marca, la liquidación (que ahora cierra solo los
+-- marcados) no los cerraría nunca y el siguiente ciclo se los volvería a pagar al
+-- inversionista.
+--
+-- Se usa el link `espejo.abono_capital_id`, que para los datos previos es
+-- completo: en el modelo viejo había UNA sola fila abierta por par
+-- (crédito, inversionista) y era justo la linkeada. Los abonos sin link son los
+-- que ningún espejo consumió todavía: quedan en NULL, que es lo correcto.
+UPDATE "cartera"."abonos_capital" a
+   SET "pago_espejo_id" = e."id"
+  FROM "cartera"."pagos_credito_inversionistas_espejo" e
+ WHERE e."abono_capital_id" = a."abono_id"
+   AND a."pago_espejo_id" IS NULL;

--- a/apps/cartera-back/src/controllers/abonosCapital.test.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.test.ts
@@ -14,7 +14,9 @@ mock.module("../utils/comprasAjuste", () => ({
     Promise.resolve(new Big(pendientesPorInv[invId] ?? 0)),
 }));
 
-const { registrarCancelacionEspejo } = await import("./abonosCapital");
+const { registrarCancelacionEspejo, revertirAbonoCapitalEspejo } = await import(
+  "./abonosCapital"
+);
 
 // Mock del handle de transacción (tx) de drizzle. Simula:
 //   tx.select().from().innerJoin().where()  -> filas del espejo
@@ -133,5 +135,82 @@ describe("registrarCancelacionEspejo", () => {
     await registrarCancelacionEspejo(tx, 1);
 
     expect(inserted[0].monto).toBe("1000.5");
+  });
+});
+
+// Mock del executor para revertirAbonoCapitalEspejo. Simula:
+//   ex.select().from().where()   -> las filas de abonos_capital de ese pago
+//   ex.delete().where()          -> borrado (contado en state.deleteCalls)
+function makeExecutor(filas: any[]) {
+  const state = { deleteCalls: 0 };
+  const ex: any = {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(filas) }) }),
+    delete: () => ({
+      where: () => {
+        state.deleteCalls++;
+        return Promise.resolve([]);
+      },
+    }),
+  };
+  return { ex, state };
+}
+
+describe("revertirAbonoCapitalEspejo", () => {
+  it("borra las filas que generó ese pago", async () => {
+    const { ex, state } = makeExecutor([
+      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
+      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: false },
+    ]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(res.success).toBe(true);
+    expect(state.deleteCalls).toBe(1);
+    expect(res.data!.borrados).toHaveLength(2);
+    expect(res.data!.borrados[0]).toMatchObject({ abono_id: 1, inversionista_id: 10, monto: "600" });
+    expect(res.data!.omitidos).toHaveLength(0);
+  });
+
+  it("no hace nada si el pago no generó ningún abono", async () => {
+    // Caso normal: una cuota corriente nunca creó filas en abonos_capital.
+    const { ex, state } = makeExecutor([]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(res.success).toBe(true);
+    expect(state.deleteCalls).toBe(0);
+    expect(res.data!.borrados).toHaveLength(0);
+  });
+
+  it("no borra las filas ya liquidadas: las reporta como omitidas", async () => {
+    // La plata ya le salió al inversionista: borrarla la haría desaparecer.
+    const { ex, state } = makeExecutor([
+      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: true },
+    ]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(state.deleteCalls).toBe(0);
+    expect(res.data!.borrados).toHaveLength(0);
+    expect(res.data!.omitidos).toHaveLength(1);
+    expect(res.data!.omitidos[0]).toMatchObject({
+      abono_id: 1,
+      motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
+    });
+  });
+
+  it("borra las abiertas y conserva las liquidadas cuando vienen mezcladas", async () => {
+    const { ex, state } = makeExecutor([
+      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
+      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: true },
+    ]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(state.deleteCalls).toBe(1);
+    expect(res.data!.borrados).toHaveLength(1);
+    expect(res.data!.borrados[0].abono_id).toBe(1);
+    expect(res.data!.omitidos).toHaveLength(1);
+    expect(res.data!.omitidos[0].abono_id).toBe(2);
   });
 });

--- a/apps/cartera-back/src/controllers/abonosCapital.test.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.test.ts
@@ -141,13 +141,15 @@ describe("registrarCancelacionEspejo", () => {
 // Mock del executor para revertirAbonoCapitalEspejo. Simula:
 //   ex.select().from().where()   -> las filas de abonos_capital de ese pago
 //   ex.delete().where()          -> borrado (contado en state.deleteCalls)
-function makeExecutor(filas: any[]) {
+// `failDelete` simula que el borrado revienta (error de DB/FK/conexión).
+function makeExecutor(filas: any[], failDelete = false) {
   const state = { deleteCalls: 0 };
   const ex: any = {
     select: () => ({ from: () => ({ where: () => Promise.resolve(filas) }) }),
     delete: () => ({
       where: () => {
         state.deleteCalls++;
+        if (failDelete) return Promise.reject(new Error("connection reset"));
         return Promise.resolve([]);
       },
     }),
@@ -155,11 +157,21 @@ function makeExecutor(filas: any[]) {
   return { ex, state };
 }
 
+const abonoAbierto = (over: any = {}) => ({
+  abono_id: 1,
+  inversionista_id: 10,
+  monto: "600",
+  tipo: "CAPITAL",
+  liquidado: false,
+  pago_espejo_id: null,
+  ...over,
+});
+
 describe("revertirAbonoCapitalEspejo", () => {
   it("borra las filas que generó ese pago", async () => {
     const { ex, state } = makeExecutor([
-      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
-      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: false },
+      abonoAbierto({ abono_id: 1, inversionista_id: 10, monto: "600" }),
+      abonoAbierto({ abono_id: 2, inversionista_id: 20, monto: "400" }),
     ]);
 
     const res = await revertirAbonoCapitalEspejo(555, ex);
@@ -167,8 +179,11 @@ describe("revertirAbonoCapitalEspejo", () => {
     expect(res.success).toBe(true);
     expect(state.deleteCalls).toBe(1);
     expect(res.data!.borrados).toHaveLength(2);
-    expect(res.data!.borrados[0]).toMatchObject({ abono_id: 1, inversionista_id: 10, monto: "600" });
-    expect(res.data!.omitidos).toHaveLength(0);
+    expect(res.data!.borrados[0]).toMatchObject({
+      abono_id: 1,
+      inversionista_id: 10,
+      monto: "600",
+    });
   });
 
   it("no hace nada si el pago no generó ningún abono", async () => {
@@ -182,35 +197,34 @@ describe("revertirAbonoCapitalEspejo", () => {
     expect(res.data!.borrados).toHaveLength(0);
   });
 
-  it("no borra las filas ya liquidadas: las reporta como omitidas", async () => {
-    // La plata ya le salió al inversionista: borrarla la haría desaparecer.
-    const { ex, state } = makeExecutor([
-      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: true },
-    ]);
+  it("TIRA ERROR y no borra nada si el abono ya fue liquidado", async () => {
+    // La plata ya le salió al inversionista: el pago no se puede revertir.
+    const { ex, state } = makeExecutor([abonoAbierto({ liquidado: true })]);
 
-    const res = await revertirAbonoCapitalEspejo(555, ex);
-
+    await expect(revertirAbonoCapitalEspejo(555, ex)).rejects.toThrow(
+      /\[ABONO_YA_LIQUIDADO\]/
+    );
     expect(state.deleteCalls).toBe(0);
-    expect(res.data!.borrados).toHaveLength(0);
-    expect(res.data!.omitidos).toHaveLength(1);
-    expect(res.data!.omitidos[0]).toMatchObject({
-      abono_id: 1,
-      motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
-    });
   });
 
-  it("borra las abiertas y conserva las liquidadas cuando vienen mezcladas", async () => {
-    const { ex, state } = makeExecutor([
-      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
-      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: true },
-    ]);
+  it("TIRA ERROR y no borra nada si el abono ya entró en un cálculo de pagos", async () => {
+    // El espejo ya congeló ese monto y se lo va a pagar igual: borrar el abono
+    // dejaría al inversionista cobrando un capital que se revirtió.
+    const { ex, state } = makeExecutor([abonoAbierto({ pago_espejo_id: 77 })]);
 
-    const res = await revertirAbonoCapitalEspejo(555, ex);
+    await expect(revertirAbonoCapitalEspejo(555, ex)).rejects.toThrow(
+      /\[ABONO_EN_CALCULO_PENDIENTE\]/
+    );
+    expect(state.deleteCalls).toBe(0);
+  });
 
-    expect(state.deleteCalls).toBe(1);
-    expect(res.data!.borrados).toHaveLength(1);
-    expect(res.data!.borrados[0].abono_id).toBe(1);
-    expect(res.data!.omitidos).toHaveLength(1);
-    expect(res.data!.omitidos[0].abono_id).toBe(2);
+  it("propaga el error si el borrado falla, para que la transacción se caiga", async () => {
+    // Si se tragara el error, el pago se revertiría igual y el abono quedaría
+    // huérfano: justo el bug que esta función viene a evitar.
+    const { ex } = makeExecutor([abonoAbierto()], true);
+
+    await expect(revertirAbonoCapitalEspejo(555, ex)).rejects.toThrow(
+      /connection reset/
+    );
   });
 });

--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -40,14 +40,21 @@ export async function createAbonoCapital(data: {
 }
 
 /**
- * Distribuye un abono a capital entre los inversionistas del espejo.
- * Si ya existe un registro con credito_id + inversionista_id y liquidado = false, suma el monto.
- * Si no existe, inserta uno nuevo.
+ * Distribuye un abono a capital entre los inversionistas del espejo:
+ * INSERTA una fila por inversionista, marcada con el `pago_id` que la originó.
+ *
+ * NO acumula sobre una fila abierta previa (como hacía antes): cada pago tiene
+ * sus propias filas. Eso es lo que hace que revertir un pago sea simplemente
+ * borrar sus filas, sin tocar lo que aportaron los demás pagos.
+ *
+ * `pago_id` es opcional porque resetCredit distribuye una CANCELACION que no
+ * nace de un pago.
  */
 export async function distribuirAbonoCapitalEspejo(
   credito_id: number,
   monto_abono_capital: number | string,
-  tipo: "CANCELACION" | "CAPITAL" = "CAPITAL"
+  tipo: "CANCELACION" | "CAPITAL" = "CAPITAL",
+  pago_id?: number
 ) {
   try {
     const abonoBig = new Big(monto_abono_capital);
@@ -95,58 +102,28 @@ export async function distribuirAbonoCapitalEspejo(
       // Monto que le toca del abono
       const montoAbono = abonoBig.times(porcentajeGeneral).round(6);
 
-      // Buscar si ya existe uno no liquidado
-      const [existente] = await db
-        .select()
-        .from(abonos_capital)
-        .where(
-          and(
-            eq(abonos_capital.credito_id, credito_id),
-            eq(abonos_capital.inversionista_id, inv.inversionista_id),
-            eq(abonos_capital.liquidado, false)
-          )
-        )
-        .limit(1);
-
-      if (existente) {
-        // Sumar al existente
-        const nuevoMonto = new Big(existente.monto).plus(montoAbono).toString();
-        const [actualizado] = await db
-          .update(abonos_capital)
-          .set({ monto: nuevoMonto, updated_at: new Date() })
-          .where(eq(abonos_capital.abono_id, existente.abono_id))
-          .returning();
-
-        resultados.push({
-          inversionista: inv.nombre,
+      // Una fila propia por (pago, inversionista): nunca se suma sobre una
+      // fila previa, así revertir el pago no le toca lo suyo a otros pagos.
+      const [nuevo] = await db
+        .insert(abonos_capital)
+        .values({
+          credito_id,
           inversionista_id: inv.inversionista_id,
-          accion: "SUMADO",
-          monto_agregado: montoAbono.toString(),
-          monto_total: nuevoMonto,
-          porcentaje: porcentajeGeneral.toFixed(4),
-        });
-      } else {
-        // Insertar nuevo
-        const [nuevo] = await db
-          .insert(abonos_capital)
-          .values({
-            credito_id,
-            inversionista_id: inv.inversionista_id,
-            monto: montoAbono.toString(),
-            tipo,
-            liquidado: false,
-          })
-          .returning();
+          pago_id: pago_id ?? null,
+          monto: montoAbono.toString(),
+          tipo,
+          liquidado: false,
+        })
+        .returning();
 
-        resultados.push({
-          inversionista: inv.nombre,
-          inversionista_id: inv.inversionista_id,
-          accion: "INSERTADO",
-          monto_agregado: montoAbono.toString(),
-          monto_total: montoAbono.toString(),
-          porcentaje: porcentajeGeneral.toFixed(4),
-        });
-      }
+      resultados.push({
+        inversionista: inv.nombre,
+        inversionista_id: inv.inversionista_id,
+        abono_id: nuevo.abono_id,
+        pago_id: pago_id ?? null,
+        monto_agregado: montoAbono.toString(),
+        porcentaje: porcentajeGeneral.toFixed(4),
+      });
     }
 
     return {
@@ -164,6 +141,82 @@ export async function distribuirAbonoCapitalEspejo(
     return {
       success: false,
       message: "Error al distribuir el abono a capital",
+      error: error.message,
+      data: null,
+    };
+  }
+}
+
+/**
+ * Revierte el abono a capital de un pago: borra las filas de `abonos_capital`
+ * que ese pago generó (una por inversionista, marcadas con su `pago_id`).
+ *
+ * Se puede borrar sin miedo porque cada fila es exclusiva de un pago: no
+ * acumula aportes de otros pagos, así que nadie más pierde plata.
+ *
+ * Las filas YA LIQUIDADAS no se borran (la plata ya le salió al inversionista):
+ * se devuelven en `omitidos` para tratarlas a mano. Es el caso que decidimos
+ * dejar fuera de este cambio.
+ *
+ * `executor` permite pasar el `tx` de una transacción para que la reversión sea
+ * atómica con el resto del reverso.
+ */
+export async function revertirAbonoCapitalEspejo(
+  pago_id: number,
+  executor: any = db
+) {
+  try {
+    // 1. Las filas que generó este pago
+    const filas = await executor
+      .select()
+      .from(abonos_capital)
+      .where(eq(abonos_capital.pago_id, pago_id));
+
+    if (filas.length === 0) {
+      return {
+        success: true,
+        message: "El pago no generó abonos a capital: nada que revertir",
+        data: { pago_id, borrados: [], omitidos: [] },
+      };
+    }
+
+    // 2. Las liquidadas NO se tocan: esa plata ya salió.
+    const liquidadas = filas.filter((f: any) => f.liquidado);
+    const borrables = filas.filter((f: any) => !f.liquidado);
+
+    if (borrables.length > 0) {
+      await executor.delete(abonos_capital).where(
+        and(
+          eq(abonos_capital.pago_id, pago_id),
+          eq(abonos_capital.liquidado, false)
+        )
+      );
+    }
+
+    return {
+      success: true,
+      message: "Abonos a capital del pago revertidos",
+      data: {
+        pago_id,
+        borrados: borrables.map((f: any) => ({
+          abono_id: f.abono_id,
+          inversionista_id: f.inversionista_id,
+          monto: f.monto,
+          tipo: f.tipo,
+        })),
+        omitidos: liquidadas.map((f: any) => ({
+          abono_id: f.abono_id,
+          inversionista_id: f.inversionista_id,
+          monto: f.monto,
+          motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
+        })),
+      },
+    };
+  } catch (error: any) {
+    console.error("Error al revertir abono a capital:", error);
+    return {
+      success: false,
+      message: "Error al revertir el abono a capital",
       error: error.message,
       data: null,
     };

--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -154,9 +154,21 @@ export async function distribuirAbonoCapitalEspejo(
  * Se puede borrar sin miedo porque cada fila es exclusiva de un pago: no
  * acumula aportes de otros pagos, así que nadie más pierde plata.
  *
- * Las filas YA LIQUIDADAS no se borran (la plata ya le salió al inversionista):
- * se devuelven en `omitidos` para tratarlas a mano. Es el caso que decidimos
- * dejar fuera de este cambio.
+ * TIRA ERROR (y voltea la transacción del reverso) en dos casos, porque en los
+ * dos el abono ya no se puede tocar:
+ *
+ *  - `liquidado`: la plata ya le salió al inversionista.
+ *  - `pago_espejo_id` seteado: una fila de espejo ya lo consumió. El espejo
+ *    CONGELA el monto a pagar al generarse y no se regenera mientras esté sin
+ *    liquidar, así que la liquidación le va a pagar ese capital igual. Borrar el
+ *    abono no la frena: el inversionista terminaría cobrando un capital que se
+ *    revirtió, mientras el cliente lo sigue debiendo.
+ *
+ * Los dos se resuelven a mano antes de revertir; el sistema no puede adivinar.
+ *
+ * Los errores NO se atrapan a propósito: si el borrado falla, el reverso entero
+ * tiene que caerse. Si se tragara el error, el pago se revertiría igual y el
+ * abono quedaría huérfano — justo lo que esta función viene a evitar.
  *
  * `executor` permite pasar el `tx` de una transacción para que la reversión sea
  * atómica con el resto del reverso.
@@ -165,62 +177,58 @@ export async function revertirAbonoCapitalEspejo(
   pago_id: number,
   executor: any = db
 ) {
-  try {
-    // 1. Las filas que generó este pago
-    const filas = await executor
-      .select()
-      .from(abonos_capital)
-      .where(eq(abonos_capital.pago_id, pago_id));
+  // 1. Las filas que generó este pago
+  const filas = await executor
+    .select()
+    .from(abonos_capital)
+    .where(eq(abonos_capital.pago_id, pago_id));
 
-    if (filas.length === 0) {
-      return {
-        success: true,
-        message: "El pago no generó abonos a capital: nada que revertir",
-        data: { pago_id, borrados: [], omitidos: [] },
-      };
-    }
-
-    // 2. Las liquidadas NO se tocan: esa plata ya salió.
-    const liquidadas = filas.filter((f: any) => f.liquidado);
-    const borrables = filas.filter((f: any) => !f.liquidado);
-
-    if (borrables.length > 0) {
-      await executor.delete(abonos_capital).where(
-        and(
-          eq(abonos_capital.pago_id, pago_id),
-          eq(abonos_capital.liquidado, false)
-        )
-      );
-    }
-
+  if (filas.length === 0) {
     return {
       success: true,
-      message: "Abonos a capital del pago revertidos",
-      data: {
-        pago_id,
-        borrados: borrables.map((f: any) => ({
-          abono_id: f.abono_id,
-          inversionista_id: f.inversionista_id,
-          monto: f.monto,
-          tipo: f.tipo,
-        })),
-        omitidos: liquidadas.map((f: any) => ({
-          abono_id: f.abono_id,
-          inversionista_id: f.inversionista_id,
-          monto: f.monto,
-          motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
-        })),
-      },
-    };
-  } catch (error: any) {
-    console.error("Error al revertir abono a capital:", error);
-    return {
-      success: false,
-      message: "Error al revertir el abono a capital",
-      error: error.message,
-      data: null,
+      message: "El pago no generó abonos a capital: nada que revertir",
+      data: { pago_id, borrados: [] },
     };
   }
+
+  // 2. Portero: la plata ya salió.
+  const liquidadas = filas.filter((f: any) => f.liquidado);
+  if (liquidadas.length > 0) {
+    throw new Error(
+      `[ABONO_YA_LIQUIDADO] El pago ${pago_id} tiene ${liquidadas.length} abono(s) a capital ya liquidado(s) ` +
+        `(abono_id: ${liquidadas.map((f: any) => f.abono_id).join(", ")}). ` +
+        `Esa plata ya se le pagó al inversionista: hay que revertir la liquidación antes de revertir el pago.`
+    );
+  }
+
+  // 3. Portero: ya entró en una foto que se va a pagar.
+  const enEspejo = filas.filter((f: any) => f.pago_espejo_id != null);
+  if (enEspejo.length > 0) {
+    throw new Error(
+      `[ABONO_EN_CALCULO_PENDIENTE] El pago ${pago_id} tiene ${enEspejo.length} abono(s) a capital que ya entraron ` +
+        `en un cálculo de pagos (espejo id: ${enEspejo.map((f: any) => f.pago_espejo_id).join(", ")}). ` +
+        `Ese monto ya quedó congelado para liquidar: hay que liquidar o descartar el espejo antes de revertir el pago.`
+    );
+  }
+
+  // 4. Ninguna foto los tomó y ninguno se pagó: se borran.
+  await executor
+    .delete(abonos_capital)
+    .where(eq(abonos_capital.pago_id, pago_id));
+
+  return {
+    success: true,
+    message: "Abonos a capital del pago revertidos",
+    data: {
+      pago_id,
+      borrados: filas.map((f: any) => ({
+        abono_id: f.abono_id,
+        inversionista_id: f.inversionista_id,
+        monto: f.monto,
+        tipo: f.tipo,
+      })),
+    },
+  };
 }
 
 /**

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -2484,6 +2484,30 @@ export async function revertirLiquidacion(liquidacion_id: number) {
     }
 
     // ──────────────────────────────────────────────
+    // PASO 4.5: Reabrir los abonos a capital que esta liquidación cerró
+    //   Los espejos vuelven a NO_LIQUIDADO, así que sus abonos tienen que volver
+    //   a estar abiertos: la próxima liquidación los paga de nuevo.
+    //
+    //   Sin esto quedan liquidado=true para siempre y:
+    //     - nunca se le vuelven a pagar al inversionista,
+    //     - el reporte no los ve (quedan con liquidacion_id=NULL),
+    //     - el portero de revertirAbonoCapitalEspejo los da por pagados y bloquea
+    //       el reverso del pago.
+    //
+    //   `pago_espejo_id` NO se limpia: la fila de espejo sigue existiendo y sigue
+    //   teniendo ese monto congelado, solo que ahora sin liquidar.
+    //
+    //   Va ANTES del PASO 8 (borrar la liquidación): después, el FK
+    //   ON DELETE SET NULL limpia el liquidacion_id y ya no hay cómo encontrarlos.
+    const abonosReabiertos = await tx
+      .update(abonos_capital)
+      .set({ liquidado: false, liquidacion_id: null, updated_at: new Date() })
+      .where(eq(abonos_capital.liquidacion_id, liquidacion_id))
+      .returning({ abono_id: abonos_capital.abono_id });
+
+    console.log(`  ✅ ${abonosReabiertos.length} abono(s) a capital reabiertos`);
+
+    // ──────────────────────────────────────────────
     // PASO 5: Revertir cuotas del crédito
     //   Marcamos liquidado_inversionistas = false y limpiamos fecha
     // ──────────────────────────────────────────────

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3990,7 +3990,11 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
         if (creditoIdsLiquidados.length > 0) {
           const abonosCerrados = await tx
             .update(abonos_capital)
-            .set({ liquidado: true, updated_at: new Date() })
+            .set({
+              liquidado: true,
+              liquidacion_id: liquidacion.liquidacion_id,
+              updated_at: new Date(),
+            })
             .where(
               and(
                 eq(abonos_capital.inversionista_id, inv_id),

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3974,20 +3974,21 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
         // de liquidación creado. También se cierran los abonos a capital asociados
         // y se marca cada cuota como pagada al inversionista para que no vuelva a
         // procesarse en futuras ejecuciones.
-        // Se cierran TODOS los abonos abiertos de los pares (crédito, inversionista)
-        // que entraron en esta liquidación, no solo el que apunta `abono_capital_id`.
-        // Motivo: calcularYRegistrarPagosEspejo suma al espejo TODAS las filas
-        // abiertas del par (payments.ts) pero solo linkea la primera. Ahora que
-        // cada pago inserta su propia fila, cerrar solo la linkeada dejaría a las
-        // hermanas abiertas y la próxima liquidación se las volvería a pagar.
-        const creditoIdsLiquidados = [
-          ...new Set(
-            pagosNoLiquidados
-              .map((p) => p.credito_id)
-              .filter((id): id is number => id != null)
-          ),
-        ];
-        if (creditoIdsLiquidados.length > 0) {
+        // Se cierran EXACTAMENTE los abonos que estas filas de espejo consumieron
+        // (`pago_espejo_id`), que son los que se pagaron: el monto liquidado sale
+        // de `p.abono_capital`, la foto que el espejo congeló al generarse.
+        //
+        // No se cierra por par (crédito, inversionista): un abono nacido DESPUÉS
+        // de esa foto no está en el monto pagado — el espejo no se regenera
+        // mientras haya uno sin liquidar (payments.ts) — así que cerrarlo lo
+        // dejaría cobrado sin haberse pagado y el inversionista nunca vería esa
+        // plata. Sin marca queda abierto y lo toma el siguiente calcular pagos.
+        //
+        // Tampoco se cierra solo el de `abono_capital_id`: ese link es una sola
+        // casilla y apunta a uno, pero el espejo sumó todos los abiertos del par.
+        // Cerrar solo ese dejaría a las hermanas abiertas y la próxima liquidación
+        // se las volvería a pagar.
+        if (pagosIds.length > 0) {
           const abonosCerrados = await tx
             .update(abonos_capital)
             .set({
@@ -3997,8 +3998,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
             })
             .where(
               and(
-                eq(abonos_capital.inversionista_id, inv_id),
-                inArray(abonos_capital.credito_id, creditoIdsLiquidados),
+                inArray(abonos_capital.pago_espejo_id, pagosIds),
                 eq(abonos_capital.liquidado, false)
               )
             )

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3974,19 +3974,32 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
         // de liquidación creado. También se cierran los abonos a capital asociados
         // y se marca cada cuota como pagada al inversionista para que no vuelva a
         // procesarse en futuras ejecuciones.
-        const abonoIdsALiquidar = [
+        // Se cierran TODOS los abonos abiertos de los pares (crédito, inversionista)
+        // que entraron en esta liquidación, no solo el que apunta `abono_capital_id`.
+        // Motivo: calcularYRegistrarPagosEspejo suma al espejo TODAS las filas
+        // abiertas del par (payments.ts) pero solo linkea la primera. Ahora que
+        // cada pago inserta su propia fila, cerrar solo la linkeada dejaría a las
+        // hermanas abiertas y la próxima liquidación se las volvería a pagar.
+        const creditoIdsLiquidados = [
           ...new Set(
             pagosNoLiquidados
-              .map((p) => p.abono_capital_id)
+              .map((p) => p.credito_id)
               .filter((id): id is number => id != null)
           ),
         ];
-        if (abonoIdsALiquidar.length > 0) {
-          await tx
+        if (creditoIdsLiquidados.length > 0) {
+          const abonosCerrados = await tx
             .update(abonos_capital)
             .set({ liquidado: true, updated_at: new Date() })
-            .where(inArray(abonos_capital.abono_id, abonoIdsALiquidar));
-          console.log(`  ✅ ${abonoIdsALiquidar.length} abono(s) a capital marcados como liquidados`);
+            .where(
+              and(
+                eq(abonos_capital.inversionista_id, inv_id),
+                inArray(abonos_capital.credito_id, creditoIdsLiquidados),
+                eq(abonos_capital.liquidado, false)
+              )
+            )
+            .returning({ abono_id: abonos_capital.abono_id });
+          console.log(`  ✅ ${abonosCerrados.length} abono(s) a capital marcados como liquidados`);
         }
 
         // Marcar cuotas como liquidado_inversionistas

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -895,6 +895,10 @@ export async function insertPagosCreditoInversionistas(
       );
 
     let abonoCapitalId: number | null = null;
+    // Abonos que esta fila de espejo consume (los que suma en su abono_capital).
+    // Se marcan con el id de la fila después del insert: son "los que entraron en
+    // la foto" y por lo tanto los únicos que la liquidación puede cerrar.
+    let abonoIdsConsumidos: number[] = [];
     if (abonosNoLiquidados.length > 0) {
       if (inv.status_inversionista === "pendiente_devolucion" || aplicarDevolucionCube) {
         // 🆕 Si está en pendiente_devolucion o el crédito usa devolucion_cube,
@@ -919,6 +923,8 @@ export async function insertPagosCreditoInversionistas(
           abono_capital = abono_capital.plus(montoAbono);
         }
         abonoCapitalId = abonosNoLiquidados[0].abono_id;
+        // Todos, no solo el linkeado: el abono_capital de arriba los sumó a todos.
+        abonoIdsConsumidos = abonosNoLiquidados.map((a) => a.abono_id);
 
         console.log(`   💰 Abono a capital encontrado (id: ${abonoCapitalId}): +${montoAbono.toFixed(6)} (tipo: ${abonosNoLiquidados[0].tipo})`);
         console.log(`      abono_capital con abono sumado: ${abono_capital.toString()}`);
@@ -961,6 +967,8 @@ export async function insertPagosCreditoInversionistas(
       estado_liquidacion: "NO_LIQUIDADO" as const,
       abono_capital_id: abonoCapitalId,
       fecha_pago: fechaDelPeriodo,
+      // No es columna del espejo: se separa antes del insert (ver abajo).
+      _abonoIdsConsumidos: abonoIdsConsumidos,
     };
 
     console.log(`   ✅ Resultado final para ${inv.nombre}:`, {
@@ -980,11 +988,42 @@ export async function insertPagosCreditoInversionistas(
   // 4. Insertar todos los registros (ESPEJO)
   const resolvedInserts = await Promise.all(inserts);
 
-  await db
-    .insert(pagos_credito_inversionistas_espejo)
-    .values(resolvedInserts);
+  // `_abonoIdsConsumidos` es interno, no es columna: se separa antes del insert.
+  const filas = resolvedInserts.map(
+    ({ _abonoIdsConsumidos, ...fila }) => fila
+  );
 
-  return resolvedInserts;
+  const filasInsertadas = await db
+    .insert(pagos_credito_inversionistas_espejo)
+    .values(filas)
+    .returning({
+      id: pagos_credito_inversionistas_espejo.id,
+      inversionista_id: pagos_credito_inversionistas_espejo.inversionista_id,
+    });
+
+  // 5. Marcar los abonos que cada fila consumió. Sin esta marca la liquidación
+  //    no sabe cuáles se pagaron de verdad: cerraría también los que nacieron
+  //    después de esta foto, y esa plata no se le pagaría nunca al inversionista.
+  //    Se matchea por inversionista_id (hay una fila por inversionista) y no por
+  //    índice, para no depender del orden que devuelve el INSERT.
+  for (const insertada of filasInsertadas) {
+    const origen = resolvedInserts.find(
+      (r) => r.inversionista_id === insertada.inversionista_id
+    );
+    const abonoIds = origen?._abonoIdsConsumidos ?? [];
+    if (abonoIds.length === 0) continue;
+
+    await db
+      .update(abonos_capital)
+      .set({ pago_espejo_id: insertada.id, updated_at: new Date() })
+      .where(inArray(abonos_capital.abono_id, abonoIds));
+
+    console.log(
+      `   🔖 ${abonoIds.length} abono(s) marcados como consumidos por el espejo ${insertada.id}`
+    );
+  }
+
+  return filas;
 }
 
 export async function insertPagosCreditoInversionistasV2(

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2790,9 +2790,10 @@ export async function aplicarAbonoCapitalInversionistas(
 ) {
   console.log("\n💵 ========== APLICANDO ABONO A CAPITAL ==========");
 
-  // Distribuir abono a capital en tabla espejo
+  // Distribuir abono a capital en tabla espejo. El pago_id deja cada fila
+  // amarrada a este pago, para poder revertirla si el pago se reversa.
   try {
-    await distribuirAbonoCapitalEspejo(credito_id, abono_capital);
+    await distribuirAbonoCapitalEspejo(credito_id, abono_capital, "CAPITAL", pago_id);
     console.log("✅ Abono distribuido en tabla abonos_capital (espejo)");
   } catch (err) {
     console.error("⚠️ Error al distribuir abono en espejo:", err);

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -853,20 +853,21 @@ export async function getReinversionLiquidaciones({
     (cubeRows.rows[0] as Record<string, unknown>)?.interes_cube ?? 0
   );
 
-  // Pagos extras recibidos (abonos a capital / cancelaciones) que fluyen desde
-  // las liquidaciones del mes: liquidación → pago espejo → abono.
-  // Cada abono se cuenta una sola vez (DISTINCT) aunque tenga varios pagos espejo.
+  // Pagos extras recibidos (abonos a capital / cancelaciones) de las
+  // liquidaciones del mes, leídos directo del abono.
+  //
+  // Antes se llegaba al abono por `espejo.abono_capital_id`, pero esa es una
+  // sola casilla: apunta a UN abono. Mientras hubo una fila por par
+  // (crédito, inversionista) daba igual — ese uno era todo. Ahora que cada pago
+  // inserta su propia fila, ir por el link se comía las hermanas y subcontaba.
+  // `abonos_capital.liquidacion_id` se setea al cerrar el abono, así que no hace
+  // falta el rodeo ni el DISTINCT.
   const extrasRows = await db.execute(sql`
     SELECT a.tipo, COALESCE(SUM(a.monto::numeric), 0) AS total
     FROM cartera.abonos_capital a
-    WHERE a.abono_id IN (
-      SELECT DISTINCT e.abono_capital_id
-      FROM cartera.pagos_credito_inversionistas_espejo e
-      JOIN cartera.liquidaciones l ON l.liquidacion_id = e.liquidacion_id
-      WHERE e.abono_capital_id IS NOT NULL
-        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
-        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
-    )
+    JOIN cartera.liquidaciones l ON l.liquidacion_id = a.liquidacion_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
     GROUP BY a.tipo
   `);
 

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -153,6 +153,24 @@ export const reversePayment = async ({ body, set }: any) => {
       console.log("✅ Usuario encontrado");
 
       // ======================================================================
+      // 4️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
+      // ======================================================================
+      // Borra las filas que ESTE pago generó (van marcadas con su pago_id); si no
+      // generó ninguna, no hace nada: el pago_id ya dice la verdad.
+      //
+      // Tira error si el abono ya se liquidó o si ya entró en un cálculo de
+      // pagos, y ahí el reverso no puede seguir.
+      //
+      // 🔴 VA ACÁ, LO MÁS TEMPRANO POSIBLE, Y NO MÁS ABAJO: de acá para adelante
+      // hay tres cosas que escriben FUERA de esta transacción (usan el `db`
+      // global, no el `tx`): updateMora (6️⃣), reverseConvenioPayment (6️⃣.5️⃣) y
+      // processAndReplaceCreditInvestorsReverse (8️⃣). Si el portero tirara
+      // después de ellas, el rollback NO las desharía: el pago quedaría sin
+      // revertir pero la mora, el convenio y el saldo del inversionista ya
+      // habrían cambiado. Se aborta antes de tocar nada.
+      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
+
+      // ======================================================================
       // 5️⃣ RECALCULAR VALORES DEL CRÉDITO (solo si cuota está pagada)
       // ======================================================================
       let nuevoCapital = new Big(creditData.creditos.capital ?? 0);
@@ -254,15 +272,6 @@ export const reversePayment = async ({ body, set }: any) => {
         pago_id,
       );
       console.log("✅ Inversiones reversadas correctamente");
-
-      // ======================================================================
-      // 8️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
-      // ======================================================================
-      // Borra las filas que ESTE pago generó (van marcadas con su pago_id). Si
-      // el pago no generó ninguna, no hace nada: el pago_id ya dice la verdad.
-      // Tira error (y voltea esta transacción) si el abono ya se liquidó o si ya
-      // entró en un cálculo de pagos: en esos casos el reverso no puede seguir.
-      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
 
       // ======================================================================
       // 9️⃣ DEVOLVER ABONOS A LOS "RESTANTES" DEL PAGO

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -259,16 +259,10 @@ export const reversePayment = async ({ body, set }: any) => {
       // 8️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
       // ======================================================================
       // Borra las filas que ESTE pago generó (van marcadas con su pago_id). Si
-      // el pago no generó ninguna, la función no hace nada: no hace falta
-      // filtrar por estado del pago, el pago_id ya dice la verdad.
+      // el pago no generó ninguna, no hace nada: el pago_id ya dice la verdad.
+      // Tira error (y voltea esta transacción) si el abono ya se liquidó o si ya
+      // entró en un cálculo de pagos: en esos casos el reverso no puede seguir.
       const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
-
-      if (reversionEspejo?.data?.omitidos?.length) {
-        console.warn(
-          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
-          reversionEspejo.data.omitidos,
-        );
-      }
 
       // ======================================================================
       // 9️⃣ DEVOLVER ABONOS A LOS "RESTANTES" DEL PAGO
@@ -793,7 +787,11 @@ try {
       error.message === "Payment is not marked as paid" ||
       error.message === "Credit not found or not active" ||
       error.message === "Incobrable structural row cannot be reversed" ||
-      error.message === "User not found"
+      error.message === "User not found" ||
+      // Porteros del abono a capital: no es una falla del sistema, es que este
+      // pago no se puede revertir hasta resolver el abono a mano.
+      error.message?.startsWith("[ABONO_YA_LIQUIDADO]") ||
+      error.message?.startsWith("[ABONO_EN_CALCULO_PENDIENTE]")
     ) {
       set.status = 400;
     } else {

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -15,6 +15,7 @@ import {
   facturas_electronicas,
 } from "../database/db";
 import { processAndReplaceCreditInvestorsReverse } from "./investor";
+import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { updateMora } from "./latefee";
 import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
@@ -253,6 +254,21 @@ export const reversePayment = async ({ body, set }: any) => {
         pago_id,
       );
       console.log("✅ Inversiones reversadas correctamente");
+
+      // ======================================================================
+      // 8️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
+      // ======================================================================
+      // Borra las filas que ESTE pago generó (van marcadas con su pago_id). Si
+      // el pago no generó ninguna, la función no hace nada: no hace falta
+      // filtrar por estado del pago, el pago_id ya dice la verdad.
+      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
+
+      if (reversionEspejo?.data?.omitidos?.length) {
+        console.warn(
+          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
+          reversionEspejo.data.omitidos,
+        );
+      }
 
       // ======================================================================
       // 9️⃣ DEVOLVER ABONOS A LOS "RESTANTES" DEL PAGO
@@ -693,6 +709,7 @@ export const reversePayment = async ({ body, set }: any) => {
         facturasAnuladas,
         facturasConError,
         totalFacturas: facturasDelPago.length,
+        reversionEspejo,
       };
     });
 try {
@@ -747,6 +764,8 @@ try {
           usuario_id: result.user.usuario_id,
           saldo_a_favor: result.nuevoSaldoAFavor.toString(),
         },
+        // Presente solo si el pago era un abono directo a capital.
+        abonoCapitalEspejo: result.reversionEspejo?.data ?? undefined,
         // 🆕 Info de facturas anuladas
         facturas:
           result.totalFacturas > 0

--- a/apps/cartera-back/src/controllers/revertPaymentToPending.ts
+++ b/apps/cartera-back/src/controllers/revertPaymentToPending.ts
@@ -10,6 +10,7 @@ import {
   facturas_electronicas,
 } from "../database/db";
 import { processAndReplaceCreditInvestorsReverse } from "./investor";
+import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { anularFacturaEnCofidi } from "./reversePayment";
 
 // ============================================================================
@@ -96,6 +97,20 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
 
       console.log("✅ Crédito encontrado y activo");
 
+      // 3️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
+      // Borra las filas que ESTE pago generó (marcadas con su pago_id); si no
+      // generó ninguna, no hace nada. Va ANTES del branch de `pagoValidado`
+      // porque ese solo mira `validated`, así que un abono a capital se iría
+      // por el early-return de abajo sin revertirse.
+      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
+
+      if (reversionEspejo?.data?.omitidos?.length) {
+        console.warn(
+          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
+          reversionEspejo.data.omitidos,
+        );
+      }
+
       if (!pagoValidado) {
         console.log("ℹ️ El pago ya está en estado PENDIENTE. Solo se reversarán las inversiones.");
         
@@ -106,6 +121,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
           credito_id,
           numero_credito_sifco: creditData.numero_credito_sifco,
           cuota: creditData.cuota,
+          abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
           message: "Inversiones reversadas exitosamente (el pago ya estaba pendiente)"
         };
       }
@@ -248,6 +264,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
         nuevoCapital: nuevoCapital.toString(),
         facturasAnuladas,
         facturasConError,
+        abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
         numero_credito_sifco: creditData.numero_credito_sifco,
         cuota: creditData.cuota
       };

--- a/apps/cartera-back/src/controllers/revertPaymentToPending.ts
+++ b/apps/cartera-back/src/controllers/revertPaymentToPending.ts
@@ -10,7 +10,6 @@ import {
   facturas_electronicas,
 } from "../database/db";
 import { processAndReplaceCreditInvestorsReverse } from "./investor";
-import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { anularFacturaEnCofidi } from "./reversePayment";
 
 // ============================================================================
@@ -97,19 +96,14 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
 
       console.log("✅ Crédito encontrado y activo");
 
-      // 3️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
-      // Borra las filas que ESTE pago generó (marcadas con su pago_id); si no
-      // generó ninguna, no hace nada. Va ANTES del branch de `pagoValidado`
-      // porque ese solo mira `validated`, así que un abono a capital se iría
-      // por el early-return de abajo sin revertirse.
-      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
-
-      if (reversionEspejo?.data?.omitidos?.length) {
-        console.warn(
-          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
-          reversionEspejo.data.omitidos,
-        );
-      }
+      // Ojo: acá NO se revierten los abonos a capital del espejo. `pagoValidado`
+      // solo reconoce `validated`, así que un `capital_validated` cae en el
+      // early-return de abajo sin devolver el capital ni cambiar de estado;
+      // borrarle los abonos antes lo dejaría a medias (abono borrado + pago
+      // todavía aplicado). Los pagos que esta ruta sí maneja (cuotas normales)
+      // nunca generan abonos, así que no hay nada que revertir.
+      // El reverso del abono vive en reversePayment.ts, que usa esPagoAplicado
+      // y sí reconoce los abonos directos a capital.
 
       if (!pagoValidado) {
         console.log("ℹ️ El pago ya está en estado PENDIENTE. Solo se reversarán las inversiones.");
@@ -121,7 +115,6 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
           credito_id,
           numero_credito_sifco: creditData.numero_credito_sifco,
           cuota: creditData.cuota,
-          abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
           message: "Inversiones reversadas exitosamente (el pago ya estaba pendiente)"
         };
       }
@@ -264,7 +257,6 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
         nuevoCapital: nuevoCapital.toString(),
         facturasAnuladas,
         facturasConError,
-        abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
         numero_credito_sifco: creditData.numero_credito_sifco,
         cuota: creditData.cuota
       };

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1708,6 +1708,19 @@
     monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
     tipo: tipoAbonoEnum("tipo").notNull(),
     liquidado: boolean("liquidado").notNull().default(false),
+    // Fila de espejo que YA consumió este abono (lo sumó en su `abono_capital`).
+    // Se setea al generar el espejo. Es la marca de "este abono entró en la foto":
+    // el espejo congela el monto a pagar y no se regenera mientras haya uno sin
+    // liquidar, así que un abono que nace DESPUÉS no está en esa foto, no se paga
+    // en esa liquidación y debe quedar abierto para el siguiente ciclo.
+    // La liquidación cierra solo los marcados con las filas que liquida.
+    //
+    // Sin `.references()` a propósito: `pagos_credito_inversionistas_espejo` ya
+    // apunta acá con `abono_capital_id`, y declarar la vuelta en Drizzle deja las
+    // dos tablas referenciándose entre sí — TypeScript no puede inferir el tipo y
+    // el schema entero se cae a `any`. El FK real (con ON DELETE SET NULL) se crea
+    // en la migración 0021; Drizzle no lo necesita para consultar.
+    pago_espejo_id: integer("pago_espejo_id"),
     // Liquidación en la que se cerró este abono. Se setea junto con
     // `liquidado`. Hace explícito lo que antes había que deducir dando la
     // vuelta por `pagos_credito_inversionistas_espejo.abono_capital_id`, que al

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1708,11 +1708,21 @@
     monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
     tipo: tipoAbonoEnum("tipo").notNull(),
     liquidado: boolean("liquidado").notNull().default(false),
+    // Liquidación en la que se cerró este abono. Se setea junto con
+    // `liquidado`. Hace explícito lo que antes había que deducir dando la
+    // vuelta por `pagos_credito_inversionistas_espejo.abono_capital_id`, que al
+    // ser una sola casilla solo apunta a un abono: con varias filas por par
+    // (una por pago) los reportes que iban por ahí subcontaban.
+    liquidacion_id: integer("liquidacion_id").references(
+      () => liquidaciones.liquidacion_id,
+      { onDelete: "set null" }
+    ),
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
   }, (t) => ({
     ixPago: index("ix_abonos_capital_pago_id").on(t.pago_id),
     ixCredInv: index("ix_abonos_capital_cred_inv").on(t.credito_id, t.inversionista_id),
+    ixLiquidacion: index("ix_abonos_capital_liquidacion_id").on(t.liquidacion_id),
   }));
 
   export const historico_liquidaciones_espejo = customSchema.table(

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1696,12 +1696,24 @@
     inversionista_id: integer("inversionista_id")
       .notNull()
       .references(() => inversionistas.inversionista_id),
+    // Pago que generó este abono. Una fila por (pago, inversionista): NO se
+    // acumula, así revertir el pago es borrar exactamente sus filas.
+    // Nullable a propósito: las filas previas a esta columna, las CANCELACION
+    // (devolución/reset, que no nacen de un pago) y el alta manual por API no
+    // tienen pago. CASCADE: si el pago se borra (reversePayment borra los
+    // parciales), su abono se va con él en vez de quedar huérfano.
+    pago_id: integer("pago_id").references(() => pagos_credito.pago_id, {
+      onDelete: "cascade",
+    }),
     monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
     tipo: tipoAbonoEnum("tipo").notNull(),
     liquidado: boolean("liquidado").notNull().default(false),
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
-  });
+  }, (t) => ({
+    ixPago: index("ix_abonos_capital_pago_id").on(t.pago_id),
+    ixCredInv: index("ix_abonos_capital_cred_inv").on(t.credito_id, t.inversionista_id),
+  }));
 
   export const historico_liquidaciones_espejo = customSchema.table(
     "historico_liquidaciones_espejo",


### PR DESCRIPTION
Reemplaza al #1109 (cerrado). Incluye los arreglos de los 3 hallazgos de Codex.

## El problema

Al revertir un pago, el sistema devolvía el capital al crédito y anulaba la factura, **pero no tocaba `abonos_capital`**: el monto seguía sumado en el espejo del inversionista como si el pago existiera. Abonos huérfanos.

Caso que lo destapó: el abono 90 (crédito 404, inversionista 30, Q810) sigue ahí aunque el pago que lo generó ya no existe.

## Por qué hubo que cambiar el modelo

`abonos_capital` era un **acumulado**: una fila por par (crédito, inversionista) sobre la que cada pago **sumaba**. Una fila = N pagos.

Por eso no se podía "borrar el abono de ese pago": no existía tal cosa. Borrar la fila le hubiera quitado al inversionista lo que aportaron los otros pagos, que siguen siendo válidos.

**Ahora cada pago inserta su propia fila con su `pago_id`.** Revertir = borrar sus filas. Seguro, porque la fila es exclusiva de ese pago.

## Los porteros

Un abono ya comprometido no se puede tocar, así que **no se deja revertir el pago**:

| Condición | Error | Status |
|---|---|---|
| `liquidado` — la plata ya le salió al inversionista | `[ABONO_YA_LIQUIDADO]` | 400 |
| `pago_espejo_id` — ya entró en un cálculo de pagos | `[ABONO_EN_CALCULO_PENDIENTE]` | 400 |

El segundo es clave: el espejo **congela** el monto al generarse y no se regenera mientras esté sin liquidar, así que le pagaría al inversionista un capital ya revertido. En vez de invalidar o recalcular el espejo (tocar el flujo de plata), **no se llega a esa situación**. Se resuelve a mano; el sistema no adivina.

Y los errores **se propagan**: si el borrado falla, se cae la transacción entera. Antes se los tragaba y el pago se revertía igual, dejando el huérfano.

## `pago_espejo_id`: qué es y por qué

La fila de espejo que consumió el abono, seteada al generar el espejo. Sirve para dos cosas:

1. El portero de arriba.
2. Que la liquidación cierre **exactamente** los abonos que pagó.

(2) arregla un bug que ya está en producción: un abono nacido **después** de la foto se cerraba sin haberse pagado y el inversionista **nunca lo veía**. Ahora queda abierto y lo toma el siguiente calcular pagos.

Va **sin `.references()`** en Drizzle a propósito: el espejo ya apunta acá con `abono_capital_id`, y declarar la vuelta deja las dos tablas referenciándose entre sí → TypeScript no infiere y el schema entero se cae a `any`. El FK real se crea en la migración.

## Reporte `/reportes/reinversion-liquidaciones`

Llegaba al abono por `espejo.abono_capital_id`, que es **una sola casilla**: apunta a UN abono. Con una fila por par daba igual — ese uno era todo. Con una fila por pago, **subcontaba en silencio**.

Se agrega `liquidacion_id` al abono (mismo UPDATE que ya seteaba `liquidado`) y el reporte suma directo. **Verificado contra prod**: los 4 meses con datos (abr–jul 2026) dan idéntico al decimal.

El reporte de la liquidación (`liquidateInvestor.ts`) **no se toca**: lee el monto ya sumado del espejo y nunca dependió del link.

## Migraciones (no se corrieron)

- `0019_abonos_capital_pago_id.sql`
- `0020_abonos_capital_liquidacion_id.sql` — + backfill del histórico
- `0021_abonos_capital_pago_espejo_id.sql` — + backfill vía el link viejo

## Verificación

- Typecheck limpio.
- 10/10 en `abonosCapital.test.ts` (5 nuevos: borra las filas del pago, no hace nada si no generó abonos, tira error si ya se liquidó, tira error si ya entró en un cálculo, propaga el error si el borrado falla).
- Suite: 145 pasan / 24 fallan — **las 24 ya fallaban en develop** (son de Excel, ajenas), verificado contra el árbol limpio.
- El bloque de liquidación **no tiene tests unitarios** (no existían para ese flujo). Conviene probar en dev una liquidación con un crédito con 2 pagos capital y confirmar que se cierran ambos.

## Qué NO hace

- **No corrige lo viejo**: es hacia adelante. Los abonos ya huérfanos siguen igual.
- Quedan dos agujeros **preexistentes** detectados de paso, para ticket aparte: `falsePayment` genera espejos sin el guard de `NO_LIQUIDADO` (y sin `await`), y ese guard es un SELECT-y-después-INSERT sin lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
