### PR TITLE
feat(cobros): premora nombra cuotas vencidas y mora en la variante B1+

### DIFF
--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -24,6 +24,9 @@ const pagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
     AND pc.validation_status IN ('validated', 'no_required')
     AND COALESCE(pc.monto_aplicado, 0) > 0`;
 
+// Estados que NO devengan mora (espejo de STATUS_EXCLUIDOS_MORA en latefee.ts).
+const ESTADOS_SIN_MORA = sql`('EN_CONVENIO', 'INCOBRABLE', 'CANCELADO', 'PENDIENTE_CANCELACION', 'CAIDO')`;
+
 export async function getCuotasProximasVencer(
   dias: number[],
   opts: { soloAlDia?: boolean; buckets?: number[] } = {},
@@ -104,6 +107,23 @@ export async function getCuotasProximasVencer(
       -- UNIQUE (credito_id) WHERE activa → el LEFT JOIN nunca duplica filas.
       COALESCE(ROUND(m.monto_mora::numeric, 2), 0)::text AS monto_mora,
       COALESCE(m.cuotas_atrasadas, 0)::int AS cuotas_atrasadas,
+      -- Cuotas vencidas REALES en este instante (espejo de
+      -- isOverdueInstallmentForMora en latefee.ts). moras_credito es una FOTO
+      -- que solo se refresca cuando corre procesarMoras (review Codex): entre
+      -- que CONTA valida una cuota vencida y la siguiente corrida del job, la
+      -- fila sigue diciendo las cuotas y el recargo VIEJOS. El CRM compara este
+      -- conteo vivo contra cuotas_atrasadas y solo cita números cuando cuadran.
+      CASE
+        WHEN c."statusCredit" IN ${ESTADOS_SIN_MORA} THEN 0
+        ELSE (
+          SELECT COUNT(*)
+          FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
+          WHERE v.credito_id = c.credito_id
+            AND v.fecha_vencimiento::date < ${hoyGT}
+            AND v.pagado = false
+            AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+        )
+      END::int AS cuotas_vencidas_reales,
       u.nombre AS cliente,
       -- usuarios NO tiene teléfono en cartera (solo asesores/admins/conta/
       -- inversionistas lo tienen). Se devuelve NULL para mantener la forma

--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -97,6 +97,13 @@ export async function getCuotasProximasVencer(
         ORDER BY h.fecha DESC, h.historial_id DESC
         LIMIT 1) AS bucket,
       ROUND(c.cuota::numeric, 2)::text AS monto_cuota,
+      -- Mora ACTIVA del crédito (0 si no tiene). OJO: monto_mora es SOLO el
+      -- RECARGO (capital × porcentaje × cuotas atrasadas), NO incluye las
+      -- cuotas vencidas — por eso se devuelve junto a cuotas_atrasadas y el
+      -- mensaje las nombra por separado. moras_credito tiene
+      -- UNIQUE (credito_id) WHERE activa → el LEFT JOIN nunca duplica filas.
+      COALESCE(ROUND(m.monto_mora::numeric, 2), 0)::text AS monto_mora,
+      COALESCE(m.cuotas_atrasadas, 0)::int AS cuotas_atrasadas,
       u.nombre AS cliente,
       -- usuarios NO tiene teléfono en cartera (solo asesores/admins/conta/
       -- inversionistas lo tienen). Se devuelve NULL para mantener la forma
@@ -109,6 +116,8 @@ export async function getCuotasProximasVencer(
     INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
     INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
     LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
+      ON m.credito_id = c.credito_id AND m.activa = true
     WHERE ${filtroEstado}
       ${filtroBuckets}
       AND cu.pagado = false

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.test.ts
@@ -119,6 +119,7 @@ Tel: {telefonoAsesor}`);
 			placa: "",
 			marcaLineaModelo: "",
 			montoAdeudado: "",
+			montoMora: "",
 			cuotasAtraso: 0,
 			telefonoAsesor: "41286630",
 			nombreAsesor: "Carlos Pérez",

--- a/apps/crm/apps/server/src/lib/cobros-plantillas.ts
+++ b/apps/crm/apps/server/src/lib/cobros-plantillas.ts
@@ -24,6 +24,8 @@ export interface VariablesPlantilla {
 	placa: string;
 	marcaLineaModelo: string;
 	montoAdeudado: string;
+	/** SOLO el recargo por mora (no incluye las cuotas vencidas). Ver `cuotasAtraso`. */
+	montoMora: string;
 	cuotasAtraso: number;
 	telefonoAsesor: string;
 	nombreAsesor: string;
@@ -84,6 +86,7 @@ export function interpolar(
 		.replace(/{placa}/g, v(variables.placa))
 		.replace(/{marcaLineaModelo}/g, v(variables.marcaLineaModelo))
 		.replace(/{montoAdeudado}/g, v(variables.montoAdeudado))
+		.replace(/{montoMora}/g, v(variables.montoMora))
 		.replace(/{cuotasAtraso}/g, v(variables.cuotasAtraso))
 		.replace(/{telefonoAsesor}/g, v(variables.telefonoAsesor))
 		.replace(/{nombreAsesor}/g, v(variables.nombreAsesor));
@@ -237,7 +240,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		etapa: "pre_mora",
 		asunto: "Recordatorio: su cuota vence en 5 días",
 		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
-		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence el {fechaPago} (en 5 días). Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence el {fechaPago} (en 5 días). Además su crédito registra {cuotasAtraso} cuota(s) vencida(s) y Q{montoMora} de mora.
 
 ${COBROS_CUENTAS_PAGO}
 
@@ -253,7 +256,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		etapa: "pre_mora",
 		asunto: "Recordatorio: su cuota vence en 3 días",
 		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
-		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence el {fechaPago} (en 3 días). Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence el {fechaPago} (en 3 días). Además su crédito registra {cuotasAtraso} cuota(s) vencida(s) y Q{montoMora} de mora.
 
 ${COBROS_CUENTAS_PAGO}
 
@@ -269,7 +272,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		etapa: "pre_mora",
 		asunto: "Recordatorio: su cuota vence mañana",
 		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
-		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence MAÑANA {fechaPago}. Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+		cuerpo: `Hola {clienteNombre}, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q{cuotaMensual} vence MAÑANA {fechaPago}. Además su crédito registra {cuotasAtraso} cuota(s) vencida(s) y Q{montoMora} de mora.
 
 ${COBROS_CUENTAS_PAGO}
 
@@ -285,7 +288,7 @@ Atentamente, {nombreAsesor} Tel: {telefonoAsesor}.`,
 		etapa: "pre_mora",
 		asunto: "Hoy es su día de pago",
 		// 5 bloques; SimpleTech colapsa a template `mensaje4parametros`.
-		cuerpo: `Estimado(a) {clienteNombre}, buen día. Le saludamos de Clubcashin.com para recordarle que HOY {fechaPago} vence la cuota de su crédito por Q{cuotaMensual}. Además, su crédito presenta saldo vencido: comuníquese con su asesor para regularizar su cuenta y evitar cargos adicionales.
+		cuerpo: `Estimado(a) {clienteNombre}, buen día. Le saludamos de Clubcashin.com para recordarle que HOY {fechaPago} vence la cuota de su crédito por Q{cuotaMensual}. Además su crédito registra {cuotasAtraso} cuota(s) vencida(s) y Q{montoMora} de mora.
 
 ${COBROS_CUENTAS_PAGO}
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -3992,6 +3992,13 @@ export const cobrosRouter = {
 									maximumFractionDigits: 2,
 								})
 							: "",
+					montoMora:
+						montoMora > 0
+							? montoMora.toLocaleString("es-GT", {
+									minimumFractionDigits: 2,
+									maximumFractionDigits: 2,
+								})
+							: "",
 					cuotasAtraso: credito.mora?.cuotas_atrasadas ?? 0,
 					telefonoAsesor: telefonoAsesor.telefonoAsesor,
 					nombreAsesor: asesor.nombre ?? "",
@@ -4769,16 +4776,21 @@ export const cobrosRouter = {
 					margenAlertaValor: z.number().min(0),
 				})
 				.refine(
-					(v) => v.margenAlertaTipo !== "porcentaje" || v.margenAlertaValor <= 100,
+					(v) =>
+						v.margenAlertaTipo !== "porcentaje" || v.margenAlertaValor <= 100,
 					{
-						message: "margenAlertaValor debe ser <= 100 cuando el tipo es porcentaje",
+						message:
+							"margenAlertaValor debe ser <= 100 cuando el tipo es porcentaje",
 						path: ["margenAlertaValor"],
 					},
 				)
-				.refine((v) => v.margenAlertaTipo !== "fijo" || v.margenAlertaValor <= 500, {
-					message: "margenAlertaValor debe ser <= 500 cuando el tipo es fijo",
-					path: ["margenAlertaValor"],
-				}),
+				.refine(
+					(v) => v.margenAlertaTipo !== "fijo" || v.margenAlertaValor <= 500,
+					{
+						message: "margenAlertaValor debe ser <= 500 cuando el tipo es fijo",
+						path: ["margenAlertaValor"],
+					},
+				),
 		)
 		.handler(async ({ input }) => {
 			if (!isCarteraBackEnabled()) {
@@ -4801,7 +4813,9 @@ export const cobrosRouter = {
 				// cartera-back a BAD_REQUEST en vez de burbujear como 500 genérico.
 				throw new ORPCError("BAD_REQUEST", {
 					message:
-						err instanceof Error ? err.message : "No se pudo actualizar la capacidad",
+						err instanceof Error
+							? err.message
+							: "No se pudo actualizar la capacidad",
 				});
 			}
 		}),

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -294,12 +294,23 @@ export async function sendPremoraReminders(
 			// venir stale (un crédito recién curado sigue en B2 en
 			// buckets_historial hasta que corra procesarMoras) → mirar el bucket
 			// histórico le mandaría "saldo vencido" a quien ya está al día.
-			// La variante `_mora` NOMBRA las cuotas vencidas y el recargo, así que
-			// exige el dato real de `moras_credito`: si el bucket dice B1+ pero no
-			// hay mora activa (bucket stale, mora aún sin procesar) el mensaje
-			// diría "registra  cuota(s) vencida(s)" → cae a la plantilla base.
+			// La variante `_mora` NOMBRA las cuotas vencidas y el recargo, y esos
+			// números salen de `moras_credito`, que es una FOTO refrescada solo
+			// cuando corre procesarMoras (review Codex). Si CONTA validó una cuota
+			// vencida hace un rato, la foto todavía dice las cuotas y el recargo
+			// viejos → le diríamos "registra 2 cuota(s) vencida(s)" a quien ya
+			// bajó a 1. Por eso solo citamos números cuando la foto COINCIDE con
+			// las cuotas vencidas reales de este instante; si están desfasadas (o
+			// ya no hay vencidas) va la plantilla base, que nunca miente: solo
+			// recuerda la cuota próxima a vencer.
+			// El monto NO se recalcula acá a propósito: la fórmula del recargo es
+			// del motor de moras (latefee.ts) y duplicarla sería una segunda
+			// fuente de verdad que puede discrepar.
+			const vencidasReales = cuota.cuotas_vencidas_reales ?? 0;
+			const fotoMoraAlDia =
+				vencidasReales > 0 && vencidasReales === cuota.cuotas_atrasadas;
 			const plantillaId =
-				!soloB0 && (cuota.bucket ?? 0) >= 1 && cuota.cuotas_atrasadas > 0
+				!soloB0 && (cuota.bucket ?? 0) >= 1 && fotoMoraAlDia
 					? `${tipo}_mora`
 					: tipo;
 			const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === plantillaId);
@@ -340,7 +351,8 @@ export async function sendPremoraReminders(
 				marcaLineaModelo: "",
 				montoAdeudado: "",
 				montoMora: montoLegible(cuota.monto_mora),
-				cuotasAtraso: cuota.cuotas_atrasadas,
+				// Conteo VIVO (== cuotas_atrasadas cuando se usa la variante _mora).
+				cuotasAtraso: vencidasReales,
 				telefonoAsesor: asesorCheck.telefonoAsesor,
 				nombreAsesor: cuota.asesor ?? "",
 			});

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -294,8 +294,14 @@ export async function sendPremoraReminders(
 			// venir stale (un crédito recién curado sigue en B2 en
 			// buckets_historial hasta que corra procesarMoras) → mirar el bucket
 			// histórico le mandaría "saldo vencido" a quien ya está al día.
+			// La variante `_mora` NOMBRA las cuotas vencidas y el recargo, así que
+			// exige el dato real de `moras_credito`: si el bucket dice B1+ pero no
+			// hay mora activa (bucket stale, mora aún sin procesar) el mensaje
+			// diría "registra  cuota(s) vencida(s)" → cae a la plantilla base.
 			const plantillaId =
-				!soloB0 && (cuota.bucket ?? 0) >= 1 ? `${tipo}_mora` : tipo;
+				!soloB0 && (cuota.bucket ?? 0) >= 1 && cuota.cuotas_atrasadas > 0
+					? `${tipo}_mora`
+					: tipo;
 			const plantilla = PLANTILLAS_MENSAJES.find((p) => p.id === plantillaId);
 			if (!plantilla) {
 				console.error(`${LOG_PREFIX} Plantilla "${plantillaId}" no encontrada`);
@@ -333,7 +339,8 @@ export async function sendPremoraReminders(
 				placa: "",
 				marcaLineaModelo: "",
 				montoAdeudado: "",
-				cuotasAtraso: 0,
+				montoMora: montoLegible(cuota.monto_mora),
+				cuotasAtraso: cuota.cuotas_atrasadas,
 				telefonoAsesor: asesorCheck.telefonoAsesor,
 				nombreAsesor: cuota.asesor ?? "",
 			});

--- a/apps/crm/apps/server/src/services/send-welcome-message.ts
+++ b/apps/crm/apps/server/src/services/send-welcome-message.ts
@@ -144,6 +144,7 @@ export async function sendWelcomeMessage(
 			placa: "",
 			marcaLineaModelo: "",
 			montoAdeudado: "",
+			montoMora: "",
 			cuotasAtraso: 0,
 			telefonoAsesor: credito.asesor?.telefono ?? "",
 			nombreAsesor: credito.asesor?.nombre ?? "",

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -909,6 +909,9 @@ export interface CarteraCuotaProximaVencer {
 	status_credit: string; // ACTIVO | MOROSO | INCOBRABLE (funnel)
 	bucket: number | null; // bucket MOTOR (último de buckets_historial)
 	monto_cuota: string;
+	/** Mora ACTIVA: SOLO el recargo, NO incluye las cuotas vencidas ("0.00" si no tiene). */
+	monto_mora: string;
+	cuotas_atrasadas: number;
 	cliente: string;
 	telefono_cliente_cartera: string | null;
 	asesor_id: number | null;

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -911,7 +911,10 @@ export interface CarteraCuotaProximaVencer {
 	monto_cuota: string;
 	/** Mora ACTIVA: SOLO el recargo, NO incluye las cuotas vencidas ("0.00" si no tiene). */
 	monto_mora: string;
+	/** Cuotas atrasadas según la FOTO de `moras_credito` (puede venir stale). */
 	cuotas_atrasadas: number;
+	/** Cuotas vencidas reales en tiempo real. Si difiere de `cuotas_atrasadas`, la foto está stale. */
+	cuotas_vencidas_reales: number;
 	cliente: string;
 	telefono_cliente_cartera: string | null;
 	asesor_id: number | null;


### PR DESCRIPTION
## Qué cambia

Las plantillas `premora_X_mora` (las que van a créditos **B1 en adelante**) decían *"su crédito presenta saldo vencido: comuníquese con su asesor"* — sin ningún número. Y el job les pasaba `montoAdeudado: ""` y `cuotasAtraso: 0`, así que ni siquiera había datos que imprimir.

Ahora nombran el dato real:

> Hola Juan Perez, le saludamos de Clubcashin.com. Le recordamos que la próxima cuota de su crédito por Q2,450.00 vence el 23/07/2026 (en 3 días). **Además su crédito registra 2 cuota(s) vencida(s) y Q137.76 de mora.**

## Cómo

- **`cuotasProximas.ts`** — `LEFT JOIN moras_credito ... AND m.activa = true` → devuelve `monto_mora` y `cuotas_atrasadas`. No duplica filas: hay `UNIQUE (credito_id) WHERE activa`.
- **`cobros-plantillas.ts`** — nueva variable `{montoMora}` + las 4 plantillas `_mora`.
- **`send-premora-reminders.ts`** — pasa los valores reales.
- Los demás call sites de `interpolar` (bienvenida, masivo de cobros, test) rellenan `montoMora`; ninguna plantilla existente usa el placeholder, así que **su texto no cambia**.

## ⚠️ Sobre el monto

`monto_mora` es **solo el recargo** (`capital × 1.12% × cuotas atrasadas`), **no** incluye las cuotas vencidas. Por eso el texto las nombra por separado en vez de sumarlas en un total.

Sumarlas requeriría definir una regla de "total a pagar" que hoy no existe bien: el masivo usa `monto_mora + cuota` ([cobros.ts](../blob/COBROS-02/apps/crm/apps/server/src/routers/cobros.ts)), que cuadra para B1 pero **se queda corto en B2+** porque suma una sola cuota. Eso ya se envía así hoy — no se tocó aquí, pero vale que cobros lo revise.

## Por qué B0 no lo ve

Tres garantías independientes:

1. `!soloB0` — con el default `PREMORA_BUCKETS=0` el job usa **siempre** la plantilla base.
2. `bucket >= 1` — aun con el funnel encendido, un B0 cae a la base.
3. `cuotas_atrasadas > 0` — candado nuevo contra el bucket stale: si `buckets_historial` dice B1 pero no hay mora activa todavía, cae a la base en vez de imprimir *"registra  cuota(s) vencida(s) y Q0.00 de mora"*.

Y las plantillas base ni siquiera tienen los placeholders, así que físicamente no pueden imprimir la frase.

## Verificación

- Typecheck limpio en `cartera-back` y `crm/server` (solo el baseline conocido de `lib/auth.ts`).
- Los 10 tests de `cobros-plantillas.test.ts` pasan.
- Render real comparado base vs `_mora` con las mismas variables: la base sale sin la frase.

## Nota de revisión: no se le manda a quien ya pagó

Se revisó a fondo el filtro por dos casos que preocupaban, y **ambos quedan cubiertos**:

- **Pago parcial** → el pago solo se marca completo si *todos* los rubros quedan en cero (`shouldMarkInstallmentPaymentPaid`), así que un abono parcial **sí** recibe recordatorio.
- **Pagó solo la mora** → esos pagos se cuelgan de la primera cuota pendiente con `pagado=true` pero `monto_aplicado=0`; el `AND monto_aplicado > 0` los descarta. Es el mismo bug que ya explotó en el motor de moras (documentado en `latefee.ts`: bajaba el bucket sin merecerlo), y el filtro de premora es espejo a propósito de ese predicado ya corregido.

Pendiente aparte: al que abonó parcial le llega el mensaje con el **monto completo de la cuota**, no con lo que le falta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)