### PR TITLE
feat(cobros): CRM web — Promesa de Pago atada a rango de cuotas y/o mora (CB-020)

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros-contacto-schema.test.ts
+++ b/apps/crm/apps/server/src/routers/cobros-contacto-schema.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { createContactoCobrosSchema } from "./cobros";
+
+/**
+ * CB-020 (Codex, PR #1147): los 2 .refine() de promesa_pago (rango/mora
+ * obligatorio, fecha obligatoria) estuvieron comentados por varias rondas
+ * mientras el web viejo no los soportaba — se repusieron cuando el web nuevo
+ * se mergeó (PR #1147). Este test es la regresión que faltaba: si alguien
+ * vuelve a comentarlos o los rompe sin querer, esto lo atrapa antes de
+ * producción.
+ */
+
+function base(overrides: Partial<Record<string, unknown>> = {}) {
+	return {
+		casoCobroId: "00000000-0000-0000-0000-000000000000",
+		metodoContacto: "llamada" as const,
+		estadoContacto: "promesa_pago" as const,
+		comentarios: "Cliente confirmó pago",
+		requiereSeguimiento: true,
+		fechaProximoContacto: new Date("2026-08-01"),
+		incluyeMora: false,
+		...overrides,
+	};
+}
+
+describe("createContactoCobrosSchema — promesa_pago", () => {
+	test("rango de cuotas sin mora → válido", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ cuotaInicio: 1, cuotaFin: 2 }),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	test("solo mora sin rango → válido", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ incluyeMora: true }),
+		);
+		expect(result.success).toBe(true);
+	});
+
+	test("sin rango Y sin mora → inválido (regla repuesta)", () => {
+		const result = createContactoCobrosSchema.safeParse(base());
+		expect(result.success).toBe(false);
+	});
+
+	test("sin fechaProximoContacto → inválido (regla repuesta)", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ cuotaInicio: 1, cuotaFin: 1, fechaProximoContacto: undefined }),
+		);
+		expect(result.success).toBe(false);
+	});
+
+	test("rango a medias (solo cuotaInicio) → inválido", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ cuotaInicio: 1, incluyeMora: true }),
+		);
+		expect(result.success).toBe(false);
+	});
+
+	test("cuotaFin menor que cuotaInicio → inválido", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({ cuotaInicio: 5, cuotaFin: 2 }),
+		);
+		expect(result.success).toBe(false);
+	});
+
+	test("estadoContacto distinto de promesa_pago → reglas de promesa no aplican", () => {
+		const result = createContactoCobrosSchema.safeParse(
+			base({
+				estadoContacto: "contactado",
+				fechaProximoContacto: undefined,
+				requiereSeguimiento: false,
+			}),
+		);
+		expect(result.success).toBe(true);
+	});
+});

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -399,6 +399,84 @@ async function autoCrearDatosMigrate({
 	};
 }
 
+// CB-020: input de createContactoCobros, extraído como constante exportada
+// (Codex, PR #1147) para poder testear los .refine() de promesa_pago
+// (rango/mora obligatorio, fecha obligatoria) sin depender de DB/contexto —
+// antes vivía inline dentro de .input(), sin forma de importarlo en un test.
+export const createContactoCobrosSchema = z
+	.object({
+		casoCobroId: z.string().uuid(),
+		metodoContacto: z.enum(metodoContactoEnum.enumValues),
+		estadoContacto: z.enum(estadoContactoEnum.enumValues),
+		duracionLlamada: z.number().optional(),
+		comentarios: z.string().min(1, "Los comentarios son requeridos"),
+		acuerdosAlcanzados: z.string().optional(),
+		compromisosPago: z.string().optional(),
+		requiereSeguimiento: z.boolean().default(false),
+		fechaProximoContacto: z.date().optional(),
+		// CB-020: promesa de pago atada a cuotas — solo relevantes cuando
+		// estadoContacto = 'promesa_pago'.
+		cuotaInicio: z.number().int().positive().optional(),
+		cuotaFin: z.number().int().positive().optional(),
+		incluyeMora: z.boolean().default(false),
+	})
+	// CB-020: promesa_pago exige rango de cuotas y/o mora — una
+	// promesa vacía de ambos no verifica nada real. El web (PR
+	// #1147, mergeado) ya exige esto en el modal; este .refine()
+	// estuvo deshabilitado temporalmente mientras el web viejo en
+	// producción todavía mandaba promesa_pago sin ninguno de los
+	// dos — repuesto ahora que ese web se reemplazó.
+	.refine(
+		(v) =>
+			v.estadoContacto !== "promesa_pago" ||
+			v.cuotaInicio != null ||
+			v.cuotaFin != null ||
+			v.incluyeMora,
+		{
+			message: "Indica un rango de cuotas, marca que incluye mora, o ambos",
+			path: ["incluyeMora"],
+		},
+	)
+	.refine(
+		(v) =>
+			v.cuotaInicio == null ||
+			v.cuotaFin == null ||
+			v.cuotaFin >= v.cuotaInicio,
+		{
+			message: "cuotaFin debe ser mayor o igual a cuotaInicio",
+			path: ["cuotaFin"],
+		},
+	)
+	// CB-020: fechaProximoContacto es la fecha prometida — sin ella,
+	// check-promesas-pago.ts (job nocturno) salta la fila para
+	// siempre, dejándola "pendiente" eterna. El web (PR #1147,
+	// mergeado) ya la exige en el modal (obligatoria al submit);
+	// repuesto ahora que ese web se reemplazó.
+	.refine(
+		(v) => v.estadoContacto !== "promesa_pago" || v.fechaProximoContacto != null,
+		{
+			message: "La fecha prometida es obligatoria",
+			path: ["fechaProximoContacto"],
+		},
+	)
+	.refine(
+		// CB-020 (review Codex): el primer .refine() de arriba solo exige
+		// "rango completo O incluyeMora" — eso deja pasar un rango A
+		// MEDIAS (ej. cuotaInicio=5, cuotaFin=null) siempre que
+		// incluyeMora=true, porque esa condición sola ya satisface el
+		// OR. evaluarPromesa trata cuotaFin=null como "sin rango, no
+		// bloquea" (tieneRango=false), así que la cuota #5 que el
+		// usuario SÍ especificó nunca se verifica — una promesa de
+		// "mora + cuota" puede marcarse cumplida con solo que se
+		// salde la mora. Ambos bounds o ninguno, SIEMPRE, sin
+		// importar incluyeMora.
+		(v) => (v.cuotaInicio == null) === (v.cuotaFin == null),
+		{
+			message: "Debes indicar ambas cuotas (desde y hasta) o ninguna",
+			path: ["cuotaFin"],
+		},
+	);
+
 export const cobrosRouter = {
 	// Dashboard de cobros - Vista general del embudo
 	getDashboardStats: cobrosProcedure
@@ -1337,94 +1415,7 @@ export const cobrosRouter = {
 
 	// Registrar contacto de cobros
 	createContactoCobros: cobrosProcedure
-		.input(
-			z
-				.object({
-					casoCobroId: z.string().uuid(),
-					metodoContacto: z.enum(metodoContactoEnum.enumValues),
-					estadoContacto: z.enum(estadoContactoEnum.enumValues),
-					duracionLlamada: z.number().optional(),
-					comentarios: z.string().min(1, "Los comentarios son requeridos"),
-					acuerdosAlcanzados: z.string().optional(),
-					compromisosPago: z.string().optional(),
-					requiereSeguimiento: z.boolean().default(false),
-					fechaProximoContacto: z.date().optional(),
-					// CB-020: promesa de pago atada a cuotas — solo relevantes cuando
-					// estadoContacto = 'promesa_pago'.
-					cuotaInicio: z.number().int().positive().optional(),
-					cuotaFin: z.number().int().positive().optional(),
-					incluyeMora: z.boolean().default(false),
-				})
-				// ⚠️ DEUDA TÉCNICA TEMPORAL (review Codex, ronda 3 — PR #1145) ⚠️
-				// Este .refine() era OBLIGATORIO (rango o mora) — pero el web
-				// ACTUAL en COBROS-02 todavía manda promesa_pago SIN ninguno de
-				// los dos. El modal nuevo (con selector de cuotas + checkbox de
-				// mora) vive en `git stash show stash@{0}` de esta sesión —
-				// "CRM web: promesa de pago (CB-020)" — sin PR abierto todavía.
-				// Con el .refine() estricto, desplegar este PR solo hubiera roto
-				// el botón "Promesa de Pago" que ya funciona en producción.
-				//
-				// Se quita esta exigencia por completo — el "ambos bounds o
-				// ninguno" del .refine() de más abajo sigue vigente y es
-				// suficiente para bloquear rangos a medias; lo único que se
-				// relaja es "algo es obligatorio" (rango o mora), permitiendo de
-				// nuevo el caso 100% vacío del web viejo.
-				//
-				// ACCIÓN REQUERIDA cuando el PR de web (stash de arriba) se
-				// mergee: reponer este .refine() y el de fechaProximoContacto
-				// (más abajo, mismo motivo) en un PR de limpieza aparte. Buscar
-				// "DEUDA TÉCNICA TEMPORAL" en este archivo para encontrar ambos.
-				.refine(
-					(v) =>
-						v.cuotaInicio == null ||
-						v.cuotaFin == null ||
-						v.cuotaFin >= v.cuotaInicio,
-					{
-						message: "cuotaFin debe ser mayor o igual a cuotaInicio",
-						path: ["cuotaFin"],
-					},
-				)
-				// ⚠️ DEUDA TÉCNICA TEMPORAL (review Codex, ronda 3 — PR #1145) ⚠️
-				// Este .refine() asumía que "el front la exige en el modal" —
-				// cierto SOLO para la variante nueva (`git stash show
-				// stash@{0}`, "CRM web: promesa de pago (CB-020)", sin PR
-				// abierto). El web ACTUAL en COBROS-02 tiene "requiereSeguimiento"
-				// como checkbox GENÉRICO e independiente de estadoContacto: un
-				// asesor puede registrar promesa_pago sin marcarlo, y
-				// fechaProximoContacto queda undefined. Con este .refine() activo,
-				// ESE registro (que hoy funciona en producción) sería rechazado.
-				//
-				// Se quita hasta que el PR de web se mergee (ahí la fecha SÍ es
-				// obligatoria en el modal nuevo).
-				//
-				// El riesgo que motivó este .refine() (check-promesas-pago.ts
-				// salta filas sin fecha para siempre) sigue documentado y
-				// pendiente — sin fecha, esas promesas simplemente no se evalúan,
-				// comportamiento IGUAL al que ya tenía el código antes de esta
-				// feature (no es una regresión, es mantener el status quo).
-				//
-				// ACCIÓN REQUERIDA cuando el PR de web se mergee: reponer este
-				// .refine() junto con el de rango/mora obligatorio de arriba (en
-				// un PR de limpieza aparte). Buscar "DEUDA TÉCNICA TEMPORAL" en
-				// este archivo para encontrar ambos.
-				.refine(
-					// CB-020 (review Codex): el primer .refine() de arriba solo exige
-					// "rango completo O incluyeMora" — eso deja pasar un rango A
-					// MEDIAS (ej. cuotaInicio=5, cuotaFin=null) siempre que
-					// incluyeMora=true, porque esa condición sola ya satisface el
-					// OR. evaluarPromesa trata cuotaFin=null como "sin rango, no
-					// bloquea" (tieneRango=false), así que la cuota #5 que el
-					// usuario SÍ especificó nunca se verifica — una promesa de
-					// "mora + cuota" puede marcarse cumplida con solo que se
-					// salde la mora. Ambos bounds o ninguno, SIEMPRE, sin
-					// importar incluyeMora.
-					(v) => (v.cuotaInicio == null) === (v.cuotaFin == null),
-					{
-						message: "Debes indicar ambas cuotas (desde y hasta) o ninguna",
-						path: ["cuotaFin"],
-					},
-				),
-		)
+		.input(createContactoCobrosSchema)
 		.handler(async ({ input, context }) => {
 			const estadoPromesa =
 				input.estadoContacto === "promesa_pago" ? "pendiente" : undefined;

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -64,6 +64,39 @@ import {
 import { cn } from "@/lib/utils";
 import { client, orpc } from "@/utils/orpc";
 
+// CB-020: regla "rango o mora" — un checkbox de mora, un guard onSubmit del
+// campo y otro del form la repetían con el mismo string literal cada vez
+// (Codex, PR #1147). Centralizado para que un cambio de mensaje o condición
+// no pueda desincronizarse entre las 3 copias.
+const MENSAJE_RANGO_O_MORA_REQUERIDO =
+	"Indica un rango de cuotas, marca que incluye mora, o ambos";
+
+function faltaRangoOMora(
+	cuotaInicio: number | null | undefined,
+	cuotaFin: number | null | undefined,
+	incluyeMora: boolean,
+): boolean {
+	return cuotaInicio == null && cuotaFin == null && !incluyeMora;
+}
+
+/**
+ * CB-020 (Codex, PR #1147): el backend asume fechaProximoContacto guardada
+ * como medianoche GT (ver gtDateStrToDate en
+ * server/src/lib/guatemala-month-window.ts, T06:00:00Z = 00:00 GT) — la
+ * gracia de +24h de evaluarPromesa depende de ese punto de partida exacto.
+ * El Calendar de shadcn devolvía el Date crudo del navegador (medianoche en
+ * la zona horaria LOCAL del asesor, no necesariamente GT); si algún asesor
+ * corre con el reloj/timezone del sistema desalineado, la fecha guardada se
+ * corría de día. Se normaliza aquí al mismo formato que usa el backend, sin
+ * importar código de server (web no puede importar de apps/server).
+ */
+function fechaAMedianocheGT(date: Date): Date {
+	const anio = date.getFullYear();
+	const mes = String(date.getMonth() + 1).padStart(2, "0");
+	const dia = String(date.getDate()).padStart(2, "0");
+	return new Date(`${anio}-${mes}-${dia}T06:00:00.000Z`);
+}
+
 interface ContactoModalProps {
 	casoCobroId: string;
 	clienteNombre: string;
@@ -230,12 +263,24 @@ export function ContactoModal({
 			incluyeMora: false,
 		},
 		onSubmit: async ({ value }) => {
-			// Guard explícito además del validator del campo (Codex, PR #1147):
-			// si el campo nunca se toca, su validator onChange nunca corre y
-			// canSubmit puede no reflejar el error a tiempo — sin esto, una
-			// promesa podía enviarse con fechaProximoContacto undefined.
+			// NO ELIMINAR sin también quitar el botón submit de canSubmit
+			// (Codex, PR #1147): este guard es la defensa REAL — los
+			// validators onSubmit de los campos (fechaProximoContacto,
+			// incluyeMora, más abajo en el JSX) alimentan `canSubmit`, pero
+			// TanStack Form corre validators onSubmit DESPUÉS de invocar este
+			// handler, no antes — si algún día se asume que `canSubmit` ya
+			// garantiza esto y se borra este guard pensando que es
+			// redundante, reaparece el bug original: campo nunca tocado =
+			// onChange nunca corrió = se guarda sin fecha/rango/mora.
 			if (esPromesa && !value.fechaProximoContacto) {
 				toast.error("La fecha prometida es obligatoria");
+				return;
+			}
+			if (
+				esPromesa &&
+				faltaRangoOMora(value.cuotaInicio, value.cuotaFin, value.incluyeMora)
+			) {
+				toast.error(MENSAJE_RANGO_O_MORA_REQUERIDO);
 				return;
 			}
 			createContactoMutation.mutate(value);
@@ -1016,10 +1061,21 @@ export function ContactoModal({
 										const cuotaInicio =
 											fieldApi.form.getFieldValue("cuotaInicio");
 										const cuotaFin = fieldApi.form.getFieldValue("cuotaFin");
-										if (cuotaInicio == null && cuotaFin == null && !value) {
-											return "Indica un rango de cuotas, marca que incluye mora, o ambos";
-										}
-										return undefined;
+										return faltaRangoOMora(cuotaInicio, cuotaFin, value)
+											? MENSAJE_RANGO_O_MORA_REQUERIDO
+											: undefined;
+									},
+									// onChange no corre si el asesor nunca toca cuotas NI el
+									// checkbox (form arranca en undefined/undefined/false) —
+									// mismo patrón del bug de fecha (Codex, PR #1147): sin
+									// onSubmit, se podía guardar una promesa sin rango ni mora.
+									onSubmit: ({ value, fieldApi }) => {
+										const cuotaInicio =
+											fieldApi.form.getFieldValue("cuotaInicio");
+										const cuotaFin = fieldApi.form.getFieldValue("cuotaFin");
+										return faltaRangoOMora(cuotaInicio, cuotaFin, value)
+											? MENSAJE_RANGO_O_MORA_REQUERIDO
+											: undefined;
 									},
 								}}
 							>
@@ -1047,12 +1103,13 @@ export function ContactoModal({
 								]}
 							>
 								{([cuotaInicio, cuotaFin, incluyeMora]) =>
-									cuotaInicio == null &&
-									cuotaFin == null &&
-									!incluyeMora && (
+									faltaRangoOMora(
+										cuotaInicio as number | null | undefined,
+										cuotaFin as number | null | undefined,
+										!!incluyeMora,
+									) && (
 										<p className="text-red-500 text-sm">
-											Indica un rango de cuotas, marca que incluye mora, o
-											ambos.
+											{MENSAJE_RANGO_O_MORA_REQUERIDO}.
 										</p>
 									)
 								}
@@ -1142,7 +1199,11 @@ export function ContactoModal({
 														<Calendar
 															mode="single"
 															selected={field.state.value}
-															onSelect={(date) => field.handleChange(date)}
+															onSelect={(date) =>
+																field.handleChange(
+																	date ? fechaAMedianocheGT(date) : date,
+																)
+															}
 															disabled={(date) =>
 																date < new Date(new Date().setHours(0, 0, 0, 0))
 															}

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -230,6 +230,14 @@ export function ContactoModal({
 			incluyeMora: false,
 		},
 		onSubmit: async ({ value }) => {
+			// Guard explícito además del validator del campo (Codex, PR #1147):
+			// si el campo nunca se toca, su validator onChange nunca corre y
+			// canSubmit puede no reflejar el error a tiempo — sin esto, una
+			// promesa podía enviarse con fechaProximoContacto undefined.
+			if (esPromesa && !value.fechaProximoContacto) {
+				toast.error("La fecha prometida es obligatoria");
+				return;
+			}
 			createContactoMutation.mutate(value);
 		},
 	});
@@ -1089,7 +1097,17 @@ export function ContactoModal({
 									<form.Field
 										name="fechaProximoContacto"
 										validators={{
+											// onChange no corre si el campo nunca se toca (form
+											// arranca en undefined) — sin onSubmit, un asesor que
+											// nunca abre el calendario puede enviar la promesa sin
+											// fecha (Codex, PR #1147): la fila queda invisible para
+											// getEstadoPromesasPago (este mismo archivo filtra por
+											// fechaProximoContacto antes de armar promesaIds).
 											onChange: ({ value }) =>
+												esPromesa && !value
+													? "La fecha prometida es obligatoria"
+													: undefined,
+											onSubmit: ({ value }) =>
 												esPromesa && !value
 													? "La fecha prometida es obligatoria"
 													: undefined,

--- a/apps/crm/apps/web/src/components/contacto-modal.tsx
+++ b/apps/crm/apps/web/src/components/contacto-modal.tsx
@@ -75,6 +75,16 @@ interface ContactoModalProps {
 	// Modo controlado opcional (cuando el padre maneja el estado open)
 	open?: boolean;
 	onOpenChange?: (open: boolean) => void;
+	// CB-020: "promesa" = modal reducido — solo Detalles de la Conversación +
+	// fecha prometida (obligatoria). Oculta método/estado/plantilla/envío:
+	// esos ya quedan fijos (estadoContacto=promesa_pago) porque la promesa se
+	// registra DESPUÉS de haber contactado al cliente por otro medio.
+	variante?: "completo" | "promesa";
+	// CB-020: cuotas ATRASADAS (no pagadas Y ya vencidas — no incluye cuotas
+	// futuras aún no vencidas) para el selector de rango en variante "promesa".
+	// $id.tsx filtra por fechaVencimiento < hoy antes de pasarlas — reusa la
+	// data que ya carga vía getHistorialPagos, no duplica el fetch aquí.
+	cuotasDisponibles?: Array<{ numeroCuota: number }>;
 	// Variables para plantillas de mensaje
 	fechaPago?: string;
 	cuotaMensual?: string;
@@ -98,6 +108,8 @@ export function ContactoModal({
 	children,
 	open,
 	onOpenChange,
+	variante = "completo",
+	cuotasDisponibles = [],
 	fechaPago = "",
 	cuotaMensual = "",
 	placa = "",
@@ -191,16 +203,31 @@ export function ContactoModal({
 		}
 	};
 
+	const esPromesa = variante === "promesa";
+
 	const form = useForm({
 		defaultValues: {
 			metodoContacto: metodoInicial,
-			estadoContacto: "contactado" as const,
+			// CB-020: variante promesa fija el estado — no pasa por el selector.
+			estadoContacto: (esPromesa ? "promesa_pago" : "contactado") as
+				| "contactado"
+				| "no_contesta"
+				| "numero_equivocado"
+				| "promesa_pago"
+				| "acuerdo_parcial"
+				| "rechaza_pagar",
 			comentarios: "",
 			acuerdosAlcanzados: "",
 			compromisosPago: "",
-			requiereSeguimiento: false,
+			// La fecha prometida ES la fecha de próximo contacto — nunca opcional
+			// en la variante promesa (por eso arranca en true).
+			requiereSeguimiento: esPromesa,
 			fechaProximoContacto: undefined as Date | undefined,
 			duracionLlamada: undefined as number | undefined,
+			// CB-020: rango de cuotas + mora — solo relevantes en variante promesa.
+			cuotaInicio: undefined as number | undefined,
+			cuotaFin: undefined as number | undefined,
+			incluyeMora: false,
 		},
 		onSubmit: async ({ value }) => {
 			createContactoMutation.mutate(value);
@@ -431,12 +458,18 @@ export function ContactoModal({
 			<DialogContent className="max-h-[90vh] min-w-3xl max-w-4xl overflow-y-auto">
 				<DialogHeader>
 					<DialogTitle className="flex items-center gap-2">
-						{getIconoMetodo(metodoInicial)}
-						Registrar Contacto - {clienteNombre}
+						{esPromesa ? (
+							<MessageSquare className="h-4 w-4" />
+						) : (
+							getIconoMetodo(metodoInicial)
+						)}
+						{esPromesa ? "Promesa de Pago" : "Registrar Contacto"} -{" "}
+						{clienteNombre}
 					</DialogTitle>
 					<DialogDescription>
-						Registra los detalles de la interacción con el cliente y programa el
-						próximo seguimiento.
+						{esPromesa
+							? "Registra lo hablado y la fecha en la que el cliente prometió pagar."
+							: "Registra los detalles de la interacción con el cliente y programa el próximo seguimiento."}
 					</DialogDescription>
 				</DialogHeader>
 
@@ -448,273 +481,278 @@ export function ContactoModal({
 					}}
 					className="space-y-6"
 				>
-					{/* Sección: Información del Contacto */}
-					<div className="space-y-4">
-						<h3 className="font-medium text-lg">Información del Contacto</h3>
+					{/* Sección: Información del Contacto — oculta en variante "promesa":
+					    el método/estado/plantilla/envío no aplican, la promesa se
+					    registra sobre un contacto que ya ocurrió por otro medio. */}
+					{!esPromesa && (
+						<div className="space-y-4">
+							<h3 className="font-medium text-lg">Información del Contacto</h3>
 
-						<div className="grid grid-cols-2 gap-4">
-							<form.Field name="metodoContacto">
-								{(field) => (
+							<div className="grid grid-cols-2 gap-4">
+								<form.Field name="metodoContacto">
+									{(field) => (
+										<div className="space-y-2">
+											<Label>Método de Contacto</Label>
+											<Select
+												onValueChange={(value) =>
+													form.setFieldValue(
+														field.name,
+														value as typeof field.state.value,
+													)
+												}
+												defaultValue={field.state.value}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="Seleccionar método" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="llamada">📞 Llamada</SelectItem>
+													<SelectItem value="whatsapp">💬 WhatsApp</SelectItem>
+													<SelectItem value="email">📧 Email</SelectItem>
+													<SelectItem value="visita_domicilio">
+														🏠 Visita Domicilio
+													</SelectItem>
+													<SelectItem value="carta_notarial">
+														📋 Carta Notarial
+													</SelectItem>
+												</SelectContent>
+											</Select>
+										</div>
+									)}
+								</form.Field>
+
+								<form.Field name="estadoContacto">
+									{(field) => (
+										<div className="space-y-2">
+											<Label>Estado del Contacto</Label>
+											<Select
+												onValueChange={(value) =>
+													form.setFieldValue(
+														field.name,
+														value as typeof field.state.value,
+													)
+												}
+												defaultValue={field.state.value}
+											>
+												<SelectTrigger>
+													<SelectValue placeholder="Estado del contacto" />
+												</SelectTrigger>
+												<SelectContent>
+													<SelectItem value="contactado">
+														✅ Contactado
+													</SelectItem>
+													<SelectItem value="no_contesta">
+														❌ No Contesta
+													</SelectItem>
+													<SelectItem value="numero_equivocado">
+														📱 Número Equivocado
+													</SelectItem>
+													{/* CB-020: "Promesa de Pago" se registra SOLO desde el
+													    botón dedicado (modal reducido) — no aquí. */}
+													<SelectItem value="acuerdo_parcial">
+														📝 Acuerdo Parcial
+													</SelectItem>
+													<SelectItem value="rechaza_pagar">
+														🚫 Rechaza Pagar
+													</SelectItem>
+												</SelectContent>
+											</Select>
+										</div>
+									)}
+								</form.Field>
+							</div>
+
+							{/* Selector de plantilla para WhatsApp y Email */}
+							{mostrarPlantillas && (
+								<div className="space-y-3 rounded-md border p-3">
 									<div className="space-y-2">
-										<Label>Método de Contacto</Label>
+										<Label>Plantilla de mensaje</Label>
 										<Select
-											onValueChange={(value) =>
-												form.setFieldValue(
-													field.name,
-													value as typeof field.state.value,
-												)
-											}
-											defaultValue={field.state.value}
+											value={plantillaId}
+											onValueChange={handlePlantillaChange}
 										>
 											<SelectTrigger>
-												<SelectValue placeholder="Seleccionar método" />
+												<SelectValue placeholder="Seleccionar plantilla..." />
 											</SelectTrigger>
 											<SelectContent>
-												<SelectItem value="llamada">📞 Llamada</SelectItem>
-												<SelectItem value="whatsapp">💬 WhatsApp</SelectItem>
-												<SelectItem value="email">📧 Email</SelectItem>
-												<SelectItem value="visita_domicilio">
-													🏠 Visita Domicilio
-												</SelectItem>
-												<SelectItem value="carta_notarial">
-													📋 Carta Notarial
-												</SelectItem>
+												{PLANTILLAS_MENSAJES.map((p) => (
+													<SelectItem key={p.id} value={p.id}>
+														{p.nombre}
+													</SelectItem>
+												))}
 											</SelectContent>
 										</Select>
 									</div>
-								)}
-							</form.Field>
 
-							<form.Field name="estadoContacto">
-								{(field) => (
-									<div className="space-y-2">
-										<Label>Estado del Contacto</Label>
-										<Select
-											onValueChange={(value) =>
-												form.setFieldValue(
-													field.name,
-													value as typeof field.state.value,
-												)
-											}
-											defaultValue={field.state.value}
-										>
-											<SelectTrigger>
-												<SelectValue placeholder="Estado del contacto" />
-											</SelectTrigger>
-											<SelectContent>
-												<SelectItem value="contactado">
-													✅ Contactado
-												</SelectItem>
-												<SelectItem value="no_contesta">
-													❌ No Contesta
-												</SelectItem>
-												<SelectItem value="numero_equivocado">
-													📱 Número Equivocado
-												</SelectItem>
-												<SelectItem value="promesa_pago">
-													🤝 Promesa de Pago
-												</SelectItem>
-												<SelectItem value="acuerdo_parcial">
-													📝 Acuerdo Parcial
-												</SelectItem>
-												<SelectItem value="rechaza_pagar">
-													🚫 Rechaza Pagar
-												</SelectItem>
-											</SelectContent>
-										</Select>
-									</div>
-								)}
-							</form.Field>
-						</div>
+									{plantillaId && metodoInicial === "email" && (
+										<div className="space-y-2">
+											<Label>Asunto</Label>
+											<Input
+												value={asuntoEditado}
+												onChange={(e) => setAsuntoEditado(e.target.value)}
+											/>
+										</div>
+									)}
 
-						{/* Selector de plantilla para WhatsApp y Email */}
-						{mostrarPlantillas && (
-							<div className="space-y-3 rounded-md border p-3">
+									{plantillaId && (
+										<div className="space-y-2">
+											<Label>Mensaje (editable)</Label>
+											<Textarea
+												className="min-h-[150px] text-sm"
+												value={mensajeEditable}
+												onChange={(e) =>
+													handleMensajeEditableChange(e.target.value)
+												}
+											/>
+										</div>
+									)}
+								</div>
+							)}
+
+							{/* Selector de teléfono cuando hay múltiples */}
+							{telefonos.length > 1 && (
 								<div className="space-y-2">
-									<Label>Plantilla de mensaje</Label>
+									<Label>Teléfono a contactar</Label>
 									<Select
-										value={plantillaId}
-										onValueChange={handlePlantillaChange}
+										value={telefonoSeleccionado}
+										onValueChange={setTelefonoSeleccionado}
 									>
 										<SelectTrigger>
-											<SelectValue placeholder="Seleccionar plantilla..." />
+											<SelectValue />
 										</SelectTrigger>
 										<SelectContent>
-											{PLANTILLAS_MENSAJES.map((p) => (
-												<SelectItem key={p.id} value={p.id}>
-													{p.nombre}
+											{telefonos.map((t) => (
+												<SelectItem key={t} value={t}>
+													{t}
 												</SelectItem>
 											))}
 										</SelectContent>
 									</Select>
 								</div>
+							)}
 
-								{plantillaId && metodoInicial === "email" && (
-									<div className="space-y-2">
-										<Label>Asunto</Label>
-										<Input
-											value={asuntoEditado}
-											onChange={(e) => setAsuntoEditado(e.target.value)}
-										/>
-									</div>
-								)}
-
-								{plantillaId && (
-									<div className="space-y-2">
-										<Label>Mensaje (editable)</Label>
-										<Textarea
-											className="min-h-[150px] text-sm"
-											value={mensajeEditable}
-											onChange={(e) =>
-												handleMensajeEditableChange(e.target.value)
-											}
-										/>
-									</div>
-								)}
-							</div>
-						)}
-
-						{/* Selector de teléfono cuando hay múltiples */}
-						{telefonos.length > 1 && (
-							<div className="space-y-2">
-								<Label>Teléfono a contactar</Label>
-								<Select
-									value={telefonoSeleccionado}
-									onValueChange={setTelefonoSeleccionado}
+							{/* Botones para ejecutar acción */}
+							<div className="flex flex-wrap gap-2">
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => ejecutarAccion("llamada")}
+									disabled={envioEnCurso}
+									className="flex items-center gap-2"
 								>
-									<SelectTrigger>
-										<SelectValue />
-									</SelectTrigger>
-									<SelectContent>
-										{telefonos.map((t) => (
-											<SelectItem key={t} value={t}>
-												{t}
-											</SelectItem>
-										))}
-									</SelectContent>
-								</Select>
+									<Phone className="h-4 w-4" />
+									Llamar {telefonos.length <= 1 ? telefonos[0] || "" : ""}
+								</Button>
+
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											disabled={envioEnCurso}
+											className="flex items-center gap-2"
+										>
+											{whatsappApiMutation.isPending ? (
+												<Loader2 className="h-4 w-4 animate-spin" />
+											) : (
+												<MessageCircle className="h-4 w-4" />
+											)}
+											WhatsApp
+											{whatsappApiMutation.isPending ? null : (
+												<ChevronDown className="h-3 w-3" />
+											)}
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start">
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("whatsapp-api")}
+										>
+											Enviar Directo (Automático)
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("whatsapp-link")}
+										>
+											Abrir WhatsApp Web (Manual)
+										</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>
+
+								<DropdownMenu>
+									<DropdownMenuTrigger asChild>
+										<Button
+											type="button"
+											variant="outline"
+											size="sm"
+											disabled={envioEnCurso}
+											className="flex items-center gap-2"
+										>
+											{emailApiMutation.isPending ? (
+												<Loader2 className="h-4 w-4 animate-spin" />
+											) : (
+												<Mail className="h-4 w-4" />
+											)}
+											Email
+											{emailApiMutation.isPending ? null : (
+												<ChevronDown className="h-3 w-3" />
+											)}
+										</Button>
+									</DropdownMenuTrigger>
+									<DropdownMenuContent align="start">
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("email-api")}
+										>
+											Enviar Directo (Automático)
+										</DropdownMenuItem>
+										<DropdownMenuItem
+											onClick={() => ejecutarAccion("email-link")}
+										>
+											Abrir cliente de correo (Manual)
+										</DropdownMenuItem>
+									</DropdownMenuContent>
+								</DropdownMenu>
+
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={() => ejecutarAccion("sms-api")}
+									disabled={envioEnCurso}
+									className="flex items-center gap-2"
+								>
+									{smsApiMutation.isPending ? (
+										<Loader2 className="h-4 w-4 animate-spin" />
+									) : (
+										<MessageSquare className="h-4 w-4" />
+									)}
+									{smsApiMutation.isPending ? "Enviando SMS..." : "SMS"}
+								</Button>
 							</div>
-						)}
 
-						{/* Botones para ejecutar acción */}
-						<div className="flex flex-wrap gap-2">
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={() => ejecutarAccion("llamada")}
-								disabled={envioEnCurso}
-								className="flex items-center gap-2"
-							>
-								<Phone className="h-4 w-4" />
-								Llamar {telefonos.length <= 1 ? telefonos[0] || "" : ""}
-							</Button>
-
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										disabled={envioEnCurso}
-										className="flex items-center gap-2"
-									>
-										{whatsappApiMutation.isPending ? (
-											<Loader2 className="h-4 w-4 animate-spin" />
-										) : (
-											<MessageCircle className="h-4 w-4" />
-										)}
-										WhatsApp
-										{whatsappApiMutation.isPending ? null : (
-											<ChevronDown className="h-3 w-3" />
-										)}
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent align="start">
-									<DropdownMenuItem
-										onClick={() => ejecutarAccion("whatsapp-api")}
-									>
-										Enviar Directo (Automático)
-									</DropdownMenuItem>
-									<DropdownMenuItem
-										onClick={() => ejecutarAccion("whatsapp-link")}
-									>
-										Abrir WhatsApp Web (Manual)
-									</DropdownMenuItem>
-								</DropdownMenuContent>
-							</DropdownMenu>
-
-							<DropdownMenu>
-								<DropdownMenuTrigger asChild>
-									<Button
-										type="button"
-										variant="outline"
-										size="sm"
-										disabled={envioEnCurso}
-										className="flex items-center gap-2"
-									>
-										{emailApiMutation.isPending ? (
-											<Loader2 className="h-4 w-4 animate-spin" />
-										) : (
-											<Mail className="h-4 w-4" />
-										)}
-										Email
-										{emailApiMutation.isPending ? null : (
-											<ChevronDown className="h-3 w-3" />
-										)}
-									</Button>
-								</DropdownMenuTrigger>
-								<DropdownMenuContent align="start">
-									<DropdownMenuItem onClick={() => ejecutarAccion("email-api")}>
-										Enviar Directo (Automático)
-									</DropdownMenuItem>
-									<DropdownMenuItem
-										onClick={() => ejecutarAccion("email-link")}
-									>
-										Abrir cliente de correo (Manual)
-									</DropdownMenuItem>
-								</DropdownMenuContent>
-							</DropdownMenu>
-
-							<Button
-								type="button"
-								variant="outline"
-								size="sm"
-								onClick={() => ejecutarAccion("sms-api")}
-								disabled={envioEnCurso}
-								className="flex items-center gap-2"
-							>
-								{smsApiMutation.isPending ? (
-									<Loader2 className="h-4 w-4 animate-spin" />
-								) : (
-									<MessageSquare className="h-4 w-4" />
-								)}
-								{smsApiMutation.isPending ? "Enviando SMS..." : "SMS"}
-							</Button>
+							<form.Field name="metodoContacto">
+								{(metodoField) =>
+									metodoField.state.value === "llamada" && (
+										<form.Field name="duracionLlamada">
+											{(field) => (
+												<div className="space-y-2">
+													<Label>Duración de la Llamada (segundos)</Label>
+													<Input
+														type="number"
+														placeholder="Ej: 180"
+														value={field.state.value}
+														onChange={(e) =>
+															field.handleChange(Number(e.target.value))
+														}
+													/>
+												</div>
+											)}
+										</form.Field>
+									)
+								}
+							</form.Field>
 						</div>
-
-						<form.Field name="metodoContacto">
-							{(metodoField) =>
-								metodoField.state.value === "llamada" && (
-									<form.Field name="duracionLlamada">
-										{(field) => (
-											<div className="space-y-2">
-												<Label>Duración de la Llamada (segundos)</Label>
-												<Input
-													type="number"
-													placeholder="Ej: 180"
-													value={field.state.value}
-													onChange={(e) =>
-														field.handleChange(Number(e.target.value))
-													}
-												/>
-											</div>
-										)}
-									</form.Field>
-								)
-							}
-						</form.Field>
-					</div>
+					)}
 
 					{/* Sección: Detalles de la Conversación */}
 					<div className="space-y-4">
@@ -827,37 +865,243 @@ export function ContactoModal({
 						</div>
 					</div>
 
-					{/* Sección: Próximo Seguimiento */}
-					<div className="space-y-4">
-						<h3 className="font-medium text-lg">Próximo Seguimiento</h3>
+					{/* CB-020: Sección de cuotas — SOLO en variante promesa. cartera-back
+					    NO separa la mora por cuota (moras_credito es un monto agregado
+					    del crédito, no por cuota individual) — por eso el checkbox de
+					    mora es independiente del rango: puede haber rango sin mora,
+					    mora sin rango ("solo mora"), o ambos. */}
+					{esPromesa && (
+						<div className="space-y-4">
+							<h3 className="font-medium text-lg">¿Qué prometió pagar?</h3>
 
-						<form.Field name="requiereSeguimiento">
-							{(field) => (
-								<div className="flex items-center space-x-2">
-									<Checkbox
-										id="requiereSeguimiento"
-										checked={field.state.value}
-										onCheckedChange={(checked) => {
-											field.handleChange(!!checked);
-											if (!checked) {
-												form.setFieldValue("fechaProximoContacto", undefined);
-											}
+							{cuotasDisponibles.length === 0 ? (
+								<p className="text-muted-foreground text-sm">
+									Este contrato no tiene cuotas atrasadas.
+								</p>
+							) : (
+								<div className="grid grid-cols-2 gap-4">
+									<form.Field
+										name="cuotaInicio"
+										validators={{
+											// listenTo cuotaFin: si el usuario baja cuotaFin por
+											// debajo de un cuotaInicio ya elegido, este validator
+											// re-corre aunque cuotaInicio no haya cambiado (mismo
+											// fix que cuotaFin de abajo, en la dirección opuesta).
+											onChangeListenTo: ["cuotaFin"],
+											onChange: ({ value, fieldApi }) => {
+												const cuotaFin =
+													fieldApi.form.getFieldValue("cuotaFin");
+												if (
+													value != null &&
+													cuotaFin != null &&
+													cuotaFin < value
+												) {
+													return "Debe ser menor o igual a la cuota final";
+												}
+												return undefined;
+											},
 										}}
-									/>
-									<Label htmlFor="requiereSeguimiento">
-										Requiere seguimiento programado
-									</Label>
+									>
+										{(field) => (
+											<div className="space-y-2">
+												<Label>Cuota desde</Label>
+												<Select
+													value={field.state.value?.toString() ?? ""}
+													onValueChange={(value) =>
+														field.handleChange(
+															value ? Number(value) : undefined,
+														)
+													}
+												>
+													<SelectTrigger>
+														<SelectValue placeholder="Sin cuota" />
+													</SelectTrigger>
+													<SelectContent>
+														{cuotasDisponibles.map((c) => (
+															<SelectItem
+																key={c.numeroCuota}
+																value={c.numeroCuota.toString()}
+															>
+																Cuota #{c.numeroCuota}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+												{field.state.meta.errors.length > 0 && (
+													<p className="text-red-500 text-sm">
+														{field.state.meta.errors.join(", ")}
+													</p>
+												)}
+											</div>
+										)}
+									</form.Field>
+
+									<form.Field
+										name="cuotaFin"
+										validators={{
+											// Espejo del validator de cuotaInicio: sin esto, cambiar
+											// SOLO cuotaFin a un valor menor que cuotaInicio ya
+											// elegido no muestra error ni bloquea el submit (el
+											// validator de cuotaInicio no se re-corre porque ese
+											// campo no cambió) — el .refine() del server sí lo
+											// atrapa, pero como error de red, no como UX inmediata.
+											onChangeListenTo: ["cuotaInicio"],
+											onChange: ({ value, fieldApi }) => {
+												const cuotaInicio =
+													fieldApi.form.getFieldValue("cuotaInicio");
+												if (
+													value != null &&
+													cuotaInicio != null &&
+													value < cuotaInicio
+												) {
+													return "Debe ser mayor o igual a la cuota inicial";
+												}
+												return undefined;
+											},
+										}}
+									>
+										{(field) => (
+											<div className="space-y-2">
+												<Label>Cuota hasta</Label>
+												<Select
+													value={field.state.value?.toString() ?? ""}
+													onValueChange={(value) =>
+														field.handleChange(
+															value ? Number(value) : undefined,
+														)
+													}
+												>
+													<SelectTrigger>
+														<SelectValue placeholder="Igual a 'desde' si es solo una" />
+													</SelectTrigger>
+													<SelectContent>
+														{cuotasDisponibles.map((c) => (
+															<SelectItem
+																key={c.numeroCuota}
+																value={c.numeroCuota.toString()}
+															>
+																Cuota #{c.numeroCuota}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+												{field.state.meta.errors.length > 0 && (
+													<p className="text-red-500 text-sm">
+														{field.state.meta.errors.join(", ")}
+													</p>
+												)}
+											</div>
+										)}
+									</form.Field>
 								</div>
 							)}
-						</form.Field>
+
+							<form.Field
+								name="incluyeMora"
+								validators={{
+									// Re-corre cuando cuotaInicio/cuotaFin cambian (no solo
+									// cuando cambia este checkbox) para que canSubmit refleje
+									// la regla "rango O mora" en tiempo real — antes el error
+									// solo se mostraba como texto, sin bloquear el submit.
+									onChangeListenTo: ["cuotaInicio", "cuotaFin"],
+									onChange: ({ value, fieldApi }) => {
+										const cuotaInicio =
+											fieldApi.form.getFieldValue("cuotaInicio");
+										const cuotaFin = fieldApi.form.getFieldValue("cuotaFin");
+										if (cuotaInicio == null && cuotaFin == null && !value) {
+											return "Indica un rango de cuotas, marca que incluye mora, o ambos";
+										}
+										return undefined;
+									},
+								}}
+							>
+								{(field) => (
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											id="incluyeMora"
+											checked={field.state.value}
+											onCheckedChange={(checked) =>
+												field.handleChange(!!checked)
+											}
+										/>
+										<Label htmlFor="incluyeMora">
+											Incluye pago de mora del crédito
+										</Label>
+									</div>
+								)}
+							</form.Field>
+
+							<form.Subscribe
+								selector={(state) => [
+									state.values.cuotaInicio,
+									state.values.cuotaFin,
+									state.values.incluyeMora,
+								]}
+							>
+								{([cuotaInicio, cuotaFin, incluyeMora]) =>
+									cuotaInicio == null &&
+									cuotaFin == null &&
+									!incluyeMora && (
+										<p className="text-red-500 text-sm">
+											Indica un rango de cuotas, marca que incluye mora, o
+											ambos.
+										</p>
+									)
+								}
+							</form.Subscribe>
+						</div>
+					)}
+
+					{/* Sección: Próximo Seguimiento — en variante "promesa" la fecha ES
+					    la fecha prometida y es obligatoria: no hay checkbox que la
+					    haga opcional (requiereSeguimiento arranca en true y no se
+					    puede desmarcar). */}
+					<div className="space-y-4">
+						<h3 className="font-medium text-lg">
+							{esPromesa ? "Fecha Prometida" : "Próximo Seguimiento"}
+						</h3>
+
+						{!esPromesa && (
+							<form.Field name="requiereSeguimiento">
+								{(field) => (
+									<div className="flex items-center space-x-2">
+										<Checkbox
+											id="requiereSeguimiento"
+											checked={field.state.value}
+											onCheckedChange={(checked) => {
+												field.handleChange(!!checked);
+												if (!checked) {
+													form.setFieldValue("fechaProximoContacto", undefined);
+												}
+											}}
+										/>
+										<Label htmlFor="requiereSeguimiento">
+											Requiere seguimiento programado
+										</Label>
+									</div>
+								)}
+							</form.Field>
+						)}
 
 						<form.Field name="requiereSeguimiento">
 							{(seguimientoField) =>
-								seguimientoField.state.value && (
-									<form.Field name="fechaProximoContacto">
+								(esPromesa || seguimientoField.state.value) && (
+									<form.Field
+										name="fechaProximoContacto"
+										validators={{
+											onChange: ({ value }) =>
+												esPromesa && !value
+													? "La fecha prometida es obligatoria"
+													: undefined,
+										}}
+									>
 										{(field) => (
 											<div className="space-y-2">
-												<Label>Fecha de próximo contacto *</Label>
+												<Label>
+													{esPromesa
+														? "Fecha en la que prometió pagar *"
+														: "Fecha de próximo contacto *"}
+												</Label>
 												<Popover>
 													<PopoverTrigger asChild>
 														<Button
@@ -888,6 +1132,11 @@ export function ContactoModal({
 														/>
 													</PopoverContent>
 												</Popover>
+												{field.state.meta.errors.length > 0 && (
+													<p className="text-red-500 text-sm">
+														{field.state.meta.errors.join(", ")}
+													</p>
+												)}
 											</div>
 										)}
 									</form.Field>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -73,6 +73,18 @@ import { formatFechaLocal } from "@/lib/date-utils";
 import { ROLES } from "@/lib/roles";
 import { client, orpc } from "@/utils/orpc";
 
+// CB-020 (Codex, PR #1148): toLocaleDateString("es-GT") sin `timeZone`
+// explícito usa la zona horaria LOCAL del navegador para decidir qué día
+// es, no Guatemala — el string "es-GT" solo cambia el FORMATO (dd/mm/yyyy),
+// no la zona horaria del cálculo. Un asesor en una zona horaria distinta
+// (ej. America/Los_Angeles) ve un día distinto al que realmente se guardó
+// en medianoche GT (ver fechaAMedianocheGT en contacto-modal.tsx). Fuerza
+// la zona horaria de Guatemala para que la fecha mostrada coincida siempre
+// con la que se guardó, sin importar dónde esté físicamente el asesor.
+function formatFechaGT(date: Date): string {
+	return date.toLocaleDateString("es-GT", { timeZone: "America/Guatemala" });
+}
+
 export const Route = createFileRoute("/cobros/$id")({
 	component: RouteComponent,
 	validateSearch: (search: Record<string, unknown>) => ({
@@ -260,8 +272,22 @@ function RouteComponent() {
 				numeroSifco: casoDetails.data?.numeroCreditoSifco || id || "",
 				// El server carga cuotaInicio/cuotaFin/incluyeMora/fechaPrometida de
 				// DB por id (no confía en lo que mande el cliente) — solo manda ids.
+				// getHistorialContactos ahora pide limit=200 (ver arriba) — un caso
+				// con más de 100 promesas con fecha excedería el .max(100) del
+				// server y el request completo sería rechazado (Codex, PR #1148),
+				// dejando estadoPromesa estancado para TODAS. Se ordena por fecha
+				// prometida más reciente primero y se cortan las primeras 100: las
+				// más viejas conservan su estadoPromesa ya persistido en DB (mismo
+				// fallback que usa la tarjeta cuando el id no viene en la
+				// respuesta), solo dejan de recalcularse en cada visita.
 				promesaIds: promesasPago
 					.filter((p: any) => p.fechaProximoContacto)
+					.sort(
+						(a: any, b: any) =>
+							new Date(b.fechaProximoContacto).getTime() -
+							new Date(a.fechaProximoContacto).getTime(),
+					)
+					.slice(0, 100)
 					.map((p: any) => p.id),
 			},
 		}),
@@ -1747,7 +1773,7 @@ function RouteComponent() {
 															)}
 															<span className="text-muted-foreground text-sm">
 																{fechaPrometida
-																	? fechaPrometida.toLocaleDateString("es-GT")
+																	? formatFechaGT(fechaPrometida)
 																	: "Sin fecha"}
 															</span>
 															<Badge className={badge.color}>
@@ -1762,9 +1788,7 @@ function RouteComponent() {
 														<p className="text-muted-foreground text-sm">
 															Registrada:{" "}
 															{promesa.fechaContacto
-																? new Date(
-																		promesa.fechaContacto,
-																	).toLocaleDateString("es-GT")
+																? formatFechaGT(new Date(promesa.fechaContacto))
 																: "Sin fecha"}
 														</p>
 													</div>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -222,9 +222,17 @@ function RouteComponent() {
 	});
 
 	// Obtener historial de contactos (solo para casos)
+	// CB-020 (Codex, PR #1147): getHistorialContactos aplica su límite ANTES
+	// de que este archivo separe promesa_pago del resto (ver `contactos` y
+	// `promesasPago` abajo) — con el default de 20, un caso con varias
+	// promesas dejaba el Historial general corto y perdía promesas viejas
+	// fuera de esa ventana en ambas listas. El server no filtra por tipo ni
+	// pagina de verdad (solo un límite plano) — hasta que eso se separe en
+	// el backend, subir el límite es el workaround práctico: cubre el caso
+	// real (decenas de contactos), no infinito.
 	const historialContactos = useQuery({
 		...orpc.getHistorialContactos.queryOptions({
-			input: { casoCobroId: casoDetails.data?.id || "" },
+			input: { casoCobroId: casoDetails.data?.id || "", limit: 200 },
 		}),
 		enabled: !!session && !!casoDetails.data?.id,
 	});
@@ -1670,9 +1678,19 @@ function RouteComponent() {
 												)?.[promesa.id] ??
 												promesa.estadoPromesa ??
 												"pendiente";
+											// Mismo criterio de gracia que el backend (ver
+											// finDeGraciaGT en lib/promesa-pago.ts): comparar el
+											// instante crudo marcaba VENCIDA desde medianoche GT
+											// del MISMO día prometido, contradiciendo el badge
+											// "Pendiente" que sí usa esa gracia (Codex, PR #1147).
+											const finDeGraciaGT = fechaPrometida
+												? new Date(
+														fechaPrometida.getTime() + 24 * 60 * 60 * 1000,
+													)
+												: null;
 											const vencida =
-												fechaPrometida !== null &&
-												fechaPrometida < hoy &&
+												finDeGraciaGT !== null &&
+												finDeGraciaGT <= hoy &&
 												estadoPromesa !== "cumplida";
 											const estadoBadge: Record<
 												EstadoPromesa,

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -11,6 +11,7 @@ import {
 	Clock,
 	Eye,
 	FileText,
+	HandCoins,
 	Loader,
 	Mail,
 	MapPin,
@@ -24,7 +25,7 @@ import {
 	Users,
 	X,
 } from "lucide-react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ReferenciasView } from "@/components/cobros/ReferenciasView";
 import { SeguimientoRecurrenteModal } from "@/components/cobros/seguimiento-recurrente-modal";
@@ -226,6 +227,40 @@ function RouteComponent() {
 			input: { casoCobroId: casoDetails.data?.id || "" },
 		}),
 		enabled: !!session && !!casoDetails.data?.id,
+	});
+
+	// CB-020: promesas de pago registradas en el historial. El estado
+	// (pendiente/cumplida/incumplida) vive en estadoPromesa (columna DB) y se
+	// recalcula/persiste vía getEstadoPromesasPago (ver abajo). La tarjeta
+	// prioriza el resultado EN MEMORIA de esa query (más fresco) sobre
+	// promesa.estadoPromesa (columna DB, puede estar un ciclo atrás) — NO se
+	// invalida/refetchea historialContactos tras el cálculo: eso generaba un
+	// array `promesasPago` con nueva identidad en cada éxito, lo que a su vez
+	// recalculaba el input de esta misma query (key distinta) y volvía a
+	// disparar el efecto — un ciclo de refetch innecesario que se evita
+	// leyendo el resultado directo en vez de ir a buscarlo de nuevo a la DB.
+	const promesasPago = useMemo(
+		() =>
+			(historialContactos.data || []).filter(
+				(c: any) => c.estadoContacto === "promesa_pago",
+			),
+		[historialContactos.data],
+	);
+	const estadoPromesasPago = useQuery({
+		...orpc.getEstadoPromesasPago.queryOptions({
+			input: {
+				numeroSifco: casoDetails.data?.numeroCreditoSifco || id || "",
+				// El server carga cuotaInicio/cuotaFin/incluyeMora/fechaPrometida de
+				// DB por id (no confía en lo que mande el cliente) — solo manda ids.
+				promesaIds: promesasPago
+					.filter((p: any) => p.fechaProximoContacto)
+					.map((p: any) => p.id),
+			},
+		}),
+		enabled:
+			!!session &&
+			promesasPago.length > 0 &&
+			!!(casoDetails.data?.numeroCreditoSifco || id),
 	});
 
 	// Obtener seguimientos activos
@@ -467,7 +502,11 @@ function RouteComponent() {
 	}
 
 	const caso = casoDetails.data;
-	const contactos = historialContactos.data || [];
+	// CB-020: las promesas de pago viven SOLO en la tarjeta "Promesas de
+	// Pago" (ver promesasPago) — no en el Historial de Contactos general.
+	const contactos = (historialContactos.data || []).filter(
+		(c: any) => c.estadoContacto !== "promesa_pago",
+	);
 	const convenios = conveniosPago.data || [];
 	const cuotas = historialPagos.data || [];
 	const recuperacion = recuperacionInfo.data;
@@ -1210,6 +1249,56 @@ function RouteComponent() {
 												Email
 											</Button>
 										</ContactoModal>
+
+										{/* CB-020: modal reducido — solo Detalles de la
+										    Conversación + fecha prometida (obligatoria). */}
+										<ContactoModal
+											casoCobroId={caso.id}
+											clienteNombre={caso.clienteNombre || ""}
+											telefonoPrincipal={caso.telefonoPrincipal || ""}
+											telefonoAlternativo={
+												caso.telefonoAlternativo
+													? String(caso.telefonoAlternativo)
+													: undefined
+											}
+											emailCliente={caso.emailContacto || ""}
+											metodoInicial="llamada"
+											variante="promesa"
+											cuotasDisponibles={cuotas
+												.filter(
+													(c: any) =>
+														c.estadoMora !== "pagado" &&
+														c.fechaVencimiento &&
+														new Date(c.fechaVencimiento) < new Date(),
+												)
+												.map((c: any) => ({ numeroCuota: c.numeroCuota }))}
+											fechaPago={String(caso.diaPagoMensual || 15)}
+											cuotaMensual={Number(
+												caso.cuotaMensual || 0,
+											).toLocaleString()}
+											placa={caso.vehiculoPlaca || ""}
+											marcaLineaModelo={`${caso.vehiculoMarca || ""} ${caso.vehiculoModelo || ""} ${caso.vehiculoYear || ""}`.trim()}
+											montoAdeudado={(
+												Number(caso.montoEnMora || 0) +
+												Number(caso.cuotaMensual || 0)
+											).toLocaleString("es-GT", {
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											})}
+											cuotasAtraso={caso.cuotasVencidas ?? 0}
+											estadoMora={caso.estadoMora || undefined}
+											fechaInicio={caso.fechaInicio || null}
+											nombreAsesor={caso.asesor?.nombre || ""}
+											telefonoAsesor={caso.asesor?.telefono || ""}
+										>
+											<Button
+												variant="outline"
+												className="flex items-center gap-2"
+											>
+												<HandCoins className="h-4 w-4" />
+												Promesa de Pago
+											</Button>
+										</ContactoModal>
 									</div>
 								</>
 							) : (
@@ -1539,6 +1628,128 @@ function RouteComponent() {
 							)}
 						</CardContent>
 					</Card>
+
+					{/* CB-020: Promesas de Pago — filtro sobre los mismos contactos
+					    (no query aparte para listarlas). Las promesas ya NO aparecen
+					    en el Historial de arriba (se filtran ahí, ver `contactos`).
+					    Cumplida/incumplida/pendiente viene de estadoPromesa, persistido
+					    por getEstadoPromesasPago verificando cuotas + mora del crédito
+					    en cartera-back — 100% automático, sin confirmación manual. */}
+					{(() => {
+						if (promesasPago.length === 0) return null;
+						const hoy = new Date();
+						// Redeclarado localmente (no importado del server): igual al
+						// EstadoPromesa de lib/promesa-pago.ts en el backend — mantener
+						// ambos alineados si ese union cambia.
+						type EstadoPromesa = "pendiente" | "cumplida" | "incumplida";
+						return (
+							<Card>
+								<CardHeader>
+									<CardTitle className="flex items-center gap-2">
+										<HandCoins className="h-5 w-5" />
+										Promesas de Pago
+									</CardTitle>
+									<CardDescription>
+										Cuotas y/o mora que el cliente prometió pagar
+									</CardDescription>
+								</CardHeader>
+								<CardContent>
+									<div className="space-y-4">
+										{promesasPago.map((promesa: any) => {
+											const fechaPrometida = promesa.fechaProximoContacto
+												? new Date(promesa.fechaProximoContacto)
+												: null;
+											// Prioriza el resultado recién calculado (en memoria,
+											// sin refetch) sobre la columna DB, que puede estar un
+											// ciclo atrás si esta es la primera visita al caso.
+											const estadoPromesa: EstadoPromesa =
+												(
+													estadoPromesasPago.data as
+														| Record<string, EstadoPromesa>
+														| undefined
+												)?.[promesa.id] ??
+												promesa.estadoPromesa ??
+												"pendiente";
+											const vencida =
+												fechaPrometida !== null &&
+												fechaPrometida < hoy &&
+												estadoPromesa !== "cumplida";
+											const estadoBadge: Record<
+												EstadoPromesa,
+												{ label: string; color: string }
+											> = {
+												cumplida: {
+													label: "Cumplida",
+													color: "bg-green-100 text-green-800",
+												},
+												incumplida: {
+													label: "Incumplida",
+													color: "bg-red-100 text-red-800",
+												},
+												pendiente: {
+													label: "Pendiente",
+													color: "bg-blue-100 text-blue-800",
+												},
+											};
+											const badge = estadoBadge[estadoPromesa];
+											const tieneRango =
+												promesa.cuotaInicio != null && promesa.cuotaFin != null;
+											const etiquetaRango = tieneRango
+												? promesa.cuotaInicio === promesa.cuotaFin
+													? `Cuota #${promesa.cuotaInicio}`
+													: `Cuotas #${promesa.cuotaInicio} a #${promesa.cuotaFin}`
+												: "Mora del crédito";
+											return (
+												<div key={promesa.id} className="rounded-lg border p-4">
+													<div className="mb-2 flex items-start justify-between">
+														<div className="flex flex-wrap items-center gap-2">
+															<span className="font-medium">
+																{etiquetaRango}
+															</span>
+															{tieneRango && promesa.incluyeMora && (
+																<Badge variant="outline">+ Mora</Badge>
+															)}
+															<span className="text-muted-foreground text-sm">
+																{fechaPrometida
+																	? fechaPrometida.toLocaleDateString("es-GT")
+																	: "Sin fecha"}
+															</span>
+															<Badge className={badge.color}>
+																{badge.label}
+															</Badge>
+															{vencida && (
+																<Badge className="bg-red-600 text-white">
+																	VENCIDA
+																</Badge>
+															)}
+														</div>
+														<p className="text-muted-foreground text-sm">
+															Registrada:{" "}
+															{promesa.fechaContacto
+																? new Date(
+																		promesa.fechaContacto,
+																	).toLocaleDateString("es-GT")
+																: "Sin fecha"}
+														</p>
+													</div>
+													<p className="mb-2 text-sm">{promesa.comentarios}</p>
+													{promesa.compromisosPago && (
+														<div className="rounded bg-green-50 p-2 text-sm">
+															<span className="font-medium">Compromiso: </span>
+															{promesa.compromisosPago}
+														</div>
+													)}
+													<div className="mt-2 text-muted-foreground text-xs">
+														Por: {promesa.realizadoPor || "Sin asignar"}
+													</div>
+												</div>
+											);
+										})}
+									</div>
+								</CardContent>
+							</Card>
+						);
+					})()}
 
 					{/* Historial de Pagos */}
 					<Card>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1712,16 +1712,34 @@ function RouteComponent() {
 											const badge = estadoBadge[estadoPromesa];
 											const tieneRango =
 												promesa.cuotaInicio != null && promesa.cuotaFin != null;
+											// Fila legacy (creada antes de CB-020, ver
+											// promesa-pago.test.ts) puede tener rango null e
+											// incluyeMora=false — sin esto "Mora del crédito" se
+											// mostraba igual, mintiendo sobre lo que prometió el
+											// cliente (Codex, PR #1147).
 											const etiquetaRango = tieneRango
 												? promesa.cuotaInicio === promesa.cuotaFin
 													? `Cuota #${promesa.cuotaInicio}`
 													: `Cuotas #${promesa.cuotaInicio} a #${promesa.cuotaFin}`
-												: "Mora del crédito";
+												: promesa.incluyeMora
+													? "Mora del crédito"
+													: "Sin rango ni mora especificado";
 											return (
 												<div key={promesa.id} className="rounded-lg border p-4">
 													<div className="mb-2 flex items-start justify-between">
 														<div className="flex flex-wrap items-center gap-2">
-															<span className="font-medium">
+															<span
+																className={
+																	tieneRango || promesa.incluyeMora
+																		? "font-medium"
+																		: "font-medium text-muted-foreground italic"
+																}
+																title={
+																	tieneRango || promesa.incluyeMora
+																		? undefined
+																		: "Registro anterior a la validación de rango/mora obligatorio — revisar comentarios para saber qué prometió el cliente."
+																}
+															>
 																{etiquetaRango}
 															</span>
 															{tieneRango && promesa.incluyeMora && (


### PR DESCRIPTION
## Summary
- Botón dedicado "Promesa de Pago" en el detalle del caso, con modal reducido (`ContactoModal variante="promesa"`) que oculta método/estado/plantilla y solo pide detalles de conversación + rango de cuotas + checkbox de mora + fecha prometida (obligatoria).
- Selector de rango de cuotas (desde/hasta) sobre las cuotas atrasadas reales del contrato, más checkbox "Incluye pago de mora del crédito" — independientes entre sí (puede ser solo rango, solo mora, o ambos), con validación cruzada en el form y guard en submit (no solo onChange).
- Tarjeta "Promesas de Pago" separada del Historial de Contactos general, con badge de estado (pendiente/cumplida/incumplida) y badge "VENCIDA" con la misma gracia de +24h que el backend.
- `getEstadoPromesasPago` recibe `{ numeroSifco, promesaIds: string[] }` — el server carga los datos reales de DB por id en vez de confiar en lo que mande el cliente.
- `createContactoCobros` vuelve a exigir server-side (vía `.refine()`) rango-o-mora y fecha obligatoria en `promesa_pago` — deuda técnica temporal repuesta ahora que el web viejo ya no existe.
- `fechaAMedianocheGT` normaliza la selección del Calendar a medianoche GT antes de guardar, igual criterio que `gtDateStrToDate` del backend.
- Test de regresión (`cobros-contacto-schema.test.ts`) sobre el schema Zod extraído, cubriendo los 4 `.refine()`.

## Test plan
- [ ] Registrar promesa con rango de cuotas (sin mora) → aparece en tarjeta "Promesas de Pago", no en Historial, estado "Pendiente".
- [ ] Registrar promesa de solo mora (sin rango) → tarjeta muestra "Mora del crédito".
- [ ] Intentar registrar promesa sin rango ni mora, o sin fecha → bloqueado (front y server).
- [ ] Promesa con rango ya pagado en cartera-back → pasa a "Cumplida" al abrir el caso.
- [ ] Promesa con fecha vencida y rango sin pagar → "Incumplida" + badge "VENCIDA" (mismo día que la fecha prometida NO debe verse vencida).
- [x] `bun check-types`: server limpio, sin errores nuevos en web.
- [x] `bun test` en `cobros-contacto-schema.test.ts` + `promesa-pago.test.ts`: 26/26 pasan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)