### PR TITLE
feat(cobros): CRM server — Cola del Día priorizada (CB-020)

### DIFF
--- a/apps/crm/apps/server/src/lib/cola-dia.test.ts
+++ b/apps/crm/apps/server/src/lib/cola-dia.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type CreditoParaClasificar,
+	calificaParaColaDia,
+	calificaParaFiltro,
+	clasificarCreditoColaDia,
+	ordenColaDia,
+} from "./cola-dia";
+
+// Hoy fijo para todos los tests: 2026-07-23 (mediodía GT = 18:00 UTC, sin
+// riesgo de cruzar medianoche por TZ).
+const HOY = new Date("2026-07-23T18:00:00.000Z");
+const AYER = new Date("2026-07-22T18:00:00.000Z");
+const MANANA = new Date("2026-07-24T18:00:00.000Z");
+
+function creditoBase(
+	overrides: Partial<CreditoParaClasificar> = {},
+): CreditoParaClasificar {
+	return {
+		fechaLimiteSla: null,
+		contactadoHoy: false,
+		promesas: [],
+		diasSinContacto: null,
+		...overrides,
+	};
+}
+
+describe("clasificarCreditoColaDia — SLA", () => {
+	test("fecha límite SLA = hoy y sin contacto hoy → slaHoy", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ fechaLimiteSla: "2026-07-23" }),
+			HOY,
+		);
+		expect(c.slaHoy).toBe(true);
+	});
+
+	test("fecha límite SLA = hoy PERO ya se contactó hoy → NO slaHoy", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ fechaLimiteSla: "2026-07-23", contactadoHoy: true }),
+			HOY,
+		);
+		expect(c.slaHoy).toBe(false);
+	});
+
+	test("fecha límite SLA en el pasado → NO slaHoy (esa urgencia la cubre incumplida/otro mecanismo, no esta bandera)", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ fechaLimiteSla: "2026-07-22" }),
+			HOY,
+		);
+		expect(c.slaHoy).toBe(false);
+	});
+
+	test("fechaLimiteSla null (B0 o sin historial) → NO slaHoy", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ fechaLimiteSla: null }),
+			HOY,
+		);
+		expect(c.slaHoy).toBe(false);
+	});
+});
+
+describe("clasificarCreditoColaDia — promesa de pago", () => {
+	test("promesa pendiente con fecha prometida hoy → promesaHoy", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({
+				promesas: [{ estadoPromesa: "pendiente", fechaPrometida: HOY }],
+			}),
+			HOY,
+		);
+		expect(c.promesaHoy).toBe(true);
+		expect(c.incumplida).toBe(false);
+	});
+
+	test("promesa pendiente con fecha prometida futura → ninguna bandera", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({
+				promesas: [{ estadoPromesa: "pendiente", fechaPrometida: MANANA }],
+			}),
+			HOY,
+		);
+		expect(c.promesaHoy).toBe(false);
+		expect(c.incumplida).toBe(false);
+	});
+
+	test("promesa pendiente con fecha prometida ayer (job nocturno no la marcó aún) → incumplida", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({
+				promesas: [{ estadoPromesa: "pendiente", fechaPrometida: AYER }],
+			}),
+			HOY,
+		);
+		expect(c.incumplida).toBe(true);
+		expect(c.promesaHoy).toBe(false);
+	});
+
+	test("promesa ya marcada incumplida → incumplida, sin importar la fecha", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({
+				promesas: [{ estadoPromesa: "incumplida", fechaPrometida: MANANA }],
+			}),
+			HOY,
+		);
+		expect(c.incumplida).toBe(true);
+	});
+});
+
+describe("clasificarCreditoColaDia — días sin contacto", () => {
+	test("6 días sin contacto (> umbral de 5) → sinContacto", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ diasSinContacto: 6 }),
+			HOY,
+		);
+		expect(c.sinContacto).toBe(true);
+	});
+
+	test("exactamente 5 días (= umbral, no lo supera) → NO sinContacto", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ diasSinContacto: 5 }),
+			HOY,
+		);
+		expect(c.sinContacto).toBe(false);
+	});
+
+	test("1 día sin contacto → NO sinContacto", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ diasSinContacto: 1 }),
+			HOY,
+		);
+		expect(c.sinContacto).toBe(false);
+	});
+
+	test("diasSinContacto null (nunca se le registró contacto) → NO sinContacto, no se inventa una fecha base", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({ diasSinContacto: null }),
+			HOY,
+		);
+		expect(c.sinContacto).toBe(false);
+	});
+});
+
+describe("clasificarCreditoColaDia — solapes", () => {
+	test("un crédito puede calificar en las 4 categorías a la vez", () => {
+		const c = clasificarCreditoColaDia(
+			creditoBase({
+				fechaLimiteSla: "2026-07-23",
+				promesas: [
+					{ estadoPromesa: "pendiente", fechaPrometida: HOY },
+					{ estadoPromesa: "incumplida", fechaPrometida: AYER },
+				],
+				diasSinContacto: 10,
+			}),
+			HOY,
+		);
+		expect(c).toEqual({
+			slaHoy: true,
+			promesaHoy: true,
+			incumplida: true,
+			sinContacto: true,
+		});
+	});
+});
+
+describe("calificaParaColaDia / calificaParaFiltro", () => {
+	test("sin ninguna bandera → no califica para la cola", () => {
+		expect(
+			calificaParaColaDia({
+				slaHoy: false,
+				promesaHoy: false,
+				incumplida: false,
+				sinContacto: false,
+			}),
+		).toBe(false);
+	});
+
+	test("con al menos una bandera → califica para la cola", () => {
+		expect(
+			calificaParaColaDia({
+				slaHoy: true,
+				promesaHoy: false,
+				incumplida: false,
+				sinContacto: false,
+			}),
+		).toBe(true);
+	});
+
+	test("solo sinContacto también califica para la cola", () => {
+		expect(
+			calificaParaColaDia({
+				slaHoy: false,
+				promesaHoy: false,
+				incumplida: false,
+				sinContacto: true,
+			}),
+		).toBe(true);
+	});
+
+	test("calificaParaFiltro solo mira la categoría pedida", () => {
+		const c = {
+			slaHoy: true,
+			promesaHoy: false,
+			incumplida: false,
+			sinContacto: false,
+		};
+		expect(calificaParaFiltro(c, "sla_hoy")).toBe(true);
+		expect(calificaParaFiltro(c, "promesa_hoy")).toBe(false);
+		expect(calificaParaFiltro(c, "incumplida")).toBe(false);
+		expect(calificaParaFiltro(c, "sin_contacto")).toBe(false);
+	});
+
+	test("calificaParaFiltro('sin_contacto') solo mira sinContacto", () => {
+		const c = {
+			slaHoy: true,
+			promesaHoy: true,
+			incumplida: true,
+			sinContacto: false,
+		};
+		expect(calificaParaFiltro(c, "sin_contacto")).toBe(false);
+	});
+});
+
+describe("ordenColaDia", () => {
+	test("prioriza slaHoy sobre promesaHoy sobre incumplida sobre sinContacto", () => {
+		expect(
+			ordenColaDia({
+				slaHoy: true,
+				promesaHoy: true,
+				incumplida: true,
+				sinContacto: true,
+			}),
+		).toBe(0);
+		expect(
+			ordenColaDia({
+				slaHoy: false,
+				promesaHoy: true,
+				incumplida: true,
+				sinContacto: true,
+			}),
+		).toBe(1);
+		expect(
+			ordenColaDia({
+				slaHoy: false,
+				promesaHoy: false,
+				incumplida: true,
+				sinContacto: true,
+			}),
+		).toBe(2);
+		expect(
+			ordenColaDia({
+				slaHoy: false,
+				promesaHoy: false,
+				incumplida: false,
+				sinContacto: true,
+			}),
+		).toBe(3);
+	});
+});

--- a/apps/crm/apps/server/src/lib/cola-dia.ts
+++ b/apps/crm/apps/server/src/lib/cola-dia.ts
@@ -1,0 +1,125 @@
+/**
+ * CB-020 — Cola del Día (función pura, sin DB ni red). Clasifica un crédito
+ * en las 4 categorías de la cola priorizada:
+ *
+ *  1. slaHoy: el límite de SLA (fecha_entrada_bucket + dias_sla del bucket,
+ *     calculado en cartera-back, día GT) cae HOY — y el asesor NO registró
+ *     contacto hoy (si ya llamó hoy, el crédito ya no urge por SLA).
+ *  2. promesaHoy: hay una promesa de pago pendiente (contactos_cobros,
+ *     estado_promesa='pendiente') cuya fecha prometida es HOY.
+ *  3. incumplida: hay una promesa incumplida (estado_promesa='incumplida'),
+ *     o pendiente cuya fecha prometida ya pasó (venció antes de hoy y el job
+ *     nocturno / getEstadoPromesasPago aún no la marcó incumplida).
+ *  4. sinContacto: lleva más de UMBRAL_SIN_CONTACTO días sin que NADIE lo
+ *     contacte (MAX(fecha_contacto) por caso), sin importar bucket ni SLA —
+ *     un crédito puede llevar meses en el mismo bucket sin que nadie lo
+ *     toque, y SLA no lo detecta porque solo mira la entrada al bucket, no
+ *     la actividad real. Un crédito SIN NINGÚN contacto (nunca se le llamó)
+ *     no tiene fecha base para medir días → NO califica (decisión explícita:
+ *     mejor omitir que inventar una fecha de referencia).
+ *
+ * Un crédito puede tener varias banderas a la vez — sale una sola vez en la
+ * cola con todas las que aplican. Sin filtro, el orden priorizado es
+ * slaHoy → promesaHoy → incumplida → sinContacto (ver ordenColaDia).
+ */
+
+import { toDateStrGT } from "./guatemala-month-window";
+
+// Única fuente de verdad de las categorías — el input zod de getColaDia
+// (routers/cobros.ts) usa z.enum(CATEGORIAS_COLA_DIA) directo sobre este
+// array, así el tipo inferido por zod y CategoriaColaDia son el MISMO tipo
+// (no dos declaraciones estructuralmente iguales pero nominalmente distintas)
+// y no hace falta castear el input validado al pasarlo a calificaParaFiltro.
+export const CATEGORIAS_COLA_DIA = [
+	"sla_hoy",
+	"promesa_hoy",
+	"incumplida",
+	"sin_contacto",
+] as const;
+
+export type CategoriaColaDia = (typeof CATEGORIAS_COLA_DIA)[number];
+
+/** Días sin contacto a partir de los cuales un crédito entra a la categoría "sin_contacto". */
+export const UMBRAL_DIAS_SIN_CONTACTO = 5;
+
+export interface CreditoParaClasificar {
+	/** YYYY-MM-DD (día GT), ya calculado por cartera-back. null = sin SLA (crédito sin fila en buckets_historial, o B0). */
+	fechaLimiteSla: string | null;
+	/** true si ya se registró un contacto (cualquier tipo) HOY para este crédito. */
+	contactadoHoy: boolean;
+	/** Promesas activas del crédito (pendiente o incumplida; 'cumplida' es terminal, se excluye antes de llamar). */
+	promesas: Array<{
+		estadoPromesa: "pendiente" | "incumplida";
+		fechaPrometida: Date;
+	}>;
+	/**
+	 * Días transcurridos desde el ÚLTIMO contacto registrado (cualquier tipo),
+	 * ya calculados en día GT. null = nunca se registró ningún contacto para
+	 * este crédito — sin fecha base, no califica para "sin_contacto".
+	 */
+	diasSinContacto: number | null;
+}
+
+export interface ClasificacionColaDia {
+	slaHoy: boolean;
+	promesaHoy: boolean;
+	incumplida: boolean;
+	sinContacto: boolean;
+}
+
+export function clasificarCreditoColaDia(
+	credito: CreditoParaClasificar,
+	hoy: Date = new Date(),
+): ClasificacionColaDia {
+	const hoyStr = toDateStrGT(hoy);
+
+	const slaHoy = credito.fechaLimiteSla === hoyStr && !credito.contactadoHoy;
+
+	let promesaHoy = false;
+	let incumplida = false;
+	for (const promesa of credito.promesas) {
+		const fechaStr = toDateStrGT(promesa.fechaPrometida);
+		if (promesa.estadoPromesa === "incumplida") {
+			incumplida = true;
+			continue;
+		}
+		// pendiente
+		if (fechaStr === hoyStr) promesaHoy = true;
+		else if (fechaStr < hoyStr) incumplida = true; // vencida, aún no marcada por el job nocturno
+	}
+
+	const sinContacto =
+		credito.diasSinContacto != null &&
+		credito.diasSinContacto > UMBRAL_DIAS_SIN_CONTACTO;
+
+	return { slaHoy, promesaHoy, incumplida, sinContacto };
+}
+
+/** true si el crédito califica para AL MENOS una categoría (entra a la cola sin filtro). */
+export function calificaParaColaDia(c: ClasificacionColaDia): boolean {
+	return c.slaHoy || c.promesaHoy || c.incumplida || c.sinContacto;
+}
+
+/** true si el crédito califica para la categoría pedida (cola CON filtro). */
+export function calificaParaFiltro(
+	c: ClasificacionColaDia,
+	filtro: CategoriaColaDia,
+): boolean {
+	if (filtro === "sla_hoy") return c.slaHoy;
+	if (filtro === "promesa_hoy") return c.promesaHoy;
+	if (filtro === "incumplida") return c.incumplida;
+	return c.sinContacto;
+}
+
+/**
+ * Orden priorizado (sin filtro): SLA hoy primero, luego promesa hoy, luego
+ * incumplida, luego sin contacto (la menos urgente — no vencimiento puntual,
+ * sino inactividad acumulada). Un crédito con varias banderas gana por la de
+ * mayor prioridad.
+ */
+export function ordenColaDia(c: ClasificacionColaDia): number {
+	if (c.slaHoy) return 0;
+	if (c.promesaHoy) return 1;
+	if (c.incumplida) return 2;
+	return 3; // sinContacto (única forma de calificar si llegamos aquí)
+}

--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -17,7 +17,9 @@ describe("estadoMoraPorCuotas", () => {
 	// implementación, no contrato documentado). Cambiar la implementación del
 	// MISMO handle (`mockResolvedValue`/`mockRejectedValue`) es el patrón
 	// correcto y no depende de ese detalle.
-	let getBucketsCatalogoSpy: ReturnType<typeof spyOn<typeof carteraBackClient, "getBucketsCatalogo">>;
+	let getBucketsCatalogoSpy: ReturnType<
+		typeof spyOn<typeof carteraBackClient, "getBucketsCatalogo">
+	>;
 
 	beforeEach(() => {
 		// El módulo es un singleton con estado global (cache + timestamp) que
@@ -126,6 +128,7 @@ describe("estadoMoraPorCuotas", () => {
 				orden: -1,
 				color: null,
 				estado_mora: null,
+				dias_sla: null,
 			},
 			...catalogo,
 		]);
@@ -156,6 +159,7 @@ describe("estadoMoraPorCuotas", () => {
 				orden: -1,
 				color: null,
 				estado_mora: "mora_90",
+				dias_sla: null,
 			},
 			...catalogo,
 		]);
@@ -209,12 +213,48 @@ describe("getBucketsParaUI", () => {
 		const ui = getBucketsParaUI();
 
 		expect(ui).toEqual([
-			{ estadoMora: "al_dia", label: "Cartera Sana", prefijo: "B0", color: null, orden: 0 },
-			{ estadoMora: "mora_30", label: "Alerta Temprana", prefijo: "B1", color: null, orden: 1 },
-			{ estadoMora: "mora_60", label: "Gestión Activa", prefijo: "B2", color: null, orden: 2 },
-			{ estadoMora: "mora_90", label: "Rescate", prefijo: "B3", color: null, orden: 3 },
-			{ estadoMora: "mora_120", label: "Última Instancia / Pre Jurídico", prefijo: "B4", color: null, orden: 4 },
-			{ estadoMora: "mora_120_plus", label: "Jurídico", prefijo: "B5", color: null, orden: 5 },
+			{
+				estadoMora: "al_dia",
+				label: "Cartera Sana",
+				prefijo: "B0",
+				color: null,
+				orden: 0,
+			},
+			{
+				estadoMora: "mora_30",
+				label: "Alerta Temprana",
+				prefijo: "B1",
+				color: null,
+				orden: 1,
+			},
+			{
+				estadoMora: "mora_60",
+				label: "Gestión Activa",
+				prefijo: "B2",
+				color: null,
+				orden: 2,
+			},
+			{
+				estadoMora: "mora_90",
+				label: "Rescate",
+				prefijo: "B3",
+				color: null,
+				orden: 3,
+			},
+			{
+				estadoMora: "mora_120",
+				label: "Última Instancia / Pre Jurídico",
+				prefijo: "B4",
+				color: null,
+				orden: 4,
+			},
+			{
+				estadoMora: "mora_120_plus",
+				label: "Jurídico",
+				prefijo: "B5",
+				color: null,
+				orden: 5,
+			},
 		]);
 	});
 
@@ -338,14 +378,51 @@ function buildCatalogoCompleto(
 	orden: number;
 	color: string | null;
 	estado_mora: string | null;
+	dias_sla: number | null;
 }> {
 	const buckets = [
-		{ numero: 0, nombre: "Cartera Sana", cuotas_min: 0, cuotas_max: 0, estadoMora: "al_dia" },
-		{ numero: 1, nombre: "Alerta Temprana", cuotas_min: 1, cuotas_max: 1, estadoMora: "mora_30" },
-		{ numero: 2, nombre: "Gestión Activa", cuotas_min: 2, cuotas_max: 2, estadoMora: "mora_60" },
-		{ numero: 3, nombre: "Rescate", cuotas_min: 3, cuotas_max: 3, estadoMora: "mora_90" },
-		{ numero: 4, nombre: "Última Instancia", cuotas_min: 4, cuotas_max: 4, estadoMora: "mora_120" },
-		{ numero: 5, nombre: "Jurídico", cuotas_min: 5, cuotas_max: null, estadoMora: "mora_120_plus" },
+		{
+			numero: 0,
+			nombre: "Cartera Sana",
+			cuotas_min: 0,
+			cuotas_max: 0,
+			estadoMora: "al_dia",
+		},
+		{
+			numero: 1,
+			nombre: "Alerta Temprana",
+			cuotas_min: 1,
+			cuotas_max: 1,
+			estadoMora: "mora_30",
+		},
+		{
+			numero: 2,
+			nombre: "Gestión Activa",
+			cuotas_min: 2,
+			cuotas_max: 2,
+			estadoMora: "mora_60",
+		},
+		{
+			numero: 3,
+			nombre: "Rescate",
+			cuotas_min: 3,
+			cuotas_max: 3,
+			estadoMora: "mora_90",
+		},
+		{
+			numero: 4,
+			nombre: "Última Instancia",
+			cuotas_min: 4,
+			cuotas_max: 4,
+			estadoMora: "mora_120",
+		},
+		{
+			numero: 5,
+			nombre: "Jurídico",
+			cuotas_min: 5,
+			cuotas_max: null,
+			estadoMora: "mora_120_plus",
+		},
 	];
 	return buckets.map((b) => ({
 		numero: b.numero,
@@ -359,5 +436,6 @@ function buildCatalogoCompleto(
 		orden: b.numero,
 		color: null,
 		estado_mora: estadoMoraOverrides[b.numero] ?? b.estadoMora,
+		dias_sla: null,
 	}));
 }

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -11,6 +11,7 @@ import {
 	ilike,
 	inArray,
 	isNotNull,
+	isNull,
 	max,
 	or,
 	sql,
@@ -2351,7 +2352,14 @@ export const cobrosRouter = {
 				// `casoIds` pero son independientes entre sí → en paralelo.
 				const [promesas, ultimosContactos] = await Promise.all([
 					// Promesas ACTIVAS (pendiente/incumplida — 'cumplida' es terminal,
-					// se excluye), para clasificar.
+					// se excluye), para clasificar. `estadoPromesa IS NULL` (filas
+					// legacy nunca evaluadas, o creadas antes de que
+					// getEstadoPromesasPago/el job nocturno les asignara un valor)
+					// cuenta como "pendiente" — mismo criterio que
+					// getEstadoPromesasPago (línea ~2160: `estadoPromesa ?? "pendiente"`)
+					// — sin este OR, `eq(estadoPromesa, "pendiente")` nunca matchea
+					// NULL en SQL y esas promesas se colaban fuera de la Cola del Día
+					// hasta que algo más las recalculara (review Codex).
 					casoIds.length === 0
 						? Promise.resolve([])
 						: db
@@ -2369,6 +2377,7 @@ export const cobrosRouter = {
 										or(
 											eq(contactosCobros.estadoPromesa, "pendiente"),
 											eq(contactosCobros.estadoPromesa, "incumplida"),
+											isNull(contactosCobros.estadoPromesa),
 										),
 									),
 								),
@@ -2397,10 +2406,15 @@ export const cobrosRouter = {
 					}>
 				>();
 				for (const p of promesas) {
-					if (!p.estadoPromesa || p.estadoPromesa === "cumplida") continue;
+					if (p.estadoPromesa === "cumplida") continue;
+					// NULL (legacy, nunca evaluada) cuenta como "pendiente" — el SQL
+					// de arriba ya la deja pasar con isNull(estadoPromesa), acá se
+					// resuelve el valor por defecto (mismo criterio que
+					// getEstadoPromesasPago: `estadoPromesa ?? "pendiente"`).
+					const estadoPromesa = p.estadoPromesa ?? "pendiente";
 					const lista = promesasPorCaso.get(p.casoCobroId) ?? [];
 					lista.push({
-						estadoPromesa: p.estadoPromesa,
+						estadoPromesa,
 						fechaPrometida: p.fechaProximoContacto as Date,
 					});
 					promesasPorCaso.set(p.casoCobroId, lista);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -11,6 +11,7 @@ import {
 	ilike,
 	inArray,
 	isNotNull,
+	max,
 	or,
 	sql,
 } from "drizzle-orm";
@@ -51,8 +52,15 @@ import {
 	prepararTelefonoAsesorParaEnvio,
 } from "../lib/cobros-plantillas";
 import { filterCobrosSearchResults } from "../lib/cobros-search";
+import {
+	CATEGORIAS_COLA_DIA,
+	calificaParaColaDia,
+	calificaParaFiltro,
+	clasificarCreditoColaDia,
+	ordenColaDia,
+} from "../lib/cola-dia";
 import { fetchAllPages } from "../lib/fetch-all-pages";
-import { toDateStrGT } from "../lib/guatemala-month-window";
+import { gtDateStrToDate, toDateStrGT } from "../lib/guatemala-month-window";
 import {
 	getTestPhone,
 	isTestModeEnabled,
@@ -453,7 +461,8 @@ export const createContactoCobrosSchema = z
 	// mergeado) ya la exige en el modal (obligatoria al submit);
 	// repuesto ahora que ese web se reemplazó.
 	.refine(
-		(v) => v.estadoContacto !== "promesa_pago" || v.fechaProximoContacto != null,
+		(v) =>
+			v.estadoContacto !== "promesa_pago" || v.fechaProximoContacto != null,
 		{
 			message: "La fecha prometida es obligatoria",
 			path: ["fechaProximoContacto"],
@@ -2194,6 +2203,323 @@ export const cobrosRouter = {
 			}
 
 			return resultado;
+		}),
+
+	// CB-020: Cola del Día priorizada. Combina el universo SLA de cartera-back
+	// (créditos del pool asesor_bucket con su fecha_limite_sla) con las
+	// promesas de pago del CRM (contactos_cobros, que solo viven acá) para
+	// armar las 3 categorías: SLA vence hoy, promesa vence hoy, incumplida.
+	// Mismo patrón de "asesor forzado" que getAgendaDia — el rol cobros solo
+	// ve su propia cola (match por email contra cartera-back.getAdvisors).
+	getColaDia: cobrosProcedure
+		.input(
+			z.object({
+				filtro: z.enum(CATEGORIAS_COLA_DIA).optional(),
+				asesorId: z.number().int().positive().optional(),
+				buckets: z.array(z.number().int().min(0).max(5)).optional(),
+				page: z.number().int().positive().optional(),
+				perPage: z.number().int().min(1).max(200).optional(),
+			}),
+		)
+		.handler(async ({ input, context }) => {
+			try {
+				const puedeVerTodos = PERMISSIONS.canAssignCobros(
+					context.userRole ?? "",
+				);
+				const perPage = input.perPage ?? 50;
+				const page = input.page ?? 1;
+
+				let asesorForzado: { asesorId: number; nombre: string } | null = null;
+				let asesorIdFiltro: number | undefined;
+				if (!puedeVerTodos) {
+					const email = context.session?.user?.email?.trim().toLowerCase();
+					const advisors = await carteraBackClient.getAdvisors({
+						page: 1,
+						perPage: 500,
+					});
+					const propio = (advisors.data ?? []).find(
+						(a) => a.email?.trim().toLowerCase() === email,
+					);
+					if (!propio) {
+						return {
+							success: true,
+							sinAsesor: true,
+							asesorForzado: null,
+							items: [],
+							total: 0,
+							page,
+							perPage,
+							totalPages: 1,
+						};
+					}
+					asesorForzado = {
+						asesorId: propio.asesor_id,
+						nombre: propio.nombre,
+					};
+					asesorIdFiltro = propio.asesor_id;
+				} else if (input.asesorId) {
+					asesorIdFiltro = input.asesorId;
+				}
+
+				// Universo SLA: TODOS los créditos del pool del asesor (o de todos
+				// los asesores, si no se filtra) — sin paginar acá todavía, porque
+				// la paginación real ocurre DESPUÉS de cruzar con promesas y
+				// clasificar (un crédito puede calificar o no calificar para la
+				// cola; paginar antes de saber eso rompería la página). "Promesa
+				// hoy"/"incumplida" son independientes del SLA — cartera-back NO
+				// filtra por fecha (no sabe de promesas, viven solo en el CRM), así
+				// que hay que traer el universo COMPLETO del pool, no solo lo que
+				// vence pronto. fetchAllPages pagina de verdad (perPage 100, en
+				// paralelo) en vez de forzar un perPage gigante en una sola
+				// llamada — mismo patrón que obtenerTodasLasPaginasCreditos, arriba
+				// en este archivo.
+				const universoData = await fetchAllPages(
+					async (page) => {
+						const resp = await carteraBackClient.getColaDiaSLA({
+							asesorId: asesorIdFiltro,
+							buckets: input.buckets,
+							page,
+							perPage: 100,
+						});
+						return { data: resp.data, totalPages: resp.totalPages ?? 0 };
+					},
+					{ maxPages: 200 }, // 200 * 100 = 20k créditos, muy por encima de la cartera real
+				);
+				const universo = { data: universoData };
+
+				if (universo.data.length === 0) {
+					return {
+						success: true,
+						sinAsesor: false,
+						asesorForzado,
+						items: [],
+						total: 0,
+						page,
+						perPage,
+						totalPages: 1,
+					};
+				}
+
+				const sifcos = [
+					...new Set(universo.data.map((c) => c.numero_credito_sifco)),
+				];
+
+				// Casos de cobros del CRM por SIFCO (teléfono + id para ir al detalle)
+				// y teléfono vía lead (cartera no tiene teléfonos de clientes) — ambas
+				// dependen solo de `sifcos`, sin dependencia entre sí → en paralelo.
+				const [casos, oportunidades] = await Promise.all([
+					db
+						.select({
+							id: casosCobros.id,
+							numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+							telefonoPrincipal: casosCobros.telefonoPrincipal,
+							activo: casosCobros.activo,
+							updatedAt: casosCobros.updatedAt,
+						})
+						.from(casosCobros)
+						.where(inArray(casosCobros.numeroCreditoSifco, sifcos)),
+					db
+						.select({
+							numeroSifco: opportunities.numeroSifco,
+							leadPhone: leads.phone,
+						})
+						.from(opportunities)
+						.leftJoin(leads, eq(opportunities.leadId, leads.id))
+						.where(inArray(opportunities.numeroSifco, sifcos)),
+				]);
+
+				// Con varios casos por SIFCO gana el activo y a igualdad el más
+				// reciente — mismo criterio que getAgendaDia.
+				const casoPorSifco = new Map<string, (typeof casos)[number]>();
+				for (const caso of casos) {
+					const sifco = caso.numeroCreditoSifco ?? "";
+					const previo = casoPorSifco.get(sifco);
+					const gana =
+						!previo ||
+						(Boolean(caso.activo) && !previo.activo) ||
+						(Boolean(caso.activo) === Boolean(previo.activo) &&
+							(caso.updatedAt?.getTime() ?? 0) >
+								(previo.updatedAt?.getTime() ?? 0));
+					if (gana) casoPorSifco.set(sifco, caso);
+				}
+				const casoIds = [...casoPorSifco.values()].map((c) => c.id);
+				const leadPhonePorSifco = new Map(
+					oportunidades.map((o) => [o.numeroSifco ?? "", o.leadPhone]),
+				);
+
+				// Promesas activas y último contacto por caso — ambas dependen de
+				// `casoIds` pero son independientes entre sí → en paralelo.
+				const [promesas, ultimosContactos] = await Promise.all([
+					// Promesas ACTIVAS (pendiente/incumplida — 'cumplida' es terminal,
+					// se excluye), para clasificar.
+					casoIds.length === 0
+						? Promise.resolve([])
+						: db
+								.select({
+									casoCobroId: contactosCobros.casoCobroId,
+									estadoPromesa: contactosCobros.estadoPromesa,
+									fechaProximoContacto: contactosCobros.fechaProximoContacto,
+								})
+								.from(contactosCobros)
+								.where(
+									and(
+										inArray(contactosCobros.casoCobroId, casoIds),
+										eq(contactosCobros.estadoContacto, "promesa_pago"),
+										isNotNull(contactosCobros.fechaProximoContacto),
+										or(
+											eq(contactosCobros.estadoPromesa, "pendiente"),
+											eq(contactosCobros.estadoPromesa, "incumplida"),
+										),
+									),
+								),
+					// Último contacto (CUALQUIER tipo) por caso — una sola fuente para
+					// dos usos: "contactado hoy" (saca la bandera slaHoy si el asesor
+					// ya llamó hoy) y "días sin contacto" (categoría sinContacto,
+					// CB-020). Mismo patrón que checkCasosSinContacto
+					// (jobs/cobros-notifications.ts): MAX(fecha_contacto) agrupado por
+					// caso_cobro_id.
+					casoIds.length === 0
+						? Promise.resolve([])
+						: db
+								.select({
+									casoCobroId: contactosCobros.casoCobroId,
+									ultimaFecha: max(contactosCobros.fechaContacto),
+								})
+								.from(contactosCobros)
+								.where(inArray(contactosCobros.casoCobroId, casoIds))
+								.groupBy(contactosCobros.casoCobroId),
+				]);
+				const promesasPorCaso = new Map<
+					string,
+					Array<{
+						estadoPromesa: "pendiente" | "incumplida";
+						fechaPrometida: Date;
+					}>
+				>();
+				for (const p of promesas) {
+					if (!p.estadoPromesa || p.estadoPromesa === "cumplida") continue;
+					const lista = promesasPorCaso.get(p.casoCobroId) ?? [];
+					lista.push({
+						estadoPromesa: p.estadoPromesa,
+						fechaPrometida: p.fechaProximoContacto as Date,
+					});
+					promesasPorCaso.set(p.casoCobroId, lista);
+				}
+
+				const hoyStr = toDateStrGT(new Date());
+				const contactadoHoyPorCaso = new Set<string>();
+				const diasSinContactoPorCaso = new Map<string, number>();
+				// gtDateStrToDate: medianoche GT del día, no medianoche UTC — misma
+				// convención que usa el resto del proyecto para comparar fechas GT
+				// por día calendario (ver promesa-pago.ts).
+				const hoyMs = gtDateStrToDate(hoyStr).getTime();
+				const MS_POR_DIA = 24 * 60 * 60 * 1000;
+				for (const c of ultimosContactos) {
+					if (!c.ultimaFecha) continue;
+					if (toDateStrGT(c.ultimaFecha) === hoyStr) {
+						contactadoHoyPorCaso.add(c.casoCobroId);
+					}
+					const ultimaFechaStr = toDateStrGT(c.ultimaFecha);
+					const ultimaMs = gtDateStrToDate(ultimaFechaStr).getTime();
+					const dias = Math.floor((hoyMs - ultimaMs) / MS_POR_DIA);
+					diasSinContactoPorCaso.set(c.casoCobroId, dias);
+				}
+
+				const hoy = new Date();
+				const items = universo.data
+					.map((credito) => {
+						const caso = casoPorSifco.get(credito.numero_credito_sifco);
+						const promesasCredito = caso
+							? (promesasPorCaso.get(caso.id) ?? [])
+							: [];
+						const diasSinContacto = caso
+							? (diasSinContactoPorCaso.get(caso.id) ?? null)
+							: null;
+						const clasificacion = clasificarCreditoColaDia(
+							{
+								fechaLimiteSla: credito.fecha_limite_sla,
+								contactadoHoy: caso ? contactadoHoyPorCaso.has(caso.id) : false,
+								promesas: promesasCredito,
+								diasSinContacto,
+							},
+							hoy,
+						);
+						return {
+							credito,
+							caso,
+							promesasCredito,
+							clasificacion,
+							diasSinContacto,
+						};
+					})
+					.filter(({ clasificacion }) =>
+						input.filtro
+							? calificaParaFiltro(clasificacion, input.filtro)
+							: calificaParaColaDia(clasificacion),
+					)
+					.sort(
+						(a, b) =>
+							ordenColaDia(a.clasificacion) - ordenColaDia(b.clasificacion),
+					)
+					.map(
+						({
+							credito,
+							caso,
+							promesasCredito,
+							clasificacion,
+							diasSinContacto,
+						}) => ({
+							creditoId: credito.credito_id,
+							numeroCreditoSifco: credito.numero_credito_sifco,
+							cliente: credito.cliente,
+							asesorId: credito.asesor_id,
+							asesor: credito.asesor,
+							bucket: credito.bucket,
+							bucketPrefijo: credito.bucket_prefijo,
+							bucketNombre: credito.bucket_nombre,
+							fechaLimiteSla: credito.fecha_limite_sla,
+							// Próxima promesa activa a mostrar: la más próxima en el tiempo.
+							fechaPromesa:
+								promesasCredito.length > 0
+									? promesasCredito
+											.map((p) => p.fechaPrometida)
+											.sort((x, y) => x.getTime() - y.getTime())[0]
+									: null,
+							telefono:
+								primerTelefono(caso?.telefonoPrincipal) ??
+								primerTelefono(
+									leadPhonePorSifco.get(credito.numero_credito_sifco),
+								) ??
+								null,
+							casoId: caso?.id ?? null,
+							slaHoy: clasificacion.slaHoy,
+							promesaHoy: clasificacion.promesaHoy,
+							incumplida: clasificacion.incumplida,
+							sinContacto: clasificacion.sinContacto,
+							diasSinContacto,
+						}),
+					);
+
+				const total = items.length;
+				const totalPages = Math.max(1, Math.ceil(total / perPage));
+				const offset = (page - 1) * perPage;
+
+				return {
+					success: true,
+					sinAsesor: false,
+					asesorForzado,
+					items: items.slice(offset, offset + perPage),
+					total,
+					page,
+					perPage,
+					totalPages,
+				};
+			} catch (error) {
+				console.error("[getColaDia] Error:", error);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "No se pudo obtener la cola del día",
+				});
+			}
 		}),
 
 	// Obtener historial de cuotas de pago de un contrato

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -144,6 +144,7 @@ export const cobrosAppRouter = {
 	getBucketsHistorial: cobrosRouter.getBucketsHistorial,
 	getBucketsHistorialCredito: cobrosRouter.getBucketsHistorialCredito,
 	getAgendaDia: cobrosRouter.getAgendaDia,
+	getColaDia: cobrosRouter.getColaDia,
 	getRecordatoriosPremora: cobrosRouter.getRecordatoriosPremora,
 	getCreditosPorBucket: cobrosRouter.getCreditosPorBucket,
 	getPoolAsesoresPorBucket: cobrosRouter.getPoolAsesoresPorBucket,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -16,6 +16,7 @@ import type {
 	CarteraBucketCatalogo,
 	CarteraBucketHistorialEvento,
 	CarteraBucketsHistorialResponse,
+	CarteraColaDiaResponse,
 	CarteraCredito,
 	CarteraCuotasProximasResponse,
 	CarteraInversionista,
@@ -37,6 +38,7 @@ import type {
 	GetAsesorHistorialParams,
 	GetBucketsHistorialParams,
 	GetCargaPorAsesorBucketParams,
+	GetColaDiaSLAParams,
 	GetCreditosPorBucketParams,
 	GetInvestorReportParams,
 	GetInvestorsParams,
@@ -1098,6 +1100,27 @@ export class CarteraBackClient {
 			total: response.totalCount,
 			totalPages: response.totalPages,
 		};
+	}
+
+	// CB-020: universo SLA de la Cola del Día — créditos del POOL de buckets
+	// del asesor (asesor_bucket, no el asesor_id individual del crédito) con
+	// su fecha_limite_sla. Sin cache: la cola debe reflejar el estado real del
+	// bucket/SLA al instante, mismo criterio que sus hermanas de /buckets.
+	async getColaDiaSLA(
+		params: GetColaDiaSLAParams = {},
+	): Promise<CarteraColaDiaResponse> {
+		const queryParams = new URLSearchParams({
+			...(params.asesorId !== undefined && {
+				asesor_id: String(params.asesorId),
+			}),
+			...(params.buckets?.length && { bucket: params.buckets.join(",") }),
+			...(params.page && { page: params.page.toString() }),
+			...(params.perPage && { perPage: params.perPage.toString() }),
+		});
+		return this.request<CarteraColaDiaResponse>(
+			`/buckets/cola-dia?${queryParams}`,
+			{ method: "GET" },
+		);
 	}
 
 	// CB-018: carga de cuentas por asesor y bucket (dashboard gerencial) —

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -815,6 +815,8 @@ export interface CarteraBucketCatalogo {
 	orden: number;
 	color: string | null;
 	estado_mora: string | null;
+	/** CB-020: días de SLA para contactar desde que el crédito entró a este bucket. null = sin SLA (B0). */
+	dias_sla: number | null;
 }
 
 // ============================================================================
@@ -894,6 +896,49 @@ export interface CarteraBucketHistorialEvento {
 	asesor_atribucion: string | null;
 	pago_id: number | null;
 	motivo: string | null;
+}
+
+// ============================================================================
+// CB-020 · COLA DEL DÍA — universo SLA (GET /buckets/cola-dia)
+// ============================================================================
+
+/**
+ * Fila del universo SLA: un crédito del pool de buckets del asesor con la
+ * fecha en que entró a su bucket ACTUAL (buckets_historial) + la fecha límite
+ * derivada (fecha_entrada + dias_sla del bucket, día GT). El CRM cruza esto
+ * contra sus propias promesas de pago (contactos_cobros) para clasificar la
+ * cola en sus 3 categorías (SLA hoy / promesa hoy / incumplida).
+ */
+export interface CarteraColaDiaFila {
+	credito_id: number;
+	numero_credito_sifco: string;
+	cliente: string;
+	asesor_id: number;
+	asesor: string;
+	bucket: number;
+	bucket_prefijo: string;
+	bucket_nombre: string;
+	dias_sla: number;
+	fecha_entrada_bucket: string;
+	/** YYYY-MM-DD, día GT. */
+	fecha_limite_sla: string;
+}
+
+export interface CarteraColaDiaResponse {
+	success: boolean;
+	data: CarteraColaDiaFila[];
+	page: number;
+	perPage: number;
+	total: number;
+	totalPages: number;
+}
+
+export interface GetColaDiaSLAParams {
+	asesorId?: number;
+	/** Filtra por bucket(s) del catálogo (0-5). Omitir = todos los buckets con SLA. */
+	buckets?: number[];
+	page?: number;
+	perPage?: number;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Contexto

Segunda parte de CB-020 (la primera, endpoint de cartera-back, ya está
mergeada — #1154). Este PR agrega el lado CRM server: el endpoint ORPC
`getColaDia` que cruza el universo SLA de cartera-back con las promesas de
pago y el historial de contacto, que solo viven en la base del CRM.

**Definición confirmada con el usuario**: la Cola del Día prioriza cuentas
por 4 categorías, un crédito puede calificar en varias a la vez:

1. **SLA vence hoy** — ya lo calcula cartera-back (`fecha_limite_sla`); este
   PR le suma "y el asesor no lo contactó hoy" (si ya llamó, deja de urgir).
2. **Promesa vence hoy** — `contactos_cobros.estado_promesa='pendiente'` con
   `fecha_proximo_contacto` = hoy.
3. **Promesa incumplida** — marcada `incumplida`, o `pendiente` cuya fecha ya
   pasó (venció antes de hoy y el job nocturno aún no la re-evaluó).
4. **+5 días sin contacto** — más de 5 días (umbral fijo) desde el ÚLTIMO
   contacto registrado, sin importar bucket ni SLA. Distinto del SLA: un
   crédito puede llevar meses en el mismo bucket sin que nadie lo llame, y
   el SLA no lo detecta porque solo mira cuándo entró al bucket. Un crédito
   sin NINGÚN contacto no tiene fecha base para medir días → no califica (se
   omite, no se inventa una fecha de referencia — decisión explícita).

Sin filtro, el orden priorizado es `slaHoy → promesaHoy → incumplida →
sinContacto`.

## Qué se agregó

### `lib/cola-dia.ts` — función pura de clasificación (19 tests)
`clasificarCreditoColaDia()` recibe `{ fechaLimiteSla, contactadoHoy,
promesas, diasSinContacto }` y devuelve las 4 banderas. Sin DB ni red, fácil
de testear aislada — mismo patrón que `lib/promesa-pago.ts`. Cubre: cada
categoría individual, límites exactos (5 días = no califica, 6 = sí),
solapes (un crédito en las 4 a la vez), y el caso "nunca contactado".

### `routers/cobros.ts` — procedimiento `getColaDia`
- Mismo patrón de "asesor forzado" que `getAgendaDia`: rol `cobros` ve solo
  su cola (match por email contra `cartera-back.getAdvisors`);
  admin/supervisor filtran por asesor o ven todos.
- Trae el universo completo del pool de buckets vía `fetchAllPages`
  (paginado real, perPage 100, en paralelo — mismo patrón que
  `obtenerTodasLasPaginasCreditos` en este archivo). Necesario: como
  "promesa hoy"/"incumplida"/"sin contacto" son independientes del SLA,
  cartera-back no puede filtrar por fecha sin perder esos casos, así que se
  trae todo y se clasifica del lado CRM.
- Cruza contra `casos_cobros` (teléfono, id del caso),
  `opportunities`→`leads` (teléfono alterno), promesas activas
  (`contactos_cobros`) y último contacto por caso
  (`MAX(fecha_contacto)`, mismo patrón que `checkCasosSinContacto` en
  `jobs/cobros-notifications.ts`). Las 4 consultas corren en 2 tandas
  paralelas según sus dependencias reales (`Promise.all`).
- Filtros: `filtro` (una de las 4 categorías), `asesorId`, `buckets` (0-5,
  validado con zod).

### Soporte
- `cartera-back-client.ts`: `getColaDiaSLA` + filtro por `buckets`.
- `types/cartera-back.ts`: tipos del universo SLA + `dias_sla` en el
  catálogo.
- `moraBuckets.test.ts`: fixtures actualizados con el campo `dias_sla` nuevo.

## Gaps de review ya corregidos
- `diasSinContacto` usa `gtDateStrToDate` (medianoche GT) en vez de una
  construcción de fecha a mano — consistente con el resto del proyecto
  (`promesa-pago.ts`).
- Cast `input.filtro as CategoriaColaDia` eliminado: el enum zod
  (`z.enum(CATEGORIAS_COLA_DIA)`) y el tipo de dominio comparten una sola
  fuente, ya no son dos tipos estructuralmente iguales pero distintos.
- Las 4 queries independientes (antes secuenciales) ahora corren en 2
  `Promise.all`.
- Manejo de `isError` pendiente de UI (PR de web).

## Qué NO incluye este PR
- El endpoint de cartera-back (ya mergeado, #1154).
- La UI (`/cobros/cola`, filtro por bucket, badges) — PR aparte sobre
  `apps/crm/apps/web`.

## Test plan
- [x] `bun test src/lib/cola-dia.test.ts` — 19/19 pass.
- [x] `bun run check-types` — limpio.
- [ ] Probar `getColaDia` end-to-end una vez el PR de web esté abierto (la
  UI es la forma más directa de probarlo manualmente).
- [ ] Confirmar que rol `cobros` solo ve su propia cola, admin/supervisor ven
  todas o filtran por asesor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>