### PR TITLE
feat(cobros): CRM web — Promesa de Pago atada a rango de cuotas y/o mora (CB-020)

### DIFF
--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -230,6 +230,14 @@ export function ContactoModal({
 			incluyeMora: false,
 		},
 		onSubmit: async ({ value }) => {
+			// Guard explícito además del validator del campo (Codex, PR #1147):
+			// si el campo nunca se toca, su validator onChange nunca corre y
+			// canSubmit puede no reflejar el error a tiempo — sin esto, una
+			// promesa podía enviarse con fechaProximoContacto undefined.
+			if (esPromesa && !value.fechaProximoContacto) {
+				toast.error("La fecha prometida es obligatoria");
+				return;
+			}
 			createContactoMutation.mutate(value);
 		},
 	});
@@ -1089,7 +1097,17 @@ export function ContactoModal({
 									<form.Field
 										name="fechaProximoContacto"
 										validators={{
+											// onChange no corre si el campo nunca se toca (form
+											// arranca en undefined) — sin onSubmit, un asesor que
+											// nunca abre el calendario puede enviar la promesa sin
+											// fecha (Codex, PR #1147): la fila queda invisible para
+											// getEstadoPromesasPago (este mismo archivo filtra por
+											// fechaProximoContacto antes de armar promesaIds).
 											onChange: ({ value }) =>
+												esPromesa && !value
+													? "La fecha prometida es obligatoria"
+													: undefined,
+											onSubmit: ({ value }) =>
 												esPromesa && !value
 													? "La fecha prometida es obligatoria"
 													: undefined,

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -75,6 +75,16 @@ interface ContactoModalProps {
 	// Modo controlado opcional (cuando el padre maneja el estado open)
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
+	// CB-020: "promesa" = modal reducido — solo Detalles de la Conversación +
+	// fecha prometida (obligatoria). Oculta método/estado/plantilla/envío:
+	// esos ya quedan fijos (estadoContacto=promesa_pago) porque la promesa se
+	// registra DESPUÉS de haber contactado al cliente por otro medio.
+	variante?: "completo" | "promesa";
+	// CB-020: cuotas ATRASADAS (no pagadas Y ya vencidas — no incluye cuotas
+	// futuras aún no vencidas) para el selector de rango en variante "promesa".
+	// $id.tsx filtra por fechaVencimiento < hoy antes de pasarlas — reusa la
+	// data que ya carga vía getHistorialPagos, no duplica el fetch aquí.
+	cuotasDisponibles?: Array<{ numeroCuota: number }>;
 	// Variables para plantillas de mensaje
 	fechaPago?: string;
 	cuotaMensual?: string;
@@ -98,6 +108,8 @@ export function ContactoModal({
 	children,
 	open,
 	onOpenChange,
+	variante = "completo",
+	cuotasDisponibles = [],
 	fechaPago = "",
 	cuotaMensual = "",
 	placa = "",
@@ -191,16 +203,31 @@ export function ContactoModal({
 		}
 	};
 
+	const esPromesa = variante === "promesa";
+
 	const form = useForm({
 		defaultValues: {
 			metodoContacto: metodoInicial,
-			estadoContacto: "contactado" as const,
+			// CB-020: variante promesa fija el estado — no pasa por el selector.
+			estadoContacto: (esPromesa ? "promesa_pago" : "contactado") as
+				| "contactado"
+				| "no_contesta"
+				| "numero_equivocado"
+				| "promesa_pago"
+				| "acuerdo_parcial"
+				| "rechaza_pagar",
 			comentarios: "",
 			acuerdosAlcanzados: "",
 			compromisosPago: "",
-			requiereSeguimiento: false,
+			// La fecha prometida ES la fecha de próximo contacto — nunca opcional
+			// en la variante promesa (por eso arranca en true).
+			requiereSeguimiento: esPromesa,
 			fechaProximoContacto: undefined as Date | undefined,
 			duracionLlamada: undefined as number | undefined,
+			// CB-020: rango de cuotas + mora — solo relevantes en variante promesa.
+			cuotaInicio: undefined as number | undefined,
+			cuotaFin: undefined as number | undefined,
+			incluyeMora: false,
 		},
 		onSubmit: async ({ value }) => {
 			createContactoMutation.mutate(value);
@@ -431,12 +458,18 @@ export function ContactoModal({
 			<DialogContent className="max-h-[90vh] min-w-3xl max-w-4xl overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
-						{getIconoMetodo(metodoInicial)}
-						Registrar Contacto - {clienteNombre}
+						{esPromesa ? (
+							<MessageSquare className="h-4 w-4" />
+						) : (
+							getIconoMetodo(metodoInicial)
+						)}
+						{esPromesa ? "Promesa de Pago" : "Registrar Contacto"} -{" "}
+						{clienteNombre}
 					</DialogTitle>
 					<DialogDescription>
-						Registra los detalles de la interacción con el cliente y programa el
-						próximo seguimiento.
+						{esPromesa
+							? "Registra lo hablado y la fecha en la que el cliente prometió pagar."
+							: "Registra los detalles de la interacción con el cliente y programa el próximo seguimiento."}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -448,273 +481,278 @@ export function ContactoModal({
 					}}
 					className="space-y-6"
 				>
-					{/* Sección: Información del Contacto */}
-					<div className="space-y-4">
-						<h3 className="font-medium text-lg">Información del Contacto</h3>
+					{/* Sección: Información del Contacto — oculta en variante "promesa":
+					    el método/estado/plantilla/envío no aplican, la promesa se
+					    registra sobre un contacto que ya ocurrió por otro medio. */}
+					{!esPromesa && (
+						<div className="space-y-4">
+							<h3 className="font-medium text-lg">Información del Contacto</h3>
 
-						<div className="grid grid-cols-2 gap-4">
-							<form.Field name="metodoContacto">
-								{(field) => (
+							<div className="grid grid-cols-2 gap-4">
+								<form.Field name="metodoContacto">
+									{(field) => (
+										<div className="space-y-2">
+											<Label>Método de Contacto</Label>
+											<Select
+												onValueChange={(value) =>
+													form.setFieldValue(
+														field.name,
+														value as typeof field.state.value,
+													)
+												}
+												defaultValue={field.state.value}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="Seleccionar método" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="llamada">📞 Llamada</SelectItem>
+													<SelectItem value="whatsapp">💬 WhatsApp</SelectItem>
+													<SelectItem value="email">📧 Email</SelectItem>
+													<SelectItem value="visita_domicilio">
+														🏠 Visita Domicilio
+													</SelectItem>
+													<SelectItem value="carta_notarial">
+														📋 Carta Notarial
+													</SelectItem>
+												</SelectContent>
+											</Select>
+										</div>
+									)}
+								</form.Field>
+
+								<form.Field name="estadoContacto">
+									{(field) => (
+										<div className="space-y-2">
+											<Label>Estado del Contacto</Label>
+											<Select
+												onValueChange={(value) =>
+													form.setFieldValue(
+														field.name,
+														value as typeof field.state.value,
+													)
+												}
+												defaultValue={field.state.value}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="Estado del contacto" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="contactado">
+														✅ Contactado
+													</SelectItem>
+													<SelectItem value="no_contesta">
+														❌ No Contesta
+													</SelectItem>
+													<SelectItem value="numero_equivocado">
+														📱 Número Equivocado
+													</SelectItem>
+													{/* CB-020: "Promesa de Pago" se registra SOLO desde el
+													    botón dedicado (modal reducido) — no aquí. */}
+													<SelectItem value="acuerdo_parcial">
+														📝 Acuerdo Parcial
+													</SelectItem>
+													<SelectItem value="rechaza_pagar">
+														🚫 Rechaza Pagar
+													</SelectItem>
+												</SelectContent>
+											</Select>
+										</div>
+									)}
+								</form.Field>
+							</div>
+
+							{/* Selector de plantilla para WhatsApp y Email */}
+							{mostrarPlantillas && (
+								<div className="space-y-3 rounded-md border p-3">
 									<div className="space-y-2">
-										<Label>Método de Contacto</Label>
+										<Label>Plantilla de mensaje</Label>
 										<Select
-											onValueChange={(value) =>
-												form.setFieldValue(
-													field.name,
-													value as typeof field.state.value,
-												)
-											}
-											defaultValue={field.state.value}
+											value={plantillaId}
+											onValueChange={handlePlantillaChange}
 										>
 											<SelectTrigger>
-												<SelectValue placeholder="Seleccionar método" />
+												<SelectValue placeholder="Seleccionar plantilla..." />
 											</SelectTrigger>
 											<SelectContent>
-												<SelectItem value="llamada">📞 Llamada</SelectItem>
-												<SelectItem value="whatsapp">💬 WhatsApp</SelectItem>
-												<SelectItem value="email">📧 Email</SelectItem>
-												<SelectItem value="visita_domicilio">
-													🏠 Visita Domicilio
-												</SelectItem>
-												<SelectItem value="carta_notarial">
-													📋 Carta Notarial
-												</SelectItem>
+												{PLANTILLAS_MENSAJES.map((p) => (
+													<SelectItem key={p.id} value={p.id}>
+														{p.nombre}
+													</SelectItem>
+												))}
 											</SelectContent>
 										</Select>
 									</div>
-								)}
-							</form.Field>
 
-							<form.Field name="estadoContacto">
-								{(field) => (
-									<div className="space-y-2">
-										<Label>Estado del Contacto</Label>
-										<Select
-											onValueChange={(value) =>
-												form.setFieldValue(
-													field.name,
-													value as typeof field.state.value,
-												)
-											}
-											defaultValue={field.state.value}
-										>
-											<SelectTrigger>
-												<SelectValue placeholder="Estado del contacto" />
-											</SelectTrigger>
-											<SelectContent>
-												<SelectItem value="contactado">
-													✅ Contactado
-												</SelectItem>
-												<SelectItem value="no_contesta">
-													❌ No Contesta
-												</SelectItem>
-												<SelectItem value="numero_equivocado">
-													📱 Número Equivocado
-												</SelectItem>
-												<SelectItem value="promesa_pago">
-													🤝 Promesa de Pago
-												</SelectItem>
-												<SelectItem value="acuerdo_parcial">
-													📝 Acuerdo Parcial
-												</SelectItem>
-												<SelectItem value="rechaza_pagar">
-													🚫 Rechaza Pagar
-												</SelectItem>
-											</SelectContent>
-										</Select>
-									</div>
-								)}
-							</form.Field>
-						</div>
+									{plantillaId && metodoInicial === "email" && (
+										<div className="space-y-2">
+											<Label>Asunto</Label>
+											<Input
+												value={asuntoEditado}
+												onChange={(e) => setAsuntoEditado(e.target.value)}
+											/>
+										</div>
+									)}
 
-						{/* Selector de plantilla para WhatsApp y Email */}
-						{mostrarPlantillas && (
-							<div className="space-y-3 rounded-md border p-3">
+									{plantillaId && (
+										<div className="space-y-2">
+											<Label>Mensaje (editable)</Label>
+											<Textarea
+												className="min-h-[150px] text-sm"
+												value={mensajeEditable}
+												onChange={(e) =>
+													handleMensajeEditableChange(e.target.value)
+												}
+											/>
+										</div>
+									)}
+								</div>
+							)}
+
+							{/* Selector de teléfono cuando hay múltiples */}
+							{telefonos.length > 1 && (
 								<div className="space-y-2">
-									<Label>Plantilla de mensaje</Label>
+									<Label>Teléfono a contactar</Label>
 									<Select
-										value={plantillaId}
-										onValueChange={handlePlantillaChange}
+										value={telefonoSeleccionado}
+										onValueChange={setTelefonoSeleccionado}
 									>
 										<SelectTrigger>
-											<SelectValue placeholder="Seleccionar plantilla..." />
+											<SelectValue />
 										</SelectTrigger>
 										<SelectContent>
-											{PLANTILLAS_MENSAJES.map((p) => (
-												<SelectItem key={p.id} value={p.id}>
-													{p.nombre}
+											{telefonos.map((t) => (
+												<SelectItem key={t} value={t}>
+													{t}
 												</SelectItem>
 											))}
 										</SelectContent>
 									</Select>
 								</div>
+							)}
 
-								{plantillaId && metodoInicial === "email" && (
-									<div className="space-y-2">
-										<Label>Asunto</Label>
-										<Input
-											value={asuntoEditado}
-											onChange={(e) => setAsuntoEditado(e.target.value)}
-										/>
-									</div>
-								)}
-
-								{plantillaId && (
-									<div className="space-y-2">
-										<Label>Mensaje (editable)</Label>
-										<Textarea
-											className="min-h-[150px] text-sm"
-											value={mensajeEditable}
-											onChange={(e) =>
-												handleMensajeEditableChange(e.target.value)
-											}
-										/>
-									</div>
-								)}
-							</div>
-						)}
-
-						{/* Selector de teléfono cuando hay múltiples */}
-						{telefonos.length > 1 && (
-							<div className="space-y-2">
-								<Label>Teléfono a contactar</Label>
-								<Select
-									value={telefonoSeleccionado}
-									onValueChange={setTelefonoSeleccionado}
+							{/* Botones para ejecutar acción */}
+							<div className="flex flex-wrap gap-2">
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => ejecutarAccion("llamada")}
+									disabled={envioEnCurso}
+									className="flex items-center gap-2"
 								>
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{telefonos.map((t) => (
-											<SelectItem key={t} value={t}>
-												{t}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
+									<Phone className="h-4 w-4" />
+									Llamar {telefonos.length <= 1 ? telefonos[0] || "" : ""}
+								</Button>
+
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											disabled={envioEnCurso}
+											className="flex items-center gap-2"
+										>
+											{whatsappApiMutation.isPending ? (
+												<Loader2 className="h-4 w-4 animate-spin" />
+											) : (
+												<MessageCircle className="h-4 w-4" />
+											)}
+											WhatsApp
+											{whatsappApiMutation.isPending ? null : (
+												<ChevronDown className="h-3 w-3" />
+											)}
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start">
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("whatsapp-api")}
+										>
+											Enviar Directo (Automático)
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("whatsapp-link")}
+										>
+											Abrir WhatsApp Web (Manual)
+										</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>
+
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											disabled={envioEnCurso}
+											className="flex items-center gap-2"
+										>
+											{emailApiMutation.isPending ? (
+												<Loader2 className="h-4 w-4 animate-spin" />
+											) : (
+												<Mail className="h-4 w-4" />
+											)}
+											Email
+											{emailApiMutation.isPending ? null : (
+												<ChevronDown className="h-3 w-3" />
+											)}
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start">
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("email-api")}
+										>
+											Enviar Directo (Automático)
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("email-link")}
+										>
+											Abrir cliente de correo (Manual)
+										</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>
+
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => ejecutarAccion("sms-api")}
+									disabled={envioEnCurso}
+									className="flex items-center gap-2"
+								>
+									{smsApiMutation.isPending ? (
+										<Loader2 className="h-4 w-4 animate-spin" />
+									) : (
+										<MessageSquare className="h-4 w-4" />
+									)}
+									{smsApiMutation.isPending ? "Enviando SMS..." : "SMS"}
+								</Button>
 							</div>
-						)}
 
-						{/* Botones para ejecutar acción */}
-						<div className="flex flex-wrap gap-2">
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={() => ejecutarAccion("llamada")}
-								disabled={envioEnCurso}
-								className="flex items-center gap-2"
-							>
-								<Phone className="h-4 w-4" />
-								Llamar {telefonos.length <= 1 ? telefonos[0] || "" : ""}
-							</Button>
-
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										disabled={envioEnCurso}
-										className="flex items-center gap-2"
-									>
-										{whatsappApiMutation.isPending ? (
-											<Loader2 className="h-4 w-4 animate-spin" />
-										) : (
-											<MessageCircle className="h-4 w-4" />
-										)}
-										WhatsApp
-										{whatsappApiMutation.isPending ? null : (
-											<ChevronDown className="h-3 w-3" />
-										)}
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent align="start">
-									<DropdownMenuItem
-										onClick={() => ejecutarAccion("whatsapp-api")}
-									>
-										Enviar Directo (Automático)
-									</DropdownMenuItem>
-									<DropdownMenuItem
-										onClick={() => ejecutarAccion("whatsapp-link")}
-									>
-										Abrir WhatsApp Web (Manual)
-									</DropdownMenuItem>
-								</DropdownMenuContent>
-							</DropdownMenu>
-
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										disabled={envioEnCurso}
-										className="flex items-center gap-2"
-									>
-										{emailApiMutation.isPending ? (
-											<Loader2 className="h-4 w-4 animate-spin" />
-										) : (
-											<Mail className="h-4 w-4" />
-										)}
-										Email
-										{emailApiMutation.isPending ? null : (
-											<ChevronDown className="h-3 w-3" />
-										)}
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent align="start">
-									<DropdownMenuItem onClick={() => ejecutarAccion("email-api")}>
-										Enviar Directo (Automático)
-									</DropdownMenuItem>
-									<DropdownMenuItem
-										onClick={() => ejecutarAccion("email-link")}
-									>
-										Abrir cliente de correo (Manual)
-									</DropdownMenuItem>
-								</DropdownMenuContent>
-							</DropdownMenu>
-
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={() => ejecutarAccion("sms-api")}
-								disabled={envioEnCurso}
-								className="flex items-center gap-2"
-							>
-								{smsApiMutation.isPending ? (
-									<Loader2 className="h-4 w-4 animate-spin" />
-								) : (
-									<MessageSquare className="h-4 w-4" />
-								)}
-								{smsApiMutation.isPending ? "Enviando SMS..." : "SMS"}
-							</Button>
+							<form.Field name="metodoContacto">
+								{(metodoField) =>
+									metodoField.state.value === "llamada" && (
+										<form.Field name="duracionLlamada">
+											{(field) => (
+												<div className="space-y-2">
+													<Label>Duración de la Llamada (segundos)</Label>
+													<Input
+														type="number"
+														placeholder="Ej: 180"
+														value={field.state.value}
+														onChange={(e) =>
+															field.handleChange(Number(e.target.value))
+														}
+													/>
+												</div>
+											)}
+										</form.Field>
+									)
+								}
+							</form.Field>
 						</div>
-
-						<form.Field name="metodoContacto">
-							{(metodoField) =>
-								metodoField.state.value === "llamada" && (
-									<form.Field name="duracionLlamada">
-										{(field) => (
-											<div className="space-y-2">
-												<Label>Duración de la Llamada (segundos)</Label>
-												<Input
-													type="number"
-													placeholder="Ej: 180"
-													value={field.state.value}
-													onChange={(e) =>
-														field.handleChange(Number(e.target.value))
-													}
-												/>
-											</div>
-										)}
-									</form.Field>
-								)
-							}
-						</form.Field>
-					</div>
+					)}
 
 					{/* Sección: Detalles de la Conversación */}
 					<div className="space-y-4">
@@ -827,37 +865,243 @@ export function ContactoModal({
 						</div>
 					</div>
 
-					{/* Sección: Próximo Seguimiento */}
-					<div className="space-y-4">
-						<h3 className="font-medium text-lg">Próximo Seguimiento</h3>
+					{/* CB-020: Sección de cuotas — SOLO en variante promesa. cartera-back
+					    NO separa la mora por cuota (moras_credito es un monto agregado
+					    del crédito, no por cuota individual) — por eso el checkbox de
+					    mora es independiente del rango: puede haber rango sin mora,
+					    mora sin rango ("solo mora"), o ambos. */}
+					{esPromesa && (
+						<div className="space-y-4">
+							<h3 className="font-medium text-lg">¿Qué prometió pagar?</h3>
 
-						<form.Field name="requiereSeguimiento">
-							{(field) => (
-								<div className="flex items-center space-x-2">
-									<Checkbox
-										id="requiereSeguimiento"
-										checked={field.state.value}
-										onCheckedChange={(checked) => {
-											field.handleChange(!!checked);
-											if (!checked) {
-												form.setFieldValue("fechaProximoContacto", undefined);
-											}
+							{cuotasDisponibles.length === 0 ? (
+								<p className="text-muted-foreground text-sm">
+									Este contrato no tiene cuotas atrasadas.
+								</p>
+							) : (
+								<div className="grid grid-cols-2 gap-4">
+									<form.Field
+										name="cuotaInicio"
+										validators={{
+											// listenTo cuotaFin: si el usuario baja cuotaFin por
+											// debajo de un cuotaInicio ya elegido, este validator
+											// re-corre aunque cuotaInicio no haya cambiado (mismo
+											// fix que cuotaFin de abajo, en la dirección opuesta).
+											onChangeListenTo: ["cuotaFin"],
+											onChange: ({ value, fieldApi }) => {
+												const cuotaFin =
+													fieldApi.form.getFieldValue("cuotaFin");
+												if (
+													value != null &&
+													cuotaFin != null &&
+													cuotaFin < value
+												) {
+													return "Debe ser menor o igual a la cuota final";
+												}
+												return undefined;
+											},
 										}}
-									/>
-									<Label htmlFor="requiereSeguimiento">
-										Requiere seguimiento programado
-									</Label>
+									>
+										{(field) => (
+											<div className="space-y-2">
+												<Label>Cuota desde</Label>
+												<Select
+													value={field.state.value?.toString() ?? ""}
+													onValueChange={(value) =>
+														field.handleChange(
+															value ? Number(value) : undefined,
+														)
+													}
+												>
+													<SelectTrigger>
+														<SelectValue placeholder="Sin cuota" />
+													</SelectTrigger>
+													<SelectContent>
+														{cuotasDisponibles.map((c) => (
+															<SelectItem
+																key={c.numeroCuota}
+																value={c.numeroCuota.toString()}
+															>
+																Cuota #{c.numeroCuota}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+												{field.state.meta.errors.length > 0 && (
+													<p className="text-red-500 text-sm">
+														{field.state.meta.errors.join(", ")}
+													</p>
+												)}
+											</div>
+										)}
+									</form.Field>
+
+									<form.Field
+										name="cuotaFin"
+										validators={{
+											// Espejo del validator de cuotaInicio: sin esto, cambiar
+											// SOLO cuotaFin a un valor menor que cuotaInicio ya
+											// elegido no muestra error ni bloquea el submit (el
+											// validator de cuotaInicio no se re-corre porque ese
+											// campo no cambió) — el .refine() del server sí lo
+											// atrapa, pero como error de red, no como UX inmediata.
+											onChangeListenTo: ["cuotaInicio"],
+											onChange: ({ value, fieldApi }) => {
+												const cuotaInicio =
+													fieldApi.form.getFieldValue("cuotaInicio");
+												if (
+													value != null &&
+													cuotaInicio != null &&
+													value < cuotaInicio
+												) {
+													return "Debe ser mayor o igual a la cuota inicial";
+												}
+												return undefined;
+											},
+										}}
+									>
+										{(field) => (
+											<div className="space-y-2">
+												<Label>Cuota hasta</Label>
+												<Select
+													value={field.state.value?.toString() ?? ""}
+													onValueChange={(value) =>
+														field.handleChange(
+															value ? Number(value) : undefined,
+														)
+													}
+												>
+													<SelectTrigger>
+														<SelectValue placeholder="Igual a 'desde' si es solo una" />
+													</SelectTrigger>
+													<SelectContent>
+														{cuotasDisponibles.map((c) => (
+															<SelectItem
+																key={c.numeroCuota}
+																value={c.numeroCuota.toString()}
+															>
+																Cuota #{c.numeroCuota}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+												{field.state.meta.errors.length > 0 && (
+													<p className="text-red-500 text-sm">
+														{field.state.meta.errors.join(", ")}
+													</p>
+												)}
+											</div>
+										)}
+									</form.Field>
 								</div>
 							)}
-						</form.Field>
+
+							<form.Field
+								name="incluyeMora"
+								validators={{
+									// Re-corre cuando cuotaInicio/cuotaFin cambian (no solo
+									// cuando cambia este checkbox) para que canSubmit refleje
+									// la regla "rango O mora" en tiempo real — antes el error
+									// solo se mostraba como texto, sin bloquear el submit.
+									onChangeListenTo: ["cuotaInicio", "cuotaFin"],
+									onChange: ({ value, fieldApi }) => {
+										const cuotaInicio =
+											fieldApi.form.getFieldValue("cuotaInicio");
+										const cuotaFin = fieldApi.form.getFieldValue("cuotaFin");
+										if (cuotaInicio == null && cuotaFin == null && !value) {
+											return "Indica un rango de cuotas, marca que incluye mora, o ambos";
+										}
+										return undefined;
+									},
+								}}
+							>
+								{(field) => (
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											id="incluyeMora"
+											checked={field.state.value}
+											onCheckedChange={(checked) =>
+												field.handleChange(!!checked)
+											}
+										/>
+										<Label htmlFor="incluyeMora">
+											Incluye pago de mora del crédito
+										</Label>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Subscribe
+								selector={(state) => [
+									state.values.cuotaInicio,
+									state.values.cuotaFin,
+									state.values.incluyeMora,
+								]}
+							>
+								{([cuotaInicio, cuotaFin, incluyeMora]) =>
+									cuotaInicio == null &&
+									cuotaFin == null &&
+									!incluyeMora && (
+										<p className="text-red-500 text-sm">
+											Indica un rango de cuotas, marca que incluye mora, o
+											ambos.
+										</p>
+									)
+								}
+							</form.Subscribe>
+						</div>
+					)}
+
+					{/* Sección: Próximo Seguimiento — en variante "promesa" la fecha ES
+					    la fecha prometida y es obligatoria: no hay checkbox que la
+					    haga opcional (requiereSeguimiento arranca en true y no se
+					    puede desmarcar). */}
+					<div className="space-y-4">
+						<h3 className="font-medium text-lg">
+							{esPromesa ? "Fecha Prometida" : "Próximo Seguimiento"}
+						</h3>
+
+						{!esPromesa && (
+							<form.Field name="requiereSeguimiento">
+								{(field) => (
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											id="requiereSeguimiento"
+											checked={field.state.value}
+											onCheckedChange={(checked) => {
+												field.handleChange(!!checked);
+												if (!checked) {
+													form.setFieldValue("fechaProximoContacto", undefined);
+												}
+											}}
+										/>
+										<Label htmlFor="requiereSeguimiento">
+											Requiere seguimiento programado
+										</Label>
+									</div>
+								)}
+							</form.Field>
+						)}
 
 						<form.Field name="requiereSeguimiento">
 							{(seguimientoField) =>
-								seguimientoField.state.value && (
-									<form.Field name="fechaProximoContacto">
+								(esPromesa || seguimientoField.state.value) && (
+									<form.Field
+										name="fechaProximoContacto"
+										validators={{
+											onChange: ({ value }) =>
+												esPromesa && !value
+													? "La fecha prometida es obligatoria"
+													: undefined,
+										}}
+									>
 										{(field) => (
 											<div className="space-y-2">
-												<Label>Fecha de próximo contacto *</Label>
+												<Label>
+													{esPromesa
+														? "Fecha en la que prometió pagar *"
+														: "Fecha de próximo contacto *"}
+												</Label>
 												<Popover>
 													<PopoverTrigger asChild>
 														<Button
@@ -888,6 +1132,11 @@ export function ContactoModal({
 														/>
 													</PopoverContent>
 												</Popover>
+												{field.state.meta.errors.length > 0 && (
+													<p className="text-red-500 text-sm">
+														{field.state.meta.errors.join(", ")}
+													</p>
+												)}
 											</div>
 										)}
 									</form.Field>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -222,9 +222,17 @@ function RouteComponent() {
 	});
 
 	// Obtener historial de contactos (solo para casos)
+	// CB-020 (Codex, PR #1147): getHistorialContactos aplica su límite ANTES
+	// de que este archivo separe promesa_pago del resto (ver `contactos` y
+	// `promesasPago` abajo) — con el default de 20, un caso con varias
+	// promesas dejaba el Historial general corto y perdía promesas viejas
+	// fuera de esa ventana en ambas listas. El server no filtra por tipo ni
+	// pagina de verdad (solo un límite plano) — hasta que eso se separe en
+	// el backend, subir el límite es el workaround práctico: cubre el caso
+	// real (decenas de contactos), no infinito.
 	const historialContactos = useQuery({
 		...orpc.getHistorialContactos.queryOptions({
-			input: { casoCobroId: casoDetails.data?.id || "" },
+			input: { casoCobroId: casoDetails.data?.id || "", limit: 200 },
 		}),
 		enabled: !!session && !!casoDetails.data?.id,
 	});
@@ -1670,9 +1678,19 @@ function RouteComponent() {
 												)?.[promesa.id] ??
 												promesa.estadoPromesa ??
 												"pendiente";
+											// Mismo criterio de gracia que el backend (ver
+											// finDeGraciaGT en lib/promesa-pago.ts): comparar el
+											// instante crudo marcaba VENCIDA desde medianoche GT
+											// del MISMO día prometido, contradiciendo el badge
+											// "Pendiente" que sí usa esa gracia (Codex, PR #1147).
+											const finDeGraciaGT = fechaPrometida
+												? new Date(
+														fechaPrometida.getTime() + 24 * 60 * 60 * 1000,
+													)
+												: null;
 											const vencida =
-												fechaPrometida !== null &&
-												fechaPrometida < hoy &&
+												finDeGraciaGT !== null &&
+												finDeGraciaGT <= hoy &&
 												estadoPromesa !== "cumplida";
 											const estadoBadge: Record<
 												EstadoPromesa,

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -11,6 +11,7 @@ import {
 	Clock,
 	Eye,
 	FileText,
+	HandCoins,
 	Loader,
 	Mail,
 	MapPin,
@@ -24,7 +25,7 @@ import {
 	Users,
 	X,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ReferenciasView } from "@/components/cobros/ReferenciasView";
 import { SeguimientoRecurrenteModal } from "@/components/cobros/seguimiento-recurrente-modal";
@@ -226,6 +227,40 @@ function RouteComponent() {
 			input: { casoCobroId: casoDetails.data?.id || "" },
 		}),
 		enabled: !!session && !!casoDetails.data?.id,
+	});
+
+	// CB-020: promesas de pago registradas en el historial. El estado
+	// (pendiente/cumplida/incumplida) vive en estadoPromesa (columna DB) y se
+	// recalcula/persiste vía getEstadoPromesasPago (ver abajo). La tarjeta
+	// prioriza el resultado EN MEMORIA de esa query (más fresco) sobre
+	// promesa.estadoPromesa (columna DB, puede estar un ciclo atrás) — NO se
+	// invalida/refetchea historialContactos tras el cálculo: eso generaba un
+	// array `promesasPago` con nueva identidad en cada éxito, lo que a su vez
+	// recalculaba el input de esta misma query (key distinta) y volvía a
+	// disparar el efecto — un ciclo de refetch innecesario que se evita
+	// leyendo el resultado directo en vez de ir a buscarlo de nuevo a la DB.
+	const promesasPago = useMemo(
+		() =>
+			(historialContactos.data || []).filter(
+				(c: any) => c.estadoContacto === "promesa_pago",
+			),
+		[historialContactos.data],
+	);
+	const estadoPromesasPago = useQuery({
+		...orpc.getEstadoPromesasPago.queryOptions({
+			input: {
+				numeroSifco: casoDetails.data?.numeroCreditoSifco || id || "",
+				// El server carga cuotaInicio/cuotaFin/incluyeMora/fechaPrometida de
+				// DB por id (no confía en lo que mande el cliente) — solo manda ids.
+				promesaIds: promesasPago
+					.filter((p: any) => p.fechaProximoContacto)
+					.map((p: any) => p.id),
+			},
+		}),
+		enabled:
+			!!session &&
+			promesasPago.length > 0 &&
+			!!(casoDetails.data?.numeroCreditoSifco || id),
 	});
 
 	// Obtener seguimientos activos
@@ -467,7 +502,11 @@ function RouteComponent() {
 	}
 
 	const caso = casoDetails.data;
-	const contactos = historialContactos.data || [];
+	// CB-020: las promesas de pago viven SOLO en la tarjeta "Promesas de
+	// Pago" (ver promesasPago) — no en el Historial de Contactos general.
+	const contactos = (historialContactos.data || []).filter(
+		(c: any) => c.estadoContacto !== "promesa_pago",
+	);
 	const convenios = conveniosPago.data || [];
 	const cuotas = historialPagos.data || [];
 	const recuperacion = recuperacionInfo.data;
@@ -1210,6 +1249,56 @@ function RouteComponent() {
 												Email
 											</Button>
 										</ContactoModal>
+
+										{/* CB-020: modal reducido — solo Detalles de la
+										    Conversación + fecha prometida (obligatoria). */}
+										<ContactoModal
+											casoCobroId={caso.id}
+											clienteNombre={caso.clienteNombre || ""}
+											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											telefonoAlternativo={
+												caso.telefonoAlternativo
+													? String(caso.telefonoAlternativo)
+													: undefined
+											}
+											emailCliente={caso.emailContacto || ""}
+											metodoInicial="llamada"
+											variante="promesa"
+											cuotasDisponibles={cuotas
+												.filter(
+													(c: any) =>
+														c.estadoMora !== "pagado" &&
+														c.fechaVencimiento &&
+														new Date(c.fechaVencimiento) < new Date(),
+												)
+												.map((c: any) => ({ numeroCuota: c.numeroCuota }))}
+											fechaPago={String(caso.diaPagoMensual || 15)}
+											cuotaMensual={Number(
+												caso.cuotaMensual || 0,
+											).toLocaleString()}
+											placa={caso.vehiculoPlaca || ""}
+											marcaLineaModelo={`${caso.vehiculoMarca || ""} ${caso.vehiculoModelo || ""} ${caso.vehiculoYear || ""}`.trim()}
+											montoAdeudado={(
+												Number(caso.montoEnMora || 0) +
+												Number(caso.cuotaMensual || 0)
+											).toLocaleString("es-GT", {
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											})}
+											cuotasAtraso={caso.cuotasVencidas ?? 0}
+											estadoMora={caso.estadoMora || undefined}
+											fechaInicio={caso.fechaInicio || null}
+											nombreAsesor={caso.asesor?.nombre || ""}
+											telefonoAsesor={caso.asesor?.telefono || ""}
+										>
+											<Button
+												variant="outline"
+												className="flex items-center gap-2"
+											>
+												<HandCoins className="h-4 w-4" />
+												Promesa de Pago
+											</Button>
+										</ContactoModal>
 									</div>
 								</>
 							) : (
@@ -1539,6 +1628,128 @@ function RouteComponent() {
 							)}
 						</CardContent>
 					</Card>
+
+					{/* CB-020: Promesas de Pago — filtro sobre los mismos contactos
+					    (no query aparte para listarlas). Las promesas ya NO aparecen
+					    en el Historial de arriba (se filtran ahí, ver `contactos`).
+					    Cumplida/incumplida/pendiente viene de estadoPromesa, persistido
+					    por getEstadoPromesasPago verificando cuotas + mora del crédito
+					    en cartera-back — 100% automático, sin confirmación manual. */}
+					{(() => {
+						if (promesasPago.length === 0) return null;
+						const hoy = new Date();
+						// Redeclarado localmente (no importado del server): igual al
+						// EstadoPromesa de lib/promesa-pago.ts en el backend — mantener
+						// ambos alineados si ese union cambia.
+						type EstadoPromesa = "pendiente" | "cumplida" | "incumplida";
+						return (
+							<Card>
+								<CardHeader>
+									<CardTitle className="flex items-center gap-2">
+										<HandCoins className="h-5 w-5" />
+										Promesas de Pago
+									</CardTitle>
+									<CardDescription>
+										Cuotas y/o mora que el cliente prometió pagar
+									</CardDescription>
+								</CardHeader>
+								<CardContent>
+									<div className="space-y-4">
+										{promesasPago.map((promesa: any) => {
+											const fechaPrometida = promesa.fechaProximoContacto
+												? new Date(promesa.fechaProximoContacto)
+												: null;
+											// Prioriza el resultado recién calculado (en memoria,
+											// sin refetch) sobre la columna DB, que puede estar un
+											// ciclo atrás si esta es la primera visita al caso.
+											const estadoPromesa: EstadoPromesa =
+												(
+													estadoPromesasPago.data as
+														| Record<string, EstadoPromesa>
+														| undefined
+												)?.[promesa.id] ??
+												promesa.estadoPromesa ??
+												"pendiente";
+											const vencida =
+												fechaPrometida !== null &&
+												fechaPrometida < hoy &&
+												estadoPromesa !== "cumplida";
+											const estadoBadge: Record<
+												EstadoPromesa,
+												{ label: string; color: string }
+											> = {
+												cumplida: {
+													label: "Cumplida",
+													color: "bg-green-100 text-green-800",
+												},
+												incumplida: {
+													label: "Incumplida",
+													color: "bg-red-100 text-red-800",
+												},
+												pendiente: {
+													label: "Pendiente",
+													color: "bg-blue-100 text-blue-800",
+												},
+											};
+											const badge = estadoBadge[estadoPromesa];
+											const tieneRango =
+												promesa.cuotaInicio != null && promesa.cuotaFin != null;
+											const etiquetaRango = tieneRango
+												? promesa.cuotaInicio === promesa.cuotaFin
+													? `Cuota #${promesa.cuotaInicio}`
+													: `Cuotas #${promesa.cuotaInicio} a #${promesa.cuotaFin}`
+												: "Mora del crédito";
+											return (
+												<div key={promesa.id} className="rounded-lg border p-4">
+													<div className="mb-2 flex items-start justify-between">
+														<div className="flex flex-wrap items-center gap-2">
+															<span className="font-medium">
+																{etiquetaRango}
+															</span>
+															{tieneRango && promesa.incluyeMora && (
+																<Badge variant="outline">+ Mora</Badge>
+															)}
+															<span className="text-muted-foreground text-sm">
+																{fechaPrometida
+																	? fechaPrometida.toLocaleDateString("es-GT")
+																	: "Sin fecha"}
+															</span>
+															<Badge className={badge.color}>
+																{badge.label}
+															</Badge>
+															{vencida && (
+																<Badge className="bg-red-600 text-white">
+																	VENCIDA
+																</Badge>
+															)}
+														</div>
+														<p className="text-muted-foreground text-sm">
+															Registrada:{" "}
+															{promesa.fechaContacto
+																? new Date(
+																		promesa.fechaContacto,
+																	).toLocaleDateString("es-GT")
+																: "Sin fecha"}
+														</p>
+													</div>
+													<p className="mb-2 text-sm">{promesa.comentarios}</p>
+													{promesa.compromisosPago && (
+														<div className="rounded bg-green-50 p-2 text-sm">
+															<span className="font-medium">Compromiso: </span>
+															{promesa.compromisosPago}
+														</div>
+													)}
+													<div className="mt-2 text-muted-foreground text-xs">
+														Por: {promesa.realizadoPor || "Sin asignar"}
+													</div>
+												</div>
+											);
+										})}
+									</div>
+								</CardContent>
+							</Card>
+						);
+					})()}
 
 					{/* Historial de Pagos */}
 					<Card>


### PR DESCRIPTION
## Summary
- Botón dedicado "Promesa de Pago" en el detalle del caso, con modal reducido (`ContactoModal variante="promesa"`) que oculta método/estado/plantilla y solo pide detalles de conversación + rango de cuotas + checkbox de mora + fecha prometida (obligatoria).
- Selector de rango de cuotas (desde/hasta) sobre las cuotas atrasadas reales del contrato, más checkbox "Incluye pago de mora del crédito" — independientes entre sí (puede ser solo rango, solo mora, o ambos), con validación cruzada en el form.
- Tarjeta "Promesas de Pago" separada del Historial de Contactos general (las promesas ya no aparecen ahí), con badge de estado (pendiente/cumplida/incumplida) y badge "VENCIDA" cuando aplica.
- Ajustado el payload de `getEstadoPromesasPago` a `{ numeroSifco, promesaIds: string[] }` para coincidir con el contrato final del server (PR #1146, ya mergeado a `COBROS-02`) — el server carga los datos reales de DB por id en vez de confiar en lo que mande el cliente.

## Test plan
- [ ] Registrar promesa con rango de cuotas (sin mora) → aparece en tarjeta "Promesas de Pago", no en Historial, estado "Pendiente".
- [ ] Registrar promesa de solo mora (sin rango) → tarjeta muestra "Mora del crédito".
- [ ] Registrar promesa con rango + mora → badge "+ Mora" junto al rango.
- [ ] Promesa con rango ya pagado en cartera-back → pasa a "Cumplida" al abrir el caso.
- [ ] Promesa con fecha vencida y rango sin pagar → "Incumplida" + badge "VENCIDA".
- [ ] `bun check-types` en server limpio (web tiene errores preexistentes no relacionados, ver nota abajo).

## Nota
`bun check-types` en `web` reporta que varios procedures del router (`getEstadoPromesasPago`, `getAgendaDia`, `getRecordatoriosPremora`, etc.) "no existen" — es un falso positivo preexistente en `COBROS-02` por límite de inferencia de TS sobre el router de cobros (5000+ líneas en un solo objeto), no un error real: todos esos procedures están registrados y funcionan en runtime, y `server check-types` (que compila `cobros.ts` en su propio scope) pasa limpio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)