### PR TITLE
feat(crm): capturar respuestas de formularios de captación de leads (Meta Instant Forms)

### DIFF
--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -1,4 +1,4 @@
-import { and, asc, count, eq, or } from "drizzle-orm";
+import { and, asc, count, eq, or, sql } from "drizzle-orm";
 import type { Context } from "hono";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
@@ -8,6 +8,7 @@ import {
 	opportunities,
 	salesStages,
 } from "../db/schema/crm";
+import { leadIntakeAnswers } from "../db/schema/lead-intake";
 import {
 	findSalesUserWithLeastAutoAssignedLeads,
 	resolveExistingLeadAssigneeFromDatabase,
@@ -18,6 +19,134 @@ import { validarDpi } from "../utils/cui-validation";
 import { getOnlyRenapInfoController } from "./bot";
 
 type LeadSource = (typeof leadSourceEnum.enumValues)[number];
+
+/**
+ * Valida que la solicitud venga con el secreto compartido configurado para integraciones
+ * externas (ej. Make) vía header "Authorization: Bearer <secret>".
+ */
+export async function validatePublicLeadToken(
+	c: Context,
+	next: () => Promise<void>,
+) {
+	const secret = process.env.BETTER_SECRET_PUBLIC_LEAD;
+
+	if (!secret) {
+		console.error("[ERROR] BETTER_SECRET_PUBLIC_LEAD not configured");
+		return c.json(
+			{ success: false, error: "Configuración de autorización no disponible" },
+			500,
+		);
+	}
+
+	const authHeader = c.req.header("Authorization");
+
+	if (authHeader !== `Bearer ${secret}`) {
+		return c.json(
+			{ success: false, error: "No autorizado" },
+			401,
+		);
+	}
+
+	await next();
+}
+
+type IntakeAnswer = { fieldKey: string; fieldValue?: string | null };
+
+// Campos/valores válidos por formulario (campaignFormKey) — única barrera de validación,
+// ya que la tabla es llave-valor sin tipos. Reutiliza un fieldKey entre formularios solo si
+// es el mismo concepto; si no, dale uno propio. Rangos de presupuesto/ingreso son
+// provisionales hasta confirmar las opciones reales del formulario de Meta.
+const INTAKE_FORM_FIELDS: Record<string, Record<string, string[]>> = {
+	credito_filtro_julio2026: {
+		vehicle_condition: ["nuevo", "usado", "no_seguro"],
+		budget_range: [
+			"Menos de Q30,000",
+			"Q30,000 - Q50,000",
+			"Q50,000 - Q80,000",
+			"Q80,000 - Q120,000",
+			"Q120,000 - Q180,000",
+			"Q180,000 o más",
+		],
+		income_range: [
+			"Menos de Q4,000",
+			"Q4,000 - Q6,000",
+			"Q6,000 - Q8,000",
+			"Q8,000 - Q12,000",
+			"Q12,000 - Q18,000",
+			"Q18,000 o más",
+		],
+	},
+};
+
+export function validateIntakeAnswers(
+	campaignFormKey: string,
+	answers: IntakeAnswer[],
+): string | null {
+	const allowedFields = INTAKE_FORM_FIELDS[campaignFormKey];
+
+	if (!allowedFields) {
+		return `campaignFormKey no reconocido: ${campaignFormKey}`;
+	}
+
+	for (const answer of answers) {
+		const allowedValues = allowedFields[answer.fieldKey];
+
+		if (!allowedValues) {
+			return `El campo "${answer.fieldKey}" no pertenece al formulario "${campaignFormKey}"`;
+		}
+
+		if (answer.fieldValue && !allowedValues.includes(answer.fieldValue)) {
+			return `Valor no válido para ${answer.fieldKey}: ${answer.fieldValue}`;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Guarda las respuestas de un formulario de captación (ej. Meta Instant Forms) en formato
+ * llave-valor, sin requerir migración cuando se agregue una pregunta nueva al formulario.
+ * campaignFormKey identifica de qué campaña/formulario vienen, para que dos formularios
+ * distintos puedan reusar el mismo fieldKey sin pisarse entre sí.
+ */
+async function upsertIntakeAnswers(
+	leadId: string,
+	campaignFormKey: string,
+	answers: IntakeAnswer[],
+) {
+	if (!campaignFormKey || !Array.isArray(answers) || answers.length === 0) {
+		return;
+	}
+
+	const rows = answers
+		.filter((a) => a && a.fieldKey)
+		.map((a) => ({
+			leadId,
+			campaignFormKey,
+			fieldKey: a.fieldKey,
+			fieldValue: a.fieldValue ?? null,
+		}));
+
+	if (rows.length === 0) return;
+
+	// Todo o nada: las respuestas de un mismo envío se guardan juntas o ninguna se guarda.
+	await db.transaction(async (tx) => {
+		await tx
+			.insert(leadIntakeAnswers)
+			.values(rows)
+			.onConflictDoUpdate({
+				target: [
+					leadIntakeAnswers.leadId,
+					leadIntakeAnswers.campaignFormKey,
+					leadIntakeAnswers.fieldKey,
+				],
+				set: {
+					fieldValue: sql`excluded.field_value`,
+					updatedAt: new Date(),
+				},
+			});
+	});
+}
 
 /**
  * Encuentra al usuario de ventas con menos oportunidades asignadas.
@@ -151,6 +280,31 @@ export async function createPublicLead(c: Context) {
 			);
 		}
 
+		if (body.intakeAnswers) {
+			if (!Array.isArray(body.intakeAnswers)) {
+				return c.json(
+					{ success: false, error: "intakeAnswers debe ser un arreglo" },
+					400,
+				);
+			}
+			if (!body.campaignFormKey) {
+				return c.json(
+					{
+						success: false,
+						error: "campaignFormKey es requerido cuando se envían intakeAnswers",
+					},
+					400,
+				);
+			}
+			const intakeError = validateIntakeAnswers(
+				body.campaignFormKey,
+				body.intakeAnswers,
+			);
+			if (intakeError) {
+				return c.json({ success: false, error: intakeError }, 400);
+			}
+		}
+
 		const creditType = body.creditType || "autocompra";
 		const hasDpi = !!(body.dpi && body.dpi.trim() !== "");
 
@@ -183,6 +337,14 @@ export async function createPublicLead(c: Context) {
 				return c.json(
 					{ success: true, data: existingLead, message: "Lead ya existe" },
 					200,
+				);
+			}
+
+			if (body.campaignFormKey && body.intakeAnswers) {
+				await upsertIntakeAnswers(
+					existingLead.id,
+					body.campaignFormKey,
+					body.intakeAnswers,
 				);
 			}
 
@@ -353,6 +515,14 @@ export async function createPublicLead(c: Context) {
 				updatedAt: new Date(),
 			})
 			.returning();
+
+		if (body.campaignFormKey && body.intakeAnswers) {
+			await upsertIntakeAnswers(
+				newLead.id,
+				body.campaignFormKey,
+				body.intakeAnswers,
+			);
+		}
 
 		// RENAP solo si tiene DPI y teléfono
 		const renapInfo = hasDpi

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -20,30 +20,95 @@ import { getOnlyRenapInfoController } from "./bot";
 
 type LeadSource = (typeof leadSourceEnum.enumValues)[number];
 
+// Rate limit en memoria por IP para leads públicos sin token. No sobrevive restart ni
+// escala entre instancias, pero basta para frenar abuso casual.
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+const RATE_LIMIT_CLEANUP_EVERY_N_CALLS = 500;
+const rateLimitBuckets = new Map<string, { count: number; windowStart: number }>();
+let rateLimitCallCount = 0;
+
+function cleanupExpiredBuckets() {
+	const now = Date.now();
+	for (const [ip, bucket] of rateLimitBuckets) {
+		if (now - bucket.windowStart > RATE_LIMIT_WINDOW_MS) {
+			rateLimitBuckets.delete(ip);
+		}
+	}
+}
+
+function isRateLimited(ip: string): boolean {
+	rateLimitCallCount += 1;
+	if (rateLimitCallCount % RATE_LIMIT_CLEANUP_EVERY_N_CALLS === 0) {
+		cleanupExpiredBuckets();
+	}
+
+	const now = Date.now();
+	const bucket = rateLimitBuckets.get(ip);
+
+	if (!bucket || now - bucket.windowStart > RATE_LIMIT_WINDOW_MS) {
+		rateLimitBuckets.set(ip, { count: 1, windowStart: now });
+		return false;
+	}
+
+	bucket.count += 1;
+	return bucket.count > RATE_LIMIT_MAX_REQUESTS;
+}
+
+function getClientIp(c: Context): string {
+	return (
+		c.req.header("cf-connecting-ip") ||
+		c.req.header("x-forwarded-for") ||
+		"unknown"
+	);
+}
+
 /**
- * Valida que la solicitud venga con el secreto compartido configurado para integraciones
- * externas (ej. Make) vía header "Authorization: Bearer <secret>".
+ * Creación básica de lead: pública, solo con rate limit por IP (comportamiento de siempre).
+ * campaignFormKey/intakeAnswers (Make) sí exige "Authorization: Bearer <secret>".
  */
 export async function validatePublicLeadToken(
 	c: Context,
 	next: () => Promise<void>,
 ) {
-	const secret = process.env.BETTER_SECRET_PUBLIC_LEAD;
+	const authHeader = c.req.header("Authorization");
 
-	if (!secret) {
-		console.error("[ERROR] BETTER_SECRET_PUBLIC_LEAD not configured");
+	if (authHeader) {
+		const secret = process.env.BETTER_SECRET_PUBLIC_LEAD;
+
+		if (!secret) {
+			console.error("[ERROR] BETTER_SECRET_PUBLIC_LEAD not configured");
+			return c.json(
+				{ success: false, error: "Configuración de autorización no disponible" },
+				500,
+			);
+		}
+
+		if (authHeader !== `Bearer ${secret}`) {
+			return c.json({ success: false, error: "No autorizado" }, 401);
+		}
+
+		await next();
+		return;
+	}
+
+	const body = await c.req.json().catch(() => null);
+	const hasBody = typeof body === "object" && body !== null;
+
+	if (hasBody && body.intakeAnswers) {
 		return c.json(
-			{ success: false, error: "Configuración de autorización no disponible" },
-			500,
+			{
+				success: false,
+				error: "Se requiere autenticación para enviar datos de formulario de captación",
+			},
+			401,
 		);
 	}
 
-	const authHeader = c.req.header("Authorization");
-
-	if (authHeader !== `Bearer ${secret}`) {
+	if (isRateLimited(getClientIp(c))) {
 		return c.json(
-			{ success: false, error: "No autorizado" },
-			401,
+			{ success: false, error: "Demasiadas solicitudes, intenta más tarde" },
+			429,
 		);
 	}
 

--- a/apps/crm/apps/server/src/controllers/public-lead.ts
+++ b/apps/crm/apps/server/src/controllers/public-lead.ts
@@ -64,7 +64,8 @@ function getClientIp(c: Context): string {
 }
 
 /**
- * Creación básica de lead: pública, solo con rate limit por IP (comportamiento de siempre).
+ * Creación básica de lead: pública, solo para el origen de portal-web y con rate limit
+ * por IP (comportamiento de siempre, ahora con esa validación de dominio agregada).
  * campaignFormKey/intakeAnswers (Make) sí exige "Authorization: Bearer <secret>".
  */
 export async function validatePublicLeadToken(
@@ -103,6 +104,16 @@ export async function validatePublicLeadToken(
 			},
 			401,
 		);
+	}
+
+	const origin = c.req.header("origin") || "";
+	const isLocalDev =
+		origin.startsWith("http://localhost:") ||
+		origin.startsWith("http://127.0.0.1:");
+	const allowedOrigin = process.env.PORTAL_WEB_ORIGIN;
+
+	if (!isLocalDev && (!allowedOrigin || origin !== allowedOrigin)) {
+		return c.json({ success: false, error: "Origen no permitido" }, 403);
 	}
 
 	if (isRateLimited(getClientIp(c))) {

--- a/apps/crm/apps/server/src/db/migrations/0027_add_lead_intake_answers.sql
+++ b/apps/crm/apps/server/src/db/migrations/0027_add_lead_intake_answers.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "lead_intake_answers" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"lead_id" uuid NOT NULL,
+	"campaign_form_key" text NOT NULL,
+	"field_key" text NOT NULL,
+	"field_value" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);--> statement-breakpoint
+ALTER TABLE "lead_intake_answers" ADD CONSTRAINT "lead_intake_answers_lead_id_leads_id_fk" FOREIGN KEY ("lead_id") REFERENCES "public"."leads"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "lead_intake_answers_lead_form_field_unique" ON "lead_intake_answers" USING btree ("lead_id","campaign_form_key","field_key");

--- a/apps/crm/apps/server/src/db/schema/index.ts
+++ b/apps/crm/apps/server/src/db/schema/index.ts
@@ -12,6 +12,7 @@ export * from "./documents";
 export * from "./insurance";
 export * from "./investments";
 export * from "./juridico-dashboard";
+export * from "./lead-intake";
 export * from "./legal-contracts";
 export * from "./locations";
 export * from "./metas";

--- a/apps/crm/apps/server/src/db/schema/lead-intake.ts
+++ b/apps/crm/apps/server/src/db/schema/lead-intake.ts
@@ -1,0 +1,32 @@
+import {
+	pgTable,
+	text,
+	timestamp,
+	uniqueIndex,
+	uuid,
+} from "drizzle-orm/pg-core";
+import { leads } from "./crm";
+
+// Respuestas autodeclaradas de formularios de captación (ej. Meta Instant Forms),
+// modelo llave-valor para no requerir migración cuando marketing agregue una pregunta nueva.
+// campaignFormKey identifica de qué formulario/campaña viene cada respuesta, para que
+// dos formularios distintos puedan reusar el mismo fieldKey sin pisarse entre sí.
+export const leadIntakeAnswers = pgTable(
+	"lead_intake_answers",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		leadId: uuid("lead_id")
+			.notNull()
+			.references(() => leads.id, { onDelete: "cascade" }),
+		campaignFormKey: text("campaign_form_key").notNull(),
+		fieldKey: text("field_key").notNull(),
+		fieldValue: text("field_value"),
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => ({
+		leadFormFieldUnique: uniqueIndex(
+			"lead_intake_answers_lead_form_field_unique",
+		).on(table.leadId, table.campaignFormKey, table.fieldKey),
+	}),
+);

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -25,7 +25,10 @@ import {
 	updateLeadByEmail,
 	validatePortalToken,
 } from "./controllers/portal-lead";
-import { createPublicLead } from "./controllers/public-lead";
+import {
+	createPublicLead,
+	validatePublicLeadToken,
+} from "./controllers/public-lead";
 import {
 	getVehicleByCodigoController,
 	getVehiclesBySifcoController,
@@ -953,7 +956,7 @@ app.post("/api/notifications/pay-investors", async (c) => {
 });
 
 // REST endpoint for public lead creation (for external web forms)
-app.post("/api/public/lead", createPublicLead);
+app.post("/api/public/lead", validatePublicLeadToken, createPublicLead);
 
 // REST endpoint for investment lead creation (for external APIs)
 app.post("/api/public/investment-lead", async (c) => {

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -745,7 +745,26 @@ export const crmRouter = {
 	// Respuestas de formularios de captación (ej. Meta Instant Forms) guardadas en llave-valor
 	getLeadIntakeAnswers: crmProcedure
 		.input(z.object({ leadId: z.string().uuid() }))
-		.handler(async ({ input }) => {
+		.handler(async ({ input, context }) => {
+			const [lead] = await db
+				.select({ assignedTo: leads.assignedTo })
+				.from(leads)
+				.where(eq(leads.id, input.leadId))
+				.limit(1);
+
+			if (!lead) {
+				throw new ORPCError("NOT_FOUND", {
+					message: "Lead no encontrado",
+				});
+			}
+
+			// Sales users can only see their assigned leads
+			if (context.userRole === "sales" && lead.assignedTo !== context.userId) {
+				throw new ORPCError("FORBIDDEN", {
+					message: "No tienes permiso para ver este lead",
+				});
+			}
+
 			const answers = await db
 				.select({
 					campaignFormKey: leadIntakeAnswers.campaignFormKey,

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -41,6 +41,7 @@ import {
 	opportunityStageHistory,
 	salesStages,
 } from "../db/schema/crm";
+import { leadIntakeAnswers } from "../db/schema/lead-intake";
 import {
 	analysisChecklists,
 	disbursementChecklists,
@@ -739,6 +740,22 @@ export const crmRouter = {
 				limit,
 				offset,
 			};
+		}),
+
+	// Respuestas de formularios de captación (ej. Meta Instant Forms) guardadas en llave-valor
+	getLeadIntakeAnswers: crmProcedure
+		.input(z.object({ leadId: z.string().uuid() }))
+		.handler(async ({ input }) => {
+			const answers = await db
+				.select({
+					campaignFormKey: leadIntakeAnswers.campaignFormKey,
+					fieldKey: leadIntakeAnswers.fieldKey,
+					fieldValue: leadIntakeAnswers.fieldValue,
+				})
+				.from(leadIntakeAnswers)
+				.where(eq(leadIntakeAnswers.leadId, input.leadId));
+
+			return { data: answers };
 		}),
 
 	getLeadById: crmProcedure

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -40,6 +40,7 @@ export const crmAppRouter = {
 	updateCompany: crmRouter.updateCompany,
 	getLeads: crmRouter.getLeads,
 	getLeadById: crmRouter.getLeadById,
+	getLeadIntakeAnswers: crmRouter.getLeadIntakeAnswers,
 	getLeadsStats: crmRouter.getLeadsStats,
 	createLead: crmRouter.createLead,
 	updateLead: crmRouter.updateLead,

--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -25,6 +25,7 @@ import {
 	getOccupationLabel,
 	getSourceLabel,
 	getStatusLabel,
+	getVehicleConditionLabel,
 	getWorkTimeLabel,
 } from "@/lib/crm-formatters";
 import { client, orpc } from "@/utils/orpc";
@@ -119,6 +120,17 @@ export function LeadDetailModal({
 		}),
 		enabled: open && !!lead?.id,
 	});
+
+	// Respuestas de formulario de captación (llave-valor)
+	const intakeAnswersQuery = useQuery({
+		...orpc.getLeadIntakeAnswers.queryOptions({
+			input: { leadId: lead?.id ?? "" },
+		}),
+		enabled: open && !!lead?.id,
+	});
+	const intakeAnswers = new Map(
+		(intakeAnswersQuery.data?.data ?? []).map((a) => [a.fieldKey, a.fieldValue]),
+	);
 
 	const queryClient = useQueryClient();
 
@@ -444,6 +456,43 @@ export function LeadDetailModal({
 							</div>
 						</div>
 					</div>
+
+					{/* Intake Section - Datos autodeclarados en formulario de captación */}
+					{intakeAnswers.size > 0 && (
+						<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+							<h3 className="font-semibold text-base">Datos de Formulario</h3>
+							<div className="grid grid-cols-3 gap-4">
+								<div>
+									<Label className="font-medium text-muted-foreground text-sm">
+										Tipo de Vehículo
+									</Label>
+									<p className="text-sm">
+										{intakeAnswers.get("vehicle_condition")
+											? getVehicleConditionLabel(
+													intakeAnswers.get("vehicle_condition") as string,
+												)
+											: "No especificado"}
+									</p>
+								</div>
+								<div>
+									<Label className="font-medium text-muted-foreground text-sm">
+										Presupuesto (rango)
+									</Label>
+									<p className="text-sm">
+										{intakeAnswers.get("budget_range") || "No especificado"}
+									</p>
+								</div>
+								<div>
+									<Label className="font-medium text-muted-foreground text-sm">
+										Ingreso Mensual (rango)
+									</Label>
+									<p className="text-sm">
+										{intakeAnswers.get("income_range") || "No especificado"}
+									</p>
+								</div>
+							</div>
+						</div>
+					)}
 
 					{/* Location Section */}
 					{(displayLead.direccion ||

--- a/apps/crm/apps/web/src/lib/crm-formatters.ts
+++ b/apps/crm/apps/web/src/lib/crm-formatters.ts
@@ -121,6 +121,19 @@ export const getWorkTimeLabel = (time: string) => {
 	}
 };
 
+export const getVehicleConditionLabel = (condition: string) => {
+	switch (condition) {
+		case "nuevo":
+			return "Nuevo";
+		case "usado":
+			return "Usado";
+		case "no_seguro":
+			return "No está seguro";
+		default:
+			return condition;
+	}
+};
+
 export const getClientTypeLabel = (clientType: string) => {
 	switch (clientType) {
 		case "individual":

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -85,6 +85,7 @@ import {
 	getOccupationLabel,
 	getSourceLabel,
 	getStatusLabel,
+	getVehicleConditionLabel,
 	getWorkTimeLabel,
 	LEAD_SOURCE_OPTIONS,
 } from "@/lib/crm-formatters";
@@ -283,6 +284,18 @@ function RouteComponent() {
 			: () => Promise.resolve(null),
 		enabled: !!selectedLead?.id && isDetailsDialogOpen,
 	});
+
+	// Respuestas de formulario de captación (llave-valor)
+	const intakeAnswersQuery = useQuery({
+		queryKey: ["getLeadIntakeAnswers", selectedLead?.id],
+		queryFn: selectedLead?.id
+			? () => client.getLeadIntakeAnswers({ leadId: selectedLead.id })
+			: () => Promise.resolve({ data: [] }),
+		enabled: !!selectedLead?.id && isDetailsDialogOpen,
+	});
+	const intakeAnswers = new Map(
+		(intakeAnswersQuery.data?.data ?? []).map((a) => [a.fieldKey, a.fieldValue]),
+	);
 
 	// Query para obtener las oportunidades del lead
 	const leadOpportunitiesQuery = useQuery({
@@ -2485,6 +2498,43 @@ function RouteComponent() {
 									</div>
 								</div>
 							</div>
+
+							{/* Intake Section - Datos autodeclarados en formulario de captación */}
+							{intakeAnswers.size > 0 && (
+								<div className="space-y-3 rounded-lg border bg-muted/30 p-4">
+									<h3 className="font-semibold text-base">Datos de Formulario</h3>
+									<div className="grid grid-cols-3 gap-4">
+										<div>
+											<Label className="font-medium text-muted-foreground text-sm">
+												Tipo de Vehículo
+											</Label>
+											<p className="text-sm">
+												{intakeAnswers.get("vehicle_condition")
+													? getVehicleConditionLabel(
+															intakeAnswers.get("vehicle_condition") as string,
+														)
+													: "No especificado"}
+											</p>
+										</div>
+										<div>
+											<Label className="font-medium text-muted-foreground text-sm">
+												Presupuesto (rango)
+											</Label>
+											<p className="text-sm">
+												{intakeAnswers.get("budget_range") || "No especificado"}
+											</p>
+										</div>
+										<div>
+											<Label className="font-medium text-muted-foreground text-sm">
+												Ingreso Mensual (rango)
+											</Label>
+											<p className="text-sm">
+												{intakeAnswers.get("income_range") || "No especificado"}
+											</p>
+										</div>
+									</div>
+								</div>
+							)}
 
 							{/* Bottom Section - Assets & Status */}
 							<div className="grid grid-cols-3 gap-6">


### PR DESCRIPTION
## Descripción

Se agrega soporte para recibir, en `/api/public/lead`, las respuestas de formularios de captación de Meta (Instant Forms) que traen preguntas adicionales a los datos de contacto — inicialmente para el formulario "Credito Filtro" (tipo de vehículo, presupuesto y ingreso mensual en rangos).

**Modelo de datos:** tabla nueva `lead_intake_answers` (llave-valor: `lead_id`, `campaign_form_key`, `field_key`, `field_value`), separada de `leads`, para no ensuciar esa tabla con campos que no aplican a todos los leads y para no requerir una migración cada vez que se agregue una pregunta nueva a un formulario. `campaign_form_key` identifica a qué formulario pertenece cada respuesta, para que dos formularios distintos puedan reutilizar el mismo nombre de campo sin pisarse entre sí.

**Endpoint (`/api/public/lead`):**
- Acepta `campaignFormKey` + `intakeAnswers: [{fieldKey, fieldValue}]` de forma genérica.
- Valida cada respuesta contra un catálogo (`INTAKE_FORM_FIELDS`) de campos y valores permitidos por formulario — única barrera de validación posible ya que la tabla es llave-valor sin tipos a nivel de base de datos.
- El insert de las respuestas es transaccional y usa upsert (`ON CONFLICT`), así un reenvío del mismo formulario actualiza solo el campo que cambió sin duplicar filas.
- La creación básica de un lead (nombre, email, teléfono) sigue siendo pública, protegida con rate limiting por IP — los formularios existentes (ej. portal-web) no requieren ningún cambio. Enviar `campaignFormKey`/`intakeAnswers` sí exige autenticación (`Authorization: Bearer <secret>`, variable `BETTER_SECRET_PUBLIC_LEAD`), por ser la capacidad nueva exclusiva de la integración con Make.
- Además del rate limit, la ruta sin token también valida que el request venga del origen configurado en `PORTAL_WEB_ORIGIN` (con excepción de `localhost` para desarrollo).

**UI:** se muestra una sección "Datos de Formulario" (oculta si el lead no tiene respuestas) en las dos vistas donde se ve el detalle de un lead — la vista principal de Gestión de Leads (`/crm/leads`) y el modal compartido usado en Jurídico y Análisis de crédito — vía un procedure nuevo `getLeadIntakeAnswers`, que respeta la misma restricción de acceso que el resto de endpoints de lead (los usuarios de ventas solo ven las respuestas de sus leads asignados).

## Pruebas

Se probó de dos formas: (1) escenarios automatizados contra el servidor local apuntando a la base de DEV, (2) confirmación manual desde Make con un formulario de Facebook real.

| # | Escenario | Esperado | Resultado |
|---|---|---|---|
| 1 | Token válido + los 3 `intakeAnswers` válidos | 200, lead + 3 respuestas creadas | ✅ |
| 2 | Token incorrecto | 401 | ✅ |
| 3 | `campaignFormKey` no reconocido | 400, nada se inserta | ✅ |
| 4 | `fieldKey` no reconocido (typo) | 400, nada se inserta | ✅ |
| 5 | `fieldValue` fuera de las opciones permitidas | 400, nada se inserta | ✅ |
| 6 | `intakeAnswers` sin `campaignFormKey` | 400 | ✅ |
| 7 | Lead normal sin datos de captación (compatibilidad hacia atrás) | 200, lead creado, 0 respuestas | ✅ |
| 8 | Reenvío del mismo lead con un valor distinto | 200 ambas veces, upsert sin duplicar fila | ✅ |
| 9 | Sin token, con `campaignFormKey` pero sin `intakeAnswers` | 200, lead creado, sin escribir en `lead_intake_answers` | ✅ |
| 10 | Sin token, con `intakeAnswers` | 401 | ✅ |
| 11 | 6ª solicitud sin token desde la misma IP en menos de 1 minuto | 429 | ✅ |
| — | Prueba manual desde Make (formulario real de Facebook) | Flujo correcto acepta, `fieldKey` inválido y sin token se rechazan | ✅ |

## Cosas pendientes

1. **Rangos reales de `budget_range`/`income_range`** — hoy son 6 valores provisionales por campo en `INTAKE_FORM_FIELDS`, pendientes de que se confirmen las opciones exactas del formulario en Meta.
2. **Falta correr las pruebas automatizadas de la validación de origen (`PORTAL_WEB_ORIGIN`)** recién agregada — todavía no se verificó end-to-end.

Se sube en draft para evaluar (tabla dinámica + validación por formulario).