### PR TITLE
feat(cobros): motor de buckets — endpoint universo SLA para Cola del Día (CB-020)

### DIFF
--- a/apps/cartera-back/drizzle/cobros-02/0006_buckets_dias_sla.sql
+++ b/apps/cartera-back/drizzle/cobros-02/0006_buckets_dias_sla.sql
@@ -1,0 +1,30 @@
+-- ============================================================================
+-- COBROS-02 · Motor de Buckets — 0006_buckets_dias_sla
+-- ============================================================================
+-- CB-020: días de SLA para contactar un crédito desde que ENTRÓ a su bucket
+-- ACTUAL (fecha = última fila de buckets_historial para ese credito_id). Lo
+-- consume la Cola del Día del CRM (GET /buckets/cola-dia) para calcular
+-- fecha_limite_sla = fecha_entrada_bucket + dias_sla.
+--
+-- B0 (Cartera Sana) queda en NULL a propósito: al día, no aplica SLA de
+-- contacto. Los valores de B1-B5 son PLACEHOLDER — Cartera/negocio debe
+-- confirmar los días reales por bucket antes de que la Cola del Día salga a
+-- producción; se pueden corregir con un UPDATE directo en cualquier momento
+-- (mismo criterio que el resto de este catálogo: editable a mano por SQL).
+--
+-- NOTA: Cartera aplica el SQL a mano (no drizzle-kit). Idempotente.
+-- Se aplica DESPUÉS de 0001_buckets_catalogo.sql.
+-- ============================================================================
+
+ALTER TABLE cartera.buckets ADD COLUMN IF NOT EXISTS dias_sla integer;
+--> statement-breakpoint
+
+UPDATE cartera.buckets SET dias_sla = 3 WHERE numero = 1 AND dias_sla IS NULL;
+--> statement-breakpoint
+UPDATE cartera.buckets SET dias_sla = 3 WHERE numero = 2 AND dias_sla IS NULL;
+--> statement-breakpoint
+UPDATE cartera.buckets SET dias_sla = 2 WHERE numero = 3 AND dias_sla IS NULL;
+--> statement-breakpoint
+UPDATE cartera.buckets SET dias_sla = 2 WHERE numero = 4 AND dias_sla IS NULL;
+--> statement-breakpoint
+UPDATE cartera.buckets SET dias_sla = 1 WHERE numero = 5 AND dias_sla IS NULL;

--- a/apps/cartera-back/drizzle/cobros-02/README.md
+++ b/apps/cartera-back/drizzle/cobros-02/README.md
@@ -17,6 +17,7 @@ para que se sepa que se aplican como bloque cuando salga esa versión.
 | `0001_buckets_catalogo.sql` | Catálogo dinámico `buckets` (nombre/prefijo/rangos/estados/color) + CHECK de rangos + seed B0-B5 + FKs de `asesor_bucket.bucket` y `buckets_historial.bucket_(nuevo\|anterior)` al catálogo. |
 | `0002_credito_asesor.sql` | Bitácora de reasignaciones `credito_asesor_historial` + enum `credito_asesor_origen`. **La asignación vive en `creditos.asesor_id`** (no hay tabla de estado): en cartera el asesor del crédito ES el cobrador (el vendedor vive en el CRM). Reasignar (futuro) = `UPDATE creditos SET asesor_id` (solo ese campo) + INSERT en la bitácora. |
 | `0003_buckets_estado_mora.sql` | Agrega `buckets.estado_mora` (puente numero↔estadoMora: al_dia..mora_120_plus) + seed. Retira la duplicación con `config/moraBuckets.ts` (cartera-back) y el mirror en CRM. |
+| `0006_buckets_dias_sla.sql` | CB-020: agrega `buckets.dias_sla` (días para contactar desde que el crédito entra al bucket) + seed placeholder B1-B5 (B0 = NULL, sin SLA). Consumido por la Cola del Día del CRM (`GET /buckets/cola-dia`). |
 
 ## Asignación inicial (`asignacion/`) — carga de datos, NO schema
 

--- a/apps/cartera-back/src/controllers/buckets/colaDia.ts
+++ b/apps/cartera-back/src/controllers/buckets/colaDia.ts
@@ -1,0 +1,161 @@
+import { sql } from "drizzle-orm";
+import { db } from "../../database";
+import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CB-020 · Buckets — Cola del Día (universo SLA).
+// Créditos del POOL de buckets del asesor (`asesor_bucket`, activo=true) — NO
+// del asesor_id asignado al crédito individual (eso es lo que usa la Agenda,
+// getCuotasProximasVencer). Un bucket puede tener varios asesores cubriéndolo.
+//
+// Por cada crédito: su bucket ACTUAL viene de la última fila de
+// `buckets_historial` (misma fuente que bucketActualSql, pero acá necesitamos
+// también LA FECHA de esa fila, no solo el número — el índice
+// buckets_historial_credito_fecha_idx (credito_id, fecha DESC, historial_id
+// DESC) cubre el DISTINCT ON exacto). B0 (Cartera Sana) se excluye siempre:
+// no tiene dias_sla (al día, no aplica SLA de contacto).
+//
+// Créditos sin ninguna fila en buckets_historial (ambiente sin backfill de
+// COBROS-02) no tienen fecha de entrada confiable → se excluyen de la cola en
+// vez de asumir una fecha, mismo criterio "degradar sin inventar dato" que el
+// resto del motor de buckets.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type ColaDiaFila = {
+	credito_id: number;
+	numero_credito_sifco: string;
+	cliente: string;
+	asesor_id: number;
+	asesor: string;
+	bucket: number;
+	bucket_prefijo: string;
+	bucket_nombre: string;
+	dias_sla: number;
+	fecha_entrada_bucket: string; // ISO
+	fecha_limite_sla: string; // YYYY-MM-DD, día GT
+};
+
+export type GetColaDiaSLAParams = {
+	asesor_id?: number;
+	/** Filtra por bucket(s) del catálogo (0-5). Omitir = todos los buckets con SLA. */
+	buckets?: number[];
+	page?: number;
+	perPage?: number;
+};
+
+export type GetColaDiaSLAResultado = {
+	success: true;
+	data: ColaDiaFila[];
+	page: number;
+	perPage: number;
+	total: number;
+	totalPages: number;
+};
+
+// Última fila de buckets_historial por crédito (DISTINCT ON, aprovecha el
+// índice compuesto credito_id+fecha+historial_id) + su bucket destino, filtrado
+// a los buckets que el asesor (o cualquiera, si no se filtra) cubre en el pool.
+export async function getColaDiaSLA(
+	params: GetColaDiaSLAParams,
+): Promise<GetColaDiaSLAResultado> {
+	const pageFloor = Math.floor(Number(params.page ?? 1));
+	const page = Number.isFinite(pageFloor) && pageFloor > 0 ? pageFloor : 1;
+	const perPageFloor = Math.floor(Number(params.perPage ?? 50));
+	const perPage =
+		Number.isFinite(perPageFloor) && perPageFloor > 0
+			? Math.min(perPageFloor, 500)
+			: 50;
+	const offset = (page - 1) * perPage;
+
+	const filtroAsesor = params.asesor_id
+		? sql`AND ab.asesor_id = ${params.asesor_id}`
+		: sql``;
+	const filtroBuckets =
+		params.buckets && params.buckets.length > 0
+			? sql`AND b.numero IN (${sql.join(params.buckets.map((n) => sql`${n}`), sql`, `)})`
+			: sql``;
+
+	// ultima_entrada: 1 fila por crédito con su bucket_nuevo/fecha más reciente.
+	// pool: buckets que el asesor (o cualquier asesor activo) cubre.
+	const cte = sql`
+    WITH ultima_entrada AS (
+      SELECT DISTINCT ON (h.credito_id)
+        h.credito_id, h.bucket_nuevo, h.fecha
+      FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+      ORDER BY h.credito_id, h.fecha DESC, h.historial_id DESC
+    )
+  `;
+
+	const joins = sql`
+    FROM ultima_entrada ue
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.buckets b ON b.numero = ue.bucket_nuevo
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.asesor_bucket ab
+      ON ab.bucket = ue.bucket_nuevo AND ab.activo = true
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = ue.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+    WHERE b.numero > 0
+      AND b.dias_sla IS NOT NULL
+      ${filtroAsesor}
+      ${filtroBuckets}
+  `;
+
+	const [totRes, dataRes] = await Promise.all([
+		db.execute<{ total: string }>(sql`
+      ${cte}
+      SELECT COUNT(DISTINCT ue.credito_id)::int AS total
+      ${joins}
+    `),
+		db.execute<{
+			credito_id: number;
+			numero_credito_sifco: string;
+			cliente: string;
+			asesor_id: number;
+			asesor: string;
+			bucket: number;
+			bucket_prefijo: string;
+			bucket_nombre: string;
+			dias_sla: number;
+			fecha_entrada_bucket: string;
+			fecha_limite_sla: string;
+		}>(sql`
+      ${cte},
+      base AS (
+        SELECT DISTINCT ON (ue.credito_id)
+          ue.credito_id,
+          c.numero_credito_sifco,
+          u.nombre AS cliente,
+          c.asesor_id,
+          a.nombre AS asesor,
+          b.numero AS bucket,
+          b.prefijo AS bucket_prefijo,
+          b.nombre AS bucket_nombre,
+          b.dias_sla,
+          ue.fecha::text AS fecha_entrada_bucket,
+          (
+            (
+              (ue.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date
+              + (b.dias_sla || ' days')::interval
+            )::date
+          )::text AS fecha_limite_sla
+        ${joins}
+        -- DISTINCT ON exige empezar el ORDER BY por credito_id; el orden real
+        -- (priorizado por fecha_limite_sla) se aplica afuera, en el SELECT final.
+        ORDER BY ue.credito_id
+      )
+      SELECT * FROM base
+      ORDER BY fecha_limite_sla ASC, credito_id ASC
+      LIMIT ${perPage} OFFSET ${offset}
+    `),
+	]);
+
+	const total = Number(totRes.rows[0]?.total ?? 0);
+	return {
+		success: true,
+		data: dataRes.rows,
+		page,
+		perPage,
+		total,
+		totalPages: Math.max(1, Math.ceil(total / perPage)),
+	};
+}

--- a/apps/cartera-back/src/controllers/buckets/colaDia.ts
+++ b/apps/cartera-back/src/controllers/buckets/colaDia.ts
@@ -1,6 +1,7 @@
 import { sql } from "drizzle-orm";
 import { db } from "../../database";
 import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
+import { STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CB-020 · Buckets — Cola del Día (universo SLA).
@@ -74,6 +75,16 @@ export async function getColaDiaSLA(
 		params.buckets && params.buckets.length > 0
 			? sql`AND b.numero IN (${sql.join(params.buckets.map((n) => sql`${n}`), sql`, `)})`
 			: sql``;
+	// Un crédito que salió del funnel (CANCELADO, EN_CONVENIO, CAIDO, etc.) no
+	// siempre escribe una transición de "salida" en buckets_historial — su
+	// última fila puede seguir siendo un B1-B5 viejo. Sin este filtro (mismo
+	// patrón que getCreditosWithUserByMesAnio en credits.ts), esos créditos
+	// quedarían en la Cola del Día indefinidamente aunque ya no se cobren
+	// activamente (review Codex).
+	const statusFueraSql = sql.join(
+		STATUS_BUCKET_FUERA.map((s) => sql`${s}`),
+		sql`, `,
+	);
 
 	// ultima_entrada: 1 fila por crédito con su bucket_nuevo/fecha más reciente.
 	// pool: buckets que el asesor (o cualquier asesor activo) cubre.
@@ -96,6 +107,7 @@ export async function getColaDiaSLA(
     INNER JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
     WHERE b.numero > 0
       AND b.dias_sla IS NOT NULL
+      AND c."statusCredit" NOT IN (${statusFueraSql})
       ${filtroAsesor}
       ${filtroBuckets}
   `;

--- a/apps/cartera-back/src/controllers/latefee.ts
+++ b/apps/cartera-back/src/controllers/latefee.ts
@@ -74,12 +74,12 @@ export type { BucketCatalogo, BucketCatalogoCompleto };
 // ambiente): sin esto, GET /config/buckets devolvía 500 en vez de degradar,
 // a diferencia de los demás consumidores de getBucketsCatalogo() en credits.ts.
 const FALLBACK_BUCKETS_CATALOGO: BucketCatalogoCompleto[] = [
-  { numero: 0, prefijo: "B0", nombre: "Cartera Sana", descripcion: null, cuotas_min: 0, cuotas_max: 0, estados_incluidos: [], es_operativo: true, orden: 0, color: null, estado_mora: "al_dia" },
-  { numero: 1, prefijo: "B1", nombre: "Alerta Temprana", descripcion: null, cuotas_min: 1, cuotas_max: 1, estados_incluidos: [], es_operativo: true, orden: 1, color: null, estado_mora: "mora_30" },
-  { numero: 2, prefijo: "B2", nombre: "Gestión Activa", descripcion: null, cuotas_min: 2, cuotas_max: 2, estados_incluidos: [], es_operativo: true, orden: 2, color: null, estado_mora: "mora_60" },
-  { numero: 3, prefijo: "B3", nombre: "Rescate", descripcion: null, cuotas_min: 3, cuotas_max: 3, estados_incluidos: [], es_operativo: true, orden: 3, color: null, estado_mora: "mora_90" },
-  { numero: 4, prefijo: "B4", nombre: "Última Instancia / Pre Jurídico", descripcion: null, cuotas_min: 4, cuotas_max: 4, estados_incluidos: [], es_operativo: true, orden: 4, color: null, estado_mora: "mora_120" },
-  { numero: 5, prefijo: "B5", nombre: "Jurídico", descripcion: null, cuotas_min: 5, cuotas_max: null, estados_incluidos: ["INCOBRABLE"], es_operativo: false, orden: 5, color: null, estado_mora: "mora_120_plus" },
+  { numero: 0, prefijo: "B0", nombre: "Cartera Sana", descripcion: null, cuotas_min: 0, cuotas_max: 0, estados_incluidos: [], es_operativo: true, orden: 0, color: null, estado_mora: "al_dia", dias_sla: null },
+  { numero: 1, prefijo: "B1", nombre: "Alerta Temprana", descripcion: null, cuotas_min: 1, cuotas_max: 1, estados_incluidos: [], es_operativo: true, orden: 1, color: null, estado_mora: "mora_30", dias_sla: 3 },
+  { numero: 2, prefijo: "B2", nombre: "Gestión Activa", descripcion: null, cuotas_min: 2, cuotas_max: 2, estados_incluidos: [], es_operativo: true, orden: 2, color: null, estado_mora: "mora_60", dias_sla: 3 },
+  { numero: 3, prefijo: "B3", nombre: "Rescate", descripcion: null, cuotas_min: 3, cuotas_max: 3, estados_incluidos: [], es_operativo: true, orden: 3, color: null, estado_mora: "mora_90", dias_sla: 2 },
+  { numero: 4, prefijo: "B4", nombre: "Última Instancia / Pre Jurídico", descripcion: null, cuotas_min: 4, cuotas_max: 4, estados_incluidos: [], es_operativo: true, orden: 4, color: null, estado_mora: "mora_120", dias_sla: 2 },
+  { numero: 5, prefijo: "B5", nombre: "Jurídico", descripcion: null, cuotas_min: 5, cuotas_max: null, estados_incluidos: ["INCOBRABLE"], es_operativo: false, orden: 5, color: null, estado_mora: "mora_120_plus", dias_sla: 1 },
 ];
 
 export type CatalogoBucketsResultado = {
@@ -111,6 +111,7 @@ export async function getBucketsCatalogoConEstado(): Promise<CatalogoBucketsResu
         orden: buckets.orden,
         color: buckets.color,
         estado_mora: buckets.estado_mora,
+        dias_sla: buckets.dias_sla,
       })
       .from(buckets)
       .where(eq(buckets.activo, true))

--- a/apps/cartera-back/src/database/db/schema.ts
+++ b/apps/cartera-back/src/database/db/schema.ts
@@ -451,6 +451,10 @@
     orden: integer("orden").notNull().default(0),
     color: varchar("color", { length: 16 }),
     estado_mora: varchar("estado_mora", { length: 24 }), // puente numero↔estadoMora (al_dia..mora_120_plus), consumido por CRM
+    // CB-020: días de SLA para contactar un crédito desde que ENTRÓ a este
+    // bucket (ver buckets_historial). null = sin SLA (B0/Cartera Sana: al día,
+    // no aplica). Solo editable a mano (mismo patrón que el resto del catálogo).
+    dias_sla: integer("dias_sla"),
     activo: boolean("activo").notNull().default(true),
     created_at: timestamp("created_at").defaultNow(),
     updated_at: timestamp("updated_at").defaultNow(),

--- a/apps/cartera-back/src/lib/buckets-classification.ts
+++ b/apps/cartera-back/src/lib/buckets-classification.ts
@@ -25,6 +25,8 @@ export type BucketCatalogoCompleto = {
   orden: number;
   color: string | null;
   estado_mora: string | null;
+  /** CB-020: días de SLA para contactar desde que el crédito ENTRÓ a este bucket. null = sin SLA (B0). */
+  dias_sla: number | null;
 };
 
 // El bucket se DERIVA del catálogo dinámico `cartera.buckets` (nombres, rangos y

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -13,6 +13,7 @@ import {
 } from "../controllers/buckets/reasignarAsesor";
 import { getCargaPorAsesorBucket } from "../controllers/buckets/cargaAsesorBucket";
 import { actualizarCapacidadAsesorBucket } from "../controllers/buckets/actualizarAsesorBucket";
+import { getColaDiaSLA } from "../controllers/buckets/colaDia";
 import { StatusCredit } from "../database/db/schema";
 
 // Estados DENTRO del funnel operativo (= enum de statusCredit menos
@@ -402,6 +403,54 @@ export const bucketsRouter = new Elysia()
         return {
           success: false,
           message: "[ERROR] No se pudo obtener el pool de asesores del bucket",
+          error: String(err),
+        };
+      }
+    },
+  )
+
+  // CB-020 · Cola del Día — universo SLA: créditos del POOL de buckets del
+  // asesor (asesor_bucket, no el asesor_id del crédito individual) con la
+  // fecha en que entraron a su bucket ACTUAL + fecha_limite_sla derivada. El
+  // CRM cruza esto contra sus propias promesas de pago (contactos_cobros,
+  // que viven solo ahí) para armar las 3 categorías de la cola.
+  .get(
+    "/buckets/cola-dia",
+    async ({ query, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        const asesorId = query?.asesor_id ? Number(query.asesor_id) : undefined;
+        if (asesorId !== undefined && (!Number.isInteger(asesorId) || asesorId <= 0)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] asesor_id inválido" };
+        }
+        // esBucket solo valida "entero no-negativo"; acá además se acota al
+        // rango real del catálogo (0-5) — sin esto, ?bucket=999 pasaba la
+        // validación y devolvía 0 filas en silencio en vez de rechazar.
+        if (csvInvalido(query?.bucket, (s) => esBucket(s) && Number(s) <= 5)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] bucket inválido (CSV de enteros 0-5, ej. 3 o 3,4)" };
+        }
+        const buckets = query?.bucket
+          ? [...new Set(
+              String(query.bucket)
+                .split(",")
+                .map((s: string) => Number(s.trim()))
+                .filter((n: number) => Number.isInteger(n)),
+            )] as number[]
+          : undefined;
+        const pageFloor = Math.floor(Number(query?.page ?? 1));
+        const page = Number.isFinite(pageFloor) && pageFloor > 0 ? pageFloor : 1;
+        const perPageFloor = Math.floor(Number(query?.perPage ?? 50));
+        // Tope real (500) vive en getColaDiaSLA.
+        const perPage =
+          Number.isFinite(perPageFloor) && perPageFloor > 0 ? perPageFloor : 50;
+        return await getColaDiaSLA({ asesor_id: asesorId, buckets, page, perPage });
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener la cola del día",
           error: String(err),
         };
       }


### PR DESCRIPTION
## Contexto

CB-020 pide una "Cola del Día" para que el asesor sepa qué cuentas gestionar
primero, priorizadas por SLA de contacto, promesa de pago y días sin
contacto. Este PR es la **parte de cartera-back**: expone el universo de
créditos con su SLA calculado. La clasificación final (cruzar con promesas
de pago, que viven en la base del CRM) y la UI van en un PR aparte sobre
`apps/crm`.

**Definición de SLA** (confirmada con el usuario): días que tiene el asesor
para contactar un crédito desde que **entró a su bucket actual** (ej. B1 = 3
días).

## Qué se agregó

### 1. Columna `dias_sla` en `cartera_cobros2.buckets`
- Migración manual idempotente: `drizzle/cobros-02/0006_buckets_dias_sla.sql`
  (mismo patrón que `0003`/`0005`: `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`
  + `UPDATE ... WHERE dias_sla IS NULL`, aplicada a mano — Cartera no usa
  drizzle-kit para esta carpeta).
- **B0 (Cartera Sana) queda `NULL` a propósito**: al día, no aplica SLA de
  contacto.
- **Seed son PLACEHOLDERS** (B1=3, B2=3, B3=2, B4=2, B5=1) — documentado en
  el propio SQL que Cartera/negocio debe confirmar los valores reales antes
  de que la Cola del Día salga a producción. Se corrigen con un `UPDATE`
  directo cuando estén definidos, mismo criterio que el resto del catálogo
  (editable a mano por SQL, sin endpoint de escritura).
- Reflejada en el modelo Drizzle (`src/database/db/schema.ts`) y expuesta en
  el catálogo dinámico `GET /config/buckets` (`getBucketsCatalogoConEstado`
  en `latefee.ts` + `FALLBACK_BUCKETS_CATALOGO` + tipo `BucketCatalogoCompleto`
  en `buckets-classification.ts`).

### 2. Endpoint `GET /buckets/cola-dia`
Nuevo controller `src/controllers/buckets/colaDia.ts`, expuesto en
`src/routers/buckets.ts`.

- **Universo = pool de buckets del asesor** (`asesor_bucket`, `activo=true`),
  **no** el `asesor_id` individual asignado al crédito — un bucket puede
  tener varios asesores cubriéndolo. Distinto del criterio que usa
  `getCuotasProximasVencer` (Agenda del día), que sí filtra por asesor
  asignado al crédito.
- Por cada crédito calcula:
  - `fecha_entrada_bucket`: última fila de `buckets_historial` para ese
    `credito_id` (`DISTINCT ON`, aprovecha el índice compuesto
    `credito_id, fecha DESC, historial_id DESC` ya existente).
  - `fecha_limite_sla` = `fecha_entrada_bucket + dias_sla` del bucket, en
    día calendario Guatemala.
- Créditos sin ninguna fila en `buckets_historial` (ambiente sin backfill de
  COBROS-02) se **excluyen** — no se inventa una fecha de referencia, mismo
  criterio de "degradar sin asumir dato" que usa el resto del motor de
  buckets (`getCreditosWithUserByMesAnio`).
- B0 se excluye siempre (sin `dias_sla`, no aplica).
- Filtros opcionales: `asesor_id` y `bucket` (CSV de 0-5). El filtro de
  bucket ahora valida el rango explícitamente — antes un valor fuera de
  0-5 pasaba la regex genérica (`esBucket`, solo valida "entero no
  negativo") y devolvía 0 filas en silencio en vez de rechazar; ahora
  responde 400.
- **Sin filtro de fecha, a propósito**: el endpoint expone el universo
  completo, paginado normal (tope 500 por página, igual que el resto de
  `/buckets/*`). La decisión de qué mostrar "hoy" cruza esto contra
  promesas de pago del CRM — dato que cartera-back no tiene — así que ese
  filtrado vive del lado del CRM, no acá.
- Mismo gate de rol que el resto de `/buckets/*` (`requireBucketsRole`,
  ADMIN/CONTA — token de servicio del CRM).

## Qué NO incluye este PR
- Clasificación de categorías (SLA hoy / promesa hoy / incumplida / días sin
  contacto), consumo del cliente CRM, router ORPC y UI — van en un PR
  separado sobre `apps/crm/apps/server` y `apps/crm/apps/web`.
- No modifica ningún endpoint existente de `/buckets/*`.

## Test plan
- [ ] Aplicar `0006_buckets_dias_sla.sql` a mano en dev (`cartera_cobros2`) y
  confirmar `\d cartera_cobros2.buckets` muestra `dias_sla`.
- [ ] `GET /config/buckets` devuelve `dias_sla` por bucket (null en B0).
- [ ] `GET /buckets/cola-dia?asesor_id=<uno con pool>` devuelve créditos de
  sus buckets con `fecha_limite_sla` = `fecha_entrada_bucket + dias_sla`
  correcto.
- [ ] `GET /buckets/cola-dia?bucket=999` responde 400 (antes devolvía 0
  filas).
- [ ] `GET /buckets/cola-dia?bucket=3,4` filtra solo esos buckets.
- [ ] Confirmar con Cartera/negocio los valores reales de `dias_sla` antes
  de aplicar esta migración en producción.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>