### PR TITLE
feat(cobros): CB-020 configuración de días de SLA por bucket

### DIFF
--- a/apps/cartera-back/src/controllers/buckets/actualizarDiasSla.ts
+++ b/apps/cartera-back/src/controllers/buckets/actualizarDiasSla.ts
@@ -40,13 +40,15 @@ export async function actualizarDiasSlaBuckets(
 		}
 	}
 
-	for (const config of configs) {
-		await db.execute(sql`
-			UPDATE ${SQL_CARTERA_SCHEMA}.buckets
-			SET dias_sla = ${config.dias_sla}
-			WHERE numero = ${config.bucket}
-		`);
-	}
+	await db.transaction(async (tx) => {
+		for (const config of configs) {
+			await tx.execute(sql`
+				UPDATE ${SQL_CARTERA_SCHEMA}.buckets
+				SET dias_sla = ${config.dias_sla}
+				WHERE numero = ${config.bucket}
+			`);
+		}
+	});
 
 	return { success: true };
 }

--- a/apps/cartera-back/src/controllers/buckets/actualizarDiasSla.ts
+++ b/apps/cartera-back/src/controllers/buckets/actualizarDiasSla.ts
@@ -1,0 +1,52 @@
+import { sql } from "drizzle-orm";
+import { db } from "../../database";
+import { SQL_CARTERA_SCHEMA } from "../../database/db/schema";
+
+export type ConfigDiasSla = {
+	bucket: number;
+	dias_sla: number;
+};
+
+export async function actualizarDiasSlaBuckets(
+	configs: ConfigDiasSla[],
+): Promise<{ success: boolean; message?: string }> {
+	if (!Array.isArray(configs) || configs.length === 0) {
+		return { success: false, message: "Lista de configuraciones vacía" };
+	}
+
+	for (const config of configs) {
+		if (
+			typeof config.bucket !== "number" ||
+			config.bucket < 1 ||
+			config.bucket > 5 ||
+			!Number.isInteger(config.bucket)
+		) {
+			return {
+				success: false,
+				message: `Bucket inválido: ${config.bucket}. Debe estar entre 1 y 5.`,
+			};
+		}
+
+		if (
+			typeof config.dias_sla !== "number" ||
+			config.dias_sla < 1 ||
+			config.dias_sla > 30 ||
+			!Number.isInteger(config.dias_sla)
+		) {
+			return {
+				success: false,
+				message: `dias_sla inválido para bucket B${config.bucket}: ${config.dias_sla}. Debe estar entre 1 y 30.`,
+			};
+		}
+	}
+
+	for (const config of configs) {
+		await db.execute(sql`
+			UPDATE ${SQL_CARTERA_SCHEMA}.buckets
+			SET dias_sla = ${config.dias_sla}
+			WHERE numero = ${config.bucket}
+		`);
+	}
+
+	return { success: true };
+}

--- a/apps/cartera-back/src/lib/buckets-validation.test.ts
+++ b/apps/cartera-back/src/lib/buckets-validation.test.ts
@@ -4,12 +4,12 @@ import { bucketDeCredito } from "./buckets-classification";
 import type { BucketCatalogo, BucketCatalogoCompleto } from "./buckets-classification";
 
 const SEED_VALIDO: BucketCatalogoCompleto[] = [
-  { numero: 0, prefijo: "B0", nombre: "Cartera Sana", descripcion: null, cuotas_min: 0, cuotas_max: 0, estados_incluidos: [], es_operativo: true, orden: 0, color: null, estado_mora: "al_dia" },
-  { numero: 1, prefijo: "B1", nombre: "Alerta Temprana", descripcion: null, cuotas_min: 1, cuotas_max: 1, estados_incluidos: [], es_operativo: true, orden: 1, color: null, estado_mora: "mora_30" },
-  { numero: 2, prefijo: "B2", nombre: "Gestión Activa", descripcion: null, cuotas_min: 2, cuotas_max: 2, estados_incluidos: [], es_operativo: true, orden: 2, color: null, estado_mora: "mora_60" },
-  { numero: 3, prefijo: "B3", nombre: "Rescate", descripcion: null, cuotas_min: 3, cuotas_max: 3, estados_incluidos: [], es_operativo: true, orden: 3, color: null, estado_mora: "mora_90" },
-  { numero: 4, prefijo: "B4", nombre: "Última Instancia / Pre Jurídico", descripcion: null, cuotas_min: 4, cuotas_max: 4, estados_incluidos: [], es_operativo: true, orden: 4, color: null, estado_mora: "mora_120" },
-  { numero: 5, prefijo: "B5", nombre: "Jurídico", descripcion: null, cuotas_min: 5, cuotas_max: null, estados_incluidos: ["INCOBRABLE"], es_operativo: false, orden: 5, color: null, estado_mora: "mora_120_plus" },
+  { numero: 0, prefijo: "B0", nombre: "Cartera Sana", descripcion: null, cuotas_min: 0, cuotas_max: 0, estados_incluidos: [], es_operativo: true, orden: 0, color: null, estado_mora: "al_dia", dias_sla: null },
+  { numero: 1, prefijo: "B1", nombre: "Alerta Temprana", descripcion: null, cuotas_min: 1, cuotas_max: 1, estados_incluidos: [], es_operativo: true, orden: 1, color: null, estado_mora: "mora_30", dias_sla: 3 },
+  { numero: 2, prefijo: "B2", nombre: "Gestión Activa", descripcion: null, cuotas_min: 2, cuotas_max: 2, estados_incluidos: [], es_operativo: true, orden: 2, color: null, estado_mora: "mora_60", dias_sla: 3 },
+  { numero: 3, prefijo: "B3", nombre: "Rescate", descripcion: null, cuotas_min: 3, cuotas_max: 3, estados_incluidos: [], es_operativo: true, orden: 3, color: null, estado_mora: "mora_90", dias_sla: 2 },
+  { numero: 4, prefijo: "B4", nombre: "Última Instancia / Pre Jurídico", descripcion: null, cuotas_min: 4, cuotas_max: 4, estados_incluidos: [], es_operativo: true, orden: 4, color: null, estado_mora: "mora_120", dias_sla: 2 },
+  { numero: 5, prefijo: "B5", nombre: "Jurídico", descripcion: null, cuotas_min: 5, cuotas_max: null, estados_incluidos: ["INCOBRABLE"], es_operativo: false, orden: 5, color: null, estado_mora: "mora_120_plus", dias_sla: 1 },
 ];
 
 describe("validarCatalogoBuckets", () => {

--- a/apps/cartera-back/src/routers/buckets.ts
+++ b/apps/cartera-back/src/routers/buckets.ts
@@ -15,6 +15,7 @@ import { getCargaPorAsesorBucket } from "../controllers/buckets/cargaAsesorBucke
 import { actualizarCapacidadAsesorBucket } from "../controllers/buckets/actualizarAsesorBucket";
 import { getColaDiaSLA } from "../controllers/buckets/colaDia";
 import { getAperturaDia } from "../controllers/buckets/aperturaDia";
+import { actualizarDiasSlaBuckets } from "../controllers/buckets/actualizarDiasSla";
 import { StatusCredit } from "../database/db/schema";
 
 // Estados DENTRO del funnel operativo (= enum de statusCredit menos
@@ -669,6 +670,39 @@ export const bucketsRouter = new Elysia()
     {
       query: t.Object({
         fecha: t.Optional(t.String()),
+      }),
+    },
+  )
+
+  // CB-020: actualización de los días de SLA (dias_sla) para cada bucket (B1-B5).
+  .put(
+    "/buckets/dias-sla",
+    async ({ body, set, user }: any) => {
+      if (!requireBucketsRole(user, set)) return NO_AUTORIZADO;
+      try {
+        const result = await actualizarDiasSlaBuckets(body.configuraciones);
+        if (!result.success) {
+          set.status = 400;
+          return { success: false, message: result.message };
+        }
+        return result;
+      } catch (err) {
+        set.status = 500;
+        return {
+          success: false,
+          message: "[ERROR] No se pudieron actualizar los días de SLA de los buckets",
+          error: String(err),
+        };
+      }
+    },
+    {
+      body: t.Object({
+        configuraciones: t.Array(
+          t.Object({
+            bucket: t.Number(),
+            dias_sla: t.Number(),
+          }),
+        ),
       }),
     },
   );

--- a/apps/crm/apps/server/src/lib/moraBuckets.test.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.test.ts
@@ -219,6 +219,7 @@ describe("getBucketsParaUI", () => {
 				prefijo: "B0",
 				color: null,
 				orden: 0,
+				diasSla: null,
 			},
 			{
 				estadoMora: "mora_30",
@@ -226,6 +227,7 @@ describe("getBucketsParaUI", () => {
 				prefijo: "B1",
 				color: null,
 				orden: 1,
+				diasSla: 3,
 			},
 			{
 				estadoMora: "mora_60",
@@ -233,6 +235,7 @@ describe("getBucketsParaUI", () => {
 				prefijo: "B2",
 				color: null,
 				orden: 2,
+				diasSla: 3,
 			},
 			{
 				estadoMora: "mora_90",
@@ -240,6 +243,7 @@ describe("getBucketsParaUI", () => {
 				prefijo: "B3",
 				color: null,
 				orden: 3,
+				diasSla: 2,
 			},
 			{
 				estadoMora: "mora_120",
@@ -247,6 +251,7 @@ describe("getBucketsParaUI", () => {
 				prefijo: "B4",
 				color: null,
 				orden: 4,
+				diasSla: 2,
 			},
 			{
 				estadoMora: "mora_120_plus",
@@ -254,6 +259,7 @@ describe("getBucketsParaUI", () => {
 				prefijo: "B5",
 				color: null,
 				orden: 5,
+				diasSla: 1,
 			},
 		]);
 	});
@@ -278,6 +284,7 @@ describe("getBucketsParaUI", () => {
 			prefijo: "B0",
 			color: "#000",
 			orden: 0,
+			diasSla: null,
 		});
 		expect(ui[5]).toEqual({
 			estadoMora: "mora_120_plus",
@@ -285,6 +292,7 @@ describe("getBucketsParaUI", () => {
 			prefijo: "B5",
 			color: "#555",
 			orden: 5,
+			diasSla: 1,
 		});
 	});
 
@@ -336,6 +344,7 @@ describe("getBucketsParaUIAsync", () => {
 			prefijo: "B0",
 			color: "#000",
 			orden: 0,
+			diasSla: null,
 		});
 	});
 
@@ -360,6 +369,7 @@ describe("getBucketsParaUIAsync", () => {
 			prefijo: "B0",
 			color: null,
 			orden: 0,
+			diasSla: null,
 		});
 	});
 });

--- a/apps/crm/apps/server/src/lib/moraBuckets.ts
+++ b/apps/crm/apps/server/src/lib/moraBuckets.ts
@@ -29,6 +29,8 @@ export interface MoraBucket {
 	color: string | null;
 	/** Orden de presentación (embudo, filtros). */
 	orden: number;
+	/** Días de SLA para contactar al cliente desde que entra al bucket. */
+	diasSla: number | null;
 }
 
 export const MORA_BUCKETS: readonly MoraBucket[] = [
@@ -41,6 +43,7 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 		prefijo: "B0",
 		color: null,
 		orden: 0,
+		diasSla: null,
 	},
 	{
 		key: "1",
@@ -51,6 +54,7 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 		prefijo: "B1",
 		color: null,
 		orden: 1,
+		diasSla: 3,
 	},
 	{
 		key: "2",
@@ -61,6 +65,7 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 		prefijo: "B2",
 		color: null,
 		orden: 2,
+		diasSla: 3,
 	},
 	{
 		key: "3",
@@ -71,6 +76,7 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 		prefijo: "B3",
 		color: null,
 		orden: 3,
+		diasSla: 2,
 	},
 	{
 		key: "4",
@@ -81,6 +87,7 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 		prefijo: "B4",
 		color: null,
 		orden: 4,
+		diasSla: 2,
 	},
 	{
 		key: "5",
@@ -91,6 +98,7 @@ export const MORA_BUCKETS: readonly MoraBucket[] = [
 		prefijo: "B5",
 		color: null,
 		orden: 5,
+		diasSla: 1,
 	},
 ] as const;
 
@@ -174,9 +182,10 @@ export async function refreshMoraBucketsCache(): Promise<void> {
 		const mapped = Array.from(porNumero.values())
 			.sort((a, b) => a.orden - b.orden)
 			.map((b) => {
-				const fallbackEstado = MORA_BUCKETS.find(
+				const fallback = MORA_BUCKETS.find(
 					(f) => f.key === String(b.numero),
-				)?.estadoMora as string;
+				);
+				const fallbackEstado = fallback?.estadoMora as string;
 				const estadoMora =
 					b.estado_mora && ESTADOS_AGING_VALIDOS.has(b.estado_mora)
 						? b.estado_mora
@@ -190,6 +199,7 @@ export async function refreshMoraBucketsCache(): Promise<void> {
 					prefijo: b.prefijo,
 					color: b.color,
 					orden: b.orden,
+					diasSla: b.dias_sla ?? fallback?.diasSla ?? null,
 				};
 			});
 		// Guard: catálogo vacío, o sin cubrir cada bucket conocido (siembra
@@ -279,6 +289,7 @@ export type BucketParaUI = {
 	prefijo: string | null;
 	color: string | null;
 	orden: number;
+	diasSla: number | null;
 };
 
 function mapearBucketsParaUI(): BucketParaUI[] {
@@ -289,6 +300,7 @@ function mapearBucketsParaUI(): BucketParaUI[] {
 			prefijo: b.prefijo,
 			color: b.color,
 			orden: b.orden,
+			diasSla: b.diasSla,
 		}))
 		.sort((a, b) => a.orden - b.orden);
 }

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -74,6 +74,7 @@ import {
 	getBucketsParaUIAsync,
 	MORA_BUCKETS,
 	rangoCuotasPorEstadoMora,
+	refreshMoraBucketsCache,
 } from "../lib/moraBuckets";
 import {
 	adminProcedure,
@@ -2560,6 +2561,7 @@ export const cobrosRouter = {
 						message: res.message ?? "No se pudieron actualizar los días de SLA",
 					});
 				}
+				await refreshMoraBucketsCache();
 				return { success: true };
 			} catch (error) {
 				if (error instanceof ORPCError) throw error;

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2536,6 +2536,40 @@ export const cobrosRouter = {
 			}
 		}),
 
+	// CB-020: actualizar días de SLA (dias_sla) por bucket (B1-B5). Solo supervisor / admin.
+	actualizarDiasSlaBuckets: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				configuraciones: z.array(
+					z.object({
+						bucket: z.number().int().min(1).max(5),
+						diasSla: z.number().int().min(1).max(30),
+					}),
+				),
+			}),
+		)
+		.handler(async ({ input }) => {
+			try {
+				const payload = input.configuraciones.map((c) => ({
+					bucket: c.bucket,
+					dias_sla: c.diasSla,
+				}));
+				const res = await carteraBackClient.updateBucketsSLA(payload);
+				if (!res.success) {
+					throw new ORPCError("BAD_REQUEST", {
+						message: res.message ?? "No se pudieron actualizar los días de SLA",
+					});
+				}
+				return { success: true };
+			} catch (error) {
+				if (error instanceof ORPCError) throw error;
+				console.error("[actualizarDiasSlaBuckets] Error:", error);
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "Error al actualizar la configuración de SLA",
+				});
+			}
+		}),
+
 	// Obtener historial de cuotas de pago de un contrato
 	getHistorialPagos: cobrosProcedure
 		.input(z.object({ numeroSifco: z.string() }))

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -145,6 +145,7 @@ export const cobrosAppRouter = {
 	getBucketsHistorialCredito: cobrosRouter.getBucketsHistorialCredito,
 	getAgendaDia: cobrosRouter.getAgendaDia,
 	getColaDia: cobrosRouter.getColaDia,
+	actualizarDiasSlaBuckets: cobrosRouter.actualizarDiasSlaBuckets,
 	getRecordatoriosPremora: cobrosRouter.getRecordatoriosPremora,
 	getCreditosPorBucket: cobrosRouter.getCreditosPorBucket,
 	getPoolAsesoresPorBucket: cobrosRouter.getPoolAsesoresPorBucket,

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1124,6 +1124,18 @@ export class CarteraBackClient {
 		);
 	}
 
+	async updateBucketsSLA(
+		configuraciones: Array<{ bucket: number; dias_sla: number }>,
+	): Promise<{ success: boolean; message?: string }> {
+		return this.request<{ success: boolean; message?: string }>(
+			"/buckets/dias-sla",
+			{
+				method: "PUT",
+				body: JSON.stringify({ configuraciones }),
+			},
+		);
+	}
+
 	// CB-018: carga de cuentas por asesor y bucket (dashboard gerencial) —
 	// cuentas asignadas, capacidad base, % utilización, sobrecarga y alerta de
 	// nueva posición. Fuente de la página /cobros/carga del CRM.

--- a/apps/crm/apps/server/src/services/cartera-back-client.ts
+++ b/apps/crm/apps/server/src/services/cartera-back-client.ts
@@ -1127,13 +1127,15 @@ export class CarteraBackClient {
 	async updateBucketsSLA(
 		configuraciones: Array<{ bucket: number; dias_sla: number }>,
 	): Promise<{ success: boolean; message?: string }> {
-		return this.request<{ success: boolean; message?: string }>(
+		const result = await this.request<{ success: boolean; message?: string }>(
 			"/buckets/dias-sla",
 			{
 				method: "PUT",
 				body: JSON.stringify({ configuraciones }),
 			},
 		);
+		this.cache.invalidate("/config/buckets");
+		return result;
 	}
 
 	// CB-018: carga de cuentas por asesor y bucket (dashboard gerencial) —

--- a/apps/crm/apps/web/src/components/cobros/configurar-sla-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/configurar-sla-modal.tsx
@@ -103,7 +103,8 @@ export function ConfigurarSlaModal({
 		return typeof val !== "number" || val < 1 || val > 30;
 	});
 
-	const isValid = !invalidBucket;
+	const catalogoListo = catalogo !== undefined;
+	const isValid = !invalidBucket && catalogoListo;
 
 	return (
 		<Dialog open={open} onOpenChange={onOpenChange}>
@@ -200,10 +201,16 @@ export function ConfigurarSlaModal({
 					<Button
 						onClick={() => updateMutation.mutate()}
 						disabled={!isValid || updateMutation.isPending}
-						title={!isValid ? "Debes ingresar valores entre 1 y 30 días para todos los buckets" : ""}
+						title={
+							!catalogoListo
+								? "Esperando a que cargue el catálogo de buckets..."
+								: !isValid
+									? "Debes ingresar valores entre 1 y 30 días para todos los buckets"
+									: ""
+						}
 						className="gap-2 bg-indigo-600 hover:bg-indigo-700 text-white disabled:opacity-50"
 					>
-						{updateMutation.isPending ? (
+						{updateMutation.isPending || !catalogoListo ? (
 							<Loader2 className="h-4 w-4 animate-spin" />
 						) : (
 							<Save className="h-4 w-4" />

--- a/apps/crm/apps/web/src/components/cobros/configurar-sla-modal.tsx
+++ b/apps/crm/apps/web/src/components/cobros/configurar-sla-modal.tsx
@@ -1,0 +1,217 @@
+import { useMutation } from "@tanstack/react-query";
+import { AlertCircle, Clock, Loader2, Save } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+	type BucketsCatalogoQueryData,
+	bucketDeEstado,
+	estiloBucket,
+} from "@/lib/cobros/buckets-catalogo";
+import { client, orpc, queryClient } from "@/utils/orpc";
+
+interface ConfigurarSlaModalProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	catalogo: BucketsCatalogoQueryData | undefined;
+}
+
+const BUCKETS_CONFIG = [
+	{ numero: 1, key: "mora_30", labelDefault: "Alerta Temprana", defaultSla: 3 },
+	{ numero: 2, key: "mora_60", labelDefault: "Gestión Activa", defaultSla: 3 },
+	{ numero: 3, key: "mora_90", labelDefault: "Rescate", defaultSla: 2 },
+	{
+		numero: 4,
+		key: "mora_120",
+		labelDefault: "Última Instancia / Pre Jurídico",
+		defaultSla: 2,
+	},
+	{ numero: 5, key: "mora_120_plus", labelDefault: "Jurídico", defaultSla: 1 },
+] as const;
+
+export function ConfigurarSlaModal({
+	open,
+	onOpenChange,
+	catalogo,
+}: ConfigurarSlaModalProps) {
+	const [values, setValues] = useState<Record<number, number>>({
+		1: 3,
+		2: 3,
+		3: 2,
+		4: 2,
+		5: 1,
+	});
+
+	// Cargar valores actuales desde el catálogo dinámico si está disponible
+	useEffect(() => {
+		if (catalogo && open) {
+			const initial: Record<number, number> = {};
+			for (const item of BUCKETS_CONFIG) {
+				const ui = bucketDeEstado(item.key, catalogo);
+				const catItem = catalogo.find(
+					(c) => c.prefijo === `B${item.numero}` || c.label === ui.label,
+				);
+				initial[item.numero] = catItem?.diasSla ?? item.defaultSla;
+			}
+			setValues(initial);
+		}
+	}, [catalogo, open]);
+
+	const updateMutation = useMutation({
+		mutationFn: async () => {
+			const configuraciones = BUCKETS_CONFIG.map((b) => ({
+				bucket: b.numero,
+				diasSla: Number(values[b.numero]) || b.defaultSla,
+			}));
+			return client.actualizarDiasSlaBuckets({ configuraciones });
+		},
+		onSuccess: () => {
+			toast.success("Días de SLA actualizados correctamente");
+			queryClient.invalidateQueries({
+				queryKey: orpc.getColaDia.key(),
+			});
+			queryClient.invalidateQueries({
+				queryKey: orpc.getBucketsCatalogo.key(),
+			});
+			onOpenChange(false);
+		},
+		onError: (err: Error) => {
+			toast.error(err.message || "Error al actualizar la configuración de SLA");
+		},
+	});
+
+	const handleChange = (numero: number, valStr: string) => {
+		const num = parseInt(valStr, 10);
+		setValues((prev) => ({
+			...prev,
+			[numero]: Number.isNaN(num) ? 0 : num,
+		}));
+	};
+
+	const invalidBucket = BUCKETS_CONFIG.find((b) => {
+		const val = values[b.numero];
+		return typeof val !== "number" || val < 1 || val > 30;
+	});
+
+	const isValid = !invalidBucket;
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[520px]">
+				<DialogHeader>
+					<DialogTitle className="flex items-center gap-2 text-xl font-bold">
+						<Clock className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+						Configurar Días de SLA por Bucket
+					</DialogTitle>
+					<DialogDescription>
+						Define los días de plazo (entre 1 y 30 días) para contactar a un cliente según su bucket de mora.
+					</DialogDescription>
+				</DialogHeader>
+
+				<div className="py-3 space-y-3">
+					{BUCKETS_CONFIG.map((b) => {
+						const ui = bucketDeEstado(b.key, catalogo);
+						const val = values[b.numero];
+						const isError = typeof val !== "number" || val < 1 || val > 30;
+
+						return (
+							<div
+								key={b.numero}
+								className={`p-3 rounded-lg border transition-colors ${
+									isError
+										? "border-red-300 bg-red-50/40 dark:border-red-900/60 dark:bg-red-950/20"
+										: "bg-card hover:bg-slate-50 dark:hover:bg-slate-900/50"
+								}`}
+							>
+								<div className="flex items-center justify-between">
+									<div className="flex items-center gap-3">
+										<Badge
+											variant="outline"
+											className="font-bold text-xs px-2.5 py-0.5"
+											style={estiloBucket(ui.colorHex)}
+										>
+											B{b.numero}
+										</Badge>
+										<div>
+											<p className="font-semibold text-sm text-foreground">
+												{ui.label || b.labelDefault}
+											</p>
+											<p className="text-xs text-muted-foreground">
+												Días hábiles / calendario desde ingreso
+											</p>
+										</div>
+									</div>
+
+									<div className="flex flex-col items-end gap-1">
+										<div className="flex items-center gap-2">
+											<Input
+												type="number"
+												min={1}
+												max={30}
+												value={val === 0 ? "" : val}
+												onChange={(e) => handleChange(b.numero, e.target.value)}
+												className={`w-20 text-center font-medium ${
+													isError ? "border-red-500 focus-visible:ring-red-500 text-red-600 font-bold" : ""
+												}`}
+											/>
+											<span className="text-xs text-muted-foreground w-8">
+												días
+											</span>
+										</div>
+									</div>
+								</div>
+								{isError && (
+									<p className="text-[11px] text-red-600 dark:text-red-400 font-medium text-right mt-1">
+										⚠️ El valor debe ser de 1 a 30 días
+									</p>
+								)}
+							</div>
+						);
+					})}
+
+					{!isValid && (
+						<div className="flex items-center gap-2 p-3 rounded-md bg-red-50 text-red-800 dark:bg-red-950/40 dark:text-red-300 text-xs border border-red-200 dark:border-red-800">
+							<AlertCircle className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
+							<span>
+								No es posible guardar: El plazo de SLA para el bucket <strong>B{invalidBucket?.numero}</strong> debe estar en el rango de <strong>1 a 30 días</strong>.
+							</span>
+						</div>
+					)}
+				</div>
+
+				<DialogFooter className="gap-2 sm:gap-0">
+					<Button
+						variant="outline"
+						onClick={() => onOpenChange(false)}
+						disabled={updateMutation.isPending}
+					>
+						Cancelar
+					</Button>
+					<Button
+						onClick={() => updateMutation.mutate()}
+						disabled={!isValid || updateMutation.isPending}
+						title={!isValid ? "Debes ingresar valores entre 1 y 30 días para todos los buckets" : ""}
+						className="gap-2 bg-indigo-600 hover:bg-indigo-700 text-white disabled:opacity-50"
+					>
+						{updateMutation.isPending ? (
+							<Loader2 className="h-4 w-4 animate-spin" />
+						) : (
+							<Save className="h-4 w-4" />
+						)}
+						Guardar Cambios
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
+++ b/apps/crm/apps/web/src/lib/cobros/buckets-catalogo.ts
@@ -131,6 +131,7 @@ export type BucketsCatalogoQueryData = {
 	prefijo: string | null;
 	color: string | null;
 	orden: number;
+	diasSla?: number | null;
 }[];
 
 /** Catálogo dinámico de buckets de aging (B0-B5), vía ORPC. Cachea 5 min en el server. */

--- a/apps/crm/apps/web/src/routes/cobros/cola.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/cola.tsx
@@ -4,12 +4,14 @@ import {
 	ChevronLeft,
 	ChevronRight,
 	ClipboardList,
+	Clock,
 	Loader2,
 	Phone,
 	UserRound,
 } from "lucide-react";
 import { useState } from "react";
 import { BucketMultiSelect } from "@/components/cobros/bucket-multi-select";
+import { ConfigurarSlaModal } from "@/components/cobros/configurar-sla-modal";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -204,6 +206,7 @@ function ColaDiaPage() {
 	const [filtro, setFiltro] = useState<Filtro>("todos");
 	const [bucketsSel, setBucketsSel] = useState<number[] | null>(null);
 	const [page, setPage] = useState(1);
+	const [isSlaModalOpen, setIsSlaModalOpen] = useState(false);
 
 	const asesorIdInput =
 		esSupervisor && asesorSel !== "todos" ? Number(asesorSel) : undefined;
@@ -290,7 +293,20 @@ function ColaDiaPage() {
 								<ClipboardList className="h-5 w-5" />
 							</div>
 							<div>
-								<CardTitle className="text-xl">Cola del día</CardTitle>
+								<div className="flex items-center gap-3">
+									<CardTitle className="text-xl">Cola del día</CardTitle>
+									{esSupervisor && (
+										<Button
+											variant="outline"
+											size="sm"
+											className="gap-2 border-indigo-200 bg-indigo-50/80 hover:bg-indigo-100 text-indigo-700 dark:border-indigo-800 dark:bg-indigo-950/60 dark:text-indigo-300 dark:hover:bg-indigo-900/60 font-semibold"
+											onClick={() => setIsSlaModalOpen(true)}
+										>
+											<Clock className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
+											Configurar SLA
+										</Button>
+									)}
+								</div>
 								<CardDescription>
 									Cuentas priorizadas para gestionar hoy: SLA vencido, promesas
 									de pago que vencen hoy, promesas incumplidas y cuentas sin
@@ -489,6 +505,11 @@ function ColaDiaPage() {
 						</CardContent>
 					</Card>
 				)}
+			<ConfigurarSlaModal
+				open={isSlaModalOpen}
+				onOpenChange={setIsSlaModalOpen}
+				catalogo={bucketsCatalogo.data}
+			/>
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary
- Nuevo endpoint `PUT /buckets/dias-sla` en cartera-back para actualizar `dias_sla` (B1-B5)
- Proc ORPC `actualizarDiasSlaBuckets` (solo supervisor/admin) que llama a cartera-back
- Modal "Configurar SLA" en Cola del Día para que supervisores editen los días por bucket
- `diasSla` propagado por el catálogo dinámico de buckets (moraBuckets, buckets-catalogo) hasta el UI

## Test plan
- [x] `bun test` en cartera-back (buckets-validation) — 19 pass
- [x] `bun test` en crm/apps/server (moraBuckets) — 15 pass
- [x] `bun run check-types` completo (server + web) — limpio
- [x] Migración `0006_buckets_dias_sla.sql` ya existe y agrega columna + valores placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)