### PR TITLE
fix(cartera): modal Ver Inversionistas revienta con fila sintética de CUBE (prod)

### DIFF
--- a/apps/cartera-back/src/controllers/payments.test.ts
+++ b/apps/cartera-back/src/controllers/payments.test.ts
@@ -532,10 +532,10 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     expect(invA.abonoInteres).toBe("100");
     expect(invA.abonoIva).toBe("12");
 
-    // CUBE reemplazado con los valores del desglose (formato toFixed(2))
+    // CUBE reemplazado con los valores del desglose (como number)
     const cube = out.find((r: any) => r.inversionistaId === 86)!;
-    expect(cube.abonoInteres).toBe("70.00");
-    expect(cube.abonoIva).toBe("8.40");
+    expect(cube.abonoInteres).toBe(70);
+    expect(cube.abonoIva).toBe(8.4);
   });
 
   it("caso 6 (isr): isr de CUBE = round2(net × 0.05); net 70 → isr 3.5", () => {
@@ -561,7 +561,7 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     });
 
     const cube = out.find((r: any) => r.inversionistaId === 86)!;
-    expect(cube.isr).toBe("3.50"); // 70 * 0.05 = 3.5, formatted as toFixed(2)
+    expect(cube.isr).toBe(3.5); // 70 * 0.05 = 3.5, como number
   });
 
   it("caso 2: CUBE NO en pci → crea fila CUBE nueva con el desglose", () => {
@@ -591,7 +591,7 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     expect(out).toHaveLength(2);
     const cube = out.find((r: any) => r.inversionistaId === 86)!;
     expect(cube).toBeDefined();
-    expect(cube.abonoInteres).toBe("15.00");
+    expect(cube.abonoInteres).toBe(15);
     expect(cube.emiteFactura).toBe(true);
   });
 
@@ -606,7 +606,7 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
     expect(out).toHaveLength(1);
     const cube = out.find((r: any) => r.inversionistaId === 86)!;
     expect(cube).toBeDefined();
-    expect(cube.abonoInteres).toBe("20.00");
+    expect(cube.abonoInteres).toBe(20);
   });
 
   it("caso 4: sin desglose (fallback) → devuelve pci tal cual, sin cambios", () => {
@@ -725,8 +725,8 @@ describe("armarInversionistasPago (interés CUBE del desglose)", () => {
 
     // CUBE sigue saliendo del desglose (net 65.20), como antes.
     const cube = out.find((r: any) => r.inversionistaId === 86)!;
-    expect(cube.abonoInteres).toBe("65.20");
-    expect(cube.abonoIva).toBe("7.83");
+    expect(cube.abonoInteres).toBe(65.2);
+    expect(cube.abonoIva).toBe(7.83);
   });
 
   it("caso 8 (sim): si YA hay filas pci, el reparto real manda y no se simula", () => {

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1937,17 +1937,23 @@ export function armarInversionistasPago(args: {
   // no estaba en pci tampoco se agrega fila vacía.
   if (cubeNet.abs().lte(new Big("0.005")) && !pciCube) return noCube;
 
+  // ⚠️ NUMBERS, no strings: el modal del front (modalViewInvestor) hace
+  // .toFixed() sobre estos campos — un string o null lo revienta con
+  // "toFixed is not a function" y deja la página en blanco.
+  const aNumero = (v: string | number | null | undefined): number | null =>
+    v == null || v === "" ? null : Number(v);
+
   const cubeRow: ReportInvRow = {
     inversionistaId: args.cubeId,
     nombreInversionista: pciCube?.nombreInversionista ?? args.cubeMeta?.nombreInversionista ?? "Cube Investments S.A.",
     emiteFactura: pciCube?.emiteFactura ?? args.cubeMeta?.emiteFactura ?? false,
-    abonoCapital: pciCube?.abonoCapital ?? "0",
-    abonoInteres: cubeNet.round(2).toFixed(2),
-    abonoIva: cubeIva.round(2).toFixed(2),
-    isr: cubeNet.times("0.05").round(2).toFixed(2),
+    abonoCapital: aNumero(pciCube?.abonoCapital) ?? 0,
+    abonoInteres: Number(cubeNet.round(2).toFixed(2)),
+    abonoIva: Number(cubeIva.round(2).toFixed(2)),
+    isr: Number(cubeNet.times("0.05").round(2).toFixed(2)),
     cuotaPago: pciCube?.cuotaPago ?? (args.cuota ?? "0"),
-    montoAportado: pciCube?.montoAportado ?? args.cubeMeta?.montoAportado ?? null,
-    porcentajeParticipacion: pciCube?.porcentajeParticipacion ?? args.cubeMeta?.porcentajeParticipacion ?? null,
+    montoAportado: aNumero(pciCube?.montoAportado ?? args.cubeMeta?.montoAportado),
+    porcentajeParticipacion: aNumero(pciCube?.porcentajeParticipacion ?? args.cubeMeta?.porcentajeParticipacion),
   };
   return [...noCube, cubeRow];
 }

--- a/apps/carteraFront/src/private/cartera/components/modalViewInvestor.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalViewInvestor.tsx
@@ -10,6 +10,12 @@ interface ModalInversionistasProps {
   inversionistas: InversionistaPago[];
 }
 
+// El API puede devolver estos montos como number, string (filas sintéticas /
+// respuestas viejas) o null (montoAportado sin creditos_inversionistas):
+// convertir SIEMPRE antes de .toFixed para no reventar el modal.
+const monto = (v: number | string | null | undefined): string =>
+  v == null || v === "" || isNaN(Number(v)) ? "--" : Number(v).toFixed(2);
+
 export function ModalInversionistas({ open, onClose, inversionistas }: ModalInversionistasProps) {
   return (
     <Dialog open={open} onOpenChange={onClose}>
@@ -24,23 +30,23 @@ export function ModalInversionistas({ open, onClose, inversionistas }: ModalInve
               <div className="grid grid-cols-2 gap-3 mt-2 text-sm text-blue-900">
                 <div className="flex items-center gap-2">
                   <BadgeDollarSign className="w-4 h-4 text-green-700" /> Abono Capital:{" "}
-                  <span className="font-semibold">{inv.abonoCapital.toFixed(2)}</span>
+                  <span className="font-semibold">{monto(inv.abonoCapital)}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <BadgeDollarSign className="w-4 h-4 text-indigo-700" /> Abono Interés:{" "}
-                  <span className="font-semibold">{inv.abonoInteres.toFixed(2)}</span>
+                  <span className="font-semibold">{monto(inv.abonoInteres)}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <BadgeDollarSign className="w-4 h-4 text-yellow-700" /> Abono IVA:{" "}
-                  <span className="font-semibold">{inv.abonoIva.toFixed(2)}</span>
+                  <span className="font-semibold">{monto(inv.abonoIva)}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Info className="w-4 h-4 text-blue-700" /> ISR (5%):{" "}
-                  <span className="font-semibold">{inv.isr.toFixed(2)}</span>
+                  <span className="font-semibold">{monto(inv.isr)}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <BadgeDollarSign className="w-4 h-4 text-blue-800" /> Monto Aportado:{" "}
-                  <span className="font-semibold">{inv.montoAportado.toFixed(2)}</span>
+                  <span className="font-semibold">{monto(inv.montoAportado)}</span>
                 </div>
                 <div className="flex items-center gap-2">
                   <Percent className="w-4 h-4 text-blue-600" /> % Participación:{" "}


### PR DESCRIPTION
## Problema (prod)

Al dar **"Ver Inversionistas"** en un pago, la página queda en blanco:

```
Uncaught TypeError: inv.abonoCapital.toFixed is not a function
  at modalViewInvestor.tsx:27
```

**Causa:** la fila sintética de CUBE que `armarInversionistasPago` construye desde el desglose (código previo al PR #1137) emite **strings** (`"0"`, `.toFixed(2)`) y su `montoAportado` puede venir string o **null**, mientras el modal hace `.toFixed(2)` sin defensa sobre cinco campos. El crash era pre-existente, pero el #1137 lo expuso: ahora muchos más pagos (los parciales) muestran inversionistas e invitan al click.

## Solución (doble capa)

1. **Back:** la fila de CUBE emite **numbers** — misma convención que las filas simuladas y que el pci real vía `json_build_object`.
2. **Front:** el modal convierte defensivamente (`Number()`, `"--"` para null) — ningún string/null futuro vuelve a tirar la página, incluso con respuestas viejas cacheadas.

## Pruebas

- 19 tests pasan (aserciones de la fila CUBE actualizadas a numbers)
- Typecheck limpio en back y front

🤖 Generated with [Claude Code](https://claude.com/claude-code)