### PR TITLE
feat(cobros): cartera-back — carga de cuentas por asesor y bucket (CB-018)

### DIFF
--- a/apps/cartera-back/drizzle/cobros-02/0004_buckets_capacidad_base.sql
+++ b/apps/cartera-back/drizzle/cobros-02/0004_buckets_capacidad_base.sql
@@ -1,0 +1,17 @@
+-- ============================================================================
+-- COBROS-02 · Motor de Buckets — 0004_buckets_capacidad_base
+-- ============================================================================
+-- CB-018: dashboard de carga de cuentas por asesor y bucket. Agrega la
+-- capacidad "base" de cuentas activas al pool `cartera.asesor_bucket`
+-- (parametrizable por fila asesor+bucket, default 300 según el ticket).
+--
+-- Confirmado con el informador del ticket (CB-018): el techo de 300 es POR
+-- ASESOR dentro de un bucket ("la cantidad que puede atender un asesor"), NO
+-- un techo agregado del bucket completo. Por eso vive en `asesor_bucket`
+-- (1 fila por (asesor_id, bucket)) y no en el catálogo `buckets` — cada
+-- asesor puede tener su propio techo, incluso dentro del mismo bucket.
+--
+-- NOTA: Cartera aplica el SQL a mano (no drizzle-kit). Idempotente.
+-- ============================================================================
+
+ALTER TABLE cartera.asesor_bucket ADD COLUMN IF NOT EXISTS capacidad_base integer NOT NULL DEFAULT 300;

--- a/apps/cartera-back/drizzle/cobros-02/0005_asesor_bucket_margen_alerta.sql
+++ b/apps/cartera-back/drizzle/cobros-02/0005_asesor_bucket_margen_alerta.sql
@@ -1,0 +1,69 @@
+-- ============================================================================
+-- COBROS-02 · Motor de Buckets — 0005_asesor_bucket_margen_alerta
+-- ============================================================================
+-- CB-018: margen sobre capacidad_base antes de disparar la alerta de nueva
+-- posición. Confirmado con el informador del ticket: la alerta NO debe salir
+-- apenas se toca el límite (capacidad_base) sino con un margen encima (ej.
+-- límite=100, alerta a partir de 110 = 100 + 10%). El margen es parametrizable
+-- por fila (asesor+bucket) como PORCENTAJE o CANTIDAD FIJA, "para que lo
+-- parametricen como quieran más adelante" sin tocar código.
+--
+-- margen_alerta_tipo = 'porcentaje' (default) → margen = capacidad_base * (valor/100)
+-- margen_alerta_tipo = 'fijo'                 → margen = valor (cuentas)
+-- umbral de alerta = capacidad_base + margen resuelto
+--
+-- `sobrecarga` (cuentas > capacidad_base, sin margen) NO cambia con esto — es
+-- una señal distinta ("ya pasó su cupo nominal") de "alerta_nueva_posicion"
+-- ("ya amerita contratar").
+--
+-- CHECKs (review): margen_alerta_valor negativo invierte el orden de las
+-- señales (alerta dispararía ANTES que sobrecarga, contradice el invariante
+-- de arriba) — se bloquea a nivel BD. capacidad_base también se protege aquí
+-- (>0): con 0 permitido, utilizacion_pct muestra 0% pero sobrecarga/alerta
+-- igual disparan true (fila contradictoria en el dashboard). capacidad_base
+-- la agregó la migración 0004 (sin CHECK); se corrige acá porque ninguna de
+-- las dos migraciones se ha corrido aún.
+--
+-- NOTA: Cartera aplica el SQL a mano (no drizzle-kit). Idempotente.
+-- ============================================================================
+
+ALTER TABLE cartera.asesor_bucket ADD COLUMN IF NOT EXISTS margen_alerta_tipo varchar(16) NOT NULL DEFAULT 'porcentaje';
+--> statement-breakpoint
+
+ALTER TABLE cartera.asesor_bucket ADD COLUMN IF NOT EXISTS margen_alerta_valor numeric NOT NULL DEFAULT 10;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'asesor_bucket_margen_alerta_tipo_check'
+  ) THEN
+    ALTER TABLE cartera.asesor_bucket
+      ADD CONSTRAINT asesor_bucket_margen_alerta_tipo_check
+      CHECK (margen_alerta_tipo IN ('porcentaje', 'fijo'));
+  END IF;
+END $$;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'asesor_bucket_margen_alerta_valor_check'
+  ) THEN
+    ALTER TABLE cartera.asesor_bucket
+      ADD CONSTRAINT asesor_bucket_margen_alerta_valor_check
+      CHECK (margen_alerta_valor >= 0);
+  END IF;
+END $$;
+--> statement-breakpoint
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'asesor_bucket_capacidad_base_check'
+  ) THEN
+    ALTER TABLE cartera.asesor_bucket
+      ADD CONSTRAINT asesor_bucket_capacidad_base_check
+      CHECK (capacidad_base > 0);
+  END IF;
+END $$;

--- a/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.test.ts
@@ -100,15 +100,23 @@ describe("getCargaPorAsesorBucket", () => {
     expect(detalle.alerta_nueva_posicion).toBe(false);
   });
 
-  it("margen PORCENTAJE (default 10%): alerta arranca en 111, no en 101 (capacidad=100)", async () => {
+  it("margen PORCENTAJE (default 10%): alerta arranca EN 110 inclusive (capacidad=100), no antes", async () => {
     estado.pool = [poolRow({ asesor_id: 1, bucket: 0, capacidad_base: 100 })];
 
     estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 105 }];
     let r = await getCargaPorAsesorBucket();
     let d = r.porAsesor[0].porBucket[0];
     expect(d.sobrecarga).toBe(true); // ya pasó capacidad_base (100)
-    expect(d.alerta_nueva_posicion).toBe(false); // pero no pasó 110 (100+10%)
+    expect(d.alerta_nueva_posicion).toBe(false); // 105 aún no llega a 110
     expect(d.umbral_alerta_cuentas).toBe(110);
+
+    // Caso límite EXACTO (review Codex): 110 = umbral exacto, debe SÍ disparar
+    // (el ticket/migración 0005 documentan "alerta a partir de 110" —
+    // inclusive, no estrictamente mayor).
+    estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 110 }];
+    r = await getCargaPorAsesorBucket();
+    d = r.porAsesor[0].porBucket[0];
+    expect(d.alerta_nueva_posicion).toBe(true);
 
     estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 111 }];
     r = await getCargaPorAsesorBucket();
@@ -116,7 +124,7 @@ describe("getCargaPorAsesorBucket", () => {
     expect(d.alerta_nueva_posicion).toBe(true);
   });
 
-  it("margen FIJO: capacidad=100, margen fijo=15 → alerta arranca en 116, no en 110", async () => {
+  it("margen FIJO: capacidad=100, margen fijo=15 → alerta arranca EN 115 inclusive, no en 110", async () => {
     estado.pool = [
       poolRow({
         asesor_id: 1,
@@ -131,7 +139,13 @@ describe("getCargaPorAsesorBucket", () => {
     let r = await getCargaPorAsesorBucket();
     let d = r.porAsesor[0].porBucket[0];
     expect(d.umbral_alerta_cuentas).toBe(115);
-    expect(d.alerta_nueva_posicion).toBe(false); // 112 no pasa 115
+    expect(d.alerta_nueva_posicion).toBe(false); // 112 aún no llega a 115
+
+    // Caso límite EXACTO (review Codex): 115 = umbral exacto, debe SÍ disparar.
+    estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 115 }];
+    r = await getCargaPorAsesorBucket();
+    d = r.porAsesor[0].porBucket[0];
+    expect(d.alerta_nueva_posicion).toBe(true);
 
     estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 116 }];
     r = await getCargaPorAsesorBucket();

--- a/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+/**
+ * Tests del controller REAL getCargaPorAsesorBucket con la DB (frontera del
+ * sistema) fakeada — mismo espíritu que reasignarAsesor.test.ts: un fakeDb que
+ * despacha db.execute() por una firma reconocible en el SQL (bucket_actual,
+ * FROM buckets, FROM asesor_bucket) ya que las 3 queries del controller son
+ * crudas (sql`...`), no drizzle builder.
+ *
+ * NOTA: capacidad_base (ticket CB-018, confirmado con el informador: "la
+ * cantidad que puede atender un asesor") es un techo POR ASESOR dentro de un
+ * bucket — vive en `asesor_bucket` (1 fila por asesor+bucket), NO en el
+ * catálogo `buckets`. `sobrecarga` = cuentas > capacidad_base (sin margen).
+ * `alerta_nueva_posicion` = cuentas > capacidad_base + margen (margen % o
+ * fijo, también por fila, confirmado con el informador: "límite 100, alerta
+ * a los 110" = capacidad + 10%). El resumen de bucket es solo informativo:
+ * cuentas totales + conteos de asesores en alerta/sobrecarga.
+ */
+
+type Fila = Record<string, any>;
+
+const estado = {
+  cuentas: [] as Fila[],
+  catalogo: [] as Fila[],
+  pool: [] as Fila[],
+};
+
+function firmaDe(query: any): "cuentas" | "catalogo" | "pool" {
+  const texto = (query?.queryChunks ?? [])
+    .map((c: any) => (typeof c === "string" ? c : JSON.stringify(c)))
+    .join(" ");
+  if (texto.includes("bucket_actual")) return "cuentas";
+  if (texto.includes("asesor_bucket")) return "pool";
+  return "catalogo";
+}
+
+const fakeDb: any = {
+  execute: async (query: any) => {
+    const firma = firmaDe(query);
+    if (firma === "cuentas") return { rows: estado.cuentas };
+    if (firma === "pool") return { rows: estado.pool };
+    return { rows: estado.catalogo };
+  },
+};
+
+mock.module("../../database", () => ({ db: fakeDb }));
+
+const { getCargaPorAsesorBucket, resolverMargen } = await import("./cargaAsesorBucket");
+
+// Helper: fila de pool con margen porcentaje 10% (default) salvo que se
+// sobreescriba explícitamente.
+function poolRow(over: Partial<Fila> & { asesor_id: number; bucket: number; capacidad_base: number }) {
+  return {
+    margen_alerta_tipo: "porcentaje",
+    margen_alerta_valor: 10,
+    ...over,
+  };
+}
+
+function reset() {
+  estado.cuentas = [];
+  estado.catalogo = [
+    { numero: 0, prefijo: "B0", nombre: "Cartera Sana", color: "#22c55e" },
+    { numero: 1, prefijo: "B1", nombre: "Alerta Temprana", color: "#eab308" },
+  ];
+  estado.pool = [];
+}
+
+describe("resolverMargen (pura)", () => {
+  it("porcentaje: margen = capacidad * (valor/100)", () => {
+    expect(resolverMargen(100, "porcentaje", 10)).toBe(10);
+    expect(resolverMargen(300, "porcentaje", 10)).toBe(30);
+  });
+
+  it("fijo: margen = valor directo, independiente de la capacidad", () => {
+    expect(resolverMargen(100, "fijo", 15)).toBe(15);
+    expect(resolverMargen(300, "fijo", 15)).toBe(15);
+  });
+});
+
+describe("getCargaPorAsesorBucket", () => {
+  beforeEach(reset);
+
+  it("calcula % utilización y sobrecarga por asesor+bucket usando la capacidad_base de ESA fila del pool", async () => {
+    estado.cuentas = [
+      { asesor_id: 1, nombre: "Ana", email_asesor: "ana@x.com", bucket: 0, cuentas: 150 },
+    ];
+    estado.pool = [poolRow({ asesor_id: 1, bucket: 0, capacidad_base: 300 })];
+
+    const r = await getCargaPorAsesorBucket();
+
+    expect(r.porAsesor).toHaveLength(1);
+    const detalle = r.porAsesor[0].porBucket[0];
+    expect(detalle.bucket).toBe(0);
+    expect(detalle.cuentas).toBe(150);
+    expect(detalle.capacidad_base).toBe(300);
+    expect(detalle.utilizacion_pct).toBe(50);
+    expect(detalle.elegible).toBe(true);
+    expect(detalle.sobrecarga).toBe(false);
+    expect(detalle.alerta_nueva_posicion).toBe(false);
+  });
+
+  it("margen PORCENTAJE (default 10%): alerta arranca en 111, no en 101 (capacidad=100)", async () => {
+    estado.pool = [poolRow({ asesor_id: 1, bucket: 0, capacidad_base: 100 })];
+
+    estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 105 }];
+    let r = await getCargaPorAsesorBucket();
+    let d = r.porAsesor[0].porBucket[0];
+    expect(d.sobrecarga).toBe(true); // ya pasó capacidad_base (100)
+    expect(d.alerta_nueva_posicion).toBe(false); // pero no pasó 110 (100+10%)
+    expect(d.umbral_alerta_cuentas).toBe(110);
+
+    estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 111 }];
+    r = await getCargaPorAsesorBucket();
+    d = r.porAsesor[0].porBucket[0];
+    expect(d.alerta_nueva_posicion).toBe(true);
+  });
+
+  it("margen FIJO: capacidad=100, margen fijo=15 → alerta arranca en 116, no en 110", async () => {
+    estado.pool = [
+      poolRow({
+        asesor_id: 1,
+        bucket: 0,
+        capacidad_base: 100,
+        margen_alerta_tipo: "fijo",
+        margen_alerta_valor: 15,
+      }),
+    ];
+
+    estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 112 }];
+    let r = await getCargaPorAsesorBucket();
+    let d = r.porAsesor[0].porBucket[0];
+    expect(d.umbral_alerta_cuentas).toBe(115);
+    expect(d.alerta_nueva_posicion).toBe(false); // 112 no pasa 115
+
+    estado.cuentas = [{ asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 116 }];
+    r = await getCargaPorAsesorBucket();
+    d = r.porAsesor[0].porBucket[0];
+    expect(d.alerta_nueva_posicion).toBe(true);
+  });
+
+  it("2 asesores en el mismo bucket con DISTINTA capacidad_base: sobrecarga y alerta se evalúan independiente para cada uno", async () => {
+    estado.cuentas = [
+      { asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 331 },
+      { asesor_id: 2, nombre: "Bruno", email_asesor: null, bucket: 0, cuentas: 260 },
+    ];
+    estado.pool = [
+      poolRow({ asesor_id: 1, bucket: 0, capacidad_base: 300 }), // umbral alerta = 330 → 331 sí alerta
+      poolRow({ asesor_id: 2, bucket: 0, capacidad_base: 250 }), // 260 > 250 → sobrecarga; umbral alerta 275 → no alerta
+    ];
+
+    const r = await getCargaPorAsesorBucket();
+    const ana = r.porAsesor.find((a) => a.asesor_id === 1)!.porBucket[0];
+    const bruno = r.porAsesor.find((a) => a.asesor_id === 2)!.porBucket[0];
+
+    expect(ana.capacidad_base).toBe(300);
+    expect(ana.sobrecarga).toBe(true);
+    expect(ana.alerta_nueva_posicion).toBe(true);
+
+    expect(bruno.capacidad_base).toBe(250);
+    expect(bruno.sobrecarga).toBe(true);
+    expect(bruno.alerta_nueva_posicion).toBe(false);
+  });
+
+  it("asesor sobrecargado (pasó capacidad) pero SIN alerta (no pasó capacidad+margen) — bucket total cómodo", async () => {
+    estado.cuentas = [
+      { asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 105 },
+      { asesor_id: 2, nombre: "Bruno", email_asesor: null, bucket: 0, cuentas: 10 },
+    ];
+    estado.pool = [
+      poolRow({ asesor_id: 1, bucket: 0, capacidad_base: 100 }), // 105 > 100 sobrecarga, pero < 110 umbral alerta
+      poolRow({ asesor_id: 2, bucket: 0, capacidad_base: 300 }),
+    ];
+
+    const r = await getCargaPorAsesorBucket();
+    const ana = r.porAsesor.find((a) => a.asesor_id === 1)!.porBucket[0];
+    const bruno = r.porAsesor.find((a) => a.asesor_id === 2)!.porBucket[0];
+
+    expect(ana.sobrecarga).toBe(true);
+    expect(ana.alerta_nueva_posicion).toBe(false);
+    expect(bruno.sobrecarga).toBe(false);
+
+    const b0 = r.buckets.find((b) => b.numero === 0)!;
+    expect(b0.cuentas_totales).toBe(115);
+    expect(b0.asesores_sobrecargados).toBe(1);
+    expect(b0.asesores_en_alerta).toBe(0);
+  });
+
+  it("asesor con cuentas en un bucket donde NO está en el pool → elegible=false, capacidad y margen default", async () => {
+    estado.cuentas = [
+      { asesor_id: 2, nombre: "Bruno", email_asesor: null, bucket: 1, cuentas: 5 },
+    ];
+    estado.pool = []; // Bruno no está en ningún pool.
+
+    const r = await getCargaPorAsesorBucket();
+    const detalle = r.porAsesor[0].porBucket[0];
+    expect(detalle.elegible).toBe(false);
+    expect(detalle.capacidad_base).toBe(300);
+    expect(detalle.umbral_alerta_cuentas).toBe(330); // 300 + 10% default
+  });
+
+  it("bucket con 0 cuentas sigue apareciendo en el resumen (capacidad ociosa)", async () => {
+    estado.cuentas = [];
+    estado.pool = [poolRow({ asesor_id: 1, bucket: 0, capacidad_base: 300 })];
+
+    const r = await getCargaPorAsesorBucket();
+    const b0 = r.buckets.find((b) => b.numero === 0)!;
+    expect(b0.cuentas_totales).toBe(0);
+    expect(b0.asesores_en_pool).toBe(1);
+    expect(b0.asesores_en_alerta).toBe(0);
+    expect(b0.asesores_sobrecargados).toBe(0);
+  });
+
+  it("filtro por bucket limita el resumen de buckets", async () => {
+    estado.cuentas = [
+      { asesor_id: 1, nombre: "Ana", email_asesor: null, bucket: 0, cuentas: 10 },
+    ];
+    const r = await getCargaPorAsesorBucket({ bucket: 0 });
+    expect(r.buckets).toHaveLength(1);
+    expect(r.buckets[0].numero).toBe(0);
+  });
+});

--- a/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.ts
+++ b/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.ts
@@ -31,10 +31,12 @@ import { bucketActualSql, STATUS_BUCKET_FUERA } from "../../lib/buckets-classifi
 // auto-ajuste, que sea una decisión explícita nueva, no un efecto colateral.
 //
 // ⚠️ `sobrecarga` (cuentas > capacidad_base) y `alerta_nueva_posicion`
-// (cuentas > capacidad_base + margen) son señales DISTINTAS y ambas a nivel
-// asesor+bucket: sobrecarga = ya pasó su cupo nominal; alerta = ya amerita
-// abrir nueva posición (dispara más tarde, con el margen encima — confirmado
-// con el informador: "límite 100, alerta a los 110").
+// (cuentas >= capacidad_base + margen, INCLUSIVE — review Codex #1113: con
+// capacidad=100/margen=10%, el umbral es 110 y 110 exacto YA debe disparar,
+// no solo 111+) son señales DISTINTAS y ambas a nivel asesor+bucket:
+// sobrecarga = ya pasó su cupo nominal; alerta = ya amerita abrir nueva
+// posición (dispara más tarde, con el margen encima — confirmado con el
+// informador: "límite 100, alerta a los 110").
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type CargaBucketFila = {
@@ -300,7 +302,7 @@ export async function getCargaPorAsesorBucket(params: {
           const utilizacionPct =
             capacidad > 0 ? Math.round((cuentas / capacidad) * 1000) / 10 : 0;
           const sobrecarga = cuentas > capacidad;
-          const alerta = cuentas > umbralAlertaCuentas;
+          const alerta = cuentas >= umbralAlertaCuentas;
           if (alerta) alertaPorBucket.set(bucket, (alertaPorBucket.get(bucket) ?? 0) + 1);
           if (sobrecarga) sobrecargaPorBucket.set(bucket, (sobrecargaPorBucket.get(bucket) ?? 0) + 1);
           return {

--- a/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.ts
+++ b/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.ts
@@ -1,0 +1,339 @@
+import { sql } from "drizzle-orm";
+import { db } from "../../database";
+import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
+import { bucketActualSql, STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CB-018 · Buckets — Carga de cuentas por asesor y bucket (dashboard gerencial).
+// Cuenta, por asesor y por bucket ACTUAL (bucketActualSql, lib/buckets-
+// classification.ts: COALESCE(último buckets_historial → estado que fuerza
+// bucket → rango de cuotas) — misma fuente que reasignarAsesor.ts usa para no
+// divergir), cuántas cuentas del funnel operativo lleva HOY (creditos.asesor_id,
+// decisión de raíz schema.ts:539-567).
+// Se cruza contra el pool (asesor_bucket) para marcar elegibilidad y contra
+// asesor_bucket.capacidad_base (default 300, migración 0004) para % de
+// utilización. Mismo par de tablas que ya usa el motor (latefee.ts:1072-1102)
+// para calcular "carga" en memoria — aquí se expone como query consultable.
+//
+// ⚠️ El techo de 300 es POR ASESOR dentro de un bucket, NO agregado del bucket
+// completo (confirmado con el informador del ticket: "es la cantidad que
+// puede atender un asesor, no necesariamente el bucket tiene el límite").
+// Por eso capacidad_base vive en `asesor_bucket` (1 fila por asesor+bucket) y
+// sobrecarga/utilización/alerta se calculan por esa misma combinación, nunca
+// agregadas a nivel bucket completo.
+//
+// ⚠️ capacidad_base/margen_alerta_* son SOLO LECTURA aquí: son el techo y el
+// margen que gerencia configura a mano (mismo patrón que el resto del
+// catálogo — SQL manual, ver migraciones 0001/0003/0004/0005, "Cartera aplica
+// el SQL a mano"). Este módulo nunca debe escribirlas, y tampoco lo hacen
+// latefee.ts (job automático) ni reasignarAsesor.ts (reasignación manual) —
+// ambos solo LEEN asesor_bucket para el pool. Si algún día se agrega
+// auto-ajuste, que sea una decisión explícita nueva, no un efecto colateral.
+//
+// ⚠️ `sobrecarga` (cuentas > capacidad_base) y `alerta_nueva_posicion`
+// (cuentas > capacidad_base + margen) son señales DISTINTAS y ambas a nivel
+// asesor+bucket: sobrecarga = ya pasó su cupo nominal; alerta = ya amerita
+// abrir nueva posición (dispara más tarde, con el margen encima — confirmado
+// con el informador: "límite 100, alerta a los 110").
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type CargaBucketFila = {
+  asesor_id: number;
+  nombre: string;
+  email_asesor: string | null;
+  bucket: number;
+  cuentas: number;
+};
+
+type BucketCatalogoRow = {
+  numero: number;
+  prefijo: string;
+  nombre: string;
+  color: string | null;
+};
+
+type MargenAlertaTipo = "porcentaje" | "fijo";
+
+type PoolRow = {
+  asesor_id: number;
+  bucket: number;
+  capacidad_base: number;
+  margen_alerta_tipo: MargenAlertaTipo;
+  margen_alerta_valor: number;
+};
+
+// Deben reflejar los DEFAULT de asesor_bucket (migraciones 0004/0005). Solo se
+// usan como fallback para asesores con cuentas en un bucket donde NO tienen
+// fila en el pool (fuera de pool) — con NOT NULL DEFAULT no debería faltar en
+// el caso normal (asesor sí está en el pool).
+const CAPACIDAD_BASE_DEFAULT = 300;
+const MARGEN_ALERTA_TIPO_DEFAULT: MargenAlertaTipo = "porcentaje";
+const MARGEN_ALERTA_VALOR_DEFAULT = 10;
+
+/**
+ * Margen (en cuentas) sobre capacidad_base antes de disparar
+ * alerta_nueva_posicion. 'porcentaje' → valor% de capacidad_base;
+ * 'fijo' → valor directo en cuentas. Pura, testeable aislada.
+ */
+export function resolverMargen(
+  capacidad: number,
+  tipo: MargenAlertaTipo,
+  valor: number,
+): number {
+  return tipo === "fijo" ? valor : capacidad * (valor / 100);
+}
+
+export type CargaPorAsesorBucketDetalle = {
+  bucket: number;
+  cuentas: number;
+  capacidad_base: number;
+  utilizacion_pct: number;
+  elegible: boolean;
+  sobrecarga: boolean;
+  alerta_nueva_posicion: boolean;
+  // Umbral absoluto de cuentas (capacidad_base + margen resuelto) a partir del
+  // cual esta fila entra en alerta_nueva_posicion — el frontend lo consume
+  // directo, sin recalcular la fórmula del margen (que puede ser % o fijo).
+  umbral_alerta_cuentas: number;
+};
+
+export type CargaPorAsesor = {
+  asesor_id: number;
+  nombre: string;
+  email_asesor: string | null;
+  porBucket: CargaPorAsesorBucketDetalle[];
+};
+
+export type CargaPorBucketResumen = {
+  numero: number;
+  prefijo: string;
+  nombre: string;
+  color: string | null;
+  cuentas_totales: number;
+  asesores_en_pool: number;
+  asesores_en_alerta: number;
+  asesores_sobrecargados: number;
+};
+
+export type CargaPorAsesorBucketResultado = {
+  buckets: CargaPorBucketResumen[];
+  porAsesor: CargaPorAsesor[];
+  fecha: string;
+};
+
+function hoyGTStr(): string {
+  return new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+}
+
+/**
+ * Créditos activos del funnel operativo, agrupados por dueño actual
+ * (creditos.asesor_id) y bucket ACTUAL (motor: buckets_historial, con el mismo
+ * fallback que bucketActualDeCredito para créditos aún sin INICIAL).
+ */
+async function getCuentasPorAsesorYBucket(params: {
+  bucket?: number;
+  asesor_id?: number;
+}): Promise<CargaBucketFila[]> {
+  const fueraSql = sql.join(STATUS_BUCKET_FUERA.map((s) => sql`${s}`), sql`, `);
+  const bucketFilter =
+    params.bucket !== undefined ? sql`AND bucket_actual.bucket = ${params.bucket}` : sql``;
+  const asesorFilter =
+    params.asesor_id !== undefined ? sql`AND a.asesor_id = ${params.asesor_id}` : sql``;
+
+  const res = await db.execute<{
+    asesor_id: number;
+    nombre: string;
+    email_asesor: string | null;
+    bucket: number;
+    cuentas: string;
+  }>(sql`
+    WITH bucket_actual AS (
+      SELECT
+        c.credito_id,
+        ${bucketActualSql("c", "m")} AS bucket
+      FROM ${SQL_CARTERA_SCHEMA}.creditos c
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
+        ON m.credito_id = c.credito_id AND m.activa = true
+      WHERE c."statusCredit" NOT IN (${fueraSql})
+    )
+    SELECT
+      a.asesor_id, a.nombre, a.email_cash_in AS email_asesor,
+      bucket_actual.bucket AS bucket,
+      COUNT(*)::int AS cuentas
+    FROM bucket_actual
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = bucket_actual.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+    WHERE bucket_actual.bucket IS NOT NULL
+      ${bucketFilter}
+      ${asesorFilter}
+    GROUP BY a.asesor_id, a.nombre, a.email_cash_in, bucket_actual.bucket
+  `);
+
+  return res.rows.map((r) => ({
+    asesor_id: r.asesor_id,
+    nombre: r.nombre,
+    email_asesor: r.email_asesor,
+    bucket: Number(r.bucket),
+    cuentas: Number(r.cuentas),
+  }));
+}
+
+async function getCatalogoBuckets(): Promise<BucketCatalogoRow[]> {
+  const res = await db.execute<BucketCatalogoRow>(sql`
+    SELECT numero, prefijo, nombre, color
+    FROM ${SQL_CARTERA_SCHEMA}.buckets
+    WHERE activo = true
+    ORDER BY numero
+  `);
+  return res.rows;
+}
+
+/**
+ * Pool de asesor_bucket. Acepta los mismos filtros `bucket`/`asesor_id` que
+ * getCuentasPorAsesorYBucket para que `asesores_en_pool`/`elegible` en la
+ * respuesta queden consistentes con `cuentas_totales`/`asesores_en_alerta`/
+ * `asesores_sobrecargados` cuando se filtra — antes ignoraba `bucket` (traía
+ * TODOS los buckets aunque el caller pidiera uno solo): inofensivo hoy porque
+ * el resto del pipeline solo lee las claves (bucket,asesor) que aparecen en
+ * `cuentas` (que sí filtra), pero era una trampa para un futuro uso directo
+ * de esta función fuera de getCargaPorAsesorBucket.
+ */
+async function getPoolPorBucket(params: { bucket?: number; asesor_id?: number }): Promise<PoolRow[]> {
+  const bucketFilter =
+    params.bucket !== undefined ? sql`AND bucket = ${params.bucket}` : sql``;
+  const asesorFilter =
+    params.asesor_id !== undefined ? sql`AND asesor_id = ${params.asesor_id}` : sql``;
+  const res = await db.execute<{
+    asesor_id: number;
+    bucket: number;
+    capacidad_base: number;
+    margen_alerta_tipo: string;
+    margen_alerta_valor: string;
+  }>(sql`
+    SELECT asesor_id, bucket, capacidad_base, margen_alerta_tipo, margen_alerta_valor
+    FROM ${SQL_CARTERA_SCHEMA}.asesor_bucket
+    WHERE activo = true
+      ${bucketFilter}
+      ${asesorFilter}
+  `);
+  return res.rows.map((r) => ({
+    asesor_id: Number(r.asesor_id),
+    bucket: Number(r.bucket),
+    capacidad_base: Number(r.capacidad_base),
+    margen_alerta_tipo: r.margen_alerta_tipo === "fijo" ? "fijo" : "porcentaje",
+    margen_alerta_valor: Number(r.margen_alerta_valor),
+  }));
+}
+
+/**
+ * Carga de cuentas por asesor y bucket. Capacidad, % de utilización,
+ * sobrecarga y alerta de nueva posición son SIEMPRE por combinación
+ * asesor+bucket (ticket: techo de 300 es "la cantidad que puede atender un
+ * asesor", no un agregado del bucket). El resumen por bucket es informativo:
+ * cuentas totales + conteos de cuántos de sus asesores están en
+ * alerta/sobrecarga. Filtros opcionales por bucket / asesor_id.
+ */
+export async function getCargaPorAsesorBucket(params: {
+  bucket?: number;
+  asesor_id?: number;
+} = {}): Promise<CargaPorAsesorBucketResultado> {
+  const [cuentas, catalogo, pool] = await Promise.all([
+    getCuentasPorAsesorYBucket(params),
+    getCatalogoBuckets(),
+    getPoolPorBucket(params),
+  ]);
+
+  // capacidad_base + margen por (asesor_id, bucket) — de la fila del pool si
+  // el asesor está en él; defaults si no (fuera de pool, sin fila propia).
+  const poolDataPorAsesorBucket = new Map<
+    string,
+    { capacidad: number; margenTipo: MargenAlertaTipo; margenValor: number }
+  >();
+  const poolPorBucket = new Map<number, Set<number>>();
+  for (const p of pool) {
+    if (!poolPorBucket.has(p.bucket)) poolPorBucket.set(p.bucket, new Set());
+    poolPorBucket.get(p.bucket)!.add(p.asesor_id);
+    poolDataPorAsesorBucket.set(`${p.asesor_id}:${p.bucket}`, {
+      capacidad: p.capacidad_base,
+      margenTipo: p.margen_alerta_tipo,
+      margenValor: p.margen_alerta_valor,
+    });
+  }
+
+  // Acumular cuentas por asesor y por bucket (una fila por asesor con detalle
+  // de todos los buckets donde tiene al menos 1 cuenta).
+  const asesorMap = new Map<
+    number,
+    { asesor_id: number; nombre: string; email_asesor: string | null; porBucket: Map<number, number> }
+  >();
+  const cuentasPorBucket = new Map<number, number>();
+  for (const fila of cuentas) {
+    if (!asesorMap.has(fila.asesor_id)) {
+      asesorMap.set(fila.asesor_id, {
+        asesor_id: fila.asesor_id,
+        nombre: fila.nombre,
+        email_asesor: fila.email_asesor,
+        porBucket: new Map(),
+      });
+    }
+    asesorMap.get(fila.asesor_id)!.porBucket.set(fila.bucket, fila.cuentas);
+    cuentasPorBucket.set(fila.bucket, (cuentasPorBucket.get(fila.bucket) ?? 0) + fila.cuentas);
+  }
+
+  // Conteos por bucket de asesores en alerta/sobrecarga, derivados del mismo
+  // recorrido de abajo (se llenan mientras se construye porAsesor).
+  const alertaPorBucket = new Map<number, number>();
+  const sobrecargaPorBucket = new Map<number, number>();
+
+  const porAsesor: CargaPorAsesor[] = Array.from(asesorMap.values())
+    .map((a) => ({
+      asesor_id: a.asesor_id,
+      nombre: a.nombre,
+      email_asesor: a.email_asesor,
+      porBucket: Array.from(a.porBucket.entries())
+        .map(([bucket, cuentas]) => {
+          const poolData = poolDataPorAsesorBucket.get(`${a.asesor_id}:${bucket}`);
+          const capacidad = poolData?.capacidad ?? CAPACIDAD_BASE_DEFAULT;
+          const margenTipo = poolData?.margenTipo ?? MARGEN_ALERTA_TIPO_DEFAULT;
+          const margenValor = poolData?.margenValor ?? MARGEN_ALERTA_VALOR_DEFAULT;
+          const umbralAlertaCuentas = capacidad + resolverMargen(capacidad, margenTipo, margenValor);
+          const utilizacionPct =
+            capacidad > 0 ? Math.round((cuentas / capacidad) * 1000) / 10 : 0;
+          const sobrecarga = cuentas > capacidad;
+          const alerta = cuentas > umbralAlertaCuentas;
+          if (alerta) alertaPorBucket.set(bucket, (alertaPorBucket.get(bucket) ?? 0) + 1);
+          if (sobrecarga) sobrecargaPorBucket.set(bucket, (sobrecargaPorBucket.get(bucket) ?? 0) + 1);
+          return {
+            bucket,
+            cuentas,
+            capacidad_base: capacidad,
+            utilizacion_pct: utilizacionPct,
+            elegible: poolPorBucket.get(bucket)?.has(a.asesor_id) ?? false,
+            sobrecarga,
+            alerta_nueva_posicion: alerta,
+            umbral_alerta_cuentas: Math.round(umbralAlertaCuentas * 10) / 10,
+          };
+        })
+        .sort((x, y) => x.bucket - y.bucket),
+    }))
+    .sort((a, b) => a.nombre.localeCompare(b.nombre));
+
+  const bucketsResumen: CargaPorBucketResumen[] = catalogo
+    .filter((b) => params.bucket === undefined || b.numero === params.bucket)
+    .map((b) => ({
+      numero: b.numero,
+      prefijo: b.prefijo,
+      nombre: b.nombre,
+      color: b.color,
+      cuentas_totales: cuentasPorBucket.get(b.numero) ?? 0,
+      asesores_en_pool: poolPorBucket.get(b.numero)?.size ?? 0,
+      asesores_en_alerta: alertaPorBucket.get(b.numero) ?? 0,
+      asesores_sobrecargados: sobrecargaPorBucket.get(b.numero) ?? 0,
+    }));
+
+  return {
+    buckets: bucketsResumen,
+    porAsesor,
+    fecha: hoyGTStr(),
+  };
+}

--- a/apps/cartera-back/src/controllers/buckets/reasignarAsesor.ts
+++ b/apps/cartera-back/src/controllers/buckets/reasignarAsesor.ts
@@ -8,7 +8,7 @@ import {
   platform_users,
   SQL_CARTERA_SCHEMA,
 } from "../../database/db/schema";
-import { STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
+import { bucketActualSql, STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // COBROS-02 · Buckets — Reasignación MANUAL de asesor (supervisor/gerente).
@@ -46,21 +46,7 @@ async function bucketActualDeCredito(credito_id: number): Promise<number | null>
   const res = await db.execute<{ bucket: number | null; fuera: boolean }>(sql`
     SELECT
       (c."statusCredit" IN (${fueraSql})) AS fuera,
-      COALESCE(
-        (SELECT h.bucket_nuevo FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
-          WHERE h.credito_id = c.credito_id
-          ORDER BY h.fecha DESC, h.historial_id DESC
-          LIMIT 1),
-        (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
-          WHERE b.activo = true
-            AND c."statusCredit" = ANY (b.estados_incluidos)
-          ORDER BY b.numero LIMIT 1),
-        (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
-          WHERE b.activo = true
-            AND COALESCE(m.cuotas_atrasadas, 0) >= b.cuotas_min
-            AND (b.cuotas_max IS NULL OR COALESCE(m.cuotas_atrasadas, 0) <= b.cuotas_max)
-          ORDER BY b.numero LIMIT 1)
-      ) AS bucket
+      ${bucketActualSql("c", "m")} AS bucket
     FROM ${SQL_CARTERA_SCHEMA}.creditos c
     LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
       ON m.credito_id = c.credito_id AND m.activa = true

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -469,6 +469,26 @@
         .notNull()
         .references(() => buckets.numero), // 0-5 (FK al catálogo)
       activo: boolean("activo").notNull().default(true),
+      // CB-018: capacidad base de cuentas activas que ESTE asesor puede
+      // atender en ESTE bucket (default 300, parametrizable por fila —
+      // confirmado con el informador del ticket: el techo es por asesor, no
+      // agregado del bucket). Denominador de % utilización/sobrecarga.
+      // SOLO se edita a mano (SQL directo, mismo patrón que el catálogo
+      // `buckets`). Ni el job automático (latefee.ts) ni la reasignación
+      // manual (reasignarAsesor.ts) la escriben — es config de gerencia, no
+      // dato derivado de actividad.
+      capacidad_base: integer("capacidad_base").notNull().default(300),
+      // CB-018: margen sobre capacidad_base antes de disparar
+      // alerta_nueva_posicion (default 10%: alerta a partir de capacidad+10%,
+      // NO apenas se toca capacidad_base — eso lo marca `sobrecarga`, sin
+      // margen). Parametrizable por fila, mismo patrón/invariante que
+      // capacidad_base (SOLO editable a mano, ni job ni reasignación la
+      // escriben). 'porcentaje' → valor% de capacidad_base; 'fijo' → valor en
+      // cuentas absolutas.
+      margen_alerta_tipo: varchar("margen_alerta_tipo", { length: 16 })
+        .notNull()
+        .default("porcentaje"),
+      margen_alerta_valor: numeric("margen_alerta_valor").notNull().default("10"),
       created_at: timestamp("created_at").defaultNow(),
       updated_at: timestamp("updated_at").defaultNow(),
     },

--- a/apps/cartera-back/src/lib/buckets-classification.ts
+++ b/apps/cartera-back/src/lib/buckets-classification.ts
@@ -1,3 +1,6 @@
+import { sql } from "drizzle-orm";
+import { SQL_CARTERA_SCHEMA } from "../database/db/schema";
+
 // Fila del catálogo de buckets relevante para la derivación.
 export type BucketCatalogo = {
   numero: number;
@@ -60,3 +63,43 @@ export function bucketDeCredito(
   );
   return porRango ? porRango.numero : null;
 }
+
+/**
+ * Fragmento SQL compartido: bucket ACTUAL de un crédito ya presente en el
+ * FROM/JOIN de la query que lo usa — COALESCE(último buckets_historial →
+ * estado que fuerza bucket vía estados_incluidos → rango de cuotas de la mora
+ * activa).
+ *
+ * `credAlias`/`moraAlias` son PARÁMETROS explícitos (no un comentario que se
+ * puede ignorar): el caller debe declarar en el FROM/JOIN de su query una
+ * tabla `creditos` con ese alias y un LEFT JOIN `moras_credito` (ON
+ * moraAlias.credito_id = credAlias.credito_id AND moraAlias.activa = true)
+ * con el suyo. Si el alias no coincide, Postgres falla en tiempo de query con
+ * "missing FROM-clause entry" — señal clara e inmediata, no un resultado
+ * incorrecto silencioso.
+ *
+ * Única fuente de este COALESCE — antes vivía duplicado carácter por carácter
+ * en reasignarAsesor.ts (bucketActualDeCredito) y cargaAsesorBucket.ts
+ * (CTE bucket_actual); ambos ahora lo importan de aquí para no divergir.
+ */
+export const bucketActualSql = (credAlias: string, moraAlias: string) => {
+  const c = sql.raw(credAlias);
+  const m = sql.raw(moraAlias);
+  return sql`
+  COALESCE(
+    (SELECT h.bucket_nuevo FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+      WHERE h.credito_id = ${c}.credito_id
+      ORDER BY h.fecha DESC, h.historial_id DESC
+      LIMIT 1),
+    (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
+      WHERE b.activo = true
+        AND ${c}."statusCredit" = ANY (b.estados_incluidos)
+      ORDER BY b.numero LIMIT 1),
+    (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
+      WHERE b.activo = true
+        AND COALESCE(${m}.cuotas_atrasadas, 0) >= b.cuotas_min
+        AND (b.cuotas_max IS NULL OR COALESCE(${m}.cuotas_atrasadas, 0) <= b.cuotas_max)
+      ORDER BY b.numero LIMIT 1)
+  )
+`;
+};

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -11,6 +11,7 @@ import {
   getAsesoresPorBucket,
   reasignarAsesorManual,
 } from "../controllers/buckets/reasignarAsesor";
+import { getCargaPorAsesorBucket } from "../controllers/buckets/cargaAsesorBucket";
 import { StatusCredit } from "../database/db/schema";
 
 // Estados DENTRO del funnel operativo (= enum de statusCredit menos
@@ -26,6 +27,19 @@ const STATUS_FUNNEL: StatusCredit[] = [
 
 // Gate de rol server-side: el histórico expone data de TODOS los créditos
 // (igual criterio que el historial de mora). authMiddleware solo autentica.
+//
+// ⚠️ 3 gates INDEPENDIENTES protegen esta misma ruta de datos (/buckets/*),
+// con vocabularios de rol DISTINTOS (no hay traducción automática entre
+// ellos — son 2 sistemas de auth separados, cartera-back con su JWT propio y
+// CRM con better-auth):
+//   1. Este (ADMIN/CONTA) — token de servicio del CRM, no un usuario humano.
+//   2. requireCobrosSupervisor (crm/apps/server/src/lib/orpc.ts) — admin/
+//      cobros_supervisor del usuario humano autenticado en el CRM.
+//   3. PERMISSIONS.canAssignCobros (crm/apps/web/src/lib/roles.ts) — mismo
+//      criterio que (2), pero evaluado en el cliente solo para UX (ocultar
+//      el nav item); NO es seguridad real, (2) es la que de verdad protege.
+// Si cambias el criterio de acceso a /buckets/carga (o cualquier /buckets/*),
+// revisa los 3 — no hay una sola fuente de verdad que los sincronice.
 const requireBucketsRole = (user: any, set: any): boolean => {
   if (!user || !["ADMIN", "CONTA"].includes(user.role)) {
     set.status = 403;
@@ -387,6 +401,43 @@ export const bucketsRouter = new Elysia()
         return {
           success: false,
           message: "[ERROR] No se pudo obtener el pool de asesores del bucket",
+          error: String(err),
+        };
+      }
+    },
+  )
+
+  // CB-018 · Carga de cuentas por asesor y bucket (dashboard gerencial): cuentas
+  // asignadas, capacidad base, % utilización, sobrecarga y alerta de nueva
+  // posición. Filtros opcionales por bucket y asesor_id.
+  .get(
+    "/buckets/carga",
+    async ({ query, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        // esBucket solo valida "entero no-negativo" (la usan otras rutas con
+        // CSVs de buckets históricos); aquí además se acota al rango real del
+        // catálogo (0-5) para no devolver vacío en silencio con p.ej. bucket=99.
+        if (
+          query?.bucket !== undefined &&
+          (!esBucket(String(query.bucket)) || Number(query.bucket) > 5)
+        ) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] bucket inválido (rango 0-5)" };
+        }
+        const bucket = query?.bucket !== undefined ? Number(query.bucket) : undefined;
+        const asesorIdRaw = query?.asesor_id !== undefined ? Number(query.asesor_id) : undefined;
+        if (asesorIdRaw !== undefined && (!Number.isInteger(asesorIdRaw) || asesorIdRaw <= 0)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] asesor_id inválido" };
+        }
+        const data = await getCargaPorAsesorBucket({ bucket, asesor_id: asesorIdRaw });
+        return { success: true, data };
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener la carga por asesor y bucket",
           error: String(err),
         };
       }


### PR DESCRIPTION
## Resumen
- Endpoint `GET /buckets/carga`: cuentas asignadas, capacidad base, % de utilización, sobrecarga y alerta de nueva posición por **asesor+bucket** — el techo (default 300) es por asesor dentro de un bucket, no agregado del bucket completo (confirmado con el informador del ticket).
- `sobrecarga` = ya pasó `capacidad_base`. `alerta_nueva_posicion` = ya pasó `capacidad_base + margen` (margen % o cantidad fija, parametrizable por fila, default 10% — ej. límite 100, alerta a partir de 110).

## Migraciones (sin correr, aplicar a mano en dev primero)
- `0004_buckets_capacidad_base.sql`: `asesor_bucket.capacidad_base` (default 300).
- `0005_asesor_bucket_margen_alerta.sql`: `asesor_bucket.margen_alerta_tipo` ('porcentaje'|'fijo', default 'porcentaje') + `margen_alerta_valor` (default 10). CHECKs de rango en ambas (`capacidad_base > 0`, `margen_alerta_valor >= 0`).

## Cambios
- `controllers/buckets/cargaAsesorBucket.ts` (nuevo): agregación por asesor+bucket, `resolverMargen()` pura.
- `lib/buckets-classification.ts`: `bucketActualSql(credAlias, moraAlias)` — fragmento SQL de derivación del bucket actual, extraído para compartirlo con `reasignarAsesor.ts` (antes duplicado carácter por carácter).
- `routers/buckets.ts`: `GET /buckets/carga`, gate `requireBucketsRole`, valida rango 0-5.
- `database/db/schema.ts`: columnas nuevas en `asesor_bucket`.

## Este PR es solo cartera-back
Parte 1/3 de CB-018. El consumidor (CRM server + web) va en PRs separados, encima de este, una vez mergeado.

## Test plan
- [x] `bunx tsc --noEmit` limpio
- [x] `bun test src/controllers/buckets/cargaAsesorBucket.test.ts src/controllers/buckets/reasignarAsesor.test.ts` — 21 tests, 0 fail (DB fakeada)
- [ ] Aplicar migraciones 0004/0005 en dev (`ep-green-tree`) y probar `GET /buckets/carga` manualmente

🤖 Generated with [Claude Code](https://claude.com/claude-code)