### PR TITLE
hotfix(cartera): recalcular cuotas pendientes al aplicar un abono a capital

### DIFF
--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3076,8 +3076,11 @@ export async function aplicarAbonoCapitalInversionistas(
         .limit(1);
       if (parcialAplicado) {
         recalculo_pendientes = "revisar_parciales";
+        // OJO: aquí NO se recomienda el botón "Recalcular Pagos": su modo con
+        // numero_cuota también redistribuye el parcial aplicado (reescribiría
+        // el reparto validado). Este caso requiere revisión manual del reparto.
         console.log(
-          "⚠️ Cuota con pago parcial aplicado: recálculo automático omitido — usar Recalcular Pagos manual"
+          "⚠️ Cuota con pago parcial aplicado: recálculo automático omitido — revisar el reparto manualmente (el botón también redistribuiría el parcial)"
         );
       } else {
         await recalcularPagosCredito({

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -15,6 +15,7 @@ import {
   cuentasEmpresa,
 } from "../database/db";
 import { eq, and, lt, lte, asc, desc, sql, gt, or, ne, inArray } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { updateMora } from "./latefee";
 import { insertPagosCreditoInversionistas, insertPagosCreditoInversionistasV2 } from "./payments";
 import { processAndReplaceCreditInvestors } from "./investor"; 
@@ -3162,7 +3163,35 @@ export async function aplicarAbonoCapitalInversionistas(
           )
         )
         .limit(1);
-      if (parcialAplicado) {
+      // Cuota "MIXTA": un pago VALIDADO (ya aplicado) convive con un pago
+      // PENDIENTE en la misma cuota — típico parcial validado + cierre sin
+      // validar. El cierre volteó pagado=true en toda la cuota, así que el
+      // guard de arriba no lo ve. El recálculo redistribuiría el pendiente
+      // contra el saldo COMPLETO del mes sin descontar lo que el validado ya
+      // consumió → reparto doblado al validarse. Mismo tratamiento: revisión
+      // manual.
+      const pcValidado = alias(pagos_credito, "pc_validado");
+      const [cuotaMixta] = await db
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .innerJoin(
+          pcValidado,
+          eq(pagos_credito.cuota_id, pcValidado.cuota_id)
+        )
+        .where(
+          and(
+            eq(pagos_credito.credito_id, credito_id),
+            eq(pagos_credito.validationStatus, "pending"),
+            eq(pagos_credito.paymentFalse, false),
+            gt(pagos_credito.monto_aplicado, "0"),
+            ne(pagos_credito.pago_id, pago_id),
+            eq(pcValidado.validationStatus, "validated"),
+            eq(pcValidado.paymentFalse, false),
+            gt(pcValidado.monto_aplicado, "0")
+          )
+        )
+        .limit(1);
+      if (parcialAplicado || cuotaMixta) {
         recalculo_pendientes = "revisar_parciales";
         // OJO: aquí NO se recomienda el botón "Recalcular Pagos": su modo con
         // numero_cuota también redistribuye el parcial aplicado (reescribiría

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -1,6 +1,6 @@
 import Big from "big.js";
 import z from "zod";
-import { db, client } from "../database";
+import { db, lockPool } from "../database";
 import { withCapitalContext } from "../utils/withAuditContext";
 import {
   creditos,
@@ -599,7 +599,9 @@ export const insertPayment = async ({ body, set }: any) => {
     // validación anti-sobreaplicación no los detiene porque ambos leen el
     // estado previo. El lock obliga a que el segundo espere a que el primero
     // termine y vea el saldo ya actualizado.
-    lockConn = await client.connect();
+    // Conexión del pool DEDICADO de locks: los waiters de pg_advisory_lock no
+    // deben consumir conexiones del pool de trabajo (deadlock de pool).
+    lockConn = await lockPool.connect();
     lockedCreditoId = credito_id;
     await lockConn.query("SELECT pg_advisory_lock($1, $2)", [
       PAYMENT_ADVISORY_LOCK_NAMESPACE,
@@ -2268,7 +2270,11 @@ export async function aplicarPagoAlCredito(pago_id: number) {
     // casos (pago inexistente o credito_id null).
     return aplicarPagoAlCreditoSinLock(pago_id);
   }
-  const lockConn: PaymentAdvisoryLockConnection = await client.connect();
+  // Conexión del pool DEDICADO de locks: un waiter bloqueado en
+  // pg_advisory_lock retiene su conexión; si viviera en el pool de trabajo
+  // podría agotarlo y el dueño del lock ya no tendría conexiones para sus
+  // queries (drizzle) → deadlock de pool.
+  const lockConn: PaymentAdvisoryLockConnection = await lockPool.connect();
   try {
     await lockConn.query("SELECT pg_advisory_lock($1, $2)", [
       PAYMENT_ADVISORY_LOCK_NAMESPACE,

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3057,11 +3057,17 @@ export async function aplicarAbonoCapitalInversionistas(
     );
   } else {
     try {
-      // Cuotas abiertas con pagos PARCIALES ya aplicados (monto_aplicado>0 y
-      // pagado=false): recalcular automáticamente redistribuiría su reparto
-      // histórico ya validado — el capital del crédito ya se movió con los
-      // montos originales y una reversa restauraría montos reescritos. En ese
-      // caso se omite el recálculo automático y se manda al botón manual.
+      // Cuotas abiertas con pagos PARCIALES ya aplicados (monto_aplicado>0,
+      // pagado=false y validationStatus≠'pending'): recalcular automáticamente
+      // redistribuiría su reparto histórico ya validado — el capital del
+      // crédito ya se movió con los montos originales y una reversa
+      // restauraría montos reescritos. En ese caso se omite el recálculo
+      // automático y se manda a revisión manual.
+      // Los parciales solo REGISTRADOS ('pending') NO bloquean: su reparto aún
+      // no tocó el capital y `aplicarPagoAlCredito` lo aplicará después con los
+      // abono_* guardados, así que DEBEN entrar al recálculo para que ese
+      // reparto se refresque con el capital nuevo antes de que conta los
+      // valide (si no, validarían el split viejo → mismo bug del abono).
       const [parcialAplicado] = await db
         .select({ pago_id: pagos_credito.pago_id })
         .from(pagos_credito)
@@ -3070,6 +3076,7 @@ export async function aplicarAbonoCapitalInversionistas(
             eq(pagos_credito.credito_id, credito_id),
             eq(pagos_credito.pagado, false),
             gt(pagos_credito.monto_aplicado, "0"),
+            ne(pagos_credito.validationStatus, "pending"),
             ne(pagos_credito.pago_id, pago_id)
           )
         )

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3044,7 +3044,8 @@ export async function aplicarAbonoCapitalInversionistas(
     | "ok"
     | "error"
     | "omitido_solo_interes"
-    | "revisar_pendientes_validacion" = "ok";
+    | "revisar_pendientes_validacion"
+    | "revisar_parciales" = "ok";
   if (credito.no_amortiza_capital) {
     // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
     // convertiría en amortización de capital la diferencia cuota − interés
@@ -3056,31 +3057,55 @@ export async function aplicarAbonoCapitalInversionistas(
     );
   } else {
     try {
-      await recalcularPagosCredito({
-        numero_credito_sifco: credito.numero_credito_sifco,
-      });
-      // Pagos ya registrados (pagado=true) pero aún SIN validar por conta
-      // quedan fuera del recálculo (solo toma pendientes): si conta los valida
-      // después de este abono, confirmaría su reparto viejo. Se reporta para
-      // correr "Recalcular Pagos" a mano después de validarlos.
-      const [pendienteValidacion] = await db
+      // Cuotas abiertas con pagos PARCIALES ya aplicados (monto_aplicado>0 y
+      // pagado=false): recalcular automáticamente redistribuiría su reparto
+      // histórico ya validado — el capital del crédito ya se movió con los
+      // montos originales y una reversa restauraría montos reescritos. En ese
+      // caso se omite el recálculo automático y se manda al botón manual.
+      const [parcialAplicado] = await db
         .select({ pago_id: pagos_credito.pago_id })
         .from(pagos_credito)
         .where(
           and(
             eq(pagos_credito.credito_id, credito_id),
-            eq(pagos_credito.pagado, true),
-            eq(pagos_credito.validationStatus, "pending")
+            eq(pagos_credito.pagado, false),
+            gt(pagos_credito.monto_aplicado, "0"),
+            ne(pagos_credito.pago_id, pago_id)
           )
         )
         .limit(1);
-      if (pendienteValidacion) {
-        recalculo_pendientes = "revisar_pendientes_validacion";
+      if (parcialAplicado) {
+        recalculo_pendientes = "revisar_parciales";
         console.log(
-          "⚠️ Hay pagos registrados pendientes de validación: recalcular a mano después de validarlos"
+          "⚠️ Cuota con pago parcial aplicado: recálculo automático omitido — usar Recalcular Pagos manual"
         );
       } else {
-        console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+        await recalcularPagosCredito({
+          numero_credito_sifco: credito.numero_credito_sifco,
+        });
+        // Pagos ya registrados (pagado=true) pero aún SIN validar por conta
+        // quedan fuera del recálculo (solo toma pendientes): si conta los valida
+        // después de este abono, confirmaría su reparto viejo. Se reporta para
+        // correr "Recalcular Pagos" a mano después de validarlos.
+        const [pendienteValidacion] = await db
+          .select({ pago_id: pagos_credito.pago_id })
+          .from(pagos_credito)
+          .where(
+            and(
+              eq(pagos_credito.credito_id, credito_id),
+              eq(pagos_credito.pagado, true),
+              eq(pagos_credito.validationStatus, "pending")
+            )
+          )
+          .limit(1);
+        if (pendienteValidacion) {
+          recalculo_pendientes = "revisar_pendientes_validacion";
+          console.log(
+            "⚠️ Hay pagos registrados pendientes de validación: recalcular a mano después de validarlos"
+          );
+        } else {
+          console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+        }
       }
     } catch (error) {
       // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3032,33 +3032,40 @@ export async function aplicarAbonoCapitalInversionistas(
     })
     .where(eq(pagos_credito.pago_id, pago_id));
 
-  // 5️⃣ Re-sembrar los recibos de las cuotas SIGUIENTES con el capital nuevo.
+  // 5️⃣ Re-sembrar los recibos PENDIENTES con el capital nuevo.
   // Sin esto, el próximo pago se aplicaría con el interés pre-sembrado sobre el
   // capital viejo (y de ahí saldrían factura y liquidación infladas). Se
-  // recalcula desde la cuota siguiente a la del abono, manteniendo la cuota
-  // mensual del crédito. El espejo NO se toca aquí: lo maneja la liquidación
-  // del inversionista.
-  let recalculo_pendientes: "ok" | "error" = "ok";
-  try {
-    const [cuotaAbono] = await db
-      .select({ numero_cuota: cuotas_credito.numero_cuota })
-      .from(cuotas_credito)
-      .innerJoin(pagos_credito, eq(pagos_credito.cuota_id, cuotas_credito.cuota_id))
-      .where(eq(pagos_credito.pago_id, pago_id))
-      .limit(1);
-
-    const desdeCuota = (cuotaAbono?.numero_cuota ?? 0) + 1;
-    await recalcularPagosCredito({
-      numero_credito_sifco: credito.numero_credito_sifco,
-      numero_cuota: desdeCuota,
-    });
-    console.log(`✅ Recibos recalculados desde la cuota ${desdeCuota} con el capital nuevo`);
-  } catch (error) {
-    // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
-    // NO puede pasar silencioso: los recibos quedarían con interés viejo, así
-    // que se reporta en la respuesta para correr Recalcular Pagos a mano.
-    recalculo_pendientes = "error";
-    console.error("❌ Error recalculando recibos post-abono (correr Recalcular Pagos manual):", error);
+  // recalculan SOLO los pagos pendientes (pagado=false): eso cubre también la
+  // cuota de referencia del abono cuando aún no está pagada (abono antes de la
+  // primera cuota), y nunca toca pagos ya aplicados — este mismo abono queda
+  // pagado=true y fuera del recálculo. La cuota mensual del crédito no cambia.
+  // El espejo NO se toca aquí: lo maneja la liquidación del inversionista.
+  let recalculo_pendientes: "ok" | "error" | "omitido_solo_interes" = "ok";
+  if (credito.no_amortiza_capital) {
+    // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
+    // convertiría en amortización de capital la diferencia cuota − interés
+    // nuevo, contra el contrato. Se mantiene el comportamiento actual (sin
+    // re-siembra automática) hasta definir la re-siembra para este formato.
+    recalculo_pendientes = "omitido_solo_interes";
+    console.log(
+      "⚠️ Crédito solo-interés (no_amortiza_capital): recálculo automático omitido"
+    );
+  } else {
+    try {
+      await recalcularPagosCredito({
+        numero_credito_sifco: credito.numero_credito_sifco,
+      });
+      console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+    } catch (error) {
+      // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
+      // NO puede pasar silencioso: los recibos quedarían con interés viejo, así
+      // que se reporta en la respuesta para correr Recalcular Pagos a mano.
+      recalculo_pendientes = "error";
+      console.error(
+        "❌ Error recalculando recibos post-abono (correr Recalcular Pagos manual):",
+        error
+      );
+    }
   }
 
   console.log(`✅ ========== ABONO APLICADO EXITOSAMENTE ==========\n`);

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2881,6 +2881,41 @@ export async function aplicarAbonoCapitalInversionistas(
   abono_capital: number | string,
   pago_id: number
 ) {
+  // 🔒 Mismo advisory lock por crédito que insertPayment: serializa el abono
+  // completo (espejo + update del crédito + recálculo de recibos) contra un
+  // registro concurrente del mismo crédito. Sin esto, un /newPayment que ya
+  // leyó el saldo pre-abono puede commitear justo después del recálculo y el
+  // recibo recién registrado se queda con el split viejo (TOCTOU).
+  const lockConn: PaymentAdvisoryLockConnection = await client.connect();
+  try {
+    await lockConn.query("SELECT pg_advisory_lock($1, $2)", [
+      PAYMENT_ADVISORY_LOCK_NAMESPACE,
+      credito_id,
+    ]);
+    return await aplicarAbonoCapitalInversionistasSinLock(
+      credito_id,
+      abono_capital,
+      pago_id
+    );
+  } finally {
+    // 🔓 Liberar el lock y devolver la conexión al pool, pase lo que pase.
+    try {
+      await lockConn.query("SELECT pg_advisory_unlock($1, $2)", [
+        PAYMENT_ADVISORY_LOCK_NAMESPACE,
+        credito_id,
+      ]);
+    } catch (unlockError) {
+      console.error("⚠️ Error liberando advisory lock del abono:", unlockError);
+    }
+    lockConn.release();
+  }
+}
+
+async function aplicarAbonoCapitalInversionistasSinLock(
+  credito_id: number,
+  abono_capital: number | string,
+  pago_id: number
+) {
   console.log("\n💵 ========== APLICANDO ABONO A CAPITAL ==========");
 
   // Distribuir abono a capital en tabla espejo. El pago_id deja cada fila

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3074,7 +3074,8 @@ export async function aplicarAbonoCapitalInversionistas(
     | "error"
     | "omitido_solo_interes"
     | "revisar_vencidas"
-    | "revisar_parciales" = "ok";
+    | "revisar_parciales"
+    | "revisar_sobrante" = "ok";
   if (credito.no_amortiza_capital) {
     // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
     // convertiría en amortización de capital la diferencia cuota − interés
@@ -3158,7 +3159,50 @@ export async function aplicarAbonoCapitalInversionistas(
           await recalcularPagosCredito({
             numero_credito_sifco: credito.numero_credito_sifco,
           });
-          console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+          // Pagos registrados SIN validar cuyo monto quedó por ENCIMA del
+          // recibo recalculado (ej.: pagaron la cuota completa y el abono dejó
+          // el último recibo más chico): el reparto nuevo no usa toda la
+          // boleta, y ese resto no llegaría ni al crédito ni a inversionistas
+          // al validar. Se reporta para que el equipo decida (saldo a favor /
+          // devolución) ANTES de validar ese pago.
+          const candidatosSobrante = await db
+            .select({
+              monto_aplicado: pagos_credito.monto_aplicado,
+              pago_del_mes: pagos_credito.pago_del_mes,
+              mora: pagos_credito.mora,
+              otros: pagos_credito.otros,
+              pagoConvenio: pagos_credito.pagoConvenio,
+            })
+            .from(pagos_credito)
+            .where(
+              and(
+                eq(pagos_credito.credito_id, credito_id),
+                eq(pagos_credito.paymentFalse, false),
+                eq(pagos_credito.validationStatus, "pending"),
+                gt(pagos_credito.monto_aplicado, "0"),
+                ne(pagos_credito.pago_id, pago_id)
+              )
+            );
+          // monto_aplicado legacy puede cargar mora/otros/convenio: se restan
+          // para no marcar sobrante falso. Tolerancia de centavos por redondeo.
+          const haySobrante = candidatosSobrante.some((p) =>
+            new Big(p.monto_aplicado ?? 0)
+              .minus(p.pago_del_mes ?? 0)
+              .minus(p.mora ?? 0)
+              .minus(p.otros ?? 0)
+              .minus(p.pagoConvenio ?? 0)
+              .gt(0.05)
+          );
+          if (haySobrante) {
+            recalculo_pendientes = "revisar_sobrante";
+            console.log(
+              "⚠️ Pago registrado sin validar con monto mayor al recibo recalculado: revisar sobrante (saldo a favor/devolución) antes de validarlo"
+            );
+          } else {
+            console.log(
+              `✅ Recibos pendientes recalculados con el capital nuevo`
+            );
+          }
         }
       }
     } catch (error) {

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2362,6 +2362,34 @@ export async function aplicarPagoAlCredito(pago_id: number) {
       console.log(
         `📊 Cuota ${pago.cuota_id}: aplicado ${totalAplicadoEnCuota.toFixed(2)} / esperado ${cuotaAmount.toFixed(2)} (otros validated: ${otrosPagosValidados.length}) → ${cuotaCompleta ? "COMPLETA" : "incompleta"}`
       );
+
+      // Recibos MENORES a la cuota mensual: tras un abono grande, el recálculo
+      // topa el capital del último recibo (y los de cola quedan solo con
+      // seguro/GPS/membresías), así que su total real es menor a
+      // `credito.cuota` y la suma de arriba nunca los daría por completos.
+      // Si este pago dejó el recibo con TODOS sus restantes en 0, la cuota
+      // cierra — mismo criterio con el que el registro ya marcó la fila como
+      // pagada (shouldMarkInstallmentPaymentPaid) y el recálculo decide
+      // `pagado` al redistribuir. No afecta cuotas normales (su recibo suma la
+      // cuota completa y cierran por la suma) ni parciales (dejan restantes).
+      // El override de INCOBRABLE de abajo sigue mandando sobre esto.
+      if (!cuotaCompleta) {
+        const restantesRecibo = new Big(pago.interes_restante ?? 0)
+          .plus(pago.iva_12_restante ?? 0)
+          .plus(pago.seguro_restante ?? 0)
+          .plus(pago.gps_restante ?? 0)
+          .plus(pago.membresias ?? 0)
+          .plus(pago.capital_restante ?? 0);
+        if (
+          restantesRecibo.lte(0.01) &&
+          new Big(pago.monto_aplicado ?? 0).gt(0)
+        ) {
+          cuotaCompleta = true;
+          console.log(
+            `📊 Cuota ${pago.cuota_id}: recibo menor a la cuota mensual cubierto por completo (restantes en 0) → COMPLETA`
+          );
+        }
+      }
     }
 
     // INCOBRABLE: la cuota se cierra SI Y SOLO SI el capital del crédito llega

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2246,8 +2246,52 @@ export async function insertarPago({
  * - Si pagado = false: Solo actualiza el pago para validarlo
  * - Si pagado = true: Aplica los abonos al crédito
  * @param pago_id - ID del pago a aplicar
+ *
+ * 🔒 Serializa TODO /aplicar-pago (validación normal, reset y abono a
+ * capital) con el MISMO advisory lock por crédito que usa insertPayment.
+ * Sin esto, validar un pago del mismo crédito en plena ventana de un abono
+ * (entre el update de creditos.capital y el recálculo) aplicaría el split
+ * viejo pre-abono, o marcaría la fila validated para que el recálculo la
+ * salte. La lectura real del pago ocurre adentro, YA bajo el lock.
  */
 export async function aplicarPagoAlCredito(pago_id: number) {
+  // Pre-lectura mínima: solo para conocer el crédito a serializar.
+  const [pagoPre] = await db
+    .select({ credito_id: pagos_credito.credito_id })
+    .from(pagos_credito)
+    .where(eq(pagos_credito.pago_id, pago_id))
+    .limit(1);
+  const creditoIdLock = pagoPre?.credito_id ?? null;
+  if (creditoIdLock === null) {
+    // Sin crédito no hay qué serializar; la lógica interna ya maneja estos
+    // casos (pago inexistente o credito_id null).
+    return aplicarPagoAlCreditoSinLock(pago_id);
+  }
+  const lockConn: PaymentAdvisoryLockConnection = await client.connect();
+  try {
+    await lockConn.query("SELECT pg_advisory_lock($1, $2)", [
+      PAYMENT_ADVISORY_LOCK_NAMESPACE,
+      creditoIdLock,
+    ]);
+    return await aplicarPagoAlCreditoSinLock(pago_id);
+  } finally {
+    // 🔓 Liberar el lock y devolver la conexión al pool, pase lo que pase.
+    try {
+      await lockConn.query("SELECT pg_advisory_unlock($1, $2)", [
+        PAYMENT_ADVISORY_LOCK_NAMESPACE,
+        creditoIdLock,
+      ]);
+    } catch (unlockError) {
+      console.error(
+        "⚠️ Error liberando advisory lock de aplicar-pago:",
+        unlockError
+      );
+    }
+    lockConn.release();
+  }
+}
+
+async function aplicarPagoAlCreditoSinLock(pago_id: number) {
   try {
     console.log("🔄 Iniciando aplicación de pago al crédito:", pago_id);
 
@@ -2881,41 +2925,9 @@ export async function aplicarAbonoCapitalInversionistas(
   abono_capital: number | string,
   pago_id: number
 ) {
-  // 🔒 Mismo advisory lock por crédito que insertPayment: serializa el abono
-  // completo (espejo + update del crédito + recálculo de recibos) contra un
-  // registro concurrente del mismo crédito. Sin esto, un /newPayment que ya
-  // leyó el saldo pre-abono puede commitear justo después del recálculo y el
-  // recibo recién registrado se queda con el split viejo (TOCTOU).
-  const lockConn: PaymentAdvisoryLockConnection = await client.connect();
-  try {
-    await lockConn.query("SELECT pg_advisory_lock($1, $2)", [
-      PAYMENT_ADVISORY_LOCK_NAMESPACE,
-      credito_id,
-    ]);
-    return await aplicarAbonoCapitalInversionistasSinLock(
-      credito_id,
-      abono_capital,
-      pago_id
-    );
-  } finally {
-    // 🔓 Liberar el lock y devolver la conexión al pool, pase lo que pase.
-    try {
-      await lockConn.query("SELECT pg_advisory_unlock($1, $2)", [
-        PAYMENT_ADVISORY_LOCK_NAMESPACE,
-        credito_id,
-      ]);
-    } catch (unlockError) {
-      console.error("⚠️ Error liberando advisory lock del abono:", unlockError);
-    }
-    lockConn.release();
-  }
-}
-
-async function aplicarAbonoCapitalInversionistasSinLock(
-  credito_id: number,
-  abono_capital: number | string,
-  pago_id: number
-) {
+  // 🔒 NO toma el lock aquí: su único caller es aplicarPagoAlCredito, que ya
+  // serializa TODO /aplicar-pago (normal, reset y capital) con el advisory
+  // lock por crédito. Tomarlo de nuevo en otra conexión sería deadlock.
   console.log("\n💵 ========== APLICANDO ABONO A CAPITAL ==========");
 
   // Distribuir abono a capital en tabla espejo. El pago_id deja cada fila
@@ -3166,22 +3178,41 @@ async function aplicarAbonoCapitalInversionistasSinLock(
         // inversionista), así que si hay alguna NO se recalcula nada y se
         // manda a revisión del equipo. La cuota que vence HOY no cuenta como
         // vencida (fecha GT).
+        // Una fila ANULADA (paymentFalse) también cuenta si su cuota sigue
+        // sin pagarse: la cuota vencida existe aunque su única fila esté
+        // anulada — sin esto, el recálculo la re-sembraría y se saltaría
+        // esta regla conservadora.
         const hoyGuatemala = new Date().toLocaleDateString("en-CA", {
           timeZone: "America/Guatemala",
         });
         const [cuotaVencida] = await db
           .select({ pago_id: pagos_credito.pago_id })
           .from(pagos_credito)
+          .innerJoin(
+            cuotas_credito,
+            eq(pagos_credito.cuota_id, cuotas_credito.cuota_id)
+          )
           .where(
             and(
               eq(pagos_credito.credito_id, credito_id),
-              eq(pagos_credito.paymentFalse, false),
               lt(pagos_credito.fecha_vencimiento, hoyGuatemala),
+              ne(pagos_credito.pago_id, pago_id),
               or(
-                eq(pagos_credito.pagado, false),
-                eq(pagos_credito.validationStatus, "pending")
-              ),
-              ne(pagos_credito.pago_id, pago_id)
+                // Fila viva sin aplicar: no pagada o registrada sin validar
+                and(
+                  eq(pagos_credito.paymentFalse, false),
+                  or(
+                    eq(pagos_credito.pagado, false),
+                    eq(pagos_credito.validationStatus, "pending")
+                  )
+                ),
+                // Fila anulada de una cuota que sigue sin pagarse
+                and(
+                  eq(pagos_credito.paymentFalse, true),
+                  eq(pagos_credito.pagado, false),
+                  eq(cuotas_credito.pagado, false)
+                )
+              )
             )
           )
           .limit(1);

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3096,6 +3096,9 @@ export async function aplicarAbonoCapitalInversionistas(
       // abono_* guardados, así que DEBEN entrar al recálculo para que ese
       // reparto se refresque con el capital nuevo antes de que conta los
       // valide (si no, validarían el split viejo → mismo bug del abono).
+      // paymentFalse=false: un pago anulado conserva monto_aplicado y su
+      // status, pero ya no es un parcial vivo — no debe bloquear el recálculo
+      // (mismo filtro que usan las sumas de cuota en la validación).
       const [parcialAplicado] = await db
         .select({ pago_id: pagos_credito.pago_id })
         .from(pagos_credito)
@@ -3103,6 +3106,7 @@ export async function aplicarAbonoCapitalInversionistas(
           and(
             eq(pagos_credito.credito_id, credito_id),
             eq(pagos_credito.pagado, false),
+            eq(pagos_credito.paymentFalse, false),
             gt(pagos_credito.monto_aplicado, "0"),
             ne(pagos_credito.validationStatus, "pending"),
             ne(pagos_credito.pago_id, pago_id)

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -2312,6 +2312,22 @@ async function aplicarPagoAlCreditoSinLock(pago_id: number) {
     if (!pago) {
       throw new Error(`Pago ${pago_id} no encontrado`);
     }
+    // 🔒 Re-chequeo BAJO EL LOCK: dos /aplicar-pago del mismo pago pueden
+    // pasar el pre-check del router antes de que alguno tome el lock (doble
+    // click / reintento); el segundo entra aquí cuando el primero ya aplicó.
+    // Esta lectura ocurre ya con el lock tomado, así que ver un status
+    // aplicado es definitivo — se rechaza en vez de volver a mover capital y
+    // re-distribuir a inversionistas.
+    if (
+      pago.validationStatus === "validated" ||
+      pago.validationStatus === "capital_validated"
+    ) {
+      return {
+        success: false,
+        applied: false,
+        message: `El pago ${pago_id} ya fue aplicado (${pago.validationStatus}); no se aplica dos veces.`,
+      };
+    }
     if (pago.validationStatus === "capital") {
       return applyCapitalPaymentAndBuildResponse(
         pago,

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -14,7 +14,7 @@ import {
   pagos_credito_inversionistas,
   cuentasEmpresa,
 } from "../database/db";
-import { eq, and, lte, asc, desc, sql, gt, or, ne, inArray } from "drizzle-orm";
+import { eq, and, lt, lte, asc, desc, sql, gt, or, ne, inArray } from "drizzle-orm";
 import { updateMora } from "./latefee";
 import { insertPagosCreditoInversionistas, insertPagosCreditoInversionistasV2 } from "./payments";
 import { processAndReplaceCreditInvestors } from "./investor"; 
@@ -3063,16 +3063,17 @@ export async function aplicarAbonoCapitalInversionistas(
   // 5️⃣ Re-sembrar los recibos PENDIENTES con el capital nuevo.
   // Sin esto, el próximo pago se aplicaría con el interés pre-sembrado sobre el
   // capital viejo (y de ahí saldrían factura y liquidación infladas). Se
-  // recalculan SOLO los pagos pendientes (pagado=false): eso cubre también la
-  // cuota de referencia del abono cuando aún no está pagada (abono antes de la
-  // primera cuota), y nunca toca pagos ya aplicados — este mismo abono queda
-  // pagado=true y fuera del recálculo. La cuota mensual del crédito no cambia.
+  // recalcula lo que AÚN NO SE APLICÓ al crédito: cuotas no pagadas Y pagos
+  // registrados sin validar por conta (pending) — esos no han movido capital
+  // y al validarse aplicarían el split viejo si no se refrescan. Nunca toca
+  // pagos ya aplicados/validados — este mismo abono queda capital_validated y
+  // fuera del recálculo. La cuota mensual del crédito no cambia.
   // El espejo NO se toca aquí: lo maneja la liquidación del inversionista.
   let recalculo_pendientes:
     | "ok"
     | "error"
     | "omitido_solo_interes"
-    | "revisar_pendientes_validacion"
+    | "revisar_vencidas"
     | "revisar_parciales" = "ok";
   if (credito.no_amortiza_capital) {
     // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
@@ -3122,30 +3123,41 @@ export async function aplicarAbonoCapitalInversionistas(
           "⚠️ Cuota con pago parcial aplicado: recálculo automático omitido — revisar el reparto manualmente (el botón también redistribuiría el parcial)"
         );
       } else {
-        await recalcularPagosCredito({
-          numero_credito_sifco: credito.numero_credito_sifco,
+        // Cuotas VENCIDAS sin aplicar (no pagadas, o registradas sin validar):
+        // su interés corresponde a meses en los que el capital viejo todavía
+        // estaba prestado completo. Recalcularlas con el capital post-abono
+        // repreciaría deuda histórica a favor del cliente (y en contra del
+        // inversionista), así que si hay alguna NO se recalcula nada y se
+        // manda a revisión del equipo. La cuota que vence HOY no cuenta como
+        // vencida (fecha GT).
+        const hoyGuatemala = new Date().toLocaleDateString("en-CA", {
+          timeZone: "America/Guatemala",
         });
-        // Pagos ya registrados (pagado=true) pero aún SIN validar por conta
-        // quedan fuera del recálculo (solo toma pendientes): si conta los valida
-        // después de este abono, confirmaría su reparto viejo. Se reporta para
-        // correr "Recalcular Pagos" a mano después de validarlos.
-        const [pendienteValidacion] = await db
+        const [cuotaVencida] = await db
           .select({ pago_id: pagos_credito.pago_id })
           .from(pagos_credito)
           .where(
             and(
               eq(pagos_credito.credito_id, credito_id),
-              eq(pagos_credito.pagado, true),
-              eq(pagos_credito.validationStatus, "pending")
+              eq(pagos_credito.paymentFalse, false),
+              lt(pagos_credito.fecha_vencimiento, hoyGuatemala),
+              or(
+                eq(pagos_credito.pagado, false),
+                eq(pagos_credito.validationStatus, "pending")
+              ),
+              ne(pagos_credito.pago_id, pago_id)
             )
           )
           .limit(1);
-        if (pendienteValidacion) {
-          recalculo_pendientes = "revisar_pendientes_validacion";
+        if (cuotaVencida) {
+          recalculo_pendientes = "revisar_vencidas";
           console.log(
-            "⚠️ Hay pagos registrados pendientes de validación: recalcular a mano después de validarlos"
+            "⚠️ Crédito con cuotas vencidas sin aplicar: recálculo automático omitido — revisar con el equipo cómo tratar el interés de las vencidas antes de recalcular"
           );
         } else {
+          await recalcularPagosCredito({
+            numero_credito_sifco: credito.numero_credito_sifco,
+          });
           console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
         }
       }

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -20,6 +20,7 @@ import { insertPagosCreditoInversionistas, insertPagosCreditoInversionistasV2 } 
 import { processAndReplaceCreditInvestors } from "./investor"; 
 import { processConvenioPayment } from "./paymentAgreement";
 import { distribuirAbonoCapitalEspejo } from "./abonosCapital";
+import { recalcularPagosCredito } from "./updateCredit";
 import {
   applyCapitalPaymentAndBuildResponse,
   calcularSaldoNetoCuota,
@@ -3031,10 +3032,40 @@ export async function aplicarAbonoCapitalInversionistas(
     })
     .where(eq(pagos_credito.pago_id, pago_id));
 
+  // 5️⃣ Re-sembrar los recibos de las cuotas SIGUIENTES con el capital nuevo.
+  // Sin esto, el próximo pago se aplicaría con el interés pre-sembrado sobre el
+  // capital viejo (y de ahí saldrían factura y liquidación infladas). Se
+  // recalcula desde la cuota siguiente a la del abono, manteniendo la cuota
+  // mensual del crédito. El espejo NO se toca aquí: lo maneja la liquidación
+  // del inversionista.
+  let recalculo_pendientes: "ok" | "error" = "ok";
+  try {
+    const [cuotaAbono] = await db
+      .select({ numero_cuota: cuotas_credito.numero_cuota })
+      .from(cuotas_credito)
+      .innerJoin(pagos_credito, eq(pagos_credito.cuota_id, cuotas_credito.cuota_id))
+      .where(eq(pagos_credito.pago_id, pago_id))
+      .limit(1);
+
+    const desdeCuota = (cuotaAbono?.numero_cuota ?? 0) + 1;
+    await recalcularPagosCredito({
+      numero_credito_sifco: credito.numero_credito_sifco,
+      numero_cuota: desdeCuota,
+    });
+    console.log(`✅ Recibos recalculados desde la cuota ${desdeCuota} con el capital nuevo`);
+  } catch (error) {
+    // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
+    // NO puede pasar silencioso: los recibos quedarían con interés viejo, así
+    // que se reporta en la respuesta para correr Recalcular Pagos a mano.
+    recalculo_pendientes = "error";
+    console.error("❌ Error recalculando recibos post-abono (correr Recalcular Pagos manual):", error);
+  }
+
   console.log(`✅ ========== ABONO APLICADO EXITOSAMENTE ==========\n`);
 
   return {
     message: "Abono a capital aplicado exitosamente",
+    recalculo_pendientes,
     credito_id,
     pago_id,
     abono_total: abonoCapitalBig.toString(),

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -42,6 +42,7 @@ import {
 } from "./registerPaymentPolicy";
 import {
   PAYMENT_ADVISORY_LOCK_NAMESPACE,
+  withPaymentAdvisoryLock,
   type PaymentAdvisoryLockConnection,
 } from "../utils/paymentAdvisoryLock";
 
@@ -3469,8 +3470,32 @@ export async function actualizarCuentaPago(
  * Aplica un monto adicional a los restantes de un pago existente.
  * Recibe pago_id y monto, distribuye en orden: interés → IVA → seguro → GPS → membresías → capital.
  * Actualiza solo ese pago y llama a inversionistas.
+ *
+ * 🔒 Escritor de filas de pago: corre bajo el MISMO advisory lock por crédito
+ * que registrar/aplicar/revalidar. Sin él, usarlo en plena ventana del
+ * recálculo post-abono cruzaría dos escritores (el recálculo pisa el monto
+ * manual, o la validación manual queda con el reparto pre-abono).
  */
 export async function aplicarMontoAPago(pago_id: number, monto: number, fecha_pago?: string, validationStatus?: string) {
+  // Pre-lectura mínima: solo para conocer el crédito a serializar. La
+  // lectura real del pago ocurre adentro, ya bajo el lock.
+  const [pagoPre] = await db
+    .select({ credito_id: pagos_credito.credito_id })
+    .from(pagos_credito)
+    .where(eq(pagos_credito.pago_id, pago_id))
+    .limit(1);
+  const creditoIdLock = pagoPre?.credito_id ?? null;
+  if (creditoIdLock === null) {
+    // Sin crédito no hay qué serializar (pago inexistente o credito_id null);
+    // la lógica interna maneja esos casos.
+    return aplicarMontoAPagoSinLock(pago_id, monto, fecha_pago, validationStatus);
+  }
+  return withPaymentAdvisoryLock(creditoIdLock, () =>
+    aplicarMontoAPagoSinLock(pago_id, monto, fecha_pago, validationStatus)
+  );
+}
+
+async function aplicarMontoAPagoSinLock(pago_id: number, monto: number, fecha_pago?: string, validationStatus?: string) {
   try {
     // 1. Obtener el pago
     const [pago] = await db

--- a/apps/cartera-back/src/controllers/registerPayment.ts
+++ b/apps/cartera-back/src/controllers/registerPayment.ts
@@ -3040,7 +3040,11 @@ export async function aplicarAbonoCapitalInversionistas(
   // primera cuota), y nunca toca pagos ya aplicados — este mismo abono queda
   // pagado=true y fuera del recálculo. La cuota mensual del crédito no cambia.
   // El espejo NO se toca aquí: lo maneja la liquidación del inversionista.
-  let recalculo_pendientes: "ok" | "error" | "omitido_solo_interes" = "ok";
+  let recalculo_pendientes:
+    | "ok"
+    | "error"
+    | "omitido_solo_interes"
+    | "revisar_pendientes_validacion" = "ok";
   if (credito.no_amortiza_capital) {
     // Crédito solo-interés: recalcularPagosCredito no conoce el flag y
     // convertiría en amortización de capital la diferencia cuota − interés
@@ -3055,7 +3059,29 @@ export async function aplicarAbonoCapitalInversionistas(
       await recalcularPagosCredito({
         numero_credito_sifco: credito.numero_credito_sifco,
       });
-      console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+      // Pagos ya registrados (pagado=true) pero aún SIN validar por conta
+      // quedan fuera del recálculo (solo toma pendientes): si conta los valida
+      // después de este abono, confirmaría su reparto viejo. Se reporta para
+      // correr "Recalcular Pagos" a mano después de validarlos.
+      const [pendienteValidacion] = await db
+        .select({ pago_id: pagos_credito.pago_id })
+        .from(pagos_credito)
+        .where(
+          and(
+            eq(pagos_credito.credito_id, credito_id),
+            eq(pagos_credito.pagado, true),
+            eq(pagos_credito.validationStatus, "pending")
+          )
+        )
+        .limit(1);
+      if (pendienteValidacion) {
+        recalculo_pendientes = "revisar_pendientes_validacion";
+        console.log(
+          "⚠️ Hay pagos registrados pendientes de validación: recalcular a mano después de validarlos"
+        );
+      } else {
+        console.log(`✅ Recibos pendientes recalculados con el capital nuevo`);
+      }
     } catch (error) {
       // El abono ya quedó aplicado y distribuido; no se revierte por esto. Pero
       // NO puede pasar silencioso: los recibos quedarían con interés viejo, así

--- a/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
+++ b/apps/cartera-back/src/controllers/registerPaymentPolicy.ts
@@ -478,11 +478,22 @@ export const applyCapitalPaymentAndBuildResponse = async (
     throw new Error("No se puede aplicar el abono: credito_id es null");
   }
 
-  await applyCapitalAbono(pago.credito_id, pago.abono_capital ?? "0", pagoId);
+  const resultado = await applyCapitalAbono(
+    pago.credito_id,
+    pago.abono_capital ?? "0",
+    pagoId
+  );
   console.log("⚠️ El pago es un abono directo a capital");
+  // Propagar el estado del recálculo de recibos pendientes: si falló (o se
+  // omitió por solo-interés), el caller debe enterarse para correr
+  // "Recalcular Pagos" a mano — no puede quedarse solo en los logs.
+  const recalculo_pendientes = (
+    resultado as { recalculo_pendientes?: string } | null | undefined
+  )?.recalculo_pendientes;
   return {
     success: true,
     applied: false,
+    ...(recalculo_pendientes ? { recalculo_pendientes } : {}),
     message:
       "Pago validado como abono a capital , se abonó a inversionistas correctamente",
   };

--- a/apps/cartera-back/src/controllers/revalidatePayment.test.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.test.ts
@@ -28,10 +28,20 @@ const tx = {
   })),
 };
 
+const lockQuery = mock(() => Promise.resolve());
+const lockRelease = mock(() => {});
+
 mock.module("../database", () => ({
   db: {
     transaction: mock(
       (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx),
+    ),
+  },
+  // Pool de advisory locks: el wrapper withPaymentAdvisoryLock pide una
+  // conexión, lockea/deslockea y la libera.
+  lockPool: {
+    connect: mock(() =>
+      Promise.resolve({ query: lockQuery, release: lockRelease }),
     ),
   },
 }));
@@ -81,6 +91,8 @@ describe("revalidatePayment", () => {
     selectResults = [[pagoCompletoPendiente], [credito], []];
     tx.execute.mockClear();
     insertInvestors.mockClear();
+    lockQuery.mockClear();
+    lockRelease.mockClear();
   });
 
   it("restaura la cuota cerrada al revalidar el pago completo reversado", async () => {
@@ -94,7 +106,16 @@ describe("revalidatePayment", () => {
     expect(set.status).toBe(200);
     expect(updates.some((values) => values.pagado === true)).toBeTrue();
     expect(insertInvestors).toHaveBeenCalledWith(30, 10, undefined, tx);
-    expect(tx.execute).toHaveBeenCalledTimes(1);
+    // El lock por crédito ahora se toma/libera en el pool dedicado, no con
+    // pg_advisory_xact_lock dentro de la transacción.
+    expect(lockQuery).toHaveBeenCalledWith("SELECT pg_advisory_lock($1, $2)", [
+      8765, 10,
+    ]);
+    expect(lockQuery).toHaveBeenCalledWith(
+      "SELECT pg_advisory_unlock($1, $2)",
+      [8765, 10],
+    );
+    expect(lockRelease).toHaveBeenCalledTimes(1);
   });
 
   it("valida un pago parcial sin cerrar la cuota", async () => {

--- a/apps/cartera-back/src/controllers/revalidatePayment.ts
+++ b/apps/cartera-back/src/controllers/revalidatePayment.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { eq, and, ne, sql } from "drizzle-orm";
+import { eq, and, ne } from "drizzle-orm";
 import Big from "big.js";
 import { db } from "../database";
 import { setCapitalSource } from "../utils/withAuditContext";
@@ -10,7 +10,7 @@ import {
   calcularCoberturaCuota,
   shouldRejectZeroAppliedNormalValidation,
 } from "./registerPaymentPolicy";
-import { PAYMENT_ADVISORY_LOCK_NAMESPACE } from "../utils/paymentAdvisoryLock";
+import { withPaymentAdvisoryLock } from "../utils/paymentAdvisoryLock";
 
 // ============================================================================
 // SCHEMA DE VALIDACIÓN
@@ -40,11 +40,13 @@ export const revalidatePayment = async ({ body, set }: any) => {
     console.log(`📋 Crédito ID: ${credito_id}`);
     console.log(`🧾 Pago ID: ${pago_id}`);
 
-    // 🔥 INICIAR TRANSACCIÓN ATÓMICA
-    const result = await db.transaction(async (tx) => {
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(${PAYMENT_ADVISORY_LOCK_NAMESPACE}, ${credito_id})`
-      );
+    // 🔥 TRANSACCIÓN ATÓMICA bajo el lock por crédito. El lock se espera en
+    // el pool DEDICADO (withPaymentAdvisoryLock), NO dentro de la tx: antes,
+    // cada waiter del pg_advisory_xact_lock retenía una conexión del pool de
+    // trabajo mientras esperaba, y suficientes waiters dejaban sin conexión
+    // al dueño del lock (deadlock de pool).
+    const result = await withPaymentAdvisoryLock(credito_id, () =>
+      db.transaction(async (tx) => {
       // 2️⃣ OBTENER DATOS DEL PAGO
       const [pago] = await tx
         .select()
@@ -218,7 +220,8 @@ export const revalidatePayment = async ({ body, set }: any) => {
         numero_credito_sifco: credito.numero_credito_sifco,
         cuota: credito.cuota
       };
-    });
+      })
+    );
 
     if ("success" in result && result.success === false) {
       set.status = 400;

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -2106,7 +2106,16 @@ export const recalcularPagosCredito = async ({
       rem.capital.eq(0);
 
     for (const pago of pagosOrdenados) {
-      const montoAplicado = new Big(pago.monto_aplicado ?? 0);
+      // Pagos ANULADOS (paymentFalse): conservan monto_aplicado, pero esa
+      // plata ya no existe — no debe consumir el saldo de la cuota ni marcar
+      // nada como pagado. Se tratan como monto 0 y caen a la rama de abajo:
+      // la fila se re-siembra como recibo limpio (abonos 0, restantes del
+      // saldo vigente). No se excluyen del SELECT a propósito: tras anular,
+      // esta fila suele ser el destino que el próximo registro sobreescribe,
+      // y así cascadea contra el saldo nuevo en vez del sembrado viejo.
+      const montoAplicado = pago.paymentFalse
+        ? new Big(0)
+        : new Big(pago.monto_aplicado ?? 0);
 
       if (montoAplicado.gt(0)) {
         // Distribuir monto_aplicado contra el saldo restante en orden de prioridad

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -2034,12 +2034,18 @@ export const recalcularPagosCredito = async ({
     // Amortización de esta cuota
     const interesMes = capitalEnMemoria.times(porcentajeInteres).round(2);
     const ivaMes = interesMes.times(0.12).round(2);
-    const abonoCapital = cuotaMensual
+    let abonoCapital = cuotaMensual
       .minus(interesMes)
       .minus(ivaMes)
       .minus(seguroFijo)
       .minus(gpsFijo)
       .minus(membresiasFijo);
+
+    // Tope: un recibo nunca proyecta más capital del que queda en el crédito
+    // (tras un abono grande la última porción es menor a la de una cuota
+    // normal), y con saldo 0 las cuotas restantes ya no llevan capital. Sin
+    // esto se sobre-cobraría capital y se sobre-distribuiría a inversionistas.
+    if (abonoCapital.gt(capitalEnMemoria)) abonoCapital = capitalEnMemoria;
 
     capitalEnMemoria = capitalEnMemoria.minus(abonoCapital);
     if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -2031,6 +2031,11 @@ export const recalcularPagosCredito = async ({
   const porcentajeInteres = new Big(credito.porcentaje_interes ?? 0).div(100);
   const cuotaMensual = new Big(credito.cuota);
   let capitalEnMemoria = new Big(credito.capital);
+  // Un sobre-abono (o data histórica) puede dejar el capital del crédito en
+  // negativo; para la amortización un saldo negativo no existe. Sin este
+  // clamp, el tope de abajo asignaría el negativo como abono_capital y los
+  // recibos quedarían con capital_restante/abono_capital negativos.
+  if (capitalEnMemoria.lt(0)) capitalEnMemoria = new Big(0);
 
   // 5️⃣ Procesar cada cuota en orden
   const actualizaciones: { pago_id: number; datos: Record<string, unknown> }[] = [];

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -1987,10 +1987,16 @@ export const recalcularPagosCredito = async ({
           eq(pagos_credito.credito_id, credito.credito_id),
           or(
             eq(pagos_credito.pagado, false),
+            // Pagos registrados sin validar: solo con monto_aplicado > 0.
+            // Los recibos especiales de solo mora/otros/convenio se guardan
+            // pagado=true con monto_aplicado=0 — no son pago de cuota, no
+            // tienen split que refrescar, y reescribirlos aquí los volvería
+            // recibos de cuota (incluso volteando su pagado).
             and(
               eq(pagos_credito.pagado, true),
               eq(pagos_credito.validationStatus, "pending"),
               eq(pagos_credito.paymentFalse, false),
+              gt(pagos_credito.monto_aplicado, "0"),
             ),
           ),
         );

--- a/apps/cartera-back/src/controllers/updateCredit.ts
+++ b/apps/cartera-back/src/controllers/updateCredit.ts
@@ -1,5 +1,5 @@
 import Big from "big.js";
-import { eq, and, inArray, asc, gt, lte, gte, sql } from "drizzle-orm";
+import { eq, and, or, inArray, asc, gt, lte, gte, sql } from "drizzle-orm";
 import jwt from "jsonwebtoken";
 import { db } from "../database";
 import {
@@ -1971,7 +1971,12 @@ export const recalcularPagosCredito = async ({
 
   // 2️⃣ Obtener pagos con su cuota
   // Si numero_cuota está definido → desde esa cuota en adelante (pagadas y no pagadas)
-  // Si no → solo no pagadas
+  // Si no → solo lo que AÚN NO SE APLICÓ al crédito: cuotas no pagadas y
+  // también pagos ya registrados como pagados pero SIN validar por conta
+  // (validationStatus='pending', vivos). Esos pagos no han movido capital ni
+  // distribuido a inversionistas — su reparto guardado recién se aplica al
+  // validarse, así que refrescarlo aquí es seguro y necesario: si quedaran
+  // fuera, conta validaría el split viejo (interés pre-abono).
   const whereConditions =
     numero_cuota !== undefined
       ? and(
@@ -1980,7 +1985,14 @@ export const recalcularPagosCredito = async ({
         )
       : and(
           eq(pagos_credito.credito_id, credito.credito_id),
-          eq(pagos_credito.pagado, false),
+          or(
+            eq(pagos_credito.pagado, false),
+            and(
+              eq(pagos_credito.pagado, true),
+              eq(pagos_credito.validationStatus, "pending"),
+              eq(pagos_credito.paymentFalse, false),
+            ),
+          ),
         );
 
   const rows = await db

--- a/apps/cartera-back/src/database/index.ts
+++ b/apps/cartera-back/src/database/index.ts
@@ -16,5 +16,18 @@ const client = new Pool({
 
 console.log('Conexión a la base de datos establecida');
 
-export { client };
+// Pool DEDICADO para advisory locks (pg_advisory_lock por crédito).
+// Tiene que ser un pool aparte del de trabajo: un waiter bloqueado en
+// pg_advisory_lock retiene su conexión mientras espera; si esos waiters
+// vivieran en `client`, podrían agotarlo y el que SÍ tiene el lock ya no
+// conseguiría conexión para sus queries (drizzle usa `client`) → deadlock
+// de pool: nadie avanza, nadie suelta. Separados, los waiters solo llenan
+// este pool y el trabajo del ganador siempre respira.
+const lockPool = new Pool({
+  connectionString,
+  ssl: isLocalDb ? false : { rejectUnauthorized: false },
+  max: 10,
+});
+
+export { client, lockPool };
 export const db = drizzle(client, { schema });

--- a/apps/cartera-back/src/utils/paymentAdvisoryLock.ts
+++ b/apps/cartera-back/src/utils/paymentAdvisoryLock.ts
@@ -1,6 +1,40 @@
+import { lockPool } from "../database";
+
 export const PAYMENT_ADVISORY_LOCK_NAMESPACE = 8765;
 
 export type PaymentAdvisoryLockConnection = {
   query: (text: string, values?: unknown[]) => Promise<unknown>;
   release: () => void;
 };
+
+/**
+ * Corre `fn` sosteniendo el advisory lock por crédito, con la conexión del
+ * pool DEDICADO de locks (`lockPool`). Los waiters bloqueados en
+ * `pg_advisory_lock` retienen su conexión mientras esperan: si esperaran en
+ * el pool de trabajo podrían agotarlo y dejar sin conexiones al dueño del
+ * lock (deadlock de pool). Por eso NUNCA esperar este lock con conexiones de
+ * `client`/`db` (p.ej. `pg_advisory_xact_lock` dentro de una transacción).
+ */
+export async function withPaymentAdvisoryLock<T>(
+  credito_id: number,
+  fn: () => Promise<T>
+): Promise<T> {
+  const lockConn: PaymentAdvisoryLockConnection = await lockPool.connect();
+  try {
+    await lockConn.query("SELECT pg_advisory_lock($1, $2)", [
+      PAYMENT_ADVISORY_LOCK_NAMESPACE,
+      credito_id,
+    ]);
+    return await fn();
+  } finally {
+    try {
+      await lockConn.query("SELECT pg_advisory_unlock($1, $2)", [
+        PAYMENT_ADVISORY_LOCK_NAMESPACE,
+        credito_id,
+      ]);
+    } catch (unlockError) {
+      console.error("⚠️ Error liberando advisory lock:", unlockError);
+    }
+    lockConn.release();
+  }
+}

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -82,6 +82,12 @@ export function useAplicarPago() {
           description:
             "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado y el recálculo automático se omitió para no reescribir ese pago. OJO: NO corras 'Recalcular Pagos' aquí sin revisarlo antes con el equipo — el botón también redistribuiría el pago parcial. Revisen el reparto de esa cuota manualmente.",
         });
+      } else if (data.recalculo_pendientes === "revisar_sobrante") {
+        toast.warning("⚠️ PAGO CON SOBRANTE — REVISAR ANTES DE VALIDAR", {
+          ...avisoGrande,
+          description:
+            "Se recalcularon las cuotas, pero hay un pago registrado SIN validar que trae más dinero del que pide el recibo nuevo (el abono achicó la cuota). NO lo validen todavía: revisen con el equipo si va como saldo a favor o devolución.",
+        });
       } else if (data.recalculo_pendientes === "omitido_solo_interes") {
         toast.info("Abono aplicado", {
           description:

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { getApiErrorMessage } from "@/lib/apiError";
 import {
   getPagosConInversionistasService,
@@ -49,24 +50,43 @@ export function useAplicarPago() {
     mutationFn: (pagoId: number) => pagosService.aplicarPago(pagoId),
     
     onSuccess: (data) => {
-      // ⚠️ Estado del recálculo de recibos tras un abono a capital: si quedó
-      // pendiente, operaciones debe correr "Recalcular Pagos" a mano.
+      // ⚠️ Estado del recálculo de recibos tras un abono a capital. Los avisos
+      // que requieren acción van en toast GRANDE y persistente (no se cierra
+      // solo) para que conta no los pase por alto.
+      const avisoGrande = {
+        duration: Infinity,
+        closeButton: true,
+        style: {
+          width: "560px",
+          maxWidth: "92vw",
+          fontSize: "1.05rem",
+          padding: "20px",
+        },
+      } as const;
+
       if (data.recalculo_pendientes === "error") {
-        alert(
-          "El abono se aplicó, pero FALLÓ el recálculo de las cuotas pendientes. Corré 'Recalcular Pagos' manualmente en este crédito."
-        );
-      } else if (data.recalculo_pendientes === "revisar_pendientes_validacion") {
-        alert(
-          "El abono se aplicó y se recalcularon las cuotas pendientes, pero hay pagos registrados SIN validar que quedaron fuera: después de validarlos, corré 'Recalcular Pagos' manualmente."
-        );
+        toast.error("🚨 NO SE RECALCULARON LAS CUOTAS", {
+          ...avisoGrande,
+          description:
+            "El abono se aplicó, pero FALLÓ el recálculo de las cuotas pendientes. Corré 'Recalcular Pagos' manualmente en este crédito.",
+        });
+      } else if (data.recalculo_pendientes === "revisar_vencidas") {
+        toast.warning("⚠️ CUOTAS VENCIDAS — NO SE RECALCULÓ", {
+          ...avisoGrande,
+          description:
+            "El abono se aplicó, pero este crédito tiene cuotas VENCIDAS sin aplicar y el recálculo automático se omitió para no cambiarles el interés que ya se debía. Revisen con el equipo cómo tratar esas cuotas antes de correr 'Recalcular Pagos'.",
+        });
       } else if (data.recalculo_pendientes === "revisar_parciales") {
-        alert(
-          "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado y el recálculo automático se omitió para no reescribir ese pago. OJO: NO corras 'Recalcular Pagos' aquí sin revisarlo antes con el equipo — el botón también redistribuiría el pago parcial. Revisen el reparto de esa cuota manualmente."
-        );
+        toast.warning("⚠️ PAGO PARCIAL — NO SE RECALCULÓ", {
+          ...avisoGrande,
+          description:
+            "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado y el recálculo automático se omitió para no reescribir ese pago. OJO: NO corras 'Recalcular Pagos' aquí sin revisarlo antes con el equipo — el botón también redistribuiría el pago parcial. Revisen el reparto de esa cuota manualmente.",
+        });
       } else if (data.recalculo_pendientes === "omitido_solo_interes") {
-        alert(
-          "Abono aplicado. Crédito solo-interés: el recálculo automático no aplica para este formato."
-        );
+        toast.info("Abono aplicado", {
+          description:
+            "Crédito solo-interés: el recálculo automático no aplica para este formato.",
+        });
       }
 
       // 🔄 Invalidar la caché para refrescar la tabla

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -61,7 +61,7 @@ export function useAplicarPago() {
         );
       } else if (data.recalculo_pendientes === "revisar_parciales") {
         alert(
-          "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado: el recálculo automático se omitió para no reescribir su historial. Corré 'Recalcular Pagos' manualmente en este crédito."
+          "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado y el recálculo automático se omitió para no reescribir ese pago. OJO: NO corras 'Recalcular Pagos' aquí sin revisarlo antes con el equipo — el botón también redistribuiría el pago parcial. Revisen el reparto de esa cuota manualmente."
         );
       } else if (data.recalculo_pendientes === "omitido_solo_interes") {
         alert(

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -59,6 +59,10 @@ export function useAplicarPago() {
         alert(
           "El abono se aplicó y se recalcularon las cuotas pendientes, pero hay pagos registrados SIN validar que quedaron fuera: después de validarlos, corré 'Recalcular Pagos' manualmente."
         );
+      } else if (data.recalculo_pendientes === "revisar_parciales") {
+        alert(
+          "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado: el recálculo automático se omitió para no reescribir su historial. Corré 'Recalcular Pagos' manualmente en este crédito."
+        );
       } else if (data.recalculo_pendientes === "omitido_solo_interes") {
         alert(
           "Abono aplicado. Crédito solo-interés: el recálculo automático no aplica para este formato."

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -83,10 +83,10 @@ export function useAplicarPago() {
             "El abono se aplicó, pero este crédito tiene una cuota con pago PARCIAL aplicado y el recálculo automático se omitió para no reescribir ese pago. OJO: NO corras 'Recalcular Pagos' aquí sin revisarlo antes con el equipo — el botón también redistribuiría el pago parcial. Revisen el reparto de esa cuota manualmente.",
         });
       } else if (data.recalculo_pendientes === "revisar_sobrante") {
-        toast.warning("⚠️ PAGO CON SOBRANTE — REVISAR ANTES DE VALIDAR", {
+        toast.warning("⚠️ NO VALIDEN EL PAGO PENDIENTE — TRAE SOBRANTE", {
           ...avisoGrande,
           description:
-            "Se recalcularon las cuotas, pero hay un pago registrado SIN validar que trae más dinero del que pide el recibo nuevo (el abono achicó la cuota). NO lo validen todavía: revisen con el equipo si va como saldo a favor o devolución.",
+            "El abono se aplicó y las cuotas se recalcularon bien. PERO este crédito tiene un pago PENDIENTE de validar que trae más dinero del que pide su recibo nuevo (el abono achicó la cuota). NO validen ese pago pendiente todavía: revisen con el equipo si el sobrante va como saldo a favor o devolución.",
         });
       } else if (data.recalculo_pendientes === "omitido_solo_interes") {
         toast.info("Abono aplicado", {

--- a/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
+++ b/apps/carteraFront/src/private/cartera/hooks/reportPayments.ts
@@ -49,11 +49,25 @@ export function useAplicarPago() {
     mutationFn: (pagoId: number) => pagosService.aplicarPago(pagoId),
     
     onSuccess: (data) => {
-    
+      // ⚠️ Estado del recálculo de recibos tras un abono a capital: si quedó
+      // pendiente, operaciones debe correr "Recalcular Pagos" a mano.
+      if (data.recalculo_pendientes === "error") {
+        alert(
+          "El abono se aplicó, pero FALLÓ el recálculo de las cuotas pendientes. Corré 'Recalcular Pagos' manualmente en este crédito."
+        );
+      } else if (data.recalculo_pendientes === "revisar_pendientes_validacion") {
+        alert(
+          "El abono se aplicó y se recalcularon las cuotas pendientes, pero hay pagos registrados SIN validar que quedaron fuera: después de validarlos, corré 'Recalcular Pagos' manualmente."
+        );
+      } else if (data.recalculo_pendientes === "omitido_solo_interes") {
+        alert(
+          "Abono aplicado. Crédito solo-interés: el recálculo automático no aplica para este formato."
+        );
+      }
 
       // 🔄 Invalidar la caché para refrescar la tabla
-      queryClient.invalidateQueries({ 
-        queryKey: ["pagos-inversionistas"] 
+      queryClient.invalidateQueries({
+        queryKey: ["pagos-inversionistas"]
       });
 
       // 📊 Log adicional si se aplicó al crédito

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -2003,10 +2003,12 @@ export interface AplicarPagoResponse {
    *   (ambos redistribuirían el parcial); revisar el reparto con el equipo.
    *   (Un pago solo registrado sin validar — parcial o completo — NO cae aquí:
    *   ese sí se recalcula para que conta lo valide con el reparto nuevo.)
-   * - "revisar_sobrante": tras recalcular, hay un pago registrado sin validar
-   *   cuyo monto supera lo que pide el recibo nuevo (ej. pagó la cuota
-   *   completa y el abono dejó el último recibo más chico) — decidir saldo a
-   *   favor/devolución con el equipo ANTES de validar ese pago.
+   * - "revisar_sobrante": el abono se aplicó y se recalculó bien, pero hay un
+   *   pago PENDIENTE de validar cuyo monto supera lo que pide su recibo nuevo
+   *   (ej. pagó la cuota completa y el abono dejó el último recibo más chico)
+   *   — NO validar ese pago pendiente hasta decidir con el equipo si el
+   *   sobrante va como saldo a favor o devolución. Solo es un aviso: el botón
+   *   de validar sigue funcionando igual.
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1997,13 +1997,16 @@ export interface AplicarPagoResponse {
    * - "error": falló — correr "Recalcular Pagos" manualmente.
    * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
    *   quedaron fuera — recalcular a mano después de validarlos.
+   * - "revisar_parciales": hay cuota con pago parcial aplicado — el recálculo
+   *   automático se omitió para no reescribir su historial; usar el botón.
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:
     | "ok"
     | "error"
     | "omitido_solo_interes"
-    | "revisar_pendientes_validacion";
+    | "revisar_pendientes_validacion"
+    | "revisar_parciales";
   data?: {
     credito_id: number;
     capital_anterior: string;

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1997,8 +1997,9 @@ export interface AplicarPagoResponse {
    * - "error": falló — correr "Recalcular Pagos" manualmente.
    * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
    *   quedaron fuera — recalcular a mano después de validarlos.
-   * - "revisar_parciales": hay cuota con pago parcial aplicado — el recálculo
-   *   automático se omitió para no reescribir su historial; usar el botón.
+   * - "revisar_parciales": hay cuota con pago parcial aplicado — NI el
+   *   recálculo automático NI el botón "Recalcular Pagos" son seguros ahí
+   *   (ambos redistribuirían el parcial); revisar el reparto con el equipo.
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -2003,6 +2003,10 @@ export interface AplicarPagoResponse {
    *   (ambos redistribuirían el parcial); revisar el reparto con el equipo.
    *   (Un pago solo registrado sin validar — parcial o completo — NO cae aquí:
    *   ese sí se recalcula para que conta lo valide con el reparto nuevo.)
+   * - "revisar_sobrante": tras recalcular, hay un pago registrado sin validar
+   *   cuyo monto supera lo que pide el recibo nuevo (ej. pagó la cuota
+   *   completa y el abono dejó el último recibo más chico) — decidir saldo a
+   *   favor/devolución con el equipo ANTES de validar ese pago.
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:
@@ -2010,7 +2014,8 @@ export interface AplicarPagoResponse {
     | "error"
     | "omitido_solo_interes"
     | "revisar_vencidas"
-    | "revisar_parciales";
+    | "revisar_parciales"
+    | "revisar_sobrante";
   data?: {
     credito_id: number;
     capital_anterior: string;

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1997,9 +1997,11 @@ export interface AplicarPagoResponse {
    * - "error": falló — correr "Recalcular Pagos" manualmente.
    * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
    *   quedaron fuera — recalcular a mano después de validarlos.
-   * - "revisar_parciales": hay cuota con pago parcial aplicado — NI el
-   *   recálculo automático NI el botón "Recalcular Pagos" son seguros ahí
+   * - "revisar_parciales": hay cuota con pago parcial YA APLICADO al crédito —
+   *   NI el recálculo automático NI el botón "Recalcular Pagos" son seguros ahí
    *   (ambos redistribuirían el parcial); revisar el reparto con el equipo.
+   *   (Un parcial solo registrado, aún sin validar, NO cae aquí: ese sí se
+   *   recalcula para que conta lo valide con el reparto nuevo.)
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1992,6 +1992,18 @@ export interface AplicarPagoResponse {
   success: boolean;
   applied?: boolean;
   message: string;
+  /**
+   * Estado del recálculo automático de recibos tras aplicar un abono a capital:
+   * - "error": falló — correr "Recalcular Pagos" manualmente.
+   * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
+   *   quedaron fuera — recalcular a mano después de validarlos.
+   * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
+   */
+  recalculo_pendientes?:
+    | "ok"
+    | "error"
+    | "omitido_solo_interes"
+    | "revisar_pendientes_validacion";
   data?: {
     credito_id: number;
     capital_anterior: string;

--- a/apps/carteraFront/src/private/cartera/services/services.ts
+++ b/apps/carteraFront/src/private/cartera/services/services.ts
@@ -1995,20 +1995,21 @@ export interface AplicarPagoResponse {
   /**
    * Estado del recálculo automático de recibos tras aplicar un abono a capital:
    * - "error": falló — correr "Recalcular Pagos" manualmente.
-   * - "revisar_pendientes_validacion": hay pagos registrados sin validar que
-   *   quedaron fuera — recalcular a mano después de validarlos.
+   * - "revisar_vencidas": el crédito tiene cuotas VENCIDAS sin aplicar — no se
+   *   recalculó nada para no repreciar el interés de meses ya debidos; revisar
+   *   con el equipo cómo tratarlas antes de recalcular.
    * - "revisar_parciales": hay cuota con pago parcial YA APLICADO al crédito —
    *   NI el recálculo automático NI el botón "Recalcular Pagos" son seguros ahí
    *   (ambos redistribuirían el parcial); revisar el reparto con el equipo.
-   *   (Un parcial solo registrado, aún sin validar, NO cae aquí: ese sí se
-   *   recalcula para que conta lo valide con el reparto nuevo.)
+   *   (Un pago solo registrado sin validar — parcial o completo — NO cae aquí:
+   *   ese sí se recalcula para que conta lo valide con el reparto nuevo.)
    * - "omitido_solo_interes": crédito solo-interés, no aplica el recálculo.
    */
   recalculo_pendientes?:
     | "ok"
     | "error"
     | "omitido_solo_interes"
-    | "revisar_pendientes_validacion"
+    | "revisar_vencidas"
     | "revisar_parciales";
   data?: {
     credito_id: number;


### PR DESCRIPTION
# Abonos a capital: las cuotas se actualizan solas

## El viaje de un abono, antes y ahora

**Antes** 😰

> El cliente abona Q250,000 → el capital del crédito baja → **pero las cuotas siguientes se quedan calculadas con el capital viejo** → el siguiente pago cobra interés de más → factura inflada, liquidación del inversionista inflada. La única defensa: que alguien se acordara de apretar "Recalcular Pagos" a mano (pasaba en ~14% de los abonos según los audit logs).

**Ahora** ✅

1. El asesor **registra** el abono — igual que siempre
2. Caja lo **aplica** — igual que siempre: baja el capital y reparte a inversionistas
3. 🆕 El sistema **actualiza solo las cuotas que vienen** con el capital nuevo — incluyendo pagos ya registrados que conta aún no valida, para que al validarlos usen los números correctos
4. 🆕 Si hay algo que una persona debe decidir, sale un **aviso GRANDE en pantalla que no se cierra solo**, con la instrucción exacta

Caso real que motivó esto: crédito `01010214120840` — tras un abono de Q250k, el siguiente pago cobró Q4,689 de interés cuando tocaban Q939.

## Cuándo actúa solo y cuándo pide ayuda

| Situación | Qué hace | Aviso |
|---|---|---|
| Caso normal | Actualiza las cuotas pendientes ✅ | Ninguno |
| Crédito "solo interés" | No toca nada (ese formato no amortiza capital) | Informativo |
| Pagos registrados que conta aún no valida | Los actualiza también (aún no han movido nada) | Ninguno |
| Pagos anulados en el crédito | Los ignora (esa plata no existe) y deja su cuota lista | Ninguno |
| Cuota pagada a medias ya aplicada — o cuota "mixta" (parcial validado + cierre sin validar) | No toca nada — un pago hecho no se reescribe | 🔶 Revisar reparto con el equipo (tampoco usar el botón ahí) |
| Cuotas VENCIDAS sin pagar (aunque su pago esté anulado) | No toca nada — el interés de meses ya debidos no se rebaja por un abono posterior | 🔶 Revisar con el equipo antes de recalcular |
| Un pago pendiente trae más dinero del que pide su recibo nuevo | Recalcula bien, pero el sobrante no se reparte solo | 🔶 NO validar ese pago pendiente — decidir saldo a favor/devolución |
| El recálculo falla | El abono queda aplicado igual | 🔴 Correr "Recalcular Pagos" a mano |

Los avisos 🔶🔴 son grandes y persistentes, pero **solo informan**: ningún botón se bloquea.

## Qué NO cambia nunca

- **El valor de la cuota mensual** — el abono acorta plazo, no baja cuota
- **El espejo / liquidación de inversionistas** — sigue su flujo normal
- **Pagos ya hechos y validados** — jamás se reescriben automáticamente

## Blindaje extra que salió del review

- **Candado por crédito en `/aplicar-pago`**: registrar, aplicar, revalidar y editar montos de pagos del mismo crédito ya no pueden pisarse entre sí — los cuatro escritores esperan el mismo candado en un pool dedicado.
- El botón manual "Recalcular Pagos" hereda dos arreglos: cerca de liquidar ya no proyecta más capital del que queda, y ya no deja fuera los pagos registrados sin validar.
- La última cuota tras un abono grande puede quedar más chica que la mensual: el cierre de cuota ahora la reconoce y cierra cuando el recibo se cubre completo.
- Sobre-abonos (más que el capital restante) ya no pueden escribir números negativos en los recibos.

## Estado

- Review de Codex: **26 hallazgos en 4 rondas** (PRs #1178, #1179, #1180 y #1187 cerrados a favor de este): 25 corregidos + 1 documentado como no-aplica (pagos falsos, función descontinuada con población cero), todos con su hilo respondido. Rama al día con main (merge del aplicar-pago transaccional)
- Typecheck limpio; tests del flujo de aplicación 57/57
- **Pendiente antes del merge**: prueba de un abono real en dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)






