### PR TITLE
hotfix(cartera): recalcular recibos pendientes al aplicar abono a capital

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3076,8 +3076,11 @@ export async function aplicarAbonoCapitalInversionistas(
         .limit(1);
       if (parcialAplicado) {
         recalculo_pendientes = "revisar_parciales";
+        // OJO: aquí NO se recomienda el botón "Recalcular Pagos": su modo con
+        // numero_cuota también redistribuye el parcial aplicado (reescribiría
+        // el reparto validado). Este caso requiere revisión manual del reparto.
         console.log(
-          "⚠️ Cuota con pago parcial aplicado: recálculo automático omitido — usar Recalcular Pagos manual"
+          "⚠️ Cuota con pago parcial aplicado: recálculo automático omitido — revisar el reparto manualmente (el botón también redistribuiría el parcial)"
         );
       } else {
         await recalcularPagosCredito({

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3044,7 +3044,8 @@ export async function aplicarAbonoCapitalInversionistas(
     | "ok"
     | "error"
     | "omitido_solo_interes"
-    | "revisar_pendientes_validacion" = "ok";
+    | "revisar_pendientes_validacion"
+    | "revisar_parciales" = "ok";
   if (credito.no_amortiza_capital) {
     // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
     // convertiría en amortización de capital la diferencia cuota − interés
@@ -3056,31 +3057,55 @@ export async function aplicarAbonoCapitalInversionistas(
     );
   } else {
     try {
-      await recalcularPagosCredito({
-        numero_credito_sifco: credito.numero_credito_sifco,
-      });
-      // Pagos ya registrados (pagado=true) pero aún SIN validar por conta
-      // quedan fuera del recálculo (solo toma pendientes): si conta los valida
-      // después de este abono, confirmaría su reparto viejo. Se reporta para
-      // correr "Recalcular Pagos" a mano después de validarlos.
-      const [pendienteValidacion] = await db
+      // Cuotas abiertas con pagos PARCIALES ya aplicados (monto_aplicado>0 y
+      // pagado=false): recalcular automáticamente redistribuiría su reparto
+      // histórico ya validado — el capital del crédito ya se movió con los
+      // montos originales y una reversa restauraría montos reescritos. En ese
+      // caso se omite el recálculo automático y se manda al botón manual.
+      const [parcialAplicado] = await db
         .select({ pago_id: pagos_credito.pago_id })
         .from(pagos_credito)
         .where(
           and(
             eq(pagos_credito.credito_id, credito_id),
-            eq(pagos_credito.pagado, true),
-            eq(pagos_credito.validationStatus, "pending")
+            eq(pagos_credito.pagado, false),
+            gt(pagos_credito.monto_aplicado, "0"),
+            ne(pagos_credito.pago_id, pago_id)
           )
         )
         .limit(1);
-      if (pendienteValidacion) {
-        recalculo_pendientes = "revisar_pendientes_validacion";
+      if (parcialAplicado) {
+        recalculo_pendientes = "revisar_parciales";
         console.log(
-          "⚠️ Hay pagos registrados pendientes de validación: recalcular a mano después de validarlos"
+          "⚠️ Cuota con pago parcial aplicado: recálculo automático omitido — usar Recalcular Pagos manual"
         );
       } else {
-        console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+        await recalcularPagosCredito({
+          numero_credito_sifco: credito.numero_credito_sifco,
+        });
+        // Pagos ya registrados (pagado=true) pero aún SIN validar por conta
+        // quedan fuera del recálculo (solo toma pendientes): si conta los valida
+        // después de este abono, confirmaría su reparto viejo. Se reporta para
+        // correr "Recalcular Pagos" a mano después de validarlos.
+        const [pendienteValidacion] = await db
+          .select({ pago_id: pagos_credito.pago_id })
+          .from(pagos_credito)
+          .where(
+            and(
+              eq(pagos_credito.credito_id, credito_id),
+              eq(pagos_credito.pagado, true),
+              eq(pagos_credito.validationStatus, "pending")
+            )
+          )
+          .limit(1);
+        if (pendienteValidacion) {
+          recalculo_pendientes = "revisar_pendientes_validacion";
+          console.log(
+            "⚠️ Hay pagos registrados pendientes de validación: recalcular a mano después de validarlos"
+          );
+        } else {
+          console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+        }
       }
     } catch (error) {
       // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3032,33 +3032,40 @@ export async function aplicarAbonoCapitalInversionistas(
     })
     .where(eq(pagos_credito.pago_id, pago_id));
 
-  // 5️⃣ Re-sembrar los recibos de las cuotas SIGUIENTES con el capital nuevo.
+  // 5️⃣ Re-sembrar los recibos PENDIENTES con el capital nuevo.
   // Sin esto, el próximo pago se aplicaría con el interés pre-sembrado sobre el
   // capital viejo (y de ahí saldrían factura y liquidación infladas). Se
-  // recalcula desde la cuota siguiente a la del abono, manteniendo la cuota
-  // mensual del crédito. El espejo NO se toca aquí: lo maneja la liquidación
-  // del inversionista.
-  let recalculo_pendientes: "ok" | "error" = "ok";
-  try {
-    const [cuotaAbono] = await db
-      .select({ numero_cuota: cuotas_credito.numero_cuota })
-      .from(cuotas_credito)
-      .innerJoin(pagos_credito, eq(pagos_credito.cuota_id, cuotas_credito.cuota_id))
-      .where(eq(pagos_credito.pago_id, pago_id))
-      .limit(1);
-
-    const desdeCuota = (cuotaAbono?.numero_cuota ?? 0) + 1;
-    await recalcularPagosCredito({
-      numero_credito_sifco: credito.numero_credito_sifco,
-      numero_cuota: desdeCuota,
-    });
-    console.log(`✅ Recibos recalculados desde la cuota ${desdeCuota} con el capital nuevo`);
-  } catch (error) {
-    // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
-    // NO puede pasar silencioso: los recibos quedarían con interés viejo, así
-    // que se reporta en la respuesta para correr Recalcular Pagos a mano.
-    recalculo_pendientes = "error";
-    console.error("❌ Error recalculando recibos post-abono (correr Recalcular Pagos manual):", error);
+  // recalculan SOLO los pagos pendientes (pagado=false): eso cubre también la
+  // cuota de referencia del abono cuando aún no está pagada (abono antes de la
+  // primera cuota), y nunca toca pagos ya aplicados — este mismo abono queda
+  // pagado=true y fuera del recálculo. La cuota mensual del crédito no cambia.
+  // El espejo NO se toca aquí: lo maneja la liquidación del inversionista.
+  let recalculo_pendientes: "ok" | "error" | "omitido_solo_interes" = "ok";
+  if (credito.no_amortiza_capital) {
+    // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
+    // convertiría en amortización de capital la diferencia cuota − interés
+    // nuevo, contra el contrato. Se mantiene el comportamiento actual (sin
+    // re-siembra automática) hasta definir la re-siembra para este formato.
+    recalculo_pendientes = "omitido_solo_interes";
+    console.log(
+      "⚠️ Crédito solo-interés (no_amortiza_capital): recálculo automático omitido"
+    );
+  } else {
+    try {
+      await recalcularPagosCredito({
+        numero_credito_sifco: credito.numero_credito_sifco,
+      });
+      console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+    } catch (error) {
+      // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
+      // NO puede pasar silencioso: los recibos quedarían con interés viejo, así
+      // que se reporta en la respuesta para correr Recalcular Pagos a mano.
+      recalculo_pendientes = "error";
+      console.error(
+        "❌ Error recalculando recibos post-abono (correr Recalcular Pagos manual):",
+        error
+      );
+    }
   }
 
   console.log(`✅ ========== ABONO APLICADO EXITOSAMENTE ==========\n`);

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -20,6 +20,7 @@ import { insertPagosCreditoInversionistas, insertPagosCreditoInversionistasV2 } 
 import { processAndReplaceCreditInvestors } from "./investor"; 
 import { processConvenioPayment } from "./paymentAgreement";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
+import { recalcularPagosCredito } from "./updateCredit";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
@@ -3031,10 +3032,40 @@ export async function aplicarAbonoCapitalInversionistas(
     })
     .where(eq(pagos_credito.pago_id, pago_id));
 
+  // 5️⃣ Re-sembrar los recibos de las cuotas SIGUIENTES con el capital nuevo.
+  // Sin esto, el próximo pago se aplicaría con el interés pre-sembrado sobre el
+  // capital viejo (y de ahí saldrían factura y liquidación infladas). Se
+  // recalcula desde la cuota siguiente a la del abono, manteniendo la cuota
+  // mensual del crédito. El espejo NO se toca aquí: lo maneja la liquidación
+  // del inversionista.
+  let recalculo_pendientes: "ok" | "error" = "ok";
+  try {
+    const [cuotaAbono] = await db
+      .select({ numero_cuota: cuotas_credito.numero_cuota })
+      .from(cuotas_credito)
+      .innerJoin(pagos_credito, eq(pagos_credito.cuota_id, cuotas_credito.cuota_id))
+      .where(eq(pagos_credito.pago_id, pago_id))
+      .limit(1);
+
+    const desdeCuota = (cuotaAbono?.numero_cuota ?? 0) + 1;
+    await recalcularPagosCredito({
+      numero_credito_sifco: credito.numero_credito_sifco,
+      numero_cuota: desdeCuota,
+    });
+    console.log(`✅ Recibos recalculados desde la cuota ${desdeCuota} con el capital nuevo`);
+  } catch (error) {
+    // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
+    // NO puede pasar silencioso: los recibos quedarían con interés viejo, así
+    // que se reporta en la respuesta para correr Recalcular Pagos a mano.
+    recalculo_pendientes = "error";
+    console.error("❌ Error recalculando recibos post-abono (correr Recalcular Pagos manual):", error);
+  }
+
   console.log(`✅ ========== ABONO APLICADO EXITOSAMENTE ==========\n`);
 
   return {
     message: "Abono a capital aplicado exitosamente",
+    recalculo_pendientes,
     credito_id,
     pago_id,
     abono_total: abonoCapitalBig.toString(),

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3040,7 +3040,11 @@ export async function aplicarAbonoCapitalInversionistas(
   // primera cuota), y nunca toca pagos ya aplicados — este mismo abono queda
   // pagado=true y fuera del recálculo. La cuota mensual del crédito no cambia.
   // El espejo NO se toca aquí: lo maneja la liquidación del inversionista.
-  let recalculo_pendientes: "ok" | "error" | "omitido_solo_interes" = "ok";
+  let recalculo_pendientes:
+    | "ok"
+    | "error"
+    | "omitido_solo_interes"
+    | "revisar_pendientes_validacion" = "ok";
   if (credito.no_amortiza_capital) {
     // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
     // convertiría en amortización de capital la diferencia cuota − interés
@@ -3055,7 +3059,29 @@ export async function aplicarAbonoCapitalInversionistas(
       await recalcularPagosCredito({
         numero_credito_sifco: credito.numero_credito_sifco,
       });
-      console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+      // Pagos ya registrados (pagado=true) pero aún SIN validar por conta
+      // quedan fuera del recálculo (solo toma pendientes): si conta los valida
+      // después de este abono, confirmaría su reparto viejo. Se reporta para
+      // correr "Recalcular Pagos" a mano después de validarlos.
+      const [pendienteValidacion] = await db
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .where(
+          and(
+            eq(pagos_credito.credito_id, credito_id),
+            eq(pagos_credito.pagado, true),
+            eq(pagos_credito.validationStatus, "pending")
+          )
+        )
+        .limit(1);
+      if (pendienteValidacion) {
+        recalculo_pendientes = "revisar_pendientes_validacion";
+        console.log(
+          "⚠️ Hay pagos registrados pendientes de validación: recalcular a mano después de validarlos"
+        );
+      } else {
+        console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+      }
     } catch (error) {
       // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
       // NO puede pasar silencioso: los recibos quedarían con interés viejo, así

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -478,11 +478,22 @@ export const applyCapitalPaymentAndBuildResponse = async (
     throw new Error("No se puede aplicar el abono: credito_id es null");
   }
 
-  await applyCapitalAbono(pago.credito_id, pago.abono_capital ?? "0", pagoId);
+  const resultado = await applyCapitalAbono(
+    pago.credito_id,
+    pago.abono_capital ?? "0",
+    pagoId
+  );
   console.log("⚠️ El pago es un abono directo a capital");
+  // Propagar el estado del recálculo de recibos pendientes: si falló (o se
+  // omitió por solo-interés), el caller debe enterarse para correr
+  // "Recalcular Pagos" a mano — no puede quedarse solo en los logs.
+  const recalculo_pendientes = (
+    resultado as { recalculo_pendientes?: string } | null | undefined
+  )?.recalculo_pendientes;
   return {
     success: true,
     applied: false,
+    ...(recalculo_pendientes ? { recalculo_pendientes } : {}),
     message:
       "Pago validado como abono a capital , se abonó a inversionistas correctamente",
   };

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -2034,12 +2034,18 @@ export const recalcularPagosCredito = async ({
     // Amortización de esta cuota
     const interesMes = capitalEnMemoria.times(porcentajeInteres).round(2);
     const ivaMes = interesMes.times(0.12).round(2);
-    const abonoCapital = cuotaMensual
+    let abonoCapital = cuotaMensual
       .minus(interesMes)
       .minus(ivaMes)
       .minus(seguroFijo)
       .minus(gpsFijo)
       .minus(membresiasFijo);
+
+    // Tope: un recibo nunca proyecta más capital del que queda en el crédito
+    // (tras un abono grande la última porción es menor a la de una cuota
+    // normal), y con saldo 0 las cuotas restantes ya no llevan capital. Sin
+    // esto se sobre-cobraría capital y se sobre-distribuiría a inversionistas.
+    if (abonoCapital.gt(capitalEnMemoria)) abonoCapital = capitalEnMemoria;
 
     capitalEnMemoria = capitalEnMemoria.minus(abonoCapital);
     if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -61,7 +61,7 @@ export function useAplicarPago() {
         );
       } else if (data.recalculo_pendientes === "revisar_parciales") {
         alert(
-          "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado: el recálculo automático se omitió para no reescribir su historial. Corré 'Recalcular Pagos' manualmente en este crédito."
+          "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado y el recálculo automático se omitió para no reescribir ese pago. OJO: NO corras 'Recalcular Pagos' aquí sin revisarlo antes con el equipo — el botón también redistribuiría el pago parcial. Revisen el reparto de esa cuota manualmente."
         );
       } else if (data.recalculo_pendientes === "omitido_solo_interes") {
         alert(

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -59,6 +59,10 @@ export function useAplicarPago() {
         alert(
           "El abono se aplicó y se recalcularon las cuotas pendientes, pero hay pagos registrados SIN validar que quedaron fuera: después de validarlos, corré 'Recalcular Pagos' manualmente."
         );
+      } else if (data.recalculo_pendientes === "revisar_parciales") {
+        alert(
+          "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado: el recálculo automático se omitió para no reescribir su historial. Corré 'Recalcular Pagos' manualmente en este crédito."
+        );
       } else if (data.recalculo_pendientes === "omitido_solo_interes") {
         alert(
           "Abono aplicado. Crédito solo-interés: el recálculo automático no aplica para este formato."

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -49,11 +49,25 @@ export function useAplicarPago() {
     mutationFn: (pagoId: number) => pagosService.aplicarPago(pagoId),
     
     onSuccess: (data) => {
-    
+      // ⚠️ Estado del recálculo de recibos tras un abono a capital: si quedó
+      // pendiente, operaciones debe correr "Recalcular Pagos" a mano.
+      if (data.recalculo_pendientes === "error") {
+        alert(
+          "El abono se aplicó, pero FALLÓ el recálculo de las cuotas pendientes. Corré 'Recalcular Pagos' manualmente en este crédito."
+        );
+      } else if (data.recalculo_pendientes === "revisar_pendientes_validacion") {
+        alert(
+          "El abono se aplicó y se recalcularon las cuotas pendientes, pero hay pagos registrados SIN validar que quedaron fuera: después de validarlos, corré 'Recalcular Pagos' manualmente."
+        );
+      } else if (data.recalculo_pendientes === "omitido_solo_interes") {
+        alert(
+          "Abono aplicado. Crédito solo-interés: el recálculo automático no aplica para este formato."
+        );
+      }
 
       // 🔄 Invalidar la caché para refrescar la tabla
-      queryClient.invalidateQueries({ 
-        queryKey: ["pagos-inversionistas"] 
+      queryClient.invalidateQueries({
+        queryKey: ["pagos-inversionistas"]
       });
 
       // 📊 Log adicional si se aplicó al crédito

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1997,13 +1997,16 @@ export interface AplicarPagoResponse {
    * - "error": falló — correr "Recalcular Pagos" manualmente.
    * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
    *   quedaron fuera — recalcular a mano después de validarlos.
+   * - "revisar_parciales": hay cuota con pago parcial aplicado — el recálculo
+   *   automático se omitió para no reescribir su historial; usar el botón.
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:
     | "ok"
     | "error"
     | "omitido_solo_interes"
-    | "revisar_pendientes_validacion";
+    | "revisar_pendientes_validacion"
+    | "revisar_parciales";
   data?: {
     credito_id: number;
     capital_anterior: string;

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1997,8 +1997,9 @@ export interface AplicarPagoResponse {
    * - "error": falló — correr "Recalcular Pagos" manualmente.
    * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
    *   quedaron fuera — recalcular a mano después de validarlos.
-   * - "revisar_parciales": hay cuota con pago parcial aplicado — el recálculo
-   *   automático se omitió para no reescribir su historial; usar el botón.
+   * - "revisar_parciales": hay cuota con pago parcial aplicado — NI el
+   *   recálculo automático NI el botón "Recalcular Pagos" son seguros ahí
+   *   (ambos redistribuirían el parcial); revisar el reparto con el equipo.
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1992,6 +1992,18 @@ export interface AplicarPagoResponse {
   success: boolean;
   applied?: boolean;
   message: string;
+  /**
+   * Estado del recálculo automático de recibos tras aplicar un abono a capital:
+   * - "error": falló — correr "Recalcular Pagos" manualmente.
+   * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
+   *   quedaron fuera — recalcular a mano después de validarlos.
+   * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
+   */
+  recalculo_pendientes?:
+    | "ok"
+    | "error"
+    | "omitido_solo_interes"
+    | "revisar_pendientes_validacion";
   data?: {
     credito_id: number;
     capital_anterior: string;


### PR DESCRIPTION
## Problema

Al aplicar un **abono directo a capital** (`validationStatus: 'capital'` → `capital_validated`), el flujo `aplicarAbonoCapitalInversionistas` actualiza el crédito (capital, cuota_interes, iva_12, deudatotal) y distribuye a inversionistas, pero **no re-siembra los recibos pendientes** de `pagos_credito`. Como aplicar-pago cobra contra esos recibos pre-sembrados (nunca consulta `creditos.capital`), el siguiente pago del cliente entra con el **interés calculado sobre el capital viejo** — y de ahí salen factura del % Cash-In y liquidación del inversionista infladas.



## Fix

Una llamada al final del flujo de abono, justo después de estampar `capital_validated` (capital ya actualizado, inversionistas ya distribuidos):

- `recalcularPagosCredito` **desde la cuota siguiente** a la del abono → recibos re-sembrados con el interés del capital nuevo, **manteniendo la cuota mensual** del crédito (no cambia el valor de la cuota).
- **Solo dispara en abonos a capital**: el call-site (`aplicarPagoAlCredito`) solo entra aquí con `validationStatus === 'capital'`; los pagos normales de cuota no pasan por este flujo.
- **El espejo no se toca** — lo maneja la liquidación del inversionista.
- Si el recálculo falla, el abono **no se revierte** (ya quedó aplicado y distribuido); la respuesta lo reporta en `recalculo_pendientes: "ok" | "error"` y queda el log, para correr Recalcular Pagos manual. Sin errores tragados.

## Notas para el review

- `recalcularPagosCredito` es idempotente (correrlo dos veces da lo mismo) y es la misma lógica del botón "Recalcular Pagos" que operaciones ya usa (711 corridas desde marzo).
- Typecheck limpio (el error pre-existente de `lockConn` en L603 no es de este cambio).
- Prueba funcional en dev pendiente de un abono de prueba — se puede validar comparando el interés del primer recibo pendiente vs `capital × %interes` después de aplicar el abono.
- Va directo a `main` como hotfix porque cada abono que entra sin esto genera recibos viejos (casos activos: 4 créditos por recalcular a mano + 1 con pagos ya cobrados de más).

🤖 Generated with [Claude Code](https://claude.com/claude-code)