### PR TITLE
feat(cobros): cartera-back — apertura matutina del supervisor (CB-023) y resolución de review Codex

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/actualizarAsesorBucket.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/actualizarAsesorBucket.test.ts
@@ -39,7 +39,7 @@ const fakeDb: any = {
   },
 };
 
-mock.module("../../database", () => ({ db: fakeDb }));
+mock.module("../../database", () => ({ db: fakeDb, client: {} }));
 
 const schema = await import("../../database/db/schema");
 const { actualizarCapacidadAsesorBucket } = await import("./actualizarAsesorBucket");

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
@@ -1,0 +1,490 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+/**
+ * Tests de CB-023 (apertura matutina). Dos capas:
+ *
+ *  1. Funciones PURAS (calcularMontoAdeudado / rankearTop3 / resumirCumplimiento)
+ *     — sin DB, sin mock. Son la especificación legible de la fórmula del
+ *     ranking y del cumplimiento; el SQL las replica en set-based.
+ *
+ *  2. getAperturaDia con la DB fakeada por FIRMA del SQL (mismo espíritu que
+ *     cargaAsesorBucket.test.ts): las 3 queries del controller son crudas
+ *     (sql`...`), así que un fakeDb despacha db.execute() según qué texto
+ *     reconoce en la query (buckets_historial → cuentas nuevas, ROW_NUMBER →
+ *     top3, cuotas_ayer → cumplimiento).
+ */
+
+type Fila = Record<string, any>;
+
+const estado = {
+  cuentasNuevas: [] as Fila[],
+  top3: [] as Fila[],
+  cumplimiento: [] as Fila[],
+  asignacion: [] as Fila[],
+  movimientos: [] as Fila[],
+};
+
+function firmaDe(
+  query: any,
+): "cuentasNuevas" | "top3" | "cumplimiento" | "asignacion" | "movimientos" {
+  const texto = (query?.queryChunks ?? [])
+    .map((c: any) => (typeof c === "string" ? c : JSON.stringify(c)))
+    .join(" ");
+  if (texto.includes("cuotas_ayer")) return "cumplimiento";
+  if (texto.includes("ROW_NUMBER")) return "top3";
+  // Las 3 restantes leen buckets_historial; las distinguen sus JOINs propios.
+  if (texto.includes("LATERAL")) return "movimientos";
+  if (texto.includes("c.asesor_id")) return "asignacion";
+  return "cuentasNuevas";
+}
+
+const fakeDb: any = {
+  execute: async (query: any) => {
+    const firma = firmaDe(query);
+    return { rows: estado[firma] };
+  },
+};
+
+mock.module("../../database", () => ({ db: fakeDb }));
+
+const {
+  calcularMontoAdeudado,
+  rankearTop3,
+  resumirCumplimiento,
+  getAperturaDia,
+} = await import("./aperturaDia");
+
+// ─────────────────────────── Funciones puras ───────────────────────────────
+
+describe("calcularMontoAdeudado (pura)", () => {
+  it("(cuotas vencidas × cuota) + recargo de mora", () => {
+    // 3 vencidas × Q10,000 + Q1,200 recargo = Q31,200.
+    expect(calcularMontoAdeudado(3, 10000, 1200)).toBe(31200);
+  });
+
+  it("cero vencidas → solo el recargo", () => {
+    expect(calcularMontoAdeudado(0, 10000, 1200)).toBe(1200);
+  });
+
+  it("mora null/NaN → COALESCE a 0", () => {
+    expect(calcularMontoAdeudado(2, 5000, Number.NaN)).toBe(10000);
+  });
+
+  it("cuotas negativas se tratan como 0 (no restan)", () => {
+    expect(calcularMontoAdeudado(-4, 5000, 300)).toBe(300);
+  });
+});
+
+describe("rankearTop3 (pura)", () => {
+  it("ordena por monto adeudado desc y corta a 3", () => {
+    const filas = [
+      { credito_id: 1, monto_adeudado: 100, cuotas_vencidas: 1 },
+      { credito_id: 2, monto_adeudado: 900, cuotas_vencidas: 3 },
+      { credito_id: 3, monto_adeudado: 500, cuotas_vencidas: 2 },
+      { credito_id: 4, monto_adeudado: 700, cuotas_vencidas: 2 },
+    ];
+    const r = rankearTop3(filas);
+    expect(r.map((x) => x.credito_id)).toEqual([2, 4, 3]);
+  });
+
+  it("la de 8 cuotas × Q3,000 (Q25,900) va ANTES que la de 3 × Q7,500 (Q23,100)", () => {
+    // El caso exacto discutido: gana el acumulado, no el monto de cuota suelto.
+    const grande = { credito_id: 10, monto_adeudado: 44800, cuotas_vencidas: 3 };
+    const acumulada = { credito_id: 20, monto_adeudado: 25900, cuotas_vencidas: 8 };
+    const chica = { credito_id: 30, monto_adeudado: 23100, cuotas_vencidas: 3 };
+    const r = rankearTop3([chica, grande, acumulada]);
+    expect(r.map((x) => x.credito_id)).toEqual([10, 20, 30]);
+  });
+
+  it("desempate determinístico: mismo monto → más cuotas vencidas, luego credito_id asc", () => {
+    const filas = [
+      { credito_id: 5, monto_adeudado: 1000, cuotas_vencidas: 2 },
+      { credito_id: 3, monto_adeudado: 1000, cuotas_vencidas: 4 },
+      { credito_id: 9, monto_adeudado: 1000, cuotas_vencidas: 2 },
+    ];
+    const r = rankearTop3(filas);
+    expect(r.map((x) => x.credito_id)).toEqual([3, 5, 9]);
+  });
+});
+
+describe("resumirCumplimiento (pura)", () => {
+  it("pct = pagadas / esperadas × 100", () => {
+    const r = resumirCumplimiento({
+      fecha: "2026-07-21",
+      cuentas_esperadas: 60,
+      cuentas_pagadas: 45,
+      monto_esperado: 250000,
+      monto_pagado: 187500,
+    });
+    expect(r.pct).toBe(75);
+    expect(r.cuentas_pagadas).toBe(45);
+  });
+
+  it("cero esperadas → pct 0, nunca NaN (no divide por cero)", () => {
+    const r = resumirCumplimiento({
+      fecha: "2026-07-21",
+      cuentas_esperadas: 0,
+      cuentas_pagadas: 0,
+      monto_esperado: 0,
+      monto_pagado: 0,
+    });
+    expect(r.pct).toBe(0);
+    expect(Number.isNaN(r.pct)).toBe(false);
+  });
+});
+
+// ─────────────────────────── Controller (DB fakeada) ───────────────────────
+
+function reset() {
+  estado.cuentasNuevas = [];
+  estado.top3 = [];
+  estado.asignacion = [];
+  estado.movimientos = [];
+  estado.cumplimiento = [
+    {
+      fecha_ayer: "2026-07-21",
+      cuentas_esperadas: 0,
+      cuentas_pagadas: 0,
+      monto_esperado: "0",
+      monto_pagado: "0",
+    },
+  ];
+}
+
+describe("getAperturaDia", () => {
+  beforeEach(reset);
+
+  it("arma las 3 secciones desde las 3 queries", async () => {
+    estado.cuentasNuevas = [
+      { bucket: 1, desde: 0, tipo_evento: "SUBIDA", cantidad: 4 },
+      { bucket: 1, desde: 2, tipo_evento: "BAJADA", cantidad: 1 },
+    ];
+    estado.top3 = [
+      {
+        credito_id: 10, numero_credito_sifco: "C-10", cliente: "Juan", bucket: 2,
+        status_credito: "MOROSO", cuotas_vencidas: 3, monto_cuota: "10000.00",
+        monto_mora: "1200.00", monto_adeudado: "31200.00", dias_mora: 92,
+        asesor_id: 7, asesor: "Ana", total_criticos: 5, rn: 1,
+      },
+    ];
+    estado.cumplimiento = [
+      { fecha_ayer: "2026-07-21", cuentas_esperadas: 60, cuentas_pagadas: 45, monto_esperado: "250000", monto_pagado: "187500" },
+    ];
+
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+
+    expect(r.fecha).toBe("2026-07-22");
+    expect(r.cuentas_nuevas[0]).toMatchObject({ bucket: 1, subidas: 4, bajadas: 1, entradas: 5 });
+    expect(r.cumplimiento.pct).toBe(75);
+    expect(r.top3[0].bucket).toBe(2);
+    expect(r.top3[0].peor_monto).toBe(31200);
+    expect(r.top3[0].total_criticos).toBe(5);
+    expect(r.top3[0].top[0].monto_adeudado).toBe(31200);
+  });
+
+  it("bucket sin críticos → no aparece en top3 (el front rellena las 6 secciones)", async () => {
+    estado.top3 = []; // ningún crédito crítico
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.top3).toEqual([]);
+  });
+
+  it("agrupa varias filas del mismo bucket y toma el peor monto", async () => {
+    estado.top3 = [
+      { credito_id: 1, numero_credito_sifco: "A", cliente: "x", bucket: 3, status_credito: "MOROSO", cuotas_vencidas: 8, monto_cuota: "3000", monto_mora: "1900", monto_adeudado: "25900", dias_mora: 241, asesor_id: null, asesor: null, total_criticos: 2, rn: 1 },
+      { credito_id: 2, numero_credito_sifco: "B", cliente: "y", bucket: 3, status_credito: "MOROSO", cuotas_vencidas: 3, monto_cuota: "7500", monto_mora: "600", monto_adeudado: "23100", dias_mora: 88, asesor_id: null, asesor: null, total_criticos: 2, rn: 2 },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.top3).toHaveLength(1);
+    expect(r.top3[0].top).toHaveLength(2);
+    expect(r.top3[0].peor_monto).toBe(25900);
+  });
+});
+
+describe("asignación del día: ingresos al bucket del asesor", () => {
+  beforeEach(reset);
+
+  it("suma los ingresos del asesor sin distinguir subida de bajada", async () => {
+    // Samuel atiende B2: le entró 1 desde B1 (venía subiendo) y 1 desde B3
+    // (venía bajando). Para él son 2 cuentas nuevas, punto.
+    estado.asignacion = [
+      { asesor_id: 6, asesor: "Samuel", desde: 1, bucket: 2, cantidad: 1, buckets_pool: [2] },
+      { asesor_id: 6, asesor: "Samuel", desde: 3, bucket: 2, cantidad: 1, buckets_pool: [2] },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+
+    expect(r.asignacion).toHaveLength(1);
+    expect(r.asignacion[0].ingresos).toBe(2);
+    expect(r.asignacion[0].porBucket.map((b) => b.desde)).toEqual([1, 3]);
+  });
+
+  it("conserva el bucket de ORIGEN de cada ingreso", async () => {
+    estado.asignacion = [
+      { asesor_id: 3, asesor: "Erik", desde: 3, bucket: 4, cantidad: 2, buckets_pool: [4] },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion[0].porBucket).toEqual([
+      { desde: 3, bucket: 4, cantidad: 2 },
+    ]);
+  });
+
+  it("ordena por cantidad de ingresos desc", async () => {
+    estado.asignacion = [
+      { asesor_id: 9, asesor: "Ana", desde: 0, bucket: 1, cantidad: 1, buckets_pool: [1] },
+      { asesor_id: 7, asesor: "Diego", desde: 0, bucket: 1, cantidad: 5, buckets_pool: [1] },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion.map((a) => a.asesor)).toEqual(["Diego", "Ana"]);
+  });
+
+  it("a igual cantidad, el asesor del bucket más alto va primero", async () => {
+    estado.asignacion = [
+      { asesor_id: 4, asesor: "Caren", desde: 1, bucket: 0, cantidad: 2, buckets_pool: [0] },
+      { asesor_id: 3, asesor: "Erik", desde: 3, bucket: 4, cantidad: 2, buckets_pool: [4] },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion.map((a) => a.asesor)).toEqual(["Erik", "Caren"]);
+  });
+
+  it("expone el pool del asesor (buckets_pool)", async () => {
+    estado.asignacion = [
+      { asesor_id: 7, asesor: "Diego", desde: 0, bucket: 1, cantidad: 2, buckets_pool: [1] },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion[0].buckets_pool).toEqual([1]);
+  });
+
+  it("asesor sin fila en el pool → buckets_pool vacío, no revienta", async () => {
+    estado.asignacion = [
+      { asesor_id: 7, asesor: "Diego", desde: 0, bucket: 1, cantidad: 1, buckets_pool: null },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion[0].buckets_pool).toEqual([]);
+  });
+
+  it("agrupa los créditos sin asesor bajo asesor_id null (no los pierde)", async () => {
+    estado.asignacion = [
+      { asesor_id: null, asesor: null, desde: 2, bucket: 3, cantidad: 2 },
+      { asesor_id: null, asesor: null, desde: 4, bucket: 3, cantidad: 1 },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion).toHaveLength(1);
+    expect(r.asignacion[0]).toMatchObject({ asesor_id: null, ingresos: 3 });
+  });
+
+  it("día sin transiciones → asignación vacía", async () => {
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion).toEqual([]);
+  });
+
+  // El filtro "solo entradas al bucket del asesor" vive en el WHERE del SQL
+  // (EXISTS contra asesor_bucket), así que el fakeDb ya recibe filas filtradas.
+  // Lo que se verifica aquí es la consecuencia visible: un asesor al que no le
+  // entró nada simplemente no viene en el resultado.
+  it("un asesor sin entradas a su bucket no aparece en la lista", async () => {
+    // Gerencia atiende B5 y hoy solo tuvo movimiento en B1/B2 → el SQL no la
+    // devuelve. Solo llega Erik, con lo que entró a su B4.
+    estado.asignacion = [
+      { asesor_id: 3, asesor: "Erik", desde: 3, bucket: 4, cantidad: 2, buckets_pool: [4] },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.asignacion).toHaveLength(1);
+    expect(r.asignacion[0].asesor).toBe("Erik");
+    expect(r.asignacion[0].porBucket[0].bucket).toBe(4);
+  });
+});
+
+describe("cuentas nuevas: desglose por bucket de origen", () => {
+  beforeEach(reset);
+
+  it("pliega varios orígenes en un bucket destino y suma subidas/bajadas", async () => {
+    // B1 recibe: 2 que SUBIERON desde B0, 3 que BAJARON desde B2, 1 desde B3.
+    estado.cuentasNuevas = [
+      { bucket: 1, desde: 0, tipo_evento: "SUBIDA", cantidad: 2 },
+      { bucket: 1, desde: 2, tipo_evento: "BAJADA", cantidad: 3 },
+      { bucket: 1, desde: 3, tipo_evento: "BAJADA", cantidad: 1 },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+
+    expect(r.cuentas_nuevas).toHaveLength(1);
+    const b1 = r.cuentas_nuevas[0];
+    expect(b1).toMatchObject({ bucket: 1, subidas: 2, bajadas: 4, entradas: 6 });
+    expect(b1.origenes).toEqual([
+      { desde: 0, tipo: "SUBIDA", cantidad: 2 },
+      { desde: 2, tipo: "BAJADA", cantidad: 3 },
+      { desde: 3, tipo: "BAJADA", cantidad: 1 },
+    ]);
+  });
+
+  it("ordena los buckets destino por número", async () => {
+    estado.cuentasNuevas = [
+      { bucket: 3, desde: 2, tipo_evento: "SUBIDA", cantidad: 1 },
+      { bucket: 0, desde: 1, tipo_evento: "BAJADA", cantidad: 2 },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.cuentas_nuevas.map((c) => c.bucket)).toEqual([0, 3]);
+  });
+});
+
+describe("movimientos del día (detalle por crédito)", () => {
+  beforeEach(reset);
+
+  it("calcula los saltos de bucket del movimiento", async () => {
+    estado.movimientos = [
+      {
+        credito_id: 10, numero_credito_sifco: "C-10", cliente: "Juan",
+        bucket_anterior: 1, bucket_nuevo: 3, tipo_evento: "SUBIDA",
+        status_credito: "MOROSO", cuotas_vencidas: 3, monto_cuota: "10000",
+        monto_mora: "1200", monto_adeudado: "31200", dias_mora: 92,
+        asesor_id: 7, asesor: "Diego", fecha: "2026-07-22T02:00:00",
+      },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.movimientos[0]).toMatchObject({
+      credito_id: 10,
+      saltos: 2, // B1 → B3
+      monto_adeudado: 31200,
+      tipo_evento: "SUBIDA",
+    });
+  });
+
+  it("una bajada también cuenta saltos (valor absoluto, nunca negativo)", async () => {
+    estado.movimientos = [
+      {
+        credito_id: 11, numero_credito_sifco: "C-11", cliente: "Ana",
+        bucket_anterior: 3, bucket_nuevo: 1, tipo_evento: "BAJADA",
+        status_credito: "MOROSO", cuotas_vencidas: 1, monto_cuota: "5000",
+        monto_mora: "0", monto_adeudado: "5000", dias_mora: 10,
+        asesor_id: null, asesor: null, fecha: "2026-07-22T02:00:00",
+      },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.movimientos[0].saltos).toBe(2);
+  });
+
+  it("día sin movimientos → lista vacía", async () => {
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.movimientos).toEqual([]);
+  });
+});
+
+// ─────────────────────── Frontera de día en timezone GT ────────────────────
+//
+// El código marca esta conversión como fuente recurrente de bugs, y con razón:
+// ya falló una vez en producción de pruebas. `buckets_historial.fecha` es un
+// timestamp SIN timezone guardado con now() (UTC). Convertirlo a día GT exige
+// DOS etapas — marcar el naive como UTC y después pasar a Guatemala. Con una
+// sola conversión Postgres interpreta el naive COMO hora GT y suma 6h en vez
+// de restarlas, así que todo evento después de las 18:00 GT se contaba en el
+// día siguiente (justo la franja del job de moras nocturno).
+//
+// Estos tests inspeccionan el SQL emitido: la regresión sería silenciosa (no
+// tira error, solo devuelve filas de menos), así que se verifica la FORMA de
+// la expresión, no el resultado.
+describe("conversión de día GT (regresión: AT TIME ZONE invertido)", () => {
+  // Los chunks de drizzle anidan: strings sueltos, StringChunk {value: []} y
+  // fragmentos sql`` con sus propios queryChunks. Se recorre en profundidad.
+  const sqlDe = (query: any): string => {
+    const partes: string[] = [];
+    const walk = (n: any, d = 0) => {
+      if (n == null || d > 8) return;
+      if (typeof n === "string") return void partes.push(n);
+      if (Array.isArray(n)) return void n.forEach((x) => walk(x, d + 1));
+      if (typeof n === "object") {
+        if (typeof n.value === "string") partes.push(n.value);
+        else if (Array.isArray(n.value)) walk(n.value, d + 1);
+        if (n.queryChunks) walk(n.queryChunks, d + 1);
+      }
+    };
+    walk(query?.queryChunks);
+    return partes.join(" ");
+  };
+
+  it("toda query que filtre por día usa las DOS etapas UTC → America/Guatemala", async () => {
+    reset();
+    const capturadas: string[] = [];
+    const original = fakeDb.execute;
+    fakeDb.execute = async (query: any) => {
+      capturadas.push(sqlDe(query));
+      return original(query);
+    };
+    await getAperturaDia({ fecha: "2026-07-22" });
+    fakeDb.execute = original;
+
+    // Conteo EXACTO, no un mínimo: son 3 las queries que filtran transiciones
+    // por día — cuentas nuevas, movimientos y asignación. (El top3 NO entra:
+    // usa la fecha contra cuotas_credito, no contra buckets_historial.) Un
+    // `>=` dejaría pasar que una de las 3 pierda la conversión, justo la
+    // regresión que estos tests existen para atrapar.
+    // `diaGTDe` parte la expresión en chunks (el nombre de columna viaja en un
+    // sql.raw aparte), así que se normalizan los espacios antes de buscar.
+    const norm = (s: string) => s.replace(/\s+/g, " ");
+    const conFecha = capturadas
+      .map(norm)
+      .filter((s) => s.includes("h.fecha AT TIME ZONE"));
+    expect(conFecha).toHaveLength(3);
+    for (const s of conFecha) {
+      // El orden importa: 'UTC' SIEMPRE antes que 'America/Guatemala'.
+      const idxUtc = s.indexOf("AT TIME ZONE 'UTC'");
+      const idxGt = s.indexOf("AT TIME ZONE 'America/Guatemala'");
+      if (idxGt !== -1 && s.includes("h.fecha")) {
+        expect(idxUtc).toBeGreaterThan(-1);
+        expect(idxUtc).toBeLessThan(idxGt);
+      }
+    }
+  });
+
+  it("ninguna query convierte h.fecha directo a GT (la forma que causó el bug)", async () => {
+    reset();
+    const capturadas: string[] = [];
+    const original = fakeDb.execute;
+    fakeDb.execute = async (query: any) => {
+      capturadas.push(sqlDe(query));
+      return original(query);
+    };
+    await getAperturaDia({ fecha: "2026-07-22" });
+    fakeDb.execute = original;
+
+    for (const s of capturadas) {
+      expect(s).not.toContain("h.fecha AT TIME ZONE 'America/Guatemala'");
+    }
+  });
+});
+
+// ─────────────────────────── Errores de la DB ──────────────────────────────
+describe("errores de la base de datos", () => {
+  it("un fallo de cualquier sección propaga el error (no devuelve data a medias)", async () => {
+    reset();
+    const original = fakeDb.execute;
+    fakeDb.execute = async () => {
+      throw new Error("connection terminated unexpectedly");
+    };
+    // Promise.all: si una query cae, la vista completa falla. Es lo correcto —
+    // una apertura con secciones vacías en silencio haría que el supervisor
+    // creyera que no hubo movimiento. El router lo traduce a 500.
+    await expect(getAperturaDia({ fecha: "2026-07-22" })).rejects.toThrow(
+      "connection terminated unexpectedly",
+    );
+    fakeDb.execute = original;
+  });
+
+  it("filas con columnas nulas no revientan el mapeo", async () => {
+    reset();
+    // Un LEFT JOIN sin match deja nulls; el mapeo debe absorberlos.
+    estado.movimientos = [
+      {
+        credito_id: 10, numero_credito_sifco: null, cliente: null,
+        bucket_anterior: null, bucket_nuevo: 2, tipo_evento: "SUBIDA",
+        status_credito: null, cuotas_vencidas: null, monto_cuota: "0",
+        monto_mora: "0", monto_adeudado: "0", dias_mora: 0,
+        asesor_id: null, asesor: null, fecha: "2026-07-22T02:00:00",
+      },
+    ];
+    const r = await getAperturaDia({ fecha: "2026-07-22" });
+    expect(r.movimientos[0]).toMatchObject({
+      credito_id: 10,
+      cuotas_vencidas: 0, // null → 0, no NaN
+      saltos: 0, // sin bucket_anterior no hay salto que medir
+      asesor: null,
+    });
+  });
+});

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
@@ -551,4 +551,27 @@ describe("regresiones de SQL (orden por enum / bucket a la fecha)", () => {
       "AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala') ::date <=",
     );
   });
+
+  it("top3 y movimientos usan el predicado 'vencida a la fecha' (con rama legacy)", async () => {
+    // Una cuota que vencía antes de `f` pero se pagó DESPUÉS seguía vencida ese
+    // día. El predicado histórico (cuotaVencidaALaFecha) reemplaza al viejo
+    // `v.pagado = false`: acota el pago cubriente por fecha y trata la data
+    // legacy (pagado=true sin pago cubriente) como pagada. Sin él, la apertura
+    // de un día pasado sub-reporta las cuentas críticas de esa mañana.
+    //
+    // La cota de fecha en sí (COALESCE(pc.fecha_pago,...)) viaja en un sql.raw
+    // anidado que este extractor no aplana; lo que sí queda visible y es
+    // exclusivo del predicado nuevo es la rama legacy `v.pagado = true AND NOT
+    // EXISTS`, y la AUSENCIA del viejo `v.pagado = false`.
+    const capturadas = (await capturarSql()).map((s) => s.replace(/\s+/g, " "));
+    const historicas = capturadas.filter(
+      (s) => s.includes("ROW_NUMBER") || s.includes("LATERAL"),
+    );
+    // top3 (ROW_NUMBER) y movimientos (LATERAL).
+    expect(historicas.length).toBeGreaterThanOrEqual(2);
+    for (const s of historicas) {
+      expect(s).toContain("v .pagado = true AND NOT EXISTS");
+      expect(s).not.toContain("v .fecha_vencimiento::date < 2026-07-22 ::date AND v .pagado = false");
+    }
+  });
 });

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
@@ -488,3 +488,67 @@ describe("errores de la base de datos", () => {
     });
   });
 });
+
+// ─────────────── Regresiones estructurales del SQL (review Codex) ───────────
+//
+// Dos bugs que no tiran error ni cambian el shape del resultado — solo
+// devuelven filas mal ordenadas o mal clasificadas. Se atrapan inspeccionando
+// el SQL emitido, no el resultado.
+describe("regresiones de SQL (orden por enum / bucket a la fecha)", () => {
+  const sqlDe = (query: any): string => {
+    const partes: string[] = [];
+    const walk = (n: any, d = 0) => {
+      if (n == null || d > 8) return;
+      if (typeof n === "string") return void partes.push(n);
+      if (Array.isArray(n)) return void n.forEach((x) => walk(x, d + 1));
+      if (typeof n === "object") {
+        if (typeof n.value === "string") partes.push(n.value);
+        else if (Array.isArray(n.value)) walk(n.value, d + 1);
+        if (n.queryChunks) walk(n.queryChunks, d + 1);
+      }
+    };
+    walk(query?.queryChunks);
+    return partes.join(" ");
+  };
+
+  const capturarSql = async (): Promise<string[]> => {
+    reset();
+    const capturadas: string[] = [];
+    const original = fakeDb.execute;
+    fakeDb.execute = async (query: any) => {
+      capturadas.push(sqlDe(query));
+      return original(query);
+    };
+    await getAperturaDia({ fecha: "2026-07-22" });
+    fakeDb.execute = original;
+    return capturadas;
+  };
+
+  it("movimientos ordena SUBIDA antes que BAJADA por CASE, NO por enum DESC", async () => {
+    // `tipo_evento` es enum ('INICIAL','SUBIDA','BAJADA'); Postgres ordena
+    // enums por orden de declaración, así que `ORDER BY tipo_evento DESC`
+    // pondría BAJADA antes que SUBIDA — con el LIMIT, cortaría lo grave.
+    const capturadas = (await capturarSql()).map((s) => s.replace(/\s+/g, " "));
+    // La query de movimientos es la única con el CASE de tipo_evento (top3 y
+    // cuentas nuevas no lo tienen).
+    const movimientos = capturadas.find((s) =>
+      s.includes("CASE h.tipo_evento WHEN 'SUBIDA'"),
+    );
+    expect(movimientos).toBeDefined();
+    expect(movimientos).not.toContain("ORDER BY h.tipo_evento DESC");
+  });
+
+  it("top3 deriva el bucket a la fecha (cota fecha <= f), no el bucket 'ahora'", async () => {
+    // Sin la cota de fecha, el bucket sería el ACTUAL mientras las cuotas se
+    // cuentan a la fecha pedida → foto incoherente al revisar un día pasado.
+    const capturadas = (await capturarSql()).map((s) => s.replace(/\s+/g, " "));
+    const top3 = capturadas.find((s) => s.includes("ROW_NUMBER"));
+    expect(top3).toBeDefined();
+    // La subquery del bucket acota por día: convierte h.fecha a día GT y lo
+    // compara con `<=`. (h.fecha viaja en un sql.raw aparte, por eso el match
+    // es sobre la porción de conversión + el operador de cota.)
+    expect(top3).toContain(
+      "AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala') ::date <=",
+    );
+  });
+});

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.test.ts
@@ -45,7 +45,7 @@ const fakeDb: any = {
   },
 };
 
-mock.module("../../database", () => ({ db: fakeDb }));
+mock.module("../../database", () => ({ db: fakeDb, client: {} }));
 
 const {
   calcularMontoAdeudado,
@@ -573,5 +573,57 @@ describe("regresiones de SQL (orden por enum / bucket a la fecha)", () => {
       expect(s).toContain("v .pagado = true AND NOT EXISTS");
       expect(s).not.toContain("v .fecha_vencimiento::date < 2026-07-22 ::date AND v .pagado = false");
     }
+  });
+});
+
+// ──────────────── Validation de ventana acotada (fechaEnRangoApertura) ───────
+
+const { fechaEnRangoApertura, APERTURA_DIAS_ATRAS, hoyGT } = await import(
+  "../../routers/buckets"
+);
+
+describe("fechaEnRangoApertura (regresión cota de fechas en apertura)", () => {
+  it("acepta hoy (límite superior exacto)", () => {
+    const hoy = hoyGT();
+    expect(fechaEnRangoApertura(hoy)).toBe(true);
+  });
+
+  it(`acepta hoy - ${APERTURA_DIAS_ATRAS} días (límite inferior exacto)`, () => {
+    const hoy = "2026-07-24";
+    // 2026-07-24 - 7 días = 2026-07-17
+    expect(fechaEnRangoApertura("2026-07-17", hoy)).toBe(true);
+  });
+
+  it(`rechaza hoy - ${APERTURA_DIAS_ATRAS + 1} días (fuera de ventana)`, () => {
+    const hoy = "2026-07-24";
+    // 2026-07-24 - 8 días = 2026-07-16
+    expect(fechaEnRangoApertura("2026-07-16", hoy)).toBe(false);
+  });
+
+  it("rechaza fechas futuras (mañana o posterior)", () => {
+    const hoy = "2026-07-24";
+    expect(fechaEnRangoApertura("2026-07-25", hoy)).toBe(false);
+    expect(fechaEnRangoApertura("2026-08-01", hoy)).toBe(false);
+  });
+
+  it("calcula correctamente la cota en transiciones de fin de mes", () => {
+    // 2026-03-03 - 7 días = 2026-02-24
+    const hoy = "2026-03-03";
+    expect(fechaEnRangoApertura("2026-02-24", hoy)).toBe(true);
+    expect(fechaEnRangoApertura("2026-02-23", hoy)).toBe(false);
+  });
+
+  it("calcula correctamente la cota en transiciones de año bisiesto", () => {
+    // 2028 es bisiesto (29 días en feb). 2028-03-01 - 7 días = 2028-02-23
+    const hoy = "2028-03-01";
+    expect(fechaEnRangoApertura("2028-02-23", hoy)).toBe(true);
+    expect(fechaEnRangoApertura("2028-02-22", hoy)).toBe(false);
+  });
+
+  it("calcula correctamente la cota en transiciones de fin de año", () => {
+    // 2026-01-05 - 7 días = 2025-12-29
+    const hoy = "2026-01-05";
+    expect(fechaEnRangoApertura("2025-12-29", hoy)).toBe(true);
+    expect(fechaEnRangoApertura("2025-12-28", hoy)).toBe(false);
   });
 });

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
@@ -679,7 +679,10 @@ async function getCumplimientoAyer(fecha?: string): Promise<Cumplimiento> {
       SELECT
         cu.cuota_id,
         c.cuota AS monto_cuota,
-        (cu.pagado = true OR EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))})) AS pagada
+        (
+          EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"), f)})
+          OR (cu.pagado = true AND NOT EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))}))
+        ) AS pagada
       FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
       INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
       WHERE cu.fecha_vencimiento::date = (${f} - INTERVAL '1 day')::date

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
@@ -1,0 +1,718 @@
+import { sql } from "drizzle-orm";
+import { db } from "../../database";
+import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
+import { bucketActualSql, STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CB-023 · Buckets — Vista de APERTURA MATUTINA para el supervisor (8:00 AM).
+// Una sola llamada que arma 3 secciones (la 4ª — asignación del día — la compone
+// el CRM con getCargaPorAsesorBucket, CB-018, para no duplicar esa lógica):
+//
+//   1. Cuentas NUEVAS por bucket   → transiciones de buckets_historial del día.
+//   2. Cumplimiento del día ANTERIOR → de las cuotas que vencían ayer, cuántas
+//      se pagaron (cuentas + monto).
+//   3. TOP 3 por bucket            → los 3 créditos más críticos de cada bucket,
+//      ordenados por monto ADEUDADO.
+//
+// ⚠️ FÓRMULA DEL MONTO ADEUDADO (decisión CB-023, confirmada con el usuario):
+//   monto_adeudado = (cuotas_vencidas_reales × creditos.cuota) + monto_mora
+// `moras_credito.monto_mora` es SOLO el RECARGO (capital × % × cuotas
+// atrasadas) — NO incluye las cuotas vencidas (mismo detalle que documenta
+// cuotasProximas.ts:184). Por eso hay que sumar las cuotas vencidas por su
+// valor (creditos.cuota, fijo por crédito — cuotas_credito no tiene columna de
+// monto) además del recargo. Este orden ya incorpora "prioridad los de mayor
+// monto de cuota" (una cuota de 10k pesa 10k por cada vencida) y además pesa la
+// antigüedad (más cuotas vencidas = más adeudado).
+//
+// ⚠️ moras_credito es una FOTO que solo se refresca cuando corre procesarMoras.
+// Por eso `cuotas_vencidas_reales` se cuenta EN VIVO desde cuotas_credito
+// (espejo de cuotasProximas.ts / isOverdueInstallmentForMora en latefee.ts),
+// no desde m.cuotas_atrasadas. `monto_mora` sí sale de la foto (no hay forma de
+// recalcular el recargo en vivo); si el job no ha corrido, el recargo puede
+// estar viejo — aceptable: el orden lo domina el vencido.
+//
+// ⚠️ `dias_mora` se deriva de la cuota vencida MÁS VIEJA (MIN fecha_vencimiento
+// de las pendientes), NO de moras_credito.created_at — este último se reinicia
+// si la mora se desactiva y se vuelve a crear.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Fila de pago que realmente cubre una cuota (predicado espejo del motor de
+// moras — mismo criterio que cuotasProximas.pagoCubriente para no divergir).
+const pagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
+  SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
+  WHERE pc.cuota_id = ${cuotaIdCol}
+    AND pc."paymentFalse" = false
+    AND pc.pagado = true
+    AND pc.validation_status IN ('validated', 'no_required')
+    AND COALESCE(pc.monto_aplicado, 0) > 0`;
+
+// Estados que NO devengan mora (espejo de ESTADOS_SIN_MORA en cuotasProximas.ts
+// / STATUS_EXCLUIDOS_MORA en latefee.ts).
+const ESTADOS_SIN_MORA = sql`('EN_CONVENIO', 'INCOBRABLE', 'CANCELADO', 'PENDIENTE_CANCELACION', 'CAIDO')`;
+
+/**
+ * Tope de sanidad para el detalle de movimientos del día — la ÚNICA query de
+ * esta vista que devuelve filas por crédito (las otras 4 son agregados
+ * acotados por el catálogo o por el número de asesores, igual que
+ * cargaAsesorBucket.ts, que tampoco lleva LIMIT).
+ *
+ * NO es paginación: son los movimientos de UN día (decenas en operación
+ * normal) y el front filtra por bucket en memoria para que el chip responda
+ * sin volver al server. El tope existe para que una corrida masiva del job
+ * —una migración, un recálculo histórico— no traiga miles de filas de golpe.
+ * Mismo valor que el techo de página de colaDia.ts/bucketsHistorial.ts.
+ */
+const MAX_MOVIMIENTOS_DIA = 500;
+
+/**
+ * Día GT de un timestamp de `buckets_historial.fecha`.
+ *
+ * Las DOS etapas son obligatorias y el orden importa: `fecha` es `timestamp`
+ * SIN timezone (se guarda con now() = UTC), así que primero hay que MARCARLO
+ * como UTC y recién después convertirlo a Guatemala. Con una sola conversión
+ * a 'America/Guatemala' Postgres INTERPRETA el naive como hora GT y lo pasa a
+ * UTC — suma 6h en vez de restarlas, y todo evento posterior a las 18:00 GT
+ * se contaba en el día siguiente (bug real, detectado con datos de prueba:
+ * un evento de las 21:26 del 23-jul salía como 24-jul y desaparecía del
+ * filtro de "hoy" — justo la franja en que corre el job de moras).
+ *
+ * Vive en un solo lugar a propósito: las 4 queries de esta vista lo usan y
+ * duplicar la expresión es exactamente cómo el bug volvería en una sola.
+ * Mismo patrón que bucketsHistorial.ts:43 y colaDia.ts:149.
+ */
+const diaGTDe = (col: string) =>
+  sql`(${sql.raw(col)} AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')`;
+
+// ─────────────────────────── Tipos de respuesta ────────────────────────────
+
+/**
+ * De dónde vinieron los créditos que ENTRARON a un bucket. `bucket_anterior`
+ * null solo en eventos INICIAL (que aquí no entran: filtramos SUBIDA/BAJADA),
+ * así que en la práctica siempre trae origen.
+ */
+export type CuentasNuevasOrigen = {
+  desde: number; // bucket de origen
+  tipo: "SUBIDA" | "BAJADA";
+  cantidad: number;
+};
+
+export type CuentasNuevasBucket = {
+  bucket: number;
+  entradas: number; // SUBIDA + BAJADA que aterrizan en este bucket
+  subidas: number;
+  bajadas: number;
+  // Desglose "2 subieron desde B0, 3 bajaron desde B2": ordenado por cantidad
+  // desc para que el origen dominante se lea primero.
+  origenes: CuentasNuevasOrigen[];
+};
+
+/**
+ * Un crédito que cambió de bucket hoy. Trae TODO el contexto (adeudado, días
+ * en mora, asesor) aunque el front hoy muestre solo las columnas básicas: así
+ * agregar una columna o una fila expandible no requiere tocar el backend.
+ */
+export type MovimientoCredito = {
+  credito_id: number;
+  numero_credito_sifco: string | null;
+  cliente: string | null;
+  bucket_anterior: number | null;
+  bucket_nuevo: number;
+  tipo_evento: "SUBIDA" | "BAJADA";
+  // Saltos de bucket del movimiento (B1→B3 = 2). Permite marcar escalaciones
+  // fuertes sin recalcular en el front.
+  saltos: number;
+  status_credito: string | null;
+  cuotas_vencidas: number;
+  monto_cuota: number;
+  monto_mora: number;
+  monto_adeudado: number;
+  dias_mora: number;
+  asesor_id: number | null;
+  asesor: string | null;
+  fecha: string; // timestamp del evento, ya en hora GT
+};
+
+export type Top3Fila = {
+  credito_id: number;
+  numero_credito_sifco: string | null;
+  cliente: string | null;
+  bucket: number;
+  status_credito: string;
+  cuotas_vencidas: number;
+  monto_cuota: number;
+  monto_mora: number;
+  monto_adeudado: number;
+  dias_mora: number;
+  asesor_id: number | null;
+  asesor: string | null;
+};
+
+export type Top3Bucket = {
+  bucket: number;
+  total_criticos: number; // cuentas con ≥1 cuota vencida en el bucket
+  peor_monto: number; // monto_adeudado del #1 (para el encabezado del acordeón)
+  top: Top3Fila[];
+};
+
+export type Cumplimiento = {
+  fecha: string; // el día evaluado (ayer respecto de `fecha`)
+  cuentas_esperadas: number;
+  cuentas_pagadas: number;
+  pct: number; // 0..100, 0 si no había cuotas esperadas (nunca NaN)
+  monto_esperado: number;
+  monto_pagado: number;
+};
+
+/**
+ * CB-023 · "Asignación del día": qué cuentas NUEVAS le cayeron HOY a cada
+ * asesor por transición de bucket. Lo accionable a las 8 AM es el DELTA del
+ * día por asesor, no el acumulado de carga (eso ya lo responde CB-018 en
+ * /cobros/carga).
+ *
+ * Solo cuentan las ENTRADAS al bucket que el asesor atiende (su pool en
+ * asesor_bucket): lo que se le FUE a otro bucket ya no es trabajo suyo — pasa
+ * a ser del asesor que atiende el bucket destino. Un asesor sin entradas en el
+ * día no aparece en la lista.
+ *
+ * Es el cruce de las transiciones de hoy (buckets_historial) con el dueño
+ * ACTUAL del crédito (creditos.asesor_id, decisión de raíz del modelo).
+ */
+/**
+ * Un ingreso agregado al bucket del asesor: "2 cuentas entraron desde B1".
+ *
+ * NO se distingue SUBIDA de BAJADA: para el asesor que RECIBE la cuenta el
+ * hecho relevante es que le entró trabajo nuevo — que el crédito viniera
+ * empeorando (subida) o mejorando (bajada) es historia del bucket de origen,
+ * no de él. Por eso el conteo es uno solo y lo único que se conserva es de
+ * dónde vino.
+ */
+export type AsignacionAsesorBucket = {
+  desde: number | null;
+  bucket: number; // destino (= bucket que atiende el asesor)
+  cantidad: number;
+};
+
+export type AsignacionDiaAsesor = {
+  asesor_id: number | null; // null = créditos sin asesor asignado
+  asesor: string | null;
+  // Cuentas que ENTRARON hoy al bucket del asesor, sin distinguir si venían
+  // subiendo o bajando (ver AsignacionAsesorBucket).
+  ingresos: number;
+  // Bucket(s) del POOL del asesor (asesor_bucket): a qué buckets está asignado
+  // a atender. Es config estable, distinta de `porBucket` (de dónde vinieron
+  // los ingresos de HOY). Array porque el modelo permite varios por asesor,
+  // aunque hoy cada uno tenga solo el suyo.
+  buckets_pool: number[];
+  porBucket: AsignacionAsesorBucket[];
+};
+
+export type AperturaDiaResultado = {
+  fecha: string;
+  cuentas_nuevas: CuentasNuevasBucket[];
+  cumplimiento: Cumplimiento;
+  top3: Top3Bucket[];
+  asignacion: AsignacionDiaAsesor[];
+  // Detalle crédito por crédito de los movimientos del día (el agregado vive
+  // en `cuentas_nuevas`). El front lo filtra por bucket destino.
+  movimientos: MovimientoCredito[];
+};
+
+// ─────────────────────────── Funciones puras ───────────────────────────────
+// Exportadas para test aislado (sin DB). El SQL las replica en set-based; estas
+// son la especificación legible y el punto de verificación.
+
+/**
+ * Monto adeudado de un crédito para el ranking de apertura.
+ * (cuotas vencidas × valor de cuota) + recargo de mora.
+ */
+export function calcularMontoAdeudado(
+  cuotasVencidas: number,
+  montoCuota: number,
+  montoMora: number,
+): number {
+  const vencidas = Math.max(cuotasVencidas, 0);
+  const cuota = Number.isFinite(montoCuota) ? montoCuota : 0;
+  const mora = Number.isFinite(montoMora) ? montoMora : 0;
+  return vencidas * cuota + mora;
+}
+
+/**
+ * Ordena las filas de un bucket por monto adeudado (desc), desempata por
+ * cuotas vencidas (desc) y luego por credito_id (asc, determinístico), y corta
+ * a las primeras `n` (default 3).
+ */
+export function rankearTop3<T extends { monto_adeudado: number; cuotas_vencidas: number; credito_id: number }>(
+  filas: T[],
+  n = 3,
+): T[] {
+  return [...filas]
+    .sort((a, b) => {
+      if (b.monto_adeudado !== a.monto_adeudado) return b.monto_adeudado - a.monto_adeudado;
+      if (b.cuotas_vencidas !== a.cuotas_vencidas) return b.cuotas_vencidas - a.cuotas_vencidas;
+      return a.credito_id - b.credito_id;
+    })
+    .slice(0, n);
+}
+
+/**
+ * Resume el cumplimiento del día: pct = pagadas / esperadas × 100.
+ * Sin cuotas esperadas → pct 0 (nunca división por cero / NaN).
+ */
+export function resumirCumplimiento(input: {
+  fecha: string;
+  cuentas_esperadas: number;
+  cuentas_pagadas: number;
+  monto_esperado: number;
+  monto_pagado: number;
+}): Cumplimiento {
+  const esperadas = Math.max(input.cuentas_esperadas, 0);
+  const pagadas = Math.max(input.cuentas_pagadas, 0);
+  const pct = esperadas > 0 ? Math.round((pagadas / esperadas) * 1000) / 10 : 0;
+  return {
+    fecha: input.fecha,
+    cuentas_esperadas: esperadas,
+    cuentas_pagadas: pagadas,
+    pct,
+    monto_esperado: input.monto_esperado,
+    monto_pagado: input.monto_pagado,
+  };
+}
+
+// ─────────────────────────── Queries ───────────────────────────────────────
+
+// Fecha default = hoy en GT (mismo patrón que cuotasProximas.ts). Se pasa como
+// literal validado (esFecha en el router) — nunca input crudo al ::date.
+function fechaSql(fecha?: string) {
+  return fecha
+    ? sql`${fecha}::date`
+    : sql`(now() AT TIME ZONE 'America/Guatemala')::date`;
+}
+
+/**
+ * Bloque 1: transiciones del día por bucket DESTINO, con el desglose de
+ * dónde vino cada entrada ("2 subieron desde B0, 3 bajaron desde B2").
+ * Se agrupa por (destino, origen, tipo) y se pliega en memoria — el volumen
+ * es de a lo sumo 6×6×2 filas, no vale una segunda query.
+ */
+async function getCuentasNuevas(fecha?: string): Promise<CuentasNuevasBucket[]> {
+  const f = fechaSql(fecha);
+  const res = await db.execute<{
+    bucket: number;
+    desde: number | null;
+    tipo_evento: "SUBIDA" | "BAJADA";
+    cantidad: number;
+  }>(sql`
+    SELECT
+      h.bucket_nuevo AS bucket,
+      h.bucket_anterior AS desde,
+      h.tipo_evento,
+      COUNT(*)::int AS cantidad
+    FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+    -- fecha es timestamp SIN timezone (se guarda con now() = UTC). La
+    -- conversión a día GT necesita las DOS etapas: marcar el naive como UTC y
+    -- recién ahí pasarlo a Guatemala. Con una sola conversión a
+    -- America/Guatemala, Postgres INTERPRETA el naive como hora GT y lo
+    -- convierte a UTC (+6h) — dirección invertida, que empujaba los eventos de
+    -- la tarde al día siguiente y los dejaba fuera del filtro. Mismo patrón que
+    -- bucketsHistorial.ts:43 y colaDia.ts:149.
+    WHERE ${diaGTDe("h.fecha")}::date = ${f}
+      AND h.tipo_evento IN ('SUBIDA', 'BAJADA')
+    GROUP BY h.bucket_nuevo, h.bucket_anterior, h.tipo_evento
+    ORDER BY h.bucket_nuevo, COUNT(*) DESC
+  `);
+
+  const porBucket = new Map<number, CuentasNuevasBucket>();
+  for (const r of res.rows) {
+    const bucket = Number(r.bucket);
+    let grupo = porBucket.get(bucket);
+    if (!grupo) {
+      grupo = { bucket, entradas: 0, subidas: 0, bajadas: 0, origenes: [] };
+      porBucket.set(bucket, grupo);
+    }
+    const cantidad = Number(r.cantidad);
+    if (r.tipo_evento === "SUBIDA") grupo.subidas += cantidad;
+    else grupo.bajadas += cantidad;
+    grupo.entradas += cantidad;
+    // bucket_anterior es NOT NULL para SUBIDA/BAJADA (lo garantiza el CHECK
+    // de coherencia de la tabla), pero el tipo lo permite: -1 sería un dato
+    // corrupto, mejor visible que escondido.
+    grupo.origenes.push({
+      desde: r.desde != null ? Number(r.desde) : -1,
+      tipo: r.tipo_evento,
+      cantidad,
+    });
+  }
+  return [...porBucket.values()].sort((a, b) => a.bucket - b.bucket);
+}
+
+/**
+ * Detalle crédito por crédito de los movimientos del día. Trae TODO el
+ * contexto del crédito (adeudado, días en mora, asesor) aunque el front hoy
+ * pinte solo algunas columnas — así crecer la tabla no toca backend.
+ *
+ * Sin paginar a propósito: son los movimientos de UN día (decenas, no miles);
+ * el front filtra por bucket destino en memoria y así el chip responde
+ * instantáneo sin ida y vuelta al server.
+ */
+async function getMovimientosDia(fecha?: string): Promise<MovimientoCredito[]> {
+  const f = fechaSql(fecha);
+  const res = await db.execute<{
+    credito_id: number;
+    numero_credito_sifco: string | null;
+    cliente: string | null;
+    bucket_anterior: number | null;
+    bucket_nuevo: number;
+    tipo_evento: "SUBIDA" | "BAJADA";
+    status_credito: string | null;
+    cuotas_vencidas: number;
+    monto_cuota: string;
+    monto_mora: string;
+    monto_adeudado: string;
+    dias_mora: number;
+    asesor_id: number | null;
+    asesor: string | null;
+    fecha: string;
+  }>(sql`
+    SELECT
+      h.credito_id,
+      c.numero_credito_sifco,
+      u.nombre AS cliente,
+      h.bucket_anterior,
+      h.bucket_nuevo,
+      h.tipo_evento,
+      COALESCE(h.status_credito, c."statusCredit") AS status_credito,
+      cv.cuotas_vencidas,
+      ROUND(c.cuota::numeric, 2)::text AS monto_cuota,
+      ROUND(COALESCE(m.monto_mora, 0)::numeric, 2)::text AS monto_mora,
+      ROUND(
+        (cv.cuotas_vencidas * c.cuota + COALESCE(m.monto_mora, 0))::numeric, 2
+      )::text AS monto_adeudado,
+      COALESCE((${f} - cv.mas_vieja), 0)::int AS dias_mora,
+      c.asesor_id,
+      a.nombre AS asesor,
+      to_char(${diaGTDe("h.fecha")}, 'YYYY-MM-DD"T"HH24:MI:SS') AS fecha
+    FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = h.credito_id
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
+      ON m.credito_id = c.credito_id AND m.activa = true
+    -- Cuotas vencidas EN VIVO + la más vieja (para días de mora), mismo
+    -- criterio que getTop3PorBucket. LATERAL para calcular ambas de una pasada.
+    LEFT JOIN LATERAL (
+      SELECT
+        COUNT(*)::int AS cuotas_vencidas,
+        MIN(v.fecha_vencimiento)::date AS mas_vieja
+      FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
+      WHERE v.credito_id = c.credito_id
+        AND v.fecha_vencimiento::date < ${f}
+        AND v.pagado = false
+        AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+    ) cv ON true
+    WHERE ${diaGTDe("h.fecha")}::date = ${f}
+      AND h.tipo_evento IN ('SUBIDA', 'BAJADA')
+    -- Lo más grave primero: subidas antes que bajadas, y dentro de cada una el
+    -- bucket destino más alto arriba.
+    ORDER BY h.tipo_evento DESC, h.bucket_nuevo DESC, h.historial_id DESC
+    LIMIT ${MAX_MOVIMIENTOS_DIA}
+  `);
+
+  return res.rows.map((r) => {
+    const anterior = r.bucket_anterior != null ? Number(r.bucket_anterior) : null;
+    const nuevo = Number(r.bucket_nuevo);
+    return {
+      credito_id: Number(r.credito_id),
+      numero_credito_sifco: r.numero_credito_sifco,
+      cliente: r.cliente,
+      bucket_anterior: anterior,
+      bucket_nuevo: nuevo,
+      tipo_evento: r.tipo_evento,
+      saltos: anterior != null ? Math.abs(nuevo - anterior) : 0,
+      status_credito: r.status_credito,
+      cuotas_vencidas: Number(r.cuotas_vencidas ?? 0),
+      monto_cuota: Number(r.monto_cuota),
+      monto_mora: Number(r.monto_mora),
+      monto_adeudado: Number(r.monto_adeudado),
+      dias_mora: Number(r.dias_mora),
+      asesor_id: r.asesor_id != null ? Number(r.asesor_id) : null,
+      asesor: r.asesor,
+      fecha: r.fecha,
+    };
+  });
+}
+
+/** Bloque 3: hasta 3 créditos más críticos por bucket + total de críticos. */
+async function getTop3PorBucket(fecha?: string): Promise<Top3Bucket[]> {
+  const f = fechaSql(fecha);
+  const fueraSql = sql.join(STATUS_BUCKET_FUERA.map((s) => sql`${s}`), sql`, `);
+
+  // cuotas_vencidas_reales EN VIVO (CASE de estados sin mora, espejo de
+  // cuotasProximas.ts). monto_adeudado = vencidas × cuota + recargo.
+  // ROW_NUMBER particionado por bucket corta a 3 EN SQL — no traer ~1,600
+  // créditos del funnel para quedarse con 18.
+  const res = await db.execute<{
+    credito_id: number;
+    numero_credito_sifco: string | null;
+    cliente: string | null;
+    bucket: number;
+    status_credito: string;
+    cuotas_vencidas: number;
+    monto_cuota: string;
+    monto_mora: string;
+    monto_adeudado: string;
+    dias_mora: number;
+    asesor_id: number | null;
+    asesor: string | null;
+    total_criticos: number;
+    rn: number;
+  }>(sql`
+    WITH base AS (
+      SELECT
+        c.credito_id,
+        c.numero_credito_sifco,
+        u.nombre AS cliente,
+        ${bucketActualSql("c", "m")} AS bucket,
+        c."statusCredit" AS status_credito,
+        c.cuota AS monto_cuota,
+        COALESCE(m.monto_mora, 0) AS monto_mora,
+        c.asesor_id,
+        a.nombre AS asesor,
+        (
+          CASE
+            WHEN c."statusCredit" IN ${ESTADOS_SIN_MORA} THEN 0
+            ELSE (
+              SELECT COUNT(*)
+              FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
+              WHERE v.credito_id = c.credito_id
+                AND v.fecha_vencimiento::date < ${f}
+                AND v.pagado = false
+                AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+            )
+          END
+        )::int AS cuotas_vencidas,
+        (
+          SELECT MIN(v.fecha_vencimiento)::date
+          FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
+          WHERE v.credito_id = c.credito_id
+            AND v.fecha_vencimiento::date < ${f}
+            AND v.pagado = false
+            AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+        ) AS cuota_vencida_mas_vieja
+      FROM ${SQL_CARTERA_SCHEMA}.creditos c
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+      LEFT JOIN ${SQL_CARTERA_SCHEMA}.moras_credito m
+        ON m.credito_id = c.credito_id AND m.activa = true
+      WHERE c."statusCredit" NOT IN (${fueraSql})
+    ),
+    criticos AS (
+      SELECT
+        base.*,
+        (cuotas_vencidas * monto_cuota + monto_mora) AS monto_adeudado,
+        COALESCE((${f} - cuota_vencida_mas_vieja), 0)::int AS dias_mora
+      FROM base
+      WHERE bucket IS NOT NULL
+        AND cuotas_vencidas > 0
+    ),
+    ranked AS (
+      SELECT
+        criticos.*,
+        COUNT(*) OVER (PARTITION BY bucket)::int AS total_criticos,
+        ROW_NUMBER() OVER (
+          PARTITION BY bucket
+          ORDER BY monto_adeudado DESC, cuotas_vencidas DESC, credito_id ASC
+        )::int AS rn
+      FROM criticos
+    )
+    SELECT
+      credito_id, numero_credito_sifco, cliente, bucket, status_credito,
+      cuotas_vencidas,
+      ROUND(monto_cuota::numeric, 2)::text AS monto_cuota,
+      ROUND(monto_mora::numeric, 2)::text AS monto_mora,
+      ROUND(monto_adeudado::numeric, 2)::text AS monto_adeudado,
+      dias_mora, asesor_id, asesor, total_criticos, rn
+    FROM ranked
+    WHERE rn <= 3
+    ORDER BY bucket, rn
+  `);
+
+  // Agrupar filas por bucket (ya vienen ordenadas bucket, rn).
+  const porBucket = new Map<number, Top3Bucket>();
+  for (const r of res.rows) {
+    const bucket = Number(r.bucket);
+    let grupo = porBucket.get(bucket);
+    if (!grupo) {
+      grupo = { bucket, total_criticos: Number(r.total_criticos), peor_monto: 0, top: [] };
+      porBucket.set(bucket, grupo);
+    }
+    const fila: Top3Fila = {
+      credito_id: Number(r.credito_id),
+      numero_credito_sifco: r.numero_credito_sifco,
+      cliente: r.cliente,
+      bucket,
+      status_credito: r.status_credito,
+      cuotas_vencidas: Number(r.cuotas_vencidas),
+      monto_cuota: Number(r.monto_cuota),
+      monto_mora: Number(r.monto_mora),
+      monto_adeudado: Number(r.monto_adeudado),
+      dias_mora: Number(r.dias_mora),
+      asesor_id: r.asesor_id != null ? Number(r.asesor_id) : null,
+      asesor: r.asesor,
+    };
+    grupo.top.push(fila);
+    if (fila.monto_adeudado > grupo.peor_monto) grupo.peor_monto = fila.monto_adeudado;
+  }
+  return [...porBucket.values()].sort((a, b) => a.bucket - b.bucket);
+}
+
+/** Bloque 2: cumplimiento del día ANTERIOR (cuotas que vencían `fecha - 1`). */
+async function getCumplimientoAyer(fecha?: string): Promise<Cumplimiento> {
+  const f = fechaSql(fecha);
+  const fueraSql = sql.join(STATUS_BUCKET_FUERA.map((s) => sql`${s}`), sql`, `);
+  const res = await db.execute<{
+    fecha_ayer: string;
+    cuentas_esperadas: number;
+    cuentas_pagadas: number;
+    monto_esperado: string;
+    monto_pagado: string;
+  }>(sql`
+    WITH cuotas_ayer AS (
+      SELECT
+        cu.cuota_id,
+        c.cuota AS monto_cuota,
+        (cu.pagado = true OR EXISTS (${pagoCubriente(sql.raw("cu.cuota_id"))})) AS pagada
+      FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito cu
+      INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = cu.credito_id
+      WHERE cu.fecha_vencimiento::date = (${f} - INTERVAL '1 day')::date
+        AND c."statusCredit" NOT IN (${fueraSql})
+    )
+    SELECT
+      (${f} - INTERVAL '1 day')::date::text AS fecha_ayer,
+      COUNT(*)::int AS cuentas_esperadas,
+      COUNT(*) FILTER (WHERE pagada)::int AS cuentas_pagadas,
+      ROUND(COALESCE(SUM(monto_cuota), 0)::numeric, 2)::text AS monto_esperado,
+      ROUND(COALESCE(SUM(monto_cuota) FILTER (WHERE pagada), 0)::numeric, 2)::text AS monto_pagado
+    FROM cuotas_ayer
+  `);
+  const row = res.rows[0];
+  return resumirCumplimiento({
+    fecha: row?.fecha_ayer ?? "",
+    cuentas_esperadas: Number(row?.cuentas_esperadas ?? 0),
+    cuentas_pagadas: Number(row?.cuentas_pagadas ?? 0),
+    monto_esperado: Number(row?.monto_esperado ?? 0),
+    monto_pagado: Number(row?.monto_pagado ?? 0),
+  });
+}
+
+/**
+ * Bloque 4: "asignación del día" — transiciones de HOY agrupadas por ASESOR
+ * dueño del crédito y bucket destino. Responde "¿a quién le cayó trabajo
+ * nuevo anoche?", que es lo que el supervisor necesita a las 8 AM.
+ *
+ * El asesor sale de `creditos.asesor_id` (dueño ACTUAL) y no de
+ * `buckets_historial.asesor_id` — este último es atribución de quién GATILLÓ
+ * la transición (el que registró el pago en una BAJADA), no quién se queda
+ * con la cuenta. Para "a quién le cayó" manda el dueño actual.
+ */
+async function getAsignacionDia(fecha?: string): Promise<AsignacionDiaAsesor[]> {
+  const f = fechaSql(fecha);
+  const res = await db.execute<{
+    asesor_id: number | null;
+    asesor: string | null;
+    desde: number | null;
+    bucket: number;
+    cantidad: number;
+    buckets_pool: number[] | null;
+  }>(sql`
+    SELECT
+      c.asesor_id,
+      a.nombre AS asesor,
+      h.bucket_anterior AS desde,
+      h.bucket_nuevo AS bucket,
+      COUNT(*)::int AS cantidad,
+      -- Bucket(s) del pool del asesor (config estable, no movimiento de hoy).
+      -- Subquery agregada: devuelve un array por asesor sin multiplicar filas
+      -- como haría un JOIN a asesor_bucket.
+      (SELECT ARRAY_AGG(ab.bucket ORDER BY ab.bucket)
+         FROM ${SQL_CARTERA_SCHEMA}.asesor_bucket ab
+        WHERE ab.asesor_id = c.asesor_id AND ab.activo = true) AS buckets_pool
+    FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+    INNER JOIN ${SQL_CARTERA_SCHEMA}.creditos c ON c.credito_id = h.credito_id
+    LEFT JOIN ${SQL_CARTERA_SCHEMA}.asesores a ON a.asesor_id = c.asesor_id
+    -- Misma conversión de dos etapas que getCuentasNuevas (ver comentario allá).
+    WHERE ${diaGTDe("h.fecha")}::date = ${f}
+      AND h.tipo_evento IN ('SUBIDA', 'BAJADA')
+      -- Solo ENTRADAS al bucket que el asesor atiende: el movimiento tiene que
+      -- ATERRIZAR en su pool. Una cuenta que se le fue (p.ej. atiende B4 y el
+      -- crédito pasó B4→B5) ya no es trabajo suyo hoy — la recibe el asesor de
+      -- B5, y aparece en la fila de ese. Sin este filtro la tabla mezclaba lo
+      -- que le llegó con lo que se le fue.
+      AND EXISTS (
+        SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.asesor_bucket ab
+        WHERE ab.asesor_id = c.asesor_id
+          AND ab.activo = true
+          AND ab.bucket = h.bucket_nuevo
+      )
+    -- Sin tipo_evento en el GROUP BY: subidas y bajadas al MISMO bucket desde
+    -- el MISMO origen se cuentan juntas — para quien recibe, ambas son un
+    -- ingreso.
+    GROUP BY c.asesor_id, a.nombre, h.bucket_anterior, h.bucket_nuevo
+    -- El origen que más aportó primero.
+    ORDER BY a.nombre NULLS LAST, COUNT(*) DESC, h.bucket_anterior
+  `);
+
+  // Agrupar por asesor (las filas vienen por asesor+bucket).
+  const porAsesor = new Map<number | null, AsignacionDiaAsesor>();
+  for (const r of res.rows) {
+    const asesorId = r.asesor_id != null ? Number(r.asesor_id) : null;
+    let grupo = porAsesor.get(asesorId);
+    if (!grupo) {
+      grupo = {
+        asesor_id: asesorId,
+        asesor: r.asesor,
+        ingresos: 0,
+        buckets_pool: (r.buckets_pool ?? []).map(Number),
+        porBucket: [],
+      };
+      porAsesor.set(asesorId, grupo);
+    }
+    const cantidad = Number(r.cantidad);
+    grupo.porBucket.push({
+      desde: r.desde != null ? Number(r.desde) : null,
+      bucket: Number(r.bucket),
+      cantidad,
+    });
+    grupo.ingresos += cantidad;
+  }
+  // Más ingresos primero (a quién le cayó más trabajo hoy); desempate por
+  // bucket atendido descendente — el asesor del bucket más alto gestiona la
+  // mora más vieja — y luego por nombre, para que el orden sea estable.
+  return [...porAsesor.values()].sort((a, b) => {
+    if (a.ingresos !== b.ingresos) return b.ingresos - a.ingresos;
+    const ba = a.buckets_pool[0] ?? -1;
+    const bb = b.buckets_pool[0] ?? -1;
+    if (ba !== bb) return bb - ba;
+    return (a.asesor ?? "").localeCompare(b.asesor ?? "");
+  });
+}
+
+/**
+ * Vista de apertura matutina: las 4 secciones que dependen de cartera-back
+ * (cuentas nuevas por bucket, cumplimiento de ayer, top 3 por bucket y la
+ * asignación del día por asesor).
+ */
+export async function getAperturaDia(params: { fecha?: string } = {}): Promise<AperturaDiaResultado> {
+  const [cuentas_nuevas, top3, cumplimiento, asignacion, movimientos] =
+    await Promise.all([
+      getCuentasNuevas(params.fecha),
+      getTop3PorBucket(params.fecha),
+      getCumplimientoAyer(params.fecha),
+      getAsignacionDia(params.fecha),
+      getMovimientosDia(params.fecha),
+    ]);
+  const fecha =
+    params.fecha ??
+    new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+
+  return { fecha, cuentas_nuevas, cumplimiento, top3, asignacion, movimientos };
+}

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
@@ -34,6 +34,16 @@ import { STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
 // ⚠️ `dias_mora` se deriva de la cuota vencida MÁS VIEJA (MIN fecha_vencimiento
 // de las pendientes), NO de moras_credito.created_at — este último se reinicia
 // si la mora se desactiva y se vuelve a crear.
+//
+// ⚠️ ALCANCE HISTÓRICO. Bucket, cuotas vencidas y pago se calculan a la fecha
+// `f` (buckets_historial y pagos tienen fecha). Pero el DUEÑO del crédito
+// (creditos.asesor_id) y su STATUS (creditos."statusCredit") se leen del estado
+// ACTUAL: no hay historial continuo de status, y reconstruir el dueño exacto
+// desde credito_asesor_historial en cada sección no compensa para una vista que
+// se usa sobre todo HOY. Por eso el router acota la fecha a una ventana reciente
+// (APERTURA_DIAS_ATRAS en routers/buckets.ts): en pocos días dueño y status casi
+// no cambian, así que la foto sigue siendo fiel. Fuera de esa ventana el
+// endpoint responde 400 en vez de una foto silenciosamente incorrecta.
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Fila de pago que realmente cubre una cuota (predicado espejo del motor de

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
@@ -38,13 +38,54 @@ import { STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
 
 // Fila de pago que realmente cubre una cuota (predicado espejo del motor de
 // moras — mismo criterio que cuotasProximas.pagoCubriente para no divergir).
-const pagoCubriente = (cuotaIdCol: ReturnType<typeof sql.raw>) => sql`
+//
+// `hasta` (opcional): solo cuenta pagos registrados AL DÍA `hasta` o antes.
+// Necesario para las secciones que miran un día PASADO — sin esa cota, una
+// cuota que vencía el 10 pero se pagó el 15 se leería como no-vencida al
+// revisar el 10. Se usa `fecha_pago` (fallback a `fecha_aplicado` para pagos
+// viejos sin registrar), convertido a día GT. Sin `hasta` el predicado es el
+// clásico "pagó alguna vez".
+const pagoCubriente = (
+  cuotaIdCol: ReturnType<typeof sql.raw>,
+  hasta?: ReturnType<typeof sql>,
+) => sql`
   SELECT 1 FROM ${SQL_CARTERA_SCHEMA}.pagos_credito pc
   WHERE pc.cuota_id = ${cuotaIdCol}
     AND pc."paymentFalse" = false
     AND pc.pagado = true
     AND pc.validation_status IN ('validated', 'no_required')
-    AND COALESCE(pc.monto_aplicado, 0) > 0`;
+    AND COALESCE(pc.monto_aplicado, 0) > 0${
+      hasta
+        ? sql`
+    AND ${diaGTDe("COALESCE(pc.fecha_pago, pc.fecha_aplicado)")}::date <= ${hasta}`
+        : sql``
+    }`;
+
+/**
+ * Predicado "la cuota `v` seguía vencida al cierre del día `f`". Se usa en las
+ * secciones históricas (top3, movimientos) — el cumplimiento tiene su propia
+ * lógica porque ahí sí importa quién pagó, sin importar cuándo.
+ *
+ * Una cuota cuenta como vencida-a-la-fecha si venció antes de `f` y NO estaba
+ * pagada ESE día. "Pagada ese día" tiene dos formas:
+ *  - Pago real cubriente con fecha <= f  → pagoCubriente(v, f).
+ *  - Legado: `cuotas_credito.pagado = true` SIN ninguna fila de pago cubriente
+ *    (data vieja, ~2.7k filas en el schema real). Esas no traen fecha de pago,
+ *    así que no se pueden ubicar en el tiempo; se tratan como pagadas siempre
+ *    —el mismo criterio con el que el motor de moras ya convive— para no
+ *    inflar el histórico con miles de falsos vencidos.
+ * `v` es el alias de cuotas_credito en la subquery que lo llama.
+ */
+const cuotaVencidaALaFecha = (v: string, f: ReturnType<typeof sql>) => {
+  const vr = sql.raw(v);
+  return sql`
+    ${vr}.fecha_vencimiento::date < ${f}
+    AND NOT EXISTS (${pagoCubriente(sql.raw(`${v}.cuota_id`), f)})
+    AND NOT (
+      ${vr}.pagado = true
+      AND NOT EXISTS (${pagoCubriente(sql.raw(`${v}.cuota_id`))})
+    )`;
+};
 
 // Estados que NO devengan mora (espejo de ESTADOS_SIN_MORA en cuotasProximas.ts
 // / STATUS_EXCLUIDOS_MORA en latefee.ts).
@@ -449,9 +490,7 @@ async function getMovimientosDia(fecha?: string): Promise<MovimientoCredito[]> {
         MIN(v.fecha_vencimiento)::date AS mas_vieja
       FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
       WHERE v.credito_id = c.credito_id
-        AND v.fecha_vencimiento::date < ${f}
-        AND v.pagado = false
-        AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+        AND ${cuotaVencidaALaFecha("v", f)}
     ) cv ON true
     WHERE ${diaGTDe("h.fecha")}::date = ${f}
       AND h.tipo_evento IN ('SUBIDA', 'BAJADA')
@@ -538,9 +577,7 @@ async function getTop3PorBucket(fecha?: string): Promise<Top3Bucket[]> {
               SELECT COUNT(*)
               FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
               WHERE v.credito_id = c.credito_id
-                AND v.fecha_vencimiento::date < ${f}
-                AND v.pagado = false
-                AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+                AND ${cuotaVencidaALaFecha("v", f)}
             )
           END
         )::int AS cuotas_vencidas,
@@ -548,9 +585,7 @@ async function getTop3PorBucket(fecha?: string): Promise<Top3Bucket[]> {
           SELECT MIN(v.fecha_vencimiento)::date
           FROM ${SQL_CARTERA_SCHEMA}.cuotas_credito v
           WHERE v.credito_id = c.credito_id
-            AND v.fecha_vencimiento::date < ${f}
-            AND v.pagado = false
-            AND NOT EXISTS (${pagoCubriente(sql.raw("v.cuota_id"))})
+            AND ${cuotaVencidaALaFecha("v", f)}
         ) AS cuota_vencida_mas_vieja
       FROM ${SQL_CARTERA_SCHEMA}.creditos c
       INNER JOIN ${SQL_CARTERA_SCHEMA}.usuarios u ON u.usuario_id = c.usuario_id

--- a/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
+++ b/apps/cartera-back/src/controllers/buckets/aperturaDia.ts
@@ -1,7 +1,7 @@
 import { sql } from "drizzle-orm";
 import { db } from "../../database";
 import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
-import { bucketActualSql, STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
+import { STATUS_BUCKET_FUERA } from "../../lib/buckets-classification";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CB-023 · Buckets — Vista de APERTURA MATUTINA para el supervisor (8:00 AM).
@@ -82,6 +82,50 @@ const MAX_MOVIMIENTOS_DIA = 500;
  */
 const diaGTDe = (col: string) =>
   sql`(${sql.raw(col)} AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')`;
+
+/**
+ * Bucket de un crédito TAL COMO ESTABA al cierre de un día `f` (no "ahora").
+ *
+ * `bucketActualSql` (lib/buckets-classification) da el bucket ACTUAL — su
+ * subquery toma el último `buckets_historial` sin cota de fecha. Sirve para la
+ * carga de hoy, pero en la apertura de un día PASADO desincroniza: las cuotas
+ * vencidas se cuentan a la fecha `f`, y si el crédito se movió de bucket
+ * DESPUÉS de `f`, quedaría rankeado bajo un bucket que no tenía ese día. Aquí
+ * el bucket se deriva del último evento CON `fecha <= f` para que ambos lados
+ * (bucket y cuotas) sean la misma foto.
+ *
+ * Con `f = hoy` el resultado coincide con `bucketActualSql` (todos los eventos
+ * pasan la cota), así que la vista del día actual no cambia. Los fallbacks por
+ * estado y por rango de mora son intencionalmente "de ahora": para un día
+ * pasado sin ningún INICIAL registrado no hay foto histórica que reconstruir,
+ * y es el mismo criterio que ya usa el resto del motor.
+ */
+const bucketALaFechaSql = (
+  credAlias: string,
+  moraAlias: string,
+  f: ReturnType<typeof sql>,
+) => {
+  const c = sql.raw(credAlias);
+  const m = sql.raw(moraAlias);
+  return sql`
+  COALESCE(
+    (SELECT h.bucket_nuevo FROM ${SQL_CARTERA_SCHEMA}.buckets_historial h
+      WHERE h.credito_id = ${c}.credito_id
+        AND ${diaGTDe("h.fecha")}::date <= ${f}
+      ORDER BY h.fecha DESC, h.historial_id DESC
+      LIMIT 1),
+    (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
+      WHERE b.activo = true
+        AND ${c}."statusCredit" = ANY (b.estados_incluidos)
+      ORDER BY b.numero LIMIT 1),
+    (SELECT b.numero FROM ${SQL_CARTERA_SCHEMA}.buckets b
+      WHERE b.activo = true
+        AND COALESCE(${m}.cuotas_atrasadas, 0) >= b.cuotas_min
+        AND (b.cuotas_max IS NULL OR COALESCE(${m}.cuotas_atrasadas, 0) <= b.cuotas_max)
+      ORDER BY b.numero LIMIT 1)
+  )
+`;
+};
 
 // ─────────────────────────── Tipos de respuesta ────────────────────────────
 
@@ -412,8 +456,16 @@ async function getMovimientosDia(fecha?: string): Promise<MovimientoCredito[]> {
     WHERE ${diaGTDe("h.fecha")}::date = ${f}
       AND h.tipo_evento IN ('SUBIDA', 'BAJADA')
     -- Lo más grave primero: subidas antes que bajadas, y dentro de cada una el
-    -- bucket destino más alto arriba.
-    ORDER BY h.tipo_evento DESC, h.bucket_nuevo DESC, h.historial_id DESC
+    -- bucket destino más alto arriba. El orden de SUBIDA/BAJADA va por CASE
+    -- explícito, NO por tipo_evento DESC: es un enum
+    -- ('INICIAL','SUBIDA','BAJADA') y Postgres ordena enums por su orden de
+    -- DECLARACIÓN, así que DESC pondría BAJADA (declarado después) antes que
+    -- SUBIDA — lo contrario de lo que queremos, y con el LIMIT un día pesado
+    -- cortaría las subidas (lo grave) dejando bajadas.
+    ORDER BY
+      CASE h.tipo_evento WHEN 'SUBIDA' THEN 0 ELSE 1 END,
+      h.bucket_nuevo DESC,
+      h.historial_id DESC
     LIMIT ${MAX_MOVIMIENTOS_DIA}
   `);
 
@@ -471,7 +523,9 @@ async function getTop3PorBucket(fecha?: string): Promise<Top3Bucket[]> {
         c.credito_id,
         c.numero_credito_sifco,
         u.nombre AS cliente,
-        ${bucketActualSql("c", "m")} AS bucket,
+        -- Bucket a la fecha f, NO "ahora": debe cuadrar con las cuotas
+        -- vencidas, que también se cuentan a f (ver bucketALaFechaSql).
+        ${bucketALaFechaSql("c", "m", f)} AS bucket,
         c."statusCredit" AS status_credito,
         c.cuota AS monto_cuota,
         COALESCE(m.monto_mora, 0) AS monto_mora,

--- a/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/cargaAsesorBucket.test.ts
@@ -43,7 +43,7 @@ const fakeDb: any = {
   },
 };
 
-mock.module("../../database", () => ({ db: fakeDb }));
+mock.module("../../database", () => ({ db: fakeDb, client: {} }));
 
 const { getCargaPorAsesorBucket, resolverMargen } = await import("./cargaAsesorBucket");
 

--- a/apps/cartera-back/src/controllers/buckets/reasignarAsesor.test.ts
+++ b/apps/cartera-back/src/controllers/buckets/reasignarAsesor.test.ts
@@ -77,7 +77,7 @@ const fakeDb: any = {
   transaction: async (cb: any) => cb(crearMutadores()),
 };
 
-mock.module("../../database", () => ({ db: fakeDb }));
+mock.module("../../database", () => ({ db: fakeDb, client: {} }));
 
 const schema = await import("../../database/db/schema");
 const {

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -14,6 +14,7 @@ import {
 import { getCargaPorAsesorBucket } from "../controllers/buckets/cargaAsesorBucket";
 import { actualizarCapacidadAsesorBucket } from "../controllers/buckets/actualizarAsesorBucket";
 import { getColaDiaSLA } from "../controllers/buckets/colaDia";
+import { getAperturaDia } from "../controllers/buckets/aperturaDia";
 import { StatusCredit } from "../database/db/schema";
 
 // Estados DENTRO del funnel operativo (= enum de statusCredit menos
@@ -597,6 +598,40 @@ export const bucketsRouter = new Elysia()
         asesor_nuevo_id: t.Union([t.Number(), t.String()]),
         motivo: t.String(),
         usuario_email: t.Optional(t.String()),
+      }),
+    },
+  )
+
+  // CB-023: vista de APERTURA MATUTINA del supervisor (8:00 AM). Devuelve el
+  // payload completo: cuentas nuevas por bucket (con el desglose de qué bucket
+  // vinieron), cumplimiento del día anterior, top 3 críticos por bucket, la
+  // asignación del día por asesor y el detalle crédito por crédito de los
+  // movimientos. `fecha` opcional (default hoy GT) para revisar días pasados.
+  .get(
+    "/buckets/apertura",
+    async ({ query, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        // Validar la fecha ANTES del cast ::date (misma razón que el resto de
+        // endpoints: un typo debe dar 400, no reventar en PG).
+        if (query.fecha && !esFecha(query.fecha)) {
+          set.status = 400;
+          return { success: false, message: "[ERROR] fecha inválida (formato YYYY-MM-DD)" };
+        }
+        const data = await getAperturaDia({ fecha: query.fecha });
+        return { success: true, data };
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudo obtener la apertura del día",
+          error: String(err),
+        };
+      }
+    },
+    {
+      query: t.Object({
+        fecha: t.Optional(t.String()),
       }),
     },
   );

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -87,19 +87,19 @@ const esFecha = (s: string): boolean => {
 // aquí el dueño y el status del crédito se leerían del estado actual (el modelo
 // no guarda historial continuo de status), así que se acota en vez de devolver
 // una foto histórica silenciosamente incorrecta.
-const APERTURA_DIAS_ATRAS = 7;
+export const APERTURA_DIAS_ATRAS = 7;
 
 // Hoy en GT (YYYY-MM-DD). Espejo de la fecha default del controller.
-const hoyGT = (): string =>
-  new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+export const hoyGT = (refDate = new Date()): string =>
+  refDate.toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
 
 // La fecha cae en [hoy - APERTURA_DIAS_ATRAS, hoy]. Sin futuras (no hay datos)
 // ni más atrás de la ventana. Asume `s` ya validada por esFecha. El mínimo se
 // deriva del DÍA GT (no de Date.now() en UTC) para no correrse por el offset
 // de zona horaria; con strings YYYY-MM-DD la comparación lexicográfica es
 // equivalente a la cronológica.
-const fechaEnRangoApertura = (s: string): boolean => {
-  const hoy = hoyGT();
+export const fechaEnRangoApertura = (s: string, refHoy?: string): boolean => {
+  const hoy = refHoy ?? hoyGT();
   const [y, m, d] = hoy.split("-").map(Number);
   const minDate = new Date(Date.UTC(y, m - 1, d - APERTURA_DIAS_ATRAS));
   const min = minDate.toISOString().slice(0, 10);

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -83,6 +83,29 @@ const esFecha = (s: string): boolean => {
   );
 };
 
+// Ventana en la que la apertura garantiza una foto FIEL a la fecha. Fuera de
+// aquí el dueño y el status del crédito se leerían del estado actual (el modelo
+// no guarda historial continuo de status), así que se acota en vez de devolver
+// una foto histórica silenciosamente incorrecta.
+const APERTURA_DIAS_ATRAS = 7;
+
+// Hoy en GT (YYYY-MM-DD). Espejo de la fecha default del controller.
+const hoyGT = (): string =>
+  new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+
+// La fecha cae en [hoy - APERTURA_DIAS_ATRAS, hoy]. Sin futuras (no hay datos)
+// ni más atrás de la ventana. Asume `s` ya validada por esFecha. El mínimo se
+// deriva del DÍA GT (no de Date.now() en UTC) para no correrse por el offset
+// de zona horaria; con strings YYYY-MM-DD la comparación lexicográfica es
+// equivalente a la cronológica.
+const fechaEnRangoApertura = (s: string): boolean => {
+  const hoy = hoyGT();
+  const [y, m, d] = hoy.split("-").map(Number);
+  const minDate = new Date(Date.UTC(y, m - 1, d - APERTURA_DIAS_ATRAS));
+  const min = minDate.toISOString().slice(0, 10);
+  return s >= min && s <= hoy;
+};
+
 export const bucketsRouter = new Elysia()
   .use(authMiddleware)
 
@@ -617,6 +640,20 @@ export const bucketsRouter = new Elysia()
         if (query.fecha && !esFecha(query.fecha)) {
           set.status = 400;
           return { success: false, message: "[ERROR] fecha inválida (formato YYYY-MM-DD)" };
+        }
+        // La vista solo garantiza una foto FIEL de hoy y de la ventana reciente
+        // (APERTURA_DIAS_ATRAS). Más atrás, el dueño del crédito y su status se
+        // leen del estado ACTUAL —no del de esa fecha—, así que la foto
+        // histórica se degrada en silencio. En vez de reconstruir todo el
+        // estado a la fecha (el modelo no guarda historial continuo de status),
+        // se acota el rango a una ventana en la que dueño/status casi no cambian
+        // y la foto sigue siendo confiable. Fuera de rango → 400.
+        if (query.fecha && !fechaEnRangoApertura(query.fecha)) {
+          set.status = 400;
+          return {
+            success: false,
+            message: `[ERROR] fecha fuera de rango (hoy o hasta ${APERTURA_DIAS_ATRAS} días atrás, sin futuras)`,
+          };
         }
         const data = await getAperturaDia({ fecha: query.fecha });
         return { success: true, data };


### PR DESCRIPTION
# feat(cobros): cartera-back — apertura matutina del supervisor (CB-023) y resolución de review Codex

## 📌 Contexto y Objetivo
El endpoint **`GET /buckets/apertura`** (CB-023) provee la fotografía operativa que el supervisor de cobranza necesita a las **8:00 AM** para arrancar la jornada diaria en una única llamada unificada. 

Adicionalmente, esta entrega consolida las soluciones a los hallazgos señalados durante las rondas de **Code Review del PR #1160 (Codex)** sobre la fidelidad de los datos históricos, el ordenamiento en base de datos y la cota estricta de fechas.

---

## 🚀 Secciones del Endpoint `GET /buckets/apertura`

El endpoint calcula **cinco secciones operativas** evaluadas sobre el mismo día en zona horaria de Guatemala (`America/Guatemala`):

1. **`cuentas_nuevas`**: 
   - Muestra las transiciones del día agrupadas por su **bucket DESTINO**, incluyendo el desglose detallado de su origen (*ej. "2 subieron desde B0, 3 bajaron desde B2"*).
   - Se deriva directamente del campo `buckets_historial.bucket_anterior`.

2. **`cumplimiento`**:
   - Analiza el universo de cuotas que **vencían el día de ayer**: cuántas fueron efectivamente pagadas, su monto acumulado y porcentaje global.
   - **Garantía matemática**: `pct` nunca devuelve `NaN` (si no existían cuotas esperadas retorna `0` en lugar de dividir entre cero).

3. **`top3`**:
   - Devuelve los 3 créditos más críticos de cada bucket, exponiendo además el total de créditos críticos del bucket y el peor monto acumulado para el encabezado de la interfaz.

4. **`asignacion`**:
   - Calcula las cuentas que **ENTRARON hoy al bucket de cada asesor**, agrupadas por su bucket de origen.
   - Representa el **delta neto del día** (a diferencia de CB-018 `/buckets/carga` que responde el acumulado de carga).

5. **`movimientos`**:
   - Detalle crédito por crédito del día (monto adeudado, días en mora reales, saltos de bucket y asesor asignado).

---

## 🧮 Fórmula del Ranking y Decisiones de Modelo

Para determinar cuáles son los créditos más críticos en el **Top 3**, se implementó la fórmula:

$$\text{monto\_adeudado} = (\text{cuotas\_vencidas\_reales} \times \text{creditos.cuota}) + \text{monto\_mora}$$

### Justificación Técnica:
- **`monto_mora`** (`moras_credito.monto_mora`): Es **únicamente el recargo por mora** (no incluye el valor de las cuotas vencidas), por lo que fue necesario sumar explícitamente el valor de cada cuota.
- **`cuotas_vencidas_reales`**: Se calcula **en vivo** desde `cuotas_credito`, no desde `moras_credito.cuotas_atrasadas` (ya que esa tabla es un snapshot que solo se refresca cuando ejecuta el job nocturno `procesarMoras`).
- **`dias_mora`**: Se deriva de la cuota vencida **MÁS VIEJA** (`MIN(fecha_vencimiento)` de las pendientes), y **NO** de `moras_credito.created_at` (el cual se reinicia si la mora se desactiva y se recrea).
- **Corte Top 3 en SQL**: Se realiza a nivel de base de datos usando `ROW_NUMBER() OVER (PARTITION BY bucket ORDER BY ...)` para evitar traer los ~1,600 créditos del funnel a memoria cuando solo se necesitan 18.
- **Límite de seguridad**: `getMovimientosDia` cuenta con un `LIMIT 500` para proteger la respuesta ante corridas masivas del motor de moras.

---

## 🌐 Conversión Fiel de Zona Horaria (Día Guatemala)

El campo `buckets_historial.fecha` es de tipo `timestamp` sin zona horaria (almacenado en UTC). Convertirlo correctamente al día local de Guatemala exige **DOS etapas explícitas en PostgreSQL**:

```sql
(h.fecha AT TIME ZONE 'UTC' AT TIME ZONE 'America/Guatemala')::date
