### PR TITLE
 Hotfix CRM: placas de vehículos + candado de etapa 90%

### DIFF
--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -2049,6 +2049,14 @@ export const crmRouter = {
 					});
 				}
 
+				// Bloquear cualquier retroceso una vez alcanzada Formalización Final (90%+)
+				if (fromPercentage >= 90 && toPercentage < fromPercentage) {
+					throw new ORPCError("BAD_REQUEST", {
+						message:
+							"La oportunidad ya alcanzó Formalización Final (90%) y no puede retroceder de etapa.",
+					});
+				}
+
 				// Validate credit detail approval when moving from <=40% to >=50%
 				if (fromPercentage <= 40 && toPercentage >= 50) {
 					// Check if credit detail has been approved

--- a/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
+++ b/apps/crm/apps/web/src/components/credit/CreditDetailView.tsx
@@ -2577,7 +2577,8 @@ export function CreditDetailView({
 							<div className="mx-6 mb-2 flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2">
 								<Car className="h-4 w-4 shrink-0 text-muted-foreground" />
 								<span className="text-muted-foreground text-sm">
-									{vehicleString}
+									{vehicleString} ·{" "}
+									{vehiculo.licensePlate?.trim() || "(sin placas)"}
 								</span>
 								{(vehiculo as any).isOwned && (
 									<Badge

--- a/apps/crm/apps/web/src/routes/vehicles/index.tsx
+++ b/apps/crm/apps/web/src/routes/vehicles/index.tsx
@@ -2588,7 +2588,8 @@ function VehiclesDashboard() {
 								<p className="text-muted-foreground text-xs">
 									La información de un vehículo vendido no se puede editar; el
 									estado debe pasar primero a Disponible para habilitar los
-									campos.
+									campos. La placa sí puede actualizarse, por si el vehículo
+									recibe placas después de la venta.
 								</p>
 							)}
 						</div>
@@ -2752,7 +2753,6 @@ function VehiclesDashboard() {
 									<Label htmlFor="edit-licensePlate">Placa</Label>
 									<Input
 										id="edit-licensePlate"
-										disabled={isVehicleSoldLocked}
 										value={editVehicleForm.licensePlate}
 										onChange={(e) =>
 											setEditVehicleForm({


### PR DESCRIPTION
# 🔥 Hotfix CRM — Placas de vehículos y candado de etapa 90%+

Tres ajustes puntuales al CRM:

## 📄 Emisión de Cheques

- El chip del vehículo ahora muestra la placa junto a marca/modelo/año, o **"(sin placas)"** si el vehículo no tiene placa registrada.

## 🔒 Candado de etapa (Formalización Final)

- Una oportunidad que ya alcanzó **90% o más no puede retroceder de etapa**, para ningún rol.
- Esto también cierra un bypass del candado de desembolso: los gates comparaban porcentajes con igualdad exacta, así que se podía hacer 90 → etapa baja → 100 sin aprobación del checklist de desembolso.
- Las demás vías que mueven etapa ya estaban protegidas (validan etapa exacta hacia adelante o bloquean >=90 por su cuenta).

## 🚗 Panel de Vehículos

- En el modal de edición de un vehículo **Vendido**, el campo **Placa vuelve a ser editable** (los demás campos siguen bloqueados): un carro nuevo puede recibir sus placas después de la venta.
- Aplica para cualquier rol con acceso al módulo; el hint del modal explica la excepción.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
