### PR TITLE
feat(cobros): CRM server — escritura de capacidad_base/margen_alerta por asesor+bucket (CB-019)

### DIFF
--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -41,6 +41,7 @@ import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
 import { getTestPhone, isTestModeEnabled } from "./lib/messaging-test-mode";
 import { PERMISSIONS } from "./lib/roles";
+import { bucketCapacidadRouter } from "./routers/bucket-capacidad";
 import {
 	appRouter,
 	disbursementRouter,
@@ -177,6 +178,7 @@ const handler = new RPCHandler(
 		manualVehicleRouter,
 		investmentsRouter,
 		disbursementRouter,
+		bucketCapacidadRouter,
 	),
 );
 app.use("/rpc/*", async (c, next) => {

--- a/apps/crm/apps/server/src/routers/bucket-capacidad.ts
+++ b/apps/crm/apps/server/src/routers/bucket-capacidad.ts
@@ -1,0 +1,12 @@
+import { cobrosRouter } from "./cobros";
+
+// CB-019 · exportado en su propio archivo (mismo motivo que
+// disbursementRouter/proyeccionRouter en routers/index.ts: cobrosAppRouter ya
+// está en el límite donde TS7056 empieza a truncar SILENCIOSAMENTE el tipo
+// inferido de routers/index.ts — agregar una key más ahí, o incluso un nuevo
+// export en el mismo archivo, hacía desaparecer la key del tipo de `orpc` en
+// el web sin ningún error de compilación. Archivo aparte = módulo con su
+// propio tipo, sin tocar el tamaño de index.ts).
+export const bucketCapacidadRouter = {
+	actualizarCapacidadAsesorBucket: cobrosRouter.actualizarCapacidadAsesorBucket,
+};

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -67,6 +67,7 @@ import {
 	rangoCuotasPorEstadoMora,
 } from "../lib/moraBuckets";
 import {
+	adminProcedure,
 	cobrosProcedure,
 	cobrosSupervisorProcedure,
 	crmCobrosOrInvestmentsProcedure,
@@ -4747,6 +4748,62 @@ export const cobrosRouter = {
 				bucket: input.bucket,
 				asesor_id: input.asesorId,
 			});
+		}),
+
+	// ────────────────────────────────────────────────────────────────────────
+	// CB-019 · Configurar capacidad_base/margen_alerta por asesor+bucket
+	// Solo admin (a diferencia de getCargaPorAsesorBucket, que sigue siendo
+	// admin+supervisor): el supervisor puede ver el dashboard pero no editar
+	// capacidades, pedido explícito del negocio.
+	// ────────────────────────────────────────────────────────────────────────
+	actualizarCapacidadAsesorBucket: adminProcedure
+		.input(
+			z
+				.object({
+					asesorId: z.number().int().positive(),
+					bucket: z.number().int().min(0).max(5),
+					// Tope de sanidad (review code-review): un asesor no atiende más de
+					// 2000 cuentas en un bucket — evita un fat-finger tipo 999999.
+					capacidadBase: z.number().int().positive().max(2000),
+					margenAlertaTipo: z.enum(["porcentaje", "fijo"]),
+					margenAlertaValor: z.number().min(0),
+				})
+				.refine(
+					(v) => v.margenAlertaTipo !== "porcentaje" || v.margenAlertaValor <= 100,
+					{
+						message: "margenAlertaValor debe ser <= 100 cuando el tipo es porcentaje",
+						path: ["margenAlertaValor"],
+					},
+				)
+				.refine((v) => v.margenAlertaTipo !== "fijo" || v.margenAlertaValor <= 500, {
+					message: "margenAlertaValor debe ser <= 500 cuando el tipo es fijo",
+					path: ["margenAlertaValor"],
+				}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+			try {
+				return await carteraBackClient.actualizarCapacidadAsesorBucket({
+					asesor_id: input.asesorId,
+					bucket: input.bucket,
+					capacidad_base: input.capacidadBase,
+					margen_alerta_tipo: input.margenAlertaTipo,
+					margen_alerta_valor: input.margenAlertaValor,
+				});
+			} catch (err) {
+				// cartera-back-client.ts (request()) lanza Error en cualquier no-2xx
+				// (400/404/500) — el {success:false} del client method nunca se
+				// alcanza (review code-review #1). Se mapea el mensaje real de
+				// cartera-back a BAD_REQUEST en vez de burbujear como 500 genérico.
+				throw new ORPCError("BAD_REQUEST", {
+					message:
+						err instanceof Error ? err.message : "No se pudo actualizar la capacidad",
+				});
+			}
 		}),
 
 	// Reasignación manual. Solo supervisor/gerente (cobrosSupervisorProcedure).

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1096,6 +1096,30 @@ export class CarteraBackClient {
 		return response.data ?? { buckets: [], porAsesor: [], fecha: "" };
 	}
 
+	// CB-019: escritura de capacidad_base/margen_alerta por asesor+bucket (antes
+	// solo editable a mano por SQL). Sin cache que invalidar aquí (getCargaPorAsesorBucket
+	// ya es sin cache — ver comentario arriba); el caller invalida su propia query.
+	async actualizarCapacidadAsesorBucket(input: {
+		asesor_id: number;
+		bucket: number;
+		capacidad_base: number;
+		margen_alerta_tipo: "porcentaje" | "fijo";
+		margen_alerta_valor: number;
+	}): Promise<{ success: boolean; message?: string }> {
+		const response = await this.request<{
+			success: boolean;
+			message?: string;
+		}>(`/buckets/asesor-bucket/${input.asesor_id}/${input.bucket}`, {
+			method: "PATCH",
+			body: JSON.stringify({
+				capacidad_base: input.capacidad_base,
+				margen_alerta_tipo: input.margen_alerta_tipo,
+				margen_alerta_valor: input.margen_alerta_valor,
+			}),
+		});
+		return response;
+	}
+
 	// Pool de asesores elegibles de un bucket (alimenta el dropdown del modal).
 	async getPoolAsesoresPorBucket(
 		bucket: number,

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -228,6 +228,9 @@ export interface CargaPorAsesorBucketDetalle {
 	alerta_nueva_posicion: boolean;
 	/** Umbral absoluto (capacidad_base + margen resuelto) a partir del cual esta fila entra en alerta_nueva_posicion. */
 	umbral_alerta_cuentas: number;
+	/** CB-019: crudos de margen, para prellenar el formulario de edición de capacidad. */
+	margen_alerta_tipo: "porcentaje" | "fijo";
+	margen_alerta_valor: number;
 }
 
 export interface CargaPorAsesor {
@@ -253,6 +256,15 @@ export interface CargaPorAsesorBucketResponse {
 	buckets: CargaPorBucketResumen[];
 	porAsesor: CargaPorAsesor[];
 	fecha: string;
+}
+
+/** CB-019: input de PATCH /buckets/asesor-bucket/:asesor_id/:bucket. */
+export interface ActualizarCapacidadAsesorBucketInput {
+	asesor_id: number;
+	bucket: number;
+	capacidad_base: number;
+	margen_alerta_tipo: "porcentaje" | "fijo";
+	margen_alerta_valor: number;
 }
 
 export interface GetAsesorHistorialParams {


### PR DESCRIPTION
## Summary
PR 2/3 de CB-019 (config de capacidad máxima por bucket para alertas, no bloqueo duro). PR 1 (cartera-back, ya mergeado a `COBROS-02`): #1128. Este PR es solo `apps/crm/apps/server` — el PR 3 (`apps/crm/apps/web`) va aparte y depende de este.

### Qué ya existía antes de este PR
- CB-018 dejó `cartera.asesor_bucket.capacidad_base`/`margen_alerta_*` (por asesor+bucket) solo-lectura: gerencia las editaba a mano por SQL.
- El CRM ya exponía la lectura (`getCargaPorAsesorBucket`, `cobrosSupervisorProcedure` — admin+supervisor) alimentando el dashboard `/cobros/carga`, que ya calculaba `sobrecarga`/`alerta_nueva_posicion` (la semántica de "alerta, no bloqueo" que pide CB-019 ya existía ahí).
- PR 1 agregó en cartera-back el único camino de escritura: `PATCH /buckets/asesor-bucket/:asesor_id/:bucket`, con topes de sanidad y filtro de pool activo (ver #1128 y sus fixes post-review de Codex).

### Qué agrega este PR
- Nueva procedure oRPC `actualizarCapacidadAsesorBucket` (`routers/cobros.ts`), gateada por `adminProcedure` — **solo admin**, a diferencia de la lectura que sigue siendo admin+supervisor (pedido explícito: supervisor ve el dashboard pero no edita capacidades).
- Zod espeja los mismos topes que cartera-back: `capacidadBase` 1-2000, `margenAlertaValor` ≤100 si `porcentaje` o ≤500 si `fijo` — defensa en profundidad, no depender solo de la validación de cartera-back.
- `try/catch` alrededor de la llamada al cliente: `cartera-back-client.ts` lanza `Error` en cualquier respuesta no-2xx (nunca devuelve `{success:false}`), así que el catch mapea el mensaje real de cartera-back a `ORPCError("BAD_REQUEST")` en vez de burbujear como 500 genérico.
- Nuevo método en `cartera-back-client.ts` (`actualizarCapacidadAsesorBucket`) + tipo de input en `types/cartera-back.ts`, mismo patrón que el resto del cliente.
- `bucket-capacidad.ts` — la procedure vive en archivo propio, no dentro de `cobrosAppRouter`: ese router ya está en el límite donde TS7056 trunca **silenciosamente** el tipo inferido (sin error de compilación) si se le agrega una key más — lo verifiqué con probes de tipo antes de descartar meterla ahí. Mismo patrón ya usado en este archivo para `disbursementRouter`/`manualVehicleRouter`/`proyeccionRouter`. Requiere wiring en `index.ts` (runtime, `Object.assign` del handler RPC) — sin eso el endpoint existe en el tipo pero nunca responde.

### Qué falta (PR 3, aparte)
- `apps/crm/apps/web`: registrar el router nuevo en `MergedRouter` (`utils/orpc.ts`) y el modal de edición en `/cobros/carga` (lápiz solo visible para admin, validación de UX con mensaje de motivo, invalidación de query con `.key()`).

## Test plan
- [x] `bun run check-types` — server exit 0 (los errores de `web` en este momento son de `agenda.tsx`/`$id.tsx`, pre-existentes de `COBROS-02`, no de este PR)
- [x] `bun test src/controllers/buckets/` (cartera-back) — 32/32 pass, sin regresión
- [ ] Smoke test end-to-end una vez el PR 3 (web) esté conectado

🤖 Generated with [Claude Code](https://claude.com/claude-code)