### PR TITLE
feat(portal-web): reemplazar tasa de interés por disclaimer de seguro/GPS en calculadora de crédito

### DIFF
--- a/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
+++ b/apps/portal-web/src/features/Marketplace/Sections/CalculatorCredit.tsx
@@ -180,12 +180,6 @@ export const CalculatorCredit = ({ standalone = false }: CalculatorCreditProps) 
                 <div className="rounded-lg mt-6 shadow-sm">
                   <div className="space-y-3">
                     <div className="flex justify-between items-center">
-                      <span className="text-white">Tasa de interés:</span>
-                      <span className="text-xl text-white font-semibold">
-                        {resultado.interes}%
-                      </span>
-                    </div>
-                    <div className="flex justify-between items-center">
                       <span className="text-primary">Pago mensual:</span>
                       <span className="text-xl text-primary font-semibold">
                         Q.
@@ -195,6 +189,9 @@ export const CalculatorCredit = ({ standalone = false }: CalculatorCreditProps) 
                       </span>
                     </div>
                   </div>
+                  <p className="text-xs text-white/40 mt-3 text-center">
+                    Seguro y GPS incluido en cuota, plazo: usado hasta 60 meses y nuevo hasta 84 meses.
+                  </p>
                   <p className="text-xs text-white/40 mt-3 text-center">
                     *Esta calculadora es una estimación referencial y puede variar según la evaluación y las condiciones finales del crédito.
                   </p>


### PR DESCRIPTION
## Resumen
- Se elimina la visualización de la "Tasa de interés" en la calculadora pública de crédito vehicular (`/calculadora` y `/credit`).
- Se agrega el disclaimer requerido por negocio: "Seguro y GPS incluido en cuota, plazo: usado hasta 60 meses y nuevo hasta 84 meses."

## Alcance
Solo afecta `CalculatorCredit.tsx` (calculadora pública de pre-venta). No se modificó `MyLoans` (`/loans`), donde la tasa de interés se mantiene visible por corresponder a información contractual de un crédito ya otorgado, no a una estimación publicitaria.

## Vista 
<img width="1032" height="383" alt="image" src="https://github.com/user-attachments/assets/6bef7405-72bc-4031-b284-7245eaa34e86" />
