### PR TITLE
fix(cartera): aclarar bloqueo de pagos por cancelación pendiente

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.test.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.test.ts
@@ -14,9 +14,19 @@ import {
   shouldMarkInstallmentPaymentPaid,
   sumarAplicadoACuota,
   calcularCoberturaCuota,
+  getCreditPaymentBlock,
 } from "./registerPaymentPolicy";
 
 describe("register payment", () => {
+  it("clasifica un crédito pendiente de cancelación con un mensaje descriptivo", () => {
+    expect(getCreditPaymentBlock("PENDIENTE_CANCELACION")).toEqual({
+      code: "CREDIT_PENDING_CANCELLATION",
+      message:
+        "No se puede registrar el pago porque el crédito está pendiente de cancelación.",
+    });
+    expect(getCreditPaymentBlock("ACTIVO")).toBeNull();
+  });
+
   it("usa null en vez de 0 cuando el pago no tiene cuota", () => {
     expect(getCuotaIdForPaymentInsert(null)).toBeNull();
     expect(getCuotaIdForPaymentInsert(undefined)).toBeNull();

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -26,6 +26,8 @@ import {
   esDestinoSobrescribible,
   getCuotaIdForPaymentInsert,
   getCoveredOpenInstallment,
+  CREDIT_PENDING_CANCELLATION_ERROR,
+  getCreditPaymentBlock,
   getRequestedInstallmentFloor,
   getSpecialPaymentInstallmentFields,
   getSpecialPaymentCuotaId,
@@ -287,21 +289,29 @@ const obtenerInfoCompletaCredito = async (
           eq(moras_credito.activa, true) // ✅ Solo traer mora activa
         )
       )
-      .where(
-        and(
-          eq(creditos.credito_id, credito_id),
-          or(
-            eq(creditos.statusCredit, "ACTIVO"),
-            eq(creditos.statusCredit, "MOROSO"),
-            eq(creditos.statusCredit, "EN_CONVENIO") 
-            ,eq(creditos.statusCredit, "INCOBRABLE")// 🚨 También traer créditos en convenio
-          )
-        )
-      )
+      .where(eq(creditos.credito_id, credito_id))
       .limit(1);
 
-    // ❌ Validación: Crédito no encontrado o inactivo
+    // ❌ Validación: Crédito no encontrado
     if (!info || !info.credito) {
+      set.status = 404;
+      throw new Error("Credit not found");
+    }
+
+    const paymentBlock = getCreditPaymentBlock(info.credito.statusCredit);
+    if (paymentBlock) {
+      set.status = 409;
+      throw Object.assign(new Error(paymentBlock.message), {
+        code: paymentBlock.code,
+      });
+    }
+
+    // Mantener intactos los estados que históricamente admiten pagos.
+    if (
+      !["ACTIVO", "MOROSO", "EN_CONVENIO", "INCOBRABLE"].includes(
+        info.credito.statusCredit
+      )
+    ) {
       set.status = 404;
       throw new Error("Credit not found");
     }
@@ -432,6 +442,10 @@ const obtenerInfoCompletaCredito = async (
       error instanceof Error &&
       error.message.startsWith(CUOTA_INTEGRITY_ERROR_PREFIX)
     ) {
+      throw error;
+    }
+
+    if ((error as { code?: string }).code === CREDIT_PENDING_CANCELLATION_ERROR.code) {
       throw error;
     }
 
@@ -1971,6 +1985,13 @@ if (creditoInfo.credito.statusCredit === "EN_CONVENIO") {
     }
   } catch (error) {
     console.error("[insertPayment] Error:", error);
+    if ((error as { code?: string }).code === CREDIT_PENDING_CANCELLATION_ERROR.code) {
+      set.status = 409;
+      return {
+        success: false,
+        ...CREDIT_PENDING_CANCELLATION_ERROR,
+      };
+    }
     if (
       error instanceof Error &&
       error.message.startsWith(CUOTA_INTEGRITY_ERROR_PREFIX)

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -2,6 +2,17 @@ import Big from "big.js";
 
 type BigInput = number | string | Big;
 
+export const CREDIT_PENDING_CANCELLATION_ERROR = {
+  code: "CREDIT_PENDING_CANCELLATION",
+  message:
+    "No se puede registrar el pago porque el crédito está pendiente de cancelación.",
+} as const;
+
+export const getCreditPaymentBlock = (statusCredit: string | null | undefined) =>
+  statusCredit === "PENDIENTE_CANCELACION"
+    ? CREDIT_PENDING_CANCELLATION_ERROR
+    : null;
+
 export const getCuotaIdForPaymentInsert = (
   cuotaId: number | null | undefined
 ) => cuotaId ?? null;

--- a/apps/carteraFront/src/lib/apiError.test.ts
+++ b/apps/carteraFront/src/lib/apiError.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { AxiosError } from "axios";
+import { getApiErrorMessage } from "./apiError";
+
+describe("getApiErrorMessage", () => {
+  it("presenta en español el bloqueo por cancelación pendiente", () => {
+    const error = new AxiosError(
+      "Request failed with status code 409",
+      "ERR_BAD_REQUEST",
+      undefined,
+      undefined,
+      {
+        status: 409,
+        statusText: "Conflict",
+        headers: {},
+        config: {} as never,
+        data: {
+          code: "CREDIT_PENDING_CANCELLATION",
+          message: "Internal server error",
+        },
+      },
+    );
+
+    expect(getApiErrorMessage(error, "No se pudo registrar el pago")).toBe(
+      "No se pudo registrar el pago: No se puede registrar el pago porque el crédito está pendiente de cancelación.",
+    );
+  });
+});

--- a/apps/carteraFront/src/lib/apiError.ts
+++ b/apps/carteraFront/src/lib/apiError.ts
@@ -57,6 +57,11 @@ function traducirDetalleTecnico(detail: string): string {
  */
 const MENSAJE_SIN_INFORMACION = /^internal server error$/i;
 
+const MENSAJES_POR_CODIGO: Record<string, string> = {
+  CREDIT_PENDING_CANCELLATION:
+    "No se puede registrar el pago porque el crédito está pendiente de cancelación.",
+};
+
 /**
  * Firmas de errores técnicos que nunca deben mostrarse al usuario.
  * Los throws de negocio del backend ("Payment not found", "No se encontró
@@ -89,13 +94,23 @@ function esDetalleTecnicoCrudo(detail: string): boolean {
  *    `error`, no solo cuando los roles están invertidos.
  */
 function extraerDetalle(data: unknown): string | undefined {
-  const cuerpo = (data ?? {}) as { message?: unknown; error?: unknown; mensaje?: unknown };
+  const cuerpo = (data ?? {}) as {
+    code?: unknown;
+    message?: unknown;
+    error?: unknown;
+    mensaje?: unknown;
+  };
+  const code = typeof cuerpo.code === "string" ? cuerpo.code : "";
   const message = typeof cuerpo.message === "string" ? cuerpo.message.trim() : "";
   const mensaje = typeof cuerpo.mensaje === "string" ? cuerpo.mensaje.trim() : "";
   const errorRaw = typeof cuerpo.error === "string" ? cuerpo.error.trim() : "";
 
   const errorUtilizable =
     !!errorRaw && (buscarTraduccion(errorRaw) !== null || !esDetalleTecnicoCrudo(errorRaw));
+
+  if (MENSAJES_POR_CODIGO[code]) {
+    return MENSAJES_POR_CODIGO[code];
+  }
 
   // `message` curado tiene prioridad, salvo que sea el genérico sin información.
   if (message && !MENSAJE_SIN_INFORMACION.test(message)) {


### PR DESCRIPTION
## Resumen
- distingue créditos inexistentes de créditos en `PENDIENTE_CANCELACION`
- responde `409` con código `CREDIT_PENDING_CANCELLATION`
- muestra un mensaje descriptivo en el frontend aunque el mensaje HTTP sea genérico
- conserva sin cambios los estados que ya admitían pagos

## Mensaje al usuario
> No se puede registrar el pago porque el crédito está pendiente de cancelación.

## Pruebas
- Backend: `57 passed, 0 failed`
- Frontend: `1 passed, 0 failed`
- TypeScript frontend: correcto
- `git diff --check`: correcto

## Alcance
No cambia reglas financieras ni habilita pagos para créditos bloqueados; únicamente mejora la clasificación y presentación del error.