### PR TITLE
fix(abonos-capital): revertir el abono cuando se revierte el pago

### DIFF
--- a/apps/cartera-back/drizzle/0019_abonos_capital_pago_id.sql
+++ b/apps/cartera-back/drizzle/0019_abonos_capital_pago_id.sql
@@ -1,0 +1,36 @@
+-- Enlaza cada abono a capital con el pago que lo generó.
+--
+-- Contexto: hasta ahora `abonos_capital` era un ACUMULADO — una fila por par
+-- (credito_id, inversionista_id) sobre la que cada pago sumaba su monto. Por eso
+-- al revertir un pago no se podía saber qué parte de la fila era suya, y el
+-- monto quedaba sumado para siempre (abono huérfano).
+--
+-- Ahora cada pago inserta su propia fila con su `pago_id`, y revertir el pago
+-- borra exactamente esas filas.
+--
+-- NULLABLE a propósito:
+--   * las filas que ya existen (no se puede reconstruir qué pagos las formaron:
+--     esa información nunca se guardó),
+--   * las CANCELACION de devolución/reset, que no nacen de un pago,
+--   * el alta manual por POST /api/abonos-capital.
+--
+-- ON DELETE CASCADE: reversePayment borra los pagos parciales; sin el cascade su
+-- abono quedaría huérfano apuntando a un pago inexistente.
+
+ALTER TABLE "cartera"."abonos_capital"
+  ADD COLUMN IF NOT EXISTS "pago_id" integer;
+
+DO $$ BEGIN
+  ALTER TABLE "cartera"."abonos_capital"
+    ADD CONSTRAINT "abonos_capital_pago_id_pagos_credito_pago_id_fk"
+    FOREIGN KEY ("pago_id") REFERENCES "cartera"."pagos_credito"("pago_id")
+    ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_pago_id"
+  ON "cartera"."abonos_capital" ("pago_id");
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_cred_inv"
+  ON "cartera"."abonos_capital" ("credito_id", "inversionista_id");

--- a/apps/cartera-back/drizzle/0020_abonos_capital_liquidacion_id.sql
+++ b/apps/cartera-back/drizzle/0020_abonos_capital_liquidacion_id.sql
@@ -1,0 +1,45 @@
+-- Anota en cada abono a capital en qué liquidación se cerró.
+--
+-- Contexto: el reporte /reportes/reinversion-liquidaciones llegaba al abono por
+-- `pagos_credito_inversionistas_espejo.abono_capital_id`. Esa columna es una sola
+-- casilla: apunta a UN abono. Mientras hubo una fila por par (crédito,
+-- inversionista) daba igual — ese uno era todo. Con una fila por pago (ver
+-- 0019), ir por el link solo agarra la primera y el reporte subcuenta.
+--
+-- Con `liquidacion_id` seteado al cerrar el abono, el reporte suma directo y no
+-- necesita el link ni el DISTINCT.
+--
+-- El backfill hace UNA vez el mismo rodeo que el reporte hacía en cada consulta,
+-- y es exacto para lo viejo: en el modelo anterior había una sola fila abierta
+-- por par y era justo la linkeada.
+
+ALTER TABLE "cartera"."abonos_capital"
+  ADD COLUMN IF NOT EXISTS "liquidacion_id" integer;
+
+DO $$ BEGIN
+  ALTER TABLE "cartera"."abonos_capital"
+    ADD CONSTRAINT "abonos_capital_liquidacion_id_liquidaciones_liquidacion_id_fk"
+    FOREIGN KEY ("liquidacion_id") REFERENCES "cartera"."liquidaciones"("liquidacion_id")
+    ON DELETE SET NULL ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_liquidacion_id"
+  ON "cartera"."abonos_capital" ("liquidacion_id");
+
+-- Backfill del histórico: se recorre el link una sola vez y se guarda.
+-- MIN() por determinismo: si un abono estuviera linkeado desde espejos de más de
+-- una liquidación, se le atribuye la primera (la que efectivamente lo pagó).
+UPDATE "cartera"."abonos_capital" a
+   SET "liquidacion_id" = sub.liquidacion_id
+  FROM (
+    SELECT e."abono_capital_id" AS abono_id,
+           MIN(e."liquidacion_id") AS liquidacion_id
+      FROM "cartera"."pagos_credito_inversionistas_espejo" e
+     WHERE e."abono_capital_id" IS NOT NULL
+       AND e."liquidacion_id" IS NOT NULL
+     GROUP BY e."abono_capital_id"
+  ) sub
+ WHERE a."abono_id" = sub.abono_id
+   AND a."liquidacion_id" IS NULL;

--- a/apps/cartera-back/drizzle/0021_abonos_capital_pago_espejo_id.sql
+++ b/apps/cartera-back/drizzle/0021_abonos_capital_pago_espejo_id.sql
@@ -1,0 +1,43 @@
+-- Marca qué fila de espejo consumió cada abono a capital.
+--
+-- Por qué: el espejo CONGELA el monto a pagar cuando se genera, y no se regenera
+-- mientras haya uno sin liquidar. La liquidación paga esa foto
+-- (`espejo.abono_capital`). Un abono que nace DESPUÉS de la foto NO está en ese
+-- monto: no se pagó. Cerrarlo igual lo daría por cobrado y el inversionista
+-- nunca vería esa plata.
+--
+-- Con `pago_espejo_id` la liquidación cierra exactamente los abonos que la foto
+-- incluyó. Los que nacieron después quedan sin marca → abiertos → los toma el
+-- siguiente calcular pagos, que es como debe funcionar.
+--
+-- Se setea en insertPagosCreditoInversionistas (payments.ts) al generar el espejo.
+
+ALTER TABLE "cartera"."abonos_capital"
+  ADD COLUMN IF NOT EXISTS "pago_espejo_id" integer;
+
+DO $$ BEGIN
+  ALTER TABLE "cartera"."abonos_capital"
+    ADD CONSTRAINT "abonos_capital_pago_espejo_id_pagos_credito_inversionistas_espejo_id_fk"
+    FOREIGN KEY ("pago_espejo_id") REFERENCES "cartera"."pagos_credito_inversionistas_espejo"("id")
+    ON DELETE SET NULL ON UPDATE NO ACTION;
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "ix_abonos_capital_pago_espejo_id"
+  ON "cartera"."abonos_capital" ("pago_espejo_id");
+
+-- Backfill. CRÍTICO para los abonos ABIERTOS que ya están dentro de un espejo
+-- NO_LIQUIDADO: si quedaran sin marca, la liquidación (que ahora cierra solo los
+-- marcados) no los cerraría nunca y el siguiente ciclo se los volvería a pagar al
+-- inversionista.
+--
+-- Se usa el link `espejo.abono_capital_id`, que para los datos previos es
+-- completo: en el modelo viejo había UNA sola fila abierta por par
+-- (crédito, inversionista) y era justo la linkeada. Los abonos sin link son los
+-- que ningún espejo consumió todavía: quedan en NULL, que es lo correcto.
+UPDATE "cartera"."abonos_capital" a
+   SET "pago_espejo_id" = e."id"
+  FROM "cartera"."pagos_credito_inversionistas_espejo" e
+ WHERE e."abono_capital_id" = a."abono_id"
+   AND a."pago_espejo_id" IS NULL;

--- a/apps/cartera-back/drizzle/0022_abonos_capital_unique_pago_inversionista.sql
+++ b/apps/cartera-back/drizzle/0022_abonos_capital_unique_pago_inversionista.sql
@@ -1,0 +1,18 @@
+-- Un pago aporta UNA fila por inversionista, garantizado por la base.
+--
+-- Hasta ahora era solo una convención del código: distribuirAbonoCapitalEspejo
+-- inserta una fila por inversionista y nada impedía que corriera dos veces para
+-- el mismo pago. Si dos aplicaciones del mismo pago se pisan (doble click, retry,
+-- dos procesos), se duplicaban los abonos y se le restaba el capital DOS VECES al
+-- inversionista. Con el índice único la segunda revienta en vez de duplicar.
+--
+-- Las filas con `pago_id` NULL no chocan entre sí: en Postgres los NULL no
+-- colisionan en un índice único. Eso deja fuera, por diseño:
+--   * las filas previas a la migración 0019 (nunca se supo qué pago las creó),
+--   * las CANCELACION de devolución/reset, que no nacen de un pago.
+--
+-- Verificado contra prod antes de crearlo: 0 pares (pago_id, inversionista_id)
+-- duplicados, así que entra sin conflictos.
+
+CREATE UNIQUE INDEX IF NOT EXISTS "ux_abonos_capital_pago_inversionista"
+  ON "cartera"."abonos_capital" ("pago_id", "inversionista_id");

--- a/apps/cartera-back/drizzle/0023_backfill_abonos_capital_pago_id.sql
+++ b/apps/cartera-back/drizzle/0023_backfill_abonos_capital_pago_id.sql
@@ -1,0 +1,44 @@
+-- Sincroniza los abonos históricos con el pago que los creó — los que se puede.
+--
+-- La migración 0019 dejó `pago_id` en NULL para todo lo anterior, porque el
+-- modelo viejo acumulaba: una fila por par (crédito, inversionista) mezclaba N
+-- pagos y no había forma de saber cuál era cuál.
+--
+-- Pero hay un subconjunto donde SÍ se puede, sin ambigüedad: los créditos que
+-- tienen UN SOLO pago de abono directo a capital. Ahí la fila solo puede venir
+-- de ese pago. No hay nada que adivinar.
+--
+-- Por qué importa: sin `pago_id`, revertir uno de esos pagos entra por la rama de
+-- "este pago no generó abonos" y sigue como si nada, dejando el abono vivo para
+-- que se pague en una liquidación. Con el `pago_id` puesto, el reverso lo
+-- encuentra y lo borra (o lo frena, si ya está comprometido).
+--
+-- Alcance real medido contra prod (34 abonos CAPITAL abiertos):
+--   * 19 (13 créditos) → 1 solo pago capital  → SE LLENAN acá
+--   *  4 ( 3 créditos) → 2-3 pagos capital    → la fila es una mezcla, imposible
+--   * 11 (11 créditos) → 0 pagos capital      → el pago ya no existe (reversePayment
+--                                               borra los parciales). Son los
+--                                               huérfanos que este PR viene a
+--                                               evitar hacia adelante.
+--
+-- Solo se tocan los ABIERTOS (`liquidado = false`): los ya liquidados están
+-- cerrados, el reverso los frena igual por `liquidado`, y llenarlos podría chocar
+-- con el índice único de 0022.
+--
+-- Verificado antes de correr: llena exactamente 19 filas y 0 pares
+-- (pago_id, inversionista_id) colisionan con el índice único.
+
+UPDATE "cartera"."abonos_capital" a
+   SET "pago_id" = sub.pago_id,
+       "updated_at" = NOW()
+  FROM (
+    SELECT p."credito_id", MIN(p."pago_id") AS pago_id
+      FROM "cartera"."pagos_credito" p
+     WHERE p."validation_status" IN ('capital', 'capital_validated')
+     GROUP BY p."credito_id"
+    HAVING COUNT(*) = 1
+  ) sub
+ WHERE a."credito_id" = sub.credito_id
+   AND a."tipo" = 'CAPITAL'
+   AND a."liquidado" = false
+   AND a."pago_id" IS NULL;

--- a/apps/cartera-back/src/controllers/abonosCapital.test.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.test.ts
@@ -14,7 +14,9 @@ mock.module("../utils/comprasAjuste", () => ({
     Promise.resolve(new Big(pendientesPorInv[invId] ?? 0)),
 }));
 
-const { registrarCancelacionEspejo } = await import("./abonosCapital");
+const { registrarCancelacionEspejo, revertirAbonoCapitalEspejo } = await import(
+  "./abonosCapital"
+);
 
 // Mock del handle de transacción (tx) de drizzle. Simula:
 //   tx.select().from().innerJoin().where()  -> filas del espejo
@@ -133,5 +135,82 @@ describe("registrarCancelacionEspejo", () => {
     await registrarCancelacionEspejo(tx, 1);
 
     expect(inserted[0].monto).toBe("1000.5");
+  });
+});
+
+// Mock del executor para revertirAbonoCapitalEspejo. Simula:
+//   ex.select().from().where()   -> las filas de abonos_capital de ese pago
+//   ex.delete().where()          -> borrado (contado en state.deleteCalls)
+function makeExecutor(filas: any[]) {
+  const state = { deleteCalls: 0 };
+  const ex: any = {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(filas) }) }),
+    delete: () => ({
+      where: () => {
+        state.deleteCalls++;
+        return Promise.resolve([]);
+      },
+    }),
+  };
+  return { ex, state };
+}
+
+describe("revertirAbonoCapitalEspejo", () => {
+  it("borra las filas que generó ese pago", async () => {
+    const { ex, state } = makeExecutor([
+      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
+      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: false },
+    ]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(res.success).toBe(true);
+    expect(state.deleteCalls).toBe(1);
+    expect(res.data!.borrados).toHaveLength(2);
+    expect(res.data!.borrados[0]).toMatchObject({ abono_id: 1, inversionista_id: 10, monto: "600" });
+    expect(res.data!.omitidos).toHaveLength(0);
+  });
+
+  it("no hace nada si el pago no generó ningún abono", async () => {
+    // Caso normal: una cuota corriente nunca creó filas en abonos_capital.
+    const { ex, state } = makeExecutor([]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(res.success).toBe(true);
+    expect(state.deleteCalls).toBe(0);
+    expect(res.data!.borrados).toHaveLength(0);
+  });
+
+  it("no borra las filas ya liquidadas: las reporta como omitidas", async () => {
+    // La plata ya le salió al inversionista: borrarla la haría desaparecer.
+    const { ex, state } = makeExecutor([
+      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: true },
+    ]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(state.deleteCalls).toBe(0);
+    expect(res.data!.borrados).toHaveLength(0);
+    expect(res.data!.omitidos).toHaveLength(1);
+    expect(res.data!.omitidos[0]).toMatchObject({
+      abono_id: 1,
+      motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
+    });
+  });
+
+  it("borra las abiertas y conserva las liquidadas cuando vienen mezcladas", async () => {
+    const { ex, state } = makeExecutor([
+      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
+      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: true },
+    ]);
+
+    const res = await revertirAbonoCapitalEspejo(555, ex);
+
+    expect(state.deleteCalls).toBe(1);
+    expect(res.data!.borrados).toHaveLength(1);
+    expect(res.data!.borrados[0].abono_id).toBe(1);
+    expect(res.data!.omitidos).toHaveLength(1);
+    expect(res.data!.omitidos[0].abono_id).toBe(2);
   });
 });

--- a/apps/cartera-back/src/controllers/abonosCapital.test.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.test.ts
@@ -141,13 +141,15 @@ describe("registrarCancelacionEspejo", () => {
 // Mock del executor para revertirAbonoCapitalEspejo. Simula:
 //   ex.select().from().where()   -> las filas de abonos_capital de ese pago
 //   ex.delete().where()          -> borrado (contado en state.deleteCalls)
-function makeExecutor(filas: any[]) {
+// `failDelete` simula que el borrado revienta (error de DB/FK/conexión).
+function makeExecutor(filas: any[], failDelete = false) {
   const state = { deleteCalls: 0 };
   const ex: any = {
     select: () => ({ from: () => ({ where: () => Promise.resolve(filas) }) }),
     delete: () => ({
       where: () => {
         state.deleteCalls++;
+        if (failDelete) return Promise.reject(new Error("connection reset"));
         return Promise.resolve([]);
       },
     }),
@@ -155,11 +157,21 @@ function makeExecutor(filas: any[]) {
   return { ex, state };
 }
 
+const abonoAbierto = (over: any = {}) => ({
+  abono_id: 1,
+  inversionista_id: 10,
+  monto: "600",
+  tipo: "CAPITAL",
+  liquidado: false,
+  pago_espejo_id: null,
+  ...over,
+});
+
 describe("revertirAbonoCapitalEspejo", () => {
   it("borra las filas que generó ese pago", async () => {
     const { ex, state } = makeExecutor([
-      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
-      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: false },
+      abonoAbierto({ abono_id: 1, inversionista_id: 10, monto: "600" }),
+      abonoAbierto({ abono_id: 2, inversionista_id: 20, monto: "400" }),
     ]);
 
     const res = await revertirAbonoCapitalEspejo(555, ex);
@@ -167,8 +179,11 @@ describe("revertirAbonoCapitalEspejo", () => {
     expect(res.success).toBe(true);
     expect(state.deleteCalls).toBe(1);
     expect(res.data!.borrados).toHaveLength(2);
-    expect(res.data!.borrados[0]).toMatchObject({ abono_id: 1, inversionista_id: 10, monto: "600" });
-    expect(res.data!.omitidos).toHaveLength(0);
+    expect(res.data!.borrados[0]).toMatchObject({
+      abono_id: 1,
+      inversionista_id: 10,
+      monto: "600",
+    });
   });
 
   it("no hace nada si el pago no generó ningún abono", async () => {
@@ -182,35 +197,34 @@ describe("revertirAbonoCapitalEspejo", () => {
     expect(res.data!.borrados).toHaveLength(0);
   });
 
-  it("no borra las filas ya liquidadas: las reporta como omitidas", async () => {
-    // La plata ya le salió al inversionista: borrarla la haría desaparecer.
-    const { ex, state } = makeExecutor([
-      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: true },
-    ]);
+  it("TIRA ERROR y no borra nada si el abono ya fue liquidado", async () => {
+    // La plata ya le salió al inversionista: el pago no se puede revertir.
+    const { ex, state } = makeExecutor([abonoAbierto({ liquidado: true })]);
 
-    const res = await revertirAbonoCapitalEspejo(555, ex);
-
+    await expect(revertirAbonoCapitalEspejo(555, ex)).rejects.toThrow(
+      /\[ABONO_YA_LIQUIDADO\]/
+    );
     expect(state.deleteCalls).toBe(0);
-    expect(res.data!.borrados).toHaveLength(0);
-    expect(res.data!.omitidos).toHaveLength(1);
-    expect(res.data!.omitidos[0]).toMatchObject({
-      abono_id: 1,
-      motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
-    });
   });
 
-  it("borra las abiertas y conserva las liquidadas cuando vienen mezcladas", async () => {
-    const { ex, state } = makeExecutor([
-      { abono_id: 1, inversionista_id: 10, monto: "600", tipo: "CAPITAL", liquidado: false },
-      { abono_id: 2, inversionista_id: 20, monto: "400", tipo: "CAPITAL", liquidado: true },
-    ]);
+  it("TIRA ERROR y no borra nada si el abono ya entró en un cálculo de pagos", async () => {
+    // El espejo ya congeló ese monto y se lo va a pagar igual: borrar el abono
+    // dejaría al inversionista cobrando un capital que se revirtió.
+    const { ex, state } = makeExecutor([abonoAbierto({ pago_espejo_id: 77 })]);
 
-    const res = await revertirAbonoCapitalEspejo(555, ex);
+    await expect(revertirAbonoCapitalEspejo(555, ex)).rejects.toThrow(
+      /\[ABONO_EN_CALCULO_PENDIENTE\]/
+    );
+    expect(state.deleteCalls).toBe(0);
+  });
 
-    expect(state.deleteCalls).toBe(1);
-    expect(res.data!.borrados).toHaveLength(1);
-    expect(res.data!.borrados[0].abono_id).toBe(1);
-    expect(res.data!.omitidos).toHaveLength(1);
-    expect(res.data!.omitidos[0].abono_id).toBe(2);
+  it("propaga el error si el borrado falla, para que la transacción se caiga", async () => {
+    // Si se tragara el error, el pago se revertiría igual y el abono quedaría
+    // huérfano: justo el bug que esta función viene a evitar.
+    const { ex } = makeExecutor([abonoAbierto()], true);
+
+    await expect(revertirAbonoCapitalEspejo(555, ex)).rejects.toThrow(
+      /connection reset/
+    );
   });
 });

--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -40,14 +40,21 @@ export async function createAbonoCapital(data: {
 }
 
 /**
- * Distribuye un abono a capital entre los inversionistas del espejo.
- * Si ya existe un registro con credito_id + inversionista_id y liquidado = false, suma el monto.
- * Si no existe, inserta uno nuevo.
+ * Distribuye un abono a capital entre los inversionistas del espejo:
+ * INSERTA una fila por inversionista, marcada con el `pago_id` que la originó.
+ *
+ * NO acumula sobre una fila abierta previa (como hacía antes): cada pago tiene
+ * sus propias filas. Eso es lo que hace que revertir un pago sea simplemente
+ * borrar sus filas, sin tocar lo que aportaron los demás pagos.
+ *
+ * `pago_id` es opcional porque resetCredit distribuye una CANCELACION que no
+ * nace de un pago.
  */
 export async function distribuirAbonoCapitalEspejo(
   credito_id: number,
   monto_abono_capital: number | string,
-  tipo: "CANCELACION" | "CAPITAL" = "CAPITAL"
+  tipo: "CANCELACION" | "CAPITAL" = "CAPITAL",
+  pago_id?: number
 ) {
   try {
     const abonoBig = new Big(monto_abono_capital);
@@ -95,58 +102,28 @@ export async function distribuirAbonoCapitalEspejo(
       // Monto que le toca del abono
       const montoAbono = abonoBig.times(porcentajeGeneral).round(6);
 
-      // Buscar si ya existe uno no liquidado
-      const [existente] = await db
-        .select()
-        .from(abonos_capital)
-        .where(
-          and(
-            eq(abonos_capital.credito_id, credito_id),
-            eq(abonos_capital.inversionista_id, inv.inversionista_id),
-            eq(abonos_capital.liquidado, false)
-          )
-        )
-        .limit(1);
-
-      if (existente) {
-        // Sumar al existente
-        const nuevoMonto = new Big(existente.monto).plus(montoAbono).toString();
-        const [actualizado] = await db
-          .update(abonos_capital)
-          .set({ monto: nuevoMonto, updated_at: new Date() })
-          .where(eq(abonos_capital.abono_id, existente.abono_id))
-          .returning();
-
-        resultados.push({
-          inversionista: inv.nombre,
+      // Una fila propia por (pago, inversionista): nunca se suma sobre una
+      // fila previa, así revertir el pago no le toca lo suyo a otros pagos.
+      const [nuevo] = await db
+        .insert(abonos_capital)
+        .values({
+          credito_id,
           inversionista_id: inv.inversionista_id,
-          accion: "SUMADO",
-          monto_agregado: montoAbono.toString(),
-          monto_total: nuevoMonto,
-          porcentaje: porcentajeGeneral.toFixed(4),
-        });
-      } else {
-        // Insertar nuevo
-        const [nuevo] = await db
-          .insert(abonos_capital)
-          .values({
-            credito_id,
-            inversionista_id: inv.inversionista_id,
-            monto: montoAbono.toString(),
-            tipo,
-            liquidado: false,
-          })
-          .returning();
+          pago_id: pago_id ?? null,
+          monto: montoAbono.toString(),
+          tipo,
+          liquidado: false,
+        })
+        .returning();
 
-        resultados.push({
-          inversionista: inv.nombre,
-          inversionista_id: inv.inversionista_id,
-          accion: "INSERTADO",
-          monto_agregado: montoAbono.toString(),
-          monto_total: montoAbono.toString(),
-          porcentaje: porcentajeGeneral.toFixed(4),
-        });
-      }
+      resultados.push({
+        inversionista: inv.nombre,
+        inversionista_id: inv.inversionista_id,
+        abono_id: nuevo.abono_id,
+        pago_id: pago_id ?? null,
+        monto_agregado: montoAbono.toString(),
+        porcentaje: porcentajeGeneral.toFixed(4),
+      });
     }
 
     return {
@@ -164,6 +141,82 @@ export async function distribuirAbonoCapitalEspejo(
     return {
       success: false,
       message: "Error al distribuir el abono a capital",
+      error: error.message,
+      data: null,
+    };
+  }
+}
+
+/**
+ * Revierte el abono a capital de un pago: borra las filas de `abonos_capital`
+ * que ese pago generó (una por inversionista, marcadas con su `pago_id`).
+ *
+ * Se puede borrar sin miedo porque cada fila es exclusiva de un pago: no
+ * acumula aportes de otros pagos, así que nadie más pierde plata.
+ *
+ * Las filas YA LIQUIDADAS no se borran (la plata ya le salió al inversionista):
+ * se devuelven en `omitidos` para tratarlas a mano. Es el caso que decidimos
+ * dejar fuera de este cambio.
+ *
+ * `executor` permite pasar el `tx` de una transacción para que la reversión sea
+ * atómica con el resto del reverso.
+ */
+export async function revertirAbonoCapitalEspejo(
+  pago_id: number,
+  executor: any = db
+) {
+  try {
+    // 1. Las filas que generó este pago
+    const filas = await executor
+      .select()
+      .from(abonos_capital)
+      .where(eq(abonos_capital.pago_id, pago_id));
+
+    if (filas.length === 0) {
+      return {
+        success: true,
+        message: "El pago no generó abonos a capital: nada que revertir",
+        data: { pago_id, borrados: [], omitidos: [] },
+      };
+    }
+
+    // 2. Las liquidadas NO se tocan: esa plata ya salió.
+    const liquidadas = filas.filter((f: any) => f.liquidado);
+    const borrables = filas.filter((f: any) => !f.liquidado);
+
+    if (borrables.length > 0) {
+      await executor.delete(abonos_capital).where(
+        and(
+          eq(abonos_capital.pago_id, pago_id),
+          eq(abonos_capital.liquidado, false)
+        )
+      );
+    }
+
+    return {
+      success: true,
+      message: "Abonos a capital del pago revertidos",
+      data: {
+        pago_id,
+        borrados: borrables.map((f: any) => ({
+          abono_id: f.abono_id,
+          inversionista_id: f.inversionista_id,
+          monto: f.monto,
+          tipo: f.tipo,
+        })),
+        omitidos: liquidadas.map((f: any) => ({
+          abono_id: f.abono_id,
+          inversionista_id: f.inversionista_id,
+          monto: f.monto,
+          motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
+        })),
+      },
+    };
+  } catch (error: any) {
+    console.error("Error al revertir abono a capital:", error);
+    return {
+      success: false,
+      message: "Error al revertir el abono a capital",
       error: error.message,
       data: null,
     };

--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -49,6 +49,14 @@ export async function createAbonoCapital(data: {
  *
  * `pago_id` es opcional porque resetCredit distribuye una CANCELACION que no
  * nace de un pago.
+ *
+ * Los errores NO se atrapan a propósito: si esto falla, quien aplica el pago
+ * tiene que enterarse y abortar. Antes se los tragaba y devolvía
+ * `{success:false}`, así que el pago se aplicaba igual: al crédito se le bajaba
+ * el capital y el inversionista se quedaba sin su abono.
+ *
+ * `{success:false}` queda solo para los casos donde no hay NADA que hacer (sin
+ * inversionistas en el espejo, capital total en 0). Eso no es una falla.
  */
 export async function distribuirAbonoCapitalEspejo(
   credito_id: number,
@@ -56,11 +64,10 @@ export async function distribuirAbonoCapitalEspejo(
   tipo: "CANCELACION" | "CAPITAL" = "CAPITAL",
   pago_id?: number
 ) {
-  try {
-    const abonoBig = new Big(monto_abono_capital);
+  const abonoBig = new Big(monto_abono_capital);
 
-    // 1. Traer inversionistas del espejo
-    const invsEspejo = await db
+  // 1. Traer inversionistas del espejo
+  const invsEspejo = await db
       .select({
         inversionista_id: creditos_inversionistas_espejo.inversionista_id,
         monto_aportado: creditos_inversionistas_espejo.monto_aportado,
@@ -126,25 +133,16 @@ export async function distribuirAbonoCapitalEspejo(
       });
     }
 
-    return {
-      success: true,
-      message: "Abono a capital distribuido entre inversionistas",
-      data: {
-        credito_id,
-        monto_total: abonoBig.toString(),
-        capital_credito: capitalTotal.toString(),
-        distribucion: resultados,
-      },
-    };
-  } catch (error: any) {
-    console.error("Error al distribuir abono a capital:", error);
-    return {
-      success: false,
-      message: "Error al distribuir el abono a capital",
-      error: error.message,
-      data: null,
-    };
-  }
+  return {
+    success: true,
+    message: "Abono a capital distribuido entre inversionistas",
+    data: {
+      credito_id,
+      monto_total: abonoBig.toString(),
+      capital_credito: capitalTotal.toString(),
+      distribucion: resultados,
+    },
+  };
 }
 
 /**

--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -154,9 +154,21 @@ export async function distribuirAbonoCapitalEspejo(
  * Se puede borrar sin miedo porque cada fila es exclusiva de un pago: no
  * acumula aportes de otros pagos, así que nadie más pierde plata.
  *
- * Las filas YA LIQUIDADAS no se borran (la plata ya le salió al inversionista):
- * se devuelven en `omitidos` para tratarlas a mano. Es el caso que decidimos
- * dejar fuera de este cambio.
+ * TIRA ERROR (y voltea la transacción del reverso) en dos casos, porque en los
+ * dos el abono ya no se puede tocar:
+ *
+ *  - `liquidado`: la plata ya le salió al inversionista.
+ *  - `pago_espejo_id` seteado: una fila de espejo ya lo consumió. El espejo
+ *    CONGELA el monto a pagar al generarse y no se regenera mientras esté sin
+ *    liquidar, así que la liquidación le va a pagar ese capital igual. Borrar el
+ *    abono no la frena: el inversionista terminaría cobrando un capital que se
+ *    revirtió, mientras el cliente lo sigue debiendo.
+ *
+ * Los dos se resuelven a mano antes de revertir; el sistema no puede adivinar.
+ *
+ * Los errores NO se atrapan a propósito: si el borrado falla, el reverso entero
+ * tiene que caerse. Si se tragara el error, el pago se revertiría igual y el
+ * abono quedaría huérfano — justo lo que esta función viene a evitar.
  *
  * `executor` permite pasar el `tx` de una transacción para que la reversión sea
  * atómica con el resto del reverso.
@@ -165,62 +177,58 @@ export async function revertirAbonoCapitalEspejo(
   pago_id: number,
   executor: any = db
 ) {
-  try {
-    // 1. Las filas que generó este pago
-    const filas = await executor
-      .select()
-      .from(abonos_capital)
-      .where(eq(abonos_capital.pago_id, pago_id));
+  // 1. Las filas que generó este pago
+  const filas = await executor
+    .select()
+    .from(abonos_capital)
+    .where(eq(abonos_capital.pago_id, pago_id));
 
-    if (filas.length === 0) {
-      return {
-        success: true,
-        message: "El pago no generó abonos a capital: nada que revertir",
-        data: { pago_id, borrados: [], omitidos: [] },
-      };
-    }
-
-    // 2. Las liquidadas NO se tocan: esa plata ya salió.
-    const liquidadas = filas.filter((f: any) => f.liquidado);
-    const borrables = filas.filter((f: any) => !f.liquidado);
-
-    if (borrables.length > 0) {
-      await executor.delete(abonos_capital).where(
-        and(
-          eq(abonos_capital.pago_id, pago_id),
-          eq(abonos_capital.liquidado, false)
-        )
-      );
-    }
-
+  if (filas.length === 0) {
     return {
       success: true,
-      message: "Abonos a capital del pago revertidos",
-      data: {
-        pago_id,
-        borrados: borrables.map((f: any) => ({
-          abono_id: f.abono_id,
-          inversionista_id: f.inversionista_id,
-          monto: f.monto,
-          tipo: f.tipo,
-        })),
-        omitidos: liquidadas.map((f: any) => ({
-          abono_id: f.abono_id,
-          inversionista_id: f.inversionista_id,
-          monto: f.monto,
-          motivo: "YA_LIQUIDADO_LA_PLATA_YA_SALIO",
-        })),
-      },
-    };
-  } catch (error: any) {
-    console.error("Error al revertir abono a capital:", error);
-    return {
-      success: false,
-      message: "Error al revertir el abono a capital",
-      error: error.message,
-      data: null,
+      message: "El pago no generó abonos a capital: nada que revertir",
+      data: { pago_id, borrados: [] },
     };
   }
+
+  // 2. Portero: la plata ya salió.
+  const liquidadas = filas.filter((f: any) => f.liquidado);
+  if (liquidadas.length > 0) {
+    throw new Error(
+      `[ABONO_YA_LIQUIDADO] El pago ${pago_id} tiene ${liquidadas.length} abono(s) a capital ya liquidado(s) ` +
+        `(abono_id: ${liquidadas.map((f: any) => f.abono_id).join(", ")}). ` +
+        `Esa plata ya se le pagó al inversionista: hay que revertir la liquidación antes de revertir el pago.`
+    );
+  }
+
+  // 3. Portero: ya entró en una foto que se va a pagar.
+  const enEspejo = filas.filter((f: any) => f.pago_espejo_id != null);
+  if (enEspejo.length > 0) {
+    throw new Error(
+      `[ABONO_EN_CALCULO_PENDIENTE] El pago ${pago_id} tiene ${enEspejo.length} abono(s) a capital que ya entraron ` +
+        `en un cálculo de pagos (espejo id: ${enEspejo.map((f: any) => f.pago_espejo_id).join(", ")}). ` +
+        `Ese monto ya quedó congelado para liquidar: hay que liquidar o descartar el espejo antes de revertir el pago.`
+    );
+  }
+
+  // 4. Ninguna foto los tomó y ninguno se pagó: se borran.
+  await executor
+    .delete(abonos_capital)
+    .where(eq(abonos_capital.pago_id, pago_id));
+
+  return {
+    success: true,
+    message: "Abonos a capital del pago revertidos",
+    data: {
+      pago_id,
+      borrados: filas.map((f: any) => ({
+        abono_id: f.abono_id,
+        inversionista_id: f.inversionista_id,
+        monto: f.monto,
+        tipo: f.tipo,
+      })),
+    },
+  };
 }
 
 /**

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -2484,6 +2484,30 @@ export async function revertirLiquidacion(liquidacion_id: number) {
     }
 
     // ──────────────────────────────────────────────
+    // PASO 4.5: Reabrir los abonos a capital que esta liquidación cerró
+    //   Los espejos vuelven a NO_LIQUIDADO, así que sus abonos tienen que volver
+    //   a estar abiertos: la próxima liquidación los paga de nuevo.
+    //
+    //   Sin esto quedan liquidado=true para siempre y:
+    //     - nunca se le vuelven a pagar al inversionista,
+    //     - el reporte no los ve (quedan con liquidacion_id=NULL),
+    //     - el portero de revertirAbonoCapitalEspejo los da por pagados y bloquea
+    //       el reverso del pago.
+    //
+    //   `pago_espejo_id` NO se limpia: la fila de espejo sigue existiendo y sigue
+    //   teniendo ese monto congelado, solo que ahora sin liquidar.
+    //
+    //   Va ANTES del PASO 8 (borrar la liquidación): después, el FK
+    //   ON DELETE SET NULL limpia el liquidacion_id y ya no hay cómo encontrarlos.
+    const abonosReabiertos = await tx
+      .update(abonos_capital)
+      .set({ liquidado: false, liquidacion_id: null, updated_at: new Date() })
+      .where(eq(abonos_capital.liquidacion_id, liquidacion_id))
+      .returning({ abono_id: abonos_capital.abono_id });
+
+    console.log(`  ✅ ${abonosReabiertos.length} abono(s) a capital reabiertos`);
+
+    // ──────────────────────────────────────────────
     // PASO 5: Revertir cuotas del crédito
     //   Marcamos liquidado_inversionistas = false y limpiamos fecha
     // ──────────────────────────────────────────────

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3990,7 +3990,11 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
         if (creditoIdsLiquidados.length > 0) {
           const abonosCerrados = await tx
             .update(abonos_capital)
-            .set({ liquidado: true, updated_at: new Date() })
+            .set({
+              liquidado: true,
+              liquidacion_id: liquidacion.liquidacion_id,
+              updated_at: new Date(),
+            })
             .where(
               and(
                 eq(abonos_capital.inversionista_id, inv_id),

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3974,20 +3974,21 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
         // de liquidación creado. También se cierran los abonos a capital asociados
         // y se marca cada cuota como pagada al inversionista para que no vuelva a
         // procesarse en futuras ejecuciones.
-        // Se cierran TODOS los abonos abiertos de los pares (crédito, inversionista)
-        // que entraron en esta liquidación, no solo el que apunta `abono_capital_id`.
-        // Motivo: calcularYRegistrarPagosEspejo suma al espejo TODAS las filas
-        // abiertas del par (payments.ts) pero solo linkea la primera. Ahora que
-        // cada pago inserta su propia fila, cerrar solo la linkeada dejaría a las
-        // hermanas abiertas y la próxima liquidación se las volvería a pagar.
-        const creditoIdsLiquidados = [
-          ...new Set(
-            pagosNoLiquidados
-              .map((p) => p.credito_id)
-              .filter((id): id is number => id != null)
-          ),
-        ];
-        if (creditoIdsLiquidados.length > 0) {
+        // Se cierran EXACTAMENTE los abonos que estas filas de espejo consumieron
+        // (`pago_espejo_id`), que son los que se pagaron: el monto liquidado sale
+        // de `p.abono_capital`, la foto que el espejo congeló al generarse.
+        //
+        // No se cierra por par (crédito, inversionista): un abono nacido DESPUÉS
+        // de esa foto no está en el monto pagado — el espejo no se regenera
+        // mientras haya uno sin liquidar (payments.ts) — así que cerrarlo lo
+        // dejaría cobrado sin haberse pagado y el inversionista nunca vería esa
+        // plata. Sin marca queda abierto y lo toma el siguiente calcular pagos.
+        //
+        // Tampoco se cierra solo el de `abono_capital_id`: ese link es una sola
+        // casilla y apunta a uno, pero el espejo sumó todos los abiertos del par.
+        // Cerrar solo ese dejaría a las hermanas abiertas y la próxima liquidación
+        // se las volvería a pagar.
+        if (pagosIds.length > 0) {
           const abonosCerrados = await tx
             .update(abonos_capital)
             .set({
@@ -3997,8 +3998,7 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
             })
             .where(
               and(
-                eq(abonos_capital.inversionista_id, inv_id),
-                inArray(abonos_capital.credito_id, creditoIdsLiquidados),
+                inArray(abonos_capital.pago_espejo_id, pagosIds),
                 eq(abonos_capital.liquidado, false)
               )
             )

--- a/apps/cartera-back/src/controllers/investor.ts
+++ b/apps/cartera-back/src/controllers/investor.ts
@@ -3974,19 +3974,32 @@ export async function liquidateByInvestorId(inversionista_id?: number, fechaLiqu
         // de liquidación creado. También se cierran los abonos a capital asociados
         // y se marca cada cuota como pagada al inversionista para que no vuelva a
         // procesarse en futuras ejecuciones.
-        const abonoIdsALiquidar = [
+        // Se cierran TODOS los abonos abiertos de los pares (crédito, inversionista)
+        // que entraron en esta liquidación, no solo el que apunta `abono_capital_id`.
+        // Motivo: calcularYRegistrarPagosEspejo suma al espejo TODAS las filas
+        // abiertas del par (payments.ts) pero solo linkea la primera. Ahora que
+        // cada pago inserta su propia fila, cerrar solo la linkeada dejaría a las
+        // hermanas abiertas y la próxima liquidación se las volvería a pagar.
+        const creditoIdsLiquidados = [
           ...new Set(
             pagosNoLiquidados
-              .map((p) => p.abono_capital_id)
+              .map((p) => p.credito_id)
               .filter((id): id is number => id != null)
           ),
         ];
-        if (abonoIdsALiquidar.length > 0) {
-          await tx
+        if (creditoIdsLiquidados.length > 0) {
+          const abonosCerrados = await tx
             .update(abonos_capital)
             .set({ liquidado: true, updated_at: new Date() })
-            .where(inArray(abonos_capital.abono_id, abonoIdsALiquidar));
-          console.log(`  ✅ ${abonoIdsALiquidar.length} abono(s) a capital marcados como liquidados`);
+            .where(
+              and(
+                eq(abonos_capital.inversionista_id, inv_id),
+                inArray(abonos_capital.credito_id, creditoIdsLiquidados),
+                eq(abonos_capital.liquidado, false)
+              )
+            )
+            .returning({ abono_id: abonos_capital.abono_id });
+          console.log(`  ✅ ${abonosCerrados.length} abono(s) a capital marcados como liquidados`);
         }
 
         // Marcar cuotas como liquidado_inversionistas

--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -66,8 +66,7 @@ mock.module("../database/index", () => {
     return { innerJoin, leftJoin, where };
   };
 
-  return {
-    db: {
+  const mockDbInstance: any = {
       select: mock((fields: any) => {
         const isSelectNoFields = !fields || Object.keys(fields).length === 0;
         let isMainQuery = false;
@@ -113,6 +112,11 @@ mock.module("../database/index", () => {
           where: () => Promise.resolve()
         })
       })),
+      // insertPagosCreditoInversionistas mete el insert del espejo y el marcado
+      // de los abonos en una transacción, para que no puedan quedar sueltos.
+      // El mock corre el callback con el mismo `db`: acá no se prueba el
+      // rollback, solo que el flujo siga funcionando.
+      transaction: mock(async (cb: any) => cb(mockDbInstance)),
       query: {
         creditos_inversionistas_espejo: {
           findMany: mock(() => Promise.resolve(
@@ -147,8 +151,9 @@ mock.module("../database/index", () => {
           }))
         }
       }
-    }
   };
+
+  return { db: mockDbInstance };
 });
 
 // Mock @cci/email

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -993,35 +993,47 @@ export async function insertPagosCreditoInversionistas(
     ({ _abonoIdsConsumidos, ...fila }) => fila
   );
 
-  const filasInsertadas = await db
-    .insert(pagos_credito_inversionistas_espejo)
-    .values(filas)
-    .returning({
-      id: pagos_credito_inversionistas_espejo.id,
-      inversionista_id: pagos_credito_inversionistas_espejo.inversionista_id,
-    });
+  // 5. Insertar el espejo y marcar los abonos que consumió, ATADOS en una sola
+  //    transacción: o se guardan los dos o ninguno.
+  //
+  //    🔴 Van juntos y no sueltos porque la marca (`pago_espejo_id`) es lo único
+  //    que dice "este abono ya entró en una foto que se va a pagar". Si el espejo
+  //    quedara guardado con el monto adentro pero los abonos sin marcar (falla el
+  //    update, se cae la conexión, se reinicia el proceso), la liquidación —que
+  //    cierra SOLO los marcados— los dejaría abiertos: se pagarían con esta foto
+  //    y el siguiente cálculo los agarraría de nuevo, pagándole DOS VECES el
+  //    mismo capital al inversionista.
+  //
+  //    Atados, si se rompe en el medio no queda foto tampoco y el cálculo se
+  //    rehace limpio la próxima vez.
+  await db.transaction(async (tx) => {
+    const filasInsertadas = await tx
+      .insert(pagos_credito_inversionistas_espejo)
+      .values(filas)
+      .returning({
+        id: pagos_credito_inversionistas_espejo.id,
+        inversionista_id: pagos_credito_inversionistas_espejo.inversionista_id,
+      });
 
-  // 5. Marcar los abonos que cada fila consumió. Sin esta marca la liquidación
-  //    no sabe cuáles se pagaron de verdad: cerraría también los que nacieron
-  //    después de esta foto, y esa plata no se le pagaría nunca al inversionista.
-  //    Se matchea por inversionista_id (hay una fila por inversionista) y no por
-  //    índice, para no depender del orden que devuelve el INSERT.
-  for (const insertada of filasInsertadas) {
-    const origen = resolvedInserts.find(
-      (r) => r.inversionista_id === insertada.inversionista_id
-    );
-    const abonoIds = origen?._abonoIdsConsumidos ?? [];
-    if (abonoIds.length === 0) continue;
+    // Se matchea por inversionista_id (hay una fila por inversionista) y no por
+    // índice, para no depender del orden que devuelve el INSERT.
+    for (const insertada of filasInsertadas) {
+      const origen = resolvedInserts.find(
+        (r) => r.inversionista_id === insertada.inversionista_id
+      );
+      const abonoIds = origen?._abonoIdsConsumidos ?? [];
+      if (abonoIds.length === 0) continue;
 
-    await db
-      .update(abonos_capital)
-      .set({ pago_espejo_id: insertada.id, updated_at: new Date() })
-      .where(inArray(abonos_capital.abono_id, abonoIds));
+      await tx
+        .update(abonos_capital)
+        .set({ pago_espejo_id: insertada.id, updated_at: new Date() })
+        .where(inArray(abonos_capital.abono_id, abonoIds));
 
-    console.log(
-      `   🔖 ${abonoIds.length} abono(s) marcados como consumidos por el espejo ${insertada.id}`
-    );
-  }
+      console.log(
+        `   🔖 ${abonoIds.length} abono(s) marcados como consumidos por el espejo ${insertada.id}`
+      );
+    }
+  });
 
   return filas;
 }

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -895,6 +895,10 @@ export async function insertPagosCreditoInversionistas(
       );
 
     let abonoCapitalId: number | null = null;
+    // Abonos que esta fila de espejo consume (los que suma en su abono_capital).
+    // Se marcan con el id de la fila después del insert: son "los que entraron en
+    // la foto" y por lo tanto los únicos que la liquidación puede cerrar.
+    let abonoIdsConsumidos: number[] = [];
     if (abonosNoLiquidados.length > 0) {
       if (inv.status_inversionista === "pendiente_devolucion" || aplicarDevolucionCube) {
         // 🆕 Si está en pendiente_devolucion o el crédito usa devolucion_cube,
@@ -919,6 +923,8 @@ export async function insertPagosCreditoInversionistas(
           abono_capital = abono_capital.plus(montoAbono);
         }
         abonoCapitalId = abonosNoLiquidados[0].abono_id;
+        // Todos, no solo el linkeado: el abono_capital de arriba los sumó a todos.
+        abonoIdsConsumidos = abonosNoLiquidados.map((a) => a.abono_id);
 
         console.log(`   💰 Abono a capital encontrado (id: ${abonoCapitalId}): +${montoAbono.toFixed(6)} (tipo: ${abonosNoLiquidados[0].tipo})`);
         console.log(`      abono_capital con abono sumado: ${abono_capital.toString()}`);
@@ -961,6 +967,8 @@ export async function insertPagosCreditoInversionistas(
       estado_liquidacion: "NO_LIQUIDADO" as const,
       abono_capital_id: abonoCapitalId,
       fecha_pago: fechaDelPeriodo,
+      // No es columna del espejo: se separa antes del insert (ver abajo).
+      _abonoIdsConsumidos: abonoIdsConsumidos,
     };
 
     console.log(`   ✅ Resultado final para ${inv.nombre}:`, {
@@ -980,11 +988,42 @@ export async function insertPagosCreditoInversionistas(
   // 4. Insertar todos los registros (ESPEJO)
   const resolvedInserts = await Promise.all(inserts);
 
-  await db
-    .insert(pagos_credito_inversionistas_espejo)
-    .values(resolvedInserts);
+  // `_abonoIdsConsumidos` es interno, no es columna: se separa antes del insert.
+  const filas = resolvedInserts.map(
+    ({ _abonoIdsConsumidos, ...fila }) => fila
+  );
 
-  return resolvedInserts;
+  const filasInsertadas = await db
+    .insert(pagos_credito_inversionistas_espejo)
+    .values(filas)
+    .returning({
+      id: pagos_credito_inversionistas_espejo.id,
+      inversionista_id: pagos_credito_inversionistas_espejo.inversionista_id,
+    });
+
+  // 5. Marcar los abonos que cada fila consumió. Sin esta marca la liquidación
+  //    no sabe cuáles se pagaron de verdad: cerraría también los que nacieron
+  //    después de esta foto, y esa plata no se le pagaría nunca al inversionista.
+  //    Se matchea por inversionista_id (hay una fila por inversionista) y no por
+  //    índice, para no depender del orden que devuelve el INSERT.
+  for (const insertada of filasInsertadas) {
+    const origen = resolvedInserts.find(
+      (r) => r.inversionista_id === insertada.inversionista_id
+    );
+    const abonoIds = origen?._abonoIdsConsumidos ?? [];
+    if (abonoIds.length === 0) continue;
+
+    await db
+      .update(abonos_capital)
+      .set({ pago_espejo_id: insertada.id, updated_at: new Date() })
+      .where(inArray(abonos_capital.abono_id, abonoIds));
+
+    console.log(
+      `   🔖 ${abonoIds.length} abono(s) marcados como consumidos por el espejo ${insertada.id}`
+    );
+  }
+
+  return filas;
 }
 
 export async function insertPagosCreditoInversionistasV2(

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2790,9 +2790,10 @@ export async function aplicarAbonoCapitalInversionistas(
 ) {
   console.log("\n💵 ========== APLICANDO ABONO A CAPITAL ==========");
 
-  // Distribuir abono a capital en tabla espejo
+  // Distribuir abono a capital en tabla espejo. El pago_id deja cada fila
+  // amarrada a este pago, para poder revertirla si el pago se reversa.
   try {
-    await distribuirAbonoCapitalEspejo(credito_id, abono_capital);
+    await distribuirAbonoCapitalEspejo(credito_id, abono_capital, "CAPITAL", pago_id);
     console.log("✅ Abono distribuido en tabla abonos_capital (espejo)");
   } catch (err) {
     console.error("⚠️ Error al distribuir abono en espejo:", err);

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2792,12 +2792,14 @@ export async function aplicarAbonoCapitalInversionistas(
 
   // Distribuir abono a capital en tabla espejo. El pago_id deja cada fila
   // amarrada a este pago, para poder revertirla si el pago se reversa.
-  try {
-    await distribuirAbonoCapitalEspejo(credito_id, abono_capital, "CAPITAL", pago_id);
-    console.log("✅ Abono distribuido en tabla abonos_capital (espejo)");
-  } catch (err) {
-    console.error("⚠️ Error al distribuir abono en espejo:", err);
-  }
+  //
+  // 🔴 SIN try/catch a propósito: si esto falla, aplicar el pago NO puede seguir.
+  // Antes se tragaba el error y continuaba como si nada: al crédito se le bajaba
+  // el capital pero el inversionista nunca recibía su abono — le desaparecía la
+  // plata, sin que nadie se enterara salvo por un console.error.
+  // Es el mismo bug que teníamos del lado del reverso.
+  await distribuirAbonoCapitalEspejo(credito_id, abono_capital, "CAPITAL", pago_id);
+  console.log("✅ Abono distribuido en tabla abonos_capital (espejo)");
 
   const abonoCapitalBig = new Big(abono_capital);
   console.log(`💵 Abono Total: ${abonoCapitalBig.toString()}`);

--- a/apps/cartera-back/src/controllers/reportes.ts
+++ b/apps/cartera-back/src/controllers/reportes.ts
@@ -853,20 +853,21 @@ export async function getReinversionLiquidaciones({
     (cubeRows.rows[0] as Record<string, unknown>)?.interes_cube ?? 0
   );
 
-  // Pagos extras recibidos (abonos a capital / cancelaciones) que fluyen desde
-  // las liquidaciones del mes: liquidación → pago espejo → abono.
-  // Cada abono se cuenta una sola vez (DISTINCT) aunque tenga varios pagos espejo.
+  // Pagos extras recibidos (abonos a capital / cancelaciones) de las
+  // liquidaciones del mes, leídos directo del abono.
+  //
+  // Antes se llegaba al abono por `espejo.abono_capital_id`, pero esa es una
+  // sola casilla: apunta a UN abono. Mientras hubo una fila por par
+  // (crédito, inversionista) daba igual — ese uno era todo. Ahora que cada pago
+  // inserta su propia fila, ir por el link se comía las hermanas y subcontaba.
+  // `abonos_capital.liquidacion_id` se setea al cerrar el abono, así que no hace
+  // falta el rodeo ni el DISTINCT.
   const extrasRows = await db.execute(sql`
     SELECT a.tipo, COALESCE(SUM(a.monto::numeric), 0) AS total
     FROM cartera.abonos_capital a
-    WHERE a.abono_id IN (
-      SELECT DISTINCT e.abono_capital_id
-      FROM cartera.pagos_credito_inversionistas_espejo e
-      JOIN cartera.liquidaciones l ON l.liquidacion_id = e.liquidacion_id
-      WHERE e.abono_capital_id IS NOT NULL
-        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
-        AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
-    )
+    JOIN cartera.liquidaciones l ON l.liquidacion_id = a.liquidacion_id
+    WHERE (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date >= ${inicioMes}::date
+      AND (l.fecha_liquidacion AT TIME ZONE 'America/Guatemala')::date < ${inicioMesSiguiente}::date
     GROUP BY a.tipo
   `);
 

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -153,6 +153,24 @@ export const reversePayment = async ({ body, set }: any) => {
       console.log("✅ Usuario encontrado");
 
       // ======================================================================
+      // 4️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
+      // ======================================================================
+      // Borra las filas que ESTE pago generó (van marcadas con su pago_id); si no
+      // generó ninguna, no hace nada: el pago_id ya dice la verdad.
+      //
+      // Tira error si el abono ya se liquidó o si ya entró en un cálculo de
+      // pagos, y ahí el reverso no puede seguir.
+      //
+      // 🔴 VA ACÁ, LO MÁS TEMPRANO POSIBLE, Y NO MÁS ABAJO: de acá para adelante
+      // hay tres cosas que escriben FUERA de esta transacción (usan el `db`
+      // global, no el `tx`): updateMora (6️⃣), reverseConvenioPayment (6️⃣.5️⃣) y
+      // processAndReplaceCreditInvestorsReverse (8️⃣). Si el portero tirara
+      // después de ellas, el rollback NO las desharía: el pago quedaría sin
+      // revertir pero la mora, el convenio y el saldo del inversionista ya
+      // habrían cambiado. Se aborta antes de tocar nada.
+      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
+
+      // ======================================================================
       // 5️⃣ RECALCULAR VALORES DEL CRÉDITO (solo si cuota está pagada)
       // ======================================================================
       let nuevoCapital = new Big(creditData.creditos.capital ?? 0);
@@ -254,15 +272,6 @@ export const reversePayment = async ({ body, set }: any) => {
         pago_id,
       );
       console.log("✅ Inversiones reversadas correctamente");
-
-      // ======================================================================
-      // 8️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
-      // ======================================================================
-      // Borra las filas que ESTE pago generó (van marcadas con su pago_id). Si
-      // el pago no generó ninguna, no hace nada: el pago_id ya dice la verdad.
-      // Tira error (y voltea esta transacción) si el abono ya se liquidó o si ya
-      // entró en un cálculo de pagos: en esos casos el reverso no puede seguir.
-      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
 
       // ======================================================================
       // 9️⃣ DEVOLVER ABONOS A LOS "RESTANTES" DEL PAGO

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -259,16 +259,10 @@ export const reversePayment = async ({ body, set }: any) => {
       // 8️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
       // ======================================================================
       // Borra las filas que ESTE pago generó (van marcadas con su pago_id). Si
-      // el pago no generó ninguna, la función no hace nada: no hace falta
-      // filtrar por estado del pago, el pago_id ya dice la verdad.
+      // el pago no generó ninguna, no hace nada: el pago_id ya dice la verdad.
+      // Tira error (y voltea esta transacción) si el abono ya se liquidó o si ya
+      // entró en un cálculo de pagos: en esos casos el reverso no puede seguir.
       const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
-
-      if (reversionEspejo?.data?.omitidos?.length) {
-        console.warn(
-          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
-          reversionEspejo.data.omitidos,
-        );
-      }
 
       // ======================================================================
       // 9️⃣ DEVOLVER ABONOS A LOS "RESTANTES" DEL PAGO
@@ -793,7 +787,11 @@ try {
       error.message === "Payment is not marked as paid" ||
       error.message === "Credit not found or not active" ||
       error.message === "Incobrable structural row cannot be reversed" ||
-      error.message === "User not found"
+      error.message === "User not found" ||
+      // Porteros del abono a capital: no es una falla del sistema, es que este
+      // pago no se puede revertir hasta resolver el abono a mano.
+      error.message?.startsWith("[ABONO_YA_LIQUIDADO]") ||
+      error.message?.startsWith("[ABONO_EN_CALCULO_PENDIENTE]")
     ) {
       set.status = 400;
     } else {

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -15,6 +15,7 @@ import {
   facturas_electronicas,
 } from "../database/db";
 import { processAndReplaceCreditInvestorsReverse } from "./investor";
+import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { updateMora } from "./latefee";
 import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
@@ -253,6 +254,21 @@ export const reversePayment = async ({ body, set }: any) => {
         pago_id,
       );
       console.log("✅ Inversiones reversadas correctamente");
+
+      // ======================================================================
+      // 8️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
+      // ======================================================================
+      // Borra las filas que ESTE pago generó (van marcadas con su pago_id). Si
+      // el pago no generó ninguna, la función no hace nada: no hace falta
+      // filtrar por estado del pago, el pago_id ya dice la verdad.
+      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
+
+      if (reversionEspejo?.data?.omitidos?.length) {
+        console.warn(
+          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
+          reversionEspejo.data.omitidos,
+        );
+      }
 
       // ======================================================================
       // 9️⃣ DEVOLVER ABONOS A LOS "RESTANTES" DEL PAGO
@@ -693,6 +709,7 @@ export const reversePayment = async ({ body, set }: any) => {
         facturasAnuladas,
         facturasConError,
         totalFacturas: facturasDelPago.length,
+        reversionEspejo,
       };
     });
 try {
@@ -747,6 +764,8 @@ try {
           usuario_id: result.user.usuario_id,
           saldo_a_favor: result.nuevoSaldoAFavor.toString(),
         },
+        // Presente solo si el pago era un abono directo a capital.
+        abonoCapitalEspejo: result.reversionEspejo?.data ?? undefined,
         // 🆕 Info de facturas anuladas
         facturas:
           result.totalFacturas > 0

--- a/apps/cartera-back/src/controllers/revertPaymentToPending.ts
+++ b/apps/cartera-back/src/controllers/revertPaymentToPending.ts
@@ -10,6 +10,7 @@ import {
   facturas_electronicas,
 } from "../database/db";
 import { processAndReplaceCreditInvestorsReverse } from "./investor";
+import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { anularFacturaEnCofidi } from "./reversePayment";
 
 // ============================================================================
@@ -96,6 +97,20 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
 
       console.log("✅ Crédito encontrado y activo");
 
+      // 3️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
+      // Borra las filas que ESTE pago generó (marcadas con su pago_id); si no
+      // generó ninguna, no hace nada. Va ANTES del branch de `pagoValidado`
+      // porque ese solo mira `validated`, así que un abono a capital se iría
+      // por el early-return de abajo sin revertirse.
+      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
+
+      if (reversionEspejo?.data?.omitidos?.length) {
+        console.warn(
+          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
+          reversionEspejo.data.omitidos,
+        );
+      }
+
       if (!pagoValidado) {
         console.log("ℹ️ El pago ya está en estado PENDIENTE. Solo se reversarán las inversiones.");
         
@@ -106,6 +121,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
           credito_id,
           numero_credito_sifco: creditData.numero_credito_sifco,
           cuota: creditData.cuota,
+          abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
           message: "Inversiones reversadas exitosamente (el pago ya estaba pendiente)"
         };
       }
@@ -248,6 +264,7 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
         nuevoCapital: nuevoCapital.toString(),
         facturasAnuladas,
         facturasConError,
+        abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
         numero_credito_sifco: creditData.numero_credito_sifco,
         cuota: creditData.cuota
       };

--- a/apps/cartera-back/src/controllers/revertPaymentToPending.ts
+++ b/apps/cartera-back/src/controllers/revertPaymentToPending.ts
@@ -10,7 +10,6 @@ import {
   facturas_electronicas,
 } from "../database/db";
 import { processAndReplaceCreditInvestorsReverse } from "./investor";
-import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { anularFacturaEnCofidi } from "./reversePayment";
 
 // ============================================================================
@@ -97,19 +96,14 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
 
       console.log("✅ Crédito encontrado y activo");
 
-      // 3️⃣.5️⃣ REVERSAR EL ABONO A CAPITAL DEL ESPEJO (abonos_capital)
-      // Borra las filas que ESTE pago generó (marcadas con su pago_id); si no
-      // generó ninguna, no hace nada. Va ANTES del branch de `pagoValidado`
-      // porque ese solo mira `validated`, así que un abono a capital se iría
-      // por el early-return de abajo sin revertirse.
-      const reversionEspejo = await revertirAbonoCapitalEspejo(pago_id, tx);
-
-      if (reversionEspejo?.data?.omitidos?.length) {
-        console.warn(
-          `⚠️ Abono a capital NO revertido del todo en el espejo (revisar a mano):`,
-          reversionEspejo.data.omitidos,
-        );
-      }
+      // Ojo: acá NO se revierten los abonos a capital del espejo. `pagoValidado`
+      // solo reconoce `validated`, así que un `capital_validated` cae en el
+      // early-return de abajo sin devolver el capital ni cambiar de estado;
+      // borrarle los abonos antes lo dejaría a medias (abono borrado + pago
+      // todavía aplicado). Los pagos que esta ruta sí maneja (cuotas normales)
+      // nunca generan abonos, así que no hay nada que revertir.
+      // El reverso del abono vive en reversePayment.ts, que usa esPagoAplicado
+      // y sí reconoce los abonos directos a capital.
 
       if (!pagoValidado) {
         console.log("ℹ️ El pago ya está en estado PENDIENTE. Solo se reversarán las inversiones.");
@@ -121,7 +115,6 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
           credito_id,
           numero_credito_sifco: creditData.numero_credito_sifco,
           cuota: creditData.cuota,
-          abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
           message: "Inversiones reversadas exitosamente (el pago ya estaba pendiente)"
         };
       }
@@ -264,7 +257,6 @@ export const revertPaymentToPending = async ({ body, set }: any) => {
         nuevoCapital: nuevoCapital.toString(),
         facturasAnuladas,
         facturasConError,
-        abonoCapitalEspejo: reversionEspejo?.data ?? undefined,
         numero_credito_sifco: creditData.numero_credito_sifco,
         cuota: creditData.cuota
       };

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1708,6 +1708,19 @@
     monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
     tipo: tipoAbonoEnum("tipo").notNull(),
     liquidado: boolean("liquidado").notNull().default(false),
+    // Fila de espejo que YA consumió este abono (lo sumó en su `abono_capital`).
+    // Se setea al generar el espejo. Es la marca de "este abono entró en la foto":
+    // el espejo congela el monto a pagar y no se regenera mientras haya uno sin
+    // liquidar, así que un abono que nace DESPUÉS no está en esa foto, no se paga
+    // en esa liquidación y debe quedar abierto para el siguiente ciclo.
+    // La liquidación cierra solo los marcados con las filas que liquida.
+    //
+    // Sin `.references()` a propósito: `pagos_credito_inversionistas_espejo` ya
+    // apunta acá con `abono_capital_id`, y declarar la vuelta en Drizzle deja las
+    // dos tablas referenciándose entre sí — TypeScript no puede inferir el tipo y
+    // el schema entero se cae a `any`. El FK real (con ON DELETE SET NULL) se crea
+    // en la migración 0021; Drizzle no lo necesita para consultar.
+    pago_espejo_id: integer("pago_espejo_id"),
     // Liquidación en la que se cerró este abono. Se setea junto con
     // `liquidado`. Hace explícito lo que antes había que deducir dando la
     // vuelta por `pagos_credito_inversionistas_espejo.abono_capital_id`, que al

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1708,11 +1708,21 @@
     monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
     tipo: tipoAbonoEnum("tipo").notNull(),
     liquidado: boolean("liquidado").notNull().default(false),
+    // Liquidación en la que se cerró este abono. Se setea junto con
+    // `liquidado`. Hace explícito lo que antes había que deducir dando la
+    // vuelta por `pagos_credito_inversionistas_espejo.abono_capital_id`, que al
+    // ser una sola casilla solo apunta a un abono: con varias filas por par
+    // (una por pago) los reportes que iban por ahí subcontaban.
+    liquidacion_id: integer("liquidacion_id").references(
+      () => liquidaciones.liquidacion_id,
+      { onDelete: "set null" }
+    ),
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
   }, (t) => ({
     ixPago: index("ix_abonos_capital_pago_id").on(t.pago_id),
     ixCredInv: index("ix_abonos_capital_cred_inv").on(t.credito_id, t.inversionista_id),
+    ixLiquidacion: index("ix_abonos_capital_liquidacion_id").on(t.liquidacion_id),
   }));
 
   export const historico_liquidaciones_espejo = customSchema.table(

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1736,6 +1736,19 @@
     ixPago: index("ix_abonos_capital_pago_id").on(t.pago_id),
     ixCredInv: index("ix_abonos_capital_cred_inv").on(t.credito_id, t.inversionista_id),
     ixLiquidacion: index("ix_abonos_capital_liquidacion_id").on(t.liquidacion_id),
+    ixPagoEspejo: index("ix_abonos_capital_pago_espejo_id").on(t.pago_espejo_id),
+    // Un pago aporta UNA fila por inversionista. Deja de ser una convención del
+    // código y pasa a ser una garantía de la base: si dos aplicaciones del mismo
+    // pago corren a la vez, la segunda revienta en vez de duplicar el abono y
+    // restarle el capital dos veces al inversionista.
+    //
+    // Las filas con `pago_id` NULL (las previas a la migración y las CANCELACION
+    // de devolución/reset, que no nacen de un pago) NO chocan entre sí: en
+    // Postgres los NULL no colisionan en un índice único.
+    uxPagoInversionista: uniqueIndex("ux_abonos_capital_pago_inversionista").on(
+      t.pago_id,
+      t.inversionista_id
+    ),
   }));
 
   export const historico_liquidaciones_espejo = customSchema.table(

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -1696,12 +1696,24 @@
     inversionista_id: integer("inversionista_id")
       .notNull()
       .references(() => inversionistas.inversionista_id),
+    // Pago que generó este abono. Una fila por (pago, inversionista): NO se
+    // acumula, así revertir el pago es borrar exactamente sus filas.
+    // Nullable a propósito: las filas previas a esta columna, las CANCELACION
+    // (devolución/reset, que no nacen de un pago) y el alta manual por API no
+    // tienen pago. CASCADE: si el pago se borra (reversePayment borra los
+    // parciales), su abono se va con él en vez de quedar huérfano.
+    pago_id: integer("pago_id").references(() => pagos_credito.pago_id, {
+      onDelete: "cascade",
+    }),
     monto: numeric("monto", { precision: 18, scale: 6 }).notNull(),
     tipo: tipoAbonoEnum("tipo").notNull(),
     liquidado: boolean("liquidado").notNull().default(false),
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),
-  });
+  }, (t) => ({
+    ixPago: index("ix_abonos_capital_pago_id").on(t.pago_id),
+    ixCredInv: index("ix_abonos_capital_cred_inv").on(t.credito_id, t.inversionista_id),
+  }));
 
   export const historico_liquidaciones_espejo = customSchema.table(
     "historico_liquidaciones_espejo",


### PR DESCRIPTION
## Qué arregla

Cuando se revertía un pago, el sistema le devolvía el capital al crédito y anulaba la factura — **pero la libreta del inversionista quedaba intacta**. La plata seguía anotada ahí como si el pago existiera, y nadie la sacaba nunca.

Ejemplo real: el crédito 404 tiene un abono de Q810 a nombre del inversionista 30 desde el 20 de abril, y el pago que lo generó ya ni existe.

## Por qué no era tan simple

Cada inversionista tenía **una sola libreta** por crédito, y cada pago **sumaba** encima. Una libreta = varios pagos mezclados.

Entonces no existía "el abono de ese pago" para borrar. Si borrabas la libreta, le sacabas también la plata de los otros pagos, que están bien.

```
Pago A → Ana: Q600
Pago B → Ana: Q300
Libreta de Ana: Q900   ← un solo número, no se sabe qué es de quién
```

## Qué cambia

**Ahora cada pago escribe su propio renglón.** Revertir el pago = borrar su renglón. Sin riesgo, porque ese renglón es solo suyo: los otros pagos ni se enteran.

## Cuándo NO se deja revertir

Si el abono ya está comprometido, el reverso **se frena con un mensaje claro** en vez de romper algo:

- **Ya se le pagó al inversionista** → esa plata ya salió, no se puede deshacer sola.
- **Ya entró en un cálculo de pagos** → ese monto ya quedó congelado para liquidar.

En los dos casos hay que resolverlo a mano primero. El sistema no adivina.

## Qué se tocó de calcular pagos y liquidación

Esto es lo que el equipo preguntó. **El monto que se le paga al inversionista no cambia en ningún caso.**

| Flujo | ¿Cambia lo que se paga? | Qué cambia |
|---|---|---|
| **Calcular pagos** | **No** | Solo anota qué abonos entraron en ese cálculo |
| **Liquidar** | **No** | Solo a cuáles se les pone "ya pagado" |
| **Revertir liquidación** | **No** | Ahora reabre los abonos (antes quedaban cerrados para siempre) |

**Por qué había que tocar el cierre de la liquidación:** al haber varios renglones por inversionista, el sistema cerraba solo el primero. Los otros quedaban abiertos y **la liquidación siguiente se los volvía a pagar**. Ir juntos no es opcional.

**De yapa arregla un bug que ya estaba:** al revertir una liquidación, los abonos quedaban cerrados para siempre y **nunca se le volvían a pagar al inversionista**.

## Qué NO se toca

- **Créditos sin abonos a capital** → no les pasa absolutamente nada.
- **Pagos de cuota normales** → nunca crearon abonos, ni se enteran.
- **El reporte que sale al liquidar** (el del inversionista) → intacto.
- **El monto que se paga**, el histórico, las cuotas, las validaciones → todo igual.

Solo entran los pagos de **abono directo a capital**.

## Un reporte que había que ajustar

El reporte mensual de reinversión sumaba mal (de menos) al haber varios renglones. Ya está corregido y **verificado contra producción: los 4 meses con datos dan idéntico**.

## Antes de mergear

- ⚠️ **Hay 3 migraciones que correr** (dev y prod).
- ⚠️ **Este flujo no tiene tests automáticos.** Conviene probar a mano en dev: revertir un pago de abono a capital, y liquidar un crédito con 2 pagos de esos.
- **No corrige lo viejo**: es de acá en adelante. Los abonos ya huérfanos siguen como están.

## Cosas que aparecieron de paso (no son de este PR)

Se detectaron problemas que **ya existen hoy** en producción. No los toca este PR, quedan anotados para tratarlos aparte:

- Un abono que nace después de un cálculo de pagos se cierra sin haberse pagado.
- `falsePayment` puede generar cálculos duplicados.
- Algunas partes del reverso escriben fuera de la transacción, así que si algo falla quedan a medias.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
