### PR TITLE
🚀 Pase a Producción — Release develop → main

### DIFF
--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -673,4 +673,160 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     expect(out).toHaveLength(1);
     expect(out.find((r: any) => r.inversionistaId === 86)).toBeUndefined();
   });
+
+  // ── 🆕 Simulación de parciales sin reparto (simularSinPci) ────────────────
+  // Caso real (crédito 01010214120570, pago 144366 del 2026-07-07): parcial de
+  // interés Q365.17 facturado el día 7; el reparto real (pci) no se creó sino
+  // hasta que la cuota cerró el día 20. La simulación debe mostrar al
+  // inversionista desde el día 7 con el MISMO monto que pci escribió después.
+  const creditoInvsJennifer = [
+    {
+      inversionista_id: 14,
+      nombre: "Carlos Fernando Carrillo Cifuentes",
+      emite_factura: false,
+      porcentaje_participacion_inversionista: "80",
+      porcentaje_cash_in: "20",
+      monto_aportado: "100176.29",
+    },
+    {
+      inversionista_id: 86,
+      nombre: "Cube Investments S.A.",
+      emite_factura: false,
+      porcentaje_participacion_inversionista: "0",
+      porcentaje_cash_in: "100",
+      monto_aportado: "0",
+    },
+  ];
+
+  it("caso 7 (sim): parcial sin pci + simularSinPci → simula no-CUBE igual que el reparto real", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("73.03"), iva: new Big("7.83") },
+      cuota: "3751.32",
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+    });
+
+    expect(out).toHaveLength(2);
+
+    // Carlos: 365.17 × 100% (aportado) × 80% (participación) = 292.14 —
+    // exactamente lo que pci registró al cerrar la cuota el día 20.
+    // Numbers (no strings): el front tipa number y hace .toFixed().
+    const carlos = out.find((r: any) => r.inversionistaId === 14)!;
+    expect(carlos.abonoInteres).toBe(292.14);
+    expect(carlos.abonoIva).toBe(0);
+    expect(carlos.abonoCapital).toBe(0); // capital solo se reparte al cierre
+    expect(carlos.isr).toBe(14.61);
+    expect(carlos.montoAportado).toBe(100176.29);
+    expect(carlos.porcentajeParticipacion).toBe(80);
+
+    // CUBE sigue saliendo del desglose (net 65.20), como antes.
+    const cube = out.find((r: any) => r.inversionistaId === 86)!;
+    expect(cube.abonoInteres).toBe("65.20");
+    expect(cube.abonoIva).toBe("7.83");
+  });
+
+  it("caso 8 (sim): si YA hay filas pci, el reparto real manda y no se simula", () => {
+    const pciRows = [
+      {
+        inversionistaId: 14,
+        nombreInversionista: "Carlos Fernando Carrillo Cifuentes",
+        emiteFactura: false,
+        abonoCapital: "0.00",
+        abonoInteres: "292.14",
+        abonoIva: "0.00",
+        isr: "14.61",
+        cuotaPago: "3751.32",
+        montoAportado: "100176.29",
+        porcentajeParticipacion: "80",
+      },
+    ];
+
+    const out = armarInversionistasPago({
+      pciRows,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("73.03"), iva: new Big("7.83") },
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+    });
+
+    // 1 fila pci (Carlos) + fila CUBE del desglose; nada duplicado por simulación.
+    expect(out).toHaveLength(2);
+    expect(out.filter((r: any) => r.inversionistaId === 14)).toHaveLength(1);
+  });
+
+  it("caso 9 (sim): reparte por monto_aportado entre varios inversionistas", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("29.6"), iva: new Big("3.17") },
+      creditoInvs: [
+        {
+          inversionista_id: 1,
+          nombre: "InvA",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "90",
+          porcentaje_cash_in: "10",
+          monto_aportado: "60000",
+        },
+        {
+          inversionista_id: 2,
+          nombre: "InvB",
+          emite_factura: true,
+          porcentaje_participacion_inversionista: "85",
+          porcentaje_cash_in: "15",
+          monto_aportado: "40000",
+        },
+      ],
+      abonoInteresPago: "100",
+      abonoIvaPago: "12",
+      simularSinPci: true,
+    });
+
+    // InvA: 100 × 0.6 × 0.90 = 54.00 | IVA 12 × 0.6 × 0.90 = 6.48
+    const invA = out.find((r: any) => r.inversionistaId === 1)!;
+    expect(invA.abonoInteres).toBe(54);
+    expect(invA.abonoIva).toBe(6.48);
+
+    // InvB (emite_factura=true también se simula: pci lo incluye al cierre):
+    // 100 × 0.4 × 0.85 = 34.00 | IVA 12 × 0.4 × 0.85 = 4.08
+    const invB = out.find((r: any) => r.inversionistaId === 2)!;
+    expect(invB.abonoInteres).toBe(34);
+    expect(invB.abonoIva).toBe(4.08);
+    expect(invB.emiteFactura).toBe(true);
+  });
+
+  it("caso 10 (sim): sin desglose (pago no facturado) NO se simula aunque simularSinPci=true", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: null,
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+    });
+
+    expect(out).toHaveLength(0);
+  });
+
+  it("caso 11 (sim): simularSinPci=false conserva el comportamiento previo (solo CUBE)", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("73.03"), iva: new Big("7.83") },
+      creditoInvs: creditoInvsJennifer,
+      abonoInteresPago: "365.17",
+      abonoIvaPago: "0",
+      simularSinPci: false,
+    });
+
+    expect(out).toHaveLength(1);
+    expect(out[0].inversionistaId).toBe(86);
+  });
 });

--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -815,6 +815,70 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     expect(out).toHaveLength(0);
   });
 
+  it("caso 12 (sim): bandera_reinversion excluye SOLO al redirigido a CUBE (espejo pendiente); los demás sí se simulan", () => {
+    const out = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("60"), iva: new Big("6.43") },
+      creditoInvs: [
+        {
+          inversionista_id: 1,
+          nombre: "InvNormal",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "90",
+          porcentaje_cash_in: "10",
+          monto_aportado: "50000",
+          status_espejo: "activo",
+        },
+        {
+          inversionista_id: 2,
+          nombre: "InvRedirigido",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "85",
+          porcentaje_cash_in: "15",
+          monto_aportado: "50000",
+          status_espejo: "pendiente_compra_cartera",
+        },
+      ],
+      abonoInteresPago: "100",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+      banderaReinversion: true,
+    });
+
+    // InvNormal se simula: 100 × 0.5 × 0.90 = 45.00
+    const invNormal = out.find((r: any) => r.inversionistaId === 1)!;
+    expect(invNormal).toBeDefined();
+    expect(invNormal.abonoInteres).toBe(45);
+
+    // InvRedirigido NO aparece (su interés ya va dentro del desglose de CUBE)
+    expect(out.find((r: any) => r.inversionistaId === 2)).toBeUndefined();
+
+    // Sin bandera, el mismo roster simula a AMBOS (el espejo pendiente solo,
+    // sin bandera, no redirige — misma condición que cofidi).
+    const outSinBandera = armarInversionistasPago({
+      pciRows: null,
+      cubeId: 86,
+      desgloseCubeInteres: { total: new Big("60"), iva: new Big("6.43") },
+      creditoInvs: [
+        {
+          inversionista_id: 2,
+          nombre: "InvRedirigido",
+          emite_factura: false,
+          porcentaje_participacion_inversionista: "85",
+          porcentaje_cash_in: "15",
+          monto_aportado: "50000",
+          status_espejo: "pendiente_compra_cartera",
+        },
+      ],
+      abonoInteresPago: "100",
+      abonoIvaPago: "0",
+      simularSinPci: true,
+      banderaReinversion: false,
+    });
+    expect(outSinBandera.find((r: any) => r.inversionistaId === 2)).toBeDefined();
+  });
+
   it("caso 11 (sim): simularSinPci=false conserva el comportamiento previo (solo CUBE)", () => {
     const out = armarInversionistasPago({
       pciRows: null,

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -2618,6 +2618,9 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
     // Solo no-CUBE: el interés de CUBE ya se corrige desde el desglose abajo
     // (incluye parciales). Excluye redirigidos a CUBE (bandera + espejo
     // pendiente), igual que la simulación del detalle.
+    // Con filtro == CUBE la query se salta por completo (Codex P2): un resumen
+    // solo-CUBE no debe ganar filas no-CUBE por los parciales simulables.
+    const esFiltroCube = Boolean(inversionistaId) && Number(inversionistaId) === CUBE_ID;
     const totalesSimQuery = sql`
       WITH pf AS (
         SELECT p.pago_id, p.credito_id, c.bandera_reinversion,
@@ -2657,7 +2660,9 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       GROUP BY ci.inversionista_id, i.nombre, i.emite_factura
     `;
 
-    const totalesSimResult = await db.execute(totalesSimQuery);
+    const totalesSimResult = esFiltroCube
+      ? { rows: [] as any[] }
+      : await db.execute(totalesSimQuery);
     for (const simRow of totalesSimResult.rows as any[]) {
       const interesSim = new Big(simRow.interesSim ?? 0);
       const ivaSim = new Big(simRow.ivaSim ?? 0);

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1793,6 +1793,10 @@ export type ReportCreditoInv = {
   porcentaje_participacion_inversionista: string | number;
   porcentaje_cash_in: string | number;
   monto_aportado: string | number;
+  // status del espejo (creditos_inversionistas_espejo): con bandera_reinversion
+  // activa, 'pendiente_reinversion'/'pendiente_compra_cartera' redirigen el
+  // interés de ESE inversionista a CUBE en la facturación (cofidi.ts).
+  status_espejo?: string | null;
 };
 
 
@@ -1813,7 +1817,17 @@ function simularInversionistasSinPci(args: {
   abonoInteresPago: string | number | null | undefined;
   abonoIvaPago: string | number | null | undefined;
   cuota?: string | number | null;
+  banderaReinversion?: boolean;
 }): ReportInvRow[] {
+  // Redirigido a CUBE (misma condición que cofidi al facturar): su interés ya
+  // está dentro del desglose INTERES de CUBE — simularle su parte regular lo
+  // doble-contaría. Solo se excluye a ESE inversionista; los demás del mismo
+  // crédito se facturan normal y sí se simulan (Codex P2, PR #1137).
+  const esRedirigidoACube = (ci: ReportCreditoInv) =>
+    args.banderaReinversion === true &&
+    (ci.status_espejo === "pendiente_reinversion" ||
+      ci.status_espejo === "pendiente_compra_cartera");
+
   const split = calcularSplitInteresPci({
     inversionistas: args.creditoInvs.map((ci) => ({
       inversionista_id: ci.inversionista_id,
@@ -1832,7 +1846,7 @@ function simularInversionistasSinPci(args: {
   // json_build_object y el front (modalViewInvestor) les hace .toFixed() —
   // una fila simulada con strings reventaría el modal.
   return args.creditoInvs
-    .filter((ci) => ci.inversionista_id !== args.cubeId)
+    .filter((ci) => ci.inversionista_id !== args.cubeId && !esRedirigidoACube(ci))
     .map((ci) => {
       const s = splitPorInv.get(ci.inversionista_id);
       const interes = (s?.abono_interes ?? new Big(0)).round(2);
@@ -1889,6 +1903,7 @@ export function armarInversionistasPago(args: {
   abonoInteresPago?: string | number | null;            // pagos_credito.abono_interes
   abonoIvaPago?: string | number | null;                // pagos_credito.abono_iva_12
   simularSinPci?: boolean;                              // el caller gatea: validated + !pendienteFacturar
+  banderaReinversion?: boolean;                         // excluye SOLO a los redirigidos a CUBE (espejo pendiente)
 }): ReportInvRow[] {
   const rows = Array.isArray(args.pciRows) ? args.pciRows : [];
   let noCube = rows.filter((r) => r.inversionistaId !== args.cubeId);
@@ -1910,6 +1925,7 @@ export function armarInversionistasPago(args: {
       abonoInteresPago: args.abonoInteresPago,
       abonoIvaPago: args.abonoIvaPago,
       cuota: args.cuota,
+      banderaReinversion: args.banderaReinversion,
     });
   }
 
@@ -2298,9 +2314,13 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           i.emite_factura AS "emiteFactura",
           ci.porcentaje_participacion_inversionista AS "porcentajeParticipacion",
           ci.porcentaje_cash_in AS "porcentajeCashIn",
-          ci.monto_aportado AS "montoAportado"
+          ci.monto_aportado AS "montoAportado",
+          esp.status AS "statusEspejo"
         FROM cartera.creditos_inversionistas ci
         INNER JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+        LEFT JOIN cartera.creditos_inversionistas_espejo esp
+          ON esp.credito_id = ci.credito_id
+          AND esp.inversionista_id = ci.inversionista_id
         WHERE ci.credito_id = ANY(${"{" + creditoIds.join(",") + "}"}::bigint[])
       `);
       for (const row of ciResult.rows as any[]) {
@@ -2313,6 +2333,7 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           porcentaje_participacion_inversionista: row.porcentajeParticipacion ?? 0,
           porcentaje_cash_in: row.porcentajeCashIn ?? 0,
           monto_aportado: row.montoAportado ?? 0,
+          status_espejo: row.statusEspejo ?? null,
         });
         creditoInvsByCredito.set(cid, arr);
       }
@@ -2376,18 +2397,18 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
             cuota: r.cuotaMonto as any,
             // 🆕 Parciales sin reparto: simular filas no-CUBE con la misma
             // matemática del cierre (calcularSplitInteresPci). Solo pagos
-            // 'validated' (reset/cancelación reparte distinto), sin compra de
-            // cartera pendiente (esos usan prorrateo por días, no aportado) y
-            // sin bandera_reinversion (en esa ventana la facturación redirige
-            // el interés del inversionista a CUBE → el desglose INTERES ya lo
-            // incluye y simular su parte regular lo doble-contaría).
+            // 'validated' (reset/cancelación reparte distinto) y sin compra de
+            // cartera pendiente (esos usan prorrateo por días, no aportado).
+            // Con bandera_reinversion se excluye POR INVERSIONISTA solo a los
+            // redirigidos a CUBE (espejo pendiente) — los demás del crédito se
+            // facturan normal y sí se simulan.
             creditoInvs,
             abonoInteresPago: r.abono_interes as any,
             abonoIvaPago: r.abono_iva_12 as any,
             simularSinPci:
               (r as any).validation_status === "validated" &&
-              !((r as any).pendienteFacturar ?? false) &&
-              !((r as any).banderaReinversion ?? false),
+              !((r as any).pendienteFacturar ?? false),
+            banderaReinversion: (r as any).banderaReinversion ?? false,
           })
         : pciRows;
 

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -2016,6 +2016,24 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       );
     }
 
+    // 🧮 Elegibilidad de SIMULACIÓN a nivel pago (espejo SQL de los gates del
+    // detalle en armarInversionistasPago/simularInversionistasSinPci): pago
+    // validated con interés, ya facturado (desglose INTERES), sin reparto pci
+    // y sin compra de cartera pendiente (prorrateo). La condición por
+    // inversionista (membresía en el crédito y no-redirigido a CUBE) se agrega
+    // donde se usa. Mantener en sync con los gates del detalle.
+    const pagoSimulableSQL = `
+      NOT EXISTS (SELECT 1 FROM cartera.pagos_credito_inversionistas pci_sim
+                  WHERE pci_sim.pago_id = p.pago_id)
+      AND p.validation_status = 'validated'
+      AND p.abono_interes > 0
+      AND EXISTS (SELECT 1 FROM cartera.facturacion_desglose fd_sim
+                  WHERE fd_sim.pago_id = p.pago_id AND fd_sim.rubro::text = 'INTERES')
+      AND NOT EXISTS (SELECT 1 FROM cartera.compras_credito_inversionista cci_sim
+                      WHERE cci_sim.credito_id = p.credito_id
+                        AND cci_sim.pendiente_facturar = true
+                        AND cci_sim.tipo_operacion = 'compra_cartera')`;
+
     if (inversionistaId) {
       if (Number(inversionistaId) === CUBE_ID) {
         // Para CUBE, el rubro INTERES del desglose ES de CUBE aunque no haya fila pci
@@ -2036,12 +2054,28 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
           )
         )`);
       } else {
+        // Con reparto real (pci) O parcial simulable donde este inversionista
+        // participa y NO está redirigido a CUBE — así el filtro ve los mismos
+        // pagos cuyo detalle ya muestra la fila simulada (Codex P2, PR #1137).
         whereClauses.push(`
-          EXISTS (
-            SELECT 1
-            FROM cartera.pagos_credito_inversionistas pci2
-            WHERE pci2.pago_id = p.pago_id
-            AND pci2.inversionista_id = '${inversionistaId}'
+          (
+            EXISTS (
+              SELECT 1
+              FROM cartera.pagos_credito_inversionistas pci2
+              WHERE pci2.pago_id = p.pago_id
+              AND pci2.inversionista_id = '${inversionistaId}'
+            )
+            OR (
+              ${pagoSimulableSQL}
+              AND EXISTS (SELECT 1 FROM cartera.creditos_inversionistas ci_sim
+                          WHERE ci_sim.credito_id = p.credito_id
+                            AND ci_sim.inversionista_id = '${inversionistaId}')
+              AND NOT (c.bandera_reinversion = true AND EXISTS (
+                    SELECT 1 FROM cartera.creditos_inversionistas_espejo esp_sim
+                    WHERE esp_sim.credito_id = p.credito_id
+                      AND esp_sim.inversionista_id = '${inversionistaId}'
+                      AND esp_sim.status IN ('pendiente_reinversion','pendiente_compra_cartera')))
+            )
           )
         `);
       }
@@ -2574,6 +2608,92 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
       totalIsr: new Big(r.totalIsr).round(2).toNumber(),
       totalMontoAportado: new Big(r.totalMontoAportado).round(2).toNumber(),
     }));
+
+    // 💰 FIX (Codex P2, PR #1137): el detalle muestra filas SIMULADAS en los
+    // parciales sin pci; el resumen por inversionista debe sumarlas también,
+    // o el total no cuadra contra las filas listadas. Réplica en SQL de
+    // calcularSplitInteresPci (flujo regular, redondeo por pago-inversionista):
+    //   interés_inv = ROUND(abono_interes × (aporte/Σaportes) × pct/100, 2)
+    // Si cambia src/cofidi/splitInteresPci.ts hay que actualizar esta fórmula.
+    // Solo no-CUBE: el interés de CUBE ya se corrige desde el desglose abajo
+    // (incluye parciales). Excluye redirigidos a CUBE (bandera + espejo
+    // pendiente), igual que la simulación del detalle.
+    const totalesSimQuery = sql`
+      WITH pf AS (
+        SELECT p.pago_id, p.credito_id, c.bandera_reinversion,
+               p.abono_interes::numeric AS interes,
+               COALESCE(p.abono_iva_12, 0)::numeric AS iva
+        FROM cartera.pagos_credito p
+        LEFT JOIN cartera.creditos c ON c.credito_id = p.credito_id
+        LEFT JOIN cartera.usuarios u ON u.usuario_id = c.usuario_id
+        ${sql.raw(whereSQL)}
+        AND ${sql.raw(pagoSimulableSQL)}
+      ),
+      aportes AS (
+        SELECT ci.credito_id, SUM(ci.monto_aportado::numeric) AS total
+        FROM cartera.creditos_inversionistas ci
+        WHERE ci.credito_id IN (SELECT DISTINCT credito_id FROM pf)
+        GROUP BY ci.credito_id
+      )
+      SELECT ci.inversionista_id AS "inversionistaId",
+             i.nombre AS "nombreInversionista",
+             i.emite_factura AS "emiteFactura",
+             SUM(ROUND(pf.interes * (ci.monto_aportado::numeric / a.total)
+                 * (ci.porcentaje_participacion_inversionista::numeric / 100), 2)) AS "interesSim",
+             SUM(ROUND(pf.iva * (ci.monto_aportado::numeric / a.total)
+                 * (ci.porcentaje_participacion_inversionista::numeric / 100), 2)) AS "ivaSim",
+             SUM(ci.monto_aportado::numeric) AS "aporteSim"
+      FROM pf
+      JOIN aportes a ON a.credito_id = pf.credito_id AND a.total > 0
+      JOIN cartera.creditos_inversionistas ci ON ci.credito_id = pf.credito_id
+      JOIN cartera.inversionistas i ON i.inversionista_id = ci.inversionista_id
+      WHERE UPPER(TRIM(i.nombre)) NOT LIKE '%CUBE INVESTMENTS%'
+        AND NOT (pf.bandera_reinversion = true AND EXISTS (
+              SELECT 1 FROM cartera.creditos_inversionistas_espejo esp
+              WHERE esp.credito_id = pf.credito_id
+                AND esp.inversionista_id = ci.inversionista_id
+                AND esp.status IN ('pendiente_reinversion','pendiente_compra_cartera')))
+        ${sql.raw(inversionistaId && Number(inversionistaId) !== CUBE_ID ? `AND ci.inversionista_id = '${inversionistaId}'` : "")}
+      GROUP BY ci.inversionista_id, i.nombre, i.emite_factura
+    `;
+
+    const totalesSimResult = await db.execute(totalesSimQuery);
+    for (const simRow of totalesSimResult.rows as any[]) {
+      const interesSim = new Big(simRow.interesSim ?? 0);
+      const ivaSim = new Big(simRow.ivaSim ?? 0);
+      if (interesSim.lte(0) && ivaSim.lte(0)) continue;
+      const idx = totalesInversionistas.findIndex(
+        (t) => Number(t.inversionistaId) === Number(simRow.inversionistaId)
+      );
+      if (idx >= 0) {
+        const t = totalesInversionistas[idx];
+        const interesTotal = new Big(t.totalAbonoInteres).plus(interesSim);
+        totalesInversionistas[idx] = {
+          ...t,
+          totalAbonoInteres: interesTotal.round(2).toNumber(),
+          totalAbonoIva: new Big(t.totalAbonoIva).plus(ivaSim).round(2).toNumber(),
+          totalIsr: interesTotal.times("0.05").round(2).toNumber(),
+          totalMontoAportado: new Big(t.totalMontoAportado)
+            .plus(simRow.aporteSim ?? 0)
+            .round(2)
+            .toNumber(),
+        };
+      } else {
+        totalesInversionistas.push({
+          inversionistaId: Number(simRow.inversionistaId),
+          nombreInversionista: simRow.nombreInversionista,
+          emiteFactura: simRow.emiteFactura ?? false,
+          totalAbonoCapital: 0,
+          totalAbonoInteres: interesSim.round(2).toNumber(),
+          totalAbonoIva: ivaSim.round(2).toNumber(),
+          totalIsr: interesSim.times("0.05").round(2).toNumber(),
+          totalMontoAportado: new Big(simRow.aporteSim ?? 0).round(2).toNumber(),
+        });
+      }
+    }
+    totalesInversionistas.sort((a, b) =>
+      String(a.nombreInversionista).localeCompare(String(b.nombreInversionista))
+    );
 
     // 💰 FIX: la fila de CUBE en el resumen debe reflejar el desglose (rubro INTERES),
     // igual que el detalle per-pago (armarInversionistasPago). El pci crudo de CUBE NO

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1797,18 +1797,83 @@ export type ReportCreditoInv = {
 
 
 /**
+ * 🧮 Simula las filas no-CUBE de un pago PARCIAL que todavía no tiene reparto en
+ * pagos_credito_inversionistas (la distribución real se crea hasta que la cuota
+ * se completa — aplicarPagoAlCredito, rama de cierre). Usa la MISMA función pura
+ * del reparto real (calcularSplitInteresPci) alimentada con los
+ * creditos_inversionistas del crédito, de modo que lo simulado hoy sea idéntico
+ * a lo que pci escribirá al cerrar la cuota (flujo regular; los pagos con compra
+ * de cartera pendiente de facturar se excluyen en el caller vía pendienteFacturar
+ * porque su reparto real usa el prorrateo por días).
+ * Capital: se deja en 0 — el reparto de capital solo ocurre al cierre.
+ */
+function simularInversionistasSinPci(args: {
+  creditoInvs: ReportCreditoInv[];
+  cubeId: number;
+  abonoInteresPago: string | number | null | undefined;
+  abonoIvaPago: string | number | null | undefined;
+  cuota?: string | number | null;
+}): ReportInvRow[] {
+  const split = calcularSplitInteresPci({
+    inversionistas: args.creditoInvs.map((ci) => ({
+      inversionista_id: ci.inversionista_id,
+      nombre: ci.nombre,
+      porcentaje_participacion_inversionista:
+        ci.porcentaje_participacion_inversionista ?? 0,
+      porcentaje_cash_in: ci.porcentaje_cash_in ?? 0,
+      monto_aportado: ci.monto_aportado ?? 0,
+    })),
+    pagoAbonoInteres: new Big(args.abonoInteresPago ?? 0),
+    pagoAbonoIva: new Big(args.abonoIvaPago ?? 0),
+  });
+  const splitPorInv = new Map(split.map((s) => [s.inversionista_id, s]));
+
+  // ⚠️ Emitir NUMBERS (no strings): las filas pci reales llegan como número vía
+  // json_build_object y el front (modalViewInvestor) les hace .toFixed() —
+  // una fila simulada con strings reventaría el modal.
+  return args.creditoInvs
+    .filter((ci) => ci.inversionista_id !== args.cubeId)
+    .map((ci) => {
+      const s = splitPorInv.get(ci.inversionista_id);
+      const interes = (s?.abono_interes ?? new Big(0)).round(2);
+      const iva = (s?.abono_iva_12 ?? new Big(0)).round(2);
+      return {
+        inversionistaId: ci.inversionista_id,
+        nombreInversionista: ci.nombre,
+        emiteFactura: ci.emite_factura ?? false,
+        abonoCapital: 0,
+        abonoInteres: Number(interes.toFixed(2)),
+        abonoIva: Number(iva.toFixed(2)),
+        isr: Number(interes.times("0.05").round(2).toFixed(2)),
+        cuotaPago: args.cuota != null ? Number(args.cuota) : 0,
+        montoAportado:
+          ci.monto_aportado != null ? Number(ci.monto_aportado) : null,
+        porcentajeParticipacion:
+          ci.porcentaje_participacion_inversionista != null
+            ? Number(ci.porcentaje_participacion_inversionista)
+            : null,
+      };
+    });
+}
+
+/**
  * 🧮 Arma el array `inversionistas` de UN pago para el reporte JSON, reflejando
  * el interés facturado de CUBE leído del desglose:
  *   - CUBE: su interés = el del desglose (rubro INTERES, CON IVA). Reemplaza la
  *     fila CUBE del pci (si existía) o crea una nueva.
  *   - Inversionistas no-CUBE: del pci, SIN CAMBIO.
- *   - Parciales (sin filas pci): solo aparece CUBE del desglose; los demás
- *     inversionistas se difieren hasta que la cuota se complete.
+ *   - Parciales (sin filas pci) con simularSinPci=true: los no-CUBE se SIMULAN
+ *     desde creditos_inversionistas con la misma matemática del reparto real
+ *     (ver simularInversionistasSinPci); así el reporte los muestra desde el
+ *     día del parcial y no hasta que la cuota se complete.
+ *   - Parciales sin simularSinPci: solo aparece CUBE del desglose (comportamiento
+ *     previo; aplica a pagos reset/cancelación y prorrateados por compra de cartera).
  *   - Sin desglose (pagos pre-facturación / pendientes): fallback → conservar el
- *     array pci tal cual (comportamiento previo).
+ *     array pci tal cual (comportamiento previo). La simulación también queda
+ *     detrás de este gate: sin desglose no hay facturación que reflejar.
  *
  * Función PURA (sin DB) → testeable en aislamiento. NO toca abono_capital ni la
- * parte de los inversionistas no-CUBE; solo ajusta/crea la fila de CUBE.
+ * parte de los inversionistas no-CUBE del pci; solo ajusta/crea la fila de CUBE.
  *
  * Invariante (cuotas completas): Σ(salida.abonoInteres) =
  *   Σ(no-CUBE pci) + (desglose CUBE net) = el interés facturado del pago.
@@ -1819,13 +1884,34 @@ export function armarInversionistasPago(args: {
   desgloseCubeInteres: { total: Big; iva: Big } | null; // del desglose rubro INTERES (monto_total CON iva, monto_iva)
   cubeMeta?: Partial<ReportInvRow> | null;              // metadatos de CUBE (de creditos_inversionistas) si CUBE no está en pci
   cuota?: string | number | null;
+  // 🆕 Simulación de parciales sin reparto (ver simularInversionistasSinPci):
+  creditoInvs?: ReportCreditoInv[] | null;              // inversionistas del crédito
+  abonoInteresPago?: string | number | null;            // pagos_credito.abono_interes
+  abonoIvaPago?: string | number | null;                // pagos_credito.abono_iva_12
+  simularSinPci?: boolean;                              // el caller gatea: validated + !pendienteFacturar
 }): ReportInvRow[] {
   const rows = Array.isArray(args.pciRows) ? args.pciRows : [];
-  const noCube = rows.filter((r) => r.inversionistaId !== args.cubeId);
+  let noCube = rows.filter((r) => r.inversionistaId !== args.cubeId);
   const pciCube = rows.find((r) => r.inversionistaId === args.cubeId) ?? null;
 
   // Sin desglose → fallback: conservar el pci tal cual.
   if (!args.desgloseCubeInteres) return rows;
+
+  // 🆕 PARCIAL sin reparto (cuota aún abierta) ya facturado: simular los no-CUBE.
+  // Solo cuando NO hay filas pci — si el reparto real ya existe, ese manda.
+  if (
+    rows.length === 0 &&
+    args.simularSinPci === true &&
+    (args.creditoInvs?.length ?? 0) > 0
+  ) {
+    noCube = simularInversionistasSinPci({
+      creditoInvs: args.creditoInvs!,
+      cubeId: args.cubeId,
+      abonoInteresPago: args.abonoInteresPago,
+      abonoIvaPago: args.abonoIvaPago,
+      cuota: args.cuota,
+    });
+  }
 
   const cubeNet = args.desgloseCubeInteres.total.minus(args.desgloseCubeInteres.iva);
   const cubeIva = args.desgloseCubeInteres.iva;
@@ -2288,6 +2374,20 @@ export async function getPagosConInversionistas(options: GetPagosOptions = {}) {
             desgloseCubeInteres: desgloseCubeByPago.get(Number(r.pagoId)) ?? null,
             cubeMeta,
             cuota: r.cuotaMonto as any,
+            // 🆕 Parciales sin reparto: simular filas no-CUBE con la misma
+            // matemática del cierre (calcularSplitInteresPci). Solo pagos
+            // 'validated' (reset/cancelación reparte distinto), sin compra de
+            // cartera pendiente (esos usan prorrateo por días, no aportado) y
+            // sin bandera_reinversion (en esa ventana la facturación redirige
+            // el interés del inversionista a CUBE → el desglose INTERES ya lo
+            // incluye y simular su parte regular lo doble-contaría).
+            creditoInvs,
+            abonoInteresPago: r.abono_interes as any,
+            abonoIvaPago: r.abono_iva_12 as any,
+            simularSinPci:
+              (r as any).validation_status === "validated" &&
+              !((r as any).pendienteFacturar ?? false) &&
+              !((r as any).banderaReinversion ?? false),
           })
         : pciRows;
 

--- a/apps/crm/apps/server/src/lib/orpc.ts
+++ b/apps/crm/apps/server/src/lib/orpc.ts
@@ -342,6 +342,37 @@ const requireMetaColocacionReport = o.middleware(async ({ context, next }) => {
 	});
 });
 
+const requireEfectividadPorEtapaReport = o.middleware(
+	async ({ context, next }) => {
+		if (!context.session?.user) {
+			throw new ORPCError("UNAUTHORIZED");
+		}
+
+		const userId = context.session.user.id;
+		const userData = await db
+			.select()
+			.from(user)
+			.where(eq(user.id, userId))
+			.limit(1);
+		const userRole = userData[0]?.role;
+
+		if (!PERMISSIONS.canAccessEfectividadPorEtapaReport(userRole)) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "Efectividad por etapa report access required",
+			});
+		}
+
+		return next({
+			context: {
+				session: context.session,
+				user: userData[0],
+				userId,
+				userRole,
+			},
+		});
+	},
+);
+
 const requireViewOpportunityContracts = o.middleware(
 	async ({ context, next }) => {
 		if (!context.session?.user) {
@@ -575,6 +606,9 @@ export const porcentajeEfectividadReportProcedure = publicProcedure.use(
 );
 export const metaColocacionReportProcedure = publicProcedure.use(
 	requireMetaColocacionReport,
+);
+export const efectividadPorEtapaReportProcedure = publicProcedure.use(
+	requireEfectividadPorEtapaReport,
 );
 export const viewOpportunityContractsProcedure = publicProcedure.use(
 	requireViewOpportunityContracts,

--- a/apps/crm/apps/server/src/lib/roles.ts
+++ b/apps/crm/apps/server/src/lib/roles.ts
@@ -171,6 +171,9 @@ export const PERMISSIONS = {
 	canAccessMetaColocacionReport: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
 
+	canAccessEfectividadPorEtapaReport: (role: UserRole | string): boolean =>
+		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,
+
 	// Credit Detail Approval (40% → 50%)
 	canApproveCreditDetail: (role: UserRole | string): boolean =>
 		role === ROLES.ADMIN || role === ROLES.SALES_SUPERVISOR,

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -340,6 +340,7 @@ export const reportsAppRouter = {
 	getReportePorcentajeEfectividad:
 		reportsRouter.getReportePorcentajeEfectividad,
 	getReporteMetaColocacion: reportsRouter.getReporteMetaColocacion,
+	getReporteEfectividadPorEtapa: reportsRouter.getReporteEfectividadPorEtapa,
 	// Reportes unificados (cartera-back + CRM)
 	getReporteCarteraCompleto: reportesCarteraRouter.getReporteCarteraCompleto,
 	getReporteEficienciaCobros: reportesCarteraRouter.getReporteEficienciaCobros,

--- a/apps/crm/apps/server/src/routers/reports.ts
+++ b/apps/crm/apps/server/src/routers/reports.ts
@@ -26,6 +26,7 @@ import {
 } from "../lib/lead-sources";
 import {
 	closedCreditsReportProcedure,
+	efectividadPorEtapaReportProcedure,
 	metaColocacionReportProcedure,
 	porcentajeEfectividadReportProcedure,
 	protectedProcedure,
@@ -657,6 +658,13 @@ export const getReporteInventario = protectedProcedure.handler(async () => {
 
 const CLOSED_STAGE_THRESHOLD = 90;
 const MAX_REPORT_ROWS = 10_000;
+// Primeras 4 etapas del pipeline: Preparación, Llamada de presentación, Solución
+// y propuesta, Recepción de documentación y traslado a análisis.
+const EFECTIVIDAD_POR_ETAPA_MAX_ORDER = 4;
+
+function pctOf(numerator: number, denominator: number) {
+	return denominator > 0 ? Math.round((numerator * 1000) / denominator) / 10 : 0;
+}
 
 type PorcentajeEfectividadFuenteBaseRow = {
 	source: string;
@@ -984,6 +992,164 @@ export const getReporteTiempoCierre = tiempoCierreReportProcedure
 			porFuente: porFuenteRows,
 			porTipoCanal: aggregateTiempoCierrePorTipoCanal(porFuenteRows),
 		};
+	});
+
+type EfectividadPorEtapaRawRow = {
+	stageId: string;
+	stageOrder: number;
+	stageName: string;
+	source: string | null;
+	llegaron: number;
+	avanzaron: number;
+	cerraron: number;
+};
+
+export function buildEfectividadPorEtapaRows(rows: EfectividadPorEtapaRawRow[]) {
+	const porEtapaFuente = rows
+		.filter((row): row is EfectividadPorEtapaRawRow & { source: string } =>
+			row.source !== null,
+		)
+		.map((row) => ({
+			stageId: row.stageId,
+			stageOrder: row.stageOrder,
+			stageName: row.stageName,
+			source: row.source,
+			llegaron: row.llegaron,
+			avanzaron: row.avanzaron,
+			cerraron: row.cerraron,
+			pctAvance: pctOf(row.avanzaron, row.llegaron),
+			pctEfectividad: pctOf(row.cerraron, row.llegaron),
+		}))
+		.sort((a, b) => a.stageOrder - b.stageOrder || b.llegaron - a.llegaron);
+
+	const byStage = new Map<
+		string,
+		{
+			stageId: string;
+			stageOrder: number;
+			stageName: string;
+			llegaron: number;
+			avanzaron: number;
+			cerraron: number;
+		}
+	>();
+
+	for (const row of rows) {
+		const current = byStage.get(row.stageId) ?? {
+			stageId: row.stageId,
+			stageOrder: row.stageOrder,
+			stageName: row.stageName,
+			llegaron: 0,
+			avanzaron: 0,
+			cerraron: 0,
+		};
+		current.llegaron += row.llegaron;
+		current.avanzaron += row.avanzaron;
+		current.cerraron += row.cerraron;
+		byStage.set(row.stageId, current);
+	}
+
+	const porEtapa = [...byStage.values()]
+		.sort((a, b) => a.stageOrder - b.stageOrder)
+		.map((stage) => ({
+			...stage,
+			pctAvance: pctOf(stage.avanzaron, stage.llegaron),
+			pctEfectividad: pctOf(stage.cerraron, stage.llegaron),
+		}));
+
+	return { porEtapa, porEtapaFuente };
+}
+
+/**
+ * Reporte de Efectividad por Etapa
+ * De las oportunidades creadas en el rango, cuántas llegan a cada una de las
+ * primeras 4 etapas del pipeline ("llegar" = etapa actual o alguna vez en su
+ * historial), cuántas avanzan más allá de esa etapa y cuántas terminan
+ * cerrando (etapa con closurePercentage >= 90), desglosado por etapa y fuente.
+ */
+export const getReporteEfectividadPorEtapa = efectividadPorEtapaReportProcedure
+	.input(closedCreditsReportInputSchema)
+	.handler(async ({ input }) => {
+		const { start, end } = parseGuatemalaDateRange(
+			input.startDate,
+			input.endDate,
+		);
+
+		const result = await db.execute(sql`
+			WITH target_stages AS (
+				SELECT id, "order", name
+				FROM sales_stages
+				WHERE "order" <= ${EFECTIVIDAD_POR_ETAPA_MAX_ORDER}
+			), touched_stages AS (
+				SELECT o.id AS opportunity_id, o.stage_id AS stage_id
+				FROM opportunities o
+				WHERE o.stage_id IN (SELECT id FROM target_stages)
+				UNION
+				SELECT h.opportunity_id, h.from_stage_id
+				FROM opportunity_stage_history h
+				WHERE h.from_stage_id IN (SELECT id FROM target_stages)
+				UNION
+				SELECT h.opportunity_id, h.to_stage_id
+				FROM opportunity_stage_history h
+				WHERE h.to_stage_id IN (SELECT id FROM target_stages)
+			), max_order_reached AS (
+				SELECT h.opportunity_id, MAX(s."order") AS max_order
+				FROM opportunity_stage_history h
+				JOIN sales_stages s ON s.id = h.to_stage_id
+				GROUP BY h.opportunity_id
+			), ever_closed AS (
+				SELECT DISTINCT h.opportunity_id
+				FROM opportunity_stage_history h
+				JOIN sales_stages s ON s.id = h.to_stage_id
+				WHERE s.closure_percentage >= ${CLOSED_STAGE_THRESHOLD}
+			), cohort AS (
+				SELECT o.id, COALESCE(o.source, 'other') AS source, o.stage_id AS current_stage_id
+				FROM opportunities o
+				WHERE o.created_at >= ${start}
+					AND o.created_at <= ${end}
+					AND o.status != 'migrate'
+			)
+			SELECT
+				ts.id AS stage_id,
+				ts."order" AS stage_order,
+				ts.name AS stage_name,
+				c.source AS source,
+				COUNT(DISTINCT c.id)::int AS llegaron,
+				COUNT(DISTINCT CASE
+					WHEN GREATEST(cs."order", COALESCE(mo.max_order, 0)) > ts."order" THEN c.id
+				END)::int AS avanzaron,
+				COUNT(DISTINCT CASE WHEN ec.opportunity_id IS NOT NULL THEN c.id END)::int AS cerraron
+			FROM target_stages ts
+			LEFT JOIN touched_stages tch ON tch.stage_id = ts.id
+			LEFT JOIN cohort c ON c.id = tch.opportunity_id
+			LEFT JOIN sales_stages cs ON cs.id = c.current_stage_id
+			LEFT JOIN max_order_reached mo ON mo.opportunity_id = c.id
+			LEFT JOIN ever_closed ec ON ec.opportunity_id = c.id
+			GROUP BY ts.id, ts."order", ts.name, c.source
+			ORDER BY ts."order", c.source
+		`);
+
+		const rawRows = result.rows as {
+			stage_id: string;
+			stage_order: number;
+			stage_name: string;
+			source: string | null;
+			llegaron: number;
+			avanzaron: number;
+			cerraron: number;
+		}[];
+
+		return buildEfectividadPorEtapaRows(
+			rawRows.map((row) => ({
+				stageId: row.stage_id,
+				stageOrder: row.stage_order,
+				stageName: row.stage_name,
+				source: row.source,
+				llegaron: row.llegaron,
+				avanzaron: row.avanzaron,
+				cerraron: row.cerraron,
+			})),
+		);
 	});
 
 /**

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -47,6 +47,7 @@ import { Route as InversionesLiquidacionesInversionistaIdRouteImport } from './r
 import { Route as CrmReportesTiempoCierreRouteImport } from './routes/crm/reportes/tiempo-cierre'
 import { Route as CrmReportesPorcentajeEfectividadRouteImport } from './routes/crm/reportes/porcentaje-efectividad'
 import { Route as CrmReportesMetaColocacionRouteImport } from './routes/crm/reportes/meta-colocacion'
+import { Route as CrmReportesEfectividadPorEtapaRouteImport } from './routes/crm/reportes/efectividad-por-etapa'
 import { Route as CrmAnalysisOpportunityIdRouteImport } from './routes/crm/analysis/$opportunityId'
 import { Route as CrmAdminMiniagentRouteImport } from './routes/crm/admin/miniagent'
 
@@ -246,6 +247,12 @@ const CrmReportesMetaColocacionRoute =
     path: '/crm/reportes/meta-colocacion',
     getParentRoute: () => rootRouteImport,
   } as any)
+const CrmReportesEfectividadPorEtapaRoute =
+  CrmReportesEfectividadPorEtapaRouteImport.update({
+    id: '/crm/reportes/efectividad-por-etapa',
+    path: '/crm/reportes/efectividad-por-etapa',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const CrmAnalysisOpportunityIdRoute =
   CrmAnalysisOpportunityIdRouteImport.update({
     id: '/crm/analysis/$opportunityId',
@@ -290,6 +297,7 @@ export interface FileRoutesByFullPath {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/efectividad-por-etapa': typeof CrmReportesEfectividadPorEtapaRoute
   '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
@@ -332,6 +340,7 @@ export interface FileRoutesByTo {
   '/vehicles': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/efectividad-por-etapa': typeof CrmReportesEfectividadPorEtapaRoute
   '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
@@ -375,6 +384,7 @@ export interface FileRoutesById {
   '/vehicles/': typeof VehiclesIndexRoute
   '/crm/admin/miniagent': typeof CrmAdminMiniagentRoute
   '/crm/analysis/$opportunityId': typeof CrmAnalysisOpportunityIdRoute
+  '/crm/reportes/efectividad-por-etapa': typeof CrmReportesEfectividadPorEtapaRoute
   '/crm/reportes/meta-colocacion': typeof CrmReportesMetaColocacionRoute
   '/crm/reportes/porcentaje-efectividad': typeof CrmReportesPorcentajeEfectividadRoute
   '/crm/reportes/tiempo-cierre': typeof CrmReportesTiempoCierreRoute
@@ -419,6 +429,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/efectividad-por-etapa'
     | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
@@ -461,6 +472,7 @@ export interface FileRouteTypes {
     | '/vehicles'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/efectividad-por-etapa'
     | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
@@ -503,6 +515,7 @@ export interface FileRouteTypes {
     | '/vehicles/'
     | '/crm/admin/miniagent'
     | '/crm/analysis/$opportunityId'
+    | '/crm/reportes/efectividad-por-etapa'
     | '/crm/reportes/meta-colocacion'
     | '/crm/reportes/porcentaje-efectividad'
     | '/crm/reportes/tiempo-cierre'
@@ -546,6 +559,7 @@ export interface RootRouteChildren {
   VehiclesIndexRoute: typeof VehiclesIndexRoute
   CrmAdminMiniagentRoute: typeof CrmAdminMiniagentRoute
   CrmAnalysisOpportunityIdRoute: typeof CrmAnalysisOpportunityIdRoute
+  CrmReportesEfectividadPorEtapaRoute: typeof CrmReportesEfectividadPorEtapaRoute
   CrmReportesMetaColocacionRoute: typeof CrmReportesMetaColocacionRoute
   CrmReportesPorcentajeEfectividadRoute: typeof CrmReportesPorcentajeEfectividadRoute
   CrmReportesTiempoCierreRoute: typeof CrmReportesTiempoCierreRoute
@@ -825,6 +839,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CrmReportesMetaColocacionRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/crm/reportes/efectividad-por-etapa': {
+      id: '/crm/reportes/efectividad-por-etapa'
+      path: '/crm/reportes/efectividad-por-etapa'
+      fullPath: '/crm/reportes/efectividad-por-etapa'
+      preLoaderRoute: typeof CrmReportesEfectividadPorEtapaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/crm/analysis/$opportunityId': {
       id: '/crm/analysis/$opportunityId'
       path: '/crm/analysis/$opportunityId'
@@ -874,6 +895,7 @@ const rootRouteChildren: RootRouteChildren = {
   VehiclesIndexRoute: VehiclesIndexRoute,
   CrmAdminMiniagentRoute: CrmAdminMiniagentRoute,
   CrmAnalysisOpportunityIdRoute: CrmAnalysisOpportunityIdRoute,
+  CrmReportesEfectividadPorEtapaRoute: CrmReportesEfectividadPorEtapaRoute,
   CrmReportesMetaColocacionRoute: CrmReportesMetaColocacionRoute,
   CrmReportesPorcentajeEfectividadRoute: CrmReportesPorcentajeEfectividadRoute,
   CrmReportesTiempoCierreRoute: CrmReportesTiempoCierreRoute,

--- a/apps/crm/apps/web/src/routes/crm/reportes/efectividad-por-etapa.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/efectividad-por-etapa.tsx
@@ -1,0 +1,469 @@
+import { useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Activity, ArrowRightCircle, CheckCircle2, ListChecks } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import type { DateRange } from "react-day-picker";
+import {
+	Bar,
+	BarChart,
+	CartesianGrid,
+	Cell,
+	ResponsiveContainer,
+	Tooltip,
+	XAxis,
+	YAxis,
+} from "recharts";
+import { toast } from "sonner";
+import {
+	DEFAULT_PRESET,
+	RangePresetFilter,
+	rangeForPreset,
+} from "@/components/reports/range-preset-filter";
+import { ReportCard } from "@/components/reports/report-card";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { getSourceLabel } from "@/lib/crm-formatters";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/crm/reportes/efectividad-por-etapa")({
+	component: RouteComponent,
+});
+
+const GUATEMALA_TZ = "America/Guatemala";
+const BAR_HEIGHT_PX = 52;
+
+const SOURCE_COLORS: Record<string, string> = {
+	website: "#8b5cf6",
+	referral: "#10b981",
+	cold_call: "#f97316",
+	email: "#6366f1",
+	social_media: "#d946ef",
+	event: "#a855f7",
+	facebook: "#3b82f6",
+	instagram: "#ec4899",
+	google: "#ef4444",
+	meta: "#0ea5e9",
+	linkedin: "#1d4ed8",
+	// "Whatsapp" con W mayúscula es el valor real del enum en BD
+	Whatsapp: "#22c55e",
+	agency: "#14b8a6",
+	property: "#f59e0b",
+	recurrent: "#7c3aed",
+	recurrent_active: "#0891b2",
+	other: "#9ca3af",
+};
+
+function getSourceColor(source: string): string {
+	return SOURCE_COLORS[source] ?? "#9ca3af";
+}
+
+function formatDateInput(date: Date): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: GUATEMALA_TZ,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(date);
+}
+
+function RouteComponent() {
+	const {
+		data: session,
+		error: sessionError,
+		isPending: sessionPending,
+	} = authClient.useSession();
+	const navigate = useNavigate();
+
+	const userProfile = useQuery(orpc.getUserProfile.queryOptions());
+	const userRole = userProfile.data?.role;
+	const canAccess = userRole
+		? PERMISSIONS.canAccessEfectividadPorEtapaReport(userRole)
+		: false;
+	const isPending = sessionPending || userProfile.isPending;
+
+	useEffect(() => {
+		if (
+			shouldRedirectToLogin({
+				error: sessionError,
+				isPending: sessionPending,
+				session,
+			})
+		) {
+			navigate({ to: "/login" });
+		} else if (session && !userProfile.isPending && !canAccess) {
+			navigate({ to: "/dashboard" });
+			toast.error("Acceso denegado");
+		}
+	}, [
+		session,
+		sessionError,
+		sessionPending,
+		userProfile.isPending,
+		canAccess,
+		navigate,
+	]);
+
+	if (isPending) {
+		return (
+			<div className="flex h-96 items-center justify-center text-muted-foreground">
+				Cargando...
+			</div>
+		);
+	}
+
+	if (!canAccess) return null;
+
+	return (
+		<div className="container mx-auto space-y-6 p-6">
+			<EfectividadPorEtapaContent />
+		</div>
+	);
+}
+
+export function EfectividadPorEtapaContent() {
+	const [dateRange, setDateRange] = useState<DateRange | undefined>(() =>
+		rangeForPreset(DEFAULT_PRESET),
+	);
+	const [selectedStageId, setSelectedStageId] = useState<string | null>(null);
+
+	const input =
+		dateRange?.from && dateRange?.to
+			? {
+					startDate: formatDateInput(dateRange.from),
+					endDate: formatDateInput(dateRange.to),
+				}
+			: null;
+
+	const reportQuery = useQuery({
+		...orpc.getReporteEfectividadPorEtapa.queryOptions({
+			input: input ?? { startDate: "", endDate: "" },
+		}),
+		enabled: !!input,
+	});
+	const data = reportQuery.data;
+	const isLoading = reportQuery.isLoading;
+
+	const porEtapa = data?.porEtapa ?? [];
+	const porEtapaFuente = data?.porEtapaFuente ?? [];
+
+	const activeStageId = selectedStageId ?? porEtapa[0]?.stageId ?? null;
+	const activeStage = porEtapa.find((e) => e.stageId === activeStageId) ?? null;
+
+	const chartData = useMemo(
+		() =>
+			porEtapaFuente
+				.filter((row) => row.stageId === activeStageId)
+				.map((row) => ({
+					rawSource: row.source,
+					source: getSourceLabel(row.source),
+					pctEfectividad: row.pctEfectividad,
+					pctAvance: row.pctAvance,
+					llegaron: row.llegaron,
+					avanzaron: row.avanzaron,
+					cerraron: row.cerraron,
+				}))
+				.sort((a, b) => b.pctEfectividad - a.pctEfectividad),
+		[porEtapaFuente, activeStageId],
+	);
+
+	const chartHeight = Math.max(280, chartData.length * BAR_HEIGHT_PX);
+
+	return (
+		<div className="space-y-6">
+			<div>
+				<h1 className="font-bold text-3xl tracking-tight">
+					Efectividad por Etapa
+				</h1>
+				<p className="mt-1 text-muted-foreground">
+					De las oportunidades creadas en el rango, cuántas llegan a cada una de
+					las primeras 4 etapas del pipeline, cuántas avanzan más allá y cuántas
+					terminan cerrando.
+				</p>
+			</div>
+
+			<RangePresetFilter dateRange={dateRange} onDateRangeChange={setDateRange} />
+
+			{/* ── Progresión por Etapa ── */}
+			<Card>
+				<CardHeader>
+					<CardTitle>Progresión por Etapa</CardTitle>
+					<CardDescription>
+						Preparación → Llamada de presentación → Solución y propuesta →
+						Recepción de documentación y traslado a análisis
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Etapa</TableHead>
+								<TableHead className="text-right">Llegaron</TableHead>
+								<TableHead className="text-right">Avanzaron</TableHead>
+								<TableHead className="text-right">% Avance</TableHead>
+								<TableHead className="text-right">Cerraron</TableHead>
+								<TableHead className="text-right">% Efectividad</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : porEtapa.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								porEtapa.map((row) => (
+									<TableRow
+										key={row.stageId}
+										className={
+											row.stageId === activeStageId ? "bg-muted/50" : undefined
+										}
+									>
+										<TableCell className="font-medium">
+											{row.stageName}
+										</TableCell>
+										<TableCell className="text-right">{row.llegaron}</TableCell>
+										<TableCell className="text-right">
+											{row.avanzaron}
+										</TableCell>
+										<TableCell className="text-right text-muted-foreground">
+											{row.pctAvance}%
+										</TableCell>
+										<TableCell className="text-right">
+											{row.cerraron}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.pctEfectividad}%
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+
+			{/* ── Selector de etapa + detalle por fuente ── */}
+			<div className="flex items-center gap-3">
+				<span className="text-muted-foreground text-sm">Ver detalle de:</span>
+				<Select
+					value={activeStageId ?? undefined}
+					onValueChange={setSelectedStageId}
+					disabled={porEtapa.length === 0}
+				>
+					<SelectTrigger className="w-[340px]">
+						<SelectValue placeholder="Selecciona una etapa" />
+					</SelectTrigger>
+					<SelectContent>
+						{porEtapa.map((row) => (
+							<SelectItem key={row.stageId} value={row.stageId}>
+								{row.stageName}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+
+			{activeStage && (
+				<div className="grid gap-4 md:grid-cols-4">
+					<ReportCard
+						title="Llegaron"
+						value={isLoading ? "—" : activeStage.llegaron}
+						description="Oportunidades en esta etapa"
+						icon={Activity}
+					/>
+					<ReportCard
+						title="Avanzaron"
+						value={isLoading ? "—" : activeStage.avanzaron}
+						description={`${activeStage.pctAvance}% avanzó más allá`}
+						icon={ArrowRightCircle}
+					/>
+					<ReportCard
+						title="Cerraron"
+						value={isLoading ? "—" : activeStage.cerraron}
+						description="Llegaron a etapa de cierre"
+						icon={CheckCircle2}
+					/>
+					<ReportCard
+						title="Efectividad"
+						value={isLoading ? "—" : `${activeStage.pctEfectividad}%`}
+						description="Cerraron / llegaron"
+						icon={ListChecks}
+					/>
+				</div>
+			)}
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Efectividad por fuente</CardTitle>
+					<CardDescription>
+						{activeStage
+							? `Desglose por fuente para "${activeStage.stageName}"`
+							: "Selecciona una etapa para ver el desglose"}
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					{isLoading ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							Cargando...
+						</div>
+					) : chartData.length === 0 ? (
+						<div className="flex h-[280px] items-center justify-center text-muted-foreground">
+							No hay datos para el período seleccionado
+						</div>
+					) : (
+						<ResponsiveContainer width="100%" height={chartHeight}>
+							<BarChart
+								data={chartData}
+								layout="vertical"
+								margin={{ top: 0, right: 56, left: 0, bottom: 0 }}
+							>
+								<CartesianGrid strokeDasharray="3 3" horizontal={false} />
+								<XAxis
+									type="number"
+									domain={[0, 100]}
+									tickFormatter={(v: number) => `${v}%`}
+									tick={{ fontSize: 12 }}
+								/>
+								<YAxis
+									dataKey="source"
+									type="category"
+									width={110}
+									tick={{ fontSize: 12 }}
+								/>
+								<Tooltip
+									formatter={(value) => [`${value}%`, "Efectividad"]}
+									labelFormatter={(label) => `Fuente: ${label}`}
+								/>
+								<Bar
+									dataKey="pctEfectividad"
+									name="Efectividad"
+									radius={[0, 4, 4, 0]}
+								>
+									{chartData.map((entry) => (
+										<Cell
+											key={entry.rawSource}
+											fill={getSourceColor(entry.rawSource)}
+										/>
+									))}
+								</Bar>
+							</BarChart>
+						</ResponsiveContainer>
+					)}
+				</CardContent>
+			</Card>
+
+			<Card>
+				<CardHeader>
+					<CardTitle>Detalle por fuente</CardTitle>
+					<CardDescription>
+						{activeStage
+							? `Llegaron, avanzaron y cerraron por fuente en "${activeStage.stageName}"`
+							: "Selecciona una etapa para ver el desglose"}
+					</CardDescription>
+				</CardHeader>
+				<CardContent>
+					<Table>
+						<TableHeader>
+							<TableRow>
+								<TableHead>Fuente</TableHead>
+								<TableHead className="text-right">Llegaron</TableHead>
+								<TableHead className="text-right">Avanzaron</TableHead>
+								<TableHead className="text-right">% Avance</TableHead>
+								<TableHead className="text-right">Cerraron</TableHead>
+								<TableHead className="text-right">% Efectividad</TableHead>
+							</TableRow>
+						</TableHeader>
+						<TableBody>
+							{isLoading ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										Cargando...
+									</TableCell>
+								</TableRow>
+							) : chartData.length === 0 ? (
+								<TableRow>
+									<TableCell
+										colSpan={6}
+										className="py-8 text-center text-muted-foreground"
+									>
+										No hay datos para el período seleccionado
+									</TableCell>
+								</TableRow>
+							) : (
+								chartData.map((row) => (
+									<TableRow key={row.rawSource}>
+										<TableCell className="font-medium">
+											<div className="flex items-center gap-2">
+												<span
+													className="h-2.5 w-2.5 shrink-0 rounded-full"
+													style={{
+														backgroundColor: getSourceColor(row.rawSource),
+													}}
+												/>
+												{row.source}
+											</div>
+										</TableCell>
+										<TableCell className="text-right">
+											{row.llegaron}
+										</TableCell>
+										<TableCell className="text-right">
+											{row.avanzaron}
+										</TableCell>
+										<TableCell className="text-right text-muted-foreground">
+											{row.pctAvance}%
+										</TableCell>
+										<TableCell className="text-right">
+											{row.cerraron}
+										</TableCell>
+										<TableCell className="text-right font-semibold">
+											{row.pctEfectividad}%
+										</TableCell>
+									</TableRow>
+								))
+							)}
+						</TableBody>
+					</Table>
+				</CardContent>
+			</Card>
+		</div>
+	);
+}

--- a/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/reportes/index.tsx
@@ -7,6 +7,7 @@ import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
 import { PERMISSIONS } from "@/lib/roles";
 import { orpc } from "@/utils/orpc";
+import { EfectividadPorEtapaContent } from "./efectividad-por-etapa";
 import { MetaColocacionContent } from "./meta-colocacion";
 import { PorcentajeEfectividadContent } from "./porcentaje-efectividad";
 import { TiempoCierreContent } from "./tiempo-cierre";
@@ -34,7 +35,10 @@ function RouteComponent() {
 	const canMeta = userRole
 		? PERMISSIONS.canAccessMetaColocacionReport(userRole)
 		: false;
-	const canAny = canTiempo || canEfectividad || canMeta;
+	const canEtapa = userRole
+		? PERMISSIONS.canAccessEfectividadPorEtapaReport(userRole)
+		: false;
+	const canAny = canTiempo || canEfectividad || canMeta || canEtapa;
 	const isPending = sessionPending || userProfile.isPending;
 
 	useEffect(() => {
@@ -73,14 +77,17 @@ function RouteComponent() {
 		? "meta"
 		: canEfectividad
 			? "efectividad"
-			: "tiempo";
+			: canTiempo
+				? "tiempo"
+				: "etapa";
 
 	return (
 		<div className="container mx-auto space-y-6 p-6">
 			<div>
 				<h1 className="font-bold text-3xl tracking-tight">Reportes</h1>
 				<p className="mt-1 text-muted-foreground">
-					Reportes de ventas: colocación, efectividad y tiempo de cierre.
+					Reportes de ventas: colocación, efectividad, tiempo de cierre y
+					efectividad por etapa.
 				</p>
 			</div>
 
@@ -92,6 +99,9 @@ function RouteComponent() {
 					)}
 					{canTiempo && (
 						<TabsTrigger value="tiempo">Tiempo de cierre</TabsTrigger>
+					)}
+					{canEtapa && (
+						<TabsTrigger value="etapa">Efectividad por Etapa</TabsTrigger>
 					)}
 				</TabsList>
 
@@ -108,6 +118,11 @@ function RouteComponent() {
 				{canTiempo && (
 					<TabsContent value="tiempo" className="space-y-6">
 						<TiempoCierreContent />
+					</TabsContent>
+				)}
+				{canEtapa && (
+					<TabsContent value="etapa" className="space-y-6">
+						<EfectividadPorEtapaContent />
 					</TabsContent>
 				)}
 			</Tabs>


### PR DESCRIPTION
# 🚀 Pase a Producción — `develop` → `main`

Release de los cambios acumulados en `develop`. Resumen general por área:

## 💳 Cartera — Reporte de pagos con inversionistas
- Los pagos parciales ahora muestran a los inversionistas desde el primer pago (antes aparecían hasta que la cuota cerraba completa, retroactivos en fechas ya cuadradas por contabilidad)
- La simulación usa la misma matemática que el reparto real al cierre — los montos no cambian ni un centavo cuando la cuota se completa (verificado end-to-end en dev con caso real)
- Filtro por inversionista y totales del resumen consistentes con el detalle (también ven los parciales)
- Exclusión precisa por inversionista en créditos con reinversión/compra de cartera en transición

## 👥 CRM — Reportes
- Nuevo reporte de **Efectividad por Etapa** en `/crm/reportes`: conversión de las primeras 4 etapas del pipeline, desglosado por etapa y por fuente

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)