### PR TITLE
fix(cartera): revertir un pago ya no pisa membresías/restantes de cuotas pagadas

### DIFF
--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -19,7 +19,6 @@ import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { updateMora } from "./latefee";
 import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
-import { updateInstallments } from "./updateCredit";
 import { esPagoAplicado } from "../utils/paymentStatus";
 import {
   getRemainingPaymentPaidStatusAfterReversal,
@@ -715,30 +714,15 @@ export const reversePayment = async ({ body, set }: any) => {
         reversionEspejo,
       };
     });
-try {
-  // En un INCOBRABLE NO se refrescan las cuotas: updateInstallments recalcula
-  // interes_restante/iva_12_restante de cada fila con `porcentaje_interes`
-  // (preservado en el castigo) y revivirían interés/IVA sobre un calendario
-  // que debe ser capital-only, corrompiendo el castigo tras la reversa.
-  if (result.creditData.creditos.statusCredit === "INCOBRABLE") {
-    console.log(
-      "⏭️ INCOBRABLE: se omite updateInstallments (cuota capital-only, no se recalcula interés)"
-    );
-  } else {
-    // Solo cuotas NO pagadas: con all:true se reescribían las cuotas ya
-    // pagadas del crédito (restantes teóricos + membresias_pago en 0),
-    // corrompiendo la historia liquidada cada vez que se revertía un pago.
-    await updateInstallments({
-      numero_credito_sifco: result.creditData.creditos.numero_credito_sifco,
-      nueva_cuota: Number(result.creditData.creditos.cuota),
-    });
-
-    console.log("✅ Cuotas pendientes recalculadas correctamente");
-  }
-} catch (updateError: any) {
-  console.error("⚠️ Error en UPDATE ALL STATEMENT:", updateError.message);
-  // NO hacer throw aquí porque la transacción ya se completó
-}
+// La reversión NO recalcula ninguna otra fila del crédito. La transacción de
+// arriba ya deja todo consistente (pago reseteado, capital/deuda restaurados).
+// Aquí vivía un updateInstallments({all: true}) (agregado en 0183a387, ene-2026)
+// que reescribía las cuotas YA PAGADAS del crédito: restantes teóricos,
+// cuota actual y membresias_pago/membresias_mes en 0 — corrompiendo la
+// historia liquidada en cada reversión (los INCOBRABLES ya lo omitían por un
+// clavo análogo, PR #890). La proyección teórica de las cuotas pendientes se
+// refresca por el flujo normal (siguiente pago aplicado o el botón manual
+// "Recalcular Pagos"), igual que antes de enero 2026.
     // ========================================================================
     // ✅ TRANSACCIÓN COMPLETADA - RETORNAR RESULTADO EXITOSO
     // ========================================================================

--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -725,13 +725,15 @@ try {
       "⏭️ INCOBRABLE: se omite updateInstallments (cuota capital-only, no se recalcula interés)"
     );
   } else {
+    // Solo cuotas NO pagadas: con all:true se reescribían las cuotas ya
+    // pagadas del crédito (restantes teóricos + membresias_pago en 0),
+    // corrompiendo la historia liquidada cada vez que se revertía un pago.
     await updateInstallments({
       numero_credito_sifco: result.creditData.creditos.numero_credito_sifco,
       nueva_cuota: Number(result.creditData.creditos.cuota),
-      all: true,
     });
 
-    console.log("✅ UPDATE ALL STATEMENT ejecutado correctamente");
+    console.log("✅ Cuotas pendientes recalculadas correctamente");
   }
 } catch (updateError: any) {
   console.error("⚠️ Error en UPDATE ALL STATEMENT:", updateError.message);

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -97,7 +97,7 @@ const updateInstallments = async ({
   let capitalEnMemoria = capitalInicial;
 
   // 4️⃣ Amortización real: interés calculado sobre capital que va quedando
-  const actualizaciones = todosPagos.map((pago) => {
+  const actualizaciones = todosPagos.flatMap((pago) => {
     const interesMes = capitalEnMemoria.times(porcentajeInteres).round(2);
     const ivaMes = interesMes.times(0.12).round(2);
 
@@ -111,7 +111,13 @@ const updateInstallments = async ({
     capitalEnMemoria = capitalEnMemoria.minus(abonoCapital);
     if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);
 
-    return {
+    // Un pago con dinero aplicado (cuota pagada o parcial) es historia
+    // liquidada: sus restantes/membresías reflejan lo realmente cobrado y no
+    // deben pisarse con la re-proyección teórica. Avanza el capital en memoria
+    // (la cuota ocupa su lugar en el calendario) pero no se reescribe la fila.
+    if (new Big(pago.monto_aplicado ?? 0).gt(0)) return [];
+
+    return [{
       pago_id: pago.pago_id,
       datos: {
         cuota: cuotaMensual.toString(),
@@ -126,7 +132,7 @@ const updateInstallments = async ({
         membresias_pago: pago.validationStatus === "pending" ? pago.membresias_pago : "0",
         membresias_mes: pago.validationStatus === "pending" ? pago.membresias_mes : "0",
       },
-    };
+    }];
   });
 
   // 5️⃣ Ejecutar TODAS las actualizaciones en paralelo (batch update)

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -108,14 +108,23 @@ const updateInstallments = async ({
       .plus(membresiasFijoPorMes);
     const abonoCapital = cuotaMensual.minus(montosExtras);
 
-    capitalEnMemoria = capitalEnMemoria.minus(abonoCapital);
-    if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);
-
     // Un pago con dinero aplicado (cuota pagada o parcial) es historia
     // liquidada: sus restantes/membresías reflejan lo realmente cobrado y no
-    // deben pisarse con la re-proyección teórica. Avanza el capital en memoria
-    // (la cuota ocupa su lugar en el calendario) pero no se reescribe la fila.
-    if (new Big(pago.monto_aplicado ?? 0).gt(0)) return [];
+    // deben pisarse con la re-proyección teórica. La cuota sigue ocupando su
+    // lugar en el calendario, pero su abono_capital real ya está descontado
+    // de creditos.capital (punto de partida de la proyección; ver
+    // aplicarPagoAlCredito, rama de cuota no completa): avanzar solo por lo
+    // que le falta amortizar evita descontarlo dos veces.
+    const aplicado = new Big(pago.monto_aplicado ?? 0);
+    let avanceCapital = abonoCapital;
+    if (aplicado.gt(0)) {
+      avanceCapital = abonoCapital.minus(new Big(pago.abono_capital ?? 0));
+      if (avanceCapital.lt(0)) avanceCapital = new Big(0);
+    }
+    capitalEnMemoria = capitalEnMemoria.minus(avanceCapital);
+    if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);
+
+    if (aplicado.gt(0)) return [];
 
     return [{
       pago_id: pago.pago_id,

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -108,23 +108,14 @@ const updateInstallments = async ({
       .plus(membresiasFijoPorMes);
     const abonoCapital = cuotaMensual.minus(montosExtras);
 
-    // Un pago con dinero aplicado (cuota pagada o parcial) es historia
-    // liquidada: sus restantes/membresías reflejan lo realmente cobrado y no
-    // deben pisarse con la re-proyección teórica. La cuota sigue ocupando su
-    // lugar en el calendario, pero su abono_capital real ya está descontado
-    // de creditos.capital (punto de partida de la proyección; ver
-    // aplicarPagoAlCredito, rama de cuota no completa): avanzar solo por lo
-    // que le falta amortizar evita descontarlo dos veces.
-    const aplicado = new Big(pago.monto_aplicado ?? 0);
-    let avanceCapital = abonoCapital;
-    if (aplicado.gt(0)) {
-      avanceCapital = abonoCapital.minus(new Big(pago.abono_capital ?? 0));
-      if (avanceCapital.lt(0)) avanceCapital = new Big(0);
-    }
-    capitalEnMemoria = capitalEnMemoria.minus(avanceCapital);
+    capitalEnMemoria = capitalEnMemoria.minus(abonoCapital);
     if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);
 
-    if (aplicado.gt(0)) return [];
+    // Un pago con dinero aplicado (cuota pagada o parcial) es historia
+    // liquidada: sus restantes/membresías reflejan lo realmente cobrado y no
+    // deben pisarse con la re-proyección teórica. Avanza el capital en memoria
+    // (la cuota ocupa su lugar en el calendario) pero no se reescribe la fila.
+    if (new Big(pago.monto_aplicado ?? 0).gt(0)) return [];
 
     return [{
       pago_id: pago.pago_id,


### PR DESCRIPTION
## Problema (reportado por conta)

Al descargar de nuevo el Reporte Asesores de fechas pasadas, la columna **Membresías** aparece en 0 en pagos que sí la cobraron (caso índice: crédito `01010214119860`, pago 75043 del 15/07, Q485.03 desaparecidos del reporte).

## Causa raíz

`reversePayment` llamaba `updateInstallments({ all: true })` (agregado en `0183a387`, ene-2026). Con ese flag el query selecciona las cuotas con `pagado = true` — o sea, al revertir **cualquier** pago de un crédito se reescribían **todas sus cuotas ya pagadas**:

- `membresias_pago` / `membresias_mes` → `0` (si no están `pending`) — el reporte lee `membresias_pago`
- restantes (interés/IVA/seguro/GPS/capital) → valores teóricos recalculados desde el capital actual (deuda fantasma en cuotas saldadas)
- `cuota` histórica → pisada con la cuota actual del crédito

Verificado en prod vía `audit_logs`: la reversión del pago duplicado del 16/07 (log 48891) barrió las cuotas 1–9 de ese crédito. Dimensión: **1,222 pagos en 463 créditos** con membresía quedaron con `membresias_pago = 0` estando pagados y validados.

## Cambios (versión mínima, sin aritmética nueva)

1. **`reversePayment.ts`**: se elimina por completo la llamada a `updateInstallments`. La transacción de reversión ya deja todo consistente (pago reseteado, capital/deuda restaurados); el recálculo posterior no aportaba nada y solo reescribía otras filas. Es el comportamiento que el sistema tuvo hasta ene-2026 y el que ya usan los INCOBRABLES (PR #890). La proyección de cuotas pendientes se refresca por el flujo normal (siguiente pago aplicado o botón "Recalcular Pagos").
2. **`updateInstallments` (`updateCredit.ts`)**: guard que omite la escritura en filas con `monto_aplicado > 0` (pagadas o parciales). No cambia ningún cálculo: el capital en memoria avanza exactamente igual que hoy; solo se dejan de pisar filas con dinero aplicado en los flujos de cambio de cuota.

Sobre el review de Codex: los hallazgos P1/P2 aplicaban al recálculo dentro de la reversión y al refinamiento de capital que se había agregado en `0aa4c28b`; ambos se eliminaron (revert `0c9e0b79` + `d8aeee50`), así que quedan sin objeto en este flujo. La exactitud de la proyección teórica con parciales es un tema pre-existente de los flujos de cambio de cuota y se atenderá en un PR aparte.

## Verificación

- `tsc --noEmit`: sin errores en los archivos tocados
- `reversePaymentPolicy.test.ts`: 11/11 pasan

## Pendiente (fuera de este PR)

- UPDATE puntual del pago 75043 (lo corre Daniel post-deploy)
- Backfill masivo opcional de los 1,222 pagos barridos (derivable por fila: `monto_aplicado − suma(abonos)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)