### PR TITLE
hotfix(crm): scope credit analysis by opportunity

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0027_add_credit_analysis_opportunity.integration.test.ts
+++ b/apps/crm/apps/server/src/db/migrations/0027_add_credit_analysis_opportunity.integration.test.ts
@@ -1,0 +1,203 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { Client, type ClientConfig } from "pg";
+
+const testDatabaseUrl = process.env.TEST_DATABASE_URL;
+const migrationFile = new URL(
+	"./0027_add_credit_analysis_opportunity.sql",
+	import.meta.url,
+);
+
+export function createSafeTestDatabaseConfig(databaseUrl: string): ClientConfig {
+	const url = new URL(databaseUrl);
+	const loopbackHosts = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+	if (
+		!loopbackHosts.has(url.hostname) ||
+		url.pathname !== "/crm_credit_analysis_test" ||
+		url.search ||
+		url.hash
+	) {
+		throw new Error(
+			"TEST_DATABASE_URL debe apuntar a un host loopback y a crm_credit_analysis_test",
+		);
+	}
+
+	return {
+		host: url.hostname,
+		port: url.port ? Number(url.port) : 5432,
+		user: decodeURIComponent(url.username),
+		password: decodeURIComponent(url.password),
+		database: "crm_credit_analysis_test",
+	};
+}
+
+test("rejects a query host override before any migration client can connect", () => {
+	expect(() =>
+		createSafeTestDatabaseConfig(
+			"postgres://postgres:postgres@localhost/crm_credit_analysis_test?host=203.0.113.1",
+		),
+	).toThrow(
+		"TEST_DATABASE_URL debe apuntar a un host loopback y a crm_credit_analysis_test",
+	);
+});
+
+test("rejects direct non-loopback hosts and wrong database names", () => {
+	for (const databaseUrl of [
+		"postgres://postgres:postgres@203.0.113.1/crm_credit_analysis_test",
+		"postgres://postgres:postgres@localhost/crm_credit_analysis_other",
+	]) {
+		expect(() => createSafeTestDatabaseConfig(databaseUrl)).toThrow(
+			"TEST_DATABASE_URL debe apuntar a un host loopback y a crm_credit_analysis_test",
+		);
+	}
+});
+
+if (!testDatabaseUrl) {
+	describe.skip("0027_add_credit_analysis_opportunity migration", () => {
+		test("requires TEST_DATABASE_URL", () => {});
+	});
+} else {
+	const clientConfig = createSafeTestDatabaseConfig(testDatabaseUrl);
+
+	describe("0027_add_credit_analysis_opportunity migration", () => {
+		const client = new Client(clientConfig);
+
+		beforeAll(async () => {
+			const migration = await Bun.file(migrationFile).text();
+			await client.connect();
+			await client.query('DROP TABLE IF EXISTS "credit_analysis"');
+			await client.query('DROP TABLE IF EXISTS "opportunities"');
+			await client.query('DROP TABLE IF EXISTS "leads"');
+			await client.query('CREATE TABLE "leads" ("id" uuid PRIMARY KEY)');
+			await client.query(
+				'CREATE TABLE "opportunities" ("id" uuid PRIMARY KEY, "lead_id" uuid)',
+			);
+			await client.query(`
+				CREATE TABLE "credit_analysis" (
+					"id" uuid PRIMARY KEY,
+					"lead_id" uuid,
+					"co_debtor_id" uuid,
+					"monthly_fixed_income" numeric(12, 2),
+					"full_analysis" text,
+					CONSTRAINT "credit_analysis_lead_id_unique" UNIQUE("lead_id")
+				)
+			`);
+			await client.query(`
+				INSERT INTO "leads" ("id") VALUES
+					('00000000-0000-0000-0000-000000000001'),
+					('00000000-0000-0000-0000-000000000002'),
+					('00000000-0000-0000-0000-000000000003'),
+					('00000000-0000-0000-0000-000000000004')
+			`);
+			await client.query(`
+				INSERT INTO "opportunities" ("id", "lead_id") VALUES
+					('10000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001'),
+					('10000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000002'),
+					('10000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000002'),
+					('10000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000004')
+			`);
+			await client.query(`
+				INSERT INTO "credit_analysis" ("id", "lead_id", "co_debtor_id", "monthly_fixed_income", "full_analysis") VALUES
+					('20000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000001', NULL, 1250.50, '{"preserve":true}'),
+					('20000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000002', NULL, 800.00, '{"ambiguous":true}'),
+					('20000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000003', NULL, 700.00, '{"zero":true}'),
+					('20000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000004', '30000000-0000-0000-0000-000000000001', 900.00, '{"coDebtor":true}')
+			`);
+			await client.query(migration);
+		});
+
+		afterAll(async () => {
+			await client.query('DROP TABLE IF EXISTS "credit_analysis"');
+			await client.query('DROP TABLE IF EXISTS "opportunities"');
+			await client.query('DROP TABLE IF EXISTS "leads"');
+			await client.end();
+		});
+
+		test("preserves rows and only backfills an unambiguous lead analysis", async () => {
+			const result = await client.query<{
+				id: string;
+				lead_id: string | null;
+				co_debtor_id: string | null;
+				opportunity_id: string | null;
+				monthly_fixed_income: string;
+				full_analysis: string;
+			}>(`
+				SELECT "id", "lead_id", "co_debtor_id", "opportunity_id", "monthly_fixed_income", "full_analysis"
+				FROM "credit_analysis"
+				ORDER BY "id"
+			`);
+
+			expect(result.rows).toEqual([
+				{
+					id: "20000000-0000-0000-0000-000000000001",
+					lead_id: "00000000-0000-0000-0000-000000000001",
+					co_debtor_id: null,
+					opportunity_id: "10000000-0000-0000-0000-000000000001",
+					monthly_fixed_income: "1250.50",
+					full_analysis: '{"preserve":true}',
+				},
+				{
+					id: "20000000-0000-0000-0000-000000000002",
+					lead_id: "00000000-0000-0000-0000-000000000002",
+					co_debtor_id: null,
+					opportunity_id: null,
+					monthly_fixed_income: "800.00",
+					full_analysis: '{"ambiguous":true}',
+				},
+				{
+					id: "20000000-0000-0000-0000-000000000003",
+					lead_id: "00000000-0000-0000-0000-000000000003",
+					co_debtor_id: null,
+					opportunity_id: null,
+					monthly_fixed_income: "700.00",
+					full_analysis: '{"zero":true}',
+				},
+				{
+					id: "20000000-0000-0000-0000-000000000004",
+					lead_id: "00000000-0000-0000-0000-000000000004",
+					co_debtor_id: "30000000-0000-0000-0000-000000000001",
+					opportunity_id: null,
+					monthly_fixed_income: "900.00",
+					full_analysis: '{"coDebtor":true}',
+				},
+			]);
+		});
+
+		test("removes the legacy lead constraint and allows separate opportunity analyses", async () => {
+			await client.query(`
+				INSERT INTO "credit_analysis" ("id", "lead_id", "opportunity_id") VALUES
+					('20000000-0000-0000-0000-000000000005', '00000000-0000-0000-0000-000000000002', NULL),
+					('20000000-0000-0000-0000-000000000006', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000002'),
+					('20000000-0000-0000-0000-000000000007', '00000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000003')
+			`);
+
+			const result = await client.query<{ count: string }>(
+				`SELECT count(*) FROM "credit_analysis" WHERE "lead_id" = '00000000-0000-0000-0000-000000000002'`,
+			);
+			expect(result.rows[0]?.count).toBe("4");
+		});
+
+		test("rejects duplicate and unknown opportunities and nulls history on opportunity deletion", async () => {
+			await expect(
+				client.query(`
+					INSERT INTO "credit_analysis" ("id", "opportunity_id")
+					VALUES ('20000000-0000-0000-0000-000000000008', '10000000-0000-0000-0000-000000000002')
+				`),
+			).rejects.toThrow();
+			await expect(
+				client.query(`
+					INSERT INTO "credit_analysis" ("id", "opportunity_id")
+					VALUES ('20000000-0000-0000-0000-000000000009', '99999999-0000-0000-0000-000000000009')
+				`),
+			).rejects.toThrow();
+
+			await client.query(
+				`DELETE FROM "opportunities" WHERE "id" = '10000000-0000-0000-0000-000000000001'`,
+			);
+			const result = await client.query<{ opportunity_id: string | null }>(
+				`SELECT "opportunity_id" FROM "credit_analysis" WHERE "id" = '20000000-0000-0000-0000-000000000001'`,
+			);
+			expect(result.rows[0]?.opportunity_id).toBeNull();
+		});
+	});
+}

--- a/apps/crm/apps/server/src/db/migrations/0027_add_credit_analysis_opportunity.sql
+++ b/apps/crm/apps/server/src/db/migrations/0027_add_credit_analysis_opportunity.sql
@@ -1,0 +1,25 @@
+ALTER TABLE "credit_analysis" ADD COLUMN "opportunity_id" uuid;
+--> statement-breakpoint
+ALTER TABLE "credit_analysis" DROP CONSTRAINT IF EXISTS "credit_analysis_lead_id_unique";
+--> statement-breakpoint
+ALTER TABLE "credit_analysis"
+	ADD CONSTRAINT "credit_analysis_opportunity_id_opportunities_id_fk"
+	FOREIGN KEY ("opportunity_id") REFERENCES "public"."opportunities"("id") ON DELETE SET NULL ON UPDATE NO ACTION;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "credit_analysis_opportunity_id_unique"
+	ON "credit_analysis" USING btree ("opportunity_id")
+	WHERE "opportunity_id" IS NOT NULL;
+--> statement-breakpoint
+UPDATE "credit_analysis" AS "analysis"
+SET "opportunity_id" = "opportunity"."id"
+FROM "opportunities" AS "opportunity"
+WHERE "analysis"."co_debtor_id" IS NULL
+	AND "opportunity"."lead_id" = "analysis"."lead_id"
+	AND (
+		SELECT count(*)
+		FROM "opportunities" AS "candidate"
+		WHERE "candidate"."lead_id" = "analysis"."lead_id"
+	) = 1;
+
+-- Resolución manual: los análisis de leads sin oportunidades o con varias permanecen en NULL.
+-- Vincúlelos solo tras confirmar la oportunidad correcta; no infiera por fechas, montos ni orden.

--- a/apps/crm/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/crm/apps/server/src/db/migrations/meta/_journal.json
@@ -99,6 +99,13 @@
 			"when": 1773705600000,
 			"tag": "0018_add_campaign_tracking",
 			"breakpoints": true
+		},
+		{
+			"idx": 14,
+			"version": "7",
+			"when": 1784839926000,
+			"tag": "0027_add_credit_analysis_opportunity",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/crm/apps/server/src/db/schema/crm-credit-analysis-opportunity.test.ts
+++ b/apps/crm/apps/server/src/db/schema/crm-credit-analysis-opportunity.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { createTableRelationsHelpers } from "drizzle-orm";
+import { getTableConfig, PgDialect } from "drizzle-orm/pg-core";
+import {
+	creditAnalysis,
+	creditAnalysisRelations,
+	opportunities,
+	opportunitiesRelations,
+} from "./crm";
+
+describe("credit_analysis opportunity linkage", () => {
+	test("declares a nullable opportunity FK that preserves historical analyses", () => {
+		const foreignKeys = getTableConfig(creditAnalysis).foreignKeys;
+		const opportunityForeignKey = foreignKeys.find(
+			(foreignKey) =>
+				foreignKey.reference().foreignTable === opportunities,
+		);
+
+		expect(creditAnalysis.opportunityId.notNull).toBe(false);
+		expect(opportunityForeignKey?.onDelete).toBe("set null");
+	});
+
+	test("declares one non-null analysis per opportunity", () => {
+		const indexes = getTableConfig(creditAnalysis).indexes;
+		const opportunityIndex = indexes.find(
+			(index) => index.config.name === "credit_analysis_opportunity_id_unique",
+		);
+
+		expect(opportunityIndex?.config.unique).toBe(true);
+		expect(opportunityIndex?.config.columns).toMatchObject([
+			{ name: creditAnalysis.opportunityId.name },
+		]);
+		if (!opportunityIndex?.config.where) {
+			throw new Error("El índice debe tener un predicado parcial");
+		}
+		expect(
+			new PgDialect().sqlToQuery(opportunityIndex.config.where).sql,
+		).toBe('"credit_analysis"."opportunity_id" IS NOT NULL');
+	});
+
+	test("maps the opportunity relation in both directions", () => {
+		const creditAnalysisRelationsConfig = creditAnalysisRelations.config(
+			createTableRelationsHelpers(creditAnalysis),
+		);
+		const opportunitiesRelationsConfig = opportunitiesRelations.config(
+			createTableRelationsHelpers(opportunities),
+		);
+
+		expect(creditAnalysisRelationsConfig.opportunity.referencedTable).toBe(
+			opportunities,
+		);
+		expect(creditAnalysisRelationsConfig.opportunity.config).toMatchObject({
+			fields: [creditAnalysis.opportunityId],
+			references: [opportunities.id],
+		});
+		expect(
+			opportunitiesRelationsConfig.creditAnalyses.referencedTable,
+		).toBe(creditAnalysis);
+		expect(
+			opportunitiesRelationsConfig.creditAnalyses.constructor.name,
+		).toBe("One");
+	});
+});

--- a/apps/crm/apps/server/src/db/schema/crm.ts
+++ b/apps/crm/apps/server/src/db/schema/crm.ts
@@ -1,3 +1,4 @@
+import { relations, sql } from "drizzle-orm";
 import {
 	boolean,
 	decimal,
@@ -7,6 +8,7 @@ import {
 	pgTable,
 	text,
 	timestamp,
+	uniqueIndex,
 	uuid,
 } from "drizzle-orm/pg-core";
 import { user } from "./auth";
@@ -242,53 +244,64 @@ export const coDebtors = pgTable("co_debtors", {
 });
 
 // Credit Analysis table - Análisis de capacidad de pago
-export const creditAnalysis = pgTable("credit_analysis", {
-	id: uuid("id").primaryKey().defaultRandom(),
-	// El análisis puede ser de un lead O de un co-deudor (uno de los dos debe estar presente)
-	leadId: uuid("lead_id").references(() => leads.id),
-	coDebtorId: uuid("co_debtor_id").references(() => coDebtors.id),
-	// Resumen de análisis completo (JSON)
-	fullAnalysis: text("full_analysis"), // JSON string with complete bank analysis
-	// Promedios mensuales
-	monthlyFixedIncome: decimal("monthly_fixed_income", {
-		precision: 12,
-		scale: 2,
-	}),
-	monthlyVariableIncome: decimal("monthly_variable_income", {
-		precision: 12,
-		scale: 2,
-	}),
-	monthlyFixedExpenses: decimal("monthly_fixed_expenses", {
-		precision: 12,
-		scale: 2,
-	}),
-	monthlyVariableExpenses: decimal("monthly_variable_expenses", {
-		precision: 12,
-		scale: 2,
-	}),
-	economicAvailability: decimal("economic_availability", {
-		precision: 12,
-		scale: 2,
-	}),
-	// Cálculos de capacidad de pago
-	minPayment: decimal("min_payment", { precision: 12, scale: 2 }),
-	maxPayment: decimal("max_payment", { precision: 12, scale: 2 }),
-	adjustedPayment: decimal("adjusted_payment", { precision: 12, scale: 2 }),
-	maxCreditAmount: decimal("max_credit_amount", { precision: 12, scale: 2 }),
-	// Hasta 3 fechas ideales de pago sugeridas por la IA, rankeadas con % de recomendación
-	suggestedPaymentDays: jsonb("suggested_payment_days").$type<
-		Array<{ dia: number; porcentaje: number }>
-	>(),
-	// Control de intentos de análisis con IA (cada llamada a IA cuesta dinero)
-	attemptCount: integer("attempt_count").notNull().default(0), // Se incrementa al llamar a la IA
-	// Metadata
-	analyzedAt: timestamp("analyzed_at"), // null hasta que haya un análisis exitoso
-	createdAt: timestamp("created_at").notNull().defaultNow(),
-	updatedAt: timestamp("updated_at").notNull().defaultNow(),
-	createdBy: text("created_by")
-		.notNull()
-		.references(() => user.id),
-});
+export const creditAnalysis = pgTable(
+	"credit_analysis",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		// El análisis puede ser de un lead O de un co-deudor (uno de los dos debe estar presente)
+		leadId: uuid("lead_id").references(() => leads.id),
+		coDebtorId: uuid("co_debtor_id").references(() => coDebtors.id),
+		opportunityId: uuid("opportunity_id").references(() => opportunities.id, {
+			onDelete: "set null",
+		}),
+		// Resumen de análisis completo (JSON)
+		fullAnalysis: text("full_analysis"), // JSON string with complete bank analysis
+		// Promedios mensuales
+		monthlyFixedIncome: decimal("monthly_fixed_income", {
+			precision: 12,
+			scale: 2,
+		}),
+		monthlyVariableIncome: decimal("monthly_variable_income", {
+			precision: 12,
+			scale: 2,
+		}),
+		monthlyFixedExpenses: decimal("monthly_fixed_expenses", {
+			precision: 12,
+			scale: 2,
+		}),
+		monthlyVariableExpenses: decimal("monthly_variable_expenses", {
+			precision: 12,
+			scale: 2,
+		}),
+		economicAvailability: decimal("economic_availability", {
+			precision: 12,
+			scale: 2,
+		}),
+		// Cálculos de capacidad de pago
+		minPayment: decimal("min_payment", { precision: 12, scale: 2 }),
+		maxPayment: decimal("max_payment", { precision: 12, scale: 2 }),
+		adjustedPayment: decimal("adjusted_payment", { precision: 12, scale: 2 }),
+		maxCreditAmount: decimal("max_credit_amount", { precision: 12, scale: 2 }),
+		// Hasta 3 fechas ideales de pago sugeridas por la IA, rankeadas con % de recomendación
+		suggestedPaymentDays: jsonb("suggested_payment_days").$type<
+			Array<{ dia: number; porcentaje: number }>
+		>(),
+		// Control de intentos de análisis con IA (cada llamada a IA cuesta dinero)
+		attemptCount: integer("attempt_count").notNull().default(0), // Se incrementa al llamar a la IA
+		// Metadata
+		analyzedAt: timestamp("analyzed_at"), // null hasta que haya un análisis exitoso
+		createdAt: timestamp("created_at").notNull().defaultNow(),
+		updatedAt: timestamp("updated_at").notNull().defaultNow(),
+		createdBy: text("created_by")
+			.notNull()
+			.references(() => user.id),
+	},
+	(table) => [
+		uniqueIndex("credit_analysis_opportunity_id_unique")
+			.on(table.opportunityId)
+			.where(sql`${table.opportunityId} IS NOT NULL`),
+	],
+);
 
 // Opportunities table
 export const opportunities = pgTable("opportunities", {
@@ -391,6 +404,25 @@ export const opportunities = pgTable("opportunities", {
 		.notNull()
 		.references(() => user.id),
 });
+
+export const creditAnalysisRelations = relations(creditAnalysis, ({ one }) => ({
+	lead: one(leads, {
+		fields: [creditAnalysis.leadId],
+		references: [leads.id],
+	}),
+	coDebtor: one(coDebtors, {
+		fields: [creditAnalysis.coDebtorId],
+		references: [coDebtors.id],
+	}),
+	opportunity: one(opportunities, {
+		fields: [creditAnalysis.opportunityId],
+		references: [opportunities.id],
+	}),
+}));
+
+export const opportunitiesRelations = relations(opportunities, ({ one }) => ({
+	creditAnalyses: one(creditAnalysis),
+}));
 
 // Clients table
 export const clients = pgTable("clients", {

--- a/apps/crm/apps/server/src/lib/analysis-checklist.ts
+++ b/apps/crm/apps/server/src/lib/analysis-checklist.ts
@@ -81,6 +81,7 @@ function carryForwardVerificationItems(
 
 	for (const nextItem of nextItems ?? []) {
 		if (!nextItem.type) continue;
+		if (nextItem.type === "capacidad_pago") continue;
 
 		const previousItem = previousByType.get(nextItem.type);
 		if (!previousItem) continue;

--- a/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
+++ b/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
@@ -114,6 +114,34 @@ describe("credit analysis ownership", () => {
 		expect(analysisReadIndex).toBeGreaterThan(permissionCheckIndex);
 	});
 
+	test("authorizes reading manual analysis by opportunity owner instead of lead owner", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/crm.ts"),
+			"utf8",
+		);
+		const handler = source.slice(
+			source.indexOf("getCreditAnalysisByLeadId: crmProcedure"),
+			source.indexOf("upsertCreditAnalysis: crmProcedure"),
+		);
+
+		expect(handler).not.toContain("lead[0].assignedTo !== context.userId");
+		expect(handler).toContain("opportunity.assignedTo");
+	});
+
+	test("authorizes saving manual analysis by opportunity owner instead of lead owner", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/crm.ts"),
+			"utf8",
+		);
+		const handler = source.slice(
+			source.indexOf("upsertCreditAnalysis: crmProcedure"),
+			source.indexOf("resetCreditAnalysis: crmProcedure"),
+		);
+
+		expect(handler).not.toContain("lead[0].assignedTo !== context.userId");
+		expect(handler).toContain("opportunity.assignedTo");
+	});
+
 	test("checks opportunity ownership before bank analysis side effects", () => {
 		const source = readFileSync(
 			join(import.meta.dir, "../routers/bank-analysis.ts"),

--- a/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
+++ b/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { PgDialect } from "drizzle-orm/pg-core";
+import {
+	assertOpportunityBelongsToLead,
+	getCreditAnalysisOwnerCondition,
+	getCreditAnalysisResourceId,
+} from "./credit-analysis-ownership";
+
+const dialect = new PgDialect();
+
+function conditionSql(
+	owner:
+		| { leadId: string; opportunityId: string }
+		| { coDebtorId: string },
+) {
+	return dialect.sqlToQuery(getCreditAnalysisOwnerCondition(owner));
+}
+
+describe("credit analysis ownership", () => {
+	test("opportunity A analysis cannot satisfy opportunity B", () => {
+		const opportunityA = conditionSql({
+			leadId: "00000000-0000-0000-0000-000000000001",
+			opportunityId: "10000000-0000-0000-0000-000000000001",
+		});
+		const opportunityB = conditionSql({
+			leadId: "00000000-0000-0000-0000-000000000001",
+			opportunityId: "10000000-0000-0000-0000-000000000002",
+		});
+
+		expect(opportunityA.sql).toContain('"credit_analysis"."opportunity_id"');
+		expect(opportunityA.params).toEqual([
+			"10000000-0000-0000-0000-000000000001",
+		]);
+		expect(opportunityB.params).toEqual([
+			"10000000-0000-0000-0000-000000000002",
+		]);
+	});
+
+	test("create and reset scope opportunity B without targeting A", () => {
+		const opportunityB = {
+			leadId: "00000000-0000-0000-0000-000000000001",
+			opportunityId: "10000000-0000-0000-0000-000000000002",
+		};
+
+		expect(conditionSql(opportunityB).params).toEqual([
+			opportunityB.opportunityId,
+		]);
+		expect(getCreditAnalysisResourceId(opportunityB)).toBe(
+			opportunityB.opportunityId,
+		);
+	});
+
+	test("rejects an opportunity owned by another lead", () => {
+		expect(() =>
+			assertOpportunityBelongsToLead(
+				{ leadId: "00000000-0000-0000-0000-000000000002" },
+				"00000000-0000-0000-0000-000000000001",
+			),
+		).toThrow("La oportunidad no pertenece al lead analizado");
+	});
+
+	test("keeps co-debtor analysis scoped by coDebtorId", () => {
+		const coDebtorId = "30000000-0000-0000-0000-000000000001";
+		const condition = conditionSql({ coDebtorId });
+
+		expect(condition.sql).toContain('"credit_analysis"."co_debtor_id"');
+		expect(condition.params).toEqual([coDebtorId]);
+		expect(getCreditAnalysisResourceId({ coDebtorId })).toBe(coDebtorId);
+	});
+});

--- a/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
+++ b/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { PgDialect } from "drizzle-orm/pg-core";
 import {
 	assertOpportunityBelongsToLead,
+	canWriteOpportunityCreditAnalysis,
 	getCreditAnalysisOwnerCondition,
 	getCreditAnalysisResourceId,
 } from "./credit-analysis-ownership";
@@ -57,6 +58,36 @@ describe("credit analysis ownership", () => {
 				"00000000-0000-0000-0000-000000000001",
 			),
 		).toThrow("La oportunidad no pertenece al lead analizado");
+	});
+
+	test("requires sales ownership of the opportunity without restricting supervisors or admins", () => {
+		const salesUserId = "00000000-0000-0000-0000-000000000001";
+		const otherSalesUserId = "00000000-0000-0000-0000-000000000002";
+
+		expect(
+			canWriteOpportunityCreditAnalysis(
+				"sales",
+				salesUserId,
+				otherSalesUserId,
+			),
+		).toBe(false);
+		expect(
+			canWriteOpportunityCreditAnalysis("sales", salesUserId, salesUserId),
+		).toBe(true);
+		expect(
+			canWriteOpportunityCreditAnalysis(
+				"sales_supervisor",
+				salesUserId,
+				otherSalesUserId,
+			),
+		).toBe(true);
+		expect(
+			canWriteOpportunityCreditAnalysis(
+				"admin",
+				salesUserId,
+				otherSalesUserId,
+			),
+		).toBe(true);
 	});
 
 	test("keeps co-debtor analysis scoped by coDebtorId", () => {

--- a/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
+++ b/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { PgDialect } from "drizzle-orm/pg-core";
 import {
 	assertOpportunityBelongsToLead,
@@ -88,6 +90,46 @@ describe("credit analysis ownership", () => {
 				otherSalesUserId,
 			),
 		).toBe(true);
+	});
+
+	test("checks opportunity ownership before returning opportunity analysis", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/crm.ts"),
+			"utf8",
+		);
+		const readHandler = source.slice(
+			source.indexOf("getCreditAnalysisByLeadId: crmProcedure"),
+			source.indexOf("upsertCreditAnalysis: crmProcedure"),
+		);
+		const assignedToIndex = readHandler.indexOf(
+			"assignedTo: opportunities.assignedTo",
+		);
+		const permissionCheckIndex = readHandler.indexOf(
+			"!canWriteOpportunityCreditAnalysis(",
+		);
+		const analysisReadIndex = readHandler.indexOf(".from(creditAnalysis)");
+
+		expect(assignedToIndex).toBeGreaterThan(-1);
+		expect(permissionCheckIndex).toBeGreaterThan(assignedToIndex);
+		expect(analysisReadIndex).toBeGreaterThan(permissionCheckIndex);
+	});
+
+	test("checks opportunity ownership before bank analysis side effects", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/bank-analysis.ts"),
+			"utf8",
+		);
+		const permissionCheckIndex = source.indexOf(
+			"!canWriteOpportunityCreditAnalysis(",
+		);
+		const uploadReadIndex = source.indexOf("verifyUploadedDocumentInR2({");
+		const attemptWriteIndex = source.indexOf(".update(creditAnalysis)");
+		const aiCallIndex = source.indexOf("const result = await generateObject({");
+
+		expect(permissionCheckIndex).toBeGreaterThan(-1);
+		expect(uploadReadIndex).toBeGreaterThan(permissionCheckIndex);
+		expect(attemptWriteIndex).toBeGreaterThan(permissionCheckIndex);
+		expect(aiCallIndex).toBeGreaterThan(permissionCheckIndex);
 	});
 
 	test("keeps co-debtor analysis scoped by coDebtorId", () => {

--- a/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
+++ b/apps/crm/apps/server/src/lib/credit-analysis-ownership.test.ts
@@ -132,6 +132,24 @@ describe("credit analysis ownership", () => {
 		expect(aiCallIndex).toBeGreaterThan(permissionCheckIndex);
 	});
 
+	test("authorizes lead bank analysis by opportunity owner instead of lead owner", () => {
+		const source = readFileSync(
+			join(import.meta.dir, "../routers/bank-analysis.ts"),
+			"utf8",
+		);
+		const handler = source.slice(source.indexOf("analyzeBankStatements:"));
+
+		expect(handler).not.toContain(
+			"lead[0].assignedTo !== context.userId",
+		);
+		expect(handler.indexOf(".from(leads)")).toBeLessThan(
+			handler.indexOf(".from(opportunities)"),
+		);
+		expect(handler.indexOf("!canWriteOpportunityCreditAnalysis(")).toBeLessThan(
+			handler.indexOf("verifyUploadedDocumentInR2({"),
+		);
+	});
+
 	test("keeps co-debtor analysis scoped by coDebtorId", () => {
 		const coDebtorId = "30000000-0000-0000-0000-000000000001";
 		const condition = conditionSql({ coDebtorId });

--- a/apps/crm/apps/server/src/lib/credit-analysis-ownership.ts
+++ b/apps/crm/apps/server/src/lib/credit-analysis-ownership.ts
@@ -1,0 +1,27 @@
+import { eq, type SQL } from "drizzle-orm";
+import { creditAnalysis } from "../db/schema/crm";
+
+export type CreditAnalysisOwner =
+	| { leadId: string; opportunityId: string }
+	| { coDebtorId: string };
+
+export function getCreditAnalysisOwnerCondition(
+	owner: CreditAnalysisOwner,
+): SQL {
+	return "opportunityId" in owner
+		? eq(creditAnalysis.opportunityId, owner.opportunityId)
+		: eq(creditAnalysis.coDebtorId, owner.coDebtorId);
+}
+
+export function getCreditAnalysisResourceId(owner: CreditAnalysisOwner): string {
+	return "opportunityId" in owner ? owner.opportunityId : owner.coDebtorId;
+}
+
+export function assertOpportunityBelongsToLead(
+	opportunity: { leadId: string | null },
+	leadId: string,
+): void {
+	if (opportunity.leadId !== leadId) {
+		throw new Error("La oportunidad no pertenece al lead analizado");
+	}
+}

--- a/apps/crm/apps/server/src/lib/credit-analysis-ownership.ts
+++ b/apps/crm/apps/server/src/lib/credit-analysis-ownership.ts
@@ -25,3 +25,11 @@ export function assertOpportunityBelongsToLead(
 		throw new Error("La oportunidad no pertenece al lead analizado");
 	}
 }
+
+export function canWriteOpportunityCreditAnalysis(
+	userRole: string,
+	userId: string,
+	assignedTo: string | null,
+): boolean {
+	return userRole !== "sales" || assignedTo === userId;
+}

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -20,6 +20,11 @@ import {
 	getBankStatementOpportunityDocumentType,
 } from "../lib/bank-statement-documents";
 import { updateChecklistForClientDocument } from "../lib/checklist";
+import {
+	assertOpportunityBelongsToLead,
+	getCreditAnalysisOwnerCondition,
+	getCreditAnalysisResourceId,
+} from "../lib/credit-analysis-ownership";
 import { calculateCreditCapacity } from "../lib/financial-math";
 import { crmProcedure } from "../lib/orpc";
 import {
@@ -60,11 +65,20 @@ export const bankAnalysisRouter = {
 				})
 				.refine((data) => data.leadId || data.coDebtorId, {
 					message: "Debe proporcionar leadId o coDebtorId",
+				})
+				.refine((data) => !data.leadId || !!data.opportunityId, {
+					message: "Debe proporcionar opportunityId para analizar un lead",
+				})
+				.refine((data) => !(data.leadId && data.coDebtorId), {
+					message: "No puede analizar un lead y un co-deudor a la vez",
 				}),
 		)
 		.handler(async ({ input, context }) => {
 			const isForLead = !!input.leadId;
-			const resourceId = input.leadId || input.coDebtorId!;
+			const owner = isForLead
+				? { leadId: input.leadId!, opportunityId: input.opportunityId! }
+				: { coDebtorId: input.coDebtorId! };
+			const resourceId = getCreditAnalysisResourceId(owner);
 			const expectedPrefix = buildUploadPrefix("bank_statement", resourceId);
 
 			// 1. Verificar que el lead/co-deudor existe y el usuario tiene acceso
@@ -107,7 +121,7 @@ export const bankAnalysisRouter = {
 				| { id: string; vehicleId: string | null }
 				| undefined;
 
-			if (isForLead && input.opportunityId) {
+			if (isForLead) {
 				const [opportunity] = await db
 					.select({
 						id: opportunities.id,
@@ -116,7 +130,7 @@ export const bankAnalysisRouter = {
 						assignedTo: opportunities.assignedTo,
 					})
 					.from(opportunities)
-					.where(eq(opportunities.id, input.opportunityId))
+					.where(eq(opportunities.id, input.opportunityId!))
 					.limit(1);
 
 				if (!opportunity) {
@@ -125,9 +139,11 @@ export const bankAnalysisRouter = {
 					});
 				}
 
-				if (opportunity.leadId !== input.leadId) {
+				try {
+					assertOpportunityBelongsToLead(opportunity, input.leadId!);
+				} catch (error) {
 					throw new ORPCError("BAD_REQUEST", {
-						message: "La oportunidad no pertenece al lead analizado",
+						message: error instanceof Error ? error.message : String(error),
 					});
 				}
 
@@ -185,9 +201,7 @@ export const bankAnalysisRouter = {
 				}
 
 				// 3. Incremento atómico del contador para evitar race conditions
-				const whereCondition = isForLead
-					? eq(creditAnalysis.leadId, input.leadId!)
-					: eq(creditAnalysis.coDebtorId, input.coDebtorId!);
+				const whereCondition = getCreditAnalysisOwnerCondition(owner);
 
 				const updateResult = await db
 					.update(creditAnalysis)
@@ -225,6 +239,7 @@ export const bankAnalysisRouter = {
 						const insertValues = isForLead
 							? {
 									leadId: input.leadId!,
+									opportunityId: input.opportunityId!,
 									attemptCount: 1,
 									createdBy: context.userId,
 								}

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -22,6 +22,7 @@ import {
 import { updateChecklistForClientDocument } from "../lib/checklist";
 import {
 	assertOpportunityBelongsToLead,
+	canWriteOpportunityCreditAnalysis,
 	getCreditAnalysisOwnerCondition,
 	getCreditAnalysisResourceId,
 } from "../lib/credit-analysis-ownership";
@@ -144,6 +145,17 @@ export const bankAnalysisRouter = {
 				} catch (error) {
 					throw new ORPCError("BAD_REQUEST", {
 						message: error instanceof Error ? error.message : String(error),
+					});
+				}
+				if (
+					!canWriteOpportunityCreditAnalysis(
+						context.userRole,
+						context.userId,
+						opportunity.assignedTo,
+					)
+				) {
+					throw new ORPCError("FORBIDDEN", {
+						message: "No tienes permiso para analizar esta oportunidad",
 					});
 				}
 

--- a/apps/crm/apps/server/src/routers/bank-analysis.ts
+++ b/apps/crm/apps/server/src/routers/bank-analysis.ts
@@ -82,7 +82,7 @@ export const bankAnalysisRouter = {
 			const resourceId = getCreditAnalysisResourceId(owner);
 			const expectedPrefix = buildUploadPrefix("bank_statement", resourceId);
 
-			// 1. Verificar que el lead/co-deudor existe y el usuario tiene acceso
+			// 1. Verificar que el lead/co-deudor existe
 			if (isForLead) {
 				const lead = await db
 					.select()
@@ -93,15 +93,6 @@ export const bankAnalysisRouter = {
 				if (lead.length === 0) {
 					throw new ORPCError("NOT_FOUND", {
 						message: "Lead no encontrado",
-					});
-				}
-
-				if (
-					context.userRole === "sales" &&
-					lead[0].assignedTo !== context.userId
-				) {
-					throw new ORPCError("FORBIDDEN", {
-						message: "No tienes permiso para analizar este lead",
 					});
 				}
 			} else {

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -296,6 +296,42 @@ describe("buildCarteraMatchedClientRows", () => {
 		]);
 	});
 
+	test("only returns SIFCO analyses owned by the sales user", () => {
+		const rows = buildCarteraMatchedClientRows({
+			lead,
+			leadOpportunities: [
+				{
+					id: "opp-sales-1",
+					numeroSifco: "SIFCO-1",
+					assignedTo: "sales-1",
+					isClosed: true,
+				},
+				{
+					id: "opp-sales-2",
+					numeroSifco: "SIFCO-2",
+					assignedTo: "sales-2",
+					isClosed: true,
+				},
+			],
+			creditAnalysisByOpportunityId: new Map([
+				["opp-sales-1", { id: "analysis-sales-1" }],
+				["opp-sales-2", { id: "analysis-sales-2" }],
+			]),
+			carteraCreditBySifco: new Map([
+				["SIFCO-1", { creditos: { numero_credito_sifco: "SIFCO-1" } }],
+				["SIFCO-2", { creditos: { numero_credito_sifco: "SIFCO-2" } }],
+			]),
+			opportunityOwnerId: "sales-1",
+		});
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.carteraCredit?.numeroSifco).toBe("SIFCO-1");
+		expect(rows[0]?.creditAnalysis).toEqual({ id: "analysis-sales-1" });
+		expect(rows[0]?.opportunities.map((opportunity) => opportunity.id)).toEqual([
+			"opp-sales-1",
+		]);
+	});
+
 	test("does not assign an analysis when the SIFCO relation is ambiguous", () => {
 		const rows = buildCarteraMatchedClientRows({
 			lead,

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { leadSourceEnum } from "../db/schema/crm";
 import {
 	buildCarteraMatchedClientRows,
@@ -453,5 +455,19 @@ describe("getClientCreditsPageFromCartera", () => {
 
 		expect(received[0]?.nombre_usuario).toBe("Juan");
 		expect(received[0]?.numeros_credito_sifco).toEqual(["X-1", "X-2"]);
+	});
+});
+
+describe("getLeadsAsClientsStats", () => {
+	test("scopes sales stats by opportunity owner without joining leads", () => {
+		const source = readFileSync(join(import.meta.dir, "crm.ts"), "utf8");
+		const handler = source.slice(
+			source.indexOf("getLeadsAsClientsStats: crmProcedure"),
+			source.indexOf("exportClientsForMarketing: crmProcedure"),
+		);
+
+		expect(handler).toContain("eq(opportunities.assignedTo, context.userId)");
+		expect(handler).not.toContain(".leftJoin(leads");
+		expect(handler).not.toContain("eq(leads.assignedTo, context.userId)");
 	});
 });

--- a/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
+++ b/apps/crm/apps/server/src/routers/crm-get-leads-input.test.ts
@@ -166,7 +166,7 @@ describe("buildCarteraMatchedClientRows", () => {
 					isClosed: true,
 				},
 			],
-			creditAnalysis: null,
+			creditAnalysisByOpportunityId: new Map(),
 			carteraCreditBySifco: new Map([
 				[
 					"SIFCO-1",
@@ -207,7 +207,7 @@ describe("buildCarteraMatchedClientRows", () => {
 					isClosed: true,
 				},
 			],
-			creditAnalysis: null,
+			creditAnalysisByOpportunityId: new Map(),
 			carteraCreditBySifco: new Map([
 				[
 					"SIFCO-1",
@@ -241,7 +241,7 @@ describe("buildCarteraMatchedClientRows", () => {
 					isClosed: true,
 				},
 			],
-			creditAnalysis: null,
+			creditAnalysisByOpportunityId: new Map(),
 			carteraCreditBySifco: new Map([
 				[
 					"SIFCO-1",
@@ -269,6 +269,50 @@ describe("buildCarteraMatchedClientRows", () => {
 			"opp-1",
 			"opp-2",
 		]);
+	});
+
+	test("uses the analysis for each opportunity matching the current SIFCO", () => {
+		const analysis1 = { id: "analysis-1", maxPayment: "100.00" };
+		const analysis2 = { id: "analysis-2", maxPayment: "200.00" };
+		const rows = buildCarteraMatchedClientRows({
+			lead,
+			leadOpportunities: [
+				{ id: "opp-1", numeroSifco: "SIFCO-1", isClosed: true },
+				{ id: "opp-2", numeroSifco: "SIFCO-2", isClosed: true },
+			],
+			creditAnalysisByOpportunityId: new Map([
+				["opp-1", analysis1],
+				["opp-2", analysis2],
+			]),
+			carteraCreditBySifco: new Map([
+				["SIFCO-1", { creditos: { numero_credito_sifco: "SIFCO-1" } }],
+				["SIFCO-2", { creditos: { numero_credito_sifco: "SIFCO-2" } }],
+			]),
+		});
+
+		expect(rows.map((row) => row.creditAnalysis)).toEqual([
+			analysis1,
+			analysis2,
+		]);
+	});
+
+	test("does not assign an analysis when the SIFCO relation is ambiguous", () => {
+		const rows = buildCarteraMatchedClientRows({
+			lead,
+			leadOpportunities: [
+				{ id: "opp-1", numeroSifco: "SIFCO-1", isClosed: true },
+				{ id: "opp-2", numeroSifco: "SIFCO-1", isClosed: true },
+			],
+			creditAnalysisByOpportunityId: new Map([
+				["opp-1", { id: "analysis-1" }],
+				["opp-2", { id: "analysis-2" }],
+			]),
+			carteraCreditBySifco: new Map([
+				["SIFCO-1", { creditos: { numero_credito_sifco: "SIFCO-1" } }],
+			]),
+		});
+
+		expect(rows[0]?.creditAnalysis).toBeNull();
 	});
 });
 

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1188,7 +1188,10 @@ export const crmRouter = {
 				}
 
 				const [opportunity] = await db
-					.select({ leadId: opportunities.leadId })
+					.select({
+						leadId: opportunities.leadId,
+						assignedTo: opportunities.assignedTo,
+					})
 					.from(opportunities)
 					.where(eq(opportunities.id, input.opportunityId))
 					.limit(1);
@@ -1202,6 +1205,17 @@ export const crmRouter = {
 				} catch (error) {
 					throw new ORPCError("BAD_REQUEST", {
 						message: error instanceof Error ? error.message : String(error),
+					});
+				}
+				if (
+					!canWriteOpportunityCreditAnalysis(
+						context.userRole,
+						context.userId,
+						opportunity.assignedTo,
+					)
+				) {
+					throw new ORPCError("FORBIDDEN", {
+						message: "No tienes permiso para ver este análisis",
 					});
 				}
 

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -3837,10 +3837,9 @@ export const crmRouter = {
 			const opps = await db
 				.select({ numeroSifco: opportunities.numeroSifco })
 				.from(opportunities)
-				.leftJoin(leads, eq(opportunities.leadId, leads.id))
 				.where(
 					and(
-						eq(leads.assignedTo, context.userId),
+						eq(opportunities.assignedTo, context.userId),
 						isNotNull(opportunities.numeroSifco),
 					),
 				);

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -62,6 +62,7 @@ import {
 } from "../lib/checklist";
 import {
 	assertOpportunityBelongsToLead,
+	canWriteOpportunityCreditAnalysis,
 	getCreditAnalysisOwnerCondition,
 } from "../lib/credit-analysis-ownership";
 import { buildDeletedOpportunitySnapshot } from "../lib/deleted-opportunity-audit";
@@ -1304,7 +1305,10 @@ export const crmRouter = {
 				}
 
 				const [opportunity] = await db
-					.select({ leadId: opportunities.leadId })
+					.select({
+						leadId: opportunities.leadId,
+						assignedTo: opportunities.assignedTo,
+					})
 					.from(opportunities)
 					.where(eq(opportunities.id, opportunityId!))
 					.limit(1);
@@ -1318,6 +1322,17 @@ export const crmRouter = {
 				} catch (error) {
 					throw new ORPCError("BAD_REQUEST", {
 						message: error instanceof Error ? error.message : String(error),
+					});
+				}
+				if (
+					!canWriteOpportunityCreditAnalysis(
+						context.userRole,
+						context.userId,
+						opportunity.assignedTo,
+					)
+				) {
+					throw new ORPCError("FORBIDDEN", {
+						message: "No tienes permiso para actualizar este análisis",
 					});
 				}
 

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -149,6 +149,7 @@ type CarteraClientCredit = {
 type ClientRowOpportunity = {
 	id: string;
 	title?: string;
+	assignedTo?: string | null;
 	value?: string | null;
 	creditType?: string | null;
 	numeroSifco: string | null;
@@ -404,11 +405,18 @@ export function buildCarteraMatchedClientRows(params: {
 	leadOpportunities: ClientRowOpportunity[];
 	creditAnalysisByOpportunityId: ReadonlyMap<string, unknown>;
 	carteraCreditBySifco: Map<string, CarteraClientCredit>;
+	opportunityOwnerId?: string;
 }): MatchedClientRow[] {
 	const rows: MatchedClientRow[] = [];
+	const leadOpportunities = params.opportunityOwnerId
+		? params.leadOpportunities.filter(
+				(opportunity) =>
+					opportunity.assignedTo === params.opportunityOwnerId,
+			)
+		: params.leadOpportunities;
 
 	for (const [sifco, credit] of params.carteraCreditBySifco) {
-		const matchingOpportunities = params.leadOpportunities.filter(
+		const matchingOpportunities = leadOpportunities.filter(
 			(opp) => opp.numeroSifco === sifco,
 		);
 		if (matchingOpportunities.length === 0) continue;
@@ -418,12 +426,12 @@ export function buildCarteraMatchedClientRows(params: {
 		rows.push({
 			...params.lead,
 			rowId: `${params.lead.id}-${sifco}`,
-			opportunities: params.leadOpportunities,
+			opportunities: leadOpportunities,
 			creditAnalysis: matchingOpportunity
 				? (params.creditAnalysisByOpportunityId.get(matchingOpportunity.id) ?? null)
 				: null,
 			totalClosedValue: getCarteraCreditAmount(credit),
-			closedOpportunitiesCount: params.leadOpportunities.filter(
+			closedOpportunitiesCount: leadOpportunities.filter(
 				(opp) => opp.isClosed,
 			).length,
 			crmMatchStatus: "matched",
@@ -3546,6 +3554,10 @@ export const crmRouter = {
 		)
 		.handler(async ({ input, context }) => {
 			const { limit, offset } = input;
+			const opportunityOwnerCondition =
+				context.userRole === "sales"
+					? eq(opportunities.assignedTo, context.userId)
+					: undefined;
 			const searchValue = input.search?.trim();
 			// Solo se busca por nombre o por No. SIFCO (no email ni teléfono). El
 			// filtro lo hace cartera: nombre vía nombre_usuario y, si el término es
@@ -3562,23 +3574,21 @@ export const crmRouter = {
 			// DB local los SIFCOs relevantes y se los pasamos a cartera para que
 			// pagine solo ese subconjunto.
 			//  - leadId: solo los créditos de ese lead (modal de detalle)
-			//  - rol sales: solo los créditos de los leads asignados al asesor
+			//  - rol sales: solo los créditos de las oportunidades asignadas al asesor
 			let scopedSifcos: string[] | undefined;
 			if (input.leadId) {
-				// Un asesor solo puede abrir leads asignados a él: sin este check, un
-				// sales podría pasar ?idLead=<uuid ajeno> y ver datos de un cliente
-				// que no le corresponde. Admin/supervisor pueden ver cualquiera.
+				// Un asesor solo puede abrir las oportunidades asignadas a él.
+				// Admin/supervisor pueden ver cualquiera.
 				const leadConditions = [
 					eq(opportunities.leadId, input.leadId),
 					isNotNull(opportunities.numeroSifco),
 				];
-				if (context.userRole === "sales") {
-					leadConditions.push(eq(leads.assignedTo, context.userId));
+				if (opportunityOwnerCondition) {
+					leadConditions.push(opportunityOwnerCondition);
 				}
 				const opps = await db
 					.select({ numeroSifco: opportunities.numeroSifco })
 					.from(opportunities)
-					.leftJoin(leads, eq(opportunities.leadId, leads.id))
 					.where(and(...leadConditions));
 				scopedSifcos = opps
 					.map((o) => o.numeroSifco)
@@ -3587,10 +3597,9 @@ export const crmRouter = {
 				const opps = await db
 					.select({ numeroSifco: opportunities.numeroSifco })
 					.from(opportunities)
-					.leftJoin(leads, eq(opportunities.leadId, leads.id))
 					.where(
 						and(
-							eq(leads.assignedTo, context.userId),
+							opportunityOwnerCondition,
 							isNotNull(opportunities.numeroSifco),
 						),
 					);
@@ -3641,7 +3650,12 @@ export const crmRouter = {
 								leadId: opportunities.leadId,
 							})
 							.from(opportunities)
-							.where(inArray(opportunities.numeroSifco, pageSifcos))
+							.where(
+								and(
+									inArray(opportunities.numeroSifco, pageSifcos),
+									opportunityOwnerCondition,
+								),
+							)
 					: [];
 
 			const sifcoToLeadId = new Map<string, string>();
@@ -3704,6 +3718,7 @@ export const crmRouter = {
 								id: opportunities.id,
 								title: opportunities.title,
 								leadId: opportunities.leadId,
+								assignedTo: opportunities.assignedTo,
 								value: opportunities.value,
 								creditType: opportunities.creditType,
 								numeroSifco: opportunities.numeroSifco,
@@ -3718,7 +3733,12 @@ export const crmRouter = {
 							})
 							.from(opportunities)
 							.leftJoin(salesStages, eq(opportunities.stageId, salesStages.id))
-							.where(inArray(opportunities.leadId, matchedLeadIds))
+							.where(
+								and(
+									inArray(opportunities.leadId, matchedLeadIds),
+									opportunityOwnerCondition,
+								),
+							)
 							.orderBy(desc(opportunities.createdAt))
 					: [];
 
@@ -3732,6 +3752,7 @@ export const crmRouter = {
 						acc[leadId].push({
 							id: opp.id,
 							title: opp.title,
+							assignedTo: opp.assignedTo,
 							value: opp.value,
 							creditType: opp.creditType,
 							numeroSifco: opp.numeroSifco,
@@ -3796,6 +3817,8 @@ export const crmRouter = {
 						leadOpportunities: opportunitiesByLead[leadId] || [],
 						creditAnalysisByOpportunityId,
 						carteraCreditBySifco: new Map([[sifco, credit]]),
+						opportunityOwnerId:
+							context.userRole === "sales" ? context.userId : undefined,
 					});
 				}
 				// Sin match CRM: las filas "sólo cartera" no aplican en vistas acotadas.

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -1181,16 +1181,6 @@ export const crmRouter = {
 					throw new ORPCError("NOT_FOUND", { message: "Lead no encontrado" });
 				}
 
-				// Sales users can only see analysis for their assigned leads
-				if (
-					context.userRole === "sales" &&
-					lead[0].assignedTo !== context.userId
-				) {
-					throw new ORPCError("FORBIDDEN", {
-						message: "No tienes permiso para ver este análisis",
-					});
-				}
-
 				if (!input.opportunityId) {
 					return null;
 				}
@@ -1314,16 +1304,6 @@ export const crmRouter = {
 
 				if (lead.length === 0) {
 					throw new ORPCError("NOT_FOUND", { message: "Lead no encontrado" });
-				}
-
-				// Sales users can only update analysis for their assigned leads
-				if (
-					context.userRole === "sales" &&
-					lead[0].assignedTo !== context.userId
-				) {
-					throw new ORPCError("FORBIDDEN", {
-						message: "No tienes permiso para actualizar este análisis",
-					});
 				}
 
 				const [opportunity] = await db

--- a/apps/crm/apps/server/src/routers/crm.ts
+++ b/apps/crm/apps/server/src/routers/crm.ts
@@ -60,6 +60,10 @@ import {
 	updateChecklistForClientDocument,
 	updateChecklistForVehicleDocument,
 } from "../lib/checklist";
+import {
+	assertOpportunityBelongsToLead,
+	getCreditAnalysisOwnerCondition,
+} from "../lib/credit-analysis-ownership";
 import { buildDeletedOpportunitySnapshot } from "../lib/deleted-opportunity-audit";
 import { getGuatemalaMonthWindow } from "../lib/guatemala-month-window";
 import {
@@ -397,7 +401,7 @@ export function buildCarteraOnlyClientRow(credit: CarteraClientCredit) {
 export function buildCarteraMatchedClientRows(params: {
 	lead: MatchedClientLead;
 	leadOpportunities: ClientRowOpportunity[];
-	creditAnalysis: unknown;
+	creditAnalysisByOpportunityId: ReadonlyMap<string, unknown>;
 	carteraCreditBySifco: Map<string, CarteraClientCredit>;
 }): MatchedClientRow[] {
 	const rows: MatchedClientRow[] = [];
@@ -407,12 +411,16 @@ export function buildCarteraMatchedClientRows(params: {
 			(opp) => opp.numeroSifco === sifco,
 		);
 		if (matchingOpportunities.length === 0) continue;
+		const matchingOpportunity =
+			matchingOpportunities.length === 1 ? matchingOpportunities[0] : null;
 
 		rows.push({
 			...params.lead,
 			rowId: `${params.lead.id}-${sifco}`,
 			opportunities: params.leadOpportunities,
-			creditAnalysis: params.creditAnalysis,
+			creditAnalysis: matchingOpportunity
+				? (params.creditAnalysisByOpportunityId.get(matchingOpportunity.id) ?? null)
+				: null,
 			totalClosedValue: getCarteraCreditAmount(credit),
 			closedOpportunitiesCount: params.leadOpportunities.filter(
 				(opp) => opp.isClosed,
@@ -1141,10 +1149,14 @@ export const crmRouter = {
 			z
 				.object({
 					leadId: z.string().uuid().optional(),
+					opportunityId: z.string().uuid().optional(),
 					coDebtorId: z.string().uuid().optional(),
 				})
 				.refine((data) => data.leadId || data.coDebtorId, {
 					message: "Debe proporcionar leadId o coDebtorId",
+				})
+				.refine((data) => !(data.leadId && data.coDebtorId), {
+					message: "No puede consultar un lead y un co-deudor a la vez",
 				}),
 		)
 		.handler(async ({ input, context }) => {
@@ -1170,10 +1182,37 @@ export const crmRouter = {
 					});
 				}
 
+				if (!input.opportunityId) {
+					return null;
+				}
+
+				const [opportunity] = await db
+					.select({ leadId: opportunities.leadId })
+					.from(opportunities)
+					.where(eq(opportunities.id, input.opportunityId))
+					.limit(1);
+				if (!opportunity) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "Oportunidad no encontrada",
+					});
+				}
+				try {
+					assertOpportunityBelongsToLead(opportunity, input.leadId);
+				} catch (error) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: error instanceof Error ? error.message : String(error),
+					});
+				}
+
 				const analysis = await db
 					.select()
 					.from(creditAnalysis)
-					.where(eq(creditAnalysis.leadId, input.leadId))
+					.where(
+						getCreditAnalysisOwnerCondition({
+							leadId: input.leadId,
+							opportunityId: input.opportunityId,
+						}),
+					)
 					.limit(1);
 
 				return analysis[0] || null;
@@ -1210,6 +1249,7 @@ export const crmRouter = {
 			z
 				.object({
 					leadId: z.string().uuid().optional(),
+					opportunityId: z.string().uuid().optional(),
 					coDebtorId: z.string().uuid().optional(),
 					monthlyFixedIncome: z.number().min(0).optional(),
 					monthlyVariableIncome: z.number().min(0).optional(),
@@ -1219,12 +1259,15 @@ export const crmRouter = {
 					maxPayment: z.number().min(0).optional(),
 					maxCreditAmount: z.number().min(0).optional(),
 				})
-				.refine((data) => data.leadId || data.coDebtorId, {
-					message: "Debe proporcionar leadId o coDebtorId",
+				.refine((data) => data.coDebtorId || (data.leadId && data.opportunityId), {
+					message: "Debe proporcionar leadId y opportunityId, o coDebtorId",
+				})
+				.refine((data) => !(data.leadId && data.coDebtorId), {
+					message: "No puede guardar un lead y un co-deudor a la vez",
 				}),
 		)
 		.handler(async ({ input, context }) => {
-			const { leadId, coDebtorId, ...analysisData } = input;
+			const { leadId, opportunityId, coDebtorId, ...analysisData } = input;
 
 			// Convert numbers to strings for decimal fields
 			const dataForDb = {
@@ -1260,11 +1303,34 @@ export const crmRouter = {
 					});
 				}
 
+				const [opportunity] = await db
+					.select({ leadId: opportunities.leadId })
+					.from(opportunities)
+					.where(eq(opportunities.id, opportunityId!))
+					.limit(1);
+				if (!opportunity) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "Oportunidad no encontrada",
+					});
+				}
+				try {
+					assertOpportunityBelongsToLead(opportunity, leadId);
+				} catch (error) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: error instanceof Error ? error.message : String(error),
+					});
+				}
+
+				const ownerCondition = getCreditAnalysisOwnerCondition({
+					leadId,
+					opportunityId: opportunityId!,
+				});
+
 				// Check if analysis already exists
 				const existing = await db
 					.select()
 					.from(creditAnalysis)
-					.where(eq(creditAnalysis.leadId, leadId))
+					.where(ownerCondition)
 					.limit(1);
 
 				if (existing.length > 0) {
@@ -1275,7 +1341,7 @@ export const crmRouter = {
 							analyzedAt: existing[0].analyzedAt ?? new Date(),
 							updatedAt: new Date(),
 						})
-						.where(eq(creditAnalysis.leadId, leadId))
+						.where(ownerCondition)
 						.returning();
 					return updated[0];
 				}
@@ -1284,6 +1350,7 @@ export const crmRouter = {
 					.insert(creditAnalysis)
 					.values({
 						leadId,
+						opportunityId: opportunityId!,
 						...dataForDb,
 						createdBy: context.userId,
 						analyzedAt: new Date(),
@@ -1348,10 +1415,14 @@ export const crmRouter = {
 			z
 				.object({
 					leadId: z.string().uuid().optional(),
+					opportunityId: z.string().uuid().optional(),
 					coDebtorId: z.string().uuid().optional(),
 				})
-				.refine((data) => data.leadId || data.coDebtorId, {
-					message: "Debe proporcionar leadId o coDebtorId",
+				.refine((data) => data.coDebtorId || (data.leadId && data.opportunityId), {
+					message: "Debe proporcionar leadId y opportunityId, o coDebtorId",
+				})
+				.refine((data) => !(data.leadId && data.coDebtorId), {
+					message: "No puede resetear un lead y un co-deudor a la vez",
 				}),
 		)
 		.handler(async ({ input, context }) => {
@@ -1365,9 +1436,31 @@ export const crmRouter = {
 				});
 			}
 
-			const whereCondition = input.leadId
-				? eq(creditAnalysis.leadId, input.leadId)
-				: eq(creditAnalysis.coDebtorId, input.coDebtorId!);
+			if (input.leadId) {
+				const [opportunity] = await db
+					.select({ leadId: opportunities.leadId })
+					.from(opportunities)
+					.where(eq(opportunities.id, input.opportunityId!))
+					.limit(1);
+				if (!opportunity) {
+					throw new ORPCError("NOT_FOUND", {
+						message: "Oportunidad no encontrada",
+					});
+				}
+				try {
+					assertOpportunityBelongsToLead(opportunity, input.leadId);
+				} catch (error) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}
+
+			const whereCondition = getCreditAnalysisOwnerCondition(
+				input.leadId
+					? { leadId: input.leadId, opportunityId: input.opportunityId! }
+					: { coDebtorId: input.coDebtorId! },
+			);
 
 			const deleted = await db
 				.delete(creditAnalysis)
@@ -3626,12 +3719,15 @@ export const crmRouter = {
 				{} as Record<string, any[]>,
 			);
 
-			// 4) Análisis de crédito de esos leads
-			const creditAnalysisByLead =
-				matchedLeadIds.length > 0
+			// 4) Análisis de crédito de las oportunidades que corresponden a esos SIFCO
+			const matchedOpportunityIds = leadsOpportunities.map(
+				(opportunity) => opportunity.id,
+			);
+			const creditAnalysisByOpportunity =
+				matchedOpportunityIds.length > 0
 					? await db
 							.select({
-								leadId: creditAnalysis.leadId,
+								opportunityId: creditAnalysis.opportunityId,
 								monthlyFixedIncome: creditAnalysis.monthlyFixedIncome,
 								monthlyVariableIncome: creditAnalysis.monthlyVariableIncome,
 								monthlyFixedExpenses: creditAnalysis.monthlyFixedExpenses,
@@ -3643,16 +3739,18 @@ export const crmRouter = {
 								analyzedAt: creditAnalysis.analyzedAt,
 							})
 							.from(creditAnalysis)
-							.where(inArray(creditAnalysis.leadId, matchedLeadIds))
+							.where(
+								inArray(creditAnalysis.opportunityId, matchedOpportunityIds),
+							)
 					: [];
-			const creditAnalysisMap = creditAnalysisByLead.reduce(
+			const creditAnalysisByOpportunityId = creditAnalysisByOpportunity.reduce(
 				(acc, ca) => {
-					if (ca.leadId) {
-						acc[ca.leadId] = ca;
+					if (ca.opportunityId) {
+						acc.set(ca.opportunityId, ca);
 					}
 					return acc;
 				},
-				{} as Record<string, (typeof creditAnalysisByLead)[0]>,
+				new Map<string, (typeof creditAnalysisByOpportunity)[0]>(),
 			);
 
 			// 5) Construir filas en el orden en que cartera devolvió los créditos.
@@ -3667,7 +3765,7 @@ export const crmRouter = {
 					return buildCarteraMatchedClientRows({
 						lead,
 						leadOpportunities: opportunitiesByLead[leadId] || [],
-						creditAnalysis: creditAnalysisMap[leadId] || null,
+						creditAnalysisByOpportunityId,
 						carteraCreditBySifco: new Map([[sifco, credit]]),
 					});
 				}
@@ -4601,14 +4699,17 @@ export const crmRouter = {
 								.where(eq(vehicles.id, opportunity.vehicleId))
 								.limit(1)
 						: Promise.resolve([]),
-					// Credit analysis (if lead exists)
-					opportunity.leadId
-						? db
-								.select()
-								.from(creditAnalysis)
-								.where(eq(creditAnalysis.leadId, opportunity.leadId))
-								.limit(1)
-						: Promise.resolve([]),
+					// Credit analysis for this opportunity only
+					db
+						.select()
+						.from(creditAnalysis)
+						.where(
+							and(
+								eq(creditAnalysis.opportunityId, input.opportunityId),
+								isNotNull(creditAnalysis.analyzedAt),
+							),
+						)
+						.limit(1),
 				]);
 
 			const uploadedTypes = new Set(uploadedDocs.map((d) => d.documentType));
@@ -4737,7 +4838,27 @@ export const crmRouter = {
 
 			// Early return if checklist already exists and is still aligned
 			if (existingChecklist) {
+				const savedCapacityItem = (
+					existingChecklist.checklistData as {
+						sections?: {
+							verificaciones?: {
+								items?: Array<{
+									type?: string;
+									completed?: boolean;
+									analysisId?: string;
+								}>;
+							};
+						};
+					}
+				).sections?.verificaciones?.items?.find(
+					(item) => item.type === "capacidad_pago",
+				);
+				const hasStaleCreditAnalysis =
+					(savedCapacityItem?.completed ?? false) !== !!creditAnalysisExists ||
+					(savedCapacityItem?.analysisId ?? null) !==
+						(creditAnalysisExists?.id ?? null);
 				if (
+					hasStaleCreditAnalysis ||
 					hasStaleAnalysisChecklistVehicleState(
 						existingChecklist.checklistData as any,
 						opportunity.vehicleId,
@@ -6624,14 +6745,12 @@ export const crmRouter = {
 
 			// 2. Obtener análisis del lead (si existe)
 			let leadAnalysis = null;
-			if (opportunity.leadId) {
-				const [analysis] = await db
-					.select()
-					.from(creditAnalysis)
-					.where(eq(creditAnalysis.leadId, opportunity.leadId))
-					.limit(1);
-				leadAnalysis = analysis || null;
-			}
+			const [analysis] = await db
+				.select()
+				.from(creditAnalysis)
+				.where(eq(creditAnalysis.opportunityId, input.opportunityId))
+				.limit(1);
+			leadAnalysis = analysis || null;
 
 			// 3. Obtener co-deudores de la oportunidad
 			const coDebtorsList = await db

--- a/apps/crm/apps/server/src/routers/upload.ts
+++ b/apps/crm/apps/server/src/routers/upload.ts
@@ -152,19 +152,19 @@ async function assertCanUploadToResource(params: {
 				});
 			}
 
-			const [lead] = await db
+			const [opportunity] = await db
 				.select({
-					id: leads.id,
-					assignedTo: leads.assignedTo,
+					id: opportunities.id,
+					assignedTo: opportunities.assignedTo,
 				})
-				.from(leads)
-				.where(eq(leads.id, resourceId))
+				.from(opportunities)
+				.where(eq(opportunities.id, resourceId))
 				.limit(1);
 
-			if (lead) {
-				if (userRole === "sales" && lead.assignedTo !== userId) {
+			if (opportunity) {
+				if (userRole === "sales" && opportunity.assignedTo !== userId) {
 					throw new ORPCError("FORBIDDEN", {
-						message: "No tienes permiso para analizar este lead",
+						message: "No tienes permiso para analizar esta oportunidad",
 					});
 				}
 				return;
@@ -178,7 +178,7 @@ async function assertCanUploadToResource(params: {
 
 			if (!coDebtor) {
 				throw new ORPCError("NOT_FOUND", {
-					message: "Lead o co-deudor no encontrado",
+					message: "Oportunidad o co-deudor no encontrado",
 				});
 			}
 			return;

--- a/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
+++ b/apps/crm/apps/web/src/components/credit/BankStatementAnalysis.tsx
@@ -52,9 +52,10 @@ export function BankStatementAnalysis({
 	const [maxVariableDebtRatio, setMaxVariableDebtRatio] = useState("0.2");
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const queryClient = useQueryClient();
+	const hasOwner = !!coDebtorId || !!(leadId && opportunityId);
 
 	const queryKey = leadId
-		? ["creditAnalysis", "lead", leadId]
+		? ["creditAnalysis", "opportunity", opportunityId]
 		: ["creditAnalysis", "coDebtor", coDebtorId];
 
 	// Obtener estado del análisis desde el servidor
@@ -62,9 +63,11 @@ export function BankStatementAnalysis({
 		queryKey,
 		queryFn: () =>
 			client.getCreditAnalysisByLeadId(
-				leadId ? { leadId } : { coDebtorId: coDebtorId! },
+				leadId
+					? { leadId, opportunityId: opportunityId! }
+					: { coDebtorId: coDebtorId! },
 			),
-		enabled: !!(leadId || coDebtorId),
+		enabled: hasOwner,
 	});
 
 	// Verificar si hay un análisis exitoso (analyzedAt debe existir y no ser null)
@@ -82,13 +85,26 @@ export function BankStatementAnalysis({
 	const resetMutation = useMutation({
 		mutationFn: () =>
 			client.resetCreditAnalysis(
-				leadId ? { leadId } : { coDebtorId: coDebtorId! },
+				leadId
+					? { leadId, opportunityId: opportunityId! }
+					: { coDebtorId: coDebtorId! },
 			),
 		onSuccess: () => {
 			toast.success(
 				"Análisis reseteado. Puede volver a subir estados de cuenta.",
 			);
 			queryClient.invalidateQueries({ queryKey });
+			if (opportunityId) {
+				queryClient.invalidateQueries({
+					queryKey: ["getAnalysisChecklist", opportunityId],
+				});
+				queryClient.invalidateQueries({
+					queryKey: ["consolidatedCreditAnalysis", opportunityId],
+				});
+				queryClient.invalidateQueries({
+					queryKey: ["getConsolidatedCreditAnalysis", opportunityId],
+				});
+			}
 			onAnalysisComplete?.();
 		},
 		onError: (error) => {
@@ -103,7 +119,7 @@ export function BankStatementAnalysis({
 				files.map(async (file) => {
 					const { key } = await uploadFileToR2WithRetry(file, {
 						resourceType: "bank_statement",
-						resourceId: leadId || coDebtorId!,
+						resourceId: leadId ? opportunityId! : coDebtorId!,
 					});
 					return {
 						name: file.name,
@@ -115,7 +131,7 @@ export function BankStatementAnalysis({
 
 			return client.analyzeBankStatements({
 				...(leadId ? { leadId } : { coDebtorId: coDebtorId! }),
-				...(leadId && opportunityId ? { opportunityId } : {}),
+				...(leadId ? { opportunityId: opportunityId! } : {}),
 				files: filePayloads,
 				annualRate: Number.parseFloat(annualRate),
 				termMonths: Number.parseInt(termMonths),
@@ -128,6 +144,20 @@ export function BankStatementAnalysis({
 			setFiles([]);
 			// Invalidar query para obtener estado actualizado del servidor
 			queryClient.invalidateQueries({ queryKey });
+			if (opportunityId) {
+				queryClient.invalidateQueries({
+					queryKey: ["getAnalysisChecklist", opportunityId],
+				});
+				queryClient.invalidateQueries({
+					queryKey: ["consolidatedCreditAnalysis", opportunityId],
+				});
+				queryClient.invalidateQueries({
+					queryKey: ["getConsolidatedCreditAnalysis", opportunityId],
+				});
+				queryClient.invalidateQueries({
+					queryKey: ["getOpportunityDocuments", opportunityId],
+				});
+			}
 			onAnalysisComplete?.();
 		},
 		onError: (error) => {
@@ -175,6 +205,11 @@ export function BankStatementAnalysis({
 				</CardDescription>
 			</CardHeader>
 			<CardContent className="space-y-3">
+				{leadId && !opportunityId && (
+					<p className="text-amber-700 text-xs">
+						Seleccione una oportunidad para consultar o crear su análisis.
+					</p>
+				)}
 				{/* File input */}
 				<div>
 					<input
@@ -305,6 +340,7 @@ export function BankStatementAnalysis({
 						isLoadingAnalysis ||
 						files.length === 0 ||
 						analyzeMutation.isPending ||
+						!hasOwner ||
 						!canAnalyze
 					}
 				>

--- a/apps/crm/apps/web/src/components/lead-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/lead-detail-modal.tsx
@@ -4,6 +4,7 @@ import { Building, Loader2, Mail, Phone, Users } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { getOpportunityCreditAnalysisInput } from "@/lib/credit-analysis";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Dialog,
@@ -93,6 +94,7 @@ type LeadDetailModalProps = {
 	open: boolean;
 	onOpenChange: (open: boolean) => void;
 	lead: LeadForModal | null;
+	opportunityId?: string;
 	readOnly?: boolean;
 	onEdit?: () => void;
 };
@@ -101,6 +103,7 @@ export function LeadDetailModal({
 	open,
 	onOpenChange,
 	lead,
+	opportunityId,
 	readOnly = false,
 	onEdit,
 }: LeadDetailModalProps) {
@@ -112,12 +115,17 @@ export function LeadDetailModal({
 		enabled: open && !!lead?.id,
 	});
 
+	const creditAnalysisInput = getOpportunityCreditAnalysisInput(
+		lead?.id,
+		opportunityId,
+	);
+
 	// Query for credit analysis data
 	const creditAnalysisQuery = useQuery({
 		...orpc.getCreditAnalysisByLeadId.queryOptions({
-			input: { leadId: lead?.id ?? "" },
+			input: creditAnalysisInput ?? { leadId: "", opportunityId: "" },
 		}),
-		enabled: open && !!lead?.id,
+		enabled: open && !!creditAnalysisInput,
 	});
 
 	const queryClient = useQueryClient();

--- a/apps/crm/apps/web/src/lib/credit-analysis.test.ts
+++ b/apps/crm/apps/web/src/lib/credit-analysis.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import {
+	getOpportunityCreditAnalysisInput,
+	resolveAnalysisOpportunityId,
+} from "./credit-analysis";
+
+describe("getOpportunityCreditAnalysisInput", () => {
+	test("includes the current opportunity in the lead analysis request", () => {
+		expect(getOpportunityCreditAnalysisInput("lead-1", "opportunity-2")).toEqual({
+			leadId: "lead-1",
+			opportunityId: "opportunity-2",
+		});
+		expect(getOpportunityCreditAnalysisInput("lead-1", undefined)).toBeNull();
+	});
+});
+
+describe("resolveAnalysisOpportunityId", () => {
+	const opportunities = [{ id: "opportunity-a" }, { id: "opportunity-b" }];
+
+	test("prefers a valid explicit selection", () => {
+		expect(
+			resolveAnalysisOpportunityId(
+				"opportunity-b",
+				"opportunity-a",
+				opportunities,
+			),
+		).toBe("opportunity-b");
+	});
+
+	test("rejects a URL opportunity that does not belong to the current lead", () => {
+		expect(
+			resolveAnalysisOpportunityId(
+				undefined,
+				"other-lead-opportunity",
+				opportunities,
+			),
+		).toBeUndefined();
+	});
+
+	test("automatically selects the only opportunity", () => {
+		expect(
+			resolveAnalysisOpportunityId(undefined, undefined, [
+				{ id: "only-opportunity" },
+			]),
+		).toBe("only-opportunity");
+	});
+
+	test("returns undefined for multiple opportunities without a selection", () => {
+		expect(
+			resolveAnalysisOpportunityId(undefined, undefined, opportunities),
+		).toBeUndefined();
+	});
+});

--- a/apps/crm/apps/web/src/lib/credit-analysis.ts
+++ b/apps/crm/apps/web/src/lib/credit-analysis.ts
@@ -1,0 +1,21 @@
+export function getOpportunityCreditAnalysisInput(
+	leadId: string | undefined,
+	opportunityId: string | undefined,
+): { leadId: string; opportunityId: string } | null {
+	return leadId && opportunityId ? { leadId, opportunityId } : null;
+}
+
+export function resolveAnalysisOpportunityId(
+	explicitOpportunityId: string | undefined,
+	urlOpportunityId: string | undefined,
+	opportunities: ReadonlyArray<{ id: string }>,
+): string | undefined {
+	const ids = new Set(opportunities.map((opportunity) => opportunity.id));
+	if (explicitOpportunityId && ids.has(explicitOpportunityId)) {
+		return explicitOpportunityId;
+	}
+	if (urlOpportunityId && ids.has(urlOpportunityId)) {
+		return urlOpportunityId;
+	}
+	return opportunities.length === 1 ? opportunities[0]?.id : undefined;
+}

--- a/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/$opportunityId.tsx
@@ -627,6 +627,7 @@ function OpportunityDocumentsPage() {
 				open={isLeadModalOpen}
 				onOpenChange={setIsLeadModalOpen}
 				lead={selectedLeadForModal}
+				opportunityId={opportunityId}
 				readOnly
 			/>
 		</div>

--- a/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
+++ b/apps/crm/apps/web/src/routes/crm/analysis/index.tsx
@@ -210,6 +210,9 @@ function AnalysisPage() {
 		useState<OpportunityForModal | null>(null);
 	const [selectedLeadForModal, setSelectedLeadForModal] =
 		useState<LeadForModal | null>(null);
+	const [selectedLeadOpportunityId, setSelectedLeadOpportunityId] = useState<
+		string | undefined
+	>();
 
 	// Check authentication and role
 	useEffect(() => {
@@ -325,6 +328,7 @@ function AnalysisPage() {
 
 	const handleOpenLeadModal = (opportunity: OpportunityForAnalysis) => {
 		if (!opportunity.lead) return;
+		setSelectedLeadOpportunityId(opportunity.id);
 		setSelectedLeadForModal({
 			id: opportunity.lead.id,
 			firstName: opportunity.lead.firstName,
@@ -720,6 +724,7 @@ function AnalysisPage() {
 				open={isLeadModalOpen}
 				onOpenChange={setIsLeadModalOpen}
 				lead={selectedLeadForModal}
+				opportunityId={selectedLeadOpportunityId}
 				readOnly
 			/>
 		</div>
@@ -829,19 +834,18 @@ function DisbursementSection({
 	};
 
 	const handleNavigateToLead = (leadId: string) => {
-		// Find the opportunity with this lead
-		const opp = opportunities?.find((o) => o.leadId === leadId);
-		if (opp) {
+		const opportunity = selectedOpportunityForModal;
+		if (opportunity?.lead?.id === leadId) {
 			const leadData = {
 				id: leadId,
-				firstName: opp.leadName?.split(" ")[0] || "",
-				lastName: opp.leadName?.split(" ").slice(1).join(" ") || "",
-				email: null,
-				phone: opp.leadPhone || null,
+				firstName: opportunity.lead.firstName,
+				lastName: opportunity.lead.lastName,
+				email: opportunity.lead.email,
+				phone: opportunity.lead.phone,
 				company: null,
 				source: "",
 				status: "qualified",
-				createdAt: opp.createdAt,
+				createdAt: opportunity.createdAt,
 			};
 			setIsOpportunityModalOpen(false);
 			// Delay opening second modal to allow first to fully close
@@ -1053,6 +1057,7 @@ function DisbursementSection({
 				open={isLeadModalOpen}
 				onOpenChange={setIsLeadModalOpen}
 				lead={selectedLeadForModal}
+				opportunityId={selectedOpportunityForModal?.id}
 				readOnly
 			/>
 		</div>

--- a/apps/crm/apps/web/src/routes/crm/leads.tsx
+++ b/apps/crm/apps/web/src/routes/crm/leads.tsx
@@ -76,6 +76,7 @@ import { usePersistedDateRange } from "@/hooks/usePersistedDateRange";
 import { usePersistedState } from "@/hooks/usePersistedState";
 import { authClient } from "@/lib/auth-client";
 import { shouldRedirectToLogin } from "@/lib/auth-session";
+import { resolveAnalysisOpportunityId } from "@/lib/credit-analysis";
 import {
 	formatCurrency,
 	formatGuatemalaDate,
@@ -155,6 +156,8 @@ function RouteComponent() {
 	};
 
 	const [isEditingCreditAnalysis, setIsEditingCreditAnalysis] = useState(false);
+	const [selectedAnalysisOpportunityId, setSelectedAnalysisOpportunityId] =
+		useState<string>();
 	const [isConvertDialogOpen, setIsConvertDialogOpen] = useState(false);
 	const [leadToConvert, setLeadToConvert] = useState<Lead | null>(null);
 	const [convertForm, setConvertForm] = useState({
@@ -276,14 +279,6 @@ function RouteComponent() {
 		enabled: !!selectedDepartamento,
 	});
 
-	const creditAnalysisQuery = useQuery({
-		queryKey: ["getCreditAnalysisByLeadId", selectedLead?.id],
-		queryFn: selectedLead?.id
-			? () => client.getCreditAnalysisByLeadId({ leadId: selectedLead.id })
-			: () => Promise.resolve(null),
-		enabled: !!selectedLead?.id && isDetailsDialogOpen,
-	});
-
 	// Query para obtener las oportunidades del lead
 	const leadOpportunitiesQuery = useQuery({
 		queryKey: ["getOpportunitiesByLeadId", selectedLead?.id],
@@ -292,7 +287,22 @@ function RouteComponent() {
 			: () => Promise.resolve([]),
 		enabled: !!selectedLead?.id && isDetailsDialogOpen,
 	});
-	const analysisOpportunityId = search.opportunityId;
+	const analysisOpportunityId = resolveAnalysisOpportunityId(
+		selectedAnalysisOpportunityId,
+		search.opportunityId,
+		leadOpportunitiesQuery.data ?? [],
+	);
+	const creditAnalysisQuery = useQuery({
+		queryKey: ["creditAnalysis", "opportunity", analysisOpportunityId],
+		queryFn: selectedLead?.id && analysisOpportunityId
+			? () =>
+					client.getCreditAnalysisByLeadId({
+						leadId: selectedLead.id,
+						opportunityId: analysisOpportunityId,
+					})
+			: () => Promise.resolve(null),
+		enabled: !!selectedLead?.id && !!analysisOpportunityId && isDetailsDialogOpen,
+	});
 
 	// Query para obtener un lead específico por ID (desde URL)
 	const specificLeadQuery = useQuery({
@@ -457,6 +467,7 @@ function RouteComponent() {
 	const upsertCreditAnalysisMutation = useMutation({
 		mutationFn: (input: {
 			leadId: string;
+			opportunityId: string;
 			monthlyFixedIncome?: number;
 			monthlyVariableIncome?: number;
 			monthlyFixedExpenses?: number;
@@ -467,7 +478,16 @@ function RouteComponent() {
 		}) => client.upsertCreditAnalysis(input),
 		onSuccess: () => {
 			queryClient.invalidateQueries({
-				queryKey: ["getCreditAnalysisByLeadId", selectedLead?.id],
+				queryKey: ["creditAnalysis", "opportunity", analysisOpportunityId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["getAnalysisChecklist", analysisOpportunityId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["consolidatedCreditAnalysis", analysisOpportunityId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["getConsolidatedCreditAnalysis", analysisOpportunityId],
 			});
 			toast.success("Análisis crediticio actualizado exitosamente");
 			setIsEditingCreditAnalysis(false);
@@ -692,6 +712,8 @@ function RouteComponent() {
 		prevDetailsOpenRef.current = isDetailsDialogOpen;
 
 		if (wasOpen && !isDetailsDialogOpen) {
+			setSelectedAnalysisOpportunityId(undefined);
+			setIsEditingCreditAnalysis(false);
 			// Skip cleanup if transitioning to edit modal
 			if (isTransitioningToEditRef.current) {
 				isTransitioningToEditRef.current = false;
@@ -705,6 +727,11 @@ function RouteComponent() {
 			}
 		}
 	}, [isDetailsDialogOpen, navigate, search.leadId]);
+
+	useEffect(() => {
+		setSelectedAnalysisOpportunityId(undefined);
+		setIsEditingCreditAnalysis(false);
+	}, [selectedLead?.id]);
 
 	// Populate form when editing a lead
 	useEffect(() => {
@@ -2660,6 +2687,7 @@ function RouteComponent() {
 										<Button
 											variant="outline"
 											size="sm"
+											disabled={!analysisOpportunityId}
 											onClick={() => {
 												const data = creditAnalysisQuery.data;
 												setCreditAnalysisForm({
@@ -2694,9 +2722,47 @@ function RouteComponent() {
 										</Button>
 									)}
 								</div>
+								{leadOpportunitiesQuery.data &&
+									leadOpportunitiesQuery.data.length > 1 && (
+										<div className="space-y-2">
+											<Label htmlFor="analysis-opportunity">
+												Oportunidad a analizar
+											</Label>
+											<Select
+												value={analysisOpportunityId}
+												onValueChange={(opportunityId) => {
+													setSelectedAnalysisOpportunityId(opportunityId);
+													setIsEditingCreditAnalysis(false);
+												}}
+											>
+												<SelectTrigger id="analysis-opportunity">
+													<SelectValue placeholder="Seleccione una oportunidad" />
+												</SelectTrigger>
+												<SelectContent>
+													{leadOpportunitiesQuery.data.map((opportunity) => (
+														<SelectItem
+															key={opportunity.id}
+															value={opportunity.id}
+														>
+															{opportunity.title || "Oportunidad"}
+															{opportunity.numeroSifco
+																? ` · SIFCO ${opportunity.numeroSifco}`
+																: ""}
+														</SelectItem>
+													))}
+												</SelectContent>
+											</Select>
+										</div>
+									)}
+								{!leadOpportunitiesQuery.isLoading &&
+									leadOpportunitiesQuery.data?.length === 0 && (
+										<p className="text-amber-700 text-sm">
+											Este lead no tiene oportunidades disponibles para analizar.
+										</p>
+									)}
 
 								{/* Análisis automático con IA */}
-								{selectedLead?.id && (
+								{selectedLead?.id && analysisOpportunityId && (
 									<BankStatementAnalysis
 										leadId={selectedLead.id}
 										opportunityId={analysisOpportunityId}
@@ -2708,9 +2774,10 @@ function RouteComponent() {
 									<form
 										onSubmit={(e) => {
 											e.preventDefault();
-											if (!selectedLead) return;
+											if (!selectedLead || !analysisOpportunityId) return;
 											upsertCreditAnalysisMutation.mutate({
 												leadId: selectedLead.id,
+												opportunityId: analysisOpportunityId,
 												monthlyFixedIncome:
 													creditAnalysisForm.monthlyFixedIncome
 														? Number(creditAnalysisForm.monthlyFixedIncome)
@@ -3114,6 +3181,7 @@ function RouteComponent() {
 										<Button
 											variant="link"
 											className="mt-2"
+											disabled={!analysisOpportunityId}
 											onClick={() => {
 												setCreditAnalysisForm({
 													monthlyFixedIncome: "",


### PR DESCRIPTION
## Contexto

Hotfix directo a `main` que replica únicamente el cambio ya revisado y aprobado en #1158, sin incluir los 12 commits adicionales que actualmente existen en `develop` y todavía no deben liberarse.

El patch aplicado sobre `main` tiene el mismo `patch-id` que #1158 y afecta exclusivamente 19 archivos dentro de `apps/crm`.

## Cambios

- identifica el análisis crediticio del lead por `leadId + opportunityId`;
- evita que la oportunidad A satisfaga o modifique el análisis de B;
- conserva ownership de co-deudor por `coDebtorId`;
- resuelve análisis de clientes por oportunidad/SIFCO inequívoco;
- exige selección explícita y pertenencia en escenarios multi-oportunidad;
- restringe lectura, escritura y análisis bancario al propietario de la oportunidad cuando el usuario es vendedor;
- mantiene históricos ambiguos con `opportunity_id = NULL`;
- agrega la migración `0027_add_credit_analysis_opportunity.sql`.

## Origen revisado

Commits equivalentes de #1158:

- `eae0ed9f` — scope por oportunidad;
- `3f41de46` — ownership en escritura;
- `5b00b8fb` — ownership en lectura/análisis bancario;
- `fd4eeb69` — ownership en clientes/SIFCO.

Codex revisó el SHA final de #1158 y respondió: “Didn't find any major issues”.

## Verificación sobre `main + hotfix`

- [x] 41 pruebas funcionales enfocadas; 0 fallos; 113 aserciones.
- [x] 5 pruebas de migración contra PostgreSQL 16 desechable; 0 fallos.
- [x] `git diff --check`.
- [x] Cherry-pick limpio, sin conflictos.
- [x] Ningún archivo fuera de `apps/crm`.
- [x] Migración `0027` sin colisión con `main`, que llega hasta `0026`.

## Baseline conocido

`bun run check-types` y `bun run build` globales fallan también en el `main` limpio por problemas preexistentes de dependencias/tipos (`@repo/sms`, `@repo/simpletech`, `@cci/email`, `pdf-lib`, Cobros/Jurídico y tipos de AI SDK). La comparación contra `main` confirmó que este hotfix no introduce esos fallos.

## Release

Este PR solo prepara el código para `main`. El merge, migración de producción, build/push de imágenes y deploy requieren gates separados.

Reemplaza la ruta de liberación de #1158 mientras `develop` contiene cambios que aún no deben subir a producción.
