### PR TITLE
feat(crm): día de pago recomendado por IA en asignación de inversión y contratos

### DIFF
--- a/apps/cartera-back/src/controllers/createCredit.ts
+++ b/apps/cartera-back/src/controllers/createCredit.ts
@@ -697,7 +697,7 @@ if (creditosInversionistasData.length > 0) {
 // 3. GENERACIÓN DE FECHAS
 // ========================================
 
-const generatePaymentDates = (plazo: number, diaPagoMensual: 15 | 30): string[] => {
+const generatePaymentDates = (plazo: number, diaPagoMensual: number): string[] => {
   const fechas: string[] = [];
   const startDate = new Date();
 
@@ -956,9 +956,10 @@ export const createCreditCore = async (
   const { newCredit, creditDataForInsert, total_monto_cash_in, total_iva_cash_in } =
     await insertCreditAndRelated(creditData, executor);
 
-  // día <= 20 → pago el 15, día > 20 → pago el 30
-  const diaPago: 15 | 30 = creditData.dia_pago_mensual <= 20 ? 15 : 30;
-  const fechas = generatePaymentDates(creditData.plazo, diaPago);
+  // El día de pago ya viene validado (1-31) desde el CRM: 15, 30, o un día
+  // recomendado por el análisis de capacidad de pago. generatePaymentDates
+  // hace el clamp de fin de mes internamente, así que se usa tal cual.
+  const fechas = generatePaymentDates(creditData.plazo, creditData.dia_pago_mensual);
 
   const { cuotaInicial, cuotasInsertadas } = await insertInstallments(
     newCredit.credito_id,

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1952,7 +1952,7 @@ export const crmRouter = {
 				tasaInteres: z.string().optional(),
 				cuotaMensual: z.string().optional(),
 				fechaInicio: z.string().optional(),
-				diaPagoMensual: z.union([z.literal(15), z.literal(30)]).optional(),
+				diaPagoMensual: z.number().int().min(1).max(31).optional(),
 				// Additional fields
 				seguro: z.number().optional(),
 				gps: z.number().optional(),
@@ -2011,6 +2011,36 @@ export const crmRouter = {
 				throw new ORPCError("NOT_FOUND", {
 					message: "Oportunidad no encontrada",
 				});
+			}
+
+			// diaPagoMensual solo puede ser 15, 30, o uno de los días recomendados
+			// por el análisis de capacidad de pago (IA) del lead de esta oportunidad.
+			if (
+				input.diaPagoMensual !== undefined &&
+				input.diaPagoMensual !== 15 &&
+				input.diaPagoMensual !== 30
+			) {
+				let suggestedDays: Array<{ dia: number; porcentaje: number }> | null =
+					null;
+				if (currentOpportunity[0].leadId) {
+					const [analysis] = await db
+						.select({
+							suggestedPaymentDays: creditAnalysis.suggestedPaymentDays,
+						})
+						.from(creditAnalysis)
+						.where(eq(creditAnalysis.leadId, currentOpportunity[0].leadId))
+						.limit(1);
+					suggestedDays = analysis?.suggestedPaymentDays ?? null;
+				}
+				const isRecommended = suggestedDays?.some(
+					(d) => d.dia === input.diaPagoMensual,
+				);
+				if (!isRecommended) {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"El día de pago mensual debe ser 15, 30, o uno de los días recomendados por el análisis de capacidad de pago",
+					});
+				}
 			}
 
 			// Validate stage transitions

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -5940,9 +5940,26 @@ export const crmRouter = {
 							.where(inArray(vehicles.id, vehicleIds))
 					: [];
 
+			// Fetch suggested payment days (fecha ideal de pago) from the lead's credit analysis
+			const creditAnalysisData =
+				leadIds.length > 0
+					? await db
+							.select({
+								leadId: creditAnalysis.leadId,
+								suggestedPaymentDays: creditAnalysis.suggestedPaymentDays,
+							})
+							.from(creditAnalysis)
+							.where(inArray(creditAnalysis.leadId, leadIds))
+					: [];
+
 			// Create maps for quick lookup
 			const leadsMap = new Map(leadsData.map((l) => [l.id, l]));
 			const vehiclesMap = new Map(vehiclesData.map((v) => [v.id, v]));
+			const creditAnalysisMap = new Map(
+				creditAnalysisData
+					.filter((ca): ca is typeof ca & { leadId: string } => !!ca.leadId)
+					.map((ca) => [ca.leadId, ca.suggestedPaymentDays]),
+			);
 
 			// Map results
 			const data = opps.map((opp) => {
@@ -5985,6 +6002,9 @@ export const crmRouter = {
 					categoria: opp.categoria,
 					nit: opp.nit,
 					diaPagoMensual: opp.diaPagoMensual,
+					suggestedPaymentDays: opp.leadId
+						? creditAnalysisMap.get(opp.leadId) ?? null
+						: null,
 					createdAt: opp.createdAt,
 					updatedAt: opp.updatedAt,
 					creditType: opp.creditType,
@@ -6058,7 +6078,7 @@ export const crmRouter = {
 					"Vehículo",
 				]),
 				nit: z.string(),
-				diaPagoMensual: z.union([z.literal(15), z.literal(30)]),
+				diaPagoMensual: z.number().int().min(1).max(31),
 			}),
 		)
 		.handler(async ({ input, context }) => {
@@ -6086,6 +6106,32 @@ export const crmRouter = {
 				throw new ORPCError("BAD_REQUEST", {
 					message: "La oportunidad debe estar en la etapa del 50%",
 				});
+			}
+
+			// diaPagoMensual solo puede ser 15, 30, o uno de los días recomendados
+			// por el análisis de capacidad de pago (IA) del lead de esta oportunidad.
+			if (input.diaPagoMensual !== 15 && input.diaPagoMensual !== 30) {
+				let suggestedDays: Array<{ dia: number; porcentaje: number }> | null =
+					null;
+				if (opportunity.leadId) {
+					const [analysis] = await db
+						.select({
+							suggestedPaymentDays: creditAnalysis.suggestedPaymentDays,
+						})
+						.from(creditAnalysis)
+						.where(eq(creditAnalysis.leadId, opportunity.leadId))
+						.limit(1);
+					suggestedDays = analysis?.suggestedPaymentDays ?? null;
+				}
+				const isRecommended = suggestedDays?.some(
+					(d) => d.dia === input.diaPagoMensual,
+				);
+				if (!isRecommended) {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"El día de pago mensual debe ser 15, 30, o uno de los días recomendados por el análisis de capacidad de pago",
+					});
+				}
 			}
 
 			// Parse existing investors from DB

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -2020,15 +2020,17 @@ export const crmRouter = {
 				input.diaPagoMensual !== 15 &&
 				input.diaPagoMensual !== 30
 			) {
+				// Lead efectivo tras el update, no el actual (por si input.leadId también cambia)
+				const effectiveLeadId = input.leadId ?? currentOpportunity[0].leadId;
 				let suggestedDays: Array<{ dia: number; porcentaje: number }> | null =
 					null;
-				if (currentOpportunity[0].leadId) {
+				if (effectiveLeadId) {
 					const [analysis] = await db
 						.select({
 							suggestedPaymentDays: creditAnalysis.suggestedPaymentDays,
 						})
 						.from(creditAnalysis)
-						.where(eq(creditAnalysis.leadId, currentOpportunity[0].leadId))
+						.where(eq(creditAnalysis.leadId, effectiveLeadId))
 						.limit(1);
 					suggestedDays = analysis?.suggestedPaymentDays ?? null;
 				}

--- a/apps/crm/apps/server/src/services/cartera-back-integration.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-integration.ts
@@ -152,7 +152,7 @@ export interface CreateCreditoParams {
 	departamento?: string | null;
 	codigo_postal?: string | null;
 	pais?: string | null;
-	dia_pago_mensual?: 15 | 30;
+	dia_pago_mensual?: number;
 	// Campos para el correo de notificación
 	vehiculo_marca?: string;
 	vehiculo_linea?: string;

--- a/apps/crm/apps/server/src/services/close-opportunity.ts
+++ b/apps/crm/apps/server/src/services/close-opportunity.ts
@@ -41,11 +41,13 @@ export const DEFAULT_CODIGO_POSTAL = "01001";
 /** Credit number prefix for CRM-generated credits */
 export const CREDIT_NUMBER_PREFIX = "CRM";
 
-function normalizePaymentDay(day: number | null | undefined): 15 | 30 | null {
+// El día de pago ya se validó al guardarlo en la oportunidad (assignInvestorAndAdvance):
+// siempre es 15, 30, o un día recomendado por el análisis de capacidad de pago del lead.
+// Aquí solo se confirma que sea un día de mes válido antes de mandarlo a cartera-back.
+function normalizePaymentDay(day: number | null | undefined): number | null {
 	if (day == null) return null;
-	if (day === 15 || day === 30) return day;
-	if (day === 31) return 30;
-	return null;
+	if (!Number.isInteger(day) || day < 1 || day > 31) return null;
+	return day;
 }
 
 // ============================================================================
@@ -951,7 +953,7 @@ async function createCredit(
 			return {
 				success: false,
 				error:
-					"La oportunidad debe tener día de pago 15 o 30 para crear el crédito en cartera-back",
+					"La oportunidad debe tener un día de pago válido (1-31) para crear el crédito en cartera-back",
 			};
 		}
 

--- a/apps/crm/apps/server/src/services/contract-data-mapper.ts
+++ b/apps/crm/apps/server/src/services/contract-data-mapper.ts
@@ -184,6 +184,10 @@ export interface ContractData {
 		tasaInteresEnLetras: string;
 		diaPago: number;
 		diaPagoEnLetras: string;
+		// Valor crudo de opportunity.diaPagoMensual (sin el fallback a 1 de diaPago).
+		// Sirve para que jurídico detecte si el analista eligió un día recomendado
+		// por la IA (distinto de 15/30) sin confundirlo con el default de diaPago.
+		diaPagoMensualRaw: number | null;
 		seguro?: number;
 		seguroEnLetras?: string;
 		gps?: number;
@@ -517,6 +521,7 @@ export async function mapOpportunityToContractData(
 			tasaInteresEnLetras: numberToWords(Math.floor(tasaInteres)),
 			diaPago,
 			diaPagoEnLetras: numberToWords(diaPago),
+			diaPagoMensualRaw: opportunity.diaPagoMensual ?? null,
 			seguro,
 			seguroEnLetras: seguro ? numberToWordsQuetzales(seguro) : undefined,
 			gps,

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -113,7 +113,7 @@ export interface CreateCreditoInput {
 	no_poliza?: string;
 	aseguradora?: string;
 	como_se_entero?: string;
-	dia_pago_mensual?: 15 | 30;
+	dia_pago_mensual?: number;
 	membresias_pago?: number;
 	categoria?: string;
 	nit?: string;

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -68,7 +68,7 @@ type CreditCategory =
 	| "Hipotecario"
 	| "Vehículo";
 
-type PaymentDay = 15 | 30;
+type PaymentDay = number;
 
 // Type for existing investor from DB
 type ExistingInvestor = {
@@ -950,7 +950,7 @@ export function InvestmentAssignmentSection({
 										<Select
 											value={editDiaPagoMensual.toString()}
 											onValueChange={(value) =>
-												setEditDiaPagoMensual(Number(value) as PaymentDay)
+												setEditDiaPagoMensual(Number(value))
 											}
 										>
 											<SelectTrigger>
@@ -959,8 +959,25 @@ export function InvestmentAssignmentSection({
 											<SelectContent>
 												<SelectItem value="15">15</SelectItem>
 												<SelectItem value="30">Fin de mes</SelectItem>
+												{selectedOpportunity.suggestedPaymentDays
+													?.filter(
+														(d: { dia: number; porcentaje: number }) =>
+															d.dia !== 15 && d.dia !== 30,
+													)
+													.map((d: { dia: number; porcentaje: number }) => (
+														<SelectItem key={d.dia} value={d.dia.toString()}>
+															Día {d.dia} ({d.porcentaje}% recomendado en Análisis)
+														</SelectItem>
+													))}
 											</SelectContent>
 										</Select>
+										{selectedOpportunity.suggestedPaymentDays &&
+											selectedOpportunity.suggestedPaymentDays.length > 0 && (
+												<p className="mt-1 text-[10px] text-muted-foreground">
+													Análisis de capacidad de pago sugiere estas fechas
+													según los ingresos detectados del cliente.
+												</p>
+											)}
 									</div>
 								</div>
 							</div>

--- a/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
+++ b/apps/crm/apps/web/src/components/analysis/InvestmentAssignmentSection.tsx
@@ -964,6 +964,10 @@ export function InvestmentAssignmentSection({
 														(d: { dia: number; porcentaje: number }) =>
 															d.dia !== 15 && d.dia !== 30,
 													)
+													.filter(
+														(d, i, arr) =>
+															arr.findIndex((x) => x.dia === d.dia) === i,
+													)
 													.map((d: { dia: number; porcentaje: number }) => (
 														<SelectItem key={d.dia} value={d.dia.toString()}>
 															Día {d.dia} ({d.porcentaje}% recomendado en Análisis)

--- a/apps/crm/apps/web/src/components/contracts/DynamicContractWizard.tsx
+++ b/apps/crm/apps/web/src/components/contracts/DynamicContractWizard.tsx
@@ -129,6 +129,9 @@ export interface CRMData {
 		cuotaMensual?: number;
 		porcentajeInteres?: number;
 		porcentajeMora?: number;
+		// Valor crudo de opportunity.diaPagoMensual. Si no es 15 ni 30, significa que
+		// el analista eligió uno de los 3 días recomendados por la IA en el 50%.
+		diaPagoMensualRaw?: number | null;
 	};
 	coDebtors?: CoDebtorData[];
 }
@@ -619,6 +622,12 @@ export function DynamicContractWizard({
 	// Date configuration states
 	const [fechaVencimiento, setFechaVencimiento] = useState<string>("");
 	const [diaPago, setDiaPago] = useState<string>("día quince"); // Default día 15
+	// Día recomendado por la IA que el analista eligió en el 50% (si aplica).
+	// Solo se llena cuando opportunity.diaPagoMensual no es 15 ni 30.
+	const [analysisSuggestedDay, setAnalysisSuggestedDay] = useState<{
+		dia: number;
+		label: string;
+	} | null>(null);
 
 	// Initialize co-debtor editable fields from CRM data
 	useEffect(() => {
@@ -818,6 +827,10 @@ export function DynamicContractWizard({
 			if (value === "último día") {
 				// Último día del mes
 				nuevoDia = new Date(anio, mes + 1, 0).getDate();
+			} else if (analysisSuggestedDay && value === analysisSuggestedDay.label) {
+				// Día recomendado por la IA que eligió el analista en el 50%
+				const diasEnMes = new Date(anio, mes + 1, 0).getDate();
+				nuevoDia = Math.min(analysisSuggestedDay.dia, diasEnMes);
 			} else {
 				// Día 15
 				nuevoDia = 15;
@@ -1233,14 +1246,23 @@ export function DynamicContractWizard({
 					let diaPagoDefault: string;
 					let diaVenc: number;
 
-					if (diaActual <= 20) {
+					const diaAnalisis = crmData.credito?.diaPagoMensualRaw;
+					const diasEnMesVenc = new Date(anioVenc, mesVenc + 1, 0).getDate();
+
+					if (diaAnalisis && diaAnalisis !== 15 && diaAnalisis !== 30) {
+						// El analista eligió uno de los 3 días recomendados por la IA en el
+						// 50%: ese es el default aquí, en vez del algoritmo por fecha de hoy.
+						diaPagoDefault = `día ${numberToText(diaAnalisis)}`;
+						diaVenc = Math.min(diaAnalisis, diasEnMesVenc);
+						setAnalysisSuggestedDay({ dia: diaAnalisis, label: diaPagoDefault });
+					} else if (diaActual <= 20) {
 						// Del 1 al 20: día de pago es 15, vencimiento día 15 del mes siguiente
 						diaPagoDefault = "día quince";
 						diaVenc = 15;
 					} else {
 						// Del 21 al 31: día de pago es último día, vencimiento último día del mes siguiente
 						diaPagoDefault = "último día";
-						diaVenc = new Date(anioVenc, mesVenc + 1, 0).getDate();
+						diaVenc = diasEnMesVenc;
 					}
 
 					const fechaStr = `${anioVenc}-${String(mesVenc + 1).padStart(2, "0")}-${String(diaVenc).padStart(2, "0")}`;
@@ -1792,6 +1814,12 @@ export function DynamicContractWizard({
 														<option value="último día">
 															Último día del mes
 														</option>
+														{analysisSuggestedDay && (
+															<option value={analysisSuggestedDay.label}>
+																Día {analysisSuggestedDay.dia} (elegido en
+																Análisis)
+															</option>
+														)}
 													</select>
 													<p className="text-muted-foreground text-xs">
 														Se usará: "{fieldValues.diaPago || "día quince"}"

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -74,7 +74,7 @@ type CreditCategory =
 	| "Hipotecario"
 	| "Vehículo";
 
-type PaymentDay = 15 | 30;
+type PaymentDay = number;
 
 // Tipo para inversionista seleccionado
 interface SelectedInversionista {
@@ -1055,11 +1055,18 @@ export function CreditDetailView({
 													<SelectValue placeholder="Seleccionar día" />
 												</SelectTrigger>
 												<SelectContent>
-													{[1, 5, 10, 15, 20, 25, 30].map((day) => (
-														<SelectItem key={day} value={String(day)}>
-															Día {day}
-														</SelectItem>
-													))}
+													<SelectItem value="15">Día 15</SelectItem>
+													<SelectItem value="30">Día 30</SelectItem>
+													{consolidatedCreditQuery.data?.lead?.suggestedPaymentDays
+														?.filter(
+															(d: { dia: number; porcentaje: number }) =>
+																d.dia !== 15 && d.dia !== 30,
+														)
+														.map((d: { dia: number; porcentaje: number }) => (
+															<SelectItem key={d.dia} value={String(d.dia)}>
+																Día {d.dia} ({d.porcentaje}% recomendado)
+															</SelectItem>
+														))}
 												</SelectContent>
 											</Select>
 										) : (

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -1062,6 +1062,10 @@ export function CreditDetailView({
 															(d: { dia: number; porcentaje: number }) =>
 																d.dia !== 15 && d.dia !== 30,
 														)
+														.filter(
+															(d, i, arr) =>
+																arr.findIndex((x) => x.dia === d.dia) === i,
+														)
 														.map((d: { dia: number; porcentaje: number }) => (
 															<SelectItem key={d.dia} value={String(d.dia)}>
 																Día {d.dia} ({d.porcentaje}% recomendado)

--- a/apps/crm/apps/web/src/routes/juridico/generate.$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/juridico/generate.$opportunityId.tsx
@@ -216,6 +216,7 @@ function RouteComponent() {
 					mesesPrestamo: previewQuery.data.credito?.numeroCuotas,
 					cuotaMensual: previewQuery.data.credito?.cuotaMensual,
 					porcentajeInteres: previewQuery.data.credito?.tasaInteres,
+					diaPagoMensualRaw: previewQuery.data.credito?.diaPagoMensualRaw,
 				},
 				coDebtors: coDebtorsQuery.data?.map((cd) => ({
 					id: cd.id,


### PR DESCRIPTION
## Qué hace este PR

Extiende "fecha ideal de pago" (#1118) para que el día recomendado por IA se pueda usar como día de pago real, de punta a punta: Asignación de Inversión (50%), Generar Contratos (jurídico), cierre de la oportunidad (90%) + cartera-back, y edición manual del crédito.

## Cambios

### Asignación de Inversión — 50%

- El select "Día de Pago Mensual" ya no está forzado a 15/30: si el lead tiene `credit_analysis.suggested_payment_days`, se agregan como opciones extra (deduplicadas por día, por si algún candidato se repitiera).
- `assignInvestorAndAdvance` valida server-side que el valor enviado sea 15, 30, o uno de los `dias_pago_sugeridos` reales del lead — no confía en lo que mande el cliente.
- Se persiste tal cual en `opportunities.diaPagoMensual`.

### Generar Contratos — jurídico

- El wizard **ignora a propósito** el día guardado en la oportunidad y decide el día de pago del contrato con su propio algoritmo por fecha de hoy. Eso es intencional y no se toca: si la oportunidad quedó en 15/30, jurídico sigue funcionando exactamente igual.
- Único cambio: si la oportunidad quedó con un día IA (no 15/30), ese día se preselecciona en el select (en vez del algoritmo por fecha), visible como `Día X (elegido en Análisis)`. Jurídico puede seguir cambiando manualmente a 15/último día si lo necesita.
- Para detectarlo se agregó `credito.diaPagoMensualRaw` (valor crudo, nullable) separado de `credito.diaPago`, porque este último tiene un fallback a `1` que hubiera generado falsos positivos en oportunidades viejas sin día asignado.

### Cierre de oportunidad (90%) + cartera-back

- `normalizePaymentDay` (CRM) ya no fuerza 15/30 (31→30) — solo valida que sea un día de mes 1-31. La validación de negocio real ya ocurrió una sola vez, al guardar el valor en `assignInvestorAndAdvance`.
- `generatePaymentDates` (cartera-back) ya era genérico internamente (clamp de fin de mes incluido); solo estaba mal tipado como `15 | 30`.
- `createCreditCore` (cartera-back) ya no bucketea el día (`<=20→15, >20→30`) — usa el valor real que manda el CRM.
- Probado, oportunidad con día 8 llega a 90%, y `cartera.cuotas_credito` cae consistentemente el día 8 de cada mes (con clamp de fin de mes), sin bucketear.

### Edición manual del crédito (`CreditDetailView.tsx`)

- Mismo patrón que el select del 50%: el dropdown de "Día de Pago Mensual" pasó de 7 opciones fijas (1/5/10/15/20/25/30, sin relación con el lead) a 15/30 + los 3 días recomendados por IA del lead (deduplicadas), leídos de `getConsolidatedCreditAnalysis` (dato que esta pantalla ya cargaba).
- `updateOpportunity` recibió la misma validación server-side que `assignInvestorAndAdvance` (15, 30, o un día real de `credit_analysis`), evaluada contra el lead efectivo de la oportunidad (el que quedará guardado si `leadId` también cambia en la misma petición, no necesariamente el actual).
