### PR TITLE
hotfix(crm): NIT y campos de crédito vacíos en la modal de oportunidad desde Clientes

### DIFF
--- a/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
+++ b/apps/crm/apps/web/src/components/opportunity-detail-modal.tsx
@@ -62,6 +62,12 @@ export type OpportunityForModal = {
 	createdAt: Date;
 	source?: string | null;
 	loanPurpose?: string | null;
+	nit?: string | null;
+	categoria?: string | null;
+	diaPagoMensual?: number | null;
+	royalti?: string | null;
+	porcentajeRoyalti?: string | null;
+	inversionistas?: string | null;
 	lead?: {
 		id: string;
 		firstName: string;

--- a/apps/crm/apps/web/src/routes/crm/clients.tsx
+++ b/apps/crm/apps/web/src/routes/crm/clients.tsx
@@ -359,6 +359,12 @@ function RouteComponent() {
 				status: opp.status,
 				expectedCloseDate: opp.expectedCloseDate ?? null,
 				createdAt: opp.createdAt,
+				nit: opp.nit,
+				categoria: opp.categoria,
+				diaPagoMensual: opp.diaPagoMensual,
+				royalti: opp.royalti,
+				porcentajeRoyalti: opp.porcentajeRoyalti,
+				inversionistas: opp.inversionistas,
 				lead: opp.lead?.id
 					? {
 							id: opp.lead.id,


### PR DESCRIPTION
## Problema

En la página de **Clientes** del CRM, la modal "Detalles de la Oportunidad" (tab Crédito) muestra el NIT como `N/A`, mientras que la misma modal abierta desde **Oportunidades** sí lo muestra.

## Causa

Ambas páginas usan `CreditDetailView`, pero cada una le pasa un objeto `opportunity` distinto:

- **Oportunidades** pasa el objeto completo que devuelve `getOpportunities` (incluye `nit`).
- **Clientes** hace la misma query (el backend sí devuelve el NIT), pero el mapeo manual a `OpportunityForModal` en `clients.tsx` omitía el campo `nit`. Como la modal castea con `as any` al pasarlo a `CreditDetailView`, TypeScript nunca lo detectó.

No era solo el NIT: el mapeo también descartaba `categoria`, `diaPagoMensual`, `royalti`, `porcentajeRoyalti` e `inversionistas`. Ojo con `diaPagoMensual`: tiene fallback `|| 15`, así que desde Clientes se mostraba "Día 15" aunque el crédito tuviera otro día real.

## Fix

- Se agregan esos 6 campos al tipo `OpportunityForModal` (`opportunity-detail-modal.tsx`).
- Se agregan como passthrough directo en el mapeo del `useMemo` de `clients.tsx`.

Sin cambios de backend (la query ya traía todo).

## Verificación

`bun run check-types` en `apps/crm/apps/web`: mismos 1020 errores preexistentes antes y después del cambio (vienen del `proyeccionRouter` no exportado en `orpc.ts`, no relacionados) — cero errores nuevos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)