### PR TITLE
fix(reportes): mostrar inversionistas en pagos parciales sin reparto (simulación)

### DIFF
--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -673,4 +673,160 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     expect(out).toHaveLength(1);
     expect(out.find((r: any) => r.inversionistaId === 86)).toBeUndefined();
   });
+
+  // ── 🆕 Simulación de parciales sin reparto (simularSinPci) ────────────────
+  // Caso real (crédito 01010214120570, pago 144366 del 2026-07-07): parcial de
+  // interés Q365.17 facturado el día 7; el reparto real (pci) no se creó sino
+  // hasta que la cuota cerró el día 20. La simulación debe mostrar al
+  // inversionista desde el día 7 con el MISMO monto que pci escribió después.
+  const creditoInvsJennifer = [
+    {
+      inversionista_id: 14,
+      nombre: "Carlos Fernando Carrillo Cifuentes",
+      emite_factura: false,
+      porcentaje_participacion_inversionista: "80",
+      porcentaje_cash_in: "20",
+      monto_aportado: "100176.29",
+    },
+    {
+      inversionista_id: 86,
+      nombre: "Cube Investments S.A.",
+      emite_factura: false,
+      porcentaje_participacion_inversionista: "0",
+      porcentaje_cash_in: "100",
+      monto_aportado: "0",
+    },
+  ];
+
+  it("caso 7 (sim): parcial sin pci + simularSinPci → simula no-CUBE igual que el reparto real", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("73.03"), iva: new Big("7.83") },
+      cuota: "3751.32",
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+    });
+
+    expect(out).toHaveLength(2);
+
+    // Carlos: 365.17 × 100% (aportado) × 80% (participación) = 292.14 —
+    // exactamente lo que pci registró al cerrar la cuota el día 20.
+    // Numbers (no strings): el front tipa number y hace .toFixed().
+    const carlos = out.find((r: any) => r.inversionistaId === 14)!;
+    expect(carlos.abonoInteres).toBe(292.14);
+    expect(carlos.abonoIva).toBe(0);
+    expect(carlos.abonoCapital).toBe(0); // capital solo se reparte al cierre
+    expect(carlos.isr).toBe(14.61);
+    expect(carlos.montoAportado).toBe(100176.29);
+    expect(carlos.porcentajeParticipacion).toBe(80);
+
+    // CUBE sigue saliendo del desglose (net 65.20), como antes.
+    const cube = out.find((r: any) => r.inversionistaId === 86)!;
+    expect(cube.abonoInteres).toBe("65.20");
+    expect(cube.abonoIva).toBe("7.83");
+  });
+
+  it("caso 8 (sim): si YA hay filas pci, el reparto real manda y no se simula", () => {
+    const pciRows = [
+      {
+        inversionistaId: 14,
+        nombreInversionista: "Carlos Fernando Carrillo Cifuentes",
+        emiteFactura: false,
+        abonoCapital: "0.00",
+        abonoInteres: "292.14",
+        abonoIva: "0.00",
+        isr: "14.61",
+        cuotaPago: "3751.32",
+        montoAportado: "100176.29",
+        porcentajeParticipacion: "80",
+      },
+    ];
+
+    const out = armarInversionistasPago({
+      pciRows,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("73.03"), iva: new Big("7.83") },
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+    });
+
+    // 1 fila pci (Carlos) + fila CUBE del desglose; nada duplicado por simulación.
+    expect(out).toHaveLength(2);
+    expect(out.filter((r: any) => r.inversionistaId === 14)).toHaveLength(1);
+  });
+
+  it("caso 9 (sim): reparte por monto_aportado entre varios inversionistas", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("29.6"), iva: new Big("3.17") },
+      creditoInvs: [
+        {
+          inversionista_id: 1,
+          nombre: "InvA",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "90",
+          porcentaje_cash_in: "10",
+          monto_aportado: "60000",
+        },
+        {
+          inversionista_id: 2,
+          nombre: "InvB",
+          emite_factura: true,
+          porcentaje_participacion_inversionista: "85",
+          porcentaje_cash_in: "15",
+          monto_aportado: "40000",
+        },
+      ],
+      abonoInteresPago: "100",
+      abonoIvaPago: "12",
+      simularSinPci: true,
+    });
+
+    // InvA: 100 × 0.6 × 0.90 = 54.00 | IVA 12 × 0.6 × 0.90 = 6.48
+    const invA = out.find((r: any) => r.inversionistaId === 1)!;
+    expect(invA.abonoInteres).toBe(54);
+    expect(invA.abonoIva).toBe(6.48);
+
+    // InvB (emite_factura=true también se simula: pci lo incluye al cierre):
+    // 100 × 0.4 × 0.85 = 34.00 | IVA 12 × 0.4 × 0.85 = 4.08
+    const invB = out.find((r: any) => r.inversionistaId === 2)!;
+    expect(invB.abonoInteres).toBe(34);
+    expect(invB.abonoIva).toBe(4.08);
+    expect(invB.emiteFactura).toBe(true);
+  });
+
+  it("caso 10 (sim): sin desglose (pago no facturado) NO se simula aunque simularSinPci=true", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: null,
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+    });
+
+    expect(out).toHaveLength(0);
+  });
+
+  it("caso 11 (sim): simularSinPci=false conserva el comportamiento previo (solo CUBE)", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("73.03"), iva: new Big("7.83") },
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: false,
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].inversionistaId).toBe(86);
+  });
 });

--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -815,6 +815,70 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     expect(out).toHaveLength(0);
   });
 
+  it("caso 12 (sim): bandera_reinversion excluye SOLO al redirigido a CUBE (espejo pendiente); los demás sí se simulan", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("60"), iva: new Big("6.43") },
+      creditoInvs: [
+        {
+          inversionista_id: 1,
+          nombre: "InvNormal",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "90",
+          porcentaje_cash_in: "10",
+          monto_aportado: "50000",
+          status_espejo: "activo",
+        },
+        {
+          inversionista_id: 2,
+          nombre: "InvRedirigido",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "85",
+          porcentaje_cash_in: "15",
+          monto_aportado: "50000",
+          status_espejo: "pendiente_compra_cartera",
+        },
+      ],
+      abonoInteresPago: "100",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+      banderaReinversion: true,
+    });
+
+    // InvNormal se simula: 100 × 0.5 × 0.90 = 45.00
+    const invNormal = out.find((r: any) => r.inversionistaId === 1)!;
+    expect(invNormal).toBeDefined();
+    expect(invNormal.abonoInteres).toBe(45);
+
+    // InvRedirigido NO aparece (su interés ya va dentro del desglose de CUBE)
+    expect(out.find((r: any) => r.inversionistaId === 2)).toBeUndefined();
+
+    // Sin bandera, el mismo roster simula a AMBOS (el espejo pendiente solo,
+    // sin bandera, no redirige — misma condición que cofidi).
+    const outSinBandera = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("60"), iva: new Big("6.43") },
+      creditoInvs: [
+        {
+          inversionista_id: 2,
+          nombre: "InvRedirigido",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "85",
+          porcentaje_cash_in: "15",
+          monto_aportado: "50000",
+          status_espejo: "pendiente_compra_cartera",
+        },
+      ],
+      abonoInteresPago: "100",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+      banderaReinversion: false,
+    });
+    expect(outSinBandera.find((r: any) => r.inversionistaId === 2)).toBeDefined();
+  });
+
   it("caso 11 (sim): simularSinPci=false conserva el comportamiento previo (solo CUBE)", () => {
     const out = armarInversionistasPago({
       pciRows: null,

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -2618,6 +2618,9 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
     // Solo no-CUBE: el interés de CUBE ya se corrige desde el desglose abajo
     // (incluye parciales). Excluye redirigidos a CUBE (bandera + espejo
     // pendiente), igual que la simulación del detalle.
+    // Con filtro == CUBE la query se salta por completo (Codex P2): un resumen
+    // solo-CUBE no debe ganar filas no-CUBE por los parciales simulables.
+    const esFiltroCube = Boolean(inversionistaId) && Number(inversionistaId) === CUBE_ID;
     const totalesSimQuery = sql`
       WITH pf AS (
         SELECT p.pago_id, p.credito_id, c.bandera_reinversion,
@@ -2657,7 +2660,9 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       GROUP BY ci.inversionista_id, i.nombre, i.emite_factura
     `;
 
-    const totalesSimResult = await db.execute(totalesSimQuery);
+    const totalesSimResult = esFiltroCube
+      ? { rows: [] as any[] }
+      : await db.execute(totalesSimQuery);
     for (const simRow of totalesSimResult.rows as any[]) {
       const interesSim = new Big(simRow.interesSim ?? 0);
       const ivaSim = new Big(simRow.ivaSim ?? 0);

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1793,6 +1793,10 @@ export type ReportCreditoInv = {
   porcentaje_participacion_inversionista: string | number;
   porcentaje_cash_in: string | number;
   monto_aportado: string | number;
+  // status del espejo (creditos_inversionistas_espejo): con bandera_reinversion
+  // activa, 'pendiente_reinversion'/'pendiente_compra_cartera' redirigen el
+  // interés de ESE inversionista a CUBE en la facturación (cofidi.ts).
+  status_espejo?: string | null;
 };
 
 
@@ -1813,7 +1817,17 @@ function simularInversionistasSinPci(args: {
   abonoInteresPago: string | number | null | undefined;
   abonoIvaPago: string | number | null | undefined;
   cuota?: string | number | null;
+  banderaReinversion?: boolean;
 }): ReportInvRow[] {
+  // Redirigido a CUBE (misma condición que cofidi al facturar): su interés ya
+  // está dentro del desglose INTERES de CUBE — simularle su parte regular lo
+  // doble-contaría. Solo se excluye a ESE inversionista; los demás del mismo
+  // crédito se facturan normal y sí se simulan (Codex P2, PR #1137).
+  const esRedirigidoACube = (ci: ReportCreditoInv) =>
+    args.banderaReinversion === true &&
+    (ci.status_espejo === "pendiente_reinversion" ||
+      ci.status_espejo === "pendiente_compra_cartera");
+
   const split = calcularSplitInteresPci({
     inversionistas: args.creditoInvs.map((ci) => ({
       inversionista_id: ci.inversionista_id,
@@ -1832,7 +1846,7 @@ function simularInversionistasSinPci(args: {
   // json_build_object y el front (modalViewInvestor) les hace .toFixed() —
   // una fila simulada con strings reventaría el modal.
   return args.creditoInvs
-    .filter((ci) => ci.inversionista_id !== args.cubeId)
+    .filter((ci) => ci.inversionista_id !== args.cubeId && !esRedirigidoACube(ci))
     .map((ci) => {
       const s = splitPorInv.get(ci.inversionista_id);
       const interes = (s?.abono_interes ?? new Big(0)).round(2);
@@ -1889,6 +1903,7 @@ export function armarInversionistasPago(args: {
   abonoInteresPago?: string | number | null;            // pagos_credito.abono_interes
   abonoIvaPago?: string | number | null;                // pagos_credito.abono_iva_12
   simularSinPci?: boolean;                              // el caller gatea: validated + !pendienteFacturar
+  banderaReinversion?: boolean;                         // excluye SOLO a los redirigidos a CUBE (espejo pendiente)
 }): ReportInvRow[] {
   const rows = Array.isArray(args.pciRows) ? args.pciRows : [];
   let noCube = rows.filter((r) => r.inversionistaId !== args.cubeId);
@@ -1910,6 +1925,7 @@ export function armarInversionistasPago(args: {
       abonoInteresPago: args.abonoInteresPago,
       abonoIvaPago: args.abonoIvaPago,
       cuota: args.cuota,
+      banderaReinversion: args.banderaReinversion,
     });
   }
 
@@ -2298,9 +2314,13 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           i.emite_factura AS "emiteFactura",
           ci.porcentaje_participacion_inversionista AS "porcentajeParticipacion",
           ci.porcentaje_cash_in AS "porcentajeCashIn",
-          ci.monto_aportado AS "montoAportado"
+          ci.monto_aportado AS "montoAportado",
+          esp.status AS "statusEspejo"
         FROM cartera.creditos_inversionistas ci
         INNER JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+        LEFT JOIN cartera.creditos_inversionistas_espejo esp
+          ON esp.credito_id = ci.credito_id
+          AND esp.inversionista_id = ci.inversionista_id
         WHERE ci.credito_id = ANY(${"{" + creditoIds.join(",") + "}"}::bigint[])
       `);
       for (const row of ciResult.rows as any[]) {
@@ -2313,6 +2333,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           porcentaje_participacion_inversionista: row.porcentajeParticipacion ?? 0,
           porcentaje_cash_in: row.porcentajeCashIn ?? 0,
           monto_aportado: row.montoAportado ?? 0,
+          status_espejo: row.statusEspejo ?? null,
         });
         creditoInvsByCredito.set(cid, arr);
       }
@@ -2376,18 +2397,18 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
             cuota: r.cuotaMonto as any,
             // 🆕 Parciales sin reparto: simular filas no-CUBE con la misma
             // matemática del cierre (calcularSplitInteresPci). Solo pagos
-            // 'validated' (reset/cancelación reparte distinto), sin compra de
-            // cartera pendiente (esos usan prorrateo por días, no aportado) y
-            // sin bandera_reinversion (en esa ventana la facturación redirige
-            // el interés del inversionista a CUBE → el desglose INTERES ya lo
-            // incluye y simular su parte regular lo doble-contaría).
+            // 'validated' (reset/cancelación reparte distinto) y sin compra de
+            // cartera pendiente (esos usan prorrateo por días, no aportado).
+            // Con bandera_reinversion se excluye POR INVERSIONISTA solo a los
+            // redirigidos a CUBE (espejo pendiente) — los demás del crédito se
+            // facturan normal y sí se simulan.
             creditoInvs,
             abonoInteresPago: r.abono_interes as any,
             abonoIvaPago: r.abono_iva_12 as any,
             simularSinPci:
               (r as any).validation_status === "validated" &&
-              !((r as any).pendienteFacturar ?? false) &&
-              !((r as any).banderaReinversion ?? false),
+              !((r as any).pendienteFacturar ?? false),
+            banderaReinversion: (r as any).banderaReinversion ?? false,
           })
         : pciRows;
 

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -2016,6 +2016,24 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       );
     }
 
+    // 🧮 Elegibilidad de SIMULACIÓN a nivel pago (espejo SQL de los gates del
+    // detalle en armarInversionistasPago/simularInversionistasSinPci): pago
+    // validated con interés, ya facturado (desglose INTERES), sin reparto pci
+    // y sin compra de cartera pendiente (prorrateo). La condición por
+    // inversionista (membresía en el crédito y no-redirigido a CUBE) se agrega
+    // donde se usa. Mantener en sync con los gates del detalle.
+    const pagoSimulableSQL = `
+      NOT EXISTS (SELECT 1 FROM cartera.pagos_credito_inversionistas pci_sim
+                  WHERE pci_sim.pago_id = p.pago_id)
+      AND p.validation_status = 'validated'
+      AND p.abono_interes > 0
+      AND EXISTS (SELECT 1 FROM cartera.facturacion_desglose fd_sim
+                  WHERE fd_sim.pago_id = p.pago_id AND fd_sim.rubro::text = 'INTERES')
+      AND NOT EXISTS (SELECT 1 FROM cartera.compras_credito_inversionista cci_sim
+                      WHERE cci_sim.credito_id = p.credito_id
+                        AND cci_sim.pendiente_facturar = true
+                        AND cci_sim.tipo_operacion = 'compra_cartera')`;
+
     if (inversionistaId) {
       if (Number(inversionistaId) === CUBE_ID) {
         // Para CUBE, el rubro INTERES del desglose ES de CUBE aunque no haya fila pci
@@ -2036,12 +2054,28 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           )
         )`);
       } else {
+        // Con reparto real (pci) O parcial simulable donde este inversionista
+        // participa y NO está redirigido a CUBE — así el filtro ve los mismos
+        // pagos cuyo detalle ya muestra la fila simulada (Codex P2, PR #1137).
         whereClauses.push(`
-          EXISTS (
-            SELECT 1
-            FROM cartera.pagos_credito_inversionistas pci2
-            WHERE pci2.pago_id = p.pago_id
-            AND pci2.inversionista_id = '${inversionistaId}'
+          (
+            EXISTS (
+              SELECT 1
+              FROM cartera.pagos_credito_inversionistas pci2
+              WHERE pci2.pago_id = p.pago_id
+              AND pci2.inversionista_id = '${inversionistaId}'
+            )
+            OR (
+              ${pagoSimulableSQL}
+              AND EXISTS (SELECT 1 FROM cartera.creditos_inversionistas ci_sim
+                          WHERE ci_sim.credito_id = p.credito_id
+                            AND ci_sim.inversionista_id = '${inversionistaId}')
+              AND NOT (c.bandera_reinversion = true AND EXISTS (
+                    SELECT 1 FROM cartera.creditos_inversionistas_espejo esp_sim
+                    WHERE esp_sim.credito_id = p.credito_id
+                      AND esp_sim.inversionista_id = '${inversionistaId}'
+                      AND esp_sim.status IN ('pendiente_reinversion','pendiente_compra_cartera')))
+            )
           )
         `);
       }
@@ -2574,6 +2608,92 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       totalIsr: new Big(r.totalIsr).round(2).toNumber(),
       totalMontoAportado: new Big(r.totalMontoAportado).round(2).toNumber(),
     }));
+
+    // 💰 FIX (Codex P2, PR #1137): el detalle muestra filas SIMULADAS en los
+    // parciales sin pci; el resumen por inversionista debe sumarlas también,
+    // o el total no cuadra contra las filas listadas. Réplica en SQL de
+    // calcularSplitInteresPci (flujo regular, redondeo por pago-inversionista):
+    //   interés_inv = ROUND(abono_interes × (aporte/Σaportes) × pct/100, 2)
+    // Si cambia src/cofidi/splitInteresPci.ts hay que actualizar esta fórmula.
+    // Solo no-CUBE: el interés de CUBE ya se corrige desde el desglose abajo
+    // (incluye parciales). Excluye redirigidos a CUBE (bandera + espejo
+    // pendiente), igual que la simulación del detalle.
+    const totalesSimQuery = sql`
+      WITH pf AS (
+        SELECT p.pago_id, p.credito_id, c.bandera_reinversion,
+               p.abono_interes::numeric AS interes,
+               COALESCE(p.abono_iva_12, 0)::numeric AS iva
+        FROM cartera.pagos_credito p
+        LEFT JOIN cartera.creditos c ON c.credito_id = p.credito_id
+        LEFT JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+        ${sql.raw(whereSQL)}
+        AND ${sql.raw(pagoSimulableSQL)}
+      ),
+      aportes AS (
+        SELECT ci.credito_id, SUM(ci.monto_aportado::numeric) AS total
+        FROM cartera.creditos_inversionistas ci
+        WHERE ci.credito_id IN (SELECT DISTINCT credito_id FROM pf)
+        GROUP BY ci.credito_id
+      )
+      SELECT ci.inversionista_id AS "inversionistaId",
+             i.nombre AS "nombreInversionista",
+             i.emite_factura AS "emiteFactura",
+             SUM(ROUND(pf.interes * (ci.monto_aportado::numeric / a.total)
+                 * (ci.porcentaje_participacion_inversionista::numeric / 100), 2)) AS "interesSim",
+             SUM(ROUND(pf.iva * (ci.monto_aportado::numeric / a.total)
+                 * (ci.porcentaje_participacion_inversionista::numeric / 100), 2)) AS "ivaSim",
+             SUM(ci.monto_aportado::numeric) AS "aporteSim"
+      FROM pf
+      JOIN aportes a ON a.credito_id = pf.credito_id AND a.total > 0
+      JOIN cartera.creditos_inversionistas ci ON ci.credito_id = pf.credito_id
+      JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+      WHERE UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
+        AND NOT (pf.bandera_reinversion = true AND EXISTS (
+              SELECT 1 FROM cartera.creditos_inversionistas_espejo esp
+              WHERE esp.credito_id = pf.credito_id
+                AND esp.inversionista_id = ci.inversionista_id
+                AND esp.status IN ('pendiente_reinversion','pendiente_compra_cartera')))
+        ${sql.raw(inversionistaId && Number(inversionistaId) !== CUBE_ID ? `AND ci.inversionista_id = '${inversionistaId}'` : "")}
+      GROUP BY ci.inversionista_id, i.nombre, i.emite_factura
+    `;
+
+    const totalesSimResult = await db.execute(totalesSimQuery);
+    for (const simRow of totalesSimResult.rows as any[]) {
+      const interesSim = new Big(simRow.interesSim ?? 0);
+      const ivaSim = new Big(simRow.ivaSim ?? 0);
+      if (interesSim.lte(0) && ivaSim.lte(0)) continue;
+      const idx = totalesInversionistas.findIndex(
+        (t) => Number(t.inversionistaId) === Number(simRow.inversionistaId)
+      );
+      if (idx >= 0) {
+        const t = totalesInversionistas[idx];
+        const interesTotal = new Big(t.totalAbonoInteres).plus(interesSim);
+        totalesInversionistas[idx] = {
+          ...t,
+          totalAbonoInteres: interesTotal.round(2).toNumber(),
+          totalAbonoIva: new Big(t.totalAbonoIva).plus(ivaSim).round(2).toNumber(),
+          totalIsr: interesTotal.times("0.05").round(2).toNumber(),
+          totalMontoAportado: new Big(t.totalMontoAportado)
+            .plus(simRow.aporteSim ?? 0)
+            .round(2)
+            .toNumber(),
+        };
+      } else {
+        totalesInversionistas.push({
+          inversionistaId: Number(simRow.inversionistaId),
+          nombreInversionista: simRow.nombreInversionista,
+          emiteFactura: simRow.emiteFactura ?? false,
+          totalAbonoCapital: 0,
+          totalAbonoInteres: interesSim.round(2).toNumber(),
+          totalAbonoIva: ivaSim.round(2).toNumber(),
+          totalIsr: interesSim.times("0.05").round(2).toNumber(),
+          totalMontoAportado: new Big(simRow.aporteSim ?? 0).round(2).toNumber(),
+        });
+      }
+    }
+    totalesInversionistas.sort((a, b) =>
+      String(a.nombreInversionista).localeCompare(String(b.nombreInversionista))
+    );
 
     // 💰 FIX: la fila de CUBE en el resumen debe reflejar el desglose (rubro INTERES),
     // igual que el detalle per-pago (armarInversionistasPago). El pci crudo de CUBE NO

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1797,18 +1797,83 @@ export type ReportCreditoInv = {
 
 
 /**
+ * 🧮 Simula las filas no-CUBE de un pago PARCIAL que todavía no tiene reparto en
+ * pagos_credito_inversionistas (la distribución real se crea hasta que la cuota
+ * se completa — aplicarPagoAlCredito, rama de cierre). Usa la MISMA función pura
+ * del reparto real (calcularSplitInteresPci) alimentada con los
+ * creditos_inversionistas del crédito, de modo que lo simulado hoy sea idéntico
+ * a lo que pci escribirá al cerrar la cuota (flujo regular; los pagos con compra
+ * de cartera pendiente de facturar se excluyen en el caller vía pendienteFacturar
+ * porque su reparto real usa el prorrateo por días).
+ * Capital: se deja en 0 — el reparto de capital solo ocurre al cierre.
+ */
+function simularInversionistasSinPci(args: {
+  creditoInvs: ReportCreditoInv[];
+  cubeId: number;
+  abonoInteresPago: string | number | null | undefined;
+  abonoIvaPago: string | number | null | undefined;
+  cuota?: string | number | null;
+}): ReportInvRow[] {
+  const split = calcularSplitInteresPci({
+    inversionistas: args.creditoInvs.map((ci) => ({
+      inversionista_id: ci.inversionista_id,
+      nombre: ci.nombre,
+      porcentaje_participacion_inversionista:
+        ci.porcentaje_participacion_inversionista ?? 0,
+      porcentaje_cash_in: ci.porcentaje_cash_in ?? 0,
+      monto_aportado: ci.monto_aportado ?? 0,
+    })),
+    pagoAbonoInteres: new Big(args.abonoInteresPago ?? 0),
+    pagoAbonoIva: new Big(args.abonoIvaPago ?? 0),
+  });
+  const splitPorInv = new Map(split.map((s) => [s.inversionista_id, s]));
+
+  // ⚠️ Emitir NUMBERS (no strings): las filas pci reales llegan como número vía
+  // json_build_object y el front (modalViewInvestor) les hace .toFixed() —
+  // una fila simulada con strings reventaría el modal.
+  return args.creditoInvs
+    .filter((ci) => ci.inversionista_id !== args.cubeId)
+    .map((ci) => {
+      const s = splitPorInv.get(ci.inversionista_id);
+      const interes = (s?.abono_interes ?? new Big(0)).round(2);
+      const iva = (s?.abono_iva_12 ?? new Big(0)).round(2);
+      return {
+        inversionistaId: ci.inversionista_id,
+        nombreInversionista: ci.nombre,
+        emiteFactura: ci.emite_factura ?? false,
+        abonoCapital: 0,
+        abonoInteres: Number(interes.toFixed(2)),
+        abonoIva: Number(iva.toFixed(2)),
+        isr: Number(interes.times("0.05").round(2).toFixed(2)),
+        cuotaPago: args.cuota != null ? Number(args.cuota) : 0,
+        montoAportado:
+          ci.monto_aportado != null ? Number(ci.monto_aportado) : null,
+        porcentajeParticipacion:
+          ci.porcentaje_participacion_inversionista != null
+            ? Number(ci.porcentaje_participacion_inversionista)
+            : null,
+      };
+    });
+}
+
+/**
  * 🧮 Arma el array `inversionistas` de UN pago para el reporte JSON, reflejando
  * el interés facturado de CUBE leído del desglose:
  *   - CUBE: su interés = el del desglose (rubro INTERES, CON IVA). Reemplaza la
  *     fila CUBE del pci (si existía) o crea una nueva.
  *   - Inversionistas no-CUBE: del pci, SIN CAMBIO.
- *   - Parciales (sin filas pci): solo aparece CUBE del desglose; los demás
- *     inversionistas se difieren hasta que la cuota se complete.
+ *   - Parciales (sin filas pci) con simularSinPci=true: los no-CUBE se SIMULAN
+ *     desde creditos_inversionistas con la misma matemática del reparto real
+ *     (ver simularInversionistasSinPci); así el reporte los muestra desde el
+ *     día del parcial y no hasta que la cuota se complete.
+ *   - Parciales sin simularSinPci: solo aparece CUBE del desglose (comportamiento
+ *     previo; aplica a pagos reset/cancelación y prorrateados por compra de cartera).
  *   - Sin desglose (pagos pre-facturación / pendientes): fallback → conservar el
- *     array pci tal cual (comportamiento previo).
+ *     array pci tal cual (comportamiento previo). La simulación también queda
+ *     detrás de este gate: sin desglose no hay facturación que reflejar.
  *
  * Función PURA (sin DB) → testeable en aislamiento. NO toca abono_capital ni la
- * parte de los inversionistas no-CUBE; solo ajusta/crea la fila de CUBE.
+ * parte de los inversionistas no-CUBE del pci; solo ajusta/crea la fila de CUBE.
  *
  * Invariante (cuotas completas): Σ(salida.abonoInteres) =
  *   Σ(no-CUBE pci) + (desglose CUBE net) = el interés facturado del pago.
@@ -1819,13 +1884,34 @@ export function armarInversionistasPago(args: {
   desgloseCubeInteres: { total: Big; iva: Big } | null; // del desglose rubro INTERES (monto_total CON iva, monto_iva)
   cubeMeta?: Partial<ReportInvRow> | null;              // metadatos de CUBE (de creditos_inversionistas) si CUBE no está en pci
   cuota?: string | number | null;
+  // 🆕 Simulación de parciales sin reparto (ver simularInversionistasSinPci):
+  creditoInvs?: ReportCreditoInv[] | null;              // inversionistas del crédito
+  abonoInteresPago?: string | number | null;            // pagos_credito.abono_interes
+  abonoIvaPago?: string | number | null;                // pagos_credito.abono_iva_12
+  simularSinPci?: boolean;                              // el caller gatea: validated + !pendienteFacturar
 }): ReportInvRow[] {
   const rows = Array.isArray(args.pciRows) ? args.pciRows : [];
-  const noCube = rows.filter((r) => r.inversionistaId !== args.cubeId);
+  let noCube = rows.filter((r) => r.inversionistaId !== args.cubeId);
   const pciCube = rows.find((r) => r.inversionistaId === args.cubeId) ?? null;
 
   // Sin desglose → fallback: conservar el pci tal cual.
   if (!args.desgloseCubeInteres) return rows;
+
+  // 🆕 PARCIAL sin reparto (cuota aún abierta) ya facturado: simular los no-CUBE.
+  // Solo cuando NO hay filas pci — si el reparto real ya existe, ese manda.
+  if (
+    rows.length === 0 &&
+    args.simularSinPci === true &&
+    (args.creditoInvs?.length ?? 0) > 0
+  ) {
+    noCube = simularInversionistasSinPci({
+      creditoInvs: args.creditoInvs!,
+      cubeId: args.cubeId,
+      abonoInteresPago: args.abonoInteresPago,
+      abonoIvaPago: args.abonoIvaPago,
+      cuota: args.cuota,
+    });
+  }
 
   const cubeNet = args.desgloseCubeInteres.total.minus(args.desgloseCubeInteres.iva);
   const cubeIva = args.desgloseCubeInteres.iva;
@@ -2288,6 +2374,20 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
             desgloseCubeInteres: desgloseCubeByPago.get(Number(r.pagoId)) ?? null,
             cubeMeta,
             cuota: r.cuotaMonto as any,
+            // 🆕 Parciales sin reparto: simular filas no-CUBE con la misma
+            // matemática del cierre (calcularSplitInteresPci). Solo pagos
+            // 'validated' (reset/cancelación reparte distinto), sin compra de
+            // cartera pendiente (esos usan prorrateo por días, no aportado) y
+            // sin bandera_reinversion (en esa ventana la facturación redirige
+            // el interés del inversionista a CUBE → el desglose INTERES ya lo
+            // incluye y simular su parte regular lo doble-contaría).
+            creditoInvs,
+            abonoInteresPago: r.abono_interes as any,
+            abonoIvaPago: r.abono_iva_12 as any,
+            simularSinPci:
+              (r as any).validation_status === "validated" &&
+              !((r as any).pendienteFacturar ?? false) &&
+              !((r as any).banderaReinversion ?? false),
           })
         : pciRows;
 


### PR DESCRIPTION
## Problema

Contabilidad reportó que en el reporte de pagos con inversionistas (botón azul "Descargar Reporte Excel" en `/pagos`) los pagos **parciales** solo muestran a CUBE. Los inversionistas reales aparecen hasta que la cuota se completa — y aparecen **retroactivos** en la fecha original del pago, en días que conta ya había descargado y cuadrado.

**Causa raíz:** el reparto (`pagos_credito_inversionistas`) solo se crea al cerrar la cuota completa (`aplicarPagoAlCredito`, rama de cierre). La fila sintética de CUBE sí se mostraba (sale del desglose de facturación), pero la simulación de los no-CUBE quedó pendiente — el propio código ya cargaba `creditos_inversionistas` "para simular parciales" sin usarlos.

**Caso real:** crédito `01010214120570`, cuota 7. Parcial del 07/07 (Q1,500): se facturó Q292.14 al inversionista ese día, pero conta no lo vio en su reporte sino hasta el 20/07 (cierre de la cuota), colgado retroactivamente de la fecha 7.

## Solución

`armarInversionistasPago` ahora **simula** las filas no-CUBE de parciales sin reparto reutilizando `calcularSplitInteresPci` — la **misma función pura** que usa `insertPagosCreditoInversionistasV2` al cerrar la cuota. Sin matemática duplicada: lo mostrado el día del parcial converge al centavo con lo que pci escribe al cierre.

**Gates (todos deben cumplirse):**
- Pago `validated` (reset/cancelación reparte distinto)
- Desglose INTERES existe (= ya facturado; el reporte refleja lo facturado)
- Sin filas pci (si el reparto real existe, ese manda)
- Sin compra de cartera `pendiente_facturar` (usa prorrateo por días, no aportado)
- Sin `bandera_reinversion` (la facturación redirige ese interés a CUBE; simular doble-contaría)

**Detalles:**
- Solo presentación: cero escrituras a DB; ningún flujo de liquidación consume el array del reporte (verificado)
- Capital simulado = 0 (el capital solo se reparte al cierre)
- Emite numbers, no strings (el modal del front hace `.toFixed()`)

## Pruebas

- 18 tests pasan (5 nuevos: caso real de Jennifer con números exactos, multi-inversionista, pci-manda, sin-desglose, flag apagado)
- **End-to-end en dev** replicando el flujo cobros→conta: parcial Q2,252 → el reporte mostró interés inversionista **937.52** (1,171.90 × 80%) el mismo día; al cerrar la cuota con el pago final, pci escribió exactamente **937.52/147.56** — convergencia exacta, y el pago de cierre reutilizó el placeholder tal como prod

## Fuera de alcance (fases siguientes)

- Facturación diaria: el rubro `INTERES_INVERSIONISTAS` no se escribe para parciales (se lee de pci al facturar) — ~Q16,511 históricos no reflejados
- El filtro por `inversionistaId` y `totalesInversionistas` siguen saliendo solo de pci (no ven parciales simulados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)