### PR TITLE
hotfix(cartera): mostrar detalle de créditos cancelados

### DIFF
--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -3,10 +3,19 @@ import { resolve } from "node:path";
 import {
 	canResetCreditByStatus,
 	canViewCreditDetailByStatus,
+	isScheduledCreditInstallment,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
 
 describe("credit detail visibility", () => {
+	it("excludes only reset credit installments from scheduled installments", () => {
+		for (const status of ["validated", "pending", null, undefined]) {
+			expect(isScheduledCreditInstallment(status)).toBeTrue();
+		}
+
+		expect(isScheduledCreditInstallment("reset")).toBeFalse();
+	});
+
 	it("only allows resetting credits pending cancellation", () => {
 		expect(canResetCreditByStatus("PENDIENTE_CANCELACION")).toBeTrue();
 

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import {
+	canResetCreditByStatus,
 	canViewCreditDetailByStatus,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
 
 describe("credit detail visibility", () => {
+	it("only allows resetting credits pending cancellation", () => {
+		expect(canResetCreditByStatus("PENDIENTE_CANCELACION")).toBeTrue();
+
+		for (const status of [
+			"CANCELADO",
+			"INCOBRABLE",
+			"ACTIVO",
+			null,
+			undefined,
+		]) {
+			expect(canResetCreditByStatus(status)).toBeFalse();
+		}
+	});
+
 	it("permite consultar créditos cancelados desde el historial de cobros", () => {
 		expect(canViewCreditDetailByStatus("CANCELADO")).toBeTrue();
 	});
@@ -43,11 +58,18 @@ describe("cancelled credit detail", () => {
 		};
 		const cancelacion = { id: 7, activo: true };
 
-		expect(withActiveCancellation(detail, cancelacion)).toEqual({
-			...detail,
-			flujo: "CANCELADO",
+		const result = withActiveCancellation(
+			detail,
 			cancelacion,
-		});
+			"PENDIENTE_CANCELACION",
+		);
+
+		expect(result).toHaveProperty("cuotasPagadas", cuotasPagadas);
+		expect(result).toHaveProperty("cuotasPendientes", cuotasPendientes);
+		expect(result).toHaveProperty("cuotasAtrasadas", cuotasAtrasadas);
+		expect(result).toHaveProperty("moraActual", "125.00");
+		expect(result).toHaveProperty("flujo", "CANCELADO");
+		expect(result).toHaveProperty("cancelacion", cancelacion);
 	});
 
 	it("marca como cancelado el detalle sin cancelación activa", () => {

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { canViewCreditDetailByStatus } from "./creditDetailPolicy";
+
+describe("credit detail visibility", () => {
+	it("permite consultar créditos cancelados desde el historial de cobros", () => {
+		expect(canViewCreditDetailByStatus("CANCELADO")).toBeTrue();
+	});
+
+	it("conserva visibles los estados operativos soportados por el detalle", () => {
+		for (const status of [
+			"ACTIVO",
+			"PENDIENTE_CANCELACION",
+			"MOROSO",
+			"EN_CONVENIO",
+			"INCOBRABLE",
+		]) {
+			expect(canViewCreditDetailByStatus(status)).toBeTrue();
+		}
+	});
+
+	it("no habilita estados fuera del flujo de detalle", () => {
+		expect(canViewCreditDetailByStatus("CAIDO")).toBeFalse();
+		expect(canViewCreditDetailByStatus(null)).toBeFalse();
+		expect(canViewCreditDetailByStatus(undefined)).toBeFalse();
+	});
+});

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { canViewCreditDetailByStatus } from "./creditDetailPolicy";
+import {
+	canViewCreditDetailByStatus,
+	withActiveCancellation,
+} from "./creditDetailPolicy";
 
 describe("credit detail visibility", () => {
 	it("permite consultar créditos cancelados desde el historial de cobros", () => {
@@ -22,5 +25,27 @@ describe("credit detail visibility", () => {
 		expect(canViewCreditDetailByStatus("CAIDO")).toBeFalse();
 		expect(canViewCreditDetailByStatus(null)).toBeFalse();
 		expect(canViewCreditDetailByStatus(undefined)).toBeFalse();
+	});
+});
+
+describe("cancelled credit detail", () => {
+	it("combina la cancelación activa con el detalle normal", () => {
+		const cuotasPagadas = [{ numero_cuota: 1 }];
+		const cuotasPendientes = [{ numero_cuota: 2 }];
+		const cuotasAtrasadas = [{ numero_cuota: 3 }];
+		const detail = {
+			flujo: "ACTIVO",
+			cuotasPagadas,
+			cuotasPendientes,
+			cuotasAtrasadas,
+			moraActual: "125.00",
+		};
+		const cancelacion = { id: 7, activo: true };
+
+		expect(withActiveCancellation(detail, cancelacion)).toEqual({
+			...detail,
+			flujo: "CANCELADO",
+			cancelacion,
+		});
 	});
 });

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
 import {
 	canViewCreditDetailByStatus,
 	withActiveCancellation,
@@ -47,5 +48,18 @@ describe("cancelled credit detail", () => {
 			flujo: "CANCELADO",
 			cancelacion,
 		});
+	});
+});
+
+describe("credit detail no-current-installment branch", () => {
+	it("maps the advisor in the no-current-installment return", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "credits.ts"),
+		).text();
+		const branch = source.match(
+			/if \(!cuotaActualDataResult[\s\S]*?(?=\n\s*const cuotaActualData)/,
+		)?.[0];
+
+		expect(branch).toContain("asesor: currentCredit.asesores,");
 	});
 });

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -49,6 +49,15 @@ describe("cancelled credit detail", () => {
 			cancelacion,
 		});
 	});
+
+	it("marca como cancelado el detalle sin cancelación activa", () => {
+		const detail = { flujo: "ACTIVO", cuotasPagadas: [] };
+
+		expect(withActiveCancellation(detail, undefined, "CANCELADO")).toEqual({
+			...detail,
+			flujo: "CANCELADO",
+		});
+	});
 });
 
 describe("credit detail no-current-installment branch", () => {

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -19,8 +19,13 @@ export function canViewCreditDetailByStatus(
 export function withActiveCancellation<T extends object, C>(
 	detail: T,
 	cancelacion: C | undefined,
+	statusCredit: string | null | undefined,
 ) {
-	return cancelacion
-		? { ...detail, cancelacion, flujo: "CANCELADO" as const }
-		: detail;
+	if (!cancelacion && statusCredit !== "CANCELADO") return detail;
+
+	return {
+		...detail,
+		...(cancelacion ? { cancelacion } : {}),
+		flujo: "CANCELADO" as const,
+	};
 }

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -16,6 +16,12 @@ export function canViewCreditDetailByStatus(
 	);
 }
 
+export function canResetCreditByStatus(
+	status: string | null | undefined,
+): boolean {
+	return status === "PENDIENTE_CANCELACION";
+}
+
 export function withActiveCancellation<T extends object, C>(
 	detail: T,
 	cancelacion: C | undefined,

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -22,6 +22,10 @@ export function canResetCreditByStatus(
 	return status === "PENDIENTE_CANCELACION";
 }
 
+export const isScheduledCreditInstallment = (
+	validationStatus: string | null | undefined,
+): boolean => validationStatus !== "reset";
+
 export function withActiveCancellation<T extends object, C>(
 	detail: T,
 	cancelacion: C | undefined,

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -1,0 +1,17 @@
+export const CREDIT_DETAIL_STATUSES = [
+	"ACTIVO",
+	"PENDIENTE_CANCELACION",
+	"MOROSO",
+	"EN_CONVENIO",
+	"INCOBRABLE",
+	"CANCELADO",
+] as const;
+
+export function canViewCreditDetailByStatus(
+	status: string | null | undefined,
+): boolean {
+	return (
+		typeof status === "string" &&
+		(CREDIT_DETAIL_STATUSES as readonly string[]).includes(status)
+	);
+}

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -15,3 +15,12 @@ export function canViewCreditDetailByStatus(
 		(CREDIT_DETAIL_STATUSES as readonly string[]).includes(status)
 	);
 }
+
+export function withActiveCancellation<T extends object, C>(
+	detail: T,
+	cancelacion: C | undefined,
+) {
+	return cancelacion
+		? { ...detail, cancelacion, flujo: "CANCELADO" as const }
+		: detail;
+}

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -309,6 +309,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         flujo: "ACTIVO",
         credito: currentCredit.creditos,
         usuario: currentCredit.usuarios,
+        asesor: currentCredit.asesores,
         cuotaActual: null,
         cuotaActualPagada: false,
         cuotaActualStatus: null,

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -321,7 +321,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         convenioActivo: null,
         cuotasEnConvenio: [],
         pagosConvenio: [],
-      }, cancelacionActiva);
+      }, cancelacionActiva, currentCredit.creditos.statusCredit);
     }
 
     const cuotaActualData = cuotaActualDataResult[0];
@@ -463,7 +463,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           : null,
       cuotasEnConvenio,
       pagosConvenio,
-    }, cancelacionActiva);
+    }, cancelacionActiva, currentCredit.creditos.statusCredit);
   } catch (error) {
     console.error("[getCreditoByNumero] Error:", error);
     return { message: "Error consultando crédito", error: String(error) };

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -42,6 +42,7 @@ import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   CREDIT_DETAIL_STATUSES,
   canResetCreditByStatus,
+  isScheduledCreditInstallment,
   withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
@@ -89,7 +90,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         : undefined;
 
     // 2. Consultar todas las cuotas pagadas (pagado = true)
-    const cuotasPagadas = await db
+    const cuotasPagadasConCierre = await db
       .select({
         // Campos de cuotas_credito
         cuota_id: cuotas_credito.cuota_id,
@@ -138,6 +139,8 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         )
       )
       .orderBy(cuotas_credito.numero_cuota);
+
+    const cuotasPagadas = cuotasPagadasConCierre.filter((row) => isScheduledCreditInstallment(row.validationStatus));
 
     // 4. Calcular la cuota que toca este mes (según meses transcurridos desde fecha_creacion)
     const fechaInicio = new Date(currentCredit.creditos.fecha_creacion);

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -39,6 +39,7 @@ import {
 } from "drizzle-orm";
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
+import { CREDIT_DETAIL_STATUSES } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
 
@@ -51,13 +52,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       .where(
         and(
           eq(creditos.numero_credito_sifco, numero_credito_sifco),
-          inArray(creditos.statusCredit, [
-            "ACTIVO",
-            "PENDIENTE_CANCELACION",
-            "MOROSO",
-            "EN_CONVENIO",
-            "INCOBRABLE"
-          ])
+          inArray(creditos.statusCredit, [...CREDIT_DETAIL_STATUSES])
         )
       )
       .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -39,7 +39,10 @@ import {
 } from "drizzle-orm";
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
-import { CREDIT_DETAIL_STATUSES } from "./creditDetailPolicy";
+import {
+  CREDIT_DETAIL_STATUSES,
+  withActiveCancellation,
+} from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
 
@@ -67,34 +70,22 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
     const creditoId = currentCredit.creditos.credito_id;
 
     // 2. Si el crédito está cancelado o pendiente de cancelación, verificar si hay cancelación activa
-    if (
+    const cancelacionActiva =
       currentCredit.creditos.statusCredit === "CANCELADO" ||
       currentCredit.creditos.statusCredit === "PENDIENTE_CANCELACION"
-    ) {
-      // Buscar la info de cancelación (solo si está activa)
-      const cancelacion = await db
-        .select()
-        .from(credit_cancelations)
-        .where(
-          and(
-            eq(credit_cancelations.credit_id, creditoId),
-            eq(credit_cancelations.activo, true)
-          )
-        )
-        .limit(1);
-
-      // Solo retornar flujo CANCELADO si hay una cancelación activa
-      if (cancelacion.length > 0) {
-        return {
-          credito: currentCredit.creditos,
-          usuario: currentCredit.usuarios,
-          asesor: currentCredit.asesores,
-          cancelacion: cancelacion[0],
-          flujo: "CANCELADO",
-        };
-      }
-      // Si no hay cancelación activa, continuar con el flujo normal
-    }
+        ? (
+            await db
+              .select()
+              .from(credit_cancelations)
+              .where(
+                and(
+                  eq(credit_cancelations.credit_id, creditoId),
+                  eq(credit_cancelations.activo, true)
+                )
+              )
+              .limit(1)
+          )[0]
+        : undefined;
 
     // 2. Consultar todas las cuotas pagadas (pagado = true)
     const cuotasPagadas = await db
@@ -314,7 +305,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
 
     // 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos sin cuota activa
     if (!cuotaActualDataResult || cuotaActualDataResult.length === 0) {
-      return {
+      return withActiveCancellation({
         flujo: "ACTIVO",
         credito: currentCredit.creditos,
         usuario: currentCredit.usuarios,
@@ -329,7 +320,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         convenioActivo: null,
         cuotasEnConvenio: [],
         pagosConvenio: [],
-      };
+      }, cancelacionActiva);
     }
 
     const cuotaActualData = cuotaActualDataResult[0];
@@ -449,7 +440,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       }
     }
 
-    return {
+    return withActiveCancellation({
       flujo: "ACTIVO",
       credito: currentCredit.creditos,
       usuario: currentCredit.usuarios,
@@ -471,7 +462,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           : null,
       cuotasEnConvenio,
       pagosConvenio,
-    };
+    }, cancelacionActiva);
   } catch (error) {
     console.error("[getCreditoByNumero] Error:", error);
     return { message: "Error consultando crédito", error: String(error) };

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -41,6 +41,7 @@ import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./paym
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   CREDIT_DETAIL_STATUSES,
+  canResetCreditByStatus,
   withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
@@ -1807,6 +1808,9 @@ export async function resetCredit({
       .where(eq(creditos.credito_id, creditId));
     if (!credito) {
       throw new Error("Crédito no encontrado.");
+    }
+    if (!canResetCreditByStatus(credito.statusCredit)) {
+      throw new Error("El crédito no está pendiente de cancelación.");
     }
 
     // 3. Determinar el estado del crédito


### PR DESCRIPTION
## Hotfix directo a `main`
Extrae únicamente el parche de #1181 sobre el `main` actual para evitar incluir cambios no desplegados de `develop`.

## Problema
El buscador de Cobros incluye créditos `CANCELADO`, pero `getCreditoByNumero` los excluía antes de llegar a la rama que ya maneja ese estado. Al abrirlos, el CRM mostraba “Caso No Encontrado” e impedía acceder a la información y documentos asociados.

## Solución
- Centraliza los estados visibles en el detalle.
- Incluye `CANCELADO` en la consulta.
- Conserva `CAIDO` fuera del flujo.
- Agrega pruebas de regresión.

## Alcance probado
- `git patch-id --stable` idéntico al parche original de #1181.
- Solo 3 archivos bajo `apps/cartera-back/src/controllers`.
- 31/31 pruebas enfocadas.
- Biome de archivos nuevos limpio.
- `git diff --check` limpio.
- Smoke read-only contra el crédito reportado: `statusCredit=CANCELADO`, `flow=CANCELADO`, estructura completa.

No incluye migraciones, cambios de datos, merge ni deploy.