### PR TITLE
feat(cobros): selector de asesor en filtro de historial de reasignaciones

### DIFF
--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1267,13 +1267,18 @@ export class CarteraBackClient {
 			JSON.stringify(response, null, 2),
 		);
 
-		// Transformar la respuesta al formato PaginatedResponse esperado
+		// El endpoint /advisor no retorna metadata de paginación; se infiere
+		// si hay más páginas según si la página actual vino completa.
+		const page = params.page || 1;
+		const perPage = params.perPage || 20;
+		const hayMasPaginas = response.length === perPage;
+
 		return {
 			data: response,
-			page: params.page || 1,
-			perPage: params.perPage || 20,
-			total: response.length,
-			totalPages: 1,
+			page,
+			perPage,
+			total: (page - 1) * perPage + response.length,
+			totalPages: hayMasPaginas ? page + 1 : page,
 		};
 	}
 

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -345,12 +345,16 @@ function HistorialReasignaciones() {
 		queryKey: ["cobros", "asesores-todos"],
 		queryFn: async () => {
 			const perPage = 100;
-			const primera = await client.getAsesores({ page: 1, perPage });
-			const todos = [...primera.asesores];
-			const totalPages = primera.pagination.totalPages;
-			for (let page = 2; page <= totalPages; page++) {
-				const siguiente = await client.getAsesores({ page, perPage });
-				todos.push(...siguiente.asesores);
+			const todos: Awaited<
+				ReturnType<typeof client.getAsesores>
+			>["asesores"] = [];
+			let page = 1;
+			let hayMasPaginas = true;
+			while (hayMasPaginas) {
+				const respuesta = await client.getAsesores({ page, perPage });
+				todos.push(...respuesta.asesores);
+				hayMasPaginas = page < respuesta.pagination.totalPages;
+				page++;
 			}
 			return todos;
 		},

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Combobox } from "@/components/ui/combobox";
 import {
 	Dialog,
 	DialogContent,
@@ -337,6 +338,15 @@ function HistorialReasignaciones() {
 	const [page, setPage] = useState(1);
 	const pageSize = 20;
 
+	const asesoresQuery = useQuery(
+		orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
+	);
+	const asesores = asesoresQuery.data?.asesores ?? [];
+	const asesorOptions = asesores.map((a) => ({
+		value: a.nombre,
+		label: a.nombre,
+	}));
+
 	const query = useQuery(
 		orpc.getHistorialReasignaciones.queryOptions({
 			input: {
@@ -413,13 +423,19 @@ function HistorialReasignaciones() {
 					</div>
 					<div className="space-y-2">
 						<Label>Asesor nuevo</Label>
-						<Input
-							placeholder="Buscar asesor..."
-							value={asesorInput}
-							onChange={(e) => setAsesorInput(e.target.value)}
-							onKeyDown={(e) => e.key === "Enter" && aplicar()}
-							className="w-[180px]"
+						<Combobox
+							options={asesorOptions}
+							value={asesorInput || null}
+							onChange={setAsesorInput}
+							placeholder="Todos los asesores"
+							isLoading={asesoresQuery.isLoading}
+							width="180px"
 						/>
+						{asesoresQuery.isError && (
+							<p className="text-destructive text-xs">
+								No se pudo cargar la lista de asesores.
+							</p>
+						)}
 					</div>
 					<div className="space-y-2">
 						<Label>No. SIFCO</Label>
@@ -617,7 +633,9 @@ function RouteComponent() {
 			<Tabs defaultValue="buckets">
 				<TabsList>
 					<TabsTrigger value="buckets">Buckets</TabsTrigger>
-					<TabsTrigger value="historial">Historial de reasignaciones</TabsTrigger>
+					<TabsTrigger value="historial">
+						Historial de reasignaciones
+					</TabsTrigger>
 				</TabsList>
 
 				<TabsContent value="buckets" className="space-y-6">

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -338,10 +338,24 @@ function HistorialReasignaciones() {
 	const [page, setPage] = useState(1);
 	const pageSize = 20;
 
-	const asesoresQuery = useQuery(
-		orpc.getAsesores.queryOptions({ input: { perPage: 100 } }),
-	);
-	const asesores = asesoresQuery.data?.asesores ?? [];
+	// getAsesores limita perPage a 100 en el server; se pagina hasta traer
+	// todos los asesores para que el combobox pueda filtrar por cualquiera,
+	// no solo los primeros 100 (regresión detectada en review de Codex).
+	const asesoresQuery = useQuery({
+		queryKey: ["cobros", "asesores-todos"],
+		queryFn: async () => {
+			const perPage = 100;
+			const primera = await client.getAsesores({ page: 1, perPage });
+			const todos = [...primera.asesores];
+			const totalPages = primera.pagination.totalPages;
+			for (let page = 2; page <= totalPages; page++) {
+				const siguiente = await client.getAsesores({ page, perPage });
+				todos.push(...siguiente.asesores);
+			}
+			return todos;
+		},
+	});
+	const asesores = asesoresQuery.data ?? [];
 	const asesorOptions = asesores.map((a) => ({
 		value: a.nombre,
 		label: a.nombre,

--- a/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/reasignaciones.tsx
@@ -437,14 +437,24 @@ function HistorialReasignaciones() {
 					</div>
 					<div className="space-y-2">
 						<Label>Asesor nuevo</Label>
-						<Combobox
-							options={asesorOptions}
-							value={asesorInput || null}
-							onChange={setAsesorInput}
-							placeholder="Todos los asesores"
-							isLoading={asesoresQuery.isLoading}
-							width="180px"
-						/>
+						{asesoresQuery.isError ? (
+							<Input
+								placeholder="Buscar asesor..."
+								value={asesorInput}
+								onChange={(e) => setAsesorInput(e.target.value)}
+								onKeyDown={(e) => e.key === "Enter" && aplicar()}
+								className="w-[180px]"
+							/>
+						) : (
+							<Combobox
+								options={asesorOptions}
+								value={asesorInput || null}
+								onChange={setAsesorInput}
+								placeholder="Todos los asesores"
+								isLoading={asesoresQuery.isLoading}
+								width="180px"
+							/>
+						)}
 						{asesoresQuery.isError && (
 							<p className="text-destructive text-xs">
 								No se pudo cargar la lista de asesores.


### PR DESCRIPTION
## Summary
- Reemplaza el input de texto libre "Asesor nuevo" en Cobros > Buckets > Historial de reasignaciones por un Combobox (mismo componente reutilizable `ui/combobox.tsx` usado en otros filtros), poblado desde `getAsesores`.
- Evita errores de tipeo al filtrar por nombre de asesor; el filtrado sigue resolviéndose en backend (`asesor_nuevo` vía `carteraBackClient.getAsesorHistorial`).
- Muestra estado de carga y error al obtener la lista de asesores.

## Test plan
- [x] `bun check-types` pasa limpio
- [x] `bunx biome check` pasa limpio
- [ ] Verificar visualmente el filtro en el navegador (seleccionar asesor, click Buscar, confirmar resultados filtrados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)