### PR TITLE
fix(cartera): mostrar detalle de créditos cancelados

### DIFF
--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { canViewCreditDetailByStatus } from "./creditDetailPolicy";
+
+describe("credit detail visibility", () => {
+	it("permite consultar créditos cancelados desde el historial de cobros", () => {
+		expect(canViewCreditDetailByStatus("CANCELADO")).toBeTrue();
+	});
+
+	it("conserva visibles los estados operativos soportados por el detalle", () => {
+		for (const status of [
+			"ACTIVO",
+			"PENDIENTE_CANCELACION",
+			"MOROSO",
+			"EN_CONVENIO",
+			"INCOBRABLE",
+		]) {
+			expect(canViewCreditDetailByStatus(status)).toBeTrue();
+		}
+	});
+
+	it("no habilita estados fuera del flujo de detalle", () => {
+		expect(canViewCreditDetailByStatus("CAIDO")).toBeFalse();
+		expect(canViewCreditDetailByStatus(null)).toBeFalse();
+		expect(canViewCreditDetailByStatus(undefined)).toBeFalse();
+	});
+});

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -1,0 +1,17 @@
+export const CREDIT_DETAIL_STATUSES = [
+	"ACTIVO",
+	"PENDIENTE_CANCELACION",
+	"MOROSO",
+	"EN_CONVENIO",
+	"INCOBRABLE",
+	"CANCELADO",
+] as const;
+
+export function canViewCreditDetailByStatus(
+	status: string | null | undefined,
+): boolean {
+	return (
+		typeof status === "string" &&
+		(CREDIT_DETAIL_STATUSES as readonly string[]).includes(status)
+	);
+}

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -39,6 +39,7 @@ import {
 } from "drizzle-orm";
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
+import { CREDIT_DETAIL_STATUSES } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
 
@@ -51,13 +52,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       .where(
         and(
           eq(creditos.numero_credito_sifco, numero_credito_sifco),
-          inArray(creditos.statusCredit, [
-            "ACTIVO",
-            "PENDIENTE_CANCELACION",
-            "MOROSO",
-            "EN_CONVENIO",
-            "INCOBRABLE"
-          ])
+          inArray(creditos.statusCredit, [...CREDIT_DETAIL_STATUSES])
         )
       )
       .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))


### PR DESCRIPTION
## Problema
El buscador de Cobros incluye créditos `CANCELADO`, pero `getCreditoByNumero` los excluía antes de llegar a la rama que ya maneja ese estado. Al abrir un resultado cancelado, el CRM mostraba “Caso No Encontrado” e impedía acceder a la información y documentos asociados.

## Solución
- Centraliza los estados visibles en el detalle.
- Incluye `CANCELADO` en la consulta de `getCreditoByNumero`.
- Conserva `CAIDO` fuera del flujo.
- Agrega pruebas de regresión para la política de visibilidad.

## Verificación
- `bun test src/controllers/creditDetailPolicy.test.ts` — 3/3.
- Suite enfocada de políticas Cartera — 31/31.
- Biome sobre los dos archivos nuevos — limpio.
- `git diff --check` — limpio.
- Smoke read-only contra el crédito reportado: devuelve `statusCredit=CANCELADO`, `flow=CANCELADO` y estructura completa.

## Observaciones del baseline
- El typecheck global de Cartera se detiene en un error preexistente de `moraPorEtapaAsesor.test.ts`.
- La ejecución conjunta de todos los tests de controladores presenta fallos preexistentes/contaminación de mocks en Excel y latefee; los tests relacionados pasan en forma enfocada.

No incluye cambios de datos, merge ni deploy.