### PR TITLE
feat(cobros): CRM server — Promesa de Pago atada a rango de cuotas + mora (CB-020)

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0026_cb020_promesa_pago_cuotas.sql
+++ b/apps/crm/apps/server/src/db/migrations/0026_cb020_promesa_pago_cuotas.sql
@@ -1,0 +1,52 @@
+-- 0026: CB-020 — Promesa de Pago atada a rango de cuotas + mora del crédito.
+-- Espejo exacto del schema drizzle `src/db/schema/cobros.ts` (contactosCobros).
+-- Idempotente: seguro de re-correr. Aplicar A MANO (no drizzle-kit push/migrate
+-- corrido desde este trabajo — mismo criterio que 0025_create_recordatorios_premora.sql).
+--
+-- Diseño acordado con Daniel Rodríguez: cartera-back NO separa la mora por
+-- cuota (moras_credito es un monto AGREGADO del crédito completo, no por
+-- cuota individual) — por eso incluye_mora es independiente de cuota_inicio/
+-- cuota_fin: puede haber rango sin mora, mora sin rango ("solo mora", caso
+-- confirmado por Daniel), o ambos.
+--
+-- estado_promesa: solo aplica a filas con estado_contacto = 'promesa_pago'.
+-- Se deriva verificando cuota_inicio..cuota_fin (pagado=true en cartera-back)
+-- y/o la mora activa del crédito (moras_credito.activa) — nunca se marca a
+-- mano; ver getEstadoPromesasPago en routers/cobros.ts.
+
+DO $$ BEGIN
+  CREATE TYPE public.estado_promesa AS ENUM ('pendiente', 'cumplida', 'incumplida');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE public.contactos_cobros
+  ADD COLUMN IF NOT EXISTS cuota_inicio integer;
+
+ALTER TABLE public.contactos_cobros
+  ADD COLUMN IF NOT EXISTS cuota_fin integer;
+
+ALTER TABLE public.contactos_cobros
+  ADD COLUMN IF NOT EXISTS incluye_mora boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.contactos_cobros
+  ADD COLUMN IF NOT EXISTS estado_promesa public.estado_promesa;
+
+-- CHECK de rango (review): la validación de "cuota_inicio > 0, cuota_fin >=
+-- cuota_inicio" solo vivía en Zod (app layer) — un INSERT/UPDATE por SQL
+-- directo o un bug futuro en el código podía dejar un rango invertido o
+-- negativo sin que la DB lo impida. NULL en cualquiera de las dos (o ambas,
+-- "solo mora" sin rango) sigue permitido — el CHECK solo exige coherencia
+-- cuando el rango SÍ está presente.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'contactos_cobros_cuota_rango_check'
+  ) THEN
+    ALTER TABLE public.contactos_cobros
+      ADD CONSTRAINT contactos_cobros_cuota_rango_check
+      CHECK (
+        cuota_inicio IS NULL
+        OR cuota_fin IS NULL
+        OR (cuota_inicio > 0 AND cuota_fin >= cuota_inicio)
+      );
+  END IF;
+END $$;

--- a/apps/crm/apps/server/src/db/migrations/0026_cb020_promesa_pago_cuotas.sql
+++ b/apps/crm/apps/server/src/db/migrations/0026_cb020_promesa_pago_cuotas.sql
@@ -30,12 +30,36 @@ ALTER TABLE public.contactos_cobros
 ALTER TABLE public.contactos_cobros
   ADD COLUMN IF NOT EXISTS estado_promesa public.estado_promesa;
 
--- CHECK de rango (review): la validación de "cuota_inicio > 0, cuota_fin >=
--- cuota_inicio" solo vivía en Zod (app layer) — un INSERT/UPDATE por SQL
--- directo o un bug futuro en el código podía dejar un rango invertido o
--- negativo sin que la DB lo impida. NULL en cualquiera de las dos (o ambas,
--- "solo mora" sin rango) sigue permitido — el CHECK solo exige coherencia
--- cuando el rango SÍ está presente.
+-- CHECK de rango (review Codex, ronda 2): la primera versión de este CHECK
+-- solo exigía coherencia CUANDO ambos bounds estaban presentes (OR cuota_fin
+-- IS NULL escapaba el chequeo) — dejaba pasar cuota_inicio=5, cuota_fin=NULL
+-- (bound parcial). Mismo hueco que ya se cerró en Zod (createContactoCobros,
+-- .refine "ambos o ninguno"): con el rango a medias, evaluarPromesa trata
+-- cuota_fin=NULL como "sin rango, no bloquea" — la cuota que el usuario SÍ
+-- especificó nunca se verifica. AMBOS bounds o NINGUNO, siempre — sin escape
+-- por un solo NULL. NULL/NULL ("solo mora" o el caso vacío del web viejo,
+-- previo al PR de web) sigue permitido.
+--
+-- Diagnóstico previo (review Codex, ronda 3): si YA existen filas con bound
+-- parcial (por SQL directo previo, u otro origen no controlado por Zod), el
+-- ADD CONSTRAINT de abajo revienta con el error genérico de Postgres
+-- ("violates check constraint") sin decir CUÁLES filas — quien aplique esto
+-- a mano queda a ciegas. Verificado en dev al escribir esta migración: 0
+-- filas afectadas — pero el ambiente donde se corra puede diferir. Este
+-- bloque falla ANTES, con mensaje explícito y los ids a corregir.
+DO $$
+DECLARE
+  filas_afectadas text;
+BEGIN
+  SELECT string_agg(id::text, ', ') INTO filas_afectadas
+  FROM public.contactos_cobros
+  WHERE (cuota_inicio IS NULL) IS DISTINCT FROM (cuota_fin IS NULL);
+
+  IF filas_afectadas IS NOT NULL THEN
+    RAISE EXCEPTION 'contactos_cobros tiene filas con cuota_inicio/cuota_fin parcial (una NULL, la otra no) — el CHECK de abajo las rechazaría. Corregir a mano antes de aplicar esta migración. ids: %', filas_afectadas;
+  END IF;
+END $$;
+
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -44,9 +68,13 @@ BEGIN
     ALTER TABLE public.contactos_cobros
       ADD CONSTRAINT contactos_cobros_cuota_rango_check
       CHECK (
-        cuota_inicio IS NULL
-        OR cuota_fin IS NULL
-        OR (cuota_inicio > 0 AND cuota_fin >= cuota_inicio)
+        (cuota_inicio IS NULL AND cuota_fin IS NULL)
+        OR (
+          cuota_inicio IS NOT NULL
+          AND cuota_fin IS NOT NULL
+          AND cuota_inicio > 0
+          AND cuota_fin >= cuota_inicio
+        )
       );
   END IF;
 END $$;

--- a/apps/crm/apps/server/src/db/schema/cobros.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import {
 	boolean,
 	check,
@@ -10,7 +11,6 @@ import {
 	timestamp,
 	uuid,
 } from "drizzle-orm/pg-core";
-import { sql } from "drizzle-orm";
 import { user } from "./auth";
 import { clients } from "./crm";
 import { vehicles } from "./vehicles";
@@ -43,6 +43,16 @@ export const estadoContactoEnum = pgEnum("estado_contacto", [
 	"promesa_pago",
 	"acuerdo_parcial",
 	"rechaza_pagar",
+]);
+
+// CB-020: estado de cumplimiento de una promesa de pago (solo aplica a filas
+// con estadoContacto = 'promesa_pago'). Se deriva cruzando cuotaInicio/
+// cuotaFin/incluyeMora contra el estado real del crédito en cartera-back
+// (getEstadoPromesasPago) — nunca se marca a mano.
+export const estadoPromesaEnum = pgEnum("estado_promesa", [
+	"pendiente",
+	"cumplida",
+	"incumplida",
 ]);
 
 export const tipoRecuperacionEnum = pgEnum("tipo_recuperacion", [
@@ -199,6 +209,17 @@ export const contactosCobros = pgTable(
 		acuerdosAlcanzados: text("acuerdos_alcanzados"),
 		compromisosPago: text("compromisos_pago"),
 
+		// CB-020: promesa de pago atada a cuotas concretas (no a una fecha
+		// genérica) — solo aplican cuando estadoContacto = 'promesa_pago'.
+		// cartera-back NO separa la mora por cuota (es un monto agregado del
+		// crédito, ver moras_credito), por eso incluyeMora es independiente del
+		// rango: puede haber rango sin mora, mora sin rango ("solo mora"), o
+		// ambos. Ver getEstadoPromesasPago para la verificación.
+		cuotaInicio: integer("cuota_inicio"),
+		cuotaFin: integer("cuota_fin"),
+		incluyeMora: boolean("incluye_mora").notNull().default(false),
+		estadoPromesa: estadoPromesaEnum("estado_promesa"),
+
 		// Próximo seguimiento
 		requiereSeguimiento: boolean("requiere_seguimiento").default(false),
 		fechaProximoContacto: timestamp("fecha_proximo_contacto"),
@@ -341,24 +362,30 @@ export const metasMoraCobros = pgTable("metas_mora_cobros", {
 });
 
 // Seguimientos programados recurrentes para casos de cobros
-export const seguimientosProgramados = pgTable("seguimientos_programados", {
-	id: uuid("id").primaryKey().defaultRandom(),
-	casoCobroId: uuid("caso_cobro_id")
-		.notNull()
-		.references(() => casosCobros.id, { onDelete: "cascade" }),
-	agenteId: text("agente_id")
-		.notNull()
-		.references(() => user.id),
-	metodoContacto: metodoContactoEnum("metodo_contacto").notNull(),
-	intervaloDias: integer("intervalo_dias").notNull(),
-	ocurrenciasMaximas: integer("ocurrencias_maximas"),
-	ocurrenciasRealizadas: integer("ocurrencias_realizadas").notNull().default(0),
-	fechaInicio: timestamp("fecha_inicio").notNull(),
-	fechaFin: timestamp("fecha_fin"),
-	presetOriginal: text("preset_original"),
-	activo: boolean("activo").default(true),
-	createdAt: timestamp("created_at").notNull().defaultNow(),
-	updatedAt: timestamp("updated_at").notNull().defaultNow(),
-}, (table) => [
-	check("intervalo_dias_positive", sql`${table.intervaloDias} > 0`),
-]);
+export const seguimientosProgramados = pgTable(
+	"seguimientos_programados",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		casoCobroId: uuid("caso_cobro_id")
+			.notNull()
+			.references(() => casosCobros.id, { onDelete: "cascade" }),
+		agenteId: text("agente_id")
+			.notNull()
+			.references(() => user.id),
+		metodoContacto: metodoContactoEnum("metodo_contacto").notNull(),
+		intervaloDias: integer("intervalo_dias").notNull(),
+		ocurrenciasMaximas: integer("ocurrencias_maximas"),
+		ocurrenciasRealizadas: integer("ocurrencias_realizadas")
+			.notNull()
+			.default(0),
+		fechaInicio: timestamp("fecha_inicio").notNull(),
+		fechaFin: timestamp("fecha_fin"),
+		presetOriginal: text("preset_original"),
+		activo: boolean("activo").default(true),
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+	},
+	(table) => [
+		check("intervalo_dias_positive", sql`${table.intervaloDias} > 0`),
+	],
+);

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -49,6 +49,7 @@ import {
 } from "./routers/index";
 import { investmentsRouter } from "./routers/investments";
 import externalContractsRouter from "./routes/external-contracts";
+import { checkPromesasPago } from "./services/check-promesas-pago";
 import { sendPremoraReminders } from "./services/send-premora-reminders";
 
 const app = new Hono();
@@ -1275,6 +1276,7 @@ setTimeout(() => {
 	checkSeguimientosVencidos().catch(console.error);
 	checkCasosSinContacto(3).catch(console.error);
 	procesarSeguimientosRecurrentes().catch(console.error);
+	checkPromesasPago().catch(console.error);
 }, 10_000);
 
 // Recordatorios Premora (CC2-11): diario a las 8:00 GT (= 14:00 UTC, GT no
@@ -1297,6 +1299,9 @@ setTimeout(() => {
 }, 15_000);
 
 // Ejecutar procesarSeguimientosRecurrentes a medianoche GT (00:00 GT = 06:00 UTC) cada día.
+// CB-020: también cierra el día evaluando TODAS las promesas de pago activas
+// (pendiente/incumplida) sin depender de que alguien abra el caso — ver
+// check-promesas-pago.ts.
 function scheduleAtMidnightGT() {
 	const now = new Date();
 	const next = new Date();
@@ -1304,6 +1309,7 @@ function scheduleAtMidnightGT() {
 	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
 	setTimeout(async () => {
 		await procesarSeguimientosRecurrentes().catch(console.error);
+		await checkPromesasPago().catch(console.error);
 		scheduleAtMidnightGT();
 	}, next.getTime() - now.getTime());
 }

--- a/apps/crm/apps/server/src/lib/promesa-pago.test.ts
+++ b/apps/crm/apps/server/src/lib/promesa-pago.test.ts
@@ -220,7 +220,7 @@ describe("evaluarPromesa", () => {
 		expect(estado).toBe("cumplida");
 	});
 
-	test("fechaPrometida = hoy exacto (medianoche del día) → NO incumplida todavía (gracia del día)", () => {
+	test("fechaPrometida = hoy exacto (mismo instante) → NO incumplida todavía", () => {
 		const estadoCredito = derivarEstadoCredito(
 			creditoFixture({ cuotasPagadas: [] }),
 		);
@@ -236,6 +236,50 @@ describe("evaluarPromesa", () => {
 			hoy,
 		);
 		expect(estado).toBe("pendiente");
+	});
+
+	// Caso real que el test anterior NO cubría (comparaba mismo instante
+	// exacto) — el que Codex encontró en review: fechaPrometida es medianoche
+	// GT del día prometido, pero "hoy" durante ESE MISMO día ya tiene hora
+	// avanzada. Debe seguir "pendiente" durante todo el día prometido.
+	test("fechaPrometida = medianoche GT de HOY, hora actual avanzada el MISMO día → sigue pendiente (gracia real del día)", () => {
+		const medianochePrometida = new Date("2026-07-22T06:00:00.000Z"); // 00:00 GT
+		const mediodiaMismoDia = new Date("2026-07-22T18:00:00.000Z"); // 12:00 GT, mismo día
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({ cuotasPagadas: [] }),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 1,
+				incluyeMora: false,
+				fechaPrometida: medianochePrometida,
+			},
+			estadoCredito,
+			mediodiaMismoDia,
+		);
+		expect(estado).toBe("pendiente");
+	});
+
+	test("fechaPrometida = medianoche GT de AYER, hoy ya es el día siguiente → incumplida", () => {
+		const medianochePrometidaAyer = new Date("2026-07-22T06:00:00.000Z"); // 00:00 GT del 22
+		const hoySiguienteDia = new Date("2026-07-23T07:00:00.000Z"); // 01:00 GT del 23 — ya pasó
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({ cuotasPagadas: [] }),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 1,
+				incluyeMora: false,
+				fechaPrometida: medianochePrometidaAyer,
+			},
+			estadoCredito,
+			hoySiguienteDia,
+		);
+		expect(estado).toBe("incumplida");
 	});
 
 	test("cuota única (cuotaInicio === cuotaFin)", () => {

--- a/apps/crm/apps/server/src/lib/promesa-pago.test.ts
+++ b/apps/crm/apps/server/src/lib/promesa-pago.test.ts
@@ -99,6 +99,43 @@ describe("evaluarPromesa", () => {
 		expect(estado).toBe("cumplida");
 	});
 
+	// Fila legacy (creada antes del .refine() en createContactoCobros, o con
+	// columnas NULL por default sin backfill) — confirmado con datos reales
+	// en dev: filas con cuota_inicio/cuota_fin/incluye_mora en null/null/false.
+	// Sin rango y sin mora no hay NINGUNA obligación que verificar: no debe
+	// marcarse "cumplida" automática solo porque ambos chequeos "no aplican".
+	test("sin rango Y sin mora (fila legacy), fecha futura → pendiente, NUNCA cumplida automática", () => {
+		const estadoCredito = derivarEstadoCredito(creditoFixture({}));
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: null,
+				cuotaFin: null,
+				incluyeMora: false,
+				fechaPrometida: futuro,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("pendiente");
+	});
+
+	test("sin rango Y sin mora (fila legacy), fecha ya pasada → incumplida (no cumplida)", () => {
+		const estadoCredito = derivarEstadoCredito(creditoFixture({}));
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: null,
+				cuotaFin: null,
+				incluyeMora: false,
+				fechaPrometida: pasado,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("incumplida");
+	});
+
 	test("rango parcialmente pagado (falta 1 cuota), fecha futura → pendiente", () => {
 		const estadoCredito = derivarEstadoCredito(
 			creditoFixture({ cuotasPagadas: [cuotaPagada(1)] }),

--- a/apps/crm/apps/server/src/lib/promesa-pago.test.ts
+++ b/apps/crm/apps/server/src/lib/promesa-pago.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+import type { CreditoDirectoResponse } from "../types/cartera-back";
+import { derivarEstadoCredito, evaluarPromesa } from "./promesa-pago";
+
+/** Solo los campos que derivarEstadoCredito lee — el resto no importa aquí. */
+function creditoFixture(
+	overrides: Partial<
+		Pick<CreditoDirectoResponse, "cuotasPagadas" | "mora" | "moraActual">
+	>,
+): CreditoDirectoResponse {
+	return {
+		cuotasPagadas: [],
+		moraActual: "0",
+		mora: null,
+		...overrides,
+	} as CreditoDirectoResponse;
+}
+
+function cuotaPagada(numero_cuota: number) {
+	return { numero_cuota } as CreditoDirectoResponse["cuotasPagadas"][number];
+}
+
+describe("derivarEstadoCredito", () => {
+	test("mora null (dato real: no hay mora activa) → saldada", () => {
+		const { moraSaldada } = derivarEstadoCredito(
+			creditoFixture({ mora: null }),
+		);
+		expect(moraSaldada).toBe(true);
+	});
+
+	test("mora undefined (campo ausente, dato faltante) → NO saldada (fail-safe)", () => {
+		const credito = creditoFixture({ mora: undefined });
+		const { moraSaldada } = derivarEstadoCredito(credito);
+		expect(moraSaldada).toBe(false);
+	});
+
+	test("mora.activa=true con monto > 0 → NO saldada", () => {
+		const { moraSaldada } = derivarEstadoCredito(
+			creditoFixture({
+				mora: { activa: true } as CreditoDirectoResponse["mora"],
+				moraActual: "205.79",
+			}),
+		);
+		expect(moraSaldada).toBe(false);
+	});
+
+	test("mora.activa=true pero monto <= 0 → saldada", () => {
+		const { moraSaldada } = derivarEstadoCredito(
+			creditoFixture({
+				mora: { activa: true } as CreditoDirectoResponse["mora"],
+				moraActual: "0.00",
+			}),
+		);
+		expect(moraSaldada).toBe(true);
+	});
+
+	test("mora.activa=false → saldada sin importar el monto", () => {
+		const { moraSaldada } = derivarEstadoCredito(
+			creditoFixture({
+				mora: { activa: false } as CreditoDirectoResponse["mora"],
+				moraActual: "999",
+			}),
+		);
+		expect(moraSaldada).toBe(true);
+	});
+
+	test("cuotasPagadas se indexa por numero_cuota", () => {
+		const { cuotasPagadasSet } = derivarEstadoCredito(
+			creditoFixture({
+				cuotasPagadas: [cuotaPagada(1), cuotaPagada(2)],
+			}),
+		);
+		expect(cuotasPagadasSet.has(1)).toBe(true);
+		expect(cuotasPagadasSet.has(2)).toBe(true);
+		expect(cuotasPagadasSet.has(3)).toBe(false);
+	});
+});
+
+describe("evaluarPromesa", () => {
+	const hoy = new Date("2026-07-22T12:00:00Z");
+	const futuro = new Date("2026-07-31T06:00:00Z");
+	const pasado = new Date("2026-07-01T06:00:00Z");
+
+	test("rango completo pagado, sin mora → cumplida", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({ cuotasPagadas: [cuotaPagada(1), cuotaPagada(2)] }),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 2,
+				incluyeMora: false,
+				fechaPrometida: futuro,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("cumplida");
+	});
+
+	test("rango parcialmente pagado (falta 1 cuota), fecha futura → pendiente", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({ cuotasPagadas: [cuotaPagada(1)] }),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 2,
+				incluyeMora: false,
+				fechaPrometida: futuro,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("pendiente");
+	});
+
+	test("rango incompleto, fecha ya pasada → incumplida", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({ cuotasPagadas: [cuotaPagada(1)] }),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 2,
+				incluyeMora: false,
+				fechaPrometida: pasado,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("incumplida");
+	});
+
+	test("solo mora (sin rango): cuotas pagadas irrelevante, mora saldada → cumplida", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({
+				mora: { activa: false } as CreditoDirectoResponse["mora"],
+			}),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: null,
+				cuotaFin: null,
+				incluyeMora: true,
+				fechaPrometida: futuro,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("cumplida");
+	});
+
+	test("solo mora: mora sigue activa, fecha pasada → incumplida", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({
+				mora: { activa: true } as CreditoDirectoResponse["mora"],
+				moraActual: "50",
+			}),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: null,
+				cuotaFin: null,
+				incluyeMora: true,
+				fechaPrometida: pasado,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("incumplida");
+	});
+
+	test("rango pagado PERO mora activa con incluyeMora=true → NO cumplida (chequeo doble)", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({
+				cuotasPagadas: [cuotaPagada(1), cuotaPagada(2)],
+				mora: { activa: true } as CreditoDirectoResponse["mora"],
+				moraActual: "50",
+			}),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 2,
+				incluyeMora: true,
+				fechaPrometida: pasado,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("incumplida");
+	});
+
+	test("rango pagado, mora activa PERO incluyeMora=false → cumplida (mora no aplica)", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({
+				cuotasPagadas: [cuotaPagada(1), cuotaPagada(2)],
+				mora: { activa: true } as CreditoDirectoResponse["mora"],
+				moraActual: "50",
+			}),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 2,
+				incluyeMora: false,
+				fechaPrometida: pasado,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("cumplida");
+	});
+
+	test("fechaPrometida = hoy exacto (medianoche del día) → NO incumplida todavía (gracia del día)", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({ cuotasPagadas: [] }),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 1,
+				cuotaFin: 1,
+				incluyeMora: false,
+				fechaPrometida: hoy,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("pendiente");
+	});
+
+	test("cuota única (cuotaInicio === cuotaFin)", () => {
+		const estadoCredito = derivarEstadoCredito(
+			creditoFixture({ cuotasPagadas: [cuotaPagada(5)] }),
+		);
+		const estado = evaluarPromesa(
+			{
+				id: "p1",
+				cuotaInicio: 5,
+				cuotaFin: 5,
+				incluyeMora: false,
+				fechaPrometida: futuro,
+			},
+			estadoCredito,
+			hoy,
+		);
+		expect(estado).toBe("cumplida");
+	});
+});

--- a/apps/crm/apps/server/src/lib/promesa-pago.ts
+++ b/apps/crm/apps/server/src/lib/promesa-pago.ts
@@ -60,7 +60,18 @@ export function evaluarPromesa(
 
 	const moraOk = promesa.incluyeMora ? estadoCredito.moraSaldada : true;
 
-	if (rangoSaldado && moraOk) return "cumplida";
+	// Sin rango Y sin mora: la promesa no tiene ninguna obligación real que
+	// verificar. rangoSaldado y moraOk son "true" por defecto (rama "no
+	// aplica, no bloquea" de cada uno) — combinados, un AND vacío da
+	// "cumplida" automática sin haber comprobado nada. createContactoCobros
+	// ya rechaza esta combinación al CREAR (review Codex, fix anterior), pero
+	// no protege filas legacy ya existentes en DB (creadas antes de ese
+	// .refine(), o con columnas NULL por default sin backfill de la
+	// migración) — confirmado con datos reales: 2 filas en dev con
+	// cuota_inicio/cuota_fin/incluye_mora en null/null/false. Nunca "cumplida"
+	// automática en este caso — cae al chequeo de fecha como cualquier otra.
+	const tieneObligacion = tieneRango || promesa.incluyeMora;
+	if (tieneObligacion && rangoSaldado && moraOk) return "cumplida";
 	// fechaPrometida se guarda como MEDIANOCHE GT del día prometido (ver
 	// gtDateStrToDate: T06:00:00Z = 00:00 GT). Comparar `fechaPrometida < hoy`
 	// a secas (instante contra instante) daba gracia solo hasta la medianoche

--- a/apps/crm/apps/server/src/lib/promesa-pago.ts
+++ b/apps/crm/apps/server/src/lib/promesa-pago.ts
@@ -61,12 +61,19 @@ export function evaluarPromesa(
 	const moraOk = promesa.incluyeMora ? estadoCredito.moraSaldada : true;
 
 	if (rangoSaldado && moraOk) return "cumplida";
-	// fechaPrometida se guarda como medianoche del día prometido (ver
-	// $id.tsx/contacto-modal) — la comparación estricta `<` da gracia el DÍA
-	// COMPLETO de la promesa: solo pasa a incumplida a partir del día
-	// siguiente. Intencional: "prometió pagar hoy" no debe marcarse vencida
-	// mientras el día sigue corriendo (coincide con el criterio de la Cola
-	// del día, donde una promesa que vence HOY sigue vigente hasta medianoche).
-	if (promesa.fechaPrometida < hoy) return "incumplida";
+	// fechaPrometida se guarda como MEDIANOCHE GT del día prometido (ver
+	// gtDateStrToDate: T06:00:00Z = 00:00 GT). Comparar `fechaPrometida < hoy`
+	// a secas (instante contra instante) daba gracia solo hasta la medianoche
+	// GT, no el día completo: alguien abriendo el caso a mediodía del MISMO
+	// día prometido ya veía "incumplida" (bug real, encontrado en review de
+	// PR — el test que lo cubría comparaba fechaPrometida === hoy exacto, no
+	// el caso real de "mismo día, hora distinta"). El corte real es el
+	// SIGUIENTE día calendario: se suma 24h a fechaPrometida (ya normalizada
+	// a medianoche GT) para obtener la medianoche GT del día después — recién
+	// ahí, si `hoy` ya la pasó, cuenta como incumplida.
+	const finDeGraciaGT = new Date(
+		promesa.fechaPrometida.getTime() + 24 * 60 * 60 * 1000,
+	);
+	if (finDeGraciaGT <= hoy) return "incumplida";
 	return "pendiente";
 }

--- a/apps/crm/apps/server/src/lib/promesa-pago.ts
+++ b/apps/crm/apps/server/src/lib/promesa-pago.ts
@@ -1,0 +1,72 @@
+/**
+ * CB-020 — Evaluación de cumplimiento de Promesa de Pago (función pura, sin
+ * DB ni red). Usada tanto por el endpoint on-demand (getEstadoPromesasPago,
+ * dispara al abrir el caso) como por el job nocturno (check-promesas-pago.ts,
+ * recorre todas las promesas pendientes sin depender de que alguien abra la
+ * página) — una sola fuente de verdad para no divergir entre ambos.
+ *
+ * Dos chequeos INDEPENDIENTES (cartera-back NO separa la mora por cuota, es
+ * un monto agregado del crédito, no por cuota individual — ver moras_credito):
+ *  1. Rango de cuotas (cuotaInicio/cuotaFin) → TODAS deben estar pagado=true.
+ *  2. incluyeMora=true → la mora ACTIVA del crédito debe estar saldada.
+ */
+
+import type { CreditoDirectoResponse } from "../types/cartera-back";
+
+export type EstadoPromesa = "pendiente" | "cumplida" | "incumplida";
+
+export interface PromesaAEvaluar {
+	id: string;
+	cuotaInicio: number | null;
+	cuotaFin: number | null;
+	incluyeMora: boolean;
+	fechaPrometida: Date;
+}
+
+/**
+ * Set de cuotas pagadas + si la mora está saldada — derivado UNA vez por
+ * crédito.
+ *
+ * Falla-SEGURO, no falla-abierto: `mora` es `CarteraMoraCredito | null |
+ * undefined`. `null` es dato real ("cartera-back consultó y no hay mora
+ * activa") → SÍ cuenta como saldada. `undefined` (campo ausente del payload,
+ * típico de un bug de red/parseo) NO se asume saldada — evita marcar
+ * "cumplida" una promesa con incluyeMora cuando en realidad no sabemos el
+ * estado real.
+ */
+export function derivarEstadoCredito(credito: CreditoDirectoResponse) {
+	const cuotasPagadasSet = new Set(
+		(credito.cuotasPagadas ?? []).map((c) => c.numero_cuota),
+	);
+	const moraSaldada =
+		credito.mora === undefined
+			? false
+			: !credito.mora?.activa || Number(credito.moraActual || 0) <= 0;
+	return { cuotasPagadasSet, moraSaldada };
+}
+
+export function evaluarPromesa(
+	promesa: PromesaAEvaluar,
+	estadoCredito: ReturnType<typeof derivarEstadoCredito>,
+	hoy: Date = new Date(),
+): EstadoPromesa {
+	const tieneRango = promesa.cuotaInicio != null && promesa.cuotaFin != null;
+	const rangoSaldado = tieneRango
+		? Array.from(
+				{ length: promesa.cuotaFin! - promesa.cuotaInicio! + 1 },
+				(_, i) => promesa.cuotaInicio! + i,
+			).every((n) => estadoCredito.cuotasPagadasSet.has(n))
+		: true; // sin rango = no aplica este chequeo, no bloquea
+
+	const moraOk = promesa.incluyeMora ? estadoCredito.moraSaldada : true;
+
+	if (rangoSaldado && moraOk) return "cumplida";
+	// fechaPrometida se guarda como medianoche del día prometido (ver
+	// $id.tsx/contacto-modal) — la comparación estricta `<` da gracia el DÍA
+	// COMPLETO de la promesa: solo pasa a incumplida a partir del día
+	// siguiente. Intencional: "prometió pagar hoy" no debe marcarse vencida
+	// mientras el día sigue corriendo (coincide con el criterio de la Cola
+	// del día, donde una promesa que vence HOY sigue vigente hasta medianoche).
+	if (promesa.fechaPrometida < hoy) return "incumplida";
+	return "pendiente";
+}

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2100,17 +2100,29 @@ export const cobrosRouter = {
 					incluyeMora: contactosCobros.incluyeMora,
 					fechaProximoContacto: contactosCobros.fechaProximoContacto,
 					estadoContacto: contactosCobros.estadoContacto,
+					estadoPromesa: contactosCobros.estadoPromesa,
 					numeroCreditoSifco: casosCobros.numeroCreditoSifco,
 				})
 				.from(contactosCobros)
 				.innerJoin(casosCobros, eq(contactosCobros.casoCobroId, casosCobros.id))
 				.where(inArray(contactosCobros.id, input.promesaIds));
 
+			// "cumplida" es TERMINAL — mismo criterio que el job nocturno
+			// (check-promesas-pago.ts). Sin este filtro, re-abrir el caso
+			// re-evaluaba una promesa YA cumplida contra el estado ACTUAL del
+			// crédito: si esa promesa tenía incluyeMora=true y el crédito
+			// acumuló mora NUEVA después (de otra cuota, ajena a esta promesa),
+			// la promesa pasaba de "cumplida" a "pendiente"/"incumplida" sin que
+			// nada relacionado a ELLA hubiera cambiado — sobrescribía un
+			// resultado correcto y ya cerrado. El front (getHistorialContactos)
+			// ya cae a `promesa.estadoPromesa` (columna DB) cuando el id no
+			// viene en este resultado, así que excluirla aquí no pierde el dato.
 			const promesasValidas = filas.filter(
 				(f) =>
 					f.estadoContacto === "promesa_pago" &&
 					f.numeroCreditoSifco === input.numeroSifco &&
-					f.fechaProximoContacto != null,
+					f.fechaProximoContacto != null &&
+					f.estadoPromesa !== "cumplida",
 			);
 			if (promesasValidas.length === 0) return {};
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1355,17 +1355,25 @@ export const cobrosRouter = {
 					cuotaFin: z.number().int().positive().optional(),
 					incluyeMora: z.boolean().default(false),
 				})
-				.refine(
-					(v) =>
-						v.estadoContacto !== "promesa_pago" ||
-						(v.cuotaInicio != null && v.cuotaFin != null) ||
-						v.incluyeMora,
-					{
-						message:
-							"La promesa debe incluir un rango de cuotas o marcar que incluye mora",
-						path: ["cuotaInicio"],
-					},
-				)
+				// ⚠️ DEUDA TÉCNICA TEMPORAL (review Codex, ronda 3 — PR #1145) ⚠️
+				// Este .refine() era OBLIGATORIO (rango o mora) — pero el web
+				// ACTUAL en COBROS-02 todavía manda promesa_pago SIN ninguno de
+				// los dos. El modal nuevo (con selector de cuotas + checkbox de
+				// mora) vive en `git stash show stash@{0}` de esta sesión —
+				// "CRM web: promesa de pago (CB-020)" — sin PR abierto todavía.
+				// Con el .refine() estricto, desplegar este PR solo hubiera roto
+				// el botón "Promesa de Pago" que ya funciona en producción.
+				//
+				// Se quita esta exigencia por completo — el "ambos bounds o
+				// ninguno" del .refine() de más abajo sigue vigente y es
+				// suficiente para bloquear rangos a medias; lo único que se
+				// relaja es "algo es obligatorio" (rango o mora), permitiendo de
+				// nuevo el caso 100% vacío del web viejo.
+				//
+				// ACCIÓN REQUERIDA cuando el PR de web (stash de arriba) se
+				// mergee: reponer este .refine() y el de fechaProximoContacto
+				// (más abajo, mismo motivo) en un PR de limpieza aparte. Buscar
+				// "DEUDA TÉCNICA TEMPORAL" en este archivo para encontrar ambos.
 				.refine(
 					(v) =>
 						v.cuotaInicio == null ||
@@ -1376,22 +1384,29 @@ export const cobrosRouter = {
 						path: ["cuotaFin"],
 					},
 				)
-				.refine(
-					// CB-020 (review Codex): fechaProximoContacto era opcional incluso
-					// para promesa_pago — el front la exige en el modal, pero el
-					// contrato del endpoint no. Sin fecha, el job nocturno
-					// (check-promesas-pago.ts) salta la fila para siempre (necesita
-					// fechaPrometida para decidir "incumplida"), dejándola "pendiente"
-					// eterna sin importar si se pagó o no.
-					(v) =>
-						v.estadoContacto !== "promesa_pago" ||
-						v.fechaProximoContacto != null,
-					{
-						message:
-							"La fecha prometida es obligatoria para una promesa de pago",
-						path: ["fechaProximoContacto"],
-					},
-				)
+				// ⚠️ DEUDA TÉCNICA TEMPORAL (review Codex, ronda 3 — PR #1145) ⚠️
+				// Este .refine() asumía que "el front la exige en el modal" —
+				// cierto SOLO para la variante nueva (`git stash show
+				// stash@{0}`, "CRM web: promesa de pago (CB-020)", sin PR
+				// abierto). El web ACTUAL en COBROS-02 tiene "requiereSeguimiento"
+				// como checkbox GENÉRICO e independiente de estadoContacto: un
+				// asesor puede registrar promesa_pago sin marcarlo, y
+				// fechaProximoContacto queda undefined. Con este .refine() activo,
+				// ESE registro (que hoy funciona en producción) sería rechazado.
+				//
+				// Se quita hasta que el PR de web se mergee (ahí la fecha SÍ es
+				// obligatoria en el modal nuevo).
+				//
+				// El riesgo que motivó este .refine() (check-promesas-pago.ts
+				// salta filas sin fecha para siempre) sigue documentado y
+				// pendiente — sin fecha, esas promesas simplemente no se evalúan,
+				// comportamiento IGUAL al que ya tenía el código antes de esta
+				// feature (no es una regresión, es mantener el status quo).
+				//
+				// ACCIÓN REQUERIDA cuando el PR de web se mergee: reponer este
+				// .refine() junto con el de rango/mora obligatorio de arriba (en
+				// un PR de limpieza aparte). Buscar "DEUDA TÉCNICA TEMPORAL" en
+				// este archivo para encontrar ambos.
 				.refine(
 					// CB-020 (review Codex): el primer .refine() de arriba solo exige
 					// "rango completo O incluyeMora" — eso deja pasar un rango A
@@ -1403,11 +1418,9 @@ export const cobrosRouter = {
 					// "mora + cuota" puede marcarse cumplida con solo que se
 					// salde la mora. Ambos bounds o ninguno, SIEMPRE, sin
 					// importar incluyeMora.
-					(v) =>
-						(v.cuotaInicio == null) === (v.cuotaFin == null),
+					(v) => (v.cuotaInicio == null) === (v.cuotaFin == null),
 					{
-						message:
-							"Debes indicar ambas cuotas (desde y hasta) o ninguna",
+						message: "Debes indicar ambas cuotas (desde y hasta) o ninguna",
 						path: ["cuotaFin"],
 					},
 				),

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2126,6 +2126,19 @@ export const cobrosRouter = {
 			);
 			if (promesasValidas.length === 0) return {};
 
+			// CB-020 (review Codex): getCredito() usa un cache de 5 min (TTL
+			// default) que createPago() intenta invalidar con un patrón que NO
+			// matchea la key real (bug preexistente y ajeno a este PR, en
+			// cartera-back-client.ts:873 — "credito:${sifco}" vs la key real
+			// "GET:.../credito?numero_credito_sifco=${sifco}:{}", confirmado con
+			// prueba directa: .includes() da false). Sin este endpoint acá abajo
+			// no vale la pena arreglar ESE bug ajeno, pero SÍ evitar que la
+			// persistencia de estadoPromesa dependa de un snapshot potencialmente
+			// viejo: se invalida la key real ANTES de leer, para esta llamada.
+			carteraBackClient.invalidateCache(
+				`/credito?numero_credito_sifco=${input.numeroSifco}`,
+			);
+
 			let credito: Awaited<ReturnType<typeof carteraBackClient.getCredito>>;
 			try {
 				credito = await carteraBackClient.getCredito(input.numeroSifco);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -74,6 +74,11 @@ import {
 	crmOrCobrosProcedure,
 } from "../lib/orpc";
 import { primerTelefono } from "../lib/phone-utils";
+import {
+	derivarEstadoCredito,
+	type EstadoPromesa,
+	evaluarPromesa,
+} from "../lib/promesa-pago";
 import { PERMISSIONS } from "../lib/roles";
 import {
 	sendWhatsappTemplate,
@@ -1333,23 +1338,54 @@ export const cobrosRouter = {
 	// Registrar contacto de cobros
 	createContactoCobros: cobrosProcedure
 		.input(
-			z.object({
-				casoCobroId: z.string().uuid(),
-				metodoContacto: z.enum(metodoContactoEnum.enumValues),
-				estadoContacto: z.enum(estadoContactoEnum.enumValues),
-				duracionLlamada: z.number().optional(),
-				comentarios: z.string().min(1, "Los comentarios son requeridos"),
-				acuerdosAlcanzados: z.string().optional(),
-				compromisosPago: z.string().optional(),
-				requiereSeguimiento: z.boolean().default(false),
-				fechaProximoContacto: z.date().optional(),
-			}),
+			z
+				.object({
+					casoCobroId: z.string().uuid(),
+					metodoContacto: z.enum(metodoContactoEnum.enumValues),
+					estadoContacto: z.enum(estadoContactoEnum.enumValues),
+					duracionLlamada: z.number().optional(),
+					comentarios: z.string().min(1, "Los comentarios son requeridos"),
+					acuerdosAlcanzados: z.string().optional(),
+					compromisosPago: z.string().optional(),
+					requiereSeguimiento: z.boolean().default(false),
+					fechaProximoContacto: z.date().optional(),
+					// CB-020: promesa de pago atada a cuotas — solo relevantes cuando
+					// estadoContacto = 'promesa_pago'.
+					cuotaInicio: z.number().int().positive().optional(),
+					cuotaFin: z.number().int().positive().optional(),
+					incluyeMora: z.boolean().default(false),
+				})
+				.refine(
+					(v) =>
+						v.estadoContacto !== "promesa_pago" ||
+						(v.cuotaInicio != null && v.cuotaFin != null) ||
+						v.incluyeMora,
+					{
+						message:
+							"La promesa debe incluir un rango de cuotas o marcar que incluye mora",
+						path: ["cuotaInicio"],
+					},
+				)
+				.refine(
+					(v) =>
+						v.cuotaInicio == null ||
+						v.cuotaFin == null ||
+						v.cuotaFin >= v.cuotaInicio,
+					{
+						message: "cuotaFin debe ser mayor o igual a cuotaInicio",
+						path: ["cuotaFin"],
+					},
+				),
 		)
 		.handler(async ({ input, context }) => {
+			const estadoPromesa =
+				input.estadoContacto === "promesa_pago" ? "pendiente" : undefined;
+
 			const nuevoContacto = await db
 				.insert(contactosCobros)
 				.values({
 					...input,
+					estadoPromesa,
 					realizadoPor: context.userId,
 				})
 				.returning();
@@ -1396,6 +1432,11 @@ export const cobrosRouter = {
 					compromisosPago: contactosCobros.compromisosPago,
 					requiereSeguimiento: contactosCobros.requiereSeguimiento,
 					fechaProximoContacto: contactosCobros.fechaProximoContacto,
+					cuotaInicio: contactosCobros.cuotaInicio,
+					cuotaFin: contactosCobros.cuotaFin,
+					incluyeMora: contactosCobros.incluyeMora,
+					estadoPromesa: contactosCobros.estadoPromesa,
+					realizadoPorId: contactosCobros.realizadoPor,
 					realizadoPor: user.name,
 				})
 				.from(contactosCobros)
@@ -1970,6 +2011,84 @@ export const cobrosRouter = {
 
 		return usuarios;
 	}),
+
+	// CB-020: estado de cumplimiento de promesas de pago. Cada promesa se
+	// verifica con DOS chequeos independientes (ver plan — cartera-back NO
+	// separa la mora por cuota, es un monto agregado del crédito):
+	//  1. Si tiene rango de cuotas (cuotaInicio/cuotaFin) → TODAS esas cuotas
+	//     deben estar pagado=true (cuotasPagadas de getCredito).
+	//  2. Si incluyeMora=true → la mora ACTIVA del crédito debe estar saldada
+	//     (mora.activa=false o moraActual="0.00").
+	// cumplida = los chequeos que apliquen se cumplen; incumplida = la fecha
+	// prometida ya pasó y alguno no se cumple; pendiente = la fecha no llega.
+	// Persiste el resultado en estadoPromesa (no solo lo devuelve) para que
+	// quede disponible sin recalcular en cada lectura.
+	getEstadoPromesasPago: cobrosProcedure
+		.input(
+			z.object({
+				numeroSifco: z.string().min(1),
+				promesas: z
+					.array(
+						z.object({
+							id: z.string(),
+							cuotaInicio: z.number().int().positive().nullable(),
+							cuotaFin: z.number().int().positive().nullable(),
+							incluyeMora: z.boolean(),
+							fechaPrometida: z.coerce.date(),
+						}),
+					)
+					.max(100),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (input.promesas.length === 0) return {};
+
+			let credito: Awaited<ReturnType<typeof carteraBackClient.getCredito>>;
+			try {
+				credito = await carteraBackClient.getCredito(input.numeroSifco);
+			} catch (error) {
+				console.error(
+					"[getEstadoPromesasPago] Error consultando crédito:",
+					error,
+				);
+				// Sin datos no se puede afirmar incumplimiento — todas quedan
+				// "pendiente" en vez de arriesgar un falso "incumplida".
+				return Object.fromEntries(
+					input.promesas.map((p) => [p.id, "pendiente" as const]),
+				);
+			}
+
+			const estadoCredito = derivarEstadoCredito(credito);
+			const hoy = new Date();
+			const resultado: Record<string, EstadoPromesa> = {};
+			for (const promesa of input.promesas) {
+				resultado[promesa.id] = evaluarPromesa(promesa, estadoCredito, hoy);
+			}
+
+			// Persistir — best-effort, no debe tumbar la respuesta de lectura.
+			// allSettled, no all: un UPDATE que falle no debe bloquear la
+			// persistencia de las demás promesas (`resultado` ya se devuelve al
+			// front sin importar esto, pero la fila en DB sí queda atrás si se
+			// pierde por una sola falla ajena).
+			const resultadosPersistencia = await Promise.allSettled(
+				Object.entries(resultado).map(([id, estado]) =>
+					db
+						.update(contactosCobros)
+						.set({ estadoPromesa: estado })
+						.where(eq(contactosCobros.id, id)),
+				),
+			);
+			for (const r of resultadosPersistencia) {
+				if (r.status === "rejected") {
+					console.error(
+						"[getEstadoPromesasPago] Error persistiendo estadoPromesa:",
+						r.reason,
+					);
+				}
+			}
+
+			return resultado;
+		}),
 
 	// Obtener historial de cuotas de pago de un contrato
 	getHistorialPagos: cobrosProcedure
@@ -4160,6 +4279,12 @@ export const cobrosRouter = {
 					// Registrar en historial del caso (mismo flujo que contacto-modal)
 					// solo cuando el envío fue exitoso y el crédito tiene caso.
 					if (ok && c.casoCobroId) {
+						// CB-020: prefijo "Envío masivo" identifica el origen del
+						// contacto (sin columna "origen" en DB) — un consumidor futuro
+						// que necesite distinguir contacto manual del asesor vs envío
+						// automático puede filtrar por este prefijo en `comentarios`.
+						// No cambiar el texto sin actualizar cualquier filtro que
+						// dependa de él.
 						contactosARegistrar.push({
 							casoCobroId: c.casoCobroId,
 							metodoContacto: "whatsapp",

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2134,10 +2134,19 @@ export const cobrosRouter = {
 					"[getEstadoPromesasPago] Error consultando crédito:",
 					error,
 				);
-				// Sin datos no se puede afirmar incumplimiento — todas quedan
-				// "pendiente" en vez de arriesgar un falso "incumplida".
+				// Sin datos no se puede RE-EVALUAR con certeza — pero forzar
+				// "pendiente" a todas (review Codex) pisaba el estado YA
+				// GUARDADO: una promesa que ya estaba "incumplida" en DB (dato
+				// real, calculado en un ciclo anterior con datos buenos)
+				// aparecía como "pendiente" en la UI durante un outage/timeout
+				// de cartera-back, ocultando delincuencia real justo cuando
+				// más importa. Preserva el estadoPromesa guardado; solo cae a
+				// "pendiente" si esa promesa NUNCA se evaluó (null en DB).
 				return Object.fromEntries(
-					promesasValidas.map((p) => [p.id, "pendiente" as const]),
+					promesasValidas.map((p) => [
+						p.id,
+						(p.estadoPromesa ?? "pendiente") as EstadoPromesa,
+					]),
 				);
 			}
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1375,6 +1375,22 @@ export const cobrosRouter = {
 						message: "cuotaFin debe ser mayor o igual a cuotaInicio",
 						path: ["cuotaFin"],
 					},
+				)
+				.refine(
+					// CB-020 (review Codex): fechaProximoContacto era opcional incluso
+					// para promesa_pago — el front la exige en el modal, pero el
+					// contrato del endpoint no. Sin fecha, el job nocturno
+					// (check-promesas-pago.ts) salta la fila para siempre (necesita
+					// fechaPrometida para decidir "incumplida"), dejándola "pendiente"
+					// eterna sin importar si se pagó o no.
+					(v) =>
+						v.estadoContacto !== "promesa_pago" ||
+						v.fechaProximoContacto != null,
+					{
+						message:
+							"La fecha prometida es obligatoria para una promesa de pago",
+						path: ["fechaProximoContacto"],
+					},
 				),
 		)
 		.handler(async ({ input, context }) => {

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -1391,6 +1391,25 @@ export const cobrosRouter = {
 							"La fecha prometida es obligatoria para una promesa de pago",
 						path: ["fechaProximoContacto"],
 					},
+				)
+				.refine(
+					// CB-020 (review Codex): el primer .refine() de arriba solo exige
+					// "rango completo O incluyeMora" — eso deja pasar un rango A
+					// MEDIAS (ej. cuotaInicio=5, cuotaFin=null) siempre que
+					// incluyeMora=true, porque esa condición sola ya satisface el
+					// OR. evaluarPromesa trata cuotaFin=null como "sin rango, no
+					// bloquea" (tieneRango=false), así que la cuota #5 que el
+					// usuario SÍ especificó nunca se verifica — una promesa de
+					// "mora + cuota" puede marcarse cumplida con solo que se
+					// salde la mora. Ambos bounds o ninguno, SIEMPRE, sin
+					// importar incluyeMora.
+					(v) =>
+						(v.cuotaInicio == null) === (v.cuotaFin == null),
+					{
+						message:
+							"Debes indicar ambas cuotas (desde y hasta) o ninguna",
+						path: ["cuotaFin"],
+					},
 				),
 		)
 		.handler(async ({ input, context }) => {
@@ -2039,25 +2058,48 @@ export const cobrosRouter = {
 	// prometida ya pasó y alguno no se cumple; pendiente = la fecha no llega.
 	// Persiste el resultado en estadoPromesa (no solo lo devuelve) para que
 	// quede disponible sin recalcular en cada lectura.
+	//
+	// CB-020 (review Codex): el input SOLO manda `id` + `numeroSifco` — los
+	// datos de evaluación (cuotaInicio/cuotaFin/incluyeMora/fechaPrometida)
+	// se CARGAN de `contactos_cobros` por id, nunca se toman del cliente.
+	// Antes el cliente los mandaba directo: un id real con
+	// cuotaInicio/cuotaFin/incluyeMora=null/null/false pasaba evaluarPromesa
+	// como "cumplida" inmediata (sin rango ni mora que chequear) y ESO se
+	// persistía, pisando el estado real de la fila.
 	getEstadoPromesasPago: cobrosProcedure
 		.input(
 			z.object({
 				numeroSifco: z.string().min(1),
-				promesas: z
-					.array(
-						z.object({
-							id: z.string(),
-							cuotaInicio: z.number().int().positive().nullable(),
-							cuotaFin: z.number().int().positive().nullable(),
-							incluyeMora: z.boolean(),
-							fechaPrometida: z.coerce.date(),
-						}),
-					)
-					.max(100),
+				promesaIds: z.array(z.string().uuid()).max(100),
 			}),
 		)
 		.handler(async ({ input }) => {
-			if (input.promesas.length === 0) return {};
+			if (input.promesaIds.length === 0) return {};
+
+			// Fila real de DB por id — el `numeroSifco` del caso debe coincidir
+			// con el pedido, si no la fila se descarta (defensa contra un id de
+			// OTRO crédito colado en la lista).
+			const filas = await db
+				.select({
+					id: contactosCobros.id,
+					cuotaInicio: contactosCobros.cuotaInicio,
+					cuotaFin: contactosCobros.cuotaFin,
+					incluyeMora: contactosCobros.incluyeMora,
+					fechaProximoContacto: contactosCobros.fechaProximoContacto,
+					estadoContacto: contactosCobros.estadoContacto,
+					numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+				})
+				.from(contactosCobros)
+				.innerJoin(casosCobros, eq(contactosCobros.casoCobroId, casosCobros.id))
+				.where(inArray(contactosCobros.id, input.promesaIds));
+
+			const promesasValidas = filas.filter(
+				(f) =>
+					f.estadoContacto === "promesa_pago" &&
+					f.numeroCreditoSifco === input.numeroSifco &&
+					f.fechaProximoContacto != null,
+			);
+			if (promesasValidas.length === 0) return {};
 
 			let credito: Awaited<ReturnType<typeof carteraBackClient.getCredito>>;
 			try {
@@ -2070,15 +2112,25 @@ export const cobrosRouter = {
 				// Sin datos no se puede afirmar incumplimiento — todas quedan
 				// "pendiente" en vez de arriesgar un falso "incumplida".
 				return Object.fromEntries(
-					input.promesas.map((p) => [p.id, "pendiente" as const]),
+					promesasValidas.map((p) => [p.id, "pendiente" as const]),
 				);
 			}
 
 			const estadoCredito = derivarEstadoCredito(credito);
 			const hoy = new Date();
 			const resultado: Record<string, EstadoPromesa> = {};
-			for (const promesa of input.promesas) {
-				resultado[promesa.id] = evaluarPromesa(promesa, estadoCredito, hoy);
+			for (const promesa of promesasValidas) {
+				resultado[promesa.id] = evaluarPromesa(
+					{
+						id: promesa.id,
+						cuotaInicio: promesa.cuotaInicio,
+						cuotaFin: promesa.cuotaFin,
+						incluyeMora: promesa.incluyeMora,
+						fechaPrometida: promesa.fechaProximoContacto as Date,
+					},
+					estadoCredito,
+					hoy,
+				);
 			}
 
 			// Persistir — best-effort, no debe tumbar la respuesta de lectura.

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -151,6 +151,7 @@ export const cobrosAppRouter = {
 	reasignarAsesorCredito: cobrosRouter.reasignarAsesorCredito,
 	getHistorialReasignaciones: cobrosRouter.getHistorialReasignaciones,
 	getHistorialPagos: cobrosRouter.getHistorialPagos,
+	getEstadoPromesasPago: cobrosRouter.getEstadoPromesasPago,
 	getRecuperacionVehiculo: cobrosRouter.getRecuperacionVehiculo,
 	getTodosLosCreditos: cobrosRouter.getTodosLosCreditos,
 	getDetallesContrato: cobrosRouter.getDetallesContrato,

--- a/apps/crm/apps/server/src/services/check-promesas-pago.ts
+++ b/apps/crm/apps/server/src/services/check-promesas-pago.ts
@@ -1,0 +1,198 @@
+/**
+ * CB-020 — Cierre nocturno de Promesas de Pago.
+ *
+ * getEstadoPromesasPago (routers/cobros.ts) recalcula el estado de una
+ * promesa cada vez que un asesor abre el caso — pero si nadie lo abre, una
+ * promesa vencida se queda "pendiente" indefinidamente. Este job corre TODAS
+ * las noches y evalúa TODAS las promesas activas (pendiente o incumplida —
+ * una incumplida puede volverse cumplida si el cliente pagó después) sin
+ * depender de que alguien visite la página del caso.
+ *
+ * Usa la MISMA lógica pura que el endpoint on-demand (lib/promesa-pago.ts) —
+ * una sola fuente de verdad, no se puede divergir entre ambos caminos.
+ *
+ * Nunca lanza al caller: devuelve un resumen y loguea (patrón premora).
+ */
+
+import { and, eq, inArray, isNull, ne, or } from "drizzle-orm";
+import { db } from "../db";
+import { casosCobros, contactosCobros } from "../db/schema/cobros";
+import {
+	derivarEstadoCredito,
+	type EstadoPromesa,
+	evaluarPromesa,
+} from "../lib/promesa-pago";
+import { carteraBackClient } from "./cartera-back-client";
+import { isCarteraBackEnabled } from "./cartera-back-integration";
+
+const LOG_PREFIX = "[PromesasPago]";
+
+export interface CheckPromesasResumen {
+	evaluadas: number;
+	cumplidas: number;
+	incumplidas: number;
+	pendientes: number;
+	sinCaso: number;
+	errores: number;
+	skipped?: boolean;
+	reason?: string;
+}
+
+function resumenVacio(
+	partial: Partial<CheckPromesasResumen> = {},
+): CheckPromesasResumen {
+	return {
+		evaluadas: 0,
+		cumplidas: 0,
+		incumplidas: 0,
+		pendientes: 0,
+		sinCaso: 0,
+		errores: 0,
+		...partial,
+	};
+}
+
+export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
+	try {
+		if (!isCarteraBackEnabled()) {
+			console.log(`${LOG_PREFIX} Cartera-back deshabilitado; job omitido`);
+			return resumenVacio({ skipped: true, reason: "cartera_back_disabled" });
+		}
+
+		// 1. Promesas activas — pendiente O incumplida (una incumplida puede
+		// pasar a cumplida si el cliente pagó después de que se marcó así).
+		// "cumplida" no se re-evalúa: es terminal, no hay forma de "des-cumplir".
+		const promesas = await db
+			.select({
+				id: contactosCobros.id,
+				casoCobroId: contactosCobros.casoCobroId,
+				cuotaInicio: contactosCobros.cuotaInicio,
+				cuotaFin: contactosCobros.cuotaFin,
+				incluyeMora: contactosCobros.incluyeMora,
+				fechaProximoContacto: contactosCobros.fechaProximoContacto,
+			})
+			.from(contactosCobros)
+			.where(
+				and(
+					eq(contactosCobros.estadoContacto, "promesa_pago"),
+					or(
+						isNull(contactosCobros.estadoPromesa),
+						ne(contactosCobros.estadoPromesa, "cumplida"),
+					),
+				),
+			);
+
+		if (promesas.length === 0) return resumenVacio();
+		// evaluadas NO se fija aquí — se calcula al final como cumplidas +
+		// incumplidas + pendientes, así siempre cuadra con lo que realmente se
+		// evaluó (promesas.length incluye filas que después se saltan por
+		// sinCaso o fecha faltante, y fijar evaluadas=promesas.length de
+		// entrada dejaba el log desalineado: "evaluó N" pero solo sumaba N-X).
+		const resumen = resumenVacio();
+
+		// 2. Batch: numeroCreditoSifco de cada caso (la llave hacia cartera-back).
+		const casoIds = [...new Set(promesas.map((p) => p.casoCobroId))];
+		const casos = await db
+			.select({
+				id: casosCobros.id,
+				numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+			})
+			.from(casosCobros)
+			.where(inArray(casosCobros.id, casoIds));
+		const sifcoPorCaso = new Map(
+			casos.map((c) => [c.id, c.numeroCreditoSifco]),
+		);
+
+		// 3. Agrupar promesas por SIFCO — un solo getCredito por crédito, sin
+		// importar cuántas promesas tenga (varias comparten la misma foto).
+		const promesasPorSifco = new Map<string, typeof promesas>();
+		for (const promesa of promesas) {
+			const sifco = sifcoPorCaso.get(promesa.casoCobroId);
+			if (!sifco) {
+				resumen.sinCaso++;
+				continue;
+			}
+			const grupo = promesasPorSifco.get(sifco) ?? [];
+			grupo.push(promesa);
+			promesasPorSifco.set(sifco, grupo);
+		}
+
+		const hoy = new Date();
+		for (const [sifco, grupo] of promesasPorSifco) {
+			try {
+				const credito = await carteraBackClient.getCredito(sifco);
+				const estadoCredito = derivarEstadoCredito(credito);
+
+				const actualizaciones: Array<{ id: string; estado: EstadoPromesa }> =
+					[];
+				for (const promesa of grupo) {
+					if (!promesa.fechaProximoContacto) continue; // fecha obligatoria en el modal, defensivo
+					const estado = evaluarPromesa(
+						{
+							id: promesa.id,
+							cuotaInicio: promesa.cuotaInicio,
+							cuotaFin: promesa.cuotaFin,
+							incluyeMora: promesa.incluyeMora,
+							fechaPrometida: promesa.fechaProximoContacto,
+						},
+						estadoCredito,
+						hoy,
+					);
+					actualizaciones.push({ id: promesa.id, estado });
+					if (estado === "cumplida") resumen.cumplidas++;
+					else if (estado === "incumplida") resumen.incumplidas++;
+					else resumen.pendientes++;
+				}
+
+				// allSettled, no all: un UPDATE que falle no debe tumbar los demás
+				// del mismo crédito — con Promise.all, una fila mala bloqueaba la
+				// persistencia de TODAS sus hermanas (aunque ya se hubieran
+				// calculado bien), y el catch de abajo las contaba a todas como
+				// error aunque solo una fallara.
+				const resultados = await Promise.allSettled(
+					actualizaciones.map(({ id, estado }) =>
+						db
+							.update(contactosCobros)
+							.set({ estadoPromesa: estado })
+							.where(eq(contactosCobros.id, id)),
+					),
+				);
+				for (let i = 0; i < resultados.length; i++) {
+					const resultado = resultados[i];
+					if (resultado.status === "rejected") {
+						const { estado } = actualizaciones[i];
+						// Revertir el conteo de éxito hecho arriba — la evaluación fue
+						// correcta pero la escritura falló, no debe contar como logro.
+						if (estado === "cumplida") resumen.cumplidas--;
+						else if (estado === "incumplida") resumen.incumplidas--;
+						else resumen.pendientes--;
+						resumen.errores++;
+						console.error(
+							`${LOG_PREFIX} Error persistiendo promesa ${actualizaciones[i].id}:`,
+							resultado.reason,
+						);
+					}
+				}
+			} catch (error) {
+				resumen.errores += grupo.length;
+				console.error(
+					`${LOG_PREFIX} Error evaluando promesas del crédito ${sifco}:`,
+					error,
+				);
+			}
+		}
+
+		// evaluadas = suma real de lo que se resolvió, no promesas.length (que
+		// incluía sinCaso/fecha-faltante/errores de credito no evaluados).
+		resumen.evaluadas =
+			resumen.cumplidas + resumen.incumplidas + resumen.pendientes;
+
+		console.log(
+			`${LOG_PREFIX} ${resumen.evaluadas} evaluada(s) → ${resumen.cumplidas} cumplida(s), ${resumen.incumplidas} incumplida(s), ${resumen.pendientes} pendiente(s), ${resumen.sinCaso} sin caso, ${resumen.errores} error(es)`,
+		);
+		return resumen;
+	} catch (err) {
+		console.error(`${LOG_PREFIX} Error general del job:`, err);
+		return resumenVacio({ errores: 1 });
+	}
+}

--- a/apps/crm/apps/server/src/services/send-premora-reminders.ts
+++ b/apps/crm/apps/server/src/services/send-premora-reminders.ts
@@ -462,6 +462,12 @@ export async function sendPremoraReminders(
 						casoCobroId: caso.id,
 						metodoContacto: "whatsapp",
 						estadoContacto: "contactado",
+						// CB-020: prefijo "Recordatorio automático" identifica el origen
+						// del contacto (sin columna "origen" en DB) — un consumidor
+						// futuro que necesite distinguir contacto manual del asesor vs
+						// envío automático puede filtrar por este prefijo en
+						// `comentarios`. No cambiar el texto sin actualizar cualquier
+						// filtro que dependa de él.
 						comentarios: `Recordatorio automático ${tipo.replace("premora_", "Premora D-")} enviado por WhatsApp al ${telefonoDestino}${testMode ? " (modo prueba)" : ""}. Cuota #${cuota.numero_cuota} vence el ${fechaLegible(cuota.fecha_vencimiento)} por Q${montoLegible(cuota.monto_cuota)}.`,
 						realizadoPor: caso.responsable ?? usuarioSistema,
 					});


### PR DESCRIPTION
## Summary
- Promesa de Pago pasa de "fecha genérica sin verificación" a estar atada a un **rango de cuotas** (`cuota_inicio`/`cuota_fin`) y/o a la **mora del crédito** (`incluye_mora`), verificado en tiempo real contra cartera-back.
- `lib/promesa-pago.ts`: `evaluarPromesa`/`derivarEstadoCredito`, función pura compartida por el endpoint on-demand (`getEstadoPromesasPago`) y el job nocturno (`check-promesas-pago.ts`) — una sola fuente de verdad.
- Migración `0026` manual (pendiente de aplicar a mano en dev): `cuota_inicio`, `cuota_fin`, `incluye_mora`, `estado_promesa` + CHECK de rango con diagnóstico previo.
- 19 tests unitarios sobre la evaluación pura.

Reemplaza el PR #1145 (cerrado manualmente tras varias rondas de review) — mismo trabajo, con 4 fixes adicionales de Codex ya incorporados:
- Comparación de fecha por día calendario (no instante exacto).
- `getEstadoPromesasPago` carga datos reales de DB en vez de confiar en el input del cliente.
- Rango de cuotas exige ambos bounds o ninguno (Zod + CHECK de DB).
- Nunca marca "cumplida" automática una promesa sin rango ni mora (protege filas legacy).

**Deuda técnica temporal, documentada en el código** (buscar "DEUDA TÉCNICA TEMPORAL" en `routers/cobros.ts`): 2 `.refine()` se relajaron para no romper el botón "Promesa de Pago" que ya funciona en producción — el web actual en `COBROS-02` no manda los campos nuevos todavía (ese modal vive sin PR, en un stash local de esta sesión). Reponer esos `.refine()` cuando el PR de web se abra y mergee.

Este PR es **solo el server** — el front va en un PR aparte una vez este se mergee.

## Test plan
- [ ] Aplicar migración `0026_cb020_promesa_pago_cuotas.sql` a mano en dev antes de desplegar
- [x] `bun test src/lib/promesa-pago.test.ts` — 19/19 pass
- [x] `bun check-types` — limpio
- [ ] Reponer los 2 `.refine()` temporales cuando el PR de web se mergee

🤖 Generated with [Claude Code](https://claude.com/claude-code)