### PR TITLE
fix(cartera): GPS por cuota en el monto de cancelación del modal

### DIFF
--- a/apps/carteraFront/src/private/cartera/components/modalCreditCancel.tsx
+++ b/apps/carteraFront/src/private/cartera/components/modalCreditCancel.tsx
@@ -87,20 +87,22 @@ export function ModalCancelCredit({
   const gps = Number(credit?.gps ?? 0);
   const mora = Number(credit?.mora ?? 0);
 
-  // Cuotas restantes - multiplica interes, membresias, seguro, iva
+  // Cuotas restantes - multiplica interes, membresias, seguro, iva, gps
   const numCuotas = Math.max(0, Math.floor(Number(cuotasRestantes || 0)));
   const totalInteres = interes * numCuotas;
   const totalMembresias = membresias * numCuotas;
   const totalSeguro = seguro * numCuotas;
   const totalIva = iva * numCuotas;
-  const totalCuotas = totalInteres + totalMembresias + totalSeguro + totalIva;
+  const totalGps = gps * numCuotas;
+  const totalCuotas =
+    totalInteres + totalMembresias + totalSeguro + totalIva + totalGps;
 
   const totalMotivos = motivos.reduce((acc, curr) => acc + curr.monto, 0);
   const totalCamposExtra =
     Number(traspaso || 0) +
     Number(garantiaMobiliaria || 0) +
     Number(otros || 0);
-  const total = capital + totalCuotas + gps + mora + totalMotivos + totalCamposExtra;
+  const total = capital + totalCuotas + mora + totalMotivos + totalCamposExtra;
 
   const handleClose = () => {
     setMotivos([]);
@@ -285,7 +287,7 @@ export function ModalCancelCredit({
                       Cuotas restantes
                     </h3>
                     <p className="text-xs text-blue-500">
-                      Multiplica interés, membresía, seguro e IVA
+                      Multiplica interés, membresía, seguro, IVA y GPS
                     </p>
                   </div>
                 </div>
@@ -336,6 +338,14 @@ export function ModalCancelCredit({
                           Q{fmt(totalIva)}
                         </span>
                       </div>
+                      {gps > 0 && (
+                        <div className="flex justify-between">
+                          <span className="text-gray-500">GPS</span>
+                          <span className="font-medium text-cyan-700">
+                            Q{fmt(totalGps)}
+                          </span>
+                        </div>
+                      )}
                       <div className="flex justify-between pt-1 border-t border-blue-100">
                         <span className="font-semibold text-gray-700">
                           Subtotal cuotas


### PR DESCRIPTION
## Problema

Para un crédito en `PENDIENTE_CANCELACION`, el **Reporte de Cancelación (PDF)** y el **Monto de cancelación** que aparece al registrar el pago mostraban valores distintos (ej. crédito `01010214105580`: Q91,610.45 vs Q89,264.45), confundiendo al admin que debe ingresar el monto exacto para cancelar.

## Causa

El modal de **Activar Cancelación** sumaba el GPS **una sola vez** al total, mientras el reporte del backend (`getCreditWithCancellationDetails`) lo cobra **por cada cuota atrasada** dentro de la columna Servicios (`servicios = seguro + gps + membresías`). El monto guardado en `credit_cancelations.monto_cancelacion` quedaba subestimado en `gps × (cuotas − 1)` — en el ejemplo, Q138 × 17 = Q2,346 — y la validación de registrar pago comparaba contra ese valor menor.

El correcto es el del reporte: el GPS es un cargo mensual que forma parte de cada cuota, igual que lo trata el flujo de pagos.

## Cambios

- `modalCreditCancel.tsx`: el GPS ahora se multiplica por las cuotas restantes (`totalGps = gps × numCuotas`) y entra al subtotal de cuotas, en vez de sumarse una vez al total.
- El desglose "Proyección × N" muestra la fila de GPS multiplicado y el texto de ayuda ahora dice "Multiplica interés, membresía, seguro, IVA y GPS".

Con esto el total del modal queda idéntico al del reporte de cancelación.

## Nota

Los créditos que ya estaban en `PENDIENTE_CANCELACION` con GPS > 0 y más de 1 cuota atrasada tienen guardado el monto subestimado; se corrigen por SQL aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)