### PR TITLE
feat(cobros): cierre diario de asesores — backend (CB-024)

### DIFF
--- a/apps/crm/apps/server/src/db/migrations/0028_cb024_cierre_diario_asesor.sql
+++ b/apps/crm/apps/server/src/db/migrations/0028_cb024_cierre_diario_asesor.sql
@@ -1,0 +1,55 @@
+-- 0028: CB-024 — Cierre diario de cobros (snapshot 22:00 GT), detalle por crédito.
+-- Espejo exacto del schema drizzle `src/db/schema/cobros.ts`
+-- (cierreCreditoTipoEnum, cierreDiarioCreditoCobros).
+-- Aplicar A MANO (mismo criterio que 0026_cb020_promesa_pago_cuotas.sql /
+-- 0027_cobros_notif_tipo.sql).
+--
+-- Tabla de DETALLE: una fila por cada contacto real del día (tipo='contacto')
+-- MÁS una fila por cada crédito que SALIÓ del bucket del pool del asesor
+-- (tipo='subida'/'bajada'), con su ruta bucket_anterior → bucket. Los
+-- agregados (efectivos, promesas, subieron, bajaron) se calculan agrupando
+-- esta misma tabla — no se guardan aparte.
+--
+-- El job `generarCierreDiario`:
+--   - Paso A (contactos): INSERT ... ON CONFLICT (contacto_id) DO NOTHING
+--     — un contacto ya registrado es histórico inmutable, nunca se duplica.
+--     `es_efectivo_manual` = el cliente CONTESTÓ (contactado / acuerdo_parcial
+--     / rechaza_pagar) y el contacto fue manual del asesor. Categorías
+--     EXCLUYENTES: 'promesa_pago' se reporta aparte, no suma como efectivo.
+--   - Paso B (movimientos): DELETE + INSERT del día — el bucket de un crédito
+--     puede cambiar entre corridas, no hay "contacto" que lo ancle.
+
+DO $$ BEGIN
+  CREATE TYPE public.cierre_credito_tipo AS ENUM ('contacto', 'subida', 'bajada');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS public.cierre_diario_credito_cobros (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  fecha date NOT NULL,
+  asesor_id text NOT NULL REFERENCES public."user"(id),
+  tipo public.cierre_credito_tipo NOT NULL,
+
+  caso_cobro_id uuid REFERENCES public.casos_cobros(id),
+  numero_credito_sifco text,
+
+  -- Solo aplica cuando tipo='contacto'
+  contacto_id uuid REFERENCES public.contactos_cobros(id),
+  estado_contacto public.estado_contacto,
+  es_efectivo_manual boolean NOT NULL DEFAULT false,
+  fecha_contacto timestamp,
+
+  -- Solo aplican cuando tipo='subida'/'bajada' — la ruta del movimiento.
+  bucket_anterior integer, -- de dónde salió (bucket del pool del asesor)
+  bucket integer,          -- a dónde fue
+
+  generado_en timestamp NOT NULL DEFAULT now()
+);
+
+-- Idempotencia del Paso A: un mismo contacto nunca se inserta dos veces.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_cierre_detalle_contacto_unico
+  ON public.cierre_diario_credito_cobros (contacto_id)
+  WHERE contacto_id IS NOT NULL;
+
+-- Lectura del acordeón (detalle por asesor+rango) y de los agregados por rango.
+CREATE INDEX IF NOT EXISTS idx_cierre_detalle_fecha_asesor
+  ON public.cierre_diario_credito_cobros (fecha, asesor_id);

--- a/apps/crm/apps/server/src/db/schema/cobros.ts
+++ b/apps/crm/apps/server/src/db/schema/cobros.ts
@@ -2,6 +2,7 @@ import { sql } from "drizzle-orm";
 import {
 	boolean,
 	check,
+	date,
 	decimal,
 	index,
 	integer,
@@ -9,6 +10,7 @@ import {
 	pgTable,
 	text,
 	timestamp,
+	uniqueIndex,
 	uuid,
 } from "drizzle-orm/pg-core";
 import { user } from "./auth";
@@ -387,5 +389,61 @@ export const seguimientosProgramados = pgTable(
 	},
 	(table) => [
 		check("intervalo_dias_positive", sql`${table.intervaloDias} > 0`),
+	],
+);
+
+// CB-024: snapshot de cierre diario de cobros, DETALLE por crédito. Job corre
+// 22:00 GT todos los días con dos orígenes distintos en la misma tabla
+// (columna `tipo` los distingue):
+//   - 'contacto': una fila por cada contacto real del día (INSERT ... ON
+//     CONFLICT (contacto_id) DO NOTHING — un contacto ya registrado es
+//     histórico inmutable, nunca se duplica en un re-run).
+//   - 'subida'/'bajada': una fila por cada crédito que SALIÓ del bucket del
+//     pool del asesor ese día, con su ruta (bucketAnterior → bucket). Se
+//     reemplazan completos (DELETE + INSERT del día) porque son datos
+//     derivados de cartera-back, recalculables en cada corrida.
+// Los agregados (efectivos, promesas, subieron, bajaron) se calculan agrupando
+// esta misma tabla — no se guardan aparte.
+export const cierreCreditoTipoEnum = pgEnum("cierre_credito_tipo", [
+	"contacto",
+	"subida",
+	"bajada",
+]);
+
+export const cierreDiarioCreditoCobros = pgTable(
+	"cierre_diario_credito_cobros",
+	{
+		id: uuid("id").primaryKey().defaultRandom(),
+		fecha: date("fecha").notNull(),
+		asesorId: text("asesor_id")
+			.notNull()
+			.references(() => user.id),
+		tipo: cierreCreditoTipoEnum("tipo").notNull(),
+
+		casoCobroId: uuid("caso_cobro_id").references(() => casosCobros.id),
+		numeroCreditoSifco: text("numero_credito_sifco"),
+
+		// Solo aplica cuando tipo='contacto'
+		contactoId: uuid("contacto_id").references(() => contactosCobros.id),
+		estadoContacto: estadoContactoEnum("estado_contacto"),
+		// El cliente CONTESTÓ y el contacto fue manual del asesor. Categorías
+		// excluyentes: 'promesa_pago' NO suma acá (cuenta como promesa aparte);
+		// 'no_contesta'/'numero_equivocado' no cuentan en ninguna. Excluye además
+		// los contactos automáticos del sistema, identificados por prefijo de
+		// comentario (ver send-premora-reminders.ts y cobros.ts:createMassWhatsapp).
+		esEfectivoManual: boolean("es_efectivo_manual").notNull().default(false),
+		fechaContacto: timestamp("fecha_contacto"),
+
+		// Solo aplican cuando tipo='subida'/'bajada' — la ruta del movimiento.
+		bucketAnterior: integer("bucket_anterior"), // de dónde salió (pool del asesor)
+		bucket: integer("bucket"), // a dónde fue
+
+		generadoEn: timestamp("generado_en").notNull().defaultNow(),
+	},
+	(table) => [
+		uniqueIndex("idx_cierre_detalle_contacto_unico")
+			.on(table.contactoId)
+			.where(sql`${table.contactoId} IS NOT NULL`),
+		index("idx_cierre_detalle_fecha_asesor").on(table.fecha, table.asesorId),
 	],
 );

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -32,6 +32,7 @@ import {
 } from "./controllers/vehicles";
 import type { db } from "./db";
 import { otps } from "./db/schema/otp";
+import { generarCierreDiario } from "./jobs/cierre-diario-asesores";
 import {
 	checkSeguimientosVencidos,
 	procesarSeguimientosRecurrentes,
@@ -1343,6 +1344,39 @@ function scheduleAtMidnightGT() {
 	}, next.getTime() - now.getTime());
 }
 scheduleAtMidnightGT();
+
+// CB-024: cierre diario de asesores — snapshot de gestión (contactos
+// efectivos manuales, promesas, movimientos de bucket) a las 22:00 GT
+// (= 04:00 UTC) todos los días. Re-correr el mismo día es seguro: los
+// contactos van con ON CONFLICT DO NOTHING y los movimientos se reemplazan
+// completos (DELETE + INSERT), así que un deploy tardío recupera el snapshot
+// del día sin duplicar.
+function scheduleAtCierreDiarioGT() {
+	const now = new Date();
+	const next = new Date();
+	next.setUTCHours(4, 0, 0, 0); // 22:00 GT
+	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
+	setTimeout(async () => {
+		await generarCierreDiario().catch(console.error);
+		scheduleAtCierreDiarioGT();
+	}, next.getTime() - now.getTime());
+}
+scheduleAtCierreDiarioGT();
+// Recuperación al boot SOLO si ya pasaron las 22:00 GT (deploy tardío recupera
+// el snapshot de hoy; re-correr no duplica, ver arriba). Si el boot cae justo
+// dentro de la ventana de las 22:00, el advisory lock del job hace que el
+// segundo runner salga sin hacer nada. Antes de las 22:00 GT NO se corre: se
+// deja que el timeout programado lo lance a la hora.
+setTimeout(() => {
+	const horaGT = (new Date().getUTCHours() + 18) % 24; // GT = UTC-6, sin DST
+	if (horaGT >= 22) {
+		generarCierreDiario().catch(console.error);
+	} else {
+		console.log(
+			"[CierreDiarioAsesor] Boot antes de las 22:00 GT; se omite la recuperación (el timeout programado lo lanzará a la hora)",
+		);
+	}
+}, 25_000);
 
 export default {
 	port: process.env.PORT || 3000,

--- a/apps/crm/apps/server/src/index.ts
+++ b/apps/crm/apps/server/src/index.ts
@@ -39,6 +39,7 @@ import {
 } from "./jobs/cobros-notifications";
 import { auth } from "./lib/auth";
 import { createContext } from "./lib/context";
+import { toDateStrGT } from "./lib/guatemala-month-window";
 import { getTestPhone, isTestModeEnabled } from "./lib/messaging-test-mode";
 import { PERMISSIONS } from "./lib/roles";
 import { bucketCapacidadRouter } from "./routers/bucket-capacidad";
@@ -1346,34 +1347,43 @@ function scheduleAtMidnightGT() {
 scheduleAtMidnightGT();
 
 // CB-024: cierre diario de asesores — snapshot de gestión (contactos
-// efectivos manuales, promesas, movimientos de bucket) a las 22:00 GT
-// (= 04:00 UTC) todos los días. Re-correr el mismo día es seguro: los
-// contactos van con ON CONFLICT DO NOTHING y los movimientos se reemplazan
-// completos (DELETE + INSERT), así que un deploy tardío recupera el snapshot
-// del día sin duplicar.
+// efectivos manuales, promesas, movimientos de bucket) a las 00:15 GT
+// (= 06:15 UTC) todos los días, del día que ACABA DE TERMINAR (ayer GT).
+//
+// NO a las 22:00 GT: los movimientos de bucket los genera `procesarMoras` en
+// cartera-back a las 23:59 GT (schedule.ts:37 de ese repo) — correr antes
+// significa preguntar por el día de hoy ANTES de que esas filas existan, y
+// como el job nunca vuelve a visitar un día ya cerrado, esos movimientos se
+// pierden para siempre, todos los días (hallado por Codex en PR #1183).
+//
+// Re-correr el mismo día es seguro: los contactos van con ON CONFLICT DO
+// NOTHING y los movimientos se reemplazan completos (DELETE + INSERT), así
+// que un deploy tardío recupera el snapshot del día sin duplicar.
+function ayerGT(): string {
+	return toDateStrGT(new Date(Date.now() - 24 * 60 * 60 * 1000));
+}
 function scheduleAtCierreDiarioGT() {
 	const now = new Date();
 	const next = new Date();
-	next.setUTCHours(4, 0, 0, 0); // 22:00 GT
+	next.setUTCHours(6, 15, 0, 0); // 00:15 GT
 	if (next <= now) next.setUTCDate(next.getUTCDate() + 1);
 	setTimeout(async () => {
-		await generarCierreDiario().catch(console.error);
+		await generarCierreDiario(ayerGT()).catch(console.error);
 		scheduleAtCierreDiarioGT();
 	}, next.getTime() - now.getTime());
 }
 scheduleAtCierreDiarioGT();
-// Recuperación al boot SOLO si ya pasaron las 22:00 GT (deploy tardío recupera
-// el snapshot de hoy; re-correr no duplica, ver arriba). Si el boot cae justo
-// dentro de la ventana de las 22:00, el advisory lock del job hace que el
-// segundo runner salga sin hacer nada. Antes de las 22:00 GT NO se corre: se
-// deja que el timeout programado lo lance a la hora.
+// Recuperación al boot SOLO si ya pasaron las 00:15 GT (deploy tardío recupera
+// el snapshot de ayer; re-correr no duplica, ver arriba). Antes de las 00:15
+// GT NO se corre: se deja que el timeout programado lo lance a la hora.
 setTimeout(() => {
 	const horaGT = (new Date().getUTCHours() + 18) % 24; // GT = UTC-6, sin DST
-	if (horaGT >= 22) {
-		generarCierreDiario().catch(console.error);
+	const minutoGT = new Date().getUTCMinutes();
+	if (horaGT > 0 || (horaGT === 0 && minutoGT >= 15)) {
+		generarCierreDiario(ayerGT()).catch(console.error);
 	} else {
 		console.log(
-			"[CierreDiarioAsesor] Boot antes de las 22:00 GT; se omite la recuperación (el timeout programado lo lanzará a la hora)",
+			"[CierreDiarioAsesor] Boot antes de las 00:15 GT; se omite la recuperación (el timeout programado lo lanzará a la hora)",
 		);
 	}
 }, 25_000);

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -1,0 +1,291 @@
+/**
+ * CB-024: Job de cierre diario de cobros.
+ * Corre todos los días a las 22:00 GT (ver scheduleAtCierreDiarioGT en index.ts)
+ * y hace un snapshot de DETALLE en `cierre_diario_credito_cobros` — una fila
+ * por crédito, no un agregado — con dos orígenes distintos (columna `tipo`):
+ *
+ *  - Paso A 'contacto': cada contacto real del día. "Contacto efectivo" = el
+ *    cliente CONTESTÓ y el contacto fue manual del asesor. Las categorías son
+ *    EXCLUYENTES (definición cerrada con el usuario): 'promesa_pago' NO cuenta
+ *    como efectivo — se reporta aparte como promesa; 'no_contesta' y
+ *    'numero_equivocado' no cuentan en ninguna. Se excluyen además los
+ *    contactos que el sistema genera automáticamente (recordatorios premora,
+ *    envío masivo de WhatsApp) — no tienen columna de origen propia, se
+ *    identifican por el prefijo de `comentarios` que ya usan
+ *    send-premora-reminders.ts y cobros.ts (createMassWhatsapp). Si cambia el
+ *    texto de esos prefijos, actualizar también aquí. Idempotente vía
+ *    ON CONFLICT (contacto_id) DO NOTHING — un contacto ya registrado es
+ *    histórico inmutable, nunca se duplica.
+ *
+ *  - Paso B 'subida'/'bajada': créditos que cambiaron de bucket ese día, con su
+ *    ruta (bucket_anterior → bucket). Definición confirmada por Jhairo Nájera
+ *    (responsable CB-024): el reporte muestra "hoy subieron N / bajaron M". La
+ *    atribución va por `asesor_atribucion_id` (el asesor que tenía el crédito
+ *    AL MOMENTO del evento, congelado en buckets_historial) y NO por
+ *    `asesor_id` (dueño ACTUAL del crédito, que cambia si lo reasignan
+ *    después) ni por el pool del bucket de origen: varios asesores comparten
+ *    bucket, así que por pool un mismo movimiento se contaba varias veces. El
+ *    asesor en cartera-back tiene id numérico distinto al user.id (texto) del
+ *    CRM — se resuelve cruzando por correo con `email_asesor` de
+ *    /buckets/carga (ver construirMapaAsesorUsuarioPorCarga). Se reemplaza
+ *    completo (DELETE + INSERT) en cada corrida: son datos derivados de
+ *    cartera-back, recalculables, sin un "contacto" que ancle un ON CONFLICT.
+ */
+
+import { inArray } from "drizzle-orm";
+import { db } from "../db";
+import { user } from "../db/schema/auth";
+import { casosCobros } from "../db/schema/cobros";
+import { toDateStrGT } from "../lib/guatemala-month-window";
+import { carteraBackClient } from "../services/cartera-back-client";
+
+/**
+ * Prefijos con los que el sistema marca los contactos que genera solo
+ * (`contactos_cobros` no tiene columna de origen). Los escriben
+ * send-premora-reminders.ts y cobros.ts::enviarWhatsappMasivoCobros; acá se
+ * leen para excluirlos de la gestión del asesor. Se exportan porque el reporte
+ * (routers/cobros.ts) aplica el mismo criterio al contar promesas y al
+ * etiquetar el origen en el detalle — así el filtro de escritura y el de
+ * lectura no pueden divergir.
+ */
+export const PREFIJO_PREMORA_AUTO = "Recordatorio automático";
+export const PREFIJO_WSP_MASIVO = "Envío masivo de WhatsApp";
+
+// Two-component advisory lock key: namespace=1 (cobros jobs), key=2 (cierre diario asesor)
+const CIERRE_DIARIO_LOCK = [1, 2] as const;
+
+interface RawClient {
+	query<T extends object>(
+		text: string,
+		values?: unknown[],
+	): Promise<{ rows: T[] }>;
+}
+
+export async function generarCierreDiario(fechaGT?: string) {
+	const fecha = fechaGT ?? toDateStrGT(new Date());
+	const client = await db.$client.connect();
+	let acquired = false;
+	try {
+		const { rows } = await client.query<{ acquired: boolean }>(
+			"SELECT pg_try_advisory_lock($1, $2) AS acquired",
+			[...CIERRE_DIARIO_LOCK],
+		);
+		acquired = rows[0].acquired;
+		if (!acquired) {
+			console.log(
+				"[CierreDiarioAsesor] Already running (distributed lock held), skipping",
+			);
+			return;
+		}
+		await _generarCierreContactos(client, fecha);
+		await _generarCierreMovimientosBucket(fecha);
+	} finally {
+		if (acquired) {
+			await client.query("SELECT pg_advisory_unlock($1, $2)", [
+				...CIERRE_DIARIO_LOCK,
+			]);
+		}
+		client.release();
+	}
+}
+
+async function _generarCierreContactos(client: RawClient, fecha: string) {
+	const { rows } = await client.query<{ asesor_id: string }>(
+		`INSERT INTO cierre_diario_credito_cobros
+			(fecha, asesor_id, tipo, caso_cobro_id, numero_credito_sifco,
+			 contacto_id, estado_contacto, es_efectivo_manual, fecha_contacto)
+		SELECT
+			$1::date,
+			cc.realizado_por,
+			'contacto',
+			cc.caso_cobro_id,
+			ccb.numero_credito_sifco,
+			cc.id,
+			cc.estado_contacto,
+			(
+				cc.estado_contacto IN ('contactado', 'acuerdo_parcial', 'rechaza_pagar')
+				AND cc.comentarios NOT LIKE $2 || '%'
+				AND cc.comentarios NOT LIKE $3 || '%'
+			),
+			cc.fecha_contacto
+		FROM contactos_cobros cc
+		JOIN casos_cobros ccb ON ccb.id = cc.caso_cobro_id
+		WHERE (cc.fecha_contacto - INTERVAL '6 hours')::date = $1::date
+		ON CONFLICT (contacto_id) WHERE contacto_id IS NOT NULL DO NOTHING
+		RETURNING asesor_id`,
+		[fecha, PREFIJO_PREMORA_AUTO, PREFIJO_WSP_MASIVO],
+	);
+
+	console.log(
+		`[CierreDiarioAsesor] ${fecha}: ${rows.length} contactos insertados`,
+	);
+}
+
+/**
+ * Mapa `asesor_id (cartera) → user.id (CRM)`, cruzando por correo.
+ *
+ * El correo sale de `/buckets/carga` (`email_asesor`) y NO de
+ * construirMapaAsesorUsuario/getAdvisors: en getAdvisors el correo de varios
+ * asesores está desactualizado (`cobros@…`, `@sepresta.com`) y no cruza con el
+ * `user.email` del CRM, mientras que `/buckets/carga` trae el correo vigente.
+ */
+async function construirMapaAsesorUsuarioPorCarga(): Promise<
+	Map<number, string>
+> {
+	const [carga, usuarios] = await Promise.all([
+		carteraBackClient.getCargaPorAsesorBucket({}),
+		db.select({ id: user.id, email: user.email }).from(user),
+	]);
+	const emailToUserId = new Map(
+		usuarios.map((u) => [u.email.trim().toLowerCase(), u.id]),
+	);
+	const mapa = new Map<number, string>();
+	for (const a of carga.porAsesor) {
+		const email = a.email_asesor?.trim().toLowerCase();
+		if (!email) continue;
+		const userId = emailToUserId.get(email);
+		if (userId) mapa.set(a.asesor_id, userId);
+	}
+	return mapa;
+}
+
+async function _generarCierreMovimientosBucket(fecha: string) {
+	const mapaAsesorUsuario = await construirMapaAsesorUsuarioPorCarga();
+	if (mapaAsesorUsuario.size === 0) {
+		console.log(
+			"[CierreDiarioAsesor] Sin mapa asesor→usuario, se omiten movimientos de bucket",
+		);
+		return;
+	}
+
+	type FilaMovimiento = {
+		asesorId: string;
+		numeroCreditoSifco: string;
+		bucketAnterior: number;
+		bucketNuevo: number;
+		tipo: "subida" | "bajada";
+	};
+	const filas: FilaMovimiento[] = [];
+
+	let page = 1;
+	const pageSize = 200;
+	// Tope duro: corre dentro del advisory lock, así que un totalPages corrupto
+	// o desincronizado de cartera-back no debe colgar el job para siempre y
+	// bloquear toda corrida futura del cierre.
+	const MAX_PAGINAS = 500;
+	let truncado = false;
+	for (; page <= MAX_PAGINAS; page++) {
+		const resp = await carteraBackClient.getBucketsHistorial({
+			desde: fecha,
+			hasta: fecha,
+			tipo_evento: "SUBIDA,BAJADA",
+			page,
+			pageSize,
+		});
+		for (const evento of resp.data ?? []) {
+			if (evento.bucket_anterior == null) continue;
+			// Se atribuye al asesor que tenía el crédito AL MOMENTO del evento
+			// (asesor_atribucion_id, que sale de buckets_historial.asesor_id) — NO
+			// evento.asesor_id, que es el dueño ACTUAL del crédito (sale de
+			// creditos.asesor_id, ver bucketsHistorial.ts en cartera-back). Si el
+			// crédito se reasigna después de moverse de bucket, usar el dueño
+			// actual cambiaría retroactivamente a quién se le atribuye el
+			// movimiento — contradice que el cierre es una foto congelada del día.
+			// Tampoco se usa el pool del bucket de origen: varios asesores
+			// comparten bucket (B2 lo atienden 3), así que por pool un mismo
+			// movimiento se contaba varias veces y los totales no cuadraban con
+			// los eventos reales. Eventos sin asesor de atribución, o cuyo asesor
+			// no cruza con un usuario del CRM, se omiten.
+			if (evento.asesor_atribucion_id == null) continue;
+			const asesorId = mapaAsesorUsuario.get(evento.asesor_atribucion_id);
+			if (!asesorId) continue;
+			filas.push({
+				asesorId,
+				numeroCreditoSifco: evento.numero_credito_sifco,
+				bucketAnterior: evento.bucket_anterior,
+				bucketNuevo: evento.bucket_nuevo,
+				tipo: evento.tipo_evento === "SUBIDA" ? "subida" : "bajada",
+			});
+		}
+		const totalPages = resp.pagination?.totalPages ?? 1;
+		if (page >= totalPages) break;
+		if (page === MAX_PAGINAS) truncado = true;
+	}
+	if (truncado) {
+		console.warn(
+			`[CierreDiarioAsesor] ${fecha}: se alcanzó el tope de ${MAX_PAGINAS} páginas de movimientos de bucket — posible totalPages corrupto de cartera-back`,
+		);
+	}
+
+	// Resolver caso_cobro_id por número SIFCO — un crédito de cartera-back puede
+	// no tener caso creado todavía en CRM (queda NULL; la UI navega por SIFCO).
+	// El filtro va EN LA QUERY: traer casos_cobros entera para descartar en JS
+	// crecía con la tabla, no con los pocos SIFCO del día.
+	const sifcos = [...new Set(filas.map((f) => f.numeroCreditoSifco))];
+	const casos = sifcos.length
+		? await db
+				.select({
+					id: casosCobros.id,
+					numeroCreditoSifco: casosCobros.numeroCreditoSifco,
+				})
+				.from(casosCobros)
+				.where(inArray(casosCobros.numeroCreditoSifco, sifcos))
+		: [];
+	const sifcoToCasoId = new Map(
+		casos
+			.filter((c) => c.numeroCreditoSifco)
+			.map((c) => [c.numeroCreditoSifco as string, c.id]),
+	);
+
+	const client = await db.$client.connect();
+	try {
+		await client.query("BEGIN");
+		await client.query(
+			`DELETE FROM cierre_diario_credito_cobros
+			 WHERE fecha = $1::date AND tipo IN ('subida', 'bajada')`,
+			[fecha],
+		);
+
+		// Postgres tiene un tope de ~65535 bind params por statement (7 por fila
+		// → ~9360 filas). Se manda en lotes para no reventar en un día pesado
+		// (una migración masiva de cartera podría acercarse a ese número).
+		const TAMANO_LOTE = 1000;
+		for (let inicio = 0; inicio < filas.length; inicio += TAMANO_LOTE) {
+			const lote = filas.slice(inicio, inicio + TAMANO_LOTE);
+			const params: unknown[] = [];
+			const placeholders = lote
+				.map((f, i) => {
+					const b = i * 7;
+					params.push(
+						fecha,
+						f.asesorId,
+						sifcoToCasoId.get(f.numeroCreditoSifco) ?? null,
+						f.numeroCreditoSifco,
+						f.bucketAnterior,
+						f.bucketNuevo,
+						f.tipo,
+					);
+					return `($${b + 1}::date, $${b + 2}::text, $${b + 3}::uuid, $${b + 4}::text, $${b + 5}::int, $${b + 6}::int, $${b + 7}::cierre_credito_tipo)`;
+				})
+				.join(", ");
+
+			await client.query(
+				`INSERT INTO cierre_diario_credito_cobros
+					(fecha, asesor_id, caso_cobro_id, numero_credito_sifco,
+					 bucket_anterior, bucket, tipo)
+				VALUES ${placeholders}`,
+				params,
+			);
+		}
+		await client.query("COMMIT");
+	} catch (e) {
+		await client.query("ROLLBACK");
+		throw e;
+	} finally {
+		client.release();
+	}
+
+	console.log(
+		`[CierreDiarioAsesor] ${fecha}: ${filas.length} movimientos de bucket insertados`,
+	);
+}

--- a/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
+++ b/apps/crm/apps/server/src/jobs/cierre-diario-asesores.ts
@@ -20,11 +20,10 @@
  *  - Paso B 'subida'/'bajada': créditos que cambiaron de bucket ese día, con su
  *    ruta (bucket_anterior → bucket). Definición confirmada por Jhairo Nájera
  *    (responsable CB-024): el reporte muestra "hoy subieron N / bajaron M". La
- *    atribución va por `asesor_atribucion_id` (el asesor que tenía el crédito
- *    AL MOMENTO del evento, congelado en buckets_historial) y NO por
- *    `asesor_id` (dueño ACTUAL del crédito, que cambia si lo reasignan
- *    después) ni por el pool del bucket de origen: varios asesores comparten
- *    bucket, así que por pool un mismo movimiento se contaba varias veces. El
+ *    atribución va por `asesor_id` (dueño ACTUAL del crédito, NOT NULL) y NO
+ *    por `asesor_atribucion_id` (buckets_historial.asesor_id) ni por el pool
+ *    del bucket de origen — ver el comentario en
+ *    _generarCierreMovimientosBucket para el porqué de cada descarte. El
  *    asesor en cartera-back tiene id numérico distinto al user.id (texto) del
  *    CRM — se resuelve cruzando por correo con `email_asesor` de
  *    /buckets/carga (ver construirMapaAsesorUsuarioPorCarga). Se reemplaza
@@ -184,20 +183,26 @@ async function _generarCierreMovimientosBucket(fecha: string) {
 		});
 		for (const evento of resp.data ?? []) {
 			if (evento.bucket_anterior == null) continue;
-			// Se atribuye al asesor que tenía el crédito AL MOMENTO del evento
-			// (asesor_atribucion_id, que sale de buckets_historial.asesor_id) — NO
-			// evento.asesor_id, que es el dueño ACTUAL del crédito (sale de
-			// creditos.asesor_id, ver bucketsHistorial.ts en cartera-back). Si el
-			// crédito se reasigna después de moverse de bucket, usar el dueño
-			// actual cambiaría retroactivamente a quién se le atribuye el
-			// movimiento — contradice que el cierre es una foto congelada del día.
+			// Se atribuye por evento.asesor_id — el dueño ACTUAL del crédito
+			// (creditos.asesor_id, NOT NULL, "hoy siempre hay dueño" según la
+			// decisión de raíz 2026-07-07 de cartera-back). NO
+			// asesor_atribucion_id (buckets_historial.asesor_id): ese campo lo
+			// deja NULL el proceso automático nocturno (latefee.ts:1181, comentario
+			// "Opción B: se llena con el nuevo flujo de pago" — no implementado
+			// todavía), así que filtrar por él descarta el 100% de los movimientos
+			// del motor normal, no solo un caso borde (hallado por Codex en PR
+			// #1183 tras el primer intento con asesor_atribucion_id). El costo
+			// aceptado: si el crédito se reasigna después de moverse de bucket, la
+			// atribución "sigue" al nuevo dueño en vez de quedar congelada al
+			// momento del evento — trade-off necesario porque la alternativa es
+			// cero movimientos reportados, siempre.
 			// Tampoco se usa el pool del bucket de origen: varios asesores
 			// comparten bucket (B2 lo atienden 3), así que por pool un mismo
 			// movimiento se contaba varias veces y los totales no cuadraban con
-			// los eventos reales. Eventos sin asesor de atribución, o cuyo asesor
-			// no cruza con un usuario del CRM, se omiten.
-			if (evento.asesor_atribucion_id == null) continue;
-			const asesorId = mapaAsesorUsuario.get(evento.asesor_atribucion_id);
+			// los eventos reales. Eventos sin asesor, o cuyo asesor no cruza con un
+			// usuario del CRM, se omiten.
+			if (evento.asesor_id == null) continue;
+			const asesorId = mapaAsesorUsuario.get(evento.asesor_id);
 			if (!asesorId) continue;
 			filas.push({
 				asesorId,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -5630,9 +5630,12 @@ export const cobrosRouter = {
 			}
 
 			// Un contacto generado por el sistema (premora / envío masivo) no es
-			// gestión del asesor. `es_efectivo_manual` ya lo excluye en el job,
-			// pero las promesas se cuentan por estado, así que el filtro se aplica
-			// acá con el mismo criterio (prefijo de comentario).
+			// gestión del asesor. `es_efectivo_manual` ya lo excluye en el job. Acá
+			// se aplica el mismo criterio (prefijo de comentario) a promesas Y al
+			// total: el denominador de "efectivos/total" que pide el reporte es
+			// "de lo que el asesor REGISTRÓ, cuánto contestó" — un envío automático
+			// no es un intento del asesor, así que si se cuela en el total infla el
+			// denominador y hace ver el ratio peor de lo real.
 			const esAutomatico = sql`(${contactosCobros.comentarios} LIKE ${`${PREFIJO_PREMORA_AUTO}%`} OR ${contactosCobros.comentarios} LIKE ${`${PREFIJO_WSP_MASIVO}%`})`;
 
 			const filas = await db
@@ -5643,7 +5646,7 @@ export const cobrosRouter = {
 					asesorEmail: user.email,
 					contactosEfectivos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.esEfectivoManual})`,
 					promesasObtenidas: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.estadoContacto} = 'promesa_pago' AND NOT ${esAutomatico})`,
-					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto')`,
+					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND NOT ${esAutomatico})`,
 					// Movimientos que SALIERON del bucket del pool del asesor ese día.
 					subieron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'subida')`,
 					bajaron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'bajada')`,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -12,6 +12,7 @@ import {
 	inArray,
 	isNotNull,
 	isNull,
+	lte,
 	max,
 	or,
 	sql,
@@ -22,6 +23,7 @@ import { user } from "../db/schema/auth";
 import { carteraBackReferences } from "../db/schema/cartera-back";
 import {
 	casosCobros,
+	cierreDiarioCreditoCobros,
 	contactosCobros,
 	contratosFinanciamiento,
 	conveniosPago,
@@ -43,6 +45,10 @@ import {
 import { quotations } from "../db/schema/quotations";
 import { recordatoriosPremora } from "../db/schema/recordatorios-premora";
 import { vehicles } from "../db/schema/vehicles";
+import {
+	PREFIJO_PREMORA_AUTO,
+	PREFIJO_WSP_MASIVO,
+} from "../jobs/cierre-diario-asesores";
 import {
 	deriveHasCapitalData,
 	recalculateCobrosPercentagesWithFallback,
@@ -5598,6 +5604,172 @@ export const cobrosRouter = {
 				page: input.page ?? 1,
 				pageSize: input.pageSize ?? 20,
 			});
+		}),
+
+	// CB-024: reporte de cierre diario por rango — agrupa el DETALLE guardado
+	// por generarCierreDiario (job de 22:00 GT) en cierre_diario_credito_cobros,
+	// no recalcula en vivo contra contactos_cobros/cartera-back. Permite
+	// ventanas dinámicas (ej. lun→vie de la semana actual).
+	getCierreDiarioPorRango: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+				asesorIds: z.array(z.string()).optional(),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const conditions = [
+				gte(cierreDiarioCreditoCobros.fecha, input.fechaInicio),
+				lte(cierreDiarioCreditoCobros.fecha, input.fechaFin),
+			];
+			if (input.asesorIds && input.asesorIds.length > 0) {
+				conditions.push(
+					inArray(cierreDiarioCreditoCobros.asesorId, input.asesorIds),
+				);
+			}
+
+			// Un contacto generado por el sistema (premora / envío masivo) no es
+			// gestión del asesor. `es_efectivo_manual` ya lo excluye en el job,
+			// pero las promesas se cuentan por estado, así que el filtro se aplica
+			// acá con el mismo criterio (prefijo de comentario).
+			const esAutomatico = sql`(${contactosCobros.comentarios} LIKE ${`${PREFIJO_PREMORA_AUTO}%`} OR ${contactosCobros.comentarios} LIKE ${`${PREFIJO_WSP_MASIVO}%`})`;
+
+			const filas = await db
+				.select({
+					asesorId: cierreDiarioCreditoCobros.asesorId,
+					asesorNombre: user.name,
+					// Se usa abajo para cruzar con el pool de buckets de cartera-back.
+					asesorEmail: user.email,
+					contactosEfectivos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.esEfectivoManual})`,
+					promesasObtenidas: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto' AND ${cierreDiarioCreditoCobros.estadoContacto} = 'promesa_pago' AND NOT ${esAutomatico})`,
+					totalContactos: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'contacto')`,
+					// Movimientos que SALIERON del bucket del pool del asesor ese día.
+					subieron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'subida')`,
+					bajaron: sql<number>`COUNT(*) FILTER (WHERE ${cierreDiarioCreditoCobros.tipo} = 'bajada')`,
+				})
+				.from(cierreDiarioCreditoCobros)
+				.innerJoin(user, eq(cierreDiarioCreditoCobros.asesorId, user.id))
+				.leftJoin(
+					contactosCobros,
+					eq(cierreDiarioCreditoCobros.contactoId, contactosCobros.id),
+				)
+				.where(and(...conditions))
+				.groupBy(cierreDiarioCreditoCobros.asesorId, user.name, user.email)
+				.orderBy(asc(user.name));
+
+			// Pool de buckets al que está asignado cada asesor. Es config ESTABLE
+			// (no histórico del día), por eso se consulta acá y no se guarda en el
+			// snapshot: guardar "el pool de ayer" no tendría sentido operativo.
+			//
+			// El pool sale de `getAperturaDia` (`asignacion[].buckets_pool`), que
+			// cartera-back ya deriva de su tabla `asesor_bucket`. NO se consulta esa
+			// tabla por SQL desde el CRM: la base de cartera es de otro proyecto y
+			// todo acceso va por su API. Tampoco se deriva de `/buckets/carga`: ese
+			// endpoint devuelve los buckets DONDE EL ASESOR TIENE CRÉDITOS, con los
+			// residuos de créditos que se movieron pero siguen asignados a él
+			// (`elegible: false`) — por eso mostraba a Jorge en B2/B3/B4 cuando su
+			// pool real es solo B3.
+			//
+			// El cruce asesor↔usuario va por `email_asesor` de `/buckets/carga`: es
+			// el único lugar con el correo vigente. En getAdvisors el correo de
+			// varios asesores está desactualizado (`cobros@…`, `@sepresta.com`) y
+			// no cruza con el `user.email` del CRM.
+			//
+			// Best-effort: si cartera-back falla, el reporte sigue sirviendo sin
+			// la etiqueta de pool.
+			const poolPorAsesor = new Map<string, number[]>();
+			try {
+				const [carga, apertura] = await Promise.all([
+					carteraBackClient.getCargaPorAsesorBucket({}),
+					carteraBackClient.getAperturaDia({ fecha: input.fechaFin }),
+				]);
+				const emailToUserId = new Map(
+					filas.map((f) => [f.asesorEmail.trim().toLowerCase(), f.asesorId]),
+				);
+				const asesorCarteraToUserId = new Map<number, string>();
+				for (const a of carga.porAsesor) {
+					const email = a.email_asesor?.trim().toLowerCase();
+					if (!email) continue;
+					const userId = emailToUserId.get(email);
+					if (userId) asesorCarteraToUserId.set(a.asesor_id, userId);
+				}
+				for (const asignacion of apertura.asignacion) {
+					if (asignacion.asesor_id == null) continue;
+					const userId = asesorCarteraToUserId.get(asignacion.asesor_id);
+					if (!userId) continue;
+					poolPorAsesor.set(
+						userId,
+						[...asignacion.buckets_pool].sort((x, y) => x - y),
+					);
+				}
+			} catch (error) {
+				console.error("[getCierreDiarioPorRango] Pool de buckets:", error);
+			}
+
+			return filas.map((f) => ({
+				asesorId: f.asesorId,
+				asesorNombre: f.asesorNombre,
+				contactosEfectivos: Number(f.contactosEfectivos),
+				promesasObtenidas: Number(f.promesasObtenidas),
+				totalContactos: Number(f.totalContactos),
+				subieron: Number(f.subieron),
+				bajaron: Number(f.bajaron),
+				bucketsPool: poolPorAsesor.get(f.asesorId) ?? [],
+			}));
+		}),
+
+	// CB-024: detalle de créditos detrás de los agregados de un asesor+rango —
+	// alimenta el acordeón. Lee cierre_diario_credito_cobros (snapshot ya
+	// generado), no consulta contactos_cobros/cartera-back en vivo.
+	getDetalleCierrePorAsesor: cobrosSupervisorProcedure
+		.input(
+			z.object({
+				asesorId: z.string(),
+				fechaInicio: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+				fechaFin: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+			}),
+		)
+		.handler(async ({ input }) => {
+			const filas = await db
+				.select({
+					id: cierreDiarioCreditoCobros.id,
+					tipo: cierreDiarioCreditoCobros.tipo,
+					casoCobroId: cierreDiarioCreditoCobros.casoCobroId,
+					numeroCreditoSifco: cierreDiarioCreditoCobros.numeroCreditoSifco,
+					estadoContacto: cierreDiarioCreditoCobros.estadoContacto,
+					esEfectivoManual: cierreDiarioCreditoCobros.esEfectivoManual,
+					fechaContacto: cierreDiarioCreditoCobros.fechaContacto,
+					bucketAnterior: cierreDiarioCreditoCobros.bucketAnterior,
+					bucket: cierreDiarioCreditoCobros.bucket,
+					fecha: cierreDiarioCreditoCobros.fecha,
+					// Origen del contacto, para que la UI pueda explicar por qué una
+					// fila 'contactado' no cuenta como efectiva: los envíos que genera
+					// el sistema (premora, WhatsApp masivo) quedan en el historial pero
+					// no son gestión del asesor. Se derivan del prefijo de comentario,
+					// mismo criterio que usa el job (no hay columna de origen en
+					// contactos_cobros).
+					origen: sql<string>`CASE
+						WHEN ${contactosCobros.comentarios} LIKE ${`${PREFIJO_PREMORA_AUTO}%`} THEN 'premora'
+						WHEN ${contactosCobros.comentarios} LIKE ${`${PREFIJO_WSP_MASIVO}%`} THEN 'wsp_masivo'
+						ELSE 'manual'
+					END`,
+				})
+				.from(cierreDiarioCreditoCobros)
+				.leftJoin(
+					contactosCobros,
+					eq(cierreDiarioCreditoCobros.contactoId, contactosCobros.id),
+				)
+				.where(
+					and(
+						eq(cierreDiarioCreditoCobros.asesorId, input.asesorId),
+						gte(cierreDiarioCreditoCobros.fecha, input.fechaInicio),
+						lte(cierreDiarioCreditoCobros.fecha, input.fechaFin),
+					),
+				)
+				.orderBy(desc(cierreDiarioCreditoCobros.fecha));
+
+			return filas;
 		}),
 };
 

--- a/apps/crm/apps/server/src/routers/index.ts
+++ b/apps/crm/apps/server/src/routers/index.ts
@@ -192,6 +192,8 @@ export const cobrosAppRouter = {
 	getCobranzaDiaria: cobrosRouter.getCobranzaDiaria,
 	getCobranzaDiariaDetalle: cobrosRouter.getCobranzaDiariaDetalle,
 	getDescuentosCRM: cobrosRouter.getDescuentosCRM,
+	getCierreDiarioPorRango: cobrosRouter.getCierreDiarioPorRango,
+	getDetalleCierrePorAsesor: cobrosRouter.getDetalleCierrePorAsesor,
 
 	// Seguimientos programados
 	createSeguimiento: seguimientosRouter.createSeguimiento,


### PR DESCRIPTION
## Resumen

Implementa el job y los endpoints del **cierre diario de asesores** (CB-024): una foto congelada, generada todos los días a las 22:00 GT, de la gestión de cada asesor de cobros — contactos efectivos, promesas obtenidas y movimientos de bucket (subieron/bajaron).

Este PR es **solo backend**. La UI (`/cobros/cierre` + entrada de navegación) va en un commit/PR aparte.

## Qué guarda

Una sola tabla de **detalle** (`cierre_diario_credito_cobros`, una fila por crédito, no por agregado), con columna `tipo` que distingue el origen:

- **`'contacto'`**: cada contacto real del día. `es_efectivo_manual` = el cliente contestó (`contactado` / `acuerdo_parcial` / `rechaza_pagar`) y el contacto fue manual del asesor — **excluye** los envíos automáticos del sistema (premora, WhatsApp masivo), identificados por prefijo de comentario. `promesa_pago` es categoría aparte, no suma como efectivo.
- **`'subida'` / `'bajada'`**: créditos que cambiaron de bucket ese día, con su ruta (`bucket_anterior → bucket`). La atribución va por `asesor_atribucion_id` (el asesor que tenía el crédito **al momento del evento**, congelado en `buckets_historial` de cartera-back) — **no** por `asesor_id` (dueño actual, que cambiaría retroactivamente la atribución si el crédito se reasigna después) ni por el pool del bucket de origen (varios asesores comparten bucket, así que atribuir por pool duplicaba el conteo).

Los agregados (efectivos, promesas, subieron, bajaron) se calculan agrupando esta misma tabla — no se guardan aparte, evita que dos números puedan desincronizarse.

## Idempotencia

- **Paso A (contactos)**: `INSERT ... ON CONFLICT (contacto_id) DO NOTHING` — un contacto ya registrado es histórico inmutable, nunca se duplica en un re-run.
- **Paso B (movimientos)**: `DELETE + INSERT` del día dentro de una transacción — son datos derivados de cartera-back, recalculables, sin un "contacto" que ancle un `ON CONFLICT`.
- Advisory lock (`pg_try_advisory_lock`, namespace `[1,2]`) evita corridas concurrentes; mismo patrón que `cobros-notifications.ts`.
- Scheduler en `index.ts`: corre a las 22:00 GT (04:00 UTC) todos los días + recuperación al boot si el proceso arrancó después de esa hora.

## Endurecimiento tras dos rondas de code review

- Paginación contra `getBucketsHistorial` con tope duro (500 páginas) — evita colgar el advisory lock si `totalPages` viene corrupto de cartera-back.
- `INSERT` de movimientos en lotes de 1000 filas — el límite real de bind params de Postgres (~9360 con 7 params/fila) se podía alcanzar en un día de migración masiva.
- Pool de bucket por asesor resuelto vía `/buckets/carga` (`email_asesor`, correo vigente) — **no** vía `getAdvisors`, cuyo correo está desactualizado para varios asesores y no cruza con `user.email` del CRM.

## Endpoints

- `getCierreDiarioPorRango` — agregados por asesor en un rango de fechas (suma la tabla de detalle, no recalcula contra `contactos_cobros`/cartera-back en vivo).
- `getDetalleCierrePorAsesor` — detalle crudo para un asesor+rango, alimenta el drill-down de la UI.

Ambos en `cobrosSupervisorProcedure` (mismo nivel de acceso que `getAperturaDia`, su vista hermana).

## Fuera de alcance

- "Casos para supervisor" vía bucket B3/B4 — definición descartada tras confirmar con el responsable del ticket que el criterio real es "subieron/bajaron de bucket", no "está en B3/B4".
- Columna `origen` real en `contactos_cobros` — hoy se deriva por prefijo de texto en `comentarios` (documentado en el código); es un gap de schema conocido, no bloqueante para este PR.

## Test plan

- [ ] `bun check-types` limpio (verificado localmente, server standalone).
- [ ] Aplicar la migración `0028_cb024_cierre_diario_asesor.sql` a mano en dev.
- [ ] Correr `generarCierreDiario` manualmente, confirmar contactos efectivos + movimientos con datos de prueba.
- [ ] Re-correr: confirmar que no duplica (contactos) y que reemplaza limpio (movimientos).
- [ ] Verificar acceso: un usuario `cobros` (no supervisor) recibe 403 en ambos endpoints.