### PR TITLE
feat(cobros): CRM server — carga de cuentas por asesor y bucket (CB-018)

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -4442,6 +4442,31 @@ export const cobrosRouter = {
 			return carteraBackClient.getPoolAsesoresPorBucket(input.bucket);
 		}),
 
+	// ────────────────────────────────────────────────────────────────────────
+	// CB-018 · Carga de cuentas por asesor y bucket (dashboard gerencial)
+	// ────────────────────────────────────────────────────────────────────────
+	getCargaPorAsesorBucket: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				// Rango del catálogo (0-5), igual que cartera-back (routers/buckets.ts,
+				// /buckets/carga) — validado en ambas capas para fallar rápido aquí en
+				// vez de depender del 400 que igual devolvería cartera-back.
+				bucket: z.number().int().min(0).max(5).optional(),
+				asesorId: z.number().int().positive().optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+			return carteraBackClient.getCargaPorAsesorBucket({
+				bucket: input.bucket,
+				asesor_id: input.asesorId,
+			});
+		}),
+
 	// Reasignación manual. Solo supervisor/gerente (cobrosSupervisorProcedure).
 	// El email del supervisor va a cartera-back para la bitácora API_MANUAL.
 	reasignarAsesorCredito: cobrosSupervisorProcedure

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -145,6 +145,7 @@ export const cobrosAppRouter = {
 	getBucketsHistorialCredito: cobrosRouter.getBucketsHistorialCredito,
 	getCreditosPorBucket: cobrosRouter.getCreditosPorBucket,
 	getPoolAsesoresPorBucket: cobrosRouter.getPoolAsesoresPorBucket,
+	getCargaPorAsesorBucket: cobrosRouter.getCargaPorAsesorBucket,
 	reasignarAsesorCredito: cobrosRouter.reasignarAsesorCredito,
 	getHistorialReasignaciones: cobrosRouter.getHistorialReasignaciones,
 	getHistorialPagos: cobrosRouter.getHistorialPagos,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -24,6 +24,7 @@ import type {
 	CreateCreditoInput,
 	CreatePagoInput,
 	CreateUsuarioInput,
+	CargaPorAsesorBucketResponse,
 	CreditActionInput,
 	CreditoBucketResponse,
 	CreditoDetailResponse,
@@ -34,6 +35,7 @@ import type {
 	GetAllCreditsParams,
 	GetAsesorHistorialParams,
 	GetBucketsHistorialParams,
+	GetCargaPorAsesorBucketParams,
 	GetCreditosPorBucketParams,
 	GetInvestorReportParams,
 	GetInvestorsParams,
@@ -1044,6 +1046,33 @@ export class CarteraBackClient {
 			total: response.totalCount,
 			totalPages: response.totalPages,
 		};
+	}
+
+	// CB-018: carga de cuentas por asesor y bucket (dashboard gerencial) —
+	// cuentas asignadas, capacidad base, % utilización, sobrecarga y alerta de
+	// nueva posición. Fuente de la página /cobros/carga del CRM.
+	// Sin cache (mismo criterio que getCreditosPorBucket, su hermana en
+	// /cobros/buckets): reasignarAsesor() NO invalida ningún substring que
+	// matchee "/buckets/carga" (solo invalida "/credito?", "getAllCredits",
+	// "stats", "mora-por-etapa-asesor") — cachear aquí dejaría el dashboard
+	// mostrando carga desactualizada hasta 5 min después de una reasignación,
+	// justo la pantalla donde gerencia decide en base al efecto de reasignar.
+	async getCargaPorAsesorBucket(
+		params: GetCargaPorAsesorBucketParams = {},
+	): Promise<CargaPorAsesorBucketResponse> {
+		const queryParams = new URLSearchParams({
+			...(params.bucket !== undefined && { bucket: String(params.bucket) }),
+			...(params.asesor_id !== undefined && {
+				asesor_id: String(params.asesor_id),
+			}),
+		});
+		const response = await this.request<{
+			success: boolean;
+			data: CargaPorAsesorBucketResponse;
+		}>(`/buckets/carga?${queryParams}`, { method: "GET" });
+		return (
+			response.data ?? { buckets: [], porAsesor: [], fecha: "" }
+		);
 	}
 
 	// Pool de asesores elegibles de un bucket (alimenta el dropdown del modal).

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -204,6 +204,57 @@ export interface GetCreditosPorBucketParams {
 	email_asesor?: string;
 }
 
+/** CB-018: filtros de GET /buckets/carga (carga por asesor y bucket). */
+export interface GetCargaPorAsesorBucketParams {
+	bucket?: number;
+	asesor_id?: number;
+}
+
+/**
+ * Detalle por asesor dentro de un bucket. Capacidad/% utilización/sobrecarga
+ * viven AQUÍ (ticket CB-018, confirmado con el informador: el techo de 300 es
+ * "la cantidad que puede atender un asesor", NO un agregado del bucket
+ * completo) — cada combinación asesor+bucket tiene su propio techo.
+ */
+export interface CargaPorAsesorBucketDetalle {
+	bucket: number;
+	cuentas: number;
+	capacidad_base: number;
+	utilizacion_pct: number;
+	elegible: boolean;
+	/** cuentas > capacidad_base (sin margen) — ya pasó su cupo nominal. */
+	sobrecarga: boolean;
+	/** cuentas > capacidad_base + margen (margen %/fijo configurable por fila) — señal de abrir plaza. */
+	alerta_nueva_posicion: boolean;
+	/** Umbral absoluto (capacidad_base + margen resuelto) a partir del cual esta fila entra en alerta_nueva_posicion. */
+	umbral_alerta_cuentas: number;
+}
+
+export interface CargaPorAsesor {
+	asesor_id: number;
+	nombre: string;
+	email_asesor: string | null;
+	porBucket: CargaPorAsesorBucketDetalle[];
+}
+
+/** Resumen informativo del bucket: totales y conteos de sus asesores en alerta/sobrecarga. */
+export interface CargaPorBucketResumen {
+	numero: number;
+	prefijo: string;
+	nombre: string;
+	color: string | null;
+	cuentas_totales: number;
+	asesores_en_pool: number;
+	asesores_en_alerta: number;
+	asesores_sobrecargados: number;
+}
+
+export interface CargaPorAsesorBucketResponse {
+	buckets: CargaPorBucketResumen[];
+	porAsesor: CargaPorAsesor[];
+	fecha: string;
+}
+
 export interface GetAsesorHistorialParams {
 	desde?: string; // YYYY-MM-DD
 	hasta?: string; // YYYY-MM-DD


### PR DESCRIPTION
## Resumen
Parte 2/3 de CB-018 (backend #1113, ya mergeado). Expone al CRM server la carga por asesor/bucket de cartera-back: cliente HTTP, tipos y procedure oRPC. **Ningún consumidor en el web todavía** — ese es el PR 3.

## Cambios
- `cartera-back-client.ts`: `getCargaPorAsesorBucket`. **Sin cache** (mismo criterio que `getCreditosPorBucket`, su hermana en `/cobros/buckets`): `reasignarAsesor` no invalida ningún substring que matchee `/buckets/carga`, así que cachear dejaría el dashboard con datos viejos justo tras reasignar.
- `cobros.ts` router: `getCargaPorAsesorBucket` bajo `cobrosSupervisorProcedure` (admin/cobros_supervisor). `bucket` con `.max(5)` — mismo rango que valida cartera-back, falla rápido en esta capa en vez de depender del 400 de abajo.
- `routers/index.ts`: wiring del procedure nuevo en `cobrosAppRouter`.
- `types/cartera-back.ts`: tipos de request/response, incluye `umbral_alerta_cuentas` por fila asesor+bucket (capacidad_base + margen resuelto) para que el frontend no recalcule la fórmula del margen.

## Test plan
- [x] `bunx tsc --noEmit` limpio
- [ ] Probar `getCargaPorAsesorBucket` con rol `cobros_supervisor` → 200; con rol `cobros` → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)