### PR TITLE
feat(crm): filtro Pendiente Cancelación en casos de cobranza

### DIFF
--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -91,6 +91,7 @@ async function obtenerTodosLosCreditosCarteraBack(params: {
 		| "CANCELADO"
 		| "INCOBRABLE"
 		| "PENDIENTE_CANCELACION"
+		| "EN_CONVENIO"
 		| "MOROSO";
 	nombre_usuario?: string;
 	numero_credito_sifco?: string;
@@ -677,7 +678,13 @@ export const cobrosRouter = {
 
 					// Mapear filtro de estadoMora a parámetros de cartera-back
 					let cuotasAtrasadas: number | undefined;
-					let estadoCartera: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | undefined;
+					let estadoCartera:
+						| "ACTIVO"
+						| "CANCELADO"
+						| "INCOBRABLE"
+						| "PENDIENTE_CANCELACION"
+						| "EN_CONVENIO"
+						| undefined;
 					const searchTerm = input.searchTerm?.trim() || "";
 					const numeroSifcoExacto = input.numeroSifco?.trim() || "";
 					const hasNumber = /\d/.test(searchTerm);
@@ -720,7 +727,11 @@ export const cobrosRouter = {
 								estadoCartera = "CANCELADO";
 								break;
 							case "en_convenio":
-								estadoCartera = "EN_CONVENIO" as typeof estadoCartera;
+								estadoCartera = "EN_CONVENIO";
+								break;
+							case "pendiente_cancelacion":
+								// Solo cambiar el estado, sin filtrar por cuotas
+								estadoCartera = "PENDIENTE_CANCELACION";
 								break;
 							default:
 								// Sin filtro, mantener ACTIVO como predeterminado
@@ -1049,6 +1060,8 @@ export const cobrosRouter = {
 							if (statusCredit === "CANCELADO") estadoContrato = "completado";
 							else if (statusCredit === "INCOBRABLE")
 								estadoContrato = "incobrable";
+							else if (statusCredit === "PENDIENTE_CANCELACION")
+								estadoContrato = "pendiente_cancelacion";
 
 							// Buscar la oportunidad por número SIFCO para obtener datos del vehículo
 							const numeroSifco = credito.creditos.numero_credito_sifco;
@@ -2217,6 +2230,8 @@ export const cobrosRouter = {
 				let estadoContrato = "activo";
 				if (statusCredit === "CANCELADO") estadoContrato = "completado";
 				else if (statusCredit === "INCOBRABLE") estadoContrato = "incobrable";
+				else if (statusCredit === "PENDIENTE_CANCELACION")
+					estadoContrato = "pendiente_cancelacion";
 
 				return {
 					// ID del caso de cobros (si existe)
@@ -3250,8 +3265,12 @@ export const cobrosRouter = {
 			// 1. Mapear estadoMora → params de cartera-back (mismo mapping que
 			// getTodosLosCreditos).
 			let cuotasAtrasadas: number | undefined;
-			let estadoCartera: "ACTIVO" | "CANCELADO" | "INCOBRABLE" | undefined =
-				"ACTIVO";
+			let estadoCartera:
+				| "ACTIVO"
+				| "CANCELADO"
+				| "INCOBRABLE"
+				| "PENDIENTE_CANCELACION"
+				| undefined = "ACTIVO";
 			if (input.estadoMora) {
 				switch (input.estadoMora) {
 					case "al_dia":
@@ -3279,6 +3298,9 @@ export const cobrosRouter = {
 						break;
 					case "completado":
 						estadoCartera = "CANCELADO";
+						break;
+					case "pendiente_cancelacion":
+						estadoCartera = "PENDIENTE_CANCELACION";
 						break;
 					default:
 						estadoCartera = "ACTIVO";

--- a/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/mass-whatsapp-modal.tsx
@@ -111,6 +111,7 @@ const ESTADO_MORA_LABELS: Record<string, string> = {
 	mora_90: "Mora 90",
 	mora_120: "Mora 120+",
 	incobrable: "Incobrable",
+	pendiente_cancelacion: "Pendiente Cancelación",
 	completado: "Completado",
 };
 

--- a/apps/crm/apps/web/src/lib/cobros/columns.tsx
+++ b/apps/crm/apps/web/src/lib/cobros/columns.tsx
@@ -45,6 +45,7 @@ function getEstadoBadge(estado: string) {
 		mora_120: "bg-red-200 text-red-900",
 		mora_120_plus: "bg-red-300 text-red-950",
 		incobrable: "bg-gray-100 text-gray-800",
+		pendiente_cancelacion: "bg-purple-100 text-purple-800",
 		completado: "bg-blue-100 text-blue-800",
 	};
 
@@ -57,6 +58,7 @@ function getEstadoBadge(estado: string) {
 		mora_120: "Mora 120+",
 		mora_120_plus: "Mora 120+",
 		incobrable: "Incobrable",
+		pendiente_cancelacion: "Pendiente Cancelación",
 		completado: "Completado",
 	};
 

--- a/apps/crm/apps/web/src/routes/cobros/index.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/index.tsx
@@ -603,6 +603,11 @@ function RouteComponent() {
 			color: "bg-gray-100 text-gray-800",
 		},
 		{
+			key: "pendiente_cancelacion",
+			label: "Pendiente Cancelación",
+			color: "bg-purple-100 text-purple-800",
+		},
+		{
 			key: "completado",
 			label: "Completado",
 			color: "bg-blue-100 text-blue-800",


### PR DESCRIPTION
## Qué hace

Los créditos en estado `PENDIENTE_CANCELACION` no aparecían en ningún lado del módulo de cobros del CRM: el listado manda `estado=ACTIVO` por defecto y cartera-back expande ese paraguas solo a `ACTIVO + MOROSO + EN_CONVENIO`.

Se agrega un chip **Pendiente Cancelación** al filtro *Etapa de Mora*, siguiendo el mismo patrón que ya usan Incobrable y Completado (un solo `estado` que viaja transversal hasta cartera-back), sin tocar cartera-back ni el paraguas `ACTIVO` que comparten carteraFront y reportes.

## Cambios

- **`routers/cobros.ts`**: caso `pendiente_cancelacion` en los dos switches de `estadoMora` (listado y envío masivo de WhatsApp) → `estadoCartera = "PENDIENTE_CANCELACION"`. Se amplió el tipo de `estadoCartera` (de paso se eliminó el cast hack de `EN_CONVENIO`). El mapeo inverso ahora marca `estadoContrato = "pendiente_cancelacion"` para que la fila no se pinte como "Al Día".
- **`routes/cobros/index.tsx`**: chip "Pendiente Cancelación" en el filtro Etapa de Mora.
- **`lib/cobros/columns.tsx`**: color y label del badge en la tabla.
- **`components/cobros/mass-whatsapp-modal.tsx`**: label del filtro en el resumen del envío masivo.

## Comportamiento

- Con el chip seleccionado, la tabla (y el envío masivo, si se usa con ese filtro) trae los créditos en pendiente de cancelación.
- El listado por defecto ("Todas") no cambia — igual que Incobrable/Completado, solo salen al seleccionar su chip.

## Verificación

- `tsc --noEmit` en server: limpio. En web: mismos errores preexistentes con y sin el cambio (46 en los archivos tocados, ninguno nuevo).
- `bun test` en server: mismos 7 fallos preexistentes (insurance-selection), nada de cobros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)