### PR TITLE
fix(cartera): revertir un pago ya no afecta las demás cuotas del crédito

### DIFF
--- a/apps/cartera-back/src/controllers/reversePayment.ts
+++ b/apps/cartera-back/src/controllers/reversePayment.ts
@@ -19,7 +19,6 @@ import { revertirAbonoCapitalEspejo } from "./abonosCapital";
 import { updateMora } from "./latefee";
 import { SATClientService } from "../cofidi/satClientService";
 import { CLUB_CASHIN_CONFIG, SAT_CONFIG } from "../utils/functions/const";
-import { updateInstallments } from "./updateCredit";
 import { esPagoAplicado } from "../utils/paymentStatus";
 import {
   getRemainingPaymentPaidStatusAfterReversal,
@@ -715,28 +714,15 @@ export const reversePayment = async ({ body, set }: any) => {
         reversionEspejo,
       };
     });
-try {
-  // En un INCOBRABLE NO se refrescan las cuotas: updateInstallments recalcula
-  // interes_restante/iva_12_restante de cada fila con `porcentaje_interes`
-  // (preservado en el castigo) y revivirían interés/IVA sobre un calendario
-  // que debe ser capital-only, corrompiendo el castigo tras la reversa.
-  if (result.creditData.creditos.statusCredit === "INCOBRABLE") {
-    console.log(
-      "⏭️ INCOBRABLE: se omite updateInstallments (cuota capital-only, no se recalcula interés)"
-    );
-  } else {
-    await updateInstallments({
-      numero_credito_sifco: result.creditData.creditos.numero_credito_sifco,
-      nueva_cuota: Number(result.creditData.creditos.cuota),
-      all: true,
-    });
-
-    console.log("✅ UPDATE ALL STATEMENT ejecutado correctamente");
-  }
-} catch (updateError: any) {
-  console.error("⚠️ Error en UPDATE ALL STATEMENT:", updateError.message);
-  // NO hacer throw aquí porque la transacción ya se completó
-}
+// La reversión NO recalcula ninguna otra fila del crédito. La transacción de
+// arriba ya deja todo consistente (pago reseteado, capital/deuda restaurados).
+// Aquí vivía un updateInstallments({all: true}) (agregado en 0183a387, ene-2026)
+// que reescribía las cuotas YA PAGADAS del crédito: restantes teóricos,
+// cuota actual y membresias_pago/membresias_mes en 0 — corrompiendo la
+// historia liquidada en cada reversión (los INCOBRABLES ya lo omitían por un
+// clavo análogo, PR #890). La proyección teórica de las cuotas pendientes se
+// refresca por el flujo normal (siguiente pago aplicado o el botón manual
+// "Recalcular Pagos"), igual que antes de enero 2026.
     // ========================================================================
     // ✅ TRANSACCIÓN COMPLETADA - RETORNAR RESULTADO EXITOSO
     // ========================================================================

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -97,7 +97,7 @@ const updateInstallments = async ({
   let capitalEnMemoria = capitalInicial;
 
   // 4️⃣ Amortización real: interés calculado sobre capital que va quedando
-  const actualizaciones = todosPagos.map((pago) => {
+  const actualizaciones = todosPagos.flatMap((pago) => {
     const interesMes = capitalEnMemoria.times(porcentajeInteres).round(2);
     const ivaMes = interesMes.times(0.12).round(2);
 
@@ -111,7 +111,13 @@ const updateInstallments = async ({
     capitalEnMemoria = capitalEnMemoria.minus(abonoCapital);
     if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);
 
-    return {
+    // Un pago con dinero aplicado (cuota pagada o parcial) es historia
+    // liquidada: sus restantes/membresías reflejan lo realmente cobrado y no
+    // deben pisarse con la re-proyección teórica. Avanza el capital en memoria
+    // (la cuota ocupa su lugar en el calendario) pero no se reescribe la fila.
+    if (new Big(pago.monto_aplicado ?? 0).gt(0)) return [];
+
+    return [{
       pago_id: pago.pago_id,
       datos: {
         cuota: cuotaMensual.toString(),
@@ -126,7 +132,7 @@ const updateInstallments = async ({
         membresias_pago: pago.validationStatus === "pending" ? pago.membresias_pago : "0",
         membresias_mes: pago.validationStatus === "pending" ? pago.membresias_mes : "0",
       },
-    };
+    }];
   });
 
   // 5️⃣ Ejecutar TODAS las actualizaciones en paralelo (batch update)


### PR DESCRIPTION
Mismo fix que #1170 (develop), en rama propia desde `main` para poder llegar a producción directo.

## El problema, con un ejemplo

María paga su cuota de julio: Q4,966, que incluye Q485 de membresía. Ese día contabilidad descarga el reporte y todo cuadra: la membresía aparece.

Al día siguiente, por error se registra un pago duplicado en el mismo crédito. Caja lo revierte — algo normal, pasa todos los días.

Y aquí estaba el bug: al revertir ese duplicado, el sistema aprovechaba para "rehacer" **todas las demás cuotas del crédito**, incluidas las que ya estaban pagadas y cuadradas. En esa rehecha, la membresía de María quedaba en Q0 y sus cuotas ya saldadas volvían a mostrar saldos pendientes que no existen.

Resultado: si contabilidad vuelve a descargar el reporte de ese día, la membresía de María ya no aparece — aunque ella sí la pagó y el dinero sí entró.

Esto no es hipotético: es exactamente lo que pasó con el crédito de Jorge Alejandro — pagó Q485.03 de membresía el 15/07, el 16/07 Caja revirtió un pago duplicado, y hoy el reporte de ese día muestra Q0. Revisando la base de datos, lo mismo le pasó a ~1,200 pagos de ~460 créditos desde febrero.

## Qué cambia con este PR

- **Antes:** revertir un pago = deshacer ese pago **+ rehacer todas las demás cuotas del crédito** (ahí se dañaban).
- **Ahora:** revertir un pago = deshacer ese pago. Punto. Las demás cuotas del crédito no se tocan.

De remate queda un seguro extra: ningún recálculo de cuotas puede volver a escribir encima de una cuota que ya tiene dinero pagado.

## Qué NO cambia

- No se mueve dinero: los pagos aplicados, los abonos y los saldos reales quedan exactamente igual.
- Para Caja y los asesores, revertir un pago se ve y se usa igual que siempre.
- Así funcionaba el sistema antes de enero 2026 — solo volvemos a ese comportamiento, que es el mismo que ya usan los créditos incobrables hoy.

## Qué sigue después de esto (fuera de este PR)

- Restaurar la membresía del pago de Jorge Alejandro (ajuste puntual ya preparado).
- Restaurar los ~1,200 pagos históricos dañados, con respaldo previo y revisión de contabilidad.

🤖 Generated with [Claude Code](https://claude.com/claude-code)