### PR TITLE
fix(crm): getAnalysisChecklist ya no lanza 500 en oportunidades sin vehículo

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -4877,7 +4877,7 @@ export const crmRouter = {
 									required: true,
 									completed: false,
 								},
-								...(vehicle.isNew
+								...(vehicle?.isNew
 									? [
 											{
 												name: "Factura del vehículo nuevo",


### PR DESCRIPTION
## Problema

En producción, `getAnalysisChecklist` devolvía `500 INTERNAL_SERVER_ERROR` (genérico) al abrir el análisis de ciertas oportunidades. El `RPCHandler` de ORPC no tiene `onError`, así que el error real quedaba enmascarado y solo se veía el 500 en el navegador.

## Causa raíz

Cuando la oportunidad **no tiene vehículo** (`vehicle_id = NULL`), `const [vehicle] = vehicleResult` queda `undefined`. Al construir el `checklistData`, la subsección de verificaciones del vehículo evaluaba `vehicle.isNew` **sin optional chaining**:

```ts
...(vehicle.isNew ? [ { name: "Factura del vehículo nuevo", ... } ] : [])
```

Eso lanza `TypeError: Cannot read properties of undefined (reading 'isNew')`. Las otras lecturas de `vehicle.isNew` (líneas ~4623/4634/4673) están dentro de `if (vehicle) {`, por eso son seguras; esta era la única sin proteger.

## Fix

`vehicle.isNew` → `vehicle?.isNew` (una línea).

## Verificación

- Reproducido contra la DB de prod con la oportunidad `ed31b64f-84d0-4de0-8ff7-2953fed1a363` (`autocompra`, `vehicle_id = NULL`, con `credit_analysis`, sin checklist previo → por eso el 500 era constante y nunca se creaba la fila).
- Se descartó drift de schema: todas las tablas y columnas que el handler consulta existen en prod; no faltan tablas ni valores de enum.
- Alcance: hay **~705 oportunidades abiertas sin vehículo** en prod; cualquiera que se abriera en análisis disparaba este 500.

## Nota (aparte de este PR)

Vale la pena agregar un `onError` al `RPCHandler` en `apps/crm/apps/server/src/index.ts` para loguear el error real en el servidor y no volver a depender de reconstruir el 500 a mano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)