### PR TITLE
feat(credit-analysis): fecha ideal de pago según ingresos del cliente

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_day.sql
+++ b/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_day.sql
@@ -1,4 +1,0 @@
--- Agrega la fecha ideal de pago sugerida por la IA al análisis de capacidad de pago.
--- Día del mes (1-31) según cuándo recibe ingresos el solicitante. Dato informativo;
--- el detalle (días detectados y justificación) vive en credit_analysis.full_analysis.
-ALTER TABLE "credit_analysis" ADD COLUMN IF NOT EXISTS "suggested_payment_day" integer;

--- a/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_day.sql
+++ b/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_day.sql
@@ -1,0 +1,4 @@
+-- Agrega la fecha ideal de pago sugerida por la IA al análisis de capacidad de pago.
+-- Día del mes (1-31) según cuándo recibe ingresos el solicitante. Dato informativo;
+-- el detalle (días detectados y justificación) vive en credit_analysis.full_analysis.
+ALTER TABLE "credit_analysis" ADD COLUMN IF NOT EXISTS "suggested_payment_day" integer;

--- a/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_days.sql
+++ b/apps/crm/apps/server/src/db/migrations/0025_add_suggested_payment_days.sql
@@ -1,0 +1,5 @@
+-- Agrega las fechas ideales de pago sugeridas por la IA al análisis de capacidad de pago.
+-- Hasta 3 candidatos rankeados con su % de recomendación (ej. [{"dia":5,"porcentaje":50}, ...]).
+-- Dato informativo; el detalle (días de ingreso detectados y justificación) vive en
+-- credit_analysis.full_analysis.
+ALTER TABLE "credit_analysis" ADD COLUMN IF NOT EXISTS "suggested_payment_days" jsonb;

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -275,6 +275,8 @@ export const creditAnalysis = pgTable("credit_analysis", {
 	maxPayment: decimal("max_payment", { precision: 12, scale: 2 }),
 	adjustedPayment: decimal("adjusted_payment", { precision: 12, scale: 2 }),
 	maxCreditAmount: decimal("max_credit_amount", { precision: 12, scale: 2 }),
+	// Fecha ideal de pago sugerida por la IA (día del mes 1-31, según cuándo recibe ingresos)
+	suggestedPaymentDay: integer("suggested_payment_day"),
 	// Control de intentos de análisis con IA (cada llamada a IA cuesta dinero)
 	attemptCount: integer("attempt_count").notNull().default(0), // Se incrementa al llamar a la IA
 	// Metadata

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -275,8 +275,10 @@ export const creditAnalysis = pgTable("credit_analysis", {
 	maxPayment: decimal("max_payment", { precision: 12, scale: 2 }),
 	adjustedPayment: decimal("adjusted_payment", { precision: 12, scale: 2 }),
 	maxCreditAmount: decimal("max_credit_amount", { precision: 12, scale: 2 }),
-	// Fecha ideal de pago sugerida por la IA (día del mes 1-31, según cuándo recibe ingresos)
-	suggestedPaymentDay: integer("suggested_payment_day"),
+	// Hasta 3 fechas ideales de pago sugeridas por la IA, rankeadas con % de recomendación
+	suggestedPaymentDays: jsonb("suggested_payment_days").$type<
+		Array<{ dia: number; porcentaje: number }>
+	>(),
 	// Control de intentos de análisis con IA (cada llamada a IA cuesta dinero)
 	attemptCount: integer("attempt_count").notNull().default(0), // Se incrementa al llamar a la IA
 	// Metadata

--- a/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
+++ b/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
@@ -34,7 +34,14 @@ export const bankStatementAnalysisSchema = z.object({
 	analisis_fecha_pago: z
 		.object({
 			dias_ingreso_detectados: z.array(z.number().int().min(1).max(31)),
-			dia_pago_sugerido: z.number().int().min(1).max(31),
+			dias_pago_sugeridos: z
+				.array(
+					z.object({
+						dia: z.number().int().min(1).max(31),
+						porcentaje: z.number().int().min(0).max(100),
+					}),
+				)
+				.length(3),
 			justificacion: z.string(),
 		})
 		.nullable()
@@ -76,8 +83,10 @@ Eres un analista de capacidad de pago para una financiera que otorga créditos p
 
 4. **analisis_fecha_pago**: Determina la fecha ideal de pago según CUÁNDO recibe ingresos el solicitante, analizando las FECHAS de las transacciones de crédito (no solo los totales). Devuelve:
    - dias_ingreso_detectados: Días del mes (1-31) en que se repiten sus ingresos recurrentes. Si es quincena, incluye ambos (ej. [15, 30]).
-   - dia_pago_sugerido: Día del mes (1-31) para la cuota, entre 1 y 5 días después de su ingreso recurrente de mayor monto, para no caer donde el dinero ya se gastó. En quincena, elige la que deje más liquidez. Devuelve el día real, no un valor fijo.
-   - justificacion: 1-2 frases justificando el día según el patrón detectado. Si el ingreso es irregular, elige el día más conservador y acláralo; no inventes precisión.
+   - dias_pago_sugeridos: SIEMPRE exactamente 3 candidatos de día de pago, ordenados de mejor a peor. Cada candidato es un objeto con:
+     - dia: Día del mes (1-31) para la cuota, típicamente poco después de un ingreso recurrente detectado, para no caer donde el dinero ya se gastó. En quincena, prioriza la que deje más liquidez. Devuelve días reales, no valores fijos.
+     - porcentaje: Qué tan recomendado es ese día frente a los otros dos (0-100, entero). El primero debe tener el porcentaje más alto.
+   - justificacion: 1-2 frases explicando el orden de los 3 candidatos según el patrón detectado. Si el ingreso es irregular, elige los 3 días más conservadores y acláralo; no inventes precisión.
 
 ## IMPORTANTE: Múltiples cuentas bancarias del mismo titular
 

--- a/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
+++ b/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
@@ -30,6 +30,14 @@ export const bankStatementAnalysisSchema = z.object({
 		promedio_gastos_variables: z.number(),
 		disponibilidad_economica: z.number(),
 	}),
+	// Nullable e informativo: no debe tumbar el análisis core; días acotados a 1-31 enteros
+	analisis_fecha_pago: z
+		.object({
+			dias_ingreso_detectados: z.array(z.number().int().min(1).max(31)),
+			dia_pago_sugerido: z.number().int().min(1).max(31),
+			justificacion: z.string(),
+		})
+		.nullable(),
 });
 
 export type BankStatementAnalysis = z.infer<typeof bankStatementAnalysisSchema>;
@@ -64,6 +72,11 @@ Eres un analista de capacidad de pago para una financiera que otorga créditos p
    - promedio_gastos_variables: Promedio mensual de gastos variables.
    - disponibilidad_economica: Promedio de la diferencia entre créditos y débitos totales. Se calcula como: (promedio_creditos - promedio_debitos).
    **Nota**: El promedio de créditos es la suma de 'total_creditos' a lo largo de los meses analizados dividido por la cantidad de meses. El promedio de débitos es la suma de 'total_debitos' a lo largo de los meses analizados dividido por la cantidad de meses.
+
+4. **analisis_fecha_pago**: Determina la fecha ideal de pago según CUÁNDO recibe ingresos el solicitante, analizando las FECHAS de las transacciones de crédito (no solo los totales). Devuelve:
+   - dias_ingreso_detectados: Días del mes (1-31) en que se repiten sus ingresos recurrentes. Si es quincena, incluye ambos (ej. [15, 30]).
+   - dia_pago_sugerido: Día del mes (1-31) para la cuota, entre 1 y 5 días después de su ingreso recurrente de mayor monto, para no caer donde el dinero ya se gastó. En quincena, elige la que deje más liquidez. Devuelve el día real, no un valor fijo.
+   - justificacion: 1-2 frases justificando el día según el patrón detectado. Si el ingreso es irregular, elige el día más conservador y acláralo; no inventes precisión.
 
 ## IMPORTANTE: Múltiples cuentas bancarias del mismo titular
 

--- a/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
+++ b/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
@@ -30,14 +30,15 @@ export const bankStatementAnalysisSchema = z.object({
 		promedio_gastos_variables: z.number(),
 		disponibilidad_economica: z.number(),
 	}),
-	// Nullish e informativo: la key puede faltar o venir null sin tumbar el análisis core; días acotados a 1-31 enteros
+	// Informativo y tolerante a fallos: ausente, null o con valores fuera de rango cae a null sin tumbar el análisis core
 	analisis_fecha_pago: z
 		.object({
 			dias_ingreso_detectados: z.array(z.number().int().min(1).max(31)),
 			dia_pago_sugerido: z.number().int().min(1).max(31),
 			justificacion: z.string(),
 		})
-		.nullish(),
+		.nullable()
+		.catch(null),
 });
 
 export type BankStatementAnalysis = z.infer<typeof bankStatementAnalysisSchema>;

--- a/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
+++ b/apps/crm/apps/server/src/lib/bank-analysis-schema.ts
@@ -30,14 +30,14 @@ export const bankStatementAnalysisSchema = z.object({
 		promedio_gastos_variables: z.number(),
 		disponibilidad_economica: z.number(),
 	}),
-	// Nullable e informativo: no debe tumbar el análisis core; días acotados a 1-31 enteros
+	// Nullish e informativo: la key puede faltar o venir null sin tumbar el análisis core; días acotados a 1-31 enteros
 	analisis_fecha_pago: z
 		.object({
 			dias_ingreso_detectados: z.array(z.number().int().min(1).max(31)),
 			dia_pago_sugerido: z.number().int().min(1).max(31),
 			justificacion: z.string(),
 		})
-		.nullable(),
+		.nullish(),
 });
 
 export type BankStatementAnalysis = z.infer<typeof bankStatementAnalysisSchema>;

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -339,6 +339,14 @@ export const bankAnalysisRouter = {
 					});
 				}
 
+				// 5.5. ordenar por porcentaje descendente antes de persistir, ya que la UI
+				// asume que el índice 0 es siempre la mejor recomendación.
+				if (analysis.analisis_fecha_pago) {
+					analysis.analisis_fecha_pago.dias_pago_sugeridos = [
+						...analysis.analisis_fecha_pago.dias_pago_sugeridos,
+					].sort((a, b) => b.porcentaje - a.porcentaje);
+				}
+
 				// 6. Calcular capacidad crediticia
 				const creditCapacity = calculateCreditCapacity(analysis, {
 					annualRate: input.annualRate,

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -364,6 +364,8 @@ export const bankAnalysisRouter = {
 							analysis.promedio_mensual.disponibilidad_economica.toString(),
 						maxPayment: creditCapacity.maxPayment.toString(),
 						maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
+						suggestedPaymentDay:
+							analysis.analisis_fecha_pago?.dia_pago_sugerido ?? null,
 						analyzedAt: new Date(),
 						updatedAt: new Date(),
 					})

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -364,8 +364,8 @@ export const bankAnalysisRouter = {
 							analysis.promedio_mensual.disponibilidad_economica.toString(),
 						maxPayment: creditCapacity.maxPayment.toString(),
 						maxCreditAmount: creditCapacity.maxCreditAmount.toString(),
-						suggestedPaymentDay:
-							analysis.analisis_fecha_pago?.dia_pago_sugerido ?? null,
+						suggestedPaymentDays:
+							analysis.analisis_fecha_pago?.dias_pago_sugeridos ?? null,
 						analyzedAt: new Date(),
 						updatedAt: new Date(),
 					})

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3631,7 +3631,7 @@ export const crmRouter = {
 								economicAvailability: creditAnalysis.economicAvailability,
 								maxPayment: creditAnalysis.maxPayment,
 								maxCreditAmount: creditAnalysis.maxCreditAmount,
-								suggestedPaymentDay: creditAnalysis.suggestedPaymentDay,
+								suggestedPaymentDays: creditAnalysis.suggestedPaymentDays,
 								analyzedAt: creditAnalysis.analyzedAt,
 							})
 							.from(creditAnalysis)
@@ -6666,7 +6666,7 @@ export const crmRouter = {
 				economicAvailability: parseDecimal(leadAnalysis?.economicAvailability),
 				maxPayment: parseDecimal(leadAnalysis?.maxPayment),
 				maxCreditAmount: parseDecimal(leadAnalysis?.maxCreditAmount),
-				suggestedPaymentDay: leadAnalysis?.suggestedPaymentDay ?? null,
+				suggestedPaymentDays: leadAnalysis?.suggestedPaymentDays ?? null,
 				hasAnalysis: leadAnalysis?.analyzedAt != null,
 			};
 

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3631,6 +3631,7 @@ export const crmRouter = {
 								economicAvailability: creditAnalysis.economicAvailability,
 								maxPayment: creditAnalysis.maxPayment,
 								maxCreditAmount: creditAnalysis.maxCreditAmount,
+								suggestedPaymentDay: creditAnalysis.suggestedPaymentDay,
 								analyzedAt: creditAnalysis.analyzedAt,
 							})
 							.from(creditAnalysis)
@@ -6665,6 +6666,7 @@ export const crmRouter = {
 				economicAvailability: parseDecimal(leadAnalysis?.economicAvailability),
 				maxPayment: parseDecimal(leadAnalysis?.maxPayment),
 				maxCreditAmount: parseDecimal(leadAnalysis?.maxCreditAmount),
+				suggestedPaymentDay: leadAnalysis?.suggestedPaymentDay ?? null,
 				hasAnalysis: leadAnalysis?.analyzedAt != null,
 			};
 

--- a/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
+++ b/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
@@ -553,6 +553,18 @@ function CoDebtorCard({
 										</p>
 									</div>
 
+									{/* Fecha ideal de pago */}
+									{creditAnalysisQuery.data?.suggestedPaymentDay != null && (
+										<div className="flex items-center justify-between rounded border px-2 py-1 text-xs">
+											<span className="text-muted-foreground">
+												Fecha ideal de pago
+											</span>
+											<span className="font-semibold text-blue-600">
+												Día {creditAnalysisQuery.data.suggestedPaymentDay}
+											</span>
+										</div>
+									)}
+
 									{/* Capacidad de pago */}
 									<div className="grid grid-cols-2 gap-2 text-center text-xs">
 										<div className="rounded border p-2">

--- a/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
+++ b/apps/crm/apps/web/src/components/co-debtors/CoDebtorsView.tsx
@@ -554,14 +554,26 @@ function CoDebtorCard({
 									</div>
 
 									{/* Fecha ideal de pago */}
-									{creditAnalysisQuery.data?.suggestedPaymentDay != null && (
-										<div className="flex items-center justify-between rounded border px-2 py-1 text-xs">
-											<span className="text-muted-foreground">
-												Fecha ideal de pago
-											</span>
-											<span className="font-semibold text-blue-600">
-												Día {creditAnalysisQuery.data.suggestedPaymentDay}
-											</span>
+									{creditAnalysisQuery.data?.suggestedPaymentDays != null && (
+										<div className="space-y-1">
+											<p className="mb-3 text-muted-foreground text-xs italic">
+												Porcentaje indica día mejor ajustado
+											</p>
+											{creditAnalysisQuery.data.suggestedPaymentDays.map(
+												(c, i) => (
+													<div
+														key={c.dia}
+														className="flex items-center justify-between rounded border px-2 py-1 text-xs"
+													>
+														<span className="text-muted-foreground">
+															Fecha ideal de pago {i + 1}
+														</span>
+														<span className="font-semibold text-blue-600">
+															Día {c.dia} ({c.porcentaje}%)
+														</span>
+													</div>
+												),
+											)}
 										</div>
 									)}
 

--- a/apps/crm/apps/web/src/components/credit/ConsolidatedCreditSummary.tsx
+++ b/apps/crm/apps/web/src/components/credit/ConsolidatedCreditSummary.tsx
@@ -117,14 +117,24 @@ export function ConsolidatedCreditSummary({
 			</div>
 
 			{/* Fecha ideal de pago sugerida (solo del deudor principal) */}
-			{lead.suggestedPaymentDay != null && (
-				<div className="rounded-md bg-white/80 p-2 text-center dark:bg-white/5">
-					<p className="text-muted-foreground text-xs">
-						Fecha ideal de pago
+			{lead.suggestedPaymentDays != null && (
+				<div className="space-y-1.5">
+					<p className="mb-3 text-center text-muted-foreground text-xs italic">
+						Porcentaje indica día mejor ajustado
 					</p>
-					<p className="font-semibold text-blue-600 text-sm">
-						Día {lead.suggestedPaymentDay}
-					</p>
+					{lead.suggestedPaymentDays.map((c, i) => (
+						<div
+							key={c.dia}
+							className="flex items-center justify-between rounded-md bg-white/80 px-2 py-1 dark:bg-white/5"
+						>
+							<span className="text-muted-foreground text-xs">
+								Fecha ideal de pago {i + 1}
+							</span>
+							<span className="font-semibold text-blue-600 text-sm">
+								Día {c.dia} ({c.porcentaje}%)
+							</span>
+						</div>
+					))}
 				</div>
 			)}
 

--- a/apps/crm/apps/web/src/components/credit/ConsolidatedCreditSummary.tsx
+++ b/apps/crm/apps/web/src/components/credit/ConsolidatedCreditSummary.tsx
@@ -116,6 +116,18 @@ export function ConsolidatedCreditSummary({
 				</div>
 			</div>
 
+			{/* Fecha ideal de pago sugerida (solo del deudor principal) */}
+			{lead.suggestedPaymentDay != null && (
+				<div className="rounded-md bg-white/80 p-2 text-center dark:bg-white/5">
+					<p className="text-muted-foreground text-xs">
+						Fecha ideal de pago
+					</p>
+					<p className="font-semibold text-blue-600 text-sm">
+						Día {lead.suggestedPaymentDay}
+					</p>
+				</div>
+			)}
+
 			{/* Desglose si hay co-firmantes */}
 			{coDebtorsCount > 0 && (
 				<div className="border-t pt-3">

--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -741,15 +741,26 @@ export function LeadDetailModal({
 								</div>
 							)}
 
-							{/* Suggested Payment Day */}
-							{creditAnalysisQuery.data.suggestedPaymentDay != null && (
-								<div className="flex items-center justify-between rounded-lg border px-3 py-2">
-									<span className="text-muted-foreground text-xs">
-										Fecha Ideal de Pago
-									</span>
-									<span className="font-bold text-blue-600 text-sm">
-										Día {creditAnalysisQuery.data.suggestedPaymentDay}
-									</span>
+							{/* Suggested Payment Days */}
+							{creditAnalysisQuery.data.suggestedPaymentDays != null && (
+								<div className="space-y-1.5">
+									<h4 className="font-medium text-sm">Fechas de Pago</h4>
+									<p className="mb-3 text-muted-foreground text-xs italic">
+										Porcentaje indica día mejor ajustado
+									</p>
+									{creditAnalysisQuery.data.suggestedPaymentDays.map((c, i) => (
+										<div
+											key={c.dia}
+											className="flex items-center justify-between rounded-lg border px-3 py-2"
+										>
+											<span className="text-muted-foreground text-xs">
+												Fecha Ideal de Pago {i + 1}
+											</span>
+											<span className="font-bold text-blue-600 text-sm">
+												Día {c.dia} ({c.porcentaje}%)
+											</span>
+										</div>
+									))}
 								</div>
 							)}
 

--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -741,6 +741,18 @@ export function LeadDetailModal({
 								</div>
 							)}
 
+							{/* Suggested Payment Day */}
+							{creditAnalysisQuery.data.suggestedPaymentDay != null && (
+								<div className="flex items-center justify-between rounded-lg border px-3 py-2">
+									<span className="text-muted-foreground text-xs">
+										Fecha Ideal de Pago
+									</span>
+									<span className="font-bold text-blue-600 text-sm">
+										Día {creditAnalysisQuery.data.suggestedPaymentDay}
+									</span>
+								</div>
+							)}
+
 							{/* Payment Capacity */}
 							<div className="grid grid-cols-2 gap-4">
 								{creditAnalysisQuery.data.maxPayment && (

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -226,6 +226,7 @@ type CreditAnalysisData = {
 	economicAvailability: string | null;
 	maxPayment: string | null;
 	maxCreditAmount: string | null;
+	suggestedPaymentDay: number | null;
 	analyzedAt: Date;
 } | null;
 
@@ -1566,6 +1567,20 @@ function RouteComponent() {
 											</span>
 										</div>
 									</div>
+
+									{/* Fecha Ideal de Pago Sugerida */}
+									{selectedClient.creditAnalysis.suggestedPaymentDay !=
+										null && (
+										<div className="flex items-center justify-between rounded-lg border px-3 py-2">
+											<span className="text-muted-foreground text-xs">
+												Fecha Ideal de Pago
+											</span>
+											<span className="font-bold text-blue-600 text-sm">
+												Día{" "}
+												{selectedClient.creditAnalysis.suggestedPaymentDay}
+											</span>
+										</div>
+									)}
 
 									{/* Capacidad de Pago */}
 									<div className="grid grid-cols-2 gap-3">

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -226,7 +226,7 @@ type CreditAnalysisData = {
 	economicAvailability: string | null;
 	maxPayment: string | null;
 	maxCreditAmount: string | null;
-	suggestedPaymentDay: number | null;
+	suggestedPaymentDays: { dia: number; porcentaje: number }[] | null;
 	analyzedAt: Date;
 } | null;
 
@@ -1569,16 +1569,28 @@ function RouteComponent() {
 									</div>
 
 									{/* Fecha Ideal de Pago Sugerida */}
-									{selectedClient.creditAnalysis.suggestedPaymentDay !=
+									{selectedClient.creditAnalysis.suggestedPaymentDays !=
 										null && (
-										<div className="flex items-center justify-between rounded-lg border px-3 py-2">
-											<span className="text-muted-foreground text-xs">
-												Fecha Ideal de Pago
-											</span>
-											<span className="font-bold text-blue-600 text-sm">
-												Día{" "}
-												{selectedClient.creditAnalysis.suggestedPaymentDay}
-											</span>
+										<div className="space-y-1.5">
+											<h4 className="font-medium text-sm">Fechas de Pago</h4>
+											<p className="mb-3 text-muted-foreground text-xs italic">
+												Porcentaje indica día mejor ajustado
+											</p>
+											{selectedClient.creditAnalysis.suggestedPaymentDays.map(
+												(c, i) => (
+													<div
+														key={c.dia}
+														className="flex items-center justify-between rounded-lg border px-3 py-2"
+													>
+														<span className="text-muted-foreground text-xs">
+															Fecha Ideal de Pago {i + 1}
+														</span>
+														<span className="font-bold text-blue-600 text-sm">
+															Día {c.dia} ({c.porcentaje}%)
+														</span>
+													</div>
+												),
+											)}
 										</div>
 									)}
 

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -3047,6 +3047,18 @@ function RouteComponent() {
 											<h4 className="font-medium text-base">
 												Capacidad de Pago
 											</h4>
+											{creditAnalysisQuery.data.suggestedPaymentDay !=
+												null && (
+												<div className="flex items-center justify-between rounded-lg border px-3 py-2">
+													<span className="text-muted-foreground text-xs">
+														Fecha Ideal de Pago
+													</span>
+													<span className="font-bold text-blue-600 text-sm">
+														Día{" "}
+														{creditAnalysisQuery.data.suggestedPaymentDay}
+													</span>
+												</div>
+											)}
 											<div className="grid grid-cols-2 gap-4">
 												<div className="rounded-lg border p-4 text-center">
 													<Label className="text-muted-foreground text-xs">

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -3044,9 +3044,6 @@ function RouteComponent() {
 
 										{/* Payment Capacity */}
 										<div className="space-y-4">
-											<h4 className="font-medium text-base">
-												Capacidad de Pago
-											</h4>
 											{creditAnalysisQuery.data.suggestedPaymentDay !=
 												null && (
 												<div className="flex items-center justify-between rounded-lg border px-3 py-2">
@@ -3059,6 +3056,9 @@ function RouteComponent() {
 													</span>
 												</div>
 											)}
+											<h4 className="font-medium text-base">
+												Capacidad de Pago
+											</h4>
 											<div className="grid grid-cols-2 gap-4">
 												<div className="rounded-lg border p-4 text-center">
 													<Label className="text-muted-foreground text-xs">

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -3044,16 +3044,30 @@ function RouteComponent() {
 
 										{/* Payment Capacity */}
 										<div className="space-y-4">
-											{creditAnalysisQuery.data.suggestedPaymentDay !=
+											{creditAnalysisQuery.data.suggestedPaymentDays !=
 												null && (
-												<div className="flex items-center justify-between rounded-lg border px-3 py-2">
-													<span className="text-muted-foreground text-xs">
-														Fecha Ideal de Pago
-													</span>
-													<span className="font-bold text-blue-600 text-sm">
-														Día{" "}
-														{creditAnalysisQuery.data.suggestedPaymentDay}
-													</span>
+												<div className="space-y-1.5">
+													<h4 className="font-medium text-base">
+														Fechas de Pago 
+													</h4>
+													<p className="text-muted-foreground text-xs italic mb-3">
+														Porcentaje indica día mejor ajustado
+													</p>
+													{creditAnalysisQuery.data.suggestedPaymentDays.map(
+														(c, i) => (
+															<div
+																key={c.dia}
+																className="flex items-center justify-between rounded-lg border px-3 py-2"
+															>
+																<span className="text-muted-foreground text-xs">
+																	Fecha Ideal de Pago {i + 1}
+																</span>
+																<span className="font-bold text-blue-600 text-sm">
+																	Día {c.dia} ({c.porcentaje}%)
+																</span>
+															</div>
+														),
+													)}
 												</div>
 											)}
 											<h4 className="font-medium text-base">


### PR DESCRIPTION
## 1. Fecha ideal de pago según los ingresos del cliente

Agrega, dentro del análisis de capacidad de pago existente, el cálculo de la fecha ideal de pago del cliente a partir de los estados de cuenta que ya se suben. Es un dato informativo que ayuda al analista a estructurar el crédito según cuándo el cliente recibe liquidez. No modifica el `diaPagoMensual` del crédito ni ningún campo operativo.

### Qué hace

En la misma llamada a la IA que ya analiza los estados de cuenta, el modelo revisa las fechas de las transacciones de ingreso (no solo los totales), detecta los días en que el cliente recibe ingresos recurrentes (sueldo/quincena) y devuelve **3 fechas candidatas de pago, rankeadas de mejor a peor**, cada una con un % que indica qué tan recomendada es frente a las otras dos. En caso de quincena, prioriza la que deja más liquidez; si el ingreso es irregular, elige los 3 días más conservadores y lo explica.

### Cambios

**IA — bank-analysis-schema.ts**
- Nuevo bloque `analisis_fecha_pago` en el schema de respuesta:
  - `dias_ingreso_detectados`: días del mes donde se repiten los ingresos (evidencia).
  - `dias_pago_sugeridos`: siempre 3 candidatos `{ dia: 1-31, porcentaje: 0-100 }`, ordenados del más al menos recomendado.
  - `justificacion`: explica el orden elegido.
- Se resuelve en la misma llamada a Gemini, sin costo ni intentos adicionales.
- El bloque completo es `.nullable().catch(null)`: si Gemini omite la key, la manda null, o algún subcampo sale fuera de rango, el parseo cae a null en vez de rechazar toda la respuesta. Así, un estado de cuenta sin patrón de ingreso claro no quema un intento de IA pagado ni pierde el análisis de capacidad de pago ya calculado.

**Base de datos — crm.ts (schema) + migración 0025**
- Columna `suggested_payment_days` (**jsonb**, nullable) en `credit_analysis`, con el array de 3 candidatos `{dia, porcentaje}`. El detalle adicional (días de ingreso detectados + justificación) queda en `full_analysis`.
- Migración consolidada en un solo archivo (`0025_add_suggested_payment_days.sql`) ya que el feature nunca llegó a producción — no hace falta un paso intermedio.

**Backend — bank-analysis.ts + crm.ts (router)**
- Persiste `suggested_payment_days` al guardar el análisis exitoso, leyendo el bloque de forma defensiva (`analysis.analisis_fecha_pago?.dias_pago_sugeridos ?? null`).
- Lo expone en la lectura por lead, en el consolidado (solo el del lead — una fecha no es aditiva entre co-deudores como sí lo son los montos) y en la query de clientes.

**Frontend — leads.tsx, clients.tsx, lead-detail-modal.tsx, CoDebtorsView.tsx, ConsolidatedCreditSummary.tsx**
- Muestra las 3 fechas como "Fecha Ideal de Pago 1 / 2 / 3", con el día y el % pegados a la derecha, y el texto informativo "Porcentaje indica día mejor ajustado" arriba.
- Solo se renderiza cuando hay dato; para análisis sin el campo, el componente no aparece.
- La `justificacion` no se muestra en la UI (queda solo en `full_analysis` para auditoría del razonamiento).

### Decisiones de diseño

- **El dato es hacia adelante**: se calcula solo en análisis nuevos. Los registros previos al deploy no se re-analizan ni se backfillean (su `full_analysis` tampoco contiene el bloque), por lo que el campo simplemente no se muestra para ellos.
- **Siempre exactamente 3 candidatos (no 1 a 3), por decisión de producto**: queremos darle al analista siempre 3 alternativas, no solo la mejor opción. Esto es un trade-off consciente: si la IA alguna vez no devuelve exactamente 3 (poco común pero posible), la sección de fechas simplemente no aparece para ese análisis — el análisis financiero (ingresos, gastos, capacidad de pago) **nunca se pierde**, se guarda igual. No es un bug ni rompe nada; en el peor caso, se resetea el análisis y se vuelve a correr.
- **Los 3 porcentajes no están forzados a sumar 100**: cada uno es independiente y representa qué tan recomendado es ese día frente a los otros dos, no una probabilidad conjunta.

### Pruebas

Se validó el flujo end-to-end con 4 pruebas, subiendo estados de cuenta bancarios sintéticos con distintos patrones de ingreso, y se verificó en base de datos que cada resultado coincide exactamente con lo mostrado en la UI. Los casos 2-4 son multi-banco (mismo titular) e incluyen transferencias entre cuentas propias, para confirmar que la IA las excluye correctamente.

<table>
<thead>
<tr>
<th width="3%">#</th>
<th width="10%">Escenario</th>
<th width="10%">Archivos subidos</th>
<th width="15%">Patrón de ingreso</th>
<th width="14%">Fechas sugeridas</th>
<th width="48%">Resumen</th>
</tr>
</thead>
<tbody>
<tr>
<td>1</td>
<td>Sueldo mensual</td>
<td>3 PDFs (1 banco)</td>
<td>Sueldo fijo día 5 + ingreso variable día 15</td>
<td>1) Día 6 (70%)<br>2) Día 7 (20%)<br>3) Día 16 (10%)</td>
<td>Nómina el día 5; sugiere pagar 1-2 días después.</td>
</tr>
<tr>
<td>2</td>
<td>Sueldo multi-banco</td>
<td>9 PDFs (3 bancos)</td>
<td>Sueldo fijo día 25</td>
<td>1) Día 26 (95%)<br>2) Día 27 (85%)<br>3) Día 25 (70%)</td>
<td>Nómina el día 25; excluyó bien las transferencias propias.</td>
</tr>
<tr>
<td>3</td>
<td>Quincena multi-banco</td>
<td>9 PDFs (3 bancos)</td>
<td>Ingreso quincenal (día 15 y fin de mes)</td>
<td>1) Día 2 (100%)<br>2) Día 17 (85%)<br>3) Día 3 (70%)</td>
<td>Quincena; prioriza el día después del pago más grande (fin de mes).</td>
</tr>
<tr>
<td>4</td>
<td>Ingreso irregular</td>
<td>9 PDFs (3 bancos)</td>
<td>Ventas variables sin día fijo</td>
<td>1) Día 17 (45%)<br>2) Día 28 (35%)<br>3) Día 4 (20%)</td>
<td>Ventas variables; reconoció la irregularidad (Q0 en ingresos fijos) y sugirió días conservadores tras los picos de venta.</td>
</tr>
</tbody>
</table>

En los casos 2, 3 y 4 se confirmó que la IA excluye las transferencias entre cuentas propias (no las cuenta como ingreso ni gasto) y consolida los 3 bancos en 3 meses.

La `justificacion` mostrada en la tabla no se refleja en la UI (ver sección de Frontend); solo se muestran las 3 fechas con su porcentaje.

### Vista en Leads

<img width="634" height="774" alt="image" src="https://github.com/user-attachments/assets/4f69be57-03da-4f43-b7e5-b464d95483da" />


### Vista en oportunidades
<img width="613" height="272" alt="image" src="https://github.com/user-attachments/assets/4ffd6d7c-ed75-4b10-b86a-dd18a4e38bb6" />

### Migración

Aplicar `0025_add_suggested_payment_days.sql` en producción al desplegar (columna `jsonb`, nullable, sin backfill).




