### PR TITLE
perf(cobros): agenda del día paginada por sección (una query por día)

### DIFF
--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -29,7 +29,13 @@ const ESTADOS_SIN_MORA = sql`('EN_CONVENIO', 'INCOBRABLE', 'CANCELADO', 'PENDIEN
 
 export async function getCuotasProximasVencer(
   dias: number[],
-  opts: { soloAlDia?: boolean; buckets?: number[] } = {},
+  opts: {
+    soloAlDia?: boolean;
+    buckets?: number[];
+    asesorId?: number;
+    page?: number;
+    perPage?: number;
+  } = {},
 ) {
   // Default true: premora SOLO recuerda a créditos al día (B0). Con false
   // (la Agenda del día del CRM) entra TODO el funnel — el asesor gestiona
@@ -42,6 +48,23 @@ export async function getCuotasProximasVencer(
   // a soloAlDia: el job del CRM manda soloAlDia=false + buckets=0,1,...
   // cuando el funnel de recordatorios está encendido.
   const buckets = opts.buckets ?? [];
+
+  // Filtro por asesor DUEÑO del crédito (Agenda del día por asesor). Se baja al
+  // SQL a propósito — NO filtrar en el CRM después de traer todo — para que la
+  // paginación sea correcta: el LIMIT/OFFSET tiene que aplicar sobre las filas
+  // del asesor, no sobre el universo completo.
+  const filtroAsesor =
+    opts.asesorId != null ? sql`AND c.asesor_id = ${opts.asesorId}` : sql``;
+
+  // Paginación OPCIONAL: la Agenda del CRM manda page/per_page (el día 15/30
+  // trae ~600 cuentas y se pagina de a perPage). El job de recordatorios NO los
+  // manda: necesita TODAS las cuotas del día para enviarlas. Sin perPage → se
+  // devuelven todas las filas (comportamiento clásico intacto).
+  const paginar = opts.perPage != null && opts.perPage > 0;
+  const page = Math.max(1, opts.page ?? 1);
+  const perPage = paginar ? (opts.perPage as number) : 0;
+  const offset = paginar ? (page - 1) * perPage : 0;
+
   const hoyGT = sql`(now() AT TIME ZONE 'America/Guatemala')::date`;
   const diasList = sql.join(
     dias.map((d) => sql`${d}`),
@@ -86,6 +109,7 @@ export async function getCuotasProximasVencer(
 
   const res = await db.execute<any>(sql`
     SELECT
+      ${paginar ? sql`COUNT(*) OVER()::int AS _total,` : sql``}
       cu.cuota_id,
       cu.credito_id,
       cu.numero_cuota,
@@ -140,6 +164,7 @@ export async function getCuotasProximasVencer(
       ON m.credito_id = c.credito_id AND m.activa = true
     WHERE ${filtroEstado}
       ${filtroBuckets}
+      ${filtroAsesor}
       AND cu.pagado = false
       AND NOT EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))})
       -- Ya hay un pago REGISTRADO para esta cuota aunque CONTA no lo haya
@@ -164,8 +189,31 @@ export async function getCuotasProximasVencer(
       )`
           : sql``
       }
-    ORDER BY dias_para_vencer ASC, c.numero_credito_sifco ASC
+    ORDER BY dias_para_vencer ASC, u.nombre ASC, cu.cuota_id ASC
+    ${paginar ? sql`LIMIT ${perPage} OFFSET ${offset}` : sql``}
   `);
 
-  return { success: true, total: res.rows.length, data: res.rows };
+  const rows = res.rows as Array<Record<string, unknown>>;
+
+  // Sin paginación (job de recordatorios): forma clásica, todas las filas.
+  if (!paginar) {
+    return { success: true, total: rows.length, data: rows };
+  }
+
+  // COUNT(*) OVER() da el total del set filtrado (antes del LIMIT) en la misma
+  // pasada — sin una segunda query que repita las subconsultas correlacionadas.
+  // Una página fuera de rango vuelve vacía → total 0 (el CRM ya conoce el total
+  // desde la página 1, no pide páginas fuera de rango).
+  const total = rows.length > 0 ? Number(rows[0]._total ?? 0) : 0;
+  for (const r of rows) {
+    delete r._total;
+  }
+  return {
+    success: true,
+    total,
+    page,
+    perPage,
+    totalPages: Math.max(1, Math.ceil(total / perPage)),
+    data: rows,
+  };
 }

--- a/apps/cartera-back/src/controllers/cuotasProximas.ts
+++ b/apps/cartera-back/src/controllers/cuotasProximas.ts
@@ -107,9 +107,66 @@ export async function getCuotasProximasVencer(
     )`
       : sql``;
 
+  // FROM + JOINs y WHERE se comparten entre el COUNT y la query de datos para
+  // que el total sea EXACTAMENTE el del set paginado (los mismos predicados).
+  const fromJoins = sql`
+    FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
+      ON m.credito_id = c.credito_id AND m.activa = true`;
+
+  const whereClause = sql`
+    WHERE ${filtroEstado}
+      ${filtroBuckets}
+      ${filtroAsesor}
+      AND cu.pagado = false
+      AND NOT EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))})
+      -- Ya hay un pago REGISTRADO para esta cuota aunque CONTA no lo haya
+      -- validado todavía: no recordarle a quien ya mandó su boleta.
+      AND NOT EXISTS (
+        SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pr
+        WHERE pr.cuota_id = cu.cuota_id
+          AND pr."paymentFalse" = false
+          AND pr.validation_status = 'pending'
+          AND COALESCE(pr.monto_boleta, 0) > 0
+      )
+      AND (cu.fecha_vencimiento::date - ${hoyGT}) IN (${diasList})
+      -- Crédito AL DÍA: ninguna cuota ya vencida sigue pendiente (solo premora).
+      ${
+        soloAlDia
+          ? sql`AND NOT EXISTS (
+        SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
+        WHERE v.credito_id = cu.credito_id
+          AND v.fecha_vencimiento::date < ${hoyGT}
+          AND v.pagado = false
+          AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+      )`
+          : sql``
+      }`;
+
+  // Total + clamp de página ANTES de traer la página (review Codex): con un
+  // COUNT(*) OVER() en la misma query, una página fuera de rango vuelve VACÍA →
+  // total 0 → la sección de la agenda desaparecería si el día encogió (un pago
+  // o una reasignación) mientras el usuario estaba en una página tardía. Un
+  // COUNT dedicado da el total real siempre, y si la página quedó fuera de rango
+  // se devuelve la ÚLTIMA página válida en vez de una vacía.
+  let totalPaginado = 0;
+  let pageEfectiva = page;
+  let offsetEfectivo = offset;
+  if (paginar) {
+    const countRes = await db.execute<any>(
+      sql`SELECT COUNT(*)::int AS total ${fromJoins} ${whereClause}`,
+    );
+    totalPaginado = Number(countRes.rows[0]?.total ?? 0);
+    const totalPages = Math.max(1, Math.ceil(totalPaginado / perPage));
+    pageEfectiva = Math.min(page, totalPages);
+    offsetEfectivo = (pageEfectiva - 1) * perPage;
+  }
+
   const res = await db.execute<any>(sql`
     SELECT
-      ${paginar ? sql`COUNT(*) OVER()::int AS _total,` : sql``}
       cu.cuota_id,
       cu.credito_id,
       cu.numero_cuota,
@@ -156,41 +213,10 @@ export async function getCuotasProximasVencer(
       c.asesor_id,
       a.nombre AS asesor,
       a.telefono AS telefono_asesor
-    FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
-    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
-    INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
-    LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
-    LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
-      ON m.credito_id = c.credito_id AND m.activa = true
-    WHERE ${filtroEstado}
-      ${filtroBuckets}
-      ${filtroAsesor}
-      AND cu.pagado = false
-      AND NOT EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))})
-      -- Ya hay un pago REGISTRADO para esta cuota aunque CONTA no lo haya
-      -- validado todavía: no recordarle a quien ya mandó su boleta.
-      AND NOT EXISTS (
-        SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pr
-        WHERE pr.cuota_id = cu.cuota_id
-          AND pr."paymentFalse" = false
-          AND pr.validation_status = 'pending'
-          AND COALESCE(pr.monto_boleta, 0) > 0
-      )
-      AND (cu.fecha_vencimiento::date - ${hoyGT}) IN (${diasList})
-      -- Crédito AL DÍA: ninguna cuota ya vencida sigue pendiente (solo premora).
-      ${
-        soloAlDia
-          ? sql`AND NOT EXISTS (
-        SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
-        WHERE v.credito_id = cu.credito_id
-          AND v.fecha_vencimiento::date < ${hoyGT}
-          AND v.pagado = false
-          AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
-      )`
-          : sql``
-      }
+    ${fromJoins}
+    ${whereClause}
     ORDER BY dias_para_vencer ASC, u.nombre ASC, cu.cuota_id ASC
-    ${paginar ? sql`LIMIT ${perPage} OFFSET ${offset}` : sql``}
+    ${paginar ? sql`LIMIT ${perPage} OFFSET ${offsetEfectivo}` : sql``}
   `);
 
   const rows = res.rows as Array<Record<string, unknown>>;
@@ -200,20 +226,12 @@ export async function getCuotasProximasVencer(
     return { success: true, total: rows.length, data: rows };
   }
 
-  // COUNT(*) OVER() da el total del set filtrado (antes del LIMIT) en la misma
-  // pasada — sin una segunda query que repita las subconsultas correlacionadas.
-  // Una página fuera de rango vuelve vacía → total 0 (el CRM ya conoce el total
-  // desde la página 1, no pide páginas fuera de rango).
-  const total = rows.length > 0 ? Number(rows[0]._total ?? 0) : 0;
-  for (const r of rows) {
-    delete r._total;
-  }
   return {
     success: true,
-    total,
-    page,
+    total: totalPaginado,
+    page: pageEfectiva,
     perPage,
-    totalPages: Math.max(1, Math.ceil(total / perPage)),
+    totalPages: Math.max(1, Math.ceil(totalPaginado / perPage)),
     data: rows,
   };
 }

--- a/apps/cartera-back/src/routers/cuotas.ts
+++ b/apps/cartera-back/src/routers/cuotas.ts
@@ -63,10 +63,54 @@ export const cuotasRouter = new Elysia()
           }
           buckets = [...new Set(bTokens.map(Number))];
         }
+        // asesor_id: opcional, entero positivo — filtra por asesor DUEÑO del
+        // crédito (Agenda del día por asesor). Se baja al SQL para paginar bien.
+        let asesorId: number | undefined;
+        if (query.asesor_id != null && String(query.asesor_id).trim() !== "") {
+          const s = String(query.asesor_id).trim();
+          if (!/^\d{1,9}$/.test(s) || Number(s) < 1) {
+            set.status = 400;
+            return {
+              success: false,
+              message: "[ERROR] asesor_id inválido (entero positivo)",
+            };
+          }
+          asesorId = Number(s);
+        }
+        // page / per_page: paginación OPCIONAL (Agenda del día). per_page se topa
+        // a 200 para no permitir pedir toda la cartera de un jalón. Sin ellos →
+        // sin paginación (el job de recordatorios necesita todas las cuotas).
+        let perPage: number | undefined;
+        if (query.per_page != null && String(query.per_page).trim() !== "") {
+          const s = String(query.per_page).trim();
+          if (!/^\d{1,3}$/.test(s) || Number(s) < 1 || Number(s) > 200) {
+            set.status = 400;
+            return {
+              success: false,
+              message: "[ERROR] per_page inválido (entero 1-200)",
+            };
+          }
+          perPage = Number(s);
+        }
+        let page: number | undefined;
+        if (query.page != null && String(query.page).trim() !== "") {
+          const s = String(query.page).trim();
+          if (!/^\d{1,6}$/.test(s) || Number(s) < 1) {
+            set.status = 400;
+            return {
+              success: false,
+              message: "[ERROR] page inválido (entero positivo)",
+            };
+          }
+          page = Number(s);
+        }
         const dias = [...new Set(tokens.map(Number))];
         return await getCuotasProximasVencer(dias, {
           soloAlDia: rawSoloAlDia === "true",
           buckets,
+          asesorId,
+          page,
+          perPage,
         });
       } catch (err) {
         set.status = 500;
@@ -82,6 +126,9 @@ export const cuotasRouter = new Elysia()
         dias: t.Optional(t.String()),
         solo_al_dia: t.Optional(t.String()),
         buckets: t.Optional(t.String()),
+        asesor_id: t.Optional(t.String()),
+        page: t.Optional(t.String()),
+        per_page: t.Optional(t.String()),
       }),
     },
   );

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1701,6 +1701,11 @@ export const cobrosRouter = {
 				const cuotas = respuesta.data ?? [];
 				const total = respuesta.total ?? cuotas.length;
 				const totalPages = respuesta.totalPages ?? 1;
+				// Página EFECTIVA: cartera-back clampa la página a la última válida
+				// si la pedida quedó fuera de rango (día encogido); hay que devolver
+				// ESA, no la pedida, o el paginador del front queda pegado en una
+				// página imposible (review Codex).
+				const pageEfectiva = respuesta.page ?? page;
 
 				if (cuotas.length === 0) {
 					return {
@@ -1710,7 +1715,7 @@ export const cobrosRouter = {
 						dia: input.dia,
 						items: [],
 						total,
-						page,
+						page: pageEfectiva,
 						perPage,
 						totalPages,
 					};
@@ -1876,7 +1881,7 @@ export const cobrosRouter = {
 					dia: input.dia,
 					items,
 					total,
-					page,
+					page: pageEfectiva,
 					perPage,
 					totalPages,
 				};

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1633,24 +1633,29 @@ export const cobrosRouter = {
 	// asesor con `asesorId` o ven todos.
 	getAgendaDia: cobrosProcedure
 		.input(
-			z.object({ asesorId: z.number().int().positive().optional() }).optional(),
+			z.object({
+				// Un día del embudo D-0..D-5 por llamada: la Agenda dispara una query
+				// por sección y cada una pagina sola (el 15/30 son ~600 cuentas).
+				dia: z.number().int().min(0).max(5),
+				asesorId: z.number().int().positive().optional(),
+				page: z.number().int().positive().optional(),
+				perPage: z.number().int().min(1).max(200).optional(),
+			}),
 		)
 		.handler(async ({ input, context }) => {
 			try {
 				const puedeVerTodos = PERMISSIONS.canAssignCobros(
 					context.userRole ?? "",
 				);
+				const perPage = input.perPage ?? 50;
+				const page = input.page ?? 1;
 
-				// Todo el funnel (soloAlDia: false): la agenda es pareja para todos
-				// los asesores — cuentas al día Y en mora con cuota próxima. Los
-				// recordatorios WhatsApp (premora) siguen siendo solo B0.
-				const respuesta = await carteraBackClient.getCuotasProximasVencer(
-					[0, 1, 2, 3, 4, 5],
-					{ soloAlDia: false },
-				);
-				let cuotas = respuesta.data ?? [];
-
+				// Asesor a filtrar EN EL SQL. El rol `cobros` queda FORZADO a su
+				// propio asesor (matcheo por correo, nunca ve otro); admin/supervisor
+				// eligen uno o ven todos. getAdvisors va cacheado (TTL 5m) → las 6
+				// llamadas por día resuelven el asesor de un solo hit real.
 				let asesorForzado: { asesorId: number; nombre: string } | null = null;
+				let asesorIdFiltro: number | undefined;
 				if (!puedeVerTodos) {
 					const email = context.session?.user?.email?.trim().toLowerCase();
 					const advisors = await carteraBackClient.getAdvisors({
@@ -1667,20 +1672,48 @@ export const cobrosRouter = {
 							success: true,
 							sinAsesor: true,
 							asesorForzado: null,
+							dia: input.dia,
 							items: [],
+							total: 0,
+							page,
+							perPage,
+							totalPages: 1,
 						};
 					}
 					asesorForzado = {
 						asesorId: propio.asesor_id,
 						nombre: propio.nombre,
 					};
-					cuotas = cuotas.filter((c) => c.asesor_id === propio.asesor_id);
-				} else if (input?.asesorId) {
-					cuotas = cuotas.filter((c) => c.asesor_id === input.asesorId);
+					asesorIdFiltro = propio.asesor_id;
+				} else if (input.asesorId) {
+					asesorIdFiltro = input.asesorId;
 				}
 
+				// Todo el funnel (soloAlDia: false): la agenda es pareja para todos
+				// — cuentas al día Y en mora con cuota próxima. Los recordatorios
+				// WhatsApp (premora) siguen siendo solo B0. Filtro de asesor +
+				// paginación EN EL SQL: el día pesado llega de a perPage y el LIMIT
+				// aplica sobre las filas del asesor, no sobre el universo.
+				const respuesta = await carteraBackClient.getCuotasProximasVencer(
+					[input.dia],
+					{ soloAlDia: false, asesorId: asesorIdFiltro, page, perPage },
+				);
+				const cuotas = respuesta.data ?? [];
+				const total = respuesta.total ?? cuotas.length;
+				const totalPages = respuesta.totalPages ?? 1;
+
 				if (cuotas.length === 0) {
-					return { success: true, sinAsesor: false, asesorForzado, items: [] };
+					return {
+						success: true,
+						sinAsesor: false,
+						asesorForzado,
+						dia: input.dia,
+						items: [],
+						total,
+						page,
+						perPage,
+						totalPages,
+					};
 				}
 
 				const sifcos = [...new Set(cuotas.map((c) => c.numero_credito_sifco))];
@@ -1796,51 +1829,57 @@ export const cobrosRouter = {
 					enviosPorSifco.set(sifco, porTipo);
 				}
 
-				const items = cuotas
-					.map((c) => {
-						const caso = casoPorSifco.get(c.numero_credito_sifco);
-						return {
-							cuotaId: c.cuota_id,
-							creditoId: c.credito_id,
-							numeroCuota: c.numero_cuota,
-							fechaVencimiento: c.fecha_vencimiento,
-							diasParaVencer: c.dias_para_vencer,
-							numeroCreditoSifco: c.numero_credito_sifco,
-							statusCredit: c.status_credit,
-							bucket: c.bucket,
-							montoCuota: c.monto_cuota,
-							cliente: c.cliente,
-							telefono:
-								primerTelefono(caso?.telefonoPrincipal) ??
-								primerTelefono(leadPhonePorSifco.get(c.numero_credito_sifco)) ??
-								null,
-							casoId: caso?.id ?? null,
-							asesorId: c.asesor_id,
-							asesor: c.asesor,
-							recordatorios: (() => {
-								// Claims exactos por cuota + envíos por SIFCO (dedupe por
-								// tipo; el claim real gana sobre el log).
-								const lista = [...(recPorCuota.get(c.cuota_id) ?? [])];
-								const tipos = new Set(lista.map((r) => r.tipo));
-								const envios = enviosPorSifco.get(c.numero_credito_sifco);
-								if (envios) {
-									for (const [tipo, envio] of envios) {
-										if (!tipos.has(tipo)) {
-											lista.push({ tipo, ...envio });
-										}
+				const items = cuotas.map((c) => {
+					const caso = casoPorSifco.get(c.numero_credito_sifco);
+					return {
+						cuotaId: c.cuota_id,
+						creditoId: c.credito_id,
+						numeroCuota: c.numero_cuota,
+						fechaVencimiento: c.fecha_vencimiento,
+						diasParaVencer: c.dias_para_vencer,
+						numeroCreditoSifco: c.numero_credito_sifco,
+						statusCredit: c.status_credit,
+						bucket: c.bucket,
+						montoCuota: c.monto_cuota,
+						cliente: c.cliente,
+						telefono:
+							primerTelefono(caso?.telefonoPrincipal) ??
+							primerTelefono(leadPhonePorSifco.get(c.numero_credito_sifco)) ??
+							null,
+						casoId: caso?.id ?? null,
+						asesorId: c.asesor_id,
+						asesor: c.asesor,
+						recordatorios: (() => {
+							// Claims exactos por cuota + envíos por SIFCO (dedupe por
+							// tipo; el claim real gana sobre el log).
+							const lista = [...(recPorCuota.get(c.cuota_id) ?? [])];
+							const tipos = new Set(lista.map((r) => r.tipo));
+							const envios = enviosPorSifco.get(c.numero_credito_sifco);
+							if (envios) {
+								for (const [tipo, envio] of envios) {
+									if (!tipos.has(tipo)) {
+										lista.push({ tipo, ...envio });
 									}
 								}
-								return lista;
-							})(),
-						};
-					})
-					.sort(
-						(a, b) =>
-							a.diasParaVencer - b.diasParaVencer ||
-							(a.cliente ?? "").localeCompare(b.cliente ?? ""),
-					);
+							}
+							return lista;
+						})(),
+					};
+				});
+				// Sin re-ordenar: el SQL ya viene ORDER BY nombre del cliente y ese
+				// orden ES el de la paginación (re-ordenar acá partiría las páginas).
 
-				return { success: true, sinAsesor: false, asesorForzado, items };
+				return {
+					success: true,
+					sinAsesor: false,
+					asesorForzado,
+					dia: input.dia,
+					items,
+					total,
+					page,
+					perPage,
+					totalPages,
+				};
 			} catch (error) {
 				console.error("[getAgendaDia] Error:", error);
 				throw new ORPCError("INTERNAL_SERVER_ERROR", {

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1023,7 +1023,13 @@ export class CarteraBackClient {
 	 */
 	async getCuotasProximasVencer(
 		dias: number[] = [5, 3, 1, 0],
-		opts: { soloAlDia?: boolean; buckets?: number[] } = {},
+		opts: {
+			soloAlDia?: boolean;
+			buckets?: number[];
+			asesorId?: number;
+			page?: number;
+			perPage?: number;
+		} = {},
 	): Promise<CarteraCuotasProximasResponse> {
 		const queryParams = new URLSearchParams({ dias: dias.join(",") });
 		// Default true (premora, solo B0). false = Agenda del día (todo el funnel).
@@ -1032,6 +1038,13 @@ export class CarteraBackClient {
 		// solo cuenta como B0 si está al día en tiempo real.
 		if (opts.buckets?.length)
 			queryParams.set("buckets", opts.buckets.join(","));
+		// Agenda del día: filtro por asesor + paginación (el job de premora no los
+		// manda → sin límite). Sin cache: la agenda tiene que reflejar pagos y
+		// ajustes de fecha al instante, igual que getBucketsHistorial.
+		if (opts.asesorId != null)
+			queryParams.set("asesor_id", String(opts.asesorId));
+		if (opts.page != null) queryParams.set("page", String(opts.page));
+		if (opts.perPage != null) queryParams.set("per_page", String(opts.perPage));
 		return this.request<CarteraCuotasProximasResponse>(
 			`/cuotas/proximas-vencer?${queryParams}`,
 			{ method: "GET" },

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -925,6 +925,10 @@ export interface CarteraCuotaProximaVencer {
 export interface CarteraCuotasProximasResponse {
 	success: boolean;
 	total: number;
+	/** Presentes solo cuando se pidió paginación (Agenda del día); el job no la usa. */
+	page?: number;
+	perPage?: number;
+	totalPages?: number;
 	data: CarteraCuotaProximaVencer[];
 }
 

--- a/apps/crm/apps/web/src/routes/cobros/agenda.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/agenda.tsx
@@ -1,8 +1,10 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQueries, useQuery } from "@tanstack/react-query";
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import {
 	CalendarClock,
 	CheckCircle2,
+	ChevronLeft,
+	ChevronRight,
 	Loader2,
 	MessageCircle,
 	Phone,
@@ -10,6 +12,7 @@ import {
 } from "lucide-react";
 import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
 	Card,
 	CardContent,
@@ -74,8 +77,16 @@ interface AgendaResponse {
 	success: boolean;
 	sinAsesor: boolean;
 	asesorForzado: { asesorId: number; nombre: string } | null;
+	dia: number;
 	items: AgendaItem[];
+	total: number;
+	page: number;
+	perPage: number;
+	totalPages: number;
 }
+
+const DIAS_AGENDA = [0, 1, 2, 3, 4, 5] as const;
+const PER_PAGE_AGENDA = 50;
 
 interface AsesorOption {
 	asesorId: number;
@@ -182,15 +193,28 @@ function AgendaDiaPage() {
 
 	// "todos" | asesorId como string (Select de shadcn trabaja con strings).
 	const [asesorSel, setAsesorSel] = useState("todos");
+	// Página por día (cada sección pagina sola). Sin entrada = página 1.
+	const [pagPorDia, setPagPorDia] = useState<Record<number, number>>({});
 
-	const agendaQuery = useQuery({
-		...orpc.getAgendaDia.queryOptions({
-			input: {
-				asesorId:
-					esSupervisor && asesorSel !== "todos" ? Number(asesorSel) : undefined,
-			},
-		}),
-		enabled: !!session,
+	const asesorIdInput =
+		esSupervisor && asesorSel !== "todos" ? Number(asesorSel) : undefined;
+
+	// Una query POR DÍA (D-0..D-5). Cada sección pagina sola: el día 15/30
+	// (~600 cuentas) llega de a PER_PAGE, no de un jalón. keepPreviousData deja
+	// la tabla visible mientras cambia de página (no parpadea a vacío).
+	const dayQueries = useQueries({
+		queries: DIAS_AGENDA.map((dia) => ({
+			...orpc.getAgendaDia.queryOptions({
+				input: {
+					dia,
+					asesorId: asesorIdInput,
+					page: pagPorDia[dia] ?? 1,
+					perPage: PER_PAGE_AGENDA,
+				},
+			}),
+			enabled: !!session,
+			placeholderData: keepPreviousData,
+		})),
 	});
 
 	const asesoresQuery = useQuery({
@@ -215,35 +239,51 @@ function AgendaDiaPage() {
 		);
 	}
 
-	const agenda = agendaQuery.data as AgendaResponse | undefined;
-	const items = agenda?.items ?? [];
+	const secciones = DIAS_AGENDA.map((dia, idx) => ({
+		dia,
+		query: dayQueries[idx],
+		data: dayQueries[idx]?.data as AgendaResponse | undefined,
+	}));
+
 	const asesores = (
 		(asesoresQuery.data as { asesores?: AsesorOption[] } | undefined)
 			?.asesores ?? []
 	).filter((a) => a.activo);
 
-	// Agrupar por urgencia manteniendo el orden D-0 → D-5 del server.
-	const grupos = [0, 1, 2, 3, 4, 5]
-		.map((dias) => ({
-			dias,
-			items: items.filter((i) => i.diasParaVencer === dias),
-		}))
-		.filter((g) => g.items.length > 0);
+	const sinAsesor = secciones.some((s) => s.data?.sinAsesor);
+	const asesorForzado =
+		secciones.find((s) => s.data?.asesorForzado)?.data?.asesorForzado ?? null;
+	// Total real (no limitado por la página): suma del `total` de cada día.
+	const totalCuentas = secciones.reduce(
+		(acc, s) => acc + (s.data?.total ?? 0),
+		0,
+	);
+	const totalHoy = secciones[0]?.data?.total ?? 0;
 
-	const totalHoy = items.filter((i) => i.diasParaVencer === 0).length;
+	const primeraCarga = dayQueries.every((q) => q.isPending);
+	const sinCuotas =
+		!sinAsesor && dayQueries.every((q) => !q.isPending) && totalCuentas === 0;
 
 	// Con "todos" el bucket va por FILA (varía); con UN asesor (elegido o
 	// forzado por rol) va GENERAL en el header — sus buckets, sin repetirse.
+	// Se calcula sobre las filas cargadas (asesor→bucket es estable, así que la
+	// unión de las páginas visibles ya cubre sus buckets).
 	const mostrandoTodos = esSupervisor && asesorSel === "todos";
 	const bucketsDelAsesor = mostrandoTodos
 		? []
 		: [
 				...new Set(
-					items
+					secciones
+						.flatMap((s) => s.data?.items ?? [])
 						.map((i) => i.bucket)
 						.filter((b): b is number => b !== null && b !== undefined),
 				),
 			].sort((a, b) => a - b);
+
+	const cambiarAsesor = (v: string) => {
+		setAsesorSel(v);
+		setPagPorDia({}); // reset de todas las secciones a la página 1
+	};
 
 	const irAlDetalle = (sifco: string) => {
 		navigate({
@@ -268,9 +308,7 @@ function AgendaDiaPage() {
 								<CardDescription>
 									Cuentas con cuota próxima a vencer — de hoy (D-0) a 5 días
 									(D-5), de todo el funnel
-									{agenda?.asesorForzado
-										? ` · Agenda de ${agenda.asesorForzado.nombre}`
-										: ""}
+									{asesorForzado ? ` · Agenda de ${asesorForzado.nombre}` : ""}
 								</CardDescription>
 							</div>
 						</div>
@@ -283,7 +321,7 @@ function AgendaDiaPage() {
 									{totalHoy} pagan hoy
 								</Badge>
 							)}
-							<Badge variant="secondary">{items.length} cuentas</Badge>
+							<Badge variant="secondary">{totalCuentas} cuentas</Badge>
 							{bucketsDelAsesor.length > 0 && (
 								<span className="inline-flex items-center gap-1">
 									{bucketsDelAsesor.map((b) => (
@@ -296,7 +334,7 @@ function AgendaDiaPage() {
 								</span>
 							)}
 							{esSupervisor && (
-								<Select value={asesorSel} onValueChange={setAsesorSel}>
+								<Select value={asesorSel} onValueChange={cambiarAsesor}>
 									<SelectTrigger className="h-8 w-52">
 										<UserRound className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
 										<SelectValue placeholder="Asesor" />
@@ -317,13 +355,13 @@ function AgendaDiaPage() {
 			</Card>
 
 			{/* Estados */}
-			{agendaQuery.isLoading && (
+			{primeraCarga && (
 				<div className="flex items-center justify-center py-16">
 					<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
 				</div>
 			)}
 
-			{!agendaQuery.isLoading && agenda?.sinAsesor && (
+			{sinAsesor && (
 				<Card>
 					<CardContent className="py-10 text-center text-muted-foreground">
 						Tu usuario no está vinculado a un asesor de cartera (por correo).
@@ -332,7 +370,7 @@ function AgendaDiaPage() {
 				</Card>
 			)}
 
-			{!agendaQuery.isLoading && !agenda?.sinAsesor && items.length === 0 && (
+			{sinCuotas && (
 				<Card>
 					<CardContent className="py-10 text-center text-muted-foreground">
 						Sin cuotas próximas a vencer en los próximos 5 días. 🎉
@@ -340,12 +378,18 @@ function AgendaDiaPage() {
 				</Card>
 			)}
 
-			{/* Grupos por urgencia */}
-			{grupos.map((grupo) => {
-				const urgencia = URGENCIA[grupo.dias];
-				const fecha = grupo.items[0]?.fechaVencimiento;
+			{/* Una sección (card) por día, cada una paginada de forma independiente */}
+			{secciones.map(({ dia, query, data }) => {
+				const dayTotal = data?.total ?? 0;
+				// La sección solo aparece cuando ya cargó y tiene cuentas.
+				if (query.isPending || dayTotal === 0) return null;
+				const dayItems = data?.items ?? [];
+				const dayTotalPages = data?.totalPages ?? 1;
+				const dayPage = pagPorDia[dia] ?? 1;
+				const urgencia = URGENCIA[dia];
+				const fecha = dayItems[0]?.fechaVencimiento;
 				return (
-					<Card key={grupo.dias}>
+					<Card key={dia}>
 						<CardHeader className="pb-2">
 							<div className="flex items-center gap-2">
 								<span className={`h-2.5 w-2.5 rounded-full ${urgencia.dot}`} />
@@ -354,7 +398,7 @@ function AgendaDiaPage() {
 									variant="outline"
 									className={`border-transparent text-[10px] ${urgencia.chip}`}
 								>
-									{grupo.items.length}
+									{dayTotal}
 								</Badge>
 								{fecha && (
 									<span className="text-muted-foreground text-xs">
@@ -381,7 +425,7 @@ function AgendaDiaPage() {
 										</TableRow>
 									</TableHeader>
 									<TableBody>
-										{grupo.items.map((item) => (
+										{dayItems.map((item) => (
 											<TableRow
 												key={item.cuotaId}
 												className="cursor-pointer"
@@ -455,6 +499,42 @@ function AgendaDiaPage() {
 									</TableBody>
 								</Table>
 							</div>
+
+							{/* Paginador de la sección (solo si hay más de una página) */}
+							{dayTotalPages > 1 && (
+								<div className="flex items-center justify-between pt-3">
+									<span className="text-muted-foreground text-xs">
+										Mostrando {dayItems.length} de {dayTotal} · página {dayPage}{" "}
+										de {dayTotalPages}
+									</span>
+									<div className="flex items-center gap-1">
+										<Button
+											variant="outline"
+											size="sm"
+											className="h-8"
+											disabled={dayPage <= 1 || query.isFetching}
+											onClick={() =>
+												setPagPorDia((p) => ({ ...p, [dia]: dayPage - 1 }))
+											}
+										>
+											<ChevronLeft className="h-4 w-4" />
+											Anterior
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											className="h-8"
+											disabled={dayPage >= dayTotalPages || query.isFetching}
+											onClick={() =>
+												setPagPorDia((p) => ({ ...p, [dia]: dayPage + 1 }))
+											}
+										>
+											Siguiente
+											<ChevronRight className="h-4 w-4" />
+										</Button>
+									</div>
+								</div>
+							)}
 						</CardContent>
 					</Card>
 				);

--- a/apps/crm/apps/web/src/routes/cobros/agenda.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/agenda.tsx
@@ -86,7 +86,7 @@ interface AgendaResponse {
 }
 
 const DIAS_AGENDA = [0, 1, 2, 3, 4, 5] as const;
-const PER_PAGE_AGENDA = 50;
+const PER_PAGE_AGENDA = 25;
 
 interface AsesorOption {
 	asesorId: number;
@@ -385,7 +385,10 @@ function AgendaDiaPage() {
 				if (query.isPending || dayTotal === 0) return null;
 				const dayItems = data?.items ?? [];
 				const dayTotalPages = data?.totalPages ?? 1;
-				const dayPage = pagPorDia[dia] ?? 1;
+				// Página EFECTIVA del server (ya viene clamped si el día encogió y
+				// la página pedida quedó fuera de rango) → el paginador se
+				// auto-corrige en vez de quedarse pegado en una página vacía.
+				const dayPage = data?.page ?? pagPorDia[dia] ?? 1;
 				const urgencia = URGENCIA[dia];
 				const fecha = dayItems[0]?.fechaVencimiento;
 				return (


### PR DESCRIPTION
## El problema (medido, no supuesto)

El 15 y el 30 concentran **~10× el resto** de días. Contra la data de dev:

| Fecha | Créditos con cuota que vence |
|---|---|
| **30** | **681** |
| **15** | **550** |
| Otros días | 200–350 |

La agenda traía los 6 días (D-0..D-5) en **una sola query sin límite**, filtraba el asesor **en JS después** de traer todo, y el front renderizaba **todas** las filas sin virtualizar. En el día pico: query pesada + scroll con lag.

## La solución 

La agenda ya está partida visualmente por día → cada sección es su propia query paginada. El día pesado llega **de a 50**, no de un jalón, y ves "Pagan HOY" al instante sin esperar el día grande.

### Backend
- **`cuotasProximas.ts`** gana `asesorId` (filtro **en el SQL**, no en JS) y `page`/`perPage` **opcionales**. El total sale en la misma pasada con `COUNT(*) OVER()` — sin una segunda query que repita las subconsultas correlacionadas. ORDER BY por nombre del cliente → páginas alfabéticas y estables.
- **El filtro de asesor al SQL es requisito, no opcional**: si se pagina con `LIMIT/OFFSET` y luego se filtra en JS, una página de 50 podría traer 0 filas del asesor → paginación rota.
- **`cuotas.ts`**: valida `asesor_id`, `page`, `per_page` (tope duro 200) → 400 si inválidos.
- **`getAgendaDia`**: input `{ dia, asesorId?, page?, perPage? }`, baja el filtro al SQL. El rol `cobros` sigue **forzado** a su propio asesor por correo. El enriquecimiento (teléfono/casos/badges) ahora corre sobre ≤perPage filas.

### El job de premora NO se toca
`sendPremoraReminders` **no** manda `page`/`perPage` → sin límite, sigue trayendo **todas** las cuotas del día (le manda a los ~600 del 30). Comportamiento clásico 100% intacto.

### Frontend
- **`agenda.tsx`**: `useQueries` dispara una query por día (D-0..D-5), cada sección con su propio paginador (‹ Anterior · página X de Y · Siguiente ›). `keepPreviousData` evita el parpadeo al cambiar de página. El header suma el total real de cada día (no el de la página).

## Verificación

- Typecheck limpio en `cartera-back` (cuotasProximas/cuotas) y `crm/server` (solo baseline de `lib/auth.ts`).
- Los 10 tests de `cobros-plantillas.test.ts` pasan (el job no se rompió).
- SQL validado en vivo contra dev (solo SELECT):
  - `COUNT(*) OVER()` da el total del set filtrado (40 para 6 días), `LIMIT 3` devuelve 3.
  - Filtro por asesor: asesor 8 / día 0 → total **2** (sus filas), no 40. Página 2 (offset 2) vuelve vacía. Orden por cliente correcto.

perPage = 50 (igual que `getTodosLosCreditos`), estilo de paginación consistente con el índice de cobros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)