### PR TITLE
feat(cobros): Agenda del día por asesor + herramientas de prueba premora (CC2-11)

### DIFF
--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -33,9 +33,11 @@ export async function getCuotasProximasVencer(
   // también las cuotas próximas de créditos en mora.
   const soloAlDia = opts.soloAlDia !== false;
   // buckets: filtro por bucket MOTOR (PREMORA_BUCKETS del CRM). Un crédito
-  // sin INICIAL en buckets_historial cuenta como B0 (COALESCE). Orthogonal a
-  // soloAlDia: el job del CRM manda soloAlDia=false + buckets=0,1,... cuando
-  // el funnel de recordatorios está encendido.
+  // SIN historial de buckets NO se asume B0 a ciegas (review Codex): solo
+  // cuenta como B0 si además está al día EN TIEMPO REAL — si no, un moroso
+  // sin INICIAL recibiría la plantilla amistosa de cartera sana. Orthogonal
+  // a soloAlDia: el job del CRM manda soloAlDia=false + buckets=0,1,...
+  // cuando el funnel de recordatorios está encendido.
   const buckets = opts.buckets ?? [];
   const hoyGT = sql`(now() AT TIME ZONE 'America/Guatemala')::date`;
   const diasList = sql.join(
@@ -47,16 +49,36 @@ export async function getCuotasProximasVencer(
     ? sql`c."statusCredit" = 'ACTIVO'`
     : sql`c."statusCredit" IN ('ACTIVO', 'MOROSO', 'INCOBRABLE')`;
 
+  const bucketMotorSub = sql`(SELECT h.bucket_nuevo
+      FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+      WHERE h.credito_id = c.credito_id
+      ORDER BY h.fecha DESC, h.historial_id DESC
+      LIMIT 1)`;
+
+  // Crédito al día EN TIEMPO REAL (mismo criterio estricto del modo premora).
+  const esAlDiaReal = sql`(c."statusCredit" = 'ACTIVO'
+      AND NOT EXISTS (
+        SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
+        WHERE v.credito_id = c.credito_id
+          AND v.fecha_vencimiento::date < ${hoyGT}
+          AND v.pagado = false
+          AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+      ))`;
+
+  const bucketsList = sql.join(
+    buckets.map((b) => sql`${b}`),
+    sql`, `,
+  );
   const filtroBuckets =
     buckets.length > 0
-      ? sql`AND COALESCE(
-      (SELECT h.bucket_nuevo FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
-        WHERE h.credito_id = c.credito_id
-        ORDER BY h.fecha DESC, h.historial_id DESC
-        LIMIT 1), 0) IN (${sql.join(
-          buckets.map((b) => sql`${b}`),
-          sql`, `,
-        )})`
+      ? sql`AND (
+      ${bucketMotorSub} IN (${bucketsList})
+      ${
+        buckets.includes(0)
+          ? sql`OR (${bucketMotorSub} IS NULL AND ${esAlDiaReal})`
+          : sql``
+      }
+    )`
       : sql``;
 
   const res = await db.execute<any>(sql`

--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -41,7 +41,10 @@ export async function getCuotasProximasVencer(dias: number[]) {
       c.numero_credito_sifco,
       ROUND(c.cuota::numeric, 2)::text AS monto_cuota,
       u.nombre AS cliente,
-      u.telefono AS telefono_cliente_cartera,
+      -- usuarios NO tiene teléfono en cartera (solo asesores/admins/conta/
+      -- inversionistas lo tienen). Se devuelve NULL para mantener la forma
+      -- del API: el CRM resuelve el teléfono real con caso de cobros → lead.
+      NULL::text AS telefono_cliente_cartera,
       c.asesor_id,
       a.nombre AS asesor,
       a.telefono AS telefono_asesor

--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -26,12 +26,17 @@ const pagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
 
 export async function getCuotasProximasVencer(
   dias: number[],
-  opts: { soloAlDia?: boolean } = {},
+  opts: { soloAlDia?: boolean; buckets?: number[] } = {},
 ) {
   // Default true: premora SOLO recuerda a créditos al día (B0). Con false
   // (la Agenda del día del CRM) entra TODO el funnel — el asesor gestiona
   // también las cuotas próximas de créditos en mora.
   const soloAlDia = opts.soloAlDia !== false;
+  // buckets: filtro por bucket MOTOR (PREMORA_BUCKETS del CRM). Un crédito
+  // sin INICIAL en buckets_historial cuenta como B0 (COALESCE). Orthogonal a
+  // soloAlDia: el job del CRM manda soloAlDia=false + buckets=0,1,... cuando
+  // el funnel de recordatorios está encendido.
+  const buckets = opts.buckets ?? [];
   const hoyGT = sql`(now() AT TIME ZONE 'America/Guatemala')::date`;
   const diasList = sql.join(
     dias.map((d) => sql`${d}`),
@@ -41,6 +46,18 @@ export async function getCuotasProximasVencer(
   const filtroEstado = soloAlDia
     ? sql`c."statusCredit" = 'ACTIVO'`
     : sql`c."statusCredit" IN ('ACTIVO', 'MOROSO', 'INCOBRABLE')`;
+
+  const filtroBuckets =
+    buckets.length > 0
+      ? sql`AND COALESCE(
+      (SELECT h.bucket_nuevo FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+        WHERE h.credito_id = c.credito_id
+        ORDER BY h.fecha DESC, h.historial_id DESC
+        LIMIT 1), 0) IN (${sql.join(
+          buckets.map((b) => sql`${b}`),
+          sql`, `,
+        )})`
+      : sql``;
 
   const res = await db.execute<any>(sql`
     SELECT
@@ -71,6 +88,7 @@ export async function getCuotasProximasVencer(
     INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
     LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
     WHERE ${filtroEstado}
+      ${filtroBuckets}
       AND cu.pagado = false
       AND NOT EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))})
       -- Ya hay un pago REGISTRADO para esta cuota aunque CONTA no lo haya

--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -24,12 +24,23 @@ const pagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
     AND pc.validation_status IN ('validated', 'no_required')
     AND COALESCE(pc.monto_aplicado, 0) > 0`;
 
-export async function getCuotasProximasVencer(dias: number[]) {
+export async function getCuotasProximasVencer(
+  dias: number[],
+  opts: { soloAlDia?: boolean } = {},
+) {
+  // Default true: premora SOLO recuerda a créditos al día (B0). Con false
+  // (la Agenda del día del CRM) entra TODO el funnel — el asesor gestiona
+  // también las cuotas próximas de créditos en mora.
+  const soloAlDia = opts.soloAlDia !== false;
   const hoyGT = sql`(now() AT TIME ZONE 'America/Guatemala')::date`;
   const diasList = sql.join(
     dias.map((d) => sql`${d}`),
     sql`, `,
   );
+
+  const filtroEstado = soloAlDia
+    ? sql`c."statusCredit" = 'ACTIVO'`
+    : sql`c."statusCredit" IN ('ACTIVO', 'MOROSO', 'INCOBRABLE')`;
 
   const res = await db.execute<any>(sql`
     SELECT
@@ -39,6 +50,13 @@ export async function getCuotasProximasVencer(dias: number[]) {
       cu.fecha_vencimiento::date::text AS fecha_vencimiento,
       (cu.fecha_vencimiento::date - ${hoyGT})::int AS dias_para_vencer,
       c.numero_credito_sifco,
+      c."statusCredit" AS status_credit,
+      -- Bucket MOTOR (último de buckets_historial, misma fuente que el listado
+      -- por bucket): NULL si el crédito no tiene INICIAL registrado.
+      (SELECT h.bucket_nuevo FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+        WHERE h.credito_id = c.credito_id
+        ORDER BY h.fecha DESC, h.historial_id DESC
+        LIMIT 1) AS bucket,
       ROUND(c.cuota::numeric, 2)::text AS monto_cuota,
       u.nombre AS cliente,
       -- usuarios NO tiene teléfono en cartera (solo asesores/admins/conta/
@@ -52,7 +70,7 @@ export async function getCuotasProximasVencer(dias: number[]) {
     INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
     INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
     LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
-    WHERE c."statusCredit" = 'ACTIVO'
+    WHERE ${filtroEstado}
       AND cu.pagado = false
       AND NOT EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))})
       -- Ya hay un pago REGISTRADO para esta cuota aunque CONTA no lo haya
@@ -65,14 +83,18 @@ export async function getCuotasProximasVencer(dias: number[]) {
           AND COALESCE(pr.monto_boleta, 0) > 0
       )
       AND (cu.fecha_vencimiento::date - ${hoyGT}) IN (${diasList})
-      -- Crédito AL DÍA: ninguna cuota ya vencida sigue pendiente.
-      AND NOT EXISTS (
+      -- Crédito AL DÍA: ninguna cuota ya vencida sigue pendiente (solo premora).
+      ${
+        soloAlDia
+          ? sql`AND NOT EXISTS (
         SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
         WHERE v.credito_id = cu.credito_id
           AND v.fecha_vencimiento::date < ${hoyGT}
           AND v.pagado = false
           AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
-      )
+      )`
+          : sql``
+      }
     ORDER BY dias_para_vencer ASC, c.numero_credito_sifco ASC
   `);
 

--- a/apps/cartera-back/src/routers/cuotas.ts
+++ b/apps/cartera-back/src/routers/cuotas.ts
@@ -32,8 +32,20 @@ export const cuotasRouter = new Elysia()
             message: "[ERROR] dias inválido (CSV de enteros 0-60, ej. 5,3,1,0)",
           };
         }
+        // solo_al_dia: "true" (default, premora) | "false" (Agenda del día:
+        // todo el funnel ACTIVO/MOROSO/INCOBRABLE, sin exigir cero vencidas).
+        const rawSoloAlDia = String(query.solo_al_dia ?? "true");
+        if (rawSoloAlDia !== "true" && rawSoloAlDia !== "false") {
+          set.status = 400;
+          return {
+            success: false,
+            message: "[ERROR] solo_al_dia inválido (true|false)",
+          };
+        }
         const dias = [...new Set(tokens.map(Number))];
-        return await getCuotasProximasVencer(dias);
+        return await getCuotasProximasVencer(dias, {
+          soloAlDia: rawSoloAlDia === "true",
+        });
       } catch (err) {
         set.status = 500;
         return {
@@ -46,6 +58,7 @@ export const cuotasRouter = new Elysia()
     {
       query: t.Object({
         dias: t.Optional(t.String()),
+        solo_al_dia: t.Optional(t.String()),
       }),
     },
   );

--- a/apps/cartera-back/src/routers/cuotas.ts
+++ b/apps/cartera-back/src/routers/cuotas.ts
@@ -42,9 +42,31 @@ export const cuotasRouter = new Elysia()
             message: "[ERROR] solo_al_dia inválido (true|false)",
           };
         }
+        // buckets: CSV 0-5 opcional — filtra por bucket MOTOR (sin INICIAL
+        // cuenta como B0). Lo usa el job premora cuando PREMORA_BUCKETS
+        // incluye más que B0.
+        let buckets: number[] | undefined;
+        if (query.buckets != null && String(query.buckets).trim() !== "") {
+          const bTokens = String(query.buckets)
+            .split(",")
+            .map((s: string) => s.trim())
+            .filter(Boolean);
+          if (
+            bTokens.length === 0 ||
+            bTokens.some((s: string) => !/^[0-5]$/.test(s))
+          ) {
+            set.status = 400;
+            return {
+              success: false,
+              message: "[ERROR] buckets inválido (CSV de enteros 0-5)",
+            };
+          }
+          buckets = [...new Set(bTokens.map(Number))];
+        }
         const dias = [...new Set(tokens.map(Number))];
         return await getCuotasProximasVencer(dias, {
           soloAlDia: rawSoloAlDia === "true",
+          buckets,
         });
       } catch (err) {
         set.status = 500;
@@ -59,6 +81,7 @@ export const cuotasRouter = new Elysia()
       query: t.Object({
         dias: t.Optional(t.String()),
         solo_al_dia: t.Optional(t.String()),
+        buckets: t.Optional(t.String()),
       }),
     },
   );

--- a/apps/cartera-back/src/routers/cuotas.ts
+++ b/apps/cartera-back/src/routers/cuotas.ts
@@ -42,9 +42,9 @@ export const cuotasRouter = new Elysia()
             message: "[ERROR] solo_al_dia inválido (true|false)",
           };
         }
-        // buckets: CSV 0-5 opcional — filtra por bucket MOTOR (sin INICIAL
-        // cuenta como B0). Lo usa el job premora cuando PREMORA_BUCKETS
-        // incluye más que B0.
+        // buckets: CSV 0-5 opcional — filtra por bucket MOTOR (sin historial
+        // solo cuenta como B0 si el crédito está al día en tiempo real). Lo
+        // usa el job premora cuando PREMORA_BUCKETS incluye más que B0.
         let buckets: number[] | undefined;
         if (query.buckets != null && String(query.buckets).trim() !== "") {
           const bTokens = String(query.buckets)

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1156,13 +1156,31 @@ app.on(["GET", "POST"], "/api/premora/run", async (c) => {
 				.filter(Boolean)
 		: undefined;
 
+	// `?dias=3` (CSV) corre solo esos recordatorios; sin el param van los 4.
+	const diasParam = c.req.query("dias");
+	let dias: number[] | undefined;
+	if (diasParam) {
+		dias = diasParam
+			.split(",")
+			.map((s) => Number(s.trim()))
+			.filter((n) => Number.isInteger(n));
+		const validos = [5, 3, 1, 0];
+		if (dias.length === 0 || dias.some((d) => !validos.includes(d))) {
+			return c.json(
+				{ error: "dias inválido: solo se aceptan 5, 3, 1 y 0 (CSV)" },
+				400,
+			);
+		}
+	}
+
 	const testMode = isTestModeEnabled();
-	const resumen = await sendPremoraReminders({ force: true, sifcos });
+	const resumen = await sendPremoraReminders({ force: true, sifcos, dias });
 	return c.json({
 		success: true,
 		testMode,
 		telefonoTest: testMode ? getTestPhone() : null,
 		filtroSifco: sifcos ?? null,
+		filtroDias: dias ?? null,
 		resumen,
 	});
 });

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1180,26 +1180,41 @@ app.post("/api/premora/run", async (c) => {
 		return c.json({ error: "No tienes permiso para correr premora" }, 403);
 	}
 
+	// Filtros de la corrida. REGLA (review Codex): un filtro PRESENTE pero
+	// vacío ("?sifco=" por una variable sin valor, "?dias=,,") es un 400 —
+	// jamás degradar en silencio a un batch más amplio del que se pidió.
 	const sifcoParam = c.req.query("sifco");
-	const sifcos = sifcoParam
-		? sifcoParam
-				.split(",")
-				.map((s) => s.trim())
-				.filter(Boolean)
-		: undefined;
+	let sifcos: string[] | undefined;
+	if (sifcoParam != null) {
+		sifcos = sifcoParam
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean);
+		if (sifcos.length === 0) {
+			return c.json(
+				{ error: "sifco presente pero vacío: no se corre el batch completo" },
+				400,
+			);
+		}
+	}
 
 	// `?dias=3` (CSV) corre solo esos recordatorios; sin el param van los 4.
 	const diasParam = c.req.query("dias");
 	let dias: number[] | undefined;
-	if (diasParam) {
-		dias = diasParam
+	if (diasParam != null) {
+		const tokens = diasParam
 			.split(",")
-			.map((s) => Number(s.trim()))
-			.filter((n) => Number.isInteger(n));
+			.map((s) => s.trim())
+			.filter(Boolean);
+		dias = tokens.map((s) => Number(s)).filter((n) => Number.isInteger(n));
 		const validos = [5, 3, 1, 0];
-		if (dias.length === 0 || dias.some((d) => !validos.includes(d))) {
+		if (
+			tokens.length === 0 ||
+			dias.length !== tokens.length ||
+			dias.some((d) => !validos.includes(d))
+		) {
 			return c.json(
-				{ error: "dias inválido: solo se aceptan 5, 3, 1 y 0 (CSV)" },
+				{ error: "dias inválido o vacío: solo se aceptan 5, 3, 1 y 0 (CSV)" },
 				400,
 			);
 		}
@@ -1208,10 +1223,16 @@ app.post("/api/premora/run", async (c) => {
 	// `?buckets=0,1` (CSV 0-5): override de PREMORA_BUCKETS para esta corrida.
 	const bucketsParam = c.req.query("buckets");
 	let buckets: number[] | undefined;
-	if (bucketsParam) {
-		const tokens = bucketsParam.split(",").map((s) => s.trim());
+	if (bucketsParam != null) {
+		const tokens = bucketsParam
+			.split(",")
+			.map((s) => s.trim())
+			.filter(Boolean);
 		if (tokens.length === 0 || tokens.some((s) => !/^[0-5]$/.test(s))) {
-			return c.json({ error: "buckets inválido: CSV de enteros 0-5" }, 400);
+			return c.json(
+				{ error: "buckets inválido o vacío: CSV de enteros 0-5" },
+				400,
+			);
 		}
 		buckets = [...new Set(tokens.map(Number))];
 	}

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1133,12 +1133,44 @@ app.post("/info/vehicles-by-sifco", async (c) => {
 	}
 });
 
+// CSRF (review Codex): la cookie de sesión viaja cross-site (sameSite
+// "none"), así que una página maliciosa podría disparar el batch desde el
+// navegador de un admin logueado. Defensa: POST-only + Origin de dominios
+// propios (mismas reglas que el CORS de arriba). Sin Origin (curl/Postman)
+// se permite: un navegador SIEMPRE manda Origin en un POST cross-site.
+function esOrigenConfiable(origin: string | undefined): boolean {
+	if (!origin) return true;
+	if (
+		origin.startsWith("http://localhost:") ||
+		origin.startsWith("http://127.0.0.1:")
+	) {
+		return true;
+	}
+	if (
+		/^https?:\/\/(.*\.)?(devteamatcci\.site|servicioscashin\.com|clubcashin\.com)$/.test(
+			origin,
+		)
+	) {
+		return true;
+	}
+	const allowed = [
+		process.env.CORS_ORIGIN,
+		process.env.FRONT_URL,
+		process.env.TALLER_URL,
+	].filter((o): o is string => Boolean(o && o !== "*"));
+	return allowed.includes(origin);
+}
+
 // Corrida MANUAL de premora (pruebas / re-corridas del día). Solo admin y
-// supervisor de cobros. `force` salta el gate PREMORA_WHATSAPP_ENABLED (por
-// eso el cron puede quedar apagado en dev y este endpoint sí funciona);
-// TEST_MESSAGE y los claims de idempotencia aplican exactamente igual.
-// `?sifco=A,B` limita el batch a esos créditos para no disparar todo el día.
-app.on(["GET", "POST"], "/api/premora/run", async (c) => {
+// supervisor de cobros, POST-only con Origin validado (CSRF, arriba).
+// `force` salta el gate PREMORA_WHATSAPP_ENABLED (por eso el cron puede
+// quedar apagado en dev y este endpoint sí funciona); TEST_MESSAGE y los
+// claims de idempotencia aplican exactamente igual. `?sifco=A,B` limita el
+// batch a esos créditos para no disparar todo el día.
+app.post("/api/premora/run", async (c) => {
+	if (!esOrigenConfiable(c.req.header("origin"))) {
+		return c.json({ error: "Origen no permitido" }, 403);
+	}
 	const context = await createContext({ context: c });
 	if (!context.session?.user?.id) {
 		return c.json({ error: "No autorizado" }, 401);
@@ -1173,14 +1205,31 @@ app.on(["GET", "POST"], "/api/premora/run", async (c) => {
 		}
 	}
 
+	// `?buckets=0,1` (CSV 0-5): override de PREMORA_BUCKETS para esta corrida.
+	const bucketsParam = c.req.query("buckets");
+	let buckets: number[] | undefined;
+	if (bucketsParam) {
+		const tokens = bucketsParam.split(",").map((s) => s.trim());
+		if (tokens.length === 0 || tokens.some((s) => !/^[0-5]$/.test(s))) {
+			return c.json({ error: "buckets inválido: CSV de enteros 0-5" }, 400);
+		}
+		buckets = [...new Set(tokens.map(Number))];
+	}
+
 	const testMode = isTestModeEnabled();
-	const resumen = await sendPremoraReminders({ force: true, sifcos, dias });
+	const resumen = await sendPremoraReminders({
+		force: true,
+		sifcos,
+		dias,
+		buckets,
+	});
 	return c.json({
 		success: true,
 		testMode,
 		telefonoTest: testMode ? getTestPhone() : null,
 		filtroSifco: sifcos ?? null,
 		filtroDias: dias ?? null,
+		filtroBuckets: buckets ?? null,
 		resumen,
 	});
 });

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -39,6 +39,7 @@ import {
 } from "./jobs/cobros-notifications";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
+import { getTestPhone, isTestModeEnabled } from "./lib/messaging-test-mode";
 import { PERMISSIONS } from "./lib/roles";
 import {
 	appRouter,
@@ -1130,6 +1131,40 @@ app.post("/info/vehicles-by-sifco", async (c) => {
 			500,
 		);
 	}
+});
+
+// Corrida MANUAL de premora (pruebas / re-corridas del día). Solo admin y
+// supervisor de cobros. `force` salta el gate PREMORA_WHATSAPP_ENABLED (por
+// eso el cron puede quedar apagado en dev y este endpoint sí funciona);
+// TEST_MESSAGE y los claims de idempotencia aplican exactamente igual.
+// `?sifco=A,B` limita el batch a esos créditos para no disparar todo el día.
+app.on(["GET", "POST"], "/api/premora/run", async (c) => {
+	const context = await createContext({ context: c });
+	if (!context.session?.user?.id) {
+		return c.json({ error: "No autorizado" }, 401);
+	}
+	const userRole = context.session.user.role;
+	if (!userRole || !PERMISSIONS.canAssignCobros(userRole)) {
+		return c.json({ error: "No tienes permiso para correr premora" }, 403);
+	}
+
+	const sifcoParam = c.req.query("sifco");
+	const sifcos = sifcoParam
+		? sifcoParam
+				.split(",")
+				.map((s) => s.trim())
+				.filter(Boolean)
+		: undefined;
+
+	const testMode = isTestModeEnabled();
+	const resumen = await sendPremoraReminders({ force: true, sifcos });
+	return c.json({
+		success: true,
+		testMode,
+		telefonoTest: testMode ? getTestPhone() : null,
+		filtroSifco: sifcos ?? null,
+		resumen,
+	});
 });
 
 // Job periódico de notificaciones de cobros (cada hora)

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -227,6 +227,74 @@ ${COBROS_NO_REPLY_WARNING}
 
 Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 	},
+	// ── Variantes premora para créditos EN MORA (B1-B4, PREMORA_BUCKETS) ──
+	// Mismo esquema de 5 bloques (mensaje4parametros). El tono cambia: se
+	// recuerda la cuota próxima Y el saldo vencido. COPY BORRADOR — afinar
+	// con el equipo de cobros antes de encender el funnel.
+	{
+		id: "premora_5_mora",
+		nombre: "Premora (en mora) — 5 días antes",
+		etapa: "pre_mora",
+		asunto: "Recordatorio: su cuota vence en 5 días",
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence el {fechaPago} (en 5 días). Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+
+${COBROS_CUENTAS_PAGO}
+
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor}. SI YA REGULARIZÓ SU CUENTA POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+	},
+	{
+		id: "premora_3_mora",
+		nombre: "Premora (en mora) — 3 días antes",
+		etapa: "pre_mora",
+		asunto: "Recordatorio: su cuota vence en 3 días",
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence el {fechaPago} (en 3 días). Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+
+${COBROS_CUENTAS_PAGO}
+
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor}. SI YA REGULARIZÓ SU CUENTA POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+	},
+	{
+		id: "premora_1_mora",
+		nombre: "Premora (en mora) — 1 día antes",
+		etapa: "pre_mora",
+		asunto: "Recordatorio: su cuota vence mañana",
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence MAÑANA {fechaPago}. Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+
+${COBROS_CUENTAS_PAGO}
+
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor}. SI YA REGULARIZÓ SU CUENTA POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+	},
+	{
+		id: "premora_0_mora",
+		nombre: "Premora (en mora) — día de pago (D-0)",
+		etapa: "pre_mora",
+		asunto: "Hoy es su día de pago",
+		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
+		cuerpo: `Estimado(a) {clienteNombre}, buen día. Le saludamos de Clubcashin.com para recordarle que HOY {fechaPago} vence la cuota de su crédito por Q{cuotaMensual}. Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+
+${COBROS_CUENTAS_PAGO}
+
+Por favor, envíe su boleta o comprobante de pago al {telefonoAsesor}. SI YA REGULARIZÓ SU CUENTA POR FAVOR HACER CASO OMISO A ESTE MENSAJE.
+
+${COBROS_NO_REPLY_WARNING}
+
+Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
+	},
 	{
 		id: "mora_30",
 		nombre: "Mora 30 días",

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -39,6 +39,7 @@ import {
 	salesStages,
 } from "../db/schema/crm";
 import { quotations } from "../db/schema/quotations";
+import { recordatoriosPremora } from "../db/schema/recordatorios-premora";
 import { vehicles } from "../db/schema/vehicles";
 import {
 	deriveHasCapitalData,
@@ -71,6 +72,7 @@ import {
 	crmCobrosOrInvestmentsProcedure,
 	crmOrCobrosProcedure,
 } from "../lib/orpc";
+import { primerTelefono } from "../lib/phone-utils";
 import { PERMISSIONS } from "../lib/roles";
 import {
 	sendWhatsappTemplate,
@@ -1618,6 +1620,209 @@ export const cobrosRouter = {
 				console.error("[getBucketsHistorialCredito] Error:", error);
 				throw new ORPCError("INTERNAL_SERVER_ERROR", {
 					message: "No se pudo obtener el historial del crédito",
+				});
+			}
+		}),
+
+	// CC2-11: Agenda del día — cuotas que vencen HOY (D-0) hasta D-5 de créditos
+	// al día, agrupadas por urgencia. El rol cobros SOLO ve su agenda: se fuerza
+	// server-side matcheando su email de login contra los asesores de cartera
+	// (mismo puente por correo que el resto del módulo — la info del cliente
+	// vive en el CRM, la del crédito en cartera). Admin/supervisor eligen
+	// asesor con `asesorId` o ven todos.
+	getAgendaDia: cobrosProcedure
+		.input(
+			z.object({ asesorId: z.number().int().positive().optional() }).optional(),
+		)
+		.handler(async ({ input, context }) => {
+			try {
+				const puedeVerTodos = PERMISSIONS.canAssignCobros(
+					context.userRole ?? "",
+				);
+
+				const respuesta = await carteraBackClient.getCuotasProximasVencer([
+					0, 1, 2, 3, 4, 5,
+				]);
+				let cuotas = respuesta.data ?? [];
+
+				let asesorForzado: { asesorId: number; nombre: string } | null = null;
+				if (!puedeVerTodos) {
+					const email = context.session?.user?.email?.trim().toLowerCase();
+					const advisors = await carteraBackClient.getAdvisors({
+						page: 1,
+						perPage: 500,
+					});
+					const propio = (advisors.data ?? []).find(
+						(a) => a.email?.trim().toLowerCase() === email,
+					);
+					if (!propio) {
+						// Usuario cobros sin asesor de cartera vinculado por correo:
+						// agenda vacía con aviso (nunca la de otros).
+						return {
+							success: true,
+							sinAsesor: true,
+							asesorForzado: null,
+							items: [],
+						};
+					}
+					asesorForzado = {
+						asesorId: propio.asesor_id,
+						nombre: propio.nombre,
+					};
+					cuotas = cuotas.filter((c) => c.asesor_id === propio.asesor_id);
+				} else if (input?.asesorId) {
+					cuotas = cuotas.filter((c) => c.asesor_id === input.asesorId);
+				}
+
+				if (cuotas.length === 0) {
+					return { success: true, sinAsesor: false, asesorForzado, items: [] };
+				}
+
+				const sifcos = [...new Set(cuotas.map((c) => c.numero_credito_sifco))];
+				const cuotaIds = [...new Set(cuotas.map((c) => c.cuota_id))];
+
+				// Teléfono del cliente: caso de cobros → lead (cartera no tiene
+				// teléfonos de clientes). Casos también inactivos: con varios por
+				// SIFCO gana el activo y a igualdad el más reciente.
+				const casos = await db
+					.select({
+						id: casosCobros.id,
+						numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+						telefonoPrincipal: casosCobros.telefonoPrincipal,
+						activo: casosCobros.activo,
+						updatedAt: casosCobros.updatedAt,
+					})
+					.from(casosCobros)
+					.where(inArray(casosCobros.numeroCreditoSifco, sifcos));
+				const casoPorSifco = new Map<string, (typeof casos)[number]>();
+				for (const caso of casos) {
+					const sifco = caso.numeroCreditoSifco ?? "";
+					const previo = casoPorSifco.get(sifco);
+					const gana =
+						!previo ||
+						(Boolean(caso.activo) && !previo.activo) ||
+						(Boolean(caso.activo) === Boolean(previo.activo) &&
+							(caso.updatedAt?.getTime() ?? 0) >
+								(previo.updatedAt?.getTime() ?? 0));
+					if (gana) casoPorSifco.set(sifco, caso);
+				}
+
+				const oportunidades = await db
+					.select({
+						numeroSifco: opportunities.numeroSifco,
+						leadPhone: leads.phone,
+					})
+					.from(opportunities)
+					.leftJoin(leads, eq(opportunities.leadId, leads.id))
+					.where(inArray(opportunities.numeroSifco, sifcos));
+				const leadPhonePorSifco = new Map(
+					oportunidades.map((o) => [o.numeroSifco ?? "", o.leadPhone]),
+				);
+
+				// Recordatorios premora ya enviados por cuota (badges en la agenda).
+				const recordatorios = await db
+					.select({
+						cuotaId: recordatoriosPremora.cuotaId,
+						tipo: recordatoriosPremora.tipo,
+						enviadoAt: recordatoriosPremora.enviadoAt,
+					})
+					.from(recordatoriosPremora)
+					.where(inArray(recordatoriosPremora.cuotaId, cuotaIds));
+				const recPorCuota = new Map<
+					number,
+					{ tipo: string; enviadoAt: Date }[]
+				>();
+				for (const rec of recordatorios) {
+					const lista = recPorCuota.get(rec.cuotaId) ?? [];
+					lista.push({ tipo: rec.tipo, enviadoAt: rec.enviadoAt });
+					recPorCuota.set(rec.cuotaId, lista);
+				}
+
+				const items = cuotas
+					.map((c) => {
+						const caso = casoPorSifco.get(c.numero_credito_sifco);
+						return {
+							cuotaId: c.cuota_id,
+							creditoId: c.credito_id,
+							numeroCuota: c.numero_cuota,
+							fechaVencimiento: c.fecha_vencimiento,
+							diasParaVencer: c.dias_para_vencer,
+							numeroCreditoSifco: c.numero_credito_sifco,
+							montoCuota: c.monto_cuota,
+							cliente: c.cliente,
+							telefono:
+								primerTelefono(caso?.telefonoPrincipal) ??
+								primerTelefono(leadPhonePorSifco.get(c.numero_credito_sifco)) ??
+								null,
+							casoId: caso?.id ?? null,
+							asesorId: c.asesor_id,
+							asesor: c.asesor,
+							recordatorios: recPorCuota.get(c.cuota_id) ?? [],
+						};
+					})
+					.sort(
+						(a, b) =>
+							a.diasParaVencer - b.diasParaVencer ||
+							(a.cliente ?? "").localeCompare(b.cliente ?? ""),
+					);
+
+				return { success: true, sinAsesor: false, asesorForzado, items };
+			} catch (error) {
+				console.error("[getAgendaDia] Error:", error);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "No se pudo obtener la agenda del día",
+				});
+			}
+		}),
+
+	// CC2-11: recordatorios premora enviados a un crédito (card del detalle).
+	// Fuente = cobros_send_logs (incluye intentos fallidos y envíos en modo
+	// prueba, marcados) — la traza completa, no solo los claims.
+	getRecordatoriosPremora: cobrosProcedure
+		.input(z.object({ numeroSifco: z.string().min(1).max(100) }))
+		.handler(async ({ input }) => {
+			try {
+				const envios = await db
+					.select({
+						id: cobrosSendLogs.id,
+						plantillaId: cobrosSendLogs.plantillaId,
+						telefono: cobrosSendLogs.telefono,
+						status: cobrosSendLogs.status,
+						errorMessage: cobrosSendLogs.errorMessage,
+						providerResponse: cobrosSendLogs.providerResponse,
+						createdAt: cobrosSendLogs.createdAt,
+					})
+					.from(cobrosSendLogs)
+					.where(
+						and(
+							eq(cobrosSendLogs.numeroCreditoSifco, input.numeroSifco),
+							inArray(cobrosSendLogs.plantillaId, [
+								"premora_5",
+								"premora_3",
+								"premora_1",
+								"premora_0",
+							]),
+						),
+					)
+					.orderBy(desc(cobrosSendLogs.createdAt))
+					.limit(30);
+
+				return {
+					success: true,
+					recordatorios: envios.map((e) => ({
+						id: e.id,
+						tipo: e.plantillaId,
+						telefono: e.telefono,
+						enviado: e.status === "sent",
+						error: e.errorMessage,
+						modoPrueba: e.providerResponse?.testMode === true,
+						fecha: e.createdAt,
+					})),
+				};
+			} catch (error) {
+				console.error("[getRecordatoriosPremora] Error:", error);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "No se pudieron obtener los recordatorios",
 				});
 			}
 		}),

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1734,12 +1734,59 @@ export const cobrosRouter = {
 					.where(inArray(recordatoriosPremora.cuotaId, cuotaIds));
 				const recPorCuota = new Map<
 					number,
-					{ tipo: string; enviadoAt: Date }[]
+					{ tipo: string; enviadoAt: Date; modoPrueba: boolean }[]
 				>();
 				for (const rec of recordatorios) {
 					const lista = recPorCuota.get(rec.cuotaId) ?? [];
-					lista.push({ tipo: rec.tipo, enviadoAt: rec.enviadoAt });
+					lista.push({
+						tipo: rec.tipo,
+						enviadoAt: rec.enviadoAt,
+						modoPrueba: false,
+					});
 					recPorCuota.set(rec.cuotaId, lista);
+				}
+
+				// + envíos recientes en cobros_send_logs: el modo test NO escribe
+				// claims (a propósito — no consume el recordatorio real), así que
+				// sin esto la agenda diría "—" aunque la prueba ya salió. Los logs
+				// no traen cuota_id: se mapean por SIFCO+tipo con ventana de 10
+				// días (la ventana natural D-5→D-0 de una cuota).
+				const enviosRecientes = await db
+					.select({
+						numeroCreditoSifco: cobrosSendLogs.numeroCreditoSifco,
+						plantillaId: cobrosSendLogs.plantillaId,
+						providerResponse: cobrosSendLogs.providerResponse,
+						createdAt: cobrosSendLogs.createdAt,
+					})
+					.from(cobrosSendLogs)
+					.where(
+						and(
+							inArray(cobrosSendLogs.numeroCreditoSifco, sifcos),
+							inArray(cobrosSendLogs.plantillaId, [
+								"premora_5",
+								"premora_3",
+								"premora_1",
+								"premora_0",
+							]),
+							eq(cobrosSendLogs.status, "sent"),
+							gte(cobrosSendLogs.createdAt, sql`now() - interval '10 days'`),
+						),
+					);
+				const enviosPorSifco = new Map<
+					string,
+					Map<string, { enviadoAt: Date; modoPrueba: boolean }>
+				>();
+				for (const envio of enviosRecientes) {
+					const sifco = envio.numeroCreditoSifco ?? "";
+					const tipo = envio.plantillaId ?? "";
+					const porTipo = enviosPorSifco.get(sifco) ?? new Map();
+					if (!porTipo.has(tipo)) {
+						porTipo.set(tipo, {
+							enviadoAt: envio.createdAt,
+							modoPrueba: envio.providerResponse?.testMode === true,
+						});
+					}
+					enviosPorSifco.set(sifco, porTipo);
 				}
 
 				const items = cuotas
@@ -1763,7 +1810,21 @@ export const cobrosRouter = {
 							casoId: caso?.id ?? null,
 							asesorId: c.asesor_id,
 							asesor: c.asesor,
-							recordatorios: recPorCuota.get(c.cuota_id) ?? [],
+							recordatorios: (() => {
+								// Claims exactos por cuota + envíos por SIFCO (dedupe por
+								// tipo; el claim real gana sobre el log).
+								const lista = [...(recPorCuota.get(c.cuota_id) ?? [])];
+								const tipos = new Set(lista.map((r) => r.tipo));
+								const envios = enviosPorSifco.get(c.numero_credito_sifco);
+								if (envios) {
+									for (const [tipo, envio] of envios) {
+										if (!tipos.has(tipo)) {
+											lista.push({ tipo, ...envio });
+										}
+									}
+								}
+								return lista;
+							})(),
 						};
 					})
 					.sort(

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1767,6 +1767,10 @@ export const cobrosRouter = {
 								"premora_3",
 								"premora_1",
 								"premora_0",
+								"premora_5_mora",
+								"premora_3_mora",
+								"premora_1_mora",
+								"premora_0_mora",
 							]),
 							eq(cobrosSendLogs.status, "sent"),
 							gte(cobrosSendLogs.createdAt, sql`now() - interval '10 days'`),
@@ -1778,7 +1782,9 @@ export const cobrosRouter = {
 				>();
 				for (const envio of enviosRecientes) {
 					const sifco = envio.numeroCreditoSifco ?? "";
-					const tipo = envio.plantillaId ?? "";
+					// Tipo BASE (la variante _mora es la misma campaña D-X): así el
+					// dedupe contra los claims —que son por tipo base— funciona.
+					const tipo = (envio.plantillaId ?? "").replace("_mora", "");
 					const porTipo = enviosPorSifco.get(sifco) ?? new Map();
 					if (!porTipo.has(tipo)) {
 						porTipo.set(tipo, {
@@ -1868,6 +1874,10 @@ export const cobrosRouter = {
 								"premora_3",
 								"premora_1",
 								"premora_0",
+								"premora_5_mora",
+								"premora_3_mora",
+								"premora_1_mora",
+								"premora_0_mora",
 							]),
 						),
 					)

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1640,9 +1640,13 @@ export const cobrosRouter = {
 					context.userRole ?? "",
 				);
 
-				const respuesta = await carteraBackClient.getCuotasProximasVencer([
-					0, 1, 2, 3, 4, 5,
-				]);
+				// Todo el funnel (soloAlDia: false): la agenda es pareja para todos
+				// los asesores — cuentas al día Y en mora con cuota próxima. Los
+				// recordatorios WhatsApp (premora) siguen siendo solo B0.
+				const respuesta = await carteraBackClient.getCuotasProximasVencer(
+					[0, 1, 2, 3, 4, 5],
+					{ soloAlDia: false },
+				);
 				let cuotas = respuesta.data ?? [];
 
 				let asesorForzado: { asesorId: number; nombre: string } | null = null;
@@ -1748,6 +1752,8 @@ export const cobrosRouter = {
 							fechaVencimiento: c.fecha_vencimiento,
 							diasParaVencer: c.dias_para_vencer,
 							numeroCreditoSifco: c.numero_credito_sifco,
+							statusCredit: c.status_credit,
+							bucket: c.bucket,
 							montoCuota: c.monto_cuota,
 							cliente: c.cliente,
 							telefono:

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -143,6 +143,8 @@ export const cobrosAppRouter = {
 	getBucketsCatalogo: cobrosRouter.getBucketsCatalogo,
 	getBucketsHistorial: cobrosRouter.getBucketsHistorial,
 	getBucketsHistorialCredito: cobrosRouter.getBucketsHistorialCredito,
+	getAgendaDia: cobrosRouter.getAgendaDia,
+	getRecordatoriosPremora: cobrosRouter.getRecordatoriosPremora,
 	getCreditosPorBucket: cobrosRouter.getCreditosPorBucket,
 	getPoolAsesoresPorBucket: cobrosRouter.getPoolAsesoresPorBucket,
 	getCargaPorAsesorBucket: cobrosRouter.getCargaPorAsesorBucket,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1023,8 +1023,11 @@ export class CarteraBackClient {
 	 */
 	async getCuotasProximasVencer(
 		dias: number[] = [5, 3, 1, 0],
+		opts: { soloAlDia?: boolean } = {},
 	): Promise<CarteraCuotasProximasResponse> {
 		const queryParams = new URLSearchParams({ dias: dias.join(",") });
+		// Default true (premora, solo B0). false = Agenda del día (todo el funnel).
+		if (opts.soloAlDia === false) queryParams.set("solo_al_dia", "false");
 		return this.request<CarteraCuotasProximasResponse>(
 			`/cuotas/proximas-vencer?${queryParams}`,
 			{ method: "GET" },

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1028,7 +1028,8 @@ export class CarteraBackClient {
 		const queryParams = new URLSearchParams({ dias: dias.join(",") });
 		// Default true (premora, solo B0). false = Agenda del día (todo el funnel).
 		if (opts.soloAlDia === false) queryParams.set("solo_al_dia", "false");
-		// Filtro por bucket MOTOR (PREMORA_BUCKETS); sin INICIAL cuenta como B0.
+		// Filtro por bucket MOTOR (PREMORA_BUCKETS); un crédito sin historial
+		// solo cuenta como B0 si está al día en tiempo real.
 		if (opts.buckets?.length)
 			queryParams.set("buckets", opts.buckets.join(","));
 		return this.request<CarteraCuotasProximasResponse>(

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1023,11 +1023,14 @@ export class CarteraBackClient {
 	 */
 	async getCuotasProximasVencer(
 		dias: number[] = [5, 3, 1, 0],
-		opts: { soloAlDia?: boolean } = {},
+		opts: { soloAlDia?: boolean; buckets?: number[] } = {},
 	): Promise<CarteraCuotasProximasResponse> {
 		const queryParams = new URLSearchParams({ dias: dias.join(",") });
 		// Default true (premora, solo B0). false = Agenda del día (todo el funnel).
 		if (opts.soloAlDia === false) queryParams.set("solo_al_dia", "false");
+		// Filtro por bucket MOTOR (PREMORA_BUCKETS); sin INICIAL cuenta como B0.
+		if (opts.buckets?.length)
+			queryParams.set("buckets", opts.buckets.join(","));
 		return this.request<CarteraCuotasProximasResponse>(
 			`/cuotas/proximas-vencer?${queryParams}`,
 			{ method: "GET" },

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -64,6 +64,28 @@ export interface PremoraRunOptions {
 	sifcos?: string[];
 	/** Corre solo estos días (subconjunto de 5/3/1/0); vacío = todos. */
 	dias?: number[];
+	/** Override de PREMORA_BUCKETS para esta corrida (0-5). */
+	buckets?: number[];
+}
+
+/**
+ * Buckets del funnel a los que se les manda recordatorio, desde
+ * PREMORA_BUCKETS (CSV 0-5, default "0" = solo créditos al día). Encender
+ * B1-B4 = poner PREMORA_BUCKETS=0,1,2,3,4 en el env — sin deploy de código.
+ * B5 (jurídico) queda fuera simplemente no incluyéndolo. Valor inválido →
+ * warn y fallback a [0] (jamás mandar de más por un typo).
+ */
+function bucketsDesdeEnv(): number[] {
+	const raw = process.env.PREMORA_BUCKETS?.trim();
+	if (!raw) return [0];
+	const tokens = raw.split(",").map((s) => s.trim());
+	if (tokens.some((s) => !/^[0-5]$/.test(s))) {
+		console.warn(
+			`${LOG_PREFIX} PREMORA_BUCKETS inválido ("${raw}"); fallback a "0"`,
+		);
+		return [0];
+	}
+	return [...new Set(tokens.map(Number))].sort((a, b) => a - b);
 }
 
 export interface PremoraResumen {
@@ -139,10 +161,24 @@ export async function sendPremoraReminders(
 			return resumenVacio({ skipped: true, reason: "cartera_back_disabled" });
 		}
 
-		// 1. Cuotas próximas a vencer (créditos AL DÍA) desde cartera-back.
+		// 1. Cuotas próximas a vencer desde cartera-back. Con PREMORA_BUCKETS=0
+		// (default) va la consulta clásica: solo créditos al día en tiempo real.
+		// Con buckets extra va el funnel filtrado por bucket MOTOR — y cada
+		// cuota decide su plantilla (normal vs _mora) según su bucket.
 		const diasQuery = opts.dias?.length ? opts.dias : [5, 3, 1, 0];
-		const respuesta =
-			await carteraBackClient.getCuotasProximasVencer(diasQuery);
+		const bucketsActivos = opts.buckets?.length
+			? [...new Set(opts.buckets)].sort((a, b) => a - b)
+			: bucketsDesdeEnv();
+		const soloB0 = bucketsActivos.length === 1 && bucketsActivos[0] === 0;
+		console.log(
+			`${LOG_PREFIX} Buckets activos: ${bucketsActivos.map((b) => `B${b}`).join(", ")}`,
+		);
+		const respuesta = soloB0
+			? await carteraBackClient.getCuotasProximasVencer(diasQuery)
+			: await carteraBackClient.getCuotasProximasVencer(diasQuery, {
+					soloAlDia: false,
+					buckets: bucketsActivos,
+				});
 		let cuotas = respuesta.data ?? [];
 		if (opts.sifcos?.length) {
 			const filtro = new Set(opts.sifcos);
@@ -249,9 +285,14 @@ export async function sendPremoraReminders(
 				continue;
 			}
 
-			const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === tipo);
+			// Plantilla según el bucket MOTOR de la cuota: B0 (o sin INICIAL) la
+			// normal; B1+ la variante `_mora` (recuerda también el saldo vencido).
+			// El claim sigue siendo por tipo BASE (premora_X): un cliente jamás
+			// recibe la normal Y la de mora para la misma cuota.
+			const plantillaId = (cuota.bucket ?? 0) >= 1 ? `${tipo}_mora` : tipo;
+			const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === plantillaId);
 			if (!plantilla) {
-				console.error(`${LOG_PREFIX} Plantilla "${tipo}" no encontrada`);
+				console.error(`${LOG_PREFIX} Plantilla "${plantillaId}" no encontrada`);
 				resumen.fallidos++;
 				continue;
 			}
@@ -338,7 +379,7 @@ export async function sendPremoraReminders(
 			// Traza del intento SIEMPRE (éxito o fallo), como todos los envíos.
 			await persistCobrosSendLog({
 				numeroCreditoSifco: cuota.numero_credito_sifco,
-				plantillaId: tipo,
+				plantillaId,
 				telefono: telefonoDestino,
 				mensaje,
 				providerRequest: result.providerRequest ?? null,

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -53,6 +53,17 @@ const TIPO_POR_DIAS: Record<number, TipoPremora> = {
 	0: "premora_0",
 };
 
+export interface PremoraRunOptions {
+	/**
+	 * Corrida MANUAL (endpoint /api/premora/run): ignora el gate de env
+	 * PREMORA_WHATSAPP_ENABLED. Todo lo demás aplica igual (test-mode,
+	 * claims, historial).
+	 */
+	force?: boolean;
+	/** Limita el batch a estos créditos (pruebas quirúrgicas). */
+	sifcos?: string[];
+}
+
 export interface PremoraResumen {
 	skipped?: boolean;
 	reason?: string;
@@ -110,10 +121,12 @@ async function resolverUsuarioSistema(): Promise<string | null> {
 	return admin?.id ?? null;
 }
 
-export async function sendPremoraReminders(): Promise<PremoraResumen> {
+export async function sendPremoraReminders(
+	opts: PremoraRunOptions = {},
+): Promise<PremoraResumen> {
 	try {
 		// 0. Habilitado por env (mismo patrón que la bienvenida).
-		if (process.env.PREMORA_WHATSAPP_ENABLED !== "true") {
+		if (!opts.force && process.env.PREMORA_WHATSAPP_ENABLED !== "true") {
 			console.log(
 				`${LOG_PREFIX} PREMORA_WHATSAPP_ENABLED != "true"; job omitido`,
 			);
@@ -128,7 +141,14 @@ export async function sendPremoraReminders(): Promise<PremoraResumen> {
 		const respuesta = await carteraBackClient.getCuotasProximasVencer([
 			5, 3, 1, 0,
 		]);
-		const cuotas = respuesta.data ?? [];
+		let cuotas = respuesta.data ?? [];
+		if (opts.sifcos?.length) {
+			const filtro = new Set(opts.sifcos);
+			cuotas = cuotas.filter((c) => filtro.has(c.numero_credito_sifco));
+			console.log(
+				`${LOG_PREFIX} Filtro manual por SIFCO (${opts.sifcos.join(", ")}): ${cuotas.length} cuota(s)`,
+			);
+		}
 		console.log(
 			`${LOG_PREFIX} ${cuotas.length} cuota(s) próximas a vencer (D-5/D-3/D-1/D-0)`,
 		);

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -285,8 +285,11 @@ export async function sendPremoraReminders(
 				continue;
 			}
 
-			// Plantilla según el bucket MOTOR de la cuota: B0 (o sin INICIAL) la
-			// normal; B1+ la variante `_mora` (recuerda también el saldo vencido).
+			// Plantilla según el bucket MOTOR de la cuota: B0 la normal; B1+ la
+			// variante `_mora` (recuerda también el saldo vencido). bucket=null
+			// solo llega de créditos al día verificados (en funnel cartera-back
+			// exige al-día real para contarlos como B0; en modo clásico todo el
+			// batch es al día estricto) → normal es correcta.
 			// El claim sigue siendo por tipo BASE (premora_X): un cliente jamás
 			// recibe la normal Y la de mora para la misma cuota.
 			const plantillaId = (cuota.bucket ?? 0) >= 1 ? `${tipo}_mora` : tipo;

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -286,13 +286,16 @@ export async function sendPremoraReminders(
 			}
 
 			// Plantilla según el bucket MOTOR de la cuota: B0 la normal; B1+ la
-			// variante `_mora` (recuerda también el saldo vencido). bucket=null
-			// solo llega de créditos al día verificados (en funnel cartera-back
-			// exige al-día real para contarlos como B0; en modo clásico todo el
-			// batch es al día estricto) → normal es correcta.
-			// El claim sigue siendo por tipo BASE (premora_X): un cliente jamás
-			// recibe la normal Y la de mora para la misma cuota.
-			const plantillaId = (cuota.bucket ?? 0) >= 1 ? `${tipo}_mora` : tipo;
+			// variante `_mora` (recuerda también el saldo vencido). El claim
+			// sigue siendo por tipo BASE (premora_X): un cliente jamás recibe la
+			// normal Y la de mora para la misma cuota.
+			// En modo clásico (soloB0) SIEMPRE la normal (review Codex): ese
+			// batch es al-día estricto en TIEMPO REAL, pero el bucket motor puede
+			// venir stale (un crédito recién curado sigue en B2 en
+			// buckets_historial hasta que corra procesarMoras) → mirar el bucket
+			// histórico le mandaría "saldo vencido" a quien ya está al día.
+			const plantillaId =
+				!soloB0 && (cuota.bucket ?? 0) >= 1 ? `${tipo}_mora` : tipo;
 			const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === plantillaId);
 			if (!plantilla) {
 				console.error(`${LOG_PREFIX} Plantilla "${plantillaId}" no encontrada`);

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -62,6 +62,8 @@ export interface PremoraRunOptions {
 	force?: boolean;
 	/** Limita el batch a estos créditos (pruebas quirúrgicas). */
 	sifcos?: string[];
+	/** Corre solo estos días (subconjunto de 5/3/1/0); vacío = todos. */
+	dias?: number[];
 }
 
 export interface PremoraResumen {
@@ -138,9 +140,9 @@ export async function sendPremoraReminders(
 		}
 
 		// 1. Cuotas próximas a vencer (créditos AL DÍA) desde cartera-back.
-		const respuesta = await carteraBackClient.getCuotasProximasVencer([
-			5, 3, 1, 0,
-		]);
+		const diasQuery = opts.dias?.length ? opts.dias : [5, 3, 1, 0];
+		const respuesta =
+			await carteraBackClient.getCuotasProximasVencer(diasQuery);
 		let cuotas = respuesta.data ?? [];
 		if (opts.sifcos?.length) {
 			const filtro = new Set(opts.sifcos);

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -476,7 +476,12 @@ export async function sendPremoraReminders(
 }
 
 const TITULO_D0_INDIVIDUAL = "Pago vence hoy (Premora D-0)";
-const TITULO_D0_RESUMEN = "Agenda D-0: pagos que vencen hoy";
+// El título lleva la FECHA GT de vencimiento (review Codex en #1119): el job
+// también corre al boot, y un deploy tarde en el día GT dejaba la corrida de
+// las 8:00 del día siguiente dentro de la ventana de 20h → sin resumen para
+// OTRA fecha. Con la fecha en el título, el dedup es por día de vencimiento.
+const tituloResumenD0 = (fechaGT: string) =>
+	`Agenda D-0: pagos que vencen hoy (${fechaGT})`;
 
 /**
  * Notificaciones D-0. Dedup por título + ventana de 24h (mismo criterio que
@@ -551,12 +556,17 @@ async function notificarAgendaD0(
 			.from(user)
 			.where(eq(user.role, "cobros_supervisor"));
 		if (supervisores.length > 0) {
+			// Todos los D-0 de una corrida comparten fecha (= hoy GT): el título
+			// con esa fecha hace el dedup por día de vencimiento, no por edad.
+			const tituloResumen = tituloResumenD0(
+				fechaLegible(d0[0].fecha_vencimiento),
+			);
 			const yaResumen = await db
 				.select({ id: notifications.id })
 				.from(notifications)
 				.where(
 					and(
-						eq(notifications.titulo, TITULO_D0_RESUMEN),
+						eq(notifications.titulo, tituloResumen),
 						gt(notifications.createdAt, sql`now() - interval '20 hours'`),
 					),
 				)
@@ -569,7 +579,7 @@ async function notificarAgendaD0(
 				const extra = d0.length > 10 ? ` y ${d0.length - 10} más` : "";
 				await db.insert(notifications).values(
 					supervisores.map((s) => ({
-						titulo: TITULO_D0_RESUMEN,
+						titulo: tituloResumen,
 						descripcion: `${d0.length} crédito(s) al día tienen cuota que vence hoy: ${listado}${extra}.`,
 						type: "reminder" as const,
 						status: "pending" as const,

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -894,6 +894,8 @@ export interface CarteraCuotaProximaVencer {
 	fecha_vencimiento: string; // YYYY-MM-DD
 	dias_para_vencer: number; // 0 | 1 | 3 | 5 (según el filtro pedido)
 	numero_credito_sifco: string;
+	status_credit: string; // ACTIVO | MOROSO | INCOBRABLE (funnel)
+	bucket: number | null; // bucket MOTOR (último de buckets_historial)
 	monto_cuota: string;
 	cliente: string;
 	telefono_cliente_cartera: string | null;

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -7,6 +7,7 @@ import {
 	Briefcase,
 	Building2,
 	Calculator,
+	CalendarClock,
 	Car,
 	ChevronDown,
 	Database,
@@ -258,6 +259,12 @@ export default function Header() {
 										<Link to="/cobros" className="cursor-pointer">
 											<Banknote className="mr-2 h-4 w-4" />
 											Dashboard
+										</Link>
+									</DropdownMenuItem>
+									<DropdownMenuItem asChild>
+										<Link to="/cobros/agenda" className="cursor-pointer">
+											<CalendarClock className="mr-2 h-4 w-4" />
+											Agenda del día
 										</Link>
 									</DropdownMenuItem>
 									{PERMISSIONS.canAssignCobros(userRole) && (
@@ -634,6 +641,10 @@ function MobileNav({
 										<Link to="/cobros" className={MOBILE_LINK_CLASS}>
 											<Banknote />
 											Dashboard
+										</Link>
+										<Link to="/cobros/agenda" className={MOBILE_LINK_CLASS}>
+											<CalendarClock />
+											Agenda del día
 										</Link>
 										{PERMISSIONS.canAssignCobros(userRole) && (
 											<Link to="/cobros/metas" className={MOBILE_LINK_CLASS}>

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -36,6 +36,7 @@ import { Route as CobrosReasignacionesRouteImport } from './routes/cobros/reasig
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
 import { Route as CobrosCargaRouteImport } from './routes/cobros/carga'
 import { Route as CobrosBucketsRouteImport } from './routes/cobros/buckets'
+import { Route as CobrosAgendaRouteImport } from './routes/cobros/agenda'
 import { Route as CobrosIdRouteImport } from './routes/cobros/$id'
 import { Route as AdminUsersRouteImport } from './routes/admin/users'
 import { Route as AdminSettingsRouteImport } from './routes/admin/settings'
@@ -189,6 +190,11 @@ const CobrosBucketsRoute = CobrosBucketsRouteImport.update({
   path: '/cobros/buckets',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosAgendaRoute = CobrosAgendaRouteImport.update({
+  id: '/cobros/agenda',
+  path: '/cobros/agenda',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosIdRoute = CobrosIdRouteImport.update({
   id: '/cobros/$id',
   path: '/cobros/$id',
@@ -286,6 +292,7 @@ export interface FileRoutesByFullPath {
   '/admin/settings': typeof AdminSettingsRoute
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
+  '/cobros/agenda': typeof CobrosAgendaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
   '/cobros/metas': typeof CobrosMetasRoute
@@ -331,6 +338,7 @@ export interface FileRoutesByTo {
   '/admin/settings': typeof AdminSettingsRoute
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
+  '/cobros/agenda': typeof CobrosAgendaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
   '/cobros/metas': typeof CobrosMetasRoute
@@ -377,6 +385,7 @@ export interface FileRoutesById {
   '/admin/settings': typeof AdminSettingsRoute
   '/admin/users': typeof AdminUsersRoute
   '/cobros/$id': typeof CobrosIdRoute
+  '/cobros/agenda': typeof CobrosAgendaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
   '/cobros/metas': typeof CobrosMetasRoute
@@ -424,6 +433,7 @@ export interface FileRouteTypes {
     | '/admin/settings'
     | '/admin/users'
     | '/cobros/$id'
+    | '/cobros/agenda'
     | '/cobros/buckets'
     | '/cobros/carga'
     | '/cobros/metas'
@@ -469,6 +479,7 @@ export interface FileRouteTypes {
     | '/admin/settings'
     | '/admin/users'
     | '/cobros/$id'
+    | '/cobros/agenda'
     | '/cobros/buckets'
     | '/cobros/carga'
     | '/cobros/metas'
@@ -514,6 +525,7 @@ export interface FileRouteTypes {
     | '/admin/settings'
     | '/admin/users'
     | '/cobros/$id'
+    | '/cobros/agenda'
     | '/cobros/buckets'
     | '/cobros/carga'
     | '/cobros/metas'
@@ -560,6 +572,7 @@ export interface RootRouteChildren {
   AdminSettingsRoute: typeof AdminSettingsRoute
   AdminUsersRoute: typeof AdminUsersRoute
   CobrosIdRoute: typeof CobrosIdRoute
+  CobrosAgendaRoute: typeof CobrosAgendaRoute
   CobrosBucketsRoute: typeof CobrosBucketsRoute
   CobrosCargaRoute: typeof CobrosCargaRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
@@ -787,6 +800,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CobrosBucketsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/agenda': {
+      id: '/cobros/agenda'
+      path: '/cobros/agenda'
+      fullPath: '/cobros/agenda'
+      preLoaderRoute: typeof CobrosAgendaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/$id': {
       id: '/cobros/$id'
       path: '/cobros/$id'
@@ -912,6 +932,7 @@ const rootRouteChildren: RootRouteChildren = {
   AdminSettingsRoute: AdminSettingsRoute,
   AdminUsersRoute: AdminUsersRoute,
   CobrosIdRoute: CobrosIdRoute,
+  CobrosAgendaRoute: CobrosAgendaRoute,
   CobrosBucketsRoute: CobrosBucketsRoute,
   CobrosCargaRoute: CobrosCargaRoute,
   CobrosMetasRoute: CobrosMetasRoute,

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1383,8 +1383,18 @@ function RouteComponent() {
 														}`}
 													>
 														<MessageCircle className="mr-0.5 h-2.5 w-2.5" />
-														{(rec.tipo ?? "").replace("premora_", "D-")}
+														{(rec.tipo ?? "")
+															.replace("premora_", "D-")
+															.replace("_mora", "")}
 													</Badge>
+													{(rec.tipo ?? "").endsWith("_mora") && (
+														<Badge
+															variant="outline"
+															className="border-red-300 text-[10px] text-red-700 dark:text-red-400"
+														>
+															Variante mora
+														</Badge>
+													)}
 													<span className="text-sm">
 														{rec.enviado ? "Enviado" : "Falló"}
 														{rec.telefono ? ` al ${rec.telefono}` : ""}

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -252,6 +252,17 @@ function RouteComponent() {
 		enabled: !!session && !!id,
 	});
 
+	// Recordatorios Premora enviados al crédito (CC2-11). No depende del caso:
+	// aplica también a créditos al día sin caso de cobros.
+	const recordatoriosPremora = useQuery({
+		...orpc.getRecordatoriosPremora.queryOptions({
+			input: {
+				numeroSifco: casoDetails.data?.numeroCreditoSifco || id || "",
+			},
+		}),
+		enabled: !!session && !!(casoDetails.data?.numeroCreditoSifco || id),
+	});
+
 	// Obtener información de recuperación si es caso incobrable
 	const recuperacionInfo = useQuery({
 		...orpc.getRecuperacionVehiculo.queryOptions({
@@ -1328,6 +1339,82 @@ function RouteComponent() {
 					{matchingOpportunity?.lead?.id && (
 						<ReferenciasView leadId={matchingOpportunity.lead.id} />
 					)}
+
+					{/* Recordatorios Premora enviados (CC2-11) */}
+					<Card>
+						<CardHeader>
+							<CardTitle className="flex items-center gap-2">
+								<CalendarClock className="h-5 w-5" />
+								Recordatorios de Pago
+							</CardTitle>
+							<CardDescription>
+								Recordatorios automáticos Premora (D-5 / D-3 / D-1 / D-0)
+								enviados por WhatsApp
+							</CardDescription>
+						</CardHeader>
+						<CardContent>
+							{(recordatoriosPremora.data?.recordatorios ?? []).length === 0 ? (
+								<div className="py-6 text-center text-muted-foreground text-sm">
+									Sin recordatorios enviados a este crédito
+								</div>
+							) : (
+								<div className="space-y-2">
+									{(recordatoriosPremora.data?.recordatorios ?? []).map(
+										(rec: {
+											id: string;
+											tipo: string | null;
+											telefono: string | null;
+											enviado: boolean;
+											error: string | null;
+											modoPrueba: boolean;
+											fecha: string | Date;
+										}) => (
+											<div
+												key={rec.id}
+												className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-2.5"
+											>
+												<div className="flex items-center gap-2">
+													<Badge
+														variant="outline"
+														className={`border-transparent text-[10px] ${
+															rec.enviado
+																? "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300"
+																: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300"
+														}`}
+													>
+														<MessageCircle className="mr-0.5 h-2.5 w-2.5" />
+														{(rec.tipo ?? "").replace("premora_", "D-")}
+													</Badge>
+													<span className="text-sm">
+														{rec.enviado ? "Enviado" : "Falló"}
+														{rec.telefono ? ` al ${rec.telefono}` : ""}
+													</span>
+													{rec.modoPrueba && (
+														<Badge
+															variant="outline"
+															className="border-amber-300 text-[10px] text-amber-700 dark:text-amber-400"
+														>
+															Prueba
+														</Badge>
+													)}
+												</div>
+												<span className="text-muted-foreground text-xs">
+													{new Date(rec.fecha).toLocaleString("es-GT", {
+														timeZone: "America/Guatemala",
+														day: "2-digit",
+														month: "2-digit",
+														year: "numeric",
+														hour: "2-digit",
+														minute: "2-digit",
+													})}
+												</span>
+											</div>
+										),
+									)}
+								</div>
+							)}
+						</CardContent>
+					</Card>
 
 					{/* Historial de Contactos */}
 					<Card>

--- a/apps/crm/apps/web/src/routes/cobros/agenda.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/agenda.tsx
@@ -33,6 +33,12 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { authClient } from "@/lib/auth-client";
+import {
+	type BucketsCatalogoQueryData,
+	bucketDeEstado,
+	estiloBucket,
+	useBucketsCatalogo,
+} from "@/lib/cobros/buckets-catalogo";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
 
@@ -52,6 +58,8 @@ interface AgendaItem {
 	fechaVencimiento: string;
 	diasParaVencer: number;
 	numeroCreditoSifco: string;
+	statusCredit: string;
+	bucket: number | null;
 	montoCuota: string;
 	cliente: string | null;
 	telefono: string | null;
@@ -74,6 +82,40 @@ interface AsesorOption {
 	activo: boolean;
 	email: string;
 	isActive: boolean;
+}
+
+/** Bucket numérico del motor (0-5) → key de estadoMora del catálogo de UI. */
+const KEY_POR_NUMERO = [
+	"al_dia",
+	"mora_30",
+	"mora_60",
+	"mora_90",
+	"mora_120",
+	"mora_120_plus",
+] as const;
+
+/** Badge de bucket con label/color del catálogo dinámico (igual que /cobros/buckets). */
+function BucketBadge({
+	numero,
+	catalogo,
+}: {
+	numero: number | null;
+	catalogo: BucketsCatalogoQueryData | undefined;
+}) {
+	if (numero === null || numero === undefined) {
+		return <span className="text-muted-foreground text-xs">—</span>;
+	}
+	const ui = bucketDeEstado(KEY_POR_NUMERO[numero], catalogo);
+	return (
+		<Badge
+			variant="outline"
+			className="whitespace-nowrap text-[10px]"
+			style={estiloBucket(ui.colorHex)}
+			title={ui.label}
+		>
+			B{numero}
+		</Badge>
+	);
 }
 
 /** Urgencia visual por días para vencer: hoy = rojo → D-5 = neutro. */
@@ -135,6 +177,7 @@ function AgendaDiaPage() {
 	const { data: session } = authClient.useSession();
 	const userRole = session?.user?.role;
 	const esSupervisor = !!userRole && PERMISSIONS.canAssignCobros(userRole);
+	const bucketsCatalogo = useBucketsCatalogo();
 
 	// "todos" | asesorId como string (Select de shadcn trabaja con strings).
 	const [asesorSel, setAsesorSel] = useState("todos");
@@ -188,6 +231,19 @@ function AgendaDiaPage() {
 
 	const totalHoy = items.filter((i) => i.diasParaVencer === 0).length;
 
+	// Con "todos" el bucket va por FILA (varía); con UN asesor (elegido o
+	// forzado por rol) va GENERAL en el header — sus buckets, sin repetirse.
+	const mostrandoTodos = esSupervisor && asesorSel === "todos";
+	const bucketsDelAsesor = mostrandoTodos
+		? []
+		: [
+				...new Set(
+					items
+						.map((i) => i.bucket)
+						.filter((b): b is number => b !== null && b !== undefined),
+				),
+			].sort((a, b) => a - b);
+
 	const irAlDetalle = (sifco: string) => {
 		navigate({
 			to: "/cobros/$id",
@@ -209,8 +265,8 @@ function AgendaDiaPage() {
 							<div>
 								<CardTitle className="text-xl">Agenda del día</CardTitle>
 								<CardDescription>
-									Cuentas al día con cuota próxima a vencer — de hoy (D-0) a 5
-									días (D-5)
+									Cuentas con cuota próxima a vencer — de hoy (D-0) a 5 días
+									(D-5), de todo el funnel
 									{agenda?.asesorForzado
 										? ` · Agenda de ${agenda.asesorForzado.nombre}`
 										: ""}
@@ -227,6 +283,17 @@ function AgendaDiaPage() {
 								</Badge>
 							)}
 							<Badge variant="secondary">{items.length} cuentas</Badge>
+							{bucketsDelAsesor.length > 0 && (
+								<span className="inline-flex items-center gap-1">
+									{bucketsDelAsesor.map((b) => (
+										<BucketBadge
+											key={b}
+											numero={b}
+											catalogo={bucketsCatalogo.data}
+										/>
+									))}
+								</span>
+							)}
 							{esSupervisor && (
 								<Select value={asesorSel} onValueChange={setAsesorSel}>
 									<SelectTrigger className="h-8 w-52">
@@ -301,6 +368,7 @@ function AgendaDiaPage() {
 									<TableHeader>
 										<TableRow>
 											<TableHead>Cliente</TableHead>
+											{mostrandoTodos && <TableHead>Bucket</TableHead>}
 											<TableHead>Crédito</TableHead>
 											<TableHead className="text-center">Cuota</TableHead>
 											<TableHead className="text-right">Monto</TableHead>
@@ -321,6 +389,14 @@ function AgendaDiaPage() {
 												<TableCell className="font-medium">
 													{item.cliente ?? "—"}
 												</TableCell>
+												{mostrandoTodos && (
+													<TableCell>
+														<BucketBadge
+															numero={item.bucket}
+															catalogo={bucketsCatalogo.data}
+														/>
+													</TableCell>
+												)}
 												<TableCell className="max-w-45 truncate font-mono text-muted-foreground text-xs">
 													{item.numeroCreditoSifco}
 												</TableCell>

--- a/apps/crm/apps/web/src/routes/cobros/agenda.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/agenda.tsx
@@ -1,0 +1,383 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+	CalendarClock,
+	CheckCircle2,
+	Loader2,
+	MessageCircle,
+	Phone,
+	UserRound,
+} from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/agenda")({
+	component: AgendaDiaPage,
+});
+
+interface AgendaRecordatorio {
+	tipo: string;
+	enviadoAt: string | Date;
+}
+
+interface AgendaItem {
+	cuotaId: number;
+	creditoId: number;
+	numeroCuota: number;
+	fechaVencimiento: string;
+	diasParaVencer: number;
+	numeroCreditoSifco: string;
+	montoCuota: string;
+	cliente: string | null;
+	telefono: string | null;
+	casoId: string | null;
+	asesorId: number | null;
+	asesor: string | null;
+	recordatorios: AgendaRecordatorio[];
+}
+
+interface AgendaResponse {
+	success: boolean;
+	sinAsesor: boolean;
+	asesorForzado: { asesorId: number; nombre: string } | null;
+	items: AgendaItem[];
+}
+
+interface AsesorOption {
+	asesorId: number;
+	nombre: string;
+	activo: boolean;
+	email: string;
+	isActive: boolean;
+}
+
+/** Urgencia visual por días para vencer: hoy = rojo → D-5 = neutro. */
+const URGENCIA: Record<number, { titulo: string; chip: string; dot: string }> =
+	{
+		0: {
+			titulo: "Pagan HOY",
+			chip: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+			dot: "bg-red-500",
+		},
+		1: {
+			titulo: "Pagan mañana",
+			chip: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+			dot: "bg-amber-500",
+		},
+		2: {
+			titulo: "En 2 días",
+			chip: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300",
+			dot: "bg-yellow-500",
+		},
+		3: {
+			titulo: "En 3 días",
+			chip: "bg-sky-100 text-sky-800 dark:bg-sky-900/40 dark:text-sky-300",
+			dot: "bg-sky-500",
+		},
+		4: {
+			titulo: "En 4 días",
+			chip: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+			dot: "bg-slate-400",
+		},
+		5: {
+			titulo: "En 5 días",
+			chip: "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300",
+			dot: "bg-slate-400",
+		},
+	};
+
+/** "premora_5" → "D-5" (badge de recordatorio enviado). */
+const etiquetaRecordatorio = (tipo: string) => tipo.replace("premora_", "D-");
+
+/** "YYYY-MM-DD" → "dd/mm/aaaa" sin pasar por Date (evita corrimiento por TZ). */
+function fechaLegible(iso: string) {
+	const [y, m, d] = String(iso ?? "").split("-");
+	return y && m && d ? `${d}/${m}/${y}` : String(iso ?? "");
+}
+
+function montoQ(v: string) {
+	const n = Number(v);
+	return Number.isFinite(n)
+		? `Q${n.toLocaleString("es-GT", {
+				minimumFractionDigits: 2,
+				maximumFractionDigits: 2,
+			})}`
+		: String(v ?? "");
+}
+
+function AgendaDiaPage() {
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user?.role;
+	const esSupervisor = !!userRole && PERMISSIONS.canAssignCobros(userRole);
+
+	// "todos" | asesorId como string (Select de shadcn trabaja con strings).
+	const [asesorSel, setAsesorSel] = useState("todos");
+
+	const agendaQuery = useQuery({
+		...orpc.getAgendaDia.queryOptions({
+			input: {
+				asesorId:
+					esSupervisor && asesorSel !== "todos" ? Number(asesorSel) : undefined,
+			},
+		}),
+		enabled: !!session,
+	});
+
+	const asesoresQuery = useQuery({
+		...orpc.getAsesores.queryOptions({
+			input: { page: 1, perPage: 100 },
+		}),
+		enabled: !!session && esSupervisor,
+	});
+
+	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<div className="text-center">
+					<h1 className="mb-4 font-bold text-2xl text-gray-800">
+						Acceso Denegado
+					</h1>
+					<p className="text-gray-600">
+						Solo el equipo de cobros puede ver la agenda del día.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const agenda = agendaQuery.data as AgendaResponse | undefined;
+	const items = agenda?.items ?? [];
+	const asesores = (
+		(asesoresQuery.data as { asesores?: AsesorOption[] } | undefined)
+			?.asesores ?? []
+	).filter((a) => a.activo);
+
+	// Agrupar por urgencia manteniendo el orden D-0 → D-5 del server.
+	const grupos = [0, 1, 2, 3, 4, 5]
+		.map((dias) => ({
+			dias,
+			items: items.filter((i) => i.diasParaVencer === dias),
+		}))
+		.filter((g) => g.items.length > 0);
+
+	const totalHoy = items.filter((i) => i.diasParaVencer === 0).length;
+
+	const irAlDetalle = (sifco: string) => {
+		navigate({
+			to: "/cobros/$id",
+			params: { id: sifco },
+			search: { tipo: "caso" },
+		});
+	};
+
+	return (
+		<div className="container mx-auto space-y-4 p-4 lg:p-6">
+			{/* Header */}
+			<Card>
+				<CardHeader className="pb-4">
+					<div className="flex flex-wrap items-start justify-between gap-3">
+						<div className="flex items-center gap-3">
+							<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+								<CalendarClock className="h-5 w-5" />
+							</div>
+							<div>
+								<CardTitle className="text-xl">Agenda del día</CardTitle>
+								<CardDescription>
+									Cuentas al día con cuota próxima a vencer — de hoy (D-0) a 5
+									días (D-5)
+									{agenda?.asesorForzado
+										? ` · Agenda de ${agenda.asesorForzado.nombre}`
+										: ""}
+								</CardDescription>
+							</div>
+						</div>
+						<div className="flex items-center gap-2">
+							{totalHoy > 0 && (
+								<Badge
+									variant="outline"
+									className={`border-transparent ${URGENCIA[0].chip}`}
+								>
+									{totalHoy} pagan hoy
+								</Badge>
+							)}
+							<Badge variant="secondary">{items.length} cuentas</Badge>
+							{esSupervisor && (
+								<Select value={asesorSel} onValueChange={setAsesorSel}>
+									<SelectTrigger className="h-8 w-52">
+										<UserRound className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
+										<SelectValue placeholder="Asesor" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="todos">Todos los asesores</SelectItem>
+										{asesores.map((a) => (
+											<SelectItem key={a.asesorId} value={String(a.asesorId)}>
+												{a.nombre}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							)}
+						</div>
+					</div>
+				</CardHeader>
+			</Card>
+
+			{/* Estados */}
+			{agendaQuery.isLoading && (
+				<div className="flex items-center justify-center py-16">
+					<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+				</div>
+			)}
+
+			{!agendaQuery.isLoading && agenda?.sinAsesor && (
+				<Card>
+					<CardContent className="py-10 text-center text-muted-foreground">
+						Tu usuario no está vinculado a un asesor de cartera (por correo).
+						Pedile al supervisor que revise tu correo de asesor.
+					</CardContent>
+				</Card>
+			)}
+
+			{!agendaQuery.isLoading && !agenda?.sinAsesor && items.length === 0 && (
+				<Card>
+					<CardContent className="py-10 text-center text-muted-foreground">
+						Sin cuotas próximas a vencer en los próximos 5 días. 🎉
+					</CardContent>
+				</Card>
+			)}
+
+			{/* Grupos por urgencia */}
+			{grupos.map((grupo) => {
+				const urgencia = URGENCIA[grupo.dias];
+				const fecha = grupo.items[0]?.fechaVencimiento;
+				return (
+					<Card key={grupo.dias}>
+						<CardHeader className="pb-2">
+							<div className="flex items-center gap-2">
+								<span className={`h-2.5 w-2.5 rounded-full ${urgencia.dot}`} />
+								<CardTitle className="text-base">{urgencia.titulo}</CardTitle>
+								<Badge
+									variant="outline"
+									className={`border-transparent text-[10px] ${urgencia.chip}`}
+								>
+									{grupo.items.length}
+								</Badge>
+								{fecha && (
+									<span className="text-muted-foreground text-xs">
+										vencen el {fechaLegible(fecha)}
+									</span>
+								)}
+							</div>
+						</CardHeader>
+						<CardContent className="pt-0">
+							<div className="overflow-x-auto">
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Cliente</TableHead>
+											<TableHead>Crédito</TableHead>
+											<TableHead className="text-center">Cuota</TableHead>
+											<TableHead className="text-right">Monto</TableHead>
+											<TableHead>Teléfono</TableHead>
+											{esSupervisor && asesorSel === "todos" && (
+												<TableHead>Asesor</TableHead>
+											)}
+											<TableHead>Recordatorios</TableHead>
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{grupo.items.map((item) => (
+											<TableRow
+												key={item.cuotaId}
+												className="cursor-pointer"
+												onClick={() => irAlDetalle(item.numeroCreditoSifco)}
+											>
+												<TableCell className="font-medium">
+													{item.cliente ?? "—"}
+												</TableCell>
+												<TableCell className="max-w-45 truncate font-mono text-muted-foreground text-xs">
+													{item.numeroCreditoSifco}
+												</TableCell>
+												<TableCell className="text-center tabular-nums">
+													#{item.numeroCuota}
+												</TableCell>
+												<TableCell className="text-right font-medium tabular-nums">
+													{montoQ(item.montoCuota)}
+												</TableCell>
+												<TableCell>
+													{item.telefono ? (
+														<span className="inline-flex items-center gap-1 text-sm">
+															<Phone className="h-3 w-3 text-muted-foreground" />
+															{item.telefono}
+														</span>
+													) : (
+														<span className="text-muted-foreground text-xs">
+															Sin teléfono
+														</span>
+													)}
+												</TableCell>
+												{esSupervisor && asesorSel === "todos" && (
+													<TableCell className="text-sm">
+														{item.asesor ?? "—"}
+													</TableCell>
+												)}
+												<TableCell>
+													{item.recordatorios.length > 0 ? (
+														<span className="inline-flex flex-wrap items-center gap-1">
+															{item.recordatorios.map((r) => (
+																<Badge
+																	key={r.tipo}
+																	variant="outline"
+																	className="gap-0.5 border-transparent bg-emerald-100 text-[10px] text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300"
+																	title={`Recordatorio ${etiquetaRecordatorio(r.tipo)} enviado`}
+																>
+																	<MessageCircle className="h-2.5 w-2.5" />
+																	{etiquetaRecordatorio(r.tipo)}
+																	<CheckCircle2 className="h-2.5 w-2.5" />
+																</Badge>
+															))}
+														</span>
+													) : (
+														<span className="text-muted-foreground text-xs">
+															—
+														</span>
+													)}
+												</TableCell>
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							</div>
+						</CardContent>
+					</Card>
+				);
+			})}
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/routes/cobros/agenda.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/agenda.tsx
@@ -49,6 +49,7 @@ export const Route = createFileRoute("/cobros/agenda")({
 interface AgendaRecordatorio {
 	tipo: string;
 	enviadoAt: string | Date;
+	modoPrueba?: boolean;
 }
 
 interface AgendaItem {
@@ -430,8 +431,12 @@ function AgendaDiaPage() {
 																<Badge
 																	key={r.tipo}
 																	variant="outline"
-																	className="gap-0.5 border-transparent bg-emerald-100 text-[10px] text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300"
-																	title={`Recordatorio ${etiquetaRecordatorio(r.tipo)} enviado`}
+																	className={`gap-0.5 border-transparent text-[10px] ${
+																		r.modoPrueba
+																			? "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+																			: "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300"
+																	}`}
+																	title={`Recordatorio ${etiquetaRecordatorio(r.tipo)} enviado${r.modoPrueba ? " (modo prueba)" : ""}`}
 																>
 																	<MessageCircle className="h-2.5 w-2.5" />
 																	{etiquetaRecordatorio(r.tipo)}


### PR DESCRIPTION
## Resumen

Este PR agrega la **Agenda del día** al módulo de Cobros del CRM (la parte de CB-018 que quedó pendiente) y las **herramientas para probar premora** end-to-end en dev, más dos fixes encontrados en el camino.

## Agenda del día (CRM)

- **Pantalla `/cobros/agenda`** + ítem en el dropdown Cobros (desktop y mobile, visible para el rol `cobros`): cuentas con cuota que vence de **hoy (D-0) a 5 días (D-5)**, agrupadas por urgencia ("Pagan HOY" → "En 5 días") con fecha y conteo por grupo.
- **Todo el funnel, pareja para todos los asesores**: `/cuotas/proximas-vencer` (cartera-back) ganó `solo_al_dia=true|false` — la agenda usa `false` (ACTIVO/MOROSO/INCOBRABLE, sin exigir cero vencidas). El default `true` deja a **premora intacto (solo B0)**.
- **Bucket del motor por fila**: cada cuota trae el último `bucket_nuevo` de `buckets_historial` (misma fuente que el listado por bucket, sin fallback vivo). Viendo "todos" hay columna Bucket con el badge del catálogo; al filtrar un asesor la columna se oculta y el header muestra los **chips generales** con sus buckets (ej. `B1 B2`).
- **Permisos**: admin/supervisor eligen asesor con select (o ven todos); el rol `cobros` SOLO ve su agenda, **forzado server-side** matcheando su email de login contra los asesores de cartera (mismo puente por correo del resto del módulo). Sin match → aviso, nunca la agenda de otro.
- **Teléfono del cliente** resuelto caso de cobros → lead (la info del cliente vive en el CRM; cartera no tiene teléfonos de clientes) y **badges de recordatorios premora ya enviados** por cuota.
- Click en la fila → detalle `/cobros/$id` (ya soporta créditos sin caso).

## Card "Recordatorios de Pago" (detalle del crédito)

Traza completa de los premora enviados al crédito desde `cobros_send_logs`: tipo (D-5/D-3/D-1/D-0), teléfono, fecha/hora GT, y marcas de **"Prueba"** (modo test) y **"Falló"**. No depende del caso de cobros.

## Herramientas de prueba premora

- **`GET/POST /api/premora/run`** (solo admin/supervisor): corrida manual del job con `force` (ignora el env gate `PREMORA_WHATSAPP_ENABLED`), `?sifco=A,B` para limitar a créditos puntuales y `?dias=5,3,1,0` (CSV validado) para correr un solo tipo de recordatorio. El cron diario no cambia.

## Fixes

- **`usuarios` no tiene columna `telefono` en cartera (ningún schema)**: el SQL de `/cuotas/proximas-vencer` referenciaba `u.telefono` y habría reventado en la primera corrida real. Ahora devuelve `NULL::text` y el CRM resuelve el teléfono (caso → lead).
- Registro de `getAgendaDia`/`getRecordatoriosPremora` en `routers/index.ts` (los procedures se registran explícitamente).

## Probado en dev (modo test, mensajes al cel de prueba)

- ✅ D-5, D-3 y D-1 enviados y verificados (plantillas interpoladas correctas, log en `cobros_send_logs`, card del detalle).
- ✅ Premora sigue viendo SOLO créditos al día: con el funnel completo en la agenda (45 cuotas, 7 asesores), `dias=3` de premora devuelve 1 solo crédito (B0).
- ✅ Bucket motor en 45/45 filas del funnel; cada asesor mapea a su bucket del pool.

<img width="1735" height="913" alt="image" src="https://github.com/user-attachments/assets/196d79b4-91df-4572-ace6-0f8050be0cd8" />



## Notas

- Recordatorios para todo el funnel (no solo B0) = pendiente futuro, requiere plantillas distintas.
- Hallazgo de datos: hay leads con teléfono `00000000` que pasan el filtro de 8 dígitos — en prod ese envío iría a un número muerto (posible mejora aparte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
