### PR TITLE
feat(reportes): agregar reporte de efectividad por etapa

### DIFF
--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -342,6 +342,37 @@ const requireMetaColocacionReport = o.middleware(async ({ context, next }) => {
 	});
 });
 
+const requireEfectividadPorEtapaReport = o.middleware(
+	async ({ context, next }) => {
+		if (!context.session?.user) {
+			throw new ORPCError("UNAUTHORIZED");
+		}
+
+		const userId = context.session.user.id;
+		const userData = await db
+			.select()
+			.from(user)
+			.where(eq(user.id, userId))
+			.limit(1);
+		const userRole = userData[0]?.role;
+
+		if (!PERMISSIONS.canAccessEfectividadPorEtapaReport(userRole)) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "Efectividad por etapa report access required",
+			});
+		}
+
+		return next({
+			context: {
+				session: context.session,
+				user: userData[0],
+				userId,
+				userRole,
+			},
+		});
+	},
+);
+
 const requireViewOpportunityContracts = o.middleware(
 	async ({ context, next }) => {
 		if (!context.session?.user) {
@@ -575,6 +606,9 @@ export const porcentajeEfectividadReportProcedure = publicProcedure.use(
 );
 export const metaColocacionReportProcedure = publicProcedure.use(
 	requireMetaColocacionReport,
+);
+export const efectividadPorEtapaReportProcedure = publicProcedure.use(
+	requireEfectividadPorEtapaReport,
 );
 export const viewOpportunityContractsProcedure = publicProcedure.use(
 	requireViewOpportunityContracts,

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -171,6 +171,9 @@ export const PERMISSIONS = {
 	canAccessMetaColocacionReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
 
+	canAccessEfectividadPorEtapaReport: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
+
 	// Credit Detail Approval (40% → 50%)
 	canApproveCreditDetail: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -340,6 +340,7 @@ export const reportsAppRouter = {
 	getReportePorcentajeEfectividad:
 		reportsRouter.getReportePorcentajeEfectividad,
 	getReporteMetaColocacion: reportsRouter.getReporteMetaColocacion,
+	getReporteEfectividadPorEtapa: reportsRouter.getReporteEfectividadPorEtapa,
 	// Reportes unificados (cartera-back + CRM)
 	getReporteCarteraCompleto: reportesCarteraRouter.getReporteCarteraCompleto,
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -26,6 +26,7 @@ import {
 } from "../lib/lead-sources";
 import {
 	closedCreditsReportProcedure,
+	efectividadPorEtapaReportProcedure,
 	metaColocacionReportProcedure,
 	porcentajeEfectividadReportProcedure,
 	protectedProcedure,
@@ -657,6 +658,13 @@ export const getReporteInventario = protectedProcedure.handler(async () => {
 
 const CLOSED_STAGE_THRESHOLD = 90;
 const MAX_REPORT_ROWS = 10_000;
+// Primeras 4 etapas del pipeline: Preparación, Llamada de presentación, Solución
+// y propuesta, Recepción de documentación y traslado a análisis.
+const EFECTIVIDAD_POR_ETAPA_MAX_ORDER = 4;
+
+function pctOf(numerator: number, denominator: number) {
+	return denominator > 0 ? Math.round((numerator * 1000) / denominator) / 10 : 0;
+}
 
 type PorcentajeEfectividadFuenteBaseRow = {
 	source: string;
@@ -984,6 +992,164 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 			porFuente: porFuenteRows,
 			porTipoCanal: aggregateTiempoCierrePorTipoCanal(porFuenteRows),
 		};
+	});
+
+type EfectividadPorEtapaRawRow = {
+	stageId: string;
+	stageOrder: number;
+	stageName: string;
+	source: string | null;
+	llegaron: number;
+	avanzaron: number;
+	cerraron: number;
+};
+
+export function buildEfectividadPorEtapaRows(rows: EfectividadPorEtapaRawRow[]) {
+	const porEtapaFuente = rows
+		.filter((row): row is EfectividadPorEtapaRawRow & { source: string } =>
+			row.source !== null,
+		)
+		.map((row) => ({
+			stageId: row.stageId,
+			stageOrder: row.stageOrder,
+			stageName: row.stageName,
+			source: row.source,
+			llegaron: row.llegaron,
+			avanzaron: row.avanzaron,
+			cerraron: row.cerraron,
+			pctAvance: pctOf(row.avanzaron, row.llegaron),
+			pctEfectividad: pctOf(row.cerraron, row.llegaron),
+		}))
+		.sort((a, b) => a.stageOrder - b.stageOrder || b.llegaron - a.llegaron);
+
+	const byStage = new Map<
+		string,
+		{
+			stageId: string;
+			stageOrder: number;
+			stageName: string;
+			llegaron: number;
+			avanzaron: number;
+			cerraron: number;
+		}
+	>();
+
+	for (const row of rows) {
+		const current = byStage.get(row.stageId) ?? {
+			stageId: row.stageId,
+			stageOrder: row.stageOrder,
+			stageName: row.stageName,
+			llegaron: 0,
+			avanzaron: 0,
+			cerraron: 0,
+		};
+		current.llegaron += row.llegaron;
+		current.avanzaron += row.avanzaron;
+		current.cerraron += row.cerraron;
+		byStage.set(row.stageId, current);
+	}
+
+	const porEtapa = [...byStage.values()]
+		.sort((a, b) => a.stageOrder - b.stageOrder)
+		.map((stage) => ({
+			...stage,
+			pctAvance: pctOf(stage.avanzaron, stage.llegaron),
+			pctEfectividad: pctOf(stage.cerraron, stage.llegaron),
+		}));
+
+	return { porEtapa, porEtapaFuente };
+}
+
+/**
+ * Reporte de Efectividad por Etapa
+ * De las oportunidades creadas en el rango, cuántas llegan a cada una de las
+ * primeras 4 etapas del pipeline ("llegar" = etapa actual o alguna vez en su
+ * historial), cuántas avanzan más allá de esa etapa y cuántas terminan
+ * cerrando (etapa con closurePercentage >= 90), desglosado por etapa y fuente.
+ */
+export const getReporteEfectividadPorEtapa = efectividadPorEtapaReportProcedure
+	.input(closedCreditsReportInputSchema)
+	.handler(async ({ input }) => {
+		const { start, end } = parseGuatemalaDateRange(
+			input.startDate,
+			input.endDate,
+		);
+
+		const result = await db.execute(sql`
+			WITH target_stages AS (
+				SELECT id, "order", name
+				FROM sales_stages
+				WHERE "order" <= ${EFECTIVIDAD_POR_ETAPA_MAX_ORDER}
+			), touched_stages AS (
+				SELECT o.id AS opportunity_id, o.stage_id AS stage_id
+				FROM opportunities o
+				WHERE o.stage_id IN (SELECT id FROM target_stages)
+				UNION
+				SELECT h.opportunity_id, h.from_stage_id
+				FROM opportunity_stage_history h
+				WHERE h.from_stage_id IN (SELECT id FROM target_stages)
+				UNION
+				SELECT h.opportunity_id, h.to_stage_id
+				FROM opportunity_stage_history h
+				WHERE h.to_stage_id IN (SELECT id FROM target_stages)
+			), max_order_reached AS (
+				SELECT h.opportunity_id, MAX(s."order") AS max_order
+				FROM opportunity_stage_history h
+				JOIN sales_stages s ON s.id = h.to_stage_id
+				GROUP BY h.opportunity_id
+			), ever_closed AS (
+				SELECT DISTINCT h.opportunity_id
+				FROM opportunity_stage_history h
+				JOIN sales_stages s ON s.id = h.to_stage_id
+				WHERE s.closure_percentage >= ${CLOSED_STAGE_THRESHOLD}
+			), cohort AS (
+				SELECT o.id, COALESCE(o.source, 'other') AS source, o.stage_id AS current_stage_id
+				FROM opportunities o
+				WHERE o.created_at >= ${start}
+					AND o.created_at <= ${end}
+					AND o.status != 'migrate'
+			)
+			SELECT
+				ts.id AS stage_id,
+				ts."order" AS stage_order,
+				ts.name AS stage_name,
+				c.source AS source,
+				COUNT(DISTINCT c.id)::int AS llegaron,
+				COUNT(DISTINCT CASE
+					WHEN GREATEST(cs."order", COALESCE(mo.max_order, 0)) > ts."order" THEN c.id
+				END)::int AS avanzaron,
+				COUNT(DISTINCT CASE WHEN ec.opportunity_id IS NOT NULL THEN c.id END)::int AS cerraron
+			FROM target_stages ts
+			LEFT JOIN touched_stages tch ON tch.stage_id = ts.id
+			LEFT JOIN cohort c ON c.id = tch.opportunity_id
+			LEFT JOIN sales_stages cs ON cs.id = c.current_stage_id
+			LEFT JOIN max_order_reached mo ON mo.opportunity_id = c.id
+			LEFT JOIN ever_closed ec ON ec.opportunity_id = c.id
+			GROUP BY ts.id, ts."order", ts.name, c.source
+			ORDER BY ts."order", c.source
+		`);
+
+		const rawRows = result.rows as {
+			stage_id: string;
+			stage_order: number;
+			stage_name: string;
+			source: string | null;
+			llegaron: number;
+			avanzaron: number;
+			cerraron: number;
+		}[];
+
+		return buildEfectividadPorEtapaRows(
+			rawRows.map((row) => ({
+				stageId: row.stage_id,
+				stageOrder: row.stage_order,
+				stageName: row.stage_name,
+				source: row.source,
+				llegaron: row.llegaron,
+				avanzaron: row.avanzaron,
+				cerraron: row.cerraron,
+			})),
+		);
 	});
 
 /**

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -47,6 +47,7 @@ import { Route as InversionesLiquidacionesInversionistaIdRouteImport } from './r
 import { Route as CrmReportesTiempoCierreRouteImport } from './routes/crm/reportes/tiempo-cierre'
 import { Route as CrmReportesPorcentajeEfectividadRouteImport } from './routes/crm/reportes/porcentaje-efectividad'
 import { Route as CrmReportesMetaColocacionRouteImport } from './routes/crm/reportes/meta-colocacion'
+import { Route as CrmReportesEfectividadPorEtapaRouteImport } from './routes/crm/reportes/efectividad-por-etapa'
 import { Route as CrmAnalysisOpportunityIdRouteImport } from './routes/crm/analysis/$opportunityId'
 import { Route as CrmAdminMiniagentRouteImport } from './routes/crm/admin/miniagent'
 
@@ -246,6 +247,12 @@ const CrmReportesMetaColocacionRoute =
     path: '/crm/reportes/meta-colocacion',
     getParentRoute: () => rootRouteImport,
   } as any)
+const CrmReportesEfectividadPorEtapaRoute =
+  CrmReportesEfectividadPorEtapaRouteImport.update({
+    id: '/crm/reportes/efectividad-por-etapa',
+    path: '/crm/reportes/efectividad-por-etapa',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CrmAnalysisOpportunityIdRoute =
   CrmAnalysisOpportunityIdRouteImport.update({
     id: '/crm/analysis/$opportunityId',
@@ -290,6 +297,7 @@ export interface FileRoutesByFullPath {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/efectividad-por-etapa': typeof CrmReportesEfectividadPorEtapaRoute
   '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
@@ -332,6 +340,7 @@ export interface FileRoutesByTo {
   '/vehicles': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/efectividad-por-etapa': typeof CrmReportesEfectividadPorEtapaRoute
   '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
@@ -375,6 +384,7 @@ export interface FileRoutesById {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/efectividad-por-etapa': typeof CrmReportesEfectividadPorEtapaRoute
   '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
@@ -419,6 +429,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/efectividad-por-etapa'
     | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
@@ -461,6 +472,7 @@ export interface FileRouteTypes {
     | '/vehicles'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/efectividad-por-etapa'
     | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
@@ -503,6 +515,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/efectividad-por-etapa'
     | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
@@ -546,6 +559,7 @@ export interface RootRouteChildren {
   VehiclesIndexRoute: typeof VehiclesIndexRoute
   CrmAdminMiniagentRoute: typeof CrmAdminMiniagentRoute
   CrmAnalysisOpportunityIdRoute: typeof CrmAnalysisOpportunityIdRoute
+  CrmReportesEfectividadPorEtapaRoute: typeof CrmReportesEfectividadPorEtapaRoute
   CrmReportesMetaColocacionRoute: typeof CrmReportesMetaColocacionRoute
   CrmReportesPorcentajeEfectividadRoute: typeof CrmReportesPorcentajeEfectividadRoute
   CrmReportesTiempoCierreRoute: typeof CrmReportesTiempoCierreRoute
@@ -825,6 +839,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CrmReportesMetaColocacionRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/crm/reportes/efectividad-por-etapa': {
+      id: '/crm/reportes/efectividad-por-etapa'
+      path: '/crm/reportes/efectividad-por-etapa'
+      fullPath: '/crm/reportes/efectividad-por-etapa'
+      preLoaderRoute: typeof CrmReportesEfectividadPorEtapaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/crm/analysis/$opportunityId': {
       id: '/crm/analysis/$opportunityId'
       path: '/crm/analysis/$opportunityId'
@@ -874,6 +895,7 @@ const rootRouteChildren: RootRouteChildren = {
   VehiclesIndexRoute: VehiclesIndexRoute,
   CrmAdminMiniagentRoute: CrmAdminMiniagentRoute,
   CrmAnalysisOpportunityIdRoute: CrmAnalysisOpportunityIdRoute,
+  CrmReportesEfectividadPorEtapaRoute: CrmReportesEfectividadPorEtapaRoute,
   CrmReportesMetaColocacionRoute: CrmReportesMetaColocacionRoute,
   CrmReportesPorcentajeEfectividadRoute: CrmReportesPorcentajeEfectividadRoute,
   CrmReportesTiempoCierreRoute: CrmReportesTiempoCierreRoute,

--- a/apps/crm/apps/web/src/routes/crm/reportes/efectividad-por-etapa.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/efectividad-por-etapa.tsx
@@ -1,0 +1,469 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Activity, ArrowRightCircle, CheckCircle2, ListChecks } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { DateRange } from "react-day-picker";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { toast } from "sonner";
+import {
+	DEFAULT_PRESET,
+	RangePresetFilter,
+	rangeForPreset,
+} from "@/components/reports/range-preset-filter";
+import { ReportCard } from "@/components/reports/report-card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { getSourceLabel } from "@/lib/crm-formatters";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/crm/reportes/efectividad-por-etapa")({
+	component: RouteComponent,
+});
+
+const GUATEMALA_TZ = "America/Guatemala";
+const BAR_HEIGHT_PX = 52;
+
+const SOURCE_COLORS: Record<string, string> = {
+	website: "#8b5cf6",
+	referral: "#10b981",
+	cold_call: "#f97316",
+	email: "#6366f1",
+	social_media: "#d946ef",
+	event: "#a855f7",
+	facebook: "#3b82f6",
+	instagram: "#ec4899",
+	google: "#ef4444",
+	meta: "#0ea5e9",
+	linkedin: "#1d4ed8",
+	// "Whatsapp" con W mayúscula es el valor real del enum en BD
+	Whatsapp: "#22c55e",
+	agency: "#14b8a6",
+	property: "#f59e0b",
+	recurrent: "#7c3aed",
+	recurrent_active: "#0891b2",
+	other: "#9ca3af",
+};
+
+function getSourceColor(source: string): string {
+	return SOURCE_COLORS[source] ?? "#9ca3af";
+}
+
+function formatDateInput(date: Date): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: GUATEMALA_TZ,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+function RouteComponent() {
+	const {
+		data: session,
+		error: sessionError,
+		isPending: sessionPending,
+	} = authClient.useSession();
+	const navigate = useNavigate();
+
+	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
+	const userRole = userProfile.data?.role;
+	const canAccess = userRole
+		? PERMISSIONS.canAccessEfectividadPorEtapaReport(userRole)
+		: false;
+	const isPending = sessionPending || userProfile.isPending;
+
+	useEffect(() => {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
+			navigate({ to: "/login" });
+		} else if (session && !userProfile.isPending && !canAccess) {
+			navigate({ to: "/dashboard" });
+			toast.error("Acceso denegado");
+		}
+	}, [
+		session,
+		sessionError,
+		sessionPending,
+		userProfile.isPending,
+		canAccess,
+		navigate,
+	]);
+
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAccess) return null;
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<EfectividadPorEtapaContent />
+		</div>
+	);
+}
+
+export function EfectividadPorEtapaContent() {
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(() =>
+		rangeForPreset(DEFAULT_PRESET),
+	);
+	const [selectedStageId, setSelectedStageId] = useState<string | null>(null);
+
+	const input =
+		dateRange?.from && dateRange?.to
+			? {
+					startDate: formatDateInput(dateRange.from),
+					endDate: formatDateInput(dateRange.to),
+				}
+			: null;
+
+	const reportQuery = useQuery({
+		...orpc.getReporteEfectividadPorEtapa.queryOptions({
+			input: input ?? { startDate: "", endDate: "" },
+		}),
+		enabled: !!input,
+	});
+	const data = reportQuery.data;
+	const isLoading = reportQuery.isLoading;
+
+	const porEtapa = data?.porEtapa ?? [];
+	const porEtapaFuente = data?.porEtapaFuente ?? [];
+
+	const activeStageId = selectedStageId ?? porEtapa[0]?.stageId ?? null;
+	const activeStage = porEtapa.find((e) => e.stageId === activeStageId) ?? null;
+
+	const chartData = useMemo(
+		() =>
+			porEtapaFuente
+				.filter((row) => row.stageId === activeStageId)
+				.map((row) => ({
+					rawSource: row.source,
+					source: getSourceLabel(row.source),
+					pctEfectividad: row.pctEfectividad,
+					pctAvance: row.pctAvance,
+					llegaron: row.llegaron,
+					avanzaron: row.avanzaron,
+					cerraron: row.cerraron,
+				}))
+				.sort((a, b) => b.pctEfectividad - a.pctEfectividad),
+		[porEtapaFuente, activeStageId],
+	);
+
+	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
+
+	return (
+		<div className="space-y-6">
+			<div>
+				<h1 className="font-bold text-3xl tracking-tight">
+					Efectividad por Etapa
+				</h1>
+				<p className="mt-1 text-muted-foreground">
+					De las oportunidades creadas en el rango, cuántas llegan a cada una de
+					las primeras 4 etapas del pipeline, cuántas avanzan más allá y cuántas
+					terminan cerrando.
+				</p>
+			</div>
+
+			<RangePresetFilter dateRange={dateRange} onDateRangeChange={setDateRange} />
+
+			{/* ── Progresión por Etapa ── */}
+			<Card>
+				<CardHeader>
+					<CardTitle>Progresión por Etapa</CardTitle>
+					<CardDescription>
+						Preparación → Llamada de presentación → Solución y propuesta →
+						Recepción de documentación y traslado a análisis
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Etapa</TableHead>
+								<TableHead className="text-right">Llegaron</TableHead>
+								<TableHead className="text-right">Avanzaron</TableHead>
+								<TableHead className="text-right">% Avance</TableHead>
+								<TableHead className="text-right">Cerraron</TableHead>
+								<TableHead className="text-right">% Efectividad</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : porEtapa.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								porEtapa.map((row) => (
+									<TableRow
+										key={row.stageId}
+										className={
+											row.stageId === activeStageId ? "bg-muted/50" : undefined
+										}
+									>
+										<TableCell className="font-medium">
+											{row.stageName}
+										</TableCell>
+										<TableCell className="text-right">{row.llegaron}</TableCell>
+										<TableCell className="text-right">
+											{row.avanzaron}
+										</TableCell>
+										<TableCell className="text-right text-muted-foreground">
+											{row.pctAvance}%
+										</TableCell>
+										<TableCell className="text-right">
+											{row.cerraron}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.pctEfectividad}%
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+
+			{/* ── Selector de etapa + detalle por fuente ── */}
+			<div className="flex items-center gap-3">
+				<span className="text-muted-foreground text-sm">Ver detalle de:</span>
+				<Select
+					value={activeStageId ?? undefined}
+					onValueChange={setSelectedStageId}
+					disabled={porEtapa.length === 0}
+				>
+					<SelectTrigger className="w-[340px]">
+						<SelectValue placeholder="Selecciona una etapa" />
+					</SelectTrigger>
+					<SelectContent>
+						{porEtapa.map((row) => (
+							<SelectItem key={row.stageId} value={row.stageId}>
+								{row.stageName}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			{activeStage && (
+				<div className="grid gap-4 md:grid-cols-4">
+					<ReportCard
+						title="Llegaron"
+						value={isLoading ? "—" : activeStage.llegaron}
+						description="Oportunidades en esta etapa"
+						icon={Activity}
+					/>
+					<ReportCard
+						title="Avanzaron"
+						value={isLoading ? "—" : activeStage.avanzaron}
+						description={`${activeStage.pctAvance}% avanzó más allá`}
+						icon={ArrowRightCircle}
+					/>
+					<ReportCard
+						title="Cerraron"
+						value={isLoading ? "—" : activeStage.cerraron}
+						description="Llegaron a etapa de cierre"
+						icon={CheckCircle2}
+					/>
+					<ReportCard
+						title="Efectividad"
+						value={isLoading ? "—" : `${activeStage.pctEfectividad}%`}
+						description="Cerraron / llegaron"
+						icon={ListChecks}
+					/>
+				</div>
+			)}
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Efectividad por fuente</CardTitle>
+					<CardDescription>
+						{activeStage
+							? `Desglose por fuente para "${activeStage.stageName}"`
+							: "Selecciona una etapa para ver el desglose"}
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{isLoading ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							Cargando...
+						</div>
+					) : chartData.length === 0 ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							No hay datos para el período seleccionado
+						</div>
+					) : (
+						<ResponsiveContainer width="100%" height={chartHeight}>
+							<BarChart
+								data={chartData}
+								layout="vertical"
+								margin={{ top: 0, right: 56, left: 0, bottom: 0 }}
+							>
+								<CartesianGrid strokeDasharray="3 3" horizontal={false} />
+								<XAxis
+									type="number"
+									domain={[0, 100]}
+									tickFormatter={(v: number) => `${v}%`}
+									tick={{ fontSize: 12 }}
+								/>
+								<YAxis
+									dataKey="source"
+									type="category"
+									width={110}
+									tick={{ fontSize: 12 }}
+								/>
+								<Tooltip
+									formatter={(value) => [`${value}%`, "Efectividad"]}
+									labelFormatter={(label) => `Fuente: ${label}`}
+								/>
+								<Bar
+									dataKey="pctEfectividad"
+									name="Efectividad"
+									radius={[0, 4, 4, 0]}
+								>
+									{chartData.map((entry) => (
+										<Cell
+											key={entry.rawSource}
+											fill={getSourceColor(entry.rawSource)}
+										/>
+									))}
+								</Bar>
+							</BarChart>
+						</ResponsiveContainer>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Detalle por fuente</CardTitle>
+					<CardDescription>
+						{activeStage
+							? `Llegaron, avanzaron y cerraron por fuente en "${activeStage.stageName}"`
+							: "Selecciona una etapa para ver el desglose"}
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Fuente</TableHead>
+								<TableHead className="text-right">Llegaron</TableHead>
+								<TableHead className="text-right">Avanzaron</TableHead>
+								<TableHead className="text-right">% Avance</TableHead>
+								<TableHead className="text-right">Cerraron</TableHead>
+								<TableHead className="text-right">% Efectividad</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : chartData.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								chartData.map((row) => (
+									<TableRow key={row.rawSource}>
+										<TableCell className="font-medium">
+											<div className="flex items-center gap-2">
+												<span
+													className="h-2.5 w-2.5 shrink-0 rounded-full"
+													style={{
+														backgroundColor: getSourceColor(row.rawSource),
+													}}
+												/>
+												{row.source}
+											</div>
+										</TableCell>
+										<TableCell className="text-right">
+											{row.llegaron}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.avanzaron}
+										</TableCell>
+										<TableCell className="text-right text-muted-foreground">
+											{row.pctAvance}%
+										</TableCell>
+										<TableCell className="text-right">
+											{row.cerraron}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.pctEfectividad}%
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
@@ -7,6 +7,7 @@ import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
+import { EfectividadPorEtapaContent } from "./efectividad-por-etapa";
 import { MetaColocacionContent } from "./meta-colocacion";
 import { PorcentajeEfectividadContent } from "./porcentaje-efectividad";
 import { TiempoCierreContent } from "./tiempo-cierre";
@@ -34,7 +35,10 @@ function RouteComponent() {
 	const canMeta = userRole
 		? PERMISSIONS.canAccessMetaColocacionReport(userRole)
 		: false;
-	const canAny = canTiempo || canEfectividad || canMeta;
+	const canEtapa = userRole
+		? PERMISSIONS.canAccessEfectividadPorEtapaReport(userRole)
+		: false;
+	const canAny = canTiempo || canEfectividad || canMeta || canEtapa;
 	const isPending = sessionPending || userProfile.isPending;
 
 	useEffect(() => {
@@ -73,14 +77,17 @@ function RouteComponent() {
 		? "meta"
 		: canEfectividad
 			? "efectividad"
-			: "tiempo";
+			: canTiempo
+				? "tiempo"
+				: "etapa";
 
 	return (
 		<div className="container mx-auto space-y-6 p-6">
 			<div>
 				<h1 className="font-bold text-3xl tracking-tight">Reportes</h1>
 				<p className="mt-1 text-muted-foreground">
-					Reportes de ventas: colocación, efectividad y tiempo de cierre.
+					Reportes de ventas: colocación, efectividad, tiempo de cierre y
+					efectividad por etapa.
 				</p>
 			</div>
 
@@ -92,6 +99,9 @@ function RouteComponent() {
 					)}
 					{canTiempo && (
 						<TabsTrigger value="tiempo">Tiempo de cierre</TabsTrigger>
+					)}
+					{canEtapa && (
+						<TabsTrigger value="etapa">Efectividad por Etapa</TabsTrigger>
 					)}
 				</TabsList>
 
@@ -108,6 +118,11 @@ function RouteComponent() {
 				{canTiempo && (
 					<TabsContent value="tiempo" className="space-y-6">
 						<TiempoCierreContent />
+					</TabsContent>
+				)}
+				{canEtapa && (
+					<TabsContent value="etapa" className="space-y-6">
+						<EfectividadPorEtapaContent />
 					</TabsContent>
 				)}
 			</Tabs>


### PR DESCRIPTION
### Reporte de efectividad por etapa
Cuarto reporte del módulo `/crm/reportes`: **Efectividad por Etapa**. Mide, para las primeras 4 etapas del pipeline (Preparación → Llamada de presentación → Solución y propuesta → Recepción de documentación y traslado a análisis), cuántas oportunidades llegan a cada una, cuántas avanzan más allá y cuántas terminan cerrando — desglosado por etapa y por fuente.

### Backend
- `getReporteEfectividadPorEtapa` (`reports.ts`): query con CTEs sobre `opportunity_stage_history` y `sales_stages`, acotado a las primeras 4 etapas (`order <= 4`).
  - "Llegó a una etapa" combina la etapa actual de la oportunidad con su historial de transiciones (`fromStageId`/`toStageId`), ya que la asignación inicial de etapa nunca queda registrada como transición.
  - "Avanzó" compara el orden máximo de etapa alcanzado contra el orden de la etapa evaluada.
  - "Cerró" usa el mismo umbral que Efectividad/Tiempo de Cierre (`closurePercentage >= 90`).
  - Filtro de rango sobre `opportunities.createdAt`, mismo criterio que el reporte de Efectividad.
- Nuevo permiso `canAccessEfectividadPorEtapaReport` (ADMIN / SALES_SUPERVISOR) en `roles.ts`, con su middleware y procedure en `orpc.ts`, siguiendo el patrón de los otros 3 reportes de ventas.
- Registrado en `routers/index.ts`.

### Frontend
- Nueva página `efectividad-por-etapa.tsx`, autocontenida (sin helpers compartidos con los otros reportes de la carpeta, por convención del proyecto).
- Tabla "Progresión por Etapa": resumen fijo de las 4 etapas (Llegaron / Avanzaron / % Avance / Cerraron / % Efectividad), siempre visible.
- Selector de etapa + "Detalle por fuente": gráfica y tabla con el desglose por fuente de la etapa seleccionada.
- Registrado como 4to tab en `reportes/index.tsx`, visible solo para ADMIN / SALES_SUPERVISOR.

<img width="1427" height="789" alt="Captura de pantalla 2026-07-20 164855" src="https://github.com/user-attachments/assets/5f7ca38e-35e3-4c67-919b-637dd41fb246" />

<img width="1372" height="643" alt="Captura de pantalla 2026-07-20 165012" src="https://github.com/user-attachments/assets/1e21d0c0-dcf8-43e8-a39b-abd75059d8dc" />

<img width="1363" height="536" alt="Captura de pantalla 2026-07-20 165018" src="https://github.com/user-attachments/assets/0d0973be-051a-4ed0-8289-c34531273dc7" />
