### PR TITLE
feat(cobros): CB-023 apertura matutina — CRM server (PR 2/3)

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -5417,7 +5417,21 @@ export const cobrosRouter = {
 					message: "Integración con cartera-back no está habilitada",
 				});
 			}
-			return carteraBackClient.getAperturaDia({ fecha: input.fecha });
+			try {
+				return await carteraBackClient.getAperturaDia({ fecha: input.fecha });
+			} catch (err) {
+				// cartera-back-client.ts (request()) lanza Error en cualquier no-2xx
+				// (400/404/500) — el {success:false} del client method nunca se
+				// alcanza. Se mapea el mensaje real de cartera-back a BAD_REQUEST en
+				// vez de burbujear como 500 genérico (mismo patrón que
+				// actualizarCapacidadAsesorBucket / reasignarAsesor más abajo).
+				throw new ORPCError("BAD_REQUEST", {
+					message:
+						err instanceof Error
+							? err.message
+							: "No se pudo obtener la apertura del día",
+				});
+			}
 		}),
 
 	// ────────────────────────────────────────────────────────────────────────

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -5375,6 +5375,52 @@ export const cobrosRouter = {
 		}),
 
 	// ────────────────────────────────────────────────────────────────────────
+	// CB-023 · Apertura matutina del supervisor (8:00 AM)
+	// Solo supervisor/admin (cobrosSupervisorProcedure): el ticket es "como
+	// supervisor". A diferencia de getAgendaDia, NO hay asesor forzado — no
+	// existe el caso "el cobrador ve la suya" para esta vista.
+	//
+	// Las 4 secciones vienen de /buckets/apertura. La "asignación del día" es
+	// el DELTA del día por asesor (a quién le cayó trabajo nuevo anoche), NO el
+	// dashboard de capacidad de CB-018.
+	// ────────────────────────────────────────────────────────────────────────
+	getAperturaDia: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				// YYYY-MM-DD opcional (default hoy GT en cartera-back).
+				// El regex solo valida la FORMA: 2026-02-30 la pasa. El refine hace
+				// round-trip contra Date para descartar fechas de calendario
+				// inexistentes — mismo criterio que `esFecha` en cartera-back
+				// (routers/buckets.ts), que si no las rechaza revientan en el
+				// ::date de Postgres. Validar aquí evita el viaje de ida y vuelta.
+				fecha: z
+					.string()
+					.regex(/^\d{4}-\d{2}-\d{2}$/)
+					.refine(
+						(s) => {
+							const [y, m, d] = s.split("-").map(Number);
+							const fecha = new Date(Date.UTC(y, m - 1, d));
+							return (
+								fecha.getUTCFullYear() === y &&
+								fecha.getUTCMonth() === m - 1 &&
+								fecha.getUTCDate() === d
+							);
+						},
+						{ message: "Fecha inexistente en el calendario" },
+					)
+					.optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			if (!isCarteraBackEnabled()) {
+				throw new ORPCError("BAD_REQUEST", {
+					message: "Integración con cartera-back no está habilitada",
+				});
+			}
+			return carteraBackClient.getAperturaDia({ fecha: input.fecha });
+		}),
+
+	// ────────────────────────────────────────────────────────────────────────
 	// CB-019 · Configurar capacidad_base/margen_alerta por asesor+bucket
 	// Solo admin (a diferencia de getCargaPorAsesorBucket, que sigue siendo
 	// admin+supervisor): el supervisor puede ver el dashboard pero no editar

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -149,6 +149,7 @@ export const cobrosAppRouter = {
 	getCreditosPorBucket: cobrosRouter.getCreditosPorBucket,
 	getPoolAsesoresPorBucket: cobrosRouter.getPoolAsesoresPorBucket,
 	getCargaPorAsesorBucket: cobrosRouter.getCargaPorAsesorBucket,
+	getAperturaDia: cobrosRouter.getAperturaDia,
 	reasignarAsesorCredito: cobrosRouter.reasignarAsesorCredito,
 	getHistorialReasignaciones: cobrosRouter.getHistorialReasignaciones,
 	getHistorialPagos: cobrosRouter.getHistorialPagos,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+	AperturaDiaResponse,
 	AsesorHistorialResponse,
 	BoletaPagoInversionista,
 	CargaPorAsesorBucketResponse,
@@ -1146,6 +1147,48 @@ export class CarteraBackClient {
 			data: CargaPorAsesorBucketResponse;
 		}>(`/buckets/carga?${queryParams}`, { method: "GET" });
 		return response.data ?? { buckets: [], porAsesor: [], fecha: "" };
+	}
+
+	// CB-023: apertura matutina del supervisor (cuentas nuevas por bucket,
+	// cumplimiento del día anterior, top 3 por bucket). Sin cache, misma razón
+	// que getCargaPorAsesorBucket: es una pantalla de decisión operativa donde
+	// la data desactualizada engaña; una reasignación tampoco invalida ningún
+	// substring que matchee "/buckets/apertura".
+	async getAperturaDia(
+		params: { fecha?: string } = {},
+	): Promise<AperturaDiaResponse> {
+		const queryParams = new URLSearchParams(
+			params.fecha ? { fecha: params.fecha } : {},
+		);
+		const qs = queryParams.toString();
+		const response = await this.request<{
+			success: boolean;
+			data: AperturaDiaResponse;
+		}>(`/buckets/apertura${qs ? `?${qs}` : ""}`, { method: "GET" });
+		return (
+			response.data ?? {
+				// Sin `fecha` el caller pidió HOY, así que el fallback tiene que
+				// resolverlo igual que el controller (día GT) — un string vacío
+				// dejaría la vista sin fecha en el encabezado.
+				fecha:
+					params.fecha ??
+					new Date().toLocaleDateString("sv-SE", {
+						timeZone: "America/Guatemala",
+					}),
+				cuentas_nuevas: [],
+				cumplimiento: {
+					fecha: "",
+					cuentas_esperadas: 0,
+					cuentas_pagadas: 0,
+					pct: 0,
+					monto_esperado: 0,
+					monto_pagado: 0,
+				},
+				top3: [],
+				asignacion: [],
+				movimientos: [],
+			}
+		);
 	}
 
 	// CB-019: escritura de capacidad_base/margen_alerta por asesor+bucket (antes

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -260,6 +260,121 @@ export interface CargaPorAsesorBucketResponse {
 	fecha: string;
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// CB-023 · Apertura matutina del supervisor (GET /buckets/apertura).
+// ─────────────────────────────────────────────────────────────────────────
+
+/** De dónde vinieron los créditos que entraron a un bucket. */
+export interface AperturaCuentasNuevasOrigen {
+	desde: number;
+	tipo: "SUBIDA" | "BAJADA";
+	cantidad: number;
+}
+
+/** Transiciones de bucket del día, por bucket destino. */
+export interface AperturaCuentasNuevas {
+	bucket: number;
+	entradas: number; // SUBIDA + BAJADA que aterrizan en este bucket
+	subidas: number;
+	bajadas: number;
+	/** Desglose "2 subieron desde B0, 3 bajaron desde B2". */
+	origenes: AperturaCuentasNuevasOrigen[];
+}
+
+/**
+ * Un crédito que cambió de bucket hoy. Trae el contexto completo aunque la UI
+ * muestre solo algunas columnas — así crecer la tabla no toca backend.
+ */
+export interface AperturaMovimiento {
+	credito_id: number;
+	numero_credito_sifco: string | null;
+	cliente: string | null;
+	bucket_anterior: number | null;
+	bucket_nuevo: number;
+	tipo_evento: "SUBIDA" | "BAJADA";
+	/** Saltos de bucket del movimiento (B1→B3 = 2). */
+	saltos: number;
+	status_credito: string | null;
+	cuotas_vencidas: number;
+	monto_cuota: number;
+	monto_mora: number;
+	monto_adeudado: number;
+	dias_mora: number;
+	asesor_id: number | null;
+	asesor: string | null;
+	fecha: string;
+}
+
+/** Un crédito crítico dentro del top 3 de su bucket. */
+export interface AperturaTop3Fila {
+	credito_id: number;
+	numero_credito_sifco: string | null;
+	cliente: string | null;
+	bucket: number;
+	status_credito: string;
+	cuotas_vencidas: number;
+	monto_cuota: number;
+	monto_mora: number;
+	/** (cuotas_vencidas × monto_cuota) + monto_mora — el eje del ranking. */
+	monto_adeudado: number;
+	dias_mora: number;
+	asesor_id: number | null;
+	asesor: string | null;
+}
+
+export interface AperturaTop3Bucket {
+	bucket: number;
+	total_criticos: number;
+	peor_monto: number;
+	top: AperturaTop3Fila[];
+}
+
+/** Cumplimiento del día anterior (cuotas que vencían ayer). */
+export interface AperturaCumplimiento {
+	fecha: string;
+	cuentas_esperadas: number;
+	cuentas_pagadas: number;
+	pct: number; // 0..100, nunca NaN
+	monto_esperado: number;
+	monto_pagado: number;
+}
+
+/**
+ * Ingreso agregado al bucket del asesor: "2 cuentas entraron desde B1".
+ * No distingue subida de bajada: para quien recibe, ambas son trabajo nuevo.
+ */
+export interface AperturaAsignacionBucket {
+	desde: number | null;
+	bucket: number; // destino (= bucket que atiende el asesor)
+	cantidad: number;
+}
+
+/**
+ * "Asignación del día": cuentas que le cayeron HOY a cada asesor por
+ * transición de bucket. Es el DELTA del día, no el acumulado de carga — eso lo
+ * responde CB-018 en /cobros/carga.
+ */
+export interface AperturaAsignacionAsesor {
+	asesor_id: number | null;
+	asesor: string | null;
+	/** Cuentas que entraron hoy al bucket del asesor. */
+	ingresos: number;
+	/** Bucket(s) del pool del asesor (asesor_bucket): a qué está asignado a atender. */
+	buckets_pool: number[];
+	porBucket: AperturaAsignacionBucket[];
+}
+
+/** Payload de /buckets/apertura. */
+export interface AperturaDiaResponse {
+	fecha: string;
+	cuentas_nuevas: AperturaCuentasNuevas[];
+	cumplimiento: AperturaCumplimiento;
+	top3: AperturaTop3Bucket[];
+	asignacion: AperturaAsignacionAsesor[];
+	/** Detalle crédito por crédito de los movimientos del día. */
+	movimientos: AperturaMovimiento[];
+}
+
 /** CB-019: input de PATCH /buckets/asesor-bucket/:asesor_id/:bucket. */
 export interface ActualizarCapacidadAsesorBucketInput {
 	asesor_id: number;


### PR DESCRIPTION
## CB-023 · Apertura matutina del supervisor — CRM server

Segundo de tres PRs. **Depende del PR #1161** (cartera-back, ya mergeado en `COBROS-02`), que expone `GET /buckets/apertura`. Este PR conecta ese endpoint al CRM. El tercero (web/UI) sale después de mergear éste.

### Qué hace
Expone la **apertura del supervisor** como procedure ORPC, actuando de proxy fino del endpoint de cartera-back. Sin lógica de negocio nueva del lado del CRM — el cálculo (top 3, cumplimiento, movimientos, cuentas nuevas) vive en cartera-back.

### Cambios
- **`routers/cobros.ts`** — `getAperturaDia` sobre `cobrosSupervisorProcedure`. El ticket es *"como supervisor"*, así que el rol `cobros` no ve esta vista; a diferencia de `getAgendaDia`, **no hay asesor forzado** (no existe el caso "el cobrador ve la suya").
  - Valida `fecha` (`YYYY-MM-DD`, opcional) con regex **+ round-trip contra `Date`** para descartar fechas de calendario inexistentes (`2026-02-30` pasa el regex pero no el refine) — mismo criterio que `esFecha` en cartera-back, evitando el viaje ida/vuelta al backend.
- **`routers/index.ts`** — registra `getAperturaDia` en `cobrosAppRouter`.
- **`services/cartera-back-client.ts`** — método `getAperturaDia({ fecha? })`. **Sin cache**, coherente con `getCargaPorAsesorBucket`: es una pantalla de decisión y una reasignación no invalidaría ningún substring que matchee `/buckets/apertura`.
- **`types/cartera-back.ts`** — tipos del payload: `AperturaDiaResponse` (cuentas_nuevas, cumplimiento, top3, asignacion, movimientos) y sus sub-tipos.

### Fuente única de verdad
La **ventana fiel de 7 días** (rechazo de fechas futuras / más viejas que `hoy - 7`) la sigue imponiendo cartera-back con `fechaEnRangoApertura` → `400`. No se duplica esa lógica aquí para evitar que las dos capas divergan. El refine de zod solo cubre la *forma* de la fecha.

### Verificación
- `bun run check-types` (server) — limpio.
- `git diff --check` — sin whitespace errors.
- El endpoint de cartera-back ya fue validado contra dev (`ep-green-tree`, schema `cartera_cobros2`) en el PR #1161.

🤖 Generated with [Claude Code](https://claude.com/claude-code)