### PR TITLE
feat(cobros): CRM web — UI de la Cola del Día (CB-020)

### DIFF
--- a/apps/crm/apps/web/src/components/cobros/bucket-multi-select.tsx
+++ b/apps/crm/apps/web/src/components/cobros/bucket-multi-select.tsx
@@ -1,0 +1,93 @@
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+	Command,
+	CommandGroup,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
+
+type Bucket = { numero: number; prefijo: string; nombre: string };
+
+export function BucketMultiSelect({
+	buckets,
+	value,
+	onChange,
+}: {
+	buckets: Bucket[];
+	value: number[] | null;
+	onChange: (numeros: number[] | null) => void;
+}) {
+	const allNumeros = buckets.map((b) => b.numero);
+	const selected = value === null ? allNumeros : value;
+	// 0 marcados = mismo resultado que "todos" (downstream ya trata un array
+	// vacío como sin filtro) — así deseleccionar el último no queda bloqueado
+	// y el usuario puede simplemente marcar el único bucket que quiere, sin
+	// tener que desmarcar el resto uno por uno primero.
+	const isAll =
+		value === null ||
+		selected.length === 0 ||
+		selected.length === allNumeros.length;
+
+	function toggle(numero: number) {
+		const base = value === null ? allNumeros : value;
+		const next = base.includes(numero)
+			? base.filter((x) => x !== numero)
+			: [...base, numero];
+		onChange(next.length === allNumeros.length ? null : next);
+	}
+
+	const label = isAll
+		? "Todos los buckets"
+		: selected.length === 1
+			? (buckets.find((b) => b.numero === selected[0])?.prefijo ?? "1 bucket")
+			: `${selected.length} buckets`;
+
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<Button variant="outline" className="h-8 w-52 justify-between">
+					<span className="truncate">{label}</span>
+					<ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+				</Button>
+			</PopoverTrigger>
+			<PopoverContent className="w-52 p-0" align="start">
+				<Command>
+					<CommandList>
+						<CommandGroup>
+							<CommandItem
+								onSelect={() => onChange(null)}
+								className="font-medium"
+							>
+								Seleccionar todos
+							</CommandItem>
+							<CommandItem
+								onSelect={() => onChange([])}
+								className="font-medium"
+							>
+								Deseleccionar todos
+							</CommandItem>
+							{buckets.map((b) => {
+								const checked = selected.includes(b.numero);
+								return (
+									<CommandItem key={b.numero} onSelect={() => toggle(b.numero)}>
+										<Checkbox checked={checked} className="mr-2" />
+										<span className="truncate">
+											{b.prefijo} — {b.nombre}
+										</span>
+									</CommandItem>
+								);
+							})}
+						</CommandGroup>
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}

--- a/apps/crm/apps/web/src/components/header.tsx
+++ b/apps/crm/apps/web/src/components/header.tsx
@@ -10,6 +10,7 @@ import {
 	CalendarClock,
 	Car,
 	ChevronDown,
+	ClipboardList,
 	Database,
 	FileText,
 	Gauge,
@@ -265,6 +266,12 @@ export default function Header() {
 										<Link to="/cobros/agenda" className="cursor-pointer">
 											<CalendarClock className="mr-2 h-4 w-4" />
 											Agenda del día
+										</Link>
+									</DropdownMenuItem>
+									<DropdownMenuItem asChild>
+										<Link to="/cobros/cola" className="cursor-pointer">
+											<ClipboardList className="mr-2 h-4 w-4" />
+											Cola del día
 										</Link>
 									</DropdownMenuItem>
 									{PERMISSIONS.canAssignCobros(userRole) && (
@@ -645,6 +652,10 @@ function MobileNav({
 										<Link to="/cobros/agenda" className={MOBILE_LINK_CLASS}>
 											<CalendarClock />
 											Agenda del día
+										</Link>
+										<Link to="/cobros/cola" className={MOBILE_LINK_CLASS}>
+											<ClipboardList />
+											Cola del día
 										</Link>
 										{PERMISSIONS.canAssignCobros(userRole) && (
 											<Link to="/cobros/metas" className={MOBILE_LINK_CLASS}>

--- a/apps/crm/apps/web/src/routeTree.gen.ts
+++ b/apps/crm/apps/web/src/routeTree.gen.ts
@@ -34,6 +34,7 @@ import { Route as CrmClientsRouteImport } from './routes/crm/clients'
 import { Route as CobrosReportesRouteImport } from './routes/cobros/reportes'
 import { Route as CobrosReasignacionesRouteImport } from './routes/cobros/reasignaciones'
 import { Route as CobrosMetasRouteImport } from './routes/cobros/metas'
+import { Route as CobrosColaRouteImport } from './routes/cobros/cola'
 import { Route as CobrosCargaRouteImport } from './routes/cobros/carga'
 import { Route as CobrosBucketsRouteImport } from './routes/cobros/buckets'
 import { Route as CobrosAgendaRouteImport } from './routes/cobros/agenda'
@@ -181,6 +182,11 @@ const CobrosMetasRoute = CobrosMetasRouteImport.update({
   path: '/cobros/metas',
   getParentRoute: () => rootRouteImport,
 } as any)
+const CobrosColaRoute = CobrosColaRouteImport.update({
+  id: '/cobros/cola',
+  path: '/cobros/cola',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const CobrosCargaRoute = CobrosCargaRouteImport.update({
   id: '/cobros/carga',
   path: '/cobros/carga',
@@ -302,6 +308,7 @@ export interface FileRoutesByFullPath {
   '/cobros/agenda': typeof CobrosAgendaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
+  '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reportes': typeof CobrosReportesRoute
@@ -349,6 +356,7 @@ export interface FileRoutesByTo {
   '/cobros/agenda': typeof CobrosAgendaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
+  '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reportes': typeof CobrosReportesRoute
@@ -397,6 +405,7 @@ export interface FileRoutesById {
   '/cobros/agenda': typeof CobrosAgendaRoute
   '/cobros/buckets': typeof CobrosBucketsRoute
   '/cobros/carga': typeof CobrosCargaRoute
+  '/cobros/cola': typeof CobrosColaRoute
   '/cobros/metas': typeof CobrosMetasRoute
   '/cobros/reasignaciones': typeof CobrosReasignacionesRoute
   '/cobros/reportes': typeof CobrosReportesRoute
@@ -446,6 +455,7 @@ export interface FileRouteTypes {
     | '/cobros/agenda'
     | '/cobros/buckets'
     | '/cobros/carga'
+    | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
     | '/cobros/reportes'
@@ -493,6 +503,7 @@ export interface FileRouteTypes {
     | '/cobros/agenda'
     | '/cobros/buckets'
     | '/cobros/carga'
+    | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
     | '/cobros/reportes'
@@ -540,6 +551,7 @@ export interface FileRouteTypes {
     | '/cobros/agenda'
     | '/cobros/buckets'
     | '/cobros/carga'
+    | '/cobros/cola'
     | '/cobros/metas'
     | '/cobros/reasignaciones'
     | '/cobros/reportes'
@@ -588,6 +600,7 @@ export interface RootRouteChildren {
   CobrosAgendaRoute: typeof CobrosAgendaRoute
   CobrosBucketsRoute: typeof CobrosBucketsRoute
   CobrosCargaRoute: typeof CobrosCargaRoute
+  CobrosColaRoute: typeof CobrosColaRoute
   CobrosMetasRoute: typeof CobrosMetasRoute
   CobrosReasignacionesRoute: typeof CobrosReasignacionesRoute
   CobrosReportesRoute: typeof CobrosReportesRoute
@@ -800,6 +813,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof CobrosMetasRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/cobros/cola': {
+      id: '/cobros/cola'
+      path: '/cobros/cola'
+      fullPath: '/cobros/cola'
+      preLoaderRoute: typeof CobrosColaRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/cobros/carga': {
       id: '/cobros/carga'
       path: '/cobros/carga'
@@ -956,6 +976,7 @@ const rootRouteChildren: RootRouteChildren = {
   CobrosAgendaRoute: CobrosAgendaRoute,
   CobrosBucketsRoute: CobrosBucketsRoute,
   CobrosCargaRoute: CobrosCargaRoute,
+  CobrosColaRoute: CobrosColaRoute,
   CobrosMetasRoute: CobrosMetasRoute,
   CobrosReasignacionesRoute: CobrosReasignacionesRoute,
   CobrosReportesRoute: CobrosReportesRoute,

--- a/apps/crm/apps/web/src/routes/cobros/cola.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/cola.tsx
@@ -1,0 +1,494 @@
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import {
+	ChevronLeft,
+	ChevronRight,
+	ClipboardList,
+	Loader2,
+	Phone,
+	UserRound,
+} from "lucide-react";
+import { useState } from "react";
+import { BucketMultiSelect } from "@/components/cobros/bucket-multi-select";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import {
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from "@/components/ui/table";
+import { authClient } from "@/lib/auth-client";
+import {
+	type BucketsCatalogoQueryData,
+	bucketDeEstado,
+	estiloBucket,
+	useBucketsCatalogo,
+} from "@/lib/cobros/buckets-catalogo";
+import { PERMISSIONS } from "@/lib/roles";
+import { orpc } from "@/utils/orpc";
+
+export const Route = createFileRoute("/cobros/cola")({
+	component: ColaDiaPage,
+});
+
+interface ColaItem {
+	creditoId: number;
+	numeroCreditoSifco: string;
+	cliente: string;
+	asesorId: number;
+	asesor: string;
+	bucket: number;
+	bucketPrefijo: string;
+	bucketNombre: string;
+	fechaLimiteSla: string | null;
+	fechaPromesa: string | Date | null;
+	telefono: string | null;
+	casoId: string | null;
+	slaHoy: boolean;
+	promesaHoy: boolean;
+	incumplida: boolean;
+	sinContacto: boolean;
+	diasSinContacto: number | null;
+}
+
+interface ColaResponse {
+	success: boolean;
+	sinAsesor: boolean;
+	asesorForzado: { asesorId: number; nombre: string } | null;
+	items: ColaItem[];
+	total: number;
+	page: number;
+	perPage: number;
+	totalPages: number;
+}
+
+interface AsesorOption {
+	asesorId: number;
+	nombre: string;
+	activo: boolean;
+	email: string;
+	isActive: boolean;
+}
+
+type Filtro =
+	| "todos"
+	| "sla_hoy"
+	| "promesa_hoy"
+	| "incumplida"
+	| "sin_contacto";
+
+const PER_PAGE_COLA = 25;
+
+const FILTROS: Array<{ value: Filtro; label: string }> = [
+	{ value: "todos", label: "Todos (priorizado)" },
+	{ value: "sla_hoy", label: "SLA vence hoy" },
+	{ value: "promesa_hoy", label: "Promesa vence hoy" },
+	{ value: "incumplida", label: "Promesa incumplida" },
+	{ value: "sin_contacto", label: "+5 días sin contacto" },
+];
+
+/** Bucket numérico del motor (0-5) → key de estadoMora del catálogo de UI. */
+const KEY_POR_NUMERO = [
+	"al_dia",
+	"mora_30",
+	"mora_60",
+	"mora_90",
+	"mora_120",
+	"mora_120_plus",
+] as const;
+
+/** Buckets 1-5 (B0/Cartera Sana nunca aplica SLA, no entra a la cola). */
+function opcionesBuckets(catalogo: BucketsCatalogoQueryData | undefined) {
+	return [1, 2, 3, 4, 5].map((numero) => {
+		const ui = bucketDeEstado(KEY_POR_NUMERO[numero], catalogo);
+		return { numero, prefijo: `B${numero}`, nombre: ui.label };
+	});
+}
+
+function BucketBadge({
+	numero,
+	catalogo,
+}: {
+	numero: number;
+	catalogo: BucketsCatalogoQueryData | undefined;
+}) {
+	const ui = bucketDeEstado(KEY_POR_NUMERO[numero], catalogo);
+	return (
+		<Badge
+			variant="outline"
+			className="whitespace-nowrap text-[10px]"
+			style={estiloBucket(ui.colorHex)}
+			title={ui.label}
+		>
+			B{numero}
+		</Badge>
+	);
+}
+
+function fechaLegible(v: string | Date | null) {
+	if (!v) return "—";
+	if (typeof v === "string") {
+		// "YYYY-MM-DD" → dd/mm/aaaa sin pasar por Date (evita corrimiento por TZ).
+		const [y, m, d] = v.split("-");
+		return y && m && d ? `${d}/${m}/${y}` : v;
+	}
+	return new Date(v).toLocaleDateString("es-GT", {
+		timeZone: "America/Guatemala",
+	});
+}
+
+function CategoriaBadges({ item }: { item: ColaItem }) {
+	return (
+		<span className="inline-flex flex-wrap items-center gap-1">
+			{item.slaHoy && (
+				<Badge
+					variant="outline"
+					className="border-transparent bg-red-100 text-[10px] text-red-800 dark:bg-red-900/40 dark:text-red-300"
+				>
+					SLA hoy
+				</Badge>
+			)}
+			{item.promesaHoy && (
+				<Badge
+					variant="outline"
+					className="border-transparent bg-amber-100 text-[10px] text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+				>
+					Promesa hoy
+				</Badge>
+			)}
+			{item.incumplida && (
+				<Badge
+					variant="outline"
+					className="border-transparent bg-slate-200 text-[10px] text-slate-800 dark:bg-slate-800 dark:text-slate-300"
+				>
+					Incumplida
+				</Badge>
+			)}
+			{item.sinContacto && (
+				<Badge
+					variant="outline"
+					className="border-transparent bg-purple-100 text-[10px] text-purple-800 dark:bg-purple-900/40 dark:text-purple-300"
+				>
+					{item.diasSinContacto} días sin contacto
+				</Badge>
+			)}
+		</span>
+	);
+}
+
+function ColaDiaPage() {
+	const navigate = useNavigate();
+	const { data: session } = authClient.useSession();
+	const userRole = session?.user?.role;
+	const esSupervisor = !!userRole && PERMISSIONS.canAssignCobros(userRole);
+	const bucketsCatalogo = useBucketsCatalogo();
+
+	const [asesorSel, setAsesorSel] = useState("todos");
+	const [filtro, setFiltro] = useState<Filtro>("todos");
+	const [bucketsSel, setBucketsSel] = useState<number[] | null>(null);
+	const [page, setPage] = useState(1);
+
+	const asesorIdInput =
+		esSupervisor && asesorSel !== "todos" ? Number(asesorSel) : undefined;
+	const buckets = opcionesBuckets(bucketsCatalogo.data);
+
+	const colaQuery = useQuery({
+		...orpc.getColaDia.queryOptions({
+			input: {
+				filtro: filtro === "todos" ? undefined : filtro,
+				asesorId: asesorIdInput,
+				buckets: bucketsSel ?? undefined,
+				page,
+				perPage: PER_PAGE_COLA,
+			},
+		}),
+		enabled: !!session,
+		placeholderData: keepPreviousData,
+	});
+
+	const asesoresQuery = useQuery({
+		...orpc.getAsesores.queryOptions({
+			input: { page: 1, perPage: 100 },
+		}),
+		enabled: !!session && esSupervisor,
+	});
+
+	if (!userRole || !PERMISSIONS.canAccessCobros(userRole)) {
+		return (
+			<div className="flex min-h-screen items-center justify-center">
+				<div className="text-center">
+					<h1 className="mb-4 font-bold text-2xl text-gray-800">
+						Acceso Denegado
+					</h1>
+					<p className="text-gray-600">
+						Solo el equipo de cobros puede ver la cola del día.
+					</p>
+				</div>
+			</div>
+		);
+	}
+
+	const data = colaQuery.data as ColaResponse | undefined;
+	const items = data?.items ?? [];
+	const total = data?.total ?? 0;
+	const totalPages = data?.totalPages ?? 1;
+	const sinAsesor = !!data?.sinAsesor;
+	const asesorForzado = data?.asesorForzado ?? null;
+
+	const asesores = (
+		(asesoresQuery.data as { asesores?: AsesorOption[] } | undefined)
+			?.asesores ?? []
+	).filter((a) => a.activo);
+
+	const cambiarAsesor = (v: string) => {
+		setAsesorSel(v);
+		setPage(1);
+	};
+
+	const cambiarFiltro = (v: string) => {
+		setFiltro(v as Filtro);
+		setPage(1);
+	};
+
+	const cambiarBuckets = (numeros: number[] | null) => {
+		setBucketsSel(numeros);
+		setPage(1);
+	};
+
+	const irAlDetalle = (sifco: string) => {
+		navigate({
+			to: "/cobros/$id",
+			params: { id: sifco },
+			search: { tipo: "caso" },
+		});
+	};
+
+	return (
+		<div className="container mx-auto space-y-4 p-4 lg:p-6">
+			<Card>
+				<CardHeader className="pb-4">
+					<div className="flex flex-wrap items-start justify-between gap-3">
+						<div className="flex items-center gap-3">
+							<div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+								<ClipboardList className="h-5 w-5" />
+							</div>
+							<div>
+								<CardTitle className="text-xl">Cola del día</CardTitle>
+								<CardDescription>
+									Cuentas priorizadas para gestionar hoy: SLA vencido, promesas
+									de pago que vencen hoy, promesas incumplidas y cuentas sin
+									contacto reciente
+									{asesorForzado ? ` · Cola de ${asesorForzado.nombre}` : ""}
+								</CardDescription>
+							</div>
+						</div>
+						<div className="flex items-center gap-2">
+							<Badge variant="secondary">{total} cuentas</Badge>
+							{colaQuery.isFetching && (
+								<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+							)}
+							<BucketMultiSelect
+								buckets={buckets}
+								value={bucketsSel}
+								onChange={cambiarBuckets}
+							/>
+							{esSupervisor && (
+								<Select value={asesorSel} onValueChange={cambiarAsesor}>
+									<SelectTrigger className="h-8 w-52">
+										<UserRound className="mr-1 h-3.5 w-3.5 text-muted-foreground" />
+										<SelectValue placeholder="Asesor" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value="todos">Todos los asesores</SelectItem>
+										{asesoresQuery.isError && (
+											<div className="px-2 py-1.5 text-destructive text-xs">
+												Error al cargar asesores
+											</div>
+										)}
+										{asesores.map((a) => (
+											<SelectItem key={a.asesorId} value={String(a.asesorId)}>
+												{a.nombre}
+											</SelectItem>
+										))}
+									</SelectContent>
+								</Select>
+							)}
+						</div>
+					</div>
+					<div className="flex flex-wrap items-center gap-1.5 pt-3">
+						{FILTROS.map((f) => (
+							<Button
+								key={f.value}
+								type="button"
+								size="sm"
+								variant={filtro === f.value ? "default" : "outline"}
+								className="h-7 rounded-full px-3 text-xs"
+								onClick={() => cambiarFiltro(f.value)}
+							>
+								{f.label}
+							</Button>
+						))}
+					</div>
+				</CardHeader>
+			</Card>
+
+			{colaQuery.isPending && (
+				<div className="flex items-center justify-center py-16">
+					<Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+				</div>
+			)}
+
+			{!colaQuery.isPending && colaQuery.isError && (
+				<Card>
+					<CardContent className="py-10 text-center text-destructive">
+						Error al cargar la cola del día. Intentá recargar la página.
+					</CardContent>
+				</Card>
+			)}
+
+			{!colaQuery.isPending && !colaQuery.isError && sinAsesor && (
+				<Card>
+					<CardContent className="py-10 text-center text-muted-foreground">
+						Tu usuario no está vinculado a un asesor de cartera (por correo).
+						Pedile al supervisor que revise tu correo de asesor.
+					</CardContent>
+				</Card>
+			)}
+
+			{!colaQuery.isPending &&
+				!colaQuery.isError &&
+				!sinAsesor &&
+				total === 0 && (
+					<Card>
+						<CardContent className="py-10 text-center text-muted-foreground">
+							Sin cuentas pendientes en la cola de hoy. 🎉
+						</CardContent>
+					</Card>
+				)}
+
+			{!colaQuery.isPending &&
+				!colaQuery.isError &&
+				!sinAsesor &&
+				total > 0 && (
+					<Card>
+						<CardContent className="pt-6">
+							<div className="overflow-x-auto">
+								<Table>
+									<TableHeader>
+										<TableRow>
+											<TableHead>Cliente</TableHead>
+											<TableHead>Bucket</TableHead>
+											<TableHead>Crédito</TableHead>
+											<TableHead>Categoría</TableHead>
+											<TableHead>Límite SLA</TableHead>
+											<TableHead>Promesa</TableHead>
+											<TableHead>Teléfono</TableHead>
+											{esSupervisor && asesorSel === "todos" && (
+												<TableHead>Asesor</TableHead>
+											)}
+										</TableRow>
+									</TableHeader>
+									<TableBody>
+										{items.map((item) => (
+											<TableRow
+												key={item.creditoId}
+												className="cursor-pointer"
+												onClick={() => irAlDetalle(item.numeroCreditoSifco)}
+											>
+												<TableCell className="font-medium">
+													{item.cliente}
+												</TableCell>
+												<TableCell>
+													<BucketBadge
+														numero={item.bucket}
+														catalogo={bucketsCatalogo.data}
+													/>
+												</TableCell>
+												<TableCell className="max-w-45 truncate font-mono text-muted-foreground text-xs">
+													{item.numeroCreditoSifco}
+												</TableCell>
+												<TableCell>
+													<CategoriaBadges item={item} />
+												</TableCell>
+												<TableCell className="text-sm">
+													{fechaLegible(item.fechaLimiteSla)}
+												</TableCell>
+												<TableCell className="text-sm">
+													{fechaLegible(item.fechaPromesa)}
+												</TableCell>
+												<TableCell>
+													{item.telefono ? (
+														<span className="inline-flex items-center gap-1 text-sm">
+															<Phone className="h-3 w-3 text-muted-foreground" />
+															{item.telefono}
+														</span>
+													) : (
+														<span className="text-muted-foreground text-xs">
+															Sin teléfono
+														</span>
+													)}
+												</TableCell>
+												{esSupervisor && asesorSel === "todos" && (
+													<TableCell className="text-sm">
+														{item.asesor}
+													</TableCell>
+												)}
+											</TableRow>
+										))}
+									</TableBody>
+								</Table>
+							</div>
+
+							{totalPages > 1 && (
+								<div className="flex items-center justify-between pt-3">
+									<span className="text-muted-foreground text-xs">
+										Mostrando {items.length} de {total} · página {page} de{" "}
+										{totalPages}
+									</span>
+									<div className="flex items-center gap-1">
+										<Button
+											variant="outline"
+											size="sm"
+											className="h-8"
+											disabled={page <= 1 || colaQuery.isFetching}
+											onClick={() => setPage((p) => p - 1)}
+										>
+											<ChevronLeft className="h-4 w-4" />
+											Anterior
+										</Button>
+										<Button
+											variant="outline"
+											size="sm"
+											className="h-8"
+											disabled={page >= totalPages || colaQuery.isFetching}
+											onClick={() => setPage((p) => p + 1)}
+										>
+											Siguiente
+											<ChevronRight className="h-4 w-4" />
+										</Button>
+									</div>
+								</div>
+							)}
+						</CardContent>
+					</Card>
+				)}
+		</div>
+	);
+}


### PR DESCRIPTION
## Contexto

Última parte de CB-020. El endpoint de cartera-back (#1154) y el router del
CRM server (#1156) ya están mergeados en `COBROS-02`. Este PR es la UI: la
ruta `/cobros/cola`, la vista que el asesor abre para saber qué cuentas
gestionar primero.

## Qué se agregó

### Ruta `apps/web/src/routes/cobros/cola.tsx`
- **Tags clicables** para las 4 categorías (Todos priorizado / SLA vence hoy
  / Promesa vence hoy / Promesa incumplida / +5 días sin contacto) — en vez
  de un dropdown, para que el filtro activo sea visible de un vistazo (pedido
  explícito del usuario tras ver el dropdown en uso).
- **Badges de categoría** por fila: un crédito puede mostrar varias a la vez
  si califica en más de una (ej. SLA hoy + incumplida).
- **Filtro por bucket** (multi-select B1-B5 — B0 nunca aplica SLA) vía el
  nuevo componente `BucketMultiSelect`, mismo patrón que `AsesorMultiSelect`
  ya existente (checkboxes en popover, "seleccionar/deseleccionar todos", 0
  marcados = sin filtro).
- **Selector de asesor** (solo supervisor/admin) — el rol `cobros` ve
  automáticamente solo su propia cola (igual que Agenda del día).
- **Spinner de refetch** (`isFetching`) además del de carga inicial, para
  feedback claro al cambiar cualquier filtro.
- **Manejo de `isError`** explícito (cola y lista de asesores) — gap
  detectado en code review propio: antes, si el fetch fallaba, la UI se
  quedaba en un estado ambiguo sin avisar.
- Link en el nav de Cobros (desktop + mobile), junto a Agenda del día.

## Decisiones de diseño confirmadas con el usuario durante el desarrollo
- Tags exclusivos (uno a la vez), no multi-select de categorías.
- Filtro de bucket sí es multi-select (puede ver varios buckets juntos).
- "Deseleccionar todos" en el bucket multi-select para no tener que
  desmarcar uno por uno antes de elegir solo uno.

## Qué NO incluye este PR
- El endpoint de cartera-back (#1154, mergeado).
- El router/lógica de clasificación del CRM server (#1156, mergeado).

## Test plan
- [x] Verificado en dev con datos de prueba reales: crédito con promesa
  vencida hoy aparece bajo "Promesa vence hoy"; filtro de bucket B1 filtra
  correctamente contra el universo real de cartera-back; rol cobros ve solo
  su propia cola.
- [ ] `bun dev:web`, abrir `/cobros/cola`, confirmar visualmente con el
  usuario:
  - [ ] Tags cambian de categoría y resaltan la activa.
  - [ ] Bucket multi-select filtra bien (probar "todos", "solo B1",
    "deseleccionar todos + marcar uno").
  - [ ] Paginación funciona con `keepPreviousData` (no parpadea a vacío).
  - [ ] Estado de error visible si se simula una falla del backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>