### PR TITLE
Hotfix: detalle seguro de créditos cancelados

### DIFF
--- a/apps/cartera-back/src/controllers/abonosCapital.ts
+++ b/apps/cartera-back/src/controllers/abonosCapital.ts
@@ -4,6 +4,8 @@ import { db } from "../database";
 import Big from "big.js";
 import { obtenerSumaComprasPendientes } from "../utils/comprasAjuste";
 
+type AbonoCapitalExecutor = Pick<typeof db, "select" | "insert">;
+
 export async function createAbonoCapital(data: {
   credito_id: number;
   inversionista_id: number;
@@ -62,12 +64,13 @@ export async function distribuirAbonoCapitalEspejo(
   credito_id: number,
   monto_abono_capital: number | string,
   tipo: "CANCELACION" | "CAPITAL" = "CAPITAL",
-  pago_id?: number
+  pago_id?: number,
+  executor: AbonoCapitalExecutor = db
 ) {
   const abonoBig = new Big(monto_abono_capital);
 
   // 1. Traer inversionistas del espejo
-  const invsEspejo = await db
+  const invsEspejo = await executor
       .select({
         inversionista_id: creditos_inversionistas_espejo.inversionista_id,
         monto_aportado: creditos_inversionistas_espejo.monto_aportado,
@@ -111,7 +114,7 @@ export async function distribuirAbonoCapitalEspejo(
 
       // Una fila propia por (pago, inversionista): nunca se suma sobre una
       // fila previa, así revertir el pago no le toca lo suyo a otros pagos.
-      const [nuevo] = await db
+      const [nuevo] = await executor
         .insert(abonos_capital)
         .values({
           credito_id,
@@ -358,4 +361,3 @@ export async function updateAbonoCapital(
     };
   }
 }
-

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -37,9 +37,8 @@ describe("credit closing payments", () => {
 });
 
 describe("original principal payments", () => {
-	it("includes every original-principal validation status", () => {
+	it("accepts reversal-aware validation statuses regardless of payment flags", () => {
 		for (const validationStatus of [
-			"no_required",
 			"validated",
 			"capital_validated",
 			"reset",
@@ -47,19 +46,36 @@ describe("original principal payments", () => {
 			expect(
 				isOriginalPrincipalPayment({
 					validationStatus,
-					pagado: true,
-					paymentFalse: false,
+					pagado: false,
+					paymentFalse: true,
 				}),
 			).toBeTrue();
 		}
 	});
 
-	it("excludes pending, capital, unpaid, and false payments", () => {
+	it("accepts no_required only when paid and not marked false", () => {
+		expect(
+			isOriginalPrincipalPayment({
+				validationStatus: "no_required",
+				pagado: true,
+				paymentFalse: false,
+			}),
+		).toBeTrue();
+
+		for (const payment of [
+			{ validationStatus: "no_required", pagado: false, paymentFalse: false },
+			{ validationStatus: "no_required", pagado: true, paymentFalse: true },
+		]) {
+			expect(isOriginalPrincipalPayment(payment)).toBeFalse();
+		}
+	});
+
+	it("rejects pending, capital, null, and unknown statuses", () => {
 		for (const payment of [
 			{ validationStatus: "pending", pagado: true, paymentFalse: false },
 			{ validationStatus: "capital", pagado: true, paymentFalse: false },
-			{ validationStatus: "validated", pagado: false, paymentFalse: false },
-			{ validationStatus: "validated", pagado: true, paymentFalse: true },
+			{ validationStatus: null, pagado: null, paymentFalse: null },
+			{ validationStatus: "unknown", pagado: true, paymentFalse: false },
 		]) {
 			expect(isOriginalPrincipalPayment(payment)).toBeFalse();
 		}

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -6,6 +6,7 @@ import {
 	isAmbiguousOriginalPrincipalPayment,
 	isCreditClosingPayment,
 	isOriginalPrincipalPayment,
+	isValidResetCreditInput,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
 
@@ -125,16 +126,12 @@ describe("original principal payments", () => {
 });
 
 describe("credit detail visibility", () => {
-	it("only allows resetting credits pending cancellation", () => {
+	it("allows pending cancellation and only ready bad-debt continuations", () => {
 		expect(canResetCreditByStatus("PENDIENTE_CANCELACION")).toBeTrue();
+		expect(canResetCreditByStatus("INCOBRABLE")).toBeFalse();
+		expect(canResetCreditByStatus("INCOBRABLE", true)).toBeTrue();
 
-		for (const status of [
-			"CANCELADO",
-			"INCOBRABLE",
-			"ACTIVO",
-			null,
-			undefined,
-		]) {
+		for (const status of ["CANCELADO", "ACTIVO", null]) {
 			expect(canResetCreditByStatus(status)).toBeFalse();
 		}
 	});
@@ -258,5 +255,145 @@ describe("credit closure paymentFalse wiring", () => {
 			/paymentFalse:\s*sql<boolean>`CASE\s+WHEN \$\{pagos_credito\.paymentFalse\} IS TRUE THEN TRUE\s+WHEN \$\{pagos_credito\.validationStatus\} IN \('validated', 'capital_validated'\) THEN FALSE\s+ELSE TRUE\s+END`/g;
 
 		expect(source.match(caseExpression)).toHaveLength(2);
+	});
+});
+
+describe("reset credit bad-debt continuation wiring", () => {
+	it("requires matching bad-debt and credit capital without a system reset payment", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "credits.ts"),
+		).text();
+		const resetCredit = source.match(
+			/export async function resetCredit[\s\S]*?(?=\nexport )/,
+		)?.[0];
+
+		expect(resetCredit).toContain(
+			"monto_incobrable: bad_debts.monto_incobrable",
+		);
+		expect(resetCredit).toContain(".from(bad_debts)");
+		expect(resetCredit).toContain("pago_id: pagos_credito.pago_id");
+		expect(resetCredit).toContain(
+			'eq(pagos_credito.registerBy, "system_reset")',
+		);
+		expect(resetCredit).toContain("montoIncobrableBig.eq(creditoCapitalBig)");
+		expect(resetCredit).toContain("montoIncobrableBig.eq(badDebtCapitalBig)");
+		expect(resetCredit).toContain(
+			"canResetCreditByStatus(credito.statusCredit, incobrableContinuationReady)",
+		);
+	});
+});
+
+describe("reset credit router validation wiring", () => {
+	it("uses the reset input guard without coercing montoIncobrable", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "../routers/credits.ts"),
+		).text();
+		const route = source.match(
+			/\.post\("\/resetCredit"[\s\S]*?(?=\n\s*\.get\()/,
+		)?.[0];
+
+		expect(route).toContain("isValidResetCreditInput");
+		expect(route).not.toContain("Number(montoIncobrable)");
+	});
+});
+
+describe("reset credit input validation", () => {
+	const validInput = {
+		creditId: 1,
+		montoIncobrable: 10.5,
+		montoBoleta: 20,
+		url_boletas: ["https://example.com/boleta"],
+		cuota: 0,
+		banco_id: 2,
+		numeroAutorizacion: "ABC-123",
+	};
+
+	it("accepts numeric and decimal-string boleta bodies", () => {
+		expect(isValidResetCreditInput(validInput)).toBeTrue();
+		expect(
+			isValidResetCreditInput({ ...validInput, montoIncobrable: 0 }),
+		).toBeTrue();
+		expect(
+			isValidResetCreditInput({ ...validInput, montoBoleta: " 20.50 " }),
+		).toBeTrue();
+	});
+
+	it("rejects invalid credit IDs and bank IDs", () => {
+		for (const value of ["1", [1], Number.NaN, Number.POSITIVE_INFINITY, 1.5]) {
+			expect(
+				isValidResetCreditInput({ ...validInput, creditId: value }),
+			).toBeFalse();
+			expect(
+				isValidResetCreditInput({ ...validInput, banco_id: value }),
+			).toBeFalse();
+		}
+	});
+
+	it("rejects invalid bad-debt amounts", () => {
+		for (const value of [
+			"10",
+			[10],
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			-1,
+		]) {
+			expect(
+				isValidResetCreditInput({ ...validInput, montoIncobrable: value }),
+			).toBeFalse();
+		}
+	});
+
+	it("rejects invalid installment and boleta amounts", () => {
+		expect(isValidResetCreditInput({ ...validInput, cuota: -1 })).toBeFalse();
+		for (const value of [
+			"",
+			"   ",
+			"1e2",
+			Number.NaN,
+			Number.POSITIVE_INFINITY,
+			-1,
+		]) {
+			expect(
+				isValidResetCreditInput({ ...validInput, montoBoleta: value }),
+			).toBeFalse();
+		}
+	});
+
+	it("rejects non-string URLs and authorization numbers", () => {
+		expect(
+			isValidResetCreditInput({ ...validInput, url_boletas: ["ok", 1] }),
+		).toBeFalse();
+		expect(
+			isValidResetCreditInput({ ...validInput, numeroAutorizacion: 123 }),
+		).toBeFalse();
+	});
+});
+
+describe("reset credit atomic closing payment wiring", () => {
+	it("locks and rechecks before inserting the system reset payment", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "credits.ts"),
+		).text();
+		const resetCredit = source.match(
+			/export async function resetCredit[\s\S]*?(?=\nexport )/,
+		)?.[0];
+		const transaction = resetCredit?.match(
+			/db\.transaction\(async \(tx\) => \{[\s\S]*?\n\s*\}\)/,
+		)?.[0];
+
+		expect(transaction).toContain('.for("update")');
+		expect(transaction).toContain(".from(pagos_credito)");
+		expect(transaction).toContain(
+			'eq(pagos_credito.registerBy, "system_reset")',
+		);
+		expect(transaction).toContain("tx.insert(pagos_credito)");
+		if (!transaction)
+			throw new Error("No se encontró la transacción de cierre");
+		expect(transaction.indexOf('.for("update")')).toBeLessThan(
+			transaction.indexOf(".from(pagos_credito)"),
+		);
+		expect(transaction.indexOf(".from(pagos_credito)")).toBeLessThan(
+			transaction.indexOf("tx.insert(pagos_credito)"),
+		);
 	});
 });

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -3,19 +3,29 @@ import { resolve } from "node:path";
 import {
 	canResetCreditByStatus,
 	canViewCreditDetailByStatus,
+	isAmbiguousOriginalPrincipalPayment,
 	isCreditClosingPayment,
 	isOriginalPrincipalPayment,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
 
 describe("credit closing payments", () => {
-	it("accepts system resets with reset or validated status only", () => {
+	it("accepts reset status regardless of registerBy", () => {
 		expect(
 			isCreditClosingPayment({
 				validationStatus: "reset",
-				registerBy: "system_reset",
+				registerBy: "user",
 			}),
 		).toBeTrue();
+		expect(
+			isCreditClosingPayment({
+				validationStatus: "reset",
+				registerBy: null,
+			}),
+		).toBeTrue();
+	});
+
+	it("accepts validated status only for system resets", () => {
 		expect(
 			isCreditClosingPayment({
 				validationStatus: "validated",
@@ -24,12 +34,15 @@ describe("credit closing payments", () => {
 		).toBeTrue();
 	});
 
-	it("rejects ordinary validated, other registerBy, pending, and capital payments", () => {
+	it("rejects ordinary validated, pending, and capital payments", () => {
 		for (const payment of [
 			{ validationStatus: "validated", registerBy: "user" },
 			{ validationStatus: "validated", registerBy: "other" },
 			{ validationStatus: "pending", registerBy: "system_reset" },
 			{ validationStatus: "capital", registerBy: "system_reset" },
+			{ validationStatus: "no_required", registerBy: "system_reset" },
+			{ validationStatus: "unknown", registerBy: "system_reset" },
+			{ validationStatus: null, registerBy: "system_reset" },
 		]) {
 			expect(isCreditClosingPayment(payment)).toBeFalse();
 		}
@@ -37,7 +50,7 @@ describe("credit closing payments", () => {
 });
 
 describe("original principal payments", () => {
-	it("accepts reversal-aware validation statuses regardless of payment flags", () => {
+	it("accepts applied statuses when they are not marked false", () => {
 		for (const validationStatus of [
 			"validated",
 			"capital_validated",
@@ -47,10 +60,38 @@ describe("original principal payments", () => {
 				isOriginalPrincipalPayment({
 					validationStatus,
 					pagado: false,
-					paymentFalse: true,
+					paymentFalse: false,
 				}),
 			).toBeTrue();
 		}
+	});
+
+	it("rejects and identifies ambiguous applied partials", () => {
+		for (const validationStatus of ["validated", "capital_validated"]) {
+			const payment = {
+				validationStatus,
+				pagado: false,
+				paymentFalse: true,
+			};
+
+			expect(isOriginalPrincipalPayment(payment)).toBeFalse();
+			expect(isAmbiguousOriginalPrincipalPayment(payment)).toBeTrue();
+		}
+
+		const resetPayment = {
+			validationStatus: "reset",
+			pagado: false,
+			paymentFalse: true,
+		};
+		expect(isOriginalPrincipalPayment(resetPayment)).toBeFalse();
+		expect(isAmbiguousOriginalPrincipalPayment(resetPayment)).toBeFalse();
+		expect(
+			isAmbiguousOriginalPrincipalPayment({
+				validationStatus: "validated",
+				pagado: true,
+				paymentFalse: true,
+			}),
+		).toBeFalse();
 	});
 
 	it("accepts no_required only when paid and not marked false", () => {
@@ -58,7 +99,7 @@ describe("original principal payments", () => {
 			isOriginalPrincipalPayment({
 				validationStatus: "no_required",
 				pagado: true,
-				paymentFalse: false,
+				paymentFalse: null,
 			}),
 		).toBeTrue();
 
@@ -78,6 +119,7 @@ describe("original principal payments", () => {
 			{ validationStatus: "unknown", pagado: true, paymentFalse: false },
 		]) {
 			expect(isOriginalPrincipalPayment(payment)).toBeFalse();
+			expect(isAmbiguousOriginalPrincipalPayment(payment)).toBeFalse();
 		}
 	});
 });
@@ -188,5 +230,33 @@ describe("credit detail no-current-installment branch", () => {
 		)?.[0];
 
 		expect(branch).toContain("asesor: currentCredit.asesores,");
+	});
+});
+
+describe("credit detail contract summary wiring", () => {
+	it("sums eligible principal while gating publication on closing payments", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "credits.ts"),
+		).text();
+		const contractSummary = source.match(
+			/const contractSummary[\s\S]*?(?=\n\s*\/\/ 2\.)/,
+		)?.[0];
+
+		expect(contractSummary).toContain("eligiblePayments.reduce(");
+		expect(contractSummary).toContain("closingPayments.length > 0");
+		expect(contractSummary).toContain("!hasAmbiguousPrincipalPayments");
+		expect(contractSummary).not.toContain("closingPayments.reduce(");
+	});
+});
+
+describe("credit closure paymentFalse wiring", () => {
+	it("preserves explicit false-payment rows and keeps applied partials", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "credits.ts"),
+		).text();
+		const caseExpression =
+			/paymentFalse:\s*sql<boolean>`CASE\s+WHEN \$\{pagos_credito\.paymentFalse\} IS TRUE THEN TRUE\s+WHEN \$\{pagos_credito\.validationStatus\} IN \('validated', 'capital_validated'\) THEN FALSE\s+ELSE TRUE\s+END`/g;
+
+		expect(source.match(caseExpression)).toHaveLength(2);
 	});
 });

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -3,10 +3,19 @@ import { resolve } from "node:path";
 import {
 	canResetCreditByStatus,
 	canViewCreditDetailByStatus,
+	isScheduledCreditInstallment,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
 
 describe("credit detail visibility", () => {
+	it("excludes only reset credit installments from scheduled installments", () => {
+		for (const status of ["validated", "pending", null, undefined]) {
+			expect(isScheduledCreditInstallment(status)).toBeTrue();
+		}
+
+		expect(isScheduledCreditInstallment("reset")).toBeFalse();
+	});
+
 	it("only allows resetting credits pending cancellation", () => {
 		expect(canResetCreditByStatus("PENDIENTE_CANCELACION")).toBeTrue();
 

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -277,8 +277,8 @@ describe("reset credit bad-debt continuation wiring", () => {
 		);
 		expect(resetCredit).toContain("montoIncobrableBig.eq(creditoCapitalBig)");
 		expect(resetCredit).toContain("montoIncobrableBig.eq(badDebtCapitalBig)");
-		expect(resetCredit).toContain(
-			"canResetCreditByStatus(credito.statusCredit, incobrableContinuationReady)",
+		expect(resetCredit).toMatch(
+			/canResetCreditByStatus\(\s*credito\.statusCredit,\s*incobrableContinuationReady,?\s*\)/,
 		);
 	});
 });
@@ -370,25 +370,79 @@ describe("reset credit input validation", () => {
 });
 
 describe("reset credit atomic closing payment wiring", () => {
-	it("locks and rechecks before inserting the system reset payment", async () => {
+	it("keeps every reset write in one transaction", async () => {
 		const source = await Bun.file(
 			resolve(import.meta.dir, "credits.ts"),
 		).text();
 		const resetCredit = source.match(
 			/export async function resetCredit[\s\S]*?(?=\nexport )/,
 		)?.[0];
-		const transaction = resetCredit?.match(
-			/db\.transaction\(async \(tx\) => \{[\s\S]*?\n\s*\}\)/,
-		)?.[0];
+		const transactionStart = resetCredit?.indexOf(
+			"db.transaction(async (tx) => {",
+		);
+		const transactionEnd = resetCredit?.indexOf("\n    });", transactionStart);
+		const transaction =
+			resetCredit &&
+			transactionStart !== undefined &&
+			transactionStart >= 0 &&
+			transactionEnd !== undefined &&
+			transactionEnd >= 0
+				? resetCredit.slice(transactionStart, transactionEnd + 7)
+				: undefined;
+		if (!transaction || !resetCredit || transactionStart === undefined)
+			throw new Error("No se encontró la transacción de cierre");
+		const beforeTransaction = resetCredit.slice(0, transactionStart);
+		const lockIndex = transaction.indexOf('.for("update")');
+		const orderedReads = [
+			".from(moras_credito)",
+			".from(bad_debts)",
+			".from(pagos_credito)",
+			".from(credit_cancelations)",
+			".from(montos_adicionales)",
+			"getPagosDelMesActual(credito.credito_id, tx)",
+			".from(cuotas_credito)",
+		];
 
 		expect(transaction).toContain('.for("update")');
+		expect(
+			transaction.slice(0, lockIndex).match(/await\s+(?:db|tx)\s*\./g),
+		).toHaveLength(1);
+		expect(transaction.slice(0, lockIndex)).toMatch(
+			/await\s+tx\s*\.select\(\)[\s\S]*?\.from\(creditos\)[\s\S]*?\.where\(eq\(creditos\.credito_id, creditId\)\)/,
+		);
+		expect(beforeTransaction).not.toMatch(
+			/await\s+db\s*\.(?:select|insert|update|delete|execute|query)\b/,
+		);
+		for (const read of orderedReads) {
+			expect(transaction.indexOf(read)).toBeGreaterThan(lockIndex);
+		}
 		expect(transaction).toContain(".from(pagos_credito)");
 		expect(transaction).toContain(
 			'eq(pagos_credito.registerBy, "system_reset")',
 		);
 		expect(transaction).toContain("tx.insert(pagos_credito)");
-		if (!transaction)
-			throw new Error("No se encontró la transacción de cierre");
+		expect(transaction).toMatch(/tx\s*\.update\(pagos_credito\)/);
+		expect(transaction).toMatch(/tx\s*\.insert\(cuotas_credito\)/);
+		expect(transaction).toMatch(/tx\s*\.update\(creditos_inversionistas\)/);
+		expect(transaction).toContain("tx.insert(boletas)");
+		expect(transaction).toContain("tx.insert(bad_debts)");
+		expect(transaction).toContain("setCapitalSource(tx");
+		expect(transaction).toContain("distribuirAbonoCapitalEspejo(");
+		expect(transaction).toMatch(
+			/distribuirAbonoCapitalEspejo\([\s\S]*?tx,?\s*\)/,
+		);
+		expect(transaction).toMatch(
+			/insertPagosCreditoInversionistasV2\([\s\S]*?undefined,\s*tx,?\s*\)/,
+		);
+		expect(transaction).not.toMatch(/await db\.(?:insert|update|delete)/);
+		expect(transaction).not.toContain("withCapitalContext");
+		expect(transaction).toContain('statusCredit === "INCOBRABLE"');
+		expect(
+			transaction.lastIndexOf("return { nuevoPago, statusCredit }"),
+		).toBeGreaterThan(transaction.lastIndexOf("tx.insert(bad_debts)"));
+		expect(
+			transaction.lastIndexOf("return { nuevoPago, statusCredit }"),
+		).toBeGreaterThan(transaction.lastIndexOf(".update(creditos)"));
 		expect(transaction.indexOf('.for("update")')).toBeLessThan(
 			transaction.indexOf(".from(pagos_credito)"),
 		);

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,11 +1,26 @@
 import { describe, expect, it } from "bun:test";
 import { resolve } from "node:path";
 import {
+	canResetCreditByStatus,
 	canViewCreditDetailByStatus,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
 
 describe("credit detail visibility", () => {
+	it("only allows resetting credits pending cancellation", () => {
+		expect(canResetCreditByStatus("PENDIENTE_CANCELACION")).toBeTrue();
+
+		for (const status of [
+			"CANCELADO",
+			"INCOBRABLE",
+			"ACTIVO",
+			null,
+			undefined,
+		]) {
+			expect(canResetCreditByStatus(status)).toBeFalse();
+		}
+	});
+
 	it("permite consultar créditos cancelados desde el historial de cobros", () => {
 		expect(canViewCreditDetailByStatus("CANCELADO")).toBeTrue();
 	});
@@ -43,11 +58,18 @@ describe("cancelled credit detail", () => {
 		};
 		const cancelacion = { id: 7, activo: true };
 
-		expect(withActiveCancellation(detail, cancelacion)).toEqual({
-			...detail,
-			flujo: "CANCELADO",
+		const result = withActiveCancellation(
+			detail,
 			cancelacion,
-		});
+			"PENDIENTE_CANCELACION",
+		);
+
+		expect(result).toHaveProperty("cuotasPagadas", cuotasPagadas);
+		expect(result).toHaveProperty("cuotasPendientes", cuotasPendientes);
+		expect(result).toHaveProperty("cuotasAtrasadas", cuotasAtrasadas);
+		expect(result).toHaveProperty("moraActual", "125.00");
+		expect(result).toHaveProperty("flujo", "CANCELADO");
+		expect(result).toHaveProperty("cancelacion", cancelacion);
 	});
 
 	it("marca como cancelado el detalle sin cancelación activa", () => {

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -3,8 +3,68 @@ import { resolve } from "node:path";
 import {
 	canResetCreditByStatus,
 	canViewCreditDetailByStatus,
+	isCreditClosingPayment,
+	isOriginalPrincipalPayment,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
+
+describe("credit closing payments", () => {
+	it("accepts system resets with reset or validated status only", () => {
+		expect(
+			isCreditClosingPayment({
+				validationStatus: "reset",
+				registerBy: "system_reset",
+			}),
+		).toBeTrue();
+		expect(
+			isCreditClosingPayment({
+				validationStatus: "validated",
+				registerBy: "system_reset",
+			}),
+		).toBeTrue();
+	});
+
+	it("rejects ordinary validated, other registerBy, pending, and capital payments", () => {
+		for (const payment of [
+			{ validationStatus: "validated", registerBy: "user" },
+			{ validationStatus: "validated", registerBy: "other" },
+			{ validationStatus: "pending", registerBy: "system_reset" },
+			{ validationStatus: "capital", registerBy: "system_reset" },
+		]) {
+			expect(isCreditClosingPayment(payment)).toBeFalse();
+		}
+	});
+});
+
+describe("original principal payments", () => {
+	it("includes every original-principal validation status", () => {
+		for (const validationStatus of [
+			"no_required",
+			"validated",
+			"capital_validated",
+			"reset",
+		]) {
+			expect(
+				isOriginalPrincipalPayment({
+					validationStatus,
+					pagado: true,
+					paymentFalse: false,
+				}),
+			).toBeTrue();
+		}
+	});
+
+	it("excludes pending, capital, unpaid, and false payments", () => {
+		for (const payment of [
+			{ validationStatus: "pending", pagado: true, paymentFalse: false },
+			{ validationStatus: "capital", pagado: true, paymentFalse: false },
+			{ validationStatus: "validated", pagado: false, paymentFalse: false },
+			{ validationStatus: "validated", pagado: true, paymentFalse: true },
+		]) {
+			expect(isOriginalPrincipalPayment(payment)).toBeFalse();
+		}
+	});
+});
 
 describe("credit detail visibility", () => {
 	it("only allows resetting credits pending cancellation", () => {

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -3,19 +3,10 @@ import { resolve } from "node:path";
 import {
 	canResetCreditByStatus,
 	canViewCreditDetailByStatus,
-	isScheduledCreditInstallment,
 	withActiveCancellation,
 } from "./creditDetailPolicy";
 
 describe("credit detail visibility", () => {
-	it("excludes only reset credit installments from scheduled installments", () => {
-		for (const status of ["validated", "pending", null, undefined]) {
-			expect(isScheduledCreditInstallment(status)).toBeTrue();
-		}
-
-		expect(isScheduledCreditInstallment("reset")).toBeFalse();
-	});
-
 	it("only allows resetting credits pending cancellation", () => {
 		expect(canResetCreditByStatus("PENDIENTE_CANCELACION")).toBeTrue();
 
@@ -92,6 +83,26 @@ describe("cancelled credit detail", () => {
 });
 
 describe("credit detail no-current-installment branch", () => {
+	it("loads and returns active mora before the terminal branch", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "credits.ts"),
+		).text();
+		const moraQueryIndex = source.indexOf("const moraActual = await db");
+		const noCurrentBranchIndex = source.indexOf("if (!cuotaActualDataResult");
+		const branch = source.match(
+			/if \(!cuotaActualDataResult[\s\S]*?(?=\n\s*const cuotaActualData)/,
+		)?.[0];
+
+		expect(moraQueryIndex).toBeGreaterThan(-1);
+		expect(moraQueryIndex).toBeLessThan(noCurrentBranchIndex);
+		expect(branch).toContain(
+			"moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,",
+		);
+		expect(branch).toContain(
+			"mora: moraActual.length > 0 ? moraActual[0] : null,",
+		);
+	});
+
 	it("maps the advisor in the no-current-installment return", async () => {
 		const source = await Bun.file(
 			resolve(import.meta.dir, "credits.ts"),

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { canViewCreditDetailByStatus } from "./creditDetailPolicy";
+
+describe("credit detail visibility", () => {
+	it("permite consultar créditos cancelados desde el historial de cobros", () => {
+		expect(canViewCreditDetailByStatus("CANCELADO")).toBeTrue();
+	});
+
+	it("conserva visibles los estados operativos soportados por el detalle", () => {
+		for (const status of [
+			"ACTIVO",
+			"PENDIENTE_CANCELACION",
+			"MOROSO",
+			"EN_CONVENIO",
+			"INCOBRABLE",
+		]) {
+			expect(canViewCreditDetailByStatus(status)).toBeTrue();
+		}
+	});
+
+	it("no habilita estados fuera del flujo de detalle", () => {
+		expect(canViewCreditDetailByStatus("CAIDO")).toBeFalse();
+		expect(canViewCreditDetailByStatus(null)).toBeFalse();
+		expect(canViewCreditDetailByStatus(undefined)).toBeFalse();
+	});
+});

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { canViewCreditDetailByStatus } from "./creditDetailPolicy";
+import {
+	canViewCreditDetailByStatus,
+	withActiveCancellation,
+} from "./creditDetailPolicy";
 
 describe("credit detail visibility", () => {
 	it("permite consultar créditos cancelados desde el historial de cobros", () => {
@@ -22,5 +25,27 @@ describe("credit detail visibility", () => {
 		expect(canViewCreditDetailByStatus("CAIDO")).toBeFalse();
 		expect(canViewCreditDetailByStatus(null)).toBeFalse();
 		expect(canViewCreditDetailByStatus(undefined)).toBeFalse();
+	});
+});
+
+describe("cancelled credit detail", () => {
+	it("combina la cancelación activa con el detalle normal", () => {
+		const cuotasPagadas = [{ numero_cuota: 1 }];
+		const cuotasPendientes = [{ numero_cuota: 2 }];
+		const cuotasAtrasadas = [{ numero_cuota: 3 }];
+		const detail = {
+			flujo: "ACTIVO",
+			cuotasPagadas,
+			cuotasPendientes,
+			cuotasAtrasadas,
+			moraActual: "125.00",
+		};
+		const cancelacion = { id: 7, activo: true };
+
+		expect(withActiveCancellation(detail, cancelacion)).toEqual({
+			...detail,
+			flujo: "CANCELADO",
+			cancelacion,
+		});
 	});
 });

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
 import {
 	canViewCreditDetailByStatus,
 	withActiveCancellation,
@@ -47,5 +48,18 @@ describe("cancelled credit detail", () => {
 			flujo: "CANCELADO",
 			cancelacion,
 		});
+	});
+});
+
+describe("credit detail no-current-installment branch", () => {
+	it("maps the advisor in the no-current-installment return", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "credits.ts"),
+		).text();
+		const branch = source.match(
+			/if \(!cuotaActualDataResult[\s\S]*?(?=\n\s*const cuotaActualData)/,
+		)?.[0];
+
+		expect(branch).toContain("asesor: currentCredit.asesores,");
 	});
 });

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts
@@ -49,6 +49,15 @@ describe("cancelled credit detail", () => {
 			cancelacion,
 		});
 	});
+
+	it("marca como cancelado el detalle sin cancelación activa", () => {
+		const detail = { flujo: "ACTIVO", cuotasPagadas: [] };
+
+		expect(withActiveCancellation(detail, undefined, "CANCELADO")).toEqual({
+			...detail,
+			flujo: "CANCELADO",
+		});
+	});
 });
 
 describe("credit detail no-current-installment branch", () => {

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -7,6 +7,38 @@ export const CREDIT_DETAIL_STATUSES = [
 	"CANCELADO",
 ] as const;
 
+export const ORIGINAL_PRINCIPAL_PAYMENT_STATUSES = [
+	"no_required",
+	"validated",
+	"capital_validated",
+	"reset",
+] as const;
+
+export function isOriginalPrincipalPayment(payment: {
+	validationStatus: string | null;
+	pagado: boolean | null;
+	paymentFalse: boolean | null;
+}): boolean {
+	return (
+		payment.pagado === true &&
+		payment.paymentFalse !== true &&
+		(ORIGINAL_PRINCIPAL_PAYMENT_STATUSES as readonly string[]).includes(
+			payment.validationStatus ?? "",
+		)
+	);
+}
+
+export function isCreditClosingPayment(payment: {
+	validationStatus: string | null;
+	registerBy: string | null;
+}): boolean {
+	return (
+		payment.registerBy === "system_reset" &&
+		(payment.validationStatus === "reset" ||
+			payment.validationStatus === "validated")
+	);
+}
+
 export function canViewCreditDetailByStatus(
 	status: string | null | undefined,
 ): boolean {

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -24,9 +24,23 @@ export function isOriginalPrincipalPayment(payment: {
 	}
 
 	return (
-		payment.validationStatus === "validated" ||
-		payment.validationStatus === "capital_validated" ||
-		payment.validationStatus === "reset"
+		(payment.validationStatus === "validated" ||
+			payment.validationStatus === "capital_validated" ||
+			payment.validationStatus === "reset") &&
+		payment.paymentFalse !== true
+	);
+}
+
+export function isAmbiguousOriginalPrincipalPayment(payment: {
+	validationStatus: string | null;
+	pagado: boolean | null;
+	paymentFalse: boolean | null;
+}): boolean {
+	return (
+		(payment.validationStatus === "validated" ||
+			payment.validationStatus === "capital_validated") &&
+		payment.pagado === false &&
+		payment.paymentFalse === true
 	);
 }
 
@@ -35,9 +49,9 @@ export function isCreditClosingPayment(payment: {
 	registerBy: string | null;
 }): boolean {
 	return (
-		payment.registerBy === "system_reset" &&
-		(payment.validationStatus === "reset" ||
-			payment.validationStatus === "validated")
+		payment.validationStatus === "reset" ||
+		(payment.validationStatus === "validated" &&
+			payment.registerBy === "system_reset")
 	);
 }
 

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -19,12 +19,14 @@ export function isOriginalPrincipalPayment(payment: {
 	pagado: boolean | null;
 	paymentFalse: boolean | null;
 }): boolean {
+	if (payment.validationStatus === "no_required") {
+		return payment.pagado === true && payment.paymentFalse !== true;
+	}
+
 	return (
-		payment.pagado === true &&
-		payment.paymentFalse !== true &&
-		(ORIGINAL_PRINCIPAL_PAYMENT_STATUSES as readonly string[]).includes(
-			payment.validationStatus ?? "",
-		)
+		payment.validationStatus === "validated" ||
+		payment.validationStatus === "capital_validated" ||
+		payment.validationStatus === "reset"
 	);
 }
 

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -14,6 +14,60 @@ export const ORIGINAL_PRINCIPAL_PAYMENT_STATUSES = [
 	"reset",
 ] as const;
 
+export type StrictResetCreditInput = {
+	creditId: number;
+	montoIncobrable?: number;
+	montoBoleta: number | string;
+	url_boletas: string[];
+	cuota: number;
+	banco_id: number;
+	numeroAutorizacion?: string;
+};
+
+export function isValidResetCreditInput(
+	input: Record<string, unknown>,
+): input is StrictResetCreditInput {
+	const {
+		creditId,
+		montoIncobrable,
+		montoBoleta,
+		url_boletas,
+		cuota,
+		banco_id,
+		numeroAutorizacion,
+	} = input;
+	const montoBoletaValido =
+		(typeof montoBoleta === "number" &&
+			Number.isFinite(montoBoleta) &&
+			montoBoleta >= 0) ||
+		(typeof montoBoleta === "string" &&
+			/^\d+(?:\.\d+)?$/.test(montoBoleta.trim()) &&
+			Number.isFinite(Number(montoBoleta.trim())));
+
+	return (
+		typeof creditId === "number" &&
+		Number.isFinite(creditId) &&
+		Number.isInteger(creditId) &&
+		creditId > 0 &&
+		montoBoletaValido &&
+		Array.isArray(url_boletas) &&
+		url_boletas.every((url) => typeof url === "string") &&
+		typeof cuota === "number" &&
+		Number.isFinite(cuota) &&
+		Number.isInteger(cuota) &&
+		cuota >= 0 &&
+		typeof banco_id === "number" &&
+		Number.isFinite(banco_id) &&
+		Number.isInteger(banco_id) &&
+		banco_id > 0 &&
+		(montoIncobrable === undefined ||
+			(typeof montoIncobrable === "number" &&
+				Number.isFinite(montoIncobrable) &&
+				montoIncobrable >= 0)) &&
+		(numeroAutorizacion === undefined || typeof numeroAutorizacion === "string")
+	);
+}
+
 export function isOriginalPrincipalPayment(payment: {
 	validationStatus: string | null;
 	pagado: boolean | null;
@@ -66,8 +120,12 @@ export function canViewCreditDetailByStatus(
 
 export function canResetCreditByStatus(
 	status: string | null | undefined,
+	incobrableContinuationReady = false,
 ): boolean {
-	return status === "PENDIENTE_CANCELACION";
+	return (
+		status === "PENDIENTE_CANCELACION" ||
+		(status === "INCOBRABLE" && incobrableContinuationReady)
+	);
 }
 
 export function withActiveCancellation<T extends object, C>(

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -19,8 +19,13 @@ export function canViewCreditDetailByStatus(
 export function withActiveCancellation<T extends object, C>(
 	detail: T,
 	cancelacion: C | undefined,
+	statusCredit: string | null | undefined,
 ) {
-	return cancelacion
-		? { ...detail, cancelacion, flujo: "CANCELADO" as const }
-		: detail;
+	if (!cancelacion && statusCredit !== "CANCELADO") return detail;
+
+	return {
+		...detail,
+		...(cancelacion ? { cancelacion } : {}),
+		flujo: "CANCELADO" as const,
+	};
 }

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -16,6 +16,12 @@ export function canViewCreditDetailByStatus(
 	);
 }
 
+export function canResetCreditByStatus(
+	status: string | null | undefined,
+): boolean {
+	return status === "PENDIENTE_CANCELACION";
+}
+
 export function withActiveCancellation<T extends object, C>(
 	detail: T,
 	cancelacion: C | undefined,

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -22,6 +22,10 @@ export function canResetCreditByStatus(
 	return status === "PENDIENTE_CANCELACION";
 }
 
+export const isScheduledCreditInstallment = (
+	validationStatus: string | null | undefined,
+): boolean => validationStatus !== "reset";
+
 export function withActiveCancellation<T extends object, C>(
 	detail: T,
 	cancelacion: C | undefined,

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -1,0 +1,17 @@
+export const CREDIT_DETAIL_STATUSES = [
+	"ACTIVO",
+	"PENDIENTE_CANCELACION",
+	"MOROSO",
+	"EN_CONVENIO",
+	"INCOBRABLE",
+	"CANCELADO",
+] as const;
+
+export function canViewCreditDetailByStatus(
+	status: string | null | undefined,
+): boolean {
+	return (
+		typeof status === "string" &&
+		(CREDIT_DETAIL_STATUSES as readonly string[]).includes(status)
+	);
+}

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -22,10 +22,6 @@ export function canResetCreditByStatus(
 	return status === "PENDIENTE_CANCELACION";
 }
 
-export const isScheduledCreditInstallment = (
-	validationStatus: string | null | undefined,
-): boolean => validationStatus !== "reset";
-
 export function withActiveCancellation<T extends object, C>(
 	detail: T,
 	cancelacion: C | undefined,

--- a/apps/cartera-back/src/controllers/creditDetailPolicy.ts
+++ b/apps/cartera-back/src/controllers/creditDetailPolicy.ts
@@ -15,3 +15,12 @@ export function canViewCreditDetailByStatus(
 		(CREDIT_DETAIL_STATUSES as readonly string[]).includes(status)
 	);
 }
+
+export function withActiveCancellation<T extends object, C>(
+	detail: T,
+	cancelacion: C | undefined,
+) {
+	return cancelacion
+		? { ...detail, cancelacion, flujo: "CANCELADO" as const }
+		: detail;
+}

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -309,6 +309,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         flujo: "ACTIVO",
         credito: currentCredit.creditos,
         usuario: currentCredit.usuarios,
+        asesor: currentCredit.asesores,
         cuotaActual: null,
         cuotaActualPagada: false,
         cuotaActualStatus: null,

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -321,7 +321,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         convenioActivo: null,
         cuotasEnConvenio: [],
         pagosConvenio: [],
-      }, cancelacionActiva);
+      }, cancelacionActiva, currentCredit.creditos.statusCredit);
     }
 
     const cuotaActualData = cuotaActualDataResult[0];
@@ -463,7 +463,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           : null,
       cuotasEnConvenio,
       pagosConvenio,
-    }, cancelacionActiva);
+    }, cancelacionActiva, currentCredit.creditos.statusCredit);
   } catch (error) {
     console.error("[getCreditoByNumero] Error:", error);
     return { message: "Error consultando crédito", error: String(error) };

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -42,6 +42,7 @@ import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   CREDIT_DETAIL_STATUSES,
   canResetCreditByStatus,
+  isScheduledCreditInstallment,
   withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
@@ -89,7 +90,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         : undefined;
 
     // 2. Consultar todas las cuotas pagadas (pagado = true)
-    const cuotasPagadas = await db
+    const cuotasPagadasConCierre = await db
       .select({
         // Campos de cuotas_credito
         cuota_id: cuotas_credito.cuota_id,
@@ -138,6 +139,8 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         )
       )
       .orderBy(cuotas_credito.numero_cuota);
+
+    const cuotasPagadas = cuotasPagadasConCierre.filter((row) => isScheduledCreditInstallment(row.validationStatus));
 
     // 4. Calcular la cuota que toca este mes (según meses transcurridos desde fecha_creacion)
     const fechaInicio = new Date(currentCredit.creditos.fecha_creacion);

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -1860,8 +1860,49 @@ export async function resetCredit({
     if (!credito) {
       throw new Error("Crédito no encontrado.");
     }
-    if (!canResetCreditByStatus(credito.statusCredit)) {
-      throw new Error("El crédito no está pendiente de cancelación.");
+
+    let incobrableContinuationReady = false;
+    if (credito.statusCredit === "INCOBRABLE") {
+      const [badDebt] = await db
+        .select({ monto_incobrable: bad_debts.monto_incobrable })
+        .from(bad_debts)
+        .where(eq(bad_debts.credit_id, creditId))
+        .limit(1);
+      const [existingClosingPayment] = await db
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .where(
+          and(
+            eq(pagos_credito.credito_id, creditId),
+            eq(pagos_credito.registerBy, "system_reset")
+          )
+        )
+        .limit(1);
+
+      try {
+        if (
+          montoIncobrable !== undefined &&
+          Number.isFinite(montoIncobrable) &&
+          badDebt &&
+          !existingClosingPayment
+        ) {
+          const montoIncobrableBig = new Big(montoIncobrable);
+          const creditoCapitalBig = new Big(credito.capital ?? 0);
+          const badDebtCapitalBig = new Big(badDebt.monto_incobrable ?? 0);
+          incobrableContinuationReady =
+            montoIncobrableBig.gt(0) &&
+            montoIncobrableBig.eq(creditoCapitalBig) &&
+            montoIncobrableBig.eq(badDebtCapitalBig);
+        }
+      } catch {
+        incobrableContinuationReady = false;
+      }
+    }
+
+    if (!canResetCreditByStatus(credito.statusCredit, incobrableContinuationReady)) {
+      throw new Error(
+        "El crédito no está pendiente de cancelación ni listo para continuar como incobrable."
+      );
     }
 
     // 3. Determinar el estado del crédito
@@ -1940,9 +1981,32 @@ export async function resetCredit({
     const cuotaId = cuotaEncontrada?.cuota_id;
 
     // 10. Insertar pago de cierre con abonos reales
-    const [nuevoPago] = await db
-      .insert(pagos_credito)
-      .values({
+    const nuevoPago = await db.transaction(async (tx) => {
+      const [lockedCredit] = await tx
+        .select()
+        .from(creditos)
+        .where(eq(creditos.credito_id, creditId))
+        .limit(1)
+        .for("update");
+      if (!lockedCredit) {
+        throw new Error("Crédito no encontrado.");
+      }
+
+      const [existingClosingPayment] = await tx
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .where(
+          and(
+            eq(pagos_credito.credito_id, creditId),
+            eq(pagos_credito.registerBy, "system_reset")
+          )
+        )
+        .limit(1);
+      if (existingClosingPayment) {
+        throw new Error("El crédito ya tiene un pago de cierre system_reset.");
+      }
+
+      const [insertedPayment] = await tx.insert(pagos_credito).values({
         credito_id: credito.credito_id,
         cuota_id: cuotaId,
         cuota: credito.cuota?.toString() ?? "0",
@@ -1984,8 +2048,9 @@ export async function resetCredit({
         registerBy: "system_reset",
         pagoConvenio: "0",
         monto_aplicado: totalMontoPago.toString(),
-      })
-      .returning();
+      }).returning();
+      return insertedPayment;
+    });
 
     // 11. Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
     //     paymentFalse=true). Además se ponen los *_restante en 0: algunas queries de

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -1,856 +1,805 @@
 import { db } from "../database/index";
+import { withCapitalContext, setCapitalSource } from "../utils/withAuditContext";
 import {
-	withCapitalContext,
-	setCapitalSource,
-} from "../utils/withAuditContext";
-import {
-	aseguradoras,
-	asesores,
-	bad_debts,
-	boletas,
-	convenio_cuotas,
-	convenios_pago,
-	convenios_pagos_resume,
-	credit_cancelations,
-	creditos,
-	creditos_inversionistas,
-	creditos_inversionistas_espejo,
-	creditos_rubros_otros,
-	cuotas_credito,
-	inversionistas,
-	montos_adicionales,
-	moras_credito,
-	pagos_credito,
-	platform_users,
-	StatusCredit,
-	usuarios,
+  aseguradoras,
+  asesores,
+  bad_debts,
+  boletas,
+  convenio_cuotas,
+  convenios_pago,
+  convenios_pagos_resume,
+  credit_cancelations,
+  creditos,
+  creditos_inversionistas,
+  creditos_inversionistas_espejo,
+  creditos_rubros_otros,
+  cuotas_credito,
+  inversionistas,
+  montos_adicionales,
+  moras_credito,
+  pagos_credito,
+  platform_users,
+  StatusCredit,
+  usuarios,
 } from "../database/db/schema";
 import { z } from "zod";
 import Big from "big.js";
 import {
-	and,
-	desc,
-	eq,
-	sql,
-	inArray,
-	asc,
-	lte,
-	lt,
-	gte,
-	gt,
-	isNull,
+  and,
+  desc,
+  eq,
+  sql,
+  inArray,
+  asc,
+  lte,
+  lt,
+  gte,
+  gt,
+  isNull,
 } from "drizzle-orm";
-import {
-	getPagosDelMesActual,
-	insertPagosCreditoInversionistasV2,
-} from "./payments";
+import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
-	CREDIT_DETAIL_STATUSES,
-	canResetCreditByStatus,
-	withActiveCancellation,
+  CREDIT_DETAIL_STATUSES,
+  canResetCreditByStatus,
+  withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
+
 export const getCreditoByNumero = async (numero_credito_sifco: string) => {
-	try {
-		// 1. Buscar el crédito con su usuario
-		const creditoData = await db
-			.select()
-			.from(creditos)
-			.where(
-				and(
-					eq(creditos.numero_credito_sifco, numero_credito_sifco),
-					inArray(creditos.statusCredit, [...CREDIT_DETAIL_STATUSES]),
-				),
-			)
-			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-			.limit(1);
+  try {
+    // 1. Buscar el crédito con su usuario
+    const creditoData = await db
+      .select()
+      .from(creditos)
+      .where(
+        and(
+          eq(creditos.numero_credito_sifco, numero_credito_sifco),
+          inArray(creditos.statusCredit, [...CREDIT_DETAIL_STATUSES])
+        )
+      )
+      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+      .limit(1);
 
-		if (creditoData.length === 0) {
-			return { message: "Crédito no encontrado" };
-		}
+    if (creditoData.length === 0) {
+      return { message: "Crédito no encontrado" };
+    }
 
-		const currentCredit = creditoData[0];
-		const creditoId = currentCredit.creditos.credito_id;
+    const currentCredit = creditoData[0];
+    const creditoId = currentCredit.creditos.credito_id;
 
-		// 2. Si el crédito está cancelado o pendiente de cancelación, verificar si hay cancelación activa
-		const cancelacionActiva =
-			currentCredit.creditos.statusCredit === "CANCELADO" ||
-			currentCredit.creditos.statusCredit === "PENDIENTE_CANCELACION"
-				? (
-						await db
-							.select()
-							.from(credit_cancelations)
-							.where(
-								and(
-									eq(credit_cancelations.credit_id, creditoId),
-									eq(credit_cancelations.activo, true),
-								),
-							)
-							.limit(1)
-					)[0]
-				: undefined;
+    // 2. Si el crédito está cancelado o pendiente de cancelación, verificar si hay cancelación activa
+    const cancelacionActiva =
+      currentCredit.creditos.statusCredit === "CANCELADO" ||
+      currentCredit.creditos.statusCredit === "PENDIENTE_CANCELACION"
+        ? (
+            await db
+              .select()
+              .from(credit_cancelations)
+              .where(
+                and(
+                  eq(credit_cancelations.credit_id, creditoId),
+                  eq(credit_cancelations.activo, true)
+                )
+              )
+              .limit(1)
+          )[0]
+        : undefined;
 
-		// 2. Consultar todas las cuotas pagadas (pagado = true)
-		const cuotasPagadas = await db
-			.select({
-				// Campos de cuotas_credito
-				cuota_id: cuotas_credito.cuota_id,
-				credito_id: cuotas_credito.credito_id,
-				numero_cuota: cuotas_credito.numero_cuota,
-				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-				pagado: cuotas_credito.pagado,
-				createdAt: cuotas_credito.createdAt,
+    // 2. Consultar todas las cuotas pagadas (pagado = true)
+    const cuotasPagadas = await db
+      .select({
+        // Campos de cuotas_credito
+        cuota_id: cuotas_credito.cuota_id,
+        credito_id: cuotas_credito.credito_id,
+        numero_cuota: cuotas_credito.numero_cuota,
+        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+        pagado: cuotas_credito.pagado,
+        createdAt: cuotas_credito.createdAt,
 
-				// 🔥 Campos de pagos_credito - ABONOS
-				pago_id: pagos_credito.pago_id,
-				cuota: pagos_credito.cuota,
-				monto_boleta: pagos_credito.monto_boleta,
-				abono_capital: pagos_credito.abono_capital,
-				abono_interes: pagos_credito.abono_interes,
-				abono_iva_12: pagos_credito.abono_iva_12,
-				abono_interes_ci: pagos_credito.abono_interes_ci,
-				abono_iva_ci: pagos_credito.abono_iva_ci,
-				abono_seguro: pagos_credito.abono_seguro,
-				abono_gps: pagos_credito.abono_gps,
-				abono_membresias: pagos_credito.membresias_mes,
+        // 🔥 Campos de pagos_credito - ABONOS
+        pago_id: pagos_credito.pago_id,
+        cuota: pagos_credito.cuota,
+        monto_boleta: pagos_credito.monto_boleta,
+        abono_capital: pagos_credito.abono_capital,
+        abono_interes: pagos_credito.abono_interes,
+        abono_iva_12: pagos_credito.abono_iva_12,
+        abono_interes_ci: pagos_credito.abono_interes_ci,
+        abono_iva_ci: pagos_credito.abono_iva_ci,
+        abono_seguro: pagos_credito.abono_seguro,
+        abono_gps: pagos_credito.abono_gps,
+        abono_membresias: pagos_credito.membresias_mes,
 
-				// 🔥 RESTANTES
-				capital_restante: pagos_credito.capital_restante,
-				interes_restante: pagos_credito.interes_restante,
-				iva_12_restante: pagos_credito.iva_12_restante,
-				seguro_restante: pagos_credito.seguro_restante,
-				gps_restante: pagos_credito.gps_restante,
-				membresias_restante: pagos_credito.membresias,
-				pago_mora: pagos_credito.mora,
-				pago_otros: pagos_credito.otros,
+        // 🔥 RESTANTES
+        capital_restante: pagos_credito.capital_restante,
+        interes_restante: pagos_credito.interes_restante,
+        iva_12_restante: pagos_credito.iva_12_restante,
+        seguro_restante: pagos_credito.seguro_restante,
+        gps_restante: pagos_credito.gps_restante,
+        membresias_restante: pagos_credito.membresias,
+        pago_mora: pagos_credito.mora,
+        pago_otros: pagos_credito.otros,
 
-				// 🔥 FLAG
-				pago_cuota_completa: pagos_credito.pagado,
+        // 🔥 FLAG
+        pago_cuota_completa: pagos_credito.pagado,
 
-				validationStatus: pagos_credito.validationStatus,
-			})
-			.from(cuotas_credito)
-			.leftJoin(
-				pagos_credito,
-				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
-			)
-			.where(
-				and(
-					eq(cuotas_credito.credito_id, creditoId),
-					eq(cuotas_credito.pagado, true),
-				),
-			)
-			.orderBy(cuotas_credito.numero_cuota);
-		// 4. Calcular la cuota que toca este mes (según meses transcurridos desde fecha_creacion)
-		const fechaInicio = new Date(currentCredit.creditos.fecha_creacion);
-		const hoy = new Date();
-		const mesesTranscurridos =
-			(hoy.getFullYear() - fechaInicio.getFullYear()) * 12 +
-			(hoy.getMonth() - fechaInicio.getMonth()) +
-			1;
+        validationStatus: pagos_credito.validationStatus,
+      })
+      .from(cuotas_credito)
+      .leftJoin(
+        pagos_credito,
+        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
+      )
+      .where(
+        and(
+          eq(cuotas_credito.credito_id, creditoId),
+          eq(cuotas_credito.pagado, true)
+        )
+      )
+      .orderBy(cuotas_credito.numero_cuota);
+    // 4. Calcular la cuota que toca este mes (según meses transcurridos desde fecha_creacion)
+    const fechaInicio = new Date(currentCredit.creditos.fecha_creacion);
+    const hoy = new Date();
+    const mesesTranscurridos =
+      (hoy.getFullYear() - fechaInicio.getFullYear()) * 12 +
+      (hoy.getMonth() - fechaInicio.getMonth()) +
+      1;
 
-		// 5. Consultar cuotas pendientes (no pagadas y ya deberían haberse pagado)
-		const cuotasAtrasadas = await db
-			.select({
-				cuota_id: cuotas_credito.cuota_id,
-				credito_id: cuotas_credito.credito_id,
-				numero_cuota: cuotas_credito.numero_cuota,
-				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-				pagado: cuotas_credito.pagado,
-				createdAt: cuotas_credito.createdAt,
-				validationStatus: pagos_credito.validationStatus,
-				pago_id: pagos_credito.pago_id,
-				cuota: pagos_credito.cuota,
+    // 5. Consultar cuotas pendientes (no pagadas y ya deberían haberse pagado)
+    const cuotasAtrasadas = await db
+      .select({
+        cuota_id: cuotas_credito.cuota_id,
+        credito_id: cuotas_credito.credito_id,
+        numero_cuota: cuotas_credito.numero_cuota,
+        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+        pagado: cuotas_credito.pagado,
+        createdAt: cuotas_credito.createdAt,
+        validationStatus: pagos_credito.validationStatus,
+        pago_id: pagos_credito.pago_id,
+        cuota: pagos_credito.cuota,
 
-				monto_boleta: pagos_credito.monto_boleta,
-				abono_capital: pagos_credito.abono_capital,
-				abono_interes: pagos_credito.abono_interes,
-				abono_iva_12: pagos_credito.abono_iva_12,
-				abono_interes_ci: pagos_credito.abono_interes_ci,
-				abono_iva_ci: pagos_credito.abono_iva_ci,
-				abono_seguro: pagos_credito.abono_seguro,
-				abono_gps: pagos_credito.abono_gps,
-				abono_membresias: pagos_credito.membresias_mes,
+        monto_boleta: pagos_credito.monto_boleta,
+        abono_capital: pagos_credito.abono_capital,
+        abono_interes: pagos_credito.abono_interes,
+        abono_iva_12: pagos_credito.abono_iva_12,
+        abono_interes_ci: pagos_credito.abono_interes_ci,
+        abono_iva_ci: pagos_credito.abono_iva_ci,
+        abono_seguro: pagos_credito.abono_seguro,
+        abono_gps: pagos_credito.abono_gps,
+        abono_membresias: pagos_credito.membresias_mes,
 
-				// 🔥 RESTANTES
-				capital_restante: pagos_credito.capital_restante,
-				interes_restante: pagos_credito.interes_restante,
-				iva_12_restante: pagos_credito.iva_12_restante,
-				seguro_restante: pagos_credito.seguro_restante,
-				gps_restante: pagos_credito.gps_restante,
-				membresias_restante: pagos_credito.membresias,
-				pago_mora: pagos_credito.mora,
-				pago_otros: pagos_credito.otros,
-			})
-			.from(cuotas_credito)
-			.leftJoin(
-				pagos_credito,
-				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
-			)
-			.where(
-				and(
-					eq(cuotas_credito.credito_id, creditoId),
-					eq(cuotas_credito.pagado, false),
-					lt(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
-					sql`NOT EXISTS (
+        // 🔥 RESTANTES
+        capital_restante: pagos_credito.capital_restante,
+        interes_restante: pagos_credito.interes_restante,
+        iva_12_restante: pagos_credito.iva_12_restante,
+        seguro_restante: pagos_credito.seguro_restante,
+        gps_restante: pagos_credito.gps_restante,
+        membresias_restante: pagos_credito.membresias,
+        pago_mora: pagos_credito.mora,
+        pago_otros: pagos_credito.otros,
+      })
+      .from(cuotas_credito)
+      .leftJoin(
+        pagos_credito,
+        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
+      )
+      .where(
+        and(
+          eq(cuotas_credito.credito_id, creditoId),
+          eq(cuotas_credito.pagado, false),
+          lt(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
+          sql`NOT EXISTS (
             SELECT 1
             FROM cartera.pagos_credito p_pending
             WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
               AND p_pending.validation_status = 'pending'
               AND p_pending.pagado = true
-          )`,
-				),
-			)
-			.orderBy(asc(cuotas_credito.numero_cuota));
+          )`
+        )
+      )
+      .orderBy(asc(cuotas_credito.numero_cuota));
 
-		const cuotasPendientes = await db
-			.select({
-				cuota_id: cuotas_credito.cuota_id,
-				credito_id: cuotas_credito.credito_id,
-				numero_cuota: cuotas_credito.numero_cuota,
-				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-				pagado: cuotas_credito.pagado,
-				createdAt: cuotas_credito.createdAt,
-				// 🔥 Campos de pagos_credito - ABONOS
-				pago_id: pagos_credito.pago_id,
-				cuota: pagos_credito.cuota,
-				monto_boleta: pagos_credito.monto_boleta,
-				abono_capital: pagos_credito.abono_capital,
-				abono_interes: pagos_credito.abono_interes,
-				abono_iva_12: pagos_credito.abono_iva_12,
-				abono_interes_ci: pagos_credito.abono_interes_ci,
-				abono_iva_ci: pagos_credito.abono_iva_ci,
-				abono_seguro: pagos_credito.abono_seguro,
-				abono_gps: pagos_credito.abono_gps,
-				abono_membresias: pagos_credito.membresias_mes,
+    const cuotasPendientes = await db
+      .select({
+        cuota_id: cuotas_credito.cuota_id,
+        credito_id: cuotas_credito.credito_id,
+        numero_cuota: cuotas_credito.numero_cuota,
+        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+        pagado: cuotas_credito.pagado,
+        createdAt: cuotas_credito.createdAt,
+        // 🔥 Campos de pagos_credito - ABONOS
+        pago_id: pagos_credito.pago_id,
+        cuota: pagos_credito.cuota,
+        monto_boleta: pagos_credito.monto_boleta,
+        abono_capital: pagos_credito.abono_capital,
+        abono_interes: pagos_credito.abono_interes,
+        abono_iva_12: pagos_credito.abono_iva_12,
+        abono_interes_ci: pagos_credito.abono_interes_ci,
+        abono_iva_ci: pagos_credito.abono_iva_ci,
+        abono_seguro: pagos_credito.abono_seguro,
+        abono_gps: pagos_credito.abono_gps,
+        abono_membresias: pagos_credito.membresias_mes,
 
-				// 🔥 RESTANTES
-				capital_restante: pagos_credito.capital_restante,
-				interes_restante: pagos_credito.interes_restante,
-				iva_12_restante: pagos_credito.iva_12_restante,
-				seguro_restante: pagos_credito.seguro_restante,
-				gps_restante: pagos_credito.gps_restante,
-				membresias_restante: pagos_credito.membresias,
-				pago_mora: pagos_credito.mora,
-				pago_otros: pagos_credito.otros,
-			})
-			.from(cuotas_credito)
-			.innerJoin(
-				pagos_credito,
-				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
-			)
-			.leftJoin(
-				convenios_pagos_resume,
-				eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id),
-			)
-			.where(
-				and(
-					eq(cuotas_credito.credito_id, creditoId),
-					eq(cuotas_credito.pagado, false),
-					sql`NOT EXISTS (
+        // 🔥 RESTANTES
+        capital_restante: pagos_credito.capital_restante,
+        interes_restante: pagos_credito.interes_restante,
+        iva_12_restante: pagos_credito.iva_12_restante,
+        seguro_restante: pagos_credito.seguro_restante,
+        gps_restante: pagos_credito.gps_restante,
+        membresias_restante: pagos_credito.membresias,
+        pago_mora: pagos_credito.mora,
+        pago_otros: pagos_credito.otros,
+      })
+      .from(cuotas_credito)
+      .innerJoin(
+        pagos_credito,
+        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
+      )
+      .leftJoin(
+        convenios_pagos_resume,
+        eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id)
+      )
+      .where(
+        and(
+          eq(cuotas_credito.credito_id, creditoId),
+          eq(cuotas_credito.pagado, false),
+          sql`NOT EXISTS (
             SELECT 1
             FROM cartera.pagos_credito p_pending
             WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
               AND p_pending.validation_status = 'pending'
-          )`,
-				),
-			)
-			.orderBy(cuotas_credito.numero_cuota);
+          )`
+        )
+      )
+      .orderBy(cuotas_credito.numero_cuota);
 
-		const moraActual = await db
-			.select()
-			.from(moras_credito)
-			.where(
-				and(
-					eq(moras_credito.credito_id, creditoId),
-					eq(moras_credito.activa, true),
-				),
-			);
+    const moraActual = await db
+      .select()
+      .from(moras_credito)
+      .where(
+        and(
+          eq(moras_credito.credito_id, creditoId),
+          eq(moras_credito.activa, true)
+        )
+      );
 
-		// 6. Consultar si la cuota actual ya fue pagada
-		const cuotaActualDataResult = await db
-			.select({
-				cuota_id: cuotas_credito.cuota_id,
-				credito_id: cuotas_credito.credito_id,
-				numero_cuota: cuotas_credito.numero_cuota,
-				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-				pagado: cuotas_credito.pagado,
-				createdAt: cuotas_credito.createdAt,
-				validationStatus: pagos_credito.validationStatus,
-				// 🔥 Campos de pagos_credito - ABONOS
-				pago_id: pagos_credito.pago_id,
-				cuota: pagos_credito.cuota,
-				monto_boleta: pagos_credito.monto_boleta,
-				abono_capital: pagos_credito.abono_capital,
-				abono_interes: pagos_credito.abono_interes,
-				abono_iva_12: pagos_credito.abono_iva_12,
-				abono_interes_ci: pagos_credito.abono_interes_ci,
-				abono_iva_ci: pagos_credito.abono_iva_ci,
-				abono_seguro: pagos_credito.abono_seguro,
-				abono_gps: pagos_credito.abono_gps,
-				abono_membresias: pagos_credito.membresias_mes,
+    // 6. Consultar si la cuota actual ya fue pagada
+    const cuotaActualDataResult = await db
+      .select({
+        cuota_id: cuotas_credito.cuota_id,
+        credito_id: cuotas_credito.credito_id,
+        numero_cuota: cuotas_credito.numero_cuota,
+        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+        pagado: cuotas_credito.pagado,
+        createdAt: cuotas_credito.createdAt,
+        validationStatus: pagos_credito.validationStatus,
+        // 🔥 Campos de pagos_credito - ABONOS
+        pago_id: pagos_credito.pago_id,
+        cuota: pagos_credito.cuota,
+        monto_boleta: pagos_credito.monto_boleta,
+        abono_capital: pagos_credito.abono_capital,
+        abono_interes: pagos_credito.abono_interes,
+        abono_iva_12: pagos_credito.abono_iva_12,
+        abono_interes_ci: pagos_credito.abono_interes_ci,
+        abono_iva_ci: pagos_credito.abono_iva_ci,
+        abono_seguro: pagos_credito.abono_seguro,
+        abono_gps: pagos_credito.abono_gps,
+        abono_membresias: pagos_credito.membresias_mes,
 
-				// 🔥 RESTANTES
-				capital_restante: pagos_credito.capital_restante,
-				interes_restante: pagos_credito.interes_restante,
-				iva_12_restante: pagos_credito.iva_12_restante,
-				seguro_restante: pagos_credito.seguro_restante,
-				gps_restante: pagos_credito.gps_restante,
-				membresias_restante: pagos_credito.membresias,
-				pago_mora: pagos_credito.mora,
-				pago_otros: pagos_credito.otros,
-			})
-			.from(cuotas_credito)
-			.innerJoin(
-				pagos_credito,
-				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
-			)
-			.leftJoin(
-				convenios_pagos_resume,
-				eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id),
-			)
-			.where(
-				and(
-					eq(cuotas_credito.credito_id, creditoId),
-					gt(cuotas_credito.numero_cuota, 0),
-					gte(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
-				),
-			)
-			.orderBy(cuotas_credito.fecha_vencimiento)
-			.limit(1);
+        // 🔥 RESTANTES
+        capital_restante: pagos_credito.capital_restante,
+        interes_restante: pagos_credito.interes_restante,
+        iva_12_restante: pagos_credito.iva_12_restante,
+        seguro_restante: pagos_credito.seguro_restante,
+        gps_restante: pagos_credito.gps_restante,
+        membresias_restante: pagos_credito.membresias,
+        pago_mora: pagos_credito.mora,
+        pago_otros: pagos_credito.otros,
+      })
+      .from(cuotas_credito)
+      .innerJoin(
+        pagos_credito,
+        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
+      )
+      .leftJoin(
+        convenios_pagos_resume,
+        eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id)
+      )
+      .where(
+        and(
+          eq(cuotas_credito.credito_id, creditoId),
+          gt(cuotas_credito.numero_cuota, 0),
+          gte(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10))
+        )
+      )
+      .orderBy(cuotas_credito.fecha_vencimiento)
+      .limit(1);
 
-		// 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos sin cuota activa
-		if (!cuotaActualDataResult || cuotaActualDataResult.length === 0) {
-			return withActiveCancellation(
-				{
-					flujo: "ACTIVO",
-					credito: currentCredit.creditos,
-					usuario: currentCredit.usuarios,
-					asesor: currentCredit.asesores,
-					cuotaActual: null,
-					cuotaActualPagada: false,
-					cuotaActualStatus: null,
-					cuotasPendientes,
-					cuotasAtrasadas,
-					cuotasPagadas,
-					moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
-					mora: moraActual.length > 0 ? moraActual[0] : null,
-					convenioActivo: null,
-					cuotasEnConvenio: [],
-					pagosConvenio: [],
-				},
-				cancelacionActiva,
-				currentCredit.creditos.statusCredit,
-			);
-		}
+    // 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos sin cuota activa
+    if (!cuotaActualDataResult || cuotaActualDataResult.length === 0) {
+      return withActiveCancellation({
+        flujo: "ACTIVO",
+        credito: currentCredit.creditos,
+        usuario: currentCredit.usuarios,
+        asesor: currentCredit.asesores,
+        cuotaActual: null,
+        cuotaActualPagada: false,
+        cuotaActualStatus: null,
+        cuotasPendientes,
+        cuotasAtrasadas,
+        cuotasPagadas,
+        moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
+        mora: moraActual.length > 0 ? moraActual[0] : null,
+        convenioActivo: null,
+        cuotasEnConvenio: [],
+        pagosConvenio: [],
+      }, cancelacionActiva, currentCredit.creditos.statusCredit);
+    }
 
-		const cuotaActualData = cuotaActualDataResult[0];
+    const cuotaActualData = cuotaActualDataResult[0];
 
-		// ¿Está pagada la cuota actual?
-		const cuotaActualPagada = !!(cuotaActualData && cuotaActualData.pagado);
-		console.log("cuotaActualData", cuotaActualData);
+    // ¿Está pagada la cuota actual?
+    const cuotaActualPagada = !!(cuotaActualData && cuotaActualData.pagado);
+    console.log("cuotaActualData", cuotaActualData);
 
-		// La cuota actual del mes con toda su info
-		const cuotaActual = cuotaActualData;
-		const cuotaActualStatus = cuotaActualData.validationStatus;
+    // La cuota actual del mes con toda su info
+    const cuotaActual = cuotaActualData;
+    const cuotaActualStatus = cuotaActualData.validationStatus;
 
-		const convenioActivo = await db
-			.select()
-			.from(convenios_pago)
-			.where(
-				and(
-					eq(convenios_pago.credito_id, creditoId),
-					eq(convenios_pago.activo, true),
-					eq(convenios_pago.completado, false),
-				),
-			)
-			.limit(1);
+    const convenioActivo = await db
+      .select()
+      .from(convenios_pago)
+      .where(
+        and(
+          eq(convenios_pago.credito_id, creditoId),
+          eq(convenios_pago.activo, true),
+          eq(convenios_pago.completado, false)
+        )
+      )
+      .limit(1);
 
-		let cuotasEnConvenio: any[] = [];
-		let pagosConvenio: any[] = [];
-		let cuotasConvenioMensuales: any[] = [];
-		let cuotaConvenioAPagar = "0";
+    let cuotasEnConvenio: any[] = [];
+    let pagosConvenio: any[] = [];
+    let cuotasConvenioMensuales: any[] = [];
+    let cuotaConvenioAPagar = "0";
 
-		if (convenioActivo.length > 0) {
-			// Traer los pagos del convenio
-			pagosConvenio = await db
-				.select()
-				.from(convenios_pagos_resume)
-				.where(
-					eq(convenios_pagos_resume.convenio_id, convenioActivo[0].convenio_id),
-				);
+    if (convenioActivo.length > 0) {
+      // Traer los pagos del convenio
+      pagosConvenio = await db
+        .select()
+        .from(convenios_pagos_resume)
+        .where(
+          eq(convenios_pagos_resume.convenio_id, convenioActivo[0].convenio_id)
+        );
 
-			// 🔥 Traer las cuotas mensuales del convenio
-			cuotasConvenioMensuales = await db
-				.select()
-				.from(convenio_cuotas)
-				.where(eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id))
-				.orderBy(convenio_cuotas.numero_cuota);
+      // 🔥 Traer las cuotas mensuales del convenio
+      cuotasConvenioMensuales = await db
+        .select()
+        .from(convenio_cuotas)
+        .where(eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id))
+        .orderBy(convenio_cuotas.numero_cuota);
 
-			// Traer las cuotas que están en el convenio
-			const paymentIds = pagosConvenio.map((p) => p.pago_id);
+      // Traer las cuotas que están en el convenio
+      const paymentIds = pagosConvenio.map((p) => p.pago_id);
 
-			if (paymentIds.length > 0) {
-				// Primero traer los pagos para obtener los cuota_id
-				const pagos = await db
-					.select()
-					.from(pagos_credito)
-					.where(inArray(pagos_credito.pago_id, paymentIds));
+      if (paymentIds.length > 0) {
+        // Primero traer los pagos para obtener los cuota_id
+        const pagos = await db
+          .select()
+          .from(pagos_credito)
+          .where(inArray(pagos_credito.pago_id, paymentIds));
 
-				const cuotaIds = pagos
-					.map((p) => p.cuota_id)
-					.filter((id): id is number => id !== null);
+        const cuotaIds = pagos.map((p) => p.cuota_id).filter((id): id is number => id !== null);
 
-				// Luego traer las cuotas
-				cuotasEnConvenio = await db
-					.select()
-					.from(cuotas_credito)
-					.where(inArray(cuotas_credito.cuota_id, cuotaIds))
-					.orderBy(asc(cuotas_credito.numero_cuota));
-			}
+        // Luego traer las cuotas
+        cuotasEnConvenio = await db
+          .select()
+          .from(cuotas_credito)
+          .where(inArray(cuotas_credito.cuota_id, cuotaIds))
+          .orderBy(asc(cuotas_credito.numero_cuota));
+      }
 
-			const ahora = new Date();
-			const fechaGuatemalaString = ahora.toLocaleString("en-US", {
-				timeZone: "America/Guatemala",
-				year: "numeric",
-				month: "2-digit",
-				day: "2-digit",
-			});
+      const ahora = new Date();
+      const fechaGuatemalaString = ahora.toLocaleString("en-US", {
+        timeZone: "America/Guatemala",
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+      });
 
-			const [month, day, year] = fechaGuatemalaString.split(", ")[0].split("/");
-			const fechaActualGuatemala = `${year}-${month}-${day}`;
+      const [month, day, year] = fechaGuatemalaString.split(", ")[0].split("/");
+      const fechaActualGuatemala = `${year}-${month}-${day}`;
 
-			// 🔍 Buscar la cuota del mes actual desde la DB
-			const cuotaDelMesResult = await db
-				.select()
-				.from(convenio_cuotas)
-				.where(
-					and(
-						eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id),
-						gte(convenio_cuotas.fecha_vencimiento, fechaActualGuatemala),
-					),
-				)
-				.orderBy(asc(convenio_cuotas.fecha_vencimiento))
-				.limit(1);
+      // 🔍 Buscar la cuota del mes actual desde la DB
+      const cuotaDelMesResult = await db
+        .select()
+        .from(convenio_cuotas)
+        .where(
+          and(
+            eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id),
+            gte(convenio_cuotas.fecha_vencimiento, fechaActualGuatemala)
+          )
+        )
+        .orderBy(asc(convenio_cuotas.fecha_vencimiento))
+        .limit(1);
 
-			const cuotaDelMes = cuotaDelMesResult[0];
-			console.log("cuotaDelMes convenio:", cuotaDelMes);
+      const cuotaDelMes = cuotaDelMesResult[0];
+      console.log("cuotaDelMes convenio:", cuotaDelMes);
 
-			// Si encontramos la cuota del mes y NO tiene fecha_pago, debe pagar
-			if (cuotaDelMes && cuotaDelMes.fecha_pago === null) {
-				cuotaConvenioAPagar = convenioActivo[0].cuota_mensual;
-				console.log(
-					`💰 Debe pagar cuota #${cuotaDelMes.numero_cuota} (vence: ${cuotaDelMes.fecha_vencimiento})`,
-				);
-			} else if (cuotaDelMes && cuotaDelMes.fecha_pago) {
-				cuotaConvenioAPagar = "0";
-				console.log(
-					`✅ Cuota #${cuotaDelMes.numero_cuota} ya está pagada el ${cuotaDelMes.fecha_pago}`,
-				);
-			} else {
-				cuotaConvenioAPagar = "0";
-				console.log("📅 Aún no hay cuota vencida este mes");
-			}
-		}
+      // Si encontramos la cuota del mes y NO tiene fecha_pago, debe pagar
+      if (cuotaDelMes && cuotaDelMes.fecha_pago === null) {
+        cuotaConvenioAPagar = convenioActivo[0].cuota_mensual;
+        console.log(
+          `💰 Debe pagar cuota #${cuotaDelMes.numero_cuota} (vence: ${cuotaDelMes.fecha_vencimiento})`
+        );
+      } else if (cuotaDelMes && cuotaDelMes.fecha_pago) {
+        cuotaConvenioAPagar = "0";
+        console.log(
+          `✅ Cuota #${cuotaDelMes.numero_cuota} ya está pagada el ${cuotaDelMes.fecha_pago}`
+        );
+      } else {
+        cuotaConvenioAPagar = "0";
+        console.log("📅 Aún no hay cuota vencida este mes");
+      }
+    }
 
-		return withActiveCancellation(
-			{
-				flujo: "ACTIVO",
-				credito: currentCredit.creditos,
-				usuario: currentCredit.usuarios,
-				asesor: currentCredit.asesores,
-				cuotaActual,
-				cuotaActualPagada,
-				cuotaActualStatus,
-				cuotasPendientes,
-				cuotasAtrasadas,
-				cuotasPagadas,
-				moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
-				mora: moraActual.length > 0 ? moraActual[0] : null,
-				convenioActivo:
-					convenioActivo.length > 0
-						? {
-								...convenioActivo[0],
-								cuotaConvenioAPagar,
-							}
-						: null,
-				cuotasEnConvenio,
-				pagosConvenio,
-			},
-			cancelacionActiva,
-			currentCredit.creditos.statusCredit,
-		);
-	} catch (error) {
-		console.error("[getCreditoByNumero] Error:", error);
-		return { message: "Error consultando crédito", error: String(error) };
-	}
+    return withActiveCancellation({
+      flujo: "ACTIVO",
+      credito: currentCredit.creditos,
+      usuario: currentCredit.usuarios,
+      asesor: currentCredit.asesores,
+      cuotaActual,
+      cuotaActualPagada,
+      cuotaActualStatus,
+      cuotasPendientes,
+      cuotasAtrasadas,
+      cuotasPagadas,
+      moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
+      mora: moraActual.length > 0 ? moraActual[0] : null,
+      convenioActivo:
+        convenioActivo.length > 0
+          ? {
+              ...convenioActivo[0],
+              cuotaConvenioAPagar,
+            }
+          : null,
+      cuotasEnConvenio,
+      pagosConvenio,
+    }, cancelacionActiva, currentCredit.creditos.statusCredit);
+  } catch (error) {
+    console.error("[getCreditoByNumero] Error:", error);
+    return { message: "Error consultando crédito", error: String(error) };
+  }
 };
 
 // Interfaces para cancelaciones/incobrables
 export interface CreditCancelation {
-	id: number;
-	credit_id: number;
-	motivo: string;
-	observaciones?: string | null;
-	fecha_cancelacion: Date | string;
-	monto_cancelacion: number;
+  id: number;
+  credit_id: number;
+  motivo: string;
+  observaciones?: string | null;
+  fecha_cancelacion: Date | string;
+  monto_cancelacion: number;
 }
 
 export interface BadDebt {
-	id: number;
-	credit_id: number;
-	motivo: string;
-	observaciones?: string | null;
-	fecha_registro: Date | string;
-	monto_incobrable: number;
+  id: number;
+  credit_id: number;
+  motivo: string;
+  observaciones?: string | null;
+  fecha_registro: Date | string;
+  monto_incobrable: number;
 }
 
 // 🆕 Tipos para próxima cuota
 type ProximidadPago = "TODAY" | "WEEK" | "TWO_WEEKS" | "MONTH" | "DUEMONTH";
 
 interface ProximaCuota {
-	cuota_id: number;
-	numero_cuota: number;
-	fecha_vencimiento: string;
-	pagado: boolean;
-	pago_id?: number;
-	validation_status?: string;
-	proximidad: ProximidadPago;
+  cuota_id: number;
+  numero_cuota: number;
+  fecha_vencimiento: string;
+  pagado: boolean;
+  pago_id?: number;
+  validation_status?: string;
+  proximidad: ProximidadPago;
 }
 
 // 🔥 Interface actualizada
 export interface CreditoConInfo {
-	creditos: typeof creditos.$inferSelect;
-	usuarios: typeof usuarios.$inferSelect;
-	asesores: typeof asesores.$inferSelect;
-	inversionistas: {
-		credito_id: number;
-		inversionista_id: number;
-		nombre: string;
-		emite_factura: boolean;
-		monto_aportado: string;
-		monto_cash_in: string;
-		monto_inversionista: string;
-		iva_cash_in: string;
-		iva_inversionista: string;
-		porcentaje_participacion_inversionista: string;
-		porcentaje_cash_in: string;
-		cuota_inversionista: string;
-		fecha_inicio_participacion?: string;
-	}[];
-	resumen: {
-		total_cash_in_monto: number;
-		total_cash_in_iva: number;
-		total_inversion_monto: number;
-		total_inversion_iva: number;
-	};
-	cancelacion?: CreditCancelation | null;
-	incobrable?: BadDebt | null;
-	rubros?: { nombre_rubro: string; monto: number }[];
-	mora?: any; // 👈 Este también faltaba si no lo tenías
-	deuda_total_con_mora?: string; // 👈 Este también
-	proxima_cuota?: ProximaCuota | null; // 🆕 NUEVO CAMPO
-	creditos_inversionistas_espejo?: {
-		credito_id: number;
-		inversionista_id: number;
-		nombre: string;
-		monto_aportado: string;
-		porcentaje_participacion: string;
-		porcentaje_cash_in: string;
-		porcentaje_inversion: string;
-		monto_cash_in: string;
-		monto_inversionista: string;
-		cuota_inversionista: string;
-		fecha_inicio_participacion?: string;
-	}[];
-	fecha_inicio?: string | null;
-	/** Nombre de la aseguradora vinculada al crédito (null si no tiene). */
-	aseguradora?: string | null;
+  creditos: typeof creditos.$inferSelect;
+  usuarios: typeof usuarios.$inferSelect;
+  asesores: typeof asesores.$inferSelect;
+  inversionistas: {
+    credito_id: number;
+    inversionista_id: number;
+    nombre: string;
+    emite_factura: boolean;
+    monto_aportado: string;
+    monto_cash_in: string;
+    monto_inversionista: string;
+    iva_cash_in: string;
+    iva_inversionista: string;
+    porcentaje_participacion_inversionista: string;
+    porcentaje_cash_in: string;
+    cuota_inversionista: string;
+    fecha_inicio_participacion?: string;
+  }[];
+  resumen: {
+    total_cash_in_monto: number;
+    total_cash_in_iva: number;
+    total_inversion_monto: number;
+    total_inversion_iva: number;
+  };
+  cancelacion?: CreditCancelation | null;
+  incobrable?: BadDebt | null;
+  rubros?: { nombre_rubro: string; monto: number }[];
+  mora?: any; // 👈 Este también faltaba si no lo tenías
+  deuda_total_con_mora?: string; // 👈 Este también
+  proxima_cuota?: ProximaCuota | null; // 🆕 NUEVO CAMPO
+  creditos_inversionistas_espejo?: {
+    credito_id: number;
+    inversionista_id: number;
+    nombre: string;
+    monto_aportado: string;
+    porcentaje_participacion: string;
+    porcentaje_cash_in: string;
+    porcentaje_inversion: string;
+    monto_cash_in: string;
+    monto_inversionista: string;
+    cuota_inversionista: string;
+    fecha_inicio_participacion?: string;
+  }[];
+  fecha_inicio?: string | null;
+  /** Nombre de la aseguradora vinculada al crédito (null si no tiene). */
+  aseguradora?: string | null;
 }
 
 // 🔥 Función auxiliar para calcular proximidad (con zona horaria de Guatemala)
 function calcularProximidad(fechaVencimiento: string): ProximidadPago {
-	// 🇬🇹 Hora de Guatemala
-	const hoy = new Date(
-		new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" }),
-	);
-	hoy.setHours(0, 0, 0, 0);
+  // 🇬🇹 Hora de Guatemala
+  const hoy = new Date(
+    new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
+  );
+  hoy.setHours(0, 0, 0, 0);
 
-	// 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
-	const [year, month, day] = fechaVencimiento
-		.slice(0, 10)
-		.split("-")
-		.map(Number);
-	const vencimiento = new Date(year, month - 1, day);
-	vencimiento.setHours(0, 0, 0, 0);
+  // 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
+  const [year, month, day] = fechaVencimiento.slice(0, 10).split("-").map(Number);
+  const vencimiento = new Date(year, month - 1, day);
+  vencimiento.setHours(0, 0, 0, 0);
 
-	const diffDays = Math.floor(
-		(vencimiento.getTime() - hoy.getTime()) / (1000 * 60 * 60 * 24),
-	);
+  const diffDays = Math.floor(
+    (vencimiento.getTime() - hoy.getTime()) / (1000 * 60 * 60 * 24)
+  );
 
-	if (diffDays === 0) return "TODAY";
-	if (diffDays > 0 && diffDays <= 7) return "WEEK";
-	if (diffDays > 7 && diffDays <= 14) return "TWO_WEEKS";
-	if (diffDays > 14 && diffDays <= 30) return "MONTH";
+  if (diffDays === 0) return "TODAY";
+  if (diffDays > 0 && diffDays <= 7) return "WEEK";
+  if (diffDays > 7 && diffDays <= 14) return "TWO_WEEKS";
+  if (diffDays > 14 && diffDays <= 30) return "MONTH";
 
-	return "DUEMONTH";
+  return "DUEMONTH";
 }
 
 export async function getCreditosWithUserByMesAnio(
-	mes: number,
-	anio: number,
-	page: number = 1,
-	perPage: number = 10,
-	numero_credito_sifco?: string,
-	estado?:
-		| "ACTIVO"
-		| "CANCELADO"
-		| "INCOBRABLE"
-		| "PENDIENTE_CANCELACION"
-		| "MOROSO"
-		| "EN_CONVENIO"
-		| "CAIDO",
-	asesor_id?: number,
-	nombre_usuario?: string,
-	email_asesor?: string,
-	cuotas_atrasadas?: number,
-	proximidad_pago?: ProximidadPago,
-	is_vehiculo_propio?: boolean,
-	inversionista_ids?: number[],
-	fecha_desde?: string,
-	fecha_hasta?: string,
-	numeros_credito_sifco?: string[],
-	capital_min?: number,
-	capital_max?: number,
-	estados_credito?: StatusCredit[],
-	aseguradora_id?: number,
-	excluir_pagados_mes?: boolean,
+  mes: number,
+  anio: number,
+  page: number = 1,
+  perPage: number = 10,
+  numero_credito_sifco?: string,
+  estado?:
+    | "ACTIVO"
+    | "CANCELADO"
+    | "INCOBRABLE"
+    | "PENDIENTE_CANCELACION"
+    | "MOROSO"
+    | "EN_CONVENIO"
+    | "CAIDO",
+  asesor_id?: number,
+  nombre_usuario?: string,
+  email_asesor?: string,
+  cuotas_atrasadas?: number,
+  proximidad_pago?: ProximidadPago,
+  is_vehiculo_propio?: boolean,
+  inversionista_ids?: number[],
+  fecha_desde?: string,
+  fecha_hasta?: string,
+  numeros_credito_sifco?: string[],
+  capital_min?: number,
+  capital_max?: number,
+  estados_credito?: StatusCredit[],
+  aseguradora_id?: number,
+  excluir_pagados_mes?: boolean
 ): Promise<{
-	data: CreditoConInfo[];
-	page: number;
-	perPage: number;
-	totalCount: number;
-	totalPages: number;
+  data: CreditoConInfo[];
+  page: number;
+  perPage: number;
+  totalCount: number;
+  totalPages: number;
 }> {
-	console.log(
-		`🚀 Fetching credits | mes: ${mes}, anio: ${anio}, page: ${page}, perPage: ${perPage}`,
-	);
+  console.log(
+    `🚀 Fetching credits | mes: ${mes}, anio: ${anio}, page: ${page}, perPage: ${perPage}`
+  );
 
-	const offset = (page - 1) * perPage;
-	const conditions: any[] = [];
+  const offset = (page - 1) * perPage;
+  const conditions: any[] = [];
 
-	// 🇬🇹 Fecha actual en Guatemala. sv-SE da directamente YYYY-MM-DD y no
-	// depende del TZ del proceso (el patrón anterior new Date(toLocaleString)
-	// + toISOString solo era correcto con el server en UTC).
-	const hoyStr = new Date().toLocaleDateString("sv-SE", {
-		timeZone: "America/Guatemala",
-	});
-	// Aritmética de días en espacio UTC puro (independiente del TZ del server).
-	const hoyUTC = new Date(`${hoyStr}T00:00:00Z`);
-	const sumarDiasStr = (dias: number) => {
-		const d = new Date(hoyUTC);
-		d.setUTCDate(d.getUTCDate() + dias);
-		return d.toISOString().slice(0, 10);
-	};
+  // 🇬🇹 Fecha actual en Guatemala. sv-SE da directamente YYYY-MM-DD y no
+  // depende del TZ del proceso (el patrón anterior new Date(toLocaleString)
+  // + toISOString solo era correcto con el server en UTC).
+  const hoyStr = new Date().toLocaleDateString("sv-SE", {
+    timeZone: "America/Guatemala",
+  });
+  // Aritmética de días en espacio UTC puro (independiente del TZ del server).
+  const hoyUTC = new Date(`${hoyStr}T00:00:00Z`);
+  const sumarDiasStr = (dias: number) => {
+    const d = new Date(hoyUTC);
+    d.setUTCDate(d.getUTCDate() + dias);
+    return d.toISOString().slice(0, 10);
+  };
 
-	try {
-		// 📌 Filtros
-		// Normalizar lista multi-SIFCO (tiene prioridad sobre el filtro single).
-		const sifcosLimpios = numeros_credito_sifco
-			?.map((s) => s.trim())
-			.filter((s) => s.length > 0);
-		if (sifcosLimpios && sifcosLimpios.length > 0) {
-			console.log(
-				`🔎 Filtrando por ${sifcosLimpios.length} número(s) de crédito (multi)`,
-			);
-			conditions.push(inArray(creditos.numero_credito_sifco, sifcosLimpios));
-		} else if (numero_credito_sifco && numero_credito_sifco.trim().length > 0) {
-			console.log(
-				`🔎 Filtrando por número de crédito: ${numero_credito_sifco}`,
-			);
-			conditions.push(
-				eq(creditos.numero_credito_sifco, numero_credito_sifco.trim()),
-			);
-		} else {
-			if (mes !== 0 && anio !== 0) {
-				console.log(`🔎 Filtrando por mes/año: ${mes}/${anio}`);
-				conditions.push(
-					sql`EXTRACT(MONTH FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${mes}`,
-					sql`EXTRACT(YEAR FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${anio}`,
-				);
-			}
-		}
+  try {
+    // 📌 Filtros
+    // Normalizar lista multi-SIFCO (tiene prioridad sobre el filtro single).
+    const sifcosLimpios = numeros_credito_sifco
+      ?.map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (sifcosLimpios && sifcosLimpios.length > 0) {
+      console.log(
+        `🔎 Filtrando por ${sifcosLimpios.length} número(s) de crédito (multi)`
+      );
+      conditions.push(inArray(creditos.numero_credito_sifco, sifcosLimpios));
+    } else if (numero_credito_sifco && numero_credito_sifco.trim().length > 0) {
+      console.log(`🔎 Filtrando por número de crédito: ${numero_credito_sifco}`);
+      conditions.push(eq(creditos.numero_credito_sifco, numero_credito_sifco.trim()));
+    } else {
+      if (mes !== 0 && anio !== 0) {
+        console.log(`🔎 Filtrando por mes/año: ${mes}/${anio}`);
+        conditions.push(
+          sql`EXTRACT(MONTH FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${mes}`,
+          sql`EXTRACT(YEAR FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${anio}`
+        );
+      }
+    }
 
-		if (estado && estado.length > 0) {
-			if (estado === "ACTIVO") {
-				console.log(`🔎 Filtrando por estado: ACTIVO + MOROSO`);
-				if (cuotas_atrasadas == 0) {
-					conditions.push(sql`${creditos.statusCredit} IN ('ACTIVO')`);
-				} else {
-					conditions.push(
-						sql`${creditos.statusCredit} IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')`,
-					);
-				}
-			} else {
-				console.log(`🔎 Filtrando por estado: ${estado}`);
-				conditions.push(eq(creditos.statusCredit, estado));
-			}
-		}
+    if (estado && estado.length > 0) {
+      if (estado === "ACTIVO") {
+        console.log(`🔎 Filtrando por estado: ACTIVO + MOROSO`);
+        if (cuotas_atrasadas == 0 ) {
+          conditions.push(sql`${creditos.statusCredit} IN ('ACTIVO')`);
+        } else {
+          conditions.push(sql`${creditos.statusCredit} IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')`);
+        }
+      } else {
+        console.log(`🔎 Filtrando por estado: ${estado}`);
+        conditions.push(eq(creditos.statusCredit, estado));
+      }
+    }
 
-		if (estados_credito && estados_credito.length > 0) {
-			console.log(
-				`🔎 Filtrando por estados seleccionables: ${estados_credito.join(
-					", ",
-				)}`,
-			);
-			conditions.push(inArray(creditos.statusCredit, estados_credito));
-		}
+    if (estados_credito && estados_credito.length > 0) {
+      console.log(`🔎 Filtrando por estados seleccionables: ${estados_credito.join(", ")}`);
+      conditions.push(inArray(creditos.statusCredit, estados_credito));
+    }
 
-		if (asesor_id) {
-			console.log(`🔎 Filtrando por asesor_id: ${asesor_id}`);
-			conditions.push(eq(creditos.asesor_id, asesor_id));
-		}
+    if (asesor_id) {
+      console.log(`🔎 Filtrando por asesor_id: ${asesor_id}`);
+      conditions.push(eq(creditos.asesor_id, asesor_id));
+    }
 
-		if (nombre_usuario && nombre_usuario.trim().length > 0) {
-			console.log(`🔎 Filtrando por nombre de usuario: ${nombre_usuario}`);
-			const nameCond = buildNameSearchCondition(
-				usuarios.nombre,
-				nombre_usuario,
-			);
-			if (nameCond) conditions.push(nameCond);
-		}
+    if (nombre_usuario && nombre_usuario.trim().length > 0) {
+      console.log(`🔎 Filtrando por nombre de usuario: ${nombre_usuario}`);
+      const nameCond = buildNameSearchCondition(usuarios.nombre, nombre_usuario);
+      if (nameCond) conditions.push(nameCond);
+    }
 
-		if (email_asesor && email_asesor.trim().length > 0) {
-			console.log(`🔎 Filtrando por email de asesor: ${email_asesor}`);
-			conditions.push(
-				sql`${asesores.emailCashIn} ILIKE ${`%${email_asesor}%`}`,
-			);
-		}
+    if (email_asesor && email_asesor.trim().length > 0) {
+      console.log(`🔎 Filtrando por email de asesor: ${email_asesor}`);
+      conditions.push(
+        sql`${asesores.emailCashIn} ILIKE ${`%${email_asesor}%`}`
+      );
+    }
 
-		if (cuotas_atrasadas && cuotas_atrasadas > 0) {
-			// Mora 120+ es un bucket ABIERTO: `cuotas_atrasadas = 4` significa "4 o más",
-			// igual que el embudo (getCreditStats usa `>= 4` para ese bucket). Para 1/2/3
-			// (mora_30/60/90) cada etapa es un conteo exacto. Antes se usaba `eq` para todos,
-			// así que un crédito con 5+ cuotas se contaba en el embudo pero NO salía al
-			// filtrar la tabla por mora_120.
-			if (cuotas_atrasadas >= 4) {
-				console.log(`🔎 Filtrando por cuotas atrasadas >= ${cuotas_atrasadas}`);
-				conditions.push(gte(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
-			} else {
-				console.log(`🔎 Filtrando por cuotas atrasadas = ${cuotas_atrasadas}`);
-				conditions.push(eq(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
-			}
-		}
+    if (cuotas_atrasadas && cuotas_atrasadas > 0) {
+      // Mora 120+ es un bucket ABIERTO: `cuotas_atrasadas = 4` significa "4 o más",
+      // igual que el embudo (getCreditStats usa `>= 4` para ese bucket). Para 1/2/3
+      // (mora_30/60/90) cada etapa es un conteo exacto. Antes se usaba `eq` para todos,
+      // así que un crédito con 5+ cuotas se contaba en el embudo pero NO salía al
+      // filtrar la tabla por mora_120.
+      if (cuotas_atrasadas >= 4) {
+        console.log(`🔎 Filtrando por cuotas atrasadas >= ${cuotas_atrasadas}`);
+        conditions.push(gte(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
+      } else {
+        console.log(`🔎 Filtrando por cuotas atrasadas = ${cuotas_atrasadas}`);
+        conditions.push(eq(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
+      }
+    }
 
-		if (is_vehiculo_propio) {
-			console.log(`🔎 Filtrando solo vehículos propios`);
-			conditions.push(eq(creditos.is_vehiculo_propio, true));
-		}
+    if (is_vehiculo_propio) {
+      console.log(`🔎 Filtrando solo vehículos propios`);
+      conditions.push(eq(creditos.is_vehiculo_propio, true));
+    }
 
-		if (inversionista_ids && inversionista_ids.length > 0) {
-			console.log(`🔎 Filtrando por inversionistas: ${inversionista_ids}`);
-			conditions.push(
-				inArray(creditos_inversionistas.inversionista_id, inversionista_ids),
-			);
-		}
-	} catch (err) {
-		console.error("❌ Error construyendo filtros:", err);
-		throw new Error("Error building filters");
-	}
+    if (inversionista_ids && inversionista_ids.length > 0) {
+      console.log(`🔎 Filtrando por inversionistas: ${inversionista_ids}`);
+      conditions.push(
+        inArray(creditos_inversionistas.inversionista_id, inversionista_ids)
+      );
+    }
+  } catch (err) {
+    console.error("❌ Error construyendo filtros:", err);
+    throw new Error("Error building filters");
+  }
 
-	// 🔥 Filtro de proximidad_pago / rango de fechas - se aplica ANTES de la paginación
-	const needsProximidadJoin =
-		!!proximidad_pago || !!fecha_desde || !!fecha_hasta;
-	if (proximidad_pago) {
-		console.log(`🔎 Filtrando por proximidad de pago: ${proximidad_pago}`);
+  // 🔥 Filtro de proximidad_pago / rango de fechas - se aplica ANTES de la paginación
+  const needsProximidadJoin = !!proximidad_pago || !!fecha_desde || !!fecha_hasta;
+  if (proximidad_pago) {
+    console.log(`🔎 Filtrando por proximidad de pago: ${proximidad_pago}`);
 
-		// Calcular rangos de fecha según proximidad (derivados de hoyStr para no
-		// depender del TZ del proceso)
-		if (proximidad_pago === "TODAY") {
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date = ${hoyStr}::date`,
-			);
-		} else if (proximidad_pago === "WEEK") {
-			const finStr = sumarDiasStr(7);
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date > ${hoyStr}::date`,
-			);
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`,
-			);
-		} else if (proximidad_pago === "TWO_WEEKS") {
-			const inicioStr = sumarDiasStr(8);
-			const finStr = sumarDiasStr(14);
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`,
-			);
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`,
-			);
-		} else if (proximidad_pago === "MONTH") {
-			const inicioStr = sumarDiasStr(15);
-			const finStr = sumarDiasStr(30);
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`,
-			);
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`,
-			);
-		} else if (proximidad_pago === "DUEMONTH") {
-			const inicioStr = sumarDiasStr(31);
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`,
-			);
-		}
+    // Calcular rangos de fecha según proximidad (derivados de hoyStr para no
+    // depender del TZ del proceso)
+    if (proximidad_pago === "TODAY") {
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date = ${hoyStr}::date`);
+    } else if (proximidad_pago === "WEEK") {
+      const finStr = sumarDiasStr(7);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date > ${hoyStr}::date`);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
+    } else if (proximidad_pago === "TWO_WEEKS") {
+      const inicioStr = sumarDiasStr(8);
+      const finStr = sumarDiasStr(14);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
+    } else if (proximidad_pago === "MONTH") {
+      const inicioStr = sumarDiasStr(15);
+      const finStr = sumarDiasStr(30);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
+    } else if (proximidad_pago === "DUEMONTH") {
+      const inicioStr = sumarDiasStr(31);
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
+    }
 
-		// Solo cuotas no pagadas y con numero > 0
-		conditions.push(eq(cuotas_credito.pagado, false));
-		conditions.push(gt(cuotas_credito.numero_cuota, 0));
-	}
+    // Solo cuotas no pagadas y con numero > 0
+    conditions.push(eq(cuotas_credito.pagado, false));
+    conditions.push(gt(cuotas_credito.numero_cuota, 0));
+  }
 
-	if (fecha_desde || fecha_hasta) {
-		if (!proximidad_pago) {
-			conditions.push(eq(cuotas_credito.pagado, false));
-			conditions.push(gt(cuotas_credito.numero_cuota, 0));
-		}
-		if (fecha_desde) {
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date >= ${fecha_desde}::date`,
-			);
-		}
-		if (fecha_hasta) {
-			conditions.push(
-				sql`${cuotas_credito.fecha_vencimiento}::date <= ${fecha_hasta}::date`,
-			);
-		}
-	}
+  if (fecha_desde || fecha_hasta) {
+    if (!proximidad_pago) {
+      conditions.push(eq(cuotas_credito.pagado, false));
+      conditions.push(gt(cuotas_credito.numero_cuota, 0));
+    }
+    if (fecha_desde) {
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${fecha_desde}::date`);
+    }
+    if (fecha_hasta) {
+      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${fecha_hasta}::date`);
+    }
+  }
 
-	if (capital_min !== undefined) {
-		conditions.push(sql`${creditos.capital}::numeric >= ${capital_min}`);
-	}
-	if (capital_max !== undefined) {
-		conditions.push(sql`${creditos.capital}::numeric <= ${capital_max}`);
-	}
 
-	if (aseguradora_id !== undefined) {
-		conditions.push(eq(creditos.aseguradora_id, aseguradora_id));
-	}
+  if (capital_min !== undefined) {
+    conditions.push(sql`${creditos.capital}::numeric >= ${capital_min}`);
+  }
+  if (capital_max !== undefined) {
+    conditions.push(sql`${creditos.capital}::numeric <= ${capital_max}`);
+  }
 
-	if (excluir_pagados_mes) {
-		console.log(`🔎 Excluyendo créditos con su cuota actual ya pagada`);
-		// Cuota actual = la MISMA cuota que la tabla muestra como Fecha de Pago
-		// (proximasCuotasMap): primera cuota con fecha_vencimiento >= (fecha_desde
-		// ?? hoy), con tope fecha_hasta si hay rango — si las anclas divergen, un
-		// crédito con cuota impaga visible podría ocultarse. Se excluye el crédito
-		// solo si esa cuota está pagada (todas sus filas, por si hay duplicadas)
-		// Y no tiene mora activa; sin cuotas en el rango no se excluye.
-		// Subconsulta correlacionada en vez de join para no multiplicar filas
-		// (paginación) y para que el COUNT herede la condición.
-		const anclaDesde = fecha_desde ?? hoyStr;
-		conditions.push(sql`NOT (
+  if (aseguradora_id !== undefined) {
+    conditions.push(eq(creditos.aseguradora_id, aseguradora_id));
+  }
+
+  if (excluir_pagados_mes) {
+    console.log(`🔎 Excluyendo créditos con su cuota actual ya pagada`);
+    // Cuota actual = la MISMA cuota que la tabla muestra como Fecha de Pago
+    // (proximasCuotasMap): primera cuota con fecha_vencimiento >= (fecha_desde
+    // ?? hoy), con tope fecha_hasta si hay rango — si las anclas divergen, un
+    // crédito con cuota impaga visible podría ocultarse. Se excluye el crédito
+    // solo si esa cuota está pagada (todas sus filas, por si hay duplicadas)
+    // Y no tiene mora activa; sin cuotas en el rango no se excluye.
+    // Subconsulta correlacionada en vez de join para no multiplicar filas
+    // (paginación) y para que el COUNT herede la condición.
+    const anclaDesde = fecha_desde ?? hoyStr;
+    conditions.push(sql`NOT (
       ${moras_credito.credito_id} IS NULL
       AND COALESCE((
         SELECT bool_and(COALESCE(cc.pagado, false))
@@ -863,615 +812,606 @@ export async function getCreditosWithUserByMesAnio(
             WHERE cc2.credito_id = ${creditos.credito_id}
               AND cc2.numero_cuota > 0
               AND cc2.fecha_vencimiento >= ${anclaDesde}::date
-              ${
-								fecha_hasta
-									? sql`AND cc2.fecha_vencimiento <= ${fecha_hasta}::date`
-									: sql``
-							}
+              ${fecha_hasta ? sql`AND cc2.fecha_vencimiento <= ${fecha_hasta}::date` : sql``}
           )
       ), false)
     )`);
-	}
+  }
 
-	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+  const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
 
-	let rows: any[] = [];
-	try {
-		// 1️⃣ 🔥 QUERY OPTIMIZADO - Buscar créditos únicos
-		let query = db
-			.select({
-				creditos,
-				usuarios,
-				asesores,
-				moras_credito,
-				aseguradora_nombre: aseguradoras.nombre,
-			})
-			.from(creditos)
-			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-			.leftJoin(
-				moras_credito,
-				and(
-					eq(creditos.credito_id, moras_credito.credito_id),
-					eq(moras_credito.activa, true), // 🔥 Solo moras activas
-				),
-			)
-			.leftJoin(aseguradoras, eq(creditos.aseguradora_id, aseguradoras.id));
+  let rows: any[] = [];
+  try {
+    // 1️⃣ 🔥 QUERY OPTIMIZADO - Buscar créditos únicos
+    let query = db
+      .select({
+        creditos,
+        usuarios,
+        asesores,
+        moras_credito,
+        aseguradora_nombre: aseguradoras.nombre,
+      })
+      .from(creditos)
+      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+      .leftJoin(
+        moras_credito,
+        and(
+          eq(creditos.credito_id, moras_credito.credito_id),
+          eq(moras_credito.activa, true) // 🔥 Solo moras activas
+        )
+      )
+      .leftJoin(aseguradoras, eq(creditos.aseguradora_id, aseguradoras.id));
 
-		// 🔥 JOIN con cuotas_credito si filtramos por proximidad
-		if (needsProximidadJoin) {
-			query = query.innerJoin(
-				cuotas_credito,
-				eq(creditos.credito_id, cuotas_credito.credito_id),
-			) as any;
-		}
+    // 🔥 JOIN con cuotas_credito si filtramos por proximidad
+    if (needsProximidadJoin) {
+      query = query.innerJoin(
+        cuotas_credito,
+        eq(creditos.credito_id, cuotas_credito.credito_id)
+      ) as any;
+    }
 
-		// 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
-		if (inversionista_ids && inversionista_ids.length > 0) {
-			query = query.innerJoin(
-				creditos_inversionistas,
-				eq(creditos.credito_id, creditos_inversionistas.credito_id),
-			) as any;
-		}
+    // 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
+    if (inversionista_ids && inversionista_ids.length > 0) {
+      query = query.innerJoin(
+        creditos_inversionistas,
+        eq(creditos.credito_id, creditos_inversionistas.credito_id)
+      ) as any;
+    }
 
-		rows = await query
-			.where(whereCondition)
-			.limit(perPage)
-			.offset(offset)
-			.orderBy(desc(creditos.fecha_creacion));
+    rows = await query
+      .where(whereCondition)
+      .limit(perPage)
+      .offset(offset)
+      .orderBy(desc(creditos.fecha_creacion));
 
-		console.log(`📄 Créditos encontrados: ${rows.length}`);
-	} catch (err) {
-		console.error("❌ Error consultando créditos:", err);
-		throw new Error("Error fetching credits");
-	}
+    console.log(`📄 Créditos encontrados: ${rows.length}`);
+  } catch (err) {
+    console.error("❌ Error consultando créditos:", err);
+    throw new Error("Error fetching credits");
+  }
 
-	// 🆔 IDs únicos de créditos
-	const creditosIds = [...new Set(rows.map((r) => r.creditos.credito_id))];
-	console.log("🆔 Créditos IDs únicos:", creditosIds);
+  // 🆔 IDs únicos de créditos
+  const creditosIds = [...new Set(rows.map((r) => r.creditos.credito_id))];
+  console.log("🆔 Créditos IDs únicos:", creditosIds);
 
-	// 2️⃣ Rubros
-	let rubrosMap: Record<number, { nombre_rubro: string; monto: number }[]> = {};
-	if (creditosIds.length > 0) {
-		try {
-			const rubrosPorCredito = await db
-				.select({
-					credito_id: creditos_rubros_otros.credito_id,
-					nombre_rubro: creditos_rubros_otros.nombre_rubro,
-					monto: creditos_rubros_otros.monto,
-				})
-				.from(creditos_rubros_otros)
-				.where(inArray(creditos_rubros_otros.credito_id, creditosIds));
+  // 2️⃣ Rubros
+  let rubrosMap: Record<number, { nombre_rubro: string; monto: number }[]> = {};
+  if (creditosIds.length > 0) {
+    try {
+      const rubrosPorCredito = await db
+        .select({
+          credito_id: creditos_rubros_otros.credito_id,
+          nombre_rubro: creditos_rubros_otros.nombre_rubro,
+          monto: creditos_rubros_otros.monto,
+        })
+        .from(creditos_rubros_otros)
+        .where(inArray(creditos_rubros_otros.credito_id, creditosIds));
 
-			console.log(`📊 Rubros encontrados: ${rubrosPorCredito.length}`);
+      console.log(`📊 Rubros encontrados: ${rubrosPorCredito.length}`);
 
-			// 🔥 Agrupar por credito_id
-			rubrosMap = rubrosPorCredito.reduce(
-				(acc, r) => {
-					if (!acc[r.credito_id]) {
-						acc[r.credito_id] = [];
-					}
-					acc[r.credito_id].push({
-						nombre_rubro: r.nombre_rubro,
-						monto: Number(r.monto),
-					});
-					return acc;
-				},
-				{} as Record<number, { nombre_rubro: string; monto: number }[]>,
-			);
-		} catch (err) {
-			console.error("❌ Error consultando rubros:", err);
-		}
-	}
+      // 🔥 Agrupar por credito_id
+      rubrosMap = rubrosPorCredito.reduce((acc, r) => {
+        if (!acc[r.credito_id]) {
+          acc[r.credito_id] = [];
+        }
+        acc[r.credito_id].push({
+          nombre_rubro: r.nombre_rubro,
+          monto: Number(r.monto),
+        });
+        return acc;
+      }, {} as Record<number, { nombre_rubro: string; monto: number }[]>);
+    } catch (err) {
+      console.error("❌ Error consultando rubros:", err);
+    }
+  }
 
-	// 3️⃣ 🔥 INVERSIONISTAS - Optimizado
-	let inversionistasMap: Record<number, any> = {};
-	let inversionistasEspejoMap: Record<number, any[]> = {}; // 🆕 Mapa para Espejos
+  // 3️⃣ 🔥 INVERSIONISTAS - Optimizado
+  let inversionistasMap: Record<number, any> = {};
+  let inversionistasEspejoMap: Record<number, any[]> = {}; // 🆕 Mapa para Espejos
 
-	if (creditosIds.length > 0) {
-		try {
-			// 3.1 Inversionistas Normales (Ordenados por ID para consistencia)
-			const inversionistasPorCredito = await db
-				.select({
-					credito_id: creditos_inversionistas.credito_id,
-					inversionista_id: inversionistas.inversionista_id,
-					nombre: inversionistas.nombre,
-					emite_factura: inversionistas.emite_factura,
-					monto_aportado: creditos_inversionistas.monto_aportado,
-					monto_cash_in: creditos_inversionistas.monto_cash_in,
-					monto_inversionista: creditos_inversionistas.monto_inversionista,
-					iva_cash_in: creditos_inversionistas.iva_cash_in,
-					iva_inversionista: creditos_inversionistas.iva_inversionista,
-					porcentaje_participacion_inversionista:
-						creditos_inversionistas.porcentaje_participacion_inversionista,
-					porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
-					cuota_inversionista: creditos_inversionistas.cuota_inversionista,
-					fecha_inicio_participacion:
-						creditos_inversionistas.fecha_inicio_participacion,
-				})
-				.from(creditos_inversionistas)
-				.innerJoin(
-					inversionistas,
-					eq(
-						creditos_inversionistas.inversionista_id,
-						inversionistas.inversionista_id,
-					),
-				)
-				.where(inArray(creditos_inversionistas.credito_id, creditosIds))
-				.orderBy(asc(creditos_inversionistas.id)); // 👈 Orden garantizado
+  if (creditosIds.length > 0) {
+    try {
+      // 3.1 Inversionistas Normales (Ordenados por ID para consistencia)
+      const inversionistasPorCredito = await db
+        .select({
+          credito_id: creditos_inversionistas.credito_id,
+          inversionista_id: inversionistas.inversionista_id,
+          nombre: inversionistas.nombre,
+          emite_factura: inversionistas.emite_factura,
+          monto_aportado: creditos_inversionistas.monto_aportado,
+          monto_cash_in: creditos_inversionistas.monto_cash_in,
+          monto_inversionista: creditos_inversionistas.monto_inversionista,
+          iva_cash_in: creditos_inversionistas.iva_cash_in,
+          iva_inversionista: creditos_inversionistas.iva_inversionista,
+          porcentaje_participacion_inversionista:
+            creditos_inversionistas.porcentaje_participacion_inversionista,
+          porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
+          cuota_inversionista: creditos_inversionistas.cuota_inversionista,
+          fecha_inicio_participacion: creditos_inversionistas.fecha_inicio_participacion,
+        })
+        .from(creditos_inversionistas)
+        .innerJoin(
+          inversionistas,
+          eq(
+            creditos_inversionistas.inversionista_id,
+            inversionistas.inversionista_id
+          )
+        )
+        .where(inArray(creditos_inversionistas.credito_id, creditosIds))
+        .orderBy(asc(creditos_inversionistas.id)); // 👈 Orden garantizado
 
-			// 3.2 Inversionistas Espejo (Ordenados por ID para consistencia)
-			const inversionistasEspejoPorCredito = await db
-				.select({
-					credito_id: creditos_inversionistas_espejo.credito_id,
-					inversionista_id: inversionistas.inversionista_id,
-					nombre: inversionistas.nombre,
-					monto_aportado: creditos_inversionistas_espejo.monto_aportado,
-					porcentaje_participacion: sql<string>`'0'`, // Calculado en frontend
-					porcentaje_cash_in: creditos_inversionistas_espejo.porcentaje_cash_in,
-					porcentaje_inversion:
-						creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
-					monto_cash_in: creditos_inversionistas_espejo.monto_cash_in,
-					monto_inversionista:
-						creditos_inversionistas_espejo.monto_inversionista,
-					cuota_inversionista:
-						creditos_inversionistas_espejo.cuota_inversionista,
-					fecha_inicio_participacion:
-						creditos_inversionistas_espejo.fecha_inicio_participacion,
-				})
-				.from(creditos_inversionistas_espejo)
-				.innerJoin(
-					inversionistas,
-					eq(
-						creditos_inversionistas_espejo.inversionista_id,
-						inversionistas.inversionista_id,
-					),
-				)
-				.where(inArray(creditos_inversionistas_espejo.credito_id, creditosIds))
-				.orderBy(asc(creditos_inversionistas_espejo.id)); // 👈 Orden garantizado
+      // 3.2 Inversionistas Espejo (Ordenados por ID para consistencia)
+      const inversionistasEspejoPorCredito = await db
+        .select({
+          credito_id: creditos_inversionistas_espejo.credito_id,
+          inversionista_id: inversionistas.inversionista_id,
+          nombre: inversionistas.nombre,
+          monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+          porcentaje_participacion: sql<string>`'0'`, // Calculado en frontend
+          porcentaje_cash_in: creditos_inversionistas_espejo.porcentaje_cash_in,
+          porcentaje_inversion:
+            creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+          monto_cash_in: creditos_inversionistas_espejo.monto_cash_in,
+          monto_inversionista:
+            creditos_inversionistas_espejo.monto_inversionista,
+          cuota_inversionista:
+            creditos_inversionistas_espejo.cuota_inversionista,
+          fecha_inicio_participacion:
+            creditos_inversionistas_espejo.fecha_inicio_participacion,
+        })
+        .from(creditos_inversionistas_espejo)
+        .innerJoin(
+          inversionistas,
+          eq(
+            creditos_inversionistas_espejo.inversionista_id,
+            inversionistas.inversionista_id
+          )
+        )
+        .where(inArray(creditos_inversionistas_espejo.credito_id, creditosIds))
+        .orderBy(asc(creditos_inversionistas_espejo.id)); // 👈 Orden garantizado
 
-			// 3.3 Mapeo Normales
-			inversionistasMap = creditosIds.reduce(
-				(acc, creditoId) => {
-					const aportes = inversionistasPorCredito.filter(
-						(inv) => inv.credito_id === creditoId,
-					);
+      // 3.3 Mapeo Normales
+      inversionistasMap = creditosIds.reduce(
+        (acc, creditoId) => {
+          const aportes = inversionistasPorCredito.filter(
+            (inv) => inv.credito_id === creditoId
+          );
 
-					acc[creditoId] = {
-						aportes,
-						resumen: {
-							total_cash_in_monto: aportes.reduce(
-								(sum, cur) => sum + Number(cur.monto_cash_in ?? 0),
-								0,
-							),
-							total_cash_in_iva: aportes.reduce(
-								(sum, cur) => sum + Number(cur.iva_cash_in ?? 0),
-								0,
-							),
-							total_inversion_monto: aportes.reduce(
-								(sum, cur) => sum + Number(cur.monto_inversionista ?? 0),
-								0,
-							),
-							total_inversion_iva: aportes.reduce(
-								(sum, cur) => sum + Number(cur.iva_inversionista ?? 0),
-								0,
-							),
-						},
-					};
-					return acc;
-				},
-				{} as Record<number, any>,
-			);
+          acc[creditoId] = {
+            aportes,
+            resumen: {
+              total_cash_in_monto: aportes.reduce(
+                (sum, cur) => sum + Number(cur.monto_cash_in ?? 0),
+                0
+              ),
+              total_cash_in_iva: aportes.reduce(
+                (sum, cur) => sum + Number(cur.iva_cash_in ?? 0),
+                0
+              ),
+              total_inversion_monto: aportes.reduce(
+                (sum, cur) => sum + Number(cur.monto_inversionista ?? 0),
+                0
+              ),
+              total_inversion_iva: aportes.reduce(
+                (sum, cur) => sum + Number(cur.iva_inversionista ?? 0),
+                0
+              ),
+            },
+          };
+          return acc;
+        },
+        {} as Record<number, any>
+      );
 
-			// 3.4 Mapeo Espejos
-			inversionistasEspejoMap = creditosIds.reduce(
-				(acc, creditoId) => {
-					const aportesEspejo = inversionistasEspejoPorCredito.filter(
-						(inv) => inv.credito_id === creditoId,
-					);
-					acc[creditoId] = aportesEspejo;
-					return acc;
-				},
-				{} as Record<number, any[]>,
-			);
-		} catch (err) {
-			console.error("❌ Error consultando inversionistas:", err);
-		}
-	}
+      // 3.4 Mapeo Espejos
+      inversionistasEspejoMap = creditosIds.reduce(
+        (acc, creditoId) => {
+          const aportesEspejo = inversionistasEspejoPorCredito.filter(
+            (inv) => inv.credito_id === creditoId
+          );
+          acc[creditoId] = aportesEspejo;
+          return acc;
+        },
+        {} as Record<number, any[]>
+      );
+    } catch (err) {
+      console.error("❌ Error consultando inversionistas:", err);
+    }
+  }
 
-	// 4️⃣ Moras Map
-	const morasMap: Record<number, any> = {};
-	rows.forEach((row) => {
-		if (row.moras_credito) {
-			morasMap[row.creditos.credito_id] = row.moras_credito;
-		}
-	});
+  // 4️⃣ Moras Map
+  const morasMap: Record<number, any> = {};
+  rows.forEach((row) => {
+    if (row.moras_credito) {
+      morasMap[row.creditos.credito_id] = row.moras_credito;
+    }
+  });
 
-	// 5️⃣ Próximas cuotas
-	let proximasCuotasMap: Record<number, ProximaCuota> = {};
-	if (creditosIds.length > 0) {
-		try {
-			console.log("🔍 Buscando próximas cuotas...");
+  // 5️⃣ Próximas cuotas
+  let proximasCuotasMap: Record<number, ProximaCuota> = {};
+  if (creditosIds.length > 0) {
+    try {
+      console.log("🔍 Buscando próximas cuotas...");
 
-			const cuotasRaw = await db
-				.select({
-					credito_id: cuotas_credito.credito_id,
-					cuota_id: cuotas_credito.cuota_id,
-					numero_cuota: cuotas_credito.numero_cuota,
-					fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-					pagado: cuotas_credito.pagado,
-					pago_id: pagos_credito.pago_id,
-					validation_status: pagos_credito.validationStatus,
-				})
-				.from(cuotas_credito)
-				.leftJoin(
-					pagos_credito,
-					eq(cuotas_credito.cuota_id, pagos_credito.cuota_id),
-				)
-				.where(
-					and(
-						inArray(cuotas_credito.credito_id, creditosIds),
-						gte(cuotas_credito.fecha_vencimiento, fecha_desde ?? hoyStr),
-						fecha_hasta
-							? lte(cuotas_credito.fecha_vencimiento, fecha_hasta)
-							: undefined,
-						gt(cuotas_credito.numero_cuota, 0),
-					),
-				)
-				.orderBy(cuotas_credito.credito_id, cuotas_credito.fecha_vencimiento);
+      const cuotasRaw = await db
+        .select({
+          credito_id: cuotas_credito.credito_id,
+          cuota_id: cuotas_credito.cuota_id,
+          numero_cuota: cuotas_credito.numero_cuota,
+          fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+          pagado: cuotas_credito.pagado,
+          pago_id: pagos_credito.pago_id,
+          validation_status: pagos_credito.validationStatus,
+        })
+        .from(cuotas_credito)
+        .leftJoin(
+          pagos_credito,
+          eq(cuotas_credito.cuota_id, pagos_credito.cuota_id)
+        )
+        .where(
+          and(
+            inArray(cuotas_credito.credito_id, creditosIds),
+            gte(cuotas_credito.fecha_vencimiento, fecha_desde ?? hoyStr),
+            fecha_hasta ? lte(cuotas_credito.fecha_vencimiento, fecha_hasta) : undefined,
+            gt(cuotas_credito.numero_cuota, 0)
+          )
+        )
+        .orderBy(cuotas_credito.credito_id, cuotas_credito.fecha_vencimiento);
 
-			console.log(`📅 Cuotas encontradas: ${cuotasRaw.length}`);
+      console.log(`📅 Cuotas encontradas: ${cuotasRaw.length}`);
 
-			// 🔥 Solo la primera cuota de cada crédito
-			const cuotasPorCredito = new Map<number, any>();
-			cuotasRaw.forEach((cuota) => {
-				if (!cuotasPorCredito.has(cuota.credito_id)) {
-					cuotasPorCredito.set(cuota.credito_id, cuota);
-				}
-			});
+      // 🔥 Solo la primera cuota de cada crédito
+      const cuotasPorCredito = new Map<number, any>();
+      cuotasRaw.forEach((cuota) => {
+        if (!cuotasPorCredito.has(cuota.credito_id)) {
+          cuotasPorCredito.set(cuota.credito_id, cuota);
+        }
+      });
 
-			cuotasPorCredito.forEach((cuota, creditoId) => {
-				proximasCuotasMap[creditoId] = {
-					cuota_id: cuota.cuota_id,
-					numero_cuota: cuota.numero_cuota,
-					fecha_vencimiento: cuota.fecha_vencimiento,
-					pagado: cuota.pagado,
-					pago_id: cuota.pago_id,
-					validation_status: cuota.validation_status,
-					proximidad: calcularProximidad(cuota.fecha_vencimiento),
-				};
-			});
+      cuotasPorCredito.forEach((cuota, creditoId) => {
+        proximasCuotasMap[creditoId] = {
+          cuota_id: cuota.cuota_id,
+          numero_cuota: cuota.numero_cuota,
+          fecha_vencimiento: cuota.fecha_vencimiento,
+          pagado: cuota.pagado,
+          pago_id: cuota.pago_id,
+          validation_status: cuota.validation_status,
+          proximidad: calcularProximidad(cuota.fecha_vencimiento),
+        };
+      });
 
-			console.log(`📅 Próximas cuotas mapeadas: ${cuotasPorCredito.size}`);
-		} catch (err) {
-			console.error("❌ Error consultando próximas cuotas:", err);
-		}
-	}
+      console.log(`📅 Próximas cuotas mapeadas: ${cuotasPorCredito.size}`);
+    } catch (err) {
+      console.error("❌ Error consultando próximas cuotas:", err);
+    }
+  }
 
-	// 5.5 Fecha de inicio (cuota 1) de cada crédito
-	let fechaInicioMap: Record<number, string> = {};
-	if (creditosIds.length > 0) {
-		try {
-			const cuotasUno = await db
-				.select({
-					credito_id: cuotas_credito.credito_id,
-					fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-				})
-				.from(cuotas_credito)
-				.where(
-					and(
-						inArray(cuotas_credito.credito_id, creditosIds),
-						eq(cuotas_credito.numero_cuota, 1),
-					),
-				);
+  // 5.5 Fecha de inicio (cuota 1) de cada crédito
+  let fechaInicioMap: Record<number, string> = {};
+  if (creditosIds.length > 0) {
+    try {
+      const cuotasUno = await db
+        .select({
+          credito_id: cuotas_credito.credito_id,
+          fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+        })
+        .from(cuotas_credito)
+        .where(
+          and(
+            inArray(cuotas_credito.credito_id, creditosIds),
+            eq(cuotas_credito.numero_cuota, 1)
+          )
+        );
 
-			cuotasUno.forEach((c) => {
-				fechaInicioMap[c.credito_id] = c.fecha_vencimiento as string;
-			});
-		} catch (err) {
-			console.error("Error consultando fecha inicio:", err);
-		}
-	}
+      cuotasUno.forEach((c) => {
+        fechaInicioMap[c.credito_id] = c.fecha_vencimiento as string;
+      });
+    } catch (err) {
+      console.error("Error consultando fecha inicio:", err);
+    }
+  }
 
-	// 6️⃣ Cancelaciones & Incobrables
-	let cancelacionesMap: Record<number, CreditCancelation> = {};
-	let incobrablesMap: Record<number, BadDebt> = {};
+  // 6️⃣ Cancelaciones & Incobrables
+  let cancelacionesMap: Record<number, CreditCancelation> = {};
+  let incobrablesMap: Record<number, BadDebt> = {};
 
-	try {
-		const canceladosIds = rows
-			.filter((r) => r.creditos.statusCredit === "CANCELADO")
-			.map((r) => r.creditos.credito_id);
+  try {
+    const canceladosIds = rows
+      .filter((r) => r.creditos.statusCredit === "CANCELADO")
+      .map((r) => r.creditos.credito_id);
+      
+    if (canceladosIds.length > 0) {
+      console.log("🛑 Créditos cancelados:", canceladosIds.length);
+      const cancelacionesRaw = await db
+        .select()
+        .from(credit_cancelations)
+        .where(
+          and(
+            inArray(credit_cancelations.credit_id, canceladosIds), 
+          )
+        );
+        
+      cancelacionesRaw.forEach((row) => {
+        cancelacionesMap[row.credit_id] = {
+          ...row,
+          fecha_cancelacion: row.fecha_cancelacion ?? "",
+          monto_cancelacion: Number(row.monto_cancelacion),
+        };
+      });
+    }
+  } catch (err) {
+    console.error("❌ Error consultando cancelaciones:", err);
+  }
 
-		if (canceladosIds.length > 0) {
-			console.log("🛑 Créditos cancelados:", canceladosIds.length);
-			const cancelacionesRaw = await db
-				.select()
-				.from(credit_cancelations)
-				.where(and(inArray(credit_cancelations.credit_id, canceladosIds)));
+  try {
+    const incobrablesIds = rows
+      .filter((r) => r.creditos.statusCredit === "INCOBRABLE")
+      .map((r) => r.creditos.credito_id);
+      
+    if (incobrablesIds.length > 0) {
+      console.log("⚠️ Créditos incobrables:", incobrablesIds.length);
+      const incobrablesRaw = await db
+        .select()
+        .from(bad_debts)
+        .where(inArray(bad_debts.credit_id, incobrablesIds));
+        
+      incobrablesRaw.forEach((row) => {
+        incobrablesMap[row.credit_id] = {
+          ...row,
+          fecha_registro: row.fecha_registro ?? "",
+          monto_incobrable: Number(row.monto_incobrable),
+        };
+      });
+    }
+  } catch (err) {
+    console.error("❌ Error consultando incobrables:", err);
+  }
 
-			cancelacionesRaw.forEach((row) => {
-				cancelacionesMap[row.credit_id] = {
-					...row,
-					fecha_cancelacion: row.fecha_cancelacion ?? "",
-					monto_cancelacion: Number(row.monto_cancelacion),
-				};
-			});
-		}
-	} catch (err) {
-		console.error("❌ Error consultando cancelaciones:", err);
-	}
+  // 7️⃣ 🔥 MAP FINAL - Sin duplicados
+  let data: CreditoConInfo[] = [];
+  try {
+    // 🔥 Usar Map para asegurar créditos únicos
+    const creditosUnicos = new Map<number, any>();
+    
+    rows.forEach((row) => {
+      const creditoId = row.creditos.credito_id;
+      
+      // Solo agregar si no existe
+      if (!creditosUnicos.has(creditoId)) {
+        const info = inversionistasMap[creditoId] || {
+          aportes: [],
+          resumen: {
+            total_cash_in_monto: 0,
+            total_cash_in_iva: 0,
+            total_inversion_monto: 0,
+            total_inversion_iva: 0,
+          },
+        };
+        
+        const rubros = rubrosMap[creditoId] || [];
+        const cancelacion = row.creditos.statusCredit === "CANCELADO"
+          ? cancelacionesMap[creditoId] || null
+          : undefined;
+        const incobrable = row.creditos.statusCredit === "INCOBRABLE"
+          ? incobrablesMap[creditoId] || null
+          : undefined;
 
-	try {
-		const incobrablesIds = rows
-			.filter((r) => r.creditos.statusCredit === "INCOBRABLE")
-			.map((r) => r.creditos.credito_id);
+        const mora = morasMap[creditoId] || null;
+        const deuda_total_con_mora = new Big(row.creditos.deudatotal ?? 0)
+          .plus(new Big(mora?.monto_mora ?? 0))
+          .toString();
 
-		if (incobrablesIds.length > 0) {
-			console.log("⚠️ Créditos incobrables:", incobrablesIds.length);
-			const incobrablesRaw = await db
-				.select()
-				.from(bad_debts)
-				.where(inArray(bad_debts.credit_id, incobrablesIds));
+        const proxima_cuota = proximasCuotasMap[creditoId] || null;
+        const fecha_inicio = fechaInicioMap[creditoId] || null;
 
-			incobrablesRaw.forEach((row) => {
-				incobrablesMap[row.credit_id] = {
-					...row,
-					fecha_registro: row.fecha_registro ?? "",
-					monto_incobrable: Number(row.monto_incobrable),
-				};
-			});
-		}
-	} catch (err) {
-		console.error("❌ Error consultando incobrables:", err);
-	}
+        creditosUnicos.set(creditoId, {
+          creditos: row.creditos,
+          usuarios: row.usuarios,
+          asesores: row.asesores,
+          inversionistas: info.aportes,
+          creditos_inversionistas_espejo: inversionistasEspejoMap[creditoId] || [], // 👈 Agregado aquí
+          resumen: info.resumen,
+          cancelacion,
+          rubros,
+          incobrable,
+          mora,
+          deuda_total_con_mora,
+          proxima_cuota,
+          fecha_inicio,
+          aseguradora: row.aseguradora_nombre ?? null,
+        });
+      }
+    });
 
-	// 7️⃣ 🔥 MAP FINAL - Sin duplicados
-	let data: CreditoConInfo[] = [];
-	try {
-		// 🔥 Usar Map para asegurar créditos únicos
-		const creditosUnicos = new Map<number, any>();
+    data = Array.from(creditosUnicos.values());
+    console.log(`✅ Créditos únicos mapeados: ${data.length}`);
+  } catch (err) {
+    console.error("❌ Error mapeando créditos:", err);
+    throw new Error("Error mapping credits");
+  }
 
-		rows.forEach((row) => {
-			const creditoId = row.creditos.credito_id;
+  // 8️⃣ Filtro de proximidad - YA SE APLICA EN LA QUERY PRINCIPAL (antes de paginación)
 
-			// Solo agregar si no existe
-			if (!creditosUnicos.has(creditoId)) {
-				const info = inversionistasMap[creditoId] || {
-					aportes: [],
-					resumen: {
-						total_cash_in_monto: 0,
-						total_cash_in_iva: 0,
-						total_inversion_monto: 0,
-						total_inversion_iva: 0,
-					},
-				};
+  // 9️⃣ Paginación - Count total
+  let count = 0;
+  try {
+    let countQuery = db
+      .select({ count: sql<number>`COUNT(DISTINCT ${creditos.credito_id})` }) // 🔥 DISTINCT
+      .from(creditos)
+      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+      .leftJoin(
+        platform_users,
+        eq(asesores.asesor_id, platform_users.asesor_id)
+      )
+      .leftJoin(
+        moras_credito,
+        and(
+          eq(creditos.credito_id, moras_credito.credito_id),
+          eq(moras_credito.activa, true)
+        )
+      );
 
-				const rubros = rubrosMap[creditoId] || [];
-				const cancelacion =
-					row.creditos.statusCredit === "CANCELADO"
-						? cancelacionesMap[creditoId] || null
-						: undefined;
-				const incobrable =
-					row.creditos.statusCredit === "INCOBRABLE"
-						? incobrablesMap[creditoId] || null
-						: undefined;
+    // 🔥 JOIN con cuotas_credito si filtramos por proximidad
+    if (needsProximidadJoin) {
+      countQuery = countQuery.innerJoin(
+        cuotas_credito,
+        eq(creditos.credito_id, cuotas_credito.credito_id)
+      ) as any;
+    }
 
-				const mora = morasMap[creditoId] || null;
-				const deuda_total_con_mora = new Big(row.creditos.deudatotal ?? 0)
-					.plus(new Big(mora?.monto_mora ?? 0))
-					.toString();
+    // 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
+    if (inversionista_ids && inversionista_ids.length > 0) {
+      countQuery = countQuery.innerJoin(
+        creditos_inversionistas,
+        eq(creditos.credito_id, creditos_inversionistas.credito_id)
+      ) as any;
+    }
 
-				const proxima_cuota = proximasCuotasMap[creditoId] || null;
-				const fecha_inicio = fechaInicioMap[creditoId] || null;
+    const [{ count: total }] = await countQuery.where(whereCondition);
 
-				creditosUnicos.set(creditoId, {
-					creditos: row.creditos,
-					usuarios: row.usuarios,
-					asesores: row.asesores,
-					inversionistas: info.aportes,
-					creditos_inversionistas_espejo:
-						inversionistasEspejoMap[creditoId] || [], // 👈 Agregado aquí
-					resumen: info.resumen,
-					cancelacion,
-					rubros,
-					incobrable,
-					mora,
-					deuda_total_con_mora,
-					proxima_cuota,
-					fecha_inicio,
-					aseguradora: row.aseguradora_nombre ?? null,
-				});
-			}
-		});
+    count = Number(total);
+    console.log(`📊 Total créditos únicos: ${count}`);
+  } catch (err) {
+    console.error("❌ Error contando créditos:", err);
+  }
 
-		data = Array.from(creditosUnicos.values());
-		console.log(`✅ Créditos únicos mapeados: ${data.length}`);
-	} catch (err) {
-		console.error("❌ Error mapeando créditos:", err);
-		throw new Error("Error mapping credits");
-	}
-
-	// 8️⃣ Filtro de proximidad - YA SE APLICA EN LA QUERY PRINCIPAL (antes de paginación)
-
-	// 9️⃣ Paginación - Count total
-	let count = 0;
-	try {
-		let countQuery = db
-			.select({ count: sql<number>`COUNT(DISTINCT ${creditos.credito_id})` }) // 🔥 DISTINCT
-			.from(creditos)
-			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-			.leftJoin(
-				platform_users,
-				eq(asesores.asesor_id, platform_users.asesor_id),
-			)
-			.leftJoin(
-				moras_credito,
-				and(
-					eq(creditos.credito_id, moras_credito.credito_id),
-					eq(moras_credito.activa, true),
-				),
-			);
-
-		// 🔥 JOIN con cuotas_credito si filtramos por proximidad
-		if (needsProximidadJoin) {
-			countQuery = countQuery.innerJoin(
-				cuotas_credito,
-				eq(creditos.credito_id, cuotas_credito.credito_id),
-			) as any;
-		}
-
-		// 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
-		if (inversionista_ids && inversionista_ids.length > 0) {
-			countQuery = countQuery.innerJoin(
-				creditos_inversionistas,
-				eq(creditos.credito_id, creditos_inversionistas.credito_id),
-			) as any;
-		}
-
-		const [{ count: total }] = await countQuery.where(whereCondition);
-
-		count = Number(total);
-		console.log(`📊 Total créditos únicos: ${count}`);
-	} catch (err) {
-		console.error("❌ Error contando créditos:", err);
-	}
-
-	return {
-		data,
-		page,
-		perPage,
-		totalCount: count,
-		totalPages: Math.ceil(count / perPage),
-	};
+  return {
+    data,
+    page,
+    perPage,
+    totalCount: count,
+    totalPages: Math.ceil(count / perPage),
+  };
 }
 
 type Aporte = {
-	monto_cash_in: string; // viene como string desde la DB
-	monto_inversionista: string;
+  monto_cash_in: string; // viene como string desde la DB
+  monto_inversionista: string;
 };
 
 type ResultadoDistribucion = {
-	cuota_cash_in: Big;
-	iva_cash_in: Big;
-	cuota_inversionistas: Big;
-	iva_inversionistas: Big;
+  cuota_cash_in: Big;
+  iva_cash_in: Big;
+  cuota_inversionistas: Big;
+  iva_inversionistas: Big;
 };
 
 export function calcularDistribucionCuota({
-	capital,
-	cuota_interes,
-	aportes,
+  capital,
+  cuota_interes,
+  aportes,
 }: {
-	capital: Big;
-	cuota_interes: Big;
-	aportes: Aporte[];
+  capital: Big;
+  cuota_interes: Big;
+  aportes: Aporte[];
 }): ResultadoDistribucion {
-	const totalCashIn = aportes.reduce(
-		(acc, cur) => acc.plus(cur.monto_cash_in),
-		new Big(0),
-	);
+  const totalCashIn = aportes.reduce(
+    (acc, cur) => acc.plus(cur.monto_cash_in),
+    new Big(0)
+  );
 
-	const totalInversion = aportes.reduce(
-		(acc, cur) => acc.plus(cur.monto_inversionista),
-		new Big(0),
-	);
+  const totalInversion = aportes.reduce(
+    (acc, cur) => acc.plus(cur.monto_inversionista),
+    new Big(0)
+  );
 
-	const cuota_cash_in = totalCashIn.div(capital).times(cuota_interes).round(2);
-	const iva_cash_in = cuota_cash_in.times(0.12).round(2);
+  const cuota_cash_in = totalCashIn.div(capital).times(cuota_interes).round(2);
+  const iva_cash_in = cuota_cash_in.times(0.12).round(2);
 
-	const cuota_inversionistas = totalInversion
-		.div(capital)
-		.times(cuota_interes)
-		.round(2);
-	const iva_inversionistas = cuota_inversionistas.times(0.12).round(2);
+  const cuota_inversionistas = totalInversion
+    .div(capital)
+    .times(cuota_interes)
+    .round(2);
+  const iva_inversionistas = cuota_inversionistas.times(0.12).round(2);
 
-	return {
-		cuota_cash_in,
-		iva_cash_in,
-		cuota_inversionistas,
-		iva_inversionistas,
-	};
+  return {
+    cuota_cash_in,
+    iva_cash_in,
+    cuota_inversionistas,
+    iva_inversionistas,
+  };
 }
 
 export async function cancelCredit(creditId: number) {
-	try {
-		// 1. Obtener el crédito
-		const [credit] = await db
-			.select()
-			.from(creditos)
-			.where(eq(creditos.credito_id, creditId))
-			.limit(1);
+  try {
+    // 1. Obtener el crédito
+    const [credit] = await db
+      .select()
+      .from(creditos)
+      .where(eq(creditos.credito_id, creditId))
+      .limit(1);
 
-		if (!credit) {
-			return { message: "Crédito no encontrado." };
-		}
+    if (!credit) {
+      return { message: "Crédito no encontrado." };
+    }
 
-		// 2. Mora activa
-		const [morasCredito] = await db
-			.select()
-			.from(moras_credito)
-			.where(
-				and(
-					eq(moras_credito.credito_id, creditId),
-					eq(moras_credito.activa, true),
-				),
-			);
+    // 2. Mora activa
+    const [morasCredito] = await db
+      .select()
+      .from(moras_credito)
+      .where(
+        and(
+          eq(moras_credito.credito_id, creditId),
+          eq(moras_credito.activa, true)
+        )
+      );
 
-		// 3. Devolver valores unitarios por cuota (fijos del crédito)
-		return {
-			message: "Resumen del crédito a cancelar",
-			credito: {
-				capital: credit.capital ?? "0",
-				interes: credit.cuota_interes ?? "0",
-				iva: credit.iva_12 ?? "0",
-				membresias: credit.membresias ?? "0",
-				seguro: credit.seguro_10_cuotas ?? "0",
-				gps: credit.gps ?? "0",
-				mora: morasCredito ? morasCredito.monto_mora : "0",
-			},
-		};
-	} catch (error) {
-		console.error("Error cancelando crédito:", error);
-		return { message: "Error cancelando crédito", error: String(error) };
-	}
+    // 3. Devolver valores unitarios por cuota (fijos del crédito)
+    return {
+      message: "Resumen del crédito a cancelar",
+      credito: {
+        capital: credit.capital ?? "0",
+        interes: credit.cuota_interes ?? "0",
+        iva: credit.iva_12 ?? "0",
+        membresias: credit.membresias ?? "0",
+        seguro: credit.seguro_10_cuotas ?? "0",
+        gps: credit.gps ?? "0",
+        mora: morasCredito ? morasCredito.monto_mora : "0",
+      },
+    };
+  } catch (error) {
+    console.error("Error cancelando crédito:", error);
+    return { message: "Error cancelando crédito", error: String(error) };
+  }
 }
 
 const MontoAdicionalSchema = z.object({
-	concepto: z.string().min(1),
-	monto: z.number(), // positivo suma / negativo descuenta
+  concepto: z.string().min(1),
+  monto: z.number(), // positivo suma / negativo descuenta
 });
 // Define the inferred type from the schema
 type MontoAdicional = z.infer<typeof MontoAdicionalSchema>;
 
 const AccionCreditoParamsSchema = z.object({
-	creditId: z.number(),
-	motivo: z.string().optional(),
-	observaciones: z.string().optional(),
-	monto_cancelacion: z.number().optional(),
-	accion: z.enum([
-		"CANCELAR",
-		"ACTIVAR",
-		"INCOBRABLE",
-		"PENDIENTE_CANCELACION",
-		"EN_CONVENIO",
-		"MOROSO",
-	]),
-	montosAdicionales: z.array(MontoAdicionalSchema).optional(),
-	traspaso: z.number().optional(),
-	garantia_mobiliaria: z.number().optional(),
-	otros: z.number().optional(),
-	cuotas_atrasadas: z.number().int().min(0).optional(),
+  creditId: z.number(),
+  motivo: z.string().optional(),
+  observaciones: z.string().optional(),
+  monto_cancelacion: z.number().optional(),
+  accion: z.enum([
+    "CANCELAR",
+    "ACTIVAR",
+    "INCOBRABLE",
+    "PENDIENTE_CANCELACION",
+    "EN_CONVENIO",
+    "MOROSO",
+  ]),
+  montosAdicionales: z.array(MontoAdicionalSchema).optional(),
+  traspaso: z.number().optional(),
+  garantia_mobiliaria: z.number().optional(),
+  otros: z.number().optional(),
+  cuotas_atrasadas: z.number().int().min(0).optional(),
 });
 
 const STATUS_MAP = {
-	CANCELAR: "CANCELADO",
-	PENDIENTE_CANCELACION: "PENDIENTE_CANCELACION",
-	ACTIVAR: "ACTIVO",
-	INCOBRABLE: "INCOBRABLE",
-	EN_CONVENIO: "EN_CONVENIO",
-	MOROSO: "MOROSO",
-	// Puedes agregar más acciones aquí si las necesitas
+  CANCELAR: "CANCELADO",
+  PENDIENTE_CANCELACION: "PENDIENTE_CANCELACION",
+  ACTIVAR: "ACTIVO",
+  INCOBRABLE: "INCOBRABLE",
+  EN_CONVENIO: "EN_CONVENIO",
+  MOROSO: "MOROSO",
+  // Puedes agregar más acciones aquí si las necesitas
 };
 
 /**
@@ -1480,263 +1420,253 @@ const STATUS_MAP = {
 export type AccionCreditoParams = z.infer<typeof AccionCreditoParamsSchema>;
 
 export async function actualizarEstadoCredito(input: AccionCreditoParams) {
-	// Validate input
-	const {
-		creditId,
-		motivo,
-		observaciones,
-		monto_cancelacion,
-		accion,
-		montosAdicionales,
-		traspaso,
-		garantia_mobiliaria,
-		otros,
-		cuotas_atrasadas,
-	} = AccionCreditoParamsSchema.parse(input);
+  // Validate input
+  const {
+    creditId,
+    motivo,
+    observaciones,
+    monto_cancelacion,
+    accion,
+    montosAdicionales,
+    traspaso,
+    garantia_mobiliaria,
+    otros,
+    cuotas_atrasadas,
+  } = AccionCreditoParamsSchema.parse(input);
 
-	// Guard rails for actions that require motivo + monto
-	const needsReasonAndAmount =
-		accion === "CANCELAR" ||
-		accion === "PENDIENTE_CANCELACION" ||
-		accion === "INCOBRABLE";
-	if (needsReasonAndAmount && (!motivo || monto_cancelacion == null)) {
-		return {
-			ok: false,
-			message: "Debes enviar 'motivo' y 'monto_cancelacion' para esta acción.",
-		};
-	}
+  // Guard rails for actions that require motivo + monto
+  const needsReasonAndAmount =
+    accion === "CANCELAR" ||
+    accion === "PENDIENTE_CANCELACION" ||
+    accion === "INCOBRABLE";
+  if (needsReasonAndAmount && (!motivo || monto_cancelacion == null)) {
+    return {
+      ok: false,
+      message: "Debes enviar 'motivo' y 'monto_cancelacion' para esta acción.",
+    };
+  }
 
-	try {
-		const result = await db.transaction(async (tx) => {
-			/** 1) OPCIONAL: insertar montos adicionales ANTES del cambio de estado */
-			if (montosAdicionales?.length) {
-				await tx.insert(montos_adicionales).values(
-					montosAdicionales.map((m) => ({
-						credit_id: creditId,
-						concepto: m.concepto,
-						monto: m.monto.toString(), // numeric -> string
-					})),
-				);
-			}
+  try {
+    const result = await db.transaction(async (tx) => {
+      /** 1) OPCIONAL: insertar montos adicionales ANTES del cambio de estado */
+      if (montosAdicionales?.length) {
+        await tx.insert(montos_adicionales).values(
+          montosAdicionales.map((m) => ({
+            credit_id: creditId,
+            concepto: m.concepto,
+            monto: m.monto.toString(), // numeric -> string
+          }))
+        );
+      }
 
-			/** 2) Cambios según acción */
-			if (accion === "CANCELAR" || accion === "PENDIENTE_CANCELACION") {
-				const newStatus =
-					STATUS_MAP[accion as keyof typeof STATUS_MAP] ||
-					"PENDIENTE_CANCELACION";
+      /** 2) Cambios según acción */
+      if (accion === "CANCELAR" || accion === "PENDIENTE_CANCELACION") {
+        const newStatus =
+          STATUS_MAP[accion as keyof typeof STATUS_MAP] ||
+          "PENDIENTE_CANCELACION";
 
-				// a) Update credit status
-				await tx
-					.update(creditos)
-					.set({
-						statusCredit: newStatus as
-							| "CANCELADO"
-							| "ACTIVO"
-							| "INCOBRABLE"
-							| "PENDIENTE_CANCELACION",
-					})
-					.where(eq(creditos.credito_id, creditId));
+        // a) Update credit status
+        await tx
+          .update(creditos)
+          .set({
+            statusCredit: newStatus as
+              | "CANCELADO"
+              | "ACTIVO"
+              | "INCOBRABLE"
+              | "PENDIENTE_CANCELACION",
+          })
+          .where(eq(creditos.credito_id, creditId));
 
-				// b) Register cancelation (idempotent insert; assume one row per credit)
-				await tx.insert(credit_cancelations).values({
-					credit_id: creditId,
-					motivo: motivo!, // validated above
-					observaciones: observaciones ?? "",
-					monto_cancelacion: monto_cancelacion!.toString(),
-					traspaso: (traspaso ?? 0).toString(),
-					garantia_mobiliaria: (garantia_mobiliaria ?? 0).toString(),
-					otros: (otros ?? 0).toString(),
-					cuotas_atrasadas: cuotas_atrasadas ?? 0,
-				});
+        // b) Register cancelation (idempotent insert; assume one row per credit)
+        await tx.insert(credit_cancelations).values({
+          credit_id: creditId,
+          motivo: motivo!, // validated above
+          observaciones: observaciones ?? "",
+          monto_cancelacion: monto_cancelacion!.toString(),
+          traspaso: (traspaso ?? 0).toString(),
+          garantia_mobiliaria: (garantia_mobiliaria ?? 0).toString(),
+          otros: (otros ?? 0).toString(),
+          cuotas_atrasadas: cuotas_atrasadas ?? 0,
+        });
 
-				return {
-					ok: true,
-					message: `Crédito ${newStatus
-						.toLowerCase()
-						.replace("_", " ")} correctamente`,
-				};
-			}
+        return {
+          ok: true,
+          message: `Crédito ${newStatus.toLowerCase().replace("_", " ")} correctamente`,
+        };
+      }
 
-			if (accion === "ACTIVAR") {
-				// a) Set ACTIVE
-				await tx
-					.update(creditos)
-					.set({ statusCredit: "ACTIVO" })
-					.where(eq(creditos.credito_id, creditId));
+      if (accion === "ACTIVAR") {
+        // a) Set ACTIVE
+        await tx
+          .update(creditos)
+          .set({ statusCredit: "ACTIVO" })
+          .where(eq(creditos.credito_id, creditId));
 
-				// b) Remove cancelation & bad debt records
-				await tx
-					.delete(credit_cancelations)
-					.where(eq(credit_cancelations.credit_id, creditId));
-				await tx.delete(bad_debts).where(eq(bad_debts.credit_id, creditId));
-				await tx
-					.delete(montos_adicionales)
-					.where(eq(montos_adicionales.credit_id, creditId));
+        // b) Remove cancelation & bad debt records
+        await tx
+          .delete(credit_cancelations)
+          .where(eq(credit_cancelations.credit_id, creditId));
+        await tx.delete(bad_debts).where(eq(bad_debts.credit_id, creditId));
+        await tx
+          .delete(montos_adicionales)
+          .where(eq(montos_adicionales.credit_id, creditId));
 
-				return {
-					ok: true,
-					message: "Crédito reactivado y registros de cierre eliminados",
-				};
-			}
+        return {
+          ok: true,
+          message: "Crédito reactivado y registros de cierre eliminados",
+        };
+      }
 
-			// accion === "INCOBRABLE"
-			// TODO: Distribuir abono a capital en tabla espejo (CANCELACION)
-			// try {
-			//   await distribuirAbonoCapitalEspejo(creditId, monto_cancelacion!.toString(), "CANCELACION");
-			//   console.log("✅ Abono capital (incobrable) distribuido en tabla abonos_capital (espejo)");
-			// } catch (err) {
-			//   console.error("⚠️ Error al distribuir abono en espejo (incobrable):", err);
-			// }
+      // accion === "INCOBRABLE"
+      // TODO: Distribuir abono a capital en tabla espejo (CANCELACION)
+      // try {
+      //   await distribuirAbonoCapitalEspejo(creditId, monto_cancelacion!.toString(), "CANCELACION");
+      //   console.log("✅ Abono capital (incobrable) distribuido en tabla abonos_capital (espejo)");
+      // } catch (err) {
+      //   console.error("⚠️ Error al distribuir abono en espejo (incobrable):", err);
+      // }
 
-			// a) Obtener crédito actual
-			const [creditoActual] = await tx
-				.select()
-				.from(creditos)
-				.where(eq(creditos.credito_id, creditId));
+      // a) Obtener crédito actual
+      const [creditoActual] = await tx
+        .select()
+        .from(creditos)
+        .where(eq(creditos.credito_id, creditId));
 
-			if (!creditoActual) {
-				return { ok: false, message: "Crédito no encontrado" };
-			}
+      if (!creditoActual) {
+        return { ok: false, message: "Crédito no encontrado" };
+      }
 
-			// b) Capital = monto_incobrable, plazo = 1, cuota = capital completo
-			const capitalIncobrable = new Big(monto_cancelacion!);
+      // b) Capital = monto_incobrable, plazo = 1, cuota = capital completo
+      const capitalIncobrable = new Big(monto_cancelacion!);
 
-			// c) Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
-			//    paymentFalse=true). Además se ponen los *_restante en 0 para que las queries de
-			//    cuotas pendientes/atrasadas que NO filtran paymentFalse no muestren deuda fantasma.
-			const pagosNoPagados = await tx
-				.update(pagos_credito)
-				.set({
-					paymentFalse: true,
-					capital_restante: "0",
-					interes_restante: "0",
-					iva_12_restante: "0",
-					seguro_restante: "0",
-					gps_restante: "0",
-					total_restante: "0",
-					mora: "0",
-				})
-				.where(
-					and(
-						eq(pagos_credito.credito_id, creditId),
-						eq(pagos_credito.pagado, false),
-					),
-				)
-				.returning({ pago_id: pagos_credito.pago_id });
+      // c) Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
+      //    paymentFalse=true). Además se ponen los *_restante en 0 para que las queries de
+      //    cuotas pendientes/atrasadas que NO filtran paymentFalse no muestren deuda fantasma.
+      const pagosNoPagados = await tx
+        .update(pagos_credito)
+        .set({
+          paymentFalse: true,
+          capital_restante: "0",
+          interes_restante: "0",
+          iva_12_restante: "0",
+          seguro_restante: "0",
+          gps_restante: "0",
+          total_restante: "0",
+          mora: "0",
+        })
+        .where(
+          and(
+            eq(pagos_credito.credito_id, creditId),
+            eq(pagos_credito.pagado, false)
+          )
+        )
+        .returning({ pago_id: pagos_credito.pago_id });
 
-			const pagoIds = pagosNoPagados.map((p) => p.pago_id);
+      const pagoIds = pagosNoPagados.map(p => p.pago_id);
 
-			if (pagoIds.length > 0) {
-				console.log(
-					`🚫 Anulados (paymentFalse) ${pagoIds.length} pagos no pagados del crédito #${creditId}`,
-				);
-			}
+      if (pagoIds.length > 0) {
+        console.log(`🚫 Anulados (paymentFalse) ${pagoIds.length} pagos no pagados del crédito #${creditId}`);
+      }
 
-			// d) Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
-			//    anulados arriba, así que no aportan saldo en las vistas activas.
+      // d) Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
+      //    anulados arriba, así que no aportan saldo en las vistas activas.
 
-			// Crear cuota correlativa para el saldo incobrable
-			const [maxCuotaRowDirect] = await tx
-				.select({
-					max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
-				})
-				.from(cuotas_credito)
-				.where(eq(cuotas_credito.credito_id, creditId));
-			const nextNumeroCuotaIncobrable = Number(maxCuotaRowDirect?.max ?? 0) + 1;
+      // Crear cuota correlativa para el saldo incobrable
+      const [maxCuotaRowDirect] = await tx
+        .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
+        .from(cuotas_credito)
+        .where(eq(cuotas_credito.credito_id, creditId));
+      const nextNumeroCuotaIncobrable = Number(maxCuotaRowDirect?.max ?? 0) + 1;
 
-			const [cuotaIncobrableInsertada] = await tx
-				.insert(cuotas_credito)
-				.values({
-					credito_id: creditId,
-					numero_cuota: nextNumeroCuotaIncobrable,
-					fecha_vencimiento: new Date().toLocaleDateString("sv-SE", {
-						timeZone: "America/Guatemala",
-					}),
-					pagado: false,
-					liquidado_inversionistas: false,
-				})
-				.returning({ cuota_id: cuotas_credito.cuota_id });
+      const [cuotaIncobrableInsertada] = await tx
+        .insert(cuotas_credito)
+        .values({
+          credito_id: creditId,
+          numero_cuota: nextNumeroCuotaIncobrable,
+          fecha_vencimiento: new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" }),
+          pagado: false,
+          liquidado_inversionistas: false,
+        })
+        .returning({ cuota_id: cuotas_credito.cuota_id });
 
-			// e) Actualizar crédito: INCOBRABLE, plazo 1, cuota = capital completo
-			await setCapitalSource(tx, "CASTIGO");
-			await tx
-				.update(creditos)
-				.set({
-					statusCredit: "INCOBRABLE",
-					capital: capitalIncobrable.toString(),
-					plazo: 1,
-					cuota_interes: "0",
-					iva_12: "0",
-					membresias_pago: "0",
-					membresias: "0",
-					seguro_10_cuotas: "0",
-					gps: "0",
-					royalti: "0",
-					porcentaje_royalti: "0",
-					otros: "0",
-					cuota: capitalIncobrable.toString(),
-					deudatotal: capitalIncobrable.toString(),
-				})
-				.where(eq(creditos.credito_id, creditId));
+      // e) Actualizar crédito: INCOBRABLE, plazo 1, cuota = capital completo
+      await setCapitalSource(tx, "CASTIGO");
+      await tx
+        .update(creditos)
+        .set({
+          statusCredit: "INCOBRABLE",
+          capital: capitalIncobrable.toString(),
+          plazo: 1,
+          cuota_interes: "0",
+          iva_12: "0",
+          membresias_pago: "0",
+          membresias: "0",
+          seguro_10_cuotas: "0",
+          gps: "0",
+          royalti: "0",
+          porcentaje_royalti: "0",
+          otros: "0",
+          cuota: capitalIncobrable.toString(),
+          deudatotal: capitalIncobrable.toString(),
+        })
+        .where(eq(creditos.credito_id, creditId));
 
-			// f) Crear pago base con capital_restante = capital, enlazado a la cuota recién creada
-			await tx.insert(pagos_credito).values({
-				credito_id: creditId,
-				cuota: capitalIncobrable.toString(),
-				cuota_interes: "0",
-				cuota_id: cuotaIncobrableInsertada.cuota_id,
-				abono_capital: "0",
-				abono_interes: "0",
-				abono_iva_12: "0",
-				abono_interes_ci: "0",
-				abono_iva_ci: "0",
-				abono_seguro: "0",
-				abono_gps: "0",
-				pago_del_mes: "0",
-				monto_boleta: "0",
-				capital_restante: capitalIncobrable.toString(),
-				interes_restante: "0",
-				iva_12_restante: "0",
-				seguro_restante: "0",
-				gps_restante: "0",
-				total_restante: capitalIncobrable.toString(),
-				membresias: "0",
-				membresias_pago: "0",
-				membresias_mes: "0",
-				mora: "0",
-				monto_boleta_cuota: "0",
-				seguro_total: "0",
-				pagado: false,
-				registerBy: "SISTEMA-INCOBRABLE",
-				pagoConvenio: "0",
-				monto_aplicado: "0",
-				observaciones: `Pago base - Crédito marcado como incobrable: ${motivo}`,
-			});
+      // f) Crear pago base con capital_restante = capital, enlazado a la cuota recién creada
+      await tx.insert(pagos_credito).values({
+        credito_id: creditId,
+        cuota: capitalIncobrable.toString(),
+        cuota_interes: "0",
+        cuota_id: cuotaIncobrableInsertada.cuota_id,
+        abono_capital: "0",
+        abono_interes: "0",
+        abono_iva_12: "0",
+        abono_interes_ci: "0",
+        abono_iva_ci: "0",
+        abono_seguro: "0",
+        abono_gps: "0",
+        pago_del_mes: "0",
+        monto_boleta: "0",
+        capital_restante: capitalIncobrable.toString(),
+        interes_restante: "0",
+        iva_12_restante: "0",
+        seguro_restante: "0",
+        gps_restante: "0",
+        total_restante: capitalIncobrable.toString(),
+        membresias: "0",
+        membresias_pago: "0",
+        membresias_mes: "0",
+        mora: "0",
+        monto_boleta_cuota: "0",
+        seguro_total: "0",
+        pagado: false,
+        registerBy: "SISTEMA-INCOBRABLE",
+        pagoConvenio: "0",
+        monto_aplicado: "0",
+        observaciones: `Pago base - Crédito marcado como incobrable: ${motivo}`,
+      });
 
-			// h) Register bad debt
-			await tx.insert(bad_debts).values({
-				credit_id: creditId,
-				motivo: motivo!,
-				observaciones: observaciones ?? "",
-				monto_incobrable: monto_cancelacion!.toString(),
-			});
+      // h) Register bad debt
+      await tx.insert(bad_debts).values({
+        credit_id: creditId,
+        motivo: motivo!,
+        observaciones: observaciones ?? "",
+        monto_incobrable: monto_cancelacion!.toString(),
+      });
 
-			return {
-				ok: true,
-				message: `Crédito #${creditId} marcado como incobrable. Capital: Q${capitalIncobrable.toString()}, Plazo: 1, Cuota: Q${capitalIncobrable.toString()}, ${
-					pagoIds.length
-				} pagos anulados.`,
-			};
-		});
+      return {
+        ok: true,
+        message: `Crédito #${creditId} marcado como incobrable. Capital: Q${capitalIncobrable.toString()}, Plazo: 1, Cuota: Q${capitalIncobrable.toString()}, ${pagoIds.length} pagos anulados.`,
+      };
+    });
 
-		return result;
-	} catch (err) {
-		console.error("[ERROR] actualizarEstadoCredito:", err);
-		return {
-			ok: false,
-			message: "[ERROR] No fue posible actualizar el estado del crédito",
-		};
-	}
+    return result;
+  } catch (err) {
+    console.error("[ERROR] actualizarEstadoCredito:", err);
+    return {
+      ok: false,
+      message: "[ERROR] No fue posible actualizar el estado del crédito",
+    };
+  }
 }
 /**
  * Obtiene todos los créditos marcados como incobrables, junto con su usuario e información relevante.
@@ -1747,846 +1677,822 @@ export async function actualizarEstadoCredito(input: AccionCreditoParams) {
  * @param numero_credito_sifco (opcional) Número de crédito SIFCO para filtrar
  */
 export async function getCreditosIncobrables(
-	page: number = 1,
-	perPage: number = 20,
-	numero_credito_sifco?: string,
+  page: number = 1,
+  perPage: number = 20,
+  numero_credito_sifco?: string
 ) {
-	try {
-		console.log(
-			"[getCreditosIncobrables] Iniciando consulta de créditos incobrables...",
-		);
-		const offset = (page - 1) * perPage;
+  try {
+    console.log(
+      "[getCreditosIncobrables] Iniciando consulta de créditos incobrables..."
+    );
+    const offset = (page - 1) * perPage;
 
-		// Condición de filtro opcional por número de crédito SIFCO
-		const whereCondition =
-			numero_credito_sifco && numero_credito_sifco.length > 0
-				? and(
-						eq(creditos.statusCredit, "INCOBRABLE"),
-						eq(creditos.numero_credito_sifco, numero_credito_sifco),
-					)
-				: eq(creditos.statusCredit, "INCOBRABLE");
+    // Condición de filtro opcional por número de crédito SIFCO
+    const whereCondition =
+      numero_credito_sifco && numero_credito_sifco.length > 0
+        ? and(
+            eq(creditos.statusCredit, "INCOBRABLE"),
+            eq(creditos.numero_credito_sifco, numero_credito_sifco)
+          )
+        : eq(creditos.statusCredit, "INCOBRABLE");
 
-		// Buscar créditos incobrables paginados
-		const creditosIncobrables = await db
-			.select({
-				creditos,
-				usuarios,
-				asesores,
-				bad_debt: bad_debts,
-			})
-			.from(creditos)
-			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-			.innerJoin(bad_debts, eq(creditos.credito_id, bad_debts.credit_id))
-			.where(eq(creditos.statusCredit, "INCOBRABLE"))
-			.orderBy(desc(creditos.fecha_creacion))
-			.limit(perPage)
-			.offset(offset);
+    // Buscar créditos incobrables paginados
+    const creditosIncobrables = await db
+      .select({
+        creditos,
+        usuarios,
+        asesores,
+        bad_debt: bad_debts,
+      })
+      .from(creditos)
+      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+      .innerJoin(bad_debts, eq(creditos.credito_id, bad_debts.credit_id))
+      .where(eq(creditos.statusCredit, "INCOBRABLE"))
+      .orderBy(desc(creditos.fecha_creacion))
+      .limit(perPage)
+      .offset(offset);
 
-		// Total para paginación
-		const [{ count }] = await db
-			.select({ count: sql<number>`COUNT(*)` })
-			.from(creditos)
-			.where(eq(creditos.statusCredit, "INCOBRABLE"));
+    // Total para paginación
+    const [{ count }] = await db
+      .select({ count: sql<number>`COUNT(*)` })
+      .from(creditos)
+      .where(eq(creditos.statusCredit, "INCOBRABLE"));
 
-		console.log(
-			`[getCreditosIncobrables] Créditos incobrables encontrados: ${creditosIncobrables.length}`,
-		);
-		return {
-			ok: true,
-			data: creditosIncobrables,
-			page,
-			perPage,
-			totalCount: Number(count),
-			totalPages: Math.ceil(Number(count) / perPage),
-		};
-	} catch (error) {
-		console.error(
-			"[getCreditosIncobrables] Error al obtener créditos incobrables:",
-			error,
-		);
-		return {
-			ok: false,
-			message: "Error al obtener créditos incobrables",
-			error: String(error),
-		};
-	}
+    console.log(
+      `[getCreditosIncobrables] Créditos incobrables encontrados: ${creditosIncobrables.length}`
+    );
+    return {
+      ok: true,
+      data: creditosIncobrables,
+      page,
+      perPage,
+      totalCount: Number(count),
+      totalPages: Math.ceil(Number(count) / perPage),
+    };
+  } catch (error) {
+    console.error(
+      "[getCreditosIncobrables] Error al obtener créditos incobrables:",
+      error
+    );
+    return {
+      ok: false,
+      message: "Error al obtener créditos incobrables",
+      error: String(error),
+    };
+  }
 }
 
 export async function reiniciarCredito(
-	creditId: number,
-	montoIncobrable?: number,
+  creditId: number,
+  montoIncobrable?: number
 ) {
-	await withCapitalContext(null, "REINICIO", null, (tx) =>
-		tx
-			.update(creditos)
-			.set({
-				capital: "0",
-				deudatotal:
-					montoIncobrable !== undefined ? String(montoIncobrable) : "0",
-				cuota_interes: "0",
-				cuota: "0",
-				iva_12: "0",
-				seguro_10_cuotas: "0",
-				gps: "0",
-				membresias_pago: "0",
-				membresias: "0",
-				porcentaje_royalti: "0",
-				royalti: "0",
-				otros: "0",
-				statusCredit: "ACTIVO",
-			})
-			.where(eq(creditos.credito_id, creditId)),
-	);
+  await withCapitalContext(null, "REINICIO", null, (tx) =>
+    tx
+      .update(creditos)
+      .set({
+        capital: "0",
+        deudatotal: montoIncobrable !== undefined ? String(montoIncobrable) : "0",
+        cuota_interes: "0",
+        cuota: "0",
+        iva_12: "0",
+        seguro_10_cuotas: "0",
+        gps: "0",
+        membresias_pago: "0",
+        membresias: "0",
+        porcentaje_royalti: "0",
+        royalti: "0",
+        otros: "0",
+        statusCredit: "ACTIVO",
+      })
+      .where(eq(creditos.credito_id, creditId))
+  );
 }
 
 function construirUrlBoletas(url_boletas: string[], r2BaseUrl: string) {
-	return url_boletas.map((url_boleta) => `${r2BaseUrl}${url_boleta}`);
+  return url_boletas.map((url_boleta) => `${r2BaseUrl}${url_boleta}`);
 }
 export async function resetCredit({
-	creditId,
-	montoIncobrable,
-	montoBoleta,
-	url_boletas,
-	cuota,
-	banco_id,
-	numeroAutorizacion,
+  creditId,
+  montoIncobrable,
+  montoBoleta,
+  url_boletas,
+  cuota,
+  banco_id,
+  numeroAutorizacion,
 }: {
-	creditId: number;
-	montoIncobrable?: number;
-	montoBoleta: number | string;
-	url_boletas: string[];
-	cuota: number;
-	banco_id: number;
-	numeroAutorizacion?: string;
+  creditId: number;
+  montoIncobrable?: number;
+  montoBoleta: number | string;
+  url_boletas: string[];
+  cuota: number;
+  banco_id: number;
+  numeroAutorizacion?: string;
 }) {
-	try {
-		// 1. Jalar mora activa (si existe, se incluye en el pago de cierre)
-		const [moraActiva] = await db
-			.select({ monto_mora: moras_credito.monto_mora })
-			.from(moras_credito)
-			.where(
-				and(
-					eq(moras_credito.credito_id, creditId),
-					eq(moras_credito.activa, true),
-				),
-			)
-			.limit(1);
+  try {
+    // 1. Jalar mora activa (si existe, se incluye en el pago de cierre)
+    const [moraActiva] = await db
+      .select({ monto_mora: moras_credito.monto_mora })
+      .from(moras_credito)
+      .where(
+        and(
+          eq(moras_credito.credito_id, creditId),
+          eq(moras_credito.activa, true)
+        )
+      )
+      .limit(1);
 
-		const moraBig = new Big(
-			(moraActiva?.monto_mora as unknown as string) ?? "0",
-		);
+    const moraBig = new Big(moraActiva?.monto_mora as unknown as string ?? "0");
 
-		// 2. Consultar crédito ANTES de resetearlo (necesitamos los valores originales)
-		const [credito] = await db
-			.select()
-			.from(creditos)
-			.where(eq(creditos.credito_id, creditId));
-		if (!credito) {
-			throw new Error("Crédito no encontrado.");
-		}
-		if (!canResetCreditByStatus(credito.statusCredit)) {
-			throw new Error("El crédito no está pendiente de cancelación.");
-		}
+    // 2. Consultar crédito ANTES de resetearlo (necesitamos los valores originales)
+    const [credito] = await db
+      .select()
+      .from(creditos)
+      .where(eq(creditos.credito_id, creditId));
+    if (!credito) {
+      throw new Error("Crédito no encontrado.");
+    }
+    if (!canResetCreditByStatus(credito.statusCredit)) {
+      throw new Error("El crédito no está pendiente de cancelación.");
+    }
 
-		// 3. Determinar el estado del crédito
-		const statusCredit =
-			typeof montoIncobrable !== "undefined" &&
-			montoIncobrable > 0 &&
-			montoBoleta !== undefined
-				? "INCOBRABLE"
-				: "CANCELADO";
+    // 3. Determinar el estado del crédito
+    const statusCredit =
+      typeof montoIncobrable !== "undefined" &&
+      montoIncobrable > 0 &&
+      montoBoleta !== undefined
+        ? "INCOBRABLE"
+        : "CANCELADO";
 
-		// 4. Jalar la cancelación para obtener cuotas_atrasadas, garantía, traspaso, otros
-		const [cancelacion] = await db
-			.select()
-			.from(credit_cancelations)
-			.where(eq(credit_cancelations.credit_id, creditId))
-			.limit(1);
+    // 4. Jalar la cancelación para obtener cuotas_atrasadas, garantía, traspaso, otros
+    const [cancelacion] = await db
+      .select()
+      .from(credit_cancelations)
+      .where(eq(credit_cancelations.credit_id, creditId))
+      .limit(1);
 
-		const n = cancelacion?.cuotas_atrasadas ?? 0;
+    const n = cancelacion?.cuotas_atrasadas ?? 0;
 
-		// 5. Jalar extras (montos_adicionales)
-		const extrasRows = await db
-			.select({ monto: montos_adicionales.monto })
-			.from(montos_adicionales)
-			.where(eq(montos_adicionales.credit_id, creditId));
+    // 5. Jalar extras (montos_adicionales)
+    const extrasRows = await db
+      .select({ monto: montos_adicionales.monto })
+      .from(montos_adicionales)
+      .where(eq(montos_adicionales.credit_id, creditId));
 
-		const totalExtras = extrasRows.reduce(
-			(acc, row) => acc.plus(row.monto as unknown as string),
-			new Big(0),
-		);
+    const totalExtras = extrasRows.reduce(
+      (acc, row) => acc.plus(row.monto as unknown as string),
+      new Big(0)
+    );
 
-		// 6. Calcular abonos reales
-		const capitalOriginal = new Big(credito.capital ?? "0");
-		const abonoCapital =
-			statusCredit === "INCOBRABLE"
-				? capitalOriginal.minus(new Big(montoIncobrable!))
-				: capitalOriginal;
-		const abonoInteres = new Big(credito.cuota_interes ?? "0").times(n);
-		const abonoIva = new Big(credito.iva_12 ?? "0").times(n);
-		const abonoSeguro = new Big(credito.seguro_10_cuotas ?? "0").times(n);
-		const abonoGps = new Big(credito.gps ?? "0").times(n);
-		const abonoMembresias = new Big(credito.membresias ?? "0").times(n);
+    // 6. Calcular abonos reales
+    const capitalOriginal = new Big(credito.capital ?? "0");
+    const abonoCapital = statusCredit === "INCOBRABLE"
+      ? capitalOriginal.minus(new Big(montoIncobrable!))
+      : capitalOriginal;
+    const abonoInteres = new Big(credito.cuota_interes ?? "0").times(n);
+    const abonoIva = new Big(credito.iva_12 ?? "0").times(n);
+    const abonoSeguro = new Big(credito.seguro_10_cuotas ?? "0").times(n);
+    const abonoGps = new Big(credito.gps ?? "0").times(n);
+    const abonoMembresias = new Big(credito.membresias ?? "0").times(n);
 
-		const otrosCancelacion = new Big(cancelacion?.garantia_mobiliaria ?? "0")
-			.plus(cancelacion?.traspaso ?? "0")
-			.plus(cancelacion?.otros ?? "0")
-			.plus(totalExtras);
+    const otrosCancelacion = new Big(cancelacion?.garantia_mobiliaria ?? "0")
+      .plus(cancelacion?.traspaso ?? "0")
+      .plus(cancelacion?.otros ?? "0")
+      .plus(totalExtras);
 
-		const totalMontoPago = abonoCapital
-			.plus(abonoInteres)
-			.plus(abonoIva)
-			.plus(abonoSeguro)
-			.plus(abonoGps)
-			.plus(abonoMembresias)
-			.plus(otrosCancelacion)
-			.plus(moraBig);
+    const totalMontoPago = abonoCapital
+      .plus(abonoInteres)
+      .plus(abonoIva)
+      .plus(abonoSeguro)
+      .plus(abonoGps)
+      .plus(abonoMembresias)
+      .plus(otrosCancelacion)
+      .plus(moraBig);
 
-		// 7. Construir URLs de boletas
-		const r2BaseUrl = import.meta.env.URL_PUBLIC_R2 ?? "";
-		const urlCompletas = construirUrlBoletas(url_boletas, r2BaseUrl);
+    // 7. Construir URLs de boletas
+    const r2BaseUrl = import.meta.env.URL_PUBLIC_R2 ?? "";
+    const urlCompletas = construirUrlBoletas(url_boletas, r2BaseUrl);
 
-		// 8. Obtener pagos del mes + monto de boleta
-		const pago_del_mes = await getPagosDelMesActual(credito.credito_id);
-		const pago_del_mesBig = new Big(pago_del_mes ?? 0).add(montoBoleta ?? 0);
+    // 8. Obtener pagos del mes + monto de boleta
+    const pago_del_mes = await getPagosDelMesActual(credito.credito_id);
+    const pago_del_mesBig = new Big(pago_del_mes ?? 0).add(montoBoleta ?? 0);
 
-		// 9. Buscar cuota_id correspondiente
-		const [cuotaEncontrada] = await db
-			.select({ cuota_id: cuotas_credito.cuota_id })
-			.from(cuotas_credito)
-			.where(
-				and(
-					eq(cuotas_credito.credito_id, credito.credito_id),
-					eq(cuotas_credito.numero_cuota, cuota),
-				),
-			)
-			.limit(1);
+    // 9. Buscar cuota_id correspondiente
+    const [cuotaEncontrada] = await db
+      .select({ cuota_id: cuotas_credito.cuota_id })
+      .from(cuotas_credito)
+      .where(
+        and(
+          eq(cuotas_credito.credito_id, credito.credito_id),
+          eq(cuotas_credito.numero_cuota, cuota)
+        )
+      )
+      .limit(1);
 
-		const cuotaId = cuotaEncontrada?.cuota_id;
+    const cuotaId = cuotaEncontrada?.cuota_id;
 
-		// 10. Insertar pago de cierre con abonos reales
-		const [nuevoPago] = await db
-			.insert(pagos_credito)
-			.values({
-				credito_id: credito.credito_id,
-				cuota_id: cuotaId,
-				cuota: credito.cuota?.toString() ?? "0",
-				cuota_interes: credito.cuota_interes?.toString() ?? "0",
-				abono_capital: abonoCapital.toString(),
-				abono_interes: abonoInteres.toString(),
-				abono_iva_12: abonoIva.toString(),
-				abono_interes_ci: "0",
-				abono_iva_ci: "0",
-				abono_seguro: abonoSeguro.toString(),
-				abono_gps: abonoGps.toString(),
-				pago_del_mes: pago_del_mesBig.toString(),
-				monto_boleta: montoBoleta.toString(),
-				capital_restante: "0",
-				interes_restante: "0",
-				iva_12_restante: "0",
-				seguro_restante: "0",
-				gps_restante: "0",
-				total_restante: "0",
-				llamada: "",
-				renuevo_o_nuevo: "renuevo",
-				membresias: "0",
-				membresias_pago: abonoMembresias.toString(),
-				membresias_mes: abonoMembresias.toString(),
-				otros: otrosCancelacion.toString(),
-				mora: moraBig.toString(),
-				monto_boleta_cuota: montoBoleta.toString(),
-				seguro_total: credito.seguro_10_cuotas?.toString() ?? "0",
-				pagado: true,
-				facturacion: "si",
-				mes_pagado: "",
-				seguro_facturado: abonoSeguro.toString(),
-				gps_facturado: abonoGps.toString(),
-				reserva: "0",
-				observaciones: "",
-				validationStatus: "reset" as const,
-				banco_id: banco_id,
-				numeroAutorizacion: numeroAutorizacion ?? "",
-				registerBy: "system_reset",
-				pagoConvenio: "0",
-				monto_aplicado: totalMontoPago.toString(),
-			})
-			.returning();
+    // 10. Insertar pago de cierre con abonos reales
+    const [nuevoPago] = await db
+      .insert(pagos_credito)
+      .values({
+        credito_id: credito.credito_id,
+        cuota_id: cuotaId,
+        cuota: credito.cuota?.toString() ?? "0",
+        cuota_interes: credito.cuota_interes?.toString() ?? "0",
+        abono_capital: abonoCapital.toString(),
+        abono_interes: abonoInteres.toString(),
+        abono_iva_12: abonoIva.toString(),
+        abono_interes_ci: "0",
+        abono_iva_ci: "0",
+        abono_seguro: abonoSeguro.toString(),
+        abono_gps: abonoGps.toString(),
+        pago_del_mes: pago_del_mesBig.toString(),
+        monto_boleta: montoBoleta.toString(),
+        capital_restante: "0",
+        interes_restante: "0",
+        iva_12_restante: "0",
+        seguro_restante: "0",
+        gps_restante: "0",
+        total_restante: "0",
+        llamada: "",
+        renuevo_o_nuevo: "renuevo",
+        membresias: "0",
+        membresias_pago: abonoMembresias.toString(),
+        membresias_mes: abonoMembresias.toString(),
+        otros: otrosCancelacion.toString(),
+        mora: moraBig.toString(),
+        monto_boleta_cuota: montoBoleta.toString(),
+        seguro_total: credito.seguro_10_cuotas?.toString() ?? "0",
+        pagado: true,
+        facturacion: "si",
+        mes_pagado: "",
+        seguro_facturado: abonoSeguro.toString(),
+        gps_facturado: abonoGps.toString(),
+        reserva: "0",
+        observaciones: "",
+        validationStatus: "reset" as const,
+        banco_id: banco_id,
+        numeroAutorizacion: numeroAutorizacion ?? "",
+        registerBy: "system_reset",
+        pagoConvenio: "0",
+        monto_aplicado: totalMontoPago.toString(),
+      })
+      .returning();
 
-		// 11. Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
-		//     paymentFalse=true). Además se ponen los *_restante en 0: algunas queries de
-		//     cuotas pendientes/atrasadas (getCreditoByNumero, reportes) NO filtran paymentFalse,
-		//     así que sin esto mostrarían "deuda fantasma" con los restantes viejos.
-		await db
-			.update(pagos_credito)
-			.set({
-				paymentFalse: true,
-				capital_restante: "0",
-				interes_restante: "0",
-				iva_12_restante: "0",
-				seguro_restante: "0",
-				gps_restante: "0",
-				total_restante: "0",
-				mora: "0",
-			})
-			.where(
-				and(
-					eq(pagos_credito.credito_id, credito.credito_id),
-					eq(pagos_credito.pagado, false),
-				),
-			);
+    // 11. Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
+    //     paymentFalse=true). Además se ponen los *_restante en 0: algunas queries de
+    //     cuotas pendientes/atrasadas (getCreditoByNumero, reportes) NO filtran paymentFalse,
+    //     así que sin esto mostrarían "deuda fantasma" con los restantes viejos.
+    await db
+      .update(pagos_credito)
+      .set({
+        paymentFalse: true,
+        capital_restante: "0",
+        interes_restante: "0",
+        iva_12_restante: "0",
+        seguro_restante: "0",
+        gps_restante: "0",
+        total_restante: "0",
+        mora: "0",
+      })
+      .where(
+        and(
+          eq(pagos_credito.credito_id, credito.credito_id),
+          eq(pagos_credito.pagado, false)
+        )
+      );
 
-		// 12.1 Crear cuota correlativa (MAX(numero_cuota) + 1) para enlazar el pago de cierre
-		const [maxCuotaRow] = await db
-			.select({
-				max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
-			})
-			.from(cuotas_credito)
-			.where(eq(cuotas_credito.credito_id, credito.credito_id));
-		const nextNumeroCuotaCierre = Number(maxCuotaRow?.max ?? 0) + 1;
+    // 12.1 Crear cuota correlativa (MAX(numero_cuota) + 1) para enlazar el pago de cierre
+    const [maxCuotaRow] = await db
+      .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
+      .from(cuotas_credito)
+      .where(eq(cuotas_credito.credito_id, credito.credito_id));
+    const nextNumeroCuotaCierre = Number(maxCuotaRow?.max ?? 0) + 1;
 
-		const [cuotaCierre] = await db
-			.insert(cuotas_credito)
-			.values({
-				credito_id: credito.credito_id,
-				numero_cuota: nextNumeroCuotaCierre,
-				fecha_vencimiento: new Date().toLocaleDateString("sv-SE", {
-					timeZone: "America/Guatemala",
-				}),
-				liquidado_inversionistas: false,
-				pagado: true,
-			})
-			.returning();
+    const [cuotaCierre] = await db
+      .insert(cuotas_credito)
+      .values({
+        credito_id: credito.credito_id,
+        numero_cuota: nextNumeroCuotaCierre,
+        fecha_vencimiento: new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" }),
+        liquidado_inversionistas: false,
+        pagado: true,
+      })
+      .returning();
 
-		// 12.2 Enlazar el pago de cierre a la cuota recién creada (cuota correlativa "pagada"),
-		// para que el cierre quede asociado a una cuota limpia y no a una cuota vigente del plan.
-		if (nuevoPago?.pago_id && cuotaCierre?.cuota_id) {
-			await db
-				.update(pagos_credito)
-				.set({ cuota_id: cuotaCierre.cuota_id })
-				.where(eq(pagos_credito.pago_id, nuevoPago.pago_id));
-		}
+    // 12.2 Enlazar el pago de cierre a la cuota recién creada (cuota correlativa "pagada"),
+    // para que el cierre quede asociado a una cuota limpia y no a una cuota vigente del plan.
+    if (nuevoPago?.pago_id && cuotaCierre?.cuota_id) {
+      await db
+        .update(pagos_credito)
+        .set({ cuota_id: cuotaCierre.cuota_id })
+        .where(eq(pagos_credito.pago_id, nuevoPago.pago_id));
+    }
 
-		// 12. Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
-		//     anulados (paymentFalse=true) en el paso 11, así que no aportan saldo en las vistas activas.
+    // 12. Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
+    //     anulados (paymentFalse=true) en el paso 11, así que no aportan saldo en las vistas activas.
 
-		// 12.5 Distribuir abono a capital en tabla espejo (CANCELACION)
-		try {
-			await distribuirAbonoCapitalEspejo(
-				credito.credito_id,
-				abonoCapital.toString(),
-				"CANCELACION",
-			);
-			console.log(
-				"✅ Abono capital (reset) distribuido en tabla abonos_capital (espejo)",
-			);
-		} catch (err) {
-			console.error("⚠️ Error al distribuir abono en espejo (reset):", err);
-		}
+    // 12.5 Distribuir abono a capital en tabla espejo (CANCELACION)
+    try {
+      await distribuirAbonoCapitalEspejo(credito.credito_id, abonoCapital.toString(), "CANCELACION");
+      console.log("✅ Abono capital (reset) distribuido en tabla abonos_capital (espejo)");
+    } catch (err) {
+      console.error("⚠️ Error al distribuir abono en espejo (reset):", err);
+    }
 
-		// 13. Distribuir pago entre inversionistas (ANTES de reiniciar, necesita monto_aportado).
-		//     Si la suma de aportes es 0 (p.ej. crédito ya reseteado antes) la distribución lanza
-		//     excepción; la atrapamos para no abortar el cierre del crédito.
-		if (nuevoPago?.pago_id) {
-			try {
-				await insertPagosCreditoInversionistasV2(
-					nuevoPago.pago_id,
-					credito.credito_id,
-				);
-			} catch (err) {
-				// Solo silenciamos el caso conocido y benigno: crédito SIN aportes (suma = 0),
-				// típico de un crédito ya reseteado antes. Cualquier otro fallo (inversionistas o
-				// pagos faltantes, error de DB, distribución a medias) SÍ se re-lanza: dejar el
-				// cierre sin liquidación de inversionistas e irreintentable sería peor.
-				const msg = err instanceof Error ? err.message : String(err);
-				if (msg.includes("suma de montos aportados es 0")) {
-					console.warn(
-						`⚠️ Distribución a inversionistas omitida (crédito ${credito.credito_id} sin aportes).`,
-					);
-				} else {
-					throw err;
-				}
-			}
-		}
+    // 13. Distribuir pago entre inversionistas (ANTES de reiniciar, necesita monto_aportado).
+    //     Si la suma de aportes es 0 (p.ej. crédito ya reseteado antes) la distribución lanza
+    //     excepción; la atrapamos para no abortar el cierre del crédito.
+    if (nuevoPago?.pago_id) {
+      try {
+        await insertPagosCreditoInversionistasV2(
+          nuevoPago.pago_id,
+          credito.credito_id
+        );
+      } catch (err) {
+        // Solo silenciamos el caso conocido y benigno: crédito SIN aportes (suma = 0),
+        // típico de un crédito ya reseteado antes. Cualquier otro fallo (inversionistas o
+        // pagos faltantes, error de DB, distribución a medias) SÍ se re-lanza: dejar el
+        // cierre sin liquidación de inversionistas e irreintentable sería peor.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("suma de montos aportados es 0")) {
+          console.warn(
+            `⚠️ Distribución a inversionistas omitida (crédito ${credito.credito_id} sin aportes).`
+          );
+        } else {
+          throw err;
+        }
+      }
+    }
 
-		// 14. Reiniciar creditos_inversionistas (no espejo)
-		await db
-			.update(creditos_inversionistas)
-			.set({
-				monto_aportado: "0",
-				monto_inversionista: "0",
-				monto_cash_in: "0",
-				iva_inversionista: "0",
-				iva_cash_in: "0",
-			})
-			.where(eq(creditos_inversionistas.credito_id, credito.credito_id));
+    // 14. Reiniciar creditos_inversionistas (no espejo)
+    await db
+      .update(creditos_inversionistas)
+      .set({
+        monto_aportado: "0",
+        monto_inversionista: "0",
+        monto_cash_in: "0",
+        iva_inversionista: "0",
+        iva_cash_in: "0",
+      })
+      .where(eq(creditos_inversionistas.credito_id, credito.credito_id));
 
-		// 15. Insertar boletas si existen
-		if (
-			urlCompletas &&
-			urlCompletas.length > 0 &&
-			nuevoPago &&
-			nuevoPago?.pago_id
-		) {
-			await db.insert(boletas).values(
-				urlCompletas.map((url) => ({
-					pago_id: nuevoPago?.pago_id,
-					url_boleta: url,
-				})),
-			);
-		}
+    // 15. Insertar boletas si existen
+    if (
+      urlCompletas &&
+      urlCompletas.length > 0 &&
+      nuevoPago &&
+      nuevoPago?.pago_id
+    ) {
+      await db.insert(boletas).values(
+        urlCompletas.map((url) => ({
+          pago_id: nuevoPago?.pago_id,
+          url_boleta: url,
+        }))
+      );
+    }
 
-		// 16. Al final: zerear el crédito y ponerle el status
-		const fechaHoyGT = new Date().toLocaleDateString("sv-SE", {
-			timeZone: "America/Guatemala",
-		});
+    // 16. Al final: zerear el crédito y ponerle el status
+    const fechaHoyGT = new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
 
-		if (statusCredit === "INCOBRABLE") {
-			const capitalIncobrable = new Big(montoIncobrable!);
+    if (statusCredit === "INCOBRABLE") {
+      const capitalIncobrable = new Big(montoIncobrable!);
 
-			// 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
-			await withCapitalContext(null, "CASTIGO", null, (tx) =>
-				tx
-					.update(creditos)
-					.set({
-						capital: capitalIncobrable.toString(),
-						deudatotal: capitalIncobrable.toString(),
-						cuota_interes: "0",
-						cuota: capitalIncobrable.toString(),
-						iva_12: "0",
-						seguro_10_cuotas: "0",
-						gps: "0",
-						membresias_pago: "0",
-						membresias: "0",
-						porcentaje_royalti: "0",
-						royalti: "0",
-						otros: "0",
-						plazo: 1,
-						statusCredit: "INCOBRABLE",
-					})
-					.where(eq(creditos.credito_id, creditId)),
-			);
+      // 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
+      await withCapitalContext(null, "CASTIGO", null, (tx) =>
+        tx
+          .update(creditos)
+          .set({
+            capital: capitalIncobrable.toString(),
+            deudatotal: capitalIncobrable.toString(),
+            cuota_interes: "0",
+            cuota: capitalIncobrable.toString(),
+            iva_12: "0",
+            seguro_10_cuotas: "0",
+            gps: "0",
+            membresias_pago: "0",
+            membresias: "0",
+            porcentaje_royalti: "0",
+            royalti: "0",
+            otros: "0",
+            plazo: 1,
+            statusCredit: "INCOBRABLE",
+          })
+          .where(eq(creditos.credito_id, creditId))
+      );
 
-			// 16b. Crear cuota pendiente para el monto incobrable (correlativa)
-			const [maxCuotaRowInc] = await db
-				.select({
-					max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
-				})
-				.from(cuotas_credito)
-				.where(eq(cuotas_credito.credito_id, credito.credito_id));
-			const nextNumeroCuotaPendiente = Number(maxCuotaRowInc?.max ?? 0) + 1;
+      // 16b. Crear cuota pendiente para el monto incobrable (correlativa)
+      const [maxCuotaRowInc] = await db
+        .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
+        .from(cuotas_credito)
+        .where(eq(cuotas_credito.credito_id, credito.credito_id));
+      const nextNumeroCuotaPendiente = Number(maxCuotaRowInc?.max ?? 0) + 1;
 
-			const [cuotaPendiente] = await db
-				.insert(cuotas_credito)
-				.values({
-					credito_id: credito.credito_id,
-					numero_cuota: nextNumeroCuotaPendiente,
-					fecha_vencimiento: fechaHoyGT,
-					pagado: false,
-					liquidado_inversionistas: false,
-				})
-				.returning();
+      const [cuotaPendiente] = await db
+        .insert(cuotas_credito)
+        .values({
+          credito_id: credito.credito_id,
+          numero_cuota: nextNumeroCuotaPendiente,
+          fecha_vencimiento: fechaHoyGT,
+          pagado: false,
+          liquidado_inversionistas: false,
+        })
+        .returning();
 
-			// 16c. Crear pago placeholder (no pagado) con capital_restante = incobrable
-			await db.insert(pagos_credito).values({
-				credito_id: credito.credito_id,
-				cuota_id: cuotaPendiente.cuota_id,
-				cuota: capitalIncobrable.toString(),
-				cuota_interes: "0",
-				abono_capital: "0",
-				abono_interes: "0",
-				abono_iva_12: "0",
-				abono_interes_ci: "0",
-				abono_iva_ci: "0",
-				abono_seguro: "0",
-				abono_gps: "0",
-				pago_del_mes: "0",
-				monto_boleta: "0",
-				capital_restante: capitalIncobrable.toString(),
-				interes_restante: "0",
-				iva_12_restante: "0",
-				seguro_restante: "0",
-				gps_restante: "0",
-				total_restante: capitalIncobrable.toString(),
-				membresias: "0",
-				membresias_pago: "0",
-				membresias_mes: "0",
-				mora: "0",
-				monto_boleta_cuota: "0",
-				seguro_total: "0",
-				pagado: false,
-				registerBy: "SISTEMA-INCOBRABLE",
-				pagoConvenio: "0",
-				monto_aplicado: "0",
-				observaciones: `Pago base - Crédito marcado como incobrable (reset)`,
-			});
+      // 16c. Crear pago placeholder (no pagado) con capital_restante = incobrable
+      await db.insert(pagos_credito).values({
+        credito_id: credito.credito_id,
+        cuota_id: cuotaPendiente.cuota_id,
+        cuota: capitalIncobrable.toString(),
+        cuota_interes: "0",
+        abono_capital: "0",
+        abono_interes: "0",
+        abono_iva_12: "0",
+        abono_interes_ci: "0",
+        abono_iva_ci: "0",
+        abono_seguro: "0",
+        abono_gps: "0",
+        pago_del_mes: "0",
+        monto_boleta: "0",
+        capital_restante: capitalIncobrable.toString(),
+        interes_restante: "0",
+        iva_12_restante: "0",
+        seguro_restante: "0",
+        gps_restante: "0",
+        total_restante: capitalIncobrable.toString(),
+        membresias: "0",
+        membresias_pago: "0",
+        membresias_mes: "0",
+        mora: "0",
+        monto_boleta_cuota: "0",
+        seguro_total: "0",
+        pagado: false,
+        registerBy: "SISTEMA-INCOBRABLE",
+        pagoConvenio: "0",
+        monto_aplicado: "0",
+        observaciones: `Pago base - Crédito marcado como incobrable (reset)`,
+      });
 
-			// 16d. Registrar en bad_debts
-			await db.insert(bad_debts).values({
-				credit_id: creditId,
-				motivo: cancelacion?.motivo ?? "Incobrable",
-				observaciones: cancelacion?.observaciones ?? "",
-				monto_incobrable: capitalIncobrable.toString(),
-			});
-		} else {
-			// CANCELADO: zerear todo (preservamos porcentaje_interes)
-			await withCapitalContext(null, "CANCELACION", null, (tx) =>
-				tx
-					.update(creditos)
-					.set({
-						capital: "0",
-						deudatotal: "0",
-						cuota_interes: "0",
-						cuota: "0",
-						iva_12: "0",
-						seguro_10_cuotas: "0",
-						gps: "0",
-						membresias_pago: "0",
-						membresias: "0",
-						porcentaje_royalti: "0",
-						royalti: "0",
-						otros: "0",
-						statusCredit: "CANCELADO",
-					})
-					.where(eq(creditos.credito_id, creditId)),
-			);
-		}
+      // 16d. Registrar en bad_debts
+      await db.insert(bad_debts).values({
+        credit_id: creditId,
+        motivo: cancelacion?.motivo ?? "Incobrable",
+        observaciones: cancelacion?.observaciones ?? "",
+        monto_incobrable: capitalIncobrable.toString(),
+      });
+    } else {
+      // CANCELADO: zerear todo (preservamos porcentaje_interes)
+      await withCapitalContext(null, "CANCELACION", null, (tx) =>
+        tx
+          .update(creditos)
+          .set({
+            capital: "0",
+            deudatotal: "0",
+            cuota_interes: "0",
+            cuota: "0",
+            iva_12: "0",
+            seguro_10_cuotas: "0",
+            gps: "0",
+            membresias_pago: "0",
+            membresias: "0",
+            porcentaje_royalti: "0",
+            royalti: "0",
+            otros: "0",
+            statusCredit: "CANCELADO",
+          })
+          .where(eq(creditos.credito_id, creditId))
+      );
+    }
 
-		// 17. Retorno OK
-		return {
-			ok: true,
-			message:
-				statusCredit === "INCOBRABLE"
-					? `Crédito reiniciado como incobrable. Deuda pendiente: ${montoIncobrable}`
-					: "Crédito reiniciado y pago creado exitosamente.",
-		};
-	} catch (error) {
-		console.error("[ERROR] resetCredit:", error);
-		throw new Error(
-			error instanceof Error
-				? error.message
-				: "Error al reiniciar el crédito y crear el pago.",
-		);
-	}
+    // 17. Retorno OK
+    return {
+      ok: true,
+      message: statusCredit === "INCOBRABLE"
+        ? `Crédito reiniciado como incobrable. Deuda pendiente: ${montoIncobrable}`
+        : "Crédito reiniciado y pago creado exitosamente.",
+    };
+  } catch (error) {
+    console.error("[ERROR] resetCredit:", error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : "Error al reiniciar el crédito y crear el pago."
+    );
+  }
 }
 
 type SyncTermsInput = {
-	creditoId: number;
-	newCuota: number; // incoming updated cuota
-	newPlazo: number; // incoming updated plazo (months)
-	// Optional: pass preloaded credit to save a roundtrip (if you already fetched it)
-	preloadCredit?: {
-		cuota: string | number;
-		plazo: number;
-		capital: string | number;
-		porcentaje_interes: string | number;
-		iva_12: string | number;
-		deudatotal: string | number;
-		seguro_10_cuotas: string | number;
-		gps: string | number;
-		membresias_pago: string | number;
-		formato_credito?: string | null;
-	};
+  creditoId: number;
+  newCuota: number; // incoming updated cuota
+  newPlazo: number; // incoming updated plazo (months)
+  // Optional: pass preloaded credit to save a roundtrip (if you already fetched it)
+  preloadCredit?: {
+    cuota: string | number;
+    plazo: number;
+    capital: string | number;
+    porcentaje_interes: string | number;
+    iva_12: string | number;
+    deudatotal: string | number;
+    seguro_10_cuotas: string | number;
+    gps: string | number;
+    membresias_pago: string | number;
+    formato_credito?: string | null;
+  };
 };
 
 export async function syncScheduleOnTermsChange({
-	creditoId,
-	newCuota,
-	newPlazo,
-	preloadCredit,
+  creditoId,
+  newCuota,
+  newPlazo,
+  preloadCredit,
 }: SyncTermsInput) {
-	return await db.transaction(async (tx) => {
-		// 1) Load current credit
-		const [credit] = preloadCredit
-			? [{ credito_id: creditoId, ...preloadCredit }]
-			: await tx
-					.select({
-						credito_id: creditos.credito_id,
-						cuota: creditos.cuota,
-						plazo: creditos.plazo,
-						capital: creditos.capital,
-						porcentaje_interes: creditos.porcentaje_interes,
-						iva_12: creditos.iva_12,
-						deudatotal: creditos.deudatotal,
-						seguro_10_cuotas: creditos.seguro_10_cuotas,
-						gps: creditos.gps,
-						membresias_pago: creditos.membresias_pago,
-						formato_credito: creditos.formato_credito,
-					})
-					.from(creditos)
-					.where(eq(creditos.credito_id, creditoId));
+  return await db.transaction(async (tx) => {
+    // 1) Load current credit
+    const [credit] = preloadCredit
+      ? [{ credito_id: creditoId, ...preloadCredit }]
+      : await tx
+          .select({
+            credito_id: creditos.credito_id,
+            cuota: creditos.cuota,
+            plazo: creditos.plazo,
+            capital: creditos.capital,
+            porcentaje_interes: creditos.porcentaje_interes,
+            iva_12: creditos.iva_12,
+            deudatotal: creditos.deudatotal,
+            seguro_10_cuotas: creditos.seguro_10_cuotas,
+            gps: creditos.gps,
+            membresias_pago: creditos.membresias_pago,
+            formato_credito: creditos.formato_credito,
+          })
+          .from(creditos)
+          .where(eq(creditos.credito_id, creditoId));
 
-		if (!credit) {
-			throw new Error("[ERROR] Credit not found");
-		}
+    if (!credit) {
+      throw new Error("[ERROR] Credit not found");
+    }
 
-		const oldCuotaNum = Number(credit.cuota ?? 0);
-		const oldPlazoNum = Number(credit.plazo ?? 0);
-		const changedCuota = Number(newCuota) !== oldCuotaNum;
-		const changedPlazo = Number(newPlazo) !== oldPlazoNum;
+    const oldCuotaNum = Number(credit.cuota ?? 0);
+    const oldPlazoNum = Number(credit.plazo ?? 0);
+    const changedCuota = Number(newCuota) !== oldCuotaNum;
+    const changedPlazo = Number(newPlazo) !== oldPlazoNum;
 
-		if (!changedCuota && !changedPlazo) {
-			// Nothing to do
-			return { updated: false, reason: "No changes" };
-		}
+    if (!changedCuota && !changedPlazo) {
+      // Nothing to do
+      return { updated: false, reason: "No changes" };
+    }
 
-		// --- helper: generate due dates like your creation logic (30th or last day) ---
-		function generateNextDates(fromDateISO: string, count: number): string[] {
-			// fromDateISO = 'YYYY-MM-DD'
-			const [y, m, d] = fromDateISO.split("-").map((v) => Number(v));
-			const base = new Date(Date.UTC(y, m - 1, d, 12, 0, 0)); // noon UTC
-			const dates: string[] = [];
+    // --- helper: generate due dates like your creation logic (30th or last day) ---
+    function generateNextDates(fromDateISO: string, count: number): string[] {
+      // fromDateISO = 'YYYY-MM-DD'
+      const [y, m, d] = fromDateISO.split("-").map((v) => Number(v));
+      const base = new Date(Date.UTC(y, m - 1, d, 12, 0, 0)); // noon UTC
+      const dates: string[] = [];
 
-			for (let i = 0; i < count; i++) {
-				const dt = new Date(base);
-				// move month + i + 1 (next months)
-				dt.setUTCMonth(dt.getUTCMonth() + i + 1);
+      for (let i = 0; i < count; i++) {
+        const dt = new Date(base);
+        // move month + i + 1 (next months)
+        dt.setUTCMonth(dt.getUTCMonth() + i + 1);
 
-				const month = dt.getUTCMonth();
-				const year = dt.getUTCFullYear();
-				// last day of month
-				const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-				const day = lastDay < 30 ? lastDay : 30;
+        const month = dt.getUTCMonth();
+        const year = dt.getUTCFullYear();
+        // last day of month
+        const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+        const day = lastDay < 30 ? lastDay : 30;
 
-				const final = new Date(Date.UTC(year, month, day, 12, 0, 0));
-				// Return in 'sv-SE' like your logic (YYYY-MM-DD)
-				const iso = final
-					.toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
-					.toString();
-				dates.push(iso);
-			}
-			return dates;
-		}
+        const final = new Date(Date.UTC(year, month, day, 12, 0, 0));
+        // Return in 'sv-SE' like your logic (YYYY-MM-DD)
+        const iso = final
+          .toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
+          .toString();
+        dates.push(iso);
+      }
+      return dates;
+    }
 
-		// --- 2) If only cuota changed: update cuota in UNPAID payments ---
-		if (changedCuota && !changedPlazo) {
-			await tx
-				.update(pagos_credito)
-				.set({
-					// only cuota changes, everything else stays as-is
-					cuota: new Big(newCuota).round(2).toString(),
-				})
-				.where(
-					and(
-						eq(pagos_credito.credito_id, creditoId),
-						eq(pagos_credito.pagado, false),
-					),
-				);
+    // --- 2) If only cuota changed: update cuota in UNPAID payments ---
+    if (changedCuota && !changedPlazo) {
+      await tx
+        .update(pagos_credito)
+        .set({
+          // only cuota changes, everything else stays as-is
+          cuota: new Big(newCuota).round(2).toString(),
+        })
+        .where(
+          and(
+            eq(pagos_credito.credito_id, creditoId),
+            eq(pagos_credito.pagado, false)
+          )
+        );
 
-			// Reflect new cuota in creditos row (keeping your other totals untouched)
-			await tx
-				.update(creditos)
-				.set({ cuota: new Big(newCuota).round(2).toString() })
-				.where(eq(creditos.credito_id, creditoId));
+      // Reflect new cuota in creditos row (keeping your other totals untouched)
+      await tx
+        .update(creditos)
+        .set({ cuota: new Big(newCuota).round(2).toString() })
+        .where(eq(creditos.credito_id, creditoId));
 
-			return { updated: true, changedCuota: true, changedPlazo: false };
-		}
+      return { updated: true, changedCuota: true, changedPlazo: false };
+    }
 
-		// --- 3) If plazo changed: add/remove schedule, and also handle cuota change if applies ---
-		// Load current cuotas (excluding numero_cuota = 0 "cuota inicial")
-		const cuotasRows = await tx
-			.select({
-				cuota_id: cuotas_credito.cuota_id,
-				numero_cuota: cuotas_credito.numero_cuota,
-				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-				pagado: cuotas_credito.pagado,
-			})
-			.from(cuotas_credito)
-			.where(eq(cuotas_credito.credito_id, creditoId));
+    // --- 3) If plazo changed: add/remove schedule, and also handle cuota change if applies ---
+    // Load current cuotas (excluding numero_cuota = 0 "cuota inicial")
+    const cuotasRows = await tx
+      .select({
+        cuota_id: cuotas_credito.cuota_id,
+        numero_cuota: cuotas_credito.numero_cuota,
+        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+        pagado: cuotas_credito.pagado,
+      })
+      .from(cuotas_credito)
+      .where(eq(cuotas_credito.credito_id, creditoId));
 
-		const cuotasReal = cuotasRows.filter((c) => c.numero_cuota > 0);
-		const maxNumero = cuotasReal.reduce(
-			(acc, r) => Math.max(acc, Number(r.numero_cuota)),
-			0,
-		);
+    const cuotasReal = cuotasRows.filter((c) => c.numero_cuota > 0);
+    const maxNumero = cuotasReal.reduce(
+      (acc, r) => Math.max(acc, Number(r.numero_cuota)),
+      0
+    );
 
-		// Update cuota for unpaid rows if cuota also changed
-		if (changedCuota) {
-			await tx
-				.update(pagos_credito)
-				.set({
-					cuota: new Big(newCuota).round(2).toString(),
-				})
-				.where(
-					and(
-						eq(pagos_credito.credito_id, creditoId),
-						eq(pagos_credito.pagado, false),
-					),
-				);
-		}
+    // Update cuota for unpaid rows if cuota also changed
+    if (changedCuota) {
+      await tx
+        .update(pagos_credito)
+        .set({
+          cuota: new Big(newCuota).round(2).toString(),
+        })
+        .where(
+          and(
+            eq(pagos_credito.credito_id, creditoId),
+            eq(pagos_credito.pagado, false)
+          )
+        );
+    }
 
-		if (newPlazo > oldPlazoNum) {
-			// --- 3.a) Increase plazo: append missing cuotas & pagos ---
-			const toAppend = newPlazo - oldPlazoNum;
+    if (newPlazo > oldPlazoNum) {
+      // --- 3.a) Increase plazo: append missing cuotas & pagos ---
+      const toAppend = newPlazo - oldPlazoNum;
 
-			// last scheduled date to continue from:
-			const lastCuota = cuotasReal.sort(
-				(a, b) => a.numero_cuota - b.numero_cuota,
-			)[cuotasReal.length - 1];
-			const lastDateISO = lastCuota
-				? (lastCuota.fecha_vencimiento as string)
-				: // fallback: if for some reason there is no cuota > 0, base from today like insert
-					new Date()
-						.toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
-						.toString();
+      // last scheduled date to continue from:
+      const lastCuota = cuotasReal.sort(
+        (a, b) => a.numero_cuota - b.numero_cuota
+      )[cuotasReal.length - 1];
+      const lastDateISO = lastCuota
+        ? (lastCuota.fecha_vencimiento as string)
+        : // fallback: if for some reason there is no cuota > 0, base from today like insert
+          new Date()
+            .toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
+            .toString();
 
-			const newDates = generateNextDates(lastDateISO, toAppend);
+      const newDates = generateNextDates(lastDateISO, toAppend);
 
-			// Insert cuotas_credito batch
-			const newCuotasToInsert = newDates.map((fecha, idx) => ({
-				credito_id: creditoId,
-				numero_cuota: maxNumero + idx + 1,
-				fecha_vencimiento: fecha,
-				pagado: false,
-			}));
+      // Insert cuotas_credito batch
+      const newCuotasToInsert = newDates.map((fecha, idx) => ({
+        credito_id: creditoId,
+        numero_cuota: maxNumero + idx + 1,
+        fecha_vencimiento: fecha,
+        pagado: false,
+      }));
 
-			const insertedCuotas = await tx
-				.insert(cuotas_credito)
-				.values(newCuotasToInsert)
-				.returning({
-					cuota_id: cuotas_credito.cuota_id,
-					numero_cuota: cuotas_credito.numero_cuota,
-					fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-				});
+      const insertedCuotas = await tx
+        .insert(cuotas_credito)
+        .values(newCuotasToInsert)
+        .returning({
+          cuota_id: cuotas_credito.cuota_id,
+          numero_cuota: cuotas_credito.numero_cuota,
+          fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+        });
 
-			// Build pagos for each new cuota, mirroring your creation template
-			const cuotaStr = new Big(changedCuota ? newCuota : oldCuotaNum)
-				.round(2)
-				.toString();
+      // Build pagos for each new cuota, mirroring your creation template
+      const cuotaStr = new Big(changedCuota ? newCuota : oldCuotaNum)
+        .round(2)
+        .toString();
 
-			const pagosToInsert = insertedCuotas.map((c) => {
-				// 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
-				const [year, month, day] = c.fecha_vencimiento
-					.slice(0, 10)
-					.split("-")
-					.map(Number);
-				const fechaPagoLocal = new Date(year, month - 1, day);
+      const pagosToInsert = insertedCuotas.map((c) => {
+        // 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
+        const [year, month, day] = c.fecha_vencimiento.slice(0, 10).split("-").map(Number);
+        const fechaPagoLocal = new Date(year, month - 1, day);
 
-				return {
-					credito_id: creditoId,
-					cuota: cuotaStr,
-					// keep interest per your credit row (unchanged here)
-					cuota_interes: new Big(credit.porcentaje_interes ?? 0)
-						.times(new Big(credit.capital ?? 0).div(100))
-						.round(2)
-						.toString(), // same formula you used on create (capital * rate%)
-					cuota_id: c.cuota_id,
-					fecha_pago: fechaPagoLocal,
-					abono_capital: "0",
-					abono_interes: "0",
-					abono_iva_12: "0",
-					abono_interes_ci: "0",
-					abono_iva_ci: "0",
-					abono_seguro:
-						Number(credit.seguro_10_cuotas ?? 0) > 0 ? "0" : undefined,
-					abono_gps: Number(credit.gps ?? 0) > 0 ? "0" : undefined,
-					pago_del_mes: "0",
-					monto_boleta: "0",
-					fecha_vencimiento: c.fecha_vencimiento,
-					renuevo_o_nuevo: "",
-					capital_restante: new Big(credit.capital ?? 0).toString(),
-					interes_restante: new Big(credit.porcentaje_interes ?? 0)
-						.times(new Big(credit.capital ?? 0).div(100))
-						.round(2)
-						.toString(),
-					iva_12_restante: new Big(credit.porcentaje_interes ?? 0)
-						.times(new Big(credit.capital ?? 0).div(100))
-						.times(0.12)
-						.round(2)
-						.toString(),
-					seguro_restante: new Big(credit.seguro_10_cuotas ?? 0).toString(),
-					gps_restante: new Big(credit.gps ?? 0).toString(),
-					total_restante: new Big(credit.deudatotal ?? 0).toString(),
-					membresias: new Big(credit.membresias_pago ?? 0).toString(),
-					membresias_pago: "0",
-					membresias_mes: "0",
-					otros: "",
-					mora: "0",
-					monto_boleta_cuota: "0",
-					seguro_total: new Big(credit.seguro_10_cuotas ?? 0).toString(),
-					pagado: false,
-					facturacion: "si",
-					mes_pagado: "",
-					seguro_facturado: new Big(credit.seguro_10_cuotas ?? 0).toString(),
-					gps_facturado: new Big(credit.gps ?? 0).toString(),
-					reserva: "0",
-					observaciones: "",
-					paymentFalse: false,
-					registerBy: "system_reset",
-					pagoConvenio: "0",
-					monto_aplicado: "0",
-				};
-			});
+        return {
+        credito_id: creditoId,
+        cuota: cuotaStr,
+        // keep interest per your credit row (unchanged here)
+        cuota_interes: new Big(credit.porcentaje_interes ?? 0)
+          .times(new Big(credit.capital ?? 0).div(100))
+          .round(2)
+          .toString(), // same formula you used on create (capital * rate%)
+        cuota_id: c.cuota_id,
+        fecha_pago: fechaPagoLocal,
+        abono_capital: "0",
+        abono_interes: "0",
+        abono_iva_12: "0",
+        abono_interes_ci: "0",
+        abono_iva_ci: "0",
+        abono_seguro:
+          Number(credit.seguro_10_cuotas ?? 0) > 0 ? "0" : undefined,
+        abono_gps: Number(credit.gps ?? 0) > 0 ? "0" : undefined,
+        pago_del_mes: "0",
+        monto_boleta: "0",
+        fecha_vencimiento: c.fecha_vencimiento,
+        renuevo_o_nuevo: "",
+        capital_restante: new Big(credit.capital ?? 0).toString(),
+        interes_restante: new Big(credit.porcentaje_interes ?? 0)
+          .times(new Big(credit.capital ?? 0).div(100))
+          .round(2)
+          .toString(),
+        iva_12_restante: new Big(credit.porcentaje_interes ?? 0)
+          .times(new Big(credit.capital ?? 0).div(100))
+          .times(0.12)
+          .round(2)
+          .toString(),
+        seguro_restante: new Big(credit.seguro_10_cuotas ?? 0).toString(),
+        gps_restante: new Big(credit.gps ?? 0).toString(),
+        total_restante: new Big(credit.deudatotal ?? 0).toString(),
+        membresias: new Big(credit.membresias_pago ?? 0).toString(),
+        membresias_pago: "0",
+        membresias_mes: "0",
+        otros: "",
+        mora: "0",
+        monto_boleta_cuota: "0",
+        seguro_total: new Big(credit.seguro_10_cuotas ?? 0).toString(),
+        pagado: false,
+        facturacion: "si",
+        mes_pagado: "",
+        seguro_facturado: new Big(credit.seguro_10_cuotas ?? 0).toString(),
+        gps_facturado: new Big(credit.gps ?? 0).toString(),
+        reserva: "0",
+        observaciones: "",
+        paymentFalse: false,
+        registerBy: "system_reset",
+        pagoConvenio: "0",
+        monto_aplicado: "0",
+      };
+      });
 
-			await tx.insert(pagos_credito).values(pagosToInsert);
-		} else if (newPlazo < oldPlazoNum) {
-			// --- 3.b) Decrease plazo: remove extra unpaid quotas & their payments ---
-			const extra = cuotasReal.filter((c) => Number(c.numero_cuota) > newPlazo);
+      await tx.insert(pagos_credito).values(pagosToInsert);
+    } else if (newPlazo < oldPlazoNum) {
+      // --- 3.b) Decrease plazo: remove extra unpaid quotas & their payments ---
+      const extra = cuotasReal.filter((c) => Number(c.numero_cuota) > newPlazo);
 
-			// Safety: if any of the "extra" are paid, abort
-			const paidExtra = extra.filter((c) => c.pagado);
-			if (paidExtra.length > 0) {
-				throw new Error(
-					"[ERROR] Cannot reduce plazo below a paid cuota. Please reverse or adjust paid cuotas first.",
-				);
-			}
+      // Safety: if any of the "extra" are paid, abort
+      const paidExtra = extra.filter((c) => c.pagado);
+      if (paidExtra.length > 0) {
+        throw new Error(
+          "[ERROR] Cannot reduce plazo below a paid cuota. Please reverse or adjust paid cuotas first."
+        );
+      }
 
-			const extraCuotaIds = extra.map((c) => c.cuota_id);
-			if (extraCuotaIds.length > 0) {
-				const safeExtraCuotaIds = extraCuotaIds.filter(
-					(id): id is number => id !== null,
-				);
-				if (safeExtraCuotaIds.length > 0) {
-					// delete related pagos first
-					await tx
-						.delete(pagos_credito)
-						.where(inArray(pagos_credito.cuota_id, safeExtraCuotaIds));
-					// then delete cuotas
-					await tx
-						.delete(cuotas_credito)
-						.where(inArray(cuotas_credito.cuota_id, safeExtraCuotaIds));
-				}
-			}
-		}
+      const extraCuotaIds = extra.map((c) => c.cuota_id);
+      if (extraCuotaIds.length > 0) {
+        const safeExtraCuotaIds = extraCuotaIds.filter((id): id is number => id !== null);
+        if (safeExtraCuotaIds.length > 0) {
+          // delete related pagos first
+          await tx
+            .delete(pagos_credito)
+            .where(inArray(pagos_credito.cuota_id, safeExtraCuotaIds));
+          // then delete cuotas
+          await tx
+            .delete(cuotas_credito)
+            .where(inArray(cuotas_credito.cuota_id, safeExtraCuotaIds));
+        }
+      }
+    }
 
-		// --- 4) Persist credit row fields actually changed (only cuota/plazo) ---
-		const updateSet: Record<string, any> = {};
-		if (changedCuota) updateSet.cuota = new Big(newCuota).round(2).toString();
-		if (changedPlazo) updateSet.plazo = Number(newPlazo);
+    // --- 4) Persist credit row fields actually changed (only cuota/plazo) ---
+    const updateSet: Record<string, any> = {};
+    if (changedCuota) updateSet.cuota = new Big(newCuota).round(2).toString();
+    if (changedPlazo) updateSet.plazo = Number(newPlazo);
 
-		if (Object.keys(updateSet).length > 0) {
-			await tx
-				.update(creditos)
-				.set(updateSet)
-				.where(eq(creditos.credito_id, creditoId));
-		}
+    if (Object.keys(updateSet).length > 0) {
+      await tx
+        .update(creditos)
+        .set(updateSet)
+        .where(eq(creditos.credito_id, creditoId));
+    }
 
-		return { updated: true, changedCuota, changedPlazo };
-	});
+    return { updated: true, changedCuota, changedPlazo };
+  });
 }
 interface MergeCreditParams {
-	numero_credito_origen: string; // El crédito que se va a absorber
-	numero_credito_destino: string; // El crédito que va a quedar activo
+  numero_credito_origen: string; // El crédito que se va a absorber
+  numero_credito_destino: string; // El crédito que va a quedar activo
 }
 
 interface CreditoCompleto {
-	credito_id: number;
-	capital: string;
-	porcentaje_interes: string;
-	cuota: string;
-	cuota_interes: string;
-	deudatotal: string;
-	plazo: number;
-	iva_12: string;
-	seguro_10_cuotas: string;
-	gps: string;
-	membresias_pago: string;
-	membresias: string;
-	otros: string;
-	usuario_id: number;
-	asesor_id: number;
-	numero_credito_sifco: string;
-	[key: string]: any;
+  credito_id: number;
+  capital: string;
+  porcentaje_interes: string;
+  cuota: string;
+  cuota_interes: string;
+  deudatotal: string;
+  plazo: number;
+  iva_12: string;
+  seguro_10_cuotas: string;
+  gps: string;
+  membresias_pago: string;
+  membresias: string;
+  otros: string;
+  usuario_id: number;
+  asesor_id: number;
+  numero_credito_sifco: string;
+  [key: string]: any;
 }
 
 // ========================================
@@ -2594,308 +2500,304 @@ interface CreditoCompleto {
 // ========================================
 
 export const mergeCreditosAndUpdate = async ({
-	numero_credito_origen,
-	numero_credito_destino,
+  numero_credito_origen,
+  numero_credito_destino,
 }: MergeCreditParams): Promise<{
-	success: boolean;
-	message: string;
-	creditoFinal: any;
-	nueva_cuota: number;
+  success: boolean;
+  message: string;
+  creditoFinal: any;
+  nueva_cuota: number;
 }> => {
-	console.log("🔄 ========================================");
-	console.log("🔄 INICIANDO FUSIÓN DE CRÉDITOS");
-	console.log("🔄 ========================================");
-	console.log(`📋 Crédito ORIGEN (se absorberá): ${numero_credito_origen}`);
-	console.log(`📋 Crédito DESTINO (quedará activo): ${numero_credito_destino}`);
-	console.log("");
+  console.log("🔄 ========================================");
+  console.log("🔄 INICIANDO FUSIÓN DE CRÉDITOS");
+  console.log("🔄 ========================================");
+  console.log(`📋 Crédito ORIGEN (se absorberá): ${numero_credito_origen}`);
+  console.log(`📋 Crédito DESTINO (quedará activo): ${numero_credito_destino}`);
+  console.log("");
 
-	try {
-		// ========================================
-		// PASO 1: OBTENER AMBOS CRÉDITOS
-		// ========================================
-		console.log("📥 PASO 1: Buscando ambos créditos...");
+  try {
+    // ========================================
+    // PASO 1: OBTENER AMBOS CRÉDITOS
+    // ========================================
+    console.log("📥 PASO 1: Buscando ambos créditos...");
 
-		const [creditoOrigen] = (await db
-			.select()
-			.from(creditos)
-			.where(eq(creditos.numero_credito_sifco, numero_credito_origen))
-			.limit(1)) as CreditoCompleto[];
+    const [creditoOrigen] = (await db
+      .select()
+      .from(creditos)
+      .where(eq(creditos.numero_credito_sifco, numero_credito_origen))
+      .limit(1)) as CreditoCompleto[];
 
-		const [creditoDestino] = (await db
-			.select()
-			.from(creditos)
-			.where(eq(creditos.numero_credito_sifco, numero_credito_destino))
-			.limit(1)) as CreditoCompleto[];
+    const [creditoDestino] = (await db
+      .select()
+      .from(creditos)
+      .where(eq(creditos.numero_credito_sifco, numero_credito_destino))
+      .limit(1)) as CreditoCompleto[];
 
-		if (!creditoOrigen) {
-			console.log("❌ ERROR: No se encontró el crédito origen");
-			throw new Error(`Crédito origen ${numero_credito_origen} no encontrado`);
-		}
+    if (!creditoOrigen) {
+      console.log("❌ ERROR: No se encontró el crédito origen");
+      throw new Error(`Crédito origen ${numero_credito_origen} no encontrado`);
+    }
 
-		if (!creditoDestino) {
-			console.log("❌ ERROR: No se encontró el crédito destino");
-			throw new Error(
-				`Crédito destino ${numero_credito_destino} no encontrado`,
-			);
-		}
+    if (!creditoDestino) {
+      console.log("❌ ERROR: No se encontró el crédito destino");
+      throw new Error(
+        `Crédito destino ${numero_credito_destino} no encontrado`
+      );
+    }
 
-		console.log(
-			`✅ Crédito ORIGEN encontrado - ID: ${creditoOrigen.credito_id}`,
-		);
-		console.log(`   - Capital: Q${creditoOrigen.capital}`);
-		console.log(`   - Cuota: Q${creditoOrigen.cuota}`);
-		console.log(`   - Seguro: Q${creditoOrigen.seguro_10_cuotas}`);
-		console.log(`   - GPS: Q${creditoOrigen.gps}`);
-		console.log(`   - Membresías: Q${creditoOrigen.membresias_pago}`);
-		console.log(`   - Otros: Q${creditoOrigen.otros}`);
+    console.log(
+      `✅ Crédito ORIGEN encontrado - ID: ${creditoOrigen.credito_id}`
+    );
+    console.log(`   - Capital: Q${creditoOrigen.capital}`);
+    console.log(`   - Cuota: Q${creditoOrigen.cuota}`);
+    console.log(`   - Seguro: Q${creditoOrigen.seguro_10_cuotas}`);
+    console.log(`   - GPS: Q${creditoOrigen.gps}`);
+    console.log(`   - Membresías: Q${creditoOrigen.membresias_pago}`);
+    console.log(`   - Otros: Q${creditoOrigen.otros}`);
 
-		console.log(
-			`✅ Crédito DESTINO encontrado - ID: ${creditoDestino.credito_id}`,
-		);
-		console.log(`   - Capital: Q${creditoDestino.capital}`);
-		console.log(`   - Cuota: Q${creditoDestino.cuota}`);
-		console.log(`   - Seguro: Q${creditoDestino.seguro_10_cuotas}`);
-		console.log(`   - GPS: Q${creditoDestino.gps}`);
-		console.log(`   - Membresías: Q${creditoDestino.membresias_pago}`);
-		console.log(`   - Otros: Q${creditoDestino.otros}`);
-		console.log("");
+    console.log(
+      `✅ Crédito DESTINO encontrado - ID: ${creditoDestino.credito_id}`
+    );
+    console.log(`   - Capital: Q${creditoDestino.capital}`);
+    console.log(`   - Cuota: Q${creditoDestino.cuota}`);
+    console.log(`   - Seguro: Q${creditoDestino.seguro_10_cuotas}`);
+    console.log(`   - GPS: Q${creditoDestino.gps}`);
+    console.log(`   - Membresías: Q${creditoDestino.membresias_pago}`);
+    console.log(`   - Otros: Q${creditoDestino.otros}`);
+    console.log("");
 
-		// ========================================
-		// PASO 2: SUMAR VALORES Y RECALCULAR
-		// ========================================
-		console.log("🧮 PASO 2: Sumando capitales y recalculando todo...");
+    // ========================================
+    // PASO 2: SUMAR VALORES Y RECALCULAR
+    // ========================================
+    console.log("🧮 PASO 2: Sumando capitales y recalculando todo...");
 
-		// Sumar capitales
-		const capitalOrigen = new Big(creditoOrigen.capital);
-		const capitalDestino = new Big(creditoDestino.capital);
-		const capitalTotal = capitalOrigen.plus(capitalDestino);
+    // Sumar capitales
+    const capitalOrigen = new Big(creditoOrigen.capital);
+    const capitalDestino = new Big(creditoDestino.capital);
+    const capitalTotal = capitalOrigen.plus(capitalDestino);
 
-		console.log(`   📊 Capital ORIGEN: Q${capitalOrigen.toString()}`);
-		console.log(`   📊 Capital DESTINO: Q${capitalDestino.toString()}`);
-		console.log(`   ➕ CAPITAL TOTAL: Q${capitalTotal.toString()}`);
+    console.log(`   📊 Capital ORIGEN: Q${capitalOrigen.toString()}`);
+    console.log(`   📊 Capital DESTINO: Q${capitalDestino.toString()}`);
+    console.log(`   ➕ CAPITAL TOTAL: Q${capitalTotal.toString()}`);
 
-		// Usar el porcentaje de interés del crédito destino
-		const porcentaje_interes = new Big(creditoDestino.porcentaje_interes);
-		console.log(`   📈 Porcentaje interés: ${porcentaje_interes.toString()}%`);
+    // Usar el porcentaje de interés del crédito destino
+    const porcentaje_interes = new Big(creditoDestino.porcentaje_interes);
+    console.log(`   📈 Porcentaje interés: ${porcentaje_interes.toString()}%`);
 
-		// Calcular cuota_interes con el nuevo capital
-		const cuota_interes = capitalTotal
-			.times(porcentaje_interes.div(100))
-			.round(2);
-		console.log(
-			`   💵 Cuota interés (recalculada): Q${cuota_interes.toString()}`,
-		);
+    // Calcular cuota_interes con el nuevo capital
+    const cuota_interes = capitalTotal
+      .times(porcentaje_interes.div(100))
+      .round(2);
+    console.log(
+      `   💵 Cuota interés (recalculada): Q${cuota_interes.toString()}`
+    );
 
-		// Calcular IVA 12%
-		const iva_12 = cuota_interes.times(0.12).round(2);
-		console.log(`   🧾 IVA 12%: Q${iva_12.toString()}`);
+    // Calcular IVA 12%
+    const iva_12 = cuota_interes.times(0.12).round(2);
+    console.log(`   🧾 IVA 12%: Q${iva_12.toString()}`);
 
-		// Sumar seguros, GPS, membresías, otros
-		const seguro_total = new Big(creditoOrigen.seguro_10_cuotas || "0").plus(
-			new Big(creditoDestino.seguro_10_cuotas || "0"),
-		);
+    // Sumar seguros, GPS, membresías, otros
+    const seguro_total = new Big(creditoOrigen.seguro_10_cuotas || "0").plus(
+      new Big(creditoDestino.seguro_10_cuotas || "0")
+    );
 
-		const gps_total = new Big(creditoOrigen.gps || "0").plus(
-			new Big(creditoDestino.gps || "0"),
-		);
+    const gps_total = new Big(creditoOrigen.gps || "0").plus(
+      new Big(creditoDestino.gps || "0")
+    );
 
-		const membresias_total = new Big(creditoOrigen.membresias_pago || "0").plus(
-			new Big(creditoDestino.membresias_pago || "0"),
-		);
+    const membresias_total = new Big(creditoOrigen.membresias_pago || "0").plus(
+      new Big(creditoDestino.membresias_pago || "0")
+    );
 
-		const otros_total = new Big(creditoOrigen.otros || "0").plus(
-			new Big(creditoDestino.otros || "0"),
-		);
+    const otros_total = new Big(creditoOrigen.otros || "0").plus(
+      new Big(creditoDestino.otros || "0")
+    );
 
-		console.log(`   🛡️  Seguro total: Q${seguro_total.toString()}`);
-		console.log(`   📡 GPS total: Q${gps_total.toString()}`);
-		console.log(`   💳 Membresías total: Q${membresias_total.toString()}`);
-		console.log(`   📝 Otros total: Q${otros_total.toString()}`);
+    console.log(`   🛡️  Seguro total: Q${seguro_total.toString()}`);
+    console.log(`   📡 GPS total: Q${gps_total.toString()}`);
+    console.log(`   💳 Membresías total: Q${membresias_total.toString()}`);
+    console.log(`   📝 Otros total: Q${otros_total.toString()}`);
 
-		// Sumar cuotas
-		const cuota_origen = new Big(creditoOrigen.cuota);
-		const cuota_destino = new Big(creditoDestino.cuota);
-		const cuota_total = cuota_origen.plus(cuota_destino).round(2);
+    // Sumar cuotas
+    const cuota_origen = new Big(creditoOrigen.cuota);
+    const cuota_destino = new Big(creditoDestino.cuota);
+    const cuota_total = cuota_origen.plus(cuota_destino).round(2);
 
-		console.log(`   💰 Cuota ORIGEN: Q${cuota_origen.toString()}`);
-		console.log(`   💰 Cuota DESTINO: Q${cuota_destino.toString()}`);
-		console.log(`   ➕ CUOTA TOTAL: Q${cuota_total.toString()}`);
+    console.log(`   💰 Cuota ORIGEN: Q${cuota_origen.toString()}`);
+    console.log(`   💰 Cuota DESTINO: Q${cuota_destino.toString()}`);
+    console.log(`   ➕ CUOTA TOTAL: Q${cuota_total.toString()}`);
 
-		// Calcular deuda total
-		const deudatotal = capitalTotal
-			.plus(cuota_interes)
-			.plus(iva_12)
-			.plus(seguro_total)
-			.plus(gps_total)
-			.plus(membresias_total)
-			.plus(otros_total)
-			.round(2);
+    // Calcular deuda total
+    const deudatotal = capitalTotal
+      .plus(cuota_interes)
+      .plus(iva_12)
+      .plus(seguro_total)
+      .plus(gps_total)
+      .plus(membresias_total)
+      .plus(otros_total)
+      .round(2);
 
-		console.log(`   💵💵 DEUDA TOTAL (recalculada): Q${deudatotal.toString()}`);
-		console.log("");
+    console.log(`   💵💵 DEUDA TOTAL (recalculada): Q${deudatotal.toString()}`);
+    console.log("");
 
-		// ========================================
-		// PASO 3: ACTUALIZAR CRÉDITO DESTINO
-		// ========================================
-		console.log(
-			"💾 PASO 3: Actualizando crédito destino con valores consolidados...",
-		);
+    // ========================================
+    // PASO 3: ACTUALIZAR CRÉDITO DESTINO
+    // ========================================
+    console.log(
+      "💾 PASO 3: Actualizando crédito destino con valores consolidados..."
+    );
 
-		const [creditoActualizado] = await withCapitalContext(
-			null,
-			"MERGE",
-			null,
-			(tx) =>
-				tx
-					.update(creditos)
-					.set({
-						capital: capitalTotal.toString(),
-						cuota: cuota_total.toString(),
-						cuota_interes: cuota_interes.toString(),
-						iva_12: iva_12.toString(),
-						deudatotal: deudatotal.toString(),
-						seguro_10_cuotas: seguro_total.toString(),
-						gps: gps_total.toString(),
-						membresias_pago: membresias_total.toString(),
-						membresias: membresias_total.toString(),
-						otros: otros_total.toString(),
-					})
-					.where(eq(creditos.credito_id, creditoDestino.credito_id))
-					.returning(),
-		);
+    const [creditoActualizado] = await withCapitalContext(null, "MERGE", null, (tx) =>
+      tx
+        .update(creditos)
+        .set({
+          capital: capitalTotal.toString(),
+          cuota: cuota_total.toString(),
+          cuota_interes: cuota_interes.toString(),
+          iva_12: iva_12.toString(),
+          deudatotal: deudatotal.toString(),
+          seguro_10_cuotas: seguro_total.toString(),
+          gps: gps_total.toString(),
+          membresias_pago: membresias_total.toString(),
+          membresias: membresias_total.toString(),
+          otros: otros_total.toString(),
+        })
+        .where(eq(creditos.credito_id, creditoDestino.credito_id))
+        .returning()
+    );
 
-		console.log(
-			`   ✅ Crédito ${creditoDestino.numero_credito_sifco} actualizado exitosamente`,
-		);
-		console.log(`   📊 Nuevo capital: Q${capitalTotal.toString()}`);
-		console.log(`   💰 Nueva cuota: Q${cuota_total.toString()}`);
-		console.log(`   💵 Nueva deuda total: Q${deudatotal.toString()}`);
-		console.log("");
+    console.log(
+      `   ✅ Crédito ${creditoDestino.numero_credito_sifco} actualizado exitosamente`
+    );
+    console.log(`   📊 Nuevo capital: Q${capitalTotal.toString()}`);
+    console.log(`   💰 Nueva cuota: Q${cuota_total.toString()}`);
+    console.log(`   💵 Nueva deuda total: Q${deudatotal.toString()}`);
+    console.log("");
 
-		// ========================================
-		// PASO 4: TRASLADAR INVERSIONISTAS DEL ORIGEN AL DESTINO
-		// ========================================
-		console.log(
-			"👥 PASO 4: Trasladando inversionistas del crédito ORIGEN al DESTINO...",
-		);
+    // ========================================
+    // PASO 4: TRASLADAR INVERSIONISTAS DEL ORIGEN AL DESTINO
+    // ========================================
+    console.log(
+      "👥 PASO 4: Trasladando inversionistas del crédito ORIGEN al DESTINO..."
+    );
 
-		const inversionistasOrigen = await db
-			.select()
-			.from(creditos_inversionistas)
-			.where(eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id));
+    const inversionistasOrigen = await db
+      .select()
+      .from(creditos_inversionistas)
+      .where(eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id));
 
-		if (inversionistasOrigen.length > 0) {
-			console.log(
-				`   📋 Se encontraron ${inversionistasOrigen.length} inversionistas en el crédito origen`,
-			);
+    if (inversionistasOrigen.length > 0) {
+      console.log(
+        `   📋 Se encontraron ${inversionistasOrigen.length} inversionistas en el crédito origen`
+      );
 
-			// Actualizar el credito_id de todos los inversionistas del origen
-			await db
-				.update(creditos_inversionistas)
-				.set({
-					credito_id: creditoDestino.credito_id,
-				})
-				.where(
-					eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id),
-				);
+      // Actualizar el credito_id de todos los inversionistas del origen
+      await db
+        .update(creditos_inversionistas)
+        .set({
+          credito_id: creditoDestino.credito_id,
+        })
+        .where(
+          eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id)
+        );
 
-			console.log(
-				`   ✅ ${inversionistasOrigen.length} inversionistas trasladados al crédito destino`,
-			);
+      console.log(
+        `   ✅ ${inversionistasOrigen.length} inversionistas trasladados al crédito destino`
+      );
 
-			inversionistasOrigen.forEach((inv, index) => {
-				console.log(
-					`      ${index + 1}. Inversionista ID: ${inv.inversionista_id}`,
-				);
-				console.log(`         - Monto aportado: Q${inv.monto_aportado}`);
-				console.log(`         - Cuota: Q${inv.cuota_inversionista}`);
-			});
-		} else {
-			console.log(
-				`   ℹ️  No hay inversionistas en el crédito origen para trasladar`,
-			);
-		}
-		console.log("");
+      inversionistasOrigen.forEach((inv, index) => {
+        console.log(
+          `      ${index + 1}. Inversionista ID: ${inv.inversionista_id}`
+        );
+        console.log(`         - Monto aportado: Q${inv.monto_aportado}`);
+        console.log(`         - Cuota: Q${inv.cuota_inversionista}`);
+      });
+    } else {
+      console.log(
+        `   ℹ️  No hay inversionistas en el crédito origen para trasladar`
+      );
+    }
+    console.log("");
 
-		// ========================================
-		// PASO 5: MARCAR CRÉDITO ORIGEN COMO CANCELADO
-		// ========================================
-		console.log("🔒 PASO 5: Marcando crédito origen como CANCELADO...");
+    // ========================================
+    // PASO 5: MARCAR CRÉDITO ORIGEN COMO CANCELADO
+    // ========================================
+    console.log("🔒 PASO 5: Marcando crédito origen como CANCELADO...");
 
-		await db
-			.update(creditos)
-			.set({
-				statusCredit: "CANCELADO",
-			})
-			.where(eq(creditos.credito_id, creditoOrigen.credito_id));
+    await db
+      .update(creditos)
+      .set({
+        statusCredit: "CANCELADO",
+      })
+      .where(eq(creditos.credito_id, creditoOrigen.credito_id));
 
-		console.log(
-			`   ✅ Crédito ${creditoOrigen.numero_credito_sifco} (ID: ${creditoOrigen.credito_id}) marcado como CANCELADO`,
-		);
-		console.log("");
+    console.log(
+      `   ✅ Crédito ${creditoOrigen.numero_credito_sifco} (ID: ${creditoOrigen.credito_id}) marcado como CANCELADO`
+    );
+    console.log("");
 
-		// ========================================
-		// PASO 6: LLAMAR A updateInstallments
-		// ========================================
-		console.log("📅 PASO 6: Recalculando cuotas con updateInstallments...");
-		console.log(`   🔄 Llamando updateInstallments con:`);
-		console.log(`      - numero_credito_sifco: ${numero_credito_destino}`);
-		console.log(`      - nueva_cuota: Q${cuota_total.toNumber()}`);
+    // ========================================
+    // PASO 6: LLAMAR A updateInstallments
+    // ========================================
+    console.log("📅 PASO 6: Recalculando cuotas con updateInstallments...");
+    console.log(`   🔄 Llamando updateInstallments con:`);
+    console.log(`      - numero_credito_sifco: ${numero_credito_destino}`);
+    console.log(`      - nueva_cuota: Q${cuota_total.toNumber()}`);
 
-		await updateInstallments({
-			numero_credito_sifco: numero_credito_destino,
-			nueva_cuota: cuota_total.toNumber(),
-		});
+    await updateInstallments({
+      numero_credito_sifco: numero_credito_destino,
+      nueva_cuota: cuota_total.toNumber(),
+    });
 
-		console.log(`   ✅ Cuotas recalculadas exitosamente`);
-		console.log("");
+    console.log(`   ✅ Cuotas recalculadas exitosamente`);
+    console.log("");
 
-		// ========================================
-		// RESULTADO FINAL
-		// ========================================
-		const inversionistasDestino = await db
-			.select()
-			.from(creditos_inversionistas)
-			.where(eq(creditos_inversionistas.credito_id, creditoDestino.credito_id));
+    // ========================================
+    // RESULTADO FINAL
+    // ========================================
+    const inversionistasDestino = await db
+      .select()
+      .from(creditos_inversionistas)
+      .where(eq(creditos_inversionistas.credito_id, creditoDestino.credito_id));
 
-		const totalInversionistas = inversionistasDestino.length;
+    const totalInversionistas = inversionistasDestino.length;
 
-		console.log("✅ ========================================");
-		console.log("✅ FUSIÓN COMPLETADA EXITOSAMENTE");
-		console.log("✅ ========================================");
-		console.log(
-			`📋 Crédito activo: ${numero_credito_destino} (ID: ${creditoDestino.credito_id})`,
-		);
-		console.log(`💰 Capital consolidado: Q${capitalTotal.toString()}`);
-		console.log(`💵 Nueva cuota mensual: Q${cuota_total.toString()}`);
-		console.log(`💵 Nueva deuda total: Q${deudatotal.toString()}`);
-		console.log(`👥 Total inversionistas: ${totalInversionistas}`);
-		console.log(
-			`🔒 Crédito cancelado: ${numero_credito_origen} (ID: ${creditoOrigen.credito_id})`,
-		);
-		console.log("");
+    console.log("✅ ========================================");
+    console.log("✅ FUSIÓN COMPLETADA EXITOSAMENTE");
+    console.log("✅ ========================================");
+    console.log(
+      `📋 Crédito activo: ${numero_credito_destino} (ID: ${creditoDestino.credito_id})`
+    );
+    console.log(`💰 Capital consolidado: Q${capitalTotal.toString()}`);
+    console.log(`💵 Nueva cuota mensual: Q${cuota_total.toString()}`);
+    console.log(`💵 Nueva deuda total: Q${deudatotal.toString()}`);
+    console.log(`👥 Total inversionistas: ${totalInversionistas}`);
+    console.log(
+      `🔒 Crédito cancelado: ${numero_credito_origen} (ID: ${creditoOrigen.credito_id})`
+    );
+    console.log("");
 
-		return {
-			success: true,
-			message: "Créditos fusionados exitosamente",
-			nueva_cuota: cuota_total.toNumber(),
-			creditoFinal: {
-				numero_credito: numero_credito_destino,
-				credito_id: creditoDestino.credito_id,
-				capital_total: capitalTotal.toString(),
-				cuota: cuota_total.toString(),
-				deuda_total: deudatotal.toString(),
-				total_inversionistas: totalInversionistas,
-				credito_cancelado: numero_credito_origen,
-			},
-		};
-	} catch (error) {
-		console.log("❌ ========================================");
-		console.log("❌ ERROR EN LA FUSIÓN DE CRÉDITOS");
-		console.log("❌ ========================================");
-		console.error(error);
-		throw error;
-	}
+    return {
+      success: true,
+      message: "Créditos fusionados exitosamente",
+      nueva_cuota: cuota_total.toNumber(),
+      creditoFinal: {
+        numero_credito: numero_credito_destino,
+        credito_id: creditoDestino.credito_id,
+        capital_total: capitalTotal.toString(),
+        cuota: cuota_total.toString(),
+        deuda_total: deudatotal.toString(),
+        total_inversionistas: totalInversionistas,
+        credito_cancelado: numero_credito_origen,
+      },
+    };
+  } catch (error) {
+    console.log("❌ ========================================");
+    console.log("❌ ERROR EN LA FUSIÓN DE CRÉDITOS");
+    console.log("❌ ========================================");
+    console.error(error);
+    throw error;
+  }
 };
 
 // ========================================
@@ -2903,18 +2805,18 @@ export const mergeCreditosAndUpdate = async ({
 // ========================================
 
 interface UpdateInstallmentsParams {
-	numero_credito_sifco: string;
-	nueva_cuota: number;
+  numero_credito_sifco: string;
+  nueva_cuota: number;
 }
 
 const updateInstallments = async ({
-	numero_credito_sifco,
-	nueva_cuota,
+  numero_credito_sifco,
+  nueva_cuota,
 }: UpdateInstallmentsParams): Promise<void> => {
-	console.log(`   🔄 Ejecutando updateInstallments...`);
-	console.log(`   📋 Crédito: ${numero_credito_sifco}`);
-	console.log(`   💰 Nueva cuota: Q${nueva_cuota}`);
-	// Aquí va tu implementación existente
+  console.log(`   🔄 Ejecutando updateInstallments...`);
+  console.log(`   📋 Crédito: ${numero_credito_sifco}`);
+  console.log(`   💰 Nueva cuota: Q${nueva_cuota}`);
+  // Aquí va tu implementación existente
 };
 
 // ========================================
@@ -2922,311 +2824,287 @@ const updateInstallments = async ({
 // ========================================
 
 interface CreditStats {
-	cantidad: number;
-	porcentaje: string;
-	sumaCapital: string;
-	sumaMora: string;
+  cantidad: number;
+  porcentaje: string;
+  sumaCapital: string;
+  sumaMora: string;
 }
 
 interface CreditStatsResponse {
-	totalCreditos: number;
-	efectividad: string; // Porcentaje de créditos SIN cuotas atrasadas
-	porCuotasAtrasadas: {
-		"0": CreditStats;
-		"1": CreditStats;
-		"2": CreditStats;
-		"3": CreditStats;
-		"4": CreditStats;
-	};
-	porEstado: {
-		cancelado: CreditStats;
-		incobrable: CreditStats;
-	};
+  totalCreditos: number;
+  efectividad: string; // Porcentaje de créditos SIN cuotas atrasadas
+  porCuotasAtrasadas: {
+    "0": CreditStats;
+    "1": CreditStats;
+    "2": CreditStats;
+    "3": CreditStats;
+    "4": CreditStats;
+  };
+  porEstado: {
+    cancelado: CreditStats;
+    incobrable: CreditStats;
+  };
 }
 
-export const getCreditStats = async (
-	email?: string,
-): Promise<CreditStatsResponse> => {
-	console.log(`📊 Obteniendo estadísticas de créditos...`);
-	if (email) {
-		console.log(`   🔍 Filtrando por asesor con email: ${email}`);
-	}
+export const getCreditStats = async (email?: string): Promise<CreditStatsResponse> => {
+  console.log(`📊 Obteniendo estadísticas de créditos...`);
+  if (email) {
+    console.log(`   🔍 Filtrando por asesor con email: ${email}`);
+  }
 
-	// Obtener el asesor_id si se proporciona email
-	let asesorId: number | null = null;
-	if (email) {
-		const platformUser = await db
-			.select({ asesor_id: asesores.asesor_id })
-			.from(asesores)
-			// 🔥 case/espacios-insensible: el email de sesión del CRM puede venir con otro casing
-			.where(
-				sql`LOWER(${asesores.emailCashIn}) = ${email.trim().toLowerCase()}`,
-			)
-			.limit(1);
+  // Obtener el asesor_id si se proporciona email
+  let asesorId: number | null = null;
+  if (email) {
+    const platformUser = await db
+      .select({ asesor_id: asesores.asesor_id })
+      .from(asesores)
+      // 🔥 case/espacios-insensible: el email de sesión del CRM puede venir con otro casing
+      .where(sql`LOWER(${asesores.emailCashIn}) = ${email.trim().toLowerCase()}`)
+      .limit(1);
 
-		if (platformUser.length > 0 && platformUser[0].asesor_id) {
-			asesorId = platformUser[0].asesor_id;
-			console.log(`   ✅ Asesor encontrado con ID: ${asesorId}`);
-		} else {
-			console.log(`   ⚠️ No se encontró asesor con email: ${email}`);
-		}
-	}
+    if (platformUser.length > 0 && platformUser[0].asesor_id) {
+      asesorId = platformUser[0].asesor_id;
+      console.log(`   ✅ Asesor encontrado con ID: ${asesorId}`);
+    } else {
+      console.log(`   ⚠️ No se encontró asesor con email: ${email}`);
+    }
+  }
 
-	// Primero obtener el total de créditos activos para calcular porcentajes
-	const baseConditionsTotal = [
-		inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
-	];
-	if (asesorId) {
-		baseConditionsTotal.push(eq(creditos.asesor_id, asesorId));
-	}
+  // Primero obtener el total de créditos activos para calcular porcentajes
+  const baseConditionsTotal = [
+    inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
+  ];
+  if (asesorId) {
+    baseConditionsTotal.push(eq(creditos.asesor_id, asesorId));
+  }
 
-	const totalResult = await db
-		.select({
-			total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-		})
-		.from(creditos)
-		.where(and(...baseConditionsTotal));
+  const totalResult = await db
+    .select({
+      total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+    })
+    .from(creditos)
+    .where(and(...baseConditionsTotal));
 
-	const totalCreditosActivos = totalResult[0]?.total || 0;
+  const totalCreditosActivos = totalResult[0]?.total || 0;
 
-	// Estadísticas por cuotas atrasadas (0, 1, 2, 3, 4) - Solo créditos ACTIVOS o MOROSOS
-	const statsPerCuotasAtrasadas: Record<string, CreditStats> = {
-		"0": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-		"1": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-		"2": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-		"3": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-		"4": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-	};
+  // Estadísticas por cuotas atrasadas (0, 1, 2, 3, 4) - Solo créditos ACTIVOS o MOROSOS
+  const statsPerCuotasAtrasadas: Record<string, CreditStats> = {
+    "0": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "1": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "2": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "3": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    "4": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+  };
 
-	// Consulta para créditos activos/morosos con sus moras
-	const baseConditionsActive = [
-		inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
-	];
+  // Consulta para créditos activos/morosos con sus moras
+  const baseConditionsActive = [
+    inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
+  ];
 
-	if (asesorId) {
-		baseConditionsActive.push(eq(creditos.asesor_id, asesorId));
-	}
+  if (asesorId) {
+    baseConditionsActive.push(eq(creditos.asesor_id, asesorId));
+  }
 
-	let creditosSinAtraso = 0;
+  let creditosSinAtraso = 0;
 
-	for (const cuotasNum of [0, 1, 2, 3, 4]) {
-		const result = await db
-			.select({
-				cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-				sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
-				sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
-			})
-			.from(creditos)
-			.leftJoin(
-				moras_credito,
-				and(
-					eq(creditos.credito_id, moras_credito.credito_id),
-					eq(moras_credito.activa, true),
-				),
-			)
-			.where(
-				and(
-					...baseConditionsActive,
-					cuotasNum === 4
-						? sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) >= 4`
-						: sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) = ${cuotasNum}`,
-				),
-			);
+  for (const cuotasNum of [0, 1, 2, 3, 4]) {
+    const result = await db
+      .select({
+        cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+        sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
+        sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
+      })
+      .from(creditos)
+      .leftJoin(
+        moras_credito,
+        and(
+          eq(creditos.credito_id, moras_credito.credito_id),
+          eq(moras_credito.activa, true)
+        )
+      )
+      .where(
+        and(
+          ...baseConditionsActive,
+          cuotasNum === 4
+            ? sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) >= 4`
+            : sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) = ${cuotasNum}`
+        )
+      );
 
-		const cantidad = result[0]?.cantidad || 0;
-		const porcentaje =
-			totalCreditosActivos > 0
-				? ((cantidad / totalCreditosActivos) * 100).toFixed(2)
-				: "0";
+    const cantidad = result[0]?.cantidad || 0;
+    const porcentaje = totalCreditosActivos > 0 
+      ? ((cantidad / totalCreditosActivos) * 100).toFixed(2) 
+      : "0";
 
-		if (cuotasNum === 0) {
-			creditosSinAtraso = cantidad;
-		}
+    if (cuotasNum === 0) {
+      creditosSinAtraso = cantidad;
+    }
 
-		statsPerCuotasAtrasadas[cuotasNum.toString()] = {
-			cantidad,
-			porcentaje,
-			sumaCapital: result[0]?.sumaCapital || "0",
-			sumaMora: result[0]?.sumaMora || "0",
-		};
-	}
+    statsPerCuotasAtrasadas[cuotasNum.toString()] = {
+      cantidad,
+      porcentaje,
+      sumaCapital: result[0]?.sumaCapital || "0",
+      sumaMora: result[0]?.sumaMora || "0",
+    };
+  }
 
-	// Calcular efectividad: porcentaje de créditos SIN cuotas atrasadas
-	const efectividad =
-		totalCreditosActivos > 0
-			? ((creditosSinAtraso / totalCreditosActivos) * 100).toFixed(2)
-			: "0";
+  // Calcular efectividad: porcentaje de créditos SIN cuotas atrasadas
+  const efectividad = totalCreditosActivos > 0 
+    ? ((creditosSinAtraso / totalCreditosActivos) * 100).toFixed(2) 
+    : "0";
 
-	// Estadísticas por estado (CANCELADO, INCOBRABLE)
-	const statsPerEstado = {
-		cancelado: {
-			cantidad: 0,
-			porcentaje: "0",
-			sumaCapital: "0",
-			sumaMora: "0",
-		},
-		incobrable: {
-			cantidad: 0,
-			porcentaje: "0",
-			sumaCapital: "0",
-			sumaMora: "0",
-		},
-	};
+  // Estadísticas por estado (CANCELADO, INCOBRABLE)
+  const statsPerEstado = {
+    cancelado: { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+    incobrable: { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+  };
 
-	// Obtener total de créditos cancelados + incobrables para sus porcentajes
-	const baseConditionsStatusTotal = [
-		inArray(creditos.statusCredit, ["CANCELADO", "INCOBRABLE"]),
-	];
-	if (asesorId) {
-		baseConditionsStatusTotal.push(eq(creditos.asesor_id, asesorId));
-	}
+  // Obtener total de créditos cancelados + incobrables para sus porcentajes
+  const baseConditionsStatusTotal = [
+    inArray(creditos.statusCredit, ["CANCELADO", "INCOBRABLE"]),
+  ];
+  if (asesorId) {
+    baseConditionsStatusTotal.push(eq(creditos.asesor_id, asesorId));
+  }
 
-	const totalStatusResult = await db
-		.select({
-			total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-		})
-		.from(creditos)
-		.where(and(...baseConditionsStatusTotal));
+  const totalStatusResult = await db
+    .select({
+      total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+    })
+    .from(creditos)
+    .where(and(...baseConditionsStatusTotal));
 
-	const totalCreditosStatus = totalStatusResult[0]?.total || 0;
+  const totalCreditosStatus = totalStatusResult[0]?.total || 0;
 
-	for (const estado of ["CANCELADO", "INCOBRABLE"] as const) {
-		const baseConditionsStatus = [eq(creditos.statusCredit, estado)];
+  for (const estado of ["CANCELADO", "INCOBRABLE"] as const) {
+    const baseConditionsStatus = [eq(creditos.statusCredit, estado)];
 
-		if (asesorId) {
-			baseConditionsStatus.push(eq(creditos.asesor_id, asesorId));
-		}
+    if (asesorId) {
+      baseConditionsStatus.push(eq(creditos.asesor_id, asesorId));
+    }
 
-		const result = await db
-			.select({
-				cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-				sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
-				sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
-			})
-			.from(creditos)
-			.leftJoin(
-				moras_credito,
-				and(
-					eq(creditos.credito_id, moras_credito.credito_id),
-					eq(moras_credito.activa, true),
-				),
-			)
-			.where(and(...baseConditionsStatus));
+    const result = await db
+      .select({
+        cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+        sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
+        sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
+      })
+      .from(creditos)
+      .leftJoin(
+        moras_credito,
+        and(
+          eq(creditos.credito_id, moras_credito.credito_id),
+          eq(moras_credito.activa, true)
+        )
+      )
+      .where(and(...baseConditionsStatus));
 
-		const cantidad = result[0]?.cantidad || 0;
-		const porcentaje =
-			totalCreditosStatus > 0
-				? ((cantidad / totalCreditosStatus) * 100).toFixed(2)
-				: "0";
+    const cantidad = result[0]?.cantidad || 0;
+    const porcentaje = totalCreditosStatus > 0 
+      ? ((cantidad / totalCreditosStatus) * 100).toFixed(2) 
+      : "0";
 
-		const key = estado.toLowerCase() as "cancelado" | "incobrable";
-		statsPerEstado[key] = {
-			cantidad,
-			porcentaje,
-			sumaCapital: result[0]?.sumaCapital || "0",
-			sumaMora: result[0]?.sumaMora || "0",
-		};
-	}
+    const key = estado.toLowerCase() as "cancelado" | "incobrable";
+    statsPerEstado[key] = {
+      cantidad,
+      porcentaje,
+      sumaCapital: result[0]?.sumaCapital || "0",
+      sumaMora: result[0]?.sumaMora || "0",
+    };
+  }
 
-	console.log(`📊 Estadísticas obtenidas exitosamente`);
+  console.log(`📊 Estadísticas obtenidas exitosamente`);
 
-	return {
-		totalCreditos: totalCreditosActivos,
-		efectividad,
-		porCuotasAtrasadas:
-			statsPerCuotasAtrasadas as CreditStatsResponse["porCuotasAtrasadas"],
-		porEstado: statsPerEstado,
-	};
+  return {
+    totalCreditos: totalCreditosActivos,
+    efectividad,
+    porCuotasAtrasadas: statsPerCuotasAtrasadas as CreditStatsResponse["porCuotasAtrasadas"],
+    porEstado: statsPerEstado,
+  };
 };
 
 // ============================================
 // 🔥 Activar/Desactivar Cancelación de Crédito
 // ============================================
 export async function toggleCancelacionActivo(params: {
-	creditId: number;
-	activo: boolean;
+  creditId: number;
+  activo: boolean;
 }) {
-	const { creditId, activo } = params;
+  const { creditId, activo } = params;
 
-	try {
-		// 1. Verificar que existe la cancelación
-		const [cancelacion] = await db
-			.select()
-			.from(credit_cancelations)
-			.where(eq(credit_cancelations.credit_id, creditId))
-			.limit(1);
+  try {
+    // 1. Verificar que existe la cancelación
+    const [cancelacion] = await db
+      .select()
+      .from(credit_cancelations)
+      .where(eq(credit_cancelations.credit_id, creditId))
+      .limit(1);
 
-		if (!cancelacion) {
-			return {
-				success: false,
-				message: "No existe una cancelación para este crédito.",
-			};
-		}
+    if (!cancelacion) {
+      return {
+        success: false,
+        message: "No existe una cancelación para este crédito.",
+      };
+    }
 
-		// 2. Actualizar el estado
-		await db
-			.update(credit_cancelations)
-			.set({ activo })
-			.where(eq(credit_cancelations.credit_id, creditId));
+    // 2. Actualizar el estado
+    await db
+      .update(credit_cancelations)
+      .set({ activo })
+      .where(eq(credit_cancelations.credit_id, creditId));
 
-		console.log(
-			`✅ Cancelación de crédito ${creditId} ${
-				activo ? "ACTIVADA" : "DESACTIVADA"
-			}`,
-		);
+    console.log(`✅ Cancelación de crédito ${creditId} ${activo ? "ACTIVADA" : "DESACTIVADA"}`);
 
-		return {
-			success: true,
-			message: `Cancelación ${
-				activo ? "activada" : "desactivada"
-			} exitosamente.`,
-			data: {
-				credit_id: creditId,
-				activo,
-			},
-		};
-	} catch (error) {
-		console.error("❌ Error actualizando estado de cancelación:", error);
-		return {
-			success: false,
-			message: "Error actualizando estado de cancelación",
-			error: String(error),
-		};
-	}
+    return {
+      success: true,
+      message: `Cancelación ${activo ? "activada" : "desactivada"} exitosamente.`,
+      data: {
+        credit_id: creditId,
+        activo,
+      },
+    };
+  } catch (error) {
+    console.error("❌ Error actualizando estado de cancelación:", error);
+    return {
+      success: false,
+      message: "Error actualizando estado de cancelación",
+      error: String(error),
+    };
+  }
 }
 
 // ============================================
 // Actualizar NIT de un crédito (usuario)
 // ============================================
 export async function actualizarNitCredito({
-	numero_credito_sifco,
-	nit,
+  numero_credito_sifco,
+  nit,
 }: {
-	numero_credito_sifco: string;
-	nit: string;
+  numero_credito_sifco: string;
+  nit: string;
 }) {
-	// 1. Buscar el crédito
-	const [credito] = await db
-		.select({
-			credito_id: creditos.credito_id,
-			usuario_id: creditos.usuario_id,
-		})
-		.from(creditos)
-		.where(eq(creditos.numero_credito_sifco, numero_credito_sifco))
-		.limit(1);
+  // 1. Buscar el crédito
+  const [credito] = await db
+    .select({
+      credito_id: creditos.credito_id,
+      usuario_id: creditos.usuario_id,
+    })
+    .from(creditos)
+    .where(eq(creditos.numero_credito_sifco, numero_credito_sifco))
+    .limit(1);
 
-	if (!credito) {
-		return { success: false, message: "Crédito no encontrado" };
-	}
+  if (!credito) {
+    return { success: false, message: "Crédito no encontrado" };
+  }
 
-	// 2. Actualizar el NIT del usuario
-	await db
-		.update(usuarios)
-		.set({ nit })
-		.where(eq(usuarios.usuario_id, credito.usuario_id));
+  // 2. Actualizar el NIT del usuario
+  await db
+    .update(usuarios)
+    .set({ nit })
+    .where(eq(usuarios.usuario_id, credito.usuario_id));
 
-	return {
-		success: true,
-		message: `NIT actualizado a ${nit} para el crédito ${numero_credito_sifco}`,
-	};
+  return {
+    success: true,
+    message: `NIT actualizado a ${nit} para el crédito ${numero_credito_sifco}`,
+  };
 }

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -39,6 +39,7 @@ import {
 } from "drizzle-orm";
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
+import { CREDIT_DETAIL_STATUSES } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
 
@@ -51,13 +52,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       .where(
         and(
           eq(creditos.numero_credito_sifco, numero_credito_sifco),
-          inArray(creditos.statusCredit, [
-            "ACTIVO",
-            "PENDIENTE_CANCELACION",
-            "MOROSO",
-            "EN_CONVENIO",
-            "INCOBRABLE"
-          ])
+          inArray(creditos.statusCredit, [...CREDIT_DETAIL_STATUSES])
         )
       )
       .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -42,6 +42,8 @@ import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   CREDIT_DETAIL_STATUSES,
   canResetCreditByStatus,
+  isCreditClosingPayment,
+  isOriginalPrincipalPayment,
   withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
@@ -69,6 +71,42 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
 
     const currentCredit = creditoData[0];
     const creditoId = currentCredit.creditos.credito_id;
+
+    const contractSummary =
+      currentCredit.creditos.statusCredit === "CANCELADO"
+        ? await (async () => {
+            const payments = await db
+              .select({
+                abono_capital: pagos_credito.abono_capital,
+                cuota: pagos_credito.cuota,
+                validationStatus: pagos_credito.validationStatus,
+                registerBy: pagos_credito.registerBy,
+                pagado: pagos_credito.pagado,
+                paymentFalse: pagos_credito.paymentFalse,
+              })
+              .from(pagos_credito)
+              .where(eq(pagos_credito.credito_id, creditoId));
+            const eligiblePayments = payments.filter(isOriginalPrincipalPayment);
+            const closingPayments = eligiblePayments.filter(isCreditClosingPayment);
+
+            return {
+              originalPrincipal: (() => {
+                const principal = eligiblePayments.reduce(
+                  (total, payment) => total.plus(payment.abono_capital ?? 0),
+                  new Big(0),
+                );
+                return principal.gt(0) ? principal.toFixed(2) : null;
+              })(),
+              installment:
+                closingPayments.find((payment) => payment.cuota != null)?.cuota ??
+                eligiblePayments.find(
+                  (payment) => payment.validationStatus === "reset" && payment.cuota != null
+                )?.cuota ??
+                eligiblePayments.find((payment) => payment.cuota != null)?.cuota ??
+                null,
+            };
+          })()
+        : undefined;
 
     // 2. Si el crédito está cancelado o pendiente de cancelación, verificar si hay cancelación activa
     const cancelacionActiva =
@@ -335,6 +373,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         convenioActivo: null,
         cuotasEnConvenio: [],
         pagosConvenio: [],
+        ...(contractSummary ? { contractSummary } : {}),
       }, cancelacionActiva, currentCredit.creditos.statusCredit);
     }
 
@@ -467,6 +506,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           : null,
       cuotasEnConvenio,
       pagosConvenio,
+      ...(contractSummary ? { contractSummary } : {}),
     }, cancelacionActiva, currentCredit.creditos.statusCredit);
   } catch (error) {
     console.error("[getCreditoByNumero] Error:", error);

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -39,7 +39,10 @@ import {
 } from "drizzle-orm";
 import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
-import { CREDIT_DETAIL_STATUSES } from "./creditDetailPolicy";
+import {
+  CREDIT_DETAIL_STATUSES,
+  withActiveCancellation,
+} from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
 
@@ -67,34 +70,22 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
     const creditoId = currentCredit.creditos.credito_id;
 
     // 2. Si el crédito está cancelado o pendiente de cancelación, verificar si hay cancelación activa
-    if (
+    const cancelacionActiva =
       currentCredit.creditos.statusCredit === "CANCELADO" ||
       currentCredit.creditos.statusCredit === "PENDIENTE_CANCELACION"
-    ) {
-      // Buscar la info de cancelación (solo si está activa)
-      const cancelacion = await db
-        .select()
-        .from(credit_cancelations)
-        .where(
-          and(
-            eq(credit_cancelations.credit_id, creditoId),
-            eq(credit_cancelations.activo, true)
-          )
-        )
-        .limit(1);
-
-      // Solo retornar flujo CANCELADO si hay una cancelación activa
-      if (cancelacion.length > 0) {
-        return {
-          credito: currentCredit.creditos,
-          usuario: currentCredit.usuarios,
-          asesor: currentCredit.asesores,
-          cancelacion: cancelacion[0],
-          flujo: "CANCELADO",
-        };
-      }
-      // Si no hay cancelación activa, continuar con el flujo normal
-    }
+        ? (
+            await db
+              .select()
+              .from(credit_cancelations)
+              .where(
+                and(
+                  eq(credit_cancelations.credit_id, creditoId),
+                  eq(credit_cancelations.activo, true)
+                )
+              )
+              .limit(1)
+          )[0]
+        : undefined;
 
     // 2. Consultar todas las cuotas pagadas (pagado = true)
     const cuotasPagadas = await db
@@ -314,7 +305,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
 
     // 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos sin cuota activa
     if (!cuotaActualDataResult || cuotaActualDataResult.length === 0) {
-      return {
+      return withActiveCancellation({
         flujo: "ACTIVO",
         credito: currentCredit.creditos,
         usuario: currentCredit.usuarios,
@@ -329,7 +320,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         convenioActivo: null,
         cuotasEnConvenio: [],
         pagosConvenio: [],
-      };
+      }, cancelacionActiva);
     }
 
     const cuotaActualData = cuotaActualDataResult[0];
@@ -449,7 +440,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       }
     }
 
-    return {
+    return withActiveCancellation({
       flujo: "ACTIVO",
       credito: currentCredit.creditos,
       usuario: currentCredit.usuarios,
@@ -471,7 +462,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
           : null,
       cuotasEnConvenio,
       pagosConvenio,
-    };
+    }, cancelacionActiva);
   } catch (error) {
     console.error("[getCreditoByNumero] Error:", error);
     return { message: "Error consultando crédito", error: String(error) };

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -1,801 +1,856 @@
 import { db } from "../database/index";
-import { withCapitalContext, setCapitalSource } from "../utils/withAuditContext";
 import {
-  aseguradoras,
-  asesores,
-  bad_debts,
-  boletas,
-  convenio_cuotas,
-  convenios_pago,
-  convenios_pagos_resume,
-  credit_cancelations,
-  creditos,
-  creditos_inversionistas,
-  creditos_inversionistas_espejo,
-  creditos_rubros_otros,
-  cuotas_credito,
-  inversionistas,
-  montos_adicionales,
-  moras_credito,
-  pagos_credito,
-  platform_users,
-  StatusCredit,
-  usuarios,
+	withCapitalContext,
+	setCapitalSource,
+} from "../utils/withAuditContext";
+import {
+	aseguradoras,
+	asesores,
+	bad_debts,
+	boletas,
+	convenio_cuotas,
+	convenios_pago,
+	convenios_pagos_resume,
+	credit_cancelations,
+	creditos,
+	creditos_inversionistas,
+	creditos_inversionistas_espejo,
+	creditos_rubros_otros,
+	cuotas_credito,
+	inversionistas,
+	montos_adicionales,
+	moras_credito,
+	pagos_credito,
+	platform_users,
+	StatusCredit,
+	usuarios,
 } from "../database/db/schema";
 import { z } from "zod";
 import Big from "big.js";
 import {
-  and,
-  desc,
-  eq,
-  sql,
-  inArray,
-  asc,
-  lte,
-  lt,
-  gte,
-  gt,
-  isNull,
+	and,
+	desc,
+	eq,
+	sql,
+	inArray,
+	asc,
+	lte,
+	lt,
+	gte,
+	gt,
+	isNull,
 } from "drizzle-orm";
-import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./payments";
+import {
+	getPagosDelMesActual,
+	insertPagosCreditoInversionistasV2,
+} from "./payments";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
-  CREDIT_DETAIL_STATUSES,
-  canResetCreditByStatus,
-  withActiveCancellation,
+	CREDIT_DETAIL_STATUSES,
+	canResetCreditByStatus,
+	withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
 
-
 export const getCreditoByNumero = async (numero_credito_sifco: string) => {
-  try {
-    // 1. Buscar el crédito con su usuario
-    const creditoData = await db
-      .select()
-      .from(creditos)
-      .where(
-        and(
-          eq(creditos.numero_credito_sifco, numero_credito_sifco),
-          inArray(creditos.statusCredit, [...CREDIT_DETAIL_STATUSES])
-        )
-      )
-      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-      .limit(1);
+	try {
+		// 1. Buscar el crédito con su usuario
+		const creditoData = await db
+			.select()
+			.from(creditos)
+			.where(
+				and(
+					eq(creditos.numero_credito_sifco, numero_credito_sifco),
+					inArray(creditos.statusCredit, [...CREDIT_DETAIL_STATUSES]),
+				),
+			)
+			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+			.limit(1);
 
-    if (creditoData.length === 0) {
-      return { message: "Crédito no encontrado" };
-    }
+		if (creditoData.length === 0) {
+			return { message: "Crédito no encontrado" };
+		}
 
-    const currentCredit = creditoData[0];
-    const creditoId = currentCredit.creditos.credito_id;
+		const currentCredit = creditoData[0];
+		const creditoId = currentCredit.creditos.credito_id;
 
-    // 2. Si el crédito está cancelado o pendiente de cancelación, verificar si hay cancelación activa
-    const cancelacionActiva =
-      currentCredit.creditos.statusCredit === "CANCELADO" ||
-      currentCredit.creditos.statusCredit === "PENDIENTE_CANCELACION"
-        ? (
-            await db
-              .select()
-              .from(credit_cancelations)
-              .where(
-                and(
-                  eq(credit_cancelations.credit_id, creditoId),
-                  eq(credit_cancelations.activo, true)
-                )
-              )
-              .limit(1)
-          )[0]
-        : undefined;
+		// 2. Si el crédito está cancelado o pendiente de cancelación, verificar si hay cancelación activa
+		const cancelacionActiva =
+			currentCredit.creditos.statusCredit === "CANCELADO" ||
+			currentCredit.creditos.statusCredit === "PENDIENTE_CANCELACION"
+				? (
+						await db
+							.select()
+							.from(credit_cancelations)
+							.where(
+								and(
+									eq(credit_cancelations.credit_id, creditoId),
+									eq(credit_cancelations.activo, true),
+								),
+							)
+							.limit(1)
+					)[0]
+				: undefined;
 
-    // 2. Consultar todas las cuotas pagadas (pagado = true)
-    const cuotasPagadas = await db
-      .select({
-        // Campos de cuotas_credito
-        cuota_id: cuotas_credito.cuota_id,
-        credito_id: cuotas_credito.credito_id,
-        numero_cuota: cuotas_credito.numero_cuota,
-        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-        pagado: cuotas_credito.pagado,
-        createdAt: cuotas_credito.createdAt,
+		// 2. Consultar todas las cuotas pagadas (pagado = true)
+		const cuotasPagadas = await db
+			.select({
+				// Campos de cuotas_credito
+				cuota_id: cuotas_credito.cuota_id,
+				credito_id: cuotas_credito.credito_id,
+				numero_cuota: cuotas_credito.numero_cuota,
+				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+				pagado: cuotas_credito.pagado,
+				createdAt: cuotas_credito.createdAt,
 
-        // 🔥 Campos de pagos_credito - ABONOS
-        pago_id: pagos_credito.pago_id,
-        monto_boleta: pagos_credito.monto_boleta,
-        abono_capital: pagos_credito.abono_capital,
-        abono_interes: pagos_credito.abono_interes,
-        abono_iva_12: pagos_credito.abono_iva_12,
-        abono_interes_ci: pagos_credito.abono_interes_ci,
-        abono_iva_ci: pagos_credito.abono_iva_ci,
-        abono_seguro: pagos_credito.abono_seguro,
-        abono_gps: pagos_credito.abono_gps,
-        abono_membresias: pagos_credito.membresias_mes,
+				// 🔥 Campos de pagos_credito - ABONOS
+				pago_id: pagos_credito.pago_id,
+				cuota: pagos_credito.cuota,
+				monto_boleta: pagos_credito.monto_boleta,
+				abono_capital: pagos_credito.abono_capital,
+				abono_interes: pagos_credito.abono_interes,
+				abono_iva_12: pagos_credito.abono_iva_12,
+				abono_interes_ci: pagos_credito.abono_interes_ci,
+				abono_iva_ci: pagos_credito.abono_iva_ci,
+				abono_seguro: pagos_credito.abono_seguro,
+				abono_gps: pagos_credito.abono_gps,
+				abono_membresias: pagos_credito.membresias_mes,
 
-        // 🔥 RESTANTES
-        capital_restante: pagos_credito.capital_restante,
-        interes_restante: pagos_credito.interes_restante,
-        iva_12_restante: pagos_credito.iva_12_restante,
-        seguro_restante: pagos_credito.seguro_restante,
-        gps_restante: pagos_credito.gps_restante,
-        membresias_restante: pagos_credito.membresias,
-        pago_mora: pagos_credito.mora,
-        pago_otros: pagos_credito.otros,
+				// 🔥 RESTANTES
+				capital_restante: pagos_credito.capital_restante,
+				interes_restante: pagos_credito.interes_restante,
+				iva_12_restante: pagos_credito.iva_12_restante,
+				seguro_restante: pagos_credito.seguro_restante,
+				gps_restante: pagos_credito.gps_restante,
+				membresias_restante: pagos_credito.membresias,
+				pago_mora: pagos_credito.mora,
+				pago_otros: pagos_credito.otros,
 
-        // 🔥 FLAG
-        pago_cuota_completa: pagos_credito.pagado,
+				// 🔥 FLAG
+				pago_cuota_completa: pagos_credito.pagado,
 
-        validationStatus: pagos_credito.validationStatus,
-      })
-      .from(cuotas_credito)
-      .leftJoin(
-        pagos_credito,
-        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
-      )
-      .where(
-        and(
-          eq(cuotas_credito.credito_id, creditoId),
-          eq(cuotas_credito.pagado, true)
-        )
-      )
-      .orderBy(cuotas_credito.numero_cuota);
-    // 4. Calcular la cuota que toca este mes (según meses transcurridos desde fecha_creacion)
-    const fechaInicio = new Date(currentCredit.creditos.fecha_creacion);
-    const hoy = new Date();
-    const mesesTranscurridos =
-      (hoy.getFullYear() - fechaInicio.getFullYear()) * 12 +
-      (hoy.getMonth() - fechaInicio.getMonth()) +
-      1;
+				validationStatus: pagos_credito.validationStatus,
+			})
+			.from(cuotas_credito)
+			.leftJoin(
+				pagos_credito,
+				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
+			)
+			.where(
+				and(
+					eq(cuotas_credito.credito_id, creditoId),
+					eq(cuotas_credito.pagado, true),
+				),
+			)
+			.orderBy(cuotas_credito.numero_cuota);
+		// 4. Calcular la cuota que toca este mes (según meses transcurridos desde fecha_creacion)
+		const fechaInicio = new Date(currentCredit.creditos.fecha_creacion);
+		const hoy = new Date();
+		const mesesTranscurridos =
+			(hoy.getFullYear() - fechaInicio.getFullYear()) * 12 +
+			(hoy.getMonth() - fechaInicio.getMonth()) +
+			1;
 
-    // 5. Consultar cuotas pendientes (no pagadas y ya deberían haberse pagado)
-    const cuotasAtrasadas = await db
-      .select({
-        cuota_id: cuotas_credito.cuota_id,
-        credito_id: cuotas_credito.credito_id,
-        numero_cuota: cuotas_credito.numero_cuota,
-        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-        pagado: cuotas_credito.pagado,
-        createdAt: cuotas_credito.createdAt,
-        validationStatus: pagos_credito.validationStatus,
-        pago_id: pagos_credito.pago_id,
+		// 5. Consultar cuotas pendientes (no pagadas y ya deberían haberse pagado)
+		const cuotasAtrasadas = await db
+			.select({
+				cuota_id: cuotas_credito.cuota_id,
+				credito_id: cuotas_credito.credito_id,
+				numero_cuota: cuotas_credito.numero_cuota,
+				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+				pagado: cuotas_credito.pagado,
+				createdAt: cuotas_credito.createdAt,
+				validationStatus: pagos_credito.validationStatus,
+				pago_id: pagos_credito.pago_id,
+				cuota: pagos_credito.cuota,
 
-        monto_boleta: pagos_credito.monto_boleta,
-        abono_capital: pagos_credito.abono_capital,
-        abono_interes: pagos_credito.abono_interes,
-        abono_iva_12: pagos_credito.abono_iva_12,
-        abono_interes_ci: pagos_credito.abono_interes_ci,
-        abono_iva_ci: pagos_credito.abono_iva_ci,
-        abono_seguro: pagos_credito.abono_seguro,
-        abono_gps: pagos_credito.abono_gps,
-        abono_membresias: pagos_credito.membresias_mes,
+				monto_boleta: pagos_credito.monto_boleta,
+				abono_capital: pagos_credito.abono_capital,
+				abono_interes: pagos_credito.abono_interes,
+				abono_iva_12: pagos_credito.abono_iva_12,
+				abono_interes_ci: pagos_credito.abono_interes_ci,
+				abono_iva_ci: pagos_credito.abono_iva_ci,
+				abono_seguro: pagos_credito.abono_seguro,
+				abono_gps: pagos_credito.abono_gps,
+				abono_membresias: pagos_credito.membresias_mes,
 
-        // 🔥 RESTANTES
-        capital_restante: pagos_credito.capital_restante,
-        interes_restante: pagos_credito.interes_restante,
-        iva_12_restante: pagos_credito.iva_12_restante,
-        seguro_restante: pagos_credito.seguro_restante,
-        gps_restante: pagos_credito.gps_restante,
-        membresias_restante: pagos_credito.membresias,
-        pago_mora: pagos_credito.mora,
-        pago_otros: pagos_credito.otros,
-      })
-      .from(cuotas_credito)
-      .leftJoin(
-        pagos_credito,
-        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
-      )
-      .where(
-        and(
-          eq(cuotas_credito.credito_id, creditoId),
-          eq(cuotas_credito.pagado, false),
-          lt(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
-          sql`NOT EXISTS (
+				// 🔥 RESTANTES
+				capital_restante: pagos_credito.capital_restante,
+				interes_restante: pagos_credito.interes_restante,
+				iva_12_restante: pagos_credito.iva_12_restante,
+				seguro_restante: pagos_credito.seguro_restante,
+				gps_restante: pagos_credito.gps_restante,
+				membresias_restante: pagos_credito.membresias,
+				pago_mora: pagos_credito.mora,
+				pago_otros: pagos_credito.otros,
+			})
+			.from(cuotas_credito)
+			.leftJoin(
+				pagos_credito,
+				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
+			)
+			.where(
+				and(
+					eq(cuotas_credito.credito_id, creditoId),
+					eq(cuotas_credito.pagado, false),
+					lt(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
+					sql`NOT EXISTS (
             SELECT 1
             FROM cartera.pagos_credito p_pending
             WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
               AND p_pending.validation_status = 'pending'
               AND p_pending.pagado = true
-          )`
-        )
-      )
-      .orderBy(asc(cuotas_credito.numero_cuota));
+          )`,
+				),
+			)
+			.orderBy(asc(cuotas_credito.numero_cuota));
 
-    const cuotasPendientes = await db
-      .select({
-        cuota_id: cuotas_credito.cuota_id,
-        credito_id: cuotas_credito.credito_id,
-        numero_cuota: cuotas_credito.numero_cuota,
-        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-        pagado: cuotas_credito.pagado,
-        createdAt: cuotas_credito.createdAt,
-        // 🔥 Campos de pagos_credito - ABONOS
-        pago_id: pagos_credito.pago_id,
-        monto_boleta: pagos_credito.monto_boleta,
-        abono_capital: pagos_credito.abono_capital,
-        abono_interes: pagos_credito.abono_interes,
-        abono_iva_12: pagos_credito.abono_iva_12,
-        abono_interes_ci: pagos_credito.abono_interes_ci,
-        abono_iva_ci: pagos_credito.abono_iva_ci,
-        abono_seguro: pagos_credito.abono_seguro,
-        abono_gps: pagos_credito.abono_gps,
-        abono_membresias: pagos_credito.membresias_mes,
+		const cuotasPendientes = await db
+			.select({
+				cuota_id: cuotas_credito.cuota_id,
+				credito_id: cuotas_credito.credito_id,
+				numero_cuota: cuotas_credito.numero_cuota,
+				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+				pagado: cuotas_credito.pagado,
+				createdAt: cuotas_credito.createdAt,
+				// 🔥 Campos de pagos_credito - ABONOS
+				pago_id: pagos_credito.pago_id,
+				cuota: pagos_credito.cuota,
+				monto_boleta: pagos_credito.monto_boleta,
+				abono_capital: pagos_credito.abono_capital,
+				abono_interes: pagos_credito.abono_interes,
+				abono_iva_12: pagos_credito.abono_iva_12,
+				abono_interes_ci: pagos_credito.abono_interes_ci,
+				abono_iva_ci: pagos_credito.abono_iva_ci,
+				abono_seguro: pagos_credito.abono_seguro,
+				abono_gps: pagos_credito.abono_gps,
+				abono_membresias: pagos_credito.membresias_mes,
 
-        // 🔥 RESTANTES
-        capital_restante: pagos_credito.capital_restante,
-        interes_restante: pagos_credito.interes_restante,
-        iva_12_restante: pagos_credito.iva_12_restante,
-        seguro_restante: pagos_credito.seguro_restante,
-        gps_restante: pagos_credito.gps_restante,
-        membresias_restante: pagos_credito.membresias,
-        pago_mora: pagos_credito.mora,
-        pago_otros: pagos_credito.otros,
-      })
-      .from(cuotas_credito)
-      .innerJoin(
-        pagos_credito,
-        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
-      )
-      .leftJoin(
-        convenios_pagos_resume,
-        eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id)
-      )
-      .where(
-        and(
-          eq(cuotas_credito.credito_id, creditoId),
-          eq(cuotas_credito.pagado, false),
-          sql`NOT EXISTS (
+				// 🔥 RESTANTES
+				capital_restante: pagos_credito.capital_restante,
+				interes_restante: pagos_credito.interes_restante,
+				iva_12_restante: pagos_credito.iva_12_restante,
+				seguro_restante: pagos_credito.seguro_restante,
+				gps_restante: pagos_credito.gps_restante,
+				membresias_restante: pagos_credito.membresias,
+				pago_mora: pagos_credito.mora,
+				pago_otros: pagos_credito.otros,
+			})
+			.from(cuotas_credito)
+			.innerJoin(
+				pagos_credito,
+				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
+			)
+			.leftJoin(
+				convenios_pagos_resume,
+				eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id),
+			)
+			.where(
+				and(
+					eq(cuotas_credito.credito_id, creditoId),
+					eq(cuotas_credito.pagado, false),
+					sql`NOT EXISTS (
             SELECT 1
             FROM cartera.pagos_credito p_pending
             WHERE p_pending.cuota_id = ${cuotas_credito.cuota_id}
               AND p_pending.validation_status = 'pending'
-          )`
-        )
-      )
-      .orderBy(cuotas_credito.numero_cuota);
+          )`,
+				),
+			)
+			.orderBy(cuotas_credito.numero_cuota);
 
-    const moraActual = await db
-      .select()
-      .from(moras_credito)
-      .where(
-        and(
-          eq(moras_credito.credito_id, creditoId),
-          eq(moras_credito.activa, true)
-        )
-      );
+		const moraActual = await db
+			.select()
+			.from(moras_credito)
+			.where(
+				and(
+					eq(moras_credito.credito_id, creditoId),
+					eq(moras_credito.activa, true),
+				),
+			);
 
-    // 6. Consultar si la cuota actual ya fue pagada
-    const cuotaActualDataResult = await db
-      .select({
-        cuota_id: cuotas_credito.cuota_id,
-        credito_id: cuotas_credito.credito_id,
-        numero_cuota: cuotas_credito.numero_cuota,
-        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-        pagado: cuotas_credito.pagado,
-        createdAt: cuotas_credito.createdAt,
-        validationStatus: pagos_credito.validationStatus,
-        // 🔥 Campos de pagos_credito - ABONOS
-        pago_id: pagos_credito.pago_id,
-        monto_boleta: pagos_credito.monto_boleta,
-        abono_capital: pagos_credito.abono_capital,
-        abono_interes: pagos_credito.abono_interes,
-        abono_iva_12: pagos_credito.abono_iva_12,
-        abono_interes_ci: pagos_credito.abono_interes_ci,
-        abono_iva_ci: pagos_credito.abono_iva_ci,
-        abono_seguro: pagos_credito.abono_seguro,
-        abono_gps: pagos_credito.abono_gps,
-        abono_membresias: pagos_credito.membresias_mes,
+		// 6. Consultar si la cuota actual ya fue pagada
+		const cuotaActualDataResult = await db
+			.select({
+				cuota_id: cuotas_credito.cuota_id,
+				credito_id: cuotas_credito.credito_id,
+				numero_cuota: cuotas_credito.numero_cuota,
+				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+				pagado: cuotas_credito.pagado,
+				createdAt: cuotas_credito.createdAt,
+				validationStatus: pagos_credito.validationStatus,
+				// 🔥 Campos de pagos_credito - ABONOS
+				pago_id: pagos_credito.pago_id,
+				cuota: pagos_credito.cuota,
+				monto_boleta: pagos_credito.monto_boleta,
+				abono_capital: pagos_credito.abono_capital,
+				abono_interes: pagos_credito.abono_interes,
+				abono_iva_12: pagos_credito.abono_iva_12,
+				abono_interes_ci: pagos_credito.abono_interes_ci,
+				abono_iva_ci: pagos_credito.abono_iva_ci,
+				abono_seguro: pagos_credito.abono_seguro,
+				abono_gps: pagos_credito.abono_gps,
+				abono_membresias: pagos_credito.membresias_mes,
 
-        // 🔥 RESTANTES
-        capital_restante: pagos_credito.capital_restante,
-        interes_restante: pagos_credito.interes_restante,
-        iva_12_restante: pagos_credito.iva_12_restante,
-        seguro_restante: pagos_credito.seguro_restante,
-        gps_restante: pagos_credito.gps_restante,
-        membresias_restante: pagos_credito.membresias,
-        pago_mora: pagos_credito.mora,
-        pago_otros: pagos_credito.otros,
-      })
-      .from(cuotas_credito)
-      .innerJoin(
-        pagos_credito,
-        eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
-      )
-      .leftJoin(
-        convenios_pagos_resume,
-        eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id)
-      )
-      .where(
-        and(
-          eq(cuotas_credito.credito_id, creditoId),
-          gt(cuotas_credito.numero_cuota, 0),
-          gte(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10))
-        )
-      )
-      .orderBy(cuotas_credito.fecha_vencimiento)
-      .limit(1);
+				// 🔥 RESTANTES
+				capital_restante: pagos_credito.capital_restante,
+				interes_restante: pagos_credito.interes_restante,
+				iva_12_restante: pagos_credito.iva_12_restante,
+				seguro_restante: pagos_credito.seguro_restante,
+				gps_restante: pagos_credito.gps_restante,
+				membresias_restante: pagos_credito.membresias,
+				pago_mora: pagos_credito.mora,
+				pago_otros: pagos_credito.otros,
+			})
+			.from(cuotas_credito)
+			.innerJoin(
+				pagos_credito,
+				eq(pagos_credito.cuota_id, cuotas_credito.cuota_id),
+			)
+			.leftJoin(
+				convenios_pagos_resume,
+				eq(convenios_pagos_resume.pago_id, pagos_credito.pago_id),
+			)
+			.where(
+				and(
+					eq(cuotas_credito.credito_id, creditoId),
+					gt(cuotas_credito.numero_cuota, 0),
+					gte(cuotas_credito.fecha_vencimiento, hoy.toISOString().slice(0, 10)),
+				),
+			)
+			.orderBy(cuotas_credito.fecha_vencimiento)
+			.limit(1);
 
-    // 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos sin cuota activa
-    if (!cuotaActualDataResult || cuotaActualDataResult.length === 0) {
-      return withActiveCancellation({
-        flujo: "ACTIVO",
-        credito: currentCredit.creditos,
-        usuario: currentCredit.usuarios,
-        asesor: currentCredit.asesores,
-        cuotaActual: null,
-        cuotaActualPagada: false,
-        cuotaActualStatus: null,
-        cuotasPendientes,
-        cuotasAtrasadas,
-        cuotasPagadas,
-        moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
-        mora: moraActual.length > 0 ? moraActual[0] : null,
-        convenioActivo: null,
-        cuotasEnConvenio: [],
-        pagosConvenio: [],
-      }, cancelacionActiva, currentCredit.creditos.statusCredit);
-    }
+		// 🔥 VALIDACIÓN: Si no hay cuota actual, retornar datos sin cuota activa
+		if (!cuotaActualDataResult || cuotaActualDataResult.length === 0) {
+			return withActiveCancellation(
+				{
+					flujo: "ACTIVO",
+					credito: currentCredit.creditos,
+					usuario: currentCredit.usuarios,
+					asesor: currentCredit.asesores,
+					cuotaActual: null,
+					cuotaActualPagada: false,
+					cuotaActualStatus: null,
+					cuotasPendientes,
+					cuotasAtrasadas,
+					cuotasPagadas,
+					moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
+					mora: moraActual.length > 0 ? moraActual[0] : null,
+					convenioActivo: null,
+					cuotasEnConvenio: [],
+					pagosConvenio: [],
+				},
+				cancelacionActiva,
+				currentCredit.creditos.statusCredit,
+			);
+		}
 
-    const cuotaActualData = cuotaActualDataResult[0];
+		const cuotaActualData = cuotaActualDataResult[0];
 
-    // ¿Está pagada la cuota actual?
-    const cuotaActualPagada = !!(cuotaActualData && cuotaActualData.pagado);
-    console.log("cuotaActualData", cuotaActualData);
+		// ¿Está pagada la cuota actual?
+		const cuotaActualPagada = !!(cuotaActualData && cuotaActualData.pagado);
+		console.log("cuotaActualData", cuotaActualData);
 
-    // La cuota actual del mes con toda su info
-    const cuotaActual = cuotaActualData;
-    const cuotaActualStatus = cuotaActualData.validationStatus;
+		// La cuota actual del mes con toda su info
+		const cuotaActual = cuotaActualData;
+		const cuotaActualStatus = cuotaActualData.validationStatus;
 
-    const convenioActivo = await db
-      .select()
-      .from(convenios_pago)
-      .where(
-        and(
-          eq(convenios_pago.credito_id, creditoId),
-          eq(convenios_pago.activo, true),
-          eq(convenios_pago.completado, false)
-        )
-      )
-      .limit(1);
+		const convenioActivo = await db
+			.select()
+			.from(convenios_pago)
+			.where(
+				and(
+					eq(convenios_pago.credito_id, creditoId),
+					eq(convenios_pago.activo, true),
+					eq(convenios_pago.completado, false),
+				),
+			)
+			.limit(1);
 
-    let cuotasEnConvenio: any[] = [];
-    let pagosConvenio: any[] = [];
-    let cuotasConvenioMensuales: any[] = [];
-    let cuotaConvenioAPagar = "0";
+		let cuotasEnConvenio: any[] = [];
+		let pagosConvenio: any[] = [];
+		let cuotasConvenioMensuales: any[] = [];
+		let cuotaConvenioAPagar = "0";
 
-    if (convenioActivo.length > 0) {
-      // Traer los pagos del convenio
-      pagosConvenio = await db
-        .select()
-        .from(convenios_pagos_resume)
-        .where(
-          eq(convenios_pagos_resume.convenio_id, convenioActivo[0].convenio_id)
-        );
+		if (convenioActivo.length > 0) {
+			// Traer los pagos del convenio
+			pagosConvenio = await db
+				.select()
+				.from(convenios_pagos_resume)
+				.where(
+					eq(convenios_pagos_resume.convenio_id, convenioActivo[0].convenio_id),
+				);
 
-      // 🔥 Traer las cuotas mensuales del convenio
-      cuotasConvenioMensuales = await db
-        .select()
-        .from(convenio_cuotas)
-        .where(eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id))
-        .orderBy(convenio_cuotas.numero_cuota);
+			// 🔥 Traer las cuotas mensuales del convenio
+			cuotasConvenioMensuales = await db
+				.select()
+				.from(convenio_cuotas)
+				.where(eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id))
+				.orderBy(convenio_cuotas.numero_cuota);
 
-      // Traer las cuotas que están en el convenio
-      const paymentIds = pagosConvenio.map((p) => p.pago_id);
+			// Traer las cuotas que están en el convenio
+			const paymentIds = pagosConvenio.map((p) => p.pago_id);
 
-      if (paymentIds.length > 0) {
-        // Primero traer los pagos para obtener los cuota_id
-        const pagos = await db
-          .select()
-          .from(pagos_credito)
-          .where(inArray(pagos_credito.pago_id, paymentIds));
+			if (paymentIds.length > 0) {
+				// Primero traer los pagos para obtener los cuota_id
+				const pagos = await db
+					.select()
+					.from(pagos_credito)
+					.where(inArray(pagos_credito.pago_id, paymentIds));
 
-        const cuotaIds = pagos.map((p) => p.cuota_id).filter((id): id is number => id !== null);
+				const cuotaIds = pagos
+					.map((p) => p.cuota_id)
+					.filter((id): id is number => id !== null);
 
-        // Luego traer las cuotas
-        cuotasEnConvenio = await db
-          .select()
-          .from(cuotas_credito)
-          .where(inArray(cuotas_credito.cuota_id, cuotaIds))
-          .orderBy(asc(cuotas_credito.numero_cuota));
-      }
+				// Luego traer las cuotas
+				cuotasEnConvenio = await db
+					.select()
+					.from(cuotas_credito)
+					.where(inArray(cuotas_credito.cuota_id, cuotaIds))
+					.orderBy(asc(cuotas_credito.numero_cuota));
+			}
 
-      const ahora = new Date();
-      const fechaGuatemalaString = ahora.toLocaleString("en-US", {
-        timeZone: "America/Guatemala",
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-      });
+			const ahora = new Date();
+			const fechaGuatemalaString = ahora.toLocaleString("en-US", {
+				timeZone: "America/Guatemala",
+				year: "numeric",
+				month: "2-digit",
+				day: "2-digit",
+			});
 
-      const [month, day, year] = fechaGuatemalaString.split(", ")[0].split("/");
-      const fechaActualGuatemala = `${year}-${month}-${day}`;
+			const [month, day, year] = fechaGuatemalaString.split(", ")[0].split("/");
+			const fechaActualGuatemala = `${year}-${month}-${day}`;
 
-      // 🔍 Buscar la cuota del mes actual desde la DB
-      const cuotaDelMesResult = await db
-        .select()
-        .from(convenio_cuotas)
-        .where(
-          and(
-            eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id),
-            gte(convenio_cuotas.fecha_vencimiento, fechaActualGuatemala)
-          )
-        )
-        .orderBy(asc(convenio_cuotas.fecha_vencimiento))
-        .limit(1);
+			// 🔍 Buscar la cuota del mes actual desde la DB
+			const cuotaDelMesResult = await db
+				.select()
+				.from(convenio_cuotas)
+				.where(
+					and(
+						eq(convenio_cuotas.convenio_id, convenioActivo[0].convenio_id),
+						gte(convenio_cuotas.fecha_vencimiento, fechaActualGuatemala),
+					),
+				)
+				.orderBy(asc(convenio_cuotas.fecha_vencimiento))
+				.limit(1);
 
-      const cuotaDelMes = cuotaDelMesResult[0];
-      console.log("cuotaDelMes convenio:", cuotaDelMes);
+			const cuotaDelMes = cuotaDelMesResult[0];
+			console.log("cuotaDelMes convenio:", cuotaDelMes);
 
-      // Si encontramos la cuota del mes y NO tiene fecha_pago, debe pagar
-      if (cuotaDelMes && cuotaDelMes.fecha_pago === null) {
-        cuotaConvenioAPagar = convenioActivo[0].cuota_mensual;
-        console.log(
-          `💰 Debe pagar cuota #${cuotaDelMes.numero_cuota} (vence: ${cuotaDelMes.fecha_vencimiento})`
-        );
-      } else if (cuotaDelMes && cuotaDelMes.fecha_pago) {
-        cuotaConvenioAPagar = "0";
-        console.log(
-          `✅ Cuota #${cuotaDelMes.numero_cuota} ya está pagada el ${cuotaDelMes.fecha_pago}`
-        );
-      } else {
-        cuotaConvenioAPagar = "0";
-        console.log("📅 Aún no hay cuota vencida este mes");
-      }
-    }
+			// Si encontramos la cuota del mes y NO tiene fecha_pago, debe pagar
+			if (cuotaDelMes && cuotaDelMes.fecha_pago === null) {
+				cuotaConvenioAPagar = convenioActivo[0].cuota_mensual;
+				console.log(
+					`💰 Debe pagar cuota #${cuotaDelMes.numero_cuota} (vence: ${cuotaDelMes.fecha_vencimiento})`,
+				);
+			} else if (cuotaDelMes && cuotaDelMes.fecha_pago) {
+				cuotaConvenioAPagar = "0";
+				console.log(
+					`✅ Cuota #${cuotaDelMes.numero_cuota} ya está pagada el ${cuotaDelMes.fecha_pago}`,
+				);
+			} else {
+				cuotaConvenioAPagar = "0";
+				console.log("📅 Aún no hay cuota vencida este mes");
+			}
+		}
 
-    return withActiveCancellation({
-      flujo: "ACTIVO",
-      credito: currentCredit.creditos,
-      usuario: currentCredit.usuarios,
-      asesor: currentCredit.asesores,
-      cuotaActual,
-      cuotaActualPagada,
-      cuotaActualStatus,
-      cuotasPendientes,
-      cuotasAtrasadas,
-      cuotasPagadas,
-      moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
-      mora: moraActual.length > 0 ? moraActual[0] : null,
-      convenioActivo:
-        convenioActivo.length > 0
-          ? {
-              ...convenioActivo[0],
-              cuotaConvenioAPagar,
-            }
-          : null,
-      cuotasEnConvenio,
-      pagosConvenio,
-    }, cancelacionActiva, currentCredit.creditos.statusCredit);
-  } catch (error) {
-    console.error("[getCreditoByNumero] Error:", error);
-    return { message: "Error consultando crédito", error: String(error) };
-  }
+		return withActiveCancellation(
+			{
+				flujo: "ACTIVO",
+				credito: currentCredit.creditos,
+				usuario: currentCredit.usuarios,
+				asesor: currentCredit.asesores,
+				cuotaActual,
+				cuotaActualPagada,
+				cuotaActualStatus,
+				cuotasPendientes,
+				cuotasAtrasadas,
+				cuotasPagadas,
+				moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
+				mora: moraActual.length > 0 ? moraActual[0] : null,
+				convenioActivo:
+					convenioActivo.length > 0
+						? {
+								...convenioActivo[0],
+								cuotaConvenioAPagar,
+							}
+						: null,
+				cuotasEnConvenio,
+				pagosConvenio,
+			},
+			cancelacionActiva,
+			currentCredit.creditos.statusCredit,
+		);
+	} catch (error) {
+		console.error("[getCreditoByNumero] Error:", error);
+		return { message: "Error consultando crédito", error: String(error) };
+	}
 };
 
 // Interfaces para cancelaciones/incobrables
 export interface CreditCancelation {
-  id: number;
-  credit_id: number;
-  motivo: string;
-  observaciones?: string | null;
-  fecha_cancelacion: Date | string;
-  monto_cancelacion: number;
+	id: number;
+	credit_id: number;
+	motivo: string;
+	observaciones?: string | null;
+	fecha_cancelacion: Date | string;
+	monto_cancelacion: number;
 }
 
 export interface BadDebt {
-  id: number;
-  credit_id: number;
-  motivo: string;
-  observaciones?: string | null;
-  fecha_registro: Date | string;
-  monto_incobrable: number;
+	id: number;
+	credit_id: number;
+	motivo: string;
+	observaciones?: string | null;
+	fecha_registro: Date | string;
+	monto_incobrable: number;
 }
 
 // 🆕 Tipos para próxima cuota
 type ProximidadPago = "TODAY" | "WEEK" | "TWO_WEEKS" | "MONTH" | "DUEMONTH";
 
 interface ProximaCuota {
-  cuota_id: number;
-  numero_cuota: number;
-  fecha_vencimiento: string;
-  pagado: boolean;
-  pago_id?: number;
-  validation_status?: string;
-  proximidad: ProximidadPago;
+	cuota_id: number;
+	numero_cuota: number;
+	fecha_vencimiento: string;
+	pagado: boolean;
+	pago_id?: number;
+	validation_status?: string;
+	proximidad: ProximidadPago;
 }
 
 // 🔥 Interface actualizada
 export interface CreditoConInfo {
-  creditos: typeof creditos.$inferSelect;
-  usuarios: typeof usuarios.$inferSelect;
-  asesores: typeof asesores.$inferSelect;
-  inversionistas: {
-    credito_id: number;
-    inversionista_id: number;
-    nombre: string;
-    emite_factura: boolean;
-    monto_aportado: string;
-    monto_cash_in: string;
-    monto_inversionista: string;
-    iva_cash_in: string;
-    iva_inversionista: string;
-    porcentaje_participacion_inversionista: string;
-    porcentaje_cash_in: string;
-    cuota_inversionista: string;
-    fecha_inicio_participacion?: string;
-  }[];
-  resumen: {
-    total_cash_in_monto: number;
-    total_cash_in_iva: number;
-    total_inversion_monto: number;
-    total_inversion_iva: number;
-  };
-  cancelacion?: CreditCancelation | null;
-  incobrable?: BadDebt | null;
-  rubros?: { nombre_rubro: string; monto: number }[];
-  mora?: any; // 👈 Este también faltaba si no lo tenías
-  deuda_total_con_mora?: string; // 👈 Este también
-  proxima_cuota?: ProximaCuota | null; // 🆕 NUEVO CAMPO
-  creditos_inversionistas_espejo?: {
-    credito_id: number;
-    inversionista_id: number;
-    nombre: string;
-    monto_aportado: string;
-    porcentaje_participacion: string;
-    porcentaje_cash_in: string;
-    porcentaje_inversion: string;
-    monto_cash_in: string;
-    monto_inversionista: string;
-    cuota_inversionista: string;
-    fecha_inicio_participacion?: string;
-  }[];
-  fecha_inicio?: string | null;
-  /** Nombre de la aseguradora vinculada al crédito (null si no tiene). */
-  aseguradora?: string | null;
+	creditos: typeof creditos.$inferSelect;
+	usuarios: typeof usuarios.$inferSelect;
+	asesores: typeof asesores.$inferSelect;
+	inversionistas: {
+		credito_id: number;
+		inversionista_id: number;
+		nombre: string;
+		emite_factura: boolean;
+		monto_aportado: string;
+		monto_cash_in: string;
+		monto_inversionista: string;
+		iva_cash_in: string;
+		iva_inversionista: string;
+		porcentaje_participacion_inversionista: string;
+		porcentaje_cash_in: string;
+		cuota_inversionista: string;
+		fecha_inicio_participacion?: string;
+	}[];
+	resumen: {
+		total_cash_in_monto: number;
+		total_cash_in_iva: number;
+		total_inversion_monto: number;
+		total_inversion_iva: number;
+	};
+	cancelacion?: CreditCancelation | null;
+	incobrable?: BadDebt | null;
+	rubros?: { nombre_rubro: string; monto: number }[];
+	mora?: any; // 👈 Este también faltaba si no lo tenías
+	deuda_total_con_mora?: string; // 👈 Este también
+	proxima_cuota?: ProximaCuota | null; // 🆕 NUEVO CAMPO
+	creditos_inversionistas_espejo?: {
+		credito_id: number;
+		inversionista_id: number;
+		nombre: string;
+		monto_aportado: string;
+		porcentaje_participacion: string;
+		porcentaje_cash_in: string;
+		porcentaje_inversion: string;
+		monto_cash_in: string;
+		monto_inversionista: string;
+		cuota_inversionista: string;
+		fecha_inicio_participacion?: string;
+	}[];
+	fecha_inicio?: string | null;
+	/** Nombre de la aseguradora vinculada al crédito (null si no tiene). */
+	aseguradora?: string | null;
 }
 
 // 🔥 Función auxiliar para calcular proximidad (con zona horaria de Guatemala)
 function calcularProximidad(fechaVencimiento: string): ProximidadPago {
-  // 🇬🇹 Hora de Guatemala
-  const hoy = new Date(
-    new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
-  );
-  hoy.setHours(0, 0, 0, 0);
+	// 🇬🇹 Hora de Guatemala
+	const hoy = new Date(
+		new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" }),
+	);
+	hoy.setHours(0, 0, 0, 0);
 
-  // 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
-  const [year, month, day] = fechaVencimiento.slice(0, 10).split("-").map(Number);
-  const vencimiento = new Date(year, month - 1, day);
-  vencimiento.setHours(0, 0, 0, 0);
+	// 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
+	const [year, month, day] = fechaVencimiento
+		.slice(0, 10)
+		.split("-")
+		.map(Number);
+	const vencimiento = new Date(year, month - 1, day);
+	vencimiento.setHours(0, 0, 0, 0);
 
-  const diffDays = Math.floor(
-    (vencimiento.getTime() - hoy.getTime()) / (1000 * 60 * 60 * 24)
-  );
+	const diffDays = Math.floor(
+		(vencimiento.getTime() - hoy.getTime()) / (1000 * 60 * 60 * 24),
+	);
 
-  if (diffDays === 0) return "TODAY";
-  if (diffDays > 0 && diffDays <= 7) return "WEEK";
-  if (diffDays > 7 && diffDays <= 14) return "TWO_WEEKS";
-  if (diffDays > 14 && diffDays <= 30) return "MONTH";
+	if (diffDays === 0) return "TODAY";
+	if (diffDays > 0 && diffDays <= 7) return "WEEK";
+	if (diffDays > 7 && diffDays <= 14) return "TWO_WEEKS";
+	if (diffDays > 14 && diffDays <= 30) return "MONTH";
 
-  return "DUEMONTH";
+	return "DUEMONTH";
 }
 
 export async function getCreditosWithUserByMesAnio(
-  mes: number,
-  anio: number,
-  page: number = 1,
-  perPage: number = 10,
-  numero_credito_sifco?: string,
-  estado?:
-    | "ACTIVO"
-    | "CANCELADO"
-    | "INCOBRABLE"
-    | "PENDIENTE_CANCELACION"
-    | "MOROSO"
-    | "EN_CONVENIO"
-    | "CAIDO",
-  asesor_id?: number,
-  nombre_usuario?: string,
-  email_asesor?: string,
-  cuotas_atrasadas?: number,
-  proximidad_pago?: ProximidadPago,
-  is_vehiculo_propio?: boolean,
-  inversionista_ids?: number[],
-  fecha_desde?: string,
-  fecha_hasta?: string,
-  numeros_credito_sifco?: string[],
-  capital_min?: number,
-  capital_max?: number,
-  estados_credito?: StatusCredit[],
-  aseguradora_id?: number,
-  excluir_pagados_mes?: boolean
+	mes: number,
+	anio: number,
+	page: number = 1,
+	perPage: number = 10,
+	numero_credito_sifco?: string,
+	estado?:
+		| "ACTIVO"
+		| "CANCELADO"
+		| "INCOBRABLE"
+		| "PENDIENTE_CANCELACION"
+		| "MOROSO"
+		| "EN_CONVENIO"
+		| "CAIDO",
+	asesor_id?: number,
+	nombre_usuario?: string,
+	email_asesor?: string,
+	cuotas_atrasadas?: number,
+	proximidad_pago?: ProximidadPago,
+	is_vehiculo_propio?: boolean,
+	inversionista_ids?: number[],
+	fecha_desde?: string,
+	fecha_hasta?: string,
+	numeros_credito_sifco?: string[],
+	capital_min?: number,
+	capital_max?: number,
+	estados_credito?: StatusCredit[],
+	aseguradora_id?: number,
+	excluir_pagados_mes?: boolean,
 ): Promise<{
-  data: CreditoConInfo[];
-  page: number;
-  perPage: number;
-  totalCount: number;
-  totalPages: number;
+	data: CreditoConInfo[];
+	page: number;
+	perPage: number;
+	totalCount: number;
+	totalPages: number;
 }> {
-  console.log(
-    `🚀 Fetching credits | mes: ${mes}, anio: ${anio}, page: ${page}, perPage: ${perPage}`
-  );
+	console.log(
+		`🚀 Fetching credits | mes: ${mes}, anio: ${anio}, page: ${page}, perPage: ${perPage}`,
+	);
 
-  const offset = (page - 1) * perPage;
-  const conditions: any[] = [];
+	const offset = (page - 1) * perPage;
+	const conditions: any[] = [];
 
-  // 🇬🇹 Fecha actual en Guatemala. sv-SE da directamente YYYY-MM-DD y no
-  // depende del TZ del proceso (el patrón anterior new Date(toLocaleString)
-  // + toISOString solo era correcto con el server en UTC).
-  const hoyStr = new Date().toLocaleDateString("sv-SE", {
-    timeZone: "America/Guatemala",
-  });
-  // Aritmética de días en espacio UTC puro (independiente del TZ del server).
-  const hoyUTC = new Date(`${hoyStr}T00:00:00Z`);
-  const sumarDiasStr = (dias: number) => {
-    const d = new Date(hoyUTC);
-    d.setUTCDate(d.getUTCDate() + dias);
-    return d.toISOString().slice(0, 10);
-  };
+	// 🇬🇹 Fecha actual en Guatemala. sv-SE da directamente YYYY-MM-DD y no
+	// depende del TZ del proceso (el patrón anterior new Date(toLocaleString)
+	// + toISOString solo era correcto con el server en UTC).
+	const hoyStr = new Date().toLocaleDateString("sv-SE", {
+		timeZone: "America/Guatemala",
+	});
+	// Aritmética de días en espacio UTC puro (independiente del TZ del server).
+	const hoyUTC = new Date(`${hoyStr}T00:00:00Z`);
+	const sumarDiasStr = (dias: number) => {
+		const d = new Date(hoyUTC);
+		d.setUTCDate(d.getUTCDate() + dias);
+		return d.toISOString().slice(0, 10);
+	};
 
-  try {
-    // 📌 Filtros
-    // Normalizar lista multi-SIFCO (tiene prioridad sobre el filtro single).
-    const sifcosLimpios = numeros_credito_sifco
-      ?.map((s) => s.trim())
-      .filter((s) => s.length > 0);
-    if (sifcosLimpios && sifcosLimpios.length > 0) {
-      console.log(
-        `🔎 Filtrando por ${sifcosLimpios.length} número(s) de crédito (multi)`
-      );
-      conditions.push(inArray(creditos.numero_credito_sifco, sifcosLimpios));
-    } else if (numero_credito_sifco && numero_credito_sifco.trim().length > 0) {
-      console.log(`🔎 Filtrando por número de crédito: ${numero_credito_sifco}`);
-      conditions.push(eq(creditos.numero_credito_sifco, numero_credito_sifco.trim()));
-    } else {
-      if (mes !== 0 && anio !== 0) {
-        console.log(`🔎 Filtrando por mes/año: ${mes}/${anio}`);
-        conditions.push(
-          sql`EXTRACT(MONTH FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${mes}`,
-          sql`EXTRACT(YEAR FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${anio}`
-        );
-      }
-    }
+	try {
+		// 📌 Filtros
+		// Normalizar lista multi-SIFCO (tiene prioridad sobre el filtro single).
+		const sifcosLimpios = numeros_credito_sifco
+			?.map((s) => s.trim())
+			.filter((s) => s.length > 0);
+		if (sifcosLimpios && sifcosLimpios.length > 0) {
+			console.log(
+				`🔎 Filtrando por ${sifcosLimpios.length} número(s) de crédito (multi)`,
+			);
+			conditions.push(inArray(creditos.numero_credito_sifco, sifcosLimpios));
+		} else if (numero_credito_sifco && numero_credito_sifco.trim().length > 0) {
+			console.log(
+				`🔎 Filtrando por número de crédito: ${numero_credito_sifco}`,
+			);
+			conditions.push(
+				eq(creditos.numero_credito_sifco, numero_credito_sifco.trim()),
+			);
+		} else {
+			if (mes !== 0 && anio !== 0) {
+				console.log(`🔎 Filtrando por mes/año: ${mes}/${anio}`);
+				conditions.push(
+					sql`EXTRACT(MONTH FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${mes}`,
+					sql`EXTRACT(YEAR FROM ${creditos.fecha_creacion} AT TIME ZONE 'America/Guatemala') = ${anio}`,
+				);
+			}
+		}
 
-    if (estado && estado.length > 0) {
-      if (estado === "ACTIVO") {
-        console.log(`🔎 Filtrando por estado: ACTIVO + MOROSO`);
-        if (cuotas_atrasadas == 0 ) {
-          conditions.push(sql`${creditos.statusCredit} IN ('ACTIVO')`);
-        } else {
-          conditions.push(sql`${creditos.statusCredit} IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')`);
-        }
-      } else {
-        console.log(`🔎 Filtrando por estado: ${estado}`);
-        conditions.push(eq(creditos.statusCredit, estado));
-      }
-    }
+		if (estado && estado.length > 0) {
+			if (estado === "ACTIVO") {
+				console.log(`🔎 Filtrando por estado: ACTIVO + MOROSO`);
+				if (cuotas_atrasadas == 0) {
+					conditions.push(sql`${creditos.statusCredit} IN ('ACTIVO')`);
+				} else {
+					conditions.push(
+						sql`${creditos.statusCredit} IN ('ACTIVO', 'MOROSO', 'EN_CONVENIO')`,
+					);
+				}
+			} else {
+				console.log(`🔎 Filtrando por estado: ${estado}`);
+				conditions.push(eq(creditos.statusCredit, estado));
+			}
+		}
 
-    if (estados_credito && estados_credito.length > 0) {
-      console.log(`🔎 Filtrando por estados seleccionables: ${estados_credito.join(", ")}`);
-      conditions.push(inArray(creditos.statusCredit, estados_credito));
-    }
+		if (estados_credito && estados_credito.length > 0) {
+			console.log(
+				`🔎 Filtrando por estados seleccionables: ${estados_credito.join(
+					", ",
+				)}`,
+			);
+			conditions.push(inArray(creditos.statusCredit, estados_credito));
+		}
 
-    if (asesor_id) {
-      console.log(`🔎 Filtrando por asesor_id: ${asesor_id}`);
-      conditions.push(eq(creditos.asesor_id, asesor_id));
-    }
+		if (asesor_id) {
+			console.log(`🔎 Filtrando por asesor_id: ${asesor_id}`);
+			conditions.push(eq(creditos.asesor_id, asesor_id));
+		}
 
-    if (nombre_usuario && nombre_usuario.trim().length > 0) {
-      console.log(`🔎 Filtrando por nombre de usuario: ${nombre_usuario}`);
-      const nameCond = buildNameSearchCondition(usuarios.nombre, nombre_usuario);
-      if (nameCond) conditions.push(nameCond);
-    }
+		if (nombre_usuario && nombre_usuario.trim().length > 0) {
+			console.log(`🔎 Filtrando por nombre de usuario: ${nombre_usuario}`);
+			const nameCond = buildNameSearchCondition(
+				usuarios.nombre,
+				nombre_usuario,
+			);
+			if (nameCond) conditions.push(nameCond);
+		}
 
-    if (email_asesor && email_asesor.trim().length > 0) {
-      console.log(`🔎 Filtrando por email de asesor: ${email_asesor}`);
-      conditions.push(
-        sql`${asesores.emailCashIn} ILIKE ${`%${email_asesor}%`}`
-      );
-    }
+		if (email_asesor && email_asesor.trim().length > 0) {
+			console.log(`🔎 Filtrando por email de asesor: ${email_asesor}`);
+			conditions.push(
+				sql`${asesores.emailCashIn} ILIKE ${`%${email_asesor}%`}`,
+			);
+		}
 
-    if (cuotas_atrasadas && cuotas_atrasadas > 0) {
-      // Mora 120+ es un bucket ABIERTO: `cuotas_atrasadas = 4` significa "4 o más",
-      // igual que el embudo (getCreditStats usa `>= 4` para ese bucket). Para 1/2/3
-      // (mora_30/60/90) cada etapa es un conteo exacto. Antes se usaba `eq` para todos,
-      // así que un crédito con 5+ cuotas se contaba en el embudo pero NO salía al
-      // filtrar la tabla por mora_120.
-      if (cuotas_atrasadas >= 4) {
-        console.log(`🔎 Filtrando por cuotas atrasadas >= ${cuotas_atrasadas}`);
-        conditions.push(gte(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
-      } else {
-        console.log(`🔎 Filtrando por cuotas atrasadas = ${cuotas_atrasadas}`);
-        conditions.push(eq(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
-      }
-    }
+		if (cuotas_atrasadas && cuotas_atrasadas > 0) {
+			// Mora 120+ es un bucket ABIERTO: `cuotas_atrasadas = 4` significa "4 o más",
+			// igual que el embudo (getCreditStats usa `>= 4` para ese bucket). Para 1/2/3
+			// (mora_30/60/90) cada etapa es un conteo exacto. Antes se usaba `eq` para todos,
+			// así que un crédito con 5+ cuotas se contaba en el embudo pero NO salía al
+			// filtrar la tabla por mora_120.
+			if (cuotas_atrasadas >= 4) {
+				console.log(`🔎 Filtrando por cuotas atrasadas >= ${cuotas_atrasadas}`);
+				conditions.push(gte(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
+			} else {
+				console.log(`🔎 Filtrando por cuotas atrasadas = ${cuotas_atrasadas}`);
+				conditions.push(eq(moras_credito.cuotas_atrasadas, cuotas_atrasadas));
+			}
+		}
 
-    if (is_vehiculo_propio) {
-      console.log(`🔎 Filtrando solo vehículos propios`);
-      conditions.push(eq(creditos.is_vehiculo_propio, true));
-    }
+		if (is_vehiculo_propio) {
+			console.log(`🔎 Filtrando solo vehículos propios`);
+			conditions.push(eq(creditos.is_vehiculo_propio, true));
+		}
 
-    if (inversionista_ids && inversionista_ids.length > 0) {
-      console.log(`🔎 Filtrando por inversionistas: ${inversionista_ids}`);
-      conditions.push(
-        inArray(creditos_inversionistas.inversionista_id, inversionista_ids)
-      );
-    }
-  } catch (err) {
-    console.error("❌ Error construyendo filtros:", err);
-    throw new Error("Error building filters");
-  }
+		if (inversionista_ids && inversionista_ids.length > 0) {
+			console.log(`🔎 Filtrando por inversionistas: ${inversionista_ids}`);
+			conditions.push(
+				inArray(creditos_inversionistas.inversionista_id, inversionista_ids),
+			);
+		}
+	} catch (err) {
+		console.error("❌ Error construyendo filtros:", err);
+		throw new Error("Error building filters");
+	}
 
-  // 🔥 Filtro de proximidad_pago / rango de fechas - se aplica ANTES de la paginación
-  const needsProximidadJoin = !!proximidad_pago || !!fecha_desde || !!fecha_hasta;
-  if (proximidad_pago) {
-    console.log(`🔎 Filtrando por proximidad de pago: ${proximidad_pago}`);
+	// 🔥 Filtro de proximidad_pago / rango de fechas - se aplica ANTES de la paginación
+	const needsProximidadJoin =
+		!!proximidad_pago || !!fecha_desde || !!fecha_hasta;
+	if (proximidad_pago) {
+		console.log(`🔎 Filtrando por proximidad de pago: ${proximidad_pago}`);
 
-    // Calcular rangos de fecha según proximidad (derivados de hoyStr para no
-    // depender del TZ del proceso)
-    if (proximidad_pago === "TODAY") {
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date = ${hoyStr}::date`);
-    } else if (proximidad_pago === "WEEK") {
-      const finStr = sumarDiasStr(7);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date > ${hoyStr}::date`);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
-    } else if (proximidad_pago === "TWO_WEEKS") {
-      const inicioStr = sumarDiasStr(8);
-      const finStr = sumarDiasStr(14);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
-    } else if (proximidad_pago === "MONTH") {
-      const inicioStr = sumarDiasStr(15);
-      const finStr = sumarDiasStr(30);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`);
-    } else if (proximidad_pago === "DUEMONTH") {
-      const inicioStr = sumarDiasStr(31);
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`);
-    }
+		// Calcular rangos de fecha según proximidad (derivados de hoyStr para no
+		// depender del TZ del proceso)
+		if (proximidad_pago === "TODAY") {
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date = ${hoyStr}::date`,
+			);
+		} else if (proximidad_pago === "WEEK") {
+			const finStr = sumarDiasStr(7);
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date > ${hoyStr}::date`,
+			);
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`,
+			);
+		} else if (proximidad_pago === "TWO_WEEKS") {
+			const inicioStr = sumarDiasStr(8);
+			const finStr = sumarDiasStr(14);
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`,
+			);
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`,
+			);
+		} else if (proximidad_pago === "MONTH") {
+			const inicioStr = sumarDiasStr(15);
+			const finStr = sumarDiasStr(30);
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`,
+			);
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date <= ${finStr}::date`,
+			);
+		} else if (proximidad_pago === "DUEMONTH") {
+			const inicioStr = sumarDiasStr(31);
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date >= ${inicioStr}::date`,
+			);
+		}
 
-    // Solo cuotas no pagadas y con numero > 0
-    conditions.push(eq(cuotas_credito.pagado, false));
-    conditions.push(gt(cuotas_credito.numero_cuota, 0));
-  }
+		// Solo cuotas no pagadas y con numero > 0
+		conditions.push(eq(cuotas_credito.pagado, false));
+		conditions.push(gt(cuotas_credito.numero_cuota, 0));
+	}
 
-  if (fecha_desde || fecha_hasta) {
-    if (!proximidad_pago) {
-      conditions.push(eq(cuotas_credito.pagado, false));
-      conditions.push(gt(cuotas_credito.numero_cuota, 0));
-    }
-    if (fecha_desde) {
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date >= ${fecha_desde}::date`);
-    }
-    if (fecha_hasta) {
-      conditions.push(sql`${cuotas_credito.fecha_vencimiento}::date <= ${fecha_hasta}::date`);
-    }
-  }
+	if (fecha_desde || fecha_hasta) {
+		if (!proximidad_pago) {
+			conditions.push(eq(cuotas_credito.pagado, false));
+			conditions.push(gt(cuotas_credito.numero_cuota, 0));
+		}
+		if (fecha_desde) {
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date >= ${fecha_desde}::date`,
+			);
+		}
+		if (fecha_hasta) {
+			conditions.push(
+				sql`${cuotas_credito.fecha_vencimiento}::date <= ${fecha_hasta}::date`,
+			);
+		}
+	}
 
+	if (capital_min !== undefined) {
+		conditions.push(sql`${creditos.capital}::numeric >= ${capital_min}`);
+	}
+	if (capital_max !== undefined) {
+		conditions.push(sql`${creditos.capital}::numeric <= ${capital_max}`);
+	}
 
-  if (capital_min !== undefined) {
-    conditions.push(sql`${creditos.capital}::numeric >= ${capital_min}`);
-  }
-  if (capital_max !== undefined) {
-    conditions.push(sql`${creditos.capital}::numeric <= ${capital_max}`);
-  }
+	if (aseguradora_id !== undefined) {
+		conditions.push(eq(creditos.aseguradora_id, aseguradora_id));
+	}
 
-  if (aseguradora_id !== undefined) {
-    conditions.push(eq(creditos.aseguradora_id, aseguradora_id));
-  }
-
-  if (excluir_pagados_mes) {
-    console.log(`🔎 Excluyendo créditos con su cuota actual ya pagada`);
-    // Cuota actual = la MISMA cuota que la tabla muestra como Fecha de Pago
-    // (proximasCuotasMap): primera cuota con fecha_vencimiento >= (fecha_desde
-    // ?? hoy), con tope fecha_hasta si hay rango — si las anclas divergen, un
-    // crédito con cuota impaga visible podría ocultarse. Se excluye el crédito
-    // solo si esa cuota está pagada (todas sus filas, por si hay duplicadas)
-    // Y no tiene mora activa; sin cuotas en el rango no se excluye.
-    // Subconsulta correlacionada en vez de join para no multiplicar filas
-    // (paginación) y para que el COUNT herede la condición.
-    const anclaDesde = fecha_desde ?? hoyStr;
-    conditions.push(sql`NOT (
+	if (excluir_pagados_mes) {
+		console.log(`🔎 Excluyendo créditos con su cuota actual ya pagada`);
+		// Cuota actual = la MISMA cuota que la tabla muestra como Fecha de Pago
+		// (proximasCuotasMap): primera cuota con fecha_vencimiento >= (fecha_desde
+		// ?? hoy), con tope fecha_hasta si hay rango — si las anclas divergen, un
+		// crédito con cuota impaga visible podría ocultarse. Se excluye el crédito
+		// solo si esa cuota está pagada (todas sus filas, por si hay duplicadas)
+		// Y no tiene mora activa; sin cuotas en el rango no se excluye.
+		// Subconsulta correlacionada en vez de join para no multiplicar filas
+		// (paginación) y para que el COUNT herede la condición.
+		const anclaDesde = fecha_desde ?? hoyStr;
+		conditions.push(sql`NOT (
       ${moras_credito.credito_id} IS NULL
       AND COALESCE((
         SELECT bool_and(COALESCE(cc.pagado, false))
@@ -808,606 +863,615 @@ export async function getCreditosWithUserByMesAnio(
             WHERE cc2.credito_id = ${creditos.credito_id}
               AND cc2.numero_cuota > 0
               AND cc2.fecha_vencimiento >= ${anclaDesde}::date
-              ${fecha_hasta ? sql`AND cc2.fecha_vencimiento <= ${fecha_hasta}::date` : sql``}
+              ${
+								fecha_hasta
+									? sql`AND cc2.fecha_vencimiento <= ${fecha_hasta}::date`
+									: sql``
+							}
           )
       ), false)
     )`);
-  }
+	}
 
-  const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
+	const whereCondition = conditions.length > 0 ? and(...conditions) : undefined;
 
-  let rows: any[] = [];
-  try {
-    // 1️⃣ 🔥 QUERY OPTIMIZADO - Buscar créditos únicos
-    let query = db
-      .select({
-        creditos,
-        usuarios,
-        asesores,
-        moras_credito,
-        aseguradora_nombre: aseguradoras.nombre,
-      })
-      .from(creditos)
-      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-      .leftJoin(
-        moras_credito,
-        and(
-          eq(creditos.credito_id, moras_credito.credito_id),
-          eq(moras_credito.activa, true) // 🔥 Solo moras activas
-        )
-      )
-      .leftJoin(aseguradoras, eq(creditos.aseguradora_id, aseguradoras.id));
+	let rows: any[] = [];
+	try {
+		// 1️⃣ 🔥 QUERY OPTIMIZADO - Buscar créditos únicos
+		let query = db
+			.select({
+				creditos,
+				usuarios,
+				asesores,
+				moras_credito,
+				aseguradora_nombre: aseguradoras.nombre,
+			})
+			.from(creditos)
+			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+			.leftJoin(
+				moras_credito,
+				and(
+					eq(creditos.credito_id, moras_credito.credito_id),
+					eq(moras_credito.activa, true), // 🔥 Solo moras activas
+				),
+			)
+			.leftJoin(aseguradoras, eq(creditos.aseguradora_id, aseguradoras.id));
 
-    // 🔥 JOIN con cuotas_credito si filtramos por proximidad
-    if (needsProximidadJoin) {
-      query = query.innerJoin(
-        cuotas_credito,
-        eq(creditos.credito_id, cuotas_credito.credito_id)
-      ) as any;
-    }
+		// 🔥 JOIN con cuotas_credito si filtramos por proximidad
+		if (needsProximidadJoin) {
+			query = query.innerJoin(
+				cuotas_credito,
+				eq(creditos.credito_id, cuotas_credito.credito_id),
+			) as any;
+		}
 
-    // 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
-    if (inversionista_ids && inversionista_ids.length > 0) {
-      query = query.innerJoin(
-        creditos_inversionistas,
-        eq(creditos.credito_id, creditos_inversionistas.credito_id)
-      ) as any;
-    }
+		// 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
+		if (inversionista_ids && inversionista_ids.length > 0) {
+			query = query.innerJoin(
+				creditos_inversionistas,
+				eq(creditos.credito_id, creditos_inversionistas.credito_id),
+			) as any;
+		}
 
-    rows = await query
-      .where(whereCondition)
-      .limit(perPage)
-      .offset(offset)
-      .orderBy(desc(creditos.fecha_creacion));
+		rows = await query
+			.where(whereCondition)
+			.limit(perPage)
+			.offset(offset)
+			.orderBy(desc(creditos.fecha_creacion));
 
-    console.log(`📄 Créditos encontrados: ${rows.length}`);
-  } catch (err) {
-    console.error("❌ Error consultando créditos:", err);
-    throw new Error("Error fetching credits");
-  }
+		console.log(`📄 Créditos encontrados: ${rows.length}`);
+	} catch (err) {
+		console.error("❌ Error consultando créditos:", err);
+		throw new Error("Error fetching credits");
+	}
 
-  // 🆔 IDs únicos de créditos
-  const creditosIds = [...new Set(rows.map((r) => r.creditos.credito_id))];
-  console.log("🆔 Créditos IDs únicos:", creditosIds);
+	// 🆔 IDs únicos de créditos
+	const creditosIds = [...new Set(rows.map((r) => r.creditos.credito_id))];
+	console.log("🆔 Créditos IDs únicos:", creditosIds);
 
-  // 2️⃣ Rubros
-  let rubrosMap: Record<number, { nombre_rubro: string; monto: number }[]> = {};
-  if (creditosIds.length > 0) {
-    try {
-      const rubrosPorCredito = await db
-        .select({
-          credito_id: creditos_rubros_otros.credito_id,
-          nombre_rubro: creditos_rubros_otros.nombre_rubro,
-          monto: creditos_rubros_otros.monto,
-        })
-        .from(creditos_rubros_otros)
-        .where(inArray(creditos_rubros_otros.credito_id, creditosIds));
+	// 2️⃣ Rubros
+	let rubrosMap: Record<number, { nombre_rubro: string; monto: number }[]> = {};
+	if (creditosIds.length > 0) {
+		try {
+			const rubrosPorCredito = await db
+				.select({
+					credito_id: creditos_rubros_otros.credito_id,
+					nombre_rubro: creditos_rubros_otros.nombre_rubro,
+					monto: creditos_rubros_otros.monto,
+				})
+				.from(creditos_rubros_otros)
+				.where(inArray(creditos_rubros_otros.credito_id, creditosIds));
 
-      console.log(`📊 Rubros encontrados: ${rubrosPorCredito.length}`);
+			console.log(`📊 Rubros encontrados: ${rubrosPorCredito.length}`);
 
-      // 🔥 Agrupar por credito_id
-      rubrosMap = rubrosPorCredito.reduce((acc, r) => {
-        if (!acc[r.credito_id]) {
-          acc[r.credito_id] = [];
-        }
-        acc[r.credito_id].push({
-          nombre_rubro: r.nombre_rubro,
-          monto: Number(r.monto),
-        });
-        return acc;
-      }, {} as Record<number, { nombre_rubro: string; monto: number }[]>);
-    } catch (err) {
-      console.error("❌ Error consultando rubros:", err);
-    }
-  }
+			// 🔥 Agrupar por credito_id
+			rubrosMap = rubrosPorCredito.reduce(
+				(acc, r) => {
+					if (!acc[r.credito_id]) {
+						acc[r.credito_id] = [];
+					}
+					acc[r.credito_id].push({
+						nombre_rubro: r.nombre_rubro,
+						monto: Number(r.monto),
+					});
+					return acc;
+				},
+				{} as Record<number, { nombre_rubro: string; monto: number }[]>,
+			);
+		} catch (err) {
+			console.error("❌ Error consultando rubros:", err);
+		}
+	}
 
-  // 3️⃣ 🔥 INVERSIONISTAS - Optimizado
-  let inversionistasMap: Record<number, any> = {};
-  let inversionistasEspejoMap: Record<number, any[]> = {}; // 🆕 Mapa para Espejos
+	// 3️⃣ 🔥 INVERSIONISTAS - Optimizado
+	let inversionistasMap: Record<number, any> = {};
+	let inversionistasEspejoMap: Record<number, any[]> = {}; // 🆕 Mapa para Espejos
 
-  if (creditosIds.length > 0) {
-    try {
-      // 3.1 Inversionistas Normales (Ordenados por ID para consistencia)
-      const inversionistasPorCredito = await db
-        .select({
-          credito_id: creditos_inversionistas.credito_id,
-          inversionista_id: inversionistas.inversionista_id,
-          nombre: inversionistas.nombre,
-          emite_factura: inversionistas.emite_factura,
-          monto_aportado: creditos_inversionistas.monto_aportado,
-          monto_cash_in: creditos_inversionistas.monto_cash_in,
-          monto_inversionista: creditos_inversionistas.monto_inversionista,
-          iva_cash_in: creditos_inversionistas.iva_cash_in,
-          iva_inversionista: creditos_inversionistas.iva_inversionista,
-          porcentaje_participacion_inversionista:
-            creditos_inversionistas.porcentaje_participacion_inversionista,
-          porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
-          cuota_inversionista: creditos_inversionistas.cuota_inversionista,
-          fecha_inicio_participacion: creditos_inversionistas.fecha_inicio_participacion,
-        })
-        .from(creditos_inversionistas)
-        .innerJoin(
-          inversionistas,
-          eq(
-            creditos_inversionistas.inversionista_id,
-            inversionistas.inversionista_id
-          )
-        )
-        .where(inArray(creditos_inversionistas.credito_id, creditosIds))
-        .orderBy(asc(creditos_inversionistas.id)); // 👈 Orden garantizado
+	if (creditosIds.length > 0) {
+		try {
+			// 3.1 Inversionistas Normales (Ordenados por ID para consistencia)
+			const inversionistasPorCredito = await db
+				.select({
+					credito_id: creditos_inversionistas.credito_id,
+					inversionista_id: inversionistas.inversionista_id,
+					nombre: inversionistas.nombre,
+					emite_factura: inversionistas.emite_factura,
+					monto_aportado: creditos_inversionistas.monto_aportado,
+					monto_cash_in: creditos_inversionistas.monto_cash_in,
+					monto_inversionista: creditos_inversionistas.monto_inversionista,
+					iva_cash_in: creditos_inversionistas.iva_cash_in,
+					iva_inversionista: creditos_inversionistas.iva_inversionista,
+					porcentaje_participacion_inversionista:
+						creditos_inversionistas.porcentaje_participacion_inversionista,
+					porcentaje_cash_in: creditos_inversionistas.porcentaje_cash_in,
+					cuota_inversionista: creditos_inversionistas.cuota_inversionista,
+					fecha_inicio_participacion:
+						creditos_inversionistas.fecha_inicio_participacion,
+				})
+				.from(creditos_inversionistas)
+				.innerJoin(
+					inversionistas,
+					eq(
+						creditos_inversionistas.inversionista_id,
+						inversionistas.inversionista_id,
+					),
+				)
+				.where(inArray(creditos_inversionistas.credito_id, creditosIds))
+				.orderBy(asc(creditos_inversionistas.id)); // 👈 Orden garantizado
 
-      // 3.2 Inversionistas Espejo (Ordenados por ID para consistencia)
-      const inversionistasEspejoPorCredito = await db
-        .select({
-          credito_id: creditos_inversionistas_espejo.credito_id,
-          inversionista_id: inversionistas.inversionista_id,
-          nombre: inversionistas.nombre,
-          monto_aportado: creditos_inversionistas_espejo.monto_aportado,
-          porcentaje_participacion: sql<string>`'0'`, // Calculado en frontend
-          porcentaje_cash_in: creditos_inversionistas_espejo.porcentaje_cash_in,
-          porcentaje_inversion:
-            creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
-          monto_cash_in: creditos_inversionistas_espejo.monto_cash_in,
-          monto_inversionista:
-            creditos_inversionistas_espejo.monto_inversionista,
-          cuota_inversionista:
-            creditos_inversionistas_espejo.cuota_inversionista,
-          fecha_inicio_participacion:
-            creditos_inversionistas_espejo.fecha_inicio_participacion,
-        })
-        .from(creditos_inversionistas_espejo)
-        .innerJoin(
-          inversionistas,
-          eq(
-            creditos_inversionistas_espejo.inversionista_id,
-            inversionistas.inversionista_id
-          )
-        )
-        .where(inArray(creditos_inversionistas_espejo.credito_id, creditosIds))
-        .orderBy(asc(creditos_inversionistas_espejo.id)); // 👈 Orden garantizado
+			// 3.2 Inversionistas Espejo (Ordenados por ID para consistencia)
+			const inversionistasEspejoPorCredito = await db
+				.select({
+					credito_id: creditos_inversionistas_espejo.credito_id,
+					inversionista_id: inversionistas.inversionista_id,
+					nombre: inversionistas.nombre,
+					monto_aportado: creditos_inversionistas_espejo.monto_aportado,
+					porcentaje_participacion: sql<string>`'0'`, // Calculado en frontend
+					porcentaje_cash_in: creditos_inversionistas_espejo.porcentaje_cash_in,
+					porcentaje_inversion:
+						creditos_inversionistas_espejo.porcentaje_participacion_inversionista,
+					monto_cash_in: creditos_inversionistas_espejo.monto_cash_in,
+					monto_inversionista:
+						creditos_inversionistas_espejo.monto_inversionista,
+					cuota_inversionista:
+						creditos_inversionistas_espejo.cuota_inversionista,
+					fecha_inicio_participacion:
+						creditos_inversionistas_espejo.fecha_inicio_participacion,
+				})
+				.from(creditos_inversionistas_espejo)
+				.innerJoin(
+					inversionistas,
+					eq(
+						creditos_inversionistas_espejo.inversionista_id,
+						inversionistas.inversionista_id,
+					),
+				)
+				.where(inArray(creditos_inversionistas_espejo.credito_id, creditosIds))
+				.orderBy(asc(creditos_inversionistas_espejo.id)); // 👈 Orden garantizado
 
-      // 3.3 Mapeo Normales
-      inversionistasMap = creditosIds.reduce(
-        (acc, creditoId) => {
-          const aportes = inversionistasPorCredito.filter(
-            (inv) => inv.credito_id === creditoId
-          );
+			// 3.3 Mapeo Normales
+			inversionistasMap = creditosIds.reduce(
+				(acc, creditoId) => {
+					const aportes = inversionistasPorCredito.filter(
+						(inv) => inv.credito_id === creditoId,
+					);
 
-          acc[creditoId] = {
-            aportes,
-            resumen: {
-              total_cash_in_monto: aportes.reduce(
-                (sum, cur) => sum + Number(cur.monto_cash_in ?? 0),
-                0
-              ),
-              total_cash_in_iva: aportes.reduce(
-                (sum, cur) => sum + Number(cur.iva_cash_in ?? 0),
-                0
-              ),
-              total_inversion_monto: aportes.reduce(
-                (sum, cur) => sum + Number(cur.monto_inversionista ?? 0),
-                0
-              ),
-              total_inversion_iva: aportes.reduce(
-                (sum, cur) => sum + Number(cur.iva_inversionista ?? 0),
-                0
-              ),
-            },
-          };
-          return acc;
-        },
-        {} as Record<number, any>
-      );
+					acc[creditoId] = {
+						aportes,
+						resumen: {
+							total_cash_in_monto: aportes.reduce(
+								(sum, cur) => sum + Number(cur.monto_cash_in ?? 0),
+								0,
+							),
+							total_cash_in_iva: aportes.reduce(
+								(sum, cur) => sum + Number(cur.iva_cash_in ?? 0),
+								0,
+							),
+							total_inversion_monto: aportes.reduce(
+								(sum, cur) => sum + Number(cur.monto_inversionista ?? 0),
+								0,
+							),
+							total_inversion_iva: aportes.reduce(
+								(sum, cur) => sum + Number(cur.iva_inversionista ?? 0),
+								0,
+							),
+						},
+					};
+					return acc;
+				},
+				{} as Record<number, any>,
+			);
 
-      // 3.4 Mapeo Espejos
-      inversionistasEspejoMap = creditosIds.reduce(
-        (acc, creditoId) => {
-          const aportesEspejo = inversionistasEspejoPorCredito.filter(
-            (inv) => inv.credito_id === creditoId
-          );
-          acc[creditoId] = aportesEspejo;
-          return acc;
-        },
-        {} as Record<number, any[]>
-      );
-    } catch (err) {
-      console.error("❌ Error consultando inversionistas:", err);
-    }
-  }
+			// 3.4 Mapeo Espejos
+			inversionistasEspejoMap = creditosIds.reduce(
+				(acc, creditoId) => {
+					const aportesEspejo = inversionistasEspejoPorCredito.filter(
+						(inv) => inv.credito_id === creditoId,
+					);
+					acc[creditoId] = aportesEspejo;
+					return acc;
+				},
+				{} as Record<number, any[]>,
+			);
+		} catch (err) {
+			console.error("❌ Error consultando inversionistas:", err);
+		}
+	}
 
-  // 4️⃣ Moras Map
-  const morasMap: Record<number, any> = {};
-  rows.forEach((row) => {
-    if (row.moras_credito) {
-      morasMap[row.creditos.credito_id] = row.moras_credito;
-    }
-  });
+	// 4️⃣ Moras Map
+	const morasMap: Record<number, any> = {};
+	rows.forEach((row) => {
+		if (row.moras_credito) {
+			morasMap[row.creditos.credito_id] = row.moras_credito;
+		}
+	});
 
-  // 5️⃣ Próximas cuotas
-  let proximasCuotasMap: Record<number, ProximaCuota> = {};
-  if (creditosIds.length > 0) {
-    try {
-      console.log("🔍 Buscando próximas cuotas...");
+	// 5️⃣ Próximas cuotas
+	let proximasCuotasMap: Record<number, ProximaCuota> = {};
+	if (creditosIds.length > 0) {
+		try {
+			console.log("🔍 Buscando próximas cuotas...");
 
-      const cuotasRaw = await db
-        .select({
-          credito_id: cuotas_credito.credito_id,
-          cuota_id: cuotas_credito.cuota_id,
-          numero_cuota: cuotas_credito.numero_cuota,
-          fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-          pagado: cuotas_credito.pagado,
-          pago_id: pagos_credito.pago_id,
-          validation_status: pagos_credito.validationStatus,
-        })
-        .from(cuotas_credito)
-        .leftJoin(
-          pagos_credito,
-          eq(cuotas_credito.cuota_id, pagos_credito.cuota_id)
-        )
-        .where(
-          and(
-            inArray(cuotas_credito.credito_id, creditosIds),
-            gte(cuotas_credito.fecha_vencimiento, fecha_desde ?? hoyStr),
-            fecha_hasta ? lte(cuotas_credito.fecha_vencimiento, fecha_hasta) : undefined,
-            gt(cuotas_credito.numero_cuota, 0)
-          )
-        )
-        .orderBy(cuotas_credito.credito_id, cuotas_credito.fecha_vencimiento);
+			const cuotasRaw = await db
+				.select({
+					credito_id: cuotas_credito.credito_id,
+					cuota_id: cuotas_credito.cuota_id,
+					numero_cuota: cuotas_credito.numero_cuota,
+					fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+					pagado: cuotas_credito.pagado,
+					pago_id: pagos_credito.pago_id,
+					validation_status: pagos_credito.validationStatus,
+				})
+				.from(cuotas_credito)
+				.leftJoin(
+					pagos_credito,
+					eq(cuotas_credito.cuota_id, pagos_credito.cuota_id),
+				)
+				.where(
+					and(
+						inArray(cuotas_credito.credito_id, creditosIds),
+						gte(cuotas_credito.fecha_vencimiento, fecha_desde ?? hoyStr),
+						fecha_hasta
+							? lte(cuotas_credito.fecha_vencimiento, fecha_hasta)
+							: undefined,
+						gt(cuotas_credito.numero_cuota, 0),
+					),
+				)
+				.orderBy(cuotas_credito.credito_id, cuotas_credito.fecha_vencimiento);
 
-      console.log(`📅 Cuotas encontradas: ${cuotasRaw.length}`);
+			console.log(`📅 Cuotas encontradas: ${cuotasRaw.length}`);
 
-      // 🔥 Solo la primera cuota de cada crédito
-      const cuotasPorCredito = new Map<number, any>();
-      cuotasRaw.forEach((cuota) => {
-        if (!cuotasPorCredito.has(cuota.credito_id)) {
-          cuotasPorCredito.set(cuota.credito_id, cuota);
-        }
-      });
+			// 🔥 Solo la primera cuota de cada crédito
+			const cuotasPorCredito = new Map<number, any>();
+			cuotasRaw.forEach((cuota) => {
+				if (!cuotasPorCredito.has(cuota.credito_id)) {
+					cuotasPorCredito.set(cuota.credito_id, cuota);
+				}
+			});
 
-      cuotasPorCredito.forEach((cuota, creditoId) => {
-        proximasCuotasMap[creditoId] = {
-          cuota_id: cuota.cuota_id,
-          numero_cuota: cuota.numero_cuota,
-          fecha_vencimiento: cuota.fecha_vencimiento,
-          pagado: cuota.pagado,
-          pago_id: cuota.pago_id,
-          validation_status: cuota.validation_status,
-          proximidad: calcularProximidad(cuota.fecha_vencimiento),
-        };
-      });
+			cuotasPorCredito.forEach((cuota, creditoId) => {
+				proximasCuotasMap[creditoId] = {
+					cuota_id: cuota.cuota_id,
+					numero_cuota: cuota.numero_cuota,
+					fecha_vencimiento: cuota.fecha_vencimiento,
+					pagado: cuota.pagado,
+					pago_id: cuota.pago_id,
+					validation_status: cuota.validation_status,
+					proximidad: calcularProximidad(cuota.fecha_vencimiento),
+				};
+			});
 
-      console.log(`📅 Próximas cuotas mapeadas: ${cuotasPorCredito.size}`);
-    } catch (err) {
-      console.error("❌ Error consultando próximas cuotas:", err);
-    }
-  }
+			console.log(`📅 Próximas cuotas mapeadas: ${cuotasPorCredito.size}`);
+		} catch (err) {
+			console.error("❌ Error consultando próximas cuotas:", err);
+		}
+	}
 
-  // 5.5 Fecha de inicio (cuota 1) de cada crédito
-  let fechaInicioMap: Record<number, string> = {};
-  if (creditosIds.length > 0) {
-    try {
-      const cuotasUno = await db
-        .select({
-          credito_id: cuotas_credito.credito_id,
-          fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-        })
-        .from(cuotas_credito)
-        .where(
-          and(
-            inArray(cuotas_credito.credito_id, creditosIds),
-            eq(cuotas_credito.numero_cuota, 1)
-          )
-        );
+	// 5.5 Fecha de inicio (cuota 1) de cada crédito
+	let fechaInicioMap: Record<number, string> = {};
+	if (creditosIds.length > 0) {
+		try {
+			const cuotasUno = await db
+				.select({
+					credito_id: cuotas_credito.credito_id,
+					fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+				})
+				.from(cuotas_credito)
+				.where(
+					and(
+						inArray(cuotas_credito.credito_id, creditosIds),
+						eq(cuotas_credito.numero_cuota, 1),
+					),
+				);
 
-      cuotasUno.forEach((c) => {
-        fechaInicioMap[c.credito_id] = c.fecha_vencimiento as string;
-      });
-    } catch (err) {
-      console.error("Error consultando fecha inicio:", err);
-    }
-  }
+			cuotasUno.forEach((c) => {
+				fechaInicioMap[c.credito_id] = c.fecha_vencimiento as string;
+			});
+		} catch (err) {
+			console.error("Error consultando fecha inicio:", err);
+		}
+	}
 
-  // 6️⃣ Cancelaciones & Incobrables
-  let cancelacionesMap: Record<number, CreditCancelation> = {};
-  let incobrablesMap: Record<number, BadDebt> = {};
+	// 6️⃣ Cancelaciones & Incobrables
+	let cancelacionesMap: Record<number, CreditCancelation> = {};
+	let incobrablesMap: Record<number, BadDebt> = {};
 
-  try {
-    const canceladosIds = rows
-      .filter((r) => r.creditos.statusCredit === "CANCELADO")
-      .map((r) => r.creditos.credito_id);
-      
-    if (canceladosIds.length > 0) {
-      console.log("🛑 Créditos cancelados:", canceladosIds.length);
-      const cancelacionesRaw = await db
-        .select()
-        .from(credit_cancelations)
-        .where(
-          and(
-            inArray(credit_cancelations.credit_id, canceladosIds), 
-          )
-        );
-        
-      cancelacionesRaw.forEach((row) => {
-        cancelacionesMap[row.credit_id] = {
-          ...row,
-          fecha_cancelacion: row.fecha_cancelacion ?? "",
-          monto_cancelacion: Number(row.monto_cancelacion),
-        };
-      });
-    }
-  } catch (err) {
-    console.error("❌ Error consultando cancelaciones:", err);
-  }
+	try {
+		const canceladosIds = rows
+			.filter((r) => r.creditos.statusCredit === "CANCELADO")
+			.map((r) => r.creditos.credito_id);
 
-  try {
-    const incobrablesIds = rows
-      .filter((r) => r.creditos.statusCredit === "INCOBRABLE")
-      .map((r) => r.creditos.credito_id);
-      
-    if (incobrablesIds.length > 0) {
-      console.log("⚠️ Créditos incobrables:", incobrablesIds.length);
-      const incobrablesRaw = await db
-        .select()
-        .from(bad_debts)
-        .where(inArray(bad_debts.credit_id, incobrablesIds));
-        
-      incobrablesRaw.forEach((row) => {
-        incobrablesMap[row.credit_id] = {
-          ...row,
-          fecha_registro: row.fecha_registro ?? "",
-          monto_incobrable: Number(row.monto_incobrable),
-        };
-      });
-    }
-  } catch (err) {
-    console.error("❌ Error consultando incobrables:", err);
-  }
+		if (canceladosIds.length > 0) {
+			console.log("🛑 Créditos cancelados:", canceladosIds.length);
+			const cancelacionesRaw = await db
+				.select()
+				.from(credit_cancelations)
+				.where(and(inArray(credit_cancelations.credit_id, canceladosIds)));
 
-  // 7️⃣ 🔥 MAP FINAL - Sin duplicados
-  let data: CreditoConInfo[] = [];
-  try {
-    // 🔥 Usar Map para asegurar créditos únicos
-    const creditosUnicos = new Map<number, any>();
-    
-    rows.forEach((row) => {
-      const creditoId = row.creditos.credito_id;
-      
-      // Solo agregar si no existe
-      if (!creditosUnicos.has(creditoId)) {
-        const info = inversionistasMap[creditoId] || {
-          aportes: [],
-          resumen: {
-            total_cash_in_monto: 0,
-            total_cash_in_iva: 0,
-            total_inversion_monto: 0,
-            total_inversion_iva: 0,
-          },
-        };
-        
-        const rubros = rubrosMap[creditoId] || [];
-        const cancelacion = row.creditos.statusCredit === "CANCELADO"
-          ? cancelacionesMap[creditoId] || null
-          : undefined;
-        const incobrable = row.creditos.statusCredit === "INCOBRABLE"
-          ? incobrablesMap[creditoId] || null
-          : undefined;
+			cancelacionesRaw.forEach((row) => {
+				cancelacionesMap[row.credit_id] = {
+					...row,
+					fecha_cancelacion: row.fecha_cancelacion ?? "",
+					monto_cancelacion: Number(row.monto_cancelacion),
+				};
+			});
+		}
+	} catch (err) {
+		console.error("❌ Error consultando cancelaciones:", err);
+	}
 
-        const mora = morasMap[creditoId] || null;
-        const deuda_total_con_mora = new Big(row.creditos.deudatotal ?? 0)
-          .plus(new Big(mora?.monto_mora ?? 0))
-          .toString();
+	try {
+		const incobrablesIds = rows
+			.filter((r) => r.creditos.statusCredit === "INCOBRABLE")
+			.map((r) => r.creditos.credito_id);
 
-        const proxima_cuota = proximasCuotasMap[creditoId] || null;
-        const fecha_inicio = fechaInicioMap[creditoId] || null;
+		if (incobrablesIds.length > 0) {
+			console.log("⚠️ Créditos incobrables:", incobrablesIds.length);
+			const incobrablesRaw = await db
+				.select()
+				.from(bad_debts)
+				.where(inArray(bad_debts.credit_id, incobrablesIds));
 
-        creditosUnicos.set(creditoId, {
-          creditos: row.creditos,
-          usuarios: row.usuarios,
-          asesores: row.asesores,
-          inversionistas: info.aportes,
-          creditos_inversionistas_espejo: inversionistasEspejoMap[creditoId] || [], // 👈 Agregado aquí
-          resumen: info.resumen,
-          cancelacion,
-          rubros,
-          incobrable,
-          mora,
-          deuda_total_con_mora,
-          proxima_cuota,
-          fecha_inicio,
-          aseguradora: row.aseguradora_nombre ?? null,
-        });
-      }
-    });
+			incobrablesRaw.forEach((row) => {
+				incobrablesMap[row.credit_id] = {
+					...row,
+					fecha_registro: row.fecha_registro ?? "",
+					monto_incobrable: Number(row.monto_incobrable),
+				};
+			});
+		}
+	} catch (err) {
+		console.error("❌ Error consultando incobrables:", err);
+	}
 
-    data = Array.from(creditosUnicos.values());
-    console.log(`✅ Créditos únicos mapeados: ${data.length}`);
-  } catch (err) {
-    console.error("❌ Error mapeando créditos:", err);
-    throw new Error("Error mapping credits");
-  }
+	// 7️⃣ 🔥 MAP FINAL - Sin duplicados
+	let data: CreditoConInfo[] = [];
+	try {
+		// 🔥 Usar Map para asegurar créditos únicos
+		const creditosUnicos = new Map<number, any>();
 
-  // 8️⃣ Filtro de proximidad - YA SE APLICA EN LA QUERY PRINCIPAL (antes de paginación)
+		rows.forEach((row) => {
+			const creditoId = row.creditos.credito_id;
 
-  // 9️⃣ Paginación - Count total
-  let count = 0;
-  try {
-    let countQuery = db
-      .select({ count: sql<number>`COUNT(DISTINCT ${creditos.credito_id})` }) // 🔥 DISTINCT
-      .from(creditos)
-      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-      .leftJoin(
-        platform_users,
-        eq(asesores.asesor_id, platform_users.asesor_id)
-      )
-      .leftJoin(
-        moras_credito,
-        and(
-          eq(creditos.credito_id, moras_credito.credito_id),
-          eq(moras_credito.activa, true)
-        )
-      );
+			// Solo agregar si no existe
+			if (!creditosUnicos.has(creditoId)) {
+				const info = inversionistasMap[creditoId] || {
+					aportes: [],
+					resumen: {
+						total_cash_in_monto: 0,
+						total_cash_in_iva: 0,
+						total_inversion_monto: 0,
+						total_inversion_iva: 0,
+					},
+				};
 
-    // 🔥 JOIN con cuotas_credito si filtramos por proximidad
-    if (needsProximidadJoin) {
-      countQuery = countQuery.innerJoin(
-        cuotas_credito,
-        eq(creditos.credito_id, cuotas_credito.credito_id)
-      ) as any;
-    }
+				const rubros = rubrosMap[creditoId] || [];
+				const cancelacion =
+					row.creditos.statusCredit === "CANCELADO"
+						? cancelacionesMap[creditoId] || null
+						: undefined;
+				const incobrable =
+					row.creditos.statusCredit === "INCOBRABLE"
+						? incobrablesMap[creditoId] || null
+						: undefined;
 
-    // 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
-    if (inversionista_ids && inversionista_ids.length > 0) {
-      countQuery = countQuery.innerJoin(
-        creditos_inversionistas,
-        eq(creditos.credito_id, creditos_inversionistas.credito_id)
-      ) as any;
-    }
+				const mora = morasMap[creditoId] || null;
+				const deuda_total_con_mora = new Big(row.creditos.deudatotal ?? 0)
+					.plus(new Big(mora?.monto_mora ?? 0))
+					.toString();
 
-    const [{ count: total }] = await countQuery.where(whereCondition);
+				const proxima_cuota = proximasCuotasMap[creditoId] || null;
+				const fecha_inicio = fechaInicioMap[creditoId] || null;
 
-    count = Number(total);
-    console.log(`📊 Total créditos únicos: ${count}`);
-  } catch (err) {
-    console.error("❌ Error contando créditos:", err);
-  }
+				creditosUnicos.set(creditoId, {
+					creditos: row.creditos,
+					usuarios: row.usuarios,
+					asesores: row.asesores,
+					inversionistas: info.aportes,
+					creditos_inversionistas_espejo:
+						inversionistasEspejoMap[creditoId] || [], // 👈 Agregado aquí
+					resumen: info.resumen,
+					cancelacion,
+					rubros,
+					incobrable,
+					mora,
+					deuda_total_con_mora,
+					proxima_cuota,
+					fecha_inicio,
+					aseguradora: row.aseguradora_nombre ?? null,
+				});
+			}
+		});
 
-  return {
-    data,
-    page,
-    perPage,
-    totalCount: count,
-    totalPages: Math.ceil(count / perPage),
-  };
+		data = Array.from(creditosUnicos.values());
+		console.log(`✅ Créditos únicos mapeados: ${data.length}`);
+	} catch (err) {
+		console.error("❌ Error mapeando créditos:", err);
+		throw new Error("Error mapping credits");
+	}
+
+	// 8️⃣ Filtro de proximidad - YA SE APLICA EN LA QUERY PRINCIPAL (antes de paginación)
+
+	// 9️⃣ Paginación - Count total
+	let count = 0;
+	try {
+		let countQuery = db
+			.select({ count: sql<number>`COUNT(DISTINCT ${creditos.credito_id})` }) // 🔥 DISTINCT
+			.from(creditos)
+			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+			.leftJoin(
+				platform_users,
+				eq(asesores.asesor_id, platform_users.asesor_id),
+			)
+			.leftJoin(
+				moras_credito,
+				and(
+					eq(creditos.credito_id, moras_credito.credito_id),
+					eq(moras_credito.activa, true),
+				),
+			);
+
+		// 🔥 JOIN con cuotas_credito si filtramos por proximidad
+		if (needsProximidadJoin) {
+			countQuery = countQuery.innerJoin(
+				cuotas_credito,
+				eq(creditos.credito_id, cuotas_credito.credito_id),
+			) as any;
+		}
+
+		// 🔥 JOIN con creditos_inversionistas si filtramos por inversionistas
+		if (inversionista_ids && inversionista_ids.length > 0) {
+			countQuery = countQuery.innerJoin(
+				creditos_inversionistas,
+				eq(creditos.credito_id, creditos_inversionistas.credito_id),
+			) as any;
+		}
+
+		const [{ count: total }] = await countQuery.where(whereCondition);
+
+		count = Number(total);
+		console.log(`📊 Total créditos únicos: ${count}`);
+	} catch (err) {
+		console.error("❌ Error contando créditos:", err);
+	}
+
+	return {
+		data,
+		page,
+		perPage,
+		totalCount: count,
+		totalPages: Math.ceil(count / perPage),
+	};
 }
 
 type Aporte = {
-  monto_cash_in: string; // viene como string desde la DB
-  monto_inversionista: string;
+	monto_cash_in: string; // viene como string desde la DB
+	monto_inversionista: string;
 };
 
 type ResultadoDistribucion = {
-  cuota_cash_in: Big;
-  iva_cash_in: Big;
-  cuota_inversionistas: Big;
-  iva_inversionistas: Big;
+	cuota_cash_in: Big;
+	iva_cash_in: Big;
+	cuota_inversionistas: Big;
+	iva_inversionistas: Big;
 };
 
 export function calcularDistribucionCuota({
-  capital,
-  cuota_interes,
-  aportes,
+	capital,
+	cuota_interes,
+	aportes,
 }: {
-  capital: Big;
-  cuota_interes: Big;
-  aportes: Aporte[];
+	capital: Big;
+	cuota_interes: Big;
+	aportes: Aporte[];
 }): ResultadoDistribucion {
-  const totalCashIn = aportes.reduce(
-    (acc, cur) => acc.plus(cur.monto_cash_in),
-    new Big(0)
-  );
+	const totalCashIn = aportes.reduce(
+		(acc, cur) => acc.plus(cur.monto_cash_in),
+		new Big(0),
+	);
 
-  const totalInversion = aportes.reduce(
-    (acc, cur) => acc.plus(cur.monto_inversionista),
-    new Big(0)
-  );
+	const totalInversion = aportes.reduce(
+		(acc, cur) => acc.plus(cur.monto_inversionista),
+		new Big(0),
+	);
 
-  const cuota_cash_in = totalCashIn.div(capital).times(cuota_interes).round(2);
-  const iva_cash_in = cuota_cash_in.times(0.12).round(2);
+	const cuota_cash_in = totalCashIn.div(capital).times(cuota_interes).round(2);
+	const iva_cash_in = cuota_cash_in.times(0.12).round(2);
 
-  const cuota_inversionistas = totalInversion
-    .div(capital)
-    .times(cuota_interes)
-    .round(2);
-  const iva_inversionistas = cuota_inversionistas.times(0.12).round(2);
+	const cuota_inversionistas = totalInversion
+		.div(capital)
+		.times(cuota_interes)
+		.round(2);
+	const iva_inversionistas = cuota_inversionistas.times(0.12).round(2);
 
-  return {
-    cuota_cash_in,
-    iva_cash_in,
-    cuota_inversionistas,
-    iva_inversionistas,
-  };
+	return {
+		cuota_cash_in,
+		iva_cash_in,
+		cuota_inversionistas,
+		iva_inversionistas,
+	};
 }
 
 export async function cancelCredit(creditId: number) {
-  try {
-    // 1. Obtener el crédito
-    const [credit] = await db
-      .select()
-      .from(creditos)
-      .where(eq(creditos.credito_id, creditId))
-      .limit(1);
+	try {
+		// 1. Obtener el crédito
+		const [credit] = await db
+			.select()
+			.from(creditos)
+			.where(eq(creditos.credito_id, creditId))
+			.limit(1);
 
-    if (!credit) {
-      return { message: "Crédito no encontrado." };
-    }
+		if (!credit) {
+			return { message: "Crédito no encontrado." };
+		}
 
-    // 2. Mora activa
-    const [morasCredito] = await db
-      .select()
-      .from(moras_credito)
-      .where(
-        and(
-          eq(moras_credito.credito_id, creditId),
-          eq(moras_credito.activa, true)
-        )
-      );
+		// 2. Mora activa
+		const [morasCredito] = await db
+			.select()
+			.from(moras_credito)
+			.where(
+				and(
+					eq(moras_credito.credito_id, creditId),
+					eq(moras_credito.activa, true),
+				),
+			);
 
-    // 3. Devolver valores unitarios por cuota (fijos del crédito)
-    return {
-      message: "Resumen del crédito a cancelar",
-      credito: {
-        capital: credit.capital ?? "0",
-        interes: credit.cuota_interes ?? "0",
-        iva: credit.iva_12 ?? "0",
-        membresias: credit.membresias ?? "0",
-        seguro: credit.seguro_10_cuotas ?? "0",
-        gps: credit.gps ?? "0",
-        mora: morasCredito ? morasCredito.monto_mora : "0",
-      },
-    };
-  } catch (error) {
-    console.error("Error cancelando crédito:", error);
-    return { message: "Error cancelando crédito", error: String(error) };
-  }
+		// 3. Devolver valores unitarios por cuota (fijos del crédito)
+		return {
+			message: "Resumen del crédito a cancelar",
+			credito: {
+				capital: credit.capital ?? "0",
+				interes: credit.cuota_interes ?? "0",
+				iva: credit.iva_12 ?? "0",
+				membresias: credit.membresias ?? "0",
+				seguro: credit.seguro_10_cuotas ?? "0",
+				gps: credit.gps ?? "0",
+				mora: morasCredito ? morasCredito.monto_mora : "0",
+			},
+		};
+	} catch (error) {
+		console.error("Error cancelando crédito:", error);
+		return { message: "Error cancelando crédito", error: String(error) };
+	}
 }
 
 const MontoAdicionalSchema = z.object({
-  concepto: z.string().min(1),
-  monto: z.number(), // positivo suma / negativo descuenta
+	concepto: z.string().min(1),
+	monto: z.number(), // positivo suma / negativo descuenta
 });
 // Define the inferred type from the schema
 type MontoAdicional = z.infer<typeof MontoAdicionalSchema>;
 
 const AccionCreditoParamsSchema = z.object({
-  creditId: z.number(),
-  motivo: z.string().optional(),
-  observaciones: z.string().optional(),
-  monto_cancelacion: z.number().optional(),
-  accion: z.enum([
-    "CANCELAR",
-    "ACTIVAR",
-    "INCOBRABLE",
-    "PENDIENTE_CANCELACION",
-    "EN_CONVENIO",
-    "MOROSO",
-  ]),
-  montosAdicionales: z.array(MontoAdicionalSchema).optional(),
-  traspaso: z.number().optional(),
-  garantia_mobiliaria: z.number().optional(),
-  otros: z.number().optional(),
-  cuotas_atrasadas: z.number().int().min(0).optional(),
+	creditId: z.number(),
+	motivo: z.string().optional(),
+	observaciones: z.string().optional(),
+	monto_cancelacion: z.number().optional(),
+	accion: z.enum([
+		"CANCELAR",
+		"ACTIVAR",
+		"INCOBRABLE",
+		"PENDIENTE_CANCELACION",
+		"EN_CONVENIO",
+		"MOROSO",
+	]),
+	montosAdicionales: z.array(MontoAdicionalSchema).optional(),
+	traspaso: z.number().optional(),
+	garantia_mobiliaria: z.number().optional(),
+	otros: z.number().optional(),
+	cuotas_atrasadas: z.number().int().min(0).optional(),
 });
 
 const STATUS_MAP = {
-  CANCELAR: "CANCELADO",
-  PENDIENTE_CANCELACION: "PENDIENTE_CANCELACION",
-  ACTIVAR: "ACTIVO",
-  INCOBRABLE: "INCOBRABLE",
-  EN_CONVENIO: "EN_CONVENIO",
-  MOROSO: "MOROSO",
-  // Puedes agregar más acciones aquí si las necesitas
+	CANCELAR: "CANCELADO",
+	PENDIENTE_CANCELACION: "PENDIENTE_CANCELACION",
+	ACTIVAR: "ACTIVO",
+	INCOBRABLE: "INCOBRABLE",
+	EN_CONVENIO: "EN_CONVENIO",
+	MOROSO: "MOROSO",
+	// Puedes agregar más acciones aquí si las necesitas
 };
 
 /**
@@ -1416,253 +1480,263 @@ const STATUS_MAP = {
 export type AccionCreditoParams = z.infer<typeof AccionCreditoParamsSchema>;
 
 export async function actualizarEstadoCredito(input: AccionCreditoParams) {
-  // Validate input
-  const {
-    creditId,
-    motivo,
-    observaciones,
-    monto_cancelacion,
-    accion,
-    montosAdicionales,
-    traspaso,
-    garantia_mobiliaria,
-    otros,
-    cuotas_atrasadas,
-  } = AccionCreditoParamsSchema.parse(input);
+	// Validate input
+	const {
+		creditId,
+		motivo,
+		observaciones,
+		monto_cancelacion,
+		accion,
+		montosAdicionales,
+		traspaso,
+		garantia_mobiliaria,
+		otros,
+		cuotas_atrasadas,
+	} = AccionCreditoParamsSchema.parse(input);
 
-  // Guard rails for actions that require motivo + monto
-  const needsReasonAndAmount =
-    accion === "CANCELAR" ||
-    accion === "PENDIENTE_CANCELACION" ||
-    accion === "INCOBRABLE";
-  if (needsReasonAndAmount && (!motivo || monto_cancelacion == null)) {
-    return {
-      ok: false,
-      message: "Debes enviar 'motivo' y 'monto_cancelacion' para esta acción.",
-    };
-  }
+	// Guard rails for actions that require motivo + monto
+	const needsReasonAndAmount =
+		accion === "CANCELAR" ||
+		accion === "PENDIENTE_CANCELACION" ||
+		accion === "INCOBRABLE";
+	if (needsReasonAndAmount && (!motivo || monto_cancelacion == null)) {
+		return {
+			ok: false,
+			message: "Debes enviar 'motivo' y 'monto_cancelacion' para esta acción.",
+		};
+	}
 
-  try {
-    const result = await db.transaction(async (tx) => {
-      /** 1) OPCIONAL: insertar montos adicionales ANTES del cambio de estado */
-      if (montosAdicionales?.length) {
-        await tx.insert(montos_adicionales).values(
-          montosAdicionales.map((m) => ({
-            credit_id: creditId,
-            concepto: m.concepto,
-            monto: m.monto.toString(), // numeric -> string
-          }))
-        );
-      }
+	try {
+		const result = await db.transaction(async (tx) => {
+			/** 1) OPCIONAL: insertar montos adicionales ANTES del cambio de estado */
+			if (montosAdicionales?.length) {
+				await tx.insert(montos_adicionales).values(
+					montosAdicionales.map((m) => ({
+						credit_id: creditId,
+						concepto: m.concepto,
+						monto: m.monto.toString(), // numeric -> string
+					})),
+				);
+			}
 
-      /** 2) Cambios según acción */
-      if (accion === "CANCELAR" || accion === "PENDIENTE_CANCELACION") {
-        const newStatus =
-          STATUS_MAP[accion as keyof typeof STATUS_MAP] ||
-          "PENDIENTE_CANCELACION";
+			/** 2) Cambios según acción */
+			if (accion === "CANCELAR" || accion === "PENDIENTE_CANCELACION") {
+				const newStatus =
+					STATUS_MAP[accion as keyof typeof STATUS_MAP] ||
+					"PENDIENTE_CANCELACION";
 
-        // a) Update credit status
-        await tx
-          .update(creditos)
-          .set({
-            statusCredit: newStatus as
-              | "CANCELADO"
-              | "ACTIVO"
-              | "INCOBRABLE"
-              | "PENDIENTE_CANCELACION",
-          })
-          .where(eq(creditos.credito_id, creditId));
+				// a) Update credit status
+				await tx
+					.update(creditos)
+					.set({
+						statusCredit: newStatus as
+							| "CANCELADO"
+							| "ACTIVO"
+							| "INCOBRABLE"
+							| "PENDIENTE_CANCELACION",
+					})
+					.where(eq(creditos.credito_id, creditId));
 
-        // b) Register cancelation (idempotent insert; assume one row per credit)
-        await tx.insert(credit_cancelations).values({
-          credit_id: creditId,
-          motivo: motivo!, // validated above
-          observaciones: observaciones ?? "",
-          monto_cancelacion: monto_cancelacion!.toString(),
-          traspaso: (traspaso ?? 0).toString(),
-          garantia_mobiliaria: (garantia_mobiliaria ?? 0).toString(),
-          otros: (otros ?? 0).toString(),
-          cuotas_atrasadas: cuotas_atrasadas ?? 0,
-        });
+				// b) Register cancelation (idempotent insert; assume one row per credit)
+				await tx.insert(credit_cancelations).values({
+					credit_id: creditId,
+					motivo: motivo!, // validated above
+					observaciones: observaciones ?? "",
+					monto_cancelacion: monto_cancelacion!.toString(),
+					traspaso: (traspaso ?? 0).toString(),
+					garantia_mobiliaria: (garantia_mobiliaria ?? 0).toString(),
+					otros: (otros ?? 0).toString(),
+					cuotas_atrasadas: cuotas_atrasadas ?? 0,
+				});
 
-        return {
-          ok: true,
-          message: `Crédito ${newStatus.toLowerCase().replace("_", " ")} correctamente`,
-        };
-      }
+				return {
+					ok: true,
+					message: `Crédito ${newStatus
+						.toLowerCase()
+						.replace("_", " ")} correctamente`,
+				};
+			}
 
-      if (accion === "ACTIVAR") {
-        // a) Set ACTIVE
-        await tx
-          .update(creditos)
-          .set({ statusCredit: "ACTIVO" })
-          .where(eq(creditos.credito_id, creditId));
+			if (accion === "ACTIVAR") {
+				// a) Set ACTIVE
+				await tx
+					.update(creditos)
+					.set({ statusCredit: "ACTIVO" })
+					.where(eq(creditos.credito_id, creditId));
 
-        // b) Remove cancelation & bad debt records
-        await tx
-          .delete(credit_cancelations)
-          .where(eq(credit_cancelations.credit_id, creditId));
-        await tx.delete(bad_debts).where(eq(bad_debts.credit_id, creditId));
-        await tx
-          .delete(montos_adicionales)
-          .where(eq(montos_adicionales.credit_id, creditId));
+				// b) Remove cancelation & bad debt records
+				await tx
+					.delete(credit_cancelations)
+					.where(eq(credit_cancelations.credit_id, creditId));
+				await tx.delete(bad_debts).where(eq(bad_debts.credit_id, creditId));
+				await tx
+					.delete(montos_adicionales)
+					.where(eq(montos_adicionales.credit_id, creditId));
 
-        return {
-          ok: true,
-          message: "Crédito reactivado y registros de cierre eliminados",
-        };
-      }
+				return {
+					ok: true,
+					message: "Crédito reactivado y registros de cierre eliminados",
+				};
+			}
 
-      // accion === "INCOBRABLE"
-      // TODO: Distribuir abono a capital en tabla espejo (CANCELACION)
-      // try {
-      //   await distribuirAbonoCapitalEspejo(creditId, monto_cancelacion!.toString(), "CANCELACION");
-      //   console.log("✅ Abono capital (incobrable) distribuido en tabla abonos_capital (espejo)");
-      // } catch (err) {
-      //   console.error("⚠️ Error al distribuir abono en espejo (incobrable):", err);
-      // }
+			// accion === "INCOBRABLE"
+			// TODO: Distribuir abono a capital en tabla espejo (CANCELACION)
+			// try {
+			//   await distribuirAbonoCapitalEspejo(creditId, monto_cancelacion!.toString(), "CANCELACION");
+			//   console.log("✅ Abono capital (incobrable) distribuido en tabla abonos_capital (espejo)");
+			// } catch (err) {
+			//   console.error("⚠️ Error al distribuir abono en espejo (incobrable):", err);
+			// }
 
-      // a) Obtener crédito actual
-      const [creditoActual] = await tx
-        .select()
-        .from(creditos)
-        .where(eq(creditos.credito_id, creditId));
+			// a) Obtener crédito actual
+			const [creditoActual] = await tx
+				.select()
+				.from(creditos)
+				.where(eq(creditos.credito_id, creditId));
 
-      if (!creditoActual) {
-        return { ok: false, message: "Crédito no encontrado" };
-      }
+			if (!creditoActual) {
+				return { ok: false, message: "Crédito no encontrado" };
+			}
 
-      // b) Capital = monto_incobrable, plazo = 1, cuota = capital completo
-      const capitalIncobrable = new Big(monto_cancelacion!);
+			// b) Capital = monto_incobrable, plazo = 1, cuota = capital completo
+			const capitalIncobrable = new Big(monto_cancelacion!);
 
-      // c) Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
-      //    paymentFalse=true). Además se ponen los *_restante en 0 para que las queries de
-      //    cuotas pendientes/atrasadas que NO filtran paymentFalse no muestren deuda fantasma.
-      const pagosNoPagados = await tx
-        .update(pagos_credito)
-        .set({
-          paymentFalse: true,
-          capital_restante: "0",
-          interes_restante: "0",
-          iva_12_restante: "0",
-          seguro_restante: "0",
-          gps_restante: "0",
-          total_restante: "0",
-          mora: "0",
-        })
-        .where(
-          and(
-            eq(pagos_credito.credito_id, creditId),
-            eq(pagos_credito.pagado, false)
-          )
-        )
-        .returning({ pago_id: pagos_credito.pago_id });
+			// c) Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
+			//    paymentFalse=true). Además se ponen los *_restante en 0 para que las queries de
+			//    cuotas pendientes/atrasadas que NO filtran paymentFalse no muestren deuda fantasma.
+			const pagosNoPagados = await tx
+				.update(pagos_credito)
+				.set({
+					paymentFalse: true,
+					capital_restante: "0",
+					interes_restante: "0",
+					iva_12_restante: "0",
+					seguro_restante: "0",
+					gps_restante: "0",
+					total_restante: "0",
+					mora: "0",
+				})
+				.where(
+					and(
+						eq(pagos_credito.credito_id, creditId),
+						eq(pagos_credito.pagado, false),
+					),
+				)
+				.returning({ pago_id: pagos_credito.pago_id });
 
-      const pagoIds = pagosNoPagados.map(p => p.pago_id);
+			const pagoIds = pagosNoPagados.map((p) => p.pago_id);
 
-      if (pagoIds.length > 0) {
-        console.log(`🚫 Anulados (paymentFalse) ${pagoIds.length} pagos no pagados del crédito #${creditId}`);
-      }
+			if (pagoIds.length > 0) {
+				console.log(
+					`🚫 Anulados (paymentFalse) ${pagoIds.length} pagos no pagados del crédito #${creditId}`,
+				);
+			}
 
-      // d) Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
-      //    anulados arriba, así que no aportan saldo en las vistas activas.
+			// d) Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
+			//    anulados arriba, así que no aportan saldo en las vistas activas.
 
-      // Crear cuota correlativa para el saldo incobrable
-      const [maxCuotaRowDirect] = await tx
-        .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
-        .from(cuotas_credito)
-        .where(eq(cuotas_credito.credito_id, creditId));
-      const nextNumeroCuotaIncobrable = Number(maxCuotaRowDirect?.max ?? 0) + 1;
+			// Crear cuota correlativa para el saldo incobrable
+			const [maxCuotaRowDirect] = await tx
+				.select({
+					max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
+				})
+				.from(cuotas_credito)
+				.where(eq(cuotas_credito.credito_id, creditId));
+			const nextNumeroCuotaIncobrable = Number(maxCuotaRowDirect?.max ?? 0) + 1;
 
-      const [cuotaIncobrableInsertada] = await tx
-        .insert(cuotas_credito)
-        .values({
-          credito_id: creditId,
-          numero_cuota: nextNumeroCuotaIncobrable,
-          fecha_vencimiento: new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" }),
-          pagado: false,
-          liquidado_inversionistas: false,
-        })
-        .returning({ cuota_id: cuotas_credito.cuota_id });
+			const [cuotaIncobrableInsertada] = await tx
+				.insert(cuotas_credito)
+				.values({
+					credito_id: creditId,
+					numero_cuota: nextNumeroCuotaIncobrable,
+					fecha_vencimiento: new Date().toLocaleDateString("sv-SE", {
+						timeZone: "America/Guatemala",
+					}),
+					pagado: false,
+					liquidado_inversionistas: false,
+				})
+				.returning({ cuota_id: cuotas_credito.cuota_id });
 
-      // e) Actualizar crédito: INCOBRABLE, plazo 1, cuota = capital completo
-      await setCapitalSource(tx, "CASTIGO");
-      await tx
-        .update(creditos)
-        .set({
-          statusCredit: "INCOBRABLE",
-          capital: capitalIncobrable.toString(),
-          plazo: 1,
-          cuota_interes: "0",
-          iva_12: "0",
-          membresias_pago: "0",
-          membresias: "0",
-          seguro_10_cuotas: "0",
-          gps: "0",
-          royalti: "0",
-          porcentaje_royalti: "0",
-          otros: "0",
-          cuota: capitalIncobrable.toString(),
-          deudatotal: capitalIncobrable.toString(),
-        })
-        .where(eq(creditos.credito_id, creditId));
+			// e) Actualizar crédito: INCOBRABLE, plazo 1, cuota = capital completo
+			await setCapitalSource(tx, "CASTIGO");
+			await tx
+				.update(creditos)
+				.set({
+					statusCredit: "INCOBRABLE",
+					capital: capitalIncobrable.toString(),
+					plazo: 1,
+					cuota_interes: "0",
+					iva_12: "0",
+					membresias_pago: "0",
+					membresias: "0",
+					seguro_10_cuotas: "0",
+					gps: "0",
+					royalti: "0",
+					porcentaje_royalti: "0",
+					otros: "0",
+					cuota: capitalIncobrable.toString(),
+					deudatotal: capitalIncobrable.toString(),
+				})
+				.where(eq(creditos.credito_id, creditId));
 
-      // f) Crear pago base con capital_restante = capital, enlazado a la cuota recién creada
-      await tx.insert(pagos_credito).values({
-        credito_id: creditId,
-        cuota: capitalIncobrable.toString(),
-        cuota_interes: "0",
-        cuota_id: cuotaIncobrableInsertada.cuota_id,
-        abono_capital: "0",
-        abono_interes: "0",
-        abono_iva_12: "0",
-        abono_interes_ci: "0",
-        abono_iva_ci: "0",
-        abono_seguro: "0",
-        abono_gps: "0",
-        pago_del_mes: "0",
-        monto_boleta: "0",
-        capital_restante: capitalIncobrable.toString(),
-        interes_restante: "0",
-        iva_12_restante: "0",
-        seguro_restante: "0",
-        gps_restante: "0",
-        total_restante: capitalIncobrable.toString(),
-        membresias: "0",
-        membresias_pago: "0",
-        membresias_mes: "0",
-        mora: "0",
-        monto_boleta_cuota: "0",
-        seguro_total: "0",
-        pagado: false,
-        registerBy: "SISTEMA-INCOBRABLE",
-        pagoConvenio: "0",
-        monto_aplicado: "0",
-        observaciones: `Pago base - Crédito marcado como incobrable: ${motivo}`,
-      });
+			// f) Crear pago base con capital_restante = capital, enlazado a la cuota recién creada
+			await tx.insert(pagos_credito).values({
+				credito_id: creditId,
+				cuota: capitalIncobrable.toString(),
+				cuota_interes: "0",
+				cuota_id: cuotaIncobrableInsertada.cuota_id,
+				abono_capital: "0",
+				abono_interes: "0",
+				abono_iva_12: "0",
+				abono_interes_ci: "0",
+				abono_iva_ci: "0",
+				abono_seguro: "0",
+				abono_gps: "0",
+				pago_del_mes: "0",
+				monto_boleta: "0",
+				capital_restante: capitalIncobrable.toString(),
+				interes_restante: "0",
+				iva_12_restante: "0",
+				seguro_restante: "0",
+				gps_restante: "0",
+				total_restante: capitalIncobrable.toString(),
+				membresias: "0",
+				membresias_pago: "0",
+				membresias_mes: "0",
+				mora: "0",
+				monto_boleta_cuota: "0",
+				seguro_total: "0",
+				pagado: false,
+				registerBy: "SISTEMA-INCOBRABLE",
+				pagoConvenio: "0",
+				monto_aplicado: "0",
+				observaciones: `Pago base - Crédito marcado como incobrable: ${motivo}`,
+			});
 
-      // h) Register bad debt
-      await tx.insert(bad_debts).values({
-        credit_id: creditId,
-        motivo: motivo!,
-        observaciones: observaciones ?? "",
-        monto_incobrable: monto_cancelacion!.toString(),
-      });
+			// h) Register bad debt
+			await tx.insert(bad_debts).values({
+				credit_id: creditId,
+				motivo: motivo!,
+				observaciones: observaciones ?? "",
+				monto_incobrable: monto_cancelacion!.toString(),
+			});
 
-      return {
-        ok: true,
-        message: `Crédito #${creditId} marcado como incobrable. Capital: Q${capitalIncobrable.toString()}, Plazo: 1, Cuota: Q${capitalIncobrable.toString()}, ${pagoIds.length} pagos anulados.`,
-      };
-    });
+			return {
+				ok: true,
+				message: `Crédito #${creditId} marcado como incobrable. Capital: Q${capitalIncobrable.toString()}, Plazo: 1, Cuota: Q${capitalIncobrable.toString()}, ${
+					pagoIds.length
+				} pagos anulados.`,
+			};
+		});
 
-    return result;
-  } catch (err) {
-    console.error("[ERROR] actualizarEstadoCredito:", err);
-    return {
-      ok: false,
-      message: "[ERROR] No fue posible actualizar el estado del crédito",
-    };
-  }
+		return result;
+	} catch (err) {
+		console.error("[ERROR] actualizarEstadoCredito:", err);
+		return {
+			ok: false,
+			message: "[ERROR] No fue posible actualizar el estado del crédito",
+		};
+	}
 }
 /**
  * Obtiene todos los créditos marcados como incobrables, junto con su usuario e información relevante.
@@ -1673,822 +1747,846 @@ export async function actualizarEstadoCredito(input: AccionCreditoParams) {
  * @param numero_credito_sifco (opcional) Número de crédito SIFCO para filtrar
  */
 export async function getCreditosIncobrables(
-  page: number = 1,
-  perPage: number = 20,
-  numero_credito_sifco?: string
+	page: number = 1,
+	perPage: number = 20,
+	numero_credito_sifco?: string,
 ) {
-  try {
-    console.log(
-      "[getCreditosIncobrables] Iniciando consulta de créditos incobrables..."
-    );
-    const offset = (page - 1) * perPage;
+	try {
+		console.log(
+			"[getCreditosIncobrables] Iniciando consulta de créditos incobrables...",
+		);
+		const offset = (page - 1) * perPage;
 
-    // Condición de filtro opcional por número de crédito SIFCO
-    const whereCondition =
-      numero_credito_sifco && numero_credito_sifco.length > 0
-        ? and(
-            eq(creditos.statusCredit, "INCOBRABLE"),
-            eq(creditos.numero_credito_sifco, numero_credito_sifco)
-          )
-        : eq(creditos.statusCredit, "INCOBRABLE");
+		// Condición de filtro opcional por número de crédito SIFCO
+		const whereCondition =
+			numero_credito_sifco && numero_credito_sifco.length > 0
+				? and(
+						eq(creditos.statusCredit, "INCOBRABLE"),
+						eq(creditos.numero_credito_sifco, numero_credito_sifco),
+					)
+				: eq(creditos.statusCredit, "INCOBRABLE");
 
-    // Buscar créditos incobrables paginados
-    const creditosIncobrables = await db
-      .select({
-        creditos,
-        usuarios,
-        asesores,
-        bad_debt: bad_debts,
-      })
-      .from(creditos)
-      .innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
-      .innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
-      .innerJoin(bad_debts, eq(creditos.credito_id, bad_debts.credit_id))
-      .where(eq(creditos.statusCredit, "INCOBRABLE"))
-      .orderBy(desc(creditos.fecha_creacion))
-      .limit(perPage)
-      .offset(offset);
+		// Buscar créditos incobrables paginados
+		const creditosIncobrables = await db
+			.select({
+				creditos,
+				usuarios,
+				asesores,
+				bad_debt: bad_debts,
+			})
+			.from(creditos)
+			.innerJoin(usuarios, eq(creditos.usuario_id, usuarios.usuario_id))
+			.innerJoin(asesores, eq(creditos.asesor_id, asesores.asesor_id))
+			.innerJoin(bad_debts, eq(creditos.credito_id, bad_debts.credit_id))
+			.where(eq(creditos.statusCredit, "INCOBRABLE"))
+			.orderBy(desc(creditos.fecha_creacion))
+			.limit(perPage)
+			.offset(offset);
 
-    // Total para paginación
-    const [{ count }] = await db
-      .select({ count: sql<number>`COUNT(*)` })
-      .from(creditos)
-      .where(eq(creditos.statusCredit, "INCOBRABLE"));
+		// Total para paginación
+		const [{ count }] = await db
+			.select({ count: sql<number>`COUNT(*)` })
+			.from(creditos)
+			.where(eq(creditos.statusCredit, "INCOBRABLE"));
 
-    console.log(
-      `[getCreditosIncobrables] Créditos incobrables encontrados: ${creditosIncobrables.length}`
-    );
-    return {
-      ok: true,
-      data: creditosIncobrables,
-      page,
-      perPage,
-      totalCount: Number(count),
-      totalPages: Math.ceil(Number(count) / perPage),
-    };
-  } catch (error) {
-    console.error(
-      "[getCreditosIncobrables] Error al obtener créditos incobrables:",
-      error
-    );
-    return {
-      ok: false,
-      message: "Error al obtener créditos incobrables",
-      error: String(error),
-    };
-  }
+		console.log(
+			`[getCreditosIncobrables] Créditos incobrables encontrados: ${creditosIncobrables.length}`,
+		);
+		return {
+			ok: true,
+			data: creditosIncobrables,
+			page,
+			perPage,
+			totalCount: Number(count),
+			totalPages: Math.ceil(Number(count) / perPage),
+		};
+	} catch (error) {
+		console.error(
+			"[getCreditosIncobrables] Error al obtener créditos incobrables:",
+			error,
+		);
+		return {
+			ok: false,
+			message: "Error al obtener créditos incobrables",
+			error: String(error),
+		};
+	}
 }
 
 export async function reiniciarCredito(
-  creditId: number,
-  montoIncobrable?: number
+	creditId: number,
+	montoIncobrable?: number,
 ) {
-  await withCapitalContext(null, "REINICIO", null, (tx) =>
-    tx
-      .update(creditos)
-      .set({
-        capital: "0",
-        deudatotal: montoIncobrable !== undefined ? String(montoIncobrable) : "0",
-        cuota_interes: "0",
-        cuota: "0",
-        iva_12: "0",
-        seguro_10_cuotas: "0",
-        gps: "0",
-        membresias_pago: "0",
-        membresias: "0",
-        porcentaje_royalti: "0",
-        royalti: "0",
-        otros: "0",
-        statusCredit: "ACTIVO",
-      })
-      .where(eq(creditos.credito_id, creditId))
-  );
+	await withCapitalContext(null, "REINICIO", null, (tx) =>
+		tx
+			.update(creditos)
+			.set({
+				capital: "0",
+				deudatotal:
+					montoIncobrable !== undefined ? String(montoIncobrable) : "0",
+				cuota_interes: "0",
+				cuota: "0",
+				iva_12: "0",
+				seguro_10_cuotas: "0",
+				gps: "0",
+				membresias_pago: "0",
+				membresias: "0",
+				porcentaje_royalti: "0",
+				royalti: "0",
+				otros: "0",
+				statusCredit: "ACTIVO",
+			})
+			.where(eq(creditos.credito_id, creditId)),
+	);
 }
 
 function construirUrlBoletas(url_boletas: string[], r2BaseUrl: string) {
-  return url_boletas.map((url_boleta) => `${r2BaseUrl}${url_boleta}`);
+	return url_boletas.map((url_boleta) => `${r2BaseUrl}${url_boleta}`);
 }
 export async function resetCredit({
-  creditId,
-  montoIncobrable,
-  montoBoleta,
-  url_boletas,
-  cuota,
-  banco_id,
-  numeroAutorizacion,
+	creditId,
+	montoIncobrable,
+	montoBoleta,
+	url_boletas,
+	cuota,
+	banco_id,
+	numeroAutorizacion,
 }: {
-  creditId: number;
-  montoIncobrable?: number;
-  montoBoleta: number | string;
-  url_boletas: string[];
-  cuota: number;
-  banco_id: number;
-  numeroAutorizacion?: string;
+	creditId: number;
+	montoIncobrable?: number;
+	montoBoleta: number | string;
+	url_boletas: string[];
+	cuota: number;
+	banco_id: number;
+	numeroAutorizacion?: string;
 }) {
-  try {
-    // 1. Jalar mora activa (si existe, se incluye en el pago de cierre)
-    const [moraActiva] = await db
-      .select({ monto_mora: moras_credito.monto_mora })
-      .from(moras_credito)
-      .where(
-        and(
-          eq(moras_credito.credito_id, creditId),
-          eq(moras_credito.activa, true)
-        )
-      )
-      .limit(1);
+	try {
+		// 1. Jalar mora activa (si existe, se incluye en el pago de cierre)
+		const [moraActiva] = await db
+			.select({ monto_mora: moras_credito.monto_mora })
+			.from(moras_credito)
+			.where(
+				and(
+					eq(moras_credito.credito_id, creditId),
+					eq(moras_credito.activa, true),
+				),
+			)
+			.limit(1);
 
-    const moraBig = new Big(moraActiva?.monto_mora as unknown as string ?? "0");
+		const moraBig = new Big(
+			(moraActiva?.monto_mora as unknown as string) ?? "0",
+		);
 
-    // 2. Consultar crédito ANTES de resetearlo (necesitamos los valores originales)
-    const [credito] = await db
-      .select()
-      .from(creditos)
-      .where(eq(creditos.credito_id, creditId));
-    if (!credito) {
-      throw new Error("Crédito no encontrado.");
-    }
-    if (!canResetCreditByStatus(credito.statusCredit)) {
-      throw new Error("El crédito no está pendiente de cancelación.");
-    }
+		// 2. Consultar crédito ANTES de resetearlo (necesitamos los valores originales)
+		const [credito] = await db
+			.select()
+			.from(creditos)
+			.where(eq(creditos.credito_id, creditId));
+		if (!credito) {
+			throw new Error("Crédito no encontrado.");
+		}
+		if (!canResetCreditByStatus(credito.statusCredit)) {
+			throw new Error("El crédito no está pendiente de cancelación.");
+		}
 
-    // 3. Determinar el estado del crédito
-    const statusCredit =
-      typeof montoIncobrable !== "undefined" &&
-      montoIncobrable > 0 &&
-      montoBoleta !== undefined
-        ? "INCOBRABLE"
-        : "CANCELADO";
+		// 3. Determinar el estado del crédito
+		const statusCredit =
+			typeof montoIncobrable !== "undefined" &&
+			montoIncobrable > 0 &&
+			montoBoleta !== undefined
+				? "INCOBRABLE"
+				: "CANCELADO";
 
-    // 4. Jalar la cancelación para obtener cuotas_atrasadas, garantía, traspaso, otros
-    const [cancelacion] = await db
-      .select()
-      .from(credit_cancelations)
-      .where(eq(credit_cancelations.credit_id, creditId))
-      .limit(1);
+		// 4. Jalar la cancelación para obtener cuotas_atrasadas, garantía, traspaso, otros
+		const [cancelacion] = await db
+			.select()
+			.from(credit_cancelations)
+			.where(eq(credit_cancelations.credit_id, creditId))
+			.limit(1);
 
-    const n = cancelacion?.cuotas_atrasadas ?? 0;
+		const n = cancelacion?.cuotas_atrasadas ?? 0;
 
-    // 5. Jalar extras (montos_adicionales)
-    const extrasRows = await db
-      .select({ monto: montos_adicionales.monto })
-      .from(montos_adicionales)
-      .where(eq(montos_adicionales.credit_id, creditId));
+		// 5. Jalar extras (montos_adicionales)
+		const extrasRows = await db
+			.select({ monto: montos_adicionales.monto })
+			.from(montos_adicionales)
+			.where(eq(montos_adicionales.credit_id, creditId));
 
-    const totalExtras = extrasRows.reduce(
-      (acc, row) => acc.plus(row.monto as unknown as string),
-      new Big(0)
-    );
+		const totalExtras = extrasRows.reduce(
+			(acc, row) => acc.plus(row.monto as unknown as string),
+			new Big(0),
+		);
 
-    // 6. Calcular abonos reales
-    const capitalOriginal = new Big(credito.capital ?? "0");
-    const abonoCapital = statusCredit === "INCOBRABLE"
-      ? capitalOriginal.minus(new Big(montoIncobrable!))
-      : capitalOriginal;
-    const abonoInteres = new Big(credito.cuota_interes ?? "0").times(n);
-    const abonoIva = new Big(credito.iva_12 ?? "0").times(n);
-    const abonoSeguro = new Big(credito.seguro_10_cuotas ?? "0").times(n);
-    const abonoGps = new Big(credito.gps ?? "0").times(n);
-    const abonoMembresias = new Big(credito.membresias ?? "0").times(n);
+		// 6. Calcular abonos reales
+		const capitalOriginal = new Big(credito.capital ?? "0");
+		const abonoCapital =
+			statusCredit === "INCOBRABLE"
+				? capitalOriginal.minus(new Big(montoIncobrable!))
+				: capitalOriginal;
+		const abonoInteres = new Big(credito.cuota_interes ?? "0").times(n);
+		const abonoIva = new Big(credito.iva_12 ?? "0").times(n);
+		const abonoSeguro = new Big(credito.seguro_10_cuotas ?? "0").times(n);
+		const abonoGps = new Big(credito.gps ?? "0").times(n);
+		const abonoMembresias = new Big(credito.membresias ?? "0").times(n);
 
-    const otrosCancelacion = new Big(cancelacion?.garantia_mobiliaria ?? "0")
-      .plus(cancelacion?.traspaso ?? "0")
-      .plus(cancelacion?.otros ?? "0")
-      .plus(totalExtras);
+		const otrosCancelacion = new Big(cancelacion?.garantia_mobiliaria ?? "0")
+			.plus(cancelacion?.traspaso ?? "0")
+			.plus(cancelacion?.otros ?? "0")
+			.plus(totalExtras);
 
-    const totalMontoPago = abonoCapital
-      .plus(abonoInteres)
-      .plus(abonoIva)
-      .plus(abonoSeguro)
-      .plus(abonoGps)
-      .plus(abonoMembresias)
-      .plus(otrosCancelacion)
-      .plus(moraBig);
+		const totalMontoPago = abonoCapital
+			.plus(abonoInteres)
+			.plus(abonoIva)
+			.plus(abonoSeguro)
+			.plus(abonoGps)
+			.plus(abonoMembresias)
+			.plus(otrosCancelacion)
+			.plus(moraBig);
 
-    // 7. Construir URLs de boletas
-    const r2BaseUrl = import.meta.env.URL_PUBLIC_R2 ?? "";
-    const urlCompletas = construirUrlBoletas(url_boletas, r2BaseUrl);
+		// 7. Construir URLs de boletas
+		const r2BaseUrl = import.meta.env.URL_PUBLIC_R2 ?? "";
+		const urlCompletas = construirUrlBoletas(url_boletas, r2BaseUrl);
 
-    // 8. Obtener pagos del mes + monto de boleta
-    const pago_del_mes = await getPagosDelMesActual(credito.credito_id);
-    const pago_del_mesBig = new Big(pago_del_mes ?? 0).add(montoBoleta ?? 0);
+		// 8. Obtener pagos del mes + monto de boleta
+		const pago_del_mes = await getPagosDelMesActual(credito.credito_id);
+		const pago_del_mesBig = new Big(pago_del_mes ?? 0).add(montoBoleta ?? 0);
 
-    // 9. Buscar cuota_id correspondiente
-    const [cuotaEncontrada] = await db
-      .select({ cuota_id: cuotas_credito.cuota_id })
-      .from(cuotas_credito)
-      .where(
-        and(
-          eq(cuotas_credito.credito_id, credito.credito_id),
-          eq(cuotas_credito.numero_cuota, cuota)
-        )
-      )
-      .limit(1);
+		// 9. Buscar cuota_id correspondiente
+		const [cuotaEncontrada] = await db
+			.select({ cuota_id: cuotas_credito.cuota_id })
+			.from(cuotas_credito)
+			.where(
+				and(
+					eq(cuotas_credito.credito_id, credito.credito_id),
+					eq(cuotas_credito.numero_cuota, cuota),
+				),
+			)
+			.limit(1);
 
-    const cuotaId = cuotaEncontrada?.cuota_id;
+		const cuotaId = cuotaEncontrada?.cuota_id;
 
-    // 10. Insertar pago de cierre con abonos reales
-    const [nuevoPago] = await db
-      .insert(pagos_credito)
-      .values({
-        credito_id: credito.credito_id,
-        cuota_id: cuotaId,
-        cuota: credito.cuota?.toString() ?? "0",
-        cuota_interes: credito.cuota_interes?.toString() ?? "0",
-        abono_capital: abonoCapital.toString(),
-        abono_interes: abonoInteres.toString(),
-        abono_iva_12: abonoIva.toString(),
-        abono_interes_ci: "0",
-        abono_iva_ci: "0",
-        abono_seguro: abonoSeguro.toString(),
-        abono_gps: abonoGps.toString(),
-        pago_del_mes: pago_del_mesBig.toString(),
-        monto_boleta: montoBoleta.toString(),
-        capital_restante: "0",
-        interes_restante: "0",
-        iva_12_restante: "0",
-        seguro_restante: "0",
-        gps_restante: "0",
-        total_restante: "0",
-        llamada: "",
-        renuevo_o_nuevo: "renuevo",
-        membresias: "0",
-        membresias_pago: abonoMembresias.toString(),
-        membresias_mes: abonoMembresias.toString(),
-        otros: otrosCancelacion.toString(),
-        mora: moraBig.toString(),
-        monto_boleta_cuota: montoBoleta.toString(),
-        seguro_total: credito.seguro_10_cuotas?.toString() ?? "0",
-        pagado: true,
-        facturacion: "si",
-        mes_pagado: "",
-        seguro_facturado: abonoSeguro.toString(),
-        gps_facturado: abonoGps.toString(),
-        reserva: "0",
-        observaciones: "",
-        validationStatus: "reset" as const,
-        banco_id: banco_id,
-        numeroAutorizacion: numeroAutorizacion ?? "",
-        registerBy: "system_reset",
-        pagoConvenio: "0",
-        monto_aplicado: totalMontoPago.toString(),
-      })
-      .returning();
+		// 10. Insertar pago de cierre con abonos reales
+		const [nuevoPago] = await db
+			.insert(pagos_credito)
+			.values({
+				credito_id: credito.credito_id,
+				cuota_id: cuotaId,
+				cuota: credito.cuota?.toString() ?? "0",
+				cuota_interes: credito.cuota_interes?.toString() ?? "0",
+				abono_capital: abonoCapital.toString(),
+				abono_interes: abonoInteres.toString(),
+				abono_iva_12: abonoIva.toString(),
+				abono_interes_ci: "0",
+				abono_iva_ci: "0",
+				abono_seguro: abonoSeguro.toString(),
+				abono_gps: abonoGps.toString(),
+				pago_del_mes: pago_del_mesBig.toString(),
+				monto_boleta: montoBoleta.toString(),
+				capital_restante: "0",
+				interes_restante: "0",
+				iva_12_restante: "0",
+				seguro_restante: "0",
+				gps_restante: "0",
+				total_restante: "0",
+				llamada: "",
+				renuevo_o_nuevo: "renuevo",
+				membresias: "0",
+				membresias_pago: abonoMembresias.toString(),
+				membresias_mes: abonoMembresias.toString(),
+				otros: otrosCancelacion.toString(),
+				mora: moraBig.toString(),
+				monto_boleta_cuota: montoBoleta.toString(),
+				seguro_total: credito.seguro_10_cuotas?.toString() ?? "0",
+				pagado: true,
+				facturacion: "si",
+				mes_pagado: "",
+				seguro_facturado: abonoSeguro.toString(),
+				gps_facturado: abonoGps.toString(),
+				reserva: "0",
+				observaciones: "",
+				validationStatus: "reset" as const,
+				banco_id: banco_id,
+				numeroAutorizacion: numeroAutorizacion ?? "",
+				registerBy: "system_reset",
+				pagoConvenio: "0",
+				monto_aplicado: totalMontoPago.toString(),
+			})
+			.returning();
 
-    // 11. Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
-    //     paymentFalse=true). Además se ponen los *_restante en 0: algunas queries de
-    //     cuotas pendientes/atrasadas (getCreditoByNumero, reportes) NO filtran paymentFalse,
-    //     así que sin esto mostrarían "deuda fantasma" con los restantes viejos.
-    await db
-      .update(pagos_credito)
-      .set({
-        paymentFalse: true,
-        capital_restante: "0",
-        interes_restante: "0",
-        iva_12_restante: "0",
-        seguro_restante: "0",
-        gps_restante: "0",
-        total_restante: "0",
-        mora: "0",
-      })
-      .where(
-        and(
-          eq(pagos_credito.credito_id, credito.credito_id),
-          eq(pagos_credito.pagado, false)
-        )
-      );
+		// 11. Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
+		//     paymentFalse=true). Además se ponen los *_restante en 0: algunas queries de
+		//     cuotas pendientes/atrasadas (getCreditoByNumero, reportes) NO filtran paymentFalse,
+		//     así que sin esto mostrarían "deuda fantasma" con los restantes viejos.
+		await db
+			.update(pagos_credito)
+			.set({
+				paymentFalse: true,
+				capital_restante: "0",
+				interes_restante: "0",
+				iva_12_restante: "0",
+				seguro_restante: "0",
+				gps_restante: "0",
+				total_restante: "0",
+				mora: "0",
+			})
+			.where(
+				and(
+					eq(pagos_credito.credito_id, credito.credito_id),
+					eq(pagos_credito.pagado, false),
+				),
+			);
 
-    // 12.1 Crear cuota correlativa (MAX(numero_cuota) + 1) para enlazar el pago de cierre
-    const [maxCuotaRow] = await db
-      .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
-      .from(cuotas_credito)
-      .where(eq(cuotas_credito.credito_id, credito.credito_id));
-    const nextNumeroCuotaCierre = Number(maxCuotaRow?.max ?? 0) + 1;
+		// 12.1 Crear cuota correlativa (MAX(numero_cuota) + 1) para enlazar el pago de cierre
+		const [maxCuotaRow] = await db
+			.select({
+				max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
+			})
+			.from(cuotas_credito)
+			.where(eq(cuotas_credito.credito_id, credito.credito_id));
+		const nextNumeroCuotaCierre = Number(maxCuotaRow?.max ?? 0) + 1;
 
-    const [cuotaCierre] = await db
-      .insert(cuotas_credito)
-      .values({
-        credito_id: credito.credito_id,
-        numero_cuota: nextNumeroCuotaCierre,
-        fecha_vencimiento: new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" }),
-        liquidado_inversionistas: false,
-        pagado: true,
-      })
-      .returning();
+		const [cuotaCierre] = await db
+			.insert(cuotas_credito)
+			.values({
+				credito_id: credito.credito_id,
+				numero_cuota: nextNumeroCuotaCierre,
+				fecha_vencimiento: new Date().toLocaleDateString("sv-SE", {
+					timeZone: "America/Guatemala",
+				}),
+				liquidado_inversionistas: false,
+				pagado: true,
+			})
+			.returning();
 
-    // 12.2 Enlazar el pago de cierre a la cuota recién creada (cuota correlativa "pagada"),
-    // para que el cierre quede asociado a una cuota limpia y no a una cuota vigente del plan.
-    if (nuevoPago?.pago_id && cuotaCierre?.cuota_id) {
-      await db
-        .update(pagos_credito)
-        .set({ cuota_id: cuotaCierre.cuota_id })
-        .where(eq(pagos_credito.pago_id, nuevoPago.pago_id));
-    }
+		// 12.2 Enlazar el pago de cierre a la cuota recién creada (cuota correlativa "pagada"),
+		// para que el cierre quede asociado a una cuota limpia y no a una cuota vigente del plan.
+		if (nuevoPago?.pago_id && cuotaCierre?.cuota_id) {
+			await db
+				.update(pagos_credito)
+				.set({ cuota_id: cuotaCierre.cuota_id })
+				.where(eq(pagos_credito.pago_id, nuevoPago.pago_id));
+		}
 
-    // 12. Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
-    //     anulados (paymentFalse=true) en el paso 11, así que no aportan saldo en las vistas activas.
+		// 12. Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
+		//     anulados (paymentFalse=true) en el paso 11, así que no aportan saldo en las vistas activas.
 
-    // 12.5 Distribuir abono a capital en tabla espejo (CANCELACION)
-    try {
-      await distribuirAbonoCapitalEspejo(credito.credito_id, abonoCapital.toString(), "CANCELACION");
-      console.log("✅ Abono capital (reset) distribuido en tabla abonos_capital (espejo)");
-    } catch (err) {
-      console.error("⚠️ Error al distribuir abono en espejo (reset):", err);
-    }
+		// 12.5 Distribuir abono a capital en tabla espejo (CANCELACION)
+		try {
+			await distribuirAbonoCapitalEspejo(
+				credito.credito_id,
+				abonoCapital.toString(),
+				"CANCELACION",
+			);
+			console.log(
+				"✅ Abono capital (reset) distribuido en tabla abonos_capital (espejo)",
+			);
+		} catch (err) {
+			console.error("⚠️ Error al distribuir abono en espejo (reset):", err);
+		}
 
-    // 13. Distribuir pago entre inversionistas (ANTES de reiniciar, necesita monto_aportado).
-    //     Si la suma de aportes es 0 (p.ej. crédito ya reseteado antes) la distribución lanza
-    //     excepción; la atrapamos para no abortar el cierre del crédito.
-    if (nuevoPago?.pago_id) {
-      try {
-        await insertPagosCreditoInversionistasV2(
-          nuevoPago.pago_id,
-          credito.credito_id
-        );
-      } catch (err) {
-        // Solo silenciamos el caso conocido y benigno: crédito SIN aportes (suma = 0),
-        // típico de un crédito ya reseteado antes. Cualquier otro fallo (inversionistas o
-        // pagos faltantes, error de DB, distribución a medias) SÍ se re-lanza: dejar el
-        // cierre sin liquidación de inversionistas e irreintentable sería peor.
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("suma de montos aportados es 0")) {
-          console.warn(
-            `⚠️ Distribución a inversionistas omitida (crédito ${credito.credito_id} sin aportes).`
-          );
-        } else {
-          throw err;
-        }
-      }
-    }
+		// 13. Distribuir pago entre inversionistas (ANTES de reiniciar, necesita monto_aportado).
+		//     Si la suma de aportes es 0 (p.ej. crédito ya reseteado antes) la distribución lanza
+		//     excepción; la atrapamos para no abortar el cierre del crédito.
+		if (nuevoPago?.pago_id) {
+			try {
+				await insertPagosCreditoInversionistasV2(
+					nuevoPago.pago_id,
+					credito.credito_id,
+				);
+			} catch (err) {
+				// Solo silenciamos el caso conocido y benigno: crédito SIN aportes (suma = 0),
+				// típico de un crédito ya reseteado antes. Cualquier otro fallo (inversionistas o
+				// pagos faltantes, error de DB, distribución a medias) SÍ se re-lanza: dejar el
+				// cierre sin liquidación de inversionistas e irreintentable sería peor.
+				const msg = err instanceof Error ? err.message : String(err);
+				if (msg.includes("suma de montos aportados es 0")) {
+					console.warn(
+						`⚠️ Distribución a inversionistas omitida (crédito ${credito.credito_id} sin aportes).`,
+					);
+				} else {
+					throw err;
+				}
+			}
+		}
 
-    // 14. Reiniciar creditos_inversionistas (no espejo)
-    await db
-      .update(creditos_inversionistas)
-      .set({
-        monto_aportado: "0",
-        monto_inversionista: "0",
-        monto_cash_in: "0",
-        iva_inversionista: "0",
-        iva_cash_in: "0",
-      })
-      .where(eq(creditos_inversionistas.credito_id, credito.credito_id));
+		// 14. Reiniciar creditos_inversionistas (no espejo)
+		await db
+			.update(creditos_inversionistas)
+			.set({
+				monto_aportado: "0",
+				monto_inversionista: "0",
+				monto_cash_in: "0",
+				iva_inversionista: "0",
+				iva_cash_in: "0",
+			})
+			.where(eq(creditos_inversionistas.credito_id, credito.credito_id));
 
-    // 15. Insertar boletas si existen
-    if (
-      urlCompletas &&
-      urlCompletas.length > 0 &&
-      nuevoPago &&
-      nuevoPago?.pago_id
-    ) {
-      await db.insert(boletas).values(
-        urlCompletas.map((url) => ({
-          pago_id: nuevoPago?.pago_id,
-          url_boleta: url,
-        }))
-      );
-    }
+		// 15. Insertar boletas si existen
+		if (
+			urlCompletas &&
+			urlCompletas.length > 0 &&
+			nuevoPago &&
+			nuevoPago?.pago_id
+		) {
+			await db.insert(boletas).values(
+				urlCompletas.map((url) => ({
+					pago_id: nuevoPago?.pago_id,
+					url_boleta: url,
+				})),
+			);
+		}
 
-    // 16. Al final: zerear el crédito y ponerle el status
-    const fechaHoyGT = new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+		// 16. Al final: zerear el crédito y ponerle el status
+		const fechaHoyGT = new Date().toLocaleDateString("sv-SE", {
+			timeZone: "America/Guatemala",
+		});
 
-    if (statusCredit === "INCOBRABLE") {
-      const capitalIncobrable = new Big(montoIncobrable!);
+		if (statusCredit === "INCOBRABLE") {
+			const capitalIncobrable = new Big(montoIncobrable!);
 
-      // 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
-      await withCapitalContext(null, "CASTIGO", null, (tx) =>
-        tx
-          .update(creditos)
-          .set({
-            capital: capitalIncobrable.toString(),
-            deudatotal: capitalIncobrable.toString(),
-            cuota_interes: "0",
-            cuota: capitalIncobrable.toString(),
-            iva_12: "0",
-            seguro_10_cuotas: "0",
-            gps: "0",
-            membresias_pago: "0",
-            membresias: "0",
-            porcentaje_royalti: "0",
-            royalti: "0",
-            otros: "0",
-            plazo: 1,
-            statusCredit: "INCOBRABLE",
-          })
-          .where(eq(creditos.credito_id, creditId))
-      );
+			// 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
+			await withCapitalContext(null, "CASTIGO", null, (tx) =>
+				tx
+					.update(creditos)
+					.set({
+						capital: capitalIncobrable.toString(),
+						deudatotal: capitalIncobrable.toString(),
+						cuota_interes: "0",
+						cuota: capitalIncobrable.toString(),
+						iva_12: "0",
+						seguro_10_cuotas: "0",
+						gps: "0",
+						membresias_pago: "0",
+						membresias: "0",
+						porcentaje_royalti: "0",
+						royalti: "0",
+						otros: "0",
+						plazo: 1,
+						statusCredit: "INCOBRABLE",
+					})
+					.where(eq(creditos.credito_id, creditId)),
+			);
 
-      // 16b. Crear cuota pendiente para el monto incobrable (correlativa)
-      const [maxCuotaRowInc] = await db
-        .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
-        .from(cuotas_credito)
-        .where(eq(cuotas_credito.credito_id, credito.credito_id));
-      const nextNumeroCuotaPendiente = Number(maxCuotaRowInc?.max ?? 0) + 1;
+			// 16b. Crear cuota pendiente para el monto incobrable (correlativa)
+			const [maxCuotaRowInc] = await db
+				.select({
+					max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
+				})
+				.from(cuotas_credito)
+				.where(eq(cuotas_credito.credito_id, credito.credito_id));
+			const nextNumeroCuotaPendiente = Number(maxCuotaRowInc?.max ?? 0) + 1;
 
-      const [cuotaPendiente] = await db
-        .insert(cuotas_credito)
-        .values({
-          credito_id: credito.credito_id,
-          numero_cuota: nextNumeroCuotaPendiente,
-          fecha_vencimiento: fechaHoyGT,
-          pagado: false,
-          liquidado_inversionistas: false,
-        })
-        .returning();
+			const [cuotaPendiente] = await db
+				.insert(cuotas_credito)
+				.values({
+					credito_id: credito.credito_id,
+					numero_cuota: nextNumeroCuotaPendiente,
+					fecha_vencimiento: fechaHoyGT,
+					pagado: false,
+					liquidado_inversionistas: false,
+				})
+				.returning();
 
-      // 16c. Crear pago placeholder (no pagado) con capital_restante = incobrable
-      await db.insert(pagos_credito).values({
-        credito_id: credito.credito_id,
-        cuota_id: cuotaPendiente.cuota_id,
-        cuota: capitalIncobrable.toString(),
-        cuota_interes: "0",
-        abono_capital: "0",
-        abono_interes: "0",
-        abono_iva_12: "0",
-        abono_interes_ci: "0",
-        abono_iva_ci: "0",
-        abono_seguro: "0",
-        abono_gps: "0",
-        pago_del_mes: "0",
-        monto_boleta: "0",
-        capital_restante: capitalIncobrable.toString(),
-        interes_restante: "0",
-        iva_12_restante: "0",
-        seguro_restante: "0",
-        gps_restante: "0",
-        total_restante: capitalIncobrable.toString(),
-        membresias: "0",
-        membresias_pago: "0",
-        membresias_mes: "0",
-        mora: "0",
-        monto_boleta_cuota: "0",
-        seguro_total: "0",
-        pagado: false,
-        registerBy: "SISTEMA-INCOBRABLE",
-        pagoConvenio: "0",
-        monto_aplicado: "0",
-        observaciones: `Pago base - Crédito marcado como incobrable (reset)`,
-      });
+			// 16c. Crear pago placeholder (no pagado) con capital_restante = incobrable
+			await db.insert(pagos_credito).values({
+				credito_id: credito.credito_id,
+				cuota_id: cuotaPendiente.cuota_id,
+				cuota: capitalIncobrable.toString(),
+				cuota_interes: "0",
+				abono_capital: "0",
+				abono_interes: "0",
+				abono_iva_12: "0",
+				abono_interes_ci: "0",
+				abono_iva_ci: "0",
+				abono_seguro: "0",
+				abono_gps: "0",
+				pago_del_mes: "0",
+				monto_boleta: "0",
+				capital_restante: capitalIncobrable.toString(),
+				interes_restante: "0",
+				iva_12_restante: "0",
+				seguro_restante: "0",
+				gps_restante: "0",
+				total_restante: capitalIncobrable.toString(),
+				membresias: "0",
+				membresias_pago: "0",
+				membresias_mes: "0",
+				mora: "0",
+				monto_boleta_cuota: "0",
+				seguro_total: "0",
+				pagado: false,
+				registerBy: "SISTEMA-INCOBRABLE",
+				pagoConvenio: "0",
+				monto_aplicado: "0",
+				observaciones: `Pago base - Crédito marcado como incobrable (reset)`,
+			});
 
-      // 16d. Registrar en bad_debts
-      await db.insert(bad_debts).values({
-        credit_id: creditId,
-        motivo: cancelacion?.motivo ?? "Incobrable",
-        observaciones: cancelacion?.observaciones ?? "",
-        monto_incobrable: capitalIncobrable.toString(),
-      });
-    } else {
-      // CANCELADO: zerear todo (preservamos porcentaje_interes)
-      await withCapitalContext(null, "CANCELACION", null, (tx) =>
-        tx
-          .update(creditos)
-          .set({
-            capital: "0",
-            deudatotal: "0",
-            cuota_interes: "0",
-            cuota: "0",
-            iva_12: "0",
-            seguro_10_cuotas: "0",
-            gps: "0",
-            membresias_pago: "0",
-            membresias: "0",
-            porcentaje_royalti: "0",
-            royalti: "0",
-            otros: "0",
-            statusCredit: "CANCELADO",
-          })
-          .where(eq(creditos.credito_id, creditId))
-      );
-    }
+			// 16d. Registrar en bad_debts
+			await db.insert(bad_debts).values({
+				credit_id: creditId,
+				motivo: cancelacion?.motivo ?? "Incobrable",
+				observaciones: cancelacion?.observaciones ?? "",
+				monto_incobrable: capitalIncobrable.toString(),
+			});
+		} else {
+			// CANCELADO: zerear todo (preservamos porcentaje_interes)
+			await withCapitalContext(null, "CANCELACION", null, (tx) =>
+				tx
+					.update(creditos)
+					.set({
+						capital: "0",
+						deudatotal: "0",
+						cuota_interes: "0",
+						cuota: "0",
+						iva_12: "0",
+						seguro_10_cuotas: "0",
+						gps: "0",
+						membresias_pago: "0",
+						membresias: "0",
+						porcentaje_royalti: "0",
+						royalti: "0",
+						otros: "0",
+						statusCredit: "CANCELADO",
+					})
+					.where(eq(creditos.credito_id, creditId)),
+			);
+		}
 
-    // 17. Retorno OK
-    return {
-      ok: true,
-      message: statusCredit === "INCOBRABLE"
-        ? `Crédito reiniciado como incobrable. Deuda pendiente: ${montoIncobrable}`
-        : "Crédito reiniciado y pago creado exitosamente.",
-    };
-  } catch (error) {
-    console.error("[ERROR] resetCredit:", error);
-    throw new Error(
-      error instanceof Error
-        ? error.message
-        : "Error al reiniciar el crédito y crear el pago."
-    );
-  }
+		// 17. Retorno OK
+		return {
+			ok: true,
+			message:
+				statusCredit === "INCOBRABLE"
+					? `Crédito reiniciado como incobrable. Deuda pendiente: ${montoIncobrable}`
+					: "Crédito reiniciado y pago creado exitosamente.",
+		};
+	} catch (error) {
+		console.error("[ERROR] resetCredit:", error);
+		throw new Error(
+			error instanceof Error
+				? error.message
+				: "Error al reiniciar el crédito y crear el pago.",
+		);
+	}
 }
 
 type SyncTermsInput = {
-  creditoId: number;
-  newCuota: number; // incoming updated cuota
-  newPlazo: number; // incoming updated plazo (months)
-  // Optional: pass preloaded credit to save a roundtrip (if you already fetched it)
-  preloadCredit?: {
-    cuota: string | number;
-    plazo: number;
-    capital: string | number;
-    porcentaje_interes: string | number;
-    iva_12: string | number;
-    deudatotal: string | number;
-    seguro_10_cuotas: string | number;
-    gps: string | number;
-    membresias_pago: string | number;
-    formato_credito?: string | null;
-  };
+	creditoId: number;
+	newCuota: number; // incoming updated cuota
+	newPlazo: number; // incoming updated plazo (months)
+	// Optional: pass preloaded credit to save a roundtrip (if you already fetched it)
+	preloadCredit?: {
+		cuota: string | number;
+		plazo: number;
+		capital: string | number;
+		porcentaje_interes: string | number;
+		iva_12: string | number;
+		deudatotal: string | number;
+		seguro_10_cuotas: string | number;
+		gps: string | number;
+		membresias_pago: string | number;
+		formato_credito?: string | null;
+	};
 };
 
 export async function syncScheduleOnTermsChange({
-  creditoId,
-  newCuota,
-  newPlazo,
-  preloadCredit,
+	creditoId,
+	newCuota,
+	newPlazo,
+	preloadCredit,
 }: SyncTermsInput) {
-  return await db.transaction(async (tx) => {
-    // 1) Load current credit
-    const [credit] = preloadCredit
-      ? [{ credito_id: creditoId, ...preloadCredit }]
-      : await tx
-          .select({
-            credito_id: creditos.credito_id,
-            cuota: creditos.cuota,
-            plazo: creditos.plazo,
-            capital: creditos.capital,
-            porcentaje_interes: creditos.porcentaje_interes,
-            iva_12: creditos.iva_12,
-            deudatotal: creditos.deudatotal,
-            seguro_10_cuotas: creditos.seguro_10_cuotas,
-            gps: creditos.gps,
-            membresias_pago: creditos.membresias_pago,
-            formato_credito: creditos.formato_credito,
-          })
-          .from(creditos)
-          .where(eq(creditos.credito_id, creditoId));
+	return await db.transaction(async (tx) => {
+		// 1) Load current credit
+		const [credit] = preloadCredit
+			? [{ credito_id: creditoId, ...preloadCredit }]
+			: await tx
+					.select({
+						credito_id: creditos.credito_id,
+						cuota: creditos.cuota,
+						plazo: creditos.plazo,
+						capital: creditos.capital,
+						porcentaje_interes: creditos.porcentaje_interes,
+						iva_12: creditos.iva_12,
+						deudatotal: creditos.deudatotal,
+						seguro_10_cuotas: creditos.seguro_10_cuotas,
+						gps: creditos.gps,
+						membresias_pago: creditos.membresias_pago,
+						formato_credito: creditos.formato_credito,
+					})
+					.from(creditos)
+					.where(eq(creditos.credito_id, creditoId));
 
-    if (!credit) {
-      throw new Error("[ERROR] Credit not found");
-    }
+		if (!credit) {
+			throw new Error("[ERROR] Credit not found");
+		}
 
-    const oldCuotaNum = Number(credit.cuota ?? 0);
-    const oldPlazoNum = Number(credit.plazo ?? 0);
-    const changedCuota = Number(newCuota) !== oldCuotaNum;
-    const changedPlazo = Number(newPlazo) !== oldPlazoNum;
+		const oldCuotaNum = Number(credit.cuota ?? 0);
+		const oldPlazoNum = Number(credit.plazo ?? 0);
+		const changedCuota = Number(newCuota) !== oldCuotaNum;
+		const changedPlazo = Number(newPlazo) !== oldPlazoNum;
 
-    if (!changedCuota && !changedPlazo) {
-      // Nothing to do
-      return { updated: false, reason: "No changes" };
-    }
+		if (!changedCuota && !changedPlazo) {
+			// Nothing to do
+			return { updated: false, reason: "No changes" };
+		}
 
-    // --- helper: generate due dates like your creation logic (30th or last day) ---
-    function generateNextDates(fromDateISO: string, count: number): string[] {
-      // fromDateISO = 'YYYY-MM-DD'
-      const [y, m, d] = fromDateISO.split("-").map((v) => Number(v));
-      const base = new Date(Date.UTC(y, m - 1, d, 12, 0, 0)); // noon UTC
-      const dates: string[] = [];
+		// --- helper: generate due dates like your creation logic (30th or last day) ---
+		function generateNextDates(fromDateISO: string, count: number): string[] {
+			// fromDateISO = 'YYYY-MM-DD'
+			const [y, m, d] = fromDateISO.split("-").map((v) => Number(v));
+			const base = new Date(Date.UTC(y, m - 1, d, 12, 0, 0)); // noon UTC
+			const dates: string[] = [];
 
-      for (let i = 0; i < count; i++) {
-        const dt = new Date(base);
-        // move month + i + 1 (next months)
-        dt.setUTCMonth(dt.getUTCMonth() + i + 1);
+			for (let i = 0; i < count; i++) {
+				const dt = new Date(base);
+				// move month + i + 1 (next months)
+				dt.setUTCMonth(dt.getUTCMonth() + i + 1);
 
-        const month = dt.getUTCMonth();
-        const year = dt.getUTCFullYear();
-        // last day of month
-        const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-        const day = lastDay < 30 ? lastDay : 30;
+				const month = dt.getUTCMonth();
+				const year = dt.getUTCFullYear();
+				// last day of month
+				const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+				const day = lastDay < 30 ? lastDay : 30;
 
-        const final = new Date(Date.UTC(year, month, day, 12, 0, 0));
-        // Return in 'sv-SE' like your logic (YYYY-MM-DD)
-        const iso = final
-          .toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
-          .toString();
-        dates.push(iso);
-      }
-      return dates;
-    }
+				const final = new Date(Date.UTC(year, month, day, 12, 0, 0));
+				// Return in 'sv-SE' like your logic (YYYY-MM-DD)
+				const iso = final
+					.toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
+					.toString();
+				dates.push(iso);
+			}
+			return dates;
+		}
 
-    // --- 2) If only cuota changed: update cuota in UNPAID payments ---
-    if (changedCuota && !changedPlazo) {
-      await tx
-        .update(pagos_credito)
-        .set({
-          // only cuota changes, everything else stays as-is
-          cuota: new Big(newCuota).round(2).toString(),
-        })
-        .where(
-          and(
-            eq(pagos_credito.credito_id, creditoId),
-            eq(pagos_credito.pagado, false)
-          )
-        );
+		// --- 2) If only cuota changed: update cuota in UNPAID payments ---
+		if (changedCuota && !changedPlazo) {
+			await tx
+				.update(pagos_credito)
+				.set({
+					// only cuota changes, everything else stays as-is
+					cuota: new Big(newCuota).round(2).toString(),
+				})
+				.where(
+					and(
+						eq(pagos_credito.credito_id, creditoId),
+						eq(pagos_credito.pagado, false),
+					),
+				);
 
-      // Reflect new cuota in creditos row (keeping your other totals untouched)
-      await tx
-        .update(creditos)
-        .set({ cuota: new Big(newCuota).round(2).toString() })
-        .where(eq(creditos.credito_id, creditoId));
+			// Reflect new cuota in creditos row (keeping your other totals untouched)
+			await tx
+				.update(creditos)
+				.set({ cuota: new Big(newCuota).round(2).toString() })
+				.where(eq(creditos.credito_id, creditoId));
 
-      return { updated: true, changedCuota: true, changedPlazo: false };
-    }
+			return { updated: true, changedCuota: true, changedPlazo: false };
+		}
 
-    // --- 3) If plazo changed: add/remove schedule, and also handle cuota change if applies ---
-    // Load current cuotas (excluding numero_cuota = 0 "cuota inicial")
-    const cuotasRows = await tx
-      .select({
-        cuota_id: cuotas_credito.cuota_id,
-        numero_cuota: cuotas_credito.numero_cuota,
-        fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-        pagado: cuotas_credito.pagado,
-      })
-      .from(cuotas_credito)
-      .where(eq(cuotas_credito.credito_id, creditoId));
+		// --- 3) If plazo changed: add/remove schedule, and also handle cuota change if applies ---
+		// Load current cuotas (excluding numero_cuota = 0 "cuota inicial")
+		const cuotasRows = await tx
+			.select({
+				cuota_id: cuotas_credito.cuota_id,
+				numero_cuota: cuotas_credito.numero_cuota,
+				fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+				pagado: cuotas_credito.pagado,
+			})
+			.from(cuotas_credito)
+			.where(eq(cuotas_credito.credito_id, creditoId));
 
-    const cuotasReal = cuotasRows.filter((c) => c.numero_cuota > 0);
-    const maxNumero = cuotasReal.reduce(
-      (acc, r) => Math.max(acc, Number(r.numero_cuota)),
-      0
-    );
+		const cuotasReal = cuotasRows.filter((c) => c.numero_cuota > 0);
+		const maxNumero = cuotasReal.reduce(
+			(acc, r) => Math.max(acc, Number(r.numero_cuota)),
+			0,
+		);
 
-    // Update cuota for unpaid rows if cuota also changed
-    if (changedCuota) {
-      await tx
-        .update(pagos_credito)
-        .set({
-          cuota: new Big(newCuota).round(2).toString(),
-        })
-        .where(
-          and(
-            eq(pagos_credito.credito_id, creditoId),
-            eq(pagos_credito.pagado, false)
-          )
-        );
-    }
+		// Update cuota for unpaid rows if cuota also changed
+		if (changedCuota) {
+			await tx
+				.update(pagos_credito)
+				.set({
+					cuota: new Big(newCuota).round(2).toString(),
+				})
+				.where(
+					and(
+						eq(pagos_credito.credito_id, creditoId),
+						eq(pagos_credito.pagado, false),
+					),
+				);
+		}
 
-    if (newPlazo > oldPlazoNum) {
-      // --- 3.a) Increase plazo: append missing cuotas & pagos ---
-      const toAppend = newPlazo - oldPlazoNum;
+		if (newPlazo > oldPlazoNum) {
+			// --- 3.a) Increase plazo: append missing cuotas & pagos ---
+			const toAppend = newPlazo - oldPlazoNum;
 
-      // last scheduled date to continue from:
-      const lastCuota = cuotasReal.sort(
-        (a, b) => a.numero_cuota - b.numero_cuota
-      )[cuotasReal.length - 1];
-      const lastDateISO = lastCuota
-        ? (lastCuota.fecha_vencimiento as string)
-        : // fallback: if for some reason there is no cuota > 0, base from today like insert
-          new Date()
-            .toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
-            .toString();
+			// last scheduled date to continue from:
+			const lastCuota = cuotasReal.sort(
+				(a, b) => a.numero_cuota - b.numero_cuota,
+			)[cuotasReal.length - 1];
+			const lastDateISO = lastCuota
+				? (lastCuota.fecha_vencimiento as string)
+				: // fallback: if for some reason there is no cuota > 0, base from today like insert
+					new Date()
+						.toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" })
+						.toString();
 
-      const newDates = generateNextDates(lastDateISO, toAppend);
+			const newDates = generateNextDates(lastDateISO, toAppend);
 
-      // Insert cuotas_credito batch
-      const newCuotasToInsert = newDates.map((fecha, idx) => ({
-        credito_id: creditoId,
-        numero_cuota: maxNumero + idx + 1,
-        fecha_vencimiento: fecha,
-        pagado: false,
-      }));
+			// Insert cuotas_credito batch
+			const newCuotasToInsert = newDates.map((fecha, idx) => ({
+				credito_id: creditoId,
+				numero_cuota: maxNumero + idx + 1,
+				fecha_vencimiento: fecha,
+				pagado: false,
+			}));
 
-      const insertedCuotas = await tx
-        .insert(cuotas_credito)
-        .values(newCuotasToInsert)
-        .returning({
-          cuota_id: cuotas_credito.cuota_id,
-          numero_cuota: cuotas_credito.numero_cuota,
-          fecha_vencimiento: cuotas_credito.fecha_vencimiento,
-        });
+			const insertedCuotas = await tx
+				.insert(cuotas_credito)
+				.values(newCuotasToInsert)
+				.returning({
+					cuota_id: cuotas_credito.cuota_id,
+					numero_cuota: cuotas_credito.numero_cuota,
+					fecha_vencimiento: cuotas_credito.fecha_vencimiento,
+				});
 
-      // Build pagos for each new cuota, mirroring your creation template
-      const cuotaStr = new Big(changedCuota ? newCuota : oldCuotaNum)
-        .round(2)
-        .toString();
+			// Build pagos for each new cuota, mirroring your creation template
+			const cuotaStr = new Big(changedCuota ? newCuota : oldCuotaNum)
+				.round(2)
+				.toString();
 
-      const pagosToInsert = insertedCuotas.map((c) => {
-        // 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
-        const [year, month, day] = c.fecha_vencimiento.slice(0, 10).split("-").map(Number);
-        const fechaPagoLocal = new Date(year, month - 1, day);
+			const pagosToInsert = insertedCuotas.map((c) => {
+				// 🔥 Parsear fecha como local, no UTC (evita desfase de timezone)
+				const [year, month, day] = c.fecha_vencimiento
+					.slice(0, 10)
+					.split("-")
+					.map(Number);
+				const fechaPagoLocal = new Date(year, month - 1, day);
 
-        return {
-        credito_id: creditoId,
-        cuota: cuotaStr,
-        // keep interest per your credit row (unchanged here)
-        cuota_interes: new Big(credit.porcentaje_interes ?? 0)
-          .times(new Big(credit.capital ?? 0).div(100))
-          .round(2)
-          .toString(), // same formula you used on create (capital * rate%)
-        cuota_id: c.cuota_id,
-        fecha_pago: fechaPagoLocal,
-        abono_capital: "0",
-        abono_interes: "0",
-        abono_iva_12: "0",
-        abono_interes_ci: "0",
-        abono_iva_ci: "0",
-        abono_seguro:
-          Number(credit.seguro_10_cuotas ?? 0) > 0 ? "0" : undefined,
-        abono_gps: Number(credit.gps ?? 0) > 0 ? "0" : undefined,
-        pago_del_mes: "0",
-        monto_boleta: "0",
-        fecha_vencimiento: c.fecha_vencimiento,
-        renuevo_o_nuevo: "",
-        capital_restante: new Big(credit.capital ?? 0).toString(),
-        interes_restante: new Big(credit.porcentaje_interes ?? 0)
-          .times(new Big(credit.capital ?? 0).div(100))
-          .round(2)
-          .toString(),
-        iva_12_restante: new Big(credit.porcentaje_interes ?? 0)
-          .times(new Big(credit.capital ?? 0).div(100))
-          .times(0.12)
-          .round(2)
-          .toString(),
-        seguro_restante: new Big(credit.seguro_10_cuotas ?? 0).toString(),
-        gps_restante: new Big(credit.gps ?? 0).toString(),
-        total_restante: new Big(credit.deudatotal ?? 0).toString(),
-        membresias: new Big(credit.membresias_pago ?? 0).toString(),
-        membresias_pago: "0",
-        membresias_mes: "0",
-        otros: "",
-        mora: "0",
-        monto_boleta_cuota: "0",
-        seguro_total: new Big(credit.seguro_10_cuotas ?? 0).toString(),
-        pagado: false,
-        facturacion: "si",
-        mes_pagado: "",
-        seguro_facturado: new Big(credit.seguro_10_cuotas ?? 0).toString(),
-        gps_facturado: new Big(credit.gps ?? 0).toString(),
-        reserva: "0",
-        observaciones: "",
-        paymentFalse: false,
-        registerBy: "system_reset",
-        pagoConvenio: "0",
-        monto_aplicado: "0",
-      };
-      });
+				return {
+					credito_id: creditoId,
+					cuota: cuotaStr,
+					// keep interest per your credit row (unchanged here)
+					cuota_interes: new Big(credit.porcentaje_interes ?? 0)
+						.times(new Big(credit.capital ?? 0).div(100))
+						.round(2)
+						.toString(), // same formula you used on create (capital * rate%)
+					cuota_id: c.cuota_id,
+					fecha_pago: fechaPagoLocal,
+					abono_capital: "0",
+					abono_interes: "0",
+					abono_iva_12: "0",
+					abono_interes_ci: "0",
+					abono_iva_ci: "0",
+					abono_seguro:
+						Number(credit.seguro_10_cuotas ?? 0) > 0 ? "0" : undefined,
+					abono_gps: Number(credit.gps ?? 0) > 0 ? "0" : undefined,
+					pago_del_mes: "0",
+					monto_boleta: "0",
+					fecha_vencimiento: c.fecha_vencimiento,
+					renuevo_o_nuevo: "",
+					capital_restante: new Big(credit.capital ?? 0).toString(),
+					interes_restante: new Big(credit.porcentaje_interes ?? 0)
+						.times(new Big(credit.capital ?? 0).div(100))
+						.round(2)
+						.toString(),
+					iva_12_restante: new Big(credit.porcentaje_interes ?? 0)
+						.times(new Big(credit.capital ?? 0).div(100))
+						.times(0.12)
+						.round(2)
+						.toString(),
+					seguro_restante: new Big(credit.seguro_10_cuotas ?? 0).toString(),
+					gps_restante: new Big(credit.gps ?? 0).toString(),
+					total_restante: new Big(credit.deudatotal ?? 0).toString(),
+					membresias: new Big(credit.membresias_pago ?? 0).toString(),
+					membresias_pago: "0",
+					membresias_mes: "0",
+					otros: "",
+					mora: "0",
+					monto_boleta_cuota: "0",
+					seguro_total: new Big(credit.seguro_10_cuotas ?? 0).toString(),
+					pagado: false,
+					facturacion: "si",
+					mes_pagado: "",
+					seguro_facturado: new Big(credit.seguro_10_cuotas ?? 0).toString(),
+					gps_facturado: new Big(credit.gps ?? 0).toString(),
+					reserva: "0",
+					observaciones: "",
+					paymentFalse: false,
+					registerBy: "system_reset",
+					pagoConvenio: "0",
+					monto_aplicado: "0",
+				};
+			});
 
-      await tx.insert(pagos_credito).values(pagosToInsert);
-    } else if (newPlazo < oldPlazoNum) {
-      // --- 3.b) Decrease plazo: remove extra unpaid quotas & their payments ---
-      const extra = cuotasReal.filter((c) => Number(c.numero_cuota) > newPlazo);
+			await tx.insert(pagos_credito).values(pagosToInsert);
+		} else if (newPlazo < oldPlazoNum) {
+			// --- 3.b) Decrease plazo: remove extra unpaid quotas & their payments ---
+			const extra = cuotasReal.filter((c) => Number(c.numero_cuota) > newPlazo);
 
-      // Safety: if any of the "extra" are paid, abort
-      const paidExtra = extra.filter((c) => c.pagado);
-      if (paidExtra.length > 0) {
-        throw new Error(
-          "[ERROR] Cannot reduce plazo below a paid cuota. Please reverse or adjust paid cuotas first."
-        );
-      }
+			// Safety: if any of the "extra" are paid, abort
+			const paidExtra = extra.filter((c) => c.pagado);
+			if (paidExtra.length > 0) {
+				throw new Error(
+					"[ERROR] Cannot reduce plazo below a paid cuota. Please reverse or adjust paid cuotas first.",
+				);
+			}
 
-      const extraCuotaIds = extra.map((c) => c.cuota_id);
-      if (extraCuotaIds.length > 0) {
-        const safeExtraCuotaIds = extraCuotaIds.filter((id): id is number => id !== null);
-        if (safeExtraCuotaIds.length > 0) {
-          // delete related pagos first
-          await tx
-            .delete(pagos_credito)
-            .where(inArray(pagos_credito.cuota_id, safeExtraCuotaIds));
-          // then delete cuotas
-          await tx
-            .delete(cuotas_credito)
-            .where(inArray(cuotas_credito.cuota_id, safeExtraCuotaIds));
-        }
-      }
-    }
+			const extraCuotaIds = extra.map((c) => c.cuota_id);
+			if (extraCuotaIds.length > 0) {
+				const safeExtraCuotaIds = extraCuotaIds.filter(
+					(id): id is number => id !== null,
+				);
+				if (safeExtraCuotaIds.length > 0) {
+					// delete related pagos first
+					await tx
+						.delete(pagos_credito)
+						.where(inArray(pagos_credito.cuota_id, safeExtraCuotaIds));
+					// then delete cuotas
+					await tx
+						.delete(cuotas_credito)
+						.where(inArray(cuotas_credito.cuota_id, safeExtraCuotaIds));
+				}
+			}
+		}
 
-    // --- 4) Persist credit row fields actually changed (only cuota/plazo) ---
-    const updateSet: Record<string, any> = {};
-    if (changedCuota) updateSet.cuota = new Big(newCuota).round(2).toString();
-    if (changedPlazo) updateSet.plazo = Number(newPlazo);
+		// --- 4) Persist credit row fields actually changed (only cuota/plazo) ---
+		const updateSet: Record<string, any> = {};
+		if (changedCuota) updateSet.cuota = new Big(newCuota).round(2).toString();
+		if (changedPlazo) updateSet.plazo = Number(newPlazo);
 
-    if (Object.keys(updateSet).length > 0) {
-      await tx
-        .update(creditos)
-        .set(updateSet)
-        .where(eq(creditos.credito_id, creditoId));
-    }
+		if (Object.keys(updateSet).length > 0) {
+			await tx
+				.update(creditos)
+				.set(updateSet)
+				.where(eq(creditos.credito_id, creditoId));
+		}
 
-    return { updated: true, changedCuota, changedPlazo };
-  });
+		return { updated: true, changedCuota, changedPlazo };
+	});
 }
 interface MergeCreditParams {
-  numero_credito_origen: string; // El crédito que se va a absorber
-  numero_credito_destino: string; // El crédito que va a quedar activo
+	numero_credito_origen: string; // El crédito que se va a absorber
+	numero_credito_destino: string; // El crédito que va a quedar activo
 }
 
 interface CreditoCompleto {
-  credito_id: number;
-  capital: string;
-  porcentaje_interes: string;
-  cuota: string;
-  cuota_interes: string;
-  deudatotal: string;
-  plazo: number;
-  iva_12: string;
-  seguro_10_cuotas: string;
-  gps: string;
-  membresias_pago: string;
-  membresias: string;
-  otros: string;
-  usuario_id: number;
-  asesor_id: number;
-  numero_credito_sifco: string;
-  [key: string]: any;
+	credito_id: number;
+	capital: string;
+	porcentaje_interes: string;
+	cuota: string;
+	cuota_interes: string;
+	deudatotal: string;
+	plazo: number;
+	iva_12: string;
+	seguro_10_cuotas: string;
+	gps: string;
+	membresias_pago: string;
+	membresias: string;
+	otros: string;
+	usuario_id: number;
+	asesor_id: number;
+	numero_credito_sifco: string;
+	[key: string]: any;
 }
 
 // ========================================
@@ -2496,304 +2594,308 @@ interface CreditoCompleto {
 // ========================================
 
 export const mergeCreditosAndUpdate = async ({
-  numero_credito_origen,
-  numero_credito_destino,
+	numero_credito_origen,
+	numero_credito_destino,
 }: MergeCreditParams): Promise<{
-  success: boolean;
-  message: string;
-  creditoFinal: any;
-  nueva_cuota: number;
+	success: boolean;
+	message: string;
+	creditoFinal: any;
+	nueva_cuota: number;
 }> => {
-  console.log("🔄 ========================================");
-  console.log("🔄 INICIANDO FUSIÓN DE CRÉDITOS");
-  console.log("🔄 ========================================");
-  console.log(`📋 Crédito ORIGEN (se absorberá): ${numero_credito_origen}`);
-  console.log(`📋 Crédito DESTINO (quedará activo): ${numero_credito_destino}`);
-  console.log("");
+	console.log("🔄 ========================================");
+	console.log("🔄 INICIANDO FUSIÓN DE CRÉDITOS");
+	console.log("🔄 ========================================");
+	console.log(`📋 Crédito ORIGEN (se absorberá): ${numero_credito_origen}`);
+	console.log(`📋 Crédito DESTINO (quedará activo): ${numero_credito_destino}`);
+	console.log("");
 
-  try {
-    // ========================================
-    // PASO 1: OBTENER AMBOS CRÉDITOS
-    // ========================================
-    console.log("📥 PASO 1: Buscando ambos créditos...");
+	try {
+		// ========================================
+		// PASO 1: OBTENER AMBOS CRÉDITOS
+		// ========================================
+		console.log("📥 PASO 1: Buscando ambos créditos...");
 
-    const [creditoOrigen] = (await db
-      .select()
-      .from(creditos)
-      .where(eq(creditos.numero_credito_sifco, numero_credito_origen))
-      .limit(1)) as CreditoCompleto[];
+		const [creditoOrigen] = (await db
+			.select()
+			.from(creditos)
+			.where(eq(creditos.numero_credito_sifco, numero_credito_origen))
+			.limit(1)) as CreditoCompleto[];
 
-    const [creditoDestino] = (await db
-      .select()
-      .from(creditos)
-      .where(eq(creditos.numero_credito_sifco, numero_credito_destino))
-      .limit(1)) as CreditoCompleto[];
+		const [creditoDestino] = (await db
+			.select()
+			.from(creditos)
+			.where(eq(creditos.numero_credito_sifco, numero_credito_destino))
+			.limit(1)) as CreditoCompleto[];
 
-    if (!creditoOrigen) {
-      console.log("❌ ERROR: No se encontró el crédito origen");
-      throw new Error(`Crédito origen ${numero_credito_origen} no encontrado`);
-    }
+		if (!creditoOrigen) {
+			console.log("❌ ERROR: No se encontró el crédito origen");
+			throw new Error(`Crédito origen ${numero_credito_origen} no encontrado`);
+		}
 
-    if (!creditoDestino) {
-      console.log("❌ ERROR: No se encontró el crédito destino");
-      throw new Error(
-        `Crédito destino ${numero_credito_destino} no encontrado`
-      );
-    }
+		if (!creditoDestino) {
+			console.log("❌ ERROR: No se encontró el crédito destino");
+			throw new Error(
+				`Crédito destino ${numero_credito_destino} no encontrado`,
+			);
+		}
 
-    console.log(
-      `✅ Crédito ORIGEN encontrado - ID: ${creditoOrigen.credito_id}`
-    );
-    console.log(`   - Capital: Q${creditoOrigen.capital}`);
-    console.log(`   - Cuota: Q${creditoOrigen.cuota}`);
-    console.log(`   - Seguro: Q${creditoOrigen.seguro_10_cuotas}`);
-    console.log(`   - GPS: Q${creditoOrigen.gps}`);
-    console.log(`   - Membresías: Q${creditoOrigen.membresias_pago}`);
-    console.log(`   - Otros: Q${creditoOrigen.otros}`);
+		console.log(
+			`✅ Crédito ORIGEN encontrado - ID: ${creditoOrigen.credito_id}`,
+		);
+		console.log(`   - Capital: Q${creditoOrigen.capital}`);
+		console.log(`   - Cuota: Q${creditoOrigen.cuota}`);
+		console.log(`   - Seguro: Q${creditoOrigen.seguro_10_cuotas}`);
+		console.log(`   - GPS: Q${creditoOrigen.gps}`);
+		console.log(`   - Membresías: Q${creditoOrigen.membresias_pago}`);
+		console.log(`   - Otros: Q${creditoOrigen.otros}`);
 
-    console.log(
-      `✅ Crédito DESTINO encontrado - ID: ${creditoDestino.credito_id}`
-    );
-    console.log(`   - Capital: Q${creditoDestino.capital}`);
-    console.log(`   - Cuota: Q${creditoDestino.cuota}`);
-    console.log(`   - Seguro: Q${creditoDestino.seguro_10_cuotas}`);
-    console.log(`   - GPS: Q${creditoDestino.gps}`);
-    console.log(`   - Membresías: Q${creditoDestino.membresias_pago}`);
-    console.log(`   - Otros: Q${creditoDestino.otros}`);
-    console.log("");
+		console.log(
+			`✅ Crédito DESTINO encontrado - ID: ${creditoDestino.credito_id}`,
+		);
+		console.log(`   - Capital: Q${creditoDestino.capital}`);
+		console.log(`   - Cuota: Q${creditoDestino.cuota}`);
+		console.log(`   - Seguro: Q${creditoDestino.seguro_10_cuotas}`);
+		console.log(`   - GPS: Q${creditoDestino.gps}`);
+		console.log(`   - Membresías: Q${creditoDestino.membresias_pago}`);
+		console.log(`   - Otros: Q${creditoDestino.otros}`);
+		console.log("");
 
-    // ========================================
-    // PASO 2: SUMAR VALORES Y RECALCULAR
-    // ========================================
-    console.log("🧮 PASO 2: Sumando capitales y recalculando todo...");
+		// ========================================
+		// PASO 2: SUMAR VALORES Y RECALCULAR
+		// ========================================
+		console.log("🧮 PASO 2: Sumando capitales y recalculando todo...");
 
-    // Sumar capitales
-    const capitalOrigen = new Big(creditoOrigen.capital);
-    const capitalDestino = new Big(creditoDestino.capital);
-    const capitalTotal = capitalOrigen.plus(capitalDestino);
+		// Sumar capitales
+		const capitalOrigen = new Big(creditoOrigen.capital);
+		const capitalDestino = new Big(creditoDestino.capital);
+		const capitalTotal = capitalOrigen.plus(capitalDestino);
 
-    console.log(`   📊 Capital ORIGEN: Q${capitalOrigen.toString()}`);
-    console.log(`   📊 Capital DESTINO: Q${capitalDestino.toString()}`);
-    console.log(`   ➕ CAPITAL TOTAL: Q${capitalTotal.toString()}`);
+		console.log(`   📊 Capital ORIGEN: Q${capitalOrigen.toString()}`);
+		console.log(`   📊 Capital DESTINO: Q${capitalDestino.toString()}`);
+		console.log(`   ➕ CAPITAL TOTAL: Q${capitalTotal.toString()}`);
 
-    // Usar el porcentaje de interés del crédito destino
-    const porcentaje_interes = new Big(creditoDestino.porcentaje_interes);
-    console.log(`   📈 Porcentaje interés: ${porcentaje_interes.toString()}%`);
+		// Usar el porcentaje de interés del crédito destino
+		const porcentaje_interes = new Big(creditoDestino.porcentaje_interes);
+		console.log(`   📈 Porcentaje interés: ${porcentaje_interes.toString()}%`);
 
-    // Calcular cuota_interes con el nuevo capital
-    const cuota_interes = capitalTotal
-      .times(porcentaje_interes.div(100))
-      .round(2);
-    console.log(
-      `   💵 Cuota interés (recalculada): Q${cuota_interes.toString()}`
-    );
+		// Calcular cuota_interes con el nuevo capital
+		const cuota_interes = capitalTotal
+			.times(porcentaje_interes.div(100))
+			.round(2);
+		console.log(
+			`   💵 Cuota interés (recalculada): Q${cuota_interes.toString()}`,
+		);
 
-    // Calcular IVA 12%
-    const iva_12 = cuota_interes.times(0.12).round(2);
-    console.log(`   🧾 IVA 12%: Q${iva_12.toString()}`);
+		// Calcular IVA 12%
+		const iva_12 = cuota_interes.times(0.12).round(2);
+		console.log(`   🧾 IVA 12%: Q${iva_12.toString()}`);
 
-    // Sumar seguros, GPS, membresías, otros
-    const seguro_total = new Big(creditoOrigen.seguro_10_cuotas || "0").plus(
-      new Big(creditoDestino.seguro_10_cuotas || "0")
-    );
+		// Sumar seguros, GPS, membresías, otros
+		const seguro_total = new Big(creditoOrigen.seguro_10_cuotas || "0").plus(
+			new Big(creditoDestino.seguro_10_cuotas || "0"),
+		);
 
-    const gps_total = new Big(creditoOrigen.gps || "0").plus(
-      new Big(creditoDestino.gps || "0")
-    );
+		const gps_total = new Big(creditoOrigen.gps || "0").plus(
+			new Big(creditoDestino.gps || "0"),
+		);
 
-    const membresias_total = new Big(creditoOrigen.membresias_pago || "0").plus(
-      new Big(creditoDestino.membresias_pago || "0")
-    );
+		const membresias_total = new Big(creditoOrigen.membresias_pago || "0").plus(
+			new Big(creditoDestino.membresias_pago || "0"),
+		);
 
-    const otros_total = new Big(creditoOrigen.otros || "0").plus(
-      new Big(creditoDestino.otros || "0")
-    );
+		const otros_total = new Big(creditoOrigen.otros || "0").plus(
+			new Big(creditoDestino.otros || "0"),
+		);
 
-    console.log(`   🛡️  Seguro total: Q${seguro_total.toString()}`);
-    console.log(`   📡 GPS total: Q${gps_total.toString()}`);
-    console.log(`   💳 Membresías total: Q${membresias_total.toString()}`);
-    console.log(`   📝 Otros total: Q${otros_total.toString()}`);
+		console.log(`   🛡️  Seguro total: Q${seguro_total.toString()}`);
+		console.log(`   📡 GPS total: Q${gps_total.toString()}`);
+		console.log(`   💳 Membresías total: Q${membresias_total.toString()}`);
+		console.log(`   📝 Otros total: Q${otros_total.toString()}`);
 
-    // Sumar cuotas
-    const cuota_origen = new Big(creditoOrigen.cuota);
-    const cuota_destino = new Big(creditoDestino.cuota);
-    const cuota_total = cuota_origen.plus(cuota_destino).round(2);
+		// Sumar cuotas
+		const cuota_origen = new Big(creditoOrigen.cuota);
+		const cuota_destino = new Big(creditoDestino.cuota);
+		const cuota_total = cuota_origen.plus(cuota_destino).round(2);
 
-    console.log(`   💰 Cuota ORIGEN: Q${cuota_origen.toString()}`);
-    console.log(`   💰 Cuota DESTINO: Q${cuota_destino.toString()}`);
-    console.log(`   ➕ CUOTA TOTAL: Q${cuota_total.toString()}`);
+		console.log(`   💰 Cuota ORIGEN: Q${cuota_origen.toString()}`);
+		console.log(`   💰 Cuota DESTINO: Q${cuota_destino.toString()}`);
+		console.log(`   ➕ CUOTA TOTAL: Q${cuota_total.toString()}`);
 
-    // Calcular deuda total
-    const deudatotal = capitalTotal
-      .plus(cuota_interes)
-      .plus(iva_12)
-      .plus(seguro_total)
-      .plus(gps_total)
-      .plus(membresias_total)
-      .plus(otros_total)
-      .round(2);
+		// Calcular deuda total
+		const deudatotal = capitalTotal
+			.plus(cuota_interes)
+			.plus(iva_12)
+			.plus(seguro_total)
+			.plus(gps_total)
+			.plus(membresias_total)
+			.plus(otros_total)
+			.round(2);
 
-    console.log(`   💵💵 DEUDA TOTAL (recalculada): Q${deudatotal.toString()}`);
-    console.log("");
+		console.log(`   💵💵 DEUDA TOTAL (recalculada): Q${deudatotal.toString()}`);
+		console.log("");
 
-    // ========================================
-    // PASO 3: ACTUALIZAR CRÉDITO DESTINO
-    // ========================================
-    console.log(
-      "💾 PASO 3: Actualizando crédito destino con valores consolidados..."
-    );
+		// ========================================
+		// PASO 3: ACTUALIZAR CRÉDITO DESTINO
+		// ========================================
+		console.log(
+			"💾 PASO 3: Actualizando crédito destino con valores consolidados...",
+		);
 
-    const [creditoActualizado] = await withCapitalContext(null, "MERGE", null, (tx) =>
-      tx
-        .update(creditos)
-        .set({
-          capital: capitalTotal.toString(),
-          cuota: cuota_total.toString(),
-          cuota_interes: cuota_interes.toString(),
-          iva_12: iva_12.toString(),
-          deudatotal: deudatotal.toString(),
-          seguro_10_cuotas: seguro_total.toString(),
-          gps: gps_total.toString(),
-          membresias_pago: membresias_total.toString(),
-          membresias: membresias_total.toString(),
-          otros: otros_total.toString(),
-        })
-        .where(eq(creditos.credito_id, creditoDestino.credito_id))
-        .returning()
-    );
+		const [creditoActualizado] = await withCapitalContext(
+			null,
+			"MERGE",
+			null,
+			(tx) =>
+				tx
+					.update(creditos)
+					.set({
+						capital: capitalTotal.toString(),
+						cuota: cuota_total.toString(),
+						cuota_interes: cuota_interes.toString(),
+						iva_12: iva_12.toString(),
+						deudatotal: deudatotal.toString(),
+						seguro_10_cuotas: seguro_total.toString(),
+						gps: gps_total.toString(),
+						membresias_pago: membresias_total.toString(),
+						membresias: membresias_total.toString(),
+						otros: otros_total.toString(),
+					})
+					.where(eq(creditos.credito_id, creditoDestino.credito_id))
+					.returning(),
+		);
 
-    console.log(
-      `   ✅ Crédito ${creditoDestino.numero_credito_sifco} actualizado exitosamente`
-    );
-    console.log(`   📊 Nuevo capital: Q${capitalTotal.toString()}`);
-    console.log(`   💰 Nueva cuota: Q${cuota_total.toString()}`);
-    console.log(`   💵 Nueva deuda total: Q${deudatotal.toString()}`);
-    console.log("");
+		console.log(
+			`   ✅ Crédito ${creditoDestino.numero_credito_sifco} actualizado exitosamente`,
+		);
+		console.log(`   📊 Nuevo capital: Q${capitalTotal.toString()}`);
+		console.log(`   💰 Nueva cuota: Q${cuota_total.toString()}`);
+		console.log(`   💵 Nueva deuda total: Q${deudatotal.toString()}`);
+		console.log("");
 
-    // ========================================
-    // PASO 4: TRASLADAR INVERSIONISTAS DEL ORIGEN AL DESTINO
-    // ========================================
-    console.log(
-      "👥 PASO 4: Trasladando inversionistas del crédito ORIGEN al DESTINO..."
-    );
+		// ========================================
+		// PASO 4: TRASLADAR INVERSIONISTAS DEL ORIGEN AL DESTINO
+		// ========================================
+		console.log(
+			"👥 PASO 4: Trasladando inversionistas del crédito ORIGEN al DESTINO...",
+		);
 
-    const inversionistasOrigen = await db
-      .select()
-      .from(creditos_inversionistas)
-      .where(eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id));
+		const inversionistasOrigen = await db
+			.select()
+			.from(creditos_inversionistas)
+			.where(eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id));
 
-    if (inversionistasOrigen.length > 0) {
-      console.log(
-        `   📋 Se encontraron ${inversionistasOrigen.length} inversionistas en el crédito origen`
-      );
+		if (inversionistasOrigen.length > 0) {
+			console.log(
+				`   📋 Se encontraron ${inversionistasOrigen.length} inversionistas en el crédito origen`,
+			);
 
-      // Actualizar el credito_id de todos los inversionistas del origen
-      await db
-        .update(creditos_inversionistas)
-        .set({
-          credito_id: creditoDestino.credito_id,
-        })
-        .where(
-          eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id)
-        );
+			// Actualizar el credito_id de todos los inversionistas del origen
+			await db
+				.update(creditos_inversionistas)
+				.set({
+					credito_id: creditoDestino.credito_id,
+				})
+				.where(
+					eq(creditos_inversionistas.credito_id, creditoOrigen.credito_id),
+				);
 
-      console.log(
-        `   ✅ ${inversionistasOrigen.length} inversionistas trasladados al crédito destino`
-      );
+			console.log(
+				`   ✅ ${inversionistasOrigen.length} inversionistas trasladados al crédito destino`,
+			);
 
-      inversionistasOrigen.forEach((inv, index) => {
-        console.log(
-          `      ${index + 1}. Inversionista ID: ${inv.inversionista_id}`
-        );
-        console.log(`         - Monto aportado: Q${inv.monto_aportado}`);
-        console.log(`         - Cuota: Q${inv.cuota_inversionista}`);
-      });
-    } else {
-      console.log(
-        `   ℹ️  No hay inversionistas en el crédito origen para trasladar`
-      );
-    }
-    console.log("");
+			inversionistasOrigen.forEach((inv, index) => {
+				console.log(
+					`      ${index + 1}. Inversionista ID: ${inv.inversionista_id}`,
+				);
+				console.log(`         - Monto aportado: Q${inv.monto_aportado}`);
+				console.log(`         - Cuota: Q${inv.cuota_inversionista}`);
+			});
+		} else {
+			console.log(
+				`   ℹ️  No hay inversionistas en el crédito origen para trasladar`,
+			);
+		}
+		console.log("");
 
-    // ========================================
-    // PASO 5: MARCAR CRÉDITO ORIGEN COMO CANCELADO
-    // ========================================
-    console.log("🔒 PASO 5: Marcando crédito origen como CANCELADO...");
+		// ========================================
+		// PASO 5: MARCAR CRÉDITO ORIGEN COMO CANCELADO
+		// ========================================
+		console.log("🔒 PASO 5: Marcando crédito origen como CANCELADO...");
 
-    await db
-      .update(creditos)
-      .set({
-        statusCredit: "CANCELADO",
-      })
-      .where(eq(creditos.credito_id, creditoOrigen.credito_id));
+		await db
+			.update(creditos)
+			.set({
+				statusCredit: "CANCELADO",
+			})
+			.where(eq(creditos.credito_id, creditoOrigen.credito_id));
 
-    console.log(
-      `   ✅ Crédito ${creditoOrigen.numero_credito_sifco} (ID: ${creditoOrigen.credito_id}) marcado como CANCELADO`
-    );
-    console.log("");
+		console.log(
+			`   ✅ Crédito ${creditoOrigen.numero_credito_sifco} (ID: ${creditoOrigen.credito_id}) marcado como CANCELADO`,
+		);
+		console.log("");
 
-    // ========================================
-    // PASO 6: LLAMAR A updateInstallments
-    // ========================================
-    console.log("📅 PASO 6: Recalculando cuotas con updateInstallments...");
-    console.log(`   🔄 Llamando updateInstallments con:`);
-    console.log(`      - numero_credito_sifco: ${numero_credito_destino}`);
-    console.log(`      - nueva_cuota: Q${cuota_total.toNumber()}`);
+		// ========================================
+		// PASO 6: LLAMAR A updateInstallments
+		// ========================================
+		console.log("📅 PASO 6: Recalculando cuotas con updateInstallments...");
+		console.log(`   🔄 Llamando updateInstallments con:`);
+		console.log(`      - numero_credito_sifco: ${numero_credito_destino}`);
+		console.log(`      - nueva_cuota: Q${cuota_total.toNumber()}`);
 
-    await updateInstallments({
-      numero_credito_sifco: numero_credito_destino,
-      nueva_cuota: cuota_total.toNumber(),
-    });
+		await updateInstallments({
+			numero_credito_sifco: numero_credito_destino,
+			nueva_cuota: cuota_total.toNumber(),
+		});
 
-    console.log(`   ✅ Cuotas recalculadas exitosamente`);
-    console.log("");
+		console.log(`   ✅ Cuotas recalculadas exitosamente`);
+		console.log("");
 
-    // ========================================
-    // RESULTADO FINAL
-    // ========================================
-    const inversionistasDestino = await db
-      .select()
-      .from(creditos_inversionistas)
-      .where(eq(creditos_inversionistas.credito_id, creditoDestino.credito_id));
+		// ========================================
+		// RESULTADO FINAL
+		// ========================================
+		const inversionistasDestino = await db
+			.select()
+			.from(creditos_inversionistas)
+			.where(eq(creditos_inversionistas.credito_id, creditoDestino.credito_id));
 
-    const totalInversionistas = inversionistasDestino.length;
+		const totalInversionistas = inversionistasDestino.length;
 
-    console.log("✅ ========================================");
-    console.log("✅ FUSIÓN COMPLETADA EXITOSAMENTE");
-    console.log("✅ ========================================");
-    console.log(
-      `📋 Crédito activo: ${numero_credito_destino} (ID: ${creditoDestino.credito_id})`
-    );
-    console.log(`💰 Capital consolidado: Q${capitalTotal.toString()}`);
-    console.log(`💵 Nueva cuota mensual: Q${cuota_total.toString()}`);
-    console.log(`💵 Nueva deuda total: Q${deudatotal.toString()}`);
-    console.log(`👥 Total inversionistas: ${totalInversionistas}`);
-    console.log(
-      `🔒 Crédito cancelado: ${numero_credito_origen} (ID: ${creditoOrigen.credito_id})`
-    );
-    console.log("");
+		console.log("✅ ========================================");
+		console.log("✅ FUSIÓN COMPLETADA EXITOSAMENTE");
+		console.log("✅ ========================================");
+		console.log(
+			`📋 Crédito activo: ${numero_credito_destino} (ID: ${creditoDestino.credito_id})`,
+		);
+		console.log(`💰 Capital consolidado: Q${capitalTotal.toString()}`);
+		console.log(`💵 Nueva cuota mensual: Q${cuota_total.toString()}`);
+		console.log(`💵 Nueva deuda total: Q${deudatotal.toString()}`);
+		console.log(`👥 Total inversionistas: ${totalInversionistas}`);
+		console.log(
+			`🔒 Crédito cancelado: ${numero_credito_origen} (ID: ${creditoOrigen.credito_id})`,
+		);
+		console.log("");
 
-    return {
-      success: true,
-      message: "Créditos fusionados exitosamente",
-      nueva_cuota: cuota_total.toNumber(),
-      creditoFinal: {
-        numero_credito: numero_credito_destino,
-        credito_id: creditoDestino.credito_id,
-        capital_total: capitalTotal.toString(),
-        cuota: cuota_total.toString(),
-        deuda_total: deudatotal.toString(),
-        total_inversionistas: totalInversionistas,
-        credito_cancelado: numero_credito_origen,
-      },
-    };
-  } catch (error) {
-    console.log("❌ ========================================");
-    console.log("❌ ERROR EN LA FUSIÓN DE CRÉDITOS");
-    console.log("❌ ========================================");
-    console.error(error);
-    throw error;
-  }
+		return {
+			success: true,
+			message: "Créditos fusionados exitosamente",
+			nueva_cuota: cuota_total.toNumber(),
+			creditoFinal: {
+				numero_credito: numero_credito_destino,
+				credito_id: creditoDestino.credito_id,
+				capital_total: capitalTotal.toString(),
+				cuota: cuota_total.toString(),
+				deuda_total: deudatotal.toString(),
+				total_inversionistas: totalInversionistas,
+				credito_cancelado: numero_credito_origen,
+			},
+		};
+	} catch (error) {
+		console.log("❌ ========================================");
+		console.log("❌ ERROR EN LA FUSIÓN DE CRÉDITOS");
+		console.log("❌ ========================================");
+		console.error(error);
+		throw error;
+	}
 };
 
 // ========================================
@@ -2801,18 +2903,18 @@ export const mergeCreditosAndUpdate = async ({
 // ========================================
 
 interface UpdateInstallmentsParams {
-  numero_credito_sifco: string;
-  nueva_cuota: number;
+	numero_credito_sifco: string;
+	nueva_cuota: number;
 }
 
 const updateInstallments = async ({
-  numero_credito_sifco,
-  nueva_cuota,
+	numero_credito_sifco,
+	nueva_cuota,
 }: UpdateInstallmentsParams): Promise<void> => {
-  console.log(`   🔄 Ejecutando updateInstallments...`);
-  console.log(`   📋 Crédito: ${numero_credito_sifco}`);
-  console.log(`   💰 Nueva cuota: Q${nueva_cuota}`);
-  // Aquí va tu implementación existente
+	console.log(`   🔄 Ejecutando updateInstallments...`);
+	console.log(`   📋 Crédito: ${numero_credito_sifco}`);
+	console.log(`   💰 Nueva cuota: Q${nueva_cuota}`);
+	// Aquí va tu implementación existente
 };
 
 // ========================================
@@ -2820,287 +2922,311 @@ const updateInstallments = async ({
 // ========================================
 
 interface CreditStats {
-  cantidad: number;
-  porcentaje: string;
-  sumaCapital: string;
-  sumaMora: string;
+	cantidad: number;
+	porcentaje: string;
+	sumaCapital: string;
+	sumaMora: string;
 }
 
 interface CreditStatsResponse {
-  totalCreditos: number;
-  efectividad: string; // Porcentaje de créditos SIN cuotas atrasadas
-  porCuotasAtrasadas: {
-    "0": CreditStats;
-    "1": CreditStats;
-    "2": CreditStats;
-    "3": CreditStats;
-    "4": CreditStats;
-  };
-  porEstado: {
-    cancelado: CreditStats;
-    incobrable: CreditStats;
-  };
+	totalCreditos: number;
+	efectividad: string; // Porcentaje de créditos SIN cuotas atrasadas
+	porCuotasAtrasadas: {
+		"0": CreditStats;
+		"1": CreditStats;
+		"2": CreditStats;
+		"3": CreditStats;
+		"4": CreditStats;
+	};
+	porEstado: {
+		cancelado: CreditStats;
+		incobrable: CreditStats;
+	};
 }
 
-export const getCreditStats = async (email?: string): Promise<CreditStatsResponse> => {
-  console.log(`📊 Obteniendo estadísticas de créditos...`);
-  if (email) {
-    console.log(`   🔍 Filtrando por asesor con email: ${email}`);
-  }
+export const getCreditStats = async (
+	email?: string,
+): Promise<CreditStatsResponse> => {
+	console.log(`📊 Obteniendo estadísticas de créditos...`);
+	if (email) {
+		console.log(`   🔍 Filtrando por asesor con email: ${email}`);
+	}
 
-  // Obtener el asesor_id si se proporciona email
-  let asesorId: number | null = null;
-  if (email) {
-    const platformUser = await db
-      .select({ asesor_id: asesores.asesor_id })
-      .from(asesores)
-      // 🔥 case/espacios-insensible: el email de sesión del CRM puede venir con otro casing
-      .where(sql`LOWER(${asesores.emailCashIn}) = ${email.trim().toLowerCase()}`)
-      .limit(1);
+	// Obtener el asesor_id si se proporciona email
+	let asesorId: number | null = null;
+	if (email) {
+		const platformUser = await db
+			.select({ asesor_id: asesores.asesor_id })
+			.from(asesores)
+			// 🔥 case/espacios-insensible: el email de sesión del CRM puede venir con otro casing
+			.where(
+				sql`LOWER(${asesores.emailCashIn}) = ${email.trim().toLowerCase()}`,
+			)
+			.limit(1);
 
-    if (platformUser.length > 0 && platformUser[0].asesor_id) {
-      asesorId = platformUser[0].asesor_id;
-      console.log(`   ✅ Asesor encontrado con ID: ${asesorId}`);
-    } else {
-      console.log(`   ⚠️ No se encontró asesor con email: ${email}`);
-    }
-  }
+		if (platformUser.length > 0 && platformUser[0].asesor_id) {
+			asesorId = platformUser[0].asesor_id;
+			console.log(`   ✅ Asesor encontrado con ID: ${asesorId}`);
+		} else {
+			console.log(`   ⚠️ No se encontró asesor con email: ${email}`);
+		}
+	}
 
-  // Primero obtener el total de créditos activos para calcular porcentajes
-  const baseConditionsTotal = [
-    inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
-  ];
-  if (asesorId) {
-    baseConditionsTotal.push(eq(creditos.asesor_id, asesorId));
-  }
+	// Primero obtener el total de créditos activos para calcular porcentajes
+	const baseConditionsTotal = [
+		inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
+	];
+	if (asesorId) {
+		baseConditionsTotal.push(eq(creditos.asesor_id, asesorId));
+	}
 
-  const totalResult = await db
-    .select({
-      total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-    })
-    .from(creditos)
-    .where(and(...baseConditionsTotal));
+	const totalResult = await db
+		.select({
+			total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+		})
+		.from(creditos)
+		.where(and(...baseConditionsTotal));
 
-  const totalCreditosActivos = totalResult[0]?.total || 0;
+	const totalCreditosActivos = totalResult[0]?.total || 0;
 
-  // Estadísticas por cuotas atrasadas (0, 1, 2, 3, 4) - Solo créditos ACTIVOS o MOROSOS
-  const statsPerCuotasAtrasadas: Record<string, CreditStats> = {
-    "0": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-    "1": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-    "2": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-    "3": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-    "4": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-  };
+	// Estadísticas por cuotas atrasadas (0, 1, 2, 3, 4) - Solo créditos ACTIVOS o MOROSOS
+	const statsPerCuotasAtrasadas: Record<string, CreditStats> = {
+		"0": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+		"1": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+		"2": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+		"3": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+		"4": { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
+	};
 
-  // Consulta para créditos activos/morosos con sus moras
-  const baseConditionsActive = [
-    inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
-  ];
+	// Consulta para créditos activos/morosos con sus moras
+	const baseConditionsActive = [
+		inArray(creditos.statusCredit, ["ACTIVO", "MOROSO", "EN_CONVENIO"]),
+	];
 
-  if (asesorId) {
-    baseConditionsActive.push(eq(creditos.asesor_id, asesorId));
-  }
+	if (asesorId) {
+		baseConditionsActive.push(eq(creditos.asesor_id, asesorId));
+	}
 
-  let creditosSinAtraso = 0;
+	let creditosSinAtraso = 0;
 
-  for (const cuotasNum of [0, 1, 2, 3, 4]) {
-    const result = await db
-      .select({
-        cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-        sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
-        sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
-      })
-      .from(creditos)
-      .leftJoin(
-        moras_credito,
-        and(
-          eq(creditos.credito_id, moras_credito.credito_id),
-          eq(moras_credito.activa, true)
-        )
-      )
-      .where(
-        and(
-          ...baseConditionsActive,
-          cuotasNum === 4
-            ? sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) >= 4`
-            : sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) = ${cuotasNum}`
-        )
-      );
+	for (const cuotasNum of [0, 1, 2, 3, 4]) {
+		const result = await db
+			.select({
+				cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+				sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
+				sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
+			})
+			.from(creditos)
+			.leftJoin(
+				moras_credito,
+				and(
+					eq(creditos.credito_id, moras_credito.credito_id),
+					eq(moras_credito.activa, true),
+				),
+			)
+			.where(
+				and(
+					...baseConditionsActive,
+					cuotasNum === 4
+						? sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) >= 4`
+						: sql`COALESCE(${moras_credito.cuotas_atrasadas}, 0) = ${cuotasNum}`,
+				),
+			);
 
-    const cantidad = result[0]?.cantidad || 0;
-    const porcentaje = totalCreditosActivos > 0 
-      ? ((cantidad / totalCreditosActivos) * 100).toFixed(2) 
-      : "0";
+		const cantidad = result[0]?.cantidad || 0;
+		const porcentaje =
+			totalCreditosActivos > 0
+				? ((cantidad / totalCreditosActivos) * 100).toFixed(2)
+				: "0";
 
-    if (cuotasNum === 0) {
-      creditosSinAtraso = cantidad;
-    }
+		if (cuotasNum === 0) {
+			creditosSinAtraso = cantidad;
+		}
 
-    statsPerCuotasAtrasadas[cuotasNum.toString()] = {
-      cantidad,
-      porcentaje,
-      sumaCapital: result[0]?.sumaCapital || "0",
-      sumaMora: result[0]?.sumaMora || "0",
-    };
-  }
+		statsPerCuotasAtrasadas[cuotasNum.toString()] = {
+			cantidad,
+			porcentaje,
+			sumaCapital: result[0]?.sumaCapital || "0",
+			sumaMora: result[0]?.sumaMora || "0",
+		};
+	}
 
-  // Calcular efectividad: porcentaje de créditos SIN cuotas atrasadas
-  const efectividad = totalCreditosActivos > 0 
-    ? ((creditosSinAtraso / totalCreditosActivos) * 100).toFixed(2) 
-    : "0";
+	// Calcular efectividad: porcentaje de créditos SIN cuotas atrasadas
+	const efectividad =
+		totalCreditosActivos > 0
+			? ((creditosSinAtraso / totalCreditosActivos) * 100).toFixed(2)
+			: "0";
 
-  // Estadísticas por estado (CANCELADO, INCOBRABLE)
-  const statsPerEstado = {
-    cancelado: { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-    incobrable: { cantidad: 0, porcentaje: "0", sumaCapital: "0", sumaMora: "0" },
-  };
+	// Estadísticas por estado (CANCELADO, INCOBRABLE)
+	const statsPerEstado = {
+		cancelado: {
+			cantidad: 0,
+			porcentaje: "0",
+			sumaCapital: "0",
+			sumaMora: "0",
+		},
+		incobrable: {
+			cantidad: 0,
+			porcentaje: "0",
+			sumaCapital: "0",
+			sumaMora: "0",
+		},
+	};
 
-  // Obtener total de créditos cancelados + incobrables para sus porcentajes
-  const baseConditionsStatusTotal = [
-    inArray(creditos.statusCredit, ["CANCELADO", "INCOBRABLE"]),
-  ];
-  if (asesorId) {
-    baseConditionsStatusTotal.push(eq(creditos.asesor_id, asesorId));
-  }
+	// Obtener total de créditos cancelados + incobrables para sus porcentajes
+	const baseConditionsStatusTotal = [
+		inArray(creditos.statusCredit, ["CANCELADO", "INCOBRABLE"]),
+	];
+	if (asesorId) {
+		baseConditionsStatusTotal.push(eq(creditos.asesor_id, asesorId));
+	}
 
-  const totalStatusResult = await db
-    .select({
-      total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-    })
-    .from(creditos)
-    .where(and(...baseConditionsStatusTotal));
+	const totalStatusResult = await db
+		.select({
+			total: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+		})
+		.from(creditos)
+		.where(and(...baseConditionsStatusTotal));
 
-  const totalCreditosStatus = totalStatusResult[0]?.total || 0;
+	const totalCreditosStatus = totalStatusResult[0]?.total || 0;
 
-  for (const estado of ["CANCELADO", "INCOBRABLE"] as const) {
-    const baseConditionsStatus = [eq(creditos.statusCredit, estado)];
+	for (const estado of ["CANCELADO", "INCOBRABLE"] as const) {
+		const baseConditionsStatus = [eq(creditos.statusCredit, estado)];
 
-    if (asesorId) {
-      baseConditionsStatus.push(eq(creditos.asesor_id, asesorId));
-    }
+		if (asesorId) {
+			baseConditionsStatus.push(eq(creditos.asesor_id, asesorId));
+		}
 
-    const result = await db
-      .select({
-        cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
-        sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
-        sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
-      })
-      .from(creditos)
-      .leftJoin(
-        moras_credito,
-        and(
-          eq(creditos.credito_id, moras_credito.credito_id),
-          eq(moras_credito.activa, true)
-        )
-      )
-      .where(and(...baseConditionsStatus));
+		const result = await db
+			.select({
+				cantidad: sql<number>`COUNT(DISTINCT ${creditos.credito_id})::int`,
+				sumaCapital: sql<string>`COALESCE(SUM(${creditos.capital}), 0)::text`,
+				sumaMora: sql<string>`COALESCE(SUM(CASE WHEN ${moras_credito.activa} = true THEN ${moras_credito.monto_mora} ELSE 0 END), 0)::text`,
+			})
+			.from(creditos)
+			.leftJoin(
+				moras_credito,
+				and(
+					eq(creditos.credito_id, moras_credito.credito_id),
+					eq(moras_credito.activa, true),
+				),
+			)
+			.where(and(...baseConditionsStatus));
 
-    const cantidad = result[0]?.cantidad || 0;
-    const porcentaje = totalCreditosStatus > 0 
-      ? ((cantidad / totalCreditosStatus) * 100).toFixed(2) 
-      : "0";
+		const cantidad = result[0]?.cantidad || 0;
+		const porcentaje =
+			totalCreditosStatus > 0
+				? ((cantidad / totalCreditosStatus) * 100).toFixed(2)
+				: "0";
 
-    const key = estado.toLowerCase() as "cancelado" | "incobrable";
-    statsPerEstado[key] = {
-      cantidad,
-      porcentaje,
-      sumaCapital: result[0]?.sumaCapital || "0",
-      sumaMora: result[0]?.sumaMora || "0",
-    };
-  }
+		const key = estado.toLowerCase() as "cancelado" | "incobrable";
+		statsPerEstado[key] = {
+			cantidad,
+			porcentaje,
+			sumaCapital: result[0]?.sumaCapital || "0",
+			sumaMora: result[0]?.sumaMora || "0",
+		};
+	}
 
-  console.log(`📊 Estadísticas obtenidas exitosamente`);
+	console.log(`📊 Estadísticas obtenidas exitosamente`);
 
-  return {
-    totalCreditos: totalCreditosActivos,
-    efectividad,
-    porCuotasAtrasadas: statsPerCuotasAtrasadas as CreditStatsResponse["porCuotasAtrasadas"],
-    porEstado: statsPerEstado,
-  };
+	return {
+		totalCreditos: totalCreditosActivos,
+		efectividad,
+		porCuotasAtrasadas:
+			statsPerCuotasAtrasadas as CreditStatsResponse["porCuotasAtrasadas"],
+		porEstado: statsPerEstado,
+	};
 };
 
 // ============================================
 // 🔥 Activar/Desactivar Cancelación de Crédito
 // ============================================
 export async function toggleCancelacionActivo(params: {
-  creditId: number;
-  activo: boolean;
+	creditId: number;
+	activo: boolean;
 }) {
-  const { creditId, activo } = params;
+	const { creditId, activo } = params;
 
-  try {
-    // 1. Verificar que existe la cancelación
-    const [cancelacion] = await db
-      .select()
-      .from(credit_cancelations)
-      .where(eq(credit_cancelations.credit_id, creditId))
-      .limit(1);
+	try {
+		// 1. Verificar que existe la cancelación
+		const [cancelacion] = await db
+			.select()
+			.from(credit_cancelations)
+			.where(eq(credit_cancelations.credit_id, creditId))
+			.limit(1);
 
-    if (!cancelacion) {
-      return {
-        success: false,
-        message: "No existe una cancelación para este crédito.",
-      };
-    }
+		if (!cancelacion) {
+			return {
+				success: false,
+				message: "No existe una cancelación para este crédito.",
+			};
+		}
 
-    // 2. Actualizar el estado
-    await db
-      .update(credit_cancelations)
-      .set({ activo })
-      .where(eq(credit_cancelations.credit_id, creditId));
+		// 2. Actualizar el estado
+		await db
+			.update(credit_cancelations)
+			.set({ activo })
+			.where(eq(credit_cancelations.credit_id, creditId));
 
-    console.log(`✅ Cancelación de crédito ${creditId} ${activo ? "ACTIVADA" : "DESACTIVADA"}`);
+		console.log(
+			`✅ Cancelación de crédito ${creditId} ${
+				activo ? "ACTIVADA" : "DESACTIVADA"
+			}`,
+		);
 
-    return {
-      success: true,
-      message: `Cancelación ${activo ? "activada" : "desactivada"} exitosamente.`,
-      data: {
-        credit_id: creditId,
-        activo,
-      },
-    };
-  } catch (error) {
-    console.error("❌ Error actualizando estado de cancelación:", error);
-    return {
-      success: false,
-      message: "Error actualizando estado de cancelación",
-      error: String(error),
-    };
-  }
+		return {
+			success: true,
+			message: `Cancelación ${
+				activo ? "activada" : "desactivada"
+			} exitosamente.`,
+			data: {
+				credit_id: creditId,
+				activo,
+			},
+		};
+	} catch (error) {
+		console.error("❌ Error actualizando estado de cancelación:", error);
+		return {
+			success: false,
+			message: "Error actualizando estado de cancelación",
+			error: String(error),
+		};
+	}
 }
 
 // ============================================
 // Actualizar NIT de un crédito (usuario)
 // ============================================
 export async function actualizarNitCredito({
-  numero_credito_sifco,
-  nit,
+	numero_credito_sifco,
+	nit,
 }: {
-  numero_credito_sifco: string;
-  nit: string;
+	numero_credito_sifco: string;
+	nit: string;
 }) {
-  // 1. Buscar el crédito
-  const [credito] = await db
-    .select({
-      credito_id: creditos.credito_id,
-      usuario_id: creditos.usuario_id,
-    })
-    .from(creditos)
-    .where(eq(creditos.numero_credito_sifco, numero_credito_sifco))
-    .limit(1);
+	// 1. Buscar el crédito
+	const [credito] = await db
+		.select({
+			credito_id: creditos.credito_id,
+			usuario_id: creditos.usuario_id,
+		})
+		.from(creditos)
+		.where(eq(creditos.numero_credito_sifco, numero_credito_sifco))
+		.limit(1);
 
-  if (!credito) {
-    return { success: false, message: "Crédito no encontrado" };
-  }
+	if (!credito) {
+		return { success: false, message: "Crédito no encontrado" };
+	}
 
-  // 2. Actualizar el NIT del usuario
-  await db
-    .update(usuarios)
-    .set({ nit })
-    .where(eq(usuarios.usuario_id, credito.usuario_id));
+	// 2. Actualizar el NIT del usuario
+	await db
+		.update(usuarios)
+		.set({ nit })
+		.where(eq(usuarios.usuario_id, credito.usuario_id));
 
-  return {
-    success: true,
-    message: `NIT actualizado a ${nit} para el crédito ${numero_credito_sifco}`,
-  };
+	return {
+		success: true,
+		message: `NIT actualizado a ${nit} para el crédito ${numero_credito_sifco}`,
+	};
 }

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -42,7 +42,6 @@ import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   CREDIT_DETAIL_STATUSES,
   canResetCreditByStatus,
-  isScheduledCreditInstallment,
   withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
@@ -90,7 +89,7 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         : undefined;
 
     // 2. Consultar todas las cuotas pagadas (pagado = true)
-    const cuotasPagadasConCierre = await db
+    const cuotasPagadas = await db
       .select({
         // Campos de cuotas_credito
         cuota_id: cuotas_credito.cuota_id,
@@ -139,9 +138,6 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         )
       )
       .orderBy(cuotas_credito.numero_cuota);
-
-    const cuotasPagadas = cuotasPagadasConCierre.filter((row) => isScheduledCreditInstallment(row.validationStatus));
-
     // 4. Calcular la cuota que toca este mes (según meses transcurridos desde fecha_creacion)
     const fechaInicio = new Date(currentCredit.creditos.fecha_creacion);
     const hoy = new Date();
@@ -256,6 +252,16 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
       )
       .orderBy(cuotas_credito.numero_cuota);
 
+    const moraActual = await db
+      .select()
+      .from(moras_credito)
+      .where(
+        and(
+          eq(moras_credito.credito_id, creditoId),
+          eq(moras_credito.activa, true)
+        )
+      );
+
     // 6. Consultar si la cuota actual ya fue pagada
     const cuotaActualDataResult = await db
       .select({
@@ -320,8 +326,8 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
         cuotasPendientes,
         cuotasAtrasadas,
         cuotasPagadas,
-        moraActual: 0,
-        mora: null,
+        moraActual: moraActual.length > 0 ? moraActual[0].monto_mora : 0,
+        mora: moraActual.length > 0 ? moraActual[0] : null,
         convenioActivo: null,
         cuotasEnConvenio: [],
         pagosConvenio: [],
@@ -337,16 +343,6 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
     // La cuota actual del mes con toda su info
     const cuotaActual = cuotaActualData;
     const cuotaActualStatus = cuotaActualData.validationStatus;
-
-    const moraActual = await db
-      .select()
-      .from(moras_credito)
-      .where(
-        and(
-          eq(moras_credito.credito_id, creditoId),
-          eq(moras_credito.activa, true)
-        )
-      );
 
     const convenioActivo = await db
       .select()

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -1838,150 +1838,7 @@ export async function resetCredit({
   numeroAutorizacion?: string;
 }) {
   try {
-    // 1. Jalar mora activa (si existe, se incluye en el pago de cierre)
-    const [moraActiva] = await db
-      .select({ monto_mora: moras_credito.monto_mora })
-      .from(moras_credito)
-      .where(
-        and(
-          eq(moras_credito.credito_id, creditId),
-          eq(moras_credito.activa, true)
-        )
-      )
-      .limit(1);
-
-    const moraBig = new Big(moraActiva?.monto_mora as unknown as string ?? "0");
-
-    // 2. Consultar crédito ANTES de resetearlo (necesitamos los valores originales)
-    const [credito] = await db
-      .select()
-      .from(creditos)
-      .where(eq(creditos.credito_id, creditId));
-    if (!credito) {
-      throw new Error("Crédito no encontrado.");
-    }
-
-    let incobrableContinuationReady = false;
-    if (credito.statusCredit === "INCOBRABLE") {
-      const [badDebt] = await db
-        .select({ monto_incobrable: bad_debts.monto_incobrable })
-        .from(bad_debts)
-        .where(eq(bad_debts.credit_id, creditId))
-        .limit(1);
-      const [existingClosingPayment] = await db
-        .select({ pago_id: pagos_credito.pago_id })
-        .from(pagos_credito)
-        .where(
-          and(
-            eq(pagos_credito.credito_id, creditId),
-            eq(pagos_credito.registerBy, "system_reset")
-          )
-        )
-        .limit(1);
-
-      try {
-        if (
-          montoIncobrable !== undefined &&
-          Number.isFinite(montoIncobrable) &&
-          badDebt &&
-          !existingClosingPayment
-        ) {
-          const montoIncobrableBig = new Big(montoIncobrable);
-          const creditoCapitalBig = new Big(credito.capital ?? 0);
-          const badDebtCapitalBig = new Big(badDebt.monto_incobrable ?? 0);
-          incobrableContinuationReady =
-            montoIncobrableBig.gt(0) &&
-            montoIncobrableBig.eq(creditoCapitalBig) &&
-            montoIncobrableBig.eq(badDebtCapitalBig);
-        }
-      } catch {
-        incobrableContinuationReady = false;
-      }
-    }
-
-    if (!canResetCreditByStatus(credito.statusCredit, incobrableContinuationReady)) {
-      throw new Error(
-        "El crédito no está pendiente de cancelación ni listo para continuar como incobrable."
-      );
-    }
-
-    // 3. Determinar el estado del crédito
-    const statusCredit =
-      typeof montoIncobrable !== "undefined" &&
-      montoIncobrable > 0 &&
-      montoBoleta !== undefined
-        ? "INCOBRABLE"
-        : "CANCELADO";
-
-    // 4. Jalar la cancelación para obtener cuotas_atrasadas, garantía, traspaso, otros
-    const [cancelacion] = await db
-      .select()
-      .from(credit_cancelations)
-      .where(eq(credit_cancelations.credit_id, creditId))
-      .limit(1);
-
-    const n = cancelacion?.cuotas_atrasadas ?? 0;
-
-    // 5. Jalar extras (montos_adicionales)
-    const extrasRows = await db
-      .select({ monto: montos_adicionales.monto })
-      .from(montos_adicionales)
-      .where(eq(montos_adicionales.credit_id, creditId));
-
-    const totalExtras = extrasRows.reduce(
-      (acc, row) => acc.plus(row.monto as unknown as string),
-      new Big(0)
-    );
-
-    // 6. Calcular abonos reales
-    const capitalOriginal = new Big(credito.capital ?? "0");
-    const abonoCapital = statusCredit === "INCOBRABLE"
-      ? capitalOriginal.minus(new Big(montoIncobrable!))
-      : capitalOriginal;
-    const abonoInteres = new Big(credito.cuota_interes ?? "0").times(n);
-    const abonoIva = new Big(credito.iva_12 ?? "0").times(n);
-    const abonoSeguro = new Big(credito.seguro_10_cuotas ?? "0").times(n);
-    const abonoGps = new Big(credito.gps ?? "0").times(n);
-    const abonoMembresias = new Big(credito.membresias ?? "0").times(n);
-
-    const otrosCancelacion = new Big(cancelacion?.garantia_mobiliaria ?? "0")
-      .plus(cancelacion?.traspaso ?? "0")
-      .plus(cancelacion?.otros ?? "0")
-      .plus(totalExtras);
-
-    const totalMontoPago = abonoCapital
-      .plus(abonoInteres)
-      .plus(abonoIva)
-      .plus(abonoSeguro)
-      .plus(abonoGps)
-      .plus(abonoMembresias)
-      .plus(otrosCancelacion)
-      .plus(moraBig);
-
-    // 7. Construir URLs de boletas
-    const r2BaseUrl = import.meta.env.URL_PUBLIC_R2 ?? "";
-    const urlCompletas = construirUrlBoletas(url_boletas, r2BaseUrl);
-
-    // 8. Obtener pagos del mes + monto de boleta
-    const pago_del_mes = await getPagosDelMesActual(credito.credito_id);
-    const pago_del_mesBig = new Big(pago_del_mes ?? 0).add(montoBoleta ?? 0);
-
-    // 9. Buscar cuota_id correspondiente
-    const [cuotaEncontrada] = await db
-      .select({ cuota_id: cuotas_credito.cuota_id })
-      .from(cuotas_credito)
-      .where(
-        and(
-          eq(cuotas_credito.credito_id, credito.credito_id),
-          eq(cuotas_credito.numero_cuota, cuota)
-        )
-      )
-      .limit(1);
-
-    const cuotaId = cuotaEncontrada?.cuota_id;
-
-    // 10. Insertar pago de cierre con abonos reales
-    const nuevoPago = await db.transaction(async (tx) => {
+    const { statusCredit } = await db.transaction(async (tx) => {
       const [lockedCredit] = await tx
         .select()
         .from(creditos)
@@ -1991,6 +1848,31 @@ export async function resetCredit({
       if (!lockedCredit) {
         throw new Error("Crédito no encontrado.");
       }
+      const credito = lockedCredit;
+
+      // 1. Jalar mora activa (si existe, se incluye en el pago de cierre)
+      const [moraActiva] = await tx
+        .select({ monto_mora: moras_credito.monto_mora })
+        .from(moras_credito)
+        .where(
+          and(
+            eq(moras_credito.credito_id, creditId),
+            eq(moras_credito.activa, true),
+          ),
+        )
+        .limit(1);
+      const moraBig = new Big(
+        (moraActiva?.monto_mora as unknown as string) ?? "0",
+      );
+
+      const [badDebt] =
+        credito.statusCredit === "INCOBRABLE"
+          ? await tx
+              .select({ monto_incobrable: bad_debts.monto_incobrable })
+              .from(bad_debts)
+              .where(eq(bad_debts.credit_id, creditId))
+              .limit(1)
+          : [undefined];
 
       const [existingClosingPayment] = await tx
         .select({ pago_id: pagos_credito.pago_id })
@@ -1998,186 +1880,306 @@ export async function resetCredit({
         .where(
           and(
             eq(pagos_credito.credito_id, creditId),
-            eq(pagos_credito.registerBy, "system_reset")
-          )
+            eq(pagos_credito.registerBy, "system_reset"),
+          ),
         )
         .limit(1);
+
+      let incobrableContinuationReady = false;
+      if (credito.statusCredit === "INCOBRABLE") {
+        try {
+          if (
+            montoIncobrable !== undefined &&
+            Number.isFinite(montoIncobrable) &&
+            badDebt &&
+            !existingClosingPayment
+          ) {
+            const montoIncobrableBig = new Big(montoIncobrable);
+            const creditoCapitalBig = new Big(credito.capital ?? 0);
+            const badDebtCapitalBig = new Big(badDebt.monto_incobrable ?? 0);
+            incobrableContinuationReady =
+              montoIncobrableBig.gt(0) &&
+              montoIncobrableBig.eq(creditoCapitalBig) &&
+              montoIncobrableBig.eq(badDebtCapitalBig);
+          }
+        } catch {
+          incobrableContinuationReady = false;
+        }
+      }
+
+      if (
+        !canResetCreditByStatus(
+          credito.statusCredit,
+          incobrableContinuationReady,
+        )
+      ) {
+        throw new Error(
+          "El crédito no está pendiente de cancelación ni listo para continuar como incobrable.",
+        );
+      }
       if (existingClosingPayment) {
         throw new Error("El crédito ya tiene un pago de cierre system_reset.");
       }
 
-      const [insertedPayment] = await tx.insert(pagos_credito).values({
-        credito_id: credito.credito_id,
-        cuota_id: cuotaId,
-        cuota: credito.cuota?.toString() ?? "0",
-        cuota_interes: credito.cuota_interes?.toString() ?? "0",
-        abono_capital: abonoCapital.toString(),
-        abono_interes: abonoInteres.toString(),
-        abono_iva_12: abonoIva.toString(),
-        abono_interes_ci: "0",
-        abono_iva_ci: "0",
-        abono_seguro: abonoSeguro.toString(),
-        abono_gps: abonoGps.toString(),
-        pago_del_mes: pago_del_mesBig.toString(),
-        monto_boleta: montoBoleta.toString(),
-        capital_restante: "0",
-        interes_restante: "0",
-        iva_12_restante: "0",
-        seguro_restante: "0",
-        gps_restante: "0",
-        total_restante: "0",
-        llamada: "",
-        renuevo_o_nuevo: "renuevo",
-        membresias: "0",
-        membresias_pago: abonoMembresias.toString(),
-        membresias_mes: abonoMembresias.toString(),
-        otros: otrosCancelacion.toString(),
-        mora: moraBig.toString(),
-        monto_boleta_cuota: montoBoleta.toString(),
-        seguro_total: credito.seguro_10_cuotas?.toString() ?? "0",
-        pagado: true,
-        facturacion: "si",
-        mes_pagado: "",
-        seguro_facturado: abonoSeguro.toString(),
-        gps_facturado: abonoGps.toString(),
-        reserva: "0",
-        observaciones: "",
-        validationStatus: "reset" as const,
-        banco_id: banco_id,
-        numeroAutorizacion: numeroAutorizacion ?? "",
-        registerBy: "system_reset",
-        pagoConvenio: "0",
-        monto_aplicado: totalMontoPago.toString(),
-      }).returning();
-      return insertedPayment;
-    });
+      // 3. Determinar el estado del crédito
+      const statusCredit =
+        typeof montoIncobrable !== "undefined" &&
+        montoIncobrable > 0 &&
+        montoBoleta !== undefined
+          ? "INCOBRABLE"
+          : "CANCELADO";
 
-    // 11. Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
-    //     paymentFalse=true). Además se ponen los *_restante en 0: algunas queries de
-    //     cuotas pendientes/atrasadas (getCreditoByNumero, reportes) NO filtran paymentFalse,
-    //     así que sin esto mostrarían "deuda fantasma" con los restantes viejos.
-    await db
-      .update(pagos_credito)
-      .set({
-        paymentFalse: sql<boolean>`CASE
+      // 4. Jalar la cancelación para obtener cuotas_atrasadas, garantía, traspaso, otros
+      const [cancelacion] = await tx
+        .select()
+        .from(credit_cancelations)
+        .where(eq(credit_cancelations.credit_id, creditId))
+        .limit(1);
+      const n = cancelacion?.cuotas_atrasadas ?? 0;
+
+      // 5. Jalar extras (montos_adicionales)
+      const extrasRows = await tx
+        .select({ monto: montos_adicionales.monto })
+        .from(montos_adicionales)
+        .where(eq(montos_adicionales.credit_id, creditId));
+      const totalExtras = extrasRows.reduce(
+        (acc, row) => acc.plus(row.monto as unknown as string),
+        new Big(0),
+      );
+
+      // 6. Calcular abonos reales
+      const capitalOriginal = new Big(credito.capital ?? "0");
+      const abonoCapital =
+        statusCredit === "INCOBRABLE"
+          ? capitalOriginal.minus(new Big(montoIncobrable!))
+          : capitalOriginal;
+      const abonoInteres = new Big(credito.cuota_interes ?? "0").times(n);
+      const abonoIva = new Big(credito.iva_12 ?? "0").times(n);
+      const abonoSeguro = new Big(credito.seguro_10_cuotas ?? "0").times(n);
+      const abonoGps = new Big(credito.gps ?? "0").times(n);
+      const abonoMembresias = new Big(credito.membresias ?? "0").times(n);
+      const otrosCancelacion = new Big(
+        cancelacion?.garantia_mobiliaria ?? "0",
+      )
+        .plus(cancelacion?.traspaso ?? "0")
+        .plus(cancelacion?.otros ?? "0")
+        .plus(totalExtras);
+      const totalMontoPago = abonoCapital
+        .plus(abonoInteres)
+        .plus(abonoIva)
+        .plus(abonoSeguro)
+        .plus(abonoGps)
+        .plus(abonoMembresias)
+        .plus(otrosCancelacion)
+        .plus(moraBig);
+
+      // 7. Construir URLs de boletas
+      const r2BaseUrl = import.meta.env.URL_PUBLIC_R2 ?? "";
+      const urlCompletas = construirUrlBoletas(url_boletas, r2BaseUrl);
+
+      // 8. Obtener pagos del mes + monto de boleta
+      const pago_del_mes = await getPagosDelMesActual(credito.credito_id, tx);
+      const pago_del_mesBig = new Big(pago_del_mes ?? 0).add(montoBoleta ?? 0);
+
+      // 9. Buscar cuota_id correspondiente
+      const [cuotaEncontrada] = await tx
+        .select({ cuota_id: cuotas_credito.cuota_id })
+        .from(cuotas_credito)
+        .where(
+          and(
+            eq(cuotas_credito.credito_id, credito.credito_id),
+            eq(cuotas_credito.numero_cuota, cuota),
+          ),
+        )
+        .limit(1);
+      const cuotaId = cuotaEncontrada?.cuota_id;
+
+      // 10. Insertar pago de cierre con abonos reales
+
+      const [nuevoPago] = await tx
+        .insert(pagos_credito)
+        .values({
+          credito_id: credito.credito_id,
+          cuota_id: cuotaId,
+          cuota: credito.cuota?.toString() ?? "0",
+          cuota_interes: credito.cuota_interes?.toString() ?? "0",
+          abono_capital: abonoCapital.toString(),
+          abono_interes: abonoInteres.toString(),
+          abono_iva_12: abonoIva.toString(),
+          abono_interes_ci: "0",
+          abono_iva_ci: "0",
+          abono_seguro: abonoSeguro.toString(),
+          abono_gps: abonoGps.toString(),
+          pago_del_mes: pago_del_mesBig.toString(),
+          monto_boleta: montoBoleta.toString(),
+          capital_restante: "0",
+          interes_restante: "0",
+          iva_12_restante: "0",
+          seguro_restante: "0",
+          gps_restante: "0",
+          total_restante: "0",
+          llamada: "",
+          renuevo_o_nuevo: "renuevo",
+          membresias: "0",
+          membresias_pago: abonoMembresias.toString(),
+          membresias_mes: abonoMembresias.toString(),
+          otros: otrosCancelacion.toString(),
+          mora: moraBig.toString(),
+          monto_boleta_cuota: montoBoleta.toString(),
+          seguro_total: credito.seguro_10_cuotas?.toString() ?? "0",
+          pagado: true,
+          facturacion: "si",
+          mes_pagado: "",
+          seguro_facturado: abonoSeguro.toString(),
+          gps_facturado: abonoGps.toString(),
+          reserva: "0",
+          observaciones: "",
+          validationStatus: "reset" as const,
+          banco_id: banco_id,
+          numeroAutorizacion: numeroAutorizacion ?? "",
+          registerBy: "system_reset",
+          pagoConvenio: "0",
+          monto_aplicado: totalMontoPago.toString(),
+        })
+        .returning();
+
+      // 11. Anular pagos no pagados (NO se borran: se conservan como histórico marcándolos
+      //     paymentFalse=true). Además se ponen los *_restante en 0: algunas queries de
+      //     cuotas pendientes/atrasadas (getCreditoByNumero, reportes) NO filtran paymentFalse,
+      //     así que sin esto mostrarían "deuda fantasma" con los restantes viejos.
+      await tx
+        .update(pagos_credito)
+        .set({
+          paymentFalse: sql<boolean>`CASE
           WHEN ${pagos_credito.paymentFalse} IS TRUE THEN TRUE
           WHEN ${pagos_credito.validationStatus} IN ('validated', 'capital_validated') THEN FALSE
           ELSE TRUE
         END`,
-        capital_restante: "0",
-        interes_restante: "0",
-        iva_12_restante: "0",
-        seguro_restante: "0",
-        gps_restante: "0",
-        total_restante: "0",
-        mora: "0",
-      })
-      .where(
-        and(
-          eq(pagos_credito.credito_id, credito.credito_id),
-          eq(pagos_credito.pagado, false)
-        )
+          capital_restante: "0",
+          interes_restante: "0",
+          iva_12_restante: "0",
+          seguro_restante: "0",
+          gps_restante: "0",
+          total_restante: "0",
+          mora: "0",
+        })
+        .where(
+          and(
+            eq(pagos_credito.credito_id, credito.credito_id),
+            eq(pagos_credito.pagado, false),
+          ),
+        );
+
+      // 12.1 Crear cuota correlativa (MAX(numero_cuota) + 1) para enlazar el pago de cierre
+      const [maxCuotaRow] = await tx
+        .select({
+          max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
+        })
+        .from(cuotas_credito)
+        .where(eq(cuotas_credito.credito_id, credito.credito_id));
+      const nextNumeroCuotaCierre = Number(maxCuotaRow?.max ?? 0) + 1;
+
+      const [cuotaCierre] = await tx
+        .insert(cuotas_credito)
+        .values({
+          credito_id: credito.credito_id,
+          numero_cuota: nextNumeroCuotaCierre,
+          fecha_vencimiento: new Date().toLocaleDateString("sv-SE", {
+            timeZone: "America/Guatemala",
+          }),
+          liquidado_inversionistas: false,
+          pagado: true,
+        })
+        .returning();
+
+      // 12.2 Enlazar el pago de cierre a la cuota recién creada (cuota correlativa "pagada"),
+      // para que el cierre quede asociado a una cuota limpia y no a una cuota vigente del plan.
+      if (nuevoPago?.pago_id && cuotaCierre?.cuota_id) {
+        await tx
+          .update(pagos_credito)
+          .set({ cuota_id: cuotaCierre.cuota_id })
+          .where(eq(pagos_credito.pago_id, nuevoPago.pago_id));
+      }
+
+      // 12. Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
+      //     anulados (paymentFalse=true) en el paso 11, así que no aportan saldo en las vistas activas.
+
+      // 12.5 Distribuir abono a capital en tabla espejo (CANCELACION)
+      await distribuirAbonoCapitalEspejo(
+        credito.credito_id,
+        abonoCapital.toString(),
+        "CANCELACION",
+        undefined,
+        tx,
       );
 
-    // 12.1 Crear cuota correlativa (MAX(numero_cuota) + 1) para enlazar el pago de cierre
-    const [maxCuotaRow] = await db
-      .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
-      .from(cuotas_credito)
-      .where(eq(cuotas_credito.credito_id, credito.credito_id));
-    const nextNumeroCuotaCierre = Number(maxCuotaRow?.max ?? 0) + 1;
-
-    const [cuotaCierre] = await db
-      .insert(cuotas_credito)
-      .values({
-        credito_id: credito.credito_id,
-        numero_cuota: nextNumeroCuotaCierre,
-        fecha_vencimiento: new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" }),
-        liquidado_inversionistas: false,
-        pagado: true,
-      })
-      .returning();
-
-    // 12.2 Enlazar el pago de cierre a la cuota recién creada (cuota correlativa "pagada"),
-    // para que el cierre quede asociado a una cuota limpia y no a una cuota vigente del plan.
-    if (nuevoPago?.pago_id && cuotaCierre?.cuota_id) {
-      await db
-        .update(pagos_credito)
-        .set({ cuota_id: cuotaCierre.cuota_id })
-        .where(eq(pagos_credito.pago_id, nuevoPago.pago_id));
-    }
-
-    // 12. Las cuotas no pagadas NO se borran: se conservan como histórico. Sus pagos quedaron
-    //     anulados (paymentFalse=true) en el paso 11, así que no aportan saldo en las vistas activas.
-
-    // 12.5 Distribuir abono a capital en tabla espejo (CANCELACION)
-    try {
-      await distribuirAbonoCapitalEspejo(credito.credito_id, abonoCapital.toString(), "CANCELACION");
-      console.log("✅ Abono capital (reset) distribuido en tabla abonos_capital (espejo)");
-    } catch (err) {
-      console.error("⚠️ Error al distribuir abono en espejo (reset):", err);
-    }
-
-    // 13. Distribuir pago entre inversionistas (ANTES de reiniciar, necesita monto_aportado).
-    //     Si la suma de aportes es 0 (p.ej. crédito ya reseteado antes) la distribución lanza
-    //     excepción; la atrapamos para no abortar el cierre del crédito.
-    if (nuevoPago?.pago_id) {
-      try {
-        await insertPagosCreditoInversionistasV2(
-          nuevoPago.pago_id,
-          credito.credito_id
-        );
-      } catch (err) {
-        // Solo silenciamos el caso conocido y benigno: crédito SIN aportes (suma = 0),
-        // típico de un crédito ya reseteado antes. Cualquier otro fallo (inversionistas o
-        // pagos faltantes, error de DB, distribución a medias) SÍ se re-lanza: dejar el
-        // cierre sin liquidación de inversionistas e irreintentable sería peor.
-        const msg = err instanceof Error ? err.message : String(err);
-        if (msg.includes("suma de montos aportados es 0")) {
-          console.warn(
-            `⚠️ Distribución a inversionistas omitida (crédito ${credito.credito_id} sin aportes).`
+      // 13. Distribuir pago entre inversionistas (ANTES de reiniciar, necesita monto_aportado).
+      //     Si la suma de aportes es 0 (p.ej. crédito ya reseteado antes) la distribución lanza
+      //     excepción; la atrapamos para no abortar el cierre del crédito.
+      if (nuevoPago?.pago_id) {
+        try {
+          await insertPagosCreditoInversionistasV2(
+            nuevoPago.pago_id,
+            credito.credito_id,
+            undefined,
+            tx,
           );
-        } else {
-          throw err;
+        } catch (err) {
+          // Solo silenciamos el caso conocido y benigno: crédito SIN aportes (suma = 0),
+          // típico de un crédito ya reseteado antes. Cualquier otro fallo (inversionistas o
+          // pagos faltantes, error de DB, distribución a medias) SÍ se re-lanza: dejar el
+          // cierre sin liquidación de inversionistas e irreintentable sería peor.
+          const msg = err instanceof Error ? err.message : String(err);
+          if (
+            msg === "La suma de montos aportados es 0, no se puede distribuir"
+          ) {
+            console.warn(
+              `⚠️ Distribución a inversionistas omitida (crédito ${credito.credito_id} sin aportes).`,
+            );
+          } else {
+            throw err;
+          }
         }
       }
-    }
 
-    // 14. Reiniciar creditos_inversionistas (no espejo)
-    await db
-      .update(creditos_inversionistas)
-      .set({
-        monto_aportado: "0",
-        monto_inversionista: "0",
-        monto_cash_in: "0",
-        iva_inversionista: "0",
-        iva_cash_in: "0",
-      })
-      .where(eq(creditos_inversionistas.credito_id, credito.credito_id));
+      // 14. Reiniciar creditos_inversionistas (no espejo)
+      await tx
+        .update(creditos_inversionistas)
+        .set({
+          monto_aportado: "0",
+          monto_inversionista: "0",
+          monto_cash_in: "0",
+          iva_inversionista: "0",
+          iva_cash_in: "0",
+        })
+        .where(eq(creditos_inversionistas.credito_id, credito.credito_id));
 
-    // 15. Insertar boletas si existen
-    if (
-      urlCompletas &&
-      urlCompletas.length > 0 &&
-      nuevoPago &&
-      nuevoPago?.pago_id
-    ) {
-      await db.insert(boletas).values(
-        urlCompletas.map((url) => ({
-          pago_id: nuevoPago?.pago_id,
-          url_boleta: url,
-        }))
-      );
-    }
+      // 15. Insertar boletas si existen
+      if (
+        urlCompletas &&
+        urlCompletas.length > 0 &&
+        nuevoPago &&
+        nuevoPago?.pago_id
+      ) {
+        await tx.insert(boletas).values(
+          urlCompletas.map((url) => ({
+            pago_id: nuevoPago?.pago_id,
+            url_boleta: url,
+          })),
+        );
+      }
 
-    // 16. Al final: zerear el crédito y ponerle el status
-    const fechaHoyGT = new Date().toLocaleDateString("sv-SE", { timeZone: "America/Guatemala" });
+      // 16. Al final: zerear el crédito y ponerle el status
+      const fechaHoyGT = new Date().toLocaleDateString("sv-SE", {
+        timeZone: "America/Guatemala",
+      });
 
-    if (statusCredit === "INCOBRABLE") {
-      const capitalIncobrable = new Big(montoIncobrable!);
+      if (statusCredit === "INCOBRABLE") {
+        const capitalIncobrable = new Big(montoIncobrable!);
 
-      // 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
-      await withCapitalContext(null, "CASTIGO", null, (tx) =>
-        tx
+        // 16a. Actualizar crédito: capital = incobrable, lo demás en 0 (preservamos porcentaje_interes)
+        await setCapitalSource(tx, "CASTIGO", null, null);
+        await tx
           .update(creditos)
           .set({
             capital: capitalIncobrable.toString(),
@@ -2195,72 +2197,73 @@ export async function resetCredit({
             plazo: 1,
             statusCredit: "INCOBRABLE",
           })
-          .where(eq(creditos.credito_id, creditId))
-      );
+          .where(eq(creditos.credito_id, creditId));
 
-      // 16b. Crear cuota pendiente para el monto incobrable (correlativa)
-      const [maxCuotaRowInc] = await db
-        .select({ max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)` })
-        .from(cuotas_credito)
-        .where(eq(cuotas_credito.credito_id, credito.credito_id));
-      const nextNumeroCuotaPendiente = Number(maxCuotaRowInc?.max ?? 0) + 1;
+        // 16b. Crear cuota pendiente para el monto incobrable (correlativa)
+        const [maxCuotaRowInc] = await tx
+          .select({
+            max: sql<number>`COALESCE(MAX(${cuotas_credito.numero_cuota}), 0)`,
+          })
+          .from(cuotas_credito)
+          .where(eq(cuotas_credito.credito_id, credito.credito_id));
+        const nextNumeroCuotaPendiente = Number(maxCuotaRowInc?.max ?? 0) + 1;
 
-      const [cuotaPendiente] = await db
-        .insert(cuotas_credito)
-        .values({
+        const [cuotaPendiente] = await tx
+          .insert(cuotas_credito)
+          .values({
+            credito_id: credito.credito_id,
+            numero_cuota: nextNumeroCuotaPendiente,
+            fecha_vencimiento: fechaHoyGT,
+            pagado: false,
+            liquidado_inversionistas: false,
+          })
+          .returning();
+
+        // 16c. Crear pago placeholder (no pagado) con capital_restante = incobrable
+        await tx.insert(pagos_credito).values({
           credito_id: credito.credito_id,
-          numero_cuota: nextNumeroCuotaPendiente,
-          fecha_vencimiento: fechaHoyGT,
+          cuota_id: cuotaPendiente.cuota_id,
+          cuota: capitalIncobrable.toString(),
+          cuota_interes: "0",
+          abono_capital: "0",
+          abono_interes: "0",
+          abono_iva_12: "0",
+          abono_interes_ci: "0",
+          abono_iva_ci: "0",
+          abono_seguro: "0",
+          abono_gps: "0",
+          pago_del_mes: "0",
+          monto_boleta: "0",
+          capital_restante: capitalIncobrable.toString(),
+          interes_restante: "0",
+          iva_12_restante: "0",
+          seguro_restante: "0",
+          gps_restante: "0",
+          total_restante: capitalIncobrable.toString(),
+          membresias: "0",
+          membresias_pago: "0",
+          membresias_mes: "0",
+          mora: "0",
+          monto_boleta_cuota: "0",
+          seguro_total: "0",
           pagado: false,
-          liquidado_inversionistas: false,
-        })
-        .returning();
+          registerBy: "SISTEMA-INCOBRABLE",
+          pagoConvenio: "0",
+          monto_aplicado: "0",
+          observaciones: `Pago base - Crédito marcado como incobrable (reset)`,
+        });
 
-      // 16c. Crear pago placeholder (no pagado) con capital_restante = incobrable
-      await db.insert(pagos_credito).values({
-        credito_id: credito.credito_id,
-        cuota_id: cuotaPendiente.cuota_id,
-        cuota: capitalIncobrable.toString(),
-        cuota_interes: "0",
-        abono_capital: "0",
-        abono_interes: "0",
-        abono_iva_12: "0",
-        abono_interes_ci: "0",
-        abono_iva_ci: "0",
-        abono_seguro: "0",
-        abono_gps: "0",
-        pago_del_mes: "0",
-        monto_boleta: "0",
-        capital_restante: capitalIncobrable.toString(),
-        interes_restante: "0",
-        iva_12_restante: "0",
-        seguro_restante: "0",
-        gps_restante: "0",
-        total_restante: capitalIncobrable.toString(),
-        membresias: "0",
-        membresias_pago: "0",
-        membresias_mes: "0",
-        mora: "0",
-        monto_boleta_cuota: "0",
-        seguro_total: "0",
-        pagado: false,
-        registerBy: "SISTEMA-INCOBRABLE",
-        pagoConvenio: "0",
-        monto_aplicado: "0",
-        observaciones: `Pago base - Crédito marcado como incobrable (reset)`,
-      });
-
-      // 16d. Registrar en bad_debts
-      await db.insert(bad_debts).values({
-        credit_id: creditId,
-        motivo: cancelacion?.motivo ?? "Incobrable",
-        observaciones: cancelacion?.observaciones ?? "",
-        monto_incobrable: capitalIncobrable.toString(),
-      });
-    } else {
-      // CANCELADO: zerear todo (preservamos porcentaje_interes)
-      await withCapitalContext(null, "CANCELACION", null, (tx) =>
-        tx
+        // 16d. Registrar en bad_debts
+        await tx.insert(bad_debts).values({
+          credit_id: creditId,
+          motivo: cancelacion?.motivo ?? "Incobrable",
+          observaciones: cancelacion?.observaciones ?? "",
+          monto_incobrable: capitalIncobrable.toString(),
+        });
+      } else {
+        // CANCELADO: zerear todo (preservamos porcentaje_interes)
+        await setCapitalSource(tx, "CANCELACION", null, null);
+        await tx
           .update(creditos)
           .set({
             capital: "0",
@@ -2277,9 +2280,11 @@ export async function resetCredit({
             otros: "0",
             statusCredit: "CANCELADO",
           })
-          .where(eq(creditos.credito_id, creditId))
-      );
-    }
+          .where(eq(creditos.credito_id, creditId));
+      }
+
+      return { nuevoPago, statusCredit };
+    });
 
     // 17. Retorno OK
     return {

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -41,6 +41,7 @@ import { getPagosDelMesActual, insertPagosCreditoInversionistasV2 } from "./paym
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   CREDIT_DETAIL_STATUSES,
+  canResetCreditByStatus,
   withActiveCancellation,
 } from "./creditDetailPolicy";
 import { buildNameSearchCondition } from "../utils/functions/generalFunctions";
@@ -1807,6 +1808,9 @@ export async function resetCredit({
       .where(eq(creditos.credito_id, creditId));
     if (!credito) {
       throw new Error("Crédito no encontrado.");
+    }
+    if (!canResetCreditByStatus(credito.statusCredit)) {
+      throw new Error("El crédito no está pendiente de cancelación.");
     }
 
     // 3. Determinar el estado del crédito

--- a/apps/cartera-back/src/controllers/credits.ts
+++ b/apps/cartera-back/src/controllers/credits.ts
@@ -42,6 +42,7 @@ import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
 import {
   CREDIT_DETAIL_STATUSES,
   canResetCreditByStatus,
+  isAmbiguousOriginalPrincipalPayment,
   isCreditClosingPayment,
   isOriginalPrincipalPayment,
   withActiveCancellation,
@@ -88,6 +89,9 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
               .where(eq(pagos_credito.credito_id, creditoId));
             const eligiblePayments = payments.filter(isOriginalPrincipalPayment);
             const closingPayments = eligiblePayments.filter(isCreditClosingPayment);
+            const hasAmbiguousPrincipalPayments = payments.some(
+              isAmbiguousOriginalPrincipalPayment,
+            );
 
             return {
               originalPrincipal: (() => {
@@ -95,14 +99,14 @@ export const getCreditoByNumero = async (numero_credito_sifco: string) => {
                   (total, payment) => total.plus(payment.abono_capital ?? 0),
                   new Big(0),
                 );
-                return principal.gt(0) ? principal.toFixed(2) : null;
+                return closingPayments.length > 0 &&
+                  !hasAmbiguousPrincipalPayments &&
+                  principal.gt(0)
+                  ? principal.toFixed(2)
+                  : null;
               })(),
               installment:
                 closingPayments.find((payment) => payment.cuota != null)?.cuota ??
-                eligiblePayments.find(
-                  (payment) => payment.validationStatus === "reset" && payment.cuota != null
-                )?.cuota ??
-                eligiblePayments.find((payment) => payment.cuota != null)?.cuota ??
                 null,
             };
           })()
@@ -1585,7 +1589,11 @@ export async function actualizarEstadoCredito(input: AccionCreditoParams) {
       const pagosNoPagados = await tx
         .update(pagos_credito)
         .set({
-          paymentFalse: true,
+          paymentFalse: sql<boolean>`CASE
+            WHEN ${pagos_credito.paymentFalse} IS TRUE THEN TRUE
+            WHEN ${pagos_credito.validationStatus} IN ('validated', 'capital_validated') THEN FALSE
+            ELSE TRUE
+          END`,
           capital_restante: "0",
           interes_restante: "0",
           iva_12_restante: "0",
@@ -1986,7 +1994,11 @@ export async function resetCredit({
     await db
       .update(pagos_credito)
       .set({
-        paymentFalse: true,
+        paymentFalse: sql<boolean>`CASE
+          WHEN ${pagos_credito.paymentFalse} IS TRUE THEN TRUE
+          WHEN ${pagos_credito.validationStatus} IN ('validated', 'capital_validated') THEN FALSE
+          ELSE TRUE
+        END`,
         capital_restante: "0",
         interes_restante: "0",
         iva_12_restante: "0",

--- a/apps/cartera-back/src/controllers/payments.ts
+++ b/apps/cartera-back/src/controllers/payments.ts
@@ -1717,7 +1717,10 @@ export async function falsePayment(pago_id: number, credito_id: number) {
   };
 }
 
-export async function getPagosDelMesActual(credito_id: number) {
+export async function getPagosDelMesActual(
+  credito_id: number,
+  executor: Pick<typeof db, "select"> = db
+) {
   const hoy = new Date(
     new Date().toLocaleString("en-US", { timeZone: "America/Guatemala" })
   );
@@ -1725,7 +1728,7 @@ export async function getPagosDelMesActual(credito_id: number) {
   const anio = hoy.getFullYear();
 
   // Trae todos los pagos válidos de este mes y año
-  const pagos = await db
+  const pagos = await executor
     .select({ monto_boleta: pagos_credito.monto_boleta })
     .from(pagos_credito)
     .where(

--- a/apps/cartera-back/src/routers/credits.ts
+++ b/apps/cartera-back/src/routers/credits.ts
@@ -15,6 +15,7 @@ import {
 import { getCuotasPorDiaYAsesor, upsertEfectividadAsesores, getEfectividadAsesores } from "../controllers/paymentsByAdvisor";
 import { z } from "zod";
 import { getCreditWithCancellationDetails } from "../controllers/cancelCredit";
+import { isValidResetCreditInput } from "../controllers/creditDetailPolicy";
 import { launchBrowser } from "../utils/functions/browser";
 import { promises as fs } from "fs";
 import {
@@ -708,43 +709,21 @@ export const creditRouter = new Elysia()
     }
   })
   .post("/resetCredit", async ({ body, set }) => {
-    // Valida los parámetros
-    const { creditId, montoIncobrable, montoBoleta, url_boletas, cuota, banco_id, numeroAutorizacion } =
-      body as {
-        creditId?: number;
-        montoIncobrable?: number;
-        montoBoleta?: number | string;
-        url_boletas?: string[];
-        cuota?: number;
-        banco_id?: number;
-        numeroAutorizacion?: string;
-      };
-
-    // Validaciones mínimas
-    if (
-      !creditId ||
-      isNaN(Number(creditId)) ||
-      montoBoleta === undefined ||
-      isNaN(Number(montoBoleta)) ||
-      !Array.isArray(url_boletas) ||
-      cuota === undefined ||
-      isNaN(Number(cuota)) ||
-      !banco_id ||
-      isNaN(Number(banco_id))
-    ) {
+    const input = body as Record<string, unknown>;
+    if (!isValidResetCreditInput(input)) {
       set.status = 400;
       return { message: "Faltan o son inválidos los parámetros requeridos." };
     }
+    const { creditId, montoIncobrable, montoBoleta, url_boletas, cuota, banco_id, numeroAutorizacion } = input;
 
     try {
       const result = await resetCredit({
-        creditId: Number(creditId),
-        montoIncobrable:
-          montoIncobrable !== undefined ? Number(montoIncobrable) : undefined,
-        montoBoleta: montoBoleta,
-        url_boletas: url_boletas,
-        cuota: Number(cuota),
-        banco_id: Number(banco_id),
+        creditId,
+        montoIncobrable,
+        montoBoleta,
+        url_boletas,
+        cuota,
+        banco_id,
         numeroAutorizacion,
       });
       set.status = 200;

--- a/apps/carteraFront/src/private/cartera/components/ModalBadDebtCredit.tsx
+++ b/apps/carteraFront/src/private/cartera/components/ModalBadDebtCredit.tsx
@@ -19,7 +19,7 @@ export function ModalBadDebtCredit({
   open: boolean;
   onClose: () => void;
   creditId: number;
-  onSuccess?: () => void;
+  onSuccess?: (montoIncobrable: number) => void;
   montoBase: number; // Monto base de lo incobrable (por si lo quieres mostrar)
 }) {
   const [motivo, setMotivo] = useState("");
@@ -37,7 +37,8 @@ export function ModalBadDebtCredit({
       alert("Debes escribir el motivo para marcar como incobrable.");
       return;
     }
-    if (!monto || isNaN(Number(monto)) || Number(monto) <= 0) {
+    const montoIncobrable = Number(monto);
+    if (!monto || isNaN(montoIncobrable) || montoIncobrable <= 0) {
       alert("El monto incobrable debe ser mayor a cero.");
       return;
     }
@@ -47,13 +48,13 @@ export function ModalBadDebtCredit({
         accion: "INCOBRABLE",
         motivo,
         observaciones,
-        monto_cancelacion: Number(monto),
+        monto_cancelacion: montoIncobrable,
       },
       {
         onSuccess: (data) => {
           alert(data.message || "Crédito marcado como incobrable correctamente");
           handleClose();
-          if (onSuccess) onSuccess();
+          if (onSuccess) onSuccess(montoIncobrable);
         },
         onError: (error) => {
           alert(error.message || "No se pudo marcar como incobrable");

--- a/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
+++ b/apps/carteraFront/src/private/cartera/components/PagoForm.tsx
@@ -477,9 +477,9 @@ export function PagoForm() {
         onClose={() => setOpenBadDebt(false)}
         creditId={creditoCanceladoInfo?.credito.credito_id || 0}
         montoBase={montoBaseBadDebt}
-        onSuccess={async () => {
+        onSuccess={async (montoIncobrable) => {
           setOpenBadDebt(false);
-          await handleResetCredito();
+          await handleResetCredito(montoIncobrable);
         }}
       />
 

--- a/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.test.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "bun:test";
+import { canEnterCancellationPaymentFlow } from "./cancellationPaymentFlow";
+
+describe("canEnterCancellationPaymentFlow", () => {
+	it("allows only pending cancellation credits", () => {
+		expect(canEnterCancellationPaymentFlow("PENDIENTE_CANCELACION")).toBe(true);
+		expect(canEnterCancellationPaymentFlow("CANCELADO")).toBe(false);
+		expect(canEnterCancellationPaymentFlow("ACTIVO")).toBe(false);
+		expect(canEnterCancellationPaymentFlow(null)).toBe(false);
+		expect(canEnterCancellationPaymentFlow(undefined)).toBe(false);
+	});
+});

--- a/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.test.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
 import { canEnterCancellationPaymentFlow } from "./cancellationPaymentFlow";
+
+function finalizedGuard(source: string): string | undefined {
+	return source.match(
+		/result\.flujo === "CANCELADO"[\s\S]*?!canEnterCancellationPaymentFlow[\s\S]*?\) \{([\s\S]*?)\n\s*return;/,
+	)?.[1];
+}
 
 describe("canEnterCancellationPaymentFlow", () => {
 	it("allows only pending cancellation credits", () => {
@@ -8,5 +15,17 @@ describe("canEnterCancellationPaymentFlow", () => {
 		expect(canEnterCancellationPaymentFlow("ACTIVO")).toBe(false);
 		expect(canEnterCancellationPaymentFlow(null)).toBe(false);
 		expect(canEnterCancellationPaymentFlow(undefined)).toBe(false);
+	});
+});
+
+describe("finalized credit form reset wiring", () => {
+	it("resets Formik and the search field before returning", async () => {
+		const source = await Bun.file(
+			resolve(import.meta.dir, "registerPayment.ts"),
+		).text();
+		const guard = finalizedGuard(source);
+
+		expect(guard).toContain("formik.resetForm();");
+		expect(guard).toContain("setResetBuscador(true);");
 	});
 });

--- a/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.test.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.test.ts
@@ -29,3 +29,25 @@ describe("finalized credit form reset wiring", () => {
 		expect(guard).toContain("setResetBuscador(true);");
 	});
 });
+
+describe("bad debt amount wiring", () => {
+	it("propagates the selected amount through the modal, form, and reset request", async () => {
+		const componentsDir = resolve(import.meta.dir, "../components");
+		const [modalSource, formSource, hookSource] = await Promise.all([
+			Bun.file(resolve(componentsDir, "ModalBadDebtCredit.tsx")).text(),
+			Bun.file(resolve(componentsDir, "PagoForm.tsx")).text(),
+			Bun.file(resolve(import.meta.dir, "registerPayment.ts")).text(),
+		]);
+
+		expect(modalSource).toMatch(
+			/onSuccess\?: \(montoIncobrable: number\) => void/,
+		);
+		expect(modalSource).toMatch(/monto_cancelacion: montoIncobrable/);
+		expect(modalSource).toMatch(/onSuccess\(montoIncobrable\)/);
+		expect(formSource).toMatch(
+			/onSuccess=\{async \(montoIncobrable\) => \{[\s\S]*?handleResetCredito\(montoIncobrable\)/,
+		);
+		expect(hookSource).toMatch(/handleResetCredito\(montoIncobrable = 0\)/);
+		expect(hookSource).toMatch(/montoIncobrable: montoIncobrable/);
+	});
+});

--- a/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.ts
@@ -1,0 +1,5 @@
+export function canEnterCancellationPaymentFlow(
+	statusCredit: string | null | undefined,
+): boolean {
+	return statusCredit === "PENDIENTE_CANCELACION";
+}

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -2,912 +2,846 @@
 import { z } from "zod";
 import { useFormik } from "formik";
 import {
-	createPago,
-	getCreditoByNumero,
-	getAbonosCuotaService,
-	liquidatePagosInversionistasService,
-	reversePagosInversionistasService,
-	revertPaymentToPendingService,
-	revalidatePaymentService,
-	processInvestorsService,
-	recalcularPagosService,
-	uploadFileService,
-	type AbonosCuotaResponse,
-	type CancelacionCredito,
-	type Credito,
-	type Usuario,
+  createPago,
+  getCreditoByNumero,
+  getAbonosCuotaService,
+  liquidatePagosInversionistasService,
+  reversePagosInversionistasService,
+  revertPaymentToPendingService,
+  revalidatePaymentService,
+  processInvestorsService,
+  recalcularPagosService,
+  uploadFileService,
+  type AbonosCuotaResponse,
+  type CancelacionCredito,
+  type Credito,
+  type Usuario,
 } from "../services/services";
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { canEnterCancellationPaymentFlow } from "./cancellationPaymentFlow";
 import { useResetCredit } from "./resetCredit";
 import { getApiErrorMessage } from "@/lib/apiError";
 import { useAuth } from "@/Provider/authProvider";
 import { toast } from "sonner";
 import { getDisplayedPartialContribution } from "../services/installmentContribution";
-import { canEnterCancellationPaymentFlow } from "./cancellationPaymentFlow";
 export const pagoSchema = z.object({
-	credito_id: z
-		.number()
-		.int()
-		.positive({ message: "Debe seleccionar un crédito" }),
-	usuario_id: z.number().int().positive({ message: "Usuario requerido" }),
-	monto_boleta: z
-		.number()
-		.min(0.01, { message: "El monto de boleta debe ser mayor a 0" }),
-	fecha_pago: z.string().min(1, { message: "Fecha de pago requerida" }),
-	fecha_boleta: z.string().min(1, { message: "Fecha de boleta requerida" }),
-	llamada: z.string().max(100).optional(),
-	renuevo_o_nuevo: z.string().max(50).optional(),
-	otros: z.number().min(0).optional(), // OPCIONAL
-	monto_boleta_cuota: z.number().optional(),
-	credito_sifco: z.string().max(50).optional(),
-	observaciones: z.string().max(500).optional(), // OPCIONAL
-	abono_directo_capital: z.number().optional(),
-	cuotaApagar: z.number().int(),
-	url_boletas: z.array(z.string().max(500)),
-	banco_id: z.number().int().positive({ message: "Debe seleccionar un banco" }),
-	numeroAutorizacion: z.string().optional(),
-	registerBy: z.string().min(1, { message: "Usuario registrador requerido" }),
-	origen_pago: z.enum(["transferencia", "cheque", "boleta"], {
-		errorMap: () => ({ message: "Debe seleccionar un origen de pago" }),
-	}),
+  credito_id: z.number().int().positive({ message: "Debe seleccionar un crédito" }),
+  usuario_id: z.number().int().positive({ message: "Usuario requerido" }),
+  monto_boleta: z.number().min(0.01, { message: "El monto de boleta debe ser mayor a 0" }),
+  fecha_pago: z.string().min(1, { message: "Fecha de pago requerida" }),
+  fecha_boleta: z.string().min(1, { message: "Fecha de boleta requerida" }),
+  llamada: z.string().max(100).optional(),
+  renuevo_o_nuevo: z.string().max(50).optional(),
+  otros: z.number().min(0).optional(), // OPCIONAL
+  monto_boleta_cuota: z.number().optional(),
+  credito_sifco: z.string().max(50).optional(),
+  observaciones: z.string().max(500).optional(), // OPCIONAL
+  abono_directo_capital: z.number().optional(),
+  cuotaApagar: z.number().int(),
+  url_boletas: z.array(z.string().max(500)),
+  banco_id: z.number().int().positive({ message: "Debe seleccionar un banco" }),
+  numeroAutorizacion: z.string().optional(),
+  registerBy: z.string().min(1, { message: "Usuario registrador requerido" }),
+  origen_pago: z.enum(["transferencia", "cheque", "boleta"], { errorMap: () => ({ message: "Debe seleccionar un origen de pago" }) }),
 });
 
 export type PagoFormValues = z.infer<typeof pagoSchema>;
-
+ 
 function zodToFormikValidate(schema: z.ZodSchema<any>) {
-	return (values: any) => {
-		const result = schema.safeParse(values);
-		if (result.success) return {};
-		const errors: Record<string, string> = {};
-		for (const issue of result.error.issues) {
-			errors[issue.path[0]] = issue.message;
-		}
-		return errors;
-	};
+  return (values: any) => {
+    const result = schema.safeParse(values);
+    if (result.success) return {};
+    const errors: Record<string, string> = {};
+    for (const issue of result.error.issues) {
+      errors[issue.path[0]] = issue.message;
+    }
+    return errors;
+  };
 }
 
 export function usePagoForm() {
-	const queryClient = useQueryClient();
-	const { mutate: resetCredit } = useResetCredit();
-	const [resetBuscador, setResetBuscador] = useState(false);
-	const [modalMode, setModalMode] = useState<"excedente" | "pagada">(
-		"excedente",
-	);
-	const [loadingCredito, setLoadingCredito] = useState(false);
-	const [dataCredito, setDataCredito] = useState<any>(null);
-	const [errorCredito, setErrorCredito] = useState<string | null>(null);
-	const [cuotaActualInfo, setCuotaActualInfo] = useState<{
-		numero: number;
-		pagada: boolean;
-		validationStatus?:
-			| "no_required"
-			| "pending"
-			| "validated"
-			| "capital"
-			| "capital_validated"
-			| "reset";
-		data?: any;
-	} | null>(null);
-	const [mora, setMora] = useState<number>(0);
-	const [cuotasAtrasadasInfo, setCuotasAtrasadasInfo] = useState<{
-		total: number;
-		cuotas: any[];
-		cuotaMasAntigua?: number;
-	} | null>(null);
-	const [permiteAbonoCapital, setPermiteAbonoCapital] =
-		useState<boolean>(false);
-	const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
-		convenio_id: number;
-		credito_id: number;
-		monto_total_convenio: string;
-		cuota_mensual: string;
-		pagos_realizados: number;
-		pagos_pendientes: number;
-		activo: boolean;
-		completado: boolean;
-		cuotasEnConvenio: any[];
-		pagosConvenio: any[];
-		cuotasConvenioMensuales: any[]; // 🔥 NUEVO
-		cuotaConvenioAPagar: string; // 🔥 NUEVO
-	} | null>(null);
-	const [cuotasPendientesInfo, setCuotasPendientesInfo] = useState<{
-		total: number;
-		cuotas: any[];
-		cuotaMasAntigua?: number;
-	} | null>(null);
-	// Modal de exceso
-	const [modalExcesoOpen, setModalExcesoOpen] = useState(false);
-	const [saldo_a_favorUser, setSaldoAFavorUser] = useState(0);
-	const [excedente, setExcedente] = useState(0);
-	const [fileToUpload, setFileToUpload] = useState<File | null>(null);
-	// Declarar cuotaSeleccionada antes de usarla en initialValues
-	const [cuotaSeleccionada, setCuotaSeleccionada] = useState<
-		number | undefined
-	>();
-	const [archivosParaSubir, setArchivosParaSubir] = useState<File[]>([]);
-	const [abonosCuota, setAbonosCuota] = useState<AbonosCuotaResponse | null>(
-		null,
-	);
-	const { user } = useAuth(); //
-
-	// Fetch abonos cuando cambia la cuota seleccionada
-	useEffect(() => {
-		if (!cuotaSeleccionada || !dataCredito?.credito?.numero_credito_sifco) {
-			setAbonosCuota(null);
-			return;
-		}
-		let cancelled = false;
-		getAbonosCuotaService(
-			dataCredito.credito.numero_credito_sifco,
-			cuotaSeleccionada,
-		)
-			.then((res) => {
-				if (!cancelled) setAbonosCuota(res);
-			})
-			.catch(() => {
-				if (!cancelled) setAbonosCuota(null);
-			});
-		return () => {
-			cancelled = true;
-		};
-	}, [cuotaSeleccionada, dataCredito?.credito?.numero_credito_sifco]);
-
-	// Formik
-	const formik = useFormik<PagoFormValues>({
-		validateOnChange: false,
-		validateOnBlur: true,
-		initialValues: {
-			credito_id: 0,
-			usuario_id: 0,
-			monto_boleta: 0,
-			fecha_pago: "",
-			llamada: "",
-			renuevo_o_nuevo: "",
-			fecha_boleta: "",
-			otros: 0,
-			monto_boleta_cuota: undefined,
-			credito_sifco: "",
-			observaciones: "",
-			abono_directo_capital: 0,
-			cuotaApagar: cuotaSeleccionada ?? 0,
-			url_boletas: [],
-			banco_id: 0,
-			numeroAutorizacion: "",
-			registerBy: user?.email || "",
-			origen_pago: "" as any,
-		},
-		validate: zodToFormikValidate(pagoSchema),
-		onSubmit: async (values, { setSubmitting, setStatus, resetForm }) => {
-			try {
-				if (
-					creditoCanceladoInfo !== null &&
-					creditoCanceladoInfo !== undefined
-				) {
-					await handleResetCredito();
-					return;
-				}
-				console.log(cuotaSeleccionada, " cuotaSeleccionada");
-				const cuotaApagarValue =
-					typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
-				formik.setFieldValue("cuotaApagar", cuotaApagarValue);
-				if (archivosParaSubir.length === 0) {
-					toast.error(
-						"Debes seleccionar al menos un archivo de boleta (máx. 3)",
-					);
-					return;
-				}
-				if (archivosParaSubir.length > 3) {
-					toast.error("Solo puedes subir hasta 3 archivos de boleta");
-					return;
-				}
-
-				// Sube los archivos y llena el array de filenames
-				const url_boletas: string[] = [];
-				for (const archivo of archivosParaSubir) {
-					const { filename } = await uploadFileService(archivo);
-					url_boletas.push(filename);
-				}
-
-				const valuesToSend = {
-					...values,
-					cuotaApagar:
-						typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0,
-					url_boletas,
-				};
-				console.log("Valores a enviar:", valuesToSend);
-
-				const response = await createPago(valuesToSend); // Esto es la respuesta completa
-				toast.success(response.message || "¡Pago registrado correctamente!");
-
-				setStatus({ success: true });
-				resetForm();
-				setDataCredito(null); // Limpiar datos del crédito
-				setCuotaActualInfo(null);
-				setCuotasAtrasadasInfo(null);
-				setPermiteAbonoCapital(false);
-				setCuotasPendientesInfo(null);
-				setModalExcesoOpen(false); // Cerrar modal de exceso
-				setExcedente(0); // Reiniciar excedente
-				setCuotaActualInfo(null); // Reiniciar cuota actual
-				setFileToUpload(null); // Reiniciar archivo a subir
-				setArchivosParaSubir([]);
-				setResetBuscador(true);
-			} catch (error: any) {
-				const backendMessage = getApiErrorMessage(
-					error,
-					"No se pudo registrar el pago",
-				);
-				toast.error(backendMessage);
-				setStatus({ success: false, error: backendMessage });
-			} finally {
-				setSubmitting(false);
-			}
-		},
-	});
-	const [creditoCanceladoInfo, setCreditoCanceladoInfo] = useState<{
-		credito: Credito;
-		usuario: Usuario;
-		cancelacion: CancelacionCredito | null;
-	} | null>(null);
-	// Función para buscar crédito y setear los campos
-	const fetchCredito = async (numero_credito_sifco: string) => {
-		if (!numero_credito_sifco.trim()) return;
-		setLoadingCredito(true);
-		setErrorCredito(null);
-		try {
-			const result = await getCreditoByNumero(numero_credito_sifco);
-			if (
-				result.flujo === "CANCELADO" &&
-				!canEnterCancellationPaymentFlow(result.credito?.statusCredit)
-			) {
-				setDataCredito(null);
-				setCreditoCanceladoInfo(null);
-				setCuotaActualInfo(null);
-				setCuotasAtrasadasInfo(null);
-				setCuotasPendientesInfo(null);
-				setConvenioActivoInfo(null);
-				setPermiteAbonoCapital(false);
-				setCuotaSeleccionada(0);
-				setSaldoAFavorUser(0);
-				setFileToUpload(null);
-				setArchivosParaSubir([]);
-				setErrorCredito(
-					"El crédito ya está cancelado y solo está disponible para consulta en el historial.",
-				);
-				return;
-			}
-			setDataCredito(result);
-
-			// FLUJO CANCELADO
-			if (result.flujo === "CANCELADO") {
-				setCreditoCanceladoInfo({
-					credito: result.credito,
-					usuario: result.usuario,
-					cancelacion: result.cancelacion,
-				});
-				setDataCredito(result);
-				setCuotaActualInfo(null);
-				setCuotasAtrasadasInfo(null);
-				setPermiteAbonoCapital(false);
-				setCuotasPendientesInfo(null);
-				setCuotaSeleccionada(0);
-				setSaldoAFavorUser(0);
-				setArchivosParaSubir([]);
-				setResetBuscador(true);
-				setConvenioActivoInfo(null); // 👈 AGREGA ESTO
-
-				const today = new Date();
-				const fechaHoy = today.toISOString().split("T")[0];
-				formik.setValues((prev) => ({
-					...prev,
-					credito_id: result.credito.credito_id,
-					usuario_id: result.credito.usuario_id,
-					credito_sifco: result.credito.numero_credito_sifco,
-					fecha_pago: fechaHoy,
-					llamada: "",
-					monto_boleta: Number(result.cancelacion?.monto_cancelacion || 0),
-					numero_cuota: 0,
-				}));
-
-				return;
-			}
-
-			// FLUJO ACTIVO
-			// Extraer numero_cuota del objeto cuotaActual (antes era número, ahora es objeto)
-			const cuotaActualObj = result.cuotaActual as any;
-			const cuotaActualNumero =
-				typeof cuotaActualObj === "object" && cuotaActualObj !== null
-					? cuotaActualObj.numero_cuota
-					: cuotaActualObj;
-
-			const siguienteCuotaPagable = [
-				...(result.cuotasAtrasadas ?? []),
-				...(result.cuotasPendientes ?? []),
-			]
-				// Los pagos `pending` también son seleccionables para poder reportar
-				// abonos complementarios antes de que contabilidad valide el anterior.
-				.filter(
-					(c: any) =>
-						c.validationStatus !== "validated" &&
-						c.validationStatus !== "capital_validated",
-				)
-				.sort((a: any, b: any) => a.numero_cuota - b.numero_cuota)[0];
-
-			setCuotaSeleccionada(
-				siguienteCuotaPagable?.numero_cuota ?? cuotaActualNumero ?? 0,
-			);
-			setMora(result.moraActual || 0);
-
-			// 👇 AGREGA INFO DE CONVENIO
-			if (result.convenioActivo) {
-				setConvenioActivoInfo({
-					...result.convenioActivo,
-				});
-			} else {
-				setConvenioActivoInfo(null);
-			}
-
-			setCuotaActualInfo({
-				numero: cuotaActualNumero,
-				pagada: !!result.cuotaActualPagada,
-				validationStatus:
-					result.cuotaActualStatus ?? cuotaActualObj?.validationStatus,
-				data:
-					typeof cuotaActualObj === "object" && cuotaActualObj !== null
-						? cuotaActualObj
-						: result.cuotasPagadas.find(
-								(c: any) => c.numero_cuota === cuotaActualNumero,
-							) ||
-							result.cuotasAtrasadas.find(
-								(c: any) => c.numero_cuota === cuotaActualNumero,
-							) ||
-							null,
-			});
-
-			setCuotasAtrasadasInfo({
-				total: result.cuotasAtrasadas.length,
-				cuotas: result.cuotasAtrasadas,
-				cuotaMasAntigua:
-					result.cuotasAtrasadas.length > 0
-						? result.cuotasAtrasadas[0].numero_cuota
-						: undefined,
-			});
-
-			setPermiteAbonoCapital(!!result.credito?.permite_abono_capital);
-
-			setCuotasPendientesInfo({
-				total: result.cuotasPendientes.length,
-				cuotas: result.cuotasPendientes,
-				cuotaMasAntigua:
-					result.cuotasPendientes.length > 0
-						? result.cuotasPendientes[0].numero_cuota
-						: undefined,
-			});
-
-			if (result?.credito && result?.usuario) {
-				const today = new Date();
-				const fechaHoy = today.toISOString().split("T")[0];
-				setSaldoAFavorUser(result.usuario.saldo_a_favor || 0);
-				formik.setValues((prev) => ({
-					...prev,
-					credito_id: result.credito.credito_id,
-					usuario_id: result.credito.usuario_id,
-					credito_sifco: result.credito.numero_credito_sifco,
-					fecha_pago: fechaHoy,
-					llamada: "",
-					numero_cuota: result.cuotaActual,
-				}));
-			}
-		} catch (err: any) {
-			setErrorCredito(
-				err?.response?.data?.message || "Error consultando crédito",
-			);
-			setDataCredito(null);
-			setCuotaActualInfo(null);
-			setCuotasAtrasadasInfo(null);
-			setCuotasPendientesInfo(null);
-			setCuotaSeleccionada(0);
-			setSaldoAFavorUser(0);
-			setConvenioActivoInfo(null); // 👈 AGREGA ESTO
-		} finally {
-			setLoadingCredito(false);
-		}
-	};
-	const [openBadDebt, setOpenBadDebt] = useState(false);
-	const [montoBaseBadDebt, setMontoBaseBadDebt] = useState(0);
-	// Handler que revisa el excedente ANTES del submit
-
-	useEffect(() => {
-		if (openBadDebt) {
-			console.log("Modal de incobrable abierto, monto base:", montoBaseBadDebt);
-			setMontoBaseBadDebt(montoBaseBadDebt);
-		}
-	}, [openBadDebt]);
-	const handleFormSubmit = (e: React.FormEvent) => {
-		e.preventDefault();
-
-		// ===== MANEJO DE CRÉDITO CANCELADO =====
-		if (creditoCanceladoInfo) {
-			const { monto_boleta } = formik.values;
-			const monto_cancelacion = Number(
-				creditoCanceladoInfo.cancelacion?.monto_cancelacion || 0,
-			);
-
-			if (monto_boleta < 0) {
-				toast.error("El monto de la boleta debe ser mayor a cero");
-				return;
-			}
-
-			if (monto_boleta < monto_cancelacion) {
-				const resta = monto_cancelacion - monto_boleta;
-				setMontoBaseBadDebt(resta);
-				setOpenBadDebt(true);
-				return;
-			}
-
-			formik.handleSubmit();
-			return;
-		}
-
-		// ===== VALIDACIÓN: DEBE TENER CUOTA SELECCIONADA =====
-		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-			toast.error(
-				"Por favor selecciona una cuota a pagar del menú desplegable",
-			);
-			return;
-		}
-
-		// ===== CRÉDITO ACTIVO =====
-		const { monto_boleta, otros } = formik.values;
-		const cuota = Number(dataCredito?.credito?.cuota || 0);
-		const otrosNum = Number(otros || 0);
-		const saldoAFavor = Number(dataCredito?.usuario?.saldo_a_favor || 0);
-		const montoBoleta = Number(monto_boleta || 0);
-		const moraNum = Number(mora || 0);
-		const cuotaConvenioNum = Number(
-			convenioActivoInfo?.cuotaConvenioAPagar || 0,
-		);
-
-		console.log("=== DEBUG VALORES ===");
-		console.log("Saldo a Favor:", saldoAFavor);
-		console.log("Monto Boleta:", montoBoleta);
-		console.log("Otros:", otrosNum);
-		console.log("Mora:", moraNum);
-		console.log("Cuota Convenio:", cuotaConvenioNum);
-
-		// 🔥 Calcular monto disponible total (boleta + saldo a favor)
-		const montoDisponibleTotal = montoBoleta;
-		console.log(
-			"Monto Disponible Total (boleta + saldo):",
-			montoDisponibleTotal,
-		);
-
-		// 🔥 Restar lo que se va a otros conceptos
-		const montoBoletaReal =
-			montoDisponibleTotal - otrosNum - moraNum - cuotaConvenioNum;
-		const montoBoletaSinMora =
-			montoDisponibleTotal - otrosNum - cuotaConvenioNum;
-
-		console.log("Monto Boleta Real (después de descuentos):", montoBoletaReal);
-		console.log("Monto Boleta Sin Mora:", montoBoletaSinMora);
-
-		// 🔥 Validación
-		if (montoBoletaSinMora < 0) {
-			toast.error(
-				"El saldo a favor más la boleta debe cubrir la suma de otros y convenio",
-			);
-			return;
-		}
-
-		// 👇 SIEMPRE USA LA CUOTA SELECCIONADA POR EL USUARIO
-		const cuotaAPagar: number = cuotaSeleccionada;
-
-		console.log("=== CUOTA DETERMINADA ===");
-		console.log("Cuota seleccionada por usuario:", cuotaSeleccionada);
-		console.log("Cuota a usar:", cuotaAPagar);
-
-		// ===== MANEJO DE EXCEDENTES =====
-		const montoRedondeado = Math.round(montoBoletaReal * 100) / 100;
-
-		// 🔥 Calcular abonos ya realizados en la cuota SELECCIONADA (desde endpoint)
-		const abonosRealizados = getDisplayedPartialContribution(abonosCuota);
-
-		// 🔥 Cuota menos los abonos ya hechos = lo que falta por pagar
-		const cuotaComparar = Math.max(0, cuota - abonosRealizados);
-
-		console.log("=== VALIDACIÓN DE EXCEDENTES ===");
-		console.log("Monto boleta real (redondeado):", montoRedondeado);
-		console.log("Cuota base:", cuota);
-		console.log("Abonos ya realizados:", abonosRealizados);
-		console.log("Cuota a comparar (lo que falta):", cuotaComparar);
-
-		const cuotaRedondeada = Math.round(cuotaComparar * 100) / 100;
-
-		// Si hay excedente, abre el modal
-		if (montoRedondeado > cuotaRedondeada) {
-			const excedenteCalculado = montoRedondeado - cuotaRedondeada;
-
-			console.log("=== HAY EXCEDENTE ===");
-			console.log("Excedente:", excedenteCalculado);
-
-			setModalMode("excedente");
-			setExcedente(excedenteCalculado);
-			setModalExcesoOpen(true);
-			return;
-		}
-
-		console.log("=== NO HAY EXCEDENTE - CONTINUAR CON PAGO ===");
-
-		// Si la cuota actual ya está pagada y el monto no es exacto
-		if (cuotaActualInfo?.pagada && montoRedondeado !== cuotaRedondeada) {
-			// Si tiene "otros" y la suma cuadra
-			if (otrosNum > 0 && monto_boleta === otrosNum) {
-				// Todo bien, continuar
-			} else {
-				// Hay un desbalance
-				setExcedente(montoBoletaReal);
-				setModalMode("pagada");
-				setModalExcesoOpen(true);
-				return;
-			}
-		}
-
-		// 👇 SETEA LA CUOTA EN FORMIK Y HACE SUBMIT
-		console.log("=== ANTES DEL SUBMIT ===");
-		console.log("formik.values.cuotaApagar ANTES:", formik.values.cuotaApagar);
-
-		formik.values.cuotaApagar = cuotaAPagar;
-
-		console.log(
-			"formik.values.cuotaApagar DESPUÉS:",
-			formik.values.cuotaApagar,
-		);
-		console.log("=====================");
-
-		formik.handleSubmit();
-	};
-	// Acciones del modal
-	const handleAbonoCapital = () => {
-		// ✅ Validar que haya cuota seleccionada
-		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-			toast.error("Debes seleccionar una cuota antes de continuar");
-			setModalExcesoOpen(false);
-			return;
-		}
-
-		console.log("=== ABONO A CAPITAL ===");
-		console.log("Excedente:", excedente);
-		console.log("Cuota seleccionada:", cuotaSeleccionada);
-
-		// 👇 USA LA CUOTA SELECCIONADA
-		formik.values.abono_directo_capital = excedente;
-		formik.values.cuotaApagar = cuotaSeleccionada;
-
-		setModalExcesoOpen(false);
-		formik.handleSubmit();
-	};
-	const handleAbonoCapitalDirecto = () => {
-		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-			toast.error("Debes seleccionar una cuota antes de continuar");
-			return;
-		}
-
-		const montoBoleta = Number(formik.values.monto_boleta) || 0;
-
-		console.log("=== ABONO DIRECTO A CAPITAL ===");
-		console.log("Monto boleta completo:", montoBoleta);
-		console.log("Cuota seleccionada:", cuotaSeleccionada);
-
-		formik.values.abono_directo_capital = montoBoleta;
-		formik.values.cuotaApagar = cuotaSeleccionada;
-
-		setModalExcesoOpen(false);
-		formik.handleSubmit();
-	};
-	const handleAbonoSiguienteCuota = () => {
-		// ✅ Validar que haya cuota seleccionada
-		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-			toast.error("Debes seleccionar una cuota antes de continuar");
-			setModalExcesoOpen(false);
-			return;
-		}
-
-		console.log("=== ABONO SIGUIENTE CUOTA ===");
-		console.log("Cuota seleccionada:", cuotaSeleccionada);
-
-		// 👇 USA LA CUOTA SELECCIONADA
-		formik.values.abono_directo_capital = 0;
-		formik.values.cuotaApagar = cuotaSeleccionada;
-
-		console.log("Cuota a pagar final:", formik.values.cuotaApagar);
-
-		setModalExcesoOpen(false);
-		formik.handleSubmit();
-	};
-
-	const handleAbonoOtros = () => {
-		// ✅ Validar que haya cuota seleccionada
-		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-			toast.error("Debes seleccionar una cuota antes de continuar");
-			setModalExcesoOpen(false);
-			return;
-		}
-
-		const nuevosOtros =
-			Number(formik.values.otros || 0) + Number(excedente || 0);
-
-		console.log("=== ABONO A OTROS ===");
-		console.log("Nuevos otros:", nuevosOtros);
-		console.log("Cuota seleccionada:", cuotaSeleccionada);
-
-		// 👇 USA LA CUOTA SELECCIONADA
-		formik.values.otros = nuevosOtros;
-		formik.values.abono_directo_capital = 0;
-		formik.values.cuotaApagar = cuotaSeleccionada;
-
-		setModalExcesoOpen(false);
-		formik.handleSubmit();
-	};
-	function useLiquidatePagosInversionistas() {
-		return useMutation({
-			mutationFn: liquidatePagosInversionistasService,
-			onSuccess: () => {
-				toast.success("Pagos liquidados correctamente");
-				setModalExcesoOpen(false);
-
-				if (formik.values.credito_sifco) {
-					fetchCredito(formik.values.credito_sifco); // Refrescar crédito
-				}
-			},
-			onError: (err: any) => {
-				toast.error(getApiErrorMessage(err, "Error al liquidar pagos"));
-			},
-		});
-	}
-
-	function useReversePagosInversionistas() {
-		return useMutation({
-			mutationFn: reversePagosInversionistasService,
-			onSuccess: () => {
-				toast.success("Pago reversado correctamente");
-			},
-			onError: (err: any) => {
-				toast.error(getApiErrorMessage(err, "Error al reversar pago"));
-			},
-		});
-	}
-
-	function useRevertPaymentToPending() {
-		return useMutation({
-			mutationFn: revertPaymentToPendingService,
-			onSuccess: () => {
-				toast.success("Pago reversado a pendiente correctamente");
-				queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
-			},
-			onError: (err: any) => {
-				toast.error(
-					getApiErrorMessage(err, "Error al reversar pago a pendiente"),
-				);
-			},
-		});
-	}
-
-	function useRevalidatePayment() {
-		return useMutation({
-			mutationFn: revalidatePaymentService,
-			onSuccess: () => {
-				toast.success("Pago revalidado correctamente");
-				queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
-			},
-			onError: (err: any) => {
-				toast.error(getApiErrorMessage(err, "Error al revalidar pago"));
-			},
-		});
-	}
-
-	function useProcessInvestors() {
-		return useMutation({
-			mutationFn: processInvestorsService,
-			onSuccess: () => {
-				toast.success("Inversionistas procesados correctamente");
-				queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
-			},
-			onError: (err: any) => {
-				toast.error(
-					getApiErrorMessage(err, "Error al procesar inversionistas"),
-				);
-			},
-		});
-	}
-
-	const liquidatePago = useLiquidatePagosInversionistas();
-	const [liquidandoId, setLiquidandoId] = useState<number | null>(null);
-	function handleLiquidar(pago_id: number, credito_id: number, cuota?: number) {
-		try {
-			// eslint-disable-next-line react-hooks/rules-of-hooks
-
-			setLiquidandoId(pago_id);
-			liquidatePago.mutate(
-				{ pago_id, credito_id, cuota },
-				{
-					onSettled: () => setLiquidandoId(null),
-				},
-			);
-
-			// Aquí podrías hacer un refetch/queryClient.invalidateQueries para actualizar
-		} catch (error) {
-			toast.error(getApiErrorMessage(error, "Error al liquidar el pago"));
-			console.error("Error liquidando pago:", error);
-		}
-	}
-	const reversePago = useReversePagosInversionistas();
-	const revertPaymentToPending = useRevertPaymentToPending();
-	const revalidatePayment = useRevalidatePayment();
-	const processInvestors = useProcessInvestors();
-
-	function useRecalcularPagos() {
-		return useMutation({
-			mutationFn: recalcularPagosService,
-			onSuccess: () => {
-				toast.success("Pagos recalculados correctamente");
-				queryClient.invalidateQueries({ queryKey: ["pagosByCredito"] });
-			},
-			onError: (err: any) => {
-				toast.error(getApiErrorMessage(err, "Error al recalcular pagos"));
-			},
-		});
-	}
-
-	const recalcularPagos = useRecalcularPagos();
-
-	function handleRecalcularPagos(
-		numero_credito_sifco: string,
-		numero_cuota: number,
-	) {
-		recalcularPagos.mutate({ numero_credito_sifco, numero_cuota }, {});
-	}
-
-	// Handler:
-	function handleReverse(
-		pago_id: number,
-		credito_id: number,
-		reverseAccounting: boolean,
-	) {
-		reversePago.mutate({ pago_id, credito_id, reverseAccounting }, {});
-	}
-
-	// Handler:
-	function handleRevertToPending(pago_id: number, credito_id: number) {
-		revertPaymentToPending.mutate({ pago_id, credito_id }, {});
-	}
-
-	// Handler:
-	function handleRevalidatePayment(pago_id: number, credito_id: number) {
-		revalidatePayment.mutate({ pago_id, credito_id }, {});
-	}
-
-	// Handler:
-	function handleProcessInvestors(
-		pago_id: number,
-		credito_id: number,
-		fechaVencimiento?: string,
-	) {
-		const fecha_periodo = fechaVencimiento
-			? new Date(fechaVencimiento).toISOString()
-			: undefined;
-		processInvestors.mutate({ pago_id, credito_id, fecha_periodo }, {});
-	}
-
-	async function handleResetCredito() {
-		console.log(cuotaSeleccionada, " cuotaSeleccionada");
-		const cuotaApagarValue =
-			typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
-		formik.setFieldValue("cuotaApagar", cuotaApagarValue);
-		if (archivosParaSubir.length === 0) {
-			toast.error("Debes seleccionar al menos un archivo de boleta (máx. 3)");
-			return;
-		}
-		if (archivosParaSubir.length > 3) {
-			toast.error("Solo puedes subir hasta 3 archivos de boleta");
-			return;
-		}
-
-		// Sube los archivos y llena el array de filenames
-		const url_boletas: string[] = [];
-		for (const archivo of archivosParaSubir) {
-			const { filename } = await uploadFileService(archivo);
-			url_boletas.push(filename);
-		}
-
-		resetCredit(
-			{
-				creditId: Number(creditoCanceladoInfo?.credito.credito_id),
-				montoBoleta: formik.values.monto_boleta,
-				url_boletas: url_boletas,
-				cuota: cuotaActualInfo?.numero || 0,
-				banco_id: formik.values.banco_id,
-				montoIncobrable: montoBaseBadDebt,
-				numeroAutorizacion: formik.values.numeroAutorizacion || undefined,
-			},
-			{
-				onSuccess: (data) => {
-					toast.success(data.message || "Cancelacion realizada exitosamente");
-
-					formik.resetForm();
-					setDataCredito(null);
-					setCuotaActualInfo(null);
-					setCuotasAtrasadasInfo(null);
-					setPermiteAbonoCapital(false);
-					setCuotasPendientesInfo(null);
-					setModalExcesoOpen(false);
-					setExcedente(0);
-					setFileToUpload(null);
-					setArchivosParaSubir([]);
-					setCreditoCanceladoInfo(null);
-					setResetBuscador(true);
-
-					// Refetch del credito para ver el estado actualizado
-					if (formik.values.credito_sifco) {
-						fetchCredito(formik.values.credito_sifco);
-					}
-				},
-				onError: (error) => {
-					toast.error(getApiErrorMessage(error, "Error al reiniciar crédito"));
-				},
-			},
-		);
-	}
-	return {
-		formik,
-		fetchCredito,
-		dataCredito,
-		loadingCredito,
-		errorCredito,
-		cuotaActualInfo,
-		cuotasAtrasadasInfo,
-		permiteAbonoCapital,
-		cuotasPendientesInfo,
-		useReversePagosInversionistas,
-		// Para el modal de excedente:
-		handleFormSubmit,
-		modalExcesoOpen,
-		setModalExcesoOpen,
-		excedente,
-		handleAbonoCapital,
-		handleAbonoCapitalDirecto,
-		handleAbonoSiguienteCuota,
-		handleAbonoOtros,
-		useLiquidatePagosInversionistas,
-		modalMode,
-		handleLiquidar,
-		liquidandoId,
-		handleReverse,
-		handleRevertToPending,
-		handleRevalidatePayment,
-		reversePago,
-		revertPaymentToPending,
-		revalidatePayment,
-		processInvestors,
-		handleProcessInvestors,
-		recalcularPagos,
-		handleRecalcularPagos,
-		setCuotaSeleccionada,
-		setFileToUpload,
-		fileToUpload,
-		saldo_a_favorUser,
-		creditoCanceladoInfo,
-		openBadDebt,
-		setOpenBadDebt,
-		montoBaseBadDebt,
-		archivosParaSubir,
-		handleResetCredito,
-		setArchivosParaSubir,
-		resetBuscador,
-		setResetBuscador,
-		mora,
-		convenioActivoInfo,
-		cuotaSeleccionada,
-		abonosCuota,
-	};
+  const queryClient = useQueryClient();
+const { mutate: resetCredit } = useResetCredit();
+const [resetBuscador, setResetBuscador] = useState(false);
+  const [modalMode, setModalMode] = useState<"excedente" | "pagada">(
+    "excedente"
+  );
+  const [loadingCredito, setLoadingCredito] = useState(false);
+  const [dataCredito, setDataCredito] = useState<any>(null);
+  const [errorCredito, setErrorCredito] = useState<string | null>(null);
+  const [cuotaActualInfo, setCuotaActualInfo] = useState<{
+    numero: number;
+    pagada: boolean;
+    validationStatus?: 'no_required' | 'pending' | 'validated' | 'capital' | 'capital_validated' | 'reset';
+    data?: any;
+  } | null>(null);
+  const [mora, setMora] = useState<number>(0);
+  const [cuotasAtrasadasInfo, setCuotasAtrasadasInfo] = useState<{
+    total: number;
+    cuotas: any[];
+    cuotaMasAntigua?: number;
+  } | null>(null);
+  const [permiteAbonoCapital, setPermiteAbonoCapital] = useState<boolean>(false);
+const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
+  convenio_id: number;
+  credito_id: number;
+  monto_total_convenio: string;
+  cuota_mensual: string;
+  pagos_realizados: number;
+  pagos_pendientes: number;
+  activo: boolean;
+  completado: boolean;
+  cuotasEnConvenio: any[];
+  pagosConvenio: any[];
+  cuotasConvenioMensuales: any[]; // 🔥 NUEVO
+  cuotaConvenioAPagar: string; // 🔥 NUEVO
+} | null>(null);
+  const [cuotasPendientesInfo, setCuotasPendientesInfo] = useState<{
+    total: number;
+    cuotas: any[];
+    cuotaMasAntigua?: number;
+  } | null>(null);
+  // Modal de exceso
+  const [modalExcesoOpen, setModalExcesoOpen] = useState(false);
+  const [saldo_a_favorUser, setSaldoAFavorUser] = useState(0);
+  const [excedente, setExcedente] = useState(0);
+  const [fileToUpload, setFileToUpload] = useState<File | null>(null);
+  // Declarar cuotaSeleccionada antes de usarla en initialValues
+  const [cuotaSeleccionada, setCuotaSeleccionada] = useState<
+    number | undefined
+  >();
+  const [archivosParaSubir, setArchivosParaSubir] = useState<File[]>([]);
+  const [abonosCuota, setAbonosCuota] = useState<AbonosCuotaResponse | null>(null);
+  const { user } = useAuth(); //
+
+  // Fetch abonos cuando cambia la cuota seleccionada
+  useEffect(() => {
+    if (!cuotaSeleccionada || !dataCredito?.credito?.numero_credito_sifco) {
+      setAbonosCuota(null);
+      return;
+    }
+    let cancelled = false;
+    getAbonosCuotaService(dataCredito.credito.numero_credito_sifco, cuotaSeleccionada)
+      .then((res) => {
+        if (!cancelled) setAbonosCuota(res);
+      })
+      .catch(() => {
+        if (!cancelled) setAbonosCuota(null);
+      });
+    return () => { cancelled = true; };
+  }, [cuotaSeleccionada, dataCredito?.credito?.numero_credito_sifco]);
+
+  // Formik
+  const formik = useFormik<PagoFormValues>({
+    validateOnChange: false,
+    validateOnBlur: true,
+    initialValues: {
+      credito_id: 0,
+      usuario_id: 0,
+      monto_boleta: 0,
+      fecha_pago: "",
+      llamada: "",
+      renuevo_o_nuevo: "",
+      fecha_boleta: "",
+      otros: 0,
+      monto_boleta_cuota: undefined,
+      credito_sifco: "",
+      observaciones: "",
+      abono_directo_capital: 0,
+      cuotaApagar: cuotaSeleccionada ?? 0,
+      url_boletas: [],
+      banco_id: 0,
+      numeroAutorizacion: "",
+      registerBy: user?.email || "",
+      origen_pago: "" as any,
+    },
+    validate: zodToFormikValidate(pagoSchema),
+    onSubmit: async (values, { setSubmitting, setStatus, resetForm }) => {
+      try {
+        if ((creditoCanceladoInfo!== null && creditoCanceladoInfo !== undefined ) ) {
+         await handleResetCredito();
+          return;
+
+        }
+        console.log(cuotaSeleccionada, " cuotaSeleccionada");
+        const cuotaApagarValue =
+          typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
+        formik.setFieldValue("cuotaApagar", cuotaApagarValue);
+        if (archivosParaSubir.length === 0) {
+          toast.error("Debes seleccionar al menos un archivo de boleta (máx. 3)");
+          return;
+        }
+        if (archivosParaSubir.length > 3) {
+          toast.error("Solo puedes subir hasta 3 archivos de boleta");
+          return;
+        }
+
+        // Sube los archivos y llena el array de filenames
+        const url_boletas: string[] = [];
+        for (const archivo of archivosParaSubir) {
+          const { filename } = await uploadFileService(archivo);
+          url_boletas.push(filename);
+        }
+
+        const valuesToSend = {
+          ...values,
+          cuotaApagar:
+            typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0,
+          url_boletas,
+        };
+        console.log("Valores a enviar:", valuesToSend);
+         
+        const response = await createPago(valuesToSend); // Esto es la respuesta completa
+        toast.success(response.message || "¡Pago registrado correctamente!");
+    
+
+        setStatus({ success: true });
+        resetForm();
+        setDataCredito(null); // Limpiar datos del crédito
+        setCuotaActualInfo(null);
+        setCuotasAtrasadasInfo(null);
+        setPermiteAbonoCapital(false);
+        setCuotasPendientesInfo(null);
+        setModalExcesoOpen(false); // Cerrar modal de exceso
+        setExcedente(0); // Reiniciar excedente
+        setCuotaActualInfo(null); // Reiniciar cuota actual
+        setFileToUpload(null); // Reiniciar archivo a subir
+        setArchivosParaSubir([]);
+        setResetBuscador(true);
+      } catch (error: any) {
+        const backendMessage = getApiErrorMessage(
+          error,
+          "No se pudo registrar el pago",
+        );
+        toast.error(backendMessage);
+        setStatus({ success: false, error: backendMessage });
+      } finally {
+        setSubmitting(false);
+      }
+    },
+  });
+  const [creditoCanceladoInfo, setCreditoCanceladoInfo] = useState<{
+    credito: Credito;
+    usuario: Usuario;
+    cancelacion: CancelacionCredito | null;
+  } | null>(null);
+  // Función para buscar crédito y setear los campos
+    const fetchCredito = async (numero_credito_sifco: string) => {
+    if (!numero_credito_sifco.trim()) return;
+    setLoadingCredito(true);
+    setErrorCredito(null);
+    try {
+      const result = await getCreditoByNumero(numero_credito_sifco);
+      if (
+        result.flujo === "CANCELADO" &&
+        !canEnterCancellationPaymentFlow(result.credito?.statusCredit)
+      ) {
+        setDataCredito(null);
+        setCreditoCanceladoInfo(null);
+        setCuotaActualInfo(null);
+        setCuotasAtrasadasInfo(null);
+        setCuotasPendientesInfo(null);
+        setConvenioActivoInfo(null);
+        setPermiteAbonoCapital(false);
+        setCuotaSeleccionada(0);
+        setSaldoAFavorUser(0);
+        setFileToUpload(null);
+        setArchivosParaSubir([]);
+        setErrorCredito(
+          "El crédito ya está cancelado y solo está disponible para consulta en el historial."
+        );
+        return;
+      }
+      setDataCredito(result);
+
+      // FLUJO CANCELADO
+      if (result.flujo === "CANCELADO") {
+        setCreditoCanceladoInfo({
+          credito: result.credito,
+          usuario: result.usuario,
+          cancelacion: result.cancelacion,
+        });
+        setDataCredito(result);
+        setCuotaActualInfo(null);
+        setCuotasAtrasadasInfo(null);
+        setPermiteAbonoCapital(false);
+        setCuotasPendientesInfo(null);
+        setCuotaSeleccionada(0);
+        setSaldoAFavorUser(0);
+        setArchivosParaSubir([]);
+        setResetBuscador(true);
+        setConvenioActivoInfo(null); // 👈 AGREGA ESTO
+
+        const today = new Date();
+        const fechaHoy = today.toISOString().split("T")[0];
+        formik.setValues((prev) => ({
+          ...prev,
+          credito_id: result.credito.credito_id,
+          usuario_id: result.credito.usuario_id,
+          credito_sifco: result.credito.numero_credito_sifco,
+          fecha_pago: fechaHoy,
+          llamada: "",
+          monto_boleta: Number(result.cancelacion?.monto_cancelacion || 0),
+          numero_cuota: 0,
+        }));
+
+        return;
+      }
+
+      // FLUJO ACTIVO
+      // Extraer numero_cuota del objeto cuotaActual (antes era número, ahora es objeto)
+      const cuotaActualObj = result.cuotaActual as any;
+      const cuotaActualNumero = typeof cuotaActualObj === 'object' && cuotaActualObj !== null
+        ? cuotaActualObj.numero_cuota
+        : cuotaActualObj;
+
+      const siguienteCuotaPagable = [
+        ...(result.cuotasAtrasadas ?? []),
+        ...(result.cuotasPendientes ?? []),
+      ]
+        // Los pagos `pending` también son seleccionables para poder reportar
+        // abonos complementarios antes de que contabilidad valide el anterior.
+        .filter((c: any) => c.validationStatus !== "validated" && c.validationStatus !== "capital_validated")
+        .sort((a: any, b: any) => a.numero_cuota - b.numero_cuota)[0];
+
+      setCuotaSeleccionada(siguienteCuotaPagable?.numero_cuota ?? cuotaActualNumero ?? 0);
+      setMora(result.moraActual || 0);
+
+      // 👇 AGREGA INFO DE CONVENIO
+      if (result.convenioActivo) {
+        setConvenioActivoInfo({
+         ...result.convenioActivo
+        });
+      } else {
+        setConvenioActivoInfo(null);
+      }
+
+      setCuotaActualInfo({
+        numero: cuotaActualNumero,
+        pagada: !!result.cuotaActualPagada,
+        validationStatus: result.cuotaActualStatus ?? cuotaActualObj?.validationStatus,
+        data: typeof cuotaActualObj === 'object' && cuotaActualObj !== null
+          ? cuotaActualObj
+          : (result.cuotasPagadas.find(
+              (c: any) => c.numero_cuota === cuotaActualNumero
+            ) ||
+            result.cuotasAtrasadas.find(
+              (c: any) => c.numero_cuota === cuotaActualNumero
+            ) ||
+            null),
+      });
+
+      setCuotasAtrasadasInfo({
+        total: result.cuotasAtrasadas.length,
+        cuotas: result.cuotasAtrasadas,
+        cuotaMasAntigua:
+          result.cuotasAtrasadas.length > 0
+            ? result.cuotasAtrasadas[0].numero_cuota
+            : undefined,
+      });
+
+      setPermiteAbonoCapital(!!result.credito?.permite_abono_capital);
+
+      setCuotasPendientesInfo({
+        total: result.cuotasPendientes.length,
+        cuotas: result.cuotasPendientes,
+        cuotaMasAntigua:
+          result.cuotasPendientes.length > 0
+            ? result.cuotasPendientes[0].numero_cuota
+            : undefined,
+      });
+
+      if (result?.credito && result?.usuario) {
+        const today = new Date();
+        const fechaHoy = today.toISOString().split("T")[0];
+        setSaldoAFavorUser(result.usuario.saldo_a_favor || 0);
+        formik.setValues((prev) => ({
+          ...prev,
+          credito_id: result.credito.credito_id,
+          usuario_id: result.credito.usuario_id,
+          credito_sifco: result.credito.numero_credito_sifco,
+          fecha_pago: fechaHoy,
+          llamada: "",
+          numero_cuota: result.cuotaActual,
+        }));
+      }
+    } catch (err: any) {
+      setErrorCredito(
+        err?.response?.data?.message || "Error consultando crédito"
+      );
+      setDataCredito(null);
+      setCuotaActualInfo(null);
+      setCuotasAtrasadasInfo(null);
+      setCuotasPendientesInfo(null);
+      setCuotaSeleccionada(0);
+      setSaldoAFavorUser(0);
+      setConvenioActivoInfo(null); // 👈 AGREGA ESTO
+    } finally {
+      setLoadingCredito(false);
+    }
+  };
+  const [openBadDebt, setOpenBadDebt] = useState(false);
+  const [montoBaseBadDebt, setMontoBaseBadDebt] = useState(0);
+  // Handler que revisa el excedente ANTES del submit
+  
+useEffect(() => {
+  if (openBadDebt) {
+    console.log("Modal de incobrable abierto, monto base:", montoBaseBadDebt);
+    setMontoBaseBadDebt(montoBaseBadDebt);
+  }
+}, [openBadDebt]);
+const handleFormSubmit = (e: React.FormEvent) => {
+  e.preventDefault();
+
+  // ===== MANEJO DE CRÉDITO CANCELADO =====
+  if (creditoCanceladoInfo) {
+    const { monto_boleta } = formik.values;
+    const monto_cancelacion = Number(
+      creditoCanceladoInfo.cancelacion?.monto_cancelacion || 0
+    );
+
+    if (monto_boleta < 0) {
+      toast.error("El monto de la boleta debe ser mayor a cero");
+      return;
+    }
+
+    if (monto_boleta < monto_cancelacion) {
+      const resta = monto_cancelacion - monto_boleta;
+      setMontoBaseBadDebt(resta);
+      setOpenBadDebt(true);
+      return;
+    }
+
+    formik.handleSubmit();
+    return;
+  }
+
+  // ===== VALIDACIÓN: DEBE TENER CUOTA SELECCIONADA =====
+  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+    toast.error("Por favor selecciona una cuota a pagar del menú desplegable");
+    return;
+  }
+
+  // ===== CRÉDITO ACTIVO =====
+const { monto_boleta, otros } = formik.values;
+const  cuota = Number(dataCredito?.credito?.cuota || 0);
+const otrosNum = Number(otros || 0);
+const saldoAFavor = Number(dataCredito?.usuario?.saldo_a_favor || 0);
+const montoBoleta = Number(monto_boleta || 0);
+const moraNum = Number(mora || 0);
+const cuotaConvenioNum = Number(convenioActivoInfo?.cuotaConvenioAPagar || 0);
+
+console.log("=== DEBUG VALORES ===");
+console.log("Saldo a Favor:", saldoAFavor);
+console.log("Monto Boleta:", montoBoleta);
+console.log("Otros:", otrosNum);
+console.log("Mora:", moraNum);
+console.log("Cuota Convenio:", cuotaConvenioNum);
+
+// 🔥 Calcular monto disponible total (boleta + saldo a favor)
+const montoDisponibleTotal = montoBoleta ;
+console.log("Monto Disponible Total (boleta + saldo):", montoDisponibleTotal);
+
+// 🔥 Restar lo que se va a otros conceptos
+const montoBoletaReal = montoDisponibleTotal - otrosNum - moraNum - cuotaConvenioNum;
+const montoBoletaSinMora = montoDisponibleTotal - otrosNum - cuotaConvenioNum;
+
+console.log("Monto Boleta Real (después de descuentos):", montoBoletaReal);
+console.log("Monto Boleta Sin Mora:", montoBoletaSinMora);
+
+// 🔥 Validación
+if (montoBoletaSinMora < 0) {
+  toast.error("El saldo a favor más la boleta debe cubrir la suma de otros y convenio");
+  return;
+}
+
+// 👇 SIEMPRE USA LA CUOTA SELECCIONADA POR EL USUARIO
+const cuotaAPagar: number = cuotaSeleccionada;
+
+console.log("=== CUOTA DETERMINADA ===");
+console.log("Cuota seleccionada por usuario:", cuotaSeleccionada);
+console.log("Cuota a usar:", cuotaAPagar);
+
+// ===== MANEJO DE EXCEDENTES =====
+const montoRedondeado = Math.round(montoBoletaReal * 100) / 100;
+
+// 🔥 Calcular abonos ya realizados en la cuota SELECCIONADA (desde endpoint)
+const abonosRealizados = getDisplayedPartialContribution(abonosCuota);
+
+// 🔥 Cuota menos los abonos ya hechos = lo que falta por pagar
+const cuotaComparar = Math.max(0,cuota - abonosRealizados );
+
+console.log("=== VALIDACIÓN DE EXCEDENTES ===");
+console.log("Monto boleta real (redondeado):", montoRedondeado);
+console.log("Cuota base:", cuota);
+console.log("Abonos ya realizados:", abonosRealizados);
+console.log("Cuota a comparar (lo que falta):", cuotaComparar);
+
+const cuotaRedondeada = Math.round(cuotaComparar * 100) / 100;
+
+// Si hay excedente, abre el modal
+if (montoRedondeado > cuotaRedondeada) {
+  const excedenteCalculado = montoRedondeado - cuotaRedondeada;
+  
+  console.log("=== HAY EXCEDENTE ===");
+  console.log("Excedente:", excedenteCalculado);
+  
+  setModalMode("excedente");
+  setExcedente(excedenteCalculado);
+  setModalExcesoOpen(true);
+  return;
+}
+
+console.log("=== NO HAY EXCEDENTE - CONTINUAR CON PAGO ===");
+
+  // Si la cuota actual ya está pagada y el monto no es exacto
+  if (cuotaActualInfo?.pagada && montoRedondeado !== cuotaRedondeada) {
+    // Si tiene "otros" y la suma cuadra
+    if (otrosNum > 0 && monto_boleta === otrosNum) {
+      // Todo bien, continuar
+    } else {
+      // Hay un desbalance
+      setExcedente(montoBoletaReal);
+      setModalMode("pagada");
+      setModalExcesoOpen(true);
+      return;
+    }
+  }
+
+  // 👇 SETEA LA CUOTA EN FORMIK Y HACE SUBMIT
+  console.log("=== ANTES DEL SUBMIT ===");
+  console.log("formik.values.cuotaApagar ANTES:", formik.values.cuotaApagar);
+  
+  formik.values.cuotaApagar = cuotaAPagar;
+  
+  console.log("formik.values.cuotaApagar DESPUÉS:", formik.values.cuotaApagar);
+  console.log("=====================");
+  
+  formik.handleSubmit();
+};
+  // Acciones del modal
+const handleAbonoCapital = () => {
+  // ✅ Validar que haya cuota seleccionada
+  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+    toast.error("Debes seleccionar una cuota antes de continuar");
+    setModalExcesoOpen(false);
+    return;
+  }
+
+  console.log("=== ABONO A CAPITAL ===");
+  console.log("Excedente:", excedente);
+  console.log("Cuota seleccionada:", cuotaSeleccionada);
+  
+  // 👇 USA LA CUOTA SELECCIONADA
+  formik.values.abono_directo_capital = excedente;
+  formik.values.cuotaApagar = cuotaSeleccionada;
+  
+  setModalExcesoOpen(false);
+  formik.handleSubmit();
+};
+const handleAbonoCapitalDirecto = () => {
+  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+    toast.error("Debes seleccionar una cuota antes de continuar");
+    return;
+  }
+
+  const montoBoleta = Number(formik.values.monto_boleta) || 0;
+
+  console.log("=== ABONO DIRECTO A CAPITAL ===");
+  console.log("Monto boleta completo:", montoBoleta);
+  console.log("Cuota seleccionada:", cuotaSeleccionada);
+
+  formik.values.abono_directo_capital = montoBoleta;
+  formik.values.cuotaApagar = cuotaSeleccionada;
+
+  setModalExcesoOpen(false);
+  formik.handleSubmit();
+};
+const handleAbonoSiguienteCuota = () => {
+  // ✅ Validar que haya cuota seleccionada
+  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+    toast.error("Debes seleccionar una cuota antes de continuar");
+    setModalExcesoOpen(false);
+    return;
+  }
+
+  console.log("=== ABONO SIGUIENTE CUOTA ===");
+  console.log("Cuota seleccionada:", cuotaSeleccionada);
+  
+  // 👇 USA LA CUOTA SELECCIONADA
+  formik.values.abono_directo_capital = 0;
+  formik.values.cuotaApagar = cuotaSeleccionada;
+  
+  console.log("Cuota a pagar final:", formik.values.cuotaApagar);
+  
+  setModalExcesoOpen(false);
+  formik.handleSubmit();
+};
+ 
+
+const handleAbonoOtros = () => {
+  // ✅ Validar que haya cuota seleccionada
+  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+    toast.error("Debes seleccionar una cuota antes de continuar");
+    setModalExcesoOpen(false);
+    return;
+  }
+
+  const nuevosOtros = Number(formik.values.otros || 0) + Number(excedente || 0);
+  
+  console.log("=== ABONO A OTROS ===");
+  console.log("Nuevos otros:", nuevosOtros);
+  console.log("Cuota seleccionada:", cuotaSeleccionada);
+  
+  // 👇 USA LA CUOTA SELECCIONADA
+  formik.values.otros = nuevosOtros;
+  formik.values.abono_directo_capital = 0;
+  formik.values.cuotaApagar = cuotaSeleccionada;
+  
+  setModalExcesoOpen(false);
+  formik.handleSubmit();
+};
+  function useLiquidatePagosInversionistas() {
+    return useMutation({
+      mutationFn: liquidatePagosInversionistasService,
+      onSuccess: () => {
+        toast.success("Pagos liquidados correctamente");
+        setModalExcesoOpen(false);
+
+        if (formik.values.credito_sifco) {
+          fetchCredito(formik.values.credito_sifco); // Refrescar crédito
+        }
+      },
+      onError: (err: any) => {
+        toast.error(getApiErrorMessage(err, "Error al liquidar pagos"));
+      },
+    });
+  }
+
+  function useReversePagosInversionistas() {
+    return useMutation({
+      mutationFn: reversePagosInversionistasService,
+      onSuccess: () => {
+        toast.success("Pago reversado correctamente");
+      },
+      onError: (err: any) => {
+        toast.error(getApiErrorMessage(err, "Error al reversar pago"));
+      },
+    });
+  }
+
+  function useRevertPaymentToPending() {
+    return useMutation({
+      mutationFn: revertPaymentToPendingService,
+      onSuccess: () => {
+        toast.success("Pago reversado a pendiente correctamente");
+        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
+      },
+      onError: (err: any) => {
+        toast.error(getApiErrorMessage(err, "Error al reversar pago a pendiente"));
+      },
+    });
+  }
+
+  function useRevalidatePayment() {
+    return useMutation({
+      mutationFn: revalidatePaymentService,
+      onSuccess: () => {
+        toast.success("Pago revalidado correctamente");
+        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
+      },
+      onError: (err: any) => {
+        toast.error(getApiErrorMessage(err, "Error al revalidar pago"));
+      },
+    });
+  }
+
+  function useProcessInvestors() {
+    return useMutation({
+      mutationFn: processInvestorsService,
+      onSuccess: () => {
+        toast.success("Inversionistas procesados correctamente");
+        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
+      },
+      onError: (err: any) => {
+        toast.error(getApiErrorMessage(err, "Error al procesar inversionistas"));
+      },
+    });
+  }
+
+  const liquidatePago = useLiquidatePagosInversionistas();
+  const [liquidandoId, setLiquidandoId] = useState<number | null>(null);
+  function handleLiquidar(pago_id: number, credito_id: number, cuota?: number) {
+    try {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+
+      setLiquidandoId(pago_id);
+      liquidatePago.mutate(
+        { pago_id, credito_id, cuota },
+        {
+          onSettled: () => setLiquidandoId(null),
+        }
+      );
+
+      // Aquí podrías hacer un refetch/queryClient.invalidateQueries para actualizar
+    } catch (error) {
+      toast.error(getApiErrorMessage(error, "Error al liquidar el pago"));
+      console.error("Error liquidando pago:", error);
+    }
+  }
+  const reversePago = useReversePagosInversionistas();
+  const revertPaymentToPending = useRevertPaymentToPending();
+  const revalidatePayment = useRevalidatePayment();
+  const processInvestors = useProcessInvestors();
+
+  function useRecalcularPagos() {
+    return useMutation({
+      mutationFn: recalcularPagosService,
+      onSuccess: () => {
+        toast.success("Pagos recalculados correctamente");
+        queryClient.invalidateQueries({ queryKey: ["pagosByCredito"] });
+      },
+      onError: (err: any) => {
+        toast.error(getApiErrorMessage(err, "Error al recalcular pagos"));
+      },
+    });
+  }
+
+  const recalcularPagos = useRecalcularPagos();
+
+  function handleRecalcularPagos(numero_credito_sifco: string, numero_cuota: number) {
+    recalcularPagos.mutate({ numero_credito_sifco, numero_cuota }, {});
+  }
+
+  // Handler:
+  function handleReverse(pago_id: number, credito_id: number, reverseAccounting: boolean) {
+    reversePago.mutate({ pago_id, credito_id, reverseAccounting }, {});
+  }
+
+  // Handler:
+  function handleRevertToPending(pago_id: number, credito_id: number) {
+    revertPaymentToPending.mutate({ pago_id, credito_id }, {});
+  }
+
+  // Handler:
+  function handleRevalidatePayment(pago_id: number, credito_id: number) {
+    revalidatePayment.mutate({ pago_id, credito_id }, {});
+  }
+
+  // Handler:
+  function handleProcessInvestors(pago_id: number, credito_id: number, fechaVencimiento?: string) {
+    const fecha_periodo = fechaVencimiento ? new Date(fechaVencimiento).toISOString() : undefined;
+    processInvestors.mutate({ pago_id, credito_id, fecha_periodo }, {});
+  }
+
+async function handleResetCredito() {
+ 
+  console.log(cuotaSeleccionada, " cuotaSeleccionada");
+        const cuotaApagarValue =
+          typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
+        formik.setFieldValue("cuotaApagar", cuotaApagarValue);
+        if (archivosParaSubir.length === 0) {
+          toast.error("Debes seleccionar al menos un archivo de boleta (máx. 3)");
+          return;
+        }
+        if (archivosParaSubir.length > 3) {
+          toast.error("Solo puedes subir hasta 3 archivos de boleta");
+          return;
+        }
+
+        // Sube los archivos y llena el array de filenames
+        const url_boletas: string[] = [];
+        for (const archivo of archivosParaSubir) {
+          const { filename } = await uploadFileService(archivo);
+          url_boletas.push(filename);
+        }
+
+  resetCredit({
+    creditId: Number(creditoCanceladoInfo?.credito.credito_id),
+    montoBoleta: formik.values.monto_boleta,
+    url_boletas: url_boletas,
+    cuota: cuotaActualInfo?.numero || 0,
+    banco_id: formik.values.banco_id,
+    montoIncobrable: montoBaseBadDebt,
+    numeroAutorizacion: formik.values.numeroAutorizacion || undefined,
+  }, {
+    onSuccess: (data) => {
+      toast.success(data.message || "Cancelacion realizada exitosamente");
+
+        formik.resetForm();
+        setDataCredito(null);
+        setCuotaActualInfo(null);
+        setCuotasAtrasadasInfo(null);
+        setPermiteAbonoCapital(false);
+        setCuotasPendientesInfo(null);
+        setModalExcesoOpen(false);
+        setExcedente(0);
+        setFileToUpload(null);
+        setArchivosParaSubir([]);
+        setCreditoCanceladoInfo(null);
+        setResetBuscador(true);
+
+        // Refetch del credito para ver el estado actualizado
+        if (formik.values.credito_sifco) {
+          fetchCredito(formik.values.credito_sifco);
+        }
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error, "Error al reiniciar crédito"));
+    }
+  });
+}
+  return {
+    formik,
+    fetchCredito,
+    dataCredito,
+    loadingCredito,
+    errorCredito,
+    cuotaActualInfo,
+    cuotasAtrasadasInfo,
+    permiteAbonoCapital,
+    cuotasPendientesInfo,
+    useReversePagosInversionistas,
+    // Para el modal de excedente:
+    handleFormSubmit,
+    modalExcesoOpen,
+    setModalExcesoOpen,
+    excedente,
+    handleAbonoCapital,
+    handleAbonoCapitalDirecto,
+    handleAbonoSiguienteCuota,
+    handleAbonoOtros,
+    useLiquidatePagosInversionistas,
+    modalMode,
+    handleLiquidar,
+    liquidandoId,
+    handleReverse,
+    handleRevertToPending,
+    handleRevalidatePayment,
+    reversePago,
+    revertPaymentToPending,
+    revalidatePayment,
+    processInvestors,
+    handleProcessInvestors,
+    recalcularPagos,
+    handleRecalcularPagos,
+    setCuotaSeleccionada,
+    setFileToUpload,
+    fileToUpload,
+    saldo_a_favorUser,
+    creditoCanceladoInfo,
+    openBadDebt,
+    setOpenBadDebt,
+    montoBaseBadDebt,
+    archivosParaSubir,
+    handleResetCredito,
+    setArchivosParaSubir,
+    resetBuscador,
+    setResetBuscador,
+    mora,
+    convenioActivoInfo,
+    cuotaSeleccionada,
+    abonosCuota
+  };
 }

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -2,20 +2,20 @@
 import { z } from "zod";
 import { useFormik } from "formik";
 import {
-  createPago,
-  getCreditoByNumero,
-  getAbonosCuotaService,
-  liquidatePagosInversionistasService,
-  reversePagosInversionistasService,
-  revertPaymentToPendingService,
-  revalidatePaymentService,
-  processInvestorsService,
-  recalcularPagosService,
-  uploadFileService,
-  type AbonosCuotaResponse,
-  type CancelacionCredito,
-  type Credito,
-  type Usuario,
+	createPago,
+	getCreditoByNumero,
+	getAbonosCuotaService,
+	liquidatePagosInversionistasService,
+	reversePagosInversionistasService,
+	revertPaymentToPendingService,
+	revalidatePaymentService,
+	processInvestorsService,
+	recalcularPagosService,
+	uploadFileService,
+	type AbonosCuotaResponse,
+	type CancelacionCredito,
+	type Credito,
+	type Usuario,
 } from "../services/services";
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
@@ -24,803 +24,890 @@ import { getApiErrorMessage } from "@/lib/apiError";
 import { useAuth } from "@/Provider/authProvider";
 import { toast } from "sonner";
 import { getDisplayedPartialContribution } from "../services/installmentContribution";
+import { canEnterCancellationPaymentFlow } from "./cancellationPaymentFlow";
 export const pagoSchema = z.object({
-  credito_id: z.number().int().positive({ message: "Debe seleccionar un crédito" }),
-  usuario_id: z.number().int().positive({ message: "Usuario requerido" }),
-  monto_boleta: z.number().min(0.01, { message: "El monto de boleta debe ser mayor a 0" }),
-  fecha_pago: z.string().min(1, { message: "Fecha de pago requerida" }),
-  fecha_boleta: z.string().min(1, { message: "Fecha de boleta requerida" }),
-  llamada: z.string().max(100).optional(),
-  renuevo_o_nuevo: z.string().max(50).optional(),
-  otros: z.number().min(0).optional(), // OPCIONAL
-  monto_boleta_cuota: z.number().optional(),
-  credito_sifco: z.string().max(50).optional(),
-  observaciones: z.string().max(500).optional(), // OPCIONAL
-  abono_directo_capital: z.number().optional(),
-  cuotaApagar: z.number().int(),
-  url_boletas: z.array(z.string().max(500)),
-  banco_id: z.number().int().positive({ message: "Debe seleccionar un banco" }),
-  numeroAutorizacion: z.string().optional(),
-  registerBy: z.string().min(1, { message: "Usuario registrador requerido" }),
-  origen_pago: z.enum(["transferencia", "cheque", "boleta"], { errorMap: () => ({ message: "Debe seleccionar un origen de pago" }) }),
+	credito_id: z
+		.number()
+		.int()
+		.positive({ message: "Debe seleccionar un crédito" }),
+	usuario_id: z.number().int().positive({ message: "Usuario requerido" }),
+	monto_boleta: z
+		.number()
+		.min(0.01, { message: "El monto de boleta debe ser mayor a 0" }),
+	fecha_pago: z.string().min(1, { message: "Fecha de pago requerida" }),
+	fecha_boleta: z.string().min(1, { message: "Fecha de boleta requerida" }),
+	llamada: z.string().max(100).optional(),
+	renuevo_o_nuevo: z.string().max(50).optional(),
+	otros: z.number().min(0).optional(), // OPCIONAL
+	monto_boleta_cuota: z.number().optional(),
+	credito_sifco: z.string().max(50).optional(),
+	observaciones: z.string().max(500).optional(), // OPCIONAL
+	abono_directo_capital: z.number().optional(),
+	cuotaApagar: z.number().int(),
+	url_boletas: z.array(z.string().max(500)),
+	banco_id: z.number().int().positive({ message: "Debe seleccionar un banco" }),
+	numeroAutorizacion: z.string().optional(),
+	registerBy: z.string().min(1, { message: "Usuario registrador requerido" }),
+	origen_pago: z.enum(["transferencia", "cheque", "boleta"], {
+		errorMap: () => ({ message: "Debe seleccionar un origen de pago" }),
+	}),
 });
 
 export type PagoFormValues = z.infer<typeof pagoSchema>;
- 
+
 function zodToFormikValidate(schema: z.ZodSchema<any>) {
-  return (values: any) => {
-    const result = schema.safeParse(values);
-    if (result.success) return {};
-    const errors: Record<string, string> = {};
-    for (const issue of result.error.issues) {
-      errors[issue.path[0]] = issue.message;
-    }
-    return errors;
-  };
+	return (values: any) => {
+		const result = schema.safeParse(values);
+		if (result.success) return {};
+		const errors: Record<string, string> = {};
+		for (const issue of result.error.issues) {
+			errors[issue.path[0]] = issue.message;
+		}
+		return errors;
+	};
 }
 
 export function usePagoForm() {
-  const queryClient = useQueryClient();
-const { mutate: resetCredit } = useResetCredit();
-const [resetBuscador, setResetBuscador] = useState(false);
-  const [modalMode, setModalMode] = useState<"excedente" | "pagada">(
-    "excedente"
-  );
-  const [loadingCredito, setLoadingCredito] = useState(false);
-  const [dataCredito, setDataCredito] = useState<any>(null);
-  const [errorCredito, setErrorCredito] = useState<string | null>(null);
-  const [cuotaActualInfo, setCuotaActualInfo] = useState<{
-    numero: number;
-    pagada: boolean;
-    validationStatus?: 'no_required' | 'pending' | 'validated' | 'capital' | 'capital_validated' | 'reset';
-    data?: any;
-  } | null>(null);
-  const [mora, setMora] = useState<number>(0);
-  const [cuotasAtrasadasInfo, setCuotasAtrasadasInfo] = useState<{
-    total: number;
-    cuotas: any[];
-    cuotaMasAntigua?: number;
-  } | null>(null);
-  const [permiteAbonoCapital, setPermiteAbonoCapital] = useState<boolean>(false);
-const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
-  convenio_id: number;
-  credito_id: number;
-  monto_total_convenio: string;
-  cuota_mensual: string;
-  pagos_realizados: number;
-  pagos_pendientes: number;
-  activo: boolean;
-  completado: boolean;
-  cuotasEnConvenio: any[];
-  pagosConvenio: any[];
-  cuotasConvenioMensuales: any[]; // 🔥 NUEVO
-  cuotaConvenioAPagar: string; // 🔥 NUEVO
-} | null>(null);
-  const [cuotasPendientesInfo, setCuotasPendientesInfo] = useState<{
-    total: number;
-    cuotas: any[];
-    cuotaMasAntigua?: number;
-  } | null>(null);
-  // Modal de exceso
-  const [modalExcesoOpen, setModalExcesoOpen] = useState(false);
-  const [saldo_a_favorUser, setSaldoAFavorUser] = useState(0);
-  const [excedente, setExcedente] = useState(0);
-  const [fileToUpload, setFileToUpload] = useState<File | null>(null);
-  // Declarar cuotaSeleccionada antes de usarla en initialValues
-  const [cuotaSeleccionada, setCuotaSeleccionada] = useState<
-    number | undefined
-  >();
-  const [archivosParaSubir, setArchivosParaSubir] = useState<File[]>([]);
-  const [abonosCuota, setAbonosCuota] = useState<AbonosCuotaResponse | null>(null);
-  const { user } = useAuth(); //
-
-  // Fetch abonos cuando cambia la cuota seleccionada
-  useEffect(() => {
-    if (!cuotaSeleccionada || !dataCredito?.credito?.numero_credito_sifco) {
-      setAbonosCuota(null);
-      return;
-    }
-    let cancelled = false;
-    getAbonosCuotaService(dataCredito.credito.numero_credito_sifco, cuotaSeleccionada)
-      .then((res) => {
-        if (!cancelled) setAbonosCuota(res);
-      })
-      .catch(() => {
-        if (!cancelled) setAbonosCuota(null);
-      });
-    return () => { cancelled = true; };
-  }, [cuotaSeleccionada, dataCredito?.credito?.numero_credito_sifco]);
-
-  // Formik
-  const formik = useFormik<PagoFormValues>({
-    validateOnChange: false,
-    validateOnBlur: true,
-    initialValues: {
-      credito_id: 0,
-      usuario_id: 0,
-      monto_boleta: 0,
-      fecha_pago: "",
-      llamada: "",
-      renuevo_o_nuevo: "",
-      fecha_boleta: "",
-      otros: 0,
-      monto_boleta_cuota: undefined,
-      credito_sifco: "",
-      observaciones: "",
-      abono_directo_capital: 0,
-      cuotaApagar: cuotaSeleccionada ?? 0,
-      url_boletas: [],
-      banco_id: 0,
-      numeroAutorizacion: "",
-      registerBy: user?.email || "",
-      origen_pago: "" as any,
-    },
-    validate: zodToFormikValidate(pagoSchema),
-    onSubmit: async (values, { setSubmitting, setStatus, resetForm }) => {
-      try {
-        if ((creditoCanceladoInfo!== null && creditoCanceladoInfo !== undefined ) ) {
-         await handleResetCredito();
-          return;
-
-        }
-        console.log(cuotaSeleccionada, " cuotaSeleccionada");
-        const cuotaApagarValue =
-          typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
-        formik.setFieldValue("cuotaApagar", cuotaApagarValue);
-        if (archivosParaSubir.length === 0) {
-          toast.error("Debes seleccionar al menos un archivo de boleta (máx. 3)");
-          return;
-        }
-        if (archivosParaSubir.length > 3) {
-          toast.error("Solo puedes subir hasta 3 archivos de boleta");
-          return;
-        }
-
-        // Sube los archivos y llena el array de filenames
-        const url_boletas: string[] = [];
-        for (const archivo of archivosParaSubir) {
-          const { filename } = await uploadFileService(archivo);
-          url_boletas.push(filename);
-        }
-
-        const valuesToSend = {
-          ...values,
-          cuotaApagar:
-            typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0,
-          url_boletas,
-        };
-        console.log("Valores a enviar:", valuesToSend);
-         
-        const response = await createPago(valuesToSend); // Esto es la respuesta completa
-        toast.success(response.message || "¡Pago registrado correctamente!");
-    
-
-        setStatus({ success: true });
-        resetForm();
-        setDataCredito(null); // Limpiar datos del crédito
-        setCuotaActualInfo(null);
-        setCuotasAtrasadasInfo(null);
-        setPermiteAbonoCapital(false);
-        setCuotasPendientesInfo(null);
-        setModalExcesoOpen(false); // Cerrar modal de exceso
-        setExcedente(0); // Reiniciar excedente
-        setCuotaActualInfo(null); // Reiniciar cuota actual
-        setFileToUpload(null); // Reiniciar archivo a subir
-        setArchivosParaSubir([]);
-        setResetBuscador(true);
-      } catch (error: any) {
-        const backendMessage = getApiErrorMessage(
-          error,
-          "No se pudo registrar el pago",
-        );
-        toast.error(backendMessage);
-        setStatus({ success: false, error: backendMessage });
-      } finally {
-        setSubmitting(false);
-      }
-    },
-  });
-  const [creditoCanceladoInfo, setCreditoCanceladoInfo] = useState<{
-    credito: Credito;
-    usuario: Usuario;
-    cancelacion: CancelacionCredito | null;
-  } | null>(null);
-  // Función para buscar crédito y setear los campos
-    const fetchCredito = async (numero_credito_sifco: string) => {
-    if (!numero_credito_sifco.trim()) return;
-    setLoadingCredito(true);
-    setErrorCredito(null);
-    try {
-      const result = await getCreditoByNumero(numero_credito_sifco);
-      setDataCredito(result);
-
-      // FLUJO CANCELADO
-      if (result.flujo === "CANCELADO") {
-        setCreditoCanceladoInfo({
-          credito: result.credito,
-          usuario: result.usuario,
-          cancelacion: result.cancelacion,
-        });
-        setDataCredito(result);
-        setCuotaActualInfo(null);
-        setCuotasAtrasadasInfo(null);
-        setPermiteAbonoCapital(false);
-        setCuotasPendientesInfo(null);
-        setCuotaSeleccionada(0);
-        setSaldoAFavorUser(0);
-        setArchivosParaSubir([]);
-        setResetBuscador(true);
-        setConvenioActivoInfo(null); // 👈 AGREGA ESTO
-
-        const today = new Date();
-        const fechaHoy = today.toISOString().split("T")[0];
-        formik.setValues((prev) => ({
-          ...prev,
-          credito_id: result.credito.credito_id,
-          usuario_id: result.credito.usuario_id,
-          credito_sifco: result.credito.numero_credito_sifco,
-          fecha_pago: fechaHoy,
-          llamada: "",
-          monto_boleta: Number(result.cancelacion?.monto_cancelacion || 0),
-          numero_cuota: 0,
-        }));
-
-        return;
-      }
-
-      // FLUJO ACTIVO
-      // Extraer numero_cuota del objeto cuotaActual (antes era número, ahora es objeto)
-      const cuotaActualObj = result.cuotaActual as any;
-      const cuotaActualNumero = typeof cuotaActualObj === 'object' && cuotaActualObj !== null
-        ? cuotaActualObj.numero_cuota
-        : cuotaActualObj;
-
-      const siguienteCuotaPagable = [
-        ...(result.cuotasAtrasadas ?? []),
-        ...(result.cuotasPendientes ?? []),
-      ]
-        // Los pagos `pending` también son seleccionables para poder reportar
-        // abonos complementarios antes de que contabilidad valide el anterior.
-        .filter((c: any) => c.validationStatus !== "validated" && c.validationStatus !== "capital_validated")
-        .sort((a: any, b: any) => a.numero_cuota - b.numero_cuota)[0];
-
-      setCuotaSeleccionada(siguienteCuotaPagable?.numero_cuota ?? cuotaActualNumero ?? 0);
-      setMora(result.moraActual || 0);
-
-      // 👇 AGREGA INFO DE CONVENIO
-      if (result.convenioActivo) {
-        setConvenioActivoInfo({
-         ...result.convenioActivo
-        });
-      } else {
-        setConvenioActivoInfo(null);
-      }
-
-      setCuotaActualInfo({
-        numero: cuotaActualNumero,
-        pagada: !!result.cuotaActualPagada,
-        validationStatus: result.cuotaActualStatus ?? cuotaActualObj?.validationStatus,
-        data: typeof cuotaActualObj === 'object' && cuotaActualObj !== null
-          ? cuotaActualObj
-          : (result.cuotasPagadas.find(
-              (c: any) => c.numero_cuota === cuotaActualNumero
-            ) ||
-            result.cuotasAtrasadas.find(
-              (c: any) => c.numero_cuota === cuotaActualNumero
-            ) ||
-            null),
-      });
-
-      setCuotasAtrasadasInfo({
-        total: result.cuotasAtrasadas.length,
-        cuotas: result.cuotasAtrasadas,
-        cuotaMasAntigua:
-          result.cuotasAtrasadas.length > 0
-            ? result.cuotasAtrasadas[0].numero_cuota
-            : undefined,
-      });
-
-      setPermiteAbonoCapital(!!result.credito?.permite_abono_capital);
-
-      setCuotasPendientesInfo({
-        total: result.cuotasPendientes.length,
-        cuotas: result.cuotasPendientes,
-        cuotaMasAntigua:
-          result.cuotasPendientes.length > 0
-            ? result.cuotasPendientes[0].numero_cuota
-            : undefined,
-      });
-
-      if (result?.credito && result?.usuario) {
-        const today = new Date();
-        const fechaHoy = today.toISOString().split("T")[0];
-        setSaldoAFavorUser(result.usuario.saldo_a_favor || 0);
-        formik.setValues((prev) => ({
-          ...prev,
-          credito_id: result.credito.credito_id,
-          usuario_id: result.credito.usuario_id,
-          credito_sifco: result.credito.numero_credito_sifco,
-          fecha_pago: fechaHoy,
-          llamada: "",
-          numero_cuota: result.cuotaActual,
-        }));
-      }
-    } catch (err: any) {
-      setErrorCredito(
-        err?.response?.data?.message || "Error consultando crédito"
-      );
-      setDataCredito(null);
-      setCuotaActualInfo(null);
-      setCuotasAtrasadasInfo(null);
-      setCuotasPendientesInfo(null);
-      setCuotaSeleccionada(0);
-      setSaldoAFavorUser(0);
-      setConvenioActivoInfo(null); // 👈 AGREGA ESTO
-    } finally {
-      setLoadingCredito(false);
-    }
-  };
-  const [openBadDebt, setOpenBadDebt] = useState(false);
-  const [montoBaseBadDebt, setMontoBaseBadDebt] = useState(0);
-  // Handler que revisa el excedente ANTES del submit
-  
-useEffect(() => {
-  if (openBadDebt) {
-    console.log("Modal de incobrable abierto, monto base:", montoBaseBadDebt);
-    setMontoBaseBadDebt(montoBaseBadDebt);
-  }
-}, [openBadDebt]);
-const handleFormSubmit = (e: React.FormEvent) => {
-  e.preventDefault();
-
-  // ===== MANEJO DE CRÉDITO CANCELADO =====
-  if (creditoCanceladoInfo) {
-    const { monto_boleta } = formik.values;
-    const monto_cancelacion = Number(
-      creditoCanceladoInfo.cancelacion?.monto_cancelacion || 0
-    );
-
-    if (monto_boleta < 0) {
-      toast.error("El monto de la boleta debe ser mayor a cero");
-      return;
-    }
-
-    if (monto_boleta < monto_cancelacion) {
-      const resta = monto_cancelacion - monto_boleta;
-      setMontoBaseBadDebt(resta);
-      setOpenBadDebt(true);
-      return;
-    }
-
-    formik.handleSubmit();
-    return;
-  }
-
-  // ===== VALIDACIÓN: DEBE TENER CUOTA SELECCIONADA =====
-  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-    toast.error("Por favor selecciona una cuota a pagar del menú desplegable");
-    return;
-  }
-
-  // ===== CRÉDITO ACTIVO =====
-const { monto_boleta, otros } = formik.values;
-const  cuota = Number(dataCredito?.credito?.cuota || 0);
-const otrosNum = Number(otros || 0);
-const saldoAFavor = Number(dataCredito?.usuario?.saldo_a_favor || 0);
-const montoBoleta = Number(monto_boleta || 0);
-const moraNum = Number(mora || 0);
-const cuotaConvenioNum = Number(convenioActivoInfo?.cuotaConvenioAPagar || 0);
-
-console.log("=== DEBUG VALORES ===");
-console.log("Saldo a Favor:", saldoAFavor);
-console.log("Monto Boleta:", montoBoleta);
-console.log("Otros:", otrosNum);
-console.log("Mora:", moraNum);
-console.log("Cuota Convenio:", cuotaConvenioNum);
-
-// 🔥 Calcular monto disponible total (boleta + saldo a favor)
-const montoDisponibleTotal = montoBoleta ;
-console.log("Monto Disponible Total (boleta + saldo):", montoDisponibleTotal);
-
-// 🔥 Restar lo que se va a otros conceptos
-const montoBoletaReal = montoDisponibleTotal - otrosNum - moraNum - cuotaConvenioNum;
-const montoBoletaSinMora = montoDisponibleTotal - otrosNum - cuotaConvenioNum;
-
-console.log("Monto Boleta Real (después de descuentos):", montoBoletaReal);
-console.log("Monto Boleta Sin Mora:", montoBoletaSinMora);
-
-// 🔥 Validación
-if (montoBoletaSinMora < 0) {
-  toast.error("El saldo a favor más la boleta debe cubrir la suma de otros y convenio");
-  return;
-}
-
-// 👇 SIEMPRE USA LA CUOTA SELECCIONADA POR EL USUARIO
-const cuotaAPagar: number = cuotaSeleccionada;
-
-console.log("=== CUOTA DETERMINADA ===");
-console.log("Cuota seleccionada por usuario:", cuotaSeleccionada);
-console.log("Cuota a usar:", cuotaAPagar);
-
-// ===== MANEJO DE EXCEDENTES =====
-const montoRedondeado = Math.round(montoBoletaReal * 100) / 100;
-
-// 🔥 Calcular abonos ya realizados en la cuota SELECCIONADA (desde endpoint)
-const abonosRealizados = getDisplayedPartialContribution(abonosCuota);
-
-// 🔥 Cuota menos los abonos ya hechos = lo que falta por pagar
-const cuotaComparar = Math.max(0,cuota - abonosRealizados );
-
-console.log("=== VALIDACIÓN DE EXCEDENTES ===");
-console.log("Monto boleta real (redondeado):", montoRedondeado);
-console.log("Cuota base:", cuota);
-console.log("Abonos ya realizados:", abonosRealizados);
-console.log("Cuota a comparar (lo que falta):", cuotaComparar);
-
-const cuotaRedondeada = Math.round(cuotaComparar * 100) / 100;
-
-// Si hay excedente, abre el modal
-if (montoRedondeado > cuotaRedondeada) {
-  const excedenteCalculado = montoRedondeado - cuotaRedondeada;
-  
-  console.log("=== HAY EXCEDENTE ===");
-  console.log("Excedente:", excedenteCalculado);
-  
-  setModalMode("excedente");
-  setExcedente(excedenteCalculado);
-  setModalExcesoOpen(true);
-  return;
-}
-
-console.log("=== NO HAY EXCEDENTE - CONTINUAR CON PAGO ===");
-
-  // Si la cuota actual ya está pagada y el monto no es exacto
-  if (cuotaActualInfo?.pagada && montoRedondeado !== cuotaRedondeada) {
-    // Si tiene "otros" y la suma cuadra
-    if (otrosNum > 0 && monto_boleta === otrosNum) {
-      // Todo bien, continuar
-    } else {
-      // Hay un desbalance
-      setExcedente(montoBoletaReal);
-      setModalMode("pagada");
-      setModalExcesoOpen(true);
-      return;
-    }
-  }
-
-  // 👇 SETEA LA CUOTA EN FORMIK Y HACE SUBMIT
-  console.log("=== ANTES DEL SUBMIT ===");
-  console.log("formik.values.cuotaApagar ANTES:", formik.values.cuotaApagar);
-  
-  formik.values.cuotaApagar = cuotaAPagar;
-  
-  console.log("formik.values.cuotaApagar DESPUÉS:", formik.values.cuotaApagar);
-  console.log("=====================");
-  
-  formik.handleSubmit();
-};
-  // Acciones del modal
-const handleAbonoCapital = () => {
-  // ✅ Validar que haya cuota seleccionada
-  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-    toast.error("Debes seleccionar una cuota antes de continuar");
-    setModalExcesoOpen(false);
-    return;
-  }
-
-  console.log("=== ABONO A CAPITAL ===");
-  console.log("Excedente:", excedente);
-  console.log("Cuota seleccionada:", cuotaSeleccionada);
-  
-  // 👇 USA LA CUOTA SELECCIONADA
-  formik.values.abono_directo_capital = excedente;
-  formik.values.cuotaApagar = cuotaSeleccionada;
-  
-  setModalExcesoOpen(false);
-  formik.handleSubmit();
-};
-const handleAbonoCapitalDirecto = () => {
-  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-    toast.error("Debes seleccionar una cuota antes de continuar");
-    return;
-  }
-
-  const montoBoleta = Number(formik.values.monto_boleta) || 0;
-
-  console.log("=== ABONO DIRECTO A CAPITAL ===");
-  console.log("Monto boleta completo:", montoBoleta);
-  console.log("Cuota seleccionada:", cuotaSeleccionada);
-
-  formik.values.abono_directo_capital = montoBoleta;
-  formik.values.cuotaApagar = cuotaSeleccionada;
-
-  setModalExcesoOpen(false);
-  formik.handleSubmit();
-};
-const handleAbonoSiguienteCuota = () => {
-  // ✅ Validar que haya cuota seleccionada
-  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-    toast.error("Debes seleccionar una cuota antes de continuar");
-    setModalExcesoOpen(false);
-    return;
-  }
-
-  console.log("=== ABONO SIGUIENTE CUOTA ===");
-  console.log("Cuota seleccionada:", cuotaSeleccionada);
-  
-  // 👇 USA LA CUOTA SELECCIONADA
-  formik.values.abono_directo_capital = 0;
-  formik.values.cuotaApagar = cuotaSeleccionada;
-  
-  console.log("Cuota a pagar final:", formik.values.cuotaApagar);
-  
-  setModalExcesoOpen(false);
-  formik.handleSubmit();
-};
- 
-
-const handleAbonoOtros = () => {
-  // ✅ Validar que haya cuota seleccionada
-  if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
-    toast.error("Debes seleccionar una cuota antes de continuar");
-    setModalExcesoOpen(false);
-    return;
-  }
-
-  const nuevosOtros = Number(formik.values.otros || 0) + Number(excedente || 0);
-  
-  console.log("=== ABONO A OTROS ===");
-  console.log("Nuevos otros:", nuevosOtros);
-  console.log("Cuota seleccionada:", cuotaSeleccionada);
-  
-  // 👇 USA LA CUOTA SELECCIONADA
-  formik.values.otros = nuevosOtros;
-  formik.values.abono_directo_capital = 0;
-  formik.values.cuotaApagar = cuotaSeleccionada;
-  
-  setModalExcesoOpen(false);
-  formik.handleSubmit();
-};
-  function useLiquidatePagosInversionistas() {
-    return useMutation({
-      mutationFn: liquidatePagosInversionistasService,
-      onSuccess: () => {
-        toast.success("Pagos liquidados correctamente");
-        setModalExcesoOpen(false);
-
-        if (formik.values.credito_sifco) {
-          fetchCredito(formik.values.credito_sifco); // Refrescar crédito
-        }
-      },
-      onError: (err: any) => {
-        toast.error(getApiErrorMessage(err, "Error al liquidar pagos"));
-      },
-    });
-  }
-
-  function useReversePagosInversionistas() {
-    return useMutation({
-      mutationFn: reversePagosInversionistasService,
-      onSuccess: () => {
-        toast.success("Pago reversado correctamente");
-      },
-      onError: (err: any) => {
-        toast.error(getApiErrorMessage(err, "Error al reversar pago"));
-      },
-    });
-  }
-
-  function useRevertPaymentToPending() {
-    return useMutation({
-      mutationFn: revertPaymentToPendingService,
-      onSuccess: () => {
-        toast.success("Pago reversado a pendiente correctamente");
-        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
-      },
-      onError: (err: any) => {
-        toast.error(getApiErrorMessage(err, "Error al reversar pago a pendiente"));
-      },
-    });
-  }
-
-  function useRevalidatePayment() {
-    return useMutation({
-      mutationFn: revalidatePaymentService,
-      onSuccess: () => {
-        toast.success("Pago revalidado correctamente");
-        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
-      },
-      onError: (err: any) => {
-        toast.error(getApiErrorMessage(err, "Error al revalidar pago"));
-      },
-    });
-  }
-
-  function useProcessInvestors() {
-    return useMutation({
-      mutationFn: processInvestorsService,
-      onSuccess: () => {
-        toast.success("Inversionistas procesados correctamente");
-        queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
-      },
-      onError: (err: any) => {
-        toast.error(getApiErrorMessage(err, "Error al procesar inversionistas"));
-      },
-    });
-  }
-
-  const liquidatePago = useLiquidatePagosInversionistas();
-  const [liquidandoId, setLiquidandoId] = useState<number | null>(null);
-  function handleLiquidar(pago_id: number, credito_id: number, cuota?: number) {
-    try {
-      // eslint-disable-next-line react-hooks/rules-of-hooks
-
-      setLiquidandoId(pago_id);
-      liquidatePago.mutate(
-        { pago_id, credito_id, cuota },
-        {
-          onSettled: () => setLiquidandoId(null),
-        }
-      );
-
-      // Aquí podrías hacer un refetch/queryClient.invalidateQueries para actualizar
-    } catch (error) {
-      toast.error(getApiErrorMessage(error, "Error al liquidar el pago"));
-      console.error("Error liquidando pago:", error);
-    }
-  }
-  const reversePago = useReversePagosInversionistas();
-  const revertPaymentToPending = useRevertPaymentToPending();
-  const revalidatePayment = useRevalidatePayment();
-  const processInvestors = useProcessInvestors();
-
-  function useRecalcularPagos() {
-    return useMutation({
-      mutationFn: recalcularPagosService,
-      onSuccess: () => {
-        toast.success("Pagos recalculados correctamente");
-        queryClient.invalidateQueries({ queryKey: ["pagosByCredito"] });
-      },
-      onError: (err: any) => {
-        toast.error(getApiErrorMessage(err, "Error al recalcular pagos"));
-      },
-    });
-  }
-
-  const recalcularPagos = useRecalcularPagos();
-
-  function handleRecalcularPagos(numero_credito_sifco: string, numero_cuota: number) {
-    recalcularPagos.mutate({ numero_credito_sifco, numero_cuota }, {});
-  }
-
-  // Handler:
-  function handleReverse(pago_id: number, credito_id: number, reverseAccounting: boolean) {
-    reversePago.mutate({ pago_id, credito_id, reverseAccounting }, {});
-  }
-
-  // Handler:
-  function handleRevertToPending(pago_id: number, credito_id: number) {
-    revertPaymentToPending.mutate({ pago_id, credito_id }, {});
-  }
-
-  // Handler:
-  function handleRevalidatePayment(pago_id: number, credito_id: number) {
-    revalidatePayment.mutate({ pago_id, credito_id }, {});
-  }
-
-  // Handler:
-  function handleProcessInvestors(pago_id: number, credito_id: number, fechaVencimiento?: string) {
-    const fecha_periodo = fechaVencimiento ? new Date(fechaVencimiento).toISOString() : undefined;
-    processInvestors.mutate({ pago_id, credito_id, fecha_periodo }, {});
-  }
-
-async function handleResetCredito() {
- 
-  console.log(cuotaSeleccionada, " cuotaSeleccionada");
-        const cuotaApagarValue =
-          typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
-        formik.setFieldValue("cuotaApagar", cuotaApagarValue);
-        if (archivosParaSubir.length === 0) {
-          toast.error("Debes seleccionar al menos un archivo de boleta (máx. 3)");
-          return;
-        }
-        if (archivosParaSubir.length > 3) {
-          toast.error("Solo puedes subir hasta 3 archivos de boleta");
-          return;
-        }
-
-        // Sube los archivos y llena el array de filenames
-        const url_boletas: string[] = [];
-        for (const archivo of archivosParaSubir) {
-          const { filename } = await uploadFileService(archivo);
-          url_boletas.push(filename);
-        }
-
-  resetCredit({
-    creditId: Number(creditoCanceladoInfo?.credito.credito_id),
-    montoBoleta: formik.values.monto_boleta,
-    url_boletas: url_boletas,
-    cuota: cuotaActualInfo?.numero || 0,
-    banco_id: formik.values.banco_id,
-    montoIncobrable: montoBaseBadDebt,
-    numeroAutorizacion: formik.values.numeroAutorizacion || undefined,
-  }, {
-    onSuccess: (data) => {
-      toast.success(data.message || "Cancelacion realizada exitosamente");
-
-        formik.resetForm();
-        setDataCredito(null);
-        setCuotaActualInfo(null);
-        setCuotasAtrasadasInfo(null);
-        setPermiteAbonoCapital(false);
-        setCuotasPendientesInfo(null);
-        setModalExcesoOpen(false);
-        setExcedente(0);
-        setFileToUpload(null);
-        setArchivosParaSubir([]);
-        setCreditoCanceladoInfo(null);
-        setResetBuscador(true);
-
-        // Refetch del credito para ver el estado actualizado
-        if (formik.values.credito_sifco) {
-          fetchCredito(formik.values.credito_sifco);
-        }
-    },
-    onError: (error) => {
-      toast.error(getApiErrorMessage(error, "Error al reiniciar crédito"));
-    }
-  });
-}
-  return {
-    formik,
-    fetchCredito,
-    dataCredito,
-    loadingCredito,
-    errorCredito,
-    cuotaActualInfo,
-    cuotasAtrasadasInfo,
-    permiteAbonoCapital,
-    cuotasPendientesInfo,
-    useReversePagosInversionistas,
-    // Para el modal de excedente:
-    handleFormSubmit,
-    modalExcesoOpen,
-    setModalExcesoOpen,
-    excedente,
-    handleAbonoCapital,
-    handleAbonoCapitalDirecto,
-    handleAbonoSiguienteCuota,
-    handleAbonoOtros,
-    useLiquidatePagosInversionistas,
-    modalMode,
-    handleLiquidar,
-    liquidandoId,
-    handleReverse,
-    handleRevertToPending,
-    handleRevalidatePayment,
-    reversePago,
-    revertPaymentToPending,
-    revalidatePayment,
-    processInvestors,
-    handleProcessInvestors,
-    recalcularPagos,
-    handleRecalcularPagos,
-    setCuotaSeleccionada,
-    setFileToUpload,
-    fileToUpload,
-    saldo_a_favorUser,
-    creditoCanceladoInfo,
-    openBadDebt,
-    setOpenBadDebt,
-    montoBaseBadDebt,
-    archivosParaSubir,
-    handleResetCredito,
-    setArchivosParaSubir,
-    resetBuscador,
-    setResetBuscador,
-    mora,
-    convenioActivoInfo,
-    cuotaSeleccionada,
-    abonosCuota
-  };
+	const queryClient = useQueryClient();
+	const { mutate: resetCredit } = useResetCredit();
+	const [resetBuscador, setResetBuscador] = useState(false);
+	const [modalMode, setModalMode] = useState<"excedente" | "pagada">(
+		"excedente",
+	);
+	const [loadingCredito, setLoadingCredito] = useState(false);
+	const [dataCredito, setDataCredito] = useState<any>(null);
+	const [errorCredito, setErrorCredito] = useState<string | null>(null);
+	const [cuotaActualInfo, setCuotaActualInfo] = useState<{
+		numero: number;
+		pagada: boolean;
+		validationStatus?:
+			| "no_required"
+			| "pending"
+			| "validated"
+			| "capital"
+			| "capital_validated"
+			| "reset";
+		data?: any;
+	} | null>(null);
+	const [mora, setMora] = useState<number>(0);
+	const [cuotasAtrasadasInfo, setCuotasAtrasadasInfo] = useState<{
+		total: number;
+		cuotas: any[];
+		cuotaMasAntigua?: number;
+	} | null>(null);
+	const [permiteAbonoCapital, setPermiteAbonoCapital] =
+		useState<boolean>(false);
+	const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
+		convenio_id: number;
+		credito_id: number;
+		monto_total_convenio: string;
+		cuota_mensual: string;
+		pagos_realizados: number;
+		pagos_pendientes: number;
+		activo: boolean;
+		completado: boolean;
+		cuotasEnConvenio: any[];
+		pagosConvenio: any[];
+		cuotasConvenioMensuales: any[]; // 🔥 NUEVO
+		cuotaConvenioAPagar: string; // 🔥 NUEVO
+	} | null>(null);
+	const [cuotasPendientesInfo, setCuotasPendientesInfo] = useState<{
+		total: number;
+		cuotas: any[];
+		cuotaMasAntigua?: number;
+	} | null>(null);
+	// Modal de exceso
+	const [modalExcesoOpen, setModalExcesoOpen] = useState(false);
+	const [saldo_a_favorUser, setSaldoAFavorUser] = useState(0);
+	const [excedente, setExcedente] = useState(0);
+	const [fileToUpload, setFileToUpload] = useState<File | null>(null);
+	// Declarar cuotaSeleccionada antes de usarla en initialValues
+	const [cuotaSeleccionada, setCuotaSeleccionada] = useState<
+		number | undefined
+	>();
+	const [archivosParaSubir, setArchivosParaSubir] = useState<File[]>([]);
+	const [abonosCuota, setAbonosCuota] = useState<AbonosCuotaResponse | null>(
+		null,
+	);
+	const { user } = useAuth(); //
+
+	// Fetch abonos cuando cambia la cuota seleccionada
+	useEffect(() => {
+		if (!cuotaSeleccionada || !dataCredito?.credito?.numero_credito_sifco) {
+			setAbonosCuota(null);
+			return;
+		}
+		let cancelled = false;
+		getAbonosCuotaService(
+			dataCredito.credito.numero_credito_sifco,
+			cuotaSeleccionada,
+		)
+			.then((res) => {
+				if (!cancelled) setAbonosCuota(res);
+			})
+			.catch(() => {
+				if (!cancelled) setAbonosCuota(null);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [cuotaSeleccionada, dataCredito?.credito?.numero_credito_sifco]);
+
+	// Formik
+	const formik = useFormik<PagoFormValues>({
+		validateOnChange: false,
+		validateOnBlur: true,
+		initialValues: {
+			credito_id: 0,
+			usuario_id: 0,
+			monto_boleta: 0,
+			fecha_pago: "",
+			llamada: "",
+			renuevo_o_nuevo: "",
+			fecha_boleta: "",
+			otros: 0,
+			monto_boleta_cuota: undefined,
+			credito_sifco: "",
+			observaciones: "",
+			abono_directo_capital: 0,
+			cuotaApagar: cuotaSeleccionada ?? 0,
+			url_boletas: [],
+			banco_id: 0,
+			numeroAutorizacion: "",
+			registerBy: user?.email || "",
+			origen_pago: "" as any,
+		},
+		validate: zodToFormikValidate(pagoSchema),
+		onSubmit: async (values, { setSubmitting, setStatus, resetForm }) => {
+			try {
+				if (
+					creditoCanceladoInfo !== null &&
+					creditoCanceladoInfo !== undefined
+				) {
+					await handleResetCredito();
+					return;
+				}
+				console.log(cuotaSeleccionada, " cuotaSeleccionada");
+				const cuotaApagarValue =
+					typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
+				formik.setFieldValue("cuotaApagar", cuotaApagarValue);
+				if (archivosParaSubir.length === 0) {
+					toast.error(
+						"Debes seleccionar al menos un archivo de boleta (máx. 3)",
+					);
+					return;
+				}
+				if (archivosParaSubir.length > 3) {
+					toast.error("Solo puedes subir hasta 3 archivos de boleta");
+					return;
+				}
+
+				// Sube los archivos y llena el array de filenames
+				const url_boletas: string[] = [];
+				for (const archivo of archivosParaSubir) {
+					const { filename } = await uploadFileService(archivo);
+					url_boletas.push(filename);
+				}
+
+				const valuesToSend = {
+					...values,
+					cuotaApagar:
+						typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0,
+					url_boletas,
+				};
+				console.log("Valores a enviar:", valuesToSend);
+
+				const response = await createPago(valuesToSend); // Esto es la respuesta completa
+				toast.success(response.message || "¡Pago registrado correctamente!");
+
+				setStatus({ success: true });
+				resetForm();
+				setDataCredito(null); // Limpiar datos del crédito
+				setCuotaActualInfo(null);
+				setCuotasAtrasadasInfo(null);
+				setPermiteAbonoCapital(false);
+				setCuotasPendientesInfo(null);
+				setModalExcesoOpen(false); // Cerrar modal de exceso
+				setExcedente(0); // Reiniciar excedente
+				setCuotaActualInfo(null); // Reiniciar cuota actual
+				setFileToUpload(null); // Reiniciar archivo a subir
+				setArchivosParaSubir([]);
+				setResetBuscador(true);
+			} catch (error: any) {
+				const backendMessage = getApiErrorMessage(
+					error,
+					"No se pudo registrar el pago",
+				);
+				toast.error(backendMessage);
+				setStatus({ success: false, error: backendMessage });
+			} finally {
+				setSubmitting(false);
+			}
+		},
+	});
+	const [creditoCanceladoInfo, setCreditoCanceladoInfo] = useState<{
+		credito: Credito;
+		usuario: Usuario;
+		cancelacion: CancelacionCredito | null;
+	} | null>(null);
+	// Función para buscar crédito y setear los campos
+	const fetchCredito = async (numero_credito_sifco: string) => {
+		if (!numero_credito_sifco.trim()) return;
+		setLoadingCredito(true);
+		setErrorCredito(null);
+		try {
+			const result = await getCreditoByNumero(numero_credito_sifco);
+			if (
+				result.flujo === "CANCELADO" &&
+				!canEnterCancellationPaymentFlow(result.credito?.statusCredit)
+			) {
+				setDataCredito(null);
+				setCreditoCanceladoInfo(null);
+				setCuotaActualInfo(null);
+				setCuotasAtrasadasInfo(null);
+				setCuotasPendientesInfo(null);
+				setConvenioActivoInfo(null);
+				setPermiteAbonoCapital(false);
+				setCuotaSeleccionada(0);
+				setSaldoAFavorUser(0);
+				setFileToUpload(null);
+				setArchivosParaSubir([]);
+				setErrorCredito(
+					"El crédito ya está cancelado y solo está disponible para consulta en el historial.",
+				);
+				return;
+			}
+			setDataCredito(result);
+
+			// FLUJO CANCELADO
+			if (result.flujo === "CANCELADO") {
+				setCreditoCanceladoInfo({
+					credito: result.credito,
+					usuario: result.usuario,
+					cancelacion: result.cancelacion,
+				});
+				setDataCredito(result);
+				setCuotaActualInfo(null);
+				setCuotasAtrasadasInfo(null);
+				setPermiteAbonoCapital(false);
+				setCuotasPendientesInfo(null);
+				setCuotaSeleccionada(0);
+				setSaldoAFavorUser(0);
+				setArchivosParaSubir([]);
+				setResetBuscador(true);
+				setConvenioActivoInfo(null); // 👈 AGREGA ESTO
+
+				const today = new Date();
+				const fechaHoy = today.toISOString().split("T")[0];
+				formik.setValues((prev) => ({
+					...prev,
+					credito_id: result.credito.credito_id,
+					usuario_id: result.credito.usuario_id,
+					credito_sifco: result.credito.numero_credito_sifco,
+					fecha_pago: fechaHoy,
+					llamada: "",
+					monto_boleta: Number(result.cancelacion?.monto_cancelacion || 0),
+					numero_cuota: 0,
+				}));
+
+				return;
+			}
+
+			// FLUJO ACTIVO
+			// Extraer numero_cuota del objeto cuotaActual (antes era número, ahora es objeto)
+			const cuotaActualObj = result.cuotaActual as any;
+			const cuotaActualNumero =
+				typeof cuotaActualObj === "object" && cuotaActualObj !== null
+					? cuotaActualObj.numero_cuota
+					: cuotaActualObj;
+
+			const siguienteCuotaPagable = [
+				...(result.cuotasAtrasadas ?? []),
+				...(result.cuotasPendientes ?? []),
+			]
+				// Los pagos `pending` también son seleccionables para poder reportar
+				// abonos complementarios antes de que contabilidad valide el anterior.
+				.filter(
+					(c: any) =>
+						c.validationStatus !== "validated" &&
+						c.validationStatus !== "capital_validated",
+				)
+				.sort((a: any, b: any) => a.numero_cuota - b.numero_cuota)[0];
+
+			setCuotaSeleccionada(
+				siguienteCuotaPagable?.numero_cuota ?? cuotaActualNumero ?? 0,
+			);
+			setMora(result.moraActual || 0);
+
+			// 👇 AGREGA INFO DE CONVENIO
+			if (result.convenioActivo) {
+				setConvenioActivoInfo({
+					...result.convenioActivo,
+				});
+			} else {
+				setConvenioActivoInfo(null);
+			}
+
+			setCuotaActualInfo({
+				numero: cuotaActualNumero,
+				pagada: !!result.cuotaActualPagada,
+				validationStatus:
+					result.cuotaActualStatus ?? cuotaActualObj?.validationStatus,
+				data:
+					typeof cuotaActualObj === "object" && cuotaActualObj !== null
+						? cuotaActualObj
+						: result.cuotasPagadas.find(
+								(c: any) => c.numero_cuota === cuotaActualNumero,
+							) ||
+							result.cuotasAtrasadas.find(
+								(c: any) => c.numero_cuota === cuotaActualNumero,
+							) ||
+							null,
+			});
+
+			setCuotasAtrasadasInfo({
+				total: result.cuotasAtrasadas.length,
+				cuotas: result.cuotasAtrasadas,
+				cuotaMasAntigua:
+					result.cuotasAtrasadas.length > 0
+						? result.cuotasAtrasadas[0].numero_cuota
+						: undefined,
+			});
+
+			setPermiteAbonoCapital(!!result.credito?.permite_abono_capital);
+
+			setCuotasPendientesInfo({
+				total: result.cuotasPendientes.length,
+				cuotas: result.cuotasPendientes,
+				cuotaMasAntigua:
+					result.cuotasPendientes.length > 0
+						? result.cuotasPendientes[0].numero_cuota
+						: undefined,
+			});
+
+			if (result?.credito && result?.usuario) {
+				const today = new Date();
+				const fechaHoy = today.toISOString().split("T")[0];
+				setSaldoAFavorUser(result.usuario.saldo_a_favor || 0);
+				formik.setValues((prev) => ({
+					...prev,
+					credito_id: result.credito.credito_id,
+					usuario_id: result.credito.usuario_id,
+					credito_sifco: result.credito.numero_credito_sifco,
+					fecha_pago: fechaHoy,
+					llamada: "",
+					numero_cuota: result.cuotaActual,
+				}));
+			}
+		} catch (err: any) {
+			setErrorCredito(
+				err?.response?.data?.message || "Error consultando crédito",
+			);
+			setDataCredito(null);
+			setCuotaActualInfo(null);
+			setCuotasAtrasadasInfo(null);
+			setCuotasPendientesInfo(null);
+			setCuotaSeleccionada(0);
+			setSaldoAFavorUser(0);
+			setConvenioActivoInfo(null); // 👈 AGREGA ESTO
+		} finally {
+			setLoadingCredito(false);
+		}
+	};
+	const [openBadDebt, setOpenBadDebt] = useState(false);
+	const [montoBaseBadDebt, setMontoBaseBadDebt] = useState(0);
+	// Handler que revisa el excedente ANTES del submit
+
+	useEffect(() => {
+		if (openBadDebt) {
+			console.log("Modal de incobrable abierto, monto base:", montoBaseBadDebt);
+			setMontoBaseBadDebt(montoBaseBadDebt);
+		}
+	}, [openBadDebt]);
+	const handleFormSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+
+		// ===== MANEJO DE CRÉDITO CANCELADO =====
+		if (creditoCanceladoInfo) {
+			const { monto_boleta } = formik.values;
+			const monto_cancelacion = Number(
+				creditoCanceladoInfo.cancelacion?.monto_cancelacion || 0,
+			);
+
+			if (monto_boleta < 0) {
+				toast.error("El monto de la boleta debe ser mayor a cero");
+				return;
+			}
+
+			if (monto_boleta < monto_cancelacion) {
+				const resta = monto_cancelacion - monto_boleta;
+				setMontoBaseBadDebt(resta);
+				setOpenBadDebt(true);
+				return;
+			}
+
+			formik.handleSubmit();
+			return;
+		}
+
+		// ===== VALIDACIÓN: DEBE TENER CUOTA SELECCIONADA =====
+		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+			toast.error(
+				"Por favor selecciona una cuota a pagar del menú desplegable",
+			);
+			return;
+		}
+
+		// ===== CRÉDITO ACTIVO =====
+		const { monto_boleta, otros } = formik.values;
+		const cuota = Number(dataCredito?.credito?.cuota || 0);
+		const otrosNum = Number(otros || 0);
+		const saldoAFavor = Number(dataCredito?.usuario?.saldo_a_favor || 0);
+		const montoBoleta = Number(monto_boleta || 0);
+		const moraNum = Number(mora || 0);
+		const cuotaConvenioNum = Number(
+			convenioActivoInfo?.cuotaConvenioAPagar || 0,
+		);
+
+		console.log("=== DEBUG VALORES ===");
+		console.log("Saldo a Favor:", saldoAFavor);
+		console.log("Monto Boleta:", montoBoleta);
+		console.log("Otros:", otrosNum);
+		console.log("Mora:", moraNum);
+		console.log("Cuota Convenio:", cuotaConvenioNum);
+
+		// 🔥 Calcular monto disponible total (boleta + saldo a favor)
+		const montoDisponibleTotal = montoBoleta;
+		console.log(
+			"Monto Disponible Total (boleta + saldo):",
+			montoDisponibleTotal,
+		);
+
+		// 🔥 Restar lo que se va a otros conceptos
+		const montoBoletaReal =
+			montoDisponibleTotal - otrosNum - moraNum - cuotaConvenioNum;
+		const montoBoletaSinMora =
+			montoDisponibleTotal - otrosNum - cuotaConvenioNum;
+
+		console.log("Monto Boleta Real (después de descuentos):", montoBoletaReal);
+		console.log("Monto Boleta Sin Mora:", montoBoletaSinMora);
+
+		// 🔥 Validación
+		if (montoBoletaSinMora < 0) {
+			toast.error(
+				"El saldo a favor más la boleta debe cubrir la suma de otros y convenio",
+			);
+			return;
+		}
+
+		// 👇 SIEMPRE USA LA CUOTA SELECCIONADA POR EL USUARIO
+		const cuotaAPagar: number = cuotaSeleccionada;
+
+		console.log("=== CUOTA DETERMINADA ===");
+		console.log("Cuota seleccionada por usuario:", cuotaSeleccionada);
+		console.log("Cuota a usar:", cuotaAPagar);
+
+		// ===== MANEJO DE EXCEDENTES =====
+		const montoRedondeado = Math.round(montoBoletaReal * 100) / 100;
+
+		// 🔥 Calcular abonos ya realizados en la cuota SELECCIONADA (desde endpoint)
+		const abonosRealizados = getDisplayedPartialContribution(abonosCuota);
+
+		// 🔥 Cuota menos los abonos ya hechos = lo que falta por pagar
+		const cuotaComparar = Math.max(0, cuota - abonosRealizados);
+
+		console.log("=== VALIDACIÓN DE EXCEDENTES ===");
+		console.log("Monto boleta real (redondeado):", montoRedondeado);
+		console.log("Cuota base:", cuota);
+		console.log("Abonos ya realizados:", abonosRealizados);
+		console.log("Cuota a comparar (lo que falta):", cuotaComparar);
+
+		const cuotaRedondeada = Math.round(cuotaComparar * 100) / 100;
+
+		// Si hay excedente, abre el modal
+		if (montoRedondeado > cuotaRedondeada) {
+			const excedenteCalculado = montoRedondeado - cuotaRedondeada;
+
+			console.log("=== HAY EXCEDENTE ===");
+			console.log("Excedente:", excedenteCalculado);
+
+			setModalMode("excedente");
+			setExcedente(excedenteCalculado);
+			setModalExcesoOpen(true);
+			return;
+		}
+
+		console.log("=== NO HAY EXCEDENTE - CONTINUAR CON PAGO ===");
+
+		// Si la cuota actual ya está pagada y el monto no es exacto
+		if (cuotaActualInfo?.pagada && montoRedondeado !== cuotaRedondeada) {
+			// Si tiene "otros" y la suma cuadra
+			if (otrosNum > 0 && monto_boleta === otrosNum) {
+				// Todo bien, continuar
+			} else {
+				// Hay un desbalance
+				setExcedente(montoBoletaReal);
+				setModalMode("pagada");
+				setModalExcesoOpen(true);
+				return;
+			}
+		}
+
+		// 👇 SETEA LA CUOTA EN FORMIK Y HACE SUBMIT
+		console.log("=== ANTES DEL SUBMIT ===");
+		console.log("formik.values.cuotaApagar ANTES:", formik.values.cuotaApagar);
+
+		formik.values.cuotaApagar = cuotaAPagar;
+
+		console.log(
+			"formik.values.cuotaApagar DESPUÉS:",
+			formik.values.cuotaApagar,
+		);
+		console.log("=====================");
+
+		formik.handleSubmit();
+	};
+	// Acciones del modal
+	const handleAbonoCapital = () => {
+		// ✅ Validar que haya cuota seleccionada
+		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+			toast.error("Debes seleccionar una cuota antes de continuar");
+			setModalExcesoOpen(false);
+			return;
+		}
+
+		console.log("=== ABONO A CAPITAL ===");
+		console.log("Excedente:", excedente);
+		console.log("Cuota seleccionada:", cuotaSeleccionada);
+
+		// 👇 USA LA CUOTA SELECCIONADA
+		formik.values.abono_directo_capital = excedente;
+		formik.values.cuotaApagar = cuotaSeleccionada;
+
+		setModalExcesoOpen(false);
+		formik.handleSubmit();
+	};
+	const handleAbonoCapitalDirecto = () => {
+		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+			toast.error("Debes seleccionar una cuota antes de continuar");
+			return;
+		}
+
+		const montoBoleta = Number(formik.values.monto_boleta) || 0;
+
+		console.log("=== ABONO DIRECTO A CAPITAL ===");
+		console.log("Monto boleta completo:", montoBoleta);
+		console.log("Cuota seleccionada:", cuotaSeleccionada);
+
+		formik.values.abono_directo_capital = montoBoleta;
+		formik.values.cuotaApagar = cuotaSeleccionada;
+
+		setModalExcesoOpen(false);
+		formik.handleSubmit();
+	};
+	const handleAbonoSiguienteCuota = () => {
+		// ✅ Validar que haya cuota seleccionada
+		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+			toast.error("Debes seleccionar una cuota antes de continuar");
+			setModalExcesoOpen(false);
+			return;
+		}
+
+		console.log("=== ABONO SIGUIENTE CUOTA ===");
+		console.log("Cuota seleccionada:", cuotaSeleccionada);
+
+		// 👇 USA LA CUOTA SELECCIONADA
+		formik.values.abono_directo_capital = 0;
+		formik.values.cuotaApagar = cuotaSeleccionada;
+
+		console.log("Cuota a pagar final:", formik.values.cuotaApagar);
+
+		setModalExcesoOpen(false);
+		formik.handleSubmit();
+	};
+
+	const handleAbonoOtros = () => {
+		// ✅ Validar que haya cuota seleccionada
+		if (!cuotaSeleccionada || cuotaSeleccionada === 0) {
+			toast.error("Debes seleccionar una cuota antes de continuar");
+			setModalExcesoOpen(false);
+			return;
+		}
+
+		const nuevosOtros =
+			Number(formik.values.otros || 0) + Number(excedente || 0);
+
+		console.log("=== ABONO A OTROS ===");
+		console.log("Nuevos otros:", nuevosOtros);
+		console.log("Cuota seleccionada:", cuotaSeleccionada);
+
+		// 👇 USA LA CUOTA SELECCIONADA
+		formik.values.otros = nuevosOtros;
+		formik.values.abono_directo_capital = 0;
+		formik.values.cuotaApagar = cuotaSeleccionada;
+
+		setModalExcesoOpen(false);
+		formik.handleSubmit();
+	};
+	function useLiquidatePagosInversionistas() {
+		return useMutation({
+			mutationFn: liquidatePagosInversionistasService,
+			onSuccess: () => {
+				toast.success("Pagos liquidados correctamente");
+				setModalExcesoOpen(false);
+
+				if (formik.values.credito_sifco) {
+					fetchCredito(formik.values.credito_sifco); // Refrescar crédito
+				}
+			},
+			onError: (err: any) => {
+				toast.error(getApiErrorMessage(err, "Error al liquidar pagos"));
+			},
+		});
+	}
+
+	function useReversePagosInversionistas() {
+		return useMutation({
+			mutationFn: reversePagosInversionistasService,
+			onSuccess: () => {
+				toast.success("Pago reversado correctamente");
+			},
+			onError: (err: any) => {
+				toast.error(getApiErrorMessage(err, "Error al reversar pago"));
+			},
+		});
+	}
+
+	function useRevertPaymentToPending() {
+		return useMutation({
+			mutationFn: revertPaymentToPendingService,
+			onSuccess: () => {
+				toast.success("Pago reversado a pendiente correctamente");
+				queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
+			},
+			onError: (err: any) => {
+				toast.error(
+					getApiErrorMessage(err, "Error al reversar pago a pendiente"),
+				);
+			},
+		});
+	}
+
+	function useRevalidatePayment() {
+		return useMutation({
+			mutationFn: revalidatePaymentService,
+			onSuccess: () => {
+				toast.success("Pago revalidado correctamente");
+				queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
+			},
+			onError: (err: any) => {
+				toast.error(getApiErrorMessage(err, "Error al revalidar pago"));
+			},
+		});
+	}
+
+	function useProcessInvestors() {
+		return useMutation({
+			mutationFn: processInvestorsService,
+			onSuccess: () => {
+				toast.success("Inversionistas procesados correctamente");
+				queryClient.invalidateQueries({ queryKey: ["pagos-inversionistas"] });
+			},
+			onError: (err: any) => {
+				toast.error(
+					getApiErrorMessage(err, "Error al procesar inversionistas"),
+				);
+			},
+		});
+	}
+
+	const liquidatePago = useLiquidatePagosInversionistas();
+	const [liquidandoId, setLiquidandoId] = useState<number | null>(null);
+	function handleLiquidar(pago_id: number, credito_id: number, cuota?: number) {
+		try {
+			// eslint-disable-next-line react-hooks/rules-of-hooks
+
+			setLiquidandoId(pago_id);
+			liquidatePago.mutate(
+				{ pago_id, credito_id, cuota },
+				{
+					onSettled: () => setLiquidandoId(null),
+				},
+			);
+
+			// Aquí podrías hacer un refetch/queryClient.invalidateQueries para actualizar
+		} catch (error) {
+			toast.error(getApiErrorMessage(error, "Error al liquidar el pago"));
+			console.error("Error liquidando pago:", error);
+		}
+	}
+	const reversePago = useReversePagosInversionistas();
+	const revertPaymentToPending = useRevertPaymentToPending();
+	const revalidatePayment = useRevalidatePayment();
+	const processInvestors = useProcessInvestors();
+
+	function useRecalcularPagos() {
+		return useMutation({
+			mutationFn: recalcularPagosService,
+			onSuccess: () => {
+				toast.success("Pagos recalculados correctamente");
+				queryClient.invalidateQueries({ queryKey: ["pagosByCredito"] });
+			},
+			onError: (err: any) => {
+				toast.error(getApiErrorMessage(err, "Error al recalcular pagos"));
+			},
+		});
+	}
+
+	const recalcularPagos = useRecalcularPagos();
+
+	function handleRecalcularPagos(
+		numero_credito_sifco: string,
+		numero_cuota: number,
+	) {
+		recalcularPagos.mutate({ numero_credito_sifco, numero_cuota }, {});
+	}
+
+	// Handler:
+	function handleReverse(
+		pago_id: number,
+		credito_id: number,
+		reverseAccounting: boolean,
+	) {
+		reversePago.mutate({ pago_id, credito_id, reverseAccounting }, {});
+	}
+
+	// Handler:
+	function handleRevertToPending(pago_id: number, credito_id: number) {
+		revertPaymentToPending.mutate({ pago_id, credito_id }, {});
+	}
+
+	// Handler:
+	function handleRevalidatePayment(pago_id: number, credito_id: number) {
+		revalidatePayment.mutate({ pago_id, credito_id }, {});
+	}
+
+	// Handler:
+	function handleProcessInvestors(
+		pago_id: number,
+		credito_id: number,
+		fechaVencimiento?: string,
+	) {
+		const fecha_periodo = fechaVencimiento
+			? new Date(fechaVencimiento).toISOString()
+			: undefined;
+		processInvestors.mutate({ pago_id, credito_id, fecha_periodo }, {});
+	}
+
+	async function handleResetCredito() {
+		console.log(cuotaSeleccionada, " cuotaSeleccionada");
+		const cuotaApagarValue =
+			typeof cuotaSeleccionada === "number" ? cuotaSeleccionada : 0;
+		formik.setFieldValue("cuotaApagar", cuotaApagarValue);
+		if (archivosParaSubir.length === 0) {
+			toast.error("Debes seleccionar al menos un archivo de boleta (máx. 3)");
+			return;
+		}
+		if (archivosParaSubir.length > 3) {
+			toast.error("Solo puedes subir hasta 3 archivos de boleta");
+			return;
+		}
+
+		// Sube los archivos y llena el array de filenames
+		const url_boletas: string[] = [];
+		for (const archivo of archivosParaSubir) {
+			const { filename } = await uploadFileService(archivo);
+			url_boletas.push(filename);
+		}
+
+		resetCredit(
+			{
+				creditId: Number(creditoCanceladoInfo?.credito.credito_id),
+				montoBoleta: formik.values.monto_boleta,
+				url_boletas: url_boletas,
+				cuota: cuotaActualInfo?.numero || 0,
+				banco_id: formik.values.banco_id,
+				montoIncobrable: montoBaseBadDebt,
+				numeroAutorizacion: formik.values.numeroAutorizacion || undefined,
+			},
+			{
+				onSuccess: (data) => {
+					toast.success(data.message || "Cancelacion realizada exitosamente");
+
+					formik.resetForm();
+					setDataCredito(null);
+					setCuotaActualInfo(null);
+					setCuotasAtrasadasInfo(null);
+					setPermiteAbonoCapital(false);
+					setCuotasPendientesInfo(null);
+					setModalExcesoOpen(false);
+					setExcedente(0);
+					setFileToUpload(null);
+					setArchivosParaSubir([]);
+					setCreditoCanceladoInfo(null);
+					setResetBuscador(true);
+
+					// Refetch del credito para ver el estado actualizado
+					if (formik.values.credito_sifco) {
+						fetchCredito(formik.values.credito_sifco);
+					}
+				},
+				onError: (error) => {
+					toast.error(getApiErrorMessage(error, "Error al reiniciar crédito"));
+				},
+			},
+		);
+	}
+	return {
+		formik,
+		fetchCredito,
+		dataCredito,
+		loadingCredito,
+		errorCredito,
+		cuotaActualInfo,
+		cuotasAtrasadasInfo,
+		permiteAbonoCapital,
+		cuotasPendientesInfo,
+		useReversePagosInversionistas,
+		// Para el modal de excedente:
+		handleFormSubmit,
+		modalExcesoOpen,
+		setModalExcesoOpen,
+		excedente,
+		handleAbonoCapital,
+		handleAbonoCapitalDirecto,
+		handleAbonoSiguienteCuota,
+		handleAbonoOtros,
+		useLiquidatePagosInversionistas,
+		modalMode,
+		handleLiquidar,
+		liquidandoId,
+		handleReverse,
+		handleRevertToPending,
+		handleRevalidatePayment,
+		reversePago,
+		revertPaymentToPending,
+		revalidatePayment,
+		processInvestors,
+		handleProcessInvestors,
+		recalcularPagos,
+		handleRecalcularPagos,
+		setCuotaSeleccionada,
+		setFileToUpload,
+		fileToUpload,
+		saldo_a_favorUser,
+		creditoCanceladoInfo,
+		openBadDebt,
+		setOpenBadDebt,
+		montoBaseBadDebt,
+		archivosParaSubir,
+		handleResetCredito,
+		setArchivosParaSubir,
+		resetBuscador,
+		setResetBuscador,
+		mora,
+		convenioActivoInfo,
+		cuotaSeleccionada,
+		abonosCuota,
+	};
 }

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -248,6 +248,8 @@ const [convenioActivoInfo, setConvenioActivoInfo] = useState<{
         setSaldoAFavorUser(0);
         setFileToUpload(null);
         setArchivosParaSubir([]);
+        formik.resetForm();
+        setResetBuscador(true);
         setErrorCredito(
           "El crédito ya está cancelado y solo está disponible para consulta en el historial."
         );

--- a/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts
@@ -737,7 +737,7 @@ const handleAbonoOtros = () => {
     processInvestors.mutate({ pago_id, credito_id, fecha_periodo }, {});
   }
 
-async function handleResetCredito() {
+async function handleResetCredito(montoIncobrable = 0) {
  
   console.log(cuotaSeleccionada, " cuotaSeleccionada");
         const cuotaApagarValue =
@@ -765,7 +765,7 @@ async function handleResetCredito() {
     url_boletas: url_boletas,
     cuota: cuotaActualInfo?.numero || 0,
     banco_id: formik.values.banco_id,
-    montoIncobrable: montoBaseBadDebt,
+    montoIncobrable: montoIncobrable,
     numeroAutorizacion: formik.values.numeroAutorizacion || undefined,
   }, {
     onSuccess: (data) => {

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -46,6 +46,30 @@ describe("resolveCreditContractSummary", () => {
 			),
 		).toEqual({ principal: "100.00", installment: "20.00" });
 	});
+
+	it("prefers an authoritative cancelled summary including off-schedule capital", () => {
+		expect(
+			resolveCreditContractSummary(
+				"CANCELADO",
+				[{ abono_capital: "30000.00", cuota: "2200.00" }],
+				"0.00",
+				"0.00",
+				{ originalPrincipal: "51875.08", installment: "2323.10" },
+			),
+		).toEqual({ principal: "51875.08", installment: "2323.10" });
+	});
+
+	it("falls back to paid rows when authoritative values are zero", () => {
+		expect(
+			resolveCreditContractSummary(
+				"CANCELADO",
+				[{ abono_capital: "30000.00", cuota: "2200.00" }],
+				"0.00",
+				"0.00",
+				{ originalPrincipal: "0.00", installment: "0" },
+			),
+		).toEqual({ principal: "30000.00", installment: "2200.00" });
+	});
 });
 
 describe("countRemainingInstallments", () => {

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -36,7 +36,7 @@ describe("resolveCreditContractSummary", () => {
 		).toEqual({ principal: "51875.08", installment: "2323.10" });
 	});
 
-	it("uses fallbacks without paid principal", () => {
+	it("returns no principal without paid principal or reset evidence", () => {
 		expect(
 			resolveCreditContractSummary(
 				"CANCELADO",
@@ -44,7 +44,7 @@ describe("resolveCreditContractSummary", () => {
 				"100.00",
 				"20.00",
 			),
-		).toEqual({ principal: "100.00", installment: "20.00" });
+		).toEqual({ principal: null, installment: "20.00" });
 	});
 
 	it("prefers an authoritative cancelled summary including off-schedule capital", () => {
@@ -63,12 +63,35 @@ describe("resolveCreditContractSummary", () => {
 		expect(
 			resolveCreditContractSummary(
 				"CANCELADO",
-				[{ abono_capital: "30000.00", cuota: "2200.00" }],
+				[
+					{
+						abono_capital: "30000.00",
+						cuota: "2200.00",
+						validationStatus: "reset",
+					},
+				],
 				"0.00",
 				"0.00",
 				{ originalPrincipal: "0.00", installment: "0" },
 			),
 		).toEqual({ principal: "30000.00", installment: "2200.00" });
+	});
+
+	it("returns no principal for a validated partial payment without reset evidence", () => {
+		expect(
+			resolveCreditContractSummary(
+				"CANCELADO",
+				[
+					{
+						abono_capital: "30000.00",
+						cuota: "2200.00",
+						validationStatus: "validated",
+					},
+				],
+				"51875.08",
+				"2323.10",
+			),
+		).toEqual({ principal: null, installment: "2323.10" });
 	});
 });
 

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -93,6 +93,24 @@ describe("resolveCreditContractSummary", () => {
 			),
 		).toEqual({ principal: null, installment: "2323.10" });
 	});
+
+	it("preserves an authoritative null instead of reconstructing principal", () => {
+		expect(
+			resolveCreditContractSummary(
+				"CANCELADO",
+				[
+					{
+						abono_capital: "30000.00",
+						cuota: "2200.00",
+						validationStatus: "reset",
+					},
+				],
+				"0.00",
+				"0.00",
+				{ originalPrincipal: null, installment: "2200.00" },
+			),
+		).toEqual({ principal: null, installment: "2200.00" });
+	});
 });
 
 describe("countRemainingInstallments", () => {

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -1,10 +1,42 @@
 import { describe, expect, it } from "bun:test";
+import { resolve } from "node:path";
 import {
 	countRemainingInstallments,
 	countScheduledPaidInstallments,
 	resolveCreditContractSummary,
 	resolveInstallmentAmount,
+	resolveOperationalInstallment,
 } from "./cobros-credit-detail";
+
+describe("resolveOperationalInstallment", () => {
+	it("zeros cancelled installments", () => {
+		expect(resolveOperationalInstallment("CANCELADO", "2323.10")).toBe("0.00");
+	});
+
+	it("preserves active installments", () => {
+		expect(resolveOperationalInstallment("ACTIVO", "2323.10")).toBe("2323.10");
+	});
+
+	it("keeps the historical amount limited to the contractual display", async () => {
+		const [routerSource, detailSource] = await Promise.all([
+			Bun.file(resolve(import.meta.dir, "../routers/cobros.ts")).text(),
+			Bun.file(
+				resolve(import.meta.dir, "../../../web/src/routes/cobros/$id.tsx"),
+			).text(),
+		]);
+
+		expect(routerSource).toMatch(
+			/cuotaMensual:\s*resolveOperationalInstallment\(\s*statusCredit,\s*contractSummary\.installment,?\s*\)/,
+		);
+		expect(routerSource).toContain(
+			"cuotaMensualHistorica: contractSummary.installment",
+		);
+		expect(detailSource.match(/caso\.cuotaMensualHistorica/g)).toHaveLength(1);
+		expect(detailSource).toContain(
+			"caso.cuotaMensualHistorica ?? caso.cuotaMensual",
+		);
+	});
+});
 
 describe("resolveCreditContractSummary", () => {
 	it("preserves active fallbacks", () => {

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -4,6 +4,7 @@ import {
 	countRemainingInstallments,
 	countScheduledPaidInstallments,
 	resolveCreditContractSummary,
+	resolveHistoricalInstallment,
 	resolveInstallmentAmount,
 	resolveOperationalInstallment,
 } from "./cobros-credit-detail";
@@ -31,10 +32,22 @@ describe("resolveOperationalInstallment", () => {
 		expect(routerSource).toContain(
 			"cuotaMensualHistorica: contractSummary.installment",
 		);
-		expect(detailSource.match(/caso\.cuotaMensualHistorica/g)).toHaveLength(1);
+		expect(routerSource).toContain("resolveHistoricalInstallment(");
+		expect(routerSource).not.toContain(
+			"creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual",
+		);
+		expect(detailSource.match(/caso\.cuotaMensualHistorica/g)).toHaveLength(2);
 		expect(detailSource).toContain(
 			"caso.cuotaMensualHistorica ?? caso.cuotaMensual",
 		);
+	});
+});
+
+describe("resolveHistoricalInstallment", () => {
+	it("uses the cartera installment only when it is positive", () => {
+		expect(resolveHistoricalInstallment("2323.10", "1900.00")).toBe("2323.10");
+		expect(resolveHistoricalInstallment("0.00", "1900.00")).toBe("1900.00");
+		expect(resolveHistoricalInstallment(null, "1900.00")).toBe("1900.00");
 	});
 });
 

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -1,8 +1,69 @@
 import { describe, expect, it } from "bun:test";
 import {
+	countRemainingInstallments,
 	countScheduledPaidInstallments,
+	resolveCreditContractSummary,
 	resolveInstallmentAmount,
 } from "./cobros-credit-detail";
+
+describe("resolveCreditContractSummary", () => {
+	it("preserves active fallbacks", () => {
+		expect(
+			resolveCreditContractSummary(
+				"ACTIVO",
+				[{ abono_capital: "9.99" }],
+				"100.00",
+				"20.00",
+			),
+		).toEqual({ principal: "100.00", installment: "20.00" });
+	});
+
+	it("reconstructs cancelled contract values", () => {
+		expect(
+			resolveCreditContractSummary(
+				"CANCELADO",
+				[
+					{ abono_capital: "30000.08", cuota: "2200.00" },
+					{
+						abono_capital: "21875.00",
+						cuota: "2323.10",
+						validationStatus: "reset",
+					},
+				],
+				"0.00",
+				"0.00",
+			),
+		).toEqual({ principal: "51875.08", installment: "2323.10" });
+	});
+
+	it("uses fallbacks without paid principal", () => {
+		expect(
+			resolveCreditContractSummary(
+				"CANCELADO",
+				[{ abono_capital: "0.00" }],
+				"100.00",
+				"20.00",
+			),
+		).toEqual({ principal: "100.00", installment: "20.00" });
+	});
+});
+
+describe("countRemainingInstallments", () => {
+	it("returns zero for cancelled contracts", () => {
+		expect(
+			countRemainingInstallments("CANCELADO", 48, Array(22).fill({}), true),
+		).toBe(0);
+	});
+
+	it("preserves the active formula and clamps at zero", () => {
+		expect(
+			countRemainingInstallments("ACTIVO", 48, Array(22).fill({}), true),
+		).toBe(27);
+		expect(
+			countRemainingInstallments("ACTIVO", 10, Array(22).fill({}), false),
+		).toBe(0);
+	});
+});
 
 describe("resolveInstallmentAmount", () => {
 	it("prefers the row amount, including zero", () => {

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "bun:test";
+import { countScheduledPaidInstallments } from "./cobros-credit-detail";
+
+describe("countScheduledPaidInstallments", () => {
+	it("excludes only reset payments", () => {
+		expect(
+			countScheduledPaidInstallments([
+				{ validationStatus: "validated" },
+				{ validationStatus: "pending" },
+				{ validationStatus: null },
+				{ validationStatus: "reset" },
+			]),
+		).toBe(3);
+	});
+
+	it("returns zero without rows", () => {
+		expect(countScheduledPaidInstallments(null)).toBe(0);
+		expect(countScheduledPaidInstallments(undefined)).toBe(0);
+	});
+});

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts
@@ -1,5 +1,20 @@
 import { describe, expect, it } from "bun:test";
-import { countScheduledPaidInstallments } from "./cobros-credit-detail";
+import {
+	countScheduledPaidInstallments,
+	resolveInstallmentAmount,
+} from "./cobros-credit-detail";
+
+describe("resolveInstallmentAmount", () => {
+	it("prefers the row amount, including zero", () => {
+		expect(resolveInstallmentAmount("125.50", "200.00")).toBe("125.50");
+		expect(resolveInstallmentAmount("0", "200.00")).toBe("0");
+	});
+
+	it("falls back to the current credit amount", () => {
+		expect(resolveInstallmentAmount(null, "200.00")).toBe("200.00");
+		expect(resolveInstallmentAmount(undefined, "200.00")).toBe("200.00");
+	});
+});
 
 describe("countScheduledPaidInstallments", () => {
 	it("excludes only reset payments", () => {

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -11,6 +11,13 @@ export function resolveInstallmentAmount(
 	return rowAmount ?? currentCreditAmount;
 }
 
+export function resolveOperationalInstallment(
+	statusCredit: string,
+	historicalInstallment: string,
+): string {
+	return statusCredit === "CANCELADO" ? "0.00" : historicalInstallment;
+}
+
 type CreditDetailRow = {
 	abono_capital?: string | null;
 	cuota?: string | null;

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -1,0 +1,5 @@
+export function countScheduledPaidInstallments(
+	rows: readonly { validationStatus?: string | null }[] | null | undefined,
+): number {
+	return rows?.filter((row) => row.validationStatus !== "reset").length ?? 0;
+}

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -18,6 +18,16 @@ export function resolveOperationalInstallment(
 	return statusCredit === "CANCELADO" ? "0.00" : historicalInstallment;
 }
 
+export function resolveHistoricalInstallment(
+	carteraInstallment: string | null | undefined,
+	opportunityInstallment: string | null | undefined,
+): string {
+	const carteraAmount = Number(carteraInstallment);
+	return Number.isFinite(carteraAmount) && carteraAmount > 0
+		? carteraInstallment ?? "0.00"
+		: opportunityInstallment ?? "0.00";
+}
+
 type CreditDetailRow = {
 	abono_capital?: string | null;
 	cuota?: string | null;

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -54,6 +54,8 @@ export function resolveCreditContractSummary(
 		toCents(authoritativeSummary.originalPrincipal) > 0
 			? authoritativeSummary.originalPrincipal
 			: undefined;
+	const hasAuthoritativeNullPrincipal =
+		authoritativeSummary?.originalPrincipal === null;
 	const authoritativeInstallment =
 		authoritativeSummary?.installment &&
 		toCents(authoritativeSummary.installment) > 0
@@ -61,11 +63,12 @@ export function resolveCreditContractSummary(
 			: undefined;
 
 	return {
-		principal:
-			authoritativePrincipal ??
-			(hasResetEvidence && principalCents > 0
-				? fromCents(principalCents)
-				: null),
+		principal: hasAuthoritativeNullPrincipal
+			? null
+			: authoritativePrincipal ??
+				(hasResetEvidence && principalCents > 0
+					? fromCents(principalCents)
+					: null),
 		installment:
 			authoritativeInstallment ??
 			(hasResetEvidence ? resetInstallment : undefined) ??

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -10,3 +10,61 @@ export function resolveInstallmentAmount(
 ): string {
 	return rowAmount ?? currentCreditAmount;
 }
+
+type CreditDetailRow = {
+	abono_capital?: string | null;
+	cuota?: string | null;
+	validationStatus?: string | null;
+};
+
+function toCents(amount: string | null | undefined): number {
+	const [whole = "0", fraction = ""] = (amount ?? "0").split(".");
+	return Number(whole) * 100 + Number(fraction.padEnd(2, "0").slice(0, 2));
+}
+
+function fromCents(cents: number): string {
+	return `${Math.floor(cents / 100)}.${String(cents % 100).padStart(2, "0")}`;
+}
+
+export function resolveCreditContractSummary(
+	statusCredit: string,
+	paidRows: readonly CreditDetailRow[] | null | undefined,
+	fallbackPrincipal: string,
+	fallbackInstallment: string,
+): { principal: string; installment: string } {
+	if (statusCredit !== "CANCELADO") {
+		return { principal: fallbackPrincipal, installment: fallbackInstallment };
+	}
+
+	const rows = paidRows ?? [];
+	const principalCents = rows.reduce(
+		(total, row) => total + toCents(row.abono_capital),
+		0,
+	);
+	const resetInstallment = rows.find(
+		(row) => row.validationStatus === "reset" && row.cuota != null,
+	)?.cuota;
+	const installment =
+		resetInstallment ?? rows.find((row) => row.cuota != null)?.cuota;
+
+	return {
+		principal:
+			principalCents > 0 ? fromCents(principalCents) : fallbackPrincipal,
+		installment: installment ?? fallbackInstallment,
+	};
+}
+
+export function countRemainingInstallments(
+	statusCredit: string,
+	totalInstallments: number,
+	paidRows: readonly { validationStatus?: string | null }[] | null | undefined,
+	initialInstallmentPaid: boolean,
+): number {
+	if (statusCredit === "CANCELADO") return 0;
+	return Math.max(
+		0,
+		totalInstallments -
+			countScheduledPaidInstallments(paidRows) +
+			(initialInstallmentPaid ? 1 : 0),
+	);
+}

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -31,6 +31,10 @@ export function resolveCreditContractSummary(
 	paidRows: readonly CreditDetailRow[] | null | undefined,
 	fallbackPrincipal: string,
 	fallbackInstallment: string,
+	authoritativeSummary?: {
+		originalPrincipal?: string | null;
+		installment?: string | null;
+	},
 ): { principal: string; installment: string } {
 	if (statusCredit !== "CANCELADO") {
 		return { principal: fallbackPrincipal, installment: fallbackInstallment };
@@ -49,8 +53,18 @@ export function resolveCreditContractSummary(
 
 	return {
 		principal:
-			principalCents > 0 ? fromCents(principalCents) : fallbackPrincipal,
-		installment: installment ?? fallbackInstallment,
+			(authoritativeSummary?.originalPrincipal &&
+			toCents(authoritativeSummary.originalPrincipal) > 0
+				? authoritativeSummary.originalPrincipal
+				: undefined) ||
+			(principalCents > 0 ? fromCents(principalCents) : fallbackPrincipal),
+		installment:
+			(authoritativeSummary?.installment &&
+			toCents(authoritativeSummary.installment) > 0
+				? authoritativeSummary.installment
+				: undefined) ||
+			installment ||
+			fallbackInstallment,
 	};
 }
 

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -35,12 +35,13 @@ export function resolveCreditContractSummary(
 		originalPrincipal?: string | null;
 		installment?: string | null;
 	},
-): { principal: string; installment: string } {
+): { principal: string | null; installment: string } {
 	if (statusCredit !== "CANCELADO") {
 		return { principal: fallbackPrincipal, installment: fallbackInstallment };
 	}
 
 	const rows = paidRows ?? [];
+	const hasResetEvidence = rows.some((row) => row.validationStatus === "reset");
 	const principalCents = rows.reduce(
 		(total, row) => total + toCents(row.abono_capital),
 		0,
@@ -48,22 +49,26 @@ export function resolveCreditContractSummary(
 	const resetInstallment = rows.find(
 		(row) => row.validationStatus === "reset" && row.cuota != null,
 	)?.cuota;
-	const installment =
-		resetInstallment ?? rows.find((row) => row.cuota != null)?.cuota;
+	const authoritativePrincipal =
+		authoritativeSummary?.originalPrincipal &&
+		toCents(authoritativeSummary.originalPrincipal) > 0
+			? authoritativeSummary.originalPrincipal
+			: undefined;
+	const authoritativeInstallment =
+		authoritativeSummary?.installment &&
+		toCents(authoritativeSummary.installment) > 0
+			? authoritativeSummary.installment
+			: undefined;
 
 	return {
 		principal:
-			(authoritativeSummary?.originalPrincipal &&
-			toCents(authoritativeSummary.originalPrincipal) > 0
-				? authoritativeSummary.originalPrincipal
-				: undefined) ||
-			(principalCents > 0 ? fromCents(principalCents) : fallbackPrincipal),
+			authoritativePrincipal ??
+			(hasResetEvidence && principalCents > 0
+				? fromCents(principalCents)
+				: null),
 		installment:
-			(authoritativeSummary?.installment &&
-			toCents(authoritativeSummary.installment) > 0
-				? authoritativeSummary.installment
-				: undefined) ||
-			installment ||
+			authoritativeInstallment ??
+			(hasResetEvidence ? resetInstallment : undefined) ??
 			fallbackInstallment,
 	};
 }

--- a/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
+++ b/apps/crm/apps/server/src/lib/cobros-credit-detail.ts
@@ -3,3 +3,10 @@ export function countScheduledPaidInstallments(
 ): number {
 	return rows?.filter((row) => row.validationStatus !== "reset").length ?? 0;
 }
+
+export function resolveInstallmentAmount(
+	rowAmount: string | null | undefined,
+	currentCreditAmount: string,
+): string {
+	return rowAmount ?? currentCreditAmount;
+}

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -44,6 +44,7 @@ import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-perce
 import {
 	countRemainingInstallments,
 	resolveCreditContractSummary,
+	resolveHistoricalInstallment,
 	resolveInstallmentAmount,
 	resolveOperationalInstallment,
 } from "../lib/cobros-credit-detail";
@@ -2245,7 +2246,10 @@ export const cobrosRouter = {
 					statusCredit,
 					creditoCompleto.cuotasPagadas,
 					creditoCompleto.credito.capital ?? creditoCompleto.credito.deudatotal ?? "0.00",
-					creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual || "0.00",
+					resolveHistoricalInstallment(
+						creditoCompleto.credito.cuota,
+						oportunidadData?.cuotaMensual,
+					),
 					creditoCompleto.contractSummary,
 				);
 

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -42,7 +42,8 @@ import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
 import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
 import {
-	countScheduledPaidInstallments,
+	countRemainingInstallments,
+	resolveCreditContractSummary,
 	resolveInstallmentAmount,
 } from "../lib/cobros-credit-detail";
 import {
@@ -2187,16 +2188,13 @@ export const cobrosRouter = {
 				];
 				const cuota0 = todasLasCuotas.find((c) => c.numero_cuota === 0);
 				const fechaInicioCuota0 = cuota0?.fecha_vencimiento || null;
-				const cuotasPagadasCount = countScheduledPaidInstallments(
-					creditoCompleto.cuotasPagadas,
-				);
 				const totalCuotas = creditoCompleto.credito.plazo || 0;
-				let cuotasRestantes = totalCuotas;
-				if (cuota0?.pagado) {
-					cuotasRestantes = totalCuotas - cuotasPagadasCount + 1;
-				} else {
-					cuotasRestantes = totalCuotas - cuotasPagadasCount;
-				}
+				const cuotasRestantes = countRemainingInstallments(
+					creditoCompleto.credito.statusCredit,
+					totalCuotas,
+					creditoCompleto.cuotasPagadas,
+					Boolean(cuota0?.pagado),
+				);
 
 				// 6. Mapear datos correctamente
 				const cuotasAtrasadas = creditoCompleto.cuotasAtrasadas?.length || 0;
@@ -2242,6 +2240,12 @@ export const cobrosRouter = {
 				else if (statusCredit === "INCOBRABLE") estadoContrato = "incobrable";
 				else if (statusCredit === "PENDIENTE_CANCELACION")
 					estadoContrato = "pendiente_cancelacion";
+				const contractSummary = resolveCreditContractSummary(
+					statusCredit,
+					creditoCompleto.cuotasPagadas,
+					creditoCompleto.credito.capital ?? creditoCompleto.credito.deudatotal ?? "0.00",
+					creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual || "0.00",
+				);
 
 				return {
 					// ID del caso de cobros (si existe)
@@ -2270,12 +2274,8 @@ export const cobrosRouter = {
 					etiquetas: casoCobro?.etiquetas || [],
 
 					// Datos del contrato (cartera primero, fallback a nuestra BD)
-					montoFinanciado:
-						creditoCompleto.credito.capital ??
-						creditoCompleto.credito.deudatotal ??
-						"0.00",
-					cuotaMensual:
-						creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual,
+					montoFinanciado: contractSummary.principal,
+					cuotaMensual: contractSummary.installment,
 					numeroCuotas: creditoCompleto.credito.plazo,
 					fechaInicio: creditoCompleto.credito.fecha_creacion,
 					diaPagoMensual,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -407,9 +407,7 @@ export const cobrosRouter = {
 			if (isCarteraBackEnabled()) {
 				try {
 					console.log(
-						`[Cobros] Obteniendo stats desde Cartera-Back endpoint /stats${
-							input?.emailCobrador ? `?email=${input.emailCobrador}` : ""
-						}`,
+						`[Cobros] Obteniendo stats desde Cartera-Back endpoint /stats${input?.emailCobrador ? `?email=${input.emailCobrador}` : ""}`,
 					);
 
 					// Usar el nuevo endpoint de stats de cartera-back
@@ -749,15 +747,7 @@ export const cobrosRouter = {
 					}
 
 					console.log(
-						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${
-							Math.floor((input.offset || 0) / (input.limit || 50)) + 1
-						}, perPage=${
-							input.limit || 50
-						}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${
-							input.time
-						}, emailCobrador=${input.emailCobrador}, search=${
-							input.searchTerm || ""
-						}, etiquetas=${input.etiquetas?.join(",") || ""}`,
+						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${Math.floor((input.offset || 0) / (input.limit || 50)) + 1}, perPage=${input.limit || 50}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${input.time}, emailCobrador=${input.emailCobrador}, search=${input.searchTerm || ""}, etiquetas=${input.etiquetas?.join(",") || ""}`,
 					);
 
 					// Si hay filtro de etiquetas, primero resolver en CRM la lista de
@@ -811,11 +801,7 @@ export const cobrosRouter = {
 							.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 							.where(
 								and(
-									sql`LOWER(REPLACE(REPLACE(${
-										vehicles.licensePlate
-									}, '-', ''), ' ', '')) LIKE ${
-										"%" + searchTerm.toLowerCase().replace(/[\s-]+/g, "") + "%"
-									}`,
+									sql`LOWER(REPLACE(REPLACE(${vehicles.licensePlate}, '-', ''), ' ', '')) LIKE ${"%" + searchTerm.toLowerCase().replace(/[\s-]+/g, "") + "%"}`,
 									sql`${opportunities.numeroSifco} IS NOT NULL`,
 								),
 							);
@@ -1538,10 +1524,7 @@ export const cobrosRouter = {
 			// Notificar al nuevo cobrador asignado
 			await createNotification({
 				titulo: "Caso de cobro asignado",
-				descripcion: `Se te ha asignado el caso de cobro #${input.casoCobroId.slice(
-					0,
-					8,
-				)}`,
+				descripcion: `Se te ha asignado el caso de cobro #${input.casoCobroId.slice(0, 8)}`,
 				type: "aviso",
 				createdBy: context.user.id,
 				createdByRole: context.user.role,
@@ -2100,9 +2083,8 @@ export const cobrosRouter = {
 						montoAsegurado: opp.vehiculoMontoAsegurado,
 					};
 					leadInfo = {
-						nombre: `${opp.leadFirstName || ""} ${
-							opp.leadLastName || ""
-						}`.trim(),
+						nombre:
+							`${opp.leadFirstName || ""} ${opp.leadLastName || ""}`.trim(),
 						email: opp.leadEmail,
 						telefono: opp.leadTelefono,
 					};
@@ -2457,9 +2439,7 @@ export const cobrosRouter = {
 				};
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo historial de pagos: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					message: `Error obteniendo historial de pagos: ${error instanceof Error ? error.message : String(error)}`,
 				});
 			}
 		}),
@@ -2544,9 +2524,7 @@ export const cobrosRouter = {
 				};
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo crédito de cartera-back: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					message: `Error obteniendo crédito de cartera-back: ${error instanceof Error ? error.message : String(error)}`,
 				});
 			}
 		}),
@@ -2653,8 +2631,8 @@ export const cobrosRouter = {
 							inv.reinversion ?? inv.tipo_reinversion !== "sin_reinversion",
 						tipoReinversion: inv.tipo_reinversion ?? "sin_reinversion",
 						banco: inv.banco_id
-							? bancosMap.get(inv.banco_id) ?? null
-							: inv.banco ?? null,
+							? (bancosMap.get(inv.banco_id) ?? null)
+							: (inv.banco ?? null),
 						tipoCuenta: inv.tipo_cuenta ?? null,
 						numeroCuenta: inv.numero_cuenta ?? null,
 						moneda: inv.moneda ?? "quetzales",
@@ -2675,9 +2653,7 @@ export const cobrosRouter = {
 					error instanceof Error ? error.stack : "No stack",
 				);
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo inversionistas: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					message: `Error obteniendo inversionistas: ${error instanceof Error ? error.message : String(error)}`,
 				});
 			}
 		}),
@@ -2760,9 +2736,7 @@ export const cobrosRouter = {
 				};
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo detalle de inversionista: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					message: `Error obteniendo detalle de inversionista: ${error instanceof Error ? error.message : String(error)}`,
 				});
 			}
 		}),
@@ -2816,9 +2790,7 @@ export const cobrosRouter = {
 				*/
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo inversionistas del crédito: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					message: `Error obteniendo inversionistas del crédito: ${error instanceof Error ? error.message : String(error)}`,
 				});
 			}
 		}),
@@ -2888,9 +2860,7 @@ export const cobrosRouter = {
 					error instanceof Error ? error.stack : "No stack",
 				);
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo asesores: ${
-						error instanceof Error ? error.message : String(error)
-					}`,
+					message: `Error obteniendo asesores: ${error instanceof Error ? error.message : String(error)}`,
 				});
 			}
 		}),
@@ -3372,11 +3342,7 @@ export const cobrosRouter = {
 					.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 					.where(
 						and(
-							sql`LOWER(REPLACE(REPLACE(${
-								vehicles.licensePlate
-							}, '-', ''), ' ', '')) LIKE ${
-								"%" + searchTerm.toLowerCase().replaceAll(/[\s-]+/g, "") + "%"
-							}`,
+							sql`LOWER(REPLACE(REPLACE(${vehicles.licensePlate}, '-', ''), ' ', '')) LIKE ${"%" + searchTerm.toLowerCase().replaceAll(/[\s-]+/g, "") + "%"}`,
 							sql`${opportunities.numeroSifco} IS NOT NULL`,
 						),
 					);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -41,6 +41,7 @@ import {
 import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
 import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
+import { countScheduledPaidInstallments } from "../lib/cobros-credit-detail";
 import {
 	PLANTILLAS_MENSAJES,
 	interpolar as interpolarPlantilla,
@@ -2179,7 +2180,9 @@ export const cobrosRouter = {
 				];
 				const cuota0 = todasLasCuotas.find((c) => c.numero_cuota === 0);
 				const fechaInicioCuota0 = cuota0?.fecha_vencimiento || null;
-				const cuotasPagadasCount = creditoCompleto.cuotasPagadas?.length || 0;
+				const cuotasPagadasCount = countScheduledPaidInstallments(
+					creditoCompleto.cuotasPagadas,
+				);
 				const totalCuotas = creditoCompleto.credito.plazo || 0;
 				let cuotasRestantes = totalCuotas;
 				if (cuota0?.pagado) {

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -41,7 +41,10 @@ import {
 import { quotations } from "../db/schema/quotations";
 import { vehicles } from "../db/schema/vehicles";
 import { recalculateCobrosCapitalPercentages } from "../lib/cobros-capital-percentages";
-import { countScheduledPaidInstallments } from "../lib/cobros-credit-detail";
+import {
+	countScheduledPaidInstallments,
+	resolveInstallmentAmount,
+} from "../lib/cobros-credit-detail";
 import {
 	PLANTILLAS_MENSAJES,
 	interpolar as interpolarPlantilla,
@@ -404,7 +407,9 @@ export const cobrosRouter = {
 			if (isCarteraBackEnabled()) {
 				try {
 					console.log(
-						`[Cobros] Obteniendo stats desde Cartera-Back endpoint /stats${input?.emailCobrador ? `?email=${input.emailCobrador}` : ""}`,
+						`[Cobros] Obteniendo stats desde Cartera-Back endpoint /stats${
+							input?.emailCobrador ? `?email=${input.emailCobrador}` : ""
+						}`,
 					);
 
 					// Usar el nuevo endpoint de stats de cartera-back
@@ -744,7 +749,15 @@ export const cobrosRouter = {
 					}
 
 					console.log(
-						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${Math.floor((input.offset || 0) / (input.limit || 50)) + 1}, perPage=${input.limit || 50}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${input.time}, emailCobrador=${input.emailCobrador}, search=${input.searchTerm || ""}, etiquetas=${input.etiquetas?.join(",") || ""}`,
+						`[Cobros] Obteniendo créditos de Cartera-Back: mes=${mes} (todos), anio=${anio}, page=${
+							Math.floor((input.offset || 0) / (input.limit || 50)) + 1
+						}, perPage=${
+							input.limit || 50
+						}, cuotasAtrasadas=${cuotasAtrasadas}, estado=${estadoCartera}, time=${
+							input.time
+						}, emailCobrador=${input.emailCobrador}, search=${
+							input.searchTerm || ""
+						}, etiquetas=${input.etiquetas?.join(",") || ""}`,
 					);
 
 					// Si hay filtro de etiquetas, primero resolver en CRM la lista de
@@ -798,7 +811,11 @@ export const cobrosRouter = {
 							.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 							.where(
 								and(
-									sql`LOWER(REPLACE(REPLACE(${vehicles.licensePlate}, '-', ''), ' ', '')) LIKE ${"%" + searchTerm.toLowerCase().replace(/[\s-]+/g, "") + "%"}`,
+									sql`LOWER(REPLACE(REPLACE(${
+										vehicles.licensePlate
+									}, '-', ''), ' ', '')) LIKE ${
+										"%" + searchTerm.toLowerCase().replace(/[\s-]+/g, "") + "%"
+									}`,
 									sql`${opportunities.numeroSifco} IS NOT NULL`,
 								),
 							);
@@ -1521,7 +1538,10 @@ export const cobrosRouter = {
 			// Notificar al nuevo cobrador asignado
 			await createNotification({
 				titulo: "Caso de cobro asignado",
-				descripcion: `Se te ha asignado el caso de cobro #${input.casoCobroId.slice(0, 8)}`,
+				descripcion: `Se te ha asignado el caso de cobro #${input.casoCobroId.slice(
+					0,
+					8,
+				)}`,
 				type: "aviso",
 				createdBy: context.user.id,
 				createdByRole: context.user.role,
@@ -1632,11 +1652,15 @@ export const cobrosRouter = {
 							.sort((a, b) => a.numero_cuota - b.numero_cuota)
 							.map((cuota) => {
 								const montoMora = cuota.pago_mora ? Number(cuota.pago_mora) : 0;
+								const montoCuota = resolveInstallmentAmount(
+									cuota.cuota,
+									creditoCompleto.credito.cuota,
+								);
 								const montoPagadoReal =
 									cuota.pagado && cuota.monto_boleta
 										? Number(cuota.monto_boleta)
 										: cuota.pagado
-											? Number(creditoCompleto.credito.cuota)
+											? Number(montoCuota)
 											: null;
 
 								return {
@@ -1644,7 +1668,7 @@ export const cobrosRouter = {
 									id: cuota.cuota_id.toString(),
 									numeroCuota: cuota.numero_cuota,
 									fechaVencimiento: cuota.fecha_vencimiento,
-									montoCuota: creditoCompleto.credito.cuota,
+									montoCuota,
 									fechaPago: cuota.pagado ? cuota.fecha_vencimiento : null,
 									montoPagado: montoPagadoReal,
 									montoMora: montoMora.toString(),
@@ -2076,8 +2100,9 @@ export const cobrosRouter = {
 						montoAsegurado: opp.vehiculoMontoAsegurado,
 					};
 					leadInfo = {
-						nombre:
-							`${opp.leadFirstName || ""} ${opp.leadLastName || ""}`.trim(),
+						nombre: `${opp.leadFirstName || ""} ${
+							opp.leadLastName || ""
+						}`.trim(),
 						email: opp.leadEmail,
 						telefono: opp.leadTelefono,
 					};
@@ -2432,7 +2457,9 @@ export const cobrosRouter = {
 				};
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo historial de pagos: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Error obteniendo historial de pagos: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
 				});
 			}
 		}),
@@ -2517,7 +2544,9 @@ export const cobrosRouter = {
 				};
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo crédito de cartera-back: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Error obteniendo crédito de cartera-back: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
 				});
 			}
 		}),
@@ -2624,8 +2653,8 @@ export const cobrosRouter = {
 							inv.reinversion ?? inv.tipo_reinversion !== "sin_reinversion",
 						tipoReinversion: inv.tipo_reinversion ?? "sin_reinversion",
 						banco: inv.banco_id
-							? (bancosMap.get(inv.banco_id) ?? null)
-							: (inv.banco ?? null),
+							? bancosMap.get(inv.banco_id) ?? null
+							: inv.banco ?? null,
 						tipoCuenta: inv.tipo_cuenta ?? null,
 						numeroCuenta: inv.numero_cuenta ?? null,
 						moneda: inv.moneda ?? "quetzales",
@@ -2646,7 +2675,9 @@ export const cobrosRouter = {
 					error instanceof Error ? error.stack : "No stack",
 				);
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo inversionistas: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Error obteniendo inversionistas: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
 				});
 			}
 		}),
@@ -2729,7 +2760,9 @@ export const cobrosRouter = {
 				};
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo detalle de inversionista: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Error obteniendo detalle de inversionista: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
 				});
 			}
 		}),
@@ -2783,7 +2816,9 @@ export const cobrosRouter = {
 				*/
 			} catch (error) {
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo inversionistas del crédito: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Error obteniendo inversionistas del crédito: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
 				});
 			}
 		}),
@@ -2853,7 +2888,9 @@ export const cobrosRouter = {
 					error instanceof Error ? error.stack : "No stack",
 				);
 				throw new ORPCError("BAD_REQUEST", {
-					message: `Error obteniendo asesores: ${error instanceof Error ? error.message : String(error)}`,
+					message: `Error obteniendo asesores: ${
+						error instanceof Error ? error.message : String(error)
+					}`,
 				});
 			}
 		}),
@@ -3335,7 +3372,11 @@ export const cobrosRouter = {
 					.innerJoin(vehicles, eq(opportunities.vehicleId, vehicles.id))
 					.where(
 						and(
-							sql`LOWER(REPLACE(REPLACE(${vehicles.licensePlate}, '-', ''), ' ', '')) LIKE ${"%" + searchTerm.toLowerCase().replaceAll(/[\s-]+/g, "") + "%"}`,
+							sql`LOWER(REPLACE(REPLACE(${
+								vehicles.licensePlate
+							}, '-', ''), ' ', '')) LIKE ${
+								"%" + searchTerm.toLowerCase().replaceAll(/[\s-]+/g, "") + "%"
+							}`,
 							sql`${opportunities.numeroSifco} IS NOT NULL`,
 						),
 					);

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -45,6 +45,7 @@ import {
 	countRemainingInstallments,
 	resolveCreditContractSummary,
 	resolveInstallmentAmount,
+	resolveOperationalInstallment,
 } from "../lib/cobros-credit-detail";
 import {
 	PLANTILLAS_MENSAJES,
@@ -2276,7 +2277,11 @@ export const cobrosRouter = {
 
 					// Datos del contrato (cartera primero, fallback a nuestra BD)
 					montoFinanciado: contractSummary.principal,
-					cuotaMensual: contractSummary.installment,
+					cuotaMensual: resolveOperationalInstallment(
+						statusCredit,
+						contractSummary.installment,
+					),
+					cuotaMensualHistorica: contractSummary.installment,
 					numeroCuotas: creditoCompleto.credito.plazo,
 					fechaInicio: creditoCompleto.credito.fecha_creacion,
 					diaPagoMensual,

--- a/apps/crm/apps/server/src/routers/cobros.ts
+++ b/apps/crm/apps/server/src/routers/cobros.ts
@@ -2245,6 +2245,7 @@ export const cobrosRouter = {
 					creditoCompleto.cuotasPagadas,
 					creditoCompleto.credito.capital ?? creditoCompleto.credito.deudatotal ?? "0.00",
 					creditoCompleto.credito.cuota || oportunidadData?.cuotaMensual || "0.00",
+					creditoCompleto.contractSummary,
 				);
 
 				return {

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -298,6 +298,7 @@ export interface CarteraCuotaCredito {
 	pago?: CarteraPagoCredito;
 	// Campos adicionales de pago (opcionales)
 	pago_id?: number;
+	cuota?: string | null;
 	validationStatus?: ValidationStatusEnum | null;
 	monto_boleta?: string; // decimal
 	abono_capital?: string; // decimal

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -251,6 +251,10 @@ export interface CarteraConvenio {
 
 export interface CreditoDirectoResponse {
 	credito: CarteraCredito;
+	contractSummary?: {
+		originalPrincipal?: string | null;
+		installment?: string | null;
+	};
 	usuario: CarteraUsuario;
 	asesor: CarteraAsesorCredito | null;
 	cuotasPagadas: CarteraCuotaCredito[];

--- a/apps/crm/apps/server/src/types/cartera-back.ts
+++ b/apps/crm/apps/server/src/types/cartera-back.ts
@@ -298,6 +298,7 @@ export interface CarteraCuotaCredito {
 	pago?: CarteraPagoCredito;
 	// Campos adicionales de pago (opcionales)
 	pago_id?: number;
+	validationStatus?: ValidationStatusEnum | null;
 	monto_boleta?: string; // decimal
 	abono_capital?: string; // decimal
 	abono_interes?: string; // decimal

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1768,11 +1768,12 @@ function RouteComponent() {
 							<div>
 								<p className="text-muted-foreground text-sm">Capital Activo</p>
 								<p className="font-medium">
-									Q
-									{Number(caso.montoFinanciado || 0).toLocaleString("es-GT", {
-										minimumFractionDigits: 2,
-										maximumFractionDigits: 2,
-									})}
+									{caso.montoFinanciado == null
+										? "No disponible"
+										: `Q${Number(caso.montoFinanciado).toLocaleString("es-GT", {
+												minimumFractionDigits: 2,
+												maximumFractionDigits: 2,
+											})}`}
 								</p>
 							</div>
 							<div>

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -631,7 +631,9 @@ function RouteComponent() {
 									</div>
 									<p className="font-bold text-blue-600 text-lg uppercase tracking-tight">
 										Q
-										{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", {
+										{Number(
+											caso.cuotaMensualHistorica ?? caso.cuotaMensual,
+										).toLocaleString("es-GT", {
 											minimumFractionDigits: 2,
 											maximumFractionDigits: 2,
 										})}

--- a/apps/crm/apps/web/src/routes/cobros/$id.tsx
+++ b/apps/crm/apps/web/src/routes/cobros/$id.tsx
@@ -1782,7 +1782,9 @@ function RouteComponent() {
 								<p className="text-muted-foreground text-sm">Cuota Mensual</p>
 								<p className="font-medium">
 									Q
-									{Number(caso.cuotaMensual || 0).toLocaleString("es-GT", {
+									{Number(
+										caso.cuotaMensualHistorica ?? caso.cuotaMensual,
+									).toLocaleString("es-GT", {
 										minimumFractionDigits: 2,
 										maximumFractionDigits: 2,
 									})}


### PR DESCRIPTION
## Objetivo

Permitir que CRM consulte y muestre correctamente el detalle histórico de créditos cuyo estado en Cartera es `CANCELADO`, sin convertir capital/cuota históricos en deuda operativa y sin reabrir accidentalmente el flujo de cancelación en Cartera Front.

> **SHA revisado:** [`88f0731521a9b18b837d94be6a1698ea7c697a2d`](https://github.com/Engineering-Club-Cash-In/universe/commit/88f0731521a9b18b837d94be6a1698ea7c697a2d)

## Cambios funcionales por aplicación

### 1. Cartera Back

#### Consulta del detalle histórico

- `CANCELADO` se incorpora explícitamente a los estados consultables del detalle, preservando los estados operativos existentes (`ACTIVO`, `PENDIENTE_CANCELACION`, `MOROSO`, `EN_CONVENIO`, `INCOBRABLE`): [`creditDetailPolicy.ts#L1-L8`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/creditDetailPolicy.ts#L1-L8) y [`#L112-L119`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/creditDetailPolicy.ts#L112-L119).
- Un crédito ya cancelado se clasifica como detalle histórico `flujo: CANCELADO`, exista o no una cancelación activa: [`creditDetailPolicy.ts#L131-L142`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/creditDetailPolicy.ts#L131-L142).
- El detalle conserva cuotas pagadas, pendientes/atrasadas históricas, mora y asesor en lugar de devolver una respuesta terminal vacía. El armado del detalle parte de [`credits.ts#L115-L142`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/credits.ts#L115-L142) y entrega el resumen contractual junto con el detalle en [`credits.ts#L379-L380`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/credits.ts#L379-L380) / [`#L512-L513`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/credits.ts#L512-L513).

#### Capital y cuota contractual confiables

- Para créditos cancelados se calcula `contractSummary` desde pagos elegibles, incluyendo abonos a capital aplicados y requiriendo evidencia de cierre antes de publicar el principal: [`credits.ts#L76-L111`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/credits.ts#L76-L111).
- Si existen pagos parciales ambiguos o no hay evidencia suficiente, `originalPrincipal` queda en `null`; CRM puede mostrar **No disponible** en vez de inventar `Q0.00`.
- La cuota sintética `reset` se conserva como evidencia de cierre, pero no se cuenta como una cuota normal pagada en el calendario.

#### Seguridad del cierre/reset

- `resetCredit` solo continúa para `PENDIENTE_CANCELACION`, o para una continuación `INCOBRABLE` validada explícitamente: [`creditDetailPolicy.ts#L121-L128`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/creditDetailPolicy.ts#L121-L128).
- La operación bloquea la fila del crédito con `FOR UPDATE`, valida que no exista otro `system_reset` y ejecuta las lecturas/escrituras del cierre en una sola transacción: [`credits.ts#L1823-L1922`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/credits.ts#L1823-L1922).
- Las funciones auxiliares de pagos y distribución de abonos aceptan el executor transaccional para no escribir fuera de esa transacción: [`abonosCapital.ts#L64-L118`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/abonosCapital.ts#L64-L118) y [`payments.ts#L1717-L1735`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/payments.ts#L1717-L1735).
- El endpoint valida el body sin coerciones silenciosas de IDs, monto incobrable, cuota, banco, boletas o autorización: [`routers/credits.ts#L709-L744`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/routers/credits.ts#L709-L744).

#### Pruebas de Cartera Back

- Visibilidad y preservación de estados existentes: [`creditDetailPolicy.test.ts#L128-L199`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts#L128-L199).
- Mora, asesor y resumen contractual: [`#L200-L259`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts#L200-L259).
- Continuación incobrable, validación del router y atomicidad: [`#L261-L453`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/cartera-back/src/controllers/creditDetailPolicy.test.ts#L261-L453).
- Resultado actual: **25 pass, 0 fail, 129 assertions**.

---

### 2. Cartera Front

Cartera Front consume el mismo endpoint de detalle. Al permitir que un crédito ya finalizado regrese como `flujo: CANCELADO`, era necesario evitar que el Front lo confundiera con un crédito todavía en proceso de cancelación.

#### Protección del flujo existente

- El helper permite entrar al flujo operativo únicamente con `statusCredit === PENDIENTE_CANCELACION`: [`cancellationPaymentFlow.ts#L1-L5`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.ts#L1-L5).
- Si el crédito ya está finalizado, el formulario y el buscador se limpian y se informa que solo está disponible en historial; no se habilita un segundo cierre: [`registerPayment.ts#L229-L257`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts#L229-L257).
- El flujo normal de `PENDIENTE_CANCELACION` permanece inmediatamente después del guard: [`registerPayment.ts#L258-L275`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts#L258-L275).

#### Consistencia del monto incobrable

- El modal valida y reutiliza exactamente el monto elegido por el usuario: [`ModalBadDebtCredit.tsx#L19-L57`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/carteraFront/src/private/cartera/components/ModalBadDebtCredit.tsx#L19-L57).
- Ese monto se propaga `Modal → PagoForm → resetCredit`, evitando que el segundo paso use el monto base anterior: [`PagoForm.tsx#L477-L483`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/carteraFront/src/private/cartera/components/PagoForm.tsx#L477-L483) y [`registerPayment.ts#L740-L769`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/carteraFront/src/private/cartera/hooks/registerPayment.ts#L740-L769).

No se rediseñó la pantalla ni se cambió el cálculo general de pagos activos; los cambios están limitados al guard de créditos finalizados y a la propagación del monto incobrable.

#### Pruebas de Cartera Front

- Casos `PENDIENTE_CANCELACION`, `CANCELADO`, `ACTIVO`, limpieza del formulario y wiring del monto: [`cancellationPaymentFlow.test.ts#L1-L53`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/carteraFront/src/private/cartera/hooks/cancellationPaymentFlow.test.ts#L1-L53).
- Resultado actual: **3 pass, 0 fail, 13 assertions**.
- `tsc --noEmit --project apps/carteraFront/tsconfig.json`: **sin errores**.

---

### 3. CRM Server

#### Separación de información histórica y deuda operativa

- `resolveOperationalInstallment` conserva la cuota para créditos activos y devuelve `0.00` únicamente para `CANCELADO`: [`cobros-credit-detail.ts#L14-L19`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/lib/cobros-credit-detail.ts#L14-L19).
- `resolveHistoricalInstallment` usa la cuota de Cartera solo cuando es positiva; si llega `0`, `0.00` o `null`, usa la cuota histórica de la oportunidad: [`#L21-L29`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/lib/cobros-credit-detail.ts#L21-L29).
- `resolveCreditContractSummary`:
  - no modifica el comportamiento de créditos activos;
  - para cancelados prioriza el resumen autoritativo de Cartera;
  - solo reconstruye desde pagos cuando existe evidencia de cierre;
  - preserva `null` autoritativo: [`#L46-L94`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/lib/cobros-credit-detail.ts#L46-L94).
- Créditos cancelados siempre muestran cero cuotas restantes; para activos se conserva la fórmula previa: [`#L96-L109`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/lib/cobros-credit-detail.ts#L96-L109).

#### Contrato de respuesta hacia CRM Web

- El router arma el resumen histórico y separa los dos campos:
  - `cuotaMensual`: valor operativo/exigible;
  - `cuotaMensualHistorica`: valor contractual para display.
- Referencia: [`cobros.ts#L2239-L2254`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/routers/cobros.ts#L2239-L2254) y [`#L2282-L2292`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/routers/cobros.ts#L2282-L2292).

#### Pruebas de CRM

- Cuota operativa/histórica y wiring hacia la UI: [`cobros-credit-detail.test.ts#L12-L52`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts#L12-L52).
- Preservación de activos, reconstrucción de cancelados, `null` confiable y abonos parciales: [`#L54-L162`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts#L54-L162).
- Conteo de cuotas y fallbacks: [`#L164-L206`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/server/src/lib/cobros-credit-detail.test.ts#L164-L206).
- Resultado actual: **17 pass, 0 fail, 28 assertions**.

---

### 4. CRM Web

- Los dos displays contractuales muestran `cuotaMensualHistorica`, con fallback a `cuotaMensual`: [`cobros/$id.tsx#L627-L640`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/web/src/routes/cobros/$id.tsx#L627-L640) y [`#L1781-L1791`](https://github.com/Engineering-Club-Cash-In/universe/blob/88f0731521a9b18b837d94be6a1698ea7c697a2d/apps/crm/apps/web/src/routes/cobros/$id.tsx#L1781-L1791).
- Totales, mensajes de cobro y cálculos continúan usando `cuotaMensual` operativa. Por eso un crédito cancelado puede mostrar su cuota contractual sin volver a generar deuda.
- Cuando el capital original no puede determinarse con evidencia suficiente, la pantalla muestra **No disponible** en vez de asumir cero.

## Comportamiento preservado / límites del cambio

- Créditos activos conservan capital, cuota y fórmula de cuotas restantes anteriores.
- `PENDIENTE_CANCELACION` conserva el flujo normal de cierre en Cartera Front.
- El pago sintético `reset` continúa existiendo como evidencia contable; únicamente se excluye del conteo del calendario normal.
- No hay cambios de schema ni migraciones de base de datos.
- No se hizo merge, deploy ni escritura en producción.

## Verificación final

| Aplicación | Resultado enfocado |
|---|---|
| Cartera Back | **25 pass, 0 fail, 129 assertions** |
| Cartera Front | **3 pass, 0 fail, 13 assertions** |
| CRM | **17 pass, 0 fail, 28 assertions** |

Adicionalmente:

- Cartera Front TypeScript: limpio.
- Biome y `git diff --check`: limpios.
- Los typechecks globales de Cartera Back/CRM conservan errores baseline preexistentes; no se detectaron errores nuevos atribuibles a este PR.
- Codex revisó el SHA final `88f0731521` y respondió: **“Didn't find any major issues. 👍”**

Reemplaza #1182 usando el mismo branch; sin rebase ni recreación de rama.
