### PR TITLE
feat(cartera): modalidad de facturación por crédito en correos de compra de cartera

### DIFF
--- a/apps/cartera-back/src/controllers/addInvestorToCredit.ts
+++ b/apps/cartera-back/src/controllers/addInvestorToCredit.ts
@@ -1446,6 +1446,9 @@ export const addInvestorToCredit = async ({ body, set, request }: any) => {
               tipo_reinversion && tipo_reinversion !== "sin_reinversion"
                 ? tipo_reinversion
                 : null,
+            // Modalidad de facturación de esta compra (misma para todos los
+            // créditos de la operación); null si no se eligió → el email muestra "—".
+            modalidad_facturacion: modalidad_facturacion ?? null,
           })),
           usuarioNombre,
           usuarioEmail,

--- a/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
+++ b/apps/cartera-back/src/controllers/compraCarteraAceptada.ts
@@ -230,6 +230,8 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
         credito_id: creditos_inversionistas_espejo.credito_id,
         inversionista_id: creditos_inversionistas_espejo.inversionista_id,
         tipo_reinversion: creditos_inversionistas_espejo.tipo_reinversion,
+        modalidad_facturacion:
+          creditos_inversionistas_espejo.modalidad_facturacion,
       });
 
     // ── 4.5.bis. Marcar las compras pendientes como aceptadas ──
@@ -258,6 +260,12 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
       updateRes.map((r) => [r.credito_id, r.tipo_reinversion ?? null]),
     );
 
+    // Mapa credito_id → modalidad_facturacion del target (mismo criterio que
+    // tipo_reinversion: la fila que quedó en "pendiente_compra_cartera").
+    const modalidadFactPorCredito = new Map<number, string | null>(
+      updateRes.map((r) => [r.credito_id, r.modalidad_facturacion ?? null]),
+    );
+
     // Pool por crédito en el orden que vinieron los créditos en creditosRows.
     // Dentro de cada pool, CUBE va primero. Incluimos la modalidad
     // (tipo_reinversion del target en el espejo) para mostrarla en el
@@ -274,6 +282,8 @@ export const compraCarteraAceptada = async ({ body, set, request }: any) => {
         | "reinversion_excedente"
         | "reinversion_combinada"
         | null,
+      modalidad_facturacion: (modalidadFactPorCredito.get(c.credito_id) ??
+        null) as "p2p_directa" | "factura_cube" | "factura_cube_pequeno" | null,
       rows: (rowsPorCredito.get(c.credito_id) ?? [])
         .sort((a, b) => {
           if (a.inversionista_id === CUBE_INVESTMENT_ID) return -1;

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -245,6 +245,11 @@ export interface SendInvestorAddedToCreditsNotificationParams {
       | "reinversion_excedente"
       | "reinversion_variable"
       | null;
+    modalidad_facturacion?:
+      | "p2p_directa"
+      | "factura_cube"
+      | "factura_cube_pequeno"
+      | null;
   }>;
   currencySymbol?: string;
   usuarioNombre?: string;
@@ -285,6 +290,13 @@ export const sendInvestorAddedToCreditsNotification = async ({
       reinversion_variable: "Reinversión Variable",
     };
 
+    // Modalidad de facturación por operación (régimen fiscal elegido en la compra).
+    const modalidadFacturacionLabel: Record<string, string> = {
+      p2p_directa: "Facturación P2P Directa",
+      factura_cube: "1 Factura a Cube",
+      factura_cube_pequeno: "1 Factura a Cube · Pequeño Contribuyente",
+    };
+
     const filas = creditos
       .map(
         (c) => `
@@ -293,6 +305,11 @@ export const sendInvestorAddedToCreditsNotification = async ({
             <td style="padding:8px;border:1px solid #e5e7eb;text-align:right;">${currencySymbol}${c.monto_asignado}</td>
             <td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">${
               c.tipo_reinversion ? modalidadLabel[c.tipo_reinversion] ?? c.tipo_reinversion : "Tradicional"
+            }</td>
+            <td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">${
+              c.modalidad_facturacion
+                ? modalidadFacturacionLabel[c.modalidad_facturacion] ?? c.modalidad_facturacion
+                : "—"
             }</td>
             <td style="padding:8px;border:1px solid #e5e7eb;text-align:center;">
               <span style="background:#fef3c7;color:#92400e;padding:2px 8px;border-radius:9999px;font-size:12px;font-weight:600;">POR VALIDAR</span>
@@ -325,6 +342,7 @@ export const sendInvestorAddedToCreditsNotification = async ({
               <th style="padding:8px;border:1px solid #e5e7eb;text-align:left;">Crédito</th>
               <th style="padding:8px;border:1px solid #e5e7eb;text-align:right;">Monto asignado</th>
               <th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">Modalidad</th>
+              <th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">Facturación</th>
               <th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">Estado</th>
               <th style="padding:8px;border:1px solid #e5e7eb;text-align:center;">CUBE eliminado</th>
             </tr>
@@ -382,6 +400,11 @@ export interface SendCompraCarteraAcceptedNotificationParams {
       | "reinversion_variable"
       | "reinversion_excedente"
       | "reinversion_combinada"
+      | null;
+    modalidad_facturacion?:
+      | "p2p_directa"
+      | "factura_cube"
+      | "factura_cube_pequeno"
       | null;
     rows: Array<{
       inversionista_nombre: string;
@@ -446,6 +469,13 @@ export const sendCompraCarteraAcceptedNotification = async ({
       reinversion_combinada: "Reinversión Combinada",
     };
 
+    // Modalidad de facturación por operación (régimen fiscal de la compra).
+    const modalidadFacturacionLabelCreditos: Record<string, string> = {
+      p2p_directa: "Facturación P2P Directa",
+      factura_cube: "1 Factura a Cube",
+      factura_cube_pequeno: "1 Factura a Cube · Pequeño Contribuyente",
+    };
+
     // Una tabla por crédito: encabezado con cliente/SIFCO/capital/modalidad y filas de inversionistas.
     const poolsPorCredito = pool
       .map((grupo) => {
@@ -463,17 +493,23 @@ export const sendCompraCarteraAcceptedNotification = async ({
           ? modalidadLabelCreditos[grupo.tipo_reinversion] ?? grupo.tipo_reinversion
           : "Tradicional";
 
+        const facturacion = grupo.modalidad_facturacion
+          ? modalidadFacturacionLabelCreditos[grupo.modalidad_facturacion] ??
+            grupo.modalidad_facturacion
+          : "—";
+
         return `
           <p style="margin:12px 0 4px 0;font-size:13px;color:#374151;">
             <strong>${grupo.cliente_nombre}</strong>
             <span style="color:#6b7280;"> — ${grupo.numero_credito_sifco}</span>
             <span style="color:#6b7280;"> — Modalidad: ${modalidad}</span>
+            <span style="color:#6b7280;"> — Facturación: ${facturacion}</span>
           </p>
           <table style="border-collapse:collapse;width:100%;font-size:14px;margin-top:0;margin-bottom:12px;">
             <thead>
               <tr>
                 <th colspan="2" style="padding:8px 12px;border:1px solid #f59e0b;background:#fef3c7;color:#78350f;text-align:left;font-weight:600;">
-                  Modalidad: ${modalidad}
+                  Modalidad: ${modalidad} · Facturación: ${facturacion}
                 </th>
               </tr>
             </thead>


### PR DESCRIPTION
## Qué

Agrega la **modalidad de facturación** (régimen fiscal elegido en la compra) a los **dos correos** de compra de cartera, **por crédito** — va de la mano con el contrato nuevo, ya que a raíz de la aceptación se genera el contrato y ahí se necesita saber la figura fiscal de cada crédito.

Labels tomados de la fuente única del CRM (`lib/modalidad-facturacion.ts`):

| valor | label |
|---|---|
| `p2p_directa` | Facturación P2P Directa |
| `factura_cube` | 1 Factura a Cube |
| `factura_cube_pequeno` | 1 Factura a Cube · Pequeño Contribuyente |

## Cambios

**`packages/email/src/index.ts`**
- Correo de compra (`sendInvestorAddedToCreditsNotification`): nueva columna **"Facturación"** en la tabla de créditos.
- Correo de aceptación (`sendCompraCarteraAcceptedNotification`): línea **"Facturación: …"** en el header de cada crédito y en el título de su tabla de pool.

**`apps/cartera-back/src/controllers/addInvestorToCredit.ts`**
- Pasa `modalidad_facturacion` de la operación a cada crédito del correo de compra.

**`apps/cartera-back/src/controllers/compraCarteraAceptada.ts`**
- Trae `modalidad_facturacion` del espejo en el `.returning()`, arma el mapa por crédito y lo inyecta al pool.

## Notas

- **Retrocompatible**: si el crédito no tiene modalidad (compras previas a la migración `0018`) muestra **"—"**. No toca lógica financiera (spreads/brackets/tasas), solo lee y despliega el dato.
- El dato vive **por operación** en `creditos_inversionistas_espejo` / `compras_credito_inversionista` (migración 0018), así que en la aceptación cada crédito muestra su modalidad real.
- Typecheck limpio en los 3 archivos (los 7 errores de `tsc` en cartera-back son preexistentes: tipos de `pg`, un test de moras, `registerPayment.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)