### PR TITLE
feat(cobros): alertas de notificaciones con propósito + filtro por tipo (COBROS-02)

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0027_cobros_notif_tipo.sql
+++ b/apps/crm/apps/server/src/db/migrations/0027_cobros_notif_tipo.sql
@@ -1,0 +1,18 @@
+-- 0027: COBROS-02 — Enum específico de notificaciones de cobros + columna.
+-- Espejo exacto del schema drizzle `src/db/schema/notifications.ts`.
+-- Idempotente: seguro de re-correr. Aplicar A MANO (no drizzle-kit push/migrate
+-- corrido desde este trabajo — mismo criterio que 0026_cb020_promesa_pago_cuotas.sql).
+--
+-- Los jobs de cobros clasifican sus notificaciones en `cobros_tipo` (columna
+-- propia, NO en `type`, que es general del CRM). Toda otra notificación la deja
+-- NULL. La web pinta cada tarjeta de un color distinto según este valor:
+--   promesa_incumplida → una promesa venció con la(s) cuota(s) aún pendiente(s)
+--   cliente_subido     → el crédito acaba de subir de bucket (aviso al asesor)
+--   sin_contacto_3d    → 3 días hábiles en el bucket sin registro de contacto
+
+DO $$ BEGIN
+  CREATE TYPE public.cobros_notif_tipo AS ENUM ('promesa_incumplida', 'cliente_subido', 'sin_contacto_3d');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+ALTER TABLE public.notifications
+  ADD COLUMN IF NOT EXISTS cobros_tipo public.cobros_notif_tipo;

--- a/apps/crm/apps/server/src/db/schema/notifications.ts
+++ b/apps/crm/apps/server/src/db/schema/notifications.ts
@@ -53,6 +53,16 @@ export const notificationRedirectPageEnum = pgEnum(
 	],
 );
 
+// COBROS-02: subtipo específico de las notificaciones del módulo de cobros.
+// Vive en su propia columna `cobros_tipo` (NO en `type`, que es general del CRM)
+// y solo lo setean los jobs de cobros; toda otra notificación lo deja null. La
+// web lo usa para pintar cada tarjeta de un color distinto.
+export const cobrosNotifTipoEnum = pgEnum("cobros_notif_tipo", [
+	"promesa_incumplida",
+	"cliente_subido",
+	"sin_contacto_3d",
+]);
+
 // Notifications table
 export const notifications = pgTable(
 	"notifications",
@@ -81,6 +91,9 @@ export const notifications = pgTable(
 
 		// Redirect URL
 		redirectPage: notificationRedirectPageEnum("redirect_page"),
+
+		// COBROS-02: subtipo de cobros (null para el resto de notificaciones).
+		cobrosTipo: cobrosNotifTipoEnum("cobros_tipo"),
 
 		// Timestamps de estado
 		readAt: timestamp("read_at"),

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -1312,8 +1312,19 @@ function scheduleAtCobrosAlertasGT() {
 	}, next.getTime() - now.getTime());
 }
 scheduleAtCobrosAlertasGT();
+// Recuperación al boot SOLO si ya pasaron las 08:00 GT (un deploy tardío recupera
+// el batch del día; el dedup evita duplicar). Antes de las 08:00 GT NO se corre:
+// dispararía las alertas "de las 8am" en medianoche — se deja que el timeout
+// programado las lance a la hora (Codex P2).
 setTimeout(() => {
-	checkCobrosAlertas().catch(console.error);
+	const horaGT = (new Date().getUTCHours() + 18) % 24; // GT = UTC-6, sin DST
+	if (horaGT >= 8) {
+		checkCobrosAlertas().catch(console.error);
+	} else {
+		console.log(
+			"[CobrosAlertas] Boot antes de las 08:00 GT; se omite la recuperación (el timeout programado la lanzará a la hora)",
+		);
+	}
 }, 20_000);
 
 // Ejecutar procesarSeguimientosRecurrentes a medianoche GT (00:00 GT = 06:00 UTC) cada día.

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -33,7 +33,6 @@ import {
 import type { db } from "./db";
 import { otps } from "./db/schema/otp";
 import {
-	checkCasosSinContacto,
 	checkSeguimientosVencidos,
 	procesarSeguimientosRecurrentes,
 } from "./jobs/cobros-notifications";
@@ -49,6 +48,7 @@ import {
 } from "./routers/index";
 import { investmentsRouter } from "./routers/investments";
 import externalContractsRouter from "./routes/external-contracts";
+import { checkCobrosAlertas } from "./services/check-cobros-alertas";
 import { checkPromesasPago } from "./services/check-promesas-pago";
 import { sendPremoraReminders } from "./services/send-premora-reminders";
 
@@ -1263,7 +1263,6 @@ setInterval(
 	async () => {
 		try {
 			await checkSeguimientosVencidos();
-			await checkCasosSinContacto(3);
 		} catch (error) {
 			console.error("Error en job de notificaciones cobros:", error);
 		}
@@ -1274,7 +1273,6 @@ setInterval(
 // Ejecutar una vez al iniciar (con delay de 10s para que la DB esté lista)
 setTimeout(() => {
 	checkSeguimientosVencidos().catch(console.error);
-	checkCasosSinContacto(3).catch(console.error);
 	procesarSeguimientosRecurrentes().catch(console.error);
 	checkPromesasPago().catch(console.error);
 }, 10_000);
@@ -1297,6 +1295,26 @@ scheduleAtPremoraGT();
 setTimeout(() => {
 	sendPremoraReminders().catch(console.error);
 }, 15_000);
+
+// COBROS-02: alertas de cobros con propósito (cliente_subido + sin_contacto_3d),
+// diario a las 8:00 GT — DESPUÉS de que la subida de bucket de medianoche ya
+// corrió en cartera, para leer las subidas de anoche. Reemplaza las viejas
+// notificaciones masivas de "sin contacto". Idempotente por su propio dedup, así
+// que el run de boot (abajo) recupera sin duplicar.
+function scheduleAtCobrosAlertasGT() {
+	const now = new Date();
+	const next = new Date();
+	next.setUTCHours(14, 0, 0, 0); // 08:00 GT
+	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+	setTimeout(async () => {
+		await checkCobrosAlertas().catch(console.error);
+		scheduleAtCobrosAlertasGT();
+	}, next.getTime() - now.getTime());
+}
+scheduleAtCobrosAlertasGT();
+setTimeout(() => {
+	checkCobrosAlertas().catch(console.error);
+}, 20_000);
 
 // Ejecutar procesarSeguimientosRecurrentes a medianoche GT (00:00 GT = 06:00 UTC) cada día.
 // CB-020: también cierra el día evaluando TODAS las promesas de pago activas

--- a/apps/crm/apps/server/src/jobs/cobros-notifications.ts
+++ b/apps/crm/apps/server/src/jobs/cobros-notifications.ts
@@ -7,10 +7,10 @@
  * procesarSeguimientosRecurrentes: 5 queries fijas (era 1+4N)
  */
 
-import { and, eq, gt, inArray, isNotNull, lt, max, sql } from "drizzle-orm";
+import { and, eq, gt, inArray, isNotNull, lt, sql } from "drizzle-orm";
 
 import { db } from "../db";
-import { casosCobros, contactosCobros, seguimientosProgramados } from "../db/schema/cobros";
+import { casosCobros, seguimientosProgramados } from "../db/schema/cobros";
 import { notifications } from "../db/schema/notifications";
 import { toDateStrGT } from "../lib/guatemala-month-window";
 
@@ -82,94 +82,10 @@ export async function checkSeguimientosVencidos() {
 	);
 }
 
-export async function checkCasosSinContacto(diasLimite = 3) {
-	const limite = new Date();
-	limite.setDate(limite.getDate() - diasLimite);
-
-	// Query 1: Casos activos cuyo último contacto es anterior al límite
-	// Subquery con MAX(fecha_contacto) agrupado por caso_cobro_id
-	const ultimoContactoPorCaso = db
-		.select({
-			casoCobroId: contactosCobros.casoCobroId,
-			ultimaFecha: max(contactosCobros.fechaContacto).as("ultima_fecha"),
-		})
-		.from(contactosCobros)
-		.groupBy(contactosCobros.casoCobroId)
-		.as("ultimo_contacto");
-
-	const casosSinContacto = await db
-		.select({
-			id: casosCobros.id,
-			responsable: casosCobros.responsableCobros,
-			numeroCreditoSifco: casosCobros.numeroCreditoSifco,
-			ultimaFecha: ultimoContactoPorCaso.ultimaFecha,
-		})
-		.from(casosCobros)
-		.innerJoin(
-			ultimoContactoPorCaso,
-			eq(casosCobros.id, ultimoContactoPorCaso.casoCobroId),
-		)
-		.where(
-			and(
-				eq(casosCobros.activo, true),
-				lt(ultimoContactoPorCaso.ultimaFecha, limite),
-			),
-		);
-
-	if (casosSinContacto.length === 0) {
-		console.log(
-			`[CobrosNotifications] Casos sin contacto (>${diasLimite} días): 0 encontrados`,
-		);
-		return;
-	}
-
-	const casoIds = casosSinContacto.map((c) => c.id);
-
-	// Query 2: Batch dedup — IDs que ya tienen notificación en últimas 24h
-	const yaNotificados = await db
-		.select({ relatedEntityId: notifications.relatedEntityId })
-		.from(notifications)
-		.where(
-			and(
-				inArray(notifications.relatedEntityId, casoIds),
-				eq(notifications.relatedEntityType, "collection_case"),
-				eq(notifications.titulo, "Caso sin contacto reciente"),
-				gt(notifications.createdAt, sql`now() - interval '24 hours'`),
-			),
-		);
-
-	const notificadosSet = new Set(yaNotificados.map((n) => n.relatedEntityId));
-
-	const nuevasNotificaciones = casosSinContacto
-		.filter((caso) => !notificadosSet.has(caso.id))
-		.map((caso) => {
-			const dias = Math.floor(
-				(Date.now() - caso.ultimaFecha!.getTime()) / (1000 * 60 * 60 * 24),
-			);
-			return {
-				titulo: "Caso sin contacto reciente" as const,
-				descripcion: `El caso ${caso.numeroCreditoSifco || caso.id.slice(0, 8)} lleva ${dias} días sin contacto`,
-				type: "reminder" as const,
-				status: "pending" as const,
-				createdBy: caso.responsable,
-				createdByRole: "cobros" as const,
-				assignedToRole: "cobros" as const,
-				assignedTo: caso.responsable,
-				relatedEntityType: "collection_case" as const,
-				relatedEntityId: caso.id,
-				redirectPage: "cobros_detail" as const,
-			};
-		});
-
-	// Query 3: Batch insert
-	if (nuevasNotificaciones.length > 0) {
-		await db.insert(notifications).values(nuevasNotificaciones);
-	}
-
-	console.log(
-		`[CobrosNotifications] Casos sin contacto (>${diasLimite} días): ${casosSinContacto.length} encontrados, ${nuevasNotificaciones.length} notificados`,
-	);
-}
+// COBROS-02: `checkCasosSinContacto` (las notificaciones masivas "Caso sin
+// contacto reciente") se eliminó — la reemplazan las alertas con propósito de
+// check-cobros-alertas.ts (cliente_subido + sin_contacto_3d, ancladas a la
+// SUBIDA de bucket y con días hábiles) y checkPromesasPago (promesa_incumplida).
 
 // Two-component advisory lock key: namespace=1 (cobros jobs), key=1 (procesarSeguimientosRecurrentes)
 const SEGUIMIENTOS_LOCK = [1, 1] as const;
@@ -182,19 +98,26 @@ export async function procesarSeguimientosRecurrentes() {
 			[...SEGUIMIENTOS_LOCK],
 		);
 		if (!rows[0].acquired) {
-			console.log("[SeguimientosRecurrentes] Already running (distributed lock held), skipping");
+			console.log(
+				"[SeguimientosRecurrentes] Already running (distributed lock held), skipping",
+			);
 			return;
 		}
 		await _procesarSeguimientosRecurrentes(client);
 	} finally {
-		await client.query("SELECT pg_advisory_unlock($1, $2)", [...SEGUIMIENTOS_LOCK]);
+		await client.query("SELECT pg_advisory_unlock($1, $2)", [
+			...SEGUIMIENTOS_LOCK,
+		]);
 		client.release();
 	}
 }
 
 // Minimal interface so we don't need to import pg types directly.
 interface RawClient {
-	query<T extends object>(text: string, values?: unknown[]): Promise<{ rows: T[] }>;
+	query<T extends object>(
+		text: string,
+		values?: unknown[],
+	): Promise<{ rows: T[] }>;
 }
 
 async function _procesarSeguimientosRecurrentes(client: RawClient) {
@@ -218,61 +141,95 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 			responsableCobros: casosCobros.responsableCobros,
 		})
 		.from(seguimientosProgramados)
-		.innerJoin(casosCobros, eq(seguimientosProgramados.casoCobroId, casosCobros.id))
+		.innerJoin(
+			casosCobros,
+			eq(seguimientosProgramados.casoCobroId, casosCobros.id),
+		)
 		.where(eq(seguimientosProgramados.activo, true));
 
 	if (seguimientos.length === 0) {
-		console.log("[CobrosNotifications] procesarSeguimientosRecurrentes: 0 seguimientos activos, nada que procesar");
+		console.log(
+			"[CobrosNotifications] procesarSeguimientosRecurrentes: 0 seguimientos activos, nada que procesar",
+		);
 		return;
 	}
 
-	console.log(`[CobrosNotifications] procesarSeguimientosRecurrentes: ${seguimientos.length} seguimientos activos encontrados`);
+	console.log(
+		`[CobrosNotifications] procesarSeguimientosRecurrentes: ${seguimientos.length} seguimientos activos encontrados`,
+	);
 
 	// Categorize in JS — no DB roundtrip per row
 	const toDeactivateIds: string[] = [];
-	type SegRow = typeof seguimientos[number];
-	type ClaimRow = SegRow & { oldOcurrencias: number; newOcurrencias: number; proximaFecha: Date };
+	type SegRow = (typeof seguimientos)[number];
+	type ClaimRow = SegRow & {
+		oldOcurrencias: number;
+		newOcurrencias: number;
+		proximaFecha: Date;
+	};
 	const claimRows: ClaimRow[] = [];
 
 	for (const seg of seguimientos) {
 		// Datos corruptos — check constraint protege rows nuevos; esto cubre legacy.
-		if (seg.intervaloDias <= 0) { toDeactivateIds.push(seg.id); continue; }
-		if (seg.fechaFin && toDateStrGT(seg.fechaFin) < hoyStr) { toDeactivateIds.push(seg.id); continue; }
-		if (seg.ocurrenciasMaximas != null && seg.ocurrenciasRealizadas >= seg.ocurrenciasMaximas) {
-			toDeactivateIds.push(seg.id); continue;
+		if (seg.intervaloDias <= 0) {
+			toDeactivateIds.push(seg.id);
+			continue;
+		}
+		if (seg.fechaFin && toDateStrGT(seg.fechaFin) < hoyStr) {
+			toDeactivateIds.push(seg.id);
+			continue;
+		}
+		if (
+			seg.ocurrenciasMaximas != null &&
+			seg.ocurrenciasRealizadas >= seg.ocurrenciasMaximas
+		) {
+			toDeactivateIds.push(seg.id);
+			continue;
 		}
 
 		// Días transcurridos en zona GT — evita catch-up N-veces si el scheduler estuvo caído.
 		const diasTranscurridos = Math.floor(
-			(hoyMs - new Date(`${toDateStrGT(seg.fechaInicio)}T00:00:00`).getTime()) / 86_400_000,
+			(hoyMs - new Date(`${toDateStrGT(seg.fechaInicio)}T00:00:00`).getTime()) /
+				86_400_000,
 		);
 		if (diasTranscurridos < 0) continue;
 
 		// Largest k where fechaInicio + k*intervaloDias <= today
-		const ocurrenciasDebidas = Math.floor(diasTranscurridos / seg.intervaloDias);
+		const ocurrenciasDebidas = Math.floor(
+			diasTranscurridos / seg.intervaloDias,
+		);
 		if (ocurrenciasDebidas >= seg.ocurrenciasRealizadas) {
 			// Acotar al límite máximo: si el scheduler estuvo caído varios intervalos,
 			// ocurrenciasDebidas puede superar ocurrenciasMaximas y disparar una notificación extra.
-			const newOcurrencias = seg.ocurrenciasMaximas != null
-				? Math.min(ocurrenciasDebidas + 1, seg.ocurrenciasMaximas)
-				: ocurrenciasDebidas + 1;
+			const newOcurrencias =
+				seg.ocurrenciasMaximas != null
+					? Math.min(ocurrenciasDebidas + 1, seg.ocurrenciasMaximas)
+					: ocurrenciasDebidas + 1;
 			// Aritmética en ms — Guatemala no tiene DST.
 			const proximaFecha = new Date(
-				seg.fechaInicio.getTime() + seg.intervaloDias * newOcurrencias * 86_400_000,
+				seg.fechaInicio.getTime() +
+					seg.intervaloDias * newOcurrencias * 86_400_000,
 			);
-			claimRows.push({ ...seg, oldOcurrencias: seg.ocurrenciasRealizadas, newOcurrencias, proximaFecha });
+			claimRows.push({
+				...seg,
+				oldOcurrencias: seg.ocurrenciasRealizadas,
+				newOcurrencias,
+				proximaFecha,
+			});
 		}
 	}
 
 	// Query 2: batch deactivate (1 query vs N)
 	if (toDeactivateIds.length > 0) {
-		await db.update(seguimientosProgramados)
+		await db
+			.update(seguimientosProgramados)
 			.set({ activo: false, updatedAt: new Date() })
 			.where(inArray(seguimientosProgramados.id, toDeactivateIds));
 	}
 
 	if (claimRows.length === 0) {
-		console.log(`[SeguimientosRecurrentes] ${toDeactivateIds.length} desactivados, 0 a procesar`);
+		console.log(
+			`[SeguimientosRecurrentes] ${toDeactivateIds.length} desactivados, 0 a procesar`,
+		);
 		return;
 	}
 
@@ -280,11 +237,13 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 	// Sin transacción, un fallo entre el CAS y el insert de notificaciones consumía el contador
 	// permanentemente (el siguiente run lo saltaba) sin generar el recordatorio.
 	const casParams: unknown[] = [];
-	const casPh = claimRows.map((r, i) => {
-		const b = i * 3;
-		casParams.push(r.id, r.oldOcurrencias, r.newOcurrencias);
-		return `($${b + 1}::uuid, $${b + 2}::int, $${b + 3}::int)`;
-	}).join(", ");
+	const casPh = claimRows
+		.map((r, i) => {
+			const b = i * 3;
+			casParams.push(r.id, r.oldOcurrencias, r.newOcurrencias);
+			return `($${b + 1}::uuid, $${b + 2}::int, $${b + 3}::int)`;
+		})
+		.join(", ");
 
 	let claimed: ClaimRow[] = [];
 
@@ -305,7 +264,9 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 
 		if (claimed.length === 0) {
 			await client.query("COMMIT");
-			console.log("[SeguimientosRecurrentes] 0 claims ganados (runner concurrente los tomó)");
+			console.log(
+				"[SeguimientosRecurrentes] 0 claims ganados (runner concurrente los tomó)",
+			);
 			return;
 		}
 
@@ -343,19 +304,25 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 
 		// Query 5: batch insert notificaciones como raw SQL para permanecer en la misma transacción.
 		const notifParams: unknown[] = [];
-		const notifPh = claimed.map((r, i) => {
-			const b = i * 11;
-			notifParams.push(
-				"Nuevo seguimiento programado",
-				`Se ha programado automáticamente un contacto vía ${r.metodoContacto} para el crédito ${r.numeroCreditoSifco ?? r.casoCobroId.slice(0, 8)}`,
-				"reminder", "pending",
-				r.agenteId, "cobros", "cobros",
-				r.responsableCobros,
-				"collection_case", r.casoCobroId,
-				"cobros_detail",
-			);
-			return `($${b + 1}::text, $${b + 2}::text, $${b + 3}::notification_type, $${b + 4}::notification_status, $${b + 5}::text, $${b + 6}::user_role, $${b + 7}::user_role, $${b + 8}::text, $${b + 9}::notification_entity_type, $${b + 10}::uuid, $${b + 11}::notification_redirect_page)`;
-		}).join(", ");
+		const notifPh = claimed
+			.map((r, i) => {
+				const b = i * 11;
+				notifParams.push(
+					"Nuevo seguimiento programado",
+					`Se ha programado automáticamente un contacto vía ${r.metodoContacto} para el crédito ${r.numeroCreditoSifco ?? r.casoCobroId.slice(0, 8)}`,
+					"reminder",
+					"pending",
+					r.agenteId,
+					"cobros",
+					"cobros",
+					r.responsableCobros,
+					"collection_case",
+					r.casoCobroId,
+					"cobros_detail",
+				);
+				return `($${b + 1}::text, $${b + 2}::text, $${b + 3}::notification_type, $${b + 4}::notification_status, $${b + 5}::text, $${b + 6}::user_role, $${b + 7}::user_role, $${b + 8}::text, $${b + 9}::notification_entity_type, $${b + 10}::uuid, $${b + 11}::notification_redirect_page)`;
+			})
+			.join(", ");
 
 		await client.query(
 			`INSERT INTO notifications (titulo, descripcion, type, status, created_by, created_by_role, assigned_to_role, assigned_to, related_entity_type, related_entity_id, redirect_page)
@@ -370,7 +337,9 @@ async function _procesarSeguimientosRecurrentes(client: RawClient) {
 	}
 
 	for (const r of claimed) {
-		console.log(`[CobrosNotifications] ✅ Seguimiento disparado para caso ${r.casoCobroId} | próximo contacto: ${toDateStrGT(r.proximaFecha)}`);
+		console.log(
+			`[CobrosNotifications] ✅ Seguimiento disparado para caso ${r.casoCobroId} | próximo contacto: ${toDateStrGT(r.proximaFecha)}`,
+		);
 	}
 
 	console.log(

--- a/apps/crm/apps/server/src/lib/business-days-gt.test.ts
+++ b/apps/crm/apps/server/src/lib/business-days-gt.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { contarDiasHabilesGT, esDiaHabilGT } from "./business-days-gt";
+
+// Fechas ancla (verificadas): 2025-01-01 = miércoles.
+//   2025-02-01 = sábado; por tanto 2025-02-15 = sábado (quincena en finde).
+//   2025-05-31 = sábado (fin de mes en finde).
+// Se usa mediodía UTC ("...T12:00:00Z") = 6am GT → mismo día calendario GT.
+const gt = (isoDay: string) => new Date(`${isoDay}T12:00:00Z`);
+
+describe("esDiaHabilGT", () => {
+	it("Lun–Vie son hábiles", () => {
+		expect(esDiaHabilGT(gt("2025-02-10"))).toBe(true); // lunes
+		expect(esDiaHabilGT(gt("2025-02-14"))).toBe(true); // viernes
+	});
+
+	it("sábado/domingo normales NO son hábiles", () => {
+		expect(esDiaHabilGT(gt("2025-02-08"))).toBe(false); // sábado, día 8
+		expect(esDiaHabilGT(gt("2025-02-09"))).toBe(false); // domingo, día 9
+	});
+
+	it("regla de oro: quincena (15) en fin de semana SÍ es hábil", () => {
+		const d = gt("2025-02-15");
+		expect(d.getUTCDay()).toBe(6); // sábado (auto-documenta la fecha)
+		expect(esDiaHabilGT(d)).toBe(true);
+	});
+
+	it("regla de oro: fin de mes en fin de semana SÍ es hábil", () => {
+		const d = gt("2025-05-31");
+		expect(d.getUTCDay()).toBe(6); // sábado
+		expect(esDiaHabilGT(d)).toBe(true);
+	});
+});
+
+describe("contarDiasHabilesGT (intervalo [inicio, fin))", () => {
+	it("cuenta Lun→Jue como 3 (lun, mar, mié; jue excluido)", () => {
+		expect(contarDiasHabilesGT(gt("2025-02-10"), gt("2025-02-13"))).toBe(3);
+	});
+
+	it("salta el fin de semana normal", () => {
+		// [vie 07, mar 11) = {vie, sáb(no), dom(no), lun} = 2
+		expect(contarDiasHabilesGT(gt("2025-02-07"), gt("2025-02-11"))).toBe(2);
+	});
+
+	it("la regla de oro suma la quincena que cae en sábado", () => {
+		// [jue 13, lun 17) = {jue, vie, sáb-15(regla→sí), dom-16(no)} = 3
+		expect(contarDiasHabilesGT(gt("2025-02-13"), gt("2025-02-17"))).toBe(3);
+	});
+
+	it("intervalo vacío o invertido = 0", () => {
+		expect(contarDiasHabilesGT(gt("2025-02-10"), gt("2025-02-10"))).toBe(0);
+		expect(contarDiasHabilesGT(gt("2025-02-13"), gt("2025-02-10"))).toBe(0);
+	});
+});

--- a/apps/crm/apps/server/src/lib/business-days-gt.test.ts
+++ b/apps/crm/apps/server/src/lib/business-days-gt.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, it } from "bun:test";
-import { contarDiasHabilesGT, esDiaHabilGT } from "./business-days-gt";
+import {
+	contarDiasHabilesGT,
+	esDiaHabilGT,
+	siguienteDiaGT,
+} from "./business-days-gt";
+
+const gtDay = (d: Date) =>
+	new Intl.DateTimeFormat("en-CA", {
+		timeZone: "America/Guatemala",
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(d);
 
 // Fechas ancla (verificadas): 2025-01-01 = miércoles.
 //   2025-02-01 = sábado; por tanto 2025-02-15 = sábado (quincena en finde).
@@ -49,5 +61,27 @@ describe("contarDiasHabilesGT (intervalo [inicio, fin))", () => {
 	it("intervalo vacío o invertido = 0", () => {
 		expect(contarDiasHabilesGT(gt("2025-02-10"), gt("2025-02-10"))).toBe(0);
 		expect(contarDiasHabilesGT(gt("2025-02-13"), gt("2025-02-10"))).toBe(0);
+	});
+});
+
+describe("siguienteDiaGT + SLA de subida sellada 23:59 GT (Codex P2)", () => {
+	// Subida del motor: lunes 2025-02-10 23:59 GT = 2025-02-11 05:59 UTC.
+	const subidaLun2359 = new Date("2025-02-11T05:59:00Z");
+
+	it("ancla al día GT siguiente (martes 11), no al lunes", () => {
+		expect(gtDay(subidaLun2359)).toBe("2025-02-10"); // auto-documenta: es lunes GT
+		expect(gtDay(siguienteDiaGT(subidaLun2359))).toBe("2025-02-11");
+	});
+
+	it("NO escala el jueves: solo mar+mié = 2 hábiles (antes contaba lun→3)", () => {
+		expect(
+			contarDiasHabilesGT(siguienteDiaGT(subidaLun2359), gt("2025-02-13")),
+		).toBe(2);
+	});
+
+	it("escala el viernes: mar+mié+jue = 3 hábiles", () => {
+		expect(
+			contarDiasHabilesGT(siguienteDiaGT(subidaLun2359), gt("2025-02-14")),
+		).toBe(3);
 	});
 });

--- a/apps/crm/apps/server/src/lib/business-days-gt.ts
+++ b/apps/crm/apps/server/src/lib/business-days-gt.ts
@@ -1,0 +1,65 @@
+// Helpers de días hábiles en zona America/Guatemala (UTC-6, sin DST) para el
+// módulo de cobros (COBROS-02). Portado de apps/cartera-back businessDays.ts,
+// PERO con la "regla de oro" de cobros: normalmente hábil = Lun–Vie, salvo que
+// el día sea QUINCENA (15) o FIN DE MES — esos SIEMPRE cuentan como hábiles
+// aunque caigan sábado o domingo (es cuando cae la paga). No considera feriados.
+// TODO(Juanda): validar el detalle fino de la regla de oro antes de producción.
+
+const GT_TZ = "America/Guatemala";
+
+function gtYMD(d: Date): { y: number; m: number; day: number } {
+	const parts = new Intl.DateTimeFormat("en-CA", {
+		timeZone: GT_TZ,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).formatToParts(d);
+	const get = (k: string) =>
+		Number(parts.find((p) => p.type === k)?.value ?? "0");
+	return { y: get("year"), m: get("month"), day: get("day") };
+}
+
+/** Último día del mes (mes 1-indexed) — p.ej. ultimoDiaMes(2026, 2) = 28. */
+function ultimoDiaMes(y: number, m: number): number {
+	return new Date(Date.UTC(y, m, 0)).getUTCDate();
+}
+
+/**
+ * ¿Es día hábil en zona GT según la regla de oro de cobros?
+ *  - Lun–Vie: siempre hábil.
+ *  - Sáb/Dom: hábil SOLO si es quincena (día 15) o fin de mes (último día).
+ */
+export function esDiaHabilGT(d: Date): boolean {
+	const { y, m, day } = gtYMD(d);
+	// getUTCDay del mediodía UTC del día GT — sin ambigüedad de borde por tz.
+	const dow = new Date(Date.UTC(y, m - 1, day, 12, 0, 0)).getUTCDay(); // 0=Dom,6=Sáb
+	const esFinDeSemana = dow === 0 || dow === 6;
+	if (!esFinDeSemana) return true;
+	return day === 15 || day === ultimoDiaMes(y, m);
+}
+
+/**
+ * Cuenta los días hábiles (regla de oro) en el intervalo SEMIABIERTO
+ * [inicio, fin): desde el día calendario GT de `inicio` (inclusive) hasta el
+ * día calendario GT de `fin` (EXCLUSIVE). Devuelve 0 si fin <= inicio.
+ *
+ * Uso en cobros: días hábiles transcurridos desde que un crédito subió de
+ * bucket (medianoche) hasta hoy — el job de las 8am alerta al llegar a 3.
+ * Ej.: subió el lunes 00:00, hoy jueves → cuenta {lun, mar, mié} = 3.
+ */
+export function contarDiasHabilesGT(inicio: Date, fin: Date): number {
+	const { y: iy, m: im, day: iday } = gtYMD(inicio);
+	const { y: fy, m: fm, day: fday } = gtYMD(fin);
+	// Iterar por mediodía UTC de cada día evita saltos de borde (GT no tiene DST).
+	let cursor = Date.UTC(iy, im - 1, iday, 12, 0, 0);
+	const limite = Date.UTC(fy, fm - 1, fday, 12, 0, 0);
+	let habiles = 0;
+	// Guarda defensiva: nunca iterar más de ~3 años.
+	let seguridad = 0;
+	while (cursor < limite && seguridad < 1200) {
+		if (esDiaHabilGT(new Date(cursor))) habiles++;
+		cursor += 24 * 60 * 60 * 1000;
+		seguridad++;
+	}
+	return habiles;
+}

--- a/apps/crm/apps/server/src/lib/business-days-gt.ts
+++ b/apps/crm/apps/server/src/lib/business-days-gt.ts
@@ -39,6 +39,18 @@ export function esDiaHabilGT(d: Date): boolean {
 }
 
 /**
+ * Mediodía UTC del día calendario GT SIGUIENTE al de `d`. Sirve para anclar el
+ * conteo "a partir del día siguiente": una subida de bucket se sella a las 23:59
+ * GT (motor procesarMoras), así que ese día no le dio tiempo al asesor y no debe
+ * contar como día hábil de gestión.
+ */
+export function siguienteDiaGT(d: Date): Date {
+	const { y, m, day } = gtYMD(d);
+	// GT no tiene DST → +24h desde el mediodía UTC cae siempre al día GT siguiente.
+	return new Date(Date.UTC(y, m - 1, day, 12, 0, 0) + 24 * 60 * 60 * 1000);
+}
+
+/**
  * Cuenta los días hábiles (regla de oro) en el intervalo SEMIABIERTO
  * [inicio, fin): desde el día calendario GT de `inicio` (inclusive) hasta el
  * día calendario GT de `fin` (EXCLUSIVE). Devuelve 0 si fin <= inicio.

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -296,6 +296,8 @@ export const miscAppRouter = {
 	getNotificationsByRole: notificationsRouter.getNotificationsByRole,
 	getNotificationsByAssign: notificationsRouter.getNotificationsByAssign,
 	getNotificationsByRoles: notificationsRouter.getNotificationsByRoles,
+	getAvailableNotificationTypes:
+		notificationsRouter.getAvailableNotificationTypes,
 	changeNotificationStatus: notificationsRouter.changeNotificationStatus,
 	getNotificationDocuments: notificationsRouter.getNotificationDocuments,
 	addDocumentToNotification: notificationsRouter.addDocumentToNotification,

--- a/apps/crm/apps/server/src/routers/notifications.ts
+++ b/apps/crm/apps/server/src/routers/notifications.ts
@@ -1,5 +1,14 @@
 import { ORPCError } from "@orpc/server";
-import { and, count, desc, eq, inArray, isNull, or } from "drizzle-orm";
+import {
+	and,
+	count,
+	desc,
+	eq,
+	inArray,
+	isNotNull,
+	isNull,
+	or,
+} from "drizzle-orm";
 import { z } from "zod";
 import { db } from "../db";
 import { user } from "../db/schema/auth";
@@ -32,6 +41,7 @@ const notificationWithCreator = {
 	relatedEntityType: notifications.relatedEntityType,
 	relatedEntityId: notifications.relatedEntityId,
 	redirectPage: notifications.redirectPage,
+	cobrosTipo: notifications.cobrosTipo,
 	readAt: notifications.readAt,
 	resolvedAt: notifications.resolvedAt,
 	createdAt: notifications.createdAt,
@@ -207,6 +217,61 @@ export const notificationsRouter = {
 
 			return result;
 		}),
+
+	// Tipos (redirect_page) disponibles para el filtro del usuario autenticado.
+	// Devuelve SOLO los redirect_page para los que el usuario/rol tiene al menos
+	// una notificación visible (sin importar el estado), replicando la misma
+	// visibilidad que getAllNotifications / getNotificationsByRole(s) /
+	// getNotificationsByAssign. Así el dropdown solo ofrece tipos que el usuario
+	// realmente puede ver.
+	getAvailableNotificationTypes: protectedProcedure.handler(
+		async ({ context }) => {
+			const userId = context.session.user.id;
+
+			const [userData] = await db
+				.select({ role: user.role })
+				.from(user)
+				.where(eq(user.id, userId))
+				.limit(1);
+
+			if (!userData) return [];
+
+			const isAdmin = userData.role === "admin";
+			const isSalesSupervisor = userData.role === "sales_supervisor";
+
+			// Misma visibilidad que las listas de la página de notificaciones:
+			//  - admin: todo (sin filtro)
+			//  - sales_supervisor: sus roles visibles + asignación directa
+			//  - resto: su rol (sin asignar) + asignación directa
+			const visibilidad = isAdmin
+				? undefined
+				: isSalesSupervisor
+					? or(
+							inArray(notifications.assignedToRole, [
+								"sales_supervisor",
+								"analyst",
+								"juridico",
+							]),
+							eq(notifications.assignedTo, userId),
+						)
+					: or(
+							and(
+								eq(notifications.assignedToRole, userData.role),
+								isNull(notifications.assignedTo),
+							),
+							eq(notifications.assignedTo, userId),
+						);
+
+			const rows = await db
+				.selectDistinct({ redirectPage: notifications.redirectPage })
+				.from(notifications)
+				.where(and(isNotNull(notifications.redirectPage), visibilidad));
+
+			return rows
+				.map((r) => r.redirectPage)
+				.filter((rp): rp is NonNullable<typeof rp> => rp !== null);
+		},
+	),
 
 	// Cambiar el status de una notificación
 	changeNotificationStatus: protectedProcedure

--- a/apps/crm/apps/server/src/routers/notifications.ts
+++ b/apps/crm/apps/server/src/routers/notifications.ts
@@ -82,26 +82,41 @@ export const notificationsRouter = {
 			const isAdmin = userData.role === "admin";
 			const isSalesSupervisor = userData.role === "sales_supervisor";
 
-			// Supervisor de ventas ve sus notificaciones + analyst + juridico
-			const roleFilter = isSalesSupervisor
-				? inArray(notifications.assignedToRole, [
-						"sales_supervisor",
-						"analyst",
-						"juridico",
-					])
-				: eq(notifications.assignedToRole, userData.role);
-
-			const conditions = isAdmin
-				? eq(notifications.status, "pending")
-				: and(
-						eq(notifications.status, "pending"),
-						or(roleFilter, eq(notifications.assignedTo, userId)),
-					);
+			// El contador debe reflejar lo que el usuario VE en "Mis notificaciones"
+			// (lo suyo, que puede atender), no todo el sistema — si no, el asesor no
+			// sabe cuántas notificaciones tiene realmente. Misma visibilidad que las
+			// listas de la página:
+			//  - admin: su rol (admin) o asignación directa. NO todo el sistema (eso
+			//    vive en la sección "Notificaciones del sistema", aparte).
+			//  - sales_supervisor: sus roles visibles o asignación directa.
+			//  - resto: su rol SIN asignar (rol-wide) o asignación directa — no las
+			//    del mismo rol asignadas a OTRO usuario.
+			const visibilidad = isAdmin
+				? or(
+						eq(notifications.assignedToRole, "admin"),
+						eq(notifications.assignedTo, userId),
+					)
+				: isSalesSupervisor
+					? or(
+							inArray(notifications.assignedToRole, [
+								"sales_supervisor",
+								"analyst",
+								"juridico",
+							]),
+							eq(notifications.assignedTo, userId),
+						)
+					: or(
+							and(
+								eq(notifications.assignedToRole, userData.role),
+								isNull(notifications.assignedTo),
+							),
+							eq(notifications.assignedTo, userId),
+						);
 
 			const [result] = await db
 				.select({ count: count() })
 				.from(notifications)
-				.where(conditions);
+				.where(and(eq(notifications.status, "pending"), visibilidad));
 
 			return { count: result?.count ?? 0 };
 		},

--- a/apps/crm/apps/server/src/services/check-cobros-alertas.ts
+++ b/apps/crm/apps/server/src/services/check-cobros-alertas.ts
@@ -20,7 +20,7 @@ import { db } from "../db";
 import { casosCobros, contactosCobros } from "../db/schema/cobros";
 import type { NewNotification } from "../db/schema/notifications";
 import { notifications } from "../db/schema/notifications";
-import { contarDiasHabilesGT } from "../lib/business-days-gt";
+import { contarDiasHabilesGT, siguienteDiaGT } from "../lib/business-days-gt";
 import type { CarteraBucketHistorialRow } from "../types/cartera-back";
 import { carteraBackClient } from "./cartera-back-client";
 import { isCarteraBackEnabled } from "./cartera-back-integration";
@@ -231,12 +231,15 @@ async function notificarSinContacto(
 		}
 	}
 
-	// Candidatos: último evento = SUBIDA a bucket ≥ 1 con reloj vencido.
+	// Candidatos: último evento = SUBIDA a bucket ≥ 1 con reloj vencido. El
+	// conteo arranca el DÍA SIGUIENTE a la subida (sellada 23:59 GT → ese día no
+	// cuenta), si no se acusaría al asesor un día hábil antes (Codex P2).
 	const candidatos = [...ultimoPorCredito.values()].filter(
 		(e) =>
 			e.tipo_evento === "SUBIDA" &&
 			e.bucket_nuevo >= 1 &&
-			contarDiasHabilesGT(new Date(e.fecha), ahora) >= DIAS_HABILES_LIMITE,
+			contarDiasHabilesGT(siguienteDiaGT(new Date(e.fecha)), ahora) >=
+				DIAS_HABILES_LIMITE,
 	);
 	if (candidatos.length === 0) return 0;
 

--- a/apps/crm/apps/server/src/services/check-cobros-alertas.ts
+++ b/apps/crm/apps/server/src/services/check-cobros-alertas.ts
@@ -273,12 +273,15 @@ async function notificarSinContacto(
 				: null;
 		const bucketNombre =
 			x.evento.bucket_nuevo_nombre ?? `bucket ${x.evento.bucket_nuevo}`;
+		const credito = `${x.evento.numero_credito_sifco} (${x.evento.cliente})`;
+		const asesor = x.evento.asesor || "Sin asesor asignado";
 		filas.push(
 			...filasNotificacionCobros({
 				casoId: x.casoId,
 				cobrosTipo: "sin_contacto_3d",
 				titulo: "Cliente vencido: 3 días hábiles sin contacto",
-				descripcion: `El crédito ${x.evento.numero_credito_sifco} (${x.evento.cliente}) lleva 3+ días hábiles en ${bucketNombre} sin registro de contacto. Es una falta pendiente por atender.`,
+				descripcion: `El crédito ${credito} lleva 3+ días hábiles en ${bucketNombre} sin registro de contacto. Es una falta pendiente por atender.`,
+				descripcionSupervisor: `El asesor ${asesor} lleva 3+ días hábiles sin contactar el crédito ${credito} en ${bucketNombre}. Falta sin atender.`,
 				asesorUserId,
 				supervisores,
 				usuarioSistema,

--- a/apps/crm/apps/server/src/services/check-cobros-alertas.ts
+++ b/apps/crm/apps/server/src/services/check-cobros-alertas.ts
@@ -149,18 +149,24 @@ async function notificarClientesSubidos(
 	mapaAsesor: Map<number, string>,
 	usuarioSistema: string,
 ): Promise<number> {
+	// El motor de buckets corre a las 23:59 GT (procesarMoras, cartera-back), así
+	// que las SUBIDA "de anoche" llevan la fecha GT de AYER. A las 08:00 GT hay
+	// que mirar ayer + hoy (ventana), no solo hoy, o el aviso cliente_subido
+	// nunca dispararía (Codex P2). El dedup de ~20h evita repetir.
 	const hoyKey = gtDateKey(ahora);
-	const subidasHoy = eventos.filter(
+	const ayerKey = gtDateKey(new Date(ahora.getTime() - 86_400_000));
+	const ventana = new Set([ayerKey, hoyKey]);
+	const subidasRecientes = eventos.filter(
 		(e) =>
 			e.tipo_evento === "SUBIDA" &&
 			e.bucket_nuevo >= 1 &&
-			gtDateKey(new Date(e.fecha)) === hoyKey,
+			ventana.has(gtDateKey(new Date(e.fecha))),
 	);
-	if (subidasHoy.length === 0) return 0;
+	if (subidasRecientes.length === 0) return 0;
 
-	// Una por crédito (por si hubiese doble evento el mismo día).
+	// Una por crédito (por si hubiese doble evento en la ventana).
 	const porCredito = new Map<number, CarteraBucketHistorialRow>();
-	for (const e of subidasHoy) {
+	for (const e of subidasRecientes) {
 		if (!porCredito.has(e.credito_id)) porCredito.set(e.credito_id, e);
 	}
 	const subs = [...porCredito.values()];

--- a/apps/crm/apps/server/src/services/check-cobros-alertas.ts
+++ b/apps/crm/apps/server/src/services/check-cobros-alertas.ts
@@ -1,0 +1,353 @@
+/**
+ * COBROS-02 — Alertas de cobros con propósito (job de las 8:00 GT).
+ *
+ * Reemplaza las notificaciones masivas "Caso sin contacto reciente" por dos
+ * alertas ancladas a la SUBIDA de bucket (que corre a medianoche en cartera):
+ *
+ *   2. cliente_subido  → un crédito subió de bucket anoche. Avisa SOLO AL ASESOR
+ *                        para que priorice bajarlo.
+ *   3. sin_contacto_3d → pasaron 3 días hábiles (regla de oro) desde la subida
+ *                        sin ningún registro de contacto. Escala AL ASESOR +
+ *                        SUPERVISORES (es una falta del asesor).
+ *
+ * El asesor destinatario es el de cartera (`asesor_id` del evento) enlazado a un
+ * usuario del CRM por correo (ver cobros-notif-helpers). Nunca lanza al caller:
+ * devuelve un resumen y loguea (patrón premora / checkPromesasPago).
+ */
+
+import { and, eq, inArray, max } from "drizzle-orm";
+import { db } from "../db";
+import { casosCobros, contactosCobros } from "../db/schema/cobros";
+import type { NewNotification } from "../db/schema/notifications";
+import { notifications } from "../db/schema/notifications";
+import { contarDiasHabilesGT } from "../lib/business-days-gt";
+import type { CarteraBucketHistorialRow } from "../types/cartera-back";
+import { carteraBackClient } from "./cartera-back-client";
+import { isCarteraBackEnabled } from "./cartera-back-integration";
+import {
+	type CobrosNotifTipo,
+	construirMapaAsesorUsuario,
+	filasNotificacionCobros,
+	obtenerSupervisoresCobros,
+	resolverUsuarioSistemaCobros,
+} from "./cobros-notif-helpers";
+
+const LOG_PREFIX = "[CobrosAlertas]";
+
+// Ventana (días calendario) para reconstruir el último evento de bucket por
+// crédito. Un crédito estancado sin contacto más allá de esto no se re-alerta
+// (ya se habría alertado al cruzar el día 3): es una guarda de volumen.
+const VENTANA_DIAS = 60;
+
+// Umbral de la regla: 3 días hábiles en el bucket sin contacto = falta.
+const DIAS_HABILES_LIMITE = 3;
+
+const GT_TZ = "America/Guatemala";
+/** Día calendario GT como "YYYY-MM-DD". */
+function gtDateKey(d: Date): string {
+	return new Intl.DateTimeFormat("en-CA", {
+		timeZone: GT_TZ,
+		year: "numeric",
+		month: "2-digit",
+		day: "2-digit",
+	}).format(d);
+}
+
+export interface CobrosAlertasResumen {
+	subidas: number; // notificaciones cliente_subido (una por caso)
+	sinContacto: number; // casos escalados por sin_contacto_3d
+	skipped?: boolean;
+	reason?: string;
+}
+
+export async function checkCobrosAlertas(): Promise<CobrosAlertasResumen> {
+	try {
+		if (!isCarteraBackEnabled()) {
+			console.log(`${LOG_PREFIX} Cartera-back deshabilitado; job omitido`);
+			return {
+				subidas: 0,
+				sinContacto: 0,
+				skipped: true,
+				reason: "cartera_back_disabled",
+			};
+		}
+
+		const usuarioSistema = await resolverUsuarioSistemaCobros();
+		if (!usuarioSistema) {
+			console.error(
+				`${LOG_PREFIX} Sin usuario sistema (PREMORA_SYSTEM_USER_ID o admin); job omitido`,
+			);
+			return {
+				subidas: 0,
+				sinContacto: 0,
+				skipped: true,
+				reason: "sin_usuario_sistema",
+			};
+		}
+
+		const [mapaAsesor, supervisores] = await Promise.all([
+			construirMapaAsesorUsuario(),
+			obtenerSupervisoresCobros(),
+		]);
+
+		// Una sola pasada al historial (paginado): sirve a ambos propósitos.
+		const ahora = new Date();
+		const desde = new Date(ahora.getTime() - VENTANA_DIAS * 86_400_000);
+		const eventos = await traerHistorialCompleto(gtDateKey(desde));
+
+		const subidas = await notificarClientesSubidos(
+			eventos,
+			ahora,
+			mapaAsesor,
+			usuarioSistema,
+		);
+		const sinContacto = await notificarSinContacto(
+			eventos,
+			ahora,
+			mapaAsesor,
+			supervisores,
+			usuarioSistema,
+		);
+
+		console.log(
+			`${LOG_PREFIX} cliente_subido: ${subidas} · sin_contacto_3d: ${sinContacto} caso(s)`,
+		);
+		return { subidas, sinContacto };
+	} catch (err) {
+		console.error(`${LOG_PREFIX} Error general del job:`, err);
+		return { subidas: 0, sinContacto: 0 };
+	}
+}
+
+/** Trae todos los eventos de bucket desde `desde` (YYYY-MM-DD), paginando. */
+async function traerHistorialCompleto(
+	desde: string,
+): Promise<CarteraBucketHistorialRow[]> {
+	const acc: CarteraBucketHistorialRow[] = [];
+	let page = 1;
+	let totalPages = 1;
+	do {
+		const resp = await carteraBackClient.getBucketsHistorial({
+			desde,
+			page,
+			pageSize: 500,
+		});
+		acc.push(...(resp.data ?? []));
+		totalPages = resp.pagination?.totalPages ?? 1;
+		page++;
+	} while (page <= totalPages && page <= 50); // guarda: máx 50 páginas
+	return acc;
+}
+
+/**
+ * Propósito 2: subidas de HOY (la corrida de medianoche) a bucket ≥ 1 → aviso
+ * al asesor. Devuelve cuántas notificaciones creó.
+ */
+async function notificarClientesSubidos(
+	eventos: CarteraBucketHistorialRow[],
+	ahora: Date,
+	mapaAsesor: Map<number, string>,
+	usuarioSistema: string,
+): Promise<number> {
+	const hoyKey = gtDateKey(ahora);
+	const subidasHoy = eventos.filter(
+		(e) =>
+			e.tipo_evento === "SUBIDA" &&
+			e.bucket_nuevo >= 1 &&
+			gtDateKey(new Date(e.fecha)) === hoyKey,
+	);
+	if (subidasHoy.length === 0) return 0;
+
+	// Una por crédito (por si hubiese doble evento el mismo día).
+	const porCredito = new Map<number, CarteraBucketHistorialRow>();
+	for (const e of subidasHoy) {
+		if (!porCredito.has(e.credito_id)) porCredito.set(e.credito_id, e);
+	}
+	const subs = [...porCredito.values()];
+
+	const casoPorSifco = await mapearCasosPorSifco(
+		subs.map((e) => e.numero_credito_sifco),
+	);
+	const casoIds = subs
+		.map((e) => casoPorSifco.get(e.numero_credito_sifco))
+		.filter((v): v is string => Boolean(v));
+
+	// Dedup: casos ya avisados con cliente_subido en las últimas ~20h.
+	const ultimaNotif = await maxNotifPorCaso(casoIds, "cliente_subido");
+	const corte = ahora.getTime() - 20 * 60 * 60 * 1000;
+
+	const filas: NewNotification[] = [];
+	for (const e of subs) {
+		const casoId = casoPorSifco.get(e.numero_credito_sifco);
+		if (!casoId) continue;
+		const notif = ultimaNotif.get(casoId);
+		if (notif && notif.getTime() >= corte) continue;
+		// Solo al asesor: sin asesor enlazado no hay a quién avisar.
+		const asesorUserId =
+			e.asesor_id != null ? (mapaAsesor.get(e.asesor_id) ?? null) : null;
+		if (!asesorUserId) continue;
+		const bucketNombre = e.bucket_nuevo_nombre ?? `bucket ${e.bucket_nuevo}`;
+		filas.push(
+			...filasNotificacionCobros({
+				casoId,
+				cobrosTipo: "cliente_subido",
+				titulo: "Cliente subió de bucket",
+				descripcion: `El crédito ${e.numero_credito_sifco} (${e.cliente}) subió a ${bucketNombre}. Priorizá el contacto para bajarlo.`,
+				asesorUserId,
+				supervisores: [], // solo asesor
+				usuarioSistema,
+			}),
+		);
+	}
+	if (filas.length > 0) await db.insert(notifications).values(filas);
+	return filas.length;
+}
+
+/**
+ * Propósito 3: créditos cuyo ÚLTIMO evento es una SUBIDA a bucket ≥ 1 y ya
+ * pasaron ≥ 3 días hábiles sin registro de contacto → escala a asesor +
+ * supervisores. Usar el último evento (no solo subidas) descarta los que ya
+ * bajaron de bucket. Devuelve cuántos CASOS se escalaron.
+ */
+async function notificarSinContacto(
+	eventos: CarteraBucketHistorialRow[],
+	ahora: Date,
+	mapaAsesor: Map<number, string>,
+	supervisores: string[],
+	usuarioSistema: string,
+): Promise<number> {
+	// Último evento por crédito dentro de la ventana.
+	const ultimoPorCredito = new Map<number, CarteraBucketHistorialRow>();
+	for (const e of eventos) {
+		const prev = ultimoPorCredito.get(e.credito_id);
+		if (!prev || new Date(e.fecha).getTime() > new Date(prev.fecha).getTime()) {
+			ultimoPorCredito.set(e.credito_id, e);
+		}
+	}
+
+	// Candidatos: último evento = SUBIDA a bucket ≥ 1 con reloj vencido.
+	const candidatos = [...ultimoPorCredito.values()].filter(
+		(e) =>
+			e.tipo_evento === "SUBIDA" &&
+			e.bucket_nuevo >= 1 &&
+			contarDiasHabilesGT(new Date(e.fecha), ahora) >= DIAS_HABILES_LIMITE,
+	);
+	if (candidatos.length === 0) return 0;
+
+	const casoPorSifco = await mapearCasosPorSifco(
+		candidatos.map((e) => e.numero_credito_sifco),
+	);
+	const conCaso = candidatos
+		.map((e) => ({
+			evento: e,
+			casoId: casoPorSifco.get(e.numero_credito_sifco),
+			fechaSubida: new Date(e.fecha),
+		}))
+		.filter(
+			(
+				x,
+			): x is {
+				evento: CarteraBucketHistorialRow;
+				casoId: string;
+				fechaSubida: Date;
+			} => Boolean(x.casoId),
+		);
+	if (conCaso.length === 0) return 0;
+
+	const casoIds = conCaso.map((x) => x.casoId);
+	// ¿Contactaron desde la subida? ¿Ya se alertó este episodio?
+	const [ultimoContacto, ultimaNotif] = await Promise.all([
+		maxContactoPorCaso(casoIds),
+		maxNotifPorCaso(casoIds, "sin_contacto_3d"),
+	]);
+
+	const filas: NewNotification[] = [];
+	for (const x of conCaso) {
+		const contacto = ultimoContacto.get(x.casoId);
+		if (contacto && contacto.getTime() >= x.fechaSubida.getTime()) continue; // ya lo contactaron
+		const notif = ultimaNotif.get(x.casoId);
+		if (notif && notif.getTime() >= x.fechaSubida.getTime()) continue; // ya se escaló este episodio
+		const asesorUserId =
+			x.evento.asesor_id != null
+				? (mapaAsesor.get(x.evento.asesor_id) ?? null)
+				: null;
+		const bucketNombre =
+			x.evento.bucket_nuevo_nombre ?? `bucket ${x.evento.bucket_nuevo}`;
+		filas.push(
+			...filasNotificacionCobros({
+				casoId: x.casoId,
+				cobrosTipo: "sin_contacto_3d",
+				titulo: "Cliente vencido: 3 días hábiles sin contacto",
+				descripcion: `El crédito ${x.evento.numero_credito_sifco} (${x.evento.cliente}) lleva 3+ días hábiles en ${bucketNombre} sin registro de contacto. Es una falta pendiente por atender.`,
+				asesorUserId,
+				supervisores,
+				usuarioSistema,
+			}),
+		);
+	}
+	if (filas.length > 0) await db.insert(notifications).values(filas);
+	// #casos (no #filas: cada caso genera asesor + N supervisores).
+	return new Set(filas.map((f) => f.relatedEntityId)).size;
+}
+
+/** Mapa `numero_credito_sifco → caso.id` (solo casos activos). */
+async function mapearCasosPorSifco(
+	sifcos: string[],
+): Promise<Map<string, string>> {
+	const unicos = [...new Set(sifcos.filter(Boolean))];
+	if (unicos.length === 0) return new Map();
+	const rows = await db
+		.select({ id: casosCobros.id, sifco: casosCobros.numeroCreditoSifco })
+		.from(casosCobros)
+		.where(
+			and(
+				eq(casosCobros.activo, true),
+				inArray(casosCobros.numeroCreditoSifco, unicos),
+			),
+		);
+	const map = new Map<string, string>();
+	for (const r of rows) if (r.sifco) map.set(r.sifco, r.id);
+	return map;
+}
+
+/** max(fecha_contacto) por caso. */
+async function maxContactoPorCaso(
+	casoIds: string[],
+): Promise<Map<string, Date>> {
+	if (casoIds.length === 0) return new Map();
+	const rows = await db
+		.select({
+			casoId: contactosCobros.casoCobroId,
+			ultima: max(contactosCobros.fechaContacto),
+		})
+		.from(contactosCobros)
+		.where(inArray(contactosCobros.casoCobroId, casoIds))
+		.groupBy(contactosCobros.casoCobroId);
+	const map = new Map<string, Date>();
+	for (const r of rows) if (r.ultima) map.set(r.casoId, r.ultima);
+	return map;
+}
+
+/** max(created_at) por caso de las notificaciones de un `cobros_tipo`. */
+async function maxNotifPorCaso(
+	casoIds: string[],
+	tipo: CobrosNotifTipo,
+): Promise<Map<string, Date>> {
+	if (casoIds.length === 0) return new Map();
+	const rows = await db
+		.select({
+			casoId: notifications.relatedEntityId,
+			ultima: max(notifications.createdAt),
+		})
+		.from(notifications)
+		.where(
+			and(
+				inArray(notifications.relatedEntityId, casoIds),
+				eq(notifications.cobrosTipo, tipo),
+			),
+		)
+		.groupBy(notifications.relatedEntityId);
+	const map = new Map<string, Date>();
+	for (const r of rows) if (r.casoId && r.ultima) map.set(r.casoId, r.ultima);
+	return map;
+}

--- a/apps/crm/apps/server/src/services/check-promesas-pago.ts
+++ b/apps/crm/apps/server/src/services/check-promesas-pago.ts
@@ -14,7 +14,7 @@
  * Nunca lanza al caller: devuelve un resumen y loguea (patrón premora).
  */
 
-import { and, eq, gt, inArray, isNull, ne, or, sql } from "drizzle-orm";
+import { and, eq, inArray, isNull, max, ne, or } from "drizzle-orm";
 import { db } from "../db";
 import { casosCobros, contactosCobros } from "../db/schema/cobros";
 import { notifications } from "../db/schema/notifications";
@@ -77,9 +77,6 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 				cuotaFin: contactosCobros.cuotaFin,
 				incluyeMora: contactosCobros.incluyeMora,
 				fechaProximoContacto: contactosCobros.fechaProximoContacto,
-				// Estado ANTES de re-evaluar — para disparar la notificación solo en
-				// la transición (pendiente → incumplida), no cada noche.
-				estadoPromesaActual: contactosCobros.estadoPromesa,
 			})
 			.from(contactosCobros)
 			.where(
@@ -127,13 +124,17 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 			promesasPorSifco.set(sifco, grupo);
 		}
 
-		// Promesas que pasan a "incumplida" en ESTA corrida (transición) → alimentan
-		// la notificación del propósito 1 tras confirmar que el UPDATE persistió.
-		const transiciones: Array<{
+		// Promesas incumplidas de ESTA corrida → alimentan la notificación del
+		// propósito 1 tras confirmar que el UPDATE persistió. No se depende de
+		// "atrapar la transición": la de-duplicación se hace contra las
+		// notificaciones ya existentes (ver notificarPromesasIncumplidas), así que
+		// si una creación falló, la próxima corrida la reintenta (Codex P2).
+		const incumplidas: Array<{
 			casoId: string;
 			sifco: string;
 			cliente: string;
 			asesorId: number | null;
+			fechaPrometida: Date;
 		}> = [];
 
 		const hoy = new Date();
@@ -144,8 +145,13 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 
 				const actualizaciones: Array<{ id: string; estado: EstadoPromesa }> =
 					[];
-				// Candidatas a notificar (pendiente→incumplida) de este crédito.
-				const candidatos: Array<{ promesaId: string; casoId: string }> = [];
+				// Candidatas a notificar: toda promesa incumplida de este crédito
+				// (con su fecha prometida, que ancla el dedup por episodio).
+				const candidatos: Array<{
+					promesaId: string;
+					casoId: string;
+					fechaPrometida: Date;
+				}> = [];
 				for (const promesa of grupo) {
 					if (!promesa.fechaProximoContacto) continue; // fecha obligatoria en el modal, defensivo
 					const estado = evaluarPromesa(
@@ -160,13 +166,11 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 						hoy,
 					);
 					actualizaciones.push({ id: promesa.id, estado });
-					if (
-						estado === "incumplida" &&
-						promesa.estadoPromesaActual !== "incumplida"
-					) {
+					if (estado === "incumplida") {
 						candidatos.push({
 							promesaId: promesa.id,
 							casoId: promesa.casoCobroId,
+							fechaPrometida: promesa.fechaProximoContacto,
 						});
 					}
 					if (estado === "cumplida") resumen.cumplidas++;
@@ -206,15 +210,15 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 					}
 				}
 
-				// Solo notificar transiciones cuyo UPDATE sí persistió (si falló, el
-				// estado sigue viejo y la próxima corrida la vuelve a detectar).
+				// Solo considerar incumplidas cuyo UPDATE sí persistió.
 				for (const c of candidatos) {
 					if (idsRechazados.has(c.promesaId)) continue;
-					transiciones.push({
+					incumplidas.push({
 						casoId: c.casoId,
 						sifco,
 						cliente: credito.usuario?.nombre ?? "",
 						asesorId: credito.asesor?.asesor_id ?? null,
+						fechaPrometida: c.fechaPrometida,
 					});
 				}
 			} catch (error) {
@@ -234,7 +238,7 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 		// Propósito 1: avisar al asesor + supervisores de cada promesa que venció
 		// en esta corrida. Nunca tumba el job (patrón del resto de notificaciones).
 		try {
-			await notificarPromesasIncumplidas(transiciones);
+			await notificarPromesasIncumplidas(incumplidas);
 		} catch (err) {
 			console.error(
 				`${LOG_PREFIX} Error creando notificaciones de promesa incumplida:`,
@@ -253,41 +257,46 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 }
 
 /**
- * Propósito 1 (COBROS-02): notifica al asesor + supervisores por cada promesa
- * de pago que venció en la corrida. Una notificación por caso (aunque tenga
- * varias promesas vencidas hoy), deduplicada a 24h por seguridad.
+ * Propósito 1 (COBROS-02): notifica al asesor + supervisores cada promesa de
+ * pago incumplida. Una notificación por caso (la promesa incumplida más reciente
+ * si hay varias).
+ *
+ * IDEMPOTENTE Y RETRYABLE (Codex P2): en vez de depender de "atrapar la
+ * transición" pendiente→incumplida, se dispara para TODA incumplida y se
+ * deduplica contra las notificaciones ya existentes: se crea solo si NO hay una
+ * promesa_incumplida para el caso creada DESPUÉS de la fecha prometida. Así, si
+ * un insert falló (sin usuario sistema, error de DB, etc.), la próxima corrida
+ * lo reintenta; y una promesa posterior (fecha más nueva) vuelve a disparar.
  */
 async function notificarPromesasIncumplidas(
-	transiciones: Array<{
+	incumplidas: Array<{
 		casoId: string;
 		sifco: string;
 		cliente: string;
 		asesorId: number | null;
+		fechaPrometida: Date;
 	}>,
 ): Promise<void> {
-	if (transiciones.length === 0) return;
+	if (incumplidas.length === 0) return;
 
-	// Una por caso (varias promesas del mismo caso → un solo aviso).
-	const porCaso = new Map<string, (typeof transiciones)[number]>();
-	for (const t of transiciones) {
-		if (!porCaso.has(t.casoId)) porCaso.set(t.casoId, t);
+	// Una por caso: la promesa incumplida con la fecha prometida más reciente.
+	const porCaso = new Map<string, (typeof incumplidas)[number]>();
+	for (const it of incumplidas) {
+		const prev = porCaso.get(it.casoId);
+		if (!prev || it.fechaPrometida.getTime() > prev.fechaPrometida.getTime()) {
+			porCaso.set(it.casoId, it);
+		}
 	}
 	const items = [...porCaso.values()];
 	const casoIds = items.map((t) => t.casoId);
 
-	// Dedup defensivo: casos ya notificados con promesa_incumplida en 24h.
-	const yaNotificados = await db
-		.select({ relatedEntityId: notifications.relatedEntityId })
-		.from(notifications)
-		.where(
-			and(
-				inArray(notifications.relatedEntityId, casoIds),
-				eq(notifications.cobrosTipo, "promesa_incumplida"),
-				gt(notifications.createdAt, sql`now() - interval '24 hours'`),
-			),
-		);
-	const yaSet = new Set(yaNotificados.map((n) => n.relatedEntityId));
-	const pendientes = items.filter((t) => !yaSet.has(t.casoId));
+	// Dedup por episodio: última promesa_incumplida creada por caso. Se salta si
+	// ya hay una posterior a la fecha prometida de esta incumplida.
+	const ultimaNotif = await maxNotifPromesaPorCaso(casoIds);
+	const pendientes = items.filter((t) => {
+		const notif = ultimaNotif.get(t.casoId);
+		return !notif || notif.getTime() < t.fechaPrometida.getTime();
+	});
 	if (pendientes.length === 0) return;
 
 	const [mapaAsesor, supervisores, usuarioSistema] = await Promise.all([
@@ -321,4 +330,27 @@ async function notificarPromesasIncumplidas(
 			`${LOG_PREFIX} ${pendientes.length} promesa(s) incumplida(s) → ${filas.length} notificación(es) creada(s)`,
 		);
 	}
+}
+
+/** max(created_at) por caso de las notificaciones promesa_incumplida. */
+async function maxNotifPromesaPorCaso(
+	casoIds: string[],
+): Promise<Map<string, Date>> {
+	if (casoIds.length === 0) return new Map();
+	const rows = await db
+		.select({
+			casoId: notifications.relatedEntityId,
+			ultima: max(notifications.createdAt),
+		})
+		.from(notifications)
+		.where(
+			and(
+				inArray(notifications.relatedEntityId, casoIds),
+				eq(notifications.cobrosTipo, "promesa_incumplida"),
+			),
+		)
+		.groupBy(notifications.relatedEntityId);
+	const map = new Map<string, Date>();
+	for (const r of rows) if (r.casoId && r.ultima) map.set(r.casoId, r.ultima);
+	return map;
 }

--- a/apps/crm/apps/server/src/services/check-promesas-pago.ts
+++ b/apps/crm/apps/server/src/services/check-promesas-pago.ts
@@ -14,9 +14,10 @@
  * Nunca lanza al caller: devuelve un resumen y loguea (patrón premora).
  */
 
-import { and, eq, inArray, isNull, ne, or } from "drizzle-orm";
+import { and, eq, gt, inArray, isNull, ne, or, sql } from "drizzle-orm";
 import { db } from "../db";
 import { casosCobros, contactosCobros } from "../db/schema/cobros";
+import { notifications } from "../db/schema/notifications";
 import {
 	derivarEstadoCredito,
 	type EstadoPromesa,
@@ -24,6 +25,12 @@ import {
 } from "../lib/promesa-pago";
 import { carteraBackClient } from "./cartera-back-client";
 import { isCarteraBackEnabled } from "./cartera-back-integration";
+import {
+	construirMapaAsesorUsuario,
+	filasNotificacionCobros,
+	obtenerSupervisoresCobros,
+	resolverUsuarioSistemaCobros,
+} from "./cobros-notif-helpers";
 
 const LOG_PREFIX = "[PromesasPago]";
 
@@ -70,6 +77,9 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 				cuotaFin: contactosCobros.cuotaFin,
 				incluyeMora: contactosCobros.incluyeMora,
 				fechaProximoContacto: contactosCobros.fechaProximoContacto,
+				// Estado ANTES de re-evaluar — para disparar la notificación solo en
+				// la transición (pendiente → incumplida), no cada noche.
+				estadoPromesaActual: contactosCobros.estadoPromesa,
 			})
 			.from(contactosCobros)
 			.where(
@@ -117,6 +127,15 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 			promesasPorSifco.set(sifco, grupo);
 		}
 
+		// Promesas que pasan a "incumplida" en ESTA corrida (transición) → alimentan
+		// la notificación del propósito 1 tras confirmar que el UPDATE persistió.
+		const transiciones: Array<{
+			casoId: string;
+			sifco: string;
+			cliente: string;
+			asesorId: number | null;
+		}> = [];
+
 		const hoy = new Date();
 		for (const [sifco, grupo] of promesasPorSifco) {
 			try {
@@ -125,6 +144,8 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 
 				const actualizaciones: Array<{ id: string; estado: EstadoPromesa }> =
 					[];
+				// Candidatas a notificar (pendiente→incumplida) de este crédito.
+				const candidatos: Array<{ promesaId: string; casoId: string }> = [];
 				for (const promesa of grupo) {
 					if (!promesa.fechaProximoContacto) continue; // fecha obligatoria en el modal, defensivo
 					const estado = evaluarPromesa(
@@ -139,6 +160,15 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 						hoy,
 					);
 					actualizaciones.push({ id: promesa.id, estado });
+					if (
+						estado === "incumplida" &&
+						promesa.estadoPromesaActual !== "incumplida"
+					) {
+						candidatos.push({
+							promesaId: promesa.id,
+							casoId: promesa.casoCobroId,
+						});
+					}
 					if (estado === "cumplida") resumen.cumplidas++;
 					else if (estado === "incumplida") resumen.incumplidas++;
 					else resumen.pendientes++;
@@ -157,6 +187,7 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 							.where(eq(contactosCobros.id, id)),
 					),
 				);
+				const idsRechazados = new Set<string>();
 				for (let i = 0; i < resultados.length; i++) {
 					const resultado = resultados[i];
 					if (resultado.status === "rejected") {
@@ -167,11 +198,24 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 						else if (estado === "incumplida") resumen.incumplidas--;
 						else resumen.pendientes--;
 						resumen.errores++;
+						idsRechazados.add(actualizaciones[i].id);
 						console.error(
 							`${LOG_PREFIX} Error persistiendo promesa ${actualizaciones[i].id}:`,
 							resultado.reason,
 						);
 					}
+				}
+
+				// Solo notificar transiciones cuyo UPDATE sí persistió (si falló, el
+				// estado sigue viejo y la próxima corrida la vuelve a detectar).
+				for (const c of candidatos) {
+					if (idsRechazados.has(c.promesaId)) continue;
+					transiciones.push({
+						casoId: c.casoId,
+						sifco,
+						cliente: credito.usuario?.nombre ?? "",
+						asesorId: credito.asesor?.asesor_id ?? null,
+					});
 				}
 			} catch (error) {
 				resumen.errores += grupo.length;
@@ -187,6 +231,17 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 		resumen.evaluadas =
 			resumen.cumplidas + resumen.incumplidas + resumen.pendientes;
 
+		// Propósito 1: avisar al asesor + supervisores de cada promesa que venció
+		// en esta corrida. Nunca tumba el job (patrón del resto de notificaciones).
+		try {
+			await notificarPromesasIncumplidas(transiciones);
+		} catch (err) {
+			console.error(
+				`${LOG_PREFIX} Error creando notificaciones de promesa incumplida:`,
+				err,
+			);
+		}
+
 		console.log(
 			`${LOG_PREFIX} ${resumen.evaluadas} evaluada(s) → ${resumen.cumplidas} cumplida(s), ${resumen.incumplidas} incumplida(s), ${resumen.pendientes} pendiente(s), ${resumen.sinCaso} sin caso, ${resumen.errores} error(es)`,
 		);
@@ -194,5 +249,76 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 	} catch (err) {
 		console.error(`${LOG_PREFIX} Error general del job:`, err);
 		return resumenVacio({ errores: 1 });
+	}
+}
+
+/**
+ * Propósito 1 (COBROS-02): notifica al asesor + supervisores por cada promesa
+ * de pago que venció en la corrida. Una notificación por caso (aunque tenga
+ * varias promesas vencidas hoy), deduplicada a 24h por seguridad.
+ */
+async function notificarPromesasIncumplidas(
+	transiciones: Array<{
+		casoId: string;
+		sifco: string;
+		cliente: string;
+		asesorId: number | null;
+	}>,
+): Promise<void> {
+	if (transiciones.length === 0) return;
+
+	// Una por caso (varias promesas del mismo caso → un solo aviso).
+	const porCaso = new Map<string, (typeof transiciones)[number]>();
+	for (const t of transiciones) {
+		if (!porCaso.has(t.casoId)) porCaso.set(t.casoId, t);
+	}
+	const items = [...porCaso.values()];
+	const casoIds = items.map((t) => t.casoId);
+
+	// Dedup defensivo: casos ya notificados con promesa_incumplida en 24h.
+	const yaNotificados = await db
+		.select({ relatedEntityId: notifications.relatedEntityId })
+		.from(notifications)
+		.where(
+			and(
+				inArray(notifications.relatedEntityId, casoIds),
+				eq(notifications.cobrosTipo, "promesa_incumplida"),
+				gt(notifications.createdAt, sql`now() - interval '24 hours'`),
+			),
+		);
+	const yaSet = new Set(yaNotificados.map((n) => n.relatedEntityId));
+	const pendientes = items.filter((t) => !yaSet.has(t.casoId));
+	if (pendientes.length === 0) return;
+
+	const [mapaAsesor, supervisores, usuarioSistema] = await Promise.all([
+		construirMapaAsesorUsuario(),
+		obtenerSupervisoresCobros(),
+		resolverUsuarioSistemaCobros(),
+	]);
+	if (!usuarioSistema) {
+		console.error(
+			`${LOG_PREFIX} Sin usuario sistema (PREMORA_SYSTEM_USER_ID o admin); no se crean notificaciones de promesa incumplida`,
+		);
+		return;
+	}
+
+	const filas = pendientes.flatMap((t) =>
+		filasNotificacionCobros({
+			casoId: t.casoId,
+			cobrosTipo: "promesa_incumplida",
+			titulo: "Promesa de pago incumplida",
+			descripcion: `La promesa de pago del crédito ${t.sifco}${t.cliente ? ` (${t.cliente})` : ""} venció y la(s) cuota(s) prometida(s) siguen pendientes.`,
+			asesorUserId:
+				t.asesorId != null ? (mapaAsesor.get(t.asesorId) ?? null) : null,
+			supervisores,
+			usuarioSistema,
+		}),
+	);
+
+	if (filas.length > 0) {
+		await db.insert(notifications).values(filas);
+		console.log(
+			`${LOG_PREFIX} ${pendientes.length} promesa(s) incumplida(s) → ${filas.length} notificación(es) creada(s)`,
+		);
 	}
 }

--- a/apps/crm/apps/server/src/services/check-promesas-pago.ts
+++ b/apps/crm/apps/server/src/services/check-promesas-pago.ts
@@ -134,6 +134,7 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 			sifco: string;
 			cliente: string;
 			asesorId: number | null;
+			asesorNombre: string;
 			fechaPrometida: Date;
 		}> = [];
 
@@ -218,6 +219,7 @@ export async function checkPromesasPago(): Promise<CheckPromesasResumen> {
 						sifco,
 						cliente: credito.usuario?.nombre ?? "",
 						asesorId: credito.asesor?.asesor_id ?? null,
+						asesorNombre: credito.asesor?.nombre ?? "",
 						fechaPrometida: c.fechaPrometida,
 					});
 				}
@@ -274,6 +276,7 @@ async function notificarPromesasIncumplidas(
 		sifco: string;
 		cliente: string;
 		asesorId: number | null;
+		asesorNombre: string;
 		fechaPrometida: Date;
 	}>,
 ): Promise<void> {
@@ -311,18 +314,21 @@ async function notificarPromesasIncumplidas(
 		return;
 	}
 
-	const filas = pendientes.flatMap((t) =>
-		filasNotificacionCobros({
+	const filas = pendientes.flatMap((t) => {
+		const credito = `${t.sifco}${t.cliente ? ` (${t.cliente})` : ""}`;
+		const asesor = t.asesorNombre || "Sin asesor asignado";
+		return filasNotificacionCobros({
 			casoId: t.casoId,
 			cobrosTipo: "promesa_incumplida",
 			titulo: "Promesa de pago incumplida",
-			descripcion: `La promesa de pago del crédito ${t.sifco}${t.cliente ? ` (${t.cliente})` : ""} venció y la(s) cuota(s) prometida(s) siguen pendientes.`,
+			descripcion: `La promesa de pago del crédito ${credito} venció y la(s) cuota(s) prometida(s) siguen pendientes.`,
+			descripcionSupervisor: `El asesor ${asesor} tiene una promesa de pago incumplida sin gestionar: crédito ${credito} venció y la(s) cuota(s) siguen pendientes.`,
 			asesorUserId:
 				t.asesorId != null ? (mapaAsesor.get(t.asesorId) ?? null) : null,
 			supervisores,
 			usuarioSistema,
-		}),
-	);
+		});
+	});
 
 	if (filas.length > 0) {
 		await db.insert(notifications).values(filas);

--- a/apps/crm/apps/server/src/services/cobros-notif-helpers.ts
+++ b/apps/crm/apps/server/src/services/cobros-notif-helpers.ts
@@ -90,6 +90,12 @@ export function filasNotificacionCobros(params: {
 	cobrosTipo: CobrosNotifTipo;
 	titulo: string;
 	descripcion: string;
+	/**
+	 * Descripción alterna para las filas de SUPERVISOR — típicamente incluye el
+	 * nombre del asesor que no gestionó ("quién no lo tomó"). Si se omite, los
+	 * supervisores reciben la misma `descripcion` que el asesor.
+	 */
+	descripcionSupervisor?: string;
 	/** user.id del asesor (null si no se pudo enlazar por correo). */
 	asesorUserId: string | null;
 	/** Supervisores a los que escalar; [] cuando la alerta es solo del asesor. */
@@ -99,7 +105,6 @@ export function filasNotificacionCobros(params: {
 }): NewNotification[] {
 	const base = {
 		titulo: params.titulo,
-		descripcion: params.descripcion,
 		type: "reminder" as const,
 		status: "pending" as const,
 		cobrosTipo: params.cobrosTipo,
@@ -112,15 +117,18 @@ export function filasNotificacionCobros(params: {
 	if (params.asesorUserId) {
 		filas.push({
 			...base,
+			descripcion: params.descripcion,
 			createdBy: params.asesorUserId,
 			createdByRole: "cobros",
 			assignedToRole: "cobros",
 			assignedTo: params.asesorUserId,
 		});
 	}
+	const descSupervisor = params.descripcionSupervisor ?? params.descripcion;
 	for (const supervisorId of params.supervisores) {
 		filas.push({
 			...base,
+			descripcion: descSupervisor,
 			createdBy: params.usuarioSistema,
 			createdByRole: "cobros_supervisor",
 			assignedToRole: "cobros_supervisor",

--- a/apps/crm/apps/server/src/services/cobros-notif-helpers.ts
+++ b/apps/crm/apps/server/src/services/cobros-notif-helpers.ts
@@ -1,0 +1,131 @@
+/**
+ * COBROS-02 — Helpers compartidos por los jobs de alertas de cobros
+ * (promesa incumplida, cliente subido, sin contacto 3 días hábiles).
+ *
+ * Resuelven los destinatarios de las notificaciones:
+ *  - El ASESOR del crédito es el de cartera (`asesor_id`), enlazado a un usuario
+ *    del CRM por correo (`asesores.email_cash_in` == `user.email`) — mismo
+ *    puente que usa la Agenda. `construirMapaAsesorUsuario` arma ese mapa una
+ *    sola vez por corrida (getAdvisors va cacheado 5m en cartera-back).
+ *  - El SUPERVISOR son TODOS los `user.role = 'cobros_supervisor'` (no existe
+ *    mapeo asesor→supervisor; hoy son uno o dos).
+ */
+
+import { eq } from "drizzle-orm";
+import { db } from "../db";
+import { user } from "../db/schema/auth";
+import type { NewNotification } from "../db/schema/notifications";
+import { carteraBackClient } from "./cartera-back-client";
+
+export type CobrosNotifTipo =
+	| "promesa_incumplida"
+	| "cliente_subido"
+	| "sin_contacto_3d";
+
+/**
+ * Mapa `asesor_id (cartera) → user.id (CRM)`, cruzando el correo de cash-in del
+ * asesor contra el correo de login del usuario del CRM. Asesores sin usuario
+ * vinculado por correo simplemente no entran al mapa (su notificación se omite).
+ */
+export async function construirMapaAsesorUsuario(): Promise<
+	Map<number, string>
+> {
+	const advisors = await carteraBackClient.getAdvisors({
+		page: 1,
+		perPage: 500,
+	});
+	const asesores = (advisors.data ?? []).filter((a) => Boolean(a.email));
+	if (asesores.length === 0) return new Map();
+
+	// La tabla `user` es de staff (decenas): traerla entera y matchear en JS
+	// evita problemas de case/collation de un IN con lower() en SQL.
+	const usuarios = await db
+		.select({ id: user.id, email: user.email })
+		.from(user);
+	const emailToUser = new Map(
+		usuarios.map((u) => [u.email.trim().toLowerCase(), u.id]),
+	);
+
+	const mapa = new Map<number, string>();
+	for (const a of asesores) {
+		const uid = emailToUser.get(a.email.trim().toLowerCase());
+		if (uid) mapa.set(a.asesor_id, uid);
+	}
+	return mapa;
+}
+
+/** user.id de TODOS los supervisores de cobros (destinatarios del escalamiento). */
+export async function obtenerSupervisoresCobros(): Promise<string[]> {
+	const rows = await db
+		.select({ id: user.id })
+		.from(user)
+		.where(eq(user.role, "cobros_supervisor"));
+	return rows.map((r) => r.id);
+}
+
+/**
+ * Usuario "sistema" para el FK `created_by` de notificaciones automáticas:
+ * PREMORA_SYSTEM_USER_ID si está seteado, si no el primer admin. Mismo criterio
+ * que premora (resolverUsuarioSistema) — no hay humano detrás del job.
+ */
+export async function resolverUsuarioSistemaCobros(): Promise<string | null> {
+	const fromEnv = process.env.PREMORA_SYSTEM_USER_ID?.trim();
+	if (fromEnv) return fromEnv;
+	const [admin] = await db
+		.select({ id: user.id })
+		.from(user)
+		.where(eq(user.role, "admin"))
+		.limit(1);
+	return admin?.id ?? null;
+}
+
+/**
+ * Construye las filas de notificación (asesor + supervisores) para una alerta
+ * de cobros. NO inserta ni deduplica — cada job hace su propio dedup antes de
+ * insertar (la ventana difiere: 24h para las diarias, "desde la subida" para
+ * sin_contacto_3d). Devuelve [] si no hay a quién notificar.
+ */
+export function filasNotificacionCobros(params: {
+	casoId: string;
+	cobrosTipo: CobrosNotifTipo;
+	titulo: string;
+	descripcion: string;
+	/** user.id del asesor (null si no se pudo enlazar por correo). */
+	asesorUserId: string | null;
+	/** Supervisores a los que escalar; [] cuando la alerta es solo del asesor. */
+	supervisores: string[];
+	/** FK created_by para las filas de supervisor (no dependen del asesor). */
+	usuarioSistema: string;
+}): NewNotification[] {
+	const base = {
+		titulo: params.titulo,
+		descripcion: params.descripcion,
+		type: "reminder" as const,
+		status: "pending" as const,
+		cobrosTipo: params.cobrosTipo,
+		relatedEntityType: "collection_case" as const,
+		relatedEntityId: params.casoId,
+		redirectPage: "cobros_detail" as const,
+	};
+
+	const filas: NewNotification[] = [];
+	if (params.asesorUserId) {
+		filas.push({
+			...base,
+			createdBy: params.asesorUserId,
+			createdByRole: "cobros",
+			assignedToRole: "cobros",
+			assignedTo: params.asesorUserId,
+		});
+	}
+	for (const supervisorId of params.supervisores) {
+		filas.push({
+			...base,
+			createdBy: params.usuarioSistema,
+			createdByRole: "cobros_supervisor",
+			assignedToRole: "cobros_supervisor",
+			assignedTo: supervisorId,
+		});
+	}
+	return filas;
+}

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -12,7 +12,9 @@ import {
 	FileUp,
 	Info,
 	Loader2,
+	PhoneOff,
 	Send,
+	TrendingUp,
 	Upload,
 	X,
 	XCircle,
@@ -37,10 +39,10 @@ import {
 	SelectTrigger,
 	SelectValue,
 } from "@/components/ui/select";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import { getRoleLabel, ROLES } from "@/lib/roles";
 import { uploadFileToR2WithRetry } from "@/lib/upload-to-r2";
-import { usePersistedState } from "@/hooks/usePersistedState";
 import { client, orpc, queryClient } from "@/utils/orpc";
 
 export const Route = createFileRoute("/notifications")({
@@ -170,6 +172,77 @@ const REDIRECT_CONFIG: Record<
 	},
 };
 
+// Labels legibles para el filtro por tipo (redirect_page). Son sustantivos
+// (categoría), a diferencia de REDIRECT_CONFIG que usa verbos de navegación.
+const REDIRECT_PAGE_FILTER_LABEL: Record<string, string> = {
+	opportunity_details: "Oportunidades",
+	client_details: "Clientes",
+	client_details_disbursement: "Desembolsos",
+	vehicle_details: "Vehículos",
+	contract_details: "Contratos",
+	analysis_details: "Análisis",
+	analysis_50_details: "Análisis 50%",
+	analysis_90_details: "Análisis 90%",
+	pay_investors: "Pago inversionistas",
+	cobros_detail: "Casos de cobro",
+};
+
+// COBROS-02: cada subtipo de cobros (columna cobros_tipo) pinta la tarjeta de
+// un color propio — no todo amarillo. Incluye ícono, fondo/borde y badge.
+const COBROS_TIPO_CONFIG: Record<
+	string,
+	{
+		label: string;
+		card: string;
+		icon: typeof Bell;
+		iconWrap: string;
+		iconColor: string;
+		badge: string;
+	}
+> = {
+	promesa_incumplida: {
+		label: "Promesa incumplida",
+		card: "border-red-200 bg-red-50/50 dark:border-red-900/50 dark:bg-red-950/20",
+		icon: XCircle,
+		iconWrap: "bg-red-100 dark:bg-red-900/40",
+		iconColor: "text-red-600 dark:text-red-400",
+		badge: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
+	},
+	cliente_subido: {
+		label: "Subió de bucket",
+		card: "border-amber-200 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-950/20",
+		icon: TrendingUp,
+		iconWrap: "bg-amber-100 dark:bg-amber-900/40",
+		iconColor: "text-amber-600 dark:text-amber-400",
+		badge:
+			"bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
+	},
+	sin_contacto_3d: {
+		label: "3 días sin contacto",
+		card: "border-purple-200 bg-purple-50/50 dark:border-purple-900/50 dark:bg-purple-950/20",
+		icon: PhoneOff,
+		iconWrap: "bg-purple-100 dark:bg-purple-900/40",
+		iconColor: "text-purple-600 dark:text-purple-400",
+		badge:
+			"bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+	},
+};
+
+// Acento lateral por redirectPage: da variedad de color al resto de la lista
+// (las de cobros ya van coloreadas por cobros_tipo, así que no llevan acento).
+const REDIRECT_ACCENT: Record<string, string> = {
+	opportunity_details: "border-l-blue-400",
+	client_details: "border-l-emerald-400",
+	client_details_disbursement: "border-l-teal-400",
+	vehicle_details: "border-l-orange-400",
+	contract_details: "border-l-indigo-400",
+	analysis_details: "border-l-cyan-400",
+	analysis_50_details: "border-l-cyan-400",
+	analysis_90_details: "border-l-sky-400",
+	pay_investors: "border-l-green-500",
+	cobros_detail: "border-l-rose-400",
+};
+
 const PAGE_SIZE = 20;
 const SUPERVISOR_ROLES = ["sales_supervisor", "analyst", "juridico"] as const;
 
@@ -247,11 +320,33 @@ function NotificationsPage() {
 	const isAdmin = userRole === ROLES.ADMIN;
 	const isSalesSupervisor = userRole === ROLES.SALES_SUPERVISOR;
 
-	const [statusFilter, setStatusFilter] = usePersistedState<string>("notifications/statusFilter", "all");
+	const [statusFilter, setStatusFilter] = usePersistedState<string>(
+		"notifications/statusFilter",
+		"all",
+	);
+	const [typeFilter, setTypeFilter] = usePersistedState<string>(
+		"notifications/typeFilter",
+		"all",
+	);
 
-	const hasActiveFilters = statusFilter !== "all";
+	// Tipos (redirect_page) que este usuario/rol realmente tiene — alimenta el
+	// dropdown para que solo aparezcan las opciones a las que tiene acceso.
+	const availableTypesQuery = useQuery({
+		...orpc.getAvailableNotificationTypes.queryOptions(),
+		enabled: !!session,
+	});
+	const availableTypes = useMemo(
+		() =>
+			(availableTypesQuery.data ?? [])
+				.map((t) => ({ value: t, label: REDIRECT_PAGE_FILTER_LABEL[t] ?? t }))
+				.sort((a, b) => a.label.localeCompare(b.label)),
+		[availableTypesQuery.data],
+	);
+
+	const hasActiveFilters = statusFilter !== "all" || typeFilter !== "all";
 	const resetFilters = () => {
 		setStatusFilter("all");
+		setTypeFilter("all");
 	};
 
 	// Admin: todas las notificaciones
@@ -382,23 +477,28 @@ function NotificationsPage() {
 		return { myNotifications: my, systemNotifications: system };
 	}, [isAdmin, notifications, userId]);
 
-	// Aplicar filtro de status
-	const filterByStatus = useCallback(
+	// Aplicar filtros de status + tipo (redirect_page)
+	const applyFilters = useCallback(
 		(items: typeof notifications) => {
-			if (statusFilter === "all")
-				return items.filter((n) => n.status !== "dismissed");
-			return items.filter((n) => n.status === statusFilter);
+			let result =
+				statusFilter === "all"
+					? items.filter((n) => n.status !== "dismissed")
+					: items.filter((n) => n.status === statusFilter);
+			if (typeFilter !== "all") {
+				result = result.filter((n) => n.redirectPage === typeFilter);
+			}
+			return result;
 		},
-		[statusFilter],
+		[statusFilter, typeFilter],
 	);
 
 	const filteredMy = useMemo(
-		() => filterByStatus(myNotifications),
-		[filterByStatus, myNotifications],
+		() => applyFilters(myNotifications),
+		[applyFilters, myNotifications],
 	);
 	const filteredSystem = useMemo(
-		() => filterByStatus(systemNotifications),
-		[filterByStatus, systemNotifications],
+		() => applyFilters(systemNotifications),
+		[applyFilters, systemNotifications],
 	);
 
 	// Paginación
@@ -417,6 +517,12 @@ function NotificationsPage() {
 	// Reset página al cambiar filtro
 	const handleStatusFilter = (value: string) => {
 		setStatusFilter(value);
+		myPagination.setPage(1);
+		systemPagination.setPage(1);
+	};
+
+	const handleTypeFilter = (value: string) => {
+		setTypeFilter(value);
 		myPagination.setPage(1);
 		systemPagination.setPage(1);
 	};
@@ -569,12 +675,35 @@ function NotificationsPage() {
 						<SelectItem value="dismissed">Descartadas</SelectItem>
 					</SelectContent>
 				</Select>
+				{availableTypes.length > 0 && (
+					<Select value={typeFilter} onValueChange={handleTypeFilter}>
+						<SelectTrigger className="w-[200px]">
+							<SelectValue placeholder="Filtrar por tipo" />
+						</SelectTrigger>
+						<SelectContent>
+							<SelectItem value="all">Todos los tipos</SelectItem>
+							{availableTypes.map((opt) => (
+								<SelectItem key={opt.value} value={opt.value}>
+									{opt.label}
+								</SelectItem>
+							))}
+						</SelectContent>
+					</Select>
+				)}
 				{hasActiveFilters && (
-					<Button variant="ghost" size="sm" onClick={resetFilters} className="shrink-0 text-muted-foreground">
+					<Button
+						variant="ghost"
+						size="sm"
+						onClick={resetFilters}
+						className="shrink-0 text-muted-foreground"
+					>
 						<X className="mr-1 h-3 w-3" />
 						Limpiar filtros
 						<Badge variant="secondary" className="ml-1 h-4 px-1 text-xs">
-							{[statusFilter !== "all"].filter(Boolean).length}
+							{
+								[statusFilter !== "all", typeFilter !== "all"].filter(Boolean)
+									.length
+							}
 						</Badge>
 					</Button>
 				)}
@@ -643,6 +772,7 @@ function NotificationCard({
 		relatedEntityType: string | null;
 		relatedEntityId: string | null;
 		redirectPage?: string | null;
+		cobrosTipo?: string | null;
 		createdAt: Date;
 	};
 	onChangeStatus: (status: NotificationStatus) => void;
@@ -677,7 +807,16 @@ function NotificationCard({
 		STATUS_CONFIG[notification.status as NotificationStatus] ??
 		STATUS_CONFIG.pending;
 	const typeInfo = TYPE_CONFIG[notification.type] ?? TYPE_CONFIG.aviso;
-	const TypeIcon = typeInfo.icon;
+	const cobrosConfig = notification.cobrosTipo
+		? COBROS_TIPO_CONFIG[notification.cobrosTipo]
+		: undefined;
+	const CardIcon = cobrosConfig?.icon ?? typeInfo.icon;
+	// Acento lateral por dominio (redirectPage) para las NO-cobros; las de cobros
+	// ya van coloreadas por su cobros_tipo.
+	const accent =
+		!cobrosConfig && notification.redirectPage
+			? (REDIRECT_ACCENT[notification.redirectPage] ?? "")
+			: "";
 	const isPending = notification.status === "pending";
 	const isRead = notification.status === "read";
 	const isInProgress = notification.status === "in_progress";
@@ -700,24 +839,32 @@ function NotificationCard({
 		<>
 			<div
 				className={`rounded-lg border p-4 transition-colors ${
-					isPending
-						? "border-yellow-200 bg-yellow-50/40 dark:border-yellow-900/50 dark:bg-yellow-950/20"
-						: "border-border bg-card"
-				}`}
+					cobrosConfig
+						? cobrosConfig.card
+						: isPending
+							? "border-yellow-200 bg-yellow-50/40 dark:border-yellow-900/50 dark:bg-yellow-950/20"
+							: "border-border bg-card"
+				} ${accent ? `border-l-4 ${accent}` : ""}`}
 			>
 				{/* Fila superior: icono + titulo + badges */}
 				<div className="flex items-start justify-between gap-3">
 					<div className="flex min-w-0 items-start gap-3">
 						<div
 							className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full ${
-								isPending ? "bg-yellow-100 dark:bg-yellow-900/40" : "bg-muted"
+								cobrosConfig
+									? cobrosConfig.iconWrap
+									: isPending
+										? "bg-yellow-100 dark:bg-yellow-900/40"
+										: "bg-muted"
 							}`}
 						>
-							<TypeIcon
+							<CardIcon
 								className={`h-4 w-4 ${
-									isPending
-										? "text-yellow-600 dark:text-yellow-400"
-										: "text-muted-foreground"
+									cobrosConfig
+										? cobrosConfig.iconColor
+										: isPending
+											? "text-yellow-600 dark:text-yellow-400"
+											: "text-muted-foreground"
 								}`}
 							/>
 						</div>
@@ -753,15 +900,25 @@ function NotificationCard({
 								{entityLink.label}
 							</Button>
 						)}
+						{cobrosConfig && (
+							<Badge
+								variant="outline"
+								className={`text-[11px] ${cobrosConfig.badge}`}
+							>
+								{cobrosConfig.label}
+							</Badge>
+						)}
 						<Badge
 							variant="outline"
 							className={`text-[11px] ${statusInfo.color}`}
 						>
 							{statusInfo.label}
 						</Badge>
-						<Badge variant="secondary" className="text-[11px]">
-							{typeInfo.label}
-						</Badge>
+						{!cobrosConfig && (
+							<Badge variant="secondary" className="text-[11px]">
+								{typeInfo.label}
+							</Badge>
+						)}
 					</div>
 				</div>
 

--- a/apps/crm/apps/web/src/routes/notifications.tsx
+++ b/apps/crm/apps/web/src/routes/notifications.tsx
@@ -193,7 +193,8 @@ const COBROS_TIPO_CONFIG: Record<
 	string,
 	{
 		label: string;
-		card: string;
+		border: string;
+		bg: string;
 		icon: typeof Bell;
 		iconWrap: string;
 		iconColor: string;
@@ -202,7 +203,8 @@ const COBROS_TIPO_CONFIG: Record<
 > = {
 	promesa_incumplida: {
 		label: "Promesa incumplida",
-		card: "border-red-200 bg-red-50/50 dark:border-red-900/50 dark:bg-red-950/20",
+		border: "border-red-200 dark:border-red-900/50",
+		bg: "bg-red-50/50 dark:bg-red-950/20",
 		icon: XCircle,
 		iconWrap: "bg-red-100 dark:bg-red-900/40",
 		iconColor: "text-red-600 dark:text-red-400",
@@ -210,7 +212,8 @@ const COBROS_TIPO_CONFIG: Record<
 	},
 	cliente_subido: {
 		label: "Subió de bucket",
-		card: "border-amber-200 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-950/20",
+		border: "border-amber-200 dark:border-amber-900/50",
+		bg: "bg-amber-50/50 dark:bg-amber-950/20",
 		icon: TrendingUp,
 		iconWrap: "bg-amber-100 dark:bg-amber-900/40",
 		iconColor: "text-amber-600 dark:text-amber-400",
@@ -219,7 +222,8 @@ const COBROS_TIPO_CONFIG: Record<
 	},
 	sin_contacto_3d: {
 		label: "3 días sin contacto",
-		card: "border-purple-200 bg-purple-50/50 dark:border-purple-900/50 dark:bg-purple-950/20",
+		border: "border-purple-200 dark:border-purple-900/50",
+		bg: "bg-purple-50/50 dark:bg-purple-950/20",
 		icon: PhoneOff,
 		iconWrap: "bg-purple-100 dark:bg-purple-900/40",
 		iconColor: "text-purple-600 dark:text-purple-400",
@@ -840,7 +844,7 @@ function NotificationCard({
 			<div
 				className={`rounded-lg border p-4 transition-colors ${
 					cobrosConfig
-						? cobrosConfig.card
+						? `${cobrosConfig.border} ${isPending ? cobrosConfig.bg : ""}`
 						: isPending
 							? "border-yellow-200 bg-yellow-50/40 dark:border-yellow-900/50 dark:bg-yellow-950/20"
 							: "border-border bg-card"


### PR DESCRIPTION
## Qué hace

Reemplaza las notificaciones masivas **"Caso sin contacto reciente"** (`checkCasosSinContacto`, eliminado) por **3 alertas con propósito**, clasificadas en un enum específico de cobros (`cobros_tipo`) y coloreadas distinto en la web.

### Los 3 propósitos

| Tipo | Cuándo / dónde | Notifica a |
|---|---|---|
| `promesa_incumplida` | `checkPromesasPago` (medianoche), en la **transición** de una promesa a incumplida (no cada noche) | asesor **+ supervisores** |
| `cliente_subido` | job nuevo **8am GT** (`check-cobros-alertas.ts`): lee las `SUBIDA` de bucket de la medianoche (bucket≥1) | **solo asesor** |
| `sin_contacto_3d` | mismo job 8am: último evento = SUBIDA y **≥3 días hábiles** sin registro de contacto | asesor **+ supervisores** |

- **Asesor destinatario** = el de cartera (`asesor_id`) enlazado a un usuario del CRM por correo (`asesores.email_cash_in` == `user.email`, mismo puente que la Agenda).
- **Supervisor** = todos los `user.role = 'cobros_supervisor'`.
- **`created_by`** de las de supervisor = `PREMORA_SYSTEM_USER_ID` (o primer admin).

### Días hábiles con regla de oro
`lib/business-days-gt.ts` (portado de cartera-back) — Lun-Vie **+ regla de oro**: quincena (15) o fin de mes en fin de semana **cuentan como hábil**. Incluye tests (8/8). ⚠️ Falta validar el detalle fino (y feriados) con **Juanda**.

### Filtro por tipo en la página de notificaciones
Nuevo `<Select>` "Filtrar por tipo" (`redirect_page`) alimentado por `getAvailableNotificationTypes` — **data-driven**: solo aparecen los tipos que ese usuario/rol realmente tiene (cualquier estado), respetando la visibilidad de las listas.

### Coloring
`NotificationCard` pinta cada `cobros_tipo` de un color (rojo / ámbar / púrpura) + badge; acento lateral por `redirectPage` para el resto (ya no todo amarillo).

## ⚠️ Antes de mergear / probar
1. **Correr la migración `0027_cobros_notif_tipo.sql`** (enum + columna) — a mano, como el resto. Sin ella el insert de `cobros_tipo` falla.
2. `PREMORA_SYSTEM_USER_ID` (ya existe del funnel de premora) o habrá un admin.

## Verificación
- Server `tsc`: limpio en todo lo tocado.
- Web `tsc`: los errores de `notifications.tsx` son el baseline ORPC `{}` pre-existente (0 de este cambio).
- Biome aplicado. Test de días hábiles verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)